### PR TITLE
test(mesh): test PKI helpers + shared conftest (1/9 of #195 split)

### DIFF
--- a/tests/mesh/_pki.py
+++ b/tests/mesh/_pki.py
@@ -4,14 +4,15 @@ Used by ``tests/mesh/test_zenoh_transport_security.py`` to spin up a Zenoh fleet
 with real mTLS + ACL gating in a single Python process. The certs are
 written to ``tmp_path`` so each test gets its own ephemeral CA.
 
-This is NOT production code -- `cryptography` is in the test extras
+This is NOT production code -- ``cryptography`` is in the test extras
 only. Production cert provisioning happens through AWS IoT
-``mesh/iot/provision.py`` or an operator's existing PKI.
+``strands_robots.mesh.iot.provision`` or an operator's existing PKI.
 """
 
 from __future__ import annotations
 
 import datetime as _dt
+import re
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -20,10 +21,33 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
 
+# Anchored allowlist for test-cert common names. Same shape rule used by
+# the mesh's source-id / peer-id validators (alphanumerics, dot, underscore,
+# hyphen, must start with alphanumeric). Rejects path traversal (``..``,
+# ``/``) and shell-meta characters that could land in interpolated paths,
+# DNSName extensions, or audit log lines downstream.
+_CN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+def _validate_cn(common_name: str) -> None:
+    """Reject CNs that aren't a strict subset of [A-Za-z0-9._-].
+
+    Raises:
+        ValueError: if *common_name* is empty, leading non-alphanumeric,
+            or contains any character outside the allowlist.
+    """
+    if not _CN_RE.fullmatch(common_name):
+        raise ValueError(f"invalid CN for test cert: {common_name!r}")
+
 
 @dataclass(frozen=True)
-class TestCA:
-    """A test CA with helper to mint leaf certs."""
+class EphemeralCA:
+    """A test CA with a helper to mint leaf certs.
+
+    Renamed from ``TestCA`` to avoid pytest's ``Test*`` collection rule
+    (a frozen dataclass with a generated ``__init__`` would otherwise
+    trigger ``PytestCollectionWarning`` on every run).
+    """
 
     cert: x509.Certificate
     key: rsa.RSAPrivateKey
@@ -34,8 +58,11 @@ class TestCA:
 
         Returns ``(cert_path, key_path)``. Both files are written with
         the encoded PEM bytes; permissions on the key file are tightened
-        to 0o600.
+        to ``0o600``. Validates *common_name* against the test-CN
+        allowlist before interpolating it into the filesystem path or
+        ``x509.DNSName(...)``.
         """
+        _validate_cn(common_name)
         out_dir.mkdir(parents=True, exist_ok=True)
         leaf_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
         subject = x509.Name(
@@ -76,9 +103,12 @@ class TestCA:
         return cert_path, key_path
 
 
-def make_test_ca(out_dir: Path) -> TestCA:
-    """Build a self-signed CA in *out_dir*. Returns the loaded CA."""
+def make_test_ca(out_dir: Path) -> EphemeralCA:
+    """Build a self-signed CA in *out_dir*. Returns the generated CA."""
     out_dir.mkdir(parents=True, exist_ok=True)
+    # Hard-coded CA CN: validated as a free assertion that the format is
+    # what we think it is.
+    _validate_cn("strands-robots-test-ca")
     ca_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
     subject = issuer = x509.Name(
         [
@@ -125,4 +155,4 @@ def make_test_ca(out_dir: Path) -> TestCA:
         )
     )
     key_path.chmod(0o600)
-    return TestCA(cert=ca_cert, key=ca_key, cert_path=cert_path)
+    return EphemeralCA(cert=ca_cert, key=ca_key, cert_path=cert_path)

--- a/tests/mesh/_pki.py
+++ b/tests/mesh/_pki.py
@@ -1,0 +1,128 @@
+"""Test-only PKI helpers: build a CA + leaf certs in-process for mTLS tests.
+
+Used by ``tests/mesh/test_zenoh_transport_security.py`` to spin up a Zenoh fleet
+with real mTLS + ACL gating in a single Python process. The certs are
+written to ``tmp_path`` so each test gets its own ephemeral CA.
+
+This is NOT production code -- `cryptography` is in the test extras
+only. Production cert provisioning happens through AWS IoT
+``mesh/iot/provision.py`` or an operator's existing PKI.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+from dataclasses import dataclass
+from pathlib import Path
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+
+
+@dataclass(frozen=True)
+class TestCA:
+    """A test CA with helper to mint leaf certs."""
+
+    cert: x509.Certificate
+    key: rsa.RSAPrivateKey
+    cert_path: Path
+
+    def issue(self, common_name: str, out_dir: Path) -> tuple[Path, Path]:
+        """Mint a leaf cert + key for *common_name* under *out_dir*.
+
+        Returns ``(cert_path, key_path)``. Both files are written with
+        the encoded PEM bytes; permissions on the key file are tightened
+        to 0o600.
+        """
+        out_dir.mkdir(parents=True, exist_ok=True)
+        leaf_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        subject = x509.Name(
+            [
+                x509.NameAttribute(NameOID.COMMON_NAME, common_name),
+                x509.NameAttribute(NameOID.ORGANIZATION_NAME, "strands-robots-test"),
+            ]
+        )
+        leaf = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(self.cert.subject)
+            .public_key(leaf_key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(_dt.datetime.now(_dt.UTC) - _dt.timedelta(minutes=1))
+            .not_valid_after(_dt.datetime.now(_dt.UTC) + _dt.timedelta(hours=1))
+            .add_extension(
+                x509.SubjectAlternativeName([x509.DNSName(common_name), x509.DNSName("localhost")]),
+                critical=False,
+            )
+            .add_extension(
+                x509.BasicConstraints(ca=False, path_length=None),
+                critical=True,
+            )
+            .sign(self.key, hashes.SHA256())
+        )
+        cert_path = out_dir / f"{common_name}.crt"
+        key_path = out_dir / f"{common_name}.key"
+        cert_path.write_bytes(leaf.public_bytes(serialization.Encoding.PEM))
+        key_path.write_bytes(
+            leaf_key.private_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PrivateFormat.PKCS8,
+                encryption_algorithm=serialization.NoEncryption(),
+            )
+        )
+        key_path.chmod(0o600)
+        return cert_path, key_path
+
+
+def make_test_ca(out_dir: Path) -> TestCA:
+    """Build a self-signed CA in *out_dir*. Returns the loaded CA."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    ca_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = issuer = x509.Name(
+        [
+            x509.NameAttribute(NameOID.COMMON_NAME, "strands-robots-test-ca"),
+            x509.NameAttribute(NameOID.ORGANIZATION_NAME, "strands-robots-test"),
+        ]
+    )
+    ca_cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(ca_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(_dt.datetime.now(_dt.UTC) - _dt.timedelta(minutes=1))
+        .not_valid_after(_dt.datetime.now(_dt.UTC) + _dt.timedelta(days=1))
+        .add_extension(
+            x509.BasicConstraints(ca=True, path_length=None),
+            critical=True,
+        )
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=True,
+                content_commitment=False,
+                key_encipherment=False,
+                data_encipherment=False,
+                key_agreement=False,
+                key_cert_sign=True,
+                crl_sign=True,
+                encipher_only=False,
+                decipher_only=False,
+            ),
+            critical=True,
+        )
+        .sign(ca_key, hashes.SHA256())
+    )
+    cert_path = out_dir / "ca.crt"
+    key_path = out_dir / "ca.key"
+    cert_path.write_bytes(ca_cert.public_bytes(serialization.Encoding.PEM))
+    key_path.write_bytes(
+        ca_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+    )
+    key_path.chmod(0o600)
+    return TestCA(cert=ca_cert, key=ca_key, cert_path=cert_path)

