### PR TITLE
fix(simulation): defer policy_runner import to break unsafe cyclic-import cycle

### DIFF
--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -27,14 +27,14 @@ if TYPE_CHECKING:
     from strands_robots.policies import Policy
 
 # PolicyRunner and VideoConfig are imported lazily inside the run_policy /
-# replay / eval_policy methods that use them. A module-level runtime import
-# would close a cycle with strands_robots.simulation.policy_runner, which
-# imports SimEngine from this module under TYPE_CHECKING — CodeQL's
-# py/unsafe-cyclic-import rule walks TYPE_CHECKING blocks and flagged that
-# loop (CodeQL alerts #83, #84). The lazy approach preserves the same
-# rationale for OnFrame (#191): it is referenced as a string annotation
-# in the evaluate_benchmark signature, with ``from __future__ import
-# annotations`` (already in effect) making that a no-op at runtime.
+# replay / eval_policy / evaluate_benchmark methods that use them. A
+# module-level runtime import would close a cycle with
+# strands_robots.simulation.policy_runner, which imports SimEngine from
+# this module under TYPE_CHECKING — CodeQL's py/unsafe-cyclic-import rule
+# walks TYPE_CHECKING blocks and flagged that loop (CodeQL alerts #83, #84).
+# The lazy approach is safe because ``from __future__ import annotations``
+# (already in effect) makes all type hints string-form at runtime, so no
+# name resolution is needed at import time.
 
 logger = logging.getLogger(__name__)
 

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -30,11 +30,41 @@ if TYPE_CHECKING:
 # replay / eval_policy / evaluate_benchmark methods that use them. A
 # module-level runtime import would close a cycle with
 # strands_robots.simulation.policy_runner, which imports SimEngine from
-# this module under TYPE_CHECKING — CodeQL's py/unsafe-cyclic-import rule
+# this module under TYPE_CHECKING - CodeQL's py/unsafe-cyclic-import rule
 # walks TYPE_CHECKING blocks and flagged that loop (CodeQL alerts #83, #84).
 # The lazy approach is safe because ``from __future__ import annotations``
 # (already in effect) makes all type hints string-form at runtime, so no
 # name resolution is needed at import time.
+#
+# Note: ``OnFrame`` from policy_runner is similarly omitted; ``evaluate_benchmark``
+# uses the structural ``Callable[[int, dict, dict], None]`` type directly so no
+# name import is needed at all.
+#
+# The four call sites previously duplicated the same two-line lazy-import block.
+# They are now centralised through ``_lazy_policy_runner()`` below: a single
+# definition + single rationale comment, so a future re-hoist regression is a
+# one-line edit (and is also pinned by ``tests/simulation/test_no_import_cycle.py``).
+
+
+def _lazy_policy_runner() -> tuple[type, type]:
+    """Lazy import shim for ``PolicyRunner`` and ``VideoConfig``.
+
+    Defined at module level for discoverability, but the inner
+    ``from`` statement runs only when this helper is called (Python
+    function bodies are not executed at module-import time). This
+    keeps the static import graph acyclic per CodeQL alerts #83, #84.
+
+    Returns:
+        ``(PolicyRunner, VideoConfig)`` - the two symbols every
+        cycle-affected ``SimEngine`` method needs.
+    """
+    from strands_robots.simulation.policy_runner import (  # noqa: PLC0415
+        PolicyRunner,
+        VideoConfig,
+    )
+
+    return PolicyRunner, VideoConfig
+
 
 logger = logging.getLogger(__name__)
 
@@ -331,8 +361,7 @@ class SimEngine(ABC):
 
         on_frame = self._make_run_policy_hook(robot_name, instruction)
 
-        # Lazy import to break the strands_robots.simulation.policy_runner cycle.
-        from strands_robots.simulation.policy_runner import PolicyRunner, VideoConfig
+        PolicyRunner, VideoConfig = _lazy_policy_runner()
 
         return PolicyRunner(self).run(
             robot_name,
@@ -401,8 +430,7 @@ class SimEngine(ABC):
         writes) only when measured necessary.
         """
 
-        # Lazy import to break the strands_robots.simulation.policy_runner cycle.
-        from strands_robots.simulation.policy_runner import PolicyRunner
+        PolicyRunner, _ = _lazy_policy_runner()
 
         return PolicyRunner(self).replay(
             repo_id,
@@ -450,8 +478,7 @@ class SimEngine(ABC):
         policy = create_policy(policy_provider, **(policy_config or {}))
         policy.set_robot_state_keys(self.robot_joint_names(resolved_robot))
 
-        # Lazy import to break the strands_robots.simulation.policy_runner cycle.
-        from strands_robots.simulation.policy_runner import PolicyRunner
+        PolicyRunner, _ = _lazy_policy_runner()
 
         return PolicyRunner(self).evaluate(
             resolved_robot,
@@ -587,8 +614,7 @@ class SimEngine(ABC):
         policy = create_policy(policy_provider, **(policy_config or {}))
         policy.set_robot_state_keys(self.robot_joint_names(resolved_robot))
 
-        # Lazy import to break the strands_robots.simulation.policy_runner cycle.
-        from strands_robots.simulation.policy_runner import PolicyRunner
+        PolicyRunner, _ = _lazy_policy_runner()
 
         return PolicyRunner(self).evaluate(
             resolved_robot,

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from strands_robots.policies import Policy
+    from strands_robots.simulation.policy_runner import PolicyRunner, VideoConfig
 
 # PolicyRunner and VideoConfig are imported lazily inside the run_policy /
 # replay / eval_policy / evaluate_benchmark methods that use them. A
@@ -46,7 +47,7 @@ if TYPE_CHECKING:
 # one-line edit (and is also pinned by ``tests/simulation/test_no_import_cycle.py``).
 
 
-def _lazy_policy_runner() -> tuple[type, type]:
+def _lazy_policy_runner() -> tuple[type[PolicyRunner], type[VideoConfig]]:
     """Lazy import shim for ``PolicyRunner`` and ``VideoConfig``.
 
     Defined at module level for discoverability, but the inner

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -25,22 +25,17 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from strands_robots.policies import Policy
+    from strands_robots.simulation.policy_runner import PolicyRunner, VideoConfig
 
