### PR TITLE
fix(libero): scene-camera no-op + zero-jitter default for libero_panda eval (#166)

### DIFF
--- a/strands_robots/benchmarks/libero/adapter.py
+++ b/strands_robots/benchmarks/libero/adapter.py
@@ -125,7 +125,7 @@ class LiberoAdapter(BenchmarkProtocol):
         *,
         scene_path: str | None = None,
         max_steps: int | None = None,
-        init_jitter: float = 0.02,
+        init_jitter: float = 0.0,
         install_cameras: bool = True,
         cameras: dict[str, dict[str, Any]] | None = None,
         eef_body_name: str = "hand",
@@ -146,8 +146,15 @@ class LiberoAdapter(BenchmarkProtocol):
                 if enabled (see below).
             max_steps: Override the class-level 300.
             init_jitter: Per-episode ±jitter (metres) applied to xy of every
-                object referenced by ``(:init (on A B))`` clauses. Set to 0
-                to disable jitter.
+                object referenced by ``(:init (on A B))`` clauses. Default
+                ``0.0`` matches LIBERO's deterministic-reset convention -
+                the upstream training data is generated with fixed init
+                states per ``(task, seed)`` and the GR00T-LIBERO checkpoint
+                expects to see those exact poses (#166). Pass a positive
+                value (e.g. ``0.02``) to layer per-episode randomization
+                on top - useful for evaluating *generalization*, but
+                expect lower nominal success rates because the policy is
+                operating slightly out-of-distribution.
             install_cameras: When ``True`` (default), install the cameras
                 in :attr:`LIBERO_CAMERAS` (or ``cameras`` override) on
                 episode start. Set to ``False`` if your scene MJCF already
@@ -262,7 +269,7 @@ class LiberoAdapter(BenchmarkProtocol):
         *,
         scene_path: str | None = None,
         max_steps: int | None = None,
-        init_jitter: float = 0.02,
+        init_jitter: float = 0.0,
         install_cameras: bool = True,
         cameras: dict[str, dict[str, Any]] | None = None,
         eef_body_name: str = "hand",
@@ -302,7 +309,7 @@ class LiberoAdapter(BenchmarkProtocol):
         *,
         scene_path: str | None = None,
         max_steps: int | None = None,
-        init_jitter: float = 0.02,
+        init_jitter: float = 0.0,
         install_cameras: bool = True,
         cameras: dict[str, dict[str, Any]] | None = None,
         eef_body_name: str = "hand",
@@ -645,24 +652,34 @@ class LiberoAdapter(BenchmarkProtocol):
         in the sim, every direct-client call to a LIBERO server fails with
         ``Video key 'video.image' must be in observation`` (#148, Failure 1).
 
-        Cameras already present in the sim (declared by a loaded scene MJCF
-        that beats us to the name) are skipped silently. Other failures are
-        logged at WARNING but never fatal - one missing camera shouldn't
-        kill the whole eval.
+        Cameras already present in the sim are skipped silently. "Already
+        present" means *either*:
+
+        * the runtime camera registry on ``sim._world.cameras`` (added via
+          a previous ``sim.add_camera`` call, including by this adapter on
+          a prior episode), OR
+        * the *compiled MuJoCo model* (declared via ``<camera>`` elements
+          in a scene MJCF that ``sim.load_scene`` just loaded — #166).
+
+        The model-side check matters because :meth:`Simulation.load_scene`
+        creates a fresh ``SimWorld`` whose ``cameras`` registry starts
+        empty even when the loaded MJCF declares cameras. Without the
+        model-side check the install would re-add the same cameras on top
+        of the scene's ones, either silently failing on the MJCF
+        duplicate-name compile error (best case) or — if recompile order
+        let it land — overriding the scene's training-distribution poses
+        with our generic-fallback poses, which #166 traces as a likely
+        cause of the LIBERO checkpoint reporting ``success_rate=0.00``.
+
+        Other ``add_camera`` failures are logged at WARNING but never
+        fatal - one missing camera shouldn't kill the whole eval.
         """
         add_camera = getattr(sim, "add_camera", None)
         if add_camera is None:
             logger.debug("LiberoAdapter: sim has no add_camera(); skipping camera install")
             return
 
-        # Cheap check for already-installed cameras: most backends expose a
-        # ``_world.cameras`` dict. If we can't see it, just try add_camera
-        # and let it return its own "already exists" error.
-        existing: set[str] = set()
-        world = getattr(sim, "_world", None)
-        cameras_attr = getattr(world, "cameras", None) if world is not None else None
-        if isinstance(cameras_attr, dict):
-            existing = set(cameras_attr.keys())
+        existing = self._existing_camera_names(sim)
 
         for cam_name, cam_kwargs in self._cameras.items():
             if cam_name in existing:
@@ -680,6 +697,44 @@ class LiberoAdapter(BenchmarkProtocol):
                     logger.debug("LiberoAdapter: camera %r already declared by scene", cam_name)
                 else:
                     logger.warning("LiberoAdapter: add_camera(%r) failed: %s", cam_name, msg)
+
+    @staticmethod
+    def _existing_camera_names(sim: SimEngine) -> set[str]:
+        """Union of registry-side and model-side camera names known to ``sim``.
+
+        Backends without a MuJoCo-compiled model fall back to the registry
+        check only - non-MuJoCo engines are still safe (they just lose the
+        model-side detection, which is the pre-#166 behaviour).
+        """
+        names: set[str] = set()
+        world = getattr(sim, "_world", None)
+
+        # Registry-side: cameras added via sim.add_camera() previously.
+        cameras_attr = getattr(world, "cameras", None) if world is not None else None
+        if isinstance(cameras_attr, dict):
+            names.update(cameras_attr.keys())
+
+        # Model-side: cameras declared in a loaded scene MJCF. Only relevant
+        # for MuJoCo backends - reach into world._model and enumerate via
+        # mujoco's name-by-id lookup. We import mujoco lazily to keep the
+        # adapter usable on backends that don't ship it.
+        model = getattr(world, "_model", None) if world is not None else None
+        if model is None:
+            return names
+        try:
+            import mujoco as _mj
+        except ImportError:
+            logger.debug("LiberoAdapter: mujoco not importable; skipping model-side camera check")
+            return names
+        try:
+            ncam = int(getattr(model, "ncam", 0))
+            for i in range(ncam):
+                name = _mj.mj_id2name(model, _mj.mjtObj.mjOBJ_CAMERA, i)
+                if name:
+                    names.add(name)
+        except Exception as e:  # noqa: BLE001 - never fatal during camera-existence check
+            logger.debug("LiberoAdapter: model-side camera enumeration failed: %s", e)
+        return names
 
     def _apply_init_jitter(self, sim: SimEngine, rng: random.Random) -> None:
         """Apply ±jitter to xy of every body referenced by ``(:init (on A B))``.

--- a/tests/benchmarks/libero/test_libero_adapter.py
+++ b/tests/benchmarks/libero/test_libero_adapter.py
@@ -478,6 +478,167 @@ class TestLiberoCameraInstall:
         adapter.on_episode_start(sim, random.Random(0))
 
 
+# Camera-install model-side detection (#166)
+
+
+class TestSceneSuppliedCamerasNoOp:
+    """When a loaded scene MJCF declares the cameras the LIBERO data_config
+    needs, ``_install_libero_cameras`` MUST detect them via the compiled
+    model and skip its static-fallback install. Otherwise the install
+    fights the scene's training-distribution cameras (#166 root cause #1).
+    """
+
+    def test_model_side_camera_blocks_static_install(self):
+        """A scene whose compiled model declares ``image`` / ``wrist_image``
+        must shadow the adapter's static fallbacks - no add_camera calls."""
+
+        class _FakeMjModel:
+            ncam = 2
+
+        class _FakeMjEnum:
+            mjOBJ_CAMERA = 7
+
+        class _FakeMjModule:
+            mjtObj = _FakeMjEnum()
+
+            @staticmethod
+            def mj_id2name(model, obj_type, idx):  # noqa: ARG004
+                return ["image", "wrist_image"][idx]
+
+        sim = FakeSim(data_config="panda")
+        # Inject a fake compiled model into the world so the model-side
+        # enumeration finds the scene-supplied cameras.
+        sim._world._model = _FakeMjModel()  # type: ignore[attr-defined]
+
+        adapter = LiberoAdapter.from_text(PICK_CUBE_BDDL, init_jitter=0.0, auto_generate_scene=False)
+
+        with patch.dict("sys.modules", {"mujoco": _FakeMjModule()}):
+            adapter.on_episode_start(sim, random.Random(0))
+
+        # Both LIBERO cameras were detected as already-present in the
+        # model; the static install never reached add_camera.
+        assert sim._add_camera_calls == []
+
+    def test_partial_model_side_camera_still_fills_missing(self):
+        """If the scene declares ONLY ``image`` (not ``wrist_image``), the
+        adapter must still install the missing one but skip the existing."""
+
+        class _FakeMjModel:
+            ncam = 1
+
+        class _FakeMjEnum:
+            mjOBJ_CAMERA = 7
+
+        class _FakeMjModule:
+            mjtObj = _FakeMjEnum()
+
+            @staticmethod
+            def mj_id2name(model, obj_type, idx):  # noqa: ARG004
+                return ["image"][idx]
+
+        sim = FakeSim(data_config="panda")
+        sim._world._model = _FakeMjModel()  # type: ignore[attr-defined]
+
+        adapter = LiberoAdapter.from_text(PICK_CUBE_BDDL, init_jitter=0.0, auto_generate_scene=False)
+
+        with patch.dict("sys.modules", {"mujoco": _FakeMjModule()}):
+            adapter.on_episode_start(sim, random.Random(0))
+
+        installed_names = {name for name, _ in sim._add_camera_calls}
+        assert installed_names == {"wrist_image"}
+
+    def test_falls_back_to_registry_check_when_mujoco_not_importable(self):
+        """Backends without mujoco installed (future engines) keep the
+        pre-#166 behaviour: only the registry is checked."""
+        sim = FakeSim(data_config="panda", preexisting_cameras=["image"])
+        # Don't inject a model - simulates a non-MuJoCo engine.
+        sim._world._model = None  # type: ignore[attr-defined]
+
+        adapter = LiberoAdapter.from_text(PICK_CUBE_BDDL, init_jitter=0.0, auto_generate_scene=False)
+        adapter.on_episode_start(sim, random.Random(0))
+
+        # ``image`` blocked by registry; ``wrist_image`` installed.
+        installed_names = {name for name, _ in sim._add_camera_calls}
+        assert installed_names == {"wrist_image"}
+
+    def test_static_method_existing_camera_names_unions_both_sources(self):
+        """Direct exercise of ``_existing_camera_names`` - it returns the
+        union of registry-side and model-side camera names."""
+
+        class _FakeMjModel:
+            ncam = 1
+
+        class _FakeMjEnum:
+            mjOBJ_CAMERA = 7
+
+        class _FakeMjModule:
+            mjtObj = _FakeMjEnum()
+
+            @staticmethod
+            def mj_id2name(model, obj_type, idx):  # noqa: ARG004
+                return "agentview"
+
+        sim = FakeSim(data_config="panda", preexisting_cameras=["topdown"])
+        sim._world._model = _FakeMjModel()  # type: ignore[attr-defined]
+
+        with patch.dict("sys.modules", {"mujoco": _FakeMjModule()}):
+            names = LiberoAdapter._existing_camera_names(sim)
+
+        assert names == {"topdown", "agentview"}
+
+
+# init_jitter default (#166)
+
+
+class TestInitJitterDefault:
+    """``init_jitter`` defaults to 0.0 to match LIBERO's deterministic-reset
+    convention (#166 root cause #3). The GR00T-LIBERO checkpoint trains
+    against fixed init states per (task, seed); 2cm of randomization on
+    every reset puts the policy slightly out-of-distribution from t=0.
+    """
+
+    def test_default_is_zero(self):
+        adapter = LiberoAdapter.from_text(PICK_CUBE_BDDL)
+        assert adapter._init_jitter == 0.0
+
+    def test_default_is_zero_via_from_file(self, tmp_path):
+        p = tmp_path / "task.bddl"
+        p.write_text(PICK_CUBE_BDDL)
+        adapter = LiberoAdapter.from_file(p)
+        assert adapter._init_jitter == 0.0
+
+    def test_default_is_zero_via_direct_constructor(self):
+        from strands_robots.benchmarks.libero.bddl_parser import parse_bddl
+
+        problem = parse_bddl(PICK_CUBE_BDDL)
+        adapter = LiberoAdapter(problem)
+        assert adapter._init_jitter == 0.0
+
+    def test_explicit_value_still_works(self):
+        """Setting ``init_jitter=0.02`` still works for users who want
+        per-episode randomization (e.g. evaluating *generalization*)."""
+        adapter = LiberoAdapter.from_text(PICK_CUBE_BDDL, init_jitter=0.02)
+        assert adapter._init_jitter == 0.02
+
+    def test_default_skips_apply_init_jitter(self):
+        """With the new default, no move_object call should fire on reset."""
+        adapter = LiberoAdapter.from_text(
+            """
+            (define (problem p)
+              (:init (on cube_1 table_1))
+              (:goal (on cube_1 plate_1)))
+            """,
+            install_cameras=False,
+            auto_generate_scene=False,
+        )
+        sim = FakeSim(
+            bodies={"cube_1": {"position": [0, 0, 0.1]}, "table_1": {"position": [0, 0, 0]}},
+            data_config="panda",
+        )
+        adapter.on_episode_start(sim, random.Random(42))
+        assert sim._move_calls == []
+
+
 # Step semantics
 
 


### PR DESCRIPTION
## Summary

#166 investigates why end-to-end LIBERO eval against `nvidia/GR00T-N1.7-LIBERO/libero_10` reports `success_rate ≈ 0.00` even after the eight-PR catch-up wave landed. The smoking gun in the recorded MP4 is the `image` camera transitioning from a correct training-distribution view to a near-uniform yellow within **~20 s** and staying there — whatever the policy is then conditioning on, it isn't the world it trained against.

Of the five likely root causes the issue lists, **two have cheap probes that fit cleanly inside `strands_robots/`**. This PR ships both, in the order of expected information gain the issue suggests.

## Probe 1 — scene-supplied cameras override (#166 root cause #1)

`LiberoAdapter._install_libero_cameras` ([#151](https://github.com/strands-labs/robots/pull/151)) was added to inject the `image` / `wrist_image` cameras the `libero_panda` Gr00tDataConfig expects as a *fallback* for non-LIBERO worlds. After [#165](https://github.com/strands-labs/robots/pull/165)'s procedural scene-loading landed, the loaded MJCF declares its own (renamed) `image` / `wrist_image` cameras at LIBERO-canonical poses — the fallback install was supposed to no-op cleanly when this happens.

**It didn't.** The \"already exists\" check only looked at `sim._world.cameras` (the runtime registry of cameras added via `add_camera`). But `Simulation.load_scene()` creates a *fresh* `SimWorld` whose cameras dict starts empty, even when the loaded MJCF declares cameras. So the install ran anyway and fought the scene's training-distribution cameras: either silently failing on the MJCF duplicate-name compile error, or — if recompile order let it land — **overriding the scene's poses with our generic-fallback ones**. Either branch explains the camera-view degeneration.

### Fix

Extend the existence check to also enumerate the **compiled MuJoCo model's** camera names (via `mujoco.mj_id2name` over `model.ncam`). Now scene-supplied cameras shadow the static fallbacks cleanly. Backends without `mujoco` installed keep the pre-#166 registry-only behaviour.

A new staticmethod `LiberoAdapter._existing_camera_names` returns the union of registry-side and model-side camera names so future diagnostics have a single source of truth.

## Probe 2 — `init_jitter` default mismatch (#166 root cause #3)

LIBERO's training data is generated with deterministic init states per `(task, seed)` — the GR00T-LIBERO checkpoint expects to see those exact poses. The adapter's previous default of **0.02 m** of per-episode xy jitter on every init-subject body put the policy slightly out-of-distribution from t=0, every episode.

### Fix

Change `LiberoAdapter` `init_jitter` default from `0.02` → `0.0`. Users evaluating *generalization* can still pass `init_jitter=0.02` explicitly. Docstring updated:

```python
init_jitter: Per-episode ±jitter (metres) ... Default 0.0 matches LIBERO's
    deterministic-reset convention - the upstream training data is
    generated with fixed init states per (task, seed) and the GR00T-LIBERO
    checkpoint expects to see those exact poses (#166). Pass a positive
    value (e.g. 0.02) to layer per-episode randomization on top - useful
    for evaluating *generalization*, but expect lower nominal success
    rates because the policy is operating slightly out-of-distribution.
```

## Tests (+9 new)

- `TestSceneSuppliedCamerasNoOp`:
  - scene-declared `image` + `wrist_image` MUST block the static install (no `add_camera` calls)
  - partial scene cameras (only `image`) still fill the missing `wrist_image`
  - non-MuJoCo backends (no `_model` attr) keep registry-only behaviour
  - direct exercise of `_existing_camera_names` returning the union
- `TestInitJitterDefault`:
  - default `0.0` via `from_text` / `from_file` / direct constructor
  - explicit `0.02` still works for generalization-eval users
  - default skips `_apply_init_jitter` (no `move_object` calls)

```bash
hatch run lint    # clean (ruff + mypy)
hatch run pytest  # 1703 passed (no regressions; +9 new)
```

## Out of scope (intentionally)

These need a real eval run to verify, not unit tests:

- **#166 root cause #2** (initial robot pose differs from LIBERO reset). The LIBERO scene MJCF already carries the home pose via `<key>`; if it doesn't apply on `reset()`, that's a separate sim-side issue.
- **#166 root cause #4** (action scaling / convention mismatch). Would need delta-EEF trajectory comparison against LIBERO training data.
- **#166 root cause #5** (camera FOV mismatch). Depends on what `Simulation.render_all` does with the loaded scene's `<camera fovy>`.

## Verification ask (from the issue)

> Happy to run any of these locally (NVIDIA L4 / Docker / `nvidia/GR00T-N1.7-LIBERO/libero_10` already cached) if you want a specific repro before / after a change.

Once this lands, run the issue's repro:

```bash
python examples/libero_mujoco.py \
    --policy groot --port 8000 --no-auto-server \
    --task libero-10-LIVING_ROOM_SCENE5_… \
    --n-episodes 5 --seed 42
```

If the `image` camera now stays on the LIBERO living-room view past t=20s and `success_rate` moves above 0, probes #1 and #3 were both real. If the camera *still* degenerates, the residual bug lives in cause #2, #4, or #5 — file a follow-up with whichever is most actionable.

Refs #166.