### PR TITLE
mesh(core): replay caches + override-resume + safety topic handlers (6/9 of #195 split)

### DIFF
--- a/strands_robots/mesh/__init__.py
+++ b/strands_robots/mesh/__init__.py
@@ -10,8 +10,8 @@ Typical usage::
 
     mesh = init_mesh(robot, peer_id="arm-001")
     if mesh is not None:
-        print(mesh.alive)   # True
-        print(mesh.peers)   # discovered peers
+        print(mesh.alive)  # True
+        print(mesh.peers)  # discovered peers
         mesh.stop()
 
 Submodules
@@ -52,7 +52,7 @@ __all__ = [
     # Factory & registry
     "init_mesh",
     "get_local_robots",
-    # Session helpers (re-exported from .session for convenience)
+    # Session helpers (re-exported from.session for convenience)
     "put",
     "get_session",
     "release_session",

--- a/strands_robots/mesh/__init__.py
+++ b/strands_robots/mesh/__init__.py
@@ -52,7 +52,7 @@ __all__ = [
     # Factory & registry
     "init_mesh",
     "get_local_robots",
-    # Session helpers (re-exported from.session for convenience)
+    # Session helpers (re-exported from .session for convenience)
     "put",
     "get_session",
     "release_session",

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -8,6 +8,7 @@ Extended sensor loops (pose, IMU, health, etc.) are provided by
 from __future__ import annotations
 
 import base64
+import hashlib
 import hmac
 import json
 import logging
@@ -2226,11 +2227,39 @@ class Mesh(SensorLoopsMixin):
         expected = os.getenv("STRANDS_MESH_OVERRIDE_CODE", "").strip()
         provided = (override_code or "").strip()
         lockout_engaged = self._estop_lockout.is_set()
-        # Always perform the compare. If `expected` is empty, compare
-        # against a placeholder of the same byte length as the provided
-        # value so the compare runs to completion either way.
-        compare_target = expected.encode() if expected else b"\x00" * max(1, len(provided))
-        compare_ok = hmac.compare_digest(compare_target, provided.encode())
+        # Always perform the compare against fixed-length sha256 digests
+        # so the compare runs to completion regardless of:
+        #   * whether ``expected`` is configured,
+        #   * the byte length of either input.
+        # The previous formulation -- ``compare_digest(expected.encode()
+        # or b"\x00" * len(provided), provided.encode())`` -- closed the
+        # configured-vs-unconfigured oracle but left a residual
+        # ``len(expected) == len(provided)`` length oracle:
+        # ``hmac.compare_digest`` is documented constant-time only when
+        # both operands have equal length, and CPython returns a fast
+        # ``False`` on length mismatch. By pre-hashing both inputs to a
+        # fixed 32-byte digest before the compare, both length oracles
+        # collapse: the compare always runs over 32 bytes regardless of
+        # configuration or attacker probe length.
+        #
+        # The pre-hash uses sha256 (collision-resistant for the 32-byte
+        # output domain) so a digest collision is the only way for the
+        # compare to accept a wrong code; correctness is unchanged from
+        # the prior byte-equality check. When ``expected`` is empty the
+        # placeholder digest is the sha256 of a fixed sentinel value, so
+        # the compare always mismatches without paying a different-length
+        # cost.
+        _PROVIDED_HASH = hashlib.sha256(provided.encode()).digest()
+        if expected:
+            _EXPECTED_HASH = hashlib.sha256(expected.encode()).digest()
+        else:
+            # Sentinel digest: sha256(b"\x00" * 32) is a constant a
+            # remote prober cannot synthesise an override-code preimage
+            # for (it would require breaking sha256). Same byte length
+            # (32) as any real digest, so the compare-call cost is
+            # identical to the configured-code path.
+            _EXPECTED_HASH = hashlib.sha256(b"\x00" * 32).digest()
+        compare_ok = hmac.compare_digest(_EXPECTED_HASH, _PROVIDED_HASH)
 
         if not lockout_engaged:
             self.publish_safety_event(

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -406,7 +406,7 @@ class Mesh(SensorLoopsMixin):
         ImportError handling.
         """
         try:
-            from strands_robots.mesh import _acl_config, _zenoh_config
+            from strands_robots.mesh import _acl_config, _zenoh_config  # type: ignore[attr-defined,import-untyped]
         except ImportError:
             # PR-3 (`_acl_config` + `_zenoh_config`) not on the tree yet
             # -- gate is INACTIVE on PR-6 standalone. The gate becomes
@@ -886,7 +886,7 @@ class Mesh(SensorLoopsMixin):
         # Operators using ``=1`` / ``=yes`` / ``=on`` get the same
         # behaviour as ``=true``; bad values fail-loud rather than
         # silently re-enabling camera publishing on a privacy flag.
-        from strands_robots.mesh._zenoh_config import _bool_env as _zc_bool_env
+        from strands_robots.mesh._zenoh_config import _bool_env as _zc_bool_env  # type: ignore[import-untyped]
 
         if _zc_bool_env("STRANDS_MESH_CAMERA_DISABLED", default=False):
             return

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -205,8 +205,10 @@ def _evict_replay_cache[K](
     Callers own insertion and the per-cache lock; this helper is pure
     bookkeeping.
     """
-    if len(cache) < max_size:
-        return
+    # ALWAYS run the TTL purge -- on low-traffic meshes the cache may
+    # never reach max_size but stale entries still accumulate
+    # indefinitely (issue #274). The TTL purge is O(n) and bounded by
+    # the cache size, so it's cheap to run unconditionally.
     cutoff = now_mono - ttl_s
     stale = [k for k, ts in cache.items() if ts < cutoff]
     for k in stale:
@@ -1148,6 +1150,26 @@ class Mesh(SensorLoopsMixin):
                         "timestamp": time.time(),
                     },
                 )
+            # Audit the dispatch-error path so a remote prober cannot
+            # silently fish for adapter exceptions without leaving a
+            # forensic trail (issue #257). Reuses ``command_rejected``
+            # event_type with reason="dispatch error" to keep the
+            # operator audit-walker grep simple.
+            try:
+                log_safety_event(
+                    "command_rejected",
+                    self.peer_id,
+                    {
+                        "sender": sender,
+                        "reason": "dispatch error",
+                        "action": cmd.get("action") if isinstance(cmd, dict) else None,
+                    },
+                )
+            except (TypeError, ValueError, OSError) as audit_exc:
+                # Wrap audit emission in narrow except so an audit-sink
+                # failure on the dispatch-error path doesn't crash back
+                # through the mesh wire handler we just narrowed in R24-A.
+                logger.debug("[mesh] %s: audit log unavailable: %s", self.peer_id, audit_exc)
 
     def _dispatch(self, cmd: dict[str, Any]) -> dict[str, Any]:
         action = cmd.get("action", "status")
@@ -1602,11 +1624,24 @@ class Mesh(SensorLoopsMixin):
             else:
                 self._estop_replay_cache[cache_key] = (issuer_id, now_mono, wire_zid)
 
-        if not self._estop_lockout.is_set():
-            self._estop_lockout.set()
-            self._last_estop_ts = time.time()
-            self._last_estop_mono = time.monotonic()
-            sender = data.get("peer_id", "<remote>")
+            # Lockout state mutation must be inside _estop_replay_lock
+            # to close the concurrent-estops race (issue #273): two
+            # invocations from distinct issuers could both pass the
+            # is_set() check before either calls set() and both would
+            # publish remote_estop_engaged instead of one + one
+            # remote_estop_redundant. Mutating + reading
+            # _last_estop_ts/_last_estop_mono inside the lock also
+            # prevents the inconsistent timestamp pair the
+            # corroboration window check at line ~1492 depends on.
+            lockout_was_engaged = self._estop_lockout.is_set()
+            if not lockout_was_engaged:
+                self._estop_lockout.set()
+                self._last_estop_ts = time.time()
+                self._last_estop_mono = time.monotonic()
+            lockout_engaged_since = self._last_estop_ts
+
+        sender = data.get("peer_id", "<remote>")
+        if not lockout_was_engaged:
             logger.critical(
                 "[safety] %s: lockout engaged via remote estop from %s",
                 self.peer_id,
@@ -1635,7 +1670,7 @@ class Mesh(SensorLoopsMixin):
                     payload={
                         "issuer": data.get("peer_id"),
                         "issuer_t": envelope_t,
-                        "lockout_engaged_since": self._last_estop_ts,
+                        "lockout_engaged_since": lockout_engaged_since,
                     },
                 )
             except (TypeError, ValueError, OSError) as audit_exc:
@@ -1902,9 +1937,9 @@ class Mesh(SensorLoopsMixin):
             )
             self._resume_replay_cache[cache_key] = now_mono
 
+        sender = data.get("peer_id", "<remote>")
         if self._estop_lockout.is_set():
             self._estop_lockout.clear()
-            sender = data.get("peer_id", "<remote>")
             logger.warning("[safety] %s: lockout cleared via remote resume from %s", self.peer_id, sender)
             # audit the receiver-side resume transition. Mirrors
             # _on_safety_estop above so verify_audit_integrity walkers
@@ -1919,6 +1954,30 @@ class Mesh(SensorLoopsMixin):
                     "issuer_t": data.get("t"),
                 },
             )
+        else:
+            # Mirror the estop _redundant pattern: a successfully-validated
+            # resume that arrives on an already-cleared lockout still
+            # consumed a replay-cache slot, so forensics need the signal
+            # too (issue #271). Without this audit, a fleet audit-walker
+            # reconciling estop_engaged/resume_applied pairs has gaps for
+            # the case where multiple operators legitimately hit resume
+            # in close succession.
+            try:
+                self.publish_safety_event(
+                    event_type="remote_resume_redundant",
+                    severity="info",
+                    payload={
+                        "trigger": "remote",
+                        "issuer": sender,
+                        "issuer_t": data.get("t"),
+                    },
+                )
+            except (TypeError, ValueError, OSError) as audit_exc:
+                logger.debug(
+                    "[mesh] %s: remote_resume_redundant audit publish failed: %s",
+                    self.peer_id,
+                    audit_exc,
+                )
 
     # RPC -- outgoing
     def send(self, target: str, cmd: dict[str, Any], timeout: float = 30.0) -> dict[str, Any]:
@@ -2268,28 +2327,55 @@ class Mesh(SensorLoopsMixin):
             _EXPECTED_HASH = hashlib.sha256(b"\x00" * 32).digest()
         compare_ok = hmac.compare_digest(_EXPECTED_HASH, _PROVIDED_HASH)
 
+        # Issue #272: the structured ``reason`` field used to be published
+        # via ``publish_safety_event`` which fans out to
+        # ``strands/{peer_id}/safety/event`` -- any peer subscribed to
+        # ``strands/+/safety/event`` could read the rejection reason and
+        # use it as a content-channel oracle (lockout-not-engaged vs
+        # not-configured vs bad-code). Now we publish ONLY an opaque
+        # ``reason_code`` over the wire (uniform "denied" string) and
+        # write the structured reason to the LOCAL audit log via
+        # ``log_safety_event`` (file-backed; not broadcast).
+        # Issue #256: every rejection branch performs the same I/O
+        # work shape (one local audit + one wire publish) so the
+        # latency oracle collapses too.
+        def _emit_resume_denied(reason_text: str, severity: str) -> None:
+            try:
+                log_safety_event(
+                    "resume_denied",
+                    self.peer_id,
+                    {"sender_id": self.peer_id, "reason": reason_text, "severity": severity},
+                )
+            except (TypeError, ValueError, OSError) as audit_exc:
+                logger.debug(
+                    "[mesh] %s: resume_denied local audit failed: %s",
+                    self.peer_id,
+                    audit_exc,
+                )
+            try:
+                # Wire-broadcast carries ONLY the opaque code, no reason.
+                self.publish_safety_event(
+                    event_type="resume_denied",
+                    severity=severity,
+                    payload={"sender_id": self.peer_id, "reason_code": "denied"},
+                )
+            except (TypeError, ValueError, OSError) as audit_exc:
+                logger.debug(
+                    "[mesh] %s: resume_denied wire publish failed: %s",
+                    self.peer_id,
+                    audit_exc,
+                )
+
         if not lockout_engaged:
-            self.publish_safety_event(
-                event_type="resume_denied",
-                severity="info",
-                payload={"sender_id": self.peer_id, "reason": "lockout not engaged"},
-            )
+            _emit_resume_denied("lockout not engaged", "info")
             return _generic_error
 
         if not expected:
-            self.publish_safety_event(
-                event_type="resume_denied",
-                severity="warning",
-                payload={"sender_id": self.peer_id, "reason": "STRANDS_MESH_OVERRIDE_CODE not configured"},
-            )
+            _emit_resume_denied("STRANDS_MESH_OVERRIDE_CODE not configured", "warning")
             return _generic_error
 
         if not compare_ok:
-            self.publish_safety_event(
-                event_type="resume_denied",
-                severity="warning",
-                payload={"sender_id": self.peer_id, "reason": "bad override code"},
-            )
+            _emit_resume_denied("bad override code", "warning")
             return _generic_error
 
         elapsed = time.time() - self._last_estop_ts

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -333,7 +333,10 @@ class Mesh(SensorLoopsMixin):
         # Combined with the freshness check on the envelope ``t`` field
         # this closes the recorded-and-replayed-resume surface even when
         # an attacker has live ACL access on safety/**.
-        self._resume_replay_cache: dict[tuple[str, str], float] = {}
+        # Key shape: ((domain_tag, issuer), proof_nonce) where domain_tag is
+        # "wire" for TLS-bound Zenoh wire_zid or "body" for app-level issuer_id.
+        # Tuple-of-tuples prevents cross-transport namespace collision (R12).
+        self._resume_replay_cache: dict[tuple[tuple[str, str], str], float] = {}
         self._resume_replay_lock = threading.Lock()
         # estop replay defense -- mirror of resume cache, keyed on
         # (issuer_peer_id, envelope_t). Closes the captured-estop-replay DoS

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -2591,6 +2591,25 @@ class Mesh(SensorLoopsMixin):
             self._safety_sn[key] = sn
             return sn
 
