### PR TITLE
test(repo-hygiene): enforce no-emoji rule from AGENTS.md

### DIFF
--- a/tests/test_no_emoji.py
+++ b/tests/test_no_emoji.py
@@ -134,7 +134,7 @@ def test_no_emoji_in_package_source() -> None:
             continue
 
         for lineno, line in enumerate(text.splitlines(), start=1):
-            for col, ch in enumerate(line, start=1):
+            for ch in line:
                 if ord(ch) <= 0x7F:
                     continue
                 if _is_disallowed(ch):

--- a/tests/test_no_emoji.py
+++ b/tests/test_no_emoji.py
@@ -1,0 +1,194 @@
+"""Repo hygiene: block emoji / orphan combining marks from package source.
+
+History: AGENTS.md (PR #86 Review Learnings) codifies the rule:
+
+    No emojis in user-facing strings - this is a project rule. Tool result
+    dicts ({"content": [{"text": ...}]}), log messages, error messages: plain
+    ASCII only. Agents read these strings programmatically; emojis just add
+    tokenizer noise.
+
+    Hunt orphan combining marks after any emoji sweep - U+23F1 (clock) plus
+    U+FE0F (variation selector) renders as a stopwatch glyph; stripping the
+    base U+23F1 leaves an invisible U+FE0F behind.
+
+The rule was prose-only and widely violated. This test makes it executable.
+
+What it scans
+-------------
+``strands_robots/`` (package source). Tests are intentionally NOT scanned -
+test fixtures may legitimately need to assert on non-ASCII payloads.
+
+What it flags
+-------------
+Codepoints in the Unicode "So" (Symbol, other) category - the standard emoji
+class - plus U+FE0F (variation selector) regardless of category. CJK,
+accented characters, and other letter-class non-ASCII would not be flagged
+by this rule (they fall in L*, M*, N* categories), but in practice
+``strands_robots/`` is English-only and none appear today.
+
+Allowlist
+---------
+Files that are mid-flight in active review (the #195 mesh split, #196 gr00t
+hardening, #209/#216 simulation cyclic-import work) are temporarily
+allowlisted to avoid churning files under review. Each entry has a tracking
+context. As those PRs land and follow-up sweeps clean a file, REMOVE it from
+the allowlist - the test then enforces "no regression" for that file.
+
+Goal: the allowlist shrinks to {} and stays there.
+"""
+
+from __future__ import annotations
+
+import unicodedata
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Only the package itself - test fixtures may assert on emoji payloads.
+SCAN_DIRS = ("strands_robots",)
+
+# Files temporarily allowed to contain emoji / orphan U+FE0F because they are
+# under active review on an open PR. Sweep them in-place on those PRs (or in a
+# follow-up surgical PR after they merge) and drop the entry. Do NOT add new
+# entries here without an open tracking issue.
+ALLOWED_FILES: frozenset[str] = frozenset(
+    {
+        # --- mesh files in flight on the #195 split (#221, #222, #225, #226,
+        #     #227, #228) and on PR #304 (mesh tell sim dispatch). Sweep folds
+        #     into those PRs to avoid merge churn.
+        "strands_robots/tools/robot_mesh.py",
+        # --- gr00t input validation in flight on PR #196.
+        "strands_robots/tools/gr00t_inference.py",
+        # --- simulation cyclic-import work in flight on PR #209 / #216.
+        "strands_robots/simulation/base.py",
+        "strands_robots/simulation/benchmark.py",
+        "strands_robots/simulation/policy_runner.py",
+        # --- not in flight; queued for the follow-up sweep PRs (simulation/
+        #     first per issue #357, then tools/, then registry/policies).
+        "strands_robots/simulation/__init__.py",
+        "strands_robots/simulation/mujoco/simulation.py",
+        "strands_robots/simulation/mujoco/physics.py",
+        "strands_robots/simulation/mujoco/rendering.py",
+        "strands_robots/simulation/mujoco/recording.py",
+        "strands_robots/simulation/mujoco/randomization.py",
+        "strands_robots/tools/lerobot_teleoperate.py",
+        "strands_robots/tools/lerobot_camera.py",
+        "strands_robots/tools/lerobot_calibrate.py",
+        "strands_robots/tools/pose_tool.py",
+        "strands_robots/tools/serial_tool.py",
+        "strands_robots/policies/groot/policy.py",
+        "strands_robots/registry/robots.py",
+        "strands_robots/registry/user_registry.py",
+        "strands_robots/benchmarks/libero/adapter.py",
+    }
+)
+
+
+def _is_disallowed(ch: str) -> bool:
+    """Return True if ``ch`` is an emoji-class symbol or an orphan VS-16.
+
+    Implements the AGENTS.md-recommended check:
+
+        unicodedata.category(ch).startswith("So") or ord(ch) == 0xFE0F
+
+    "So" = Symbol, other (the emoji class). U+FE0F is the variation selector
+    that turns a base codepoint into its emoji presentation; it is invisible
+    on its own, which makes orphan FE0Fs the canonical PR #86 footgun.
+    """
+    if ord(ch) == 0xFE0F:
+        return True
+    return unicodedata.category(ch).startswith("So")
+
+
+def _iter_source_files() -> list[Path]:
+    files: list[Path] = []
+    for d in SCAN_DIRS:
+        root = REPO_ROOT / d
+        if not root.exists():
+            continue
+        for p in root.rglob("*.py"):
+            if "__pycache__" in p.parts or ".venv" in p.parts:
+                continue
+            files.append(p)
+    return files
+
+
+def test_no_emoji_in_package_source() -> None:
+    """Fail if any package .py file contains an emoji or orphan U+FE0F.
+
+    Plain ASCII only in tool-result strings, log messages, and error messages.
+    If a non-ASCII codepoint is genuinely needed (e.g. a math symbol used in a
+    docstring formula), document it and either narrow this check or move the
+    text to a data file.
+    """
+    offenders: list[tuple[str, int, str, str]] = []
+
+    for path in _iter_source_files():
+        rel = path.relative_to(REPO_ROOT).as_posix()
+        if rel in ALLOWED_FILES:
+            continue
+
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            for col, ch in enumerate(line, start=1):
+                if ord(ch) <= 0x7F:
+                    continue
+                if _is_disallowed(ch):
+                    offenders.append((rel, lineno, f"U+{ord(ch):04X}", line.strip()[:120]))
+                    break  # one finding per line is enough
+
+    if offenders:
+        msg = [
+            "Emoji or orphan U+FE0F variation selector detected in package source.",
+            "Project rule (AGENTS.md): plain ASCII in user-facing strings.",
+            "If a file is mid-review on an open PR, add it to ALLOWED_FILES with a tracking note.",
+            "",
+        ]
+        for rel, lineno, codepoint, snippet in offenders:
+            msg.append(f"  {rel}:{lineno} [{codepoint}]: {snippet}")
+        raise AssertionError("\n".join(msg))
+
+
+def test_allowlist_entries_still_exist() -> None:
+    """Drop allowlist entries when files are cleaned or deleted.
+
+    Stale allowlist entries silently turn this test into a no-op for those
+    paths. Whenever a sweep PR cleans a file, it must also remove the entry;
+    whenever a file is deleted/renamed, the entry must follow. This guard
+    fails fast on either drift.
+    """
+    missing = sorted(rel for rel in ALLOWED_FILES if not (REPO_ROOT / rel).is_file())
+    if missing:
+        raise AssertionError(
+            "ALLOWED_FILES references paths that no longer exist - drop them:\n" + "\n".join(f"  {m}" for m in missing)
+        )
+
+
+def test_allowlist_entries_actually_violate() -> None:
+    """Drop allowlist entries that are already clean.
+
+    If a file is in ALLOWED_FILES but no longer contains any emoji/U+FE0F, the
+    entry is dead weight - and worse, it suppresses regressions for that file.
+    Force the entry to be removed once cleanup happens.
+    """
+    clean_but_listed: list[str] = []
+    for rel in sorted(ALLOWED_FILES):
+        path = REPO_ROOT / rel
+        if not path.is_file():
+            continue  # handled by the previous test
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        if not any(_is_disallowed(ch) for ch in text):
+            clean_but_listed.append(rel)
+
+    if clean_but_listed:
+        raise AssertionError(
+            "ALLOWED_FILES contains files that are already emoji-clean - drop them:\n"
+            + "\n".join(f"  {m}" for m in clean_but_listed)
+        )


