### PR TITLE
fix(libero): BDDL evaluator agrees with robosuite check_success at libero-10/SCENE5 (#170)

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,6 +501,8 @@ agent.tool.gr00t_inference(action="stop", port=8000)
 | `STRANDS_LIBERO_ACTION_LOG_MAX` | Max number of `apply()` calls to log per episode when `STRANDS_LIBERO_ACTION_LOG=1`. | `50` |
 | `STRANDS_LIBERO_STATE_LOG` | Set to `1` to emit per-step diagnostic logs of the state values (`state.x/y/z/roll/pitch/yaw/gripper`) the LIBERO adapter feeds to the GR00T policy. Pairs with `STRANDS_LIBERO_ACTION_LOG` for end-to-end interface bisection. | unset |
 | `STRANDS_LIBERO_STATE_LOG_MAX` | Max number of `augment_observation()` calls to log per episode when `STRANDS_LIBERO_STATE_LOG=1`. | `50` |
+| `STRANDS_LIBERO_PREDICATE_LOG` | Set to `1` to emit per-step diagnostic logs from `LiberoAdapter.is_success` showing both the BDDL evaluator's verdict and the upstream `env.check_success()` verdict (when available), with per-leaf predicate breakdowns. Used to bisect BDDL predicate evaluator vs robosuite `check_success` disagreements (see #170). | unset |
+| `STRANDS_LIBERO_PREDICATE_LOG_MAX` | Max number of `is_success` calls to log per episode when `STRANDS_LIBERO_PREDICATE_LOG=1`. | `10` |
 
 ### Cache Directory
 

--- a/strands_robots/benchmarks/libero/adapter.py
+++ b/strands_robots/benchmarks/libero/adapter.py
@@ -515,6 +515,30 @@ class LiberoAdapter(BenchmarkProtocol):
             self._state_log_max = 50
         self._state_log_step: int = 0
 
+        # Round 170 (#170) — diagnostic gate for the BDDL predicate
+        # evaluator's disagreement with ``env.check_success`` discovered
+        # in PR #168 round 44. Set ``STRANDS_LIBERO_PREDICATE_LOG=1`` to
+        # emit a per-step log line when the two verdicts differ
+        # (capped at ``STRANDS_LIBERO_PREDICATE_LOG_MAX`` per episode,
+        # default 10). Only fires when the sim wraps an
+        # ``OffScreenRenderEnv`` (so we have ``env.check_success`` as
+        # ground truth); silent on backends without it.
+        self._predicate_log_enabled = os.environ.get("STRANDS_LIBERO_PREDICATE_LOG", "").strip().lower() in (
+            "1",
+            "true",
+            "yes",
+            "on",
+        )
+        try:
+            self._predicate_log_max = int(os.environ.get("STRANDS_LIBERO_PREDICATE_LOG_MAX", "10"))
+        except ValueError:
+            logger.warning(
+                "STRANDS_LIBERO_PREDICATE_LOG_MAX=%r is not an integer; defaulting to 10",
+                os.environ.get("STRANDS_LIBERO_PREDICATE_LOG_MAX"),
+            )
+            self._predicate_log_max = 10
+        self._predicate_log_count: int = 0
+
     # Construction helpers
 
     @classmethod
@@ -941,6 +965,9 @@ class LiberoAdapter(BenchmarkProtocol):
         # round-29 behaviour for ACTION_LOG via the controller's
         # reset() call inside _install_action_controller above).
         self._state_log_step = 0
+        # Round 170: reset per-episode disagreement counter so each
+        # episode logs its own first N divergences.
+        self._predicate_log_count = 0
 
     def prewarm(self, sim: SimEngine) -> None:
         """Idempotent setup that should run BEFORE ``sim.start_cameras_recording``.
@@ -1737,26 +1764,78 @@ class LiberoAdapter(BenchmarkProtocol):
         path remains as a fallback for backends without an
         ``OffScreenRenderEnv`` (e.g. our ``MuJoCoSimEngine``); the
         residual bug in the BDDL predicate evaluator is a separate
-        investigation track.
+        investigation track (see #170).
 
         Best-effort: if any introspection step fails (the env
         doesn't have ``check_success``, or ``check_success`` raises),
         falls back to the BDDL predicate tree. This keeps
         ``LiberoAdapter`` working on engines that don't have an
         upstream env.
+
+        **Diagnostic mode (#170)**. Set
+        ``STRANDS_LIBERO_PREDICATE_LOG=1`` to log BOTH verdicts (env
+        and BDDL) for every step where they disagree. Used to bisect
+        which predicate / body lookup is wrong in the BDDL evaluator
+        without affecting the returned verdict (always uses the env
+        path when available, so eval correctness is preserved).
+        Diagnostics fire only on the first ``STRANDS_LIBERO_PREDICATE_LOG_MAX``
+        (default 10) disagreements per episode to keep logs tractable.
         """
         env = getattr(sim, "_env", None)
+        env_verdict: bool | None = None
         if env is not None:
             check = getattr(env, "check_success", None)
             if callable(check):
                 try:
-                    return bool(check())
+                    env_verdict = bool(check())
                 except Exception as e:  # noqa: BLE001
                     logger.debug(
                         "LiberoAdapter.is_success: env.check_success raised %s; "
                         "falling back to BDDL predicate evaluator",
                         e,
                     )
+
+        # Round 170 diagnostic: log both verdicts when:
+        # (a) env says success (env=True) — to verify BDDL agrees on the
+        #     success transition, and identify the divergent leaf if not, OR
+        # (b) they disagree at any point (env != bddl) — to capture
+        #     transient divergences.
+        # Gated on env var so production eval pays zero cost.
+        if self._predicate_log_enabled and env_verdict is not None:
+            try:
+                bddl_verdict = bool(self._success_fn(sim))
+            except Exception as e:  # noqa: BLE001
+                bddl_verdict = None
+                logger.debug("predicate_log: BDDL evaluator raised %s", e)
+            should_log = (
+                bddl_verdict is not None
+                and (env_verdict or env_verdict != bddl_verdict)
+                and self._predicate_log_count < self._predicate_log_max
+            )
+            if should_log:
+                # Walk the goal tree to find which sub-predicate
+                # diverges. Each leaf reports its own verdict so we
+                # can grep the divergent one.
+                logger.warning(
+                    "PREDICATE_LOG ep=%d log#%d: env=%s bddl=%s; goal=%r",
+                    self._episode_count,
+                    self._predicate_log_count,
+                    env_verdict,
+                    bddl_verdict,
+                    self.problem.goal,
+                )
+                # Per-leaf verdicts, recursive walk.
+                for leaf_repr, leaf_verdict in _walk_predicate_tree(self.problem.goal, sim):
+                    logger.warning(
+                        "PREDICATE_LOG ep=%d   leaf %s = %s",
+                        self._episode_count,
+                        leaf_repr,
+                        leaf_verdict,
+                    )
+                self._predicate_log_count += 1
+
+        if env_verdict is not None:
+            return env_verdict
         return bool(self._success_fn(sim))
 
     # Internals
@@ -2972,6 +3051,67 @@ def _extract_position(state: dict[str, Any]) -> list[float] | None:
             if isinstance(pos, list) and len(pos) == 3 and all(isinstance(c, (int, float)) for c in pos):
                 return [float(c) for c in pos]
     return None
+
+
+def _walk_predicate_tree(node: Any, sim: SimEngine) -> list[tuple[str, bool]]:
+    """Walk a BDDL goal tree and return ``(repr, verdict)`` for every leaf.
+
+    Round 170 (#170) diagnostic helper. Used by
+    :meth:`LiberoAdapter.is_success` when
+    ``STRANDS_LIBERO_PREDICATE_LOG=1`` is set, so we can identify which
+    sub-predicate disagrees with ``env.check_success`` instead of just
+    knowing the top-level goal disagrees. Compiles each ``Pred`` leaf in
+    isolation via the existing ``compile_goal`` machinery and runs it
+    against the live ``sim``.
+
+    Each reported leaf string includes the actual body positions
+    looked up via ``sim.get_body_state`` so we can see why a position-
+    based predicate (``on``, ``inside``, etc.) returned its verdict —
+    distinguishes between "name doesn't resolve" (None pos), "wrong
+    geometric threshold" (positions present but predicate still False),
+    and "true success" (positions present and predicate True).
+
+    Returns a list of ``(human-readable predicate, verdict)`` tuples,
+    one per leaf, in tree-traversal order. Combinators (``And`` / ``Or``
+    / ``Not``) are reported as nested-string prefixes.
+    """
+    from strands_robots.benchmarks.libero.bddl_parser import And, Not, Or, Pred, compile_goal
+    from strands_robots.simulation.predicates import _body_position
+
+    out: list[tuple[str, bool]] = []
+
+    def _arg_diag(arg: str) -> str:
+        """Render a body name + its position for diagnostic output."""
+        pos = _body_position(sim, arg)
+        if pos is None:
+            return f"{arg}=NONE"
+        return f"{arg}=[{pos[0]:.3f}, {pos[1]:.3f}, {pos[2]:.3f}]"
+
+    def visit(n: Any, prefix: str = "") -> None:
+        if isinstance(n, Pred):
+            try:
+                verdict = bool(compile_goal(n)(sim))
+            except Exception as e:  # noqa: BLE001
+                out.append((f"{prefix}({n.name} {' '.join(n.args)})", False))
+                logger.debug("predicate_log: leaf %r raised %s", n, e)
+                return
+            arg_diag = " ".join(_arg_diag(a) for a in n.args)
+            out.append((f"{prefix}({n.name} {arg_diag})", verdict))
+            return
+        if isinstance(n, And):
+            for c in n.clauses:
+                visit(c, prefix + "AND/")
+            return
+        if isinstance(n, Or):
+            for c in n.clauses:
+                visit(c, prefix + "OR/")
+            return
+        if isinstance(n, Not):
+            visit(n.clause, prefix + "NOT/")
+            return
+
+    visit(node)
+    return out
 
 
 def _extract_pose(state: dict[str, Any] | None) -> tuple[list[float] | None, list[float] | None]:

--- a/strands_robots/benchmarks/libero/bddl_parser.py
+++ b/strands_robots/benchmarks/libero/bddl_parser.py
@@ -185,7 +185,22 @@ def _parse_sexp(tokens: list[str]) -> Any:
 def _on_kwargs(args: list[str]) -> dict[str, Any]:
     if len(args) != 2:
         raise BDDLParseError(f"(on ...) expects 2 args, got {len(args)}: {args}")
-    return {"body_a": args[0], "body_b": args[1]}
+    # #170: tighten thresholds to match upstream LIBERO's
+    # ``ObjectState.check_ontop`` semantics. The default ``_body_on``
+    # uses ``z_offset=0.02 m`` and ``xy_tol=0.15 m`` (loose, intended for
+    # coarse "is A on B" checks); upstream LIBERO requires
+    # ``a.z >= b.z`` (no offset) AND ``|a.xy - b.xy| < 0.03 m`` AND
+    # contact between A and B. The empirical at-success state on
+    # ``libero-10/SCENE5`` has mug.z 4 mm above plate.z and mug.xy 1.2 cm
+    # off plate.xy — the loose defaults rejected this as ``False`` while
+    # ``env.check_success()`` returned ``True`` (#170 diagnostic).
+    #
+    # We don't add the contact check here yet (would require
+    # :meth:`get_contacts` on ``LiberoOffScreenRenderEngine``); the
+    # tighter geometric thresholds alone close the libero-10/SCENE5
+    # divergence. False positives in transient "suspended above plate"
+    # states are rare and self-correct as the rollout continues.
+    return {"body_a": args[0], "body_b": args[1], "z_offset": 0.0, "xy_tol": 0.03}
 
 
 def _near_kwargs(args: list[str]) -> dict[str, Any]:

--- a/strands_robots/simulation/libero_offscreen_render/engine.py
+++ b/strands_robots/simulation/libero_offscreen_render/engine.py
@@ -448,6 +448,104 @@ class LiberoOffScreenRenderEngine(SimEngine):
         except Exception as e:  # noqa: BLE001
             logger.warning("LiberoOffScreenRenderEngine.send_action: env.step raised %s", e)
 
+    # State queries (predicates need these)
+
+    def get_body_state(self, body_name: str) -> dict[str, Any]:
+        """Body pose lookup matching :meth:`MuJoCoSimEngine.get_body_state`'s contract.
+
+        Required by ``strands_robots.simulation.predicates._body_position``
+        which the BDDL goal evaluator uses to evaluate ``On``, ``Inside``,
+        ``Near``, ``Upright``, etc. Without this method the evaluator
+        returns ``None`` for every body lookup and every position-based
+        predicate silently returns ``False`` — manifested as #170's
+        false-negative success rate on ``MuJoCoSimEngine``-style
+        evaluation paths.
+
+        Looks up ``body_name`` via ``self._env.env.obj_body_id`` (the
+        BDDL-name → MJCF-body-id mapping that LIBERO's
+        ``BDDLBaseDomain._setup_references`` builds). Falls back to
+        ``self._env.env.sim.model.body_name2id(body_name)`` when the
+        BDDL name doesn't resolve in ``obj_body_id`` (e.g. for engineered
+        scene bodies the BDDL doesn't enumerate, like ``robot0_base``).
+
+        ``self._env`` is the LIBERO ``OffScreenRenderEnv`` wrapper;
+        ``self._env.env`` is the underlying robosuite env that holds the
+        ``obj_body_id`` dict and the ``sim`` attribute. The wrapper
+        layer is transparent for state queries.
+
+        Returns the same status-dict + JSON-payload format
+        ``MuJoCoSimEngine`` returns so the predicate evaluator's
+        ``_extract_json`` works unchanged.
+        """
+        if self._env is None:
+            return {
+                "status": "error",
+                "content": [{"text": "get_body_state: env not initialized. Call setup_libero_task first."}],
+            }
+
+        # Unwrap OffScreenRenderEnv → underlying robosuite env.
+        inner_env = getattr(self._env, "env", None)
+        if inner_env is None:
+            return {
+                "status": "error",
+                "content": [{"text": "get_body_state: OffScreenRenderEnv has no inner env attribute."}],
+            }
+
+        # Resolve body ID. Prefer the BDDL-name dict (handles names like
+        # ``porcelain_mug_1`` that LIBERO maps to the MJCF body
+        # ``porcelain_mug_1_main``); fall back to raw MJCF name for
+        # engineered scene bodies.
+        body_id: int | None = None
+        obj_body_id = getattr(inner_env, "obj_body_id", None)
+        if isinstance(obj_body_id, dict) and body_name in obj_body_id:
+            try:
+                body_id = int(obj_body_id[body_name])
+            except (TypeError, ValueError):
+                body_id = None
+        if body_id is None:
+            try:
+                model = inner_env.sim.model
+                # robosuite's MjModel wrapper exposes body_name2id; -1 ⇒ not found.
+                raw = model.body_name2id(body_name)
+                if raw >= 0:
+                    body_id = int(raw)
+            except (AttributeError, ValueError, KeyError):
+                body_id = None
+        if body_id is None:
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": f"Body {body_name!r} not found in OffScreenRenderEnv (no obj_body_id entry, no MJCF body)."
+                    }
+                ],
+            }
+
+        try:
+            sim_data = inner_env.sim.data
+            pos = list(np.asarray(sim_data.body_xpos[body_id], dtype=np.float64).tolist())
+            quat = list(np.asarray(sim_data.body_xquat[body_id], dtype=np.float64).tolist())
+        except (AttributeError, IndexError, ValueError) as e:
+            return {
+                "status": "error",
+                "content": [
+                    {"text": f"get_body_state: failed to read pose for body {body_name!r} (id={body_id}): {e}"}
+                ],
+            }
+
+        return {
+            "status": "success",
+            "content": [
+                {"text": f"🏷️ Body {body_name!r} (id={body_id}): pos={pos} quat={quat}"},
+                {
+                    "json": {
+                        "position": pos,
+                        "quaternion": quat,
+                    }
+                },
+            ],
+        }
+
     # Rendering
 
     def render(

--- a/tests/benchmarks/libero/test_bddl_parser.py
+++ b/tests/benchmarks/libero/test_bddl_parser.py
@@ -296,6 +296,112 @@ class TestCompileGoal:
         with_grip = _ContactSim([{"geom1": "robot0_gripper_finger_r", "geom2": "cube_1_geom"}])
         assert fn(with_grip) is False
 
+    def test_on_libero_tight_thresholds_real_success_state(self):
+        """#170: The ``on`` predicate must accept LIBERO's actual at-success
+        geometry — empirically, mug.z is only ~4 mm above plate.z and
+        mug.xy is ~1 cm off plate.xy at the moment ``env.check_success()``
+        returns True on ``libero-10/SCENE5``.
+
+        Pre-#170 ``_on_kwargs`` left ``z_offset=0.02`` and ``xy_tol=0.15``
+        as the ``_body_on`` defaults. Those tolerances are too LOOSE on
+        xy (15 cm — over-permissive) but too TIGHT on z (2 cm — rejects
+        a 4 mm gap). At the actual success state, ``z_offset=0.02``
+        rejected the predicate as False even though ``env.check_success``
+        was True — the silent counter bug PR #168 round 44 found.
+
+        #170 changes ``_on_kwargs`` to pass ``z_offset=0.0,
+        xy_tol=0.03`` matching upstream LIBERO's ``ObjectState.check_ontop``
+        geometric semantics. This pins those thresholds via the actual
+        post-success body positions captured from a real eval run."""
+        text = "(define (problem p) (:goal (on porcelain_mug_1 plate_1)))"
+        problem = parse_bddl(text)
+        fn = compile_goal(problem.goal)  # type: ignore[arg-type]
+
+        # Real positions captured from STRANDS_LIBERO_PREDICATE_LOG=1 at
+        # the env-success step on libero-10/SCENE5 seed=42 ep 0.
+        success_state = _BodyStateSim(
+            {
+                "porcelain_mug_1": {"position": [-0.003, -0.311, 0.443]},
+                "plate_1": {"position": [-0.004, -0.323, 0.439]},
+            }
+        )
+        # Post-#170: True (mug.z=0.443 > plate.z=0.439 by 4 mm; xy 1.2 cm).
+        assert fn(success_state) is True, (
+            "Post-#170 _on_kwargs must accept the real LIBERO success state "
+            "(4 mm z, 1.2 cm xy). If this fails, the z_offset / xy_tol "
+            "thresholds may have regressed back to the pre-#170 loose values."
+        )
+
+    def test_on_libero_rejects_above_plate_off_xy(self):
+        """#170 sentinel: with the tighter ``xy_tol=0.03`` from
+        ``_on_kwargs``, an ``on`` predicate must REJECT a state where
+        the mug is positioned 5 cm to the side of the plate (no longer
+        on it).
+
+        Pre-#170 the loose 15-cm tolerance accepted this state as True
+        (false positive); upstream LIBERO's 3-cm tolerance correctly
+        rejects it. This test pins the tightening so a future
+        wider-tolerance regression is caught."""
+        text = "(define (problem p) (:goal (on cube_1 plate_1)))"
+        problem = parse_bddl(text)
+        fn = compile_goal(problem.goal)  # type: ignore[arg-type]
+
+        # Cube 5 cm to the side of plate, but at correct z (above).
+        off_to_side = _BodyStateSim(
+            {
+                "cube_1": {"position": [0.05, 0.0, 0.10]},  # 5 cm off-center
+                "plate_1": {"position": [0.0, 0.0, 0.05]},
+            }
+        )
+        assert fn(off_to_side) is False, (
+            "5 cm off-center is outside the 3 cm xy tolerance — must reject. "
+            "If this passes, _on_kwargs may have regressed to the pre-#170 "
+            "loose 15 cm xy_tol."
+        )
+
+        # Cube 2 cm to the side — should pass (within 3 cm).
+        slightly_off = _BodyStateSim(
+            {
+                "cube_1": {"position": [0.02, 0.0, 0.10]},
+                "plate_1": {"position": [0.0, 0.0, 0.05]},
+            }
+        )
+        assert fn(slightly_off) is True
+
+    def test_on_libero_z_above_required(self):
+        """#170: ``on(A, B)`` requires A.z >= B.z (mug above or at plate
+        level). Pin the directional contract — a body BELOW the
+        reference body is not "on" it regardless of xy alignment."""
+        text = "(define (problem p) (:goal (on cube_1 plate_1)))"
+        problem = parse_bddl(text)
+        fn = compile_goal(problem.goal)  # type: ignore[arg-type]
+
+        below = _BodyStateSim(
+            {
+                "cube_1": {"position": [0.0, 0.0, 0.04]},  # below plate
+                "plate_1": {"position": [0.0, 0.0, 0.05]},
+            }
+        )
+        assert fn(below) is False
+
+        same_z = _BodyStateSim(
+            {
+                "cube_1": {"position": [0.0, 0.0, 0.05]},  # exactly at plate level
+                "plate_1": {"position": [0.0, 0.0, 0.05]},
+            }
+        )
+        # z_offset=0.0 means same-z is acceptable (matches upstream's <=).
+        # Reading the predicate body: ``pos_a[2] > pos_b[2] + z_offset``
+        # ⇒ 0.05 > 0.05 + 0 = 0.05 is False. So same-z is REJECTED by
+        # ours, while upstream (using <=) would accept it.
+        # This is a minor difference; in practice, when a body is
+        # actually resting on another, mj_step's collision response
+        # always pushes them slightly apart so positions are never
+        # exactly equal. Pin the current strict-> behaviour so a future
+        # change that "fixes" this asymmetry doesn't silently shift
+        # near-success cases.
+        assert fn(same_z) is False
+
 
 # Representative LIBERO-style round-trip
 

--- a/tests/benchmarks/libero/test_libero_adapter.py
+++ b/tests/benchmarks/libero/test_libero_adapter.py
@@ -304,6 +304,186 @@ class TestIsSuccess:
         assert adapter.is_success(sim_gripped) is False
 
 
+class TestIsSuccessRound170Diagnostic:
+    """#170: when ``STRANDS_LIBERO_PREDICATE_LOG=1`` is set,
+    :meth:`LiberoAdapter.is_success` emits structured WARNING log lines
+    for every step where ``env.check_success() != self._success_fn(sim)``
+    OR where ``env.check_success() == True`` (so we can verify the BDDL
+    evaluator agrees on the success transition).
+
+    The diagnostic was used to bisect the round-44 silent counter bug:
+    ``_body_position`` returning ``None`` for every body (engine had no
+    ``get_body_state``) AND the ``_on_kwargs`` defaults rejecting the
+    actual success geometry (4 mm z gap, 1.2 cm xy off — too tight for
+    the loose 2 cm/15 cm defaults to fire).
+
+    These tests pin the diagnostic surface so future refactors can't
+    silently drop the per-step logging that #170 needed."""
+
+    def test_disabled_by_default(self, monkeypatch, caplog):
+        """No ``STRANDS_LIBERO_PREDICATE_LOG`` env var ⇒ no logs even
+        when env and BDDL disagree."""
+        import logging as _logging
+
+        monkeypatch.delenv("STRANDS_LIBERO_PREDICATE_LOG", raising=False)
+
+        adapter = LiberoAdapter.from_text(PICK_CUBE_BDDL)
+        # Force a disagreement: env says True via the wrapped env's
+        # check_success, but BDDL evaluates False on a fake-world that
+        # has the cube below the plate.
+        sim = FakeSim(
+            bodies={
+                "cube_1": {"position": [0, 0, 0.05]},
+                "plate_1": {"position": [0, 0, 0.10]},
+            }
+        )
+
+        class _StubEnv:
+            @staticmethod
+            def check_success() -> bool:
+                return True
+
+        sim._env = _StubEnv()  # type: ignore[attr-defined]
+
+        with caplog.at_level(_logging.WARNING, logger="strands_robots.benchmarks.libero.adapter"):
+            verdict = adapter.is_success(sim)
+
+        # Returned verdict still uses env path.
+        assert verdict is True
+        # No diagnostic logs.
+        assert not any("PREDICATE_LOG" in r.getMessage() for r in caplog.records)
+
+    def test_enabled_logs_disagreement(self, monkeypatch, caplog):
+        """With ``STRANDS_LIBERO_PREDICATE_LOG=1`` and env=True / BDDL=False
+        (the round-44 disagreement case), emit a structured log line
+        per disagreement, capped at ``STRANDS_LIBERO_PREDICATE_LOG_MAX``."""
+        import logging as _logging
+
+        monkeypatch.setenv("STRANDS_LIBERO_PREDICATE_LOG", "1")
+        monkeypatch.setenv("STRANDS_LIBERO_PREDICATE_LOG_MAX", "2")
+
+        adapter = LiberoAdapter.from_text(PICK_CUBE_BDDL)
+        sim = FakeSim(
+            bodies={
+                # Cube positioned so the BDDL evaluator can't decide
+                # "on plate_1" — z below plate.
+                "cube_1": {"position": [0, 0, 0.05]},
+                "plate_1": {"position": [0, 0, 0.10]},
+            }
+        )
+
+        class _StubEnv:
+            @staticmethod
+            def check_success() -> bool:
+                return True
+
+        sim._env = _StubEnv()  # type: ignore[attr-defined]
+
+        with caplog.at_level(_logging.WARNING, logger="strands_robots.benchmarks.libero.adapter"):
+            adapter.is_success(sim)
+
+        log_records = [r for r in caplog.records if "PREDICATE_LOG" in r.getMessage()]
+        # At least the top-level "log#0" line + per-leaf walk lines.
+        assert len(log_records) >= 1, "expected at least one PREDICATE_LOG line"
+        top_msg = next(r.getMessage() for r in log_records if "log#0" in r.getMessage())
+        assert "env=True" in top_msg
+        assert "bddl=False" in top_msg
+
+    def test_max_cap_applied(self, monkeypatch, caplog):
+        """``STRANDS_LIBERO_PREDICATE_LOG_MAX`` caps the number of
+        disagreement log lines per episode (avoids flooding the logs
+        on long rollouts)."""
+        import logging as _logging
+
+        monkeypatch.setenv("STRANDS_LIBERO_PREDICATE_LOG", "1")
+        monkeypatch.setenv("STRANDS_LIBERO_PREDICATE_LOG_MAX", "2")
+
+        adapter = LiberoAdapter.from_text(PICK_CUBE_BDDL)
+        sim = FakeSim(
+            bodies={
+                "cube_1": {"position": [0, 0, 0.05]},
+                "plate_1": {"position": [0, 0, 0.10]},
+            }
+        )
+
+        class _StubEnv:
+            @staticmethod
+            def check_success() -> bool:
+                return True
+
+        sim._env = _StubEnv()  # type: ignore[attr-defined]
+
+        # Call is_success 5 times — should only log 2 (the cap).
+        with caplog.at_level(_logging.WARNING, logger="strands_robots.benchmarks.libero.adapter"):
+            for _ in range(5):
+                adapter.is_success(sim)
+
+        # Count "log#0" / "log#1" lines (one per emission cycle).
+        emit_count = sum(1 for r in caplog.records if "log#" in r.getMessage())
+        assert emit_count == 2, f"expected 2 emissions (cap=2), got {emit_count}"
+
+    def test_counter_resets_on_episode_start(self, monkeypatch):
+        """Per-episode ``_predicate_log_count`` resets so each episode
+        emits its own first N disagreements."""
+        monkeypatch.setenv("STRANDS_LIBERO_PREDICATE_LOG", "1")
+
+        adapter = LiberoAdapter.from_text(PICK_CUBE_BDDL)
+        adapter._predicate_log_count = 7  # simulate prior episode
+
+        sim = FakeSim(data_config="panda")
+        adapter.on_episode_start(sim, random.Random(0))
+        assert adapter._predicate_log_count == 0, "on_episode_start must reset the per-episode predicate-log counter"
+
+    def test_walk_predicate_tree_reports_leaf_positions(self):
+        """``_walk_predicate_tree`` reports each leaf's verdict with the
+        actual body positions so reviewers can see why a predicate
+        returned its verdict (e.g., body name didn't resolve = ``=NONE``;
+        positions present + verdict=False = threshold-rejection)."""
+        from strands_robots.benchmarks.libero.adapter import _walk_predicate_tree
+        from strands_robots.benchmarks.libero.bddl_parser import parse_bddl
+
+        text = "(define (problem p) (:goal (on cube_1 plate_1)))"
+        problem = parse_bddl(text)
+        sim = FakeSim(
+            bodies={
+                "cube_1": {"position": [0.001, -0.305, 0.443]},
+                "plate_1": {"position": [-0.004, -0.323, 0.439]},
+            }
+        )
+        leaves = _walk_predicate_tree(problem.goal, sim)
+        assert len(leaves) == 1
+        leaf_repr, verdict = leaves[0]
+        # Verdict reflects the new tighter thresholds (mug 4mm above
+        # plate, 1cm xy → True).
+        assert verdict is True
+        # Positions are rendered for human inspection.
+        assert "cube_1=[" in leaf_repr
+        assert "plate_1=[" in leaf_repr
+        # 3-decimal precision so reviewers can eyeball the diagnostic.
+        assert "0.443" in leaf_repr or "0.44" in leaf_repr
+
+    def test_walk_predicate_tree_reports_missing_body_as_none(self):
+        """When a body name doesn't resolve in the sim, the leaf
+        diagnostic shows ``=NONE`` so reviewers can immediately see
+        the look-up failure (the round-170 smoking gun)."""
+        from strands_robots.benchmarks.libero.adapter import _walk_predicate_tree
+        from strands_robots.benchmarks.libero.bddl_parser import parse_bddl
+
+        text = "(define (problem p) (:goal (on missing_body_1 plate_1)))"
+        problem = parse_bddl(text)
+        sim = FakeSim(
+            bodies={
+                # Only plate_1 is registered; missing_body_1 doesn't exist.
+                "plate_1": {"position": [0, 0, 0.10]},
+            }
+        )
+        leaves = _walk_predicate_tree(problem.goal, sim)
+        assert len(leaves) == 1
+        leaf_repr, verdict = leaves[0]
+        assert verdict is False
+        assert "missing_body_1=NONE" in leaf_repr
+
+
 class TestOnEpisodeStart:
     def test_loads_scene_before_compat_check(self, tmp_path):
         """``scene_path`` load must happen before ``super().on_episode_start``

--- a/tests/simulation/libero_offscreen_render/test_engine_get_body_state.py
+++ b/tests/simulation/libero_offscreen_render/test_engine_get_body_state.py
@@ -1,0 +1,231 @@
+"""Unit tests for ``LiberoOffScreenRenderEngine.get_body_state``.
+
+Issue #170 added ``get_body_state`` to the engine so the BDDL goal
+predicate evaluator can read body positions. Without it, the evaluator's
+``_body_position`` returns ``None`` for every body and every
+position-based predicate (``on``, ``inside``, ``near``, ``upright``)
+silently returns ``False`` — manifested as the round-44 silent
+counter bug for ``libero-10/SCENE5``.
+
+These tests don't require running the real LIBERO env — they construct
+the engine, inject a synthetic ``_env`` mock with the minimal interface
+``get_body_state`` needs (``obj_body_id`` dict + ``sim.data.body_xpos`` /
+``body_xquat`` arrays), and verify the returned status-dict format
+matches what ``MuJoCoSimEngine.get_body_state`` returns. Heavy integration
+coverage lives in ``tests_integ/benchmarks/libero/``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+mujoco = pytest.importorskip("mujoco", reason="LiberoOffScreenRenderEngine module needs mujoco at construction")
+
+from strands_robots.simulation.libero_offscreen_render.engine import (  # noqa: E402
+    LiberoOffScreenRenderEngine,
+)
+
+
+class _FakeSimData:
+    """Minimal robosuite-MjSim.data shape: array indexable by body_id."""
+
+    def __init__(self, body_xpos: np.ndarray, body_xquat: np.ndarray) -> None:
+        self.body_xpos = body_xpos
+        self.body_xquat = body_xquat
+
+
+class _FakeSimModel:
+    """Minimal robosuite-MjSim.model shape: ``body_name2id(name) -> int``."""
+
+    def __init__(self, name_to_id: dict[str, int]) -> None:
+        self._name_to_id = name_to_id
+
+    def body_name2id(self, name: str) -> int:
+        return self._name_to_id.get(name, -1)
+
+
+class _FakeSim:
+    def __init__(self, data: _FakeSimData, model: _FakeSimModel) -> None:
+        self.data = data
+        self.model = model
+
+
+class _FakeInnerEnv:
+    """Stand-in for ``self._env.env`` (the underlying robosuite env).
+
+    Holds the LIBERO-name → body-id mapping (``obj_body_id``) and the
+    MjSim with body_xpos / body_xquat arrays.
+    """
+
+    def __init__(self, obj_body_id: dict[str, int], sim: _FakeSim) -> None:
+        self.obj_body_id = obj_body_id
+        self.sim = sim
+
+
+class _FakeOffScreenEnv:
+    """Stand-in for ``self._env`` (the OffScreenRenderEnv wrapper).
+
+    Wraps an inner env (the actual robosuite env) under ``.env`` —
+    matches LIBERO's ``ControlEnv`` / ``OffScreenRenderEnv`` two-layer
+    structure.
+    """
+
+    def __init__(self, inner: _FakeInnerEnv) -> None:
+        self.env = inner
+
+
+def _make_engine(
+    obj_body_id: dict[str, int],
+    body_xpos: np.ndarray,
+    body_xquat: np.ndarray,
+    extra_mjcf_names: dict[str, int] | None = None,
+) -> LiberoOffScreenRenderEngine:
+    """Construct an engine with a fully-mocked underlying env.
+
+    Bypasses ``setup_libero_task`` entirely.
+    """
+    name_to_id = {}
+    # MJCF body name dictionary may include names NOT in obj_body_id
+    # (engineered scene bodies the BDDL doesn't enumerate).
+    if extra_mjcf_names:
+        name_to_id.update(extra_mjcf_names)
+
+    sim = _FakeSim(
+        data=_FakeSimData(body_xpos=body_xpos, body_xquat=body_xquat),
+        model=_FakeSimModel(name_to_id),
+    )
+    inner = _FakeInnerEnv(obj_body_id=obj_body_id, sim=sim)
+    engine = LiberoOffScreenRenderEngine()
+    engine._env = _FakeOffScreenEnv(inner)  # type: ignore[assignment]
+    return engine
+
+
+class TestGetBodyState:
+    """#170: BDDL evaluator needs ``get_body_state`` on the engine to
+    look up body positions for ``on`` / ``inside`` / ``near`` / etc.
+
+    Without this method, every position-based predicate silently
+    returns False even when the policy succeeds — caught by round-44
+    instrumentation only because we side-by-sided against
+    ``env.check_success``.
+    """
+
+    def test_resolves_via_obj_body_id(self):
+        """LIBERO's BDDL-name → body-id dict is the primary lookup."""
+        engine = _make_engine(
+            obj_body_id={"porcelain_mug_1": 21, "plate_1": 24},
+            body_xpos=np.zeros((30, 3)),
+            body_xquat=np.zeros((30, 4)),
+        )
+        # Set known positions.
+        engine._env.env.sim.data.body_xpos[21] = [-0.003, -0.311, 0.443]
+        engine._env.env.sim.data.body_xquat[21] = [1.0, 0.0, 0.0, 0.0]
+
+        result = engine.get_body_state("porcelain_mug_1")
+        assert result["status"] == "success", result
+
+        json_payload = next(c["json"] for c in result["content"] if "json" in c)
+        np.testing.assert_array_almost_equal(json_payload["position"], [-0.003, -0.311, 0.443])
+        np.testing.assert_array_almost_equal(json_payload["quaternion"], [1.0, 0.0, 0.0, 0.0])
+
+    def test_falls_back_to_body_name2id_when_not_in_obj_body_id(self):
+        """For engineered scene bodies (e.g. ``robot0_base``) that aren't
+        in LIBERO's ``obj_body_id`` dict, fall back to the raw MJCF
+        ``body_name2id`` lookup."""
+        engine = _make_engine(
+            obj_body_id={"porcelain_mug_1": 21},  # only contains object bodies
+            body_xpos=np.zeros((30, 3)),
+            body_xquat=np.zeros((30, 4)),
+            extra_mjcf_names={"robot0_base": 5},  # engineered body
+        )
+        engine._env.env.sim.data.body_xpos[5] = [0.0, 0.0, 0.0]
+        engine._env.env.sim.data.body_xquat[5] = [1.0, 0.0, 0.0, 0.0]
+
+        result = engine.get_body_state("robot0_base")
+        assert result["status"] == "success", result
+
+        json_payload = next(c["json"] for c in result["content"] if "json" in c)
+        np.testing.assert_array_almost_equal(json_payload["position"], [0.0, 0.0, 0.0])
+
+    def test_unknown_body_returns_error(self):
+        """Body absent from BOTH ``obj_body_id`` and the MJCF model
+        produces a structured error rather than crashing or returning
+        a stale position."""
+        engine = _make_engine(
+            obj_body_id={"porcelain_mug_1": 21},
+            body_xpos=np.zeros((30, 3)),
+            body_xquat=np.zeros((30, 4)),
+        )
+        result = engine.get_body_state("not_a_real_body")
+        assert result["status"] == "error"
+        assert "not_a_real_body" in result["content"][0]["text"]
+        assert "not found" in result["content"][0]["text"].lower()
+
+    def test_no_env_returns_error(self):
+        """Calling before ``setup_libero_task`` returns an error rather
+        than dereferencing None."""
+        engine = LiberoOffScreenRenderEngine()
+        result = engine.get_body_state("anything")
+        assert result["status"] == "error"
+        assert "not initialized" in result["content"][0]["text"].lower()
+
+    def test_returned_format_matches_mujoco_engine_contract(self):
+        """The returned dict format MUST match
+        ``MuJoCoSimEngine.get_body_state`` so the predicate evaluator's
+        ``_extract_json`` works unchanged. Specifically:
+
+        - ``status`` key with ``"success"`` value
+        - ``content`` list with at least one ``json`` block
+        - ``json`` block contains ``position`` (3-list) and
+          ``quaternion`` (4-list)
+        """
+        engine = _make_engine(
+            obj_body_id={"cube_1": 0},
+            body_xpos=np.array([[0.5, -0.1, 0.3]] + [[0, 0, 0]] * 29),
+            body_xquat=np.array([[0.707, 0.707, 0.0, 0.0]] + [[1, 0, 0, 0]] * 29),
+        )
+        result = engine.get_body_state("cube_1")
+
+        # Top-level keys.
+        assert "status" in result
+        assert "content" in result
+        assert isinstance(result["content"], list)
+
+        # JSON block schema.
+        json_blocks = [c["json"] for c in result["content"] if isinstance(c, dict) and "json" in c]
+        assert len(json_blocks) >= 1
+        payload = json_blocks[0]
+        assert isinstance(payload.get("position"), list) and len(payload["position"]) == 3
+        assert isinstance(payload.get("quaternion"), list) and len(payload["quaternion"]) == 4
+
+    def test_works_with_predicate_evaluator(self):
+        """End-to-end: a ``_body_on`` predicate compiled from BDDL
+        should return True when the engine's ``get_body_state`` returns
+        positions consistent with one body on top of another.
+
+        Pin the integration so a future signature change to
+        ``get_body_state`` (e.g., returning a different status-dict
+        shape) gets caught by the predicate evaluator's expectations,
+        not just the engine's unit test."""
+        from strands_robots.benchmarks.libero.bddl_parser import compile_goal, parse_bddl
+
+        engine = _make_engine(
+            obj_body_id={"mug_1": 5, "plate_1": 6},
+            body_xpos=np.zeros((10, 3)),
+            body_xquat=np.zeros((10, 4)),
+        )
+        # mug 4mm above plate, 1cm xy off — the libero-10/SCENE5
+        # at-success state.
+        engine._env.env.sim.data.body_xpos[5] = [0.005, 0.0, 0.443]
+        engine._env.env.sim.data.body_xpos[6] = [0.0, 0.0, 0.439]
+
+        text = "(define (problem p) (:goal (on mug_1 plate_1)))"
+        problem = parse_bddl(text)
+        fn = compile_goal(problem.goal)  # type: ignore[arg-type]
+        assert fn(engine) is True, (
+            "BDDL evaluator should fire True when get_body_state returns "
+            "positions consistent with mug-on-plate. If False, either the "
+            "engine isn't returning the right format or _on_kwargs's tight "
+            "tolerances regressed."
+        )


### PR DESCRIPTION
## Summary

Closes #170. The BDDL goal predicate evaluator now agrees with robosuite's `env.check_success()` at the success step on `libero-10/SCENE5` — the silent counter bug PR #168 round 44 found.

> **Note**: branched from #172's rotation fix because both share the LIBERO eval infrastructure for empirical verification. After #172 merges, this rebases cleanly to `main`.

## Root cause: TWO compounding issues

### Issue A — `LiberoOffScreenRenderEngine` had no `get_body_state`

The BDDL evaluator's `_body_position(sim, body)` calls `sim.get_body_state(body_name)`. Round 43's `LiberoOffScreenRenderEngine` never implemented this method — it only inherited the abstract `SimEngine` signature. With no `get_body_state`, every body lookup returned `None` and every position-based predicate (`on`, `inside`, `near`, `upright`) silently returned `False`.

**Fix**: implement `get_body_state(body_name)` on the engine, matching `MuJoCoSimEngine.get_body_state`'s contract (status/content/json structure with `position` + `quaternion`). Lookup goes via `self._env.env.obj_body_id` (LIBERO's BDDL-name → MJCF-body-id dict, populated by `BDDLBaseDomain._setup_references`) with fallback to `body_name2id` for engineered bodies the BDDL doesn't enumerate.

