### PR TITLE
fix(sim): step physics for full control period in eval paths

### DIFF
--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -466,6 +466,11 @@ class SimEngine(ABC):
         n_episodes: int = 1,
         max_steps: int = 300,
         success_fn: str | None = None,
+        policy_object: Policy | None = None,
+        control_frequency: float = 50.0,
+        control_substeps: int | None = None,
+        action_horizon: int = 8,
+        seed: int | None = None,
     ) -> dict[str, Any]:
         """Multi-episode policy evaluation via ``PolicyRunner.evaluate``.
 
@@ -473,9 +478,19 @@ class SimEngine(ABC):
         the first robot, which is surprising in multi-robot scenes.
         ``n_episodes`` default lowered from 10 to 1 (callers opt in to
         longer evals explicitly).
-        """
-        from strands_robots.policies import create_policy
 
+        ``policy_object`` mirrors :meth:`run_policy`: pass an already-built
+        ``Policy`` to skip the ``create_policy`` round-trip (e.g. a loaded
+        SmolVLA checkpoint you want to evaluate without re-instantiating).
+        When omitted, the policy is built from ``policy_provider`` /
+        ``policy_config``.
+
+        ``control_frequency`` / ``control_substeps`` flow through to
+        :meth:`PolicyRunner.evaluate` so the eval loop steps physics for the
+        full control period per action (same servo-tracking semantics as
+        :meth:`run_policy`). Without these the arm under-steps and the policy
+        looks like a no-op (the arm under-steps each control period).
+        """
         if not robot_name:
             return {
                 "status": "error",
@@ -491,7 +506,15 @@ class SimEngine(ABC):
             }
         resolved_robot = robot_name
 
-        policy = create_policy(policy_provider, **(policy_config or {}))
+        if policy_object is not None:
+            # Pre-built policy path - mirror run_policy. Caller may have already
+            # set robot_state_keys; we set defensively so semantics match the
+            # provider path.
+            policy = policy_object
+        else:
+            from strands_robots.policies import create_policy
+
+            policy = create_policy(policy_provider, **(policy_config or {}))
         policy.set_robot_state_keys(self.robot_joint_names(resolved_robot))
 
         return PolicyRunner(self).evaluate(
@@ -501,6 +524,10 @@ class SimEngine(ABC):
             n_episodes=n_episodes,
             max_steps=max_steps,
             success_fn=success_fn,
+            control_frequency=control_frequency,
+            control_substeps=control_substeps,
+            action_horizon=action_horizon,
+            seed=seed,
         )
 
     # Benchmark protocol facades

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -244,6 +244,29 @@ class PolicyRunner:
     def __init__(self, sim: SimEngine):
         self.sim = sim
 
+    def _control_substeps(self, control_frequency: float, override: int | None = None) -> int:
+        """Physics steps per applied action so a position-servo arm tracks the
+        full control period (1/control_frequency), not a single physics dt.
+
+        Identical derivation to :meth:`run` — extracted so the eval paths
+        (:meth:`evaluate` / :meth:`_evaluate_with_spec`) step physics for the
+        SAME wall-clock period per action. Without this, eval called
+        ``send_action`` with the default ``n_substeps=1`` (a single ~2 ms
+        ``mj_step``), so the arm integrated ~10% of the way toward each target
+        before the next action overwrote ``ctrl`` — rollouts looked like the
+        policy was a no-op even when commanding valid targets.
+        """
+        if override is not None:
+            return max(1, int(override))
+        dt = None
+        try:
+            dt = self.sim.physics_timestep()
+        except Exception:  # noqa: BLE001 - never fail a run on a probe
+            dt = None
+        if dt and dt > 0 and control_frequency > 0:
+            return max(1, round((1.0 / control_frequency) / dt))
+        return 1
+
     # run(): blocking policy execution
     def run(
         self,
@@ -614,6 +637,8 @@ class PolicyRunner:
         seed: int | None = None,
         action_horizon: int = 8,
         on_frame: OnFrame | None = None,
+        control_frequency: float = 50.0,
+        control_substeps: int | None = None,
     ) -> dict[str, Any]:
         """Evaluate ``policy`` for ``n_episodes`` episodes.
 
