### PR TITLE
security(codeql): suppress py/unsafe-cyclic-import on simulation triple (closes #215)

### DIFF
--- a/.github/codeql/README.md
+++ b/.github/codeql/README.md
@@ -16,8 +16,9 @@ The `queries:` key on `github/codeql-action/init` (set to
 selects which CodeQL query *suite* runs. The `config-file:` value points
 at this directory's `config.yml`, which defines `query-filters`.
 
-Per the [CodeQL Action docs][codeql-config-docs] and the comment that
-already lives at `.github/workflows/codeql-advanced.yml:78-79`:
+Per the [CodeQL Action docs][codeql-config-docs] and the
+"queries listed here will override any specified in a config file"
+comment block in `.github/workflows/codeql-advanced.yml`:
 
 - A workflow-level `queries:` value *replaces* a config-file-level
   `queries:` value unless the workflow value is prefixed with `+`.

--- a/.github/codeql/README.md
+++ b/.github/codeql/README.md
@@ -9,6 +9,30 @@ via the `config-file:` key on the `github/codeql-action/init` step.
 - `config.yml` -- query filter rules. See inline comments for per-rule
   rationale.
 
+## Query suite vs config-file interaction
+
+The `queries:` key on `github/codeql-action/init` (set to
+`security-and-quality` in `codeql.yml`, default in `codeql-advanced.yml`)
+selects which CodeQL query *suite* runs. The `config-file:` value points
+at this directory's `config.yml`, which defines `query-filters`.
+
+Per the [CodeQL Action docs][codeql-config-docs] and the comment that
+already lives at `.github/workflows/codeql-advanced.yml:78-79`:
+
+- A workflow-level `queries:` value *replaces* a config-file-level
+  `queries:` value unless the workflow value is prefixed with `+`.
+- `query-filters` from the config-file always layer *on top* of whichever
+  suite is active.
+
+`config.yml` here intentionally does not define a `queries:` key, so the
+workflow-selected suite (`security-and-quality` in `codeql.yml`) remains
+the active set; this config only contributes the `query-filters` layer.
+If a future contributor adds `queries:` to `config.yml`, the suite will
+*replace* the workflow's `security-and-quality` selection unless
+explicitly merged with `+queries: ...` in the workflow.
+
+[codeql-config-docs]: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/customizing-your-advanced-setup-for-code-scanning#using-a-custom-configuration-file
+
 ## Suppressed queries
 
 ### `py/unsafe-cyclic-import` (global)
@@ -46,8 +70,11 @@ The CodeQL-independent regression contract pins this invariant:
 - `tests/simulation/test_no_cyclic_imports.py` -- spawns a fresh Python
   interpreter for each of the three affected modules (and a combined
   one-process run) and asserts each imports cleanly with no
-  `RecursionError` / `ImportError`. Catches the dynamic-import failure
-  mode where a top-level statement reintroduces a partial-module re-entry.
+  `RecursionError` / `ImportError` traceback frames in stderr (anchored
+  on the start-of-line `ExceptionName:` framing rather than a substring
+  match, so benign log lines that mention the exception names by name
+  do not fail the pin). Catches the dynamic-import failure mode where
+  a top-level statement reintroduces a partial-module re-entry.
 - `tests/simulation/test_no_import_cycle.py::test_no_runtime_import_cycles`
   -- builds the runtime import graph (excluding `TYPE_CHECKING` and
   inside-function edges) via `networkx.simple_cycles` and asserts it is
@@ -75,6 +102,27 @@ guard against runtime cycles independent of CodeQL, and a future
 contributor who introduces a new legitimate violation should drop this
 suppression and fix the new cycle properly rather than extend the
 filter.
+
+**Periodic audit reminder:** the assumption that the simulation triple
+is the only file shape that fires this rule today drifts silently as
+the codebase grows. Maintainers should periodically (every minor
+release or every six months, whichever is sooner) enumerate what
+`py/unsafe-cyclic-import` would flag absent the filter, e.g. by running
+the CodeQL CLI locally with the suppression dropped:
+
+```bash
+# Drop the exclude block in .github/codeql/config.yml temporarily, then:
+codeql database create db --language=python --source-root=.
+codeql database analyze db \
+    codeql/python-queries:Imports/UnsafeCyclicImport.ql \
+    --format=sarif-latest --output=cyclic-import.sarif
+# Inspect cyclic-import.sarif: every result outside the simulation
+# triple is a candidate true-positive that the global exclude is
+# silently hiding.
+```
+
+If results outside the simulation triple appear, drop the suppression
+(or narrow it via path-scoped surgery) and fix the new cycle properly.
 
 **References:**
 

--- a/.github/codeql/README.md
+++ b/.github/codeql/README.md
@@ -1,0 +1,77 @@
+# CodeQL configuration
+
+This directory contains the CodeQL configuration consumed by both
+`.github/workflows/codeql.yml` and `.github/workflows/codeql-advanced.yml`
+via the `config-file:` key on the `github/codeql-action/init` step.
+
+## Files
+
+- `config.yml` -- query filter rules. See inline comments for per-rule
+  rationale.
+
+## Suppressed queries
+
+### `py/unsafe-cyclic-import` (global)
+
+**Why it fires:** the rule walks `if TYPE_CHECKING:` blocks for cycle
+detection. `strands_robots/simulation/{base,policy_runner,benchmark}.py`
+form a deliberate static-only cycle so `policy_runner` can call into the
+`SimEngine` ABC defined in `base`, while `base` can advertise
+`PolicyRunner`-typed return values to static checkers (mypy, IDE
+navigation, `typing.get_type_hints` consumers).
+
+**Why it is safe at runtime:** every file uses `from __future__ import
+annotations` (PEP 563). All type hints are string-form at runtime and
+are never resolved at module-import time. The lazy-import shim
+`_lazy_policy_runner()` defers the actual `PolicyRunner` / `VideoConfig`
+class lookup to call time, by which point both modules are fully
+loaded. Tests pin the runtime invariants:
+
+- `tests/simulation/test_no_cyclic_imports.py` -- spawns a fresh Python
+  interpreter for each of the four affected modules and asserts each
+  imports cleanly with no recursion error.
+- `tests/simulation/test_no_import_cycle.py::test_no_runtime_import_cycles`
+  -- builds the runtime import graph (excluding `TYPE_CHECKING` edges)
+  via `networkx.simple_cycles` and asserts it is acyclic.
+
+If the runtime cycle is ever reintroduced (e.g. by hoisting a lazy
+import to module scope), those pins fail loudly in CI -- independent of
+CodeQL's view of the AST.
+
+**Why a global suppression rather than path-scoped:** CodeQL's
+`query-filters` keys filter by `id` / `tags` / `precision` only;
+path-scoped exclusion of a single query is not supported (the only
+path-aware key is `paths-ignore`, which excludes a file from all
+queries -- too broad). The simulation triple is the only file shape in
+the repository where this query fires today, so a global exclude is
+equivalent in effect and keeps the config small. A future contributor
+who introduces a *new* legitimate violation in unrelated code would
+still want to know about it; in that case, drop this suppression and
+fix the new cycle properly.
+
+**References:**
+
+- PR #209 -- the multi-round attempt to satisfy CodeQL via code surgery.
+  Paused at draft after the constraint conflict between mypy and
+  `py/unsafe-cyclic-import` was confirmed locally; full analysis in
+  the S13/R6 changelog of that PR.
+- Issue #215 -- this follow-up tracking the suppression.
+- CodeQL alerts #83, #84 -- closed by PR #209 R4.
+- CodeQL alerts #85, #86, #87 -- in `benchmark.py:42` and
+  `policy_runner.py:49-50`; closed by this suppression.
+- CodeQL alerts #253, #254, #255 -- recurrent alerts on `base.py:28`
+  introduced by PR #209 R5 attempting to recover mypy type info; closed
+  by this suppression.
+
+## How to extend
+
+When adding a new suppression:
+
+1. Add the `query-filters` entry to `config.yml` with a thorough
+   inline comment explaining the rule, why it fires here, and why
+   the suppression is safe.
+2. Add a section to this README mirroring the inline comment, plus
+   the regression contract (pin tests, runtime-safety argument).
+3. Ensure the affected source files carry a top-of-file comment
+   pointing at the config, so future readers find the rationale
+   without grep-spelunking.

--- a/.github/codeql/README.md
+++ b/.github/codeql/README.md
@@ -20,23 +20,47 @@ form a deliberate static-only cycle so `policy_runner` can call into the
 `PolicyRunner`-typed return values to static checkers (mypy, IDE
 navigation, `typing.get_type_hints` consumers).
 
-**Why it is safe at runtime:** every file uses `from __future__ import
-annotations` (PEP 563). All type hints are string-form at runtime and
-are never resolved at module-import time. The lazy-import shim
-`_lazy_policy_runner()` defers the actual `PolicyRunner` / `VideoConfig`
-class lookup to call time, by which point both modules are fully
-loaded. Tests pin the runtime invariants:
+**Why it is safe at runtime:** the cycle is asymmetric, not closed.
+
+- `simulation/base.py:50` imports `PolicyRunner` and `VideoConfig` from
+  `simulation/policy_runner.py` at module level (the runtime edge that
+  static analysers see and flag).
+- `simulation/policy_runner.py:51-54` imports `SimEngine`,
+  `BenchmarkProtocol`, and `Policy` only under `if TYPE_CHECKING:`.
+  These are not real edges at import time -- `TYPE_CHECKING` is `False`
+  at runtime, the block is skipped, and the names exist only for the
+  static type system.
+- `simulation/benchmark.py:46-47` similarly imports `SimEngine` only
+  under `TYPE_CHECKING`.
+
+There is therefore no runtime back-edge from `policy_runner` (or
+`benchmark`) into `base`. `base` finishes importing cleanly before
+anything in `policy_runner` runs at module scope, so the cycle never
+closes at import time. `from __future__ import annotations` (PEP 563)
+on every affected file is the additional belt-and-braces guarantee
+that type-hint resolution itself never re-enters `base` or
+`policy_runner` via `typing.get_type_hints` consumers.
+
+The CodeQL-independent regression contract pins this invariant:
 
 - `tests/simulation/test_no_cyclic_imports.py` -- spawns a fresh Python
-  interpreter for each of the four affected modules and asserts each
-  imports cleanly with no recursion error.
+  interpreter for each of the three affected modules (and a combined
+  one-process run) and asserts each imports cleanly with no
+  `RecursionError` / `ImportError`. Catches the dynamic-import failure
+  mode where a top-level statement reintroduces a partial-module re-entry.
 - `tests/simulation/test_no_import_cycle.py::test_no_runtime_import_cycles`
-  -- builds the runtime import graph (excluding `TYPE_CHECKING` edges)
-  via `networkx.simple_cycles` and asserts it is acyclic.
+  -- builds the runtime import graph (excluding `TYPE_CHECKING` and
+  inside-function edges) via `networkx.simple_cycles` and asserts it is
+  acyclic. Catches the static-graph failure mode where someone hoists a
+  `TYPE_CHECKING` import to module scope and re-creates the cycle.
+- `tests/simulation/test_no_import_cycle.py::test_base_does_not_lazy_import_policy_runner`
+  -- counts module-level imports of `policy_runner` from `base.py` and
+  asserts the count stays at 1 (the documented module-level edge), so a
+  re-introduced inline lazy import inside a `SimEngine` method (the
+  prior bug shape) fails loudly.
 
-If the runtime cycle is ever reintroduced (e.g. by hoisting a lazy
-import to module scope), those pins fail loudly in CI -- independent of
-CodeQL's view of the AST.
+If the runtime cycle is ever reintroduced, those pins fail loudly in CI
+-- independent of CodeQL's view of the AST.
 
 **Why a global suppression rather than path-scoped:** CodeQL's
 `query-filters` keys filter by `id` / `tags` / `precision` only;
@@ -44,10 +68,13 @@ path-scoped exclusion of a single query is not supported (the only
 path-aware key is `paths-ignore`, which excludes a file from all
 queries -- too broad). The simulation triple is the only file shape in
 the repository where this query fires today, so a global exclude is
-equivalent in effect and keeps the config small. A future contributor
-who introduces a *new* legitimate violation in unrelated code would
-still want to know about it; in that case, drop this suppression and
-fix the new cycle properly.
+equivalent in effect *today* and keeps the config small. The cost we
+accept is that a future legitimate violation in unrelated code would
+be silently suppressed too. Mitigation: the regression pins above
+guard against runtime cycles independent of CodeQL, and a future
+contributor who introduces a new legitimate violation should drop this
+suppression and fix the new cycle properly rather than extend the
+filter.
 
 **References:**
 

--- a/.github/codeql/README.md
+++ b/.github/codeql/README.md
@@ -46,16 +46,18 @@ navigation, `typing.get_type_hints` consumers).
 
 **Why it is safe at runtime:** the cycle is asymmetric, not closed.
 
-- `simulation/base.py:50` imports `PolicyRunner` and `VideoConfig` from
-  `simulation/policy_runner.py` at module level (the runtime edge that
-  static analysers see and flag).
-- `simulation/policy_runner.py:51-54` imports `SimEngine`,
-  `BenchmarkProtocol`, and `Policy` only under `if TYPE_CHECKING:`.
-  These are not real edges at import time -- `TYPE_CHECKING` is `False`
-  at runtime, the block is skipped, and the names exist only for the
-  static type system.
-- `simulation/benchmark.py:46-47` similarly imports `SimEngine` only
-  under `TYPE_CHECKING`.
+- `simulation/base.py`'s top-level `from
+  strands_robots.simulation.policy_runner import PolicyRunner,
+  VideoConfig` is the runtime edge that static analysers see and flag.
+  (Cited by symbol rather than line number so future edits above the
+  import don't silently invalidate this rationale.)
+- `simulation/policy_runner.py`'s `if TYPE_CHECKING:` block imports
+  `SimEngine`, `BenchmarkProtocol`, and `Policy`. These are not real
+  edges at import time -- `TYPE_CHECKING` is `False` at runtime, the
+  block is skipped, and the names exist only for the static type
+  system.
+- `simulation/benchmark.py`'s `if TYPE_CHECKING:` block similarly
+  imports `SimEngine`.
 
 There is therefore no runtime back-edge from `policy_runner` (or
 `benchmark`) into `base`. `base` finishes importing cleanly before
@@ -132,11 +134,15 @@ If results outside the simulation triple appear, drop the suppression
   the S13/R6 changelog of that PR.
 - Issue #215 -- this follow-up tracking the suppression.
 - CodeQL alerts #83, #84 -- closed by PR #209 R4.
-- CodeQL alerts #85, #86, #87 -- in `benchmark.py:42` and
-  `policy_runner.py:49-50`; closed by this suppression.
-- CodeQL alerts #253, #254, #255 -- recurrent alerts on `base.py:28`
-  introduced by PR #209 R5 attempting to recover mypy type info; closed
-  by this suppression.
+- CodeQL alerts #85, #86, #87 -- raised by the rule against the
+  `if TYPE_CHECKING:` blocks in `benchmark.py` and `policy_runner.py`;
+  closed by this suppression. (Historical line numbers in the alert
+  bodies: `benchmark.py:42`, `policy_runner.py:49-50` at the SHA that
+  raised the alerts.)
+- CodeQL alerts #253, #254, #255 -- recurrent alerts on `base.py`'s
+  `if TYPE_CHECKING:` block introduced by PR #209 R5 attempting to
+  recover mypy type info; closed by this suppression. (Historical line
+  number: `base.py:28` at the SHA that raised the alerts.)
 
 ## How to extend
 

--- a/.github/codeql/config.yml
+++ b/.github/codeql/config.yml
@@ -1,0 +1,45 @@
+# CodeQL configuration for strands-robots.
+#
+# Wired into both .github/workflows/codeql.yml (CodeQL) and
+# .github/workflows/codeql-advanced.yml (CodeQL Advanced) via the
+# `config-file:` key on the `github/codeql-action/init` step.
+#
+# See .github/codeql/README.md for the full rationale per query exclusion.
+
+name: "strands-robots CodeQL config"
+
+# Inherit the default query suite selected per workflow (security-and-quality
+# in codeql.yml; default in codeql-advanced.yml). We layer query-filters on
+# top to suppress documented false-positives.
+query-filters:
+  # py/unsafe-cyclic-import:
+  #
+  # Globally suppressed. The rule walks `if TYPE_CHECKING:` blocks for cycle
+  # detection, which makes it fire on the deliberate static-only cycle in
+  # strands_robots/simulation/{base,policy_runner,benchmark}.py. The runtime
+  # is provably safe under `from __future__ import annotations` (PEP 563):
+  # all type hints are string-form at runtime and never resolved at
+  # module-import time. The cycle is structurally required so policy_runner
+  # can call into the SimEngine ABC defined in base while base can advertise
+  # PolicyRunner-typed return values for static checkers.
+  #
+  # This is the only file shape in the repository where the rule fires
+  # today; a global suppression keeps the config small and avoids per-path
+  # filter syntax (CodeQL `query-filters` only filters by id/tags, not by
+  # path). If the rule ever fires on an unrelated file, the matching CodeQL
+  # alert will still appear in the Security tab as long as the underlying
+  # query is available -- this filter only suppresses the alert surfacing,
+  # not the analysis itself.
+  #
+  # Regression contract: tests/simulation/test_no_cyclic_imports.py and
+  # tests/simulation/test_no_import_cycle.py pin the runtime-safety
+  # invariants (modules import cleanly in fresh interpreters; the static
+  # graph between base and policy_runner is acyclic at runtime). Those
+  # pins fail loudly if the runtime cycle is ever introduced, independent
+  # of CodeQL's view.
+  #
+  # Refs: PR #209 (paused, full constraint analysis in S13/R6); issue #215
+  # (this suppression); CodeQL alerts #83-#87, #253-#255 (the recurrent
+  # alerts the suppression closes).
+  - exclude:
+      id: py/unsafe-cyclic-import

--- a/.github/codeql/config.yml
+++ b/.github/codeql/config.yml
@@ -19,12 +19,12 @@ query-filters:
   # strands_robots/simulation/{base,policy_runner,benchmark}.py.
   #
   # Runtime is safe because the cycle is asymmetric, not closed:
-  # base.py:50 imports PolicyRunner / VideoConfig from policy_runner at
-  # module level (the runtime edge), but policy_runner.py:51-54 imports
-  # SimEngine / BenchmarkProtocol / Policy from base only under
-  # TYPE_CHECKING. There is no runtime back-edge that would close the
-  # cycle at import time. `from __future__ import annotations` (PEP 563)
-  # is additional belt-and-braces so type-hint resolution at runtime
+  # base.py's top-level ``from .policy_runner import PolicyRunner,
+  # VideoConfig`` statement is the only runtime edge. policy_runner.py
+  # imports SimEngine / BenchmarkProtocol / Policy from base only inside
+  # its ``if TYPE_CHECKING:`` block -- no runtime back-edge closes the
+  # cycle at import time. ``from __future__ import annotations`` (PEP
+  # 563) is additional belt-and-braces so type-hint resolution at runtime
   # never re-enters either module.
   #
   # This is the only file shape in the repository where the rule fires

--- a/.github/codeql/config.yml
+++ b/.github/codeql/config.yml
@@ -16,27 +16,35 @@ query-filters:
   #
   # Globally suppressed. The rule walks `if TYPE_CHECKING:` blocks for cycle
   # detection, which makes it fire on the deliberate static-only cycle in
-  # strands_robots/simulation/{base,policy_runner,benchmark}.py. The runtime
-  # is provably safe under `from __future__ import annotations` (PEP 563):
-  # all type hints are string-form at runtime and never resolved at
-  # module-import time. The cycle is structurally required so policy_runner
-  # can call into the SimEngine ABC defined in base while base can advertise
-  # PolicyRunner-typed return values for static checkers.
+  # strands_robots/simulation/{base,policy_runner,benchmark}.py.
+  #
+  # Runtime is safe because the cycle is asymmetric, not closed:
+  # base.py:50 imports PolicyRunner / VideoConfig from policy_runner at
+  # module level (the runtime edge), but policy_runner.py:51-54 imports
+  # SimEngine / BenchmarkProtocol / Policy from base only under
+  # TYPE_CHECKING. There is no runtime back-edge that would close the
+  # cycle at import time. `from __future__ import annotations` (PEP 563)
+  # is additional belt-and-braces so type-hint resolution at runtime
+  # never re-enters either module.
   #
   # This is the only file shape in the repository where the rule fires
-  # today; a global suppression keeps the config small and avoids per-path
-  # filter syntax (CodeQL `query-filters` only filters by id/tags, not by
-  # path). If the rule ever fires on an unrelated file, the matching CodeQL
-  # alert will still appear in the Security tab as long as the underlying
-  # query is available -- this filter only suppresses the alert surfacing,
-  # not the analysis itself.
+  # today; a global suppression keeps the config small and avoids
+  # path-scoped filter syntax (CodeQL `query-filters` only filters by
+  # id / tags / precision, not by path). The cost we accept is that a
+  # future legitimate violation in unrelated code is silently suppressed
+  # too. Mitigation: the regression pins below guard runtime-safety
+  # invariants independent of CodeQL, and a future contributor who hits
+  # a new legitimate violation should drop this suppression and fix the
+  # new cycle properly rather than extend the filter.
   #
   # Regression contract: tests/simulation/test_no_cyclic_imports.py and
   # tests/simulation/test_no_import_cycle.py pin the runtime-safety
-  # invariants (modules import cleanly in fresh interpreters; the static
-  # graph between base and policy_runner is acyclic at runtime). Those
-  # pins fail loudly if the runtime cycle is ever introduced, independent
-  # of CodeQL's view.
+  # invariants. The first spawns fresh interpreters and asserts each
+  # affected module imports cleanly with no RecursionError / ImportError;
+  # the second builds the runtime import graph (excluding TYPE_CHECKING
+  # and inside-function edges) and asserts it is acyclic. Both fail
+  # loudly if the runtime cycle is ever reintroduced, independent of
+  # CodeQL's view of the AST.
   #
   # Refs: PR #209 (paused, full constraint analysis in S13/R6); issue #215
   # (this suppression); CodeQL alerts #83-#87, #253-#255 (the recurrent

--- a/.github/workflows/codeql-advanced.yml
+++ b/.github/workflows/codeql-advanced.yml
@@ -71,6 +71,9 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
+        # Repo-level query filters (suppress documented false-positives).
+        # See .github/codeql/README.md for per-rule rationale.
+        config-file: ./.github/codeql/config.yml
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,6 +33,9 @@ jobs:
           # surfaced in PR #85 (MJCF interpolation) and PR #90 (subprocess
           # injection / path traversal).
           queries: security-and-quality
+          # Repo-level filters layered on top of the selected suite. See
+          # .github/codeql/README.md for per-rule rationale.
+          config-file: ./.github/codeql/config.yml
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@4e828ff8d448a8a6e532957b1811f387a63867e8  # v3.29.4

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -26,6 +26,13 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from strands_robots.policies import Policy
 
+# CodeQL: the AST cycle base <-> policy_runner is a documented false-positive
+# suppressed via .github/codeql/config.yml (py/unsafe-cyclic-import). The
+# runtime is provably safe under `from __future__ import annotations`
+# (PEP 563); pin tests in tests/simulation/test_no_cyclic_imports.py and
+# tests/simulation/test_no_import_cycle.py guard the runtime invariants.
+# See .github/codeql/README.md for the full rationale.
+#
 # PolicyRunner and VideoConfig are used by run_policy / replay / eval_policy.
 # We could defer these with inline lazy imports (and historically did), but
 # policy_runner.py only imports `SimEngine` from base under TYPE_CHECKING so

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -27,17 +27,33 @@ if TYPE_CHECKING:
     from strands_robots.policies import Policy
 
 # CodeQL: the AST cycle base <-> policy_runner is a documented false-positive
-# suppressed via .github/codeql/config.yml (py/unsafe-cyclic-import). The
-# runtime is provably safe under `from __future__ import annotations`
-# (PEP 563); pin tests in tests/simulation/test_no_cyclic_imports.py and
-# tests/simulation/test_no_import_cycle.py guard the runtime invariants.
+# suppressed via .github/codeql/config.yml (py/unsafe-cyclic-import).
 # See .github/codeql/README.md for the full rationale.
 #
-# PolicyRunner and VideoConfig are used by run_policy / replay / eval_policy.
-# We could defer these with inline lazy imports (and historically did), but
-# policy_runner.py only imports `SimEngine` from base under TYPE_CHECKING so
-# the runtime cycle doesn't actually exist. Keep the imports at module level
-# to break the AST-visible cycle that static analysers flag.
+# Why this is safe at runtime: the cycle is asymmetric, not closed.
+# This module imports ``PolicyRunner`` / ``VideoConfig`` at module level
+# (the runtime edge), but ``policy_runner.py`` imports ``SimEngine`` from
+# ``base`` only under ``TYPE_CHECKING``. There is no runtime back-edge
+# from ``policy_runner`` into this module, so the cycle never closes at
+# import time. Do NOT hoist the ``TYPE_CHECKING`` import in
+# ``policy_runner.py`` to module scope -- that would close the loop and
+# break ``import strands_robots.simulation.policy_runner`` with
+# ``ImportError: cannot import name 'SimEngine' from partially initialized
+# module ...``. ``from __future__ import annotations`` (PEP 563) is
+# additional belt-and-braces, but the asymmetric edge is what makes the
+# import work; PEP 563 only governs how type hints are resolved later.
+#
+# Pin tests guard this invariant independent of CodeQL:
+# - tests/simulation/test_no_cyclic_imports.py: spawns fresh interpreters
+#   per affected module and asserts each imports cleanly.
+# - tests/simulation/test_no_import_cycle.py: AST-builds the runtime
+#   import graph (excluding TYPE_CHECKING / inside-function edges) and
+#   asserts it is acyclic; also pins that this module keeps exactly one
+#   module-level import of policy_runner (re-introducing inline lazy
+#   imports inside SimEngine methods was the prior bug shape).
+#
+# PolicyRunner and VideoConfig are used by run_policy / replay /
+# eval_policy on this class.
 #
 # Note (#191): we deliberately do NOT import ``OnFrame`` here, even under
 # ``TYPE_CHECKING`` — CodeQL's ``py/unsafe-cyclic-import`` rule walks

--- a/strands_robots/simulation/benchmark.py
+++ b/strands_robots/simulation/benchmark.py
@@ -38,6 +38,10 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+# CodeQL: the AST cycle benchmark <-> base is suppressed via
+# .github/codeql/config.yml (py/unsafe-cyclic-import). The edge
+# exists only under TYPE_CHECKING; runtime is safe under PEP 563.
+# See .github/codeql/README.md.
 if TYPE_CHECKING:
     from strands_robots.simulation.base import SimEngine
 

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -44,6 +44,10 @@ import numpy as np
 from strands_robots._async_utils import _resolve_coroutine
 from strands_robots.utils import require_optional
 
+# CodeQL: the AST cycle policy_runner <-> base / benchmark is suppressed
+# via .github/codeql/config.yml (py/unsafe-cyclic-import). These edges
+# exist only under TYPE_CHECKING; runtime is safe under PEP 563.
+# See .github/codeql/README.md.
 if TYPE_CHECKING:
     from strands_robots.policies.base import Policy
     from strands_robots.simulation.base import SimEngine

--- a/tests/simulation/test_no_cyclic_imports.py
+++ b/tests/simulation/test_no_cyclic_imports.py
@@ -92,12 +92,10 @@ def test_module_imports_in_fresh_interpreter(module: str) -> None:
     # An import that "succeeds" (exit 0) but emits a RecursionError on
     # stderr from a swallowed inner frame is still a regression.
     assert "RecursionError" not in result.stderr, (
-        f"RecursionError surfaced during fresh-interpreter import of {module}:\n"
-        f"{result.stderr}"
+        f"RecursionError surfaced during fresh-interpreter import of {module}:\n{result.stderr}"
     )
     assert "ImportError" not in result.stderr, (
-        f"ImportError surfaced during fresh-interpreter import of {module}:\n"
-        f"{result.stderr}"
+        f"ImportError surfaced during fresh-interpreter import of {module}:\n{result.stderr}"
     )
 
 

--- a/tests/simulation/test_no_cyclic_imports.py
+++ b/tests/simulation/test_no_cyclic_imports.py
@@ -83,7 +83,15 @@ def _subprocess_env() -> dict[str, str]:
     parts = [p for p in sys.path if p]
     inherited = env.get("PYTHONPATH", "")
     if inherited:
-        parts.append(inherited)
+        # Split on pathsep and filter empty entries individually rather
+        # than appending the inherited string verbatim. POSIX interprets
+        # any empty pathsep entry (leading ``:foo``, trailing ``foo:``,
+        # interior ``foo::bar``) as the *current working directory*, so
+        # appending an inherited PYTHONPATH that already contains an
+        # internal empty would silently inject ``cwd`` into the child's
+        # ``sys.path`` even though we filter our own ``sys.path`` empties
+        # above.
+        parts.extend(p for p in inherited.split(os.pathsep) if p)
     env["PYTHONPATH"] = os.pathsep.join(parts)
     return env
 

--- a/tests/simulation/test_no_cyclic_imports.py
+++ b/tests/simulation/test_no_cyclic_imports.py
@@ -1,0 +1,126 @@
+"""Regression: simulation triple imports cleanly in fresh interpreters.
+
+Complement to ``tests/simulation/test_no_import_cycle.py``. Where that test
+asserts the *static* runtime-import graph (parsed from source) is acyclic,
+this test asserts the *dynamic* import actually succeeds in a clean Python
+process for each affected module.
+
+The two pins catch different failure modes:
+
+- A static-graph regression (e.g. someone hoists ``from .. import SimEngine``
+  out of a ``TYPE_CHECKING`` block in ``policy_runner.py``) is caught by
+  ``test_no_import_cycle.py``: the AST scan would re-add the ``policy_runner
+  -> base`` edge and the cycle would resurface.
+- A dynamic-import regression (e.g. a top-level statement in one of the
+  modules raises during import, or the import order produces a partial-module
+  ``ImportError`` only at process start) is caught here: the static graph
+  could remain acyclic while the *actual* import still fails. A subprocess
+  per module isolates each import from cached state in the test runner.
+
+Together they form the CodeQL-independent regression contract referenced
+from ``.github/codeql/config.yml`` and ``.github/codeql/README.md``.
+
+Pinned modules (the documented static-only cycle suppressed by
+``py/unsafe-cyclic-import``):
+
+- ``strands_robots.simulation.base``
+- ``strands_robots.simulation.policy_runner``
+- ``strands_robots.simulation.benchmark``
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+# The simulation triple that participates in the documented static-only
+# cycle. If a future suppression covers a new file shape, add it here so
+# the regression contract grows with the suppression list.
+_SIMULATION_TRIPLE: tuple[str, ...] = (
+    "strands_robots.simulation.base",
+    "strands_robots.simulation.policy_runner",
+    "strands_robots.simulation.benchmark",
+)
+
+
+def _subprocess_env() -> dict[str, str]:
+    """Env that keeps the parent ``sys.path`` visible to the child.
+
+    A bare ``python -c "import ..."`` in CI relies on the parent process's
+    ``sys.path`` (set by the editable install or the wheel install on the
+    runner). Rather than re-deriving that path, propagate it via
+    ``PYTHONPATH``: same module-resolution behaviour as the parent, but a
+    fresh ``sys.modules`` cache so the per-process import-time dynamics
+    are exercised honestly.
+    """
+    env = os.environ.copy()
+    # Prepend the inherited sys.path so child resolves modules the same way
+    # this test process does -- editable install, wheel install, or src/
+    # checkout. ``-I`` would strip these and produce a false positive.
+    env["PYTHONPATH"] = os.pathsep.join(p for p in sys.path if p) + os.pathsep + env.get("PYTHONPATH", "")
+    return env
+
+
+@pytest.mark.parametrize("module", _SIMULATION_TRIPLE)
+def test_module_imports_in_fresh_interpreter(module: str) -> None:
+    """Each module imports cleanly in a brand-new Python process.
+
+    Spawns ``python -c "import <module>"`` so the import is not contaminated
+    by the test runner's already-cached ``sys.modules``. Asserts exit code 0
+    and no ``RecursionError`` / ``ImportError`` traces in stderr; on failure
+    surfaces both for diagnosis.
+
+    The 30-second timeout guards against an infinite-recursion regression
+    (the precise failure mode this pin exists to catch) hanging the suite.
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", f"import {module}"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=_subprocess_env(),
+    )
+    assert result.returncode == 0, (
+        f"fresh-interpreter import of {module} failed (exit {result.returncode}).\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
+    # Surface any import-time recursion or partial-failure traces as well.
+    # An import that "succeeds" (exit 0) but emits a RecursionError on
+    # stderr from a swallowed inner frame is still a regression.
+    assert "RecursionError" not in result.stderr, (
+        f"RecursionError surfaced during fresh-interpreter import of {module}:\n"
+        f"{result.stderr}"
+    )
+    assert "ImportError" not in result.stderr, (
+        f"ImportError surfaced during fresh-interpreter import of {module}:\n"
+        f"{result.stderr}"
+    )
+
+
+def test_full_triple_imports_in_one_process() -> None:
+    """Importing all three modules in a single process also succeeds.
+
+    Catches the failure mode where each module imports cleanly in isolation
+    (the per-module test above passes) but the *combination* hits a
+    partial-module state -- e.g. ``base`` is mid-import, ``policy_runner``
+    is imported as a side-effect, and ``policy_runner`` then re-enters
+    ``base`` before its module dict is fully populated.
+    """
+    imports = "; ".join(f"import {m}" for m in _SIMULATION_TRIPLE)
+    result = subprocess.run(
+        [sys.executable, "-c", imports],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=_subprocess_env(),
+    )
+    assert result.returncode == 0, (
+        f"combined fresh-interpreter import of the simulation triple failed "
+        f"(exit {result.returncode}).\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )

--- a/tests/simulation/test_no_cyclic_imports.py
+++ b/tests/simulation/test_no_cyclic_imports.py
@@ -31,6 +31,7 @@ Pinned modules (the documented static-only cycle suppressed by
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 import sys
 
@@ -45,6 +46,18 @@ _SIMULATION_TRIPLE: tuple[str, ...] = (
     "strands_robots.simulation.benchmark",
 )
 
+# Traceback-shape regex for the regression assertions below. We anchor on
+# the start-of-line ``ExceptionName:`` framing that Python emits for an
+# uncaught traceback (and for chained ``raise from`` re-raises) rather than
+# substring-matching the bare exception name. Substring matching is too
+# loose: any benign log line, deprecation warning, or docstring snippet
+# that happens to mention ``ImportError`` / ``RecursionError`` (for
+# example, an optional-dep warning saying "...will raise ImportError on
+# Python 3.13...") would otherwise fail the pin even though the import
+# itself succeeded. The traceback frame is the only stderr shape that
+# *actually* indicates the failure mode this pin exists to catch.
+_TRACEBACK_EXC_PATTERN = re.compile(r"^(ImportError|RecursionError):", re.MULTILINE)
+
 
 def _subprocess_env() -> dict[str, str]:
     """Env that keeps the parent ``sys.path`` visible to the child.
@@ -55,12 +68,23 @@ def _subprocess_env() -> dict[str, str]:
     ``PYTHONPATH``: same module-resolution behaviour as the parent, but a
     fresh ``sys.modules`` cache so the per-process import-time dynamics
     are exercised honestly.
+
+    Empty entries in ``sys.path`` and an empty inherited ``PYTHONPATH`` are
+    filtered out before joining. POSIX interprets a leading, trailing, or
+    interior empty pathsep entry as the *current working directory*, which
+    on a CI runner is the checkout root: that would silently inject ``.``
+    into the child's ``sys.path`` and could mask a regression where a
+    module is only importable because ``cwd`` happens to contain it.
     """
     env = os.environ.copy()
-    # Prepend the inherited sys.path so child resolves modules the same way
-    # this test process does -- editable install, wheel install, or src/
-    # checkout. ``-I`` would strip these and produce a false positive.
-    env["PYTHONPATH"] = os.pathsep.join(p for p in sys.path if p) + os.pathsep + env.get("PYTHONPATH", "")
+    # Build the explicit path list: real entries from sys.path first, then
+    # the parent's PYTHONPATH if (and only if) it is set and non-empty.
+    # ``-I`` would strip these and produce a false positive.
+    parts = [p for p in sys.path if p]
+    inherited = env.get("PYTHONPATH", "")
+    if inherited:
+        parts.append(inherited)
+    env["PYTHONPATH"] = os.pathsep.join(parts)
     return env
 
 
@@ -70,8 +94,8 @@ def test_module_imports_in_fresh_interpreter(module: str) -> None:
 
     Spawns ``python -c "import <module>"`` so the import is not contaminated
     by the test runner's already-cached ``sys.modules``. Asserts exit code 0
-    and no ``RecursionError`` / ``ImportError`` traces in stderr; on failure
-    surfaces both for diagnosis.
+    and no ``RecursionError`` / ``ImportError`` traceback frames in stderr;
+    on failure surfaces both for diagnosis.
 
     The 30-second timeout guards against an infinite-recursion regression
     (the precise failure mode this pin exists to catch) hanging the suite.
@@ -89,13 +113,14 @@ def test_module_imports_in_fresh_interpreter(module: str) -> None:
         f"stderr:\n{result.stderr}"
     )
     # Surface any import-time recursion or partial-failure traces as well.
-    # An import that "succeeds" (exit 0) but emits a RecursionError on
-    # stderr from a swallowed inner frame is still a regression.
-    assert "RecursionError" not in result.stderr, (
-        f"RecursionError surfaced during fresh-interpreter import of {module}:\n{result.stderr}"
-    )
-    assert "ImportError" not in result.stderr, (
-        f"ImportError surfaced during fresh-interpreter import of {module}:\n{result.stderr}"
+    # An import that "succeeds" (exit 0) but emits a traceback on stderr
+    # from a swallowed inner frame is still a regression. The regex anchors
+    # on the start-of-line ``ExceptionName:`` framing so benign log lines
+    # that happen to mention these exception names by name do not fail
+    # the pin.
+    match = _TRACEBACK_EXC_PATTERN.search(result.stderr)
+    assert match is None, (
+        f"{match.group(1)} traceback surfaced during fresh-interpreter import of {module}:\n{result.stderr}"
     )
 
 
@@ -121,4 +146,9 @@ def test_full_triple_imports_in_one_process() -> None:
         f"(exit {result.returncode}).\n"
         f"stdout:\n{result.stdout}\n"
         f"stderr:\n{result.stderr}"
+    )
+    match = _TRACEBACK_EXC_PATTERN.search(result.stderr)
+    assert match is None, (
+        f"{match.group(1)} traceback surfaced during combined fresh-interpreter "
+        f"import of the simulation triple:\n{result.stderr}"
     )


### PR DESCRIPTION
# security(codeql): suppress py/unsafe-cyclic-import on simulation triple (closes #215)

> Closes #215. Resolves the supply-chain hygiene concern that surfaced repeatedly across PR #216 R1-R5 reviews and the major-version drift surfaced in #216 R3.

## 1. Problem

Two separate but coupled concerns:

1. **Floating tags in `codeql-advanced.yml`.** Three `uses:` references still pin to floating `@v4` tags, violating AGENTS.md > Review Learnings (PR #92) > Action Pinning: *"All `uses:` references in workflows pin to a full 40-character commit SHA, with the version tag preserved as a trailing comment."* This is the same supply-chain pattern exploited in the `tj-actions/changed-files` incident.
2. **Major-version drift between sister workflows.** After #216 landed, both `codeql.yml` and `codeql-advanced.yml` should run on the same major of `github/codeql-action`, but they pinned different *majors*:
   - `codeql.yml`: `init@4e828ff8...` / `analyze@4e828ff8...` (v3.29.4)
   - `codeql-advanced.yml`: `init@v4` / `analyze@v4` (floating)

   Different majors can produce divergent `query-filters` semantics or different SARIF post-processing.

## 2. Solution

This PR handles **only the CodeQL config suppression and its regression contract**. The SHA-pinning + major-alignment of `codeql-advanced.yml` is handled by the companion PR #234 (`ci: pin codeql-advanced.yml action SHAs and align CodeQL major`), which landed after this PR was filed.

## 3. What this PR delivers

- `.github/codeql/config.yml` — `query-filters: [{exclude: {id: py/unsafe-cyclic-import}}]`
- `.github/codeql/README.md` — full rationale, threat-model, periodic-audit recipe, historical alert tracker
- Both `codeql.yml` and `codeql-advanced.yml` wired to `config-file: ./.github/codeql/config.yml`
- Per-file breadcrumbs in `simulation/{base,policy_runner,benchmark}.py`
- `tests/simulation/test_no_cyclic_imports.py` — fresh-interpreter regression pin (4 parametrised tests)
- Existing `tests/simulation/test_no_import_cycle.py` — static AST-graph pin (unchanged)

## 4. Files changed

| File | Change | Lines |
| --- | --- | --- |
| `.github/codeql/config.yml` | New: suppress `py/unsafe-cyclic-import` globally | +53 |
| `.github/codeql/README.md` | New: rationale, threat model, audit recipe, alert history | +150 |
| `.github/workflows/codeql.yml` | Wire `config-file:` | +1 |
| `.github/workflows/codeql-advanced.yml` | Wire `config-file:` | +1 |
| `strands_robots/simulation/base.py` | Breadcrumb comment | +28 |
| `strands_robots/simulation/policy_runner.py` | Breadcrumb comment | +8 |
| `strands_robots/simulation/benchmark.py` | Breadcrumb comment | +6 |
| `tests/simulation/test_no_cyclic_imports.py` | New: fresh-interpreter pin test | +147 |

## 5. Acceptance criteria from #215

- [x] `py/unsafe-cyclic-import` suppressed globally via `query-filters`
- [x] Both workflows wired to the config
- [x] Per-file breadcrumbs warning against hoisting `TYPE_CHECKING` imports
- [x] Fresh-interpreter regression pin test
- [x] README with rationale + periodic audit recipe
- [ ] SHA pinning of floating tags in `codeql-advanced.yml` — **addressed by PR #234**
- [ ] Post-merge alert-closure verification (AC gate)

## 6. Companion PRs

- **#234** (`ci: pin codeql-advanced.yml action SHAs and align CodeQL major`) — Addresses the SHA-pinning + v3->v4 alignment concern raised repeatedly in R2-R5 of this PR. All threads on that topic are resolved by #234.
- **#235** — `.github/workflows/dependabot.yml` path fix (Dependabot ignores current location)
- **#237** — Workflow consolidation (deduplicate CI minutes from dual-workflow coverage)

## 7. Verification

```bash
# Pin tests pass on this checkout:
hatch run test tests/simulation/test_no_cyclic_imports.py tests/simulation/test_no_import_cycle.py -v

# YAML validates:
python3 -c 'import yaml; yaml.safe_load(open(".github/codeql/config.yml"))' && echo OK
```

---

## S13 -- Review Round Changelog

| Round | Concern | Fix Commit | Pin Test |
| --- | --- | --- | --- |
| R1 | Initial submission. Breadcrumb cited `_lazy_policy_runner()` (nonexistent). Pin test path wrong. Config comment self-contradicting. | `00cf48a` | `tests/simulation/test_no_cyclic_imports.py` (4 passed) |
| R2 | Substring-match too loose (false positives from benign log lines mentioning exception names). PYTHONPATH trailing pathsep injected cwd. | `963542b` | Same pin, regex anchored on `^(ExcName):` MULTILINE |
| R3 | Inherited PYTHONPATH internal empties still injected cwd. R2 commit fixed the fully-empty case but not `":foo"` / `"foo::bar"`. | `eaf1c57` | Same pin + `_subprocess_env()` now splits and filters inherited entries individually |
| R4 | No code change needed. Triage of 14 unresolved threads: (a) 4 threads on SHA-pinning/major-alignment -- directly addressed by companion PR #234; (b) 1 thread on PYTHONPATH filtering -- already fixed in R3 commit `eaf1c57`; (c) 9 threads are nits/follow-up scope (doc-drift line-number cites, assertion robustness, env-propagation allowlist, schema validation CI, global-suppression enforcement CI, stale Note(#191) consolidation, cross-reference accuracy). Follow-ups filed as appropriate. | (description-only) | (no behaviour change) |

---
*Autonomous agent submission. [Strands Agents](https://github.com/strands-agents). Feedback to @cagataycali.*