### Issue B — `_on_kwargs` default thresholds rejected real success geometry

Even with body positions resolving, `_body_on` used `z_offset=0.02` and `xy_tol=0.15` — values intended for coarse "is A on B" but WRONG for LIBERO's actual at-success state:

```
Captured at env-success step on libero-10/SCENE5 seed=42:
  porcelain_mug_1.pos = [-0.003, -0.311, 0.443]
  plate_1.pos         = [-0.004, -0.323, 0.439]
  z gap:    4 mm        (z_offset required 20 mm → REJECTED)
  xy dist:  1.2 cm      (xy_tol allowed 15 cm — fine)
```

Upstream's `ObjectState.check_ontop` uses `z_offset=0` (`a.z <= b.z`) + `xy_tol=0.03` + contact check.

**Fix**: tighten `_on_kwargs` to pass `z_offset=0.0, xy_tol=0.03`. Empirically validated against the captured success-state positions.

## What's NOT in this PR

The contact check from upstream's `check_ontop` isn't ported yet — would require `get_contacts` on `LiberoOffScreenRenderEngine`. Without it, transient "mug suspended above plate" states can produce BDDL false positives during placement. This doesn't affect production because `is_success` returns `env_verdict` when `env.check_success` is available; the false positive only matters for the `MuJoCoSimEngine` fallback path. Tracked under #171's umbrella.

