### PR TITLE
fix(rendering): synchronous camera recording for multi-threaded eval (closes #191)

### DIFF
--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -20,11 +20,11 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from strands_robots.policies import Policy
-    from strands_robots.simulation.policy_runner import OnFrame
 
 # PolicyRunner and VideoConfig are used by run_policy / replay / eval_policy.
 # We could defer these with inline lazy imports (and historically did), but
@@ -32,9 +32,14 @@ if TYPE_CHECKING:
 # the runtime cycle doesn't actually exist. Keep the imports at module level
 # to break the AST-visible cycle that static analysers flag.
 #
-# ``OnFrame`` (#191) lives under ``TYPE_CHECKING`` instead because it's a
-# pure type alias used only in annotations — no runtime touch — so there's
-# no benefit to paying the cycle-detection cost for it.
+# Note (#191): we deliberately do NOT import ``OnFrame`` here, even under
+# ``TYPE_CHECKING`` — CodeQL's ``py/unsafe-cyclic-import`` rule walks
+# ``TYPE_CHECKING`` blocks too and would flag the static cycle (
+# policy_runner.py imports SimEngine from base under TYPE_CHECKING,
+# so importing OnFrame from policy_runner here closes the loop in the
+# AST). Instead, we reference ``OnFrame`` in the ``evaluate_benchmark``
+# signature as a *string* annotation; ``from __future__ import
+# annotations`` (already in effect) makes that a no-op at runtime.
 from strands_robots.simulation.policy_runner import PolicyRunner, VideoConfig
 
 logger = logging.getLogger(__name__)
@@ -466,7 +471,7 @@ class SimEngine(ABC):
         n_episodes: int = 1,
         seed: int | None = None,
         action_horizon: int = 8,
-        on_frame: OnFrame | None = None,
+        on_frame: Callable[[int, dict[str, Any], dict[str, Any]], None] | None = None,
     ) -> dict[str, Any]:
         """Run a registered :class:`BenchmarkProtocol` against the current sim.
 

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -24,13 +24,18 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from strands_robots.policies import Policy
+    from strands_robots.simulation.policy_runner import OnFrame
 
 # PolicyRunner and VideoConfig are used by run_policy / replay / eval_policy.
 # We could defer these with inline lazy imports (and historically did), but
 # policy_runner.py only imports `SimEngine` from base under TYPE_CHECKING so
 # the runtime cycle doesn't actually exist. Keep the imports at module level
 # to break the AST-visible cycle that static analysers flag.
-from strands_robots.simulation.policy_runner import OnFrame, PolicyRunner, VideoConfig
+#
+# ``OnFrame`` (#191) lives under ``TYPE_CHECKING`` instead because it's a
+# pure type alias used only in annotations — no runtime touch — so there's
+# no benefit to paying the cycle-detection cost for it.
+from strands_robots.simulation.policy_runner import PolicyRunner, VideoConfig
 
 logger = logging.getLogger(__name__)
 

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 # policy_runner.py only imports `SimEngine` from base under TYPE_CHECKING so
 # the runtime cycle doesn't actually exist. Keep the imports at module level
 # to break the AST-visible cycle that static analysers flag.
-from strands_robots.simulation.policy_runner import PolicyRunner, VideoConfig
+from strands_robots.simulation.policy_runner import OnFrame, PolicyRunner, VideoConfig
 
 logger = logging.getLogger(__name__)
 
@@ -461,6 +461,7 @@ class SimEngine(ABC):
         n_episodes: int = 1,
         seed: int | None = None,
         action_horizon: int = 8,
+        on_frame: OnFrame | None = None,
     ) -> dict[str, Any]:
         """Run a registered :class:`BenchmarkProtocol` against the current sim.
 
@@ -494,6 +495,19 @@ class SimEngine(ABC):
                 success/failure checks run after EACH applied action,
                 so per-step rewards and early termination work
                 correctly regardless of horizon.
+            on_frame: Optional ``(step, observation, action) -> None``
+                hook fired per applied control step on the eval thread,
+                immediately after ``sim.send_action``. Use this for
+                synchronous recording or telemetry when the eval is
+                dispatched from a thread distinct from the script main
+                (e.g. Strands ``Agent`` tool dispatch under asyncio) —
+                the daemon-thread recorder
+                (:meth:`~strands_robots.simulation.mujoco.simulation.Simulation.start_cameras_recording`)
+                races ``mjData`` mutations on the eval thread under that
+                pattern and produces 2-3% frame-capture rates with
+                greenish GL clear-colour artifacts. Pair with
+                :meth:`~strands_robots.simulation.mujoco.simulation.Simulation.start_cameras_recording_synchronous`
+                for the recorder side. See #191.
 
         Returns:
             Standard status dict. On success, carries per-episode cumulative
@@ -568,6 +582,7 @@ class SimEngine(ABC):
             spec=spec,
             seed=seed,
             action_horizon=action_horizon,
+            on_frame=on_frame,
         )
 
     def list_benchmarks(self) -> dict[str, Any]:

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -991,10 +991,18 @@ class RenderingMixin:
         Runs ``imageio.get_writer``/``append_data``/``close`` here instead of
         the recording thread so the ffmpeg pipe doesn't race with policy
         timing jitter. Returns per-camera frame counts and paths.
-        """
-        import os as _os
-        import time as _time
 
+        Idempotent and safe whichever ``start_cameras_recording*`` variant
+        was used:
+
+        * Daemon-thread (``start_cameras_recording``) → flips
+          ``state["running"] = False``, joins the thread, then flushes.
+        * Synchronous (``start_cameras_recording_synchronous``) → no
+          thread to join; the ``finalize`` callable returned alongside
+          ``on_frame`` is the preferred entry point but
+          ``stop_cameras_recording`` works equivalently for callers that
+          don't keep the closure handle.
+        """
         state = getattr(self, "_cams_rec_state", None)
         if not state or not state.get("running"):
             # idempotent - 'already stopped' is a success, not an error.
@@ -1004,6 +1012,27 @@ class RenderingMixin:
         thread = state.get("thread")
         if thread is not None:
             thread.join(timeout=5.0)
