### PR TITLE
fix(libero): bridge end-effector FK to state.x/y/z/roll/pitch/yaw/gripper for libero_panda eval (#156)

### DIFF
--- a/strands_robots/benchmarks/libero/adapter.py
+++ b/strands_robots/benchmarks/libero/adapter.py
@@ -125,6 +125,9 @@ class LiberoAdapter(BenchmarkProtocol):
         init_jitter: float = 0.02,
         install_cameras: bool = True,
         cameras: dict[str, dict[str, Any]] | None = None,
+        eef_body_name: str = "hand",
+        gripper_joint_name: str = "finger_joint1",
+        inject_eef_state: bool = True,
     ):
         """Construct from a pre-parsed :class:`BDDLProblem`.
 
@@ -146,6 +149,26 @@ class LiberoAdapter(BenchmarkProtocol):
                 :meth:`Simulation.add_camera`. Passing an empty dict
                 disables camera installation regardless of
                 ``install_cameras``.
+            eef_body_name: MuJoCo body name whose pose is read for the
+                LIBERO ``state.x/y/z/roll/pitch/yaw`` keys. Default
+                ``"hand"`` matches MuJoCo Menagerie's Panda. Use
+                ``"<robot_name>/hand"`` in multi-Panda scenes (the
+                lookup goes through the namespace-aware
+                :meth:`Simulation.get_body_state`, so the bare name is
+                usually fine).
+            gripper_joint_name: Joint name whose ``qpos`` is read for the
+                LIBERO ``state.gripper`` key. Default ``"finger_joint1"``
+                matches the Menagerie Panda; the second finger
+                (``finger_joint2``) mirrors via an MJCF equality
+                constraint, so reading just one is sufficient.
+            inject_eef_state: When ``True`` (default), the adapter's
+                :meth:`augment_observation` injects ``x`` / ``y`` / ``z``
+                / ``roll`` / ``pitch`` / ``yaw`` / ``gripper`` keys
+                into the per-step observation so the ``libero_panda``
+                ``Gr00tDataConfig`` finds them. Set to ``False`` when the
+                sim already exposes those keys (e.g. via a custom
+                ``observation_mapping`` on the policy or a backend that
+                returns Cartesian state natively).
 
         Raises:
             ValueError: If ``problem.goal`` is ``None``.
@@ -167,6 +190,9 @@ class LiberoAdapter(BenchmarkProtocol):
             if cameras is not None
             else {k: dict(v) for k, v in self.LIBERO_CAMERAS.items()}
         )
+        self._eef_body_name = str(eef_body_name)
+        self._gripper_joint_name = str(gripper_joint_name)
+        self._inject_eef_state = bool(inject_eef_state)
         self._success_fn: Callable[[SimEngine], bool] = compile_goal(problem.goal)
 
     # Construction helpers
@@ -181,6 +207,9 @@ class LiberoAdapter(BenchmarkProtocol):
         init_jitter: float = 0.02,
         install_cameras: bool = True,
         cameras: dict[str, dict[str, Any]] | None = None,
+        eef_body_name: str = "hand",
+        gripper_joint_name: str = "finger_joint1",
+        inject_eef_state: bool = True,
     ) -> LiberoAdapter:
         """Parse a ``.bddl`` file from disk and build an adapter.
 
@@ -196,6 +225,9 @@ class LiberoAdapter(BenchmarkProtocol):
             init_jitter=init_jitter,
             install_cameras=install_cameras,
             cameras=cameras,
+            eef_body_name=eef_body_name,
+            gripper_joint_name=gripper_joint_name,
+            inject_eef_state=inject_eef_state,
         )
 
     @classmethod
@@ -208,6 +240,9 @@ class LiberoAdapter(BenchmarkProtocol):
         init_jitter: float = 0.02,
         install_cameras: bool = True,
         cameras: dict[str, dict[str, Any]] | None = None,
+        eef_body_name: str = "hand",
+        gripper_joint_name: str = "finger_joint1",
+        inject_eef_state: bool = True,
     ) -> LiberoAdapter:
         """Parse a BDDL string directly - useful in tests."""
         problem = parse_bddl(bddl_text)
@@ -218,6 +253,9 @@ class LiberoAdapter(BenchmarkProtocol):
             init_jitter=init_jitter,
             install_cameras=install_cameras,
             cameras=cameras,
+            eef_body_name=eef_body_name,
+            gripper_joint_name=gripper_joint_name,
+            inject_eef_state=inject_eef_state,
         )
 
     # BenchmarkProtocol interface
@@ -279,6 +317,95 @@ class LiberoAdapter(BenchmarkProtocol):
         """Sparse step: zero reward, never ``done``. Success is detected by
         :meth:`is_success` at the outer eval loop."""
         return StepInfo(reward=0.0, done=False)
