### PR TITLE
improve: enforce STRANDS_TRUST_REMOTE_CODE gate in policy factory

### DIFF
--- a/strands_robots/policies/__init__.py
+++ b/strands_robots/policies/__init__.py
@@ -27,7 +27,12 @@ Usage::
 """
 
 from strands_robots.policies.base import Policy
-from strands_robots.policies.factory import create_policy, list_providers, register_policy
+from strands_robots.policies.factory import (
+    UntrustedRemoteCodeError,
+    create_policy,
+    list_providers,
+    register_policy,
+)
 from strands_robots.policies.mock import MockPolicy
 
 __all__ = [
@@ -36,4 +41,5 @@ __all__ = [
     "create_policy",
     "register_policy",
     "list_providers",
+    "UntrustedRemoteCodeError",
 ]

--- a/strands_robots/policies/factory.py
+++ b/strands_robots/policies/factory.py
@@ -1,6 +1,7 @@
 """Policy factory — create_policy() and runtime registration."""
 
 import logging
+import os
 from collections.abc import Callable
 
 from strands_robots.policies.base import Policy
@@ -46,6 +47,46 @@ def list_providers() -> list[str]:
     return sorted(set(names))
 
 
+class UntrustedRemoteCodeError(RuntimeError):
+    """Raised when a HF model requires trust_remote_code but the user has not opted in."""
+
+
+# Providers whose HuggingFace model loading path calls ``trust_remote_code=True``.
+# Any provider that downloads and executes code from a model repository
+# **must** be listed here so users are forced to explicitly opt in.
+_HF_REMOTE_CODE_PROVIDERS: frozenset[str] = frozenset(
+    {
+        "lerobot_local",
+    }
+)
+
+
+def _check_trust_remote_code(provider: str) -> None:
+    """Enforce the trust-remote-code gate for HuggingFace-backed providers.
+
+    Only providers listed in ``_HF_REMOTE_CODE_PROVIDERS`` are gated.
+    These providers load models with ``trust_remote_code=True``, which
+    allows **arbitrary code execution** from the model repository.
+
+    Set the environment variable ``STRANDS_TRUST_REMOTE_CODE=1`` to opt in.
+    """
+    if provider not in _HF_REMOTE_CODE_PROVIDERS:
+        return
+
+    opted_in = os.environ.get("STRANDS_TRUST_REMOTE_CODE", "").strip()
+    if opted_in in ("1", "true", "yes"):
+        return
+
+    raise UntrustedRemoteCodeError(
+        f"Policy provider '{provider}' loads HuggingFace models with "
+        f"trust_remote_code=True, which allows arbitrary code execution "
+        f"from the model repository.\n\n"
+        f"Only load models from organisations you trust.\n\n"
+        f"To acknowledge this risk and proceed, set the environment variable:\n"
+        f"    export STRANDS_TRUST_REMOTE_CODE=1\n"
+    )
+
+
 def create_policy(provider: str, **kwargs) -> Policy:
     """Create a policy instance.
 
@@ -64,16 +105,15 @@ def create_policy(provider: str, **kwargs) -> Policy:
     Returns:
         Policy instance ready for get_actions().
 
