### PR TITLE
docs(policies): clarify Policy ABC supports VLA + classical planners (#299)

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,83 @@ policy = create_policy(
 policy = create_policy(provider="mock")
 ```
 
+### Non-VLA Policies (motion planners, MPC, scripted)
+
+The `Policy` ABC is intentionally agnostic about *how* actions are produced.
+The same interface fits VLA-style providers **and** classical motion
+planners (cuRobo, MoveIt2, OMPL), model-predictive controllers, and pure-IK
+or scripted trajectories — anything that maps `(observation, goal)` to a
+list of joint targets.
+
+`MockPolicy` (`strands_robots/policies/mock.py`) is the reference: it sets
+`requires_images = False` so the simulation skips camera rendering (~10x
+throughput at 500Hz), ignores the `instruction` string, and returns a list
+of joint-target dicts.
+
+Non-VLA providers should consume **well-known `**kwargs` keys** instead of
+JSON-encoding goals into the natural-language instruction:
+
+| Key             | Type                       | Meaning                                                                |
+| --------------- | -------------------------- | ---------------------------------------------------------------------- |
+| `target_pose`   | `list[float]`              | Cartesian goal `[x, y, z, qw, qx, qy, qz]` in the robot base frame     |
+| `target_joints` | `dict[str, float]`         | Joint-space goal keyed by joint name (radians / metres)                |
+| `world_update`  | `dict \| None`             | Per-call world refresh for collision-aware planners (depth, mesh, ...) |
+
+Providers MUST ignore unknown `**kwargs` rather than raising, so callers can
+pass shared keys across providers without coupling to a specific backend.
+
+Minimal example — register a planner-style provider at runtime:
+
+```python
+from typing import Any
+from strands_robots.policies import Policy, register_policy, create_policy
+
+
+class ReachPolicy(Policy):
+    """Linear interpolation from current joint state to target_joints."""
+
+    def __init__(self, steps: int = 32, **_: Any) -> None:
+        self._keys: list[str] = []
+        self._steps = steps
+
+    @property
+    def provider_name(self) -> str:
+        return "reach"
+
+    @property
+    def requires_images(self) -> bool:
+        return False  # joint-state only -- skip camera rendering
+
+    def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
+        self._keys = list(robot_state_keys)
+
+    async def get_actions(
+        self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any
+    ) -> list[dict[str, Any]]:
+        target = kwargs.get("target_joints")
+        if target is None:
+            raise ValueError("ReachPolicy requires target_joints kwarg")
+
+        state = observation_dict.get("observation.state", [0.0] * len(self._keys))
+        out: list[dict[str, float]] = []
+        for s in range(1, self._steps + 1):
+            alpha = s / self._steps
+            out.append(
+                {k: (1 - alpha) * state[i] + alpha * target[k] for i, k in enumerate(self._keys)}
+            )
+        return out
+
+
+register_policy("reach", lambda: ReachPolicy, aliases=["lerp"])
+policy = create_policy("reach")
+```
+
+The same shape extends to cuRobo (call `MotionGen.plan_single` with the
+`target_pose` kwarg, cache the trajectory, yield `action_horizon` chunks)
+and MoveIt2 (forward `target_pose` + `joint_state` to a sidecar ROS 2
+service via ZMQ / gRPC).  Reference implementations are tracked separately
+on the [Strands Labs - Robots project board](https://github.com/orgs/strands-labs/projects/2).
+
 ## Project Structure
 
 ```

--- a/strands_robots/policies/__init__.py
+++ b/strands_robots/policies/__init__.py
@@ -1,10 +1,18 @@
-"""Policy Abstraction for Universal VLA Support.
+"""Policy Abstraction for VLA, motion planners, MPC, and scripted controllers.
 
 Plugin-based registry - all provider definitions live in registry/policies.json.
 No hardcoded if/elif chains. New providers are auto-discovered or registered at runtime.
 
+The :class:`Policy` ABC is intentionally agnostic about *how* actions are
+produced, so the same interface fits VLA-style providers (consume images +
+instruction) and non-VLA providers (cuRobo, MoveIt2, MPC, pure-IK / scripted
+trajectories).  Non-VLA providers typically set ``requires_images=False`` and
+read their goal from the well-known ``**kwargs`` keys (``target_pose``,
+``target_joints``, ``world_update``) documented on
+:meth:`Policy.get_actions`.
+
 Built-in providers (see policies.json for full list):
-    - mock: Sinusoidal test actions
+    - mock: Sinusoidal test actions (non-VLA reference, ``requires_images=False``)
     - groot: NVIDIA GR00T via ZMQ
     - lerobot_local: Direct HuggingFace inference (ACT, Pi0, SmolVLA, Diffusion, ...)
 

--- a/strands_robots/policies/base.py
+++ b/strands_robots/policies/base.py
@@ -1,4 +1,25 @@
-"""Abstract base class for VLA policies."""
+"""Abstract base class for robot policies (VLA, motion planners, MPC, scripted).
+
+The :class:`Policy` ABC is intentionally agnostic about *how* actions are
+produced.  Built-in providers (`mock`, `groot`, `lerobot_local`) are VLA-style,
+but the same interface is the right shape for:
+
+* **Classical motion planners** — cuRobo, MoveIt2, OMPL, RRT*: take a goal
+  pose and joint state, return a collision-free trajectory.
+* **Model-predictive controllers** (MPC) — solve a finite-horizon optimal
+  control problem each tick.
+* **Scripted / pure-IK trajectories** — analytic IK followed by interpolation;
+  zero learning involved.
+
+Non-VLA implementations typically set :attr:`Policy.requires_images` to
+``False`` to skip camera rendering (~10x throughput win at 500Hz) and read
+their goal from the well-known ``**kwargs`` keys documented on
+:meth:`Policy.get_actions` rather than parsing the natural-language
+``instruction`` string.
+
+See ``MockPolicy`` (``strands_robots/policies/mock.py``) for the canonical
+non-VLA reference implementation.
+"""
 
 import asyncio
 import concurrent.futures
@@ -7,10 +28,18 @@ from typing import Any
 
 
 class Policy(ABC):
-    """Abstract base class for VLA policies.
+    """Abstract base class for robot policies (VLA, motion planners, MPC, scripted).
 
-    All policies implement async get_actions().  For convenience, a
-    synchronous wrapper get_actions_sync() is provided.
+    All policies implement async :meth:`get_actions`.  For convenience, a
+    synchronous wrapper :meth:`get_actions_sync` is provided.
+
+    The interface is general enough to cover both **VLA-style** providers
+    (consume images + instruction, output joint targets) and **non-VLA**
+    providers such as classical motion planners (cuRobo, MoveIt2),
+    model-predictive controllers, and pure-IK / scripted trajectories.
+    Non-VLA providers typically set :attr:`requires_images` to ``False``
+    and read their goal from the well-known ``**kwargs`` keys documented
+    on :meth:`get_actions`.
     """
 
     @abstractmethod
@@ -20,11 +49,40 @@ class Policy(ABC):
         """Get actions from policy given observation and instruction.
 
         Args:
-            observation_dict: Robot observation (cameras + state).
-            instruction: Natural language instruction.
+            observation_dict: Robot observation (cameras + state).  VLA
+                providers consume both ``observation.images.*`` and
+                ``observation.state``.  Non-VLA providers typically
+                consume ``observation.state`` only and set
+                :attr:`requires_images` to ``False`` to skip camera
+                rendering.
+            instruction: Natural language instruction.  Required by the
+                signature for VLA providers; non-VLA providers (motion
+                planners, MPC, scripted) may ignore it and read the goal
+                from ``**kwargs`` instead.
+            **kwargs: Provider-specific parameters.  The following keys
+                are **well-known** and SHOULD be honoured by non-VLA
+                providers when present so callers don't have to JSON-encode
+                goals into the ``instruction`` string:
+
+                - ``target_pose: list[float]`` — Cartesian goal as
+                  ``[x, y, z, qw, qx, qy, qz]`` (position in metres,
+                  orientation as a unit quaternion in the robot base frame).
+                - ``target_joints: dict[str, float]`` — joint-space goal
+                  keyed by joint name; values are in radians (revolute) or
+                  metres (prismatic).
+                - ``world_update: dict | None`` — per-call world refresh
+                  for collision-aware planners (e.g. point cloud / depth
+                  image / mesh updates).  ``None`` means "reuse the world
+                  configured at init time".
+
+                Providers MUST ignore unknown ``**kwargs`` rather than
+                raising, so callers can pass shared keys across providers.
 
         Returns:
-            List of action dicts for robot execution.
+            List of action dicts for robot execution.  Each dict maps
+            robot state key (joint name) to the target value for that
+            tick; consumers typically execute the list at a fixed
+            control rate (e.g. 50Hz).
         """
         pass
 
@@ -82,10 +140,11 @@ class Policy(ABC):
     def requires_images(self) -> bool:
         """Whether this policy needs camera frames in its observation.
 
-        Default True (most VLA policies do). Subclasses that only consume
-        joint state (e.g. ``MockPolicy``, pure-IK controllers, scripted
+        Default ``True`` (most VLA policies do). Subclasses that only
+        consume joint state (e.g. ``MockPolicy``, classical motion planners
+        such as cuRobo / MoveIt2, MPC, pure-IK controllers, scripted
         trajectories) can return ``False`` to let the simulation skip
-        expensive camera rendering - a ~10x throughput win at 500Hz when
+        expensive camera rendering — a ~10x throughput win at 500Hz when
         no cameras are needed.
         """
         return True

--- a/tests/policies/test_base.py
+++ b/tests/policies/test_base.py
@@ -9,7 +9,10 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
+import pytest
+
 from strands_robots.policies.base import Policy
+from strands_robots.policies.mock import MockPolicy
 
 
 class _IdentityPolicy(Policy):
@@ -75,8 +78,6 @@ def test_well_known_kwargs_are_accepted_by_contract():
     target_joints, world_update). The Policy contract requires get_actions
     to ignore unknown kwargs rather than raising, so callers can pass
     shared keys across providers without coupling to a backend."""
-    from strands_robots.policies.mock import MockPolicy
-
     p = MockPolicy()
     p.set_robot_state_keys(["j0", "j1"])
     obs = {"observation.state": [0.0, 0.0]}
@@ -98,6 +99,46 @@ def test_well_known_kwargs_are_accepted_by_contract():
 def test_non_vla_providers_can_skip_camera_rendering():
     """``requires_images=False`` is the opt-out for joint-state-only
     providers (MockPolicy, planners, MPC, scripted)."""
-    from strands_robots.policies.mock import MockPolicy
-
     assert MockPolicy().requires_images is False
+
+
+# Providers that opt into the non-VLA path and inherit the documented
+# "ignore unknown ``**kwargs`` rather than raising" contract from the
+# Policy ABC. As CuroboPolicy / MoveIt2Policy land via #305 / #306 they
+# extend this list rather than re-asserting the same contract locally.
+_NON_VLA_PROVIDER_FACTORIES: list[Any] = [
+    pytest.param(lambda: MockPolicy(), id="mock"),
+    # pytest.param(lambda: CuroboPolicy(...), id="curobo"),     # PR #306
+    # pytest.param(lambda: MoveIt2Policy(...), id="moveit2"),   # PR #305
+]
+
+
+@pytest.mark.parametrize("provider_factory", _NON_VLA_PROVIDER_FACTORIES)
+def test_unknown_kwargs_are_silently_ignored(provider_factory):
+    """Regression pin for the cross-provider contract documented in the
+    Policy ABC module docstring: ``get_actions(**kwargs)`` MUST silently
+    ignore kwargs it does not recognise rather than raising ``TypeError``.
+
+    A made-up kwarg no provider knows about (``some_future_kwarg``) must
+    round-trip cleanly through ``get_actions_sync`` -- this fails on any
+    future provider whose ``get_actions`` signature drops ``**kwargs``
+    entirely (e.g. ``def get_actions(self, obs, instruction, target_pose=None)``),
+    which would otherwise be silently masked by the sync wrapper's own
+    ``**kwargs`` passthrough.
+
+    Centralising here means #305 / #306 inherit the contract automatically
+    instead of each PR re-asserting it locally."""
+    p = provider_factory()
+    p.set_robot_state_keys(["j0", "j1"])
+    obs = {"observation.state": [0.0, 0.0]}
+
+    actions = p.get_actions_sync(
+        obs,
+        instruction="",
+        target_pose=[0.5, 0.0, 0.3, 1.0, 0.0, 0.0, 0.0],
+        some_future_kwarg="opaque",
+    )
+    assert isinstance(actions, list) and actions, (
+        "Policy must return a non-empty action list even when passed an "
+        "unknown kwarg; the contract is to ignore, not raise."
+    )

--- a/tests/policies/test_base.py
+++ b/tests/policies/test_base.py
@@ -55,3 +55,49 @@ def test_provider_name_and_state_keys():
     assert p.provider_name == "identity"
     p.set_robot_state_keys(["a", "b", "c"])
     assert p._keys == ["a", "b", "c"]
+
+
+def test_requires_images_default_is_true():
+    """The base ABC defaults requires_images=True; subclasses opt out."""
+    p = _IdentityPolicy()
+    assert p.requires_images is True
+
+
+def test_reset_default_is_noop():
+    """Default reset() returns None and must be safe to call without a seed."""
+    p = _IdentityPolicy()
+    assert p.reset() is None
+    assert p.reset(seed=42) is None
+
+
+def test_well_known_kwargs_are_accepted_by_contract():
+    """Non-VLA providers receive goals via ``**kwargs`` (target_pose,
+    target_joints, world_update). The Policy contract requires get_actions
+    to ignore unknown kwargs rather than raising, so callers can pass
+    shared keys across providers without coupling to a backend."""
+    from strands_robots.policies.mock import MockPolicy
+
+    p = MockPolicy()
+    p.set_robot_state_keys(["j0", "j1"])
+    obs = {"observation.state": [0.0, 0.0]}
+
+    # All three well-known kwargs together must round-trip cleanly through
+    # the sync wrapper -- this is the smoke test that pins the documented
+    # API surface for non-VLA providers.
+    actions = p.get_actions_sync(
+        obs,
+        instruction="",
+        target_pose=[0.5, 0.0, 0.3, 1.0, 0.0, 0.0, 0.0],
+        target_joints={"j0": 0.1, "j1": -0.2},
+        world_update=None,
+    )
+    assert isinstance(actions, list) and actions, "Policy must return a non-empty action list"
+    assert all(isinstance(a, dict) for a in actions)
+
+
+def test_non_vla_providers_can_skip_camera_rendering():
+    """``requires_images=False`` is the opt-out for joint-state-only
+    providers (MockPolicy, planners, MPC, scripted)."""
+    from strands_robots.policies.mock import MockPolicy
+
+    assert MockPolicy().requires_images is False


### PR DESCRIPTION
## Summary

Subtask 1 of #299 — API cleanup. The `Policy` ABC at `strands_robots/policies/base.py` is already general enough to host classical motion planners (cuRobo, MoveIt2), MPC, and pure-IK / scripted controllers, but the docstrings, module description, and README all framed it as VLA-only. This PR fixes the framing, documents the well-known `**kwargs` keys planner-style providers should consume, and adds contract tests pinning the surface.

Reference implementations of `CuroboPolicy` (subtask 2) and `MoveIt2Policy` (subtask 3) are tracked as follow-up issues per the issue's own staging.

## What changed

- **`strands_robots/policies/base.py`**
  - Module docstring rewritten to call out non-VLA use cases (motion planners, MPC, scripted) with a pointer to `MockPolicy` as the reference implementation.
  - `Policy` class docstring updated to match.
  - `Policy.get_actions` docstring now documents three **well-known `**kwargs` keys**:
    - `target_pose: list[float]` — `[x, y, z, qw, qx, qy, qz]` in the robot base frame
    - `target_joints: dict[str, float]` — joint-space goal keyed by joint name
    - `world_update: dict | None` — per-call world refresh for collision-aware planners
  - Spec mandates providers ignore unknown `**kwargs` rather than raising, so callers can pass shared keys across VLA and planner backends.
  - `requires_images` docstring extended to list cuRobo / MoveIt2 / MPC alongside `MockPolicy` as canonical opt-outs.

- **`strands_robots/policies/__init__.py`** — module docstring updated; `MockPolicy` called out as the non-VLA reference (`requires_images=False`).

- **`README.md`** — new "Non-VLA Policies (motion planners, MPC, scripted)" subsection under Policy Providers. Includes the kwargs table, a runtime-registered `ReachPolicy` example using `register_policy(...)` + `target_joints`, and a pointer to the project board for the cuRobo / MoveIt2 reference work.

- **`tests/policies/test_base.py`** — four new contract tests:
  - `test_requires_images_default_is_true` — base ABC default
  - `test_reset_default_is_noop` — `reset()` and `reset(seed=...)` round-trip without state
  - `test_well_known_kwargs_are_accepted_by_contract` — `target_pose` + `target_joints` + `world_update=None` together round-trip through `get_actions_sync` on `MockPolicy` (the documented non-VLA reference)
  - `test_non_vla_providers_can_skip_camera_rendering` — `MockPolicy.requires_images is False`

No behavior changes; documentation + contract tests only.

## Why

The base.py module docstring already hinted at non-VLA use cases (`"pure-IK controllers, scripted trajectories"` at the old line 86–91), but nothing else did. Without explicit kwargs naming and a README pattern, every planner integration would invent its own goal-encoding (JSON in `instruction`, custom subclass kwargs, etc.) and never compose with the existing VLA providers. This PR sets the contract once so subtasks 2 and 3 can ship as **clients** of a stable interface rather than as **redefiners** of it.

## Test surface

- `hatch run lint` — clean (`Success: no issues found in 199 source files`)
- `hatch run test tests/policies/` — 256 passed
- `hatch run test` (full unit suite) — 2553 passed, 53 skipped, 7 pre-existing X11/OpenGL failures in `test_rendering.py` / `test_policy_runner.py` (no X server on this dev box; flagged as environmental in AGENTS.local.md)
- New tests in `tests/policies/test_base.py` exercise the documented kwargs surface end-to-end via `MockPolicy.get_actions_sync`.

## Acceptance criteria from #299

- [x] Rename `Policy` docstring at `policies/base.py:1, 9, 10` from *"VLA policies"* to *"robot policies (VLA, motion planners, MPC, scripted)"*
- [x] Document well-known `**kwargs` keys for non-VLA goals (`target_pose`, `target_joints`, `world_update`)
- [x] Add a "Non-VLA Policy" section to README explaining the pattern, citing `MockPolicy` as the reference and showing how to plug in a planner

The remaining acceptance criteria from #299 (cuRobo and MoveIt2 reference implementations, end-to-end LLM-agent demo) belong to subtasks 2 and 3 and will ship on their own PRs.

## Out of scope (follow-up issues)

- **Subtask 2** — `CuroboPolicy` reference implementation under `[curobo]` extra (issue to be filed)
- **Subtask 3** — `MoveIt2Policy` reference implementation under `[moveit2]` extra (issue to be filed)
- **Subtask 4** — mesh `tell()` dispatch sym sim/hardware so cuRobo / MoveIt2 work end-to-end on sim peers (issue to be filed)

## Project board

This PR addresses subtask 1 of [#299](https://github.com/strands-labs/robots/issues/299) on the [Strands Labs - Robots board](https://github.com/orgs/strands-labs/projects/2). Please move the umbrella issue to "In review" and keep it open — subtasks 2-4 still need to land before it closes.
