### PR TITLE
fix(libero): close #171 + #176 — MuJoCoSimEngine LIBERO eval reaches success_rate > 0

### DIFF
--- a/strands_robots/benchmarks/libero/adapter.py
+++ b/strands_robots/benchmarks/libero/adapter.py
@@ -31,6 +31,7 @@ the one that pulls in the upstream package to discover task files.
 from __future__ import annotations
 
 import hashlib
+import importlib
 import json
 import logging
 import os
@@ -959,6 +960,47 @@ class LiberoAdapter(BenchmarkProtocol):
             self._install_action_controller(sim)
         if self._init_jitter > 0:
             self._apply_init_jitter(sim, rng)
+
+        # Round 46 (#176 sub-task 3d) — settle physics by one zero-action
+        # control step so the first observation handed to the policy is
+        # at "init_state + 1 OSC step", matching upstream LIBERO's
+        # ``OffScreenRenderEnv.reset`` which does
+        # ``set_init_state(...) + env.step(np.zeros(7))`` (see
+        # ``LiberoOffScreenRenderEngine.reset:213`` and NVIDIA's
+        # ``libero_env.py:257``). Without this settle, the MuJoCoSimEngine
+        # path's first observation is at the raw ``init_state[i]`` while
+        # the offscreen path's first observation is one control step
+        # ahead — the same training data was generated against the
+        # post-step state, so feeding the raw init_state to a policy
+        # trained on post-step inputs is OOD by a few mm / mrad.
+        #
+        # The downstream effect: the policy emits actions that are
+        # ~2x off from what the offscreen path emits on identical
+        # tasks, which (combined with the OSC torque divergence from
+        # round 45) is enough to keep success_rate at 0 on libero-10.
+        # After this fix, the first observation matches upstream within
+        # numerical noise (qpos diff < 1e-9 verified empirically).
+        #
+        # Best-effort: gated on having a working OSC controller (which
+        # owns_stepping). If the controller wasn't installed (warning
+        # already logged in ``_install_action_controller``), skip the
+        # settle to avoid raising — the eval will still run, just at
+        # the un-settled init pose.
+        if scene_was_loaded:
+            world = getattr(sim, "_world", None)
+            if world is not None:
+                backend_state = getattr(world, "_backend_state", None)
+                if isinstance(backend_state, dict) and "action_controller" in backend_state:
+                    send_action = getattr(sim, "send_action", None)
+                    if callable(send_action):
+                        try:
+                            send_action({})
+                        except Exception as e:  # noqa: BLE001 - never abort eval on settle failure
+                            logger.warning(
+                                "LiberoAdapter.on_episode_start: settle send_action({}) raised %s; "
+                                "first observation will be at raw init_state instead of init_state+1step",
+                                e,
+                            )
 
         # Round 30 (#168) — reset per-episode state-log counter so each
         # episode emits its own first N STATE_LOG lines (matches the
@@ -2916,10 +2958,24 @@ class LiberoAdapter(BenchmarkProtocol):
     ) -> None:
         """Snapshot-and-restore branch of :meth:`_apply_canonical_state`.
 
-        First episode: capture ``data.qpos`` / ``data.qvel``. Subsequent
-        episodes: restore the cached snapshot via ``np.copyto`` and
-        ``mj_forward``. Procedurally-generated MJCFs (#165) hit this
-        branch because they don't ship a ``<keyframe>``.
+        First episode: write the LIBERO-canonical Panda home pose into
+        ``data.qpos[arm]`` (mirroring upstream ``Robot.reset(deterministic=True)``)
+        so the snapshot captures arm joints at home pose, then capture
+        ``data.qpos`` / ``data.qvel``. Subsequent episodes: restore the
+        cached snapshot via ``np.copyto`` and ``mj_forward``.
+
+        Procedurally-generated MJCFs (#165) hit this branch because they
+        don't ship a ``<keyframe>`` AND callers may not pass
+        ``init_states``. Without writing the home pose, ``data.qpos`` after
+        ``load_scene`` is at MuJoCo's default (all zeros for arm joints,
+        since the procedurally-generated MJCF doesn't set joint ``ref``
+        attributes). Upstream's ``OffScreenRenderEnv`` instead writes
+        ``MountedPanda.init_qpos`` (= ``[0, -0.161, 0, -2.444, 0, 2.227,
+        π/4]``) inside its ``Robot.reset`` so the env starts at the
+        ready pose. To match upstream's BDDL-default behaviour (#176
+        sub-task 3d), we replicate that write here.
+
+        Round 46 (#176 sub-task 3d).
         """
         try:
             qpos = data.qpos
@@ -2928,9 +2984,11 @@ class LiberoAdapter(BenchmarkProtocol):
             logger.debug("LiberoAdapter: data has no qpos/qvel attrs: %s", e)
             return
 
-        # First episode (or model recompile changed nq) -> capture, don't
-        # restore. The snapshot is taken after super() + _install_libero_cameras
-        # so it reflects the post-setup canonical state.
+        # First episode (or model recompile changed nq) -> write home
+        # pose into arm joints, then capture; don't restore. The
+        # snapshot is taken after super() + _install_libero_cameras
+        # so it reflects the post-setup canonical state, with the arm
+        # at the LIBERO-canonical ready pose.
         needs_capture = (
             self._canonical_qpos is None
             or self._canonical_qpos.shape != qpos.shape
@@ -2938,6 +2996,14 @@ class LiberoAdapter(BenchmarkProtocol):
             or self._canonical_qvel.shape != qvel.shape
         )
         if needs_capture:
+            # Round 46 (#176 sub-task 3d): write home pose to arm
+            # joints before snapshotting. Without this the captured
+            # snapshot is at MuJoCo's default qpos=0, which is
+            # significantly off from upstream's ``MountedPanda.init_qpos``
+            # post-``Robot.reset``. Best-effort: failures during home-
+            # pose discovery / write fall through silently — the
+            # snapshot captures whatever ``data.qpos`` happens to be.
+            self._write_libero_arm_home_qpos(model, data, mj, lock)
             try:
                 self._canonical_qpos = np.array(qpos, copy=True)
                 self._canonical_qvel = np.array(qvel, copy=True)
@@ -2974,6 +3040,91 @@ class LiberoAdapter(BenchmarkProtocol):
             logger.warning("LiberoAdapter: snapshot restore failed: %s", e)
             return
         logger.debug("LiberoAdapter: restored canonical qpos snapshot")
+
+    def _write_libero_arm_home_qpos(self, model: Any, data: Any, mj: Any, lock: Any) -> None:
+        """Write the LIBERO Panda + gripper ready pose into ``data.qpos``.
+
+        Mirrors upstream ``robosuite.robots.robot.Robot.reset(deterministic=True)``
+        which writes ``self.init_qpos`` (= ``MountedPanda.init_qpos`` for
+        LIBERO) to the arm joint qpos addresses BEFORE constructing the
+        OSC controller. Also mirrors ``SingleArm.reset`` which writes
+        ``self.gripper.init_qpos`` (= ``PandaGripper.init_qpos`` =
+        ``[0.020833, -0.020833]``) to the gripper finger joint qpos
+        addresses. Used by :meth:`_apply_snapshot_branch` to bring the
+        BDDL-default state into parity with upstream
+        ``OffScreenRenderEnv``.
+
+        Best-effort: any failure (no Panda joints, missing libero
+        package, model has no ``arm joint``s) is logged at DEBUG and
+        falls through silently, leaving ``data.qpos`` at whatever
+        MuJoCo's default was. Caller's snapshot branch then captures
+        the un-modified qpos.
+
+        Round 46 (#176 sub-task 3d).
+        """
+        # Resolve arm joint qpos addresses (same scan as
+        # _LiberoOSCController.from_sim).
+        arm_qpos_addrs: list[int] = []
+        gripper_qpos_addrs: list[int] = []
+        njnt = int(getattr(model, "njnt", 0))
+        for i in range(njnt):
+            jname = mj.mj_id2name(model, mj.mjtObj.mjOBJ_JOINT, i)
+            if not isinstance(jname, str):
+                continue
+            if jname.startswith(self._scene_robot_prefix) and not jname.startswith(self._scene_gripper_prefix):
+                arm_qpos_addrs.append(int(model.jnt_qposadr[i]))
+            elif jname.startswith(self._scene_gripper_prefix):
+                # Filter to finger joints only — match round-33 convention
+                # (gripper0_finger_joint1, gripper0_finger_joint2).
+                if "finger_joint" in jname:
+                    gripper_qpos_addrs.append(int(model.jnt_qposadr[i]))
+        if len(arm_qpos_addrs) != 7:
+            logger.debug(
+                "LiberoAdapter._write_libero_arm_home_qpos: expected 7 arm joints with prefix %r, "
+                "found %d; skipping home-pose write",
+                self._scene_robot_prefix,
+                len(arm_qpos_addrs),
+            )
+            return
+
+        home_qpos = _resolve_libero_arm_home_qpos(len(arm_qpos_addrs))
+        if home_qpos is None:
+            logger.debug(
+                "LiberoAdapter._write_libero_arm_home_qpos: no LIBERO/robosuite home pose available; "
+                "skipping home-pose write"
+            )
+            return
+
+        # Resolve gripper init_qpos (PandaGripper). Same caching pattern
+        # as arm home pose for cheap repeat lookup.
+        gripper_init = _resolve_panda_gripper_init_qpos(len(gripper_qpos_addrs))
+
+        def _do_write() -> None:
+            for adr, v in zip(arm_qpos_addrs, home_qpos, strict=True):
+                data.qpos[adr] = float(v)
+            if gripper_init is not None and len(gripper_qpos_addrs) == len(gripper_init):
+                for adr, v in zip(gripper_qpos_addrs, gripper_init, strict=True):
+                    data.qpos[adr] = float(v)
+            mj.mj_forward(model, data)
+
+        try:
+            if lock is not None:
+                with lock:
+                    _do_write()
+            else:
+                _do_write()
+        except Exception as e:  # noqa: BLE001 - best-effort, never fatal
+            logger.debug(
+                "LiberoAdapter._write_libero_arm_home_qpos: write failed (%s); snapshot will capture pre-write qpos",
+                e,
+            )
+            return
+        logger.debug(
+            "LiberoAdapter: wrote LIBERO Panda + gripper home pose into data.qpos (snapshot pre-capture); "
+            "arm=%d, gripper=%d",
+            len(arm_qpos_addrs),
+            len(gripper_qpos_addrs),
+        )
 
     def _apply_init_jitter(self, sim: SimEngine, rng: random.Random) -> None:
         """Apply ±jitter to xy of every body referenced by ``(:init (on A B))``.
@@ -3164,28 +3315,56 @@ def _fmt_state_value(value: Any) -> str:
 def _quat_wxyz_to_rpy_xyz(quat_wxyz: list[float]) -> tuple[float, float, float]:
     """MuJoCo ``(w, x, y, z)`` quaternion → extrinsic XYZ Euler ``(roll, pitch, yaw)``.
 
-    Matches RoboSuite/LIBERO's ``mat2euler(..., axes='sxyz')`` convention -
-    i.e. rotations applied about the *static* world frame in the order
-    X (roll), Y (pitch), Z (yaw). This is also what
-    ``scipy.spatial.transform.Rotation.from_quat([x, y, z, w]).as_euler('xyz')``
-    returns (lowercase ``'xyz'`` = extrinsic in scipy).
+    Matches RoboSuite/LIBERO's ``mat2euler(..., axes='sxyz')`` convention
+    byte-for-byte. RoboSuite implements ``sxyz`` as the extraction
+    ``(atan2(M[2,1], M[2,2]), asin(-M[2,0]), atan2(M[1,0], M[0,0]))``
+    where ``M`` is the rotation matrix in Hamilton convention.
 
-    Pure numpy / stdlib - **does not import scipy**, which is not a
-    declared dependency of strands_robots. Math reference:
+    For unit quat ``q = (w, x, y, z)``, the rotation-matrix entries
+    needed for the canonical extraction are (Hamilton convention,
+    standard active rotation):
 
-        R = R_x(roll) · R_y(pitch) · R_z(yaw)  (extrinsic XYZ)
+        M[0,0] = 1 - 2(y² + z²)
+        M[1,0] = 2(xy + wz)
+        M[2,0] = 2(xz - wy)
+        M[2,1] = 2(yz + wx)
+        M[2,2] = 1 - 2(x² + y²)
 
-    For unit quat ``q = (w, x, y, z)``, the rotation-matrix elements
-    needed for the canonical extraction are:
+    Hence:
 
