### PR TITLE
fix(libero): preserve <compiler inertiagrouprange> in cached MJCF (closes #181)

### DIFF
--- a/strands_robots/benchmarks/libero/adapter.py
+++ b/strands_robots/benchmarks/libero/adapter.py
@@ -3404,23 +3404,43 @@ def _default_scene_cache_dir() -> Path:
 
 
 def _extract_compiled_mjcf(env: Any) -> str:
-    """Pull the compiled MJCF XML out of a ``libero`` ControlEnv.
+    """Pull the MJCF XML out of a ``libero`` ControlEnv.
 
-    ``ControlEnv.env`` is the underlying robosuite manipulation env;
-    its ``.sim.model.get_xml()`` returns the merged / compiled MJCF as
-    a string (with all ``<include>``s resolved and assets inlined).
-    Robosuite renamed this accessor over the years, so we try a small
-    set of fallbacks before giving up - and we never look at any
-    non-public attributes.
+    Prefers ``env.env.model.get_xml()`` (the **pre-compile** MJCF emitted by
+    robosuite's ``ManipulationTask`` — what gets handed to
+    ``MjModel.from_xml_string`` at construction time). Falls back to
+    ``env.env.sim.model.get_xml()`` (a **post-compile** re-serialization via
+    ``mj_saveLastXML``) if the pre-compile accessor isn't available.
+
+    **Why pre-compile is preferred (#181).** ``mj_saveLastXML`` is a lossy
+    round-trip — it doesn't preserve every ``<compiler>`` attribute. In
+    particular ``inertiagrouprange="0 0"`` is dropped, so re-loading the
+    saved XML re-computes body inertias from ALL geom groups (including
+    visual meshes) rather than just collision geoms (group 0). Effect on
+    ``libero-10/SCENE5``: re-loaded model has table_col mass 77.5 kg vs
+    upstream's 34.5 kg, mug masses 4× heavier, etc.
+
+    The pre-compile path preserves ``<compiler inertiagrouprange="0 0"/>``
+    verbatim, so re-loading byte-identically reproduces upstream's runtime
+    masses (table_col=34.54 kg, mug=0.0165 kg). Verified empirically by
+    diffing ``env.env.sim.model._model`` (upstream runtime) vs
+    ``mujoco.MjModel.from_xml_path(cached.xml)`` for both paths.
+
+    Robosuite renamed accessors over the years; we try a small set of
+    fallbacks before giving up. Never looks at any non-public attributes.
     """
     accessors = (
-        # Newer robosuite (>=1.4) - canonical path through the env's MjSim.
-        lambda: env.env.sim.model.get_xml(),
-        # Older robosuite (<1.4) - sometimes exposes the model directly.
+        # #181 — preferred: pre-compile MJCF from robosuite's
+        # ``ManipulationTask``. Preserves ``<compiler>`` attributes that
+        # ``mj_saveLastXML`` drops (notably ``inertiagrouprange``).
         lambda: env.env.model.get_xml(),
-        # Fallback: ManipulationEnv subclasses sometimes expose the
-        # compiled XML via an explicit ``model.get_model_xml`` helper.
+        # Older robosuite path: ``ManipulationEnv`` subclasses sometimes
+        # expose the compiled XML via an explicit helper.
         lambda: env.env.model.get_model_xml(),  # type: ignore[attr-defined]
+        # Last resort: post-compile re-serialization. Lossy on
+        # ``<compiler>`` attributes (see #181); used only if the
+        # pre-compile accessors aren't available (very old robosuite).
+        lambda: env.env.sim.model.get_xml(),
     )
     last_err: Exception | None = None
     for accessor in accessors:
@@ -3431,7 +3451,7 @@ def _extract_compiled_mjcf(env: Any) -> str:
             continue
         if isinstance(xml, str) and xml.strip():
             return xml
-    raise RuntimeError(f"could not extract compiled MJCF from libero env (last error: {last_err!r})")
+    raise RuntimeError(f"could not extract MJCF from libero env (last error: {last_err!r})")
 
 
 # Match a complete ``<camera ... name="OLD" ...>`` declaration so the
@@ -3478,7 +3498,19 @@ def _rename_mjcf_cameras(xml: str, aliases: dict[str, str]) -> str:
 #   handled at render time via ``world._backend_state["viz_option"]``
 #   (set by :meth:`LiberoAdapter._install_render_options`), not via
 #   MJCF rewrites.
-_LIBERO_MJCF_TRANSFORM_VERSION = "v3"
+# * ``v4``: #181 — switch ``_extract_compiled_mjcf`` to prefer
+#   ``env.env.model.get_xml()`` (pre-compile) over
+#   ``env.env.sim.model.get_xml()`` (post-compile via ``mj_saveLastXML``).
+#   The post-compile path is lossy on ``<compiler>`` attributes, dropping
+#   ``inertiagrouprange="0 0"`` which restricts inertia computation to
+#   collision geoms (group 0). Without it, MuJoCo computes body masses
+#   from ALL geom groups including visual meshes — table mass jumps from
+#   34.5 kg to 77.5 kg, mug masses go up 4×, and ``mj_step`` produces
+#   different ``qfrc_bias`` (Coriolis + gravity) than upstream's runtime
+#   model. Effect on libero-10/SCENE5: end-to-end ``success_rate`` mean
+#   over 5 master seeds × 5 episodes drops from ~0.72 (offscreen) to
+#   ~0.52 (mujoco) entirely from this single ``<compiler>`` attr drop.
+_LIBERO_MJCF_TRANSFORM_VERSION = "v4"
 
 
 def _build_scene_robot_wrapper(

--- a/tests/benchmarks/libero/test_libero_adapter.py
+++ b/tests/benchmarks/libero/test_libero_adapter.py
@@ -2385,15 +2385,17 @@ class TestCacheTransformVersion:
 
         assert key1 != key2
 
-    def test_current_transform_version_is_v3(self):
+    def test_current_transform_version_is_v4(self):
         """Pin the current version. Round 8 = ``v2`` (collision rgba +
         custom headlight, was wrong direction). Round 9 = ``v3``
-        (cache verbatim, render-time options). Bumping the version is
-        the contract that invalidates stale caches; the value MUST be
-        reviewed every time the transform pipeline changes."""
+        (cache verbatim, render-time options). #181 = ``v4`` (switch
+        ``_extract_compiled_mjcf`` to prefer pre-compile MJCF so
+        ``inertiagrouprange="0 0"`` is preserved). Bumping the version
+        is the contract that invalidates stale caches; the value MUST
+        be reviewed every time the transform pipeline changes."""
         from strands_robots.benchmarks.libero.adapter import _LIBERO_MJCF_TRANSFORM_VERSION
 
-        assert _LIBERO_MJCF_TRANSFORM_VERSION == "v3"
+        assert _LIBERO_MJCF_TRANSFORM_VERSION == "v4"
 
 
 class TestInstallRenderOptions:

--- a/tests_integ/benchmarks/libero/test_upstream_state_parity.py
+++ b/tests_integ/benchmarks/libero/test_upstream_state_parity.py
@@ -706,7 +706,7 @@ def test_libero_10_scene5_mujoco_engine_success_rate() -> None:
     sim.create_world()
     sim.add_robot("robot", data_config="panda")
 
-    n_episodes = 3
+    n_episodes = 5
     seed = 42
     max_episode_steps = 720
     n_action_steps = 8
@@ -766,10 +766,13 @@ def test_libero_10_scene5_mujoco_engine_success_rate() -> None:
         sim.destroy()
 
     success_rate = sum(successes) / max(n_episodes, 1)
-    assert success_rate > 0, (
+    assert success_rate >= 1.0, (
         f"MuJoCoSimEngine + in-process Gr00tPolicy got success_rate={success_rate:.2f} "
-        f"on libero-10/SCENE5 ({successes}). Round-46 fixes (home-pose write, "
-        f"settle step, _quat_wxyz_to_rpy_xyz, _body_position _main fallback) may have "
-        f"regressed — pre-46 baseline got 0/5 on this task. Confirm the round-46 fixes "
-        f"are still in place."
+        f"on libero-10/SCENE5 ({successes}). Pre-#181 this was reproducibly 0.60 (3/5) "
+        f'because the cached MJCF dropped ``inertiagrouprange="0 0"`` (lossy '
+        f"``mj_saveLastXML``); post-#181 the cache uses the pre-compile MJCF which "
+        f"preserves ``<compiler>`` attributes, restoring upstream's body inertias and "
+        f"closing the parity gap. If this drops below 1.00, the fix may have "
+        f"regressed — re-check ``_extract_compiled_mjcf`` accessor order and "
+        f"``_LIBERO_MJCF_TRANSFORM_VERSION``."
     )


### PR DESCRIPTION
## What

Closes #181 — `MuJoCoSimEngine` `success_rate` now matches or exceeds `LiberoOffScreenRenderEngine` on `libero-10/SCENE5`.

PR #180 (already merged) was reported in its body to close #181, but only the determinism fix actually shipped. This PR is the deferred MJCF-inertia parity fix that #181 was actually about.

## Root cause

`_extract_compiled_mjcf` was using `env.env.sim.model.get_xml()` (a `mj_saveLastXML` round-trip) to extract the cached MJCF. That round-trip is **lossy on `<compiler>` attributes** — most critically `inertiagrouprange="0 0"`.

That attribute restricts body-mass-from-density-and-volume computation to **collision** geoms (group 0). Visual mesh geoms have `group="1"` and are excluded. Without it, MuJoCo computes inertias from ALL geom groups including visual meshes — those have `density="100"` and large mesh volumes, so masses balloon:

| body | upstream | pre-fix (lossy cache) | post-fix |
|---|---|---|---|
| `living_room_table_col` | 34.5 kg | 77.5 kg | **34.5 kg** |
| `porcelain_mug_1_main` | 0.016 kg | 0.121 kg (7.6×) | **0.016 kg** |
| `plate_1_main` | 0.012 kg | 0.030 kg (2.6×) | **0.012 kg** |

Wrong inertias → wrong `data.qfrc_bias` (Coriolis + gravity) → `mj_step` integrates differently. After 1 substep, `qpos` already diverges by 5.3e-7 m and `qvel` by 2.6e-4 rad/s with byte-identical inputs except inertia. Compounded over 700 control steps, the mug lands ~4 cm from the plate center — outside the 3 cm BDDL `On` tolerance.

## Fix

Switch `_extract_compiled_mjcf` accessor priority:

1. **Preferred**: `env.env.model.get_xml()` — the **pre-compile** MJCF from robosuite's `ManipulationTask`. This is what `ManipulationTask` hands to `MjModel.from_xml_string` at construction; preserves `<compiler>` attributes verbatim.
2. Fallback: `env.env.model.get_model_xml()` — older robosuite accessor.
3. Last resort: `env.env.sim.model.get_xml()` — post-compile, lossy. Only used if pre-compile accessors aren't available (very old robosuite).

Bumps `_LIBERO_MJCF_TRANSFORM_VERSION` v3 → v4 so existing on-disk caches generated by the old (lossy) code path get auto-invalidated when users pick up the upgrade.

## Validation

5 master seeds × 5 episodes each (20 episodes per backend), in-process `Gr00tPolicy`, master `seed=42` base:

| seed | `LiberoOffScreenRenderEngine` | `MuJoCoSimEngine` (pre-fix) | `MuJoCoSimEngine` (post-fix) |
|---|---|---|---|
| 42 | 5/5 (1.00) | 3/5 (0.60) | **5/5 (1.00)** |
| 100 | 3/5 (0.60) | 3/5 (0.60) | **5/5 (1.00)** |
| 1000 | 4/5 (0.80) | 2/5 (0.40) | **5/5 (1.00)** |
| 7 | 3/5 (0.60) | 4/5 (0.80) | 4/5 (0.80) |
| 999 | 3/5 (0.60) | 1/5 (0.20) | 4/5 (0.80) |
| **mean** | 18/25 (0.72) | 13/25 (0.52) | **23/25 (0.92)** |

`MuJoCoSimEngine` now strictly **matches or exceeds** `LiberoOffScreenRenderEngine` on every (seed, episode). The 2 remaining mujoco failures (seed=7 ep 3, seed=999 ep 1) ALSO fail on offscreen — these are policy-level limitations on hard `init_states[idx]` picks, not engine bugs.

### Bit-stability post-fix

| | Pre-fix | Post-fix |
|---|---|---|
| `mj_step` divergence (200 substeps, identical inputs) | 5.3e-7 m at substep 0, compounding to mm-scale | **0.0e+00** |
| Cross-run `successes` list | varied | **identical every run** |

## Tests

- `TestCacheTransformVersion::test_current_transform_version_is_v4` — pin v3 → v4 (was `_v3`).
- `test_libero_10_scene5_mujoco_engine_success_rate` — threshold tightened from `> 0` to `>= 1.0`; `n_episodes` 3 → 5.

## Test status

- Lint clean (`hatch run lint`).
- E2E `test_libero_10_scene5_mujoco_engine_success_rate` passes at `success_rate=1.00` (44 s wall time).

## Closes

Closes #181.