+    def _strip_wire_zid(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Return a copy of *payload* without the wire-level ``source_zid``.
+
+        Used on the legacy ``put()`` fallback path: when no Zenoh
+        ``SourceInfo`` can be attached, a body that still advertises
+        ``source_zid`` is hard-rejected by the receiver (wire-absent +
+        body-present == "publisher stripped SourceInfo"). Removing the
+        body field makes the envelope match the receiver's
+        transport-agnostic accept-without-zid contract (availability
+        fix). The body-level HMAC binding still holds for non-Zenoh
+        transports because those never bound ``source_zid`` in the
+        first place (``_local_session_zid()`` returned ``None``).
+        """
+        if "source_zid" not in payload:
+            return payload
+        clean = dict(payload)
+        clean.pop("source_zid", None)
+        return clean
+
     def _publish_safety_envelope(self, key: str, payload: dict[str, Any]) -> None:
         """Publish a safety envelope with TLS-bound source attribution.
 
@@ -2621,12 +2640,12 @@ class Mesh(SensorLoopsMixin):
         """
         pub = self._safety_publisher_for(key)
         if pub is None:
-            put(key, payload)
+            put(key, self._strip_wire_zid(payload))
             return
         try:
             import zenoh
         except ImportError:
-            put(key, payload)
+            put(key, self._strip_wire_zid(payload))
             return
         sn = self._next_safety_sn(key)
         try:
@@ -2634,7 +2653,7 @@ class Mesh(SensorLoopsMixin):
         except (TypeError, AttributeError):
             # zenoh-python without the SourceInfo ctor (very old build);
             # fall back to body-level binding only.
-            put(key, payload)
+            put(key, self._strip_wire_zid(payload))
             return
         try:
             pub.put(json.dumps(payload).encode(), source_info=source_info)
@@ -2645,7 +2664,7 @@ class Mesh(SensorLoopsMixin):
                 key,
                 exc,
             )
-            put(key, payload)
+            put(key, self._strip_wire_zid(payload))
 
     def publish(self, key: str, payload: dict[str, Any]) -> None:
         """Publish *payload* on *key* via the mesh transport.

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -382,74 +382,112 @@ class Mesh(SensorLoopsMixin):
         return f"Mesh(peer_id={self.peer_id!r}, type={self.peer_type!r}, {state})"
 
     def _refuse_under_permissive_default_acl(self) -> bool:
-        """pre-session ACL posture gate.
+        """Refuse-to-start gate per issue #218.
 
-        Returns True if ``Mesh.start()`` MUST refuse to acquire a session
-        because the operator is running ``mtls + permissive default ACL``
-        without the ``STRANDS_MESH_ACCEPT_PERMISSIVE_ACL`` opt-in.
+        Returns True (refuse) when:
+        - STRANDS_MESH_AUTH_MODE == "mtls" (ACL is the third line of defence)
+        - AND the resolved ACL is permissive-by-shape (built-in default
+          or operator file with default_permission=allow + no rules)
+        - AND STRANDS_MESH_ACCEPT_PERMISSIVE_ACL is NOT set (operator
+          has not explicitly acknowledged the dev/lab posture).
 
-        An earlier placement was AFTER session acquisition + 6
-        subscriber declarations, which left the wire live with the
-        permissive ACL applied. This helper runs at the TOP of ``start()``
-        so a refusal returns BEFORE any wire activity.
+        Logs an ERROR breadcrumb on refusal so the operator sees the
+        actionable remediation paths (set ACL file / accept opt-in /
+        disable mesh).
+
+        On opt-in (STRANDS_MESH_ACCEPT_PERMISSIVE_ACL=1) the same shape
+        is logged at INFO instead of ERROR -- the operator has
+        acknowledged the posture and the WARNING contradicting their
+        opt-in would be noise.
+
+        Implementation note: when PR-3 (snapshot_acl) is on the tree
+        we use the TOCTOU-safe single-snapshot path; when PR-6 ships
+        standalone (PR-3 not yet merged) we fall back gracefully via
+        ImportError handling.
         """
         try:
-            from strands_robots.mesh._acl_config import is_default_acl_in_use
-            from strands_robots.mesh._zenoh_config import resolve_auth_mode
+            from strands_robots.mesh import _acl_config, _zenoh_config
+        except ImportError:
+            # PR-3 (`_acl_config` + `_zenoh_config`) not on the tree yet
+            # -- gate is INACTIVE on PR-6 standalone. The gate becomes
+            # active automatically when PR-3 lands and provides the
+            # config helpers. Fail-OPEN (allow start) so PR-6 can be
+            # tested in isolation before PR-3 lands; the production
+            # posture has both PRs and the gate is enforced.
+            return False
 
-            if not (resolve_auth_mode() == "mtls" and is_default_acl_in_use()):
-                return False
-        except (ImportError, ValueError) as warn_exc:
+        try:
+            auth_mode = _zenoh_config.resolve_auth_mode()
+            namespace = _zenoh_config.resolve_namespace()
+            # Prefer snapshot_acl (PR-3) when available; fall back to
+            # the legacy is_default_acl_in_use call so PR-6 can be
+            # tested standalone before PR-3 lands.
+            if hasattr(_acl_config, "snapshot_acl"):
+                is_permissive, _resolved = _acl_config.snapshot_acl(namespace)
+            else:
+                is_permissive = _acl_config.is_default_acl_in_use(namespace)
+        except ValueError as warn_exc:
+            # Narrow tuple per AGENTS.md > Review Learnings (#86):
+            # ValueError surfaces bad STRANDS_MESH_AUTH_MODE / unloadable
+            # ACL. Fail-CLOSED (treat as permissive) so the gate refuses
+            # to bring up the wire. Wider exception types (OSError, etc.)
+            # propagate so genuine bugs aren't masked at WARNING level.
             logger.warning(
-                "[mesh] %s: ACL posture check raised %s: %s -- permissive-ACL gate may be missing; investigate",
+                "[mesh] %s: ACL gate evaluation failed (%s) -- treating as permissive default; refusing to start",
                 self.peer_id,
-                type(warn_exc).__name__,
                 warn_exc,
             )
+            auth_mode = "mtls"
+            is_permissive = True
+        if auth_mode != "mtls":
+            return False
+        if not is_permissive:
             return False
 
-        accept = os.getenv("STRANDS_MESH_ACCEPT_PERMISSIVE_ACL", "").strip().lower()
-        if accept in ("1", "true", "yes"):
+        accept_permissive = os.getenv("STRANDS_MESH_ACCEPT_PERMISSIVE_ACL", "").strip().lower() in (
+            "1",
+            "true",
+            "yes",
+        )
+        if accept_permissive:
             logger.info(
                 "[mesh] %s: permissive default ACL active under mtls "
-                "(operator opted in via STRANDS_MESH_ACCEPT_PERMISSIVE_ACL).",
+                "(STRANDS_MESH_ACCEPT_PERMISSIVE_ACL=1 acknowledged) -- "
+                "starting in dev/lab posture",
                 self.peer_id,
             )
             return False
 
-        msg = (
-            "PERMISSIVE DEFAULT ACL ACTIVE UNDER MTLS -- any "
-            "CA-signed peer would be able to publish on **/cmd and "
-            "**/safety/**. This combination turns a single compromised "
-            "cert into a fleet-wide command pivot. Mesh NOT STARTED. "
-            "Either:\n"
-            "  1. Set STRANDS_MESH_ACL_FILE to a literal-CN ACL file "
-            "     enumerating role separation (production posture; see "
-            "     examples/mesh_acl_example.json5).\n"
+        logger.error(
+            "[mesh] %s: PERMISSIVE DEFAULT ACL ACTIVE UNDER MTLS -- "
+            "Mesh NOT STARTED. Any CA-signed peer can publish/subscribe "
+            "on any key. Remediate one of:\n"
+            "  1. Supply STRANDS_MESH_ACL_FILE pointing at a role-separated "
+            "ACL (see examples/mesh_acl_example.json5).\n"
             "  2. Set STRANDS_MESH_ACCEPT_PERMISSIVE_ACL=1 to acknowledge "
-            "     the dev/lab posture explicitly (single-tenant only).\n"
-            "  3. Set STRANDS_MESH=false to disable the mesh entirely."
+            "the dev/lab posture.\n"
+            "  3. Disable the mesh (do not call Mesh.start()).",
+            self.peer_id,
         )
-        logger.error("[mesh] %s: %s", self.peer_id, msg)
         return True
 
     # Lifecycle
     def start(self) -> None:
-        """Acquire a Zenoh session and start all publishing loops.
-
-        the permissive-ACL refuse gate runs
-        BEFORE ``get_session()`` so a refusal short-circuits without
-        touching the wire (prior regression where the gate fired
-        post-session-acquisition is now closed).
-        """
+        """Acquire a Zenoh session and start all publishing loops."""
         with self._lifecycle_lock:
             if self._running:
                 return
 
-            # pre-session ACL posture gate. If this returns True,
-            # the operator has not opted in to the dangerous combination
-            # and we MUST NOT acquire a session.
+            # Issue #218 / R3: refuse-to-start gate when mtls is configured
+            # but the ACL is permissive-by-shape (built-in default OR
+            # operator file with default_permission=allow). The gate
+            # closes the "fleet thinks mTLS protects them, but ACL is
+            # wide open" silent-misconfiguration footgun. Operators who
+            # explicitly accept the dev/lab posture set
+            # STRANDS_MESH_ACCEPT_PERMISSIVE_ACL=1.
             if self._refuse_under_permissive_default_acl():
+                # Logged at ERROR; mesh stays not-started (mesh.alive == False).
+                # Caller's Robot() construction succeeds; only the wire is gated.
                 return
 
             session = get_session()

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -8,6 +8,7 @@ Extended sensor loops (pose, IMU, health, etc.) are provided by
 from __future__ import annotations
 
 import base64
+import hmac
 import json
 import logging
 import os
@@ -19,6 +20,8 @@ import uuid
 from collections.abc import Callable
 from typing import Any
 
+from strands_robots.mesh import security as _security
+from strands_robots.mesh.audit import log_safety_event
 from strands_robots.mesh.sensors import SensorLoopsMixin
 from strands_robots.mesh.session import (
     CAMERA_HZ,
@@ -49,6 +52,221 @@ def get_local_robots() -> dict[str, Mesh]:
         return dict(_LOCAL_ROBOTS)
 
 
+#: Sentinel stored in :attr:`Mesh._expected_responders` for
+#: broadcast turn_ids. Distinct from any real peer_id (no peer_id
+#: contains a NUL byte).
+BROADCAST_RESPONDER: str = "<broadcast>\x00"
+
+
+def _parse_positive_float_env(name: str, default: str, *, minimum: float = 0.0) -> float:
+    """Parse a positive-float env var, falling back to default on bad input.
+
+    Catches the case where an operator sets ``STRANDS_MESH_RESUME_FRESHNESS_S=abc``
+    or a negative value. The module would otherwise fail to import with an opaque
+    ``ValueError`` (found by running the module under bad env locally; see
+    ``test_resume_env_validation.py``).
+    """
+    raw = os.getenv(name, default)
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid %s=%r (not a float); falling back to default %r.",
+            name,
+            raw,
+            default,
+        )
+        return float(default)
+    if value < minimum:
+        logger.warning(
+            "Invalid %s=%r (must be >= %s); falling back to default %r.",
+            name,
+            value,
+            minimum,
+            default,
+        )
+        return float(default)
+    return value
+
+
+def _parse_positive_int_env(name: str, default: str, *, minimum: int = 1) -> int:
+    """Parse a positive-int env var, falling back to default on bad input.
+
+    Companion to :func:`_parse_positive_float_env` for cache-size knobs.
+    Rejects zero / negative because ``deque(maxlen=0)`` would silently disable
+    the replay cache and ``maxlen=-1`` would raise at runtime.
+    """
+    raw = os.getenv(name, default)
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid %s=%r (not an int); falling back to default %r.",
+            name,
+            raw,
+            default,
+        )
+        return int(default)
+    if value < minimum:
+        logger.warning(
+            "Invalid %s=%r (must be >= %s); falling back to default %r.",
+            name,
+            value,
+            minimum,
+            default,
+        )
+        return int(default)
+    return value
+
+
+#: Default resume-envelope freshness window. Envelopes whose t field
+#: is older than this are rejected as potential replays. Operators
+#: on drifty NTP can extend via STRANDS_MESH_RESUME_FRESHNESS_S
+#: (sane bound: keep < 600). Bad input falls back to 60.
+#:
+#: the module-level value below is captured
+#: once at import time for backward compatibility with code/tests
+#: that read these as constants. The runtime hot paths
+#: (:meth:`Mesh._on_safety_estop`, :meth:`Mesh._on_safety_resume`)
+#: now call :func:`_resume_freshness_window_s` etc. on every call so
+#: an operator setting STRANDS_MESH_RESUME_* AFTER importing the
+#: module sees the new value without a process restart. The README
+#: contract ("operator-tunable env vars") now actually holds.
+RESUME_FRESHNESS_WINDOW_S: float = _parse_positive_float_env("STRANDS_MESH_RESUME_FRESHNESS_S", "60")
+
+#: Forward-skew tolerance on the envelope t field. See
+#: :data:`RESUME_FRESHNESS_WINDOW_S` for the lazy-resolution note.
+RESUME_FORWARD_SKEW_S: float = _parse_positive_float_env("STRANDS_MESH_RESUME_FORWARD_SKEW_S", "5")
+
+#: Maximum entries in the per-receiver resume replay cache.
+#: See :data:`RESUME_FRESHNESS_WINDOW_S` for lazy-resolution note.
+RESUME_REPLAY_CACHE_MAX: int = _parse_positive_int_env("STRANDS_MESH_RESUME_REPLAY_CACHE_MAX", "4096")
+
+
+def _resume_freshness_window_s() -> float:
+    """Lazy resolver for ``STRANDS_MESH_RESUME_FRESHNESS_S``.
+
+    re-reads the env var on every call so operator-set values
+    take effect without a process restart. Cheap (one ``os.getenv``
+    + a regex parse via ``_parse_positive_float_env``) and called
+    only on safety-handler entry, which is bounded by the transport
+    rate cap.
+    """
+    return _parse_positive_float_env("STRANDS_MESH_RESUME_FRESHNESS_S", "60")
+
+
+def _resume_forward_skew_s() -> float:
+    """Lazy resolver for ``STRANDS_MESH_RESUME_FORWARD_SKEW_S``."""
+    return _parse_positive_float_env("STRANDS_MESH_RESUME_FORWARD_SKEW_S", "5")
+
+
+def _resume_replay_cache_max() -> int:
+    """Lazy resolver for ``STRANDS_MESH_RESUME_REPLAY_CACHE_MAX``."""
+    return _parse_positive_int_env("STRANDS_MESH_RESUME_REPLAY_CACHE_MAX", "4096")
+
+
+def _evict_replay_cache[K](
+    cache: dict[K, float],
+    *,
+    max_size: int,
+    ttl_s: float,
+    now_mono: float,
+) -> None:
+    """Bound *cache* to ``max_size`` entries in-place.
+
+    Eviction strategy (single-pass, no-op when the cache is below the cap):
+
+    1. Drop entries whose stored monotonic timestamp is older than
+       ``now_mono - ttl_s`` (TTL purge).
+    2. If the cache is still over budget after the TTL purge (cap is full
+       of in-window entries -- active flood), drop the oldest 20 percent
+       by stored timestamp.
+
+    Caller is responsible for passing the right ``ttl_s``. the safety-replay caches now pass
+    ``RESUME_FRESHNESS_WINDOW_S + RESUME_FORWARD_SKEW_S`` so an
+    accepted forward-skewed envelope (``t = now + skew``) stays in the
+    cache for the full ``freshness + skew`` interval -- preventing a
+    captured forward-skewed envelope from being replayed seconds after
+    its original acceptance window closed.
+
+    Single source of truth for both ``_estop_replay_cache`` and
+    ``_resume_replay_cache`` eviction. Callers own insertion and the
+    per-cache lock; this helper is pure bookkeeping.
+    """
+    if len(cache) < max_size:
+        return
+    cutoff = now_mono - ttl_s
+    stale = [k for k, ts in cache.items() if ts < cutoff]
+    for k in stale:
+        cache.pop(k, None)
+    if len(cache) >= max_size:
+        ordered = sorted(cache.items(), key=lambda kv: kv[1])
+        drop = max(1, len(ordered) // 5)
+        for k, _ in ordered[:drop]:
+            cache.pop(k, None)
+
+
+#: Lowercase hex digest at most 32 chars. ``ZenohId`` stringifies as
+#: a hex digest of the 16-byte session identifier (leading-zero
+#: trimmed, so 1..32 chars). Used by ``_extract_sample_source_zid``
+#: to reject obviously-bogus stand-ins (test ``MagicMock``,
+#: third-party transport shims) without paying the cost of importing
+#: zenoh just to ``isinstance`` check.
+_ZENOH_ZID_PATTERN = re.compile(r"^[0-9a-f]{1,32}$")
+
+
+def _extract_sample_source_zid(sample: Any) -> str | None:
+    """Return the TLS-bound publisher ZID from a Zenoh ``sample``, or ``None``.
+
+    Zenoh attaches ``sample.source_info.source_id.zid`` (the publishing
+    session's ``ZenohId``) at the wire level. The ``ZenohId`` is established
+    during the session bootstrap that follows the mTLS handshake, and the
+    ``zenoh-python`` API does not expose a public constructor for either
+    ``ZenohId`` or ``EntityGlobalId`` -- they can only be obtained from
+    ``Session.info.zid()`` or ``Publisher.id`` on a session that has already
+    completed the handshake against the trust roots in ``connect.tls``.
+
+    Combined with mTLS this means a peer holding a valid cert for one
+    session cannot mint an envelope that *also* claims the wire-level
+    ``source_zid`` of a different session: the cross-session forgery is
+    bounded by what their own session's ``ZenohId`` actually is.
+
+    The body's ``peer_id`` field remains application-level metadata (chosen
+    by the operator at ``init_mesh`` time and routable across reconnects);
+    this helper returns the wire-level identity that the safety handlers
+    pin HMAC inputs and replay caches to. The two are complementary: body
+    ``peer_id`` survives a session restart, wire ``source_zid`` survives an
+    attacker mutating the body.
+
+    Returns ``None`` when:
+
+    * the sample carries no ``source_info`` (publisher did not attach one --
+      e.g. the bridge/IoT transport path or a legacy publisher),
+    * the ``source_id`` is missing,
+    * the stringified value does not match the strict 1..32 hex digest
+      shape (a malformed sample, third-party transport shim, or unit-test
+      ``MagicMock`` whose ``source_id.zid`` defaults to a Mock repr),
+    * extraction raises (defence in depth -- treat as "no zid available"
+      rather than crashing the safety handler).
+    """
+    try:
+        si = getattr(sample, "source_info", None)
+        if si is None:
+            return None
+        sid = getattr(si, "source_id", None)
+        if sid is None:
+            return None
+        zid = getattr(sid, "zid", None)
+        if zid is None:
+            return None
+        zid_str = str(zid)
+        if not _ZENOH_ZID_PATTERN.match(zid_str):
+            return None
+        return zid_str
+    except (AttributeError, TypeError):
+        return None
+
+
 class Mesh(SensorLoopsMixin):
     """Peer-to-peer mesh component embedded in a single Robot or Simulation.
 
@@ -72,24 +290,148 @@ class Mesh(SensorLoopsMixin):
         self._inbox_lock = threading.Lock()
         self._stop_event = threading.Event()
 
-        # RPC correlation state
+        # RPC correlation state.
+        #
+        # _expected_responders maps turn_id -> the peer_id we expect to
+        # answer (set by send() at point-to-point), or the sentinel
+        # ``BROADCAST_RESPONDER`` if the turn_id was created by
+        # broadcast() and we accept responses from any peer. Phase-4 /
+        # D1: this is what _on_response uses to reject a forged
+        # response from a peer that wasn't the original target.
         self._rpc_lock = threading.Lock()
         self._pending: dict[str, threading.Event] = {}
         self._responses: dict[str, list[dict[str, Any]]] = {}
+        self._expected_responders: dict[str, str] = {}
 
         # User subscribe state
         self.inbox: dict[str, list[tuple[str, dict[str, Any]]]] = {}
         self._user_subs: dict[str, Any] = {}
 
+        # Emergency-stop lockout flag. While this Event is set, every
+        # action other than ``status`` and ``resume`` is refused (see
+        # :meth:`_dispatch`). The flag is cleared by :meth:`_resume_lockout`,
+        # which requires the operator-supplied override code.
+        self._estop_lockout = threading.Event()
+        self._last_estop_ts: float = 0.0
+        # _on_safety_resume must defend
+        # against replay of a previously-observed override-proof envelope.
+        # The receiver caches (proof_nonce, issuer_peer_id) tuples it has
+        # already accepted and refuses duplicates within a bounded window.
+        # Combined with the freshness check on the envelope ``t`` field
+        # this closes the recorded-and-replayed-resume surface even when
+        # an attacker has live ACL access on safety/**.
+        self._resume_replay_cache: dict[tuple[str, str], float] = {}
+        self._resume_replay_lock = threading.Lock()
+        # estop replay defense -- mirror of resume cache, keyed on
+        # (issuer_peer_id, envelope_t). Closes the captured-estop-replay DoS
+        # surface that previously let any peer with live ACL access to
+        # safety/** replay a captured envelope indefinitely. Reuses
+        # _resume_freshness_window_s() / _resume_forward_skew_s() /
+        # _resume_replay_cache_max() (the safety-replay defenses are
+        # symmetric in shape; sharing the bounds keeps env-var surface
+        # minimal).
+        # cache shape is
+        # ``dict[float_t, (issuer_id, mono_ts)]``. The float key
+        # preserves the prior peer_id-permutation defence (attacker
+        # cannot mint novel keys by varying untrusted JSON peer_id);
+        # the value carries issuer attribution AND the eviction
+        # timestamp. Per-issuer counts are derived from cache
+        # contents on demand -- no separate dict that can drift
+        # after eviction (the prior flaw).
+        self._estop_replay_cache: dict[float, tuple[str, float]] = {}
+        self._estop_replay_lock = threading.Lock()
+
+        # Safety topic publishers. Held lazily so the receiver path
+        # ``_publish_safety_envelope`` can attach a Zenoh
+        # ``SourceInfo(EntityGlobalId, monotonic_sn)`` -- the only API
+        # surface for getting an attacker-unforgeable wire-level zid
+        # onto an outbound sample. Reusing one publisher per topic
+        # also gives a stable ``EntityGlobalId.eid`` so the receiver
+        # can spot a same-zid attacker mutating eid mid-flight (which
+        # zenoh treats as a different publisher entity).
+        self._safety_publishers: dict[str, Any] = {}
+        self._safety_publishers_lock = threading.Lock()
+        # Monotonically increasing per-topic sequence number. Bound
+        # into ``SourceInfo.source_sn`` so the receiver can reject an
+        # off-the-wire replay even from the same session: two
+        # envelopes with the same ``(source_zid, source_sn)`` cannot
+        # both be legitimate.
+        self._safety_sn: dict[str, int] = {}
+        self._safety_sn_lock = threading.Lock()
+
     def __repr__(self) -> str:
         state = "alive" if self._running else "stopped"
         return f"Mesh(peer_id={self.peer_id!r}, type={self.peer_type!r}, {state})"
 
+    def _refuse_under_permissive_default_acl(self) -> bool:
+        """pre-session ACL posture gate.
+
+        Returns True if ``Mesh.start()`` MUST refuse to acquire a session
+        because the operator is running ``mtls + permissive default ACL``
+        without the ``STRANDS_MESH_ACCEPT_PERMISSIVE_ACL`` opt-in.
+
+        An earlier placement was AFTER session acquisition + 6
+        subscriber declarations, which left the wire live with the
+        permissive ACL applied. This helper runs at the TOP of ``start()``
+        so a refusal returns BEFORE any wire activity.
+        """
+        try:
+            from strands_robots.mesh._acl_config import is_default_acl_in_use
+            from strands_robots.mesh._zenoh_config import resolve_auth_mode
+
+            if not (resolve_auth_mode() == "mtls" and is_default_acl_in_use()):
+                return False
+        except (ImportError, ValueError) as warn_exc:
+            logger.warning(
+                "[mesh] %s: ACL posture check raised %s: %s -- permissive-ACL gate may be missing; investigate",
+                self.peer_id,
+                type(warn_exc).__name__,
+                warn_exc,
+            )
+            return False
+
+        accept = os.getenv("STRANDS_MESH_ACCEPT_PERMISSIVE_ACL", "").strip().lower()
+        if accept in ("1", "true", "yes"):
+            logger.info(
+                "[mesh] %s: permissive default ACL active under mtls "
+                "(operator opted in via STRANDS_MESH_ACCEPT_PERMISSIVE_ACL).",
+                self.peer_id,
+            )
+            return False
+
+        msg = (
+            "PERMISSIVE DEFAULT ACL ACTIVE UNDER MTLS -- any "
+            "CA-signed peer would be able to publish on **/cmd and "
+            "**/safety/**. This combination turns a single compromised "
+            "cert into a fleet-wide command pivot. Mesh NOT STARTED. "
+            "Either:\n"
+            "  1. Set STRANDS_MESH_ACL_FILE to a literal-CN ACL file "
+            "     enumerating role separation (production posture; see "
+            "     examples/mesh_acl_example.json5).\n"
+            "  2. Set STRANDS_MESH_ACCEPT_PERMISSIVE_ACL=1 to acknowledge "
+            "     the dev/lab posture explicitly (single-tenant only).\n"
+            "  3. Set STRANDS_MESH=false to disable the mesh entirely."
+        )
+        logger.error("[mesh] %s: %s", self.peer_id, msg)
+        return True
+
     # Lifecycle
     def start(self) -> None:
-        """Acquire a Zenoh session and start all publishing loops."""
+        """Acquire a Zenoh session and start all publishing loops.
+
+        the permissive-ACL refuse gate runs
+        BEFORE ``get_session()`` so a refusal short-circuits without
+        touching the wire (prior regression where the gate fired
+        post-session-acquisition is now closed).
+        """
         with self._lifecycle_lock:
             if self._running:
+                return
+
+            # pre-session ACL posture gate. If this returns True,
+            # the operator has not opted in to the dangerous combination
+            # and we MUST NOT acquire a session.
+            if self._refuse_under_permissive_default_acl():
                 return
 
             session = get_session()
@@ -105,12 +447,37 @@ class Mesh(SensorLoopsMixin):
                 declared.append(session.declare_subscriber(f"strands/{self.peer_id}/cmd", self._on_cmd))
                 declared.append(session.declare_subscriber("strands/broadcast", self._on_cmd))
                 declared.append(session.declare_subscriber(f"strands/{self.peer_id}/response/**", self._on_response))
-            except Exception as exc:
+                # Fleet-wide e-stop: any peer broadcasting on safety/estop or
+                # safety/resume engages / clears the lockout on every other
+                # peer too. Without these subscribers the lockout would only
+                # protect the issuing process, leaving receivers willing to
+                # accept the next command after they've stopped the current
+                # task.
+                declared.append(session.declare_subscriber("strands/safety/estop", self._on_safety_estop))
+                declared.append(session.declare_subscriber("strands/safety/resume", self._on_safety_resume))
+            except (RuntimeError, OSError) as exc:
+                # narrow the lifecycle cleanup catch from bare ``Exception``
+                # to the tuple Zenoh's ``declare_subscriber`` actually raises
+                # (``ZError`` is a subclass of ``RuntimeError``; transport-layer
+                # failures surface as ``OSError``). This mirrors the wire-handler
+                # tuple established earlier for ``_on_cmd`` / ``_on_safety_estop``
+                # so programmer errors (``TypeError``, ``AttributeError``,
+                # ``MemoryError``) on the partial-failure cleanup path surface
+                # in tests rather than being silently swallowed.
                 for sub in declared:
                     try:
                         sub.undeclare()
-                    except Exception:
-                        pass
+                    except (RuntimeError, OSError):
+                        # Best-effort cleanup; an undeclare failure here
+                        # cannot recover the parent failure that put us in
+                        # this branch and surfacing it would mask the
+                        # original exc. DEBUG (not WARNING) because the
+                        # operator already gets the WARNING below and a
+                        # second per-sub line per failure becomes log noise.
+                        logger.debug(
+                            "[mesh] %s: undeclare failed during cleanup",
+                            self.peer_id,
+                        )
                 logger.warning("[mesh] %s: failed to declare subscribers: %s", self.peer_id, exc)
                 release_session()
                 self._has_session_ref = False
@@ -119,7 +486,10 @@ class Mesh(SensorLoopsMixin):
             with self._subs_lock:
                 self._subs.extend(declared)
 
+            # ACL gate moved to ``_refuse_under_permissive_default_acl``,
+            # called at the TOP of start() before session acquisition.
             self._running = True
+
             with _LOCAL_ROBOTS_LOCK:
                 _LOCAL_ROBOTS[self.peer_id] = self
 
@@ -185,6 +555,24 @@ class Mesh(SensorLoopsMixin):
                 sub.undeclare()
             except Exception:
                 pass
+
+        # Undeclare any safety publishers we lazily declared so the
+        # underlying Zenoh entity is released cleanly when the
+        # process drops the last session reference. ``undeclare()``
+        # is best-effort -- any failure here cannot recover state
+        # (we are already in stop()) and would only mask a more
+        # informative WARNING from the session teardown path.
+        with self._safety_publishers_lock:
+            pubs_to_drop = list(self._safety_publishers.values())
+            self._safety_publishers.clear()
+        for pub in pubs_to_drop:
+            try:
+                pub.undeclare()
+            except (RuntimeError, OSError):
+                logger.debug(
+                    "[mesh] %s: safety publisher undeclare failed during stop()",
+                    self.peer_id,
+                )
 
         with self._rpc_lock:
             for ev in self._pending.values():
@@ -302,7 +690,7 @@ class Mesh(SensorLoopsMixin):
         period = 1.0 / HEARTBEAT_HZ
         while self._running:
             try:
-                put(f"strands/{self.peer_id}/presence", self._build_presence())
+                self.publish(f"strands/{self.peer_id}/presence", self._build_presence())
                 prune_peers()
             except Exception as exc:
                 logger.debug("[mesh] %s: heartbeat tick error: %s", self.peer_id, exc)
@@ -310,14 +698,31 @@ class Mesh(SensorLoopsMixin):
                 break
 
     def _on_presence(self, sample: Any) -> None:
+        """Handle a peer's presence broadcast.
+
+        Identity, fleet membership, and replay protection are enforced
+        at the Zenoh transport: a sample reaching this callback has
+        already cleared mTLS handshake + ACL, so its peer-id is
+        cryptographically bound to the cert CN. We only parse the
+        payload, update our peer registry, and log a debug line for
+        first-sighting.
+        """
         try:
             raw = sample.payload.to_bytes().decode()
             data = json.loads(raw)
-        except Exception:
+        except (AttributeError, UnicodeDecodeError, json.JSONDecodeError):
+            # narrow per AGENTS.md > "Exception
+            # Clauses Must Be Narrow". Same tuple as the four other
+            # wire-input handlers (_on_cmd, _on_response,
+            # _on_safety_estop, _on_safety_resume).
+            # Pin: tests/mesh/test_wire_handler_narrow_except.py
+            return
+        if not isinstance(data, dict):
             return
         peer_id = data.get("robot_id")
         if not isinstance(peer_id, str) or peer_id == self.peer_id:
             return
+
         is_new = update_peer(
             peer_id=peer_id,
             peer_type=str(data.get("robot_type", "robot")),
@@ -334,7 +739,7 @@ class Mesh(SensorLoopsMixin):
             try:
                 state = self._read_state()
                 if state:
-                    put(f"strands/{self.peer_id}/state", state)
+                    self.publish(f"strands/{self.peer_id}/state", state)
             except Exception as exc:
                 logger.debug("[mesh] %s: state tick error: %s", self.peer_id, exc)
             if self._stop_event.wait(period):
@@ -416,6 +821,19 @@ class Mesh(SensorLoopsMixin):
                 break
 
     def _publish_cameras_once(self) -> None:
+        # Privacy kill switch. Operators on sensitive deployments set
+        # STRANDS_MESH_CAMERA_DISABLED=true to short-circuit the camera
+        # loop entirely -- no frames built, no envelopes signed, nothing
+        # published.
+        # Lenient bool parsing matches the rest of the env-var surface
+        # (STRANDS_MESH_MULTICAST, STRANDS_MESH_I_KNOW_THIS_IS_INSECURE).
+        # Operators using ``=1`` / ``=yes`` / ``=on`` get the same
+        # behaviour as ``=true``; bad values fail-loud rather than
+        # silently re-enabling camera publishing on a privacy flag.
+        from strands_robots.mesh._zenoh_config import _bool_env as _zc_bool_env
+
+        if _zc_bool_env("STRANDS_MESH_CAMERA_DISABLED", default=False):
+            return
         r = self.robot
         inner = getattr(r, "robot", None)
         if inner is None or not getattr(inner, "is_connected", False):
@@ -479,7 +897,7 @@ class Mesh(SensorLoopsMixin):
                     encoded = base64.b64encode(bytes(frame)).decode("ascii")
                     encoding = "raw"
 
-                put(
+                self.publish(
                     f"strands/{self.peer_id}/camera/{cam_name}",
                     {
                         "peer_id": self.peer_id,
@@ -496,27 +914,144 @@ class Mesh(SensorLoopsMixin):
 
     # RPC — incoming
     def _on_cmd(self, sample: Any) -> None:
+        """Handle an inbound command sample.
+
+        The Zenoh transport has already enforced:
+
+        * mTLS peer identity (the sender's cert CN is bound to the link).
+        * ACL -- **when the operator supplies ``STRANDS_MESH_ACL_FILE``
+          with role separation, only peers in the ``operator_peer``
+          subject can publish on ``cmd`` / ``broadcast`` topics**. The
+          default ``default_acl()`` is permissive (any CA-signed peer
+          may publish/subscribe on any key) -- see CHANGELOG.md Section 8.
+        * Per-key-expression frequency cap (``downsampling`` block) --
+          floods are dropped pre-deserialise.
+        * Per-message size cap (``low_pass_filter`` block) -- jumbo
+          frames are dropped pre-deserialise.
+
+        We only have to parse the payload and dispatch.
+        """
         try:
             raw = sample.payload.to_bytes().decode()
             data = json.loads(raw)
-        except Exception:
+        except (AttributeError, UnicodeDecodeError, json.JSONDecodeError):
             return
-        if data.get("sender_id") == self.peer_id:
+        if not isinstance(data, dict):
             return
-        threading.Thread(target=self._exec_cmd, args=(data,), name=f"mesh-exec-{self.peer_id}", daemon=True).start()
+        sender_id = data.get("sender_id", "")
+        if sender_id == self.peer_id:
+            return
+        threading.Thread(
+            target=self._exec_cmd,
+            args=(data,),
+            name=f"mesh-exec-{self.peer_id}",
+            daemon=True,
+        ).start()
 
     def _exec_cmd(self, data: dict[str, Any]) -> None:
         sender = data.get("sender_id", "")
-        turn = data.get("turn_id") or uuid.uuid4().hex[:8]
-        cmd = data.get("command", data)
-        if isinstance(cmd, str):
-            cmd = {"action": "execute", "instruction": cmd}
+        # full 128-bit fallback. Pre-fix, an inbound command without
+        # turn_id triggered a 32-bit hex which was birthday-colliding under
+        # heavy concurrent load and cheap to predict for an attacker who
+        # could observe the response topic. D1 closed the outbound side;
+        # this closes the symmetric receive-side surface.
+        turn = data.get("turn_id") or uuid.uuid4().hex
+        # require an explicit ``command`` key.
+        # Earlier the fallback ``data.get("command", data)`` allowed a
+        # peer to publish a flat-shape envelope (sender_id, turn_id,
+        # action, instruction, policy_provider all at top level) and
+        # have ``data`` itself treated as the command. Earlier revisions rejected
+        # bare-string non-dict commands; this closes the symmetric
+        # flat-dict-envelope shape -- the wire contract REQUIRES a
+        # ``command`` field whose value is a dict.
+        cmd = data.get("command")
+        # Reject non-dict commands at the wire boundary. A bare-string
+        # coercion here would bypass validate_command's dict-shape contract --
+        # any peer that survives mTLS+ACL could drive the robot at the mock
+        # policy with arbitrary text simply by publishing "hello" instead of
+        # {"action":"execute",...}. Outgoing send/broadcast/tell still accept
+        # the ergonomic dict-or-string forms because tell() wraps internally.
+        #
         rkey = f"strands/{sender}/response/{turn}" if sender else None
+        if cmd is None or not isinstance(cmd, dict):
+            # route non-dict envelope rejection
+            # through the same audit + wire-response path as
+            # ValidationError. Earlier this branch was silent on the
+            # wire and in the audit log -- asymmetric with how every
+            # other validation rejection produces a structured error
+            # response and a forensic record.
+            logger.warning(
+                "[mesh] %s: rejected non-dict cmd from %s (type=%s)",
+                self.peer_id,
+                sender,
+                type(cmd).__name__,
+            )
+            if rkey is not None:
+                self.publish(
+                    rkey,
+                    {
+                        "type": "error",
+                        "responder_id": self.peer_id,
+                        "turn_id": turn,
+                        "error": "validation: command must be a dict with explicit `command` key",
+                        "timestamp": time.time(),
+                    },
+                )
+            try:
+                log_safety_event(
+                    "command_rejected",
+                    self.peer_id,
+                    {
+                        "sender": sender,
+                        "reason": "non-dict envelope or missing command key",
+                        "type": type(cmd).__name__,
+                    },
+                )
+            except (TypeError, ValueError, OSError) as audit_exc:
+                logger.debug("[mesh] %s: audit log unavailable: %s", self.peer_id, audit_exc)
+            return
+
+        # Validate the command shape against the action allowlist + per-action
+        # schema (instruction length, duration bounds, policy_host allowlist,...).
+        try:
+            cmd = _security.validate_command(cmd)
+        except _security.ValidationError as exc:
+            logger.warning("[mesh] %s: rejected invalid cmd from %s: %s", self.peer_id, sender, exc)
+            if rkey is not None:
+                self.publish(
+                    rkey,
+                    {
+                        "type": "error",
+                        "responder_id": self.peer_id,
+                        "turn_id": turn,
+                        "error": f"validation: {exc}",
+                        "timestamp": time.time(),
+                    },
+                )
+            try:
+                log_safety_event(
+                    "command_rejected",
+                    self.peer_id,
+                    {
+                        "sender": sender,
+                        "reason": str(exc),
+                        "action": cmd.get("action") if isinstance(cmd, dict) else None,
+                    },
+                )
+            except (TypeError, ValueError, OSError) as audit_exc:
+                # narrow per AGENTS.md > Review
+                # Learnings (#86). ``log_safety_event`` raises TypeError
+                # / ValueError on payload shape, OSError on disk failure;
+                # the audit best-effort contract means we drop those, but
+                # an unexpected RuntimeError from a future audit-module
+                # refactor should NOT be silently swallowed.
+                logger.debug("[mesh] %s: audit log unavailable: %s", self.peer_id, audit_exc)
+            return
 
         try:
             result = self._dispatch(cmd)
             if rkey is not None:
-                put(
+                self.publish(
                     rkey,
                     {
                         "type": "response",
@@ -526,10 +1061,12 @@ class Mesh(SensorLoopsMixin):
                         "timestamp": time.time(),
                     },
                 )
-        except Exception as exc:
-            logger.warning("[mesh] %s: dispatch error: %s", self.peer_id, exc)
+        except _security.LockoutError as exc:
+            # Lockout is the most operationally interesting rejection -- emit
+            # a structured error on the response topic and audit it.
+            logger.warning("[mesh] %s: rejected during lockout from %s", self.peer_id, sender)
             if rkey is not None:
-                put(
+                self.publish(
                     rkey,
                     {
                         "type": "error",
@@ -539,10 +1076,78 @@ class Mesh(SensorLoopsMixin):
                         "timestamp": time.time(),
                     },
                 )
+            try:
+                log_safety_event(
+                    "command_rejected_lockout",
+                    self.peer_id,
+                    {"sender": sender, "action": cmd.get("action") if isinstance(cmd, dict) else None},
+                )
+            except (TypeError, ValueError, OSError) as audit_exc:
+                # narrow per AGENTS.md > "Exception
+                # Clauses Must Be Narrow". Same tuple as the symmetric
+                # narrowing at the ValidationError audit path above.
+                logger.debug("[mesh] %s: audit log unavailable: %s", self.peer_id, audit_exc)
+            return
+        except (
+            ValueError,
+            KeyError,
+            AttributeError,
+            RuntimeError,
+            OSError,
+            TypeError,
+        ) as exc:
+            # narrowed from bare ``except Exception``
+            # per AGENTS.md > Review Learnings (#86). The original goal
+            # ("any unhandled exception in a robot adapter would crash
+            # the dispatch thread and silently kill the mesh") is
+            # achievable with a narrow tuple: this catches every
+            # realistic adapter failure (LeRobot raising RuntimeError,
+            # GR00T raising ValueError on bad inputs, type mismatches,
+            # missing keys, OSError from device I/O) but lets
+            # ``MemoryError``, ``SystemExit``, ``KeyboardInterrupt``,
+            # and any future programmer-error type that doesn't fit
+            # this list propagate to the test harness / supervisor.
+            #
+            # The "static dispatch error string on the wire" rationale
+            # below stays the same -- regardless of catch width, we
+            # never leak internal exception detail to a remote caller.
+            # The structured ValidationError / LockoutError paths above
+            # remain the preferred channel for client-distinguishable
+            # rejections.
+            logger.warning(
+                "[mesh] %s: dispatch error from %s: %s",
+                self.peer_id,
+                sender,
+                exc,
+                exc_info=True,
+            )
+            if rkey is not None:
+                self.publish(
+                    rkey,
+                    {
+                        "type": "error",
+                        "responder_id": self.peer_id,
+                        "turn_id": turn,
+                        "error": "dispatch error",
+                        "timestamp": time.time(),
+                    },
+                )
 
     def _dispatch(self, cmd: dict[str, Any]) -> dict[str, Any]:
         action = cmd.get("action", "status")
         r = self.robot
+
+        # While the emergency-stop lockout is engaged, only ``status`` and
+        # ``resume`` are permitted. Raise so _exec_cmd handles the rejection
+        # symmetrically with ValidationError -- emitting type="error" on the
+        # response topic and recording an audit entry. The wire response is
+        # intentionally generic so a remote caller cannot use it to map the
+        # lockout window.
+        if self._estop_lockout.is_set() and action not in ("status", "resume"):
+            raise _security.LockoutError("command rejected")
+
+        if action == "resume":
+            return self._resume_lockout(cmd.get("override_code", ""))
 
         if action == "status":
             if hasattr(r, "get_task_status"):
@@ -600,59 +1205,770 @@ class Mesh(SensorLoopsMixin):
         return {"error": f"unknown action: {action}"}
 
     def _on_response(self, sample: Any) -> None:
+        """Inbound response handler.
+
+        Identity, fleet membership, and topic ACL have already been
+        enforced at the Zenoh transport. We additionally apply a
+        point-to-point scope check: a response is accepted only if its
+        ``responder_id`` matches the expected target recorded in
+        :attr:`_expected_responders` by :meth:`send`. Broadcast turns
+        use the ``BROADCAST_RESPONDER`` sentinel and accept any
+        responder_id -- that is the broadcast contract.
+
+        Without the responder-id check, an ACL-authorised peer that
+        observes a turn_id (a fellow operator) could publish a response
+        on someone else's pending turn and have the sender accept its
+        ``result`` instead of the legitimate target's. The transport
+        ACL prevents an attacker from joining at all; this check
+        prevents lateral mischief between authorised peers.
+        """
         try:
             raw = sample.payload.to_bytes().decode()
             data = json.loads(raw)
-        except Exception:
+        except (AttributeError, UnicodeDecodeError, json.JSONDecodeError):
+            return
+        if not isinstance(data, dict):
             return
         turn = data.get("turn_id")
         if not isinstance(turn, str):
             return
+        responder = data.get("responder_id")
         with self._rpc_lock:
             event = self._pending.get(turn)
             if event is None:
                 return
+            expected = self._expected_responders.get(turn)
+            # Strict scoping for point-to-point sends. Broadcast accepts any.
+            if expected is not None and expected != BROADCAST_RESPONDER and responder != expected:
+                # structured forensic event via the audit log
+                # (``response_hijack_rejected``) plus a WARNING line is
+                # the operator-and-forensic channel; an earlier draft
+                # also raised-and-caught a typed exception around the
+                # same code, but with no real consumer it was YAGNI
+                # scaffolding and got removed.
+                logger.warning(
+                    "[mesh] %s: dropped response on turn %s -- "
+                    "responder_id=%r does not match expected target %r "
+                    "(possible response hijack)",
+                    self.peer_id,
+                    turn[:12],
+                    responder,
+                    expected,
+                )
+                try:
+                    log_safety_event(
+                        "response_hijack_rejected",
+                        self.peer_id,
+                        {
+                            "turn_prefix": turn[:12],
+                            "responder_id": responder,
+                            "expected": expected,
+                        },
+                    )
+                except (TypeError, ValueError, OSError) as audit_exc:
+                    # narrow per AGENTS.md > Review
+                    # Learnings (#86). Same tuple as the other audit-publish
+                    # wrappers in this file. Audit best-effort still holds;
+                    # MemoryError / RuntimeError / future programmer errors
+                    # propagate to the test harness instead of being
+                    # silently swallowed at DEBUG.
+                    logger.debug("[mesh] %s: audit log unavailable: %s", self.peer_id, audit_exc)
+                return
             self._responses.setdefault(turn, []).append(data)
         event.set()
 
-    # RPC — outgoing
+    # Safety -- inbound estop / resume
+    def _on_safety_estop(self, sample: Any) -> None:
+        """Engage the local emergency-stop lockout in response to a fleet-
+        wide ``strands/safety/estop`` broadcast.
+
+        Wire authentication (mTLS + ACL) admits this handler. **When the
+        operator supplies an ``STRANDS_MESH_ACL_FILE`` with role
+        separation (template at ``examples/mesh_acl_example.json5``),
+        only peers in the ``operator_peer`` subject can publish on
+        ``safety/**``.** The default ACL shipped by ``default_acl()`` is
+        permissive (CHANGELOG.md Section 8 -- "any CA-signed peer may
+        publish/subscribe on any key"), so any cert-holding peer can
+        originate an estop on out-of-the-box deployments.
+
+        Defense-in-depth -- captured-envelope replay protection. Even with an unrestricted ACL, a
+        replay of a captured ``safety/estop`` envelope cannot keep the
+        fleet locked indefinitely.  Mirrors :meth:`_on_safety_resume`:
+
+        1. Freshness window (``_resume_freshness_window_s()``) -- envelopes
+           older than the window are rejected.
+        2. Forward-skew bound (``_resume_forward_skew_s()``) -- envelopes
+           timestamped beyond the tolerance in the future are rejected
+           (defeats clock-rollback attacks against the freshness check).
+        3. Per-receiver replay cache keyed on ``float(envelope_t)`` -- bounded LRU at ``_resume_replay_cache_max()`` entries.
+           Keyed on ``t`` alone (NOT ``(issuer_id, t)``) so an attacker
+           who captures one envelope cannot replay it by varying the
+           payload ``peer_id`` field, which is untrusted (comes from the
+           JSON body, not the TLS cert CN).
+
+        E-stop without an envelope ``t`` OR without a valid string
+        ``peer_id`` is rejected as malformed (the canonical
+        :meth:`emergency_stop` issuer always sets both).
+        """
+        try:
+            raw = sample.payload.to_bytes().decode()
+            data = json.loads(raw)
+        except (AttributeError, UnicodeDecodeError, json.JSONDecodeError):
+            return
+        if not isinstance(data, dict):
+            return
+
+        # Wire-level publisher attribution (cross-session forgery defence).
+        # When the sample carries a ``source_info.source_id.zid`` set by
+        # Zenoh during the mTLS-bootstrapped session handshake AND the
+        # body advertises a ``source_zid`` field, the two MUST agree.
+        # An attacker on a different mTLS session cannot make
+        # ``sample.source_info.source_id.zid`` point at a peer's session
+        # because zenoh-python exposes no public ``ZenohId`` constructor;
+        # the value is forced to whatever the publishing session bootstrapped
+        # to under ``connect.tls``. Bridge/IoT transports do not propagate
+        # ``source_info`` -- in that case both fields are absent and we
+        # fall back to the body-level HMAC-bind defences below.
+        wire_zid = _extract_sample_source_zid(sample)
+        body_zid = data.get("source_zid")
+        if wire_zid is not None and body_zid is not None:
+            if not isinstance(body_zid, str) or wire_zid != body_zid:
+                logger.warning(
+                    "[safety] %s: refusing remote estop -- body source_zid does not "
+                    "match TLS-bound wire source_zid (cross-session forgery rejected)",
+                    self.peer_id,
+                )
+                return
+        elif wire_zid is None and body_zid is not None:
+            # Body advertises a zid but the wire does not -- a mTLS
+            # peer that forgot to attach SourceInfo, or a transport
+            # that dropped it. Treat as malformed and reject; the
+            # canonical issuer always pairs the two.
+            logger.warning(
+                "[safety] %s: refusing remote estop -- body source_zid present but wire "
+                "source_zid absent (publisher misconfigured or attacker stripped SourceInfo)",
+                self.peer_id,
+            )
+            return
+        elif wire_zid is not None and body_zid is None:
+            # Wire carries a zid but the body does not -- a publisher
+            # from a pre-binding mesh version. Reject so we never
+            # downgrade silently to the body-only HMAC binding when
+            # the wire-level binding is available. Operators upgrade
+            # all peers together.
+            logger.warning(
+                "[safety] %s: refusing remote estop -- wire source_zid present but body "
+                "source_zid absent (publisher predates source_zid binding; upgrade required)",
+                self.peer_id,
+            )
+            return
+
+        # Freshness + replay defences. An estop envelope without ``t`` is
+        # not from a canonical issuer -- reject (also closes the trivial
+        # replay surface where an attacker strips ``t`` to bypass the
+        # freshness check).
+        envelope_t = data.get("t")
+        now = time.time()
+        if not isinstance(envelope_t, (int, float)):
+            logger.warning(
+                "[safety] %s: refusing remote estop -- envelope missing/invalid ``t``",
+                self.peer_id,
+            )
+            return
+        if envelope_t > now + _resume_forward_skew_s():
+            logger.warning(
+                "[safety] %s: refusing remote estop -- ``t``=%s in future (forward_skew_s=%s, now=%s)",
+                self.peer_id,
+                envelope_t,
+                _resume_forward_skew_s(),
+                now,
+            )
+            return
+        if (now - envelope_t) > _resume_freshness_window_s():
+            logger.warning(
+                "[safety] %s: refusing remote estop -- ``t``=%s too old (freshness_window_s=%s, now=%s)",
+                self.peer_id,
+                envelope_t,
+                _resume_freshness_window_s(),
+                now,
+            )
+            return
+
+        # reject envelopes with missing/empty ``peer_id`` outright
+        # rather than coalescing to ``<unknown>``. The canonical
+        # :meth:`emergency_stop` issuer always sets ``peer_id``; a
+        # malformed envelope is either a programming bug or an attacker
+        # probing the cache. Coalescing to a shared bucket let one
+        # attacker poison the slot for legitimate operators.
+        issuer_id = data.get("peer_id")
+        if not isinstance(issuer_id, str) or not issuer_id:
+            logger.warning(
+                "[safety] %s: refusing remote estop -- envelope missing/invalid ``peer_id``",
+                self.peer_id,
+            )
+            return
+
+        # cache key is keyed on ``float(envelope_t)`` ALONE -- not
+        # ``(issuer_id, t)``. The previous (issuer, t) key let an
+        # attacker who captured one valid envelope replay it
+        # indefinitely by varying the payload ``peer_id`` (which is
+        # untrusted -- it comes from the JSON body, not the TLS cert
+        # CN). Keying on the wall-clock ``t`` alone closes that
+        # peer_id-permutation surface; the only way to mint a new key
+        # is to advance the timestamp, which is bounded by the
+        # freshness window above. A per-issuer slot cap
+        # below to bound the denial-of-estop surface where one
+        # attacker pre-publishes ``t = now + skew - eps`` to occupy
+        # cache slots that legitimate same-float-tick estops would
+
+        # (post-replay-cache: see the per-issuer denial-of-estop discussion).
+        cache_key = float(envelope_t)
+        # Per-issuer fairness bound: one issuer may occupy at
+        # most ``per_issuer_cap`` slots so a single attacker cannot
+        # fill the global cache. Default cap is _resume_replay_cache_max()
+        # / 4 -- four legitimate operators always have working slots.
+        per_issuer_cap = max(1, _resume_replay_cache_max() // 4)
+        # cache TTL bookkeeping uses time.monotonic() so an NTP step
+        # backward cannot leave entries un-evictable and a step forward
+        # cannot age fresh entries out early. Envelope freshness still
+        # uses time.time() above (it must compare against the issuer's
+        # wall-clock).
+        now_mono = time.monotonic()
+        with self._estop_replay_lock:
+            if cache_key in self._estop_replay_cache:
+                # If lockout is active and within 0.2s, this is corroboration
+                # (two distinct operators, same t) not a replay attack.
+                if self._estop_lockout.is_set() and (time.time() - self._last_estop_ts) < 0.2:
+                    try:
+                        self.publish_safety_event(
+                            event_type="estop_corroborated",
+                            severity="info",
+                            payload={"issuer": issuer_id, "issuer_t": envelope_t},
+                        )
+                    except (TypeError, ValueError, OSError) as audit_exc:
+                        # Narrow per AGENTS.md > "Exception Clauses Must Be Narrow".
+                        # publish_safety_event raises only TypeError/ValueError
+                        # on payload shape and OSError on disk failure; everything
+                        # else is a programmer bug worth seeing.
+                        logger.debug(
+                            "[mesh] %s: estop_corroborated audit publish failed: %s",
+                            self.peer_id,
+                            audit_exc,
+                        )
+                    return
+                # Original replay rejection
+                logger.warning(
+                    "[safety] %s: REJECTED remote estop -- replay of (issuer=%s, t=%s) already accepted",
+                    self.peer_id,
+                    issuer_id,
+                    envelope_t,
+                )
+                try:
+                    self.publish_safety_event(
+                        event_type="estop_replay_rejected",
+                        severity="warning",
+                        payload={"issuer": issuer_id, "issuer_t": envelope_t},
+                    )
+                except (TypeError, ValueError, OSError) as audit_exc:
+                    # Audit publish is best-effort and must never block the
+                    # safety path; narrow the catch tuple so a future
+                    # programmer error surfaces in tests rather than
+                    # being swallowed at DEBUG.
+                    logger.debug(
+                        "[mesh] %s: estop_replay_rejected audit publish failed: %s",
+                        self.peer_id,
+                        audit_exc,
+                    )
+                return
+            # evict using the tuple-valued cache. We extract a
+            # mono_ts view, run the standard eviction, then re-key
+            # the surviving entries from the original cache.
+            ts_view: dict[float, float] = {k: v[1] for k, v in self._estop_replay_cache.items()}
+            _evict_replay_cache(
+                ts_view,
+                max_size=_resume_replay_cache_max(),
+                # include forward_skew so a forward-skewed envelope
+                # at t=now+skew stays cached for the full freshness window
+                # rather than the lesser ``freshness`` only.
+                ttl_s=_resume_freshness_window_s() + _resume_forward_skew_s(),
+                now_mono=now_mono,
+            )
+            # Apply the eviction back to the real cache.
+            for evicted in set(self._estop_replay_cache.keys()) - set(ts_view.keys()):
+                self._estop_replay_cache.pop(evicted, None)
+
+            # Per-issuer fairness check derived from cache contents.
+            # No separate dict that drifts -- count entries owned by
+            # ``issuer_id`` directly. After eviction this is naturally
+            # correct: an attacker who flooded their cap and waited for
+            # eviction now has fewer entries (eviction dropped them) and
+            # can reclaim slots, which is the intended dynamic-attacker
+            # rate-limit. A sustained attacker who paces floods to land
+            # just after each eviction is bounded by ``per_issuer_cap``
+            # at every instant -- they never hold more than that fraction
+            # of the global cache, so legitimate operators always have
+            # ``_resume_replay_cache_max() - per_issuer_cap`` slots available.
+            issuer_slots = sum(1 for issuer, _mono in self._estop_replay_cache.values() if issuer == issuer_id)
+            if issuer_slots >= per_issuer_cap:
+                logger.warning(
+                    "[safety] %s: REFUSED estop cache slot -- issuer %r already at cap %d "
+                    "(per-issuer fairness bound; flood suspected)",
+                    self.peer_id,
+                    issuer_id,
+                    per_issuer_cap,
+                )
+                # Audit the over-cap rejection so an operator dashboard
+                # can alert on this. The replay-cache slot is NOT added,
+                # but the lockout below still engages -- a legitimate
+                # safety event is preserved even if the cache itself
+                # cannot hold it.
+                try:
+                    self.publish_safety_event(
+                        event_type="estop_per_issuer_cap_exceeded",
+                        severity="warning",
+                        payload={
+                            "issuer": issuer_id,
+                            "issuer_t": envelope_t,
+                            "cap": per_issuer_cap,
+                        },
+                    )
+                except (TypeError, ValueError, OSError) as audit_exc:
+                    logger.debug(
+                        "[mesh] %s: estop_per_issuer_cap_exceeded audit publish failed: %s",
+                        self.peer_id,
+                        audit_exc,
+                    )
+            else:
+                self._estop_replay_cache[cache_key] = (issuer_id, now_mono)
+
+            # when the issuer is over their
+            # cap, refuse to engage the lockout AS WELL as refuse the
+            # cache slot. Without this, a sustained attacker at-cap
+            # could still drive the lockout to engage on every novel
+            # `t` they emit -- defeating the prior fairness bound's
+            # whole point (limiting one attacker's wall-clock impact).
+            # An at-cap issuer's estops are dropped at the cache layer
+            # AND the lockout layer; they remain audited as
+            # `estop_per_issuer_cap_exceeded`.
+            if issuer_slots >= per_issuer_cap:
+                return
+
+        if not self._estop_lockout.is_set():
+            self._estop_lockout.set()
+            self._last_estop_ts = time.time()
+            sender = data.get("peer_id", "<remote>")
+            logger.critical(
+                "[safety] %s: lockout engaged via remote estop from %s",
+                self.peer_id,
+                sender,
+            )
+            self.publish_safety_event(
+                event_type="remote_estop_engaged",
+                severity="critical",
+                payload={
+                    "trigger": "remote",
+                    "issuer": sender,
+                    "issuer_t": data.get("t"),
+                },
+            )
+        else:
+            # a second legitimate estop (different issuer, fresh ``t``)
+            # arriving while the lockout is already engaged would otherwise
+            # be silently dropped from the audit trail -- forensics lose
+            # the signal that another operator also tried to engage.
+            # Mirror the corroboration audit shape so every issuer of an
+            # estop is preserved on the forensic record.
+            try:
+                self.publish_safety_event(
+                    event_type="remote_estop_redundant",
+                    severity="info",
+                    payload={
+                        "issuer": data.get("peer_id"),
+                        "issuer_t": envelope_t,
+                        "lockout_engaged_since": self._last_estop_ts,
+                    },
+                )
+            except (TypeError, ValueError, OSError) as audit_exc:
+                logger.debug(
+                    "[mesh] %s: remote_estop_redundant audit publish failed: %s",
+                    self.peer_id,
+                    audit_exc,
+                )
+
+    def _on_safety_resume(self, sample: Any) -> None:
+        """Clear the local lockout in response to ``strands/safety/resume``.
+
+        Wire authentication (mTLS + ACL) admits this handler. **When the
+        operator supplies an ``STRANDS_MESH_ACL_FILE`` with role
+        separation only ``operator_peer`` peers can publish here**; the
+        default permissive ACL admits any cert-holding peer. Resume is
+        further gated by the operator override code: the issuer signed
+        ``HMAC(STRANDS_MESH_OVERRIDE_CODE, proof_nonce)`` and we
+        recompute it locally; a mismatch means the issuer's override
+        code differs from ours and we refuse. This is what stops one
+        operator from clearing another operator's e-stop without
+        explicit shared authorisation.
+
+        Receivers without ``STRANDS_MESH_OVERRIDE_CODE`` configured
+        FAIL CLOSED -- operators must distribute the code to every peer
+        for fleet-wide remote resume to work.
+        """
+        try:
+            raw = sample.payload.to_bytes().decode()
+            data = json.loads(raw)
+        except (AttributeError, UnicodeDecodeError, json.JSONDecodeError):
+            # Narrow exception tuple matches ``_on_safety_estop``:
+            # AttributeError -> sample.payload is None or not bytes-like
+            # UnicodeDecodeError -> payload not valid UTF-8
+            # json.JSONDecodeError -> payload is not valid JSON
+            # Wider exceptions (e.g. RuntimeError) bubble up and surface in logs
+            # rather than silently leaving the fleet in a half-state.
+            return
+        if not isinstance(data, dict):
+            return
+
+        # Wire-level publisher attribution (cross-session forgery defence).
+        # Mirrors the parallel block in ``_on_safety_estop``: extract the
+        # TLS-bound zid from ``sample.source_info.source_id.zid`` and the
+        # body's advertised ``source_zid`` field. When both are present
+        # they MUST agree; when one is present but the other is not we
+        # reject (operator must upgrade all peers together so the binding
+        # is never silently downgraded). The wire-level zid is bound into
+        # the HMAC input below, so even a body mutation that flips
+        # ``peer_id`` and recomputes the MAC under the attacker's own
+        # session key cannot satisfy the compare unless the attacker can
+        # also forge ``sample.source_info.source_id.zid`` -- which they
+        # cannot, because ``ZenohId`` has no public Python constructor
+        # and the value is bootstrapped from the mTLS-authenticated
+        # session's identity.
+        wire_zid = _extract_sample_source_zid(sample)
+        body_zid = data.get("source_zid")
+        if wire_zid is not None and body_zid is not None:
+            if not isinstance(body_zid, str) or wire_zid != body_zid:
+                logger.warning(
+                    "[safety] %s: refusing remote resume -- body source_zid does not "
+                    "match TLS-bound wire source_zid (cross-session forgery rejected)",
+                    self.peer_id,
+                )
+                return
+        elif wire_zid is None and body_zid is not None:
+            logger.warning(
+                "[safety] %s: refusing remote resume -- body source_zid present but wire "
+                "source_zid absent (publisher misconfigured or attacker stripped SourceInfo)",
+                self.peer_id,
+            )
+            return
+        elif wire_zid is not None and body_zid is None:
+            logger.warning(
+                "[safety] %s: refusing remote resume -- wire source_zid present but body "
+                "source_zid absent (publisher predates source_zid binding; upgrade required)",
+                self.peer_id,
+            )
+            return
+
+        local_code = os.getenv("STRANDS_MESH_OVERRIDE_CODE", "").strip()
+        if not local_code:
+            logger.warning(
+                "[safety] %s: refusing remote resume -- STRANDS_MESH_OVERRIDE_CODE "
+                "not configured locally (operator code missing)",
+                self.peer_id,
+            )
+            return
+
+        proof_nonce = data.get("proof_nonce")
+        provided_proof = data.get("override_proof")
+        if not isinstance(proof_nonce, str) or not isinstance(provided_proof, str):
+            logger.warning(
+                "[safety] %s: refusing remote resume -- envelope missing override_proof / proof_nonce",
+                self.peer_id,
+            )
+            return
+
+        # the HMAC compare moved BELOW the
+        # envelope_t + issuer_id + lockout_elapsed_s shape validation
+        # because the MAC input now binds those fields. The
+        # ``override_proof`` is only meaningful once we've confirmed
+        # the wire envelope shape that was signed.
+
+        # freshness + replay cache.
+        # The HMAC by itself authenticates the override code but says
+        # nothing about when the envelope was minted -- a replay of a
+        # captured envelope would still verify. Two cheap defences:
+        #
+        # 1. Freshness: reject envelopes whose ``t`` field is older
+        #  than _resume_freshness_window_s() or more than the forward
+        #  skew in the future. This matches the operator NTP
+        #  requirement documented in CHANGELOG.
+        # 2. Per-receiver replay cache: refuse a (issuer, proof_nonce)
+        #  tuple we have already accepted within the freshness
+        #  window. Bounded at _resume_replay_cache_max() entries.
+        envelope_t = data.get("t")
+        now = time.time()
+        if not isinstance(envelope_t, (int, float)):
+            logger.warning(
+                "[safety] %s: refusing remote resume -- envelope missing/invalid ``t``",
+                self.peer_id,
+            )
+            return
+        if envelope_t > now + _resume_forward_skew_s():
+            logger.warning(
+                "[safety] %s: refusing remote resume -- ``t``=%s in future (forward_skew_s=%s, now=%s)",
+                self.peer_id,
+                envelope_t,
+                _resume_forward_skew_s(),
+                now,
+            )
+            return
+        if (now - envelope_t) > _resume_freshness_window_s():
+            logger.warning(
+                "[safety] %s: refusing remote resume -- ``t``=%s too old (freshness_window_s=%s, now=%s)",
+                self.peer_id,
+                envelope_t,
+                _resume_freshness_window_s(),
+                now,
+            )
+            return
+
+        # Mirror the prior estop strict-reject: an envelope without a
+        # valid issuer peer_id would coalesce every "<unknown>"-issued
+        # resume into a shared cache slot, polluting the bounded
+        # ``_resume_replay_cache_max()`` allowance and giving any peer
+        # who omits ``peer_id`` a free way to evict legitimate entries.
+        # The canonical ``Mesh.emergency_stop`` issuer always sets
+        # ``peer_id``; a malformed envelope is either a programming
+        # bug or an attacker probing the cache.
+        issuer_id = data.get("peer_id")
+        if not isinstance(issuer_id, str) or not issuer_id:
+            logger.warning(
+                "[safety] %s: refusing remote resume -- envelope missing/invalid ``peer_id``",
+                self.peer_id,
+            )
+            return
+
+        # the envelope ``lockout_elapsed_s``
+        # must be an int/float to participate in the bound MAC input.
+        # A missing/invalid value indicates a malformed envelope and
+        # is rejected outright -- the canonical issuer at line 1986
+        # always sets a real elapsed seconds value.
+        envelope_elapsed = data.get("lockout_elapsed_s")
+        if not isinstance(envelope_elapsed, (int, float)):
+            logger.warning(
+                "[safety] %s: refusing remote resume -- envelope missing/invalid ``lockout_elapsed_s``",
+                self.peer_id,
+            )
+            return
+
+        # The HMAC binds every body-routing field (peer_id, t,
+        # lockout_elapsed_s, proof_nonce) so a captured envelope mutated
+        # by the attacker on ANY of those fields fails the compare. When
+        # the wire carries a TLS-bound ``source_zid`` we additionally
+        # bind it into the MAC input so an attacker on a different mTLS
+        # session who happens to also hold the override code cannot
+        # mint a fresh resume claiming to be the legitimate session:
+        # the receiver re-derives the MAC using the wire-level
+        # ``sample.source_info.source_id.zid`` (bounded by mTLS trust
+        # roots; ``ZenohId`` has no public Python ctor) so a mutation
+        # of the body ``source_zid`` is provably caught and a same-body
+        # resume from a different session is provably caught.
+        mac_fields: dict[str, Any] = {
+            "peer_id": issuer_id,
+            "t": envelope_t,
+            "lockout_elapsed_s": envelope_elapsed,
+            "proof_nonce": proof_nonce,
+        }
+        if wire_zid is not None:
+            mac_fields["source_zid"] = wire_zid
+        mac_input = json.dumps(
+            mac_fields,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode()
+        expected_proof = hmac.new(
+            local_code.encode(),
+            mac_input,
+            "sha256",
+        ).hexdigest()
+        if not hmac.compare_digest(expected_proof, provided_proof):
+            logger.warning(
+                "[safety] %s: refusing remote resume -- override_proof mismatch "
+                "(MAC binds peer_id+t+lockout_elapsed_s+proof_nonce%s; "
+                "captured-and-mutated replay rejected, constant-time compared)",
+                self.peer_id,
+                "+source_zid" if wire_zid is not None else "",
+            )
+            return
+        # Replay-cache key incorporates the TLS-bound wire zid when
+        # available so two sessions that legitimately share the same
+        # ``proof_nonce`` (e.g. two operators racing the same resume)
+        # do not collide -- and so an attacker on a different session
+        # cannot reuse a captured ``(issuer_peer_id, proof_nonce)`` to
+        # evict legitimate cache slots.
+        cache_key = (wire_zid or issuer_id, proof_nonce)
+        with self._resume_replay_lock:
+            if cache_key in self._resume_replay_cache:
+                logger.warning(
+                    "[safety] %s: REJECTED remote resume -- replay of (issuer=%s, proof_nonce=%s) already accepted",
+                    self.peer_id,
+                    issuer_id,
+                    proof_nonce[:16] + "...",
+                )
+                # Audit the replay attempt -- this is exactly the
+                # forensic signal an operator wants on a compromised
+                # peer trying captured-and-replayed envelopes.
+                try:
+                    self.publish_safety_event(
+                        event_type="resume_replay_rejected",
+                        severity="warning",
+                        payload={
+                            "issuer": issuer_id,
+                            "proof_nonce_prefix": proof_nonce[:16],
+                        },
+                    )
+                except (TypeError, ValueError, OSError) as audit_exc:
+                    # Audit publish is best-effort and must never block the
+                    # safety path; narrow the catch tuple per AGENTS.md.
+                    logger.debug(
+                        "[mesh] %s: resume_replay_rejected audit publish failed: %s",
+                        self.peer_id,
+                        audit_exc,
+                    )
+                return
+            # TTL math uses time.monotonic() (see this PR B5) --
+            # envelope freshness above stays on time.time() because it
+            # compares against the issuer wall clock; cache eviction is
+            # local-only bookkeeping.
+            now_mono = time.monotonic()
+            _evict_replay_cache(
+                self._resume_replay_cache,
+                max_size=_resume_replay_cache_max(),
+                # see _evict_replay_cache docstring.
+                ttl_s=_resume_freshness_window_s() + _resume_forward_skew_s(),
+                now_mono=now_mono,
+            )
+            self._resume_replay_cache[cache_key] = now_mono
+
+        if self._estop_lockout.is_set():
+            self._estop_lockout.clear()
+            sender = data.get("peer_id", "<remote>")
+            logger.warning("[safety] %s: lockout cleared via remote resume from %s", self.peer_id, sender)
+            # audit the receiver-side resume transition. Mirrors
+            # _on_safety_estop above so verify_audit_integrity walkers
+            # see the close of the lockout window for every peer that
+            # entered one.
+            self.publish_safety_event(
+                event_type="remote_resume_applied",
+                severity="info",
+                payload={
+                    "trigger": "remote",
+                    "issuer": sender,
+                    "issuer_t": data.get("t"),
+                },
+            )
+
+    # RPC -- outgoing
     def send(self, target: str, cmd: dict[str, Any], timeout: float = 30.0) -> dict[str, Any]:
-        """Send a command to a single peer and return the first response."""
+        """Send a command to a single peer and return the first response.
+
+        Phase-4 / D1 hardening: turn_id is a full 128-bit uuid4 (no
+        truncation), and the expected responder is recorded so
+        :meth:`_on_response` rejects forged responses from any peer
+        other than *target*.
+
+        explicit guard against passing the
+        :data:`BROADCAST_RESPONDER` sentinel (or any string containing a
+        NUL byte) as ``target``. ``init_mesh``'s peer_id regex already
+        rejects NUL on the receive side, so a real peer can't collide,
+        but a future refactor that loosens that rule must not reopen
+        the response-hijack surface that this method's contract closes.
+        """
         if not self._running:
             return {"status": "error", "error": "mesh not running"}
-        turn = uuid.uuid4().hex[:8]
+        if not isinstance(target, str) or not target:
+            return {"status": "error", "error": "send: target must be a non-empty string"}
+        if "\x00" in target or target == BROADCAST_RESPONDER:
+            return {
+                "status": "error",
+                "error": "send: target may not contain NUL or equal the BROADCAST_RESPONDER sentinel",
+            }
+        # client-side validate before publishing. Prior to this fix,
+        # programmatic callers (tests, third-party integrations, anything
+        # that imports Mesh directly) skipped validate_command -- only the
+        # robot_mesh tool path validated client-side. Receiver-side
+        # _exec_cmd still validates, so this is defence-in-depth, but the
+        # PR description and README claimed client-side AND server-side
+        # validation; this closes the gap.
+        try:
+            cmd = _security.validate_command(cmd)
+        except _security.ValidationError as exc:
+            logger.warning("[mesh] %s: send to %s rejected client-side: %s", self.peer_id, target, exc)
+            return {"status": "error", "error": f"validation: {exc}"}
+        # 128-bit turn id -- at 32 bits the birthday-collision window
+        # under heavy concurrent RPC load was practical (~65k turns
+        # before 50% collision); 128 bits removes that surface entirely.
+        turn = uuid.uuid4().hex
         event = threading.Event()
         with self._rpc_lock:
             self._pending[turn] = event
             self._responses[turn] = []
+            # Defensively: belt-and-suspenders. The public guard above
+            # already rejects target == BROADCAST_RESPONDER and target
+            # containing NUL, but a future refactor that adds another
+            # path into this method (e.g. an internal helper that bypasses
+            # the public guard) must not reopen the response-hijack
+            # surface. Re-checking here makes the invariant explicit at
+            # the assignment site.
+            if target == BROADCAST_RESPONDER or "\x00" in target:
+                self._pending.pop(turn, None)
+                self._responses.pop(turn, None)
+                raise ValueError("send: target may not equal BROADCAST_RESPONDER or contain NUL")
+            self._expected_responders[turn] = target
         msg = {"sender_id": self.peer_id, "turn_id": turn, "command": cmd, "timestamp": time.time()}
         try:
-            put(f"strands/{target}/cmd", msg)
+            self.publish(f"strands/{target}/cmd", msg)
             event.wait(timeout=timeout)
         finally:
             with self._rpc_lock:
                 resps = self._responses.pop(turn, [])
                 self._pending.pop(turn, None)
+                self._expected_responders.pop(turn, None)
         return resps[0] if resps else {"status": "timeout"}
 
     def broadcast(self, cmd: dict[str, Any], timeout: float = 5.0) -> list[dict[str, Any]]:
-        """Broadcast a command to every peer and return all responses."""
+        """Broadcast a command to every peer and return all responses.
+
+        Phase-4 / D1: turn_id is a full 128-bit uuid4 (no truncation).
+        Broadcast turns accept responses from any responder by design,
+        so the responder_id check is bypassed (sentinel
+        ``BROADCAST_RESPONDER``).
+        """
         if not self._running:
             return []
-        turn = uuid.uuid4().hex[:8]
+        # client-side validate before publishing. broadcast()'s
+        # return type is list[dict] (responses), so a validation failure
+        # has no structured slot -- log the rejection and return [] so
+        # callers see "no responses" rather than a partial broadcast.
+        try:
+            cmd = _security.validate_command(cmd)
+        except _security.ValidationError as exc:
+            logger.warning("[mesh] %s: broadcast rejected client-side: %s", self.peer_id, exc)
+            return []
+        turn = uuid.uuid4().hex
         event = threading.Event()
         with self._rpc_lock:
             self._pending[turn] = event
             self._responses[turn] = []
+            # Sentinel -- broadcast accepts responses from any peer.
+            self._expected_responders[turn] = BROADCAST_RESPONDER
         msg = {"sender_id": self.peer_id, "turn_id": turn, "command": cmd, "timestamp": time.time()}
         try:
-            put("strands/broadcast", msg)
+            self.publish("strands/broadcast", msg)
             event.wait(timeout=timeout)
             time.sleep(0.3)
         finally:
             with self._rpc_lock:
                 resps = self._responses.pop(turn, [])
                 self._pending.pop(turn, None)
+                self._expected_responders.pop(turn, None)
         return resps
 
     def tell(self, target: str, instruction: str, **kw: Any) -> dict[str, Any]:
@@ -747,7 +2063,7 @@ class Mesh(SensorLoopsMixin):
             elif isinstance(value, (int, float, bool, str, list, tuple)):
                 act_numeric[key] = value if not isinstance(value, tuple) else list(value)
 
-        put(
+        self.publish(
             f"strands/{self.peer_id}/stream",
             {
                 "peer_id": self.peer_id,
@@ -766,18 +2082,382 @@ class Mesh(SensorLoopsMixin):
 
     # Safety — emergency stop
     def emergency_stop(self) -> list[dict[str, Any]]:
-        """Broadcast stop to every peer and audit the event."""
+        """Broadcast a stop command to every peer and engage the local lockout.
+
+        After this call the local mesh refuses every non-status, non-resume
+        action until :meth:`_resume_lockout` is invoked with the operator
+        override code (``STRANDS_MESH_OVERRIDE_CODE``). The event is also
+        published on ``strands/safety/estop`` and recorded in the audit log
+        (see :func:`strands_robots.mesh.audit.log_safety_event`).
+
+        Returns the list of responses received from peers within the broadcast
+        timeout -- useful for telemetry (which peers acknowledged before the
+        stop fanned out).
+        """
+        self._estop_lockout.set()
+        self._last_estop_ts = time.time()
         responses = self.broadcast({"action": "stop"}, timeout=3.0)
-        put("strands/safety/estop", {"peer_id": self.peer_id, "t": time.time(), "responses_received": len(responses)})
+        # Wire-level publisher attribution: bind the local TLS-bound zid
+        # into both the body (so receivers can verify the body matches
+        # ``sample.source_info.source_id.zid``) and the publish path (via
+        # ``_publish_safety_envelope`` which attaches a ``SourceInfo``).
+        # When ``local_zid`` is ``None`` we are running on the bridge/IoT
+        # transport; the body-level HMAC binding still holds, only the
+        # cross-session forgery defence is unavailable.
+        local_zid = self._local_session_zid()
+        envelope: dict[str, Any] = {
+            "peer_id": self.peer_id,
+            "t": self._last_estop_ts,
+            "responses_received": len(responses),
+            "lockout_engaged": True,
+        }
+        if local_zid is not None:
+            envelope["source_zid"] = local_zid
+        self._publish_safety_envelope("strands/safety/estop", envelope)
         self.publish_safety_event(
             event_type="emergency_stop",
             severity="critical",
-            payload={"sender_id": self.peer_id, "responses_received": len(responses)},
+            payload={
+                "sender_id": self.peer_id,
+                "responses_received": len(responses),
+                "lockout_engaged": True,
+            },
         )
+        logger.critical("[safety] %s: EMERGENCY STOP engaged -- lockout active", self.peer_id)
         return responses
 
+    def _resume_lockout(self, override_code: str) -> dict[str, Any]:
+        """Clear the emergency-stop lockout if *override_code* matches.
 
-# init_mesh — the only public constructor
+        Compared in constant time against ``STRANDS_MESH_OVERRIDE_CODE``.
+
+        the wire response is a single generic shape (``{"status":
+        "ok"}`` on success, ``{"status": "error", "error": "resume
+        rejected"}`` on every failure including "lockout not engaged" and
+        "override code unconfigured") so a remote prober cannot use
+        differential responses as oracles for:
+
+        * whether the lockout is engaged at all (``noop`` vs ``error``),
+        * whether ``STRANDS_MESH_OVERRIDE_CODE`` is configured (``not
+          configured`` vs ``invalid code``),
+        * how long the lockout was held (``lockout_elapsed_s``).
+
+        Structured detail is preserved in the local
+        ``publish_safety_event`` audit record where forensics can use it.
+        Local callers (e.g. operator tooling that wants to show "already
+        unlocked" UI) can still distinguish via the local audit log.
+            {"status": "error", "error": "<reason>"}  # rejected
+
+        Every attempt -- successful or not -- is recorded in the audit log
+        through :meth:`publish_safety_event`.
+        """
+        # every non-success path returns the same generic dict so
+        # a remote caller cannot use the response shape as an oracle.
+        # Structured rejection reasons are preserved in the local audit
+        # log via publish_safety_event.
+        _generic_error = {"status": "error", "error": "resume rejected"}
+
+        # close the timing oracle by ALWAYS
+        # running ``hmac.compare_digest`` on every code path, regardless
+        # of whether the lockout is engaged or the override code is
+        # configured. Without this, a remote prober can distinguish
+        # "compare ran" from "compare didn't run" by response time and
+        # learn:
+        #  - whether the lockout is engaged (lockout-not-engaged path
+        #  skipped the compare)
+        #  - whether STRANDS_MESH_OVERRIDE_CODE is configured (unset
+        #  path skipped the compare)
+        # The earlier response-shape parity (single generic error
+        # dict) closed the message-shape oracle but not the timing
+        # oracle.
+        #
+        # Strategy: capture lockout state and configured-code presence
+        # FIRST, then unconditionally run the compare. Regardless of
+        # outcome, the rejection branch fires in O(constant) time
+        # relative to whether each pre-condition was met.
+        expected = os.getenv("STRANDS_MESH_OVERRIDE_CODE", "").strip()
+        provided = (override_code or "").strip()
+        lockout_engaged = self._estop_lockout.is_set()
+        # Always perform the compare. If `expected` is empty, compare
+        # against a placeholder of the same byte length as the provided
+        # value so the compare runs to completion either way.
+        compare_target = expected.encode() if expected else b"\x00" * max(1, len(provided))
+        compare_ok = hmac.compare_digest(compare_target, provided.encode())
+
+        if not lockout_engaged:
+            self.publish_safety_event(
+                event_type="resume_denied",
+                severity="info",
+                payload={"sender_id": self.peer_id, "reason": "lockout not engaged"},
+            )
+            return _generic_error
+
+        if not expected:
+            self.publish_safety_event(
+                event_type="resume_denied",
+                severity="warning",
+                payload={"sender_id": self.peer_id, "reason": "STRANDS_MESH_OVERRIDE_CODE not configured"},
+            )
+            return _generic_error
+
+        if not compare_ok:
+            self.publish_safety_event(
+                event_type="resume_denied",
+                severity="warning",
+                payload={"sender_id": self.peer_id, "reason": "bad override code"},
+            )
+            return _generic_error
+
+        elapsed = time.time() - self._last_estop_ts
+        self._estop_lockout.clear()
+        self.publish_safety_event(
+            event_type="resume_ok",
+            severity="info",
+            payload={"sender_id": self.peer_id, "lockout_elapsed_s": elapsed},
+        )
+
+        # bind a proof-of-override-code into the resume envelope so
+        # receivers can re-verify on _on_safety_resume. Without this,
+        # any operator-class peer could fan-out a resume just by virtue
+        # of being on the ACL; the override code adds a second factor
+        # that every receiver re-verifies by recomputing
+        # HMAC(local_code, proof_nonce).
+        #
+        # The proof_nonce is per-resume (uuid4.hex). We deliberately do
+        # NOT include the override code itself in the published payload
+        # or the audit log -- only the HMAC of (code, nonce).
+        proof_nonce = uuid.uuid4().hex
+        envelope_t = time.time()
+        # The HMAC input binds every envelope-routing field plus the
+        # local Zenoh session ZID. Binding ``source_zid`` closes the
+        # cross-session forgery surface where an attacker holding the
+        # override code on a different mTLS-authenticated session
+        # would otherwise be able to mint a resume claiming to come
+        # from the legitimate operator's session: the receiver
+        # re-derives the MAC using the wire-level
+        # ``sample.source_info.source_id.zid``, and ``ZenohId`` cannot
+        # be chosen by the publisher (zenoh-python exposes no public
+        # constructor; the value is established by the Zenoh bootstrap
+        # that follows the mTLS handshake and bounded by the trust
+        # roots in ``connect.tls``).
+        #
+        # Body-level fields (``peer_id``, ``t``, ``lockout_elapsed_s``,
+        # ``proof_nonce``) remain bound so the cache-key + freshness
+        # defences continue to hold for non-Zenoh transports where
+        # ``source_zid`` is absent (bridge / IoT). Bound as a
+        # deterministic JSON blob (sort_keys, no whitespace) so issuer
+        # and receiver compute the same digest byte-for-byte.
+        local_zid = self._local_session_zid()
+        mac_fields: dict[str, Any] = {
+            "peer_id": self.peer_id,
+            "t": envelope_t,
+            "lockout_elapsed_s": elapsed,
+            "proof_nonce": proof_nonce,
+        }
+        if local_zid is not None:
+            mac_fields["source_zid"] = local_zid
+        mac_input = json.dumps(
+            mac_fields,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode()
+        override_proof = hmac.new(
+            expected.encode(),
+            mac_input,
+            "sha256",
+        ).hexdigest()
+        envelope: dict[str, Any] = {
+            "peer_id": self.peer_id,
+            "t": envelope_t,
+            "lockout_elapsed_s": elapsed,
+            "proof_nonce": proof_nonce,
+            "override_proof": override_proof,
+        }
+        if local_zid is not None:
+            envelope["source_zid"] = local_zid
+        self._publish_safety_envelope("strands/safety/resume", envelope)
+        logger.warning("[safety] %s: resume after %.1fs lockout", self.peer_id, elapsed)
+        # success is also generic on the wire; the local audit
+        # record (resume_ok above) carries the elapsed time for forensics.
+        return {"status": "ok"}
+
+    def _local_session_zid(self) -> str | None:
+        """Return our own Zenoh session's ZID (32-char hex), or ``None``.
+
+        The ZID is established during the Zenoh session bootstrap that
+        follows the mTLS handshake; it is unique per session and cannot
+        be chosen by the caller. Used in two places:
+
+        1. As the ``source_zid`` field embedded in safety envelope
+           bodies. Combined with the receiver-side check
+           ``body.source_zid == sample.source_info.source_id.zid`` this
+           closes the cross-session forgery window where an attacker
+           in a different session would have to convince Zenoh to
+           attach a wire-level ``source_id.zid`` that does not match
+           the body field. Zenoh-python exposes no public constructor
+           for ``ZenohId``/``EntityGlobalId``, so this binding is
+           bounded by the trust roots in ``connect.tls``.
+
+        2. As an HMAC input on resume envelopes so a captured
+           override-proof bound to one session's wire identity cannot
+           be replayed from a different session even if the attacker
+           also holds the override code (see
+           :meth:`_resume_lockout`).
+
+        Returns ``None`` for non-Zenoh transports (bridge / IoT) and
+        when no session is currently open. In that case the safety
+        path falls back to the body-level HMAC binding alone -- the
+        cross-session-forgery defence is Zenoh-specific because only
+        Zenoh exposes a TLS-bound publisher identity.
+        """
+        try:
+            from strands_robots.mesh.session import _current_zenoh_session_directly
+
+            session = _current_zenoh_session_directly()
+        except ImportError:
+            return None
+        if session is None:
+            return None
+        try:
+            zid = session.info.zid()
+        except (AttributeError, RuntimeError):
+            return None
+        if zid is None:
+            return None
+        zid_str = str(zid)
+        return zid_str or None
+
+    def _safety_publisher_for(self, key: str) -> Any | None:
+        """Lazily declare and cache a Zenoh ``Publisher`` for *key*.
+
+        The publisher is held for the lifetime of this Mesh and reused
+        across :meth:`_publish_safety_envelope` calls so:
+
+        * its ``EntityGlobalId.eid`` is stable -- a receiver-side
+          downstream defence can refuse same-zid envelopes whose eid
+          has shifted (which Zenoh treats as a fresh publisher entity).
+        * the per-publisher monotonic counter inside Zenoh increments
+          predictably; a replay across the same session is bounded by
+          our own ``_safety_sn`` counter (bound into ``source_sn``).
+
+        Returns ``None`` for non-Zenoh transports or when no session
+        is currently open. The caller falls back to the legacy
+        ``put()`` path in that case.
+        """
+        try:
+            from strands_robots.mesh.session import _current_zenoh_session_directly
+
+            session = _current_zenoh_session_directly()
+        except ImportError:
+            return None
+        if session is None:
+            return None
+        with self._safety_publishers_lock:
+            pub = self._safety_publishers.get(key)
+            if pub is not None:
+                return pub
+            try:
+                pub = session.declare_publisher(key)
+            except (RuntimeError, OSError) as exc:
+                logger.warning(
+                    "[mesh] %s: declare_publisher(%s) failed: %s",
+                    self.peer_id,
+                    key,
+                    exc,
+                )
+                return None
+            self._safety_publishers[key] = pub
+            return pub
+
+    def _next_safety_sn(self, key: str) -> int:
+        """Return a monotonically-increasing sequence number scoped to *key*.
+
+        Bound into the ``SourceInfo.source_sn`` field of every safety
+        envelope we publish. Pairs with ``source_zid`` so that the
+        receiver can refuse replays of (zid, sn) it has already
+        accepted, without coalescing with envelopes from other
+        sessions.
+        """
+        with self._safety_sn_lock:
+            sn = self._safety_sn.get(key, 0) + 1
+            self._safety_sn[key] = sn
+            return sn
+
+    def _publish_safety_envelope(self, key: str, payload: dict[str, Any]) -> None:
+        """Publish a safety envelope with TLS-bound source attribution.
+
+        Attempts the Zenoh-native path first: declare (or reuse) a
+        publisher on *key*, allocate a fresh per-topic sequence number,
+        and put the JSON-encoded *payload* with
+        ``SourceInfo(publisher.id, sn)`` attached. The receiver
+        extracts ``sample.source_info.source_id.zid`` and checks it
+        matches the body's ``source_zid`` field plus the HMAC binding
+        -- this closes the cross-session forgery window where an
+        attacker on a different session would have had to convince
+        Zenoh to attach our wire-level zid (which is bounded by mTLS
+        trust roots and the absence of a public ``ZenohId`` ctor in
+        zenoh-python).
+
+        Falls back to the legacy transport-agnostic ``put()`` path
+        when:
+
+        * the transport is not Zenoh (bridge / IoT),
+        * no Zenoh session is currently open,
+        * ``declare_publisher`` failed for any reason (logged at
+          WARNING by ``_safety_publisher_for``),
+        * the ``zenoh.SourceInfo`` constructor is unavailable on the
+          installed zenoh-python version.
+
+        In the fallback case the body-level HMAC binding still holds;
+        only the additional cross-session-forge defence is omitted.
+        """
+        pub = self._safety_publisher_for(key)
+        if pub is None:
+            put(key, payload)
+            return
+        try:
+            import zenoh
+        except ImportError:
+            put(key, payload)
+            return
+        sn = self._next_safety_sn(key)
+        try:
+            source_info = zenoh.SourceInfo(pub.id, sn)
+        except (TypeError, AttributeError):
+            # zenoh-python without the SourceInfo ctor (very old build);
+            # fall back to body-level binding only.
+            put(key, payload)
+            return
+        try:
+            pub.put(json.dumps(payload).encode(), source_info=source_info)
+        except (RuntimeError, OSError, TypeError) as exc:
+            logger.warning(
+                "[mesh] %s: safety publisher.put(%s) failed: %s",
+                self.peer_id,
+                key,
+                exc,
+            )
+            put(key, payload)
+
+    def publish(self, key: str, payload: dict[str, Any]) -> None:
+        """Publish *payload* on *key* via the mesh transport.
+
+        Wire authentication is owned by the Zenoh transport: outbound
+        bytes ride a TLS link whose cert binds the peer identity, and
+        the ACL gates which key-expressions this peer can publish on.
+        This method simply forwards to ``put()`` -- it stays as a
+        single chokepoint so a future hook (audit, telemetry,
+        compression) can land in one place.
+
+        Renamed from ``_put_signed`` after the application-layer signing
+        envelope was dropped (commit 7113742). The old name was a
+        historical artefact: nothing in the body ever signed anything
+        once Zenoh's mTLS + ACL took over identity and authorization.
+        """
+        put(key, payload)
+
+
+# init_mesh -- the only public constructor
 def init_mesh(
     robot: Any,
     peer_id: str | None = None,

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -343,14 +343,14 @@ class Mesh(SensorLoopsMixin):
         # _resume_replay_cache_max() (the safety-replay defenses are
         # symmetric in shape; sharing the bounds keeps env-var surface
         # minimal).
-        # cache shape is
-        # ``dict[float_t, (issuer_id, mono_ts)]``. The float key
-        # preserves the prior peer_id-permutation defence (attacker
-        # cannot mint novel keys by varying untrusted JSON peer_id);
-        # the value carries issuer attribution AND the eviction
-        # timestamp. Per-issuer counts are derived from cache
-        # contents on demand -- no separate dict that can drift
-        # after eviction (the prior flaw).
+        # Cache shape: ``dict[float_t, (issuer_id, mono_ts, wire_zid)]``.
+        # The float key preserves the peer_id-permutation defence
+        # (attacker cannot mint novel keys by varying untrusted JSON
+        # peer_id); the 3-tuple value carries issuer attribution,
+        # the monotonic eviction timestamp, AND the TLS wire_zid at
+        # capture (for corroboration gating). Per-issuer counts are
+        # derived from cache contents on demand -- no separate dict
+        # that can drift after eviction.
         self._estop_replay_cache: dict[float, tuple[str, float, str | None]] = {}
         self._estop_replay_lock = threading.Lock()
 
@@ -1476,14 +1476,13 @@ class Mesh(SensorLoopsMixin):
                 # also fall into the rejection branch: corroboration
                 # over an attribution-less transport cannot be proven.
                 cached_entry = self._estop_replay_cache[cache_key]
-                # Defensive unpack: the canonical value is a
-                # ``(issuer_id, mono_ts, wire_zid)`` 3-tuple, but legacy
-                # test stubs may seed the cache with a bare float
-                # mono_ts. ``isinstance`` keeps this method total.
-                if isinstance(cached_entry, tuple) and len(cached_entry) >= 3:
-                    cached_wire_zid = cached_entry[2]
-                else:
-                    cached_wire_zid = None
+                # Cache values are always ``(issuer_id, mono_ts, wire_zid)``
+                # 3-tuples. The type annotation at __init__ enforces this
+                # shape and the only writer (line ~1601) emits it. No
+                # defensive isinstance -- half-defensive code disagrees
+                # with ts_view (line ~1545) and per-issuer iteration
+                # (line ~1570) which both assume the 3-tuple shape.
+                cached_wire_zid = cached_entry[2]
                 wire_zids_distinct = (
                     cached_wire_zid is not None and wire_zid is not None and cached_wire_zid != wire_zid
                 )

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -190,9 +190,20 @@ def _evict_replay_cache[K](
     captured forward-skewed envelope from being replayed seconds after
     its original acceptance window closed.
 
-    Single source of truth for both ``_estop_replay_cache`` and
-    ``_resume_replay_cache`` eviction. Callers own insertion and the
-    per-cache lock; this helper is pure bookkeeping.
+    Single source of truth for both ``_resume_replay_cache`` (a
+    direct ``dict[K, float]``) and ``_estop_replay_cache`` (a
+    ``dict[float, tuple[issuer_id, mono_ts, wire_zid]]``, which the
+    estop call site reduces to a ``ts_view`` ``dict[K, float]`` before
+    calling this helper, then applies the surviving keyset back to its
+    real cache via set-difference). The view-shim strips the
+    issuer/zid attribution before this helper sees it; any future
+    eviction policy that needs issuer- or zid-aware behaviour (e.g.
+    "evict over-cap issuers preferentially" or "weight TTL by source
+    session") cannot live in this helper -- it would have to be
+    re-implemented inline at the estop call site, or this helper
+    widened to ``dict[K, V]`` + ``value_to_ts: Callable[[V], float]``.
+    Callers own insertion and the per-cache lock; this helper is pure
+    bookkeeping.
     """
     if len(cache) < max_size:
         return

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -1850,7 +1850,12 @@ class Mesh(SensorLoopsMixin):
         # do not collide -- and so an attacker on a different session
         # cannot reuse a captured ``(issuer_peer_id, proof_nonce)`` to
         # evict legitimate cache slots.
-        cache_key = (wire_zid or issuer_id, proof_nonce)
+        # Domain-tagged key prevents namespace collision between Zenoh
+        # wire_zid (hex, TLS-bound) and body issuer_id (app metadata).
+        # A bridge peer with peer_id="ab12cd" and a Zenoh peer with
+        # wire_zid="ab12cd" no longer conflate into the same slot.
+        issuer_key = ("wire", wire_zid) if wire_zid is not None else ("body", issuer_id)
+        cache_key = (issuer_key, proof_nonce)
         with self._resume_replay_lock:
             if cache_key in self._resume_replay_cache:
                 logger.warning(

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -338,7 +338,7 @@ class Mesh(SensorLoopsMixin):
         # timestamp. Per-issuer counts are derived from cache
         # contents on demand -- no separate dict that can drift
         # after eviction (the prior flaw).
-        self._estop_replay_cache: dict[float, tuple[str, float]] = {}
+        self._estop_replay_cache: dict[float, tuple[str, float, str | None]] = {}
         self._estop_replay_lock = threading.Lock()
 
         # Safety topic publishers. Held lazily so the receiver path
@@ -1436,14 +1436,61 @@ class Mesh(SensorLoopsMixin):
         now_mono = time.monotonic()
         with self._estop_replay_lock:
             if cache_key in self._estop_replay_cache:
-                # If lockout is active and within 0.2s, this is corroboration
-                # (two distinct operators, same t) not a replay attack.
-                if self._estop_lockout.is_set() and (time.time() - self._last_estop_ts) < 0.2:
+                # Corroboration vs replay disambiguation gated on the
+                # TLS-bound wire ``source_zid``. The previous heuristic
+                # ("lockout active + within 0.2s -> corroboration") was
+                # forgeable: a same-session attacker who captured a
+                # legitimate envelope could republish it within 200 ms
+                # with a mutated body ``peer_id`` and earn an
+                # ``estop_corroborated`` audit (severity ``info``,
+                # operator-dashboard-invisible) instead of
+                # ``estop_replay_rejected`` (severity ``warning``).
+                #
+                # The cache value tuple now carries the wire_zid in
+                # effect when the slot was first populated. A second
+                # envelope is treated as legitimate cross-session
+                # corroboration ONLY IF:
+                #   * the cached wire_zid is non-None (slot was
+                #     established by a TLS-bound publisher),
+                #   * the new wire_zid is non-None,
+                #   * the two zids differ (two distinct mTLS
+                #     sessions -> two distinct operators).
+                # Same-zid replay -- including the
+                # mutated-peer_id case -- audits as
+                # ``estop_replay_rejected`` per the original threat
+                # model. Bridge / IoT transports that legitimately have
+                # no SourceInfo (wire_zid is ``None`` on either side)
+                # also fall into the rejection branch: corroboration
+                # over an attribution-less transport cannot be proven.
+                cached_entry = self._estop_replay_cache[cache_key]
+                # Defensive unpack: the canonical value is a
+                # ``(issuer_id, mono_ts, wire_zid)`` 3-tuple, but legacy
+                # test stubs may seed the cache with a bare float
+                # mono_ts. ``isinstance`` keeps this method total.
+                if isinstance(cached_entry, tuple) and len(cached_entry) >= 3:
+                    cached_wire_zid = cached_entry[2]
+                else:
+                    cached_wire_zid = None
+                wire_zids_distinct = (
+                    cached_wire_zid is not None
+                    and wire_zid is not None
+                    and cached_wire_zid != wire_zid
+                )
+                if (
+                    wire_zids_distinct
+                    and self._estop_lockout.is_set()
+                    and (time.time() - self._last_estop_ts) < 0.2
+                ):
                     try:
                         self.publish_safety_event(
                             event_type="estop_corroborated",
                             severity="info",
-                            payload={"issuer": issuer_id, "issuer_t": envelope_t},
+                            payload={
+                                "issuer": issuer_id,
+                                "issuer_t": envelope_t,
+                                "wire_zid": wire_zid,
+                                "corroborates_wire_zid": cached_wire_zid,
+                            },
                         )
                     except (TypeError, ValueError, OSError) as audit_exc:
                         # Narrow per AGENTS.md > "Exception Clauses Must Be Narrow".
@@ -1456,7 +1503,8 @@ class Mesh(SensorLoopsMixin):
                             audit_exc,
                         )
                     return
-                # Original replay rejection
+                # Original replay rejection (now also covers same-wire-zid
+                # mutated-peer_id replays and attribution-less transports).
                 logger.warning(
                     "[safety] %s: REJECTED remote estop -- replay of (issuer=%s, t=%s) already accepted",
                     self.peer_id,
@@ -1508,7 +1556,7 @@ class Mesh(SensorLoopsMixin):
             # at every instant -- they never hold more than that fraction
             # of the global cache, so legitimate operators always have
             # ``_resume_replay_cache_max() - per_issuer_cap`` slots available.
-            issuer_slots = sum(1 for issuer, _mono in self._estop_replay_cache.values() if issuer == issuer_id)
+            issuer_slots = sum(1 for issuer, _mono, _zid in self._estop_replay_cache.values() if issuer == issuer_id)
             if issuer_slots >= per_issuer_cap:
                 logger.warning(
                     "[safety] %s: REFUSED estop cache slot -- issuer %r already at cap %d "
@@ -1539,7 +1587,7 @@ class Mesh(SensorLoopsMixin):
                         audit_exc,
                     )
             else:
-                self._estop_replay_cache[cache_key] = (issuer_id, now_mono)
+                self._estop_replay_cache[cache_key] = (issuer_id, now_mono, wire_zid)
 
             # when the issuer is over their
             # cap, refuse to engage the lockout AS WELL as refuse the

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -325,6 +325,7 @@ class Mesh(SensorLoopsMixin):
         # which requires the operator-supplied override code.
         self._estop_lockout = threading.Event()
         self._last_estop_ts: float = 0.0
+        self._last_estop_mono: float = 0.0
         # _on_safety_resume must defend
         # against replay of a previously-observed override-proof envelope.
         # The receiver caches (proof_nonce, issuer_peer_id) tuples it has
@@ -1484,14 +1485,12 @@ class Mesh(SensorLoopsMixin):
                 else:
                     cached_wire_zid = None
                 wire_zids_distinct = (
-                    cached_wire_zid is not None
-                    and wire_zid is not None
-                    and cached_wire_zid != wire_zid
+                    cached_wire_zid is not None and wire_zid is not None and cached_wire_zid != wire_zid
                 )
                 if (
                     wire_zids_distinct
                     and self._estop_lockout.is_set()
-                    and (time.time() - self._last_estop_ts) < 0.2
+                    and (time.monotonic() - self._last_estop_mono) < 0.2
                 ):
                     try:
                         self.publish_safety_event(
@@ -1616,6 +1615,7 @@ class Mesh(SensorLoopsMixin):
         if not self._estop_lockout.is_set():
             self._estop_lockout.set()
             self._last_estop_ts = time.time()
+            self._last_estop_mono = time.monotonic()
             sender = data.get("peer_id", "<remote>")
             logger.critical(
                 "[safety] %s: lockout engaged via remote estop from %s",
@@ -2156,6 +2156,7 @@ class Mesh(SensorLoopsMixin):
         """
         self._estop_lockout.set()
         self._last_estop_ts = time.time()
+        self._last_estop_mono = time.monotonic()
         responses = self.broadcast({"action": "stop"}, timeout=3.0)
         # Wire-level publisher attribution: bind the local TLS-bound zid
         # into both the body (so receivers can verify the body matches

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -1599,18 +1599,6 @@ class Mesh(SensorLoopsMixin):
             else:
                 self._estop_replay_cache[cache_key] = (issuer_id, now_mono, wire_zid)
 
-            # when the issuer is over their
-            # cap, refuse to engage the lockout AS WELL as refuse the
-            # cache slot. Without this, a sustained attacker at-cap
-            # could still drive the lockout to engage on every novel
-            # `t` they emit -- defeating the prior fairness bound's
-            # whole point (limiting one attacker's wall-clock impact).
-            # An at-cap issuer's estops are dropped at the cache layer
-            # AND the lockout layer; they remain audited as
-            # `estop_per_issuer_cap_exceeded`.
-            if issuer_slots >= per_issuer_cap:
-                return
-
         if not self._estop_lockout.is_set():
             self._estop_lockout.set()
             self._last_estop_ts = time.time()

--- a/strands_robots/mesh/input.py
+++ b/strands_robots/mesh/input.py
@@ -12,8 +12,8 @@ Topic schema for ``strands/{peer_id}/input/{device_name}``::
         "method": "arm" | "gamepad" | "keyboard" | "phone",
         "t": <unix-timestamp>,
         "seq": <monotonic-frame-counter>,
-        "action": {"motor.pos": float,...},
-        "events": {"terminate_episode": bool,...} | null
+        "action": {"motor.pos": float, ...},
+        "events": {"terminate_episode": bool, ...} | null
     }
 """
 

--- a/strands_robots/mesh/input.py
+++ b/strands_robots/mesh/input.py
@@ -12,8 +12,8 @@ Topic schema for ``strands/{peer_id}/input/{device_name}``::
         "method": "arm" | "gamepad" | "keyboard" | "phone",
         "t": <unix-timestamp>,
         "seq": <monotonic-frame-counter>,
-        "action": {"motor.pos": float, ...},
-        "events": {"terminate_episode": bool, ...} | null
+        "action": {"motor.pos": float,...},
+        "events": {"terminate_episode": bool,...} | null
     }
 """
 

--- a/strands_robots/mesh/security.py
+++ b/strands_robots/mesh/security.py
@@ -187,6 +187,16 @@ class ValidationError(SecurityError):
     """Command payload failed schema or bounds checks."""
 
 
+class LockoutError(SecurityError):
+    """Command rejected because emergency-stop lockout is engaged.
+
+    Raised by :class:`Mesh._dispatch` for every action other than ``status``
+    and ``resume`` while ``self._estop_lockout`` is set. Caught by
+    :meth:`Mesh._exec_cmd` to emit a structured ``command_rejected_lockout``
+    audit event and a ``type="error"`` wire response.
+    """
+
+
 # --- Policy-host allowlist -----------------------------------------------
 
 
@@ -848,4 +858,5 @@ __all__ = [
     "is_safe_policy_type",
     "is_safe_server_address",
     "validate_command",
+    "LockoutError",
 ]

--- a/strands_robots/mesh/sensors.py
+++ b/strands_robots/mesh/sensors.py
@@ -36,7 +36,7 @@ from strands_robots.mesh.session import (
     MAP_INFO_HZ,
     ODOM_HZ,
     POSE_HZ,
-    put,
+    put,  # noqa: F401  # re-exported so test fixtures can patch.object(sensors, "put")
 )
 
 logger = logging.getLogger(__name__)
@@ -56,11 +56,6 @@ def _resolve_hz(env_name: str, default: float) -> float:
 
 
 class SensorLoopsMixin:
-    # Type hints for attrs provided by host class (Mesh)
-    peer_id: str
-    robot: Any
-    _running: bool
-    _stop_event: threading.Event
     """Mixin providing all extended sensor publishing loops for Mesh.
 
     Requires the host class to have:
@@ -68,7 +63,29 @@ class SensorLoopsMixin:
     - self.robot: Any
     - self._running: bool
     - self._stop_event: threading.Event
+    - self.publish(key, payload) -> None
     """
+
+    # Type hints for attrs/methods provided by host class (Mesh).
+    peer_id: str
+    robot: Any
+    _running: bool
+    _stop_event: threading.Event
+
+    def publish(self, key: str, payload: dict[str, Any]) -> None:
+        """Provided by host Mesh class. Publishes payload on the given key
+        via the underlying Zenoh transport. Declared here so static
+        type-checkers see the symbol on the mixin without duplicating logic.
+
+        At runtime ``Mesh.publish`` shadows this stub via MRO
+        (``class Mesh(SensorLoopsMixin)``); this body is never executed.
+
+        Raises:
+            NotImplementedError: if the mixin is used standalone (no host
+                Mesh class). Replaces the bare ``...`` stub so static
+                analysers (CodeQL #226) don't flag a no-effect statement.
+        """
+        raise NotImplementedError("SensorLoopsMixin.publish must be provided by a host class")
 
     # Pose
 
@@ -81,7 +98,7 @@ class SensorLoopsMixin:
             try:
                 pose = self._read_pose()
                 if pose:
-                    put(f"strands/{self.peer_id}/pose", pose)
+                    self.publish(f"strands/{self.peer_id}/pose", pose)
             except Exception as exc:  # noqa: BLE001
                 logger.debug("[mesh] %s: pose tick error: %s", self.peer_id, exc)
             if self._stop_event.wait(period):
@@ -159,7 +176,7 @@ class SensorLoopsMixin:
             try:
                 health = self._read_health()
                 if health:
-                    put(f"strands/{self.peer_id}/health", health)
+                    self.publish(f"strands/{self.peer_id}/health", health)
             except Exception as exc:  # noqa: BLE001
                 logger.debug("[mesh] %s: health tick error: %s", self.peer_id, exc)
             if self._stop_event.wait(period):
@@ -241,7 +258,7 @@ class SensorLoopsMixin:
             try:
                 imu = self._read_imu()
                 if imu:
-                    put(f"strands/{self.peer_id}/imu", imu)
+                    self.publish(f"strands/{self.peer_id}/imu", imu)
             except Exception as exc:  # noqa: BLE001
                 logger.debug("[mesh] %s: imu tick error: %s", self.peer_id, exc)
             if self._stop_event.wait(period):
@@ -292,7 +309,7 @@ class SensorLoopsMixin:
             try:
                 odom = self._read_odom()
                 if odom:
-                    put(f"strands/{self.peer_id}/odom", odom)
+                    self.publish(f"strands/{self.peer_id}/odom", odom)
             except Exception as exc:  # noqa: BLE001
                 logger.debug("[mesh] %s: odom tick error: %s", self.peer_id, exc)
             if self._stop_event.wait(period):
@@ -326,12 +343,12 @@ class SensorLoopsMixin:
                 now = time.time()
                 summary = self._read_lidar_summary()
                 if summary:
-                    put(f"strands/{self.peer_id}/lidar/summary", summary)
+                    self.publish(f"strands/{self.peer_id}/lidar/summary", summary)
 
                 if now - last_state_publish >= state_period:
                     state = self._read_lidar_state()
                     if state:
-                        put(f"strands/{self.peer_id}/lidar/state", state)
+                        self.publish(f"strands/{self.peer_id}/lidar/state", state)
                     last_state_publish = now
             except Exception as exc:  # noqa: BLE001
                 logger.debug("[mesh] %s: lidar tick error: %s", self.peer_id, exc)
@@ -374,7 +391,7 @@ class SensorLoopsMixin:
                 hands = self._read_hands()
                 if hands:
                     for hand_name, hand_data in hands.items():
-                        put(f"strands/{self.peer_id}/hand/{hand_name}/state", hand_data)
+                        self.publish(f"strands/{self.peer_id}/hand/{hand_name}/state", hand_data)
             except Exception as exc:  # noqa: BLE001
                 logger.debug("[mesh] %s: hand tick error: %s", self.peer_id, exc)
             if self._stop_event.wait(period):
@@ -407,7 +424,7 @@ class SensorLoopsMixin:
             try:
                 info = self._read_map_info()
                 if info:
-                    put(f"strands/{self.peer_id}/map/info", info)
+                    self.publish(f"strands/{self.peer_id}/map/info", info)
             except Exception as exc:  # noqa: BLE001
                 logger.debug("[mesh] %s: map_info tick error: %s", self.peer_id, exc)
             if self._stop_event.wait(period):
@@ -445,7 +462,7 @@ class SensorLoopsMixin:
             "t": time.time(),
         }
 
-        put(f"strands/{self.peer_id}/safety/event", event)
+        self.publish(f"strands/{self.peer_id}/safety/event", event)
 
         try:
             log_safety_event(

--- a/strands_robots/mesh/sensors.py
+++ b/strands_robots/mesh/sensors.py
@@ -366,6 +366,10 @@ class SensorLoopsMixin:
                     if state:
                         self.publish(f"strands/{self.peer_id}/lidar/state", state)
                     last_state_publish = now
+            except NotImplementedError:
+                # MRO contract violation: surface immediately rather than
+                # silently dropping every sensor tick (issue #258).
+                raise
             except Exception as exc:  # noqa: BLE001
                 logger.debug("[mesh] %s: lidar tick error: %s", self.peer_id, exc)
             if self._stop_event.wait(summary_period):
@@ -408,6 +412,10 @@ class SensorLoopsMixin:
                 if hands:
                     for hand_name, hand_data in hands.items():
                         self.publish(f"strands/{self.peer_id}/hand/{hand_name}/state", hand_data)
+            except NotImplementedError:
+                # MRO contract violation: surface immediately rather than
+                # silently dropping every sensor tick (issue #258).
+                raise
             except Exception as exc:  # noqa: BLE001
                 logger.debug("[mesh] %s: hand tick error: %s", self.peer_id, exc)
             if self._stop_event.wait(period):
@@ -477,7 +485,11 @@ class SensorLoopsMixin:
         event: dict[str, Any] = {
             "peer_id": self.peer_id,
             "type": event_type,
-            "severity": severity,
+            # Issue #272: uniform on the wire so a subscriber on
+            # strands/+/safety/event cannot use per-branch severity as a
+            # content-channel oracle for the rejection reason. The real
+            # severity is preserved only in the local audit record below.
+            "severity": "info",
             "payload": payload or {},
             "t": time.time(),
         }

--- a/strands_robots/mesh/sensors.py
+++ b/strands_robots/mesh/sensors.py
@@ -99,6 +99,10 @@ class SensorLoopsMixin:
                 pose = self._read_pose()
                 if pose:
                     self.publish(f"strands/{self.peer_id}/pose", pose)
+            except NotImplementedError:
+                # MRO contract violation: surface immediately rather than
+                # silently dropping every sensor tick (issue #258).
+                raise
             except Exception as exc:  # noqa: BLE001
                 logger.debug("[mesh] %s: pose tick error: %s", self.peer_id, exc)
             if self._stop_event.wait(period):
@@ -177,6 +181,10 @@ class SensorLoopsMixin:
                 health = self._read_health()
                 if health:
                     self.publish(f"strands/{self.peer_id}/health", health)
+            except NotImplementedError:
+                # MRO contract violation: surface immediately rather than
+                # silently dropping every sensor tick (issue #258).
+                raise
             except Exception as exc:  # noqa: BLE001
                 logger.debug("[mesh] %s: health tick error: %s", self.peer_id, exc)
             if self._stop_event.wait(period):
@@ -259,6 +267,10 @@ class SensorLoopsMixin:
                 imu = self._read_imu()
                 if imu:
                     self.publish(f"strands/{self.peer_id}/imu", imu)
+            except NotImplementedError:
+                # MRO contract violation: surface immediately rather than
+                # silently dropping every sensor tick (issue #258).
+                raise
             except Exception as exc:  # noqa: BLE001
                 logger.debug("[mesh] %s: imu tick error: %s", self.peer_id, exc)
             if self._stop_event.wait(period):
@@ -310,6 +322,10 @@ class SensorLoopsMixin:
                 odom = self._read_odom()
                 if odom:
                     self.publish(f"strands/{self.peer_id}/odom", odom)
+            except NotImplementedError:
+                # MRO contract violation: surface immediately rather than
+                # silently dropping every sensor tick (issue #258).
+                raise
             except Exception as exc:  # noqa: BLE001
                 logger.debug("[mesh] %s: odom tick error: %s", self.peer_id, exc)
             if self._stop_event.wait(period):
@@ -425,6 +441,10 @@ class SensorLoopsMixin:
                 info = self._read_map_info()
                 if info:
                     self.publish(f"strands/{self.peer_id}/map/info", info)
+            except NotImplementedError:
+                # MRO contract violation: surface immediately rather than
+                # silently dropping every sensor tick (issue #258).
+                raise
             except Exception as exc:  # noqa: BLE001
                 logger.debug("[mesh] %s: map_info tick error: %s", self.peer_id, exc)
             if self._stop_event.wait(period):

--- a/strands_robots/tools/robot_mesh.py
+++ b/strands_robots/tools/robot_mesh.py
@@ -92,6 +92,7 @@ def robot_mesh(
     timeout: float = 30.0,
     name: str = "",
     limit: int = 50,
+    tool_context: Any = None,
 ) -> dict[str, Any]:
     """Coordinate every robot, sim, and agent on the local Zenoh mesh.
 

--- a/tests/mesh/test_corroboration_clock_domain.py
+++ b/tests/mesh/test_corroboration_clock_domain.py
@@ -52,8 +52,14 @@ def _stub_mesh() -> core.Mesh:
 
 
 def _envelope(t: float, peer_id: str = "issuer-A", source_zid: str | None = None) -> Any:
-    """Build a minimal Zenoh sample stub for _on_safety_estop."""
+    """Build a minimal Zenoh sample stub for _on_safety_estop.
+
+    Body includes ``source_zid`` to match the wire-level zid binding
+    introduced in PR-225 (rejects mismatched wire-vs-body zid).
+    """
     body: dict[str, Any] = {"peer_id": peer_id, "t": t}
+    if source_zid is not None:
+        body["source_zid"] = source_zid
     raw = json.dumps(body).encode()
     sample = SimpleNamespace(payload=SimpleNamespace(to_bytes=lambda r=raw: r))
     # Wire source_zid via the SourceInfo attribute that the handler extracts.
@@ -108,12 +114,14 @@ def test_corroboration_window_uses_monotonic_not_wall_clock() -> None:
 
     with mock.patch("time.time", return_value=wall_after_ntp):
         with mock.patch("time.monotonic", return_value=mono_after):
-            # Patch _extract_sample_source_zid to return wire_zid_b.
+            # Patch the MODULE-LEVEL _extract_sample_source_zid
+            # (called from core.py at the wire-zid extract site).
+            # Patching it on the instance with create=True was a no-op
+            # because core.py calls the module-level function.
             with mock.patch.object(
-                m,
+                core,
                 "_extract_sample_source_zid",
                 return_value=wire_zid_b,
-                create=True,
             ):
                 m._on_safety_estop(envelope)
 

--- a/tests/mesh/test_corroboration_clock_domain.py
+++ b/tests/mesh/test_corroboration_clock_domain.py
@@ -1,0 +1,159 @@
+"""Pin test for corroboration-window clock domain.
+
+The corroboration branch in ``_on_safety_estop`` compares the time since
+the last estop lockout against a 0.2s window. This MUST use
+``time.monotonic()`` (the same domain as every other local bookkeeping
+timestamp in the safety subsystem), NOT ``time.time()`` (wall-clock).
+
+A wall-clock backward step (NTP correction, VM resume from suspend)
+can make ``time.time() - _last_estop_ts`` go *negative*, which still
+passes ``< 0.2`` -- acceptable (conservative direction). But a forward
+step (NTP step forward, VM wakeup after 5s sleep) can push the
+difference past 0.2s for two estops that arrived within 0.2s of
+monotonic time, demoting a legitimate cross-session corroboration to
+``estop_replay_rejected`` (severity ``warning``).
+
+Pre-fix code used ``time.time() - self._last_estop_ts < 0.2``.
+Fixed code uses ``time.monotonic() - self._last_estop_mono < 0.2``.
+
+Pin: monkeypatch ``time.time`` to simulate a forward NTP step
+(+5s jump after first estop), assert the corroboration branch still
+fires (because monotonic did not jump). If the fix regresses, the
+second estop will be classified as ``estop_replay_rejected`` instead of
+``estop_corroborated``.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import threading
+import time
+from types import SimpleNamespace
+from typing import Any
+from unittest import mock
+
+from strands_robots.mesh import core
+
+
+def _stub_mesh() -> core.Mesh:
+    """Minimal Mesh stub sufficient to exercise _on_safety_estop."""
+    m = core.Mesh.__new__(core.Mesh)
+    m.peer_id = "test-peer"
+    m._estop_replay_cache = {}
+    m._resume_replay_cache = {}
+    m._estop_replay_lock = threading.Lock()
+    m._resume_replay_lock = threading.Lock()
+    m._estop_lockout = threading.Event()
+    m._last_estop_ts = 0.0
+    m._last_estop_mono = 0.0
+    m.publish_safety_event = mock.MagicMock()
+    return m
+
+
+def _envelope(t: float, peer_id: str = "issuer-A", source_zid: str | None = None) -> Any:
+    """Build a minimal Zenoh sample stub for _on_safety_estop."""
+    body: dict[str, Any] = {"peer_id": peer_id, "t": t}
+    raw = json.dumps(body).encode()
+    sample = SimpleNamespace(payload=SimpleNamespace(to_bytes=lambda r=raw: r))
+    # Wire source_zid via the SourceInfo attribute that the handler extracts.
+    if source_zid is not None:
+        sample.source_info = SimpleNamespace(source_id=SimpleNamespace(zid=lambda s=source_zid: s))
+    else:
+        sample.source_info = None
+    return sample
+
+
+def test_corroboration_window_uses_monotonic_not_wall_clock() -> None:
+    """Pin: corroboration window check MUST use monotonic clock.
+
+    Scenario: first estop arrives at monotonic T=100.0, wall-clock
+    W=1000000.0. NTP then jumps wall-clock forward by 5s (W becomes
+    1000005.0). A second estop from a DIFFERENT wire_zid arrives
+    at monotonic T=100.1 (within 0.2s) but wall-clock is now 1000005.1
+    (5.1s after first -- would exceed 0.2s window under wall-clock).
+
+    Expected: corroboration is detected because monotonic elapsed
+    (0.1s) is < 0.2s. If the code uses wall-clock, the elapsed would
+    be 5.1s and corroboration would be missed.
+    """
+    m = _stub_mesh()
+
+    # Simulate first estop arriving: sets lockout + timestamps.
+    first_t = 1000000.0
+    mono_at_first = 100.0
+
+    with mock.patch("time.time", return_value=first_t):
+        with mock.patch("time.monotonic", return_value=mono_at_first):
+            # Directly set state as if _on_safety_estop processed the
+            # first envelope successfully (no cache hit = fresh slot).
+            m._estop_lockout.set()
+            m._last_estop_ts = time.time()
+            m._last_estop_mono = time.monotonic()
+            # Seed the cache with the first envelope's entry.
+            wire_zid_a = "zid-session-A"
+            m._estop_replay_cache[first_t] = ("issuer-A", mono_at_first, wire_zid_a)
+
+    # Now simulate NTP step forward: wall-clock jumps +5s, monotonic
+    # advances only 0.1s.
+    wall_after_ntp = first_t + 5.1  # 5.1s later in wall-clock
+    mono_after = mono_at_first + 0.1  # only 0.1s later in monotonic
+
+    # Second estop from a DIFFERENT wire_zid, same `t` value (the
+    # replay-vs-corroboration distinction is on wire_zid, not `t`).
+    wire_zid_b = "zid-session-B"
+
+    # Build envelope with same `t` so it hits the cache-slot branch.
+    envelope = _envelope(t=first_t, peer_id="issuer-B", source_zid=wire_zid_b)
+
+    with mock.patch("time.time", return_value=wall_after_ntp):
+        with mock.patch("time.monotonic", return_value=mono_after):
+            # Patch _extract_sample_source_zid to return wire_zid_b.
+            with mock.patch.object(
+                m,
+                "_extract_sample_source_zid",
+                return_value=wire_zid_b,
+                create=True,
+            ):
+                m._on_safety_estop(envelope)
+
+    # Assert: the corroboration branch fired (not replay_rejected).
+    # Look for estop_corroborated event_type in the publish calls.
+    calls = m.publish_safety_event.call_args_list
+    event_types = [c.kwargs.get("event_type") for c in calls if c.kwargs]
+    assert "estop_corroborated" in event_types, (
+        f"Expected estop_corroborated but got events: {event_types}. "
+        "This means the corroboration window is using wall-clock (time.time) "
+        "instead of monotonic clock -- the NTP jump caused a false rejection."
+    )
+
+
+def test_corroboration_window_does_not_use_wall_clock_source() -> None:
+    """Structural pin: verify the source code at the corroboration check
+    uses ``_last_estop_mono`` not ``_last_estop_ts``."""
+    source = inspect.getsource(core.Mesh._on_safety_estop)
+    # The corroboration window MUST reference _last_estop_mono.
+    assert "_last_estop_mono" in source, (
+        "Corroboration window in _on_safety_estop does not reference _last_estop_mono -- clock domain regression."
+    )
+    # It must NOT use _last_estop_ts for the 0.2s window comparison.
+    # The _last_estop_ts is still used for audit payloads and logging,
+    # but the < 0.2 comparison must be on monotonic.
+    lines = source.split("\n")
+    for line in lines:
+        if "< 0.2" in line or "<0.2" in line:
+            assert "_last_estop_mono" in line, f"Found '< 0.2' comparison using wall-clock: {line.strip()}"
+            assert "_last_estop_ts" not in line, f"The 0.2s window check must not use _last_estop_ts: {line.strip()}"
+            break
+    else:
+        # The 0.2 literal might be extracted to a constant; check monotonic
+        # is at least referenced in a comparison context.
+        pass
+
+
+def test_last_estop_mono_initialized_at_init() -> None:
+    """Pin: _last_estop_mono MUST be initialized alongside _last_estop_ts."""
+    source = inspect.getsource(core.Mesh.__init__)
+    assert "_last_estop_mono" in source, (
+        "_last_estop_mono not initialized in Mesh.__init__ -- new code path will hit AttributeError on first estop."
+    )

--- a/tests/mesh/test_corroboration_clock_domain.py
+++ b/tests/mesh/test_corroboration_clock_domain.py
@@ -47,7 +47,7 @@ def _stub_mesh() -> core.Mesh:
     m._estop_lockout = threading.Event()
     m._last_estop_ts = 0.0
     m._last_estop_mono = 0.0
-    m.publish_safety_event = mock.MagicMock()
+    m.publish_safety_event = mock.MagicMock()  # type: ignore[method-assign]
     return m
 
 
@@ -119,7 +119,7 @@ def test_corroboration_window_uses_monotonic_not_wall_clock() -> None:
 
     # Assert: the corroboration branch fired (not replay_rejected).
     # Look for estop_corroborated event_type in the publish calls.
-    calls = m.publish_safety_event.call_args_list
+    calls = m.publish_safety_event.call_args_list  # type: ignore[attr-defined]
     event_types = [c.kwargs.get("event_type") for c in calls if c.kwargs]
     assert "estop_corroborated" in event_types, (
         f"Expected estop_corroborated but got events: {event_types}. "

--- a/tests/mesh/test_deep_mesh.py
+++ b/tests/mesh/test_deep_mesh.py
@@ -158,7 +158,11 @@ def mock_session(monkeypatch):
 
 @pytest.fixture
 def mock_put():
-    """Patch put at all locations where it's imported."""
+    """Patch put at all locations where it's imported.
+
+    Wire authentication is owned by the Zenoh transport in production;
+    in-process tests just record (key, payload) tuples as-is.
+    """
     from strands_robots.mesh import sensors as mesh_sensors
 
     calls = []
@@ -1063,9 +1067,11 @@ class TestRobotMeshTool:
 
     def test_peers_action_no_mesh(self):
         """peers action when no local mesh exists."""
+        from unittest.mock import MagicMock as _MM
+
         from strands_robots.tools.robot_mesh import robot_mesh
 
-        result = robot_mesh(action="peers")
+        result = robot_mesh(action="peers", tool_context=_MM())
         assert result["status"] == "success"
         assert "0 local" in result["content"][0]["text"]
 
@@ -1075,7 +1081,9 @@ class TestRobotMeshTool:
 
         m = Mesh(FakeRobot(), peer_id="tool-test")
         m.start()
-        result = robot_mesh(action="tell", instruction="go")
+        from unittest.mock import MagicMock as _MM
+
+        result = robot_mesh(action="tell", instruction="go", tool_context=_MM())
         assert result["status"] == "error"
         m.stop()
 
@@ -1085,7 +1093,9 @@ class TestRobotMeshTool:
 
         m = Mesh(FakeRobot(), peer_id="tool-json")
         m.start()
-        result = robot_mesh(action="send", target="peer-x", command="not{json")
+        from unittest.mock import MagicMock as _MM
+
+        result = robot_mesh(action="send", target="peer-x", command="not{json", tool_context=_MM())
         assert result["status"] == "error"
         assert "not valid JSON" in result["content"][0]["text"]
         m.stop()
@@ -1096,7 +1106,9 @@ class TestRobotMeshTool:
 
         m = Mesh(FakeRobot(), peer_id="tool-unk")
         m.start()
-        result = robot_mesh(action="foobar")
+        from unittest.mock import MagicMock as _MM
+
+        result = robot_mesh(action="foobar", tool_context=_MM())
         assert result["status"] == "error"
         assert "unknown action" in result["content"][0]["text"]
         m.stop()

--- a/tests/mesh/test_default_acl_warning.py
+++ b/tests/mesh/test_default_acl_warning.py
@@ -11,6 +11,7 @@ suppressed when either condition does not hold.
 
 from __future__ import annotations
 
+import ast
 import logging
 from pathlib import Path
 from types import SimpleNamespace
@@ -149,23 +150,41 @@ class TestPermissiveACLWarningExceptNarrow:
     def test_unexpected_exception_surfaces_loudly(self):
         """A non-(ImportError|ValueError) raised inside the warning block
         should surface at WARNING (not DEBUG silent-swallow).
+
+        Scope: assertions target the ``_refuse_under_permissive_default_acl``
+        method body specifically (AST-scoped). Other helper methods in
+        ``core.py`` legitimately use ``except ImportError:`` to guard
+        soft imports of the ``strands_robots.mesh.session`` module
+        (e.g. ``_local_session_zid``, ``_safety_publisher_for``); those
+        are unrelated to the permissive-ACL warning block and must not
+        be flagged by this pin test.
         """
 
         # Static assertion -- start() does network I/O, so we verify the
         # narrowed except clause is in the source rather than triggering it.
-        # The previous version of this test constructed a Mesh and patched
-        # resolve_auth_mode, but that scaffolding never got exercised because
-        # start() was the entry point. Removed per CodeQL #257.
+        # AST-scope to the gate method so legitimate ImportError fallbacks
+        # in unrelated helper methods do not cause false positives.
         src = Path(core_mod.__file__).read_text()
+        tree = ast.parse(src)
+        gate_src: str | None = None
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "_refuse_under_permissive_default_acl":
+                gate_src = ast.get_source_segment(src, node)
+                break
+        assert gate_src is not None, (
+            "expected _refuse_under_permissive_default_acl in core.py; "
+            "review thread core.py:121 (PR-3 + PR-6 review-feedback)."
+        )
+
         # PR-3 ships _acl_config + _zenoh_config in the same diff, so the
         # ImportError fallback was dead code (review thread core.py:121).
         # The gate now resolves snapshot_acl directly under a narrow
         # ValueError catch (fail-CLOSED on bad config).
-        assert "except ValueError as warn_exc:" in src
+        assert "except ValueError as warn_exc:" in gate_src
         # No bare `except Exception as warn_exc:` left in the start() block
-        assert "except Exception as warn_exc:" not in src
-        # And no dead ImportError fallback either.
-        assert "except ImportError:" not in src
+        assert "except Exception as warn_exc:" not in gate_src
+        # And no dead ImportError fallback in the gate method either.
+        assert "except ImportError:" not in gate_src
 
 
 # ---------------------------------------------------------------------

--- a/tests/mesh/test_estop_peer_id_replay.py
+++ b/tests/mesh/test_estop_peer_id_replay.py
@@ -1,0 +1,114 @@
+"""Pin: estop replay cache resists peer_id permutation.
+
+Background: the prior fix review flagged that the prior cache key
+``(issuer_peer_id, float(envelope_t))`` could be bypassed by an attacker
+who captures one valid estop envelope and replays it with a single-byte
+mutation to the payload ``peer_id`` field. ``peer_id`` is untrusted (it
+comes from the JSON body, not the TLS cert CN), so the cache key was
+attacker-controlled and the replay-defence claim in the prior docstring was
+overstated.
+
+Fix: cache key narrowed to ``float(envelope_t)`` alone, and
+envelopes with missing/empty ``peer_id`` are rejected outright.
+
+These tests pin both behaviours.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from strands_robots.mesh import core as core_module
+
+
+class _FakeSample:
+    """Minimal Zenoh-sample stand-in that carries a JSON payload."""
+
+    def __init__(self, payload: dict) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.payload = SimpleNamespace(to_bytes=lambda: body)
+
+
+@pytest.fixture
+def receiver():
+    """A bare ``Mesh`` with the bits ``_on_safety_estop`` actually touches."""
+    m = core_module.Mesh.__new__(core_module.Mesh)
+    m.peer_id = "receiver-1"
+    m._estop_lockout = core_module.threading.Event()
+    m._estop_replay_cache = {}
+    m._estop_replay_lock = core_module.threading.Lock()
+    m._last_estop_ts = 0.0
+    # Stub publish_safety_event so we don't need a live transport.
+    m.publish_safety_event = MagicMock()
+    return m
+
+
+def test_peer_id_permutation_cannot_replay(receiver, caplog):
+    """A captured envelope replayed with a different ``peer_id`` is dropped.
+
+    Pre-fix the cache key was ``(issuer_peer_id, t)`` so flipping
+    ``peer_id`` from ``"op-1"`` to ``"op-2"`` yielded a fresh key and the
+    replay was accepted. Post-fix the cache key is ``float(t)`` alone.
+    """
+    now = time.time()
+    captured = {"t": now, "peer_id": "op-1", "trigger": "remote"}
+
+    # First receipt -- accepted, lockout engages.
+    receiver._on_safety_estop(_FakeSample(captured))
+    assert receiver._estop_lockout.is_set(), "first receipt must engage lockout"
+    assert len(receiver._estop_replay_cache) == 1
+    receiver._estop_lockout.clear()  # reset for the replay observation
+
+    # Replay with permuted peer_id but same ``t``.
+    permuted = {"t": now, "peer_id": "op-2", "trigger": "remote"}
+    with caplog.at_level("WARNING", logger="strands_robots.mesh.core"):
+        receiver._on_safety_estop(_FakeSample(permuted))
+
+    # The replay must be REJECTED -- lockout must NOT re-engage and
+    # cache size stays at 1.
+    assert not receiver._estop_lockout.is_set(), (
+        "permuted peer_id replayed within freshness window must NOT engage lockout"
+    )
+    assert len(receiver._estop_replay_cache) == 1, (
+        f"cache must not grow on permuted-peer_id replay; got {receiver._estop_replay_cache}"
+    )
+    assert any("REJECTED" in rec.message for rec in caplog.records), "expected a REJECTED log for the permuted replay"
+
+
+def test_missing_peer_id_envelope_rejected(receiver, caplog):
+    """Envelopes with missing/empty ``peer_id`` are rejected outright."""
+    now = time.time()
+    for bad_payload in (
+        {"t": now},  # missing peer_id
+        {"t": now, "peer_id": ""},  # empty string
+        {"t": now, "peer_id": None},  # not a string
+        {"t": now, "peer_id": 123},  # not a string (int)
+    ):
+        receiver._estop_lockout.clear()
+        receiver._estop_replay_cache.clear()
+        with caplog.at_level("WARNING", logger="strands_robots.mesh.core"):
+            receiver._on_safety_estop(_FakeSample(bad_payload))
+        assert not receiver._estop_lockout.is_set(), (
+            f"envelope with bad peer_id ({bad_payload}) must NOT engage lockout"
+        )
+        assert len(receiver._estop_replay_cache) == 0, f"envelope with bad peer_id ({bad_payload}) must NOT enter cache"
+    # At least one WARNING line per bad payload.
+    msgs = [rec.message for rec in caplog.records]
+    assert sum("invalid ``peer_id``" in m for m in msgs) >= 4, f"expected >=4 invalid-peer_id warnings, got: {msgs}"
+
+
+def test_legitimate_distinct_t_envelopes_both_accepted(receiver):
+    """Two distinct-``t`` envelopes from the same issuer are both accepted."""
+    base = time.time()
+    # Two envelopes 100ms apart -- both within freshness window.
+    for offset in (0.0, 0.1):
+        receiver._estop_lockout.clear()
+        receiver._on_safety_estop(_FakeSample({"t": base + offset, "peer_id": "op-1", "trigger": "remote"}))
+    assert len(receiver._estop_replay_cache) == 2, (
+        f"two distinct-t envelopes must populate two cache entries; got {receiver._estop_replay_cache}"
+    )

--- a/tests/mesh/test_estop_replay.py
+++ b/tests/mesh/test_estop_replay.py
@@ -34,12 +34,44 @@ def _envelope(t: float, peer_id: str = "issuer", **extra):
     return SimpleNamespace(payload=SimpleNamespace(to_bytes=lambda r=raw: r))
 
 
-def test_distinct_issuers_same_t_audited_as_corroborated():
-    """
-    Two distinct operators with colliding t should audit as corroborated.
+_OPERATOR_A_ZID = "0123456789abcdef0123456789abcdef"
+_OPERATOR_B_ZID = "fedcba9876543210fedcba9876543210"
 
-    Pre-fix: second estop audited as estop_replay_rejected (false negative).
-    Post-fix: second estop within 0.2s of lockout audited as estop_corroborated.
+
+def _envelope_with_wire_zid(t, peer_id, wire_zid, **extra):
+    """Build a Zenoh-sample fake whose ``source_info.source_id.zid``
+    stringifies to *wire_zid* and whose body declares ``source_zid`` to
+    match (the production code requires body/wire agreement before the
+    cache check is reached).
+    """
+    body = {"peer_id": peer_id, "t": t, "source_zid": wire_zid, **extra}
+    raw = json.dumps(body).encode()
+
+    class _Zid:
+        def __init__(self, s):
+            self._s = s
+
+        def __str__(self):
+            return self._s
+
+    return SimpleNamespace(
+        payload=SimpleNamespace(to_bytes=lambda r=raw: r),
+        source_info=SimpleNamespace(
+            source_id=SimpleNamespace(zid=_Zid(wire_zid)),
+            source_sn=1,
+        ),
+    )
+
+
+def test_distinct_issuers_distinct_wire_zids_same_t_audited_as_corroborated():
+    """
+    Two distinct operators on distinct mTLS sessions with colliding t
+    should audit as corroborated.
+
+    The wire_zid distinctness is the trust anchor: peer_id is
+    body-supplied (untrusted) and was the original mis-classification
+    surface (R7 regression). wire_zid is bound by Zenoh's mTLS handshake
+    and cannot be forged by a same-session attacker.
     """
     mesh = _stub_mesh()
     audit_calls = []
@@ -49,23 +81,139 @@ def test_distinct_issuers_same_t_audited_as_corroborated():
 
     mesh.publish_safety_event = capture_audit  # type: ignore[method-assign]
 
-    # First estop from operator A
+    # First estop from operator A on session zid A.
     envelope_t = time.time()
     mesh._estop_lockout.set()
     mesh._last_estop_ts = envelope_t
-    mesh._estop_replay_cache[float(envelope_t)] = time.monotonic()
+    mesh._estop_replay_cache[float(envelope_t)] = (
+        "operator-A",
+        time.monotonic(),
+        _OPERATOR_A_ZID,
+    )
 
-    # Second estop from operator B with same t (colliding timestamp)
-    mesh._on_safety_estop(_envelope(t=envelope_t, peer_id="operator-B", reason="Operator B emergency"))
+    # Second estop from operator B on a DIFFERENT session zid, same t.
+    mesh._on_safety_estop(
+        _envelope_with_wire_zid(
+            t=envelope_t,
+            peer_id="operator-B",
+            wire_zid=_OPERATOR_B_ZID,
+            reason="Operator B emergency",
+        )
+    )
 
-    # Pre-fix: audit_calls contains estop_replay_rejected
-    # Post-fix: audit_calls contains estop_corroborated (lockout active, within 0.2s)
     assert len(audit_calls) == 1, f"Expected 1 audit call, got {len(audit_calls)}"
     assert audit_calls[0]["event_type"] == "estop_corroborated", (
         f"Expected estop_corroborated, got {audit_calls[0]['event_type']}"
     )
     assert audit_calls[0]["severity"] == "info"
     assert audit_calls[0]["payload"]["issuer"] == "operator-B"
+    # New: corroboration audit names the cross-session wire zids so an
+    # operator dashboard can prove independence post-hoc.
+    assert audit_calls[0]["payload"]["wire_zid"] == _OPERATOR_B_ZID
+    assert audit_calls[0]["payload"]["corroborates_wire_zid"] == _OPERATOR_A_ZID
+
+
+def test_same_wire_zid_mutated_peer_id_audited_as_replay_rejected():
+    """
+    R7 regression pin: a same-session attacker who captures a legitimate
+    estop and republishes within 200 ms with a mutated body ``peer_id``
+    must audit as ``estop_replay_rejected`` (severity ``warning``,
+    operator-dashboard-visible) -- NOT ``estop_corroborated`` (severity
+    ``info``, false-positive forensic).
+
+    Pre-fix: the corroboration heuristic was "lockout active + within
+    0.2 s of last estop", which classified this attacker case as
+    corroboration because the cache key (``float(t)``) was peer_id-blind
+    and the heuristic did not consult the wire_zid.
+
+    Post-fix: corroboration requires both wire_zids to be non-None AND
+    distinct. A same-zid replay -- regardless of body peer_id -- audits
+    as replay_rejected.
+    """
+    mesh = _stub_mesh()
+    audit_calls = []
+
+    def capture_audit(**kwargs):
+        audit_calls.append(kwargs)
+
+    mesh.publish_safety_event = capture_audit  # type: ignore[method-assign]
+
+    # Legitimate first estop establishes the cache slot bound to wire_zid A.
+    envelope_t = time.time()
+    mesh._estop_lockout.set()
+    mesh._last_estop_ts = envelope_t
+    mesh._estop_replay_cache[float(envelope_t)] = (
+        "legit-operator",
+        time.monotonic(),
+        _OPERATOR_A_ZID,
+    )
+
+    # Attacker on the SAME wire_zid republishes with a mutated body
+    # peer_id, hoping to earn an ``estop_corroborated`` (severity info)
+    # attribution they did not provide.
+    mesh._on_safety_estop(
+        _envelope_with_wire_zid(
+            t=envelope_t,
+            peer_id="attacker-claims-corroboration",
+            wire_zid=_OPERATOR_A_ZID,  # same wire_zid as the cached slot
+            reason="forged corroboration attempt",
+        )
+    )
+
+    assert len(audit_calls) == 1, f"Expected 1 audit call, got {len(audit_calls)}"
+    # Critical: the audit must classify this as REPLAY, not corroboration.
+    assert audit_calls[0]["event_type"] == "estop_replay_rejected", (
+        f"R7 regression: same-wire-zid mutated-peer_id replay must audit as "
+        f"estop_replay_rejected, got {audit_calls[0]['event_type']}"
+    )
+    assert audit_calls[0]["severity"] == "warning"
+    # The replay-rejection payload preserves the (forged) attacker peer_id
+    # and the original t for forensics, but the severity/event_type
+    # signals are correct.
+    assert audit_calls[0]["payload"]["issuer"] == "attacker-claims-corroboration"
+    assert audit_calls[0]["payload"]["issuer_t"] == envelope_t
+
+
+def test_attribution_less_transport_same_t_audited_as_replay_rejected():
+    """
+    Bridge / IoT transports legitimately have no SourceInfo, so wire_zid
+    is ``None`` on either or both sides. Without a TLS-bound attribution
+    anchor, corroboration cannot be proven -- the second envelope MUST
+    be classified as replay (the conservative, security-preserving
+    default), not silently downgraded to ``info``.
+    """
+    mesh = _stub_mesh()
+    audit_calls = []
+
+    def capture_audit(**kwargs):
+        audit_calls.append(kwargs)
+
+    mesh.publish_safety_event = capture_audit  # type: ignore[method-assign]
+
+    envelope_t = time.time()
+    mesh._estop_lockout.set()
+    mesh._last_estop_ts = envelope_t
+    # Cached slot has wire_zid=None (bridge publisher).
+    mesh._estop_replay_cache[float(envelope_t)] = (
+        "bridge-operator",
+        time.monotonic(),
+        None,
+    )
+
+    # Incoming envelope ALSO has wire_zid=None (no source_info).
+    body = {"peer_id": "second-bridge-operator", "t": envelope_t}
+    raw = json.dumps(body).encode()
+    sample = SimpleNamespace(
+        payload=SimpleNamespace(to_bytes=lambda r=raw: r),
+        source_info=None,
+    )
+    mesh._on_safety_estop(sample)
+
+    assert len(audit_calls) == 1
+    assert audit_calls[0]["event_type"] == "estop_replay_rejected", (
+        "attribution-less transports cannot prove corroboration; must "
+        "audit as replay_rejected"
+    )
 
 
 class TestEstopRedundantAudit:
@@ -158,7 +306,7 @@ class TestEstopPerIssuerFairnessBound:
         # per-issuer count is derived from cache contents, not a
         # separate dict. Count entries owned by attacker-1; the
         # attacker is capped at per_issuer_cap = MAX // 4 = 2 slots.
-        attacker_slots = sum(1 for issuer, _mono in m._estop_replay_cache.values() if issuer == "attacker-1")
+        attacker_slots = sum(1 for issuer, _mono, _zid in m._estop_replay_cache.values() if issuer == "attacker-1")
         assert attacker_slots <= 2, (
             f"attacker should be capped at 2 slots, got {attacker_slots} (cache: {m._estop_replay_cache})"
         )
@@ -195,12 +343,20 @@ class TestPerIssuerCountFromCache:
         m._on_safety_estop(S())
 
         assert len(m._estop_replay_cache) == 1
-        # Value is now (issuer_id, mono_ts) tuple
+        # Value is (issuer_id, mono_ts, wire_zid_or_None) 3-tuple.
+        # The third element captures the TLS-bound publisher zid in
+        # effect when the slot was first populated; it gates the
+        # corroboration-vs-replay classification on later same-t hits.
         value = next(iter(m._estop_replay_cache.values()))
-        assert isinstance(value, tuple), "cache value must be (issuer_id, mono_ts) tuple"
-        issuer, mono_ts = value
+        assert isinstance(value, tuple), "cache value must be (issuer_id, mono_ts, wire_zid) tuple"
+        assert len(value) == 3, f"cache value must be 3-tuple, got len={len(value)}"
+        issuer, mono_ts, wire_zid = value
         assert issuer == "alice"
         assert isinstance(mono_ts, float)
+        # No source_info on the test envelope -> wire_zid is None.
+        # This is the bridge/IoT path; corroboration is unavailable but
+        # the cache entry is still valid for replay-rejection.
+        assert wire_zid is None, f"expected wire_zid=None for source_info-less stub, got {wire_zid!r}"
 
 
 class TestF14OverCapBlocksLockout:

--- a/tests/mesh/test_estop_replay.py
+++ b/tests/mesh/test_estop_replay.py
@@ -1,0 +1,254 @@
+"""
+Pin test for estop corroboration attribution.
+
+When two distinct operators broadcast safety/estop at colliding t values,
+the audit log should record this as estop_corroborated (positive forensic)
+not estop_replay_rejected (false negative).
+"""
+
+import json
+import threading
+import time
+from types import SimpleNamespace
+
+from strands_robots.mesh import audit as audit_mod
+from strands_robots.mesh import core
+
+
+def _stub_mesh() -> core.Mesh:
+    """Minimal Mesh stub for safety handler testing."""
+    m = core.Mesh.__new__(core.Mesh)
+    m.peer_id = "test-peer"
+    m._estop_replay_cache = {}
+    m._resume_replay_cache = {}
+    m._estop_replay_lock = threading.Lock()
+    m._resume_replay_lock = threading.Lock()
+    m._estop_lockout = threading.Event()
+    m._last_estop_ts = 0.0
+    return m
+
+
+def _envelope(t: float, peer_id: str = "issuer", **extra):
+    body = {"peer_id": peer_id, "t": t, **extra}
+    raw = json.dumps(body).encode()
+    return SimpleNamespace(payload=SimpleNamespace(to_bytes=lambda r=raw: r))
+
+
+def test_distinct_issuers_same_t_audited_as_corroborated():
+    """
+    Two distinct operators with colliding t should audit as corroborated.
+
+    Pre-fix: second estop audited as estop_replay_rejected (false negative).
+    Post-fix: second estop within 0.2s of lockout audited as estop_corroborated.
+    """
+    mesh = _stub_mesh()
+    audit_calls = []
+
+    def capture_audit(**kwargs):
+        audit_calls.append(kwargs)
+
+    mesh.publish_safety_event = capture_audit  # type: ignore[method-assign]
+
+    # First estop from operator A
+    envelope_t = time.time()
+    mesh._estop_lockout.set()
+    mesh._last_estop_ts = envelope_t
+    mesh._estop_replay_cache[float(envelope_t)] = time.monotonic()
+
+    # Second estop from operator B with same t (colliding timestamp)
+    mesh._on_safety_estop(_envelope(t=envelope_t, peer_id="operator-B", reason="Operator B emergency"))
+
+    # Pre-fix: audit_calls contains estop_replay_rejected
+    # Post-fix: audit_calls contains estop_corroborated (lockout active, within 0.2s)
+    assert len(audit_calls) == 1, f"Expected 1 audit call, got {len(audit_calls)}"
+    assert audit_calls[0]["event_type"] == "estop_corroborated", (
+        f"Expected estop_corroborated, got {audit_calls[0]['event_type']}"
+    )
+    assert audit_calls[0]["severity"] == "info"
+    assert audit_calls[0]["payload"]["issuer"] == "operator-B"
+
+
+class TestEstopRedundantAudit:
+    """When a second-operator estop arrives while lockout is already
+    engaged, an audit event must be emitted (forensic preservation).
+    """
+
+    def test_redundant_estop_emits_audit_event(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("STRANDS_MESH_AUDIT_DIR", str(tmp_path))
+        # Reset audit state for isolated test
+        audit_mod._AUDIT_STATE.psk_fingerprint = None
+        audit_mod._AUDIT_STATE.seq_loaded = False
+        audit_mod._SEQ_COUNTERS.clear()
+
+        class StubRobot:
+            pass
+
+        m = core.Mesh(robot=StubRobot(), peer_id="robot-r")
+        # publish_safety_event is gated on self._running; flip it on
+        # without calling start() (which does network I/O). Stub publish()
+        # since we only care about the audit-log side-effect.
+        m._running = True
+        m.publish = lambda key, data: None
+        # First estop engages
+        e1 = {"peer_id": "op-1", "t": time.time(), "type": "estop"}
+
+        class S:
+            def __init__(self, e):
+                self.payload = type("P", (), {"to_bytes": lambda self: json.dumps(e).encode()})()
+
+        m._on_safety_estop(S(e1))
+        assert m._estop_lockout.is_set()
+
+        # Second-operator estop, fresh `t`, lockout already engaged
+        e2 = {"peer_id": "op-2", "t": time.time() + 0.5, "type": "estop"}
+        m._on_safety_estop(S(e2))
+
+        # Walk the audit log
+        records = audit_mod.read_audit_log()
+        events = [r["event"] for r in records]
+        assert "remote_estop_engaged" in events, f"first engagement missing: {events}"
+        assert "remote_estop_redundant" in events, f"second-operator audit missing: {events}"
+
+
+# ---------------------------------------------------------------------
+# the prior fix-1: _PSK_STATE_LOCK exists and protects fingerprint snapshot
+# ---------------------------------------------------------------------
+
+
+# === per-issuer fairness bound on the estop replay cache ===
+
+
+class TestEstopPerIssuerFairnessBound:
+    """The the prior float-only key closes peer_id-permutation replay but
+    opened a denial-of-estop surface where one attacker pre-publishing
+    at ``t = now + skew - eps`` could occupy float slots.
+
+    the prior fix adds a per-issuer slot cap: each issuer may occupy at most
+    ``RESUME_REPLAY_CACHE_MAX // 4`` slots before their newer entries
+    are refused. This means at least 4 distinct issuers always have
+    working slots regardless of attacker volume.
+    """
+
+    def test_one_issuer_cannot_exceed_cap(self, monkeypatch):
+        # Tighten the cache size via env (prior made this lazy-resolved)
+        monkeypatch.setenv("STRANDS_MESH_RESUME_REPLAY_CACHE_MAX", "8")
+        # 8 / 4 = 2 slots per issuer
+
+        m = core.Mesh.__new__(core.Mesh)
+        m.peer_id = "test-peer"
+        m._estop_replay_cache = {}
+        m._estop_replay_lock = threading.Lock()
+        m._estop_lockout = threading.Event()
+        m._last_estop_ts = 0.0
+        m._running = True
+        m.publish = lambda key, data: None
+        m.publish_safety_event = lambda **kw: None  # don't audit in this test
+
+        now = time.time()
+
+        # Attacker fires 5 envelopes at distinct fresh `t` values
+        for i in range(5):
+            envelope = {"peer_id": "attacker-1", "t": now + 0.001 * i, "type": "estop"}
+
+            class S:
+                payload = type("P", (), {"to_bytes": lambda self, e=envelope: json.dumps(e).encode()})()
+
+            m._on_safety_estop(S())
+
+        # per-issuer count is derived from cache contents, not a
+        # separate dict. Count entries owned by attacker-1; the
+        # attacker is capped at per_issuer_cap = MAX // 4 = 2 slots.
+        attacker_slots = sum(1 for issuer, _mono in m._estop_replay_cache.values() if issuer == "attacker-1")
+        assert attacker_slots <= 2, (
+            f"attacker should be capped at 2 slots, got {attacker_slots} (cache: {m._estop_replay_cache})"
+        )
+
+
+# === per-issuer count derived from cache contents ===
+
+
+class TestPerIssuerCountFromCache:
+    """the per-issuer fairness bound counts entries
+    by issuer from cache contents, not a separate dict that drifts after
+    eviction. After eviction, an attacker who flooded their cap legitimately
+    has fewer entries and can reclaim slots -- the dynamic-attacker rate
+    limit. A sustained attacker is bounded by ``per_issuer_cap`` AT EVERY
+    INSTANT, not just between eviction windows.
+    """
+
+    def test_cache_carries_issuer_attribution_in_value(self):
+        m = core.Mesh.__new__(core.Mesh)
+        m.peer_id = "test-peer"
+        m._estop_replay_cache = {}
+        m._estop_replay_lock = threading.Lock()
+        m._estop_lockout = threading.Event()
+        m._last_estop_ts = 0.0
+        m._running = True
+        m.publish = lambda key, data: None
+        m.publish_safety_event = lambda **kw: None
+
+        envelope = {"peer_id": "alice", "t": time.time(), "type": "estop"}
+
+        class S:
+            payload = type("P", (), {"to_bytes": lambda self: json.dumps(envelope).encode()})()
+
+        m._on_safety_estop(S())
+
+        assert len(m._estop_replay_cache) == 1
+        # Value is now (issuer_id, mono_ts) tuple
+        value = next(iter(m._estop_replay_cache.values()))
+        assert isinstance(value, tuple), "cache value must be (issuer_id, mono_ts) tuple"
+        issuer, mono_ts = value
+        assert issuer == "alice"
+        assert isinstance(mono_ts, float)
+
+
+class TestF14OverCapBlocksLockout:
+    """when an issuer exceeds per_issuer_cap,
+    the lockout MUST NOT engage on their over-cap envelopes. the prior implementation
+    the over-cap branch dropped only the cache slot but still let the
+    fall-through ``self._estop_lockout.set()`` run, defeating the
+    fairness bound's whole point (a sustained attacker at-cap still
+    triggered fleet-wide lockouts on every novel ``t`` they emitted).
+    """
+
+    def test_at_cap_envelope_does_not_engage_lockout(self, monkeypatch):
+        # Tighten cap for fast test
+        monkeypatch.setenv("STRANDS_MESH_RESUME_REPLAY_CACHE_MAX", "8")
+        # 8 / 4 = 2 slots per issuer
+
+        m = core.Mesh.__new__(core.Mesh)
+        m.peer_id = "test-peer"
+        m._estop_replay_cache = {}
+        m._estop_replay_lock = threading.Lock()
+        m._estop_lockout = threading.Event()
+        m._last_estop_ts = 0.0
+        m._running = True
+        m.publish = lambda key, data: None
+        m.publish_safety_event = lambda **kw: None
+
+        now = time.time()
+
+        # First two envelopes from attacker fill the cap and engage lockout
+        for i in range(2):
+            envelope = {"peer_id": "attacker", "t": now + 0.001 * i, "type": "estop"}
+
+            class S:
+                payload = type("P", (), {"to_bytes": lambda self, e=envelope: json.dumps(e).encode()})()
+
+            m._on_safety_estop(S())
+
+        assert m._estop_lockout.is_set(), "first 2 should engage lockout"
+
+        # Clear lockout and try a 3rd envelope (over cap) -- it must NOT re-engage
+        m._estop_lockout.clear()
+        envelope = {"peer_id": "attacker", "t": now + 0.005, "type": "estop"}
+
+        class S2:
+            payload = type("P", (), {"to_bytes": lambda self: json.dumps(envelope).encode()})()
+
+        m._on_safety_estop(S2())
+
+        assert not m._estop_lockout.is_set(), (
+            f"F14-B: over-cap envelope must NOT engage lockout. Cache: {m._estop_replay_cache}"
+        )

--- a/tests/mesh/test_estop_replay.py
+++ b/tests/mesh/test_estop_replay.py
@@ -25,6 +25,7 @@ def _stub_mesh() -> core.Mesh:
     m._resume_replay_lock = threading.Lock()
     m._estop_lockout = threading.Event()
     m._last_estop_ts = 0.0
+    m._last_estop_mono = 0.0
     return m
 
 
@@ -85,6 +86,7 @@ def test_distinct_issuers_distinct_wire_zids_same_t_audited_as_corroborated():
     envelope_t = time.time()
     mesh._estop_lockout.set()
     mesh._last_estop_ts = envelope_t
+    mesh._last_estop_mono = time.monotonic()  # corroboration window check uses _last_estop_mono
     mesh._estop_replay_cache[float(envelope_t)] = (
         "operator-A",
         time.monotonic(),
@@ -222,10 +224,13 @@ class TestEstopRedundantAudit:
 
     def test_redundant_estop_emits_audit_event(self, tmp_path, monkeypatch):
         monkeypatch.setenv("STRANDS_MESH_AUDIT_DIR", str(tmp_path))
-        # Reset audit state for isolated test
-        audit_mod._AUDIT_STATE.psk_fingerprint = None
-        audit_mod._AUDIT_STATE.seq_loaded = False
-        audit_mod._SEQ_COUNTERS.clear()
+        # Reset audit state for isolated test (PR4 audit-tamper-evident
+        # adds these globals; on PR6 standalone they may not exist).
+        if hasattr(audit_mod, "_AUDIT_STATE"):
+            audit_mod._AUDIT_STATE.psk_fingerprint = None
+            audit_mod._AUDIT_STATE.seq_loaded = False
+        if hasattr(audit_mod, "_SEQ_COUNTERS"):
+            audit_mod._SEQ_COUNTERS.clear()
 
         class StubRobot:
             pass
@@ -358,16 +363,19 @@ class TestPerIssuerCountFromCache:
         assert wire_zid is None, f"expected wire_zid=None for source_info-less stub, got {wire_zid!r}"
 
 
-class TestF14OverCapBlocksLockout:
-    """when an issuer exceeds per_issuer_cap,
-    the lockout MUST NOT engage on their over-cap envelopes. the prior implementation
-    the over-cap branch dropped only the cache slot but still let the
-    fall-through ``self._estop_lockout.set()`` run, defeating the
-    fairness bound's whole point (a sustained attacker at-cap still
-    triggered fleet-wide lockouts on every novel ``t`` they emitted).
+class TestF14OverCapStillEngagesLockout:
+    """Issue #263/#270: per-issuer cap MUST NOT deny lockout-engagement.
+    The cap protects the bounded replay-cache resource; the lockout itself
+    is idempotent boolean state with no resource cost. Suppressing the
+    lockout for an over-cap issuer is a denial-of-estop on legitimate
+    operators (e.g. fault-handling loops re-emitting estop on every
+    detection cycle, or multi-robot consoles fanning repeated stops).
+
+    The cap-exceeded audit event still fires; only the cache-slot
+    insertion is gated. Safety-over-DoS priority is preserved.
     """
 
-    def test_at_cap_envelope_does_not_engage_lockout(self, monkeypatch):
+    def test_at_cap_envelope_still_engages_lockout(self, monkeypatch):
         # Tighten cap for fast test
         monkeypatch.setenv("STRANDS_MESH_RESUME_REPLAY_CACHE_MAX", "8")
         # 8 / 4 = 2 slots per issuer
@@ -378,15 +386,16 @@ class TestF14OverCapBlocksLockout:
         m._estop_replay_lock = threading.Lock()
         m._estop_lockout = threading.Event()
         m._last_estop_ts = 0.0
+        m._last_estop_mono = 0.0
         m._running = True
         m.publish = lambda key, data: None
         m.publish_safety_event = lambda **kw: None
 
         now = time.time()
 
-        # First two envelopes from attacker fill the cap and engage lockout
+        # First two envelopes from operator fill the cap and engage lockout
         for i in range(2):
-            envelope = {"peer_id": "attacker", "t": now + 0.001 * i, "type": "estop"}
+            envelope = {"peer_id": "operator", "t": now + 0.001 * i, "type": "estop"}
 
             class S:
                 payload = type("P", (), {"to_bytes": lambda self, e=envelope: json.dumps(e).encode()})()
@@ -395,15 +404,24 @@ class TestF14OverCapBlocksLockout:
 
         assert m._estop_lockout.is_set(), "first 2 should engage lockout"
 
-        # Clear lockout and try a 3rd envelope (over cap) -- it must NOT re-engage
+        # Clear lockout and try a 3rd envelope (over cap) -- it MUST re-engage
+        # for safety-over-DoS reasons. The cache-slot is still gated.
         m._estop_lockout.clear()
-        envelope = {"peer_id": "attacker", "t": now + 0.005, "type": "estop"}
+        cache_size_before = len(m._estop_replay_cache)
+        envelope = {"peer_id": "operator", "t": now + 0.005, "type": "estop"}
 
         class S2:
             payload = type("P", (), {"to_bytes": lambda self: json.dumps(envelope).encode()})()
 
         m._on_safety_estop(S2())
 
-        assert not m._estop_lockout.is_set(), (
-            f"F14-B: over-cap envelope must NOT engage lockout. Cache: {m._estop_replay_cache}"
+        # Per issue #263: the lockout MUST engage even when the issuer is
+        # at-cap. The cap only suppresses the cache-slot insert (DoS bound).
+        assert m._estop_lockout.is_set(), (
+            f"#263: over-cap envelope MUST still engage lockout (safety-over-DoS). "
+            f"Cache: {m._estop_replay_cache}"
+        )
+        # Cache slot was NOT consumed (cap held)
+        assert len(m._estop_replay_cache) == cache_size_before, (
+            "cap-exceeded envelope should not consume a cache slot"
         )

--- a/tests/mesh/test_estop_replay.py
+++ b/tests/mesh/test_estop_replay.py
@@ -418,10 +418,7 @@ class TestF14OverCapStillEngagesLockout:
         # Per issue #263: the lockout MUST engage even when the issuer is
         # at-cap. The cap only suppresses the cache-slot insert (DoS bound).
         assert m._estop_lockout.is_set(), (
-            f"#263: over-cap envelope MUST still engage lockout (safety-over-DoS). "
-            f"Cache: {m._estop_replay_cache}"
+            f"#263: over-cap envelope MUST still engage lockout (safety-over-DoS). Cache: {m._estop_replay_cache}"
         )
         # Cache slot was NOT consumed (cap held)
-        assert len(m._estop_replay_cache) == cache_size_before, (
-            "cap-exceeded envelope should not consume a cache slot"
-        )
+        assert len(m._estop_replay_cache) == cache_size_before, "cap-exceeded envelope should not consume a cache slot"

--- a/tests/mesh/test_estop_replay.py
+++ b/tests/mesh/test_estop_replay.py
@@ -211,8 +211,7 @@ def test_attribution_less_transport_same_t_audited_as_replay_rejected():
 
     assert len(audit_calls) == 1
     assert audit_calls[0]["event_type"] == "estop_replay_rejected", (
-        "attribution-less transports cannot prove corroboration; must "
-        "audit as replay_rejected"
+        "attribution-less transports cannot prove corroboration; must audit as replay_rejected"
     )
 
 

--- a/tests/mesh/test_mesh_robustness.py
+++ b/tests/mesh/test_mesh_robustness.py
@@ -232,7 +232,7 @@ def test_hardware_robot_cleanup_stops_mesh() -> None:
     from strands_robots import hardware_robot
 
     # Build a HardwareRobot without going through the full robot() path —
-    # we just need an instance with the.mesh attribute and a cleanup() that
+    # we just need an instance with the .mesh attribute and a cleanup() that
     # works (no real hardware).
     hw = hardware_robot.Robot.__new__(hardware_robot.Robot)
     # Minimal fields cleanup() reads.

--- a/tests/mesh/test_mesh_robustness.py
+++ b/tests/mesh/test_mesh_robustness.py
@@ -232,7 +232,7 @@ def test_hardware_robot_cleanup_stops_mesh() -> None:
     from strands_robots import hardware_robot
 
     # Build a HardwareRobot without going through the full robot() path —
-    # we just need an instance with the .mesh attribute and a cleanup() that
+    # we just need an instance with the.mesh attribute and a cleanup() that
     # works (no real hardware).
     hw = hardware_robot.Robot.__new__(hardware_robot.Robot)
     # Minimal fields cleanup() reads.

--- a/tests/mesh/test_mesh_rpc.py
+++ b/tests/mesh/test_mesh_rpc.py
@@ -89,7 +89,12 @@ def fake_session() -> Iterator[MagicMock]:
 
 @pytest.fixture
 def captured_puts() -> Iterator[list[tuple[str, dict[str, Any]]]]:
-    """Capture every mesh_mod.put() call as (key, data) tuples."""
+    """Capture every mesh.put() call as (key, payload) tuples.
+
+    Wire-level authentication is owned by the Zenoh transport in
+    production; ``put()`` itself just hands plain JSON to the
+    transport. The fixture records the payload as-is.
+    """
     seen: list[tuple[str, dict[str, Any]]] = []
 
     def _spy(key: str, data: dict[str, Any]) -> None:
@@ -156,7 +161,7 @@ def test_dispatch_reset() -> None:
 def test_dispatch_execute_calls_execute_task_sync() -> None:
     r = _FakeRobot()
     m = Mesh(r, peer_id="p")
-    out = m._dispatch({"action": "execute", "instruction": "go", "duration": 5.0})
+    out = m._dispatch({"action": "execute", "instruction": "go", "duration": 5.0, "policy_provider": "mock"})
     assert out == {"executed": "go"}
     assert ("execute", {"instruction": "go", "provider": "mock", "duration": 5.0}) in r.calls
 
@@ -164,7 +169,7 @@ def test_dispatch_execute_calls_execute_task_sync() -> None:
 def test_dispatch_start_calls_start_task() -> None:
     r = _FakeRobot()
     m = Mesh(r, peer_id="p")
-    out = m._dispatch({"action": "start", "instruction": "go"})
+    out = m._dispatch({"action": "start", "instruction": "go", "policy_provider": "mock"})
     assert out == {"started": "go"}
 
 
@@ -229,19 +234,49 @@ def test_exec_cmd_publishes_error_on_dispatch_exception(
     captured_puts: list[tuple[str, dict[str, Any]]],
 ) -> None:
     m = Mesh(_FakeRobot(), peer_id="me")
-    with patch.object(m, "_dispatch", side_effect=RuntimeError("boom")):
-        m._exec_cmd({"sender_id": "alice", "turn_id": "t2", "command": {"action": "x"}})
+    # Use a valid action (status) so we get past command validation and exercise
+    # the original dispatch-exception path that this test was written for.
+    with patch.object(m, "_dispatch", side_effect=RuntimeError("boom-with-internal-detail")):
+        m._exec_cmd({"sender_id": "alice", "turn_id": "t2", "command": {"action": "status"}})
     payload = next(d for k, d in captured_puts if k == "strands/alice/response/t2")
     assert payload["type"] == "error"
-    assert "boom" in payload["error"]
+    # internal exception detail MUST NOT leak onto the wire. The
+    # error string is sanitised to a static "dispatch error" so a remote
+    # caller cannot pivot on path / attribute / library-trace fragments.
+    assert payload["error"] == "dispatch error"
+    assert "boom-with-internal-detail" not in payload["error"]
 
 
-def test_exec_cmd_string_command_becomes_execute() -> None:
+def test_exec_cmd_rejects_unknown_action_with_validation_error(
+    captured_puts: list[tuple[str, dict[str, Any]]],
+) -> None:
+    """An unknown action is rejected at the validation gate, well before any
+    robot side-effect runs. The reply is a structured error envelope that
+    includes the offending action name."""
+    m = Mesh(_FakeRobot(), peer_id="me")
+    m._exec_cmd({"sender_id": "alice", "turn_id": "t3", "command": {"action": "rm_rf"}})
+    payload = next(d for k, d in captured_puts if k == "strands/alice/response/t3")
+    assert payload["type"] == "error"
+    assert "validation" in payload["error"]
+    assert "rm_rf" in payload["error"]
+
+
+def test_exec_cmd_string_command_rejected() -> None:
+    """bare-string commands on the wire bypass validate_command's dict-shape
+    contract. _exec_cmd must reject them, not silently coerce to {action:execute}.
+
+    Pre-the prior fix contract was auto-wrap (a peer publishing "hello" got a mock-policy
+    execute), which let any mTLS+ACL-authorised peer drive the robot at the mock
+    provider with arbitrary text.
+    """
     r = _FakeRobot()
     m = Mesh(r, peer_id="me")
     with patch.object(mesh_mod, "put"):
         m._exec_cmd({"sender_id": "alice", "turn_id": "t", "command": "do thing"})
-    assert any(name == "execute" and args["instruction"] == "do thing" for name, args in r.calls)
+    # No execute call; bare string was rejected at the wire boundary.
+    assert not any(name == "execute" for name, _ in r.calls), (
+        "_exec_cmd must NOT coerce bare-string commands into mock-policy executes"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -262,7 +297,11 @@ def test_send_returns_first_response(started_mesh: Mesh, captured_puts) -> None:
             time.sleep(0.01)
         else:  # pragma: no cover — defensive
             return
-        sample = _make_sample({"turn_id": turn, "result": {"ok": 1}})
+        # Phase-4 / D1: _on_response now requires responder_id to match the
+        # target the sender originally addressed (otherwise an
+        # authenticated peer that observes the turn_id can hijack the
+        # response). Include responder_id="peer-b" to match send target.
+        sample = _make_sample({"turn_id": turn, "responder_id": "peer-b", "result": {"ok": 1}})
         started_mesh._on_response(sample)
 
     threading.Thread(target=fake_responder, daemon=True).start()

--- a/tests/mesh/test_pr6_review_pins.py
+++ b/tests/mesh/test_pr6_review_pins.py
@@ -12,7 +12,6 @@ import pytest
 
 from strands_robots.mesh import core
 
-
 # ---------------------------------------------------------------------------
 # Thread 4: _resume_lockout HMAC compare is constant-time independent of
 # the byte length of the provided override code.
@@ -48,9 +47,7 @@ class TestResumeLockoutTimingOracleClosed:
         m.publish_safety_event = lambda **kw: None
         return m
 
-    def test_compare_target_is_fixed_length_when_expected_unset(
-        self, stub_mesh, monkeypatch
-    ):
+    def test_compare_target_is_fixed_length_when_expected_unset(self, stub_mesh, monkeypatch):
         """When ``STRANDS_MESH_OVERRIDE_CODE`` is unset the placeholder
         digest must still be 32 bytes (the sha256 of a fixed sentinel),
         matching the byte length of any real digest. This collapses the
@@ -71,9 +68,7 @@ class TestResumeLockoutTimingOracleClosed:
         # Lockout must not have cleared either way.
         assert stub_mesh._estop_lockout.is_set()
 
-    def test_compare_runs_on_fixed_digest_length_regardless_of_provided_length(
-        self, stub_mesh, monkeypatch
-    ):
+    def test_compare_runs_on_fixed_digest_length_regardless_of_provided_length(self, stub_mesh, monkeypatch):
         """The compare must operate on 32-byte sha256 digests so probes
         of varying length cannot leak ``len(expected)``.
 
@@ -96,9 +91,7 @@ class TestResumeLockoutTimingOracleClosed:
             assert result == {"status": "error", "error": "resume rejected"}, (
                 f"length-{len(probe)} probe leaked through compare (expected reject)"
             )
-            assert stub_mesh._estop_lockout.is_set(), (
-                f"length-{len(probe)} probe cleared lockout (compare oracle leak)"
-            )
+            assert stub_mesh._estop_lockout.is_set(), f"length-{len(probe)} probe cleared lockout (compare oracle leak)"
 
     def test_correct_override_code_clears_lockout(self, stub_mesh, monkeypatch):
         """The pre-hash refactor must not break the happy path: a
@@ -186,7 +179,96 @@ def test_mesh_publish_shadows_sensor_loops_mixin():
     # not just inherit it from somewhere on the MRO. This catches the
     # subtler regression where someone deletes ``Mesh.publish`` and
     # accidentally relies on a different mixin's implementation.
-    assert "publish" in core.Mesh.__dict__, (
-        "Mesh.publish must be defined on Mesh itself, not inherited "
-        "from the mixin."
-    )
+    assert "publish" in core.Mesh.__dict__, "Mesh.publish must be defined on Mesh itself, not inherited from the mixin."
+
+
+# ---------------------------------------------------------------------------
+# Thread 6: _estop_replay_cache shape invariant -- all entries are 3-tuples
+# (issuer_id, mono_ts, wire_zid). No half-defensive isinstance shim.
+# ---------------------------------------------------------------------------
+
+
+class TestEstopReplayCacheShapeInvariant:
+    """The ``_estop_replay_cache`` must only contain ``(str, float, str | None)``
+    3-tuple values. The type annotation at ``__init__`` declares this and the
+    sole writer (the acceptance path in ``_on_safety_estop``) emits it.
+
+    Pre-fix: a defensive ``isinstance(cached_entry, tuple) and len(cached_entry) >= 3``
+    at the corroboration-branch entry tolerated bare-float legacy stubs, but the
+    ts_view comprehension (``v[1]``) and per-issuer iteration (``for issuer, _mono,
+    _zid in ...values()``) both crashed on bare floats. The half-defensive state
+    masked contract violations at the corroboration site while letting them explode
+    at eviction time -- the worst of both worlds.
+
+    Post-fix: no isinstance guard. A bare-float entry crashes immediately on the
+    cache-hit path (``cached_entry[2]`` on a float raises TypeError), so shape
+    violations surface as close to the writer bug as possible.
+
+    This test pins the structural invariant: ``_on_safety_estop`` writes
+    3-tuples AND no defensive isinstance exists in the source.
+
+    Addresses review thread on core.py:1570.
+    """
+
+    def test_cache_writer_emits_3_tuple(self):
+        """The acceptance path writes (issuer_id, mono_ts, wire_zid)."""
+        import inspect
+
+        source = inspect.getsource(core.Mesh._on_safety_estop)
+        # The writer line: self._estop_replay_cache[cache_key] = (issuer_id, now_mono, wire_zid)
+        assert "(issuer_id, now_mono, wire_zid)" in source, (
+            "The estop replay cache writer must emit the canonical 3-tuple "
+            "(issuer_id, now_mono, wire_zid). If this fails, the shape "
+            "contract at __init__ has drifted from the writer."
+        )
+
+    def test_no_defensive_isinstance_on_cache_entry(self):
+        """The isinstance shim must be absent -- direct subscript access
+        surfaces shape violations immediately."""
+        import inspect
+
+        source = inspect.getsource(core.Mesh._on_safety_estop)
+        assert "isinstance(cached_entry, tuple)" not in source, (
+            "The defensive isinstance(cached_entry, tuple) shim was removed "
+            "because it disagreed with ts_view and per-issuer iteration. "
+            "If this fires, someone reintroduced the half-defensive state."
+        )
+
+    def test_bare_float_in_cache_crashes_on_hit(self):
+        """Verify that a bare-float cache entry is not tolerated.
+
+        Pre-fix this would silently set cached_wire_zid=None (degrading
+        corroboration to always-rejected). Post-fix it raises TypeError
+        on ``cached_entry[2]`` immediately.
+        """
+        import threading
+        import time
+
+        m = core.Mesh.__new__(core.Mesh)
+        m.peer_id = "test-receiver"
+        m._estop_replay_cache = {}
+        m._estop_replay_lock = threading.Lock()
+        m._estop_lockout = threading.Event()
+        m._last_estop_ts = 0.0
+        m._last_estop_mono = 0.0
+
+        # Seed a BARE FLOAT (the shape the removed isinstance tolerated)
+        bad_key = time.time()
+        m._estop_replay_cache[bad_key] = 123.456  # type: ignore[assignment]
+
+        # Simulate a cache-hit read at the corroboration branch.
+        # Post-fix: direct ``cached_entry[2]`` on a float raises TypeError.
+        cached_entry = m._estop_replay_cache[bad_key]
+        with pytest.raises(TypeError):
+            _ = cached_entry[2]  # type: ignore[index]
+
+    def test_type_annotation_matches_3_tuple(self):
+        """The __init__ type annotation must declare the 3-tuple shape."""
+        import inspect
+
+        source = inspect.getsource(core.Mesh.__init__)
+        assert "dict[float, tuple[str, float, str | None]]" in source, (
+            "The _estop_replay_cache type annotation must be "
+            "dict[float, tuple[str, float, str | None]] to enforce "
+            "the 3-tuple shape contract."
+        )

--- a/tests/mesh/test_pr6_review_pins.py
+++ b/tests/mesh/test_pr6_review_pins.py
@@ -330,7 +330,7 @@ class TestEstopLockoutEngagesAtCap:
         for i, line in enumerate(lines):
             if "self._estop_replay_cache[cache_key] =" in line:
                 cache_write_idx = i
-            if "if not self._estop_lockout.is_set():" in line:
+            if "if not lockout_was_engaged:" in line or "if not self._estop_lockout.is_set():" in line:
                 lockout_check_idx = i
                 break
 

--- a/tests/mesh/test_pr6_review_pins.py
+++ b/tests/mesh/test_pr6_review_pins.py
@@ -1,0 +1,141 @@
+"""R7 review-feedback regression pins (timing oracle).
+
+Each test here pins an invariant flagged in PR-6 review threads. Keep
+this file thin and citation-heavy: each test docstring should name the
+exact thread it pins so a future reader can trace the fix to the
+review without spelunking PR history.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from strands_robots.mesh import core
+
+
+# ---------------------------------------------------------------------------
+# Thread 4: _resume_lockout HMAC compare is constant-time independent of
+# the byte length of the provided override code.
+# ---------------------------------------------------------------------------
+
+
+class TestResumeLockoutTimingOracleClosed:
+    """The ``hmac.compare_digest`` call in ``_resume_lockout`` must run
+    over fixed-length 32-byte sha256 digests so an attacker probing with
+    varying-length override codes cannot use response time to learn
+    ``len(STRANDS_MESH_OVERRIDE_CODE)``.
+
+    Pre-fix: ``compare_digest(expected.encode() or b"\x00" * len(provided),
+    provided.encode())`` left a residual ``len(expected) ==
+    len(provided)`` oracle when ``expected`` was configured. CPython's
+    ``hmac.compare_digest`` is documented constant-time only when both
+    inputs share a length; on length mismatch it shortcircuits to
+    ``False`` quickly.
+
+    Post-fix: both inputs are sha256-hashed before the compare, so the
+    compare always operates on 32-byte buffers regardless of input
+    length or whether ``expected`` is configured at all.
+    """
+
+    @pytest.fixture
+    def stub_mesh(self):
+        import threading
+
+        m = core.Mesh.__new__(core.Mesh)
+        m.peer_id = "test-peer"
+        m._estop_lockout = threading.Event()
+        m._last_estop_ts = 0.0
+        m.publish_safety_event = lambda **kw: None
+        return m
+
+    def test_compare_target_is_fixed_length_when_expected_unset(
+        self, stub_mesh, monkeypatch
+    ):
+        """When ``STRANDS_MESH_OVERRIDE_CODE`` is unset the placeholder
+        digest must still be 32 bytes (the sha256 of a fixed sentinel),
+        matching the byte length of any real digest. This collapses the
+        ``configured-vs-unconfigured`` oracle that the prior fix only
+        partially closed.
+        """
+        monkeypatch.delenv("STRANDS_MESH_OVERRIDE_CODE", raising=False)
+        stub_mesh._estop_lockout.set()
+
+        # We do not expose the internal _EXPECTED_HASH; instead, assert
+        # the source-level invariant: any call path through
+        # _resume_lockout must always reject when expected is unset, and
+        # the rejection must NOT depend on the provided length.
+        result_short = stub_mesh._resume_lockout("ab")
+        result_long = stub_mesh._resume_lockout("a" * 4096)
+        assert result_short == {"status": "error", "error": "resume rejected"}
+        assert result_long == {"status": "error", "error": "resume rejected"}
+        # Lockout must not have cleared either way.
+        assert stub_mesh._estop_lockout.is_set()
+
+    def test_compare_runs_on_fixed_digest_length_regardless_of_provided_length(
+        self, stub_mesh, monkeypatch
+    ):
+        """The compare must operate on 32-byte sha256 digests so probes
+        of varying length cannot leak ``len(expected)``.
+
+        We cannot directly observe ``hmac.compare_digest``'s internal
+        length-mismatch shortcut, but we can verify that probes of
+        wildly varying lengths against a configured but wrong code are
+        all rejected uniformly, AND that the source code calls
+        ``hashlib.sha256(...).digest()`` on both compare inputs (pinned
+        in ``test_source_level_pre_hash_invariant``).
+        """
+        monkeypatch.setenv("STRANDS_MESH_OVERRIDE_CODE", "secret-32char-hex-1234567890abcd")
+        stub_mesh._estop_lockout.set()
+
+        # Length-varied probes -- all must reject (none equals the
+        # configured code; the sha256 pre-hash ensures the compare runs
+        # over 32 bytes regardless).
+        for probe in ["", "a", "ab", "a" * 16, "a" * 32, "a" * 1024, "a" * 65536]:
+            stub_mesh._estop_lockout.set()  # re-arm in case any path cleared it
+            result = stub_mesh._resume_lockout(probe)
+            assert result == {"status": "error", "error": "resume rejected"}, (
+                f"length-{len(probe)} probe leaked through compare (expected reject)"
+            )
+            assert stub_mesh._estop_lockout.is_set(), (
+                f"length-{len(probe)} probe cleared lockout (compare oracle leak)"
+            )
+
+    def test_correct_override_code_clears_lockout(self, stub_mesh, monkeypatch):
+        """The pre-hash refactor must not break the happy path: a
+        matching override code still clears the lockout. Without this
+        the security-hardening could silently lock the resume path."""
+        secret = "correct-override-code-32-chars-x"
+        monkeypatch.setenv("STRANDS_MESH_OVERRIDE_CODE", secret)
+        stub_mesh._estop_lockout.set()
+
+        result = stub_mesh._resume_lockout(secret)
+        assert result == {"status": "ok"}
+        assert not stub_mesh._estop_lockout.is_set()
+
+    def test_source_level_pre_hash_invariant(self):
+        """Structural pin: the resume-compare path must hash both
+        inputs to a fixed digest before calling
+        ``hmac.compare_digest``. Pin via source-text inspection so an
+        accidental revert (e.g. someone restoring the
+        ``b"\x00" * len(provided)`` placeholder) trips this test
+        regardless of runtime path coverage.
+        """
+        import inspect
+
+        source = inspect.getsource(core.Mesh._resume_lockout)
+        assert "hashlib.sha256(provided.encode()).digest()" in source, (
+            "_resume_lockout must hash provided to a fixed-length digest "
+            "before compare_digest -- the prior placeholder approach "
+            "left a len(expected)-vs-len(provided) timing oracle."
+        )
+        assert "hashlib.sha256(expected.encode()).digest()" in source, (
+            "_resume_lockout must hash expected when configured."
+        )
+        # The prior placeholder pattern must NOT reappear -- a
+        # readback of the form ``b"\x00" * max(1, len(provided))``
+        # would re-introduce the length oracle.
+        assert 'b"\\x00" * max(1, len(provided))' not in source, (
+            "the variable-length placeholder must not re-appear -- it "
+            "leaks len(provided) via compare_digest's length-mismatch "
+            "shortcut."
+        )

--- a/tests/mesh/test_pr6_review_pins.py
+++ b/tests/mesh/test_pr6_review_pins.py
@@ -272,3 +272,76 @@ class TestEstopReplayCacheShapeInvariant:
             "dict[float, tuple[str, float, str | None]] to enforce "
             "the 3-tuple shape contract."
         )
+
+
+class TestEstopLockoutEngagesAtCap:
+    """Pin: lockout ALWAYS engages even when per-issuer cache cap is exceeded.
+
+    Regression for review thread core.py:1611 (2026-05-30).
+
+    Pre-fix: issuer_slots >= per_issuer_cap triggered an early return,
+    preventing lockout engagement. A legitimate operator whose estops
+    filled their per-issuer cache cap had subsequent estops silently
+    dropped from BOTH cache AND lockout -- inverting the safety contract.
+
+    Post-fix: the cache slot is still refused (resource fairness), but
+    the lockout engages unconditionally (safety-primitive availability).
+    """
+
+    def test_lockout_engages_when_issuer_at_cap(self):
+        """A legitimate operator at per-issuer cache cap still engages lockout."""
+        import inspect
+        import threading
+
+        m = core.Mesh.__new__(core.Mesh)
+        m.peer_id = "test-receiver"
+        m._estop_replay_cache = {}
+        m._estop_replay_lock = threading.Lock()
+        m._estop_lockout = threading.Event()
+        m._last_estop_ts = 0.0
+        m._last_estop_mono = 0.0
+
+        # Verify the early return is absent from the source.
+        source = inspect.getsource(core.Mesh._on_safety_estop)
+
+        # The problematic pattern: a second `issuer_slots >= per_issuer_cap`
+        # check followed by `return` that prevented lockout engagement.
+        # Count occurrences of "issuer_slots >= per_issuer_cap" -- there should
+        # be exactly ONE (the cache-slot gating), not TWO (cache + lockout).
+        occurrences = source.count("issuer_slots >= per_issuer_cap")
+        assert occurrences == 1, (
+            f"Expected exactly 1 occurrence of 'issuer_slots >= per_issuer_cap' "
+            f"(the cache-slot gate), found {occurrences}. "
+            f"A second occurrence that early-returns before lockout engagement "
+            f"is the safety regression this test pins against."
+        )
+
+    def test_no_early_return_between_cache_and_lockout(self):
+        """Structural: no bare `return` between cache logic and lockout block."""
+        import inspect
+        import re
+
+        source = inspect.getsource(core.Mesh._on_safety_estop)
+        lines = source.split("\n")
+
+        # Find the line with "self._estop_replay_cache[cache_key] ="
+        cache_write_idx = None
+        lockout_check_idx = None
+        for i, line in enumerate(lines):
+            if "self._estop_replay_cache[cache_key] =" in line:
+                cache_write_idx = i
+            if "if not self._estop_lockout.is_set():" in line:
+                lockout_check_idx = i
+                break
+
+        assert cache_write_idx is not None, "Could not find cache write line"
+        assert lockout_check_idx is not None, "Could not find lockout check line"
+
+        # Between cache write and lockout check, there must be no bare `return`
+        between = lines[cache_write_idx + 1 : lockout_check_idx]
+        bare_returns = [line.strip() for line in between if re.match(r"^\s*return\s*$", line)]
+        assert not bare_returns, (
+            f"Found bare 'return' statement(s) between cache-write and "
+            f"lockout-engage block: {bare_returns}. This would silently "
+            f"drop the lockout for at-cap issuers (safety regression)."
+        )

--- a/tests/mesh/test_pr6_review_pins.py
+++ b/tests/mesh/test_pr6_review_pins.py
@@ -139,3 +139,54 @@ class TestResumeLockoutTimingOracleClosed:
             "leaks len(provided) via compare_digest's length-mismatch "
             "shortcut."
         )
+
+
+# ---------------------------------------------------------------------------
+# Thread 5: Mesh.publish must shadow SensorLoopsMixin.publish via MRO.
+# ---------------------------------------------------------------------------
+
+
+def test_mesh_publish_shadows_sensor_loops_mixin():
+    """``Mesh.publish`` must shadow the ``SensorLoopsMixin.publish`` stub.
+
+    Review feedback: the mixin's ``publish`` body raises
+    ``NotImplementedError`` -- a deliberate replacement for the prior
+    ``...`` no-effect statement (CodeQL #226). The contract is that
+    ``Mesh`` itself defines a real ``publish`` so the stub is never
+    reached at runtime.
+
+    The contract chain ('``Mesh.publish`` shadows this stub via MRO')
+    depends on every host class declaring ``class Mesh(SensorLoopsMixin)``
+    AND defining its own ``publish``. A future refactor that inserts
+    another mixin between them (e.g. one that also implements ``publish``
+    but forwards differently), or removes ``Mesh.publish`` entirely,
+    would silently fall through to ``NotImplementedError`` only at
+    runtime when a sensor loop fires (POSE_HZ tick, IMU tick, etc.) --
+    a latent fault that escapes import-time checks and unit tests of
+    other paths.
+
+    This test surfaces such a regression at collection time, so a
+    subclass authoring error trips CI before any sensor loop runs in
+    production. Per AGENTS.md > "Pin regression tests for reviewed
+    fixes".
+    """
+    from strands_robots.mesh import sensors
+
+    mesh_publish = core.Mesh.publish
+    mixin_publish = sensors.SensorLoopsMixin.publish
+
+    assert mesh_publish is not mixin_publish, (
+        "Mesh.publish must override SensorLoopsMixin.publish; the mixin "
+        "stub raises NotImplementedError and is never meant to execute. "
+        "If this fires, either Mesh lost its publish definition or a "
+        "mixin was reordered -- check the MRO."
+    )
+
+    # Belt-and-braces: Mesh's own ``__dict__`` must carry ``publish``,
+    # not just inherit it from somewhere on the MRO. This catches the
+    # subtler regression where someone deletes ``Mesh.publish`` and
+    # accidentally relies on a different mixin's implementation.
+    assert "publish" in core.Mesh.__dict__, (
+        "Mesh.publish must be defined on Mesh itself, not inherited "
+        "from the mixin."
+    )

--- a/tests/mesh/test_pr6_review_pins.py
+++ b/tests/mesh/test_pr6_review_pins.py
@@ -345,3 +345,66 @@ class TestEstopLockoutEngagesAtCap:
             f"lockout-engage block: {bare_returns}. This would silently "
             f"drop the lockout for at-cap issuers (safety regression)."
         )
+
+
+# ---------------------------------------------------------------------------
+# Thread (2026-05-30 R14): cache-key namespace conflation -- a bridge
+# peer with peer_id matching a Zenoh wire_zid must not collide.
+# Reviewer: "one-line fix worth landing in this PR."
+# ---------------------------------------------------------------------------
+
+
+class TestResumeCacheKeyNamespaceIsolation:
+    """The resume replay cache key MUST domain-tag the issuer identifier
+    so a Zenoh wire_zid and a body issuer_id from a bridge transport
+    never share the same tuple slot.
+
+    Pre-fix: ``cache_key = (wire_zid or issuer_id, proof_nonce)``
+    Post-fix: ``cache_key = (("wire", wire_zid) if wire_zid is not None else ("body", issuer_id), proof_nonce)``
+
+    Pin: thread core.py:1853 (2026-05-30 review batch).
+    """
+
+    def test_domain_tagged_key_no_collision(self):
+        """A bridge peer with peer_id='ab12cd' and a Zenoh peer with
+        wire_zid='ab12cd' must produce distinct cache keys."""
+        import inspect
+
+        source = inspect.getsource(core.Mesh._on_safety_resume)
+
+        # Structural: the old conflating pattern must be absent.
+        assert "wire_zid or issuer_id" not in source, (
+            "cache_key still uses the conflating 'wire_zid or issuer_id' pattern -- namespace collision is possible"
+        )
+
+        # Structural: domain tag must be present.
+        assert '"wire"' in source or "'wire'" in source, "cache_key does not contain a 'wire' domain tag"
+        assert '"body"' in source or "'body'" in source, "cache_key does not contain a 'body' domain tag"
+
+    def test_same_string_different_transport_distinct_keys(self):
+        """Simulate key construction logic: same string via wire vs body
+        must produce distinct first-tuple elements."""
+        # Simulate the new key construction
+        shared_hex = "ab12cd34ef567890"
+        proof = "nonce-123"
+
+        # Zenoh peer: wire_zid is set
+        wire_key = (("wire", shared_hex), proof)
+        # Bridge peer: wire_zid is None, issuer_id matches the hex
+        body_key = (("body", shared_hex), proof)
+
+        assert wire_key != body_key, (
+            "Same string from different transports must produce distinct cache keys to prevent cross-transport eviction"
+        )
+
+    def test_none_wire_zid_uses_body_domain(self):
+        """When wire_zid is None (bridge/IoT transport), the key must
+        use the 'body' domain tag with issuer_id."""
+        import inspect
+
+        source = inspect.getsource(core.Mesh._on_safety_resume)
+
+        # The conditional must check for None explicitly
+        assert "wire_zid is not None" in source or "wire_zid is None" in source, (
+            "Domain tag conditional must use explicit None check, not truthy/falsy (empty string '' is falsy but valid)"
+        )

--- a/tests/mesh/test_replay_cache_eviction.py
+++ b/tests/mesh/test_replay_cache_eviction.py
@@ -1,0 +1,116 @@
+"""Unit tests for :func:`strands_robots.mesh.core._evict_replay_cache`.
+
+The helper is a single source of truth for the eviction strategy used by
+both ``_estop_replay_cache`` and ``_resume_replay_cache``. End-to-end
+behaviour through the handlers is already covered by
+``test_estop_replay.py`` / ``test_resume_replay.py`` /
+``test_replay_cache_monotonic.py``; this file pins the eviction
+contract at the unit level so a refactor of either caller cannot
+silently change the semantics.
+
+Pin coverage:
+
+- below cap is a no-op (cache untouched).
+- TTL purge drops only stale entries.
+- when the cache is full of in-window (fresh) entries, drop oldest 20
+  percent (drop>=1, ordered by stored timestamp).
+- generic over key type: works for ``float`` keys (estop shape) and
+  ``tuple[str, str]`` keys (resume shape).
+
+Pre-fix verification: the helper is new in the prior fix. The pre-the prior fix code
+duplicates the eviction body inline; without this helper the duplicate
+implementations could drift (e.g. one caller could silently revert to
+``time.time()`` for the cutoff, or change the drop fraction). These
+tests anchor the contract so any future divergence between the helper
+and a hand-inlined re-implementation surfaces here, not in production.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from strands_robots.mesh.core import _evict_replay_cache
+
+
+def test_below_cap_is_noop() -> None:
+    """If the cache is below ``max_size`` the helper must not touch it."""
+    cache: dict[float, float] = {1.0: 100.0, 2.0: 101.0}
+    _evict_replay_cache(cache, max_size=10, ttl_s=60.0, now_mono=200.0)
+    assert cache == {1.0: 100.0, 2.0: 101.0}
+
+
+def test_at_cap_with_stale_entries_drops_only_stale() -> None:
+    """At cap, stale entries (ts < now_mono - ttl_s) are dropped; fresh stay."""
+    cache: dict[float, float] = {
+        1.0: 50.0,  # stale (ts=50, cutoff=140)
+        2.0: 60.0,  # stale
+        3.0: 150.0,  # fresh
+        4.0: 160.0,  # fresh
+    }
+    _evict_replay_cache(cache, max_size=4, ttl_s=60.0, now_mono=200.0)
+    assert cache == {3.0: 150.0, 4.0: 160.0}
+
+
+def test_at_cap_all_fresh_drops_oldest_twenty_percent() -> None:
+    """If the cache is full of in-window entries, drop oldest 20%
+    (rounded down, but at least one entry)."""
+    cache: dict[float, float] = {float(i): 100.0 + i for i in range(10)}
+    # cap=10, all 10 entries fresh (ttl very large).
+    _evict_replay_cache(cache, max_size=10, ttl_s=1000.0, now_mono=200.0)
+    # 10 // 5 == 2 entries dropped (the two oldest by stored ts).
+    assert len(cache) == 8
+    # Oldest two (stored ts 100.0 and 101.0) should be gone.
+    assert 0.0 not in cache
+    assert 1.0 not in cache
+    # All fresher entries retained.
+    for i in range(2, 10):
+        assert float(i) in cache
+
+
+def test_drop_at_least_one_when_small_full_cache() -> None:
+    """``len // 5`` rounds down -- a cap-3 fresh cache must still drop one."""
+    cache: dict[float, float] = {1.0: 100.0, 2.0: 101.0, 3.0: 102.0}
+    _evict_replay_cache(cache, max_size=3, ttl_s=1000.0, now_mono=200.0)
+    # 3 // 5 == 0 but max(1, 0) == 1 -- oldest one dropped.
+    assert len(cache) == 2
+    assert 1.0 not in cache  # the oldest by stored ts
+
+
+def test_works_with_tuple_keys() -> None:
+    """Resume cache uses ``tuple[str, str]`` keys; helper must be generic."""
+    cache: dict[tuple[str, str], float] = {
+        ("issuer-a", "nonce-1"): 50.0,  # stale
+        ("issuer-b", "nonce-2"): 150.0,  # fresh
+    }
+    _evict_replay_cache(cache, max_size=2, ttl_s=60.0, now_mono=200.0)
+    assert cache == {("issuer-b", "nonce-2"): 150.0}
+
+
+def test_ttl_purge_runs_before_lru_drop() -> None:
+    """If the TTL purge brings the cache under ``max_size``, the LRU
+    drop branch must NOT run -- otherwise an in-window entry could be
+    evicted unnecessarily."""
+    cache: dict[float, float] = {
+        1.0: 50.0,  # stale (will be purged)
+        2.0: 150.0,  # fresh -- must survive
+    }
+    _evict_replay_cache(cache, max_size=2, ttl_s=60.0, now_mono=200.0)
+    # After TTL purge cache has 1 entry (< max_size=2), LRU branch skipped.
+    assert cache == {2.0: 150.0}
+
+
+def test_empty_cache_is_noop() -> None:
+    """Empty cache must not raise."""
+    cache: dict[float, float] = {}
+    _evict_replay_cache(cache, max_size=10, ttl_s=60.0, now_mono=200.0)
+    assert cache == {}
+
+
+@pytest.mark.parametrize("size", [100, 1000, 4096])
+def test_cap_values_used_in_production(size: int) -> None:
+    """Spot-check eviction at cap sizes the production code uses."""
+    cache: dict[float, float] = {float(i): 100.0 + i for i in range(size)}
+    _evict_replay_cache(cache, max_size=size, ttl_s=1000.0, now_mono=200.0)
+    # Drop max(1, size // 5) entries.
+    expected_remaining = size - max(1, size // 5)
+    assert len(cache) == expected_remaining

--- a/tests/mesh/test_replay_cache_eviction.py
+++ b/tests/mesh/test_replay_cache_eviction.py
@@ -32,11 +32,22 @@ import pytest
 from strands_robots.mesh.core import _evict_replay_cache
 
 
-def test_below_cap_is_noop() -> None:
-    """If the cache is below ``max_size`` the helper must not touch it."""
+def test_below_cap_keeps_fresh_entries() -> None:
+    """If the cache is below ``max_size`` AND entries are fresh, no-op (issue #274)."""
+    # Fresh entries: ts=180, 181 with cutoff=200-60=140 -> all fresh
+    cache: dict[float, float] = {1.0: 180.0, 2.0: 181.0}
+    _evict_replay_cache(cache, max_size=10, ttl_s=60.0, now_mono=200.0)
+    assert cache == {1.0: 180.0, 2.0: 181.0}
+
+
+def test_below_cap_still_purges_stale_entries() -> None:
+    """Issue #274: TTL purge MUST run even when below max_size to prevent
+    indefinite accumulation of stale entries on low-traffic meshes."""
+    # ts=100, 101 with cutoff=200-60=140 -> both stale
     cache: dict[float, float] = {1.0: 100.0, 2.0: 101.0}
     _evict_replay_cache(cache, max_size=10, ttl_s=60.0, now_mono=200.0)
-    assert cache == {1.0: 100.0, 2.0: 101.0}
+    # Stale entries dropped despite below-cap
+    assert cache == {}
 
 
 def test_at_cap_with_stale_entries_drops_only_stale() -> None:

--- a/tests/mesh/test_replay_cache_monotonic.py
+++ b/tests/mesh/test_replay_cache_monotonic.py
@@ -1,0 +1,125 @@
+"""Pin test for replay-cache TTL eviction must use time.monotonic(). a wall-clock backward step (NTP correction, VM resume)
+must NOT leave cache entries un-evictable; a forward step must NOT age
+fresh entries out early. The cache is local-only bookkeeping; envelope
+freshness still uses wall-clock because it compares the issuer's
+wall-clock-stamped ``t``.
+
+Pin: drives the actual handler ``_on_safety_estop`` / ``_on_safety_resume``,
+asserts the resulting cache value is in the time.monotonic() domain,
+NOT in the time.time() domain. Pre-fix HEAD stored time.time() so the
+gap between the cached value and time.monotonic() at test time is
+typically large (epoch seconds vs process-uptime seconds).
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from types import SimpleNamespace
+from unittest import mock
+
+from strands_robots.mesh import core
+
+
+def _stub_mesh() -> core.Mesh:
+    """Minimal Mesh stub sufficient to exercise the safety handlers."""
+    m = core.Mesh.__new__(core.Mesh)
+    m.peer_id = "test-peer"
+    m._estop_replay_cache = {}
+    m._resume_replay_cache = {}
+    import threading
+
+    m._estop_replay_lock = threading.Lock()
+    m._resume_replay_lock = threading.Lock()
+    m._estop_lockout = threading.Event()
+    m._last_estop_ts = 0.0
+    # publish_safety_event is best-effort and called on accept; stub it.
+    m.publish_safety_event = lambda **kwargs: None  # type: ignore[method-assign]
+    return m
+
+
+def _envelope(t: float, peer_id: str = "issuer-A", **extra) -> Any:
+    body = {"peer_id": peer_id, "t": t, **extra}
+    raw = json.dumps(body).encode()
+    return SimpleNamespace(payload=SimpleNamespace(to_bytes=lambda r=raw: r))
+
+
+def test_estop_cache_value_is_monotonic_not_wall_clock() -> None:
+    """After a remote estop is accepted the stored cache value must be
+    time.monotonic()-derived (process-uptime seconds), NOT time.time()
+    (epoch seconds). The two clock domains differ by ~1.7e9, so the
+    pin is robust."""
+    m = _stub_mesh()
+    wall_now = time.time()
+    m._on_safety_estop(_envelope(t=wall_now, peer_id="alice"))
+
+    assert len(m._estop_replay_cache) == 1
+    # cache value is now (issuer_id, mono_ts) tuple
+    stored_value = next(iter(m._estop_replay_cache.values()))
+    if isinstance(stored_value, tuple):
+        stored_ts = stored_value[1]  # F9-A tuple shape
+    else:
+        stored_ts = stored_value  # legacy shape (resume cache, etc.)
+
+    # Post-fix invariant: stored value is monotonic-derived.
+    # On pre-fix HEAD this fails because time.time() (~1.7e9) is many
+    # orders of magnitude larger than time.monotonic() (process uptime,
+    # typically < 1e6).
+    monotonic_now = time.monotonic()
+    assert abs(stored_ts - monotonic_now) < 5.0, (
+        f"cache value {stored_ts} is not in time.monotonic() domain "
+        f"(monotonic_now={monotonic_now}, wall_now={time.time()}); "
+        f"pre-R19 regression"
+    )
+
+
+def test_resume_cache_value_is_monotonic_not_wall_clock() -> None:
+    """Resume cache mirrors estop -- cache value must be monotonic-derived."""
+    import hashlib
+    import hmac as hmac_mod
+    import os
+
+    m = _stub_mesh()
+    # Resume needs a configured override code on the receiver.
+    # HMAC binds (peer_id, t, lockout_elapsed_s, proof_nonce).
+    import json as _json
+
+    code = "test-override"
+    proof_nonce = "n1"
+    wall_now = time.time()
+    lockout_elapsed = 1.0
+    mac_input = _json.dumps(
+        {
+            "peer_id": "alice",
+            "t": wall_now,
+            "lockout_elapsed_s": lockout_elapsed,
+            "proof_nonce": proof_nonce,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    proof = hmac_mod.new(code.encode(), mac_input, hashlib.sha256).hexdigest()
+
+    with mock.patch.dict(os.environ, {"STRANDS_MESH_OVERRIDE_CODE": code}):
+        m._on_safety_resume(
+            _envelope(
+                t=wall_now,
+                peer_id="alice",
+                lockout_elapsed_s=lockout_elapsed,
+                proof_nonce=proof_nonce,
+                override_proof=proof,
+            )
+        )
+
+    assert len(m._resume_replay_cache) == 1
+    stored_ts = next(iter(m._resume_replay_cache.values()))
+    monotonic_now = time.monotonic()
+    assert abs(stored_ts - monotonic_now) < 5.0, (
+        f"cache value {stored_ts} is not in time.monotonic() domain "
+        f"(monotonic_now={monotonic_now}, wall_now={time.time()}); "
+        f"pre-R19 regression"
+    )
+
+
+# Re-export for ruff
+from typing import Any  # noqa: E402

--- a/tests/mesh/test_resume_env_validation.py
+++ b/tests/mesh/test_resume_env_validation.py
@@ -1,0 +1,174 @@
+"""Pin tests for STRANDS_MESH_RESUME_* env-var input validation.
+
+Without input validation, importing :mod:`strands_robots.mesh.core` with
+a malformed env var (e.g. ``STRANDS_MESH_RESUME_FRESHNESS_S=abc``) would
+raise an opaque :class:`ValueError` at import-time, breaking the whole
+package -- not just the mesh subsystem. Negative values would either
+silently disable the replay cache (``maxlen=0``) or crash later when
+the deque is sized (``maxlen=-1``).
+
+These regressions were discovered by running the module under bad env
+locally before any test would have flagged them. The fix adds
+``_parse_positive_float_env`` / ``_parse_positive_int_env`` helpers that
+log a warning and fall back to the default on bad input.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+@pytest.fixture
+def reload_core(monkeypatch):
+    """Reload ``strands_robots.mesh.core`` with a fresh env state."""
+
+    def _reload():
+        import strands_robots.mesh.core as core_module
+
+        return importlib.reload(core_module)
+
+    return _reload
+
+
+# --- Float env vars ------------------------------------------------------
+
+
+def test_freshness_non_numeric_falls_back(monkeypatch, reload_core, caplog):
+    monkeypatch.setenv("STRANDS_MESH_RESUME_FRESHNESS_S", "abc")
+    with caplog.at_level("WARNING", logger="strands_robots.mesh.core"):
+        core = reload_core()
+    assert core.RESUME_FRESHNESS_WINDOW_S == 60.0
+    assert any("STRANDS_MESH_RESUME_FRESHNESS_S" in r.message for r in caplog.records)
+
+
+def test_freshness_negative_falls_back(monkeypatch, reload_core, caplog):
+    monkeypatch.setenv("STRANDS_MESH_RESUME_FRESHNESS_S", "-10")
+    with caplog.at_level("WARNING", logger="strands_robots.mesh.core"):
+        core = reload_core()
+    assert core.RESUME_FRESHNESS_WINDOW_S == 60.0
+
+
+def test_freshness_valid_passes_through(monkeypatch, reload_core):
+    monkeypatch.setenv("STRANDS_MESH_RESUME_FRESHNESS_S", "120")
+    core = reload_core()
+    assert core.RESUME_FRESHNESS_WINDOW_S == 120.0
+
+
+def test_forward_skew_non_numeric_falls_back(monkeypatch, reload_core, caplog):
+    monkeypatch.setenv("STRANDS_MESH_RESUME_FORWARD_SKEW_S", "not-a-number")
+    with caplog.at_level("WARNING", logger="strands_robots.mesh.core"):
+        core = reload_core()
+    assert core.RESUME_FORWARD_SKEW_S == 5.0
+
+
+def test_forward_skew_negative_falls_back(monkeypatch, reload_core, caplog):
+    monkeypatch.setenv("STRANDS_MESH_RESUME_FORWARD_SKEW_S", "-3.5")
+    with caplog.at_level("WARNING", logger="strands_robots.mesh.core"):
+        core = reload_core()
+    assert core.RESUME_FORWARD_SKEW_S == 5.0
+
+
+# --- Int env vars --------------------------------------------------------
+
+
+def test_replay_cache_max_non_numeric_falls_back(monkeypatch, reload_core, caplog):
+    monkeypatch.setenv("STRANDS_MESH_RESUME_REPLAY_CACHE_MAX", "abc")
+    with caplog.at_level("WARNING", logger="strands_robots.mesh.core"):
+        core = reload_core()
+    assert core.RESUME_REPLAY_CACHE_MAX == 4096
+
+
+def test_replay_cache_max_zero_falls_back(monkeypatch, reload_core, caplog):
+    monkeypatch.setenv("STRANDS_MESH_RESUME_REPLAY_CACHE_MAX", "0")
+    with caplog.at_level("WARNING", logger="strands_robots.mesh.core"):
+        core = reload_core()
+    assert core.RESUME_REPLAY_CACHE_MAX == 4096
+
+
+def test_replay_cache_max_negative_falls_back(monkeypatch, reload_core, caplog):
+    monkeypatch.setenv("STRANDS_MESH_RESUME_REPLAY_CACHE_MAX", "-1")
+    with caplog.at_level("WARNING", logger="strands_robots.mesh.core"):
+        core = reload_core()
+    assert core.RESUME_REPLAY_CACHE_MAX == 4096
+
+
+def test_replay_cache_max_valid_passes_through(monkeypatch, reload_core):
+    monkeypatch.setenv("STRANDS_MESH_RESUME_REPLAY_CACHE_MAX", "8192")
+    core = reload_core()
+    assert core.RESUME_REPLAY_CACHE_MAX == 8192
+
+
+# --- Module imports cleanly with all defaults missing --------------------
+
+
+def test_module_imports_with_no_env_vars(monkeypatch, reload_core):
+    """No env vars set -> defaults must apply, no warnings, no exceptions."""
+    for name in (
+        "STRANDS_MESH_RESUME_FRESHNESS_S",
+        "STRANDS_MESH_RESUME_FORWARD_SKEW_S",
+        "STRANDS_MESH_RESUME_REPLAY_CACHE_MAX",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    core = reload_core()
+    assert core.RESUME_FRESHNESS_WINDOW_S == 60.0
+    assert core.RESUME_FORWARD_SKEW_S == 5.0
+    assert core.RESUME_REPLAY_CACHE_MAX == 4096
+
+
+# === lazy resolution of RESUME_* env vars ===
+
+
+class TestResumeEnvLazyResolution:
+    """RESUME_* env vars are now re-read on every
+    safety-handler call, not snapshotted at module import time. This
+    means an operator setting STRANDS_MESH_RESUME_FRESHNESS_S AFTER
+    importing strands_robots.mesh.core sees the new value without a
+    process restart -- removing the import-order coupling reviewer
+    yinsong1986 flagged in the 21:34 batch.
+    """
+
+    def test_freshness_window_resolves_at_call_time(self, monkeypatch):
+        from strands_robots.mesh import core as core_mod
+
+        monkeypatch.setenv("STRANDS_MESH_RESUME_FRESHNESS_S", "120")
+        # Lazy resolver picks up the new value
+        assert core_mod._resume_freshness_window_s() == 120.0
+
+        monkeypatch.setenv("STRANDS_MESH_RESUME_FRESHNESS_S", "30")
+        assert core_mod._resume_freshness_window_s() == 30.0
+
+    def test_forward_skew_resolves_at_call_time(self, monkeypatch):
+        from strands_robots.mesh import core as core_mod
+
+        monkeypatch.setenv("STRANDS_MESH_RESUME_FORWARD_SKEW_S", "10")
+        assert core_mod._resume_forward_skew_s() == 10.0
+
+    def test_replay_cache_max_resolves_at_call_time(self, monkeypatch):
+        from strands_robots.mesh import core as core_mod
+
+        monkeypatch.setenv("STRANDS_MESH_RESUME_REPLAY_CACHE_MAX", "256")
+        assert core_mod._resume_replay_cache_max() == 256
+
+    def test_module_constants_remain_for_back_compat(self):
+        """The module-level RESUME_* constants are still defined (some
+        downstream code may read them); they are the import-time defaults.
+        Hot paths use the lazy resolvers."""
+        from strands_robots.mesh import core as core_mod
+
+        assert hasattr(core_mod, "RESUME_FRESHNESS_WINDOW_S")
+        assert hasattr(core_mod, "RESUME_FORWARD_SKEW_S")
+        assert hasattr(core_mod, "RESUME_REPLAY_CACHE_MAX")
+        assert isinstance(core_mod.RESUME_FRESHNESS_WINDOW_S, float)
+        assert isinstance(core_mod.RESUME_FORWARD_SKEW_S, float)
+        assert isinstance(core_mod.RESUME_REPLAY_CACHE_MAX, int)
+
+    def test_bad_env_falls_back_to_default_at_call_time(self, monkeypatch):
+        """Bad env values fall back to the documented defaults (matching
+        the existing _parse_positive_*_env contracts)."""
+        from strands_robots.mesh import core as core_mod
+
+        monkeypatch.setenv("STRANDS_MESH_RESUME_FRESHNESS_S", "abc")
+        # Falls back to default 60
+        assert core_mod._resume_freshness_window_s() == 60.0

--- a/tests/mesh/test_resume_replay.py
+++ b/tests/mesh/test_resume_replay.py
@@ -109,7 +109,8 @@ def test_replay_of_same_envelope_is_rejected(monkeypatch):
     assert m._estop_lockout.is_set() is True  # lockout stays set
 
     # Verify cache contains the (issuer, proof_nonce) tuple
-    cache_key = (env["peer_id"], env["proof_nonce"])
+    # issue #264: domain-tagged cache key prevents wire_zid/issuer_id namespace collision
+    cache_key = (("body", env["peer_id"]), env["proof_nonce"])
     assert cache_key in m._resume_replay_cache
 
     # Verify audit event was emitted

--- a/tests/mesh/test_resume_replay.py
+++ b/tests/mesh/test_resume_replay.py
@@ -1,0 +1,380 @@
+"""Regression tests for resume-replay defenses in Mesh._on_safety_resume.
+
+This test suite validates the fix for this PR reviewer concern:
+the cryptographic shape `HMAC(override_code, proof_nonce)` with the issuer
+choosing the nonce originally gave no replay defense between fellow
+operator-class peers.
+
+The fix in core.py adds:
+1. Freshness window (RESUME_FRESHNESS_WINDOW_S, default 60s)
+2. Forward-skew bound (RESUME_FORWARD_SKEW_S, default 5s)
+3. Per-receiver replay cache ((issuer_peer_id, proof_nonce) tuple)
+4. Bounded cache (RESUME_REPLAY_CACHE_MAX, default 4096) with stale-entry
+   sweep + oldest-20%-drop fallback
+"""
+
+import hmac
+import json
+import logging
+import time
+import uuid
+from unittest.mock import MagicMock
+
+from strands_robots.mesh.core import Mesh
+
+
+def _make_mesh(peer_id="r-test"):
+    """Construct a minimally-instantiated Mesh without calling init_mesh."""
+    robot = MagicMock()
+    m = Mesh.__new__(Mesh)  # bypass __init__ side-effects
+    Mesh.__init__(m, robot, peer_id)
+    return m
+
+
+def _sample(payload_dict):
+    """Make a fake zenoh sample with a JSON payload."""
+    s = MagicMock()
+    s.payload.to_bytes.return_value = json.dumps(payload_dict).encode()
+    return s
+
+
+def _make_envelope(override_code, *, t=None, peer_id="op-1", proof_nonce=None, lockout_elapsed_s=1.0):
+    """Mint a valid resume envelope keyed off a specific override code.
+
+    the HMAC binds (peer_id, t, lockout_elapsed_s, proof_nonce)
+    via a deterministic JSON encoding -- we mirror that on the issuing
+    fixture side so the receiver-side compare passes.
+    """
+    import json as _json
+
+    proof_nonce = proof_nonce or uuid.uuid4().hex
+    envelope_t = t if t is not None else time.time()
+    mac_input = _json.dumps(
+        {
+            "peer_id": peer_id,
+            "t": envelope_t,
+            "lockout_elapsed_s": lockout_elapsed_s,
+            "proof_nonce": proof_nonce,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    proof = hmac.new(override_code.encode(), mac_input, "sha256").hexdigest()
+    return {
+        "peer_id": peer_id,
+        "t": envelope_t,
+        "lockout_elapsed_s": lockout_elapsed_s,
+        "proof_nonce": proof_nonce,
+        "override_proof": proof,
+    }
+
+
+def test_first_legitimate_resume_clears_lockout(monkeypatch):
+    """Sanity / happy path: a valid fresh envelope clears the lockout."""
+    monkeypatch.setenv("STRANDS_MESH_OVERRIDE_CODE", "secret")
+    m = _make_mesh()
+    m.publish_safety_event = MagicMock()  # stub out audit publishing
+
+    # Set lockout
+    m._estop_lockout.set()
+    assert m._estop_lockout.is_set()
+
+    # Send valid resume
+    env = _make_envelope("secret")
+    m._on_safety_resume(_sample(env))
+
+    # Lockout should be cleared
+    assert m._estop_lockout.is_set() is False
+
+
+def test_replay_of_same_envelope_is_rejected(monkeypatch):
+    """Replay of the same envelope is rejected via cache."""
+    monkeypatch.setenv("STRANDS_MESH_OVERRIDE_CODE", "secret")
+    m = _make_mesh()
+    m.publish_safety_event = MagicMock()
+
+    # Mint ONE envelope
+    env = _make_envelope("secret", peer_id="op-1")
+
+    # First resume: accepted
+    m._estop_lockout.set()
+    m._on_safety_resume(_sample(env))
+    assert m._estop_lockout.is_set() is False
+
+    # Re-arm lockout
+    m._estop_lockout.set()
+
+    # Second resume with SAME envelope: rejected (replay)
+    m._on_safety_resume(_sample(env))
+    assert m._estop_lockout.is_set() is True  # lockout stays set
+
+    # Verify cache contains the (issuer, proof_nonce) tuple
+    cache_key = (env["peer_id"], env["proof_nonce"])
+    assert cache_key in m._resume_replay_cache
+
+    # Verify audit event was emitted
+    calls = [c for c in m.publish_safety_event.call_args_list if c[1].get("event_type") == "resume_replay_rejected"]
+    assert len(calls) == 1
+
+
+def test_stale_envelope_rejected(monkeypatch):
+    """Envelope older than RESUME_FRESHNESS_WINDOW_S is rejected."""
+    monkeypatch.setenv("STRANDS_MESH_OVERRIDE_CODE", "secret")
+    m = _make_mesh()
+    m.publish_safety_event = MagicMock()
+
+    # Mint envelope with t = 1 hour ago
+    env = _make_envelope("secret", t=time.time() - 3600)
+
+    m._estop_lockout.set()
+    m._on_safety_resume(_sample(env))
+
+    # Lockout should still be set (envelope rejected for staleness)
+    assert m._estop_lockout.is_set() is True
+
+
+def test_future_envelope_rejected_beyond_skew(monkeypatch):
+    """Envelope with t beyond RESUME_FORWARD_SKEW_S is rejected."""
+    monkeypatch.setenv("STRANDS_MESH_OVERRIDE_CODE", "secret")
+    m = _make_mesh()
+    m.publish_safety_event = MagicMock()
+
+    # Mint envelope with t = 60s in future (beyond default 5s skew)
+    env = _make_envelope("secret", t=time.time() + 60)
+
+    m._estop_lockout.set()
+    m._on_safety_resume(_sample(env))
+
+    # Lockout should still be set
+    assert m._estop_lockout.is_set() is True
+
+
+def test_envelope_within_forward_skew_accepted(monkeypatch):
+    """Envelope with t within RESUME_FORWARD_SKEW_S is accepted."""
+    monkeypatch.setenv("STRANDS_MESH_OVERRIDE_CODE", "secret")
+    m = _make_mesh()
+    m.publish_safety_event = MagicMock()
+
+    # Mint envelope with t = 1s in future (within default 5s skew)
+    env = _make_envelope("secret", t=time.time() + 1.0)
+
+    m._estop_lockout.set()
+    m._on_safety_resume(_sample(env))
+
+    # Lockout should be cleared
+    assert m._estop_lockout.is_set() is False
+
+
+def test_replay_cache_bounded(monkeypatch):
+    """Replay cache is bounded at RESUME_REPLAY_CACHE_MAX.
+
+    hot paths now re-read the env var via lazy resolver, so the
+    test sets the env var directly rather than monkeypatching the
+    module-level constant (which is now only the import-time default).
+    """
+    monkeypatch.setenv("STRANDS_MESH_OVERRIDE_CODE", "secret")
+    monkeypatch.setenv("STRANDS_MESH_RESUME_REPLAY_CACHE_MAX", "8")
+
+    m = _make_mesh()
+    m.publish_safety_event = MagicMock()
+
+    # Drive 20 distinct nonces through the resume handler
+    for i in range(20):
+        env = _make_envelope("secret", peer_id=f"op-{i}", proof_nonce=uuid.uuid4().hex)
+        m._estop_lockout.set()
+        m._on_safety_resume(_sample(env))
+
+    # Cache should be bounded
+    assert len(m._resume_replay_cache) <= 8
+
+
+def test_envelope_missing_t_field_rejected(monkeypatch):
+    """Envelope missing the t field is rejected."""
+    monkeypatch.setenv("STRANDS_MESH_OVERRIDE_CODE", "secret")
+    m = _make_mesh()
+    m.publish_safety_event = MagicMock()
+
+    # Mint envelope then delete t field
+    env = _make_envelope("secret")
+    del env["t"]
+
+    m._estop_lockout.set()
+    m._on_safety_resume(_sample(env))
+
+    # Lockout should still be set
+    assert m._estop_lockout.is_set() is True
+
+
+def test_envelope_invalid_t_type_rejected(monkeypatch):
+    """Envelope with invalid t type is rejected."""
+    monkeypatch.setenv("STRANDS_MESH_OVERRIDE_CODE", "secret")
+    m = _make_mesh()
+    m.publish_safety_event = MagicMock()
+
+    # Mint envelope with invalid t type
+    env = _make_envelope("secret")
+    env["t"] = "not-a-number"
+
+    m._estop_lockout.set()
+    m._on_safety_resume(_sample(env))
+
+    # Lockout should still be set
+    assert m._estop_lockout.is_set() is True
+
+
+def test_replay_emits_audit_event(monkeypatch):
+    """Replay rejection emits resume_replay_rejected audit event."""
+    monkeypatch.setenv("STRANDS_MESH_OVERRIDE_CODE", "secret")
+    m = _make_mesh()
+    m.publish_safety_event = MagicMock()
+
+    # Mint ONE envelope
+    env = _make_envelope("secret", peer_id="op-attacker")
+
+    # First resume: accepted
+    m._estop_lockout.set()
+    m._on_safety_resume(_sample(env))
+    assert m._estop_lockout.is_set() is False
+
+    # Check that resume_clear event was emitted
+    clear_calls = [
+        c for c in m.publish_safety_event.call_args_list if c[1].get("event_type") == "remote_resume_applied"
+    ]
+    assert len(clear_calls) == 1
+
+    # Re-arm lockout
+    m._estop_lockout.set()
+
+    # Second resume with SAME envelope: replay rejected
+    m._on_safety_resume(_sample(env))
+
+    # Check that resume_replay_rejected event was emitted
+    replay_calls = [
+        c for c in m.publish_safety_event.call_args_list if c[1].get("event_type") == "resume_replay_rejected"
+    ]
+    assert len(replay_calls) == 1
+
+    # Verify payload contains issuer
+    replay_payload = replay_calls[0][1]["payload"]
+    assert replay_payload["issuer"] == "op-attacker"
+    assert "proof_nonce_prefix" in replay_payload
+
+
+class TestResumeStrictPeerId:
+    """The estop handler rejects envelopes with empty/missing
+    peer_id outright. Resume must mirror that posture.
+    """
+
+    def test_resume_with_empty_peer_id_rejected(self, caplog):
+        class StubRobot:
+            pass
+
+        m = Mesh(robot=StubRobot(), peer_id="robot-test")
+        m._estop_lockout.set()  # lockout is engaged so resume would normally clear it
+
+        # Forge a resume envelope that's otherwise well-formed but has empty peer_id
+        envelope = {
+            "peer_id": "",
+            "t": time.time(),
+            "proof_nonce": "n" * 32,
+            "override_proof": "x" * 64,
+        }
+
+        class FakeSample:
+            payload = type("P", (), {"to_bytes": lambda self: json.dumps(envelope).encode()})()
+
+        with caplog.at_level(logging.WARNING, logger="strands_robots.mesh.core"):
+            m._on_safety_resume(FakeSample())
+
+        # Lockout MUST still be engaged (resume rejected)
+        assert m._estop_lockout.is_set(), "resume with empty peer_id should NOT clear lockout"
+        # Cache should NOT have a polluting entry
+        assert len(m._resume_replay_cache) == 0, "no cache entry should be created for invalid peer_id"
+
+
+# ---------------------------------------------------------------------
+# the prior fix-4: remote_estop_redundant audit on second-operator estop
+# ---------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------
+# HMAC binds envelope routing fields (peer_id, t,
+# lockout_elapsed_s, proof_nonce). A captured envelope mutated on ANY
+# of those four fields by an attacker is rejected at the MAC layer
+# regardless of the cache state.
+# ---------------------------------------------------------------------
+
+
+def test_f18a_captured_envelope_with_mutated_peer_id_rejected(monkeypatch):
+    """Captured legitimate envelope, attacker rewrites peer_id only:
+    pre-the prior fix the MAC compare passed (covered nonce only), and the
+    cache key (issuer_id, proof_nonce) became (NEW_id, proof_nonce)
+    -- a cache miss -- so the lockout cleared on every replay.
+    Post-the prior fix the MAC compare fails because peer_id is now bound."""
+    monkeypatch.setenv("STRANDS_MESH_OVERRIDE_CODE", "secret")
+    m = _make_mesh()
+
+    # 1. Legitimate envelope minted by the canonical issuer.
+    env = _make_envelope("secret", peer_id="op-legit")
+
+    # 2. Attacker captures the envelope and mutates peer_id only.
+    env["peer_id"] = "op-attacker-impersonating"
+
+    # 3. Lockout is engaged; receiver sees the mutated envelope.
+    m._estop_lockout.set()
+    m._on_safety_resume(_sample(env))
+
+    # The lockout MUST stay engaged -- the prior fix rejects mutated envelopes
+    # at the MAC layer.
+    assert m._estop_lockout.is_set() is True
+
+
+def test_f18a_captured_envelope_with_mutated_t_rejected(monkeypatch):
+    """Captured legitimate envelope, attacker rewrites t to bypass
+    the freshness check (push it forward) -- post-the prior fix the MAC compare
+    fails because t is now bound to the signature."""
+    monkeypatch.setenv("STRANDS_MESH_OVERRIDE_CODE", "secret")
+    m = _make_mesh()
+
+    # Mint at t=now.
+    original_t = time.time()
+    env = _make_envelope("secret", t=original_t, peer_id="op-legit")
+
+    # Attacker forwards t by 1 second.
+    env["t"] = original_t + 1.0
+
+    m._estop_lockout.set()
+    m._on_safety_resume(_sample(env))
+
+    assert m._estop_lockout.is_set() is True
+
+
+def test_f18a_captured_envelope_with_mutated_lockout_elapsed_rejected(monkeypatch):
+    """Mutating lockout_elapsed_s (forensic noise field) also breaks
+    the MAC -- the field is bound, so the receiver cannot trust any
+    of these wire fields without the issuer's cooperation."""
+    monkeypatch.setenv("STRANDS_MESH_OVERRIDE_CODE", "secret")
+    m = _make_mesh()
+
+    env = _make_envelope("secret", peer_id="op-legit", lockout_elapsed_s=2.5)
+    env["lockout_elapsed_s"] = 9999.0  # attacker rewrites
+
+    m._estop_lockout.set()
+    m._on_safety_resume(_sample(env))
+
+    assert m._estop_lockout.is_set() is True
+
+
+def test_f18a_envelope_without_lockout_elapsed_s_rejected(monkeypatch):
+    """A malformed envelope missing lockout_elapsed_s is rejected
+    outright before MAC compare (prior shape gate)."""
+    monkeypatch.setenv("STRANDS_MESH_OVERRIDE_CODE", "secret")
+    m = _make_mesh()
+
+    env = _make_envelope("secret", peer_id="op-legit")
+    del env["lockout_elapsed_s"]
+
+    m._estop_lockout.set()
+    m._on_safety_resume(_sample(env))
+
+    assert m._estop_lockout.is_set() is True

--- a/tests/mesh/test_safety_envelope_fallback.py
+++ b/tests/mesh/test_safety_envelope_fallback.py
@@ -1,0 +1,38 @@
+"""Regression pin: _publish_safety_envelope fallback must strip body
+source_zid so receivers do not hard-reject body-present + wire-absent
+envelopes (availability fix)."""
+
+
+def test_estop_fallback_strips_source_zid(monkeypatch):
+    from strands_robots.mesh import core
+
+    captured = {}
+
+    def fake_put(key, payload):
+        captured["key"] = key
+        captured["payload"] = payload
+
+    monkeypatch.setattr(core, "put", fake_put)
+
+    m = core.Mesh(robot=object(), peer_id="t1")
+    # Force the fallback path (no publisher available).
+    monkeypatch.setattr(m, "_safety_publisher_for", lambda key: None)
+
+    m._publish_safety_envelope(
+        "strands/safety/estop",
+        {"peer_id": "t1", "t": 1.0, "source_zid": "deadbeef"},
+    )
+
+    assert captured["key"] == "strands/safety/estop"
+    assert "source_zid" not in captured["payload"]
+    # Other fields preserved.
+    assert captured["payload"]["peer_id"] == "t1"
+
+
+def test_strip_wire_zid_noop_when_absent():
+    from strands_robots.mesh import core
+
+    m = core.Mesh(robot=object(), peer_id="t2")
+    payload = {"peer_id": "t2", "t": 1.0}
+    # No source_zid -> returns same object (cheap no-op).
+    assert m._strip_wire_zid(payload) is payload

--- a/tests/mesh/test_safety_rate_caps.py
+++ b/tests/mesh/test_safety_rate_caps.py
@@ -1,0 +1,97 @@
+"""the prior fix pin tests for safety-topic rate / size caps in zenoh transport.
+
+Yin's review on _zenoh_config.py:251 -- downsampling and low_pass_filter
+only target **/cmd / **/broadcast / **/camera/**. Neither glob covers
+**/safety/**. Under permissive default ACL, any cert-holding peer can
+flood safety/estop with novel-`t` envelopes (bypassing the receiver
+replay cache) and consume CPU on freshness checks at line rate.
+
+the prior fix fix: extend both blocks to cover **/safety/** with their own
+(lower) caps -- 2 Hz frequency, 4 KiB size. Configurable via
+``STRANDS_MESH_SAFETY_RATE_HZ`` / ``STRANDS_MESH_MAX_SAFETY_BYTES``.
+
+Per AGENTS.md > Review Learnings (#85) > "Pin regression tests for
+reviewed fixes."
+"""
+
+from __future__ import annotations
+
+import json
+
+from strands_robots.mesh import _zenoh_config as zc
+
+
+def _downsampling_rules() -> list[dict]:
+    """Parse the JSON5 downsampling block back into a rules list."""
+    _, body = zc.downsampling_block()
+    parsed = json.loads(body)
+    return parsed[0]["rules"]
+
+
+def _low_pass_filter_blocks() -> list[dict]:
+    _, body = zc.low_pass_filter_block()
+    return json.loads(body)
+
+
+def test_downsampling_covers_safety_topics():
+    """R21: ``**/safety/**`` is rate-capped via downsampling."""
+    rules = _downsampling_rules()
+    safety_rules = [r for r in rules if r["key_expr"] == "**/safety/**"]
+    assert len(safety_rules) == 1, f"exactly one safety/** downsampling rule expected; got {rules!r}"
+    assert safety_rules[0]["freq"] == zc.DEFAULT_SAFETY_RATE_HZ
+    assert safety_rules[0]["freq"] > 0
+
+
+def test_low_pass_filter_covers_safety_topics():
+    """R21: ``**/safety/**`` is byte-capped via low_pass_filter."""
+    blocks = _low_pass_filter_blocks()
+    safety_blocks = [b for b in blocks if "**/safety/**" in b["key_exprs"]]
+    assert len(safety_blocks) == 1, "exactly one safety/** low_pass_filter block expected"
+    assert safety_blocks[0]["size_limit"] == zc.DEFAULT_MAX_SAFETY_BYTES
+    assert safety_blocks[0]["size_limit"] > 0
+
+
+def test_safety_rate_hz_env_override(monkeypatch):
+    """``STRANDS_MESH_SAFETY_RATE_HZ`` overrides the default safety rate."""
+    monkeypatch.setenv("STRANDS_MESH_SAFETY_RATE_HZ", "0.5")
+    rules = _downsampling_rules()
+    safety_rule = next(r for r in rules if r["key_expr"] == "**/safety/**")
+    assert safety_rule["freq"] == 0.5
+
+
+def test_max_safety_bytes_env_override(monkeypatch):
+    """``STRANDS_MESH_MAX_SAFETY_BYTES`` overrides the default safety size."""
+    monkeypatch.setenv("STRANDS_MESH_MAX_SAFETY_BYTES", "8192")
+    blocks = _low_pass_filter_blocks()
+    safety_block = next(b for b in blocks if "**/safety/**" in b["key_exprs"])
+    assert safety_block["size_limit"] == 8192
+
+
+def test_safety_rate_below_cmd_rate_by_design():
+    """Safety legitimately is far below cmd traffic; the default cap
+    must reflect that or it lets through traffic the design considers
+    flood."""
+    assert zc.DEFAULT_SAFETY_RATE_HZ < zc.DEFAULT_CMD_RATE_HZ
+
+
+def test_safety_size_cap_below_camera_cap_by_design():
+    """Safety envelopes are small JSON dicts; camera frames are MiB.
+    Caps must differ accordingly."""
+    assert zc.DEFAULT_MAX_SAFETY_BYTES < zc.DEFAULT_MAX_CAMERA_BYTES
+
+
+def test_existing_cmd_and_broadcast_rules_unaffected():
+    """the prior fix must not regress the prior/the prior fix rate caps on cmd / broadcast --
+    those are pinned by other tests but we double-check here."""
+    rules = _downsampling_rules()
+    cmd = next((r for r in rules if r["key_expr"] == "**/cmd"), None)
+    broadcast = next((r for r in rules if r["key_expr"] == "**/broadcast"), None)
+    assert cmd is not None and cmd["freq"] == zc.DEFAULT_CMD_RATE_HZ
+    assert broadcast is not None and broadcast["freq"] == zc.DEFAULT_CMD_RATE_HZ
+
+
+def test_existing_camera_size_cap_unaffected():
+    blocks = _low_pass_filter_blocks()
+    camera = next((b for b in blocks if "**/camera/**" in b["key_exprs"]), None)
+    assert camera is not None
+    assert camera["size_limit"] == zc.DEFAULT_MAX_CAMERA_BYTES

--- a/tests/mesh/test_safety_source_zid_binding.py
+++ b/tests/mesh/test_safety_source_zid_binding.py
@@ -36,8 +36,8 @@ import hmac
 import json
 import time
 import uuid
-from typing import Any
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest

--- a/tests/mesh/test_safety_source_zid_binding.py
+++ b/tests/mesh/test_safety_source_zid_binding.py
@@ -36,6 +36,7 @@ import hmac
 import json
 import time
 import uuid
+from typing import Any
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -49,7 +50,7 @@ _LEGIT_ZID = "0123456789abcdef0123456789abcdef"
 _ATTACKER_ZID = "fedcba9876543210fedcba9876543210"
 
 
-def _zid_obj(zid_str: str) -> SimpleNamespace:
+def _zid_obj(zid_str: str) -> Any:
     """Stand-in for ``zenoh.ZenohId`` whose ``str()`` returns the hex digest."""
 
     class _Zid:

--- a/tests/mesh/test_safety_source_zid_binding.py
+++ b/tests/mesh/test_safety_source_zid_binding.py
@@ -1,0 +1,458 @@
+"""Regression tests for the wire-level ``source_zid`` binding on
+safety estop / resume envelopes.
+
+Threat model addressed
+----------------------
+Body-level HMAC binding (peer_id, t, lockout_elapsed_s, proof_nonce)
+catches an attacker who mutates body fields of a captured envelope. It
+does NOT catch an attacker on a *different* mTLS-authenticated session
+who also holds the override code: that attacker can mint a fresh
+envelope with a body of their choosing and a freshly-computed MAC. The
+receiver-side compare passes because the attacker's body matches their
+MAC.
+
+Fix: bind the publisher's TLS-authenticated Zenoh session ID
+(``sample.source_info.source_id.zid``) into both:
+
+1. The body of every safety envelope (``source_zid`` field).
+2. The HMAC input for resume envelopes.
+
+The receiver:
+
+- extracts ``sample.source_info.source_id.zid`` (set by Zenoh during
+  the mTLS-bootstrapped session handshake; ``ZenohId`` has no public
+  Python constructor),
+- requires body ``source_zid`` to equal wire ``source_zid`` when both
+  are present,
+- requires both-present-or-both-absent (no silent downgrade),
+- re-derives the resume MAC using the wire-level zid.
+
+These tests pin all four behaviours.
+"""
+
+from __future__ import annotations
+
+import hmac
+import json
+import time
+import uuid
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from strands_robots.mesh import core as core_module
+from strands_robots.mesh.core import Mesh, _extract_sample_source_zid
+
+# Real-format zid: 32 lowercase hex chars
+_LEGIT_ZID = "0123456789abcdef0123456789abcdef"
+_ATTACKER_ZID = "fedcba9876543210fedcba9876543210"
+
+
+def _zid_obj(zid_str: str) -> SimpleNamespace:
+    """Stand-in for ``zenoh.ZenohId`` whose ``str()`` returns the hex digest."""
+
+    class _Zid:
+        def __init__(self, s: str) -> None:
+            self._s = s
+
+        def __str__(self) -> str:
+            return self._s
+
+    return _Zid(zid_str)
+
+
+def _make_sample(payload: dict, source_zid: str | None = None) -> SimpleNamespace:
+    """Construct a minimal Zenoh-sample fake.
+
+    When *source_zid* is provided the sample's
+    ``source_info.source_id.zid`` returns it; otherwise ``source_info``
+    is None (mirroring a transport that did not attach SourceInfo).
+    """
+    body = json.dumps(payload).encode("utf-8")
+    if source_zid is None:
+        return SimpleNamespace(
+            payload=SimpleNamespace(to_bytes=lambda: body),
+            source_info=None,
+        )
+    return SimpleNamespace(
+        payload=SimpleNamespace(to_bytes=lambda: body),
+        source_info=SimpleNamespace(
+            source_id=SimpleNamespace(zid=_zid_obj(source_zid)),
+            source_sn=1,
+        ),
+    )
+
+
+@pytest.fixture
+def receiver():
+    """Bare ``Mesh`` instance with the bits ``_on_safety_*`` touch."""
+    m = Mesh.__new__(Mesh)
+    Mesh.__init__(m, MagicMock(), peer_id="receiver-1")
+    m.publish_safety_event = MagicMock()
+    return m
+
+
+# Extractor ---------------------------------------------------------------
+
+
+def test_extract_zid_from_well_formed_sample():
+    """A sample carrying a 32-char hex zid returns that string."""
+    sample = _make_sample({"hello": "world"}, source_zid=_LEGIT_ZID)
+    assert _extract_sample_source_zid(sample) == _LEGIT_ZID
+
+
+def test_extract_zid_returns_none_when_source_info_absent():
+    """Bridge / IoT transports do not propagate source_info."""
+    sample = _make_sample({"hello": "world"}, source_zid=None)
+    assert _extract_sample_source_zid(sample) is None
+
+
+def test_extract_zid_rejects_non_hex_stand_ins():
+    """A ``MagicMock`` whose source_id.zid stringifies to a Mock repr
+    must NOT be accepted as a real wire-bound zid."""
+    sample = MagicMock()
+    # MagicMock auto-creates source_info / source_id / zid; the str()
+    # of a MagicMock is the well-known ``<MagicMock id=...>`` form,
+    # which does not match the strict hex pattern.
+    assert _extract_sample_source_zid(sample) is None
+
+
+def test_extract_zid_rejects_uppercase_hex():
+    """ZenohId stringifies to lowercase hex; uppercase is rejected.
+
+    Defence-in-depth: the format pin is part of the binding contract.
+    A future zenoh-python that emitted uppercase would force a code
+    review (this test fails) rather than silently changing the wire
+    invariant.
+    """
+    sample = _make_sample({}, source_zid=_LEGIT_ZID.upper())
+    assert _extract_sample_source_zid(sample) is None
+
+
+def test_extract_zid_rejects_overlong_string():
+    """Strings longer than 32 hex chars are rejected as malformed."""
+    sample = _make_sample({}, source_zid="0" * 33)
+    assert _extract_sample_source_zid(sample) is None
+
+
+# Receiver-side: estop ----------------------------------------------------
+
+
+def test_estop_body_zid_matches_wire_zid_accepted(receiver):
+    """When wire and body source_zid agree, the envelope is accepted."""
+    now = time.time()
+    payload = {
+        "peer_id": "op-1",
+        "t": now,
+        "source_zid": _LEGIT_ZID,
+        "trigger": "remote",
+    }
+    receiver._on_safety_estop(_make_sample(payload, source_zid=_LEGIT_ZID))
+    assert receiver._estop_lockout.is_set()
+
+
+def test_estop_body_zid_disagreeing_with_wire_rejected(receiver, caplog):
+    """An attacker on a different session whose body claims a peer's
+    session zid is rejected: the wire zid (set by Zenoh, attacker
+    cannot choose) does not match the body claim."""
+    now = time.time()
+    payload = {
+        "peer_id": "op-1",
+        "t": now,
+        "source_zid": _LEGIT_ZID,  # attacker's body claims legit zid
+        "trigger": "remote",
+    }
+    with caplog.at_level("WARNING", logger="strands_robots.mesh.core"):
+        # ...but wire carries the attacker's actual zid.
+        receiver._on_safety_estop(_make_sample(payload, source_zid=_ATTACKER_ZID))
+    assert not receiver._estop_lockout.is_set()
+    assert any("cross-session forgery rejected" in rec.message for rec in caplog.records), (
+        "expected an explicit cross-session forgery rejection log"
+    )
+
+
+def test_estop_body_zid_present_wire_zid_absent_rejected(receiver, caplog):
+    """A publisher that advertises body source_zid but failed to attach
+    SourceInfo on the wire is rejected (no silent downgrade)."""
+    now = time.time()
+    payload = {
+        "peer_id": "op-1",
+        "t": now,
+        "source_zid": _LEGIT_ZID,
+    }
+    with caplog.at_level("WARNING", logger="strands_robots.mesh.core"):
+        receiver._on_safety_estop(_make_sample(payload, source_zid=None))
+    assert not receiver._estop_lockout.is_set()
+    assert any("body source_zid present but wire" in rec.message for rec in caplog.records)
+
+
+def test_estop_wire_zid_present_body_zid_absent_rejected(receiver, caplog):
+    """A pre-binding publisher (no body source_zid) on a Zenoh session
+    that DOES propagate source_info is rejected: operators must
+    upgrade all peers together so the binding is never silently
+    downgraded."""
+    now = time.time()
+    payload = {"peer_id": "op-1", "t": now}
+    with caplog.at_level("WARNING", logger="strands_robots.mesh.core"):
+        receiver._on_safety_estop(_make_sample(payload, source_zid=_LEGIT_ZID))
+    assert not receiver._estop_lockout.is_set()
+    assert any("wire source_zid present but body" in rec.message for rec in caplog.records)
+
+
+def test_estop_neither_wire_nor_body_zid_accepted(receiver):
+    """Bridge / IoT transports where neither wire nor body carry a zid:
+    the envelope is accepted via the body-level HMAC defences alone."""
+    now = time.time()
+    payload = {"peer_id": "op-1", "t": now, "trigger": "remote"}
+    receiver._on_safety_estop(_make_sample(payload, source_zid=None))
+    assert receiver._estop_lockout.is_set()
+
+
+# Receiver-side: resume ----------------------------------------------------
+
+
+def _make_resume_envelope(
+    *,
+    override_code: str,
+    peer_id: str = "op-1",
+    t: float | None = None,
+    elapsed: float = 1.0,
+    proof_nonce: str | None = None,
+    source_zid: str | None = None,
+) -> dict:
+    """Mint a valid resume envelope, optionally including ``source_zid``
+    in both the body and the HMAC input."""
+    if t is None:
+        t = time.time()
+    if proof_nonce is None:
+        proof_nonce = uuid.uuid4().hex
+    mac_fields = {
+        "peer_id": peer_id,
+        "t": t,
+        "lockout_elapsed_s": elapsed,
+        "proof_nonce": proof_nonce,
+    }
+    if source_zid is not None:
+        mac_fields["source_zid"] = source_zid
+    mac_input = json.dumps(mac_fields, sort_keys=True, separators=(",", ":")).encode()
+    proof = hmac.new(override_code.encode(), mac_input, "sha256").hexdigest()
+    env = {
+        "peer_id": peer_id,
+        "t": t,
+        "lockout_elapsed_s": elapsed,
+        "proof_nonce": proof_nonce,
+        "override_proof": proof,
+    }
+    if source_zid is not None:
+        env["source_zid"] = source_zid
+    return env
+
+
+def test_resume_body_zid_matches_wire_zid_clears_lockout(receiver, monkeypatch):
+    """Happy path: wire and body source_zid agree, MAC verifies."""
+    monkeypatch.setenv("STRANDS_MESH_OVERRIDE_CODE", "secret")
+    receiver._estop_lockout.set()
+
+    env = _make_resume_envelope(override_code="secret", source_zid=_LEGIT_ZID)
+    receiver._on_safety_resume(_make_sample(env, source_zid=_LEGIT_ZID))
+
+    assert not receiver._estop_lockout.is_set()
+
+
+def test_resume_cross_session_forgery_rejected(receiver, monkeypatch, caplog):
+    """An attacker on a DIFFERENT mTLS session who also holds the
+    override code mints a body whose source_zid claims to be the
+    legit session, recomputes the MAC against that body, and publishes.
+
+    The receiver:
+
+    1. Sees ``sample.source_info.source_id.zid`` is the attacker's
+       (Zenoh sets it, attacker cannot choose),
+    2. Sees the body claims a different ``source_zid``,
+    3. Rejects on the body!=wire mismatch BEFORE running the MAC
+       compare.
+
+    Even if step (3) were bypassed, step (4) would catch it: the
+    receiver re-derives the MAC using the WIRE zid (attacker's), so
+    the precomputed body MAC (built against the legit zid) fails
+    constant-time compare.
+    """
+    monkeypatch.setenv("STRANDS_MESH_OVERRIDE_CODE", "secret")
+    receiver._estop_lockout.set()
+
+    # Attacker has legit override code and forges a body claiming legit zid.
+    env = _make_resume_envelope(override_code="secret", source_zid=_LEGIT_ZID)
+    # ...but wire carries attacker's actual zid.
+    with caplog.at_level("WARNING", logger="strands_robots.mesh.core"):
+        receiver._on_safety_resume(_make_sample(env, source_zid=_ATTACKER_ZID))
+
+    assert receiver._estop_lockout.is_set(), "cross-session forgery must NOT clear lockout"
+    assert any("cross-session forgery rejected" in rec.message for rec in caplog.records)
+
+
+def test_resume_mac_binds_wire_zid_not_body_zid(receiver, monkeypatch, caplog):
+    """Defence-in-depth: even if the body!=wire shape check were
+    bypassed, the MAC re-derivation uses the wire zid. We simulate
+    "body matches wire" but the MAC was built against a third zid.
+
+    Construction:
+      - Body source_zid = _ATTACKER_ZID
+      - Wire source_zid = _ATTACKER_ZID  (so shape check passes)
+      - MAC built against _LEGIT_ZID  (attacker tried to bind a
+        different zid into the MAC than they're publishing under)
+
+    Result: receiver re-derives MAC against _ATTACKER_ZID, compare
+    fails, envelope is rejected.
+    """
+    monkeypatch.setenv("STRANDS_MESH_OVERRIDE_CODE", "secret")
+    receiver._estop_lockout.set()
+
+    # Manual construction: body source_zid = attacker, but MAC was
+    # computed binding source_zid=legit (a captured-and-mutated MAC).
+    proof_nonce = uuid.uuid4().hex
+    envelope_t = time.time()
+    elapsed = 1.0
+    mac_fields = {
+        "peer_id": "op-1",
+        "t": envelope_t,
+        "lockout_elapsed_s": elapsed,
+        "proof_nonce": proof_nonce,
+        "source_zid": _LEGIT_ZID,  # MAC binds legit
+    }
+    mac_input = json.dumps(mac_fields, sort_keys=True, separators=(",", ":")).encode()
+    proof = hmac.new(b"secret", mac_input, "sha256").hexdigest()
+    env = {
+        "peer_id": "op-1",
+        "t": envelope_t,
+        "lockout_elapsed_s": elapsed,
+        "proof_nonce": proof_nonce,
+        "override_proof": proof,
+        "source_zid": _ATTACKER_ZID,  # body publishes attacker
+    }
+    # NOTE: shape check rejects on body!=wire (legit vs attacker),
+    # so we set wire == body to specifically test the MAC binding.
+    with caplog.at_level("WARNING", logger="strands_robots.mesh.core"):
+        receiver._on_safety_resume(_make_sample(env, source_zid=_ATTACKER_ZID))
+
+    assert receiver._estop_lockout.is_set()
+    assert any("override_proof mismatch" in rec.message for rec in caplog.records)
+
+
+def test_resume_replay_cache_keyed_on_wire_zid(receiver, monkeypatch):
+    """Same proof_nonce from two distinct sessions must NOT collide.
+
+    Pre-fix: cache key was ``(issuer_peer_id, proof_nonce)``. An attacker
+    could replay one session's nonce from a different session by
+    setting body ``peer_id`` to match. Post-fix the cache key uses the
+    wire-bound zid when available.
+    """
+    monkeypatch.setenv("STRANDS_MESH_OVERRIDE_CODE", "secret")
+    receiver._estop_lockout.set()
+
+    nonce = uuid.uuid4().hex
+    # Session A
+    env_a = _make_resume_envelope(
+        override_code="secret",
+        peer_id="op-1",
+        proof_nonce=nonce,
+        source_zid=_LEGIT_ZID,
+    )
+    receiver._on_safety_resume(_make_sample(env_a, source_zid=_LEGIT_ZID))
+    assert not receiver._estop_lockout.is_set()
+    receiver._estop_lockout.set()  # re-lock for observation
+
+    # Session B publishes the SAME nonce + same body peer_id but its
+    # OWN session zid. Pre-fix this would have hit the cache (key was
+    # peer_id+nonce); post-fix the wire zid differs so it's a cache
+    # miss and proceeds through MAC verification (which it passes
+    # because MAC includes session B's zid).
+    env_b = _make_resume_envelope(
+        override_code="secret",
+        peer_id="op-1",
+        proof_nonce=nonce,
+        source_zid=_ATTACKER_ZID,
+    )
+    receiver._on_safety_resume(_make_sample(env_b, source_zid=_ATTACKER_ZID))
+
+    # Two distinct cache entries -- one per session.
+    assert len(receiver._resume_replay_cache) == 2, (
+        f"expected 2 cache entries (one per session zid); got {receiver._resume_replay_cache}"
+    )
+
+
+def test_resume_pre_binding_publisher_rejected_when_wire_has_zid(receiver, monkeypatch, caplog):
+    """A pre-binding peer (no body source_zid) communicating over a
+    Zenoh session that DOES propagate source_info is rejected so the
+    fleet upgrade is atomic."""
+    monkeypatch.setenv("STRANDS_MESH_OVERRIDE_CODE", "secret")
+    receiver._estop_lockout.set()
+
+    # Old envelope, no source_zid in body or in MAC.
+    env = _make_resume_envelope(override_code="secret", source_zid=None)
+    with caplog.at_level("WARNING", logger="strands_robots.mesh.core"):
+        receiver._on_safety_resume(_make_sample(env, source_zid=_LEGIT_ZID))
+
+    assert receiver._estop_lockout.is_set()
+    assert any("publisher predates source_zid binding" in rec.message for rec in caplog.records)
+
+
+def test_resume_bridge_transport_no_zid_either_side_accepted(receiver, monkeypatch):
+    """Bridge / IoT transport: neither wire nor body carries a zid.
+    The envelope is accepted via the body-level HMAC binding alone --
+    cross-session-forgery defence is Zenoh-specific."""
+    monkeypatch.setenv("STRANDS_MESH_OVERRIDE_CODE", "secret")
+    receiver._estop_lockout.set()
+
+    env = _make_resume_envelope(override_code="secret", source_zid=None)
+    receiver._on_safety_resume(_make_sample(env, source_zid=None))
+
+    assert not receiver._estop_lockout.is_set()
+
+
+# Publisher-side helpers --------------------------------------------------
+
+
+def test_local_session_zid_returns_none_without_zenoh_session(receiver):
+    """When no Zenoh session is open, ``_local_session_zid`` returns
+    ``None`` and the safety publisher path falls back to body-only
+    binding."""
+    # Default fixture has no live session; the helper must return None
+    # rather than raising.
+    assert receiver._local_session_zid() is None
+
+
+def test_safety_publisher_for_returns_none_without_session(receiver):
+    """``_safety_publisher_for`` returns None when no session is open;
+    callers fall back to ``put()``."""
+    assert receiver._safety_publisher_for("strands/safety/estop") is None
+
+
+def test_next_safety_sn_is_monotonic_per_topic(receiver):
+    """Sequence numbers increment per-topic and never repeat."""
+    a1 = receiver._next_safety_sn("strands/safety/estop")
+    a2 = receiver._next_safety_sn("strands/safety/estop")
+    a3 = receiver._next_safety_sn("strands/safety/estop")
+    assert a1 < a2 < a3
+
+    b1 = receiver._next_safety_sn("strands/safety/resume")
+    b2 = receiver._next_safety_sn("strands/safety/resume")
+    assert b1 < b2
+
+    # Per-topic counters are independent.
+    assert b1 == 1, "resume topic counter starts at 1 independently of the estop topic"
+
+
+def test_publish_safety_envelope_falls_back_to_put_without_session(receiver, monkeypatch):
+    """Without a Zenoh session ``_publish_safety_envelope`` MUST call
+    ``put()`` so the bridge / IoT transport path still delivers the
+    envelope (just without TLS-bound source attribution)."""
+    calls = []
+
+    def fake_put(key, payload):
+        calls.append((key, dict(payload)))
+
+    monkeypatch.setattr(core_module, "put", fake_put)
+    receiver._publish_safety_envelope("strands/safety/estop", {"hello": "world"})
+
+    assert calls == [("strands/safety/estop", {"hello": "world"})]

--- a/tests/mesh/test_security_no_dead_exports.py
+++ b/tests/mesh/test_security_no_dead_exports.py
@@ -1,29 +1,31 @@
 """Regression test: AGENTS.md Key Conventions #10 -- no dead code in public API.
 
-Pinned by review R3 on PR #223: `LockoutError` was defined and exported
-in `__all__` with no consumer in this PR's scope. Same shape as the R1
-removal of `MAX_TIMEOUT_S`. Will re-land in PR-6 alongside Mesh._dispatch
-(the consumer). This test pins the invariant that every name in
-`security.__all__` is either importable from the module AND has at least
-one test or internal reference demonstrating usage.
+PR-6 is the consumer of LockoutError (raised by Mesh._dispatch when the
+emergency-stop lockout is engaged), so the class is now both defined in
+security.py and exported in __all__. This test pins:
+
+- LockoutError IS defined and exported (the PR-6 consumer landed)
+- Every export in __all__ is importable (catches typos / refactor breaks)
 """
 
 from strands_robots.mesh import security
 
 
-def test_lockout_error_not_exported():
-    """LockoutError must not be in __all__ until a consumer lands."""
-    assert "LockoutError" not in security.__all__, (
-        "LockoutError re-introduced in __all__ without a consumer in this module. "
-        "Per AGENTS.md Key Conventions #10, land the exception alongside "
-        "Mesh._dispatch (PR-6) which raises it."
+def test_lockout_error_is_exported():
+    """PR-6 consumer (Mesh._dispatch) is now in scope, so LockoutError lands."""
+    assert "LockoutError" in security.__all__, (
+        "LockoutError must be exported now that PR-6 (Mesh._dispatch) "
+        "is the consumer."
     )
 
 
-def test_lockout_error_class_not_defined():
-    """LockoutError must not be defined in this module until a consumer lands."""
-    assert not hasattr(security, "LockoutError"), (
-        "LockoutError class re-introduced in security.py without a consumer. Land alongside Mesh._dispatch in PR-6."
+def test_lockout_error_class_is_defined():
+    """LockoutError class is defined alongside its consumer."""
+    assert hasattr(security, "LockoutError"), (
+        "LockoutError class must be defined alongside Mesh._dispatch consumer."
+    )
+    assert issubclass(security.LockoutError, security.SecurityError), (
+        "LockoutError must inherit from SecurityError."
     )
 
 

--- a/tests/mesh/test_security_no_dead_exports.py
+++ b/tests/mesh/test_security_no_dead_exports.py
@@ -14,19 +14,14 @@ from strands_robots.mesh import security
 def test_lockout_error_is_exported():
     """PR-6 consumer (Mesh._dispatch) is now in scope, so LockoutError lands."""
     assert "LockoutError" in security.__all__, (
-        "LockoutError must be exported now that PR-6 (Mesh._dispatch) "
-        "is the consumer."
+        "LockoutError must be exported now that PR-6 (Mesh._dispatch) is the consumer."
     )
 
 
 def test_lockout_error_class_is_defined():
     """LockoutError class is defined alongside its consumer."""
-    assert hasattr(security, "LockoutError"), (
-        "LockoutError class must be defined alongside Mesh._dispatch consumer."
-    )
-    assert issubclass(security.LockoutError, security.SecurityError), (
-        "LockoutError must inherit from SecurityError."
-    )
+    assert hasattr(security, "LockoutError"), "LockoutError class must be defined alongside Mesh._dispatch consumer."
+    assert issubclass(security.LockoutError, security.SecurityError), "LockoutError must inherit from SecurityError."
 
 
 def test_all_exports_are_importable():

--- a/tests/mesh/test_wire_handler_narrow_except.py
+++ b/tests/mesh/test_wire_handler_narrow_except.py
@@ -1,0 +1,105 @@
+"""Regression: ``_on_cmd`` and ``_on_response`` use the same narrow exception
+tuple as ``_on_safety_estop`` / ``_on_safety_resume``.
+
+Pre-fix: both wire handlers caught bare :class:`Exception`, masking
+programmer-bug ``RuntimeError`` / ``TypeError`` / ``MemoryError`` from a
+future Zenoh API change. Per AGENTS.md > Review Learnings (#86) > "Exception
+Clauses Must Be Narrow", the four wire-input handlers must use the same
+``(AttributeError, UnicodeDecodeError, json.JSONDecodeError)`` tuple.
+
+Pre-fix verification:
+    git stash && pytest tests/mesh/test_wire_handler_narrow_except.py -v
+    -> 3 tests fail: bare-except still present in source.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from strands_robots.mesh import core as mesh_core
+
+
+def _source_of(method) -> str:
+    return inspect.getsource(method)
+
+
+def test_on_cmd_uses_narrow_exception_tuple() -> None:
+    src = _source_of(mesh_core.Mesh._on_cmd)
+    assert "except (AttributeError, UnicodeDecodeError, json.JSONDecodeError):" in src, (
+        "_on_cmd must use the same narrow tuple as _on_safety_estop "
+        "(AGENTS.md > Review Learnings #86: 'Exception Clauses Must Be Narrow')"
+    )
+    assert "except Exception:" not in src.split("def _on_cmd", 1)[1].split("def ", 1)[0], (
+        "_on_cmd must not contain bare 'except Exception:' on the wire-input parse path"
+    )
+
+
+def test_on_response_uses_narrow_exception_tuple() -> None:
+    src = _source_of(mesh_core.Mesh._on_response)
+    assert "except (AttributeError, UnicodeDecodeError, json.JSONDecodeError):" in src, (
+        "_on_response must use the same narrow tuple as _on_safety_resume "
+        "(AGENTS.md > Review Learnings #86: 'Exception Clauses Must Be Narrow')"
+    )
+    assert "except Exception:" not in src.split("def _on_response", 1)[1].split("def ", 1)[0], (
+        "_on_response must not contain bare 'except Exception:' on the wire-input parse path"
+    )
+
+
+def test_all_four_wire_handlers_use_same_tuple() -> None:
+    """The wire-input parse pattern is identical across the four handlers.
+
+    Symmetric-reasoning audit: if one handler narrows, all must narrow.
+    This test pins the symmetry so a future refactor cannot regress one
+    without the others.
+    """
+    handlers = [
+        mesh_core.Mesh._on_cmd,
+        mesh_core.Mesh._on_response,
+        mesh_core.Mesh._on_safety_estop,
+        mesh_core.Mesh._on_safety_resume,
+    ]
+    expected = "except (AttributeError, UnicodeDecodeError, json.JSONDecodeError):"
+    for handler in handlers:
+        src = _source_of(handler)
+        assert expected in src, (
+            f"{handler.__qualname__} must use the canonical narrow tuple; "
+            f"see _on_safety_estop for the reference pattern"
+        )
+
+
+# === bridge_transport dedup decode path uses the same narrow tuple ===
+
+
+def test_bridge_transport_dedup_decode_uses_narrow_tuple() -> None:
+    """The bridge dedup decode path was a fifth wire-shaped exception
+    site. the prior fix narrowed it to the same ``(AttributeError,
+    UnicodeDecodeError, json.JSONDecodeError)`` tuple used by the four
+    safety/cmd/response handlers.
+    """
+    from strands_robots.mesh.transport import bridge_transport as bt
+
+    src = inspect.getsource(bt)
+    # Look for the specific pattern AROUND the dedup decode block
+    # (the comment in the source mentions the exact tuple).
+    assert "except (AttributeError, UnicodeDecodeError, json.JSONDecodeError):" in src, (
+        "bridge_transport.py dedup decode path must use the same narrow "
+        "tuple as the four wire handlers in core.py "
+        "(AGENTS.md > Review Learnings #86)"
+    )
+
+
+# === _on_presence is the fifth wire-input handler ===
+
+
+def test_on_presence_uses_narrow_exception_tuple() -> None:
+    """``_on_presence`` is the fifth wire-input
+    handler in core.py. the prior implementation it was the only one with a bare
+    ``except Exception`` on the parse path -- AGENTS.md > Review
+    Learnings (#86) calls that out as forbidden, and the same threat
+    model applies to presence (a Zenoh sample.payload parse).
+
+    Same tuple as the other four wire handlers."""
+    src = _source_of(mesh_core.Mesh._on_presence)
+    assert "except (AttributeError, UnicodeDecodeError, json.JSONDecodeError):" in src, (
+        "_on_presence must use the same narrow tuple as the four other wire handlers"
+    )


### PR DESCRIPTION
Part 6 / 9 of the split of #195 — tracked by #219.

**Drafted** until PR-2 (#223), PR-3 (#224), PR-4 (#221), and PR-5 (#222) merge. CI on this branch in isolation is **expected red on imports** — it imports from `strands_robots.mesh.security` (PR-2), `strands_robots.mesh.audit.log_safety_event` (PR-4), `strands_robots.mesh.session.start` (PR-3), and the new bridge contract (PR-5). The lint step is now green on the project's mypy gate after R11.

## The integration centre

This is where everything else gets wired together. It carries ~50 of the 213 review threads on #195 — the largest slice. **Recommend two reviewers.**

## What's in this PR

- `strands_robots/mesh/core.py` (+1,713/-33) — mesh lifecycle, RPC dispatch, replay caches with `_evict_replay_cache` helper (R23 PEP-695 generic over key type), override-code resume, safety topic handlers (`_on_safety_estop` / `_on_safety_resume`), wire-handler exception narrowing (R24-A 4-handler symmetry pin: `AttributeError` / `UnicodeDecodeError` / `json.JSONDecodeError`), per-peer source_zid HMAC binding (R25), `_exec_cmd` non-dict rejection (R24-B — bare string commands no longer auto-coerce to `{action:execute, instruction:<str>, policy_provider:mock}`).
- `strands_robots/mesh/sensors.py` (+32/-15) — SensorLoopsMixin cleanup, narrowed exception clauses.
- `strands_robots/mesh/input.py` (+2/-2) — minor signature fixes.
- `strands_robots/mesh/__init__.py` (+3/-3) — export surface tweak.

## Reviewer focus

- Wire-handler exception narrowness symmetry (R24-A pin test enforces this across all 4 handlers).
- `time.monotonic()` for replay TTL (R19) and corroboration window (R8).
- Per-peer source_zid HMAC binding (R25 commit `7423be2` on the source PR — prevents replay-from-different-peer-zid).
- Wire-zid-gated corroboration (R7-1) — same-session mutated peer_id audited as `estop_replay_rejected`, not `estop_corroborated`.
- Resume HMAC clauses with pre-hashed fixed-length compare (R7-4).
- `_exec_cmd` non-dict rejection (R24-B).
- 3-tuple cache shape invariant (R9).
- **R13: lockout always engages at-cap** — removed early return that silently dropped safety-primitive availability.
- **R14: domain-tagged resume cache key** — prevents cross-transport namespace collision between wire_zid and body issuer_id.

## Carries review fixes from #195

R9, R13, R17, R19, R23, R24-A, R25-source-zid — see commit message for the full list.

## Optional further split

If reviewers ask, I'll split into PR-6a (safety topics + replay caches) / PR-6b (override-resume + RPC). Both halves still ~800 LOC and call into each other, so a single PR is cleaner.

## Tests

1,420 LOC across 12 files: every wire handler, every safety topic, replay-cache eviction (10 helper unit tests + 25 integration tests preserved), the 4-handler exception symmetry pin, source_zid binding (458-LOC `test_safety_source_zid_binding.py`), resume env validation (10 tests), resume replay (380 LOC).

## Stacking note

Depends on PR-1 (#220), PR-2 (#223), PR-3 (#224), PR-4 (#221), PR-5 (#222). Will be marked Ready for Review once all four upstream PRs land. Until then the diff is reviewable but CI is expected-red on imports.

---

Landing order: PR-1 → PR-2/3/4/5 → **PR-6** → PR-7 → PR-8 → PR-9. Full plan: [`PR_LIST.md`](https://github.com/cagataycali/robots/blob/mesh/zenoh-native-security/PR_LIST.md). Tracking: #219.

---

## §13 — Review-feedback rounds

| Round | Concern | Commit | Pin test |
| --- | --- | --- | --- |
| R7-1 | estop corroboration forgeable via same-session mutated peer_id | [`3bd9c6b`](https://github.com/cagataycali/robots/commit/3bd9c6b) | `tests/mesh/test_estop_replay.py::test_same_wire_zid_mutated_peer_id_audited_as_replay_rejected` |
| R7-2 | drive-by whitespace regressions (3 files) | [`bf6362f`](https://github.com/cagataycali/robots/commit/bf6362f) | N/A (revert) |
| R7-3 | `_evict_replay_cache` docstring overstated single-source-of-truth | [`06f665b`](https://github.com/cagataycali/robots/commit/06f665b) | N/A (docstring) |
| R7-4 | `_resume_lockout` HMAC len-oracle leak | [`6c9b863`](https://github.com/cagataycali/robots/commit/6c9b863) | `tests/mesh/test_pr6_review_pins.py::TestResumeLockoutTimingOracleClosed` |
| R7-5 | `Mesh.publish` MRO shadow no regression test | [`80918df`](https://github.com/cagataycali/robots/commit/80918df) | `tests/mesh/test_pr6_review_pins.py::test_mesh_publish_shadows_sensor_loops_mixin` |
| R8 | corroboration window uses wall-clock (`time.time`) instead of `time.monotonic` | [`f31f2d2`](https://github.com/cagataycali/robots/commit/f31f2d2) | `tests/mesh/test_corroboration_clock_domain.py::test_corroboration_window_uses_monotonic_not_wall_clock` |
| R9 | cache shape inconsistency: half-defensive `isinstance` shim disagrees with `ts_view` and per-issuer iteration | [`4562c98`](https://github.com/cagataycali/robots/commit/4562c98) | `tests/mesh/test_pr6_review_pins.py::TestEstopReplayCacheShapeInvariant` |
| R10 | `ruff format --check` red on R7-1 pin test | [`571f7a5`](https://github.com/cagataycali/robots/commit/571f7a5) | N/A (formatter, no semantic change) |
| R11 | mypy gate red on R8/R9 pin tests | [`4c77296`](https://github.com/cagataycali/robots/commit/4c77296) | N/A (lint-only) |
| R12 | ruff isort gate red on `test_safety_source_zid_binding.py` (typing/types import order — alphabetical: `types` < `typing`) | [`a142110`](https://github.com/cagataycali/robots/commit/a142110) | N/A (lint-only, `hatch run lint` implicit) |
| **R13** | **per-issuer-cap early return silently drops lockout for legitimate operators (safety regression)** | [`7a222b0`](https://github.com/cagataycali/robots/commit/7a222b0) | `tests/mesh/test_pr6_review_pins.py::TestEstopLockoutEngagesAtCap` |
| **R14** | **resume cache-key namespace conflation: `wire_zid or issuer_id` mixes two trust domains** | [`57656f4`](https://github.com/cagataycali/robots/commit/57656f4) | `tests/mesh/test_pr6_review_pins.py::TestResumeCacheKeyNamespaceIsolation` |
| R15 | merge upstream/main (#222 PR-5 bridge dedup, #228 mesh/iot hardening) — branch was stale on `origin/main` (author's fork) and missed the post-PR-4 landings; `tests/mesh/test_wire_handler_narrow_except.py::test_bridge_transport_dedup_decode_uses_narrow_tuple` could not pass without the PR-5 dedup-decode block | merge `8ceee1c` | N/A (merge) |
| R16 | CI-only: `tests/mesh/test_default_acl_warning.py::TestPermissiveACLWarningExceptNarrow::test_unexpected_exception_surfaces_loudly` was author-intended to pin the dead `except ImportError:` fallback in the warning block, but its `"except ImportError:" not in src` assertion scanned the entire `core.py` and false-positively fired on the legitimate soft-import fallbacks added in `_local_session_zid` / `_safety_publisher_for` / `_publish_safety_envelope` for `strands_robots.mesh.session`. Switched to AST-scoped extraction of `_refuse_under_permissive_default_acl` so the assertion only inspects the gate method body. Verified the pin still fails on regression by injecting a fake `except ImportError:` into the gate method (assertion fires). | [`9fa3d84`](https://github.com/cagataycali/robots/commit/9fa3d84) | `tests/mesh/test_default_acl_warning.py::TestPermissiveACLWarningExceptNarrow::test_unexpected_exception_surfaces_loudly` (now AST-scoped) |

### Round-budget closure (2026-05-30; post-R14)

The 3-round substantive budget was reached at R9 per AGENTS.md section 0 tenet 8. R10/R11/R12 were CI-only lint/mypy/isort fixes (no semantic changes). R13 was a safety-invariant regression fix. R14 absorbed the cache-key namespace collision per explicit reviewer guidance ("one-line fix worth landing in this PR"). R15 is the post-PR-5/PR-228 upstream merge to bring the branch up to current main (no semantic change to PR-6's diff). R16 is a CI-only test-scope narrowing — the assertion was always intended to pin the warning-block specifically, and the AST-scope makes that intent literal in code. No production-code change in R16.

**No further substantive commits will land on this PR.** Beyond what is necessary to keep CI green once the upstream stack (PR-1..PR-5) merges and any test-scope corrections needed to keep pin tests aligned with their author-intended scope, all remaining unresolved review threads are tracked as focused follow-up issues so each can be reviewed against its own diff and pin tests rather than expanding this PR's review surface further.

Remaining follow-up issues (deferred, all non-safety-critical at this severity level given the R13/R14 absorptions; tracked for individual PRs):

| Thread | Concern | Follow-up issue |
|---|---|---|
| `core.py:1907` | Resume cache lacks per-issuer fairness cap (asymmetric vs estop cache) | #266 |
| `core.py:1396` | Repeated `os.getenv` in safety-handler hot path under lock | #265 |
| `core.py:1909` | Resume-redundant audit gap (no `remote_resume_redundant` event) | #271 |
| `core.py:2273` | `_resume_lockout` post-compare audit branch I/O cost observable (timing oracle residual) | #256 |
| `core.py:1144` | `_exec_cmd` dispatch-exception branch emits no `log_safety_event` | #257 |
| `sensors.py:88` | `SensorLoopsMixin.publish` `NotImplementedError` swallowed by bare-except | #258 |
| `core.py:2280` | Wire leak of structured rejection reason via `strands/+/safety/event` broadcast (content-channel oracle) | #272 |
| `core.py:1605` | Lockout state mutation outside `_estop_replay_lock` (concurrent-estop race) | #273 |
| `core.py:218` | `_evict_replay_cache` skips TTL purge below `max_size` (low-traffic memory growth) | #274 |
| `core.py:1949` | `_exec_cmd` catch tuple width — partly subsumed by #257's audit-emission pin (low priority) | #257 |