### PR TITLE
fix: bugs and error handling improvements

### DIFF
--- a/strands_robots/policies/__init__.py
+++ b/strands_robots/policies/__init__.py
@@ -239,7 +239,11 @@ def create_policy(provider: str, **kwargs) -> Policy:
     if _needs_resolution:
         try:
             resolved_provider, resolved_kwargs = resolve_policy_string(provider, **kwargs)
-        except Exception:
+        except ImportError:
+            resolved_provider = None
+            resolved_kwargs = {}
+        except Exception as e:
+            logger.warning(f"Policy resolution failed for '{provider}': {e}")
             resolved_provider = None
             resolved_kwargs = {}
 

--- a/strands_robots/policies/dreamzero/__init__.py
+++ b/strands_robots/policies/dreamzero/__init__.py
@@ -65,6 +65,7 @@ class DreamzeroPolicy(Policy):
         session_id: Optional[str] = None,
         image_resize: Optional[tuple] = None,
         action_horizon: int = 24,
+        recv_timeout: float = 120.0,
         **kwargs,
     ):
         """Initialize DreamZero policy client.
@@ -76,6 +77,7 @@ class DreamzeroPolicy(Policy):
             session_id: Session ID for tracking (auto-generated if None)
             image_resize: Override image resize (default: use server config)
             action_horizon: Expected action horizon from server
+            recv_timeout: Timeout in seconds for WebSocket recv calls
         """
         self._host = host
         self._port = port
@@ -83,6 +85,7 @@ class DreamzeroPolicy(Policy):
         self._session_id = session_id or str(uuid.uuid4())
         self._image_resize = image_resize
         self._action_horizon = action_horizon
+        self._recv_timeout = recv_timeout
         self._robot_state_keys: List[str] = []
 
         # Connection state (lazy connect)
@@ -134,11 +137,11 @@ class DreamzeroPolicy(Policy):
                 compression=None,
                 max_size=None,
                 ping_interval=60,
-                ping_timeout=600,
+                ping_timeout=120,
             )
 
             # Server sends config on connect
-            raw_config = self._ws.recv()
+            raw_config = self._ws.recv(timeout=self._recv_timeout)
             self._server_config = msgpack_numpy.unpackb(raw_config)
             self._packer = msgpack_numpy.Packer()
             self._connected = True
@@ -161,9 +164,9 @@ class DreamzeroPolicy(Policy):
                     compression=None,
                     max_size=None,
                     ping_interval=60,
-                    ping_timeout=600,
+                    ping_timeout=120,
                 )
-                raw_config = self._ws.recv()
+                raw_config = self._ws.recv(timeout=self._recv_timeout)
                 self._server_config = msgpack_numpy.unpackb(raw_config)
                 self._packer = msgpack_numpy.Packer()
                 self._connected = True
@@ -332,7 +335,7 @@ class DreamzeroPolicy(Policy):
         data = self._packer.pack(obs)
         self._ws.send(data)
 
-        response = self._ws.recv()
+        response = self._ws.recv(timeout=self._recv_timeout)
         if isinstance(response, str):
             raise RuntimeError(f"DreamZero server error:\n{response}")
 
@@ -392,7 +395,7 @@ class DreamzeroPolicy(Policy):
 
         reset_msg = {"endpoint": "reset"}
         self._ws.send(self._packer.pack(reset_msg))
-        self._ws.recv()  # "reset successful"
+        self._ws.recv(timeout=self._recv_timeout)  # "reset successful"
 
         # New session
         self._session_id = str(uuid.uuid4())

--- a/strands_robots/policies/lerobot_local/__init__.py
+++ b/strands_robots/policies/lerobot_local/__init__.py
@@ -129,6 +129,8 @@ class LerobotLocalPolicy(Policy):
         self._output_features = {}
         self._loaded = False
         self._processor_bridge = None
+        self._consecutive_failures = 0
+        self._max_consecutive_failures = 5
 
         if pretrained_name_or_path:
             self._load_model()
@@ -297,9 +299,18 @@ class LerobotLocalPolicy(Policy):
             if self._processor_bridge and self._processor_bridge.has_postprocessor:
                 action_tensor = self._processor_bridge.postprocess(action_tensor)
 
