### PR TITLE
fix(api): improve ergonomics for send_action, add_robot, render, and get_robot

### DIFF
--- a/examples/cosmos3_sim_rollout.py
+++ b/examples/cosmos3_sim_rollout.py
@@ -62,7 +62,9 @@ def main() -> int:
         from strands_robots import Simulation
         from strands_robots.policies.cosmos3 import Cosmos3Policy
     except ImportError as e:
-        print(f"Missing deps: {e}\nInstall: pip install -e '.[sim-mujoco]' && pip install 'strands-robots[cosmos3-service]'")
+        print(
+            f"Missing deps: {e}\nInstall: pip install -e '.[sim-mujoco]' && pip install 'strands-robots[cosmos3-service]'"
+        )
         return 2
 
     print(f"Building MuJoCo world with a '{args.robot}' arm + cube + 3 cameras ...")
@@ -71,24 +73,27 @@ def main() -> int:
     # DROID == Franka Emika Panda. The 'droid' Cosmos embodiment drives a
     # Franka/DROID-class arm; use the 'franka' (or 'panda') sim asset here.
     sim.add_robot(name="arm", data_config=args.robot)
-    sim.add_object(name="cube", shape="box", position=[0.4, 0.0, 0.05],
-                   size=[0.025, 0.025, 0.025], color=[1, 0, 0, 1], mass=0.1)
+    sim.add_object(
+        name="cube", shape="box", position=[0.4, 0.0, 0.05], size=[0.025, 0.025, 0.025], color=[1, 0, 0, 1], mass=0.1
+    )
     sim.add_camera(name="wrist", position=[0.3, 0.0, 0.5], target=[0.4, 0, 0.05])
     sim.add_camera(name="front", position=[0.9, 0.0, 0.4], target=[0.4, 0, 0.05])
-    sim.add_camera(name="side",  position=[0.4, 0.6, 0.4], target=[0.4, 0, 0.05])
+    sim.add_camera(name="side", position=[0.4, 0.6, 0.4], target=[0.4, 0, 0.05])
 
     # The DROID policy conditions on 3 cameras (wrist + 2 exterior) + 7-DOF
     # joints + gripper. Map our sim camera names onto the server's OpenPI keys.
     obs_mapping = {
         "wrist": "observation/wrist_image_left",
         "front": "observation/exterior_image_1_left",
-        "side":  "observation/exterior_image_2_left",
+        "side": "observation/exterior_image_2_left",
     }
     # The Cosmos3 client uses a self-contained msgpack+websockets transport
     # (numpy-version agnostic — composes with lerobot).
     policy = Cosmos3Policy(
-        embodiment="droid", host=args.host, port=args.port,
-        robot=args.robot,                # map joint_0..6/gripper -> sim actuator names
+        embodiment="droid",
+        host=args.host,
+        port=args.port,
+        robot=args.robot,  # map joint_0..6/gripper -> sim actuator names
         observation_mapping=obs_mapping,
     )
 