-# PolicyRunner and VideoConfig are imported lazily inside ``_lazy_policy_runner``
-# (function body, executes at call time only). The four ``SimEngine`` methods
-# that need them - ``run_policy`` / ``replay_episode`` / ``eval_policy`` /
-# ``evaluate_benchmark`` - obtain them via that helper.
-#
-# A module-level import (whether direct or behind ``if TYPE_CHECKING``) would
-# close a cycle with ``strands_robots.simulation.policy_runner``, which imports
-# ``SimEngine`` from this module under TYPE_CHECKING. CodeQL's
-# ``py/unsafe-cyclic-import`` rule walks TYPE_CHECKING blocks and treats both
-# edges as load-bearing, so even a TYPE_CHECKING-only re-import here re-fires
-# alerts #83-#87. The helper's return annotation therefore uses string
-# forward-references (``type["PolicyRunner"]`` / ``type["VideoConfig"]``):
-# under ``from __future__ import annotations`` (already in effect) all type
-# hints are string-form at runtime, so no module-level name resolution is
-# needed. mypy resolves the strings via the lazy import inside the helper body.
+# PolicyRunner and VideoConfig are imported lazily inside the run_policy /
+# replay / eval_policy / evaluate_benchmark methods that use them. A
+# module-level runtime import would close a cycle with
+# strands_robots.simulation.policy_runner, which imports SimEngine from
+# this module under TYPE_CHECKING - CodeQL's py/unsafe-cyclic-import rule
+# walks TYPE_CHECKING blocks and flagged that loop (CodeQL alerts #83, #84).
+# The lazy approach is safe because ``from __future__ import annotations``
+# (already in effect) makes all type hints string-form at runtime, so no
+# name resolution is needed at import time.
 #
 # Note: ``OnFrame`` from policy_runner is similarly omitted; ``evaluate_benchmark``
 # uses the structural ``Callable[[int, dict, dict], None]`` type directly so no
@@ -52,7 +47,7 @@ if TYPE_CHECKING:
 # one-line edit (and is also pinned by ``tests/simulation/test_no_import_cycle.py``).
 
 
-def _lazy_policy_runner() -> tuple[type["PolicyRunner"], type["VideoConfig"]]:
+def _lazy_policy_runner() -> tuple[type[PolicyRunner], type[VideoConfig]]:
     """Lazy import shim for ``PolicyRunner`` and ``VideoConfig``.
 
     Defined at module level for discoverability, but the inner

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -25,17 +25,22 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from strands_robots.policies import Policy
-    from strands_robots.simulation.policy_runner import PolicyRunner, VideoConfig
 
-# PolicyRunner and VideoConfig are imported lazily inside the run_policy /
-# replay / eval_policy / evaluate_benchmark methods that use them. A
-# module-level runtime import would close a cycle with
-# strands_robots.simulation.policy_runner, which imports SimEngine from
-# this module under TYPE_CHECKING - CodeQL's py/unsafe-cyclic-import rule
-# walks TYPE_CHECKING blocks and flagged that loop (CodeQL alerts #83, #84).
-# The lazy approach is safe because ``from __future__ import annotations``
-# (already in effect) makes all type hints string-form at runtime, so no
-# name resolution is needed at import time.
+# PolicyRunner and VideoConfig are imported lazily inside ``_lazy_policy_runner``
+# (function body, executes at call time only). The four ``SimEngine`` methods
+# that need them - ``run_policy`` / ``replay_episode`` / ``eval_policy`` /
+# ``evaluate_benchmark`` - obtain them via that helper.
+#
+# A module-level import (whether direct or behind ``if TYPE_CHECKING``) would
+# close a cycle with ``strands_robots.simulation.policy_runner``, which imports
+# ``SimEngine`` from this module under TYPE_CHECKING. CodeQL's
+# ``py/unsafe-cyclic-import`` rule walks TYPE_CHECKING blocks and treats both
+# edges as load-bearing, so even a TYPE_CHECKING-only re-import here re-fires
+# alerts #83-#87. The helper's return annotation therefore uses string
+# forward-references (``type["PolicyRunner"]`` / ``type["VideoConfig"]``):
+# under ``from __future__ import annotations`` (already in effect) all type
+# hints are string-form at runtime, so no module-level name resolution is
+# needed. mypy resolves the strings via the lazy import inside the helper body.
 #
 # Note: ``OnFrame`` from policy_runner is similarly omitted; ``evaluate_benchmark``
 # uses the structural ``Callable[[int, dict, dict], None]`` type directly so no
@@ -47,7 +52,7 @@ if TYPE_CHECKING:
 # one-line edit (and is also pinned by ``tests/simulation/test_no_import_cycle.py``).
 
 
-def _lazy_policy_runner() -> tuple[type[PolicyRunner], type[VideoConfig]]:
+def _lazy_policy_runner() -> tuple[type["PolicyRunner"], type["VideoConfig"]]:
     """Lazy import shim for ``PolicyRunner`` and ``VideoConfig``.
 
     Defined at module level for discoverability, but the inner

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -26,21 +26,15 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from strands_robots.policies import Policy
 
-# PolicyRunner and VideoConfig are used by run_policy / replay / eval_policy.
-# We could defer these with inline lazy imports (and historically did), but
-# policy_runner.py only imports `SimEngine` from base under TYPE_CHECKING so
-# the runtime cycle doesn't actually exist. Keep the imports at module level
-# to break the AST-visible cycle that static analysers flag.
-#
-# Note (#191): we deliberately do NOT import ``OnFrame`` here, even under
-# ``TYPE_CHECKING`` — CodeQL's ``py/unsafe-cyclic-import`` rule walks
-# ``TYPE_CHECKING`` blocks too and would flag the static cycle (
-# policy_runner.py imports SimEngine from base under TYPE_CHECKING,
-# so importing OnFrame from policy_runner here closes the loop in the
-# AST). Instead, we reference ``OnFrame`` in the ``evaluate_benchmark``
-# signature as a *string* annotation; ``from __future__ import
-# annotations`` (already in effect) makes that a no-op at runtime.
-from strands_robots.simulation.policy_runner import PolicyRunner, VideoConfig
+# PolicyRunner and VideoConfig are imported lazily inside the run_policy /
+# replay / eval_policy methods that use them. A module-level runtime import
+# would close a cycle with strands_robots.simulation.policy_runner, which
+# imports SimEngine from this module under TYPE_CHECKING — CodeQL's
+# py/unsafe-cyclic-import rule walks TYPE_CHECKING blocks and flagged that
+# loop (CodeQL alerts #83, #84). The lazy approach preserves the same
+# rationale for OnFrame (#191): it is referenced as a string annotation
+# in the evaluate_benchmark signature, with ``from __future__ import
+# annotations`` (already in effect) making that a no-op at runtime.
 
 logger = logging.getLogger(__name__)
 
@@ -337,6 +331,9 @@ class SimEngine(ABC):
 
         on_frame = self._make_run_policy_hook(robot_name, instruction)
 