-        R[0,2] =  2 (xz + wy)        →  sin(pitch)
-        R[0,0] =  1 - 2 (y² + z²)
-        R[0,1] = -2 (wz - xy)
-        R[1,2] = -2 (wx - yz)
-        R[2,2] =  1 - 2 (x² + y²)
+        roll  = atan2(M[2,1], M[2,2]) = atan2(2(wx + yz), 1 - 2(x² + y²))
+        pitch = asin(-M[2,0])         = asin(2(wy - xz))
+        yaw   = atan2(M[1,0], M[0,0]) = atan2(2(wz + xy), 1 - 2(y² + z²))
+
+    Pure numpy / stdlib — **does not import scipy**, which is not a
+    declared dependency of strands_robots. Equivalent to
+    ``LiberoOffScreenRenderEngine._quat_xyzw_to_rpy_xyz`` (which takes
+    xyzw input).
+
+    **Round 46 (#176 sub-task 3d)** corrected three sign errors in the
+    pre-46 derivation. The pre-46 formula was based on
+    ``R = R_x · R_y · R_z`` (intrinsic XYZ, NOT extrinsic), giving:
+
+        roll  = atan2(2(wx - yz), ...)  [WRONG SIGN on yz]
+        pitch = asin(2(wy + xz))         [WRONG SIGN on xz]
+        yaw   = atan2(2(wz - xy), ...)  [WRONG SIGN on xy]
+
+    These produced sign-flipped Euler angles for the EEF wrist body
+    on the LIBERO ready pose (verified empirically against
+    robosuite's ``mat2euler``: a quat=(0, 0.707, 0.707, 0) returns
+    (π, 0, π/2) under sxyz but the pre-46 formula returned (-π, 0,
+    -π/2)). The sign flip in yaw is genuinely a different rotation
+    (left vs right twist about z). The state.yaw reported to the
+    policy was therefore systematically inverted relative to
+    training data, putting the policy out-of-distribution from the
+    very first observation. (The state-parity test passed at canonical
+    init because canonical-pose yaw is ~0.0005 rad and the test uses
+    ``_angle_diff_mod_2pi`` which masked the sign flip; the test
+    should also be made to forbid sign-flips for non-π rotations.)
 
     Gimbal lock (``|sin(pitch)| ≥ 1 - 1e-6``) collapses roll into yaw;
-    we use the ``atan2(R[1,0], R[1,1])`` resolution that matches scipy.
+    we use the ``atan2(-M[1,2], M[1,1])`` resolution that matches
+    scipy / robosuite.
 
     Returns:
         ``(roll, pitch, yaw)`` in **radians**, each in the principal
@@ -3195,16 +3374,20 @@ def _quat_wxyz_to_rpy_xyz(quat_wxyz: list[float]) -> tuple[float, float, float]:
     import math
 
     w, x, y, z = quat_wxyz
-    # Clamp argument to asin to handle minor numerical drift on unit quats.
-    sin_pitch = max(-1.0, min(1.0, 2.0 * (x * z + w * y)))
+    # Clamp asin argument to handle minor numerical drift on unit quats.
+    sin_pitch = max(-1.0, min(1.0, 2.0 * (w * y - x * z)))
     pitch = math.asin(sin_pitch)
     if abs(sin_pitch) >= 1.0 - 1e-6:
-        # Gimbal-lock branch: roll absorbed into yaw.
+        # Gimbal lock: roll absorbed into yaw. Use the same fallback
+        # robosuite's ``mat2euler`` does (atan2(-M[1,2], M[1,1])).
         roll = 0.0
-        yaw = math.atan2(2.0 * (x * y + w * z), 1.0 - 2.0 * (y * y + z * z))
+        # M[1,2] = 2(yz - wx); M[1,1] = 1 - 2(x² + z²).
+        yaw = math.atan2(-2.0 * (y * z - w * x), 1.0 - 2.0 * (x * x + z * z))
     else:
-        roll = math.atan2(-2.0 * (y * z - w * x), 1.0 - 2.0 * (x * x + y * y))
-        yaw = math.atan2(-2.0 * (x * y - w * z), 1.0 - 2.0 * (y * y + z * z))
+        # M[2,1] = 2(yz + wx); M[2,2] = 1 - 2(x² + y²).
+        roll = math.atan2(2.0 * (w * x + y * z), 1.0 - 2.0 * (x * x + y * y))
+        # M[1,0] = 2(xy + wz); M[0,0] = 1 - 2(y² + z²).
+        yaw = math.atan2(2.0 * (w * z + x * y), 1.0 - 2.0 * (y * y + z * z))
     return (roll, pitch, yaw)
 
 
@@ -3711,7 +3894,113 @@ class _LiberoOSCController:
             dtype=np.float32,
         )
         controller_config["actuator_range"] = (ctrl_low, ctrl_high)
+
+        # Round 45 (#176) — temporarily set ``data.qpos[arm]`` to the
+        # LIBERO-canonical Panda "ready" pose around the
+        # ``controller_factory`` call so the controller's
+        # construction-time state capture matches upstream LIBERO
+        # byte-for-byte.
+        #
+        # **Why this is needed.** Robosuite's ``BaseController.__init__``
+        # ends with ``self.update_initial_joints(initial_joints)``,
+        # which:
+        #
+        # 1. sets ``self.initial_joint = initial_joints``,
+        # 2. calls ``self.update(force=True)`` reading ``ee_pos`` /
+        #    ``ee_ori_mat`` / ``joint_pos`` from the *current*
+        #    ``data.qpos``,
+        # 3. stores those reads into ``self.initial_ee_pos`` and
+        #    ``self.initial_ee_ori_mat``.
+        #
+        # ``OSC_POSE.__init__`` then sets
+        # ``self.goal_pos = np.array(self.initial_ee_pos)`` and
+        # ``self.goal_ori = np.array(self.initial_ee_ori_mat)``. So the
+        # controller's *initial goal pose* is whatever ``data.qpos``
+        # happened to be at construction time.
+        #
+        # Upstream LIBERO's ``Robot.reset(deterministic=True)``
+        # (``robosuite/robots/robot.py``) writes ``self.init_qpos`` (=
+        # ``MountedPanda.init_qpos`` = ``[0, -0.161, 0, -2.4446, 0,
+        # 2.2268, π/4]``) into ``data.qpos[arm]`` BEFORE constructing
+        # the controller, so ``initial_ee_pos`` / ``initial_ee_ori_mat``
+        # / ``goal_pos`` / ``goal_ori`` all latch on to the ready-pose
+        # EEF location. Then ``env.set_init_state(init_states[i])``
+        # overwrites ``data.qpos`` with the per-episode canonical
+        # state, but the controller's initial-state attributes are
+        # frozen — leading to a non-trivial nullspace bias and a
+        # ``goal_ori`` that's ~54 mrad different from the perturbed
+        # canonical pose.
+        #
+        # Our ``LiberoAdapter._install_action_controller`` runs from
+        # ``on_episode_start`` AFTER ``_apply_canonical_state`` has
+        # already loaded the canonical ``init_states[i]`` into
+        # ``data.qpos``, AND we never write the Panda ready pose
+        # ourselves. The upstream-style ``Robot.reset`` step happens
+        # implicitly via the LIBERO env construction in upstream's
+        # path; we have no analog. So we replicate it here by
+        # snapshotting ``data.qpos[arm]`` (the current canonical
+        # values), writing the LIBERO Panda ready pose into those
+        # addresses, calling ``mj_forward`` so site_xpos / site_xmat
+        # reflect the home pose, building the controller (which
+        # captures everything from the home-pose state), then
+        # restoring ``data.qpos[arm]`` and calling ``mj_forward``
+        # again. ``data.qvel`` is left as-is — upstream's
+        # ``Robot.reset`` doesn't touch qvel, and our canonical
+        # ``init_state`` is at zero velocity anyway.
+        #
+        # This fixes the ~50× torque divergence in #176 root cause: not
+        # just the nullspace bias (``initial_joint``), but ALSO the
+        # ``goal_ori`` initialization that without the swap would
+        # latch on to the perturbed pose's EEF orientation.
+        #
+        # See ``probe_osc_internals_v3.py`` for the verification
+        # showing torques match within tolerance after this swap.
+        snapshot_qpos: np.ndarray | None = None
+        home_qpos = _resolve_libero_arm_home_qpos(len(arm_qpos_addrs))
+        if home_qpos is not None:
+            try:
+                # Snapshot current canonical arm qpos so we can restore.
+                snapshot_qpos = np.array(
+                    [float(data.qpos[adr]) for adr in arm_qpos_addrs],
+                    dtype=np.float64,
+                )
+                # Write home pose into arm joint addresses.
+                for adr, v in zip(arm_qpos_addrs, home_qpos, strict=True):
+                    data.qpos[adr] = float(v)
+                # Update derived state (site_xpos, site_xmat, jacobians)
+                # so the controller's __init__ ``update(force=True)``
+                # reads home-pose values.
+                _mj.mj_forward(model, data)
+            except (AttributeError, IndexError, TypeError, ValueError) as e:
+                # Defensive: if we can't snapshot, don't proceed with
+                # the swap (would leak home pose into the sim).
+                logger.debug(
+                    "_LiberoOSCController.from_sim: failed to swap qpos to home pose for "
+                    "controller construction (%s); falling back to construction-time state",
+                    e,
+                )
+                snapshot_qpos = None
+
         controller = controller_factory("OSC_POSE", controller_config)
+
+        # Restore the per-episode canonical qpos and re-forward so
+        # data is byte-identical to its pre-swap state. The
+        # controller has already captured ``initial_*`` and ``goal_*``
+        # at the home pose; subsequent ``update()`` calls will read
+        # the restored canonical state, which is exactly upstream's
+        # behavior post-``set_init_state``.
+        if snapshot_qpos is not None:
+            try:
+                for adr, v in zip(arm_qpos_addrs, snapshot_qpos, strict=True):
+                    data.qpos[adr] = float(v)
+                _mj.mj_forward(model, data)
+            except (AttributeError, IndexError, TypeError, ValueError) as e:
+                # If restore fails the sim is in an unknown state;
+                # raise loudly rather than silently leaving home pose.
+                raise _ControllerInstallError(
+                    f"failed to restore qpos after controller construction (snapshot was "
+                    f"{snapshot_qpos.tolist()}): {e}. Sim may be in inconsistent state."
+                ) from e
 
         # Compute physics-substeps-per-control from sim's actual timestep.
         # LIBERO trains at 20 Hz control rate. With dt=0.002 (default 500 Hz
@@ -4033,6 +4322,191 @@ class _LiberoOSCController:
 
         mj.mju_mat2Quat(quat, xmat)
         return pos, quat
+
+
+# Module-level cache: resolving the LIBERO-canonical Panda home pose
+# imports the libero robot module, which transitively imports robosuite,
+# loads MJCF assets, and warns about missing macro files. The result is
+# immutable per-process — cache it after the first lookup so calls 50×
+# per second from ``_install_action_controller`` are free.
+_CACHED_LIBERO_HOME_QPOS: np.ndarray | None = None
+_CACHED_LIBERO_HOME_QPOS_RESOLVED: bool = False
+
+
+def _resolve_libero_arm_home_qpos(n_arm: int) -> np.ndarray | None:
+    """Return the LIBERO-canonical Panda 7-DoF home pose, or ``None``.
+
+    Resolution order:
+
+    1. ``libero.libero.envs.robots.mounted_panda.MountedPanda().init_qpos``
+       — stock LIBERO layout (``pip install libero``).
+    2. ``libero.envs.robots.mounted_panda.MountedPanda().init_qpos``
+       — LIBERO-PRO layout (the LIBERO-PRO fork uses a flatter package
+       structure). Same canonical ``init_qpos`` byte-for-byte.
+    3. ``robosuite.models.robots.Panda().init_qpos`` (stock
+       robosuite, slightly different — ``[0, π/16, 0, -π/2-π/3, 0,
+       π-0.2, π/4]`` vs ``[0, -0.161, 0, -2.4446, 0, 2.2268, π/4]``).
+       Only used when neither libero variant is importable.
+    4. ``None`` if nothing is available — caller falls back to the
+       controller's construction-time default.
+
+    Both LIBERO layouts produce the same ``MountedPanda.init_qpos``,
+    which is what upstream ``OffScreenRenderEnv``'s
+    ``Robot.reset(deterministic=True)`` writes to ``data.qpos`` BEFORE
+    constructing the OSC controller. That's the value upstream's
+    ``controller.initial_joint`` ends up holding, and the value the
+    round-45 swap-and-restore in :meth:`_LiberoOSCController.from_sim`
+    needs to write into ``data.qpos`` around ``controller_factory``.
+
+    Refs #176.
+    """
+    global _CACHED_LIBERO_HOME_QPOS, _CACHED_LIBERO_HOME_QPOS_RESOLVED
+
+    if _CACHED_LIBERO_HOME_QPOS_RESOLVED:
+        if _CACHED_LIBERO_HOME_QPOS is None:
+            return None
+        if _CACHED_LIBERO_HOME_QPOS.shape != (n_arm,):
+            # Different robot than the cached one (e.g. a 6-DoF arm).
+            # Don't reuse the cached 7-DoF Panda value.
+            return None
+        return _CACHED_LIBERO_HOME_QPOS
+
+    home: np.ndarray | None = None
+    # Try both LIBERO package layouts. The class is identical between
+    # them (same numerical init_qpos); only the import path differs.
+    libero_module_paths = (
+        "libero.libero.envs.robots.mounted_panda",  # stock libero
+        "libero.envs.robots.mounted_panda",  # LIBERO-PRO
+    )
+    for module_path in libero_module_paths:
+        try:
+            module = importlib.import_module(module_path)
+        except ImportError:
+            continue
+        mounted_panda_cls = getattr(module, "MountedPanda", None)
+        if mounted_panda_cls is None:
+            logger.debug(
+                "%s exposes no MountedPanda; trying next libero layout",
+                module_path,
+            )
+            continue
+        try:
+            # ``MountedPanda.init_qpos`` is a property that returns a
+            # fresh ndarray on each access. Instantiating triggers
+            # MJCF asset load (``robots/panda/robot.xml``); the property
+            # itself reads from constants so the construction cost is
+            # paid once per process.
+            home = np.asarray(mounted_panda_cls().init_qpos, dtype=np.float64)
+        except Exception as e:  # noqa: BLE001 - any failure soft-fall-through
+            logger.debug(
+                "MountedPanda(%s).init_qpos raised %s; trying next libero layout",
+                module_path,
+                e,
+            )
+            continue
+        if home.shape != (n_arm,):
+            logger.debug(
+                "MountedPanda(%s).init_qpos shape %s does not match arm DoF %d; ignoring",
+                module_path,
+                home.shape,
+                n_arm,
+            )
+            home = None
+            continue
+        # Successfully resolved.
+        break
+
+    if home is None:
+        # Fall through to stock robosuite Panda. Its init_qpos differs
+        # slightly from MountedPanda's (~30 mrad on j2/j6) but it's
+        # closer to upstream than the perturbed canonical pose, so it's
+        # still a useful fallback when libero is unavailable.
+        try:
+            from robosuite.models.robots.manipulators.panda_robot import (  # type: ignore[import-not-found]
+                Panda,
+            )
+
+            home = np.asarray(Panda().init_qpos, dtype=np.float64)
+            if home.shape != (n_arm,):
+                logger.debug(
+                    "robosuite Panda.init_qpos shape %s does not match arm DoF %d; ignoring",
+                    home.shape,
+                    n_arm,
+                )
+                home = None
+        except ImportError:
+            pass
+        except Exception as e:  # noqa: BLE001
+            logger.debug("robosuite Panda init_qpos lookup raised %s; no fallback", e)
+
+    _CACHED_LIBERO_HOME_QPOS = home
+    _CACHED_LIBERO_HOME_QPOS_RESOLVED = True
+    return home
+
+
+# Module-level cache for the Panda gripper init_qpos (mirrors the arm
+# home pose cache above). Used by
+# ``LiberoAdapter._write_libero_arm_home_qpos`` to set finger joints to
+# upstream's open canonical position.
+_CACHED_PANDA_GRIPPER_INIT_QPOS: np.ndarray | None = None
+_CACHED_PANDA_GRIPPER_INIT_QPOS_RESOLVED: bool = False
+
+
+def _resolve_panda_gripper_init_qpos(n_finger: int) -> np.ndarray | None:
+    """Return the LIBERO-canonical Panda gripper finger init qpos, or ``None``.
+
+    Mirrors ``robosuite.models.grippers.panda_gripper.PandaGripper.init_qpos``,
+    which is ``[0.020833, -0.020833]`` (≈ 2 cm fingertip separation,
+    "open" position). Used by :meth:`LiberoAdapter._write_libero_arm_home_qpos`
+    to initialise gripper finger qpos to upstream's canonical open
+    pose, mirroring upstream ``SingleArm.reset`` which writes
+    ``self.gripper.init_qpos`` to the gripper joint qpos addresses
+    BEFORE constructing the OSC controller.
+
+    Resolution order:
+
+    1. ``robosuite.models.grippers.panda_gripper.PandaGripper().init_qpos``
+       (the library function used by both stock libero and LIBERO-PRO).
+    2. ``None`` — caller leaves gripper qpos at MuJoCo's default (zero,
+       which is "fingers touching" — significantly different from the
+       open canonical pose). The 14 mm divergence between
+       ``data.qpos[gripper] = 0`` (closed) and ``data.qpos[gripper] =
+       0.0208`` (open) is enough to put the policy out-of-distribution
+       on ``state.gripper`` from the very first observation.
+
+    Refs #176 sub-task 3d.
+    """
+    global _CACHED_PANDA_GRIPPER_INIT_QPOS, _CACHED_PANDA_GRIPPER_INIT_QPOS_RESOLVED
+
+    if _CACHED_PANDA_GRIPPER_INIT_QPOS_RESOLVED:
+        if _CACHED_PANDA_GRIPPER_INIT_QPOS is None:
+            return None
+        if _CACHED_PANDA_GRIPPER_INIT_QPOS.shape != (n_finger,):
+            return None
+        return _CACHED_PANDA_GRIPPER_INIT_QPOS
+
+    init_qpos: np.ndarray | None = None
+    try:
+        from robosuite.models.grippers.panda_gripper import (  # type: ignore[import-not-found]
+            PandaGripper,
+        )
+
+        init_qpos = np.asarray(PandaGripper().init_qpos, dtype=np.float64)
+        if init_qpos.shape != (n_finger,):
+            logger.debug(
+                "PandaGripper.init_qpos shape %s does not match finger count %d; ignoring",
+                init_qpos.shape,
+                n_finger,
+            )
+            init_qpos = None
+    except ImportError:
+        pass
+    except Exception as e:  # noqa: BLE001
+        logger.debug("PandaGripper.init_qpos lookup raised %s; no fallback", e)
+
+    _CACHED_PANDA_GRIPPER_INIT_QPOS = init_qpos
+    _CACHED_PANDA_GRIPPER_INIT_QPOS_RESOLVED = True
+    return init_qpos
 
 
 def _to_scalar(value: Any) -> float:

--- a/strands_robots/benchmarks/libero/adapter.py
+++ b/strands_robots/benchmarks/libero/adapter.py
@@ -3811,7 +3811,21 @@ class _LiberoOSCController:
             ],
             dtype=np.float64,
         )
-        gripper_value = _to_scalar(action_dict.get("gripper", 0.0))
+        # Default 0.5 (RLDS midway = no command) so an action dict
+        # WITHOUT a gripper key produces no gripper movement. Round 41
+        # added the RLDS→robosuite conversion ``-sign(2*v - 1)`` which
+        # maps a default of 0.0 (RLDS close) to +1 (LIBERO close),
+        # silently closing the gripper on every empty-dict
+        # ``send_action({})`` call. With default 0.5 the conversion
+        # gives 0 → no ramp → ``current_action`` stays at its previous
+        # value → ctrl = bias (mid-range, holds open). #171 sub-task 3c
+        # found this via the deep-rollout state parity test: gripper
+        # drifted -19.6 mm in 50 zero-action steps while upstream stayed
+        # at ~+20 mm.
+        #
+        # Production eval is unaffected — the policy always sends
+        # ``gripper`` in the action chunk so the default never fires.
+        gripper_value = _to_scalar(action_dict.get("gripper", 0.5))
 
         # Round 41 (#168) — convert RLDS gripper convention → robosuite/LIBERO
         # convention. The GR00T-N1.7-LIBERO checkpoint emits ``action.gripper``

--- a/strands_robots/benchmarks/libero/bddl_parser.py
+++ b/strands_robots/benchmarks/libero/bddl_parser.py
@@ -195,12 +195,21 @@ def _on_kwargs(args: list[str]) -> dict[str, Any]:
     # off plate.xy — the loose defaults rejected this as ``False`` while
     # ``env.check_success()`` returned ``True`` (#170 diagnostic).
     #
-    # We don't add the contact check here yet (would require
-    # :meth:`get_contacts` on ``LiberoOffScreenRenderEngine``); the
-    # tighter geometric thresholds alone close the libero-10/SCENE5
-    # divergence. False positives in transient "suspended above plate"
-    # states are rare and self-correct as the rollout continues.
-    return {"body_a": args[0], "body_b": args[1], "z_offset": 0.0, "xy_tol": 0.03}
+    # #171 sub-task 3e: also require physics contact via
+    # ``sim.get_contacts``. Without this, transient
+    # "mug-suspended-above-plate" placement states produce BDDL false
+    # positives (mug 5 cm above plate, xy-aligned, no contact yet) — on
+    # ``LiberoOffScreenRenderEngine`` this is masked by ``is_success``
+    # delegating to ``env.check_success``; on ``MuJoCoSimEngine`` it
+    # could over-report. Graceful degradation: engines without
+    # ``get_contacts`` skip the check (preserves pre-#171 behaviour).
+    return {
+        "body_a": args[0],
+        "body_b": args[1],
+        "z_offset": 0.0,
+        "xy_tol": 0.03,
+        "require_contact": True,
+    }
 
 
 def _near_kwargs(args: list[str]) -> dict[str, Any]:

--- a/strands_robots/simulation/libero_offscreen_render/engine.py
+++ b/strands_robots/simulation/libero_offscreen_render/engine.py
@@ -710,7 +710,98 @@ class LiberoOffScreenRenderEngine(SimEngine):
         return {"status": "error", "content": [{"text": "randomize: not supported on LiberoOffScreenRenderEngine."}]}
 
     def get_contacts(self) -> dict[str, Any]:
-        return {"status": "error", "content": [{"text": "get_contacts: not supported on LiberoOffScreenRenderEngine."}]}
+        """Return active geom-geom contacts at the current step.
+
+        Required by ``strands_robots.simulation.predicates._contact_between``
+        and the contact-aware variant of ``_body_on`` (see
+        :func:`strands_robots.simulation.predicates._body_contact`).
+
+        Without this method the BDDL evaluator's contact-based predicates
+        (``grasped``, the contact half of ``on``, ``inside``) silently
+        return ``False`` because ``getattr(sim, "get_contacts", None)``
+        is ``None``. Pre-#171 sub-task 3e this method returned an
+        ``"error"`` stub which had the same effect — pinned by issue
+        #170's diagnostic showing transient ``env=False bddl=True``
+        false positives at "mug-suspended-above-plate" states (no
+        contact yet, but our geometric-only ``_body_on`` fired True).
+
+        Reads contacts directly from the underlying robosuite
+        ``sim.data.contact[]`` array; mirrors
+        :meth:`MuJoCoSimEngine.get_contacts`'s schema (``status`` /
+        ``content`` / ``json`` with ``contacts`` list of
+        ``{geom1, geom2, dist, pos}`` dicts) so the
+        ``predicates._contact_between`` code path works unchanged.
+
+        We also call ``mj_forward`` first so the contact list reflects
+        the current qpos/qvel even immediately after ``reset`` (without
+        this, stale contacts from the previous step or uninitialised
+        memory can appear as phantom penetrations at t=0). Same
+        precaution as the MuJoCoSimEngine implementation.
+        """
+        if self._env is None:
+            return {
+                "status": "error",
+                "content": [{"text": "get_contacts: env not initialized. Call setup_libero_task first."}],
+            }
+        inner_env = getattr(self._env, "env", None)
+        if inner_env is None:
+            return {
+                "status": "error",
+                "content": [{"text": "get_contacts: OffScreenRenderEnv has no inner env attribute."}],
+            }
+
+        try:
+            import mujoco as _mj
+        except ImportError as e:
+            return {
+                "status": "error",
+                "content": [{"text": f"get_contacts: mujoco not importable: {e}"}],
+            }
+
+        try:
+            sim = inner_env.sim
+            # ``robosuite.utils.binding_utils.MjModel`` wraps the raw
+            # ``mujoco.MjModel`` under ``._model``. ``MjData`` is wrapped
+            # under ``._data`` similarly. We need the raw refs for
+            # ``mj_forward``.
+            model_raw = sim.model._model
+            data_raw = sim.data._data
+            _mj.mj_forward(model_raw, data_raw)
+            ncon = int(data_raw.ncon)
+        except (AttributeError, ValueError) as e:
+            return {
+                "status": "error",
+                "content": [{"text": f"get_contacts: failed to read contact array: {e}"}],
+            }
+
+        contacts: list[dict[str, Any]] = []
+        for i in range(ncon):
+            c = data_raw.contact[i]
+            g1, g2 = int(c.geom1), int(c.geom2)
+            try:
+                g1_name = _mj.mj_id2name(model_raw, _mj.mjtObj.mjOBJ_GEOM, g1) or f"geom_{g1}"
+                g2_name = _mj.mj_id2name(model_raw, _mj.mjtObj.mjOBJ_GEOM, g2) or f"geom_{g2}"
+            except (AttributeError, IndexError):
+                # Defensive: if name lookup fails, skip the contact rather
+                # than emitting a malformed record.
+                continue
+            contacts.append(
+                {
+                    "geom1": g1_name,
+                    "geom2": g2_name,
+                    "dist": float(c.dist),
+                    "pos": list(np.asarray(c.pos, dtype=np.float64).tolist()),
+                }
+            )
+
+        text = f"💥 {len(contacts)} contacts" if contacts else "No contacts."
+        return {
+            "status": "success",
+            "content": [
+                {"text": text},
+                {"json": {"contacts": contacts}},
+            ],
+        }
 
     def cleanup(self) -> None:
         if self._env is not None:

--- a/strands_robots/simulation/predicates.py
+++ b/strands_robots/simulation/predicates.py
@@ -271,18 +271,88 @@ def _contact_any() -> BoolPredicate:
     return check
 
 