+            self._consecutive_failures = 0
             return self._tensor_to_action_dicts(action_tensor)
         except Exception as e:
-            logger.error(f"Inference error: {e}")
+            self._consecutive_failures += 1
+            logger.error(
+                f"Inference error ({self._consecutive_failures}/{self._max_consecutive_failures}): {e}"
+            )
+            if self._consecutive_failures >= self._max_consecutive_failures:
+                raise RuntimeError(
+                    f"LeRobot policy failed {self._consecutive_failures} consecutive times, "
+                    f"last error: {e}"
+                ) from e
             return self._zero_actions()
 
     def select_action_sync(self, observation_dict: Dict[str, Any]) -> np.ndarray:
@@ -345,26 +356,33 @@ class LerobotLocalPolicy(Policy):
         has_lerobot_keys = any(k.startswith("observation.") for k in observation_dict)
         if has_lerobot_keys:
             for k, v in observation_dict.items():
+                # Detect image-like data by shape or key name
+                is_image = "image" in k or k in self._input_features and hasattr(
+                    self._input_features.get(k), "shape"
+                ) and len(getattr(self._input_features.get(k), "shape", ())) >= 2
+
                 if isinstance(v, torch.Tensor):
                     t = v
-                    # Ensure images are CHW format
-                    if "image" in k and t.dim() == 3 and t.shape[-1] in (1, 3, 4):
+                    # Detect image by shape: 3D with channel-like last dim
+                    if not is_image and t.dim() == 3 and t.shape[-1] in (1, 3, 4):
+                        is_image = True
+                    if is_image and t.dim() == 3 and t.shape[-1] in (1, 3, 4):
                         t = t.permute(2, 0, 1)
-                    # Add batch dimension if needed
-                    if "image" in k and t.dim() == 3:
+                    if is_image and t.dim() == 3:
                         t = t.unsqueeze(0)
-                    elif t.dim() < 2 and "image" not in k:
+                    elif t.dim() < 2 and not is_image:
                         t = t.unsqueeze(0)
                     batch[k] = t.to(self._device)
                 elif isinstance(v, np.ndarray):
                     if v.ndim >= 2:
+                        if not is_image and v.ndim == 3 and v.shape[-1] in (1, 3, 4):
+                            is_image = True
                         t = torch.from_numpy(v.copy()).float()
-                        if t.dim() == 3 and t.shape[-1] in (1, 3, 4):
+                        if is_image and t.dim() == 3 and t.shape[-1] in (1, 3, 4):
                             t = t.permute(2, 0, 1)
-                        # Normalize based on source dtype, not value range
-                        if "image" in k and v.dtype == np.uint8:
+                        if is_image and v.dtype == np.uint8:
                             t = t / 255.0
-                        if "image" in k and t.dim() == 3:
+                        if is_image and t.dim() == 3:
                             t = t.unsqueeze(0)
                         elif t.dim() < 2:
                             t = t.unsqueeze(0)
@@ -392,11 +410,11 @@ class LerobotLocalPolicy(Policy):
                         continue
                     if arr.ndim >= 2:
                         t = torch.from_numpy(arr).float()
-                        if t.dim() == 3 and t.shape[-1] in (1, 3, 4):
+                        if is_image and t.dim() == 3 and t.shape[-1] in (1, 3, 4):
                             t = t.permute(2, 0, 1)
-                        if "image" in k and arr.dtype == np.uint8:
+                        if is_image and arr.dtype == np.uint8:
                             t = t / 255.0
-                        if "image" in k and t.dim() == 3:
+                        if is_image and t.dim() == 3:
                             t = t.unsqueeze(0)
                         batch[k] = t.to(self._device)
                     else:

--- a/strands_robots/robot.py
+++ b/strands_robots/robot.py
@@ -416,17 +416,8 @@ class Robot(AgentTool):
                 # This is expected and fine - robot is already connected
                 logger.info(f"✅ {self.robot} was already connected")
 
