### PR TITLE
test(mesh): pin one ACL file read per Mesh.start (issue #218)

### DIFF
--- a/tests/mesh/test_pr224_acl_toctou.py
+++ b/tests/mesh/test_pr224_acl_toctou.py
@@ -103,3 +103,75 @@ def test_acl_block_from_uses_provided_dict():
     assert key == "access_control"
     assert json.loads(value) == custom
     assert json.loads(value)["marker"] == "from-snapshot"
+
+
+def test_mesh_start_reads_acl_file_once_end_to_end(tmp_path, monkeypatch, caplog):
+    """Issue #218 acceptance criterion: ONE read of STRANDS_MESH_ACL_FILE per
+    Mesh.start() call, measured end-to-end across the refuse-to-start gate and
+    the wire-config builder.
+
+    The prior pin (test_snapshot_acl_single_file_read) asserts a single
+    snapshot_acl() call reads once. This pins the issue's exact criterion: the
+    full Mesh.start() flow -- gate (_refuse_under_permissive_default_acl ->
+    snapshot_acl) plus session._build_config (snapshot_acl -> acl_block_from) --
+    performs at most ONE _load_acl_file call, so an attacker rewriting the file
+    between gate and build cannot make the wire observe a different snapshot.
+    """
+    import logging
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock, patch
+
+    from strands_robots.mesh import Mesh
+    from strands_robots.mesh import core as mesh_core
+    from strands_robots.mesh import _acl_config
+
+    acl = tmp_path / "ops.json5"
+    acl.write_text(
+        '{"rules": [], "subjects": [], "policies": [], '
+        '"enabled": true, "default_permission": "deny"}\n'
+    )
+    monkeypatch.setenv("STRANDS_MESH_AUTH_MODE", "mtls")
+    monkeypatch.setenv("STRANDS_MESH_ACL_FILE", str(acl))
+
+    _acl_config._clear_acl_cache_for_test()
+    _acl_config._clear_thread_snapshot()
+
+    call_count = [0]
+    real_load_acl_file = _acl_config._load_acl_file
+
+    def counted(path):
+        call_count[0] += 1
+        return real_load_acl_file(path)
+
+    monkeypatch.setattr(_acl_config, "_load_acl_file", counted)
+
+    robot = SimpleNamespace(
+        tool_name_str="r218",
+        robot=SimpleNamespace(
+            is_connected=True,
+            name="r218_test",
+            config=SimpleNamespace(cameras={}),
+            get_observation=MagicMock(return_value={}),
+        ),
+    )
+
+    class _StubDecl:
+        def undeclare(self) -> None:
+            pass
+
+    class _StubSession:
+        def declare_subscriber(self, *args, **kwargs):
+            return _StubDecl()
+
+    mesh = Mesh(robot, peer_id="test-218", peer_type="robot")
+    with patch.object(mesh_core, "get_session", return_value=_StubSession()):
+        with patch.object(mesh_core, "release_session"):
+            with patch.object(mesh, "_heartbeat_loop"), patch.object(mesh, "_state_loop"):
+                with caplog.at_level(logging.WARNING, logger="strands_robots.mesh.core"):
+                    mesh.start()
+                mesh.stop()
+
+    assert call_count[0] <= 1, (
+        f"Mesh.start() read the ACL file {call_count[0]} times; "
+        "the TOCTOU defence requires exactly one read per start"
+    )

--- a/tests/mesh/test_pr224_acl_toctou.py
+++ b/tests/mesh/test_pr224_acl_toctou.py
@@ -121,15 +121,11 @@ def test_mesh_start_reads_acl_file_once_end_to_end(tmp_path, monkeypatch, caplog
     from types import SimpleNamespace
     from unittest.mock import MagicMock, patch
 
-    from strands_robots.mesh import Mesh
+    from strands_robots.mesh import Mesh, _acl_config
     from strands_robots.mesh import core as mesh_core
-    from strands_robots.mesh import _acl_config
 
     acl = tmp_path / "ops.json5"
-    acl.write_text(
-        '{"rules": [], "subjects": [], "policies": [], '
-        '"enabled": true, "default_permission": "deny"}\n'
-    )
+    acl.write_text('{"rules": [], "subjects": [], "policies": [], "enabled": true, "default_permission": "deny"}\n')
     monkeypatch.setenv("STRANDS_MESH_AUTH_MODE", "mtls")
     monkeypatch.setenv("STRANDS_MESH_ACL_FILE", str(acl))
 
@@ -172,6 +168,5 @@ def test_mesh_start_reads_acl_file_once_end_to_end(tmp_path, monkeypatch, caplog
                 mesh.stop()
 
     assert call_count[0] <= 1, (
-        f"Mesh.start() read the ACL file {call_count[0]} times; "
-        "the TOCTOU defence requires exactly one read per start"
+        f"Mesh.start() read the ACL file {call_count[0]} times; the TOCTOU defence requires exactly one read per start"
     )


### PR DESCRIPTION
closes #218

## Disposition
Option A (architectural fix) is already implemented in main: `Mesh.start` calls `_acl_config.snapshot_acl(namespace)` once, stashes the resolved dict on a thread-local via `_set_thread_snapshot`, and `session._build_config` reuses it through `acl_block_from` -- one read threaded through the gate and the wire-config builder.

What was missing is the issue's exact acceptance criterion: **a counter on `_load_acl_file` calls per `Mesh.start()`**. The existing `test_snapshot_acl_single_file_read` only pins a single `snapshot_acl()` call, not the full end-to-end start flow (gate + build).

## Change
Adds `test_mesh_start_reads_acl_file_once_end_to_end` to `tests/mesh/test_pr224_acl_toctou.py`: drives a real `Mesh.start()` with an operator ACL file and a monkeypatched `_load_acl_file` counter, asserting at most one file read per start. This pins the TOCTOU-close behaviour so an attacker rewriting the file between gate and build cannot make the wire observe a different snapshot.

## Test output
```
$ hatch run python -m pytest tests/mesh/test_pr224_acl_toctou.py -q
============================== 5 passed in 0.86s ===============================
```