+def _body_contact(sim: SimEngine, body_a: str, body_b: str) -> bool | None:
+    """Best-effort body-contact lookup.
+
+    Returns ``True`` / ``False`` when ``sim.get_contacts()`` is available
+    AND any geom of ``body_a`` is in contact with any geom of ``body_b``.
+    Returns ``None`` when ``get_contacts()`` is unavailable so the
+    caller can decide whether to gracefully degrade (fall back to
+    geometric-only checks) or hard-fail.
+
+    Heuristic: matches contacts by **geom name prefix** (``<bddl_name>_g``
+    for LIBERO scenes; works for any scene whose geoms follow the
+    ``<body_name>_g<idx>`` convention). Mirrors how upstream LIBERO's
+    ``ObjectState.check_contact`` walks the per-object geom list, but
+    avoids hard-coding the body→geom map by using the naming
+    convention.
+
+    Used by the contact-aware branch of :func:`_body_on` (LIBERO's
+    ``On(A, B)`` predicate semantics requires
+    ``arg2.check_contact(arg1)`` per
+    ``libero/libero/envs/predicates/base_predicates.py``).
+    """
+    get_contacts = getattr(sim, "get_contacts", None)
+    if get_contacts is None:
+        return None
+    try:
+        result = get_contacts()
+    except Exception as e:  # noqa: BLE001 - defensive
+        logger.debug("body_contact(%r, %r) get_contacts raised: %s", body_a, body_b, e)
+        return None
+    if not isinstance(result, dict) or result.get("status") != "success":
+        # Engine returned an error stub or a malformed payload; treat as
+        # "unknown" so the caller can degrade gracefully (False would
+        # be a false negative; we want geometric-only fallback).
+        return None
+    payload = _extract_json(result)
+    contacts = payload.get("contacts")
+    if not isinstance(contacts, list):
+        return None
+
+    prefix_a = f"{body_a}_g"
+    prefix_b = f"{body_b}_g"
+    for c in contacts:
+        if not isinstance(c, dict):
+            continue
+        g1 = c.get("geom1") or ""
+        g2 = c.get("geom2") or ""
+        # Geom-prefix matching: ``<bddl_name>_g<idx>`` is LIBERO's
+        # convention. Either direction (a-then-b or b-then-a) counts.
+        if (g1.startswith(prefix_a) and g2.startswith(prefix_b)) or (
+            g1.startswith(prefix_b) and g2.startswith(prefix_a)
+        ):
+            return True
+    return False
+
+
 def _body_on(
     body_a: str,
     body_b: str,
     z_offset: float = 0.02,
     xy_tol: float = 0.15,
+    require_contact: bool = False,
 ) -> BoolPredicate:
     """Approximate ``(on A B)`` predicate - A resting on top of B.
 
     True when ``A.z > B.z + z_offset`` AND horizontal distance ``|A.xy - B.xy|
-    < xy_tol``. The z-offset parameter accounts for B's half-height + a small
-    buffer; tune per scene. Intended for sparse-success benchmarks (LIBERO,
-    etc.) where exact geometric containment isn't required.
+    < xy_tol``. When ``require_contact=True``, ALSO requires physics
+    contact between A and B via ``sim.get_contacts()`` — matches
+    upstream LIBERO's ``ObjectState.check_ontop`` which combines a
+    geometric check with ``check_contact``. The z-offset parameter
+    accounts for B's half-height + a small buffer; tune per scene.
+    Intended for sparse-success benchmarks (LIBERO, etc.) where exact
+    geometric containment isn't required.
+
+    Contact-check graceful degradation: when
+    ``require_contact=True`` but the sim engine doesn't expose
+    ``get_contacts`` (e.g. test stubs, custom engines), the contact
+    check is skipped and only the geometric check fires. This
+    preserves backwards compatibility — engines without contact
+    support get the pre-#171 behaviour. LIBERO benchmarks running on
+    ``LiberoOffScreenRenderEngine`` or ``MuJoCoSimEngine`` (both
+    implement ``get_contacts``) get the strict upstream-matching
+    semantics.
 
     For full fidelity (MJCF geom size lookup + narrow-phase collision), write
     a scene-specific predicate and register it via :func:`register_predicate`.
@@ -297,7 +367,18 @@ def _body_on(
         dy = pos_a[1] - pos_b[1]
         if (dx * dx + dy * dy) ** 0.5 > float(xy_tol):
             return False
-        return pos_a[2] > pos_b[2] + float(z_offset)
+        if not (pos_a[2] > pos_b[2] + float(z_offset)):
+            return False
+        if require_contact:
+            in_contact = _body_contact(sim, body_a, body_b)
+            # ``None`` ⇒ engine doesn't support contacts; fall back to
+            # geometric-only verdict (preserves pre-#171 behaviour).
+            # ``False`` ⇒ engine reports no contact ⇒ predicate False.
+            # ``True`` ⇒ contact confirmed ⇒ predicate True (combined
+            # with the passing geometric check above).
+            if in_contact is False:
+                return False
+        return True
 
     return check
 

--- a/strands_robots/simulation/predicates.py
+++ b/strands_robots/simulation/predicates.py
@@ -83,21 +83,48 @@ def _body_position(sim: SimEngine, body: str) -> list[float] | None:
     Requires the backend to implement ``get_body_state`` (MuJoCo only at time
     of writing). Future backends can add the same method signature - see
     :meth:`strands_robots.simulation.mujoco.physics.PhysicsMixin.get_body_state`.
+
+    LIBERO body-name convention: BDDL names objects without a suffix
+    (``porcelain_mug_1``), but the MJCF root body is suffixed with
+    ``_main`` (``porcelain_mug_1_main``). Upstream resolves this via
+    ``env.objects_dict[name].root_body`` (see
+    ``libero/libero/envs/bddl_base_domain.py``). We mirror that with a
+    bounded fallback: try the bare name first, then ``<name>_main`` if
+    the bare lookup fails. Round 46 (#176 sub-task 3d) — without this
+    fallback, BDDL goal predicates like ``(On porcelain_mug_1
+    plate_1)`` resolve to ``None`` (body not found) → predicate
+    silently False even when the mug is physically on the plate.
     """
     get_body_state = getattr(sim, "get_body_state", None)
     if get_body_state is None:
         return None
-    try:
-        result = get_body_state(body_name=body)
-    except Exception as e:  # noqa: BLE001 - defensive: predicates never raise
-        logger.debug("body_position(%r) failed: %s", body, e)
+
+    def _try(name: str) -> list[float] | None:
+        try:
+            result = get_body_state(body_name=name)
+        except Exception as e:  # noqa: BLE001 - defensive: predicates never raise
+            logger.debug("body_position(%r) failed: %s", name, e)
+            return None
+        if not isinstance(result, dict) or result.get("status") != "success":
+            return None
+        payload = _extract_json(result)
+        pos = payload.get("position")
+        if isinstance(pos, list) and len(pos) == 3 and all(isinstance(c, (int, float)) for c in pos):
+            return [float(c) for c in pos]
         return None
-    if not isinstance(result, dict) or result.get("status") != "success":
-        return None
-    payload = _extract_json(result)
-    pos = payload.get("position")
-    if isinstance(pos, list) and len(pos) == 3 and all(isinstance(c, (int, float)) for c in pos):
-        return [float(c) for c in pos]
+
+    # 1. Bare name (works for fixtures with explicit body names matching
+    # the BDDL name, e.g. ``living_room_table``).
+    pos = _try(body)
+    if pos is not None:
+        return pos
+    # 2. LIBERO ``<name>_main`` convention (the root body of
+    # procedurally-generated objects). Skip if the name already has
+    # the suffix to avoid double-suffixing on retries.
+    if not body.endswith("_main"):
+        pos = _try(f"{body}_main")
+        if pos is not None:
+            return pos
     return None
 
 

--- a/tests/benchmarks/libero/test_bddl_parser.py
+++ b/tests/benchmarks/libero/test_bddl_parser.py
@@ -402,6 +402,98 @@ class TestCompileGoal:
         # near-success cases.
         assert fn(same_z) is False
 
+    def test_on_libero_requires_contact_when_get_contacts_available(self):
+        """#171 sub-task 3e: ``on(A, B)`` now requires physics contact
+        between A and B when ``sim.get_contacts`` is available. Matches
+        upstream LIBERO's ``ObjectState.check_ontop`` which combines
+        geometric thresholds with ``check_contact``.
+
+        Pre-#171 the geometric check alone fired True at "mug suspended
+        5cm above plate, xy-aligned" transient states; this is now
+        rejected because there's no contact.
+
+        Sentinel for the false-positive elimination: a sim with the
+        right geometry but NO contact must reject the predicate.
+        """
+        text = "(define (problem p) (:goal (on cube_1 plate_1)))"
+        problem = parse_bddl(text)
+        fn = compile_goal(problem.goal)  # type: ignore[arg-type]
+
+        # Geometry passes (cube above plate, xy aligned within 3cm).
+        # But contacts list is EMPTY — engine reports no contact.
+        no_contact = _CombinedSim(
+            bodies={
+                "cube_1": {"position": [0.0, 0.0, 0.443]},
+                "plate_1": {"position": [0.0, 0.0, 0.439]},
+            },
+            contacts=[],  # ← no contact = no "on"
+        )
+        assert fn(no_contact) is False, (
+            "Without contact, on() should return False even when geometry passes. "
+            "If True, the contact check (require_contact=True from _on_kwargs) "
+            "may have regressed."
+        )
+
+        # Same geometry + a contact between cube_g0 and plate_g0 → True.
+        with_contact = _CombinedSim(
+            bodies={
+                "cube_1": {"position": [0.0, 0.0, 0.443]},
+                "plate_1": {"position": [0.0, 0.0, 0.439]},
+            },
+            contacts=[{"geom1": "cube_1_g0", "geom2": "plate_1_g0"}],
+        )
+        assert fn(with_contact) is True
+
+    def test_on_libero_contact_check_matches_either_direction(self):
+        """#171 sub-task 3e: contact records may list (cube_geom,
+        plate_geom) or (plate_geom, cube_geom) — both must match the
+        same predicate. Pin the order-insensitivity so a robosuite
+        contact-record convention change doesn't silently break us.
+        """
+        text = "(define (problem p) (:goal (on cube_1 plate_1)))"
+        problem = parse_bddl(text)
+        fn = compile_goal(problem.goal)  # type: ignore[arg-type]
+
+        bodies = {
+            "cube_1": {"position": [0.0, 0.0, 0.443]},
+            "plate_1": {"position": [0.0, 0.0, 0.439]},
+        }
+        # Direction 1: cube first.
+        forward = _CombinedSim(
+            bodies=bodies,
+            contacts=[{"geom1": "cube_1_g3", "geom2": "plate_1_g7"}],
+        )
+        assert fn(forward) is True
+        # Direction 2: plate first.
+        reverse = _CombinedSim(
+            bodies=bodies,
+            contacts=[{"geom1": "plate_1_g7", "geom2": "cube_1_g3"}],
+        )
+        assert fn(reverse) is True
+
+    def test_on_libero_contact_check_gracefully_degrades_without_get_contacts(self):
+        """#171 sub-task 3e: when the sim engine doesn't expose
+        ``get_contacts`` (e.g. a custom backend, test stub), the
+        contact check is SKIPPED rather than failing. The geometric
+        check alone determines the verdict — preserves pre-#171
+        behaviour for engines without contact support.
+
+        Without this graceful degradation, every non-mujoco backend
+        would suddenly fail every ``on`` predicate."""
+        text = "(define (problem p) (:goal (on cube_1 plate_1)))"
+        problem = parse_bddl(text)
+        fn = compile_goal(problem.goal)  # type: ignore[arg-type]
+
+        # _BodyStateSim has NO get_contacts → graceful degradation.
+        no_contacts_method = _BodyStateSim(
+            {
+                "cube_1": {"position": [0.0, 0.0, 0.443]},
+                "plate_1": {"position": [0.0, 0.0, 0.439]},
+            }
+        )
+        # Geometric check passes, contact check skipped → True.
+        assert fn(no_contacts_method) is True
+
 
 # Representative LIBERO-style round-trip
 

--- a/tests/benchmarks/libero/test_libero_adapter.py
+++ b/tests/benchmarks/libero/test_libero_adapter.py
@@ -270,7 +270,11 @@ class TestIsSuccess:
             bodies={
                 "cube_1": {"position": [0, 0, 0.25]},
                 "plate_1": {"position": [0, 0, 0.1]},
-            }
+            },
+            # #171 sub-task 3e: ``_body_on`` now requires a contact via
+            # ``get_contacts``. Geom-prefix convention is
+            # ``<bddl_name>_g<idx>`` (matches what LIBERO scenes emit).
+            contacts=[{"geom1": "cube_1_g0", "geom2": "plate_1_g0"}],
         )
         assert adapter.is_success(sim) is True
 
@@ -448,7 +452,9 @@ class TestIsSuccessRound170Diagnostic:
             bodies={
                 "cube_1": {"position": [0.001, -0.305, 0.443]},
                 "plate_1": {"position": [-0.004, -0.323, 0.439]},
-            }
+            },
+            # #171 sub-task 3e: ``on`` predicate also requires contact.
+            contacts=[{"geom1": "cube_1_g0", "geom2": "plate_1_g0"}],
         )
         leaves = _walk_predicate_tree(problem.goal, sim)
         assert len(leaves) == 1

--- a/tests/benchmarks/libero/test_libero_adapter.py
+++ b/tests/benchmarks/libero/test_libero_adapter.py
@@ -1910,6 +1910,101 @@ class TestQuaternionToEuler:
         _roll, pitch, _yaw = _quat_wxyz_to_rpy_xyz(quat)
         assert pitch == pytest.approx(math.pi / 2, abs=1e-6)
 
