### PR TITLE
fix(mesh): validate teleop input frames before apply

### DIFF
--- a/strands_robots/mesh/input.py
+++ b/strands_robots/mesh/input.py
@@ -25,6 +25,7 @@ import time
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
+from strands_robots.mesh.security import ValidationError, validate_input_frame
 from strands_robots.mesh.session import put
 
 if TYPE_CHECKING:
@@ -202,6 +203,7 @@ class InputReceiver:
         self._error_count = 0
         self._last_seq = -1
         self._drops = 0
+        self._rejected = 0
         self._start_time = 0.0
 
     def __repr__(self) -> str:
@@ -222,6 +224,7 @@ class InputReceiver:
             "frames_received": self._frame_count,
             "errors": self._error_count,
             "drops": self._drops,
+            "rejected": self._rejected,
             "hz_actual": self._frame_count / elapsed if elapsed > 0 else 0,
         }
 
@@ -271,7 +274,25 @@ class InputReceiver:
             if self._last_seq >= 0 and seq > self._last_seq + 1:
                 self._drops += seq - self._last_seq - 1
             self._last_seq = seq
-            self._apply_fn(self.robot, action)
+            # B-04 / F-02: validate the teleop frame before it reaches
+            # send_action(). A LAN-adjacent peer that discovers this
+            # source peer_id could otherwise drive the follower's joints
+            # directly with unbounded / non-finite values. validate_input_frame
+            # bounds key count, key charset, and clamps each value to a
+            # finite magnitude. Rejected frames are counted + logged and
+            # dropped (never applied) rather than crashing the receiver.
+            try:
+                safe_action = validate_input_frame(action)
+            except ValidationError as verr:
+                self._rejected = getattr(self, "_rejected", 0) + 1
+                if self._rejected <= 5:
+                    logger.warning(
+                        "[mesh] input frame rejected from %s: %s",
+                        self.source_peer_id,
+                        verr,
+                    )
+                return
+            self._apply_fn(self.robot, safe_action)
             self._frame_count += 1
         except Exception as exc:
             self._error_count += 1

--- a/strands_robots/mesh/security.py
+++ b/strands_robots/mesh/security.py
@@ -117,6 +117,28 @@ MAX_PASSTHROUGH_LEN: int = 128
 #: string.
 MAX_OVERRIDE_CODE_LEN: int = 256
 
+#: Maximum number of joint/motor keys accepted in a single teleop input
+#: frame. A leader arm streams a fixed small set of motor positions
+#: (typically 6-16); 64 leaves generous headroom while bounding a peer
+#: that floods ``_on_input`` with a giant dict to exhaust CPU/memory in
+#: the apply path. See pentest finding B-04 / F-02.
+MAX_INPUT_FRAME_KEYS: int = 64
+
+#: Absolute bound on any single joint/motor value in a teleop frame.
+#: Real normalized actions live in small ranges (radians, [-1, 1]
+#: normalized, or degrees); this clamp-or-reject bound stops a peer from
+#: driving a joint to 1e308 / inf / nan and slamming hardware or the sim
+#: integrator. Applied symmetrically.
+MAX_INPUT_VALUE_ABS: float = 1.0e6
+
+#: Charset for teleop input-frame keys (motor/joint names like
+#: ``"motor.pos"``, ``"shoulder_pan"``, ``"j0"``). Printable, no
+#: whitespace, no shell metacharacters, no path separators.
+_INPUT_KEY_RE = re.compile(r"^[A-Za-z0-9_.\-]+$")
+
+#: Maximum length of a single input-frame key name.
+MAX_INPUT_KEY_LEN: int = 64
+
 #: Charset for entries in ``STRANDS_MESH_HF_REPO_ALLOW``. Operator-supplied
 #: HuggingFace org / ``<org>/<repo>`` prefixes; rejects shell metacharacters,
 #: whitespace, NUL bytes, and any byte outside the printable ASCII subset.
@@ -841,11 +863,88 @@ def validate_command(cmd: dict[str, Any]) -> dict[str, Any]:
     return out
 
 