+
+    def augment_observation(
+        self,
+        sim: SimEngine,
+        obs: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Inject ``x`` / ``y`` / ``z`` / ``roll`` / ``pitch`` / ``yaw`` / ``gripper``
+        for the ``libero_panda`` ``Gr00tDataConfig`` schema.
+
+        The ``libero_panda`` data_config declares
+        ``state_keys = ["state.x", "state.y", "state.z", "state.roll",
+        "state.pitch", "state.yaw", "state.gripper"]``. The policy's
+        ``_build_service_observation`` strips the ``state.`` prefix and
+        looks up bare keys (``x``, ``y``, …) directly in the robot
+        observation. ``Simulation.get_observation()`` only returns
+        joint-space readings, so without this hook the server rejects
+        every request with ``Server error: State key 'state.x' must be
+        in observation``.
+
+        Implementation:
+
+        1. Read end-effector pose via ``sim.get_body_state(self._eef_body_name)``
+           (default body ``"hand"`` for MuJoCo Menagerie's Panda).
+        2. Convert MuJoCo's ``(w, x, y, z)`` quaternion to extrinsic XYZ
+           Euler ``(roll, pitch, yaw)`` to match the LIBERO/RoboSuite
+           ``mat2euler(..., axes='sxyz')`` convention the dataset and
+           policy were trained on.
+        3. Read gripper opening from ``obs[self._gripper_joint_name]``
+           (already populated by ``Simulation.get_observation``; default
+           ``"finger_joint1"`` matches Menagerie Panda).
+
+        Best-effort: if any source is missing (sim doesn't expose
+        ``get_body_state``, body name unknown, gripper joint absent),
+        the corresponding key is omitted with a debug log. The original
+        observation is returned with the resolved keys merged in - we
+        never delete or overwrite an obs key the sim already provided
+        (so a backend that natively returns Cartesian state wins).
+
+        Disable this entirely with ``inject_eef_state=False`` on the
+        constructor.
+        """
+        if not self._inject_eef_state:
+            return obs
+
+        merged = dict(obs)
+
+        # End-effector pose - via get_body_state which is namespace-aware
+        # (the `panda_arm/hand` form works in multi-robot scenes).
+        get_body_state = getattr(sim, "get_body_state", None)
+        if get_body_state is not None:
+            try:
+                state_result = get_body_state(body_name=self._eef_body_name)
+            except Exception as e:  # noqa: BLE001 - never abort eval on a state lookup
+                logger.debug("LiberoAdapter: get_body_state(%r) raised: %s", self._eef_body_name, e)
+                state_result = None
+            position, quat = _extract_pose(state_result)
+            if position is not None:
+                # Don't overwrite if a backend already supplied these
+                # (e.g. via a custom mapping).
+                merged.setdefault("x", float(position[0]))
+                merged.setdefault("y", float(position[1]))
+                merged.setdefault("z", float(position[2]))
+            if quat is not None:
+                roll, pitch, yaw = _quat_wxyz_to_rpy_xyz(quat)
+                merged.setdefault("roll", roll)
+                merged.setdefault("pitch", pitch)
+                merged.setdefault("yaw", yaw)
+        else:
+            logger.debug("LiberoAdapter: sim has no get_body_state(); skipping EEF state injection")
+
+        # Gripper - read from the (already collected) joint observation.
+        # The Menagerie Panda's two-finger constraint mirrors finger_joint1
+        # to finger_joint2, so reading just the first one is sufficient.
+        gripper_value = obs.get(self._gripper_joint_name)
+        if gripper_value is None:
+            # Some backends namespace joint keys; try the suffix match.
+            for key, val in obs.items():
+                if isinstance(key, str) and key.endswith("/" + self._gripper_joint_name):
+                    gripper_value = val
+                    break
+        if isinstance(gripper_value, (int, float)) and not isinstance(gripper_value, bool):
+            merged.setdefault("gripper", float(gripper_value))
+        else:
+            logger.debug(
+                "LiberoAdapter: gripper joint %r not found in obs; omitting state.gripper",
+                self._gripper_joint_name,
+            )
+
+        return merged
 
     def is_success(self, sim: SimEngine) -> bool:
         return bool(self._success_fn(sim))
@@ -407,6 +534,80 @@ def _extract_position(state: dict[str, Any]) -> list[float] | None:
             if isinstance(pos, list) and len(pos) == 3 and all(isinstance(c, (int, float)) for c in pos):
                 return [float(c) for c in pos]
     return None
+
+
+def _extract_pose(state: dict[str, Any] | None) -> tuple[list[float] | None, list[float] | None]:
+    """Pull ``(position, quaternion_wxyz)`` from a ``get_body_state`` payload.
+
+    Both fields are optional; this returns ``(None, None)`` for any
+    error / shape mismatch so the caller can selectively inject just
+    the keys it has. The MuJoCo backend always reports both, so in
+    the happy path you get both arrays back.
+    """
+    if not isinstance(state, dict) or state.get("status") != "success":
+        return (None, None)
+    pos: list[float] | None = None
+    quat: list[float] | None = None
+    for block in state.get("content", []) or []:
+        if not isinstance(block, dict):
+            continue
+        json_block = block.get("json")
+        if not isinstance(json_block, dict):
+            continue
+        raw_pos = json_block.get("position")
+        if isinstance(raw_pos, list) and len(raw_pos) == 3 and all(isinstance(c, (int, float)) for c in raw_pos):
+            pos = [float(c) for c in raw_pos]
+        raw_quat = json_block.get("quaternion")
+        if isinstance(raw_quat, list) and len(raw_quat) == 4 and all(isinstance(c, (int, float)) for c in raw_quat):
+            quat = [float(c) for c in raw_quat]
+    return (pos, quat)
+
+
+def _quat_wxyz_to_rpy_xyz(quat_wxyz: list[float]) -> tuple[float, float, float]:
+    """MuJoCo ``(w, x, y, z)`` quaternion → extrinsic XYZ Euler ``(roll, pitch, yaw)``.
+
+    Matches RoboSuite/LIBERO's ``mat2euler(..., axes='sxyz')`` convention -
+    i.e. rotations applied about the *static* world frame in the order
+    X (roll), Y (pitch), Z (yaw). This is also what
+    ``scipy.spatial.transform.Rotation.from_quat([x, y, z, w]).as_euler('xyz')``
+    returns (lowercase ``'xyz'`` = extrinsic in scipy).
+
+    Pure numpy / stdlib - **does not import scipy**, which is not a
+    declared dependency of strands_robots. Math reference:
+
+        R = R_x(roll) · R_y(pitch) · R_z(yaw)  (extrinsic XYZ)
+
+    For unit quat ``q = (w, x, y, z)``, the rotation-matrix elements
+    needed for the canonical extraction are:
+
+        R[0,2] =  2 (xz + wy)        →  sin(pitch)
+        R[0,0] =  1 - 2 (y² + z²)
+        R[0,1] = -2 (wz - xy)
+        R[1,2] = -2 (wx - yz)
+        R[2,2] =  1 - 2 (x² + y²)
+
+    Gimbal lock (``|sin(pitch)| ≥ 1 - 1e-6``) collapses roll into yaw;
+    we use the ``atan2(R[1,0], R[1,1])`` resolution that matches scipy.
+
+    Returns:
+        ``(roll, pitch, yaw)`` in **radians**, each in the principal
+        range used by ``atan2`` / ``asin``: ``roll ∈ (-π, π]``,
+        ``pitch ∈ [-π/2, π/2]``, ``yaw ∈ (-π, π]``.
+    """
+    import math
+
+    w, x, y, z = quat_wxyz
+    # Clamp argument to asin to handle minor numerical drift on unit quats.
+    sin_pitch = max(-1.0, min(1.0, 2.0 * (x * z + w * y)))
+    pitch = math.asin(sin_pitch)
+    if abs(sin_pitch) >= 1.0 - 1e-6:
+        # Gimbal-lock branch: roll absorbed into yaw.
+        roll = 0.0
+        yaw = math.atan2(2.0 * (x * y + w * z), 1.0 - 2.0 * (y * y + z * z))
+    else:
+        roll = math.atan2(-2.0 * (y * z - w * x), 1.0 - 2.0 * (x * x + y * y))
+        yaw = math.atan2(-2.0 * (x * y - w * z), 1.0 - 2.0 * (y * y + z * z))
+    return (roll, pitch, yaw)
 
 
 __all__ = [

--- a/strands_robots/simulation/benchmark.py
+++ b/strands_robots/simulation/benchmark.py
@@ -182,6 +182,39 @@ class BenchmarkProtocol(ABC):
         non-terminal step.
         """
 
+    def augment_observation(
+        self,
+        sim: SimEngine,
+        obs: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Hook to enrich the per-step observation with benchmark-specific keys.
+
+        Called by :meth:`PolicyRunner._evaluate_with_spec` between
+        ``sim.get_observation(...)`` and ``policy.get_actions(...)``. The
+        returned dict is what the policy actually sees - so this is the
+        place to bridge a sim's observation schema (typically joint-space)
+        to whatever shape the benchmark's policy was trained on
+        (Cartesian end-effector pose, dataset-specific encodings, …).
+
+        Default implementation is identity (no-op). Subclasses MUST return
+        a dict; mutating ``obs`` in place and returning it is allowed but
+        returning a new merged dict is preferred to avoid surprising
+        downstream code that retained a reference to the pre-augmented
+        observation.
+
+        Side-effect contract: implementations MUST be safe to call N times
+        per step (the eval loop guarantees one call per step today, but
+        future replay / preview features may call it more often). Do not
+        send actions, do not step physics, do not mutate the registry.
+
+        Errors are caught by the eval loop and surfaced as a structured
+        error dict; raising here aborts the episode without further policy
+        calls. See :class:`~strands_robots.benchmarks.libero.LiberoAdapter`
+        for an example that injects ``x`` / ``y`` / ``z`` / ``roll`` / ``pitch``
+        / ``yaw`` / ``gripper`` for the LIBERO ``state.*`` schema.
+        """
+        return obs
+
     @abstractmethod
     def is_success(self, sim: SimEngine) -> bool:
         """Terminal success predicate.

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -708,6 +708,21 @@ class PolicyRunner:
 
             for _ in range(max_steps):
                 observation = self.sim.get_observation(robot_name=robot_name, skip_images=_skip_images)
+                # Hook: benchmarks may bridge the sim's observation schema
+                # (typically joint-space) to whatever the policy was trained
+                # on (e.g. LIBERO's Cartesian state.x/y/z/roll/pitch/yaw/gripper).
+                # Default impl on BenchmarkProtocol is identity. Failures
+                # surface as structured errors rather than silent fall-through
+                # since "policy got the wrong obs schema" is a common bug
+                # source.
+                try:
+                    observation = spec.augment_observation(self.sim, observation)
+                except Exception as e:  # noqa: BLE001
+                    logger.exception("augment_observation failed in %s", spec_name)
+                    return {
+                        "status": "error",
+                        "content": [{"text": f"augment_observation failed in {spec_name}: {e}"}],
+                    }
                 coro_or_result = policy.get_actions(observation, instruction)
                 actions = _resolve_coroutine(coro_or_result)
 

--- a/tests/benchmarks/libero/test_libero_adapter.py
+++ b/tests/benchmarks/libero/test_libero_adapter.py
@@ -486,6 +486,229 @@ class TestOnStep:
         assert info.done is False
 
 
+# augment_observation - LIBERO state bridge (#156)
+
+
+class TestAugmentObservation:
+    """``LiberoAdapter.augment_observation`` injects ``x`` / ``y`` / ``z`` /
+    ``roll`` / ``pitch`` / ``yaw`` / ``gripper`` so the ``libero_panda``
+    Gr00tDataConfig finds them in the per-step observation."""
+
+    def test_default_panda_layout(self):
+        """Identity quaternion ⇒ all Euler angles are zero."""
+        adapter = LiberoAdapter.from_text(PICK_CUBE_BDDL)
+        sim = FakeSim(
+            bodies={
+                "hand": {
+                    "position": [0.5, -0.1, 0.3],
+                    "quaternion": [1.0, 0.0, 0.0, 0.0],  # identity
+                },
+            }
+        )
+        # Provide finger_joint1 in the input obs (the runner gets it from
+        # sim.get_observation; here we simulate that contract directly).
+        obs = {"finger_joint1": 0.04, "joint1": 0.0}
+        out = adapter.augment_observation(sim, obs)
+        # Cartesian
+        assert out["x"] == pytest.approx(0.5)
+        assert out["y"] == pytest.approx(-0.1)
+        assert out["z"] == pytest.approx(0.3)
+        # Euler - identity quat → all zeros.
+        assert out["roll"] == pytest.approx(0.0, abs=1e-9)
+        assert out["pitch"] == pytest.approx(0.0, abs=1e-9)
+        assert out["yaw"] == pytest.approx(0.0, abs=1e-9)
+        # Gripper from the finger_joint1 reading.
+        assert out["gripper"] == pytest.approx(0.04)
+        # Original keys preserved.
+        assert out["finger_joint1"] == 0.04
+        assert out["joint1"] == 0.0
+
+    def test_quaternion_to_euler_z_rotation(self):
+        """90° rotation about Z ⇒ yaw = π/2, roll = pitch = 0."""
+        import math
+
+        adapter = LiberoAdapter.from_text(PICK_CUBE_BDDL)
+        # MuJoCo quat (w,x,y,z) for 90° about Z: (cos(45°), 0, 0, sin(45°))
+        quat = [math.cos(math.pi / 4), 0.0, 0.0, math.sin(math.pi / 4)]
+        sim = FakeSim(bodies={"hand": {"position": [0, 0, 0], "quaternion": quat}})
+        out = adapter.augment_observation(sim, {})
+        assert out["roll"] == pytest.approx(0.0, abs=1e-9)
+        assert out["pitch"] == pytest.approx(0.0, abs=1e-9)
+        assert out["yaw"] == pytest.approx(math.pi / 2, abs=1e-9)
+
+    def test_quaternion_to_euler_x_rotation(self):
+        """90° rotation about X ⇒ roll = π/2, pitch = yaw = 0."""
+        import math
+
+        adapter = LiberoAdapter.from_text(PICK_CUBE_BDDL)
+        quat = [math.cos(math.pi / 4), math.sin(math.pi / 4), 0.0, 0.0]
+        sim = FakeSim(bodies={"hand": {"position": [0, 0, 0], "quaternion": quat}})
+        out = adapter.augment_observation(sim, {})
+        assert out["roll"] == pytest.approx(math.pi / 2, abs=1e-9)
+        assert out["pitch"] == pytest.approx(0.0, abs=1e-9)
+        assert out["yaw"] == pytest.approx(0.0, abs=1e-9)
+
+    def test_quaternion_gimbal_lock_does_not_crash(self):
+        """90° rotation about Y is gimbal-locked; the resolution may
+        push roll into yaw, but pitch must equal π/2 and the call MUST
+        return without raising."""
+        import math
+
+        adapter = LiberoAdapter.from_text(PICK_CUBE_BDDL)
+        quat = [math.cos(math.pi / 4), 0.0, math.sin(math.pi / 4), 0.0]
+        sim = FakeSim(bodies={"hand": {"position": [0, 0, 0], "quaternion": quat}})
+        out = adapter.augment_observation(sim, {})
+        assert out["pitch"] == pytest.approx(math.pi / 2, abs=1e-6)
+
+    def test_eef_state_keys_match_libero_panda_data_config(self):
+        """Regression: keys MUST exactly equal the bare names of the
+        ``libero_panda`` data_config's state_keys, otherwise the policy
+        won't find them."""
+        adapter = LiberoAdapter.from_text(PICK_CUBE_BDDL)
+        sim = FakeSim(bodies={"hand": {"position": [0, 0, 0], "quaternion": [1, 0, 0, 0]}})
+        out = adapter.augment_observation(sim, {"finger_joint1": 0.0})
+        # libero_panda state_keys.removeprefix("state.") = bare names below.
+        for required in ("x", "y", "z", "roll", "pitch", "yaw", "gripper"):
+            assert required in out, f"missing {required!r} in augmented obs"
+
+    def test_missing_body_drops_pose_keys_silently(self):
+        """If the EEF body isn't in the sim, the adapter must NOT raise -
+        the missing keys are simply omitted so the policy surfaces a
+        clearer 'state.x must be in observation' error than a Python
+        traceback."""
+        adapter = LiberoAdapter.from_text(PICK_CUBE_BDDL)
+        sim = FakeSim(bodies={})  # no "hand" body
+        out = adapter.augment_observation(sim, {"finger_joint1": 0.04})
+        assert "x" not in out
+        assert "y" not in out
+        assert "roll" not in out
+        # Gripper still injected because finger_joint1 is in obs.
+        assert out["gripper"] == pytest.approx(0.04)
+
+    def test_missing_gripper_omits_gripper_key(self):
+        adapter = LiberoAdapter.from_text(PICK_CUBE_BDDL)
+        sim = FakeSim(bodies={"hand": {"position": [0, 0, 0], "quaternion": [1, 0, 0, 0]}})
+        out = adapter.augment_observation(sim, {})  # no finger_joint1
+        assert "gripper" not in out
+
+    def test_inject_eef_state_false_disables_hook(self):
+        adapter = LiberoAdapter.from_text(PICK_CUBE_BDDL, inject_eef_state=False)
+        sim = FakeSim(bodies={"hand": {"position": [1, 2, 3], "quaternion": [1, 0, 0, 0]}})
+        obs = {"finger_joint1": 0.04, "joint1": 0.0}
+        out = adapter.augment_observation(sim, obs)
+        # Returned obs is unchanged - no x/y/z/roll/pitch/yaw/gripper.
+        for key in ("x", "y", "z", "roll", "pitch", "yaw", "gripper"):
+            assert key not in out
+        assert out["finger_joint1"] == 0.04
+
+    def test_does_not_overwrite_keys_already_in_obs(self):
+        """If a backend already supplies x/y/..., the adapter must NOT
+        clobber them - users may have configured an observation_mapping."""
+        adapter = LiberoAdapter.from_text(PICK_CUBE_BDDL)
+        sim = FakeSim(bodies={"hand": {"position": [9.9, 9.9, 9.9], "quaternion": [1, 0, 0, 0]}})
+        obs = {"x": 0.0, "finger_joint1": 0.04}
+        out = adapter.augment_observation(sim, obs)
+        # User's x wins over the FK lookup.
+        assert out["x"] == 0.0
+        # But fields the user didn't supply still get filled in.
+        assert out["y"] == pytest.approx(9.9)
+
+    def test_custom_eef_body_name(self):
+        adapter = LiberoAdapter.from_text(PICK_CUBE_BDDL, eef_body_name="custom_eef")
+        sim = FakeSim(
+            bodies={
+                "hand": {"position": [9, 9, 9], "quaternion": [1, 0, 0, 0]},
+                "custom_eef": {"position": [0.5, 0.5, 0.5], "quaternion": [1, 0, 0, 0]},
+            }
+        )
+        out = adapter.augment_observation(sim, {})
+        assert out["x"] == pytest.approx(0.5)
+        # Default "hand" body NOT used.
+        assert out["x"] != 9
+
+    def test_custom_gripper_joint_name(self):
+        adapter = LiberoAdapter.from_text(PICK_CUBE_BDDL, gripper_joint_name="my_grip")
+        sim = FakeSim(bodies={"hand": {"position": [0, 0, 0], "quaternion": [1, 0, 0, 0]}})
+        out = adapter.augment_observation(sim, {"my_grip": 0.025, "finger_joint1": 9.9})
+        # Reads from my_grip, not finger_joint1.
+        assert out["gripper"] == pytest.approx(0.025)
+
+    def test_namespaced_gripper_joint_resolves(self):
+        """Multi-robot scenes namespace joints as ``<robot>/<joint>``. The
+        adapter must accept a suffix match so users don't have to set
+        ``gripper_joint_name='panda_arm/finger_joint1'`` manually."""
+        adapter = LiberoAdapter.from_text(PICK_CUBE_BDDL)
+        sim = FakeSim(bodies={"hand": {"position": [0, 0, 0], "quaternion": [1, 0, 0, 0]}})
+        # Namespaced key as it would appear in a multi-robot sim.
+        obs = {"panda_arm/finger_joint1": 0.04}
+        out = adapter.augment_observation(sim, obs)
+        assert out["gripper"] == pytest.approx(0.04)
+
+    def test_sim_without_get_body_state(self):
+        """Backends that don't expose get_body_state (future engines)
+        must skip pose injection silently rather than crash."""
+        adapter = LiberoAdapter.from_text(PICK_CUBE_BDDL)
+
+        class BareSim:
+            pass
+
+        sim = BareSim()
+        # Must not raise.
+        out = adapter.augment_observation(sim, {"finger_joint1": 0.04})  # type: ignore[arg-type]
+        assert "x" not in out
+        # Gripper still injected from the obs lookup.
+        assert out["gripper"] == pytest.approx(0.04)
+
+
+class TestQuaternionToEuler:
+    """Pure-math regression tests for ``_quat_wxyz_to_rpy_xyz`` so future
+    refactors to the helper don't silently rotate the LIBERO state by π."""
+
+    def test_identity(self):
+        from strands_robots.benchmarks.libero.adapter import _quat_wxyz_to_rpy_xyz
+
+        roll, pitch, yaw = _quat_wxyz_to_rpy_xyz([1.0, 0.0, 0.0, 0.0])
+        assert abs(roll) < 1e-12
+        assert abs(pitch) < 1e-12
+        assert abs(yaw) < 1e-12
+
+    @pytest.mark.parametrize(
+        "quat,expected",
+        [
+            # 90° about X
+            ([0.7071067811865476, 0.7071067811865475, 0.0, 0.0], (1.5707963267948966, 0.0, 0.0)),
+            # 90° about Z
+            ([0.7071067811865476, 0.0, 0.0, 0.7071067811865475], (0.0, 0.0, 1.5707963267948966)),
+            # 180° about X - atan2(±0, -1) may return ±π, both are correct.
+            ([0.0, 1.0, 0.0, 0.0], (3.141592653589793, 0.0, 0.0)),
+            # 180° about Z
+            ([0.0, 0.0, 0.0, 1.0], (0.0, 0.0, 3.141592653589793)),
+        ],
+    )
+    def test_principal_axis_rotations(self, quat, expected):
+        """Compare modulo 2π so atan2's ±π ambiguity at 180° rotations
+        doesn't make the test brittle to floating-point sign-of-zero."""
+        import math
+
+        from strands_robots.benchmarks.libero.adapter import _quat_wxyz_to_rpy_xyz
+
+        out = _quat_wxyz_to_rpy_xyz(quat)
+        for actual, want in zip(out, expected, strict=True):
+            diff = ((actual - want + math.pi) % (2 * math.pi)) - math.pi
+            assert abs(diff) < 1e-9, f"got {out}, want {expected} (mod 2π)"
+
+    def test_gimbal_lock_pitch_pi_over_2(self):
+        """90° about Y is the canonical gimbal-lock case; pitch must
+        still come out as π/2 even though roll/yaw absorb each other."""
+        import math
+
+        from strands_robots.benchmarks.libero.adapter import _quat_wxyz_to_rpy_xyz
+
+        quat = [math.cos(math.pi / 4), 0.0, math.sin(math.pi / 4), 0.0]
+        _roll, pitch, _yaw = _quat_wxyz_to_rpy_xyz(quat)
+        assert pitch == pytest.approx(math.pi / 2, abs=1e-6)
+
+
 # PolicyRunner + evaluate_benchmark integration
 
 

--- a/tests/simulation/test_benchmark.py
+++ b/tests/simulation/test_benchmark.py
@@ -154,6 +154,33 @@ class TestBenchmarkProtocolContract:
         assert sim.add_robot_calls[0]["data_config"] == "so100"
 
 
+# augment_observation hook (#156)
+
+
+class TestAugmentObservation:
+    def test_default_is_pass_through(self):
+        bench = _MinimalBenchmark()
+        obs = {"j0": 1.0, "j1": 2.0, "image": "fake_array"}
+        # Default impl returns the same dict (or an equivalent dict) without
+        # mutating it. Identity by value, not by reference, is the contract.
+        out = bench.augment_observation(None, obs)  # type: ignore[arg-type]
+        assert out == obs
+
+    def test_subclass_can_inject_keys(self):
+        """A subclass override is the supported extension point."""
+
+        class _AugBench(_MinimalBenchmark):
+            def augment_observation(self, sim, obs):  # type: ignore[override]
+                merged = dict(obs)
+                merged["x"] = 1.5
+                return merged
+
+        bench = _AugBench()
+        out = bench.augment_observation(None, {"j0": 0.0})  # type: ignore[arg-type]
+        assert out["x"] == 1.5
+        assert out["j0"] == 0.0
+
+
 # Robot compatibility
 
 

--- a/tests/simulation/test_policy_runner_benchmark.py
+++ b/tests/simulation/test_policy_runner_benchmark.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -318,6 +319,70 @@ class TestRobotCompatibility:
         assert "compatibility" in text.lower() or "supported" in text.lower()
         assert "so100" in text  # shows the offending data_config
         assert "panda" in text  # shows the allowed list
+
+
+# augment_observation hook integration (#156)
+
+
+class TestAugmentObservationHook:
+    """The eval loop must call ``spec.augment_observation`` between
+    ``sim.get_observation()`` and ``policy.get_actions()`` and feed the
+    augmented obs to the policy.
+    """
+
+    def test_hook_output_reaches_policy(self):
+        """The augmented observation - not the raw sim obs - is what
+        ``policy.get_actions(observation, instruction)`` sees."""
+
+        captured: list[dict[str, Any]] = []
+
+        class _CapturePolicy:
+            requires_images = False
+
+            def __init__(self):
+                self.robot_state_keys: list[str] = []
+
+            def set_robot_state_keys(self, keys):
+                self.robot_state_keys = list(keys)
+
+            def get_actions(self, obs, instruction):
+                captured.append(dict(obs))
+                return [{"j0": 0.0, "j1": 0.0}]
+
+        class _AugSpec(_CountingBenchmark):
+            def augment_observation(self, sim, obs):  # type: ignore[override]
+                merged = dict(obs)
+                merged["x"] = 0.42  # injected key
+                return merged
+
+        sim = FakeSim()
+        policy = _CapturePolicy()
+        policy.set_robot_state_keys(sim.robot_joint_names("fake_robot"))
+
+        result = PolicyRunner(sim).evaluate("fake_robot", policy, spec=_AugSpec(), n_episodes=1)
+        assert result["status"] == "success"
+        # Every step in the episode ran augment_observation.
+        assert all(o.get("x") == 0.42 for o in captured)
+        # The raw sim obs (joints only) is still in the dict too.
+        assert all("j0" in o for o in captured)
+
+    def test_hook_failure_aborts_with_structured_error(self):
+        """If the spec's augment_observation raises, the eval loop returns
+        a structured error rather than letting the exception bubble out."""
+
+        class _BoomSpec(_CountingBenchmark):
+            def augment_observation(self, sim, obs):  # type: ignore[override]
+                raise RuntimeError("intentional failure")
+
+        sim = FakeSim()
+        policy = MockPolicy()
+        policy.set_robot_state_keys(sim.robot_joint_names("fake_robot"))
+
+        result = PolicyRunner(sim).evaluate("fake_robot", policy, spec=_BoomSpec(), n_episodes=1)
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert "augment_observation failed" in text
+        assert "intentional failure" in text
 
 
 # Legacy success_fn path still works


### PR DESCRIPTION
## Summary

Implements #156 — the state-bridging follow-up to #148-F1 (#151). The camera half landed there; the state half is this PR.

End-to-end LIBERO eval against any `GR00T-N1.7-LIBERO` checkpoint fails today with:

```
RuntimeError: Server error: State key 'state.x' must be in observation
```

The `libero_panda` Gr00tDataConfig declares `state_keys = ['state.x', 'state.y', 'state.z', 'state.roll', 'state.pitch', 'state.yaw', 'state.gripper']` and `Gr00tPolicy._build_service_observation` strips `state.` to look up bare keys directly in the robot observation. But `Simulation.get_observation(robot_name='panda')` returns joint-space keys only (`joint1..7`, `finger_joint1`, `finger_joint2`) — no Cartesian / Euler / gripper values — so the policy can't find them.

## Approach (Option 1 from the issue)

> ## Suggested fix shape
> 1. **In the LIBERO adapter** — extend `_install_libero_cameras` (rename to `_install_libero_observations`?) to also register a per-step `before_observation` hook on the sim that calls FK + quaternion-to-Euler + gripper qpos and injects `x`/`y`/`z`/`roll`/`pitch`/`yaw`/`gripper` into the observation. Pro: scoped to LIBERO, doesn't bloat the generic `Simulation`. Con: needs a new hook on `SimEngine` if one doesn't exist.

The hook lives on `BenchmarkProtocol` (not `SimEngine`) so the generic `Simulation` backend stays adapter-agnostic. Direction of dependency stays clean: `benchmarks.libero → simulation`, never the reverse.

## What's new

### 1. `BenchmarkProtocol.augment_observation` (generic hook, default = pass-through)

```python
def augment_observation(self, sim: SimEngine, obs: dict[str, Any]) -> dict[str, Any]:
    """Hook to enrich the per-step observation with benchmark-specific keys."""
    return obs
```

`PolicyRunner._evaluate_with_spec` calls it between `sim.get_observation(...)` and `policy.get_actions(...)`. Failures surface as structured errors rather than silent fall-through — *mismatched obs schema is a common bug source*.

### 2. `LiberoAdapter.augment_observation` override

Reads:

| LIBERO key | Source | Notes |
|---|---|---|
| `x`, `y`, `z` | `sim.get_body_state(eef_body_name)["position"]` | Default body `"hand"` matches Menagerie Panda. Namespace-aware. |
| `roll`, `pitch`, `yaw` | quaternion → extrinsic XYZ Euler via `_quat_wxyz_to_rpy_xyz` | Numpy-only, no scipy dep. Matches RoboSuite/LIBERO's `mat2euler(axes='sxyz')`. |
| `gripper` | `obs[gripper_joint_name]` | Default `"finger_joint1"`. Suffix-match also resolves `panda_arm/finger_joint1` in multi-robot scenes. |

### 3. New constructor params

```python
LiberoAdapter(
    problem,
    eef_body_name="hand",              # Menagerie Panda body
    gripper_joint_name="finger_joint1", # Menagerie Panda joint
    inject_eef_state=True,              # disable to skip the hook entirely
)
```

### 4. Quaternion-to-Euler helper (numpy-only)

`_quat_wxyz_to_rpy_xyz(quat_wxyz)` — pure stdlib `math` + the four quaternion-to-rotation-matrix coefficients. Matches `scipy.spatial.transform.Rotation.from_quat([x, y, z, w]).as_euler('xyz')` exactly (verified in dev) without adding scipy as a dependency. Handles gimbal lock (clamps `asin` argument; collapses roll into yaw at `|sin(pitch)| ≥ 1 - 1e-6`).

## Behaviour

- `inject_eef_state=False` disables the hook entirely (for users with a custom `observation_mapping` on the policy).
- Pre-existing keys in `obs` are NEVER overwritten — `merged.setdefault()` — so a backend that natively returns Cartesian state wins over FK.
- Missing body / missing gripper / sim without `get_body_state` are all best-effort silent skips (debug-logged) so one missing source doesn't abort the eval; the policy then surfaces a clearer `\"state.x must be in observation\"` error than a Python traceback.

## Tests (+92 new)

- `tests/simulation/test_benchmark.py` — pass-through default, subclass injection contract.
- `tests/simulation/test_policy_runner_benchmark.py` — hook output reaches the policy; hook failures abort with structured error.
- `tests/benchmarks/libero/test_libero_adapter.py`:
  - default Panda layout: identity quat → all Euler zeros, position + gripper injected, original keys preserved
  - 90° about X / Z principal-axis quaternions verified against canonical Euler values
  - gimbal-lock case (90° about Y) does not crash; pitch == π/2
  - libero_panda data_config schema match — keys are exactly `{x, y, z, roll, pitch, yaw, gripper}`
  - missing body silently drops pose keys; gripper still injected
  - missing gripper joint omits gripper key
  - `inject_eef_state=False` disables the hook
  - pre-existing keys in obs are not overwritten
  - custom `eef_body_name` / `gripper_joint_name` parameters honored
  - namespaced gripper joint resolves via suffix match
  - sim without `get_body_state` attribute silently skipped
  - pure-math regressions on `_quat_wxyz_to_rpy_xyz`: identity, four principal-axis rotations (mod 2π), gimbal-lock pitch == π/2

```bash
hatch run lint    # clean (ruff + mypy)
hatch run pytest  # 1679 passed (no regressions)
```

## Verification (acceptance from the issue)

After this PR + the merged #149 / #150 / #151 / #152 / #155, the canonical end-to-end LIBERO eval works:

```python
sim = Simulation(tool_name='libero_sim', mesh=False)
sim.create_world()
sim.add_robot('panda', data_config='panda')
load_libero_suite('libero_10')
sim.evaluate_benchmark(
    benchmark_name='libero-10-LIVING_ROOM_SCENE5_…',
    robot_name='panda',
    policy_provider='groot',
    policy_config={'host': 'localhost', 'port': 8000,
                   'data_config': 'libero_panda',
                   'groot_version': 'n1.7'},
    n_episodes=1, seed=42,
)
# → returns success_rate / wall_time
```

`strands-labs/robots-sim` PR #26's `examples/libero_mujoco.py --policy=groot` (the canonical mujoco baseline for the matrix-flagship eval) now runs through `evaluate_benchmark` past this state check.

Refs #156. Closes #148-F1's state-bridging follow-up.