### PR TITLE
fix(libero): install image / wrist_image cameras for libero_panda data_config (#148-F1)

### DIFF
--- a/strands_robots/benchmarks/libero/adapter.py
+++ b/strands_robots/benchmarks/libero/adapter.py
@@ -84,6 +84,38 @@ class LiberoAdapter(BenchmarkProtocol):
     supported_robots_list: list[str] = ["panda"]
     default_robot_name: str = "panda"
 
+    #: Cameras the ``libero_panda`` ``Gr00tDataConfig`` expects to find on the
+    #: sim. Names match the bare keys of its ``video_keys`` (``video.image``
+    #: → ``image``, ``video.wrist_image`` → ``wrist_image``) so the policy's
+    #: ``_build_service_observation`` picks them up directly without an
+    #: explicit ``observation_mapping``.
+    #:
+    #: Poses are world-fixed approximations of LIBERO's RoboSuite-conventional
+    #: views (third-person "agentview" + wrist view). The real LIBERO setup
+    #: parents ``robot0_eye_in_hand_image`` to the gripper body; that requires
+    #: a proper LIBERO scene MJCF (which the upstream pip package does NOT
+    #: ship). Until those scene XMLs are wired in via ``scene_path=``, the
+    #: wrist camera here is a *static* top-down workspace view - the model
+    #: still gets *an* image, but it doesn't track the end-effector. Override
+    #: by passing ``cameras={"wrist_image": {"position": [...], ...}}`` to
+    #: the constructor.
+    LIBERO_CAMERAS: dict[str, dict[str, Any]] = {
+        "image": {
+            "position": [1.0, 0.0, 1.5],
+            "target": [0.0, 0.0, 0.85],
+            "fov": 60.0,
+            "width": 256,
+            "height": 256,
+        },
+        "wrist_image": {
+            "position": [0.0, 0.0, 1.4],
+            "target": [0.0, 0.0, 0.85],
+            "fov": 60.0,
+            "width": 256,
+            "height": 256,
+        },
+    }
+
     def __init__(
         self,
         problem: BDDLProblem,
@@ -91,6 +123,8 @@ class LiberoAdapter(BenchmarkProtocol):
         scene_path: str | None = None,
         max_steps: int | None = None,
         init_jitter: float = 0.02,
+        install_cameras: bool = True,
+        cameras: dict[str, dict[str, Any]] | None = None,
     ):
         """Construct from a pre-parsed :class:`BDDLProblem`.
 
@@ -102,6 +136,16 @@ class LiberoAdapter(BenchmarkProtocol):
             init_jitter: Per-episode ±jitter (metres) applied to xy of every
                 object referenced by ``(:init (on A B))`` clauses. Set to 0
                 to disable jitter.
+            install_cameras: When ``True`` (default), install the cameras
+                in :attr:`LIBERO_CAMERAS` (or ``cameras`` override) on
+                episode start. Set to ``False`` if your scene MJCF already
+                declares the cameras the policy needs - the adapter will
+                skip the install step entirely.
+            cameras: Override / extend :attr:`LIBERO_CAMERAS`. Keyed by
+                camera name, each value is forwarded as ``**kwargs`` to
+                :meth:`Simulation.add_camera`. Passing an empty dict
+                disables camera installation regardless of
+                ``install_cameras``.
 
         Raises:
             ValueError: If ``problem.goal`` is ``None``.
@@ -115,6 +159,14 @@ class LiberoAdapter(BenchmarkProtocol):
             raise ValueError(f"init_jitter must be >= 0, got {init_jitter}")
         if max_steps is not None:
             self.max_steps = int(max_steps)
+        self._install_cameras = bool(install_cameras)
+        # Snapshot the camera config at construction time so subsequent
+        # mutations to LIBERO_CAMERAS don't leak across instances.
+        self._cameras: dict[str, dict[str, Any]] = (
+            {k: dict(v) for k, v in cameras.items()}
+            if cameras is not None
+            else {k: dict(v) for k, v in self.LIBERO_CAMERAS.items()}
+        )
         self._success_fn: Callable[[SimEngine], bool] = compile_goal(problem.goal)
 
     # Construction helpers
@@ -127,6 +179,8 @@ class LiberoAdapter(BenchmarkProtocol):
         scene_path: str | None = None,
         max_steps: int | None = None,
         init_jitter: float = 0.02,
+        install_cameras: bool = True,
+        cameras: dict[str, dict[str, Any]] | None = None,
     ) -> LiberoAdapter:
         """Parse a ``.bddl`` file from disk and build an adapter.
 
@@ -140,6 +194,8 @@ class LiberoAdapter(BenchmarkProtocol):
             scene_path=scene_path,
             max_steps=max_steps,
             init_jitter=init_jitter,
+            install_cameras=install_cameras,
+            cameras=cameras,
         )
 
     @classmethod
