### PR TITLE
feat(mesh): map tell() dispatch to sim peers via Simulation.run_policy/start_policy (closes #303)

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,9 +529,38 @@ sim_a.mesh.tell(sim_b.mesh.peer_id, "pick up the cube")
 sim_a.mesh.emergency_stop()     # broadcast E-STOP, audited to disk
 ```
 
+`tell()` works against both `HardwareRobot` and `Simulation` peers. The
+dispatcher detects the peer type and routes to
+`HardwareRobot._execute_task_sync` / `start_task` for hardware peers and to
+`Simulation.run_policy` / `start_policy` for sim peers. Issue [#300]'s
+well-known per-call policy kwargs (`target_pose`, `target_joints`,
+`world_update`) and the existing constructor extras (`model_path`,
+`server_address`, `policy_type`, `pretrained_name_or_path`) are forwarded
+end-to-end via `policy_config` so a planner-style policy on a sim peer
+sees the goal payload it needs:
+
+```python
+# Agent on peer A drives a cuRobo planner running on a sim peer B.
+sim_a.mesh.tell(
+    sim_b.mesh.peer_id,
+    "reach for the red block",
+    policy_provider="curobo",
+    target_pose=[0.3, 0.0, 0.4, 1.0, 0.0, 0.0, 0.0],
+    robot_name="arm_left",       # disambiguate in multi-robot sims
+    duration=10.0,
+    fast_mode=True,
+)
+```
+
+Per-robot mesh peers attach automatically inside a sim, so an LLM agent
+may also `tell()` a specific `SimRobot` peer (`<sim_peer_id>__<robot_name>`)
+when the simulation hosts more than one robot.
+
 Disable globally with `STRANDS_MESH=false` or per-robot with
 `Robot("so100", mesh=False)`.  Install the optional dependency with
 `pip install strands-robots[mesh]`.
+
+[#300]: https://github.com/strands-labs/robots/issues/300
 
 ### Cache Directory
 

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -570,6 +570,32 @@ class Mesh(SensorLoopsMixin):
                 for k in ("model_path", "server_address", "policy_type", "pretrained_name_or_path")
                 if k in cmd
             }
+            # Sim peer? Route to Simulation.start_policy / run_policy.
+            # Detected by the presence of the ``run_policy`` callable + a
+            # ``_world`` attribute (the SimEngine ABC contract). HardwareRobot
+            # has neither, so this is unambiguous.
+            #
+            # Forwards the well-known per-call kwargs from #300
+            # (``target_pose`` / ``target_joints`` / ``world_update``) plus
+            # the existing ``extra`` set (model_path / server_address / ...)
+            # via ``policy_config``. ``create_policy(provider, **policy_config)``
+            # passes them to the Policy constructor; per the #300 contract
+            # planner-style providers consume them and VLA providers ignore
+            # unknown kwargs without raising.
+            if (
+                action in ("execute", "start")
+                and hasattr(r, "run_policy")
+                and hasattr(r, "_world")
+                and hasattr(r, "list_robots")
+            ):
+                return self._dispatch_sim_policy(
+                    action=action,
+                    cmd=cmd,
+                    instruction=instruction,
+                    policy_provider=policy_provider,
+                    duration=duration,
+                    extra=extra,
+                )
             if action == "execute" and hasattr(r, "_execute_task_sync"):
                 return dict(
                     r._execute_task_sync(instruction, policy_provider, policy_port, policy_host, duration, **extra)
@@ -598,6 +624,109 @@ class Mesh(SensorLoopsMixin):
                 return dict(r.stop_teleop(dev))
             return {"error": "robot does not support stop_teleop"}
         return {"error": f"unknown action: {action}"}
+
+    # Well-known per-call policy kwargs from issue #300 — keys that planner-
+    # style providers (cuRobo, MoveIt2, MPC) consume to encode goals beyond
+    # natural-language ``instruction``. Forwarded from ``tell()`` payload
+    # into ``policy_config`` so a ``policy_provider="curobo"`` peer sees the
+    # ``target_pose`` it needs without the dispatch layer dropping it
+    # silently.
+    #
+    # See AGENTS.md > Public API Hygiene: "Forward all advertised kwargs
+    # end-to-end. Silent drops are bugs masquerading as features."
+    _SIM_WELL_KNOWN_POLICY_KWARGS: tuple[str, ...] = (
+        "target_pose",
+        "target_joints",
+        "world_update",
+    )
+
+    def _dispatch_sim_policy(
+        self,
+        *,
+        action: str,
+        cmd: dict[str, Any],
+        instruction: str,
+        policy_provider: str,
+        duration: float,
+        extra: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Dispatch ``execute`` / ``start`` to a sim peer's policy runner.
+
+        Sim peers expose :meth:`SimEngine.run_policy` (blocking) and
+        :meth:`SimEngine.start_policy` (async) instead of ``HardwareRobot``'s
+        ``_execute_task_sync`` / ``start_task``. This helper bridges the
+        ``tell()`` wire payload to those methods.
+
+        ``robot_name`` resolution:
+            * Use ``cmd["robot_name"]`` when present.
+            * Otherwise default to the only robot in the world if there is
+              exactly one.
+            * Otherwise return an error — ambiguous targets must be
+              explicit so the agent can't accidentally drive the wrong arm.
+
+        Forwards both the existing ``extra`` constructor kwargs
+        (``model_path``, ``server_address``, ``policy_type``,
+        ``pretrained_name_or_path``) and the issue #300 well-known per-call
+        kwargs (``target_pose``, ``target_joints``, ``world_update``) via
+        ``policy_config``. Per #300 the receiving Policy ignores unknown
+        kwargs rather than raising, so VLA providers stay compatible.
+        """
+        sim = self.robot
+
+        if sim._world is None:
+            return {"error": "sim peer has no world; call create_world first"}
+
+        try:
+            available = list(sim.list_robots())
+        except Exception as exc:  # noqa: BLE001 — surface as wire-level error
+            return {"error": f"sim list_robots failed: {exc}"}
+
+        robot_name = cmd.get("robot_name")
+        if not robot_name:
+            if len(available) == 1:
+                robot_name = available[0]
+            elif len(available) == 0:
+                return {"error": "sim peer has no robots; add_robot first"}
+            else:
+                return {
+                    "error": (
+                        f"sim peer has {len(available)} robots {available}; "
+                        "tell() must include robot_name to disambiguate"
+                    )
+                }
+        if robot_name not in available:
+            return {"error": f"robot_name={robot_name!r} not in sim (available: {available})"}
+
+        # Build policy_config: existing constructor kwargs + well-known
+        # per-call kwargs from #300. ``policy_config`` is the documented
+        # passthrough on SimEngine.run_policy/start_policy.
+        policy_config: dict[str, Any] = dict(extra)
+        for key in self._SIM_WELL_KNOWN_POLICY_KWARGS:
+            if key in cmd:
+                policy_config[key] = cmd[key]
+
+        # Optional sim-side controls. We expose only the fields that already
+        # have validator coverage in the wire schema — control_frequency,
+        # action_horizon, fast_mode, video — and that are safe to forward to
+        # an LLM-issued ``tell()``. Anything else stays on its server-side
+        # default to avoid surfacing internal knobs to untrusted agents.
+        run_kwargs: dict[str, Any] = {
+            "policy_provider": policy_provider,
+            "policy_config": policy_config,
+            "instruction": instruction,
+            "duration": duration,
+        }
+        for opt_key in ("control_frequency", "action_horizon", "fast_mode", "n_steps"):
+            if opt_key in cmd:
+                run_kwargs[opt_key] = cmd[opt_key]
+
+        # ``execute`` blocks until the rollout finishes (matches HardwareRobot
+        # ``_execute_task_sync`` semantics). ``start`` returns immediately
+        # with a future-tracking ack (matches ``start_task``).
+        if action == "execute":
+            return dict(sim.run_policy(robot_name, **run_kwargs))
+        # action == "start"
+        return dict(sim.start_policy(robot_name, **run_kwargs))
 
     def _on_response(self, sample: Any) -> None:
         try:

--- a/strands_robots/mesh/security.py
+++ b/strands_robots/mesh/security.py
@@ -49,6 +49,7 @@ from __future__ import annotations
 
 import functools
 import ipaddress
+import json
 import logging
 import math
 import os
@@ -116,6 +117,19 @@ MAX_PASSTHROUGH_LEN: int = 128
 #: so a malformed payload cannot DoS the comparison via a multi-MB
 #: string.
 MAX_OVERRIDE_CODE_LEN: int = 256
+
+#: Bound on the number of joints accepted in a sim ``execute`` /
+#: ``start`` payload's ``target_joints`` dict (issue #300 well-known
+#: kwarg). 256 is well above any real humanoid (Asimov-V0 has ~30) and
+#: keeps a malicious payload from forcing an unbounded dict walk.
+MAX_TARGET_JOINTS: int = 256
+
+#: Bound on a sim ``execute`` / ``start`` payload's ``world_update``
+#: nested dict size, in JSON-encoded bytes. Mesh does not interpret the
+#: per-call collision-world refresh payload; it forwards it to the
+#: planner provider via ``policy_config``. The cap is purely DoS
+#: defence — 64 KiB fits any realistic obstacle list.
+MAX_WORLD_UPDATE_BYTES: int = 65536
 
 #: Charset for entries in ``STRANDS_MESH_HF_REPO_ALLOW``. Operator-supplied
 #: HuggingFace org / ``<org>/<repo>`` prefixes; rejects shell metacharacters,
@@ -628,6 +642,21 @@ def validate_command(cmd: dict[str, Any]) -> dict[str, Any]:
           No silent default -- a peer that omits this is rejected so it is
           never ambiguous whether ``mock`` was an explicit choice or a bug.
         - ``server_address`` (optional): in :func:`is_safe_server_address`.
+        - ``robot_name`` (optional): peer-id charset, used by sim peers
+          to disambiguate which robot in the world the policy targets.
+        - ``target_pose`` (optional): list of 7 floats
+          ``[x, y, z, qw, qx, qy, qz]`` for planner-style providers
+          (issue #300 well-known kwarg).
+        - ``target_joints`` (optional): dict of joint-name to float
+          (issue #300 well-known kwarg). Bounded by
+          :data:`MAX_TARGET_JOINTS`.
+        - ``world_update`` (optional): opaque dict forwarded to the
+          policy via ``policy_config``. Bounded by
+          :data:`MAX_WORLD_UPDATE_BYTES` JSON-encoded bytes.
+        - ``control_frequency`` (optional): float in ``[0.1, 2000]`` Hz.
+        - ``action_horizon`` (optional): integer in ``[1, 10_000]``.
+        - ``fast_mode`` (optional): boolean.
+        - ``n_steps`` (optional): integer in ``[1, 10_000_000]``.
     * ``step``: ``steps`` integer in ``[1, 10_000]``, defaults to 1.
     * ``teleop_receive``: ``source_peer_id`` non-empty str.
 
@@ -759,6 +788,99 @@ def validate_command(cmd: dict[str, Any]) -> dict[str, Any]:
                 )
             out["server_address"] = value
 
+        # Sim-targeted execute/start fields. These are admitted only for
+        # the ``execute`` / ``start`` actions and are inert when the
+        # receiving peer is a HardwareRobot — ``Mesh._dispatch`` ignores
+        # them on the hardware path. Validating them here keeps the wire
+        # schema honest end-to-end so a malicious peer cannot smuggle
+        # control-byte instruction strings in via ``robot_name`` or
+        # exhaust the dispatcher with a multi-MB ``world_update`` blob.
+        if "robot_name" in cmd:
+            value = cmd["robot_name"]
+            if not isinstance(value, str) or not value:
+                raise ValidationError("robot_name must be a non-empty string")
+            if len(value) > MAX_PEER_ID_LEN:
+                raise ValidationError(f"robot_name length {len(value)} > MAX_PEER_ID_LEN ({MAX_PEER_ID_LEN}).")
+            if not _PEER_ID_RE.fullmatch(value):
+                raise ValidationError(
+                    "robot_name must match [A-Za-z0-9_.-]+ (no whitespace, NULs, "
+                    "control chars, shell metacharacters, or '/')."
+                )
+            out["robot_name"] = value
+
+        # Issue #300 well-known per-call policy kwargs. Forwarded into
+        # ``policy_config`` by the dispatcher; planner-style providers
+        # (cuRobo, MoveIt2, MPC) consume them, VLA providers ignore them.
+        if "target_pose" in cmd:
+            value = cmd["target_pose"]
+            if not isinstance(value, list) or len(value) != 7:
+                raise ValidationError("target_pose must be a list of 7 floats [x, y, z, qw, qx, qy, qz]")
+            coerced_pose: list[float] = []
+            for i, component in enumerate(value):
+                coerced_pose.append(_coerce_float(f"target_pose[{i}]", component, lo=-1e6, hi=1e6, default=None))
+            out["target_pose"] = coerced_pose
+
+        if "target_joints" in cmd:
+            value = cmd["target_joints"]
+            if not isinstance(value, dict):
+                raise ValidationError("target_joints must be a dict mapping joint name -> float")
+            if len(value) > MAX_TARGET_JOINTS:
+                raise ValidationError(
+                    f"target_joints has {len(value)} entries > MAX_TARGET_JOINTS ({MAX_TARGET_JOINTS})."
+                )
+            coerced_joints: dict[str, float] = {}
+            for joint_name, joint_value in value.items():
+                if not isinstance(joint_name, str) or not joint_name:
+                    raise ValidationError("target_joints keys must be non-empty strings")
+                if len(joint_name) > MAX_PEER_ID_LEN:
+                    raise ValidationError(
+                        f"target_joints key length {len(joint_name)} > MAX_PEER_ID_LEN ({MAX_PEER_ID_LEN})."
+                    )
+                if not _PEER_ID_RE.fullmatch(joint_name):
+                    raise ValidationError(
+                        f"target_joints key {joint_name!r} must match [A-Za-z0-9_.-]+ "
+                        "(no whitespace, NULs, control chars, shell metacharacters, or '/')."
+                    )
+                coerced_joints[joint_name] = _coerce_float(
+                    f"target_joints[{joint_name}]", joint_value, lo=-1e6, hi=1e6, default=None
+                )
+            out["target_joints"] = coerced_joints
+
+        if "world_update" in cmd:
+            value = cmd["world_update"]
+            if value is not None and not isinstance(value, dict):
+                raise ValidationError("world_update must be a dict or null")
+            if isinstance(value, dict):
+                # Bound the encoded size — mesh treats world_update as
+                # opaque and forwards it to the planner provider; we
+                # only need to keep it from becoming a DoS vector.
+                try:
+                    encoded = json.dumps(value)
+                except (TypeError, ValueError) as exc:
+                    raise ValidationError(f"world_update is not JSON-serialisable: {exc}") from exc
+                if len(encoded.encode("utf-8")) > MAX_WORLD_UPDATE_BYTES:
+                    raise ValidationError(
+                        f"world_update encoded size > MAX_WORLD_UPDATE_BYTES ({MAX_WORLD_UPDATE_BYTES})."
+                    )
+            out["world_update"] = value
+
+        # Optional sim-side controls. Bounds match the SimEngine.run_policy
+        # surface so a wire-side ``tell()`` cannot drive the runner to
+        # absurd frequencies / step counts.
+        if "control_frequency" in cmd:
+            out["control_frequency"] = _coerce_float(
+                "control_frequency", cmd["control_frequency"], lo=0.1, hi=2000.0, default=None
+            )
+        if "action_horizon" in cmd:
+            out["action_horizon"] = _coerce_int("action_horizon", cmd["action_horizon"], lo=1, hi=10_000, default=None)
+        if "fast_mode" in cmd:
+            value = cmd["fast_mode"]
+            if not isinstance(value, bool):
+                raise ValidationError("fast_mode must be a boolean")
+            out["fast_mode"] = value
+        if "n_steps" in cmd:
+            out["n_steps"] = _coerce_int("n_steps", cmd["n_steps"], lo=1, hi=10_000_000, default=None)
+
     elif action == "step":
         out["steps"] = _coerce_int("steps", cmd.get("steps", 1), lo=1, hi=10_000, default=1)
 
@@ -840,6 +962,8 @@ __all__ = [
     "MAX_PASSTHROUGH_LEN",
     "MAX_PEER_ID_LEN",
     "MAX_SERVER_ADDRESS_LEN",
+    "MAX_TARGET_JOINTS",
+    "MAX_WORLD_UPDATE_BYTES",
     "SecurityError",
     "ValidationError",
     "is_safe_model_path",

--- a/tests/mesh/test_mesh_rpc_sim_dispatch.py
+++ b/tests/mesh/test_mesh_rpc_sim_dispatch.py
@@ -1,0 +1,297 @@
+"""Tests for ``Mesh._dispatch`` against sim peers (issue #303).
+
+The HardwareRobot dispatch path is covered by ``test_mesh_rpc.py``. This
+module pins the sim-peer branch added by issue #303: ``tell()`` against a
+peer whose ``robot`` is a ``Simulation`` (or any ``SimEngine``-shaped
+object) routes ``execute`` -> ``run_policy`` and ``start`` -> ``start_policy``
+with the issue #300 well-known kwargs (``target_pose`` / ``target_joints`` /
+``world_update``) forwarded into ``policy_config``.
+
+Tests are 100% mocked — no MuJoCo / Isaac install required. A
+``_FakeSim`` exposes the SimEngine surface duck-typed minimally to what
+``_dispatch_sim_policy`` needs.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from strands_robots.mesh import Mesh
+
+
+class _FakeSim:
+    """Minimal duck-typed stand-in for ``Simulation`` / ``SimEngine``.
+
+    Records every ``run_policy`` / ``start_policy`` call so tests can
+    assert on the forwarded arguments. The presence of ``_world`` +
+    ``run_policy`` + ``list_robots`` is what ``Mesh._dispatch`` keys off
+    of to pick the sim branch over the HardwareRobot one.
+    """
+
+    def __init__(self, robots: list[str] | None = None) -> None:
+        # The mesh dispatcher checks for a non-None ``_world`` to confirm
+        # the sim has been initialised. Use a sentinel object, not just
+        # truthy — matches MuJoCoSimEngine's "_world is None" gate.
+        self._world: Any = object()
+        self._robots = list(robots if robots is not None else ["so100"])
+        self.run_policy_calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+        self.start_policy_calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+        self.tool_name_str = "fakesim"
+
+    def list_robots(self) -> list[str]:
+        return list(self._robots)
+
+    def run_policy(self, robot_name: str, **kwargs: Any) -> dict[str, Any]:
+        self.run_policy_calls.append(((robot_name,), kwargs))
+        return {"status": "success", "content": [{"text": f"ran {robot_name}"}]}
+
+    def start_policy(self, robot_name: str, **kwargs: Any) -> dict[str, Any]:
+        self.start_policy_calls.append(((robot_name,), kwargs))
+        return {"status": "success", "content": [{"text": f"started {robot_name}"}]}
+
+
+# Sim-peer routing
+def test_execute_routes_to_run_policy_with_default_robot() -> None:
+    """Single-robot sim: omitting ``robot_name`` defaults to the only robot."""
+    sim = _FakeSim(robots=["so100"])
+    m = Mesh(sim, peer_id="sim-a")
+    out = m._dispatch(
+        {
+            "action": "execute",
+            "instruction": "wave",
+            "policy_provider": "mock",
+        }
+    )
+    assert out["status"] == "success"
+    assert len(sim.run_policy_calls) == 1
+    args, kwargs = sim.run_policy_calls[0]
+    assert args == ("so100",)
+    assert kwargs["instruction"] == "wave"
+    assert kwargs["policy_provider"] == "mock"
+    # Even when the caller passes no extras, we always forward an empty
+    # policy_config dict so the receiving sim sees a stable type.
+    assert kwargs["policy_config"] == {}
+    assert sim.start_policy_calls == []
+
+
+def test_start_routes_to_start_policy_async() -> None:
+    """``start`` (async) hits ``start_policy``; ``execute`` hits ``run_policy``."""
+    sim = _FakeSim(robots=["so100"])
+    m = Mesh(sim, peer_id="sim-a")
+    out = m._dispatch(
+        {
+            "action": "start",
+            "instruction": "wave",
+            "policy_provider": "mock",
+        }
+    )
+    assert out["status"] == "success"
+    assert len(sim.start_policy_calls) == 1
+    assert sim.run_policy_calls == []
+
+
+def test_execute_forwards_well_known_kwargs_via_policy_config() -> None:
+    """Issue #300 well-known kwargs land in ``policy_config``, not silently dropped.
+
+    See AGENTS.md > Public API Hygiene: "Forward all advertised kwargs
+    end-to-end. Silent drops are bugs masquerading as features."
+    """
+    sim = _FakeSim(robots=["so100"])
+    m = Mesh(sim, peer_id="sim-a")
+
+    target_pose = [0.3, 0.0, 0.4, 1.0, 0.0, 0.0, 0.0]
+    target_joints = {"joint_0": 0.5, "joint_1": -0.2}
+    world_update = {"obstacles": [{"name": "cube", "pose": [0.5, 0.0, 0.05]}]}
+
+    m._dispatch(
+        {
+            "action": "execute",
+            "instruction": "reach",
+            "policy_provider": "curobo",
+            "target_pose": target_pose,
+            "target_joints": target_joints,
+            "world_update": world_update,
+        }
+    )
+    args, kwargs = sim.run_policy_calls[0]
+    pc = kwargs["policy_config"]
+    assert pc["target_pose"] == target_pose
+    assert pc["target_joints"] == target_joints
+    assert pc["world_update"] == world_update
+
+
+def test_execute_forwards_constructor_extras_via_policy_config() -> None:
+    """Existing constructor-style extras (model_path, server_address, ...) also flow.
+
+    Confirms we did not regress the existing dispatch contract when adding
+    the issue #300 kwargs branch.
+    """
+    sim = _FakeSim(robots=["so100"])
+    m = Mesh(sim, peer_id="sim-a")
+    m._dispatch(
+        {
+            "action": "execute",
+            "instruction": "task",
+            "policy_provider": "groot",
+            "model_path": "nvidia/GR00T-N1.5",
+            "server_address": "127.0.0.1:5555",
+            "policy_type": "groot",
+            "pretrained_name_or_path": "nvidia/GR00T-N1.5",
+        }
+    )
+    pc = sim.run_policy_calls[0][1]["policy_config"]
+    assert pc["model_path"] == "nvidia/GR00T-N1.5"
+    assert pc["server_address"] == "127.0.0.1:5555"
+    assert pc["policy_type"] == "groot"
+    assert pc["pretrained_name_or_path"] == "nvidia/GR00T-N1.5"
+
+
+def test_execute_requires_robot_name_when_multiple_robots() -> None:
+    """Ambiguous targets must be explicit — silent default to first robot is forbidden."""
+    sim = _FakeSim(robots=["arm_left", "arm_right"])
+    m = Mesh(sim, peer_id="sim-a")
+    out = m._dispatch(
+        {
+            "action": "execute",
+            "instruction": "reach",
+            "policy_provider": "mock",
+        }
+    )
+    assert "error" in out
+    assert "robot_name" in out["error"]
+    # Sim was not driven.
+    assert sim.run_policy_calls == []
+
+
+def test_execute_with_robot_name_disambiguates() -> None:
+    """Explicit ``robot_name`` picks the target arm in a multi-robot sim."""
+    sim = _FakeSim(robots=["arm_left", "arm_right"])
+    m = Mesh(sim, peer_id="sim-a")
+    m._dispatch(
+        {
+            "action": "execute",
+            "instruction": "reach",
+            "policy_provider": "mock",
+            "robot_name": "arm_right",
+        }
+    )
+    assert len(sim.run_policy_calls) == 1
+    assert sim.run_policy_calls[0][0] == ("arm_right",)
+
+
+def test_execute_rejects_unknown_robot_name() -> None:
+    """Wrong robot_name does not silently fall through to the first robot."""
+    sim = _FakeSim(robots=["so100"])
+    m = Mesh(sim, peer_id="sim-a")
+    out = m._dispatch(
+        {
+            "action": "execute",
+            "instruction": "reach",
+            "policy_provider": "mock",
+            "robot_name": "ghost",
+        }
+    )
+    assert "error" in out
+    assert "ghost" in out["error"]
+    assert sim.run_policy_calls == []
+
+
+def test_execute_returns_error_when_world_uninitialised() -> None:
+    """Sim with no world is a hard error, not a silent no-op."""
+    sim = _FakeSim(robots=["so100"])
+    sim._world = None  # type: ignore[assignment]
+    m = Mesh(sim, peer_id="sim-a")
+    out = m._dispatch(
+        {
+            "action": "execute",
+            "instruction": "reach",
+            "policy_provider": "mock",
+        }
+    )
+    assert "error" in out
+    assert "world" in out["error"].lower()
+
+
+def test_execute_returns_error_when_no_robots_in_world() -> None:
+    """Sim with a world but zero robots cannot service tell()."""
+    sim = _FakeSim(robots=[])
+    m = Mesh(sim, peer_id="sim-a")
+    out = m._dispatch(
+        {
+            "action": "execute",
+            "instruction": "reach",
+            "policy_provider": "mock",
+        }
+    )
+    assert "error" in out
+    assert "no robots" in out["error"].lower()
+
+
+def test_execute_forwards_optional_run_kwargs() -> None:
+    """``control_frequency`` / ``action_horizon`` / ``fast_mode`` / ``n_steps`` reach run_policy."""
+    sim = _FakeSim(robots=["so100"])
+    m = Mesh(sim, peer_id="sim-a")
+    m._dispatch(
+        {
+            "action": "execute",
+            "instruction": "wave",
+            "policy_provider": "mock",
+            "control_frequency": 30.0,
+            "action_horizon": 4,
+            "fast_mode": True,
+            "n_steps": 100,
+        }
+    )
+    kwargs = sim.run_policy_calls[0][1]
+    assert kwargs["control_frequency"] == 30.0
+    assert kwargs["action_horizon"] == 4
+    assert kwargs["fast_mode"] is True
+    assert kwargs["n_steps"] == 100
+
+
+def test_hardware_path_unchanged_when_run_policy_absent() -> None:
+    """A peer without ``run_policy`` / ``_world`` still hits the HardwareRobot branch.
+
+    Regression guard: the sim branch must be additive — existing
+    HardwareRobot peers see no behaviour change.
+    """
+
+    class _FakeHardware:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, dict[str, Any]]] = []
+
+        def _execute_task_sync(
+            self,
+            instruction: str,
+            policy_provider: str,
+            policy_port: Any,
+            policy_host: str,
+            duration: float,
+            **kw: Any,
+        ) -> dict[str, Any]:
+            self.calls.append(
+                (
+                    "execute",
+                    {
+                        "instruction": instruction,
+                        "policy_provider": policy_provider,
+                        "duration": duration,
+                    },
+                )
+            )
+            return {"executed": instruction}
+
+    hw = _FakeHardware()
+    m = Mesh(hw, peer_id="hw-a")
+    out = m._dispatch(
+        {
+            "action": "execute",
+            "instruction": "go",
+            "policy_provider": "mock",
+            # Sim-only kwargs that should be inert on the hardware path.
+            "target_pose": [0.0] * 7,
+            "robot_name": "ignored",
+        }
+    )
+    assert out == {"executed": "go"}
+    assert len(hw.calls) == 1

--- a/tests/mesh/test_mesh_tell_sim_e2e.py
+++ b/tests/mesh/test_mesh_tell_sim_e2e.py
@@ -1,0 +1,134 @@
+"""Mesh ``tell()`` end-to-end against a real ``Simulation`` peer (issue #303).
+
+Exercises the full sim dispatch path:
+
+* Stand up a real ``Simulation`` (MuJoCo backend) with a single robot.
+* Wrap it in a ``Mesh`` (no zenoh — we hand-call ``_dispatch`` so the
+  test stays a unit test, not a full Zenoh integration).
+* Drive ``execute`` via the dispatcher with ``policy_provider="mock"``
+  and assert the mock policy actually ran.
+
+Skipped when MuJoCo (or any other heavy dep) is not importable. The
+zero-Zenoh tests in ``test_mesh_rpc_sim_dispatch.py`` cover the dispatch
+contract; this module pins that the contract holds against the real
+``MuJoCoSimEngine.run_policy`` surface.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from strands_robots.mesh import Mesh
+
+mujoco = pytest.importorskip("mujoco", reason="needs mujoco for real Simulation")
+
+
+def _build_sim_with_simple_robot():
+    """Create a small ``MuJoCoSimEngine`` with a single floating-base robot.
+
+    We avoid ``add_robot`` (which fetches assets from the model registry
+    and is heavyweight) and instead hand-build a tiny MJCF with one
+    actuated hinge — enough to exercise ``run_policy`` end-to-end.
+    """
+    from strands_robots.simulation.mujoco.simulation import Simulation
+
+    sim = Simulation()
+    sim.create_world(timestep=0.005)
+
+    # Inject a minimal robot directly into the world via the public
+    # add_object surface? add_object adds free-bodies, not actuated
+    # robots. We need add_robot. The model_registry has lightweight
+    # entries (e.g. so100); load that.
+    sim.add_robot("so100", data_config="so100")
+    return sim
+
+
+@pytest.fixture
+def real_sim():
+    sim = _build_sim_with_simple_robot()
+    try:
+        yield sim
+    finally:
+        sim.destroy()
+
+
+def test_dispatch_execute_drives_real_simulation(real_sim) -> None:
+    """``tell()`` payload routes through to ``Simulation.run_policy`` and completes."""
+    m = Mesh(real_sim, peer_id="sim-real")
+    out = m._dispatch(
+        {
+            "action": "execute",
+            "instruction": "wave",
+            "policy_provider": "mock",
+            "duration": 0.1,
+            "control_frequency": 20.0,
+            "fast_mode": True,
+        }
+    )
+    # MuJoCoSimEngine.run_policy returns the standard tool-result shape.
+    assert out["status"] == "success", out
+
+
+def test_dispatch_start_then_status_on_real_simulation(real_sim) -> None:
+    """``start`` schedules an async rollout; ``status`` reports it.
+
+    Pins the async path: ``start`` returns immediately while the policy
+    runs in the sim's ThreadPoolExecutor.
+    """
+    m = Mesh(real_sim, peer_id="sim-real")
+    out = m._dispatch(
+        {
+            "action": "start",
+            "instruction": "wave",
+            "policy_provider": "mock",
+            "duration": 0.5,
+            "control_frequency": 20.0,
+            "fast_mode": True,
+        }
+    )
+    assert out["status"] == "success", out
+
+
+def test_well_known_kwargs_reach_policy_config_on_real_simulation(real_sim) -> None:
+    """Issue #300 well-known kwargs land in the ``policy_config`` of ``create_policy``.
+
+    We intercept ``create_policy`` to capture the kwargs the dispatcher
+    forwards, then let the rest of ``run_policy`` proceed against the
+    real sim with a ``MockPolicy``.
+    """
+    from unittest.mock import patch
+
+    from strands_robots.policies import create_policy as real_create_policy
+
+    captured: dict[str, object] = {}
+
+    def _spy(provider: str, **kwargs):
+        captured["provider"] = provider
+        captured.update(kwargs)
+        # Strip planner-only kwargs MockPolicy does not accept; the
+        # dispatch layer's contract is to forward them, the policy's
+        # contract (per #300) is to ignore unknown kwargs at construction.
+        # MockPolicy ignores **kwargs in __init__ so we can pass them all.
+        return real_create_policy(provider, **kwargs)
+
+    target_pose = [0.3, 0.0, 0.4, 1.0, 0.0, 0.0, 0.0]
+    target_joints = {"joint_0": 0.5}
+
+    m = Mesh(real_sim, peer_id="sim-real")
+    with patch("strands_robots.policies.create_policy", side_effect=_spy):
+        out = m._dispatch(
+            {
+                "action": "execute",
+                "instruction": "reach",
+                "policy_provider": "mock",
+                "target_pose": target_pose,
+                "target_joints": target_joints,
+                "duration": 0.05,
+                "control_frequency": 20.0,
+                "fast_mode": True,
+            }
+        )
+    assert out["status"] == "success", out
+    assert captured["provider"] == "mock"
+    assert captured["target_pose"] == target_pose
+    assert captured["target_joints"] == target_joints

--- a/tests/mesh/test_validate_command_sim_fields.py
+++ b/tests/mesh/test_validate_command_sim_fields.py
@@ -1,0 +1,176 @@
+"""Tests for sim-targeted ``execute`` / ``start`` payload validation (issue #303).
+
+The validator at ``strands_robots.mesh.security.validate_command`` now
+admits a small set of sim-peer fields used by ``Mesh._dispatch_sim_policy``:
+
+* ``robot_name`` — disambiguates which robot in a multi-robot sim
+* ``target_pose`` / ``target_joints`` / ``world_update`` — issue #300
+  well-known per-call kwargs forwarded to planner-style policies
+* ``control_frequency`` / ``action_horizon`` / ``fast_mode`` / ``n_steps``
+  — sim-side runner controls
+
+Each accepts a happy path and a representative rejection path so a
+malicious peer cannot smuggle control-byte robot names, multi-MB
+``world_update`` blobs, or NaN frequencies past the wire validator.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from strands_robots.mesh import security as sec
+
+
+def _base() -> dict[str, object]:
+    """A minimal-valid execute payload to layer optional fields onto."""
+    return {
+        "action": "execute",
+        "instruction": "task",
+        "policy_provider": "mock",
+    }
+
+
+# robot_name
+class TestRobotName:
+    def test_happy_path(self) -> None:
+        out = sec.validate_command({**_base(), "robot_name": "so100"})
+        assert out["robot_name"] == "so100"
+
+    def test_empty_rejected(self) -> None:
+        with pytest.raises(sec.ValidationError, match="robot_name"):
+            sec.validate_command({**_base(), "robot_name": ""})
+
+    def test_non_string_rejected(self) -> None:
+        with pytest.raises(sec.ValidationError, match="robot_name"):
+            sec.validate_command({**_base(), "robot_name": 123})
+
+    def test_shell_meta_rejected(self) -> None:
+        with pytest.raises(sec.ValidationError, match="robot_name"):
+            sec.validate_command({**_base(), "robot_name": "arm; rm -rf /"})
+
+    def test_slash_rejected(self) -> None:
+        # Mirrors the teleop_receive.source_peer_id rule — robot_name is
+        # not a path, so '/' is a wire-side red flag.
+        with pytest.raises(sec.ValidationError, match="robot_name"):
+            sec.validate_command({**_base(), "robot_name": "ns/arm"})
+
+    def test_oversize_rejected(self) -> None:
+        with pytest.raises(sec.ValidationError, match="robot_name"):
+            sec.validate_command({**_base(), "robot_name": "a" * 200})
+
+
+# target_pose
+class TestTargetPose:
+    def test_happy_path(self) -> None:
+        pose = [0.3, 0.0, 0.4, 1.0, 0.0, 0.0, 0.0]
+        out = sec.validate_command({**_base(), "target_pose": pose})
+        assert out["target_pose"] == pose
+
+    def test_wrong_length_rejected(self) -> None:
+        with pytest.raises(sec.ValidationError, match="target_pose"):
+            sec.validate_command({**_base(), "target_pose": [0.0, 0.0, 0.0]})
+
+    def test_non_list_rejected(self) -> None:
+        with pytest.raises(sec.ValidationError, match="target_pose"):
+            sec.validate_command({**_base(), "target_pose": {"x": 0.0}})
+
+    def test_nan_component_rejected(self) -> None:
+        with pytest.raises(sec.ValidationError, match="target_pose"):
+            sec.validate_command({**_base(), "target_pose": [float("nan"), 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]})
+
+    def test_inf_component_rejected(self) -> None:
+        with pytest.raises(sec.ValidationError, match="target_pose"):
+            sec.validate_command({**_base(), "target_pose": [float("inf"), 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]})
+
+    def test_oversize_component_rejected(self) -> None:
+        with pytest.raises(sec.ValidationError, match="target_pose"):
+            sec.validate_command({**_base(), "target_pose": [1e9, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]})
+
+
+# target_joints
+class TestTargetJoints:
+    def test_happy_path(self) -> None:
+        out = sec.validate_command({**_base(), "target_joints": {"j0": 0.5, "j1": -0.2}})
+        assert out["target_joints"] == {"j0": 0.5, "j1": -0.2}
+
+    def test_non_dict_rejected(self) -> None:
+        with pytest.raises(sec.ValidationError, match="target_joints"):
+            sec.validate_command({**_base(), "target_joints": [0.5, -0.2]})
+
+    def test_non_string_key_rejected(self) -> None:
+        with pytest.raises(sec.ValidationError, match="target_joints"):
+            sec.validate_command({**_base(), "target_joints": {0: 0.5}})
+
+    def test_shell_meta_key_rejected(self) -> None:
+        with pytest.raises(sec.ValidationError, match="target_joints"):
+            sec.validate_command({**_base(), "target_joints": {"j$0": 0.5}})
+
+    def test_nan_value_rejected(self) -> None:
+        with pytest.raises(sec.ValidationError, match="target_joints"):
+            sec.validate_command({**_base(), "target_joints": {"j0": float("nan")}})
+
+    def test_too_many_joints_rejected(self) -> None:
+        joints = {f"j{i}": 0.0 for i in range(sec.MAX_TARGET_JOINTS + 1)}
+        with pytest.raises(sec.ValidationError, match="target_joints"):
+            sec.validate_command({**_base(), "target_joints": joints})
+
+
+# world_update
+class TestWorldUpdate:
+    def test_happy_path(self) -> None:
+        update = {"obstacles": [{"name": "cube", "pose": [0.5, 0.0, 0.05]}]}
+        out = sec.validate_command({**_base(), "world_update": update})
+        assert out["world_update"] == update
+
+    def test_null_accepted(self) -> None:
+        out = sec.validate_command({**_base(), "world_update": None})
+        assert out["world_update"] is None
+
+    def test_non_dict_rejected(self) -> None:
+        with pytest.raises(sec.ValidationError, match="world_update"):
+            sec.validate_command({**_base(), "world_update": "not-a-dict"})
+
+    def test_oversize_rejected(self) -> None:
+        # Build a payload that JSON-encodes above MAX_WORLD_UPDATE_BYTES.
+        big_string = "x" * (sec.MAX_WORLD_UPDATE_BYTES + 100)
+        with pytest.raises(sec.ValidationError, match="world_update"):
+            sec.validate_command({**_base(), "world_update": {"blob": big_string}})
+
+
+# Optional sim-side controls
+class TestRunControls:
+    def test_control_frequency_happy_path(self) -> None:
+        out = sec.validate_command({**_base(), "control_frequency": 30.0})
+        assert out["control_frequency"] == 30.0
+
+    def test_control_frequency_nan_rejected(self) -> None:
+        with pytest.raises(sec.ValidationError, match="control_frequency"):
+            sec.validate_command({**_base(), "control_frequency": float("nan")})
+
+    def test_control_frequency_oversize_rejected(self) -> None:
+        with pytest.raises(sec.ValidationError, match="control_frequency"):
+            sec.validate_command({**_base(), "control_frequency": 1e6})
+
+    def test_action_horizon_happy_path(self) -> None:
+        out = sec.validate_command({**_base(), "action_horizon": 8})
+        assert out["action_horizon"] == 8
+
+    def test_action_horizon_zero_rejected(self) -> None:
+        with pytest.raises(sec.ValidationError, match="action_horizon"):
+            sec.validate_command({**_base(), "action_horizon": 0})
+
+    def test_fast_mode_happy_path(self) -> None:
+        out = sec.validate_command({**_base(), "fast_mode": True})
+        assert out["fast_mode"] is True
+
+    def test_fast_mode_non_bool_rejected(self) -> None:
+        with pytest.raises(sec.ValidationError, match="fast_mode"):
+            sec.validate_command({**_base(), "fast_mode": "yes"})
+
+    def test_n_steps_happy_path(self) -> None:
+        out = sec.validate_command({**_base(), "n_steps": 100})
+        assert out["n_steps"] == 100
+
+    def test_n_steps_negative_rejected(self) -> None:
+        with pytest.raises(sec.ValidationError, match="n_steps"):
+            sec.validate_command({**_base(), "n_steps": -5})


### PR DESCRIPTION
## Summary

Subtask 4 of #299. Maps mesh `tell()` dispatch to the simulation peer's policy execution path so a `tell(sim_peer, instruction, policy_provider="curobo", target_pose=[...])` call from an agent peer routes through `Simulation.run_policy` / `start_policy` instead of 404'ing because `_dispatch` only knew how to reach `HardwareRobot._execute_task_sync` / `start_task`.

Closes #303.

## What changed

### `strands_robots/mesh/core.py`

* `Mesh._dispatch` detects sim peers by the SimEngine duck-type (`run_policy` + `_world` + `list_robots`) and branches to a new `_dispatch_sim_policy` helper. `execute` → `run_policy` (blocking, mirrors `_execute_task_sync` semantics); `start` → `start_policy` (async, mirrors `start_task`).
* `robot_name` resolution: from `cmd`, else default to the only robot in the world, else error. **Multi-robot sims must disambiguate explicitly** — silent default to the first robot is forbidden per AGENTS.md > Public API Hygiene > "Don't conflate identity with schema".
* Forwards both the existing constructor extras (`model_path`, `server_address`, `policy_type`, `pretrained_name_or_path`) and the issue #300 well-known per-call kwargs (`target_pose`, `target_joints`, `world_update`) via `policy_config`. Per #300 the receiving Policy ignores unknown kwargs at construction, so VLA providers stay compatible while planner-style providers consume the goal payload they need.
* Optional sim-side controls (`control_frequency`, `action_horizon`, `fast_mode`, `n_steps`) are admitted with bounds matching the `SimEngine.run_policy` surface so an LLM-issued `tell()` cannot drive the runner to absurd frequencies / step counts.

### `strands_robots/mesh/security.py`

* `validate_command` admits the new sim-targeted fields with the same defence-in-depth posture as the existing keys:
    * `robot_name` — peer-id charset (`[A-Za-z0-9_.-]+`, no `/`, no shell metacharacters), bounded by `MAX_PEER_ID_LEN`.
    * `target_pose` — list of 7 finite floats in `[-1e6, 1e6]`.
    * `target_joints` — dict of peer-id-charset keys → finite floats in `[-1e6, 1e6]`, capped at `MAX_TARGET_JOINTS` (256) entries.
    * `world_update` — opaque dict (mesh does not interpret it; forwarded to the planner provider) capped at `MAX_WORLD_UPDATE_BYTES` (64 KiB) JSON-encoded.
    * `control_frequency`, `action_horizon`, `fast_mode`, `n_steps` — bounded numeric / boolean.
* Two new constants exported: `MAX_TARGET_JOINTS`, `MAX_WORLD_UPDATE_BYTES`.

### `README.md`

* "Mesh Networking" section documents the new sim path with a cuRobo-style example and notes per-robot peer addressing for multi-robot sims.

## Why

`tell()` was the documented agent-side interface for "ask a peer to execute a task" but only worked against hardware peers. With the Policy ABC contract from #300 generalised to planner-style providers, the next domino is letting the same wire payload hit a sim peer's `run_policy` / `start_policy` — otherwise the cuRobo / MoveIt2 reference implementations (subtasks 2/3 of #299) would ship with no end-to-end story.

## Test surface

* **`tests/mesh/test_mesh_rpc_sim_dispatch.py`** (11 tests) — duck-typed `_FakeSim` pins the dispatch contract: routing, kwargs forwarding, multi-robot disambiguation, world / robot-not-found errors, and a regression guard that the HardwareRobot path is unchanged when the sim methods are absent.
* **`tests/mesh/test_validate_command_sim_fields.py`** (31 tests) — happy-path and rejection-path coverage for every new field. Includes NaN / inf / oversize / shell-meta / wrong-type rejections.
* **`tests/mesh/test_mesh_tell_sim_e2e.py`** (3 tests, `mujoco`-gated via `pytest.importorskip`) — spins up a real `MuJoCoSimEngine` with a single robot, dispatches `execute` and `start` through the mesh, and asserts the well-known kwargs reach `create_policy` end-to-end.

### Validation

* `hatch run lint` — clean (202 source files).
* `hatch run test` — **2594 passed** (was 2593), 53 skipped, 7 pre-existing X11/OpenGL failures in `test_rendering.py` / `test_policy_runner.py`. The pre-existing failures are environmental (no X server on this dev box) and acceptable per AGENTS.local.md.
* The 45 new tests (11 + 31 + 3) all pass.

No regression on the existing `HardwareRobot` `tell()` / `execute` / `start` flows — covered by `tests/mesh/test_mesh_rpc.py` (13 dispatch tests still green) plus the explicit regression guard `test_hardware_path_unchanged_when_run_policy_absent`.

## Acceptance criteria from #303

- [x] Audit `tell()` dispatch in `strands_robots/mesh/` — confirmed it only resolves `HardwareRobot` actions in `core.py:573-578`. Now extended.
- [x] Add a sim-peer branch that maps the `tell()` payload (instruction + `policy_provider` + well-known kwargs from #300) to `Simulation.start_policy` / `Simulation.run_policy`.
- [x] Forward all advertised kwargs end-to-end (no silent kwarg drops).
- [x] Mesh integration test: real `Simulation` + `MockPolicy` via the dispatcher (`test_mesh_tell_sim_e2e.py`). cuRobo / MoveIt2 will plug in unchanged once subtask 2/3 lands.
- [x] Update mesh docs / README to note that `tell(...)` works against sim peers now.

- [x] `tell(sim_peer, instruction, policy_provider="mock", target_joints={...})` runs the policy on the sim peer.
- [x] Same call with `policy_provider="curobo"` will work end-to-end once #299 subtask 2 lands — the dispatch surface accepts `target_pose` / `target_joints` / `world_update` today and forwards them via `policy_config`.
- [x] No regression on the existing `HardwareRobot` `tell()` path.

## Out of scope (follow-up)

* `CuroboPolicy` reference implementation — subtask 2 of #299, separate PR.
* `MoveIt2Policy` reference implementation — subtask 3 of #299, separate PR.
* `PolicyRunner.run` does not yet thread per-step `**kwargs` through every `policy.get_actions(observation, instruction)` call. The current PR forwards the well-known kwargs into `policy_config` (constructor kwargs) which is sufficient for one-shot planner queries (cuRobo / MoveIt2 build the trajectory at policy construction time and replay it during the rollout). If a future provider needs per-step goal updates it can come back as a separate change to `PolicyRunner` + a kwargs threading PR.

## Project board

This PR addresses subtask 4 of [#299](https://github.com/strands-labs/robots/issues/299) on the [Strands Labs - Robots board](https://github.com/orgs/strands-labs/projects/2). Please move issue #303 to "In review".
