### PR TITLE
fix(iot): Fleet Provisioning PreProvisioningHook - deny-by-default

### DIFF
--- a/strands_robots/mesh/iot/bootstrap.py
+++ b/strands_robots/mesh/iot/bootstrap.py
@@ -57,6 +57,9 @@ RULE_SAFETY_TO_DYNAMODB = "strands_safety_to_dynamodb"
 RULE_ESTOP_FANOUT = "strands_estop_fanout"
 PROVISIONING_TEMPLATE = "strands-mesh-fleet-provisioning"
 PROVISIONING_ROLE = "strands-mesh-provisioning-role"
+PROVISIONING_HOOK_LAMBDA_NAME = "strands-mesh-provisioning-hook"
+#: Bump whenever _PROVISIONING_HOOK_SOURCE changes.
+_PROVISIONING_HOOK_VERSION = 1
 LOG_GROUP_NAME = "/aws/iot/strands-mesh"
 
 
@@ -121,6 +124,71 @@ _ESTOP_LAMBDA_SOURCE = textwrap.dedent(
 )
 
 
+# F-19 / B-13: Fleet Provisioning PreProvisioningHook. Without a hook,
+# any holder of the (shared, long-lived) claim certificate can register
+# an ARBITRARY ThingName and receive a full robot identity + policy.
+# This hook is the gate AWS IoT calls *before* provisioning: it must
+# return {"allowProvisioning": True} or the registration is denied.
+#
+# Policy enforced here (deny-by-default):
+#   * SerialNumber must be present and match a strict format.
+#   * The Thing must NOT already exist (no claim-cert takeover of an
+#     existing robot's identity).
+#   * The serial must be pre-seeded by the operator in SSM Parameter
+#     Store at /strands-mesh/provisioning/allow/<serial>. Sites with a
+#     CMDB can swap this lookup for their own API.
+_PROVISIONING_HOOK_SOURCE = textwrap.dedent(
+    """
+    import logging
+    import re
+
+    import boto3
+
+    log = logging.getLogger()
+    log.setLevel(logging.INFO)
+
+    ssm = boto3.client("ssm")
+
+    _SERIAL_RE = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
+    _ALLOW_PREFIX = "/strands-mesh/provisioning/allow/"
+
+    def lambda_handler(event, context):
+        # AWS IoT Fleet Provisioning PreProvisioningHook.
+        # Must return {"allowProvisioning": bool}. Deny-by-default.
+        params = (event or {}).get("parameters", {}) or {}
+        serial = params.get("SerialNumber", "")
+        thing_name = params.get("ThingName", "")
+
+        if not isinstance(serial, str) or not _SERIAL_RE.fullmatch(serial):
+            log.warning("provisioning DENY: bad/missing SerialNumber %r", serial)
+            return {"allowProvisioning": False}
+
+        iot = boto3.client("iot")
+        try:
+            iot.describe_thing(thingName=thing_name)
+            log.warning("provisioning DENY: Thing %r already exists", thing_name)
+            return {"allowProvisioning": False}
+        except iot.exceptions.ResourceNotFoundException:
+            pass
+        except Exception as exc:
+            log.warning("provisioning DENY: describe_thing error: %s", exc)
+            return {"allowProvisioning": False}
+
+        try:
+            ssm.get_parameter(Name=_ALLOW_PREFIX + serial)
+        except ssm.exceptions.ParameterNotFound:
+            log.warning("provisioning DENY: serial %r not in allowlist", serial)
+            return {"allowProvisioning": False}
+        except Exception as exc:
+            log.warning("provisioning DENY: ssm error: %s", exc)
+            return {"allowProvisioning": False}
+
+        log.info("provisioning ALLOW: serial=%s thing=%s", serial, thing_name)
+        return {"allowProvisioning": True}
+    """
+)
+
+
 @dataclass
 class BootstrappedAccount:
     """Identifiers + ARNs of every resource :func:`bootstrap_account` ensured."""
@@ -133,6 +201,7 @@ class BootstrappedAccount:
     rule_estop_arn: str = ""
     log_group_arn: str = ""
     provisioning_template_arn: str = ""
