### PR TITLE
tech-debt(deps): consolidate duplicate dependency pins (#214)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,20 @@ world ``ground`` plane (configurable via ``create_world(ground_plane=...)``)
 is the single source of truth; robots contribute only their own
 bodies/joints/actuators/sensors.
 
+## Unreleased - #214 (dependency pin consolidation)
+
+### Changed: hatch default env inherits deps via extras
+
+The seven dev/runtime deps that were duplicated between the project metadata
+(`[project.dependencies]` / `[project.optional-dependencies]`) and
+`[tool.hatch.envs.default].dependencies` (Pillow, pytest, pytest-cov, mypy,
+msgpack, pyzmq, ruff) are no longer re-pinned in the hatch env. The default
+env now sets `features = ["all", "dev"]` and inherits them, so a Dependabot
+bump edits a single site. Only `requests` (which has no project-level home)
+remains pinned in the hatch env. A new regression test
+(`tests/test_dependency_pin_sites.py`) fails if a project-managed dep is
+re-introduced into the hatch env list.
+
 ## Unreleased - #228 (AWS IoT provisioning hardening)
 
 ### Changed: default presigned-URL TTL for camera offload
@@ -59,6 +73,10 @@ Applies to ``strands_robots.mesh.iot.provision`` and
   ``provision_operator``, and ``teardown_thing``. Rejects path
   separators, dots, spaces, NUL, non-ASCII, and trailing
   ``\n``/``\r``/``\t``. Pre-existing AWS IoT Things containing ``:``
+
+  ``
+``/``
+``/``	``. Pre-existing AWS IoT Things containing ``:``
   must be renamed (we deliberately reject ``:`` due to NTFS / classic
   Mac filesystem semantics).
 - **IoT policy scope** — robot/operator policies use explicit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,16 +107,13 @@ packages = ["strands_robots"]
 
 [tool.hatch.envs.default]
 installer = "uv"
-features = ["all"]
+# Dev tooling (pytest, ruff, mypy, ...) is inherited from the "dev" extra and
+# runtime deps from "all"; nothing is re-pinned here to avoid the two-site
+# duplication tracked in issue #214. Only deps with no project-level home live
+# below.
+features = ["all", "dev"]
 dependencies = [
-    "pytest>=6.0,<9.0.0",
-    "pytest-cov>=4.0.0,<6.0.0",
-    "ruff>=0.4.0,<1.0.0",
-    "mypy>=1.0.0,<2.0.0",
-    "Pillow>=8.0.0,<12.0.0",
     "requests>=2.28.0,<3.0.0",
-    "msgpack>=1.0.0,<2.0.0",
-    "pyzmq>=27.0.0,<28.0.0",
 ]
 
 [tool.hatch.envs.default.scripts]

--- a/tests/test_dependency_pin_sites.py
+++ b/tests/test_dependency_pin_sites.py
@@ -1,0 +1,75 @@
+"""Repo hygiene: forbid pinning a dependency in two pyproject sites at once.
+
+History: issue #214. Seven deps (Pillow, pytest, pytest-cov, mypy, msgpack,
+pyzmq, ruff) were pinned both in the project metadata
+(``[project.dependencies]`` / ``[project.optional-dependencies]``) and in
+``[tool.hatch.envs.default].dependencies``. That forced every Dependabot bump
+to edit both sites in lockstep. The hatch ``default`` env now inherits those
+deps via ``features`` (the "all" and "dev" extras), so the duplication was
+removed.
+
+This test ratchets the consolidation in: it fails if any project-managed
+dependency name is re-introduced into the hatch ``default`` env dependency
+list. Deps with no project-level home (declared via the allowlist below) are
+permitted to live in the hatch env only.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
+
+# Dependency names allowed to be pinned ONLY in the hatch default env because
+# they have no [project] home. Keep this narrow.
+HATCH_ONLY_ALLOWLIST = {"requests"}
+
+
+def _name(requirement: str) -> str:
+    """Extract the lowercased distribution name from a requirement string."""
+    head = requirement.strip()
+    for sep in (">", "<", "=", "!", "~", ";", "[", " "):
+        head = head.split(sep, 1)[0]
+    return head.strip().lower()
+
+
+def _project_dependency_names(data: dict) -> set[str]:
+    names: set[str] = set()
+    for req in data["project"].get("dependencies", []):
+        names.add(_name(req))
+    for reqs in data["project"].get("optional-dependencies", {}).values():
+        for req in reqs:
+            names.add(_name(req))
+    return names
+
+
+def _hatch_default_dependency_names(data: dict) -> set[str]:
+    env = data["tool"]["hatch"]["envs"]["default"]
+    return {_name(req) for req in env.get("dependencies", [])}
+
+
+def test_hatch_default_env_does_not_duplicate_project_pins() -> None:
+    data = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    project_names = _project_dependency_names(data)
+    hatch_names = _hatch_default_dependency_names(data)
+
+    duplicated = sorted(hatch_names & project_names)
+    assert not duplicated, (
+        "These deps are pinned in both [project] metadata and "
+        "[tool.hatch.envs.default].dependencies; inherit them via env "
+        f"features instead: {duplicated}"
+    )
+
+
+def test_hatch_only_dependencies_are_allowlisted() -> None:
+    data = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    project_names = _project_dependency_names(data)
+    hatch_names = _hatch_default_dependency_names(data)
+
+    hatch_only = hatch_names - project_names
+    unexpected = sorted(hatch_only - HATCH_ONLY_ALLOWLIST)
+    assert not unexpected, (
+        "Hatch-only deps must be added to HATCH_ONLY_ALLOWLIST with a rationale "
+        f"or moved into a [project] extra: {unexpected}"
+    )


### PR DESCRIPTION
closes #214

## What

The hatch \`default\` env re-pinned 7 deps already declared in project metadata (Pillow, pytest, pytest-cov, mypy, msgpack, pyzmq, ruff). The env now inherits them via \`features = ["all", "dev"]\`; only \`requests\` (no project-level home) remains pinned in the env.

## Acceptance criteria

- No dep pinned in both \`[project]\` metadata and \`[tool.hatch.envs.default].dependencies\`.
- New regression test \`tests/test_dependency_pin_sites.py\` ratchets the invariant in (replaces the per-bump consistency burden referenced in the issue).
- CHANGELOG entry added.

## Verification

Pre-fix (duplication present), test fails:
```
FAILED tests/test_dependency_pin_sites.py::test_hatch_default_env_does_not_duplicate_project_pins
1 failed, 1 passed in 0.76s
```

Post-fix:
```
2 passed in 0.80s
```