### PR TITLE
fix(iot): scope OperatorShadow to strands-managed Things

### DIFF
--- a/strands_robots/mesh/iot/provision.py
+++ b/strands_robots/mesh/iot/provision.py
@@ -302,10 +302,20 @@ _OPERATOR_POLICY_DOC: dict[str, Any] = {
             ],
         },
         {
+            # F-20 / B-14: scope shadow access to strands-managed Things
+            # only. The bare ``thing/*`` resource let an operator cert
+            # GetThingShadow / UpdateThingShadow on EVERY Thing in the
+            # account (the attribute Condition does not restrict shadow
+            # APIs by resource name -- the pentest wrote shadow.reported
+            # on non-strands Things). AWS does not apply the attribute
+            # condition to the shadow data-plane resource, so the practical
+            # fix is a resource-name prefix: strands robots are provisioned
+            # with ``strands-`` ThingName prefixes (see PROVISIONING
+            # template + _validate_thing_name).
             "Sid": "OperatorShadow",
             "Effect": "Allow",
             "Action": ["iot:GetThingShadow", "iot:UpdateThingShadow"],
-            "Resource": ["arn:aws:iot:*:*:thing/*"],
+            "Resource": ["arn:aws:iot:*:*:thing/strands-*"],
             "Condition": {
                 "StringEquals": {
                     "iot:Connection.Thing.Attributes.strands-mesh-role": "robot",


### PR DESCRIPTION
## Operator policy permits cross-Thing shadow write

**Severity:** High

The `strands-operator` policy's `OperatorShadow` statement allowed `iot:GetThingShadow` / `iot:UpdateThingShadow` on `arn:aws:iot:*:*:thing/*`. PoC 06 wrote `shadow.reported.poc06` on **every Thing in the account**, including non-strands Things — the attribute `Condition` (`strands-mesh-role=robot`) does **not** restrict the shadow data-plane resource by name, so the wildcard was the effective grant.

## Fix
Scope the resource to `arn:aws:iot:*:*:thing/strands-*` (the engagement's recommended fix). Operator shadow access is now limited to strands-managed robot Things.

> **Note:** this establishes a `strands-` ThingName prefix convention for robots that need operator shadow access. Operators with unprefixed Thing names must rename or extend this resource pattern.

## Tests
Full IoT policy + provision suites green (42 passed). The other two F-20-group cases (good vs cross-thing wildcards) already passed.

---

*F-15 (robot response spoof) is intentionally handled in a separate PR — it is protocol-coupled (robots currently publish to the operator's response topic) and needs a coordinated topic-schema change in `core.py` + transports, unlike this isolated policy fix.*