### PR TITLE
mesh(tools): robot_mesh HITL via tool_context.interrupt + per-action rate limit (7/9 of #195 split)

### DIFF
--- a/strands_robots/tools/robot_mesh.py
+++ b/strands_robots/tools/robot_mesh.py
@@ -476,7 +476,7 @@ def robot_mesh(
             # error, lockout, etc.). Previously only ``success=True`` was
             # emitted, leaving a forensic gap on failure paths.
             _audit_tool_action(action, target, False, f"dispatch error: {type(exc).__name__}: {exc}")
-            raise
+            return _err(f"[tell -> {target}] dispatch error: {type(exc).__name__}: {exc}")
         _audit_tool_action(action, target, True, f"instruction={instruction[:200]}")
         return _ok(f"[tell -> {target}] {json.dumps(result, default=str)[:600]}")
 
@@ -505,7 +505,7 @@ def robot_mesh(
             result = mesh.send(target, cmd, timeout=timeout)
         except Exception as exc:  # noqa: BLE001
             _audit_tool_action(action, target, False, f"dispatch error: {type(exc).__name__}: {exc}")
-            raise
+            return _err(f"[send -> {target}] dispatch error: {type(exc).__name__}: {exc}")
         _audit_tool_action(action, target, True, f"action={cmd.get('action')}")
         return _ok(f"[send -> {target}] {json.dumps(result, default=str)[:600]}")
 
@@ -523,7 +523,7 @@ def robot_mesh(
             results = mesh.broadcast(cmd, timeout=timeout)
         except Exception as exc:  # noqa: BLE001
             _audit_tool_action(action, "*", False, f"dispatch error: {type(exc).__name__}: {exc}")
-            raise
+            return _err(f"[broadcast] dispatch error: {type(exc).__name__}: {exc}")
         _audit_tool_action(action, "*", True, f"action={cmd.get('action')} responses={len(results)}")
         text = f"[broadcast] {len(results)} responses\n"
         for r in results[:10]:
@@ -541,7 +541,7 @@ def robot_mesh(
             result = mesh.send(target, {"action": "stop"}, timeout=min(timeout, 5.0))
         except Exception as exc:  # noqa: BLE001
             _audit_tool_action(action, target, False, f"dispatch error: {type(exc).__name__}: {exc}")
-            raise
+            return _err(f"[stop -> {target}] dispatch error: {type(exc).__name__}: {exc}")
         _audit_tool_action(action, target, True, "")
         return _ok(f"[stop -> {target}] {json.dumps(result, default=str)[:600]}")
 
@@ -553,7 +553,7 @@ def robot_mesh(
             results = mesh.emergency_stop()
         except Exception as exc:  # noqa: BLE001
             _audit_tool_action(action, "*", False, f"dispatch error: {type(exc).__name__}: {exc}")
-            raise
+            return _err(f"[emergency_stop] dispatch error: {type(exc).__name__}: {exc}")
         _audit_tool_action(action, "*", True, f"responses={len(results)}")
         return _ok(f"[E-STOP] broadcast complete - {len(results)} responses (audit log written)")
 

--- a/strands_robots/tools/robot_mesh.py
+++ b/strands_robots/tools/robot_mesh.py
@@ -463,7 +463,14 @@ def robot_mesh(
         except _security.ValidationError as exc:
             _audit_tool_action(action, target, False, f"validation: {exc}")
             return _err(f"tell rejected: {exc}")
-        result = mesh.tell(target, instruction, **kwargs)
+        try:
+            result = mesh.tell(target, instruction, **kwargs)
+        except Exception as exc:  # noqa: BLE001
+            # Audit dispatch failures (mesh.tell may raise on transport
+            # error, lockout, etc.). Previously only ``success=True`` was
+            # emitted, leaving a forensic gap on failure paths.
+            _audit_tool_action(action, target, False, f"dispatch error: {type(exc).__name__}: {exc}")
+            raise
         _audit_tool_action(action, target, True, f"instruction={instruction[:200]}")
         return _ok(f"[tell -> {target}] {json.dumps(result, default=str)[:600]}")
 
@@ -488,21 +495,29 @@ def robot_mesh(
         except _security.ValidationError as exc:
             _audit_tool_action(action, target, False, f"validation: {exc}")
             return _err(f"send rejected: {exc}")
-        result = mesh.send(target, cmd, timeout=timeout)
+        try:
+            result = mesh.send(target, cmd, timeout=timeout)
+        except Exception as exc:  # noqa: BLE001
+            _audit_tool_action(action, target, False, f"dispatch error: {type(exc).__name__}: {exc}")
+            raise
         _audit_tool_action(action, target, True, f"action={cmd.get('action')}")
         return _ok(f"[send -> {target}] {json.dumps(result, default=str)[:600]}")
 
     # ── action: broadcast ─────────────────────────────────────────────────
     if action == "broadcast":
         # R8-7: pre-validated above before the HITL interrupt fired, so
-        # the cmd here is already a clean validated dict. Defensive
-        # assert: validated_broadcast_cmd is None only on a programmer
-        # error (someone added "broadcast" without the pre-validate).
-        assert validated_broadcast_cmd is not None, (
-            "broadcast reached its handler without pre-validation — R8-7 contract broken"
-        )
+        # the cmd here is already a clean validated dict.
+        # Use explicit raise (not assert) -- assert is stripped under
+        # ``python -O`` / ``PYTHONOPTIMIZE=1`` which would silently send
+        # an unvalidated cmd to mesh.broadcast.
+        if validated_broadcast_cmd is None:
+            raise RuntimeError("broadcast reached its handler without pre-validation -- R8-7 contract broken")
         cmd = validated_broadcast_cmd
-        results = mesh.broadcast(cmd, timeout=timeout)
+        try:
+            results = mesh.broadcast(cmd, timeout=timeout)
+        except Exception as exc:  # noqa: BLE001
+            _audit_tool_action(action, "*", False, f"dispatch error: {type(exc).__name__}: {exc}")
+            raise
         _audit_tool_action(action, "*", True, f"action={cmd.get('action')} responses={len(results)}")
         text = f"[broadcast] {len(results)} responses\n"
         for r in results[:10]:
@@ -516,7 +531,11 @@ def robot_mesh(
         if not target:
             _audit_tool_action(action, target, False, "missing target")
             return _err("stop requires target")
-        result = mesh.send(target, {"action": "stop"}, timeout=min(timeout, 5.0))
+        try:
+            result = mesh.send(target, {"action": "stop"}, timeout=min(timeout, 5.0))
+        except Exception as exc:  # noqa: BLE001
+            _audit_tool_action(action, target, False, f"dispatch error: {type(exc).__name__}: {exc}")
+            raise
         _audit_tool_action(action, target, True, "")
         return _ok(f"[stop -> {target}] {json.dumps(result, default=str)[:600]}")
 
@@ -524,7 +543,11 @@ def robot_mesh(
     if action == "emergency_stop":
         # Operator approval was already obtained above through the
         # interrupt gate; this branch only runs on an affirmative response.
-        results = mesh.emergency_stop()
+        try:
+            results = mesh.emergency_stop()
+        except Exception as exc:  # noqa: BLE001
+            _audit_tool_action(action, "*", False, f"dispatch error: {type(exc).__name__}: {exc}")
+            raise
         _audit_tool_action(action, "*", True, f"responses={len(results)}")
         return _ok(f"[E-STOP] broadcast complete - {len(results)} responses (audit log written)")
 

--- a/strands_robots/tools/robot_mesh.py
+++ b/strands_robots/tools/robot_mesh.py
@@ -251,7 +251,7 @@ def _resolve_mesh(target: str) -> Any | None:
 @tool(context=True)
 def robot_mesh(
     action: str,
-    tool_context: ToolContext,
+    tool_context: ToolContext | None = None,
     target: str = "",
     instruction: str = "",
     command: str = "",
@@ -349,6 +349,12 @@ def robot_mesh(
     # "y" / "n") is delivered back outside the LLM's tool-argument flow,
     # so an injected prompt cannot smuggle approval.
     if action in _INTERRUPT_REQUIRED:
+        if tool_context is None:
+            _audit_tool_action(action, target, False, "interrupt unavailable: no tool_context")
+            return _err(
+                f"action '{action}' requires a human-in-the-loop interrupt, "
+                "but no tool_context is available in this calling context."
+            )
         try:
             response = tool_context.interrupt(
                 f"robot_mesh-{action}-approval",

--- a/strands_robots/tools/robot_mesh.py
+++ b/strands_robots/tools/robot_mesh.py
@@ -32,13 +32,181 @@ human-readable text payload so the calling agent can recover.
 
 from __future__ import annotations
 
+import collections
 import json
 import logging
+import threading
+import time
 from typing import Any
 
 from strands import tool
+from strands.types.tools import ToolContext
+
+from strands_robots.mesh import security as _security
 
 logger = logging.getLogger(__name__)
+
+
+# Per-action sliding-window rate limiter for LLM-facing actions.
+_RATE_LIMITS: dict[str, tuple[int, float]] = {
+    "tell": (30, 60.0),
+    "send": (30, 60.0),
+    "broadcast": (10, 60.0),
+    "stop": (20, 60.0),
+    "emergency_stop": (3, 60.0),
+}
+_RATE_HISTORY: dict[str, collections.deque[float]] = {}
+_RATE_LOCK = threading.Lock()
+
+# Actions whose physical effect is fleet-wide. Each one routes through a
+# Strands SDK interrupt so the calling host can request explicit human
+# approval before the mesh issues the command. Unlike a boolean tool
+# parameter the interrupt response is delivered by the framework
+# out-of-band of the LLM's tool-argument flow, so an injected prompt
+# cannot smuggle approval.
+_INTERRUPT_REQUIRED: frozenset[str] = frozenset({"emergency_stop", "broadcast"})
+
+# Affirmative responses accepted from the interrupt prompt. Anything else
+# (empty string, "n", "no", "cancel", whitespace) is treated as decline.
+_AFFIRMATIVE_RESPONSES: frozenset[str] = frozenset({"y", "yes", "approve", "approved"})
+
+
+def _interrupt_approves(response: object) -> bool:
+    """True iff *response* is an explicit affirmative.
+
+    The interrupt mechanism returns whatever the operator submitted, which
+    is normally a string but the contract is "JSON-serialisable any". We
+    accept the canonical short forms only — defence in depth against
+    accidental approval from a typo.
+    """
+    if not isinstance(response, str):
+        return False
+    return response.strip().lower() in _AFFIRMATIVE_RESPONSES
+
+
+def _rate_limit_check(action: str) -> str | None:
+    """Return None if a slot is available, else the rejection message.
+
+    Inspects the sliding-window history but does NOT consume a slot.
+    Use :func:`_rate_limit_record` after a fleet-wide action's HITL
+    approval is positively granted (or unconditionally for actions
+    that do not require approval).
+
+    Splitting check from record means a *declined* HITL approval no
+    longer consumes a slot — without the split, three nuisance LLM
+    prompts that an operator declined within a minute would lock the
+    agent out of issuing a real ``emergency_stop``. That's the
+    opposite of the intended safety property: the rate limit exists
+    to bound LLM-driven nuisance, not to inhibit a genuine emergency.
+    """
+    cfg = _RATE_LIMITS.get(action)
+    if cfg is None:
+        return None
+    max_calls, window = cfg
+    now = time.monotonic()
+    with _RATE_LOCK:
+        bucket = _RATE_HISTORY.setdefault(action, collections.deque())
+        cutoff = now - window
+        while bucket and bucket[0] < cutoff:
+            bucket.popleft()
+        if len(bucket) >= max_calls:
+            wait = window - (now - bucket[0])
+            return (
+                f"rate limit exceeded for action '{action}': "
+                f"max {max_calls} calls per {window:.0f}s window. "
+                f"Try again in {wait:.1f}s."
+            )
+    return None
+
+
+def _rate_limit_record(action: str) -> None:
+    """Append a slot to *action*'s sliding-window history.
+
+    Call this only after a HITL-required action's approval is granted,
+    or unconditionally for actions that do not require an interrupt.
+    Pairs with :func:`_rate_limit_check`.
+    """
+    cfg = _RATE_LIMITS.get(action)
+    if cfg is None:
+        return
+    _, window = cfg
+    now = time.monotonic()
+    with _RATE_LOCK:
+        bucket = _RATE_HISTORY.setdefault(action, collections.deque())
+        cutoff = now - window
+        while bucket and bucket[0] < cutoff:
+            bucket.popleft()
+        bucket.append(now)
+
+
+def _reset_rate_limits() -> None:
+    """Test helper: clear sliding-window history."""
+    with _RATE_LOCK:
+        _RATE_HISTORY.clear()
+
+
+def _rate_limit_check_and_record(action: str) -> str | None:
+    """Atomic check+record under a single _RATE_LOCK acquisition.
+
+    Used on the post-HITL-approval path to close the TOCTOU between
+    :func:`_rate_limit_check` (called BEFORE the operator interrupt) and
+    :func:`_rate_limit_record` (called AFTER). Without this, two
+    concurrent emergency_stop or broadcast invocations could each pass
+    the pre-interrupt check, both get operator-approved on different
+    threads, and both record -- briefly exceeding the configured limit.
+
+    Returns None if the slot was atomically reserved, else the
+    rejection message (caller should treat as 'rate limit raced past us
+    while we were waiting on the operator interrupt; reject this one').
+    """
+    cfg = _RATE_LIMITS.get(action)
+    if cfg is None:
+        return None
+    max_calls, window = cfg
+    now = time.monotonic()
+    with _RATE_LOCK:
+        bucket = _RATE_HISTORY.setdefault(action, collections.deque())
+        cutoff = now - window
+        while bucket and bucket[0] < cutoff:
+            bucket.popleft()
+        if len(bucket) >= max_calls:
+            wait = window - (now - bucket[0])
+            return (
+                f"rate limit exceeded for action '{action}' between check "
+                f"and record (concurrent approval raced past): max {max_calls} "
+                f"calls per {window:.0f}s window. Try again in {wait:.1f}s."
+            )
+        bucket.append(now)
+        return None
+
+
+def _audit_tool_action(action: str, target: str, success: bool, detail: str) -> None:
+    """Best-effort audit log of every safety-significant tool call.
+
+    R7-5: a swallowed exception with no log line means a broken audit
+    path silently disappears. Match the ``core.py:_on_cmd`` pattern —
+    log at DEBUG so operators investigating "why don't I see my LLM
+    tool actions in the audit log?" get a breadcrumb without flooding
+    production. Audit failures must NEVER propagate up into the safety
+    code path; the catch is intentionally wide for that reason and
+    documented here so AGENTS.md > "Exception Clauses Must Be Narrow"
+    is not violated implicitly.
+    """
+    try:
+        from strands_robots.mesh.audit import log_safety_event
+
+        log_safety_event(
+            "llm_tool_action",
+            "robot_mesh_tool",
+            {
+                "action": action,
+                "target": target,
+                "success": success,
+                "detail": detail[:500],
+            },
+        )
+    except Exception as audit_exc:  # noqa: BLE001 — see docstring
+        logger.debug("[robot_mesh] audit log unavailable: %s", audit_exc)
 
 
 def _err(text: str) -> dict[str, Any]:
@@ -80,9 +248,10 @@ def _resolve_mesh(target: str) -> Any | None:
     return next(iter(locals_.values()))
 
 
-@tool
+@tool(context=True)
 def robot_mesh(
     action: str,
+    tool_context: ToolContext,
     target: str = "",
     instruction: str = "",
     command: str = "",
@@ -120,8 +289,120 @@ def robot_mesh(
                    instruction="pick up the cube")
         robot_mesh(action="send", target="peer-b",
                    command='{"action": "status"}')
-        robot_mesh(action="emergency_stop")
+        robot_mesh(action="emergency_stop")    # raises a HITL interrupt;
+                                               # runs only on operator approval
+
+    Safety controls:
+        * **Human-in-the-loop interrupts** for ``emergency_stop`` and
+          ``broadcast``. The tool calls
+          ``tool_context.interrupt("robot_mesh-<action>-approval", reason=...)``
+          and only proceeds if the operator's response is an affirmative
+          ("y" / "yes" / "approve"). The Strands SDK delivers the response
+          out-of-band of the LLM's tool arguments, so prompt-injection that
+          flips a boolean cannot bypass this gate.
+        * Per-action sliding-window rate limit (e.g. emergency_stop is capped
+          at 3 calls/min). Reject reason includes wait-time estimate.
+        * ``send`` / ``broadcast`` payloads are validated through
+          :func:`strands_robots.mesh.security.validate_command` before
+          leaving the agent. The same validator runs on the receiver side,
+          so a malformed or out-of-policy payload is rejected client-side
+          before it hits the wire.
+        * Every ``tell`` / ``send`` / ``broadcast`` / ``stop`` /
+          ``emergency_stop`` is audited.
     """
+    # Check the per-action rate limit before doing any work — but
+    # do NOT consume a slot until we know the action is going to run.
+    # See _rate_limit_check / _rate_limit_record for rationale.
+    rl_err = _rate_limit_check(action)
+    if rl_err is not None:
+        _audit_tool_action(action, target, False, f"rate_limit: {rl_err}")
+        return _err(rl_err)
+
+    # R8-7: for broadcast, parse + validate the command BEFORE the HITL
+    # interrupt so the operator does not approve an action that the
+    # validator then rejects (which would burn an audit "operator
+    # approved" record and a rate-limit slot for an action that never
+    # ran). emergency_stop has no command body so the existing order
+    # is fine for that path.
+    validated_broadcast_cmd: dict[str, Any] | None = None
+    if action == "broadcast":
+        if not command:
+            _audit_tool_action(action, "*", False, "missing command")
+            return _err("broadcast requires command (JSON string)")
+        try:
+            parsed = json.loads(command)
+        except json.JSONDecodeError as exc:
+            _audit_tool_action(action, "*", False, f"bad json: {exc}")
+            return _err(f"command is not valid JSON: {exc}")
+        if not isinstance(parsed, dict):
+            _audit_tool_action(action, "*", False, "command not a dict")
+            return _err("command must decode to a JSON object (dict)")
+        try:
+            validated_broadcast_cmd = _security.validate_command(parsed)
+        except _security.ValidationError as exc:
+            _audit_tool_action(action, "*", False, f"validation: {exc}")
+            return _err(f"broadcast rejected: {exc}")
+
+    # Human-in-the-loop approval gate for fleet-wide actions. The Strands
+    # runtime pauses the agent loop on tool_context.interrupt(...) and
+    # returns control to the host process; the operator's response (e.g.
+    # "y" / "n") is delivered back outside the LLM's tool-argument flow,
+    # so an injected prompt cannot smuggle approval.
+    if action in _INTERRUPT_REQUIRED:
+        try:
+            response = tool_context.interrupt(
+                f"robot_mesh-{action}-approval",
+                reason={
+                    "action": action,
+                    "target": target if target else "*ALL_PEERS*",
+                    # R8-7: surface the validated command so the operator
+                    # approves the post-validation form, not the raw LLM
+                    # string. emergency_stop has no command body so we
+                    # fall back to the raw value.
+                    "command": (validated_broadcast_cmd if validated_broadcast_cmd is not None else command),
+                    "instruction": instruction,
+                    "warning": ("Fleet-wide physical effect. Reply 'y' to approve, anything else to deny."),
+                },
+            )
+        except RuntimeError as exc:
+            # ToolContext.interrupt raises RuntimeError when no agent
+            # instance is attached — i.e. the tool is being invoked
+            # outside a Strands agent loop (a direct
+            # ``agent.tool.robot_mesh(...)`` call, a unit test that did
+            # not wire up the SDK, etc.). In those contexts there is no
+            # operator to ask, so fail-closed.
+            #
+            # NB: the SDK's ``InterruptException`` MUST propagate up to
+            # pause the agent loop, so we deliberately do NOT catch
+            # ``Exception`` here — that would swallow the normal
+            # interrupt-pause flow and turn every approval into an
+            # immediate "interrupt unavailable" error.
+            _audit_tool_action(action, target, False, f"interrupt unavailable: {exc}")
+            return _err(
+                f"action '{action}' requires a human-in-the-loop interrupt. Interrupts are not available here: {exc}"
+            )
+
+        if not _interrupt_approves(response):
+            # Declined approval does NOT consume a rate-limit slot —
+            # see _rate_limit_check docstring for the safety rationale.
+            _audit_tool_action(action, target, False, f"operator declined: {response!r}")
+            return _err(f"action '{action}' was declined by the operator interrupt (response={response!r}).")
+        # Approval granted. Re-check under the lock and consume the
+        # slot atomically -- a concurrent invocation that ALSO passed
+        # the pre-interrupt check (different operator thread, etc.)
+        # will be rejected here so the configured limit cannot be
+        # exceeded by HITL races.
+        rl_race_err = _rate_limit_check_and_record(action)
+        if rl_race_err is not None:
+            _audit_tool_action(action, target, False, f"rate_limit_race: {rl_race_err}")
+            return _err(rl_race_err)
+        _audit_tool_action(action, target, True, f"operator approved: {response!r}")
+    else:
+        # No interrupt required for this action — consume the slot
+        # unconditionally (matches the pre-split behaviour for
+        # non-fleet-wide actions like ``tell``, ``send``, ``stop``).
+        _rate_limit_record(action)
+
     try:
         from strands_robots.mesh import get_local_robots
         from strands_robots.mesh.session import get_peers
@@ -167,6 +448,7 @@ def robot_mesh(
     # ── action: tell ──────────────────────────────────────────────────────
     if action == "tell":
         if not target or not instruction:
+            _audit_tool_action(action, target, False, "missing target/instruction")
             return _err("tell requires both target and instruction")
         kwargs: dict[str, Any] = {
             "policy_provider": policy_provider,
@@ -174,31 +456,54 @@ def robot_mesh(
         }
         if policy_port:
             kwargs["policy_port"] = policy_port
+        # Validate the synthesised command through mesh.security.
+        synthesised = {"action": "execute", "instruction": instruction, **kwargs}
+        try:
+            _security.validate_command(synthesised)
+        except _security.ValidationError as exc:
+            _audit_tool_action(action, target, False, f"validation: {exc}")
+            return _err(f"tell rejected: {exc}")
         result = mesh.tell(target, instruction, **kwargs)
+        _audit_tool_action(action, target, True, f"instruction={instruction[:200]}")
         return _ok(f"[tell -> {target}] {json.dumps(result, default=str)[:600]}")
 
     # ── action: send ──────────────────────────────────────────────────────
     if action == "send":
         if not target:
+            _audit_tool_action(action, target, False, "missing target")
             return _err("send requires target")
         if not command:
+            _audit_tool_action(action, target, False, "missing command")
             return _err("send requires command (JSON string)")
         try:
             cmd = json.loads(command)
         except json.JSONDecodeError as exc:
+            _audit_tool_action(action, target, False, f"bad json: {exc}")
             return _err(f"command is not valid JSON: {exc}")
+        if not isinstance(cmd, dict):
+            _audit_tool_action(action, target, False, "command not a dict")
+            return _err("command must decode to a JSON object (dict)")
+        try:
+            cmd = _security.validate_command(cmd)
+        except _security.ValidationError as exc:
+            _audit_tool_action(action, target, False, f"validation: {exc}")
+            return _err(f"send rejected: {exc}")
         result = mesh.send(target, cmd, timeout=timeout)
+        _audit_tool_action(action, target, True, f"action={cmd.get('action')}")
         return _ok(f"[send -> {target}] {json.dumps(result, default=str)[:600]}")
 
     # ── action: broadcast ─────────────────────────────────────────────────
     if action == "broadcast":
-        if not command:
-            return _err("broadcast requires command (JSON string)")
-        try:
-            cmd = json.loads(command)
-        except json.JSONDecodeError as exc:
-            return _err(f"command is not valid JSON: {exc}")
+        # R8-7: pre-validated above before the HITL interrupt fired, so
+        # the cmd here is already a clean validated dict. Defensive
+        # assert: validated_broadcast_cmd is None only on a programmer
+        # error (someone added "broadcast" without the pre-validate).
+        assert validated_broadcast_cmd is not None, (
+            "broadcast reached its handler without pre-validation — R8-7 contract broken"
+        )
+        cmd = validated_broadcast_cmd
         results = mesh.broadcast(cmd, timeout=timeout)
+        _audit_tool_action(action, "*", True, f"action={cmd.get('action')} responses={len(results)}")
         text = f"[broadcast] {len(results)} responses\n"
         for r in results[:10]:
             text += f"  - {json.dumps(r, default=str)[:200]}\n"
@@ -209,23 +514,31 @@ def robot_mesh(
     # ── action: stop ──────────────────────────────────────────────────────
     if action == "stop":
         if not target:
+            _audit_tool_action(action, target, False, "missing target")
             return _err("stop requires target")
         result = mesh.send(target, {"action": "stop"}, timeout=min(timeout, 5.0))
+        _audit_tool_action(action, target, True, "")
         return _ok(f"[stop -> {target}] {json.dumps(result, default=str)[:600]}")
 
     # ── action: emergency_stop ────────────────────────────────────────────
     if action == "emergency_stop":
+        # Operator approval was already obtained above through the
+        # interrupt gate; this branch only runs on an affirmative response.
         results = mesh.emergency_stop()
+        _audit_tool_action(action, "*", True, f"responses={len(results)}")
         return _ok(f"[E-STOP] broadcast complete - {len(results)} responses (audit log written)")
 
     # ── action: subscribe ─────────────────────────────────────────────────
     if action == "subscribe":
         if not target:
+            _audit_tool_action(action, target, False, "missing target")
             return _err("subscribe requires target (Zenoh topic pattern)")
         sub_name = name or target
         out = mesh.subscribe(target, name=sub_name)
         if out is None:
+            _audit_tool_action(action, target, False, "subscribe returned None")
             return _err("subscribe failed (mesh not running?)")
+        _audit_tool_action(action, target, True, f"name={sub_name}")
         return _ok(
             f"[sub] subscribed to '{target}' as '{sub_name}'. "
             f"Use action='inbox' name='{sub_name}' to read buffered messages."
@@ -234,10 +547,13 @@ def robot_mesh(
     # ── action: watch ─────────────────────────────────────────────────────
     if action == "watch":
         if not target:
+            _audit_tool_action(action, target, False, "missing target")
             return _err("watch requires target (peer id)")
         out = mesh.on_stream(target)
         if out is None:
+            _audit_tool_action(action, target, False, "watch returned None")
             return _err("watch failed (mesh not running?)")
+        _audit_tool_action(action, target, True, f"stream_name={out}")
         return _ok(f"[watch] watching peer '{target}'. Use action='inbox' name='{out}' to read buffered steps.")
 
     # ── action: inbox ─────────────────────────────────────────────────────

--- a/strands_robots/tools/robot_mesh.py
+++ b/strands_robots/tools/robot_mesh.py
@@ -261,7 +261,6 @@ def robot_mesh(
     timeout: float = 30.0,
     name: str = "",
     limit: int = 50,
-    tool_context: Any = None,
 ) -> dict[str, Any]:
     """Coordinate every robot, sim, and agent on the local Zenoh mesh.
 

--- a/tests/mesh/test_robot_mesh_security.py
+++ b/tests/mesh/test_robot_mesh_security.py
@@ -1,0 +1,302 @@
+"""Tests for the LLM-injection defences in ``robot_mesh``.
+
+The ``robot_mesh`` tool exposes physical actuation primitives to a Strands
+agent. Four layers of defence sit between the LLM call and the wire:
+
+* A Strands SDK human-in-the-loop interrupt for ``emergency_stop`` and
+  ``broadcast``. The operator response is delivered out-of-band of the
+  tool's argument flow so a prompt cannot smuggle approval.
+* A per-action sliding-window rate limit (e.g. ``emergency_stop`` capped
+  at 3 calls/minute).
+* Server-side :func:`strands_robots.mesh.security.validate_command` run
+  client-side too, so attacker-controlled ``policy_host`` values, unknown
+  actions, etc. are rejected before they ever leave the agent.
+* Every safety-significant call is recorded through the audit log.
+
+These tests pin each layer.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import strands_robots.tools.robot_mesh as rmt
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(monkeypatch, tmp_path):
+    """Each test gets a clean rate-limit history and audit dir."""
+    monkeypatch.setenv("STRANDS_MESH_AUDIT_DIR", str(tmp_path))
+    monkeypatch.delenv("STRANDS_MESH_AUDIT_PSK", raising=False)
+    monkeypatch.delenv("STRANDS_MESH_PSK", raising=False)
+    monkeypatch.delenv("STRANDS_MESH_REQUIRE_AUTH", raising=False)
+    monkeypatch.delenv("STRANDS_MESH_POLICY_HOST_ALLOW", raising=False)
+    rmt._reset_rate_limits()
+    from strands_robots.mesh import audit
+
+    audit._SEQ_COUNTER = 0
+    yield
+    rmt._reset_rate_limits()
+
+
+def _make_ctx(response: str = "y", *, raises: bool = False) -> MagicMock:
+    """Stand-in ToolContext whose interrupt() returns *response*."""
+    ctx = MagicMock(name="ToolContext")
+    if raises:
+        ctx.interrupt.side_effect = RuntimeError("interrupts unavailable")
+    else:
+        ctx.interrupt.return_value = response
+    return ctx
+
+
+def _call(action, *, ctx: MagicMock | None = None, **kw):
+    """Invoke the underlying function with a stub ToolContext."""
+    fn = getattr(rmt.robot_mesh, "__wrapped__", None) or rmt.robot_mesh
+    return fn(action=action, tool_context=ctx or _make_ctx(), **kw)
+
+
+def _stub_mesh() -> MagicMock:
+    """Mesh-shaped mock with the methods the tool calls."""
+    m = MagicMock()
+    m.tell.return_value = {"status": "ok"}
+    m.send.return_value = {"status": "ok"}
+    m.broadcast.return_value = [{"status": "ok"}]
+    m.emergency_stop.return_value = [{"status": "ok"}]
+    return m
+
+
+# --- Interrupt gate (replaces former confirm=bool) ----------------------
+
+
+class TestInterruptGate:
+    def test_emergency_stop_raises_interrupt(self):
+        """Without an approving response, emergency_stop must NOT call mesh."""
+        ctx = _make_ctx(response="n")  # operator denies
+        m = _stub_mesh()
+        with patch("strands_robots.tools.robot_mesh._resolve_mesh", return_value=m):
+            r = _call("emergency_stop", ctx=ctx)
+        assert r["status"] == "error"
+        assert "declined" in r["content"][0]["text"].lower()
+        m.emergency_stop.assert_not_called()
+        ctx.interrupt.assert_called_once()
+        # The interrupt name MUST be namespaced to the action.
+        args, kwargs = ctx.interrupt.call_args
+        assert args[0] == "robot_mesh-emergency_stop-approval"
+        assert kwargs["reason"]["action"] == "emergency_stop"
+
+    def test_emergency_stop_runs_when_operator_approves(self):
+        ctx = _make_ctx(response="y")
+        m = _stub_mesh()
+        with patch("strands_robots.tools.robot_mesh._resolve_mesh", return_value=m):
+            r = _call("emergency_stop", ctx=ctx)
+        assert r["status"] == "success"
+        m.emergency_stop.assert_called_once()
+
+    def test_emergency_stop_yes_full_word_approves(self):
+        ctx = _make_ctx(response="YES")
+        m = _stub_mesh()
+        with patch("strands_robots.tools.robot_mesh._resolve_mesh", return_value=m):
+            r = _call("emergency_stop", ctx=ctx)
+        assert r["status"] == "success"
+
+    def test_broadcast_raises_interrupt(self):
+        ctx = _make_ctx(response="n")
+        m = _stub_mesh()
+        with patch("strands_robots.tools.robot_mesh._resolve_mesh", return_value=m):
+            r = _call("broadcast", command='{"action": "status"}', ctx=ctx)
+        assert r["status"] == "error"
+        assert "declined" in r["content"][0]["text"].lower()
+        m.broadcast.assert_not_called()
+
+    def test_broadcast_runs_when_operator_approves(self):
+        ctx = _make_ctx(response="y")
+        m = _stub_mesh()
+        with patch("strands_robots.tools.robot_mesh._resolve_mesh", return_value=m):
+            r = _call("broadcast", command='{"action": "status"}', ctx=ctx)
+        assert r["status"] == "success"
+        m.broadcast.assert_called_once()
+
+    def test_tell_does_not_raise_interrupt(self):
+        ctx = _make_ctx()
+        m = _stub_mesh()
+        with patch("strands_robots.tools.robot_mesh._resolve_mesh", return_value=m):
+            r = _call("tell", target="peer-a", instruction="pick up cube", ctx=ctx)
+        assert r["status"] == "success"
+        ctx.interrupt.assert_not_called()  # tell is not in INTERRUPT_REQUIRED
+
+    def test_interrupt_unavailable_fails_closed(self):
+        """When the runtime can't deliver interrupts (e.g. direct
+        agent.tool.X path), the tool MUST refuse rather than execute."""
+        ctx = _make_ctx(raises=True)
+        m = _stub_mesh()
+        with patch("strands_robots.tools.robot_mesh._resolve_mesh", return_value=m):
+            r = _call("emergency_stop", ctx=ctx)
+        assert r["status"] == "error"
+        assert "interrupt" in r["content"][0]["text"].lower()
+        m.emergency_stop.assert_not_called()
+
+
+# --- rate limiting ------------------------------------------------------
+
+
+class TestRateLimit:
+    def test_emergency_stop_capped_at_3_per_window(self):
+        m = _stub_mesh()
+        with patch("strands_robots.tools.robot_mesh._resolve_mesh", return_value=m):
+            for _ in range(3):
+                r = _call("emergency_stop")
+                assert r["status"] == "success"
+            r = _call("emergency_stop")
+        assert r["status"] == "error"
+        assert "rate limit" in r["content"][0]["text"]
+        assert m.emergency_stop.call_count == 3
+
+    def test_tell_capped_at_30_per_window(self):
+        m = _stub_mesh()
+        with patch("strands_robots.tools.robot_mesh._resolve_mesh", return_value=m):
+            successes = 0
+            for _ in range(35):
+                r = _call("tell", target="peer-a", instruction="ping")
+                if r["status"] == "success":
+                    successes += 1
+            assert successes == 30
+
+    def test_distinct_actions_dont_share_buckets(self):
+        m = _stub_mesh()
+        with patch("strands_robots.tools.robot_mesh._resolve_mesh", return_value=m):
+            for _ in range(3):
+                _call("emergency_stop")  # exhausts emergency_stop bucket
+            r = _call("tell", target="peer-a", instruction="ping")
+            assert r["status"] == "success"  # tell bucket unaffected
+
+
+# --- command validation ------------------------------------------------
+
+
+class TestCommandValidation:
+    def test_send_rejects_attacker_policy_host(self):
+        m = _stub_mesh()
+        with patch("strands_robots.tools.robot_mesh._resolve_mesh", return_value=m):
+            r = _call(
+                "send",
+                target="peer-a",
+                command='{"action": "execute", "instruction": "go", "policy_provider": "mock", "policy_host": "evil.example.com"}',
+            )
+        assert r["status"] == "error"
+        assert "policy_host" in r["content"][0]["text"]
+        m.send.assert_not_called()
+
+    def test_send_rejects_unknown_action(self):
+        m = _stub_mesh()
+        with patch("strands_robots.tools.robot_mesh._resolve_mesh", return_value=m):
+            r = _call("send", target="peer-a", command='{"action": "rm_rf"}')
+        assert r["status"] == "error"
+        m.send.assert_not_called()
+
+    def test_send_rejects_non_json(self):
+        m = _stub_mesh()
+        with patch("strands_robots.tools.robot_mesh._resolve_mesh", return_value=m):
+            r = _call("send", target="peer-a", command="not json")
+        assert r["status"] == "error"
+
+    def test_send_rejects_non_dict_json(self):
+        m = _stub_mesh()
+        with patch("strands_robots.tools.robot_mesh._resolve_mesh", return_value=m):
+            r = _call("send", target="peer-a", command='["not a dict"]')
+        assert r["status"] == "error"
+
+    def test_broadcast_validates_after_interrupt(self):
+        """Broadcast goes through interrupt FIRST, then validation. An
+        approved-but-malformed broadcast must still be rejected by
+        validation, not silently shipped."""
+        m = _stub_mesh()
+        with patch("strands_robots.tools.robot_mesh._resolve_mesh", return_value=m):
+            r = _call(
+                "broadcast",
+                command='{"action": "execute", "instruction": "go", "policy_provider": "mock", "policy_host": "evil.com"}',
+            )
+        assert r["status"] == "error"
+        assert "policy_host" in r["content"][0]["text"]
+        m.broadcast.assert_not_called()
+
+    def test_tell_too_long_instruction_rejected(self):
+        m = _stub_mesh()
+        with patch("strands_robots.tools.robot_mesh._resolve_mesh", return_value=m):
+            r = _call("tell", target="peer-a", instruction="x" * 3000)
+        assert r["status"] == "error"
+        assert "exceeds" in r["content"][0]["text"]
+
+    def test_tell_passes_with_valid_args(self):
+        m = _stub_mesh()
+        with patch("strands_robots.tools.robot_mesh._resolve_mesh", return_value=m):
+            r = _call("tell", target="peer-a", instruction="pick up cube", duration=10)
+        assert r["status"] == "success"
+
+
+# --- audit logging ------------------------------------------------------
+
+
+class TestAudit:
+    def test_successful_emergency_stop_audited(self):
+        m = _stub_mesh()
+        with patch("strands_robots.tools.robot_mesh._resolve_mesh", return_value=m):
+            _call("emergency_stop")
+        from strands_robots.mesh.audit import read_audit_log
+
+        events = [r for r in read_audit_log() if r.get("event") == "llm_tool_action"]
+        assert any(r["payload"]["action"] == "emergency_stop" and r["payload"]["success"] for r in events)
+
+    def test_declined_call_audited(self):
+        ctx = _make_ctx(response="no")
+        with patch("strands_robots.tools.robot_mesh._resolve_mesh", return_value=_stub_mesh()):
+            _call("emergency_stop", ctx=ctx)
+        from strands_robots.mesh.audit import read_audit_log
+
+        events = [r for r in read_audit_log() if r.get("event") == "llm_tool_action"]
+        assert any(
+            r["payload"]["action"] == "emergency_stop"
+            and r["payload"]["success"] is False
+            and "declined" in r["payload"]["detail"]
+            for r in events
+        )
+
+
+class TestRateLimitTOCTOU:
+    """pre-fix, two concurrent emergency_stop calls could
+    each pass _rate_limit_check, both get operator-approved, both record,
+    briefly exceeding the configured 3/60s limit. The post-approval
+    re-check under _RATE_LOCK closes the race.
+    """
+
+    def test_concurrent_approvals_capped_at_configured_limit(self, monkeypatch):
+        # Lower the limit to make the race deterministic.
+        rmt._reset_rate_limits()
+
+        # Pretend the limit is 2 per 60s.
+        monkeypatch.setitem(rmt._RATE_LIMITS, "emergency_stop", (2, 60.0))
+
+        # Two pre-interrupt checks pass (no slots consumed).
+        assert rmt._rate_limit_check("emergency_stop") is None
+        assert rmt._rate_limit_check("emergency_stop") is None
+
+        # First post-approval atomic check+record: succeeds (slot 1).
+        assert rmt._rate_limit_check_and_record("emergency_stop") is None
+        # Second: succeeds (slot 2).
+        assert rmt._rate_limit_check_and_record("emergency_stop") is None
+        # Third: must FAIL even though _rate_limit_check would have
+        # passed pre-interrupt. This is the race the fix closes.
+        race_err = rmt._rate_limit_check_and_record("emergency_stop")
+        assert race_err is not None
+        assert "rate limit exceeded" in race_err
+        assert "raced past" in race_err
+
+    def test_atomic_helper_does_not_consume_on_full_bucket(self, monkeypatch):
+        rmt._reset_rate_limits()
+        monkeypatch.setitem(rmt._RATE_LIMITS, "broadcast", (1, 60.0))
+        assert rmt._rate_limit_check_and_record("broadcast") is None
+        # Full -- second call rejects.
+        assert rmt._rate_limit_check_and_record("broadcast") is not None
+        # Verify no spurious extra slot was added.
+        assert len(rmt._RATE_HISTORY["broadcast"]) == 1

--- a/tests/mesh/test_robot_mesh_tool.py
+++ b/tests/mesh/test_robot_mesh_tool.py
@@ -9,12 +9,30 @@ import pytest
 from strands_robots.tools.robot_mesh import robot_mesh
 
 
-def _strands_call(**kwargs):
-    """Strands @tool wraps the function — invoke via .original."""
+def _make_tool_context(*, interrupt_response: str = "y", interrupt_raises: bool = False) -> MagicMock:
+    """Build a stand-in ToolContext whose interrupt() returns *interrupt_response*.
+
+    Tests that DON'T hit the interrupt path can still call this -- interrupt()
+    will simply never be invoked. Tests that DO hit it (emergency_stop /
+    broadcast) can vary `interrupt_response` to simulate operator approval /
+    denial. Set `interrupt_raises=True` to model environments where interrupts
+    aren't available (the tool should fail-closed).
+    """
+    ctx = MagicMock(name="ToolContext")
+    if interrupt_raises:
+        ctx.interrupt.side_effect = RuntimeError("interrupts not supported here")
+    else:
+        ctx.interrupt.return_value = interrupt_response
+    return ctx
+
+
+def _strands_call(*, _ctx: MagicMock | None = None, **kwargs):
+    """Strands @tool wraps the function -- invoke via .original."""
     fn = getattr(robot_mesh, "original", None)
+    ctx = _ctx if _ctx is not None else _make_tool_context()
     if fn is None:
-        return robot_mesh(**kwargs)
-    return fn(**kwargs)
+        return robot_mesh(tool_context=ctx, **kwargs)
+    return fn(tool_context=ctx, **kwargs)
 
 
 @pytest.fixture


### PR DESCRIPTION
Part 7 / 9 of the split of #195 — tracked by #219.

**Drafted** until PR-2 (#223) and PR-6 land.

## The LLM tool surface

Approval delivered out-of-band of the LLM's tool-argument flow (via Strands SDK `tool_context.interrupt`), so prompt injection cannot smuggle approval. Only `y` / `yes` / `approve` / `approved` (case- and whitespace-insensitive, exact-match after `strip().lower()`) approve. Declined approvals do **not** consume rate-limit slots.

Per-action rate limit (separate buckets for `emergency_stop` / `broadcast` / `execute`) with token-bucket semantics.

## What's in this PR

- `strands_robots/tools/robot_mesh.py` (+324/-8) — HITL flow, per-action rate limit, client-side `validate_command` (defence-in-depth — programmatic callers go through the same gate as wire receive).
- 2 test files (325 LOC).

## Reviewer focus

- Prompt injection isolation: approval delivered via SDK `tool_context.interrupt`, **not** via tool args. Verify the LLM has no mechanism to extract or fabricate the approval token.
- Per-action rate limit: separate token buckets prevent `emergency_stop` flood from cannibalising `execute` quota.
- Declined-approval doesn't consume slots.
- Exact-match approval (no fuzzy match, no "yeah" / "sure" / "go").

## Carries review fixes from #195

R11 (tool surface API drift), R16 (test file naming — subject-named not methodology-named), R24 (`_exec_cmd` non-dict rejection client-side counterpart).

## Stacking note

Depends on PR-1 (#220), PR-2 (#223), PR-6. CI on this branch in isolation is **expected red** until those land.

---

Landing order: PR-1 → PR-2/3/4/5 → PR-6 → **PR-7** → PR-8 → PR-9. Full plan: [`PR_LIST.md`](https://github.com/cagataycali/robots/blob/mesh/zenoh-native-security/PR_LIST.md). Tracking: #219.