+
+def validate_input_frame(action: Any) -> dict[str, float]:
+    """Validate and sanitise a teleop input frame, returning a clean copy.
+
+    A teleop input frame is the flat ``{motor_name: float}`` payload
+    streamed by :class:`~strands_robots.mesh.input.InputPublisher` at up
+    to 50 Hz and applied by
+    :class:`~strands_robots.mesh.input.InputReceiver` via
+    ``robot.send_action()``. Unlike :func:`validate_command`, this is not
+    a dispatch envelope -- it is raw actuator data -- so it gets its own
+    bounded validator.
+
+    Pentest finding **B-04 / F-02**: ``InputReceiver._on_input`` applied
+    frames straight to ``send_action()`` with no validation, so any
+    LAN-adjacent peer that discovered a source peer_id could drive the
+    follower's joints directly, bypassing the action allowlist + rate
+    limit that guard the command path.
+
+    Performed checks:
+
+    * Frame must be a ``dict``.
+    * At most :data:`MAX_INPUT_FRAME_KEYS` keys (DoS bound).
+    * Each key: ``str``, ``<= MAX_INPUT_KEY_LEN`` chars, matching
+      :data:`_INPUT_KEY_RE` (no control bytes / path separators / shell
+      metacharacters).
+    * Each value: coercible to ``float``, **finite** (no ``nan`` /
+      ``inf``), and within ``+/- MAX_INPUT_VALUE_ABS``.
+
+    Returns a sanitised ``dict[str, float]`` containing only validated
+    entries. Raises :class:`ValidationError` on any violation.
+    """
+    if not isinstance(action, dict):
+        raise ValidationError(f"input frame must be a dict (got {type(action).__name__})")
+    if len(action) > MAX_INPUT_FRAME_KEYS:
+        raise ValidationError(
+            f"input frame has too many keys: {len(action)} > {MAX_INPUT_FRAME_KEYS}"
+        )
+
+    out: dict[str, float] = {}
+    for key, value in action.items():
+        if not isinstance(key, str):
+            raise ValidationError(f"input frame key must be a string (got {type(key).__name__})")
+        if not key or len(key) > MAX_INPUT_KEY_LEN:
+            raise ValidationError(f"input frame key length out of range: {key!r}")
+        if not _INPUT_KEY_RE.fullmatch(key):
+            raise ValidationError(f"input frame key has illegal characters: {key!r}")
+
+        # Coerce to float with a finite check. bool is an int subclass;
+        # reject it explicitly so a stray True/False can't masquerade as
+        # a 1.0/0.0 actuator command.
+        if isinstance(value, bool):
+            raise ValidationError(f"input frame value for {key!r} must be numeric, not bool")
+        if hasattr(value, "item"):
+            # numpy scalar / 0-d array -> python scalar
+            try:
+                value = value.item()
+            except Exception as exc:  # pragma: no cover - defensive
+                raise ValidationError(f"input frame value for {key!r} is not a scalar") from exc
+        if not isinstance(value, (int, float)):
+            raise ValidationError(
+                f"input frame value for {key!r} must be numeric (got {type(value).__name__})"
+            )
+        fval = float(value)
+        if not math.isfinite(fval):
+            raise ValidationError(f"input frame value for {key!r} must be finite, got {fval}")
+        if abs(fval) > MAX_INPUT_VALUE_ABS:
+            raise ValidationError(
+                f"input frame value for {key!r} out of range: |{fval}| > {MAX_INPUT_VALUE_ABS}"
+            )
+        out[key] = fval
+
+    return out
+
+
 __all__ = [
     "ALLOWED_ACTIONS",
     "MAX_DURATION_S",
     "MAX_INSTRUCTION_LEN",
     "MAX_MODEL_PATH_LEN",
+    "MAX_INPUT_FRAME_KEYS",
+    "MAX_INPUT_KEY_LEN",
+    "MAX_INPUT_VALUE_ABS",
     "MAX_OVERRIDE_CODE_LEN",
     "MAX_PASSTHROUGH_LEN",
     "MAX_PEER_ID_LEN",
@@ -858,5 +957,6 @@ __all__ = [
     "is_safe_policy_type",
     "is_safe_server_address",
     "validate_command",
+    "validate_input_frame",
     "LockoutError",
 ]

--- a/tests/mesh/test_input_validation.py
+++ b/tests/mesh/test_input_validation.py
@@ -1,0 +1,113 @@
+"""Tests for teleop input-frame validation (pentest B-04 / F-02).
+
+InputReceiver._on_input must validate frames via
+security.validate_input_frame before applying them to the robot, so a
+LAN-adjacent peer cannot drive joints with unbounded / non-finite /
+malformed values.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from strands_robots.mesh import security
+from strands_robots.mesh.input import InputReceiver
+
+
+# --- validate_input_frame unit tests -------------------------------------
+
+
+def test_valid_frame_passes_through():
+    frame = {"motor.pos": 0.5, "shoulder_pan": -1.25, "j0": 10}
+    out = security.validate_input_frame(frame)
+    assert out == {"motor.pos": 0.5, "shoulder_pan": -1.25, "j0": 10.0}
+    assert all(isinstance(v, float) for v in out.values())
+
+
+def test_non_dict_rejected():
+    with pytest.raises(security.ValidationError):
+        security.validate_input_frame([1, 2, 3])
+
+
+def test_too_many_keys_rejected():
+    frame = {f"j{i}": 0.0 for i in range(security.MAX_INPUT_FRAME_KEYS + 1)}
+    with pytest.raises(security.ValidationError):
+        security.validate_input_frame(frame)
+
+
+@pytest.mark.parametrize("bad", [math.inf, -math.inf, math.nan])
+def test_non_finite_rejected(bad):
+    with pytest.raises(security.ValidationError):
+        security.validate_input_frame({"j0": bad})
+
+
+def test_out_of_range_rejected():
+    with pytest.raises(security.ValidationError):
+        security.validate_input_frame({"j0": security.MAX_INPUT_VALUE_ABS * 2})
+
+
+def test_bad_key_charset_rejected():
+    with pytest.raises(security.ValidationError):
+        security.validate_input_frame({"../etc/passwd": 0.0})
+
+
+def test_bool_value_rejected():
+    with pytest.raises(security.ValidationError):
+        security.validate_input_frame({"j0": True})
+
+
+def test_non_numeric_value_rejected():
+    with pytest.raises(security.ValidationError):
+        security.validate_input_frame({"j0": "0.5"})
+
+
+# --- InputReceiver wiring tests ------------------------------------------
+
+
+class _FakeMesh:
+    peer_id = "follower-1"
+
+    def subscribe(self, *a, **k):
+        return "sub"
+
+    def unsubscribe(self, *a, **k):
+        pass
+
+
+def _make_receiver():
+    applied: list[dict] = []
+    recv = InputReceiver(
+        mesh=_FakeMesh(),
+        robot=object(),
+        source_peer_id="leader-1",
+        apply_fn=lambda robot, action: applied.append(action),
+    )
+    recv._running = True
+    return recv, applied
+
+
+def test_on_input_applies_valid_frame():
+    recv, applied = _make_receiver()
+    recv._on_input(recv.topic, {"action": {"j0": 0.1, "j1": 0.2}, "seq": 0})
+    assert applied == [{"j0": 0.1, "j1": 0.2}]
+    assert recv._frame_count == 1
+    assert recv._rejected == 0
+
+
+def test_on_input_rejects_malicious_frame():
+    recv, applied = _make_receiver()
+    # non-finite value would otherwise reach send_action()
+    recv._on_input(recv.topic, {"action": {"j0": math.inf}, "seq": 0})
+    assert applied == []  # never applied
+    assert recv._frame_count == 0
+    assert recv._rejected == 1
+
+
+def test_on_input_rejects_giant_frame():
+    recv, applied = _make_receiver()
+    giant = {f"j{i}": 0.0 for i in range(security.MAX_INPUT_FRAME_KEYS + 5)}
+    recv._on_input(recv.topic, {"action": giant, "seq": 0})
+    assert applied == []
+    assert recv._rejected == 1


### PR DESCRIPTION
## Teleop bypass of validation

**Severity:** High

`InputReceiver._on_input` applied teleop frames straight to `robot.send_action()` with **zero validation**. A LAN-adjacent peer that discovered a source `peer_id` could drive the follower's joints directly with unbounded / non-finite / malformed values, **bypassing the action allowlist + rate limit** that guard the command path (`validate_command`).

## Fix
- New `security.validate_input_frame(action) -> dict[str, float]`:
  - frame must be a `dict`, `<= MAX_INPUT_FRAME_KEYS` (64) keys — DoS bound
  - each key: `str`, `<= MAX_INPUT_KEY_LEN`, matches `_INPUT_KEY_RE` (no control bytes / path separators / shell metachars)
  - each value: numeric (rejects `bool`/`str`), **finite** (no `nan`/`inf`), `|v| <= MAX_INPUT_VALUE_ABS`
- Wired into `InputReceiver._on_input`: rejected frames are counted (`stats['rejected']`) + logged and **dropped, never applied**.

## Tests
- `tests/mesh/test_input_validation.py` — 13 cases (unit + receiver wiring)
- Full `tests/mesh/` suite green (1151 passed; 1 pre-existing order-dependent failure in `test_pr224_review_blockers` unrelated to this change — fails on clean `main` too).