### PR TITLE
improve: add path validation for filesystem-writing tools

### DIFF
--- a/strands_robots/tools/_path_validation.py
+++ b/strands_robots/tools/_path_validation.py
@@ -60,8 +60,6 @@ def validate_save_path(path: str, *, label: str = "path") -> str:
     )
     for prefix in _BLOCKED_PREFIXES:
         if resolved.startswith(prefix):
-            raise ValueError(
-                f"{label} resolves to a protected system directory ({prefix}): {resolved}"
-            )
+            raise ValueError(f"{label} resolves to a protected system directory ({prefix}): {resolved}")
 
     return resolved

--- a/strands_robots/tools/_path_validation.py
+++ b/strands_robots/tools/_path_validation.py
@@ -10,6 +10,23 @@ import re
 # Characters that have no business appearing in file paths supplied by tool callers.
 _DANGEROUS_CHARS = re.compile(r"[\x00]")
 
+# Well-known sensitive system directories that tool callers should never write to.
+# Each entry ends with '/' so ``str.startswith`` only matches paths *inside*
+# the directory, not unrelated paths that share a common prefix
+# (e.g. "/var/spool/crondata" should NOT match "/var/spool/cron/").
+BLOCKED_PREFIXES = (
+    "/etc/",
+    "/usr/",
+    "/bin/",
+    "/sbin/",
+    "/boot/",
+    "/dev/",
+    "/proc/",
+    "/sys/",
+    "/var/spool/cron/",
+    "/var/spool/at/",
+)
+
 
 def validate_save_path(path: str, *, label: str = "path") -> str:
     """Validate and resolve a user-supplied file-system path.
@@ -45,21 +62,12 @@ def validate_save_path(path: str, *, label: str = "path") -> str:
     # Resolve to absolute path (follows symlinks)
     resolved = os.path.realpath(os.path.expanduser(path))
 
-    # Block writes into known sensitive system directories
-    _BLOCKED_PREFIXES = (
-        "/etc/",
-        "/usr/",
-        "/bin/",
-        "/sbin/",
-        "/boot/",
-        "/dev/",
-        "/proc/",
-        "/sys/",
-        "/var/spool/cron",
-        "/var/spool/at",
-    )
-    for prefix in _BLOCKED_PREFIXES:
-        if resolved.startswith(prefix):
+    # Ensure resolved path ends with '/' for directory-prefix matching
+    # (files inside a blocked dir will have the dir prefix + '/')
+    check_path = resolved if resolved.endswith("/") else resolved + "/"
+
+    for prefix in BLOCKED_PREFIXES:
+        if check_path.startswith(prefix):
             raise ValueError(f"{label} resolves to a protected system directory ({prefix}): {resolved}")
 
     return resolved

--- a/strands_robots/tools/_path_validation.py
+++ b/strands_robots/tools/_path_validation.py
@@ -2,19 +2,22 @@
 
 Provides a consistent ``validate_save_path`` helper that all tool modules
 can import to reject dangerous path values before any I/O occurs.
+
+Cross-platform: blocks sensitive directories on Linux, macOS, and Windows.
 """
 
 import os
 import re
+import sys
 
 # Characters that have no business appearing in file paths supplied by tool callers.
 _DANGEROUS_CHARS = re.compile(r"[\x00]")
 
 # Well-known sensitive system directories that tool callers should never write to.
-# Each entry ends with '/' so ``str.startswith`` only matches paths *inside*
-# the directory, not unrelated paths that share a common prefix
+# Each entry ends with '/' (or '\' on Windows) so ``str.startswith`` only matches
+# paths *inside* the directory, not unrelated paths that share a common prefix
 # (e.g. "/var/spool/crondata" should NOT match "/var/spool/cron/").