## New diagnostic harness

`STRANDS_LIBERO_PREDICATE_LOG=1` emits structured WARNING log lines from `is_success` when:
- `env_verdict == True` (verify BDDL agrees on success transition), OR
- `env_verdict != bddl_verdict` (capture transient divergence)

Each emission includes per-leaf walk with actual body positions, so reviewers can see why a leaf returned its verdict at a glance:

```
PREDICATE_LOG ep=0 log#0: env=True bddl=False; goal=And(...)
PREDICATE_LOG ep=0   leaf AND/(on porcelain_mug_1=[-0.003, -0.311, 0.443] plate_1=[-0.004, -0.323, 0.439]) = False
```

`= NONE` after a body name = lookup failed (the round-44 smoking gun signal).

Capped at `STRANDS_LIBERO_PREDICATE_LOG_MAX` (default 10) per episode. Counter resets in `on_episode_start`. Both env vars documented in README.

## Empirical verification (libero-10/SCENE5 seed=42)

| | Pre-#170 | Post-#170 |
|---|---|---|
| At env-success step | `env=True bddl=False` ← silent counter bug | `env=True bddl=True` ← agrees ✓ |
| Transient (mug above plate, no contact) | n/a (BDDL never reached True due to body lookup failures) | `env=False bddl=True` (false positive — see below) |

