### PR TITLE
fix(libero/bddl): case-insensitive predicate + connective parsing

### DIFF
--- a/strands_robots/benchmarks/libero/bddl_parser.py
+++ b/strands_robots/benchmarks/libero/bddl_parser.py
@@ -335,19 +335,26 @@ def _compile_ast(expr: Any) -> Node:
     head = expr[0]
     if not isinstance(head, str):
         raise BDDLParseError(f"expected symbol head, got {head!r}")
-    if head == "and":
+    # PDDL grammar is case-insensitive for predicates and connectives. Real
+    # LIBERO BDDL files mix cases: every spatial / object / goal task uses
+    # ``(And (On ...))``  with capital initials in the goal, even though
+    # ``PREDICATE_VOCABULARY`` and the connective branches below were
+    # written in lowercase. Normalise once at the head; keep the original
+    # ``head`` for error messages so debugging shows the source casing.
+    head_norm = head.lower()
+    if head_norm == "and":
         if len(expr) == 1:
             raise BDDLParseError("(and ...) requires at least one clause")
         return And(tuple(_compile_ast(c) for c in expr[1:]))
-    if head == "or":
+    if head_norm == "or":
         if len(expr) == 1:
             raise BDDLParseError("(or ...) requires at least one clause")
         return Or(tuple(_compile_ast(c) for c in expr[1:]))
-    if head == "not":
+    if head_norm == "not":
         if len(expr) != 2:
             raise BDDLParseError(f"(not ...) expects 1 clause, got {len(expr) - 1}")
         return Not(_compile_ast(expr[1]))
-    if head not in PREDICATE_VOCABULARY:
+    if head_norm not in PREDICATE_VOCABULARY:
         valid = sorted(PREDICATE_VOCABULARY)
         raise BDDLParseError(f"unknown predicate {head!r}. Supported: {valid}")
     # Leaf predicate - args are the remainder, must all be strings.
@@ -357,9 +364,11 @@ def _compile_ast(expr: Any) -> Node:
             raise BDDLParseError(f"predicate {head!r}: expected string args, got {a!r}")
         args.append(a)
     # Validate arity by attempting the kwargs conversion now (fail-fast).
-    _, adapter = PREDICATE_VOCABULARY[head]
+    _, adapter = PREDICATE_VOCABULARY[head_norm]
     adapter(args)  # raises BDDLParseError on bad arity
-    return Pred(name=head, args=tuple(args))
+    # Store the normalised name so ``compile_goal`` can look it up in
+    # ``PREDICATE_VOCABULARY`` (whose keys are all lowercase).
+    return Pred(name=head_norm, args=tuple(args))
 
 
 # Compile AST → callable

--- a/tests/benchmarks/libero/test_bddl_parser.py
+++ b/tests/benchmarks/libero/test_bddl_parser.py
@@ -369,3 +369,88 @@ class TestParseBDDLFile:
     def test_not_a_file(self, tmp_path):
         with pytest.raises(ValueError):
             parse_bddl_file(tmp_path)
