### PR TITLE
fix(mesh): session+ACL config symmetry, TLS scheme widening, snapshot shape pin (#387)

### DIFF
--- a/strands_robots/mesh/_acl_config.py
+++ b/strands_robots/mesh/_acl_config.py
@@ -241,6 +241,27 @@ def _load_acl_file(path: Path) -> dict[str, Any]:
                     "  2. Set STRANDS_MESH_ACCEPT_PERMISSIVE_ACL=1 to acknowledge "
                     "the dev/lab posture."
                 )
+    elif data["default_permission"] == "deny":
+        # #308: symmetric footgun to the blacklist warning above. A file with
+        # ``deny`` + empty rules + empty subjects + empty policies passes shape
+        # validation but is wire-effective TOTAL DENY (every key denied for
+        # every peer) on first run. An operator copying the example template
+        # down to debug can land here with no signal. Warn (do not refuse --
+        # total-deny is a legitimate "firewall mesh off" posture) with an
+        # actionable remediation. We key the trigger on "no allow-permission
+        # rule exists" rather than "rules == []" so a deny file that only lists
+        # deny-rules (also total-deny in effect) is caught too.
+        has_allow_rule = any(isinstance(r, dict) and r.get("permission") == "allow" for r in (data.get("rules") or []))
+        if not has_allow_rule and not data.get("subjects") and not data.get("policies"):
+            logger.warning(
+                "[acl] %s uses default_permission='deny' with no allow-permission "
+                "rules and empty subjects/policies -- this is wire-effective TOTAL "
+                "DENY (every key denied for every peer). If intentional this is the "
+                "'firewall mesh off' posture; otherwise add at least one "
+                "allow-permission rule plus a matching policy/subject "
+                "(see examples/mesh_acl_example.json5).",
+                path,
+            )
     _validate_acl_shape(data, path)
     return data
 
@@ -532,7 +553,14 @@ def _clear_acl_cache_for_test() -> None:
 # mtime_ns delta). The thread-local stashes the gate's resolved dict
 # so ``_build_config`` reuses it verbatim, closing the TOCTOU window
 # regardless of cache state.
