### PR TITLE
mesh(safety): mirror estop per-issuer fairness cap on resume cache (closes #267)

### DIFF
--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -2123,6 +2123,48 @@ class Mesh(SensorLoopsMixin):
                 ttl_s=_resume_freshness_window_s() + _resume_forward_skew_s(),
                 now_mono=now_mono,
             )
+            # Per-issuer fairness bound -- mirror of the estop path
+            # (_on_safety_estop, search "per_issuer_cap"). Without this
+            # a single wire_zid (or body issuer_id on an attribution-less
+            # transport) holding the override code can fill all
+            # _resume_replay_cache_max() slots and then churn legitimate
+            # other-issuer entries out via the eviction 20%-oldest-drop
+            # branch, suppressing real replay-rejection signals. The cap
+            # is computed from the SAME expression as the estop site so
+            # the two replay-cache defenses stay symmetric.
+            per_issuer_cap = max(1, _resume_replay_cache_max() // 4)
+            issuer_slots = sum(1 for k in self._resume_replay_cache if k[0] == issuer_key)
+            if issuer_slots >= per_issuer_cap:
+                logger.warning(
+                    "[safety] %s: REFUSED resume cache slot -- issuer %r already at cap %d "
+                    "(per-issuer fairness bound; flood suspected)",
+                    self.peer_id,
+                    issuer_key,
+                    per_issuer_cap,
+                )
+                # Audit the over-cap rejection so an operator dashboard
+                # can alert. The cache slot is NOT added; the resume
+                # itself is refused (unlike estop, which still engages
+                # lockout, a refused resume must NOT clear lockout --
+                # returning here is the safe direction).
+                try:
+                    self.publish_safety_event(
+                        event_type="resume_per_issuer_cap_exceeded",
+                        severity="warning",
+                        payload={
+                            "issuer": issuer_id,
+                            "proof_nonce_prefix": proof_nonce[:16],
+                            "cap": per_issuer_cap,
+                        },
+                    )
+                except (TypeError, ValueError, OSError) as audit_exc:
+                    # Narrow per AGENTS.md > "Exception Clauses Must Be Narrow".
+                    logger.debug(
+                        "[mesh] %s: resume_per_issuer_cap_exceeded audit publish failed: %s",
+                        self.peer_id,
+                        audit_exc,
+                    )
+                return
             self._resume_replay_cache[cache_key] = now_mono
 
         sender = data.get("peer_id", "<remote>")

--- a/tests/mesh/test_resume_replay.py
+++ b/tests/mesh/test_resume_replay.py
@@ -379,3 +379,82 @@ def test_f18a_envelope_without_lockout_elapsed_s_rejected(monkeypatch):
     m._on_safety_resume(_sample(env))
 
     assert m._estop_lockout.is_set() is True
+
+
+def test_resume_cache_per_issuer_cap_enforced(monkeypatch):
+    """One issuer cannot exceed per_issuer_cap slots in the resume cache.
+
+    Mirrors the estop per-issuer fairness bound: with CACHE_MAX=8 the cap
+    is max(1, 8//4) == 2, so the third distinct-nonce resume from the same
+    issuer is refused with a resume_per_issuer_cap_exceeded audit and the
+    cache holds at most the cap for that issuer.
+    """
+    monkeypatch.setenv("STRANDS_MESH_OVERRIDE_CODE", "secret")
+    monkeypatch.setenv("STRANDS_MESH_RESUME_REPLAY_CACHE_MAX", "8")
+
+    m = _make_mesh()
+    m.publish_safety_event = MagicMock()
+
+    # cap = max(1, 8 // 4) == 2
+    for _ in range(3):
+        env = _make_envelope("secret", peer_id="op-flooder", proof_nonce=uuid.uuid4().hex)
+        m._estop_lockout.set()
+        m._on_safety_resume(_sample(env))
+
+    flooder_slots = sum(1 for k in m._resume_replay_cache if k[0] == ("body", "op-flooder"))
+    assert flooder_slots == 2
+
+    audit_types = [c.kwargs.get("event_type") for c in m.publish_safety_event.call_args_list]
+    assert "resume_per_issuer_cap_exceeded" in audit_types
+
+
+def test_resume_cache_other_issuer_entries_not_evicted(monkeypatch):
+    """A flooding issuer at cap cannot evict another issuer's cached slot.
+
+    Issuer A fills its cap, issuer B records one legitimate slot, then A
+    floods again (refused, no eviction). Replaying B's original envelope
+    is still detected as a replay -- B's slot survived A's churn.
+    """
+    monkeypatch.setenv("STRANDS_MESH_OVERRIDE_CODE", "secret")
+    monkeypatch.setenv("STRANDS_MESH_RESUME_REPLAY_CACHE_MAX", "8")
+
+    m = _make_mesh()
+    m.publish_safety_event = MagicMock()
+
+    # A fills its cap of 2.
+    for _ in range(2):
+        env_a = _make_envelope("secret", peer_id="op-A", proof_nonce=uuid.uuid4().hex)
+        m._estop_lockout.set()
+        m._on_safety_resume(_sample(env_a))
+
+    # B records one legitimate slot.
+    env_b = _make_envelope("secret", peer_id="op-B", proof_nonce=uuid.uuid4().hex)
+    m._estop_lockout.set()
+    m._on_safety_resume(_sample(env_b))
+    assert ("body", "op-B") in {k[0] for k in m._resume_replay_cache}
+
+    # A keeps flooding -- every attempt is refused, none evicts B.
+    for _ in range(5):
+        env_a = _make_envelope("secret", peer_id="op-A", proof_nonce=uuid.uuid4().hex)
+        m._estop_lockout.set()
+        m._on_safety_resume(_sample(env_a))
+
+    # B's slot survives: replay of B's exact envelope is still rejected.
+    m.publish_safety_event.reset_mock()
+    m._estop_lockout.set()
+    m._on_safety_resume(_sample(env_b))
+    audit_types = [c.kwargs.get("event_type") for c in m.publish_safety_event.call_args_list]
+    assert "resume_replay_rejected" in audit_types
+
+
+def test_resume_and_estop_per_issuer_cap_use_same_expression():
+    """Structural symmetry pin: both replay-cache handlers must derive
+    per_issuer_cap from the identical expression so the two fairness
+    defenses cannot silently diverge."""
+    import inspect
+
+    resume_src = inspect.getsource(Mesh._on_safety_resume)
+    estop_src = inspect.getsource(Mesh._on_safety_estop)
+    cap_expr = "per_issuer_cap = max(1, _resume_replay_cache_max() // 4)"
+    assert cap_expr in resume_src
+    assert cap_expr in estop_src


### PR DESCRIPTION
## Summary

`_on_safety_resume` added entries to `_resume_replay_cache` unconditionally, while `_on_safety_estop` bounds each issuer to `max(1, _resume_replay_cache_max() // 4)` slots. A single `wire_zid` (or body `issuer_id` on an attribution-less transport) holding the override code could fill all cache slots and then churn legitimate other-issuer entries out via the eviction oldest-drop branch, suppressing real replay-rejection signals.

## Fix

Mirror the estop per-issuer-cap pattern in the resume path using the **identical expression** (`per_issuer_cap = max(1, _resume_replay_cache_max() // 4)`), counting slots by the domain-tagged `issuer_key`. Over-cap resumes are refused (returning before clearing lockout -- the safe direction) and audited as `resume_per_issuer_cap_exceeded`.

## Pin tests

- `test_resume_cache_per_issuer_cap_enforced`
- `test_resume_cache_other_issuer_entries_not_evicted`
- `test_resume_and_estop_per_issuer_cap_use_same_expression` (structural symmetry)

Cap + symmetry tests fail pre-fix, all pass post-fix.

## Test output

```
$ hatch run python -m pytest tests/mesh/test_resume_replay.py -q
============================== 17 passed in 0.95s ==============================
```

closes #267