### PR TITLE
fix(lerobot_local): move model to resolved device + warn on missing postprocessor

### DIFF
--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -379,6 +379,20 @@ class LerobotLocalPolicy(Policy):
         else:
             self._device = next(self._policy.parameters()).device
 
+        # Move the model onto the resolved device. LeRobot's from_pretrained
+        # places weights on config.device (e.g. 'mps'/'cuda' baked into the
+        # checkpoint config), which may differ from the user's requested
+        # device. get_actions() moves every input tensor onto self._device,
+        # so without this the model weights and inputs land on different
+        # devices and the first conv2d raises "input and weight must be on
+        # the same device". Keep them in lockstep.
+        try:
+            current = next(self._policy.parameters()).device
+            if current != self._device:
+                self._policy.to(self._device)
+        except StopIteration:
+            pass  # parameterless policy - nothing to move
+
         if hasattr(self._policy, "config"):
             config = self._policy.config
             if hasattr(config, "input_features"):
@@ -437,6 +451,24 @@ class LerobotLocalPolicy(Policy):
                     ) from exc
                 logger.debug("Processor bridge not loaded: %s", exc)
                 self._processor_bridge = None
+
+        # Action unnormalization only happens when a postprocessor pipeline is
+        # present (get_actions: ``if self._processor_bridge.has_postprocessor``).
+        # A checkpoint shipped without a ``policy_postprocessor.json`` emits raw
+        # normalized actions (~[-1, 1] or z-scored) straight to the robot. Fed
+        # to a radian-joint sim those are micro-motions and the arm barely
+        # moves. Warn once at load so this isn't debugged as a frozen policy.
+        if self.use_processor and (self._processor_bridge is None or not self._processor_bridge.has_postprocessor):
+            logger.warning(
+                "lerobot_local: %s loaded WITHOUT an action postprocessor "
+                "(no policy_postprocessor.json). Actions are emitted in the "
+                "model's RAW/normalized space and are NOT unnormalized to robot "
+                "units -- if the arm barely moves, this is why. Provide the "
+                "checkpoint's postprocessor, or drive it through a provider with "
+                "explicit unit handling (e.g. the 'transformers' provider's "
+                "state_units/action_units/stats knobs).",
+                self.pretrained_name_or_path or "<model>",
+            )
 
         # Initialize RTC if supported by this policy
         self._init_rtc()

--- a/tests/policies/lerobot_local/test_policy.py
+++ b/tests/policies/lerobot_local/test_policy.py
@@ -1022,3 +1022,124 @@ class TestRTCGetActionsIntegration:
 
         policy._policy.select_action.assert_called_once()
         assert isinstance(result, list)
