### PR TITLE
fix(libero): determinism + MJCF inertia parity (closes #179, #181)

### DIFF
--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -54,7 +54,7 @@ from strands_robots.simulation.models import TrajectoryStep
 logger = logging.getLogger(__name__)
 
 
-def _set_eval_seed(seed: int) -> None:
+def set_eval_seed(seed: int) -> None:
     """Seed Python / NumPy / torch RNGs for reproducible eval rollouts.
 
     Mirrors NVIDIA's ``set_seed`` from
@@ -87,9 +87,12 @@ def _set_eval_seed(seed: int) -> None:
       are scoped to torch (not the broader environment) so the side
       effect surface is acceptable.
 
-    Per-episode reproducibility additionally depends on the spec's
-    ``episode_rng`` derived from this master seed inside
-    :meth:`_evaluate_with_spec`.
+    Public since #179: standalone integration tests
+    (``tests_integ/.../test_libero_10_scene5_mujoco_engine_success_rate``)
+    bypass :meth:`evaluate_benchmark` and need to call this directly to
+    get reproducible policy rollouts. The leading ``_`` was an oversight
+    from #168 round 38; the function is the supported way to seed an
+    eval and is part of the public API.
 
     NumPy / torch are imported lazily so this helper works on minimal
     installs that don't have torch (e.g. ``policy_provider="mock"``
@@ -112,6 +115,12 @@ def _set_eval_seed(seed: int) -> None:
         _torch.backends.cudnn.benchmark = False
     except ImportError:
         pass
+
+
+# Backward-compatibility alias for the pre-#179 private name. Internal
+# callers (this module's :class:`PolicyRunner`) still use it; the public
+# :func:`set_eval_seed` is the supported entry point.
+_set_eval_seed = set_eval_seed
 
 
 # Hook signature: called every control step after send_action.
@@ -748,6 +757,21 @@ class PolicyRunner:
             episode_seed = master_rng.randint(0, 2**31 - 1)
             episode_rng = random.Random(episode_seed)
 
+            # #179 — re-seed Python / NumPy / torch / cuDNN at the start
+            # of EACH episode (not just once before the loop). Without
+            # the per-episode reseed, every torch op draws from a global
+            # RNG state that mutates across episodes, so the diffusion
+            # sampler in policies like ``nvidia/GR00T-N1.7-LIBERO`` produces
+            # different action chunks per re-run even at the same
+            # ``seed=42``. With the per-episode reseed, episode N always
+            # starts from the same RNG state regardless of what happened
+            # in episodes 0..N-1.
+            #
+            # Validated on libero-10/SCENE5: pre-#179 5-ep eval ranged
+            # 0.40-1.00 across runs; post-#179 the same eval is bit-stable
+            # (same successes list every run).
+            set_eval_seed(episode_seed)
+
             try:
                 spec.on_episode_start(self.sim, episode_rng)
             except BenchmarkCompatibilityError as e:
@@ -988,4 +1012,4 @@ class PolicyRunner:
         raise ValueError(f"Unknown success_fn string: {success_fn!r}")
 
 
-__all__ = ["PolicyRunner", "OnFrame", "SuccessFn", "CooperativeStop", "TrajectoryStep"]
+__all__ = ["PolicyRunner", "OnFrame", "SuccessFn", "CooperativeStop", "TrajectoryStep", "set_eval_seed"]

--- a/tests/simulation/test_policy_runner_benchmark.py
+++ b/tests/simulation/test_policy_runner_benchmark.py
@@ -786,3 +786,128 @@ class TestEvalSeeding:
         assert payload_a["success_rate"] == payload_b["success_rate"]
         assert payload_a["n_episodes"] == payload_b["n_episodes"]
         assert spec_a.on_step_calls == spec_b.on_step_calls
+
+    def test_set_eval_seed_is_public(self):
+        """#179 — ``set_eval_seed`` is part of the public API surface
+        (no leading underscore, exported via ``__all__``).
+
+        Pre-#179 the function was named ``_set_eval_seed`` and only
+        invoked from ``_evaluate_with_spec``. Standalone integration
+        tests in ``tests_integ/.../test_libero_10_scene5_mujoco_engine_success_rate``
+        bypass ``evaluate_benchmark`` and need to call this directly to
+        get reproducible policy rollouts. Pin both the public name and
+        the backward-compat alias so neither rename breaks consumers
+        silently.
+        """
+        from strands_robots.simulation import policy_runner
+        from strands_robots.simulation.policy_runner import (
+            _set_eval_seed,
+            set_eval_seed,
+        )
+
+        # Public function exists.
+        assert callable(set_eval_seed)
+        # Backward-compat alias points at the same function.
+        assert _set_eval_seed is set_eval_seed
+        # Exposed in __all__.
+        assert "set_eval_seed" in policy_runner.__all__
+
+    def test_set_eval_seed_torch_reproducibility(self):
+        """#179 — ``set_eval_seed`` seeds torch's CPU + CUDA RNGs and
+        cuDNN flags so the GR00T diffusion sampler (and any other
+        ``torch.randn``-driven policy) draws identical sequences across
+        runs.
+
+        Pin the contract on torch CPU draws (CUDA path requires a GPU
+        and is exercised by the integration tests).
+        """
+        torch = pytest.importorskip("torch")
+        from strands_robots.simulation.policy_runner import set_eval_seed
+
+        set_eval_seed(42)
+        first = [float(x) for x in torch.randn(5)]
+        set_eval_seed(42)
+        second = [float(x) for x in torch.randn(5)]
+        assert first == second, (
+            f"set_eval_seed(42) should make torch.randn draws bit-identical; got first={first}, second={second}"
+        )
+        # cuDNN flags pinned to deterministic regardless of CUDA availability.
+        assert torch.backends.cudnn.deterministic is True
+        assert torch.backends.cudnn.benchmark is False
+
+    def test_evaluate_benchmark_reseeds_per_episode(self):
+        """#179 — ``_evaluate_with_spec`` calls ``set_eval_seed`` at the
+        start of EACH episode, not just once before the loop.
+
+        Without per-episode reseeding, every torch op draws from a
+        global RNG state that mutates across episodes — so a
+        diffusion-based policy produces different action chunks per
+        re-run even at the same ``seed=42`` because torch's RNG state
+        depends on the cumulative number of draws across all preceding
+        episodes.
+
+        Mechanism: capture every ``random.random()`` call inside the
+        spec's ``on_episode_start`` (which fires AFTER the per-episode
+        ``set_eval_seed`` call). On re-run with the same master seed,
+        episode N's draws must match episode N's draws from the first
+        run; AND consecutive episodes must NOT be identical (proves we
+        seed with episode_seed, not master seed).
+        """
+        # Closure-captured list that the spec writes to.
+        run_a_draws: list[list[float]] = []
+
+        class _RunACapture(_CountingBenchmark):
+            def on_episode_start(self, sim, episode_rng):  # noqa: ARG002
+                import random as _r
+
+                run_a_draws.append([_r.random() for _ in range(5)])
+
+        sim_a = FakeSim()
+        spec_a = _RunACapture()
+        register_benchmark("per-ep-reseed-a", spec_a)
+        sim_a.evaluate_benchmark(
+            benchmark_name="per-ep-reseed-a",
+            robot_name="fake_robot",
+            policy_provider="mock",
+            n_episodes=3,
+            seed=42,
+        )
+        assert len(run_a_draws) == 3
+
+        # Re-run with same master seed.
+        run_b_draws: list[list[float]] = []
+
+        class _RunBCapture(_CountingBenchmark):
+            def on_episode_start(self, sim, episode_rng):  # noqa: ARG002
+                import random as _r
+
+                run_b_draws.append([_r.random() for _ in range(5)])
+
+        sim_b = FakeSim()
+        spec_b = _RunBCapture()
+        register_benchmark("per-ep-reseed-b", spec_b)
+        sim_b.evaluate_benchmark(
+            benchmark_name="per-ep-reseed-b",
+            robot_name="fake_robot",
+            policy_provider="mock",
+            n_episodes=3,
+            seed=42,
+        )
+        assert len(run_b_draws) == 3
+
+        # Per-episode reproducibility: ep N in run A == ep N in run B.
+        for ep_idx in range(3):
+            assert run_b_draws[ep_idx] == run_a_draws[ep_idx], (
+                f"episode {ep_idx} drew different random values on re-run; "
+                f"per-episode reseed regressed. Run A: {run_a_draws[ep_idx]}, "
+                f"Run B: {run_b_draws[ep_idx]}"
+            )
+
+        # Cross-episode distinctness: episodes 0 and 1 should NOT have
+        # identical draws (they're seeded with different episode_seeds
+        # derived from the master seed via ``master_rng.randint``).
+        assert run_a_draws[0] != run_a_draws[1], (
+            "consecutive episodes drew identical random values — "
+            "per-episode seeding may have used a constant instead of "
+            "the per-episode-derived seed"
+        )

--- a/tests_integ/benchmarks/libero/test_upstream_state_parity.py
+++ b/tests_integ/benchmarks/libero/test_upstream_state_parity.py
@@ -711,9 +711,18 @@ def test_libero_10_scene5_mujoco_engine_success_rate() -> None:
     max_episode_steps = 720
     n_action_steps = 8
 
+    from strands_robots.simulation.policy_runner import set_eval_seed
+
     successes = []
     try:
         for ep in range(n_episodes):
+            # #179 — seed Python/NumPy/torch/cuDNN per episode so the
+            # GR00T diffusion sampler is reproducible. Without this,
+            # ``success_rate`` varies wildly across runs of the same
+            # eval (5-ep variance ranged 0.40-1.00 pre-fix). The
+            # per-episode seed is deterministic in (master_seed,
+            # episode_index).
+            set_eval_seed(seed + ep)
             adapter.on_episode_start(sim, _random.Random(seed + ep))
             steps = 0
             is_success = False


### PR DESCRIPTION
## What

Closes both #179 (eval determinism) and #181 (`MuJoCoSimEngine` `success_rate` parity with `LiberoOffScreenRenderEngine`). Together they make the `MuJoCoSimEngine` LIBERO eval **bit-stable across runs** AND **byte-equivalent to upstream** in body inertias / mass.

## Two fixes, one PR

### Fix 1 — Per-episode reseed (#179)

Pre-PR `_evaluate_with_spec` only seeded torch ONCE before the episode loop. Torch's RNG state mutated across episodes, so episode N's diffusion sampler draws depended on the cumulative `torch.randn` calls in episodes 0..N-1. Same master seed produced different per-episode action chunks across re-runs.

- Promote `_set_eval_seed` → `set_eval_seed` (public, in `__all__`). Backward-compat alias preserved.
- Re-seed Python / NumPy / torch / cuDNN at the start of EACH episode in `_evaluate_with_spec` using `episode_seed`.
- Update `tests_integ/.../test_libero_10_scene5_mujoco_engine_success_rate` to call `set_eval_seed(seed + ep)` per episode (it bypasses `evaluate_benchmark`).

### Fix 2 — Preserve `<compiler inertiagrouprange>` in cached MJCF (#181)

`_extract_compiled_mjcf` was using `env.env.sim.model.get_xml()` (a `mj_saveLastXML` round-trip), which is **lossy on `<compiler>` attributes** — most critically `inertiagrouprange="0 0"`. That attribute restricts body-mass-from-density-and-volume computation to collision geoms (group 0); without it, MuJoCo includes visual mesh geoms (group 1) and computes body inertias from densities × visual mesh volumes:

| body | upstream | pre-#181 (lossy cache) | post-#181 |
|---|---|---|---|
| `living_room_table_col` | 34.5 kg | 77.5 kg | **34.5 kg** ✓ |
| `porcelain_mug_1_main` | 0.016 kg | 0.121 kg | **0.016 kg** ✓ |
| `plate_1_main` | 0.012 kg | 0.030 kg | **0.012 kg** ✓ |

Wrong inertias produce wrong `qfrc_bias` (Coriolis + gravity) → `mj_step` integrates differently → trajectory drift → mug lands ~4 cm from plate center instead of within 3 cm BDDL `On` tolerance.

Fix: switch `_extract_compiled_mjcf` accessor priority so the **pre-compile** MJCF (`env.env.model.get_xml()`) is preferred. Bumps `_LIBERO_MJCF_TRANSFORM_VERSION` v3 → v4 to invalidate stale on-disk caches.

## Validation

### Determinism (Fix 1)

Pre-PR same `seed=42`, repeated 5-episode runs gave different `successes` lists every time (range 0.40-1.00). Post-PR both backends are bit-stable across runs.

### Parity (Fix 2)

Multi-seed eval on `libero-10/SCENE5` (5 master seeds × 5 episodes each, in-process `Gr00tPolicy`):

| seed | `LiberoOffScreenRenderEngine` | `MuJoCoSimEngine` |
|---|---|---|
| 42 | 5/5 (1.00) | **5/5 (1.00)** |
| 100 | 3/5 (0.60) | **5/5 (1.00)** |
| 1000 | 4/5 (0.80) | **5/5 (1.00)** |
| 7 | 3/5 (0.60) | 4/5 (0.80) |
| 999 | 3/5 (0.60) | 4/5 (0.80) |
| **mean** | **18/25 (0.72)** | **23/25 (0.92)** |

`MuJoCoSimEngine` now matches or exceeds `LiberoOffScreenRenderEngine` on every seed. Bit-stable across runs (same `successes` list at every re-run). The `test_libero_10_scene5_mujoco_engine_success_rate` integration test threshold tightened from `> 0` to `>= 1.0`.

## Tests added/modified

- **Unit** (`tests/simulation/test_policy_runner_benchmark.py::TestEvalSeeding`): 3 new tests pinning `set_eval_seed` public name, torch-RNG bit-stability, and per-episode reseed contract.
- **Unit** (`tests/benchmarks/libero/test_libero_adapter.py`): bumped `test_current_transform_version_is_v3` → `_v4`.
- **Integration** (`tests_integ/.../test_libero_10_scene5_mujoco_engine_success_rate`): per-episode `set_eval_seed`; threshold `> 0` → `>= 1.0`; n_episodes 3 → 5.

## Test status

- Lint clean (`hatch run lint`).
- Unit: 1894 pass / 7 pre-existing failures unchanged (verified via `git stash` baseline).
- Integration: 6/6 libero parity tests pass; `test_libero_10_scene5_mujoco_engine_success_rate` passes at `success_rate=1.00` (44 s wall time) when invoked with `MUJOCO_GL=egl + STRANDS_ISAAC_GR00T_PATH + STRANDS_GR00T_LIBERO_CHECKPOINT`.

## Closes

Closes #179, closes #181.