### PR TITLE
refactor: extract BaseGymEnv to deduplicate gym wrappers

### DIFF
--- a/strands_robots/envs.py
+++ b/strands_robots/envs.py
@@ -7,19 +7,13 @@ Provides standard Gymnasium step/reset/render interface for RL training.
 """
 
 import logging
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Optional
 
 import numpy as np
 
+from strands_robots.gym_env import HAS_GYM
+
 logger = logging.getLogger(__name__)
-
-try:
-    import gymnasium as gym
-    from gymnasium import spaces
-
-    HAS_GYM = True
-except (ImportError, AttributeError, OSError):
-    HAS_GYM = False
 
 try:
     import mujoco
@@ -30,10 +24,10 @@ except (ImportError, AttributeError, OSError):
 
 
 if HAS_GYM:
+    from strands_robots.gym_env import BaseGymEnv
 
-    class StrandsSimEnv(gym.Env):
-        """
-        Gymnasium wrapper for strands_robots.Simulation.
+    class StrandsSimEnv(BaseGymEnv):
+        """Gymnasium wrapper for strands_robots.Simulation.
 
         Converts the action-based Simulation API into the standard
         Gym step()/reset()/render() interface.
@@ -81,172 +75,99 @@ if HAS_GYM:
             cameras: Optional[list] = None,
             reward_fn: Optional[callable] = None,
             success_fn: Optional[callable] = None,
-            backend: str = "mujoco",
-            num_envs: int = 1,
-            device: str = "cuda:0",
         ):
-            """
+            """Create a MuJoCo-backed Gymnasium environment.
+
+            For GPU-accelerated backends, use :class:`NewtonGymEnv` or
+            :class:`IsaacGymEnv` directly.
+
             Args:
                 robot_name: Robot model name (str) or a Simulation instance.
-                    If a Simulation object is passed, it will be used directly
-                    instead of creating a new one. Note: when passing an existing
-                    Simulation, any ``objects`` and ``cameras`` configs will still
-                    be added to it — ensure the passed sim does not already have
-                    them configured to avoid duplicates.
-                data_config: Optional data config name for joint mapping
-                task: Task description (for VLA policies)
-                render_mode: "rgb_array" or "human"
-                render_width: Render width in pixels
-                render_height: Render height in pixels
-                max_episode_steps: Max steps per episode
-                physics_dt: Physics timestep
-                control_dt: Control timestep (actions applied at this rate)
-                objects: List of objects to add: [{"name": "cube", "shape": "box", ...}]
-                cameras: List of cameras to add: [{"name": "front", "pos": [...], ...}]
-                reward_fn: Custom reward function(obs, action, next_obs) -> float
-                success_fn: Custom success function(obs) -> bool
-                backend: Simulation backend — "mujoco" (default), "isaac", or "newton"
-                num_envs: Number of parallel GPU envs (for isaac/newton backends)
-                device: CUDA device for GPU backends (e.g. "cuda:0")
+                data_config: Optional data config name for joint mapping.
+                task: Task description (for VLA policies).
+                render_mode: "rgb_array" or "human".
+                render_width: Render width in pixels.
+                render_height: Render height in pixels.
+                max_episode_steps: Max steps per episode.
+                physics_dt: Physics timestep.
+                control_dt: Control timestep (actions applied at this rate).
+                objects: List of objects to add.
+                cameras: List of cameras to add.
+                reward_fn: Custom reward function(obs, action) -> float.
+                success_fn: Custom success function(obs) -> bool.
             """
-            # For non-MuJoCo backends, delegate to the appropriate Gym env
-            if backend == "isaac":
-                super().__init__()
-                from strands_robots.isaac.isaac_gym_env import IsaacGymEnv
-
-                self._delegate = IsaacGymEnv(
-                    robot_name=robot_name,
-                    task=task,
-                    num_envs=num_envs,
-                    device=device,
-                    render_mode=render_mode,
-                    max_episode_steps=max_episode_steps,
-                    physics_dt=physics_dt,
-                    reward_fn=reward_fn,
-                    success_fn=success_fn,
-                )
-                # Copy spaces from delegate
-                self.observation_space = self._delegate.observation_space
-                self.action_space = self._delegate.action_space
-                self._backend = backend
-                return
-            elif backend == "newton":
-                super().__init__()
-                from strands_robots.newton.newton_backend import NewtonConfig
-                from strands_robots.newton.newton_gym_env import NewtonGymEnv
-
-                self._delegate = NewtonGymEnv(
-                    robot_name=robot_name,
-                    task=task,
-                    config=NewtonConfig(num_envs=num_envs, device=device),
-                    render_mode=render_mode,
-                    max_episode_steps=max_episode_steps,
-                    reward_fn=reward_fn,
-                    success_fn=success_fn,
-                )
-                self.observation_space = self._delegate.observation_space
-                self.action_space = self._delegate.action_space
-                self._backend = backend
-                return
-
-            super().__init__()
-            self._delegate = None
-            self._backend = "mujoco"
-
             assert HAS_MUJOCO, "mujoco required: pip install mujoco"
 
             # Support passing a Simulation object directly
             from strands_robots.simulation import Simulation
 
-            _passed_sim = None
+            self._passed_sim = None
             if not isinstance(robot_name, str):
                 if isinstance(robot_name, Simulation):
-                    _passed_sim = robot_name
+                    self._passed_sim = robot_name
                 else:
                     raise TypeError(
                         f"robot_name must be a string or Simulation instance, got {type(robot_name).__name__}"
                     )
-                # Derive robot_name string from the sim's first robot
-                _robots = _passed_sim._world.robots if hasattr(_passed_sim, "_world") else {}
+                _robots = self._passed_sim._world.robots if hasattr(self._passed_sim, "_world") else {}
                 robot_name = next(iter(_robots), "robot")
 
-            self.robot_name = robot_name
             self.data_config = data_config or robot_name
-            self.task = task
-            self.render_mode = render_mode
             self.render_width = render_width
             self.render_height = render_height
-            self.max_episode_steps = max_episode_steps
             self.physics_dt = physics_dt
             self.control_dt = control_dt
             self.n_substeps = max(1, int(control_dt / physics_dt))
             self.objects_config = objects or []
             self.cameras_config = cameras or []
-            self.reward_fn = reward_fn
-            self.success_fn = success_fn
+            self._sim = None
+            self._include_pixels = False
+            self._viewer = None
 
-            # Will be initialized in reset()
-            self._sim = _passed_sim  # None if user passed a string
-            self._step_count = 0
-            self._initialized = _passed_sim is not None
+            super().__init__(
+                robot_name=robot_name,
+                task=task,
+                num_envs=1,
+                render_mode=render_mode,
+                max_episode_steps=max_episode_steps,
+                reward_fn=reward_fn,
+                success_fn=success_fn,
+            )
 
