### PR TITLE
fix: Newton up_axis string→Axis enum, add warp-lang to [isaac], platform-gate usd-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,8 @@ isaac = [
     # pip install isaaclab isaaclab_assets isaaclab_tasks (from Isaac Lab source)
     "h5py>=3.0",
     "mujoco>=3.0.0",
-    "usd-core>=24.0",  # OpenUSD (pxr) for MJCF→USD asset conversion
+    "usd-core>=24.0; platform_machine != 'aarch64'",  # no aarch64 wheels
+    "warp-lang>=1.0.0",  # required by Isaac Lab
 ]
 newton = [
     "newton>=1.0.0",

--- a/strands_robots/newton/newton_backend.py
+++ b/strands_robots/newton/newton_backend.py
@@ -611,19 +611,20 @@ class NewtonBackend:
             gravity_mag = -abs(gy) if gy != 0 else -9.81
 
         try:
-            self._builder = newton.ModelBuilder(gravity=gravity_mag)
+            self._builder = newton.ModelBuilder(
+                up_axis=up_axis.upper(), gravity=gravity_mag
+            )
         except (TypeError, AttributeError):
             self._builder = newton.ModelBuilder()
-        # Set scalar gravity and up_vector
-        try:
-            self._builder.gravity = gravity_mag
-        except Exception:
-            pass
-        try:
-            self._builder.up_vector = up_vec
-            self._builder.up_axis = up_axis
-        except Exception:
-            pass
+            # Fallback: set gravity and up_vector as attributes
+            try:
+                self._builder.gravity = gravity_mag
+            except Exception:
+                pass
+            try:
+                self._builder.up_vector = up_vec
+            except Exception:
+                pass
 
         self._ground_plane_requested = ground_plane
         if ground_plane:
@@ -657,18 +658,21 @@ class NewtonBackend:
         newton = self._newton
         gravity_mag = getattr(self._builder, "gravity", -9.81)
         up_vec = getattr(self._builder, "up_vector", (0.0, 0.0, 1.0))
+        up_axis_str = "z" if up_vec[2] > up_vec[1] else "y"
         try:
-            self._builder = newton.ModelBuilder(gravity=gravity_mag)
+            self._builder = newton.ModelBuilder(
+                up_axis=up_axis_str.upper(), gravity=gravity_mag
+            )
         except (TypeError, AttributeError):
             self._builder = newton.ModelBuilder()
-        try:
-            self._builder.gravity = gravity_mag
-        except Exception:
-            pass
-        try:
-            self._builder.up_vector = up_vec
-        except Exception:
-            pass
+            try:
+                self._builder.gravity = gravity_mag
+            except Exception:
+                pass
+            try:
+                self._builder.up_vector = up_vec
+            except Exception:
+                pass
         if getattr(self, "_ground_plane_requested", True):
             try:
                 self._builder.add_ground_plane()
@@ -1111,7 +1115,14 @@ class NewtonBackend:
             self._dof_per_world = getattr(main_builder, "joint_count", 0)
 
             # Use Newton's replicate — instance method on a new builder
-            replicated_builder = newton.ModelBuilder()
+            # Propagate up_axis from main builder to replicated builder
+            _up_axis = getattr(main_builder, "up_axis", "Y")
+            if hasattr(_up_axis, "name"):
+                _up_axis = _up_axis.name  # Axis enum → string
+            try:
+                replicated_builder = newton.ModelBuilder(up_axis=str(_up_axis).upper())
+            except (TypeError, AttributeError):
+                replicated_builder = newton.ModelBuilder()
             replicated_builder.replicate(
                 main_builder,
                 world_count=num_envs,


### PR DESCRIPTION
## Summary

Ports three GPU-blocker fixes validated in the GPU test campaign ([cagataycali/strands-gtc-nvidia#290](https://github.com/cagataycali/strands-gtc-nvidia/issues/290), 4 test campaigns across Thor sm_110 + Isaac Sim EC2 L40S).

PR #49 was closed because it targeted the pre-refactor file structure. This PR applies the same fixes to the current `dev` branch (post-Newton backend split in #38).

### 1. Newton `up_axis` bug (BLOCKER)

`create_world()` sets `up_axis` on `ModelBuilder` as a string via attribute assignment. Newton's `up_vector` property then calls `.to_vector()` on that string → `AttributeError: 'str' object has no attribute 'to_vector'`.

**Fix:** Pass `up_axis` to the `ModelBuilder` constructor, which handles string→`Axis` enum conversion internally. Applied to:
- `create_world()` — primary builder creation
- `_recreate_builder()` — builder reset after failed loads
- `replicate()` — propagate `up_axis` to replicated builder

This unblocks all Newton stepping, robot loading, diffsim, sensors, and dual solver.

### 2. Missing `warp-lang` in `[isaac]` extras

`IsaacSimBackend.create_world()` fails with `RuntimeError: Isaac Lab not available: No module named 'warp'`. Added `warp-lang>=1.0.0` to the `[isaac]` extras.

### 3. `usd-core` aarch64 platform gating

`usd-core` has no aarch64 wheels, blocking `pip install -e '.[isaac]'` on Jetson Thor. Added: `platform_machine != 'aarch64'`.

## Testing

- 73/73 tests pass
- Fixes validated on Thor (sm_110, 132GB) and Isaac Sim EC2 (L40S, 46GB) across 4 test campaigns

## Changes

- `strands_robots/newton/newton_backend.py` — 3 locations: pass `up_axis` to `ModelBuilder()` constructor
- `pyproject.toml` — add `warp-lang>=1.0.0` to `[isaac]`, platform-gate `usd-core`

---
🤖 *AI agent response. [Strands Agents](https://github.com/strands-agents). Feedback welcome!*