### PR DESCRIPTION
## What

Land `tests/test_no_emoji.py` to make the AGENTS.md "no emojis in user-facing strings" rule executable. The rule was prose-only at L180-185 of AGENTS.md and is currently violated by 20 files in `strands_robots/` (Unicode `So` category or orphan `U+FE0F` variation selectors).

## Why test-first

A single mega-PR that sweeps all 20 files would be unreviewable and would fight the in-flight #195 mesh split (PRs #221, #222, #225, #226, #227, #228) and PR #196 (gr00t input validation). This test lands first to **lock in the contract** with a documented allowlist; surgical follow-up sweep PRs each remove one or more entries from the allowlist. The drift guards in the test mean an allowlist entry **cannot** be left behind once a file is cleaned.

## What the test does

Mirrors `tests/test_no_host_paths.py` exactly (same scan-dirs / allowlist / per-line-offender pattern). Three assertions:

| Test | Fails when |
|------|-----------|
| `test_no_emoji_in_package_source` | A non-allowlisted file in `strands_robots/` contains a codepoint where `unicodedata.category(ch).startswith("So")` or `ord(ch) == 0xFE0F` (the exact AGENTS.md-recommended check). Reports `path:line [U+XXXX]: snippet`. |
| `test_allowlist_entries_still_exist` | `ALLOWED_FILES` references a path that no longer exists (rename/delete drift). |
| `test_allowlist_entries_actually_violate` | An allowlisted file is already clean. Forces sweep PRs to remove the entry; otherwise the allowlist silently suppresses regressions. |

