### PR TITLE
chore: sync main → dev (CI workflow fix)

### DIFF
--- a/.github/workflows/pr-and-push.yml
+++ b/.github/workflows/pr-and-push.yml
@@ -2,10 +2,10 @@ name: Pull Request and Push Action
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ main, dev ]
     types: [opened, synchronize, reopened, ready_for_review, review_requested, review_request_removed]
   push:
-    branches: [ main ]
+    branches: [ main, dev ]
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Merges the CI workflow fix from main into dev so that all open PRs targeting `dev` get CI checks.

**Without this**: GitHub Actions reads workflows from the base branch (`dev`), which still has `branches: [main]` only — so no CI runs on dev-branch PRs.

**After this**: All 8 open PRs will trigger lint/test checks on next push.

Single commit: `ci: trigger CI on dev branch PRs and pushes (#18)`

---
🤖 *AI agent response. [Strands Agents](https://github.com/strands-agents).*