### PR TITLE
fix(groot): N1.7 service observation wire format (B, T, ...) shape + float32 state (#148-F2)

### DIFF
--- a/strands_robots/policies/groot/policy.py
+++ b/strands_robots/policies/groot/policy.py
@@ -660,23 +660,68 @@ class Gr00tPolicy(Policy):
         return self._unpack_service_actions(action_chunk)
 
     def _build_service_observation(self, robot_obs: dict[str, Any], instruction: str) -> dict:
-        """Build flat-key observation for legacy service servers."""
+        """Build flat-key observation for legacy service servers.
+
+        Wire-format dimensions differ across server versions:
+
+        * **N1.5 / N1.6** (default): video tensors are ``(B, H, W, C)`` and
+          state tensors are ``(B, D)``. Single observation step per call,
+          so leading ``B=1`` is sufficient.
+        * **N1.7** (``self._groot_version == "n1.7"``): the
+          ``gr00t.eval.run_gr00t_server`` entrypoint adds an explicit time
+          axis, so video must be ``(B, T, H, W, C)`` and state must be
+          ``(B, T, D)`` with ``T=1`` for one observation step. State
+          tensors must additionally be ``np.float32`` (the server rejects
+          ``float64``).
+
+        Language values stay a ``list[str]`` of length ``B`` regardless of
+        protocol version - the server matches it against the batch axis,
+        not a time axis.
+
+        Versioning is opt-in via the ``groot_version=`` constructor kwarg
+        (or auto-detected from the *client*-side ``gr00t`` import). Service
+        mode cannot introspect the remote server's version, so users
+        targeting an N1.7 server must pass ``groot_version="n1.7"``
+        explicitly when constructing the policy.
+        """
         obs: dict = {}
+        # Track which keys are video vs. state vs. other (language) so the
+        # newaxis-fanout below stays type-safe per category.
+        video_keys: list[str] = []
+        state_keys: list[str] = []
+
         for vk in self.data_config.video_keys:
             bare = vk.removeprefix("video.")
             if bare in robot_obs:
                 obs[vk] = robot_obs[bare]
+                video_keys.append(vk)
         for sk in self.data_config.state_keys:
             bare = sk.removeprefix("state.")
             if bare in robot_obs:
-                obs[sk] = np.asarray(robot_obs[bare], dtype=np.float32)
+                arr = np.asarray(robot_obs[bare], dtype=np.float32)
+                # Scalars (joint readings, gripper pose components, …)
+                # arrive as 0-D arrays. Promote to (D=1,) so the newaxis
+                # loop below produces the canonical (B, [T,] D) shape
+                # rather than (B, [T,]) that breaks the n1.7 server.
+                if arr.ndim == 0:
+                    arr = arr[np.newaxis]
+                obs[sk] = arr
+                state_keys.append(sk)
         if self.data_config.language_keys:
             obs[self.data_config.language_keys[0]] = instruction
-        for k in obs:
-            if isinstance(obs[k], np.ndarray):
-                obs[k] = obs[k][np.newaxis, ...]
+
+        # Add the leading batch (and time, for n1.7) axes. Language and any
+        # non-ndarray values stay as B-length list[str] regardless of
+        # version - the server matches them against batch, not time.
+        n_lead = 2 if self._groot_version == "n1.7" else 1
+        for k in list(obs.keys()):
+            v = obs[k]
+            if isinstance(v, np.ndarray):
+                for _ in range(n_lead):
+                    v = v[np.newaxis, ...]
+                obs[k] = v
             else:
-                obs[k] = [obs[k]]
+                obs[k] = [v]
         return obs
 
     def _unpack_service_actions(self, action_chunk: dict) -> list[dict[str, Any]]:

--- a/tests/policies/groot/test_policy.py
+++ b/tests/policies/groot/test_policy.py
@@ -613,6 +613,68 @@ class TestServiceObs:
         obs = Gr00tPolicy(data_config="so100")._build_service_observation({}, "t")
         assert "annotation.human.task_description" in obs
 
+    # GH #148 / Failure 2 - regressions for the N1.7 wire format.
+    #
+    # The N1.5 / N1.6 inference servers accept (B, ...) tensors. The N1.7
+    # ``run_gr00t_server`` entrypoint adds an explicit time axis and rejects
+    # float64 state, so video must be (B, T, H, W, C) and state must be
+    # (B, T, D) float32.
+
+    def test_n15_default_video_shape_is_4d(self):
+        """Pre-fix behaviour preserved when groot_version != 'n1.7' (back-compat)."""
+        p = Gr00tPolicy(data_config="so100_dualcam", host="localhost", port=19999)
+        p._groot_version = None  # mimic env where gr00t isn't installed
+        obs = p._build_service_observation({"front": np.zeros((64, 64, 3), dtype=np.uint8)}, "t")
+        # (B=1, H=64, W=64, C=3) - no T axis.
+        assert obs["video.front"].shape == (1, 64, 64, 3)
+
+    def test_n17_video_shape_is_5d_with_T(self):
+        """N1.7 servers require (B, T, H, W, C) - one extra leading axis."""
+        p = Gr00tPolicy(data_config="so100_dualcam", host="localhost", port=19999)
+        p._groot_version = "n1.7"
+        obs = p._build_service_observation({"front": np.zeros((64, 64, 3), dtype=np.uint8)}, "t")
+        # (B=1, T=1, H=64, W=64, C=3).
+        assert obs["video.front"].shape == (1, 1, 64, 64, 3)
+
+    def test_n17_state_is_float32_and_3d(self):
+        """N1.7 server rejects float64 state and requires (B, T, D) shape."""
+        p = Gr00tPolicy(data_config="so100", host="localhost", port=19999)
+        p._groot_version = "n1.7"
+        # ``state.single_arm`` is on so100; provide a Python float so the
+        # promotion-to-float32 path is exercised (not just np.float32 input).
+        obs = p._build_service_observation({"single_arm": [0.1, 0.2, 0.3]}, "t")
+        arr = obs["state.single_arm"]
+        assert arr.dtype == np.float32
+        # (B=1, T=1, D=3).
+        assert arr.shape == (1, 1, 3)
+
+    def test_n17_scalar_state_promoted_to_3d(self):
+        """A 0-D / scalar joint reading must surface as (B=1, T=1, D=1) in n1.7."""
+        p = Gr00tPolicy(data_config="so100", host="localhost", port=19999)
+        p._groot_version = "n1.7"
+        obs = p._build_service_observation({"gripper": 0.5}, "t")
+        arr = obs["state.gripper"]
+        assert arr.dtype == np.float32
+        assert arr.shape == (1, 1, 1)
+
+    def test_n17_language_remains_b_length_list_str(self):
+        """Language is matched against the batch axis - same shape as N1.5/6."""
+        p = Gr00tPolicy(data_config="so100", host="localhost", port=19999)
+        p._groot_version = "n1.7"
+        obs = p._build_service_observation({}, "pick the cube")
+        v = obs["annotation.human.task_description"]
+        assert v == ["pick the cube"]
+
+    def test_n15_state_remains_2d(self):
+        """Pre-fix shape preserved: (B, D), no T axis. Float32 dtype unchanged."""
+        p = Gr00tPolicy(data_config="so100", host="localhost", port=19999)
+        p._groot_version = "n1.6"
+        obs = p._build_service_observation({"gripper": 0.5}, "t")
+        arr = obs["state.gripper"]
+        assert arr.dtype == np.float32
+        # (B=1, D=1) - no T axis on n1.6.
+        assert arr.shape == (1, 1)
+
 
 class TestServiceUnpackWithMapping:
     """_unpack_service_actions should apply _action_mapping when available."""


### PR DESCRIPTION
## Summary

Implements **Failure 2** of #148. The N1.7 ``gr00t.eval.run_gr00t_server`` entrypoint added an explicit time axis to its observation contract and started rejecting ``float64`` state — ``_build_service_observation`` was still on the N1.5 / N1.6 wire format, so any direct-client call against an N1.7 server got rejected at the input-validation layer:

```
RuntimeError: Server error: Video key 'image' must be a numpy array of shape (B, T, H, W, C), got (1, 256, 256, 3)
RuntimeError: Server error: State key 'x' must be a numpy array of type np.float32. Got float64
```

Independent of Failures 1 and 3 — first PR in the suggested ordering from #148 because it's the smallest and unblocks direct-client testing.

## Fix

Gate the leading-axis count on the existing ``self._groot_version`` field:

| Version | Video shape | State shape | State dtype |
|---|---|---|---|
| N1.5 / N1.6 (existing) | `(B, H, W, C)` | `(B, D)` | float32 |
| N1.7 (new) | `(B, T, H, W, C)` | `(B, T, D)` | float32 |

Scalar state values (single joint readings, gripper components) are promoted from 0-D to ``(D=1,)`` before the newaxis fanout so N1.7 lands at the canonical ``(B=1, T=1, D=1)`` shape rather than ``(1, 1)`` — which the server still rejects. Language values stay a ``B``-length ``list[str]`` regardless of version (the server matches them against the batch axis, not time).

Versioning is opt-in via the existing ``groot_version=`` constructor kwarg. Service mode cannot introspect the remote server's version, so users targeting an N1.7 server must pass ``groot_version=\"n1.7\"`` explicitly when constructing the policy:

```python
from strands_robots.policies.groot import Gr00tPolicy

policy = Gr00tPolicy(
    data_config=\"libero_panda\",
    host=\"localhost\",
    port=8000,
    groot_version=\"n1.7\",
)
```

The expanded docstring documents this contract.

## Tests

* Existing ``TestServiceObs`` tests preserved (back-compat: ``groot_version=None`` keeps the existing ``(B, ...)`` shape unchanged).
* 6 new regressions in ``TestServiceObs``:
  * ``n1.5`` default video stays ``(B, H, W, C)``
  * ``n1.7`` video is ``(B, T, H, W, C)``
  * ``n1.7`` state is float32 + ``(B, T, D)``
  * scalar state promoted to ``(1, 1, 1)`` under ``n1.7``
  * language remains ``list[str]`` under ``n1.7``
  * ``n1.6`` state remains ``(B, D)`` — 2D, not 3D

```bash
hatch run lint    # clean (ruff + mypy)
hatch run pytest tests/policies/groot/  # 124 passed
```

## Out of scope

This PR only fixes the wire format. The other two failures from #148 land in follow-up PRs:

* **Failure 1**: ``LiberoAdapter`` doesn't install the ``image`` / ``wrist_image`` cameras LIBERO scenes need.
* **Failure 3**: ``gr00t_inference`` tool wraps the N1.5 ``inference_service.py`` script that no longer exists in the N1.7 image.

Refs #148.