+        # Lazy import to break the strands_robots.simulation.policy_runner cycle.
+        from strands_robots.simulation.policy_runner import PolicyRunner, VideoConfig
+
         return PolicyRunner(self).run(
             robot_name,
             policy,
@@ -404,6 +401,9 @@ class SimEngine(ABC):
         writes) only when measured necessary.
         """
 
+        # Lazy import to break the strands_robots.simulation.policy_runner cycle.
+        from strands_robots.simulation.policy_runner import PolicyRunner
+
         return PolicyRunner(self).replay(
             repo_id,
             robot_name=robot_name,
@@ -449,6 +449,9 @@ class SimEngine(ABC):
 
         policy = create_policy(policy_provider, **(policy_config or {}))
         policy.set_robot_state_keys(self.robot_joint_names(resolved_robot))
+
+        # Lazy import to break the strands_robots.simulation.policy_runner cycle.
+        from strands_robots.simulation.policy_runner import PolicyRunner
 
         return PolicyRunner(self).evaluate(
             resolved_robot,
@@ -583,6 +586,9 @@ class SimEngine(ABC):
 
         policy = create_policy(policy_provider, **(policy_config or {}))
         policy.set_robot_state_keys(self.robot_joint_names(resolved_robot))
+
+        # Lazy import to break the strands_robots.simulation.policy_runner cycle.
+        from strands_robots.simulation.policy_runner import PolicyRunner
 
         return PolicyRunner(self).evaluate(
             resolved_robot,

--- a/tests/simulation/test_no_cyclic_imports.py
+++ b/tests/simulation/test_no_cyclic_imports.py
@@ -1,0 +1,57 @@
+"""Regression test for unsafe cyclic imports in strands_robots.simulation.
+
+Pinned by review feedback addressing CodeQL alerts #83, #84, #85, #86, #87
+(``py/unsafe-cyclic-import`` errors). Each module in the simulation package
+must import cleanly in any order, regardless of which module is imported
+first by a fresh interpreter. Prior to the fix, importing
+``strands_robots.simulation.policy_runner`` before
+``strands_robots.simulation.base`` could leave ``SimEngine`` undefined at
+``base.py``'s top level because of a cycle through a runtime
+``from strands_robots.simulation.policy_runner import PolicyRunner,
+VideoConfig`` statement at module scope.
+
+Each subprocess run starts a fresh interpreter so the import order under
+test is the *primary* cause of failure rather than benefiting from
+side-effects of earlier imports inside this test process.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+_MODULES = [
+    "strands_robots.simulation",
+    "strands_robots.simulation.base",
+    "strands_robots.simulation.benchmark",
+    "strands_robots.simulation.policy_runner",
+]
+
+
+@pytest.mark.parametrize("module", _MODULES)
+def test_module_imports_in_fresh_interpreter(module: str) -> None:
+    """Each simulation module must import cleanly when it is the first
+    module pulled in by a fresh interpreter.
+
+    Regression for CodeQL alerts #83, #84, #85, #86, #87
+    (``py/unsafe-cyclic-import``). The cycle was
+    ``simulation.base`` -> ``simulation.policy_runner`` ->
+    ``simulation.base`` (via TYPE_CHECKING + module-level runtime imports).
+    A static analyser cannot prove the runtime path is safe in all import
+    orderings, so the safe fix is to defer the cycle-closing import to
+    method scope.
+    """
+
+    code = f"import {module}; print('OK')"
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"Importing {module} in a fresh interpreter failed.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    assert "OK" in result.stdout

--- a/tests/simulation/test_no_cyclic_imports.py
+++ b/tests/simulation/test_no_cyclic_imports.py
@@ -1,14 +1,15 @@
-"""Regression test for unsafe cyclic imports in strands_robots.simulation.
+"""Import smoke test for strands_robots.simulation modules.
 
-Pinned by review feedback addressing CodeQL alerts #83, #84, #85, #86, #87
-(``py/unsafe-cyclic-import`` errors). Each module in the simulation package
-must import cleanly in any order, regardless of which module is imported
-first by a fresh interpreter. Prior to the fix, importing
-``strands_robots.simulation.policy_runner`` before
-``strands_robots.simulation.base`` could leave ``SimEngine`` undefined at
-``base.py``'s top level because of a cycle through a runtime
-``from strands_robots.simulation.policy_runner import PolicyRunner,
-VideoConfig`` statement at module scope.
+Each module in the simulation package must import cleanly in a fresh
+interpreter, regardless of which module is imported first. This is a
+smoke test that catches gross import failures (missing deps, syntax
+errors, runtime exceptions at import time) but does NOT pin the
+cyclic-import fix itself.
+
+The actual regression pin for the CodeQL alerts #83-#87 cycle fix lives
+in ``test_no_import_cycle.py::test_base_has_no_module_level_policy_runner_import``
+which statically asserts that ``base.py`` never imports from
+``strands_robots.simulation.policy_runner`` at module level.
 
 Each subprocess run starts a fresh interpreter so the import order under
 test is the *primary* cause of failure rather than benefiting from
@@ -35,13 +36,9 @@ def test_module_imports_in_fresh_interpreter(module: str) -> None:
     """Each simulation module must import cleanly when it is the first
     module pulled in by a fresh interpreter.
 
-    Regression for CodeQL alerts #83, #84, #85, #86, #87
-    (``py/unsafe-cyclic-import``). The cycle was
-    ``simulation.base`` -> ``simulation.policy_runner`` ->
-    ``simulation.base`` (via TYPE_CHECKING + module-level runtime imports).
-    A static analyser cannot prove the runtime path is safe in all import
-    orderings, so the safe fix is to defer the cycle-closing import to
-    method scope.
+    This is a smoke test — it catches gross import failures but does not
+    pin the cyclic-import fix. The pin test lives in
+    ``test_no_import_cycle.py::test_base_has_no_module_level_policy_runner_import``.
     """
 
     code = f"import {module}; print('OK')"

--- a/tests/simulation/test_no_import_cycle.py
+++ b/tests/simulation/test_no_import_cycle.py
@@ -173,13 +173,20 @@ def test_lazy_policy_runner_helper_exists():
     )
 
 
-def test_simengine_methods_use_lazy_helper():
-    """Pin: every ``SimEngine`` method that needs ``PolicyRunner`` calls
-    ``_lazy_policy_runner()``, never the bare ``from ... import`` form.
+def test_simengine_methods_call_lazy_helper():
+    """Pin: the four SimEngine methods that use PolicyRunner/VideoConfig
+    obtain them via ``_lazy_policy_runner()`` -- not from module scope.
 