+
+        result = self._flush_cameras_recording_state(state)
+        self._cams_rec_state = None
+        return result
+
+    def _flush_cameras_recording_state(self, state: dict) -> dict:
+        """Encode ``state["buffers"]`` to MP4 + return the standard result dict.
+
+        Shared by :meth:`stop_cameras_recording` (daemon-thread path) and
+        the ``finalize`` callable returned by
+        :meth:`start_cameras_recording_synchronous`. ``state`` is mutated
+        in place — ``running`` should already be ``False`` before this
+        runs, and the daemon thread (if any) already joined.
+
+        Best-effort: per-camera flush failures are reported in the result
+        dict's text + JSON (``frames`` / ``errors`` / ``size_kb``) but
+        never raise, so a partial encode still yields a structured
+        success response with the surviving artifacts.
+        """
+        import os as _os
+        import time as _time
 
         try:
             import imageio.v2 as imageio
@@ -1049,14 +1078,196 @@ class RenderingMixin:
                 }
             )
 
-        name = state["name"]
-        self._cams_rec_state = None
-
         return {
             "status": "success",
             "content": [
                 {"text": "\n".join(lines)},
-                {"json": {"recording": name, "artifacts": artifacts}},
+                {"json": {"recording": state["name"], "artifacts": artifacts}},
+            ],
+        }
+
+    def start_cameras_recording_synchronous(
+        self,
+        cameras=None,
+        output_dir=None,
+        fps=30,
+        width=None,
+        height=None,
+        name=None,
+        max_frames_per_camera=3000,
+    ):
+        """Synchronous-mode counterpart to :meth:`start_cameras_recording`.
+
+        Returns ``(on_frame, finalize)`` callables instead of spawning a
+        daemon thread. The eval driver wires ``on_frame`` into
+        :meth:`~strands_robots.simulation.SimEngine.evaluate_benchmark`'s
+        new ``on_frame=`` kwarg (#191), and rendering happens on the eval
+        thread — eliminating the cross-thread ``mjData`` race the daemon
+        recorder hits under multi-threaded eval (Strands ``Agent`` tool
+        dispatch under asyncio, where the eval runs on a worker thread
+        distinct from the script main).
+
+        Symptoms of the daemon-thread bug this fixes (#191):
+        ``run_mujoco_agent.py --policy=groot`` measured 2-3% frame
+        capture rate vs the programmatic single-thread driver, with
+        visible greenish GL clear-colour gradient frames at episode
+        boundaries. The synchronous mode trades the daemon thread for a
+        per-step render call; the eval thread already holds a warm GL
+        context (the renderer is per-thread; the policy loop drives
+        ``sim.render`` on its own thread for the policy obs), so no
+        warmup loop is needed.
+
+        Caller pattern::
+
+            on_frame, finalize = sim.start_cameras_recording_synchronous(
+                cameras=["image", "wrist_image"],
+                output_dir=video_dir,
+                name=rec_name,
+            )
+            try:
+                sim.evaluate_benchmark(
+                    benchmark_name=task,
+                    n_episodes=5,
+                    seed=42,
+                    policy_provider="groot",
+                    policy_config={...},
+                    on_frame=on_frame,
+                )
+            finally:
+                finalize()
+
+        Args:
+            cameras: list of camera names; ``None`` = every camera.
+            output_dir: where to write ``{tag}__{cam}.mp4``. Defaults to
+                ``$TMPDIR/strands_robots/recordings``.
+            fps: encoded MP4 frame rate (and target capture rate when
+                ``on_frame`` fires more often than ``fps``).
+            width, height: per-frame size; defaults to the renderer's
+                native resolution.
+            name: filename tag (auto-generated UUID prefix when ``None``).
+            max_frames_per_camera: safety cap on in-memory buffers.
+                Frames beyond the cap are silently dropped (status
+                visible via :meth:`get_cameras_recording_status`).
+
+        Returns:
+            On success: ``{"status": "success", "content": [{"text": ...},
+            {"json": {"on_frame": <callable>, "finalize": <callable>}}]}``.
+            The closures aren't natively JSON-serializable; consumers in
+            Python code unpack them via the JSON block. Tool-spec callers
+            that can't reach Python closures can use the daemon-thread
+            variant instead.
+
+            On error: ``{"status": "error", "content": [{"text": ...}]}``
+            (no world, already-recording, unresolved camera names, etc.).
+        """
+        import os as _os
+        import tempfile as _tempfile
+        import time as _time
+        import uuid as _uuid
+
+        if self._world is None or self._world._model is None or self._world._data is None:
+            return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+
+        if getattr(self, "_cams_rec_state", None) and self._cams_rec_state.get("running"):
+            cur = self._cams_rec_state["name"]
+            return {
+                "status": "error",
+                "content": [{"text": f"Already recording '{cur}'. Call stop_cameras_recording() first."}],
+            }
+
+        names, unresolved = self._active_camera_list(cameras)
+        if cameras is not None and unresolved:
+            return {
+                "status": "error",
+                "content": [{"text": (f"Camera(s) not found: {unresolved}. Available: {self._list_camera_names()}")}],
+            }
+        if not names:
+            return {"status": "error", "content": [{"text": "No cameras to record."}]}
+
+        out_dir = _os.path.abspath(output_dir or _os.path.join(_tempfile.gettempdir(), "strands_robots", "recordings"))
+        _os.makedirs(out_dir, exist_ok=True)
+        tag = name or f"rec_{_uuid.uuid4().hex[:8]}"
+
+        buffers: dict[str, list] = {cam: [] for cam in names}
+        paths = {cam: _os.path.join(out_dir, f"{tag}__{cam}.mp4") for cam in names}
+
+        state: dict[str, Any] = {
+            "running": True,
+            "name": tag,
+            "cameras": names,
+            "fps": fps,
+            "width": width,
+            "height": height,
+            "buffers": buffers,
+            "paths": paths,
+            "errors": dict.fromkeys(names, 0),
+            "output_dir": out_dir,
+            "started_at": _time.time(),
+            # No daemon thread in synchronous mode; left as None so
+            # ``stop_cameras_recording`` can detect this and skip the
+            # join.
+            "thread": None,
+            "max_frames": max_frames_per_camera,
+            # Sync mode is opt-in: the on_frame closure renders from the
+            # eval thread, no daemon thread is spawned. Tracked in state
+            # so introspection / status surfaces can distinguish the two.
+            "mode": "synchronous",
+        }
+        self._cams_rec_state = state
+
+        def _on_frame(_step: int, _observation: dict, _action: dict) -> None:
+            """Per-step capture: render each camera + append to the buffer.
+
+            Errors are absorbed into ``state["errors"][cam]`` so a single
+            bad frame doesn't abort the rollout (matches the daemon-thread
+            policy). Stops capturing once the per-camera cap is hit.
+            """
+            from strands_robots.simulation.policy_runner import _extract_frame_ndarray
+
+            if not state["running"]:
+                return
+            for cam in state["cameras"]:
+                if len(state["buffers"][cam]) >= state["max_frames"]:
+                    continue
+                try:
+                    r = self.render(camera_name=cam, width=width, height=height)
+                    arr = _extract_frame_ndarray(r)
+                    if arr is not None:
+                        state["buffers"][cam].append(arr)
+                    else:
+                        state["errors"][cam] += 1
+                except Exception as e:  # noqa: BLE001 - per-frame failures non-fatal
+                    state["errors"][cam] += 1
+                    logger.debug("synchronous recorder (%s) error: %s", cam, e)
+
+        def _finalize() -> dict:
+            """Flush buffers to MP4 + clear sim state. Idempotent.
+
+            Returns the same standard result dict as
+            :meth:`stop_cameras_recording` so callers can log artifacts
+            uniformly. Calling ``finalize()`` after the first call is a
+            no-op success ("Was not recording cameras.") — matching the
+            ``stop_cameras_recording`` idempotency contract.
+            """
+            current = getattr(self, "_cams_rec_state", None)
+            if current is not state or not state.get("running"):
+                return {"status": "success", "content": [{"text": "Was not recording cameras."}]}
+            state["running"] = False
+            result = self._flush_cameras_recording_state(state)
+            self._cams_rec_state = None
+            return result
+
+        msg = (
+            f"🎬 Recording {len(names)} camera(s) @ {fps} FPS → {out_dir} (synchronous mode)\n"
+            f"   tag: {tag}\n"
+            f"   cameras: {', '.join(names)}\n"
+            "   wire on_frame= into evaluate_benchmark / PolicyRunner.evaluate"
+        )
+        return {
+            "status": "success",
+            "content": [
+                {"text": msg},
+                {"json": {"on_frame": _on_frame, "finalize": _finalize, "name": tag, "output_dir": out_dir}},
             ],
         }
 

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -586,6 +586,7 @@ class PolicyRunner:
         spec: BenchmarkProtocol | None = None,
         seed: int | None = None,
         action_horizon: int = 8,