+
+
+# Case-insensitivity (PDDL grammar is case-insensitive)
+#
+# Real LIBERO BDDL files mix lowercase predicate vocabulary keys (`on`,
+# `grasped`, …) with capital-initial spelling in the source files
+# (`(And (On cube_1 plate_1))`). The parser needs to accept both forms;
+# this section pins the contract.
+
+
+class TestCaseInsensitivity:
+    def test_capital_and_connective(self):
+        """``(And ...)`` parses identically to ``(and ...)``."""
+        text = """
+            (define (problem p)
+              (:goal (And (on cube_1 plate_1) (upright cube_1))))
+        """
+        problem = parse_bddl(text)
+        assert isinstance(problem.goal, And)
+        assert len(problem.goal.clauses) == 2
+
+    def test_capital_or_and_not_connectives(self):
+        text = """
+            (define (problem p)
+              (:goal (Or (grasped cube_1) (Not (on cube_1 table_1)))))
+        """
+        problem = parse_bddl(text)
+        assert isinstance(problem.goal, Or)
+        assert isinstance(problem.goal.clauses[1], Not)
+
+    def test_capital_predicate_normalises_to_lowercase(self):
+        """Leaf predicate names are normalised so ``compile_goal`` can look
+        them up against the lowercase ``PREDICATE_VOCABULARY``."""
+        text = """
+            (define (problem p)
+              (:goal (On cube_1 plate_1)))
+        """
+        problem = parse_bddl(text)
+        assert isinstance(problem.goal, Pred)
+        assert problem.goal.name == "on"  # normalised, not "On"
+        assert problem.goal.args == ("cube_1", "plate_1")
+
+    def test_real_libero_spatial_shape_round_trips(self):
+        """End-to-end shape mirroring real LIBERO ``libero_spatial`` BDDLs:
+        capital connectives, capital predicate, typed objects, init clauses.
+        Every spatial / object / goal task in upstream LIBERO follows this
+        layout, so this is the regression that gates ``load_libero_suite``
+        actually registering tasks instead of skipping all of them."""
+        text = """
+            (define (problem libero_pick_bowl)
+              (:domain kitchen)
+              (:language "pick up the black bowl and place it on the plate")
+              (:objects akita_black_bowl_1 plate_1 - object)
+              (:init
+                (On akita_black_bowl_1 main_table_region)
+                (On plate_1 main_table_plate_region))
+              (:goal
+                (And (On akita_black_bowl_1 plate_1))))
+        """
+        problem = parse_bddl(text)
+        assert problem.name == "libero_pick_bowl"
+        assert problem.language == "pick up the black bowl and place it on the plate"
+        assert isinstance(problem.goal, And)
+        assert len(problem.goal.clauses) == 1
+        inner = problem.goal.clauses[0]
+        assert isinstance(inner, Pred)
+        assert inner.name == "on"
+        assert inner.args == ("akita_black_bowl_1", "plate_1")
+
+    def test_unknown_predicate_error_preserves_source_casing(self):
+        """When a predicate is genuinely unknown (not just mis-cased), the
+        error message should show the original casing so users see exactly
+        what they wrote in the BDDL file."""
+        with pytest.raises(BDDLParseError, match="'NotAPredicate'"):
+            parse_bddl("(define (problem p) (:goal (NotAPredicate cube_1)))")
+
+    def test_compile_goal_works_after_capital_parse(self):
+        """A capital-cased BDDL should compile to a working goal callable."""
+        text = """
+            (define (problem p)
+              (:goal (Grasped cube_1)))
+        """
+        problem = parse_bddl(text)
+        callable_ = compile_goal(problem.goal)
+        assert callable(callable_)


### PR DESCRIPTION
## Summary

PDDL grammar is case-insensitive but `_compile_ast` in `bddl_parser.py` was hard-coding lowercase comparisons:

```python
if head == "and": ...
if head not in PREDICATE_VOCABULARY: ...
```

Real LIBERO BDDL files mix cases — every spatial / object / goal / 10 / 90 task ships with capital-initial connectives and predicates in its goal clause:

```
(:goal (And (On akita_black_bowl_1 plate_1)))
```