Only `strands_robots/` is scanned. Tests are intentionally not scanned -- test fixtures may legitimately need non-ASCII payloads.

## Allowlist (20 files, all annotated)

Grouped by tracking PR. Each entry's comment names which open PR has it in flight, so the right sweep target is obvious.

* **Active review (sweep folds into existing PRs)** -- 5 files: `tools/robot_mesh.py` (PRs #221-228, #304), `tools/gr00t_inference.py` (#196), `simulation/{base,benchmark,policy_runner}.py` (#209/#216).
* **Queued for follow-up sweep PRs** -- 15 files: `simulation/__init__.py`, `simulation/mujoco/{simulation,physics,rendering,recording,randomization}.py`, `tools/{lerobot_teleoperate,lerobot_camera,lerobot_calibrate,pose_tool,serial_tool}.py`, `policies/groot/policy.py`, `registry/{robots,user_registry}.py`, `benchmarks/libero/adapter.py`.

The v0.4.1 polish items raised in review are tracked at #330. Sweep PRs land separately.

## Verification

```bash
hatch run lint        # ruff clean, ruff format clean
pytest tests/test_no_emoji.py -v   # 3 passed
```

Negative tests run locally to confirm the test actually fires:

* Inject `U+1F600` into `utils.py` -> `test_no_emoji_in_package_source` FAILS, names the file and codepoint.
* Inject an orphan `U+FE0F` -> `test_no_emoji_in_package_source` FAILS (the PR #86 footgun is covered).
* Allowlist a clean file (`utils.py`) -> `test_allowlist_entries_actually_violate` FAILS with `already emoji-clean -- drop them`.

The test file itself contains zero non-ASCII codepoints.

## Scope

`quality`-class, not blocking. Single-file diff, +194 / -0. No package code touched.

## Refs

* AGENTS.md L180-185 -- PR #86 Review Learnings (the rule).
* `tests/test_no_host_paths.py` -- the structural template this test follows.
* #330 -- consolidated v0.4.1 follow-up tracking issue (JSON/MD scan widening, ZWJ coverage, multi-codepoint reporting, deterministic ordering, helper unit test, CI-gating assertion).

---

_Disclosure: this PR was authored by an autonomous Strands agent (GitHub Actions). All code was generated, locally tested (positive + 3 negative cases), and reviewed for compliance with AGENTS.md before push._

---

## Review Rounds

| Round | Concern | Resolution | Reference |
|-------|---------|------------|-----------|
| R1 | Unused `col` loop variable (AGENTS.md: no dead code) | Simplified to `for ch in line:`; `col` was captured by `enumerate` but never read because the inner loop breaks on first match. | Commit `821a9c9`; thread on `tests/test_no_emoji.py:137` resolved. |
| R2 | Five `[FOLLOW-UP]`-tagged polish items: `*.json`/`*.md` scan widening, ZWJ/`Sk` coverage gap, multi-codepoint per-line reporting (drop `break`), `sorted(rglob(...))` for deterministic offender order, `_is_disallowed` helper unit test. Plus one R1 carryover (CI gating assertion). | Tracked together as #330 with concrete pin-test sketches per item. Reviewer explicitly tagged every R2 thread `[FOLLOW-UP]` and stated *"Must fix before merge: (none)"*; per AGENTS.md round-budget tenet (3 rounds max) and the project-board-as-source-of-truth rule, materializing as an issue rather than expanding this PR's scope. | Issue #330; no commit on this branch. |

All review threads are tagged `[FOLLOW-UP]` by the reviewer and explicitly marked non-blocking. Each is captured in #330 with a pin-test sketch.