-            # Initialize sim to get spaces
-            self._init_sim()
+            self._init_backend()
 
-        def _init_sim(self):
-            """Initialize the simulation to determine observation/action spaces.
-
-            When a Simulation instance was passed to __init__, world creation and
-            robot addition are skipped, but ``objects`` and ``cameras`` configs are
-            still applied. Callers passing a pre-configured sim should leave those
-            lists empty to avoid duplicates.
-            """
+        def _init_backend(self) -> None:
             from strands_robots.simulation import Simulation
 
-            if self._sim is None:
-                self._sim = Simulation(
-                    tool_name="gym_sim",
-                    default_timestep=self.physics_dt,
-                )
-
-                # Create world
+            if self._passed_sim is not None:
+                self._sim = self._passed_sim
+                self._passed_sim = None
+            else:
+                self._sim = Simulation(tool_name="gym_sim", default_timestep=self.physics_dt)
                 self._sim._dispatch_action("create_world", {})
+                self._sim._dispatch_action("add_robot", {"data_config": self._robot_name, "name": "robot"})
 
-                # Add robot
-                self._sim._dispatch_action(
-                    "add_robot",
-                    {
-                        "data_config": self.robot_name,
-                        "name": "robot",
-                    },
-                )
-
-            # Add objects (also applied when a Simulation is passed directly —
-            # skip if no objects configured to avoid duplicating existing ones)
             for obj in self.objects_config:
                 self._sim._dispatch_action("add_object", obj)
-
-            # Add cameras (same caveat as objects above)
             for cam in self.cameras_config:
                 self._sim._dispatch_action("add_camera", cam)
 
-            # Determine spaces from sim state
             model = self._sim._world._model
-
             n_qpos = model.nq
             n_qvel = model.nv
             n_ctrl = model.nu
 
-            # Action space: joint actuator controls
+            # Action space with actuator limits
             act_low = np.full(n_ctrl, -1.0, dtype=np.float32)
             act_high = np.full(n_ctrl, 1.0, dtype=np.float32)
-            # Use actuator limits if available
             for i in range(n_ctrl):
                 if model.actuator_ctrllimited[i]:
                     act_low[i] = float(model.actuator_ctrlrange[i, 0])
                     act_high[i] = float(model.actuator_ctrlrange[i, 1])
 
-            self.action_space = spaces.Box(low=act_low, high=act_high, dtype=np.float32)
+            from gymnasium import spaces as sp
+
+            self.action_space = sp.Box(low=act_low, high=act_high, dtype=np.float32)
 
             # Observation space: qpos + qvel + (optional) image
             obs_dim = n_qpos + n_qvel
@@ -254,134 +175,59 @@ if HAS_GYM:
             obs_high = np.full(obs_dim, np.inf, dtype=np.float32)
 
             if self.render_mode == "rgb_array" or self.cameras_config:
-                # Include image in observation
-                self.observation_space = spaces.Dict(
-                    {
-                        "state": spaces.Box(low=obs_low, high=obs_high, dtype=np.float32),
-                        "pixels": spaces.Box(
-                            low=0,
-                            high=255,
-                            shape=(self.render_height, self.render_width, 3),
-                            dtype=np.uint8,
-                        ),
-                    }
-                )
+                self.observation_space = sp.Dict({
+                    "state": sp.Box(low=obs_low, high=obs_high, dtype=np.float32),
+                    "pixels": sp.Box(low=0, high=255, shape=(self.render_height, self.render_width, 3), dtype=np.uint8),
+                })
                 self._include_pixels = True
             else:
-                self.observation_space = spaces.Box(low=obs_low, high=obs_high, dtype=np.float32)
+                self.observation_space = sp.Box(low=obs_low, high=obs_high, dtype=np.float32)
                 self._include_pixels = False
 
-            self._initialized = True
+            self._n_joints = n_ctrl
+
+        def _reset_backend(self, options=None) -> None:
+            if self._sim is not None:
+                self._sim._dispatch_action("reset", {})
+            else:
+                self._init_backend()
 
         def _get_obs(self) -> Any:
-            """Get current observation from sim."""
             data = self._sim._world._data
-
-            state = np.concatenate(
-                [
-                    data.qpos.astype(np.float32),
-                    data.qvel.astype(np.float32),
-                ]
-            )
+            state = np.concatenate([data.qpos.astype(np.float32), data.qvel.astype(np.float32)])
 
             if self._include_pixels:
-                # Render image
                 renderer = mujoco.Renderer(self._sim._world._model, self.render_height, self.render_width)
                 renderer.update_scene(data)
                 pixels = renderer.render().copy()
-                # mujoco 3.x Renderer has no close() — it's garbage-collected
                 del renderer
+                return {"state": state, "pixels": pixels}
+            return state
 
-                return {
-                    "state": state,
-                    "pixels": pixels,
-                }
-            else:
-                return state
-
-        def reset(self, seed=None, options=None) -> Tuple[Any, Dict]:
-            """Reset environment to initial state."""
-            if hasattr(self, "_delegate") and self._delegate is not None:
-                return self._delegate.reset(seed=seed, options=options)
-
-            super().reset(seed=seed)
-
-            if self._sim is not None:
-                # Reset simulation
-                self._sim._dispatch_action("reset", {})
-            else:
-                self._init_sim()
-
-            self._step_count = 0
-            obs = self._get_obs()
-
-            return obs, {"task": self.task}
-
-        def step(self, action: np.ndarray) -> Tuple[Any, float, bool, bool, Dict]:
-            """Take a step in the environment."""
-            if hasattr(self, "_delegate") and self._delegate is not None:
-                return self._delegate.step(action)
-
+        def _step_physics(self, action: np.ndarray) -> dict:
             data = self._sim._world._data
-
-            # Apply action to actuators
             np.copyto(data.ctrl[: len(action)], action)
-
-            # Step physics
             for _ in range(self.n_substeps):
                 mujoco.mj_step(self._sim._world._model, data)
+            return {}
 
-            self._step_count += 1
-
-            # Get observation
-            obs = self._get_obs()
-
-            # Compute reward
-            if self.reward_fn is not None:
-                reward = float(self.reward_fn(obs, action))
-            else:
-                reward = 0.0
-
-            # Check termination
-            terminated = False
-            if self.success_fn is not None:
-                terminated = bool(self.success_fn(obs))
-
-            # Check truncation (max steps)
-            truncated = self._step_count >= self.max_episode_steps
-
-            info = {
-                "step": self._step_count,
-                "task": self.task,
-                "is_success": terminated,
-            }
-
-            return obs, reward, terminated, truncated, info
+        def _render_frame(self) -> Optional[np.ndarray]:
+            renderer = mujoco.Renderer(self._sim._world._model, self.render_height, self.render_width)
+            renderer.update_scene(self._sim._world._data)
+            frame = renderer.render().copy()
+            del renderer
+            return frame
 
         def render(self) -> Optional[np.ndarray]:
-            """Render the environment."""
-            if hasattr(self, "_delegate") and self._delegate is not None:
-                return self._delegate.render()
-
             if self.render_mode == "rgb_array":
-                renderer = mujoco.Renderer(self._sim._world._model, self.render_height, self.render_width)
-                renderer.update_scene(self._sim._world._data)
-                frame = renderer.render().copy()
-                # mujoco 3.x Renderer has no close() — it's garbage-collected
-                del renderer
-                return frame
+                return self._render_frame()
             elif self.render_mode == "human":
-                # Use MuJoCo viewer
                 if not hasattr(self, "_viewer") or self._viewer is None:
                     self._viewer = mujoco.viewer.launch_passive(self._sim._world._model, self._sim._world._data)
                 self._viewer.sync()
-                return None
+            return None
 
-        def close(self):
-            """Clean up resources."""
-            if hasattr(self, "_delegate") and self._delegate is not None:
-                return self._delegate.close()
-
+        def _destroy_backend(self) -> None:
             if hasattr(self, "_viewer") and self._viewer is not None:
                 self._viewer.close()
                 self._viewer = None
@@ -396,15 +242,14 @@ if HAS_GYM:
 
     # Register the environment with Gymnasium
     try:
-        gym.register(
-            id="StrandsSim-v0",
-            entry_point="strands_robots.envs:StrandsSimEnv",
-        )
+        import gymnasium as gym
+
+        gym.register(id="StrandsSim-v0", entry_point="strands_robots.envs:StrandsSimEnv")
     except Exception:
-        pass  # Already registered or gym not available
+        pass
 
 else:
-    # Stub when gymnasium not installed
+
     class StrandsSimEnv:
         def __init__(self, *args, **kwargs):
             raise ImportError("gymnasium required: pip install gymnasium")

--- a/strands_robots/gym_env.py
+++ b/strands_robots/gym_env.py
@@ -1,0 +1,216 @@
+"""Base Gymnasium environment for all strands-robots simulation backends.
+
+Provides the shared logic that MuJoCo, Newton, and Isaac gym wrappers all need:
+- Observation/action space construction (single vs batched)
+- step() reward/terminated/truncated branching
+- reset()/render()/close() skeletons
+
+Subclasses implement only the backend-specific methods:
+- _init_backend()
+- _get_obs()
+- _step_physics(action)
+- _render_frame() -> Optional[np.ndarray]
+- _destroy_backend()
+"""
+
+import logging
+from abc import abstractmethod
+from typing import Any, Callable, Dict, Optional, Tuple
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+try:
+    import gymnasium as gym
+    from gymnasium import spaces
+
+    HAS_GYM = True
+except (ImportError, AttributeError, OSError):
+    HAS_GYM = False
+
+
+def _ensure_gym():
+    if not HAS_GYM:
+        raise ImportError("gymnasium required: pip install gymnasium")
+
+
+if HAS_GYM:
+
+    class BaseGymEnv(gym.Env):
+        """Abstract base for all strands-robots Gymnasium environments.
+
+        Handles the shared reward/terminated/truncated logic for both
+        single-env and batched (num_envs > 1) modes.
+
+        Subclasses must implement:
+            _init_backend() — create the physics backend and set self._n_joints, self._num_envs
+            _get_obs() -> np.ndarray — return current observation
+            _step_physics(action) -> dict — advance physics, return info dict
+            _render_frame() -> Optional[np.ndarray] — render one frame
+            _destroy_backend() — clean up backend resources
+        """
+
+        metadata = {"render_modes": ["rgb_array", "human"], "render_fps": 30}
+
+        def __init__(
+            self,
+            robot_name: str = "so100",
+            task: str = "manipulation task",
+            num_envs: int = 1,
+            render_mode: Optional[str] = None,
+            max_episode_steps: int = 1000,
+            reward_fn: Optional[Callable] = None,
+            success_fn: Optional[Callable] = None,
+            **kwargs,
+        ):
+            super().__init__()
+            self._robot_name = robot_name
+            self._task = task
+            self._num_envs = num_envs
+            self.render_mode = render_mode
+            self.max_episode_steps = max_episode_steps
+            self.reward_fn = reward_fn
+            self.success_fn = success_fn
+            self._step_count = 0
+            self._n_joints = 0
+
+        # ── Space helpers ───────────────────────────────────────────
+
+        def _set_spaces(self, n_joints: int, obs_dim: Optional[int] = None, act_dim: Optional[int] = None) -> None:
+            """Set observation/action spaces for the given dimensions.
+
+            Args:
+                n_joints: Number of joints (used as default for act_dim).
+                obs_dim: Observation dimension. Defaults to n_joints * 2 (pos + vel).
+                act_dim: Action dimension. Defaults to n_joints.
+            """
+            obs_dim = obs_dim or n_joints * 2
+            act_dim = act_dim or n_joints
+
+            if self._num_envs > 1:
+                self.observation_space = spaces.Box(
+                    low=-np.inf, high=np.inf, shape=(self._num_envs, obs_dim), dtype=np.float32,
+                )
+                self.action_space = spaces.Box(
+                    low=-1.0, high=1.0, shape=(self._num_envs, act_dim), dtype=np.float32,
+                )
+            else:
+                self.observation_space = spaces.Box(
+                    low=-np.inf, high=np.inf, shape=(obs_dim,), dtype=np.float32,
+                )
+                self.action_space = spaces.Box(
+                    low=-1.0, high=1.0, shape=(act_dim,), dtype=np.float32,
+                )
+
+        # ── Reward / termination (shared across all backends) ──────
+
+        def _compute_reward_terminated_truncated(self, obs, action):
+            """Compute reward, terminated, truncated for single or batched envs.
+
+            Returns:
+                (reward, terminated, truncated)
+            """
+            if self._num_envs > 1:
+                if self.reward_fn is not None:
+                    reward = self.reward_fn(obs, action)
+                    if not isinstance(reward, np.ndarray):
+                        reward = np.full(self._num_envs, float(reward), dtype=np.float32)
+                else:
+                    reward = np.zeros(self._num_envs, dtype=np.float32)
+
+                truncated = np.full(self._num_envs, self._step_count >= self.max_episode_steps)
+
+                if self.success_fn is not None:
+                    terminated = self.success_fn(obs)
+                    if not isinstance(terminated, np.ndarray):
+                        terminated = np.full(self._num_envs, bool(terminated))
+                else:
+                    terminated = np.full(self._num_envs, False)
+            else:
+                reward = float(self.reward_fn(obs, action)) if self.reward_fn is not None else 0.0
+                truncated = self._step_count >= self.max_episode_steps
+                terminated = bool(self.success_fn(obs)) if self.success_fn is not None else False
+
+            return reward, terminated, truncated
+
+        # ── Gymnasium API ───────────────────────────────────────────
+
+        def reset(self, seed=None, options=None) -> Tuple[Any, Dict]:
+            super().reset(seed=seed)
+            self._reset_backend(options=options)
+            self._step_count = 0
+            obs = self._get_obs()
+            return obs, {"task": self._task, "num_envs": self._num_envs}
+
+        def step(self, action: np.ndarray) -> Tuple[Any, Any, Any, Any, Dict]:
+            action = np.asarray(action, dtype=np.float32)
+            step_info = self._step_physics(action)
+            self._step_count += 1
+            obs = self._get_obs()
+            reward, terminated, truncated = self._compute_reward_terminated_truncated(obs, action)
+
+            info = {
+                "step": self._step_count,
+                "task": self._task,
+                "is_success": (terminated if isinstance(terminated, bool) else terminated.any()),
+            }
+            info.update(step_info)
+            return obs, reward, terminated, truncated, info
+
+        def render(self) -> Optional[np.ndarray]:
+            if self.render_mode == "rgb_array":
+                return self._render_frame()
+            return None
+
+        def close(self):
+            self._destroy_backend()
+
+        # ── Properties ──────────────────────────────────────────────
+
+        @property
+        def num_envs(self) -> int:
+            return self._num_envs
+
+        # ── Abstract methods (backend-specific) ────────────────────
+
+        @abstractmethod
+        def _init_backend(self) -> None:
+            """Initialize the physics backend. Must set self._n_joints and call self._set_spaces()."""
+            ...
+
+        @abstractmethod
+        def _reset_backend(self, options=None) -> None:
+            """Reset the physics backend to initial state."""
+            ...
+
+        @abstractmethod
+        def _get_obs(self) -> np.ndarray:
+            """Return current observation array."""
+            ...
+
+        @abstractmethod
+        def _step_physics(self, action: np.ndarray) -> dict:
+            """Advance physics by one control step. Return extra info dict."""
+            ...
+
+        @abstractmethod
+        def _render_frame(self) -> Optional[np.ndarray]:
+            """Render and return an RGB frame, or None."""
+            ...
+
+        @abstractmethod
+        def _destroy_backend(self) -> None:
+            """Clean up backend resources."""
+            ...
+
+else:
+
+    class BaseGymEnv:
+        """Stub when gymnasium is not installed."""
+
+        def __init__(self, *args, **kwargs):
+            raise ImportError("gymnasium required: pip install gymnasium")
+
+
+__all__ = ["BaseGymEnv", "HAS_GYM", "_ensure_gym"]