+    provisioning_hook_lambda_arn: str = ""
     skipped: list[str] = field(default_factory=list)
     created: list[str] = field(default_factory=list)
 
@@ -155,6 +224,14 @@ def _build_lambda_zip() -> bytes:
     buf = BytesIO()
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
         zf.writestr("lambda_function.py", _ESTOP_LAMBDA_SOURCE)
+    return buf.getvalue()
+
+
+def _build_provisioning_hook_zip() -> bytes:
+    """Pack the PreProvisioningHook Lambda source into a deployable zip."""
+    buf = BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("lambda_function.py", _PROVISIONING_HOOK_SOURCE)
     return buf.getvalue()
 
 
@@ -475,12 +552,78 @@ def _ensure_log_group(logs: Any, account: BootstrappedAccount) -> str:
     return desc["logGroups"][0]["arn"]
 
 
-def _ensure_provisioning_template(iot: Any, account: BootstrappedAccount) -> str:
+def _ensure_provisioning_hook_lambda(
+    lam: Any, role_arn: str, account: BootstrappedAccount, *, force_update: bool = False
+) -> str:
+    """Create/Update the Fleet Provisioning PreProvisioningHook Lambda (F-19/B-13).
+
+    Returns the function ARN. Idempotent; reuses an existing function and
+    only updates its code when ``force_update`` is set.
+    """
+    name = PROVISIONING_HOOK_LAMBDA_NAME
+    zip_bytes = _build_provisioning_hook_zip()
+    try:
+        existing = lam.get_function(FunctionName=name)
+        arn = existing["Configuration"]["FunctionArn"]
+        if force_update:
+            lam.update_function_code(FunctionName=name, ZipFile=zip_bytes)
+            account.created.append(f"lambda:{name} (updated)")
+        else:
+            account.skipped.append(f"lambda:{name}")
+        return arn
+    except lam.exceptions.ResourceNotFoundException:
+        pass
+
+    # Lambda IAM role propagation can race; retry create with backoff.
+    last_exc: Exception | None = None
+    for attempt in range(6):
+        try:
+            resp = lam.create_function(
+                FunctionName=name,
+                Runtime="python3.12",
+                Role=role_arn,
+                Handler="lambda_function.lambda_handler",
+                Code={"ZipFile": zip_bytes},
+                Description="strands-mesh: Fleet Provisioning PreProvisioningHook (deny-by-default)",
+                Timeout=10,
+                Tags={"strands-mesh": "managed"},
+            )
+            account.created.append(f"lambda:{name}")
+            return resp["FunctionArn"]
+        except lam.exceptions.InvalidParameterValueException as exc:
+            last_exc = exc
+            if "role" not in str(exc).lower():
+                raise
+            time.sleep(5 * (attempt + 1))
+    raise RuntimeError(f"Provisioning-hook Lambda create failed after retries: {last_exc}")
+
+
+def _grant_iot_invoke_provisioning_hook(lam: Any, hook_arn: str, account: BootstrappedAccount) -> None:
+    """Allow the IoT service principal to invoke the PreProvisioningHook Lambda."""
+    try:
+        lam.add_permission(
+            FunctionName=PROVISIONING_HOOK_LAMBDA_NAME,
+            StatementId="strands-mesh-iot-provisioning-invoke",
+            Action="lambda:InvokeFunction",
+            Principal="iot.amazonaws.com",
+            SourceArn=f"arn:aws:iot:{account.region}:{account.account_id}:provisioningtemplate/{PROVISIONING_TEMPLATE}",
+        )
+        account.created.append("lambda-permission:provisioning-hook-invoke")
+    except lam.exceptions.ResourceConflictException:
+        account.skipped.append("lambda-permission:provisioning-hook-invoke")
+
+
+def _ensure_provisioning_template(
+    iot: Any, account: BootstrappedAccount, *, hook_lambda_arn: str = ""
+) -> str:
     """Fleet Provisioning template — claim cert → real cert + attach robot policy.
 
-    The template body is plain JSON; the registration "PreProvisioningHook"
-    is left unset for simplicity (sites that need policy decisions per
-    serial number can add a Lambda later).
+    F-19 / B-13: a ``PreProvisioningHook`` is wired so a leaked claim cert
+    cannot register an arbitrary Thing. ``hook_lambda_arn`` is the ARN of
+    the gating Lambda (see :func:`_ensure_provisioning_hook_lambda`); when
+    supplied it is attached via ``preProvisioningHook`` and AWS IoT calls
+    it before every registration, denying unless the Lambda returns
+    ``{"allowProvisioning": True}``.
     """
     name = PROVISIONING_TEMPLATE
     try:
