### PR TITLE
fix(sim): make robot_name optional across get_robot_state-family methods

### DIFF
--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -88,6 +88,33 @@ class SimEngine(ABC):
         sim.destroy()
     """
 
+    def _resolve_single_robot(self, robot_name: str | None) -> str:
+        """Resolve an optional robot name to a concrete one.
+
+        None + exactly one robot -> that robot.
+        None + zero robots -> ValueError.
+        None + many robots -> ValueError listing the candidates so the
+        caller can recover in zero extra calls.
+
+        Args:
+            robot_name: Explicit robot name (returned unchanged) or None.
+
+        Returns:
+            Resolved robot name string.
+
+        Raises:
+            ValueError: When robot_name is None and the resolution is
+                ambiguous or impossible.
+        """
+        if robot_name is not None:
+            return robot_name
+        names = self.list_robots()
+        if len(names) == 1:
+            return names[0]
+        if len(names) == 0:
+            raise ValueError("No robots registered in the simulation. Add a robot first (add_robot or Robot factory).")
+        raise ValueError(f"Multiple robots registered; specify robot_name. Available: {names}")
+
     # World lifecycle
 
     @abstractmethod
@@ -263,7 +290,7 @@ class SimEngine(ABC):
 
     def run_policy(
         self,
-        robot_name: str,
+        robot_name: str | None = None,
         policy_provider: str = "mock",
         policy_config: dict[str, Any] | None = None,
         instruction: str = "",
@@ -314,6 +341,8 @@ class SimEngine(ABC):
             Standard status dict.
         """
         from strands_robots.policies import create_policy
+
+        robot_name = self._resolve_single_robot(robot_name)
 
         # accept n_steps (or legacy max_steps) as an alternate horizon
         # specification. duration = n_steps / control_frequency. If both
