### PR TITLE
perf(mesh/transport): bound _CommandDeduplicator GC cost under sustained pressure

### DIFF
--- a/strands_robots/mesh/transport/bridge_transport.py
+++ b/strands_robots/mesh/transport/bridge_transport.py
@@ -248,6 +248,13 @@ def _should_bridge(
 # ``STRANDS_MESH_DEDUP_TTL`` (seconds; default 120).
 _DEFAULT_DEDUP_TTL_S = 120.0
 _MAX_DEDUP_ENTRIES = 10_000
+# Issue #231: hysteresis band on the sort-and-slice GC trigger. The cheap
+# stale-eviction sweep still runs at the soft boundary (_MAX), but the
+# heap-select-and-evict pass only runs once the cache exceeds this hard
+# boundary, so its O(n log k) cost amortises across many calls instead of
+# firing on every call while the cache hovers at the cap.
+_DEDUP_GC_HARD_RATIO = 1.1
+_MAX_DEDUP_ENTRIES_HARD = int(_MAX_DEDUP_ENTRIES * _DEDUP_GC_HARD_RATIO)
 
 
 def _resolve_dedup_ttl() -> float:
@@ -416,26 +423,62 @@ class _CommandDeduplicator:
             return False  # nothing to dedup against -- pass through
         cache_key = (key, ident)
         now = time.monotonic()  # NTP-safe, snapshot-resume-safe
+
+        # Issue #231: bound GC cost on two axes -- algorithmic and lock-hold.
+        #
+        # Axis 1 (algorithm): a hysteresis band defers the expensive
+        # heap-select pass until the cache exceeds the hard boundary
+        # (_MAX_DEDUP_ENTRIES_HARD), so it amortises across calls instead of
+        # firing every call while the cache hovers at the soft cap. The cheap
+        # stale-eviction sweep still runs at the soft boundary (_MAX).
+        #
+        # Axis 2 (lock-hold): the heap walk runs OUTSIDE self._lock via a
+        # snapshot-then-apply pattern. We snapshot self._seen.items() under
+        # the lock, release it, compute the eviction set with heapq.nsmallest
+        # (O(n log k), the only expensive step), then re-acquire to apply.
+        # The lock is held only for the snapshot copy and the eviction apply,
+        # never for the heap walk -- so concurrent is_duplicate() callers are
+        # not serialised behind the GC compute.
+        #
+        # Concurrency note: another thread may insert a new entry between the
+        # snapshot and the apply. We tolerate this by re-reading each entry's
+        # timestamp under the apply lock and only evicting it if it still
+        # matches the snapshot timestamp; a key re-inserted with a newer
+        # timestamp is kept (its newer identity is the live one). Dedup
+        # correctness is unaffected: identity semantics, TTL eviction, and the
+        # (topic_key, dedup_id) cache key shape are all unchanged.
         with self._lock:
-            # Cheap GC if oversized
-            if len(self._seen) > _MAX_DEDUP_ENTRIES:
+            size = len(self._seen)
+            run_stale = size > _MAX_DEDUP_ENTRIES
+            if run_stale:
                 cutoff = now - self._ttl
                 stale = [k for k, ts in self._seen.items() if ts < cutoff]
                 for k in stale:
                     self._seen.pop(k, None)
-                if len(self._seen) > _MAX_DEDUP_ENTRIES:
-                    # Issue #231: replace O(n log n) full-sort + slice with
-                    # ``heapq.nsmallest`` partial-selection (O(n log k) where
-                    # k = drop count). For the typical k = n/5 case this is
-                    # ~5x faster on the lock-hold than a full sort. The
-                    # heapq impl uses an O(k) heap and an O(n) scan, which
-                    # is bounded by the cap (10k entries) -- a few ms at
-                    # most under the lock.
-                    drop = max(1, len(self._seen) // 5)
-                    oldest = heapq.nsmallest(drop, self._seen.items(), key=lambda kv: kv[1])
-                    for k, _ in oldest:
+            run_select = len(self._seen) > _MAX_DEDUP_ENTRIES_HARD
+            snapshot = list(self._seen.items()) if run_select else None
+
+        if run_stale or run_select:
+            logger.debug(
+                "[bridge] dedup GC: stale-eviction=%s sort-and-slice=%s size=%d",
+                run_stale,
+                run_select,
+                size,
+            )
+
+        if run_select and snapshot is not None:
+            # Heap walk OUTSIDE the lock (axis 2). O(n log k), k = n // 5.
+            drop = max(1, len(snapshot) // 5)
+            oldest = heapq.nsmallest(drop, snapshot, key=lambda kv: kv[1])
+            with self._lock:
+                for k, ts in oldest:
+                    # Only evict if the live timestamp still matches the
+                    # snapshot -- a key re-inserted between snapshot and apply
+                    # carries a newer identity we must not drop.
+                    if self._seen.get(k) == ts:
                         self._seen.pop(k, None)
 
+        with self._lock:
             seen_ts = self._seen.get(cache_key)
             if seen_ts is not None and (now - seen_ts) <= self._ttl:
                 return True

--- a/tests/mesh/test_bridge_dedup.py
+++ b/tests/mesh/test_bridge_dedup.py
@@ -965,18 +965,23 @@ class TestGCPartialSelection:
     """
 
     def test_eviction_keeps_freshest_entries(self):
+        # Issue #231: the hysteresis band defers the heap-select eviction until
+        # the cache exceeds the hard boundary (_MAX_DEDUP_ENTRIES_HARD), so the
+        # cache must be driven past that boundary (not just the soft cap) to
+        # arm the sort-and-slice pass.
         from strands_robots.mesh.transport.bridge_transport import (
-            _MAX_DEDUP_ENTRIES,
+            _MAX_DEDUP_ENTRIES_HARD,
             _CommandDeduplicator,
         )
 
         dedup = _CommandDeduplicator(ttl_s=1000.0)  # long TTL so nothing is stale
-        # Fill past the cap
-        for i in range(_MAX_DEDUP_ENTRIES + 100):
+        # Fill past the hard boundary so the heap-select GC runs.
+        for i in range(_MAX_DEDUP_ENTRIES_HARD + 100):
             payload = {"sender_id": "robot-a", "turn_id": f"t{i}", "command": {"k": i}}
             dedup.is_duplicate(f"strands/robot-a/cmd/{i}", payload)
-        # Eviction triggered; ~20% dropped
-        assert len(dedup._seen) <= _MAX_DEDUP_ENTRIES
+        # Eviction triggered; ~20% dropped, so the cache drops back under the
+        # hard boundary.
+        assert len(dedup._seen) <= _MAX_DEDUP_ENTRIES_HARD
 
     def test_uses_heapq_not_sorted(self):
         """Source-grep pin: confirm heapq.nsmallest is in the GC path."""

--- a/tests_integ/mesh/test_dedup_gc_perf_bounded.py
+++ b/tests_integ/mesh/test_dedup_gc_perf_bounded.py
@@ -81,7 +81,7 @@ def test_gc_max_lock_hold_does_not_serialise_concurrent_caller():
     # Heap walk is outside the lock, so the contender's worst case is the
     # snapshot copy + eviction apply, not the O(n log k) compute.
     assert max_latency[0] < 0.05, (
-        f"contender single-call latency too high: {max_latency[0]*1000:.1f}ms "
+        f"contender single-call latency too high: {max_latency[0] * 1000:.1f}ms "
         "(GC likely holding the lock across the heap walk)"
     )
 

--- a/tests_integ/mesh/test_dedup_gc_perf_bounded.py
+++ b/tests_integ/mesh/test_dedup_gc_perf_bounded.py
@@ -1,0 +1,98 @@
+"""Issue #231 regression: bound _CommandDeduplicator GC cost under sustained
+pressure on two axes -- total wall-clock and max GC lock-hold time.
+
+These pin the perf rework against the pre-fix implementation, which (a) ran the
+sort-and-slice on every call once the cache hovered at the cap (no hysteresis
+band) and (b) held self._lock for the entire O(n log n) sort. Both axes are
+asserted with generous absolute bounds so the test is a coarse regression guard,
+not a flaky tight-loop benchmark.
+"""
+
+import threading
+import time
+
+from strands_robots.mesh.transport.bridge_transport import (
+    _MAX_DEDUP_ENTRIES,
+    _MAX_DEDUP_ENTRIES_HARD,
+    _CommandDeduplicator,
+)
+
+
+def _make_payload(i: int) -> dict:
+    return {"sender_id": "s", "turn_id": str(i), "command": {"op": i}}
+
+
+def _fill_to_hard_cap(dedup: _CommandDeduplicator) -> None:
+    # Push the cache past the hard boundary so GC is armed.
+    for i in range(_MAX_DEDUP_ENTRIES_HARD + 200):
+        dedup.is_duplicate("topic", _make_payload(i))
+
+
+def test_sustained_pressure_total_wall_clock_is_bounded():
+    """Axis (a): N further is_duplicate() calls past the cap stay well under a
+    coarse wall-clock ceiling. The pre-fix sort-and-slice-every-call path blows
+    past this once the cache sits at the cap."""
+    dedup = _CommandDeduplicator(ttl_s=3600.0, strict=True)
+    _fill_to_hard_cap(dedup)
+
+    n_calls = 2000
+    start = time.monotonic()
+    for i in range(n_calls):
+        dedup.is_duplicate("topic", _make_payload(_MAX_DEDUP_ENTRIES_HARD + 1000 + i))
+    elapsed = time.monotonic() - start
+
+    # Hysteresis means most of these calls do no heap-select work at all.
+    # 2000 calls in well under 2s even on a loaded CI box.
+    assert elapsed < 2.0, f"sustained pressure too slow: {elapsed:.3f}s for {n_calls} calls"
+
+
+def test_gc_max_lock_hold_does_not_serialise_concurrent_caller():
+    """Axis (b): while one thread drives the cache past the hard cap (triggering
+    GC), a contender thread timing its own is_duplicate() call must not be
+    blocked for the full GC compute. The pre-fix path held the lock across the
+    whole sort, so the contender's max single-call latency spiked; the
+    snapshot-then-apply pattern keeps it bounded."""
+    dedup = _CommandDeduplicator(ttl_s=3600.0, strict=True)
+    _fill_to_hard_cap(dedup)
+
+    stop = threading.Event()
+    max_latency = [0.0]
+
+    def contender():
+        i = 0
+        while not stop.is_set():
+            t0 = time.monotonic()
+            dedup.is_duplicate("other", _make_payload(10_000_000 + i))
+            dt = time.monotonic() - t0
+            if dt > max_latency[0]:
+                max_latency[0] = dt
+            i += 1
+
+    t = threading.Thread(target=contender, daemon=True)
+    t.start()
+    try:
+        # Drive sustained GC pressure on the main topic.
+        for i in range(3000):
+            dedup.is_duplicate("topic", _make_payload(20_000_000 + i))
+    finally:
+        stop.set()
+        t.join(timeout=5.0)
+
+    # Single is_duplicate() call must never block for the full GC sweep.
+    # Heap walk is outside the lock, so the contender's worst case is the
+    # snapshot copy + eviction apply, not the O(n log k) compute.
+    assert max_latency[0] < 0.05, (
+        f"contender single-call latency too high: {max_latency[0]*1000:.1f}ms "
+        "(GC likely holding the lock across the heap walk)"
+    )
+
+
+def test_dedup_correctness_unchanged_after_gc():
+    """The snapshot-then-apply GC must not break dedup identity semantics:
+    a freshly inserted entry is still reported duplicate on immediate repeat."""
+    dedup = _CommandDeduplicator(ttl_s=3600.0, strict=True)
+    _fill_to_hard_cap(dedup)
+
+    payload = _make_payload(99_999_999)
+    assert dedup.is_duplicate("topic", payload) is False
+    assert dedup.is_duplicate("topic", payload) is True

--- a/tests_integ/mesh/test_dedup_gc_perf_bounded.py
+++ b/tests_integ/mesh/test_dedup_gc_perf_bounded.py
@@ -12,7 +12,6 @@ import threading
 import time
 
 from strands_robots.mesh.transport.bridge_transport import (
-    _MAX_DEDUP_ENTRIES,
     _MAX_DEDUP_ENTRIES_HARD,
     _CommandDeduplicator,
 )


### PR DESCRIPTION
Closes #231.

Implements the four-part GC rework requested across PR #222's R2/R3/R4 reviews.

## Changes

1. **Hysteresis band** (`_MAX_DEDUP_ENTRIES_HARD = _MAX * 1.1`): the heap-select-and-evict pass only runs once the cache exceeds the hard boundary, so its O(n log k) cost amortises across calls instead of firing on every call while the cache hovers at the cap. The cheap stale-eviction sweep still runs at the soft boundary.
2. **heapq.nsmallest** replaces the `sorted(...)[:drop]` pattern in the oversize-after-stale branch (O(n log k) vs O(n log n)).
3. **Snapshot-then-apply**: the heap walk runs *outside* `self._lock`. The lock is held only for the snapshot copy and the eviction apply. Concurrent re-insertion between snapshot and apply is handled by re-checking the live timestamp before eviction (a key re-inserted with a newer identity is kept).
4. **logger.debug** on GC entry indicating which branch ran (stale-eviction / sort-and-slice).

No behavioural change to dedup correctness: same identity semantics, same TTL eviction, same `(topic_key, dedup_id)` cache key shape.

## Tests

New two-axis regression microbenchmark `tests_integ/mesh/test_dedup_gc_perf_bounded.py`:
- axis (a) total wall-clock under sustained pressure
- axis (b) max GC lock-hold via a contender thread timing its own call mid-sweep
- correctness-unchanged-after-GC

Updated the existing soft-cap eviction test for the new hysteresis boundary.

```
hatch run python -m pytest tests/mesh/test_bridge_dedup.py tests_integ/mesh/test_dedup_gc_perf_bounded.py -q
============================== 54 passed in 7.35s ==============================
```

---

## Round 2 changelog

- Removed the unused `_MAX_DEDUP_ENTRIES` import from the integ test flagged by CodeQL code-scanning; only `_MAX_DEDUP_ENTRIES_HARD` is referenced. No behavioral change.

Deferred `[FOLLOW-UP]` items (deterministic mid-snapshot re-insertion test, latency-bound widening, freshest-entry-retention assertion, `pre_gc_size` log rename) are explicitly non-blocking per reviewer and noted for follow-up.