### PR TITLE
fix(mesh): hard-refuse operator denylist ACL without opt-in

### DIFF
--- a/strands_robots/mesh/_acl_config.py
+++ b/strands_robots/mesh/_acl_config.py
@@ -41,6 +41,22 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+
+class PermissiveACLError(RuntimeError):
+    """Raised when an operator-supplied ACL uses the blacklist footgun
+    (``default_permission='allow'`` with explicit rules) without opting
+    in via ``STRANDS_MESH_ACCEPT_PERMISSIVE_ACL``. Pentest B-08 / F-14.
+
+    The built-in permissive default (allow + EMPTY rules) is exempt --
+    it is gated separately by the ``Mesh.start`` refuse-to-start path
+    (:meth:`Mesh._refuse_under_permissive_default_acl`) which fires under
+    mTLS. This error closes the *operator-file blacklist* footgun: a
+    hand-written ``allow + rules`` ACL is an explicit, load-bearing
+    anti-pattern that should fail loud rather than silently expose any
+    rule gap.
+    """
+
+
 #: Maximum bytes of an ACL file we will load. Anything larger is almost
 #: certainly an attacker probing for an OOM.
 ACL_FILE_MAX_BYTES: int = 256 * 1024
@@ -202,6 +218,29 @@ def _load_acl_file(path: Path) -> dict[str, Any]:
                 path,
                 len(data["rules"]),
             )
+            # B-08 / F-14: the warning above is the first-line signal; this
+            # is the hard gate. An operator-supplied blacklist ACL
+            # (allow + explicit rules) is a load-bearing anti-pattern --
+            # any gap in the rule set exposes the mesh. Refuse to load it
+            # unless the operator has explicitly acknowledged the posture
+            # via STRANDS_MESH_ACCEPT_PERMISSIVE_ACL. The built-in default
+            # (allow + EMPTY rules) does not reach this branch and stays
+            # gated by Mesh.start's refuse-to-start path.
+            accept = os.getenv("STRANDS_MESH_ACCEPT_PERMISSIVE_ACL", "").strip().lower() in (
+                "1",
+                "true",
+                "yes",
+            )
+            if not accept:
+                raise PermissiveACLError(
+                    f"ACL file {path} uses default_permission='allow' with "
+                    f"{len(data['rules'])} rule(s) -- a blacklist policy where any "
+                    "rule gap exposes the mesh. Refusing to load. Remediate one of:\n"
+                    "  1. Rewrite the ACL with default_permission='deny' and "
+                    "explicit allow rules (see examples/mesh_acl_example.json5).\n"
+                    "  2. Set STRANDS_MESH_ACCEPT_PERMISSIVE_ACL=1 to acknowledge "
+                    "the dev/lab posture."
+                )
     _validate_acl_shape(data, path)
     return data
 

--- a/tests/mesh/test_acl_config.py
+++ b/tests/mesh/test_acl_config.py
@@ -167,9 +167,35 @@ class TestACLFileLoader:
         path = tmp_path / "blacklist.json"
         path.write_text(json.dumps(bad))
         monkeypatch.setenv("STRANDS_MESH_ACL_FILE", str(path))
+        # B-08 / F-14: an allow+rules blacklist ACL now hard-refuses unless
+        # the operator acknowledges the posture. Ack so we can still observe
+        # the (first-line) warning this test pins.
+        monkeypatch.setenv("STRANDS_MESH_ACCEPT_PERMISSIVE_ACL", "1")
+        ac._clear_acl_cache_for_test()
         with caplog.at_level("WARNING"):
             ac.resolve_acl("strands")
         assert any("blacklist" in rec.message for rec in caplog.records)
+
+    def test_default_allow_with_rules_refuses_without_ack(self, monkeypatch, tmp_path):
+        """B-08 / F-14: allow+rules ACL refuses to load without explicit ack."""
+        bad = self._good_acl_dict()
+        bad["default_permission"] = "allow"
+        bad["rules"] = [
+            {
+                "id": "blacklisted",
+                "key_exprs": ["strands/secret/**"],
+                "messages": ["put"],
+                "flows": ["ingress"],
+                "permission": "deny",
+            }
+        ]
+        path = tmp_path / "blacklist.json"
+        path.write_text(json.dumps(bad))
+        monkeypatch.setenv("STRANDS_MESH_ACL_FILE", str(path))
+        monkeypatch.delenv("STRANDS_MESH_ACCEPT_PERMISSIVE_ACL", raising=False)
+        ac._clear_acl_cache_for_test()
+        with pytest.raises(ac.PermissiveACLError):
+            ac.resolve_acl("strands")
 
 
 # --- JSON5 preprocessor tests ------------------------------------------

