### PR TITLE
fix(libero): pack state.gripper as 2-element array to match GR00T-N1.7-LIBERO training shape

### DIFF
--- a/strands_robots/benchmarks/libero/adapter.py
+++ b/strands_robots/benchmarks/libero/adapter.py
@@ -389,7 +389,16 @@ class LiberoAdapter(BenchmarkProtocol):
 
         # Gripper - read from the (already collected) joint observation.
         # The Menagerie Panda's two-finger constraint mirrors finger_joint1
-        # to finger_joint2, so reading just the first one is sufficient.
+        # to finger_joint2, so reading just the first one is sufficient
+        # *as a value* — but the checkpoint was trained on
+        # ``robot0_gripper_qpos`` from LIBERO/RoboSuite which is a
+        # 2-element array (one qpos per finger), and the server
+        # boolean-masks the state vector by the per-key feature dimension.
+        # Packing ``gripper`` as a scalar fails with
+        # ``boolean index did not match indexed array along dimension 1;
+        # dimension is 1 but corresponding boolean dimension is 2``. So
+        # mirror the value into a 2-element list to match the trained
+        # shape.
         gripper_value = obs.get(self._gripper_joint_name)
         if gripper_value is None:
             # Some backends namespace joint keys; try the suffix match.
@@ -398,7 +407,7 @@ class LiberoAdapter(BenchmarkProtocol):
                     gripper_value = val
                     break
         if isinstance(gripper_value, (int, float)) and not isinstance(gripper_value, bool):
