### PR TITLE
fix(gr00t_inference): symlink-resolve volume guard + posttrain docstring split (#391)

### DIFF
--- a/strands_robots/tools/gr00t_inference.py
+++ b/strands_robots/tools/gr00t_inference.py
@@ -69,6 +69,15 @@ _DEFAULT_REPO_URL_ALLOW: tuple[str, ...] = (
 # of these hands the container (and anything that can influence its command)
 # control over the host: root fs, the docker socket (daemon takeover),
 # credential/identity dirs, and kernel/proc/sys pseudo-filesystems.
+# NOTE (#384, item 1): ``/home`` is blocked wholesale, not narrowed to the
+# sensitive subpaths (~/.ssh, ~/.aws, ~/.config). Rationale: this guard is
+# defence-in-depth for an untrusted/prompt-injected caller, and any home
+# directory may hold credentials, tokens, or dotfiles whose names we cannot
+# enumerate ahead of time. Operators who need a checkpoint bind-mount must
+# place it OUTSIDE ``/home`` (e.g. ``/data/checkpoints`` or ``/opt/...``); the
+# auto-derived default (``~/.cache/huggingface``) is never agent-controlled
+# and reaches docker only via the curated ``effective_volumes`` set. See the
+# README Configuration section for the operator-facing guidance.
 _BLOCKED_VOLUME_HOST_PATHS: tuple[str, ...] = (
     "/",
     "/etc",
@@ -231,6 +240,26 @@ def _normalize_host_path(host_path: str) -> str:
     return os.path.normpath(expanded)
 
 
+def _resolve_host_path(host_path: str) -> str:
+    """Resolve a bind-mount host path through symlinks for blocklist comparison.
+
+    NOTE (#384, item 2): ``_normalize_host_path`` only canonicalises slashes
+    and runs ``normpath`` -- it does NOT follow symlinks. A pre-existing host
+    symlink pointing at a protected dir (e.g. ``/data/ckpt -> /etc``) would
+    pass the blocklist while docker mounts the resolved target. We additionally
+    compare the ``realpath`` so the symlink target is also checked.
+
+    Residual TOCTOU: ``realpath`` resolves at check time; a symlink swapped
+    between check and ``docker run`` could still differ. That race is not
+    closable at this layer (it is a host-fs-mutation primitive the gr00t tool
+    does not expose to the agent), so we resolve best-effort and accept the
+    residual gap. ``os.path.realpath`` does not raise on missing paths -- it
+    resolves as far as it can -- so this is safe to call on not-yet-created
+    mount sources.
+    """
+    return os.path.realpath(os.path.expanduser(host_path))
+
+
 def _check_volume_safety(volumes: dict[str, str] | None) -> str | None:
     """Return None if all bind-mount host paths are safe, else a reason.
 
@@ -245,7 +274,11 @@ def _check_volume_safety(volumes: dict[str, str] | None) -> str | None:
     blocked_exact = {os.path.normpath(p) for p in _BLOCKED_VOLUME_EXACT}
     for host_path in volumes:
         norm = _normalize_host_path(str(host_path))
-        if norm in blocked_exact:
+        # #384 item 2: also evaluate the symlink-resolved path so a host symlink
+        # pointing into a protected dir cannot slip past the prefix check.
+        resolved = _resolve_host_path(str(host_path))
+        candidates = {norm, resolved}
+        if blocked_exact & candidates:
             return f"refusing to mount {host_path!r}: docker socket / sensitive path"
         # Prefix check: reject the protected dir itself AND any child of it, so
         # mounting /etc/shadow, /root/.ssh/id_rsa, /home/<u>/.aws/credentials,
@@ -254,11 +287,12 @@ def _check_volume_safety(volumes: dict[str, str] | None) -> str | None:
         # every absolute path, including legitimate operator mounts.
         for blocked in blocked_dirs:
             if blocked == os.sep:
-                if norm == os.sep:
+                if os.sep in candidates:
                     return f"refusing to mount {host_path!r}: host root filesystem"
                 continue
-            if norm == blocked or norm.startswith(blocked + os.sep):
-                return f"refusing to mount {host_path!r}: under protected host path {blocked!r}"
+            for cand in candidates:
+                if cand == blocked or cand.startswith(blocked + os.sep):
+                    return f"refusing to mount {host_path!r}: under protected host path {blocked!r}"
     return None
 
 
@@ -378,9 +412,15 @@ def gr00t_inference(
           ``fourier_gr1_full_upper_body``
 
         **Unitree G1 humanoid:**
-          ``unitree_g1``, ``unitree_g1_full_body``, ``unitree_g1_locomanip``,
-          ``unitree_g1_real`` (N1.7 REAL_G1 embodiment - locomotion + bimanual manipulation),
-          ``unitree_g1_sonic`` (SONIC whole-body controller - VLA action space is SONIC latents; requires a finetuned checkpoint, not the base nvidia/GR00T-N1.7-3B)
+          ``unitree_g1_real`` (N1.7 REAL_G1 embodiment - locomotion + bimanual
+          manipulation; PRETRAIN - works directly with the base model),
+          ``unitree_g1`` [posttrain], ``unitree_g1_full_body`` [posttrain],
+          ``unitree_g1_locomanip``,
+          ``unitree_g1_sonic`` [posttrain] (SONIC whole-body controller - the
+          VLA emits 64-dim SONIC motion-token latents, NOT executable joint
+          commands; they must be decoded by the SONIC runtime from
+          NVlabs/GR00T-WholeBodyControl. Requires a finetuned checkpoint, not
+          the base nvidia/GR00T-N1.7-3B)
 
         **Franka Panda manipulators:**
           ``single_panda_gripper``, ``bimanual_panda_gripper``, ``bimanual_panda_hand``
@@ -389,7 +429,8 @@ def gr00t_inference(
           ``oxe_droid``, ``oxe_google``, ``oxe_widowx``
 
         **Simulation:**
-          ``libero_panda``
+          ``libero_panda`` [posttrain], ``libero_sim`` [posttrain],
+          ``simpler_env_google`` [posttrain], ``simpler_env_widowx`` [posttrain]
 
         **AgiBOT:**
           ``agibot_genie1``, ``agibot_dual_arm_gripper`` (alias: ``agibot_dual_arm``),
@@ -397,6 +438,15 @@ def gr00t_inference(
 
         **Galaxea:**
           ``galaxea_r1_pro``
+
+        .. note::
+           Entries marked ``[posttrain]`` correspond to upstream
+           ``POSTTRAIN_TAGS`` (Isaac-GR00T ``gr00t/data/embodiment_tags.py``):
+           ``unitree_g1``, ``unitree_g1_sonic``, ``libero_panda`` / ``libero_sim``,
+           ``simpler_env_google``, ``simpler_env_widowx``. They REQUIRE a
+           finetuned checkpoint - pointing the base ``nvidia/GR00T-N1.7-3B`` at a
+           posttrain tag silently emits garbage actions. Unmarked entries are
+           pretrain tags baked into the base model and work directly.
 
     TensorRT acceleration:
         Set ``use_tensorrt=True`` to enable TensorRT inference. This compiles the model

--- a/tests/policies/groot/test_data_config.py
+++ b/tests/policies/groot/test_data_config.py
@@ -238,6 +238,49 @@ class TestDataConfigMap:
             "before the next double-backtick-quoted tag entry"
         )
 
+    # The upstream POSTTRAIN_TAGS set (Isaac-GR00T gr00t/data/embodiment_tags.py).
+    # Every posttrain embodiment exposed in the gr00t_inference docstring MUST
+    # carry a posttrain marker so a user does not point the base checkpoint at
+    # one and get silent garbage actions. Pinned here so a future addition of a
+    # posttrain tag to the docstring fails CI until it is marked (#213).
+    _POSTTRAIN_TAGS = [
+        "unitree_g1",
+        "unitree_g1_sonic",
+        "libero_panda",
+        "libero_sim",
+        "simpler_env_google",
+        "simpler_env_widowx",
+    ]
+
+    @pytest.mark.parametrize("tag", _POSTTRAIN_TAGS)
+    def test_gr00t_inference_docstring_marks_posttrain_tags(self, tag):
+        """Every POSTTRAIN_TAGS embodiment in the docstring is flagged posttrain.
+
+        The docstring carries a ``[posttrain]`` marker per entry plus a footnote
+        defining what it means (requires a finetuned checkpoint, not the base
+        model). This pin enumerates the upstream posttrain set so a new addition
+        cannot land unmarked.
+        """
+        from strands_robots.tools.gr00t_inference import gr00t_inference
+
+        doc = gr00t_inference.__doc__ or ""
+        assert tag in doc, f"posttrain tag {tag!r} missing from the gr00t_inference docstring"
+        # The docstring must define the posttrain contract once (footnote).
+        assert "[posttrain]" in doc, "docstring must mark posttrain entries with a [posttrain] tag"
+        assert "POSTTRAIN_TAGS" in doc, "docstring footnote must reference upstream POSTTRAIN_TAGS"
+        assert "finetuned checkpoint" in doc, "docstring must state posttrain tags require a finetuned checkpoint"
+
+    def test_gr00t_inference_docstring_sonic_decoder_disclaimer(self):
+        """The SONIC entry must warn that the action stream is motion-token
+        latents needing the GR00T-WholeBodyControl decoder (#213, PR #128 R7)."""
+        from strands_robots.tools.gr00t_inference import gr00t_inference
+
+        doc = (gr00t_inference.__doc__ or "").replace("\n", " ")
+        assert "GR00T-WholeBodyControl" in doc, "SONIC entry must name the GR00T-WholeBodyControl decoder runtime"
+        assert "motion-token" in doc or "motion_token" in doc or "motion token" in doc, (
+            "SONIC entry must call out that the action stream is motion-token latents"
+        )
+
     def test_unitree_g1_real_alias(self):
         """The REAL_G1 embodiment tag value resolves to unitree_g1_real."""
         alias = DATA_CONFIG_MAP["real_g1_relative_eef_relative_joints"]

--- a/tests/tools/test_gr00t_container_hardening.py
+++ b/tests/tools/test_gr00t_container_hardening.py
@@ -545,3 +545,36 @@ def test_no_agent_controlled_host_exec_or_path_params():
         f"agent-facing params reintroduce a host-exec/mount surface: {sorted(leaked)}. "
         "These must be operator-config + allowlist driven, not agent parameters."
     )
+
+
+# --------------------------------------------------------------------------- #
+# #384 item 2 — symlink (realpath) resolution in volume safety                 #
+# --------------------------------------------------------------------------- #
+def test_check_volume_safety_resolves_symlink_into_protected_dir(tmp_path):
+    """A host symlink whose target is a protected dir must be rejected.
+
+    Pre-fix (#384): ``_normalize_host_path`` ran ``normpath`` only, so a
+    pre-existing symlink ``/data/ckpt -> /etc`` passed the blocklist while
+    docker would mount the resolved ``/etc``. The realpath check closes this.
+    """
+    link = tmp_path / "sneaky_ckpt"
+    link.symlink_to("/etc")  # target is a protected dir
+    reason = gi._check_volume_safety({str(link): "/data/checkpoints"})
+    assert reason is not None, "symlink resolving to /etc must be rejected; the realpath guard is missing"
+    assert "/etc" in reason or "protected" in reason
+
+
+def test_check_volume_safety_allows_symlink_into_safe_dir(tmp_path):
+    """A symlink resolving to a non-protected dir must still be allowed."""
+    safe_target = tmp_path / "real_models"
+    safe_target.mkdir()
+    link = tmp_path / "models_link"
+    link.symlink_to(safe_target)
+    assert gi._check_volume_safety({str(link): "/data/checkpoints"}) is None
+
+
+def test_resolve_host_path_does_not_raise_on_missing_path():
+    """``_resolve_host_path`` must resolve best-effort on a not-yet-created
+    mount source (realpath resolves as far as it can, never raises)."""
+    out = gi._resolve_host_path("/does/not/exist/yet/ckpt")
+    assert isinstance(out, str) and out.startswith("/")


### PR DESCRIPTION
## Summary

`gr00t_inference` hardening + docs bundle for the v0.4.0 umbrella (#391).

## Changes

| Issue | Fix | Kind |
|-------|-----|------|
| **#384** item 2 | Volume-safety guard ran `normpath` only — a pre-existing host symlink pointing at a protected dir (`/data/ckpt -> /etc`) passed the blocklist while docker mounted the resolved target. Added `_resolve_host_path` (realpath) and now check **both** the normalized and symlink-resolved forms against the blocklist. Residual check-vs-mount-time TOCTOU documented. | prod |
| **#384** item 1 | Documented the wholesale `/home` block decision inline (`NOTE`): it is intentional defence-in-depth; operators place checkpoints outside `/home`. The auto-derived default (`~/.cache/huggingface`) is never agent-controlled. | docs |
| **#213** | Restructured the embodiment docstring into **pretrain vs posttrain**. Marked every upstream `POSTTRAIN_TAGS` entry `[posttrain]` and added a footnote stating they require a finetuned checkpoint, not the base `nvidia/GR00T-N1.7-3B`. Extended the SONIC entry to call out that the action stream is 64-dim **motion-token latents** needing the `NVlabs/GR00T-WholeBodyControl` decoder. | docs |

## Resolved-by-refactor (closed for tracking)

`#327` (IPv6 `-p` bracketing), `#328` (`_validate_path` empty-string + `lifecycle` validator-bypass) and `#329` (`validate_inputs` rename) all targeted the **pre-#372** validation API. The agent-controlled host/volume/command surface was removed in #372 — the tool no longer threads `host` into docker `-p` (`-p {port}:{port}`), and `validate_inputs`/`_validate_path` no longer exist. These are resolved by that refactor; pinned closed here. The current agent-surface invariant remains pinned by `test_no_agent_controlled_host_exec_or_path_params`.

## Test plan

```
python -m pytest tests/tools/test_gr00t_container_hardening.py tests/policies/groot/test_data_config.py -q  # 121 passed
ruff check . && ruff format --check .   # clean
mypy strands_robots/tools/gr00t_inference.py   # Success
```

Regression pin verified: removing the realpath candidate from `_check_volume_safety` makes `test_check_volume_safety_resolves_symlink_into_protected_dir` fail; restoring it passes.

Closes #213, #327, #328, #329, #384.
Part of #391.
