### PR TITLE
test(mesh): pin camera privacy kill-switch gate + document env var (closes #249)

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,6 +580,7 @@ agent.tool.gr00t_inference(action="stop", port=8000)
 | `STRANDS_MESH_AUDIT_DIR` | Directory for the safety audit log (`mesh_audit.jsonl`) | `~/.strands_robots/` |
 | `STRANDS_MESH_CA_PINS` | Comma-separated SHA-256 hex pins, **additive** to the bundled Amazon Root CA1 pin tuple. Operator break-glass for an AWS-side root rotation that arrives before the next `strands-robots` release ships the new pin. Must match `^[0-9a-fA-F]{64}$` per entry. | unset |
 | `STRANDS_MESH_DISABLE_CA_PIN` | Set to `true` (case-insensitive) to skip CA pin verification on the *download* path only. The on-disk re-use path always raw-checks the pin regardless. Last-resort break-glass; prefer `STRANDS_MESH_CA_PINS` for rotations. | `false` |
+| `STRANDS_MESH_CAMERA_DISABLED` | Privacy kill-switch. Set truthy (`true`/`1`/`yes`/`on`, case-insensitive) to short-circuit the mesh camera publish loop before any frame is collected, encoded, or uploaded. Invalid values raise `ValueError`. | `false` |
 | `STRANDS_MESH_CAMERA_PRESIGN_TTL` | Default TTL (seconds) for S3 presigned URLs emitted on the IoT camera-offload path. Capped at 3600s (1h); a `0` is clamped to 1s. Non-integer values fall back to the default with a WARNING. | `60` |
 | `GROOT_API_TOKEN` | API token for GR00T inference service | - |
 | `STRANDS_ROBOT_MODE` | Override `Robot()` factory mode detection (`sim`, `real`, `auto`) | `auto` |

--- a/tests/mesh/test_camera_schema.py
+++ b/tests/mesh/test_camera_schema.py
@@ -131,3 +131,47 @@ def test_publish_cameras_once_handles_missing_frame(fake_robot_with_camera):
     with patch("strands_robots.mesh.core.put") as mock_put:
         m._publish_cameras_once()
     assert not mock_put.called
+
+
+def test_publish_cameras_once_kill_switch_blocks_publish(fake_robot_with_camera, monkeypatch):
+    """STRANDS_MESH_CAMERA_DISABLED=true short-circuits before any publish.
+
+    Pins the privacy kill-switch gate at the top of _publish_cameras_once:
+    when the env var is truthy, no frame is collected and put() is never
+    called, even though the inner robot is connected and has a camera.
+    """
+    from strands_robots.mesh import Mesh
+
+    monkeypatch.setenv("STRANDS_MESH_CAMERA_DISABLED", "true")
+    m = Mesh(fake_robot_with_camera, peer_id="test-cam-killswitch")
+    with patch("strands_robots.mesh.core.put") as mock_put:
+        m._publish_cameras_once()
+    assert not mock_put.called
+    assert not fake_robot_with_camera.robot.get_observation.called
+
+
+def test_publish_cameras_once_publishes_when_kill_switch_unset(fake_robot_with_camera, monkeypatch):
+    """With the kill-switch unset, the camera frame is published normally.
+
+    Companion to test_publish_cameras_once_kill_switch_blocks_publish: proves
+    the gate is the reason for the no-op above, not an unrelated short-circuit.
+    """
+    from strands_robots.mesh import Mesh
+
+    monkeypatch.delenv("STRANDS_MESH_CAMERA_DISABLED", raising=False)
+    m = Mesh(fake_robot_with_camera, peer_id="test-cam-killswitch-off")
+    with patch("strands_robots.mesh.core.put") as mock_put:
+        m._publish_cameras_once()
+    assert mock_put.called
+
+
+def test_publish_cameras_once_kill_switch_lenient_truthy(fake_robot_with_camera, monkeypatch):
+    """Lenient truthy values (on/1/yes) also engage the kill-switch."""
+    from strands_robots.mesh import Mesh
+
+    for raw in ("on", "1", "YES", "True"):
+        monkeypatch.setenv("STRANDS_MESH_CAMERA_DISABLED", raw)
+        m = Mesh(fake_robot_with_camera, peer_id="test-cam-killswitch-lenient")
+        with patch("strands_robots.mesh.core.put") as mock_put:
+            m._publish_cameras_once()
+        assert not mock_put.called, f"value {raw!r} should disable publishing"


### PR DESCRIPTION
Closes #249.

## Summary
The privacy kill-switch (`STRANDS_MESH_CAMERA_DISABLED`) gate and the `_bool_env` helper are already implemented in main (`core.py` `_publish_cameras_once`, `_zenoh_config._bool_env`), and the S3 ACL question was resolved via path (a) (documented `BucketOwnerEnforced` contract in `camera_offload.py` module docstring; no `ACL=` kwarg). Two gaps remained per the acceptance criteria:

1. No pin test exercised the kill-switch gate itself. The prior `tests/mesh/test_camera_acl.py::TestCameraKillSwitch` was removed for being vacuous (short-circuited at the inner-None guard, not the kill-switch).
2. README `STRANDS_*` matrix did not list `STRANDS_MESH_CAMERA_DISABLED`.

## Changes
- Added 3 regression tests in `tests/mesh/test_camera_schema.py` that drive a real `Mesh._publish_cameras_once()` with a connected fake robot + camera:
  - `test_publish_cameras_once_kill_switch_blocks_publish`: env truthy -> `put()` not called, `get_observation` not called.
  - `test_publish_cameras_once_publishes_when_kill_switch_unset`: env unset -> `put()` IS called (proves the gate is the cause, not an unrelated short-circuit).
  - `test_publish_cameras_once_kill_switch_lenient_truthy`: `on`/`1`/`YES`/`True` all engage the gate.
- Documented `STRANDS_MESH_CAMERA_DISABLED` in the README env-var matrix.

## Test output
```
hatch run python -m pytest tests/mesh/test_camera_schema.py -k "kill_switch" -q
======================= 3 passed, 8 deselected in 1.17s ========================
```

> Generated with AI assistance.