### PR TITLE
fix(hardware): narrow plugin except, audit cross-robot kwarg drops, thor deps (#389)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,18 @@ cosmos3-service = [
 ]
 lerobot = [
     "lerobot[feetech]>=0.5.0,<0.6.0",
+    # #378: lerobot 0.5.1's pyav video fallback calls torchvision.io.VideoReader,
+    # which torchvision 0.26 (resolved on linux+aarch64 via the torch 2.11 Thor
+    # override below) removed -- crashing dataset video read-back. lerobot's own
+    # torchcodec dependency marker EXCLUDES aarch64, so a `pip install
+    # strands-robots[lerobot]` on Thor/Jetson gets no decoder. Add torchcodec
+    # explicitly on linux+aarch64 so lerobot uses its preferred (working)
+    # torchcodec decoder instead of the removed VideoReader. (The hatch dev env
+    # carries the same pin; this makes the public extra self-sufficient too.)
+    # NOTE: torchcodec ships as +cuXXX wheels resolved by UV_TORCH_BACKEND; a
+    # plain `pip install` on Thor may need the matching CUDA index -- see the
+    # README Installation section for the Thor/Jetson caveat.
+    "torchcodec>=0.7; platform_machine == 'aarch64' and sys_platform == 'linux'",
 ]
 sim = [
     "robot_descriptions>=1.11.0,<2.0.0",

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -170,7 +170,17 @@ def _ensure_lerobot_robots_registered() -> None:
     else:
         try:
             register_third_party_plugins()
-        except Exception as exc:  # noqa: BLE001 -- third-party plugin code is untrusted
+        except (ImportError, AttributeError, OSError) as exc:
+            # #291: narrowed from bare ``except Exception`` per AGENTS.md
+            # Review Learnings (#86). Third-party plugin registration can fail
+            # for three benign, recoverable reasons: a plugin distribution
+            # whose import chain is broken (ImportError), a lerobot version
+            # whose loader entry-point shape differs (AttributeError), or an
+            # OS-level probe inside a plugin's registration (OSError). Any of
+            # these should degrade to "that plugin is absent from the registry"
+            # -- not crash hardware init. A genuinely unexpected exception
+            # (e.g. a plugin raising ValueError from buggy registration code)
+            # now propagates so it is not silently masked.
             logger.warning("[hardware_robot] third-party plugin registration failed: %s", exc)
 
 
@@ -472,6 +482,22 @@ class Robot(AgentTool):
         # right_arm.json). Default to the strands tool name otherwise.
         if "id" in valid_fields:
             config_data["id"] = kwargs.get("id", self.tool_name_str)
+        elif "id" in kwargs:
+            # #292: every lerobot RobotConfig declares ``id`` today, so an
+            # operator-supplied ``id=`` is normally consumed above. If a future
+            # RobotConfig subclass drops the field, silently discarding an
+            # explicit ``id=`` would namespace calibration files wrong with no
+            # signal. Surface it: the generic unknown-kwarg gate below would
+            # also catch it, but this names the specific regression so the
+            # diagnostic is actionable.
+            logger.warning(
+                "[hardware_robot] robot_type=%r config %s does not declare an 'id' "
+                "field; the explicit id=%r will not namespace calibration files. "
+                "This is unexpected for a lerobot RobotConfig -- please file an issue.",
+                robot_type,
+                ConfigClass.__name__,
+                kwargs["id"],
+            )
 
         # Cameras are common to every lerobot Robot.
         if "cameras" in valid_fields:
@@ -485,6 +511,22 @@ class Robot(AgentTool):
         for key in forwardable:
             if key in kwargs and key in valid_fields:
                 config_data[key] = kwargs[key]
+            elif key in kwargs:
+                # #294/#297: the kwarg is in the cross-robot allowlist but the
+                # resolved dataclass does not declare it -- the documented
+                # polymorphism carve-out (e.g. ``Robot('so101', kp=[...])``
+                # against a heterogeneous fleet). This is intentional, but a
+                # silent drop leaves operators with no way to audit why a kwarg
+                # they passed had no effect. Emit a debug signal naming the
+                # dropped kwarg and the robot type so the drop is observable
+                # without changing the tolerant behaviour.
+                logger.debug(
+                    "[hardware_robot] dropping cross-robot kwarg %r for robot_type=%r: "
+                    "not declared on %s (forwardable-allowlist polymorphism carve-out)",
+                    key,
+                    robot_type,
+                    ConfigClass.__name__,
+                )
 
         # Forward kwargs that are declared on the target dataclass but not
         # in the cross-robot allowlist. This future-proofs new lerobot fields

--- a/tests/test_robot_factory.py
+++ b/tests/test_robot_factory.py
@@ -975,3 +975,63 @@ class TestRealModeConfigDiscovery:
         cfg = hw._create_minimal_config("so101_follower", cameras={}, **{target_field: "test_value"})
         # The field should have been forwarded to the config
         assert hasattr(cfg, target_field)
+
+
+class TestHardwareConfigV040Followups:
+    """v0.4.0 hardware_robot follow-up bundle (#389) — PR #276 review trail."""
+
+    def test_cross_robot_kwarg_drop_emits_debug_signal(self, caplog):
+        """#294/#297: dropping a forwardable kwarg the target dataclass does
+        not declare is tolerated (polymorphism), but must now emit a DEBUG
+        signal naming the kwarg so operators can audit why it had no effect."""
+        import logging
+
+        pytest.importorskip("lerobot.robots.so_follower")
+        from strands_robots.hardware_robot import Robot as HwRobot
+
+        hw = HwRobot.__new__(HwRobot)
+        hw.tool_name_str = "so101_drop_signal"
+
+        with caplog.at_level(logging.DEBUG, logger="strands_robots.hardware_robot"):
+            cfg = hw._create_minimal_config(
+                "so101_follower",
+                cameras={},
+                port="/dev/null",
+                kp=[1.0] * 29,  # forwardable, not on so101 dataclass -> dropped
+            )
+        assert not hasattr(cfg, "kp")
+        drop_msgs = [r.getMessage() for r in caplog.records if "dropping cross-robot kwarg" in r.getMessage()]
+        assert any("'kp'" in m for m in drop_msgs), (
+            f"expected a DEBUG signal naming the dropped 'kp' kwarg; got {drop_msgs}"
+        )
+
+    def test_register_third_party_plugins_exception_is_narrow(self):
+        """#291: the register_third_party_plugins() guard must NOT be a bare
+        except Exception. Pin the narrowed (ImportError, AttributeError,
+        OSError) tuple by source inspection so the BLE001 pattern cannot
+        silently return."""
+        import inspect
+
+        from strands_robots import hardware_robot
+
+        src = inspect.getsource(hardware_robot._ensure_lerobot_robots_registered)
+        assert "except (ImportError, AttributeError, OSError)" in src, (
+            "register_third_party_plugins must be guarded by a narrow exception tuple (#291)"
+        )
+        assert "except Exception as exc:  # noqa: BLE001 -- third-party plugin" not in src, (
+            "the bare except Exception on plugin registration must be gone (#291)"
+        )
+
+    def test_lerobot_extra_pins_torchcodec_on_aarch64(self):
+        """#378: the public [lerobot] extra must carry the aarch64 torchcodec
+        pin so a `pip install strands-robots[lerobot]` on Thor/Jetson gets a
+        working video decoder (not just the hatch dev env)."""
+        import tomllib
+        from pathlib import Path
+
+        root = Path(__file__).resolve().parents[1]
+        data = tomllib.load(open(root / "pyproject.toml", "rb"))
+        lerobot_extra = data["project"]["optional-dependencies"]["lerobot"]
+        assert any("torchcodec" in dep and "aarch64" in dep for dep in lerobot_extra), (
+            f"[lerobot] extra must pin torchcodec on linux+aarch64 (#378); got {lerobot_extra}"
+        )


### PR DESCRIPTION
## Summary

`hardware_robot` + `robot_factory` follow-up bundle for the v0.4.0 umbrella (#389), from the PR #276 review trail.

Most of that trail already landed on `main` via #276/#379 — verified present: #275 (`SOFollowerRobotConfig` via registry), #281 (narrowed construction `except (TypeError, ValueError)`), #282/#289 (`is_pkg` walker), #283 (`valid_fields` auto-forward), #287 (walker debug-vs-warning split), #285/#290/#293/#298 (test discipline). This PR closes the remaining open gaps.

## Changes

| Issue | Fix | Kind |
|-------|-----|------|
| **#291** | `register_third_party_plugins()` was guarded by a bare `except Exception  # noqa: BLE001`. Narrowed to `(ImportError, AttributeError, OSError)` per AGENTS.md Review Learnings (#86); anything else now propagates instead of being masked. | prod |
| **#294/#297** | Dropping a forwardable kwarg the resolved dataclass does not declare (cross-robot polymorphism carve-out, e.g. `kp=` to so101) was **silent**. Added `logger.debug` naming the dropped kwarg + robot type so it is auditable — tolerant behaviour unchanged. | prod |
| **#292** | Guarded the case where a future `RobotConfig` subclass omits the `id` field — an explicit `id=` would be silently discarded. Emit a targeted WARNING naming the specific regression. | prod |
| **#378** | Added the aarch64 `torchcodec` pin to the **public** `[lerobot]` extra (not just the hatch dev env), so `pip install strands-robots[lerobot]` on Thor/Jetson gets a working video decoder; documented the `+cuXXX` index caveat. | deps |

## Already-satisfied (closed for tracking)

#275, #281, #283, #285, #287, #288, #289, #290, #293, #298 — verified present on `main`. **#377** (future lerobot 0.5.2 → cu130) is already covered by the existing `torch>=2.11,<2.12` + `+cu130` aarch64 override in `[tool.uv]`.

## Test plan

```
python -m pytest tests/test_robot_factory.py -q     # 63 passed, 1 skipped
ruff check . && ruff format --check .               # clean
mypy strands_robots/hardware_robot.py               # Success
```

Regression pin verified: reverting the #291 guard to bare `except Exception` makes `test_register_third_party_plugins_exception_is_narrow` fail; restoring passes.

Closes #275, #281, #283, #285, #287, #288, #289, #290, #291, #292, #293, #294, #297, #298, #377, #378.
Part of #389.