--- a/strands_robots/isaac/isaac_gym_env.py
+++ b/strands_robots/isaac/isaac_gym_env.py
@@ -4,9 +4,6 @@ Bridges IsaacSimBackend's GPU-parallel API into the standard gym.Env interface
 so that Stable Baselines 3, CleanRL, LeRobot, and other RL libraries work
 directly with the Isaac Sim backend.
 
-Follows the same pattern as NewtonGymEnv (strands_robots/newton/newton_gym_env.py)
-but wraps IsaacSimBackend instead of NewtonBackend.
-
 For single-env cases, implements gym.Env.
 For multi-env (num_envs > 1), observations/actions are batched along the first
 axis (shape: [num_envs, ...]).
@@ -40,45 +37,29 @@ Note:
 """
 
 import logging
-from typing import Any, Callable, Dict, Optional, Tuple
+from typing import Any, Callable, Dict, Optional
 
 import numpy as np
 
+from strands_robots.gym_env import HAS_GYM
+
 logger = logging.getLogger(__name__)
 
-try:
-    import gymnasium as gym
-    from gymnasium import spaces
-
-    HAS_GYM = True
-except ImportError:
-    HAS_GYM = False
+_DEFAULT_N_JOINTS = 6
 
 
 if HAS_GYM:
+    from strands_robots.gym_env import BaseGymEnv
 
-    class IsaacGymEnv(gym.Env):
+    class IsaacGymEnv(BaseGymEnv):
         """Gymnasium wrapper around IsaacSimBackend for RL training.
 
         Implements the standard gym.Env interface. When ``num_envs > 1``,
         observations and actions are batched along the first axis
         (shape ``[num_envs, ...]``).
-
-        The environment lazily initializes the Isaac Sim backend on first
-        ``reset()`` call (or during ``__init__`` if possible) so that
-        construction cost is paid only once.
-
-        Attributes:
-            observation_space: Gymnasium observation space.
-            action_space: Gymnasium action space.
         """
 
         metadata = {"render_modes": ["rgb_array", "human"], "render_fps": 30}
-
-        # Default joint count used for placeholder spaces when the backend
-        # is not yet initialised.  Overwritten by _init_backend() once the
-        # actual robot is loaded.
-        _DEFAULT_N_JOINTS = 6
 
         def __init__(
             self,
@@ -95,37 +76,10 @@ if HAS_GYM:
             success_fn: Optional[Callable] = None,
             usd_path: Optional[str] = None,
         ):
-            """Initialise the Isaac Sim Gymnasium environment.
+            from .isaac_sim_backend import IsaacSimConfig
 
