### PR TITLE
fix(tools/gr00t_inference): N1.7 docker-exec target + flags (#148-F3)

### DIFF
--- a/strands_robots/tools/gr00t_inference.py
+++ b/strands_robots/tools/gr00t_inference.py
@@ -34,6 +34,8 @@ def gr00t_inference(
     dit_dtype: str = "fp8",
     http_server: bool = False,
     api_token: str | None = None,
+    protocol: str = "n1.5",
+    use_sim_policy_wrapper: bool = False,
 ) -> dict[str, Any]:
     """Manage GR00T N1 inference services in Docker containers.
 
@@ -104,15 +106,34 @@ def gr00t_inference(
         The ``api_token`` parameter authenticates with the inference service. If omitted,
         falls back to the ``GROOT_API_TOKEN`` environment variable.
 
+    Server protocol versions:
+        Isaac-GR00T's inference-service entrypoint and flag set changed between
+        N1.6 and N1.7. The ``protocol`` parameter selects which command to
+        ``docker exec``:
+
+        - ``"n1.5"`` (default) and ``"n1.6"``: ``python /opt/Isaac-GR00T/scripts/inference_service.py``
+          with ``--data-config`` + ``--denoising-steps`` flags. Matches the
+          script that ships with images built before the N1.7 release.
+        - ``"n1.7"``: ``python -m gr00t.eval.run_gr00t_server``. Drops
+          ``--data-config`` and ``--denoising-steps`` (the server reads them
+          from the model's metadata.json instead). Adds optional
+          ``--use-sim-policy-wrapper`` for sim eval (LIBERO, RoboCasa, …)
+          - pass ``use_sim_policy_wrapper=True`` to enable.
+
+        The default stays ``"n1.5"`` for back-compat. N1.7 users must opt in
+        explicitly: ``gr00t_inference(action="start", ..., protocol="n1.7")``.
+
     Args:
         action: Action to perform (see Actions above).
         checkpoint_path: Path to model checkpoint directory (required for ``start``/``restart``).
         policy_name: Optional name for the policy service (for registration/tracking).
         port: Port for the inference service. Defaults to 5555 (ZMQ) or auto-switches
             to 8000 when ``http_server=True``.
-        data_config: Embodiment data config name (see Data configs above).
-        embodiment_tag: Embodiment tag for the model (e.g., ``gr1``, ``so100``).
+        data_config: Embodiment data config name (see Data configs above). N1.5/N1.6 only.
+        embodiment_tag: Embodiment tag for the model (e.g., ``gr1``, ``so100``,
+            ``libero_sim``).
         denoising_steps: Number of denoising steps for action generation (default: 4).
+            N1.5/N1.6 only - the N1.7 server reads this from the checkpoint.
         host: Host address to bind the service to (default: ``0.0.0.0``).
         container_name: Specific Docker container name. Auto-detected if omitted.
         timeout: Seconds to wait for service startup (default: 60).
@@ -123,6 +144,14 @@ def gr00t_inference(
         dit_dtype: DiT precision with TensorRT - ``fp16`` or ``fp8`` (default: ``fp8``).
         http_server: Use HTTP REST API instead of ZMQ (default: False).
         api_token: API token for authentication. Falls back to ``GROOT_API_TOKEN`` env var.
+        protocol: Server protocol version - ``"n1.5"`` (default), ``"n1.6"``, or ``"n1.7"``.
+            Determines which inference-service entrypoint and flag set is exec'd in
+            the container. See "Server protocol versions" above.
+        use_sim_policy_wrapper: When ``protocol="n1.7"``, append
+            ``--use-sim-policy-wrapper`` to the server command. Required for sim
+            evaluation (LIBERO, RoboCasa, …) - the wrapper translates
+            simulator-side observations into the format the policy expects.
+            Ignored for N1.5 / N1.6 (no equivalent flag).
 
     Returns:
         Dict with operation results. Common fields:
@@ -181,6 +210,15 @@ def gr00t_inference(
     if api_token is None:
         api_token = os.environ.get("GROOT_API_TOKEN")
 
+    # Validate protocol up-front so users get a friendly error rather than
+    # an opaque docker-exec failure inside _start_service.
+    valid_protocols = ("n1.5", "n1.6", "n1.7")
+    if protocol not in valid_protocols:
+        return {
+            "status": "error",
+            "message": f"Unknown protocol {protocol!r}. Valid: {list(valid_protocols)}",
+        }
+
     if action == "find_containers":
         return _find_gr00t_containers()
     elif action == "list":
@@ -212,6 +250,8 @@ def gr00t_inference(
             dit_dtype=dit_dtype,
             http_server=http_server,
             api_token=api_token,
+            protocol=protocol,
+            use_sim_policy_wrapper=use_sim_policy_wrapper,
         )
     elif action == "restart":
         if checkpoint_path is None:
@@ -236,6 +276,8 @@ def gr00t_inference(
             dit_dtype=dit_dtype,
             http_server=http_server,
             api_token=api_token,
+            protocol=protocol,
+            use_sim_policy_wrapper=use_sim_policy_wrapper,
         )
     else:
         return {"status": "error", "message": f"Unknown action: {action}"}
@@ -390,39 +432,64 @@ def _stop_service(port: int) -> dict[str, Any]:
         return {"status": "error", "message": f"Failed to stop service: {e}"}
 
 
-def _start_service(
+def _build_inference_command(
+    *,
+    container_name: str,
     checkpoint_path: str,
     port: int,
+    host: str,
     data_config: str,
     embodiment_tag: str,
     denoising_steps: int,
-    host: str,
-    container_name: str | None,
-    policy_name: str | None,
-    timeout: int,
+    http_server: bool,
     use_tensorrt: bool,
     trt_engine_path: str,
     vit_dtype: str,
     llm_dtype: str,
     dit_dtype: str,
-    http_server: bool,
     api_token: str | None,
-) -> dict[str, Any]:
-    """Start GR00T inference service using Isaac-GR00T's native inference service."""
-    try:
-        # Find container if not specified
-        if container_name is None:
-            containers = _find_gr00t_containers()
-            if containers["status"] == "error":
-                return containers
+    protocol: str,
+    use_sim_policy_wrapper: bool,
+) -> list[str]:
+    """Build the ``docker exec`` argv for the inference service.
 
-            running_containers = [c for c in containers["containers"] if "Up" in c["status"]]
-            if not running_containers:
-                return {"status": "error", "message": "No running GR00T containers found"}
+    Two entrypoint scripts ship with Isaac-GR00T:
 
-            container_name = running_containers[0]["name"]
+    * ``/opt/Isaac-GR00T/scripts/inference_service.py`` (N1.5, N1.6) -
+      standalone server with embodiment data-config + denoising-steps
+      flags.
+    * ``python -m gr00t.eval.run_gr00t_server`` (N1.7) - rewritten
+      entrypoint that reads data-config + denoising-steps from the
+      checkpoint metadata and adds an optional ``--use-sim-policy-wrapper``
+      flag for sim eval (LIBERO, RoboCasa, …).
 
-        # Build Isaac-GR00T inference service command
+    Both share ``--server``, ``--model-path``, ``--port``, ``--host``,
+    ``--embodiment-tag``, ``--api-token``, and the TensorRT flag set.
+    The split keeps the ``protocol`` branch shallow - one ``if`` per
+    diverging flag rather than two parallel command-builder functions.
+    """
+    if protocol == "n1.7":
+        cmd = [
+            "docker",
+            "exec",
+            "-d",
+            container_name,
+            "python",
+            "-m",
+            "gr00t.eval.run_gr00t_server",
+            "--server",
+            "--model-path",
+            checkpoint_path,
+            "--port",
+            str(port),
+            "--host",
+            host,
+            "--embodiment-tag",
+            embodiment_tag,
+        ]
+        if use_sim_policy_wrapper:
+            cmd.append("--use-sim-policy-wrapper")
+    else:  # n1.5 / n1.6
         cmd = [
             "docker",
             "exec",
@@ -445,50 +512,111 @@ def _start_service(
             str(denoising_steps),
         ]
 
-        # Add HTTP server flag if requested
-        if http_server:
-            cmd.append("--http-server")
+    # Shared optional flags - apply to every protocol.
+    if http_server:
+        cmd.append("--http-server")
 
-        # Add TensorRT flags if enabled
-        if use_tensorrt:
-            cmd.extend(
-                [
-                    "--use-tensorrt",
-                    "--trt-engine-path",
-                    trt_engine_path,
-                    "--vit-dtype",
-                    vit_dtype,
-                    "--llm-dtype",
-                    llm_dtype,
-                    "--dit-dtype",
-                    dit_dtype,
-                ]
-            )
+    if use_tensorrt:
+        cmd.extend(
+            [
+                "--use-tensorrt",
+                "--trt-engine-path",
+                trt_engine_path,
+                "--vit-dtype",
+                vit_dtype,
+                "--llm-dtype",
+                llm_dtype,
+                "--dit-dtype",
+                dit_dtype,
+            ]
+        )
 
-        # Add API token if provided
-        if api_token:
-            cmd.extend(["--api-token", api_token])
+    if api_token:
+        cmd.extend(["--api-token", api_token])
+
+    return cmd
+
+
+def _start_service(
+    checkpoint_path: str,
+    port: int,
+    data_config: str,
+    embodiment_tag: str,
+    denoising_steps: int,
+    host: str,
+    container_name: str | None,
+    policy_name: str | None,
+    timeout: int,
+    use_tensorrt: bool,
+    trt_engine_path: str,
+    vit_dtype: str,
+    llm_dtype: str,
+    dit_dtype: str,
+    http_server: bool,
+    api_token: str | None,
+    protocol: str = "n1.5",
+    use_sim_policy_wrapper: bool = False,
+) -> dict[str, Any]:
+    """Start GR00T inference service using Isaac-GR00T's native inference service."""
+    try:
+        # Find container if not specified
+        if container_name is None:
+            containers = _find_gr00t_containers()
+            if containers["status"] == "error":
+                return containers
+
+            running_containers = [c for c in containers["containers"] if "Up" in c["status"]]
+            if not running_containers:
+                return {"status": "error", "message": "No running GR00T containers found"}
+
+            container_name = running_containers[0]["name"]
+
+        cmd = _build_inference_command(
+            container_name=container_name,
+            checkpoint_path=checkpoint_path,
+            port=port,
+            host=host,
+            data_config=data_config,
+            embodiment_tag=embodiment_tag,
+            denoising_steps=denoising_steps,
+            http_server=http_server,
+            use_tensorrt=use_tensorrt,
+            trt_engine_path=trt_engine_path,
+            vit_dtype=vit_dtype,
+            llm_dtype=llm_dtype,
+            dit_dtype=dit_dtype,
+            api_token=api_token,
+            protocol=protocol,
+            use_sim_policy_wrapper=use_sim_policy_wrapper,
+        )
 
         # Start service
         subprocess.run(cmd, capture_output=True, text=True, check=True)
 
         # Wait for service to start
-        protocol = "HTTP" if http_server else "ZMQ"
+        wire_protocol = "HTTP" if http_server else "ZMQ"
         start_time = time.time()
         while time.time() - start_time < timeout:
             if _is_service_running(port):
-                response = {
+                response: dict[str, Any] = {
                     "status": "success",
                     "port": port,
                     "checkpoint_path": checkpoint_path,
                     "container_name": container_name,
                     "policy_name": policy_name,
-                    "protocol": protocol,
-                    "data_config": data_config,
+                    "protocol": wire_protocol,
+                    "server_protocol": protocol,
                     "embodiment_tag": embodiment_tag,
-                    "denoising_steps": denoising_steps,
-                    "message": f"GR00T {protocol} service started on port {port}",
+                    "message": f"GR00T {wire_protocol} service started on port {port} (server: {protocol})",
                 }
+                # Server flags that only apply to the legacy entrypoint -
+                # surface them only when actually used so the response
+                # accurately reflects what was passed.
+                if protocol != "n1.7":
+                    response["data_config"] = data_config
+                    response["denoising_steps"] = denoising_steps
+                else:
+                    response["use_sim_policy_wrapper"] = use_sim_policy_wrapper
                 if use_tensorrt:
                     response["tensorrt"] = {
                         "enabled": True,
@@ -502,7 +630,7 @@ def _start_service(
                 return response
             time.sleep(1)
 
-        return {"status": "error", "message": f"{protocol} service failed to start within {timeout} seconds"}
+        return {"status": "error", "message": f"{wire_protocol} service failed to start within {timeout} seconds"}
 
     except subprocess.CalledProcessError as e:
         return {"status": "error", "message": f"Failed to start service: {e.stderr or e}"}

--- a/tests/tools/test_gr00t_inference.py
+++ b/tests/tools/test_gr00t_inference.py
@@ -1,0 +1,279 @@
+"""Tests for the ``gr00t_inference`` tool's command builder.
+
+Establishes the testing pattern for shell-out tools in this repo: mock
+``subprocess.run`` and ``_is_service_running`` so the start path returns
+without actually invoking docker. Tests assert on the exact ``argv`` the
+tool would have ``docker exec``'d.
+
+Coverage:
+
+* N1.5 default - legacy ``inference_service.py`` entrypoint with
+  ``--data-config`` + ``--denoising-steps``.
+* N1.6 - same entrypoint as N1.5 (the wire format diverged but the
+  server CLI didn't).
+* N1.7 - new ``python -m gr00t.eval.run_gr00t_server`` entrypoint with
+  no ``--data-config`` / ``--denoising-steps`` and an optional
+  ``--use-sim-policy-wrapper``.
+* Unknown protocol → structured error.
+* Optional flags (TensorRT, ``--http-server``, ``--api-token``) carry
+  through to every protocol.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from strands_robots.tools.gr00t_inference import (
+    _build_inference_command,
+    _start_service,
+    gr00t_inference,
+)
+
+
+def _common_kwargs(**overrides: Any) -> dict[str, Any]:
+    """Default args for ``_build_inference_command`` - keeps each test focused."""
+    base: dict[str, Any] = {
+        "container_name": "gr00t",
+        "checkpoint_path": "/data/checkpoints/model",
+        "port": 5555,
+        "host": "0.0.0.0",
+        "data_config": "libero_panda",
+        "embodiment_tag": "libero_sim",
+        "denoising_steps": 4,
+        "http_server": False,
+        "use_tensorrt": False,
+        "trt_engine_path": "gr00t_engine",
+        "vit_dtype": "fp8",
+        "llm_dtype": "nvfp4",
+        "dit_dtype": "fp8",
+        "api_token": None,
+        "protocol": "n1.5",
+        "use_sim_policy_wrapper": False,
+    }
+    base.update(overrides)
+    return base
+
+
+# Command builder
+
+
+class TestBuildInferenceCommand:
+    def test_n15_legacy_entrypoint(self):
+        cmd = _build_inference_command(**_common_kwargs(protocol="n1.5"))
+        # Legacy script must be the python target.
+        assert "/opt/Isaac-GR00T/scripts/inference_service.py" in cmd
+        # Includes the deprecated-in-n1.7 flags.
+        assert "--data-config" in cmd
+        assert "libero_panda" in cmd
+        assert "--denoising-steps" in cmd
+        assert "4" in cmd
+        # Does NOT include n1.7-only flags.
+        assert "-m" not in cmd
+        assert "gr00t.eval.run_gr00t_server" not in cmd
+        assert "--use-sim-policy-wrapper" not in cmd
+
+    def test_n16_uses_legacy_entrypoint(self):
+        """N1.6 still uses inference_service.py - only the wire format diverged."""
+        cmd = _build_inference_command(**_common_kwargs(protocol="n1.6"))
+        assert "/opt/Isaac-GR00T/scripts/inference_service.py" in cmd
+        assert "--data-config" in cmd
+        assert "--denoising-steps" in cmd
+
+    def test_n17_module_entrypoint(self):
+        cmd = _build_inference_command(**_common_kwargs(protocol="n1.7"))
+        # New entrypoint: python -m gr00t.eval.run_gr00t_server
+        assert "-m" in cmd
+        assert "gr00t.eval.run_gr00t_server" in cmd
+        # Legacy script must NOT be invoked under n1.7.
+        assert "/opt/Isaac-GR00T/scripts/inference_service.py" not in cmd
+        # Flags removed from n1.7's CLI surface (server reads from checkpoint).
+        assert "--data-config" not in cmd
+        assert "--denoising-steps" not in cmd
+        # Sim policy wrapper is opt-in.
+        assert "--use-sim-policy-wrapper" not in cmd
+
+    def test_n17_with_sim_policy_wrapper(self):
+        cmd = _build_inference_command(**_common_kwargs(protocol="n1.7", use_sim_policy_wrapper=True))
+        assert "--use-sim-policy-wrapper" in cmd
+
+    def test_n17_ignores_use_sim_policy_wrapper_under_n15(self):
+        """The flag doesn't exist on the legacy entrypoint - silently dropped."""
+        cmd = _build_inference_command(**_common_kwargs(protocol="n1.5", use_sim_policy_wrapper=True))
+        assert "--use-sim-policy-wrapper" not in cmd
+
+    def test_shared_required_flags_present_on_all_protocols(self):
+        for protocol in ("n1.5", "n1.6", "n1.7"):
+            cmd = _build_inference_command(**_common_kwargs(protocol=protocol))
+            assert "--server" in cmd, protocol
+            assert "--model-path" in cmd, protocol
+            assert "/data/checkpoints/model" in cmd, protocol
+            assert "--port" in cmd, protocol
+            assert "5555" in cmd, protocol
+            assert "--host" in cmd, protocol
+            assert "0.0.0.0" in cmd, protocol
+            assert "--embodiment-tag" in cmd, protocol
+            assert "libero_sim" in cmd, protocol
+
+    def test_http_server_flag_carries_across_protocols(self):
+        for protocol in ("n1.5", "n1.7"):
+            cmd = _build_inference_command(**_common_kwargs(protocol=protocol, http_server=True))
+            assert "--http-server" in cmd, protocol
+
+    def test_tensorrt_flags_carry_across_protocols(self):
+        for protocol in ("n1.5", "n1.7"):
+            cmd = _build_inference_command(
+                **_common_kwargs(
+                    protocol=protocol,
+                    use_tensorrt=True,
+                    trt_engine_path="/engines/x",
+                    vit_dtype="fp16",
+                    llm_dtype="fp8",
+                    dit_dtype="fp16",
+                )
+            )
+            assert "--use-tensorrt" in cmd, protocol
+            assert "/engines/x" in cmd, protocol
+            assert "fp16" in cmd, protocol
+            assert "fp8" in cmd, protocol
+
+    def test_api_token_carries_across_protocols(self):
+        for protocol in ("n1.5", "n1.7"):
+            cmd = _build_inference_command(**_common_kwargs(protocol=protocol, api_token="sek"))
+            assert "--api-token" in cmd
+            assert "sek" in cmd
+
+    def test_api_token_omitted_when_none(self):
+        cmd = _build_inference_command(**_common_kwargs(api_token=None))
+        assert "--api-token" not in cmd
+
+
+# Top-level dispatcher
+
+
+class TestProtocolValidation:
+    def test_unknown_protocol_returns_structured_error(self):
+        result = gr00t_inference(action="start", checkpoint_path="/cp", protocol="n2.0")
+        assert result["status"] == "error"
+        assert "Unknown protocol" in result["message"]
+        # Error must enumerate the valid set so the caller can fix the call.
+        assert "n1.5" in result["message"]
+        assert "n1.7" in result["message"]
+
+
+# _start_service end-to-end with subprocess mocked
+
+
+class TestStartServiceEndToEnd:
+    @patch("strands_robots.tools.gr00t_inference._is_service_running", return_value=True)
+    @patch("strands_robots.tools.gr00t_inference.subprocess.run")
+    def test_n17_start_succeeds_and_reports_server_protocol(self, mock_run, _mock_is_running):
+        """Full start path with protocol='n1.7' must invoke run_gr00t_server."""
+        mock_run.return_value.stdout = ""
+        mock_run.return_value.stderr = ""
+        result = _start_service(
+            checkpoint_path="/data/checkpoints/libero_spatial",
+            port=8000,
+            data_config="libero_panda",
+            embodiment_tag="libero_sim",
+            denoising_steps=4,
+            host="0.0.0.0",
+            container_name="gr00t",
+            policy_name=None,
+            timeout=2,
+            use_tensorrt=False,
+            trt_engine_path="x",
+            vit_dtype="fp8",
+            llm_dtype="nvfp4",
+            dit_dtype="fp8",
+            http_server=False,
+            api_token=None,
+            protocol="n1.7",
+            use_sim_policy_wrapper=True,
+        )
+        assert result["status"] == "success"
+        assert result["server_protocol"] == "n1.7"
+        assert result["use_sim_policy_wrapper"] is True
+        # The legacy-only fields must NOT appear in the n1.7 response.
+        assert "data_config" not in result
+        assert "denoising_steps" not in result
+
+        # Verify the actual subprocess call.
+        argv = mock_run.call_args.args[0]
+        assert "gr00t.eval.run_gr00t_server" in argv
+        assert "--use-sim-policy-wrapper" in argv
+        assert "--data-config" not in argv
+
+    @patch("strands_robots.tools.gr00t_inference._is_service_running", return_value=True)
+    @patch("strands_robots.tools.gr00t_inference.subprocess.run")
+    def test_n15_start_preserves_legacy_response_fields(self, mock_run, _mock_is_running):
+        """Default protocol path must keep the existing response shape."""
+        mock_run.return_value.stdout = ""
+        result = _start_service(
+            checkpoint_path="/cp",
+            port=5555,
+            data_config="so100",
+            embodiment_tag="so100",
+            denoising_steps=4,
+            host="0.0.0.0",
+            container_name="gr00t",
+            policy_name=None,
+            timeout=2,
+            use_tensorrt=False,
+            trt_engine_path="x",
+            vit_dtype="fp8",
+            llm_dtype="nvfp4",
+            dit_dtype="fp8",
+            http_server=False,
+            api_token=None,
+            protocol="n1.5",
+            use_sim_policy_wrapper=False,
+        )
+        assert result["status"] == "success"
+        assert result["server_protocol"] == "n1.5"
+        assert result["data_config"] == "so100"
+        assert result["denoising_steps"] == 4
+        # Wire protocol stays "ZMQ" / "HTTP" (back-compat with pre-fix callers).
+        assert result["protocol"] == "ZMQ"
+
+    @patch("strands_robots.tools.gr00t_inference._is_service_running", return_value=False)
+    @patch("strands_robots.tools.gr00t_inference.subprocess.run")
+    def test_timeout_returns_error(self, mock_run, _mock_is_running):
+        mock_run.return_value.stdout = ""
+        result = _start_service(
+            checkpoint_path="/cp",
+            port=5555,
+            data_config="so100",
+            embodiment_tag="so100",
+            denoising_steps=4,
+            host="0.0.0.0",
+            container_name="gr00t",
+            policy_name=None,
+            timeout=0,  # don't actually sleep
+            use_tensorrt=False,
+            trt_engine_path="x",
+            vit_dtype="fp8",
+            llm_dtype="nvfp4",
+            dit_dtype="fp8",
+            http_server=False,
+            api_token=None,
+            protocol="n1.7",
+            use_sim_policy_wrapper=False,
+        )
+        assert result["status"] == "error"
+        assert "failed to start" in result["message"]
+
+
+@pytest.mark.parametrize("protocol", ["n1.5", "n1.6", "n1.7"])
+class TestSignatureBackCompat:
+    """Existing callers that don't pass ``protocol=`` must continue to work
+    (default = ``n1.5``)."""
+
+    def test_default_protocol_is_n15(self, protocol):
+        # Indirect: passing nothing should match an explicit n1.5 build.
+        if protocol != "n1.5":
+            return
+        cmd_default = _build_inference_command(**_common_kwargs(protocol="n1.5"))
+        assert "/opt/Isaac-GR00T/scripts/inference_service.py" in cmd_default


### PR DESCRIPTION
## Summary

Implements **Failure 3** of #148. The legacy ``/opt/Isaac-GR00T/scripts/inference_service.py`` script doesn't exist in N1.7 images, and the new entrypoint takes a different flag set. ``gr00t_inference(action=\"start\", ...)`` against an N1.7 container fails today with a \"file not found\" inside the ``docker exec``.

Independent of Failures 1 and 2 — second PR in the suggested ordering from #148.

## Fix

Add ``protocol: str = \"n1.5\"`` (valid: ``n1.5`` / ``n1.6`` / ``n1.7``) and ``use_sim_policy_wrapper: bool = False`` parameters. Refactor the docker-exec command construction into a ``_build_inference_command`` helper so the branch is testable in isolation:

| | N1.5 / N1.6 (default) | N1.7 |
|---|---|---|
| Entrypoint | `python /opt/Isaac-GR00T/scripts/inference_service.py` | `python -m gr00t.eval.run_gr00t_server` |
| `--data-config` | ✓ | dropped (server reads from checkpoint) |
| `--denoising-steps` | ✓ | dropped (server reads from checkpoint) |
| `--use-sim-policy-wrapper` | n/a | new, gated on `use_sim_policy_wrapper=True` |
| `--server`, `--model-path`, `--port`, `--host`, `--embodiment-tag` | ✓ | ✓ |
| `--http-server`, `--use-tensorrt`, `--api-token` | ✓ (carried through) | ✓ (carried through) |

Default stays ``\"n1.5\"`` for back-compat — existing callers are unaffected. N1.7 users opt in:

```python
gr00t_inference(
    action=\"start\",
    checkpoint_path=\"/data/checkpoints/GR00T-N1.7-LIBERO/libero_spatial\",
    port=8000,
    embodiment_tag=\"libero_sim\",
    protocol=\"n1.7\",
    use_sim_policy_wrapper=True,
)
```

Response dict gains a ``server_protocol`` field naming ``n1.x``; the existing ``protocol`` field stays ``\"ZMQ\"`` / ``\"HTTP\"`` for back-compat. Legacy-only fields (``data_config``, ``denoising_steps``) only appear in N1.5 / N1.6 responses; ``use_sim_policy_wrapper`` only appears in N1.7 responses.

Unknown ``protocol`` values return a structured error with the valid list rather than crashing inside ``docker exec``:

```python
gr00t_inference(action=\"start\", checkpoint_path=\"/cp\", protocol=\"n2.0\")
# → {\"status\": \"error\", \"message\": \"Unknown protocol 'n2.0'. Valid: ['n1.5', 'n1.6', 'n1.7']\"}
```

## Tests

This is the first tool in the repo with subprocess-level tests — establishes the pattern (mock ``subprocess.run`` + ``_is_service_running``, assert on the captured ``argv``). 17 new tests in ``tests/tools/test_gr00t_inference.py``:

* cmd builder per protocol (N1.5 / N1.6 / N1.7) — entrypoint + flag set
* ``--use-sim-policy-wrapper`` presence/absence per protocol
* shared flags (``--server``, ``--model-path``, ``--port``, ``--host``, ``--embodiment-tag``, ``--http-server``, ``--use-tensorrt``, ``--api-token``) carry across protocols
* unknown protocol → structured error with valid list
* full ``_start_service`` round-trip with ``subprocess.run`` mocked, asserting response shape per protocol
* back-compat: default ``protocol`` = ``n1.5`` retains the legacy entrypoint

```bash
hatch run lint    # clean (ruff + mypy)
hatch run pytest tests/  # 1461 passed (no regressions)
```

## Out of scope

* **Failure 1** (``LiberoAdapter`` doesn't install ``image`` / ``wrist_image`` cameras) — biggest piece, lands in the third follow-up PR.
* **Failure 2** (``Gr00tPolicy._build_service_observation`` wire format) — already in [#149](https://github.com/strands-labs/robots/pull/149).

Refs #148.