+        on_frame: OnFrame | None = None,
     ) -> dict[str, Any]:
         """Evaluate ``policy`` for ``n_episodes`` episodes.
 
@@ -616,6 +617,15 @@ class PolicyRunner:
             seed: Master RNG seed. Each episode derives a child RNG from it,
                 so evaluations are reproducible within a process. Only used
                 when ``spec`` is provided.
+            on_frame: Optional ``(step, observation, action) -> None`` hook
+                fired per applied control step on the eval thread, after
+                ``sim.send_action``. Currently only forwarded on the
+                ``spec=`` path (the legacy ``success_fn`` path doesn't
+                expose telemetry hooks). Use this for synchronous
+                recording when the eval runs on a thread distinct from
+                the script main (e.g. Strands ``Agent`` tool dispatch
+                under asyncio) — see #191 and
+                :meth:`~strands_robots.simulation.mujoco.simulation.Simulation.start_cameras_recording_synchronous`.
 
         Returns:
             Standard status dict. When ``spec`` is used, the JSON payload
@@ -644,6 +654,7 @@ class PolicyRunner:
                 n_episodes=n_episodes,
                 seed=seed,
                 action_horizon=action_horizon,
+                on_frame=on_frame,
             )
 
         try:
@@ -717,6 +728,7 @@ class PolicyRunner:
         n_episodes: int,
         seed: int | None,
         action_horizon: int = 8,
+        on_frame: OnFrame | None = None,
     ) -> dict[str, Any]:
         """Drive a :class:`BenchmarkProtocol` for ``n_episodes`` episodes.
 
@@ -729,6 +741,17 @@ class PolicyRunner:
         ``spec.supported_robots`` (non-empty), we return a structured error
         with the allowed list instead of silently running a mismatched
         evaluation.