@@ -682,6 +707,8 @@ class PolicyRunner:
                 seed=seed,
                 action_horizon=action_horizon,
                 on_frame=on_frame,
+                control_frequency=control_frequency,
+                control_substeps=control_substeps,
             )
 
         try:
@@ -691,6 +718,9 @@ class PolicyRunner:
 
         # T26: skip camera rendering when the policy does not need images.
         _skip_images = not getattr(policy, "requires_images", True)
+        # Step physics for the full control period per action, same derivation
+        # as run(). The default n_substeps=1 made eval rollouts under-step.
+        n_substeps = self._control_substeps(control_frequency, control_substeps)
         results: list[dict[str, Any]] = []
         for ep in range(n_episodes):
             self.sim.reset()
@@ -703,7 +733,7 @@ class PolicyRunner:
                 actions = _resolve_coroutine(coro_or_result)
 
                 if actions:
-                    self.sim.send_action(actions[0], robot_name=robot_name)
+                    self.sim.send_action(actions[0], robot_name=robot_name, n_substeps=n_substeps)
                 else:
                     # Policy returned nothing - still advance one physics step
                     # so episodes don't hang on degenerate policies.
@@ -756,6 +786,8 @@ class PolicyRunner:
         seed: int | None,
         action_horizon: int = 8,
         on_frame: OnFrame | None = None,
