### PR TITLE
fix(sim): ground-plane strip guards, tendon scale, RNG parity (#393)

### DIFF
--- a/strands_robots/policies/_rng.py
+++ b/strands_robots/policies/_rng.py
@@ -1,0 +1,54 @@
+"""Shared RNG reseed helper for Policy providers.
+
+#331: ``Gr00tPolicy.reset`` reseeds Python ``random``, NumPy, torch CPU + CUDA,
+and toggles cuDNN determinism, while ``Cosmos3Policy.reset`` only mutated the
+global NumPy RNG. Two providers conforming to the same ``Policy`` contract must
+behave identically for ``set_eval_seed``-style reproducibility (#187). This
+module is the single source of truth for the client-side reseed so both
+providers stay in parity.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def reseed_client_rngs(seed: int | None) -> None:
+    """Reseed the client-side RNGs for per-episode reproducibility.
+
+    Seeds Python ``random``, NumPy, and (if importable) torch CPU + CUDA, and
+    toggles cuDNN into deterministic mode. ``None`` is a no-op. Best-effort:
+    a missing torch is skipped silently (it is an optional dependency for the
+    policy providers); any other failure is logged and swallowed because
+    ``reset`` is a soft reproducibility hint, not a hard requirement.
+
+    Args:
+        seed: Master per-episode seed, or ``None`` to leave RNGs untouched.
+    """
+    if seed is None:
+        return
+    try:
+        import random as _random
+
+        _random.seed(seed)
+
+        import numpy as _np
+
+        _np.random.seed(seed)
+
+        try:
+            import torch as _torch
+
+            _torch.manual_seed(seed)
+            if _torch.cuda.is_available():
+                _torch.cuda.manual_seed_all(seed)
+            _torch.backends.cudnn.deterministic = True
+            _torch.backends.cudnn.benchmark = False
+        except ImportError:
+            # torch is optional for the policy providers (mock / service-only
+            # installs); no torch RNG state to seed when it is not present.
+            pass
+    except Exception as exc:  # noqa: BLE001 - reset is best-effort
+        logger.info("reseed_client_rngs: reseed failed (seed=%r): %s", seed, exc)

--- a/strands_robots/policies/cosmos3/policy.py
+++ b/strands_robots/policies/cosmos3/policy.py
@@ -243,9 +243,13 @@ class Cosmos3Policy(Policy):
             per-request seed (tracked as an upstream feature request).
         """
         self._client.reset()
-        # Local reseed only — np.random.seed(int) never raises, so no guard.
-        if seed is not None:
-            np.random.seed(seed)
+        # #331: reseed via the shared helper so Cosmos3Policy reaches RNG parity
+        # with Gr00tPolicy (Python random + NumPy + torch CPU/CUDA + cuDNN
+        # determinism), not just the global NumPy RNG. Same set_eval_seed
+        # behaviour across both providers for #187 reproducibility.
+        from strands_robots.policies._rng import reseed_client_rngs
+
+        reseed_client_rngs(seed)
 
     async def get_actions(
         self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any

--- a/strands_robots/policies/groot/policy.py
+++ b/strands_robots/policies/groot/policy.py
@@ -598,33 +598,14 @@ class Gr00tPolicy(Policy):
                 )
             return
 
-        # LOCAL mode: same reseed set_eval_seed would do.
+        # LOCAL mode: same reseed set_eval_seed would do. #331: delegate to the
+        # shared helper so Gr00tPolicy and Cosmos3Policy reseed identically.
         if seed is None:
             return
-        try:
-            import random as _random
+        from strands_robots.policies._rng import reseed_client_rngs
 
-            _random.seed(seed)
-            np.random.seed(seed)
-            try:
-                import torch as _torch
-
-                _torch.manual_seed(seed)
-                if _torch.cuda.is_available():
-                    _torch.cuda.manual_seed_all(seed)
-                _torch.backends.cudnn.deterministic = True
-                _torch.backends.cudnn.benchmark = False
-            except ImportError:
-                # Torch is an optional dependency for `Gr00tPolicy`; minimal
-                # installs (e.g. ``policy_provider="mock"`` smoke tests, or
-                # SERVICE-only deployments without local model loading) won't
-                # have it. Silently skipping the reseed in that case is the
-                # right behaviour — there's no torch RNG state to seed when
-                # torch isn't even imported.
-                pass
-            logger.debug("Gr00tPolicy.reset: local-mode reseed applied (seed=%r)", seed)
-        except Exception as e:  # noqa: BLE001 - reset is best-effort
-            logger.info("Gr00tPolicy.reset: local-mode reseed failed: %s", e)
+        reseed_client_rngs(seed)
+        logger.debug("Gr00tPolicy.reset: local-mode reseed applied (seed=%r)", seed)
 
     async def get_actions(self, observation_dict: dict[str, Any], instruction: str, **kwargs) -> list[dict[str, Any]]:
         if self._mode == "local":

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -379,10 +379,16 @@ class RenderingMixin:
             # finger joint - see issue #318.
             jnt_id = _lookup(mj.mjtObj.mjOBJ_JOINT, key)
             if jnt_id < 0:
+                # #367: an action key that resolves to neither an actuator nor
+                # a joint is silently dropped today. Silent gripper drops are
+                # exactly the failure mode #318 was filed to fix, so surface it
+                # -- once per (prefix, key) to avoid per-step log spam at 50Hz.
+                self._warn_unresolved_action_key(pfx, key, "no actuator or joint")
                 continue
 
             ai = self._actuator_for_joint(model, jnt_id, mj)
             if ai < 0:
+                self._warn_unresolved_action_key(pfx, key, "joint has no driving actuator")
                 continue
 
             # Scale a logical command into the actuator's ctrlrange when the
@@ -390,6 +396,30 @@ class RenderingMixin:
             # tendon units, not a finger-joint position). Direct JOINT
             # actuators keep the raw value (positions/torques in joint units).
             data.ctrl[ai] = self._scale_ctrl_for_actuator(model, ai, float(value), mj)
+
+    def _warn_unresolved_action_key(self, pfx: str, key: str, reason: str) -> None:
+        """Warn once per (prefix, key) that an action key could not be applied.
+
+        #367: replaces the prior silent ``continue`` on unresolved action keys.
+        De-duplicated via a per-world set so a 50Hz control loop does not spam
+        the log -- the operator sees the missing key once and can act on it.
+        """
+        warned = getattr(self, "_warned_unresolved_keys", None)
+        if warned is None:
+            warned = set()
+            self._warned_unresolved_keys = warned
+        dedup = (pfx, key)
+        if dedup in warned:
+            return
+        warned.add(dedup)
+        logger.warning(
+            "[sim] action key %r (prefix=%r) could not be applied: %s. "
+            "The value was dropped. Check the action/joint naming against the "
+            "scene's actuators.",
+            key,
+            pfx,
+            reason,
+        )
 
     @staticmethod
     def _actuator_for_joint(model: Any, jnt_id: int, mj: Any) -> int:
@@ -448,6 +478,13 @@ class RenderingMixin:
         if not bool(model.actuator_ctrllimited[ai]) or hi <= lo:
             return value
         span = hi - lo
+        # #367 item 1a: a ctrlrange that spans zero (e.g. [-1, 1]) is itself the
+        # normalised command space -- the caller passes the command verbatim and
+        # we must NOT re-map it onto [lo, hi] (which would clip a symmetric
+        # -0.5 to 0.0 -> -1.0). Treat lo < 0 as "already normalised, pass
+        # through clamped to the range".
+        if lo < 0.0:
+            return min(hi, max(lo, value))
         # A normalised [0, 1] open/close fraction is the conventional gripper
         # command from VLA policies. When the actuator ctrlrange is much wider
         # than unit scale (e.g. the Panda tendon's [0, 255]), a value within
@@ -455,7 +492,12 @@ class RenderingMixin:
         # than a literal tendon-unit command, so we map it onto the full range.
         # If the caller already passes a clearly in-range value (> lo + 1 and
         # <= hi), we trust it verbatim.
-        if span > 1.0 and value > (lo + 1.0) and value <= hi:
+        #
+        # #367 item 1b: use a small epsilon on the boundary so a normalised
+        # 1.0 + FP-noise (from a quantised VLA head) is still treated as the
+        # fraction 1.0 (-> hi) rather than slipping into the verbatim branch and
+        # writing ~1.0 onto a [0, 255] range (a nearly-closed gripper).
+        if span > 1.0 and value > (lo + 1.0 + 1e-6) and value <= hi:
             return value
         # Treat the incoming value as a normalised [0, 1] open/close fraction.
         frac = min(1.0, max(0.0, value))

--- a/strands_robots/simulation/mujoco/spec_builder.py
+++ b/strands_robots/simulation/mujoco/spec_builder.py
@@ -476,8 +476,45 @@ class SpecBuilder:
         # floor render. The world ``ground`` plane (configurable via
         # ``create_world(ground_plane=...)``) is the single source of truth;
         # robots contribute only their own bodies/joints/actuators. See #320.
-        for plane in [g for g in robot_spec.geoms if g.type == mujoco.mjtGeom.mjGEOM_PLANE]:
-            robot_spec.delete(plane)
+        #
+        # Three guards from the #360 review (#363):
+        #   1. Conditional strip -- only remove the robot's floor when the world
+        #      actually owns a ground plane to replace it. Under
+        #      ``create_world(ground_plane=False)`` the world has no ground, so
+        #      stripping the robot's plane would leave the scene floorless; in
+        #      that case we keep the robot's plane (it is the only floor source).
+        #   2. Narrow predicate -- only strip planes that are plausibly the z=0
+        #      axis-aligned ground (a robot MJCF may intentionally ship an
+        #      angled/elevated plane, e.g. a ramp or wall, which must survive).
+        #   3. Debug log -- record which geoms were stripped so a disappearing
+        #      (or surviving) robot floor is diagnosable.
+        world_has_ground = any(g.type == mujoco.mjtGeom.mjGEOM_PLANE for g in scene_spec.geoms)
+        stripped: list[str] = []
+        if world_has_ground:
+            for plane in [
+                g for g in robot_spec.geoms if g.type == mujoco.mjtGeom.mjGEOM_PLANE and _is_z0_ground_plane(g)
+            ]:
+                stripped.append(plane.name or "<unnamed>")
+                robot_spec.delete(plane)
+            if stripped:
+                logger.debug(
+                    "attach_robot: stripped %d robot-scene z=0 ground plane geom(s) "
+                    "for %r (world owns the ground plane): %r",
+                    len(stripped),
+                    robot.name,
+                    stripped,
+                )
+        else:
+            # ground_plane=False opt-out: keep the robot's own floor (if any) so
+            # the scene is not left without any ground.
+            kept = [g for g in robot_spec.geoms if g.type == mujoco.mjtGeom.mjGEOM_PLANE]
+            if kept:
+                logger.debug(
+                    "attach_robot: world has no ground plane (ground_plane=False); "
+                    "keeping %d robot-scene plane geom(s) for %r as the floor source",
+                    len(kept),
+                    robot.name,
+                )
 
         # Collect source joint names BEFORE attach - attach mutates the child
         # spec in-place (the child gets reparented).
@@ -503,8 +540,30 @@ class SpecBuilder:
         return source_joint_names
 
 
+def _is_z0_ground_plane(geom: Any) -> bool:
+    """True if a plane geom is plausibly the z=0 axis-aligned ground.
+
+    MuJoCo planes default to a +Z normal at the body origin. We treat a plane
+    as "ground" when its body-frame position z is ~0 and its orientation is
+    axis-aligned (quat ~ identity, so the normal stays +Z). A robot MJCF that
+    ships an intentional ramp/wall plane (rotated or elevated) is NOT matched
+    and survives the attach. See #363.
+    """
+    pos = getattr(geom, "pos", None)
+    if pos is not None and abs(float(pos[2])) > 1e-6:
+        return False
+    quat = getattr(geom, "quat", None)
+    if quat is not None:
+        # Identity quat is (1, 0, 0, 0); allow small FP noise.
+        w, x, y, z = (float(quat[0]), float(quat[1]), float(quat[2]), float(quat[3]))
+        if abs(w - 1.0) > 1e-6 or abs(x) > 1e-6 or abs(y) > 1e-6 or abs(z) > 1e-6:
+            return False
+    return True
+
+
 __all__ = [
     "SpecBuilder",
+    "_is_z0_ground_plane",
     "_geom_type",
     "_normalize_size",
     "_target_quat",

--- a/tests/policies/test_rng_parity.py
+++ b/tests/policies/test_rng_parity.py
@@ -1,0 +1,67 @@
+"""#331: shared client-side RNG reseed helper + provider parity.
+
+Pins that ``reseed_client_rngs`` reseeds Python ``random`` + NumPy (and torch
+when present) deterministically, and that both Gr00tPolicy and Cosmos3Policy
+route their reset reseed through it so they behave identically for #187
+reproducibility.
+"""
+
+from __future__ import annotations
+
+import random
+
+import numpy as np
+
+from strands_robots.policies._rng import reseed_client_rngs
+
+
+def test_reseed_is_deterministic_across_python_and_numpy():
+    reseed_client_rngs(1234)
+    py_a = [random.random() for _ in range(3)]
+    np_a = np.random.rand(3).tolist()
+
+    reseed_client_rngs(1234)
+    py_b = [random.random() for _ in range(3)]
+    np_b = np.random.rand(3).tolist()
+
+    assert py_a == py_b, "Python random must be reproducible after reseed"
+    assert np_a == np_b, "NumPy RNG must be reproducible after reseed"
+
+
+def test_reseed_none_is_noop():
+    # Establish a known state, draw once, then call with None and confirm the
+    # stream is NOT reset (the next draw differs from a fresh-seed draw).
+    reseed_client_rngs(7)
+    first = random.random()
+    reseed_client_rngs(None)  # must not reset
+    second = random.random()
+    reseed_client_rngs(7)
+    fresh = random.random()
+    assert first == fresh, "reseed(7) must reproduce the first draw"
+    assert second != first, "reseed(None) must be a no-op, not a reset"
+
+
+def test_distinct_seeds_diverge():
+    reseed_client_rngs(1)
+    a = np.random.rand(4).tolist()
+    reseed_client_rngs(2)
+    b = np.random.rand(4).tolist()
+    assert a != b
+
+
+def test_both_providers_route_reset_through_shared_helper():
+    """Source-level parity pin: both reset() methods call reseed_client_rngs
+    so they cannot drift apart again (the #331 root cause)."""
+    import inspect
+
+    from strands_robots.policies.cosmos3 import policy as cosmos_mod
+    from strands_robots.policies.groot import policy as groot_mod
+
+    cosmos_src = inspect.getsource(cosmos_mod.Cosmos3Policy.reset)
+    groot_src = inspect.getsource(groot_mod.Gr00tPolicy.reset)
+    assert "reseed_client_rngs" in cosmos_src, "Cosmos3Policy.reset must use the shared reseed helper (#331)"
+    assert "reseed_client_rngs" in groot_src, "Gr00tPolicy.reset must use the shared reseed helper (#331)"
+    # The old global-only mutation must be gone from cosmos3.
+    assert "np.random.seed(seed)" not in cosmos_src, (
+        "Cosmos3Policy.reset must not reseed only the global NumPy RNG anymore (#331)"
+    )

--- a/tests/simulation/mujoco/test_spec_builder.py
+++ b/tests/simulation/mujoco/test_spec_builder.py
@@ -476,6 +476,101 @@ class TestAttachRobot:
         ]
         assert planes == ["ground"]
 
+    def test_attach_robot_keeps_floor_when_world_ground_disabled(self, tmp_path):
+        """#363 guard 1: under ``ground_plane=False`` the world owns no ground
+        plane, so the robot's own floor must NOT be stripped -- otherwise the
+        opt-out scene is left with zero ground planes."""
+        robot_with_floor = """
+        <mujoco model="arm_with_floor">
+          <compiler angle="radian"/>
+          <worldbody>
+            <geom name="floor" size="0 0 0.05" type="plane"/>
+            <body name="base" pos="0 0 0.1">
+              <joint name="pan" type="hinge" axis="0 0 1"/>
+              <geom type="cylinder" size="0.05 0.05"/>
+            </body>
+          </worldbody>
+        </mujoco>
+        """
+        path = tmp_path / "arm_with_floor.xml"
+        path.write_text(robot_with_floor)
+
+        scene = SpecBuilder.build(SimWorld(ground_plane=False))
+        robot = SimRobot(name="arm1", urdf_path=str(path), position=[0.0, 0.0, 0.0])
+        SpecBuilder.attach_robot(scene, robot, str(path))
+        model = scene.compile()
+        planes = [
+            mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_GEOM, g)
+            for g in range(model.ngeom)
+            if model.geom_type[g] == mujoco.mjtGeom.mjGEOM_PLANE
+        ]
+        # The robot floor is the ONLY floor source -- it must survive.
+        assert len(planes) == 1, f"opt-out scene must keep the robot floor, got {planes}"
+
+    def test_attach_robot_logs_debug_on_strip(self, tmp_path, caplog):
+        """#363 guard 2: the plane strip emits a DEBUG record naming what was
+        removed so a disappearing floor is diagnosable."""
+        import logging
+
+        robot_with_floor = """
+        <mujoco model="arm_with_floor">
+          <compiler angle="radian"/>
+          <worldbody>
+            <geom name="floor" size="0 0 0.05" type="plane"/>
+            <body name="base" pos="0 0 0.1">
+              <joint name="pan" type="hinge" axis="0 0 1"/>
+              <geom type="cylinder" size="0.05 0.05"/>
+            </body>
+          </worldbody>
+        </mujoco>
+        """
+        path = tmp_path / "arm_with_floor.xml"
+        path.write_text(robot_with_floor)
+        scene = SpecBuilder.build(SimWorld())
+        robot = SimRobot(name="arm1", urdf_path=str(path), position=[0.0, 0.0, 0.0])
+        with caplog.at_level(logging.DEBUG, logger="strands_robots.simulation.mujoco.spec_builder"):
+            SpecBuilder.attach_robot(scene, robot, str(path))
+        msgs = [r.getMessage() for r in caplog.records if "stripped" in r.getMessage()]
+        assert msgs, f"expected a DEBUG record about the stripped plane; got {[r.getMessage() for r in caplog.records]}"
+
+    def test_attach_robot_keeps_non_z0_plane(self, tmp_path):
+        """#363 guard 3: a robot plane that is NOT z=0 axis-aligned (e.g. an
+        elevated/angled ramp modeled as a plane) must survive the strip; only
+        the z=0 ground floor is removed."""
+        robot_with_ramp = """
+        <mujoco model="arm_with_ramp">
+          <compiler angle="radian"/>
+          <worldbody>
+            <geom name="floor" size="0 0 0.05" type="plane"/>
+            <geom name="ramp" size="1 1 0.05" type="plane" pos="0 0 0.5"/>
+            <body name="base" pos="0 0 0.1">
+              <joint name="pan" type="hinge" axis="0 0 1"/>
+              <geom type="cylinder" size="0.05 0.05"/>
+            </body>
+          </worldbody>
+        </mujoco>
+        """
+        path = tmp_path / "arm_with_ramp.xml"
+        path.write_text(robot_with_ramp)
+        scene = SpecBuilder.build(SimWorld())
+        robot = SimRobot(name="arm1", urdf_path=str(path), position=[0.0, 0.0, 0.0])
+        SpecBuilder.attach_robot(scene, robot, str(path))
+        model = scene.compile()
+        plane_labels = [
+            mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_GEOM, g)
+            for g in range(model.ngeom)
+            if model.geom_type[g] == mujoco.mjtGeom.mjGEOM_PLANE
+        ]
+        # World ground survives + the elevated ramp survives; the z=0 robot
+        # floor is the only plane stripped.
+        assert "ground" in plane_labels
+        assert any("ramp" in (lbl or "") for lbl in plane_labels), (
+            f"the non-z=0 ramp plane must survive the strip; got {plane_labels}"
+        )
+        assert not any(lbl and lbl.endswith("floor") for lbl in plane_labels), (
+            f"the z=0 robot floor should have been stripped; got {plane_labels}"
+        )
+
 
 # from_mjcf_string / from_file
 

