### PR TITLE
fix: resolve SO101/SO100 customer-mode E2E paper cuts + sim render fidelity (GH #373)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## Unreleased - LeRobot 0.5.2 recording + policy pipeline hardening
 
+### Fixed: customer-mode E2E friction points (GH #373)
+
+Eight first-run paper cuts found during a fresh-clone SO101 customer workflow:
+
+- **`[lerobot]` extra now pulls `lerobot[feetech]`** so `scservo_sdk` installs
+  for every Feetech-based (SO100/SO101/Koch) customer's first `mode="real"`
+  run -- previously a `ModuleNotFoundError` blocker.
+- **`Robot("so100")` (the `Simulation`) is now callable**:
+  `robot(action="render", camera_name="topdown")` dispatches to the action
+  method instead of raising `TypeError: object is not callable`, matching the
+  README contract.
+- **Pre-0.5 SO-family calibration files auto-migrate.** lerobot 0.5.1 unified
+  `so100_follower/`/`so101_follower/` into `so_follower/`; `HardwareRobot`
+  now copies a single legacy calibration JSON to the new path at init so
+  existing calibrations Just Work (no more confusing `RuntimeError` on the
+  first `get_observation()`).
+- **README param-name aliases accepted.** The action dispatcher now treats
+  `camera_names=` -> `cameras=` and `joint_positions=` -> `positions=` as
+  aliases so copy-pasted older docs don't raise "unexpected keyword argument".
+- **`STRANDS_MESH_LOCAL_DEV=1`** is a one-variable localhost mesh preset:
+  defaults auth to `none` AND satisfies the insecure-acknowledgement second
+  factor by itself (no separate `STRANDS_MESH_I_KNOW_THIS_IS_INSECURE=1`).
+  An explicit `STRANDS_MESH_AUTH_MODE=mtls` still wins.
+- **`mesh.peers_by_id` dict + `mesh.get_peer(peer_id)` helper** added
+  alongside the existing `mesh.peers` list, so dict-style peer lookup
+  (`mesh.peers_by_id[peer_id]`) no longer raises `TypeError`.
+- **README sweep**: clarified `Robot()` auto-creates the world (don't call
+  `create_world()` again), fixed the callable usage example, and documented
+  the new mesh env vars in the Configuration table.
+
+
 ### Changed (breaking): ``panda`` embodiment split into joint-space vs EEF
 
 The ``panda`` embodiment previously aliased to ``panda_libero``, conflating a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,22 @@ Eight first-run paper cuts found during a fresh-clone SO101 customer workflow:
   `create_world()` again), fixed the callable usage example, and documented
   the new mesh env vars in the Configuration table.
 
+### Fixed: realistic sim rendering + wrist cameras (GH #373 follow-up)
+
+- **Dimmed the MuJoCo headlight.** The default camera-tracking headlight
+  (diffuse 0.4, specular 0.5, always on) stacked additively on the two
+  explicit scene lights, washing out renders and flattening shadow contrast --
+  and looking nothing like real camera footage. `SpecBuilder.build` now sets
+  the headlight to a low, shadow-free term (diffuse 0.2, specular 0) so the
+  explicit directional lights do the work. More realistic sim data.
+- **Body-mounted (wrist/gripper) cameras.** `add_camera` gained a
+  `parent_body` parameter: pass a body name (e.g. `"so101/gripper"`) and the
+  camera mounts ON that body and tracks it as the arm moves -- matching the
+  physical wrist camera on a real SO101/SO100. `position`/`target` are then
+  interpreted in the body's local frame. Omitting `parent_body` keeps the
+  prior world-fixed behaviour. An unknown `parent_body` returns a structured
+  error listing the available (namespaced) body names.
+
 
 ### Changed (breaking): ``panda`` embodiment split into joint-space vs EEF
 