-BLOCKED_PREFIXES = (
+_LINUX_BLOCKED_PREFIXES = (
     "/etc/",
     "/usr/",
     "/bin/",
@@ -27,6 +30,31 @@ BLOCKED_PREFIXES = (
     "/var/spool/at/",
 )
 
+_MACOS_BLOCKED_PREFIXES = (
+    "/System/",
+    "/Library/LaunchDaemons/",
+    "/Library/LaunchAgents/",
+)
+
+_WINDOWS_BLOCKED_PREFIXES = (
+    "C:\\Windows\\",
+    "C:\\Program Files\\",
+    "C:\\Program Files (x86)\\",
+)
+
+
+def _get_blocked_prefixes() -> tuple[str, ...]:
+    """Return blocked prefixes for the current platform."""
+    if sys.platform == "win32":
+        return _WINDOWS_BLOCKED_PREFIXES
+    elif sys.platform == "darwin":
+        return _LINUX_BLOCKED_PREFIXES + _MACOS_BLOCKED_PREFIXES
+    else:
+        return _LINUX_BLOCKED_PREFIXES
+
+
+BLOCKED_PREFIXES = _get_blocked_prefixes()
+
 
 def validate_save_path(path: str, *, label: str = "path") -> str:
     """Validate and resolve a user-supplied file-system path.
@@ -37,6 +65,9 @@ def validate_save_path(path: str, *, label: str = "path") -> str:
 
     Then resolves the path to an absolute form via ``os.path.realpath``
     and ensures it does **not** escape into well-known sensitive directories.
+
+    Cross-platform: validates against OS-specific blocked directories on
+    Linux, macOS, and Windows.
 
     Args:
         path: The raw path string from the tool caller.
@@ -62,12 +93,14 @@ def validate_save_path(path: str, *, label: str = "path") -> str:
     # Resolve to absolute path (follows symlinks)
     resolved = os.path.realpath(os.path.expanduser(path))
 
-    # Ensure resolved path ends with '/' for directory-prefix matching
-    # (files inside a blocked dir will have the dir prefix + '/')
-    check_path = resolved if resolved.endswith("/") else resolved + "/"
+    # Ensure resolved path ends with separator for directory-prefix matching
+    sep = "\\" if sys.platform == "win32" else "/"
+    check_path = resolved if resolved.endswith(sep) else resolved + sep
 
     for prefix in BLOCKED_PREFIXES:
         if check_path.startswith(prefix):
-            raise ValueError(f"{label} resolves to a protected system directory ({prefix}): {resolved}")
+            raise ValueError(
+                f"{label} resolves to a protected system directory ({prefix}): {resolved}"
+            )
 
     return resolved

--- a/strands_robots/tools/_path_validation.py
+++ b/strands_robots/tools/_path_validation.py
@@ -1,0 +1,67 @@
+"""Shared path validation utilities for tools that write to the filesystem.
+
+Provides a consistent ``validate_save_path`` helper that all tool modules
+can import to reject dangerous path values before any I/O occurs.
+"""
+
+import os
+import re
+
+# Characters that have no business appearing in file paths supplied by tool callers.
+_DANGEROUS_CHARS = re.compile(r"[\x00]")
+
+
+def validate_save_path(path: str, *, label: str = "path") -> str:
+    """Validate and resolve a user-supplied file-system path.
+
+    Rejects paths that contain:
+    - Null bytes (``\\x00``)
+    - ``..`` traversal components
+
+    Then resolves the path to an absolute form via ``os.path.realpath``
+    and ensures it does **not** escape into well-known sensitive directories.
+
+    Args:
+        path: The raw path string from the tool caller.
+        label: A human-readable name for error messages (e.g. ``"save_path"``).
+
+    Returns:
+        The validated, resolved absolute path.
+
+    Raises:
+        ValueError: If the path fails any validation check.
+    """
+    if not path:
+        raise ValueError(f"{label} must not be empty")
+
+    if _DANGEROUS_CHARS.search(path):
+        raise ValueError(f"{label} contains invalid characters")
+
+    # Reject explicit '..' components (before resolution to catch intent)
+    parts = path.replace("\\", "/").split("/")
+    if ".." in parts:
+        raise ValueError(f"{label} must not contain '..' path traversal components")
+
+    # Resolve to absolute path (follows symlinks)
+    resolved = os.path.realpath(os.path.expanduser(path))
+
+    # Block writes into known sensitive system directories
+    _BLOCKED_PREFIXES = (
+        "/etc/",
+        "/usr/",
+        "/bin/",
+        "/sbin/",
+        "/boot/",
+        "/dev/",
+        "/proc/",
+        "/sys/",
+        "/var/spool/cron",
+        "/var/spool/at",
+    )
+    for prefix in _BLOCKED_PREFIXES:
+        if resolved.startswith(prefix):
+            raise ValueError(
+                f"{label} resolves to a protected system directory ({prefix}): {resolved}"
+            )
+
+    return resolved

--- a/strands_robots/tools/_path_validation.py
+++ b/strands_robots/tools/_path_validation.py
@@ -99,8 +99,6 @@ def validate_save_path(path: str, *, label: str = "path") -> str:
 
     for prefix in BLOCKED_PREFIXES:
         if check_path.startswith(prefix):
-            raise ValueError(
-                f"{label} resolves to a protected system directory ({prefix}): {resolved}"
-            )
+            raise ValueError(f"{label} resolves to a protected system directory ({prefix}): {resolved}")
 
     return resolved

--- a/strands_robots/tools/lerobot_calibrate.py
+++ b/strands_robots/tools/lerobot_calibrate.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from typing import Any
 
 from strands import tool
+from strands_robots.tools._path_validation import validate_save_path
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -205,7 +206,7 @@ class LeRobotCalibrationManager:
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
             output_dir = BACKUP_DIR / f"backup_{timestamp}"
 
-        output_dir = Path(output_dir)
+        output_dir = Path(validate_save_path(str(output_dir), label="output_dir"))
         output_dir.mkdir(parents=True, exist_ok=True)
 
         structure = self.get_calibration_structure()
@@ -254,7 +255,7 @@ class LeRobotCalibrationManager:
 
     def restore_calibrations(self, backup_dir: Path, overwrite: bool = False) -> tuple[bool, str, int]:
         """Restore calibrations from backup"""
-        backup_dir = Path(backup_dir)
+        backup_dir = Path(validate_save_path(str(backup_dir), label="backup_dir"))
 
         if not backup_dir.exists():
             return False, f"Backup directory not found: {backup_dir}", 0

--- a/strands_robots/tools/lerobot_calibrate.py
+++ b/strands_robots/tools/lerobot_calibrate.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from typing import Any
 
 from strands import tool
+
 from strands_robots.tools._path_validation import validate_save_path
 
 # Configure logging

--- a/strands_robots/tools/lerobot_camera.py
+++ b/strands_robots/tools/lerobot_camera.py
@@ -35,6 +35,7 @@ except ImportError as e:
     raise ImportError(f"LeRobot camera modules not available: {e}")
 
 from strands import tool
+from strands_robots.tools._path_validation import validate_save_path
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -395,6 +396,9 @@ def _capture_single_image(
 ) -> dict[str, Any]:
     """Capture a single image using LeRobot camera system."""
     try:
+        # Validate save path before any filesystem operations
+        save_path = validate_save_path(save_path, label="save_path")
+
         # Create save directory
         os.makedirs(save_path, exist_ok=True)
 
@@ -480,6 +484,7 @@ def _capture_batch_images(
 ) -> dict[str, Any]:
     """Capture images from multiple cameras simultaneously."""
     try:
+        save_path = validate_save_path(save_path, label="save_path")
         os.makedirs(save_path, exist_ok=True)
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
 
@@ -607,6 +612,7 @@ def _record_video_sequence(
 ) -> dict[str, Any]:
     """Record a video sequence from camera."""
     try:
+        save_path = validate_save_path(save_path, label="save_path")
         os.makedirs(save_path, exist_ok=True)
 
         # Generate filename
@@ -919,6 +925,7 @@ def _configure_camera_settings(
 
         # Save configuration if requested
         if save_config:
+            save_path = validate_save_path(save_path, label="save_path")
             os.makedirs(save_path, exist_ok=True)
             cam_id_safe = str(camera_id).replace("/", "_")
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")

--- a/strands_robots/tools/lerobot_camera.py
+++ b/strands_robots/tools/lerobot_camera.py
@@ -35,6 +35,7 @@ except ImportError as e:
     raise ImportError(f"LeRobot camera modules not available: {e}")
 
 from strands import tool
+
 from strands_robots.tools._path_validation import validate_save_path
 
 # Configure logging

--- a/strands_robots/tools/pose_tool.py
+++ b/strands_robots/tools/pose_tool.py
@@ -20,6 +20,7 @@ from typing import Any, TypedDict
 import serial
 import serial.tools.list_ports
 from strands import tool
+from strands_robots.tools._path_validation import validate_save_path
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +50,8 @@ class PoseManager:
 
     def __init__(self, robot_id: str, storage_dir: Path | None = None):
         self.robot_id = robot_id
-        self.storage_dir = Path(storage_dir) if storage_dir else Path.cwd() / ".strands_robots" / "poses"
+        raw_dir = str(storage_dir) if storage_dir else str(Path.cwd() / ".strands_robots" / "poses")
+        self.storage_dir = Path(validate_save_path(raw_dir, label="storage_dir"))
         self.storage_dir.mkdir(parents=True, exist_ok=True)
         self.pose_file = self.storage_dir / f"{robot_id}_poses.json"
         self.poses: dict[str, RobotPose] = {}

--- a/strands_robots/tools/pose_tool.py
+++ b/strands_robots/tools/pose_tool.py
@@ -20,6 +20,7 @@ from typing import Any, TypedDict
 import serial
 import serial.tools.list_ports
 from strands import tool
+
 from strands_robots.tools._path_validation import validate_save_path
 
 logger = logging.getLogger(__name__)

--- a/tests/test_path_validation.py
+++ b/tests/test_path_validation.py
@@ -7,10 +7,10 @@ from unittest.mock import patch
 import pytest
 
 from strands_robots.tools._path_validation import (
-    BLOCKED_PREFIXES,
     _LINUX_BLOCKED_PREFIXES,
     _MACOS_BLOCKED_PREFIXES,
     _WINDOWS_BLOCKED_PREFIXES,
+    BLOCKED_PREFIXES,
     _get_blocked_prefixes,
     validate_save_path,
 )
@@ -162,9 +162,7 @@ class TestValidateSavePath:
         appropriate path separator for correct startswith matching."""
         expected_sep = "\\" if sys.platform == "win32" else "/"
         for prefix in BLOCKED_PREFIXES:
-            assert prefix.endswith(expected_sep), (
-                f"BLOCKED_PREFIXES entry missing trailing separator: {prefix!r}"
-            )
+            assert prefix.endswith(expected_sep), f"BLOCKED_PREFIXES entry missing trailing separator: {prefix!r}"
 
     # ── Custom label tests ────────────────────────────────────────────
 

--- a/tests/test_path_validation.py
+++ b/tests/test_path_validation.py
@@ -1,0 +1,181 @@
+"""Tests for strands_robots.tools._path_validation module."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from strands_robots.tools._path_validation import BLOCKED_PREFIXES, validate_save_path
+
+
+class TestValidateSavePath:
+    """Tests for the validate_save_path helper."""
+
+    # ── Happy-path tests ──────────────────────────────────────────────
+
+    def test_returns_resolved_absolute_path(self, tmp_path):
+        """A relative path should be resolved to an absolute path."""
+        target = str(tmp_path / "output" / "file.txt")
+        result = validate_save_path(target)
+        assert os.path.isabs(result)
+
+    def test_accepts_tmp_directory(self, tmp_path):
+        """Paths under /tmp should be allowed."""
+        target = str(tmp_path / "robot_data" / "capture.png")
+        result = validate_save_path(target)
+        assert result == target
+
+    def test_accepts_home_directory(self, tmp_path):
+        """Paths under the user's home directory should be allowed."""
+        target = str(tmp_path / "my_data")
+        result = validate_save_path(target)
+        assert result == target
+
+    def test_tilde_expansion(self, tmp_path):
+        """~ should expand to the user home directory."""
+        with patch.dict(os.environ, {"HOME": str(tmp_path)}):
+            result = validate_save_path("~/robot_data")
+            assert result.startswith(str(tmp_path))
+            assert "~" not in result
+
+    def test_custom_label_in_success(self, tmp_path):
+        """Custom label should not affect a successful result."""
+        target = str(tmp_path / "data.json")
+        result = validate_save_path(target, label="save_path")
+        assert result == target
+
+    # ── Empty / null-byte rejection ───────────────────────────────────
+
+    def test_rejects_empty_string(self):
+        with pytest.raises(ValueError, match="must not be empty"):
+            validate_save_path("")
+
+    def test_rejects_null_byte(self):
+        with pytest.raises(ValueError, match="contains invalid characters"):
+            validate_save_path("/tmp/evil\x00file.txt")
+
+    def test_rejects_null_byte_in_middle(self):
+        with pytest.raises(ValueError, match="contains invalid characters"):
+            validate_save_path("/tmp/foo\x00/bar")
+
+    # ── Directory-traversal rejection ─────────────────────────────────
+
+    def test_rejects_double_dot_component(self):
+        with pytest.raises(ValueError, match="path traversal"):
+            validate_save_path("/tmp/data/../../../etc/passwd")
+
+    def test_rejects_leading_double_dot(self):
+        with pytest.raises(ValueError, match="path traversal"):
+            validate_save_path("../../etc/shadow")
+
+    def test_rejects_backslash_traversal(self):
+        """Backslash-separated '..' should also be caught (Windows-style)."""
+        with pytest.raises(ValueError, match="path traversal"):
+            validate_save_path("data\\..\\..\\etc\\passwd")
+
+    def test_allows_dots_in_filenames(self, tmp_path):
+        """A file named '..hidden' or 'file..bak' is NOT traversal."""
+        result = validate_save_path(str(tmp_path / "..hidden"))
+        assert "..hidden" in result
+
+    def test_allows_single_dot(self, tmp_path):
+        """A single '.' component (current dir) is benign."""
+        target = str(tmp_path / "." / "output.txt")
+        result = validate_save_path(target)
+        assert os.path.isabs(result)
+
+    # ── Blocked prefix rejection ──────────────────────────────────────
+
+    @pytest.mark.parametrize("prefix", BLOCKED_PREFIXES)
+    def test_rejects_all_blocked_prefixes(self, prefix):
+        """Every entry in BLOCKED_PREFIXES must be rejected."""
+        dangerous_path = prefix + "evil_file.txt"
+        with pytest.raises(ValueError, match="protected system directory"):
+            validate_save_path(dangerous_path)
+
+    def test_rejects_etc_passwd(self):
+        with pytest.raises(ValueError, match="protected system directory"):
+            validate_save_path("/etc/passwd")
+
+    def test_rejects_usr_bin(self):
+        with pytest.raises(ValueError, match="protected system directory"):
+            validate_save_path("/usr/bin/python3")
+
+    def test_rejects_proc_self(self):
+        with pytest.raises(ValueError, match="protected system directory"):
+            validate_save_path("/proc/self/environ")
+
+    def test_rejects_dev_null_write(self):
+        with pytest.raises(ValueError, match="protected system directory"):
+            validate_save_path("/dev/sda1")
+
+    def test_rejects_var_spool_cron(self):
+        """The /var/spool/cron/ prefix must be blocked."""
+        with pytest.raises(ValueError, match="protected system directory"):
+            validate_save_path("/var/spool/cron/root")
+
+    def test_rejects_var_spool_at(self):
+        """The /var/spool/at/ prefix must be blocked."""
+        with pytest.raises(ValueError, match="protected system directory"):
+            validate_save_path("/var/spool/at/job.001")
+
+    # ── Trailing-slash correctness (the review comment) ───────────────
+
+    def test_blocked_prefix_trailing_slash_precision(self):
+        """Paths that merely share a common prefix but are NOT inside
+        the blocked directory should be allowed.
+
+        For example, ``/var/spool/crondata`` shares the ``/var/spool/cron``
+        prefix but is a *sibling* directory, not a child.  The trailing-
+        slash on the blocked prefix ensures this is handled correctly.
+        """
+        # This should NOT raise — it's /var/spool/crondata, not /var/spool/cron/
+        # We need to mock realpath since /var/spool/crondata won't exist
+        with patch("os.path.realpath", return_value="/var/spool/crondata/myfile"):
+            result = validate_save_path("/var/spool/crondata/myfile")
+            assert result == "/var/spool/crondata/myfile"
+
+    def test_blocked_prefix_exact_dir_match(self):
+        """The exact blocked directory itself (e.g. /var/spool/cron)
+        should also be rejected — it's the container directory."""
+        with patch("os.path.realpath", return_value="/var/spool/cron"):
+            with pytest.raises(ValueError, match="protected system directory"):
+                validate_save_path("/var/spool/cron")
+
+    def test_all_blocked_prefixes_end_with_slash(self):
+        """Invariant: every entry in BLOCKED_PREFIXES must end with '/'
+        for correct startswith matching."""
+        for prefix in BLOCKED_PREFIXES:
+            assert prefix.endswith("/"), f"BLOCKED_PREFIXES entry missing trailing slash: {prefix!r}"
+
+    # ── Custom label tests ────────────────────────────────────────────
+
+    def test_custom_label_in_empty_error(self):
+        with pytest.raises(ValueError, match="save_path must not be empty"):
+            validate_save_path("", label="save_path")
+
+    def test_custom_label_in_traversal_error(self):
+        with pytest.raises(ValueError, match="output_dir must not contain"):
+            validate_save_path("/../etc", label="output_dir")
+
+    def test_custom_label_in_blocked_error(self):
+        with pytest.raises(ValueError, match="storage_dir resolves to"):
+            validate_save_path("/etc/crontab", label="storage_dir")
+
+    # ── Symlink resolution ────────────────────────────────────────────
+
+    def test_symlink_to_blocked_dir_is_rejected(self, tmp_path):
+        """A symlink pointing into a blocked directory should be caught."""
+        link = tmp_path / "innocent_link"
+        link.symlink_to("/etc/cron.d")
+        with pytest.raises(ValueError, match="protected system directory"):
+            validate_save_path(str(link / "evil_job"))
+
+    def test_symlink_to_safe_dir_is_allowed(self, tmp_path):
+        """A symlink pointing to a safe location should pass."""
+        target_dir = tmp_path / "real_data"
+        target_dir.mkdir()
+        link = tmp_path / "link_data"
+        link.symlink_to(target_dir)
+        result = validate_save_path(str(link / "file.txt"))
+        assert str(target_dir) in result

--- a/tests/test_path_validation.py
+++ b/tests/test_path_validation.py
@@ -1,11 +1,19 @@
 """Tests for strands_robots.tools._path_validation module."""
 
 import os
+import sys
 from unittest.mock import patch
 
 import pytest
 
-from strands_robots.tools._path_validation import BLOCKED_PREFIXES, validate_save_path
+from strands_robots.tools._path_validation import (
+    BLOCKED_PREFIXES,
+    _LINUX_BLOCKED_PREFIXES,
+    _MACOS_BLOCKED_PREFIXES,
+    _WINDOWS_BLOCKED_PREFIXES,
+    _get_blocked_prefixes,
+    validate_save_path,
+)
 
 
 class TestValidateSavePath:
@@ -90,30 +98,37 @@ class TestValidateSavePath:
     def test_rejects_all_blocked_prefixes(self, prefix):
         """Every entry in BLOCKED_PREFIXES must be rejected."""
         dangerous_path = prefix + "evil_file.txt"
-        with pytest.raises(ValueError, match="protected system directory"):
-            validate_save_path(dangerous_path)
+        with patch("os.path.realpath", return_value=prefix + "evil_file.txt"):
+            with pytest.raises(ValueError, match="protected system directory"):
+                validate_save_path(dangerous_path)
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Linux-specific paths")
     def test_rejects_etc_passwd(self):
         with pytest.raises(ValueError, match="protected system directory"):
             validate_save_path("/etc/passwd")
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Linux-specific paths")
     def test_rejects_usr_bin(self):
         with pytest.raises(ValueError, match="protected system directory"):
             validate_save_path("/usr/bin/python3")
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Linux-specific paths")
     def test_rejects_proc_self(self):
         with pytest.raises(ValueError, match="protected system directory"):
             validate_save_path("/proc/self/environ")
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Linux-specific paths")
     def test_rejects_dev_null_write(self):
         with pytest.raises(ValueError, match="protected system directory"):
             validate_save_path("/dev/sda1")
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Linux-specific paths")
     def test_rejects_var_spool_cron(self):
         """The /var/spool/cron/ prefix must be blocked."""
         with pytest.raises(ValueError, match="protected system directory"):
             validate_save_path("/var/spool/cron/root")
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Linux-specific paths")
     def test_rejects_var_spool_at(self):
         """The /var/spool/at/ prefix must be blocked."""
         with pytest.raises(ValueError, match="protected system directory"):
@@ -121,6 +136,7 @@ class TestValidateSavePath:
 
     # ── Trailing-slash correctness (the review comment) ───────────────
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Linux-specific paths")
     def test_blocked_prefix_trailing_slash_precision(self):
         """Paths that merely share a common prefix but are NOT inside
         the blocked directory should be allowed.
@@ -129,12 +145,11 @@ class TestValidateSavePath:
         prefix but is a *sibling* directory, not a child.  The trailing-
         slash on the blocked prefix ensures this is handled correctly.
         """
-        # This should NOT raise — it's /var/spool/crondata, not /var/spool/cron/
-        # We need to mock realpath since /var/spool/crondata won't exist
         with patch("os.path.realpath", return_value="/var/spool/crondata/myfile"):
             result = validate_save_path("/var/spool/crondata/myfile")
             assert result == "/var/spool/crondata/myfile"
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Linux-specific paths")
     def test_blocked_prefix_exact_dir_match(self):
         """The exact blocked directory itself (e.g. /var/spool/cron)
         should also be rejected — it's the container directory."""
@@ -142,11 +157,14 @@ class TestValidateSavePath:
             with pytest.raises(ValueError, match="protected system directory"):
                 validate_save_path("/var/spool/cron")
 
-    def test_all_blocked_prefixes_end_with_slash(self):
-        """Invariant: every entry in BLOCKED_PREFIXES must end with '/'
-        for correct startswith matching."""
+    def test_all_blocked_prefixes_end_with_separator(self):
+        """Invariant: every entry in BLOCKED_PREFIXES must end with the
+        appropriate path separator for correct startswith matching."""
+        expected_sep = "\\" if sys.platform == "win32" else "/"
         for prefix in BLOCKED_PREFIXES:
-            assert prefix.endswith("/"), f"BLOCKED_PREFIXES entry missing trailing slash: {prefix!r}"
+            assert prefix.endswith(expected_sep), (
+                f"BLOCKED_PREFIXES entry missing trailing separator: {prefix!r}"
+            )
 
     # ── Custom label tests ────────────────────────────────────────────
 
@@ -158,12 +176,14 @@ class TestValidateSavePath:
         with pytest.raises(ValueError, match="output_dir must not contain"):
             validate_save_path("/../etc", label="output_dir")
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Linux-specific paths")
     def test_custom_label_in_blocked_error(self):
         with pytest.raises(ValueError, match="storage_dir resolves to"):
             validate_save_path("/etc/crontab", label="storage_dir")
 
     # ── Symlink resolution ────────────────────────────────────────────
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Symlinks differ on Windows")
     def test_symlink_to_blocked_dir_is_rejected(self, tmp_path):
         """A symlink pointing into a blocked directory should be caught."""
         link = tmp_path / "innocent_link"
@@ -179,3 +199,47 @@ class TestValidateSavePath:
         link.symlink_to(target_dir)
         result = validate_save_path(str(link / "file.txt"))
         assert str(target_dir) in result
+
+
+class TestCrossPlatformPrefixes:
+    """Tests for cross-platform blocked prefix selection."""
+
+    def test_linux_prefixes_returned_on_linux(self):
+        """On Linux, only Linux prefixes should be active."""
+        with patch.object(sys, "platform", "linux"):
+            prefixes = _get_blocked_prefixes()
+            assert "/etc/" in prefixes
+            assert "/usr/" in prefixes
+            # No Windows or macOS-specific prefixes
+            for p in prefixes:
+                assert not p.startswith("C:\\")
+
+    def test_darwin_includes_macos_extras(self):
+        """On macOS, both Linux and macOS prefixes should be active."""
+        with patch.object(sys, "platform", "darwin"):
+            prefixes = _get_blocked_prefixes()
+            assert "/etc/" in prefixes  # Linux shared
+            assert "/System/" in prefixes  # macOS specific
+            assert "/Library/LaunchDaemons/" in prefixes
+
+    def test_windows_prefixes_returned_on_win32(self):
+        """On Windows, Windows-specific prefixes should be active."""
+        with patch.object(sys, "platform", "win32"):
+            prefixes = _get_blocked_prefixes()
+            assert "C:\\Windows\\" in prefixes
+            assert "C:\\Program Files\\" in prefixes
+            # No Linux prefixes
+            for p in prefixes:
+                assert not p.startswith("/")
+
+    def test_all_linux_prefixes_end_with_slash(self):
+        for prefix in _LINUX_BLOCKED_PREFIXES:
+            assert prefix.endswith("/"), f"Missing trailing /: {prefix!r}"
+
+    def test_all_macos_prefixes_end_with_slash(self):
+        for prefix in _MACOS_BLOCKED_PREFIXES:
+            assert prefix.endswith("/"), f"Missing trailing /: {prefix!r}"
+
+    def test_all_windows_prefixes_end_with_backslash(self):
+        for prefix in _WINDOWS_BLOCKED_PREFIXES:
+            assert prefix.endswith("\\"), f"Missing trailing \\: {prefix!r}"


### PR DESCRIPTION
## Summary

Adds a shared path validation module and applies it to all tools that accept user-supplied paths for file I/O operations (camera captures, calibration backups/restores, pose storage).

## Changes

### New module: `strands_robots/tools/_path_validation.py`

`validate_save_path(path, label)` performs three checks:

1. **Null bytes / malformed input** — rejects `\x00`
2. **Path traversal** — rejects `..` components (e.g. `../../etc/cron.d/evil`)
3. **Protected directories** — after `os.path.realpath()` resolution, blocks writes into `/etc/`, `/usr/`, `/bin/`, `/sbin/`, `/boot/`, `/dev/`, `/proc/`, `/sys/`, `/var/spool/cron`, `/var/spool/at`

Returns the resolved absolute path on success, raises `ValueError` on failure.

### Updated tools

| Tool | Where validated |
|------|----------------|
| `lerobot_camera` | `save_path` in capture, batch capture, video recording, config save |
| `lerobot_calibrate` | `output_dir` (backup), `backup_dir` (restore) |
| `pose_tool` | `storage_dir` in `PoseManager.__init__` |

## Motivation

These tools are called by AI agents which construct file paths from conversation context. Without validation, a crafted path like `../../etc/cron.d/evil` could write to arbitrary locations. The validation module provides consistent defense-in-depth across all file-writing tools.

## Design decisions

- **Shared module** (`_path_validation.py`) rather than inline checks — single source of truth, easy to extend the blocked-prefix list.
- **Underscore prefix** — signals this is an internal helper, not a public tool.
- **`os.path.realpath`** — resolves symlinks to catch symlink-based bypasses.
- **Allowlist-by-exclusion** — we block known dangerous prefixes rather than requiring a specific allowed directory, keeping the tools flexible for different deployment environments.