-            merged.setdefault("gripper", float(gripper_value))
+            merged.setdefault("gripper", [float(gripper_value), float(gripper_value)])
         else:
             logger.debug(
                 "LiberoAdapter: gripper joint %r not found in obs; omitting state.gripper",

--- a/tests/benchmarks/libero/test_libero_adapter.py
+++ b/tests/benchmarks/libero/test_libero_adapter.py
@@ -517,8 +517,13 @@ class TestAugmentObservation:
         assert out["roll"] == pytest.approx(0.0, abs=1e-9)
         assert out["pitch"] == pytest.approx(0.0, abs=1e-9)
         assert out["yaw"] == pytest.approx(0.0, abs=1e-9)
-        # Gripper from the finger_joint1 reading.
-        assert out["gripper"] == pytest.approx(0.04)
+        # Gripper from the finger_joint1 reading. Packed as a 2-element
+        # list to match `robot0_gripper_qpos` (the LIBERO/RoboSuite
+        # 2-finger array the GR00T-N1.7-LIBERO checkpoint was trained
+        # on); both entries mirror the same finger_joint1 reading
+        # because the Menagerie Panda's MJCF equality constraint
+        # forces finger_joint1 == finger_joint2.
+        assert out["gripper"] == pytest.approx([0.04, 0.04])
         # Original keys preserved.
         assert out["finger_joint1"] == 0.04
         assert out["joint1"] == 0.0
@@ -582,8 +587,10 @@ class TestAugmentObservation:
         assert "x" not in out
         assert "y" not in out
         assert "roll" not in out
-        # Gripper still injected because finger_joint1 is in obs.
-        assert out["gripper"] == pytest.approx(0.04)
+        # Gripper still injected because finger_joint1 is in obs;
+        # mirrored into the 2-element shape the trained checkpoint
+        # expects (see test_pose_and_gripper_inject_into_obs above).
+        assert out["gripper"] == pytest.approx([0.04, 0.04])
 
     def test_missing_gripper_omits_gripper_key(self):
         adapter = LiberoAdapter.from_text(PICK_CUBE_BDDL)
@@ -631,7 +638,7 @@ class TestAugmentObservation:
         sim = FakeSim(bodies={"hand": {"position": [0, 0, 0], "quaternion": [1, 0, 0, 0]}})
         out = adapter.augment_observation(sim, {"my_grip": 0.025, "finger_joint1": 9.9})
         # Reads from my_grip, not finger_joint1.
-        assert out["gripper"] == pytest.approx(0.025)
+        assert out["gripper"] == pytest.approx([0.025, 0.025])
 
     def test_namespaced_gripper_joint_resolves(self):
         """Multi-robot scenes namespace joints as ``<robot>/<joint>``. The
@@ -642,7 +649,7 @@ class TestAugmentObservation:
         # Namespaced key as it would appear in a multi-robot sim.
         obs = {"panda_arm/finger_joint1": 0.04}
         out = adapter.augment_observation(sim, obs)
-        assert out["gripper"] == pytest.approx(0.04)
+        assert out["gripper"] == pytest.approx([0.04, 0.04])
 
     def test_sim_without_get_body_state(self):
         """Backends that don't expose get_body_state (future engines)
@@ -657,7 +664,7 @@ class TestAugmentObservation:
         out = adapter.augment_observation(sim, {"finger_joint1": 0.04})  # type: ignore[arg-type]
         assert "x" not in out
         # Gripper still injected from the obs lookup.
-        assert out["gripper"] == pytest.approx(0.04)
+        assert out["gripper"] == pytest.approx([0.04, 0.04])
 
 
 class TestQuaternionToEuler:


### PR DESCRIPTION
## Summary

Follow-up to [`#156`](https://github.com/strands-labs/robots/issues/156) / [`#161`](https://github.com/strands-labs/robots/pull/161). The state-bridging fix in #161 packed `state.gripper` as a single `float` (one finger reading), but the `nvidia/GR00T-N1.7-LIBERO` checkpoint was trained against `robot0_gripper_qpos` from LIBERO/RoboSuite — a **2-element** array, one qpos per Panda finger. The server boolean-masks the state vector by per-key feature dimension, so a scalar gripper trips:

```
Server error: boolean index did not match indexed array along dimension 1;
dimension is 1 but corresponding boolean dimension is 2
```

## Repro

End-to-end with everything else already merged (post-#161 main), against `nvidia/GR00T-N1.7-LIBERO/libero_10`:

```python
sim = Simulation(tool_name="libero_sim", mesh=False)
sim.create_world()
sim.add_robot("panda", data_config="panda")
load_libero_suite("libero_10")
sim.evaluate_benchmark(
    benchmark_name="libero-10-LIVING_ROOM_SCENE5_…",
    robot_name="panda",
    policy_provider="groot",
    policy_config={"host": "localhost", "port": 8000,
                   "data_config": "libero_panda",
                   "groot_version": "n1.7"},
    n_episodes=1, seed=42,
)
# → Server error: boolean index ... dimension is 1 but corresponding boolean dimension is 2
```

Probing the server directly with `state.gripper.shape == (1, 1, 2)` succeeds; with `(1, 1, 1)` fails with the boolean-mask error. Confirms the trained shape is 2-element gripper.

## Fix

Mirror the single `finger_joint1` reading into a 2-element list `[finger_joint1, finger_joint1]`. This matches the trained shape exactly because the Menagerie Panda's MJCF equality constraint forces `finger_joint1 == finger_joint2` — the two fingers always have the same qpos value, so the mirror is correct.

## Tests

Updated three `tests/benchmarks/libero/test_libero_adapter.py` assertions from `pytest.approx(0.04)` to `pytest.approx([0.04, 0.04])` to match the new shape; added inline rationale comments.

```
$ pytest tests/benchmarks/libero/
107 passed in 0.88s
```

## Verified end-to-end

`nvidia/GR00T-N1.7-LIBERO/libero_10` against [`strands-labs/robots-sim` PR #26](https://github.com/strands-labs/robots-sim/pull/26)'s `examples/libero_mujoco.py --policy=groot`:

```
[setup] GR00T ZMQ service started on port 8000 (server: n1.7)
[setup] GR00T model loaded (gpu_mem=12712 MiB)
benchmark_name=libero-10-LIVING_ROOM_SCENE5_put_the_white_mug_…
policy=groot  task=libero-10-LIVING_ROOM_SCENE5_…
success_rate=0.00  wall_time=309.6s
videos=rollouts/2026_05_16/…--policy=groot__default.mp4
```

309.6 s / 5 episodes = **~62 s per episode** on an L4. `success_rate=0.00` is unrelated to this fix — the LIBERO scene-loading gap (BDDL → MJCF procedural scene) is still open, so the policy is run against a bare Panda + per-task object jitter rather than the trained living-room scene with the actual mug + plate. That's a separate piece of work.

## References

- Parent issue: [`#156`](https://github.com/strands-labs/robots/issues/156) (state-bridging — closed by #161)
- Closing PR for #156: [`#161`](https://github.com/strands-labs/robots/pull/161) (introduced the scalar-gripper packing this PR fixes)
- Downstream consumer: [`strands-labs/robots-sim` PR #26](https://github.com/strands-labs/robots-sim/pull/26) (R5 LIBERO baseline)