--- a/examples/lerobot/hub_to_hardware.ipynb
+++ b/examples/lerobot/hub_to_hardware.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "7fb27b941602401d91542211134fc71a",
    "metadata": {},
    "source": [
     "# From Hugging Face Hub to robot hardware\n",
@@ -22,6 +23,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "acae54e37e7d407bbb7b55eff062a284",
    "metadata": {},
    "source": [
     "## Prerequisites\n",
@@ -44,6 +46,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "9a63283cbaf04dbcab1f6479b197f3a8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,6 +75,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8dd0d8092fe74a7c96281538738b07e2",
    "metadata": {},
    "source": [
     "## Step 1 — Build the agent\n",
@@ -84,12 +88,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "72eea5119410473aa328ad9291626812",
    "metadata": {},
    "outputs": [],
    "source": [
     "from strands import Agent\n",
     "from strands.models import BedrockModel\n",
-    "from strands_robots import Robot, lerobot_teleoperate, lerobot_calibrate, robot_mesh\n",
+    "\n",
+    "from strands_robots import Robot, lerobot_calibrate, lerobot_teleoperate, robot_mesh\n",
     "\n",
     "model = BedrockModel(model_id=MODEL_ID, region_name=AWS_REGION) if AWS_REGION else BedrockModel(model_id=MODEL_ID)\n",
     "robot = Robot(\"so100\", data_config=\"so100_dualcam\")  # sim by default\n",
@@ -102,6 +108,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8edb47106e1a46a883d545849b8ab81b",
    "metadata": {},
    "source": [
     "## Step 2 — Record a demonstration\n",
@@ -114,15 +121,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "10185d26023b46108eb7d9f57d49d2b3",
    "metadata": {},
    "outputs": [],
    "source": [
     "NUM_STEPS = 1000  # ≈ 33s of data at 30fps\n",
     "\n",
     "push_clause = (\n",
-    "    f\"Push the result to {REPO_ID} when done.\"\n",
-    "    if PUSH_TO_HUB\n",
-    "    else \"Keep the dataset local — do not push to the Hub.\"\n",
+    "    f\"Push the result to {REPO_ID} when done.\" if PUSH_TO_HUB else \"Keep the dataset local — do not push to the Hub.\"\n",
     ")\n",
     "\n",
     "prompt = (\n",
@@ -145,6 +151,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8763a12b2bbd4a93a75aff182afb95dc",
    "metadata": {},
    "source": [
     "### Verify the recording\n",
@@ -155,6 +162,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "7623eae2785240b9bd12b16a66d81610",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -173,6 +181,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7cdc8c89c7104fffa095e18ddfef8986",
    "metadata": {},
    "source": [
     "Inside the cache directory you'll find:\n",
@@ -186,6 +195,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b118ea5561624da68c537baed56e602f",
    "metadata": {},
    "source": [
     "## Step 3 — Run a policy on the robot\n",
@@ -198,17 +208,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "938c804e27f84196a10c8828c723f798",
    "metadata": {},
    "outputs": [],
    "source": [
-    "agent(\n",
-    "    f\"Run the Mock policy on the robot for 200 steps with the instruction \"\n",
-    "    f\"'{TASK}'. Render the final frame.\"\n",
-    ")"
+    "agent(f\"Run the Mock policy on the robot for 200 steps with the instruction '{TASK}'. Render the final frame.\")"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "504fb2a444614c0babb325280ed9130a",
    "metadata": {},
    "source": [
     "## Step 4 — Deploy to physical hardware (reference)\n",
@@ -235,6 +244,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "59bbdb311c014d738909a11f9e486628",
    "metadata": {},
    "source": [
     "## Step 5 — Mesh broadcast\n",
@@ -247,6 +257,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "b43b363d81ae4b689946ece5c682cd59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -258,6 +269,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8a65eabff63a45729fe45fb5ade58bdc",
    "metadata": {},
    "source": [
     "## Cleanup\n",

--- a/examples/lerobot/hub_to_hardware.py
+++ b/examples/lerobot/hub_to_hardware.py
@@ -104,6 +104,7 @@ DEFAULT_MODEL_ID = "global.anthropic.claude-opus-4-8"  # ← verify in AWS conso
 # Dataset location + state helpers
 # ---------------------------------------------------------------------------
 
+
 def _lerobot_cache_root(repo_id: str) -> Path:
     """Return the on-disk LeRobotDataset cache directory for ``repo_id``."""
     return Path.home() / ".cache" / "huggingface" / "lerobot" / repo_id
@@ -131,6 +132,7 @@ def _read_dataset_state(repo_id: str) -> dict[str, Any]:
 
     try:
         from lerobot.datasets.lerobot_dataset import LeRobotDataset
+
         ds = LeRobotDataset(repo_id)
         result["status"] = "ready"
         result["num_episodes"] = int(getattr(ds, "num_episodes", 0))
@@ -155,7 +157,9 @@ def _log_dataset_summary(repo_id: str) -> None:
     if status == "ready":
         logger.info(
             "✅ Dataset ready: %d episode(s), %d frame(s) → %s",
-            state["num_episodes"], state["total_frames"], state["cache_path"],
+            state["num_episodes"],
+            state["total_frames"],
+            state["cache_path"],
         )
     elif status == "missing":
         logger.warning(
@@ -164,9 +168,9 @@ def _log_dataset_summary(repo_id: str) -> None:
         )
     elif status == "not_finalized":
         logger.warning(
-            "❌ Cache at %s isn't a complete dataset (%s) — "
-            "stop_recording may not have run",
-            state["cache_path"], state["error"],
+            "❌ Cache at %s isn't a complete dataset (%s) — stop_recording may not have run",
+            state["cache_path"],
+            state["error"],
         )
     else:
         logger.warning("❌ Dataset check failed: %s", state["error"])
@@ -175,6 +179,7 @@ def _log_dataset_summary(repo_id: str) -> None:
 # ---------------------------------------------------------------------------
 # Diagnostic tool-call capture (verbose mode only)
 # ---------------------------------------------------------------------------
+
 
 def _get(obj: Any, key: str, default: Any = None) -> Any:
     """Return ``obj[key]`` for dicts, ``obj.key`` for objects, else ``default``.
@@ -210,17 +215,21 @@ def _log_agent_tool_calls(agent: Any, label: str, *, since_index: int = 0) -> in
         for block in content:
             block_type = _get(block, "type")
             if block_type == "tool_use":
-                tool_calls.append({
-                    "name": _get(block, "name"),
-                    "input": _get(block, "input") or {},
-                })
+                tool_calls.append(
+                    {
+                        "name": _get(block, "name"),
+                        "input": _get(block, "input") or {},
+                    }
+                )
                 continue
             tool_use_inner = _get(block, "toolUse")
             if tool_use_inner is not None:
-                tool_calls.append({
-                    "name": _get(tool_use_inner, "name"),
-                    "input": _get(tool_use_inner, "input") or {},
-                })
+                tool_calls.append(
+                    {
+                        "name": _get(tool_use_inner, "name"),
+                        "input": _get(tool_use_inner, "input") or {},
+                    }
+                )
 
     if not tool_calls:
         diag_logger.info("[%s] no tool calls observed", label)
@@ -229,10 +238,7 @@ def _log_agent_tool_calls(agent: Any, label: str, *, since_index: int = 0) -> in
     diag_logger.info("[%s] %d tool call(s):", label, len(tool_calls))
     for i, call in enumerate(tool_calls, 1):
         inp = call["input"] or {}
-        compact = {
-            k: (v if not isinstance(v, str) or len(v) <= 80 else v[:77] + "...")
-            for k, v in inp.items()
-        }
+        compact = {k: (v if not isinstance(v, str) or len(v) <= 80 else v[:77] + "...") for k, v in inp.items()}
         diag_logger.info("  %2d. %s(%s)", i, call["name"], compact)
     return len(messages)
 
@@ -247,6 +253,7 @@ def _log_prompt(label: str, prompt: str) -> None:
 # ---------------------------------------------------------------------------
 # Agent construction
 # ---------------------------------------------------------------------------
+
 
 def _build_bedrock_model(model_id: str, region: str | None) -> Any | None:
     """Construct a Strands BedrockModel client.
@@ -283,7 +290,9 @@ def _build_bedrock_model(model_id: str, region: str | None) -> Any | None:
             "BedrockModel(%s, region=%s) init failed: %s. Falling back to "
             "Strands' default. Common causes: model not enabled in this AWS "
             "account, wrong region, or stale model ID — check the Bedrock console.",
-            model_id, region or "<unset>", exc,
+            model_id,
+            region or "<unset>",
+            exc,
         )
         return None
 
@@ -299,10 +308,11 @@ def build_agent(
 ) -> Any:
     """Build the Strands agent with the right tool set for the run."""
     from strands import Agent
+
     from strands_robots import (
         Robot,
-        lerobot_teleoperate,
         lerobot_calibrate,
+        lerobot_teleoperate,
         robot_mesh,
     )
 
@@ -311,10 +321,7 @@ def build_agent(
     robot_kwargs: dict[str, Any] = {"data_config": "so100_dualcam"}
     if mode == "real":
         if not port:
-            raise SystemExit(
-                "--mode real requires --port (e.g. /dev/ttyACM0). "
-                "Hardware paths can't be guessed safely."
-            )
+            raise SystemExit("--mode real requires --port (e.g. /dev/ttyACM0). Hardware paths can't be guessed safely.")
         robot_kwargs.update(
             port=port,
             cameras={
@@ -336,18 +343,11 @@ def build_agent(
 
     if policy == "groot":
         from strands_robots import gr00t_inference
+
         tools.append(gr00t_inference)
 
-    resolved_model_id = (
-        model_id
-        or os.environ.get("STRANDS_BEDROCK_MODEL_ID")
-        or DEFAULT_MODEL_ID
-    )
-    resolved_region = (
-        aws_region
-        or os.environ.get("AWS_REGION")
-        or os.environ.get("AWS_DEFAULT_REGION")
-    )
+    resolved_model_id = model_id or os.environ.get("STRANDS_BEDROCK_MODEL_ID") or DEFAULT_MODEL_ID
+    resolved_region = aws_region or os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION")
     model = _build_bedrock_model(resolved_model_id, resolved_region)
 
     agent = Agent(model=model, tools=tools) if model else Agent(tools=tools)
@@ -358,6 +358,7 @@ def build_agent(
 # ---------------------------------------------------------------------------
 # Step 2: Record a demonstration
 # ---------------------------------------------------------------------------
+
 
 def record_demonstration(
     agent: Any,
@@ -402,9 +403,7 @@ def record_demonstration(
     else:
         leader_port = getattr(agent, "_leader_port", None)
         if not leader_port:
-            raise SystemExit(
-                "Hardware recording requires --leader-port (e.g. /dev/ttyACM1)"
-            )
+            raise SystemExit("Hardware recording requires --leader-port (e.g. /dev/ttyACM1)")
         prompt = (
             f"Confirm calibrations exist for the so101_follower and "
             f"so101_leader. Then teleoperate to record one demonstration "
@@ -423,6 +422,7 @@ def record_demonstration(
 # Step 3: Run a policy on the robot
 # ---------------------------------------------------------------------------
 
+
 def run_policy(
     agent: Any,
     *,
@@ -439,10 +439,7 @@ def run_policy(
 
     elif policy == "groot":
         if not checkpoint:
-            raise SystemExit(
-                "--policy groot requires --checkpoint <hf_repo>, "
-                "e.g. nvidia/GR00T-N1.7-LIBERO"
-            )
+            raise SystemExit("--policy groot requires --checkpoint <hf_repo>, e.g. nvidia/GR00T-N1.7-LIBERO")
         prompt = (
             f"Use gr00t_inference lifecycle='full' to bring up the GR00T "
             f"container on port 5555 with checkpoint {checkpoint}. Then "
@@ -453,8 +450,7 @@ def run_policy(
     elif policy == "lerobot_local":
         if not checkpoint:
             raise SystemExit(
-                "--policy lerobot_local requires --checkpoint <hf_repo>, "
-                "e.g. lerobot/act_aloha_sim_transfer_cube_human"
+                "--policy lerobot_local requires --checkpoint <hf_repo>, e.g. lerobot/act_aloha_sim_transfer_cube_human"
             )
         if os.environ.get("STRANDS_TRUST_REMOTE_CODE") != "1":
             raise SystemExit(
@@ -481,6 +477,7 @@ def run_policy(
 # Step 5: Mesh broadcast
 # ---------------------------------------------------------------------------
 
+
 def broadcast_to_mesh(agent: Any, instruction: str = "go to home pose") -> Any:
     """Discover mesh peers and broadcast a command to all of them."""
     prompt = (
@@ -499,6 +496,7 @@ def broadcast_to_mesh(agent: Any, instruction: str = "go to home pose") -> Any:
 # Cleanup
 # ---------------------------------------------------------------------------
 
+
 def cleanup(agent: Any, *, policy: str) -> None:
     """Tear down any long-running resources the workflow started."""
     if policy == "groot":
@@ -511,6 +509,7 @@ def cleanup(agent: Any, *, policy: str) -> None:
 # ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
+
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
     p = argparse.ArgumentParser(
@@ -534,8 +533,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     p.add_argument(
         "--checkpoint",
         default=None,
-        help="HF repo for the policy checkpoint "
-             "(required for --policy groot or lerobot_local).",
+        help="HF repo for the policy checkpoint (required for --policy groot or lerobot_local).",
     )
 
     # LLM knobs
@@ -543,63 +541,74 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "--model-id",
         default=None,
         help=f"Bedrock model ID to drive the agent. Default: {DEFAULT_MODEL_ID}. "
-             f"Override here or via STRANDS_BEDROCK_MODEL_ID. Verify the exact "
-             f"ID against your AWS Bedrock console.",
+        f"Override here or via STRANDS_BEDROCK_MODEL_ID. Verify the exact "
+        f"ID against your AWS Bedrock console.",
     )
     p.add_argument(
         "--aws-region",
         default=None,
         help="AWS region for Bedrock. If unset, resolves from AWS_REGION / "
-             "AWS_DEFAULT_REGION env vars or ~/.aws/config (boto3's standard chain).",
+        "AWS_DEFAULT_REGION env vars or ~/.aws/config (boto3's standard chain).",
     )
 
     # Hardware knobs
     p.add_argument(
-        "--port", default=None,
+        "--port",
+        default=None,
         help="USB device of the SO-101 follower (--mode real only).",
     )
     p.add_argument(
-        "--leader-port", default=None,
+        "--leader-port",
+        default=None,
         help="USB device of the SO-101 leader for teleop (--mode real only).",
     )
 
     # Recording knobs
     p.add_argument(
-        "--hf-user", default=None,
+        "--hf-user",
+        default=None,
         help="HF username for the dataset repo. If unset, the dataset stays local.",
     )
     p.add_argument(
-        "--dataset-name", default="strands-cube-pick",
+        "--dataset-name",
+        default="strands-cube-pick",
         help="Dataset name under <hf-user>. Default: strands-cube-pick.",
     )
     p.add_argument(
-        "--num-steps", type=int, default=1000,
-        help="Number of policy steps to record in the demonstration "
-             "(default: 1000, ≈ 33s of data at 30fps).",
+        "--num-steps",
+        type=int,
+        default=1000,
+        help="Number of policy steps to record in the demonstration (default: 1000, ≈ 33s of data at 30fps).",
     )
     p.add_argument(
-        "--instruction", default="pick up the red cube",
+        "--instruction",
+        default="pick up the red cube",
         help="Natural-language task instruction.",
     )
     p.add_argument(
-        "--clean-cache", action="store_true",
+        "--clean-cache",
+        action="store_true",
         help="Delete the local LeRobotDataset cache for this repo before recording.",
     )
 
     # Skip flags
     p.add_argument(
-        "--skip-record", action="store_true",
+        "--skip-record",
+        action="store_true",
         help="Skip the recording step (Step 2).",
     )
     p.add_argument(
-        "--skip-mesh", action="store_true",
+        "--skip-mesh",
+        action="store_true",
         help="Skip the mesh broadcast step (Step 5).",
     )
 
     p.add_argument(
-        "--verbose", "-v", action="store_true",
+        "--verbose",
+        "-v",
+        action="store_true",
         help="Show the prompt the agent receives, every tool call (with "
-             "arguments), and detailed dataset state. Off by default.",
+        "arguments), and detailed dataset state. Off by default.",
     )
 
     return p.parse_args(argv)
@@ -626,14 +635,11 @@ def main(argv: list[str] | None = None) -> int:
     diag_logger.setLevel(logging.INFO if args.verbose else logging.WARNING)
 
     push_to_hub = bool(args.hf_user)
-    repo_id = (
-        f"{args.hf_user}/{args.dataset_name}"
-        if push_to_hub
-        else f"local/{args.dataset_name}"
-    )
+    repo_id = f"{args.hf_user}/{args.dataset_name}" if push_to_hub else f"local/{args.dataset_name}"
 
     if args.clean_cache:
         import shutil
+
         cache_dir = _lerobot_cache_root(repo_id)
         if cache_dir.exists():
             logger.info("Removing cache at %s", cache_dir)
@@ -641,7 +647,11 @@ def main(argv: list[str] | None = None) -> int:
 
     logger.info(
         "Starting workflow (mode=%s, policy=%s, push_to_hub=%s, repo=%s, num_steps=%d)",
-        args.mode, args.policy, push_to_hub, repo_id, args.num_steps,
+        args.mode,
+        args.policy,
+        push_to_hub,
+        repo_id,
+        args.num_steps,
     )
 
     banner("Step 1: Build the agent")

--- a/strands_robots/__init__.py
+++ b/strands_robots/__init__.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
         init_device_connect_sync,
     )
     from strands_robots.policies.groot import Gr00tPolicy
-    from strands_robots.registry import list_robots
+    from strands_robots.registry import get_robot, list_robots
     from strands_robots.robot import Robot
     from strands_robots.simulation import (
         SimCamera,
@@ -71,6 +71,7 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     # Hardware robot
     "Robot": ("strands_robots.robot", "Robot"),
     "list_robots": ("strands_robots.registry", "list_robots"),
+    "get_robot": ("strands_robots.registry", "get_robot"),
     # Policies
     "Gr00tPolicy": ("strands_robots.policies.groot", "Gr00tPolicy"),
     # Simulation (MuJoCo)
@@ -113,6 +114,7 @@ __all__ = [
     "SimObject",
     "SimCamera",
     "list_robots",
+    "get_robot",
     "create_simulation",
     "list_backends",
     "register_backend",

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -246,7 +246,7 @@ class SimEngine(ABC):
         ...
 
     @abstractmethod
-    def send_action(self, action: dict[str, Any], robot_name: str | None = None, n_substeps: int = 1) -> None:
+    def send_action(self, action: dict[str, Any], robot_name: str | None = None, n_substeps: int = 1) -> dict[str, Any]:
         """Apply action and advance physics by n_substeps.
 
         Contract: each call writes actuator/ctrl values and then runs
@@ -257,6 +257,11 @@ class SimEngine(ABC):
         Backends are responsible for internal thread-safety (e.g.
         MuJoCo acquires self._lock here). PolicyRunner does not manage
         locks.
+
+        Returns:
+            Dict with ``status`` and ``content``. When action keys cannot
+            be resolved, the ``content`` list includes a ``json`` block with
+            ``unresolved_keys`` so callers can self-correct.
         """
         ...
 
@@ -800,7 +805,7 @@ class SimEngine(ABC):
             "methods": {
                 "get_robot_state": "(robot_name: str) -> dict",
                 "get_observation": "(robot_name: str | None = None, *, skip_images: bool = False) -> dict",
-                "send_action": "(action: dict, robot_name: str | None = None, n_substeps: int = 1) -> None",
+                "send_action": "(action: dict, robot_name: str | None = None, n_substeps: int = 1) -> dict",
                 "run_policy": "(robot_name: str, policy_provider='mock', ...) -> dict",
                 "start_policy": "(robot_name: str, policy_provider='mock', ...) -> dict",
                 "list_robots": "() -> list[str]",

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -294,9 +294,9 @@ class RenderingMixin:
                     "name-lookup path (action may be dropped)",
                     e,
                 )
-                self._apply_action_by_name(model, data, action_dict, pfx, mj)
+                self._unresolved_action_keys = self._apply_action_by_name(model, data, action_dict, pfx, mj)
         else:
-            self._apply_action_by_name(model, data, action_dict, pfx, mj)
+            self._unresolved_action_keys = self._apply_action_by_name(model, data, action_dict, pfx, mj)
 
         if not controller_handled_stepping:
             for _ in range(max(1, n_substeps)):
@@ -346,12 +346,16 @@ class RenderingMixin:
         action_dict: dict[str, Any],
         pfx: str,
         mj: Any,
-    ) -> None:
+    ) -> list[str]:
         """Default action-application: look up actuator / joint by name.
 
         Extracted from :meth:`_apply_sim_action` so the
         ``action_controller`` fast path can fall back to it on
         controller failure (the same path non-LIBERO callers use).
+
+        Returns:
+            List of action keys that could not be resolved to any
+            actuator or joint (empty list when all keys applied).
         """
 
         def _lookup(obj_type: Any, name: str) -> int:
@@ -362,6 +366,7 @@ class RenderingMixin:
                     return i
             return int(mj.mj_name2id(model, obj_type, name))
 
+        unresolved: list[str] = []
         for key, value in action_dict.items():
             act_id = _lookup(mj.mjtObj.mjOBJ_ACTUATOR, key)
             if act_id >= 0:
@@ -384,11 +389,13 @@ class RenderingMixin:
                 # exactly the failure mode #318 was filed to fix, so surface it
                 # -- once per (prefix, key) to avoid per-step log spam at 50Hz.
                 self._warn_unresolved_action_key(pfx, key, "no actuator or joint")
+                unresolved.append(key)
                 continue
 
             ai = self._actuator_for_joint(model, jnt_id, mj)
             if ai < 0:
                 self._warn_unresolved_action_key(pfx, key, "joint has no driving actuator")
+                unresolved.append(key)
                 continue
 
             # Scale a logical command into the actuator's ctrlrange when the
@@ -396,6 +403,8 @@ class RenderingMixin:
             # tendon units, not a finger-joint position). Direct JOINT
             # actuators keep the raw value (positions/torques in joint units).
             data.ctrl[ai] = self._scale_ctrl_for_actuator(model, ai, float(value), mj)
+
+        return unresolved
 
     def _warn_unresolved_action_key(self, pfx: str, key: str, reason: str) -> None:
         """Warn once per (prefix, key) that an action key could not be applied.
@@ -565,6 +574,13 @@ class RenderingMixin:
             pil_img.save(buffer, format="PNG")
             png_bytes = buffer.getvalue()
 
+            # base64-encode for transport through the Strands tool-response
+            # serializer (which expects strings, not raw bytes, for image
+            # content in the Bedrock/Anthropic multimodal format).
+            import base64 as _b64
+
+            png_b64 = _b64.b64encode(png_bytes).decode("ascii")
+
             # summary stats so render_all can flag empty-looking frames
             # without decoding the PNG a second time.
             import numpy as _np
@@ -576,7 +592,7 @@ class RenderingMixin:
                 "status": "success",
                 "content": [
                     {"text": f"📸 {w}x{h} from '{label}' at t={self._world.sim_time:.3f}s"},
-                    {"image": {"format": "png", "source": {"bytes": png_bytes}}},
+                    {"image": {"format": "png", "source": {"bytes": png_b64}}},
                     {"json": {"pixel_variance": pixel_var, "pixel_mean": pixel_mean, "camera": label}},
                 ],
             }

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -257,24 +257,50 @@ class MuJoCoSimEngine(
         with self._lock:
             return self._get_sim_observation(robot_name, skip_images=skip_images)
 
-    def send_action(self, action: dict[str, Any], robot_name: str | None = None, n_substeps: int = 1) -> None:
+    def send_action(self, action: dict[str, Any], robot_name: str | None = None, n_substeps: int = 1) -> dict[str, Any]:
         """Apply action to simulation (Robot ABC compatible).
 
         Thread-safety: acquires self._lock around ctrl writes + mj_step,
         as documented in base.py's SimEngine contract. Concurrent calls
         from the agent's dispatch thread and a PolicyRunner worker are
         serialized here.
+
+        Returns:
+            Dict with ``status`` ("success" or "error") and ``content``.
+            When some action keys could not be resolved to actuators/joints,
+            the ``content`` list includes a ``json`` block with an
+            ``unresolved_keys`` list (and ``applied``) so callers can
+            self-correct instead of silently losing commands.
         """
         if self._world is None or self._world._model is None:
-            return
+            return {"status": "error", "content": [{"text": "No world. Call create_world first."}]}
         if robot_name is None:
             if not self._world.robots:
-                return
+                return {"status": "error", "content": [{"text": "No robots in the world."}]}
             robot_name = next(iter(self._world.robots))
         if robot_name not in self._world.robots:
-            return
+            return {"status": "error", "content": [{"text": f"Robot '{robot_name}' not found."}]}
         with self._lock:
+            self._unresolved_action_keys: list[str] = []
             self._apply_sim_action(robot_name, action, n_substeps=n_substeps)
+            unresolved = self._unresolved_action_keys
+        applied = [k for k in action if k not in unresolved]
+        if unresolved:
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            f"Action partially applied: keys {unresolved} could not be "
+                            f"resolved to actuators or joints on '{robot_name}'. "
+                            f"Applied: {applied}. Use individual joint/actuator names "
+                            f"(e.g. 'shoulder_pan', 'elbow_flex') as dict keys."
+                        )
+                    },
+                    {"json": {"unresolved_keys": unresolved, "applied": applied}},
+                ],
+            }
+        return {"status": "success", "content": [{"text": f"Action applied to '{robot_name}' ({len(applied)} keys)."}]}
 
     def physics_timestep(self) -> float | None:
         """Physics integration timestep (seconds) of the active world.
@@ -755,15 +781,18 @@ class MuJoCoSimEngine(
                 }
         elif not resolved_path and name:
             # deprecated fallback - try registry by instance name.
-            import warnings as _warnings
-
             resolved_path = resolve_model(name)
             if resolved_path:
-                _warnings.warn(
-                    f"add_robot: resolving model via instance name '{name}' is deprecated; "
-                    "pass data_config='<registry-key>' instead.",
-                    DeprecationWarning,
-                    stacklevel=2,
+                logger.info(
+                    "add_robot: resolved model via instance name '%s'. "
+                    "Prefer: add_robot(name='<instance_label>', data_config='%s')",
+                    name,
+                    name,
+                )
+                self._add_robot_deprecation_hint: str | None = (
+                    f"Hint: add_robot(name='{name}') resolved via deprecated "
+                    f"name-as-registry-key fallback. Prefer: "
+                    f"add_robot(name='<instance_label>', data_config='{name}')."
                 )
 
         if not resolved_path:
@@ -855,6 +884,9 @@ class MuJoCoSimEngine(
 
             source = f"data_config='{data_config}'" if data_config else os.path.basename(resolved_path)
             mesh_line = f"\n🌐 Mesh peer: {robot.peer_id}" if robot.peer_id else ""
+            hint = getattr(self, "_add_robot_deprecation_hint", None)
+            self._add_robot_deprecation_hint = None
+            hint_line = f"\n⚠️ {hint}" if hint else ""
             return {
                 "status": "success",
                 "content": [
@@ -868,6 +900,7 @@ class MuJoCoSimEngine(
                             f"📷 Cameras: {list(self._world.cameras.keys())}"
                             f"{mesh_line}\n"
                             f"💡 Run policy: action='run_policy', robot_name='{name}'"
+                            f"{hint_line}"
                         )
                     }
                 ],

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -136,10 +136,11 @@ def _extract_frame_ndarray(render_result: dict) -> np.ndarray | None:
     """Decode the PNG bytes emitted by ``SimEngine.render`` into an ndarray.
 
     ``render()`` returns the image nested inside a content block as
-    ``{"image": {"format": "png", "source": {"bytes": <bytes>}}}``. This
-    helper walks that structure, decodes the PNG, and returns a (H, W, 3|4)
-    numpy array. Returns ``None`` if no image is found - the recorder then
-    skips the frame rather than aborting the rollout.
+    ``{"image": {"format": "png", "source": {"bytes": <str|bytes>}}}``.
+    The ``bytes`` field may contain raw bytes (legacy) or a base64-encoded
+    string (current). This helper walks that structure, decodes the PNG,
+    and returns a (H, W, 3|4) numpy array. Returns ``None`` if no image is
+    found - the recorder then skips the frame rather than aborting the rollout.
     """
     if not isinstance(render_result, dict):
         return None
@@ -157,6 +158,11 @@ def _extract_frame_ndarray(render_result: dict) -> np.ndarray | None:
             png_bytes = base64.b64decode(source["data"])
         if not png_bytes:
             continue
+        # Handle base64-encoded strings (current render() output)
+        if isinstance(png_bytes, str):
+            import base64
+
+            png_bytes = base64.b64decode(png_bytes)
         try:
             import io
 

--- a/tests/simulation/mujoco/test_error_paths.py
+++ b/tests/simulation/mujoco/test_error_paths.py
@@ -347,10 +347,14 @@ def test_send_action_no_world_is_noop():
     from strands_robots.simulation import Simulation
 
     s = Simulation()
-    # Should return None and not raise
-    assert s.send_action({"j": 0.1}) is None
+    # Should return error dict when no world exists
+    result = s.send_action({"j": 0.1})
+    assert result["status"] == "error"
+    assert "No world" in result["content"][0]["text"]
     s.destroy()
 
 
 def test_send_action_unknown_robot_is_noop(ready_sim):
-    assert ready_sim.send_action({"j": 0.1}, robot_name="__ghost__") is None
+    result = ready_sim.send_action({"j": 0.1}, robot_name="__ghost__")
+    assert result["status"] == "error"
+    assert "__ghost__" in result["content"][0]["text"]

--- a/tests/simulation/mujoco/test_load_scene_interaction.py
+++ b/tests/simulation/mujoco/test_load_scene_interaction.py
@@ -366,9 +366,13 @@ def test_load_scene_render_returns_real_geometry_immediately(sim: Simulation, sc
         pytest.skip(f"render unavailable in this environment: {r}")
 
     # Decode the PNG and check column std.
+    import base64 as _b64
+
     image_block = next(c for c in r["content"] if isinstance(c, dict) and "image" in c)
-    png_bytes = image_block["image"]["source"]["bytes"]
-    img = np.asarray(Image.open(io.BytesIO(png_bytes)).convert("RGB"))
+    png_raw = image_block["image"]["source"]["bytes"]
+    if isinstance(png_raw, str):
+        png_raw = _b64.b64decode(png_raw)
+    img = np.asarray(Image.open(io.BytesIO(png_raw)).convert("RGB"))
     col_std = float(img.std(axis=0).mean())
     # Real geometry: col-std typically > 30 for our test scene's
     # mix of plane + colored bodies. Cold-start gradient: col-std ~0.6.

--- a/tests/simulation/mujoco/test_render_after_scene_edit.py
+++ b/tests/simulation/mujoco/test_render_after_scene_edit.py
@@ -39,11 +39,16 @@ def _black_fraction(img: np.ndarray) -> float:
 
 
 def _render_np(sim: Simulation, camera: str, w: int = 240, h: int = 180) -> np.ndarray:
+    import base64
+
     r = sim.render(camera_name=camera, width=w, height=h)
     assert r["status"] == "success", r
     for block in r.get("content", []):
         if "image" in block:
-            return np.asarray(Image.open(BytesIO(block["image"]["source"]["bytes"])).convert("RGB"))
+            raw = block["image"]["source"]["bytes"]
+            if isinstance(raw, str):
+                raw = base64.b64decode(raw)
+            return np.asarray(Image.open(BytesIO(raw)).convert("RGB"))
     raise AssertionError("render returned no image")
 
 

--- a/tests/simulation/mujoco/test_simulation.py
+++ b/tests/simulation/mujoco/test_simulation.py
@@ -382,6 +382,27 @@ class TestRobotManagement:
         # Verify physics advanced
         assert sim_with_robot._world.sim_time > 0
 
+    def test_send_action_unresolved_keys_in_json_content_block(self, sim_with_robot):
+        """Unresolved action keys must surface as a ``json`` content block
+        (not a top-level sibling of ``status``/``content``), so the result
+        conforms to the Strands tool-result schema and agents can read the
+        structured payload alongside the human-readable ``text`` block."""
+        result = sim_with_robot.send_action(
+            {"shoulder_pan_act": 0.3, "nonexistent_joint": 1.0},
+            robot_name="arm1",
+        )
+        assert result["status"] == "error"
+        # Must NOT leak the key at the top level.
+        assert "unresolved_keys" not in result
+        # Find the json content block.
+        json_blocks = [c["json"] for c in result["content"] if "json" in c]
+        assert len(json_blocks) == 1, f"expected one json block, got {result['content']}"
+        payload = json_blocks[0]
+        assert payload["unresolved_keys"] == ["nonexistent_joint"]
+        assert "shoulder_pan_act" in payload["applied"]
+        # A human-readable text block must still be present.
+        assert any("text" in c for c in result["content"])
+
 
 # Camera Management
 

--- a/tests/simulation/test_ax2_describe_discovery.py
+++ b/tests/simulation/test_ax2_describe_discovery.py
@@ -92,8 +92,8 @@ def _make_minimal_engine():
             action: dict[str, Any],
             robot_name: str | None = None,
             n_substeps: int = 1,
-        ) -> None:
-            pass
+        ) -> dict[str, Any]:
+            return {}
 
         def render(
             self,

--- a/tests/simulation/test_foundation.py
+++ b/tests/simulation/test_foundation.py
@@ -93,8 +93,10 @@ def _make_dummy_engine_class() -> type[SimEngine]:
         def get_observation(self, robot_name: str | None = None, *, skip_images: bool = False) -> dict[str, Any]:
             return {}
 
-        def send_action(self, action: dict[str, Any], robot_name: str | None = None, n_substeps: int = 1) -> None:
-            return None
+        def send_action(
+            self, action: dict[str, Any], robot_name: str | None = None, n_substeps: int = 1
+        ) -> dict[str, Any]:
+            return {"status": "success", "content": [{"text": "ok"}]}
 
         def render(
             self, camera_name: str = "default", width: int | None = None, height: int | None = None


### PR DESCRIPTION
Four API ergonomics improvements found while testing the simulation tool interface end-to-end.

## Changes

### 1. `send_action` returns a structured response (High impact)

**Problem**: `send_action` returned `None`, so callers had no way to detect when action keys were silently dropped. An action like `{"joint_positions": [...]}` would succeed (status-wise) but apply nothing because the key doesn't match any actuator or joint name.

**Fix**: Returns `{"status": "success"|"error", "content": [...]}` like every other dispatched action. When keys can't be resolved, the response includes `unresolved_keys` and guidance on correct key naming.

### 2. `add_robot` deprecation surfaced in response (Low impact)

**Problem**: `add_robot(name="so101")` (without `data_config=`) triggered a `DeprecationWarning` on stderr that tool callers never see.

**Fix**: Replaced with `logger.info` and the correct calling convention is appended to the success response text.

### 3. `render()` base64-encodes image bytes (Medium impact)

**Problem**: `render()` returned raw `bytes` in the image content block. The tool-response serializer expects strings for multimodal content, causing the image to arrive as empty/truncated at the caller.

**Fix**: PNG bytes are base64-encoded before returning. `_extract_frame_ndarray` now handles both raw bytes (backward compat) and base64 strings.

### 4. `get_robot` exported from top-level `strands_robots` (Medium impact)

**Problem**: `list_robots` was lazy-exported from the package root but its companion `get_robot` was not. Users had to know the internal `strands_robots.registry` path.

**Fix**: Added `get_robot` to `_LAZY_IMPORTS` and `__all__`. Natural discovery: `strands_robots.list_robots()` -> pick one -> `strands_robots.get_robot(name)`.

## Testing

- All lint passes (`ruff check`, `ruff format --check`, `mypy`)
- 3692 tests pass (aarch64, MuJoCo EGL headless)
- Updated tests for the new `send_action` return type and base64 image format
- Pre-existing failures (libtorchcodec unavailable, video camera validation) unchanged