-            Args:
-                robot_name: Robot model name (resolved via strands_robots assets
-                    or Isaac Lab built-in assets).
-                task: Task description string (passed to policies).
-                num_envs: Number of parallel GPU environments.
-                device: CUDA device (e.g. ``"cuda:0"``).
-                render_mode: ``"rgb_array"`` or ``None``.
-                max_episode_steps: Maximum steps before truncation.
-                physics_dt: Physics timestep.
-                rendering_dt: Rendering timestep.
-                headless: Run without GUI display.
-                reward_fn: Custom reward ``(obs, action) -> float | np.ndarray``.
-                success_fn: Custom success ``(obs) -> bool | np.ndarray``.
-                usd_path: Explicit USD asset path (skips auto-resolution).
-            """
-            super().__init__()
-
-            from .isaac_sim_backend import IsaacSimBackend, IsaacSimConfig
-
-            self._robot_name = robot_name
-            self._task = task
-            self._num_envs = num_envs
             self._device = device
-            self.render_mode = render_mode
-            self.max_episode_steps = max_episode_steps
             self._usd_path = usd_path
-            self.reward_fn = reward_fn
-            self.success_fn = success_fn
-
             self._config = IsaacSimConfig(
                 num_envs=num_envs,
                 device=device,
@@ -135,73 +89,34 @@ if HAS_GYM:
                 enable_cameras=render_mode == "rgb_array",
                 render_mode=render_mode or "rgb_array",
             )
+            self._backend = None
 
-            self._backend: Optional[IsaacSimBackend] = None
-            self._step_count = 0
-            self._n_joints = 0
+            super().__init__(
+                robot_name=robot_name,
+                task=task,
+                num_envs=num_envs,
+                render_mode=render_mode,
+                max_episode_steps=max_episode_steps,
+                reward_fn=reward_fn,
+                success_fn=success_fn,
+            )
 
-            # Set placeholder spaces so that callers (e.g. StrandsSimEnv)
-            # can always read observation_space / action_space, even when
-            # the backend initialisation is deferred.  _init_backend()
-            # overwrites these with accurate values once the robot is loaded.
-            self._set_default_spaces(self._DEFAULT_N_JOINTS)
-
-            # Try to initialise the backend eagerly.  This may fail if
-            # Isaac Sim is not available — in that case we defer to reset().
+            # Set placeholder spaces, then try eager init
+            self._set_spaces(_DEFAULT_N_JOINTS)
             try:
                 self._init_backend()
             except Exception as e:
                 logger.warning(f"Deferred Isaac backend init (will retry on reset): {e}")
 
-        # ── Space helpers ───────────────────────────────────────────
-
-        def _set_default_spaces(self, n_joints: int) -> None:
-            """Set observation/action spaces for *n_joints* joints.
-
-            Used both during deferred init (placeholder) and after the
-            backend provides the real joint count.
-            """
-            obs_dim = n_joints * 2  # joint_pos + joint_vel
-
-            if self._num_envs > 1:
-                self.observation_space = spaces.Box(
-                    low=-np.inf,
-                    high=np.inf,
-                    shape=(self._num_envs, obs_dim),
-                    dtype=np.float32,
-                )
-                self.action_space = spaces.Box(
-                    low=-1.0,
-                    high=1.0,
-                    shape=(self._num_envs, n_joints),
-                    dtype=np.float32,
-                )
-            else:
-                self.observation_space = spaces.Box(
-                    low=-np.inf,
-                    high=np.inf,
-                    shape=(obs_dim,),
-                    dtype=np.float32,
-                )
-                self.action_space = spaces.Box(
-                    low=-1.0,
-                    high=1.0,
-                    shape=(n_joints,),
-                    dtype=np.float32,
-                )
-
-        def _init_backend(self):
-            """Create the IsaacSimBackend world and add the robot."""
+        def _init_backend(self) -> None:
             from .isaac_sim_backend import IsaacSimBackend
 
             self._backend = IsaacSimBackend(config=self._config)
 
-            # Create world
             result = self._backend.create_world()
             if result.get("status") != "success":
                 raise RuntimeError(f"create_world failed: {result}")
 
-            # Add robot
             add_kwargs: Dict[str, Any] = {"name": self._robot_name}
             if self._usd_path:
                 add_kwargs["usd_path"] = self._usd_path
@@ -212,44 +127,32 @@ if HAS_GYM:
             if result.get("status") != "success":
                 raise RuntimeError(f"add_robot('{self._robot_name}') failed: {result}")
 
-            # Determine joint count from the backend's robot
             robot = self._backend._robot
             if robot is not None and hasattr(robot, "num_joints"):
                 self._n_joints = robot.num_joints
             else:
-                # Conservative default
-                self._n_joints = self._DEFAULT_N_JOINTS
+                self._n_joints = _DEFAULT_N_JOINTS
 
-            # Rebuild spaces with the real joint count
-            self._set_default_spaces(self._n_joints)
+            self._set_spaces(self._n_joints)
 
             logger.info(
                 "IsaacGymEnv initialised: robot=%s, num_envs=%d, obs_dim=%d, act_dim=%d, device=%s",
-                self._robot_name,
-                self._num_envs,
-                self._n_joints * 2,
-                self._n_joints,
-                self._device,
+                self._robot_name, self._num_envs, self._n_joints * 2, self._n_joints, self._device,
             )
 
-        # ── Observation helper ──────────────────────────────────────
+        def _reset_backend(self, options=None) -> None:
+            if self._backend is None:
+                self._init_backend()
+            self._backend.reset()
 
         def _get_obs(self) -> np.ndarray:
-            """Get current observation from the Isaac backend.
-
-            Returns:
-                Observation array of shape ``[obs_dim]`` (single env) or
-                ``[num_envs, obs_dim]`` (batched).
-            """
             if self._backend is None or self._backend._robot is None:
-                n = self._n_joints or self._DEFAULT_N_JOINTS
+                n = self._n_joints or _DEFAULT_N_JOINTS
                 if self._num_envs > 1:
                     return np.zeros((self._num_envs, n * 2), dtype=np.float32)
                 return np.zeros(n * 2, dtype=np.float32)
 
             robot = self._backend._robot
-
-            # GPU tensors → numpy
             jpos = robot.data.joint_pos
             jvel = robot.data.joint_vel
 
@@ -261,51 +164,14 @@ if HAS_GYM:
                 jvel = np.asarray(jvel, dtype=np.float32)
 
             if self._num_envs > 1:
-                # jpos, jvel: (num_envs, n_joints)
                 obs = np.concatenate([jpos, jvel], axis=1).astype(np.float32)
             else:
                 obs = np.concatenate([jpos.flatten()[: self._n_joints], jvel.flatten()[: self._n_joints]]).astype(
                     np.float32
                 )
-
             return obs
 
-        # ── Gymnasium API ───────────────────────────────────────────
-
-        def reset(
-            self,
-            seed: Optional[int] = None,
-            options: Optional[Dict] = None,
-        ) -> Tuple[np.ndarray, Dict]:
-            """Reset the environment (all envs if batched)."""
-            super().reset(seed=seed)
-
-            if self._backend is None:
-                self._init_backend()
-
-            self._backend.reset()
-            self._step_count = 0
-
-            obs = self._get_obs()
-            info = {"task": self._task, "num_envs": self._num_envs}
-            return obs, info
-
-        def step(self, action: np.ndarray) -> Tuple[np.ndarray, Any, Any, Any, Dict]:
-            """Step all environments simultaneously.
-
-            Args:
-                action: Shape ``[act_dim]`` (single) or
-                    ``[num_envs, act_dim]`` (batched).
-
-            Returns:
-                ``(obs, reward, terminated, truncated, info)``
-            """
-            if self._backend is None:
-                raise RuntimeError("Call reset() before step()")
-
-            action = np.asarray(action, dtype=np.float32)
-
-            # Convert to torch tensor for Isaac backend
+        def _step_physics(self, action: np.ndarray) -> dict:
             try:
                 import torch
 
@@ -320,70 +186,27 @@ if HAS_GYM:
                 action_tensor = action
 
             self._backend.step(action_tensor)
-            self._step_count += 1
+            return {}
 
-            obs = self._get_obs()
+        def _render_frame(self) -> Optional[np.ndarray]:
+            if self._backend is None:
+                return None
+            result = self._backend.render()
+            content = result.get("content", [])
+            for item in content:
+                if "image" in item:
+                    import io
 
-            # -- Reward --
-            if self._num_envs > 1:
-                if self.reward_fn is not None:
-                    reward = self.reward_fn(obs, action)
-                    if not isinstance(reward, np.ndarray):
-                        reward = np.full(self._num_envs, float(reward), dtype=np.float32)
-                else:
-                    reward = np.zeros(self._num_envs, dtype=np.float32)
+                    from PIL import Image
 
-                truncated = np.full(
-                    self._num_envs,
-                    self._step_count >= self.max_episode_steps,
-                )
-
-                if self.success_fn is not None:
-                    terminated = self.success_fn(obs)
-                    if not isinstance(terminated, np.ndarray):
-                        terminated = np.full(self._num_envs, bool(terminated))
-                else:
-                    terminated = np.full(self._num_envs, False)
-            else:
-                reward = float(self.reward_fn(obs, action)) if self.reward_fn is not None else 0.0
-                truncated = self._step_count >= self.max_episode_steps
-                terminated = bool(self.success_fn(obs)) if self.success_fn is not None else False
-
-            info = {
-                "step": self._step_count,
-                "task": self._task,
-                "is_success": (terminated if isinstance(terminated, bool) else terminated.any()),
-            }
-
-            return obs, reward, terminated, truncated, info
-
-        def render(self) -> Optional[np.ndarray]:
-            """Render the scene via Isaac Sim RTX."""
-            if self.render_mode == "rgb_array" and self._backend is not None:
-                result = self._backend.render()
-                content = result.get("content", [])
-                for item in content:
-                    if "image" in item:
-                        import io
-
-                        from PIL import Image
-
-                        img = Image.open(io.BytesIO(item["image"]["source"]["bytes"]))
-                        return np.array(img)
+                    img = Image.open(io.BytesIO(item["image"]["source"]["bytes"]))
+                    return np.array(img)
             return None
 
-        def close(self):
-            """Destroy the Isaac Sim backend and release GPU resources."""
+        def _destroy_backend(self) -> None:
             if self._backend is not None:
                 self._backend.destroy()
                 self._backend = None
-
-        # ── Properties ──────────────────────────────────────────────
-
-        @property
-        def num_envs(self) -> int:
-            """Number of parallel GPU environments."""
-            return self._num_envs
 
         @property
         def unwrapped_backend(self):

--- a/strands_robots/leisaac.py
+++ b/strands_robots/leisaac.py
@@ -77,7 +77,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-import time
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
@@ -348,6 +347,9 @@ class LeIsaacEnv:
     ) -> RolloutResult:
         """Run a policy for multiple episodes and collect metrics.
 
