### PR TITLE
mesh(audit): NEXT_SEQ_DEGRADED poison record + v0.4.0 safety follow-ups (#386)

### DIFF
--- a/strands_robots/mesh/audit.py
+++ b/strands_robots/mesh/audit.py
@@ -1018,6 +1018,7 @@ def log_safety_event(event_type: str, peer_id: str, payload: dict[str, Any]) -> 
         path that called this function.
     """
     seq_lock_degraded_reason: str | None = None
+    next_seq_degraded_reason: str | None = None
     try:
         seq = _next_seq(peer_id)
     except SeqLockSymlinkError as exc:
@@ -1035,12 +1036,21 @@ def log_safety_event(event_type: str, peer_id: str, payload: dict[str, Any]) -> 
         seq = 0
         seq_lock_degraded_reason = str(exc)
     except Exception as exc:  # noqa: BLE001 -- audit log failures MUST be soft per contract
-        logger.warning(
-            "[audit] _next_seq failed for peer_id=%r: %s -- record dropped (no seq)",
+        # #324: a non-symlink _next_seq failure (e.g. OSError on the seq
+        # sidecar, a corrupt counter file, a permissions flip) previously
+        # dropped the record silently -- leaving a gap on this peer's stream
+        # that no verifier could attribute. Mirror the SEQ_LOCK_DEGRADED /
+        # PSK_DEGRADED / SIGN_FAILED poison-record discipline: emit a
+        # NEXT_SEQ_DEGRADED poison record with seq=0 so verify_audit_integrity
+        # walkers see (and can classify) the seq-counter integrity gap instead
+        # of a silent hole.
+        logger.error(
+            "[audit] NEXT_SEQ_DEGRADED for peer_id=%r: %s -- writing poison record",
             peer_id,
             exc,
         )
-        return
+        seq = 0
+        next_seq_degraded_reason = str(exc)
     record: dict[str, Any] = {
         "ts": time.time(),
         "event": event_type,
@@ -1048,14 +1058,18 @@ def log_safety_event(event_type: str, peer_id: str, payload: dict[str, Any]) -> 
         "payload": payload,
         "seq": seq,
     }
-    if seq_lock_degraded_reason is not None:
+    if next_seq_degraded_reason is not None:
+        # #324: non-symlink _next_seq failure -- poison the record so the gap
+        # is attributable on this peer's stream (symmetry with SEQ_LOCK_DEGRADED).
+        record["sig"] = "NEXT_SEQ_DEGRADED"
+    elif seq_lock_degraded_reason is not None:
         # Poison-record discipline: signal SEQ_LOCK_DEGRADED so a
         # verifier flags the seq-counter integrity gap. Mirrors the
         # PSK_DEGRADED / SIGN_FAILED poison patterns below.
         record["sig"] = "SEQ_LOCK_DEGRADED"
         record["seq_lock_degraded"] = seq_lock_degraded_reason
     sig: str | None = None
-    if seq_lock_degraded_reason is None:
+    if seq_lock_degraded_reason is None and next_seq_degraded_reason is None:
         try:
             sig = _sign_record(record)
         except AuditPSKDegradedError as exc:

--- a/tests/mesh/test_audit_integrity.py
+++ b/tests/mesh/test_audit_integrity.py
@@ -315,10 +315,16 @@ def test_missing_sig_does_not_advance_cursor_when_psk_present(tmp_path, monkeypa
 
 
 def test_log_safety_event_does_not_propagate_seq_errors(monkeypatch, tmp_path, caplog):
-    """log_safety_event's docstring says 'Raises: Nothing'
-    but _next_seq used to be invoked outside the try/except. Verify the fix:
-    even when _next_seq raises, log_safety_event swallows and logs a WARNING.
+    """log_safety_event's docstring says 'Raises: Nothing'. Even when
+    _next_seq raises, log_safety_event must swallow the error (not propagate
+    into the safety code path).
+
+    #324 update: instead of dropping the record silently, a non-symlink
+    _next_seq failure now writes a NEXT_SEQ_DEGRADED poison record (seq=0) so
+    a verifier can attribute the gap. The no-propagate contract is unchanged;
+    the silent-drop is replaced by an attributable poison record.
     """
+    import json as _json
 
     monkeypatch.setenv("STRANDS_MESH_AUDIT_DIR", str(tmp_path))
     monkeypatch.delenv("STRANDS_MESH_AUDIT_PSK", raising=False)
@@ -329,19 +335,23 @@ def test_log_safety_event_does_not_propagate_seq_errors(monkeypatch, tmp_path, c
 
     monkeypatch.setattr(audit, "_next_seq", boom)
 
-    with caplog.at_level(logging.WARNING, logger="strands_robots.mesh.audit"):
+    with caplog.at_level(logging.ERROR, logger="strands_robots.mesh.audit"):
         # Must NOT raise.
         audit.log_safety_event("test_event", "peer-x", {"k": "v"})
 
-    # Warning was emitted.
-    assert any("_next_seq failed" in record.message for record in caplog.records), (
-        f"expected _next_seq failure WARNING in {[r.message for r in caplog.records]}"
+    # #324: a NEXT_SEQ_DEGRADED diagnostic is emitted (ERROR level).
+    assert any("NEXT_SEQ_DEGRADED" in record.message for record in caplog.records), (
+        f"expected NEXT_SEQ_DEGRADED diagnostic in {[r.message for r in caplog.records]}"
     )
 
-    # No record was written.
+    # #324: a poison record IS written now (not a silent drop), tagged so a
+    # verifier flags the seq gap.
     log_path = audit.audit_log_path()
-    if log_path.exists():
-        assert log_path.read_text().strip() == "", "record was written despite _next_seq failure"
+    assert log_path.exists(), "a poison record must be written, not dropped"
+    records = [_json.loads(line) for line in log_path.read_text().splitlines() if line.strip()]
+    assert any(r.get("sig") == "NEXT_SEQ_DEGRADED" and r.get("seq") == 0 for r in records), (
+        f"expected a NEXT_SEQ_DEGRADED poison record with seq=0; got {records}"
+    )
 
 
 def test_psk_degrade_drops_record(monkeypatch, tmp_path, caplog):

--- a/tests/mesh/test_safety_audit_v040_followups.py
+++ b/tests/mesh/test_safety_audit_v040_followups.py
@@ -1,0 +1,110 @@
+"""v0.4.0 mesh safety+audit follow-up pins (#386), from the #221/#225 R12 trail.
+
+- #324: a non-symlink _next_seq failure writes a NEXT_SEQ_DEGRADED poison
+  record (symmetry with SEQ_LOCK_DEGRADED) instead of dropping the record.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from strands_robots.mesh import audit
+
+
+@pytest.fixture(autouse=True)
+def _isolate_audit_state(tmp_path, monkeypatch):
+    monkeypatch.setenv("STRANDS_MESH_AUDIT_DIR", str(tmp_path))
+    audit._AUDIT_STATE.seq_loaded = False
+    audit._AUDIT_STATE.audit_log_seeded = False
+    audit._SEQ_COUNTERS.clear()
+    yield
+    audit._AUDIT_STATE.seq_loaded = False
+    audit._AUDIT_STATE.audit_log_seeded = False
+    audit._SEQ_COUNTERS.clear()
+
+
+# --------------------------------------------------------------------------- #
+# #324 — NEXT_SEQ_DEGRADED poison record                                       #
+# --------------------------------------------------------------------------- #
+def test_next_seq_non_symlink_failure_writes_poison_record(tmp_path, monkeypatch, caplog):
+    """A non-SeqLockSymlinkError failure inside _next_seq must NOT drop the
+    record silently -- it writes a NEXT_SEQ_DEGRADED poison record so a verifier
+    can attribute the seq gap. Pre-fix the record was dropped (return)."""
+    import logging
+
+    def _boom(_peer_id):
+        raise OSError("simulated seq sidecar I/O failure")
+
+    monkeypatch.setattr(audit, "_next_seq", _boom)
+
+    with caplog.at_level(logging.ERROR, logger="strands_robots.mesh.audit"):
+        audit.log_safety_event("emergency_stop", "peerA", {"reason": "test"})
+
+    # The audit log file must contain a NEXT_SEQ_DEGRADED poison record.
+    log_path = Path(tmp_path) / "mesh_audit.jsonl"
+    assert log_path.exists(), "a poison record must still be written (not dropped)"
+    records = [json.loads(line) for line in log_path.read_text().splitlines() if line.strip()]
+    poison = [r for r in records if r.get("sig") == "NEXT_SEQ_DEGRADED"]
+    assert poison, f"expected a NEXT_SEQ_DEGRADED poison record; got {records}"
+    assert poison[0]["peer_id"] == "peerA"
+    assert poison[0]["seq"] == 0
+
+
+def test_seqlock_symlink_still_writes_seq_lock_degraded(tmp_path, monkeypatch):
+    """The pre-existing SEQ_LOCK_DEGRADED path must be unchanged by #324."""
+    from strands_robots.mesh.audit import SeqLockSymlinkError
+
+    def _symlink_boom(_peer_id):
+        raise SeqLockSymlinkError("symlinked seq lockfile")
+
+    monkeypatch.setattr(audit, "_next_seq", _symlink_boom)
+    audit.log_safety_event("emergency_stop", "peerB", {"reason": "test"})
+
+    log_path = Path(tmp_path) / "mesh_audit.jsonl"
+    records = [json.loads(line) for line in log_path.read_text().splitlines() if line.strip()]
+    assert any(r.get("sig") == "SEQ_LOCK_DEGRADED" for r in records), (
+        f"SEQ_LOCK_DEGRADED path must be preserved; got {records}"
+    )
+    assert not any(r.get("sig") == "NEXT_SEQ_DEGRADED" for r in records)
+
+
+# --------------------------------------------------------------------------- #
+# #324 — NEXT_SEQ_DEGRADED poison survives PSK signing gate                    #
+# --------------------------------------------------------------------------- #
+def test_next_seq_degraded_poison_survives_psk_signing(tmp_path, monkeypatch, caplog):
+    """Regression pin: when STRANDS_MESH_AUDIT_PSK is configured, the
+    NEXT_SEQ_DEGRADED poison marker must NOT be overwritten by _sign_record.
+
+    The signing-skip gate must cover both seq_lock_degraded_reason AND
+    next_seq_degraded_reason. Without the fix, _sign_record runs on the
+    poison record and clobbers record['sig'] with a valid HMAC, making
+    the seq-counter integrity gap invisible to verifiers."""
+    import logging
+
+    # Configure a real PSK (32-byte hex = 64 hex chars).
+    psk_hex = "a" * 64
+    monkeypatch.setenv("STRANDS_MESH_AUDIT_PSK", psk_hex)
+
+    # Force a non-symlink _next_seq failure.
+    def _boom(_peer_id):
+        raise OSError("simulated seq sidecar permissions failure")
+
+    monkeypatch.setattr(audit, "_next_seq", _boom)
+
+    with caplog.at_level(logging.ERROR, logger="strands_robots.mesh.audit"):
+        audit.log_safety_event("emergency_stop", "peerC", {"reason": "psk_regression"})
+
+    # The poison marker must survive -- NOT be overwritten by a real HMAC.
+    log_path = Path(tmp_path) / "mesh_audit.jsonl"
+    assert log_path.exists(), "poison record must be written even with PSK configured"
+    records = [json.loads(line) for line in log_path.read_text().splitlines() if line.strip()]
+    poison = [r for r in records if r.get("peer_id") == "peerC"]
+    assert poison, f"expected a record for peerC; got {records}"
+    assert poison[0]["sig"] == "NEXT_SEQ_DEGRADED", (
+        f"NEXT_SEQ_DEGRADED poison must survive PSK signing gate; "
+        f"got sig={poison[0].get('sig')!r} (likely overwritten by HMAC)"
+    )
+    assert poison[0]["seq"] == 0


### PR DESCRIPTION
## Problem

A degraded sequence state in the mesh audit path could be skipped without an explicit record, leaving a gap in the audit log. Several v0.4.0 safety follow-ups were also outstanding.

## Change

Write an explicit NEXT_SEQ_DEGRADED poison record when the sequence state degrades, so the audit log captures it rather than silently advancing, and land the v0.4.0 safety follow-ups.

## Tests

`test_audit_integrity.py` + `test_safety_audit_v040_followups.py` (28 cases). `hatch run lint` clean.

Resolves #386.