### PR TITLE
fix(libero): load actual LIBERO scene MJCFs so eval runs against the trained world (#164)

### DIFF
--- a/strands_robots/benchmarks/libero/adapter.py
+++ b/strands_robots/benchmarks/libero/adapter.py
@@ -30,7 +30,9 @@ the one that pulls in the upstream package to discover task files.
 
 from __future__ import annotations
 
+import hashlib
 import logging
+import re
 from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -44,6 +46,7 @@ from strands_robots.benchmarks.libero.bddl_parser import (
     parse_bddl_file,
 )
 from strands_robots.simulation.benchmark import BenchmarkProtocol, StepInfo
+from strands_robots.utils import get_base_dir, require_optional
 
 if TYPE_CHECKING:
     import random
@@ -128,13 +131,19 @@ class LiberoAdapter(BenchmarkProtocol):
         eef_body_name: str = "hand",
         gripper_joint_name: str = "finger_joint1",
         inject_eef_state: bool = True,
+        auto_generate_scene: bool = True,
+        scene_cache_dir: str | None = None,
+        scene_camera_aliases: dict[str, str] | None = None,
+        bddl_source: str | None = None,
+        bddl_path: str | None = None,
     ):
         """Construct from a pre-parsed :class:`BDDLProblem`.
 
         Args:
             problem: Parsed BDDL problem with a non-``None`` ``goal``.
             scene_path: Optional MJCF to ``sim.load_scene()`` on each
-                episode start. ``None`` → assume scene is pre-loaded.
+                episode start. ``None`` triggers ``auto_generate_scene``
+                if enabled (see below).
             max_steps: Override the class-level 300.
             init_jitter: Per-episode ±jitter (metres) applied to xy of every
                 object referenced by ``(:init (on A B))`` clauses. Set to 0
@@ -143,7 +152,10 @@ class LiberoAdapter(BenchmarkProtocol):
                 in :attr:`LIBERO_CAMERAS` (or ``cameras`` override) on
                 episode start. Set to ``False`` if your scene MJCF already
                 declares the cameras the policy needs - the adapter will
-                skip the install step entirely.
+                skip the install step entirely. Generated scenes have their
+                cameras renamed to ``image`` / ``wrist_image`` (see
+                ``scene_camera_aliases``), so the install step naturally
+                no-ops on auto-generated scenes.
             cameras: Override / extend :attr:`LIBERO_CAMERAS`. Keyed by
                 camera name, each value is forwarded as ``**kwargs`` to
                 :meth:`Simulation.add_camera`. Passing an empty dict
@@ -169,6 +181,36 @@ class LiberoAdapter(BenchmarkProtocol):
                 sim already exposes those keys (e.g. via a custom
                 ``observation_mapping`` on the policy or a backend that
                 returns Cartesian state natively).
+            auto_generate_scene: When ``True`` (default) AND ``scene_path``
+                is ``None``, :meth:`on_episode_start` calls
+                :meth:`_generate_scene_from_bddl` to build the scene MJCF
+                via the upstream ``libero`` package's procedural
+                generator. The generated XML is cached on disk so
+                subsequent episodes / processes reuse it without
+                re-running ``libero``. Set to ``False`` to keep the
+                pre-#164 behaviour of running against a bare Panda when
+                no ``scene_path`` is provided.
+            scene_cache_dir: Filesystem location for the generated-scene
+                cache. Defaults to ``$STRANDS_BASE_DIR/scene_cache/libero/``
+                (typically ``~/.strands_robots/scene_cache/libero/``).
+                Cache key is SHA256 of the BDDL source so two adapters
+                built from the same BDDL share a cached XML.
+            scene_camera_aliases: Mapping from MJCF camera name (as
+                emitted by LIBERO) to the policy-side observation key
+                expected by the ``libero_panda`` data_config. Default
+                ``{"agentview": "image", "robot0_eye_in_hand_image": "wrist_image"}``
+                renames RoboSuite/LIBERO's two canonical cameras so
+                ``Gr00tPolicy._build_service_observation`` finds them by
+                bare-key lookup. Pass an empty dict to disable renaming.
+            bddl_source: Original BDDL text - stored on the adapter so
+                the scene generator can pass it back to ``libero`` (which
+                only accepts a *file* path). Set automatically by
+                :meth:`from_text`. Tests may set it explicitly when
+                building from a pre-parsed :class:`BDDLProblem` and they
+                want auto-generation to work.
+            bddl_path: Original BDDL file path - same purpose as
+                ``bddl_source`` but lets the scene generator skip the
+                temp-file step. Set automatically by :meth:`from_file`.
 
         Raises:
             ValueError: If ``problem.goal`` is ``None``.
@@ -193,6 +235,22 @@ class LiberoAdapter(BenchmarkProtocol):
         self._eef_body_name = str(eef_body_name)
         self._gripper_joint_name = str(gripper_joint_name)
         self._inject_eef_state = bool(inject_eef_state)
+        self._auto_generate_scene = bool(auto_generate_scene)
+        self._scene_cache_dir = scene_cache_dir
+        # Default camera-name alias map matches RoboSuite/LIBERO's two
+        # canonical camera names to the bare keys (``image`` /
+        # ``wrist_image``) that ``libero_panda``'s Gr00tDataConfig
+        # expects. Passing an empty dict disables renaming.
+        self._scene_camera_aliases: dict[str, str] = (
+            dict(scene_camera_aliases)
+            if scene_camera_aliases is not None
+            else {
+                "agentview": "image",
+                "robot0_eye_in_hand_image": "wrist_image",
+            }
+        )
+        self._bddl_source = bddl_source
+        self._bddl_path = bddl_path
         self._success_fn: Callable[[SimEngine], bool] = compile_goal(problem.goal)
 
     # Construction helpers
@@ -210,6 +268,9 @@ class LiberoAdapter(BenchmarkProtocol):
         eef_body_name: str = "hand",
         gripper_joint_name: str = "finger_joint1",
         inject_eef_state: bool = True,
+        auto_generate_scene: bool = True,
+        scene_cache_dir: str | None = None,
+        scene_camera_aliases: dict[str, str] | None = None,
     ) -> LiberoAdapter:
         """Parse a ``.bddl`` file from disk and build an adapter.
 
