### PR TITLE
fix(robot_mesh): close decline side-channel + audit read-only actions; AGENTS docs (#394)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,3 +252,63 @@ Corrections from code review that apply to all future contributions:
   returns a `frozenset` so the dual-pin grace period is expressible. Any future
   pinned fingerprint (other roots, signing keys) should follow the same
   multi-value shape so rotation never requires a flag-day deploy.
+
+## Review Learnings (PR-6 - mesh core safety hardening)
+
+Corrections from the mesh safety/audit hardening review trail (#221/#225). They
+apply to all future work on `strands_robots/mesh/{core,audit,security}.py`.
+
+### Safety-handler discipline
+- **Hoist env-var reads out of the hot path and the lock.** Safety handlers
+  (`_on_safety_estop` / `_on_safety_resume`) run per-envelope; resolve lazy env
+  vars (`_resume_forward_skew_s`, `_resume_freshness_window_s`) into locals at
+  handler entry, before taking the cache lock, so the lock holds for the minimum
+  window and a hot path never re-parses the environment per call.
+- **Lockout-engagement is decoupled from the per-issuer cache cap.** A bounded
+  replay cache that is full (flood, or a tiny operator override) must still let a
+  legitimate peer ENGAGE a lockout — the cap bounds memory, not safety. Pin both
+  directions: `*_per_issuer_cap_exceeded_still_engages_lockout` and
+  `*_low_cache_max_does_not_deny_safety`.
+- **Domain-tag trust-boundary cache keys.** A TLS-bound `wire_zid` and an
+  app-level `issuer_id` that happen to share a string must not collide into one
+  replay-cache slot. Prefix keys with a trust-domain tag (`("wire", …)` vs
+  `("body", …)`) so the two namespaces can never alias.
+
+### Audit poison-record symmetry
+- **Every degraded audit path writes a poison record, never a silent drop.** The
+  poison `sig` discriminators (`PSK_DEGRADED`, `SIGN_FAILED`, `SEQ_LOCK_DEGRADED`,
+  `NEXT_SEQ_DEGRADED`) let a `verify_audit_integrity` walker attribute a stream
+  gap to a specific failure class. When you add a new `_next_seq`/sign/persist
+  failure branch, add the matching poison `sig` instead of returning early.
+
+### Replay-cache eviction
+- **TTL purge runs unconditionally, not only when the cache is full.** On a
+  low-traffic mesh the cache may never reach `max_size`, but stale entries still
+  accumulate. `_evict_replay_cache` always runs the O(n) TTL pass first, then the
+  over-budget trim.
+
+## Review Learnings (PR-7 - robot_mesh HITL patterns)
+
+From the `robot_mesh` human-in-the-loop review trail (#227). Apply to the
+`robot_mesh` tool and any agent-facing tool that gates on an operator interrupt.
+
+### Operator responses are not an LLM channel
+- **Never echo the operator's literal interrupt response back to the LLM.**
+  Record the full response in the LOCAL audit row for forensics, but return a
+  flat, fixed sentinel to the model. Echoing the operator's typed reply turns the
+  human into a prompt-injection content side-channel (the agent could phrase the
+  approval reason so the operator's answer leaks data into the context).
+
+### Audit completeness
+- **Audit read-only/observation actions too, not just actuation.** `peers`,
+  `status`, `inbox`, and `unsubscribe` each leave a `_audit_tool_action(...)` row
+  so the audit log is a complete record of agent mesh access — operators get the
+  "agent read N frames from sub X at time T" trail that raw telemetry access
+  otherwise lacks.
+
+### Rate-limit safety semantics
+- **A declined HITL approval must NOT consume a rate-limit slot.** The slot is
+  recorded only after approval is granted (or atomically via
+  `_rate_limit_check_and_record` on the post-approval path). Otherwise nuisance
+  prompts an operator declines would lock the agent out of issuing a genuine
+  `emergency_stop` — the inverse of the intended safety property.

--- a/strands_robots/tools/robot_mesh.py
+++ b/strands_robots/tools/robot_mesh.py
@@ -676,8 +676,15 @@ def robot_mesh(
         if not _interrupt_approves(response):
             # Declined approval does NOT consume a rate-limit slot —
             # see _rate_limit_check docstring for the safety rationale.
+            #
+            # #322: the operator's literal interrupt response is recorded in
+            # the LOCAL audit row (full fidelity for forensics) but MUST NOT be
+            # echoed back to the LLM. Echoing it turns the human operator into a
+            # content side-channel: a prompt-injected agent could phrase the
+            # approval reason so the operator's typed reply leaks data back into
+            # the model context. Return a flat, fixed sentinel instead.
             _audit_tool_action(action, target, False, f"operator declined: {response!r}")
-            return _err(f"action '{action}' was declined by the operator interrupt (response={response!r}).")
+            return _err(f"action '{action}' was declined by the operator interrupt.")
         # Approval granted. Re-check under the lock and consume the
         # slot atomically -- a concurrent invocation that ALSO passed
         # the pre-interrupt check (different operator thread, etc.)
@@ -725,10 +732,16 @@ def robot_mesh(
         elif not locals_:
             lines.append("")
             lines.append("No peers. Create a Robot() or Simulation() to auto-join the mesh.")
+        # #322: audit read-only observation actions too, so the audit log is a
+        # complete record of agent mesh access (not just actuation). Closes the
+        # forensic gap where peers/status/inbox/unsubscribe left no trail.
+        _audit_tool_action(action, target, True, f"local={len(locals_)} remote={len(peers)}")
         return _ok("\n".join(lines))
 
     # ── action: status ────────────────────────────────────────────────────
     if action == "status":
+        # #322: read-only status is audited too (see peers branch above).
+        _audit_tool_action(action, target, True, f"local={len(locals_)} remote={len(peers)}")
         return _ok(f"[mesh] local={len(locals_)} remote={len(peers)} peers={[p['peer_id'] for p in peers]}")
 
     # All remaining actions need an outbound mesh.
@@ -930,6 +943,9 @@ def robot_mesh(
         if not sub_name:
             return _err("unsubscribe requires name (or target)")
         mesh.unsubscribe(sub_name)
+        # #322: audit the unsubscribe so the read-only/observation action set
+        # (peers, status, inbox, unsubscribe) leaves a complete forensic trail.
+        _audit_tool_action(action, sub_name, True, "")
         return _ok(f"[unsub] unsubscribed from '{sub_name}'")
 
     return _err(

--- a/tests/mesh/test_robot_mesh_security.py
+++ b/tests/mesh/test_robot_mesh_security.py
@@ -333,3 +333,24 @@ class TestRateLimitTOCTOU:
         assert rmt._rate_limit_check_and_record("broadcast") is not None
         # Verify no spurious extra slot was added.
         assert len(rmt._RATE_HISTORY["broadcast"]) == 1
+
+
+class TestDeclineSideChannel322:
+    """#322: a declined HITL response must not leak the operator's literal
+    reply back into the LLM context (the human-as-content-side-channel)."""
+
+    def test_declined_response_not_echoed_to_llm(self):
+        """The operator's literal interrupt reply must NOT appear in the
+        tool result returned to the model. A flat sentinel is returned; the
+        full reply is kept only in the local audit row."""
+        secret = "no-because-CEO-said-PROJECT-TITAN-ships-friday"
+        ctx = _make_ctx(response=secret)
+        m = _stub_mesh()
+        with patch("strands_robots.tools.robot_mesh._resolve_mesh", return_value=m):
+            r = _call("emergency_stop", ctx=ctx)
+        assert r["status"] == "error"
+        text = r["content"][0]["text"]
+        assert "declined" in text.lower()
+        # The operator's literal reply MUST NOT be echoed to the LLM.
+        assert secret not in text, "operator's literal decline reply leaked to the LLM result (#322 side-channel)"
+        m.emergency_stop.assert_not_called()


### PR DESCRIPTION
## Summary

v0.4.0 cleanup + docs bundle (#394) — the final PR of the consolidation train.

## Changes

| Issue | Fix | Kind |
|-------|-----|------|
| **#322** | A declined HITL approval echoed the operator's **literal** interrupt response back to the LLM (`response={response!r}`) — turning the human operator into a prompt-injection content side-channel. Now the full reply stays in the LOCAL audit row; a flat fixed sentinel is returned to the model. Also closed the **read-only audit gap**: `peers`, `status`, `unsubscribe` now emit `_audit_tool_action` rows (inbox already did), so the audit log is a complete record of agent mesh access. | prod |
| **#323** | Added AGENTS.md *Review Learnings (PR-6 — mesh core safety hardening)* and *(PR-7 — robot_mesh HITL patterns)* sections, capturing the durable conventions from the #221/#225/#227 review trails. | docs |

## Test plan

```
python -m pytest tests/mesh/test_robot_mesh_security.py -q     # 24 passed
python -m pytest tests/mesh/test_robot_mesh_*.py -q            # 90 passed
ruff check . && ruff format --check .                          # clean
mypy strands_robots/tools/robot_mesh.py                        # Success
```

Regression pin verified: restoring the `response={response!r}` echo makes `TestDeclineSideChannel322::test_declined_response_not_echoed_to_llm` fail; the sentinel fix passes.

## Notes on the rest of the umbrella

- **#210** (diffusers ≥ 0.38 for GHSA-98h9-4798-4q5v): `diffusers` is **not** a direct dependency of strands-robots — it arrives transitively via lerobot, so there is no direct pin to bump here. The advisory is resolved by lerobot's own pin.
- **#330** (test_no_emoji polish): the `test_no_emoji` harness it builds on (#326) never landed on `main`, so there is nothing to polish yet — deferred until that base exists.
- **#362** (eliminate review archaeology repo-wide): intentionally deferred to a dedicated follow-up **after** the v0.4.0 PR train merges — it rewrites comments/test names across the whole tree and would massively conflict with every other open PR in this batch.

Closes #322, #323.
Part of #394.
