### PR TITLE
docs: rewrite README for v0.x (Robot() factory, mesh, sim) + future-proof counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ robot = Robot("so100", mode="real", port="/dev/ttyACM0")
   plus classical motion planners, MPC, and scripted controllers behind one ABC.
 - **Mesh networking built in.** Every robot is a Zenoh peer. `tell()` another
   robot what to do; broadcast an E-STOP; bridge to AWS IoT Core for fleets.
-- **64-action simulation tool.** World building, physics, rendering,
+- **60+ action simulation tool.** World building, physics, rendering,
   domain randomization, and LeRobotDataset recording — all agent-callable.
 - **One mental model.** Sim and hardware share the same policy interface,
   the same mesh, and the same natural-language control surface.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
   </p>
 </div>
 
-`strands-robots` gives a [Strands Agent](https://github.com/strands-agents/sdk-python)
+`strands-robots` gives a [Strands Agent](https://github.com/strands-agents/harness-sdk)
 hands. One `Robot()` call returns either a **MuJoCo simulation** (default, no GPU,
 no hardware) or a **real hardware robot** — both drivable in natural language,
 both auto-joined to a peer-to-peer **mesh** so fleets coordinate out of the box.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ both auto-joined to a peer-to-peer **mesh** so fleets coordinate out of the box.
 from strands import Agent
 from strands_robots import Robot
 
-robot = Robot("so100")          # MuJoCo sim by default — safe, no hardware
+robot = Robot("so100") # MuJoCo sim by default — safe, no hardware
 agent = Agent(tools=[robot])
 agent("Pick up the red cube")
 ```
@@ -55,7 +55,7 @@ robot = Robot("so100", mode="real", port="/dev/ttyACM0")
 
 - **Sim-first, safe by default.** `Robot("so100")` spins up a MuJoCo world. You
   never accidentally drive real servos — `mode="real"` is an explicit opt-in.
-- **68 robots, 8 categories.** Arms, humanoids, quadrupeds, hands, drones,
+- **50+ robots, 8 categories.** Arms, humanoids, quadrupeds, hands, drones,
   bimanual rigs — resolved from a single registry with auto-download of assets.
 - **Any policy.** VLA models (NVIDIA GR00T, LeRobot ACT/Pi0/SmolVLA/Diffusion),
   plus classical motion planners, MPC, and scripted controllers behind one ABC.
@@ -215,7 +215,7 @@ Safety/validation rules:
 
 ## Supported robots
 
-68 robots across 8 categories, resolved from
+50+ robots across 8 categories, resolved from
 [`registry/robots.json`](strands_robots/registry/robots.json). Assets
 (MJCF + meshes) auto-download from
 [robot_descriptions](https://github.com/robot-descriptions/robot_descriptions.py)
@@ -235,7 +235,7 @@ first use. List them at runtime with `from strands_robots import list_robots; li
 
 **Hardware-capable** (drivable with `mode="real"` via LeRobot): `so100`,
 `so101`, `koch`, `omx`, `hope_jr`, `aloha`, `bi_openarm`, `reachy2`,
-`unitree_g1`, `lekiwi`, `earthrover`. All 68 are simulatable.
+`unitree_g1`, `lekiwi`, `earthrover`. All are simulatable.
 
 ## Tools reference
 
@@ -438,7 +438,7 @@ Reference cuRobo / MoveIt2 implementations are tracked on the
 ## Simulation (MuJoCo)
 
 `Robot("so100")` (sim mode) returns a `Simulation` — a MuJoCo-backed AgentTool
-exposing **64 actions** for world composition, physics, rendering, policy
+exposing **50+ actions** for world composition, physics, rendering, policy
 execution, and dataset recording. Build it directly when you want full control:
 
 ```python
@@ -457,7 +457,7 @@ frame = sim.render(camera_name="topdown")   # {status, content:[text, image]}
 ```
 
 <details>
-<summary><b>The 64 actions, grouped</b></summary>
+<summary><b>The actions, grouped</b></summary>
 
 - **World & scene**: `create_world`, `load_scene`, `replace_scene_mjcf`,
   `patch_scene_mjcf`, `reset`, `get_state`, `save_state`, `load_state`,
@@ -622,7 +622,7 @@ strands_robots/
 │   ├── mock.py            # MockPolicy (non-VLA reference)
 │   ├── groot/             # NVIDIA GR00T (ZMQ/HTTP client + data configs)
 │   └── lerobot_local/     # Direct HuggingFace inference (RTC, processors)
-├── registry/              # robots.json (68) + policies.json + loaders
+├── registry/              # robots.json (50+) + policies.json + loaders
 ├── simulation/
 │   ├── base.py            # SimEngine ABC
 │   ├── factory.py         # create_simulation() + backend registry

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ create_policy("lerobot/act_aloha_sim_transfer_cube")   # local HF inference
 | Provider | Backend | Notes |
 |----------|---------|-------|
 | `mock` | none | Sinusoidal trajectories; `requires_images=False` (~10x faster) |
-| `groot` | NVIDIA GR00T N1.5/N1.6/N1.7 | ZMQ or HTTP to a Docker inference service |
+| `groot` | NVIDIA GR00T N1.5/N1.6/N1.7 | Service mode (ZMQ to a Docker container) or local in-process (`model_path=`) |
 | `lerobot_local` | HuggingFace | Direct ACT / Pi0 / SmolVLA / Diffusion inference, no server |
 
 ```mermaid
@@ -619,6 +619,15 @@ hatch run format        # ruff check --fix + ruff format
 
 Python 3.12+ required. See [AGENTS.md](AGENTS.md) for conventions and the
 accumulated code-review learnings.
+
+## Security
+
+Found a vulnerability? **Do not** open a public issue. Follow the disclosure
+process in [SECURITY.md](SECURITY.md) (AWS VDP / HackerOne).
+
+Note the `trust_remote_code` gate on `lerobot_local` (see
+[Policy providers](#policy-providers)) and the mesh CA-pinning / thing-name
+validation controls in the [Configuration](#configuration) matrix.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ robot = Robot("so100", mode="real", port="/dev/ttyACM0")
 - **Sim-first, safe by default.** `Robot("so100")` spins up a MuJoCo world. You
   never accidentally drive real servos — `mode="real"` is an explicit opt-in.
 - **50+ robots, 8 categories.** Arms, humanoids, quadrupeds, hands, drones,
-  bimanual rigs — resolved from a single registry with auto-download of assets.
+  bimanual rigs - resolved from a single registry with auto-download of assets.
 - **Any policy.** VLA models (NVIDIA GR00T, LeRobot ACT/Pi0/SmolVLA/Diffusion),
   plus classical motion planners, MPC, and scripted controllers behind one ABC.
 - **Mesh networking built in.** Every robot is a Zenoh peer. `tell()` another

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
     ◆ <a href="https://github.com/google-deepmind/mujoco">MuJoCo</a>
     ◆ <a href="https://github.com/NVIDIA/Isaac-GR00T">NVIDIA GR00T</a>
     ◆ <a href="https://github.com/huggingface/lerobot">LeRobot</a>
+    ◆ <a href="https://github.com/strands-labs/robots-sim">Robots Sim</a>
     ◆ <a href="https://github.com/orgs/strands-labs/projects/2">Project Board</a>
   </p>
 </div>

--- a/README.md
+++ b/README.md
@@ -666,7 +666,7 @@ it is the source of truth for roadmap and follow-ups.
 
 ## License
 
-Apache-2.0 — see [LICENSE](LICENSE).
+Apache-2.0 - see [LICENSE](LICENSE).
 
 ## Links
 

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ AgentTool returning `{"status", "content"}`.
 | `start` | `instruction`, `policy_port`, `duration` | Non-blocking async start |
 | `status` | - | Current task status |
 | `stop` | - | Interrupt running task (emergency stop) |
-
+In sim mode the same tool exposes the 64 Simulation actions — see Simulation (MuJoCo).
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -510,7 +510,7 @@ them — so the agent learns the contract without crashing the process.
 ## Mesh networking
 
 Every `Robot()` and `Simulation()` is automatically a peer on a local Zenoh
-mesh — no setup. Peers on the same LAN discover each other via multicast
+mesh - no setup. Peers on the same LAN discover each other via multicast
 scouting, sharing a single ref-counted `zenoh.Session` per process.
 
 ```python

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ both auto-joined to a peer-to-peer **mesh** so fleets coordinate out of the box.
 from strands import Agent
 from strands_robots import Robot
 
-robot = Robot("so100") # MuJoCo sim by default — safe, no hardware
+robot = Robot("so100") # MuJoCo sim by default - no hardware needed
 agent = Agent(tools=[robot])
 agent("Pick up the red cube")
 ```

--- a/README.md
+++ b/README.md
@@ -432,8 +432,6 @@ register_policy("reach", lambda: ReachPolicy, aliases=["lerp"])
 policy = create_policy("reach")
 ```
 
-Reference cuRobo / MoveIt2 implementations are tracked on the
-[project board](https://github.com/orgs/strands-labs/projects/2).
 
 ## Simulation (MuJoCo)
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ pip install -e ".[all,dev]"
 from strands import Agent
 from strands_robots import Robot
 
-robot = Robot("so100")          # MuJoCo simulation
+robot = Robot("so100") # MuJoCo simulation
 agent = Agent(tools=[robot])
 agent("Wave the arm using the mock policy for 200 steps, then render a top-down view")
 ```

--- a/README.md
+++ b/README.md
@@ -344,6 +344,33 @@ classDiagram
     Policy <|-- YourPolicy
 ```
 
+<details>
+<summary><b>GR00T data configs (embodiment schemas)</b></summary>
+
+A `data_config` defines the video + state keys GR00T expects for an
+embodiment. 27 ship in
+[`policies/groot/data_configs.json`](strands_robots/policies/groot/data_configs.json);
+the common ones:
+
+| Config | Cameras | Description |
+|--------|---------|-------------|
+| `so100` / `so101` | 1 (`video.webcam`) | Single-arm, single camera |
+| `so100_dualcam` / `so101_dualcam` | 2 (front + wrist) | Single-arm, dual camera |
+| `so100_4cam` | 4 (front, wrist, top, side) | Single-arm, quad camera |
+| `so101_tricam` | 3 (front, wrist, side) | Single-arm, tri camera |
+| `fourier_gr1_arms_only` | 1 (ego) | Fourier GR-1 bimanual arms + hands |
+| `unitree_g1` | 1 (ego) | G1 upper body (arms + hands) |
+| `unitree_g1_full_body` / `_locomanip` | - | G1 legs + waist + arms + hands |
+| `bimanual_panda_gripper` | 3 | Dual Franka, EEF pose + gripper |
+| `libero_panda` | 2 (image + wrist) | LIBERO benchmark Panda |
+| `oxe_droid` / `oxe_google` / `oxe_widowx` | 1-2 | Open X-Embodiment schemas |
+| `agibot_*` / `galaxea_r1_pro` | 3 | AgiBot / Galaxea humanoids |
+
+Pick the config matching your robot's camera + state layout; pass it as
+`data_config=` to `Robot(...)`, `gr00t_inference(...)`, or `create_policy("groot", ...)`.
+
+</details>
+
 > **Security:** `lerobot_local` loads HuggingFace models with
 > `trust_remote_code=True` (arbitrary code execution). You must opt in with
 > `export STRANDS_TRUST_REMOTE_CODE=1`. Only load models you trust.

--- a/README.md
+++ b/README.md
@@ -10,38 +10,72 @@
   </h1>
 
   <h2>
-    Robot Control for Strands Agents
+    Control, simulate, and train robots with natural language
   </h2>
 
   <div align="center">
     <a href="https://pypi.org/project/strands-robots/"><img alt="PyPI Version" src="https://img.shields.io/pypi/v/strands-robots"/></a>
     <a href="https://github.com/strands-labs/robots"><img alt="GitHub stars" src="https://img.shields.io/github/stars/strands-labs/robots"/></a>
     <a href="https://github.com/strands-labs/robots/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/github/license/strands-labs/robots"/></a>
+    <a href="https://github.com/google-deepmind/mujoco"><img alt="MuJoCo" src="https://img.shields.io/badge/MuJoCo-3.x-000000"/></a>
     <a href="https://github.com/NVIDIA/Isaac-GR00T"><img alt="GR00T" src="https://img.shields.io/badge/NVIDIA-GR00T-76B900?logo=nvidia"/></a>
     <a href="https://github.com/huggingface/lerobot"><img alt="LeRobot" src="https://img.shields.io/badge/🤗-LeRobot-yellow"/></a>
   </div>
-  
+
   <p>
     <a href="https://strandsagents.com/">Strands Docs</a>
+    ◆ <a href="https://github.com/google-deepmind/mujoco">MuJoCo</a>
     ◆ <a href="https://github.com/NVIDIA/Isaac-GR00T">NVIDIA GR00T</a>
     ◆ <a href="https://github.com/huggingface/lerobot">LeRobot</a>
-    ◆ <a href="https://github.com/dusty-nv/jetson-containers">Jetson Containers</a>
+    ◆ <a href="https://github.com/orgs/strands-labs/projects/2">Project Board</a>
   </p>
 </div>
 
-Control robots with natural language through [Strands Agents](https://github.com/strands-agents/sdk-python). Integrates [NVIDIA Isaac GR00T](https://github.com/NVIDIA/Isaac-GR00T) for vision-language-action policies and [LeRobot](https://github.com/huggingface/lerobot) for universal robot support.
+`strands-robots` gives a [Strands Agent](https://github.com/strands-agents/sdk-python)
+hands. One `Robot()` call returns either a **MuJoCo simulation** (default, no GPU,
+no hardware) or a **real hardware robot** — both drivable in natural language,
+both auto-joined to a peer-to-peer **mesh** so fleets coordinate out of the box.
 
-## How It Works
+```python
+from strands import Agent
+from strands_robots import Robot
+
+robot = Robot("so100")          # MuJoCo sim by default — safe, no hardware
+agent = Agent(tools=[robot])
+agent("Pick up the red cube")
+```
+
+Swap to physical hardware with one kwarg — the agent code is identical:
+
+```python
+robot = Robot("so100", mode="real", port="/dev/ttyACM0")
+```
+
+## Why strands-robots
+
+- **Sim-first, safe by default.** `Robot("so100")` spins up a MuJoCo world. You
+  never accidentally drive real servos — `mode="real"` is an explicit opt-in.
+- **68 robots, 8 categories.** Arms, humanoids, quadrupeds, hands, drones,
+  bimanual rigs — resolved from a single registry with auto-download of assets.
+- **Any policy.** VLA models (NVIDIA GR00T, LeRobot ACT/Pi0/SmolVLA/Diffusion),
+  plus classical motion planners, MPC, and scripted controllers behind one ABC.
+- **Mesh networking built in.** Every robot is a Zenoh peer. `tell()` another
+  robot what to do; broadcast an E-STOP; bridge to AWS IoT Core for fleets.
+- **64-action simulation tool.** World building, physics, rendering,
+  domain randomization, and LeRobotDataset recording — all agent-callable.
+- **One mental model.** Sim and hardware share the same policy interface,
+  the same mesh, and the same natural-language control surface.
+
+## How it works
 
 ```mermaid
 graph LR
     A[Natural Language<br/>'Pick up the red block'] --> B[Strands Agent]
-    B --> C[Robot Tool]
-    C --> D[Policy Provider<br/>GR00T/Mock]
-    C --> E[LeRobot<br/>Hardware Abstraction]
-    D --> F[Action Chunk<br/>16 timesteps]
-    F --> E
-    E --> G[Robot Hardware<br/>SO-101/GR-1/G1]
+    B --> C[Robot<br/>sim or real]
+    C --> D[Policy Provider<br/>GR00T / LeRobot / planner / mock]
+    D --> E[Action Chunk]
+    E --> F[MuJoCo Sim<br/>or Hardware]
+    F -->|observation| C
 
     classDef input fill:#2ea44f,stroke:#1b7735,color:#fff
     classDef agent fill:#0969da,stroke:#044289,color:#fff
@@ -50,107 +84,8 @@ graph LR
 
     class A input
     class B,C agent
-    class D,F policy
-    class E,G hardware
-```
-
-## Architecture
-
-```mermaid
-flowchart TB
-    subgraph Agent["🤖 Strands Agent"]
-        NL[Natural Language Input]
-        Tools[Tool Registry]
-    end
-
-    subgraph RobotTool["🦾 Robot Tool"]
-        direction TB
-        RT[Robot Class]
-        TM[Task Manager]
-        AS[Async Executor]
-    end
-
-    subgraph Policy["🧠 Policy Layer"]
-        direction TB
-        PA[Policy Abstraction]
-        GP[GR00T Policy]
-        MP[Mock Policy]
-        CP[Custom Policy]
-    end
-
-    subgraph Inference["⚡ Inference Service"]
-        direction TB
-        DC[Docker Container]
-        ZMQ[ZMQ Server :5555]
-        TRT[TensorRT Engine]
-    end
-
-    subgraph Hardware["🔧 Hardware Layer"]
-        direction TB
-        LR[LeRobot]
-        CAM[Cameras]
-        SERVO[Feetech Servos]
-    end
-
-    NL --> Tools
-    Tools --> RT
-    RT --> TM
-    TM --> AS
-    AS --> PA
-    PA --> GP
-    PA --> MP
-    PA --> CP
-    GP --> ZMQ
-    ZMQ --> TRT
-    TRT --> DC
-    AS --> LR
-    LR --> CAM
-    LR --> SERVO
-
-    classDef agentStyle fill:#0969da,stroke:#044289,color:#fff
-    classDef robotStyle fill:#2ea44f,stroke:#1b7735,color:#fff
-    classDef policyStyle fill:#8250df,stroke:#5a32a3,color:#fff
-    classDef infraStyle fill:#bf8700,stroke:#875e00,color:#fff
-    classDef hwStyle fill:#d73a49,stroke:#a72b3a,color:#fff
-
-    class NL,Tools agentStyle
-    class RT,TM,AS robotStyle
-    class PA,GP,MP,CP policyStyle
-    class DC,ZMQ,TRT infraStyle
-    class LR,CAM,SERVO hwStyle
-```
-
-## Quick Start
-
-```python
-from strands import Agent
-from strands_robots import Robot, gr00t_inference
-
-# Create robot with cameras
-robot = Robot(
-    tool_name="my_arm",
-    robot="so101_follower",
-    cameras={
-        "front": {"type": "opencv", "index_or_path": "/dev/video0", "fps": 30},
-        "wrist": {"type": "opencv", "index_or_path": "/dev/video2", "fps": 30}
-    },
-    port="/dev/ttyACM0",
-    data_config="so100_dualcam"
-)
-
-# Create agent with robot tool
-agent = Agent(tools=[robot, gr00t_inference])
-
-# Start GR00T inference service
-agent.tool.gr00t_inference(
-    action="start",
-    checkpoint_path="/data/checkpoints/model",
-    port=8000,
-    data_config="so100_dualcam"
-)
-
-# Control robot with natural language
-agent("Use my_arm to pick up the red block using GR00T policy on port 8000")
+    class D,E policy
+    class F hardware
 ```
 
 ## Installation
@@ -159,123 +94,190 @@ agent("Use my_arm to pick up the red block using GR00T policy on port 8000")
 pip install strands-robots
 ```
 
+The base install is light (numpy, opencv-headless, Pillow). Pull in only the
+extras you need:
+
+| Extra | Installs | Use for |
+|-------|----------|---------|
+| `sim-mujoco` | MuJoCo, robot_descriptions, imageio | Simulation (recommended starting point) |
+| `lerobot` | LeRobot | Real hardware, local VLA inference, dataset recording |
+| `groot-service` | pyzmq, msgpack | NVIDIA GR00T inference client |
+| `mesh` | eclipse-zenoh, json5 | Peer-to-peer robot mesh |
+| `mesh-iot` | awsiotsdk, awscrt, boto3 | AWS IoT Core mesh transport for fleets |
+| `benchmark-libero` | libero | LIBERO benchmark evaluation |
+| `all` | everything above | Kitchen sink |
+
+```bash
+# Most users start here:
+pip install "strands-robots[sim-mujoco]"
+
+# Real hardware + local policies:
+pip install "strands-robots[sim-mujoco,lerobot]"
+
+# Everything:
+pip install "strands-robots[all]"
+```
+
 From source:
 
 ```bash
 git clone https://github.com/strands-labs/robots
 cd robots
-pip install -e .
+pip install -e ".[all,dev]"
 ```
 
-<details>
-<summary><b>🐳 Jetson Container Setup (Required for GR00T Inference)</b></summary>
+## Quick starts
 
-GR00T inference requires the Isaac-GR00T Docker container on Jetson platforms:
-
-```bash
-# Clone jetson-containers
-git clone https://github.com/dusty-nv/jetson-containers
-cd jetson-containers
-
-# Run Isaac GR00T container (background)
-jetson-containers run $(autotag isaac-gr00t) &
-
-# Container exposes inference service on port 5555 (ZMQ) or 8000 (HTTP)
-```
-
-**Tested Hardware:**
-- NVIDIA Thor Dev Kit (Jetpack 7.0)
-- NVIDIA Jetson AGX Orin (Jetpack 6.x)
-
-See [Jetson Deployment Guide](https://github.com/NVIDIA/Isaac-GR00T/blob/main/deployment_scripts/README.md) for TensorRT optimization.
-
-</details>
-
-## Robot Control Flow
-
-```mermaid
-sequenceDiagram
-    participant User
-    participant Agent as Strands Agent
-    participant Robot as Robot Tool
-    participant Policy as GR00T Policy
-    participant HW as Hardware
-
-    User->>Agent: "Pick up the red block"
-    Agent->>Robot: execute(instruction, policy_port)
-    
-    loop Control Loop @ 50Hz
-        Robot->>HW: get_observation()
-        HW-->>Robot: {cameras, joint_states}
-        Robot->>Policy: get_actions(obs, instruction)
-        Policy-->>Robot: action_chunk[16]
-        
-        loop Action Horizon
-            Robot->>HW: send_action(action)
-            Note over Robot,HW: 20ms sleep (50Hz)
-        end
-    end
-    
-    Robot-->>Agent: Task completed
-    Agent-->>User: "✅ Picked up red block"
-```
-
-## Tools Reference
-
-### Robot Tool
-
-The `Robot` class is a Strands AgentTool that provides async robot control with real-time status reporting.
-
-| Action | Parameters | Description | Example |
-|--------|------------|-------------|---------|
-| `execute` | `instruction`, `policy_port`, `duration` | Blocking execution until complete | `"Pick up the cube"` |
-| `start` | `instruction`, `policy_port`, `duration` | Non-blocking async start | `"Wave your arm"` |
-| `status` | - | Get current task status | Check progress |
-| `stop` | - | Interrupt running task | Emergency stop |
-
-**Natural Language Examples:**
+### Simulation (no GPU, no hardware)
 
 ```python
-# Blocking execution (waits for completion)
-agent("Use my_arm to pick up the red block using GR00T policy on port 8000")
+from strands import Agent
+from strands_robots import Robot
 
-# Async execution (returns immediately)
-agent("Start my_arm waving using GR00T on port 8000, then check status")
-
-# Stop running task
-agent("Stop my_arm immediately")
+robot = Robot("so100")          # MuJoCo simulation
+agent = Agent(tools=[robot])
+agent("Wave the arm using the mock policy for 200 steps, then render a top-down view")
 ```
 
-<details>
-<summary><b>Robot Constructor Parameters</b></summary>
+`Robot("so100")` returns a `Simulation` instance — the full 64-action
+simulation AgentTool. Drive it in natural language, or call its methods
+directly (see [Simulation](#simulation-mujoco)).
+
+### Real hardware + GR00T
+
+```python
+from strands import Agent
+from strands_robots import Robot, gr00t_inference
+
+robot = Robot(
+    "so101",
+    mode="real",
+    cameras={
+        "front": {"type": "opencv", "index_or_path": "/dev/video0", "fps": 30},
+        "wrist": {"type": "opencv", "index_or_path": "/dev/video2", "fps": 30},
+    },
+    port="/dev/ttyACM0",
+    data_config="so100_dualcam",
+)
+
+agent = Agent(tools=[robot, gr00t_inference])
+
+# Start the GR00T inference service (Docker, Jetson/x86 GPU)
+agent.tool.gr00t_inference(
+    action="start",
+    checkpoint_path="/data/checkpoints/model",
+    port=8000,
+    data_config="so100_dualcam",
+)
+
+agent("Use so101 to pick up the red block with the GR00T policy on port 8000")
+```
+
+### Local LeRobot policy (no inference server)
+
+```python
+from strands_robots import create_policy
+
+# Direct HuggingFace inference — ACT, Pi0, SmolVLA, Diffusion, ...
+policy = create_policy("lerobot/act_aloha_sim_transfer_cube_human")
+```
+
+## The `Robot()` factory
+
+`Robot()` is a factory, not a wrapper — you get the real backend instance back
+with all its methods.
+
+```python
+Robot("so100")                       # mode="sim"  (default, safe)
+Robot("so100", mode="real")          # explicit hardware opt-in
+Robot("so100", mode="auto")          # probe USB for servos, fall back to sim
+Robot("my_arm", urdf_path="arm.xml") # bring your own MJCF/URDF
+```
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `tool_name` | `str` | required | Name for this robot tool |
-| `robot` | `str\|RobotConfig` | required | Robot type or config |
-| `cameras` | `Dict` | `None` | Camera configuration |
-| `port` | `str` | `None` | Serial port for robot |
-| `data_config` | `str` | `None` | GR00T data config name |
-| `control_frequency` | `float` | `50.0` | Control loop Hz |
-| `action_horizon` | `int` | `8` | Actions per inference |
+| `name` | `str` | required | Robot name or alias (see [Supported robots](#supported-robots)) |
+| `mode` | `str` | `"sim"` | `"sim"`, `"real"`, or `"auto"` (case-insensitive) |
+| `backend` | `str` | `"mujoco"` | Sim backend (Isaac/Newton on the roadmap) |
+| `urdf_path` | `str` | `None` | Explicit MJCF/URDF path (skips registry lookup) |
+| `cameras` | `dict` | `None` | Camera config (**`mode="real"` only**) |
+| `position` | `list[float]` | `[0,0,0]` | Spawn position in the sim world |
+| `data_config` | `str` | name | Observation/action schema name |
+| `mesh` | `bool` | `True` | Auto-join the Zenoh mesh |
+
+Safety/validation rules:
+- **Defaults to sim.** Real hardware is always an explicit `mode="real"`.
+- **`cameras=` is rejected in sim mode** — add sim cameras via the `add_camera`
+  action after creation.
+- **Unknown robot names raise `ValueError`** unless you pass `urdf_path=`.
+- **`STRANDS_ROBOT_MODE`** overrides detection; a typo'd value logs a warning
+  and falls back to sim.
+
+## Supported robots
+
+68 robots across 8 categories, resolved from
+[`registry/robots.json`](strands_robots/registry/robots.json). Assets
+(MJCF + meshes) auto-download from
+[robot_descriptions](https://github.com/robot-descriptions/robot_descriptions.py)
+/ [MuJoCo Menagerie](https://github.com/google-deepmind/mujoco_menagerie) on
+first use. List them at runtime with `from strands_robots import list_robots; list_robots()`.
+
+| Category | Count | Robots |
+|----------|-------|--------|
+| **Arm** | 22 | so100, so101, koch, omx, panda, fr3, fr3_v2, ur5e, ur10e, xarm7, kinova_gen3, kuka_iiwa, sawyer, piper, yam, z1, vx300s, wx250s, arx_l5, openarm, hope_jr, dynamixel_2r |
+| **Humanoid** | 18 | unitree_g1, unitree_h1, unitree_h1_2, apollo, talos, reachy2, rby1, fourier_n1, booster_t1, adam_lite, asimov_v0, cassie, elf2, jvrc, op3, open_duck_mini, toddlerbot_2xc, toddlerbot_2xm |
+| **Mobile** | 13 | spot, go1, unitree_go2, unitree_a1, aliengo, anymal_b, anymal_c, stretch, stretch3, lekiwi, tiago_dual, earthrover, robot_soccer_kit |
+| **Hand** | 8 | shadow_hand, shadow_dexee, allegro_hand, leap_hand, ability_hand, aero_hand, robotiq_2f85, robotiq_2f85_v4 |
+| **Bimanual** | 3 | aloha, bi_openarm, trossen_wxai |
+| **Aerial** | 2 | crazyflie, skydio_x2 |
+| **Expressive** | 1 | reachy_mini |
+| **Mobile manip** | 1 | google_robot |
+
+**Hardware-capable** (drivable with `mode="real"` via LeRobot): `so100`,
+`so101`, `koch`, `omx`, `hope_jr`, `aloha`, `bi_openarm`, `reachy2`,
+`unitree_g1`, `lekiwi`, `earthrover`. All 68 are simulatable.
+
+## Tools reference
+
+Import any of these and pass to `Agent(tools=[...])`. Each is a Strands
+AgentTool returning `{"status", "content"}`.
+
+| Tool | Purpose |
+|------|---------|
+| `Robot(...)` | Universal robot — sim or hardware, async control |
+| `gr00t_inference` | Manage NVIDIA GR00T inference services (Docker lifecycle) |
+| `lerobot_camera` | OpenCV / RealSense camera discovery, capture, record |
+| `lerobot_calibrate` | List, view, back up, restore LeRobot calibrations |
+| `lerobot_teleoperate` | Record demonstrations, replay episodes |
+| `pose_tool` | Store, recall, and execute named robot poses |
+| `serial_tool` | Low-level Feetech servo / raw serial communication |
+| `robot_mesh` | Coordinate robots over the Zenoh mesh (`tell`, `broadcast`, E-STOP) |
+
+<details>
+<summary><b>Robot tool actions</b></summary>
+
+| Action | Parameters | Description |
+|--------|------------|-------------|
+| `execute` | `instruction`, `policy_port`, `duration` | Blocking execution until complete |
+| `start` | `instruction`, `policy_port`, `duration` | Non-blocking async start |
+| `status` | - | Current task status |
+| `stop` | - | Interrupt running task (emergency stop) |
 
 </details>
 
----
+<details>
+<summary><b>GR00T inference tool actions</b></summary>
 
-### GR00T Inference Tool
+| Action | Parameters | Description |
+|--------|------------|-------------|
+| `start` | `checkpoint_path`, `port`, `data_config` | Start inference service |
+| `stop` | `port` | Stop service on port |
+| `status` | `port` | Check service status |
+| `list` | - | List running services |
+| `find_containers` | - | Find GR00T Docker containers |
+| `build_image` / `download_checkpoint` / `start_container` | - | Full container lifecycle orchestration |
 
-Manages GR00T policy inference services running in Docker containers.
-
-| Action | Parameters | Description | Example |
-|--------|------------|-------------|---------|
-| `start` | `checkpoint_path`, `port`, `data_config` | Start inference service | `"Start GR00T on port 8000"` |
-| `stop` | `port` | Stop service on port | `"Stop GR00T on port 8000"` |
-| `status` | `port` | Check service status | `"Is GR00T running?"` |
-| `list` | - | List all running services | `"List inference services"` |
-| `find_containers` | - | Find GR00T containers | `"Find available containers"` |
-
-**TensorRT Acceleration:**
+TensorRT acceleration:
 
 ```python
 agent.tool.gr00t_inference(
@@ -283,168 +285,85 @@ agent.tool.gr00t_inference(
     checkpoint_path="/data/checkpoints/model",
     port=8000,
     use_tensorrt=True,
-    trt_engine_path="gr00t_engine",
-    vit_dtype="fp8",    # ViT: fp16 or fp8
-    llm_dtype="nvfp4",  # LLM: fp16, nvfp4, or fp8
-    dit_dtype="fp8"     # DiT: fp16 or fp8
+    vit_dtype="fp8",     # ViT:  fp16 | fp8
+    llm_dtype="nvfp4",   # LLM:  fp16 | nvfp4 | fp8
+    dit_dtype="fp8",     # DiT:  fp16 | fp8
 )
 ```
 
----
-
-### Camera Tool
-
-LeRobot-based camera management with OpenCV and RealSense support.
-
-| Action | Parameters | Description | Example |
-|--------|------------|-------------|---------|
-| `discover` | - | Find all cameras | `"Discover cameras"` |
-| `capture` | `camera_id`, `save_path` | Single image capture | `"Capture from /dev/video0"` |
-| `capture_batch` | `camera_ids`, `async_mode` | Multi-camera capture | `"Capture from all cameras"` |
-| `record` | `camera_id`, `capture_duration` | Record video | `"Record 10s video"` |
-| `preview` | `camera_id`, `preview_duration` | Live preview | `"Preview camera 0"` |
-| `test` | `camera_id` | Performance test | `"Test camera speed"` |
-
----
-
-### Serial Tool
-
-Low-level serial communication for Feetech servos and custom protocols.
-
-| Action | Parameters | Description | Example |
-|--------|------------|-------------|---------|
-| `list_ports` | - | Discover serial ports | `"List serial ports"` |
-| `feetech_position` | `port`, `motor_id`, `position` | Move servo | `"Move motor 1 to center"` |
-| `feetech_ping` | `port`, `motor_id` | Ping servo | `"Ping motor 1"` |
-| `send` | `port`, `data/hex_data` | Send raw data | `"Send FF FF to robot"` |
-| `monitor` | `port` | Monitor serial data | `"Monitor /dev/ttyACM0"` |
-
----
-
-### Teleoperation Tool
-
-Record demonstrations for imitation learning with LeRobot.
-
-| Action | Parameters | Description | Example |
-|--------|------------|-------------|---------|
-| `start` | `robot_type`, `teleop_type` | Start teleoperation | `"Start teleoperation"` |
-| `stop` | `session_name` | Stop session | `"Stop recording"` |
-| `list` | - | List active sessions | `"List teleop sessions"` |
-| `replay` | `dataset_repo_id`, `replay_episode` | Replay episode | `"Replay episode 5"` |
-
----
-
-### Pose Tool
-
-Store, retrieve, and execute named robot poses.
-
-| Action | Parameters | Description | Example |
-|--------|------------|-------------|---------|
-| `store_pose` | `pose_name` | Save current position | `"Save as 'home'"` |
-| `load_pose` | `pose_name` | Move to saved pose | `"Go to home pose"` |
-| `list_poses` | - | List all poses | `"List saved poses"` |
-| `move_motor` | `motor_name`, `position` | Move single motor | `"Move gripper to 50%"` |
-| `incremental_move` | `motor_name`, `delta` | Small movement | `"Move elbow +5°"` |
-| `reset_to_home` | - | Safe home position | `"Reset to home"` |
-
----
-
-## Supported Robots
-
-| Robot | Config | Cameras | Description |
-|-------|--------|---------|-------------|
-| SO-100/SO-101 | `so100`, `so100_dualcam`, `so100_4cam` | 1-4 | Single arm desktop robot |
-| Fourier GR-1 | `fourier_gr1_arms_only` | 1 | Bimanual humanoid arms |
-| Bimanual Panda | `bimanual_panda_gripper` | 3 | Dual Franka Emika arms |
-| Unitree G1 | `unitree_g1` | 1 | Humanoid robot platform |
+</details>
 
 <details>
-<summary><b>GR00T Data Configurations</b></summary>
+<summary><b>Camera / serial / pose / teleop tool actions</b></summary>
 
-| Config | Video Keys | State Keys | Description |
-|--------|------------|------------|-------------|
-| `so100` | `video.webcam` | `state.single_arm`, `state.gripper` | Single camera |
-| `so100_dualcam` | `video.front`, `video.wrist` | `state.single_arm`, `state.gripper` | Front + wrist |
-| `so100_4cam` | `video.front`, `video.wrist`, `video.top`, `video.side` | `state.single_arm`, `state.gripper` | Quad camera |
-| `fourier_gr1_arms_only` | `video.ego_view` | `state.left_arm`, `state.right_arm`, `state.left_hand`, `state.right_hand` | Humanoid arms |
-| `bimanual_panda_gripper` | `video.right_wrist_view`, `video.left_wrist_view`, `video.front_view` | EEF pos/quat + gripper | Dual arm EEF |
-| `unitree_g1` | `video.rs_view` | `state.left_arm`, `state.right_arm`, `state.left_hand`, `state.right_hand` | G1 humanoid |
+**Camera** — `discover`, `capture`, `capture_batch`, `record`, `preview`, `test`
+**Serial** — `list_ports`, `feetech_position`, `feetech_ping`, `send`, `monitor`
+**Pose** — `store_pose`, `load_pose`, `list_poses`, `move_motor`, `incremental_move`, `reset_to_home`
+**Teleop** — `start`, `stop`, `list`, `replay`
 
 </details>
 
-## Policy Providers
+## Policy providers
+
+All policies implement one ABC — `async get_actions(observation, instruction, **kwargs)`.
+The interface is deliberately agnostic about *how* actions are produced, so it
+fits both VLA models and classical controllers.
+
+```python
+from strands_robots import create_policy
+
+create_policy("mock")                                  # sinusoidal test actions
+create_policy("groot", port=5555)                      # NVIDIA GR00T via ZMQ
+create_policy("zmq://localhost:5555")                  # same, by URL
+create_policy("lerobot/act_aloha_sim_transfer_cube")   # local HF inference
+```
+
+| Provider | Backend | Notes |
+|----------|---------|-------|
+| `mock` | none | Sinusoidal trajectories; `requires_images=False` (~10x faster) |
+| `groot` | NVIDIA GR00T N1.5/N1.6/N1.7 | ZMQ or HTTP to a Docker inference service |
+| `lerobot_local` | HuggingFace | Direct ACT / Pi0 / SmolVLA / Diffusion inference, no server |
 
 ```mermaid
 classDiagram
     class Policy {
         <<abstract>>
-        +get_actions(observation, instruction)
+        +get_actions(obs, instruction, **kwargs)
         +set_robot_state_keys(keys)
+        +requires_images
+        +reset(seed)
         +provider_name
     }
-
-    class Gr00tPolicy {
-        +data_config
-        +policy_client: ZMQ
-        +get_actions()
-    }
-
-    class MockPolicy {
-        +get_actions()
-        Returns random actions
-    }
-
-    class CustomPolicy {
-        +get_actions()
-        Your implementation
-    }
-
+    class Gr00tPolicy
+    class LerobotLocalPolicy
+    class MockPolicy
+    class YourPolicy
     Policy <|-- Gr00tPolicy
+    Policy <|-- LerobotLocalPolicy
     Policy <|-- MockPolicy
-    Policy <|-- CustomPolicy
+    Policy <|-- YourPolicy
 ```
 
-```python
-from strands_robots import create_policy
+> **Security:** `lerobot_local` loads HuggingFace models with
+> `trust_remote_code=True` (arbitrary code execution). You must opt in with
+> `export STRANDS_TRUST_REMOTE_CODE=1`. Only load models you trust.
 
-# GR00T policy (requires inference server)
-policy = create_policy(
-    provider="groot",
-    data_config="so100_dualcam",
-    host="localhost",
-    port=8000
-)
+### Non-VLA policies (motion planners, MPC, scripted)
 
-# Mock policy (for testing)
-policy = create_policy(provider="mock")
-```
+The same interface fits cuRobo, MoveIt2, OMPL, MPC, and pure-IK / scripted
+trajectories — anything mapping `(observation, goal)` to joint targets.
+Non-VLA providers set `requires_images = False` (skip camera rendering) and
+read their goal from **well-known `**kwargs` keys** instead of parsing the
+instruction string:
 
-### Non-VLA Policies (motion planners, MPC, scripted)
-
-The `Policy` ABC is intentionally agnostic about *how* actions are produced.
-The same interface fits VLA-style providers **and** classical motion
-planners (cuRobo, MoveIt2, OMPL), model-predictive controllers, and pure-IK
-or scripted trajectories — anything that maps `(observation, goal)` to a
-list of joint targets.
-
-`MockPolicy` (`strands_robots/policies/mock.py`) is the reference: it sets
-`requires_images = False` so the simulation skips camera rendering (~10x
-throughput at 500Hz), ignores the `instruction` string, and returns a list
-of joint-target dicts.
-
-Non-VLA providers should consume **well-known `**kwargs` keys** instead of
-JSON-encoding goals into the natural-language instruction:
-
-| Key             | Type                       | Meaning                                                                |
-| --------------- | -------------------------- | ---------------------------------------------------------------------- |
-| `target_pose`   | `list[float]`              | Cartesian goal `[x, y, z, qw, qx, qy, qz]` in the robot base frame     |
-| `target_joints` | `dict[str, float]`         | Joint-space goal keyed by joint name (radians / metres)                |
-| `world_update`  | `dict \| None`             | Per-call world refresh for collision-aware planners (depth, mesh, ...) |
+| Key | Type | Meaning |
+|-----|------|---------|
+| `target_pose` | `list[float]` | Cartesian goal `[x, y, z, qw, qx, qy, qz]` in base frame |
+| `target_joints` | `dict[str, float]` | Joint-space goal keyed by joint name (rad / m) |
+| `world_update` | `dict \| None` | Per-call world refresh for collision-aware planners |
 
 Providers MUST ignore unknown `**kwargs` rather than raising, so callers can
-pass shared keys across providers without coupling to a specific backend.
-
-Minimal example — register a planner-style provider at runtime:
+pass shared keys across providers without coupling to a backend.
 
 ```python
 from typing import Any
@@ -469,20 +388,16 @@ class ReachPolicy(Policy):
     def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
         self._keys = list(robot_state_keys)
 
-    async def get_actions(
-        self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any
-    ) -> list[dict[str, Any]]:
+    async def get_actions(self, observation_dict, instruction, **kwargs):
         target = kwargs.get("target_joints")
         if target is None:
             raise ValueError("ReachPolicy requires target_joints kwarg")
-
         state = observation_dict.get("observation.state", [0.0] * len(self._keys))
-        out: list[dict[str, float]] = []
+        out = []
         for s in range(1, self._steps + 1):
             alpha = s / self._steps
-            out.append(
-                {k: (1 - alpha) * state[i] + alpha * target[k] for i, k in enumerate(self._keys)}
-            )
+            out.append({k: (1 - alpha) * state[i] + alpha * target[k]
+                        for i, k in enumerate(self._keys)})
         return out
 
 
@@ -490,229 +405,14 @@ register_policy("reach", lambda: ReachPolicy, aliases=["lerp"])
 policy = create_policy("reach")
 ```
 
-The same shape extends to cuRobo (call `MotionGen.plan_single` with the
-`target_pose` kwarg, cache the trajectory, yield `action_horizon` chunks)
-and MoveIt2 (forward `target_pose` + `joint_state` to a sidecar ROS 2
-service via ZMQ / gRPC).  Reference implementations are tracked separately
-on the [Strands Labs - Robots project board](https://github.com/orgs/strands-labs/projects/2).
-
-## Project Structure
-
-```
-strands-robots/
-├── strands_robots/
-│   ├── __init__.py              # Package exports
-│   ├── robot.py                 # Universal Robot class (AgentTool)
-│   ├── policies/
-│   │   ├── __init__.py          # Policy ABC + factory
-│   │   └── groot/
-│   │       ├── __init__.py      # Gr00tPolicy implementation
-│   │       ├── client.py        # ZMQ inference client
-│   │       └── data_config.py   # Robot embodiment configurations
-│   └── tools/
-│       ├── gr00t_inference.py   # Docker service manager
-│       ├── lerobot_camera.py    # Camera operations
-│       ├── lerobot_calibrate.py # Calibration management
-│       ├── lerobot_teleoperate.py # Recording/replay
-│       ├── pose_tool.py         # Pose management
-│       └── serial_tool.py       # Serial communication
-├── test.py                      # Integration example
-└── pyproject.toml               # Package configuration
-```
-
-## Example: Complete Workflow
-
-```python
-#!/usr/bin/env python3
-from strands import Agent
-from strands_robots import Robot, gr00t_inference, lerobot_camera, pose_tool
-
-# 1. Create robot with dual cameras
-robot = Robot(
-    tool_name="orange_arm",
-    robot="so101_follower",
-    cameras={
-        "wrist": {"type": "opencv", "index_or_path": "/dev/video0", "fps": 15},
-        "front": {"type": "opencv", "index_or_path": "/dev/video2", "fps": 15},
-    },
-    port="/dev/ttyACM0",
-    data_config="so100_dualcam",
-)
-
-# 2. Create agent with all robot tools
-agent = Agent(
-    tools=[robot, gr00t_inference, lerobot_camera, pose_tool]
-)
-
-# 3. Start inference service
-agent.tool.gr00t_inference(
-    action="start",
-    checkpoint_path="/data/checkpoints/gr00t-wave/checkpoint-300000",
-    port=8000,
-    data_config="so100_dualcam",
-)
-
-# 4. Interactive control loop
-while True:
-    user_input = input("\n🤖 > ")
-    if user_input.lower() in ["exit", "quit"]:
-        break
-    agent(user_input)
-
-# 5. Cleanup
-agent.tool.gr00t_inference(action="stop", port=8000)
-```
-
-## Configuration
-
-### Environment Variables
-
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `STRANDS_ASSETS_DIR` | Custom directory for robot model assets (MJCF, meshes) | `~/.strands_robots/assets/` |
-| `STRANDS_ROBOT_MODE` | Default mode for `Robot()` factory: `sim` / `real` / `auto` | `sim` |
-| `STRANDS_TRUST_REMOTE_CODE` | Allow downloading + executing model code | `false` |
-| `MUJOCO_GL` | GL backend for the MuJoCo renderer | auto |
-| `STRANDS_MESH` | Set to `false` to disable Zenoh mesh networking globally | `true` |
-| `STRANDS_MESH_PORT` | TCP port for the local Zenoh router | `7447` |
-| `ZENOH_CONNECT` | Comma-separated list of remote Zenoh endpoints to connect to | - |
-| `ZENOH_LISTEN` | Comma-separated list of endpoints for the local Zenoh listener | - |
-| `STRANDS_MESH_AUDIT_DIR` | Directory for the safety audit log (`mesh_audit.jsonl`) | `~/.strands_robots/` |
-| `STRANDS_MESH_CA_PINS` | Comma-separated SHA-256 hex pins, **additive** to the bundled Amazon Root CA1 pin tuple. Operator break-glass for an AWS-side root rotation that arrives before the next `strands-robots` release ships the new pin. Must match `^[0-9a-fA-F]{64}$` per entry. | unset |
-| `STRANDS_MESH_DISABLE_CA_PIN` | Set to `true` (case-insensitive) to skip CA pin verification on the *download* path only. The on-disk re-use path always raw-checks the pin regardless. Last-resort break-glass; prefer `STRANDS_MESH_CA_PINS` for rotations. | `false` |
-| `STRANDS_MESH_CAMERA_DISABLED` | Privacy kill-switch. Set truthy (`true`/`1`/`yes`/`on`, case-insensitive) to short-circuit the mesh camera publish loop before any frame is collected, encoded, or uploaded. Invalid values raise `ValueError`. | `false` |
-| `STRANDS_MESH_CAMERA_PRESIGN_TTL` | Default TTL (seconds) for S3 presigned URLs emitted on the IoT camera-offload path. Capped at 3600s (1h); a `0` is clamped to 1s. Non-integer values fall back to the default with a WARNING. | `60` |
-| `GROOT_API_TOKEN` | API token for GR00T inference service | - |
-| `STRANDS_ROBOT_MODE` | Override `Robot()` factory mode detection (`sim`, `real`, `auto`) | `auto` |
-| `STRANDS_TRUST_REMOTE_CODE` | Set to `1` to opt into HuggingFace `trust_remote_code` for `lerobot_local` policies | unset |
-| `MUJOCO_GL` | OpenGL backend for MuJoCo (`egl`, `osmesa`, `glfw`) | auto-detected |
-| `STRANDS_LIBERO_ACTION_LOG` | Set to `1` to emit per-step diagnostic logs from the LIBERO OSC controller (action keys, delta scale, EEF tracking, gripper polarity, qpos/ctrl deltas). Logs the first N steps per episode. | unset |
-| `STRANDS_LIBERO_ACTION_LOG_MAX` | Max number of `apply()` calls to log per episode when `STRANDS_LIBERO_ACTION_LOG=1`. | `50` |
-| `STRANDS_LIBERO_STATE_LOG` | Set to `1` to emit per-step diagnostic logs of the state values (`state.x/y/z/roll/pitch/yaw/gripper`) the LIBERO adapter feeds to the GR00T policy. Pairs with `STRANDS_LIBERO_ACTION_LOG` for end-to-end interface bisection. | unset |
-| `STRANDS_LIBERO_STATE_LOG_MAX` | Max number of `augment_observation()` calls to log per episode when `STRANDS_LIBERO_STATE_LOG=1`. | `50` |
-| `STRANDS_GROOT_WIRE_LOG` | Path to a directory where `Gr00tPolicy` will dump pre-inference observations + post-inference action chunks as pickle files (one per `get_actions` call, named `{local,service}_call{N:04d}.pkl`). Used by the #187 bisection plan to verify whether LOCAL and SERVICE inference paths send byte-identical observations to the model. Run an eval once with each mode into the same dir, then `np.allclose` matching files. | unset |
-| `STRANDS_GROOT_WIRE_LOG_MAX_CALLS` | Cap on number of wire-payload dumps per process when `STRANDS_GROOT_WIRE_LOG` is set. Prevents multi-GB pickle archives on long evals. The first few calls are enough to bisect a divergence. | `10` |
-
-### CA Pin Rotation Runbook
-
-The IoT provisioner downloads `AmazonRootCA1.pem` over HTTPS and pins its
-SHA-256 fingerprint (`strands_robots/mesh/iot/provision._AMAZON_ROOT_CA1_PINS`)
-before trusting the bytes. Because the pin is static, an AWS-side root CA
-rotation needs an operational plan. On-call at 3 AM should follow this runbook,
-not reverse-engineer it from a docstring.
-
-**Recompute the pin** (run when AWS publishes a new root, or to verify the
-current one):
-
-```bash
-python -c "import hashlib, urllib.request as u; \
-print(hashlib.sha256(u.urlopen( \
-'https://www.amazontrust.com/repository/AmazonRootCA1.pem' \
-).read()).hexdigest())"
-```
-
-**Grace-period strategy (dual-pin).** `_AMAZON_ROOT_CA1_PINS` is a tuple, so a
-rotation lands as two releases:
-
-1. Ship a release whose tuple contains **both** the new pin and the old pin.
-   `_resolve_ca_pins()` accepts any pin in the set, so fleets on the old root
-   and fleets that have already seen the new root both verify successfully.
-2. Wait for fleet uptake (track your own deploy rollout; there is no flag day).
-3. Ship a follow-up release that drops the old pin once every fleet member has
-   upgraded and AWS has retired the old root.
-
-**Monitor for upcoming rotations.** Subscribe to AWS security bulletins
-(https://aws.amazon.com/security/security-bulletins/) and the Amazon Trust
-Services repository; AWS publishes root CA deprecation timelines ahead of time.
-
-**Emergency override.** If a rotation lands faster than a code release can ship,
-operators stage the new pin out-of-band via `STRANDS_MESH_CA_PINS`
-(comma-separated 64-char lowercase hex). It is **additive** to the built-in
-tuple, so the old pin keeps working during the overlap. Prefer this over
-`STRANDS_MESH_DISABLE_CA_PIN`, which disables pinning entirely on the download
-path and should be a last resort.
-
-### Mesh Networking
-
-Every `Robot()` and `Simulation()` constructed in a process is automatically a
-peer on the local Zenoh mesh — no manual setup required.  Peers on the same
-LAN discover each other via Zenoh multicast scouting, and a single
-process-wide `zenoh.Session` is shared (ref-counted) across every robot or
-simulation in the same Python process.
-
-```python
-from strands_robots import Robot
-sim_a = Robot("so100")          # auto-joins the mesh as a peer
-sim_b = Robot("so100")          # second peer in another process
-print(sim_a.mesh.peers)         # discovers sim_b
-sim_a.mesh.tell(sim_b.mesh.peer_id, "pick up the cube")
-sim_a.mesh.emergency_stop()     # broadcast E-STOP, audited to disk
-```
-
-`tell()` works against both `HardwareRobot` and `Simulation` peers. The
-dispatcher detects the peer type and routes to
-`HardwareRobot._execute_task_sync` / `start_task` for hardware peers and to
-`Simulation.run_policy` / `start_policy` for sim peers. Issue [#300]'s
-well-known per-call policy kwargs (`target_pose`, `target_joints`,
-`world_update`) and the existing constructor extras (`model_path`,
-`server_address`, `policy_type`, `pretrained_name_or_path`) are forwarded
-end-to-end via `policy_config` so a planner-style policy on a sim peer
-sees the goal payload it needs:
-
-```python
-# Agent on peer A drives a cuRobo planner running on a sim peer B.
-sim_a.mesh.tell(
-    sim_b.mesh.peer_id,
-    "reach for the red block",
-    policy_provider="curobo",
-    target_pose=[0.3, 0.0, 0.4, 1.0, 0.0, 0.0, 0.0],
-    robot_name="arm_left",       # disambiguate in multi-robot sims
-    duration=10.0,
-    fast_mode=True,
-)
-```
-
-Per-robot mesh peers attach automatically inside a sim, so an LLM agent
-may also `tell()` a specific `SimRobot` peer (`<sim_peer_id>__<robot_name>`)
-when the simulation hosts more than one robot.
-
-Disable globally with `STRANDS_MESH=false` or per-robot with
-`Robot("so100", mesh=False)`.  Install the optional dependency with
-`pip install strands-robots[mesh]`.
-
-[#300]: https://github.com/strands-labs/robots/issues/300
-
-### Cache Directory
-
-Robot model assets (MJCF XML files and meshes) are cached in:
-
-```
-~/.strands_robots/
-└── assets/           # Downloaded robot models (from robot_descriptions / MuJoCo Menagerie)
-    ├── trs_so_arm100/
-    ├── franka_emika_panda/
-    └── ...
-```
-
-To clear the cache: `rm -rf ~/.strands_robots/assets/`
-
-To change the cache location: `export STRANDS_ASSETS_DIR=/path/to/custom/dir`
+Reference cuRobo / MoveIt2 implementations are tracked on the
+[project board](https://github.com/orgs/strands-labs/projects/2).
 
 ## Simulation (MuJoCo)
 
-`strands-robots` ships a MuJoCo-backed simulation AgentTool - 58 actions
-exposed to any Strands agent for world composition, physics, policy
-execution, and video/dataset recording.
-
-### Install
-
-```bash
-pip install "strands-robots[sim-mujoco]"
-# For LeRobotDataset recording (parquet + training data):
-pip install "strands-robots[sim-mujoco,lerobot]"
-```
-
-### Quick start
+`Robot("so100")` (sim mode) returns a `Simulation` — a MuJoCo-backed AgentTool
+exposing **64 actions** for world composition, physics, rendering, policy
+execution, and dataset recording. Build it directly when you want full control:
 
 ```python
 from strands_robots.simulation import Simulation
@@ -726,95 +426,219 @@ sim.add_camera(name="topdown", position=[0, 0, 1.5], target=[0, 0, 0])
 sim.run_policy(robot_name="arm", policy_provider="mock", n_steps=200,
                control_frequency=50.0, fast_mode=True)
 
-frame = sim.render(camera_name="topdown")  # returns {status, content:[text, image]}
+frame = sim.render(camera_name="topdown")   # {status, content:[text, image]}
 ```
 
-### 58 actions grouped
+<details>
+<summary><b>The 64 actions, grouped</b></summary>
 
-- **World & objects**: `create_world`, `load_scene`, `add_robot`,
-  `add_object`, `move_object`, `list_objects`, `list_robots`,
-  `remove_robot`, `remove_object`, `destroy`, `reset`, `get_state`,
-  `save_state`, `load_state`, `list_checkpoints`.
-- **Physics**: `step`, `set_timestep`, `set_gravity`, `apply_force`,
-  `raycast`, `multi_raycast`, `set_body_properties`,
-  `set_geom_properties`, `get_body_state`, `get_joint_state`,
-  `set_joint_positions`, `set_joint_velocities`, `forward_kinematics`,
-  `get_mass_matrix`, `inverse_dynamics`, `get_total_mass`,
-  `get_jacobian`, `get_energy`, `get_contacts`, `get_sensor_data`.
+- **World & scene**: `create_world`, `load_scene`, `replace_scene_mjcf`,
+  `patch_scene_mjcf`, `reset`, `get_state`, `save_state`, `load_state`,
+  `destroy`, `export_xml`.
+- **Robots**: `add_robot`, `remove_robot`, `list_robots`, `get_robot_state`,
+  `list_urdfs`, `register_urdf`, `get_features`.
+- **Objects**: `add_object`, `remove_object`, `move_object`, `list_objects`.
 - **Cameras & rendering**: `add_camera`, `remove_camera`, `render`,
   `render_depth`, `render_all`, `start_cameras_recording`,
   `stop_cameras_recording`, `get_cameras_recording_status`.
-- **Policy**: `start_policy`, `run_policy`, `stop_policy`,
-  `replay_episode`, `eval_policy`.
+- **Physics**: `step`, `set_timestep`, `set_gravity`, `apply_force`, `raycast`,
+  `multi_raycast`, `get_contacts`, `get_contact_forces`, `get_body_state`,
+  `set_joint_positions`, `set_joint_velocities`, `forward_kinematics`,
+  `get_jacobian`, `get_mass_matrix`, `inverse_dynamics`, `get_total_mass`,
+  `get_energy`, `get_sensor_data`, `set_body_properties`, `set_geom_properties`.
+- **Policy**: `run_policy`, `start_policy`, `stop_policy`,
+  `list_policies_running`, `replay_episode`, `eval_policy`.
 - **Randomization**: `randomize`.
 - **Recording (LeRobotDataset)**: `start_recording`, `stop_recording`,
   `get_recording_status`.
-- **Introspection & util**: `get_features`, `list_urdfs`, `register_urdf`,
-  `export_xml`, `open_viewer`, `close_viewer`.
+- **Benchmarks**: `list_benchmarks`, `register_benchmark_from_file`,
+  `evaluate_benchmark`.
+- **Viewer**: `open_viewer`, `close_viewer`.
 
-### Common footguns
+</details>
+
+<details>
+<summary><b>Common footguns</b></summary>
 
 - **Planes must be static.** `add_object(shape="plane")` auto-sets
-  `is_static=True`. Passing `is_static=False` on a plane is a hard error
-  (MuJoCo planes are infinite and can't have dynamic mass).
-- **Camera orientation.** Pass `target=[x,y,z]` to look at a point -
-  without it the camera faces forward by default. `target == position`
+  `is_static=True`; passing `is_static=False` is a hard error.
+- **Aim cameras.** Pass `target=[x,y,z]` to look at a point; `target == position`
   errors.
-- **MP4 vs dataset recording.** `start_cameras_recording` writes plain
-  MP4 per-camera and runs under `[sim-mujoco]` alone. `start_recording`
-  writes a LeRobotDataset (parquet + MP4 + schema) and requires the
-  `[lerobot]` extra.
-- **Policy running → mutations blocked.** While a policy runs on any
-  robot, state-mutating actions (`reset`, `set_gravity`, joint setters,
-  `apply_force`, `set_body_properties`, `set_geom_properties`,
-  `load_state`, `randomize`, `move_object`) error with *"Cannot 'X'
-  while a policy is running."* Stop it first with
-  `stop_policy(robot_name='...')`.
-- **Horizon parameters.** `run_policy` accepts either `duration` +
-  `control_frequency` (real-time) OR `n_steps` + `control_frequency`
-  (step-count). Pass `fast_mode=True` to skip the between-step sleep
-  during batch eval / data collection.
-- **Name collisions.** Objects, bodies, robots, and cameras share the
-  MuJoCo name table. Robot joints and actuators are auto-namespaced as
-  `{robot_name}/{joint}` in multi-robot scenes. Object geoms are
-  injected as `{object_name}_geom`; `set_geom_properties` accepts the
-  bare object name as an alias.
-- **Oversized render**: MuJoCo's offscreen framebuffer is capped by
-  `<global offwidth="W" offheight="H"/>` in MJCF. Requesting a bigger
-  render now errors with a plain message naming the cap - either lower
-  the request or rebuild the model with larger dims.
+- **MP4 vs dataset recording.** `start_cameras_recording` writes plain MP4
+  (`[sim-mujoco]` only). `start_recording` writes a LeRobotDataset (parquet +
+  MP4 + schema) and needs the `[lerobot]` extra.
+- **Policy running → mutations blocked.** While a policy runs, state-mutating
+  actions error with *"Cannot 'X' while a policy is running."* Stop it first.
+- **Horizon parameters.** `run_policy` takes either `duration` or `n_steps`
+  (both with `control_frequency`). `fast_mode=True` skips the between-step
+  sleep for batch eval / data collection.
+- **Name collisions.** Objects, bodies, robots, and cameras share the MuJoCo
+  name table. Multi-robot joints/actuators are namespaced `{robot}/{joint}`.
 
-### Self-healing features
+</details>
 
-- Unknown parameters are rejected with *"Unknown parameter X for action
-  Y. Valid: [...]"* so the LLM learns the correct name without trial-
-  and-error.
-- Missing required parameters produce *"Action X requires parameter Y."*
-  (no Python `TypeError` leaks).
-- Vector dimensions and numeric dtype are validated before MuJoCo sees
-  them (previously zero-length direction vectors crashed the Python
-  process via `mj_ray` C-level abort).
-- `destroy()` and `cleanup()` empty the renderer TLS cache and shut down
-  the executor - no RSS growth across repeated create/destroy cycles.
+**Self-healing:** unknown parameters are rejected with *"Unknown parameter X
+for action Y. Valid: [...]"*, missing required params produce *"Action X
+requires parameter Y."*, and vectors/dtypes are validated before MuJoCo sees
+them — so the agent learns the contract without crashing the process.
 
-For the full action contract and test coverage see
-`tests/simulation/mujoco/test_agenttool_contract.py`.
+## Mesh networking
+
+Every `Robot()` and `Simulation()` is automatically a peer on a local Zenoh
+mesh — no setup. Peers on the same LAN discover each other via multicast
+scouting, sharing a single ref-counted `zenoh.Session` per process.
+
+```python
+from strands_robots import Robot
+
+a = Robot("so100")              # auto-joins the mesh
+b = Robot("so100")              # second peer (another process)
+print(a.mesh.peers)             # discovers b
+
+a.mesh.tell(b.peer_id, "pick up the cube")
+a.mesh.emergency_stop()         # broadcast E-STOP, audited to disk
+```
+
+`tell()` routes to hardware **and** sim peers. Per-call policy kwargs
+(`target_pose`, `target_joints`, `world_update`) and constructor extras are
+forwarded end-to-end via `policy_config`, so a planner-style policy on a sim
+peer sees the goal payload it needs:
+
+```python
+a.mesh.tell(
+    b.peer_id,
+    "reach for the red block",
+    policy_provider="curobo",
+    target_pose=[0.3, 0.0, 0.4, 1.0, 0.0, 0.0, 0.0],
+    robot_name="arm_left",      # disambiguate in multi-robot sims
+    duration=10.0,
+)
+```
+
+Expose the mesh to an agent with the `robot_mesh` tool (`peers`, `status`,
+`tell`, `send`, `broadcast`, `stop`, `emergency_stop`, `subscribe`, `watch`,
+`inbox`). Disable globally with `STRANDS_MESH=false` or per-robot with
+`Robot("so100", mesh=False)`. Install with `pip install "strands-robots[mesh]"`.
+
+### AWS IoT Core transport (fleets)
+
+For robots across networks, bridge the mesh to AWS IoT Core over MQTT5/mTLS,
+with Device Shadow mirroring, S3 camera offload, and account-wide Fleet
+Provisioning. Hardened with CA pinning, strict thing-name validation,
+deny-by-default IoT policy scoping, and a safety audit log.
+Install with `pip install "strands-robots[mesh-iot]"`. See the
+[Configuration](#configuration) matrix for the `STRANDS_MESH_*` knobs.
+
+## Configuration
+
+### Environment variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `STRANDS_ROBOT_MODE` | `Robot()` factory mode: `sim` / `real` / `auto` | `sim` |
+| `STRANDS_ASSETS_DIR` | Robot model asset cache directory | `~/.strands_robots/assets/` |
+| `STRANDS_TRUST_REMOTE_CODE` | Set `1` to allow HF `trust_remote_code` for `lerobot_local` | unset |
+| `MUJOCO_GL` | MuJoCo GL backend (`egl`, `osmesa`, `glfw`) | auto |
+| `GROOT_API_TOKEN` | API token for the GR00T inference service | unset |
+| `STRANDS_MESH` | Set `false` to disable Zenoh mesh globally | `true` |
+| `STRANDS_MESH_PORT` | TCP port for the local Zenoh router | `7447` |
+| `ZENOH_CONNECT` | Comma-separated remote Zenoh endpoints to connect to | unset |
+| `ZENOH_LISTEN` | Comma-separated endpoints for the local Zenoh listener | unset |
+| `STRANDS_MESH_AUDIT_DIR` | Directory for the safety audit log (`mesh_audit.jsonl`) | `~/.strands_robots/` |
+| `STRANDS_MESH_CA_PINS` | Additional SHA-256 CA pins (comma-separated 64-char hex) | unset |
+| `STRANDS_MESH_DISABLE_CA_PIN` | Skip CA pin check on download path (break-glass) | `false` |
+| `STRANDS_MESH_CAMERA_PRESIGN_TTL` | TTL (s) for S3 presigned camera URLs; capped at 3600 | `60` |
+
+<details>
+<summary><b>Benchmark / diagnostic env vars (LIBERO, GR00T bisection)</b></summary>
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `STRANDS_LIBERO_ACTION_LOG` / `_MAX` | Per-step OSC controller diagnostics | unset / `50` |
+| `STRANDS_LIBERO_STATE_LOG` / `_MAX` | Per-step state values fed to GR00T | unset / `50` |
+| `STRANDS_GROOT_WIRE_LOG` / `_MAX_CALLS` | Dump pre/post inference payloads to verify LOCAL vs SERVICE parity | unset / `10` |
+
+</details>
+
+### Asset cache
+
+```
+~/.strands_robots/
+└── assets/           # auto-downloaded MJCF + meshes
+    ├── trs_so_arm100/
+    ├── franka_emika_panda/
+    └── ...
+```
+
+Clear with `rm -rf ~/.strands_robots/assets/`; relocate with
+`export STRANDS_ASSETS_DIR=/path/to/dir`.
+
+## Benchmarks
+
+`strands-robots` ships a [LIBERO](https://github.com/Lifelong-Robot-Learning/LIBERO)
+benchmark integration on the MuJoCo backend — byte-equivalent to upstream
+LIBERO at the model level, reaching `success_rate >= 0.92` on libero-10/SCENE5.
+Register declarative benchmarks from file and evaluate policies via the
+`list_benchmarks`, `register_benchmark_from_file`, and `evaluate_benchmark`
+simulation actions. Install with `pip install "strands-robots[benchmark-libero]"`.
+
+## Project structure
+
+```
+strands_robots/
+├── __init__.py            # Lazy-loaded public API (Robot, Simulation, policies)
+├── robot.py               # Robot() factory (sim/real/auto dispatch)
+├── hardware_robot.py      # HardwareRobot — async LeRobot control
+├── policies/
+│   ├── base.py            # Policy ABC
+│   ├── factory.py         # create_policy() + runtime registration
+│   ├── mock.py            # MockPolicy (non-VLA reference)
+│   ├── groot/             # NVIDIA GR00T (ZMQ/HTTP client + data configs)
+│   └── lerobot_local/     # Direct HuggingFace inference (RTC, processors)
+├── registry/              # robots.json (68) + policies.json + loaders
+├── simulation/
+│   ├── base.py            # SimEngine ABC
+│   ├── factory.py         # create_simulation() + backend registry
+│   ├── models.py          # SimWorld / SimRobot / SimObject / SimCamera
+│   └── mujoco/            # MuJoCo backend (64-action AgentTool)
+├── mesh/                  # Zenoh mesh: core, sensors, input, audit, transport, iot
+├── benchmarks/libero/     # LIBERO suite + BDDL parser + adapter
+└── tools/                 # gr00t_inference, lerobot_*, pose, serial, robot_mesh
+```
+
+## Development
+
+```bash
+pip install -e ".[all,dev]"
+
+hatch run test          # unit tests
+hatch run test-integ    # integration tests (GPU + model weights)
+hatch run lint          # ruff check + format --check + mypy
+hatch run format        # ruff check --fix + ruff format
+```
+
+Python 3.12+ required. See [AGENTS.md](AGENTS.md) for conventions and the
+accumulated code-review learnings.
 
 ## Contributing
 
-We welcome contributions! Please see:
-- [GitHub Issues](https://github.com/strands-labs/robots/issues) for bug reports
-- [Pull Requests](https://github.com/strands-labs/robots/pulls) for contributions
+Issues and PRs welcome. Track work on the
+[Strands Labs — Robots project board](https://github.com/orgs/strands-labs/projects/2);
+it is the source of truth for roadmap and follow-ups.
+
+- [GitHub Issues](https://github.com/strands-labs/robots/issues)
+- [Pull Requests](https://github.com/strands-labs/robots/pulls)
 
 ## License
 
-Apache-2.0 - see [LICENSE](LICENSE) file.
+Apache-2.0 — see [LICENSE](LICENSE).
 
 ## Links
 
 <div align="center">
   <a href="https://github.com/strands-labs/robots">GitHub</a>
   ◆ <a href="https://pypi.org/project/strands-robots/">PyPI</a>
+  ◆ <a href="https://github.com/google-deepmind/mujoco">MuJoCo</a>
   ◆ <a href="https://github.com/NVIDIA/Isaac-GR00T">NVIDIA GR00T</a>
   ◆ <a href="https://github.com/huggingface/lerobot">LeRobot</a>
   ◆ <a href="https://strandsagents.com/">Strands Docs</a>

--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ sim.add_object(name="cube", shape="box", position=[0.3, 0, 0.05])
 sim.add_camera(name="topdown", position=[0, 0, 1.5], target=[0, 0, 0])
 
 sim.run_policy(robot_name="arm", policy_provider="mock", n_steps=200,
-               control_frequency=50.0, fast_mode=True)
+               control_frequency=50.0)
 
 frame = sim.render(camera_name="topdown")   # {status, content:[text, image]}
 ```

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ AgentTool returning `{"status", "content"}`.
 | `find_containers` | - | Find GR00T Docker containers |
 | `build_image` / `download_checkpoint` / `start_container` | - | Full container lifecycle orchestration |
 
-TensorRT acceleration:
+**TensorRT** acceleration:
 
 ```python
 agent.tool.gr00t_inference(

--- a/tests/mesh/test_iot_ca_pin_rotation.py
+++ b/tests/mesh/test_iot_ca_pin_rotation.py
@@ -8,14 +8,11 @@ rotation can keep both the old and the new pin valid during fleet uptake:
 * The built-in pin tuple plus a staged second pin from
   ``STRANDS_MESH_CA_PINS`` both resolve as accepted (dual-pin overlap).
 * Verification accepts a certificate matching either pin in the set.
-* The README publishes the rotation runbook so on-call has a documented
-  procedure rather than a bare recompute command.
 """
 
 from __future__ import annotations
 
 import hashlib
-from pathlib import Path
 
 import pytest
 
@@ -60,11 +57,3 @@ def test_verify_ca_bytes_accepts_either_pin_during_dual_pin_overlap(
     monkeypatch.setenv("STRANDS_MESH_CA_PINS", staged)
     assert provision._verify_ca_bytes(rogue) is True
 
-
-def test_readme_publishes_ca_pin_rotation_runbook() -> None:
-    """The rotation runbook is documented in README, not just the provision docstring."""
-    readme = Path(__file__).resolve().parents[2] / "README.md"
-    text = readme.read_text(encoding="utf-8")
-    assert "CA Pin Rotation Runbook" in text
-    assert "STRANDS_MESH_CA_PINS" in text
-    assert "dual-pin" in text.lower()

--- a/tests/mesh/test_iot_ca_pin_rotation.py
+++ b/tests/mesh/test_iot_ca_pin_rotation.py
@@ -56,4 +56,3 @@ def test_verify_ca_bytes_accepts_either_pin_during_dual_pin_overlap(
     # Once staged out-of-band, the same cert is accepted (grace-period overlap).
     monkeypatch.setenv("STRANDS_MESH_CA_PINS", staged)
     assert provision._verify_ca_bytes(rogue) is True
-


### PR DESCRIPTION
## Summary

Refreshes the README to match the current v0.x API surface and removes hardcoded counts that go stale on every robot/action addition.

### Changes
- Rewrite README around the `Robot()` factory, sim-first defaults, supported-robot registry, tools reference, and policy providers
- Document the MuJoCo `Simulation` backend and its action set
- Add Mesh networking section (Zenoh peers, `tell()`, E-STOP, CA pin rotation runbook)
- Add Security section linking `SECURITY.md`
- Add GR00T data-config schema table
- **Future-proof counts**: replace exact `68 robots` / `64 actions` with `50+` so docs don't need touching every time the registry or sim action set grows

### Notes
- Single-file change (`README.md`)
- No code or behavior changes