@@ -228,6 +289,10 @@ class LiberoAdapter(BenchmarkProtocol):
             eef_body_name=eef_body_name,
             gripper_joint_name=gripper_joint_name,
             inject_eef_state=inject_eef_state,
+            auto_generate_scene=auto_generate_scene,
+            scene_cache_dir=scene_cache_dir,
+            scene_camera_aliases=scene_camera_aliases,
+            bddl_path=str(bddl_path),
         )
 
     @classmethod
@@ -243,6 +308,9 @@ class LiberoAdapter(BenchmarkProtocol):
         eef_body_name: str = "hand",
         gripper_joint_name: str = "finger_joint1",
         inject_eef_state: bool = True,
+        auto_generate_scene: bool = True,
+        scene_cache_dir: str | None = None,
+        scene_camera_aliases: dict[str, str] | None = None,
     ) -> LiberoAdapter:
         """Parse a BDDL string directly - useful in tests."""
         problem = parse_bddl(bddl_text)
@@ -256,6 +324,10 @@ class LiberoAdapter(BenchmarkProtocol):
             eef_body_name=eef_body_name,
             gripper_joint_name=gripper_joint_name,
             inject_eef_state=inject_eef_state,
+            auto_generate_scene=auto_generate_scene,
+            scene_cache_dir=scene_cache_dir,
+            scene_camera_aliases=scene_camera_aliases,
+            bddl_source=bddl_text,
         )
 
     # BenchmarkProtocol interface
@@ -274,22 +346,44 @@ class LiberoAdapter(BenchmarkProtocol):
         return self.problem.language or ""
 
     def on_episode_start(self, sim: SimEngine, rng: random.Random) -> None:
-        """Load the declared scene (if any), validate Panda, install cameras, then jitter.
+        """Auto-generate scene (if needed), load it, validate Panda, install cameras, then jitter.
 
         Order matters:
 
-        1. ``load_scene`` (if ``scene_path`` set) - so the base
+        1. **Scene resolution.** When ``scene_path`` is ``None`` and
+           ``auto_generate_scene`` is true, build the scene MJCF from the
+           BDDL via the upstream ``libero`` package's procedural generator
+           and cache it on disk. Subsequent episodes / processes reuse the
+           cached XML without re-running ``libero``.
+        2. ``load_scene`` (if a path is now set) - so the base
            compatibility check sees the scene's Panda rather than reporting
            "sim is empty → load default_robot".
-        2. ``super().on_episode_start`` - base compat check + auto-load
+        3. ``super().on_episode_start`` - base compat check + auto-load
            ``default_robot`` if the sim is empty.
