### PR TITLE
example(molmoact2): use only strands_robots imports, add --mode sim/real

### DIFF
--- a/examples/molmoact2_so101_pickplace.py
+++ b/examples/molmoact2_so101_pickplace.py
@@ -1,25 +1,24 @@
 #!/usr/bin/env python3
-"""SO101 pick-and-place driven by MolmoAct2 — strands_robots simplified API.
+"""SO101 pick-and-place driven by MolmoAct2 — strands_robots API only.
 
-Demonstrates how strands_robots.policies.create_policy() eliminates manual
-configuration that the raw lerobot path requires. The embodiment="so_real"
-parameter handles:
-  - Motor key mapping (shoulder_pan.pos, shoulder_lift.pos, ...)
-  - Camera observation rename (front -> observation.images.image)
-  - State/action dimensionality reconciliation (dim_policy="pad")
-  - MolmoAct2 transformers-native checkpoint detection
-  - Normalization tag auto-discovery from norm_stats.json
-  - Processor bridge construction (pre/post processing pipelines)
+Demonstrates a complete VLA-driven manipulation loop using ONLY
+``strands_robots`` imports. The Robot() factory handles lerobot robot
+construction internally; create_policy() handles model loading, embodiment
+mapping, and processor pipeline construction.
 
-Hardware requirements:
+This example works identically with ``--mode sim`` and ``--mode real`` —
+the same policy, the same observation loop, the same action dispatch. That
+is the core value proposition of the strands_robots abstraction.
+
+Hardware requirements (mode=real):
   - SO101 follower arm on a serial port
   - Front camera (OpenCV-compatible, index 0)
-  - CUDA GPU for inference (or cpu for testing)
+  - CUDA GPU for inference (or cpu with --device cpu)
 
 Usage:
   export STRANDS_TRUST_REMOTE_CODE=1
   python molmoact2_so101_pickplace.py --task "Pick up the pen"