--- a/tests/simulation/mujoco/test_tendon_actuator.py
+++ b/tests/simulation/mujoco/test_tendon_actuator.py
@@ -147,3 +147,83 @@ def test_apply_action_by_name_direct_joint_unscaled(model):
     mixin._apply_action_by_name(model, data, {"arm_joint": 0.5}, "", mujoco)
     arm = _aid(model, "arm_act")
     assert data.ctrl[arm] == pytest.approx(0.5)
+
+
+# --------------------------------------------------------------------------- #
+# #367 v0.4.1 polish bundle                                                    #
+# --------------------------------------------------------------------------- #
+# A tendon actuator whose ctrlrange spans zero ([-1, 1]) -- the #367 item-1a
+# case. The scale helper only special-cases TENDON transmissions, so the
+# symmetric-range pin must use a tendon actuator (not the direct arm joint).
+_XML_SYMMETRIC_TENDON = """
+<mujoco model="symmetric_tendon">
+  <worldbody>
+    <body name="hand">
+      <body name="f1" pos="0.03 0 0">
+        <joint name="fj1" type="slide" axis="1 0 0" range="-1 1"/>
+        <geom type="box" size="0.005 0.01 0.02"/>
+      </body>
+      <body name="f2" pos="-0.03 0 0">
+        <joint name="fj2" type="slide" axis="-1 0 0" range="-1 1"/>
+        <geom type="box" size="0.005 0.01 0.02"/>
+      </body>
+    </body>
+  </worldbody>
+  <tendon>
+    <fixed name="sym_split">
+      <joint joint="fj1" coef="1"/>
+      <joint joint="fj2" coef="1"/>
+    </fixed>
+  </tendon>
+  <actuator>
+    <position name="sym_act" tendon="sym_split" ctrlrange="-1 1" kp="1"/>
+  </actuator>
+</mujoco>
+"""
+
+
+def test_scale_symmetric_tendon_ctrlrange_passes_negative_verbatim():
+    """#367 item 1a: a TENDON ctrlrange spanning zero ([-1, 1]) is itself the
+    normalised command space -- a symmetric negative command must pass through
+    clamped, NOT be re-mapped onto [lo, hi]. Pre-fix (lo<0 with value<lo+1)
+    fell into the fraction branch and clipped -0.5 toward lo=-1.0."""
+    m = mujoco.MjModel.from_xml_string(_XML_SYMMETRIC_TENDON)
+    sym = _aid(m, "sym_act")
+    out_neg = RenderingMixin._scale_ctrl_for_actuator(m, sym, -0.5, mujoco)
+    assert out_neg == pytest.approx(-0.5), f"symmetric -0.5 must pass verbatim, got {out_neg}"
+    out_pos = RenderingMixin._scale_ctrl_for_actuator(m, sym, 0.5, mujoco)
+    assert out_pos == pytest.approx(0.5)
+    # Out-of-range clamps to the symmetric bounds.
+    assert RenderingMixin._scale_ctrl_for_actuator(m, sym, -5.0, mujoco) == pytest.approx(-1.0)
+    assert RenderingMixin._scale_ctrl_for_actuator(m, sym, 5.0, mujoco) == pytest.approx(1.0)
+
+
+def test_scale_epsilon_boundary_treats_one_plus_noise_as_fraction(model):
+    """#367 item 1b: a normalised 1.0 + FP noise must still map to hi (255),
+    not slip into the verbatim branch and write ~1.0 onto the [0, 255] range
+    (a nearly-closed gripper when fully-open was intended)."""
+    grip = _aid(model, "grip_act")
+    out = RenderingMixin._scale_ctrl_for_actuator(model, grip, 1.0 + 1e-9, mujoco)
+    assert out == pytest.approx(255.0), f"1.0+noise should map to hi, got {out}"
+
+
+def test_scale_clamps_above_hi(model):
+    """#367 item 3a: a value above hi clamps to hi (characterization pin)."""
+    grip = _aid(model, "grip_act")
+    out = RenderingMixin._scale_ctrl_for_actuator(model, grip, 300.0, mujoco)
+    assert out == pytest.approx(255.0)
+
+
+def test_apply_action_warns_once_on_unresolved_key(model, caplog):
+    """#367 item 2: an action key resolving to neither actuator nor joint is
+    no longer silently dropped -- it emits a WARNING (once per key)."""
+    import logging
+
+    data = mujoco.MjData(model)
+    mixin = RenderingMixin()
+    with caplog.at_level(logging.WARNING, logger="strands_robots.simulation.mujoco.rendering"):
+        mixin._apply_action_by_name(model, data, {"nonexistent_joint": 1.0}, "", mujoco)
+        # Second call with the same key must NOT add another warning.
+        mixin._apply_action_by_name(model, data, {"nonexistent_joint": 1.0}, "", mujoco)
+    warns = [r.getMessage() for r in caplog.records if "nonexistent_joint" in r.getMessage()]
+    assert len(warns) == 1, f"expected exactly one warn-once for the unresolved key, got {warns}"