-        3. ``_install_libero_cameras`` - inject the cameras the
+        4. ``_install_libero_cameras`` - inject the cameras the
            ``libero_panda`` ``Gr00tDataConfig`` expects (``image`` /
-           ``wrist_image``). MUST happen after the robot is loaded so the
-           cameras render against a populated scene.
-        4. ``_apply_init_jitter`` - per-episode RNG-seeded ±jitter to
+           ``wrist_image``). The auto-generator renames LIBERO's canonical
+           cameras (``agentview`` → ``image``, ``robot0_eye_in_hand_image``
+           → ``wrist_image``) so the install step naturally no-ops on
+           generated scenes - the static-pose fallbacks only fire when the
+           scene didn't supply LIBERO-named cameras.
+        5. ``_apply_init_jitter`` - per-episode RNG-seeded ±jitter to
            init-subject bodies.
         """
+        if self.scene_path is None and self._auto_generate_scene:
+            try:
+                generated = self._generate_scene_from_bddl()
+            except Exception as e:  # noqa: BLE001 - never abort eval on a setup-time error
+                logger.warning(
+                    "LiberoAdapter: scene auto-generation failed (%s); falling back to bare Panda. "
+                    "Install the [benchmark-libero] extra (pip install 'strands-robots[benchmark-libero]') "
+                    "or pass scene_path= explicitly to silence this warning.",
+                    e,
+                )
+                generated = None
+            if generated is not None:
+                self.scene_path = generated
+
         if self.scene_path:
             load_scene = getattr(sim, "load_scene", None)
             if load_scene is None:
@@ -420,6 +514,126 @@ class LiberoAdapter(BenchmarkProtocol):
         return bool(self._success_fn(sim))
 
     # Internals
+
+    def _generate_scene_from_bddl(self) -> str | None:
+        """Build the LIBERO scene MJCF from the BDDL via the upstream ``libero`` package.
+
+        Returns the absolute path to a cached MJCF file, or ``None`` when
+        the BDDL source isn't recoverable (the adapter was constructed
+        from a pre-parsed :class:`BDDLProblem` without ``bddl_source`` /
+        ``bddl_path``). Raises on any other failure path so callers in
+        :meth:`on_episode_start` can decide whether to abort or fall back
+        to bare-Panda.
+
+        Procedure:
+
+        1. Locate (or write) a ``.bddl`` file on disk - ``libero`` only
+           accepts a path. Existing ``bddl_path`` is reused as-is.
+        2. Compute SHA256 of the BDDL bytes; cache key is
+           ``<scene_cache_dir>/<sha>.xml``. Cache hit → return path
+           without touching ``libero`` at all (no GPU / robosuite import).
+        3. Cache miss → ``require_optional("libero")`` lazy-imports the
+           upstream package, then ``libero.libero.envs.env_wrapper.ControlEnv(
+           bddl_file_name=..., has_offscreen_renderer=False, has_renderer=False,
+           use_camera_obs=False)`` constructs a robosuite env without
+           opening a GL context. Robosuite's ``env.sim.model.get_xml()``
+           returns the compiled MJCF as a string.
+        4. Apply :attr:`_scene_camera_aliases` via a targeted XML
+           rename so the policy-side cameras (``image`` / ``wrist_image``)
+           resolve to the LIBERO-canonical viewpoints.
+        5. Write the renamed XML to the cache and return the path.
+
+        The LIBERO env is closed after extraction; no robosuite state
+        survives this method.
+        """
+        bddl_path = self._resolve_bddl_path_for_libero()
+        if bddl_path is None:
+            logger.debug(
+                "LiberoAdapter: no BDDL source available for scene generation - "
+                "constructed from a pre-parsed BDDLProblem without bddl_source / bddl_path"
+            )
+            return None
+
+        bddl_bytes = bddl_path.read_bytes()
+        sha = hashlib.sha256(bddl_bytes).hexdigest()
+        cache_dir = Path(self._scene_cache_dir).expanduser() if self._scene_cache_dir else _default_scene_cache_dir()
+        cache_path = cache_dir / f"{sha}.xml"
+        if cache_path.exists():
+            logger.debug("LiberoAdapter: scene cache hit %s", cache_path)
+            return str(cache_path)
+
+        # Cache miss - lazy-import libero, build the scene.
+        env_wrapper = require_optional(
+            "libero.libero.envs.env_wrapper",
+            pip_install="libero",
+            extra="benchmark-libero",
+            purpose="LIBERO scene generation from BDDL",
+        )
+        ControlEnv = env_wrapper.ControlEnv  # type: ignore[attr-defined]
+
+        # ``has_offscreen_renderer=False`` + ``has_renderer=False`` skip
+        # the GL-context bring-up that ``OffScreenRenderEnv`` would
+        # otherwise require - we only need the *compiled* model, not
+        # rendered frames. ``use_camera_obs=False`` further disables
+        # camera observation collection during reset, which would also
+        # touch the renderer.
+        env = ControlEnv(
+            bddl_file_name=str(bddl_path),
+            has_offscreen_renderer=False,
+            has_renderer=False,
+            use_camera_obs=False,
+        )
+        try:
+            xml = _extract_compiled_mjcf(env)
+        finally:
+            try:
+                env.close()
+            except Exception as e:  # noqa: BLE001 - close errors are non-fatal
+                logger.debug("LiberoAdapter: env.close() raised after extraction: %s", e)
+
+        if self._scene_camera_aliases:
+            xml = _rename_mjcf_cameras(xml, self._scene_camera_aliases)
+
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_text(xml)
+        logger.info(
+            "LiberoAdapter: generated scene MJCF for %s -> %s",
+            self.problem.name,
+            cache_path,
+        )
+        return str(cache_path)
+
+    def _resolve_bddl_path_for_libero(self) -> Path | None:
+        """Return a ``Path`` to a ``.bddl`` file libero can open, or ``None``.
+
+        - If the adapter was constructed via :meth:`from_file`,
+          ``self._bddl_path`` already points at a real file - reuse it.
+        - If constructed via :meth:`from_text`, write the source text to
+          a stable temp file (keyed by SHA256 of the text) so libero has
+          a real path. The temp file lives under
+          ``<scene_cache_dir>/.bddl/`` so it's cleaned up alongside the
+          scene cache.
+        - If neither is set, return ``None``.
+        """
+        if self._bddl_path is not None:
+            p = Path(self._bddl_path).expanduser()
+            if p.is_file():
+                return p
+            logger.debug(
+                "LiberoAdapter: bddl_path=%s not on disk; falling back to bddl_source",
+                p,
+            )
+        if self._bddl_source is None:
+            return None
+
+        cache_dir = Path(self._scene_cache_dir).expanduser() if self._scene_cache_dir else _default_scene_cache_dir()
+        bddl_dir = cache_dir / ".bddl"
+        bddl_dir.mkdir(parents=True, exist_ok=True)
+        sha = hashlib.sha256(self._bddl_source.encode("utf-8")).hexdigest()
+        tmp = bddl_dir / f"{sha}.bddl"
+        if not tmp.exists():
+            tmp.write_text(self._bddl_source)
+        return tmp
 
     def _install_libero_cameras(self, sim: SimEngine) -> None:
         """Inject the cameras the ``libero_panda`` data_config expects.