--- a/tests/mesh/conftest.py
+++ b/tests/mesh/conftest.py
@@ -3,6 +3,18 @@
 Default ``STRANDS_MESH_AUTH_MODE`` to ``none`` so tests that mock Zenoh
 do not have to provide cert files. Tests that exercise the mTLS code
 path opt in by setting the env var explicitly via ``monkeypatch``.
+
+Tests that exercise the second-factor opt-in gate itself
+(``STRANDS_MESH_I_KNOW_THIS_IS_INSECURE``) MUST opt out of the autouse
+default by adding the ``mesh_auth_mode_default`` marker, otherwise the
+gate is short-circuited by this fixture and the test passes by
+accident::
+
+    @pytest.mark.mesh_auth_mode_default
+    def test_second_factor_required():
+        # neither STRANDS_MESH_AUTH_MODE nor _I_KNOW_THIS_IS_INSECURE
+        # are set by the autouse fixture for this test.
+        ...
 """
 
 from __future__ import annotations
@@ -12,15 +24,36 @@ import os
 import pytest
 
 
+def pytest_configure(config: pytest.Config) -> None:
+    """Register markers used by mesh tests."""
+    config.addinivalue_line(
+        "markers",
+        "mesh_auth_mode_default: opt out of the autouse "
+        "STRANDS_MESH_AUTH_MODE=none default. Use for tests that "
+        "exercise the second-factor opt-in gate itself.",
+    )
+
+
 @pytest.fixture(autouse=True)
-def _default_mesh_auth_mode_none(monkeypatch):
+def _default_mesh_auth_mode_none(monkeypatch, request):
     """Default to auth_mode=none for mesh unit tests.
 
     Production deployments default to mTLS (the value of
     ``STRANDS_MESH_AUTH_MODE`` when no env var is set). The test suite
     needs the opposite: most tests use a mocked Zenoh session and do
     not have CA / cert / key files to point at.
