### PR TITLE
fix: newton observation key mismatch and async policy resolution

### DIFF
--- a/strands_robots/newton/newton_backend.py
+++ b/strands_robots/newton/newton_backend.py
@@ -52,6 +52,8 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 
+from strands_robots._async_utils import _resolve_coroutine
+
 logger = logging.getLogger(__name__)
 
 # Lazily imported
@@ -1888,9 +1890,10 @@ class NewtonBackend:
         for i in range(num_steps):
             obs = self.get_observation(robot_name)
             try:
-                actions = policy.get_actions(
+                coro_or_result = policy.get_actions(
                     obs.get("observations", {}).get(robot_name, {}), instruction
                 )
+                actions = _resolve_coroutine(coro_or_result)
                 self.step(actions)
                 trajectory.append(
                     {"step": i, "sim_time": self._sim_time, "observation": obs}

--- a/strands_robots/newton/newton_gym_env.py
+++ b/strands_robots/newton/newton_gym_env.py
@@ -86,7 +86,7 @@ if HAS_GYM:
                 max_episode_steps: Maximum steps before truncation.
                 reward_fn: Custom reward function(obs_dict, action) -> float or np.ndarray.
                 success_fn: Custom success function(obs_dict) -> bool or np.ndarray.
-                obs_keys: Which observation keys to include. Default: ["joint_positions", "joint_velocities"].
+                obs_keys: Which observation keys to include. Default: ["joint_q", "joint_qd"].
             """
             super().__init__()
 
@@ -101,7 +101,7 @@ if HAS_GYM:
             self.max_episode_steps = max_episode_steps
             self.reward_fn = reward_fn
             self.success_fn = success_fn
-            self._obs_keys = obs_keys or ["joint_positions", "joint_velocities"]
+            self._obs_keys = obs_keys or ["joint_q", "joint_qd"]
 
             self._backend: Optional[NewtonBackend] = None
             self._step_count = 0
@@ -193,12 +193,22 @@ if HAS_GYM:
             result = self._backend.get_observation(self._robot_name)
             obs_data = result.get("observations", {}).get(self._robot_name, {})
 
-            jpos = obs_data.get("joint_positions")
-            jvel = obs_data.get("joint_velocities")
+            jpos = obs_data.get("joint_q")
+            jvel = obs_data.get("joint_qd")
 
             if jpos is None:
+                logger.warning(
+                    'joint_q not found in observation (available keys: %s). '
+                    'Falling back to zeros — RL training will be ineffective.',
+                    list(obs_data.keys()),
+                )
                 jpos = np.zeros(self._n_joints * self._num_envs, dtype=np.float32)
             if jvel is None:
+                logger.warning(
+                    'joint_qd not found in observation (available keys: %s). '
+                    'Falling back to zeros — RL training will be ineffective.',
+                    list(obs_data.keys()),
+                )
                 jvel = np.zeros(self._n_joints * self._num_envs, dtype=np.float32)
 
             jpos = np.asarray(jpos, dtype=np.float32).flatten()

--- a/strands_robots/newton/test_newton_backend.py
+++ b/strands_robots/newton/test_newton_backend.py
@@ -122,7 +122,7 @@ def test_observation():
     obs = b.get_observation("quad")
     assert obs["success"]
     assert "quad" in obs["observations"]
-    jp = obs["observations"]["quad"]["joint_positions"]
+    jp = obs["observations"]["quad"]["joint_q"]
     assert jp is not None
     assert len(jp) > 0
     b.destroy()


### PR DESCRIPTION
## Summary

Fixes two silent party-stopper bugs in the Newton simulation backend discovered during E2E testing of the `dev` branch.

## Bug 1: Observation Key Mismatch (Silent All-Zero RL Training)

`NewtonGymEnv._get_obs()` reads `"joint_positions"` / `"joint_velocities"` but `NewtonBackend.get_observation()` returns `"joint_q"` / `"joint_qd"`.

**Impact**: `obs_data.get("joint_positions")` returns `None`, falls through to `np.zeros()` silently. RL agents receive all-zero observations every step. Training appears to run but learns nothing. This is the worst kind of bug — silent, no errors, wastes GPU compute.

```python
# newton_gym_env.py L196-197 (before)
jpos = obs_data.get("joint_positions")  # → None → np.zeros()
jvel = obs_data.get("joint_velocities")  # → None → np.zeros()

# newton_backend.py L1754 (actual output)
obs["joint_q"] = state_0.joint_q.numpy()
obs["joint_qd"] = state_0.joint_qd.numpy()
```

## Bug 2: Missing Async Resolution (VLA Policy Crash)

`NewtonBackend.run_policy()` calls `policy.get_actions()` synchronously, but all `Policy` subclasses define `get_actions` as `async def`. The MuJoCo backend correctly uses `_resolve_coroutine()` at all 3 call sites; Newton skips it.

**Impact**: Any real VLA policy (GR00T N1.5/N1.6, DreamGen, DreamZero, LeRobot, SmolVLA) returns a coroutine object which gets passed as `actions` to `self.step()`. Only `MockPolicy` (sync inner class) works, which is why CI passes.

## Changes

| File | Change |
|------|--------|
| `newton_gym_env.py` | Fix obs keys: `joint_positions` → `joint_q`, `joint_velocities` → `joint_qd` |
| `newton_gym_env.py` | Add `logger.warning()` on zero-fallback to prevent silent failures |
| `newton_backend.py` | Add `_resolve_coroutine()` wrapper in `run_policy()` (matching MuJoCo) |
| `newton_backend.py` | Import `_resolve_coroutine` from `_async_utils` |
| `test_newton_backend.py` | Fix observation key assertion (`joint_positions` → `joint_q`) |

## Testing

- ✅ 73/73 unit tests pass
- ✅ `ruff check` clean
- ✅ 3 files changed, 19 insertions, 6 deletions

## Why CI Didn't Catch This

1. Newton tests require `warp-lang` + GPU → always SKIPPED in CI
2. `test_newton_backend.py` lives inside the package (not in `tests/`)
3. `MockPolicy` uses sync `get_actions()` inner class → async bug invisible
4. Zero-fallback has no warning log → key mismatch invisible

---
🤖 *AI agent response. [Strands Agents](https://github.com/strands-agents). Feedback welcome!*