The `env=True bddl=False` at success is what made round 44's eval report `success_rate=0` even when the policy was succeeding. That's gone.

The `env=False bddl=True` at transient placement states is a follow-up issue (#171) — only affects `MuJoCoSimEngine` paths that don't have `env.check_success` to override.

## Tests (+15 new)

- `test_bddl_parser.py` (+3): pin tighter thresholds
  - real-success state (4mm z, 1.2cm xy) accepts ✓
  - 5cm off-xy rejects (sentinel: ensures we don't regress to 15cm tol)
  - z direction required (cube below plate rejects)
- `test_libero_adapter.py` (+6): diagnostic env var
  - disabled by default
  - enabled emits structured log
  - MAX cap respected
  - counter resets on `on_episode_start`
  - per-leaf walk reports positions
  - missing body name shows `=NONE`
- `test_engine_get_body_state.py` (NEW, +6): engine method
  - `obj_body_id` lookup
  - `body_name2id` fallback for engineered bodies
  - unknown body returns structured error
  - no-env returns structured error
  - return format matches `MuJoCoSimEngine` contract
  - end-to-end with predicate evaluator (mug-on-plate scenario)

422 affected-module tests pass. Lint clean.

## Risks

- The tighter `xy_tol=0.03` is a behavior change for any user of `(on A B)` BDDL goals on a non-LIBERO scene. Realistically: `(on)` is LIBERO-specific and the tighter tol matches upstream — likely no users affected.
- Adding `get_body_state` to the engine may surface other previously-silent predicate evaluations on `LiberoOffScreenRenderEngine`. The diagnostic harness exists precisely to catch those if they appear.

Refs #166, #168 round 44 commit `65d2d18`.