-  python molmoact2_so101_pickplace.py --dry-run  # no motor commands
+  python molmoact2_so101_pickplace.py --mode sim --device cpu --dry-run
 """
 
 from __future__ import annotations
@@ -36,56 +35,80 @@ REPO = "allenai/MolmoAct2-SO100_101"
 
 
 def main():
-    ap = argparse.ArgumentParser()
-    ap.add_argument("--port", default="/dev/ttyACM1")
-    ap.add_argument("--cal", default="orange_follower")
-    ap.add_argument("--camera", type=int, default=0)
+    ap = argparse.ArgumentParser(description="SO101 MolmoAct2 pick-and-place")
+    ap.add_argument("--mode", choices=["real", "sim"], default="real",
+                    help="Robot mode: 'real' for hardware, 'sim' for MuJoCo (default: real)")
+    ap.add_argument("--port", default="/dev/ttyACM1",
+                    help="Serial port for real hardware (ignored in sim mode)")
+    ap.add_argument("--id", default=None,
+                    help="Calibration ID / namespace (default: auto)")
+    ap.add_argument("--camera", type=int, default=0,
+                    help="Camera index for observation (default: 0)")
     ap.add_argument("--task", default="Pick up the pen and place it on the paper")
     ap.add_argument("--steps", type=int, default=30)
     ap.add_argument("--hz", type=float, default=5.0)
-    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--device", default="cuda", help="Inference device (default: cuda)")
+    ap.add_argument("--dry-run", action="store_true", help="Run inference without sending actions")
     args = ap.parse_args()
 
-    from lerobot.cameras.opencv import OpenCVCameraConfig
-    from lerobot.robots.so_follower import SO101Follower, SO101FollowerConfig
+    from strands_robots import Robot, create_policy
 
-    from strands_robots.policies import create_policy
+    # Construct the robot via the unified factory.
+    # In real mode: wraps lerobot SO101Follower with camera config.
+    # In sim mode: creates a MuJoCo simulation with the SO101 model.
+    if args.mode == "real":
+        robot = Robot(
+            "so101",
+            mode="real",
+            port=args.port,
+            **({"id": args.id} if args.id else {}),
+            cameras={"front": {
+                "type": "opencv",
+                "index_or_path": args.camera,
+                "width": 640,
+                "height": 480,
+                "fps": 30,
+            }},
+        )
+    else:
+        robot = Robot("so101", mode="sim")
 
-    # Camera config: 'front' matches the so_real embodiment's obs_rename
-    cam_cfg = {"front": OpenCVCameraConfig(index_or_path=args.camera, width=640, height=480, fps=30)}
-    robot = SO101Follower(SO101FollowerConfig(port=args.port, id=args.cal, cameras=cam_cfg))
-    log.info("Connecting SO101 @ %s (cal=%s)...", args.port, args.cal)
-    robot.connect(calibrate=False)
-    log.info("Connected. obs keys: %s", list(robot.get_observation().keys()))
+    # Connect the hardware robot (sim is ready immediately).
+    if args.mode == "real":
+        log.info("Connecting SO101 @ %s ...", args.port)
+        robot.robot.connect(calibrate=False)
+        log.info("Connected. obs keys: %s", list(robot.robot.get_observation().keys()))
 
     # ONE call creates and configures the entire policy:
     #   - Detects MolmoAct2 transformers-native checkpoint
     #   - Loads 'so_real' embodiment (motor keys + camera renames)
     #   - Builds MolmoAct2Config, norm_tag, processor bridge
     #   - robot_state_keys auto-set from embodiment.action_keys
-    policy = create_policy(REPO, embodiment="so_real", device="cuda")
+    policy = create_policy(REPO, embodiment="so_real", device=args.device)
     policy.reset()
 
     async def run():
         period = 1.0 / args.hz
         for step in range(args.steps):
-            obs = robot.get_observation()
+            obs = robot.robot.get_observation()
             t = time.time()
             actions = await policy.get_actions(obs, args.task)
             dt = time.time() - t
             a = actions[0]
-            log.info("step %d infer=%.2fs action=%s", step, dt, {k: round(v, 1) for k, v in a.items()})
+            log.info("step %d infer=%.2fs action=%s", step, dt,
+                     {k: round(v, 1) for k, v in a.items()})
             if not args.dry_run:
-                robot.send_action(a)
+                robot.robot.send_action(a)
             await asyncio.sleep(max(0, period - dt))
 
     try:
         asyncio.run(run())
     finally:
-        try:
-            robot.disconnect()
-        except Exception as e:
-            log.warning("disconnect: %s", str(e)[:80])
+        if args.mode == "real":
+            try:
+                robot.robot.disconnect()
+            except Exception as e:
+                log.warning("disconnect: %s", str(e)[:80])
         log.info("Done.")
 
 

--- a/tests/test_examples_no_raw_lerobot.py
+++ b/tests/test_examples_no_raw_lerobot.py
@@ -1,0 +1,59 @@
+"""Verify that top-level examples use only strands_robots imports for robot/policy.
+
+The examples/ directory is the first thing new users see. If an example
+imports from lerobot directly (for robot construction, cameras, or policy
+creation), it undermines the abstraction and teaches users to bypass
+strands_robots.
+
+The examples/lerobot/ subdirectory is explicitly excluded — it exists to
+show hub-to-hardware integration and is allowed to use lerobot directly.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+EXAMPLES_DIR = Path(__file__).resolve().parent.parent / "examples"
+
+# Subdirectories that are allowed to use raw lerobot imports
+ALLOWED_SUBDIRS = {"lerobot"}
+
+
+def _top_level_example_files() -> list[Path]:
+    """Collect .py files in examples/ excluding allowed subdirs."""
+    if not EXAMPLES_DIR.exists():
+        return []
+    files = []
+    for p in EXAMPLES_DIR.rglob("*.py"):
+        # Skip files in allowed subdirectories
+        relative = p.relative_to(EXAMPLES_DIR)
+        if relative.parts and relative.parts[0] in ALLOWED_SUBDIRS:
+            continue
+        files.append(p)
+    return files
+
+
+_LEROBOT_IMPORT_RE = re.compile(r"^\s*(from\s+lerobot\b|import\s+lerobot\b)", re.MULTILINE)
+
+
+@pytest.mark.parametrize(
+    "example_file",
+    _top_level_example_files(),
+    ids=lambda p: str(p.relative_to(EXAMPLES_DIR)),
+)
+def test_no_raw_lerobot_imports(example_file: Path):
+    """Top-level examples must not import from lerobot directly.
+
+    Use strands_robots.Robot() for robot construction and
+    strands_robots.create_policy() for policy loading instead.
+    """
+    content = example_file.read_text(encoding="utf-8")
+    matches = _LEROBOT_IMPORT_RE.findall(content)
+    assert not matches, (
+        f"{example_file.name} imports lerobot directly: {matches}. "
+        f"Top-level examples should use only strands_robots imports. "
+        f"Move lerobot-specific examples to examples/lerobot/ if needed."
+    )


### PR DESCRIPTION
## Problem

The canonical `examples/molmoact2_so101_pickplace.py` imported lerobot directly for robot construction (`SO101Follower`, `OpenCVCameraConfig`). This:

1. Teaches users to bypass the `strands_robots` abstraction
2. Makes it impossible to switch between sim and real with a single flag
3. Sends the wrong message about the SDK's value proposition

## Changes

- Replace raw lerobot imports with `Robot('so101', mode='real/sim')` factory
- Add `--mode` flag so the same script works in simulation or on hardware
- Add `--device` flag for CPU testing without GPU
- Add CI regression test (`test_examples_no_raw_lerobot.py`) that fails if any top-level example imports from `lerobot` directly

The `examples/lerobot/` subdirectory is explicitly allowed to use raw lerobot imports for advanced hub-to-hardware demos.

## Before

```python
from lerobot.cameras.opencv import OpenCVCameraConfig
from lerobot.robots.so_follower import SO101Follower, SO101FollowerConfig
```

## After

```python
from strands_robots import Robot, create_policy

robot = Robot("so101", mode="real", port=args.port, cameras={...})
# or
robot = Robot("so101", mode="sim")
```

## Test

All 3640 tests pass, lint clean. The new `test_examples_no_raw_lerobot.py` parametrizes over every top-level example file and asserts no `from lerobot` / `import lerobot` lines exist.