### PR TITLE
Document ActionConfig metadata elision in groot data_configs (closes #211)

### DIFF
--- a/strands_robots/policies/groot/data_config.py
+++ b/strands_robots/policies/groot/data_config.py
@@ -35,7 +35,12 @@ class Gr00tDataConfig:
         name: Config identifier (e.g. "so100_dualcam").
         video_keys: Camera observation keys (e.g. ["video.front", "video.wrist"]).
         state_keys: Robot state keys (e.g. ["state.single_arm", "state.gripper"]).
-        action_keys: Action output keys from the model.
+        action_keys: Action output keys from the model. Keys are by-name
+            only: this schema omits the upstream Isaac-GR00T ActionConfig
+            metadata (rep / type / format). Downstream code must not assume
+            joint-angle semantics for action keys -- some keys are learned
+            latents (for example unitree_g1_sonic action.motion_token is a
+            64-dim SONIC latent, not a joint angle). See issue #211.
         language_keys: Natural-language instruction keys.
         observation_indices: Temporal indices for observations.
         action_indices: Temporal indices for actions (horizon).

--- a/strands_robots/policies/groot/data_configs.json
+++ b/strands_robots/policies/groot/data_configs.json
@@ -1,4 +1,5 @@
 {
+  "_note": "Action keys in every config are by-name only. This schema deliberately omits the upstream Isaac-GR00T ActionConfig metadata (rep / type / format) attached per action key. Downstream consumers must NOT assume joint-angle semantics for action keys: some keys are learned latents (for example unitree_g1_sonic action.motion_token is a 64-dim SONIC latent decoded by the SONIC controller, not a joint angle). Map and consume action keys by name. See issue strands-labs/robots#211.",
   "configs": {
     "so100": {
       "video_keys": [

--- a/tests/policies/groot/test_data_config.py
+++ b/tests/policies/groot/test_data_config.py
@@ -349,3 +349,33 @@ class TestCreateCustomDataConfig:
         second = load_data_config("overwrite_test")
         assert second.video_keys == ["v2"]
         assert first is not second
+
+
+# (section)
+# Schema documentation of ActionConfig metadata elision (issue #211)
+# (section)
+
+
+class TestActionConfigElisionDocumented:
+    """Issue #211: the schema drops upstream ActionConfig (rep/type/format)
+    metadata; this must stay explicitly documented so downstream code does
+    not assume joint-angle semantics for action keys."""
+
+    def test_data_configs_json_has_top_level_note_about_action_key_semantics(self):
+        note = _RAW.get("_note", "")
+        assert note, "data_configs.json must carry a top-level _note documenting the schema"
+        lowered = note.lower()
+        assert "motion_token" in lowered
+        assert "by-name" in lowered
+        assert "joint-angle" in lowered
+        assert "211" in note
+
+    def test_top_level_note_is_not_treated_as_a_config_entry(self):
+        assert "_note" not in DATA_CONFIG_MAP
+        assert "_note" not in _RAW_CONFIGS
+
+    def test_gr00t_data_config_docstring_warns_against_joint_angle_assumption(self):
+        doc = Gr00tDataConfig.__doc__ or ""
+        lowered = doc.lower()
+        assert "joint-angle" in lowered
+        assert "motion_token" in lowered


### PR DESCRIPTION
## Summary

Resolves #211 via **option 2** (document the schema elision explicitly), the surgically-scoped choice: the repo has no downstream code that applies joint-angle post-processing to the action stream (`groot/policy.py` maps action keys by name/positionally), so preserving the full upstream `ActionConfig` table (option 1) would add unused schema surface. Documenting the by-name contract is the smallest correct fix.

## Changes
- `strands_robots/policies/groot/data_configs.json`: add a top-level `_note` stating action keys are by-name only, the upstream `ActionConfig` (rep/type/format) metadata is intentionally omitted, and downstream code must not assume joint-angle semantics (calls out `unitree_g1_sonic action.motion_token` as a learned latent). The loader reads `configs`/`aliases` only, so `_note` is inert.
- `strands_robots/policies/groot/data_config.py`: docstring warning on `Gr00tDataConfig.action_keys`.
- `tests/policies/groot/test_data_config.py`: regression tests pinning the documentation (note presence + content, `_note` not treated as a config entry, docstring warning).

## Test output
```
hatch run python -m pytest tests/policies/groot/test_data_config.py -k "ActionConfigElision" -q
3 passed, 30 deselected in 0.85s

hatch run python -m pytest tests/policies/groot/test_data_config.py -q
33 passed in 3.52s
```
