### PR TITLE
fix(test): skip groot RNG-reproducibility tests under torch mock

### DIFF
--- a/tests/policies/groot/test_policy.py
+++ b/tests/policies/groot/test_policy.py
@@ -93,6 +93,24 @@ def _make_policy(data_config="so100", version="n1.6", obs_mapping=None, action_m
     return p
 
 
+def _require_real_torch():
+    """Return real torch, or skip when the numpy-backed torch mock is active.
+
+    The RNG-reproducibility tests below assert that ``policy.reset(seed=...)``
+    reseeds torch deterministically. That contract is only observable against
+    real torch: the test-suite torch mock (tests/mocks/torch_mock.py) has a
+    no-op ``manual_seed`` and its tensors have no ``tolist``, so the assertion
+    is both meaningless and crash-prone under the mock. ``importorskip`` alone
+    is insufficient because the mock registers a ``torch`` module in
+    ``sys.modules`` (so the import succeeds); the mock never sets
+    ``__version__``, which is the discriminator used here.
+    """
+    torch = pytest.importorskip("torch", reason="torch not installed")
+    if not hasattr(torch, "__version__"):
+        pytest.skip("requires real torch (mock active); RNG reproducibility is real-torch-only")
+    return torch
+
+
 # (section)
 # Construction
 # (section)
@@ -669,7 +687,7 @@ class TestPolicyReset:
         the same way ``set_eval_seed`` does, so the in-process diffusion
         sampler is deterministic across reset boundaries.
         """
-        torch = pytest.importorskip("torch", reason="torch not installed")
+        torch = _require_real_torch()
 
         # Construct a LOCAL-mode Gr00tPolicy via the test's __new__-bypass
         # fixture to skip model loading. The reset path doesn't depend on
@@ -694,7 +712,7 @@ class TestPolicyReset:
         state untouched. Reset is a hint, not a hard reset; without an
         explicit seed there's nothing to apply.
         """
-        torch = pytest.importorskip("torch", reason="torch not installed")
+        torch = _require_real_torch()
         from strands_robots.policies.groot.policy import Gr00tPolicy
 
         p = Gr00tPolicy.__new__(Gr00tPolicy)


### PR DESCRIPTION
## Summary

Two GR00T policy tests crash with `AttributeError: 'MockTensor' object has no attribute 'tolist'` in any CI lane where the numpy-backed torch mock is active (real torch not installed). This makes those lanes red and currently blocks #374 (and any mock-only lane) from merging. The test and the mock are byte-identical on `main` and have been for some time; the failure is purely environment-driven (mock vs. real torch), not introduced by any recent code change.

## Root cause

`test_local_reset_reseeds_torch` and `test_local_reset_without_seed_is_noop` assert real torch RNG reproducibility across `reset(seed=...)` boundaries (#187). They guard with `pytest.importorskip("torch")` to skip when torch is absent.

But the suite's torch mock (`tests/mocks/torch_mock.py`) registers a `torch` module into `sys.modules`, so the import **succeeds** and `importorskip` does not skip. The tests then run against the mock, where:

1. `MockTensor` has no `.tolist()` -> `AttributeError` (the actual crash), and
2. `manual_seed` is a no-op -> even with `.tolist()`, the reproducibility assertion would be meaningless.

`importorskip` answers "is a module named torch importable?" -- the wrong question. The tests need "is the **real** torch present?".

## Fix

Add a small `_require_real_torch()` helper next to the existing test helpers: `importorskip` plus a guard that skips when the torch mock is active. The mock never sets `__version__`, so `hasattr(torch, "__version__")` is a clean, RNG-free discriminator. Both affected tests now call the helper.

- Real-torch CI keeps running the assertions unchanged (helper returns torch as before).
- Mock-only lanes skip the two real-torch-only tests instead of crashing.
- No production code touched; no change to the shared `torch_mock.py` (adding `.tolist()` alone would not fix the reproducibility assertion, and seeding numpy in the mock's `manual_seed` is a wide-blast-radius change to a shared fixture).

## Diff

Single file, +18 / -2: one new helper, two call-site swaps.

## Verification

- `ruff check` + `ruff format --check`: clean.
- Simulated both paths under pytest: mock active (no `__version__`) -> test SKIPPED (no crash); real torch (has `__version__`) -> helper returns the module and the test runs.

Unblocks #374.