-            except Exception as e:
-                # Check if it's the string version of "already connected" error
-                error_str = str(e).lower()
-                if (
-                    "already connected" in error_str
-                    or "is already connected" in error_str
-                ):
-                    logger.info(f"✅ {self.robot} connection already established")
-                else:
-                    # Re-raise if it's a different error
-                    raise e
+            except Exception:
+                raise
 
             # Final connection check
             if not self.robot.is_connected:

--- a/strands_robots/simulation.py
+++ b/strands_robots/simulation.py
@@ -1589,7 +1589,13 @@ class Simulation(AgentTool):
                     if jid >= 0:
                         robot.joint_ids.append(jid)
                 for i in range(new_model.nu):
-                    robot.actuator_ids.append(i)
+                    jnt_id = new_model.actuator_trnid[i, 0]
+                    if jnt_id in robot.joint_ids:
+                        robot.actuator_ids.append(i)
+                # Fallback: if no actuators matched by joint, assign all (single-robot scene)
+                if not robot.actuator_ids:
+                    for i in range(new_model.nu):
+                        robot.actuator_ids.append(i)
 
             # Clean up temp directory
             try:
@@ -3525,13 +3531,16 @@ class Simulation(AgentTool):
 
         # Robots
         elif action == "add_robot":
-            return self.add_robot(
-                name=d.get("robot_name", d.get("name", "robot_0")),
-                urdf_path=d.get("urdf_path"),
-                data_config=d.get("data_config"),
-                position=d.get("position"),
-                orientation=d.get("orientation"),
-            )
+            ar_kwargs = {"name": d.get("robot_name", d.get("name", "robot_0"))}
+            if d.get("urdf_path") is not None:
+                ar_kwargs["urdf_path"] = d["urdf_path"]
+            if d.get("data_config") is not None:
+                ar_kwargs["data_config"] = d["data_config"]
+            if d.get("position") is not None:
+                ar_kwargs["position"] = d["position"]
+            if d.get("orientation") is not None:
+                ar_kwargs["orientation"] = d["orientation"]
+            return self.add_robot(**ar_kwargs)
         elif action == "remove_robot":
             return self.remove_robot(d.get("robot_name", d.get("name", "")))
         elif action == "list_robots":

--- a/strands_robots/zenoh_mesh.py
+++ b/strands_robots/zenoh_mesh.py
@@ -320,10 +320,10 @@ class Mesh:
             if hasattr(r, "_action_features"):
                 p["action_keys"] = list(r._action_features.keys())
             # Simulation
-            if hasattr(r, "_robots"):
-                p["sim_robots"] = list(r._robots.keys())
             if hasattr(r, "_world") and r._world is not None:
                 p["world"] = True
+                if hasattr(r._world, "robots"):
+                    p["sim_robots"] = list(r._world.robots.keys())
         except Exception:
             pass
         return p


### PR DESCRIPTION
## Bug fixes

- **zenoh_mesh presence**: `_build_presence` references non-existent `r._robots`, use `r._world.robots` consistent with `_read_state`
- **dispatch add_robot**: passes `None` for absent keys, overriding method defaults. Only forward keys present in the dispatch dict
- **actuator re-discovery**: `_inject_object_into_scene` assigns all actuators to every robot after XML round-trip. Use `actuator_trnid` matching (same as `add_robot`)
- **image normalization**: LeRobot local normalization gated on `"image" in key_name` - cameras named `wrist` or `front` skip normalization. Detect images by shape and input_features instead

## Error handling

- **robot.py connection**: `raise e` destroys traceback, and fragile string matching for "already connected" duplicates the `DeviceAlreadyConnectedError` catch. Remove redundant branch, use bare `raise`
- **create_policy resolution**: bare `except Exception` swallows the real error when `resolve_policy_string` fails. Log at warning level for non-`ImportError`
- **LeRobot inference fallback**: returns zero-actions on any inference error with no escalation. Track consecutive failures and raise after 5 in a row
- **DreamZero recv timeout**: `.recv()` calls have no timeout (`ping_timeout` was 10 min). Add configurable `recv_timeout` (default 120s), reduce `ping_timeout` to 120s

## Testing

All 73 existing tests pass. Lint clean.


---
*AI agent PR on behalf of @awsarron. [Strands Agents](https://github.com/strands-agents). Feedback welcome!*