+
+
+# (section)
+# Tests: _load_model device + postprocessor regressions
+# (section)
+
+
+def _load_model_with_mocks(policy, *, param_device="cpu", has_postprocessor=True, bridge_active=True):
+    """Drive the real LerobotLocalPolicy._load_model with the heavy load seams
+    mocked, so the device-move and postprocessor-warning branches execute.
+
+    Returns the mocked lerobot policy object (so tests can assert on .to(...)).
+    """
+    mock_lerobot_policy = MagicMock()
+    mock_param = torch.nn.Parameter(torch.zeros(1, device=param_device))
+    # parameters() is consumed via next(...) at multiple points in _load_model,
+    # so hand back a FRESH iterator on every call (a stored list breaks next()).
+    mock_lerobot_policy.parameters.side_effect = lambda: iter([mock_param])
+    mock_lerobot_policy.config = MagicMock(spec=[])  # no .device / .input_features
+
+    PolicyClass = MagicMock()
+    PolicyClass.from_pretrained.return_value = mock_lerobot_policy
+
+    bridge = None
+    if bridge_active:
+        bridge = MagicMock()
+        bridge.is_active = True
+        bridge.has_postprocessor = has_postprocessor
+
+    with (
+        patch.object(
+            LerobotLocalPolicy,
+            "_load_model",
+            LerobotLocalPolicy._load_model,
+        ),
+        patch(
+            "strands_robots.policies.lerobot_local.policy.resolve_policy_class_by_name",
+            return_value=PolicyClass,
+        ),
+        patch.object(LerobotLocalPolicy, "_configure_embodiment", lambda self: None),
+        patch.object(LerobotLocalPolicy, "_init_rtc", lambda self: None),
+        patch.object(ProcessorBridge, "from_pretrained", return_value=bridge),
+    ):
+        policy._load_model()
+    return mock_lerobot_policy
+
+
+class TestLoadModelDeviceMove:
+    """Regression: from_pretrained may place weights on a device that differs
+    from the resolved self._device. _load_model must move the model so weights
+    and inputs stay in lockstep (else the first conv2d raises 'input and weight
+    must be on the same device')."""
+
+    def test_moves_model_when_param_device_differs(self):
+        # requested cpu, but the checkpoint params land on 'meta' (stand-in for
+        # an mps/cuda baked into the checkpoint config that != requested).
+        policy = LerobotLocalPolicy.__new__(LerobotLocalPolicy)
+        policy.pretrained_name_or_path = "test/model"
+        policy.policy_type = "act"
+        policy.requested_device = "cpu"
+        policy.use_processor = False
+        policy.robot_state_keys = []
+        policy._processor_bridge = None
+        policy._output_features = {}
+        policy._input_features = {}
+        policy.processor_overrides = {}
+
+        mock_policy = _load_model_with_mocks(policy, param_device="meta", bridge_active=False)
+
+        mock_policy.to.assert_called_once()
+        assert policy._device == torch.device("cpu")
+
+    def test_no_move_when_param_device_matches(self):
+        policy = LerobotLocalPolicy.__new__(LerobotLocalPolicy)
+        policy.pretrained_name_or_path = "test/model"
+        policy.policy_type = "act"
+        policy.requested_device = "cpu"
+        policy.use_processor = False
+        policy.robot_state_keys = []
+        policy._processor_bridge = None
+        policy._output_features = {}
+        policy._input_features = {}
+        policy.processor_overrides = {}
+
+        mock_policy = _load_model_with_mocks(policy, param_device="cpu", bridge_active=False)
+
+        mock_policy.to.assert_not_called()
+
+
+class TestLoadModelPostprocessorWarning:
+    """Regression: a checkpoint without an action postprocessor emits RAW
+    normalized actions -> micro-motion. _load_model must warn once at load."""
+
+    def _base_policy(self):
+        policy = LerobotLocalPolicy.__new__(LerobotLocalPolicy)
+        policy.pretrained_name_or_path = "test/model"
+        policy.policy_type = "act"
+        policy.requested_device = "cpu"
+        policy.use_processor = True
+        policy.robot_state_keys = []
+        policy._processor_bridge = None
+        policy._output_features = {}
+        policy._input_features = {}
+        policy.processor_overrides = {}
+        return policy
+
+    def test_warns_without_postprocessor(self, caplog):
+        import logging
+
+        policy = self._base_policy()
+        with caplog.at_level(logging.WARNING, logger="strands_robots.policies.lerobot_local.policy"):
+            _load_model_with_mocks(policy, has_postprocessor=False)
+        assert any("WITHOUT an action postprocessor" in r.message for r in caplog.records)
+
+    def test_no_warn_with_postprocessor(self, caplog):
+        import logging
+
+        policy = self._base_policy()
+        with caplog.at_level(logging.WARNING, logger="strands_robots.policies.lerobot_local.policy"):
+            _load_model_with_mocks(policy, has_postprocessor=True)
+        assert not any("WITHOUT an action postprocessor" in r.message for r in caplog.records)


### PR DESCRIPTION
Two correctness fixes in `LerobotLocalPolicy._load_model`.

## 1. Device mismatch (real crash)

LeRobot's `from_pretrained()` places weights on `config.device` (e.g. an `mps`/`cuda` baked into the checkpoint config), which may differ from the user's requested device. `get_actions()` moves every **input** tensor onto `self._device`, so without moving the **model** the weights and inputs land on different devices and the first `conv2d` raises:

```
RuntimeError: input and weight must be on the same device
```

`_load_model` now moves the model onto `self._device` when the param device differs (`StopIteration`-safe for parameterless policies).

## 2. Missing postprocessor (silent micro-motion)

Action unnormalization only runs when a postprocessor pipeline is present (`get_actions`: `if self._processor_bridge.has_postprocessor`). A checkpoint shipped **without** `policy_postprocessor.json` emits raw normalized actions (~`[-1, 1]` / z-scored) straight to the robot -> in a radian-joint sim the arm barely moves. Warn once at load so this is not debugged as a frozen policy.

## Scope

Provider-correctness slice only, split out from a larger sim/policy bug-fix branch so it can land independently (lighting #428, eval substeps #429).

## Tests (`tests/policies/lerobot_local/test_policy.py`)

New `TestLoadModelDeviceMove` + `TestLoadModelPostprocessorWarning` drive the **real** `_load_model` with the heavy load seams mocked (`resolve_policy_class_by_name`, `ProcessorBridge.from_pretrained`, `_configure_embodiment`, `_init_rtc`). They pin:

- `.to()` is called **iff** the param device differs from the resolved device.
- the no-postprocessor warning fires **only** when the postprocessor is absent.

Per AGENTS.md ("pin every reviewed fix with a regression test"), both positive assertions were verified to **fail on pre-fix code** (reverted `policy.py` to `main` -> `2 failed, 2 passed`).

Local checks: `ruff check` / `ruff format --check` clean, `mypy` no issues (src + test), `pytest tests/policies/lerobot_local/test_policy.py` -> **77 passed**.