### PR TITLE
docs(mesh): publish CA pin rotation runbook (closes #250)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,3 +239,16 @@ Corrections from code review that apply to all future contributions:
 - **Especially `pypa/gh-action-pypi-publish`** — it uses a moving `release/v1`
   branch, which is exactly the supply-chain pattern that the `tj-actions/changed-files`
   incident exploited. This pin is non-negotiable.
+
+### Operational Runbooks for Security Pins
+- **A static security pin must ship with a rotation runbook, not just a recompute
+  command.** A docstring one-liner that recomputes a pin is necessary but not
+  sufficient; on-call at 3 AM needs a documented grace-period strategy. For the
+  Amazon Root CA1 pin (`provision._AMAZON_ROOT_CA1_PINS`) the runbook lives in
+  README.md > "CA Pin Rotation Runbook": dual-pin tuple during the overlap, ship
+  the new pin first, drop the old pin in a follow-up release after fleet uptake,
+  and use `STRANDS_MESH_CA_PINS` only as an emergency out-of-band override.
+- **Make the accepted-pin set a collection, never a scalar.** `_resolve_ca_pins()`
+  returns a `frozenset` so the dual-pin grace period is expressible. Any future
+  pinned fingerprint (other roots, signing keys) should follow the same
+  multi-value shape so rotation never requires a flag-day deploy.

--- a/README.md
+++ b/README.md
@@ -592,6 +592,45 @@ agent.tool.gr00t_inference(action="stop", port=8000)
 | `STRANDS_GROOT_WIRE_LOG` | Path to a directory where `Gr00tPolicy` will dump pre-inference observations + post-inference action chunks as pickle files (one per `get_actions` call, named `{local,service}_call{N:04d}.pkl`). Used by the #187 bisection plan to verify whether LOCAL and SERVICE inference paths send byte-identical observations to the model. Run an eval once with each mode into the same dir, then `np.allclose` matching files. | unset |
 | `STRANDS_GROOT_WIRE_LOG_MAX_CALLS` | Cap on number of wire-payload dumps per process when `STRANDS_GROOT_WIRE_LOG` is set. Prevents multi-GB pickle archives on long evals. The first few calls are enough to bisect a divergence. | `10` |
 
+### CA Pin Rotation Runbook
+
+The IoT provisioner downloads `AmazonRootCA1.pem` over HTTPS and pins its
+SHA-256 fingerprint (`strands_robots/mesh/iot/provision._AMAZON_ROOT_CA1_PINS`)
+before trusting the bytes. Because the pin is static, an AWS-side root CA
+rotation needs an operational plan. On-call at 3 AM should follow this runbook,
+not reverse-engineer it from a docstring.
+
+**Recompute the pin** (run when AWS publishes a new root, or to verify the
+current one):
+
+```bash
+python -c "import hashlib, urllib.request as u; \
+print(hashlib.sha256(u.urlopen( \
+'https://www.amazontrust.com/repository/AmazonRootCA1.pem' \
+).read()).hexdigest())"
+```
+
+**Grace-period strategy (dual-pin).** `_AMAZON_ROOT_CA1_PINS` is a tuple, so a
+rotation lands as two releases:
+
+1. Ship a release whose tuple contains **both** the new pin and the old pin.
+   `_resolve_ca_pins()` accepts any pin in the set, so fleets on the old root
+   and fleets that have already seen the new root both verify successfully.
+2. Wait for fleet uptake (track your own deploy rollout; there is no flag day).
+3. Ship a follow-up release that drops the old pin once every fleet member has
+   upgraded and AWS has retired the old root.
+
+**Monitor for upcoming rotations.** Subscribe to AWS security bulletins
+(https://aws.amazon.com/security/security-bulletins/) and the Amazon Trust
+Services repository; AWS publishes root CA deprecation timelines ahead of time.
+
+**Emergency override.** If a rotation lands faster than a code release can ship,
+operators stage the new pin out-of-band via `STRANDS_MESH_CA_PINS`
+(comma-separated 64-char lowercase hex). It is **additive** to the built-in
+tuple, so the old pin keeps working during the overlap. Prefer this over
+`STRANDS_MESH_DISABLE_CA_PIN`, which disables pinning entirely on the download
+path and should be a last resort.
+
 ### Mesh Networking
 
 Every `Robot()` and `Simulation()` constructed in a process is automatically a

--- a/tests/mesh/test_iot_ca_pin_rotation.py
+++ b/tests/mesh/test_iot_ca_pin_rotation.py
@@ -1,0 +1,70 @@
+"""Tests for the CA pin rotation grace-period contract (issue #250).
+
+Issue #250 (Option B) ships a documented rotation runbook for the Amazon
+Root CA1 pin instead of a signed-manifest fetch. The operational guarantee
+the runbook depends on is that the accepted-pin set is a collection, so a
+rotation can keep both the old and the new pin valid during fleet uptake:
+
+* The built-in pin tuple plus a staged second pin from
+  ``STRANDS_MESH_CA_PINS`` both resolve as accepted (dual-pin overlap).
+* Verification accepts a certificate matching either pin in the set.
+* The README publishes the rotation runbook so on-call has a documented
+  procedure rather than a bare recompute command.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from strands_robots.mesh.iot import provision
+
+
+def test_resolve_ca_pins_accepts_both_builtin_and_staged_pin_for_grace_period(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """During a rotation, the built-in pin and a staged STRANDS_MESH_CA_PINS pin coexist."""
+    builtin = set(provision._AMAZON_ROOT_CA1_PINS)
+    assert builtin, "expected at least one built-in pin"
+    staged = "a" * 64  # stand-in for the next root CA1 pin staged out-of-band
+    assert staged not in builtin
+
+    monkeypatch.setenv("STRANDS_MESH_CA_PINS", staged)
+    resolved = provision._resolve_ca_pins()
+
+    assert builtin.issubset(resolved), "old pin must stay valid during overlap"
+    assert staged in resolved, "newly staged pin must also be accepted"
+    assert len(resolved) >= len(builtin) + 1
+
+
+def test_resolve_ca_pins_returns_collection_not_scalar() -> None:
+    """The accepted-pin surface is a set so the dual-pin grace period is expressible."""
+    resolved = provision._resolve_ca_pins()
+    assert isinstance(resolved, frozenset)
+
+
+def test_verify_ca_bytes_accepts_either_pin_during_dual_pin_overlap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cert matching the staged pin verifies even when it is not the built-in pin."""
+    rogue = b"-----BEGIN CERTIFICATE-----\nstaged-root-bytes\n-----END CERTIFICATE-----\n"
+    staged = hashlib.sha256(rogue).hexdigest()
+    assert staged not in set(provision._AMAZON_ROOT_CA1_PINS)
+
+    # Without the staged pin, the rogue cert is rejected.
+    assert provision._verify_ca_bytes(rogue) is False
+
+    # Once staged out-of-band, the same cert is accepted (grace-period overlap).
+    monkeypatch.setenv("STRANDS_MESH_CA_PINS", staged)
+    assert provision._verify_ca_bytes(rogue) is True
+
+
+def test_readme_publishes_ca_pin_rotation_runbook() -> None:
+    """The rotation runbook is documented in README, not just the provision docstring."""
+    readme = Path(__file__).resolve().parents[2] / "README.md"
+    text = readme.read_text(encoding="utf-8")
+    assert "CA Pin Rotation Runbook" in text
+    assert "STRANDS_MESH_CA_PINS" in text
+    assert "dual-pin" in text.lower()


### PR DESCRIPTION
Closes #250.

Ships **Option B** (documented rotation runbook) from the issue rather than the heavier signed-manifest fetch (Option A).

## Changes
- **README.md** — new `### CA Pin Rotation Runbook` section:
  - Promotes the recompute one-liner out of the `provision.py` docstring.
  - Documents the dual-pin grace-period strategy: ship a release with both new and old pins, wait for fleet uptake, drop the old pin in a follow-up release.
  - How to monitor AWS security bulletins for upcoming root CA rotations.
  - `STRANDS_MESH_CA_PINS` emergency out-of-band override guidance (preferred over `STRANDS_MESH_DISABLE_CA_PIN`).
- **AGENTS.md** — Review Learnings entry: a static security pin must ship with a rotation runbook, and the accepted-pin surface must be a collection so the grace period is expressible.
- **tests/mesh/test_iot_ca_pin_rotation.py** — pins the dual-pin contract (acceptance criterion: 'asserts that the dual-pin grace-period state parses correctly').

## Acceptance criteria
- [x] Rotation runbook published in README.md (Option B).
- [x] AGENTS.md learnings entry for the operational-fragility-of-static-pins lesson.
- [x] Pin test `tests/mesh/test_iot_ca_pin_rotation.py` asserts dual-pin grace-period state parses correctly.

## Test output
```
hatch run python -m pytest tests/mesh/test_iot_ca_pin_rotation.py -q
============================== 4 passed in 0.82s ===============================
```