### PR DESCRIPTION
## Summary

Simulation + VLA polish bundle for the v0.4.0 umbrella (#393), from the PR #360/#359/#317 review trails.

## Changes

### Ground-plane strip (#363 — `spec_builder.attach_robot`)
| Guard | Fix |
|-------|-----|
| **Conditional strip** | Only remove the robot scene's floor when the world actually owns a ground plane to replace it. Under `create_world(ground_plane=False)` the robot's plane is the only floor source, so it is **kept** (was unconditionally stripped → floorless opt-out scene). |
| **Narrow predicate** | Only strip planes plausibly at z=0 axis-aligned (new `_is_z0_ground_plane`). A robot MJCF shipping an intentional ramp/wall plane now survives. |
| **Debug log** | Names the stripped geoms so a disappearing/surviving robot floor is diagnosable. |

### Tendon scaling + fail-loud (#367 — `rendering.py`)
- **item 2 (priority):** unresolved action keys were silently dropped (`if ai < 0: continue`) — the exact #318 failure mode. Now **warn-once** per `(prefix, key)`.
- **item 1a:** a tendon ctrlrange spanning zero (`[-1, 1]`) is itself the normalised command space; pass through clamped instead of re-mapping onto `[lo, hi]` (which clipped a symmetric `-0.5` toward `lo`).
- **item 1b:** epsilon on the fraction/verbatim boundary so a normalised `1.0` + FP noise maps to `hi`, not a nearly-closed gripper on `[0, 255]`.

### RNG parity (#331 — new `policies/_rng.py`)
`Cosmos3Policy.reset` only mutated the global NumPy RNG while `Gr00tPolicy` reseeded Python `random` + NumPy + torch CPU/CUDA + cuDNN determinism. Extracted a shared `reseed_client_rngs(seed)` helper and routed **both** providers through it, so they reach #187 reproducibility parity and cannot drift apart again.

## Test plan

```
MUJOCO_GL=egl python -m pytest tests/simulation/mujoco/test_spec_builder.py \
  tests/simulation/mujoco/test_tendon_actuator.py -q     # 53 passed
python -m pytest tests/policies/test_rng_parity.py -q     # 4 passed
ruff check . && ruff format --check .                     # clean
mypy <touched files>                                      # Success
```

Regression pins verified: reverting the #367 1a `lo < 0` branch makes the symmetric-tendon test fail; restoring passes.

## Notes

#369 (lerobot-recording) items were applied directly to the #366 branch per that issue's Round-1 changelog; closed here for tracking completeness.

Closes #331, #363, #367, #369.
Part of #393.
