### PR TITLE
docs(mesh/iot): document Subscribe/Receive scope asymmetry (#254)

### DIFF
--- a/strands_robots/mesh/iot/provision.py
+++ b/strands_robots/mesh/iot/provision.py
@@ -194,6 +194,11 @@ _ROBOT_POLICY_DOC: dict[str, Any] = {
             ],
         },
         {
+            # Intentional asymmetry vs ``AllowReceiveScoped`` below:
+            # Subscribe covers all own-prefix topics, but Receive is narrow
+            # to topics the robot actually processes inbound (cmd,
+            # response/*). Outbound-only topics (state, health, safety/event)
+            # are published by the robot, never locally subscribed-and-received.
             "Sid": "AllowOwnSubscriptions",
             "Effect": "Allow",
             "Action": "iot:Subscribe",


### PR DESCRIPTION
Completes the final outstanding item (item 4) of issue #254 (PR #228 R5 follow-ups).

## What
Adds an in-code comment on the `AllowOwnSubscriptions` IoT Policy statement in `provision.py` documenting the intentional asymmetry with `AllowReceiveScoped`:
- Subscribe covers all own-prefix topics.
- Receive is narrow to inbound-processed topics (`cmd`, `response/*`).
- Outbound-only topics (state, health, safety/event) are published by the robot, never locally subscribed-and-received.

## Status of the 4 items
- [x] Item 1 (camera_offload.py AllowOwnTopics comment) -- already on main
- [x] Item 2 (multi-pin rotation test, `test_tuple_supports_multiple_pins`) -- already on main (tests/mesh/test_iot_ca_pin.py)
- [x] Item 3 (#251 chunked-read cross-ref) -- already on main
- [x] Item 4 (Subscribe/Receive asymmetry doc) -- this PR

## Verification
Documentation only, no behavioural change.

```
49 passed in 1.18s
```
(tests/mesh/test_iot_provision.py tests/mesh/test_iot_ca_pin.py)

closes #254