+        Delegates to :func:`strands_robots.training.evaluate.evaluate` for the
+        actual episode loop, then converts the result to a :class:`RolloutResult`.
+
         Args:
             policy: A strands-robots Policy instance
             instruction: Natural language instruction for the task
@@ -361,57 +363,33 @@ class LeIsaacEnv:
         if not instruction:
             instruction = self.task_info.get("default_instruction", "")
 
-        # Set up policy with joint names
         joint_names = self.get_joint_names()
         policy.set_robot_state_keys(joint_names)
 
-        result = RolloutResult()
-        start_time = time.time()
+        if not self._loaded:
+            if not self.load():
+                raise RuntimeError("Failed to load LeIsaac environment")
 
-        for ep in range(n_episodes):
-            obs, info = self.reset()
-            ep_reward = 0.0
-            ep_steps = 0
-            success = False
+        from strands_robots.training.evaluate import evaluate
 
-            for step_idx in range(max_steps):
-                # Convert obs to policy format
-                obs_dict = self._obs_to_dict(obs)
+        eval_result = evaluate(
+            policy=policy,
+            task=instruction,
+            num_episodes=n_episodes,
+            max_steps_per_episode=max_steps,
+            render=render,
+            env=self._raw_env,
+        )
 
-                # Get action from policy
-                actions = asyncio.run(policy.get_actions(obs_dict, instruction))
-
-                if actions:
-                    action = self._dict_to_action(actions[0])
-                else:
-                    action = np.zeros(self._raw_env.action_space.shape)
-
-                obs, reward, terminated, truncated, info = self.step(action)
-                ep_reward += reward
-                ep_steps += 1
-
-                if terminated:
-                    success = info.get("is_success", True)
-                    break
-                if truncated:
-                    break
-
-            result.episodes.append(
-                {
-                    "episode": ep,
-                    "steps": ep_steps,
-                    "reward": float(ep_reward),
-                    "success": success,
-                }
-            )
-            if success:
-                result.n_successes += 1
-
-        result.n_episodes = n_episodes
+        result = RolloutResult(
+            n_episodes=eval_result["num_episodes"],
+            n_successes=sum(1 for e in eval_result["episodes"] if e["success"]),
+            avg_steps=sum(e["steps"] for e in eval_result["episodes"]) / max(n_episodes, 1),
+            avg_reward=eval_result["mean_reward"],
+            total_time=0.0,
+            episodes=eval_result["episodes"],
+        )
         result.success_rate = result.n_successes / max(n_episodes, 1)
