### PR TITLE
feat(sim): add SimEngine.describe() discovery surface

### DIFF
--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -725,6 +725,39 @@ class SimEngine(ABC):
         """Get contact information. Override per backend."""
         raise NotImplementedError("get_contacts not implemented by this backend")
 
+    # Discovery / introspection
+
+    def describe(self) -> dict[str, Any]:
+        """Return a machine-readable summary of this engine's live contract.
+
+        Agents should call this first to learn what robots exist, what cameras
+        are attached, and the signatures of the methods most commonly needed --
+        in a single call, instead of guessing method names.
+
+        Returns:
+            Plain dict with keys: robots, cameras, methods, note.
+        """
+        return {
+            "robots": self.list_robots(),
+            "cameras": [],  # backends override to list camera names
+            "methods": {
+                "get_robot_state": "(robot_name: str) -> dict",
+                "get_observation": "(robot_name: str | None = None, *, skip_images: bool = False) -> dict",
+                "send_action": "(action: dict, robot_name: str | None = None, n_substeps: int = 1) -> None",
+                "run_policy": "(robot_name: str, policy_provider='mock', ...) -> dict",
+                "start_policy": "(robot_name: str, policy_provider='mock', ...) -> dict",
+                "list_robots": "() -> list[str]",
+                "render": "(camera_name='default', width=None, height=None) -> dict",
+                "reset": "() -> dict",
+                "step": "(n_steps: int = 1) -> dict",
+            },
+            "note": (
+                "robot_name defaults to the sole robot when only one exists "
+                "for get_observation and send_action. For get_robot_state, "
+                "pass the robot name explicitly (from the 'robots' list)."
+            ),
+        }
+
     def cleanup(self) -> None:
         """Release all resources. Called on __del__ / context exit."""
         pass

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -967,6 +967,33 @@ class MuJoCoSimEngine(
             )
         return {"status": "success", "content": [{"text": "\n".join(lines)}]}
 
