### PR TITLE
docs: document MolmoAct2 lerobot-from-source requirement + Jetson install path

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -4,7 +4,7 @@ description: Install strands-robots with uv — extras matrix, platform notes, h
 
 # Installation
 
-Requires **Python ≥ 3.12**. Examples use [`uv`](https://docs.astral.sh/uv/) (`curl -LsSf https://astral.sh/uv/install.sh | sh`); plain `pip install` works too.
+Requires **Python >= 3.12**. Examples use [`uv`](https://docs.astral.sh/uv/) (`curl -LsSf https://astral.sh/uv/install.sh | sh`); plain `pip install` works too.
 
 ## Extras matrix
 
@@ -41,11 +41,37 @@ sudo usermod -aG dialout $USER   # USB serial access; re-login after
 
 **Windows:** WSL2 + Ubuntu 22.04 (native Windows works for sim, not actively tested).
 
-**Jetson (JetPack):**
+**Jetson / aarch64 (JetPack):**
 ```bash
 uv pip install "numpy<2" "pandas==2.1.4"
 uv pip install "strands-robots[sim-mujoco,lerobot]"
 ```
+
+The `[lerobot]` extra includes `torchcodec` on aarch64 (required because
+torchvision 0.26 removed `VideoReader` and lerobot's own torchcodec marker
+excludes aarch64). If torch CUDA is needed on Jetson, ensure you install from
+NVIDIA's index or set `UV_TORCH_BACKEND=auto`:
+
+```bash
+export UV_TORCH_BACKEND=auto   # resolves +cu130 wheels for Thor/Jetson
+uv pip install "strands-robots[sim-mujoco,lerobot]"
+```
+
+### MolmoAct2 on Jetson (lerobot from source)
+
+MolmoAct2 checkpoints (e.g. `allenai/MolmoAct2-SO100_101`) require lerobot
+**from source** (git main) because `MolmoAct2Policy` was added after lerobot
+0.5.1 (the latest PyPI release). See
+[LeRobot Local: MolmoAct2](../policies/lerobot-local.md#molmoact2) for full
+instructions. Quick path:
+
+```bash
+# Install lerobot from source (skips pyav if it fails on aarch64):
+uv pip install "lerobot[feetech] @ git+https://github.com/huggingface/lerobot.git" --no-build-isolation
+uv pip install torchcodec>=0.7   # video decode backend for aarch64
+```
+
+This will be unnecessary once lerobot >= 0.5.2 is published to PyPI.
 
 ## Headless rendering
 

--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -51,9 +51,30 @@ LerobotLocalPolicy(
 | SmolVLA | HuggingFace small VLA |
 | Diffusion Policy | flow-matching |
 | VQ-BeT | discrete action tokenisation |
-| MolmoAct2 | transformers-native SO100/SO101; use `norm_tag` + `image_keys` |
+| MolmoAct2 | transformers-native SO100/SO101; **requires lerobot from source** (see below) |
 
 ## MolmoAct2
+
+> **Important:** MolmoAct2 requires lerobot installed **from source** (git main).
+> The `MolmoAct2Policy` class was added after lerobot 0.5.1 (the latest PyPI
+> release as of June 2025). A plain `pip install strands-robots[lerobot]` resolves
+> lerobot 0.5.1, which does NOT include MolmoAct2.
+
+Install lerobot from source before using MolmoAct2:
+
+```bash
+# Standard (x86_64, macOS):
+uv pip install "lerobot[feetech] @ git+https://github.com/huggingface/lerobot.git"
+
+# Jetson / aarch64 (pyav wheel may fail to build — skip it, lerobot uses torchcodec):
+uv pip install "lerobot[feetech] @ git+https://github.com/huggingface/lerobot.git" --no-build-isolation
+# If pyav still blocks the install, exclude it and add torchcodec manually:
+uv pip install torchcodec>=0.7
+uv pip install "lerobot[feetech] @ git+https://github.com/huggingface/lerobot.git" --no-deps
+uv pip install -r <(pip show lerobot 2>/dev/null | grep Requires | sed 's/Requires: //;s/, /\n/g' | grep -v "^av$")
+```
+
+Once lerobot from source is installed, MolmoAct2 works:
 
 ```python
 policy = create_policy(
@@ -66,6 +87,10 @@ policy = create_policy(
 )
 # see examples/molmoact2_so101_pickplace.py
 ```
+
+This requirement will go away once HuggingFace publishes lerobot >= 0.5.2 to PyPI
+(which will include MolmoAct2 natively). At that point the standard
+`pip install strands-robots[lerobot]` path will work.
 
 ## RTC
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -11,6 +11,8 @@ description: Error → fix table for the most common gotchas across install, sim
 | `ModuleNotFoundError: mujoco` | Missing `[sim-mujoco]` | `uv pip install "strands-robots[sim-mujoco]"` |
 | `ModuleNotFoundError: lerobot` | Missing `[lerobot]` | `uv pip install "strands-robots[lerobot]"` |
 | `ImportError: cannot import name '...' from 'lerobot'` | LeRobot version skew | `uv pip install "lerobot>=0.5.0,<0.6"` |
+| `ImportError: cannot import name 'MolmoAct2Policy'` | MolmoAct2 not in PyPI lerobot (added post-0.5.1) | Install from source: `uv pip install "lerobot[feetech] @ git+https://github.com/huggingface/lerobot.git"` |
+| pyav build fails on Jetson/aarch64 | No prebuilt wheel for sm_110 | Use `--no-build-isolation` or install `torchcodec>=0.7` and skip pyav. See [installation](getting-started/installation.md#molmoact2-on-jetson-lerobot-from-source) |
 | numpy ABI mismatch on Jetson | System pandas vs pip numpy | `uv pip install "numpy<2" "pandas==2.1.4"` then reinstall |
 | `uv pip install -e .` errors | Wrong cwd | `cd` to repo root first |
 

--- a/strands_robots/policies/lerobot_local/molmoact2.py
+++ b/strands_robots/policies/lerobot_local/molmoact2.py
@@ -226,7 +226,16 @@ def build_policy(
         Tuple ``(policy, preprocessor, postprocessor, config)``.
     """
     import torch
-    from lerobot.configs import FeatureType, PolicyFeature
+
+    try:
+        from lerobot.configs import FeatureType, PolicyFeature
+    except ImportError as exc:
+        raise ImportError(
+            "MolmoAct2 requires lerobot >= 0.5.2 (from source). The PyPI release "
+            "(0.5.1) does not include MolmoAct2Policy. Install from source:\n"
+            "  uv pip install 'lerobot[feetech] @ git+https://github.com/huggingface/lerobot.git'\n"
+            "On Jetson/aarch64, add --no-build-isolation if pyav fails to build."
+        ) from exc
 
     # Use lerobot's PUBLIC factory API rather than importing the molmoact2
     # config/processor classes directly:
@@ -241,11 +250,19 @@ def build_policy(
     # from_pretrained's _load_as_safetensor path fails -- direct construction is
     # exactly what lerobot's own make_policy() does in its from-scratch branch
     # (MolmoAct2Policy.__init__ loads the HF weights via checkpoint_path).
-    from lerobot.policies.factory import (
-        get_policy_class,
-        make_policy_config,
-        make_pre_post_processors,
-    )
+    try:
+        from lerobot.policies.factory import (
+            get_policy_class,
+            make_policy_config,
+            make_pre_post_processors,
+        )
+    except ImportError as exc:
+        raise ImportError(
+            "MolmoAct2 requires lerobot >= 0.5.2 (from source). The PyPI release "
+            "(0.5.1) does not include MolmoAct2Policy. Install from source:\n"
+            "  uv pip install 'lerobot[feetech] @ git+https://github.com/huggingface/lerobot.git'\n"
+            "On Jetson/aarch64, add --no-build-isolation if pyav fails to build."
+        ) from exc
 
     resolved_device = device or ("cuda" if torch.cuda.is_available() else "cpu")
     resolved_tag = auto_norm_tag(pretrained_name_or_path, norm_tag)


### PR DESCRIPTION
## Problem

`MolmoAct2Policy` was added to lerobot after the 0.5.1 PyPI release (in PR huggingface/lerobot#3604). The `[lerobot]` extra resolves `lerobot>=0.5.0,<0.6.0` which installs 0.5.1 from PyPI — this version does NOT include MolmoAct2. Users who follow the docs (`uv pip install strands-robots[lerobot]`) then try the MolmoAct2 example hit an opaque `ImportError` with no guidance on how to fix it.

On Jetson/aarch64 the situation is compounded by `pyav` wheel build failures, making the from-source install path non-obvious.

## Changes

**docs/policies/lerobot-local.md**: Add a prominent callout in the MolmoAct2 section explaining the from-source requirement, with install commands for x86_64/macOS and Jetson/aarch64 (including the pyav workaround).

**docs/getting-started/installation.md**: Add a "MolmoAct2 on Jetson" subsection under the Jetson platform notes with the quick-path install commands.

**docs/troubleshooting.md**: Add two rows to the Install table — `MolmoAct2Policy` ImportError and pyav build failure on aarch64.

**strands_robots/policies/lerobot_local/molmoact2.py**: Wrap the lerobot factory imports in `build_policy()` with `try/except ImportError` that raises a clear, actionable error message pointing users to the from-source install command.

## Notes

This will become unnecessary once HuggingFace publishes lerobot >= 0.5.2 to PyPI (which will include MolmoAct2 natively). At that point these docs can be simplified to just the standard extra install path.