+    def test_matches_robosuite_mat2euler_sxyz(self):
+        """Round 46 (#176 sub-task 3d) — pin byte-equivalence to
+        robosuite's ``mat2euler(R, axes='sxyz')``.
+
+        The pre-46 formula derived sin(pitch) = R[0,2] from
+        ``R = R_x · R_y · R_z`` (intrinsic XYZ), which produced
+        sign-flipped Euler angles for some quaternions vs robosuite.
+        E.g. q=(0, 0.7071, 0.7071, 0) → robosuite returns (π, 0, π/2)
+        but pre-46 returned (-π, 0, -π/2) — different yaw direction
+        (left vs right twist about z), genuinely different rotation.
+
+        This test pins the post-46 formula against pre-computed
+        expected values derived from robosuite's algorithm so a
+        future "simplification" can't silently re-introduce the sign
+        flip and put state.yaw out-of-distribution from the policy's
+        training data.
+
+        Expected values were obtained from
+        ``robosuite.utils.transform_utils.mat2euler(quat2mat(q), axes='sxyz')``
+        (see ``tools/recompute_robosuite_euler.py`` if regenerating).
+        """
+        import math
+
+        from strands_robots.benchmarks.libero.adapter import _quat_wxyz_to_rpy_xyz
+
+        # (q_wxyz, robosuite_sxyz_rpy) pairs. Each q is normalised
+        # to make the test data length-independent.
+        cases = [
+            # identity → (0, 0, 0)
+            ([1.0, 0.0, 0.0, 0.0], (0.0, 0.0, 0.0)),
+            # 90° about X → (π/2, 0, 0)
+            ([0.7071067811865476, 0.7071067811865475, 0.0, 0.0], (math.pi / 2, 0.0, 0.0)),
+            # 90° about Y → (0, π/2, 0); gimbal-lock branch may
+            # absorb roll into yaw, accept (0, π/2, 0) up to the
+            # gimbal-lock degeneracy.
+            ([0.7071067811865476, 0.0, 0.7071067811865475, 0.0], (0.0, math.pi / 2, 0.0)),
+            # 90° about Z → (0, 0, π/2)
+            ([0.7071067811865476, 0.0, 0.0, 0.7071067811865475], (0.0, 0.0, math.pi / 2)),
+            # 180° about (x+y)/sqrt(2) (the case that exposed the
+            # pre-46 sign-flip bug). robosuite returns (π, 0, π/2);
+            # pre-46 incorrectly returned (-π, 0, -π/2).
+            ([0.0, 0.7071067811865475, 0.7071067811865475, 0.0], (math.pi, 0.0, math.pi / 2)),
+            # equal-component quat (0.5, 0.5, 0.5, 0.5):
+            # robosuite returns (π/2, 0, π/2)
+            ([0.5, 0.5, 0.5, 0.5], (math.pi / 2, 0.0, math.pi / 2)),
+        ]
+        for q_wxyz, expected_rpy in cases:
+            ours = _quat_wxyz_to_rpy_xyz(list(q_wxyz))
+            for axis_idx, axis_name in enumerate(("roll", "pitch", "yaw")):
+                # Mod 2π for ±π wraparound; use a generous 1e-5 tol
+                # because asin/atan2 numerical precision dominates.
+                diff = ((ours[axis_idx] - expected_rpy[axis_idx] + math.pi) % (2 * math.pi)) - math.pi
+                # Gimbal-lock case (90° about Y): the (0, π/2, 0)
+                # decomposition isn't unique — roll and yaw both
+                # absorb into a single rotation. Skip the roll/yaw
+                # axis check at exactly pitch=π/2.
+                if abs(expected_rpy[1] - math.pi / 2) < 1e-9 and axis_name in ("roll", "yaw"):
+                    continue
+                assert abs(diff) < 1e-5, (
+                    f"q={q_wxyz}: ours.{axis_name}={ours[axis_idx]:.6f} "
+                    f"vs robosuite expected={expected_rpy[axis_idx]:.6f} "
+                    f"(diff_mod_2pi={diff:.6e}). "
+                    f"Round-46 ``mat2euler(sxyz)`` parity may have regressed."
+                )
+
+    def test_pre_46_sign_flip_regression(self):
+        """Round 46 (#176 sub-task 3d) — explicit pin against the
+        sign-flip bug that the pre-46 formula introduced.
+
+        For ``q = (0, sqrt(2)/2, sqrt(2)/2, 0)`` (180° about (1,1,0)
+        axis), the correct sxyz Euler is ``(π, 0, π/2)``. The pre-46
+        formula returned ``(-π, 0, -π/2)`` — same roll modulo 2π but
+        OPPOSITE yaw (which is genuinely a different rotation about
+        the world Z axis at this orientation).
+
+        Pin: ours_yaw must be CLOSE TO +π/2, not -π/2.
+        """
+        import math
+
+        from strands_robots.benchmarks.libero.adapter import _quat_wxyz_to_rpy_xyz
+
+        q = [0.0, 0.7071067811865475, 0.7071067811865475, 0.0]
+        roll, pitch, yaw = _quat_wxyz_to_rpy_xyz(q)
+        # roll: ±π are both correct (180° rotation is sign-ambiguous).
+        # ``abs(abs(roll) - π)`` is small for both +π and -π.
+        assert abs(abs(roll) - math.pi) < 1e-5, f"roll={roll:.6f}, expected ±π"
+        # pitch must be 0
+        assert abs(pitch) < 1e-5
+        # yaw must be +π/2, NOT -π/2
+        assert abs(yaw - math.pi / 2) < 1e-5, (
+            f"yaw={yaw:.6f}, expected +π/2 ≈ 1.5708. "
+            f"Sign-flip bug from pre-46 ``_quat_wxyz_to_rpy_xyz`` may have "
+            f"regressed — would break state.yaw OOD on the policy."
+        )
+
 
 # Scene auto-generation from BDDL (#164)
 
@@ -3074,6 +3169,194 @@ class TestInstallActionController:
         assert len(ctrl.arm_actuator_ids) == 7
         assert len(ctrl.gripper_actuator_ids) >= 2
         assert ctrl.eef_site_name == "gripper0_grip_site"
+
+    def test_initial_joint_anchored_to_libero_home_pose_not_construction_state(self, libero_scene_xml):
+        """Round 45 (#176): the OSC controller's ``initial_joint`` —
+        the nullspace-bias target — must be the LIBERO-canonical Panda
+        "ready" pose, NOT the joint angles at the moment the controller
+        was constructed.
+
+        Why this matters: ``LiberoAdapter._install_action_controller``
+        runs from ``on_episode_start`` AFTER ``_apply_canonical_state``
+        has already loaded the per-episode ``init_state`` into
+        ``data.qpos``. Robosuite's ``BaseController.__init__`` captures
+        ``self.initial_joint = self.joint_pos`` (= live ``data.qpos``)
+        once at construction. Without the round-45 swap-and-restore
+        around ``controller_factory``, ``initial_joint`` captures the
+        perturbed canonical pose instead of the LIBERO
+        ``MountedPanda.init_qpos`` ready pose — the OSC's
+        ``nullspace_torques`` term ``(initial_joint - joint_pos)``
+        then collapses to ~0 instead of producing the ~5 N·m bias
+        upstream LIBERO produces (where upstream constructs the
+        controller AFTER ``Robot.reset(deterministic=True)`` writes
+        ``MountedPanda.init_qpos`` to ``data.qpos`` but BEFORE
+        ``set_init_state`` perturbs it to the per-episode canonical).
+
+        This was the root cause of the 50× torque divergence between
+        our OSC and upstream's, surfaced by ``probe_osc_internals.py``
+        in #176 sub-task 3b.
+
+        Pin: build a controller after perturbing ``data.qpos[arm]``
+        away from MJCF defaults. The controller's ``initial_joint``,
+        ``initial_ee_pos``, ``initial_ee_ori_mat``, ``goal_pos``, and
+        ``goal_ori`` must all match the values they would have if
+        ``data.qpos[arm]`` had been at ``MountedPanda.init_qpos``
+        when ``__init__`` ran.
+
+        Also verify ``data.qpos`` is restored to the perturbed
+        values after install — the swap is around the
+        ``controller_factory`` call, so the sim's actual state must
+        be the canonical state we passed in, not the home pose.
+        """
+        pytest.importorskip("mujoco")
+        pytest.importorskip("robosuite")
+        libero = pytest.importorskip("libero")
+        import mujoco
+
+        # Resolve the canonical LIBERO Panda home pose. Skip if libero
+        # version doesn't expose MountedPanda (e.g. future rename).
+        try:
+            from libero.libero.envs.robots.mounted_panda import MountedPanda
+        except ImportError:
+            pytest.skip(f"libero {libero.__version__} does not expose MountedPanda")
+        expected_home_qpos = np.asarray(MountedPanda().init_qpos, dtype=np.float64)
+        assert expected_home_qpos.shape == (7,), (
+            f"MountedPanda.init_qpos must be 7-DoF for Panda, got {expected_home_qpos.shape}"
+        )
+
+        adapter = LiberoAdapter.from_text(
+            PICK_CUBE_BDDL,
+            scene_path=libero_scene_xml,
+            install_cameras=False,
+            auto_generate_scene=False,
+        )
+        sim = FakeSim(data_config="panda")
+        sim._world._model = mujoco.MjModel.from_xml_path(libero_scene_xml)  # type: ignore[attr-defined]
+        sim._world._data = mujoco.MjData(sim._world._model)  # type: ignore[attr-defined]
+        mujoco.mj_forward(sim._world._model, sim._world._data)  # type: ignore[attr-defined]
+
+        # Perturb the arm joints by a non-trivial amount that would
+        # flow into ``initial_*`` / ``goal_*`` if we naively captured
+        # live qpos. If ``initial_joint`` is captured at construction
+        # time (without our fix), it would equal these perturbed
+        # values.
+        model = sim._world._model  # type: ignore[attr-defined]
+        data = sim._world._data  # type: ignore[attr-defined]
+        # Find arm joint qpos addresses (robot0_joint1..7).
+        arm_qpos_addrs: list[int] = []
+        for i in range(model.njnt):
+            jname = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, i)
+            if isinstance(jname, str) and jname.startswith("robot0_joint"):
+                arm_qpos_addrs.append(int(model.jnt_qposadr[i]))
+        assert len(arm_qpos_addrs) == 7, f"expected 7 arm joints, found {len(arm_qpos_addrs)}"
+
+        # Perturb each arm joint by 0.05 rad (~2.9 deg). Pre-fix,
+        # ``initial_joint`` would equal ``data.qpos[arm] + 0.05``
+        # after install.
+        perturbation = 0.05
+        for adr in arm_qpos_addrs:
+            data.qpos[adr] += perturbation
+        mujoco.mj_forward(model, data)
+
+        # Snapshot perturbed qpos so we can assert it's restored
+        # after install (the swap-and-restore must put data back
+        # exactly where it was).
+        perturbed_qpos = np.array([float(data.qpos[adr]) for adr in arm_qpos_addrs])
+
+        # Capture the EEF pose at the HOME joint configuration so we
+        # can assert the controller latched on to those values for
+        # ``initial_ee_pos`` / ``initial_ee_ori_mat`` / ``goal_pos`` /
+        # ``goal_ori``. Approach: write home qpos, mj_forward, read
+        # site_xpos/xmat, restore.
+        eef_site_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_SITE, "gripper0_grip_site")
+        for adr, v in zip(arm_qpos_addrs, expected_home_qpos, strict=True):
+            data.qpos[adr] = float(v)
+        mujoco.mj_forward(model, data)
+        expected_home_ee_pos = np.array(data.site_xpos[eef_site_id])
+        expected_home_ee_ori_mat = np.array(data.site_xmat[eef_site_id]).reshape(3, 3)
+        # Restore perturbed qpos.
+        for adr, v in zip(arm_qpos_addrs, perturbed_qpos, strict=True):
+            data.qpos[adr] = float(v)
+        mujoco.mj_forward(model, data)
+
+        adapter._install_action_controller(sim)
+        ctrl = sim._world._backend_state.get("action_controller")
+        if ctrl is None:
+            pytest.skip("action_controller install failed")
+
+        # 1. ``initial_joint`` matches the home pose.
+        captured_init_joint = np.array(ctrl.controller.initial_joint)
+        np.testing.assert_allclose(
+            captured_init_joint,
+            expected_home_qpos,
+            atol=1e-6,
+            err_msg=(
+                f"initial_joint was NOT re-anchored to LIBERO MountedPanda.init_qpos "
+                f"={expected_home_qpos.tolist()}. The OSC controller will compute wrong "
+                f"nullspace bias when constructed after _apply_canonical_state. See PR #176. "
+                f"captured={captured_init_joint.tolist()}, perturbed={perturbed_qpos.tolist()}"
+            ),
+        )
+
+        # 2. ``initial_ee_pos`` matches the EEF position at home pose
+        # (NOT the EEF position at perturbed qpos). Tolerance 1e-5 m
+        # because mj_forward involves ~10 floating-point ops per joint.
+        captured_initial_ee_pos = np.array(ctrl.controller.initial_ee_pos)
+        np.testing.assert_allclose(
+            captured_initial_ee_pos,
+            expected_home_ee_pos,
+            atol=1e-5,
+            err_msg=(
+                f"initial_ee_pos={captured_initial_ee_pos.tolist()} does not match "
+                f"expected home EEF pos={expected_home_ee_pos.tolist()}. The swap-and-"
+                f"restore around controller_factory may not have written home qpos "
+                f"to data before construction."
+            ),
+        )
+
+        # 3. ``initial_ee_ori_mat`` matches the EEF orientation at
+        # home pose. Same tolerance reasoning.
+        captured_initial_ee_ori = np.array(ctrl.controller.initial_ee_ori_mat)
+        np.testing.assert_allclose(
+            captured_initial_ee_ori,
+            expected_home_ee_ori_mat,
+            atol=1e-5,
+            err_msg=(
+                "initial_ee_ori_mat does not match expected home EEF orientation. "
+                "This causes goal_ori to latch on to the perturbed pose's orientation, "
+                "producing torques ~50× off from upstream. See PR #176."
+            ),
+        )
+
+        # 4. ``goal_pos`` and ``goal_ori`` are initialised in
+        # ``OSC_POSE.__init__`` to ``initial_ee_pos`` / ``initial_ee_ori_mat``.
+        # Verify they too track home pose, not perturbed.
+        np.testing.assert_allclose(np.array(ctrl.controller.goal_pos), expected_home_ee_pos, atol=1e-5)
+        np.testing.assert_allclose(np.array(ctrl.controller.goal_ori), expected_home_ee_ori_mat, atol=1e-5)
+
+        # 5. ``data.qpos[arm]`` restored to perturbed values (the
+        # swap-and-restore must not leak home pose into the sim's
+        # actual state).
+        restored_qpos = np.array([float(data.qpos[adr]) for adr in arm_qpos_addrs])
+        np.testing.assert_allclose(
+            restored_qpos,
+            perturbed_qpos,
+            atol=1e-9,
+            err_msg=(
+                f"data.qpos[arm] not restored after controller install — sim's "
+                f"actual state is now the home pose {restored_qpos.tolist()} instead "
+                f"of the canonical {perturbed_qpos.tolist()}. The swap-and-restore "
+                f"contract is broken."
+            ),
+        )
+
+        # 6. Sentinel: ``initial_joint`` must NOT equal the perturbed
+        # qpos at install time. If they're equal (within float
+        # tolerance), the round-45 fix didn't run.
+        assert not np.allclose(captured_init_joint, perturbed_qpos, atol=1e-3), (
+            f"initial_joint={captured_init_joint.tolist()} equals perturbed qpos "
+            f"{perturbed_qpos.tolist()} — round-45 swap-and-restore didn't run."
+        )
 
     def test_apply_writes_nonzero_torques_to_data_ctrl(self, libero_scene_xml):
         """Round-24 acceptance pin: after a non-trivial Cartesian delta,

--- a/tests/simulation/libero_offscreen_render/test_engine_get_contacts.py
+++ b/tests/simulation/libero_offscreen_render/test_engine_get_contacts.py
@@ -1,0 +1,227 @@
+"""Unit tests for ``LiberoOffScreenRenderEngine.get_contacts``.
+
+Issue #171 sub-task 3e replaced the engine's stub ``get_contacts``
+(which returned a status='error' "not supported" message) with a real
+implementation that reads from ``self._env.env.sim.data.contact[]``.
+Required by the BDDL evaluator's contact-aware predicates (``_body_on``
+with ``require_contact=True``, ``_grasped``, etc.) — without it, the
+contact check silently no-ops and predicates fall back to
+geometric-only verdicts (the pre-#171 behaviour, with transient false
+positives during placement).
+
+These tests don't require running the real LIBERO env — they construct
+the engine, inject mock mujoco model + data with known contacts, and
+verify the returned status-dict format matches what
+``MuJoCoSimEngine.get_contacts`` returns.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+mujoco = pytest.importorskip("mujoco", reason="LiberoOffScreenRenderEngine module needs mujoco at construction")
+
+from strands_robots.simulation.libero_offscreen_render.engine import (  # noqa: E402
+    LiberoOffScreenRenderEngine,
+)
+
+
+class _FakeContact:
+    """Mimics a single record from ``mujoco.MjData.contact[i]``."""
+
+    def __init__(self, geom1: int, geom2: int, dist: float = 0.0, pos: list[float] | None = None):
+        self.geom1 = geom1
+        self.geom2 = geom2
+        self.dist = dist
+        self.pos = np.asarray(pos if pos is not None else [0.0, 0.0, 0.0], dtype=np.float64)
+
+
+class _FakeData:
+    """Mimics ``mujoco.MjData`` for the slice ``get_contacts`` reads."""
+
+    def __init__(self, contacts: list[_FakeContact]):
+        self.ncon = len(contacts)
+        self.contact = contacts
+
+
+class _FakeModel:
+    """Mimics ``mujoco.MjModel`` — an opaque token passed to mj_forward."""
+
+
+class _FakeWrappedModel:
+    """Robosuite's ``binding_utils.MjModel`` wraps the raw ``mujoco.MjModel`` under ``._model``."""
+
+    def __init__(self, raw):
+        self._model = raw
+
+
+class _FakeWrappedData:
+    """Robosuite's ``binding_utils.MjData`` wraps under ``._data``."""
+
+    def __init__(self, raw):
+        self._data = raw
+
+
+class _FakeSim:
+    def __init__(self, model_raw, data_raw):
+        self.model = _FakeWrappedModel(model_raw)
+        self.data = _FakeWrappedData(data_raw)
+
+
+class _FakeInnerEnv:
+    def __init__(self, sim):
+        self.sim = sim
+
+
+class _FakeOffScreenEnv:
+    def __init__(self, inner):
+        self.env = inner
+
+
+def _make_engine(contacts: list[dict[str, object]]) -> LiberoOffScreenRenderEngine:
+    """Build an engine with the given fake contacts wired through."""
+    fake_contacts = [
+        _FakeContact(
+            geom1=int(c["geom1"]),  # type: ignore[call-overload]
+            geom2=int(c["geom2"]),  # type: ignore[call-overload]
+            dist=float(c.get("dist", 0.0)),  # type: ignore[arg-type]
+            pos=list(c.get("pos", [0.0, 0.0, 0.0])),  # type: ignore[call-overload]
+        )
+        for c in contacts
+    ]
+    fake_model = _FakeModel()
+    fake_data = _FakeData(fake_contacts)
+    sim = _FakeSim(fake_model, fake_data)
+    inner = _FakeInnerEnv(sim)
+    engine = LiberoOffScreenRenderEngine()
+    engine._env = _FakeOffScreenEnv(inner)  # type: ignore[assignment]
+    return engine
+
+
+@pytest.fixture
+def patched_mujoco():
+    """Patch ``mujoco.mj_forward`` (no-op on our fakes) and
+    ``mujoco.mj_id2name`` (table-driven)."""
+    geom_table: dict[int, str | None] = {}
+
+    def fake_id2name(model, obj_type, obj_id):
+        if obj_type == mujoco.mjtObj.mjOBJ_GEOM:
+            return geom_table.get(obj_id)
+        return None
+
+    def fake_forward(model, data):
+        # No-op — we don't need real physics.
+        pass
+
+    with (
+        patch.object(mujoco, "mj_forward", side_effect=fake_forward),
+        patch.object(mujoco, "mj_id2name", side_effect=fake_id2name),
+    ):
+        yield geom_table
+
+
+class TestGetContacts:
+    """#171 sub-task 3e: engine returns active contacts in
+    MuJoCoSimEngine-compatible schema. The BDDL evaluator's
+    ``_contact_between`` and ``_body_contact`` consume the same format.
+    """
+
+    def test_returns_empty_list_when_no_contacts(self, patched_mujoco):
+        """No active contacts ⇒ empty list, status=success."""
+        engine = _make_engine([])
+        result = engine.get_contacts()
+        assert result["status"] == "success"
+        json_payload = next(c["json"] for c in result["content"] if "json" in c)
+        assert json_payload["contacts"] == []
+
+    def test_returns_contact_with_geom_names(self, patched_mujoco):
+        """Each contact record has ``geom1`` / ``geom2`` (string names),
+        ``dist`` (float), ``pos`` (3-list). Schema matches
+        ``MuJoCoSimEngine.get_contacts``."""
+        patched_mujoco.update({1: "cube_1_g0", 2: "plate_1_g0"})
+        engine = _make_engine([{"geom1": 1, "geom2": 2, "dist": -0.0001, "pos": [0.0, 0.0, 0.5]}])
+        result = engine.get_contacts()
+        assert result["status"] == "success"
+        json_payload = next(c["json"] for c in result["content"] if "json" in c)
+        contacts = json_payload["contacts"]
+        assert len(contacts) == 1
+        c = contacts[0]
+        assert c["geom1"] == "cube_1_g0"
+        assert c["geom2"] == "plate_1_g0"
+        assert isinstance(c["dist"], float)
+        assert isinstance(c["pos"], list)
+        assert len(c["pos"]) == 3
+
+    def test_unnamed_geom_falls_back_to_id_string(self, patched_mujoco):
+        """When a geom has no name (mj_id2name returns None), the record
+        uses ``geom_<id>`` format. Defensive — robosuite-compiled MJCFs
+        sometimes have unnamed visual geoms."""
+        # No entries in geom_table ⇒ mj_id2name returns None.
+        engine = _make_engine([{"geom1": 999, "geom2": 1000}])
+        result = engine.get_contacts()
+        assert result["status"] == "success"
+        json_payload = next(c["json"] for c in result["content"] if "json" in c)
+        contacts = json_payload["contacts"]
+        assert contacts[0]["geom1"] == "geom_999"
+        assert contacts[0]["geom2"] == "geom_1000"
+
+    def test_no_env_returns_error(self):
+        """Calling before ``setup_libero_task`` returns structured error."""
+        engine = LiberoOffScreenRenderEngine()
+        result = engine.get_contacts()
+        assert result["status"] == "error"
+        assert "not initialized" in result["content"][0]["text"].lower()
+
+    def test_returned_format_matches_mujoco_engine_contract(self, patched_mujoco):
+        """Schema parity with ``MuJoCoSimEngine.get_contacts``: top-level
+        ``status`` / ``content`` list with a ``json`` block whose
+        ``contacts`` key is a list of contact dicts."""
+        patched_mujoco.update({0: "a_g0", 1: "b_g0"})
+        engine = _make_engine([{"geom1": 0, "geom2": 1}])
+        result = engine.get_contacts()
+        assert "status" in result
+        assert isinstance(result["content"], list)
+        assert any(isinstance(c, dict) and "json" in c for c in result["content"])
+        json_payload = next(c["json"] for c in result["content"] if "json" in c)
+        assert "contacts" in json_payload
+        assert isinstance(json_payload["contacts"], list)
+
+    def test_used_by_predicate_evaluator(self, patched_mujoco):
+        """End-to-end: a contact-aware ``on`` predicate compiled from
+        BDDL fires True when the engine reports the matching contact.
+        Pin the integration so a future schema change to
+        ``get_contacts`` breaks both this test and the predicate
+        evaluator at once (rather than only the predicate evaluator
+        silently)."""
+        from strands_robots.benchmarks.libero.bddl_parser import compile_goal, parse_bddl
+
+        patched_mujoco.update({0: "cube_1_g0", 1: "plate_1_g0"})
+        engine = _make_engine([{"geom1": 0, "geom2": 1}])
+
+        # Also need ``get_body_state`` to work — patch it.
+        def fake_get_body_state(self, body_name):
+            positions = {
+                "cube_1": [0.0, 0.0, 0.443],
+                "plate_1": [0.0, 0.0, 0.439],
+            }
+            if body_name in positions:
+                return {
+                    "status": "success",
+                    "content": [
+                        {"text": ""},
+                        {"json": {"position": positions[body_name], "quaternion": [1, 0, 0, 0]}},
+                    ],
+                }
+            return {"status": "error", "content": [{"text": "missing"}]}
+
+        with patch.object(LiberoOffScreenRenderEngine, "get_body_state", fake_get_body_state):
+            text = "(define (problem p) (:goal (on cube_1 plate_1)))"
+            problem = parse_bddl(text)
+            fn = compile_goal(problem.goal)  # type: ignore[arg-type]
+            assert fn(engine) is True, (
+                "Contact-aware ``on`` predicate must fire True when "
+                "engine.get_contacts reports a matching cube_1↔plate_1 contact"
+            )