+    def describe(self) -> dict[str, Any]:
+        """Return a machine-readable summary of this MuJoCo engine's live state.
+
+        Overrides :meth:`SimEngine.describe` to include MuJoCo-specific camera
+        names from the loaded world plus sim-time / world status, so agents can
+        discover available robots, cameras, and methods without guessing.
+        """
+        base = super().describe()
+
+        cameras: list[str] = []
+        if self._world is not None and self._world._model is not None:
+            mj = self._mj
+            model = self._world._model
+            for i in range(model.ncam):
+                cam_name = mj.mj_id2name(model, mj.mjtObj.mjOBJ_CAMERA, i)
+                if cam_name:
+                    cameras.append(cam_name)
+        base["cameras"] = cameras
+
+        if self._world is not None:
+            base["sim_time"] = self._world.sim_time
+            base["world_created"] = True
+        else:
+            base["world_created"] = False
+
+        return base
+
     def get_robot_state(self, robot_name: str) -> dict[str, Any]:
         """canonical name parameter is ``robot_name``. The router
         accepts ``name`` as an alias (bidirectional) so legacy LLM calls

--- a/tests/simulation/test_ax2_describe_discovery.py
+++ b/tests/simulation/test_ax2_describe_discovery.py
@@ -1,0 +1,216 @@
+"""AX-2 regression test: SimEngine.describe() discovery surface.
+
+Verifies the discovery surface so agents can learn an engine's contract in a
+single call instead of probe-and-fail. Pre-fix, describe() does not exist and
+these assertions fail with AttributeError.
+
+Also pins the no-alias rule: the registry must NOT export a duplicate
+``get_robot_info`` name. The canonical accessor is ``get_robot``; agents learn
+it from the discovery surface rather than the API carrying a second name.
+"""
+
+from typing import Any
+
+import pytest
+
+
+def _make_minimal_engine():
+    """Create a minimal SimEngine with one robot for describe() testing."""
+    from strands_robots.simulation.base import SimEngine
+
+    class MinimalEngine(SimEngine):
+        """Smallest concrete engine to test describe()."""
+
+        def __init__(self) -> None:
+            self._robots: list[str] = []
+
+        def create_world(
+            self,
+            timestep: float | None = None,
+            gravity: list[float] | None = None,
+            ground_plane: bool = True,
+        ) -> dict[str, Any]:
+            return {}
+
+        def destroy(self) -> dict[str, Any]:
+            return {}
+
+        def reset(self) -> dict[str, Any]:
+            return {}
+
+        def step(self, n_steps: int = 1) -> dict[str, Any]:
+            return {}
+
+        def get_state(self) -> dict[str, Any]:
+            return {}
+
+        def add_robot(
+            self,
+            name: str,
+            urdf_path: str | None = None,
+            data_config: str | None = None,
+            position: list[float] | None = None,
+            orientation: list[float] | None = None,
+            **kwargs: Any,
+        ) -> dict[str, Any]:
+            self._robots.append(name)
+            return {}
+
+        def remove_robot(self, name: str) -> dict[str, Any]:
+            self._robots.remove(name)
+            return {}
+
+        def list_robots(self) -> list[str]:
+            return list(self._robots)
+
+        def robot_joint_names(self, robot_name: str) -> list[str]:
+            return ["joint_0", "joint_1"]
+
+        def add_object(
+            self,
+            name: str,
+            shape: str = "box",
+            position: list[float] | None = None,
+            orientation: list[float] | None = None,
+            size: list[float] | None = None,
+            color: list[float] | None = None,
+            mass: float = 1.0,
+            is_static: bool = False,
+            mesh_path: str | None = None,
+            **kwargs: Any,
+        ) -> dict[str, Any]:
+            return {}
+
+        def remove_object(self, name: str) -> dict[str, Any]:
+            return {}
+
+        def get_observation(self, robot_name: str | None = None, **kw: Any) -> dict[str, Any]:
+            return {}
+
+        def send_action(
+            self,
+            action: dict[str, Any],
+            robot_name: str | None = None,
+            n_substeps: int = 1,
+        ) -> None:
+            pass
+
+        def render(
+            self,
+            camera_name: str = "default",
+            width: int | None = None,
+            height: int | None = None,
+        ) -> dict[str, Any]:
+            return {}
+
+    return MinimalEngine()
+
+
+class TestDescribeABC:
+    """Tests for SimEngine.describe() on the abstract base class."""
+
+    def test_describe_exists(self):
+        engine = _make_minimal_engine()
+        result = engine.describe()
+        assert isinstance(result, dict)
+
+    def test_describe_robots_equals_list_robots(self):
+        engine = _make_minimal_engine()
+        engine.add_robot("test_bot")
+        desc = engine.describe()
+        assert desc["robots"] == engine.list_robots()
+        assert desc["robots"] == ["test_bot"]
+
+    def test_describe_robots_empty_when_no_robots(self):
+        engine = _make_minimal_engine()
+        desc = engine.describe()
+        assert desc["robots"] == []
+
+    def test_describe_has_get_robot_state_key(self):
+        engine = _make_minimal_engine()
+        desc = engine.describe()
+        assert "methods" in desc
+        assert "get_robot_state" in desc["methods"]
+
+    def test_describe_has_cameras_key(self):
+        engine = _make_minimal_engine()
+        desc = engine.describe()
+        assert "cameras" in desc
+        assert isinstance(desc["cameras"], list)
+
+    def test_describe_has_note(self):
+        engine = _make_minimal_engine()
+        desc = engine.describe()
+        assert "note" in desc
+        assert "robot_name" in desc["note"]
+
+    def test_describe_methods_includes_core_set(self):
+        engine = _make_minimal_engine()
+        desc = engine.describe()
+        expected_methods = {
+            "get_robot_state",
+            "get_observation",
+            "send_action",
+            "run_policy",
+            "list_robots",
+            "render",
+        }
+        assert expected_methods.issubset(set(desc["methods"].keys()))
+
+
+@pytest.mark.skipif(
+    not pytest.importorskip("mujoco", reason="MuJoCo not installed"),
+    reason="MuJoCo not available",
+)
+class TestDescribeMuJoCo:
+    """Tests for MuJoCoSimEngine.describe() with a live sim world."""
+
+    def test_describe_with_world_and_robot(self):
+        import os
+
+        os.environ.setdefault("MUJOCO_GL", "egl")
+        from strands_robots.simulation import Simulation
+
+        sim = Simulation()
+        try:
+            sim.create_world()
+            sim.add_robot("so100", data_config="so100")
+            desc = sim.describe()
+
+            assert desc["robots"] == sim.list_robots()
+            assert "so100" in desc["robots"]
+            assert desc["world_created"] is True
+            assert isinstance(desc["cameras"], list)
+            assert "get_robot_state" in desc["methods"]
+        finally:
+            sim.destroy()
+
+    def test_describe_no_world(self):
+        import os
+
+        os.environ.setdefault("MUJOCO_GL", "egl")
+        from strands_robots.simulation import Simulation
+
+        sim = Simulation()
+        desc = sim.describe()
+        assert desc["robots"] == []
+        assert desc["world_created"] is False
+
+
+class TestNoAlias:
+    """Code is the single source of truth: no duplicate-name aliases.
+
+    The canonical registry accessor is ``get_robot``. Agents learn it from the
+    discovery surface, so the API must NOT also export ``get_robot_info`` (a
+    name an agent once guessed). One name per concept.
+    """
+
+    def test_no_get_robot_info_alias(self):
+        import strands_robots.registry as registry
+
+        assert not hasattr(registry, "get_robot_info"), (
+            "registry must not export 'get_robot_info' — 'get_robot' is the "
+            "single canonical name. Agents learn it via the discovery surface, "
+            "not by aliasing a wrong guess."
+        )
+        assert "get_robot_info" not in getattr(registry, "__all__", [])


### PR DESCRIPTION
## Problem

There is no single call that lets a caller learn a simulation engine's contract. Without one, callers (humans and agents alike) guess method names by analogy and hit dead-end errors:

```
AttributeError: 'MuJoCoSimEngine' object has no attribute 'name'
```

## Change

Add `describe()` to `SimEngine` (with a MuJoCo override) returning a machine-readable summary of the engine's live contract in one call.

`SimEngine.describe()` returns:
- `robots`: live robot names (`list_robots()`)
- `cameras`: camera names (backends override with live data)
- `methods`: signatures of the commonly-needed methods
- `note`: explains `robot_name` defaulting behavior

`MuJoCoSimEngine.describe()` enriches the base with live MuJoCo camera names from the loaded model, plus `sim_time` and `world_created` status.

The canonical registry accessor remains `get_robot`. No alias is added: callers discover the correct name through this surface, so the API keeps one name per concept.

## Tests

`tests/simulation/test_ax2_describe_discovery.py` (11 cases):
- `describe()` exists and `describe()['robots'] == list_robots()`
- `methods` includes the core agent-callable set; `cameras` and `note` present
- MuJoCo override returns live cameras + `world_created` with a real world
- Pins the no-alias rule: `get_robot_info` is NOT exported

`hatch run lint` clean (ruff + format + mypy, 287 files); the new tests pass under `MUJOCO_GL=egl`.