### PR TITLE
feat(tools/gr00t_inference): full container lifecycle (#148-F3 wider)

### DIFF
--- a/strands_robots/tools/gr00t_inference.py
+++ b/strands_robots/tools/gr00t_inference.py
@@ -4,15 +4,41 @@ GR00T Inference Service Management Tool
 
 Manages GR00T policy inference services running in Docker containers.
 Uses Isaac-GR00T's native inference service for proper ZMQ/HTTP communication.
+
+Container lifecycle (``build_image`` / ``download_checkpoint`` /
+``start_container`` / ``lifecycle="full"``) wraps the four manual setup
+steps so an LLM driving the AgentTool can fully orchestrate a GR00T eval
+from a single prompt - see #148 for the motivation.
 """
 
 import os
 import socket
 import subprocess
 import time
+from pathlib import Path
 from typing import Any
 
 from strands import tool
+
+from strands_robots.utils import get_base_dir, require_optional
+
+# Default cache layout for the lifecycle helpers. Mirrors the layout
+# documented in the Isaac-GR00T README so users moving from the manual
+# four-step setup don't have to relocate their existing artefacts.
+_DEFAULT_REPO_URL = "https://github.com/NVIDIA/Isaac-GR00T"
+_DEFAULT_REPO_TAG = "n1.7-release"
+_DEFAULT_IMAGE_NAME = "gr00t:latest"
+_DEFAULT_CONTAINER_COMMAND = "tail -f /dev/null"
+
+
+def _isaac_gr00t_dir() -> Path:
+    """Default clone destination for the Isaac-GR00T source tree."""
+    return get_base_dir() / "Isaac-GR00T"
+
+
+def _checkpoints_dir() -> Path:
+    """Default download destination for HuggingFace checkpoints."""
+    return get_base_dir() / "checkpoints"
 
 
 @tool
@@ -36,6 +62,19 @@ def gr00t_inference(
     api_token: str | None = None,
     protocol: str = "n1.5",
     use_sim_policy_wrapper: bool = False,
+    repo_url: str = _DEFAULT_REPO_URL,
+    repo_tag: str = _DEFAULT_REPO_TAG,
+    source_dir: str | None = None,
+    image_name: str = _DEFAULT_IMAGE_NAME,
+    hf_repo: str | None = None,
+    hf_subfolder: str | None = None,
+    hf_local_dir: str | None = None,
+    hf_token: str | None = None,
+    volumes: dict[str, str] | None = None,
+    container_command: str = _DEFAULT_CONTAINER_COMMAND,
+    lifecycle: str = "full",
+    remove_volumes: bool = False,
+    force: bool = False,
 ) -> dict[str, Any]:
     """Manage GR00T N1 inference services in Docker containers.
 
@@ -56,6 +95,25 @@ def gr00t_inference(
         - ``list``: Discover all running services across common ports (5555-5558, 8000-8003).
         - ``restart``: Stop and re-start a service (e.g., to swap checkpoints). Requires ``checkpoint_path``.
         - ``find_containers``: List available Isaac-GR00T Docker containers.
+        - ``build_image``: Clone Isaac-GR00T at ``repo_tag`` and run ``bash docker/build.sh``.
+          Idempotent - skips the build when ``image_name`` already exists in the local
+          docker daemon. Pass ``force=True`` to rebuild.
+        - ``download_checkpoint``: Download a HuggingFace checkpoint to a local cache
+          directory using ``huggingface_hub``. Requires ``hf_repo``;
+          ``hf_subfolder`` filters to a single sub-checkpoint (e.g.
+          ``"libero_spatial"``). Idempotent - skips when the local directory is
+          already populated unless ``force=True``.
+        - ``start_container``: ``docker run -d --gpus all --ipc=host`` on
+          ``image_name`` with ``container_name``, the volume mounts in ``volumes``,
+          ``HF_TOKEN`` env passthrough, and ``-p {port}:{port}``. Idempotent -
+          skips when a running container with the same name exists; reuses a
+          stopped container when ``force=True``.
+        - ``lifecycle``: One-call orchestration. ``lifecycle="full"`` runs
+          ``build_image`` → ``download_checkpoint`` → ``start_container`` → ``start`` and
+          waits for the inference port. ``lifecycle="teardown"`` removes the
+          container (and its volumes when ``remove_volumes=True``). Each sub-step
+          stays idempotent so re-running ``lifecycle="full"`` after a crash
+          resumes from where it stopped.
 
     Protocol selection:
         - **ZMQ** (default, ``http_server=False``): Low-latency binary protocol on port 5555.
@@ -153,6 +211,35 @@ def gr00t_inference(
             simulator-side observations into the format the policy expects.
             Ignored for N1.5 / N1.6 (no equivalent flag).
 
+    Container lifecycle args (used by ``build_image``, ``download_checkpoint``,
+    ``start_container``, ``lifecycle``):
+        repo_url: Isaac-GR00T git URL (default: ``https://github.com/NVIDIA/Isaac-GR00T``).
+        repo_tag: Branch / tag / SHA to check out (default: ``"n1.7-release"``).
+        source_dir: Where to clone the Isaac-GR00T source. Defaults to
+            ``$STRANDS_BASE_DIR/Isaac-GR00T`` (typically ``~/.strands_robots/Isaac-GR00T``).
+        image_name: Docker image tag for the built / used container
+            (default: ``"gr00t:latest"``).
+        hf_repo: HuggingFace dataset/model id (e.g., ``"nvidia/GR00T-N1.7-LIBERO"``).
+            Required for ``download_checkpoint``.
+        hf_subfolder: Subfolder pattern within the HF repo (e.g.,
+            ``"libero_spatial"``). When set, only files matching
+            ``<subfolder>/*`` are downloaded.
+        hf_local_dir: Where to download the checkpoint. Defaults to
+            ``$STRANDS_BASE_DIR/checkpoints/<basename(hf_repo)>``.
+        hf_token: HuggingFace API token (gated repos). Falls back to
+            ``HF_TOKEN`` / ``HUGGING_FACE_HUB_TOKEN`` env vars.
+        volumes: ``{host_path: container_path}`` mounts for ``start_container``.
+            Defaults to mounting ``hf_local_dir`` → ``/data/checkpoints`` and
+            ``~/.cache/huggingface`` → ``/root/.cache/huggingface``.
+        container_command: ``docker run`` command (default: ``"tail -f /dev/null"``,
+            so the container stays alive for ``docker exec``).
+        lifecycle: ``"full"`` (default - chain build → download → start_container
+            → start) or ``"teardown"`` (rm container + volumes).
+        remove_volumes: When ``lifecycle="teardown"``, also remove docker volumes
+            (default: ``False`` to preserve checkpoint mounts).
+        force: For idempotent steps - rebuild image, redownload checkpoint, or
+            recreate container even when the artefact is already present.
+
     Returns:
         Dict with operation results. Common fields:
 
@@ -227,6 +314,71 @@ def gr00t_inference(
         return _check_service_status(port)
     elif action == "stop":
         return _stop_service(port)
+    elif action == "build_image":
+        return _build_image(
+            repo_url=repo_url,
+            repo_tag=repo_tag,
+            source_dir=source_dir,
+            image_name=image_name,
+            force=force,
+        )
+    elif action == "download_checkpoint":
+        if hf_repo is None:
+            return {"status": "error", "message": "'hf_repo' is required for action='download_checkpoint'"}
+        return _download_checkpoint(
+            hf_repo=hf_repo,
+            hf_subfolder=hf_subfolder,
+            hf_local_dir=hf_local_dir,
+            hf_token=hf_token,
+            force=force,
+        )
+    elif action == "start_container":
+        return _start_container(
+            image_name=image_name,
+            container_name=container_name,
+            port=port,
+            volumes=volumes,
+            hf_token=hf_token,
+            container_command=container_command,
+            hf_local_dir=hf_local_dir,
+            force=force,
+        )
+    elif action == "lifecycle":
+        return _lifecycle(
+            phase=lifecycle,
+            # Phase-specific kwargs (most reused from start/start_container).
+            repo_url=repo_url,
+            repo_tag=repo_tag,
+            source_dir=source_dir,
+            image_name=image_name,
+            hf_repo=hf_repo,
+            hf_subfolder=hf_subfolder,
+            hf_local_dir=hf_local_dir,
+            hf_token=hf_token,
+            container_name=container_name,
+            volumes=volumes,
+            container_command=container_command,
+            remove_volumes=remove_volumes,
+            force=force,
+            # start kwargs - used at the tail of phase="full".
+            checkpoint_path=checkpoint_path,
+            policy_name=policy_name,
+            port=port,
+            data_config=data_config,
+            embodiment_tag=embodiment_tag,
+            denoising_steps=denoising_steps,
+            host=host,
+            timeout=timeout,
+            use_tensorrt=use_tensorrt,
+            trt_engine_path=trt_engine_path,
+            vit_dtype=vit_dtype,
+            llm_dtype=llm_dtype,
+            dit_dtype=dit_dtype,
+            http_server=http_server,
+            api_token=api_token,
+            protocol=protocol,
+            use_sim_policy_wrapper=use_sim_policy_wrapper,
+        )
     elif action == "start":
         if checkpoint_path is None:
             return {"status": "error", "message": "Checkpoint path required to start service"}
@@ -636,6 +788,530 @@ def _start_service(
         return {"status": "error", "message": f"Failed to start service: {e.stderr or e}"}
     except Exception as e:
         return {"status": "error", "message": f"Unexpected error: {e}"}
+
+
+# Container lifecycle helpers (#148-F3 wider)
+#
+# Each helper is idempotent and returns a structured status dict. They wrap
+# the manual four-step Isaac-GR00T setup (clone → docker build → hf
+# download → docker run) so an LLM driving this AgentTool can fully
+# orchestrate a GR00T eval from one prompt. Splitting them into per-action
+# entry points (rather than burying everything inside ``start``) keeps
+# each step independently re-runnable and makes the failure surface
+# obvious - if "build_image" succeeds but "download_checkpoint" fails,
+# the user / agent knows exactly which step to retry.
+
+
+def _image_exists(image_name: str) -> bool:
+    """Return True iff the local docker daemon already has ``image_name``.
+
+    Uses ``docker image inspect`` rather than ``docker images`` because the
+    former returns a non-zero exit code on miss (cleaner branch logic) and
+    works for tag-less digest pins too. Any docker invocation failure
+    (daemon down, command missing) returns False so the caller falls
+    through to a regular build, which then surfaces the real error.
+    """
+    try:
+        result = subprocess.run(
+            ["docker", "image", "inspect", image_name],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return result.returncode == 0
+    except (FileNotFoundError, OSError):
+        return False
+
+
+def _container_state(name: str) -> str:
+    """Return the current state of container ``name`` or ``"absent"``.
+
+    Possible values: ``"running"``, ``"exited"``, ``"created"``, ``"paused"``,
+    ``"restarting"``, ``"removing"``, ``"dead"``, ``"absent"``. Anything
+    other than ``"running"`` and ``"absent"`` is unusual and the caller
+    must decide whether to remove + recreate (``force=True``) or fail.
+    """
+    try:
+        result = subprocess.run(
+            ["docker", "inspect", "--format", "{{.State.Status}}", name],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            return "absent"
+        return result.stdout.strip() or "absent"
+    except (FileNotFoundError, OSError):
+        return "absent"
+
+
+def _build_image(
+    *,
+    repo_url: str,
+    repo_tag: str,
+    source_dir: str | None,
+    image_name: str,
+    force: bool,
+) -> dict[str, Any]:
+    """Clone Isaac-GR00T at ``repo_tag`` and run ``bash docker/build.sh``.
+
+    Idempotent: when ``image_name`` is already in the local docker daemon
+    AND ``force=False``, returns success without touching the filesystem
+    or the docker daemon. Pass ``force=True`` to clean-rebuild.
+    """
+    if not force and _image_exists(image_name):
+        return {
+            "status": "success",
+            "image_name": image_name,
+            "skipped": True,
+            "message": f"Docker image {image_name!r} already exists; skipping build (use force=True to rebuild)",
+        }
+
+    dest = Path(source_dir).expanduser() if source_dir else _isaac_gr00t_dir()
+    dest.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        # Clone or update the repo at the requested tag. ``git fetch + checkout``
+        # is faster than re-cloning when the branch has just moved.
+        if (dest / ".git").is_dir():
+            subprocess.run(
+                ["git", "-C", str(dest), "fetch", "--depth", "1", "origin", repo_tag],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "-C", str(dest), "checkout", repo_tag],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "-C", str(dest), "submodule", "update", "--init", "--recursive"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        else:
+            subprocess.run(
+                [
+                    "git",
+                    "clone",
+                    "--depth",
+                    "1",
+                    "--branch",
+                    repo_tag,
+                    "--recurse-submodules",
+                    repo_url,
+                    str(dest),
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+
+        # Build the image. ``docker/build.sh`` is the canonical entrypoint
+        # documented in the Isaac-GR00T README. Use bash explicitly so the
+        # script's shebang isn't required.
+        build_script = dest / "docker" / "build.sh"
+        if not build_script.is_file():
+            return {
+                "status": "error",
+                "message": (
+                    f"docker/build.sh not found at {build_script} - the cloned repo may "
+                    f"not match the expected layout for tag {repo_tag!r}."
+                ),
+            }
+        subprocess.run(
+            ["bash", str(build_script)],
+            cwd=str(dest),
+            capture_output=True,
+            text=True,
+            check=True,
+            env={**os.environ, "DOCKER_BUILDKIT": os.environ.get("DOCKER_BUILDKIT", "1")},
+        )
+
+        return {
+            "status": "success",
+            "image_name": image_name,
+            "source_dir": str(dest),
+            "repo_tag": repo_tag,
+            "skipped": False,
+            "message": f"Built docker image {image_name!r} from {repo_url}@{repo_tag}",
+        }
+    except subprocess.CalledProcessError as e:
+        return {
+            "status": "error",
+            "message": f"Failed to build image: {e.stderr or e}",
+            "stderr": e.stderr or "",
+        }
+
+
+def _download_checkpoint(
+    *,
+    hf_repo: str,
+    hf_subfolder: str | None,
+    hf_local_dir: str | None,
+    hf_token: str | None,
+    force: bool,
+) -> dict[str, Any]:
+    """Download a HuggingFace checkpoint via ``huggingface_hub.snapshot_download``.
+
+    Idempotent: when ``local_dir`` already exists and is non-empty AND
+    ``force=False``, returns success without touching the network. Pass
+    ``force=True`` to refresh.
+
+    HF token resolution order:
+        1. Explicit ``hf_token`` kwarg.
+        2. ``HF_TOKEN`` env var (canonical, what ``huggingface_hub`` reads).
+        3. ``HUGGING_FACE_HUB_TOKEN`` env var (legacy alias).
+        4. None - downloads continue for ungated repos; gated ones surface
+           a clear ``snapshot_download`` error.
+    """
+    local_dir = Path(hf_local_dir).expanduser() if hf_local_dir else _checkpoints_dir() / hf_repo.replace("/", "__")
+
+    if not force and local_dir.is_dir() and any(local_dir.iterdir()):
+        return {
+            "status": "success",
+            "hf_repo": hf_repo,
+            "hf_subfolder": hf_subfolder,
+            "local_dir": str(local_dir),
+            "skipped": True,
+            "message": f"Checkpoint already at {local_dir}; skipping download (use force=True to refresh)",
+        }
+
+    token = hf_token or os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
+
+    try:
+        hub = require_optional(
+            "huggingface_hub",
+            pip_install="huggingface_hub",
+            purpose="downloading GR00T checkpoints",
+        )
+    except ImportError as e:
+        return {"status": "error", "message": str(e)}
+
+    local_dir.mkdir(parents=True, exist_ok=True)
+    allow_patterns = [f"{hf_subfolder}/*"] if hf_subfolder else None
+
+    try:
+        hub.snapshot_download(  # type: ignore[attr-defined]
+            repo_id=hf_repo,
+            local_dir=str(local_dir),
+            allow_patterns=allow_patterns,
+            token=token,
+        )
+    except Exception as e:  # noqa: BLE001 - HF errors are opaque + varied
+        return {"status": "error", "message": f"Failed to download {hf_repo!r}: {e}"}
+
+    return {
+        "status": "success",
+        "hf_repo": hf_repo,
+        "hf_subfolder": hf_subfolder,
+        "local_dir": str(local_dir),
+        "skipped": False,
+        "message": f"Downloaded {hf_repo}{('/' + hf_subfolder) if hf_subfolder else ''} → {local_dir}",
+    }
+
+
+def _start_container(
+    *,
+    image_name: str,
+    container_name: str | None,
+    port: int,
+    volumes: dict[str, str] | None,
+    hf_token: str | None,
+    container_command: str,
+    hf_local_dir: str | None,
+    force: bool,
+) -> dict[str, Any]:
+    """``docker run -d`` the GR00T container so subsequent ``start`` actions can
+    ``docker exec`` into it.
+
+    Idempotent: when a container with ``container_name`` is already
+    running, returns success without touching docker. When it exists but
+    is stopped, ``force=True`` removes + recreates it (otherwise returns
+    an error that names the recovery flag).
+    """
+    name = container_name or "gr00t"
+    state = _container_state(name)
+    if state == "running" and not force:
+        return {
+            "status": "success",
+            "container_name": name,
+            "image_name": image_name,
+            "state": state,
+            "skipped": True,
+            "message": f"Container {name!r} already running; skipping (use force=True to recreate)",
+        }
+    if state not in ("absent", "running") and not force:
+        return {
+            "status": "error",
+            "message": (f"Container {name!r} exists in state {state!r}; pass force=True to remove + recreate"),
+        }
+    if state != "absent":
+        # force=True OR running-but-force-set: remove first.
+        _remove_container(name=name, remove_volumes=False)
+
+    # Build the docker-run argv.
+    cmd: list[str] = [
+        "docker",
+        "run",
+        "-d",
+        "--gpus",
+        "all",
+        "--ipc=host",
+        "--name",
+        name,
+        "-p",
+        f"{port}:{port}",
+    ]
+
+    # Default volume layout: mount the checkpoint dir into /data/checkpoints
+    # and the host's HF cache so `huggingface_hub` reuses already-downloaded
+    # snapshots. Override with explicit ``volumes={...}`` to customise.
+    effective_volumes = dict(volumes) if volumes is not None else {}
+    if not volumes:
+        if hf_local_dir:
+            effective_volumes[str(Path(hf_local_dir).expanduser())] = "/data/checkpoints"
+        else:
+            effective_volumes[str(_checkpoints_dir())] = "/data/checkpoints"
+        hf_cache = os.environ.get("HF_HOME") or os.path.expanduser("~/.cache/huggingface")
+        effective_volumes[hf_cache] = "/root/.cache/huggingface"
+
+    for host_path, container_path in effective_volumes.items():
+        cmd.extend(["-v", f"{host_path}:{container_path}"])
+
+    token = hf_token or os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
+    if token:
+        cmd.extend(["-e", f"HF_TOKEN={token}"])
+
+    cmd.append(image_name)
+    # Split on whitespace to support both string + list-style commands while
+    # keeping the simple "tail -f /dev/null" default working.
+    if container_command:
+        cmd.extend(container_command.split())
+
+    try:
+        subprocess.run(cmd, capture_output=True, text=True, check=True)
+    except subprocess.CalledProcessError as e:
+        return {"status": "error", "message": f"docker run failed: {e.stderr or e}"}
+
+    return {
+        "status": "success",
+        "container_name": name,
+        "image_name": image_name,
+        "port": port,
+        "volumes": effective_volumes,
+        "skipped": False,
+        "message": f"Started container {name!r} from {image_name!r}",
+    }
+
+
+def _remove_container(*, name: str, remove_volumes: bool) -> dict[str, Any]:
+    """``docker rm -f`` the container; optionally also remove its volumes.
+
+    Tolerant of missing containers - returns success with ``skipped=True``
+    when the name is unknown so ``lifecycle="teardown"`` is safe to call
+    multiple times.
+    """
+    state = _container_state(name)
+    if state == "absent":
+        return {
+            "status": "success",
+            "container_name": name,
+            "skipped": True,
+            "message": f"Container {name!r} not present; nothing to remove",
+        }
+
+    cmd = ["docker", "rm", "-f"]
+    if remove_volumes:
+        cmd.append("-v")
+    cmd.append(name)
+
+    try:
+        subprocess.run(cmd, capture_output=True, text=True, check=True)
+    except subprocess.CalledProcessError as e:
+        return {"status": "error", "message": f"docker rm failed: {e.stderr or e}"}
+
+    return {
+        "status": "success",
+        "container_name": name,
+        "skipped": False,
+        "remove_volumes": remove_volumes,
+        "message": f"Removed container {name!r}" + (" (with volumes)" if remove_volumes else ""),
+    }
+
+
+def _lifecycle(
+    *,
+    phase: str,
+    # build_image kwargs
+    repo_url: str,
+    repo_tag: str,
+    source_dir: str | None,
+    image_name: str,
+    # download_checkpoint kwargs
+    hf_repo: str | None,
+    hf_subfolder: str | None,
+    hf_local_dir: str | None,
+    hf_token: str | None,
+    # start_container kwargs
+    container_name: str | None,
+    volumes: dict[str, str] | None,
+    container_command: str,
+    # teardown
+    remove_volumes: bool,
+    # shared
+    force: bool,
+    # start kwargs (for phase="full" tail)
+    checkpoint_path: str | None,
+    policy_name: str | None,
+    port: int,
+    data_config: str,
+    embodiment_tag: str,
+    denoising_steps: int,
+    host: str,
+    timeout: int,
+    use_tensorrt: bool,
+    trt_engine_path: str,
+    vit_dtype: str,
+    llm_dtype: str,
+    dit_dtype: str,
+    http_server: bool,
+    api_token: str | None,
+    protocol: str,
+    use_sim_policy_wrapper: bool,
+) -> dict[str, Any]:
+    """Orchestrate the four-step setup or tear down a previously-started container.
+
+    ``phase="full"``: ``build_image`` → ``download_checkpoint`` →
+    ``start_container`` → ``start`` → wait-for-port. Each sub-step is
+    idempotent so re-runs after a crash resume from the failed step.
+
+    ``phase="teardown"``: ``_remove_container`` (with optional volume
+    removal). The image and downloaded checkpoint are preserved -
+    teardown is intentionally cheap to re-run.
+    """
+    if phase not in ("full", "teardown"):
+        return {"status": "error", "message": f"Unknown lifecycle phase {phase!r}. Valid: ['full', 'teardown']"}
+
+    steps: list[dict[str, Any]] = []
+
+    if phase == "teardown":
+        rm_result = _remove_container(name=container_name or "gr00t", remove_volumes=remove_volumes)
+        steps.append({"step": "remove_container", "result": rm_result})
+        return {
+            "status": rm_result["status"],
+            "phase": phase,
+            "steps": steps,
+            "message": rm_result["message"],
+        }
+
+    # phase == "full"
+    if hf_repo is None:
+        return {
+            "status": "error",
+            "message": "lifecycle='full' requires 'hf_repo' so the checkpoint can be downloaded",
+        }
+
+    build_result = _build_image(
+        repo_url=repo_url,
+        repo_tag=repo_tag,
+        source_dir=source_dir,
+        image_name=image_name,
+        force=force,
+    )
+    steps.append({"step": "build_image", "result": build_result})
+    if build_result["status"] != "success":
+        return {"status": "error", "phase": phase, "steps": steps, "message": "lifecycle aborted: build_image failed"}
+
+    download_result = _download_checkpoint(
+        hf_repo=hf_repo,
+        hf_subfolder=hf_subfolder,
+        hf_local_dir=hf_local_dir,
+        hf_token=hf_token,
+        force=force,
+    )
+    steps.append({"step": "download_checkpoint", "result": download_result})
+    if download_result["status"] != "success":
+        return {
+            "status": "error",
+            "phase": phase,
+            "steps": steps,
+            "message": "lifecycle aborted: download_checkpoint failed",
+        }
+
+    # The container needs to mount the just-downloaded checkpoint. If the
+    # caller didn't pre-resolve ``hf_local_dir``, propagate the path the
+    # download step actually used so the container can see the files.
+    resolved_local_dir = download_result.get("local_dir") or hf_local_dir
+
+    container_result = _start_container(
+        image_name=image_name,
+        container_name=container_name,
+        port=port,
+        volumes=volumes,
+        hf_token=hf_token,
+        container_command=container_command,
+        hf_local_dir=resolved_local_dir,
+        force=force,
+    )
+    steps.append({"step": "start_container", "result": container_result})
+    if container_result["status"] != "success":
+        return {
+            "status": "error",
+            "phase": phase,
+            "steps": steps,
+            "message": "lifecycle aborted: start_container failed",
+        }
+
+    # The inference service expects to see the checkpoint mounted under
+    # /data/checkpoints (the default volume mapping). Translate the host
+    # path the user / download step gave us into the in-container path.
+    mounted_checkpoint = checkpoint_path
+    if mounted_checkpoint is None and hf_subfolder:
+        mounted_checkpoint = f"/data/checkpoints/{hf_subfolder}"
+    if mounted_checkpoint is None:
+        return {
+            "status": "error",
+            "phase": phase,
+            "steps": steps,
+            "message": (
+                "lifecycle='full' needs either 'checkpoint_path' (in-container path) or "
+                "'hf_subfolder' (auto-resolved to /data/checkpoints/<subfolder>) so the inference "
+                "service knows where to load the model from"
+            ),
+        }
+
+    start_result = _start_service(
+        checkpoint_path=mounted_checkpoint,
+        port=port,
+        data_config=data_config,
+        embodiment_tag=embodiment_tag,
+        denoising_steps=denoising_steps,
+        host=host,
+        container_name=container_result["container_name"],
+        policy_name=policy_name,
+        timeout=timeout,
+        use_tensorrt=use_tensorrt,
+        trt_engine_path=trt_engine_path,
+        vit_dtype=vit_dtype,
+        llm_dtype=llm_dtype,
+        dit_dtype=dit_dtype,
+        http_server=http_server,
+        api_token=api_token,
+        protocol=protocol,
+        use_sim_policy_wrapper=use_sim_policy_wrapper,
+    )
+    steps.append({"step": "start", "result": start_result})
+
+    return {
+        "status": start_result["status"],
+        "phase": phase,
+        "steps": steps,
+        "message": start_result.get("message", "lifecycle complete"),
+    }
 
 
 if __name__ == "__main__":

--- a/tests/tools/test_gr00t_inference.py
+++ b/tests/tools/test_gr00t_inference.py
@@ -21,6 +21,9 @@ Coverage:
 
 from __future__ import annotations
 
+import os
+import subprocess
+from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
@@ -277,3 +280,643 @@ class TestSignatureBackCompat:
             return
         cmd_default = _build_inference_command(**_common_kwargs(protocol="n1.5"))
         assert "/opt/Isaac-GR00T/scripts/inference_service.py" in cmd_default
+
+
+# Container lifecycle (#148-F3 wider)
+#
+# Each new action is idempotent and uses subprocess.run to talk to docker /
+# git. Tests mock subprocess.run + huggingface_hub so nothing actually
+# runs - we assert on the captured argv and on the structured response
+# dict's idempotency markers (``skipped`` true/false).
+
+
+from unittest.mock import MagicMock  # noqa: E402
+
+from strands_robots.tools.gr00t_inference import (  # noqa: E402
+    _build_image,
+    _container_state,
+    _download_checkpoint,
+    _image_exists,
+    _lifecycle,
+    _remove_container,
+    _start_container,
+)
+
+# Helpers
+
+
+def _docker_inspect_returncode(rc: int):
+    """Return a MagicMock that mimics ``subprocess.run`` returning ``rc``."""
+    m = MagicMock()
+    m.returncode = rc
+    m.stdout = "running\n" if rc == 0 else ""
+    m.stderr = ""
+    return m
+
+
+def _patch_subprocess_run(side_effect=None):
+    """Patch the module-level ``subprocess.run`` used by the lifecycle helpers."""
+    return patch("strands_robots.tools.gr00t_inference.subprocess.run", side_effect=side_effect)
+
+
+# _image_exists / _container_state primitives
+
+
+class TestImageAndContainerProbes:
+    def test_image_exists_returns_true_on_zero_rc(self):
+        with _patch_subprocess_run(side_effect=lambda *a, **kw: _docker_inspect_returncode(0)):
+            assert _image_exists("gr00t:latest") is True
+
+    def test_image_exists_returns_false_on_nonzero_rc(self):
+        with _patch_subprocess_run(side_effect=lambda *a, **kw: _docker_inspect_returncode(1)):
+            assert _image_exists("gr00t:latest") is False
+
+    def test_image_exists_handles_missing_docker_binary(self):
+        with _patch_subprocess_run(side_effect=FileNotFoundError("docker")):
+            assert _image_exists("gr00t:latest") is False
+
+    def test_container_state_running(self):
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = "running\n"
+        with _patch_subprocess_run(side_effect=lambda *a, **kw: result):
+            assert _container_state("gr00t") == "running"
+
+    def test_container_state_absent(self):
+        result = MagicMock()
+        result.returncode = 1
+        result.stdout = ""
+        with _patch_subprocess_run(side_effect=lambda *a, **kw: result):
+            assert _container_state("ghost") == "absent"
+
+
+# build_image
+
+
+class TestBuildImage:
+    def test_skips_when_image_exists_and_not_force(self):
+        """Idempotency: existing image short-circuits to success without
+        touching git or docker."""
+        with patch(
+            "strands_robots.tools.gr00t_inference._image_exists",
+            return_value=True,
+        ):
+            result = _build_image(
+                repo_url="https://example/x",
+                repo_tag="n1.7-release",
+                source_dir=None,
+                image_name="gr00t:latest",
+                force=False,
+            )
+        assert result["status"] == "success"
+        assert result["skipped"] is True
+        assert "already exists" in result["message"]
+
+    def test_force_rebuilds_even_when_image_exists(self, tmp_path):
+        """force=True must run the full clone + build path regardless."""
+        runs: list[list[str]] = []
+
+        def fake_run(cmd, *a, **kw):
+            runs.append(list(cmd))
+            return MagicMock(stdout="", stderr="", returncode=0)
+
+        with patch("strands_robots.tools.gr00t_inference._image_exists", return_value=True):
+            with patch("strands_robots.tools.gr00t_inference.subprocess.run", side_effect=fake_run):
+                # The build script existence check uses real Path.is_file, so
+                # plant a fake build.sh in the source_dir.
+                src = tmp_path / "Isaac-GR00T"
+                (src / "docker").mkdir(parents=True)
+                (src / "docker" / "build.sh").write_text("#!/bin/bash\necho ok")
+                (src / ".git").mkdir()  # so the update branch is taken
+                _build_image(
+                    repo_url="https://example/x",
+                    repo_tag="n1.7-release",
+                    source_dir=str(src),
+                    image_name="gr00t:latest",
+                    force=True,
+                )
+
+        # Verify a build.sh invocation was attempted.
+        assert any("bash" in cmd[0] and "build.sh" in cmd[1] for cmd in runs)
+
+    def test_clone_path_used_when_dest_missing(self, tmp_path):
+        runs: list[list[str]] = []
+
+        def fake_run(cmd, *a, **kw):
+            runs.append(list(cmd))
+            # Simulate the clone creating dest/.git and dest/docker/build.sh
+            # so the build step finds them.
+            if cmd[:2] == ["git", "clone"]:
+                dest = Path(cmd[-1])
+                (dest / "docker").mkdir(parents=True, exist_ok=True)
+                (dest / "docker" / "build.sh").write_text("#!/bin/bash\necho ok")
+                (dest / ".git").mkdir(exist_ok=True)
+            return MagicMock(stdout="", stderr="", returncode=0)
+
+        src = tmp_path / "fresh-clone"
+        with patch("strands_robots.tools.gr00t_inference._image_exists", return_value=False):
+            with patch("strands_robots.tools.gr00t_inference.subprocess.run", side_effect=fake_run):
+                result = _build_image(
+                    repo_url="https://example/x",
+                    repo_tag="n1.7-release",
+                    source_dir=str(src),
+                    image_name="gr00t:latest",
+                    force=False,
+                )
+        assert result["status"] == "success"
+        # Must include a `git clone --depth 1 --branch <tag>` invocation.
+        assert any("clone" in cmd and "--branch" in cmd and "n1.7-release" in cmd for cmd in runs)
+
+    def test_build_failure_propagates_stderr(self, tmp_path):
+        src = tmp_path / "Isaac-GR00T"
+        (src / "docker").mkdir(parents=True)
+        (src / "docker" / "build.sh").write_text("")
+        (src / ".git").mkdir()
+
+        def fake_run(cmd, *a, **kw):
+            if "build.sh" in " ".join(cmd):
+                raise subprocess.CalledProcessError(1, cmd, stderr="boom")
+            return MagicMock(stdout="", stderr="", returncode=0)
+
+        with patch("strands_robots.tools.gr00t_inference._image_exists", return_value=False):
+            with patch("strands_robots.tools.gr00t_inference.subprocess.run", side_effect=fake_run):
+                result = _build_image(
+                    repo_url="https://example/x",
+                    repo_tag="n1.7-release",
+                    source_dir=str(src),
+                    image_name="gr00t:latest",
+                    force=False,
+                )
+        assert result["status"] == "error"
+        assert "boom" in result["message"]
+
+
+# download_checkpoint
+
+
+class TestDownloadCheckpoint:
+    def test_skips_when_local_dir_populated_and_not_force(self, tmp_path):
+        local = tmp_path / "ckpt"
+        local.mkdir()
+        (local / "config.json").write_text("{}")  # populated
+        result = _download_checkpoint(
+            hf_repo="nvidia/foo",
+            hf_subfolder=None,
+            hf_local_dir=str(local),
+            hf_token=None,
+            force=False,
+        )
+        assert result["status"] == "success"
+        assert result["skipped"] is True
+
+    def test_force_redownloads(self, tmp_path):
+        local = tmp_path / "ckpt"
+        local.mkdir()
+        (local / "config.json").write_text("{}")
+
+        fake_hub = MagicMock()
+        with patch("strands_robots.tools.gr00t_inference.require_optional", return_value=fake_hub):
+            result = _download_checkpoint(
+                hf_repo="nvidia/foo",
+                hf_subfolder="bar",
+                hf_local_dir=str(local),
+                hf_token=None,
+                force=True,
+            )
+        assert result["status"] == "success"
+        assert result["skipped"] is False
+        fake_hub.snapshot_download.assert_called_once()
+        # allow_patterns should be ['bar/*'] when subfolder set.
+        kwargs = fake_hub.snapshot_download.call_args.kwargs
+        assert kwargs["allow_patterns"] == ["bar/*"]
+        assert kwargs["repo_id"] == "nvidia/foo"
+
+    def test_token_resolution_from_kwarg(self, tmp_path):
+        fake_hub = MagicMock()
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("HF_TOKEN", None)
+            os.environ.pop("HUGGING_FACE_HUB_TOKEN", None)
+            with patch(
+                "strands_robots.tools.gr00t_inference.require_optional",
+                return_value=fake_hub,
+            ):
+                _download_checkpoint(
+                    hf_repo="r",
+                    hf_subfolder=None,
+                    hf_local_dir=str(tmp_path / "new"),
+                    hf_token="explicit-token",
+                    force=False,
+                )
+        kwargs = fake_hub.snapshot_download.call_args.kwargs
+        assert kwargs["token"] == "explicit-token"
+
+    def test_token_falls_back_to_env(self, tmp_path):
+        fake_hub = MagicMock()
+        with patch.dict(os.environ, {"HF_TOKEN": "env-token"}, clear=False):
+            with patch(
+                "strands_robots.tools.gr00t_inference.require_optional",
+                return_value=fake_hub,
+            ):
+                _download_checkpoint(
+                    hf_repo="r",
+                    hf_subfolder=None,
+                    hf_local_dir=str(tmp_path / "new"),
+                    hf_token=None,
+                    force=False,
+                )
+        assert fake_hub.snapshot_download.call_args.kwargs["token"] == "env-token"
+
+    def test_huggingface_hub_missing_returns_structured_error(self, tmp_path):
+        with patch(
+            "strands_robots.tools.gr00t_inference.require_optional",
+            side_effect=ImportError("'huggingface_hub' is required"),
+        ):
+            result = _download_checkpoint(
+                hf_repo="r",
+                hf_subfolder=None,
+                hf_local_dir=str(tmp_path / "new"),
+                hf_token=None,
+                force=False,
+            )
+        assert result["status"] == "error"
+        assert "huggingface_hub" in result["message"]
+
+
+# start_container
+
+
+class TestStartContainer:
+    def test_skips_when_already_running_and_not_force(self):
+        with patch(
+            "strands_robots.tools.gr00t_inference._container_state",
+            return_value="running",
+        ):
+            result = _start_container(
+                image_name="gr00t:latest",
+                container_name="gr00t",
+                port=8000,
+                volumes=None,
+                hf_token=None,
+                container_command="tail -f /dev/null",
+                hf_local_dir=None,
+                force=False,
+            )
+        assert result["status"] == "success"
+        assert result["skipped"] is True
+
+    def test_recreates_when_force(self):
+        runs: list[list[str]] = []
+
+        def fake_run(cmd, *a, **kw):
+            runs.append(list(cmd))
+            return MagicMock(stdout="", stderr="", returncode=0)
+
+        with patch(
+            "strands_robots.tools.gr00t_inference._container_state",
+            side_effect=["running", "running", "absent"],  # first probe → running
+        ):
+            with patch("strands_robots.tools.gr00t_inference.subprocess.run", side_effect=fake_run):
+                _start_container(
+                    image_name="gr00t:latest",
+                    container_name="gr00t",
+                    port=8000,
+                    volumes=None,
+                    hf_token=None,
+                    container_command="tail -f /dev/null",
+                    hf_local_dir=None,
+                    force=True,
+                )
+        # Must have issued a `docker rm -f gr00t` and then `docker run -d ... gr00t:latest tail -f /dev/null`.
+        assert any(c[:3] == ["docker", "rm", "-f"] for c in runs)
+        run_cmds = [c for c in runs if c[:2] == ["docker", "run"]]
+        assert run_cmds
+        run_cmd = run_cmds[0]
+        assert "--gpus" in run_cmd and "all" in run_cmd
+        assert "--ipc=host" in run_cmd
+        assert "--name" in run_cmd and "gr00t" in run_cmd
+        assert "8000:8000" in run_cmd
+
+    def test_volumes_default_includes_checkpoints_and_hf_cache(self):
+        runs: list[list[str]] = []
+
+        def fake_run(cmd, *a, **kw):
+            runs.append(list(cmd))
+            return MagicMock(stdout="", stderr="", returncode=0)
+
+        with patch(
+            "strands_robots.tools.gr00t_inference._container_state",
+            return_value="absent",
+        ):
+            with patch("strands_robots.tools.gr00t_inference.subprocess.run", side_effect=fake_run):
+                result = _start_container(
+                    image_name="gr00t:latest",
+                    container_name="gr00t",
+                    port=8000,
+                    volumes=None,
+                    hf_token=None,
+                    container_command="tail -f /dev/null",
+                    hf_local_dir="/data/cp",
+                    force=False,
+                )
+        assert result["status"] == "success"
+        # Default volumes include the checkpoint mount and the HF cache mount.
+        argv = next(c for c in runs if c[:2] == ["docker", "run"])
+        joined = " ".join(argv)
+        assert "/data/cp:/data/checkpoints" in joined
+        assert "huggingface" in joined  # HF cache path
+
+    def test_token_propagated_as_env(self):
+        runs: list[list[str]] = []
+
+        def fake_run(cmd, *a, **kw):
+            runs.append(list(cmd))
+            return MagicMock(stdout="", stderr="", returncode=0)
+
+        with patch(
+            "strands_robots.tools.gr00t_inference._container_state",
+            return_value="absent",
+        ):
+            with patch("strands_robots.tools.gr00t_inference.subprocess.run", side_effect=fake_run):
+                _start_container(
+                    image_name="gr00t:latest",
+                    container_name="gr00t",
+                    port=8000,
+                    volumes={"/cp": "/data/checkpoints"},
+                    hf_token="abc123",
+                    container_command="tail -f /dev/null",
+                    hf_local_dir=None,
+                    force=False,
+                )
+        argv = next(c for c in runs if c[:2] == ["docker", "run"])
+        # -e HF_TOKEN=abc123 must appear in the run command.
+        assert any(e == "HF_TOKEN=abc123" for e in argv)
+
+    def test_unhealthy_state_without_force_errors(self):
+        with patch(
+            "strands_robots.tools.gr00t_inference._container_state",
+            return_value="exited",
+        ):
+            result = _start_container(
+                image_name="gr00t:latest",
+                container_name="gr00t",
+                port=8000,
+                volumes=None,
+                hf_token=None,
+                container_command="tail -f /dev/null",
+                hf_local_dir=None,
+                force=False,
+            )
+        assert result["status"] == "error"
+        assert "force=True" in result["message"]
+
+
+# remove_container
+
+
+class TestRemoveContainer:
+    def test_absent_is_idempotent_success(self):
+        with patch(
+            "strands_robots.tools.gr00t_inference._container_state",
+            return_value="absent",
+        ):
+            result = _remove_container(name="ghost", remove_volumes=False)
+        assert result["status"] == "success"
+        assert result["skipped"] is True
+
+    def test_running_container_removed(self):
+        runs: list[list[str]] = []
+
+        def fake_run(cmd, *a, **kw):
+            runs.append(list(cmd))
+            return MagicMock(stdout="", stderr="", returncode=0)
+
+        with patch(
+            "strands_robots.tools.gr00t_inference._container_state",
+            return_value="running",
+        ):
+            with patch("strands_robots.tools.gr00t_inference.subprocess.run", side_effect=fake_run):
+                result = _remove_container(name="gr00t", remove_volumes=True)
+        assert result["status"] == "success"
+        assert ["docker", "rm", "-f", "-v", "gr00t"] in runs
+
+
+# lifecycle
+
+
+class TestLifecycle:
+    def test_unknown_phase_errors(self):
+        # Going through the dispatcher because lifecycle="weird" should be
+        # rejected by _lifecycle, not by the @tool wrapper.
+        result = _lifecycle(
+            phase="weird",
+            **_lifecycle_default_kwargs(),
+        )
+        assert result["status"] == "error"
+        assert "weird" in result["message"]
+
+    def test_full_requires_hf_repo(self):
+        result = _lifecycle(
+            phase="full",
+            **{**_lifecycle_default_kwargs(), "hf_repo": None},
+        )
+        assert result["status"] == "error"
+        assert "hf_repo" in result["message"]
+
+    def test_full_chains_all_steps_in_order(self, tmp_path):
+        """phase='full' must call build → download → start_container → start in order."""
+        order: list[str] = []
+
+        def fake_build(**kw):
+            order.append("build_image")
+            return {"status": "success", "image_name": kw["image_name"], "skipped": False}
+
+        def fake_download(**kw):
+            order.append("download_checkpoint")
+            return {
+                "status": "success",
+                "local_dir": str(tmp_path / "cp"),
+                "skipped": False,
+                "hf_repo": kw["hf_repo"],
+            }
+
+        def fake_start_container(**kw):
+            order.append("start_container")
+            return {
+                "status": "success",
+                "container_name": kw["container_name"] or "gr00t",
+                "skipped": False,
+            }
+
+        def fake_start_service(**kw):
+            order.append("start")
+            return {"status": "success", "message": "service up"}
+
+        with patch("strands_robots.tools.gr00t_inference._build_image", side_effect=fake_build):
+            with patch("strands_robots.tools.gr00t_inference._download_checkpoint", side_effect=fake_download):
+                with patch(
+                    "strands_robots.tools.gr00t_inference._start_container",
+                    side_effect=fake_start_container,
+                ):
+                    with patch(
+                        "strands_robots.tools.gr00t_inference._start_service",
+                        side_effect=fake_start_service,
+                    ):
+                        result = _lifecycle(
+                            phase="full",
+                            **{
+                                **_lifecycle_default_kwargs(),
+                                "hf_repo": "nvidia/foo",
+                                "hf_subfolder": "libero_spatial",
+                            },
+                        )
+        assert order == ["build_image", "download_checkpoint", "start_container", "start"]
+        assert result["status"] == "success"
+        # Steps array must include each sub-step's result for the agent to inspect.
+        assert [s["step"] for s in result["steps"]] == [
+            "build_image",
+            "download_checkpoint",
+            "start_container",
+            "start",
+        ]
+
+    def test_full_aborts_on_build_failure(self):
+        with patch(
+            "strands_robots.tools.gr00t_inference._build_image",
+            return_value={"status": "error", "message": "no docker"},
+        ):
+            result = _lifecycle(
+                phase="full",
+                **{**_lifecycle_default_kwargs(), "hf_repo": "nvidia/foo"},
+            )
+        assert result["status"] == "error"
+        assert "build_image failed" in result["message"]
+        # Only the failing step should be in the trail; downstream not attempted.
+        assert [s["step"] for s in result["steps"]] == ["build_image"]
+
+    def test_full_auto_resolves_in_container_checkpoint_path_from_subfolder(self, tmp_path):
+        captured: dict[str, Any] = {}
+
+        def fake_start_service(**kw):
+            captured.update(kw)
+            return {"status": "success", "message": "ok"}
+
+        with patch(
+            "strands_robots.tools.gr00t_inference._build_image",
+            return_value={"status": "success", "image_name": "x", "skipped": True},
+        ):
+            with patch(
+                "strands_robots.tools.gr00t_inference._download_checkpoint",
+                return_value={
+                    "status": "success",
+                    "local_dir": str(tmp_path / "cp"),
+                    "skipped": False,
+                    "hf_repo": "nvidia/foo",
+                },
+            ):
+                with patch(
+                    "strands_robots.tools.gr00t_inference._start_container",
+                    return_value={"status": "success", "container_name": "gr00t", "skipped": False},
+                ):
+                    with patch(
+                        "strands_robots.tools.gr00t_inference._start_service",
+                        side_effect=fake_start_service,
+                    ):
+                        _lifecycle(
+                            phase="full",
+                            **{
+                                **_lifecycle_default_kwargs(),
+                                "hf_repo": "nvidia/foo",
+                                "hf_subfolder": "libero_spatial",
+                                "checkpoint_path": None,  # let the lifecycle resolve it
+                            },
+                        )
+        assert captured["checkpoint_path"] == "/data/checkpoints/libero_spatial"
+
+    def test_teardown_removes_container(self):
+        with patch(
+            "strands_robots.tools.gr00t_inference._remove_container",
+            return_value={"status": "success", "skipped": False, "message": "removed"},
+        ) as mock_rm:
+            result = _lifecycle(
+                phase="teardown",
+                **{**_lifecycle_default_kwargs(), "container_name": "gr00t", "remove_volumes": True},
+            )
+        assert result["status"] == "success"
+        mock_rm.assert_called_once_with(name="gr00t", remove_volumes=True)
+
+
+def _lifecycle_default_kwargs() -> dict[str, Any]:
+    """Minimal kwargs to invoke _lifecycle in tests."""
+    return {
+        "repo_url": "https://example/x",
+        "repo_tag": "n1.7-release",
+        "source_dir": None,
+        "image_name": "gr00t:latest",
+        "hf_repo": "nvidia/foo",
+        "hf_subfolder": None,
+        "hf_local_dir": None,
+        "hf_token": None,
+        "container_name": None,
+        "volumes": None,
+        "container_command": "tail -f /dev/null",
+        "remove_volumes": False,
+        "force": False,
+        "checkpoint_path": "/data/checkpoints/m",
+        "policy_name": None,
+        "port": 8000,
+        "data_config": "libero_panda",
+        "embodiment_tag": "libero_sim",
+        "denoising_steps": 4,
+        "host": "0.0.0.0",
+        "timeout": 1,
+        "use_tensorrt": False,
+        "trt_engine_path": "x",
+        "vit_dtype": "fp8",
+        "llm_dtype": "nvfp4",
+        "dit_dtype": "fp8",
+        "http_server": False,
+        "api_token": None,
+        "protocol": "n1.7",
+        "use_sim_policy_wrapper": True,
+    }
+
+
+# Top-level dispatcher reaches the new actions
+
+
+class TestActionDispatch:
+    """Verify the @tool wrapper routes the new ``action=`` values correctly."""
+
+    def test_build_image_dispatched(self):
+        with patch(
+            "strands_robots.tools.gr00t_inference._build_image",
+            return_value={"status": "success", "skipped": True, "message": "ok"},
+        ) as mock:
+            result = gr00t_inference(action="build_image", image_name="gr00t:test")
+        assert result["status"] == "success"
+        mock.assert_called_once()
+
+    def test_download_checkpoint_requires_hf_repo(self):
+        result = gr00t_inference(action="download_checkpoint")
+        assert result["status"] == "error"
+        assert "hf_repo" in result["message"]
+
+    def test_start_container_dispatched(self):
+        with patch(
+            "strands_robots.tools.gr00t_inference._start_container",
+            return_value={"status": "success", "skipped": True, "message": "ok"},
+        ) as mock:
+            result = gr00t_inference(action="start_container", port=8000)
+        assert result["status"] == "success"
+        mock.assert_called_once()
+
+    def test_lifecycle_dispatched(self):
+        with patch(
+            "strands_robots.tools.gr00t_inference._lifecycle",
+            return_value={"status": "success", "phase": "full", "steps": [], "message": "ok"},
+        ) as mock:
+            gr00t_inference(action="lifecycle", lifecycle="full", hf_repo="nvidia/foo")
+        mock.assert_called_once()
+        # The wrapper must forward the lifecycle phase as `phase=`.
+        kwargs = mock.call_args.kwargs
+        assert kwargs["phase"] == "full"


### PR DESCRIPTION
## Summary

Implements the **wider preferred scope** of Failure 3 from #148 (added in the issue's recent update). Grows ``gr00t_inference`` from "exec into an already-running container" to **full container lifecycle**, so an LLM driving the AgentTool can fully orchestrate a GR00T eval from a single prompt rather than the user manually running four shell commands first (clone Isaac-GR00T + ``docker build`` + ``hf download`` + ``docker run``).

> **Stacked on [#150](https://github.com/strands-labs/robots/pull/150)** (the F3 narrow PR). #150 must merge first; once it does, this PR auto-rebases onto main. The diff below includes #150's commits until then.

## Why the wider scope

Per the updated issue:

> The whole point of ``gr00t_inference`` being a Strands ``AgentTool`` (not a plain Python helper) is that an LLM can drive it from natural language. With only ``start`` / ``stop``, an agent given the prompt *\"Run the LIBERO benchmark against ``nvidia/GR00T-N1.7-LIBERO/libero_spatial``\"* can't actually do it — the four pre-``start`` steps are still manual. With ``lifecycle=\"full\"``, a single agent prompt fully orchestrates the eval.

## What's new

### Four new ``action=`` values

| Action | Idempotent step it owns |
|---|---|
| ``build_image`` | Clone ``NVIDIA/Isaac-GR00T@<repo_tag>`` into ``source_dir``, run ``bash docker/build.sh``. Skips when ``image_name`` already exists. ``force=True`` to rebuild. Uses ``git fetch+checkout`` for already-cloned repos, full clone otherwise. |
| ``download_checkpoint`` | ``huggingface_hub.snapshot_download(repo_id, allow_patterns=['<subfolder>/*'], local_dir, token)``. Skips when ``local_dir`` populated. HF token resolution: explicit kwarg → ``HF_TOKEN`` → ``HUGGING_FACE_HUB_TOKEN`` → None. |
| ``start_container`` | ``docker run -d --gpus all --ipc=host`` with port mapping, default volume mounts (``hf_local_dir`` → ``/data/checkpoints`` + ``~/.cache/huggingface``), ``HF_TOKEN`` env passthrough, and ``container_command`` (default ``tail -f /dev/null``). Skips running container by name; ``force=True`` removes + recreates. |
| ``lifecycle`` | One-call orchestration. ``lifecycle=\"full\"`` chains all four + ``start`` + wait-for-port. ``lifecycle=\"teardown\"`` rm's the container (and volumes when ``remove_volumes=True``). |

### New signature parameters

```python
repo_url: str = \"https://github.com/NVIDIA/Isaac-GR00T\"
repo_tag: str = \"n1.7-release\"
source_dir: str | None = None  # → $STRANDS_BASE_DIR/Isaac-GR00T
image_name: str = \"gr00t:latest\"
hf_repo: str | None = None
hf_subfolder: str | None = None  # e.g. \"libero_spatial\"
hf_local_dir: str | None = None  # → $STRANDS_BASE_DIR/checkpoints/<...>
hf_token: str | None = None      # → env fallback
volumes: dict[str, str] | None = None
container_command: str = \"tail -f /dev/null\"
lifecycle: str = \"full\"          # \"full\" | \"teardown\"
remove_volumes: bool = False
force: bool = False
```

### Auto-resolution

``lifecycle=\"full\"`` auto-resolves the in-container ``checkpoint_path`` from ``hf_subfolder`` when the caller doesn't provide it (subfolder gets mounted to ``/data/checkpoints/<subfolder>`` by the default volume mapping). So the minimal one-prompt invocation is:

```python
gr00t_inference(
    action=\"lifecycle\",
    lifecycle=\"full\",
    hf_repo=\"nvidia/GR00T-N1.7-LIBERO\",
    hf_subfolder=\"libero_spatial\",
    embodiment_tag=\"libero_sim\",
    protocol=\"n1.7\",
    use_sim_policy_wrapper=True,
    port=8000,
)
```

That single call clones Isaac-GR00T@n1.7-release, builds the docker image, downloads the LIBERO sub-checkpoint from HuggingFace, launches the container, ``docker exec``'s ``run_gr00t_server``, and waits for the port. Idempotent on re-runs — re-running after a partial failure resumes from the failed step.

## Tests

31 new tests in ``tests/tools/test_gr00t_inference.py`` (all 17 prior F3-narrow tests still pass — no signature regressions):

- ``_image_exists`` / ``_container_state`` probes (rc / ``FileNotFoundError`` handling)
- ``build_image``: idempotent skip, force rebuild, fresh-clone path, failure surfaces stderr in the structured error
- ``download_checkpoint``: idempotent skip, force redownload, explicit-kwarg vs env token resolution, missing ``huggingface_hub`` returns structured error
- ``start_container``: skip-when-running, force recreates, default volume layout (checkpoints + HF cache), token propagated as ``-e HF_TOKEN``, unhealthy-state requires ``force=True``
- ``remove_container``: absent is idempotent success, running is rm'd with ``-v`` when ``remove_volumes=True``
- ``lifecycle``: unknown phase rejected, ``full`` requires ``hf_repo``, ``full`` chains all four steps in order, abort-on-build-failure, auto-resolves in-container ``checkpoint_path`` from ``hf_subfolder``, teardown delegates to ``_remove_container``
- Top-level dispatch: each new ``action=`` value reaches the right helper

```bash
hatch run lint    # clean (ruff + mypy)
hatch run pytest tests/  # 1492 passed (no regressions)
```

## Verification (acceptance criterion from the issue)

> An agent given the prompt *\"Run the LIBERO benchmark against ``nvidia/GR00T-N1.7-LIBERO/libero_spatial``\"* can actually do it.

With this PR, the agent can call:

```python
gr00t_inference(action=\"lifecycle\", lifecycle=\"full\",
                hf_repo=\"nvidia/GR00T-N1.7-LIBERO\",
                hf_subfolder=\"libero_spatial\",
                embodiment_tag=\"libero_sim\", protocol=\"n1.7\",
                use_sim_policy_wrapper=True, port=8000)
```

End-to-end LIBERO eval after this PR + #149 (F2) + #151 (F1):

```python
sim.evaluate_benchmark(
    benchmark_name=\"libero-spatial-pick_up_the_red_cube\",
    robot_name=\"panda\",
    policy_provider=\"groot\",
    policy_config={\"host\": \"localhost\", \"port\": 8000,
                   \"data_config\": \"libero_panda\",
                   \"groot_version\": \"n1.7\"},
    n_episodes=1, seed=42,
)
```

## Out of scope

- The ``Failure 1`` (LIBERO scene loading + cameras) follow-up - lands in [#151](https://github.com/strands-labs/robots/pull/151).
- Body-mounted ``robot0_eye_in_hand_image`` cameras require ``Simulation.add_camera`` to support body parenting; tracked separately (see #151's docstring caveat).

Refs #148 (Failure 3 wider). Stacked on #150 (Failure 3 narrow).