--- a/tests/simulation/test_benchmark_predicates.py
+++ b/tests/simulation/test_benchmark_predicates.py
@@ -198,6 +198,58 @@ class TestBodyPositionPredicates:
         pred = make_predicate("body_above_z", body="cube", z=0)
         assert pred(sim) is False
 
+    def test_body_position_libero_main_suffix_fallback(self):
+        """Round 46 (#176 sub-task 3d) — LIBERO objects' BDDL names
+        (``porcelain_mug_1``) map to MJCF root bodies suffixed with
+        ``_main`` (``porcelain_mug_1_main``). The predicate evaluator
+        must transparently retry with the suffix when the bare name
+        misses, mirroring upstream LIBERO's
+        ``env.objects_dict[name].root_body`` resolution. Without this,
+        BDDL goal predicates like ``(On porcelain_mug_1 plate_1)``
+        silently resolve to ``False`` even when physics has the mug
+        on the plate.
+
+        Pin: a sim that only exposes ``porcelain_mug_1_main`` (NOT
+        ``porcelain_mug_1``) must still resolve via the predicate as
+        if the bare name worked.
+        """
+        # Sim only knows the suffixed name (mimics MJCF body naming).
+        sim = _BodyStateSim({"porcelain_mug_1_main": [0.0, 0.0, 0.5]})
+        pred = make_predicate("body_above_z", body="porcelain_mug_1", z=0.4)
+        assert pred(sim) is True, (
+            "body_above_z with bare BDDL name should fall back to ``<name>_main`` "
+            "for LIBERO scenes; round-46 fix may have regressed."
+        )
+
+    def test_body_position_main_suffix_no_double_suffix(self):
+        """Already-suffixed names must not double-suffix on retry.
+        Round 46 (#176 sub-task 3d).
+        """
+        # Sim only knows the suffixed name; caller passes already-suffixed.
+        sim = _BodyStateSim({"plate_1_main": [0.0, 0.0, 0.4]})
+        pred = make_predicate("body_above_z", body="plate_1_main", z=0.3)
+        assert pred(sim) is True
+
+    def test_body_position_bare_name_wins_over_suffix(self):
+        """When BOTH ``<name>`` and ``<name>_main`` exist, prefer the
+        bare lookup. This preserves the contract for fixtures /
+        explicit-named bodies (e.g. ``living_room_table``) which don't
+        use the LIBERO suffix.
+
+        Round 46 (#176 sub-task 3d).
+        """
+        sim = _BodyStateSim(
+            {
+                "living_room_table": [0.0, 0.0, 0.46],
+                "living_room_table_main": [99.0, 99.0, 99.0],  # decoy
+            }
+        )
+        pred = make_predicate("body_above_z", body="living_room_table", z=0.4)
+        assert pred(sim) is True
+        # Decoy at 99.0 should not be reached if bare lookup wins.
+        pred2 = make_predicate("body_above_z", body="living_room_table", z=98.0)
+        assert pred2(sim) is False, "bare name should win over _main suffix; double-resolve detected"
+
 
 # Joint predicates
 

--- a/tests_integ/benchmarks/libero/test_upstream_state_parity.py
+++ b/tests_integ/benchmarks/libero/test_upstream_state_parity.py
@@ -288,3 +288,106 @@ def test_state_gripper_joint_names_resolve_in_real_libero_scene() -> None:
             )
     finally:
         sim.destroy()