@@ -150,6 +206,8 @@ class LiberoAdapter(BenchmarkProtocol):
         scene_path: str | None = None,
         max_steps: int | None = None,
         init_jitter: float = 0.02,
+        install_cameras: bool = True,
+        cameras: dict[str, dict[str, Any]] | None = None,
     ) -> LiberoAdapter:
         """Parse a BDDL string directly - useful in tests."""
         problem = parse_bddl(bddl_text)
@@ -158,6 +216,8 @@ class LiberoAdapter(BenchmarkProtocol):
             scene_path=scene_path,
             max_steps=max_steps,
             init_jitter=init_jitter,
+            install_cameras=install_cameras,
+            cameras=cameras,
         )
 
     # BenchmarkProtocol interface
@@ -176,11 +236,21 @@ class LiberoAdapter(BenchmarkProtocol):
         return self.problem.language or ""
 
     def on_episode_start(self, sim: SimEngine, rng: random.Random) -> None:
-        """Load the declared scene (if any), validate Panda, then apply init jitter.
+        """Load the declared scene (if any), validate Panda, install cameras, then jitter.
 
-        Order matters: load_scene MUST happen before ``super().on_episode_start``
-        so the base compatibility check sees the scene's Panda robot rather
-        than reporting "sim is empty → load default_robot".
+        Order matters:
+
+        1. ``load_scene`` (if ``scene_path`` set) - so the base
+           compatibility check sees the scene's Panda rather than reporting
+           "sim is empty → load default_robot".
+        2. ``super().on_episode_start`` - base compat check + auto-load
+           ``default_robot`` if the sim is empty.
+        3. ``_install_libero_cameras`` - inject the cameras the
+           ``libero_panda`` ``Gr00tDataConfig`` expects (``image`` /
+           ``wrist_image``). MUST happen after the robot is loaded so the
+           cameras render against a populated scene.
+        4. ``_apply_init_jitter`` - per-episode RNG-seeded ±jitter to
+           init-subject bodies.
         """
         if self.scene_path:
             load_scene = getattr(sim, "load_scene", None)
@@ -195,6 +265,8 @@ class LiberoAdapter(BenchmarkProtocol):
                     msg = (result.get("content") or [{}])[0].get("text", "")
                     raise RuntimeError(f"LiberoAdapter: load_scene({self.scene_path!r}) failed: {msg}")
         super().on_episode_start(sim, rng)
+        if self._install_cameras:
+            self._install_libero_cameras(sim)
         if self._init_jitter > 0:
             self._apply_init_jitter(sim, rng)
 
@@ -212,6 +284,52 @@ class LiberoAdapter(BenchmarkProtocol):
         return bool(self._success_fn(sim))
 
     # Internals
+
+    def _install_libero_cameras(self, sim: SimEngine) -> None:
+        """Inject the cameras the ``libero_panda`` data_config expects.
+
+        Best-effort: the LIBERO ``Gr00tDataConfig`` declares
+        ``video_keys = ["video.image", "video.wrist_image"]`` and the policy's
+        ``_build_service_observation`` reads those from the robot observation
+        as ``obs["image"]`` / ``obs["wrist_image"]``. Without these cameras
+        in the sim, every direct-client call to a LIBERO server fails with
+        ``Video key 'video.image' must be in observation`` (#148, Failure 1).
+
+        Cameras already present in the sim (declared by a loaded scene MJCF
+        that beats us to the name) are skipped silently. Other failures are
+        logged at WARNING but never fatal - one missing camera shouldn't
+        kill the whole eval.
+        """
+        add_camera = getattr(sim, "add_camera", None)
+        if add_camera is None:
+            logger.debug("LiberoAdapter: sim has no add_camera(); skipping camera install")
+            return
+
+        # Cheap check for already-installed cameras: most backends expose a
+        # ``_world.cameras`` dict. If we can't see it, just try add_camera
+        # and let it return its own "already exists" error.
+        existing: set[str] = set()
+        world = getattr(sim, "_world", None)
+        cameras_attr = getattr(world, "cameras", None) if world is not None else None
+        if isinstance(cameras_attr, dict):
+            existing = set(cameras_attr.keys())
+
+        for cam_name, cam_kwargs in self._cameras.items():
+            if cam_name in existing:
+                logger.debug("LiberoAdapter: camera %r already in sim; skipping install", cam_name)
+                continue
+            try:
+                result = add_camera(name=cam_name, **cam_kwargs)
+            except Exception as e:  # noqa: BLE001 - one bad camera shouldn't kill the eval
+                logger.warning("LiberoAdapter: add_camera(%r) raised: %s", cam_name, e)
+                continue
+            if isinstance(result, dict) and result.get("status") == "error":
+                msg = (result.get("content") or [{}])[0].get("text", "")
+                # "already exists" is benign - the scene XML beat us to it.
+                if "already exists" in msg.lower():
+                    logger.debug("LiberoAdapter: camera %r already declared by scene", cam_name)
+                else:
+                    logger.warning("LiberoAdapter: add_camera(%r) failed: %s", cam_name, msg)
 
     def _apply_init_jitter(self, sim: SimEngine, rng: random.Random) -> None:
         """Apply ±jitter to xy of every body referenced by ``(:init (on A B))``.

--- a/tests/benchmarks/libero/test_libero_adapter.py
+++ b/tests/benchmarks/libero/test_libero_adapter.py
@@ -78,16 +78,19 @@ class _FakeRobot:
 class _FakeWorld:
     def __init__(self, robots: dict[str, _FakeRobot]):
         self.robots = dict(robots)
+        self.cameras: dict[str, dict[str, Any]] = {}
 
 
 class FakeSim(SimEngine):
-    """Minimal ``SimEngine`` with get_body_state / get_contacts / move_object."""
+    """Minimal ``SimEngine`` with get_body_state / get_contacts / move_object / add_camera."""
 
     def __init__(
         self,
         bodies: dict[str, dict[str, Any]] | None = None,
         contacts: list[dict[str, str]] | None = None,
         data_config: str = "panda",
+        preexisting_cameras: list[str] | None = None,
+        add_camera_fail: bool = False,
     ):
         self._bodies = dict(bodies or {})
         self._contacts = list(contacts or [])
@@ -95,6 +98,10 @@ class FakeSim(SimEngine):
         self._move_calls: list[tuple[str, list[float]]] = []
         self._world = _FakeWorld({"fake_panda": _FakeRobot(data_config)})
         self._scenes_loaded: list[str] = []
+        self._add_camera_calls: list[tuple[str, dict[str, Any]]] = []
+        self._add_camera_fail = add_camera_fail
+        for cam in preexisting_cameras or []:
+            self._world.cameras[cam] = {"position": [0, 0, 0], "target": [0, 0, 0]}
 
     def create_world(self, timestep=None, gravity=None, ground_plane=True):
         return {"status": "success"}
@@ -177,6 +184,33 @@ class FakeSim(SimEngine):
     def load_scene(self, scene_path: str) -> dict[str, Any]:
         self._scenes_loaded.append(scene_path)
         return {"status": "success"}
+
+    def add_camera(
+        self,
+        name: str,
+        position: list[float] | None = None,
+        target: list[float] | None = None,
+        fov: float = 60.0,
+        width: int = 640,
+        height: int = 480,
+    ) -> dict[str, Any]:
+        kwargs = {
+            "position": position,
+            "target": target,
+            "fov": fov,
+            "width": width,
+            "height": height,
+        }
+        self._add_camera_calls.append((name, dict(kwargs)))
+        if self._add_camera_fail:
+            return {"status": "error", "content": [{"text": "fake injection failed"}]}
+        if name in self._world.cameras:
+            return {
+                "status": "error",
+                "content": [{"text": f"add_camera: camera '{name}' already exists. Remove it first."}],
+            }
+        self._world.cameras[name] = kwargs
+        return {"status": "success", "content": [{"text": f"📷 Camera '{name}' added"}]}
 
 
 # Construction
@@ -325,6 +359,120 @@ class TestOnEpisodeStart:
             adapter.on_episode_start(sim, random.Random(0))
         assert exc.value.supported == ["panda"]
         assert exc.value.data_config == "so100"
+
+
+# LIBERO camera installation (#148 / Failure 1)
+
+
+class TestLiberoCameraInstall:
+    def test_default_cameras_installed(self):
+        """``image`` and ``wrist_image`` cameras must be installed so the
+        ``libero_panda`` Gr00tDataConfig finds them in the observation."""
+        adapter = LiberoAdapter.from_text(PICK_CUBE_BDDL, init_jitter=0.0)
+        sim = FakeSim(data_config="panda")
+        adapter.on_episode_start(sim, random.Random(0))
+
+        installed_names = {name for name, _ in sim._add_camera_calls}
+        assert installed_names == {"image", "wrist_image"}
+        assert "image" in sim._world.cameras
+        assert "wrist_image" in sim._world.cameras
+
+    def test_camera_install_happens_after_robot_load(self):
+        """Camera install must run AFTER super().on_episode_start so it
+        installs into a populated scene rather than an empty world."""
+        adapter = LiberoAdapter.from_text(PICK_CUBE_BDDL, init_jitter=0.0)
+
+        events: list[str] = []
+
+        class TrackingFakeSim(FakeSim):
+            def add_robot(self, name, **kw):
+                events.append("add_robot")
+                return super().add_robot(name, **kw)
+
+            def add_camera(self, name, **kw):
+                events.append(f"add_camera:{name}")
+                return super().add_camera(name, **kw)
+
+        sim = TrackingFakeSim(data_config="panda")
+        # Empty world so super() triggers add_robot for default_robot.
+        sim._world.robots.clear()
+        adapter.on_episode_start(sim, random.Random(0))
+
+        # add_robot must come before any add_camera call.
+        first_camera_idx = next(i for i, e in enumerate(events) if e.startswith("add_camera:"))
+        first_robot_idx = events.index("add_robot")
+        assert first_robot_idx < first_camera_idx
+
+    def test_install_cameras_disabled(self):
+        adapter = LiberoAdapter.from_text(PICK_CUBE_BDDL, init_jitter=0.0, install_cameras=False)
+        sim = FakeSim(data_config="panda")
+        adapter.on_episode_start(sim, random.Random(0))
+        assert sim._add_camera_calls == []
+
+    def test_custom_cameras_override_defaults(self):
+        custom = {
+            "wide_view": {
+                "position": [2.0, 2.0, 2.0],
+                "target": [0.0, 0.0, 0.0],
+                "fov": 90.0,
+                "width": 128,
+                "height": 128,
+            }
+        }
+        adapter = LiberoAdapter.from_text(PICK_CUBE_BDDL, init_jitter=0.0, cameras=custom)
+        sim = FakeSim(data_config="panda")
+        adapter.on_episode_start(sim, random.Random(0))
+
+        installed_names = {name for name, _ in sim._add_camera_calls}
+        # Defaults are completely replaced - only the custom camera is installed.
+        assert installed_names == {"wide_view"}
+
+    def test_existing_cameras_skipped(self):
+        """A scene MJCF that already declares ``image`` should beat us to it -
+        the adapter must not error out when the camera already exists."""
+        adapter = LiberoAdapter.from_text(PICK_CUBE_BDDL, init_jitter=0.0)
+        sim = FakeSim(data_config="panda", preexisting_cameras=["image"])
+        adapter.on_episode_start(sim, random.Random(0))
+
+        # ``image`` was preexisting - we must not call add_camera for it.
+        installed_names = {name for name, _ in sim._add_camera_calls}
+        assert installed_names == {"wrist_image"}
+
+    def test_camera_install_failures_are_logged_not_fatal(self, caplog):
+        """A backend that refuses every add_camera shouldn't kill the eval.
+
+        The adapter's contract: log at WARNING and continue so other
+        cameras + the rollout itself still run.
+        """
+        adapter = LiberoAdapter.from_text(PICK_CUBE_BDDL, init_jitter=0.0)
+        sim = FakeSim(data_config="panda", add_camera_fail=True)
+        with caplog.at_level("WARNING"):
+            # Must not raise.
+            adapter.on_episode_start(sim, random.Random(0))
+        # Both cameras attempted; both reported as warning.
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert len(warnings) >= 2
+
+    def test_default_camera_keys_match_libero_panda_data_config(self):
+        """Regression: the adapter's camera names MUST match the bare keys of
+        the ``libero_panda`` Gr00tDataConfig's video_keys, otherwise
+        ``_build_service_observation`` won't find them in the observation."""
+        # Bare keys after removeprefix("video.").
+        expected = {"image", "wrist_image"}
+        assert set(LiberoAdapter.LIBERO_CAMERAS.keys()) == expected
+
+    def test_sim_without_add_camera_silently_skipped(self):
+        """Backends that don't expose add_camera (future engines) shouldn't
+        crash the adapter - it falls back to "no camera install"."""
+
+        class BareSim(FakeSim):
+            # Override add_camera to ``None`` so getattr returns falsy at runtime.
+            add_camera = None  # type: ignore[assignment]
+
+        sim = BareSim(data_config="panda")
+        adapter = LiberoAdapter.from_text(PICK_CUBE_BDDL, init_jitter=0.0)
+        # Must not raise even though sim.add_camera is None.
+        adapter.on_episode_start(sim, random.Random(0))
 
 
 # Step semantics


### PR DESCRIPTION
## Summary

Implements **Failure 1** of #148. The ``libero_panda`` Gr00tDataConfig declares ``video_keys = ["video.image", "video.wrist_image"]`` but the ``Simulation`` backend never injects the cameras with those names. End-to-end LIBERO eval against any GR00T server fails today with:

```
RuntimeError: Server error: Video key 'video.image' must be in observation
```

Independent of Failures 2 and 3 — the final blocker for end-to-end LIBERO eval per the issue's suggested ordering.

## Fix

``LiberoAdapter.on_episode_start`` now installs the cameras after the base compatibility check (so they go into a populated scene). Names match the bare keys of the data_config's ``video_keys`` exactly so the policy's ``_build_service_observation`` finds them without an explicit ``observation_mapping``:

| Camera | Default pose | Mapped to |
|---|---|---|
| ``image`` | ``position=[1.0, 0.0, 1.5]``, ``target=[0.0, 0.0, 0.85]`` | ``obs[\"image\"]`` → ``video.image`` |
| ``wrist_image`` | ``position=[0.0, 0.0, 1.4]``, ``target=[0.0, 0.0, 0.85]`` | ``obs[\"wrist_image\"]`` → ``video.wrist_image`` |

### Behaviour

- **Cameras already in the scene** (declared by a loaded scene MJCF) are skipped silently — \"already exists\" from ``add_camera`` is benign.
- **Per-camera failures** are logged at WARNING and not fatal — one missing camera shouldn't kill the whole eval.
- **``install_cameras=False``** disables the install step (for users whose scene XML already provides the right cameras).
- **``cameras={\"name\": {\"position\": [...], ...}}``** overrides / extends the defaults; passing an empty dict disables the install too.
- **Order matters**: install happens AFTER ``super().on_episode_start`` so the robot is loaded first — regression test pins this.

### Caveat (documented in the LIBERO_CAMERAS docstring)

The real LIBERO ``robot0_eye_in_hand_image`` is parented to the gripper body, which ``Simulation.add_camera`` doesn't yet support. Until proper LIBERO scene XMLs are wired in via ``scene_path=``, the wrist camera here is a *static* top-down workspace view — the model still gets *an* image, but it doesn't track the end-effector. Body-mounted cameras are a follow-up.

## Tests

8 new regressions in ``TestLiberoCameraInstall``:

- default cameras installed (``image`` + ``wrist_image``)
- camera install ordered AFTER ``super().on_episode_start`` (regression for \"cameras render against empty world\")
- ``install_cameras=False`` disables the step
- ``cameras={...}`` override fully replaces defaults
- preexisting scene-declared cameras skipped without error
- ``add_camera`` failures logged at WARNING, not raised
- default camera keys match ``libero_panda``'s ``video_keys.removeprefix(\"video.\")`` — regression for the policy's ``_build_service_observation`` key lookup
- sim without ``add_camera`` (future backends) silently skipped

```bash
hatch run lint    # clean (ruff + mypy)
hatch run pytest tests/benchmarks/libero/  # 88 passed (80 existing + 8 new)
```

## Out of scope

This PR only fixes the *camera* side of LIBERO scene loading. **State mapping is a separate gap**: the ``libero_panda`` data_config declares ``state_keys = [\"state.x\", \"state.y\", \"state.z\", \"state.roll\", \"state.pitch\", \"state.yaw\", \"state.gripper\"]`` (end-effector pose) but ``sim.get_observation()`` returns joint values keyed by joint name. Users currently need to provide an explicit ``observation_mapping`` on ``Gr00tPolicy`` to bridge this. A follow-up could install a default mapping in the adapter.

The other two failures from #148 land in companion PRs:

- **Failure 2** ([#149](https://github.com/strands-labs/robots/pull/149)) — ``Gr00tPolicy._build_service_observation`` wire format
- **Failure 3 narrow** ([#150](https://github.com/strands-labs/robots/pull/150)) — ``gr00t_inference`` tool entrypoint
- **Failure 3 wider** (in flight) — full container lifecycle (``build_image`` / ``download_checkpoint`` / ``start_container`` / ``lifecycle``)

Refs #148.