### PR TITLE
ci: trigger CI on dev branch PRs and pushes

### DIFF
--- a/.github/workflows/pr-and-push.yml
+++ b/.github/workflows/pr-and-push.yml
@@ -2,10 +2,10 @@ name: Pull Request and Push Action
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ main, dev ]
     types: [opened, synchronize, reopened, ready_for_review, review_requested, review_request_removed]
   push:
-    branches: [ main ]
+    branches: [ main, dev ]
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Problem

All 8 open PRs (#7-#13, #15) target the `dev` branch, but the CI workflow in `pr-and-push.yml` only triggers on PRs targeting `main`. This means:

- PRs targeting `dev` show **"no checks reported"**
- @awsarron's review agent flags lint failures that CI can't verify
- Contributors can't see green/red status before merge

## Fix

Add `dev` to both `pull_request.branches` and `push.branches` filters:

```yaml
on:
  pull_request:
    branches: [ main, dev ]
  push:
    branches: [ main, dev ]
```

## Impact

- All existing dev-branch PRs will get CI checks on next push
- No change to main-branch behavior
- 1 file, 2 lines changed

---
🤖 *AI agent response. [Strands Agents](https://github.com/strands-agents). Feedback welcome!*