### PR TITLE
fix: Newton up_axis string→Axis enum, add warp-lang to isaac extras, platform-gate usd-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,8 @@ isaac = [
     # pip install isaaclab isaaclab_assets isaaclab_tasks (from Isaac Lab source)
     "h5py>=3.0",
     "mujoco>=3.0.0",
-    "usd-core>=24.0",  # OpenUSD (pxr) for MJCF→USD asset conversion
+    "usd-core>=24.0; platform_machine != 'aarch64'",  # OpenUSD (no aarch64 wheels)
+    "warp-lang>=1.0.0",
 ]
 newton = [
     "newton>=1.0.0",

--- a/strands_robots/newton/newton_backend.py
+++ b/strands_robots/newton/newton_backend.py
@@ -611,19 +611,11 @@ class NewtonBackend:
             gravity_mag = -abs(gy) if gy != 0 else -9.81
 
         try:
-            self._builder = newton.ModelBuilder(gravity=gravity_mag)
+            self._builder = newton.ModelBuilder(
+                up_axis=up_axis.upper(), gravity=gravity_mag
+            )
         except (TypeError, AttributeError):
             self._builder = newton.ModelBuilder()
-        # Set scalar gravity and up_vector
-        try:
-            self._builder.gravity = gravity_mag
-        except Exception:
-            pass
-        try:
-            self._builder.up_vector = up_vec
-            self._builder.up_axis = up_axis
-        except Exception:
-            pass
 
         self._ground_plane_requested = ground_plane
         if ground_plane:
@@ -656,19 +648,13 @@ class NewtonBackend:
         """Recreate the model builder to clear any partial state from failed loads."""
         newton = self._newton
         gravity_mag = getattr(self._builder, "gravity", -9.81)
-        up_vec = getattr(self._builder, "up_vector", (0.0, 0.0, 1.0))
+        up_axis_str = getattr(self._config, "up_axis", "z")
         try:
-            self._builder = newton.ModelBuilder(gravity=gravity_mag)
+            self._builder = newton.ModelBuilder(
+                up_axis=up_axis_str.upper(), gravity=gravity_mag
+            )
         except (TypeError, AttributeError):
             self._builder = newton.ModelBuilder()
-        try:
-            self._builder.gravity = gravity_mag
-        except Exception:
-            pass
-        try:
-            self._builder.up_vector = up_vec
-        except Exception:
-            pass
         if getattr(self, "_ground_plane_requested", True):
             try:
                 self._builder.add_ground_plane()


### PR DESCRIPTION
## Summary

Ports three GPU-blocker fixes from the GPU test campaign ([cagataycali/strands-gtc-nvidia#290](https://github.com/cagataycali/strands-gtc-nvidia/issues/290)) to strands-labs/robots.

### 1. Newton `up_axis` bug (BLOCKER)

`create_world()` was setting `up_axis` on `ModelBuilder` via `setattr`, bypassing the constructor's string→Axis enum conversion. Newton's `up_vector` property then called `.to_vector()` on a plain string, crashing with `AttributeError: 'str' object has no attribute 'to_vector'`.

**Fix:** Pass `up_axis` directly to the `ModelBuilder` constructor, which handles the conversion internally. Also fixed in `_recreate_builder()`.

This unblocks all Newton stepping, robot loading, diffsim, sensors, and dual solver.

### 2. Missing `warp-lang` in `[isaac]` extras

`IsaacSimBackend.create_world()` was failing with `RuntimeError: Isaac Lab not available: No module named 'warp'`. Added `warp-lang>=1.0.0` to the `[isaac]` extras in `pyproject.toml`.

### 3. `usd-core` platform gating for aarch64

`usd-core` has no aarch64 wheels, which blocked `pip install -e ".[isaac]"` on Jetson Thor. Added platform marker: `platform_machine != 'aarch64'`.

## Testing

- 73/73 tests pass
- Verified fix matches [commit 8272d9d on cagataycali/strands-gtc-nvidia dev](https://github.com/cagataycali/strands-gtc-nvidia/commit/8272d9d)

## Changes

- `strands_robots/newton/newton_backend.py`: Pass `up_axis` to `ModelBuilder` constructor instead of setting via `setattr` (both `create_world` and `_recreate_builder`)
- `pyproject.toml`: Add `warp-lang>=1.0.0` to `[isaac]` extras, add `platform_machine != 'aarch64'` marker to `usd-core`

---
🤖 *AI agent response. [Strands Agents](https://github.com/strands-agents). Feedback welcome!*