### PR TITLE
fix(sim): strip robot-asset ground plane on attach to stop floor z-fighting

### DIFF
--- a/strands_robots/simulation/mujoco/spec_builder.py
+++ b/strands_robots/simulation/mujoco/spec_builder.py
@@ -420,7 +420,7 @@ class SpecBuilder:
         # second coplanar infinite plane at z=0 with a different material causes
         # severe depth-buffer Z-fighting (the floor renders as a flickering
         # checker/triangle mess). Remove the robot scene's plane(s) so exactly
-        # one ground plane survives. See #319.
+        # one ground plane survives. See #320.
         _plane_geoms = [g for g in robot_spec.geoms if g.type == mujoco.mjtGeom.mjGEOM_PLANE]
         for _g in _plane_geoms:
             robot_spec.delete(_g)

--- a/strands_robots/simulation/mujoco/spec_builder.py
+++ b/strands_robots/simulation/mujoco/spec_builder.py
@@ -413,6 +413,18 @@ class SpecBuilder:
 
         robot_spec = mujoco.MjSpec.from_file(str(robot_file_path))
 
+        # Strip any ground/floor PLANE geom shipped by the robot's own scene
+        # MJCF (e.g. franka_emika_panda/scene.xml ships
+        # ``<geom name="floor" type="plane" .../>`` at z=0). The world already
+        # owns a single ``ground`` plane (see SpecBuilder.build); attaching a
+        # second coplanar infinite plane at z=0 with a different material causes
+        # severe depth-buffer Z-fighting (the floor renders as a flickering
+        # checker/triangle mess). Remove the robot scene's plane(s) so exactly
+        # one ground plane survives. See #319.
+        _plane_geoms = [g for g in robot_spec.geoms if g.type == mujoco.mjtGeom.mjGEOM_PLANE]
+        for _g in _plane_geoms:
+            robot_spec.delete(_g)
+
         # Collect source joint names BEFORE attach - attach mutates the child
         # spec in-place (the child gets reparented).
         source_joint_names: list[str] = []

--- a/strands_robots/simulation/mujoco/spec_builder.py
+++ b/strands_robots/simulation/mujoco/spec_builder.py
@@ -408,6 +408,19 @@ class SpecBuilder:
             List of joint names belonging to the attached robot, in the order
             MuJoCo discovered them (no prefix - caller namespaces via
             ``robot.namespace`` when it resolves IDs post-compile).