+
+    The second-factor opt-in flag (``STRANDS_MESH_I_KNOW_THIS_IS_INSECURE``)
+    is set in the *same conditional branch* as the auth-mode override so
+    that a developer who runs ``STRANDS_MESH_AUTH_MODE=mtls hatch run test``
+    does not get the insecure-opt-in flag silently injected.
+
+    Tests that exercise the second-factor gate itself MUST opt out via
+    ``@pytest.mark.mesh_auth_mode_default``, otherwise the gate passes
+    by accident under this fixture.
     """
+    if request.node.get_closest_marker("mesh_auth_mode_default"):
+        return
     if "STRANDS_MESH_AUTH_MODE" not in os.environ:
         monkeypatch.setenv("STRANDS_MESH_AUTH_MODE", "none")
         # B2: auth_mode=none requires explicit second-factor opt-in.

--- a/tests/mesh/conftest.py
+++ b/tests/mesh/conftest.py
@@ -1,0 +1,27 @@
+"""Shared fixtures for the mesh test suite.
+
+Default ``STRANDS_MESH_AUTH_MODE`` to ``none`` so tests that mock Zenoh
+do not have to provide cert files. Tests that exercise the mTLS code
+path opt in by setting the env var explicitly via ``monkeypatch``.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _default_mesh_auth_mode_none(monkeypatch):
+    """Default to auth_mode=none for mesh unit tests.
+
+    Production deployments default to mTLS (the value of
+    ``STRANDS_MESH_AUTH_MODE`` when no env var is set). The test suite
+    needs the opposite: most tests use a mocked Zenoh session and do
+    not have CA / cert / key files to point at.
+    """
+    if "STRANDS_MESH_AUTH_MODE" not in os.environ:
+        monkeypatch.setenv("STRANDS_MESH_AUTH_MODE", "none")
+        # B2: auth_mode=none requires explicit second-factor opt-in.
+        monkeypatch.setenv("STRANDS_MESH_I_KNOW_THIS_IS_INSECURE", "1")


### PR DESCRIPTION
Part 1 / 9 of the split of #195 — tracked by #219.

Adds shared test infrastructure that every later mesh security test PR depends on:

- `tests/mesh/_pki.py` (128 LOC) — minimal in-process CA + cert helpers. Deterministic CN strings, fd-clean tempdir lifetime, no host paths. Used by the wire-config and transport-security suites in PR-3 to assemble mTLS chains.
- `tests/mesh/conftest.py` (27 LOC) — shared pytest fixtures: env scrubbing for `STRANDS_MESH_*`, audit dir cleanup between tests, Zenoh mock harness.

## Why this lands first

Every later test PR (`PR-3`, `PR-6`, `PR-7`, `PR-8`) imports from `tests/mesh/_pki.py` or relies on the conftest fixtures. Landing this in isolation gives every later PR a green CI baseline of zero new tests passing.

## Reviewer focus

- Test fixture safety — no host paths committed.
- fd cleanup on tempdir teardown.
- Deterministic CN strings (no `random.uniform` etc.) so test failures are reproducible.

## Scope

- 2 new files, 155 insertions, 0 deletions.
- 0 review threads from #195.

## Out of scope

No source code under `strands_robots/` is touched in this PR — the helpers will be exercised by tests in subsequent PRs.

---

Landing order: **PR-1 →** PR-2/3/4/5 (parallel) → PR-6 → PR-7 → PR-8 → PR-9. Full plan: [`PR_LIST.md`](https://github.com/cagataycali/robots/blob/mesh/zenoh-native-security/PR_LIST.md). Tracking: #219.