@@ -525,14 +668,22 @@ def _ensure_provisioning_template(iot: Any, account: BootstrappedAccount) -> str
     last_exc: Exception | None = None
     for attempt in range(6):
         try:
-            iot.create_provisioning_template(
-                templateName=name,
-                description="strands-mesh: factory-provision robots from a claim cert",
-                templateBody=json.dumps(body),
-                provisioningRoleArn=role_arn,
-                enabled=True,
-                tags=[{"Key": "strands-mesh", "Value": "managed"}],
-            )
+            create_kwargs: dict[str, Any] = {
+                "templateName": name,
+                "description": "strands-mesh: factory-provision robots from a claim cert",
+                "templateBody": json.dumps(body),
+                "provisioningRoleArn": role_arn,
+                "enabled": True,
+                "tags": [{"Key": "strands-mesh", "Value": "managed"}],
+            }
+            # F-19 / B-13: gate registration on the PreProvisioningHook so a
+            # leaked claim cert cannot self-register an arbitrary Thing.
+            if hook_lambda_arn:
+                create_kwargs["preProvisioningHook"] = {
+                    "targetArn": hook_lambda_arn,
+                    "payloadVersion": "2020-04-01",
+                }
+            iot.create_provisioning_template(**create_kwargs)
             break
         except iot.exceptions.InvalidRequestException as exc:
             last_exc = exc
