### PR TITLE
fix(sim): strip robot-scene ground plane on attach to stop z-fighting (closes #320)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,9 +58,7 @@ Applies to ``strands_robots.mesh.iot.provision`` and
   ``re.fullmatch``) applied symmetrically across ``provision_robot``,
   ``provision_operator``, and ``teardown_thing``. Rejects path
   separators, dots, spaces, NUL, non-ASCII, and trailing
-  ``
-``/``
-``/``	``. Pre-existing AWS IoT Things containing ``:``
+  ``\n``/``\r``/``\t``. Pre-existing AWS IoT Things containing ``:``
   must be renamed (we deliberately reject ``:`` due to NTFS / classic
   Mac filesystem semantics).
 - **IoT policy scope** — robot/operator policies use explicit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable behavioural changes to `strands-robots` are logged here. Follows
 [Keep a Changelog](https://keepachangelog.com/) conventions.
 
+## Unreleased - #320 (MuJoCo robot-scene ground-plane z-fighting)
+
+### Fixed: broken floor render when a robot asset ships its own ground plane
+
+Robots whose asset MJCF includes its own ground/floor plane (e.g.
+``franka_emika_panda/scene.xml`` ships ``<geom name="floor" type="plane"/>``)
+produced a **severely broken floor** - a flickering checkerboard/triangle mess
+- when added to a world created with ``ground_plane=True`` (the default). Two
+coplanar infinite ground planes at z=0 with different checker materials
+(``grid_mat`` vs the robot's ``groundplane``) caused depth-buffer Z-fighting.
+The artifact corrupted rendered videos, camera observations fed to policies,
+and demos, with no error raised.
+
+``SpecBuilder.attach_robot`` now strips plane geoms from the robot scene MJCF
+before attaching it, so exactly one world-owned ``ground`` plane survives. The
+world ``ground`` plane (configurable via ``create_world(ground_plane=...)``)
+is the single source of truth; robots contribute only their own
+bodies/joints/actuators/sensors.
+
 ## Unreleased - #228 (AWS IoT provisioning hardening)
 
 ### Changed: default presigned-URL TTL for camera offload
@@ -40,7 +59,8 @@ Applies to ``strands_robots.mesh.iot.provision`` and
   ``provision_operator``, and ``teardown_thing``. Rejects path
   separators, dots, spaces, NUL, non-ASCII, and trailing
   ``
-``/````/``	``. Pre-existing AWS IoT Things containing ``:``
+``/``
+``/``	``. Pre-existing AWS IoT Things containing ``:``
   must be renamed (we deliberately reject ``:`` due to NTFS / classic
   Mac filesystem semantics).
 - **IoT policy scope** — robot/operator policies use explicit

--- a/strands_robots/simulation/mujoco/spec_builder.py
+++ b/strands_robots/simulation/mujoco/spec_builder.py
@@ -413,6 +413,17 @@ class SpecBuilder:
 
         robot_spec = mujoco.MjSpec.from_file(str(robot_file_path))
 
+        # Strip the robot scene's own ground/floor plane(s) before attaching.
+        # Many menagerie scenes (e.g. franka_emika_panda/scene.xml) ship a
+        # ``floor`` plane at z=0; merged in alongside the world's own ``ground``
+        # plane (also z=0) it produces two coplanar infinite planes with
+        # different checker materials -> depth-buffer Z-fighting and a broken
+        # floor render. The world ``ground`` plane (configurable via
+        # ``create_world(ground_plane=...)``) is the single source of truth;
+        # robots contribute only their own bodies/joints/actuators. See #320.
+        for plane in [g for g in robot_spec.geoms if g.type == mujoco.mjtGeom.mjGEOM_PLANE]:
+            robot_spec.delete(plane)
+
         # Collect source joint names BEFORE attach - attach mutates the child
         # spec in-place (the child gets reparented).
         source_joint_names: list[str] = []

--- a/tests/simulation/mujoco/test_spec_builder.py
+++ b/tests/simulation/mujoco/test_spec_builder.py
@@ -353,6 +353,66 @@ class TestAttachRobot:
         # (simpler: compile works at all - spec.attach validates positions)
         assert bid >= 0
 
+    def test_attach_robot_strips_robot_scene_ground_plane(self, tmp_path):
+        """A robot scene that ships its own ``floor`` plane must not add a
+        second coplanar ground plane (issue #320).
+
+        Many menagerie scenes (e.g. franka_emika_panda/scene.xml) include a
+        ``floor`` plane at z=0. Attached alongside the world's own ``ground``
+        plane (also z=0) it caused two coplanar infinite planes with different
+        materials -> depth-buffer Z-fighting / broken floor render.
+        ``attach_robot`` now strips plane geoms from the robot scene so exactly
+        one world-owned ``ground`` plane survives.
+        """
+        robot_with_floor = """
+        <mujoco model="arm_with_floor">
+          <compiler angle="radian"/>
+          <worldbody>
+            <geom name="floor" size="0 0 0.05" type="plane"/>
+            <body name="base" pos="0 0 0.1">
+              <joint name="pan" type="hinge" axis="0 0 1"/>
+              <geom type="cylinder" size="0.05 0.05"/>
+            </body>
+          </worldbody>
+          <actuator>
+            <position name="pan_act" joint="pan" kp="50"/>
+          </actuator>
+        </mujoco>
+        """
+        path = tmp_path / "arm_with_floor.xml"
+        path.write_text(robot_with_floor)
+
+        scene = SpecBuilder.build(SimWorld())  # ground_plane=True by default
+        robot = SimRobot(name="arm1", urdf_path=str(path), position=[0.0, 0.0, 0.0])
+        SpecBuilder.attach_robot(scene, robot, str(path))
+
+        model = scene.compile()
+        plane_labels = [
+            mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_GEOM, g)
+            for g in range(model.ngeom)
+            if model.geom_type[g] == mujoco.mjtGeom.mjGEOM_PLANE
+        ]
+        assert len(plane_labels) == 1, f"expected exactly one ground plane, got {plane_labels}"
+        assert plane_labels == ["ground"], f"the surviving plane must be the world ground, got {plane_labels}"
+
+        # The robot's own body/joint/actuator must still be present.
+        assert mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, "arm1/pan") >= 0
+        assert mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, "arm1/pan_act") >= 0
+
+    def test_attach_robot_without_floor_is_unchanged(self, arm_path):
+        """A robot scene with no plane geom attaches normally - the strip is a
+        no-op and the single world ``ground`` plane survives."""
+        scene = SpecBuilder.build(SimWorld())
+        robot = SimRobot(name="arm1", urdf_path=arm_path, position=[0.0, 0.0, 0.0])
+        SpecBuilder.attach_robot(scene, robot, arm_path)
+        model = scene.compile()
+        planes = [
+            mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_GEOM, g)
+            for g in range(model.ngeom)
+            if model.geom_type[g] == mujoco.mjtGeom.mjGEOM_PLANE
+        ]
+        assert planes == ["ground"]
+
 
 # from_mjcf_string / from_file
 


