### PR TITLE
feat: Zenoh-native web dashboard, camera streaming & teleop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,11 @@ dependencies = [
     "msgpack>=1.0.0",
 ]
 
+
+[project.scripts]
+robots = "strands_robots.dashboard:main"
+robots-dashboard = "strands_robots.dashboard:main"
+
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
 lint = "ruff check strands_robots tests"

--- a/strands_robots/dashboard/__init__.py
+++ b/strands_robots/dashboard/__init__.py
@@ -1,0 +1,1 @@
+# Dashboard package

--- a/strands_robots/dashboard/__init__.py
+++ b/strands_robots/dashboard/__init__.py
@@ -1,1 +1,4 @@
 # Dashboard package
+from strands_robots.dashboard.server import main
+
+__all__ = ["main"]

--- a/strands_robots/dashboard/__main__.py
+++ b/strands_robots/dashboard/__main__.py
@@ -1,0 +1,4 @@
+"""Run the dashboard: python -m strands_robots.dashboard"""
+from strands_robots.dashboard.server import main
+
+main()

--- a/strands_robots/dashboard/server.py
+++ b/strands_robots/dashboard/server.py
@@ -1,0 +1,1591 @@
+#!/usr/bin/env python3
+"""Strands Robots Dashboard — Zenoh-native web dashboard for all Robot() instances.
+
+Every Robot("so100"), Robot("panda"), etc. auto-joins the Zenoh mesh.
+This dashboard subscribes to ALL mesh traffic and renders it in a
+real-time web UI:
+
+- Live peer discovery (robots, sims, agents)
+- Joint state visualization (sparklines + gauges)
+- VLA execution stream (watch policy steps live)
+- Camera feeds (JPEG frames from sim/real cameras over Zenoh)
+- Action vector visualization (live bar charts)
+- Command dispatch (tell any robot to do something)
+- Emergency stop (broadcast to all)
+- Agent grid layout — switch between peers, see everything at once
+
+Architecture:
+    Robot() ──► Zenoh mesh ◄── Dashboard (this)
+    Robot() ──►              ◄── Agent
+    Sim()   ──►              ◄── Other dashboards
+
+Usage:
+    python -m strands_robots.dashboard.server --port 7860
+    # Opens http://localhost:7860
+
+    # Or from Python:
+    from strands_robots.dashboard.server import start_dashboard
+    start_dashboard(port=7860)
+"""
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import socket
+import threading
+import time
+import uuid
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+from socketserver import ThreadingMixIn
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# State — shared between Zenoh subscribers and WebSocket clients
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+_STATE: Dict[str, Any] = {
+    "peers": {},           # peer_id → {type, hostname, last_seen, caps, ...}
+    "states": {},          # peer_id → {joints, sim_time, task, ...}
+    "streams": {},         # peer_id → [last N stream steps]
+    "cameras": {},         # peer_id → {camera_name: base64_jpeg}
+    "commands_sent": [],   # [{target, cmd, ts}, ...]
+    "responses": [],       # [{from, turn, result, ts}, ...]
+    "events": [],          # [{ts, type, data}, ...] ring buffer
+}
+_STATE_LOCK = threading.Lock()
+_WS_CLIENTS: List[Any] = []
+_WS_LOCK = threading.Lock()
+_ZENOH_SESSION = None
+_ZENOH_SUBS = []
+_DASHBOARD_PEER_ID = f"dashboard-{uuid.uuid4().hex[:6]}"
+
+MAX_EVENTS = 500
+MAX_STREAM_STEPS = 200
+
+
+def _add_event(event_type: str, data: dict):
+    """Add event to the ring buffer."""
+    with _STATE_LOCK:
+        _STATE["events"].append({
+            "ts": time.time(),
+            "type": event_type,
+            "data": data,
+        })
+        if len(_STATE["events"]) > MAX_EVENTS:
+            _STATE["events"] = _STATE["events"][-MAX_EVENTS:]
+    _broadcast_ws({"type": "event", "event_type": event_type, "data": data, "ts": time.time()})
+
+
+def _broadcast_ws(msg: dict):
+    """Send message to all connected WebSocket clients."""
+    payload = json.dumps(msg, default=str)
+    with _WS_LOCK:
+        dead = []
+        for ws in _WS_CLIENTS:
+            try:
+                ws.send(payload)
+            except Exception:
+                dead.append(ws)
+        for ws in dead:
+            _WS_CLIENTS.remove(ws)
+
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# Zenoh Mesh Subscriber — listens to everything on strands/**
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+def _start_zenoh():
+    """Connect to the Zenoh mesh and subscribe to all robot traffic."""
+    global _ZENOH_SESSION
+
+    try:
+        import zenoh
+    except ImportError:
+        logger.warning("eclipse-zenoh not installed. Dashboard runs without live mesh data.")
+        logger.warning("Install: pip install eclipse-zenoh")
+        return False
+
+    try:
+        config = zenoh.Config()
+
+        MESH_PORT = int(os.getenv("STRANDS_MESH_PORT", "7447"))
+        MESH_EP = f"tcp/127.0.0.1:{MESH_PORT}"
+
+        connect = os.getenv("ZENOH_CONNECT")
+        listen = os.getenv("ZENOH_LISTEN")
+
+        if connect:
+            config.insert_json5("connect/endpoints", json.dumps([e.strip() for e in connect.split(",")]))
+        if listen:
+            config.insert_json5("listen/endpoints", json.dumps([e.strip() for e in listen.split(",")]))
+
+        if not connect and not listen:
+            try:
+                cfg_try = zenoh.Config()
+                cfg_try.insert_json5("listen/endpoints", json.dumps([MESH_EP]))
+                cfg_try.insert_json5("connect/endpoints", json.dumps([MESH_EP]))
+                _ZENOH_SESSION = zenoh.open(cfg_try)
+                logger.info("Zenoh dashboard session opened (listener on %s)", MESH_EP)
+            except Exception:
+                config.insert_json5("mode", '"client"')
+                config.insert_json5("connect/endpoints", json.dumps([MESH_EP]))
+                _ZENOH_SESSION = zenoh.open(config)
+                logger.info("Zenoh dashboard session opened (client)")
+        else:
+            _ZENOH_SESSION = zenoh.open(config)
+            logger.info("Zenoh dashboard session opened")
+
+        # Subscribe to all strands topics
+        _ZENOH_SUBS.append(_ZENOH_SESSION.declare_subscriber("strands/*/presence", _on_presence))
+        _ZENOH_SUBS.append(_ZENOH_SESSION.declare_subscriber("strands/*/state", _on_state))
+        _ZENOH_SUBS.append(_ZENOH_SESSION.declare_subscriber("strands/*/stream", _on_stream))
+        _ZENOH_SUBS.append(_ZENOH_SESSION.declare_subscriber("strands/*/camera", _on_camera))
+        _ZENOH_SUBS.append(_ZENOH_SESSION.declare_subscriber("strands/*/event", _on_sim_event))
+        _ZENOH_SUBS.append(_ZENOH_SESSION.declare_subscriber("strands/broadcast", _on_broadcast))
+        _ZENOH_SUBS.append(_ZENOH_SESSION.declare_subscriber("reachy_mini/**", _on_external))
+
+        # Publish dashboard presence
+        threading.Thread(target=_dashboard_heartbeat, daemon=True).start()
+
+        logger.info("Zenoh subscriptions active — listening for robots")
+        return True
+
+    except Exception as e:
+        logger.error("Zenoh setup failed: %s", e)
+        return False
+
+
+def _dashboard_heartbeat():
+    """Publish dashboard presence on the mesh."""
+    while _ZENOH_SESSION:
+        try:
+            _ZENOH_SESSION.put(
+                f"strands/{_DASHBOARD_PEER_ID}/presence",
+                json.dumps({
+                    "robot_id": _DASHBOARD_PEER_ID,
+                    "robot_type": "dashboard",
+                    "hostname": socket.gethostname(),
+                    "timestamp": time.time(),
+                    "ws_clients": len(_WS_CLIENTS),
+                }).encode(),
+            )
+        except Exception:
+            pass
+        time.sleep(2.0)
+
+
+def _on_presence(sample):
+    """Handle presence heartbeats from robots/sims."""
+    try:
+        data = json.loads(sample.payload.to_bytes().decode())
+        peer_id = data.get("robot_id", "")
+        if not peer_id or peer_id == _DASHBOARD_PEER_ID:
+            return
+
+        with _STATE_LOCK:
+            is_new = peer_id not in _STATE["peers"]
+            _STATE["peers"][peer_id] = {
+                **data,
+                "last_seen": time.time(),
+            }
+
+        if is_new:
+            _add_event("peer_join", {"peer_id": peer_id, **data})
+            logger.info("🤖 New peer: %s (%s)", peer_id, data.get("robot_type", "?"))
+
+            # Auto-request camera stream from sim and robot peers
+            role = data.get("role", data.get("robot_type", ""))
+            if role in ("sim", "robot"):
+                threading.Thread(
+                    target=lambda pid=peer_id: (
+                        time.sleep(1),  # Wait for peer to be fully ready
+                        _send_command(pid, {"action": "start_camera_stream", "camera": "default", "fps": 10 if role == "sim" else 5}),
+                        logger.info("📹 Auto-requested camera stream from %s", pid),
+                    ),
+                    daemon=True,
+                ).start()
+
+        _broadcast_ws({"type": "peers", "peers": _get_peers()})
+
+    except Exception as e:
+        logger.debug("Presence parse error: %s", e)
+
+
+def _on_state(sample):
+    """Handle state updates (joint positions, sim time, task status)."""
+    try:
+        data = json.loads(sample.payload.to_bytes().decode())
+        peer_id = data.get("peer_id", "")
+        if not peer_id:
+            return
+
+        with _STATE_LOCK:
+            _STATE["states"][peer_id] = {
+                **data,
+                "_received_at": time.time(),
+            }
+
+        _broadcast_ws({"type": "state", "peer_id": peer_id, "state": data})
+
+    except Exception as e:
+        logger.debug("State parse error: %s", e)
+
+
+def _on_stream(sample):
+    """Handle VLA execution stream steps."""
+    try:
+        data = json.loads(sample.payload.to_bytes().decode())
+        peer_id = data.get("peer_id", "")
+        if not peer_id:
+            return
+
+        with _STATE_LOCK:
+            if peer_id not in _STATE["streams"]:
+                _STATE["streams"][peer_id] = []
+            _STATE["streams"][peer_id].append(data)
+            if len(_STATE["streams"][peer_id]) > MAX_STREAM_STEPS:
+                _STATE["streams"][peer_id] = _STATE["streams"][peer_id][-MAX_STREAM_STEPS:]
+
+        _broadcast_ws({"type": "stream_step", "peer_id": peer_id, "step": data})
+
+    except Exception as e:
+        logger.debug("Stream parse error: %s", e)
+
+
+def _on_camera(sample):
+    """Handle camera frame data (base64 JPEG from sim/real cameras)."""
+    try:
+        data = json.loads(sample.payload.to_bytes().decode())
+        peer_id = data.get("peer_id", "")
+        cam_name = data.get("camera", "default")
+        frame_b64 = data.get("frame", "")
+        if not peer_id or not frame_b64:
+            return
+
+        with _STATE_LOCK:
+            if peer_id not in _STATE["cameras"]:
+                _STATE["cameras"][peer_id] = {}
+            _STATE["cameras"][peer_id][cam_name] = frame_b64
+
+        # Forward camera frame to WS clients that are watching this peer
+        _broadcast_ws({
+            "type": "camera_frame",
+            "peer_id": peer_id,
+            "camera": cam_name,
+            "frame": frame_b64,
+            "ts": data.get("ts", time.time()),
+        })
+
+    except Exception as e:
+        logger.debug("Camera parse error: %s", e)
+
+
+def _on_broadcast(sample):
+    """Handle broadcast messages (e.g., emergency stop)."""
+    try:
+        data = json.loads(sample.payload.to_bytes().decode())
+        _add_event("broadcast", data)
+    except Exception:
+        pass
+
+
+def _on_sim_event(sample):
+    """Handle discrete simulation events (object added/removed, policy started, etc.)."""
+    try:
+        data = json.loads(sample.payload.to_bytes().decode())
+        peer_id = data.get("peer_id", "")
+        event_type = data.get("event_type", "")
+        event_data = data.get("data", {})
+        if not peer_id or not event_type:
+            return
+
+        _add_event(f"sim:{event_type}", {"peer_id": peer_id, **event_data})
+
+        # Forward to WS clients as a dedicated message type
+        _broadcast_ws({
+            "type": "sim_event",
+            "peer_id": peer_id,
+            "event_type": event_type,
+            "data": event_data,
+            "ts": data.get("ts", time.time()),
+        })
+
+    except Exception as e:
+        logger.debug("Sim event parse error: %s", e)
+
+
+def _on_external(sample):
+    """Handle external robot topics (Reachy Mini, etc.)."""
+    try:
+        key = str(sample.key_expr)
+        raw = sample.payload.to_bytes().decode()
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            data = {"raw": raw}
+
+        _add_event("external", {"topic": key, "data": data})
+    except Exception:
+        pass
+
+
+def _get_peers() -> list:
+    """Get all peers with age calculation."""
+    now = time.time()
+    with _STATE_LOCK:
+        peers = []
+        stale = []
+        for pid, info in _STATE["peers"].items():
+            age = now - info.get("last_seen", 0)
+            if age > 15.0:
+                stale.append(pid)
+                continue
+            peers.append({
+                "peer_id": pid,
+                "type": info.get("robot_type", "unknown"),
+                "hostname": info.get("hostname", "?"),
+                "age": round(age, 1),
+                "task_status": info.get("task_status", ""),
+                "instruction": info.get("instruction", ""),
+                "tool_name": info.get("tool_name", ""),
+                "connected": info.get("connected", None),
+                "sim_robots": info.get("sim_robots", []),
+                "world": info.get("world", False),
+                "action_keys": info.get("action_keys", []),
+            })
+        for pid in stale:
+            del _STATE["peers"][pid]
+            _add_event("peer_leave", {"peer_id": pid})
+        return peers
+
+
+def _send_command(target: str, command: dict):
+    """Send a command to a peer via Zenoh."""
+    if not _ZENOH_SESSION:
+        return {"error": "Zenoh not connected"}
+
+    turn_id = uuid.uuid4().hex[:8]
+    msg = {
+        "sender_id": _DASHBOARD_PEER_ID,
+        "turn_id": turn_id,
+        "command": command,
+        "timestamp": time.time(),
+    }
+
+    try:
+        if target == "broadcast":
+            _ZENOH_SESSION.put("strands/broadcast", json.dumps(msg).encode())
+        else:
+            _ZENOH_SESSION.put(f"strands/{target}/cmd", json.dumps(msg).encode())
+
+        with _STATE_LOCK:
+            _STATE["commands_sent"].append({
+                "target": target,
+                "command": command,
+                "turn_id": turn_id,
+                "ts": time.time(),
+            })
+            if len(_STATE["commands_sent"]) > 100:
+                _STATE["commands_sent"] = _STATE["commands_sent"][-100:]
+
+        _add_event("command_sent", {"target": target, "command": command, "turn_id": turn_id})
+        return {"status": "sent", "turn_id": turn_id}
+
+    except Exception as e:
+        return {"error": str(e)}
+
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# WebSocket Handler (using websockets library)
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+async def _ws_handler(websocket):
+    """Handle a single WebSocket client connection."""
+    class WSWrapper:
+        def __init__(self, ws):
+            self._ws = ws
+            self._loop = asyncio.get_event_loop()
+
+        def send(self, data):
+            asyncio.run_coroutine_threadsafe(self._ws.send(data), self._loop)
+
+    wrapper = WSWrapper(websocket)
+    with _WS_LOCK:
+        _WS_CLIENTS.append(wrapper)
+
+    logger.info("WebSocket client connected (%d total)", len(_WS_CLIENTS))
+
+    try:
+        # Send initial state
+        await websocket.send(json.dumps({
+            "type": "init",
+            "peers": _get_peers(),
+            "dashboard_id": _DASHBOARD_PEER_ID,
+            "states": {k: v for k, v in _STATE.get("states", {}).items()},
+            "events": _STATE.get("events", [])[-50:],
+        }, default=str))
+
+        async for message in websocket:
+            try:
+                msg = json.loads(message)
+                msg_type = msg.get("type", "")
+
+                if msg_type == "command":
+                    target = msg.get("target", "")
+                    command = msg.get("command", {})
+                    result = _send_command(target, command)
+                    await websocket.send(json.dumps({"type": "command_result", **result}, default=str))
+
+                elif msg_type == "tell":
+                    target = msg.get("target", "")
+                    instruction = msg.get("instruction", "")
+                    policy = msg.get("policy_provider", "mock")
+                    duration = msg.get("duration", 30.0)
+
+                    # Handle special commands
+                    if instruction == "__stop__" or msg.get("stop"):
+                        result = _send_command(target, {"action": "stop"})
+                        await websocket.send(json.dumps({"type": "command_result", "action": "stop", **result}, default=str))
+                    elif instruction == "__teleop_start__" or msg.get("teleop"):
+                        cmd = {
+                            "action": "teleop_start",
+                            "policy_provider": policy,
+                            "duration": duration,
+                        }
+                        for k in ("pretrained_name_or_path", "model_path", "server_address", "policy_type"):
+                            if k in msg:
+                                cmd[k] = msg[k]
+                        result = _send_command(target, cmd)
+                        await websocket.send(json.dumps({"type": "command_result", "action": "teleop_start", **result}, default=str))
+                    elif instruction == "__teleop_stop__" or msg.get("teleop_stop"):
+                        result = _send_command(target, {"action": "teleop_stop"})
+                        await websocket.send(json.dumps({"type": "command_result", "action": "teleop_stop", **result}, default=str))
+                    elif instruction == "__teleop_delta__" and msg.get("teleop_delta"):
+                        delta = msg["teleop_delta"]
+                        result = _send_command(target, {"action": "teleop_delta", **delta})
+                        # Don't send ack for delta (too noisy)
+                    else:
+                        cmd = {
+                            "action": "execute",
+                            "instruction": instruction,
+                            "policy_provider": policy,
+                            "duration": duration,
+                        }
+                        # Forward extra policy kwargs
+                        for k in ("pretrained_name_or_path", "model_path", "server_address", "policy_type"):
+                            if k in msg:
+                                cmd[k] = msg[k]
+                        result = _send_command(target, cmd)
+                        await websocket.send(json.dumps({"type": "command_result", **result}, default=str))
+
+                elif msg_type == "emergency_stop":
+                    result = _send_command("broadcast", {"action": "stop"})
+                    await websocket.send(json.dumps({"type": "command_result", "action": "emergency_stop", **result}, default=str))
+
+                elif msg_type == "get_peers":
+                    await websocket.send(json.dumps({"type": "peers", "peers": _get_peers()}, default=str))
+
+                elif msg_type == "get_state":
+                    peer_id = msg.get("peer_id", "")
+                    state = _STATE.get("states", {}).get(peer_id, {})
+                    await websocket.send(json.dumps({"type": "state", "peer_id": peer_id, "state": state}, default=str))
+
+                elif msg_type == "get_stream":
+                    peer_id = msg.get("peer_id", "")
+                    steps = _STATE.get("streams", {}).get(peer_id, [])
+                    await websocket.send(json.dumps({"type": "stream_history", "peer_id": peer_id, "steps": steps[-50:]}, default=str))
+
+                elif msg_type == "get_camera":
+                    peer_id = msg.get("peer_id", "")
+                    cams = _STATE.get("cameras", {}).get(peer_id, {})
+                    await websocket.send(json.dumps({"type": "camera_state", "peer_id": peer_id, "cameras": cams}, default=str))
+
+                elif msg_type == "request_camera_stream":
+                    # Ask a sim peer to start publishing camera frames
+                    target = msg.get("peer_id", "")
+                    cam = msg.get("camera", "default")
+                    fps = msg.get("fps", 10)
+                    result = _send_command(target, {
+                        "action": "start_camera_stream",
+                        "camera": cam,
+                        "fps": fps,
+                    })
+                    await websocket.send(json.dumps({"type": "command_result", **result}, default=str))
+
+                elif msg_type == "ping":
+                    await websocket.send(json.dumps({"type": "pong", "ts": time.time()}))
+
+            except json.JSONDecodeError:
+                await websocket.send(json.dumps({"type": "error", "message": "Invalid JSON"}))
+            except Exception as e:
+                await websocket.send(json.dumps({"type": "error", "message": str(e)}))
+
+    except Exception:
+        pass
+    finally:
+        with _WS_LOCK:
+            if wrapper in _WS_CLIENTS:
+                _WS_CLIENTS.remove(wrapper)
+        logger.info("WebSocket client disconnected (%d remaining)", len(_WS_CLIENTS))
+
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# HTML Dashboard UI — Full Agent Grid
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+DASHBOARD_HTML = r"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Strands Robots Dashboard</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+:root{
+  --bg:#07070d;--surface:#0e0e18;--surface2:#151524;--surface3:#1c1c30;
+  --border:#252540;--border2:#35355a;
+  --text:#e8e8f0;--text2:#8888aa;--text3:#555570;
+  --accent:#7c6cf0;--accent2:#a89afe;--accent-dim:rgba(124,108,240,0.15);
+  --green:#00d4a0;--green-dim:rgba(0,212,160,0.15);
+  --red:#ff5252;--red-dim:rgba(255,82,82,0.15);
+  --orange:#ffb74d;--orange-dim:rgba(255,183,77,0.15);
+  --blue:#64b5f6;--blue-dim:rgba(100,181,246,0.15);
+  --cyan:#4dd0e1;--yellow:#ffd54f;
+  --radius:8px;--radius-lg:12px;
+}
+body{font-family:'Inter','SF Pro',system-ui,sans-serif;background:var(--bg);color:var(--text);min-height:100vh;overflow:hidden}
+
+/* ── Header ── */
+.header{background:var(--surface);border-bottom:1px solid var(--border);padding:10px 20px;display:flex;align-items:center;gap:14px;height:48px;z-index:100}
+.header .logo{font-size:16px;font-weight:700;display:flex;align-items:center;gap:8px}
+.header .logo span{background:linear-gradient(135deg,var(--accent),var(--cyan));-webkit-background-clip:text;-webkit-text-fill-color:transparent}
+.header .status{font-size:11px;color:var(--text3);display:flex;align-items:center;gap:4px}
+.header .status .dot{width:6px;height:6px;border-radius:50%;background:var(--text3)}
+.header .status.connected .dot{background:var(--green);box-shadow:0 0 6px var(--green)}
+.header .status.connected{color:var(--green)}
+.header .peer-count{font-size:11px;color:var(--text2);background:var(--surface2);padding:3px 10px;border-radius:12px;border:1px solid var(--border)}
+.header .view-toggle{display:flex;gap:2px;background:var(--surface2);border-radius:6px;padding:2px;border:1px solid var(--border);margin-left:auto}
+.header .view-toggle button{background:none;border:none;color:var(--text3);padding:4px 12px;border-radius:4px;cursor:pointer;font-size:11px;font-weight:500}
+.header .view-toggle button.active{background:var(--accent-dim);color:var(--accent2)}
+.header .estop{background:var(--red);color:white;border:none;padding:6px 14px;border-radius:6px;cursor:pointer;font-weight:700;font-size:12px;letter-spacing:0.5px;transition:all 0.15s}
+.header .estop:hover{background:#ff3333;box-shadow:0 0 20px rgba(255,82,82,0.4)}
+
+/* ── Layout ── */
+.app{display:flex;height:calc(100vh - 48px)}
+.sidebar{width:240px;background:var(--surface);border-right:1px solid var(--border);overflow-y:auto;flex-shrink:0;padding:12px}
+.sidebar h3{font-size:10px;color:var(--text3);text-transform:uppercase;letter-spacing:1.5px;margin-bottom:8px;padding:0 4px}
+.main-area{flex:1;overflow:auto;padding:16px}
+.event-sidebar{width:280px;background:var(--surface);border-left:1px solid var(--border);overflow-y:auto;flex-shrink:0;padding:12px}
+.event-sidebar h3{font-size:10px;color:var(--text3);text-transform:uppercase;letter-spacing:1.5px;margin-bottom:8px}
+
+/* ── Peer Cards (sidebar) ── */
+.peer-item{background:var(--surface2);border:1px solid var(--border);border-radius:var(--radius);padding:10px;margin-bottom:6px;cursor:pointer;transition:all 0.15s}
+.peer-item:hover{border-color:var(--border2);background:var(--surface3)}
+.peer-item.selected{border-color:var(--accent);background:var(--accent-dim)}
+.peer-item .top{display:flex;align-items:center;gap:6px;margin-bottom:4px}
+.peer-item .dot{width:7px;height:7px;border-radius:50%;flex-shrink:0}
+.peer-item .dot.alive{background:var(--green);box-shadow:0 0 4px var(--green)}
+.peer-item .dot.stale{background:var(--orange)}
+.peer-item .name{font-size:12px;font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1}
+.peer-item .badge{font-size:9px;padding:1px 6px;border-radius:4px;font-weight:600;flex-shrink:0}
+.peer-item .badge.sim{background:var(--blue-dim);color:var(--blue)}
+.peer-item .badge.robot{background:var(--green-dim);color:var(--green)}
+.peer-item .badge.agent{background:var(--accent-dim);color:var(--accent2)}
+.peer-item .badge.dashboard{background:var(--surface3);color:var(--text3)}
+.peer-item .meta{font-size:10px;color:var(--text3);display:flex;gap:8px}
+.peer-item .task{font-size:10px;color:var(--orange);margin-top:3px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+
+/* ── Grid View ── */
+.grid-view{display:grid;grid-template-columns:repeat(auto-fill,minmax(420px,1fr));gap:12px}
+.grid-card{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-lg);overflow:hidden;display:flex;flex-direction:column}
+.grid-card .card-header{padding:10px 14px;border-bottom:1px solid var(--border);display:flex;align-items:center;gap:8px;background:var(--surface2)}
+.grid-card .card-header .name{font-size:13px;font-weight:600;flex:1}
+.grid-card .card-header .pill{font-size:9px;padding:2px 8px;border-radius:10px;font-weight:600}
+.grid-card .card-body{display:grid;grid-template-columns:1fr 1fr;gap:0;flex:1;min-height:0}
+
+/* ── Camera Feed ── */
+.camera-panel{background:#000;position:relative;min-height:180px;display:flex;align-items:center;justify-content:center;border-right:1px solid var(--border)}
+.camera-panel img{max-width:100%;max-height:100%;object-fit:contain}
+.camera-panel .no-feed{color:var(--text3);font-size:11px;text-align:center}
+.camera-panel .no-feed .icon{font-size:28px;margin-bottom:6px;opacity:0.3}
+.camera-panel .fps-badge{position:absolute;top:6px;right:6px;background:rgba(0,0,0,0.7);color:var(--green);font-size:9px;padding:2px 6px;border-radius:4px;font-family:monospace}
+
+/* ── Joint State Panel ── */
+.joints-panel{padding:10px;overflow-y:auto;max-height:300px}
+.joints-panel h4{font-size:9px;color:var(--text3);text-transform:uppercase;letter-spacing:1px;margin-bottom:6px}
+.joint-row{display:flex;align-items:center;gap:6px;margin-bottom:3px;font-size:11px}
+.joint-row .jname{color:var(--text2);min-width:70px;font-size:10px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.joint-row .jbar{flex:1;height:4px;background:var(--surface3);border-radius:2px;overflow:hidden;position:relative}
+.joint-row .jbar .fill{height:100%;border-radius:2px;transition:width 0.1s ease}
+.joint-row .jval{color:var(--accent2);font-family:monospace;font-size:10px;min-width:50px;text-align:right}
+
+/* ── Action Vector Panel ── */
+.action-panel{padding:10px;border-top:1px solid var(--border);grid-column:1/-1}
+.action-panel h4{font-size:9px;color:var(--text3);text-transform:uppercase;letter-spacing:1px;margin-bottom:6px}
+.action-bars{display:flex;gap:3px;align-items:end;height:40px}
+.action-bar{flex:1;background:var(--accent-dim);border-radius:2px 2px 0 0;transition:height 0.1s;position:relative;min-width:0}
+.action-bar .tip{position:absolute;top:-14px;left:50%;transform:translateX(-50%);font-size:8px;color:var(--text3);white-space:nowrap;display:none}
+.action-bars:hover .action-bar .tip{display:block}
+
+/* ── Stream Panel ── */
+.stream-panel{padding:10px;border-top:1px solid var(--border);grid-column:1/-1;max-height:150px;overflow-y:auto}
+.stream-panel h4{font-size:9px;color:var(--text3);text-transform:uppercase;letter-spacing:1px;margin-bottom:6px;display:flex;align-items:center;gap:6px}
+.stream-panel h4 .live{width:6px;height:6px;border-radius:50%;background:var(--red);animation:pulse 1.5s infinite}
+@keyframes pulse{0%,100%{opacity:1}50%{opacity:0.3}}
+.stream-line{font-size:10px;font-family:monospace;padding:2px 0;color:var(--text2);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.stream-line .step{color:var(--accent);margin-right:6px}
+.stream-line .instr{color:var(--orange)}
+
+/* ── Detail View ── */
+.detail-view{display:grid;grid-template-columns:1fr 340px;gap:16px;height:100%}
+.detail-main{display:flex;flex-direction:column;gap:12px;overflow-y:auto}
+.detail-sidebar{display:flex;flex-direction:column;gap:12px;overflow-y:auto}
+.detail-camera{background:#000;border-radius:var(--radius-lg);min-height:300px;display:flex;align-items:center;justify-content:center;position:relative;overflow:hidden}
+.detail-camera img{max-width:100%;max-height:100%;object-fit:contain}
+.detail-joints{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-lg);padding:14px}
+.detail-actions{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-lg);padding:14px}
+.detail-stream{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-lg);padding:14px;max-height:300px;overflow-y:auto}
+
+/* ── Command Bar ── */
+.cmd-bar{padding:12px 14px;border-top:1px solid var(--border);grid-column:1/-1;background:var(--surface2);display:flex;flex-direction:column;gap:8px}
+.cmd-bar .cmd-row{display:flex;gap:6px;align-items:center}
+.cmd-bar select{background:var(--surface3);border:1px solid var(--border);color:var(--text);padding:6px 8px;border-radius:var(--radius);font-size:11px;cursor:pointer}
+.cmd-bar input{flex:1;background:var(--surface3);border:1px solid var(--border);color:var(--text);padding:8px 10px;border-radius:var(--radius);font-size:12px;font-family:inherit}
+.cmd-bar input:focus{outline:none;border-color:var(--accent)}
+.cmd-bar input::placeholder{color:var(--text3)}
+.cmd-bar .btn{border:none;padding:7px 14px;border-radius:var(--radius);cursor:pointer;font-size:11px;font-weight:600;transition:all 0.15s;white-space:nowrap;display:flex;align-items:center;gap:4px}
+.cmd-bar .btn-primary{background:var(--accent);color:white}
+.cmd-bar .btn-primary:hover{background:var(--accent2)}
+.cmd-bar .btn-green{background:var(--green);color:#111}
+.cmd-bar .btn-green:hover{background:#00e8b0;box-shadow:0 0 12px rgba(0,212,160,0.3)}
+.cmd-bar .btn-orange{background:var(--orange);color:#111}
+.cmd-bar .btn-orange:hover{background:#ffc76e}
+.cmd-bar .btn-red{background:var(--red-dim);color:var(--red);border:1px solid var(--red)}
+.cmd-bar .btn-red:hover{background:var(--red);color:white}
+.cmd-bar .cmd-label{font-size:9px;color:var(--text3);text-transform:uppercase;letter-spacing:0.5px;font-weight:600}
+
+/* ── Events ── */
+.evt{font-size:10px;padding:5px 0;border-bottom:1px solid rgba(37,37,64,0.5);line-height:1.4}
+.evt .ts{color:var(--text3);margin-right:4px;font-family:monospace;font-size:9px}
+.evt .tag{font-weight:600;margin-right:3px;font-size:9px}
+.evt .tag.peer_join{color:var(--green)}.evt .tag.peer_leave{color:var(--red)}
+.evt .tag.command_sent{color:var(--blue)}.evt .tag.broadcast{color:var(--orange)}
+.evt .tag.stream_step{color:var(--accent2)}.evt .tag.external{color:var(--cyan)}
+.evt .tag[class*="sim\:"]{color:var(--green)}
+
+.no-data{color:var(--text3);font-size:12px;text-align:center;padding:40px 20px}
+.no-data .big{font-size:32px;margin-bottom:8px;opacity:0.2}
+
+/* ── Sparkline canvas ── */
+.sparkline{width:100%;height:24px}
+
+/* ── Scrollbar ── */
+::-webkit-scrollbar{width:4px}::-webkit-scrollbar-track{background:transparent}::-webkit-scrollbar-thumb{background:var(--border);border-radius:2px}
+
+@media(max-width:900px){.sidebar,.event-sidebar{display:none}.grid-view{grid-template-columns:1fr}}
+.hf-search-wrap{position:relative;flex:0.8;min-width:160px}
+.hf-search-wrap input{width:100%;box-sizing:border-box}
+.hf-dropdown{position:absolute;top:100%;left:0;right:0;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);max-height:280px;overflow-y:auto;z-index:1000;display:none;box-shadow:0 8px 24px rgba(0,0,0,0.4)}
+.hf-dropdown.open{display:block}
+.hf-item{padding:8px 10px;cursor:pointer;border-bottom:1px solid var(--border);font-size:11px;transition:background 0.1s}
+.hf-item:hover,.hf-item.selected{background:var(--surface3)}
+.hf-item:last-child{border-bottom:none}
+.hf-item .hf-name{color:var(--accent);font-weight:600;font-size:11px}
+.hf-item .hf-meta{color:var(--text3);font-size:9px;margin-top:2px;display:flex;gap:8px}
+.hf-item .hf-tag{background:var(--surface2);padding:1px 5px;border-radius:3px;font-size:8px;color:var(--text2)}
+.hf-searching{padding:10px;color:var(--text3);font-size:11px;text-align:center}
+</style>
+</head>
+<body>
+<div class="header">
+  <div class="logo">🤖 <span>Strands Robots</span></div>
+  <div class="status" id="ws-status"><div class="dot"></div>connecting</div>
+  <div class="peer-count" id="peer-count">0 peers</div>
+  <div class="view-toggle">
+    <button class="active" onclick="setView('grid')" id="btn-grid">Grid</button>
+    <button onclick="setView('detail')" id="btn-detail">Detail</button>
+  </div>
+  <button class="estop" onclick="emergencyStop()">⛔ E-STOP</button>
+</div>
+
+<div class="app">
+  <div class="sidebar">
+    <h3>Peers</h3>
+    <div id="peers-list"><div class="no-data"><div class="big">📡</div>Waiting for robots...</div></div>
+  </div>
+  <div class="main-area" id="main-area">
+    <div class="grid-view" id="grid-view"></div>
+    <div class="detail-view" id="detail-view" style="display:none"></div>
+    <div id="empty-state" class="no-data"><div class="big">🤖</div>Create a Robot() to see it here<br><code style="color:var(--accent);font-size:11px;margin-top:8px;display:inline-block">from strands_robots import Robot; sim = Robot("so100")</code></div>
+  </div>
+  <div class="event-sidebar">
+    <h3>Event Log</h3>
+    <div id="events-list"></div>
+  </div>
+</div>
+
+<script>
+// ━━━ State ━━━
+let ws, selectedPeer = null, currentView = 'grid', reconnectTimer = null;
+const peers = new Map(); // peer_id → peer info
+const states = new Map(); // peer_id → latest state
+const streams = new Map(); // peer_id → [steps]
+const jointHistory = new Map(); // peer_id → {joint_name → [values]}
+const cameraFrames = new Map(); // peer_id → {cam → dataurl}
+const lastActions = new Map(); // peer_id → {action dict}
+const WS_PORT = location.port ? parseInt(location.port) + 1 : 7861;
+const MAX_HISTORY = 60; // sparkline points
+
+// ━━━ Connection ━━━
+function connect() {
+  ws = new WebSocket(`ws://${location.hostname}:${WS_PORT}`);
+  ws.onopen = () => {
+    document.getElementById('ws-status').innerHTML = '<div class="dot"></div>connected';
+    document.getElementById('ws-status').className = 'status connected';
+    if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
+  };
+  ws.onclose = () => {
+    document.getElementById('ws-status').innerHTML = '<div class="dot"></div>disconnected';
+    document.getElementById('ws-status').className = 'status';
+    reconnectTimer = setTimeout(connect, 2000);
+  };
+  ws.onmessage = (e) => {
+    const msg = JSON.parse(e.data);
+    switch(msg.type) {
+      case 'init': handleInit(msg); break;
+      case 'peers': handlePeers(msg.peers); break;
+      case 'state': handleState(msg.peer_id, msg.state); break;
+      case 'stream_step': handleStreamStep(msg.peer_id, msg.step); break;
+      case 'camera_frame': handleCameraFrame(msg.peer_id, msg.camera, msg.frame); break;
+      case 'sim_event': handleSimEvent(msg); break;
+      case 'event': addEvent(msg); break;
+    }
+  };
+}
+
+function handleInit(msg) {
+  handlePeers(msg.peers);
+  if (msg.states) Object.entries(msg.states).forEach(([pid, s]) => handleState(pid, s));
+  if (msg.events) msg.events.forEach(e => addEvent({event_type: e.type, data: e.data, ts: e.ts}));
+}
+
+// ━━━ Peer Management ━━━
+const cameraRequested = new Set(); // track which peers we already asked for camera
+
+function handlePeers(list) {
+  const ids = new Set();
+  list.forEach(p => { peers.set(p.peer_id, p); ids.add(p.peer_id); });
+  // Remove stale
+  for (const pid of peers.keys()) { if (!ids.has(pid)) { peers.delete(pid); cameraRequested.delete(pid); } }
+  document.getElementById('peer-count').textContent = `${peers.size} peer${peers.size!==1?'s':''}`;
+  // Skip full re-render if user is focused on an input/select (prevents losing focus & typed text)
+  const ae = document.activeElement;
+  const userBusy = ae && (ae.tagName === 'INPUT' || ae.tagName === 'SELECT' || ae.tagName === 'TEXTAREA' || ae.closest('.hf-dropdown.open'));
+  if (!userBusy) {
+    renderSidebar();
+    renderMain();
+  } else {
+    // Still update peer count badge in sidebar without full rebuild
+    document.querySelectorAll('.peer-item .dot').forEach(dot => {
+      const item = dot.closest('.peer-item');
+      if (!item) return;
+      const pid = item.getAttribute('onclick')?.match(/'([^']+)'/)?.[1];
+      const p = pid && peers.get(pid);
+      if (p) dot.className = 'dot ' + (p.age < 5 ? 'alive' : 'stale');
+    });
+  }
+
+  // Auto-request camera stream from sim and robot peers that we haven't asked yet
+  list.forEach(p => {
+    if ((p.type === 'sim' || p.type === 'robot') && !cameraRequested.has(p.peer_id)) {
+      cameraRequested.add(p.peer_id);
+      const fps = p.type === 'sim' ? 10 : 5;
+      ws.send(JSON.stringify({type: 'request_camera_stream', peer_id: p.peer_id, camera: 'default', fps: fps}));
+      console.log('📹 Auto-requested camera stream from', p.peer_id);
+    }
+  });
+}
+
+// ━━━ State Handling ━━━
+function handleState(peerId, state) {
+  states.set(peerId, state);
+  // Track joint history for sparklines
+  const joints = state.joints || {};
+  if (!jointHistory.has(peerId)) jointHistory.set(peerId, {});
+  const hist = jointHistory.get(peerId);
+  for (const [k, v] of Object.entries(joints)) {
+    const val = typeof v === 'object' ? (v.position ?? v) : v;
+    if (typeof val !== 'number') continue;
+    if (!hist[k]) hist[k] = [];
+    hist[k].push(val);
+    if (hist[k].length > MAX_HISTORY) hist[k].shift();
+  }
+  updateGridCard(peerId);
+  const ae2 = document.activeElement;
+  const busy2 = ae2 && (ae2.tagName === 'INPUT' || ae2.tagName === 'SELECT' || ae2.closest('.hf-dropdown.open'));
+  if (currentView === 'detail' && selectedPeer === peerId && !busy2) renderDetailView();
+}
+
+function handleStreamStep(peerId, step) {
+  if (!streams.has(peerId)) streams.set(peerId, []);
+  const s = streams.get(peerId);
+  s.push(step);
+  if (s.length > MAX_STREAM_STEPS) s.splice(0, s.length - MAX_STREAM_STEPS);
+  // Track last action
+  if (step.action) lastActions.set(peerId, step.action);
+  updateStreamPanel(peerId);
+  updateActionPanel(peerId);
+}
+
+function handleCameraFrame(peerId, camera, frame) {
+  if (!cameraFrames.has(peerId)) cameraFrames.set(peerId, {});
+  cameraFrames.get(peerId)[camera] = 'data:image/jpeg;base64,' + frame;
+  updateCameraPanel(peerId);
+}
+
+// ━━━ Views ━━━
+function setView(v) {
+  currentView = v;
+  document.getElementById('btn-grid').classList.toggle('active', v === 'grid');
+  document.getElementById('btn-detail').classList.toggle('active', v === 'detail');
+  document.getElementById('grid-view').style.display = v === 'grid' ? '' : 'none';
+  document.getElementById('detail-view').style.display = v === 'detail' ? '' : 'none';
+  renderMain();
+}
+
+function selectPeer(pid) {
+  selectedPeer = pid;
+  renderSidebar();
+  if (currentView === 'detail') renderDetailView();
+  // Request state+stream
+  if (ws?.readyState === 1) {
+    ws.send(JSON.stringify({type: 'get_state', peer_id: pid}));
+    ws.send(JSON.stringify({type: 'get_stream', peer_id: pid}));
+  }
+}
+
+// ━━━ Sidebar ━━━
+function renderSidebar() {
+  const el = document.getElementById('peers-list');
+  if (!peers.size) { el.innerHTML = '<div class="no-data"><div class="big">📡</div>Waiting for robots...</div>'; return; }
+  el.innerHTML = [...peers.values()].map(p => {
+    const icon = {robot:'🤖',sim:'🎮',agent:'🧠',dashboard:'📊'}[p.type]||'🔧';
+    const dotCls = p.age < 5 ? 'alive' : 'stale';
+    const sel = p.peer_id === selectedPeer ? ' selected' : '';
+    const badgeCls = p.type || 'robot';
+    const task = p.instruction ? `<div class="task">🎯 ${p.instruction}</div>` : '';
+    return `<div class="peer-item${sel}" onclick="selectPeer('${p.peer_id}')">
+      <div class="top"><div class="dot ${dotCls}"></div><div class="name">${icon} ${p.peer_id}</div><div class="badge ${badgeCls}">${p.type}</div></div>
+      <div class="meta"><span>${p.hostname}</span><span>${p.age}s</span></div>
+      ${task}
+    </div>`;
+  }).join('');
+}
+
+// ━━━ Grid View ━━━
+function renderMain() {
+  const empty = document.getElementById('empty-state');
+  if (!peers.size) { empty.style.display = ''; return; }
+  empty.style.display = 'none';
+  if (currentView === 'grid') renderGridView();
+  else renderDetailView();
+}
+
+function renderGridView() {
+  const el = document.getElementById('grid-view');
+  // Only re-render structure if peer count changed
+  const existingIds = new Set(el.querySelectorAll('.grid-card').length ? [...el.querySelectorAll('.grid-card')].map(c => c.dataset.peer) : []);
+  const currentIds = new Set(peers.keys());
+  const needsRebuild = existingIds.size !== currentIds.size || [...currentIds].some(id => !existingIds.has(id));
+
+  if (needsRebuild) {
+    el.innerHTML = [...peers.values()].filter(p => p.type !== 'dashboard').map(p => {
+      const icon = {robot:'🤖',sim:'🎮',agent:'🧠'}[p.type]||'🔧';
+      return `<div class="grid-card" data-peer="${p.peer_id}">
+        <div class="card-header">
+          <div class="name">${icon} ${p.peer_id}</div>
+          <div class="pill" style="background:var(--${p.type==='sim'?'blue':'green'}-dim);color:var(--${p.type==='sim'?'blue':'green'})">${p.type}</div>
+        </div>
+        <div class="card-body">
+          <div class="camera-panel" id="cam-${CSS.escape(p.peer_id)}">
+            <div class="no-feed"><div class="icon">📷</div>No camera feed</div>
+          </div>
+          <div class="joints-panel" id="joints-${CSS.escape(p.peer_id)}">
+            <h4>Joint States</h4>
+            <div class="no-data" style="padding:20px;font-size:11px">Waiting for data...</div>
+          </div>
+          <div class="action-panel" id="actions-${CSS.escape(p.peer_id)}">
+            <h4>Actions</h4>
+            <div class="action-bars" id="abars-${CSS.escape(p.peer_id)}"></div>
+          </div>
+          <div class="stream-panel" id="stream-${CSS.escape(p.peer_id)}">
+            <h4><div class="live"></div>Policy Stream</h4>
+          </div>
+          <div class="action-panel" id="objects-${CSS.escape(p.peer_id)}" style="padding:10px;border-top:1px solid var(--border);grid-column:1/-1">
+            <h4>Scene Objects</h4>
+          </div>
+          <div class="cmd-bar">
+            <div class="cmd-row">
+              <span class="cmd-label">Model</span>
+              <div class="hf-search-wrap" style="flex:1">
+                <input type="text" id="model-${CSS.escape(p.peer_id)}" placeholder="🔍 Search HuggingFace policies..." value="lerobot/act_aloha_sim_transfer_cube_human" autocomplete="off" onfocus="hfSearchFocus(this)" oninput="hfSearch(this)" onkeydown="hfKeydown(event,this)">
+                <div class="hf-dropdown" id="hf-dd-${CSS.escape(p.peer_id)}"></div>
+              </div>
+            </div>
+            <div class="cmd-row">
+              <span class="cmd-label">Action</span>
+              <select id="policy-${CSS.escape(p.peer_id)}">
+                <option value="mock">mock</option>
+                <option value="lerobot_local" selected>lerobot_local</option>
+                <option value="groot">groot</option>
+                <option value="lerobot_async">lerobot_async</option>
+              </select>
+              <input type="text" id="cmd-${CSS.escape(p.peer_id)}" placeholder="Instruction (e.g. pick up the cube)" style="flex:1" onkeydown="if(event.key==='Enter')sendTo('${p.peer_id}')">
+              <button class="btn btn-green" onclick="sendTo('${p.peer_id}')">▶ Run</button>
+              <button class="btn btn-orange" onclick="startTeleop('${p.peer_id}')">🎮 Teleop</button>
+              <button class="btn btn-red" onclick="stopPeer('${p.peer_id}')">⏹ Stop</button>
+            </div>
+          </div>
+        </div>
+      </div>`;
+    }).join('');
+  }
+
+  // Update all cards
+  for (const pid of peers.keys()) {
+    updateGridCard(pid);
+  }
+}
+
+function updateGridCard(peerId) {
+  updateJointsPanel(peerId);
+  updateCameraPanel(peerId);
+  updateActionPanel(peerId);
+  updateObjectsPanel(peerId);
+}
+
+// ━━━ Joint State Rendering ━━━
+function updateJointsPanel(peerId) {
+  const el = document.getElementById('joints-' + CSS.escape(peerId));
+  if (!el) return;
+  const state = states.get(peerId);
+  if (!state?.joints) return;
+
+  const joints = state.joints;
+  const entries = Object.entries(joints);
+  if (!entries.length) return;
+
+  let html = '<h4>Joint States</h4>';
+  for (const [name, v] of entries) {
+    const val = typeof v === 'object' ? (v.position ?? 0) : (typeof v === 'number' ? v : 0);
+    // Normalize to 0-100% for bar (assuming range roughly -3.14 to 3.14)
+    const pct = Math.min(100, Math.max(0, ((val + 3.14) / 6.28) * 100));
+    const color = val >= 0 ? 'var(--accent)' : 'var(--cyan)';
+    html += `<div class="joint-row">
+      <span class="jname" title="${name}">${name}</span>
+      <div class="jbar"><div class="fill" style="width:${pct}%;background:${color}"></div></div>
+      <span class="jval">${val.toFixed(3)}</span>
+    </div>`;
+  }
+  el.innerHTML = html;
+}
+
+// ━━━ Camera Panel ━━━
+function updateCameraPanel(peerId) {
+  const el = document.getElementById('cam-' + CSS.escape(peerId));
+  if (!el) return;
+  const cams = cameraFrames.get(peerId);
+  if (!cams) return;
+  const firstCam = Object.values(cams)[0];
+  if (firstCam) {
+    el.innerHTML = `<img src="${firstCam}" alt="camera"><div class="fps-badge">LIVE</div>`;
+  }
+}
+
+// ━━━ Action Vector Bars ━━━
+function updateActionPanel(peerId) {
+  const el = document.getElementById('abars-' + CSS.escape(peerId));
+  if (!el) return;
+  const action = lastActions.get(peerId);
+  if (!action) return;
+
+  const vals = Object.entries(action);
+  if (!vals.length) return;
+
+  el.innerHTML = vals.map(([k, v]) => {
+    const val = Array.isArray(v) ? v[0] : (typeof v === 'number' ? v : 0);
+    const h = Math.min(40, Math.max(2, Math.abs(val) * 400));
+    const color = val >= 0 ? 'var(--accent)' : 'var(--cyan)';
+    return `<div class="action-bar" style="height:${h}px;background:${color}"><div class="tip">${k}: ${typeof val==='number'?val.toFixed(3):val}</div></div>`;
+  }).join('');
+}
+
+// ━━━ Stream Panel ━━━
+function updateStreamPanel(peerId) {
+  const el = document.getElementById('stream-' + CSS.escape(peerId));
+  if (!el) return;
+  const s = streams.get(peerId);
+  if (!s || !s.length) return;
+
+  const recent = s.slice(-8);
+  let html = '<h4><div class="live"></div>Policy Stream</h4>';
+  for (const step of recent) {
+    const obsKeys = Object.keys(step.observation || {}).slice(0, 3).join(', ');
+    html += `<div class="stream-line"><span class="step">#${step.step}</span><span class="instr">${step.instruction||''}</span> ${step.policy||''} [${obsKeys}]</div>`;
+  }
+  el.innerHTML = html;
+}
+
+// ━━━ Detail View ━━━
+function renderDetailView() {
+  const el = document.getElementById('detail-view');
+  if (!selectedPeer) {
+    el.innerHTML = '<div class="no-data"><div class="big">👈</div>Select a peer from the sidebar</div>';
+    return;
+  }
+  const p = peers.get(selectedPeer);
+  if (!p) return;
+
+  const state = states.get(selectedPeer) || {};
+  const action = lastActions.get(selectedPeer) || {};
+  const s = streams.get(selectedPeer) || [];
+
+  // Joints
+  let jointsHtml = '';
+  if (state.joints) {
+    for (const [name, v] of Object.entries(state.joints)) {
+      const val = typeof v === 'object' ? (v.position ?? 0) : (typeof v === 'number' ? v : 0);
+      const pct = Math.min(100, Math.max(0, ((val + 3.14) / 6.28) * 100));
+      jointsHtml += `<div class="joint-row">
+        <span class="jname">${name}</span>
+        <div class="jbar"><div class="fill" style="width:${pct}%;background:var(--accent)"></div></div>
+        <span class="jval">${val.toFixed(4)}</span>
+      </div>`;
+    }
+  }
+
+  // Actions
+  let actHtml = '';
+  const actEntries = Object.entries(action);
+  if (actEntries.length) {
+    actHtml = '<div class="action-bars" style="height:50px">' + actEntries.map(([k, v]) => {
+      const val = Array.isArray(v) ? v[0] : (typeof v === 'number' ? v : 0);
+      const h = Math.min(50, Math.max(2, Math.abs(val) * 500));
+      return `<div class="action-bar" style="height:${h}px;background:var(--accent)"><div class="tip">${k}: ${typeof val==='number'?val.toFixed(4):val}</div></div>`;
+    }).join('') + '</div>';
+  }
+
+  // Stream
+  let streamHtml = s.slice(-20).map(step =>
+    `<div class="stream-line"><span class="step">#${step.step}</span><span class="instr">${step.instruction||''}</span> ${step.policy||''}</div>`
+  ).join('');
+
+  // Camera
+  const cams = cameraFrames.get(selectedPeer);
+  const camImg = cams ? Object.values(cams)[0] : null;
+  const camHtml = camImg ? `<img src="${camImg}" alt="camera"><div class="fps-badge">LIVE</div>` : '<div class="no-feed"><div class="icon">📷</div>No camera feed</div>';
+
+  el.innerHTML = `
+    <div class="detail-main">
+      <div class="detail-camera">${camHtml}</div>
+      <div class="detail-actions" style="padding:14px">
+        <h4 style="font-size:9px;color:var(--text3);text-transform:uppercase;letter-spacing:1px;margin-bottom:8px">Last Action Vector</h4>
+        ${actHtml || '<div style="color:var(--text3);font-size:11px">No actions yet</div>'}
+      </div>
+      <div class="cmd-bar" style="background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-lg)">
+        <div class="cmd-row">
+          <span class="cmd-label">Model</span>
+          <div class="hf-search-wrap" style="flex:1">
+            <input type="text" id="detail-model" placeholder="🔍 Search HuggingFace policies..." value="lerobot/act_aloha_sim_transfer_cube_human" autocomplete="off" onfocus="hfSearchFocus(this)" oninput="hfSearch(this)" onkeydown="hfKeydown(event,this)">
+            <div class="hf-dropdown" id="hf-dd-detail"></div>
+          </div>
+        </div>
+        <div class="cmd-row">
+          <span class="cmd-label">Action</span>
+          <select id="detail-policy">
+            <option value="mock">mock</option><option value="lerobot_local" selected>lerobot_local</option>
+            <option value="groot">groot</option><option value="lerobot_async">lerobot_async</option>
+          </select>
+          <input type="text" id="detail-cmd" placeholder="Instruction (e.g. pick up the cube)" style="flex:1" onkeydown="if(event.key==='Enter')sendToDetail()">
+          <button class="btn btn-green" onclick="sendToDetail()">▶ Run</button>
+          <button class="btn btn-orange" onclick="startTeleop(selectedPeer)">🎮 Teleop</button>
+          <button class="btn btn-red" onclick="stopPeer(selectedPeer)">⏹ Stop</button>
+        </div>
+      </div>
+    </div>
+    <div class="detail-sidebar">
+      <div class="detail-joints">
+        <h4 style="font-size:9px;color:var(--text3);text-transform:uppercase;letter-spacing:1px;margin-bottom:8px">Joint States ${state.sim_time !== undefined ? `· t=${state.sim_time.toFixed(3)}s`:''}</h4>
+        ${jointsHtml || '<div style="color:var(--text3);font-size:11px">No joint data</div>'}
+      </div>
+      <div class="detail-stream">
+        <h4 style="font-size:9px;color:var(--text3);text-transform:uppercase;letter-spacing:1px;margin-bottom:8px;display:flex;align-items:center;gap:6px"><div class="live"></div>Policy Stream</h4>
+        ${streamHtml || '<div style="color:var(--text3);font-size:11px">No stream data</div>'}
+      </div>
+    </div>
+  `;
+}
+
+// ━━━ Sim Events ━━━
+const simObjects = new Map(); // peer_id → {name → {shape, position, color}}
+
+function handleSimEvent(msg) {
+  const {peer_id, event_type, data} = msg;
+  addEvent({ts: msg.ts, event_type: `sim:${event_type}`, data: {peer_id, ...data}});
+
+  // Flash the grid card to indicate a change
+  const card = document.querySelector(`.grid-card[data-peer="${peer_id}"]`);
+  if (card) {
+    card.style.borderColor = 'var(--green)';
+    card.style.boxShadow = '0 0 12px rgba(0,212,160,0.3)';
+    setTimeout(() => { card.style.borderColor = ''; card.style.boxShadow = ''; }, 1500);
+  }
+
+  // Update objects panel immediately
+  updateObjectsPanel(peer_id);
+}
+
+// ━━━ Objects Panel ━━━
+function updateObjectsPanel(peerId) {
+  const el = document.getElementById('objects-' + CSS.escape(peerId));
+  if (!el) return;
+  const state = states.get(peerId);
+  const objs = state?.objects;
+  if (!objs || !Object.keys(objs).length) {
+    el.innerHTML = '<h4>Scene Objects</h4><div style="color:var(--text3);font-size:10px;padding:4px 0">No objects</div>';
+    return;
+  }
+  let html = `<h4>Scene Objects <span style="color:var(--text2);font-weight:normal">(${Object.keys(objs).length})</span></h4>`;
+  for (const [name, obj] of Object.entries(objs)) {
+    const c = obj.color || [0.5, 0.5, 0.5];
+    const rgb = `rgb(${Math.round(c[0]*255)},${Math.round(c[1]*255)},${Math.round(c[2]*255)})`;
+    const pos = (obj.position || []).map(v => v.toFixed(2)).join(', ');
+    html += `<div style="display:flex;align-items:center;gap:5px;padding:2px 0;font-size:10px">
+      <div style="width:8px;height:8px;border-radius:2px;background:${rgb};flex-shrink:0"></div>
+      <span style="color:var(--text);flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="${name}">${name}</span>
+      <span style="color:var(--text3);font-size:9px">${obj.shape}</span>
+    </div>`;
+  }
+  el.innerHTML = html;
+}
+
+// ━━━ Events ━━━
+function addEvent(evt) {
+  const el = document.getElementById('events-list');
+  const div = document.createElement('div');
+  div.className = 'evt';
+  const ts = new Date((evt.ts || Date.now()/1000) * 1000).toLocaleTimeString();
+  const evType = evt.event_type || evt.type || '?';
+  const summary = evType === 'peer_join' ? `${evt.data?.peer_id} (${evt.data?.robot_type||'?'})` :
+    evType === 'peer_leave' ? evt.data?.peer_id :
+    evType === 'command_sent' ? `→ ${evt.data?.target}: ${JSON.stringify(evt.data?.command||{}).slice(0,60)}` :
+    JSON.stringify(evt.data || {}).slice(0, 100);
+  div.innerHTML = `<span class="ts">${ts}</span><span class="tag ${evType}">${evType}</span> ${summary}`;
+  el.prepend(div);
+  while (el.children.length > 200) el.lastChild.remove();
+}
+
+// ━━━ Commands ━━━
+// --- HuggingFace Model Search ---
+let _hfCache = {};
+let _hfDebounce = null;
+let _hfSelectedIdx = -1;
+let _hfActiveInput = null;
+
+async function hfFetch(query) {
+  if (_hfCache[query]) return _hfCache[query];
+  // Search HF Hub API for lerobot-compatible POLICY models (not datasets)
+  const searchQ = query.includes('/') ? query : `lerobot ${query}`;
+  // Use filter=lerobot to only get models tagged with 'lerobot' (policies have this tag)
+  const params = new URLSearchParams({search: searchQ, limit: '20', sort: 'downloads', direction: '-1', filter: 'lerobot'});
+  try {
+    const resp = await fetch(`https://huggingface.co/api/models?${params}`);
+    if (!resp.ok) return [];
+    const models = await resp.json();
+    // Filter: only show models (policies) not datasets — policies have config.json
+    // Heuristic: exclude repos with 'dataset' in tags or pipeline_tag
+    const results = models
+      .filter(m => !(m.pipeline_tag || '').includes('dataset') && !(m.tags || []).some(t => t === 'dataset'))
+      .map(m => ({
+        id: m.modelId || m.id,
+        downloads: m.downloads || 0,
+        likes: m.likes || 0,
+        tags: (m.tags || []).filter(t => ['act','diffusion','tdmpc','vla','pi0','smolvla','xvla','vqbet','sac'].some(k => t.toLowerCase().includes(k))).slice(0, 3),
+        pipeline: m.pipeline_tag || '',
+        updated: m.lastModified ? new Date(m.lastModified).toLocaleDateString() : '',
+      }));
+    _hfCache[query] = results;
+    return results;
+  } catch(e) { console.warn('HF search error:', e); return []; }
+}
+
+function hfGetDropdown(input) {
+  const wrap = input.closest('.hf-search-wrap');
+  return wrap ? wrap.querySelector('.hf-dropdown') : null;
+}
+
+function hfRender(dropdown, results, input) {
+  if (!results.length) {
+    dropdown.innerHTML = '<div class="hf-searching">No models found</div>';
+    dropdown.classList.add('open');
+    return;
+  }
+  dropdown.innerHTML = results.map((m, i) => `
+    <div class="hf-item${i === _hfSelectedIdx ? ' selected' : ''}" data-id="${m.id}" onclick="hfSelect('${m.id}', this)">
+      <div class="hf-name">${m.id}</div>
+      <div class="hf-meta">
+        <span>⬇ ${m.downloads.toLocaleString()}</span>
+        <span>♥ ${m.likes}</span>
+        ${m.pipeline ? `<span>${m.pipeline}</span>` : ''}
+        ${m.updated ? `<span>${m.updated}</span>` : ''}
+      </div>
+      ${m.tags.length ? `<div class="hf-meta">${m.tags.map(t => `<span class="hf-tag">${t}</span>`).join('')}</div>` : ''}
+    </div>
+  `).join('');
+  dropdown.classList.add('open');
+}
+
+function hfSelect(modelId, el) {
+  // Find the input in the same wrapper
+  const wrap = el.closest('.hf-search-wrap');
+  const input = wrap.querySelector('input');
+  input.value = modelId;
+  const dropdown = wrap.querySelector('.hf-dropdown');
+  dropdown.classList.remove('open');
+  _hfSelectedIdx = -1;
+  // Auto-set policy to lerobot_local when selecting a HF model
+  const cmdBar = wrap.closest('.cmd-bar');
+  if (cmdBar) {
+    const policySelect = cmdBar.querySelector('select');
+    if (policySelect) policySelect.value = 'lerobot_local';
+  }
+}
+
+function hfSearch(input) {
+  const query = input.value.trim();
+  const dropdown = hfGetDropdown(input);
+  if (!dropdown) return;
+  _hfActiveInput = input;
+  _hfSelectedIdx = -1;
+  if (query.length < 2) { dropdown.classList.remove('open'); return; }
+  clearTimeout(_hfDebounce);
+  dropdown.innerHTML = '<div class="hf-searching">🔍 Searching HuggingFace...</div>';
+  dropdown.classList.add('open');
+  _hfDebounce = setTimeout(async () => {
+    const results = await hfFetch(query);
+    if (_hfActiveInput === input) hfRender(dropdown, results, input);
+  }, 300);
+}
+
+function hfSearchFocus(input) {
+  const query = input.value.trim();
+  if (query.length >= 2) hfSearch(input);
+}
+
+function hfKeydown(e, input) {
+  const dropdown = hfGetDropdown(input);
+  if (!dropdown || !dropdown.classList.contains('open')) return;
+  const items = dropdown.querySelectorAll('.hf-item');
+  if (e.key === 'ArrowDown') {
+    e.preventDefault();
+    _hfSelectedIdx = Math.min(_hfSelectedIdx + 1, items.length - 1);
+    items.forEach((el, i) => el.classList.toggle('selected', i === _hfSelectedIdx));
+    if (items[_hfSelectedIdx]) items[_hfSelectedIdx].scrollIntoView({block: 'nearest'});
+  } else if (e.key === 'ArrowUp') {
+    e.preventDefault();
+    _hfSelectedIdx = Math.max(_hfSelectedIdx - 1, 0);
+    items.forEach((el, i) => el.classList.toggle('selected', i === _hfSelectedIdx));
+    if (items[_hfSelectedIdx]) items[_hfSelectedIdx].scrollIntoView({block: 'nearest'});
+  } else if (e.key === 'Enter' && _hfSelectedIdx >= 0 && items[_hfSelectedIdx]) {
+    e.preventDefault();
+    const id = items[_hfSelectedIdx].dataset.id;
+    hfSelect(id, items[_hfSelectedIdx]);
+  } else if (e.key === 'Escape') {
+    dropdown.classList.remove('open');
+    _hfSelectedIdx = -1;
+  }
+}
+
+// Close dropdowns on outside click
+document.addEventListener('click', (e) => {
+  if (!e.target.closest('.hf-search-wrap')) {
+    document.querySelectorAll('.hf-dropdown').forEach(d => d.classList.remove('open'));
+  }
+});
+
+
+function sendTo(peerId) {
+  const input = document.getElementById('cmd-' + CSS.escape(peerId));
+  const policy = document.getElementById('policy-' + CSS.escape(peerId));
+  const model = document.getElementById('model-' + CSS.escape(peerId));
+  if (!input?.value.trim()) return;
+  const msg = {
+    type: 'tell', target: peerId,
+    instruction: input.value.trim(),
+    policy_provider: policy?.value || 'mock',
+    duration: 30.0
+  };
+  if (model?.value.trim()) msg.pretrained_name_or_path = model.value.trim();
+  ws.send(JSON.stringify(msg));
+  addEvent({ts: Date.now()/1000, event_type: 'command_sent', data: {target: peerId, command: {instruction: input.value.trim(), policy: policy?.value, model: model?.value}}});
+  input.value = '';
+}
+
+function sendToDetail() {
+  if (!selectedPeer) return;
+  const input = document.getElementById('detail-cmd');
+  const policy = document.getElementById('detail-policy');
+  const model = document.getElementById('detail-model');
+  if (!input?.value.trim()) return;
+  const msg = {
+    type: 'tell', target: selectedPeer,
+    instruction: input.value.trim(),
+    policy_provider: policy?.value || 'mock',
+    duration: 30.0
+  };
+  if (model?.value.trim()) msg.pretrained_name_or_path = model.value.trim();
+  ws.send(JSON.stringify(msg));
+  addEvent({ts: Date.now()/1000, event_type: 'command_sent', data: {target: selectedPeer, command: {instruction: input.value.trim(), policy: policy?.value, model: model?.value}}});
+  input.value = '';
+}
+
+// ━━━ Teleop & Stop ━━━
+let _teleopActive = {};
+
+function startTeleop(peerId) {
+  if (!peerId || !ws || ws.readyState !== 1) return;
+  if (_teleopActive[peerId]) { stopTeleop(peerId); return; }
+
+  // Get selected model
+  const modelEl = document.getElementById('model-' + CSS.escape(peerId)) || document.getElementById('detail-model');
+  const modelId = modelEl?.value?.trim() || 'lerobot/act_aloha_sim_transfer_cube_human';
+
+  // Send teleop start command via zenoh
+  ws.send(JSON.stringify({
+    type: 'tell', target: peerId,
+    instruction: '__teleop_start__',
+    policy_provider: 'lerobot_local',
+    pretrained_name_or_path: modelId,
+    teleop: true,
+    duration: 300.0
+  }));
+
+  _teleopActive[peerId] = true;
+  addEvent({ts: Date.now()/1000, event_type: 'command_sent', data: {target: peerId, command: {action: 'teleop_start', model: modelId}}});
+
+  // Update button states
+  updateTeleopButtons(peerId);
+
+  // Enable keyboard teleop listener
+  if (!window._teleopKeyHandler) {
+    window._teleopKeyHandler = (e) => handleTeleopKey(e);
+    document.addEventListener('keydown', window._teleopKeyHandler);
+    document.addEventListener('keyup', (e) => handleTeleopKeyUp(e));
+  }
+  window._teleopPeer = peerId;
+}
+
+function stopTeleop(peerId) {
+  if (!peerId) return;
+  ws.send(JSON.stringify({type: 'tell', target: peerId, instruction: '__teleop_stop__', teleop_stop: true}));
+  delete _teleopActive[peerId];
+  updateTeleopButtons(peerId);
+  addEvent({ts: Date.now()/1000, event_type: 'command_sent', data: {target: peerId, command: {action: 'teleop_stop'}}});
+  if (window._teleopPeer === peerId) window._teleopPeer = null;
+}
+
+function stopPeer(peerId) {
+  if (!peerId || !ws || ws.readyState !== 1) return;
+  ws.send(JSON.stringify({type: 'tell', target: peerId, instruction: '__stop__', stop: true}));
+  delete _teleopActive[peerId];
+  updateTeleopButtons(peerId);
+  addEvent({ts: Date.now()/1000, event_type: 'command_sent', data: {target: peerId, command: {action: 'stop'}}});
+}
+
+function updateTeleopButtons(peerId) {
+  // Toggle button appearance based on active state
+  const active = !!_teleopActive[peerId];
+  document.querySelectorAll('.cmd-bar .btn-orange').forEach(btn => {
+    const card = btn.closest('.grid-card') || btn.closest('.detail-main');
+    if (!card) return;
+    const cardPeer = card.dataset?.peer || selectedPeer;
+    if (cardPeer === peerId) {
+      btn.innerHTML = active ? '🎮 Stop Teleop' : '🎮 Teleop';
+      btn.style.background = active ? 'var(--red)' : '';
+      btn.style.color = active ? 'white' : '';
+    }
+  });
+}
+
+// Keyboard teleop: WASD + QE for joint control
+const TELEOP_KEYS = {
+  'w': {joint: 0, delta: 0.05},   // shoulder up
+  's': {joint: 0, delta: -0.05},  // shoulder down
+  'a': {joint: 1, delta: -0.05},  // base left
+  'd': {joint: 1, delta: 0.05},   // base right
+  'q': {joint: 2, delta: 0.05},   // elbow up
+  'e': {joint: 2, delta: -0.05},  // elbow down
+  'r': {joint: 3, delta: 0.05},   // wrist up
+  'f': {joint: 3, delta: -0.05},  // wrist down
+  'z': {joint: 4, delta: 0.05},   // wrist rotate
+  'x': {joint: 4, delta: -0.05},  // wrist rotate back
+  'c': {joint: 5, delta: 0.05},   // gripper open
+  'v': {joint: 5, delta: -0.05},  // gripper close
+};
+
+let _teleopPressed = {};
+
+function handleTeleopKey(e) {
+  if (!window._teleopPeer || !_teleopActive[window._teleopPeer]) return;
+  // Don't capture if typing in an input
+  if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.tagName === 'SELECT') return;
+  const k = e.key.toLowerCase();
+  if (TELEOP_KEYS[k] && !_teleopPressed[k]) {
+    e.preventDefault();
+    _teleopPressed[k] = true;
+    sendTeleopDelta(window._teleopPeer, TELEOP_KEYS[k].joint, TELEOP_KEYS[k].delta);
+  }
+}
+
+function handleTeleopKeyUp(e) {
+  const k = e.key.toLowerCase();
+  delete _teleopPressed[k];
+}
+
+function sendTeleopDelta(peerId, jointIdx, delta) {
+  if (!ws || ws.readyState !== 1) return;
+  ws.send(JSON.stringify({
+    type: 'tell', target: peerId,
+    instruction: '__teleop_delta__',
+    teleop_delta: {joint: jointIdx, delta: delta}
+  }));
+}
+
+function emergencyStop() {
+  if (!confirm('⛔ EMERGENCY STOP — Send to ALL robots?')) return;
+  ws.send(JSON.stringify({type: 'emergency_stop'}));
+  addEvent({ts: Date.now()/1000, event_type: 'broadcast', data: {action: 'emergency_stop'}});
+}
+
+// ━━━ Init ━━━
+connect();
+setInterval(() => { if (ws?.readyState === 1) ws.send(JSON.stringify({type: 'get_peers'})); }, 3000);
+</script>
+</body>
+</html>"""
+
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# HTTP + WebSocket Server
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+class ThreadingHTTPServer(ThreadingMixIn, HTTPServer):
+    """HTTPServer that handles each request in a separate thread."""
+    daemon_threads = True
+
+
+class DashboardHTTPHandler(SimpleHTTPRequestHandler):
+    """Serve the dashboard HTML and API endpoints."""
+
+    def do_GET(self):
+        if self.path == "/" or self.path == "/index.html":
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.end_headers()
+            self.wfile.write(DASHBOARD_HTML.encode("utf-8"))
+        elif self.path == "/api/peers":
+            self._json_response(_get_peers())
+        elif self.path == "/api/state":
+            self._json_response(_STATE.get("states", {}))
+        elif self.path == "/api/events":
+            self._json_response(_STATE.get("events", [])[-100:])
+        elif self.path.startswith("/api/state/"):
+            peer_id = self.path.split("/api/state/")[1]
+            self._json_response(_STATE.get("states", {}).get(peer_id, {}))
+        elif self.path.startswith("/api/cameras/"):
+            peer_id = self.path.split("/api/cameras/")[1]
+            self._json_response(_STATE.get("cameras", {}).get(peer_id, {}))
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def _json_response(self, data):
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.end_headers()
+        self.wfile.write(json.dumps(data, default=str).encode())
+
+    def log_message(self, format, *args):
+        pass
+
+
+def start_dashboard(port: int = 7860, open_browser: bool = True):
+    """Start the Strands Robots Dashboard.
+
+    Args:
+        port: HTTP port (WebSocket will be port+1)
+        open_browser: Auto-open browser
+    """
+    ws_port = port + 1
+
+    print(f"🤖 Strands Robots Dashboard")
+    print(f"=" * 50)
+
+    zenoh_ok = _start_zenoh()
+    if zenoh_ok:
+        print(f"✅ Zenoh mesh connected (peer: {_DASHBOARD_PEER_ID})")
+    else:
+        print(f"⚠️  Zenoh not available — dashboard will show no live data")
+        print(f"   Install: pip install eclipse-zenoh")
+
+    async def _ws_server():
+        import websockets
+        async with websockets.serve(_ws_handler, "0.0.0.0", ws_port):
+            logger.info("WebSocket server on :%d", ws_port)
+            await asyncio.Future()
+
+    ws_thread = threading.Thread(
+        target=lambda: asyncio.new_event_loop().run_until_complete(_ws_server()),
+        daemon=True,
+    )
+    ws_thread.start()
+    print(f"✅ WebSocket server: ws://localhost:{ws_port}")
+
+    httpd = ThreadingHTTPServer(("0.0.0.0", port), DashboardHTTPHandler)
+    print(f"✅ Dashboard: http://localhost:{port}")
+    print(f"=" * 50)
+    print(f"📡 Listening for Robot() instances on Zenoh mesh...")
+    print(f"   Create a robot to see it here: Robot('so100')")
+    print()
+
+    if open_browser:
+        try:
+            import webbrowser
+            webbrowser.open(f"http://localhost:{port}")
+        except Exception:
+            pass
+
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        print("\n🛑 Dashboard stopped")
+        httpd.shutdown()
+
+
+def main():
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(description="Strands Robots Dashboard")
+    parser.add_argument("--port", "-p", type=int, default=7860, help="HTTP port (default: 7860)")
+    parser.add_argument("--no-browser", action="store_true", help="Don't auto-open browser")
+    args = parser.parse_args()
+    start_dashboard(port=args.port, open_browser=not args.no_browser)
+
+
+if __name__ == "__main__":
+    main()

--- a/strands_robots/robot.py
+++ b/strands_robots/robot.py
@@ -1037,6 +1037,62 @@ class Robot(AgentTool):
             ],
         }
 
+    # --- Camera streaming for dashboard ---
+
+    def _render_camera_jpeg_b64(self, camera_name: str = "default") -> str | None:
+        """Render a camera frame from the real robot as base64 JPEG for mesh streaming.
+
+        Grabs the latest observation and encodes the first camera image.
+        """
+        try:
+            if not getattr(self.robot, "is_connected", False):
+                return None
+
+            observation = self.robot.get_observation()
+
+            # Find camera keys
+            camera_keys = []
+            if hasattr(self.robot, "config") and hasattr(self.robot.config, "cameras"):
+                camera_keys = list(self.robot.config.cameras.keys())
+
+            # If specific camera requested, use it; otherwise use first available
+            cam_key = camera_name if camera_name in observation else (camera_keys[0] if camera_keys else None)
+            if not cam_key or cam_key not in observation:
+                return None
+
+            img = observation[cam_key]
+            if not hasattr(img, "shape") or len(img.shape) < 2:
+                return None
+
+            import base64
+            import io
+            from PIL import Image
+
+            # Convert numpy array to JPEG
+            if hasattr(img, "numpy"):
+                img = img.numpy()
+            pil_img = Image.fromarray(img)
+            buffer = io.BytesIO()
+            pil_img.save(buffer, format="JPEG", quality=60)
+            return base64.b64encode(buffer.getvalue()).decode("ascii")
+
+        except Exception as e:
+            logger.debug("Robot camera render failed: %s", e)
+            return None
+
+    def start_camera_stream(self, camera: str = "default", fps: int = 5) -> Dict[str, Any]:
+        """Start streaming camera frames from real robot over Zenoh mesh.
+
+        Args:
+            camera: Camera name (default: first available)
+            fps: Frames per second (default: 5, lower than sim for bandwidth)
+        """
+        if not self.mesh or not self.mesh.alive:
+            return {"status": "error", "content": [{"text": "❌ Mesh not enabled"}]}
+
+        self.mesh.start_camera_stream(self._render_camera_jpeg_b64, camera=camera, fps=fps)
+        return {"status": "success", "content": [{"text": f"📹 Camera stream started: {camera} @ {fps}fps"}]}
+
     def tool_name(self) -> str:
         return self.tool_name_str
 

--- a/strands_robots/simulation/_mjcf_builder.py
+++ b/strands_robots/simulation/_mjcf_builder.py
@@ -64,12 +64,25 @@ class MJCFBuilder:
         return "\n".join(parts)
 
     @staticmethod
+    def _pad4(val, default):
+        """Pad a list to exactly 4 elements (for quaternion/RGBA)."""
+        if val is None:
+            return list(default)
+        v = list(val)
+        while len(v) < 4:
+            v.append(default[len(v)] if len(v) < len(default) else 0.0)
+        return v[:4]
+
+    @staticmethod
     def _object_xml(obj: SimObject, indent: int = 4) -> str:
         """Generate MJCF XML for a single object."""
         pad = " " * indent
-        px, py, pz = obj.position
-        qw, qx, qy, qz = obj.orientation
-        r, g, b, a = obj.color
+        pos = list(obj.position) + [0.0, 0.0, 0.0]
+        px, py, pz = pos[0], pos[1], pos[2]
+        ori = MJCFBuilder._pad4(obj.orientation, [1.0, 0.0, 0.0, 0.0])
+        qw, qx, qy, qz = ori[0], ori[1], ori[2], ori[3]
+        col = MJCFBuilder._pad4(obj.color, [0.5, 0.5, 0.5, 1.0])
+        r, g, b, a = col[0], col[1], col[2], col[3]
         lines = []
 
         lines.append(f'{pad}<body name="{obj.name}" pos="{px} {py} {pz}" quat="{qw} {qx} {qy} {qz}">')

--- a/strands_robots/simulation/_policy_runner.py
+++ b/strands_robots/simulation/_policy_runner.py
@@ -77,6 +77,10 @@ class PolicyRunnerMixin:
             robot.policy_steps = 0
             next_frame_step = 0.0
 
+            # Notify dashboard
+            if hasattr(self, '_publish_event'):
+                self._publish_event("policy_started", {"robot": robot_name, "policy": policy_provider, "instruction": instruction})
+
             sim_duration = duration * control_frequency  # target number of control steps
             start_time = time.time()
             action_sleep = 1.0 / control_frequency
@@ -112,6 +116,19 @@ class PolicyRunnerMixin:
                     self._apply_sim_action(robot_name, action_dict)
                     robot.policy_steps += 1
 
+                    # Stream step to mesh for dashboard live monitoring
+                    if hasattr(self, "mesh") and self.mesh and self.mesh.alive:
+                        try:
+                            self.mesh.publish_step(
+                                step=robot.policy_steps,
+                                observation=observation,
+                                action=action_dict,
+                                instruction=instruction,
+                                policy=policy_provider,
+                            )
+                        except Exception:
+                            pass  # Never let mesh errors break the control loop
+
                     if writer and robot.policy_steps >= next_frame_step:
                         renderer = self._get_renderer(video_width, video_height)
                         if cam_id >= 0:
@@ -127,6 +144,10 @@ class PolicyRunnerMixin:
 
             elapsed = time.time() - start_time
             robot.policy_running = False
+
+            # Notify dashboard
+            if hasattr(self, '_publish_event'):
+                self._publish_event("policy_completed", {"robot": robot_name, "steps": robot.policy_steps, "elapsed": round(elapsed, 1)})
 
             result_text = (
                 f"✅ Policy complete on '{robot_name}'\n"

--- a/strands_robots/simulation/simulation.py
+++ b/strands_robots/simulation/simulation.py
@@ -219,9 +219,38 @@ class Simulation(
     def _recompile_world(self) -> Dict[str, Any]:
         try:
             self._compile_world()
+            self._invalidate_renderers()
             return {"status": "success"}
         except Exception as e:
             return {"status": "error", "content": [{"text": f"❌ Recompile failed: {e}"}]}
+
+    def _invalidate_renderers(self):
+        """Invalidate all cached renderers after model recompile.
+
+        Called after any operation that changes the MuJoCo model (add_object,
+        remove_object, add_robot, add_camera, etc.) so camera streams and
+        render() produce frames from the new model.
+
+        NOTE: We only set references to None — we do NOT call .close() here
+        because the camera stream thread may still be using the renderer.
+        The old renderer will be garbage collected when no longer referenced.
+        New renderers are lazily created on next use.
+        """
+        # Set to None so next render creates a fresh renderer for the new model.
+        # The old renderer object will be GC'd when the camera thread moves on.
+        self._cam_stream_renderer = None
+
+        # Clear all cached renderers — same pattern: just drop references
+        self._renderers.clear()
+        self._renderer_model = None
+
+    def _publish_event(self, event_type: str, data: dict = None):
+        """Publish a sim mutation event to the Zenoh mesh."""
+        if hasattr(self, "mesh") and self.mesh and self.mesh.alive:
+            try:
+                self.mesh.publish_event(event_type, data or {})
+            except Exception:
+                pass
 
     # --- Robot Management ---
 
@@ -358,6 +387,8 @@ class Simulation(
                 mj.mj_step(model, data)
 
             source = f"data_config='{data_config}'" if data_config else os.path.basename(resolved_path)
+            self._invalidate_renderers()
+            self._publish_event("robot_added", {"name": name, "joints": len(robot.joint_names), "source": source})
             return {
                 "status": "success",
                 "content": [{"text": (
@@ -385,6 +416,7 @@ class Simulation(
                 pass
             del self._policy_threads[name]
         del self._world.robots[name]
+        self._publish_event("robot_removed", {"name": name})
         return {"status": "success", "content": [{"text": f"🗑️ Robot '{name}' removed."}]}
 
     def list_robots(self) -> Dict[str, Any]:
@@ -440,12 +472,13 @@ class Simulation(
         if name in self._world.objects:
             return {"status": "error", "content": [{"text": f"❌ Object '{name}' exists."}]}
 
+        from strands_robots.simulation._mjcf_builder import MJCFBuilder
         obj = SimObject(
             name=name, shape=shape,
-            position=position or [0.0, 0.0, 0.0],
-            orientation=orientation or [1.0, 0.0, 0.0, 0.0],
-            size=size or [0.05, 0.05, 0.05],
-            color=color or [0.5, 0.5, 0.5, 1.0],
+            position=list(position or [0.0, 0.0, 0.0])[:3],
+            orientation=MJCFBuilder._pad4(orientation, [1.0, 0.0, 0.0, 0.0]),
+            size=list(size or [0.05, 0.05, 0.05]),
+            color=MJCFBuilder._pad4(color, [0.5, 0.5, 0.5, 1.0]),
             mass=mass, mesh_path=mesh_path, is_static=is_static,
         )
         self._world.objects[name] = obj
@@ -453,14 +486,18 @@ class Simulation(
         if self._world.robots:
             try:
                 result = inject_object_into_scene(self._world, obj)
+                self._invalidate_renderers()
                 if result:
+                    self._publish_event("object_added", {"name": name, "shape": shape, "position": obj.position})
                     return {"status": "success", "content": [{"text": f"📦 '{name}' spawned: {shape} at {obj.position}"}]}
+                self._publish_event("object_added", {"name": name, "shape": shape, "position": obj.position})
                 return {"status": "success", "content": [{"text": (
                     f"📦 '{name}' registered: {shape} at {obj.position}\n"
                     "⚠️ Robot scene loaded — object is tracked but not physically spawned."
                 )}]}
             except Exception as e:
                 logger.warning("Object injection failed, tracking metadata only: %s", e)
+                self._publish_event("object_added", {"name": name, "shape": shape, "position": obj.position, "warning": str(e)})
                 return {"status": "success", "content": [{"text": f"📦 '{name}' registered: {shape} at {obj.position}\n⚠️ Injection failed ({e})"}]}
 
         result = self._recompile_world()
@@ -468,6 +505,7 @@ class Simulation(
             del self._world.objects[name]
             return result
 
+        self._publish_event("object_added", {"name": name, "shape": shape, "position": obj.position})
         return {"status": "success", "content": [{"text": f"📦 '{name}' added: {shape} at {obj.position}, size={obj.size}, {'static' if is_static else f'{mass}kg'}"}]}
 
     def remove_object(self, name: str) -> Dict[str, Any]:
@@ -476,8 +514,10 @@ class Simulation(
         del self._world.objects[name]
         if self._world.robots:
             eject_body_from_scene(self._world, name)
+            self._invalidate_renderers()
         else:
             self._recompile_world()
+        self._publish_event("object_removed", {"name": name})
         return {"status": "success", "content": [{"text": f"🗑️ '{name}' removed."}]}
 
     def move_object(self, name: str, position: List[float] = None, orientation: List[float] = None) -> Dict[str, Any]:
@@ -500,6 +540,7 @@ class Simulation(
                 self._world.objects[name].orientation = orientation
             mj.mj_forward(model, data)
 
+        self._publish_event("object_moved", {"name": name, "position": position, "orientation": orientation})
         return {"status": "success", "content": [{"text": f"📍 '{name}' moved to {position or 'same'}"}]}
 
     def list_objects(self) -> Dict[str, Any]:
@@ -564,6 +605,7 @@ class Simulation(
         for r in self._world.robots.values():
             r.policy_running = False
             r.policy_steps = 0
+        self._publish_event("reset", {})
         return {"status": "success", "content": [{"text": "🔄 Reset to initial state."}]}
 
     def get_state(self) -> Dict[str, Any]:
@@ -749,12 +791,17 @@ class Simulation(
             "list_urdfs": "list_urdfs_action",
             "register_urdf": "register_urdf_action",
             "stop_policy": "_stop_policy",
+            "execute": "run_policy",
+            "stop": "_stop_policy",
+            "teleop_start": "run_policy",
+            "teleop_stop": "_stop_policy",
+            "teleop_delta": "teleop_delta",
         }
 
         method_name = _ALIASES.get(action, action)
         method = getattr(self, method_name, None)
 
-        if method is None or action.startswith("_"):
+        if method is None or (action.startswith("_") and action not in _ALIASES):
             return {"status": "error", "content": [{"text": f"❌ Unknown action: {action}"}]}
 
         # Build kwargs from input dict, excluding 'action' itself
@@ -771,6 +818,10 @@ class Simulation(
                 kwargs["name"] = d["robot_name"]
             elif param_name == "robot_name" and "robot_name" not in d and "name" in d:
                 kwargs["robot_name"] = d["name"]
+            elif param_name == "robot_name" and "robot_name" not in d and "name" not in d:
+                # Auto-detect first robot in world
+                if self._world and self._world.robots:
+                    kwargs["robot_name"] = next(iter(self._world.robots))
             elif param_name in d:
                 kwargs[param_name] = d[param_name]
             # Forward policy kwargs
@@ -782,15 +833,130 @@ class Simulation(
 
         return method(**kwargs)
 
+    def teleop_delta(self, joint: int = 0, delta: float = 0.0, robot_name: str = "", **kwargs) -> Dict[str, Any]:
+        """Apply a delta to a specific joint and step the simulation.
+
+        Used by the dashboard keyboard teleop (WASD keys) to nudge joints.
+        The joint is identified by index into the robot's joint_names list.
+
+        Args:
+            joint: Joint index (0-based into robot's joint list)
+            delta: Position delta to apply (radians)
+            robot_name: Robot name (auto-detected if empty)
+        """
+        if self._world is None or self._world._model is None:
+            return {"status": "error", "content": [{"text": "❌ No simulation."}]}
+
+        mj = _ensure_mujoco()
+        model, data = self._world._model, self._world._data
+
+        if not robot_name and self._world.robots:
+            robot_name = next(iter(self._world.robots))
+        robot = self._world.robots.get(robot_name)
+        if not robot:
+            return {"status": "error", "content": [{"text": f"❌ Robot '{robot_name}' not found."}]}
+
+        if joint < 0 or joint >= len(robot.joint_names):
+            return {"status": "error", "content": [{"text": f"❌ Joint index {joint} out of range (0-{len(robot.joint_names)-1})"}]}
+
+        jnt_name = robot.joint_names[joint]
+        jnt_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, jnt_name)
+        if jnt_id < 0:
+            return {"status": "error", "content": [{"text": f"❌ Joint '{jnt_name}' not found in model"}]}
+
+        # Apply delta to joint position
+        qpos_adr = model.jnt_qposadr[jnt_id]
+        data.qpos[qpos_adr] += delta
+
+        # Also set ctrl if there's a matching actuator
+        act_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_ACTUATOR, jnt_name)
+        if act_id >= 0:
+            data.ctrl[act_id] = float(data.qpos[qpos_adr])
+
+        # Step the simulation to apply
+        for _ in range(5):  # small burst of steps for smooth motion
+            mj.mj_step(model, data)
+        self._world.sim_time = data.time
+        self._world.step_count += 5
+
+        if hasattr(self, '_viewer_handle') and self._viewer_handle is not None:
+            self._viewer_handle.sync()
+
+        return {"status": "success"}
+
     def _stop_policy(self, robot_name: str = "", **kwargs) -> Dict[str, Any]:
+        # Auto-detect robot if not specified
+        if not robot_name and self._world and self._world.robots:
+            robot_name = next(iter(self._world.robots))
         if self._world and robot_name in self._world.robots:
             self._world.robots[robot_name].policy_running = False
             return {"status": "success", "content": [{"text": f"🛑 Stopped on '{robot_name}'"}]}
+        # Stop ALL robots if name not found
+        if self._world:
+            for rn, robj in self._world.robots.items():
+                robj.policy_running = False
+            return {"status": "success", "content": [{"text": "🛑 All policies stopped"}]}
         return {"status": "error", "content": [{"text": f"❌ '{robot_name}' not found."}]}
+
+    # --- Camera Streaming ---
+
+    def _render_camera_jpeg_b64(self, camera_name: str = "default") -> Optional[str]:
+        """Render a camera view and return as base64 JPEG string for mesh streaming.
+
+        Thread-safe: if model changes between calls, the old renderer ref is
+        dropped by _invalidate_renderers() and a new one is created here.
+        """
+        if self._world is None or self._world._model is None:
+            return None
+        try:
+            mj = _ensure_mujoco()
+            w, h = 320, 240
+            model = self._world._model
+            data = self._world._data
+            renderer = getattr(self, "_cam_stream_renderer", None)
+            if renderer is None:
+                renderer = mj.Renderer(model, height=h, width=w)
+                self._cam_stream_renderer = renderer
+            cam_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_CAMERA, camera_name)
+            if cam_id >= 0:
+                renderer.update_scene(data, camera=cam_id)
+            else:
+                renderer.update_scene(data)
+            img = renderer.render().copy()
+            from PIL import Image
+            import io
+            import base64
+            pil_img = Image.fromarray(img)
+            buffer = io.BytesIO()
+            pil_img.save(buffer, format="JPEG", quality=60)
+            return base64.b64encode(buffer.getvalue()).decode("ascii")
+        except Exception as e:
+            # If renderer is stale after model change, discard and retry next frame
+            self._cam_stream_renderer = None
+            logger.debug("Camera JPEG render failed: %s", e)
+            return None
+
+    def start_camera_stream(self, camera: str = "default", fps: int = 10, **kwargs) -> Dict[str, Any]:
+        """Start streaming camera frames over Zenoh mesh."""
+        if not hasattr(self, "mesh") or not self.mesh:
+            return {"status": "error", "content": [{"text": "❌ Mesh not enabled"}]}
+        self.mesh.start_camera_stream(self._render_camera_jpeg_b64, camera=camera, fps=fps)
+        return {"status": "success", "content": [{"text": f"📹 Camera stream started: {camera} @ {fps}fps"}]}
+
+    def stop_camera_stream(self, **kwargs) -> Dict[str, Any]:
+        """Stop camera stream."""
+        return {"status": "success", "content": [{"text": "📹 Camera stream will stop on cleanup"}]}
 
     # --- Cleanup ---
 
     def cleanup(self):
+        # Close dedicated camera stream renderer
+        if hasattr(self, "_cam_stream_renderer") and self._cam_stream_renderer:
+            try:
+                self._cam_stream_renderer.close()
+            except Exception:
+                pass
+            self._cam_stream_renderer = None
         if hasattr(self, "mesh") and self.mesh:
             self.mesh.stop()
         if self._world:

--- a/strands_robots/zenoh_mesh.py
+++ b/strands_robots/zenoh_mesh.py
@@ -348,7 +348,11 @@ class Mesh:
             time.sleep(1.0 / STATE_HZ)
 
     def _read_state(self) -> Optional[dict]:
-        """Read current robot/sim state for publishing."""
+        """Read current robot/sim state for publishing.
+
+        Includes joints, task status, simulation world metadata (objects,
+        cameras, robots) so the dashboard can render the full scene.
+        """
         r = self.robot
         s: dict = {"peer_id": self.peer_id, "t": time.time()}
         try:
@@ -371,16 +375,67 @@ class Mesh:
                     "duration": ts.duration,
                 }
 
-            # Simulation
+            # Simulation world state
             if hasattr(r, "_world") and r._world is not None:
                 w = r._world
                 if hasattr(w, "_data") and w._data is not None:
                     s["sim_time"] = float(w._data.time)
                 elif hasattr(r, "_data") and r._data is not None:
                     s["sim_time"] = float(r._data.time)
-                if hasattr(r, "_world") and r._world is not None and hasattr(r._world, "robots"):
-                    for name in r._world.robots:
-                        s.setdefault("robots", {})[name] = {"active": True}
+
+                # Sim joint positions (for dashboard joint gauges)
+                if "joints" not in s and hasattr(w, "robots") and w.robots and hasattr(w, "_model") and w._model is not None:
+                    try:
+                        import importlib
+                        mj = importlib.import_module("mujoco")
+                        model, data = w._model, w._data
+                        if data is not None:
+                            joints = {}
+                            for rname, rob in w.robots.items():
+                                for jnt_name in getattr(rob, "joint_names", []):
+                                    jnt_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, jnt_name)
+                                    if jnt_id >= 0:
+                                        joints[jnt_name] = float(data.qpos[model.jnt_qposadr[jnt_id]])
+                            if joints:
+                                s["joints"] = joints
+                    except Exception:
+                        pass
+
+                # Robots in world
+                if hasattr(w, "robots"):
+                    robots_info = {}
+                    for name, rob in w.robots.items():
+                        robots_info[name] = {
+                            "active": True,
+                            "policy_running": getattr(rob, "policy_running", False),
+                            "joints": len(getattr(rob, "joint_names", [])),
+                        }
+                    s["robots"] = robots_info
+
+                # Objects in world (scene composition)
+                if hasattr(w, "objects") and w.objects:
+                    s["objects"] = {
+                        name: {
+                            "shape": getattr(obj, "shape", "?"),
+                            "position": getattr(obj, "position", []),
+                            "color": getattr(obj, "color", [])[:3] if getattr(obj, "color", None) else [],
+                            "is_static": getattr(obj, "is_static", False),
+                        }
+                        for name, obj in w.objects.items()
+                    }
+
+                # Cameras in world
+                if hasattr(w, "cameras") and w.cameras:
+                    s["cameras"] = list(w.cameras.keys())
+
+                # World metadata
+                if hasattr(w, "_model") and w._model is not None:
+                    s["world"] = {
+                        "bodies": w._model.nbody,
+                        "joints": w._model.njnt,
+                        "actuators": w._model.nu,
+                        "step_count": getattr(w, "step_count", 0),
+                    }
 
         except Exception:
             pass
@@ -444,6 +499,11 @@ class Mesh:
             return {"status": getattr(getattr(r, "_task_state", None), "status", "unknown")}
 
         if action == "stop":
+            # Simulation: stop policy on all robots
+            if hasattr(r, "_world") and r._world:
+                for rname, robj in r._world.robots.items():
+                    robj.policy_running = False
+                return {"status": "stopped", "content": [{"text": "🛑 Policy stopped"}]}
             return r.stop_task() if hasattr(r, "stop_task") else {"ok": True}
 
         if action == "features":
@@ -470,6 +530,32 @@ class Mesh:
                 )
                 if k in cmd
             }
+
+            # Simulation backend — route to run_policy / start_policy
+            if hasattr(r, "run_policy") and hasattr(r, "_world"):
+                robot_name = None
+                if r._world and r._world.robots:
+                    robot_name = cmd.get("robot_name") or next(iter(r._world.robots))
+                if not robot_name:
+                    return {"error": "no robots in simulation"}
+                if action == "execute":
+                    return r.run_policy(
+                        robot_name=robot_name,
+                        policy_provider=pp,
+                        instruction=instr,
+                        duration=dur,
+                        **kw,
+                    )
+                else:  # start
+                    return r.start_policy(
+                        robot_name=robot_name,
+                        policy_provider=pp,
+                        instruction=instr,
+                        duration=dur,
+                        **kw,
+                    )
+
+            # Hardware robot backend
             if action == "execute" and hasattr(r, "_execute_task_sync"):
                 return r._execute_task_sync(instr, pp, port, host, dur, **kw)
             if action == "start" and hasattr(r, "start_task"):
@@ -480,6 +566,23 @@ class Mesh:
             return r.step(cmd.get("steps", 1))
         if action == "reset" and hasattr(r, "reset"):
             return r.reset()
+
+        # Camera stream — dispatch to simulation's handler or robot's
+        if action == "start_camera_stream":
+            if hasattr(r, "_dispatch_action"):
+                return r._dispatch_action("start_camera_stream", cmd)
+            elif hasattr(r, "start_camera_stream"):
+                return r.start_camera_stream(
+                    camera=cmd.get("camera", "default"),
+                    fps=cmd.get("fps", 10),
+                )
+            return {"error": "start_camera_stream not supported by this peer"}
+
+        # Teleop delta — nudge a joint in simulation
+        if action == "teleop_delta":
+            if hasattr(r, "_dispatch_action"):
+                return r._dispatch_action("teleop_delta", cmd)
+            return {"error": "teleop_delta requires Simulation backend"}
 
         return {"error": f"unknown action: {action}"}
 
@@ -577,7 +680,93 @@ class Mesh:
                 pass
             self.inbox.pop(name, None)
 
+    # ── Event publishing (discrete mutations) ─────────────────
+
+    def publish_event(self, event_type: str, data: dict = None):
+        """Publish a discrete event to the mesh.
+
+        Used for mutations like object_added, object_removed, robot_added,
+        policy_started, etc. Dashboard subscribes to strands/*/event.
+
+        Args:
+            event_type: Event type string (e.g. "object_added", "policy_started")
+            data: Event payload dict
+        """
+        _put(
+            f"strands/{self.peer_id}/event",
+            {
+                "peer_id": self.peer_id,
+                "event_type": event_type,
+                "data": data or {},
+                "ts": time.time(),
+            },
+        )
+
     # ── VLA execution stream ───────────────────────────────────
+
+    # ── Camera frame publishing ──────────────────────────────
+
+    def publish_camera_frame(
+        self,
+        frame_b64: str,
+        camera: str = "default",
+    ):
+        """Publish a camera frame (base64 JPEG) to the mesh.
+
+        Dashboard and other peers subscribe to strands/{peer_id}/camera.
+        Frames are JPEG-encoded and base64'd for JSON transport.
+
+        Args:
+            frame_b64: Base64-encoded JPEG image data
+            camera: Camera name (default: "default")
+        """
+        _put(
+            f"strands/{self.peer_id}/camera",
+            {
+                "peer_id": self.peer_id,
+                "camera": camera,
+                "frame": frame_b64,
+                "ts": time.time(),
+            },
+        )
+
+    def start_camera_stream(
+        self,
+        render_fn,
+        camera: str = "default",
+        fps: float = 10.0,
+    ):
+        """Start a background thread that publishes camera frames.
+
+        Args:
+            render_fn: Callable that returns base64 JPEG string.
+                Signature: render_fn(camera_name: str) -> str
+            camera: Camera name
+            fps: Frames per second (default: 10)
+        """
+        if not hasattr(self, "_camera_threads"):
+            self._camera_threads = {}
+
+        key = camera
+        if key in self._camera_threads and self._camera_threads[key].is_alive():
+            return  # Already streaming
+
+        def _stream_loop():
+            interval = 1.0 / fps
+            while self._running:
+                try:
+                    frame_b64 = render_fn(camera)
+                    if frame_b64:
+                        self.publish_camera_frame(frame_b64, camera)
+                except Exception as e:
+                    logger.debug("Camera stream error: %s", e)
+                time.sleep(interval)
+
+        t = threading.Thread(target=_stream_loop, daemon=True, name=f"cam-{self.peer_id}-{camera}")
+        t.start()
+        self._camera_threads[key] = t
+        logger.info("📹 %s camera stream started: %s @ %.0f fps", self.peer_id, camera, fps)
+
 
     def publish_step(
         self,


### PR DESCRIPTION
## Summary

Adds a real-time web dashboard for monitoring and controlling robots via the Zenoh mesh, plus enriches the mesh layer with camera streaming and event publishing.

## Changes

### 🖥️ Web Dashboard (`strands_robots/dashboard/`)
- Real-time peer discovery and joint state gauges
- Live camera feeds from simulation/real robots
- HuggingFace model search with autocomplete
- Keyboard teleop (WASD), E-STOP, command dispatch
- WebSocket + HTTP server with live event log

### 🔗 Zenoh Mesh Enrichment (`zenoh_mesh.py`)
- `publish_event()` for discrete mutations (object/robot add/remove)
- `publish_camera_frame()` + `start_camera_stream()` background thread
- Rich state: joints, objects, cameras, world metadata
- Dashboard command routing: execute, stop, teleop_start/stop/delta

### 🎮 Simulation Improvements
- `_invalidate_renderers()` after model recompile (fixes stale cameras)
- `teleop_delta()` for real-time joint nudging from dashboard
- Defensive `_pad4()` in MJCF builder for short color/orientation lists
- Auto-detect first robot when `robot_name` not specified
- `_publish_event()` on every scene mutation

### 📷 Robot Camera Streaming
- `_render_camera_jpeg_b64()` for real robot camera frames
- `start_camera_stream()` over Zenoh mesh

## Testing
- Manually tested dashboard with simulated SO-100 arm
- Camera streaming verified over Zenoh mesh
- Teleop verified with keyboard input from dashboard