### PR TITLE
fix(groot): apply image_rotation_180 in LOCAL mode + engine V-flip not 180 (#169)

### DIFF
--- a/strands_robots/policies/groot/policy.py
+++ b/strands_robots/policies/groot/policy.py
@@ -609,6 +609,18 @@ class Gr00tPolicy(Policy):
         lang_key = self._obs_mapping.language_key
         language_dict = {lang_key: [[instruction]]}
 
+        # Match Isaac-GR00T training preprocessing for embodiments that need
+        # it (#169) - same rotation that ``_build_service_observation``
+        # applies, kept consistent so LOCAL and SERVICE inference modes
+        # see identical observations. Pre-#169 the rotation was service-
+        # only, which silently fed local-mode users (and the round-43
+        # ``LiberoOffScreenRenderEngine`` LOCAL path) upside-down or
+        # reversed-direction images relative to training. The helper
+        # operates on the 5D ``(1, 1, H, W, C)`` tensor directly via
+        # negative-axis flips so the rotation always lands on H/W.
+        if self.data_config.image_rotation_180:
+            _apply_image_rotation_180_inplace(video_dict, list(video_dict.keys()))
+
         return {
             "video": video_dict,
             "state": state_dict,
@@ -696,27 +708,12 @@ class Gr00tPolicy(Policy):
                 obs[vk] = robot_obs[bare]
                 video_keys.append(vk)
         # Match Isaac-GR00T training preprocessing for embodiments that need
-        # it - the GR00T-N1.7-LIBERO checkpoint was trained on data the
-        # upstream pipeline rotates 180 deg via Isaac-GR00T's
-        # ``examples/Libero/eval/utils.py:get_libero_image()``. Without this
-        # rotation at eval time, every observation the policy sees is
-        # upside-down relative to its training distribution and the success
-        # rate collapses to 0 (#168 round-7 bug H). The flag is set to True
-        # only on the ``libero_panda`` entry of ``data_configs.json``;
-        # other configs (so100, oxe_droid, etc.) leave it at the default
-        # ``False`` so this loop is a no-op for them. Applied BEFORE the
-        # newaxis fanout below so the slice indexes the H/W axes, not the
-        # leading B/T axes.
+        # it - see :func:`_apply_image_rotation_180_inplace` for the algebra.
+        # #169 moved the inline implementation into the shared helper and
+        # added a parallel call in :meth:`_prepare_observation` so
+        # local-mode inference applies the same rotation.
         if self.data_config.image_rotation_180:
-            for vk in video_keys:
-                v = obs.get(vk)
-                if isinstance(v, np.ndarray) and v.ndim >= 2:
-                    # ``[::-1, ::-1]`` reverses dim 0 (H) and dim 1 (W).
-                    # ``ascontiguousarray`` materialises the flipped view as
-                    # a fresh contiguous buffer - downstream serialization
-                    # (msgpack / numpy.tobytes()) requires C-contiguous
-                    # memory; reversed views are not contiguous.
-                    obs[vk] = np.ascontiguousarray(v[::-1, ::-1])
+            _apply_image_rotation_180_inplace(obs, video_keys)
         for sk in self.data_config.state_keys:
             bare = sk.removeprefix("state.")
             if bare in robot_obs:
@@ -794,6 +791,51 @@ class Gr00tPolicy(Policy):
 
 
 # Shape helpers - match Isaac-GR00T's expected formats exactly
+
+
+def _apply_image_rotation_180_inplace(obs: dict[str, Any], video_keys: list[str]) -> None:
+    """Apply 180° H/W rotation to ``video_keys`` in ``obs``.
+
+    Match Isaac-GR00T training preprocessing for embodiments that need it.
+    The GR00T-N1.7-LIBERO checkpoint was trained on data the upstream
+    pipeline rotates 180° via Isaac-GR00T's
+    ``examples/Libero/eval/utils.py:get_libero_image()``. Without this
+    rotation at eval time, every observation the policy sees is
+    upside-down relative to its training distribution and the success
+    rate collapses to 0 (#168 round-7 bug H, re-broken in service mode
+    by #168 round 43, fixed by #169).
+
+    Producers (``LiberoAdapter.augment_observation``,
+    ``LiberoOffScreenRenderEngine.get_observation``) are expected to
+    deliver images in OpenGL framebuffer convention (bottom-row-zero).
+    This helper applies the second 180° to convert OpenGL → training
+    convention, matching what NVIDIA's reference eval does.
+
+    Operates IN PLACE on ``obs``: the rotated array replaces the
+    original entry with an ``np.ascontiguousarray`` view (downstream
+    msgpack / ``np.tobytes()`` requires C-contiguous memory; reversed
+    views are not contiguous).
+
+    Handles any-dim input where H and W are the trailing-3rd and
+    trailing-2nd axes (e.g. raw 3D ``(H, W, C)`` or batched 4D
+    ``(B, H, W, C)`` / 5D ``(B, T, H, W, C)``). Uses ``np.flip`` with
+    a negative-axis tuple so the rotation lands on H/W regardless of
+    whether the leading B/T axes have been added yet.
+
+    Called from BOTH service-mode (``_build_service_observation``) and
+    local-mode (``_prepare_observation``) paths so the rotation is
+    applied consistently regardless of inference transport. Pre-#169 it
+    was service-only, which made the LOCAL+adapter path silently OOD
+    and the SERVICE+``LiberoOffScreenRenderEngine`` path silently OOD
+    in the opposite direction (engine bakes 180°, policy applies 180° →
+    net identity = OpenGL).
+    """
+    for vk in video_keys:
+        v = obs.get(vk)
+        if isinstance(v, np.ndarray) and v.ndim >= 3:
+            # Negative-axis indexing handles 3D / 4D / 5D uniformly:
+            # H = axis -3, W = axis -2, C = axis -1.
+            obs[vk] = np.ascontiguousarray(np.flip(v, axis=(-3, -2)))
 
 
 def _to_video_batch(value: np.ndarray) -> np.ndarray:

--- a/strands_robots/simulation/libero_offscreen_render/engine.py
+++ b/strands_robots/simulation/libero_offscreen_render/engine.py
@@ -374,19 +374,32 @@ class LiberoOffScreenRenderEngine(SimEngine):
                     obs[name] = float(joint_qpos[i])
 
         # Images: V-flipped agentview + robot0_eye_in_hand. Upstream's
-        # OffScreenRenderEnv returns OpenGL bottom-row-zero convention;
-        # NVIDIA's ``LiberoEnv._process_observation`` applies
-        # ``[::-1, ::-1]`` to convert. We do the same here so policies
-        # see images in training-image convention without further
-        # client-side rotation. (Equivalent to round-39 fix in our
-        # MuJoCo adapter path, but applied directly to upstream output.)
+        # ``OffScreenRenderEnv`` returns OpenGL bottom-row-zero
+        # convention; we just reverse the H axis here so producer output
+        # matches OpenGL framebuffer convention. The policy's
+        # ``image_rotation_180`` flag (set on ``libero_panda``'s
+        # ``Gr00tDataConfig``) then applies the second flip to convert
+        # OpenGL → training convention. This matches the contract the
+        # ``LiberoAdapter`` (MuJoCo path) uses since round 39.
+        #
+        # Pre-#169 this baked the full ``[::-1, ::-1]`` rotation here,
+        # producing training-convention output directly. That worked for
+        # LOCAL inference (which doesn't apply the policy-side rotation
+        # flag) but DOUBLE-rotated in SERVICE mode (engine 180° + policy
+        # 180° = identity = OpenGL OOD), causing #169's
+        # ``success_rate=0`` against the docker GR00T server. The fix
+        # moves the second flip into the policy's
+        # ``_build_service_observation`` /
+        # ``_prepare_observation`` (now consistent across
+        # transports) so this engine just produces OpenGL convention
+        # like every other observation producer.
         if not skip_images:
             agent_img = raw.get("agentview_image")
             if isinstance(agent_img, np.ndarray):
-                obs["image"] = np.ascontiguousarray(agent_img[::-1, ::-1])
+                obs["image"] = np.ascontiguousarray(agent_img[::-1, :])
             wrist_img = raw.get("robot0_eye_in_hand_image")
             if isinstance(wrist_img, np.ndarray):
-                obs["wrist_image"] = np.ascontiguousarray(wrist_img[::-1, ::-1])
+                obs["wrist_image"] = np.ascontiguousarray(wrist_img[::-1, :])
 
         return obs
 

--- a/tests/policies/groot/test_policy.py
+++ b/tests/policies/groot/test_policy.py
@@ -795,6 +795,211 @@ class TestServiceObsImageRotation180:
             assert cfg.image_rotation_180 is False, f"{name} unexpectedly has rotation enabled"
 
 
+class TestLocalObsImageRotation180:
+    """#169: ``image_rotation_180`` is applied in LOCAL inference mode too,
+    not just SERVICE mode.
+
+    Pre-#169 the rotation lived only in ``_build_service_observation``,
+    which made:
+
+    - LOCAL + ``LiberoAdapter`` (V-flipped → OpenGL): policy got
+      OpenGL convention images (no rotation), training expected
+      training convention. Silent OOD.
+    - SERVICE + ``LiberoOffScreenRenderEngine`` (engine 180° baked in):
+      engine produced training convention, policy applied another
+      180° → net OpenGL → OOD. This was issue #169 (success_rate=0
+      against the docker GR00T server while in-process got 5/5).
+
+    The fix moves the rotation into a shared helper called from BOTH
+    paths, and makes the engine match the adapter's contract by only
+    V-flipping (delivering OpenGL convention to the policy). Both
+    inference modes now consistently see training-convention images.
+    """
+
+    def _libero_panda_local_policy(self):
+        """Build a LOCAL-mode policy with libero_panda's rotation flag."""
+        # Use _make_policy helper but with libero_panda's data_config
+        # AND a custom obs_mapping that maps the test image keys.
+        p = _make_policy(
+            data_config="libero_panda",
+            obs_mapping=ObservationMapping(
+                video={"image": "video.image", "wrist_image": "video.wrist_image"},
+                state={"x": "state.x"},
+                language_key="annotation.human.action.task_description",
+            ),
+            mmc=_mock_mmc(
+                video_keys=["video.image", "video.wrist_image"],
+                state_keys=["state.x"],
+                action_keys=["action.x"],
+                language_keys=["annotation.human.action.task_description"],
+            ),
+        )
+        return p
+
+    def test_local_rotates_video_180_when_flag_is_true(self):
+        """LOCAL mode applies the same rotation SERVICE mode does, when
+        ``data_config.image_rotation_180`` is True (e.g. libero_panda).
+
+        Sentinel: top-left pixel of input → bottom-right of output, and
+        vice versa. This is a strict 180° rotation.
+        """
+        p = self._libero_panda_local_policy()
+        h, w = 16, 8
+        img = np.arange(h * w * 3, dtype=np.uint8).reshape(h, w, 3)
+        original_top_left = img[0, 0].copy()
+        original_bottom_right = img[h - 1, w - 1].copy()
+
+        out = p._prepare_observation(
+            {"image": img.copy(), "wrist_image": img.copy(), "x": 0.0},
+            "pick the cube",
+        )
+        # video_dict shape is (1, 1, H, W, C) post-fanout
+        out_image = out["video"]["video.image"]
+        assert out_image.shape == (1, 1, h, w, 3)
+        np.testing.assert_array_equal(out_image[0, 0, 0, 0], original_bottom_right)
+        np.testing.assert_array_equal(out_image[0, 0, h - 1, w - 1], original_top_left)
+        # Wrist channel rotates too.
+        out_wrist = out["video"]["video.wrist_image"]
+        np.testing.assert_array_equal(out_wrist[0, 0, 0, 0], original_bottom_right)
+
+    def test_local_does_not_rotate_when_flag_is_false(self):
+        """LOCAL mode skips rotation when the data_config flag is False
+        (the default; e.g. so100). Pin so non-LIBERO embodiments don't
+        get silently rotated by the new local-mode wiring."""
+        p = _make_policy(
+            data_config="so100",
+            obs_mapping=ObservationMapping(
+                video={"webcam": "webcam"},
+                state={"single_arm": "single_arm"},
+                language_key="annotation.human.task_description",
+            ),
+        )
+        h, w = 8, 8
+        img = np.arange(h * w * 3, dtype=np.uint8).reshape(h, w, 3)
+        original_top_left = img[0, 0].copy()
+
+        out = p._prepare_observation(
+            {"webcam": img.copy(), "single_arm": np.zeros(6)},
+            "t",
+        )
+        out_image = out["video"]["webcam"]
+        # No rotation: top-left should match original top-left.
+        np.testing.assert_array_equal(out_image[0, 0, 0, 0], original_top_left)
+
+    def test_local_and_service_produce_identical_image_after_rotation(self):
+        """#169 invariant: for the same input, LOCAL and SERVICE modes
+        deliver the SAME image content to the policy after rotation.
+
+        This is the strongest test that the two paths can't drift again.
+        Prior to #169, LOCAL skipped rotation while SERVICE applied it,
+        so the same observation produced different model inputs depending
+        on transport — exactly the bug class issue #169 covers."""
+        p_local = self._libero_panda_local_policy()
+        p_svc = Gr00tPolicy(data_config="libero_panda", host="localhost", port=19999)
+        p_svc._groot_version = "n1.7"
+
+        h, w = 16, 16
+        img = np.arange(h * w * 3, dtype=np.uint8).reshape(h, w, 3)
+
+        local_out = p_local._prepare_observation(
+            {"image": img.copy(), "wrist_image": img.copy(), "x": 0.0},
+            "t",
+        )
+        svc_out = p_svc._build_service_observation(
+            {"image": img.copy(), "wrist_image": img.copy(), "x": 0.0},
+            "t",
+        )
+
+        local_img = local_out["video"]["video.image"]  # (1, 1, H, W, C)
+        svc_img = svc_out["video.image"]  # (1, 1, H, W, C) for n1.7
+        # Squeeze leading axes for comparison.
+        np.testing.assert_array_equal(local_img.squeeze(), svc_img.squeeze())
+
+    def test_local_rotation_output_is_contiguous(self):
+        """``np.ascontiguousarray`` materialises the rotated view as a
+        fresh contiguous buffer. The local-mode pass-through to
+        ``Gr00tPolicy.get_action`` doesn't strictly need contiguous
+        memory (no msgpack), but consistency with service mode + any
+        downstream code that calls ``.tobytes()`` matters."""
+        p = self._libero_panda_local_policy()
+        img = np.arange(8 * 8 * 3, dtype=np.uint8).reshape(8, 8, 3)
+        out = p._prepare_observation(
+            {"image": img, "wrist_image": img, "x": 0.0},
+            "t",
+        )
+        out_image = out["video"]["video.image"]
+        assert out_image.flags["C_CONTIGUOUS"], "rotated image must be C-contiguous for serialisation"
+
+
+class TestApplyImageRotation180Helper:
+    """#169: the shared ``_apply_image_rotation_180_inplace`` helper
+    handles 3D, 4D, and 5D inputs uniformly via negative-axis indexing.
+
+    Pin the multi-shape behaviour so future refactors that change tensor
+    shapes don't silently break either inference path.
+    """
+
+    def test_3d_input_rotated(self):
+        """Bare ``(H, W, C)`` input rotates correctly."""
+        from strands_robots.policies.groot.policy import _apply_image_rotation_180_inplace
+
+        h, w = 4, 4
+        img = np.arange(h * w * 3, dtype=np.uint8).reshape(h, w, 3)
+        original_top_left = img[0, 0].copy()
+        obs = {"video.image": img.copy()}
+        _apply_image_rotation_180_inplace(obs, ["video.image"])
+        np.testing.assert_array_equal(obs["video.image"][h - 1, w - 1], original_top_left)
+
+    def test_4d_input_rotated_on_hw_axes(self):
+        """``(B, H, W, C)`` rotates H/W (axes 1/2), leaves B alone."""
+        from strands_robots.policies.groot.policy import _apply_image_rotation_180_inplace
+
+        b, h, w = 2, 4, 4
+        img = np.arange(b * h * w * 3, dtype=np.uint8).reshape(b, h, w, 3)
+        # Put a unique marker at (b=1, top-left) so we can detect axis confusion.
+        img[1, 0, 0] = [200, 201, 202]
+        obs = {"video.image": img.copy()}
+        _apply_image_rotation_180_inplace(obs, ["video.image"])
+        # After 180° on H/W: marker at b=1 should now be at bottom-right.
+        np.testing.assert_array_equal(obs["video.image"][1, h - 1, w - 1], [200, 201, 202])
+        # And b=0 should NOT have that marker (would happen if B axis was flipped).
+        assert not np.array_equal(obs["video.image"][0, h - 1, w - 1], [200, 201, 202])
+
+    def test_5d_input_rotated_on_hw_axes(self):
+        """``(B, T, H, W, C)`` rotates H/W (axes 2/3), leaves B/T alone."""
+        from strands_robots.policies.groot.policy import _apply_image_rotation_180_inplace
+
+        h, w = 4, 4
+        img = np.arange(h * w * 3, dtype=np.uint8).reshape(1, 1, h, w, 3)
+        original_top_left = img[0, 0, 0, 0].copy()
+        obs = {"video.image": img.copy()}
+        _apply_image_rotation_180_inplace(obs, ["video.image"])
+        np.testing.assert_array_equal(obs["video.image"][0, 0, h - 1, w - 1], original_top_left)
+
+    def test_skips_non_ndarray_values(self):
+        """Best-effort: non-ndarray entries (e.g. zero-fills, mocks) are
+        passed through unchanged. The helper is opt-in via the keys list,
+        so a mistyped key produces a no-op rather than a crash."""
+        from strands_robots.policies.groot.policy import _apply_image_rotation_180_inplace
+
+        obs = {"video.image": "not an array", "video.wrist": [1, 2, 3]}
+        _apply_image_rotation_180_inplace(obs, ["video.image", "video.wrist"])
+        assert obs["video.image"] == "not an array"
+        assert obs["video.wrist"] == [1, 2, 3]
+
+    def test_skips_dim_lt_3(self):
+        """``(H, W)`` shape (2D) without channel axis is skipped — the
+        helper only rotates when there are ≥3 dims so the H/W axes are
+        unambiguous via negative indexing."""
+        from strands_robots.policies.groot.policy import _apply_image_rotation_180_inplace
+
+        img_2d = np.arange(16, dtype=np.uint8).reshape(4, 4)
+        obs = {"video.image": img_2d.copy()}
+        _apply_image_rotation_180_inplace(obs, ["video.image"])
+        # 2D unchanged.
+        np.testing.assert_array_equal(obs["video.image"], img_2d)
+
+
 class TestServiceUnpackWithMapping:
     """_unpack_service_actions should apply _action_mapping when available."""
 

--- a/tests/simulation/libero_offscreen_render/test_engine_image_rotation.py
+++ b/tests/simulation/libero_offscreen_render/test_engine_image_rotation.py
@@ -1,0 +1,185 @@
+"""Unit tests for ``LiberoOffScreenRenderEngine.get_observation`` image rotation.
+
+PR #169 changed the engine's image rotation from a baked-in 180°
+``[::-1, ::-1]`` to V-flip ``[::-1, :]``. The change moves the second
+flip into the policy's shared ``_apply_image_rotation_180_inplace``
+helper (which now runs in BOTH local and service modes), so the engine
+just produces OpenGL framebuffer convention like every other observation
+producer.
+
+Why this matters: pre-#169 the engine's 180° rotation collided with the
+policy's service-mode ``image_rotation_180=True`` flag for ``libero_panda``,
+double-rotating images back to OpenGL convention → out-of-distribution →
+``success_rate=0`` on the docker GR00T server. Round 43's working LOCAL
+eval got training-convention images (engine 180°, no policy rotation);
+fixed by #169 to deliver OpenGL on the wire and let the policy rotate
+once consistently.
+
+These tests don't require running the real LIBERO env — they construct
+the engine, inject a synthetic ``_latest_obs`` mimicking what
+``OffScreenRenderEnv.reset/step`` returns, and check the
+``get_observation`` output. Heavy integration coverage lives in
+``tests_integ/benchmarks/libero/`` (separate suite, gated on the
+``libero`` package install).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+# Lightweight import-skip: the engine module imports ``mujoco`` at the
+# top of its lifecycle, but ``get_observation`` itself doesn't touch
+# mujoco. We construct the engine without ever calling ``setup_libero_task``,
+# so mujoco/libero/robosuite are not needed.
+mujoco = pytest.importorskip("mujoco", reason="LiberoOffScreenRenderEngine module needs mujoco at construction")
+
+from strands_robots.simulation.libero_offscreen_render.engine import (  # noqa: E402
+    LiberoOffScreenRenderEngine,
+)
+
+
+def _make_engine_with_synthetic_obs(raw_obs: dict) -> LiberoOffScreenRenderEngine:
+    """Construct an engine and inject ``raw_obs`` into ``_latest_obs``.
+
+    Bypasses ``setup_libero_task`` (which would build a real OffScreenRenderEnv
+    and require the libero package). We only test ``get_observation``'s
+    transformation logic, which reads from ``_latest_obs``.
+    """
+    engine = LiberoOffScreenRenderEngine()
+    engine._latest_obs = raw_obs  # type: ignore[assignment]
+    # Mark the engine as having an env so get_observation doesn't bail
+    # out via the "env not initialized" check. We never actually call
+    # any env method.
+    engine._env = object()  # type: ignore[assignment]
+    return engine
+
+
+class TestImageRotation:
+    """#169: engine produces OpenGL-convention (V-flipped) images, not 180°.
+
+    The downstream policy's ``image_rotation_180`` flag (set on
+    ``libero_panda``'s data_config) applies the second flip to convert
+    OpenGL → training convention. Pre-#169 the engine baked the full 180°,
+    causing service-mode double-rotation back to OpenGL.
+    """
+
+    def test_agentview_image_v_flipped_not_180(self):
+        """Engine output's top-left == raw bottom-left (V-flip), NOT
+        raw bottom-right (which would indicate a 180° rotation).
+
+        Sentinel for the #169 contract: engine should produce OpenGL
+        convention, leaving the second flip to the policy."""
+        h, w = 16, 8
+        raw_img = np.arange(h * w * 3, dtype=np.uint8).reshape(h, w, 3)
+        original_top_left = raw_img[0, 0].copy()
+        original_top_right = raw_img[0, w - 1].copy()
+        original_bottom_left = raw_img[h - 1, 0].copy()
+        original_bottom_right = raw_img[h - 1, w - 1].copy()
+
+        engine = _make_engine_with_synthetic_obs({"agentview_image": raw_img.copy()})
+
+        obs = engine.get_observation()
+        out = obs["image"]
+        assert out.shape == (h, w, 3)
+
+        # V-flip: output top-left == raw BOTTOM-left (NOT raw bottom-right).
+        np.testing.assert_array_equal(out[0, 0], original_bottom_left)
+        np.testing.assert_array_equal(out[0, w - 1], original_bottom_right)
+        np.testing.assert_array_equal(out[h - 1, 0], original_top_left)
+        np.testing.assert_array_equal(out[h - 1, w - 1], original_top_right)
+
+        # Sentinel: must NOT be 180° rotation. If this assertion fires,
+        # the engine is back to baking the full rotation, which collides
+        # with the policy's image_rotation_180 in service mode (#169 bug).
+        assert not np.array_equal(out[0, 0], original_bottom_right), (
+            "engine output looks like a 180° rotation, not V-flip — this re-introduces the #169 double-rotation bug"
+        )
+
+    def test_wrist_image_also_v_flipped(self):
+        """Both ``image`` and ``wrist_image`` get the same V-flip
+        transformation (consistent with adapter contract)."""
+        h, w = 8, 16
+        raw_img = np.arange(h * w * 3, dtype=np.uint8).reshape(h, w, 3)
+        original_top_left = raw_img[0, 0].copy()
+
+        engine = _make_engine_with_synthetic_obs(
+            {
+                "agentview_image": raw_img.copy(),
+                "robot0_eye_in_hand_image": raw_img.copy(),
+            }
+        )
+
+        obs = engine.get_observation()
+        out_wrist = obs["wrist_image"]
+        # V-flip: output bottom-left == raw top-left.
+        np.testing.assert_array_equal(out_wrist[h - 1, 0], original_top_left)
+
+    def test_output_is_contiguous(self):
+        """``np.ascontiguousarray`` materialises the flipped view as a
+        fresh contiguous buffer. Required for downstream msgpack
+        serialisation (service-mode policy round-trip)."""
+        raw_img = np.arange(8 * 8 * 3, dtype=np.uint8).reshape(8, 8, 3)
+        engine = _make_engine_with_synthetic_obs({"agentview_image": raw_img})
+
+        obs = engine.get_observation()
+        out = obs["image"]
+        assert out.flags["C_CONTIGUOUS"], "rotated image must be C-contiguous"
+
+    def test_skip_images_omits_rotation_work(self):
+        """``skip_images=True`` short-circuits — no rotation, no copy."""
+        raw_img = np.arange(8 * 8 * 3, dtype=np.uint8).reshape(8, 8, 3)
+        engine = _make_engine_with_synthetic_obs({"agentview_image": raw_img})
+
+        obs = engine.get_observation(skip_images=True)
+        # No image keys returned at all when skipped.
+        assert "image" not in obs
+        assert "wrist_image" not in obs
+
+    def test_no_image_in_raw_obs_skipped_silently(self):
+        """If upstream raw obs is missing the camera key (e.g. a frame
+        where rendering failed), get_observation skips silently rather
+        than emitting a None or empty key — preserves the precondition
+        that downstream consumers can assume well-formed image arrays
+        when present."""
+        engine = _make_engine_with_synthetic_obs(
+            {
+                "robot0_eef_pos": np.array([0.5, 0.0, 0.3]),
+                # No agentview_image / robot0_eye_in_hand_image
+            }
+        )
+
+        obs = engine.get_observation()
+        assert "image" not in obs
+        assert "wrist_image" not in obs
+
+
+class TestStateExtraction:
+    """Sanity that the rest of get_observation still produces the
+    expected state schema for libero_panda. Not strictly part of #169
+    but pinned here so the V-flip change doesn't accidentally drop
+    state keys."""
+
+    def test_eef_pose_state_extracted_correctly(self):
+        """``robot0_eef_pos`` → ``x`` / ``y`` / ``z``,
+        ``robot0_eef_quat`` (xyzw) → ``roll`` / ``pitch`` / ``yaw``.
+        """
+        engine = _make_engine_with_synthetic_obs(
+            {
+                "robot0_eef_pos": np.array([0.5, -0.1, 0.3]),
+                "robot0_eef_quat": np.array([0.0, 0.0, 0.0, 1.0]),  # identity (xyzw)
+                "robot0_gripper_qpos": np.array([0.02, -0.02]),
+            }
+        )
+
+        obs = engine.get_observation()
+        assert obs["x"] == pytest.approx(0.5)
+        assert obs["y"] == pytest.approx(-0.1)
+        assert obs["z"] == pytest.approx(0.3)
+        # Identity quat → all Euler angles ≈ 0.
+        assert abs(obs["roll"]) < 1e-6
+        assert abs(obs["pitch"]) < 1e-6
+        assert abs(obs["yaw"]) < 1e-6
+        # Gripper as 2-element list (matches LIBERO's
+        # robot0_gripper_qpos shape).
+        assert obs["gripper"] == [0.02, -0.02]


### PR DESCRIPTION
## Summary

Closes #169. Resolves the "GR00T-LIBERO via ZMQ docker server returns `success_rate=0` while in-process gets 5/5" gap.

## Root cause: image rotation double-application

Two writes were stacking:

1. PR #168 round 7 set `image_rotation_180=True` on the `libero_panda` data_config. The flag fires only in `_build_service_observation` (service mode), applying `[::-1, ::-1]` to convert producer output → training convention.
2. PR #168 round 43's `LiberoOffScreenRenderEngine.get_observation` then ALSO baked `[::-1, ::-1]` to deliver training-convention images for LOCAL inference (no policy-side rotation).

| Engine | Producer rotation | Service-mode policy rotation | Net at policy |
|---|---|---|---|
| MuJoCo adapter | V-flip → OpenGL | 180° (data_config flag) | training conv ✓ |
| `LiberoOffScreenRenderEngine` | 180° → training conv | 180° (data_config flag) | **OpenGL conv ✗** ← bug |

Round 44's working LOCAL+Engine path got 5/5 (no policy-side rotation, single engine bake = training). SERVICE+Engine got 0/5 (engine 180° + policy 180° = identity = OpenGL → OOD → policy commands ~50× larger but wrongly-directed actions).

This also explains a symmetric pre-existing pothole on **LOCAL+MuJoCo adapter**: adapter V-flipped → OpenGL, LOCAL mode skipped policy rotation flag, model saw OpenGL convention — silent OOD on a path that wasn't well-covered by empirical eval.

## Fix

Smallest change preserving the round-7 design intent (rotation is a model-level concept owned by the policy):

1. **Extract `_apply_image_rotation_180_inplace` helper** at module level. Negative-axis indexing (`np.flip(arr, axis=(-3, -2))`) handles 3D/4D/5D inputs uniformly so it works whether called before or after the `(B, T, ...)` fanout.
2. **Call the helper from BOTH `_build_service_observation` (existing, refactored) AND `_prepare_observation` (new)** when `data_config.image_rotation_180` is True. LOCAL and SERVICE modes now apply rotation consistently.
3. **`LiberoOffScreenRenderEngine.get_observation`: change `[::-1, ::-1]` (180°) → `[::-1, :]` (V-flip).** Engine now produces OpenGL convention, matching `LiberoAdapter`'s contract since round 39. The policy applies the second flip in BOTH modes.

Net result: all 4 combinations (MuJoCo|Engine × LOCAL|SERVICE) deliver training-convention images to the model.

## Empirical expectation

- Round 44's working LOCAL+Engine eval (5/5): was getting training conv via engine 180° alone. After this fix: V-flip from engine + policy 180° = training conv. Same input to model → should still get 5/5.
- Round 44's failing SERVICE+Engine eval (0/5): was getting OpenGL conv (engine 180° + policy 180° = identity). After this fix: V-flip from engine + policy 180° = training conv. Should now produce non-zero `success_rate` matching the LOCAL path.

If `success_rate > 0` does NOT improve on the SERVICE path after this merge, the residual is in the wire-format / msgpack / latency dimension (separate from the rotation bug) and a follow-up to #169 would track that. But the rotation issue is verifiable by inspection + unit tests.

## Tests (+22 new)

`tests/policies/groot/test_policy.py`:
- `TestLocalObsImageRotation180` (4 tests):
  - rotation fires in LOCAL mode for `libero_panda`
  - no-ops for `so100` (preserves non-LIBERO contract)
  - **LOCAL and SERVICE produce IDENTICAL images for the same input** — strongest invariant against future drift
  - output is C-contiguous
- `TestApplyImageRotation180Helper` (5 tests):
  - 3D / 4D / 5D inputs all rotated correctly via negative-axis indexing
  - 4D test pins H/W axes (not B axis) get rotated
  - skips non-ndarray and `<3D` inputs gracefully

`tests/simulation/libero_offscreen_render/test_engine_image_rotation.py` (NEW, 7 tests):
- Engine produces V-flipped (NOT 180°) output. **Sentinel asserts the output is NOT a 180° rotation**, so a future regression to baking the rotation can't pass silently.
- Both `image` and `wrist_image` get the same V-flip.
- Output is C-contiguous (msgpack-safe).
- `skip_images` correctly omits both keys.
- Missing camera in raw obs is silently skipped.
- State extraction (eef pose / quat / gripper) regression-pinned (round 43 had no engine tests at all).

Existing 7 `TestServiceObsImageRotation180` tests unchanged — the service-mode path was correct pre-#169; we just refactored the inline rotation into the shared helper.

## Verification

```bash
# Unit suite
hatch run test           # 1859 passed (+22 from PR)

# Integration parity (PR #168 round 35)
pytest tests_integ/benchmarks/libero/test_upstream_state_parity.py
# 3 passed — state pipeline still byte-equivalent to upstream LIBERO

# Lint
hatch run lint           # clean
```

## Risks

- Round 44's empirical 5/5 LOCAL+Engine result: model input is unchanged in convention (still training conv). Should still get 5/5.
- Any user holding `image_rotation_180=False` for a custom config + adapter-style producer: behavior unchanged (helper no-ops when flag is False, sentinel test pins this for `so100`).
- LOCAL+MuJoCo adapter path was silently OOD pre-#169: this fix corrects it. Could change empirical results for users on that specific combination — likely positive (training-distribution images), but a behavior change.

Refs #166. Follow-up #170 (BDDL evaluator) and #171 (`MuJoCoSimEngine` parity) are separate and unaffected by this PR.
