### PR TITLE
fix(sim): return structured error from _resolve_single_robot callers

### DIFF
--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -783,8 +783,9 @@ class SimEngine(ABC):
             },
             "note": (
                 "robot_name defaults to the sole robot when only one exists "
-                "for get_observation and send_action. For get_robot_state, "
-                "pass the robot name explicitly (from the 'robots' list)."
+                "for get_observation, send_action, get_robot_state, run_policy, "
+                "and start_policy. With multiple robots, pass robot_name "
+                "explicitly (from the 'robots' list above)."
             ),
         }
 

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1000,7 +1000,10 @@ class MuJoCoSimEngine(
         keep working, but new tool specs should document only robot_name."""
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
-        robot_name = self._resolve_single_robot(robot_name)
+        try:
+            robot_name = self._resolve_single_robot(robot_name)
+        except ValueError as e:
+            return {"status": "error", "content": [{"text": str(e)}]}
         if robot_name not in self._world.robots:
             return {"status": "error", "content": [{"text": f"Robot '{robot_name}' not found."}]}
 
@@ -1889,7 +1892,10 @@ class MuJoCoSimEngine(
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
-        robot_name = self._resolve_single_robot(robot_name)
+        try:
+            robot_name = self._resolve_single_robot(robot_name)
+        except ValueError as e:
+            return {"status": "error", "content": [{"text": str(e)}]}
         if robot_name not in self._world.robots:
             return {"status": "error", "content": [{"text": f"Robot '{robot_name}' not found."}]}
 
@@ -2023,7 +2029,10 @@ class MuJoCoSimEngine(
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
 
-        robot_name = self._resolve_single_robot(robot_name)
+        try:
+            robot_name = self._resolve_single_robot(robot_name)
+        except ValueError as e:
+            return {"status": "error", "content": [{"text": str(e)}]}
 
         try:
             return super().run_policy(

--- a/tests/simulation/mujoco/test_ax1_robot_name_optional.py
+++ b/tests/simulation/mujoco/test_ax1_robot_name_optional.py
@@ -63,10 +63,13 @@ class TestGetRobotStateOptional:
         result = single_robot_sim.get_robot_state(robot_name="alice")
         assert result["status"] == "success"
 
-    def test_two_robots_no_arg_raises(self, two_robot_sim):
-        """Two-robot sim -> get_robot_state() raises ValueError listing both names."""
-        with pytest.raises(ValueError, match=".*alice.*bob.*|.*bob.*alice.*"):
-            two_robot_sim.get_robot_state()
+    def test_two_robots_no_arg_returns_error(self, two_robot_sim):
+        """Two-robot sim -> get_robot_state() returns structured error listing both names."""
+        result = two_robot_sim.get_robot_state()
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert "alice" in text
+        assert "bob" in text
 
     def test_two_robots_explicit_arg_works(self, two_robot_sim):
         """Two-robot sim -> get_robot_state(robot_name='alice') works fine."""
@@ -84,10 +87,13 @@ class TestRunPolicyOptional:
         result = single_robot_sim.run_policy(policy_provider="mock", duration=0.1, control_frequency=10.0)
         assert result["status"] == "success", f"Expected success, got: {result}"
 
-    def test_two_robots_no_arg_raises(self, two_robot_sim):
-        """Two robots -> run_policy() raises ValueError listing both names."""
-        with pytest.raises(ValueError, match=".*alice.*bob.*|.*bob.*alice.*"):
-            two_robot_sim.run_policy(policy_provider="mock", duration=0.1)
+    def test_two_robots_no_arg_returns_error(self, two_robot_sim):
+        """Two robots -> run_policy() returns structured error listing both names."""
+        result = two_robot_sim.run_policy(policy_provider="mock", duration=0.1)
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert "alice" in text
+        assert "bob" in text
 
 
 class TestStartPolicyOptional:
@@ -102,10 +108,13 @@ class TestStartPolicyOptional:
 
         time.sleep(0.5)
 
-    def test_two_robots_no_arg_raises(self, two_robot_sim):
-        """Two robots -> start_policy() raises ValueError listing both names."""
-        with pytest.raises(ValueError, match=".*alice.*bob.*|.*bob.*alice.*"):
-            two_robot_sim.start_policy(policy_provider="mock", duration=0.1)
+    def test_two_robots_no_arg_returns_error(self, two_robot_sim):
+        """Two robots -> start_policy() returns structured error listing both names."""
+        result = two_robot_sim.start_policy(policy_provider="mock", duration=0.1)
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert "alice" in text
+        assert "bob" in text
 
 
 class TestRobotFactoryEntryPoint:

--- a/tests/simulation/mujoco/test_resolve_robot_structured_error.py
+++ b/tests/simulation/mujoco/test_resolve_robot_structured_error.py
@@ -1,0 +1,104 @@
+"""Regression test: _resolve_single_robot returns structured error, not ValueError.
+
+Before this fix, calling get_robot_state(), run_policy(), or start_policy()
+with robot_name=None in a multi-robot scene raised a raw ValueError instead
+of returning a structured {"status": "error", ...} dict. This broke the
+agent-tool contract where every method returns a dict — agents caught errors
+by inspecting result["status"], not by catching exceptions.
+
+The describe() note also incorrectly stated that get_robot_state required an
+explicit robot_name even in single-robot scenes. In reality it resolves
+automatically via _resolve_single_robot, just like get_observation.
+"""
+
+import pytest
+
+from strands_robots.simulation import create_simulation
+
+
+@pytest.fixture
+def multi_robot_sim():
+    sim = create_simulation()
+    sim.create_world()
+    sim.add_robot("arm1", data_config="so100")
+    sim.add_robot("arm2", data_config="so100", position=[0.5, 0, 0])
+    yield sim
+    sim.cleanup()
+
+
+@pytest.fixture
+def single_robot_sim():
+    sim = create_simulation()
+    sim.create_world()
+    sim.add_robot("arm1", data_config="so100")
+    yield sim
+    sim.cleanup()
+
+
+class TestGetRobotStateStructuredError:
+    """get_robot_state must return error dict, not raise ValueError."""
+
+    def test_multi_robot_none_returns_error_dict(self, multi_robot_sim):
+        result = multi_robot_sim.get_robot_state(robot_name=None)
+        assert result["status"] == "error"
+        assert "Multiple robots" in result["content"][0]["text"]
+        assert "arm1" in result["content"][0]["text"]
+        assert "arm2" in result["content"][0]["text"]
+
+    def test_single_robot_none_resolves(self, single_robot_sim):
+        result = single_robot_sim.get_robot_state(robot_name=None)
+        assert result["status"] == "success"
+
+
+class TestRunPolicyStructuredError:
+    """run_policy must return error dict, not raise ValueError."""
+
+    def test_multi_robot_none_returns_error_dict(self, multi_robot_sim):
+        result = multi_robot_sim.run_policy(robot_name=None)
+        assert result["status"] == "error"
+        assert "Multiple robots" in result["content"][0]["text"]
+
+    def test_single_robot_none_resolves(self, single_robot_sim):
+        result = single_robot_sim.run_policy(robot_name=None, policy_provider="mock", duration=0.02, fast_mode=True)
+        assert result["status"] == "success"
+
+
+class TestStartPolicyStructuredError:
+    """start_policy must return error dict, not raise ValueError."""
+
+    def test_multi_robot_none_returns_error_dict(self, multi_robot_sim):
+        result = multi_robot_sim.start_policy(robot_name=None)
+        assert result["status"] == "error"
+        assert "Multiple robots" in result["content"][0]["text"]
+
+    def test_single_robot_none_resolves(self, single_robot_sim):
+        result = single_robot_sim.start_policy(robot_name=None, policy_provider="mock", duration=0.02, fast_mode=True)
+        assert result["status"] == "success"
+        # Wait for background thread to finish
+        import time
+
+        time.sleep(0.5)
+
+
+class TestDescribeNoteAccuracy:
+    """describe() note must accurately reflect auto-resolution behavior."""
+
+    def test_note_mentions_get_robot_state(self, single_robot_sim):
+        desc = single_robot_sim.describe()
+        note = desc["note"]
+        assert "get_robot_state" in note
+        # The old note said "pass the robot name explicitly" for get_robot_state.
+        # That's wrong - it resolves automatically.
+        assert (
+            "pass the robot name explicitly" not in note or "get_robot_state" not in note.split("pass")[0]
+            if "pass" in note
+            else True
+        )
+
+    def test_note_mentions_multiple_methods(self, single_robot_sim):
+        desc = single_robot_sim.describe()
+        note = desc["note"]
+        # All methods that use _resolve_single_robot should be mentioned
+        assert "get_observation" in note
+        assert "get_robot_state" in note
+        assert "run_policy" in note


### PR DESCRIPTION
## Problem

`get_robot_state()`, `run_policy()`, and `start_policy()` call `_resolve_single_robot(robot_name)` which raises a raw `ValueError` when `robot_name` is `None` in a multi-robot scene. Every other method in the simulation API returns a structured `{"status": "error", "content": [...]}` dict for error conditions. The raw exception breaks the agent-tool contract: agents inspect `result["status"]` to detect errors, not catch exceptions.

Additionally, `SimEngine.describe()` told callers that `get_robot_state` requires an explicit `robot_name`, which is incorrect since PR #412 made it use `_resolve_single_robot` (auto-resolves for single-robot scenes).

## Changes

- **`simulation.py`**: Wrap `_resolve_single_robot` in `try/except ValueError` in `get_robot_state`, `run_policy` (MuJoCo override), and `start_policy`. The ValueError message (which already lists available robot names) becomes the structured error text.
- **`base.py`**: Update `describe()` note to accurately list all methods that auto-resolve `robot_name` (`get_observation`, `send_action`, `get_robot_state`, `run_policy`, `start_policy`).
- **`test_ax1_robot_name_optional.py`**: Update 3 multi-robot test assertions from `pytest.raises(ValueError)` to verify structured error dicts.
- **`test_resolve_robot_structured_error.py`**: New regression test (8 cases) covering all three methods in single and multi-robot scenarios, plus describe() note accuracy.

## Testing

```
MUJOCO_GL=egl python -m pytest tests/simulation/ --timeout=120 -q
# 803 passed, 15 skipped, 2 failed (pre-existing torchcodec aarch64 issue)
```