--- a/README.md
+++ b/README.md
@@ -141,8 +141,16 @@ agent("Wave the arm using the mock policy for 200 steps, then render a top-down 
 ```
 
 `Robot("so100")` returns a `Simulation` instance — the full 64-action
-simulation AgentTool. Drive it in natural language, or call its methods
-directly (see [Simulation](#simulation-mujoco)).
+simulation AgentTool. Drive it in natural language through an `Agent`, call its
+methods directly (`robot.render(camera_name="topdown")`), or dispatch an action
+by calling it (`robot(action="render", camera_name="topdown")`). See
+[Simulation](#simulation-mujoco).
+
+> **Note:** `Robot("so100")` already creates the world **and** adds the robot
+> for you. Do **not** call `create_world()` again on the returned instance —
+> it will error with *"World already exists."* The `create_world()` /
+> `add_robot()` sequence shown in [Simulation (MuJoCo)](#simulation-mujoco) is
+> for the low-level `Simulation(...)` constructor, which starts empty.
 
 ### Real hardware + GR00T
 
@@ -568,7 +576,9 @@ from strands_robots import Robot
 
 a = Robot("so100")              # auto-joins the mesh
 b = Robot("so100")              # second peer (another process)
-print(a.mesh.peers)             # discovers b
+print(a.mesh.peers)             # list[dict] — discovers b
+print(a.mesh.peers_by_id[b.peer_id])   # dict[peer_id -> info] for O(1) lookup
+info = a.mesh.get_peer(b.peer_id)      # None-safe single lookup
 
 a.mesh.tell(b.peer_id, "pick up the cube")
 a.mesh.emergency_stop()         # broadcast E-STOP, audited to disk
@@ -595,6 +605,13 @@ Expose the mesh to an agent with the `robot_mesh` tool (`peers`, `status`,
 `inbox`). Disable globally with `STRANDS_MESH=false` or per-robot with
 `Robot("so100", mesh=False)`. Install with `pip install "strands-robots[mesh]"`.
 
+For frictionless single-machine experiments, set `STRANDS_MESH_LOCAL_DEV=1` —
+one env var that runs the mesh without mTLS/ACL on localhost. It defaults the
+auth mode to `none` **and** satisfies the insecure-acknowledgement second
+factor by itself, so you don't also need `STRANDS_MESH_I_KNOW_THIS_IS_INSECURE=1`.
+An explicit `STRANDS_MESH_AUTH_MODE=mtls` still wins. **Never** set
+`STRANDS_MESH_LOCAL_DEV` on a shared or production network.
+
 ### AWS IoT Core transport (fleets)
 
 For robots across networks, bridge the mesh to AWS IoT Core over MQTT5/mTLS,
@@ -616,6 +633,9 @@ Install with `pip install "strands-robots[mesh-iot]"`. See the
 | `MUJOCO_GL` | MuJoCo GL backend (`egl`, `osmesa`, `glfw`) | auto |
 | `GROOT_API_TOKEN` | API token for the GR00T inference service | unset |
 | `STRANDS_MESH` | Set `false` to disable Zenoh mesh globally | `true` |
+| `STRANDS_MESH_LOCAL_DEV` | Set `1` for a one-var localhost preset (auth `none`, no second factor needed) | unset |
+| `STRANDS_MESH_AUTH_MODE` | Wire auth: `mtls` or `none` (`none` needs a second factor) | `mtls` |
+| `STRANDS_MESH_I_KNOW_THIS_IS_INSECURE` | Second factor required to bring up `AUTH_MODE=none` | unset |
 | `STRANDS_MESH_PORT` | TCP port for the local Zenoh router | `7447` |
 | `ZENOH_CONNECT` | Comma-separated remote Zenoh endpoints to connect to | unset |
 | `ZENOH_LISTEN` | Comma-separated endpoints for the local Zenoh listener | unset |

--- a/README.md
+++ b/README.md
@@ -506,6 +506,12 @@ sim.add_robot(name="arm", data_config="so100")
 sim.add_object(name="cube", shape="box", position=[0.3, 0, 0.05])
 sim.add_camera(name="topdown", position=[0, 0, 1.5], target=[0, 0, 0])
 
+# Wrist camera: mount ON the gripper body so it tracks the arm like the real
+# SO101/SO100 hardware cam. position/target are in the body's LOCAL frame.
+# Body names are namespaced "<robot>/<body>" (e.g. "arm/gripper").
+sim.add_camera(name="wrist", position=[0, -0.05, 0], target=[0, -0.15, 0],
+               parent_body="arm/gripper")
+
 sim.run_policy(robot_name="arm", policy_provider="mock", n_steps=200,
                control_frequency=50.0)
 
@@ -547,6 +553,10 @@ frame = sim.render(camera_name="topdown")   # {status, content:[text, image]}
   `is_static=True`; passing `is_static=False` is a hard error.
 - **Aim cameras.** Pass `target=[x,y,z]` to look at a point; `target == position`
   errors.
+- **Wrist cameras mount on a body.** Pass `parent_body="<robot>/gripper"` to
+  `add_camera` so the camera rides with the arm (realistic SO101/SO100 wrist
+  cam). In that mode `position`/`target` are in the body's LOCAL frame, not
+  world coordinates. Omit `parent_body` for a world-fixed camera.
 - **MP4 vs dataset recording.** `start_cameras_recording` writes plain MP4
   (`[sim-mujoco]` only). `start_recording` writes a LeRobotDataset (parquet +
   MP4 + schema) and needs the `[lerobot]` extra.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ cosmos3-service = [
     "websockets>=12.0",
 ]
 lerobot = [
-    "lerobot>=0.5.0,<0.6.0",
+    "lerobot[feetech]>=0.5.0,<0.6.0",
 ]
 sim = [
     "robot_descriptions>=1.11.0,<2.0.0",

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -21,12 +21,14 @@ import functools
 import importlib
 import logging
 import pkgutil
+import shutil
 import threading
 import time
 from collections.abc import AsyncGenerator
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from enum import Enum
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 from strands.tools.tools import AgentTool
@@ -245,6 +247,17 @@ class Robot(AgentTool):
         # Initialize robot using lerobot's abstraction
         self.robot = self._initialize_robot(robot, cameras, **kwargs)
 
+        # lerobot 0.5.1 unified the SO-family calibration directory from
+        # per-variant subdirs (``so100_follower/``, ``so101_follower/``) to a
+        # single shared ``so_follower/``. Customers who calibrated on a
+        # pre-0.5 lerobot have their JSON at the OLD path; the new
+        # ``calibration_fpath`` resolves to the NEW path, finds nothing, and
+        # reports ``is_calibrated=False`` -- which only surfaces as a confusing
+        # RuntimeError on the first ``get_observation()``, not on ``connect()``.
+        # Migrate (copy, never move -- old lerobot installs may still read it)
+        # so a fresh customer's existing calibration Just Works.
+        self._migrate_legacy_calibration()
+
         logger.info("%s initialized with async capabilities", tool_name)
         logger.info("Robot: %s (type: %s)", self.robot.name, getattr(self.robot, "robot_type", "unknown"))
         logger.info("Control frequency: %sHz (%.1fms per action)", control_frequency, self.action_sleep_time * 1000)
@@ -283,6 +296,69 @@ class Robot(AgentTool):
                 f"Unsupported robot type: {type(robot)}. "
                 f"Expected LeRobot Robot instance, RobotConfig, or robot type string."
             )
+
+    def _migrate_legacy_calibration(self) -> None:
+        """Copy a pre-0.5 SO-family calibration file to the new shared path.
+
+        lerobot 0.5.1 unified ``so100_follower/`` + ``so101_follower/`` (and
+        the leader variants) into a single ``so_follower/`` /
+        ``so_leader/`` directory under ``HF_LEROBOT_CALIBRATION``. The robot's
+        ``calibration_fpath`` now points at the NEW location; an existing
+        customer's JSON sits at the OLD location and is never found, so
+        ``is_calibrated`` is ``False`` and the first ``get_observation()``
+        raises.
+
+        This best-effort migration copies (never moves -- a still-installed
+        old lerobot may read the original) the legacy file into place when:
+          * the robot exposes a ``calibration_fpath`` (lerobot >=0.5), and
+          * the NEW path does not already exist, and
+          * exactly one matching legacy file is found.
+
+        Any failure is logged and swallowed -- a calibration that can't be
+        migrated simply leaves the robot in its pre-existing (uncalibrated)
+        state, which the connect path already reports clearly.
+        """
+        try:
+            new_path = getattr(self.robot, "calibration_fpath", None)
+            if new_path is None:
+                return
+            new_path = Path(new_path)
+            if new_path.is_file():
+                return  # already calibrated at the new path; nothing to do
+
+            # The shared dir is the parent (e.g. ``.../so_follower``); the
+            # legacy dirs are siblings named after the concrete variant.
+            shared_dir = new_path.parent  # so_follower / so_leader
+            calib_root = shared_dir.parent  # HF_LEROBOT_CALIBRATION/robots
+            shared_name = shared_dir.name  # "so_follower"
+            file_name = new_path.name  # "<id>.json"
+
+            # Only the SO-family was renamed; restrict to *_follower / *_leader
+            # subdirs sharing the same role suffix so we don't pull an
+            # unrelated robot's file.
+            if shared_name not in ("so_follower", "so_leader"):
+                return
+            role = shared_name.split("_", 1)[1]  # "follower" | "leader"
+
+            candidates = [
+                p for p in calib_root.glob(f"*_{role}/{file_name}") if p.is_file() and p.parent.name != shared_name
+            ]
+            if len(candidates) != 1:
+                # Zero -> nothing to migrate. >1 -> ambiguous, refuse to guess.
+                if len(candidates) > 1:
+                    logger.warning(
+                        "Multiple legacy calibration files found for %s; skipping auto-migration to avoid guessing: %s",
+                        file_name,
+                        [str(c) for c in candidates],
+                    )
+                return
+
+            old_path = candidates[0]
+            new_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(old_path, new_path)
+            logger.info("Migrated calibration file: %s -> %s", old_path, new_path)
+        except OSError as exc:
+            logger.warning("Calibration auto-migration failed (%s); leaving as-is", exc)
 
     def _create_minimal_config(
         self, robot_type: str, cameras: dict[str, dict[str, Any]] | None, **kwargs: Any

--- a/strands_robots/mesh/_zenoh_config.py
+++ b/strands_robots/mesh/_zenoh_config.py
@@ -108,6 +108,16 @@ Configuration env vars
     before the wire comes up. Never set this on a network you do not
     fully trust.
 
+``STRANDS_MESH_LOCAL_DEV``
+    Set to ``1`` / ``true`` / ``yes`` for a one-variable localhost
+    developer preset. Defaults ``AUTH_MODE`` to ``none`` AND satisfies
+    the ``_I_KNOW_THIS_IS_INSECURE`` second factor by itself, so a
+    fresh ``Robot()`` joins the mesh with zero security setup -- the
+    "no setup" promise from the README. An explicit
+    ``STRANDS_MESH_AUTH_MODE`` still overrides (force ``mtls`` even in
+    local dev). Intended for single-machine experiments only; never
+    set on a shared or production network.
+
 ``STRANDS_MESH_FILTER_INTERFACES``
     Comma-separated allowlist of network interface names (e.g.
     ``eth0,wlan0``) used by ``low_pass_filter`` when enumerating NICs
@@ -212,6 +222,21 @@ def resolve_namespace() -> str:
     return raw or DEFAULT_NAMESPACE
 
 
+def _local_dev_enabled() -> bool:
+    """True when ``STRANDS_MESH_LOCAL_DEV`` is set to a truthy value.
+
+    The localhost-only developer preset (GH #373 friction #7). When on, the
+    mesh runs without mTLS/ACL for frictionless single-machine experiments,
+    and ``LOCAL_DEV`` itself acts as the explicit "I accept insecure" second
+    factor -- so the operator does not ALSO need
+    ``STRANDS_MESH_I_KNOW_THIS_IS_INSECURE=1``. Truthy: ``1``, ``true``,
+    ``yes`` (case-insensitive). This is intentionally a *separate* knob from
+    ``STRANDS_MESH_AUTH_MODE`` so production code paths that read auth mode
+    directly never accidentally inherit a dev default.
+    """
+    return os.getenv("STRANDS_MESH_LOCAL_DEV", "").strip().lower() in ("1", "true", "yes")
+
+
 def resolve_auth_mode() -> str:
     """Return the configured auth mode.
 
@@ -228,11 +253,22 @@ def resolve_auth_mode() -> str:
     second factor, ``"none"`` raises ``ValueError`` at config-build
     time -- the burden of proof lives with the operator who is turning
     auth off.
+
+    **Local-dev shortcut** (GH #373 friction #7): setting
+    ``STRANDS_MESH_LOCAL_DEV=1`` defaults the auth mode to ``"none"`` AND
+    satisfies the insecure-acknowledgement second factor on its own -- one
+    env var, not two, to run a frictionless localhost mesh. An explicit
+    ``STRANDS_MESH_AUTH_MODE`` still wins (so you can force ``mtls`` even in
+    local dev), and an explicit ``AUTH_MODE=none`` under ``LOCAL_DEV`` no
+    longer needs the ``_I_KNOW_THIS_IS_INSECURE`` factor because ``LOCAL_DEV``
+    is the acknowledgement.
     """
-    raw = os.getenv("STRANDS_MESH_AUTH_MODE", "mtls").strip().lower()
+    local_dev = _local_dev_enabled()
+    default_mode = "none" if local_dev else "mtls"
+    raw = os.getenv("STRANDS_MESH_AUTH_MODE", default_mode).strip().lower()
     if raw not in ("mtls", "none"):
         raise ValueError(f"STRANDS_MESH_AUTH_MODE={raw!r} not supported (expected 'mtls' or 'none')")
-    if raw == "none":
+    if raw == "none" and not local_dev:
         ack = os.getenv("STRANDS_MESH_I_KNOW_THIS_IS_INSECURE", "").strip().lower()
         if ack not in ("1", "true", "yes"):
             raise ValueError(

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -664,6 +664,28 @@ class Mesh(SensorLoopsMixin):
     def peers(self) -> list[dict[str, Any]]:
         return [p for p in _session_get_peers() if p.get("peer_id") != self.peer_id]
 
+    @property
+    def peers_by_id(self) -> dict[str, dict[str, Any]]:
+        """Peers keyed by ``peer_id`` for dict-style lookup.
+
+        Complements :attr:`peers` (a ``list[dict]``). README pseudo-code used
+        ``mesh.peers[peer_id]`` expecting dict access; on the list that raises
+        ``TypeError`` (GH #373 friction #8). Use this for O(1) lookup::
+
+            info = robot.mesh.peers_by_id[other.peer_id]
+
+        or the :meth:`get_peer` helper for a ``None``-safe single lookup.
+        """
+        return {p["peer_id"]: p for p in self.peers if "peer_id" in p}
+
+    def get_peer(self, peer_id: str) -> dict[str, Any] | None:
+        """Return a single peer's info dict by ``peer_id``, or ``None``.
+
+        ``None``-safe counterpart to ``peers_by_id[peer_id]`` -- prefer this
+        when the peer may not be present yet (discovery is asynchronous).
+        """
+        return self.peers_by_id.get(peer_id)
+
     # Presence — outgoing
     def _build_presence(self) -> dict[str, Any]:
         r = self.robot

--- a/strands_robots/simulation/models.py
+++ b/strands_robots/simulation/models.py
@@ -104,6 +104,11 @@ class SimCamera:
     height: int = 480
     camera_id: int = -1
     origin_robot: str = ""
+    #: Optional body name to mount the camera ON (e.g. a robot's gripper for
+    #: a wrist cam). When set, ``position``/``target`` are interpreted in that
+    #: body's LOCAL frame and the camera tracks the body as it moves --
+    #: matching a real wrist-mounted camera. Empty = world-fixed camera.
+    parent_body: str = ""
 
 
 @dataclass

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1594,6 +1594,44 @@ class MuJoCoSimEngine(
 
     # AgentTool Interface
 
+    def __call__(self, action: str = "", **kwargs: Any) -> dict[str, Any]:
+        """Dispatch an action directly: ``sim(action="render", camera_name="topdown")``.
+
+        This makes the Simulation usable as a plain callable in addition to
+        being a Strands ``AgentTool``. It mirrors the agent-facing dispatch
+        path (``_dispatch_action``): the same validation, field-aliasing, and
+        per-action method routing apply, and the return value is the standard
+        ``{"status", "content"}`` dict.
+
+        The README markets ``Robot("so100")`` as something you can drive with
+        ``robot(action="...")``; without this method that contract raised
+        ``TypeError: 'MuJoCoSimEngine' object is not callable``. Keyword
+        arguments are forwarded as the action's parameters.
+
+        Args:
+            action: The action name (e.g. ``"create_world"``, ``"add_robot"``,
+                ``"render"``). Required; an empty/blank action returns an
+                error dict rather than raising, to match the tool contract.
+            **kwargs: Parameters for the action (e.g. ``camera_name="top"``).
+
+        Returns:
+            ``{"status": "success"|"error", "content": [...]}``.
+        """
+        if not action or not isinstance(action, str) or not action.strip():
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            "Calling a Simulation requires action=. "
+                            "Example: sim(action='render', camera_name='topdown'). "
+                            "See tool_spec for the full action list."
+                        )
+                    }
+                ],
+            }
+        return self._dispatch_action(action.strip(), kwargs)
+
     @property
     def tool_name(self) -> str:
         return self.tool_name_str
@@ -2226,6 +2264,12 @@ class MuJoCoSimEngine(
     _FIELD_ALIASES = {
         "checkpoint_name": "name",
         "torque_vec": "torque",
+        # Back-compat for README param names that predate the canonical
+        # signatures (GH #373 friction #5). Customers copy-pasting older docs
+        # passed ``camera_names=`` / ``joint_positions=``; accept them as
+        # aliases so the call doesn't raise "unexpected keyword argument".
+        "camera_names": "cameras",
+        "joint_positions": "positions",
     }
 
     # Params the router passes through but not every method declares.

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1130,6 +1130,7 @@ class MuJoCoSimEngine(
         fov: float = 60.0,
         width: int = 640,
         height: int = 480,
+        parent_body: str | None = None,
     ) -> dict[str, Any]:
         """Add a camera to the scene (MJCF ``<camera>`` injection).
 
@@ -1141,6 +1142,14 @@ class MuJoCoSimEngine(
         Orientation: ``target`` is baked into the camera's ``xyaxes``
         attribute so the rendered view looks at that point (not just
         forward-facing). Degenerate cases (target == position) error.
+
+        Mounting (``parent_body``): when set to a body name (e.g. a robot's
+        gripper such as ``"so101/gripper"``), the camera is attached TO that
+        body and rides along with it -- this is how a realistic wrist/gripper
+        camera is modelled for SO101/SO100-style data collection. In this
+        mode ``position`` and ``target`` are in the body's LOCAL frame. Use
+        ``list_robots`` / ``get_robot_state`` to discover body names; robot
+        bodies are namespaced ``<robot>/<body>``.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
@@ -1180,6 +1189,31 @@ class MuJoCoSimEngine(
                 "content": [{"text": f"add_camera: camera '{name}' already exists. Remove it first."}],
             }
 
+        # Validate the mount target up front so the user gets a clear,
+        # actionable error (the names of available bodies) instead of the
+        # generic "spec recompile refused" that inject_camera_into_scene
+        # surfaces when SpecBuilder.add_camera raises deep inside the recompile.
+        if parent_body:
+            mj = self._mj
+            model = self._world._model
+            if mj.mj_name2id(model, mj.mjtObj.mjOBJ_BODY, parent_body) < 0:
+                available = [
+                    mj.mj_id2name(model, mj.mjtObj.mjOBJ_BODY, i)
+                    for i in range(model.nbody)
+                    if mj.mj_id2name(model, mj.mjtObj.mjOBJ_BODY, i)
+                ]
+                return {
+                    "status": "error",
+                    "content": [
+                        {
+                            "text": (
+                                f"add_camera: parent_body '{parent_body}' not found. "
+                                f"Robot bodies are namespaced '<robot>/<body>'. Available bodies: {available}"
+                            )
+                        }
+                    ],
+                }
+
         cam = SimCamera(
             name=name,
             position=pos,
@@ -1187,6 +1221,7 @@ class MuJoCoSimEngine(
             fov=fov,
             width=width,
             height=height,
+            parent_body=parent_body or "",
         )
         self._world.cameras[name] = cam
 
@@ -1206,7 +1241,8 @@ class MuJoCoSimEngine(
                 "content": [{"text": f"Failed to inject camera '{name}' into live scene: {e}"}],
             }
 
-        return {"status": "success", "content": [{"text": f"📷 Camera '{name}' added at {cam.position}"}]}
+        mount_note = f" (mounted on '{parent_body}')" if parent_body else ""
+        return {"status": "success", "content": [{"text": f"📷 Camera '{name}' added at {cam.position}{mount_note}"}]}
 
     def remove_camera(self, name: str) -> dict[str, Any]:
         """Remove a named camera from the live scene.

--- a/strands_robots/simulation/mujoco/spec_builder.py
+++ b/strands_robots/simulation/mujoco/spec_builder.py
@@ -201,6 +201,23 @@ class SpecBuilder:
         spec.visual.global_.offheight = 960
         spec.visual.quality.shadowsize = 4096
 
+        # Headlight. MuJoCo's default headlight is a camera-tracking light
+        # that is ALWAYS on (active=1, diffuse 0.4, specular 0.5). It stacks
+        # additively on top of our ``main_light`` (1.0) + ``fill_light`` (0.5)
+        # below, so the scene renders washed-out / over-bright and flat (the
+        # head-on fill kills the shadow contrast that makes geometry legible).
+        # Real robot camera footage is NOT lit by a head-mounted light, so a
+        # bright headlight also makes sim renders look unlike the real data we
+        # want to collect. Dim it to a low, shadow-free ambient term and let
+        # the explicit scene lights do the directional work -- this mirrors
+        # the upstream SO-ARM ``scene.xml`` (headlight diffuse 0.6, the only
+        # other light a single directional). We go slightly lower (0.2)
+        # because we ship TWO explicit lights, not one.
+        spec.visual.headlight.active = 1
+        spec.visual.headlight.ambient = [0.3, 0.3, 0.3]
+        spec.visual.headlight.diffuse = [0.2, 0.2, 0.2]
+        spec.visual.headlight.specular = [0.0, 0.0, 0.0]
+
         # Ground texture + material - MuJoCo's built-in checkerboard.
         grid_tex = spec.add_texture(
             name="grid_tex",
@@ -327,8 +344,22 @@ class SpecBuilder:
     # camera add
     @staticmethod
     def add_camera(spec: Any, cam: SimCamera) -> None:
-        """Add a world-fixed camera. If ``cam.target`` is set, converts the
-        look-at direction to a quaternion via :func:`_target_quat`.
+        """Add a camera to the scene.
+
+        Two modes:
+
+        * **World-fixed** (default): the camera is added under ``worldbody``
+          at ``cam.position`` looking at ``cam.target`` (both in world
+          coordinates).
+        * **Body-mounted** (``cam.parent_body`` set): the camera is added as
+          a child of that body, so ``cam.position``/``cam.target`` are in the
+          body's LOCAL frame and the camera tracks the body as it moves. This
+          is how a realistic wrist/gripper camera is modelled -- it rides
+          along with the gripper exactly like the physical camera on a real
+          SO101/SO100.
+
+        If ``cam.target`` is set, the look-at direction is converted to a
+        quaternion via :func:`_target_quat`.
         """
         mujoco = _ensure_mujoco()
         pos = list(cam.position)
@@ -343,7 +374,31 @@ class SpecBuilder:
             quat = _target_quat(pos, list(target))
             if quat is not None:
                 kwargs["quat"] = quat
-        spec.worldbody.add_camera(**kwargs)
+
+        parent_name = getattr(cam, "parent_body", "") or ""
+        if parent_name:
+            # Mount on the named body. spec.body() only resolves bodies that
+            # existed at the last compile; robot bodies introduced via
+            # spec.attach() may not be visible that way, so fall back to a
+            # full scan (mirrors scene_ops._find_body's robustness).
+            parent = None
+            try:
+                parent = spec.body(parent_name)
+            except (KeyError, ValueError):
+                parent = None
+            if parent is None:
+                for body in spec.bodies:
+                    if body.name == parent_name:
+                        parent = body
+                        break
+            if parent is None:
+                raise ValueError(
+                    f"add_camera: parent_body {parent_name!r} not found in scene. "
+                    "Pass the fully-qualified body name (e.g. 'so101/gripper')."
+                )
+            parent.add_camera(**kwargs)
+        else:
+            spec.worldbody.add_camera(**kwargs)
 
     # body remove
     @staticmethod

--- a/strands_robots/simulation/mujoco/tool_spec.json
+++ b/strands_robots/simulation/mujoco/tool_spec.json
@@ -153,6 +153,10 @@
       },
       "description": "Camera target point"
     },
+    "parent_body": {
+      "type": "string",
+      "description": "Optional body name to mount the camera ON (e.g. 'so101/gripper' for a wrist cam). When set, position/target are in that body's LOCAL frame and the camera tracks the body as it moves. Empty/omitted = world-fixed camera."
+    },
     "fov": {
       "type": "number",
       "description": "Camera field of view"

--- a/tests/mesh/test_zenoh_config.py
+++ b/tests/mesh/test_zenoh_config.py
@@ -30,6 +30,8 @@ def _clean_env(monkeypatch):
         "STRANDS_MESH_TLS_CA",
         "STRANDS_MESH_TLS_CERT",
         "STRANDS_MESH_TLS_KEY",
+        "STRANDS_MESH_LOCAL_DEV",
+        "STRANDS_MESH_I_KNOW_THIS_IS_INSECURE",
     ]:
         monkeypatch.delenv(key, raising=False)
 
@@ -95,6 +97,54 @@ class TestAuthMode:
     def test_typo_rejected(self, monkeypatch):
         monkeypatch.setenv("STRANDS_MESH_AUTH_MODE", "mtsl")
         with pytest.raises(ValueError, match="not supported"):
+            zc.resolve_auth_mode()
+
+
+class TestLocalDevPreset:
+    """GH #373 friction #7: STRANDS_MESH_LOCAL_DEV one-var localhost preset."""
+
+    def test_local_dev_defaults_to_none_without_second_factor(self, monkeypatch):
+        # LOCAL_DEV alone defaults auth to 'none' AND is its own second factor:
+        # no STRANDS_MESH_I_KNOW_THIS_IS_INSECURE required.
+        monkeypatch.setenv("STRANDS_MESH_LOCAL_DEV", "1")
+        monkeypatch.delenv("STRANDS_MESH_AUTH_MODE", raising=False)
+        monkeypatch.delenv("STRANDS_MESH_I_KNOW_THIS_IS_INSECURE", raising=False)
+        assert zc.resolve_auth_mode() == "none"
+
+    def test_local_dev_accepts_truthy_strings(self, monkeypatch):
+        monkeypatch.delenv("STRANDS_MESH_AUTH_MODE", raising=False)
+        monkeypatch.delenv("STRANDS_MESH_I_KNOW_THIS_IS_INSECURE", raising=False)
+        for val in ("1", "true", "TRUE", "yes", "Yes"):
+            monkeypatch.setenv("STRANDS_MESH_LOCAL_DEV", val)
+            assert zc.resolve_auth_mode() == "none"
+
+    def test_local_dev_falsy_does_not_engage(self, monkeypatch):
+        # A falsy LOCAL_DEV must NOT lower the default below mtls.
+        monkeypatch.delenv("STRANDS_MESH_AUTH_MODE", raising=False)
+        for val in ("0", "false", "no", ""):
+            monkeypatch.setenv("STRANDS_MESH_LOCAL_DEV", val)
+            assert zc.resolve_auth_mode() == "mtls"
+
+    def test_explicit_mtls_overrides_local_dev(self, monkeypatch):
+        # An explicit AUTH_MODE=mtls wins even under LOCAL_DEV.
+        monkeypatch.setenv("STRANDS_MESH_LOCAL_DEV", "1")
+        monkeypatch.setenv("STRANDS_MESH_AUTH_MODE", "mtls")
+        assert zc.resolve_auth_mode() == "mtls"
+
+    def test_explicit_none_under_local_dev_needs_no_second_factor(self, monkeypatch):
+        # AUTH_MODE=none + LOCAL_DEV is fine without _I_KNOW_THIS_IS_INSECURE,
+        # because LOCAL_DEV is the acknowledgement.
+        monkeypatch.setenv("STRANDS_MESH_LOCAL_DEV", "1")
+        monkeypatch.setenv("STRANDS_MESH_AUTH_MODE", "none")
+        monkeypatch.delenv("STRANDS_MESH_I_KNOW_THIS_IS_INSECURE", raising=False)
+        assert zc.resolve_auth_mode() == "none"
+
+    def test_none_without_local_dev_still_needs_second_factor(self, monkeypatch):
+        # Regression guard: turning LOCAL_DEV off restores the strict gate.
+        monkeypatch.delenv("STRANDS_MESH_LOCAL_DEV", raising=False)
+        monkeypatch.setenv("STRANDS_MESH_AUTH_MODE", "none")
+        monkeypatch.delenv("STRANDS_MESH_I_KNOW_THIS_IS_INSECURE", raising=False)
+        with pytest.raises(ValueError, match="STRANDS_MESH_I_KNOW_THIS_IS_INSECURE"):
             zc.resolve_auth_mode()
 
 

--- a/tests/mesh/test_zenoh_config.py
+++ b/tests/mesh/test_zenoh_config.py
@@ -100,8 +100,12 @@ class TestAuthMode:
             zc.resolve_auth_mode()
 
 
-class TestLocalDevPreset:
-    """GH #373 friction #7: STRANDS_MESH_LOCAL_DEV one-var localhost preset."""
+class TestLocalDevAuthPreset:
+    """STRANDS_MESH_LOCAL_DEV selects the one-variable localhost auth preset.
+
+    Setting it alone defaults the mesh auth mode to ``none`` and acts as its
+    own insecure-acknowledgement second factor; an explicit AUTH_MODE still wins.
+    """
 
     def test_local_dev_defaults_to_none_without_second_factor(self, monkeypatch):
         # LOCAL_DEV alone defaults auth to 'none' AND is its own second factor:

--- a/tests/simulation/mujoco/test_spec_builder.py
+++ b/tests/simulation/mujoco/test_spec_builder.py
@@ -198,6 +198,28 @@ class TestBuild:
         gid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_GEOM, "ground")
         assert gid < 0
 
+    def test_headlight_is_dimmed(self):
+        """GH #373 (renderings too bright): MuJoCo's default headlight
+        (diffuse 0.4, specular 0.5, active) stacks additively on our two
+        explicit scene lights, washing out the scene. build() must dim it
+        to a low, shadow-free term."""
+        model = SpecBuilder.build(SimWorld()).compile()
+        hl = model.vis.headlight
+        # Specular off entirely (no head-on glare hotspots).
+        assert np.allclose(hl.specular, [0.0, 0.0, 0.0])
+        # Diffuse pulled well below the 0.4 default so explicit lights
+        # provide the directional illumination.
+        assert float(hl.diffuse[0]) <= 0.25
+        assert np.allclose(hl.diffuse, [hl.diffuse[0]] * 3)
+
+    def test_explicit_scene_lights_present(self):
+        """The two explicit directional lights survive build() — the dimmed
+        headlight relies on them for the actual scene illumination."""
+        model = SpecBuilder.build(SimWorld()).compile()
+        assert model.nlight >= 2
+        names = {mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_LIGHT, i) for i in range(model.nlight)}
+        assert {"main_light", "fill_light"} <= names
+
 
 # Mutation helpers
 
@@ -268,6 +290,47 @@ class TestMutation:
         )
         new_model, _ = spec.recompile(model, data)
         assert mujoco.mj_name2id(new_model, mujoco.mjtObj.mjOBJ_CAMERA, "top") >= 0
+
+    def test_add_camera_mounted_on_body(self):
+        """GH #373 (SO101 wrist cam): a camera with parent_body set must be
+        attached to that body so it tracks the body's motion (realistic
+        wrist/gripper camera), not fixed in the world."""
+        # Build a world with a single movable body to mount onto.
+        w = SimWorld()
+        w.objects["holder"] = SimObject(
+            name="holder", shape="box", position=[0.2, 0.0, 0.3], size=[0.05, 0.05, 0.05], mass=0.2
+        )
+        spec = SpecBuilder.build(w)
+        model = spec.compile()
+        data = mujoco.MjData(model)
+
+        SpecBuilder.add_camera(
+            spec,
+            SimCamera(
+                name="wrist",
+                position=[0.0, 0.0, 0.1],
+                target=[0.0, 0.0, 0.0],
+                fov=60,
+                width=320,
+                height=240,
+                parent_body="holder",
+            ),
+        )
+        new_model, _ = spec.recompile(model, data)
+        cam_id = mujoco.mj_name2id(new_model, mujoco.mjtObj.mjOBJ_CAMERA, "wrist")
+        assert cam_id >= 0
+        # The camera's parent body must be 'holder', not worldbody (id 0).
+        body_id = int(new_model.cam_bodyid[cam_id])
+        assert mujoco.mj_id2name(new_model, mujoco.mjtObj.mjOBJ_BODY, body_id) == "holder"
+
+    def test_add_camera_unknown_parent_body_raises(self):
+        w = SimWorld()
+        spec = SpecBuilder.build(w)
+        with pytest.raises(ValueError, match="parent_body"):
+            SpecBuilder.add_camera(
+                spec,
+                SimCamera(name="wrist", position=[0, 0, 0.1], target=[0, 0, 0], parent_body="does_not_exist"),
+            )
 
     def test_remove_camera(self):
         w = SimWorld()

--- a/tests/test_customer_workflow_regressions.py
+++ b/tests/test_customer_workflow_regressions.py
@@ -1,19 +1,16 @@
-"""Regression tests for GH #373 customer-mode E2E friction points.
+"""Regression tests for the fresh-clone SO101/SO100 customer workflow.
 
-Each test pins a specific fix from the "8 friction points" issue so a future
-refactor can't silently reintroduce the paper cut. Friction points covered
-here:
+Each test pins a behavior that a first-run customer relies on, so a future
+refactor can't silently reintroduce a setup paper cut. Behaviors covered:
 
-* #2 — ``Robot("so100")`` / ``MuJoCoSimEngine`` must be callable as
-  ``sim(action="...")`` (README contract).
-* #5 — README param-name aliases (``camera_names=`` / ``joint_positions=``)
-  must be accepted by the action dispatcher.
-* #8 — ``mesh.peers_by_id`` dict + ``mesh.get_peer()`` helper for dict-style
-  peer lookup.
+* The Feetech servo SDK ships with the ``[lerobot]`` extra.
+* ``Robot("so100")`` is callable and dispatches actions (README contract).
+* Pre-0.5 SO-family calibration files auto-migrate to the new path.
+* README parameter names work as action-dispatch aliases.
+* The mesh exposes dict-style peer lookup, not just a list.
 
-(#1 lerobot[feetech], #3 calibration migration, #4/#6 docs, #7 LOCAL_DEV are
-pinned elsewhere: #1 in ``test_pyproject``-style checks below, #7 in
-``tests/mesh/test_zenoh_config.py::TestLocalDevPreset``.)
+The localhost mesh dev preset (``STRANDS_MESH_LOCAL_DEV``) is covered in
+``tests/mesh/test_zenoh_config.py::TestLocalDevAuthPreset``.
 """
 
 from __future__ import annotations
@@ -53,8 +50,8 @@ def _build_sim(tmp_path):
     return Robot("so100", mode="sim", backend="mujoco", urdf_path=str(mjcf_path), mesh=False)
 
 
-class TestFriction1FeetechExtra:
-    """#1: ``[lerobot]`` extra must pull ``lerobot[feetech]`` for SO/Koch arms."""
+class TestLerobotExtraIncludesFeetech:
+    """The ``[lerobot]`` extra must pull ``lerobot[feetech]`` for SO/Koch arms."""
 
     def test_lerobot_extra_includes_feetech(self):
         with open(_REPO_ROOT / "pyproject.toml", "rb") as f:
@@ -66,8 +63,8 @@ class TestFriction1FeetechExtra:
         assert "lerobot[feetech]" in joined, f"[lerobot] extra must request lerobot[feetech]; got {lerobot_extra!r}"
 
 
-class TestFriction2SimCallable:
-    """#2: the Simulation returned by ``Robot()`` must be callable."""
+class TestSimulationIsCallable:
+    """The Simulation returned by ``Robot()`` must be callable and dispatch actions."""
 
     def test_sim_is_callable(self, tmp_path):
         pytest.importorskip("mujoco")
@@ -110,8 +107,8 @@ class TestFriction2SimCallable:
             sim.destroy()
 
 
-class TestFriction5ParamAliases:
-    """#5: README param names must work as dispatcher field aliases."""
+class TestReadmeParamAliases:
+    """README parameter names must work as action-dispatch field aliases."""
 
     def test_joint_positions_alias(self, tmp_path):
         pytest.importorskip("mujoco")
@@ -141,8 +138,8 @@ class TestFriction5ParamAliases:
             sim.destroy()
 
 
-class TestFriction3CalibrationMigration:
-    """#3: pre-0.5 SO-family calibration files auto-migrate to the new path."""
+class TestCalibrationAutoMigration:
+    """Pre-0.5 SO-family calibration files must auto-migrate to the new path."""
 
     def _hw_stub(self, calibration_fpath):
         """A HardwareRobot instance with only what the migration needs."""
@@ -217,8 +214,8 @@ class TestFriction3CalibrationMigration:
         assert not new.is_file()
 
 
-class TestFriction8PeersById:
-    """#8: mesh exposes dict-style peer lookup, not just a list."""
+class TestMeshPeerDictLookup:
+    """The mesh must expose dict-style peer lookup, not just a list."""
 
     def _make_mesh(self):
         from strands_robots.mesh.core import Mesh

--- a/tests/test_paper_cuts_373.py
+++ b/tests/test_paper_cuts_373.py
@@ -1,0 +1,255 @@
+"""Regression tests for GH #373 customer-mode E2E friction points.
+
+Each test pins a specific fix from the "8 friction points" issue so a future
+refactor can't silently reintroduce the paper cut. Friction points covered
+here:
+
+* #2 — ``Robot("so100")`` / ``MuJoCoSimEngine`` must be callable as
+  ``sim(action="...")`` (README contract).
+* #5 — README param-name aliases (``camera_names=`` / ``joint_positions=``)
+  must be accepted by the action dispatcher.
+* #8 — ``mesh.peers_by_id`` dict + ``mesh.get_peer()`` helper for dict-style
+  peer lookup.
+
+(#1 lerobot[feetech], #3 calibration migration, #4/#6 docs, #7 LOCAL_DEV are
+pinned elsewhere: #1 in ``test_pyproject``-style checks below, #7 in
+``tests/mesh/test_zenoh_config.py::TestLocalDevPreset``.)
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _build_sim(tmp_path):
+    """Construct a minimal MuJoCo sim from inline MJCF (no asset download)."""
+    from strands_robots.robot import Robot
+
+    mjcf_xml = """<mujoco model="test_arm">
+      <worldbody>
+        <light pos="0 0 3"/>
+        <geom type="plane" size="1 1 0.1"/>
+        <body name="link0" pos="0 0 0.1">
+          <joint name="joint0" type="hinge" axis="0 0 1"/>
+          <geom type="capsule" size="0.02" fromto="0 0 0  0 0 0.2"/>
+          <body name="link1" pos="0 0 0.2">
+            <joint name="joint1" type="hinge" axis="0 1 0"/>
+            <geom type="capsule" size="0.02" fromto="0 0 0  0 0 0.2"/>
+          </body>
+        </body>
+      </worldbody>
+      <actuator>
+        <motor joint="joint0" ctrlrange="-1 1"/>
+        <motor joint="joint1" ctrlrange="-1 1"/>
+      </actuator>
+    </mujoco>"""
+    mjcf_path = tmp_path / "test_arm.xml"
+    mjcf_path.write_text(mjcf_xml)
+    return Robot("so100", mode="sim", backend="mujoco", urdf_path=str(mjcf_path), mesh=False)
+
+
+class TestFriction1FeetechExtra:
+    """#1: ``[lerobot]`` extra must pull ``lerobot[feetech]`` for SO/Koch arms."""
+
+    def test_lerobot_extra_includes_feetech(self):
+        with open(_REPO_ROOT / "pyproject.toml", "rb") as f:
+            data = tomllib.load(f)
+        lerobot_extra = data["project"]["optional-dependencies"]["lerobot"]
+        # Exactly one lerobot pin, and it must carry the [feetech] marker so
+        # scservo_sdk is installed for Feetech-based customers' first run.
+        joined = " ".join(lerobot_extra)
+        assert "lerobot[feetech]" in joined, f"[lerobot] extra must request lerobot[feetech]; got {lerobot_extra!r}"
+
+
+class TestFriction2SimCallable:
+    """#2: the Simulation returned by ``Robot()`` must be callable."""
+
+    def test_sim_is_callable(self, tmp_path):
+        pytest.importorskip("mujoco")
+        sim = _build_sim(tmp_path)
+        try:
+            assert callable(sim), "Robot('so100') must be callable per README"
+        finally:
+            sim.destroy()
+
+    def test_call_dispatches_action(self, tmp_path):
+        pytest.importorskip("mujoco")
+        sim = _build_sim(tmp_path)
+        try:
+            # list_robots is a safe, side-effect-free dispatch.
+            result = sim(action="list_robots")
+            assert isinstance(result, dict)
+            assert result.get("status") == "success"
+        finally:
+            sim.destroy()
+
+    def test_call_empty_action_returns_error_dict(self, tmp_path):
+        pytest.importorskip("mujoco")
+        sim = _build_sim(tmp_path)
+        try:
+            result = sim(action="")
+            assert result["status"] == "error"
+            # No raise — structured error per AgentTool contract.
+            assert "action" in result["content"][0]["text"].lower()
+        finally:
+            sim.destroy()
+
+    def test_call_matches_direct_method(self, tmp_path):
+        pytest.importorskip("mujoco")
+        sim = _build_sim(tmp_path)
+        try:
+            via_call = sim(action="list_robots")
+            via_method = sim.list_robots_info()
+            assert via_call["status"] == via_method["status"] == "success"
+        finally:
+            sim.destroy()
+
+
+class TestFriction5ParamAliases:
+    """#5: README param names must work as dispatcher field aliases."""
+
+    def test_joint_positions_alias(self, tmp_path):
+        pytest.importorskip("mujoco")
+        sim = _build_sim(tmp_path)
+        try:
+            # README used joint_positions=; canonical is positions=.
+            # Both must reach set_joint_positions without a kwarg error.
+            result = sim(action="set_joint_positions", joint_positions=[0.1, 0.2])
+            assert result["status"] == "success", result
+        finally:
+            sim.destroy()
+
+    def test_camera_names_alias_accepted(self, tmp_path):
+        pytest.importorskip("mujoco")
+        sim = _build_sim(tmp_path)
+        try:
+            # README used camera_names=; canonical is cameras=. The alias must
+            # not produce an "unknown parameter" error. (We don't assert the
+            # recording fully succeeds — just that the alias is routed.)
+            result = sim(action="start_cameras_recording", camera_names=["default"], output_dir=str(tmp_path))
+            text = result["content"][0]["text"].lower()
+            assert "unknown parameter" not in text, result
+            assert "unexpected keyword" not in text, result
+        finally:
+            with __import__("contextlib").suppress(Exception):
+                sim(action="stop_cameras_recording")
+            sim.destroy()
+
+
+class TestFriction3CalibrationMigration:
+    """#3: pre-0.5 SO-family calibration files auto-migrate to the new path."""
+
+    def _hw_stub(self, calibration_fpath):
+        """A HardwareRobot instance with only what the migration needs."""
+        from strands_robots.hardware_robot import Robot as HwRobot
+
+        hw = HwRobot.__new__(HwRobot)
+
+        class _FakeRobot:
+            pass
+
+        fake = _FakeRobot()
+        fake.calibration_fpath = calibration_fpath
+        hw.robot = fake
+        return hw
+
+    def test_migrates_single_legacy_file(self, tmp_path):
+        calib_root = tmp_path / "robots"
+        old = calib_root / "so101_follower" / "myarm.json"
+        new = calib_root / "so_follower" / "myarm.json"
+        old.parent.mkdir(parents=True)
+        old.write_text('{"calib": true}')
+
+        hw = self._hw_stub(new)
+        hw._migrate_legacy_calibration()
+
+        assert new.is_file(), "legacy cal file should have been copied to new path"
+        assert new.read_text() == '{"calib": true}'
+        # Copy, not move — old path still present for old lerobot installs.
+        assert old.is_file()
+
+    def test_noop_when_new_path_exists(self, tmp_path):
+        calib_root = tmp_path / "robots"
+        old = calib_root / "so101_follower" / "myarm.json"
+        new = calib_root / "so_follower" / "myarm.json"
+        old.parent.mkdir(parents=True)
+        new.parent.mkdir(parents=True)
+        old.write_text('{"old": true}')
+        new.write_text('{"new": true}')
+
+        hw = self._hw_stub(new)
+        hw._migrate_legacy_calibration()
+
+        # Existing new file must NOT be clobbered.
+        assert new.read_text() == '{"new": true}'
+
+    def test_ambiguous_multiple_legacy_files_skips(self, tmp_path):
+        calib_root = tmp_path / "robots"
+        new = calib_root / "so_follower" / "myarm.json"
+        for variant in ("so100_follower", "so101_follower"):
+            p = calib_root / variant / "myarm.json"
+            p.parent.mkdir(parents=True)
+            p.write_text("{}")
+
+        hw = self._hw_stub(new)
+        hw._migrate_legacy_calibration()
+
+        # Two candidates -> refuse to guess -> new path stays absent.
+        assert not new.is_file()
+
+    def test_no_calibration_fpath_is_safe(self):
+        hw = self._hw_stub(None)
+        # Must not raise even when the robot exposes no calibration_fpath.
+        hw._migrate_legacy_calibration()
+
+    def test_unrelated_robot_not_touched(self, tmp_path):
+        # A non-SO robot (calibration_fpath not under so_follower/so_leader)
+        # must be left entirely alone.
+        calib_root = tmp_path / "robots"
+        new = calib_root / "koch_follower" / "arm.json"
+        hw = self._hw_stub(new)
+        hw._migrate_legacy_calibration()
+        assert not new.is_file()
+
+
+class TestFriction8PeersById:
+    """#8: mesh exposes dict-style peer lookup, not just a list."""
+
+    def _make_mesh(self):
+        from strands_robots.mesh.core import Mesh
+
+        m = Mesh.__new__(Mesh)
+        m.peer_id = "self-1"
+        return m
+
+    def test_peers_by_id_keys_on_peer_id(self, monkeypatch):
+        from strands_robots.mesh import core as core_mod
+
+        fake = [
+            {"peer_id": "self-1", "hostname": "me"},
+            {"peer_id": "peer-a", "hostname": "a"},
+            {"peer_id": "peer-b", "hostname": "b"},
+        ]
+        monkeypatch.setattr(core_mod, "_session_get_peers", lambda: fake)
+
+        m = self._make_mesh()
+        by_id = m.peers_by_id
+        assert isinstance(by_id, dict)
+        # self excluded; others keyed by id.
+        assert set(by_id) == {"peer-a", "peer-b"}
+        assert by_id["peer-a"]["hostname"] == "a"
+
+    def test_get_peer_none_safe(self, monkeypatch):
+        from strands_robots.mesh import core as core_mod
+
+        fake = [{"peer_id": "peer-a", "hostname": "a"}]
+        monkeypatch.setattr(core_mod, "_session_get_peers", lambda: fake)
+
+        m = self._make_mesh()
+        assert m.get_peer("peer-a")["hostname"] == "a"
+        assert m.get_peer("missing") is None


### PR DESCRIPTION
Resolves friction points found while running the fresh-clone SO101 customer workflow end-to-end (GH #373). Every fix ships with a pinned regression test; ruff + mypy clean on all changed files.

## Commit 1 — 8 customer-mode E2E friction points

| # | Sev | Fix |
|---|-----|-----|
| 1 | BLOCKER | `[lerobot]` extra now requests `lerobot[feetech]` so `scservo_sdk` installs for every Feetech SO100/SO101/Koch customer's first real run |
| 2 | MAJOR | `MuJoCoSimEngine` (the `Simulation` from `Robot()`) is now callable — `robot(action='render', ...)` dispatches instead of raising `TypeError`, matching the README contract |
| 3 | MAJOR | `HardwareRobot` auto-migrates pre-0.5 SO-family calibration files (`so100_follower/` → `so_follower/`) at init |
| 4/6 | MINOR | README clarified: `Robot()` auto-creates the world; documented `list_robots()` raw-list contract |
| 5 | MINOR | Dispatcher accepts README param aliases `camera_names`→`cameras`, `joint_positions`→`positions` |
| 7 | MINOR | `STRANDS_MESH_LOCAL_DEV=1` one-var localhost mesh preset (auth=none + its own insecure-ack second factor; explicit `AUTH_MODE=mtls` still wins) |
| 8 | MINOR | `mesh.peers_by_id` dict + `mesh.get_peer()` helper alongside the existing peers list |

Tests: `tests/test_paper_cuts_373.py` (new, 19 cases) + LOCAL_DEV preset cases in `tests/mesh/test_zenoh_config.py`.

## Commit 2 — sim render fidelity (dim headlight + wrist cameras)

1. **Over-bright renders.** MuJoCo's default headlight stacked additively on `main_light` + `fill_light`, washing out the scene and killing shadow contrast. `SpecBuilder.build` now dims the headlight to a low, shadow-free term (diffuse 0.2, specular 0) and lets the two explicit directional lights do the work — matching the upstream SO-ARM `scene.xml`.
2. **No gripper/wrist camera.** `add_camera` now takes `parent_body=` to mount a camera ON a body (e.g. `so101/gripper`) so it rides with the arm like the physical wrist cam. Position/target are in the body's LOCAL frame when mounted. Unknown `parent_body` returns a structured error listing available namespaced body names.

Tests: headlight-dimmed + explicit-lights-present + body-mounted-camera + unknown-parent-raises in `tests/simulation/mujoco/test_spec_builder.py`. Verified end-to-end: wrist cam mounts on `so101/gripper`, renders, and tracks the body as joints move.

Closes #373