### PR TITLE
fix(tools/gr00t_inference): drop --server flag from n1.7 command builder

### DIFF
--- a/strands_robots/tools/gr00t_inference.py
+++ b/strands_robots/tools/gr00t_inference.py
@@ -621,6 +621,12 @@ def _build_inference_command(
     diverging flag rather than two parallel command-builder functions.
     """
     if protocol == "n1.7":
+        # The N1.7 entrypoint (``python -m gr00t.eval.run_gr00t_server``)
+        # does NOT accept a ``--server`` flag — passing it makes ``tyro``
+        # reject the invocation with ``Unrecognized options: --server``
+        # and the inference process exits before binding the port. The
+        # legacy N1.5/N1.6 ``inference_service.py`` did take ``--server``;
+        # keeping the flag there preserves back-compat for older images.
         cmd = [
             "docker",
             "exec",
@@ -629,7 +635,6 @@ def _build_inference_command(
             "python",
             "-m",
             "gr00t.eval.run_gr00t_server",
-            "--server",
             "--model-path",
             checkpoint_path,
             "--port",

--- a/tests/tools/test_gr00t_inference.py
+++ b/tests/tools/test_gr00t_inference.py
@@ -97,6 +97,18 @@ class TestBuildInferenceCommand:
         assert "--denoising-steps" not in cmd
         # Sim policy wrapper is opt-in.
         assert "--use-sim-policy-wrapper" not in cmd
+        # Regression: the n1.7 entrypoint does NOT take ``--server``.
+        # Passing it makes ``tyro`` reject the invocation with
+        # "Unrecognized options: --server" and the inference process
+        # exits before binding the port. See discussion on #148-F3.
+        assert "--server" not in cmd
+
+    def test_n15_keeps_server_flag(self):
+        """Conversely, the legacy entrypoint *does* require ``--server``."""
+        cmd = _build_inference_command(**_common_kwargs(protocol="n1.5"))
+        assert "--server" in cmd
+        cmd = _build_inference_command(**_common_kwargs(protocol="n1.6"))
+        assert "--server" in cmd
 
     def test_n17_with_sim_policy_wrapper(self):
         cmd = _build_inference_command(**_common_kwargs(protocol="n1.7", use_sim_policy_wrapper=True))
@@ -110,7 +122,12 @@ class TestBuildInferenceCommand:
     def test_shared_required_flags_present_on_all_protocols(self):
         for protocol in ("n1.5", "n1.6", "n1.7"):
             cmd = _build_inference_command(**_common_kwargs(protocol=protocol))
-            assert "--server" in cmd, protocol
+            # ``--server`` is N1.5/N1.6-only — see test_n17_module_entrypoint
+            # for the regression detail.
+            if protocol in ("n1.5", "n1.6"):
+                assert "--server" in cmd, protocol
+            else:
+                assert "--server" not in cmd, protocol
             assert "--model-path" in cmd, protocol
             assert "/data/checkpoints/model" in cmd, protocol
             assert "--port" in cmd, protocol


### PR DESCRIPTION
## Summary

[`PR #150`](https://github.com/strands-labs/robots/pull/150) added the n1.7 path to `_build_inference_command` but mistakenly carried over `--server` from the legacy N1.5 invocation. `gr00t.eval.run_gr00t_server` (the N1.7 entrypoint) does **not** take that flag — `tyro` rejects it as `Unrecognized options: --server` and the inference process exits before binding the port.

## Repro

End-to-end against an n1.7 container:

```bash
docker exec gr00t python -m gr00t.eval.run_gr00t_server --server \
    --model-path /data/checkpoints/GR00T-N1.7-LIBERO/libero_10 \
    --port 8000 --host 0.0.0.0 --embodiment-tag libero_sim \
    --use-sim-policy-wrapper
```

```
╭─ Unrecognized options ────────────────────────────╮
│ Unrecognized options: --server                    │
│ ───────────────────────────────────────────────── │
│ For full helptext, run run_gr00t_server.py --help │
╰───────────────────────────────────────────────────╯
```

The failure mode is **silent in production** because `gr00t_inference(action="start", ...)` runs the command via `docker exec -d` (detached), so stderr is discarded. The subsequent `_is_service_running(port)` poll either races with port reuse or times out, both reported as a hard-to-debug "service failed to start" without the `tyro` diagnostic.

## Fix

Drop `--server` from the n1.7 branch of `_build_inference_command`. Keep it on the N1.5/N1.6 branch — the legacy `scripts/inference_service.py` *does* require it.

## Tests

`tests/tools/test_gr00t_inference.py`:

- Updated `test_n17_module_entrypoint` with `assert "--server" not in cmd` (regression).
- Updated `test_shared_required_flags_present_on_all_protocols` to scope the `--server` assertion to N1.5/N1.6 only (matching reality).
- Added `test_n15_keeps_server_flag` to pin back-compat for the legacy entrypoint.

```
$ pytest tests/tools/test_gr00t_inference.py
49 passed in 0.55s
```

## Discovered while

Wiring [`strands-labs/robots-sim` PR #26](https://github.com/strands-labs/robots-sim/pull/26) to use the just-merged `lifecycle="full"` action from #152. With the `--server` bug, lifecycle reports `start: success` because the `docker exec -d` returned 0, but no GPU memory is consumed and `pgrep run_gr00t_server` is empty seconds later.

## References

- Companion: [#148](https://github.com/strands-labs/robots/issues/148) (umbrella, mostly merged)
- Introduced by: [#150](https://github.com/strands-labs/robots/pull/150) (N1.7 entrypoint rename)
- Related: [#152](https://github.com/strands-labs/robots/pull/152) (lifecycle wider) — the lifecycle tool *calls* `_build_inference_command` so without this fix `lifecycle="full"` is also broken on N1.7.