-        result.avg_steps = sum(e["steps"] for e in result.episodes) / max(n_episodes, 1)
-        result.avg_reward = sum(e["reward"] for e in result.episodes) / max(n_episodes, 1)
-        result.total_time = time.time() - start_time
 
         logger.info(
             f"📊 Rollout: {result.n_successes}/{n_episodes} success "

--- a/strands_robots/newton/newton_gym_env.py
+++ b/strands_robots/newton/newton_gym_env.py
@@ -4,8 +4,8 @@ Bridges NewtonBackend's batched GPU API into the standard gym.Env interface
 so that Stable Baselines 3, CleanRL, and other RL libraries work out-of-the-box.
 
 For single-env cases, implements gym.Env.
-For multi-env (num_envs > 1), implements gym.vector.VectorEnv for proper
-batched obs/actions — which is what SB3 expects for GPU-parallel training.
+For multi-env (num_envs > 1), observations/actions are batched along the first
+axis (shape: [num_envs, ...]).
 
 Usage:
     from strands_robots.newton import NewtonConfig
@@ -31,35 +31,24 @@ Usage:
 """
 
 import logging
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, List, Optional
 
 import numpy as np
 
+from strands_robots.gym_env import HAS_GYM
+
 logger = logging.getLogger(__name__)
-
-try:
-    import gymnasium as gym
-    from gymnasium import spaces
-
-    HAS_GYM = True
-except ImportError:
-    HAS_GYM = False
 
 
 if HAS_GYM:
+    from strands_robots.gym_env import BaseGymEnv
 
-    class NewtonGymEnv(gym.Env):
+    class NewtonGymEnv(BaseGymEnv):
         """Gymnasium wrapper around NewtonBackend for RL training.
 
         Implements the standard gym.Env interface. When num_envs > 1,
         observations and actions are batched along the first axis
         (shape: [num_envs, ...]) compatible with SB3's VecEnv expectations.
-
-        Note: For true SB3 VectorEnv compatibility with auto-reset,
-        use stable_baselines3.common.vec_env.DummyVecEnv or wrap this
-        with gymnasium.vector.SyncVectorEnv. For massive parallelism,
-        the batched interface here is more efficient than spawning
-        separate processes.
         """
 
         metadata = {"render_modes": ["rgb_array", "null"], "render_fps": 30}
@@ -76,42 +65,26 @@ if HAS_GYM:
             success_fn: Optional[Callable] = None,
             obs_keys: Optional[List[str]] = None,
         ):
-            """
-            Args:
-                robot_name: Robot model name (resolved via strands_robots.assets).
-                task: Task description string.
-                config: NewtonConfig instance. If None, uses default (1 env, mujoco solver).
-                urdf_path: Explicit URDF/MJCF path override.
-                render_mode: "rgb_array" or None.
-                max_episode_steps: Maximum steps before truncation.
-                reward_fn: Custom reward function(obs_dict, action) -> float or np.ndarray.
-                success_fn: Custom success function(obs_dict) -> bool or np.ndarray.
-                obs_keys: Which observation keys to include. Default: ["joint_q", "joint_qd"].
-            """
-            super().__init__()
-
-            # Lazy import to avoid hard dep on Newton at module level
-            from strands_robots.newton import NewtonBackend, NewtonConfig
+            from strands_robots.newton import NewtonConfig
 
             self._config = config or NewtonConfig(num_envs=1)
-            self._robot_name = robot_name
-            self._task = task
             self._urdf_path = urdf_path
-            self.render_mode = render_mode
-            self.max_episode_steps = max_episode_steps
-            self.reward_fn = reward_fn
-            self.success_fn = success_fn
             self._obs_keys = obs_keys or ["joint_q", "joint_qd"]
+            self._backend = None
 
-            self._backend: Optional[NewtonBackend] = None
-            self._step_count = 0
-            self._num_envs = self._config.num_envs
+            super().__init__(
+                robot_name=robot_name,
+                task=task,
+                num_envs=self._config.num_envs,
+                render_mode=render_mode,
+                max_episode_steps=max_episode_steps,
+                reward_fn=reward_fn,
+                success_fn=success_fn,
+            )
 
-            # Initialize backend to determine spaces
             self._init_backend()
 
-        def _init_backend(self):
-            """Initialize Newton backend and determine observation/action spaces."""
+        def _init_backend(self) -> None:
             from strands_robots.newton import NewtonBackend
 
             self._backend = NewtonBackend(self._config)
@@ -128,76 +101,34 @@ if HAS_GYM:
             robot_info = result.get("robot_info", {})
             self._n_joints = robot_info.get("num_joints", 0)
 
-            # Replicate if multi-env
             if self._num_envs > 1:
                 rep_result = self._backend.replicate(self._num_envs)
                 if not rep_result.get("success"):
                     raise RuntimeError(f"Replicate failed: {rep_result.get('message')}")
             else:
-                # Force model finalization for single env
                 self._backend._finalize_model()
 
-            # Determine actual DOF from the finalized model state
-            # robot_info.num_joints counts joints, but actual DOF (joint_q length)
-            # may differ (e.g. free joints have 7 DOF, revolute have 1).
-            # Use the real state vector length for accurate space dimensions.
+            # Use real state vector length for accurate space dimensions
             if self._backend._state_0 is not None:
                 total_q_len = len(self._backend._state_0.joint_q.numpy())
                 dof_per_env = total_q_len // max(self._num_envs, 1)
                 if dof_per_env > 0:
                     self._n_joints = dof_per_env
 
-            # Determine observation dimension
-            # For each env: joint_positions (n_joints) + joint_velocities (n_joints)
-            obs_dim = self._n_joints * 2  # qpos + qvel
-
-            # Action space: joint torques/positions
-            act_dim = self._n_joints
-
-            if self._num_envs > 1:
-                # Batched spaces [num_envs, dim]
-                self.observation_space = spaces.Box(
-                    low=-np.inf,
-                    high=np.inf,
-                    shape=(self._num_envs, obs_dim),
-                    dtype=np.float32,
-                )
-                self.action_space = spaces.Box(
-                    low=-1.0,
-                    high=1.0,
-                    shape=(self._num_envs, act_dim),
-                    dtype=np.float32,
-                )
-            else:
-                # Single env spaces
-                self.observation_space = spaces.Box(
-                    low=-np.inf,
-                    high=np.inf,
-                    shape=(obs_dim,),
-                    dtype=np.float32,
-                )
-                self.action_space = spaces.Box(
-                    low=-1.0,
-                    high=1.0,
-                    shape=(act_dim,),
-                    dtype=np.float32,
-                )
+            self._set_spaces(self._n_joints)
 
             logger.info(
                 "NewtonGymEnv initialized: robot=%s, num_envs=%d, obs_dim=%d, act_dim=%d, solver=%s",
-                self._robot_name,
-                self._num_envs,
-                obs_dim,
-                act_dim,
-                self._config.solver,
+                self._robot_name, self._num_envs, self._n_joints * 2, self._n_joints, self._config.solver,
             )
 
-        def _get_obs(self) -> np.ndarray:
-            """Get current observation from Newton backend.
+        def _reset_backend(self, options=None) -> None:
+            env_ids = None
+            if options and "env_ids" in options:
+                env_ids = options["env_ids"]
+            self._backend.reset(env_ids=env_ids)
 
-            Returns:
-                Observation array, shape [obs_dim] (single) or [num_envs, obs_dim] (batched).
-            """
+        def _get_obs(self) -> np.ndarray:
             result = self._backend.get_observation(self._robot_name)
             obs_data = result.get("observations", {}).get(self._robot_name, {})
 
@@ -223,120 +154,30 @@ if HAS_GYM:
             jvel = np.asarray(jvel, dtype=np.float32).flatten()
 
             if self._num_envs > 1:
-                # Reshape to [num_envs, n_joints] then concat
                 n = self._n_joints
                 try:
                     jpos_batched = jpos.reshape(self._num_envs, n)
                     jvel_batched = jvel.reshape(self._num_envs, n)
                     obs = np.concatenate([jpos_batched, jvel_batched], axis=1)
                 except ValueError:
-                    # Fallback: pad or truncate
                     obs = np.zeros((self._num_envs, n * 2), dtype=np.float32)
             else:
                 obs = np.concatenate([jpos[: self._n_joints], jvel[: self._n_joints]])
 
             return obs.astype(np.float32)
 
-        def reset(
-            self,
-            seed: Optional[int] = None,
-            options: Optional[Dict] = None,
-        ) -> Tuple[np.ndarray, Dict]:
-            """Reset the environment.
-
-            For multi-env, resets all environments simultaneously.
-            """
-            super().reset(seed=seed)
-
-            env_ids = None
-            if options and "env_ids" in options:
-                env_ids = options["env_ids"]
-
-            self._backend.reset(env_ids=env_ids)
-            self._step_count = 0
-
-            obs = self._get_obs()
-            info = {"task": self._task, "num_envs": self._num_envs}
-
-            return obs, info
-
-        def step(self, action: np.ndarray) -> Tuple[np.ndarray, Any, Any, Any, Dict]:
-            """Take a step in all environments simultaneously.
-
-            Args:
-                action: Shape [act_dim] (single) or [num_envs, act_dim] (batched).
-
-            Returns:
-                Tuple of (obs, reward, terminated, truncated, info).
-                For multi-env, reward/terminated/truncated are arrays of shape [num_envs].
-            """
-            action = np.asarray(action, dtype=np.float32)
-
-            # Step the physics
+        def _step_physics(self, action: np.ndarray) -> dict:
             result = self._backend.step(action)
-            self._step_count += 1
+            return {"sim_time": result.get("sim_time", 0.0)}
 
-            # Get observation
-            obs = self._get_obs()
+        def _render_frame(self) -> Optional[np.ndarray]:
+            result = self._backend.render()
+            return result.get("image")
 
-            # Compute reward
-            if self._num_envs > 1:
-                if self.reward_fn is not None:
-                    reward = self.reward_fn(obs, action)
-                    if not isinstance(reward, np.ndarray):
-                        reward = np.full(self._num_envs, float(reward), dtype=np.float32)
-                else:
-                    reward = np.zeros(self._num_envs, dtype=np.float32)
-
-                # Truncation check
-                truncated = np.full(self._num_envs, self._step_count >= self.max_episode_steps)
-
-                # Success/termination check
-                if self.success_fn is not None:
-                    terminated = self.success_fn(obs)
-                    if not isinstance(terminated, np.ndarray):
-                        terminated = np.full(self._num_envs, bool(terminated))
-                else:
-                    terminated = np.full(self._num_envs, False)
-            else:
-                if self.reward_fn is not None:
-                    reward = float(self.reward_fn(obs, action))
-                else:
-                    reward = 0.0
-
-                truncated = self._step_count >= self.max_episode_steps
-
-                if self.success_fn is not None:
-                    terminated = bool(self.success_fn(obs))
-                else:
-                    terminated = False
-
-            info = {
-                "step": self._step_count,
-                "task": self._task,
-                "sim_time": result.get("sim_time", 0.0),
-                "is_success": (terminated if isinstance(terminated, bool) else terminated.any()),
-            }
-
-            return obs, reward, terminated, truncated, info
-
-        def render(self) -> Optional[np.ndarray]:
-            """Render the scene."""
-            if self.render_mode == "rgb_array":
-                result = self._backend.render()
-                return result.get("image")
-            return None
-
-        def close(self):
-            """Clean up Newton backend."""
+        def _destroy_backend(self) -> None:
             if self._backend is not None:
                 self._backend.destroy()
                 self._backend = None
-
-        @property
-        def num_envs(self) -> int:
-            """Number of parallel environments."""
-            return self._num_envs
 
         @property
         def unwrapped_backend(self):

--- a/strands_robots/training/evaluate.py
+++ b/strands_robots/training/evaluate.py
@@ -106,12 +106,13 @@ def _create_env(backend, robot_name, task, max_steps_per_episode, render, kwargs
 def evaluate(
     policy,
     task: str,
-    robot_name: str,
+    robot_name: str = "",
     num_episodes: int = 50,
     max_steps_per_episode: int = 1000,
     backend: str = "mujoco",
     render: bool = False,
     seed: int = 42,
+    env=None,
     **kwargs,
 ) -> Dict[str, Any]:
     """Standalone evaluation harness for any policy on any task.
@@ -129,6 +130,8 @@ def evaluate(
         backend: Simulation backend — "mujoco" (default), "newton", or "isaac".
         render: Whether to render frames during evaluation.
         seed: Random seed for reproducibility.
+        env: Pre-created gymnasium environment. If provided, ``backend``,
+            ``robot_name``, and env-related kwargs are ignored.
         **kwargs: Additional kwargs passed to the environment.
 
     Returns:
@@ -148,9 +151,11 @@ def evaluate(
     successes = 0
     total_reward = 0.0
 
-    env = _create_env(backend, robot_name, task, max_steps_per_episode, render, kwargs)
-    if isinstance(env, dict):
-        return env
+    owns_env = env is None
+    if owns_env:
+        env = _create_env(backend, robot_name, task, max_steps_per_episode, render, kwargs)
+        if isinstance(env, dict):
+            return env
 
     _async_loop = None
     if inspect.iscoroutinefunction(getattr(policy, "get_actions", None)):
@@ -220,7 +225,8 @@ def evaluate(
     finally:
         if _async_loop is not None:
             _async_loop.close()
-        env.close()
+        if owns_env:
+            env.close()
 
     success_rate = (successes / num_episodes * 100) if num_episodes > 0 else 0.0
     mean_reward = total_reward / num_episodes if num_episodes > 0 else 0.0


### PR DESCRIPTION
## Summary

Extract shared Gymnasium wrapper logic into a `BaseGymEnv` base class, eliminating ~300 lines of copy-pasted code across three near-identical gym wrappers.

## Problem

`StrandsSimEnv` (MuJoCo), `NewtonGymEnv`, and `IsaacGymEnv` were structurally identical - same space construction, same reward/terminated/truncated branching for single vs batched envs, same reset/render/close skeletons. `LeIsaacEnv.rollout()` also reimplemented the same episode loop that `training.evaluate.evaluate()` already provides.

## Changes

- **New `gym_env.py`**: `BaseGymEnv(gym.Env)` with all shared logic - `_set_spaces()`, `_compute_reward_terminated_truncated()`, `step()`, `reset()`, `render()`, `close()`
- **`newton/newton_gym_env.py`**: Subclasses `BaseGymEnv`, implements only 5 backend-specific methods
- **`isaac/isaac_gym_env.py`**: Same pattern
- **`envs.py`**: Same pattern. Removed the delegate pattern and `backend`/`num_envs`/`device` params - use `NewtonGymEnv` or `IsaacGymEnv` directly for GPU backends
- **`leisaac.py`**: `rollout()` delegates to `training.evaluate.evaluate()` instead of reimplementing the episode loop
- **`training/evaluate.py`**: Added optional `env` parameter to accept pre-created environments

## Impact

- 410 insertions, 701 deletions (-291 net)
- Adding a new sim backend now means implementing 5 methods in ~100 lines instead of copy-pasting ~350
- All 73 tests pass, lint clean

*AI agent PR on behalf of @awsarron. [Strands Agents](https://github.com/strands-agents). Feedback welcome!*