### PR TITLE
test(mesh): pin WARN-on-reuse of break-glass CA (closes #261)

### DIFF
--- a/tests/mesh/test_iot_ca_pin.py
+++ b/tests/mesh/test_iot_ca_pin.py
@@ -276,9 +276,7 @@ class TestUnverifiedReuseWarning:
         with caplog.at_level("WARNING", logger="strands_robots.mesh.iot.provision"):
             provision._ensure_ca(ca_path)
         warnings = [
-            r.getMessage()
-            for r in caplog.records
-            if r.levelname == "WARNING" and "sidecar marker" in r.getMessage()
+            r.getMessage() for r in caplog.records if r.levelname == "WARNING" and "sidecar marker" in r.getMessage()
         ]
         assert len(warnings) == 1, (
             "re-using a CA written under the break-glass must emit one "
@@ -294,13 +292,10 @@ class TestUnverifiedReuseWarning:
             provision._ensure_ca(ca_path)
             provision._ensure_ca(ca_path)
         warnings = [
-            r.getMessage()
-            for r in caplog.records
-            if r.levelname == "WARNING" and "sidecar marker" in r.getMessage()
+            r.getMessage() for r in caplog.records if r.levelname == "WARNING" and "sidecar marker" in r.getMessage()
         ]
         assert len(warnings) == 1, (
-            "the unverified-origin WARNING must be gated to one emission "
-            f"per CA path per process; got {len(warnings)}"
+            f"the unverified-origin WARNING must be gated to one emission per CA path per process; got {len(warnings)}"
         )
 
     def test_reuse_without_marker_does_not_warn(self, tmp_path, monkeypatch, caplog):
@@ -315,11 +310,8 @@ class TestUnverifiedReuseWarning:
         with caplog.at_level("WARNING", logger="strands_robots.mesh.iot.provision"):
             provision._ensure_ca(ca_path)
         warnings = [
-            r.getMessage()
-            for r in caplog.records
-            if r.levelname == "WARNING" and "sidecar marker" in r.getMessage()
+            r.getMessage() for r in caplog.records if r.levelname == "WARNING" and "sidecar marker" in r.getMessage()
         ]
         assert warnings == [], (
-            "a canonically downloaded CA has no .unverified marker, so "
-            f"re-use must not WARN; got {warnings!r}"
+            f"a canonically downloaded CA has no .unverified marker, so re-use must not WARN; got {warnings!r}"
         )

--- a/tests/mesh/test_iot_ca_pin.py
+++ b/tests/mesh/test_iot_ca_pin.py
@@ -243,3 +243,83 @@ class TestUnverifiedMarkerPermissions:
             "during the download; the canonical-CA path must not leak "
             "the sentinel."
         )
+
+
+class TestUnverifiedReuseWarning:
+    """Issue #261: re-using a CA whose origin was the break-glass must WARN.
+
+    AGENTS.md > 'No silent defaults on error' -- the audit trail must
+    survive past the single writing run. After a break-glass download
+    leaves a ``.unverified`` sidecar, every later ``_ensure_ca`` re-use
+    on a host where the env var is gone must emit exactly one WARNING
+    per process so an operator can refresh via the canonical pinned
+    path. These tests pin that the warning fires on re-use and that it
+    is gated to one emission per CA path per process.
+    """
+
+    def _seed_breakglass_ca(self, ca_path, monkeypatch):
+        monkeypatch.setenv("STRANDS_MESH_DISABLE_CA_PIN", "true")
+        with patch(
+            "strands_robots.mesh.iot.provision._download_with_per_socket_timeout",
+            return_value=_REAL_CA,
+        ):
+            provision._ensure_ca(ca_path)
+        monkeypatch.delenv("STRANDS_MESH_DISABLE_CA_PIN", raising=False)
+        marker = ca_path.with_suffix(ca_path.suffix + ".unverified")
+        assert marker.exists()
+
+    def test_reuse_of_breakglass_ca_emits_warning(self, tmp_path, monkeypatch, caplog):
+        ca_path = tmp_path / "ca.pem"
+        self._seed_breakglass_ca(ca_path, monkeypatch)
+        provision._UNVERIFIED_CA_WARNED.discard(ca_path)
+        caplog.clear()
+        with caplog.at_level("WARNING", logger="strands_robots.mesh.iot.provision"):
+            provision._ensure_ca(ca_path)
+        warnings = [
+            r.getMessage()
+            for r in caplog.records
+            if r.levelname == "WARNING" and "sidecar marker" in r.getMessage()
+        ]
+        assert len(warnings) == 1, (
+            "re-using a CA written under the break-glass must emit one "
+            f"WARNING about the unverified origin; got {warnings!r}"
+        )
+
+    def test_reuse_warning_fires_once_per_process(self, tmp_path, monkeypatch, caplog):
+        ca_path = tmp_path / "ca.pem"
+        self._seed_breakglass_ca(ca_path, monkeypatch)
+        provision._UNVERIFIED_CA_WARNED.discard(ca_path)
+        with caplog.at_level("WARNING", logger="strands_robots.mesh.iot.provision"):
+            provision._ensure_ca(ca_path)
+            provision._ensure_ca(ca_path)
+            provision._ensure_ca(ca_path)
+        warnings = [
+            r.getMessage()
+            for r in caplog.records
+            if r.levelname == "WARNING" and "sidecar marker" in r.getMessage()
+        ]
+        assert len(warnings) == 1, (
+            "the unverified-origin WARNING must be gated to one emission "
+            f"per CA path per process; got {len(warnings)}"
+        )
+
+    def test_reuse_without_marker_does_not_warn(self, tmp_path, monkeypatch, caplog):
+        ca_path = tmp_path / "ca.pem"
+        monkeypatch.delenv("STRANDS_MESH_DISABLE_CA_PIN", raising=False)
+        with patch(
+            "strands_robots.mesh.iot.provision._download_with_per_socket_timeout",
+            return_value=_REAL_CA,
+        ):
+            provision._ensure_ca(ca_path)
+        provision._UNVERIFIED_CA_WARNED.discard(ca_path)
+        with caplog.at_level("WARNING", logger="strands_robots.mesh.iot.provision"):
+            provision._ensure_ca(ca_path)
+        warnings = [
+            r.getMessage()
+            for r in caplog.records
+            if r.levelname == "WARNING" and "sidecar marker" in r.getMessage()
+        ]
+        assert warnings == [], (
+            "a canonically downloaded CA has no .unverified marker, so "
+            f"re-use must not WARN; got {warnings!r}"
+        )


### PR DESCRIPTION
## Summary

Closes #261.

`_ensure_ca` already implements the full issue acceptance:
- writes a `.unverified` sidecar marker next to the CA when `STRANDS_MESH_DISABLE_CA_PIN=true` is active during download (provision.py ~L854-873)
- on subsequent on-disk re-use, emits one WARNING per process about the unverified origin, gated on the module-level `_UNVERIFIED_CA_WARNED` set (provision.py ~L806-820)

The marker-write path was pinned (TestUnverifiedMarkerPermissions) but the WARN-on-reuse behavior — the core of the issue — was not. This adds the missing regression tests.

## Tests added (tests/mesh/test_iot_ca_pin.py)
- `test_reuse_of_breakglass_ca_emits_warning` — re-use after a break-glass download fires the unverified-origin WARNING.
- `test_reuse_warning_fires_once_per_process` — gated to exactly one emission per CA path per process across 3 re-use calls.
- `test_reuse_without_marker_does_not_warn` — canonical (pinned) download leaves no marker, so re-use stays silent.

## Test output
```
$ hatch run python -m pytest tests/mesh/test_iot_ca_pin.py -q
============================== 18 passed in 1.01s ==============================
```