--- a/tests/mesh/test_pr224_review_blockers.py
+++ b/tests/mesh/test_pr224_review_blockers.py
@@ -354,7 +354,9 @@ def test_blacklist_warning_only_fires_with_rules(tmp_path: Path, caplog: pytest.
     )
 
 
-def test_blacklist_warning_fires_with_rules(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+def test_blacklist_warning_fires_with_rules(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Thread #28: ``allow + non-empty rules`` DOES trigger the
     blacklist warning -- this is the actual anti-pattern."""
     import json as _json
@@ -384,17 +386,9 @@ def test_blacklist_warning_fires_with_rules(tmp_path: Path, caplog: pytest.LogCa
     )
     # B-08 / F-14: allow+rules now hard-refuses without an explicit ack.
     # This test pins the (first-line) WARNING, so opt in to reach it.
-    import os as _os
-    _prev = _os.environ.get("STRANDS_MESH_ACCEPT_PERMISSIVE_ACL")
-    _os.environ["STRANDS_MESH_ACCEPT_PERMISSIVE_ACL"] = "1"
-    try:
-        with caplog.at_level(logging.WARNING, logger="strands_robots.mesh._acl_config"):
-            _acl_config._load_acl_file(p)
-    finally:
-        if _prev is None:
-            _os.environ.pop("STRANDS_MESH_ACCEPT_PERMISSIVE_ACL", None)
-        else:
-            _os.environ["STRANDS_MESH_ACCEPT_PERMISSIVE_ACL"] = _prev
+    monkeypatch.setenv("STRANDS_MESH_ACCEPT_PERMISSIVE_ACL", "1")
+    with caplog.at_level(logging.WARNING, logger="strands_robots.mesh._acl_config"):
+        _acl_config._load_acl_file(p)
     assert any("blacklist" in m and "1 rule(s)" in m for m in caplog.messages), (
         f"expected blacklist warning naming rule count, got: {caplog.messages}"
     )

--- a/tests/mesh/test_pr224_review_blockers.py
+++ b/tests/mesh/test_pr224_review_blockers.py
@@ -382,8 +382,19 @@ def test_blacklist_warning_fires_with_rules(tmp_path: Path, caplog: pytest.LogCa
             }
         )
     )
-    with caplog.at_level(logging.WARNING, logger="strands_robots.mesh._acl_config"):
-        _acl_config._load_acl_file(p)
+    # B-08 / F-14: allow+rules now hard-refuses without an explicit ack.
+    # This test pins the (first-line) WARNING, so opt in to reach it.
+    import os as _os
+    _prev = _os.environ.get("STRANDS_MESH_ACCEPT_PERMISSIVE_ACL")
+    _os.environ["STRANDS_MESH_ACCEPT_PERMISSIVE_ACL"] = "1"
+    try:
+        with caplog.at_level(logging.WARNING, logger="strands_robots.mesh._acl_config"):
+            _acl_config._load_acl_file(p)
+    finally:
+        if _prev is None:
+            _os.environ.pop("STRANDS_MESH_ACCEPT_PERMISSIVE_ACL", None)
+        else:
+            _os.environ["STRANDS_MESH_ACCEPT_PERMISSIVE_ACL"] = _prev
     assert any("blacklist" in m and "1 rule(s)" in m for m in caplog.messages), (
         f"expected blacklist warning naming rule count, got: {caplog.messages}"
     )


### PR DESCRIPTION
## Permissive ACL footgun warns but doesn't block

**Severity:** High

Shipping a `default_permission='allow'` ACL **with explicit rules** is a blacklist footgun — any gap in the rule set exposes the mesh. Previously the SDK only **WARNED** on this shape. The refuse-to-start gate (`Mesh._refuse_under_permissive_default_acl`) only fires under `STRANDS_MESH_AUTH_MODE=mtls`, so a permissive operator ACL loaded silently under other auth modes.

## Fix
Add a hard gate in `_load_acl_file`: an operator-supplied ACL with `default_permission='allow'` **AND non-empty rules** now raises `PermissiveACLError` unless the operator acknowledges the dev/lab posture via `STRANDS_MESH_ACCEPT_PERMISSIVE_ACL=1`.

- The first-line **WARNING** is preserved (operator signal); this is the second-line **hard stop**.
- The built-in permissive default (`allow` + **EMPTY** rules) is **exempt** — it doesn't reach this branch and stays gated by `Mesh.start`.

## Tests
- `test_acl_config.py`: new `test_default_allow_with_rules_refuses_without_ack`; existing warning test opts in to still observe the warning
- `test_pr224_review_blockers.py`: existing blacklist-warning test opts in
- Full mesh suite: 1139 passed (1 pre-existing order-dependent failure in `test_get_session_falls_back_*` unrelated to this change — fails on clean `main` in isolation too)