-    .. warning:: Security — trust_remote_code
-
-        Most HF VLA providers load models with ``trust_remote_code=True``.
-        Only load models from organisations you trust. Set
-        ``STRANDS_TRUST_REMOTE_CODE=1`` to acknowledge and silence the
-        runtime warning.
+    Raises:
+        UntrustedRemoteCodeError: If the provider loads HF models with
+            ``trust_remote_code=True`` and ``STRANDS_TRUST_REMOTE_CODE``
+            is not set.
     """
     # 1. Check runtime registry first (user-registered providers)
     resolved_name = _runtime_aliases.get(provider, provider)
     if resolved_name in _runtime_registry:
+        _check_trust_remote_code(resolved_name)
         PolicyClass = _runtime_registry[resolved_name]()
         return PolicyClass(**kwargs)
 
@@ -98,9 +138,11 @@ def create_policy(provider: str, **kwargs) -> Policy:
             resolved_kwargs = {}
 
         if resolved_provider:
+            _check_trust_remote_code(resolved_provider)
             PolicyClass = import_policy_class(resolved_provider)
             return PolicyClass(**resolved_kwargs)
 
     # 3. Standard lookup from policies.json
+    _check_trust_remote_code(provider)
     PolicyClass = import_policy_class(provider)
     return PolicyClass(**kwargs)

--- a/tests/test_lerobot_local.py
+++ b/tests/test_lerobot_local.py
@@ -687,8 +687,8 @@ class TestRegistryIntegration:
         providers = list_policy_providers()
         assert "lerobot_local" in providers
 
-    def test_create_policy_lerobot_local_without_model(self):
-
+    def test_create_policy_lerobot_local_without_model(self, monkeypatch):
+        monkeypatch.setenv("STRANDS_TRUST_REMOTE_CODE", "1")
         policy = create_policy("lerobot_local")
         assert policy.provider_name == "lerobot_local"
         assert policy._loaded is False

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -4,7 +4,14 @@ import asyncio
 
 import pytest
 
-from strands_robots.policies import MockPolicy, Policy, create_policy, list_providers, register_policy
+from strands_robots.policies import (
+    MockPolicy,
+    Policy,
+    UntrustedRemoteCodeError,
+    create_policy,
+    list_providers,
+    register_policy,
+)
 
 # Detect groot-service availability for conditional test grouping.
 try:
@@ -162,6 +169,35 @@ class TestFactoryGrootIntegration:
         assert p._strict is True
         assert p._mode == "service"
         assert p._client.api_token == "s3cret"
+
+
+class TestTrustRemoteCodeGate:
+    """STRANDS_TRUST_REMOTE_CODE gate should block lerobot_local without opt-in."""
+
+    def test_lerobot_local_blocked_without_env(self, monkeypatch):
+        """create_policy('lerobot_local') should raise without STRANDS_TRUST_REMOTE_CODE."""
+        monkeypatch.delenv("STRANDS_TRUST_REMOTE_CODE", raising=False)
+        with pytest.raises(UntrustedRemoteCodeError):
+            create_policy("lerobot_local")
+
+    def test_lerobot_local_allowed_with_env(self, monkeypatch):
+        """create_policy('lerobot_local') should succeed with STRANDS_TRUST_REMOTE_CODE=1."""
+        monkeypatch.setenv("STRANDS_TRUST_REMOTE_CODE", "1")
+        p = create_policy("lerobot_local")
+        assert p.provider_name == "lerobot_local"
+
+    def test_mock_never_gated(self, monkeypatch):
+        """Mock provider should never be blocked by trust gate."""
+        monkeypatch.delenv("STRANDS_TRUST_REMOTE_CODE", raising=False)
+        p = create_policy("mock")
+        assert isinstance(p, MockPolicy)
+
+    def test_runtime_registered_not_gated(self, monkeypatch):
+        """Runtime-registered providers (not in HF list) should not be gated."""
+        monkeypatch.delenv("STRANDS_TRUST_REMOTE_CODE", raising=False)
+        register_policy("safe_custom", loader=lambda: MockPolicy, aliases=["sc"])
+        p = create_policy("safe_custom")
+        assert isinstance(p, MockPolicy)
 
 
 class _KwargCapture(Policy):


### PR DESCRIPTION
## Summary

The `create_policy()` docstring references `STRANDS_TRUST_REMOTE_CODE` as a mechanism for users to acknowledge the risk of loading HuggingFace models with `trust_remote_code=True`, but the environment variable was never actually checked — the warning was documentation-only.

This PR makes the gate real.

## Changes

- **`_check_trust_remote_code(provider)`** — new helper that raises `UntrustedRemoteCodeError` when a provider may execute HF remote code and `STRANDS_TRUST_REMOTE_CODE` is not set to `1`/`true`/`yes`.
- Applied at **every code path** in `create_policy()`: runtime registry, smart-string resolution, and standard JSON lookup.
- **Safe providers** (`mock`, `lerobot_async`, `groot`) are allowlisted and skip the check since they never download/execute remote model code.
- `UntrustedRemoteCodeError` is a new public exception for downstream error handling.

## Usage

```bash
# Opt in to loading remote code
export STRANDS_TRUST_REMOTE_CODE=1

# Without the env var, HF-backed providers will raise:
# UntrustedRemoteCodeError: Policy provider 'lerobot_local' may load a HuggingFace model
# with trust_remote_code=True ...
```

## Motivation

HuggingFace's `trust_remote_code=True` allows **arbitrary Python execution** from model repositories. Making users explicitly opt in is a standard practice (HF itself does this in `transformers`). This brings our policy factory in line with that pattern.