### PR TITLE
feat(cli): add `strands-robots doctor` diagnostic command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,9 @@ dev = [
     "pytest-timeout>=2.0.0,<3.0.0",
 ]
 
+[project.scripts]
+strands-robots = "strands_robots.__main__:main"
+
 [project.urls]
 Homepage = "https://github.com/strands-labs/robots"
 Documentation = "https://github.com/strands-labs/robots#readme"

--- a/strands_robots/__main__.py
+++ b/strands_robots/__main__.py
@@ -1,0 +1,29 @@
+"""Entry point for ``python -m strands_robots <command>``."""
+
+from __future__ import annotations
+
+import sys
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("Usage: python -m strands_robots <command>")
+        print("Commands: doctor")
+        sys.exit(1)
+
+    cmd = sys.argv[1]
+    # Remove the command from argv so sub-parsers see clean args
+    sys.argv = [sys.argv[0]] + sys.argv[2:]
+
+    if cmd == "doctor":
+        from strands_robots.doctor import main as doctor_main
+
+        doctor_main()
+    else:
+        print(f"Unknown command: {cmd}")
+        print("Available commands: doctor")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/strands_robots/doctor.py
+++ b/strands_robots/doctor.py
@@ -1,0 +1,288 @@
+"""``strands-robots doctor`` — diagnose common setup issues in one command.
+
+Checks: Python version, extras availability, GPU/CUDA, serial permissions,
+MuJoCo GL backend, HuggingFace auth, and a sim smoke test. Prints a colored
+pass/fail table so first-time users can fix problems before they hit cryptic
+errors at runtime.
+
+Usage:
+    python -m strands_robots doctor
+    strands-robots doctor        # (after pip install with [scripts] or console_scripts)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import platform
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# ANSI color helpers (degrade gracefully if NO_COLOR / dumb term)
+_NO_COLOR = os.environ.get("NO_COLOR") or os.environ.get("TERM") == "dumb"
+
+
+def _green(s: str) -> str:
+    return s if _NO_COLOR else f"\033[32m{s}\033[0m"
+
+
+def _red(s: str) -> str:
+    return s if _NO_COLOR else f"\033[31m{s}\033[0m"
+
+
+def _yellow(s: str) -> str:
+    return s if _NO_COLOR else f"\033[33m{s}\033[0m"
+
+
+def _bold(s: str) -> str:
+    return s if _NO_COLOR else f"\033[1m{s}\033[0m"
+
+
+def _pass(msg: str) -> str:
+    return _green(f"  PASS  {msg}")
+
+
+def _fail(msg: str, fix: str = "") -> str:
+    line = _red(f"  FAIL  {msg}")
+    if fix:
+        line += f"\n        {_yellow('Fix: ' + fix)}"
+    return line
+
+
+def _warn(msg: str, note: str = "") -> str:
+    line = _yellow(f"  WARN  {msg}")
+    if note:
+        line += f"\n        {note}"
+    return line
+
+
+def _skip(msg: str) -> str:
+    return f"  SKIP  {msg}"
+
+
+def check_python_version() -> str:
+    """Python >= 3.12 required."""
+    v = sys.version_info
+    if v >= (3, 12):
+        return _pass(f"Python {v.major}.{v.minor}.{v.micro}")
+    return _fail(
+        f"Python {v.major}.{v.minor}.{v.micro} (need >= 3.12)",
+        fix="Install Python 3.12+: https://docs.astral.sh/uv/guides/install-python/",
+    )
+
+
+def check_strands_robots_version() -> str:
+    """strands-robots importable and version."""
+    try:
+        import strands_robots
+
+        ver = getattr(strands_robots, "__version__", "unknown")
+        return _pass(f"strands-robots {ver}")
+    except ImportError as e:
+        return _fail(f"strands-robots not importable: {e}", fix='uv pip install "strands-robots[sim-mujoco]"')
+
+
+def check_mujoco() -> str:
+    """MuJoCo importable (sim-mujoco extra)."""
+    try:
+        import mujoco
+
+        return _pass(f"mujoco {mujoco.__version__}")
+    except ImportError:
+        return _fail("mujoco not installed", fix='uv pip install "strands-robots[sim-mujoco]"')
+
+
+def check_mujoco_gl() -> str:
+    """MUJOCO_GL set for headless rendering."""
+    gl = os.environ.get("MUJOCO_GL", "")
+    if gl in ("egl", "osmesa"):
+        return _pass(f"MUJOCO_GL={gl}")
+    if gl == "glfw":
+        return _warn("MUJOCO_GL=glfw (needs display)", note="Set MUJOCO_GL=egl or osmesa for headless")
+    # Not set — check if a display exists
+    if os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"):
+        return _pass("MUJOCO_GL unset (display detected, glfw will work)")
+    return _fail(
+        "MUJOCO_GL not set and no display detected",
+        fix="export MUJOCO_GL=egl  # or osmesa; add to ~/.bashrc",
+    )
+
+
+def check_lerobot() -> str:
+    """LeRobot importable (lerobot extra)."""
+    try:
+        import lerobot
+
+        ver = getattr(lerobot, "__version__", "?")
+        return _pass(f"lerobot {ver}")
+    except ImportError:
+        return _warn(
+            "lerobot not installed (needed for real hardware + dataset recording)",
+            note='uv pip install "strands-robots[lerobot]"',
+        )
+
+
+def check_cuda() -> str:
+    """CUDA / GPU availability via torch."""
+    try:
+        import torch
+
+        if torch.cuda.is_available():
+            name = torch.cuda.get_device_name(0)
+            return _pass(f"CUDA available: {name} (torch {torch.__version__})")
+        # torch installed but no CUDA
+        cuda_ver = getattr(torch.version, "cuda", None)
+        if cuda_ver is None:
+            return _warn(
+                f"torch {torch.__version__} is CPU-only build",
+                note="Policy inference will run on CPU. For GPU: install torch with CUDA "
+                "(e.g. UV_TORCH_BACKEND=auto uv pip install torch)",
+            )
+        return _warn(
+            f"torch {torch.__version__} has CUDA {cuda_ver} but torch.cuda.is_available()=False",
+            note="Check CUDA drivers (nvidia-smi) and CUDA_VISIBLE_DEVICES",
+        )
+    except ImportError:
+        return _warn("torch not installed (needed for policy inference)", note="uv pip install torch")
+
+
+def check_serial_permissions() -> str:
+    """Serial port permissions for real hardware."""
+    if platform.system() != "Linux":
+        return _skip("serial permissions (non-Linux)")
+
+    # Check if user is in dialout group
+    import grp
+
+    username = os.environ.get("USER", "")
+    try:
+        dialout_members = grp.getgrnam("dialout").gr_mem
+    except KeyError:
+        return _skip("serial permissions (no dialout group)")
+
+    in_dialout = username in dialout_members
+    # Also check effective groups
+    try:
+        dialout_gid = grp.getgrnam("dialout").gr_gid
+        in_effective = dialout_gid in os.getgroups()
+    except (KeyError, OSError):
+        in_effective = False
+
+    if in_dialout or in_effective:
+        # Check if any serial devices exist
+        devs = list(Path("/dev").glob("ttyACM*")) + list(Path("/dev").glob("ttyUSB*"))
+        if devs:
+            # Check read/write permission on first device
+            dev = devs[0]
+            if os.access(dev, os.R_OK | os.W_OK):
+                return _pass(f"serial: user in dialout, {dev} accessible")
+            return _fail(
+                f"serial: user in dialout but {dev} not accessible",
+                fix=f"sudo chmod 666 {dev}  # or add udev rule",
+            )
+        return _pass("serial: user in dialout (no devices connected)")
+    return _fail(
+        f"serial: user '{username}' not in dialout group",
+        fix="sudo usermod -aG dialout $USER && newgrp dialout  # then re-login",
+    )
+
+
+def check_hf_auth() -> str:
+    """HuggingFace Hub authentication (needed for dataset push + gated models)."""
+    token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
+    if token:
+        return _pass("HF_TOKEN set")
+    # Check huggingface-cli login token
+    hf_token_path = Path.home() / ".cache" / "huggingface" / "token"
+    if hf_token_path.exists() and hf_token_path.read_text().strip():
+        return _pass("HuggingFace token found (~/.cache/huggingface/token)")
+    return _warn(
+        "No HuggingFace token found",
+        note="Needed for dataset push + gated models. Run: huggingface-cli login  # or export HF_TOKEN=hf_...",
+    )
+
+
+def check_sim_smoke() -> str:
+    """Run Robot('so100') -> step -> get_observation as a smoke test."""
+    try:
+        # Suppress mesh warnings during doctor
+        os.environ.setdefault("STRANDS_MESH", "false")
+        from strands_robots import Robot
+
+        sim = Robot("so100")
+        sim.step()
+        obs = sim.get_observation("so100")
+        if obs and len(obs) > 0:
+            return _pass(f"sim smoke test: Robot('so100') works ({len(obs)} obs keys)")
+        return _fail("sim smoke test: observation empty")
+    except Exception as e:
+        return _fail(f"sim smoke test failed: {e}", fix="Check MUJOCO_GL and mujoco install")
+
+
+def check_strands_agents() -> str:
+    """strands-agents importable (needed for Agent(tools=[robot]))."""
+    try:
+        import strands
+
+        ver = getattr(strands, "__version__", "?")
+        return _pass(f"strands-agents {ver}")
+    except ImportError:
+        return _fail("strands-agents not importable", fix='uv pip install "strands-agents>=1.0"')
+
+
+def check_mesh() -> str:
+    """Zenoh mesh availability."""
+    try:
+        import zenoh  # noqa: F401
+
+        return _pass("zenoh available (mesh networking)")
+    except ImportError:
+        return _warn("zenoh not installed (mesh disabled)", note='uv pip install "strands-robots[mesh]"')
+
+
+def run_doctor() -> int:
+    """Run all checks. Returns 0 if all pass, 1 if any fail."""
+    print(_bold("\nstrands-robots doctor"))
+    print(_bold("=" * 50))
+    print()
+
+    checks = [
+        ("Python", check_python_version),
+        ("Package", check_strands_robots_version),
+        ("Strands SDK", check_strands_agents),
+        ("MuJoCo", check_mujoco),
+        ("MuJoCo GL", check_mujoco_gl),
+        ("LeRobot", check_lerobot),
+        ("CUDA/GPU", check_cuda),
+        ("Serial", check_serial_permissions),
+        ("HF Auth", check_hf_auth),
+        ("Mesh", check_mesh),
+        ("Sim Test", check_sim_smoke),
+    ]
+
+    has_fail = False
+    for name, check_fn in checks:
+        try:
+            result = check_fn()
+        except Exception as e:
+            result = _fail(f"{name}: unexpected error: {e}")
+        if "FAIL" in result and "\033[31m" in result:
+            has_fail = True
+        print(result)
+
+    print()
+    if has_fail:
+        print(_red("Some checks failed. Fix the issues above and re-run: python -m strands_robots doctor"))
+        return 1
+    print(_green("All checks passed. Ready to use strands-robots."))
+    return 0
+
+
+def main() -> None:
+    sys.exit(run_doctor())
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,146 @@
+"""Tests for the ``strands-robots doctor`` diagnostic command."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+class TestDoctorChecks:
+    """Unit tests for individual doctor check functions."""
+
+    def test_check_python_version_passes(self) -> None:
+        from strands_robots.doctor import check_python_version
+
+        result = check_python_version()
+        # We are running on Python 3.12+, so it should pass
+        assert "PASS" in result
+
+    def test_check_strands_robots_version_passes(self) -> None:
+        from strands_robots.doctor import check_strands_robots_version
+
+        result = check_strands_robots_version()
+        assert "PASS" in result
+
+    def test_check_mujoco_passes(self) -> None:
+        from strands_robots.doctor import check_mujoco
+
+        result = check_mujoco()
+        assert "PASS" in result
+
+    def test_check_mujoco_gl_with_egl(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from strands_robots.doctor import check_mujoco_gl
+
+        monkeypatch.setenv("MUJOCO_GL", "egl")
+        result = check_mujoco_gl()
+        assert "PASS" in result
+
+    def test_check_mujoco_gl_no_display(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from strands_robots.doctor import check_mujoco_gl
+
+        monkeypatch.delenv("MUJOCO_GL", raising=False)
+        monkeypatch.delenv("DISPLAY", raising=False)
+        monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+        result = check_mujoco_gl()
+        assert "FAIL" in result
+
+    def test_check_cuda_returns_string(self) -> None:
+        from strands_robots.doctor import check_cuda
+
+        result = check_cuda()
+        # Should be one of PASS, WARN, or FAIL — never crash
+        assert any(x in result for x in ("PASS", "WARN", "FAIL"))
+
+    def test_check_hf_auth_with_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from strands_robots.doctor import check_hf_auth
+
+        monkeypatch.setenv("HF_TOKEN", "hf_test_token")
+        result = check_hf_auth()
+        assert "PASS" in result
+
+    def test_check_hf_auth_without_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from strands_robots.doctor import check_hf_auth
+
+        monkeypatch.delenv("HF_TOKEN", raising=False)
+        monkeypatch.delenv("HUGGING_FACE_HUB_TOKEN", raising=False)
+        # This might pass if ~/.cache/huggingface/token exists, or warn otherwise
+        result = check_hf_auth()
+        assert any(x in result for x in ("PASS", "WARN"))
+
+    def test_check_strands_agents(self) -> None:
+        from strands_robots.doctor import check_strands_agents
+
+        result = check_strands_agents()
+        assert "PASS" in result
+
+    def test_check_mesh(self) -> None:
+        from strands_robots.doctor import check_mesh
+
+        result = check_mesh()
+        # Either passes (zenoh installed) or warns (not installed)
+        assert any(x in result for x in ("PASS", "WARN"))
+
+    def test_check_serial_permissions_linux(self) -> None:
+        from strands_robots.doctor import check_serial_permissions
+
+        result = check_serial_permissions()
+        # Should not crash regardless of platform
+        assert any(x in result for x in ("PASS", "WARN", "FAIL", "SKIP"))
+
+
+class TestDoctorCLI:
+    """Integration tests for the doctor CLI entry point."""
+
+    def test_module_invocation(self) -> None:
+        """``python -m strands_robots doctor`` runs without crashing."""
+        env = os.environ.copy()
+        env["MUJOCO_GL"] = "egl"
+        env["STRANDS_MESH"] = "false"
+        env["NO_COLOR"] = "1"
+        result = subprocess.run(
+            [sys.executable, "-m", "strands_robots", "doctor"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            env=env,
+        )
+        # Should complete (exit 0 or 1 depending on env)
+        assert result.returncode in (0, 1)
+        assert "strands-robots doctor" in result.stdout
+
+    def test_unknown_command(self) -> None:
+        result = subprocess.run(
+            [sys.executable, "-m", "strands_robots", "nonexistent"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 1
+        assert "Unknown command" in result.stdout
+
+    def test_no_command(self) -> None:
+        result = subprocess.run(
+            [sys.executable, "-m", "strands_robots"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 1
+        assert "Usage" in result.stdout
+
+
+class TestRunDoctor:
+    """Integration test for the full run_doctor() pipeline."""
+
+    def test_run_doctor_returns_int(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from strands_robots.doctor import run_doctor
+
+        monkeypatch.setenv("MUJOCO_GL", "egl")
+        monkeypatch.setenv("STRANDS_MESH", "false")
+        monkeypatch.setenv("NO_COLOR", "1")
+        exit_code = run_doctor()
+        assert isinstance(exit_code, int)
+        assert exit_code in (0, 1)


### PR DESCRIPTION
## Problem

New users installing `strands-robots` on fresh hardware (Jetson, headless Linux, new dev machine) hit multiple friction points before their first `Robot.connect()` succeeds: missing MUJOCO_GL, wrong torch build (CPU-only), serial permissions, absent HF token for dataset push, etc. Each failure produces a different cryptic error that requires searching docs or troubleshooting.md.

## Change

Adds a `strands-robots doctor` command that runs 11 diagnostic checks in sequence and prints a colored pass/fail/warn table with actionable fix instructions:

1. Python version (>= 3.12)
2. `strands-robots` importable + version
3. `strands-agents` importable
4. MuJoCo installed
5. MUJOCO_GL configured for headless
6. LeRobot available
7. CUDA/GPU detection (warns on CPU-only torch builds)
8. Serial port permissions (dialout group, device access)
9. HuggingFace auth (HF_TOKEN or cached login)
10. Zenoh mesh availability
11. Sim smoke test (`Robot('so100')` -> step -> observe)

Invocable as:
```bash
python -m strands_robots doctor
strands-robots doctor
```

Example output on a Jetson with CPU-only torch:
```
strands-robots doctor
==================================================

  PASS  Python 3.13.12
  PASS  strands-robots 0.x.x
  PASS  strands-agents 1.x.x
  PASS  mujoco 3.9.0
  PASS  MUJOCO_GL=egl
  PASS  lerobot 0.5.2
  WARN  torch 2.10.0+cpu is CPU-only build
        Policy inference will run on CPU. For GPU: install torch with CUDA
  PASS  serial: user in dialout, /dev/ttyACM0 accessible
  PASS  HF_TOKEN set
  PASS  zenoh available (mesh networking)
  PASS  sim smoke test: Robot('so100') works (7 obs keys)

All checks passed. Ready to use strands-robots.
```

## Files

- `strands_robots/doctor.py` — all check functions + colored output
- `strands_robots/__main__.py` — `python -m strands_robots <cmd>` dispatcher
- `pyproject.toml` — `[project.scripts]` console entry point
- `tests/test_doctor.py` — 15 unit + integration tests

## Testing

- All 15 new tests pass
- Full existing test suite unaffected (3659 passed)
- Lint clean (ruff check + format + mypy)
- Manually verified on NVIDIA Jetson (aarch64) headless