@@ -366,7 +395,7 @@ class SimEngine(ABC):
 
     def start_policy(
         self,
-        robot_name: str,
+        robot_name: str | None = None,
         policy_provider: str = "mock",
         policy_config: dict[str, Any] | None = None,
         instruction: str = "",
@@ -388,6 +417,7 @@ class SimEngine(ABC):
         accepts ``n_steps`` (primary) or legacy ``max_steps`` as an
         alternate to ``duration``. See ``run_policy`` for conversion rules.
         """
+        robot_name = self._resolve_single_robot(robot_name)
         return self.run_policy(
             robot_name,
             policy_provider=policy_provider,

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -994,12 +994,13 @@ class MuJoCoSimEngine(
 
         return base
 
-    def get_robot_state(self, robot_name: str) -> dict[str, Any]:
+    def get_robot_state(self, robot_name: str | None = None) -> dict[str, Any]:
         """canonical name parameter is ``robot_name``. The router
         accepts ``name`` as an alias (bidirectional) so legacy LLM calls
         keep working, but new tool specs should document only robot_name."""
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+        robot_name = self._resolve_single_robot(robot_name)
         if robot_name not in self._world.robots:
             return {"status": "error", "content": [{"text": f"Robot '{robot_name}' not found."}]}
 
@@ -1856,7 +1857,7 @@ class MuJoCoSimEngine(
 
     def start_policy(
         self,
-        robot_name: str,
+        robot_name: str | None = None,
         policy_provider: str = "mock",
         policy_config: dict[str, Any] | None = None,
         instruction: str = "",
@@ -1888,6 +1889,7 @@ class MuJoCoSimEngine(
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+        robot_name = self._resolve_single_robot(robot_name)
         if robot_name not in self._world.robots:
             return {"status": "error", "content": [{"text": f"Robot '{robot_name}' not found."}]}
 
@@ -1993,7 +1995,7 @@ class MuJoCoSimEngine(
 
     def run_policy(
         self,
-        robot_name: str,
+        robot_name: str | None = None,
         policy_provider: str = "mock",
         policy_config: dict[str, Any] | None = None,
         instruction: str = "",
@@ -2020,6 +2022,8 @@ class MuJoCoSimEngine(
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+
+        robot_name = self._resolve_single_robot(robot_name)
 
         try:
             return super().run_policy(

--- a/tests/simulation/mujoco/test_ax1_robot_name_optional.py
+++ b/tests/simulation/mujoco/test_ax1_robot_name_optional.py
@@ -1,0 +1,157 @@
+"""AX-1 regression test: robot_name optional across get_robot_state-family methods.
+
+This test MUST FAIL before the fix and PASS after it.
+
+The inconsistency: get_observation(robot_name=None) works (infers single robot),
+but get_robot_state(robot_name) requires the arg. An agent (or human) who learns
+one signature cannot transfer to the other.
+
+Fix: a shared _resolve_single_robot(robot_name) helper that resolves None when
+exactly one robot exists, and raises ValueError listing candidates when ambiguous.
+
+Applied to: get_robot_state, run_policy, start_policy.
+Already correct: get_observation, send_action (default to None).
+"""
+
+import os
+
+import pytest
+
+os.environ.setdefault("MUJOCO_GL", "egl")
+
+
+@pytest.fixture
+def single_robot_sim():
+    """Create a sim with exactly ONE robot (so100)."""
+    from strands_robots.simulation.mujoco.simulation import MuJoCoSimEngine
+
+    sim = MuJoCoSimEngine(tool_name="test_ax1_single")
+    sim.create_world()
+    result = sim.add_robot("alice", data_config="so100")
+    assert result["status"] == "success", f"add_robot failed: {result}"
+    yield sim
+    sim.cleanup()
+
+
+@pytest.fixture
+def two_robot_sim():
+    """Create a sim with TWO robots (both so100, different names)."""
+    from strands_robots.simulation.mujoco.simulation import MuJoCoSimEngine
+
+    sim = MuJoCoSimEngine(tool_name="test_ax1_multi")
+    sim.create_world()
+    r1 = sim.add_robot("alice", data_config="so100")
+    assert r1["status"] == "success", f"add_robot alice failed: {r1}"
+    r2 = sim.add_robot("bob", data_config="so100", position=[1.0, 0.0, 0.0])
+    assert r2["status"] == "success", f"add_robot bob failed: {r2}"
+    yield sim
+    sim.cleanup()
+
+
+class TestGetRobotStateOptional:
+    """get_robot_state() should work without robot_name when exactly one robot."""
+
+    def test_single_robot_no_arg(self, single_robot_sim):
+        """Core AX-1: single-robot sim -> get_robot_state() (no arg) succeeds."""
+        result = single_robot_sim.get_robot_state()
+        assert result["status"] == "success", f"Expected success, got: {result}"
+        # Should contain joint state
+        assert any("json" in c for c in result["content"]), "Expected JSON state payload"
+
+    def test_single_robot_explicit_arg(self, single_robot_sim):
+        """Explicit robot_name still works (backwards compat)."""
+        result = single_robot_sim.get_robot_state(robot_name="alice")
+        assert result["status"] == "success"
+
+    def test_two_robots_no_arg_raises(self, two_robot_sim):
+        """Two-robot sim -> get_robot_state() raises ValueError listing both names."""
+        with pytest.raises(ValueError, match=".*alice.*bob.*|.*bob.*alice.*"):
+            two_robot_sim.get_robot_state()
+
+    def test_two_robots_explicit_arg_works(self, two_robot_sim):
+        """Two-robot sim -> get_robot_state(robot_name='alice') works fine."""
+        result = two_robot_sim.get_robot_state(robot_name="alice")
+        assert result["status"] == "success"
+        result2 = two_robot_sim.get_robot_state(robot_name="bob")
+        assert result2["status"] == "success"
+
+
+class TestRunPolicyOptional:
+    """run_policy() should infer robot_name when exactly one robot."""
+
+    def test_single_robot_no_arg(self, single_robot_sim):
+        """Single robot -> run_policy() (no robot_name) uses that robot."""
+        result = single_robot_sim.run_policy(policy_provider="mock", duration=0.1, control_frequency=10.0)
+        assert result["status"] == "success", f"Expected success, got: {result}"
+
+    def test_two_robots_no_arg_raises(self, two_robot_sim):
+        """Two robots -> run_policy() raises ValueError listing both names."""
+        with pytest.raises(ValueError, match=".*alice.*bob.*|.*bob.*alice.*"):
+            two_robot_sim.run_policy(policy_provider="mock", duration=0.1)
+
+
+class TestStartPolicyOptional:
+    """start_policy() should infer robot_name when exactly one robot."""
+
+    def test_single_robot_no_arg(self, single_robot_sim):
+        """Single robot -> start_policy() (no robot_name) uses that robot."""
+        result = single_robot_sim.start_policy(policy_provider="mock", duration=0.1, control_frequency=10.0)
+        assert result["status"] == "success", f"Expected success, got: {result}"
+        # Wait for async policy to finish
+        import time
+
+        time.sleep(0.5)
+
+    def test_two_robots_no_arg_raises(self, two_robot_sim):
+        """Two robots -> start_policy() raises ValueError listing both names."""
+        with pytest.raises(ValueError, match=".*alice.*bob.*|.*bob.*alice.*"):
+            two_robot_sim.start_policy(policy_provider="mock", duration=0.1)
+
+
+class TestRobotFactoryEntryPoint:
+    """AX-4 verification: Robot("so100", mode="sim") -> get_robot_state() works."""
+
+    def test_robot_factory_get_state_no_arg(self):
+        """Robot('so100') factory -> get_robot_state() just works."""
+        from strands_robots.robot import Robot
+
+        sim = Robot("so100", mode="sim", mesh=False)
+        try:
+            result = sim.get_robot_state()
+            assert result["status"] == "success", f"Expected success, got: {result}"
+        finally:
+            sim.cleanup()
+
+
+class TestResolveSingleRobotHelper:
+    """Unit tests for the _resolve_single_robot helper."""
+
+    def test_explicit_name_passthrough(self, single_robot_sim):
+        """Explicit name is returned unchanged."""
+        resolved = single_robot_sim._resolve_single_robot("alice")
+        assert resolved == "alice"
+
+    def test_none_single_robot(self, single_robot_sim):
+        """None + one robot -> that robot's name."""
+        resolved = single_robot_sim._resolve_single_robot(None)
+        assert resolved == "alice"
+
+    def test_none_multiple_robots(self, two_robot_sim):
+        """None + multiple robots -> ValueError with both names."""
+        with pytest.raises(ValueError) as exc_info:
+            two_robot_sim._resolve_single_robot(None)
+        msg = str(exc_info.value)
+        assert "alice" in msg
+        assert "bob" in msg
+
+    def test_none_no_robots(self):
+        """None + no robots -> ValueError."""
+        from strands_robots.simulation.mujoco.simulation import MuJoCoSimEngine
+
+        sim = MuJoCoSimEngine(tool_name="test_ax1_empty")
+        sim.create_world()
+        try:
+            with pytest.raises(ValueError, match="[Nn]o robot"):
+                sim._resolve_single_robot(None)
+        finally:
+            sim.cleanup()


### PR DESCRIPTION
## Summary

Make `robot_name` parameter optional in `get_robot_state`, `run_policy`, and `start_policy` -- matching the existing behavior of `get_observation` and `send_action` which already default to `None`.

## Problem

`get_observation(robot_name=None)` infers the single robot, but `get_robot_state(robot_name)` requires the argument. An agent (or human) who learns one cannot transfer to the other:

```
TypeError: MuJoCoSimEngine.get_robot_state() missing 1 required positional argument: 'robot_name'
```

This inconsistency costs an extra tool call every time (discovered during autonomous harness run [#27474616760](https://github.com/cagataycali/robots-harness/actions/runs/27474616760)).

## Solution

Add `_resolve_single_robot(robot_name)` helper to `SimEngine` base class:
- `None` + exactly one robot -> that robot (inferred)
- `None` + zero robots -> `ValueError`
- `None` + many robots -> `ValueError` listing candidates (actionable recovery)

Applied to: `get_robot_state`, `run_policy`, `start_policy`.  
Already correct: `get_observation`, `send_action`.

## Changes

| File | Change |
|------|--------|
| `strands_robots/simulation/base.py` | Add `_resolve_single_robot()` helper + make `robot_name` optional in `run_policy`, `start_policy` |
| `strands_robots/simulation/mujoco/simulation.py` | Make `robot_name` optional in `get_robot_state`, `run_policy`, `start_policy` |
| `tests/simulation/mujoco/test_ax1_robot_name_optional.py` | 13 regression tests (FAIL pre-fix, PASS post-fix) |

## Test Results (NVIDIA Jetson AGX Thor, headless EGL)

```
13 passed in 6.97s
```

Covers:
- Single-robot: `get_robot_state()` / `run_policy()` / `start_policy()` (no arg) succeed
- Two-robot: raises `ValueError` with both robot names (actionable)
- Explicit `robot_name=` backwards-compatible
- `Robot('so100', mode='sim').get_robot_state()` just works
- `_resolve_single_robot` helper unit tests (empty, single, multi)

## Backwards Compatibility

Fully backwards-compatible -- existing code passing `robot_name=` explicitly is unaffected. The parameter default changes from required to `None`.

Refs: cagataycali/robots-harness#6, #404