### PR TITLE
fix(sim): control-rate substepping so position-servo policies actually track

### DIFF
--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -233,6 +233,18 @@ class SimEngine(ABC):
         """
         ...
 
+    def physics_timestep(self) -> float | None:
+        """Return the physics integration timestep in seconds, or ``None``.
+
+        Used by :class:`PolicyRunner` to convert a policy's ``control_frequency``
+        into the number of physics substeps per control step
+        (``round(1 / control_frequency / physics_timestep)``) so a
+        position-servo robot actually tracks each action's target before the
+        next action overwrites ``ctrl``. Backends that cannot report a fixed
+        timestep return ``None`` and the runner falls back to ``n_substeps=1``.
+        """
+        return None
+
     # Rendering
 
     @abstractmethod
@@ -264,6 +276,7 @@ class SimEngine(ABC):
         n_steps: int | None = None,
         max_steps: int | None = None,
         max_onframe_failures: int | None = None,
+        control_substeps: int | None = None,
     ) -> dict[str, Any]:
         """Run a policy loop in the simulation (blocking).
 
@@ -348,6 +361,7 @@ class SimEngine(ABC):
             video=VideoConfig.from_dict(video),
             on_frame=on_frame,
             max_onframe_failures=max_onframe_failures,
+            control_substeps=control_substeps,
         )
 
     def start_policy(

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -276,6 +276,16 @@ class MuJoCoSimEngine(
         with self._lock:
             self._apply_sim_action(robot_name, action, n_substeps=n_substeps)
 
+    def physics_timestep(self) -> float | None:
+        """Physics integration timestep (seconds) of the active world.
+
+        Lets :class:`PolicyRunner` substep at the control rate so position-
+        servo arms track each action. Returns ``None`` when no world exists.
+        """
+        if self._world is None:
+            return None
+        return float(self._world.timestep)
+
     # World Management
 
     def _cheap_robot_count(self) -> int:
@@ -1870,6 +1880,7 @@ class MuJoCoSimEngine(
         n_steps: int | None = None,
         max_steps: int | None = None,
         max_onframe_failures: int | None = None,
+        control_substeps: int | None = None,
     ) -> dict[str, Any]:
         """MuJoCo ``run_policy`` override: pre-flight world check + graceful stop.
 
@@ -1899,6 +1910,7 @@ class MuJoCoSimEngine(
                 n_steps=n_steps,
                 max_steps=max_steps,
                 max_onframe_failures=max_onframe_failures,
+                control_substeps=control_substeps,
             )
         finally:
             if self._world is not None and robot_name in self._world.robots:

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -258,6 +258,7 @@ class PolicyRunner:
         video: VideoConfig | None = None,
         on_frame: OnFrame | None = None,
         max_onframe_failures: int | None = None,
+        control_substeps: int | None = None,
     ) -> dict[str, Any]:
         """Run ``policy`` on ``robot_name`` for ``duration`` seconds.
 
@@ -359,6 +360,32 @@ class PolicyRunner:
             total_steps = int(duration * control_frequency)
             action_sleep = 1.0 / control_frequency
 
+            # Control-rate substepping: a position-servo robot needs the physics
+            # to advance for the FULL control period (1/control_frequency) after
+            # each action so the joints actually track the commanded target
+            # before the next action overwrites ``ctrl``. With the default
+            # 1 substep/action, the arm only integrates one physics dt (~2 ms)
+            # per action and barely moves — the policy looks like a no-op even
+            # though it is sending valid targets. Derive substeps from the
+            # backend's physics timestep; fall back to 1 when unknown.
+            if control_substeps is not None:
+                n_substeps = max(1, int(control_substeps))
+            else:
+                _dt = None
+                try:
+                    _dt = self.sim.physics_timestep()
+                except Exception:  # noqa: BLE001 - never fail the run on a probe
+                    _dt = None
+                if _dt and _dt > 0 and control_frequency > 0:
+                    n_substeps = max(1, round((1.0 / control_frequency) / _dt))
+                else:
+                    n_substeps = 1
+            logger.info(
+                "PolicyRunner: control_frequency=%.1f Hz, physics substeps/action=%d",
+                control_frequency,
+                n_substeps,
+            )
+
             onframe_failure_limit = (
                 max_onframe_failures if max_onframe_failures is not None else _MAX_CONSECUTIVE_ONFRAME_FAILURES
             )
@@ -373,7 +400,7 @@ class PolicyRunner:
                     if step_count >= total_steps:
                         break
 
-                    self.sim.send_action(action_dict, robot_name=robot_name)
+                    self.sim.send_action(action_dict, robot_name=robot_name, n_substeps=n_substeps)
 
                     if on_frame is not None:
                         try:

--- a/tests/simulation/test_policy_runner.py
+++ b/tests/simulation/test_policy_runner.py
@@ -587,3 +587,65 @@ class TestDispatcherFoldsFlatVideoKeys:
             },
         )
         assert captured["video"] == explicit_video
