### PR TITLE
feat(policies): add MolmoAct2 / allenai recognition in policy registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,20 @@ policy = create_policy(
 
 # Mock policy (for testing)
 policy = create_policy(provider="mock")
+
+# LeRobot policy — direct HuggingFace inference (act / diffusion / smolvla / pi0 / ...)
+policy = create_policy(
+    provider="lerobot_local",
+    pretrained_name_or_path="lerobot/act_aloha_sim",
+)
+
+# MolmoAct2 (Allen AI VLA) — auto-routes to lerobot_local via the registry
+# Requires: pip install "lerobot>=0.6.0" (once huggingface/lerobot#3604 lands)
+policy = create_policy(
+    provider="lerobot_local",
+    pretrained_name_or_path="allenai/MolmoAct2-LIBERO-LeRobot",
+    policy_type="molmoact2",
+)
 ```
 
 ## Project Structure

--- a/strands_robots/registry/policies.json
+++ b/strands_robots/registry/policies.json
@@ -45,7 +45,7 @@
         "lerobot_local": {
             "module": "strands_robots.policies.lerobot_local",
             "class": "LerobotLocalPolicy",
-            "description": "Direct HuggingFace inference (no server)",
+            "description": "Direct HuggingFace inference for LeRobot policies (act, diffusion, smolvla, pi0, molmoact2, ...)",
             "requires": [],
             "config_keys": [
                 "pretrained_name_or_path",
@@ -58,7 +58,11 @@
                 "lerobot"
             ],
             "hf_orgs": [
-                "lerobot"
+                "lerobot",
+                "allenai"
+            ],
+            "model_id_overrides": [
+                "allenai/molmoact"
             ],
             "is_hf_default": true
         }

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -167,6 +167,29 @@ class TestResolvePolicy:
         _, kwargs = resolve_policy("zmq://host:1234", data_config="abc")
         assert kwargs["data_config"] == "abc"
 
+    def test_huggingface_model_id_allenai_routes_to_lerobot_local(self):
+        """allenai/* HF model IDs should resolve to lerobot_local (MolmoAct2 family)."""
+        for model_id in (
+            "allenai/MolmoAct2-LIBERO-LeRobot",
+            "allenai/MolmoAct2-SO100_101",
+            "allenai/MolmoAct2-DROID",
+        ):
+            provider, kwargs = resolve_policy(model_id)
+            assert provider == "lerobot_local", f"'{model_id}' should route to lerobot_local"
+            assert kwargs["pretrained_name_or_path"] == model_id
+
+    def test_huggingface_model_id_override_molmoact_legacy(self):
+        """allenai/MolmoAct-* (legacy v1) should also route via model_id_overrides."""
+        provider, kwargs = resolve_policy("allenai/MolmoAct-7B-D-Pretrain-0812")
+        assert provider == "lerobot_local"
+        assert kwargs["pretrained_name_or_path"] == "allenai/MolmoAct-7B-D-Pretrain-0812"
+
+    def test_policy_type_kwarg_forwarded_for_molmoact2(self):
+        """policy_type should pass through unchanged for explicit type pinning."""
+        provider, kwargs = resolve_policy("allenai/MolmoAct2-LIBERO-LeRobot", policy_type="molmoact2")
+        assert provider == "lerobot_local"
+        assert kwargs["policy_type"] == "molmoact2"
+
     def test_unrecognised_string_falls_back(self):
         """A random string should fall back to lerobot_local."""
         provider, kwargs = resolve_policy("totally_unknown_string_xyz")


### PR DESCRIPTION
## What

Adds first-class registry support in `strands_robots` for the **MolmoAct2** family of vision-language-action policies from Allen AI (https://allenai.org/blog/molmoact2), which is currently being ported into LeRobot in [huggingface/lerobot#3604](https://github.com/huggingface/lerobot/pull/3604).

After this PR (and once huggingface/lerobot#3604 lands and is released), all of the following will work end-to-end through the existing `lerobot_local` provider, with no further code changes on either side:

```python
from strands_robots import create_policy
from strands_robots.registry import resolve_policy

provider, kwargs = resolve_policy("allenai/MolmoAct2-LIBERO-LeRobot")
# → ("lerobot_local", {"pretrained_name_or_path": "allenai/MolmoAct2-LIBERO-LeRobot"})

policy = create_policy(
    provider="lerobot_local",
    pretrained_name_or_path="allenai/MolmoAct2-LIBERO-LeRobot",
    policy_type="molmoact2",
)
```

## Why

The `lerobot_local` provider already auto-detects any LeRobot policy type via:
1. `lerobot.configs.policies.PreTrainedConfig.from_pretrained(...)` (draccus registry)
2. fallback to `lerobot.policies.{type}.modeling_{type}` import (see `strands_robots/policies/lerobot_local/resolution.py`)

This means the **runtime** path works as soon as lerobot ships `molmoact2`. What was missing was the **registry-level recognition** so that:
- `allenai/*` model IDs route to `lerobot_local` (instead of falling through the generic `is_hf_default` path)
- The `allenai/MolmoAct-*` legacy (v1) model family also routes correctly via `model_id_overrides`
- Tests pin the behaviour so a future change to `policies.json` doesn't silently regress it

## Changes

### `strands_robots/registry/policies.json`

```diff
 "lerobot_local": {
     "module": "strands_robots.policies.lerobot_local",
     "class": "LerobotLocalPolicy",
-    "description": "Direct HuggingFace inference (no server)",
+    "description": "Direct HuggingFace inference for LeRobot policies (act, diffusion, smolvla, pi0, molmoact2, ...)",
     ...
     "hf_orgs": [
-        "lerobot"
+        "lerobot",
+        "allenai"
+    ],
+    "model_id_overrides": [
+        "allenai/molmoact"
     ],
     "is_hf_default": true
 }
```

### `tests/test_registry.py`

3 new tests in `TestResolvePolicy`:

- `test_huggingface_model_id_allenai_routes_to_lerobot_local` — pins resolution for `allenai/MolmoAct2-LIBERO-LeRobot`, `MolmoAct2-SO100_101`, `MolmoAct2-DROID`.
- `test_huggingface_model_id_override_molmoact_legacy` — pins legacy `allenai/MolmoAct-7B-D-Pretrain-0812`.
- `test_policy_type_kwarg_forwarded_for_molmoact2` — verifies `policy_type="molmoact2"` survives `resolve_policy(..., policy_type=...)`.

### `README.md`

Adds two usage examples in the *Policy Providers* section: a generic LeRobot example and the MolmoAct2 one (with the explicit dependency note).

## Compatibility

- Pure registry + tests + docs change. No source-code changes to any policy class, simulation, or tool.
- No new dependencies. No constraint changes.
- Backward compatible: `lerobot/*`, `nvidia/*`, `unknownorg/*` resolution paths remain identical (existing 60 registry tests continue to pass).
- Once `huggingface/lerobot#3604` merges and lerobot ships a release with the `molmoact2` policy type, the runtime path is automatically picked up by the existing `lerobot_local` resolution code (`strands_robots/policies/lerobot_local/resolution.py`) — no further work needed in this repo.

## Validation

```
hatch run format && hatch run lint
# All checks passed!  Success: no issues found in 139 source files

hatch run test
# 1674 passed, 1 skipped in 24.52s   (was 1671 → 3 new tests added)
```

## References

- Upstream LeRobot PR: https://github.com/huggingface/lerobot/pull/3604
- MolmoAct2 paper: https://arxiv.org/abs/2605.02881
- Hugging Face hub: https://huggingface.co/allenai/MolmoAct2
