### PR TITLE
feat(registry): add get_robot_info discovery alias (#405)

### DIFF
--- a/strands_robots/registry/__init__.py
+++ b/strands_robots/registry/__init__.py
@@ -41,6 +41,7 @@ from .robots import (
     format_robot_table,
     get_hardware_type,
     get_robot,
+    get_robot_info,
     has_hardware,
     has_sim,
     list_aliases,
@@ -58,6 +59,7 @@ __all__ = [
     # Robot registry
     "resolve_name",
     "get_robot",
+    "get_robot_info",
     "has_sim",
     "has_hardware",
     "get_hardware_type",

--- a/strands_robots/registry/robots.py
+++ b/strands_robots/registry/robots.py
@@ -74,6 +74,16 @@ def get_robot(name: str) -> dict[str, Any] | None:
     return result
 
 
+# Discoverability alias (#405 / AX-2): autonomous agents reach for
+# ``get_robot_info`` by analogy with ``get_robot_state`` and burn a call on
+# ``ImportError: cannot import name 'get_robot_info'`` before finding
+# ``get_robot``. Expose the intuitive name as a thin alias of ``get_robot`` so
+# both spellings resolve to the same definition lookup. (Distinct from
+# ``strands_robots.assets.get_robot_info``, which enriches the result with
+# resolved asset paths -- the registry alias is the pure definition lookup.)
+get_robot_info = get_robot
+
+
 def has_sim(name: str) -> bool:
     """Check if a robot has simulation assets (MJCF/URDF)."""
     info = get_robot(name)

--- a/tests/registry/test_public_api.py
+++ b/tests/registry/test_public_api.py
@@ -9,6 +9,7 @@ from strands_robots.registry.robots import (
     format_robot_table,
     get_hardware_type,
     get_robot,
+    get_robot_info,
     has_hardware,
     has_sim,
     list_aliases,
@@ -420,3 +421,34 @@ class TestRobotRegistry:
 
     def test_has_hardware_unknown_returns_false(self):
         assert has_hardware("nonexistent_xyz") is False
+
+    # #405 / AX-2: get_robot_info discovery alias.
+
+    def test_get_robot_info_is_get_robot_alias(self):
+        """registry.get_robot_info must be the same object as get_robot --
+        a thin discoverability alias, not a divergent reimplementation."""
+        assert get_robot_info is get_robot
+
+    def test_get_robot_info_importable_from_package(self):
+        """The alias must be reachable from the package root the way an
+        autonomous agent reaches for it (the import that used to ImportError)."""
+        from strands_robots.registry import get_robot_info as pkg_alias
+
+        assert pkg_alias is get_robot
+
+    def test_get_robot_info_returns_definition(self):
+        """The alias returns the same full definition as get_robot."""
+        assert get_robot_info("so100") == get_robot("so100")
+
+    def test_get_robot_info_via_alias_name(self):
+        """The alias resolves robot aliases identically to get_robot."""
+        assert get_robot_info("franka") == get_robot("panda")
+
+    def test_get_robot_info_unknown_returns_none(self):
+        assert get_robot_info("nonexistent_xyz") is None
+
+    def test_get_robot_info_in_public_all(self):
+        """The alias is exported from the registry package __all__."""
+        import strands_robots.registry as reg
+
+        assert "get_robot_info" in reg.__all__


### PR DESCRIPTION
## Summary

Closes #405 (AX-2 discovery surface).

Most of #405 already landed:
- **`SimEngine.describe()`** discovery contract → #407
- **`robot_name`-optional** defaulting across the `get_robot_state` family → #412

This PR adds the **one remaining piece**: the `registry.get_robot_info` alias.

## Problem → Fix → Why

| Issue | Fix | Why |
|---|---|---|
| Agents reach for `from strands_robots.registry import get_robot_info` by analogy with `get_robot_state` and hit `ImportError: cannot import name 'get_robot_info'`, burning a call on a dead-end traceback | Add `get_robot_info = get_robot` in `registry/robots.py`; export from `registry/__init__.py` (import + `__all__`) | Both the intuitive spelling and the canonical `get_robot` now resolve to the same definition lookup. Zero behavioural change to existing callers — it's a thin re-export of an already-public function. |

The alias is **distinct from** `strands_robots.assets.get_robot_info`, which
enriches the result with resolved asset paths. The registry alias is the pure
definition lookup (`is get_robot`).

## Test plan

Added six regression tests in `tests/registry/test_public_api.py`
(`TestRobotRegistry`):

- `test_get_robot_info_is_get_robot_alias` — alias identity (`is get_robot`)
- `test_get_robot_info_importable_from_package` — the exact import that used to `ImportError`
- `test_get_robot_info_returns_definition` — same definition as `get_robot`
- `test_get_robot_info_via_alias_name` — resolves robot aliases identically (`franka → panda`)
- `test_get_robot_info_unknown_returns_none` — unknown-returns-None contract
- `test_get_robot_info_in_public_all` — `__all__` membership

**Proof the test catches the regression**: reverting the two prod files makes
collection fail with `ImportError: cannot import name 'get_robot_info'`
(pre-fix) → all 6 pass post-fix.

Validation (all green):
- `ruff check` / `ruff format` — clean
- `mypy strands_robots/registry/robots.py strands_robots/registry/__init__.py` — `Success: no issues found`
- `pytest tests/registry/ tests/test_registry.py tests/test_registry_integrity.py` — **508 passed**, no regressions