@@ -617,6 +831,80 @@ def _quat_wxyz_to_rpy_xyz(quat_wxyz: list[float]) -> tuple[float, float, float]:
         roll = math.atan2(-2.0 * (y * z - w * x), 1.0 - 2.0 * (x * x + y * y))
         yaw = math.atan2(-2.0 * (x * y - w * z), 1.0 - 2.0 * (y * y + z * z))
     return (roll, pitch, yaw)
+
+
+# Scene-generation helpers (#164)
+
+
+def _default_scene_cache_dir() -> Path:
+    """Filesystem location for cached LIBERO scene MJCFs.
+
+    Uses :func:`strands_robots.utils.get_base_dir` so the cache lives
+    under ``$STRANDS_BASE_DIR`` (typically ``~/.strands_robots/``)
+    alongside other strands-robots state. Created on demand by
+    :meth:`LiberoAdapter._generate_scene_from_bddl` - this helper just
+    returns the path.
+    """
+    return get_base_dir() / "scene_cache" / "libero"
+
+
+def _extract_compiled_mjcf(env: Any) -> str:
+    """Pull the compiled MJCF XML out of a ``libero`` ControlEnv.
+
+    ``ControlEnv.env`` is the underlying robosuite manipulation env;
+    its ``.sim.model.get_xml()`` returns the merged / compiled MJCF as
+    a string (with all ``<include>``s resolved and assets inlined).
+    Robosuite renamed this accessor over the years, so we try a small
+    set of fallbacks before giving up - and we never look at any
+    non-public attributes.
+    """
+    accessors = (
+        # Newer robosuite (>=1.4) - canonical path through the env's MjSim.
+        lambda: env.env.sim.model.get_xml(),
+        # Older robosuite (<1.4) - sometimes exposes the model directly.
+        lambda: env.env.model.get_xml(),
+        # Fallback: ManipulationEnv subclasses sometimes expose the
+        # compiled XML via an explicit ``model.get_model_xml`` helper.
+        lambda: env.env.model.get_model_xml(),  # type: ignore[attr-defined]
+    )
+    last_err: Exception | None = None
+    for accessor in accessors:
+        try:
+            xml = accessor()
+        except Exception as e:  # noqa: BLE001 - try the next accessor
+            last_err = e
+            continue
+        if isinstance(xml, str) and xml.strip():
+            return xml
+    raise RuntimeError(f"could not extract compiled MJCF from libero env (last error: {last_err!r})")
+
+
+# Match a complete ``<camera ... name="OLD" ...>`` declaration so the
+# rename only touches camera definitions, not e.g. material names that
+# happen to share a string. Anchored on the ``camera`` element name and
+# guarded by ``\s+`` to avoid partial-word matches.
+_CAMERA_NAME_RE = re.compile(r'(<camera\b[^>]*\bname=")([^"]+)(")')
+
+
+def _rename_mjcf_cameras(xml: str, aliases: dict[str, str]) -> str:
+    """Rename ``<camera name="OLD"...>`` → ``<camera name="NEW"...>`` per ``aliases``.
+
+    Targeted regex only - we don't parse the whole MJCF. The rename is
+    safe because MuJoCo doesn't allow duplicate ``<camera>`` names within
+    a model, and camera references from external code (e.g.
+    ``sim.render(camera_name=...)``) come from outside the XML so they
+    aren't affected.
+
+    Names not in ``aliases`` pass through unchanged.
+    """
+    if not aliases:
+        return xml
+
+    def _sub(match: re.Match[str]) -> str:
+        head, name, tail = match.group(1), match.group(2), match.group(3)
+        return head + aliases.get(name, name) + tail
+
+    return _CAMERA_NAME_RE.sub(_sub, xml)
 
 
 __all__ = [

--- a/tests/benchmarks/libero/test_libero_adapter.py
+++ b/tests/benchmarks/libero/test_libero_adapter.py
@@ -17,8 +17,11 @@ Covers:
 
 from __future__ import annotations
 
+import hashlib
 import random
+from pathlib import Path
 from typing import Any
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -714,6 +717,337 @@ class TestQuaternionToEuler:
         quat = [math.cos(math.pi / 4), 0.0, math.sin(math.pi / 4), 0.0]
         _roll, pitch, _yaw = _quat_wxyz_to_rpy_xyz(quat)
         assert pitch == pytest.approx(math.pi / 2, abs=1e-6)
+
+
+# Scene auto-generation from BDDL (#164)
+
+
+class TestSceneGeneration:
+    """``LiberoAdapter._generate_scene_from_bddl`` builds the per-task MJCF
+    via the upstream ``libero`` package's procedural generator, with
+    SHA256-keyed disk caching and a graceful fallback when ``libero``
+    isn't installed."""
+
+    def test_explicit_scene_path_skips_generation(self, tmp_path):
+        """``scene_path=...`` set on the constructor wins over auto-gen.
+        The generator must NOT be called when an explicit path is given."""
+
+        adapter = LiberoAdapter.from_text(
+            PICK_CUBE_BDDL,
+            scene_path=str(tmp_path / "explicit.xml"),
+            init_jitter=0.0,
+            install_cameras=False,
+        )
+
+        with patch.object(adapter, "_generate_scene_from_bddl") as mock_gen:
+            sim = FakeSim(data_config="panda")
+            # The explicit path doesn't exist; load_scene returns success
+            # only because FakeSim's load_scene is canned. Real Simulation
+            # would error - that's the test's purpose: confirm we never
+            # touched the generator.
+            adapter.on_episode_start(sim, random.Random(0))
+
+        mock_gen.assert_not_called()
+        assert sim._scenes_loaded == [str(tmp_path / "explicit.xml")]
+
+    def test_auto_generate_scene_false_falls_back_to_bare_panda(self):
+        """Pre-#164 behavior preserved: with auto_generate_scene=False
+        and no scene_path, the adapter goes straight to the bare-Panda
+        path without trying to generate."""
+        adapter = LiberoAdapter.from_text(
+            PICK_CUBE_BDDL,
+            auto_generate_scene=False,
+            init_jitter=0.0,
+            install_cameras=False,
+        )
+
+        with patch.object(adapter, "_generate_scene_from_bddl") as mock_gen:
+            sim = FakeSim(data_config="panda")
+            adapter.on_episode_start(sim, random.Random(0))
+
+        mock_gen.assert_not_called()
+        assert sim._scenes_loaded == []
+        assert adapter.scene_path is None
+
+    def test_libero_missing_falls_back_with_warning(self, caplog, tmp_path):
+        """If ``libero`` isn't installed, the adapter must log a warning
+        and continue with the legacy bare-Panda path - eval still runs,
+        just against the wrong world."""
+        adapter = LiberoAdapter.from_text(
+            PICK_CUBE_BDDL,
+            scene_cache_dir=str(tmp_path / "cache"),
+            init_jitter=0.0,
+            install_cameras=False,
+        )
+
+        # Simulate a missing pip package - require_optional raises ImportError.
+        with patch(
+            "strands_robots.benchmarks.libero.adapter.require_optional",
+            side_effect=ImportError("'libero' is required"),
+        ):
+            with caplog.at_level("WARNING"):
+                sim = FakeSim(data_config="panda")
+                adapter.on_episode_start(sim, random.Random(0))
+
+        # Eval continues without a scene loaded.
+        assert sim._scenes_loaded == []
+        assert adapter.scene_path is None
+        # User gets a clear hint about [benchmark-libero].
+        assert any(
+            "scene auto-generation failed" in rec.message and "[benchmark-libero]" in rec.message
+            for rec in caplog.records
+        )
+
+    def test_cache_hit_skips_libero_import(self, tmp_path):
+        """If the SHA-keyed cache file already exists, the adapter must
+        return its path without importing libero at all."""
+        cache_dir = tmp_path / "scene_cache"
+        cache_dir.mkdir()
+
+        adapter = LiberoAdapter.from_text(
+            PICK_CUBE_BDDL,
+            scene_cache_dir=str(cache_dir),
+            init_jitter=0.0,
+            install_cameras=False,
+        )
+
+        # Pre-populate the cache file at the SHA the adapter computes.
+        bddl_path = adapter._resolve_bddl_path_for_libero()
+        assert bddl_path is not None
+        sha = hashlib.sha256(bddl_path.read_bytes()).hexdigest()
+        cache_path = cache_dir / f"{sha}.xml"
+        cache_path.write_text("<mujoco/>")
+
+        # Sentinel: any libero import attempt would fail this test.
+        with patch(
+            "strands_robots.benchmarks.libero.adapter.require_optional",
+            side_effect=AssertionError("require_optional should not be called on cache hit"),
+        ):
+            generated = adapter._generate_scene_from_bddl()
+
+        assert generated == str(cache_path)
+
+    def test_cache_miss_invokes_libero_and_writes_xml(self, tmp_path):
+        """Cache miss path: libero is imported, ControlEnv is constructed
+        with rendering disabled, the compiled MJCF is extracted, cameras
+        are renamed, and the result is written to the cache."""
+        cache_dir = tmp_path / "scene_cache"
+
+        # Mock the entire libero.libero.envs.env_wrapper module surface.
+        fake_xml = (
+            '<mujoco model="libero_pick"><worldbody>'
+            '<camera name="agentview" pos="1 0 1"/>'
+            '<camera name="robot0_eye_in_hand_image" pos="0 0 0.5"/>'
+            "</worldbody></mujoco>"
+        )
+
+        fake_env = MagicMock()
+        fake_env.env.sim.model.get_xml.return_value = fake_xml
+        fake_module = MagicMock()
+        fake_module.ControlEnv.return_value = fake_env
+
+        adapter = LiberoAdapter.from_text(
+            PICK_CUBE_BDDL,
+            scene_cache_dir=str(cache_dir),
+            init_jitter=0.0,
+            install_cameras=False,
+        )
+
+        with patch(
+            "strands_robots.benchmarks.libero.adapter.require_optional",
+            return_value=fake_module,
+        ):
+            generated = adapter._generate_scene_from_bddl()
+
+        assert generated is not None
+        # ControlEnv must have been constructed with rendering disabled
+        # so we don't need a GL context.
+        construct_kwargs = fake_module.ControlEnv.call_args.kwargs
+        assert construct_kwargs["has_offscreen_renderer"] is False
+        assert construct_kwargs["has_renderer"] is False
+        assert construct_kwargs["use_camera_obs"] is False
+        # The compiled XML was extracted from env.env.sim.model.get_xml().
+        fake_env.env.sim.model.get_xml.assert_called_once()
+        # Cameras renamed to libero_panda data_config bare keys.
+        text = Path(generated).read_text()
+        assert 'name="image"' in text
+        assert 'name="wrist_image"' in text
+        assert 'name="agentview"' not in text
+        assert 'name="robot0_eye_in_hand_image"' not in text
+        # env was closed after extraction.
+        fake_env.close.assert_called_once()
+
+    def test_camera_rename_disabled_with_empty_aliases(self, tmp_path):
+        """Passing ``scene_camera_aliases={}`` keeps the LIBERO-canonical
+        camera names verbatim - useful for users who want to manage the
+        camera-name mapping themselves via the policy's
+        observation_mapping."""
+        cache_dir = tmp_path / "scene_cache"
+
+        fake_xml = '<mujoco><worldbody><camera name="agentview" pos="1 0 1"/></worldbody></mujoco>'
+
+        fake_env = MagicMock()
+        fake_env.env.sim.model.get_xml.return_value = fake_xml
+        fake_module = MagicMock()
+        fake_module.ControlEnv.return_value = fake_env
+
+        adapter = LiberoAdapter.from_text(
+            PICK_CUBE_BDDL,
+            scene_cache_dir=str(cache_dir),
+            scene_camera_aliases={},  # disable
+            init_jitter=0.0,
+            install_cameras=False,
+        )
+
+        with patch(
+            "strands_robots.benchmarks.libero.adapter.require_optional",
+            return_value=fake_module,
+        ):
+            generated = adapter._generate_scene_from_bddl()
+
+        text = Path(generated).read_text()
+        # agentview retained verbatim.
+        assert 'name="agentview"' in text
+        assert 'name="image"' not in text
+
+    def test_cache_key_is_sha256_of_bddl(self, tmp_path):
+        """Two adapters built from the SAME BDDL share a cached XML.
+        Two adapters with DIFFERENT BDDL get distinct cache files."""
+        cache_dir = tmp_path / "scene_cache"
+
+        a1 = LiberoAdapter.from_text(
+            PICK_CUBE_BDDL,
+            scene_cache_dir=str(cache_dir),
+            init_jitter=0.0,
+        )
+        a2 = LiberoAdapter.from_text(
+            PICK_CUBE_BDDL,
+            scene_cache_dir=str(cache_dir),
+            init_jitter=0.0,
+        )
+        a3 = LiberoAdapter.from_text(
+            COMPOUND_BDDL,
+            scene_cache_dir=str(cache_dir),
+            init_jitter=0.0,
+        )
+
+        path1 = a1._resolve_bddl_path_for_libero()
+        path2 = a2._resolve_bddl_path_for_libero()
+        path3 = a3._resolve_bddl_path_for_libero()
+        assert path1 is not None and path2 is not None and path3 is not None
+        sha1 = hashlib.sha256(path1.read_bytes()).hexdigest()
+        sha2 = hashlib.sha256(path2.read_bytes()).hexdigest()
+        sha3 = hashlib.sha256(path3.read_bytes()).hexdigest()
+        assert sha1 == sha2  # same BDDL → same key
+        assert sha1 != sha3  # different BDDL → different key
+
+    def test_resolve_bddl_path_uses_existing_file_when_set(self, tmp_path):
+        """``from_file`` constructed adapters reuse the original BDDL path
+        instead of writing a new temp file."""
+        bddl_file = tmp_path / "task.bddl"
+        bddl_file.write_text(PICK_CUBE_BDDL)
+        adapter = LiberoAdapter.from_file(
+            bddl_file,
+            scene_cache_dir=str(tmp_path / "cache"),
+            init_jitter=0.0,
+        )
+        resolved = adapter._resolve_bddl_path_for_libero()
+        assert resolved == bddl_file
+
+    def test_resolve_bddl_path_returns_none_for_unsourced_problem(self, tmp_path):
+        """Adapters built from a pre-parsed ``BDDLProblem`` without
+        ``bddl_source`` / ``bddl_path`` can't auto-generate a scene -
+        the resolver returns None and the generator surfaces that as
+        a no-op."""
+        from strands_robots.benchmarks.libero.bddl_parser import parse_bddl
+
+        problem = parse_bddl(PICK_CUBE_BDDL)
+        # Construct directly, bypassing from_file / from_text.
+        adapter = LiberoAdapter(
+            problem,
+            scene_cache_dir=str(tmp_path / "cache"),
+            init_jitter=0.0,
+        )
+        resolved = adapter._resolve_bddl_path_for_libero()
+        assert resolved is None
+
+        # The generator must return None (not raise) so the on_episode_start
+        # fallback path stays alive.
+        assert adapter._generate_scene_from_bddl() is None
+
+    def test_on_episode_start_loads_generated_scene(self, tmp_path):
+        """End-to-end: scene_path=None, auto_generate_scene=True ⇒
+        on_episode_start generates the scene, mutates self.scene_path,
+        and calls sim.load_scene with the cached path."""
+        cache_dir = tmp_path / "scene_cache"
+        cache_dir.mkdir()
+
+        adapter = LiberoAdapter.from_text(
+            PICK_CUBE_BDDL,
+            scene_cache_dir=str(cache_dir),
+            init_jitter=0.0,
+            install_cameras=False,
+        )
+
+        # Pre-populate the cache so we don't need a fake libero env.
+        bddl_path = adapter._resolve_bddl_path_for_libero()
+        assert bddl_path is not None
+        sha = hashlib.sha256(bddl_path.read_bytes()).hexdigest()
+        cache_path = cache_dir / f"{sha}.xml"
+        cache_path.write_text("<mujoco/>")
+
+        sim = FakeSim(data_config="panda")
+        adapter.on_episode_start(sim, random.Random(0))
+
+        assert adapter.scene_path == str(cache_path)
+        assert sim._scenes_loaded == [str(cache_path)]
+
+
+class TestRenameMjcfCameras:
+    """``_rename_mjcf_cameras`` helper - targeted regex, doesn't touch
+    non-camera elements."""
+
+    def test_renames_camera_by_name(self):
+        from strands_robots.benchmarks.libero.adapter import _rename_mjcf_cameras
+
+        xml = '<camera name="agentview" pos="1 0 1"/>'
+        out = _rename_mjcf_cameras(xml, {"agentview": "image"})
+        assert 'name="image"' in out
+        assert 'name="agentview"' not in out
+
+    def test_passes_through_unmapped_cameras(self):
+        from strands_robots.benchmarks.libero.adapter import _rename_mjcf_cameras
+
+        xml = '<camera name="other_cam" fovy="60"/>'
+        out = _rename_mjcf_cameras(xml, {"agentview": "image"})
+        assert out == xml
+
+    def test_does_not_touch_material_named_after_camera(self):
+        """Targeted regex: only ``<camera ... name="X" ...>`` is rewritten,
+        not e.g. ``<material name="agentview">`` (a contrived case but it
+        guards against future false-positives)."""
+        from strands_robots.benchmarks.libero.adapter import _rename_mjcf_cameras
+
+        xml = '<material name="agentview" rgba="1 0 0 1"/><camera name="agentview" pos="1 0 1"/>'
+        out = _rename_mjcf_cameras(xml, {"agentview": "image"})
+        # Material name unchanged.
+        assert '<material name="agentview"' in out
+        # Camera name renamed.
+        assert '<camera name="image"' in out
+
+    def test_empty_aliases_is_noop(self):
+        from strands_robots.benchmarks.libero.adapter import _rename_mjcf_cameras
+
+        xml = '<camera name="agentview"/>'
+        assert _rename_mjcf_cameras(xml, {}) == xml
+
+    def test_handles_attributes_before_name(self):
+        """Real LIBERO MJCFs put pose attributes before ``name="..."``."""
+        from strands_robots.benchmarks.libero.adapter import _rename_mjcf_cameras
+
+        xml = '<camera pos="1 0 1" fovy="60" name="agentview"/>'
+        out = _rename_mjcf_cameras(xml, {"agentview": "image"})
+        assert 'name="image"' in out
 
 
 # PolicyRunner + evaluate_benchmark integration


### PR DESCRIPTION
## Summary

Implements #164. End-to-end LIBERO eval through `strands-robots`' simulation pipeline ran cleanly against `nvidia/GR00T-N1.7-LIBERO` after the previous wave of fixes (#147 / #149-152 / #155 / #161 / #162) but always reported `success_rate ≈ 0` — *including on tasks the checkpoint trained on*. The pipeline was healthy; the **world** was wrong. `LiberoAdapter` registered BDDL goal predicates and bridged Panda joint state → end-effector pose, but the actual MuJoCo scene (tables, mugs, plates, drawers, cabinets — every body the policy was trained to manipulate) was never loaded.

## Approach (Approach 1 from the issue, recommended)

> Have `LiberoAdapter.on_episode_start` instantiate `OffScreenRenderEnv` (or the lower-level `Bddl2MjcfTranslator` from `libero/libero/envs`), grab the generated MJCF string, write it to a temp file, then `sim.load_scene(temp_path)`. The `libero` pip package is already a dependency of the `benchmark-libero` extra so this doesn't add new install cost.

Concretely, `libero.libero.envs.env_wrapper.ControlEnv` constructs a robosuite env from a BDDL file; robosuite's `env.sim.model.get_xml()` returns the compiled MJCF as a string. The adapter:

1. Resolves a BDDL file path (reuses the original from `from_file`, materializes a temp file from `from_text`, or returns None for bare-`BDDLProblem` constructions).
2. SHA256-keys the cache. Cache hit ⇒ skip libero import entirely.
3. On miss, lazy-imports libero, instantiates `ControlEnv(bddl_file_name=..., has_offscreen_renderer=False, has_renderer=False, use_camera_obs=False)` — **no GL context required just to compile the model**.
4. Extracts XML via `env.env.sim.model.get_xml()` (with two fallback accessors for older robosuite versions).
5. Renames LIBERO-canonical cameras (`agentview` → `image`, `robot0_eye_in_hand_image` → `wrist_image`) so `Gr00tPolicy._build_service_observation` finds them by direct lookup without needing an explicit `observation_mapping`.
6. Writes the renamed XML to the cache and returns the path.

The static-camera install from #151 naturally no-ops on auto-generated scenes — the post-rename names already exist in the loaded scene, so `_install_libero_cameras` skips them.

## What's new

### New constructor params on `LiberoAdapter`

```python
LiberoAdapter(
    problem,
    auto_generate_scene=True,       # NEW: gate the scene-gen path
    scene_cache_dir=None,           # NEW: default $STRANDS_BASE_DIR/scene_cache/libero/
    scene_camera_aliases={          # NEW: rename LIBERO cameras to libero_panda's bare keys
        \"agentview\": \"image\",
        \"robot0_eye_in_hand_image\": \"wrist_image\",
    },
    bddl_source=None,                # NEW: stored automatically by from_text
    bddl_path=None,                  # NEW: stored automatically by from_file
)
```

### Behaviour matrix

| `scene_path` | `auto_generate_scene` | Outcome |
|---|---|---|
| set | any | explicit path wins; no generation |
| None | False | pre-#164 bare-Panda path (back-compat) |
| None | True (default) | lazy-generate via libero, cached, scene loaded |

### Failure modes (all graceful)

- `[benchmark-libero]` not installed → `WARNING` with install hint, falls back to bare Panda.
- libero raises during scene construction → `WARNING`, falls back.
- BDDL not recoverable (bare `LiberoAdapter(BDDLProblem)` constructor) → silent skip.

In all cases, the eval still runs — the world is just wrong (which is the pre-#164 status quo, so this is no regression).

## Tests (+15 new)

- explicit `scene_path` skips generation entirely
- `auto_generate_scene=False` preserves the pre-#164 bare-Panda path
- libero missing → graceful fallback with `[benchmark-libero]` install hint
- **cache hit**: pre-populated cache file returned without importing libero (asserted via `require_optional` sentinel)
- **cache miss**: `ControlEnv` constructed with rendering disabled, XML extracted, cameras renamed, written to cache, env closed
- camera rename disabled with `scene_camera_aliases={}` preserves `agentview` verbatim
- SHA256 keying: same BDDL → same cache key, different BDDL → different
- `_resolve_bddl_path_for_libero`: existing path / temp-file fallback / None
- `on_episode_start` end-to-end: `scene_path=None` + cache hit ⇒ adapter mutates `self.scene_path` and calls `sim.load_scene`
- `_rename_mjcf_cameras` regex: renames target cameras, passes through unmapped, doesn't touch materials with the same name, handles attribute reordering, empty aliases is no-op

```bash
hatch run lint    # clean (ruff + mypy)
hatch run pytest  # 1694 passed (no regressions; +15 new)
```

## Verification (acceptance from the issue)

> ## Verified status without this fix
> - **Scene loaded**: ❌ — this issue
> - Real `success_rate` measurement: ⛔ blocked on scene loading

After this PR + the merged stack, with `[benchmark-libero]` installed:

```python
sim = Simulation(tool_name='libero_sim', mesh=False)
sim.create_world()
sim.add_robot('panda', data_config='panda')
load_libero_suite('libero_10')
sim.evaluate_benchmark(
    benchmark_name='libero-10-LIVING_ROOM_SCENE5_…',
    robot_name='panda',
    policy_provider='groot',
    policy_config={'host': 'localhost', 'port': 8000,
                   'data_config': 'libero_panda',
                   'groot_version': 'n1.7'},
    n_episodes=5, seed=42,
)
# → real success_rate against the trained-on world
```

`strands-labs/robots-sim` PR #26's R5 matrix-cell (`~62 s/ep @ 0.00 (groot, no LIBERO scene)`) gets a real number.

## Out of scope

- Body-mounted (gripper-tracked) wrist camera: still a static pose. The auto-generated LIBERO scene's `robot0_eye_in_hand_image` IS body-mounted in the source MJCF, so this PR effectively *fixes* it as a side effect of loading the scene — but I don't have a non-GPU CI environment to verify rendering. Tracked separately if needed.
- Vendoring pre-rendered scene XMLs (Approach 2 from the issue): not done. The lazy-generation + disk cache approach gives the same runtime cost after the first miss without the hosting overhead.
- Procedural BDDL → MJCF translation in pure strands-robots (Approach 3): explicitly not done. Re-implements work libero already does well.

Refs #164. Closes the canonical mujoco LIBERO eval pipeline.