### PR TITLE
fix(sim): correct blown-out white ground in MuJoCo renders

### DIFF
--- a/strands_robots/simulation/mujoco/spec_builder.py
+++ b/strands_robots/simulation/mujoco/spec_builder.py
@@ -219,16 +219,21 @@ class SpecBuilder:
         spec.visual.headlight.specular = [0.0, 0.0, 0.0]
 
         # Ground texture + material - MuJoCo's built-in checkerboard.
+        # Dark blue-grey checker matching the Menagerie SO101 scene.xml
+        # groundplane (rgb1=0.2 0.3 0.4 / rgb2=0.1 0.2 0.3). The previous
+        # near-white grid (0.9/0.7) saturated to pure white under the scene
+        # lights below (measured 250/255 in rendered frames), washing out the
+        # floor and killing shadow contrast.
         grid_tex = spec.add_texture(
             name="grid_tex",
             type=mujoco.mjtTexture.mjTEXTURE_2D,
             builtin=mujoco.mjtBuiltin.mjBUILTIN_CHECKER,
             width=512,
             height=512,
-            rgb1=[0.9, 0.9, 0.9],
-            rgb2=[0.7, 0.7, 0.7],
+            rgb1=[0.2, 0.3, 0.4],
+            rgb2=[0.1, 0.2, 0.3],
         )
-        grid_mat = spec.add_material(name="grid_mat", texrepeat=[8, 8], reflectance=0.1)
+        grid_mat = spec.add_material(name="grid_mat", texrepeat=[8, 8], reflectance=0.2)
         grid_mat.textures[mujoco.mjtTextureRole.mjTEXROLE_RGB] = grid_tex.name
 
         # Mesh assets for objects that declare ``shape == "mesh"``.
@@ -236,20 +241,21 @@ class SpecBuilder:
             if obj.shape == "mesh" and obj.mesh_path:
                 spec.add_mesh(name=f"mesh_{obj.name}", file=obj.mesh_path)
 
-        # Lights.
-        spec.worldbody.add_light(
+        # Lights. A single directional light matching the Menagerie SO101
+        # scene.xml (``<light pos="0 0 3.5" dir="0 0 -1" directional="true"/>``).
+        # The previous setup stacked TWO bright point lights (main diffuse 1.0
+        # + fill 0.5) firing straight down, which over-lit the scene, blew out
+        # the floor to white, and flattened shadow contrast. A directional
+        # light is also more physically representative of overhead room
+        # lighting than a point light 3m above the origin.
+        main_light = spec.worldbody.add_light(
             name="main_light",
-            pos=[0.0, 0.0, 3.0],
+            pos=[0.0, 0.0, 3.5],
             dir=[0.0, 0.0, -1.0],
-            diffuse=[1.0, 1.0, 1.0],
-            specular=[0.3, 0.3, 0.3],
+            diffuse=[0.6, 0.6, 0.6],
+            specular=[0.2, 0.2, 0.2],
         )
-        spec.worldbody.add_light(
-            name="fill_light",
-            pos=[1.0, 1.0, 2.0],
-            dir=[-0.5, -0.5, -1.0],
-            diffuse=[0.5, 0.5, 0.5],
-        )
+        main_light.type = mujoco.mjtLightType.mjLIGHT_DIRECTIONAL
 
         # Ground plane.
         if world.ground_plane:

--- a/tests/simulation/mujoco/test_spec_builder.py
+++ b/tests/simulation/mujoco/test_spec_builder.py
@@ -213,12 +213,17 @@ class TestBuild:
         assert np.allclose(hl.diffuse, [hl.diffuse[0]] * 3)
 
     def test_explicit_scene_lights_present(self):
-        """The two explicit directional lights survive build() — the dimmed
-        headlight relies on them for the actual scene illumination."""
+        """A single directional ``main_light`` survives build(), matching the
+        Menagerie SO101 scene.xml. The previous two-point-light setup
+        (main diffuse 1.0 + fill 0.5) over-lit the scene and blew the floor
+        to white."""
         model = SpecBuilder.build(SimWorld()).compile()
-        assert model.nlight >= 2
+        assert model.nlight >= 1
         names = {mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_LIGHT, i) for i in range(model.nlight)}
-        assert {"main_light", "fill_light"} <= names
+        assert "main_light" in names
+        # main_light must be directional (not a point light firing straight down).
+        mid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_LIGHT, "main_light")
+        assert int(model.light_type[mid]) == int(mujoco.mjtLightType.mjLIGHT_DIRECTIONAL)
 
 
 # Mutation helpers


### PR DESCRIPTION
The default MuJoCo scene rendered with a near-white checkerboard floor (`rgb1=0.9`/`rgb2=0.7`) lit by **two** bright point lights (main `diffuse 1.0` + fill `0.5`) firing straight down. This saturated the ground to pure white (measured **250/255** in rendered frames), washed out the floor, and flattened shadow contrast.

## Fix

Matched the [MuJoCo Menagerie SO101 `scene.xml`](https://github.com/google-deepmind/mujoco_menagerie) reference:

- **Ground checker** -> dark blue-grey (`rgb1=0.2 0.3 0.4` / `rgb2=0.1 0.2 0.3`), `reflectance 0.1 -> 0.2`.
- **Lighting** -> replaced the two over-bright point lights with a single **directional** light (`pos 0 0 3.5`, `dir 0 0 -1`, `diffuse 0.6`, `specular 0.2`). A directional light is more physically representative of overhead room lighting than a point light 3m above the origin.

Rendered ground brightness drops **250.9 -> 110.5**.

## Scope

This is the **lighting/render-correctness slice only**, split out from a larger sim/policy bug-fix branch so it can land independently. The policy-eval substep fix, action-drop guard, and provider warnings are deferred to follow-up PRs.

## Tests

- Updated `test_explicit_scene_lights_present` to assert a single directional `main_light` (`nlight >= 1`, `light_type == DIRECTIONAL`) instead of the old two-point-light setup.
- `pytest tests/simulation/mujoco/test_spec_builder.py` -> **39 passed**.
- `ruff check` / `ruff format --check` -> clean.
- `mypy strands_robots/simulation/mujoco/spec_builder.py` -> no issues.