### PR TITLE
fix: address @awsarron PR #85 unresolved review feedback (6 items)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,11 @@ groot-service = [
 lerobot = [
     "lerobot>=0.5.0,<0.6.0",
 ]
-sim-mujoco = [
+sim = [
     "robot_descriptions>=1.11.0,<2.0.0",
+]
+sim-mujoco = [
+    "strands-robots[sim]",
     "mujoco>=3.2.0,<4.0.0",
     "imageio>=2.28.0,<3.0.0",
     "imageio-ffmpeg>=0.4.0,<1.0.0",

--- a/strands_robots/simulation/__init__.py
+++ b/strands_robots/simulation/__init__.py
@@ -57,6 +57,7 @@ from strands_robots.simulation.factory import (
     register_backend,
 )
 from strands_robots.simulation.model_registry import (
+    count_sim_robots,
     list_available_models,
     list_registered_urdfs,
     register_urdf,
@@ -74,8 +75,9 @@ from strands_robots.simulation.models import (
 
 # Heavy imports (lazy - need strands SDK + mujoco)
 _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
-    "Simulation": ("strands_robots.simulation.mujoco.simulation", "Simulation"),
-    "MuJoCoSimulation": ("strands_robots.simulation.mujoco.simulation", "Simulation"),
+    "Simulation": ("strands_robots.simulation.mujoco.simulation", "MuJoCoSimEngine"),
+    "MuJoCoSimulation": ("strands_robots.simulation.mujoco.simulation", "MuJoCoSimEngine"),
+    "MuJoCoSimEngine": ("strands_robots.simulation.mujoco.simulation", "MuJoCoSimEngine"),
     "SpecBuilder": ("strands_robots.simulation.mujoco.spec_builder", "SpecBuilder"),
     "_configure_gl_backend": ("strands_robots.simulation.mujoco.backend", "_configure_gl_backend"),
     "_ensure_mujoco": ("strands_robots.simulation.mujoco.backend", "_ensure_mujoco"),
@@ -92,6 +94,7 @@ __all__ = [
     "register_backend",
     # Default backend alias
     "Simulation",
+    "MuJoCoSimEngine",
     "MuJoCoSimulation",
     # Shared dataclasses
     "SimStatus",
@@ -107,6 +110,7 @@ __all__ = [
     "resolve_model",
     "resolve_urdf",
     "list_registered_urdfs",
+    "count_sim_robots",
     "list_available_models",
 ]
 

--- a/strands_robots/simulation/factory.py
+++ b/strands_robots/simulation/factory.py
@@ -39,7 +39,7 @@ logger = logging.getLogger(__name__)
 _BUILTIN_BACKENDS: dict[str, tuple[str, str]] = {
     "mujoco": (
         "strands_robots.simulation.mujoco.simulation",
-        "Simulation",
+        "MuJoCoSimEngine",
     ),
     # Future:
     # "isaac": ("strands_robots.simulation.isaac.simulation", "IsaacSimulation"),

--- a/strands_robots/simulation/model_registry.py
+++ b/strands_robots/simulation/model_registry.py
@@ -140,3 +140,20 @@ def list_available_models() -> str:
         status = "[OK]" if resolved else "[MISSING]"
         lines.append(f"{status} {name}: {path}")
     return "\n".join(lines)
+
+
+def count_sim_robots() -> int:
+    """Count robot models available for simulation.
+
+    Queries the robot registry for models with ``mode="sim"``.
+    This is reusable across any simulation backend (MuJoCo, Isaac, Newton).
+
+    Returns:
+        Number of available simulation-compatible robot models.
+
+    Raises:
+        ImportError: If the registry module is not installed.
+    """
+    from strands_robots.registry import list_robots as _registry_list_robots
+
+    return len(_registry_list_robots(mode="sim"))

--- a/strands_robots/simulation/mujoco/__init__.py
+++ b/strands_robots/simulation/mujoco/__init__.py
@@ -6,27 +6,30 @@ domain randomization, and LeRobotDataset recording.
 
 Usage::
 
-    from strands_robots.simulation.mujoco import MuJoCoSimulation
+    from strands_robots.simulation.mujoco import MuJoCoSimEngine
 
-    sim = MuJoCoSimulation(tool_name="my_sim")
+    sim = MuJoCoSimEngine(tool_name="mujoco_simulation")
     sim.create_world()
     sim.add_robot("so100", data_config="so100")
     sim.run_policy("so100", policy_provider="mock", instruction="wave")
 
 Or via the top-level alias::
 
-    from strands_robots.simulation import Simulation  # → MuJoCoSimulation
+    from strands_robots.simulation import MuJoCoSimEngine
 """
 
 __all__ = [
+    "MuJoCoSimEngine",
+    # Backward-compatible alias
     "MuJoCoSimulation",
 ]
 
 
 def __getattr__(name: str) -> "type":
-    if name == "MuJoCoSimulation":
-        from strands_robots.simulation.mujoco.simulation import Simulation as _Sim
+    if name in ("MuJoCoSimEngine", "MuJoCoSimulation"):
+        from strands_robots.simulation.mujoco.simulation import MuJoCoSimEngine as _Cls
 
-        globals()["MuJoCoSimulation"] = _Sim
-        return _Sim
+        globals()["MuJoCoSimEngine"] = _Cls
+        globals()["MuJoCoSimulation"] = _Cls
+        return _Cls
     raise AttributeError(f"module 'strands_robots.simulation.mujoco' has no attribute {name!r}")

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -2,7 +2,7 @@
 
 Architecture notes (honest version, see GH #118)
 
-The ``Simulation`` class uses multiple-inheritance to compose four mixins
+The ``MuJoCoSimEngine`` class uses multiple-inheritance to compose four mixins
 (``PhysicsMixin``, ``RenderingMixin``, ``RecordingMixin``, ``RandomizationMixin``)
 on top of the ``SimEngine`` ABC and the Strands ``AgentTool`` base. The
 split keeps each file navigable (physics.py ~1150 lines, rendering.py ~730,
@@ -97,7 +97,7 @@ with open(_TOOL_SPEC_PATH) as _f:
     _TOOL_SPEC_SCHEMA: dict[str, Any] = json.load(_f)
 
 
-class Simulation(
+class MuJoCoSimEngine(
     PhysicsMixin,
     RenderingMixin,
     RecordingMixin,
@@ -121,7 +121,7 @@ class Simulation(
 
     def __init__(
         self,
-        tool_name: str = "sim",
+        tool_name: str = "mujoco_simulation",
         default_timestep: float = 0.002,
         default_width: int = 640,
         default_height: int = 480,
@@ -198,7 +198,7 @@ class Simulation(
         # Fail fast: verify MuJoCo is importable at construction time
         # so consumers catch missing-dependency errors immediately.
         self._mj = _ensure_mujoco()
-        logger.info("🎮 Simulation tool '%s' initialized", tool_name)
+        logger.info("MuJoCo simulation tool '%s' initialized", tool_name)
 
     # Public Properties — read-only introspection.
     # WARNING: callers MUST NOT mutate the returned objects without holding
@@ -278,11 +278,17 @@ class Simulation(
     # World Management
 
     def _cheap_robot_count(self) -> int:
-        try:
-            from strands_robots.registry import list_robots as _registry_list_robots
+        """Count available sim-compatible robot models.
 
-            return len(_registry_list_robots(mode="sim"))
+        Delegates to :func:`~strands_robots.simulation.model_registry.count_sim_robots`.
+        Logs a warning and returns 0 when the registry is not installed.
+        """
+        from strands_robots.simulation.model_registry import count_sim_robots
+
+        try:
+            return count_sim_robots()
         except ImportError:
+            logger.warning("Robot registry not available - install strands-robots[registry] for model discovery")
             return 0
 
     def create_world(
@@ -2127,3 +2133,7 @@ class Simulation(
             self.cleanup()
         except Exception:
             pass
+
+
+# Backward-compatible alias — callers using the old internal name still work.
+Simulation = MuJoCoSimEngine

--- a/tests/simulation/test_module_api.py
+++ b/tests/simulation/test_module_api.py
@@ -29,3 +29,10 @@ def test_mujoco_getattr_raises_on_unknown():
 
     with pytest.raises(AttributeError, match="has no attribute 'NotARealClass'"):
         _ = mod.NotARealClass
+
+
+def test_mujoco_sim_engine_alias():
+    from strands_robots.simulation.mujoco import MuJoCoSimEngine
+    from strands_robots.simulation.mujoco.simulation import MuJoCoSimEngine as _Direct
+
+    assert MuJoCoSimEngine is _Direct


### PR DESCRIPTION
## Summary

Resolves all 6 unresolved review threads from @awsarron on PR #85 (2026-05-04).

## Changes

### 1. Rename `Simulation` → `MuJoCoSimEngine` (simulation.py:100)
- Class is now `MuJoCoSimEngine` for naming consistency with future backends (Isaac Sim, Newton, etc.)
- `Simulation` kept as backward-compatible alias at module bottom
- `MuJoCoSimulation` alias preserved in `__init__.py`

### 2. Move `robot_descriptions` to `sim` extras group (pyproject.toml:51)
- Created `sim` base extras group with `robot_descriptions`
- `sim-mujoco` now depends on `strands-robots[sim]`
- Future `sim-newton`/`sim-isaac` can include `strands-robots[sim]` without duplicating deps

### 3. Tool name → `mujoco_simulation` (simulation.py:124)
- Default `tool_name` changed from `"sim"` to `"mujoco_simulation"`
- Ensures unique tool names when multiple simulation backends are loaded

### 4. Remove emojis from logs (simulation.py:201)
- Removed 🎮 emoji from `logger.info` call
- Emojis in LLM-facing content text preserved (they aid agent comprehension, not log parsing)

### 5. Move `_cheap_robot_count` outside mujoco (simulation.py:280)
- Added `count_sim_robots()` to `model_registry.py` (reusable across backends)
- `_cheap_robot_count` method delegates to the shared function
- Exported from `strands_robots.simulation` package

### 6. `return 0` on exception may hide issues (simulation.py:286)
- `count_sim_robots()` now lets `ImportError` propagate (caller decides)
- `_cheap_robot_count` wrapper logs a warning when registry is unavailable
- Consumers can now diagnose missing registry dependency instead of silently getting 0

## Backward Compatibility

- `from strands_robots.simulation.mujoco.simulation import Simulation` still works
- `from strands_robots.simulation.mujoco import MuJoCoSimulation` still works
- `from strands_robots.simulation import Simulation` still works
- New canonical import: `from strands_robots.simulation import MuJoCoSimEngine`

## Testing

- `ruff check` passes
- `ruff format --check` passes
- Added `test_mujoco_sim_engine_alias` test
- Existing `test_mujoco_module_alias_is_simulation_class` still passes via backward-compat alias