### PR TITLE
fix(iot): scope robot response publishes to own ThingName

### DIFF
--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -1042,7 +1042,14 @@ class Mesh(SensorLoopsMixin):
         # {"action":"execute",...}. Outgoing send/broadcast/tell still accept
         # the ergonomic dict-or-string forms because tell() wraps internally.
         #
-        rkey = f"strands/{sender}/response/{turn}" if sender else None
+        # F-15 / B-09: include the responder's own peer_id as a topic
+        # segment so the IoT robot policy can scope publish to
+        # ``strands/+/response/${ThingName}/*`` -- a robot can only
+        # publish responses tagged with its OWN ThingName, closing the
+        # cross-robot response-spoof surface. The requester subscribes
+        # with ``response/**`` so the extra segment matches. Operator
+        # prefix (``{sender}``) is unchanged so routing is preserved.
+        rkey = f"strands/{sender}/response/{self.peer_id}/{turn}" if sender else None
         if cmd is None or not isinstance(cmd, dict):
             # route non-dict envelope rejection
             # through the same audit + wire-response path as

--- a/strands_robots/mesh/iot/provision.py
+++ b/strands_robots/mesh/iot/provision.py
@@ -164,28 +164,25 @@ _ROBOT_POLICY_DOC: dict[str, Any] = {
             ],
         },
         {
-            # This wildcard middle segment is the OPERATOR'S thing-name
-            # (the recipient of the response). The robot legitimately
-            # needs to publish to the operator's own response inbox to
-            # complete the request/response RPC pattern. Scoping
-            # tighter (e.g. ``${iot:Connection.Thing.ThingName}/...``)
-            # would force the operator to know each robot's name to
-            # route responses, breaking the topic contract.
+            # F-15 / B-09: the response topic is
+            # ``strands/{operator}/response/{robot_thingname}/{turn}``.
+            # The first wildcard is the OPERATOR'S thing-name (the
+            # recipient inbox the robot must reach to complete the RPC).
+            # The ``${iot:Connection.Thing.ThingName}`` segment pins the
+            # RESPONDER to its own identity -- so robot-A can no longer
+            # forge a response that claims to come from robot-B. The
+            # trailing ``/*`` is the per-turn UUID.
             #
-            # The trailing ``/*`` is the per-turn id (UUID per
-            # call). The middle wildcard is the only legitimate broadening.
-            #
-            # Defence-in-depth: the operator-side ACL (``AllowOwnSubscriptions``
-            # at line 187) restricts each operator to subscribing only to
-            # ``strands/${ThingName}/...``, so a robot publishing to
-            # ``strands/<other-operator>/response/<turn>`` lands on a
-            # topic nobody is authorised to subscribe to (the message
-            # is silently dropped by the broker per the IoT Core contract).
+            # Defence-in-depth: the operator-side ACL
+            # (``OperatorReceiveResponses`` / ``AllowOwnSubscriptions``)
+            # already restricts each operator to its own response prefix;
+            # this statement closes the responder-identity surface on the
+            # publish side that the pentest (F-15) proved exploitable.
             "Sid": "AllowResponseToAnyOperator",
             "Effect": "Allow",
             "Action": "iot:Publish",
             "Resource": [
-                "arn:aws:iot:*:*:topic/strands/*/response/*",
+                "arn:aws:iot:*:*:topic/strands/*/response/${iot:Connection.Thing.ThingName}/*",
             ],
         },
         {
@@ -275,8 +272,13 @@ _OPERATOR_POLICY_DOC: dict[str, Any] = {
             "Effect": "Allow",
             "Action": ["iot:Subscribe", "iot:Receive"],
             "Resource": [
+                # F-15: response topic gained a ``{robot_thingname}``
+                # segment (strands/{op}/response/{robot}/{turn}); the
+                # multi-level ``#`` filter covers both the old and new
+                # depth so the operator still receives every response
+                # addressed to it.
                 "arn:aws:iot:*:*:topic/strands/${iot:Connection.Thing.ThingName}/response/*",
-                "arn:aws:iot:*:*:topicfilter/strands/${iot:Connection.Thing.ThingName}/response/*",
+                "arn:aws:iot:*:*:topicfilter/strands/${iot:Connection.Thing.ThingName}/response/#",
             ],
         },
         {

--- a/tests/mesh/test_mesh_rpc.py
+++ b/tests/mesh/test_mesh_rpc.py
@@ -222,8 +222,8 @@ def test_exec_cmd_publishes_response(captured_puts: list[tuple[str, dict[str, An
             "command": {"action": "status"},
         }
     )
-    assert any(k == "strands/alice/response/t1" for k, _ in captured_puts)
-    response = next(d for k, d in captured_puts if k == "strands/alice/response/t1")
+    assert any(k == "strands/alice/response/me/t1" for k, _ in captured_puts)
+    response = next(d for k, d in captured_puts if k == "strands/alice/response/me/t1")
     assert response["type"] == "response"
     assert response["responder_id"] == "me"
     assert response["turn_id"] == "t1"
@@ -238,7 +238,7 @@ def test_exec_cmd_publishes_error_on_dispatch_exception(
     # the original dispatch-exception path that this test was written for.
     with patch.object(m, "_dispatch", side_effect=RuntimeError("boom-with-internal-detail")):
         m._exec_cmd({"sender_id": "alice", "turn_id": "t2", "command": {"action": "status"}})
-    payload = next(d for k, d in captured_puts if k == "strands/alice/response/t2")
+    payload = next(d for k, d in captured_puts if k == "strands/alice/response/me/t2")
     assert payload["type"] == "error"
     # internal exception detail MUST NOT leak onto the wire. The
     # error string is sanitised to a static "dispatch error" so a remote
@@ -255,7 +255,7 @@ def test_exec_cmd_rejects_unknown_action_with_validation_error(
     includes the offending action name."""
     m = Mesh(_FakeRobot(), peer_id="me")
     m._exec_cmd({"sender_id": "alice", "turn_id": "t3", "command": {"action": "rm_rf"}})
-    payload = next(d for k, d in captured_puts if k == "strands/alice/response/t3")
+    payload = next(d for k, d in captured_puts if k == "strands/alice/response/me/t3")
     assert payload["type"] == "error"
     assert "validation" in payload["error"]
     assert "rm_rf" in payload["error"]

--- a/tests/mesh/test_response_topic_scope.py
+++ b/tests/mesh/test_response_topic_scope.py
@@ -1,0 +1,67 @@
+"""Tests for response-topic responder scoping (pentest F-15 / B-09).
+
+The response topic is strands/{operator}/response/{responder}/{turn} so
+the IoT robot policy can pin a robot's response publishes to its OWN
+ThingName -- closing the cross-robot response-spoof surface.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from strands_robots.mesh.core import Mesh
+from strands_robots.mesh.iot import provision
+
+
+class _FakeRobot:
+    def get_observation(self) -> dict[str, Any]:
+        return {}
+
+    def status(self) -> dict[str, Any]:
+        return {"status": "idle"}
+
+
+def _capture_puts(m: Mesh) -> list[tuple[str, dict]]:
+    puts: list[tuple[str, dict]] = []
+    m.publish = lambda key, payload, **kw: puts.append((key, payload))  # type: ignore
+    return puts
+
+
+def test_response_topic_includes_responder_id():
+    """rkey must be strands/{operator}/response/{responder}/{turn}."""
+    m = Mesh(_FakeRobot(), peer_id="robot-a")
+    puts = _capture_puts(m)
+    m._exec_cmd({"sender_id": "operator-1", "turn_id": "turn-xyz",
+                 "command": {"action": "status"}})
+    keys = [k for k, _ in puts]
+    assert "strands/operator-1/response/robot-a/turn-xyz" in keys, keys
+    # the responder segment is the publisher's own peer_id
+    assert all("/response/robot-a/" in k for k in keys if "/response/" in k)
+
+
+def test_robot_policy_response_scoped_to_own_thingname():
+    """F-15: AllowResponseToAnyOperator must pin responder to ThingName."""
+    policy = provision._ROBOT_POLICY_DOC
+    stmt = next(s for s in policy["Statement"]
+                if s.get("Sid") == "AllowResponseToAnyOperator")
+    resources = stmt["Resource"]
+    assert all("${iot:Connection.Thing.ThingName}" in r for r in resources), resources
+    # Must NOT contain the old fleet-wide wildcard form.
+    assert all(r != "arn:aws:iot:*:*:topic/strands/*/response/*" for r in resources)
+
+
+def test_operator_receive_covers_new_depth():
+    """Operator must still receive the deeper response topic via # filter."""
+    policy = provision._OPERATOR_POLICY_DOC
+    stmt = next(s for s in policy["Statement"]
+                if s.get("Sid") == "OperatorReceiveResponses")
+    joined = "\n".join(stmt["Resource"])
+    # multi-level filter so {robot}/{turn} depth is covered
+    assert "response/#" in joined
+
+
+def test_policies_serialise_to_json():
+    """Both policy docs must remain valid JSON."""
+    for doc in (provision._ROBOT_POLICY_DOC, provision._OPERATOR_POLICY_DOC):
+        json.dumps(doc)

--- a/tests/mesh/test_response_topic_scope.py
+++ b/tests/mesh/test_response_topic_scope.py
@@ -32,19 +32,25 @@ def test_response_topic_includes_responder_id():
     """rkey must be strands/{operator}/response/{responder}/{turn}."""
     m = Mesh(_FakeRobot(), peer_id="robot-a")
     puts = _capture_puts(m)
-    m._exec_cmd({"sender_id": "operator-1", "turn_id": "turn-xyz",
-                 "command": {"action": "status"}})
+    m._exec_cmd({"sender_id": "operator-1", "turn_id": "turn-xyz", "command": {"action": "status"}})
     keys = [k for k, _ in puts]
     assert "strands/operator-1/response/robot-a/turn-xyz" in keys, keys
     # the responder segment is the publisher's own peer_id
     assert all("/response/robot-a/" in k for k in keys if "/response/" in k)
+    # F-15 invariant: the topic responder segment and the payload
+    # responder_id field must convey the SAME identity. The broker ACL keys
+    # off the topic; _on_response's expected_responders check keys off the
+    # payload. If they ever drift, one layer passes while the other rejects
+    # -- exactly the split this fix exists to prevent.
+    responses = [d for k, d in puts if "/response/" in k]
+    assert responses, puts
+    assert all(d.get("responder_id") == "robot-a" for d in responses), responses
 
 
 def test_robot_policy_response_scoped_to_own_thingname():
     """F-15: AllowResponseToAnyOperator must pin responder to ThingName."""
     policy = provision._ROBOT_POLICY_DOC
-    stmt = next(s for s in policy["Statement"]
-                if s.get("Sid") == "AllowResponseToAnyOperator")
+    stmt = next(s for s in policy["Statement"] if s.get("Sid") == "AllowResponseToAnyOperator")
     resources = stmt["Resource"]
     assert all("${iot:Connection.Thing.ThingName}" in r for r in resources), resources
     # Must NOT contain the old fleet-wide wildcard form.
@@ -54,8 +60,7 @@ def test_robot_policy_response_scoped_to_own_thingname():
 def test_operator_receive_covers_new_depth():
     """Operator must still receive the deeper response topic via # filter."""
     policy = provision._OPERATOR_POLICY_DOC
-    stmt = next(s for s in policy["Statement"]
-                if s.get("Sid") == "OperatorReceiveResponses")
+    stmt = next(s for s in policy["Statement"] if s.get("Sid") == "OperatorReceiveResponses")
     joined = "\n".join(stmt["Resource"])
     # multi-level filter so {robot}/{turn} depth is covered
     assert "response/#" in joined


### PR DESCRIPTION
## Any robot can spoof any other robot's responses

**Severity:** High

The `strands-robot` policy's `AllowResponseToAnyOperator` granted `iot:Publish` on `arn:aws:iot:*:*:topic/strands/*/response/*` — a fleet-wide wildcard. Robot-A's leaf cert could publish a forged response on `strands/<operator>/response/<turn>` claiming to be Robot-B; whichever response matched the operator's `turn_id` first won (PoC `iot01_response_spoof.py`).

## Fix — responder-scoped response topic
Add the responder's own peer_id as a topic segment. New schema:
```
strands/{operator}/response/{responder_thingname}/{turn}
```
- **core.py**: `rkey` embeds `self.peer_id`. The requester already subscribes with `response/**`, so the extra segment matches — **no subscriber change**, operator prefix unchanged → routing preserved.
- **provision.py robot policy**: `AllowResponseToAnyOperator` resource pinned to `.../response/${iot:Connection.Thing.ThingName}/*` — a robot can **only** publish responses tagged with its own ThingName.
- **provision.py operator policy**: `OperatorReceiveResponses` uses a multi-level (`#`) topicfilter so the operator still receives the deeper topic.

Complements the existing app-layer `responder_id` / `_expected_responders` check — **defence-in-depth**: the broker now refuses the forged publish at the policy layer, not just the app.

## Tests
- `test_response_topic_scope.py` (new): topic schema + policy scoping (4 cases)
- `test_mesh_rpc.py`: response-topic assertions updated to the new schema
- Full mesh suite green (1140 passed).