### PR TITLE
docs(mesh): pin IoT Subscribe/Receive asymmetry (closes #253)

### DIFF
--- a/strands_robots/mesh/iot/provision.py
+++ b/strands_robots/mesh/iot/provision.py
@@ -194,6 +194,17 @@ _ROBOT_POLICY_DOC: dict[str, Any] = {
             ],
         },
         {
+            # Design note: Subscribe is intentionally broader than Receive.
+            # ``AllowOwnSubscriptions`` permits a robot to Subscribe to any of
+            # its own ``${ThingName}/*`` topics (e.g. health, state,
+            # safety/event), but ``AllowReceiveScoped`` below does NOT grant
+            # Receive on those. The broker therefore silently drops inbound
+            # messages on them. This is deliberate: health/state/safety-event
+            # are publish-only at the robot (the operator consumes them), so
+            # the robot never needs to Receive its own copy. Do NOT widen
+            # ``AllowReceiveScoped`` back to ``${ThingName}/*`` to "fix" this
+            # asymmetry -- that re-opens the fleet-eavesdrop surface the narrow
+            # Receive list closes. See issue #253 / PR #228 R5.
             "Sid": "AllowOwnSubscriptions",
             "Effect": "Allow",
             "Action": "iot:Subscribe",

--- a/tests/mesh/test_iot_policy_scope.py
+++ b/tests/mesh/test_iot_policy_scope.py
@@ -70,10 +70,9 @@ class TestRobotPolicy:
             sub_actions = [sub_actions]
         assert "iot:Subscribe" in sub_actions
         # Subscribe covers the broad own-thing wildcard.
-        assert any(
-            r.endswith("topicfilter/strands/${iot:Connection.Thing.ThingName}/*")
-            for r in sub["Resource"]
-        ), "Subscribe should cover own ${ThingName}/* wildcard"
+        assert any(r.endswith("topicfilter/strands/${iot:Connection.Thing.ThingName}/*") for r in sub["Resource"]), (
+            "Subscribe should cover own ${ThingName}/* wildcard"
+        )
         # Receive must NOT grant the broad own-thing wildcard nor health/state.
         recv_joined = "\n".join(recv["Resource"])
         assert "${iot:Connection.Thing.ThingName}/*" not in recv_joined, (

--- a/tests/mesh/test_iot_policy_scope.py
+++ b/tests/mesh/test_iot_policy_scope.py
@@ -58,6 +58,31 @@ class TestRobotPolicy:
         assert "/strands/safety/estop" in joined
         assert "/strands/+/presence" in joined
 
+    def test_own_health_subscribable_but_not_receivable(self):
+        """Issue #253: Subscribe permits own ${ThingName}/* (incl. health)
+        while Receive deliberately omits it, so the broker drops inbound
+        copies. Pins the asymmetry against a future Receive-widening."""
+        sids = _statements_by_sid(_ROBOT_POLICY_DOC)
+        sub = sids["AllowOwnSubscriptions"]
+        recv = sids["AllowReceiveScoped"]
+        sub_actions = sub["Action"]
+        if isinstance(sub_actions, str):
+            sub_actions = [sub_actions]
+        assert "iot:Subscribe" in sub_actions
+        # Subscribe covers the broad own-thing wildcard.
+        assert any(
+            r.endswith("topicfilter/strands/${iot:Connection.Thing.ThingName}/*")
+            for r in sub["Resource"]
+        ), "Subscribe should cover own ${ThingName}/* wildcard"
+        # Receive must NOT grant the broad own-thing wildcard nor health/state.
+        recv_joined = "\n".join(recv["Resource"])
+        assert "${iot:Connection.Thing.ThingName}/*" not in recv_joined, (
+            "Receive must not widen to own ${ThingName}/* (issue #253)"
+        )
+        assert "${iot:Connection.Thing.ThingName}/health" not in recv_joined
+        assert "${iot:Connection.Thing.ThingName}/state" not in recv_joined
+        assert "${iot:Connection.Thing.ThingName}/safety/event" not in recv_joined
+
     def test_publish_still_scoped_to_own_thing(self):
         """Sanity: publish remains scoped to the robot's own topics."""
         sids = _statements_by_sid(_ROBOT_POLICY_DOC)


### PR DESCRIPTION
Closes #253.

## What
Documents the deliberate asymmetry between `AllowOwnSubscriptions` (Subscribe to own `${ThingName}/*`) and `AllowReceiveScoped` (Receive only `/cmd`, `/response/*`, broadcast, estop, presence) in the robot IoT policy, and pins it with a regression test.

## Findings (issue action items)
1. Grepped `iot_transport.py` subscribe paths: no code round-trips a message through own `${ThingName}/health|state|safety/event` and relies on the local subscriber receiving it. The narrow Receive list is a no-op for runtime behavior -- those topics are publish-only at the robot. No bug, just a doc/pin gap.
2. Added a design-note comment block on `AllowOwnSubscriptions` in `strands_robots/mesh/iot/provision.py` explaining the intent and warning against widening Receive back to `${ThingName}/*`.
3. Added regression test `test_own_health_subscribable_but_not_receivable` in `tests/mesh/test_iot_policy_scope.py` asserting Subscribe covers own `${ThingName}/*` while Receive omits the broad wildcard and health/state/safety-event.

## Test
```
hatch run python -m pytest tests/mesh/test_iot_policy_scope.py -k "asymmetry or own_health or scoped_receive" -q
======================= 2 passed, 7 deselected in 0.82s ========================
```
