### PR TITLE
test(mesh): pin dispatch-error audit event (closes #257)

### DIFF
--- a/tests/mesh/test_mesh_rpc.py
+++ b/tests/mesh/test_mesh_rpc.py
@@ -567,3 +567,80 @@ def test_stop_wakes_blocked_send(fake_session: MagicMock) -> None:
     t.join(timeout=2.0)
     assert not t.is_alive()
     assert out == [{"status": "timeout"}]
+
+
+class TestCommandDispatchErrorAudit:
+    """Pin the dispatch-error audit posture for issue #257.
+
+    The _exec_cmd dispatch-exception branch must emit a log_safety_event with
+    event_type "command_rejected" and reason "dispatch error" so a remote
+    prober cannot fish for adapter exceptions without leaving a forensic
+    trail. The audit payload must never carry the internal exception detail,
+    and an audit-sink failure on this path must not crash the handler.
+    """
+
+    def test_command_dispatch_error_emits_audit_event(
+        self, captured_puts: list[tuple[str, dict[str, Any]]]
+    ) -> None:
+        m = Mesh(_FakeRobot(), peer_id="me")
+        with patch.object(
+            mesh_core, "log_safety_event"
+        ) as mock_audit, patch.object(
+            m, "_dispatch", side_effect=RuntimeError("boom-with-internal-detail")
+        ):
+            m._exec_cmd(
+                {"sender_id": "alice", "turn_id": "t1", "command": {"action": "status"}}
+            )
+        assert mock_audit.called
+        event_type = mock_audit.call_args.args[0]
+        payload = mock_audit.call_args.args[2]
+        assert event_type == "command_rejected"
+        assert payload["reason"] == "dispatch error"
+
+    def test_command_dispatch_error_audit_payload_excludes_exception_message(
+        self, captured_puts: list[tuple[str, dict[str, Any]]]
+    ) -> None:
+        m = Mesh(_FakeRobot(), peer_id="me")
+        with patch.object(
+            mesh_core, "log_safety_event"
+        ) as mock_audit, patch.object(
+            m, "_dispatch", side_effect=RuntimeError("boom-with-internal-detail")
+        ):
+            m._exec_cmd(
+                {"sender_id": "alice", "turn_id": "t2", "command": {"action": "status"}}
+            )
+        payload = mock_audit.call_args.args[2]
+        assert "boom-with-internal-detail" not in str(payload)
+
+    def test_command_dispatch_error_audit_includes_sender_and_action(
+        self, captured_puts: list[tuple[str, dict[str, Any]]]
+    ) -> None:
+        m = Mesh(_FakeRobot(), peer_id="me")
+        with patch.object(
+            mesh_core, "log_safety_event"
+        ) as mock_audit, patch.object(
+            m, "_dispatch", side_effect=RuntimeError("boom")
+        ):
+            m._exec_cmd(
+                {"sender_id": "alice", "turn_id": "t3", "command": {"action": "status"}}
+            )
+        payload = mock_audit.call_args.args[2]
+        assert payload["sender"] == "alice"
+        assert payload["action"] == "status"
+
+    def test_command_dispatch_error_survives_audit_sink_failure(
+        self, captured_puts: list[tuple[str, dict[str, Any]]]
+    ) -> None:
+        m = Mesh(_FakeRobot(), peer_id="me")
+        with patch.object(
+            mesh_core, "log_safety_event", side_effect=OSError("audit disk full")
+        ), patch.object(m, "_dispatch", side_effect=RuntimeError("boom")):
+            # Must not raise despite the audit sink failing.
+            m._exec_cmd(
+                {"sender_id": "alice", "turn_id": "t4", "command": {"action": "status"}}
+            )
+        payload = next(
+            d for k, d in captured_puts if k == "strands/alice/response/me/t4"
+        )
+        assert payload["type"] == "error"
+        assert payload["error"] == "dispatch error"

--- a/tests/mesh/test_mesh_rpc.py
+++ b/tests/mesh/test_mesh_rpc.py
@@ -579,18 +579,13 @@ class TestCommandDispatchErrorAudit:
     and an audit-sink failure on this path must not crash the handler.
     """
 
-    def test_command_dispatch_error_emits_audit_event(
-        self, captured_puts: list[tuple[str, dict[str, Any]]]
-    ) -> None:
+    def test_command_dispatch_error_emits_audit_event(self, captured_puts: list[tuple[str, dict[str, Any]]]) -> None:
         m = Mesh(_FakeRobot(), peer_id="me")
-        with patch.object(
-            mesh_core, "log_safety_event"
-        ) as mock_audit, patch.object(
-            m, "_dispatch", side_effect=RuntimeError("boom-with-internal-detail")
+        with (
+            patch.object(mesh_core, "log_safety_event") as mock_audit,
+            patch.object(m, "_dispatch", side_effect=RuntimeError("boom-with-internal-detail")),
         ):
-            m._exec_cmd(
-                {"sender_id": "alice", "turn_id": "t1", "command": {"action": "status"}}
-            )
+            m._exec_cmd({"sender_id": "alice", "turn_id": "t1", "command": {"action": "status"}})
         assert mock_audit.called
         event_type = mock_audit.call_args.args[0]
         payload = mock_audit.call_args.args[2]
@@ -601,14 +596,11 @@ class TestCommandDispatchErrorAudit:
         self, captured_puts: list[tuple[str, dict[str, Any]]]
     ) -> None:
         m = Mesh(_FakeRobot(), peer_id="me")
-        with patch.object(
-            mesh_core, "log_safety_event"
-        ) as mock_audit, patch.object(
-            m, "_dispatch", side_effect=RuntimeError("boom-with-internal-detail")
+        with (
+            patch.object(mesh_core, "log_safety_event") as mock_audit,
+            patch.object(m, "_dispatch", side_effect=RuntimeError("boom-with-internal-detail")),
         ):
-            m._exec_cmd(
-                {"sender_id": "alice", "turn_id": "t2", "command": {"action": "status"}}
-            )
+            m._exec_cmd({"sender_id": "alice", "turn_id": "t2", "command": {"action": "status"}})
         payload = mock_audit.call_args.args[2]
         assert "boom-with-internal-detail" not in str(payload)
 
@@ -616,14 +608,11 @@ class TestCommandDispatchErrorAudit:
         self, captured_puts: list[tuple[str, dict[str, Any]]]
     ) -> None:
         m = Mesh(_FakeRobot(), peer_id="me")
-        with patch.object(
-            mesh_core, "log_safety_event"
-        ) as mock_audit, patch.object(
-            m, "_dispatch", side_effect=RuntimeError("boom")
+        with (
+            patch.object(mesh_core, "log_safety_event") as mock_audit,
+            patch.object(m, "_dispatch", side_effect=RuntimeError("boom")),
         ):
-            m._exec_cmd(
-                {"sender_id": "alice", "turn_id": "t3", "command": {"action": "status"}}
-            )
+            m._exec_cmd({"sender_id": "alice", "turn_id": "t3", "command": {"action": "status"}})
         payload = mock_audit.call_args.args[2]
         assert payload["sender"] == "alice"
         assert payload["action"] == "status"
@@ -632,15 +621,12 @@ class TestCommandDispatchErrorAudit:
         self, captured_puts: list[tuple[str, dict[str, Any]]]
     ) -> None:
         m = Mesh(_FakeRobot(), peer_id="me")
-        with patch.object(
-            mesh_core, "log_safety_event", side_effect=OSError("audit disk full")
-        ), patch.object(m, "_dispatch", side_effect=RuntimeError("boom")):
+        with (
+            patch.object(mesh_core, "log_safety_event", side_effect=OSError("audit disk full")),
+            patch.object(m, "_dispatch", side_effect=RuntimeError("boom")),
+        ):
             # Must not raise despite the audit sink failing.
-            m._exec_cmd(
-                {"sender_id": "alice", "turn_id": "t4", "command": {"action": "status"}}
-            )
-        payload = next(
-            d for k, d in captured_puts if k == "strands/alice/response/me/t4"
-        )
+            m._exec_cmd({"sender_id": "alice", "turn_id": "t4", "command": {"action": "status"}})
+        payload = next(d for k, d in captured_puts if k == "strands/alice/response/me/t4")
         assert payload["type"] == "error"
         assert payload["error"] == "dispatch error"


### PR DESCRIPTION
## Summary

Issue #257 asked for the `_exec_cmd` dispatch-exception branch to emit a `log_safety_event("command_rejected", reason="dispatch error")` so a remote prober cannot fish for adapter exceptions without leaving a forensic trail.

The fix is already present in `strands_robots/mesh/core.py` (lines ~1214-1232): the dispatch-error branch emits the audit event, never leaks `exc` into the payload, and wraps the emission in a narrow `except (TypeError, ValueError, OSError)` so an audit-sink failure does not crash the handler. This PR adds the missing pin tests.

## Tests added (tests/mesh/test_mesh_rpc.py :: TestCommandDispatchErrorAudit)

- test_command_dispatch_error_emits_audit_event
- test_command_dispatch_error_audit_payload_excludes_exception_message
- test_command_dispatch_error_audit_includes_sender_and_action
- test_command_dispatch_error_survives_audit_sink_failure

## Test output

```
======================= 4 passed, 37 deselected in 0.84s =======================
```

closes #257