### PR TITLE
test(mesh): fix flaky test_session_config (leaked zenoh MagicMock isolation)

### DIFF
--- a/tests/mesh/conftest.py
+++ b/tests/mesh/conftest.py
@@ -58,3 +58,35 @@ def _default_mesh_auth_mode_none(monkeypatch, request):
         monkeypatch.setenv("STRANDS_MESH_AUTH_MODE", "none")
         # B2: auth_mode=none requires explicit second-factor opt-in.
         monkeypatch.setenv("STRANDS_MESH_I_KNOW_THIS_IS_INSECURE", "1")
+
+
+@pytest.fixture(autouse=True)
+def _restore_real_zenoh_module():
+    """Neutralise a leaked ``zenoh`` MagicMock in ``sys.modules``.
+
+    Several mesh tests install a mock Zenoh via
+    ``patch.dict("sys.modules", {"zenoh": MagicMock()})``. ``patch.dict``
+    restores correctly on its own, but under some full-suite collection
+    orderings a real ``zenoh`` reference can still be displaced by a
+    ``unittest.mock.MagicMock`` that outlives its intended scope. When that
+    happens, :func:`strands_robots.mesh.session._build_config` does a fresh
+    ``import zenoh`` and gets the mock — ``zenoh.Config().get_json(...)``
+    then returns a ``MagicMock`` and ``json.loads(...)`` raises
+    ``TypeError: the JSON object must be str, bytes or bytearray, not
+    MagicMock``.
+
+    This autouse fixture asserts a clean baseline: if ``sys.modules["zenoh"]``
+    is a mock object, drop it so the next ``import zenoh`` re-binds the real
+    wheel (or cleanly raises ImportError where it is genuinely absent).
+    """
+    import sys
+    from unittest.mock import NonCallableMock
+
+    mod = sys.modules.get("zenoh")
+    # Only act on an unambiguous mock: a ``unittest.mock`` instance. Real
+    # ``zenoh`` (an extension module) is never from that package, so this
+    # cannot evict the genuine wheel. Dropping the mock lets the next
+    # ``import zenoh`` re-bind the real module (or cleanly ImportError).
+    if mod is not None and (isinstance(mod, NonCallableMock) or type(mod).__module__ == "unittest.mock"):
+        del sys.modules["zenoh"]
+    yield


### PR DESCRIPTION
## Problem

`tests/mesh/test_session_config.py` intermittently fails in CI with:

```
TypeError: the JSON object must be str, bytes or bytearray, not MagicMock
```

(seen on PR #319's `call-test-lint` run, and reproducible locally under specific full-suite collection orderings).

## Root cause

Several mesh tests install a mock Zenoh via `patch.dict("sys.modules", {"zenoh": MagicMock()})`. `patch.dict` restores correctly on its own, but under some full-suite orderings a `unittest.mock` instance bound to `sys.modules['zenoh']` outlives its intended scope. A later `_build_config()` then does a fresh `import zenoh`, gets the mock, and `zenoh.Config().get_json("namespace")` returns a `MagicMock` → `json.loads(MagicMock)` raises the `TypeError`.

This is **not** a regression in any feature PR — it is a pre-existing cross-test isolation flake. PR #319 happened to surface it.

## Fix

Add an autouse fixture in `tests/mesh/conftest.py` that drops any `unittest.mock` instance bound to `sys.modules['zenoh']` before each mesh test, so the next `import zenoh` re-binds the real wheel (or cleanly `ImportError`s where zenoh is genuinely absent). It can never evict the real extension module — the real `zenoh` is never from the `unittest.mock` package.

## Verification

- With a **deliberately leaked** `zenoh` MagicMock injected before `test_session_config`: **fails without** the fixture, **passes with** it.
- Full mesh suite: **1242 passed, 5 skipped**.