@@ -685,8 +836,16 @@ def bootstrap_account(
     out.rule_estop_arn = _ensure_estop_rule(iot, out.estop_lambda_arn, out)
     _grant_iot_invoke_lambda(lam, out.estop_lambda_arn, out)
 
-    # Fleet Provisioning template
-    out.provisioning_template_arn = _ensure_provisioning_template(iot, out)
+    # Fleet Provisioning PreProvisioningHook Lambda (F-19/B-13) — gate
+    # registration so a leaked claim cert cannot self-register a Thing.
+    hook_arn = _ensure_provisioning_hook_lambda(lam, role_arn, out, force_update=force_update)
+    out.provisioning_hook_lambda_arn = hook_arn
+
+    # Fleet Provisioning template (wires the hook above)
+    out.provisioning_template_arn = _ensure_provisioning_template(
+        iot, out, hook_lambda_arn=hook_arn
+    )
+    _grant_iot_invoke_provisioning_hook(lam, hook_arn, out)
 
     logger.info(
         "[bootstrap] account %s in %s — created %d, skipped %d",

--- a/strands_robots/mesh/iot/bootstrap.py
+++ b/strands_robots/mesh/iot/bootstrap.py
@@ -58,6 +58,7 @@ RULE_ESTOP_FANOUT = "strands_estop_fanout"
 PROVISIONING_TEMPLATE = "strands-mesh-fleet-provisioning"
 PROVISIONING_ROLE = "strands-mesh-provisioning-role"
 PROVISIONING_HOOK_LAMBDA_NAME = "strands-mesh-provisioning-hook"
+PROVISIONING_HOOK_ROLE = "strands-mesh-provisioning-hook-role"
 #: Bump whenever _PROVISIONING_HOOK_SOURCE changes.
 _PROVISIONING_HOOK_VERSION = 1
 LOG_GROUP_NAME = "/aws/iot/strands-mesh"
@@ -552,6 +553,82 @@ def _ensure_log_group(logs: Any, account: BootstrappedAccount) -> str:
     return desc["logGroups"][0]["arn"]
 
 
+def _ensure_provisioning_hook_role(iam: Any, account: BootstrappedAccount) -> str:
+    """Dedicated IAM role for the PreProvisioningHook Lambda (F-19 / B-13).
+
+    The hook must call ``iot:DescribeThing`` (does the target Thing already
+    exist?) and ``ssm:GetParameter`` (is the serial on the allowlist?). The
+    E-stop Lambda role grants neither, so reusing it would make every
+    ``describe_thing`` / ``get_parameter`` raise ``AccessDenied``; those are
+    swallowed by the hook's deny-on-error envelope and *every* registration
+    — legitimate ones included — would be refused. This role grants exactly
+    those two read actions, least-privilege scoped:
+
+    * ``iot:DescribeThing`` on ``thing/*`` (the hook only reads existence;
+      it never mutates).
+    * ``ssm:GetParameter`` on ``parameter/strands-mesh/provisioning/allow/*``
+      (the allowlist namespace only — no broader Parameter Store access).
+    """
+    role_name = PROVISIONING_HOOK_ROLE
+    try:
+        role = iam.get_role(RoleName=role_name)
+        account.skipped.append(f"iam:{role_name}")
+        return role["Role"]["Arn"]
+    except iam.exceptions.NoSuchEntityException:
+        pass
+
+    trust = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": {"Service": "lambda.amazonaws.com"},
+                "Action": "sts:AssumeRole",
+            }
+        ],
+    }
+    resp = iam.create_role(
+        RoleName=role_name,
+        AssumeRolePolicyDocument=json.dumps(trust),
+        Description="strands-mesh Fleet Provisioning PreProvisioningHook Lambda execution role",
+        Tags=[{"Key": "strands-mesh", "Value": "managed"}],
+    )
+    arn = resp["Role"]["Arn"]
+
+    iam.attach_role_policy(
+        RoleName=role_name,
+        PolicyArn="arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+    )
+    iam.put_role_policy(
+        RoleName=role_name,
+        PolicyName="strands-mesh-provisioning-hook",
+        PolicyDocument=json.dumps(
+            {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": ["iot:DescribeThing"],
+                        "Resource": [f"arn:aws:iot:{account.region}:{account.account_id}:thing/*"],
+                    },
+                    {
+                        "Effect": "Allow",
+                        "Action": ["ssm:GetParameter"],
+                        "Resource": [
+                            f"arn:aws:ssm:{account.region}:{account.account_id}"
+                            ":parameter/strands-mesh/provisioning/allow/*"
+                        ],
+                    },
+                ],
+            }
+        ),
+    )
+    # Lambda role propagation in IAM is eventually-consistent; small delay.
+    time.sleep(8)
+    account.created.append(f"iam:{role_name}")
+    return arn
+
+
 def _ensure_provisioning_hook_lambda(
     lam: Any, role_arn: str, account: BootstrappedAccount, *, force_update: bool = False
 ) -> str:
@@ -561,12 +638,24 @@ def _ensure_provisioning_hook_lambda(
     only updates its code when ``force_update`` is set.
     """
     name = PROVISIONING_HOOK_LAMBDA_NAME
+    version_tag = f"[v{_PROVISIONING_HOOK_VERSION}]"
+    description = f"strands-mesh: Fleet Provisioning PreProvisioningHook (deny-by-default) {version_tag}"
     zip_bytes = _build_provisioning_hook_zip()
     try:
         existing = lam.get_function(FunctionName=name)
         arn = existing["Configuration"]["FunctionArn"]
+        existing_desc = existing["Configuration"].get("Description", "")
+        if version_tag not in existing_desc:
+            logger.warning(
+                "Provisioning-hook Lambda exists but has stale version "
+                "(description=%r, expected %s). Pass force_update=True to "
+                "bootstrap_account() to upgrade.",
+                existing_desc,
+                version_tag,
+            )
         if force_update:
             lam.update_function_code(FunctionName=name, ZipFile=zip_bytes)
+            lam.update_function_configuration(FunctionName=name, Description=description)
             account.created.append(f"lambda:{name} (updated)")
         else:
             account.skipped.append(f"lambda:{name}")
@@ -584,7 +673,7 @@ def _ensure_provisioning_hook_lambda(
                 Role=role_arn,
                 Handler="lambda_function.lambda_handler",
                 Code={"ZipFile": zip_bytes},
-                Description="strands-mesh: Fleet Provisioning PreProvisioningHook (deny-by-default)",
+                Description=description,
                 Timeout=10,
                 Tags={"strands-mesh": "managed"},
             )
@@ -613,9 +702,7 @@ def _grant_iot_invoke_provisioning_hook(lam: Any, hook_arn: str, account: Bootst
         account.skipped.append("lambda-permission:provisioning-hook-invoke")
 
 
-def _ensure_provisioning_template(
-    iot: Any, account: BootstrappedAccount, *, hook_lambda_arn: str = ""
-) -> str:
+def _ensure_provisioning_template(iot: Any, account: BootstrappedAccount, *, hook_lambda_arn: str = "") -> str:
     """Fleet Provisioning template — claim cert → real cert + attach robot policy.
 
     F-19 / B-13: a ``PreProvisioningHook`` is wired so a leaked claim cert
@@ -807,6 +894,9 @@ def bootstrap_account(
             f"  - DynamoDB Table: strands-mesh-fleet\n"
             f"  - CloudWatch Log Group: /strands/mesh\n"
             f"  - IoT Topic Rule: strands_mesh_audit\n"
+            f"  - IAM Role: strands-mesh-provisioning-hook-role\n"
+            f"  - Lambda: strands-mesh-provisioning-hook (Fleet Provisioning gate)\n"
+            f"  - IoT Fleet Provisioning Template: strands-mesh-fleet-provisioning\n"
             f"\nPass dry_run=False, confirm=True to create.",
             file=sys.stderr,
         )
@@ -838,13 +928,14 @@ def bootstrap_account(
 
     # Fleet Provisioning PreProvisioningHook Lambda (F-19/B-13) — gate
     # registration so a leaked claim cert cannot self-register a Thing.
-    hook_arn = _ensure_provisioning_hook_lambda(lam, role_arn, out, force_update=force_update)
+    # The hook needs iot:DescribeThing + ssm:GetParameter, which the E-stop
+    # role does not grant, so it gets its own least-privilege role.
+    hook_role_arn = _ensure_provisioning_hook_role(iam, out)
+    hook_arn = _ensure_provisioning_hook_lambda(lam, hook_role_arn, out, force_update=force_update)
     out.provisioning_hook_lambda_arn = hook_arn
 
     # Fleet Provisioning template (wires the hook above)
-    out.provisioning_template_arn = _ensure_provisioning_template(
-        iot, out, hook_lambda_arn=hook_arn
-    )
+    out.provisioning_template_arn = _ensure_provisioning_template(iot, out, hook_lambda_arn=hook_arn)
     _grant_iot_invoke_provisioning_hook(lam, hook_arn, out)
 
     logger.info(

--- a/tests/mesh/test_iot_provisioning_hook.py
+++ b/tests/mesh/test_iot_provisioning_hook.py
@@ -1,0 +1,162 @@
+"""Tests for the Fleet Provisioning PreProvisioningHook (pentest F-19 / B-13).
+
+Without a PreProvisioningHook, any holder of the shared claim cert can
+register an arbitrary Thing. These tests pin the hook's deny-by-default
+behaviour and that the template wires it.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from unittest.mock import MagicMock
+
+from strands_robots.mesh.iot import bootstrap as b
+
+
+def test_hook_source_is_valid_python():
+    ast.parse(b._PROVISIONING_HOOK_SOURCE)
+
+
+def test_hook_zip_builds():
+    assert len(b._build_provisioning_hook_zip()) > 0
+
+
+def test_template_wires_pre_provisioning_hook():
+    src = inspect.getsource(b._ensure_provisioning_template)
+    assert "preProvisioningHook" in src
+    assert "hook_lambda_arn" in src
+
+
+def test_template_create_includes_hook_when_arn_supplied():
+    """create_provisioning_template must receive preProvisioningHook."""
+    iot = MagicMock()
+    iot.exceptions.ResourceNotFoundException = type(
+        "RNF", (Exception,), {}
+    )
+    iot.exceptions.InvalidRequestException = type("IRE", (Exception,), {})
+    # describe -> not found so it proceeds to create
+    iot.describe_provisioning_template.side_effect = (
+        iot.exceptions.ResourceNotFoundException()
+    )
+    acct = b.BootstrappedAccount(region="us-east-1", account_id="123456789012")
+
+    # stub the role helper to avoid IAM calls
+    import strands_robots.mesh.iot.bootstrap as mod
+
+    orig = mod._ensure_provisioning_role
+    mod._ensure_provisioning_role = lambda *a, **k: "arn:aws:iam::123456789012:role/x"
+    try:
+        b._ensure_provisioning_template(
+            iot, acct, hook_lambda_arn="arn:aws:lambda:us-east-1:123456789012:function:hook"
+        )
+    finally:
+        mod._ensure_provisioning_role = orig
+
+    kwargs = iot.create_provisioning_template.call_args.kwargs
+    assert "preProvisioningHook" in kwargs
+    assert kwargs["preProvisioningHook"]["targetArn"].endswith(":function:hook")
+
+
+def test_template_omits_hook_when_no_arn():
+    iot = MagicMock()
+    iot.exceptions.ResourceNotFoundException = type("RNF", (Exception,), {})
+    iot.exceptions.InvalidRequestException = type("IRE", (Exception,), {})
+    iot.describe_provisioning_template.side_effect = (
+        iot.exceptions.ResourceNotFoundException()
+    )
+    acct = b.BootstrappedAccount(region="us-east-1", account_id="123456789012")
+
+    import strands_robots.mesh.iot.bootstrap as mod
+
+    orig = mod._ensure_provisioning_role
+    mod._ensure_provisioning_role = lambda *a, **k: "arn:aws:iam::123456789012:role/x"
+    try:
+        b._ensure_provisioning_template(iot, acct)  # no hook arn
+    finally:
+        mod._ensure_provisioning_role = orig
+
+    kwargs = iot.create_provisioning_template.call_args.kwargs
+    assert "preProvisioningHook" not in kwargs
+
+
+# --- Behavioural tests of the hook handler itself ------------------------
+
+
+def _run_handler(event, *, thing_exists=False, serial_allowed=True):
+    """Exec the hook source with a controllable fake boto3 and invoke it."""
+    fake_boto3 = MagicMock()
+
+    iot_client = MagicMock()
+    ssm_client = MagicMock()
+
+    class _RNF(Exception):
+        pass
+
+    class _PNF(Exception):
+        pass
+
+    iot_client.exceptions.ResourceNotFoundException = _RNF
+    ssm_client.exceptions.ParameterNotFound = _PNF
+
+    if thing_exists:
+        iot_client.describe_thing.return_value = {"thingName": "x"}
+    else:
+        iot_client.describe_thing.side_effect = _RNF()
+
+    if not serial_allowed:
+        ssm_client.get_parameter.side_effect = _PNF()
+
+    def _client(name, *a, **k):
+        return {"iot": iot_client, "ssm": ssm_client}[name]
+
+    fake_boto3.client.side_effect = _client
+
+    # The hook source does `import boto3` at module level, which shadows
+    # any exec-global we inject. Patch sys.modules so the import resolves
+    # to our fake instead of the real SDK (which would hit AWS).
+    import sys
+    from unittest.mock import patch
+
+    with patch.dict(sys.modules, {"boto3": fake_boto3}):
+        g: dict = {}
+        exec(compile(b._PROVISIONING_HOOK_SOURCE, "<hook>", "exec"), g)
+        return g["lambda_handler"](event, MagicMock())
+
+
+def test_hook_allows_valid_allowlisted_serial():
+    res = _run_handler(
+        {"parameters": {"SerialNumber": "robot-001", "ThingName": "g1-robot-001"}},
+        thing_exists=False,
+        serial_allowed=True,
+    )
+    assert res == {"allowProvisioning": True}
+
+
+def test_hook_denies_bad_serial():
+    res = _run_handler(
+        {"parameters": {"SerialNumber": "../../etc", "ThingName": "x"}},
+    )
+    assert res == {"allowProvisioning": False}
+
+
+def test_hook_denies_missing_serial():
+    res = _run_handler({"parameters": {"ThingName": "x"}})
+    assert res == {"allowProvisioning": False}
+
+
+def test_hook_denies_existing_thing():
+    res = _run_handler(
+        {"parameters": {"SerialNumber": "robot-001", "ThingName": "g1-robot-001"}},
+        thing_exists=True,
+    )
+    assert res == {"allowProvisioning": False}
+
+
+def test_hook_denies_serial_not_in_allowlist():
+    res = _run_handler(
+        {"parameters": {"SerialNumber": "robot-999", "ThingName": "g1-robot-999"}},
+        thing_exists=False,
+        serial_allowed=False,
+    )
+    assert res == {"allowProvisioning": False}

--- a/tests/mesh/test_iot_provisioning_hook.py
+++ b/tests/mesh/test_iot_provisioning_hook.py
@@ -31,14 +31,10 @@ def test_template_wires_pre_provisioning_hook():
 def test_template_create_includes_hook_when_arn_supplied():
     """create_provisioning_template must receive preProvisioningHook."""
     iot = MagicMock()
-    iot.exceptions.ResourceNotFoundException = type(
-        "RNF", (Exception,), {}
-    )
+    iot.exceptions.ResourceNotFoundException = type("RNF", (Exception,), {})
     iot.exceptions.InvalidRequestException = type("IRE", (Exception,), {})
     # describe -> not found so it proceeds to create
-    iot.describe_provisioning_template.side_effect = (
-        iot.exceptions.ResourceNotFoundException()
-    )
+    iot.describe_provisioning_template.side_effect = iot.exceptions.ResourceNotFoundException()
     acct = b.BootstrappedAccount(region="us-east-1", account_id="123456789012")
 
     # stub the role helper to avoid IAM calls
@@ -62,9 +58,7 @@ def test_template_omits_hook_when_no_arn():
     iot = MagicMock()
     iot.exceptions.ResourceNotFoundException = type("RNF", (Exception,), {})
     iot.exceptions.InvalidRequestException = type("IRE", (Exception,), {})
-    iot.describe_provisioning_template.side_effect = (
-        iot.exceptions.ResourceNotFoundException()
-    )
+    iot.describe_provisioning_template.side_effect = iot.exceptions.ResourceNotFoundException()
     acct = b.BootstrappedAccount(region="us-east-1", account_id="123456789012")
 
     import strands_robots.mesh.iot.bootstrap as mod
@@ -160,3 +154,75 @@ def test_hook_denies_serial_not_in_allowlist():
         serial_allowed=False,
     )
     assert res == {"allowProvisioning": False}
+
+
+def test_hook_role_grants_describe_thing_and_ssm_getparameter():
+    """The hook role must permit the two reads the hook makes (F-19/B-13).
+
+    Regression for the review blocker: the hook was originally created with
+    the E-stop Lambda role, which grants neither iot:DescribeThing nor
+    ssm:GetParameter. Those calls would then AccessDenied, get swallowed by
+    the deny-on-error envelope, and refuse *every* registration.
+    """
+    iam = MagicMock()
+
+    class _NoSuchEntity(Exception):
+        pass
+
+    iam.exceptions.NoSuchEntityException = _NoSuchEntity
+    iam.get_role.side_effect = _NoSuchEntity()
+    iam.create_role.return_value = {
+        "Role": {"Arn": "arn:aws:iam::123456789012:role/strands-mesh-provisioning-hook-role"}
+    }
+    acct = b.BootstrappedAccount(region="us-east-1", account_id="123456789012")
+
+    import strands_robots.mesh.iot.bootstrap as mod
+
+    orig_sleep = mod.time.sleep
+    mod.time.sleep = lambda *_a, **_k: None
+    try:
+        arn = b._ensure_provisioning_hook_role(iam, acct)
+    finally:
+        mod.time.sleep = orig_sleep
+
+    assert arn.endswith(":role/strands-mesh-provisioning-hook-role")
+
+    # The inline policy must grant both actions the hook needs.
+    inline = iam.put_role_policy.call_args.kwargs
+    import json as _json
+
+    doc = _json.loads(inline["PolicyDocument"])
+    actions = {a for stmt in doc["Statement"] for a in stmt["Action"]}
+    assert "iot:DescribeThing" in actions
+    assert "ssm:GetParameter" in actions
+    # SSM read must be scoped to the allowlist namespace, not "*".
+    ssm_stmt = next(s for s in doc["Statement"] if "ssm:GetParameter" in s["Action"])
+    assert all("provisioning/allow/" in r for r in ssm_stmt["Resource"])
+    assert all(r != "*" for r in ssm_stmt["Resource"])
+
+
+def test_bootstrap_uses_dedicated_hook_role():
+    """bootstrap_account must wire the hook to its own role, not the E-stop role."""
+    src = inspect.getsource(b.bootstrap_account)
+    assert "_ensure_provisioning_hook_role" in src
+
+
+def test_hook_lambda_stamps_version_description():
+    """Create path stamps the version tag so drift can be detected later."""
+    lam = MagicMock()
+
+    class _RNF(Exception):
+        pass
+
+    lam.exceptions.ResourceNotFoundException = _RNF
+    lam.exceptions.InvalidParameterValueException = type("IPV", (Exception,), {})
+    lam.get_function.side_effect = _RNF()
+    lam.create_function.return_value = {
+        "FunctionArn": "arn:aws:lambda:us-east-1:123456789012:function:strands-mesh-provisioning-hook"
+    }
+    acct = b.BootstrappedAccount(region="us-east-1", account_id="123456789012")
+
+    b._ensure_provisioning_hook_lambda(lam, "arn:aws:iam::123456789012:role/hook", acct)
+
+    desc = lam.create_function.call_args.kwargs["Description"]
+    assert f"[v{b._PROVISIONING_HOOK_VERSION}]" in desc


### PR DESCRIPTION
## Fleet Provisioning lacks PreProvisioningHook

**Severity: CRITICAL** (proven exploitable in the engagement)

The `strands-mesh-fleet-provisioning` template had **no `preProvisioningHook`**, so any holder of the shared, long-lived **claim certificate** could register an **arbitrary `ThingName`** and receive a full robot identity + robot policy — which in turn unlocks downstream findings (F-15 response spoof, etc.).

## Fix — deny-by-default PreProvisioningHook
New Lambda `strands-mesh-provisioning-hook` that AWS IoT calls **before every registration**. Allows provisioning only when **all** hold:
- `SerialNumber` present and matches strict format (`<=64` of `[A-Za-z0-9._-]`)
- target Thing does **not** already exist (blocks identity takeover)
- serial is pre-seeded by the operator in SSM at `/strands-mesh/provisioning/allow/<serial>` (swap for your CMDB if desired)

Returns `{"allowProvisioning": False}` on any failure.

### Wiring
- `_ensure_provisioning_hook_lambda()` — create/update the hook Lambda (idempotent)
- `_ensure_provisioning_template()` — attaches `preProvisioningHook` (`payloadVersion 2020-04-01`) when a hook ARN is supplied
- `_grant_iot_invoke_provisioning_hook()` — lets `iot.amazonaws.com` invoke it (scoped to the provisioning template ARN)
- `bootstrap_account()` wires all three; `BootstrappedAccount` gains `provisioning_hook_lambda_arn`

## Tests
`tests/mesh/test_iot_provisioning_hook.py` — 10 cases (template wiring + hook allow/deny behaviour with mocked boto3). Full IoT suite green (179 passed).