+
+        Notes:
+            Any ``mjGEOM_PLANE`` geoms in the loaded ``robot_spec`` are
+            deleted before the attach to avoid coplanar Z-fight with the
+            world's ``ground`` plane (see #320). This currently strips every
+            plane geom by type, so a robot scene that uses ``<geom
+            type="plane">`` for a wall/divider/non-floor surface would lose
+            it too; today's ``robot_descriptions`` assets only use planes as
+            floors. If the robot scene is the only floor in your simulation,
+            build the world with ``SimWorld(ground_plane=False)`` -- note
+            that the strip is unconditional in v0.4.0, so the v0.4.1
+            conditional-strip work tracked on #320 is required to make that
+            path render a floor.
         """
         mujoco = _ensure_mujoco()
 

--- a/tests/simulation/mujoco/test_spec_builder.py
+++ b/tests/simulation/mujoco/test_spec_builder.py
@@ -378,7 +378,7 @@ class TestFromSources:
 
 
 def test_attach_robot_strips_robot_scene_ground_plane(tmp_path):
-    """Robot-scene floor planes are stripped on attach to avoid z-fighting (#319).
+    """Robot-scene floor planes are stripped on attach to avoid z-fighting (#320).
 
     A robot MJCF that ships its own ground plane (e.g. the franka_emika_panda
     scene.xml) must NOT add a second coplanar plane at z=0 when attached into a

--- a/tests/simulation/mujoco/test_spec_builder.py
+++ b/tests/simulation/mujoco/test_spec_builder.py
@@ -375,3 +375,39 @@ class TestFromSources:
         spec = SpecBuilder.from_file(str(p))
         model = spec.compile()
         assert mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, "y") >= 0
+
+
+def test_attach_robot_strips_robot_scene_ground_plane(tmp_path):
+    """Robot-scene floor planes are stripped on attach to avoid z-fighting (#319).
+
+    A robot MJCF that ships its own ground plane (e.g. the franka_emika_panda
+    scene.xml) must NOT add a second coplanar plane at z=0 when attached into a
+    world that already owns the ``ground`` plane — two coplanar infinite planes
+    cause severe depth-buffer Z-fighting in the renderer.
+    """
+    # A minimal robot MJCF that ships its own floor plane + one body/joint.
+    robot_xml = """
+    <mujoco model="bot">
+      <worldbody>
+        <geom name="floor" type="plane" size="0 0 0.05"/>
+        <body name="link" pos="0 0 0.1">
+          <joint name="j1" type="hinge" axis="0 0 1"/>
+          <geom type="box" size="0.05 0.05 0.05"/>
+        </body>
+      </worldbody>
+    </mujoco>
+    """
+    robot_file = tmp_path / "bot.xml"
+    robot_file.write_text(robot_xml)
+
+    world = SimWorld(ground_plane=True)
+    spec = SpecBuilder.build(world)  # adds exactly one "ground" plane
+    robot = SimRobot(name="arm", urdf_path=str(robot_file), position=[0.0, 0.0, 0.0], orientation=[1.0, 0.0, 0.0, 0.0])
+
+    joint_names = SpecBuilder.attach_robot(spec, robot, str(robot_file))
+    assert "j1" in joint_names  # attach still works (joint discovered)
+
+    model = spec.compile()
+    plane_ids = [g for g in range(model.ngeom) if model.geom_type[g] == mujoco.mjtGeom.mjGEOM_PLANE]
+    assert len(plane_ids) == 1, "exactly one ground plane must survive (no z-fight)"
+    assert mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_GEOM, plane_ids[0]) == "ground"


### PR DESCRIPTION
## What

Fixes the **broken floor render** (flickering checkerboard/triangle mess) that appears when a robot whose asset scene ships its own ground plane is added to a world with `ground_plane=True`.

<img width="1278" height="948" alt="image" src="https://github.com/user-attachments/assets/6d19de5f-158d-4ed6-86ed-5e1b9a9d7d01" />

## Root cause

Two coplanar infinite ground planes at z=0 -> depth-buffer **z-fighting**:
- `ground` -- added by `SpecBuilder.build` (world's `ground_plane=True`)
- `arm/floor` -- from the robot's own menagerie scene (e.g. `franka_emika_panda/scene.xml` ships `<geom name="floor" type="plane"/>`)

## Fix

`SpecBuilder.attach_robot` now deletes any `PLANE` geom from the robot spec before attaching, leaving exactly one world-owned `ground` plane.

## Verification

- Before: 2 planes at z=0, floor renders as a flickering mess.
- After: exactly 1 `ground` plane, floor renders cleanly (verified via offscreen render of a Panda + cube scene).
- New regression test `tests/simulation/mujoco/test_spec_builder.py::test_attach_robot_strips_robot_scene_ground_plane`.
- Full `tests/simulation/mujoco/` suite unaffected (the one pre-existing `so101` action-controller failure is unrelated and reproduces on clean `main`).
- `ruff check` + `ruff format --check` clean.

Discovered while rendering a Cosmos 3 policy rollout (#317).

Closes #320

---

## Review changelog

| Round | Concern | Fix commit | Pin test |
|-------|---------|-----------|----------|
| R1 | Doc-drift: inline comment referenced #319 (Qwen-VLA) instead of #320 (ground-plane issue) | `668b8f4` | N/A (comment-only) |
| R2 | Doc-drift: test docstring referenced #319 instead of #320 (same class as R1, symmetric fix) | `395dbf1` | `tests/simulation/mujoco/test_spec_builder.py::test_attach_robot_strips_robot_scene_ground_plane` |
| R3 | Doc-semantics: `attach_robot` docstring did not surface the silent `mjGEOM_PLANE` strip (per AGENTS.md PR #86 "Match docstrings to semantics") | `d29c71a` | N/A (doc-only) |

### Deferred to v0.4.1 (reviewer-confirmed non-blocking)

- Conditional strip when `world.ground_plane=False` (robot whose scene ships the only floor would silently lose it)
- Tighten plane filter from type-only (`mjGEOM_PLANE`) to name-allowlist or pose-check
- Expanded regression test matrix: `ground_plane=False`, multi-plane scenes, non-floor planes
- CHANGELOG one-liner under v0.4.0 notes flagging the silent-strip behavior for users feeding custom MJCF with deliberate non-floor `<geom type="plane">`