+
+
+@pytest.mark.timeout(300)
+def test_state_parity_after_50_steps_zero_action() -> None:
+    """#171 sub-task 3c — Deep-rollout state parity test.
+
+    Drives both upstream ``OffScreenRenderEnv`` and our
+    ``MuJoCoSimEngine``-backed adapter with the SAME action sequence
+    (50 steps of zero action — gravity + passive dynamics only) and
+    asserts state stays within tolerance per step.
+
+    The existing ``test_state_parity_at_canonical_init`` validates init
+    pose only. This test catches trajectory drift that compounds beyond
+    init: small differences in scene XML (round 9 v3 cache work),
+    OSC controller (rounds 27/28/41), or numerical integration paths
+    can produce sub-mm divergence at init that grows to cm-scale by
+    step 50.
+
+    Uses zero actions because ANY non-trivial action would route
+    through the upstream OSC controller (robosuite native) on one side
+    and our ``_LiberoOSCController`` on the other — a separate test
+    surface (sub-task 3b). Zero-action drift isolates the
+    physics-only path: same init state + same dt + (ideally) same
+    model = same trajectory.
+
+    Tolerances: position 5cm per axis (allows for dt=0.002s × 50
+    steps × small drift), orientation 200 mrad. Looser than the
+    init-only parity test because compounding numerical error is
+    expected; the test fails if drift exceeds physical-plausibility
+    bounds rather than pinning byte-equivalence.
+    """
+    upstream_env, task_bddl, init_state = _build_upstream_env()
+    sim, adapter = _build_our_adapter_at_canonical(task_bddl, init_state)
+    try:
+        # Drive both with the same scripted zero-action sequence.
+        n_steps = 50
+        zero_action = np.zeros(7)
+
+        # Upstream env: env.step(zero_action) advances physics.
+        # Our sim: send_action with zero deltas via the OSC controller.
+        # Empty action dict ⇒ OSC sees zero delta + zero gripper command,
+        # writes zero torques (gravity comp only).
+        ours_state_history: list[dict] = []
+        for _step_idx in range(n_steps):
+            # Upstream step.
+            upstream_env.step(zero_action)
+            # Our step: empty action dict ⇒ OSC apply with zero delta.
+            sim.send_action({})
+
+            # Sample state from both at this step.
+            ours_obs = sim.get_observation(skip_images=True)
+            ours_state = adapter.augment_observation(sim, ours_obs)
+            ours_state_history.append(
+                {
+                    "x": ours_state.get("x"),
+                    "y": ours_state.get("y"),
+                    "z": ours_state.get("z"),
+                    "gripper": ours_state.get("gripper"),
+                }
+            )
+
+        # Final-step comparison. Compare last sample against upstream's
+        # most recent obs returned by env.step (cached internally). One
+        # last step() call to surface the obs dict for asserting.
+        last_upstream_obs, *_ = upstream_env.step(zero_action)
+
+        ups_pos = last_upstream_obs["robot0_eef_pos"]
+        ours_final = ours_state_history[-1]
+        # Position drift bound: 5 cm per axis. Compounded over 50
+        # physics-only steps starting from the same init, real-world
+        # drift should be far less; this generous bound catches
+        # actual trajectory divergence (cm-scale) rather than
+        # numerical noise (mm-scale).
+        for axis_idx, axis_name in enumerate(["x", "y", "z"]):
+            ours_v = ours_final[axis_name]
+            ups_v = float(ups_pos[axis_idx])
+            delta = abs(ours_v - ups_v)
+            assert delta < 0.05, (
+                f"state.{axis_name} drift after {n_steps} zero-action steps: "
+                f"{delta:.4f} m > 5 cm tolerance. "
+                f"ours={ours_v:.4f}, upstream={ups_v:.4f}. "
+                f"Trajectory diverges beyond physical-plausibility — "
+                f"likely a scene XML or OSC controller divergence. "
+                f"See #171 sub-tasks 3a/3b."
+            )
+
+        # Gripper drift bound: each finger should stay within 5 mm of
+        # upstream (same convention as the init-pose test).
+        ups_gripper = last_upstream_obs["robot0_gripper_qpos"]
+        ours_gripper = ours_final["gripper"]
+        assert ours_gripper is not None and len(ours_gripper) == 2, (
+            f"state.gripper malformed after rollout: {ours_gripper}"
+        )
+        for finger_idx in range(2):
+            delta = abs(float(ours_gripper[finger_idx]) - float(ups_gripper[finger_idx]))
+            assert delta < 0.005, (
+                f"state.gripper[{finger_idx}] drift after {n_steps} steps: "
+                f"{delta:.4f} m > 5 mm. "
+                f"ours={ours_gripper[finger_idx]:.4f}, upstream={ups_gripper[finger_idx]:.4f}"
+            )
+    finally:
+        sim.destroy()
+        upstream_env.close()

--- a/tests_integ/benchmarks/libero/test_upstream_state_parity.py
+++ b/tests_integ/benchmarks/libero/test_upstream_state_parity.py
@@ -27,6 +27,7 @@ Run with:
 from __future__ import annotations
 
 import os
+from typing import Any
 
 import pytest
 
@@ -391,3 +392,375 @@ def test_state_parity_after_50_steps_zero_action() -> None:
     finally:
         sim.destroy()
         upstream_env.close()
+
+
+@pytest.mark.timeout(180)
+def test_osc_torque_parity_at_identical_state() -> None:
+    """#176 acceptance: per-step arm torques match upstream's within
+    5% relative error AT identical canonical state + same input action.
+
+    The round-45 swap-and-restore around ``controller_factory``
+    (in ``_LiberoOSCController.from_sim``) makes the controller
+    capture ``initial_joint`` / ``initial_ee_pos`` /
+    ``initial_ee_ori_mat`` / ``goal_pos`` / ``goal_ori`` from the
+    LIBERO ``MountedPanda`` ready pose, matching what upstream
+    ``OffScreenRenderEnv``'s ``Robot.reset(deterministic=True) +
+    _load_controller`` sequence captures.
+
+    Pre-fix: torques diverged by 50× because our ``initial_*``
+    attributes latched on to the perturbed canonical pose written
+    by ``_apply_canonical_state`` instead of the home pose. See
+    ``probe_osc_internals.py`` for the bisection narrowing it to
+    ``initial_joint`` and ``probe_osc_internals_v3.py`` for the
+    per-state comparison verifying the swap closes the gap.
+
+    Approach:
+    1. Build both pipelines at canonical init.
+    2. Step both once with zero action (so ``data.qpos`` /
+       ``qvel`` match upstream's post-``_build_upstream_env`` state).
+    3. Copy upstream's ``data.qpos`` / ``qvel`` into ours so any
+       residual init-state divergence is eliminated.
+    4. Force-update both controllers, set the same goal, run
+       one ``run_controller()`` call on each.
+    5. Per-joint torque comparison: rel_err <= 5%.
+
+    Without the round-45 swap, every joint's rel_err exceeds
+    100% — j5 in particular saw 4800% in pre-fix probe.
+    """
+    upstream_env, task_bddl, init_state = _build_upstream_env()
+    sim, adapter = _build_our_adapter_at_canonical(task_bddl, init_state)
+    try:
+        # Pre-step ours once to match upstream's "_build_upstream_env"
+        # pre-step (zero-action env.step inside the helper).
+        sim.send_action({})
+
+        ups_inner = upstream_env.env
+        ups_data = ups_inner.sim.data._data
+        ours_data = sim._world._data  # type: ignore[attr-defined]
+        ours_model = sim._world._model  # type: ignore[attr-defined]
+
+        # Copy upstream's full qpos/qvel into ours so byte-identical
+        # state. This isolates the OSC torque computation from any
+        # state-side divergence (#171 sub-task 3a is a separate test
+        # surface).
+        np.copyto(ours_data.qpos, ups_data.qpos)
+        np.copyto(ours_data.qvel, ups_data.qvel)
+        mujoco.mj_forward(ours_model, ours_data)
+        mujoco.mj_forward(ups_inner.sim.model._model, ups_data)
+
+        ups_ctrl = ups_inner.robots[0].controller
+        ours_ctrl = sim._world._backend_state.get("action_controller").controller  # type: ignore[attr-defined]
+
+        # Pre-conditions: state truly identical.
+        ups_ctrl.update(force=True)
+        ours_ctrl.update(force=True)
+        np.testing.assert_allclose(
+            np.array(ours_ctrl.joint_pos),
+            np.array(ups_ctrl.joint_pos),
+            atol=1e-9,
+            err_msg="state copy failed: joint_pos diverges",
+        )
+        np.testing.assert_allclose(
+            np.array(ours_ctrl.initial_joint),
+            np.array(ups_ctrl.initial_joint),
+            atol=1e-9,
+            err_msg=(
+                "initial_joint diverges between upstream and ours — round-45 "
+                "swap-and-restore in _LiberoOSCController.from_sim may have regressed."
+            ),
+        )
+
+        # Apply same delta-EEF action to both.
+        arm_action = np.array([0.05, 0.0, 0.0, 0.0, 0.0, 0.0])
+        ups_ctrl.set_goal(arm_action)
+        ours_ctrl.set_goal(arm_action)
+
+        # Goal sanity: with identical state + same delta, goal_pos
+        # and goal_ori must match exactly.
+        np.testing.assert_allclose(
+            np.array(ours_ctrl.goal_pos),
+            np.array(ups_ctrl.goal_pos),
+            atol=1e-9,
+            err_msg="goal_pos diverges after set_goal",
+        )
+        np.testing.assert_allclose(
+            np.array(ours_ctrl.goal_ori),
+            np.array(ups_ctrl.goal_ori),
+            atol=1e-6,
+            err_msg=(
+                "goal_ori diverges after set_goal — likely a regression in "
+                "the round-45 swap-and-restore that captures initial_ee_ori_mat "
+                "from data at home pose."
+            ),
+        )
+
+        # Compute torques on both.
+        ups_torques = np.array(ups_ctrl.run_controller())
+        ours_torques = np.array(ours_ctrl.run_controller())
+
+        # Per-joint relative error <= 5% (#176 acceptance criteria).
+        abs_diff = np.abs(ours_torques - ups_torques)
+        rel_err = abs_diff / (np.abs(ups_torques) + 1e-6)
+        max_rel_err = float(rel_err.max())
+        assert max_rel_err <= 0.05, (
+            f"OSC arm torques diverge from upstream: max rel_err={max_rel_err:.4f} > 5%. "
+            f"Per-joint rel_err: {rel_err.tolist()}. "
+            f"upstream torques: {ups_torques.tolist()}. "
+            f"ours torques: {ours_torques.tolist()}. "
+            f"abs diff: {abs_diff.tolist()}. "
+            f"This is the #176 acceptance criterion. The round-45 swap-and-restore "
+            f"in _LiberoOSCController.from_sim closes the divergence; if this "
+            f"test fails, that fix has regressed."
+        )
+    finally:
+        sim.destroy()
+        upstream_env.close()
+
+
+@pytest.mark.timeout(300)
+def test_state_observation_byte_equivalent_at_canonical_init() -> None:
+    """Round 46 (#176 sub-task 3d) — pin every state channel to be
+    byte-equivalent (within float precision) between MuJoCoSimEngine
+    and LiberoOffScreenRenderEngine at canonical init_states[0] for
+    libero-10/SCENE5.
+
+    This is a stricter version of ``test_state_parity_at_canonical_init``
+    that compares ALL state channels (x/y/z/roll/pitch/yaw/gripper)
+    side-by-side between engines, not just against upstream's raw obs.
+    Pre-46 had:
+      - 14.7 mm divergence on state.y (MJCF qpos defaults differ from
+        upstream Robot.reset)
+      - 114 mrad divergence on state.pitch + sign-flip on yaw
+        (``_quat_wxyz_to_rpy_xyz`` formula bug)
+      - 14 mm divergence on state.gripper (MuJoCo qpos=0 vs upstream
+        ``PandaGripper.init_qpos = [0.0208, -0.0208]``)
+
+    Post-46 should bring all of these to within 1e-4 (state precision
+    of policy obs feed).
+    """
+    from libero.libero import benchmark as libero_benchmark
+    from libero.libero import get_libero_path
+
+    from strands_robots.benchmarks.libero.adapter import LiberoAdapter
+    from strands_robots.simulation.factory import create_simulation
+
+    bd = libero_benchmark.get_benchmark_dict()["libero_10"]()
+    target = (
+        "LIVING_ROOM_SCENE5_put_the_white_mug_on_the_left_plate_and_put_the_yellow_and_white_mug_on_the_right_plate"
+    )
+    task_id = next(i for i in range(bd.get_num_tasks()) if bd.get_task(i).name == target)
+    task = bd.get_task(task_id)
+    task_bddl = os.path.join(
+        get_libero_path("bddl_files"),
+        task.problem_folder,
+        task.bddl_file,
+    )
+    init_states = bd.get_task_init_states(task_id)
+
+    import random as _random
+
+    # Offscreen path
+    adapter1 = LiberoAdapter.from_file(task_bddl, install_cameras=False, init_states=init_states)
+    sim1 = create_simulation("libero_offscreen_render")
+    sim1.create_world()
+    sim1.add_robot("robot")
+    adapter1.on_episode_start(sim1, _random.Random(42))
+    obs1 = sim1.get_observation()
+
+    # MuJoCo path
+    adapter2 = LiberoAdapter.from_file(task_bddl, install_cameras=True, init_states=init_states)
+    sim2 = create_simulation("mujoco", tool_name="libero_sim", mesh=False)
+    sim2.create_world()
+    sim2.add_robot("robot", data_config="panda")
+    adapter2.on_episode_start(sim2, _random.Random(42))
+    obs2_raw = sim2.get_observation()
+    obs2 = adapter2.augment_observation(sim2, obs2_raw)
+
+    try:
+        # Per-channel scalar state must match within 1 mrad (1e-3).
+        # Pre-46 had 14 mm divergence on y, 114 mrad on pitch, sign
+        # flips on roll/pitch/yaw. Post-46 brings everything to within
+        # ~1e-4 m / ~1e-4 rad (mj_forward settling noise).
+        for k in ("x", "y", "z", "roll", "pitch", "yaw"):
+            v1 = obs1.get(k)
+            v2 = obs2.get(k)
+            assert v1 is not None, f"offscreen.{k} missing"
+            assert v2 is not None, f"mujoco.{k} missing"
+            assert abs(float(v2) - float(v1)) < 1e-3, (
+                f"state.{k} divergence: ours_mujoco={v2!r}, offscreen={v1!r}, "
+                f"diff={abs(float(v2) - float(v1)):.6e}. "
+                f"Round-46 fixes (home-pose write to data.qpos[arm], "
+                f"_quat_wxyz_to_rpy_xyz fix) may have regressed."
+            )
+
+        # Gripper (2-element list).
+        g1 = obs1.get("gripper")
+        g2 = obs2.get("gripper")
+        assert g1 is not None and g2 is not None
+        assert len(g1) == 2 and len(g2) == 2
+        for finger_idx in range(2):
+            diff = abs(float(g2[finger_idx]) - float(g1[finger_idx]))
+            assert diff < 1e-3, (
+                f"state.gripper[{finger_idx}] divergence: ours={g2[finger_idx]!r}, "
+                f"offscreen={g1[finger_idx]!r}, diff={diff:.6e}. "
+                f"Round-46 PandaGripper.init_qpos write may have regressed."
+            )
+    finally:
+        sim1.destroy()
+        sim2.destroy()
+
+
+@pytest.mark.timeout(900)
+def test_libero_10_scene5_mujoco_engine_success_rate() -> None:
+    """Round 46 (#176 sub-task 3d) acceptance — MuJoCoSimEngine reaches
+    success_rate > 0 on libero-10/SCENE5 with in-process Gr00tPolicy.
+
+    This is the end-to-end integration test that closes out #176
+    sub-task 3d. Pre-46 (just round-45 OSC fix) got 0/5 on this task
+    on the MuJoCoSimEngine path; post-46 (with home-pose write +
+    settle step + Euler-formula fix + body-name fallback) achieves
+    4/5 ≈ 80% success.
+
+    Skipped unless:
+
+    - ``STRANDS_ISAAC_GR00T_PATH`` env var points at the Isaac-GR00T
+      repo (provides ``gr00t``).
+    - ``STRANDS_GR00T_LIBERO_CHECKPOINT`` env var points at the
+      ``GR00T-N1.7-LIBERO/libero_10`` model dir.
+    - A CUDA-capable GPU is available.
+
+    Run with::
+
+        MUJOCO_GL=egl \\
+        STRANDS_ISAAC_GR00T_PATH=$HOME/workspace/Isaac-GR00T \\
+        STRANDS_GR00T_LIBERO_CHECKPOINT=$HOME/workspace/groot-checkpoints/GR00T-N1.7-LIBERO/libero_10 \\
+        hatch run test-integ tests_integ/benchmarks/libero/test_upstream_state_parity.py::test_libero_10_scene5_mujoco_engine_success_rate
+
+    Acceptance: at least 1 out of 3 episodes succeeds. Pre-46 got 0/5
+    on this task; even 1/3 = 33% rate is a clear pass that the
+    physics + obs + predicate pipeline now functions end-to-end on
+    the MuJoCoSimEngine backend.
+    """
+    import random as _random
+    import sys
+
+    isaac_gr00t = os.environ.get("STRANDS_ISAAC_GR00T_PATH")
+    checkpoint = os.environ.get("STRANDS_GR00T_LIBERO_CHECKPOINT")
+    if not isaac_gr00t:
+        pytest.skip("STRANDS_ISAAC_GR00T_PATH not set; required for in-process Gr00tPolicy")
+    if not checkpoint:
+        pytest.skip("STRANDS_GR00T_LIBERO_CHECKPOINT not set; required for end-to-end eval")
+    if not os.path.isdir(isaac_gr00t):
+        pytest.skip(f"Isaac-GR00T not at {isaac_gr00t}; required for in-process Gr00tPolicy")
+    if not os.path.isdir(checkpoint):
+        pytest.skip(f"checkpoint not at {checkpoint}; required for end-to-end eval")
+
+    if isaac_gr00t not in sys.path:
+        sys.path.insert(0, isaac_gr00t)
+    try:
+        from gr00t.data.embodiment_tags import EmbodimentTag
+        from gr00t.policy.gr00t_policy import Gr00tPolicy as NvidiaGr00tPolicy
+        from gr00t.policy.gr00t_policy import Gr00tSimPolicyWrapper
+    except ImportError as e:
+        pytest.skip(f"gr00t imports failed ({e}); skipping end-to-end test")
+
+    try:
+        import torch
+
+        if not torch.cuda.is_available():
+            pytest.skip("no CUDA GPU available; required for in-process Gr00tPolicy")
+    except ImportError:
+        pytest.skip("torch not importable; required for in-process Gr00tPolicy")
+
+    from libero.libero import benchmark as libero_benchmark
+    from libero.libero import get_libero_path
+
+    from strands_robots.benchmarks.libero.adapter import LiberoAdapter
+    from strands_robots.simulation.factory import create_simulation
+
+    bd = libero_benchmark.get_benchmark_dict()["libero_10"]()
+    target = (
+        "LIVING_ROOM_SCENE5_put_the_white_mug_on_the_left_plate_and_put_the_yellow_and_white_mug_on_the_right_plate"
+    )
+    task_id = next(i for i in range(bd.get_num_tasks()) if bd.get_task(i).name == target)
+    task = bd.get_task(task_id)
+    task_bddl = os.path.join(
+        get_libero_path("bddl_files"),
+        task.problem_folder,
+        task.bddl_file,
+    )
+    init_states = bd.get_task_init_states(task_id)
+
+    try:
+        nvidia_policy = NvidiaGr00tPolicy(
+            embodiment_tag=EmbodimentTag.LIBERO_PANDA,
+            model_path=checkpoint,
+            device=0,
+        )
+    except Exception as e:  # noqa: BLE001 - model load failure is environmental
+        pytest.skip(f"failed to load Gr00tPolicy ({e}); skipping end-to-end test")
+    wrapped = Gr00tSimPolicyWrapper(nvidia_policy)
+
+    adapter = LiberoAdapter.from_file(task_bddl, install_cameras=True, init_states=init_states)
+    sim = create_simulation("mujoco", tool_name="libero_sim", mesh=False)
+    sim.create_world()
+    sim.add_robot("robot", data_config="panda")
+
+    n_episodes = 3
+    seed = 42
+    max_episode_steps = 720
+    n_action_steps = 8
+
+    successes = []
+    try:
+        for ep in range(n_episodes):
+            adapter.on_episode_start(sim, _random.Random(seed + ep))
+            steps = 0
+            is_success = False
+            while steps < max_episode_steps:
+                obs_raw = sim.get_observation()
+                obs = adapter.augment_observation(sim, obs_raw)
+                policy_obs: dict[str, Any] = {}
+                for sk in ("x", "y", "z", "roll", "pitch", "yaw"):
+                    v = obs.get(sk)
+                    if v is not None:
+                        policy_obs[f"state.{sk}"] = np.asarray([float(v)], dtype=np.float32)[None, None]
+                g = obs.get("gripper")
+                if g is not None:
+                    policy_obs["state.gripper"] = np.asarray(g, dtype=np.float32)[None, None]
+                for vk in ("image", "wrist_image"):
+                    v = obs.get(vk)
+                    if isinstance(v, np.ndarray):
+                        # Mujoco renderer outputs image-convention (V-flipped from
+                        # OpenGL); augment applies [::-1, :] → OpenGL; policy needs
+                        # training-convention = OpenGL[::-1, ::-1]. Bypass the
+                        # in-policy rotation by applying it here.
+                        flipped = np.ascontiguousarray(v[::-1, ::-1])
+                        policy_obs[f"video.{vk}"] = flipped[None, None]
+                policy_obs["annotation.human.action.task_description"] = [task.language or ""]
+                actions, _ = wrapped.get_action(policy_obs)
+                for t in range(n_action_steps):
+                    if steps >= max_episode_steps:
+                        break
+                    action_dict = {}
+                    for ak, arr in actions.items():
+                        action_dict[ak.removeprefix("action.")] = float(arr[0, t, 0])
+                    sim.send_action(action_dict, robot_name="robot")
+                    steps += 1
+                    if adapter.is_success(sim):
+                        is_success = True
+                        break
+                if is_success:
+                    break
+            successes.append(is_success)
+    finally:
+        sim.destroy()
+
+    success_rate = sum(successes) / max(n_episodes, 1)
+    assert success_rate > 0, (
+        f"MuJoCoSimEngine + in-process Gr00tPolicy got success_rate={success_rate:.2f} "
+        f"on libero-10/SCENE5 ({successes}). Round-46 fixes (home-pose write, "
+        f"settle step, _quat_wxyz_to_rpy_xyz, _body_position _main fallback) may have "
+        f"regressed — pre-46 baseline got 0/5 on this task. Confirm the round-46 fixes "
+        f"are still in place."
+    )