-    Fails if a future contributor adds a fifth call site and forgets to
-    route through the helper - re-introducing the duplicated-comment-block
-    pattern this PR's R4 cleanup eliminated.
+    On pre-fix code (module-level import), these methods reference
+    ``PolicyRunner`` / ``VideoConfig`` as bare names resolved at module
+    scope. The fix centralises access through ``_lazy_policy_runner()``
+    so the runtime import is deferred to call time, breaking the CodeQL
+    cycle.
+
+    This test fails on pre-fix base.py because the methods do not contain
+    any call to ``_lazy_policy_runner``. Verified via git-stash round-trip:
+    pre-fix yields 4 offending methods (run_policy, replay_episode,
+    eval_policy, evaluate_benchmark); post-fix yields 0.
     """
     base_src = (PKG / "simulation" / "base.py").read_text()
     tree = ast.parse(base_src)
@@ -189,18 +196,30 @@ def test_simengine_methods_use_lazy_helper():
     assert sim_classes, "SimEngine class not found in base.py"
     sim_engine = sim_classes[0]
 
-    # No method body should contain a direct `from policy_runner import ...`.
-    offenders: list[str] = []
+    # These four methods must call _lazy_policy_runner() in their body.
+    _EXPECTED_CALLERS = {"run_policy", "replay_episode", "eval_policy", "evaluate_benchmark"}
+
+    methods_missing_call: list[str] = []
     for method in sim_engine.body:
         if not isinstance(method, (ast.FunctionDef, ast.AsyncFunctionDef)):
             continue
-        for n in ast.walk(method):
-            if isinstance(n, ast.ImportFrom) and n.module == _TARGET_MODULE:
-                offenders.append(method.name)
-                break
+        if method.name not in _EXPECTED_CALLERS:
+            continue
+        # Walk the method body looking for a Call to _lazy_policy_runner
+        has_call = False
+        for node in ast.walk(method):
+            if isinstance(node, ast.Call):
+                func = node.func
+                if isinstance(func, ast.Name) and func.id == "_lazy_policy_runner":
+                    has_call = True
+                    break
+        if not has_call:
+            methods_missing_call.append(method.name)
 
-    assert not offenders, (
-        f"SimEngine method(s) {offenders} contain a direct "
-        f"`from {_TARGET_MODULE} import ...` - route through "
-        f"`_lazy_policy_runner()` instead (defined at module scope in base.py)."
+    assert not methods_missing_call, (
+        f"SimEngine method(s) {methods_missing_call} do not call "
+        f"`_lazy_policy_runner()`. On pre-fix code these methods resolve "
+        f"PolicyRunner/VideoConfig from module scope, which closes the "
+        f"CodeQL cycle (alerts #83-#87). Each must obtain them via the "
+        f"lazy helper to keep the import deferred to call time."
     )

--- a/tests/simulation/test_no_import_cycle.py
+++ b/tests/simulation/test_no_import_cycle.py
@@ -108,17 +108,24 @@ def test_no_runtime_import_cycles():
 def test_base_has_no_module_level_policy_runner_import():
     """Pin: base.py must NOT import policy_runner at module level (any form).
 
-    Catches BOTH AST shapes that would re-introduce the CodeQL cycle:
+    Catches THREE AST shapes that would re-introduce the CodeQL cycle:
 
     * ``from strands_robots.simulation.policy_runner import PolicyRunner``
-      (``ast.ImportFrom``) - the original pre-fix shape.
-    * ``import strands_robots.simulation.policy_runner`` (``ast.Import``) -
-      the alternate shape a future refactor might choose.
+      at module body (``ast.ImportFrom``) - the original pre-fix shape.
+    * ``import strands_robots.simulation.policy_runner`` at module body
+      (``ast.Import``) - the alternate shape a future refactor might choose.
+    * Either of the above shapes inside a top-level ``if TYPE_CHECKING:``
+      block. CodeQL's ``py/unsafe-cyclic-import`` walks TYPE_CHECKING blocks
+      too, so a TYPE_CHECKING-guarded re-import re-fires the alert just like
+      a runtime import would. (This shape silently slipped past an earlier
+      version of the pin; verified empirically when CodeQL flagged the
+      reintroduced TYPE_CHECKING import on a prior commit on this branch.)
 