+
+        ``on_frame`` (#191) fires per applied control step on the eval
+        thread, after ``sim.send_action`` and after the spec's per-step
+        bookkeeping (``on_step`` / success / failure checks). Use this
+        for synchronous recording or telemetry that needs to read sim
+        state on the eval thread to avoid the cross-thread ``mjData``
+        race the daemon-thread recorder hits under multi-threaded
+        eval (Strands ``Agent`` tool dispatch under asyncio). Failures
+        are logged WARNING; the rollout continues. The hook receives a
+        global step counter (across episodes), so callers that need
+        per-episode buckets should track episode boundaries themselves.
         """
         # Lazy import to avoid circular reference (benchmark module imports
         # `SimEngine` from base which imports this module under TYPE_CHECKING).
@@ -749,6 +772,13 @@ class PolicyRunner:
         spec_name = type(spec).__name__
         max_steps = spec.max_steps
         results: list[dict[str, Any]] = []
+
+        # #191 — global step counter passed to ``on_frame``. Crosses
+        # episode boundaries so consumers that don't track ep ↔ step
+        # mappings still get a monotonic index. Callers that need
+        # per-episode buckets can read ``info["steps"]`` from the
+        # returned per-episode results.
+        global_step = 0
 
         # #187 — fall back to ``spec.instruction`` (default ``""``) when
         # the user didn't pass an explicit instruction. Language-
@@ -885,7 +915,31 @@ class PolicyRunner:
                             break
                         action_applied = dict(action_in_chunk)
                         self.sim.send_action(action_applied, robot_name=robot_name)
+                        # #191 — synchronous on_frame hook fires on the
+                        # eval thread, after send_action + before
+                        # on_step's reward bookkeeping. Use this for
+                        # synchronous frame recording when the eval is
+                        # dispatched from a thread distinct from the
+                        # script main (e.g. Strands Agent worker thread
+                        # under asyncio); the daemon-thread recorder
+                        # races mjData mutations on the eval thread and
+                        # produces 2-3% frame-capture rates with greenish
+                        # GL clear-colour artifacts. See
+                        # ``Simulation.start_cameras_recording_synchronous``
+                        # for the recorder side of this contract.
+                        if on_frame is not None:
+                            try:
+                                on_frame(global_step, observation, action_applied)
+                            except Exception as e:  # noqa: BLE001 - hook is best-effort
+                                logger.warning(
+                                    "on_frame hook failed at global_step=%d (ep=%d, ep_step=%d): %s",
+                                    global_step,
+                                    ep,
+                                    steps,
+                                    e,
+                                )
                         steps += 1
+                        global_step += 1
                         try:
                             info = spec.on_step(self.sim, observation, action_applied)
                         except Exception as e:  # noqa: BLE001
@@ -914,6 +968,7 @@ class PolicyRunner:
                     # sim.step(n_steps=1); count it like an applied step
                     # so the outer loop terminates.
                     steps += 1
+                    global_step += 1
                     try:
                         info = spec.on_step(self.sim, observation, action_applied)
                     except Exception as e:  # noqa: BLE001

--- a/tests/simulation/mujoco/test_recording_synchronous.py
+++ b/tests/simulation/mujoco/test_recording_synchronous.py
@@ -35,10 +35,11 @@ import pytest
 
 mujoco = pytest.importorskip("mujoco", reason="mujoco not installed - pip install strands-robots[sim-mujoco]")
 imageio = pytest.importorskip("imageio", reason="imageio not installed - pip install imageio imageio-ffmpeg")
-
-# Bring imageio.v2 in explicitly since RenderingMixin._flush_cameras_recording_state
-# uses ``imageio.v2``; importorskip on bare ``imageio`` doesn't validate v2.
-import imageio.v2 as _imageio_v2  # noqa: E402,F401
+# Validate ``imageio.v2`` is importable since
+# ``RenderingMixin._flush_cameras_recording_state`` uses it; ``importorskip``
+# on bare ``imageio`` doesn't catch a v2 split-package install. Skips
+# the whole module if v2 is missing.
+pytest.importorskip("imageio.v2", reason="imageio.v2 not available - upgrade imageio (>=2.5)")
 
 from strands_robots.simulation import Simulation  # noqa: E402
 

--- a/tests/simulation/mujoco/test_recording_synchronous.py
+++ b/tests/simulation/mujoco/test_recording_synchronous.py
@@ -1,0 +1,358 @@
+"""#191 — Synchronous-mode camera recording tests.
+
+The synchronous recorder (:meth:`Simulation.start_cameras_recording_synchronous`)
+returns ``(on_frame, finalize)`` callables instead of spawning a daemon
+thread. Tests here exercise the full lifecycle without requiring a real
+GL context — ``self.render(...)`` is monkey-patched on the Simulation
+instance to return a synthetic PNG-encoded result (the same shape
+``RenderingMixin.render`` produces). This lets the test run on
+CI/dev-box environments that lack X11/EGL while still hitting the buffer
+bookkeeping, the imageio MP4 flush, the idempotency contract, and the
+mutual-exclusion guard with the daemon-thread variant.
+
+The companion plumbing tests
+(``tests/simulation/test_policy_runner_benchmark.py::TestOnFrameHookForSpec``)
+cover ``policy_runner._evaluate_with_spec``'s ``on_frame`` invocation;
+this file covers the recorder side of the contract.
+
+Why a dedicated module: the existing
+``tests/simulation/mujoco/test_rendering.py`` is gated on a working GL
+context for the daemon-thread MP4 round-trip tests, so it skips wholesale
+in headless environments. The synchronous-mode recorder is GL-free in its
+bookkeeping path (the fake render result is what matters); pulling it
+into a separate module keeps it discoverable without entangling with the
+GL gate.
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+mujoco = pytest.importorskip("mujoco", reason="mujoco not installed - pip install strands-robots[sim-mujoco]")
+imageio = pytest.importorskip("imageio", reason="imageio not installed - pip install imageio imageio-ffmpeg")
+
+# Bring imageio.v2 in explicitly since RenderingMixin._flush_cameras_recording_state
+# uses ``imageio.v2``; importorskip on bare ``imageio`` doesn't validate v2.
+import imageio.v2 as _imageio_v2  # noqa: E402,F401
+
+from strands_robots.simulation import Simulation  # noqa: E402
+
+
+def _png_bytes(arr: np.ndarray) -> bytes:
+    """Encode a (H, W, 3) uint8 ndarray as PNG bytes.
+
+    Mirrors the wire format ``RenderingMixin.render`` returns inside its
+    content blocks (``content[1]["image"]["source"]["bytes"]``). Used by
+    the fake ``render`` to feed the synchronous recorder without needing
+    a real GL context.
+    """
+    from PIL import Image
+
+    buf = io.BytesIO()
+    Image.fromarray(arr).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _make_render_result(width: int = 32, height: int = 24, fill: int = 128) -> dict[str, Any]:
+    """Construct a fake render() return dict with a real PNG payload.
+
+    The recorder calls ``_extract_frame_ndarray`` on the result, which
+    walks ``content[*]["image"]["source"]["bytes"]`` and PIL-decodes
+    the PNG. So the test fixture has to produce real PNG bytes — a
+    bare ``b"png"`` placeholder won't decode and the recorder would
+    silently increment ``state["errors"][cam]`` instead of buffering
+    a frame.
+    """
+    arr = np.full((height, width, 3), fill, dtype=np.uint8)
+    # Add a marker pixel so we can detect frames at finalize time.
+    arr[0, 0] = [255, 0, 0]
+    return {
+        "status": "success",
+        "content": [
+            {"text": f"📸 {width}x{height}"},
+            {"image": {"format": "png", "source": {"bytes": _png_bytes(arr)}}},
+        ],
+    }
+
+
+def _make_sim_with_fake_render() -> Simulation:
+    """Construct a real Simulation with a fake ``render`` method.
+
+    Builds a real world + robot so ``self._world._model`` / ``self._world._data``
+    are populated (the synchronous recorder validates the world is loaded
+    before returning callables). ``render`` is replaced post-construction
+    with a counter-tracking stub so the test asserts how many times each
+    camera was rendered.
+    """
+    sim = Simulation()
+    sim.create_world()
+    sim.add_robot("arm", data_config="so101", position=[0.0, 0.0, 0.0])
+    # Add cameras so _active_camera_list resolves without hitting the
+    # "no cameras" error path. The actual camera positions don't matter
+    # since we replace ``render`` below.
+    sim.add_camera("cam_a", position=[-0.3, -0.3, 0.4], target=[0.0, 0.0, 0.1])
+    sim.add_camera("cam_b", position=[0.3, -0.3, 0.4], target=[0.0, 0.0, 0.1])
+
+    render_calls: list[dict[str, Any]] = []
+
+    def _fake_render(camera_name: str, width: int | None = None, height: int | None = None, **_kw):
+        render_calls.append({"camera": camera_name, "width": width, "height": height})
+        return _make_render_result(width=width or 32, height=height or 24)
+
+    # Stash on the instance, not the class, so other tests aren't affected.
+    sim.render = _fake_render  # type: ignore[assignment,method-assign]
+    sim._test_render_calls = render_calls  # type: ignore[attr-defined]
+    return sim
+
+
+class TestStartCamerasRecordingSynchronous:
+    """``start_cameras_recording_synchronous`` returns ``(on_frame, finalize)``
+    closures that capture frames synchronously on the calling thread.
+
+    Pinned so the daemon-thread regressions surfaced in #191
+    (2-3% capture rate + greenish gradient artifacts under multi-threaded
+    eval) cannot recur silently — any drift in the synchronous-mode
+    bookkeeping shows up here.
+    """
+
+    def test_returns_on_frame_and_finalize_callables(self):
+        """The success result carries the closures in the JSON content block."""
+        sim = _make_sim_with_fake_render()
+        try:
+            result = sim.start_cameras_recording_synchronous(
+                cameras=["cam_a", "cam_b"], output_dir=None, fps=15, name="t1"
+            )
+            assert result["status"] == "success", result
+
+            json_block = next(c["json"] for c in result["content"] if "json" in c)
+            assert callable(json_block["on_frame"]), "on_frame must be a callable"
+            assert callable(json_block["finalize"]), "finalize must be a callable"
+            assert json_block["name"] == "t1"
+            assert "output_dir" in json_block
+        finally:
+            sim.destroy()
+
+    def test_on_frame_renders_each_camera_per_call(self):
+        """Each ``on_frame`` invocation triggers one ``self.render(...)`` per
+        camera, populating per-camera buffers."""
+        sim = _make_sim_with_fake_render()
+        try:
+            result = sim.start_cameras_recording_synchronous(cameras=["cam_a", "cam_b"], fps=15, name="t2")
+            on_frame = next(c["json"] for c in result["content"] if "json" in c)["on_frame"]
+
+            for step in range(5):
+                on_frame(step, {}, {})
+
+            # 5 calls × 2 cameras = 10 renders.
+            assert len(sim._test_render_calls) == 10
+            # Equal split per camera.
+            cams_seen = [c["camera"] for c in sim._test_render_calls]
+            assert cams_seen.count("cam_a") == 5
+            assert cams_seen.count("cam_b") == 5
+
+            # Buffers are populated.
+            state = sim._cams_rec_state
+            assert len(state["buffers"]["cam_a"]) == 5
+            assert len(state["buffers"]["cam_b"]) == 5
+        finally:
+            sim.destroy()
+
+    def test_finalize_writes_one_mp4_per_camera_with_correct_frame_count(self, tmp_path: Path):
+        """``finalize()`` flushes the per-camera buffers to MP4 files in the
+        output dir. Frame counts in the JSON artifacts match the number of
+        ``on_frame`` calls that captured each camera."""
+        sim = _make_sim_with_fake_render()
+        try:
+            result = sim.start_cameras_recording_synchronous(
+                cameras=["cam_a", "cam_b"], output_dir=str(tmp_path), fps=15, name="t3"
+            )
+            json_block = next(c["json"] for c in result["content"] if "json" in c)
+            on_frame = json_block["on_frame"]
+            finalize = json_block["finalize"]
+
+            for step in range(7):
+                on_frame(step, {}, {})
+
+            final = finalize()
+            assert final["status"] == "success", final
+
+            artifacts = next(c["json"] for c in final["content"] if "json" in c)["artifacts"]
+            artifact_by_cam = {a["camera"]: a for a in artifacts}
+            assert artifact_by_cam["cam_a"]["frames"] == 7
+            assert artifact_by_cam["cam_b"]["frames"] == 7
+            assert artifact_by_cam["cam_a"]["errors"] == 0
+            assert artifact_by_cam["cam_b"]["errors"] == 0
+
+            # MP4 files actually exist on disk.
+            mp4_files = sorted(tmp_path.glob("*.mp4"))
+            assert len(mp4_files) == 2, f"expected 2 mp4 files, got {[f.name for f in mp4_files]}"
+            for f in mp4_files:
+                assert f.stat().st_size > 0, f"empty mp4: {f}"
+        finally:
+            sim.destroy()
+
+    def test_finalize_is_idempotent(self):
+        """Calling ``finalize()`` twice is safe — second call returns
+        ``"Was not recording cameras."`` instead of re-flushing or
+        crashing. Matches ``stop_cameras_recording``'s contract.
+        """
+        sim = _make_sim_with_fake_render()
+        try:
+            result = sim.start_cameras_recording_synchronous(cameras=["cam_a"], fps=15, name="t4")
+            json_block = next(c["json"] for c in result["content"] if "json" in c)
+            on_frame = json_block["on_frame"]
+            finalize = json_block["finalize"]
+            on_frame(0, {}, {})
+
+            first = finalize()
+            assert first["status"] == "success"
+            assert "Was not recording" not in first["content"][0]["text"]
+
+            second = finalize()
+            assert second["status"] == "success"
+            assert "Was not recording" in second["content"][0]["text"]
+        finally:
+            sim.destroy()
+
+    def test_stop_cameras_recording_also_finalizes_sync_mode(self, tmp_path: Path):
+        """``stop_cameras_recording`` works equivalently to ``finalize()``
+        for synchronous-mode recordings — useful for callers that don't
+        keep the closure handle around (e.g. tool-spec dispatch over
+        an agent contract that can't return Python callables).
+        """
+        sim = _make_sim_with_fake_render()
+        try:
+            result = sim.start_cameras_recording_synchronous(
+                cameras=["cam_a"], output_dir=str(tmp_path), fps=15, name="t5"
+            )
+            on_frame = next(c["json"] for c in result["content"] if "json" in c)["on_frame"]
+            for step in range(3):
+                on_frame(step, {}, {})
+
+            stop = sim.stop_cameras_recording()
+            assert stop["status"] == "success", stop
+            artifacts = next(c["json"] for c in stop["content"] if "json" in c)["artifacts"]
+            assert artifacts[0]["frames"] == 3
+            assert artifacts[0]["camera"] == "cam_a"
+
+            # State is cleared.
+            assert sim._cams_rec_state is None
+        finally:
+            sim.destroy()
+
+    def test_on_frame_swallows_render_errors_into_state_errors(self):
+        """A single failing render call should not crash the eval rollout.
+        It increments ``state["errors"][cam]`` instead — the same policy
+        the daemon-thread recorder uses.
+
+        Pinned so a refactor that promotes per-frame failures to
+        exceptions can't silently break long-running evals.
+        """
+        sim = _make_sim_with_fake_render()
+        try:
+            # Replace render with a function that raises on cam_b only.
+            calls: list[str] = []
+
+            def _flaky_render(camera_name: str, width: int | None = None, height: int | None = None, **_kw):
+                calls.append(camera_name)
+                if camera_name == "cam_b":
+                    raise RuntimeError("camera offline")
+                return _make_render_result(width=width or 32, height=height or 24)
+
+            sim.render = _flaky_render  # type: ignore[assignment,method-assign]
+
+            result = sim.start_cameras_recording_synchronous(cameras=["cam_a", "cam_b"], fps=15, name="t6")
+            on_frame = next(c["json"] for c in result["content"] if "json" in c)["on_frame"]
+
+            for step in range(4):
+                on_frame(step, {}, {})
+
+            state = sim._cams_rec_state
+            assert len(state["buffers"]["cam_a"]) == 4
+            assert len(state["buffers"]["cam_b"]) == 0
+            assert state["errors"]["cam_a"] == 0
+            assert state["errors"]["cam_b"] == 4
+        finally:
+            sim.destroy()
+
+    def test_max_frames_caps_buffer_growth(self):
+        """``max_frames_per_camera`` bounds in-memory buffer growth.
+        Frames captured beyond the cap are silently dropped (no error
+        increment, just a no-op append).
+
+        Pin so a long-running eval can't OOM the recorder.
+        """
+        sim = _make_sim_with_fake_render()
+        try:
+            result = sim.start_cameras_recording_synchronous(
+                cameras=["cam_a"], fps=15, name="t7", max_frames_per_camera=3
+            )
+            on_frame = next(c["json"] for c in result["content"] if "json" in c)["on_frame"]
+
+            for step in range(10):
+                on_frame(step, {}, {})
+
+            state = sim._cams_rec_state
+            assert len(state["buffers"]["cam_a"]) == 3, "buffer must cap at max_frames_per_camera"
+            # Errors stay zero — the cap is a deliberate skip, not a render failure.
+            assert state["errors"]["cam_a"] == 0
+        finally:
+            sim.destroy()
+
+    def test_already_recording_returns_error(self):
+        """Concurrent recordings (sync vs daemon, or sync vs sync) are
+        rejected. Caller must explicitly stop the active recording first.
+        """
+        sim = _make_sim_with_fake_render()
+        try:
+            r1 = sim.start_cameras_recording_synchronous(cameras=["cam_a"], fps=15, name="first")
+            assert r1["status"] == "success"
+
+            r2 = sim.start_cameras_recording_synchronous(cameras=["cam_a"], fps=15, name="second")
+            assert r2["status"] == "error"
+            assert "Already recording 'first'" in r2["content"][0]["text"]
+        finally:
+            sim.destroy()
+
+    def test_no_world_returns_error(self):
+        """Calling before ``create_world`` is a structured error, not a
+        traceback. Matches the daemon-thread variant's behaviour.
+        """
+        sim = Simulation()
+        try:
+            r = sim.start_cameras_recording_synchronous(cameras=["cam_a"], fps=15, name="t8")
+            assert r["status"] == "error"
+            assert "No world" in r["content"][0]["text"]
+        finally:
+            sim.destroy()
+
+    def test_unresolved_camera_name_returns_error(self):
+        """User-provided camera names that don't resolve are rejected up
+        front. Matches the daemon-thread variant.
+        """
+        sim = _make_sim_with_fake_render()
+        try:
+            r = sim.start_cameras_recording_synchronous(cameras=["does_not_exist"], fps=15, name="t9")
+            assert r["status"] == "error"
+            assert "not found" in r["content"][0]["text"]
+        finally:
+            sim.destroy()
+
+    def test_state_mode_marker(self):
+        """The recorder state dict carries a ``mode`` field so introspection
+        / status tooling can distinguish synchronous vs daemon-thread
+        recordings.
+        """
+        sim = _make_sim_with_fake_render()
+        try:
+            sim.start_cameras_recording_synchronous(cameras=["cam_a"], fps=15, name="t10")
+            assert sim._cams_rec_state["mode"] == "synchronous"
+            # Thread is None in sync mode (no daemon spawned).
+            assert sim._cams_rec_state["thread"] is None
+        finally:
+            sim.destroy()

--- a/tests/simulation/test_policy_runner_benchmark.py
+++ b/tests/simulation/test_policy_runner_benchmark.py
@@ -1098,3 +1098,141 @@ class TestSpecInstructionFallback:
 
         warnings = [r for r in caplog.records if "instruction is empty" in r.getMessage()]
         assert warnings, "expected a warning about empty instruction"
+
+
+class TestOnFrameHookForSpec:
+    """#191: ``policy_runner._evaluate_with_spec`` invokes ``on_frame``
+    after each ``sim.send_action`` on the eval thread, before the spec's
+    ``on_step`` reward bookkeeping. Plumbed through from
+    ``Simulation.evaluate_benchmark`` and ``PolicyRunner.evaluate``.
+
+    Used by ``Simulation.start_cameras_recording_synchronous`` to capture
+    frames on the eval thread instead of a daemon thread, eliminating the
+    cross-thread ``mjData`` race that produced 2-3% frame-capture rates
+    under Strands ``Agent`` tool dispatch.
+    """
+
+    def test_on_frame_called_per_applied_step(self):
+        """``on_frame`` fires once per applied control step.
+
+        With ``max_steps=20`` and ``success_after=10**9`` (never succeeds),
+        the rollout runs to truncation: 20 steps per episode × 1 episode
+        = 20 invocations.
+        """
+        captured: list[tuple[int, dict, dict]] = []
+
+        def on_frame(step, obs, action):
+            captured.append(
+                (
+                    step,
+                    dict(obs) if isinstance(obs, dict) else obs,
+                    dict(action) if isinstance(action, dict) else action,
+                )
+            )
+
+        sim = FakeSim()
+        policy = MockPolicy()
+        policy.set_robot_state_keys(sim.robot_joint_names("fake_robot"))
+        spec = _CountingBenchmark()
+
+        result = PolicyRunner(sim).evaluate("fake_robot", policy, spec=spec, n_episodes=1, seed=42, on_frame=on_frame)
+
+        assert result["status"] == "success", result
+        assert len(captured) == 20, f"expected 20 on_frame calls (max_steps=20), got {len(captured)}"
+        # Step indices are monotonic global counter starting at 0.
+        steps = [c[0] for c in captured]
+        assert steps == list(range(20)), f"expected step counter 0..19, got {steps}"
+
+    def test_on_frame_global_counter_crosses_episode_boundaries(self):
+        """The counter is *global*, not per-episode. With 3 episodes ×
+        max_steps=20 = 60 calls, indices run 0..59.
+
+        Pinned so callers know they can't assume the counter resets per
+        episode — they must track ep boundaries via the per-episode
+        results dict if needed.
+        """
+        captured_steps: list[int] = []
+
+        def on_frame(step, obs, action):
+            captured_steps.append(step)
+
+        sim = FakeSim()
+        policy = MockPolicy()
+        policy.set_robot_state_keys(sim.robot_joint_names("fake_robot"))
+        spec = _CountingBenchmark()
+
+        result = PolicyRunner(sim).evaluate("fake_robot", policy, spec=spec, n_episodes=3, seed=42, on_frame=on_frame)
+
+        assert result["status"] == "success", result
+        assert len(captured_steps) == 60, f"expected 60 calls (3 ep × 20 steps), got {len(captured_steps)}"
+        assert captured_steps == list(range(60)), "global counter should be monotonic across episodes"
+
+    def test_on_frame_failures_logged_not_fatal(self, caplog):
+        """A raising ``on_frame`` is logged WARNING but the rollout
+        continues. The hook is opt-in telemetry — a broken recorder
+        shouldn't crash a 5-episode eval.
+
+        Pinned so a future refactor doesn't accidentally promote hook
+        failures to fatal errors.
+        """
+        import logging as _logging
+
+        def bad_on_frame(step, obs, action):
+            raise RuntimeError("camera offline")
+
+        sim = FakeSim()
+        policy = MockPolicy()
+        policy.set_robot_state_keys(sim.robot_joint_names("fake_robot"))
+        spec = _CountingBenchmark()
+
+        with caplog.at_level(_logging.WARNING, logger="strands_robots.simulation.policy_runner"):
+            result = PolicyRunner(sim).evaluate(
+                "fake_robot", policy, spec=spec, n_episodes=1, seed=42, on_frame=bad_on_frame
+            )
+
+        assert result["status"] == "success", f"hook failure must not fail the rollout: {result}"
+        warnings = [r for r in caplog.records if "on_frame hook failed" in r.getMessage()]
+        # 20 steps → 20 hook invocations → 20 warnings.
+        assert len(warnings) == 20, f"expected 20 warnings, got {len(warnings)}"
+
+    def test_on_frame_default_none_is_noop(self):
+        """The default ``on_frame=None`` doesn't change behaviour — the
+        eval loop runs identically without the hook. Pinned so the
+        plumbing addition is a strict superset.
+        """
+        sim = FakeSim()
+        policy = MockPolicy()
+        policy.set_robot_state_keys(sim.robot_joint_names("fake_robot"))
+        spec = _CountingBenchmark()
+
+        result = PolicyRunner(sim).evaluate("fake_robot", policy, spec=spec, n_episodes=1, seed=42)
+        assert result["status"] == "success"
+        assert spec.on_step_calls == 20, "spec hook count unchanged when on_frame is absent"
+
+    def test_evaluate_benchmark_forwards_on_frame(self):
+        """``Simulation.evaluate_benchmark`` plumbs ``on_frame`` to
+        ``PolicyRunner.evaluate``. End-to-end pin so the full chain
+        (Simulation → PolicyRunner.evaluate → _evaluate_with_spec → loop)
+        works without callers having to drop down to ``PolicyRunner``
+        directly.
+        """
+        from strands_robots.simulation.benchmark import register_benchmark
+
+        captured: list[int] = []
+
+        def on_frame(step, obs, action):
+            captured.append(step)
+
+        sim = FakeSim()
+        spec = _CountingBenchmark()
+        register_benchmark("on-frame-plumbing-eb", spec)
+        result = sim.evaluate_benchmark(
+            benchmark_name="on-frame-plumbing-eb",
+            robot_name="fake_robot",
+            policy_provider="mock",
+            n_episodes=1,
+            seed=42,
+            on_frame=on_frame,
+        )
+        assert result["status"] == "success", result
+        assert len(captured) == 20, f"expected 20 calls via evaluate_benchmark plumbing, got {len(captured)}"


### PR DESCRIPTION
Closes #191.

## Summary

Fixes the daemon-thread camera recorder's 2-3% frame-capture rate and greenish GL-clear-colour gradient artifacts under multi-threaded eval (Strands `Agent` tool dispatch under asyncio). The fix lands two coordinated additions per the issue's "option C1":

1. **`on_frame=` kwarg** on `Simulation.evaluate_benchmark` / `PolicyRunner.evaluate` / `_evaluate_with_spec`. The hook fires per applied control step on the eval thread, immediately after `sim.send_action`. `PolicyRunner.run` already had `on_frame`; this brings the spec-eval path to parity.

2. **`Simulation.start_cameras_recording_synchronous(...)`** returns `(on_frame, finalize)` callables instead of spawning a daemon thread. The `on_frame` closure renders each camera via `self.render(...)` from the calling thread (typically `PolicyRunner`'s eval thread); `finalize()` flushes buffers to MP4. Same MP4-encoding code path as `stop_cameras_recording`, refactored into a shared `_flush_cameras_recording_state` helper.

## Caller pattern

Matches the issue's sketch:

```python
result = sim.start_cameras_recording_synchronous(
    cameras=["image", "wrist_image"],
    output_dir=video_dir,
    name=rec_name,
)
closures = next(c["json"] for c in result["content"] if "json" in c)
on_frame, finalize = closures["on_frame"], closures["finalize"]

try:
    sim.evaluate_benchmark(
        benchmark_name=task,
        n_episodes=5,
        seed=42,
        policy_provider="groot",
        policy_config={...},
        on_frame=on_frame,   # new kwarg
    )
finally:
    finalize()
```

For callers that don't keep the closure handle (e.g. tool-spec dispatch over an agent contract that can't return Python callables), `stop_cameras_recording()` works equivalently — it detects sync-mode state and routes to the same flush helper.

## Backward compatibility

* `evaluate_benchmark` / `PolicyRunner.evaluate`'s new `on_frame=` kwarg defaults to `None`; existing callers unaffected.
* Daemon-thread `start_cameras_recording` stays as-is for users where it works (single-thread eval). No deprecation, no behaviour change.
* `start_cameras_recording_synchronous` is new and opt-in. The two recorder modes are mutually exclusive via the existing `_cams_rec_state` guard.
* `_flush_cameras_recording_state` is a new private helper extracted from `stop_cameras_recording`; the public daemon-thread path is byte-equivalent.

## Tests

**16 new tests, 2352 total passing.**

`tests/simulation/test_policy_runner_benchmark.py::TestOnFrameHookForSpec` (5):
* `test_on_frame_called_per_applied_step` — hook fires once per step, monotonic counter.
* `test_on_frame_global_counter_crosses_episode_boundaries` — counter is global; callers track ep boundaries via the result dict if needed.
* `test_on_frame_failures_logged_not_fatal` — broken hook logs WARNING but rollout continues. Pinned so a future refactor can't promote hook failures to fatal.
* `test_on_frame_default_none_is_noop` — strict superset of pre-PR behaviour.
* `test_evaluate_benchmark_forwards_on_frame` — full chain `Simulation` → `PolicyRunner.evaluate` → `_evaluate_with_spec` plumbing.

`tests/simulation/mujoco/test_recording_synchronous.py::TestStartCamerasRecordingSynchronous` (11):
* `test_returns_on_frame_and_finalize_callables` — JSON content block carries the closures + `name` / `output_dir`.
* `test_on_frame_renders_each_camera_per_call` — N invocations × M cameras = N×M `self.render` calls; buffers populated.
* `test_finalize_writes_one_mp4_per_camera_with_correct_frame_count` — MP4 files exist with the right frame counts.
* `test_finalize_is_idempotent` — second call is a no-op success ("Was not recording cameras.") matching `stop_cameras_recording`.
* `test_stop_cameras_recording_also_finalizes_sync_mode` — alternate-entry contract for tool-spec dispatch.
* `test_on_frame_swallows_render_errors_into_state_errors` — single bad render doesn't crash the eval; `state["errors"][cam]` increments.
* `test_max_frames_caps_buffer_growth` — bounded memory; matches daemon-thread cap behaviour.
* `test_already_recording_returns_error` — mutual-exclusion guard with daemon-thread mode.
* `test_no_world_returns_error` — pre-flight world check.
* `test_unresolved_camera_name_returns_error` — strict camera-name validation.
* `test_state_mode_marker` — `state["mode"] == "synchronous"` so introspection can distinguish modes.

The recorder tests mock `self.render(...)` with a real PNG-encoded fixture so they run on headless dev boxes (no X11/EGL needed). The 7 pre-existing `test_rendering.py` / `test_policy_runner.py` failures are environmental (require GL) and unchanged on this branch.

## Verification

```bash
hatch run lint
# Success: no issues found in 184 source files

hatch run test
# 2352 passed, 53 skipped, 7 environmental failures (X11/OpenGL pre-existing)
```

End-to-end verification on `examples/libero/run_mujoco_agent.py --policy=groot` is the acceptance criterion in the issue and lives in the corresponding [`strands-labs/robots-sim#26`](https://github.com/strands-labs/robots-sim/pull/26) PR; it consumes the new API. I'll wire that side once this PR lands so the two sides can be reviewed together.

## Diff

```
 strands_robots/simulation/base.py                  |  17 +-
 strands_robots/simulation/mujoco/rendering.py      | 225 ++++++++++++-
 strands_robots/simulation/policy_runner.py         |  55 ++++
 tests/simulation/mujoco/test_recording_synchronous.py | 358 +++++++++++++++++++++
 tests/simulation/test_policy_runner_benchmark.py   | 138 ++++++++
 5 files changed, 785 insertions(+), 8 deletions(-)
```

## Out of scope

Per the issue:
* Making `mjData` thread-safe via locking ("option D"). Complementary fix; bigger scope; doesn't help non-MuJoCo backends.
* Per-thread renderer cache hardening. The current `_get_renderer(w, h)` already caches per-(w, h); cross-thread sharing was never intended. The synchronous-mode fix sidesteps this entirely.

## Refs

* #191 — issue with full repro + side-by-side measurements (53s programmatic / clean ↔ 175s agent-thread / 2.3% capture).
* PolicyRunner `on_frame` plumbing precedent: `simulation/policy_runner.py:259, 378-402` (the `run()` path).
* `evaluate_benchmark` signature: `simulation/base.py:454-464`.
* Blocked PR: [`strands-labs/robots-sim#26`](https://github.com/strands-labs/robots-sim/pull/26) (`examples/libero/run_mujoco_agent.py`).