### PR DESCRIPTION
## Title

`fix(libero): close #171 + #176 — MuJoCoSimEngine LIBERO eval reaches success_rate > 0`

## Body

### What

Closes the LIBERO-eval gap on the **`MuJoCoSimEngine`** backend by addressing every sub-task tracked in #171 + the deferred 3b/3d follow-ups in #176.

| Issue | Sub-task | Status | Round |
|---|---|---|---|
| #171 | 3a (scene XML byte-diff) | Verified no divergence | r35 (1be0b74) |
| #171 | 3c (deep-rollout state parity test + gripper default fix) | Pinned + fixed | r35 (1be0b74) |
| #171 | 3e (`on()` predicate contact check) | Fixed | r34 (7c57426) |
| #176 | 3b (OSC torque parity) | Fixed | **r45 (this PR)** |
| #176 | 3d (`MuJoCoSimEngine` `success_rate > 0`) | Fixed | **r46 (this PR)** |

End-to-end measurement on `libero-10/LIVING_ROOM_SCENE5` with in-process `Gr00tPolicy`. Both backends use stochastic GR00T diffusion sampling + non-deterministic CUDA, so per-run results vary; numbers below are from 20 episodes (2 × 10-ep batches) per backend:

| Backend | Pre-PR (main) | Post-PR (this commit) |
|---|---|---|
| `LiberoOffScreenRenderEngine` | 1.00 (single run, N=5) | **0.80** (16/20 over 2 × 10-ep batches: 9/10, 7/10) |
| `MuJoCoSimEngine` | **0.00** (5/5 failures) | **0.85** (17/20 over 2 × 10-ep batches: 8/10, 9/10) |

`|0.85 - 0.80| = 0.05` → 5% gap, well within the ±20% acceptance criterion specified in #176 sub-task 3d. Pre-PR `MuJoCoSimEngine` was 0/5 across all reproduction attempts.

### Round 45 — OSC torque parity at identical state (#176 sub-task 3b)

`_LiberoOSCController.from_sim` now wraps `controller_factory` in a qpos swap-and-restore: write `MountedPanda.init_qpos = [0, -0.161, 0, -2.444, 0, 2.227, π/4]` into `data.qpos[arm]`, `mj_forward`, build the OSC controller, restore the pre-swap qpos. This makes the controller's `initial_joint` / `initial_ee_pos` / `initial_ee_ori_mat` / `goal_pos` / `goal_ori` capture the LIBERO ready pose, matching upstream `OffScreenRenderEnv`'s `Robot.reset(deterministic=True) + _load_controller` sequence.

Pre-45 the controller captured `initial_*` from whatever `data.qpos` happened to be at install time — which (post-#168 round-7) is the per-episode canonical state, NOT the home pose. The nullspace-bias term `(initial_joint - joint_pos)` therefore collapsed and `goal_ori` latched onto the perturbed pose's EEF orientation, producing a 50× torque divergence vs upstream at identical state.

Verified: per-joint torque rel_err ~0% at byte-identical state (`test_osc_torque_parity_at_identical_state`).

### Round 46 — canonical-state + observation parity (#176 sub-task 3d)

With round 45 closing the OSC torque divergence at identical state, end-to-end `MuJoCoSimEngine` LIBERO eval still got `success_rate=0` because of four downstream divergences. Each fixed independently:

**46a. Snapshot branch writes Panda + gripper home pose.** `_apply_snapshot_branch` now writes `MountedPanda.init_qpos` to arm joints and `PandaGripper.init_qpos = [0.0208, -0.0208]` to finger joints BEFORE the canonical snapshot. Mirrors upstream's `Robot.reset + SingleArm.reset` which does both writes inside `env.reset`. Pre-46a state.x diverged by 32 cm; post-46a all 6 EEF channels match within 1 mrad.

**46b. `on_episode_start` settle step.** Drive one zero-action `send_action({})` after `_install_action_controller` returns. Mirrors upstream's `LiberoOffScreenRenderEngine.reset`: `set_init_state(init_states[i]) + env.step(np.zeros(7))`. Training data was generated against the post-step state.

**46c. `_quat_wxyz_to_rpy_xyz` formula correction.** Pre-46 derivation used `R = R_x · R_y · R_z` (intrinsic XYZ), producing sign-flipped Euler angles for some quaternions vs robosuite's `mat2euler(R, axes='sxyz')`. E.g. `q=(0, 0.7071, 0.7071, 0)` → robosuite returns `(π, 0, +π/2)`, pre-46 returned `(-π, 0, -π/2)` — same roll mod 2π but OPPOSITE yaw (genuinely different rotation about world Z). Post-46 formula matches robosuite byte-for-byte.

**46d. `_body_position` `_main` suffix fallback.** LIBERO's BDDL names objects without a suffix (`porcelain_mug_1`) but the MJCF root body is suffixed with `_main` (`porcelain_mug_1_main`). Upstream resolves this via `env.objects_dict[name].root_body`. We mirror with a bounded fallback in `_body_position`. Pre-46d: BDDL goal predicates like `(On porcelain_mug_1 plate_1)` silently resolved to `False` even when physics had the mug on the plate.

### Tests

Unit (added):
- `tests/benchmarks/libero/test_libero_adapter.py::TestQuaternionToEuler::test_matches_robosuite_mat2euler_sxyz`
- `tests/benchmarks/libero/test_libero_adapter.py::TestQuaternionToEuler::test_pre_46_sign_flip_regression`
- `tests/simulation/test_benchmark_predicates.py::TestBodyPositionPredicates::test_body_position_libero_main_suffix_fallback`
- `tests/simulation/test_benchmark_predicates.py::TestBodyPositionPredicates::test_body_position_main_suffix_no_double_suffix`
- `tests/simulation/test_benchmark_predicates.py::TestBodyPositionPredicates::test_body_position_bare_name_wins_over_suffix`

Integration (added):
- `tests_integ/.../test_state_observation_byte_equivalent_at_canonical_init` — pins all 6 EEF state channels + gripper to within 1 mrad / 1 mm between `MuJoCoSimEngine` and `LiberoOffScreenRenderEngine` at canonical init.
- `tests_integ/.../test_libero_10_scene5_mujoco_engine_success_rate` — end-to-end acceptance test (gated on `STRANDS_ISAAC_GR00T_PATH` + `STRANDS_GR00T_LIBERO_CHECKPOINT` env vars; verifies `success_rate > 0` on `MuJoCoSimEngine` for SCENE5).

### Test status

- Lint clean.
- Unit: 1888 pass / 7 pre-existing failures (unrelated to this PR; verified via `git stash` + re-run).
- Integration: 6/6 libero parity tests pass (the e2e test passes when invoked with required env vars; skips otherwise).

### Closes

Closes #166, closes #171, closes #176.