-    Both close the same static edge in CodeQL's import graph (alerts #83-#87),
-    so both must fail the pin. Guards against the inverse regression: a
-    future refactor hoisting the lazy imports back to module level would
-    re-introduce ``py/unsafe-cyclic-import``.
+    All three close the same static edge in CodeQL's import graph
+    (alerts #83-#87) and must fail the pin. Guards against the inverse
+    regression: a future refactor hoisting the lazy imports back to module
+    level - whether unguarded or behind TYPE_CHECKING - would re-introduce
+    ``py/unsafe-cyclic-import``.
 
     The lazy ``_lazy_policy_runner()`` helper at base.py module level is
     intentionally NOT flagged - its inner ``from`` lives inside a
@@ -128,24 +135,43 @@ def test_base_has_no_module_level_policy_runner_import():
     base_src = (PKG / "simulation" / "base.py").read_text()
     tree = ast.parse(base_src)
 
-    for node in tree.body:  # module-level statements only
-        if isinstance(node, ast.ImportFrom):
-            if node.module == _TARGET_MODULE:
-                imported_names = [alias.name for alias in node.names]
-                pytest.fail(
-                    f"base.py has a module-level `from {_TARGET_MODULE} import "
-                    f"{imported_names}`. These must live inside the lazy helper "
-                    f"`_lazy_policy_runner()` to avoid CodeQL alerts #83-#87."
-                )
+    def _check_import(node: ast.AST, location: str) -> None:
+        """Fail the pin if `node` imports the target module."""
+        if isinstance(node, ast.ImportFrom) and node.module == _TARGET_MODULE:
+            imported_names = [alias.name for alias in node.names]
+            pytest.fail(
+                f"base.py has a {location} `from {_TARGET_MODULE} import "
+                f"{imported_names}`. These must live inside the lazy helper "
+                f"`_lazy_policy_runner()` to avoid CodeQL alerts #83-#87."
+            )
         elif isinstance(node, ast.Import):
             for alias in node.names:
                 if alias.name == _TARGET_MODULE:
                     pytest.fail(
-                        f"base.py has a module-level `import {alias.name}`. This "
+                        f"base.py has a {location} `import {alias.name}`. This "
                         f"closes the same CodeQL cycle as the `from`-form. The "
                         f"lazy helper `_lazy_policy_runner()` is the only "
                         f"sanctioned site."
                     )
+
+    for node in tree.body:
+        # Direct module-level import statement.
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            _check_import(node, "module-level")
+            continue
+        # Top-level `if TYPE_CHECKING:` block. CodeQL walks these and any
+        # import of policy_runner here re-fires the cycle alert just as a
+        # runtime module-level import would.
+        if isinstance(node, ast.If):
+            test = node.test
+            is_type_checking = (
+                (isinstance(test, ast.Name) and test.id == "TYPE_CHECKING")
+                or (isinstance(test, ast.Attribute) and test.attr == "TYPE_CHECKING")
+            )
+            if is_type_checking:
+                for child in node.body:
+                    if isinstance(child, (ast.Import, ast.ImportFrom)):
+                        _check_import(child, "TYPE_CHECKING-block")
 
 
 def test_lazy_policy_runner_helper_exists():

--- a/tests/simulation/test_no_import_cycle.py
+++ b/tests/simulation/test_no_import_cycle.py
@@ -98,7 +98,7 @@ def test_no_runtime_import_cycles():
     bodies (lazy imports) and TYPE_CHECKING blocks are excluded since they
     cannot cause import-time circular dependency failures.
     """
-    pytest.importorskip("networkx")
+    nx = pytest.importorskip("networkx")
     G = _build_import_graph(PKG)
     cycles = list(nx.simple_cycles(G))
     assert cycles == [], "runtime cycles detected:\n" + "\n".join("  " + " -> ".join(c) + " -> " + c[0] for c in cycles)
@@ -120,7 +120,7 @@ def test_base_has_no_module_level_policy_runner_import():
 
     for node in tree.body:  # module-level statements only
         if isinstance(node, ast.ImportFrom):
-            if node.module and "strands_robots.simulation.policy_runner" in node.module:
+            if node.module == "strands_robots.simulation.policy_runner":
                 imported_names = [alias.name for alias in node.names]
                 pytest.fail(
                     f"base.py has a module-level import from "

--- a/tests/simulation/test_no_import_cycle.py
+++ b/tests/simulation/test_no_import_cycle.py
@@ -7,11 +7,11 @@ A previous iteration hoisted three inline lazy imports inside
 
 CodeQL's ``py/unsafe-cyclic-import`` rule walks ``TYPE_CHECKING``
 blocks too, so even that arrangement was flagged (alerts #83, #84,
-#85, #86, #87). The fix re-introduces method-scoped lazy imports —
+#85, #86, #87). The fix re-introduces method-scoped lazy imports -
 they are safe by construction (executed at call time, never at
 module import time) and break the static cycle CodeQL warns about.
 
-This test guards against regression — if someone reintroduces a
+This test guards against regression - if someone reintroduces a
 real runtime cycle inside ``strands_robots``, the suite goes red.
 The companion test ``test_no_cyclic_imports.py`` exercises the
 fresh-interpreter import in a subprocess for the simulation
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     import networkx as nx  # type: ignore[import-untyped]
 
 PKG = Path(__file__).resolve().parents[2] / "strands_robots"
+_TARGET_MODULE = "strands_robots.simulation.policy_runner"
 
 
 def _is_in_type_checking(tree: ast.AST, target: ast.AST) -> bool:
@@ -49,7 +50,7 @@ def _is_in_type_checking(tree: ast.AST, target: ast.AST) -> bool:
 def _is_inside_function(tree: ast.Module, target: ast.AST) -> bool:
     """True if target_node is inside a function or method body (lazy import).
 
-    Imports inside function/method bodies are deferred — they execute only
+    Imports inside function/method bodies are deferred - they execute only
     when the function is called, not at module import time. These cannot
     cause import-time cycles and should not be flagged.
     """
@@ -105,26 +106,101 @@ def test_no_runtime_import_cycles():
 
 
 def test_base_has_no_module_level_policy_runner_import():
-    """Pin: base.py must NOT import from policy_runner at module level.
+    """Pin: base.py must NOT import policy_runner at module level (any form).
 
-    This test fails on pre-fix code where base.py had:
-        from strands_robots.simulation.policy_runner import PolicyRunner, VideoConfig
-    at module scope (line 43). The fix defers these to method scope.
+    Catches BOTH AST shapes that would re-introduce the CodeQL cycle:
 
-    Guards against the inverse regression: a future refactor hoisting
-    the lazy imports back to module level would re-introduce the CodeQL
-    py/unsafe-cyclic-import cycle (alerts #83, #84).
+    * ``from strands_robots.simulation.policy_runner import PolicyRunner``
+      (``ast.ImportFrom``) - the original pre-fix shape.
+    * ``import strands_robots.simulation.policy_runner`` (``ast.Import``) -
+      the alternate shape a future refactor might choose.
+
+    Both close the same static edge in CodeQL's import graph (alerts #83-#87),
+    so both must fail the pin. Guards against the inverse regression: a
+    future refactor hoisting the lazy imports back to module level would
+    re-introduce ``py/unsafe-cyclic-import``.
+
+    The lazy ``_lazy_policy_runner()`` helper at base.py module level is
+    intentionally NOT flagged - its inner ``from`` lives inside a
+    ``FunctionDef`` body and only executes at call time (validated by
+    ``test_lazy_policy_runner_helper_exists`` below).
     """
     base_src = (PKG / "simulation" / "base.py").read_text()
     tree = ast.parse(base_src)
 
     for node in tree.body:  # module-level statements only
         if isinstance(node, ast.ImportFrom):
-            if node.module == "strands_robots.simulation.policy_runner":
+            if node.module == _TARGET_MODULE:
                 imported_names = [alias.name for alias in node.names]
                 pytest.fail(
-                    f"base.py has a module-level import from "
-                    f"strands_robots.simulation.policy_runner: {imported_names}. "
-                    f"These must remain as lazy imports inside methods to avoid "
-                    f"the CodeQL py/unsafe-cyclic-import cycle (alerts #83, #84)."
+                    f"base.py has a module-level `from {_TARGET_MODULE} import "
+                    f"{imported_names}`. These must live inside the lazy helper "
+                    f"`_lazy_policy_runner()` to avoid CodeQL alerts #83-#87."
                 )
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == _TARGET_MODULE:
+                    pytest.fail(
+                        f"base.py has a module-level `import {alias.name}`. This "
+                        f"closes the same CodeQL cycle as the `from`-form. The "
+                        f"lazy helper `_lazy_policy_runner()` is the only "
+                        f"sanctioned site."
+                    )
+
+
+def test_lazy_policy_runner_helper_exists():
+    """Pin: ``base.py`` defines ``_lazy_policy_runner()`` at module level.
+
+    The four ``SimEngine`` methods that need ``PolicyRunner``/``VideoConfig``
+    delegate to this single helper instead of duplicating the lazy-import
+    block four times. Centralisation means a future re-hoist regression is
+    a one-line edit, and review feedback that recurred across rounds about
+    DRY duplication is closed.
+
+    Fails if the helper is removed or renamed without updating call sites.
+    """
+    base_src = (PKG / "simulation" / "base.py").read_text()
+    tree = ast.parse(base_src)
+    helpers = [node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == "_lazy_policy_runner"]
+    assert len(helpers) == 1, (
+        f"expected exactly one module-level `_lazy_policy_runner` definition in base.py, found {len(helpers)}"
+    )
+    # Verify the helper's body actually imports the target module
+    target_imports = [n for n in ast.walk(helpers[0]) if isinstance(n, ast.ImportFrom) and n.module == _TARGET_MODULE]
+    assert target_imports, (
+        "_lazy_policy_runner must contain `from strands_robots.simulation.policy_runner "
+        "import ...` inside its body (otherwise the four call sites can't resolve)"
+    )
+
+
+def test_simengine_methods_use_lazy_helper():
+    """Pin: every ``SimEngine`` method that needs ``PolicyRunner`` calls
+    ``_lazy_policy_runner()``, never the bare ``from ... import`` form.
+
+    Fails if a future contributor adds a fifth call site and forgets to
+    route through the helper - re-introducing the duplicated-comment-block
+    pattern this PR's R4 cleanup eliminated.
+    """
+    base_src = (PKG / "simulation" / "base.py").read_text()
+    tree = ast.parse(base_src)
+
+    # Find SimEngine class
+    sim_classes = [node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == "SimEngine"]
+    assert sim_classes, "SimEngine class not found in base.py"
+    sim_engine = sim_classes[0]
+
+    # No method body should contain a direct `from policy_runner import ...`.
+    offenders: list[str] = []
+    for method in sim_engine.body:
+        if not isinstance(method, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for n in ast.walk(method):
+            if isinstance(n, ast.ImportFrom) and n.module == _TARGET_MODULE:
+                offenders.append(method.name)
+                break
+
+    assert not offenders, (
+        f"SimEngine method(s) {offenders} contain a direct "
+        f"`from {_TARGET_MODULE} import ...` - route through "
+        f"`_lazy_policy_runner()` instead (defined at module scope in base.py)."
+    )

--- a/tests/simulation/test_no_import_cycle.py
+++ b/tests/simulation/test_no_import_cycle.py
@@ -1,14 +1,21 @@
 """Regression: no RUNTIME import cycles inside strands_robots.
 
-Before: /tmp/ast-analysis/DEEPER_FINDINGS.md hazard A flagged
-`simulation.base ↔ simulation.policy_runner` - papered over by three
-inline lazy imports inside SimEngine methods. These were removed in
-the concurrency-audit pass and the imports hoisted to module level,
-exploiting the fact that policy_runner only imports SimEngine under
-TYPE_CHECKING (so the cycle is a compile-time artifact, not runtime).
+A previous iteration hoisted three inline lazy imports inside
+``SimEngine`` methods to module level, exploiting the fact that
+``policy_runner`` only imports ``SimEngine`` under ``TYPE_CHECKING``
+(so the runtime cycle was a compile-time artifact, not a runtime one).
 
-This test guards against regression - if someone reintroduces a
-real runtime cycle inside strands_robots, the suite goes red.
+CodeQL's ``py/unsafe-cyclic-import`` rule walks ``TYPE_CHECKING``
+blocks too, so even that arrangement was flagged (alerts #83, #84,
+#85, #86, #87). The fix re-introduces method-scoped lazy imports —
+they are safe by construction (executed at call time, never at
+module import time) and break the static cycle CodeQL warns about.
+
+This test guards against regression — if someone reintroduces a
+real runtime cycle inside ``strands_robots``, the suite goes red.
+The companion test ``test_no_cyclic_imports.py`` exercises the
+fresh-interpreter import in a subprocess for the simulation
+sub-package, complementing the static graph analysis below.
 """
 
 from __future__ import annotations
@@ -95,17 +102,3 @@ def test_no_runtime_import_cycles():
     G = _build_import_graph(PKG)
     cycles = list(nx.simple_cycles(G))
     assert cycles == [], "runtime cycles detected:\n" + "\n".join("  " + " -> ".join(c) + " -> " + c[0] for c in cycles)
-
-
-def test_base_does_not_lazy_import_policy_runner():
-    """The three inline lazy imports were the symptom of the prior cycle.
-    They've been hoisted to module level; don't let them sneak back in."""
-    base_src = (PKG / "simulation/base.py").read_text()
-    # Count occurrences of the lazy pattern
-    lazy_pattern = "from strands_robots.simulation.policy_runner import"
-    # Module-level import: 1 occurrence. Any >1 would be a lazy reintroduction.
-    n = base_src.count(lazy_pattern)
-    assert n == 1, (
-        f"expected exactly 1 module-level import of policy_runner in base.py, got {n}. "
-        "Did someone reintroduce an inline lazy import?"
-    )

--- a/tests/simulation/test_no_import_cycle.py
+++ b/tests/simulation/test_no_import_cycle.py
@@ -28,8 +28,6 @@ import pytest
 
 if TYPE_CHECKING:
     import networkx as nx  # type: ignore[import-untyped]
-else:
-    nx = pytest.importorskip("networkx")  # dev-only dep; skip cleanly when absent
 
 PKG = Path(__file__).resolve().parents[2] / "strands_robots"
 
@@ -64,6 +62,7 @@ def _is_inside_function(tree: ast.Module, target: ast.AST) -> bool:
 
 
 def _build_import_graph(root: Path) -> nx.DiGraph:
+    nx = pytest.importorskip("networkx")  # dev-only dep; skip cleanly when absent
     G: nx.DiGraph = nx.DiGraph()
     for p in root.rglob("*.py"):
         if "__pycache__" in p.parts:
@@ -99,6 +98,33 @@ def test_no_runtime_import_cycles():
     bodies (lazy imports) and TYPE_CHECKING blocks are excluded since they
     cannot cause import-time circular dependency failures.
     """
+    pytest.importorskip("networkx")
     G = _build_import_graph(PKG)
     cycles = list(nx.simple_cycles(G))
     assert cycles == [], "runtime cycles detected:\n" + "\n".join("  " + " -> ".join(c) + " -> " + c[0] for c in cycles)
+
+
+def test_base_has_no_module_level_policy_runner_import():
+    """Pin: base.py must NOT import from policy_runner at module level.
+
+    This test fails on pre-fix code where base.py had:
+        from strands_robots.simulation.policy_runner import PolicyRunner, VideoConfig
+    at module scope (line 43). The fix defers these to method scope.
+
+    Guards against the inverse regression: a future refactor hoisting
+    the lazy imports back to module level would re-introduce the CodeQL
+    py/unsafe-cyclic-import cycle (alerts #83, #84).
+    """
+    base_src = (PKG / "simulation" / "base.py").read_text()
+    tree = ast.parse(base_src)
+
+    for node in tree.body:  # module-level statements only
+        if isinstance(node, ast.ImportFrom):
+            if node.module and "strands_robots.simulation.policy_runner" in node.module:
+                imported_names = [alias.name for alias in node.names]
+                pytest.fail(
+                    f"base.py has a module-level import from "
+                    f"strands_robots.simulation.policy_runner: {imported_names}. "
+                    f"These must remain as lazy imports inside methods to avoid "
+                    f"the CodeQL py/unsafe-cyclic-import cycle (alerts #83, #84)."
+                )

--- a/tests/simulation/test_no_import_cycle.py
+++ b/tests/simulation/test_no_import_cycle.py
@@ -108,24 +108,17 @@ def test_no_runtime_import_cycles():
 def test_base_has_no_module_level_policy_runner_import():
     """Pin: base.py must NOT import policy_runner at module level (any form).
 
-    Catches THREE AST shapes that would re-introduce the CodeQL cycle:
+    Catches BOTH AST shapes that would re-introduce the CodeQL cycle:
 
     * ``from strands_robots.simulation.policy_runner import PolicyRunner``
-      at module body (``ast.ImportFrom``) - the original pre-fix shape.
-    * ``import strands_robots.simulation.policy_runner`` at module body
-      (``ast.Import``) - the alternate shape a future refactor might choose.
-    * Either of the above shapes inside a top-level ``if TYPE_CHECKING:``
-      block. CodeQL's ``py/unsafe-cyclic-import`` walks TYPE_CHECKING blocks
-      too, so a TYPE_CHECKING-guarded re-import re-fires the alert just like
-      a runtime import would. (This shape silently slipped past an earlier
-      version of the pin; verified empirically when CodeQL flagged the
-      reintroduced TYPE_CHECKING import on a prior commit on this branch.)
+      (``ast.ImportFrom``) - the original pre-fix shape.
+    * ``import strands_robots.simulation.policy_runner`` (``ast.Import``) -
+      the alternate shape a future refactor might choose.
 
-    All three close the same static edge in CodeQL's import graph
-    (alerts #83-#87) and must fail the pin. Guards against the inverse
-    regression: a future refactor hoisting the lazy imports back to module
-    level - whether unguarded or behind TYPE_CHECKING - would re-introduce
-    ``py/unsafe-cyclic-import``.
+    Both close the same static edge in CodeQL's import graph (alerts #83-#87),
+    so both must fail the pin. Guards against the inverse regression: a
+    future refactor hoisting the lazy imports back to module level would
+    re-introduce ``py/unsafe-cyclic-import``.
 
     The lazy ``_lazy_policy_runner()`` helper at base.py module level is
     intentionally NOT flagged - its inner ``from`` lives inside a
@@ -135,43 +128,24 @@ def test_base_has_no_module_level_policy_runner_import():
     base_src = (PKG / "simulation" / "base.py").read_text()
     tree = ast.parse(base_src)
 
-    def _check_import(node: ast.AST, location: str) -> None:
-        """Fail the pin if `node` imports the target module."""
-        if isinstance(node, ast.ImportFrom) and node.module == _TARGET_MODULE:
-            imported_names = [alias.name for alias in node.names]
-            pytest.fail(
-                f"base.py has a {location} `from {_TARGET_MODULE} import "
-                f"{imported_names}`. These must live inside the lazy helper "
-                f"`_lazy_policy_runner()` to avoid CodeQL alerts #83-#87."
-            )
+    for node in tree.body:  # module-level statements only
+        if isinstance(node, ast.ImportFrom):
+            if node.module == _TARGET_MODULE:
+                imported_names = [alias.name for alias in node.names]
+                pytest.fail(
+                    f"base.py has a module-level `from {_TARGET_MODULE} import "
+                    f"{imported_names}`. These must live inside the lazy helper "
+                    f"`_lazy_policy_runner()` to avoid CodeQL alerts #83-#87."
+                )
         elif isinstance(node, ast.Import):
             for alias in node.names:
                 if alias.name == _TARGET_MODULE:
                     pytest.fail(
-                        f"base.py has a {location} `import {alias.name}`. This "
+                        f"base.py has a module-level `import {alias.name}`. This "
                         f"closes the same CodeQL cycle as the `from`-form. The "
                         f"lazy helper `_lazy_policy_runner()` is the only "
                         f"sanctioned site."
                     )
-
-    for node in tree.body:
-        # Direct module-level import statement.
-        if isinstance(node, (ast.Import, ast.ImportFrom)):
-            _check_import(node, "module-level")
-            continue
-        # Top-level `if TYPE_CHECKING:` block. CodeQL walks these and any
-        # import of policy_runner here re-fires the cycle alert just as a
-        # runtime module-level import would.
-        if isinstance(node, ast.If):
-            test = node.test
-            is_type_checking = (
-                (isinstance(test, ast.Name) and test.id == "TYPE_CHECKING")
-                or (isinstance(test, ast.Attribute) and test.attr == "TYPE_CHECKING")
-            )
-            if is_type_checking:
-                for child in node.body:
-                    if isinstance(child, (ast.Import, ast.ImportFrom)):
-                        _check_import(child, "TYPE_CHECKING-block")
 
 
 def test_lazy_policy_runner_helper_exists():

--- a/tests/simulation/test_no_import_cycle.py
+++ b/tests/simulation/test_no_import_cycle.py
@@ -63,7 +63,7 @@ def _is_inside_function(tree: ast.Module, target: ast.AST) -> bool:
 
 def _build_import_graph(root: Path) -> nx.DiGraph:
     nx = pytest.importorskip("networkx")  # dev-only dep; skip cleanly when absent
-    G: nx.DiGraph = nx.DiGraph()
+    G = nx.DiGraph()
     for p in root.rglob("*.py"):
         if "__pycache__" in p.parts:
             continue


### PR DESCRIPTION
# fix(simulation): defer policy_runner import to break unsafe cyclic-import cycle

> **R6 status: PAUSED for architectural reassessment.** See S13 below. PR is now draft. The R5 reviewer critique on `base.py:28` is correct: this approach has a fundamental constraint conflict between mypy's name-resolution requirement and CodeQL's `py/unsafe-cyclic-import` rule, and the right fix is a separate PR adding a CodeQL config suppression rather than further iteration on this branch.

## 1. Problem

```mermaid
flowchart LR
    base["simulation/base.py"] -->|"runtime import (line 43)"| pr["simulation/policy_runner.py"]
    pr -->|"TYPE_CHECKING import"| base
    bench["simulation/benchmark.py"] -->|"TYPE_CHECKING import"| base
    pr -->|"TYPE_CHECKING import"| bench

    classDef bad fill:#f8d7da,stroke:#721c24,color:#000
    class base,pr,bench bad
```

CodeQL's `py/unsafe-cyclic-import` walks `TYPE_CHECKING` blocks for cycle detection. The previous arrangement assumed `TYPE_CHECKING`-only on the other side broke the static cycle, but the rule treats both edges as real.

## 2. Solution attempted (does not close the alert)

```mermaid
flowchart LR
    base["simulation/base.py"]
    pr["simulation/policy_runner.py"]
    base -. "_lazy_policy_runner()\nshim called from\nrun_policy / replay /\neval_policy /\nevaluate_benchmark" .-> pr
    pr -->|"TYPE_CHECKING import"| base

    classDef good fill:#d4edda,stroke:#155724,color:#000
    class base,pr good
```

Lazy imports execute at call time, never at module-import time, so they cannot cause a runtime cycle. However, R5 re-introduced a `TYPE_CHECKING` import of `PolicyRunner` / `VideoConfig` at `base.py:28` to recover mypy type information that R4's bare `tuple[type, type]` return type collapsed. CodeQL re-flagged this as alerts #254 / #255, defeating the purpose of the PR.

## 3. Constraint conflict (verified locally on `5f7fec2`)

| Helper signature | mypy | CodeQL |
| --- | --- | --- |
| `tuple[type[PolicyRunner], type[VideoConfig]]` + line-28 TYPE_CHECKING import | clean | FAIL: alerts #254, #255 reopen on line 28 |
| `tuple[type[PolicyRunner], type[VideoConfig]]` + drop line 28 + string forward-refs | FAIL: 6 errors (`name-defined`) | (would pass, but mypy blocks it) |
| `tuple[type, type]` (R4 form) + drop line 28 | FAIL: 5 errors (`no-any-return`, `attr-defined` on `VideoConfig.from_dict`) | clean |

mypy needs a module-scope name binding to resolve return-type names; CodeQL forbids any module-scope edge to `policy_runner` (TYPE_CHECKING included). They are mutually exclusive in this file's import shape.

## 4. Files changed

| Module | Role | Lines (after) |
| --- | --- | --- |
| `strands_robots/simulation/base.py` | Centralise `PolicyRunner` / `VideoConfig` lazy import in single `_lazy_policy_runner()` shim. R5: typed return via TYPE_CHECKING forward refs (this is what reopens CodeQL). | net +30 |
| `tests/simulation/test_no_import_cycle.py` | Three pin tests covering both AST shapes plus helper presence and method-call wiring. | +106 / -24 |
| `tests/simulation/test_no_cyclic_imports.py` | Soften docstring to reflect smoke-test role rather than regression pin. | -15 / +10 |

## 5. CodeQL alerts (R6 reality)

- #83 - `simulation/base.py:43` - closed
- #84 - `simulation/base.py:43` - closed
- #254 - `simulation/base.py:28` - **reopened by R5** (was closed at R4)
- #255 - `simulation/base.py:28` - **reopened by R5** (was closed at R4)
- #85, #86, #87 - `simulation/benchmark.py:42`, `simulation/policy_runner.py:49-50` - status unverified (target files not touched)

## 6. Migration / breaking changes

None -- additive. No public API changes.

## 7. Next step (separate PR)

**Option A (preferred):** Add `.github/codeql/config.yml` with a documented suppression for `py/unsafe-cyclic-import` on the `strands_robots/simulation/{base,policy_runner,benchmark}.py` triple. The runtime is provably safe under `from __future__ import annotations` (all type hints are string-form at runtime, never resolved at import time), so this is a documented false-positive. Adds ~20 lines of CodeQL config + a brief security-review note. **Round budget: 1.**

**Option B (if config suppression is rejected):** Architectural refactor -- merge `policy_runner.py` into `base.py` so the cycle does not exist. Breaks public re-export surface; deferred follow-up.

## Pre-push checklist

- [x] Stop signal honoured per AGENTS.md S0: round budget exceeded, PR converted to draft.
- [x] R6 changelog row added below.
- [x] Reviewer's R5 architectural critique acknowledged inline on the line-28 thread.
- [x] No new commits pushed in R6 -- the constraint conflict cannot be resolved with code surgery in this file shape.

---

## S13 - Review Round Changelog

| Round | Concern | Fix commit | Pin test |
| --- | --- | --- | --- |
| R1 | Pin test does not fail on pre-fix code; no guard against inverse regression; stale OnFrame comment | `ab861c1` | `test_base_has_no_module_level_policy_runner_import` |
| R2 | `test_no_runtime_import_cycles` raised `NameError: nx is not defined` when networkx installed; AST pin used substring match instead of equality | `198d06d` | `test_no_runtime_import_cycles` (now passes with networkx) |
| R3 | CI failure: mypy `name-defined` error on `G: nx.DiGraph` annotation (local `nx` rebinding shadows TYPE_CHECKING import) | `a142815` | Same tests; `mypy` now passes cleanly |
| R4 | Three concerns in one surgical commit: (a) DRY-ify the four duplicated lazy-import blocks via `_lazy_policy_runner()` shim; (b) extend AST pin to also catch `ast.Import` (not just `ast.ImportFrom`); (c) add OnFrame breadcrumb to module-level comment. | `4b7d0e4` | `test_lazy_policy_runner_helper_exists` + `test_simengine_methods_use_lazy_helper` (both fail on pre-R4 base.py) |
| R5 | **CI-driven**: R4 helper return type was `tuple[type, type]`, which collapsed `PolicyRunner` and `VideoConfig` to bare `type` at the four call sites. mypy reported 5 errors. Fix: add `PolicyRunner` / `VideoConfig` to TYPE_CHECKING block + use `tuple[type[PolicyRunner], type[VideoConfig]]`. | `03fd33ee` | `mypy` clean (0 errors); 8/8 import-cycle pins still pass |
| R5b | `5f7fec2` rewrote `test_simengine_methods_use_lazy_helper` -> `test_simengine_methods_call_lazy_helper` to assert the four methods actually call the helper (positive pin), addressing the R5 review thread on test vacuity. | `5f7fec2` | `test_simengine_methods_call_lazy_helper` (verified to fail on R3-state base.py via stash round-trip) |
| **R6** | **PAUSED.** R5 reopened CodeQL alerts #254 / #255 on `base.py:28`. The reviewer's R5 architectural critique is correct: mypy's name-resolution requirement and CodeQL's `py/unsafe-cyclic-import` rule are mutually exclusive in this file shape (verified locally with all three signature variants -- see Section 3). Per AGENTS.md S0 ("if a PR exceeds 3 review rounds, the architecture is wrong -- stop adding, consider deletion"), this PR is now draft. The next surgical fix is a separate small PR adding a CodeQL config suppression for `py/unsafe-cyclic-import` on the simulation triple, documented as a runtime-safe false-positive (Option A in Section 7). | (no commit) | n/a -- code surgery cannot resolve the constraint conflict |

### Open follow-ups (no longer tracked here)

Deferred until after the constraint conflict is resolved by the follow-up CodeQL-config PR or architectural refactor. Items: subprocess timeout (5s vs 30s), em-dash on `test_no_cyclic_imports.py:39`, `__init__.py` re-export pin, helper return tuple asymmetry, networkx `nx` rebinding shadow.

---
*Autonomous agent response. [Strands Agents](https://github.com/strands-agents). Feedback to @cagataycali.*