+
+
+class _SubstepRecordingSim(FakeSim):
+    """FakeSim that reports a fixed physics timestep and records the
+    ``n_substeps`` PolicyRunner passes to each ``send_action`` call."""
+
+    def __init__(self, dt: float = 0.002, joint_names=("j0", "j1", "j2")):
+        super().__init__(joint_names=joint_names)
+        self._dt = dt
+        self.substeps_seen: list[int] = []
+
+    def physics_timestep(self):  # noqa: D102 - see SimEngine.physics_timestep
+        return self._dt
+
+    def send_action(self, action, robot_name=None, n_substeps=1):
+        self.substeps_seen.append(n_substeps)
+        super().send_action(action, robot_name=robot_name, n_substeps=n_substeps)
+
+
+def test_runner_substeps_at_control_rate():
+    """Runner converts control_frequency + physics dt into substeps so a
+    position-servo arm gets a full control period of physics per action.
+
+    15 Hz control with a 2 ms physics dt => round((1/15)/0.002) = 33 substeps.
+    """
+    sim = _SubstepRecordingSim(dt=0.002)
+    policy = MockPolicy()
+    policy.set_robot_state_keys(sim.robot_joint_names("fake_robot"))
+
+    res = PolicyRunner(sim).run("fake_robot", policy, duration=4 / 15, control_frequency=15.0, fast_mode=True)
+    assert res["status"] == "success"
+    assert sim.substeps_seen, "no send_action calls recorded"
+    assert all(s == 33 for s in sim.substeps_seen), sim.substeps_seen
+
+
+def test_runner_control_substeps_override():
+    """Explicit ``control_substeps`` wins over the auto-derived value."""
+    sim = _SubstepRecordingSim(dt=0.002)
+    policy = MockPolicy()
+    policy.set_robot_state_keys(sim.robot_joint_names("fake_robot"))
+
+    PolicyRunner(sim).run(
+        "fake_robot",
+        policy,
+        duration=0.2,
+        control_frequency=15.0,
+        fast_mode=True,
+        control_substeps=7,
+    )
+    assert all(s == 7 for s in sim.substeps_seen), sim.substeps_seen
+
+
+def test_runner_falls_back_to_one_substep_when_dt_unknown():
+    """A backend that returns ``None`` from physics_timestep => 1 substep
+    (preserves the legacy single-step behaviour)."""
+    sim = _SubstepRecordingSim(dt=0.002)
+    sim.physics_timestep = lambda: None  # type: ignore[assignment]
+    policy = MockPolicy()
+    policy.set_robot_state_keys(sim.robot_joint_names("fake_robot"))
+
+    PolicyRunner(sim).run("fake_robot", policy, duration=0.2, control_frequency=15.0, fast_mode=True)
+    assert all(s == 1 for s in sim.substeps_seen), sim.substeps_seen


### PR DESCRIPTION
## Summary

`PolicyRunner` advanced physics by **one substep (~2 ms)** per policy action. A
position-servo robot (Franka/Panda, most MuJoCo arms) needs the **full control
period** (`1/control_frequency`) of physics after each action to track the
commanded joint target before the next action overwrites `ctrl`. With a single
substep the arm integrates only one physics `dt` per action and barely moves —
so a perfectly valid VLA policy **looks like a no-op**.

This was found while recording NVIDIA Cosmos 3 DROID rollouts in MuJoCo: the cube
dropped and the arm hardly moved, even though the policy was returning valid
joint-target chunks.

## Fix

- `SimEngine.physics_timestep()` — new ABC method (default `None`); MuJoCo
  override returns the world timestep.
- `PolicyRunner` derives `n_substeps = round((1/control_frequency) / dt)` from
  the backend timestep and passes it to `send_action`.
- New optional `control_substeps=` override on `run_policy` / `start_policy`.
- Falls back to **1 substep** when the backend can't report a timestep — legacy
  behaviour preserved, zero change for non-MuJoCo backends.

## Verified

Real MuJoCo Franka rollout driven by `Cosmos3-Nano-Policy-DROID`:

| | before | after |
| --- | --- | --- |
| max joint travel / 24-step episode | 0.3 rad | **3.6 rad** |
| sim time / episode | 0.03 s | **1.58 s** |

+3 unit tests: auto-substep from physics dt, explicit `control_substeps`
override, and unknown-`dt` fallback to 1.

## Scope

Backend-agnostic sim fix — benefits **every** position-controlled policy
(GR00T, LeRobot, Cosmos 3). Split out of the Cosmos 3 policy PR (#317) so it can
land independently.