+        control_frequency: float = 50.0,
+        control_substeps: int | None = None,
     ) -> dict[str, Any]:
         """Drive a :class:`BenchmarkProtocol` for ``n_episodes`` episodes.
 
@@ -786,6 +818,8 @@ class PolicyRunner:
 
         # T26: skip camera rendering when the policy does not need images.
         _skip_images = not getattr(policy, "requires_images", True)
+        # Full control-period substeps per action (see run() / evaluate()).
+        n_substeps = self._control_substeps(control_frequency, control_substeps)
         # #168: seed Python / NumPy / torch / cuDNN once before
         # the episode loop so policy stochastic ops (e.g. attention
         # dropout, sampling temperature) are reproducible across re-runs
@@ -941,7 +975,7 @@ class PolicyRunner:
                         if steps >= max_steps:
                             break
                         action_applied = dict(action_in_chunk)
-                        self.sim.send_action(action_applied, robot_name=robot_name)
+                        self.sim.send_action(action_applied, robot_name=robot_name, n_substeps=n_substeps)
                         # #191 — synchronous on_frame hook fires on the
                         # eval thread, after send_action + before
                         # on_step's reward bookkeeping. Use this for

--- a/tests/simulation/test_policy_runner_behaviour.py
+++ b/tests/simulation/test_policy_runner_behaviour.py
@@ -351,3 +351,77 @@ class TestT26PerfBudget:
         assert captured, "get_observation was never called"
         # Mock policy has requires_images=False → every call skip_images=True.
         assert all(captured), f"skip_images should be True every step; got {captured}"
+
+
+class _ConstantTargetPolicy(MockPolicy):
+    """Commands every joint to a fixed target every step (no sinusoid).
+
+    A position-servo arm only tracks a constant target if
+    physics is stepped for the full control period per action. With the old
+    n_substeps=1 default, the eval paths integrated a single ~2 ms mj_step and
+    the arm crawled.
+    """
+
+    def __init__(self, target: float = 0.6) -> None:
+        super().__init__()
+        self._target = target
+
+    async def get_actions(self, observation_dict, instruction, **kwargs):
+        if not self.robot_state_keys:
+            self.robot_state_keys = list(observation_dict.keys())
+        return [{k: self._target for k in self.robot_state_keys}]
+
+
+class TestControlSubsteps:
+    """Eval paths must step physics for the full control period per action,
+    identical to run()."""
+
+    def test_control_substeps_derivation(self, sim_with_robot):
+        runner = PolicyRunner(sim_with_robot)
+        dt = sim_with_robot.physics_timestep()
+        assert dt and dt > 0
+        # 50 Hz control over a 2 ms physics dt -> 10 substeps per action.
+        assert runner._control_substeps(50.0) == round((1.0 / 50.0) / dt)
+        # Explicit override wins and is floored at 1.
+        assert runner._control_substeps(50.0, override=7) == 7
+        assert runner._control_substeps(50.0, override=0) == 1
+
+    def test_evaluate_steps_full_control_period(self, sim_with_robot):
+        """A constant-target policy must actually move the arm in evaluate().
+
+        Pre-fix (n_substeps=1) the arm integrated ~10% of the way to target;
+        this asserts a meaningful joint delta so the bug can't silently return.
+        """
+        joints = sim_with_robot.robot_joint_names("alice")
+        policy = _ConstantTargetPolicy(target=0.6)
+        policy.set_robot_state_keys(joints)
+        runner = PolicyRunner(sim_with_robot)
+
+        sim_with_robot.reset()
+        q0 = sim_with_robot.get_observation(robot_name="alice", skip_images=True)
+        runner.evaluate(
+            "alice",
+            policy,
+            n_episodes=1,
+            max_steps=80,
+            control_frequency=50.0,
+        )
+        q1 = sim_with_robot.get_observation(robot_name="alice", skip_images=True)
+        max_dq = max(abs(q1[k] - q0[k]) for k in joints)
+        assert max_dq > 0.1, f"arm barely moved in evaluate (max|dq|={max_dq:.4f})"
+
+    def test_evaluate_forwards_substeps_to_send_action(self, sim_with_robot, monkeypatch):
+        """evaluate() must pass n_substeps>1 (not the default 1) to send_action."""
+        seen: list[int] = []
+        orig = sim_with_robot.send_action
+
+        def spy(action, robot_name=None, n_substeps=1):
+            seen.append(n_substeps)
+            return orig(action, robot_name=robot_name, n_substeps=n_substeps)
+
+        monkeypatch.setattr(sim_with_robot, "send_action", spy)
+        policy = _ConstantTargetPolicy()
+        policy.set_robot_state_keys(sim_with_robot.robot_joint_names("alice"))
+        PolicyRunner(sim_with_robot).evaluate("alice", policy, n_episodes=1, max_steps=5, control_frequency=50.0)
+        assert seen, "send_action was never called"
+        assert all(n > 1 for n in seen), f"eval still under-stepping: n_substeps={seen}"


### PR DESCRIPTION
`PolicyRunner.evaluate()` / `_evaluate_with_spec()` called `send_action` with the default `n_substeps=1` (a single ~2ms `mj_step`). A position-servo arm therefore integrated only **~10%** of the way toward each target before the next action overwrote `ctrl` — so eval rollouts looked like the policy was a **no-op** even when commanding valid joint targets.

## Fix

- **`PolicyRunner._control_substeps(control_frequency, override)`** — same derivation as `run()` (`round((1/control_frequency)/physics_dt)`), floored at 1, never fails a run on a `physics_timestep()` probe.
- Thread `n_substeps` + `control_frequency` through **both** `evaluate()` and `_evaluate_with_spec()` into every `send_action` call.
- `base.py` `evaluate()` gains `control_frequency` / `control_substeps` / `action_horizon` / `seed` passthrough, plus a `policy_object` passthrough **mirroring `run_policy`** (skip the `create_policy` round-trip for an already-built `Policy`).

## Scope

Behavioral-correctness slice only, split out from a larger sim/policy bug-fix branch so it can land independently. Lighting fix is #428; action-drop guard and provider warnings are separate follow-ups.

## Tests (`test_policy_runner_behaviour.py`)

- `_control_substeps` derivation (50 Hz over 2 ms dt -> 10 substeps) + override flooring at 1.
- A constant-target policy must move the arm **> 0.1 rad** in `evaluate()` (pre-fix it crawled ~10%) — pins the bug so it cannot silently return.
- `evaluate()` must forward `n_substeps > 1` to `send_action`.

Local checks: `ruff check` / `ruff format --check` clean, `mypy` no issues, `pytest tests/simulation/test_policy_runner_behaviour.py` -> **23 passed**.