### PR DESCRIPTION
## Problem (closes #320)

When a robot whose asset MJCF ships its own ground plane (e.g. `franka_emika_panda/scene.xml`) is added to a world created with `ground_plane=True` (the default), the renderer shows a **severely broken floor** -- a flickering checkerboard/triangle mess radiating from under the robot. The robot itself renders fine.

**Root cause:** two coplanar infinite ground planes at z=0 with different checker materials -> depth-buffer **Z-fighting**.

```python
# after create_world() + add_robot(data_config="panda"):
# 2 PLANE geoms, BOTH at z=0:
#   ('ground',    [0,0,0])   <- world (SpecBuilder.build, ground_plane=True)
#   ('arm/floor', [0,0,0])   <- from franka_emika_panda/scene.xml
```

Impact: any robot whose menagerie scene includes a `floor` plane produces broken floor renders out of the box -- corrupting recorded videos, camera observations fed to policies, and demos. Silent (no error).

## Fix

`SpecBuilder.attach_robot` now strips plane geoms from the robot scene MJCF right after loading it, so exactly **one** world-owned `ground` plane survives:

```python
robot_spec = mujoco.MjSpec.from_file(str(robot_file_path))
for plane in [g for g in robot_spec.geoms if g.type == mujoco.mjtGeom.mjGEOM_PLANE]:
    robot_spec.delete(plane)
```

The world `ground` plane (configurable via `create_world(ground_plane=...)`) is the single source of truth; robots contribute only their own bodies/joints/actuators/sensors.

## Verification

On `data_config="panda"` (mujoco 3.9.0): planes go from `['ground', 'arm/floor']` -> `['ground']`; robot bodies/joints/actuators intact (8 actuators).

**2 regression tests** added to `tests/simulation/mujoco/test_spec_builder.py`:
- `test_attach_robot_strips_robot_scene_ground_plane` -- synthetic robot MJCF that ships a `floor` plane; asserts only `ground` survives + robot joint/actuator present.
- `test_attach_robot_without_floor_is_unchanged` -- strip is a no-op for plane-less robots.

Full `test_spec_builder.py`: 32 passed. ruff check + format clean. No asset download required.

Surfaced during Cosmos 3 rollout rendering (PR #317); independent of any policy.

---

## S13 Review Rounds

| Round | Concern | Fix Commit | Pin Test |
|-------|---------|-----------|----------|
| R1 | CHANGELOG inline-code whitespace artifact (literal newline/tab in backtick sequence broke rendered markdown) | [`7291eab`](https://github.com/strands-labs/robots/pull/360/commits/7291eabceed1741148c8fb9814f82ab724aff0b2) | N/A (doc rendering fix) |
| R2 | No blocking concerns. Reviewer confirmed ready to merge. 5 new [FOLLOW-UP] threads tracked below for v0.4.1. | -- | -- |

### Follow-ups tracked for v0.4.1

**Tracking issue: #363** (`tech-debt(sim-groundplane): v0.4.1 polish bundle ... (deferred from #320/#360)`) — filed to satisfy the R2 merge condition ("ready to merge once follow-ups are tracked"). Mirrors the existing bundle convention (#330, #331).

| # | Thread | Concern | Status |
|---|--------|---------|--------|
| 1 | spec_builder.py:424 | Conditional strip when `ground_plane=False` (unconditional strip removes the only floor in opt-out case) | Tracked in #363 |
| 2 | spec_builder.py:423 | `logger.debug()` on plane strip for debuggability | Tracked in #363 |
| 3 | spec_builder.py:422 | Narrow predicate to z=0 axis-aligned planes (theoretical concern, no real menagerie asset affected today) | Tracked in #363 |
| 4 | test_spec_builder.py:388 | `tests_integ/` test with real menagerie download (panda) | Tracked in #363 |
| 5 | CHANGELOG.md:61 | Escape sequence rendering nit (backslash-n vs literal) | Skip (cosmetic, unambiguous in context) |

---
*Submitted via autonomous maintainer workflow on behalf of @cagataycali. AI-generated; please review.*