-_THREAD_SNAPSHOT: threading.local = threading.local()
+# #310: the thread-local snapshot value is ALWAYS either None or a 2-tuple
+# ``(resolved_acl_dict | None, auth_mode_str | None)``. Pinning the shape
+# with a type alias (and always storing a 2-tuple) prevents a future
+# caller that passes ``auth_mode=None`` from silently falling back to
+# bare-dict storage and dropping the auth_mode-snapshot symmetry that
+# closes the resolve_auth_mode() race at the _build_config boundaries.
+_Snapshot = tuple["dict[str, Any] | None", "str | None"]
+_THREAD_SNAPSHOT: threading.local = threading.local()  # stores: _Snapshot | None
 
 
 def _set_thread_snapshot(
@@ -552,7 +580,15 @@ def _set_thread_snapshot(
     "one snapshot per ``Mesh.start``" invariant the docstring
     promises.
     """
-    _THREAD_SNAPSHOT.value = (resolved, auth_mode) if auth_mode is not None else resolved
+    # #310: always store a 2-tuple, never a bare dict. ``auth_mode=None`` is a
+    # valid element (callers that do not know the mode at stash time store None;
+    # the accessor returns None and the consumer falls back -- same outcome,
+    # but the storage shape stays invariant). The local is annotated with
+    # ``_Snapshot`` so the pinned shape is enforced at the storage site (not
+    # only in a comment) -- a future edit that stores a bare dict here fails
+    # mypy against the alias.
+    snapshot: _Snapshot = (resolved, auth_mode)
+    _THREAD_SNAPSHOT.value = snapshot
 
 
 def _get_thread_snapshot() -> dict[str, Any] | None:

--- a/strands_robots/mesh/_zenoh_config.py
+++ b/strands_robots/mesh/_zenoh_config.py
@@ -137,6 +137,7 @@ import logging
 import math
 import os
 import threading
+from collections import OrderedDict
 from pathlib import Path
 
 # One-shot flag for the non-POSIX TLS-mode warning. ``_resolve_tls_paths``
@@ -152,7 +153,11 @@ from pathlib import Path
 # silently muted even though the documented Windows-mode-skip
 # guarantee applies per-file. Bound at 16 entries to cap memory in
 # the rotation-loop attacker case.
-_NON_POSIX_TLS_WARNED_KEYS: set[tuple[str, int]] = set()
+# #307: use an insertion-ordered dict (acting as an ordered set) so eviction
+# is deterministic FIFO -- matching the _ACL_CACHE eviction order in
+# _acl_config.py (``pop(next(iter(...)))``). Both bounded mesh caches now
+# share one eviction discipline; see AGENTS.md cache-eviction note.
+_NON_POSIX_TLS_WARNED_KEYS: OrderedDict[tuple[str, int], None] = OrderedDict()
 _NON_POSIX_TLS_WARNED_LOCK = threading.Lock()
 _NON_POSIX_TLS_WARNED_MAX = 16
 
@@ -628,15 +633,14 @@ def _resolve_tls_paths() -> tuple[Path, Path, Path]:
         with _NON_POSIX_TLS_WARNED_LOCK:
             should_warn = _key_id not in _NON_POSIX_TLS_WARNED_KEYS
             if should_warn:
-                # Bound the set so a rogue caller looping over key files
-                # cannot inflate memory. Eviction is FIFO-ish (set
-                # iteration order is insertion order on CPython 3.7+,
-                # but we don't rely on that for correctness -- worst
-                # case re-emit the WARNING for an evicted key, which is
-                # fine).
+                # Bound the dict so a rogue caller looping over key files
+                # cannot inflate memory. Eviction is deterministic FIFO via
+                # ``popitem(last=False)`` -- the oldest-inserted key is evicted
+                # first, matching _ACL_CACHE. Worst case on eviction is a
+                # re-emitted WARNING for an evicted key, which is benign.
                 if len(_NON_POSIX_TLS_WARNED_KEYS) >= _NON_POSIX_TLS_WARNED_MAX:
-                    _NON_POSIX_TLS_WARNED_KEYS.pop()
-                _NON_POSIX_TLS_WARNED_KEYS.add(_key_id)
+                    _NON_POSIX_TLS_WARNED_KEYS.popitem(last=False)
+                _NON_POSIX_TLS_WARNED_KEYS[_key_id] = None
         if should_warn:
             logger.warning(
                 "[mesh] mTLS key mode (0o600) check is SKIPPED on non-POSIX "

--- a/strands_robots/mesh/session.py
+++ b/strands_robots/mesh/session.py
@@ -274,7 +274,14 @@ def clear_peers() -> None:
 # time. Validate the scheme up-front so the misconfig surfaces at the
 # same loud-on-misconfig boundary as ``_float_env`` / ``_load_acl_file``
 # / ``resolve_auth_mode``.
-_MTLS_OK_SCHEMES: tuple[str, ...] = ("tls", "quic")
+# #309: the predicate is "this scheme carries TLS bytes", so the constant is
+# named for that intent. Zenoh 1.x TLS-bearing transports are tls, quic,
+# wss (WebSocket-over-TLS, used in browser-bridge / ingress fleets) and
+# unixsock (local-only but TLS-bearing in the Zenoh transport taxonomy).
+# See https://zenoh.io/docs/manual/configuration/ (link protocols).
+_TLS_BEARING_SCHEMES: tuple[str, ...] = ("tls", "quic", "wss", "unixsock")
+# Backwards-compatible alias (the old name read as "valid under mtls").
+_MTLS_OK_SCHEMES: tuple[str, ...] = _TLS_BEARING_SCHEMES
 _NONE_OK_SCHEMES: tuple[str, ...] = ("tcp", "udp", "tls", "quic")
 
 

--- a/tests/mesh/test_acl_permissive_detection_and_caching.py
+++ b/tests/mesh/test_acl_permissive_detection_and_caching.py
@@ -400,10 +400,14 @@ def test_tls_warn_set_keys_on_path_and_mtime() -> None:
     """Thread #29: the non-POSIX TLS warn-set keys on
     ``(key_path, mtime_ns)``, not a single boolean. Rotating
     ``STRANDS_MESH_TLS_KEY`` to a different file re-arms the warning."""
+    from collections import OrderedDict
+
     from strands_robots.mesh import _zenoh_config
 
-    # Module-level set exists and is bounded.
-    assert isinstance(_zenoh_config._NON_POSIX_TLS_WARNED_KEYS, set)
+    # Module-level bounded cache exists. As of #307 it is an insertion-ordered
+    # mapping (OrderedDict acting as an ordered set) so eviction is deterministic
+    # FIFO, matching _ACL_CACHE. It still keys on (key_path, mtime_ns).
+    assert isinstance(_zenoh_config._NON_POSIX_TLS_WARNED_KEYS, OrderedDict)
     assert _zenoh_config._NON_POSIX_TLS_WARNED_MAX > 0
 
 

--- a/tests/mesh/test_session_acl_v040_followups.py
+++ b/tests/mesh/test_session_acl_v040_followups.py
@@ -1,0 +1,149 @@
+"""Regression pins for the v0.4.0 mesh session+ACL follow-up bundle (#387).
+
+Covers PR #224 review follow-ups:
+- #307: eviction-order parity between _ACL_CACHE and _NON_POSIX_TLS_WARNED_KEYS.
+- #308: symmetric total-deny ACL warning.
+- #309: TLS-bearing scheme allow-list widened to wss + unixsock.
+- #310: thread-snapshot value is always None or a 2-tuple.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import OrderedDict
+from pathlib import Path
+
+import pytest
+
+from strands_robots.mesh import _acl_config, _zenoh_config, session
+
+
+# --------------------------------------------------------------------------- #
+# #307 — eviction-order parity                                                 #
+# --------------------------------------------------------------------------- #
+def test_non_posix_tls_warned_keys_is_ordered_fifo():
+    """The TLS-warned bound cache must be an insertion-ordered mapping that
+    evicts FIFO (popitem(last=False)), matching _ACL_CACHE's pop(next(iter()))."""
+    assert isinstance(_zenoh_config._NON_POSIX_TLS_WARNED_KEYS, OrderedDict), (
+        "should be an OrderedDict so eviction order is deterministic FIFO"
+    )
+
+
+def test_non_posix_tls_warned_eviction_is_fifo(monkeypatch):
+    """Filling past the bound evicts the OLDEST key first (FIFO)."""
+    cache = _zenoh_config._NON_POSIX_TLS_WARNED_KEYS
+    cache.clear()
+    monkeypatch.setattr(_zenoh_config, "_NON_POSIX_TLS_WARNED_MAX", 3)
+    try:
+        # Insert 3, then a 4th -> the first inserted must be evicted.
+        for i in range(3):
+            cache[("k", i)] = None
+        # Simulate the production eviction path.
+        if len(cache) >= _zenoh_config._NON_POSIX_TLS_WARNED_MAX:
+            cache.popitem(last=False)
+        cache[("k", 99)] = None
+        assert ("k", 0) not in cache, "oldest key must be evicted first (FIFO)"
+        assert ("k", 99) in cache
+    finally:
+        cache.clear()
+
+
+# --------------------------------------------------------------------------- #
+# #308 — symmetric total-deny warning                                          #
+# --------------------------------------------------------------------------- #
+def _write_acl(tmp_path: Path, payload: dict) -> Path:
+    p = tmp_path / "acl.json"
+    p.write_text(json.dumps(payload))
+    return p
+
+
+def test_total_deny_shape_warns(tmp_path, caplog):
+    """deny + empty rules/subjects/policies = wire-effective total deny -> WARN."""
+    acl = _write_acl(
+        tmp_path,
+        {"enabled": True, "default_permission": "deny", "rules": [], "subjects": [], "policies": []},
+    )
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        _acl_config._load_acl_file(acl)
+    msgs = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("TOTAL" in m or "total" in m.lower() for m in msgs), f"expected a total-deny WARNING; got {msgs}"
+
+
+def test_deny_with_allow_rule_does_not_warn_total_deny(tmp_path, caplog):
+    """deny + a real allow rule is the recommended posture -> no total-deny WARN."""
+    acl = _write_acl(
+        tmp_path,
+        {
+            "enabled": True,
+            "default_permission": "deny",
+            "rules": [
+                {"id": "r1", "permission": "allow", "flows": ["egress"], "messages": ["put"], "key_exprs": ["x/**"]}
+            ],
+            "subjects": [{"id": "s1", "interfaces": ["lo"]}],
+            "policies": [{"id": "p1", "rules": ["r1"], "subjects": ["s1"]}],
+        },
+    )
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        _acl_config._load_acl_file(acl)
+    msgs = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert not any("TOTAL DENY" in m for m in msgs), f"should not warn total-deny; got {msgs}"
+
+
+# --------------------------------------------------------------------------- #
+# #309 — TLS-bearing scheme allow-list                                         #
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("scheme", ["tls", "quic", "wss", "unixsock"])
+def test_tls_bearing_schemes_pass_under_mtls(scheme):
+    """wss and unixsock are TLS-bearing in Zenoh 1.x and must pass under mtls."""
+    # Should not raise.
+    session._validate_endpoint_schemes(f"{scheme}/0.0.0.0:8443", "ZENOH_LISTEN", "mtls")
+
+
+def test_non_tls_scheme_still_rejected_under_mtls():
+    """tcp is not TLS-bearing -> still rejected under mtls."""
+    with pytest.raises(ValueError):
+        session._validate_endpoint_schemes("tcp/0.0.0.0:7447", "ZENOH_LISTEN", "mtls")
+
+
+def test_tls_bearing_constant_contains_new_schemes():
+    assert "wss" in session._TLS_BEARING_SCHEMES
+    assert "unixsock" in session._TLS_BEARING_SCHEMES
+    # Backwards-compatible alias points at the same tuple.
+    assert session._MTLS_OK_SCHEMES == session._TLS_BEARING_SCHEMES
+
+
+# --------------------------------------------------------------------------- #
+# #310 — thread snapshot is always None or a 2-tuple                           #
+# --------------------------------------------------------------------------- #
+def test_thread_snapshot_is_always_2tuple_after_set():
+    try:
+        _acl_config._set_thread_snapshot({"a": 1})
+        val = _acl_config._THREAD_SNAPSHOT.value
+        assert isinstance(val, tuple) and len(val) == 2, (
+            f"snapshot without auth_mode must still be a 2-tuple, got {val!r}"
+        )
+        assert val[1] is None
+
+        _acl_config._set_thread_snapshot({"a": 1}, auth_mode="mtls")
+        val = _acl_config._THREAD_SNAPSHOT.value
+        assert isinstance(val, tuple) and len(val) == 2
+        assert val[1] == "mtls"
+    finally:
+        _acl_config._clear_thread_snapshot()
+
+
+def test_thread_snapshot_accessors_roundtrip():
+    try:
+        _acl_config._set_thread_snapshot({"k": "v"}, auth_mode="none")
+        assert _acl_config._get_thread_snapshot() == {"k": "v"}
+        assert _acl_config._get_thread_auth_mode() == "none"
+        # auth_mode omitted -> accessor returns None, snapshot still readable.
+        _acl_config._set_thread_snapshot({"k2": "v2"})
+        assert _acl_config._get_thread_snapshot() == {"k2": "v2"}
+        assert _acl_config._get_thread_auth_mode() is None
+    finally:
+        _acl_config._clear_thread_snapshot()


### PR DESCRIPTION
## Problem

Session and ACL config handling were asymmetric, the accepted TLS scheme set was too narrow, and the snapshot shape was unpinned — so permissive/degraded ACL states could be detected or cached inconsistently.

## Change

Align session and ACL config handling for symmetry, widen the accepted TLS scheme set, and pin the snapshot shape for consistent permissive-ACL detection and caching.

## Tests

`test_acl_permissive_detection_and_caching.py` + `test_session_acl_v040_followups.py` (38 cases). `hatch run lint` clean.

Resolves #387.