So at registration time `_compile_ast` rejects `'And'` and `'On'` as unknown predicates, every task gets skipped, and `load_libero_suite(...)` returns an empty dict — meaning out-of-box LIBERO eval is currently impossible despite [PR #130](https://github.com/strands-labs/robots/pull/130) having shipped the adapter and `load_libero_suite`.

## Fix

Lowercase `head` once at the top of `_compile_ast`, use the normalised form for connective branches *and* `PREDICATE_VOCABULARY` lookup, and store the normalised name on the resulting `Pred` so `compile_goal` can look it up against the (lowercase) vocabulary without further casing logic. The original `head` is preserved for error messages so genuinely-unknown predicates still echo the user's source casing in `BDDLParseError`.

Three lines of real change in `_compile_ast`; the rest is a docstring explaining the contract.

## Impact on `load_libero_suite`

| Suite | Before | After |
|---|---:|---:|
| `libero_spatial` | 0 tasks | **10 tasks** |
| `libero_10` | 0 tasks | **2 tasks** |
| `libero_90` | 0 tasks | **35 tasks** |
| `libero_goal` | 0 tasks | **8 tasks** |
| `libero_object` | 0 tasks | 0 tasks ← unrelated gap, see below |

`libero_object` still registers 0 tasks after this fix — every task in that suite uses an `In` predicate that isn't in `PREDICATE_VOCABULARY` at all. That's a separate scope gap (the predicate vocabulary needs `inside`'s shape extended, or `in` aliased to `inside`), not a casing issue, so it's intentionally out of scope here. Happy to file as a follow-up issue.

The remaining `libero_10`, `libero_90`, `libero_goal` skip warnings on this branch are also for the missing `In` predicate — same root cause, same follow-up.

## Tests

Adds `TestCaseInsensitivity` (6 cases) to `tests/benchmarks/libero/test_bddl_parser.py`:

- `test_capital_and_connective` — `(And ...)` parses identically to `(and ...)`
- `test_capital_or_and_not_connectives` — same for `Or` / `Not`
- `test_capital_predicate_normalises_to_lowercase` — leaf `(On a b)` normalises to `Pred(name="on", ...)` so `compile_goal` works
- `test_real_libero_spatial_shape_round_trips` — full round-trip on a hand-written BDDL that mirrors real LIBERO `libero_spatial` files (capital connective + capital leaf + typed objects + init clauses)
- `test_unknown_predicate_error_preserves_source_casing` — genuinely-unknown predicates still echo the user's casing in the error message
- `test_compile_goal_works_after_capital_parse` — end-to-end compile path

Pre-existing tests untouched.

## Verification

```
pytest tests/benchmarks/libero/test_bddl_parser.py -v
44 passed   (38 existing + 6 new)

pytest tests/benchmarks tests/simulation
735 passed, 31 skipped
```

The 4 remaining failures (`test_render_all_returns_every_camera`, `test_start_stop_cameras_recording_writes_one_mp4_per_camera`, `test_run_policy_video_writes_mp4`, `test_run_policy_reuses_policy_object`) are pre-existing X11 / GLFW display issues on a headless machine, unrelated to the parser. They reproduce on `main` without this patch.

End-to-end LIBERO `evaluate_benchmark` against a MuJoCo `Simulation` now actually runs:

```
$ python examples/libero_mujoco.py   # downstream R5 example
benchmark_name=libero-spatial-pick_up_the_black_bowl_between_the_plate_and_the_ramekin_and_place_it_on_the_plate
success_rate=0.00  wall_time=0.8s
```

(Mock policy can't satisfy real goals, so success_rate=0 is expected.)

## Why now

This unblocks [`strands-labs/robots-sim` R5 / #12](https://github.com/strands-labs/robots-sim/issues/12) — the LIBERO-on-MuJoCo example needed for that issue can't satisfy its DoD ("runs end-to-end") without this fix landing first. Filing as a small focused PR rather than rolling it into R5 because it's actually upstream's bug.

## Non-goals

- Adding the `In` predicate to `PREDICATE_VOCABULARY` (separate work, will file as follow-up if you'd like).
- Touching `parse_bddl`'s section-marker handling (`:goal`, `:init`, etc.) — those are lowercase in every real BDDL file I've seen and the existing case-sensitive handling is correct there.
- Anything in `LiberoAdapter` itself — the adapter is correct; only the parser was rejecting valid input.

## References

- Downstream tracking: [`strands-labs/robots-sim#12`](https://github.com/strands-labs/robots-sim/issues/12) (R5)
- Adapter PR that originally shipped this code: #130 / #110