### PR TITLE
test(ci): fix test-integ pytest config + 3 pre-existing integration failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,7 @@ features = ["all"]
 dependencies = [
     "pytest>=6.0,<9.0.0",
     "pytest-cov>=4.0.0,<6.0.0",
+    "pytest-timeout>=2.0.0,<3.0.0",
     "ruff>=0.4.0,<1.0.0",
     "mypy>=1.0.0,<2.0.0",
     "Pillow>=8.0.0,<12.0.0",
@@ -236,4 +237,5 @@ testpaths = ["tests"]
 addopts = "-v --cov=strands_robots --cov-report=term-missing --strict-markers"
 markers = [
     "gpu: requires CUDA GPU and real model weights (run with: pytest -m gpu)",
+    "slow: long-running test (deselect with: pytest -m 'not slow')",
 ]

--- a/tests_integ/simulation/test_mujoco_journeys.py
+++ b/tests_integ/simulation/test_mujoco_journeys.py
@@ -432,11 +432,14 @@ def test_j7_multicam_recording_concurrent_with_policy(sim, mock_policy, tmp_path
         assert Path(artifact["path"]).exists()
         assert Path(artifact["path"]).stat().st_size > 0
 
-    # Post-stop: status is idle, and double-stop is a clean error
+    # Post-stop: status is idle, and double-stop is an idempotent no-op.
+    # stop_cameras_recording is documented idempotent ("already stopped is a
+    # success, not an error"), so a second stop returns success with an
+    # informational "was not recording" message rather than erroring.
     status = sim.get_cameras_recording_status()
     assert "⚪" in _content_texts(status)
     double_stop = sim.stop_cameras_recording()
-    assert double_stop["status"] == "error"
+    assert double_stop["status"] == "success"
 
 
 # J8 · SINGLE-CAMERA RUN_POLICY VIDEO - the path that used to silently fail
@@ -559,7 +562,14 @@ def test_j10_empty_sim_methods_never_raise():
         # Most state-observing methods must error on an empty sim. Status queries
         # that have a meaningful "idle" response (camera recording, regular
         # recording) legitimately return success with an informational message.
-        STATUS_QUERIES_OK_ON_EMPTY = {"get_cameras_recording_status"}
+        # Idempotent stop/status queries legitimately return an informational
+        # success on an empty sim rather than erroring (e.g. "was not recording").
+        STATUS_QUERIES_OK_ON_EMPTY = {
+            "get_cameras_recording_status",
+            "stop_cameras_recording",
+            "stop_recording",
+            "get_recording_status",
+        }
         if (
             name.startswith(
                 (
@@ -581,8 +591,10 @@ def test_j10_empty_sim_methods_never_raise():
         ):
             assert result["status"] == "error", f"{name} on empty sim should error, got: {result}"
             txt = _content_texts(result)
-            # Every error message contains either error or the word "No"
-            assert "error" in txt or "No " in txt or "Not " in txt, f"{name}: {txt!r}"
+            # Every error message conveys failure: an explicit "error", a
+            # negation ("No "/"Not "), or a "not found" / "no ..." phrasing.
+            txt_l = txt.lower()
+            assert "error" in txt_l or "no " in txt_l or "not " in txt_l, f"{name}: {txt!r}"
 
     s.destroy()
 

--- a/tests_integ/simulation/test_multi_robot_tasks.py
+++ b/tests_integ/simulation/test_multi_robot_tasks.py
@@ -38,6 +38,10 @@ def dual_robot_world():
     sim.add_object("red_cube", shape="box", size=[0.025, 0.025, 0.025], position=[-0.15, 0.2, 0.05], rgba=[1, 0, 0, 1])
     sim.add_object("blue_ball", shape="sphere", size=[0.03, 0.03, 0.03], position=[0.15, 0.2, 0.05], rgba=[0, 0, 1, 1])
     sim.add_camera("top", position=[0, 0, 0.9], target=[0, 0.2, 0.05])
+    # Per-robot wrist cameras: the "/" namespace separator is normalised to
+    # "__" in recorded LeRobot feature names (observation.images.alice__wrist_cam).
+    sim.add_camera("alice/wrist_cam", position=[-0.25, 0.2, 0.4], target=[-0.15, 0.2, 0.05])
+    sim.add_camera("bob/wrist_cam", position=[0.25, 0.2, 0.4], target=[0.15, 0.2, 0.05])
     sim.step(n_steps=10)
     yield sim
     sim.destroy()


### PR DESCRIPTION
## Summary

Fixes the test/CI-infra issues that prevent a clean `hatch run test-integ` run, plus three pre-existing integration test failures. All changes are test/config-side — no `strands_robots` source changes; the source behavior was correct in every case.

## Commit 1 — `fix(ci)`: pytest config

- **`pytest-timeout` missing from the default hatch env.** The `test-integ` script passes `--timeout=300`, but `pytest-timeout` was only in the `dev` optional-deps, so the documented `hatch run test-integ` failed with `unrecognized arguments: --timeout=300` under `--strict-markers`. Added `pytest-timeout` to the default env deps.
- **`slow` marker unregistered.** `tests_integ/test_resource_hygiene.py` uses `@pytest.mark.slow`, but only `gpu` was declared in `[tool.pytest.ini_options].markers`, so `--strict-markers` errored at collection. Registered `slow`.

## Commit 2 — `test(sim)`: three pre-existing integration failures

All three are test-side; the underlying source behavior is correct:

1. **`test_j10_empty_sim_methods_never_raise`** — the error-message substring check accepted only `error`/`No `/`Not `, missing the common `not found` phrasing (e.g. `"Robot 'ghost' not found."`). Made it case-insensitive. Also added the idempotent stop/status queries (`stop_cameras_recording`, `stop_recording`, `get_recording_status`) to `STATUS_QUERIES_OK_ON_EMPTY` — they return an informational success on an empty sim by design.
2. **`test_j7_multicam_recording_concurrent_with_policy`** — asserted a second `stop_cameras_recording()` returns `error`, but the method is documented idempotent (*"already stopped is a success, not an error"*). Now asserts `success`.
3. **`test_two_robots_two_tasks_recorded_as_single_episode`** — the fixture asserted `observation.images.alice__wrist_cam` / `bob__wrist_cam` exist but never created those cameras (so101 ships none). Added the per-robot wrist cameras via the `alice/wrist_cam` namespace; the `/`→`__` normalisation produces the asserted feature names.

## Verification

- `tests_integ/simulation`: **12 / 12 passing** (was 9 passed, 3 failed)
- `hatch run test-integ` now loads `pytest-timeout` and runs with `--timeout=300`
- `tests_integ/test_resource_hygiene.py` collects cleanly under `--strict-markers`

## Risk

Minimal. Test/config-only; no source changes.
