### PR TITLE
chore: replace em-dashes with hyphens across codebase

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  # Python dependencies — heavy ML stack pulls in long transitive trees.
+  # Python dependencies - heavy ML stack pulls in long transitive trees.
   # Grouped so the torch / lerobot / transformers cluster doesn't generate
   # a separate PR per package.
   - package-ecosystem: pip
@@ -27,7 +27,7 @@ updates:
           - "mypy"
           - "pytest*"
 
-  # GitHub Actions — keeps SHA pins fresh automatically. Without this entry,
+  # GitHub Actions - keeps SHA pins fresh automatically. Without this entry,
   # SHA pinning becomes manual maintenance. With it, every action update
   # arrives as a pre-pinned PR.
   - package-ecosystem: github-actions

--- a/.github/workflows/llm-input-safety.yml
+++ b/.github/workflows/llm-input-safety.yml
@@ -39,13 +39,13 @@ jobs:
             strands_robots/mesh/ 2>/dev/null || true)
 
           if [ -n "$MATCHES" ]; then
-            echo "::warning::Found subprocess call(s) with f-string interpolation in agent-callable code. Verify inputs are validated via an allowlist or regex before interpolation — see AGENTS.md PR #85/#90 review learnings."
+            echo "::warning::Found subprocess call(s) with f-string interpolation in agent-callable code. Verify inputs are validated via an allowlist or regex before interpolation - see AGENTS.md PR #85/#90 review learnings."
             echo ""
             echo "Locations:"
             echo "$MATCHES" | while IFS= read -r line; do
               file=$(echo "$line" | cut -d: -f1)
               lineno=$(echo "$line" | cut -d: -f2)
-              echo "::warning file=${file},line=${lineno}::subprocess + f-string — confirm LLM input is validated"
+              echo "::warning file=${file},line=${lineno}::subprocess + f-string - confirm LLM input is validated"
             done
           fi
 
@@ -54,7 +54,7 @@ jobs:
           set +e
 
           # MJCF/XML built via f-string or % formatting that includes a name-like
-          # variable. Heuristic — not exhaustive. Match the patterns surfaced
+          # variable. Heuristic - not exhaustive. Match the patterns surfaced
           # in PR #85 review.
           MATCHES=$(grep -rnE \
             '(\.format\([^)]*name|f["\047]<[a-z]+[^"]*\{[a-z_]*name)' \
@@ -62,11 +62,11 @@ jobs:
             strands_robots/simulation/ 2>/dev/null || true)
 
           if [ -n "$MATCHES" ]; then
-            echo "::warning::Found string interpolation of a name-like variable into XML/MJCF. Validate against ^[a-zA-Z0-9_-]+$ before interpolation — see AGENTS.md PR #85 review learning on sanitizing user inputs into XML."
+            echo "::warning::Found string interpolation of a name-like variable into XML/MJCF. Validate against ^[a-zA-Z0-9_-]+$ before interpolation - see AGENTS.md PR #85 review learning on sanitizing user inputs into XML."
             echo "$MATCHES" | while IFS= read -r line; do
               file=$(echo "$line" | cut -d: -f1)
               lineno=$(echo "$line" | cut -d: -f2)
-              echo "::warning file=${file},line=${lineno}::name-like variable interpolated into XML — confirm sanitization"
+              echo "::warning file=${file},line=${lineno}::name-like variable interpolated into XML - confirm sanitization"
             done
           fi
 
@@ -74,4 +74,4 @@ jobs:
         # This workflow does not fail PRs. Its purpose is reviewer attention
         # via inline annotations. The check itself always succeeds so it
         # appears green in the PR status list.
-        run: echo "LLM input safety scan complete — see annotations (if any)"
+        run: echo "LLM input safety scan complete - see annotations (if any)"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,13 +143,13 @@ Corrections from code review that apply to all future contributions:
 Corrections from code review that apply to all future contributions:
 
 ### Resource Cleanup on Partial Failure
-- **Always destroy on failure** - If `create_world()` succeeds but `add_robot()` fails, you MUST call `sim.destroy()` before raising. The `Simulation` object owns a `ThreadPoolExecutor`, MuJoCo world, and temp directory — leaking these is silent damage.
+- **Always destroy on failure** - If `create_world()` succeeds but `add_robot()` fails, you MUST call `sim.destroy()` before raising. The `Simulation` object owns a `ThreadPoolExecutor`, MuJoCo world, and temp directory - leaking these is silent damage.
 - **Pattern**: every `_dispatch_action(...)` call that could mutate persistent state needs `if result["status"] == "error": sim.destroy(); raise RuntimeError(...)`.
 - **Don't discard return values** - If a step returns `{"status": ...}`, check it. The compiler won't catch a silently-ignored failure.
 
 ### Exception Clauses Must Be Narrow
 - **`except Exception` is forbidden** for non-recovery code paths. Use the smallest superset of expected exception types.
-- **`except (ImportError, Exception)` is a bug** — `Exception` is a superclass of `ImportError`, so the tuple collapses to `except Exception`. Lint/review will catch this; don't write it.
+- **`except (ImportError, Exception)` is a bug** - `Exception` is a superclass of `ImportError`, so the tuple collapses to `except Exception`. Lint/review will catch this; don't write it.
 - **USB / hardware probing** - use `except (ImportError, OSError)`. `PermissionError` is an `OSError`, `FileNotFoundError` is an `OSError`, etc.
 
 ### Module-Level Side Effects
@@ -200,27 +200,27 @@ Corrections from code review that apply to all future contributions:
 Corrections from code review that apply to all future contributions:
 
 ### LLM Input Safety
-- **Validate before subprocess interpolation** — every parameter on an agent-callable
+- **Validate before subprocess interpolation** - every parameter on an agent-callable
   tool (`@tool` decorated function, `AgentTool.stream` dispatch handler) that flows
   into `subprocess.run`, `subprocess.Popen`, MJCF / XML interpolation, or filesystem
   path construction MUST be validated up front via regex allowlist, enum match, or
-  range check. Argv-style subprocess does not exempt you — defense-in-depth.
-- **Centralise validation in one function** — pattern: a `validate_inputs(...)` helper
+  range check. Argv-style subprocess does not exempt you - defense-in-depth.
+- **Centralise validation in one function** - pattern: a `validate_inputs(...)` helper
   at the top of the tool module that takes every user-supplied param as a keyword arg
   and raises `ValueError` with a clear message on any rejection. Single entry-point
   is independently testable. PR #90's `gr00t_inference.validate_inputs()` is the
   canonical example.
-- **Allowlist enumerable values** — `data_config`, `embodiment_tag`, dtype strings,
+- **Allowlist enumerable values** - `data_config`, `embodiment_tag`, dtype strings,
   container names: all match `^[a-z][a-z0-9_]+$` or an explicit `{"fp16", "fp8", ...}`
   set. Never accept arbitrary strings into enumerable surfaces.
-- **Reject shell metacharacters in paths** — `;`, `|`, `$`, backticks, `>`, `<`,
+- **Reject shell metacharacters in paths** - `;`, `|`, `$`, backticks, `>`, `<`,
   `\n`, `\r`, `\x00`. Also reject `..` path traversal components. Apply even when
   using argv-style subprocess.
 - **Bind to `127.0.0.1` by default**, not `0.0.0.0`. Users explicitly opt into
   network exposure.
 
 ### CI Security Baseline
-- **CodeQL findings are not PR-blocking but ARE actionable** — check the Security
+- **CodeQL findings are not PR-blocking but ARE actionable** - check the Security
   tab after pushing to a branch. False-positives get dismissed with a reason;
   real findings get fixed.
 - **Dependency Review hard-fails on high/critical CVEs in new deps.** If a PR
@@ -236,7 +236,7 @@ Corrections from code review that apply to all future contributions:
   with the version tag preserved as a trailing comment: `uses: actions/checkout@<sha>  # v4.2.2`.
 - **Dependabot keeps these fresh** via the `github-actions` ecosystem entry.
   Do not manually bump tags; merge the Dependabot PR.
-- **Especially `pypa/gh-action-pypi-publish`** — it uses a moving `release/v1`
+- **Especially `pypa/gh-action-pypi-publish`** - it uses a moving `release/v1`
   branch, which is exactly the supply-chain pattern that the `tj-actions/changed-files`
   incident exploited. This pin is non-negotiable.
 
@@ -266,7 +266,7 @@ apply to all future work on `strands_robots/mesh/{core,audit,security}.py`.
   window and a hot path never re-parses the environment per call.
 - **Lockout-engagement is decoupled from the per-issuer cache cap.** A bounded
   replay cache that is full (flood, or a tiny operator override) must still let a
-  legitimate peer ENGAGE a lockout — the cap bounds memory, not safety. Pin both
+  legitimate peer ENGAGE a lockout - the cap bounds memory, not safety. Pin both
   directions: `*_per_issuer_cap_exceeded_still_engages_lockout` and
   `*_low_cache_max_does_not_deny_safety`.
 - **Domain-tag trust-boundary cache keys.** A TLS-bound `wire_zid` and an
@@ -302,7 +302,7 @@ From the `robot_mesh` human-in-the-loop review trail (#227). Apply to the
 ### Audit completeness
 - **Audit read-only/observation actions too, not just actuation.** `peers`,
   `status`, `inbox`, and `unsubscribe` each leave a `_audit_tool_action(...)` row
-  so the audit log is a complete record of agent mesh access — operators get the
+  so the audit log is a complete record of agent mesh access - operators get the
   "agent read N frames from sub X at time T" trail that raw telemetry access
   otherwise lacks.
 
@@ -311,4 +311,4 @@ From the `robot_mesh` human-in-the-loop review trail (#227). Apply to the
   recorded only after approval is granted (or atomically via
   `_rate_limit_check_and_record` on the post-approval path). Otherwise nuisance
   prompts an operator declines would lock the agent out of issuing a genuine
-  `emergency_stop` — the inverse of the intended safety property.
+  `emergency_stop` - the inverse of the intended safety property.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,7 +205,7 @@ or pass ``presign_ttl=3600`` to ``CameraOffloader(...)`` / ``enable_for_mesh(...
 Applies to ``strands_robots.mesh.iot.provision`` and
 ``strands_robots.mesh.iot.camera_offload``:
 
-- **CA pinning** — ``AmazonRootCA1.pem`` is verified against an
+- **CA pinning** - ``AmazonRootCA1.pem`` is verified against an
   in-tree pin tuple (``_AMAZON_ROOT_CA1_PINS``) at download AND on
   every on-disk re-use. Defeats CA-substitution MITM. Operators can
   add additional pins via ``STRANDS_MESH_CA_PINS`` (comma-separated
@@ -219,7 +219,7 @@ Applies to ``strands_robots.mesh.iot.provision`` and
   ``\n``/``\r``/``\t``. Pre-existing AWS IoT Things containing ``:``
   must be renamed (we deliberately reject ``:`` due to NTFS / classic
   Mac filesystem semantics).
-- **IoT policy scope** — robot/operator policies use explicit
+- **IoT policy scope** - robot/operator policies use explicit
   per-thing topic prefixes; no ``Resource: '*'`` on Receive.
   ``OperatorPublishToFleet``'s ``*/cmd`` wildcard is documented and
   pinned as a deliberate design choice (``test_publish_to_fleet_wildcard_is_deliberate``).

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 
 `strands-robots` gives a [Strands Agent](https://github.com/strands-agents/harness-sdk)
 hands. One `Robot()` call returns either a **MuJoCo simulation** (default, no GPU,
-no hardware) or a **real hardware robot** — both drivable in natural language,
+no hardware) or a **real hardware robot** - both drivable in natural language,
 both auto-joined to a peer-to-peer **mesh** so fleets coordinate out of the box.
 
 ```python
@@ -46,7 +46,7 @@ agent = Agent(tools=[robot])
 agent("Pick up the red cube")
 ```
 
-Swap to physical hardware with one kwarg — the agent code is identical:
+Swap to physical hardware with one kwarg - the agent code is identical:
 
 ```python
 robot = Robot("so100", mode="real", port="/dev/ttyACM0")
@@ -55,7 +55,7 @@ robot = Robot("so100", mode="real", port="/dev/ttyACM0")
 ## Why strands-robots
 
 - **Sim-first, safe by default.** `Robot("so100")` spins up a MuJoCo world. You
-  never accidentally drive real servos — `mode="real"` is an explicit opt-in.
+  never accidentally drive real servos - `mode="real"` is an explicit opt-in.
 - **50+ robots, 8 categories.** Arms, humanoids, quadrupeds, hands, drones,
   bimanual rigs - resolved from a single registry with auto-download of assets.
 - **Any policy.** VLA models (NVIDIA GR00T, LeRobot ACT/Pi0/SmolVLA/Diffusion),
@@ -63,7 +63,7 @@ robot = Robot("so100", mode="real", port="/dev/ttyACM0")
 - **Mesh networking built in.** Every robot is a Zenoh peer. `tell()` another
   robot what to do; broadcast an E-STOP; bridge to AWS IoT Core for fleets.
 - **60+ action simulation tool.** World building, physics, rendering,
-  domain randomization, and LeRobotDataset recording — all agent-callable.
+  domain randomization, and LeRobotDataset recording - all agent-callable.
 - **One mental model.** Sim and hardware share the same policy interface,
   the same mesh, and the same natural-language control surface.
 
@@ -107,7 +107,7 @@ extras you need:
 | `groot-service` | pyzmq, msgpack | NVIDIA GR00T inference client |
 | `mesh` | eclipse-zenoh, json5 | Peer-to-peer robot mesh |
 | `mesh-iot` | awsiotsdk, awscrt, boto3 | AWS IoT Core mesh transport for fleets |
-| `device-connect` | device-connect-edge, device-connect-agent-tools | Device-aware networking — discovery, RPC, events, safety (falls back to the built-in mesh if absent) |
+| `device-connect` | device-connect-edge, device-connect-agent-tools | Device-aware networking - discovery, RPC, events, safety (falls back to the built-in mesh if absent) |
 | `benchmark-libero` | libero | LIBERO benchmark evaluation |
 | `all` | everything above | Kitchen sink |
 
@@ -143,14 +143,14 @@ agent = Agent(tools=[robot])
 agent("Wave the arm using the mock policy for 200 steps, then render a top-down view")
 ```
 
-`Robot("so100")` returns a `Simulation` instance — the full 64-action
+`Robot("so100")` returns a `Simulation` instance - the full 64-action
 simulation AgentTool. Drive it in natural language through an `Agent`, call its
 methods directly (`robot.render(camera_name="topdown")`), or dispatch an action
 by calling it (`robot(action="render", camera_name="topdown")`). See
 [Simulation](#simulation-mujoco).
 
 > **Note:** `Robot("so100")` already creates the world **and** adds the robot
-> for you. Do **not** call `create_world()` again on the returned instance —
+> for you. Do **not** call `create_world()` again on the returned instance -
 > it will error with *"World already exists."* The `create_world()` /
 > `add_robot()` sequence shown in [Simulation (MuJoCo)](#simulation-mujoco) is
 > for the low-level `Simulation(...)` constructor, which starts empty.
@@ -190,13 +190,13 @@ agent("Use so101 to pick up the red block with the GR00T policy on port 8000")
 ```python
 from strands_robots import create_policy
 
-# Direct HuggingFace inference — ACT, Pi0, SmolVLA, Diffusion, ...
+# Direct HuggingFace inference - ACT, Pi0, SmolVLA, Diffusion, ...
 policy = create_policy("lerobot/act_aloha_sim_transfer_cube_human")
 ```
 
 ## The `Robot()` factory
 
-`Robot()` is a factory, not a wrapper — you get the real backend instance back
+`Robot()` is a factory, not a wrapper - you get the real backend instance back
 with all its methods.
 
 ```python
@@ -219,7 +219,7 @@ Robot("my_arm", urdf_path="arm.xml") # bring your own MJCF/URDF
 
 Safety/validation rules:
 - **Defaults to sim.** Real hardware is always an explicit `mode="real"`.
-- **`cameras=` is rejected in sim mode** — add sim cameras via the `add_camera`
+- **`cameras=` is rejected in sim mode** - add sim cameras via the `add_camera`
   action after creation.
 - **Unknown robot names raise `ValueError`** unless you pass `urdf_path=`.
 - **`STRANDS_ROBOT_MODE`** overrides detection; a typo'd value logs a warning
@@ -256,7 +256,7 @@ AgentTool returning `{"status", "content"}`.
 
 | Tool | Purpose |
 |------|---------|
-| `Robot(...)` | Universal robot — sim or hardware, async control |
+| `Robot(...)` | Universal robot - sim or hardware, async control |
 | `gr00t_inference` | Manage NVIDIA GR00T inference services (Docker lifecycle) |
 | `lerobot_camera` | OpenCV / RealSense camera discovery, capture, record |
 | `lerobot_calibrate` | List, view, back up, restore LeRobot calibrations |
@@ -274,7 +274,7 @@ AgentTool returning `{"status", "content"}`.
 | `start` | `instruction`, `policy_port`, `duration` | Non-blocking async start |
 | `status` | - | Current task status |
 | `stop` | - | Interrupt running task (emergency stop) |
-In sim mode the same tool exposes the 64 Simulation actions — see Simulation (MuJoCo).
+In sim mode the same tool exposes the 64 Simulation actions - see Simulation (MuJoCo).
 </details>
 
 <details>
@@ -308,16 +308,16 @@ agent.tool.gr00t_inference(
 <details>
 <summary><b>Camera / serial / pose / teleop tool actions</b></summary>
 
-**Camera** — `discover`, `capture`, `capture_batch`, `record`, `preview`, `test`
-**Serial** — `list_ports`, `feetech_position`, `feetech_ping`, `send`, `monitor`
-**Pose** — `store_pose`, `load_pose`, `list_poses`, `move_motor`, `incremental_move`, `reset_to_home`
-**Teleop** — `start`, `stop`, `list`, `replay`
+**Camera** - `discover`, `capture`, `capture_batch`, `record`, `preview`, `test`
+**Serial** - `list_ports`, `feetech_position`, `feetech_ping`, `send`, `monitor`
+**Pose** - `store_pose`, `load_pose`, `list_poses`, `move_motor`, `incremental_move`, `reset_to_home`
+**Teleop** - `start`, `stop`, `list`, `replay`
 
 </details>
 
 ## Policy providers
 
-All policies implement one ABC — `async get_actions(observation, instruction, **kwargs)`.
+All policies implement one ABC - `async get_actions(observation, instruction, **kwargs)`.
 The interface is deliberately agnostic about *how* actions are produced, so it
 fits both VLA models and classical controllers.
 
@@ -387,11 +387,11 @@ Pick the config matching your robot's camera + state layout; pass it as
 > `trust_remote_code=True` (arbitrary code execution). You must opt in with
 > `export STRANDS_TRUST_REMOTE_CODE=1`. Only load models you trust.
 
-### Cosmos 3 (NVIDIA omnimodal VLA — service mode)
+### Cosmos 3 (NVIDIA omnimodal VLA - service mode)
 
 [`nvidia/Cosmos3-Nano-Policy-DROID`](https://huggingface.co/nvidia/Cosmos3-Nano-Policy-DROID)
 served by the Cosmos Framework RoboLab WebSocket policy server. The policy
-client is **self-contained** — it speaks the server's msgpack+NumPy wire
+client is **self-contained** - it speaks the server's msgpack+NumPy wire
 protocol directly via `websockets` + a vendored numpy packer (no
 `openpi-client` dependency, no `numpy<2` pin), so it composes cleanly with
 `lerobot` for dataset recording in the same env.
@@ -406,7 +406,7 @@ curl http://localhost:8000/healthz   # -> 200 when ready (~4 min cold)
 ```
 
 **2. Install the client** (the `cosmos3-service` extra ships only `msgpack`
-+ `websockets` — numpy-version agnostic):
++ `websockets` - numpy-version agnostic):
 
 ```bash
 uv pip install -e '.[sim-mujoco]'
@@ -425,7 +425,7 @@ chunk = policy.get_actions_sync(observation, "pick up the cube")
 # chunk == [{"joint_0": .., ..., "gripper": ..}, ...]  (one dict per timestep)
 ```
 
-**4. Roll out in MuJoCo** — the `droid` embodiment drives a Franka/DROID-class
+**4. Roll out in MuJoCo** - the `droid` embodiment drives a Franka/DROID-class
 arm, so use the `franka` (or `panda`) sim asset:
 
 ```bash
@@ -439,7 +439,7 @@ command to start it.
 ### Non-VLA policies (motion planners, MPC, scripted)
 
 The same interface fits cuRobo, MoveIt2, OMPL, MPC, and pure-IK / scripted
-trajectories — anything mapping `(observation, goal)` to joint targets.
+trajectories - anything mapping `(observation, goal)` to joint targets.
 Non-VLA providers set `requires_images = False` (skip camera rendering) and
 read their goal from **well-known `**kwargs` keys** instead of parsing the
 instruction string:
@@ -496,7 +496,7 @@ policy = create_policy("reach")
 
 ## Simulation (MuJoCo)
 
-`Robot("so100")` (sim mode) returns a `Simulation` — a MuJoCo-backed AgentTool
+`Robot("so100")` (sim mode) returns a `Simulation` - a MuJoCo-backed AgentTool
 exposing **50+ actions** for world composition, physics, rendering, policy
 execution, and dataset recording. Build it directly when you want full control:
 
@@ -576,7 +576,7 @@ frame = sim.render(camera_name="topdown")   # {status, content:[text, image]}
 **Self-healing:** unknown parameters are rejected with *"Unknown parameter X
 for action Y. Valid: [...]"*, missing required params produce *"Action X
 requires parameter Y."*, and vectors/dtypes are validated before MuJoCo sees
-them — so the agent learns the contract without crashing the process.
+them - so the agent learns the contract without crashing the process.
 
 ## Mesh networking
 
@@ -589,7 +589,7 @@ from strands_robots import Robot
 
 a = Robot("so100")              # auto-joins the mesh
 b = Robot("so100")              # second peer (another process)
-print(a.mesh.peers)             # list[dict] — discovers b
+print(a.mesh.peers)             # list[dict] - discovers b
 print(a.mesh.peers_by_id[b.peer_id])   # dict[peer_id -> info] for O(1) lookup
 info = a.mesh.get_peer(b.peer_id)      # None-safe single lookup
 
@@ -618,7 +618,7 @@ Expose the mesh to an agent with the `robot_mesh` tool (`peers`, `status`,
 `inbox`). Disable globally with `STRANDS_MESH=false` or per-robot with
 `Robot("so100", mesh=False)`. Install with `uv pip install "strands-robots[mesh]"`.
 
-For frictionless single-machine experiments, set `STRANDS_MESH_LOCAL_DEV=1` —
+For frictionless single-machine experiments, set `STRANDS_MESH_LOCAL_DEV=1` -
 one env var that runs the mesh without mTLS/ACL on localhost. It defaults the
 auth mode to `none` **and** satisfies the insecure-acknowledgement second
 factor by itself, so you don't also need `STRANDS_MESH_I_KNOW_THIS_IS_INSECURE=1`.
@@ -700,7 +700,7 @@ Clear with `rm -rf ~/.strands_robots/assets/`; relocate with
 ## Benchmarks
 
 `strands-robots` ships a [LIBERO](https://github.com/Lifelong-Robot-Learning/LIBERO)
-benchmark integration on the MuJoCo backend — byte-equivalent to upstream
+benchmark integration on the MuJoCo backend - byte-equivalent to upstream
 LIBERO at the model level, reaching `success_rate >= 0.92` on libero-10/SCENE5.
 Register declarative benchmarks from file and evaluate policies via the
 `list_benchmarks`, `register_benchmark_from_file`, and `evaluate_benchmark`
@@ -712,7 +712,7 @@ simulation actions. Install with `uv pip install "strands-robots[benchmark-liber
 strands_robots/
 ├── __init__.py            # Lazy-loaded public API (Robot, Simulation, policies)
 ├── robot.py               # Robot() factory (sim/real/auto dispatch)
-├── hardware_robot.py      # HardwareRobot — async LeRobot control
+├── hardware_robot.py      # HardwareRobot - async LeRobot control
 ├── policies/
 │   ├── base.py            # Policy ABC
 │   ├── factory.py         # create_policy() + runtime registration
@@ -756,7 +756,7 @@ validation controls in the [Configuration](#configuration) matrix.
 ## Contributing
 
 Issues and PRs welcome. Track work on the
-[Strands Labs — Robots project board](https://github.com/orgs/strands-labs/projects/2);
+[Strands Labs - Robots project board](https://github.com/orgs/strands-labs/projects/2);
 it is the source of truth for roadmap and follow-ups.
 
 - [GitHub Issues](https://github.com/strands-labs/robots/issues)

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -4,7 +4,7 @@ description: Hand a Robot() to a Strands Agent and control it with plain English
 
 # AI agents
 
-A `Robot()` is a Strands tool. Hand it to an `Agent` and it drives the robot for you — picking actions from natural language.
+A `Robot()` is a Strands tool. Hand it to an `Agent` and it drives the robot for you - picking actions from natural language.
 
 ```python
 from strands import Agent
@@ -65,11 +65,11 @@ The agent sees the same tool spec in both modes; only the implementation changes
 | "Try 10 episodes, report success" | `eval_policy(robot_name='so100', n_episodes=10)` |
 | "Record a session" | `start_recording` → `run_policy` → `stop_recording` |
 
-Inspect the full spec: `print(robot.tool_spec)` — JSON schema with all 60+ actions.
+Inspect the full spec: `print(robot.tool_spec)` - JSON schema with all 60+ actions.
 
 ## See also
 
-- [Multi-robot mesh](mesh.md) — the agent coordinates multiple robots.
-- [Hardware tools](hardware/tools.md) — the `@tool` helpers.
-- [Simulation overview](simulation/overview.md) — every action the agent can call.
-- [Strands Agents documentation](https://strandsagents.com/) — provider setup, advanced patterns.
+- [Multi-robot mesh](mesh.md) - the agent coordinates multiple robots.
+- [Hardware tools](hardware/tools.md) - the `@tool` helpers.
+- [Simulation overview](simulation/overview.md) - every action the agent can call.
+- [Strands Agents documentation](https://strandsagents.com/) - provider setup, advanced patterns.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,5 +1,5 @@
 ---
-description: Every public symbol grouped by module — Robot, registry, simulation, policies, tools, dataset_recorder, mesh.
+description: Every public symbol grouped by module - Robot, registry, simulation, policies, tools, dataset_recorder, mesh.
 ---
 
 # API reference
@@ -63,7 +63,7 @@ from strands_robots.simulation.base import SimEngine
 
 | Symbol | What |
 |--------|------|
-| `Simulation` | MuJoCo backend — 60+ agent actions. |
+| `Simulation` | MuJoCo backend - 60+ agent actions. |
 | `SimWorld`, `SimRobot`, `SimObject`, `SimCamera` | Shared dataclasses. |
 | `create_simulation(backend='mujoco')` | Factory for non-`Robot()` construction. |
 | `list_backends()` / `register_backend(name, cls)` | Backend registry. |
@@ -193,6 +193,6 @@ LIBERO task suites, BDDL parser. Install: `uv pip install "strands-robots[benchm
 
 ## See also
 
-- [Architecture](architecture.md) — module map + ABC contracts.
-- [Robot factory](getting-started/robot-factory.md) — full factory signature.
-- [Quickstart](getting-started/quickstart.md) — concept walkthroughs.
+- [Architecture](architecture.md) - module map + ABC contracts.
+- [Robot factory](getting-started/robot-factory.md) - full factory signature.
+- [Quickstart](getting-started/quickstart.md) - concept walkthroughs.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -75,7 +75,7 @@ graph TB
 |--------|--------------|-----------|
 | `strands_robots/robot.py` | Factory `Robot(name, mode, backend, **kwargs)`. Name resolution, sim/real dispatch, mesh attach. | `Robot()` function |
 | `strands_robots/registry/` | 68 robots, 106 aliases, 8 categories. `robots.json` is source of truth. | `list_robots()`, `resolve_name()`, `get_robot()` |
-| `strands_robots/simulation/` | MuJoCo `AgentTool` — 60+ actions. | `Simulation`, `SimWorld`, `SimRobot`, `SimObject`, `SimCamera` |
+| `strands_robots/simulation/` | MuJoCo `AgentTool` - 60+ actions. | `Simulation`, `SimWorld`, `SimRobot`, `SimObject`, `SimCamera` |
 | `strands_robots/simulation/base.py` | Backend ABC for future Isaac/Newton backends. | `SimEngine` |
 | `strands_robots/hardware_robot.py` | Real-servo path. Async task execution + status. | `Robot` (class), `TaskStatus`, `RobotTaskState` |
 | `strands_robots/policies/` | ABC + 4 providers + factory + JSON registry. | `Policy`, `create_policy()` |
@@ -85,11 +85,11 @@ graph TB
 
 ## ABCs
 
-**`Policy`** — `get_actions(observation_dict, instruction) -> list[dict]` (async), `set_robot_state_keys(keys)`, `provider_name` property, `requires_images` property (default `True`), `reset(seed)` (default no-op). Four implementations: `MockPolicy`, `Gr00tPolicy`, `LerobotLocalPolicy`, `Cosmos3Policy`.
+**`Policy`** - `get_actions(observation_dict, instruction) -> list[dict]` (async), `set_robot_state_keys(keys)`, `provider_name` property, `requires_images` property (default `True`), `reset(seed)` (default no-op). Four implementations: `MockPolicy`, `Gr00tPolicy`, `LerobotLocalPolicy`, `Cosmos3Policy`.
 
-**`SimEngine`** — `create_world()`, `step()`, 30+ abstract actions. Today: MuJoCo CPU. Roadmap: Isaac Sim, Newton.
+**`SimEngine`** - `create_world()`, `step()`, 30+ abstract actions. Today: MuJoCo CPU. Roadmap: Isaac Sim, Newton.
 
-**Strands `AgentTool`** — `Simulation` and `HardwareRobot` are both `AgentTool` subclasses. `Agent(tools=[robot])` calls actions through the tool dispatcher.
+**Strands `AgentTool`** - `Simulation` and `HardwareRobot` are both `AgentTool` subclasses. `Agent(tools=[robot])` calls actions through the tool dispatcher.
 
 ## The one rule
 
@@ -109,7 +109,7 @@ graph TB
 
 ## See also
 
-- [Robot factory](getting-started/robot-factory.md) — every `Robot(...)` kwarg.
-- [Custom policies](policies/custom-policies.md) — implement and register.
-- [Simulation overview](simulation/overview.md) — the 60+ action vocabulary.
-- [Contributing](contributing.md) — module conventions.
+- [Robot factory](getting-started/robot-factory.md) - every `Robot(...)` kwarg.
+- [Custom policies](policies/custom-policies.md) - implement and register.
+- [Simulation overview](simulation/overview.md) - the 60+ action vocabulary.
+- [Contributing](contributing.md) - module conventions.

--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -1,4 +1,4 @@
-/* Strands Robots — Minimal with glassmorphic dark mode */
+/* Strands Robots - Minimal with glassmorphic dark mode */
 
 /* ---- Light mode ---- */
 [data-md-color-scheme="default"] {
@@ -25,7 +25,7 @@
     --code-fg: #444;
 }
 
-/* ---- Dark mode — true black + glass ---- */
+/* ---- Dark mode - true black + glass ---- */
 [data-md-color-scheme="slate"] {
     --bg: #0a0a0a;
     --bg-surface: rgba(255, 255, 255, 0.04);
@@ -115,7 +115,7 @@ h1 {
     text-decoration-color: var(--link-underline-hover);
 }
 
-/* ---- Header — glass ---- */
+/* ---- Header - glass ---- */
 .md-header {
     background: var(--header-bg) !important;
     backdrop-filter: var(--glass-blur);
@@ -133,7 +133,7 @@ h1 {
     color: var(--fg) !important;
 }
 
-/* ---- Sidebar — glass ---- */
+/* ---- Sidebar - glass ---- */
 .md-sidebar {
     background: var(--sidebar-bg) !important;
     backdrop-filter: var(--glass-blur);
@@ -154,7 +154,7 @@ h1 {
     font-weight: 600;
 }
 
-/* ---- Code — glass card ---- */
+/* ---- Code - glass card ---- */
 .md-typeset pre {
     background: var(--glass-bg) !important;
     backdrop-filter: var(--glass-blur);
@@ -170,7 +170,7 @@ h1 {
     font-size: 0.85em;
 }
 
-/* ---- Admonitions — glass card ---- */
+/* ---- Admonitions - glass card ---- */
 .md-typeset .admonition,
 .md-typeset details {
     background: var(--glass-bg) !important;
@@ -181,7 +181,7 @@ h1 {
     box-shadow: none !important;
 }
 
-/* ---- Tables — glass ---- */
+/* ---- Tables - glass ---- */
 .md-typeset table:not([class]) {
     background: var(--glass-bg);
     border: 1px solid var(--glass-border);
@@ -207,7 +207,7 @@ h1 {
     color: var(--fg-muted) !important;
 }
 
-/* ---- Buttons — glass ---- */
+/* ---- Buttons - glass ---- */
 .md-button {
     background: var(--glass-bg) !important;
     backdrop-filter: var(--glass-blur);
@@ -223,7 +223,7 @@ h1 {
     background: var(--bg-elevated) !important;
 }
 
-/* ---- Search — glass ---- */
+/* ---- Search - glass ---- */
 .md-search__input {
     background: var(--glass-bg) !important;
     backdrop-filter: var(--glass-blur);
@@ -255,7 +255,7 @@ h1 {
     color: var(--fg);
 }
 
-/* ---- Content tabs — glass ---- */
+/* ---- Content tabs - glass ---- */
 .md-typeset .tabbed-content {
     background: var(--glass-bg);
     border: 1px solid var(--glass-border);
@@ -388,7 +388,7 @@ h1 {
     fill: var(--fg) !important;
 }
 
-/* ---- Mobile nav drawer — dark mode fix ---- */
+/* ---- Mobile nav drawer - dark mode fix ---- */
 [data-md-color-scheme="slate"] .md-nav__title {
     color: var(--fg-heading) !important;
     background: var(--bg) !important;

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,5 +1,5 @@
 ---
-description: How to land a PR — hatch envs, ruff/mypy, lazy-import discipline, JSON registries, test layout.
+description: How to land a PR - hatch envs, ruff/mypy, lazy-import discipline, JSON registries, test layout.
 ---
 
 # Contributing
@@ -27,13 +27,13 @@ CI runs `hatch run test -x --strict-markers`.
 
 ## Rules
 
-**Lazy imports** — heavy modules (`mujoco`, `lerobot`, `torch`, `zenoh`) must not load at top-level. Use PEP 562 `__getattr__`. Enforced by `tests/test_init.py`.
+**Lazy imports** - heavy modules (`mujoco`, `lerobot`, `torch`, `zenoh`) must not load at top-level. Use PEP 562 `__getattr__`. Enforced by `tests/test_init.py`.
 
-**Tests mirror source** — `tests/policies/test_groot.py` mirrors `strands_robots/policies/groot/`. Keep 1:1.
+**Tests mirror source** - `tests/policies/test_groot.py` mirrors `strands_robots/policies/groot/`. Keep 1:1.
 
-**No host paths** — `/Users/...` is CI-blocked. Use `tmp_path`, `~/.cache`, or env vars.
+**No host paths** - `/Users/...` is CI-blocked. Use `tmp_path`, `~/.cache`, or env vars.
 
-**JSON registries** — new robots and policies are JSON edits + tests. No hardcoded lookups in `.py` files.
+**JSON registries** - new robots and policies are JSON edits + tests. No hardcoded lookups in `.py` files.
 
 **Tool errors return, don't raise:**
 ```python
@@ -57,5 +57,5 @@ Releases: `hatch version` + GitHub release. Semver: minor for additive, patch fo
 
 ## See also
 
-- [Architecture](architecture.md) — module conventions.
-- [API reference](api-reference.md) — public symbols.
+- [Architecture](architecture.md) - module conventions.
+- [API reference](api-reference.md) - public symbols.

--- a/docs/examples/overview.md
+++ b/docs/examples/overview.md
@@ -1,5 +1,5 @@
 ---
-description: Runnable example scripts — links to the repo's examples/ directory.
+description: Runnable example scripts - links to the repo's examples/ directory.
 ---
 
 # Examples
@@ -24,6 +24,6 @@ python examples/molmoact2_so101_pickplace.py     # requires hardware
 
 ## See also
 
-- [Quickstart](../getting-started/quickstart.md) — minimal starter.
-- [Cosmos3Policy](../policies/cosmos3.md) — Cosmos 3 details.
-- [LerobotLocalPolicy](../policies/lerobot-local.md) — MolmoAct2 and other local models.
+- [Quickstart](../getting-started/quickstart.md) - minimal starter.
+- [Cosmos3Policy](../policies/cosmos3.md) - Cosmos 3 details.
+- [LerobotLocalPolicy](../policies/lerobot-local.md) - MolmoAct2 and other local models.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,5 +1,5 @@
 ---
-description: Install strands-robots with uv — extras matrix, platform notes, headless rendering.
+description: Install strands-robots with uv - extras matrix, platform notes, headless rendering.
 ---
 
 # Installation
@@ -10,7 +10,7 @@ Requires **Python >= 3.12**. Examples use [`uv`](https://docs.astral.sh/uv/) (`c
 
 | Extra | Pulls in | When you need it |
 |-------|----------|------------------|
-| (none) | core only — Robot factory, registry, lazy imports | Inspect the catalog, write tools |
+| (none) | core only - Robot factory, registry, lazy imports | Inspect the catalog, write tools |
 | `[sim]` | `robot_descriptions` | Sim asset resolution without MuJoCo |
 | `[sim-mujoco]` | `sim` + `mujoco`, `imageio`, `imageio-ffmpeg` | Any `Robot()` with default `mode="sim"` |
 | `[lerobot]` | `lerobot>=0.5.0,<0.6.0` | `LerobotLocalPolicy` + dataset recording |
@@ -76,7 +76,7 @@ This will be unnecessary once lerobot >= 0.5.2 is published to PyPI.
 ## Headless rendering
 
 ```bash
-export MUJOCO_GL=osmesa     # software rendering — Linux
+export MUJOCO_GL=osmesa     # software rendering - Linux
 export MUJOCO_GL=egl        # hardware EGL
 ```
 
@@ -116,6 +116,6 @@ Assets cache under `~/.strands_robots/assets/`.
 
 ## See also
 
-- [Quickstart](quickstart.md) — five minutes after install.
-- [Robot factory](robot-factory.md) — every kwarg `Robot()` accepts.
-- [Troubleshooting](../troubleshooting.md) — install gotchas.
+- [Quickstart](quickstart.md) - five minutes after install.
+- [Robot factory](robot-factory.md) - every kwarg `Robot()` accepts.
+- [Troubleshooting](../troubleshooting.md) - install gotchas.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -50,6 +50,6 @@ agent("Add a red cube and pick it up using the mock policy")
 
 ## See also
 
-- [Policy providers](../policies/overview.md) — GR00T, LeRobot Local, Cosmos 3.
-- [Robot catalog](../robots/index.md) — all 68 robots.
-- [Real hardware](../hardware/robot-control.md) — same code, `mode="real"`.
+- [Policy providers](../policies/overview.md) - GR00T, LeRobot Local, Cosmos 3.
+- [Robot catalog](../robots/index.md) - all 68 robots.
+- [Real hardware](../hardware/robot-control.md) - same code, `mode="real"`.

--- a/docs/getting-started/robot-factory.md
+++ b/docs/getting-started/robot-factory.md
@@ -1,5 +1,5 @@
 ---
-description: Robot(name, mode, backend, urdf_path, cameras, position, data_config, mesh, peer_id, **kwargs) — the full signature with every kwarg explained.
+description: Robot(name, mode, backend, urdf_path, cameras, position, data_config, mesh, peer_id, **kwargs) - the full signature with every kwarg explained.
 ---
 
 # Robot factory
@@ -21,8 +21,8 @@ robot = Robot("so100", mode="auto")  # probes USB, falls back to sim
 | `name` | str | required | Catalog name or alias. Resolved via `registry/robots.json`. |
 | `mode` | str | `"sim"` | `"sim"` / `"real"` / `"auto"`. Overridden by `STRANDS_ROBOT_MODE`. |
 | `backend` | str | `"mujoco"` | Sim backend. Ignored when `mode="real"`. |
-| `urdf_path` | str | `None` | Explicit MJCF/URDF path — bypasses registry. |
-| `cameras` | dict | `None` | Real-hardware camera config. **Rejected in `mode="sim"`** — raises `ValueError`. |
+| `urdf_path` | str | `None` | Explicit MJCF/URDF path - bypasses registry. |
+| `cameras` | dict | `None` | Real-hardware camera config. **Rejected in `mode="sim"`** - raises `ValueError`. |
 | `position` | list | `None` | Robot position `[x, y, z]` in sim world. |
 | `data_config` | str | `None` | GR00T data_config name. |
 | `mesh` | bool | `True` | Auto-join Zenoh mesh. |
@@ -72,6 +72,6 @@ Mesh failure is non-fatal; `.mesh = None` if Zenoh unavailable.
 
 ## See also
 
-- [Robot catalog](../robots/index.md) — 68 catalog names.
-- [Architecture](../architecture.md) — factory in the module map.
-- [Multi-robot mesh](../mesh.md) — mesh peer discovery.
+- [Robot catalog](../robots/index.md) - 68 catalog names.
+- [Architecture](../architecture.md) - factory in the module map.
+- [Multi-robot mesh](../mesh.md) - mesh peer discovery.

--- a/docs/hardware/robot-control.md
+++ b/docs/hardware/robot-control.md
@@ -1,5 +1,5 @@
 ---
-description: HardwareRobot — async task execution, status reporting, the LeRobot bridge.
+description: HardwareRobot - async task execution, status reporting, the LeRobot bridge.
 ---
 
 # Robot control (real hardware)
@@ -58,8 +58,8 @@ robot.cleanup()
 |--------|-----------|-------|
 | `execute` | Yes | `instruction` + `policy_port` |
 | `start` | No | `instruction` + `policy_port` |
-| `status` | — | — |
-| `stop` | — | — |
+| `status` | - | - |
+| `stop` | - | - |
 
 ## Mesh teleop
 
@@ -82,6 +82,6 @@ robot.stop_teleop()   # stop all sessions
 
 ## See also
 
-- [Hardware tools](tools.md) — calibrate / camera / teleop helpers.
-- [Robot factory](../getting-started/robot-factory.md) — every `Robot()` kwarg.
-- [Policy providers](../policies/overview.md) — available policy providers.
+- [Hardware tools](tools.md) - calibrate / camera / teleop helpers.
+- [Robot factory](../getting-started/robot-factory.md) - every `Robot()` kwarg.
+- [Policy providers](../policies/overview.md) - available policy providers.

--- a/docs/hardware/tools.md
+++ b/docs/hardware/tools.md
@@ -1,5 +1,5 @@
 ---
-description: Eight Strands @tool helpers for hardware bring-up — calibrate, camera, teleop, pose, serial, gr00t inference, mesh, download assets.
+description: Eight Strands @tool helpers for hardware bring-up - calibrate, camera, teleop, pose, serial, gr00t inference, mesh, download assets.
 ---
 
 # Hardware tools
@@ -18,14 +18,14 @@ from strands_robots.tools import (
 
 | Tool | Key actions | What |
 |------|-------------|------|
-| `lerobot_calibrate` | `"list"`, `"info"`, `"search"`, `"compare"`, `"backup"` | Manage existing calibration JSONs under `~/.cache/huggingface/lerobot/calibration/` (this tool inspects/organizes — actual calibration is run via the LeRobot CLI) |
+| `lerobot_calibrate` | `"list"`, `"info"`, `"search"`, `"compare"`, `"backup"` | Manage existing calibration JSONs under `~/.cache/huggingface/lerobot/calibration/` (this tool inspects/organizes - actual calibration is run via the LeRobot CLI) |
 | `lerobot_camera` | `"list"`, `"test"`, `"stream"` | Enumerate, test, stream connected cameras |
 | `lerobot_teleoperate` | `"start"`, `"stop"`, `"status"` | Leader-follower teleop session |
 | `pose_tool` | `"fk"`, `"ik"`, `"set_gripper"` | Forward/inverse kinematics, gripper control |
 | `serial_tool` | `"list"`, `"send"` | Enumerate serial ports, send raw commands |
-| `download_assets` | — | Pre-fetch MJCF assets to `~/.strands_robots/assets/` |
-| `gr00t_inference` | `"start_container"`, … | GR00T container lifecycle — see [GR00T](../policies/groot.md) |
-| `robot_mesh` | `"tell"`, `"broadcast"`, `"emergency_stop"` | Agent-driven mesh ops — see [Multi-robot](../mesh.md) |
+| `download_assets` | - | Pre-fetch MJCF assets to `~/.strands_robots/assets/` |
+| `gr00t_inference` | `"start_container"`, … | GR00T container lifecycle - see [GR00T](../policies/groot.md) |
+| `robot_mesh` | `"tell"`, `"broadcast"`, `"emergency_stop"` | Agent-driven mesh ops - see [Multi-robot](../mesh.md) |
 
 Parse results via `result["content"][0]["text"]`, not custom keys like `result["ports"]`.
 
@@ -56,6 +56,6 @@ agent("Find a connected so100, calibrate it, then stream the wrist camera for 10
 
 ## See also
 
-- [Robot control](robot-control.md) — the `HardwareRobot` class.
-- [Real hardware](../hardware/robot-control.md) — when each tool runs.
-- [GR00T](../policies/groot.md) — `gr00t_inference` container lifecycle.
+- [Robot control](robot-control.md) - the `HardwareRobot` class.
+- [Real hardware](../hardware/robot-control.md) - when each tool runs.
+- [GR00T](../policies/groot.md) - `gr00t_inference` container lifecycle.

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ hide:
 
 # Strands Robots
 
-A robot library for [Strands agents](https://strandsagents.com). You name a robot, you get something you can drive — in simulation by default, or on real hardware when you ask for it.
+A robot library for [Strands agents](https://strandsagents.com). You name a robot, you get something you can drive - in simulation by default, or on real hardware when you ask for it.
 
 ```python
 from strands import Agent
@@ -16,7 +16,7 @@ agent = Agent(tools=[robot])
 agent("Pick up the red cube")
 ```
 
-`Robot("so100")` gives you a MuJoCo simulation — no GPU, runs on a laptop. Add `mode="real"` and the same code drives a physical arm. The agent sees one tool with 60+ actions; it figures out which to call.
+`Robot("so100")` gives you a MuJoCo simulation - no GPU, runs on a laptop. Add `mode="real"` and the same code drives a physical arm. The agent sees one tool with 60+ actions; it figures out which to call.
 
 ```mermaid
 graph LR
@@ -36,7 +36,7 @@ graph LR
     class F policy
 ```
 
-The agent decides *what* to do. The policy (Mock, GR00T, LeRobot, or Cosmos 3) decides *how*. The backend — physics or servos — does it.
+The agent decides *what* to do. The policy (Mock, GR00T, LeRobot, or Cosmos 3) decides *how*. The backend - physics or servos - does it.
 
 ## Start here
 

--- a/docs/mesh.md
+++ b/docs/mesh.md
@@ -1,5 +1,5 @@
 ---
-description: Two Robot() instances coordinating over the Zenoh mesh — peer discovery, RPC, emergency stop, teleop.
+description: Two Robot() instances coordinating over the Zenoh mesh - peer discovery, RPC, emergency stop, teleop.
 ---
 
 # Multi-robot mesh
@@ -31,7 +31,7 @@ result = sim_a.mesh.send(target_peer_id, {"action": "status"}, timeout=5.0)
 # Fan-out → list of responses collected within timeout
 results = sim_a.mesh.broadcast({"action": "status"}, timeout=2.0)
 
-# Safety primitive — writes a tamper-evident audit log
+# Safety primitive - writes a tamper-evident audit log
 sim_a.mesh.emergency_stop()   # STRANDS_MESH_AUDIT_DIR overrides log location
 ```
 
@@ -88,10 +88,10 @@ follower.stop_teleop("leader")
 | `STRANDS_MESH=false` | process-wide kill switch |
 | `Robot("so100", mesh=False)` | per-robot opt-out |
 
-Mesh failures are non-fatal — `robot.mesh` becomes `None`; the sim/hardware instance still works.
+Mesh failures are non-fatal - `robot.mesh` becomes `None`; the sim/hardware instance still works.
 
 ## See also
 
-- [AI agents](agents.md) — drive the mesh with natural language.
-- [Architecture](architecture.md) — where the mesh sits in the module map.
-- [Mesh source](https://github.com/strands-labs/robots/tree/main/strands_robots/mesh) — `core.py`, `session.py`, `audit.py`, `sensors.py`, `input.py`.
+- [AI agents](agents.md) - drive the mesh with natural language.
+- [Architecture](architecture.md) - where the mesh sits in the module map.
+- [Mesh source](https://github.com/strands-labs/robots/tree/main/strands_robots/mesh) - `core.py`, `session.py`, `audit.py`, `sensors.py`, `input.py`.

--- a/docs/policies/cosmos3.md
+++ b/docs/policies/cosmos3.md
@@ -1,5 +1,5 @@
 ---
-description: NVIDIA Cosmos 3 omnimodal VLA — WebSocket service, droid/umi/av/bridge embodiments, MuJoCo rollout.
+description: NVIDIA Cosmos 3 omnimodal VLA - WebSocket service, droid/umi/av/bridge embodiments, MuJoCo rollout.
 ---
 
 # Cosmos 3
@@ -46,9 +46,9 @@ Cosmos3Policy(
 | Embodiment | Robot hardware | Strands sim asset |
 |------------|----------------|-------------------|
 | `droid` | Franka / DROID dataset | `"panda"` or `"franka"` |
-| `umi` | UMI gripper | — |
-| `av` | Autonomous vehicle cameras | — |
-| `bridge` | Bridge dataset robots | — |
+| `umi` | UMI gripper | - |
+| `av` | Autonomous vehicle cameras | - |
+| `bridge` | Bridge dataset robots | - |
 
 ## Rollout
 

--- a/docs/policies/custom-policies.md
+++ b/docs/policies/custom-policies.md
@@ -59,16 +59,16 @@ The factory imports lazily on first use.
 
 | Method / property | Abstract | Default |
 |---|---|---|
-| `async get_actions(obs, instruction, **kw) -> list[dict]` | yes | — |
-| `set_robot_state_keys(keys)` | yes | — |
-| `provider_name` (property) | yes | — |
+| `async get_actions(obs, instruction, **kw) -> list[dict]` | yes | - |
+| `set_robot_state_keys(keys)` | yes | - |
+| `provider_name` (property) | yes | - |
 | `requires_images` (property) | no | `True` |
 | `reset(seed=None)` | no | no-op |
 | `get_actions_sync(...)` | no | sync wrapper |
 
 ## See also
 
-- [Policy overview](overview.md) — factory, providers.
+- [Policy overview](overview.md) - factory, providers.
 - [Architecture](../architecture.md)
 - [Architecture](../architecture.md)
-- `strands_robots/policies/mock.py` — minimal reference implementation.
+- `strands_robots/policies/mock.py` - minimal reference implementation.

--- a/docs/policies/groot.md
+++ b/docs/policies/groot.md
@@ -1,5 +1,5 @@
 ---
-description: NVIDIA GR00T (N1.5 / N1.6 / N1.7) — ZMQ service or local inference, 27 embodiment data_configs, full container lifecycle.
+description: NVIDIA GR00T (N1.5 / N1.6 / N1.7) - ZMQ service or local inference, 27 embodiment data_configs, full container lifecycle.
 ---
 
 # GR00T

--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -1,5 +1,5 @@
 ---
-description: HuggingFace LeRobot direct inference — ACT, Pi0, SmolVLA, Diffusion Policy, MolmoAct2. RTC + processor bridge.
+description: HuggingFace LeRobot direct inference - ACT, Pi0, SmolVLA, Diffusion Policy, MolmoAct2. RTC + processor bridge.
 ---
 
 # LeRobot Local
@@ -66,7 +66,7 @@ Install lerobot from source before using MolmoAct2:
 # Standard (x86_64, macOS):
 uv pip install "lerobot[feetech] @ git+https://github.com/huggingface/lerobot.git"
 
-# Jetson / aarch64 (pyav wheel may fail to build — skip it, lerobot uses torchcodec):
+# Jetson / aarch64 (pyav wheel may fail to build - skip it, lerobot uses torchcodec):
 uv pip install "lerobot[feetech] @ git+https://github.com/huggingface/lerobot.git" --no-build-isolation
 # If pyav still blocks the install, exclude it and add torchcodec manually:
 uv pip install torchcodec>=0.7

--- a/docs/policies/overview.md
+++ b/docs/policies/overview.md
@@ -1,5 +1,5 @@
 ---
-description: The Policy ABC and the four providers that ship — MockPolicy, Gr00tPolicy, LerobotLocalPolicy, Cosmos3Policy.
+description: The Policy ABC and the four providers that ship - MockPolicy, Gr00tPolicy, LerobotLocalPolicy, Cosmos3Policy.
 ---
 
 # Policy providers
@@ -30,7 +30,7 @@ policy = create_policy("cosmos3", embodiment="droid", port=8000)
 from strands_robots.policies import Policy   # strands_robots/policies/base.py
 
 class MyPolicy(Policy):
-    # three abstract methods — must implement all:
+    # three abstract methods - must implement all:
     async def get_actions(self, observation_dict: dict, instruction: str, **kw) -> list[dict]: ...
     def set_robot_state_keys(self, keys: list[str]) -> None: ...
     @property
@@ -73,7 +73,7 @@ sim.run_policy(robot_name="so100", instruction="pick up the cube",
 
 ## See also
 
-- [GR00T](groot.md) — ZMQ server, 27 embodiments, container lifecycle.
-- [LeRobot Local](lerobot-local.md) — in-process HF models, RTC.
-- [Cosmos 3](cosmos3.md) — NVIDIA Cosmos 3 omnimodal VLA.
-- [Custom policies](custom-policies.md) — implement the ABC.
+- [GR00T](groot.md) - ZMQ server, 27 embodiments, container lifecycle.
+- [LeRobot Local](lerobot-local.md) - in-process HF models, RTC.
+- [Cosmos 3](cosmos3.md) - NVIDIA Cosmos 3 omnimodal VLA.
+- [Custom policies](custom-policies.md) - implement the ABC.

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -1,5 +1,5 @@
 ---
-description: DatasetRecorder — LeRobot v3 dataset writer used by both Simulation and HardwareRobot.
+description: DatasetRecorder - LeRobot v3 dataset writer used by both Simulation and HardwareRobot.
 ---
 
 # Recording & datasets
@@ -38,7 +38,7 @@ recorder = DatasetRecorder.create(
     #   robot_features=robot.observation_features,
     #   action_features=robot.action_features,
     # When recording from a sim Robot (no `observation_features` attr), pass
-    # `joint_names=[...]` instead — the recorder builds the schema for you.
+    # `joint_names=[...]` instead - the recorder builds the schema for you.
     camera_keys=["default"],
     joint_names=["joint_1", "joint_2", "joint_3", "joint_4", "joint_5", "joint_6"],
     task="pick up the red cube",
@@ -83,5 +83,5 @@ print(len(ds), ds[0].keys())
 
 ## See also
 
-- [Training](training/overview.md) — what to do with the data.
-- [LeRobot dataset docs](https://huggingface.co/docs/lerobot) — upstream spec.
+- [Training](training/overview.md) - what to do with the data.
+- [LeRobot dataset docs](https://huggingface.co/docs/lerobot) - upstream spec.

--- a/docs/robots/arms.md
+++ b/docs/robots/arms.md
@@ -1,5 +1,5 @@
 ---
-description: 22 single-arm manipulators — from a 2-DOF educational toy to industrial UR10e.
+description: 22 single-arm manipulators - from a 2-DOF educational toy to industrial UR10e.
 ---
 
 # Arms
@@ -18,12 +18,12 @@ sim = Robot("so100")            # SO-ARM100 (low-cost Feetech)
 
 | Name | Description | Joints | Aliases |
 |------|-------------|-------:|---------|
-| `arx_l5` | ARX L5 (6-DOF lightweight arm) | 11 | — |
-| `dynamixel_2r` | Dynamixel 2R Educational Arm (2-DOF) | 2 | — |
+| `arx_l5` | ARX L5 (6-DOF lightweight arm) | 11 | - |
+| `dynamixel_2r` | Dynamixel 2R Educational Arm (2-DOF) | 2 | - |
 | `fr3` | Franka Research 3 (7-DOF + gripper) | 8 | `franka_fr3` |
 | `fr3_v2` | Franka Research 3 v2 (7-DOF + gripper, updated) | 7 | `franka_fr3_v2` |
-| `hope_jr` | Hope Junior arm _(hardware-only, no sim asset)_ | ? | — |
-| `kinova_gen3` | Kinova Gen3 (7-DOF lightweight) | 7 | — |
+| `hope_jr` | Hope Junior arm _(hardware-only, no sim asset)_ | ? | - |
+| `kinova_gen3` | Kinova Gen3 (7-DOF lightweight) | 7 | - |
 | `koch` | Koch v1.1 Low Cost Robot Arm (6-DOF, Dynamixel) | 7 | `koch_follower`, `koch_v1.1`, `low_cost_robot_arm` |
 | `kuka_iiwa` | KUKA LBR iiwa 14 (7-DOF collaborative) | 11 | `kuka_iiwa_14` |
 | `omx` | OMX Robot Arm (ROBOTIS, CAN bus motors) _(hardware-only, no sim asset)_ | ? | `omx_follower`, `omx_robot`, `robotis_omx` |
@@ -33,8 +33,8 @@ sim = Robot("so100")            # SO-ARM100 (low-cost Feetech)
 | `sawyer` | Rethink Robotics Sawyer (7-DOF) | 7 | `rethink_sawyer` |
 | `so100` | TrossenRobotics SO-ARM100 (6-DOF, Feetech servos) | 13 | `so100_4cam`, `so100_dualcam`, `so100_follower` |
 | `so101` | RobotStudio SO-101 (6-DOF, upgraded SO-100) | 9 | `robotstudio_so101`, `so101_dualcam`, `so101_follower` |
-| `ur10e` | Universal Robots UR10e (6-DOF industrial) | 6 | — |
-| `ur5e` | Universal Robots UR5e (6-DOF industrial) | 8 | — |
+| `ur10e` | Universal Robots UR10e (6-DOF industrial) | 6 | - |
+| `ur5e` | Universal Robots UR5e (6-DOF industrial) | 8 | - |
 | `vx300s` | Trossen ViperX 300s (6-DOF + gripper) | 19 | `oxe_widowx`, `trossen_vx300s`, `viper_x300s` |
 | `wx250s` | Trossen WidowX 250s (6-DOF + gripper) | 16 | `widowx_250s`, `trossen_wx250s` |
 | `xarm7` | UFactory xArm 7 (7-DOF + gripper) | 13 | `ufactory_xarm7` |
@@ -105,13 +105,13 @@ _AgileX Piper (6-DOF + gripper)_
 - `panda`, `so100`, and `ur5e` are also supported on real hardware via LeRobot. The rest
   are simulation-only at the moment (real-hardware support is a per-robot effort that
   upstreams to LeRobot).
-- Joint counts include any free joints / gripper actuators — the *control* DOF is
+- Joint counts include any free joints / gripper actuators - the *control* DOF is
   usually `joints - 1` for arms with grippers.
 
 ## See also
 
-- [Robot factory](../getting-started/robot-factory.md) — how `Robot("name")` resolves
+- [Robot factory](../getting-started/robot-factory.md) - how `Robot("name")` resolves
   these names.
-- [Bimanual](bimanual.md) — two-arm setups (Aloha, Trossen WX-AI).
-- [Hands](hands.md) — pair an arm with a dexterous end-effector.
-- [Quickstart](../getting-started/quickstart.md) — spawn one of these arms in 3 lines.
+- [Bimanual](bimanual.md) - two-arm setups (Aloha, Trossen WX-AI).
+- [Hands](hands.md) - pair an arm with a dexterous end-effector.
+- [Quickstart](../getting-started/quickstart.md) - spawn one of these arms in 3 lines.

--- a/docs/robots/bimanual.md
+++ b/docs/robots/bimanual.md
@@ -1,10 +1,10 @@
 ---
-description: Two-arm robots — Aloha, Trossen WX-AI, OpenArm bimanual.
+description: Two-arm robots - Aloha, Trossen WX-AI, OpenArm bimanual.
 ---
 
 # Bimanual rigs
 
-Two-arm robots — Aloha, Trossen WX-AI, OpenArm bimanual.
+Two-arm robots - Aloha, Trossen WX-AI, OpenArm bimanual.
 
 ```python
 from strands_robots import Robot
@@ -37,6 +37,6 @@ _Trossen WidowX AI Bimanual_
 
 ## See also
 
-- [Arms](arms.md) — single-arm manipulators.
-- [Hands](hands.md) — dexterous end-effectors to mount on each arm.
-- [Multi-robot mesh](../mesh.md) — pair two single arms via the mesh as an alternative to a single bimanual rig.
+- [Arms](arms.md) - single-arm manipulators.
+- [Hands](hands.md) - dexterous end-effectors to mount on each arm.
+- [Multi-robot mesh](../mesh.md) - pair two single arms via the mesh as an alternative to a single bimanual rig.

--- a/docs/robots/hands.md
+++ b/docs/robots/hands.md
@@ -1,10 +1,10 @@
 ---
-description: Dexterous end-effectors — Allegro, Shadow, LEAP, Robotiq, etc.
+description: Dexterous end-effectors - Allegro, Shadow, LEAP, Robotiq, etc.
 ---
 
 # Hands
 
-Dexterous end-effectors — Allegro, Shadow, LEAP, Robotiq, etc.
+Dexterous end-effectors - Allegro, Shadow, LEAP, Robotiq, etc.
 
 ```python
 from strands_robots import Robot
@@ -20,11 +20,11 @@ sim = Robot("robotiq_2f85")     # Robotiq 2F-85 gripper
 | `ability_hand` | PSYONIC Ability Hand (5-finger prosthetic, 11-DOF) | 11 | `psyonic_ability_hand` |
 | `aero_hand` | Tetheria Aero Hand Open (16-DOF dexterous) | 16 | `tetheria_aero_hand`, `aero_hand_open` |
 | `allegro_hand` | Wonik Allegro Hand (16-DOF dexterous) | 16 | `wonik_allegro` |
-| `leap_hand` | LEAP Hand (16-DOF dexterous) | 41 | — |
+| `leap_hand` | LEAP Hand (16-DOF dexterous) | 41 | - |
 | `robotiq_2f85` | Robotiq 2F-85 Gripper (2-finger adaptive) | 16 | `robotiq` |
-| `robotiq_2f85_v4` | Robotiq 2F-85 v4 Gripper (updated model) | 6 | — |
-| `shadow_dexee` | Shadow DexEE Dexterous End-Effector (12-DOF) | 12 | — |
-| `shadow_hand` | Shadow Dexterous Hand (24-DOF) | 45 | — |
+| `robotiq_2f85_v4` | Robotiq 2F-85 v4 Gripper (updated model) | 6 | - |
+| `shadow_dexee` | Shadow DexEE Dexterous End-Effector (12-DOF) | 12 | - |
+| `shadow_hand` | Shadow Dexterous Hand (24-DOF) | 45 | - |
 
 ## Featured renders
 
@@ -48,6 +48,6 @@ _Shadow Dexterous Hand (24-DOF)_
 
 ## See also
 
-- [Arms](arms.md) — pair a hand with an arm via `add_robot`.
-- [Custom policies](../policies/custom-policies.md) — high-DOF hand control needs careful action-space design.
-- [Bimanual](bimanual.md) — two arms each with a hand.
+- [Arms](arms.md) - pair a hand with an arm via `add_robot`.
+- [Custom policies](../policies/custom-policies.md) - high-DOF hand control needs careful action-space design.
+- [Bimanual](bimanual.md) - two arms each with a hand.

--- a/docs/robots/humanoids.md
+++ b/docs/robots/humanoids.md
@@ -21,7 +21,7 @@ sim = Robot("reachy_mini")      # Pollen Reachy Mini (expressive)
 | `adam_lite` | PNDbotics Adam Lite Humanoid (26-DOF) | 26 | `pndbotics_adam_lite` |
 | `apollo` | Apptronik Apollo Humanoid (34-DOF) | 34 | `apptronik_apollo` |
 | `asimov_v0` | Asimov V0 Bipedal Legs (12-DOF + 2 passive toes) | 15 | `asimov` |
-| `booster_t1` | Booster T1 Humanoid (24-DOF) | 24 | — |
+| `booster_t1` | Booster T1 Humanoid (24-DOF) | 24 | - |
 | `cassie` | Agility Cassie Bipedal Robot | 28 | `agility_cassie` |
 | `elf2` | BXI Elf2 Humanoid (25-DOF) | 26 | `bxi_elf2` |
 | `fourier_n1` | Fourier N1 / GR-1 Humanoid (26-DOF) | 26 | `fourier_gr1`, `fourier_gr1_arms_only`, `fourier_gr1_arms_waist` |
@@ -29,11 +29,11 @@ sim = Robot("reachy_mini")      # Pollen Reachy Mini (expressive)
 | `op3` | ROBOTIS OP3 Humanoid (20-DOF) | 21 | `robotis_op3` |
 | `open_duck_mini` | Open Duck Mini V2 (16-DOF expressive biped, Feetech servos) | 16 | `bdx`, `mini_bdx`, `open_duck` |
 | `rby1` | Rainbow Robotics RB-Y1A Mobile Manipulator (31-DOF) | 31 | `rby1a`, `rainbow_rby1` |
-| `reachy2` | Pollen Reachy 2 _(hardware-only, no sim asset)_ | ? | — |
+| `reachy2` | Pollen Reachy 2 _(hardware-only, no sim asset)_ | ? | - |
 | `reachy_mini` | Pollen Reachy Mini (6-DOF Stewart head + antennas, 9 actuators) | 21 | `pollen_reachy_mini`, `reachy`, `reachy-mini` |
 | `talos` | PAL Robotics TALOS Humanoid (32-DOF) | 45 | `pal_talos` |
-| `toddlerbot_2xc` | Toddlerbot 2xC Humanoid (45-DOF) | 45 | — |
-| `toddlerbot_2xm` | Toddlerbot 2xM Humanoid (45-DOF) | 45 | — |
+| `toddlerbot_2xc` | Toddlerbot 2xC Humanoid (45-DOF) | 45 | - |
+| `toddlerbot_2xm` | Toddlerbot 2xM Humanoid (45-DOF) | 45 | - |
 | `unitree_g1` | Unitree G1 Humanoid (29-DOF + dexterous hands) | 46 | `g1`, `g1_wbc`, `unitree_g1_full_body` |
 | `unitree_h1` | Unitree H1 Humanoid (19-DOF) | 20 | `h1` |
 | `unitree_h1_2` | Unitree H1-2 Humanoid (52-DOF, with hands) | 52 | `h1_2` |
@@ -78,6 +78,6 @@ _Pollen Reachy Mini (6-DOF Stewart head + antennas, 9 actuators)_
 
 ## See also
 
-- [Mobile](mobile.md) — quadrupeds and wheeled bases.
-- [Bimanual](bimanual.md) — two-arm rigs without the legs.
-- [GR00T](../policies/groot.md) — many GR00T data_configs target humanoids.
+- [Mobile](mobile.md) - quadrupeds and wheeled bases.
+- [Bimanual](bimanual.md) - two-arm rigs without the legs.
+- [GR00T](../policies/groot.md) - many GR00T data_configs target humanoids.

--- a/docs/robots/index.md
+++ b/docs/robots/index.md
@@ -102,11 +102,11 @@ sim = Robot("aloha")
 ## Add a new robot
 
 Robots are JSON entries in `strands_robots/registry/robots.json`. No code change is
-needed for most additions — see [Architecture](../architecture.md)
+needed for most additions - see [Architecture](../architecture.md)
 for the JSON schema and asset-fetch strategies.
 
 ## See also
 
-- [Robot factory](../getting-started/robot-factory.md) — the `Robot()` signature.
-- [Quickstart](../getting-started/quickstart.md) — pick one,
+- [Robot factory](../getting-started/robot-factory.md) - the `Robot()` signature.
+- [Quickstart](../getting-started/quickstart.md) - pick one,
   spawn it.

--- a/docs/robots/mobile.md
+++ b/docs/robots/mobile.md
@@ -25,9 +25,9 @@ sim = Robot("crazyflie")        # Bitcraze Crazyflie 2 quadcopter
 | `earthrover` | EarthRover Mini Plus (mobile outdoor navigation) _(hardware-only, no sim asset)_ | ? | `earth_rover`, `earthrover_mini_plus`, `frodobots` |
 | `go1` | Unitree Go1 Quadruped (12-DOF) | 13 | `unitree_go1` |
 | `google_robot` | Google Robot (mobile base + arm, RT-X) | 10 | `oxe_google` |
-| `lekiwi` | LeKiwi mobile robot _(hardware-only, no sim asset)_ | ? | — |
+| `lekiwi` | LeKiwi mobile robot _(hardware-only, no sim asset)_ | ? | - |
 | `robot_soccer_kit` | Robot Soccer Kit (multi-robot soccer, 65-DOF total) | 65 | `rsk` |
-| `skydio_x2` | Skydio X2 Autonomous Drone | 1 | — |
+| `skydio_x2` | Skydio X2 Autonomous Drone | 1 | - |
 | `spot` | Boston Dynamics Spot (with arm) | 20 | `boston_dynamics_spot` |
 | `stretch` | Hello Robot Stretch (original, mobile manipulator) | 18 | `hello_robot_stretch_original` |
 | `stretch3` | Hello Robot Stretch 3 (mobile manipulator) | 41 | `hello_robot_stretch`, `hello_robot_stretch_3` |
@@ -57,6 +57,6 @@ _Unitree Go2 Quadruped_
 
 ## See also
 
-- [Humanoids](humanoids.md) — bipedal alternatives.
-- [Multi-robot mesh](../mesh.md) — coordinate a fleet via the mesh.
-- [Domain randomization](../simulation/domain-randomization.md) — terrain randomisation for legged robots.
+- [Humanoids](humanoids.md) - bipedal alternatives.
+- [Multi-robot mesh](../mesh.md) - coordinate a fleet via the mesh.
+- [Domain randomization](../simulation/domain-randomization.md) - terrain randomisation for legged robots.

--- a/docs/simulation/domain-randomization.md
+++ b/docs/simulation/domain-randomization.md
@@ -1,5 +1,5 @@
 ---
-description: What randomize() actually samples — colors, lighting, physics, positions.
+description: What randomize() actually samples - colors, lighting, physics, positions.
 ---
 
 # Domain randomization
@@ -18,14 +18,14 @@ sim.randomize(
 )
 ```
 
-**Destructive** — writes into MuJoCo model arrays. To restore: `load_scene(...)` or recreate the sim.
+**Destructive** - writes into MuJoCo model arrays. To restore: `load_scene(...)` or recreate the sim.
 
 ## Categories
 
 | Flag | What changes | Range param |
 |------|-------------|-------------|
 | `randomize_colors` | Object + floor RGB (alpha fixed at 1.0) | `color_range` |
-| `randomize_lighting` | Directional direction, intensity, ambient | — |
+| `randomize_lighting` | Directional direction, intensity, ambient | - |
 | `randomize_physics` | Per-object mass (mult), per-geom friction (scale), joint damping | `mass_range`, `friction_range` |
 | `randomize_positions` | Object position offsets (metres) | `position_noise` |
 
@@ -37,7 +37,7 @@ Defaults: `colors=True`, `lighting=True`; `physics` and `positions` default `Fal
 for episode in range(N):
     sim.reset()
     sim.randomize(randomize_colors=True, randomize_physics=True, seed=episode)
-    # eval_policy has no randomize= kwarg — call sim.randomize() before each episode
+    # eval_policy has no randomize= kwarg - call sim.randomize() before each episode
     result = sim.eval_policy(robot_name="so100", n_episodes=1, max_steps=300,
                              success_fn=my_fn)
 ```

--- a/docs/simulation/overview.md
+++ b/docs/simulation/overview.md
@@ -1,5 +1,5 @@
 ---
-description: The Simulation AgentTool — every action grouped by category, with parameters.
+description: The Simulation AgentTool - every action grouped by category, with parameters.
 ---
 
 # Simulation overview
@@ -17,10 +17,10 @@ For walkthroughs see [Simulation overview](../simulation/overview.md).
 |--------|-----------|-------|
 | `create_world` | `timestep=0.002`, `gravity=[0,0,-9.81]`, `ground_plane=True` | Implicit on `Robot()` |
 | `load_scene` | `scene_path` | Replace world with MJCF |
-| `reset` | — | State to t=0, keep model |
-| `get_state` | — | Sim time, joint positions, object poses |
-| `destroy` | — | Tear down model, data, executor |
-| `export_xml` | — | Serialise model to MJCF string |
+| `reset` | - | State to t=0, keep model |
+| `get_state` | - | Sim time, joint positions, object poses |
+| `destroy` | - | Tear down model, data, executor |
+| `export_xml` | - | Serialise model to MJCF string |
 
 ## Scene-MJCF
 
@@ -37,23 +37,23 @@ For walkthroughs see [Simulation overview](../simulation/overview.md).
 |--------|-----------|
 | `add_robot` | `robot_name`, `position=[0,0,0]`, `data_config=None`, `urdf_path=None` |
 | `remove_robot` | `name` |
-| `list_robots` | — |
+| `list_robots` | - |
 | `get_robot_state` | `name` → joint positions, velocities, torques |
 
 ## Objects
 
 | Action | Key params |
 |--------|-----------|
-| `add_object` | `name`, `shape="box"\|"sphere"\|"cylinder"\|"plane"\|"mesh"`, `size`, `position=[x,y,z]`, `color=[r,g,b,a]`, `orientation=[w,x,y,z]`, `mass=0.1`, `is_static=False`, `mesh_path=None` — `plane` requires `is_static=True` |
+| `add_object` | `name`, `shape="box"\|"sphere"\|"cylinder"\|"plane"\|"mesh"`, `size`, `position=[x,y,z]`, `color=[r,g,b,a]`, `orientation=[w,x,y,z]`, `mass=0.1`, `is_static=False`, `mesh_path=None` - `plane` requires `is_static=True` |
 | `remove_object` | `name` |
 | `move_object` | `name`, `position`, `orientation` (NOT `pos`/`quat`) |
-| `list_objects` | — |
+| `list_objects` | - |
 
 ## Cameras
 
 | Action | Key params |
 |--------|-----------|
-| `add_camera` | `name`, `position`, `target`, `fov=60.0`, `width=640`, `height=480` — no `attach_to`/`fovy`/`lookat` |
+| `add_camera` | `name`, `position`, `target`, `fov=60.0`, `width=640`, `height=480` - no `attach_to`/`fovy`/`lookat` |
 | `remove_camera` | `name` |
 
 Robot-URDF cameras are auto-discovered on `add_robot`.
@@ -76,14 +76,14 @@ Robot-URDF cameras are auto-discovered on `add_robot`.
 | `step` | `n_steps=1` (max 100 000/call) |
 | `set_gravity` | `gravity=[x,y,z]` |
 | `set_timestep` | `timestep` |
-| `get_contacts` / `get_contact_forces` | — |
+| `get_contacts` / `get_contact_forces` | - |
 | `apply_force` | `body_name`, `force`, `torque`, `point` |
 | `get_jacobian` | `body_name` *or* `site_name` *or* `geom_name` |
-| `get_mass_matrix` | — |
-| `inverse_dynamics` | — |
+| `get_mass_matrix` | - |
+| `inverse_dynamics` | - |
 | `forward_kinematics` | `body_name` (optional) |
 | `save_state` / `load_state` | snapshot/restore full physics |
-| `get_energy` | — |
+| `get_energy` | - |
 | `get_sensor_data` | `sensor_name` (optional) |
 
 ## Policy
@@ -93,7 +93,7 @@ Robot-URDF cameras are auto-discovered on `add_robot`.
 | `run_policy` | `robot_name` (required), `policy_provider="mock"`, `policy_config={}`, `policy_object=None`, `instruction=""`, `duration=10.0`, `control_frequency=50.0`, `action_horizon=8`, `n_steps=None` |
 | `start_policy` | same args, async/non-blocking |
 | `stop_policy` | `robot_name` (optional, defaults to `""`) |
-| `list_policies_running` | — |
+| `list_policies_running` | - |
 | `run_multi_policy` | `policies={robot: Policy}`, `instructions`, `duration`, `n_steps` |
 | `eval_policy` | `robot_name` (required), `n_episodes=1`, `max_steps=300`, `success_fn=None` |
 | `replay_episode` | `repo_id`, `robot_name=None`, `episode=0` |
@@ -106,7 +106,7 @@ Robot-URDF cameras are auto-discovered on `add_robot`.
 | `stop_recording(output_path=None)` | Finalise episode |
 | `get_recording_status` | Episode, frame count, output dir |
 | `start_cameras_recording(...)` | Plain MP4 via imageio-ffmpeg; `[sim-mujoco]` only, no lerobot |
-| `stop_cameras_recording` / `get_cameras_recording_status` | — |
+| `stop_cameras_recording` / `get_cameras_recording_status` | - |
 
 ## Randomize
 
@@ -114,7 +114,7 @@ Robot-URDF cameras are auto-discovered on `add_robot`.
 |--------|-----------|
 | `randomize` | `randomize_colors=True`, `randomize_lighting=True`, `randomize_physics=False`, `randomize_positions=False`, `position_noise=0.02`, `color_range=(0.1,1.0)`, `friction_range=(0.5,1.5)`, `mass_range=(0.5,2.0)`, `seed=None` |
 
-Destructive — writes into model arrays. Recompile scene to undo.
+Destructive - writes into model arrays. Recompile scene to undo.
 
 ## Registry
 
@@ -126,6 +126,6 @@ Destructive — writes into model arrays. Recompile scene to undo.
 
 ## See also
 
-- [World building](world-building.md) — composing scenes.
-- [Domain randomization](domain-randomization.md) — `randomize` distributions.
+- [World building](world-building.md) - composing scenes.
+- [Domain randomization](domain-randomization.md) - `randomize` distributions.
 - [Architecture](../architecture.md)

--- a/docs/simulation/world-building.md
+++ b/docs/simulation/world-building.md
@@ -1,5 +1,5 @@
 ---
-description: Compose non-trivial scenes — multiple robots, tables, obstacles, custom MJCF.
+description: Compose non-trivial scenes - multiple robots, tables, obstacles, custom MJCF.
 ---
 
 # World building
@@ -42,7 +42,7 @@ for i in range(5):
 
 ## Cameras
 
-Free cameras look from `position` toward `target` (`fov=60.0`, `width=640`, `height=480`). Robot-URDF cameras (wrist, etc.) are auto-discovered on `add_robot` — no `add_camera` needed.
+Free cameras look from `position` toward `target` (`fov=60.0`, `width=640`, `height=480`). Robot-URDF cameras (wrist, etc.) are auto-discovered on `add_robot` - no `add_camera` needed.
 
 ## Multi-robot policies
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,4 +1,4 @@
-/* Strands Robots — Minimal with glassmorphic dark mode */
+/* Strands Robots - Minimal with glassmorphic dark mode */
 
 /* ---- Light mode ---- */
 [data-md-color-scheme="default"] {
@@ -25,7 +25,7 @@
     --code-fg: #444;
 }
 
-/* ---- Dark mode — true black + glass ---- */
+/* ---- Dark mode - true black + glass ---- */
 [data-md-color-scheme="slate"] {
     --bg: #0a0a0a;
     --bg-surface: rgba(255, 255, 255, 0.04);
@@ -115,7 +115,7 @@ h1 {
     text-decoration-color: var(--link-underline-hover);
 }
 
-/* ---- Header — glass ---- */
+/* ---- Header - glass ---- */
 .md-header {
     background: var(--header-bg) !important;
     backdrop-filter: var(--glass-blur);
@@ -133,7 +133,7 @@ h1 {
     color: var(--fg) !important;
 }
 
-/* ---- Sidebar — glass ---- */
+/* ---- Sidebar - glass ---- */
 .md-sidebar {
     background: var(--sidebar-bg) !important;
     backdrop-filter: var(--glass-blur);
@@ -154,7 +154,7 @@ h1 {
     font-weight: 600;
 }
 
-/* ---- Code — glass card ---- */
+/* ---- Code - glass card ---- */
 .md-typeset pre {
     background: var(--glass-bg) !important;
     backdrop-filter: var(--glass-blur);
@@ -170,7 +170,7 @@ h1 {
     font-size: 0.85em;
 }
 
-/* ---- Admonitions — glass card ---- */
+/* ---- Admonitions - glass card ---- */
 .md-typeset .admonition,
 .md-typeset details {
     background: var(--glass-bg) !important;
@@ -181,7 +181,7 @@ h1 {
     box-shadow: none !important;
 }
 
-/* ---- Tables — glass ---- */
+/* ---- Tables - glass ---- */
 .md-typeset table:not([class]) {
     background: var(--glass-bg);
     border: 1px solid var(--glass-border);
@@ -207,7 +207,7 @@ h1 {
     color: var(--fg-muted) !important;
 }
 
-/* ---- Buttons — glass ---- */
+/* ---- Buttons - glass ---- */
 .md-button {
     background: var(--glass-bg) !important;
     backdrop-filter: var(--glass-blur);
@@ -223,7 +223,7 @@ h1 {
     background: var(--bg-elevated) !important;
 }
 
-/* ---- Search — glass ---- */
+/* ---- Search - glass ---- */
 .md-search__input {
     background: var(--glass-bg) !important;
     backdrop-filter: var(--glass-blur);
@@ -255,7 +255,7 @@ h1 {
     color: var(--fg);
 }
 
-/* ---- Content tabs — glass ---- */
+/* ---- Content tabs - glass ---- */
 .md-typeset .tabbed-content {
     background: var(--glass-bg);
     border: 1px solid var(--glass-border);
@@ -388,7 +388,7 @@ h1 {
     fill: var(--fg) !important;
 }
 
-/* ---- Mobile nav drawer — dark mode fix ---- */
+/* ---- Mobile nav drawer - dark mode fix ---- */
 [data-md-color-scheme="slate"] .md-nav__title {
     color: var(--fg-heading) !important;
     background: var(--bg) !important;

--- a/docs/training/overview.md
+++ b/docs/training/overview.md
@@ -1,5 +1,5 @@
 ---
-description: Where training lives — upstream LeRobot, Isaac-GR00T, Cosmos. strands-robots ships data + inference.
+description: Where training lives - upstream LeRobot, Isaac-GR00T, Cosmos. strands-robots ships data + inference.
 ---
 
 # Training
@@ -8,9 +8,9 @@ description: Where training lives — upstream LeRobot, Isaac-GR00T, Cosmos. str
 
 | Want to train | Use |
 |---------------|-----|
-| ACT, Pi0, SmolVLA, Diffusion Policy | `lerobot` — `python -m lerobot.scripts.train` |
+| ACT, Pi0, SmolVLA, Diffusion Policy | `lerobot` - `python -m lerobot.scripts.train` |
 | GR00T fine-tune | `Isaac-GR00T` (NVIDIA) |
-| Cosmos | NVIDIA Cosmos Framework — see [Cosmos3Policy](../policies/cosmos3.md) |
+| Cosmos | NVIDIA Cosmos Framework - see [Cosmos3Policy](../policies/cosmos3.md) |
 | Custom architecture | Read LeRobot v3 dataset with `pyarrow` / `datasets` |
 
 ## Round-trip
@@ -39,13 +39,13 @@ policy = create_policy("lerobot_local", pretrained_name_or_path="path/to/checkpo
 sim.run_policy(robot_name="so100", instruction="pick up the cube",
                policy_object=policy, duration=15.0)
 
-# 4. Deploy (HardwareRobot has no run_policy — use start_task)
+# 4. Deploy (HardwareRobot has no run_policy - use start_task)
 real = Robot("so100", mode="real", cameras={...})
 real.start_task(instruction="pick up the cube", policy_port=5555)
 ```
 
 ## See also
 
-- [Recording](../recording.md) — produce the dataset.
-- [LerobotLocalPolicy](../policies/lerobot-local.md) — inference with a trained checkpoint.
-- [Cosmos3Policy](../policies/cosmos3.md) — NVIDIA Cosmos 3 VLA.
+- [Recording](../recording.md) - produce the dataset.
+- [LerobotLocalPolicy](../policies/lerobot-local.md) - inference with a trained checkpoint.
+- [Cosmos3Policy](../policies/cosmos3.md) - NVIDIA Cosmos 3 VLA.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -23,7 +23,7 @@ description: Error → fix table for the most common gotchas across install, sim
 | `GLXBadFBConfig` (Linux) | Missing OSMesa | `sudo apt install libosmesa6-dev` + `export MUJOCO_GL=osmesa` |
 | Black frames from `render(...)` | Headless, no GL backend | `export MUJOCO_GL=osmesa` (Linux) or `=egl` |
 | `Robot("foo")` raises ValueError | Unknown name | Check `list_robots("all")`; or pass `urdf_path=...` |
-| Sim hangs on `create_world` | Asset download | Wait — first call downloads MJCF, then cached |
+| Sim hangs on `create_world` | Asset download | Wait - first call downloads MJCF, then cached |
 | `ModuleNotFoundError: trs_so_arm100_mj_description` | Auto-install failed | `uv pip install trs-so-arm100-mj-description` |
 | `add_robot` raises after `load_scene` | Scene XML overrides world | Use `add_robot` before `load_scene` |
 
@@ -53,7 +53,7 @@ description: Error → fix table for the most common gotchas across install, sim
 | Symptom | Likely cause | Fix |
 |---------|--------------|-----|
 | `start_recording` fails: lerobot missing | `[lerobot]` not installed | `uv pip install "strands-robots[lerobot]"` |
-| Need MP4 without LeRobot | — | Use `start_cameras_recording` / `stop_cameras_recording` |
+| Need MP4 without LeRobot | - | Use `start_cameras_recording` / `stop_cameras_recording` |
 | Empty MP4 files | Stopped before any frames | Check `get_recording_status()` frame count |
 | Push fails | Not logged into HF | `huggingface-cli login` |
 
@@ -64,7 +64,7 @@ description: Error → fix table for the most common gotchas across install, sim
 | `mesh.peers` empty | Other peer not running | Wait ~1s; verify `mesh.alive == True` on both |
 | Port already bound | Another zenoh process | Mesh auto falls back to client mode; or set `STRANDS_MESH_PORT` |
 | `init_mesh` raises | `eclipse-zenoh` missing | `uv pip install "strands-robots[mesh]"` |
-| Want mesh off | — | `STRANDS_MESH=false` or `Robot(..., mesh=False)` |
+| Want mesh off | - | `STRANDS_MESH=false` or `Robot(..., mesh=False)` |
 
 ## Agent integration
 
@@ -75,10 +75,10 @@ description: Error → fix table for the most common gotchas across install, sim
 | Agent hangs | Long-running action | Use `start_policy` instead of `run_policy` |
 | Bedrock/Anthropic auth fails | Provider credentials | See [Strands Agents docs](https://strandsagents.com/) |
 
-Bug reports: [GitHub issues](https://github.com/strands-labs/robots/issues) — include `pip show strands-robots`, Python + OS, minimal repro, full stack trace.
+Bug reports: [GitHub issues](https://github.com/strands-labs/robots/issues) - include `pip show strands-robots`, Python + OS, minimal repro, full stack trace.
 
 ## See also
 
-- [Installation](getting-started/installation.md) — extras matrix.
-- [Real hardware](hardware/robot-control.md) — bring-up sequence.
-- [Contributing](contributing.md) — fix it yourself.
+- [Installation](getting-started/installation.md) - extras matrix.
+- [Real hardware](hardware/robot-control.md) - bring-up sequence.
+- [Contributing](contributing.md) - fix it yourself.

--- a/examples/01_sim_hello_world.py
+++ b/examples/01_sim_hello_world.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-"""Spawn a robot in MuJoCo and run a policy — zero hardware required.
+"""Spawn a robot in MuJoCo and run a policy - zero hardware required.
 
 Goal: Show that Robot("so100") gives you a fully configured MuJoCo simulation
-with one call — world created and the robot already added. You just add objects
+with one call - world created and the robot already added. You just add objects
 and cameras, then run a policy.
 
 Dependencies: pip install "strands-robots[sim-mujoco]"
@@ -12,7 +12,7 @@ Runtime: ~2 seconds on CPU.
 
 from strands_robots import MockPolicy, Robot
 
-# Robot("so100") defaults to mode="sim" — safe, no hardware interaction.
+# Robot("so100") defaults to mode="sim" - safe, no hardware interaction.
 # The factory already calls create_world() and adds the "so100" robot, so
 # the scene is ready to use immediately (no create_world/add_robot needed).
 sim = Robot("so100", mesh=False)
@@ -28,7 +28,7 @@ sim.add_object(
 )
 sim.add_camera(name="front", position=[0.5, 0.0, 0.4], target=[0.2, 0, 0.05])
 
-# Run a policy — MockPolicy produces sinusoidal test actions.
+# Run a policy - MockPolicy produces sinusoidal test actions.
 # robot_name="so100" is the robot the factory created.
 result = sim.run_policy(
     robot_name="so100",

--- a/examples/02_policy_abstraction.py
+++ b/examples/02_policy_abstraction.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""One function to load any policy — mock, GR00T, ACT, MolmoAct2, Cosmos3.
+"""One function to load any policy - mock, GR00T, ACT, MolmoAct2, Cosmos3.
 
 Goal: Demonstrate create_policy() as the universal entry point. The provider
 is auto-resolved from the string: "mock", an HF repo, or a ZMQ URL.

--- a/examples/03_record_dataset.py
+++ b/examples/03_record_dataset.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Record a demonstration as a LeRobotDataset — from sim, push to HF Hub.
+"""Record a demonstration as a LeRobotDataset - from sim, push to HF Hub.
 
 Goal: Show the recording lifecycle (start -> run policy -> stop) produces
 a training-ready LeRobotDataset with zero manual feature wrangling.
@@ -20,7 +20,7 @@ sim.add_camera(name="front", position=[0.5, 0.0, 0.4], target=[0.2, 0, 0.05])
 # Start recording. Pass an explicit local root= directory: without it lerobot
 # resolves repo_id into the read-only Hub snapshot cache, where DatasetWriter
 # cannot be created (recorder init fails). Features are auto-inferred from the
-# robot — no manual schema wrangling.
+# robot - no manual schema wrangling.
 start = sim.start_recording(
     repo_id="local/my_demo",
     root="/tmp/strands_demo_dataset",
@@ -33,7 +33,7 @@ if start["status"] != "success":
     print(f"start_recording failed: {start['content'][0]['text']}", file=sys.stderr)
     raise SystemExit(1)
 
-# Run the policy — each step is automatically captured.
+# Run the policy - each step is automatically captured.
 sim.run_policy(
     robot_name="so100",
     policy_object=MockPolicy(),
@@ -41,7 +41,7 @@ sim.run_policy(
     n_steps=100,
 )
 
-# Finalize — writes parquet + video, ready for lerobot training scripts.
+# Finalize - writes parquet + video, ready for lerobot training scripts.
 # The response text reports the actual frame/episode count and on-disk path,
 # so you can confirm frames were captured rather than trusting a bare status.
 result = sim.stop_recording()

--- a/examples/04_mesh_peer_discovery.py
+++ b/examples/04_mesh_peer_discovery.py
@@ -2,7 +2,7 @@
 """Join the robot mesh and discover peers on the local network.
 
 Goal: Show that Robot() with mesh=True gives automatic peer discovery via
-Zenoh. Every robot that joins the mesh is visible to every other — no DHCP,
+Zenoh. Every robot that joins the mesh is visible to every other - no DHCP,
 no config server, no manual IP lists.
 
 Dependencies: pip install "strands-robots[sim-mujoco,mesh]"
@@ -28,7 +28,7 @@ from strands_robots.mesh import get_local_robots, get_peers
 use_mesh = os.environ.get("STRANDS_MESH", "true").lower() != "0"
 sim = Robot("so100", mesh=use_mesh, peer_id="example-arm-01")
 
-# Query the mesh — see who is online.
+# Query the mesh - see who is online.
 local = get_local_robots()
 peers = get_peers()
 

--- a/examples/05_agent_natural_language.py
+++ b/examples/05_agent_natural_language.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-"""Attach an LLM agent to a robot — control it with natural language.
+"""Attach an LLM agent to a robot - control it with natural language.
 
 Goal: Show that a Strands Agent with Robot() as a tool lets you describe
 tasks in English. The agent composes sim scenes, runs policies, and records
-datasets — all from one prompt.
+datasets - all from one prompt.
 
 Dependencies:
   pip install "strands-robots[sim-mujoco]" strands-agents
@@ -17,7 +17,7 @@ from strands import Agent
 
 from strands_robots import Robot
 
-# Robot() is a Strands AgentTool — pass it directly to the Agent.
+# Robot() is a Strands AgentTool - pass it directly to the Agent.
 sim = Robot("so100", mesh=False)
 
 agent = Agent(tools=[sim])

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,7 +1,7 @@
 # Examples
 
 Each example demonstrates ONE strands-robots primitive in under 60 lines.
-No raw lerobot wrangling — the SDK handles configuration, feature schemas,
+No raw lerobot wrangling - the SDK handles configuration, feature schemas,
 and hardware abstraction internally.
 
 ## Quick start
@@ -41,8 +41,8 @@ MUJOCO_GL=egl python examples/01_sim_hello_world.py
 
 ## Environment variables
 
-- `MUJOCO_GL=egl` — headless rendering (required on servers without display)
-- `STRANDS_MESH_LOCAL_DEV=1` — skip TLS for mesh examples in local dev
-- `STRANDS_MESH=0` — disable mesh entirely
-- `HF_TOKEN` — push datasets to Hugging Face Hub
-- `STRANDS_TRUST_REMOTE_CODE=1` — required for some HF policy checkpoints
+- `MUJOCO_GL=egl` - headless rendering (required on servers without display)
+- `STRANDS_MESH_LOCAL_DEV=1` - skip TLS for mesh examples in local dev
+- `STRANDS_MESH=0` - disable mesh entirely
+- `HF_TOKEN` - push datasets to Hugging Face Hub
+- `STRANDS_TRUST_REMOTE_CODE=1` - required for some HF policy checkpoints

--- a/examples/cosmos3_sim_rollout.py
+++ b/examples/cosmos3_sim_rollout.py
@@ -19,7 +19,7 @@ Prerequisites
    vendored numpy packer. That means it composes cleanly with ``lerobot``
    (``numpy>=2``) for LeRobotDataset recording in the same env.
 
-2. The policy server (holds the GPU) — from a Cosmos Framework checkout:
+2. The policy server (holds the GPU) - from a Cosmos Framework checkout:
 
      uv sync --all-extras --group=cu130-train --group=policy-server
      python -m cosmos_framework.scripts.action_policy_server_robolab \
@@ -52,7 +52,7 @@ def main() -> int:
     parser.add_argument("--control-frequency", type=float, default=15.0, help="Control Hz (match policy fps).")
     parser.add_argument("--action-horizon", type=int, default=8, help="Steps consumed per policy chunk.")
     parser.add_argument("--record", metavar="MP4_PATH", default=None, help="Record the rollout to this MP4.")
-    parser.add_argument("--robot", default="franka", help="Sim arm data_config (franka/panda — DROID = Franka).")
+    parser.add_argument("--robot", default="franka", help="Sim arm data_config (franka/panda - DROID = Franka).")
     args = parser.parse_args()
 
     # Headless GL default so the example runs on servers out of the box.
@@ -88,7 +88,7 @@ def main() -> int:
         "side": "observation/exterior_image_2_left",
     }
     # The Cosmos3 client uses a self-contained msgpack+websockets transport
-    # (numpy-version agnostic — composes with lerobot).
+    # (numpy-version agnostic - composes with lerobot).
     policy = Cosmos3Policy(
         embodiment="droid",
         host=args.host,
@@ -101,7 +101,7 @@ def main() -> int:
     if args.record:
         video = {"path": args.record, "camera": "front", "fps": int(args.control_frequency)}
 
-    print(f"Rolling out Cosmos 3 (ws://{args.host}:{args.port}) — {args.n_steps} steps ...")
+    print(f"Rolling out Cosmos 3 (ws://{args.host}:{args.port}) - {args.n_steps} steps ...")
     try:
         result = sim.run_policy(
             robot_name="arm",

--- a/examples/lerobot/README.md
+++ b/examples/lerobot/README.md
@@ -63,13 +63,13 @@ export AWS_REGION=<your-region>     # e.g., us-east-1, us-west-2, eu-central-1
 
 Verify the exact model ID in your AWS Bedrock console (Model catalog → Anthropic). Cross-region inference profile IDs are prefixed with `us.`, `eu.`, etc.
 
-If `BedrockModel` init fails (model not enabled in your account, wrong region, stale ID), the script logs a warning and falls back to Strands' default model — the workflow still runs.
+If `BedrockModel` init fails (model not enabled in your account, wrong region, stale ID), the script logs a warning and falls back to Strands' default model - the workflow still runs.
 
 ### Policy provider
 
 | Flag | Requirements | When to use |
 |------|--------------|-------------|
-| `--policy mock` *(default)* | None | Workflow sanity-check. Random/placeholder actions — no real grasp behaviour. |
+| `--policy mock` *(default)* | None | Workflow sanity-check. Random/placeholder actions - no real grasp behaviour. |
 | `--policy groot --checkpoint <hf_repo>` | Docker + NVIDIA GPU | NVIDIA GR00T container; brings up a ZMQ inference service alongside the agent. |
 | `--policy lerobot_local --checkpoint <hf_repo>` | GPU + `STRANDS_TRUST_REMOTE_CODE=1` | In-process LeRobot policy (ACT, Pi0, SmolVLA, Diffusion). |
 
@@ -163,7 +163,7 @@ The same dataset is consumable by upstream LeRobot training scripts (`lerobot/sc
 
 ## Production patterns
 
-This example records one longer episode per run. That keeps the agent-driven story honest — you tell the agent in English to record a demonstration once and the tool sequence comes out in one shot.
+This example records one longer episode per run. That keeps the agent-driven story honest - you tell the agent in English to record a demonstration once and the tool sequence comes out in one shot.
 
 For production multi-episode collection, wrap the loop in Python and use direct tool dispatch for the per-iteration save:
 
@@ -195,7 +195,7 @@ for episode_idx in range(50):
 agent("Stop recording and push the dataset to the Hub.")
 ```
 
-The split — agent for setup and finalization, Python loop for the per-episode boundary — pairs the agent's strength (free-form composition) with the determinism a multi-step loop needs.
+The split - agent for setup and finalization, Python loop for the per-episode boundary - pairs the agent's strength (free-form composition) with the determinism a multi-step loop needs.
 
 ## Troubleshooting
 
@@ -209,15 +209,15 @@ Common causes: the model isn't enabled in your AWS account, the region doesn't h
 A prior run's dataset cache is on disk. Pass `--clean-cache` to wipe it, or pass a fresh `--dataset-name`.
 
 **SVT-AV1 encoder output spam**  
-The `Svt[info]:` lines come from the video codec inside LeRobot's `dataset_recorder` and aren't a Python logger we can silence cleanly. They're harmless — one block per camera per encoder init.
+The `Svt[info]:` lines come from the video codec inside LeRobot's `dataset_recorder` and aren't a Python logger we can silence cleanly. They're harmless - one block per camera per encoder init.
 
 **Agent's narration claims things that don't match the tool calls**  
-LLMs sometimes confabulate in narration. The dataset on disk is the ground truth — load it through `LeRobotDataset(...)` to check episode and frame counts. Pass `--verbose` to see the actual tool calls the agent made.
+LLMs sometimes confabulate in narration. The dataset on disk is the ground truth - load it through `LeRobotDataset(...)` to check episode and frame counts. Pass `--verbose` to see the actual tool calls the agent made.
 
 ## What's next
 
 - **Train a policy** on the recorded dataset using upstream LeRobot.
-- **Swap the Mock policy** for a real one — `groot` for the NVIDIA container, `lerobot_local` for ACT/Pi0/SmolVLA/Diffusion checkpoints.
+- **Swap the Mock policy** for a real one - `groot` for the NVIDIA container, `lerobot_local` for ACT/Pi0/SmolVLA/Diffusion checkpoints.
 - **Run on physical hardware** by flipping `--mode real`.
 - **Read the blog post** for the design background and the full architecture diagram: *From Hugging Face Hub to robot hardware with Strands Agents and LeRobot*.
 

--- a/examples/lerobot/hub_to_hardware.ipynb
+++ b/examples/lerobot/hub_to_hardware.ipynb
@@ -15,7 +15,7 @@
     "4. (Reference only) Deploy the same agent code to a physical SO-101 by flipping `mode='real'`.\n",
     "5. Broadcast a command to every peer on the local Zenoh mesh.\n",
     "\n",
-    "The defaults run fully in simulation with the Mock policy — no GPU, no Docker, no Hub credentials required. To use a trained policy or push to your Hub account, see the notes in the relevant cells.\n",
+    "The defaults run fully in simulation with the Mock policy - no GPU, no Docker, no Hub credentials required. To use a trained policy or push to your Hub account, see the notes in the relevant cells.\n",
     "\n",
     "**Repository:** https://github.com/strands-labs/robots  \n",
     "**Blog post:** *From Hugging Face Hub to robot hardware with Strands Agents and LeRobot*"
@@ -60,7 +60,7 @@
     "os.environ.setdefault(\"STRANDS_MESH_LOCAL_DEV\", \"1\")\n",
     "\n",
     "# Bedrock model + region. Verify the exact ID in your AWS Bedrock console.\n",
-    "# AWS_REGION resolves from your AWS environment — set it explicitly here\n",
+    "# AWS_REGION resolves from your AWS environment - set it explicitly here\n",
     "# (e.g. \"us-east-1\") if you need to override.\n",
     "MODEL_ID = \"global.anthropic.claude-opus-4-8\"\n",
     "AWS_REGION = os.environ.get(\"AWS_REGION\") or os.environ.get(\"AWS_DEFAULT_REGION\")\n",
@@ -78,9 +78,9 @@
    "id": "8dd0d8092fe74a7c96281538738b07e2",
    "metadata": {},
    "source": [
-    "## Step 1 — Build the agent\n",
+    "## Step 1 - Build the agent\n",
     "\n",
-    "One `Robot('so100')` call returns a MuJoCo simulation by default. Pass `mode='real'` to get a hardware-backed robot driven by LeRobot — the rest of the workflow is identical.\n",
+    "One `Robot('so100')` call returns a MuJoCo simulation by default. Pass `mode='real'` to get a hardware-backed robot driven by LeRobot - the rest of the workflow is identical.\n",
     "\n",
     "The agent gets four tools: the `Robot` itself (the simulation), `lerobot_teleoperate` (leader-arm capture for hardware), `lerobot_calibrate` (one-time joint calibration), and `robot_mesh` (peer-to-peer fleet messaging)."
    ]
@@ -111,7 +111,7 @@
    "id": "8edb47106e1a46a883d545849b8ab81b",
    "metadata": {},
    "source": [
-    "## Step 2 — Record a demonstration\n",
+    "## Step 2 - Record a demonstration\n",
     "\n",
     "One agent prompt → one tool sequence → one `LeRobotDataset` episode. The agent composes the scene (red cube + front camera), starts recording, runs the Mock policy, and finalizes the episode with `stop_recording`.\n",
     "\n",
@@ -128,7 +128,7 @@
     "NUM_STEPS = 1000  # ≈ 33s of data at 30fps\n",
     "\n",
     "push_clause = (\n",
-    "    f\"Push the result to {REPO_ID} when done.\" if PUSH_TO_HUB else \"Keep the dataset local — do not push to the Hub.\"\n",
+    "    f\"Push the result to {REPO_ID} when done.\" if PUSH_TO_HUB else \"Keep the dataset local - do not push to the Hub.\"\n",
     ")\n",
     "\n",
     "prompt = (\n",
@@ -186,9 +186,9 @@
    "source": [
     "Inside the cache directory you'll find:\n",
     "\n",
-    "- `data/chunk-000/episode_000000.parquet` — joint states and actions\n",
-    "- `videos/chunk-000/observation.images.front/episode_000000.mp4` — the recording\n",
-    "- `meta/` — schema and episode metadata\n",
+    "- `data/chunk-000/episode_000000.parquet` - joint states and actions\n",
+    "- `videos/chunk-000/observation.images.front/episode_000000.mp4` - the recording\n",
+    "- `meta/` - schema and episode metadata\n",
     "\n",
     "Open the MP4 in QuickTime/VLC to see the recorded rollout."
    ]
@@ -198,9 +198,9 @@
    "id": "b118ea5561624da68c537baed56e602f",
    "metadata": {},
    "source": [
-    "## Step 3 — Run a policy on the robot\n",
+    "## Step 3 - Run a policy on the robot\n",
     "\n",
-    "The same agent now drives the policy. With the Mock policy (the default), this is purely a workflow sanity-check — the arm moves through placeholder actions rather than executing a trained grasp.\n",
+    "The same agent now drives the policy. With the Mock policy (the default), this is purely a workflow sanity-check - the arm moves through placeholder actions rather than executing a trained grasp.\n",
     "\n",
     "For real cube-picking behaviour, switch the prompt to drive `gr00t_inference` (NVIDIA GR00T container, requires Docker + GPU) or `create_policy('lerobot_local', ...)` with a checkpoint trained for the task. See this folder's README for the exact wiring."
    ]
@@ -220,7 +220,7 @@
    "id": "504fb2a444614c0babb325280ed9130a",
    "metadata": {},
    "source": [
-    "## Step 4 — Deploy to physical hardware (reference)\n",
+    "## Step 4 - Deploy to physical hardware (reference)\n",
     "\n",
     "Switching from simulation to a physical SO-101 is one flag at construction time:\n",
     "\n",
@@ -237,7 +237,7 @@
     ")\n",
     "```\n",
     "\n",
-    "The rest of the code — `Agent(tools=[robot, ...])`, the recording prompt, the policy prompt — is unchanged. The same `LeRobotDataset` writer handles real-camera frames and hardware joint reads through `lerobot_teleoperate`.\n",
+    "The rest of the code - `Agent(tools=[robot, ...])`, the recording prompt, the policy prompt - is unchanged. The same `LeRobotDataset` writer handles real-camera frames and hardware joint reads through `lerobot_teleoperate`.\n",
     "\n",
     "(Skipped in this notebook because hardware isn't typically attached to a Jupyter kernel.)"
    ]
@@ -247,7 +247,7 @@
    "id": "59bbdb311c014d738909a11f9e486628",
    "metadata": {},
    "source": [
-    "## Step 5 — Mesh broadcast\n",
+    "## Step 5 - Mesh broadcast\n",
     "\n",
     "Every `Robot()` auto-joins a local Zenoh mesh, so fleets coordinate out of the box. The agent uses the `robot_mesh` tool to enumerate peers and send commands.\n",
     "\n",
@@ -285,7 +285,7 @@
     "## Next steps\n",
     "\n",
     "- **Push to the Hub.** Set `HF_USER` in the second cell, export `HF_TOKEN=hf_...` with write scope, and re-run from Step 2.\n",
-    "- **Train on the dataset.** The `LeRobotDataset` you just produced is byte-compatible with the upstream LeRobot training scripts — `lerobot/scripts/train.py` will consume it directly.\n",
+    "- **Train on the dataset.** The `LeRobotDataset` you just produced is byte-compatible with the upstream LeRobot training scripts - `lerobot/scripts/train.py` will consume it directly.\n",
     "- **Use a real trained policy.** Swap the Mock prompt in Step 3 for a `lerobot_local` or `groot` checkpoint. See this folder's `README.md`.\n",
     "- **Run on physical hardware.** Calibrate your SO-101 once (`agent('Calibrate the so101_follower on /dev/ttyACM0')`), then re-run Step 1 with `mode='real'`."
    ]

--- a/examples/lerobot/hub_to_hardware.py
+++ b/examples/lerobot/hub_to_hardware.py
@@ -51,7 +51,7 @@ Run on physical hardware (requires SO-101 follower + leader, calibrated):
 A note on recording shape: this example records ONE demonstration per run
 (a single LeRobotDataset episode of N steps). The dataset format also
 supports multi-episode shapes, but a single longer episode keeps the
-agent-driven story honest — you tell the agent in English to record a
+agent-driven story honest - you tell the agent in English to record a
 demonstration once, and the tool sequence comes out in one shot.
 Production multi-episode collection wraps the loop in Python; that
 pattern lives in this folder's README under "Production patterns."
@@ -86,12 +86,12 @@ diag_logger = logging.getLogger("hub_to_hardware.diag")
 # Model defaults
 # ---------------------------------------------------------------------------
 # Claude Opus 4.8 on Bedrock orchestrates the LeRobot tool surface cleanly
-# in one shot — lower-tier models work but issue more defensive state-
+# in one shot - lower-tier models work but issue more defensive state-
 # querying calls and are more likely to drift on multi-step loops.
 #
 # IMPORTANT: verify the exact model ID in your AWS Bedrock console
 # (Model catalog → Anthropic → Claude Opus 4.8). Cross-region inference
-# profile IDs are prefixed by ``us.``, ``eu.``, etc. — pick the one for
+# profile IDs are prefixed by ``us.``, ``eu.``, etc. - pick the one for
 # your region. Override at runtime via --model-id or STRANDS_BEDROCK_MODEL_ID
 # without editing this file.
 DEFAULT_MODEL_ID = "global.anthropic.claude-opus-4-8"  # ← verify in AWS console
@@ -118,10 +118,10 @@ def _read_dataset_state(repo_id: str) -> dict[str, Any]:
     layout your installed LeRobot version expects.
 
     Returns a dict with one of these statuses:
-      * ``missing``        — cache dir doesn't exist
-      * ``ready``          — dataset loaded, counts populated
-      * ``not_finalized``  — cache exists but isn't a complete dataset yet
-      * ``error``          — load failed for another reason
+      * ``missing``        - cache dir doesn't exist
+      * ``ready``          - dataset loaded, counts populated
+      * ``not_finalized``  - cache exists but isn't a complete dataset yet
+      * ``error``          - load failed for another reason
     """
     cache_root = _lerobot_cache_root(repo_id)
     result: dict[str, Any] = {"cache_path": str(cache_root)}
@@ -163,12 +163,12 @@ def _log_dataset_summary(repo_id: str) -> None:
         )
     elif status == "missing":
         logger.warning(
-            "❌ No dataset cache at %s — start_recording may have been skipped",
+            "❌ No dataset cache at %s - start_recording may have been skipped",
             state["cache_path"],
         )
     elif status == "not_finalized":
         logger.warning(
-            "❌ Cache at %s isn't a complete dataset (%s) — stop_recording may not have run",
+            "❌ Cache at %s isn't a complete dataset (%s) - stop_recording may not have run",
             state["cache_path"],
             state["error"],
         )
@@ -260,7 +260,7 @@ def _build_bedrock_model(model_id: str, region: str | None) -> Any | None:
 
     Returns the model on success, None on any failure (import error, auth
     error, model-not-enabled). The caller falls back to Strands' default
-    model on None — the workflow still runs, just on whatever Strands picks.
+    model on None - the workflow still runs, just on whatever Strands picks.
 
     ``region`` may be None, in which case boto3's standard resolution chain
     (env vars, ~/.aws/config, instance metadata) decides the region.
@@ -289,7 +289,7 @@ def _build_bedrock_model(model_id: str, region: str | None) -> Any | None:
         logger.warning(
             "BedrockModel(%s, region=%s) init failed: %s. Falling back to "
             "Strands' default. Common causes: model not enabled in this AWS "
-            "account, wrong region, or stale model ID — check the Bedrock console.",
+            "account, wrong region, or stale model ID - check the Bedrock console.",
             model_id,
             region or "<unset>",
             exc,
@@ -380,7 +380,7 @@ def record_demonstration(
     push_clause = (
         f"Push the result to {repo_id} when done."
         if push_to_hub
-        else "Keep the dataset local — do not push to the Hub."
+        else "Keep the dataset local - do not push to the Hub."
     )
 
     if mode == "sim":
@@ -514,7 +514,7 @@ def cleanup(agent: Any, *, policy: str) -> None:
 def parse_args(argv: list[str]) -> argparse.Namespace:
     p = argparse.ArgumentParser(
         prog="hub_to_hardware",
-        description="From Hugging Face Hub to robot hardware — the runnable example.",
+        description="From Hugging Face Hub to robot hardware - the runnable example.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
 

--- a/examples/mesh_acl_example.json5
+++ b/examples/mesh_acl_example.json5
@@ -1,4 +1,4 @@
-// strands-robots mesh ACL — operator template (role-scoped subscribe).
+// strands-robots mesh ACL - operator template (role-scoped subscribe).
 //
 // Drop this at $STRANDS_MESH_ACL_FILE and edit the ENUMERATED CNs
 // below to match the cert Common Names of every robot and operator
@@ -10,14 +10,14 @@
 // ROLE rather than handing every authenticated peer a blanket
 // `declare_subscriber` on `**`:
 //
-//   * robot_peer  — may subscribe only to operationally low-impact,
+//   * robot_peer  - may subscribe only to operationally low-impact,
 //                   fleet-shared topic CLASSES (presence, broadcast,
 //                   safety) plus its OWN command/response. It cannot
 //                   declare a subscriber on another robot's cmd / state
 //                   / camera / input topics. This mirrors the IoT
 //                   transport's per-Thing subscribe isolation
 //                   (provision.py AllowOwnSubscriptions / AllowReceiveScoped).
-//   * operator_peer — retains broad observe privilege (`**`), because
+//   * operator_peer - retains broad observe privilege (`**`), because
 //                   operators legitimately monitor the whole fleet. This
 //                   is an INTENTIONAL operator-role grant, called out
 //                   explicitly below so it is never mistaken for a robot
@@ -31,7 +31,7 @@
 // the topic shape (there is no `${cn}` substitution like IoT's
 // `${iot:Connection.Thing.ThingName}`). For STRICT per-peer isolation
 // equivalent to the IoT policy, enumerate one rule + one subject per
-// robot CN — see examples/mesh_acl_strict_per_peer.json5. When in doubt,
+// robot CN - see examples/mesh_acl_strict_per_peer.json5. When in doubt,
 // prefer the IoT transport for fleets that require hard cross-peer
 // subscribe denial.
 //
@@ -41,7 +41,7 @@
 //  1. `enabled: true` is required. Without it the entire access_control
 //     block is a silent no-op.
 //
-//  2. `cert_common_names` matches LITERAL CNs only — `"robot-*"` and
+//  2. `cert_common_names` matches LITERAL CNs only - `"robot-*"` and
 //     `"robot-.*"` both match nothing. Enumerate every peer by exact
 //     CN below; there is no glob fallback.
 //
@@ -98,7 +98,7 @@
       // Robot subscribe is intentionally NARROW: only fleet-shared,
       // low-impact topic classes plus the robot's own cmd/response.
       // It deliberately does NOT include `**`, `**/state/**`,
-      // `**/camera/**`, or another peer's `**/cmd` — a robot has no
+      // `**/camera/**`, or another peer's `**/cmd` - a robot has no
       // operational need to observe another robot's control or sensor
       // streams. Operators that need the robot to read a specific peer
       // should route through `tell`/`send` RPC, not a raw subscribe.
@@ -117,7 +117,7 @@
     {
       // INTENTIONAL operator-role privilege: operators monitor the whole
       // fleet, so they keep a broad subscribe. Scoped to the
-      // operator_peer subject only (see policies below) — robots never
+      // operator_peer subject only (see policies below) - robots never
       // reference this rule.
       id: "operator_subscribe_all",
       messages: ["declare_subscriber"],

--- a/examples/mesh_acl_strict_per_peer.json5
+++ b/examples/mesh_acl_strict_per_peer.json5
@@ -1,4 +1,4 @@
-// strands-robots mesh ACL — STRICT per-peer isolation template.
+// strands-robots mesh ACL - STRICT per-peer isolation template.
 //
 // Use this template when you need hard cross-peer subscribe denial
 // equivalent to the AWS IoT transport's per-Thing policy isolation

--- a/examples/molmoact2_sim_pickplace.py
+++ b/examples/molmoact2_sim_pickplace.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""SO101 pick-and-place in MuJoCo simulation — same policy, sim robot.
+"""SO101 pick-and-place in MuJoCo simulation - same policy, sim robot.
 
 Identical to ``molmoact2_so101_pickplace.py`` but swaps the robot to sim mode.
 This demonstrates that the abstraction works: one line changes from real to sim,
@@ -38,7 +38,7 @@ def main():
     args = ap.parse_args()
 
     # Only difference from the real example: mode="sim" (the default).
-    # No serial port, no camera hardware — MuJoCo provides observations.
+    # No serial port, no camera hardware - MuJoCo provides observations.
     sim = Robot("so101")  # mode="sim" is the default
     log.info("Simulation world created: %s", sim.tool_name)
 
@@ -54,7 +54,7 @@ def main():
         },
     )
 
-    # Same create_policy call — the abstraction is identical.
+    # Same create_policy call - the abstraction is identical.
     policy = create_policy(REPO, embodiment="so_real", device=args.device)
     policy.reset()
 

--- a/examples/molmoact2_so101_pickplace.py
+++ b/examples/molmoact2_so101_pickplace.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-"""SO101 pick-and-place driven by MolmoAct2 — strands_robots simplified API.
+"""SO101 pick-and-place driven by MolmoAct2 - strands_robots simplified API.
 
 Demonstrates how strands_robots wraps the entire robot + policy lifecycle.
 The user never imports lerobot directly; all complexity is behind two calls:
 
-  1. ``Robot("so101", mode="real", ...)`` — creates a connected hardware robot
-  2. ``create_policy(REPO, embodiment="so_real", ...)`` — loads MolmoAct2 with
+  1. ``Robot("so101", mode="real", ...)`` - creates a connected hardware robot
+  2. ``create_policy(REPO, embodiment="so_real", ...)`` - loads MolmoAct2 with
      correct motor-key mapping, camera renames, normalization, and processors.
 
 Hardware requirements:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "strands-robots"
 dynamic = ["version"]
-description = "AI-powered robot control, simulation, and training for Strands Agents — integrates with MuJoCo, Isaac Sim, Newton, and many more"
+description = "AI-powered robot control, simulation, and training for Strands Agents - integrates with MuJoCo, Isaac Sim, Newton, and many more"
 readme = "README.md"
 requires-python = ">=3.12"
 license = {text = "Apache-2.0"}
@@ -88,7 +88,7 @@ mesh = [
     "eclipse-zenoh>=1.0.0,<2.0.0",
     "json5>=0.9.0,<1.0.0",
 ]
-# AWS IoT Core integration for the mesh — MQTT5/mTLS transport, Device
+# AWS IoT Core integration for the mesh - MQTT5/mTLS transport, Device
 # Shadow mirror, S3 camera offload, account-wide bootstrap (Rules /
 # Lambda / DynamoDB / Fleet Provisioning template). Requires:
 #   * awsiotsdk (high-level MQTT5 + mTLS client builder)
@@ -101,7 +101,7 @@ mesh-iot = [
     "awscrt>=0.20.0,<1.0.0",
     "boto3>=1.34.0,<2.0.0",
 ]
-# Device Connect — device-aware networking layer (discovery, RPC, events,
+# Device Connect - device-aware networking layer (discovery, RPC, events,
 # safety). The primary transport in server mode; when this extra is not
 # installed, robot_mesh() falls back to the built-in Zenoh mesh.
 device-connect = [
@@ -235,7 +235,7 @@ select = [
     "UP",    # pyupgrade
 ]
 ignore = [
-    "E501",  # line too long — handled by formatter
+    "E501",  # line too long - handled by formatter
 ]
 
 [tool.ruff.lint.isort]
@@ -257,7 +257,7 @@ ignore_missing_imports = false
 module = ["lerobot.*", "gr00t.*", "draccus.*", "msgpack.*", "websockets", "websockets.*", "zmq.*", "huggingface_hub.*", "serial.*", "psutil.*", "torch.*", "torchvision.*", "transformers.*", "einops.*", "robot_descriptions.*", "mujoco.*", "imageio.*", "libero.*", "zenoh.*", "boto3", "boto3.*", "awscrt", "awscrt.*", "awsiot", "awsiot.*", "botocore.*", "strands_robots.policies.cosmos3._msgpack_numpy", "openpi_client", "openpi_client.*", "openpi_server", "openpi_server.*", "openpi", "openpi.*", "device_connect_edge", "device_connect_edge.*", "device_connect_agent_tools", "device_connect_agent_tools.*"]
 ignore_missing_imports = true
 
-# Device Connect drivers — thin wrappers over the untyped device_connect_edge
+# Device Connect drivers - thin wrappers over the untyped device_connect_edge
 # SDK; their RPC handlers return dicts that bubble Any (same posture as tools.*).
 [[tool.mypy.overrides]]
 module = ["strands_robots.device_connect.*"]
@@ -277,7 +277,7 @@ module = ["strands_robots.policies.*"]
 warn_return_any = false
 disallow_untyped_defs = false
 
-# Robot core — complex dynamic assembly, optional deps
+# Robot core - complex dynamic assembly, optional deps
 [[tool.mypy.overrides]]
 module = ["strands_robots.robot"]
 disallow_untyped_defs = false
@@ -288,20 +288,20 @@ warn_return_any = false
 module = ["strands_robots.__init__"]
 disallow_untyped_defs = false
 
-# AWS IoT bootstrap modules — boto3 always returns Any from API calls.
+# AWS IoT bootstrap modules - boto3 always returns Any from API calls.
 # We type the public surface explicitly (ProvisionedThing, BootstrappedAccount)
 # but the internal helpers naturally bubble Any from boto3.
 [[tool.mypy.overrides]]
 module = ["strands_robots.mesh.iot.*", "strands_robots.mesh.transport.iot_transport"]
 warn_return_any = false
 
-# Registry modules — dynamic JSON loading returns Any
+# Registry modules - dynamic JSON loading returns Any
 [[tool.mypy.overrides]]
 module = ["strands_robots.registry.*"]
 warn_return_any = false
 disallow_untyped_defs = false
 
-# MuJoCo simulation — mixins use cooperative self._world patterns
+# MuJoCo simulation - mixins use cooperative self._world patterns
 # attr-defined: Mixins access self._world/self._lock/etc. from Simulation (cooperative pattern)
 # assignment: PEP 484 implicit Optional (= None on typed params)
 # override: Subclass signatures extend base with extra params (orientation, mesh_path)
@@ -311,13 +311,13 @@ module = ["strands_robots.simulation.mujoco.*"]
 disallow_untyped_defs = false
 warn_return_any = false
 
-# Async utils and dataset recorder — thin wrappers with dynamic types
+# Async utils and dataset recorder - thin wrappers with dynamic types
 [[tool.mypy.overrides]]
 module = ["strands_robots._async_utils", "strands_robots.dataset_recorder"]
 disallow_untyped_defs = false
 warn_return_any = false
 
-# Test files — relaxed type checking for mocks, fixtures, and test utilities
+# Test files - relaxed type checking for mocks, fixtures, and test utilities
 [[tool.mypy.overrides]]
 module = ["tests.*", "tests_integ.*"]
 disallow_untyped_defs = false

--- a/strands_robots/__init__.py
+++ b/strands_robots/__init__.py
@@ -59,7 +59,7 @@ if TYPE_CHECKING:
     from strands_robots.tools.serial_tool import serial_tool
 
 # ------------------------------------------------------------------
-# Light-weight imports — no torch / lerobot / mujoco dependency
+# Light-weight imports - no torch / lerobot / mujoco dependency
 # ------------------------------------------------------------------
 from strands_robots.policies import MockPolicy, Policy, create_policy  # noqa: F401
 
@@ -92,7 +92,7 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "serial_tool": ("strands_robots.tools.serial_tool", "serial_tool"),
     # Robot mesh coordination tool (Device Connect dispatch + mesh fallback)
     "robot_mesh": ("strands_robots.tools.robot_mesh", "robot_mesh"),
-    # Device Connect integration — wraps robots as Device Connect devices
+    # Device Connect integration - wraps robots as Device Connect devices
     "init_device_connect": ("strands_robots.device_connect", "init_device_connect"),
     "init_device_connect_sync": ("strands_robots.device_connect", "init_device_connect_sync"),
     "RobotDeviceDriver": ("strands_robots.device_connect", "RobotDeviceDriver"),
@@ -145,7 +145,7 @@ __all__ = [
 #
 # GUARD: Skip when mujoco is not installed so users without the [sim-mujoco]
 # extra do not pay import-attempt cost on every `import strands_robots`.
-# This is the canonical location — strands_robots/simulation/__init__.py
+# This is the canonical location - strands_robots/simulation/__init__.py
 # intentionally does NOT duplicate this call.
 import importlib.util as _importlib_util  # noqa: E402
 

--- a/strands_robots/benchmarks/libero/adapter.py
+++ b/strands_robots/benchmarks/libero/adapter.py
@@ -83,7 +83,7 @@ class LiberoAdapter(BenchmarkProtocol):
 
     Attributes:
         max_steps: Default 720 (NVIDIA upstream
-            ``MultiStepConfig.max_episode_steps`` for LIBERO eval —
+            ``MultiStepConfig.max_episode_steps`` for LIBERO eval -
             see ``Isaac-GR00T/gr00t/eval/rollout_policy.py``). Override
             per-task by passing ``max_steps=`` to the constructor or
             mutating the attribute after construction. Pre-#168 we used the LIBERO repository's lifelong-learning
@@ -209,7 +209,7 @@ class LiberoAdapter(BenchmarkProtocol):
                 ``"<scene_gripper_prefix>grip_site"`` (i.e.
                 ``"gripper0_grip_site"`` for LIBERO scenes), which
                 matches what RoboSuite's ``OperationalSpaceController``
-                reads for ``robot0_eef_pos`` / ``robot0_eef_quat`` —
+                reads for ``robot0_eef_pos`` / ``robot0_eef_quat`` -
                 the site is at the gripper tip, ~9.7 cm BELOW the
                 wrist body and rotated 180° around X to point fingers
                 forward. Reading from the *body* (the #168 default)
@@ -280,11 +280,11 @@ class LiberoAdapter(BenchmarkProtocol):
                 scene's canonical home state AFTER ``super().on_episode_start``
                 and any camera install. Two branches:
 
-                * **Preferred** — when ``model.nkey > 0`` (MJCF declares a
+                * **Preferred** - when ``model.nkey > 0`` (MJCF declares a
                   ``<keyframe>``, which LIBERO-authored hand-written scenes
                   do): calls ``mujoco.mj_resetDataKeyframe(model, data,
                   scene_keyframe_index)``.
-                * **Fallback** — when ``model.nkey == 0`` (MJCFs from the
+                * **Fallback** - when ``model.nkey == 0`` (MJCFs from the
                   procedural :meth:`_generate_scene_from_bddl` path don't
                   carry a keyframe): snapshot-and-restore. The first
                   episode after a scene compile captures
@@ -381,7 +381,7 @@ class LiberoAdapter(BenchmarkProtocol):
         self._gripper_joint_name: str = str(gripper_joint_name) if gripper_joint_name is not None else "finger_joint1"
         # EEF state site (#168). The state observations fed to
         # GR00T (state.x/y/z/roll/pitch/yaw) must come from the gripper
-        # *tip* — the same site that RoboSuite's
+        # *tip* - the same site that RoboSuite's
         # ``OperationalSpaceController`` reads for its
         # ``robot0_eef_pos`` / ``robot0_eef_quat`` observables. Reading
         # from the wrist *body* (the #168 default) is ~9.7 cm above
@@ -405,7 +405,7 @@ class LiberoAdapter(BenchmarkProtocol):
         self._user_gripper_joint_name: str | None = str(gripper_joint_name) if gripper_joint_name is not None else None
         # State-side gripper joint names (#168). LIBERO trains
         # ``state.gripper`` on a 2-element vector ``[finger1.qpos, finger2.qpos]``
-        # — the two fingers have OPPOSITE-sign qpos by physical
+        # - the two fingers have OPPOSITE-sign qpos by physical
         # convention (they move apart). Pre-#168 we read ONE
         # finger from ``obs[gripper_joint_name]`` and packed it as
         # ``[v, v]`` (both positive), which is structurally
@@ -480,7 +480,7 @@ class LiberoAdapter(BenchmarkProtocol):
         self._bddl_path = bddl_path
         self._success_fn: Callable[[SimEngine], bool] = compile_goal(problem.goal)
 
-        # #168 — diagnostic logging gate for the STATE side
+        # #168 - diagnostic logging gate for the STATE side
         # of the policy interface. Set ``STRANDS_LIBERO_STATE_LOG=1`` to
         # emit one structured INFO log line per ``augment_observation``
         # call for the first ``STRANDS_LIBERO_STATE_LOG_MAX`` (default
@@ -491,7 +491,7 @@ class LiberoAdapter(BenchmarkProtocol):
         # #168 verification showed ``arm_qpos`` advances and
         # ``eef_pos`` tracks deltas, but the policy is commanding tiny
         # deltas (~0.01 in [-1, +1] normalized space). The remaining
-        # `success_rate=0` is on the state-input side — GR00T sees an
+        # `success_rate=0` is on the state-input side - GR00T sees an
         # observation that says "EEF is already where it needs to be"
         # and emits near-zero deltas. STATE_LOG dumps exactly what we
         # feed GR00T so we can compare against LIBERO's
@@ -856,7 +856,7 @@ class LiberoAdapter(BenchmarkProtocol):
         # runs. Otherwise super().on_episode_start (the base
         # BenchmarkProtocol) would see an empty list_robots() (because
         # Simulation.load_scene resets world.robots = {}) and call its
-        # own sim.add_robot — which recompiles the spec, jumping
+        # own sim.add_robot - which recompiles the spec, jumping
         # model.nq from N1 → N2 (#166 second-round verification: probe
         # showed 44 → 53 with a LIBERO scene). That recompile would
         # invalidate any qpos snapshot we then capture, since ep1's
@@ -915,14 +915,14 @@ class LiberoAdapter(BenchmarkProtocol):
         if self._init_jitter > 0:
             self._apply_init_jitter(sim, rng)
 
-        # #176 (sub-task 3d) — settle physics by one zero-action
+        # #176 (sub-task 3d) - settle physics by one zero-action
         # control step so the first observation handed to the policy is
         # at "init_state + 1 OSC step", matching upstream LIBERO's
         # ``OffScreenRenderEnv.reset`` which does
         # ``set_init_state(...) + env.step(np.zeros(7))`` (see NVIDIA's
         # ``libero_env.py:257``). Without this settle, the MuJoCoSimEngine
         # path's first observation is at the raw ``init_state[i]`` while
-        # upstream's first observation is one control step ahead — the
+        # upstream's first observation is one control step ahead - the
         # same training data was generated against the
         # post-step state, so feeding the raw init_state to a policy
         # trained on post-step inputs is OOD by a few mm / mrad.
@@ -937,7 +937,7 @@ class LiberoAdapter(BenchmarkProtocol):
         # Best-effort: gated on having a working OSC controller (which
         # owns_stepping). If the controller wasn't installed (warning
         # already logged in ``_install_action_controller``), skip the
-        # settle to avoid raising — the eval will still run, just at
+        # settle to avoid raising - the eval will still run, just at
         # the un-settled init pose.
         if scene_was_loaded:
             world = getattr(sim, "_world", None)
@@ -955,7 +955,7 @@ class LiberoAdapter(BenchmarkProtocol):
                                 e,
                             )
 
-        # #168 — reset per-episode state-log counter so each
+        # #168 - reset per-episode state-log counter so each
         # episode emits its own first N STATE_LOG lines (matches the
         # #168 behaviour for ACTION_LOG via the controller's
         # reset() call inside _install_action_controller above).
@@ -1367,7 +1367,7 @@ class LiberoAdapter(BenchmarkProtocol):
         gripper *site* (``self.eef_state_site_name`` →
         ``"gripper0_grip_site"`` for LIBERO scenes) instead of the
         wrist *body* (``self._eef_body_name`` → ``"robot0_right_hand"``).
-        These differ by ~9.7 cm in z and 180° rotation around X — the
+        These differ by ~9.7 cm in z and 180° rotation around X - the
         site is at the gripper TIP, the body is at the wrist. RoboSuite's
         ``OperationalSpaceController`` reads from the site for its own
         ``robot0_eef_pos`` / ``robot0_eef_quat`` observables, so reading
@@ -1425,7 +1425,7 @@ class LiberoAdapter(BenchmarkProtocol):
             merged.setdefault("pitch", pitch)
             merged.setdefault("yaw", yaw)
 
-        # Gripper — #168. LIBERO trains ``state.gripper`` on
+        # Gripper - #168. LIBERO trains ``state.gripper`` on
         # ``robot0_gripper_qpos`` from LIBERO/RoboSuite, which is a
         # 2-element array
         # ``[gripper0_finger_joint1.qpos, gripper0_finger_joint2.qpos]``.
@@ -1434,7 +1434,7 @@ class LiberoAdapter(BenchmarkProtocol):
         # ``[+0.0208, -0.0208]``. Pre-#168 we read only one finger
         # via ``obs[self._gripper_joint_name]`` and packed it as
         # ``[v, v]`` (both positive), which fed GR00T structurally
-        # out-of-distribution state — manifest as near-zero policy
+        # out-of-distribution state - manifest as near-zero policy
         # deltas across rounds 23-32 of #168.
         #
         # Read both finger qpos directly from ``data.qpos[jnt_qposadr]``
@@ -1445,7 +1445,7 @@ class LiberoAdapter(BenchmarkProtocol):
         if gripper_qpos is not None:
             merged.setdefault("gripper", gripper_qpos)
         else:
-            # Legacy fallback — read one joint from obs and duplicate
+            # Legacy fallback - read one joint from obs and duplicate
             # (preserves pre-#168 behaviour for non-RoboSuite
             # scenes; the duplicate-packing is wrong for LIBERO but
             # there's no better default for unknown gripper layouts).
@@ -1466,7 +1466,7 @@ class LiberoAdapter(BenchmarkProtocol):
                     self._gripper_joint_name,
                 )
 
-        # #168 — flip rendered images vertically to match
+        # #168 - flip rendered images vertically to match
         # upstream LIBERO's ``OffScreenRenderEnv`` pixel convention.
         #
         # WHY: our ``sim.render()`` returns top-row-zero (image
@@ -1481,7 +1481,7 @@ class LiberoAdapter(BenchmarkProtocol):
         # #168 ``tests_integ/.../diff_libero_obs.py`` measured the
         # delta: ``mean |Δ| = 56/255`` for raw vs raw, but
         # ``mean |Δ| = 5.40/255`` after applying ``[::-1, :]`` to ours
-        # — a 10× reduction confirming the vertical-flip-only
+        # - a 10× reduction confirming the vertical-flip-only
         # mismatch (a horizontal mirror would have shown the opposite
         # asymmetry).
         #
@@ -1494,7 +1494,7 @@ class LiberoAdapter(BenchmarkProtocol):
         # Applied to BOTH ``image`` and ``wrist_image`` because both
         # come from our mujoco renderer with the same convention. We
         # use ``np.ascontiguousarray`` so downstream serialization
-        # (msgpack / numpy.tobytes()) works — reversed views are not
+        # (msgpack / numpy.tobytes()) works - reversed views are not
         # contiguous.
         #
         # Best-effort: if the image isn't a numpy ndarray (e.g. a
@@ -1506,7 +1506,7 @@ class LiberoAdapter(BenchmarkProtocol):
             if isinstance(cam_value, np.ndarray) and cam_value.ndim >= 2:
                 merged[cam_key] = np.ascontiguousarray(cam_value[::-1, :])
 
-        # #168 — emit one structured STATE_LOG line per
+        # #168 - emit one structured STATE_LOG line per
         # ``augment_observation`` call when STRANDS_LIBERO_STATE_LOG=1.
         # Captures the EXACT state values fed to GR00T's policy server,
         # for offline comparison against LIBERO's
@@ -1535,7 +1535,7 @@ class LiberoAdapter(BenchmarkProtocol):
     def _read_eef_pose(self, sim: SimEngine) -> tuple[list[float] | None, list[float] | None]:
         """Read EEF position + (wxyz) quaternion for ``augment_observation``.
 
-        **#168 — split sources matching RoboSuite exactly.**
+        **#168 - split sources matching RoboSuite exactly.**
         RoboSuite's ``robosuite/robots/single_arm.py`` reads from TWO
         DIFFERENT POINTS in the kinematic chain::
 
@@ -1550,12 +1550,12 @@ class LiberoAdapter(BenchmarkProtocol):
 
         The site sits at the gripper tip; the body sits at the wrist
         (~9.7 cm above the site). Their rotation matrices have a 90°
-        offset around Z relative to each other — RoboSuite picks the
+        offset around Z relative to each other - RoboSuite picks the
         body's orientation deliberately because that's what the
         downstream observable + dataset expects.
 
         #168 (initial diagnosis): we read both pos AND quat from the
-        wrist body — pos was 71.8 mm off in z and orientation 180°
+        wrist body - pos was 71.8 mm off in z and orientation 180°
         off in roll. #168 (first attempt): moved BOTH to the site,
         which fixed position (within 5 mm) but introduced a 90° yaw
         offset because site_xmat ≠ body xquat. #168 (final fix):
@@ -1608,7 +1608,7 @@ class LiberoAdapter(BenchmarkProtocol):
                 # 1b. BODY → orientation. Matches RoboSuite's
                 # ``eef_quat`` observable: ``data.xquat[eef_body_id]``
                 # (mujoco's xquat is wxyz, so no convert_quat needed
-                # — our downstream ``_quat_wxyz_to_rpy_xyz`` expects
+                # - our downstream ``_quat_wxyz_to_rpy_xyz`` expects
                 # wxyz).
                 body_name = self._eef_body_name
                 if body_name:
@@ -1639,7 +1639,7 @@ class LiberoAdapter(BenchmarkProtocol):
         # site, or the ``hand``-named body for bare Menagerie Panda).
         # ``sim.get_body_state`` is namespace-aware (handles
         # ``panda_arm/hand`` for multi-robot scenes) and returns
-        # ``(pos, quat_wxyz)`` — same shape we promise here.
+        # ``(pos, quat_wxyz)`` - same shape we promise here.
         get_body_state = getattr(sim, "get_body_state", None)
         fallback_pos: list[float] | None = None
         fallback_quat: list[float] | None = None
@@ -1653,7 +1653,7 @@ class LiberoAdapter(BenchmarkProtocol):
         else:
             logger.debug("LiberoAdapter: sim has no get_body_state(); skipping EEF state injection")
 
-        # 4. Mix direct and fallback reads — each axis populated by
+        # 4. Mix direct and fallback reads - each axis populated by
         # whichever source succeeded first. Site/body get top
         # priority (canonical RoboSuite split); fallback fills gaps.
         merged_pos = site_pos if site_pos is not None else fallback_pos
@@ -1686,7 +1686,7 @@ class LiberoAdapter(BenchmarkProtocol):
           compiled model
 
         ``None`` rather than partial data so the caller's fallback
-        logic stays simple — there's no half-good case worth
+        logic stays simple - there's no half-good case worth
         propagating.
         """
         world = getattr(sim, "_world", None)
@@ -1945,7 +1945,7 @@ class LiberoAdapter(BenchmarkProtocol):
         (scene-supplied + injected = two kinematic chains, ``nq``
         jumps ``44 → 53`` on LIBERO SCENE5) and leaves the redundant
         Panda's plastic shells right in front of the ``image`` camera
-        — that's #166's smoking gun: every "real-render" frame
+        - that's #166's smoking gun: every "real-render" frame
         is yellow-saturated by the second Panda's links 5/6.
 
         The fix has to register a wrapper for the **existing** Panda
@@ -2361,14 +2361,14 @@ class LiberoAdapter(BenchmarkProtocol):
                 # them via its ``cam_info.height/width`` lookup. Without
                 # this step, model-side cameras fall through to the
                 # 480×640 ``default_height``/``default_width`` of the
-                # renderer mixin — which is a different aspect ratio AND
+                # renderer mixin - which is a different aspect ratio AND
                 # resolution from training (256×256), feeding GR00T
                 # out-of-distribution images even after the #168
                 # vertical-flip fix. Diagnostic
                 # ``/tmp/opencode/eval-runs/diff_libero_obs.py`` showed
                 # ``sim.get_observation()`` returned 480×640 while
                 # ``sim.render(camera="image", width=256, height=256)``
-                # correctly returned 256×256 — the divergence was
+                # correctly returned 256×256 - the divergence was
                 # entirely in the get_observation path.
                 self._publish_camera_dims_to_world(sim, cam_name, cam_kwargs)
                 continue
@@ -2382,7 +2382,7 @@ class LiberoAdapter(BenchmarkProtocol):
                 # "already exists" is benign - the scene XML beat us to it.
                 if "already exists" in msg.lower():
                     logger.debug("LiberoAdapter: camera %r already declared by scene", cam_name)
-                    # Same publish step as the skip branch above —
+                    # Same publish step as the skip branch above -
                     # ``add_camera`` early-returned with "already exists"
                     # because the scene's MJCF declared the camera, so
                     # ``world.cameras[cam_name]`` is still empty. Inject
@@ -2408,7 +2408,7 @@ class LiberoAdapter(BenchmarkProtocol):
         the sim has no ``_world`` or no ``cameras`` registry.
 
         Note: ``camera_id`` is left at the default ``-1`` because we
-        don't know (and don't need) the model-side camera index here —
+        don't know (and don't need) the model-side camera index here -
         :meth:`_get_sim_observation` looks it up via ``mj_name2id``.
         Only the ``height`` / ``width`` fields matter for this code
         path; the pose / FOV fields are not used (the model-compiled
@@ -2760,7 +2760,7 @@ class LiberoAdapter(BenchmarkProtocol):
             # snapshot is at MuJoCo's default qpos=0, which is
             # significantly off from upstream's ``MountedPanda.init_qpos``
             # post-``Robot.reset``. Best-effort: failures during home-
-            # pose discovery / write fall through silently — the
+            # pose discovery / write fall through silently - the
             # snapshot captures whatever ``data.qpos`` happens to be.
             self._write_libero_arm_home_qpos(model, data, mj, lock)
             try:
@@ -2833,7 +2833,7 @@ class LiberoAdapter(BenchmarkProtocol):
             if jname.startswith(self._scene_robot_prefix) and not jname.startswith(self._scene_gripper_prefix):
                 arm_qpos_addrs.append(int(model.jnt_qposadr[i]))
             elif jname.startswith(self._scene_gripper_prefix):
-                # Filter to finger joints only — match #168 convention
+                # Filter to finger joints only - match #168 convention
                 # (gripper0_finger_joint1, gripper0_finger_joint2).
                 if "finger_joint" in jname:
                     gripper_qpos_addrs.append(int(model.jnt_qposadr[i]))
@@ -2975,7 +2975,7 @@ def _walk_predicate_tree(node: Any, sim: SimEngine) -> list[tuple[str, bool]]:
 
     Each reported leaf string includes the actual body positions
     looked up via ``sim.get_body_state`` so we can see why a position-
-    based predicate (``on``, ``inside``, etc.) returned its verdict —
+    based predicate (``on``, ``inside``, etc.) returned its verdict -
     distinguishes between "name doesn't resolve" (None pos), "wrong
     geometric threshold" (positions present but predicate still False),
     and "true success" (positions present and predicate True).
@@ -3094,7 +3094,7 @@ def _quat_wxyz_to_rpy_xyz(quat_wxyz: list[float]) -> tuple[float, float, float]:
         pitch = asin(-M[2,0])         = asin(2(wy - xz))
         yaw   = atan2(M[1,0], M[0,0]) = atan2(2(wz + xy), 1 - 2(y² + z²))
 
-    Pure numpy / stdlib — **does not import scipy**, which is not a
+    Pure numpy / stdlib - **does not import scipy**, which is not a
     declared dependency of strands_robots. Equivalent to
     ``robosuite.utils.transform_utils.mat2euler(R, axes='sxyz')``
     on the rotation matrix derived from ``q``.
@@ -3168,13 +3168,13 @@ def _extract_compiled_mjcf(env: Any) -> str:
     """Pull the MJCF XML out of a ``libero`` ControlEnv.
 
     Prefers ``env.env.model.get_xml()`` (the **pre-compile** MJCF emitted by
-    robosuite's ``ManipulationTask`` — what gets handed to
+    robosuite's ``ManipulationTask`` - what gets handed to
     ``MjModel.from_xml_string`` at construction time). Falls back to
     ``env.env.sim.model.get_xml()`` (a **post-compile** re-serialization via
     ``mj_saveLastXML``) if the pre-compile accessor isn't available.
 
     **Why pre-compile is preferred (#181).** ``mj_saveLastXML`` is a lossy
-    round-trip — it doesn't preserve every ``<compiler>`` attribute. In
+    round-trip - it doesn't preserve every ``<compiler>`` attribute. In
     particular ``inertiagrouprange="0 0"`` is dropped, so re-loading the
     saved XML re-computes body inertias from ALL geom groups (including
     visual meshes) rather than just collision geoms (group 0). Effect on
@@ -3191,7 +3191,7 @@ def _extract_compiled_mjcf(env: Any) -> str:
     fallbacks before giving up. Never looks at any non-public attributes.
     """
     accessors = (
-        # #181 — preferred: pre-compile MJCF from robosuite's
+        # #181 - preferred: pre-compile MJCF from robosuite's
         # ``ManipulationTask``. Preserves ``<compiler>`` attributes that
         # ``mj_saveLastXML`` drops (notably ``inertiagrouprange``).
         lambda: env.env.model.get_xml(),
@@ -3251,21 +3251,21 @@ def _rename_mjcf_cameras(xml: str, aliases: dict[str, str]) -> str:
 #
 # History:
 # * ``v1``: implicit (pre-#168, alias map alone in cache key).
-# * ``v2``: #168 (initial attempt) — applied ``_apply_libero_visual_fixes`` (rgba alpha=0 on
+# * ``v2``: #168 (initial attempt) - applied ``_apply_libero_visual_fixes`` (rgba alpha=0 on
 #   collision geoms + custom ``<visual>`` block with stacked ``<headlight>``).
 #   Empirically wrong direction (washed out contrast); reverted in v3.
-# * ``v3``: #168 (subsequent revert) — cached MJCF matches upstream ``OffScreenRenderEnv.sim.model.get_xml()``
+# * ``v3``: #168 (subsequent revert) - cached MJCF matches upstream ``OffScreenRenderEnv.sim.model.get_xml()``
 #   verbatim except for the camera-name aliases. Visual fidelity is
 #   handled at render time via ``world._backend_state["viz_option"]``
 #   (set by :meth:`LiberoAdapter._install_render_options`), not via
 #   MJCF rewrites.
-# * ``v4``: #181 — switch ``_extract_compiled_mjcf`` to prefer
+# * ``v4``: #181 - switch ``_extract_compiled_mjcf`` to prefer
 #   ``env.env.model.get_xml()`` (pre-compile) over
 #   ``env.env.sim.model.get_xml()`` (post-compile via ``mj_saveLastXML``).
 #   The post-compile path is lossy on ``<compiler>`` attributes, dropping
 #   ``inertiagrouprange="0 0"`` which restricts inertia computation to
 #   collision geoms (group 0). Without it, MuJoCo computes body masses
-#   from ALL geom groups including visual meshes — table mass jumps from
+#   from ALL geom groups including visual meshes - table mass jumps from
 #   34.5 kg to 77.5 kg, mug masses go up 4×, and ``mj_step`` produces
 #   different ``qfrc_bias`` (Coriolis + gravity) than upstream's runtime
 #   model. Effect on libero-10/SCENE5: end-to-end ``success_rate`` mean
@@ -3511,12 +3511,12 @@ class _LiberoOSCController:
             dtype=np.float64,
         )
 
-        # #168 — diagnostic logging gate. Set
+        # #168 - diagnostic logging gate. Set
         # ``STRANDS_LIBERO_ACTION_LOG=1`` to emit one structured INFO
         # log line per ``apply()`` call for the first
         # ``STRANDS_LIBERO_ACTION_LOG_MAX`` (default 50) calls per
         # episode. Captures action keys, delta scale, gripper polarity,
-        # EEF tracking, and qpos/ctrl deltas — answers the diagnostic
+        # EEF tracking, and qpos/ctrl deltas - answers the diagnostic
         # questions in PR #168 verification.
         self._action_log_enabled = os.environ.get("STRANDS_LIBERO_ACTION_LOG", "").strip().lower() in (
             "1",
@@ -3540,7 +3540,7 @@ class _LiberoOSCController:
         #168: the gripper's ``current_action`` is a stateful
         ramp accumulator (per ``PandaGripper.format_action``). Without a
         reset, the second episode starts with whatever finger position
-        the first episode ended at — typically a partially-closed
+        the first episode ended at - typically a partially-closed
         gripper, which biases every grasp attempt. Called from
         :meth:`LiberoAdapter._install_action_controller` (which itself is
         called from ``on_episode_start``) so each episode starts with a
@@ -3685,7 +3685,7 @@ class _LiberoOSCController:
         )
         controller_config["actuator_range"] = (ctrl_low, ctrl_high)
 
-        # #176 — temporarily set ``data.qpos[arm]`` to the
+        # #176 - temporarily set ``data.qpos[arm]`` to the
         # LIBERO-canonical Panda "ready" pose around the
         # ``controller_factory`` call so the controller's
         # construction-time state capture matches upstream LIBERO
@@ -3717,7 +3717,7 @@ class _LiberoOSCController:
         # EEF location. Then ``env.set_init_state(init_states[i])``
         # overwrites ``data.qpos`` with the per-episode canonical
         # state, but the controller's initial-state attributes are
-        # frozen — leading to a non-trivial nullspace bias and a
+        # frozen - leading to a non-trivial nullspace bias and a
         # ``goal_ori`` that's ~54 mrad different from the perturbed
         # canonical pose.
         #
@@ -3734,7 +3734,7 @@ class _LiberoOSCController:
         # reflect the home pose, building the controller (which
         # captures everything from the home-pose state), then
         # restoring ``data.qpos[arm]`` and calling ``mj_forward``
-        # again. ``data.qvel`` is left as-is — upstream's
+        # again. ``data.qvel`` is left as-is - upstream's
         # ``Robot.reset`` doesn't touch qvel, and our canonical
         # ``init_state`` is at zero velocity anyway.
         #
@@ -3851,7 +3851,7 @@ class _LiberoOSCController:
         via ``controller.update()`` (gated by the ``new_update`` flag
         which is set every iteration by the base class), so the OSC
         torques track the integrated state. Without the substep loop
-        we ran OSC at 500 Hz (the physics rate) — the controller
+        we ran OSC at 500 Hz (the physics rate) - the controller
         designed each torque profile for a 25-step horizon but only
         applied it for 1 step before the policy delivered a fresh
         delta, leading to the #168 "robot moves but never
@@ -3902,11 +3902,11 @@ class _LiberoOSCController:
         # drifted -19.6 mm in 50 zero-action steps while upstream stayed
         # at ~+20 mm.
         #
-        # Production eval is unaffected — the policy always sends
+        # Production eval is unaffected - the policy always sends
         # ``gripper`` in the action chunk so the default never fires.
         gripper_value = _to_scalar(action_dict.get("gripper", 0.5))
 
-        # #168 — convert RLDS gripper convention → robosuite/LIBERO
+        # #168 - convert RLDS gripper convention → robosuite/LIBERO
         # convention. The GR00T-N1.7-LIBERO checkpoint emits ``action.gripper``
         # in the RLDS dataloader's convention (``0 = close``, ``1 = open``);
         # robosuite's ``PandaGripper.format_action`` expects the opposite
@@ -3930,7 +3930,7 @@ class _LiberoOSCController:
         # Pre-#168 we passed the raw model output to our OSC's
         # ``np.sign(gripper_value)`` directly. Since the model's typical
         # outputs are in [0, 1], every "open" intent (model output ≈ 1)
-        # collapsed to ``sign=+1``, which our OSC interprets as CLOSE — so
+        # collapsed to ``sign=+1``, which our OSC interprets as CLOSE - so
         # the gripper consistently went CLOSED for OPEN commands and
         # vice-versa. This is the action-side counterpart to #168's
         # observation-side V-flip bug; both rounds together close the
@@ -3941,7 +3941,7 @@ class _LiberoOSCController:
         #
         # Diagnostic that surfaced this: NVIDIA's reference eval against
         # the SAME checkpoint+task got ``success_rate=1.0`` at 10s/ep,
-        # while ours stayed at 0.0 at 120s/ep — clear ground-truth proof
+        # while ours stayed at 0.0 at 120s/ep - clear ground-truth proof
         # the gap was on our side.
         gripper_value = -float(np.sign(2.0 * gripper_value - 1.0))
 
@@ -3982,7 +3982,7 @@ class _LiberoOSCController:
         gripper_sign = float(np.sign(gripper_value))
         ramp_step = np.array([-1.0, 1.0]) * self._GRIPPER_SPEED * gripper_sign
 
-        # #168 — capture pre-step state for diagnostic log.
+        # #168 - capture pre-step state for diagnostic log.
         # Gated on ``STRANDS_LIBERO_ACTION_LOG=1`` so production eval
         # incurs zero cost (single bool check). The full diagnostic
         # answers PR #168's "what scale, what frame, what key
@@ -4044,7 +4044,7 @@ class _LiberoOSCController:
 
             mj.mj_step(model, data)
 
-        # #168 — emit one structured log line per apply()
+        # #168 - emit one structured log line per apply()
         # while inside the captured-step window. Captures everything a
         # reviewer needs to bisect the residual bug: action key names,
         # delta scale, gripper polarity end-to-end, EEF tracking
@@ -4107,7 +4107,7 @@ class _LiberoOSCController:
         pos = np.array(data.site_xpos[self.eef_site_id], dtype=np.float64)
         xmat = np.asarray(data.site_xmat[self.eef_site_id], dtype=np.float64).reshape(9)
         quat = np.zeros(4, dtype=np.float64)
-        # Lazy import — adapter must be importable without mujoco.
+        # Lazy import - adapter must be importable without mujoco.
         import mujoco as mj
 
         mj.mju_mat2Quat(quat, xmat)
@@ -4117,7 +4117,7 @@ class _LiberoOSCController:
 # Module-level cache: resolving the LIBERO-canonical Panda home pose
 # imports the libero robot module, which transitively imports robosuite,
 # loads MJCF assets, and warns about missing macro files. The result is
-# immutable per-process — cache it after the first lookup so calls 50×
+# immutable per-process - cache it after the first lookup so calls 50×
 # per second from ``_install_action_controller`` are free.
 _CACHED_LIBERO_HOME_QPOS: np.ndarray | None = None
 _CACHED_LIBERO_HOME_QPOS_RESOLVED: bool = False
@@ -4129,15 +4129,15 @@ def _resolve_libero_arm_home_qpos(n_arm: int) -> np.ndarray | None:
     Resolution order:
 
     1. ``libero.libero.envs.robots.mounted_panda.MountedPanda().init_qpos``
-       — stock LIBERO layout (``pip install libero``).
+       - stock LIBERO layout (``pip install libero``).
     2. ``libero.envs.robots.mounted_panda.MountedPanda().init_qpos``
-       — LIBERO-PRO layout (the LIBERO-PRO fork uses a flatter package
+       - LIBERO-PRO layout (the LIBERO-PRO fork uses a flatter package
        structure). Same canonical ``init_qpos`` byte-for-byte.
     3. ``robosuite.models.robots.Panda().init_qpos`` (stock
-       robosuite, slightly different — ``[0, π/16, 0, -π/2-π/3, 0,
+       robosuite, slightly different - ``[0, π/16, 0, -π/2-π/3, 0,
        π-0.2, π/4]`` vs ``[0, -0.161, 0, -2.4446, 0, 2.2268, π/4]``).
        Only used when neither libero variant is importable.
-    4. ``None`` if nothing is available — caller falls back to the
+    4. ``None`` if nothing is available - caller falls back to the
        controller's construction-time default.
 
     Both LIBERO layouts produce the same ``MountedPanda.init_qpos``,
@@ -4257,8 +4257,8 @@ def _resolve_panda_gripper_init_qpos(n_finger: int) -> np.ndarray | None:
 
     1. ``robosuite.models.grippers.panda_gripper.PandaGripper().init_qpos``
        (the library function used by both stock libero and LIBERO-PRO).
-    2. ``None`` — caller leaves gripper qpos at MuJoCo's default (zero,
-       which is "fingers touching" — significantly different from the
+    2. ``None`` - caller leaves gripper qpos at MuJoCo's default (zero,
+       which is "fingers touching" - significantly different from the
        open canonical pose). The 14 mm divergence between
        ``data.qpos[gripper] = 0`` (closed) and ``data.qpos[gripper] =
        0.0208`` (open) is enough to put the policy out-of-distribution

--- a/strands_robots/benchmarks/libero/bddl_parser.py
+++ b/strands_robots/benchmarks/libero/bddl_parser.py
@@ -192,7 +192,7 @@ def _on_kwargs(args: list[str]) -> dict[str, Any]:
     # ``a.z >= b.z`` (no offset) AND ``|a.xy - b.xy| < 0.03 m`` AND
     # contact between A and B. The empirical at-success state on
     # ``libero-10/SCENE5`` has mug.z 4 mm above plate.z and mug.xy 1.2 cm
-    # off plate.xy — the loose defaults rejected this as ``False`` while
+    # off plate.xy - the loose defaults rejected this as ``False`` while
     # ``env.check_success()`` returned ``True`` (#170 diagnostic).
     #
     # #171 sub-task 3e: also require physics contact via

--- a/strands_robots/benchmarks/libero/suite.py
+++ b/strands_robots/benchmarks/libero/suite.py
@@ -114,10 +114,10 @@ def _resolve_libero_root() -> Path:
 
     Handles two install layouts:
 
-    1. Regular package — ``libero.__file__`` points at
+    1. Regular package - ``libero.__file__`` points at
        ``.../site-packages/libero/__init__.py``; the parent directory is
        the package root.
-    2. Namespace package (PEP 420) — ``libero.__file__`` is ``None``;
+    2. Namespace package (PEP 420) - ``libero.__file__`` is ``None``;
        ``libero.__path__`` carries one or more directory entries (e.g.
        NVIDIA's ``setup_libero.sh`` installs LIBERO this way: a
        symlinked checkout where ``libero`` has no ``__init__.py``).

--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -222,7 +222,7 @@ class DatasetRecorder:
         returns a READ-ONLY dataset (``add_frame`` raises), so ``resume()`` is
         the only correct append entry point in LeRobot 0.5.2+.
 
-        Feature schema is inherited from the existing dataset on disk — the
+        Feature schema is inherited from the existing dataset on disk - the
         caller's joint/camera layout must match what was originally recorded.
 
         Args:
@@ -538,7 +538,7 @@ class DatasetRecorder:
             }
         except Exception as e:
             logger.error("save_episode failed: %s", e)
-            # Mark recorder as poisoned — the LeRobot episode buffer is in
+            # Mark recorder as poisoned - the LeRobot episode buffer is in
             # undefined state after a failed save. Subsequent add_frame calls
             # would silently corrupt the dataset. Close to prevent drift.
             self._closed = True

--- a/strands_robots/device_connect/GUIDE.md
+++ b/strands_robots/device_connect/GUIDE.md
@@ -1,6 +1,6 @@
 # Device Connect Integration
 
-Strands Robots uses [Device Connect](https://github.com/arm/device-connect), a **device-aware runtime** by Arm — to handle discovery, presence, structured RPC, event routing, and safety — so you can focus on building cross-device experiences instead of re-implementing infrastructure.
+Strands Robots uses [Device Connect](https://github.com/arm/device-connect), a **device-aware runtime** by Arm - to handle discovery, presence, structured RPC, event routing, and safety - so you can focus on building cross-device experiences instead of re-implementing infrastructure.
 
 > **Fallback behavior:** If `device-connect-edge` is not installed, Strands Robots automatically falls back to a built-in Zenoh P2P mesh (`zenoh_mesh.py`) for basic peer discovery and coordination. Device Connect is the recommended and primary networking layer.
 
@@ -13,7 +13,7 @@ r = Robot("so100")
 r.run()  # starts listening for commands. Ctrl+C to stop.
 ```
 
-`Robot()` creates the robot. `.run()` starts Device Connect with D2D defaults (Zenoh multicast scouting, no broker) and blocks — the robot becomes discoverable on the LAN and listens for commands. Without `.run()`, the script exits and the robot is removed from the network.
+`Robot()` creates the robot. `.run()` starts Device Connect with D2D defaults (Zenoh multicast scouting, no broker) and blocks - the robot becomes discoverable on the LAN and listens for commands. Without `.run()`, the script exits and the robot is removed from the network.
 
 > **Secure by default:** Device Connect no longer enables unencrypted/unauthenticated transport implicitly. For a local, trusted-network D2D trial without a broker, explicitly opt in to insecure transport:
 > ```bash
@@ -27,8 +27,8 @@ You can optionally pass `peer_id="so100-lab-1"` for a stable address; otherwise 
 
 | Pattern | Behavior |
 |---|---|
-| `r = Robot("so100"); r.run()` | **Option A — Foreground server.** Process stays alive, listens for commands. Ctrl+C to stop. |
-| `r = Robot("so100")` | **Option B — Agent-controlled.** A Strands Agent discovers the robot via `robot_mesh` or `discover()` and invokes commands remotely. |
+| `r = Robot("so100"); r.run()` | **Option A - Foreground server.** Process stays alive, listens for commands. Ctrl+C to stop. |
+| `r = Robot("so100")` | **Option B - Agent-controlled.** A Strands Agent discovers the robot via `robot_mesh` or `discover()` and invokes commands remotely. |
 
 From another process, discover and invoke:
 
@@ -41,8 +41,8 @@ robot_mesh(action="tell", target="so100-lab-1",      # invoke (HITL-approved)
 robot_mesh(action="emergency_stop")                   # e-stop all (HITL-approved)
 ```
 
-> **Heads up:** the actuation actions — `tell`, `send`, `stop`, `broadcast`,
-> `emergency_stop`, and `rpc` — are gated behind a human-in-the-loop approval, so
+> **Heads up:** the actuation actions - `tell`, `send`, `stop`, `broadcast`,
+> `emergency_stop`, and `rpc` - are gated behind a human-in-the-loop approval, so
 > they run only from inside a Strands agent loop (where the operator approves).
 > Called from a bare script they **fail closed**. Read-only `peers` works
 > anywhere. The gated set is configurable via `STRANDS_MESH_HITL_ACTIONS`.
@@ -145,7 +145,7 @@ Expected output:
 
 ```
 Discovered 1 device(s):
-  [sim] <PEER_ID> — idle
+  [sim] <PEER_ID> - idle
     Functions: execute, getFeatures, getStatus, reset, step, stop
 ```
 
@@ -181,15 +181,15 @@ context."}]}
 
 **Emergency stop all devices:**
 
-> **Safety — human-in-the-loop.** Every physical-actuation action —
-> `emergency_stop`, `broadcast`, `tell`, `send`, `stop`, and `rpc` — is gated
+> **Safety - human-in-the-loop.** Every physical-actuation action -
+> `emergency_stop`, `broadcast`, `tell`, `send`, `stop`, and `rpc` - is gated
 > behind an operator approval interrupt (`tool_context.interrupt`), plus a
 > per-action rate limit and an audit log. They run only when invoked from inside
 > a Strands agent loop, where the operator approves the action out-of-band of the
 > LLM's tool arguments (so prompt-injection cannot smuggle approval). The gated
 > set is configurable via `STRANDS_MESH_HITL_ACTIONS`. Device Connect dispatch is
 > layered *under* this gate, so DC inherits the same safety. Called as a bare
-> script — with no operator to ask — these actions **fail closed**:
+> script - with no operator to ask - these actions **fail closed**:
 
 ```python
 python -c "
@@ -225,7 +225,7 @@ connect()
 found = discover('device(*)')
 print(f'Found {found[\"matched\"]} robot(s):')
 for d in found['results']:
-    print(f'  {d[\"device_id\"]} — {d.get(\"status\", {}).get(\"availability\", \"?\")}')
+    print(f'  {d[\"device_id\"]} - {d.get(\"status\", {}).get(\"availability\", \"?\")}')
 
 if found['results']:
     did = found['results'][0]['device_id']
@@ -241,7 +241,7 @@ if found['results']:
 ```
 
 > `device-connect-agent-tools` is the raw RPC layer, *below* the `robot_mesh`
-> tool, so it is not subject to `robot_mesh`'s human-in-the-loop gate — these
+> tool, so it is not subject to `robot_mesh`'s human-in-the-loop gate - these
 > calls invoke the device directly (the device's own per-caller allowlist still
 > applies; see *Per-caller RPC allowlist* below).
 
@@ -249,7 +249,7 @@ Expected output:
 
 ```
 Found 1 robot(s):
-  <PEER_ID> — idle
+  <PEER_ID> - idle
 Execute result: {'success': True, 'result': {'status': 'success', 'content': [...]}}
 Status: {'success': True, 'result': {...}}  # full sim state dict
 ```
@@ -286,13 +286,13 @@ export ZENOH_CONNECT=tcp/localhost:7447
 # Insecure mode is only for the local, broker-less D2D trial.
 ```
 
-All the options above (A–B) work identically with full infrastructure — the only difference is that devices register in etcd and discovery goes through the registry service instead of multicast scouting.
+All the options above (A–B) work identically with full infrastructure - the only difference is that devices register in etcd and discovery goes through the registry service instead of multicast scouting.
 
 > **What infrastructure adds over D2D:**
-> - **Persistent device registry** — devices register with TTL-based leases; stale devices are auto-cleaned. Agents can discover devices by type, location, or capability via `discover()`.
-> - **Distributed state & locks** — etcd-backed key-value store with atomic distributed locks for coordinating shared resources (e.g., preventing two agents from using the same robotic arm simultaneously).
-> - **Cross-network routing** — the Zenoh router (or NATS broker) enables communication across subnets and sites, not just the local LAN.
-> - **Authentication & authorization** — mTLS ensures only devices with certificates signed by the trusted CA can exchange data. Full authorization (per-device permissions, topic-level ACLs, certificate revocation) requires the router/registry infrastructure.
+> - **Persistent device registry** - devices register with TTL-based leases; stale devices are auto-cleaned. Agents can discover devices by type, location, or capability via `discover()`.
+> - **Distributed state & locks** - etcd-backed key-value store with atomic distributed locks for coordinating shared resources (e.g., preventing two agents from using the same robotic arm simultaneously).
+> - **Cross-network routing** - the Zenoh router (or NATS broker) enables communication across subnets and sites, not just the local LAN.
+> - **Authentication & authorization** - mTLS ensures only devices with certificates signed by the trusted CA can exchange data. Full authorization (per-device permissions, topic-level ACLs, certificate revocation) requires the router/registry infrastructure.
 
 > **Per-caller RPC allowlist (`DEVICE_CONNECT_RPC_ALLOW` / `DEVICE_CONNECT_ESTOP_ALLOW`).**
 > Devices can restrict which callers may invoke state-mutating RPCs (`execute` /
@@ -303,7 +303,7 @@ All the options above (A–B) work identically with full infrastructure — the 
 >   id automatically; an **agent** driving the robot via `robot_mesh` /
 >   `device-connect-agent-tools` is anonymous by default. Set
 >   `STRANDS_ROBOT_MESH_AGENT_ID=<id>` on the agent and add `<id>` to the
->   device's allowlist — otherwise, with an allowlist set, the device
+>   device's allowlist - otherwise, with an allowlist set, the device
 >   (correctly) **denies the anonymous agent** (fail-closed).
 > - **It is only a hard boundary under authenticated transport.** Over insecure
 >   D2D (`DEVICE_CONNECT_ALLOW_INSECURE=true`) the `source_device` is
@@ -339,7 +339,7 @@ It installs dependencies, starts a Zenoh event listener, runs `Robot("so100")` w
 
 ## Reachy Mini (Zenoh-Native Devices)
 
-Reachy Mini has built-in Zenoh support — it publishes joint positions, head pose, and IMU data natively over Zenoh topics. This makes it a special case: it can be bridged directly via `subscribe()` or wrapped as a Device Connect device for structured RPC.
+Reachy Mini has built-in Zenoh support - it publishes joint positions, head pose, and IMU data natively over Zenoh topics. This makes it a special case: it can be bridged directly via `subscribe()` or wrapped as a Device Connect device for structured RPC.
 
 ### Bridging via Subscribe
 
@@ -421,7 +421,7 @@ invoke('device(reachy-mini-1).function(nod)')
 
 | Variant | Connection | Setup |
 |---|---|---|
-| **Reachy Mini** (wireless) | Wi-Fi, onboard Pi | `host='reachy-mini.local'` — no extra install needed |
+| **Reachy Mini** (wireless) | Wi-Fi, onboard Pi | `host='reachy-mini.local'` - no extra install needed |
 | **Reachy Mini Lite** (USB) | USB, no Pi | `pip install reachy-mini` then run `reachy-mini` daemon locally. Use `host='localhost'` |
 
 **Start the Reachy Mini driver:**

--- a/strands_robots/device_connect/__init__.py
+++ b/strands_robots/device_connect/__init__.py
@@ -47,7 +47,7 @@ def resolve_allow_insecure(
     """Resolve the effective ``allow_insecure`` setting (secure by default).
 
     Precedence: explicit arg > ``DEVICE_CONNECT_ALLOW_INSECURE`` env var >
-    secure default (``False``). Insecure transport is never implicit — it
+    secure default (``False``). Insecure transport is never implicit - it
     must be opted into via the argument or the env var.
 
     Extracted as a pure function so the secure-by-default posture is unit
@@ -75,15 +75,15 @@ async def init_device_connect(
     and starts a DeviceRuntime in the background.
 
     When messaging_backend="zenoh" and messaging_url is None, the runtime
-    enters D2D mode — devices discover each other directly via Zenoh
+    enters D2D mode - devices discover each other directly via Zenoh
     multicast scouting on the LAN. No broker, no Docker, no env vars.
 
     Args:
         robot: A Robot or Simulation instance to wrap.
         peer_id: Device ID for registration (auto-generated if None).
-        peer_type: "robot" or "sim" — selects the appropriate driver.
+        peer_type: "robot" or "sim" - selects the appropriate driver.
         messaging_url: Explicit messaging URL (overrides env vars).
-        messaging_backend: Messaging backend — "zenoh" or "nats".
+        messaging_backend: Messaging backend - "zenoh" or "nats".
             None = auto-detect from MESSAGING_BACKEND env var (default "zenoh").
         tenant: Device Connect tenant namespace.
         allow_insecure: Allow insecure (unencrypted, unauthenticated)
@@ -110,9 +110,9 @@ async def init_device_connect(
 
     # Resolve allow_insecure: explicit arg > env var > secure default.
     # Security hardening: insecure (unencrypted, unauthenticated) transport is
-    # NO LONGER the default. It must be explicitly opted into — via the
+    # NO LONGER the default. It must be explicitly opted into - via the
     # ``allow_insecure=True`` argument or ``DEVICE_CONNECT_ALLOW_INSECURE`` env
-    # var — and we log a prominent warning whenever it is active so an insecure
+    # var - and we log a prominent warning whenever it is active so an insecure
     # deployment is never silent.
     allow_insecure = resolve_allow_insecure(allow_insecure, os.environ.get("DEVICE_CONNECT_ALLOW_INSECURE"))
 
@@ -157,7 +157,7 @@ def init_device_connect_sync(
     """Non-blocking sync wrapper around init_device_connect().
 
     Starts the DeviceRuntime on a dedicated daemon thread so the caller
-    returns immediately — matching the Zenoh mesh ``init_mesh()`` pattern.
+    returns immediately - matching the Zenoh mesh ``init_mesh()`` pattern.
     The runtime stays alive as long as the process (daemon thread).
 
     Same parameters as :func:`init_device_connect`.

--- a/strands_robots/device_connect/_authz.py
+++ b/strands_robots/device_connect/_authz.py
@@ -9,11 +9,11 @@ simulated) hardware.
 Allowlists are sourced from environment variables so deployments opt in without
 code changes:
 
-* ``DEVICE_CONNECT_RPC_ALLOW`` — comma-separated device ids permitted to call
+* ``DEVICE_CONNECT_RPC_ALLOW`` - comma-separated device ids permitted to call
   state-mutating RPCs. ``*`` (or unset) means "allow all" but logs a warning so
   the permissive posture is visible. An explicit empty value (``""`` after
   stripping) is treated as unset.
-* ``DEVICE_CONNECT_ESTOP_ALLOW`` — comma-separated device ids permitted to
+* ``DEVICE_CONNECT_ESTOP_ALLOW`` - comma-separated device ids permitted to
   trigger emergency-stop handling. Falls back to ``DEVICE_CONNECT_RPC_ALLOW``
   when unset.
 
@@ -27,11 +27,11 @@ Caller-identity semantics (READ THIS before relying on the allowlist):
   anonymous client carries **none** (``caller=None``).
 * When an allowlist IS set, a missing/None caller cannot be authorized and is
   denied (fail-closed). So setting ``DEVICE_CONNECT_RPC_ALLOW`` will reject
-  every anonymous caller — configure an id on the caller side to allow it.
+  every anonymous caller - configure an id on the caller side to allow it.
 * The id is only as trustworthy as the transport. Under authenticated
   transport (mTLS) it is bound to the sender's certificate. Under insecure
-  transport (``DEVICE_CONNECT_ALLOW_INSECURE``) it is **self-asserted** — any
-  peer can claim any id — so the allowlist is advisory there, not a
+  transport (``DEVICE_CONNECT_ALLOW_INSECURE``) it is **self-asserted** - any
+  peer can claim any id - so the allowlist is advisory there, not a
   cryptographic boundary. A one-time warning is logged in that case.
 """
 
@@ -114,13 +114,13 @@ def is_authorized_caller(caller: str | None, *, scope: str = "rpc") -> bool:
 
     patterns = _parse_allowlist(raw)
     if patterns is None:
-        # No allowlist configured — preserve out-of-the-box dev usability but
+        # No allowlist configured - preserve out-of-the-box dev usability but
         # make the permissive posture loud so operators notice.
         _warn_permissive_once(env_scope)
         return True
 
     # An allowlist is configured. If the transport is insecure the caller id is
-    # self-asserted, so the allowlist is advisory — say so once, loudly.
+    # self-asserted, so the allowlist is advisory - say so once, loudly.
     if _insecure_transport_active():
         _warn_insecure_acl_once(env_scope)
 

--- a/strands_robots/device_connect/reachy_mini_driver.py
+++ b/strands_robots/device_connect/reachy_mini_driver.py
@@ -1,4 +1,4 @@
-"""ReachyMiniDriver — Device Connect DeviceDriver for Pollen Reachy Mini robots.
+"""ReachyMiniDriver - Device Connect DeviceDriver for Pollen Reachy Mini robots.
 
 Auto-detects hardware variant via the daemon's ``wireless_version`` flag:
 - **Wireless** (has onboard Pi): uses Zenoh transport for real-time I/O.
@@ -335,7 +335,7 @@ class ReachyMiniDriver(DeviceDriver):
 
     @on(event_name="emergencyStop")
     async def onEmergencyStop(self, device_id: str, event_name: str, payload: dict):
-        """React to emergencyStop — disable motors and stop motion."""
-        logger.warning("Emergency stop received from %s — disabling motors", device_id)
+        """React to emergencyStop - disable motors and stop motion."""
+        logger.warning("Emergency stop received from %s - disabling motors", device_id)
         await self.stopMotion()
         await self.disableMotors()

--- a/strands_robots/device_connect/reachy_transport.py
+++ b/strands_robots/device_connect/reachy_transport.py
@@ -131,7 +131,7 @@ class HardwareLink(ABC):
 
 
 class ZenohLink(HardwareLink):
-    """Wireless variant — real-time I/O via Device Connect's Zenoh transport."""
+    """Wireless variant - real-time I/O via Device Connect's Zenoh transport."""
 
     def __init__(self, transport, prefix: str):
         self._transport = transport
@@ -161,7 +161,7 @@ class ZenohLink(HardwareLink):
 
 
 class WebSocketLink(HardwareLink):
-    """Lite variant — real-time I/O via daemon's WebSocket."""
+    """Lite variant - real-time I/O via daemon's WebSocket."""
 
     _WS_CMD_MAP = {
         "head_pose": lambda c: {"type": "set_target", "head": [v for row in c["head_pose"] for v in row]},

--- a/strands_robots/device_connect/robot_driver.py
+++ b/strands_robots/device_connect/robot_driver.py
@@ -1,4 +1,4 @@
-"""RobotDeviceDriver — Device Connect DeviceDriver adapter wrapping a strands-robots Robot.
+"""RobotDeviceDriver - Device Connect DeviceDriver adapter wrapping a strands-robots Robot.
 
 Exposes the Robot's task execution, status, and observation methods as
 structured RPCs and events via Device Connect's DeviceDriver interface.
@@ -51,11 +51,11 @@ class RobotDeviceDriver(DeviceDriver):
         )
 
     async def connect(self) -> None:
-        """No-op — the Robot manages its own hardware connection."""
+        """No-op - the Robot manages its own hardware connection."""
         pass
 
     async def disconnect(self) -> None:
-        """No-op — the Robot manages its own hardware shutdown."""
+        """No-op - the Robot manages its own hardware shutdown."""
         pass
 
     # ── RPCs ──────────────────────────────────────────────────
@@ -135,7 +135,7 @@ class RobotDeviceDriver(DeviceDriver):
         if inner and hasattr(inner, "get_observation"):
             try:
                 obs = await asyncio.to_thread(inner.get_observation)
-                # Filter out camera frames (numpy arrays) — only include scalars
+                # Filter out camera frames (numpy arrays) - only include scalars
                 result["joints"] = {k: float(v) for k, v in obs.items() if not hasattr(v, "shape")}
             except Exception as e:
                 logger.debug("Could not read observation: %s", e)
@@ -196,7 +196,7 @@ class RobotDeviceDriver(DeviceDriver):
         if not is_authorized_caller(device_id, scope="estop"):
             logger.warning("Ignoring emergencyStop from unauthorized source %s", device_id)
             return
-        logger.warning("Emergency stop received from %s — stopping task", device_id)
+        logger.warning("Emergency stop received from %s - stopping task", device_id)
         self._robot.stop_task()
 
     # ── Periodic state publishing ─────────────────────────────

--- a/strands_robots/device_connect/sim_driver.py
+++ b/strands_robots/device_connect/sim_driver.py
@@ -1,4 +1,4 @@
-"""SimulationDeviceDriver — Device Connect DeviceDriver adapter wrapping a strands-robots Simulation.
+"""SimulationDeviceDriver - Device Connect DeviceDriver adapter wrapping a strands-robots Simulation.
 
 Exposes the Simulation's physics stepping, policy execution, and world
 state as structured RPCs and events via Device Connect's DeviceDriver interface.
@@ -55,11 +55,11 @@ class SimulationDeviceDriver(DeviceDriver):
         )
 
     async def connect(self) -> None:
-        """No-op — the Simulation manages its own MuJoCo state."""
+        """No-op - the Simulation manages its own MuJoCo state."""
         pass
 
     async def disconnect(self) -> None:
-        """No-op — the Simulation manages its own cleanup."""
+        """No-op - the Simulation manages its own cleanup."""
         pass
 
     # ── RPCs ──────────────────────────────────────────────────
@@ -114,7 +114,7 @@ class SimulationDeviceDriver(DeviceDriver):
         caller = get_rpc_source_device()
         if not is_authorized_caller(caller, scope="rpc"):
             return authz_error(caller, "stop")
-        print("⏹ Stop command received — stopping all policies", flush=True)
+        print("⏹ Stop command received - stopping all policies", flush=True)
         world = getattr(self._sim, "_world", None)
         if world:
             for robot in world.robots.values():
@@ -197,7 +197,7 @@ class SimulationDeviceDriver(DeviceDriver):
         if not is_authorized_caller(device_id, scope="estop"):
             logger.warning("Ignoring emergencyStop from unauthorized source %s", device_id)
             return
-        print(f"🛑 Emergency stop received from {device_id} — stopping all policies", flush=True)
+        print(f"🛑 Emergency stop received from {device_id} - stopping all policies", flush=True)
         world = getattr(self._sim, "_world", None)
         if world:
             for robot in world.robots.values():

--- a/strands_robots/doctor.py
+++ b/strands_robots/doctor.py
@@ -1,4 +1,4 @@
-"""``strands-robots doctor`` — diagnose common setup issues in one command.
+"""``strands-robots doctor`` - diagnose common setup issues in one command.
 
 Checks: Python version, extras availability, GPU/CUDA, serial permissions,
 MuJoCo GL backend, HuggingFace auth, and a sim smoke test. Prints a colored
@@ -101,7 +101,7 @@ def check_mujoco_gl() -> str:
         return _pass(f"MUJOCO_GL={gl}")
     if gl == "glfw":
         return _warn("MUJOCO_GL=glfw (needs display)", note="Set MUJOCO_GL=egl or osmesa for headless")
-    # Not set — check if a display exists
+    # Not set - check if a display exists
     if os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"):
         return _pass("MUJOCO_GL unset (display detected, glfw will work)")
     return _fail(

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -246,7 +246,7 @@ class Robot(AgentTool):
         self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix=f"{tool_name}_executor")
         self._shutdown_event = threading.Event()
 
-        # Mesh attributes — populated by the Robot() factory after init.
+        # Mesh attributes - populated by the Robot() factory after init.
         # Plain attributes (not properties) so test code can swap a fake mesh
         # in without going through the factory.
         # Set BEFORE _initialize_robot so cleanup()/__del__ never see an
@@ -443,7 +443,7 @@ class Robot(AgentTool):
         # ``Robot()`` calls are essentially free.
         _ensure_lerobot_robots_registered()
 
-        # Resolve the config class via lerobot's draccus ChoiceRegistry —
+        # Resolve the config class via lerobot's draccus ChoiceRegistry -
         # this is the source-of-truth lookup that ``make_robot_from_config``
         # uses; staying on it means we track upstream renames automatically.
         try:
@@ -505,7 +505,7 @@ class Robot(AgentTool):
 
         # Forward known robot-specific kwargs only if the target dataclass
         # declares them. The full set is union-of-all known lerobot robot
-        # configs — adding new ones here is safe because we filter against
+        # configs - adding new ones here is safe because we filter against
         # ``valid_fields`` before constructing.
         forwardable = _FORWARDABLE_KWARGS
         for key in forwardable:
@@ -1036,7 +1036,7 @@ class Robot(AgentTool):
 
             # Tear down the Zenoh mesh component if one was attached.
             # ``self.mesh`` is any object exposing ``.stop()``; falsy values
-            # (None — the construction-time default and what a hardware robot
+            # (None - the construction-time default and what a hardware robot
             # gets when ``mesh=False``) are skipped silently.
             if self.mesh:
                 try:
@@ -1124,7 +1124,7 @@ class Robot(AgentTool):
             logger.error(f"Error stopping robot: {e}")
 
     # ------------------------------------------------------------------
-    # Teleoperation over mesh — input publishing and receiving
+    # Teleoperation over mesh - input publishing and receiving
     # ------------------------------------------------------------------
 
     def start_teleop_publish(

--- a/strands_robots/mesh/__init__.py
+++ b/strands_robots/mesh/__init__.py
@@ -1,4 +1,4 @@
-"""Robot mesh networking — peer-to-peer presence, state, RPC, and teleoperation.
+"""Robot mesh networking - peer-to-peer presence, state, RPC, and teleoperation.
 
 This package provides the Zenoh-based mesh layer for strands-robots. Each robot
 (hardware or simulated) owns a :class:`Mesh` component that broadcasts its
@@ -16,11 +16,11 @@ Typical usage::
 
 Submodules
 ----------
-- ``session`` — Shared Zenoh session singleton and peer registry
-- ``audit`` — Append-only safety event audit log
-- ``core`` — The Mesh class (lifecycle, presence, state, RPC, subscribe)
-- ``sensors`` — Extended sensor topic loops (pose, health, IMU, odom, lidar, hand, map)
-- ``input`` — InputPublisher / InputReceiver for teleoperation over mesh
+- ``session`` - Shared Zenoh session singleton and peer registry
+- ``audit`` - Append-only safety event audit log
+- ``core`` - The Mesh class (lifecycle, presence, state, RPC, subscribe)
+- ``sensors`` - Extended sensor topic loops (pose, health, IMU, odom, lidar, hand, map)
+- ``input`` - InputPublisher / InputReceiver for teleoperation over mesh
 """
 
 from strands_robots.mesh.audit import log_safety_event

--- a/strands_robots/mesh/audit.py
+++ b/strands_robots/mesh/audit.py
@@ -494,7 +494,7 @@ def _load_seq_counters() -> None:
                 # dict (or a dict with no valid entries) must NOT flip
                 # sidecar_loaded=True, otherwise the audit-log fallback
                 # is skipped and an attacker writing ``{}`` gets every
-                # peer's seq reset. (R3 follow-up — review thread on
+                # peer's seq reset. (R3 follow-up - review thread on
                 # PR#221 audit.py:531).
                 merged_any = False
                 for key, value in payload.items():
@@ -958,7 +958,7 @@ def _ensure_paths(path: Path) -> None:
     parent.mkdir(parents=True, exist_ok=True)
     try:
         os.chmod(parent, 0o700)
-    except OSError as exc:  # pragma: no cover — best-effort on exotic FS
+    except OSError as exc:  # pragma: no cover - best-effort on exotic FS
         logger.debug("[audit] could not chmod %s: %s", parent, exc)
 
     # Symlink check on the audit log itself. ``Path.is_symlink`` returns
@@ -1013,7 +1013,7 @@ def log_safety_event(event_type: str, peer_id: str, payload: dict[str, Any]) -> 
         payload: Event-specific fields.  Must be JSON-serialisable.
 
     Raises:
-        Nothing — write errors are logged at WARNING and swallowed because
+        Nothing - write errors are logged at WARNING and swallowed because
         an audit-log failure must never propagate up into the safety code
         path that called this function.
     """

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -1,4 +1,4 @@
-"""Core Mesh class — lifecycle, presence, state, cameras, RPC, and subscriptions.
+"""Core Mesh class - lifecycle, presence, state, cameras, RPC, and subscriptions.
 
 This is the primary component that a Robot or Simulation composes with.
 Extended sensor loops (pose, IMU, health, etc.) are provided by
@@ -745,7 +745,7 @@ class Mesh(SensorLoopsMixin):
         """
         return self.peers_by_id.get(peer_id)
 
-    # Presence — outgoing
+    # Presence - outgoing
     def _build_presence(self) -> dict[str, Any]:
         r = self.robot
         payload: dict[str, Any] = {
@@ -913,7 +913,7 @@ class Mesh(SensorLoopsMixin):
         if is_new:
             logger.info("[mesh] new peer: %s (%s)", peer_id, data.get("robot_type", "?"))
 
-    # State — outgoing
+    # State - outgoing
     def _state_loop(self) -> None:
         period = 1.0 / STATE_HZ
         while self._running:
@@ -1003,7 +1003,7 @@ class Mesh(SensorLoopsMixin):
 
         return snapshot if len(snapshot) > 2 else None
 
-    # Cameras — outgoing (opt-in)
+    # Cameras - outgoing (opt-in)
     def _resolve_camera_hz(self) -> float:
         env = os.getenv("STRANDS_MESH_CAMERA_HZ")
         if env is None or env.strip() == "":
@@ -1196,7 +1196,7 @@ class Mesh(SensorLoopsMixin):
             except Exception as exc:
                 logger.debug("[mesh] %s: camera %s publish failed: %s", self.peer_id, cam_name, exc)
 
-        # RPC — incoming
+        # RPC - incoming
 
     def _on_cmd(self, sample: Any) -> None:
         """Handle an inbound command sample.
@@ -1632,7 +1632,7 @@ class Mesh(SensorLoopsMixin):
             return {"error": "robot does not support stop_teleop"}
         return {"error": f"unknown action: {action}"}
 
-    # Well-known per-call policy kwargs from issue #300 — keys that planner-
+    # Well-known per-call policy kwargs from issue #300 - keys that planner-
     # style providers (cuRobo, MoveIt2, MPC) consume to encode goals beyond
     # natural-language ``instruction``. Forwarded from ``tell()`` payload
     # into ``policy_config`` so a ``policy_provider="curobo"`` peer sees the
@@ -1668,7 +1668,7 @@ class Mesh(SensorLoopsMixin):
             * Use ``cmd["robot_name"]`` when present.
             * Otherwise default to the only robot in the world if there is
               exactly one.
-            * Otherwise return an error — ambiguous targets must be
+            * Otherwise return an error - ambiguous targets must be
               explicit so the agent can't accidentally drive the wrong arm.
 
         Forwards both the existing ``extra`` constructor kwargs
@@ -1685,7 +1685,7 @@ class Mesh(SensorLoopsMixin):
 
         try:
             available = list(sim.list_robots())
-        except Exception as exc:  # noqa: BLE001 — surface as wire-level error
+        except Exception as exc:  # noqa: BLE001 - surface as wire-level error
             return {"error": f"sim list_robots failed: {exc}"}
 
         robot_name = cmd.get("robot_name")
@@ -1713,8 +1713,8 @@ class Mesh(SensorLoopsMixin):
                 policy_config[key] = cmd[key]
 
         # Optional sim-side controls. We expose only the fields that already
-        # have validator coverage in the wire schema — control_frequency,
-        # action_horizon, fast_mode, video — and that are safe to forward to
+        # have validator coverage in the wire schema - control_frequency,
+        # action_horizon, fast_mode, video - and that are safe to forward to
         # an LLM-issued ``tell()``. Anything else stays on its server-side
         # default to avoid surfacing internal knobs to untrusted agents.
         run_kwargs: dict[str, Any] = {
@@ -2749,7 +2749,7 @@ class Mesh(SensorLoopsMixin):
         """Subscribe to another peer's VLA execution stream."""
         return self.subscribe(f"strands/{peer_id}/stream", callback, name=f"stream:{peer_id}")
 
-    # Safety — emergency stop
+    # Safety - emergency stop
     def emergency_stop(self) -> list[dict[str, Any]]:
         """Broadcast a stop command to every peer and engage the local lockout.
 
@@ -3259,7 +3259,7 @@ def init_mesh(
         base = getattr(robot, "tool_name_str", None) or "robot"
         peer_id = f"{base}-{uuid.uuid4().hex[:8]}"
 
-    # Validate peer_id — reject reserved names and MQTT-unsafe characters.
+    # Validate peer_id - reject reserved names and MQTT-unsafe characters.
     _RESERVED_PEER_IDS = {"broadcast", "safety"}
     _PEER_ID_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._\-]{0,127}$")
     if peer_id in _RESERVED_PEER_IDS:
@@ -3270,7 +3270,7 @@ def init_mesh(
         raise ValueError(
             f"peer_id={peer_id!r} contains invalid characters. "
             "Must match [a-zA-Z0-9][a-zA-Z0-9._-]{{0,127}} "
-            "(no /, +, # — these break MQTT topic structure and AWS Thing-name rules)."
+            "(no /, +, # - these break MQTT topic structure and AWS Thing-name rules)."
         )
 
     instance = Mesh(robot, peer_id=peer_id, peer_type=peer_type)
@@ -3278,7 +3278,7 @@ def init_mesh(
 
     # Auto-wire IoT enrichments when the active transport supports them.
     # Both calls are no-ops when STRANDS_MESH_BACKEND=zenoh (the default),
-    # so this is purely additive — Zenoh-LAN behaviour is unchanged.
+    # so this is purely additive - Zenoh-LAN behaviour is unchanged.
     if instance.alive:
         try:
             from strands_robots.mesh.iot import (
@@ -3288,7 +3288,7 @@ def init_mesh(
 
             enable_shadow_for_mesh(instance)
             enable_camera_offload_for_mesh(instance)
-        except Exception as exc:  # noqa: BLE001 — IoT enrichment is best-effort
+        except Exception as exc:  # noqa: BLE001 - IoT enrichment is best-effort
             logger.debug("[mesh] IoT enrichment failed (continuing): %s", exc)
 
     return instance

--- a/strands_robots/mesh/input.py
+++ b/strands_robots/mesh/input.py
@@ -1,4 +1,4 @@
-"""Input device streaming over the mesh — publish and receive teleoperator actions.
+"""Input device streaming over the mesh - publish and receive teleoperator actions.
 
 Enables remote teleoperation: a leader arm on machine A publishes its joint
 positions via :class:`InputPublisher`, and the follower arm on machine B

--- a/strands_robots/mesh/iot/__init__.py
+++ b/strands_robots/mesh/iot/__init__.py
@@ -2,15 +2,15 @@
 
 This subpackage owns the cloud-side concerns of the mesh:
 
-- :mod:`provision`  — single-Thing bootstrap (cert + policy + Thing).
-- :mod:`bootstrap`  — account-wide bootstrap (Rules + Lambda +
+- :mod:`provision`  - single-Thing bootstrap (cert + policy + Thing).
+- :mod:`bootstrap`  - account-wide bootstrap (Rules + Lambda +
   DynamoDB audit + Fleet Provisioning template).
-- :mod:`shadow`  — Device Shadow named-shadow mirror of presence.
-- :mod:`camera_offload` — S3-backed camera frame offload.
+- :mod:`shadow`  - Device Shadow named-shadow mirror of presence.
+- :mod:`camera_offload` - S3-backed camera frame offload.
 
 The wire-level transport (:class:`IotMqttTransport`) lives in
 :mod:`strands_robots.mesh.transport.iot_transport` and is independent of
-this package — you can use it without ever calling :mod:`provision` if you
+this package - you can use it without ever calling :mod:`provision` if you
 already have certs.
 
 Public OOBE
@@ -29,7 +29,7 @@ For a customer's first integration, the canonical sequence is::
     # 3. Run the robot under the iot transport.
     #  (export the env vars from p.env_vars() and `Robot()` Just Works.)
 
-For a single-robot dev setup, step 1 is optional — without it E-stop
+For a single-robot dev setup, step 1 is optional - without it E-stop
 fan-out and DynamoDB audit just don't activate; everything else still
 works.
 """

--- a/strands_robots/mesh/iot/bootstrap.py
+++ b/strands_robots/mesh/iot/bootstrap.py
@@ -1,4 +1,4 @@
-"""One-shot AWS account bootstrap — IoT Rules + Fleet Provisioning template.
+"""One-shot AWS account bootstrap - IoT Rules + Fleet Provisioning template.
 
 This module is the operator-side analogue of :mod:`provision`. Where
 :func:`provision_robot` configures one Thing, :func:`bootstrap_account`
@@ -8,18 +8,18 @@ configures the **account-wide infrastructure** that every robot relies on:
 2. **DynamoDB table** ``strands-mesh-safety-events`` (KMS-encrypted, PITR)
    so safety events have a durable cloud audit trail beyond local JSONL.
 3. **IoT Rules**:
-    - ``strands_safety_to_dynamodb`` — every ``strands/+/safety/event``
+    - ``strands_safety_to_dynamodb`` - every ``strands/+/safety/event``
       writes one row to the audit table.
-    - ``strands_estop_fanout`` — defence-in-depth: an E-stop also fires
+    - ``strands_estop_fanout`` - defence-in-depth: an E-stop also fires
       a Lambda that publishes individual stop commands per robot.
-    - ``strands_health_to_logs`` — health pings to CloudWatch Logs for
+    - ``strands_health_to_logs`` - health pings to CloudWatch Logs for
       grep-friendly debugging.
 4. **Fleet Provisioning template** so factory-fresh robots can claim a
    real cert from a bootstrap claim cert with no human in the loop.
 
 The function is **idempotent**: re-running it skips resources that
 already exist (matched by name) and only adds what's missing. It NEVER
-deletes — :func:`teardown_account` is the explicit reverse.
+deletes - :func:`teardown_account` is the explicit reverse.
 
 The Lambda code is deliberately tiny and shipped as a single-file source
 string. It does what a fleet-ops engineer would write by hand on day 1
@@ -31,7 +31,7 @@ Why bake all this into the library
 The whole point of the AWS IoT integration is "Robot('so100') joins the
 mesh, fleet ops gets durable audit + alerts for free." Forcing customers
 to wire CDK/Terraform on day 1 defeats that. They can replace this with
-their own IaC later — these resources are tagged ``strands-mesh=managed``
+their own IaC later - these resources are tagged ``strands-mesh=managed``
 so external tooling can see them clearly.
 """
 
@@ -501,7 +501,7 @@ def _ensure_safety_to_dynamodb_rule(iot: Any, table_arn: str, account: Bootstrap
         iot.exceptions.UnauthorizedException,
     ):
         # AWS IoT returns UnauthorizedException (not ResourceNotFound) when a
-        # rule of this name doesn't exist yet — confusing but documented.
+        # rule of this name doesn't exist yet - confusing but documented.
         pass
 
     role_arn = _ensure_iot_action_role(account)
@@ -654,13 +654,13 @@ def _ensure_provisioning_hook_role(iam: Any, account: BootstrappedAccount) -> st
     E-stop Lambda role grants neither, so reusing it would make every
     ``describe_thing`` / ``get_parameter`` raise ``AccessDenied``; those are
     swallowed by the hook's deny-on-error envelope and *every* registration
-    — legitimate ones included — would be refused. This role grants exactly
+    - legitimate ones included - would be refused. This role grants exactly
     those two read actions, least-privilege scoped:
 
     * ``iot:DescribeThing`` on ``thing/*`` (the hook only reads existence;
       it never mutates).
     * ``ssm:GetParameter`` on ``parameter/strands-mesh/provisioning/allow/*``
-      (the allowlist namespace only — no broader Parameter Store access).
+      (the allowlist namespace only - no broader Parameter Store access).
     """
     role_name = PROVISIONING_HOOK_ROLE
     try:
@@ -796,7 +796,7 @@ def _grant_iot_invoke_provisioning_hook(lam: Any, hook_arn: str, account: Bootst
 
 
 def _ensure_provisioning_template(iot: Any, account: BootstrappedAccount, *, hook_lambda_arn: str = "") -> str:
-    """Fleet Provisioning template — claim cert → real cert + attach robot policy.
+    """Fleet Provisioning template - claim cert → real cert + attach robot policy.
 
     F-19 / B-13: a ``PreProvisioningHook`` is wired so a leaked claim cert
     cannot register an arbitrary Thing. ``hook_lambda_arn`` is the ARN of
@@ -871,7 +871,7 @@ def _ensure_provisioning_template(iot: Any, account: BootstrappedAccount, *, hoo
                 raise
             time.sleep(5 * (attempt + 1))
     else:
-        # Exhausted retries — surface the last exception so users see it.
+        # Exhausted retries - surface the last exception so users see it.
         raise RuntimeError(f"Provisioning template create failed after retries: {last_exc}")
     account.created.append(f"iot-prov-template:{name}")
     return f"arn:aws:iot:{account.region}:{account.account_id}:provisioningtemplate/{name}"
@@ -909,7 +909,7 @@ def _ensure_provisioning_role(account: BootstrappedAccount) -> str:
     )
     # IAM role propagation is eventually-consistent (typically 5–10s, but can
     # take up to 15s under load). The provisioning template creation hits IoT
-    # which then tries to AssumeRole — without the propagation wait we get
+    # which then tries to AssumeRole - without the propagation wait we get
     # InvalidRequestException("provisioning role cannot be assumed").
     time.sleep(15)
     account.created.append(f"iam:{name}")
@@ -941,7 +941,7 @@ def bootstrap_account(
             created without making API calls. Set to False + confirm=True
             to actually provision.
         account_id_expected: If provided, abort if the resolved account ID
-            does not match — guards against wrong-account provisioning.
+            does not match - guards against wrong-account provisioning.
         profile: AWS profile name to use (passed to boto3.Session).
         force_update: If True, update existing E-stop Lambda even when it
             already exists (upgrades stale versions). Default False preserves
@@ -1019,7 +1019,7 @@ def bootstrap_account(
     out.rule_estop_arn = _ensure_estop_rule(iot, out.estop_lambda_arn, out)
     _grant_iot_invoke_lambda(lam, out.estop_lambda_arn, out)
 
-    # Fleet Provisioning PreProvisioningHook Lambda (F-19/B-13) — gate
+    # Fleet Provisioning PreProvisioningHook Lambda (F-19/B-13) - gate
     # registration so a leaked claim cert cannot self-register a Thing.
     # The hook needs iot:DescribeThing + ssm:GetParameter, which the E-stop
     # role does not grant, so it gets its own least-privilege role.
@@ -1032,7 +1032,7 @@ def bootstrap_account(
     _grant_iot_invoke_provisioning_hook(lam, hook_arn, out)
 
     logger.info(
-        "[bootstrap] account %s in %s — created %d, skipped %d",
+        "[bootstrap] account %s in %s - created %d, skipped %d",
         account_id,
         region,
         len(out.created),
@@ -1042,7 +1042,7 @@ def bootstrap_account(
 
 
 def teardown_account(*, region: str | None = None) -> None:
-    """Best-effort reverse of :func:`bootstrap_account`. Safe to skip — every
+    """Best-effort reverse of :func:`bootstrap_account`. Safe to skip - every
     deletion catches NotFound silently. Tags-managed resources are removed
     in dependency order: Rules → Lambda → Roles → DynamoDB → Logs →
     Provisioning template.

--- a/strands_robots/mesh/iot/camera_offload.py
+++ b/strands_robots/mesh/iot/camera_offload.py
@@ -16,7 +16,7 @@ JPEG bytes in MQTT we:
 1. Upload the frame to S3 at ``s3://{bucket}/{peer_id}/{cam}/{ts_ns}.jpg``.
 2. Publish a tiny JSON ref on ``strands/{peer_id}/camera/{cam}/ref`` with
    ``{peer_id, cam, t, shape, encoding, s3_uri, presigned_url, expires_at}``.
-3. Subscribers GET the frame from the presigned URL directly — no MQTT
+3. Subscribers GET the frame from the presigned URL directly - no MQTT
    payload size pressure.
 
 The Zenoh path (LAN multicast) keeps publishing inline JPEG frames on
@@ -79,7 +79,7 @@ class CameraOffloader:
     """Pushes camera frames to S3 and publishes a thin MQTT reference.
 
     One instance per Mesh. Holds a lazily-initialised boto3 S3 client.
-    Failures are logged at DEBUG and silently dropped — camera offload is
+    Failures are logged at DEBUG and silently dropped - camera offload is
     enrichment, not a control-loop dependency.
     """
 
@@ -147,7 +147,7 @@ class CameraOffloader:
         try:
             import boto3
         except ImportError:
-            logger.debug("[camera_offload] boto3 missing — offload disabled")
+            logger.debug("[camera_offload] boto3 missing - offload disabled")
             return None
         self._s3 = boto3.client("s3", region_name=self.region)
         return self._s3
@@ -222,21 +222,21 @@ def enable_for_mesh(mesh: Any, offloader: CameraOffloader | None = None) -> Came
     backend = current_backend()
     if backend not in ("iot", "bridge"):
         logger.debug(
-            "[camera_offload] backend is %r — leaving _publish_cameras_once unchanged",
+            "[camera_offload] backend is %r - leaving _publish_cameras_once unchanged",
             backend,
         )
         return None
 
     off = offloader or CameraOffloader()
     if not off.enabled:
-        logger.debug("[camera_offload] STRANDS_MESH_CAMERA_S3_BUCKET unset — offload off")
+        logger.debug("[camera_offload] STRANDS_MESH_CAMERA_S3_BUCKET unset - offload off")
         return None
 
     original = mesh._publish_cameras_once
 
     def _publish_cameras_once_with_offload() -> None:
         # Run original (publishes inline-base64 to Zenoh; on iot-only it's a no-op
-        # because the IoT transport drops camera/* topics by default — we still
+        # because the IoT transport drops camera/* topics by default - we still
         # call it to preserve any user customisation that might have been added).
         try:
             original()

--- a/strands_robots/mesh/iot/provision.py
+++ b/strands_robots/mesh/iot/provision.py
@@ -27,7 +27,7 @@ generates fresh credentials and keeps the file naming stable).
 Operator provisioning
 ---------------------
 :func:`provision_operator` is the analogue for fleet operators (Bedrock
-agents, ops consoles). The two policies differ — robots can publish to
+agents, ops consoles). The two policies differ - robots can publish to
 their own topic prefix and respond to any operator; operators can publish
 ``cmd`` / ``broadcast`` and observe the whole fleet.
 
@@ -144,7 +144,7 @@ class ProvisionedThing:
         return [f"export {k}={v}" for k, v in self.env_vars().items()]
 
 
-# Policy documents — verified working in the spike
+# Policy documents - verified working in the spike
 
 _ROBOT_POLICY_DOC: dict[str, Any] = {
     "Version": "2012-10-17",
@@ -421,7 +421,7 @@ def provision_robot(
     error message will direct them here.
 
     Args:
-        thing_name: The Thing name. MUST equal the intended Mesh peer_id —
+        thing_name: The Thing name. MUST equal the intended Mesh peer_id -
             the IoT Policy uses ``${iot:Connection.Thing.ThingName}`` for
             topic ACL substitution. Should be DNS-safe (alphanumeric + ``-_``).
         region: AWS region. Defaults to the default boto3 session region.
@@ -439,7 +439,7 @@ def provision_robot(
         - Thing creation: ``CreateThing`` is idempotent if the attributes match.
         - Policy creation: skipped if the policy name already exists.
         - Cert creation: a new cert is always issued (private keys aren't
-          recoverable). Old certs from prior runs remain on the Thing —
+          recoverable). Old certs from prior runs remain on the Thing -
           call :func:`teardown_thing` to clean them up.
     """
 
@@ -448,7 +448,7 @@ def provision_robot(
     iot = boto3.client("iot", region_name=region)
     region = iot.meta.region_name
 
-    # Inject strands-mesh-role attribute for ACL — the OperatorShadow policy
+    # Inject strands-mesh-role attribute for ACL - the OperatorShadow policy
     # uses an attribute condition to scope shadow access to robot Things only.
     attributes = dict(attributes) if attributes else {}
     attributes.setdefault("strands-mesh-role", "robot")
@@ -475,7 +475,7 @@ def provision_robot(
     # Clean up stale certs from prior provision_robot runs on the same Thing.
     # Each call to AWS IoT CreateKeysAndCertificate yields a brand-new cert
     # (private keys cannot be recovered after issuance), so without cleanup
-    # the Thing would accumulate certs across re-runs — every leftover is
+    # the Thing would accumulate certs across re-runs - every leftover is
     # an active credential that could impersonate the robot.
     _cleanup_stale_certs(iot, thing_name)
 
@@ -527,7 +527,7 @@ def provision_operator(
     iot = boto3.client("iot", region_name=region)
     region = iot.meta.region_name
 
-    # Inject strands-mesh-role attribute — operators get role=operator so the
+    # Inject strands-mesh-role attribute - operators get role=operator so the
     # OperatorShadow attribute condition (role=robot) excludes their shadows.
     attributes = dict(attributes) if attributes else {}
     attributes.setdefault("strands-mesh-role", "operator")
@@ -583,7 +583,7 @@ def teardown_thing(
     Cleans up the cert files under *cert_dir* (defaults to
     :data:`DEFAULT_CERT_DIR`) if they're named after this Thing.  Pass the
     same ``cert_dir`` you used at provision time so the on-disk cert and key
-    are removed instead of orphaned.  Does NOT delete the policies — those
+    are removed instead of orphaned.  Does NOT delete the policies - those
     are shared across all robots and removing them would break siblings.
 
     Idempotent: missing Thing or no certs is a silent success.
@@ -685,7 +685,7 @@ def _ensure_thing(iot: Any, thing_name: str, attributes: dict[str, str] | None) 
 
 
 def _ensure_policy(iot: Any, name: str, document: dict[str, Any]) -> str:
-    """Create the policy if absent. Idempotent — does not update an existing
+    """Create the policy if absent. Idempotent - does not update an existing
     policy; users who want to update should bump the policy version manually."""
     try:
         existing = iot.get_policy(policyName=name)
@@ -715,7 +715,7 @@ def _cleanup_stale_certs(iot: Any, thing_name: str) -> int:
     This helper detaches every existing principal, removes its policy
     attachments, marks the cert INACTIVE, and force-deletes it. Failures
     are logged at DEBUG and swallowed so a partial cleanup never blocks
-    the new cert issuance — the new cert is what users actually want.
+    the new cert issuance - the new cert is what users actually want.
 
     Returns the number of certs cleaned up (for logging in the caller).
     """

--- a/strands_robots/mesh/iot/shadow.py
+++ b/strands_robots/mesh/iot/shadow.py
@@ -1,8 +1,8 @@
-"""Device Shadow mirror — reflects presence/state to AWS IoT named shadows.
+"""Device Shadow mirror - reflects presence/state to AWS IoT named shadows.
 
 When the robot is online, every presence heartbeat ALSO updates the named
 shadow ``presence`` for the Thing. When the robot is offline, the shadow
-stays as the last reported state — late-joining operators (Bedrock agents,
+stays as the last reported state - late-joining operators (Bedrock agents,
 fleet ops dashboards) read fleet state via ``GetThingShadow`` REST without
 subscribing to MQTT.
 
@@ -20,7 +20,7 @@ Hooking in
 ready-to-wire convenience :func:`enable_for_mesh` that binds it to the
 heartbeat path automatically. Today the heartbeat path is
 :meth:`Mesh._heartbeat_loop` which calls ``put(strands/{peer}/presence,...)``
-— we hook in by registering a publish-side observer that mirrors any
+- we hook in by registering a publish-side observer that mirrors any
 presence write to the shadow update topic.
 
 Failure mode
@@ -64,7 +64,7 @@ class ShadowMirror:
 
     The ``update`` call wraps your dict in the canonical
     ``{"state": {"reported":...}}`` envelope and publishes via the active
-    transport's ``put()``. No retain — shadows are stored server-side.
+    transport's ``put()``. No retain - shadows are stored server-side.
     """
 
     def __init__(self, thing_name: str, shadow_name: str = "presence") -> None:
@@ -76,7 +76,7 @@ class ShadowMirror:
         """Push *reported_state* into the named shadow's ``reported`` slot.
 
         Args:
-            transport: An object with ``.put(topic, dict)`` — typically the
+            transport: An object with ``.put(topic, dict)`` - typically the
                 singleton from :func:`current_transport`. Pass ``None`` to
                 make this a no-op (useful when the mesh is off).
             reported_state: The dict that becomes ``state.reported`` in the
@@ -96,12 +96,12 @@ def enable_for_mesh(mesh: Any) -> ShadowMirror | None:
 
     Replaces ``mesh._build_presence`` with a wrapper that, after the original
     builds the payload, also pushes it to the named shadow. The original
-    behaviour (publishing to ``strands/{peer}/presence``) is preserved —
+    behaviour (publishing to ``strands/{peer}/presence``) is preserved -
     this is purely additive.
 
     Returns the :class:`ShadowMirror` so callers can drive ad-hoc updates
     too. Returns ``None`` if the mesh is not running an IoT-capable
-    transport (i.e. plain Zenoh — shadows aren't relevant there).
+    transport (i.e. plain Zenoh - shadows aren't relevant there).
     """
     from strands_robots.mesh.transport.factory import current_backend, current_transport
 

--- a/strands_robots/mesh/security.py
+++ b/strands_robots/mesh/security.py
@@ -180,7 +180,7 @@ MAX_TARGET_JOINTS: int = 256
 #: nested dict size, in JSON-encoded bytes. Mesh does not interpret the
 #: per-call collision-world refresh payload; it forwards it to the
 #: planner provider via ``policy_config``. The cap is purely DoS
-#: defence — 64 KiB fits any realistic obstacle list.
+#: defence - 64 KiB fits any realistic obstacle list.
 MAX_WORLD_UPDATE_BYTES: int = 65536
 
 #: Charset for entries in ``STRANDS_MESH_HF_REPO_ALLOW``. Operator-supplied
@@ -868,7 +868,7 @@ def validate_command(cmd: dict[str, Any]) -> dict[str, Any]:
 
         # Sim-targeted execute/start fields. These are admitted only for
         # the ``execute`` / ``start`` actions and are inert when the
-        # receiving peer is a HardwareRobot — ``Mesh._dispatch`` ignores
+        # receiving peer is a HardwareRobot - ``Mesh._dispatch`` ignores
         # them on the hardware path. Validating them here keeps the wire
         # schema honest end-to-end so a malicious peer cannot smuggle
         # control-byte instruction strings in via ``robot_name`` or
@@ -929,7 +929,7 @@ def validate_command(cmd: dict[str, Any]) -> dict[str, Any]:
             if value is not None and not isinstance(value, dict):
                 raise ValidationError("world_update must be a dict or null")
             if isinstance(value, dict):
-                # Bound the encoded size — mesh treats world_update as
+                # Bound the encoded size - mesh treats world_update as
                 # opaque and forwards it to the planner provider; we
                 # only need to keep it from becoming a DoS vector.
                 try:

--- a/strands_robots/mesh/sensors.py
+++ b/strands_robots/mesh/sensors.py
@@ -4,15 +4,15 @@ These loops are started conditionally by Mesh.start() and only publish when
 the robot exposes the relevant attribute. Zero-cost when unused.
 
 Topics published:
-- strands/{peer_id}/pose — SE(3) from SLAM/odometry/VIO
-- strands/{peer_id}/health — Battery, CPU, memory, disk, temps
-- strands/{peer_id}/imu — Roll/pitch/yaw, gyro, accel
-- strands/{peer_id}/odom — Dead-reckoning odometry
-- strands/{peer_id}/lidar/summary — Point cloud stats
-- strands/{peer_id}/lidar/state — Sensor state
-- strands/{peer_id}/hand/{name}/state — End-effector joints/force
-- strands/{peer_id}/map/info — Map metadata
-- strands/{peer_id}/safety/event — On-demand safety events
+- strands/{peer_id}/pose - SE(3) from SLAM/odometry/VIO
+- strands/{peer_id}/health - Battery, CPU, memory, disk, temps
+- strands/{peer_id}/imu - Roll/pitch/yaw, gyro, accel
+- strands/{peer_id}/odom - Dead-reckoning odometry
+- strands/{peer_id}/lidar/summary - Point cloud stats
+- strands/{peer_id}/lidar/state - Sensor state
+- strands/{peer_id}/hand/{name}/state - End-effector joints/force
+- strands/{peer_id}/map/info - Map metadata
+- strands/{peer_id}/safety/event - On-demand safety events
 """
 
 from __future__ import annotations

--- a/strands_robots/mesh/session.py
+++ b/strands_robots/mesh/session.py
@@ -2,7 +2,7 @@
 
 This module provides a single, ref-counted :func:`zenoh.open` session per process
 and a thread-safe registry of discovered peers.  It is the lowest layer of the
-mesh stack — higher-level constructs (``Mesh``, presence, RPC) build on top.
+mesh stack - higher-level constructs (``Mesh``, presence, RPC) build on top.
 
 The Zenoh dependency is **lazy**: ``import strands_robots.mesh_session`` does not
 import ``zenoh`` at module level.  The first call to :func:`get_session` triggers
@@ -11,7 +11,7 @@ the real import.  If ``eclipse-zenoh`` is not installed the function returns
 
 Connection strategy (when no explicit endpoint is configured):
 
-1. Try to **listen** on ``tcp/127.0.0.1:{STRANDS_MESH_PORT}`` — this makes the
+1. Try to **listen** on ``tcp/127.0.0.1:{STRANDS_MESH_PORT}`` - this makes the
    first process the local router.
 2. If the port is already bound, fall back to **client** mode and connect to the
    same endpoint.
@@ -20,7 +20,7 @@ Connection strategy (when no explicit endpoint is configured):
 Environment variables
 ---------------------
 ``ZENOH_CONNECT``
-    Comma-separated remote endpoint(s) — e.g. ``tcp/10.0.0.1:7447``.
+    Comma-separated remote endpoint(s) - e.g. ``tcp/10.0.0.1:7447``.
 ``ZENOH_LISTEN``
     Comma-separated listen endpoint(s).
 ``STRANDS_MESH_PORT``
@@ -43,7 +43,7 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
-# Session singleton — one ``zenoh.Session`` per process, ref-counted
+# Session singleton - one ``zenoh.Session`` per process, ref-counted
 
 
 _SESSION: Any | None = None  # zenoh.Session when open, else None
@@ -61,7 +61,7 @@ HEARTBEAT_HZ: float = 2.0
 STATE_HZ: float = 10.0
 
 #: Default camera-publishing frequency (Hz).  ``0`` disables the camera
-#: loop — opt-in via the ``STRANDS_MESH_CAMERA_HZ`` environment variable
+#: loop - opt-in via the ``STRANDS_MESH_CAMERA_HZ`` environment variable
 #: because frames are large and bandwidth-heavy.
 CAMERA_HZ: float = 0.0
 
@@ -115,7 +115,7 @@ HAND_HZ: float = 50.0
 MAP_INFO_HZ: float = 0.2
 
 
-# Backend selection helpers — when STRANDS_MESH_BACKEND is "iot" or "bridge",
+# Backend selection helpers - when STRANDS_MESH_BACKEND is "iot" or "bridge",
 # get_session() / put() / current_session() / session_alive() delegate to the
 # transport factory instead of opening a Zenoh session directly. The "zenoh"
 # default keeps the historical behaviour byte-for-byte so the 200+ existing
@@ -176,7 +176,7 @@ class PeerInfo:
         return f"PeerInfo(peer_id={self.peer_id!r}, type={self.peer_type!r}, age={self.age:.1f}s)"
 
 
-# Peer registry — shared across all Mesh instances in the same process
+# Peer registry - shared across all Mesh instances in the same process
 
 
 _PEERS: dict[str, PeerInfo] = {}
@@ -186,7 +186,7 @@ _PEERS_LOCK = threading.Lock()
 
 def update_peer(peer_id: str, peer_type: str, hostname: str, caps: dict[str, Any]) -> bool:
     """Insert or update a peer.  Returns ``True`` when the peer is new."""
-    global _PEERS_VERSION  # noqa: PLW0603 — module-level singleton by design
+    global _PEERS_VERSION  # noqa: PLW0603 - module-level singleton by design
     with _PEERS_LOCK:
         is_new = peer_id not in _PEERS
         # When a NEW peer would push us over the cap, evict the oldest
@@ -477,10 +477,10 @@ def get_session() -> Any | None:
 
     Backend selection comes from ``STRANDS_MESH_BACKEND``:
 
-    - ``zenoh`` (default) — open / reuse a ``zenoh.Session`` exactly as before.
+    - ``zenoh`` (default) - open / reuse a ``zenoh.Session`` exactly as before.
       Returned object is the raw session; callers can ``.declare_subscriber()``
       on it.
-    - ``iot`` / ``bridge`` — delegate to
+    - ``iot`` / ``bridge`` - delegate to
       :mod:`strands_robots.mesh.transport.factory`; the returned object is an
       :class:`~strands_robots.mesh.transport.IotMqttTransport` or
       :class:`~strands_robots.mesh.transport.BridgeTransport` which **also**
@@ -495,7 +495,7 @@ def get_session() -> Any | None:
 
     if _is_transport_backend():
         # Delegate to the transport factory. The factory holds its own
-        # refcount independently of _SESSION_REFS — that's fine, callers
+        # refcount independently of _SESSION_REFS - that's fine, callers
         # that release_session() will see the matching release_transport().
         from strands_robots.mesh.transport.factory import get_transport
 
@@ -507,14 +507,14 @@ def get_session() -> Any | None:
             return _SESSION
 
         try:
-            import zenoh  # noqa: F811 — lazy import
+            import zenoh  # noqa: F811 - lazy import
         except ImportError:
-            logger.debug("eclipse-zenoh not installed — mesh disabled")
+            logger.debug("eclipse-zenoh not installed - mesh disabled")
             return None
 
         # STRANDS_MESH_PORT is read at session-open time so a process can be
         # configured via env vars without re-importing.  Bad input falls back
-        # to the default and warns once — never raises (the default behaviour
+        # to the default and warns once - never raises (the default behaviour
         # is to keep the mesh quietly off rather than crash the host robot).
         port_env = os.getenv("STRANDS_MESH_PORT", "7447")
         try:
@@ -523,7 +523,7 @@ def get_session() -> Any | None:
                 raise ValueError(f"port {mesh_port} out of range")
         except ValueError as exc:
             logger.warning(
-                "Invalid STRANDS_MESH_PORT=%r (%s) — falling back to 7447",
+                "Invalid STRANDS_MESH_PORT=%r (%s) - falling back to 7447",
                 port_env,
                 exc,
             )
@@ -607,12 +607,12 @@ def get_session() -> Any | None:
                 # try anyway -- belt-and-braces).
                 # Port already bound (the most common case) is not an error.
                 logger.debug(
-                    "Zenoh listener on %s unavailable (%s) — trying client mode",
+                    "Zenoh listener on %s unavailable (%s) - trying client mode",
                     local_ep,
                     exc,
                 )
 
-            # Fall back to client mode — connect to the existing listener.
+            # Fall back to client mode - connect to the existing listener.
             # Build cfg OUTSIDE the try so a config-shape ValueError
             # (NaN env clamp, missing TLS file, bad ACL) propagates
             # loudly to Mesh.start instead of being silently downgraded
@@ -673,7 +673,7 @@ def _get_zenoh_session_directly() -> Any | None:
         try:
             import zenoh
         except ImportError:
-            logger.debug("eclipse-zenoh not installed — mesh disabled")
+            logger.debug("eclipse-zenoh not installed - mesh disabled")
             return None
 
         port_env = os.getenv("STRANDS_MESH_PORT", "7447")
@@ -683,7 +683,7 @@ def _get_zenoh_session_directly() -> Any | None:
                 raise ValueError(f"port {mesh_port} out of range")
         except ValueError as exc:
             logger.warning(
-                "Invalid STRANDS_MESH_PORT=%r (%s) — falling back to 7447",
+                "Invalid STRANDS_MESH_PORT=%r (%s) - falling back to 7447",
                 port_env,
                 exc,
             )
@@ -734,7 +734,7 @@ def _get_zenoh_session_directly() -> Any | None:
                 # narrowing applied in get_session() upstairs. Config-shape
                 # ValueError now propagates instead of being swallowed at DEBUG.
                 logger.debug(
-                    "Zenoh listener on %s unavailable (%s) — trying client mode",
+                    "Zenoh listener on %s unavailable (%s) - trying client mode",
                     local_ep,
                     exc,
                 )

--- a/strands_robots/mesh/transport/__init__.py
+++ b/strands_robots/mesh/transport/__init__.py
@@ -1,4 +1,4 @@
-"""Mesh transport layer — pluggable backends behind a single Protocol.
+"""Mesh transport layer - pluggable backends behind a single Protocol.
 
 Exports the :class:`MeshTransport` Protocol, both concrete backends
 (:class:`ZenohTransport`, :class:`IotMqttTransport`), and the process-wide

--- a/strands_robots/mesh/transport/base.py
+++ b/strands_robots/mesh/transport/base.py
@@ -4,7 +4,7 @@ Defines the Protocol that :class:`~strands_robots.mesh.core.Mesh` uses to
 publish and subscribe. Every concrete backend (Zenoh, AWS IoT MQTT, Bridge)
 implements this protocol.
 
-The protocol is deliberately tiny — exactly what ``mesh.session`` already
+The protocol is deliberately tiny - exactly what ``mesh.session`` already
 exposed. Every behavioural enrichment (peer registry, RPC correlation, audit)
 lives at the Mesh layer and is transport-agnostic.
 
@@ -15,8 +15,8 @@ Zenoh callbacks receive a ``zenoh.Sample`` with ``.key_expr`` and
 ``bytes`` payload. Rather than pick a concrete type and force one transport
 to adapt, we declare the **structural protocol** all callers actually use:
 
-    sample.key_expr  # str  — the topic / key the message arrived on
-    sample.payload.to_bytes()  # bytes — the raw payload
+    sample.key_expr  # str  - the topic / key the message arrived on
+    sample.payload.to_bytes()  # bytes - the raw payload
 
 Concrete backends produce objects matching this shape. The MQTT backend ships
 a tiny ``_MqttSample`` wrapper; the Zenoh backend passes ``zenoh.Sample``
@@ -43,13 +43,13 @@ class Sample(Protocol):
     ``_on_cmd``, ``_on_response``) work unchanged regardless of transport.
     """
 
-    key_expr: Any  # zenoh: KeyExpr; mqtt: str — both stringify
+    key_expr: Any  # zenoh: KeyExpr; mqtt: str - both stringify
     payload: _PayloadLike
 
 
 @runtime_checkable
 class SubHandle(Protocol):
-    """Opaque subscription handle — must support ``undeclare()`` for teardown.
+    """Opaque subscription handle - must support ``undeclare()`` for teardown.
 
     Mirrors ``zenoh.Subscriber.undeclare()``. MQTT-backed implementations wrap
     the broker's ``unsubscribe`` packet behind the same name so Mesh teardown
@@ -78,7 +78,7 @@ class MeshTransport(Protocol):
     ------------
     A transport whose connection is dead returns ``False`` from
     :meth:`is_alive`. Callers (notably :func:`put`) treat a dead transport as
-    a no-op rather than raising — preserving the current Mesh contract that
+    a no-op rather than raising - preserving the current Mesh contract that
     publish failures never propagate up into hot control loops.
     """
 
@@ -90,7 +90,7 @@ class MeshTransport(Protocol):
 
         Args:
             key: The topic / Zenoh key expression. For MQTT-backed transports
-                this is the MQTT topic verbatim (no translation needed — our
+                this is the MQTT topic verbatim (no translation needed - our
                 topic scheme is already MQTT-safe).
             data: A JSON-serialisable dictionary. Implementations are expected
                 to encode it via ``json.dumps(...).encode()``.

--- a/strands_robots/mesh/transport/bridge_transport.py
+++ b/strands_robots/mesh/transport/bridge_transport.py
@@ -1,4 +1,4 @@
-"""Bridge transport — Zenoh LAN + AWS IoT WAN behind one MeshTransport.
+"""Bridge transport - Zenoh LAN + AWS IoT WAN behind one MeshTransport.
 
 This is the **production** transport for fleets that have both LAN peers
 (robot + sim + leader arm in the same room) AND cloud connectivity
@@ -23,7 +23,7 @@ subscribes ``h`` on both Zenoh and MQTT. Inbound deduplication happens at
 the :class:`Mesh` layer (existing :meth:`_on_presence` / :meth:`_on_cmd` /
 :meth:`_on_response` already handle duplicate / self-loop dropouts via
 ``sender_id`` and ``turn_id`` correlation), so we don't try to be clever
-here — the fact that a presence might arrive twice is harmless and the
+here - the fact that a presence might arrive twice is harmless and the
 existing peer registry deduplicates by ``peer_id``.
 
 Failure isolation
@@ -71,26 +71,26 @@ def _get_iot_transport_class() -> type[IotMqttTransport]:
     return _IT
 
 
-# Default bridge filter — derived from cost / latency analysis.
+# Default bridge filter - derived from cost / latency analysis.
 #
 # Topics in this set bridge from Zenoh to MQTT. Everything else stays LAN.
 # Suffixes are matched against the part of the topic AFTER ``strands/``.
 #
 # Why this default:
-# - presence  — rare, retained on cloud, late operators need it
-# - health  — rare, retained, threshold alerts via Rules
-# - safety/event  — must hit cloud audit
-# - safety/estop  — defence-in-depth E-stop
-# - safety/resume  — paired with safety/estop; cloud audit needs the
+# - presence  - rare, retained on cloud, late operators need it
+# - health  - rare, retained, threshold alerts via Rules
+# - safety/event  - must hit cloud audit
+# - safety/estop  - defence-in-depth E-stop
+# - safety/resume  - paired with safety/estop; cloud audit needs the
 #   resume edge to close the safety incident timeline
-# - cmd  — operator-to-robot RPC (cloud → robot direction)
-# - response  — robot-to-operator RPC reply
-# - broadcast  — fan-out RPC
+# - cmd  - operator-to-robot RPC (cloud → robot direction)
+# - response  - robot-to-operator RPC reply
+# - broadcast  - fan-out RPC
 #
 # Explicitly NOT bridged by default (opt in via STRANDS_MESH_BRIDGE_TOPICS):
-# - state, pose, imu, odom, lidar — high volume, route via Basic Ingest if
+# - state, pose, imu, odom, lidar - high volume, route via Basic Ingest if
 #  cloud needs them. See AWS_IOT_MESH_INTEGRATION.md §7.2 for the cost math.
-# - camera, input, hand — LAN-only by definition (size / latency).
+# - camera, input, hand - LAN-only by definition (size / latency).
 DEFAULT_BRIDGE_SUFFIXES: frozenset[str] = frozenset(
     {
         "presence",
@@ -527,7 +527,7 @@ class _BridgeSubHandle:
 class BridgeTransport:
     """:class:`MeshTransport` that fans out to both Zenoh (LAN) and AWS IoT (WAN).
 
-    Construct with no arguments — the underlying :class:`ZenohTransport` and
+    Construct with no arguments - the underlying :class:`ZenohTransport` and
     :class:`IotMqttTransport` read their config from env vars exactly as
     they would on their own.
 
@@ -572,14 +572,14 @@ class BridgeTransport:
 
             if self._zenoh_alive and self._iot_alive:
                 logger.info(
-                    "[bridge] both transports up — bridging %d topic suffix(es): %s",
+                    "[bridge] both transports up - bridging %d topic suffix(es): %s",
                     len(self._bridge_suffixes),
                     sorted(self._bridge_suffixes),
                 )
             elif self._zenoh_alive:
-                logger.info("[bridge] only Zenoh up — running LAN-only")
+                logger.info("[bridge] only Zenoh up - running LAN-only")
             else:
-                logger.info("[bridge] only IoT up — running cloud-only")
+                logger.info("[bridge] only IoT up - running cloud-only")
             return True
 
     def close(self) -> None:

--- a/strands_robots/mesh/transport/factory.py
+++ b/strands_robots/mesh/transport/factory.py
@@ -9,15 +9,15 @@ Backend selection
 -----------------
 Selection is done at the first :func:`get_transport` call:
 
-- ``zenoh`` (default) — :class:`ZenohTransport`
-- ``iot``  — :class:`IotMqttTransport`
-- ``bridge``  — :class:`BridgeTransport` (Zenoh + IoT)
+- ``zenoh`` (default) - :class:`ZenohTransport`
+- ``iot``  - :class:`IotMqttTransport`
+- ``bridge``  - :class:`BridgeTransport` (Zenoh + IoT)
 
 Subsequent calls in the same process bump the refcount but do NOT switch
 backends. To change the backend, every consumer must release first
 (``release_transport`` until refcount is 0) and then a new selection is made.
 
-The factory is **not** consulted by :mod:`strands_robots.mesh.session` —
+The factory is **not** consulted by :mod:`strands_robots.mesh.session` -
 that module owns the legacy zenoh path independently. The factory is the
 new path used when :class:`Mesh` is configured for ``backend="iot"``.
 """
@@ -42,12 +42,12 @@ _LOCK = threading.Lock()
 def _select_backend() -> str:
     """Resolve ``STRANDS_MESH_BACKEND``. Defaults to ``zenoh``.
 
-    Unknown values fall back to ``zenoh`` with a warning — the policy is to
+    Unknown values fall back to ``zenoh`` with a warning - the policy is to
     keep the mesh running rather than crash the host on a typo.
     """
     raw = os.getenv("STRANDS_MESH_BACKEND", "zenoh").strip().lower()
     if raw not in ("zenoh", "iot", "bridge"):
-        logger.warning("Unknown STRANDS_MESH_BACKEND=%r — falling back to 'zenoh'", raw)
+        logger.warning("Unknown STRANDS_MESH_BACKEND=%r - falling back to 'zenoh'", raw)
         return "zenoh"
     return raw
 
@@ -77,7 +77,7 @@ def get_transport() -> MeshTransport | None:
 
     Increments the refcount each call. Returns ``None`` if the underlying
     backend's :meth:`connect` failed (Zenoh missing, certs missing, broker
-    unreachable, etc.) — callers MUST treat ``None`` the same way they
+    unreachable, etc.) - callers MUST treat ``None`` the same way they
     treated ``get_session() is None`` historically: skip mesh activity and
     move on without raising.
     """
@@ -94,7 +94,7 @@ def get_transport() -> MeshTransport | None:
         ok = transport.connect()  # type: ignore[attr-defined]
         if not ok:
             logger.debug(
-                "[mesh.transport] %s backend connect failed — staying off",
+                "[mesh.transport] %s backend connect failed - staying off",
                 backend,
             )
             return None

--- a/strands_robots/mesh/transport/iot_transport.py
+++ b/strands_robots/mesh/transport/iot_transport.py
@@ -1,13 +1,13 @@
-"""AWS IoT Core MQTT5 transport — :class:`MeshTransport` over mTLS.
+"""AWS IoT Core MQTT5 transport - :class:`MeshTransport` over mTLS.
 
 Wraps an ``awscrt.mqtt5`` client behind the :class:`MeshTransport` Protocol so
 :class:`~strands_robots.mesh.core.Mesh` can publish presence, state, RPCs, and
 safety events to AWS IoT Core with X.509 mutual TLS.
 
-The strands-robots topic scheme is already MQTT-safe — every Zenoh key like
+The strands-robots topic scheme is already MQTT-safe - every Zenoh key like
 ``strands/{peer}/state`` translates verbatim. The only translations that
 happen here are wildcard mapping (``*`` → ``+``, ``**`` → ``#``) and the
-delivery shape — MQTT5's flat ``(topic_str, bytes)`` callback is wrapped in
+delivery shape - MQTT5's flat ``(topic_str, bytes)`` callback is wrapped in
 a tiny ``_MqttSample`` so existing :class:`Mesh` handlers work unmodified.
 
 Trust model
@@ -39,7 +39,7 @@ Failure mode
 If ``awsiotsdk`` is not installed, :meth:`connect` returns ``False`` and the
 transport behaves as a silent no-op (matching :class:`ZenohTransport` when
 Zenoh is missing). If the endpoint or cert files are missing, :meth:`connect`
-logs at ERROR and returns ``False`` — the mesh stays off rather than crash
+logs at ERROR and returns ``False`` - the mesh stays off rather than crash
 the host.
 """
 
@@ -81,7 +81,7 @@ _TOPIC_POLICY: dict[str, tuple[int, bool]] = {
     "safety/resume": (1, True),  # paired with safety/estop; closes incident windows
     "stream": (0, False),
     "stream/meta": (0, False),
-    # Camera frames are too big for MQTT — IotMqttTransport drops them.
+    # Camera frames are too big for MQTT - IotMqttTransport drops them.
     # See the design doc §4.2 for the S3 offload pattern.
     "camera": ("DROP", False),  # type: ignore[dict-item]
 }
@@ -89,9 +89,9 @@ _TOPIC_POLICY: dict[str, tuple[int, bool]] = {
 # Topics we strictly never publish over MQTT, regardless of caller intent.
 # Camera frames hit MQTT's 128 KB cap; teleop input has fatal latency over WAN.
 _NEVER_BRIDGE_PREFIXES: tuple[str, ...] = (
-    "camera/",  # JPEG frames — use S3 offload (Layer 3)
-    "input/",  # 50 Hz teleop — LAN-only
-    "hand/",  # 50 Hz hand control — LAN-only
+    "camera/",  # JPEG frames - use S3 offload (Layer 3)
+    "input/",  # 50 Hz teleop - LAN-only
+    "hand/",  # 50 Hz hand control - LAN-only
 )
 
 
@@ -167,9 +167,9 @@ def _zenoh_to_mqtt_filter(key_expr: str) -> str:
         if seg == "**":
             # Tail wildcard. Must be last segment in MQTT; if it isn't, log at
             # DEBUG (caller is using a Zenoh idiom that doesn't translate) and
-            # leave the rest verbatim — broker will reject.
+            # leave the rest verbatim - broker will reject.
             if i != len(segments) - 1:
-                logger.debug("Zenoh '**' is not in tail position in %r — MQTT may reject", key_expr)
+                logger.debug("Zenoh '**' is not in tail position in %r - MQTT may reject", key_expr)
             out.append("#")
         elif seg == "*":
             out.append("+")
@@ -202,25 +202,25 @@ def _qos_and_retain_for(topic: str) -> tuple[int, bool]:
     first = rest_segments[0]
 
     # Two distinct topic layouts in the strands-robots scheme. They MUST NOT
-    # be tried as a fallback chain — a peer_id that happens to be named
+    # be tried as a fallback chain - a peer_id that happens to be named
     # "broadcast" or "safety" must NOT pick up the top-level policy entry.
     #
-    #  (a) Top-level system topics — first segment IS the kind:
+    #  (a) Top-level system topics - first segment IS the kind:
     #  strands/broadcast
     #  strands/safety/estop
     #
-    #  (b) Per-peer topics — first segment is the peer_id, topic kind
+    #  (b) Per-peer topics - first segment is the peer_id, topic kind
     #  starts at segment 1:
     #  strands/{peer}/{kind}  (e.g. presence, state, cmd)
     #  strands/{peer}/{kind}/{sub}  (e.g. lidar/summary, response/{turn})
     #
     # We resolve the layout by checking whether *first* is one of the
-    # reserved top-level kinds. The set is small and closed — extending
+    # reserved top-level kinds. The set is small and closed - extending
     # the topic scheme means extending this set.
     _TOP_LEVEL_KINDS = {"broadcast", "safety"}
 
     if first in _TOP_LEVEL_KINDS:
-        # Layout (a) — match suffixes that include the first segment.
+        # Layout (a) - match suffixes that include the first segment.
         for n in range(len(rest_segments), 0, -1):
             candidate = "/".join(rest_segments[:n])
             entry = _TOPIC_POLICY.get(candidate)
@@ -231,7 +231,7 @@ def _qos_and_retain_for(topic: str) -> tuple[int, bool]:
                 return int(qos_or_drop), retain
         return 0, False
 
-    # Layout (b) — first segment is a peer_id; skip it.
+    # Layout (b) - first segment is a peer_id; skip it.
     if len(rest_segments) < 2:
         return 0, False
 
@@ -259,7 +259,7 @@ class IotMqttTransport:
     """Concrete :class:`MeshTransport` backed by AWS IoT Core MQTT5/mTLS.
 
     One instance manages exactly one ``awscrt.mqtt5.Client``. The client's
-    ``client_id`` MUST equal the Thing name attached to the cert — the
+    ``client_id`` MUST equal the Thing name attached to the cert - the
     constructor enforces this so policy variable substitution works.
 
     Subscriptions are tracked in a dict keyed by topic_filter so
@@ -308,7 +308,7 @@ class IotMqttTransport:
                 from awsiot import mqtt5_client_builder
             except ImportError:
                 logger.error(
-                    "awsiotsdk not installed — IoT transport disabled. "
+                    "awsiotsdk not installed - IoT transport disabled. "
                     "Install with: pip install 'strands-robots[mesh-iot]'"
                 )
                 return False
@@ -398,7 +398,7 @@ class IotMqttTransport:
 
         Per-topic QoS and retain flags come from :data:`_TOPIC_POLICY`.
         Topics in :data:`_NEVER_BRIDGE_PREFIXES` (camera/input/hand) are
-        silently dropped — they belong on Zenoh-LAN, not MQTT-WAN.
+        silently dropped - they belong on Zenoh-LAN, not MQTT-WAN.
         """
         if self._client is None or not self._connected.is_set():
             return
@@ -428,7 +428,7 @@ class IotMqttTransport:
     def declare_subscriber(self, key_expr: str, handler: Callable[[Any], None]) -> Any:
         """Subscribe to *key_expr* (Zenoh form) translated to an MQTT topic filter.
 
-        Multiple subscribers to the same filter are allowed — handlers are
+        Multiple subscribers to the same filter are allowed - handlers are
         appended to a per-filter list. Each :class:`_MqttSubHandle` only
         removes its own handler on undeclare.
         """
@@ -484,7 +484,7 @@ class IotMqttTransport:
                 return  # other subscribers still active
             self._handlers.pop(topic_filter, None)
 
-        # Last handler removed — unsubscribe at the broker.
+        # Last handler removed - unsubscribe at the broker.
         if self._client is None:
             return
         try:
@@ -514,7 +514,7 @@ class IotMqttTransport:
         payload = bytes(data.publish_packet.payload or b"")
 
         # Match topic against all registered filters. MQTT brokers route by
-        # filter, but our handler-dict is keyed by the original filter — so
+        # filter, but our handler-dict is keyed by the original filter - so
         # we need to test each registered filter for a topic match.
         with self._lock:
             matching = [(f, list(handlers)) for f, handlers in self._handlers.items() if _mqtt_topic_matches(f, topic)]
@@ -545,7 +545,7 @@ def _mqtt_topic_matches(filter_: str, topic: str) -> bool:
 
     for i, fp in enumerate(f_parts):
         if fp == "#":
-            # Tail wildcard — matches everything from here, including zero
+            # Tail wildcard - matches everything from here, including zero
             # remaining segments.
             return True
         if i >= len(t_parts):
@@ -555,5 +555,5 @@ def _mqtt_topic_matches(filter_: str, topic: str) -> bool:
         if fp != t_parts[i]:
             return False
 
-    # Filter exhausted — topic matches iff topic is also exhausted.
+    # Filter exhausted - topic matches iff topic is also exhausted.
     return len(t_parts) == len(f_parts)

--- a/strands_robots/mesh/transport/zenoh_transport.py
+++ b/strands_robots/mesh/transport/zenoh_transport.py
@@ -1,4 +1,4 @@
-"""Eclipse Zenoh transport — thin :class:`MeshTransport` adapter over the
+"""Eclipse Zenoh transport - thin :class:`MeshTransport` adapter over the
 existing :mod:`strands_robots.mesh.session` singleton.
 
 This wrapper deliberately delegates to the legacy ``session.get_session()`` /
@@ -7,7 +7,7 @@ reimplementing them. That keeps:
 
 1. **Zero behaviour change for existing callers.** Every test in
    ``tests/mesh/test_mesh_session.py`` that pokes
-   ``session._SESSION`` / ``_SESSION_REFS`` keeps working — the legacy
+   ``session._SESSION`` / ``_SESSION_REFS`` keeps working - the legacy
    module is the single source of truth for Zenoh state.
 2. **A single connect/teardown path.** Multiple :class:`ZenohTransport`
    instances in the same process all funnel into the same ref-counted
@@ -41,7 +41,7 @@ class ZenohTransport:
 
     Thread safety: :meth:`connect` and :meth:`close` are guarded by an
     internal lock so concurrent ``Mesh.start()`` calls don't double-acquire.
-    The hot path (:meth:`put`) is lock-free in steady-state — 50 Hz teleop
+    The hot path (:meth:`put`) is lock-free in steady-state - 50 Hz teleop
     loops never serialise on the transport.
     """
 
@@ -55,7 +55,7 @@ class ZenohTransport:
         """Acquire (or reuse) the shared Zenoh session.
 
         Returns ``True`` on success, ``False`` if Zenoh is unavailable. Calling
-        :meth:`connect` twice on the same instance is a no-op — only one
+        :meth:`connect` twice on the same instance is a no-op - only one
         reference is held per :class:`ZenohTransport` instance regardless of
         how many times it's connected.
         """
@@ -102,7 +102,7 @@ class ZenohTransport:
 
         Exposed for callers that need to perform Zenoh-specific operations
         not yet abstracted into the :class:`MeshTransport` protocol. New
-        code should not depend on this — use :meth:`put` and
+        code should not depend on this - use :meth:`put` and
         :meth:`declare_subscriber`.
         """
         from strands_robots.mesh.session import _current_zenoh_session_directly
@@ -123,7 +123,7 @@ class ZenohTransport:
     def declare_subscriber(self, key_expr: str, handler: Callable[[Any], None]) -> Any:
         """Subscribe to *key_expr* and route inbound samples to *handler*.
 
-        Returns the raw ``zenoh.Subscriber`` directly — already exposes
+        Returns the raw ``zenoh.Subscriber`` directly - already exposes
         ``.undeclare()`` so it satisfies the :class:`SubHandle` protocol.
 
         Raises ``RuntimeError`` if the session is not open.

--- a/strands_robots/policies/base.py
+++ b/strands_robots/policies/base.py
@@ -4,11 +4,11 @@ The :class:`Policy` ABC is intentionally agnostic about *how* actions are
 produced.  Built-in providers (`mock`, `groot`, `lerobot_local`) are VLA-style,
 but the same interface is the right shape for:
 
-* **Classical motion planners** — cuRobo, MoveIt2, OMPL, RRT*: take a goal
+* **Classical motion planners** - cuRobo, MoveIt2, OMPL, RRT*: take a goal
   pose and joint state, return a collision-free trajectory.
-* **Model-predictive controllers** (MPC) — solve a finite-horizon optimal
+* **Model-predictive controllers** (MPC) - solve a finite-horizon optimal
   control problem each tick.
-* **Scripted / pure-IK trajectories** — analytic IK followed by interpolation;
+* **Scripted / pure-IK trajectories** - analytic IK followed by interpolation;
   zero learning involved.
 
 Non-VLA implementations typically set :attr:`Policy.requires_images` to
@@ -64,13 +64,13 @@ class Policy(ABC):
                 providers when present so callers don't have to JSON-encode
                 goals into the ``instruction`` string:
 
-                - ``target_pose: list[float]`` — Cartesian goal as
+                - ``target_pose: list[float]`` - Cartesian goal as
                   ``[x, y, z, qw, qx, qy, qz]`` (position in metres,
                   orientation as a unit quaternion in the robot base frame).
-                - ``target_joints: dict[str, float]`` — joint-space goal
+                - ``target_joints: dict[str, float]`` - joint-space goal
                   keyed by joint name; values are in radians (revolute) or
                   metres (prismatic).
-                - ``world_update: dict | None`` — per-call world refresh
+                - ``world_update: dict | None`` - per-call world refresh
                   for collision-aware planners (e.g. point cloud / depth
                   image / mesh updates).  ``None`` means "reuse the world
                   configured at init time".
@@ -121,7 +121,7 @@ class Policy(ABC):
 
         For SERVICE-mode policies (e.g. ``Gr00tPolicy(host=...)`` over
         ZMQ), the override forwards the call to the server so its
-        per-episode RNG state can be re-initialised — without this,
+        per-episode RNG state can be re-initialised - without this,
         ``set_eval_seed`` only seeds the client-side process, leaving
         the server's diffusion sampler RNG drifting across calls and
         breaking reproducibility (#187).
@@ -144,7 +144,7 @@ class Policy(ABC):
         consume joint state (e.g. ``MockPolicy``, classical motion planners
         such as cuRobo / MoveIt2, MPC, pure-IK controllers, scripted
         trajectories) can return ``False`` to let the simulation skip
-        expensive camera rendering — a ~10x throughput win at 500Hz when
+        expensive camera rendering - a ~10x throughput win at 500Hz when
         no cameras are needed.
         """
         return True

--- a/strands_robots/policies/cosmos3/__init__.py
+++ b/strands_robots/policies/cosmos3/__init__.py
@@ -1,10 +1,10 @@
-"""Cosmos 3 Policy — NVIDIA omnimodal VLA policy for strands-robots.
+"""Cosmos 3 Policy - NVIDIA omnimodal VLA policy for strands-robots.
 
 Wraps the Cosmos 3 Generator *action* surface (e.g.
 ``nvidia/Cosmos3-Nano-Policy-DROID``) as a robots :class:`Policy`. Service mode
 speaks to the Cosmos Framework RoboLab WebSocket policy server using a
 self-contained msgpack+NumPy wire client (no ``openpi-client`` dependency
-— see ``client.py`` for the rationale).
+- see ``client.py`` for the rationale).
 
 Quickstart::
 
@@ -14,7 +14,7 @@ Quickstart::
     #        --checkpoint-path nvidia/Cosmos3-Nano-Policy-DROID --port 8000
     #    # wait for: curl http://localhost:8000/healthz  -> 200
     #
-    # 2. Client install (numpy-version agnostic — composes with lerobot):
+    # 2. Client install (numpy-version agnostic - composes with lerobot):
     #    pip install 'strands-robots[cosmos3-service]'
 
     from strands_robots.policies import create_policy
@@ -22,7 +22,7 @@ Quickstart::
     policy = create_policy("cosmos3", embodiment="droid", port=8000)
     chunk = policy.get_actions_sync(observation, "pick up the cube")
 
-In MuJoCo (the ``droid`` embodiment drives a Franka/DROID-class arm — use the
+In MuJoCo (the ``droid`` embodiment drives a Franka/DROID-class arm - use the
 ``franka`` or ``panda`` sim asset)::
 
     from strands_robots import Simulation

--- a/strands_robots/policies/cosmos3/client.py
+++ b/strands_robots/policies/cosmos3/client.py
@@ -3,8 +3,8 @@
 Cosmos Framework ships a ready-made policy server
 (``cosmos_framework.scripts.action_policy_server_robolab``) that serves
 ``nvidia/Cosmos3-Nano-Policy-DROID`` over a msgpack + NumPy WebSocket
-protocol. This module ships a self-contained client — **no
-``openpi-client`` dependency** — using only ``websockets`` + ``msgpack``
+protocol. This module ships a self-contained client - **no
+``openpi-client`` dependency** - using only ``websockets`` + ``msgpack``
 plus a vendored NumPy packer (``_msgpack_numpy``).
 
 Why no ``openpi-client``? It pins ``numpy<2.0``, which is mutually
@@ -87,7 +87,7 @@ class Cosmos3WebsocketClient:
 
     The connection is established lazily on the first :meth:`infer` (or
     :meth:`get_server_metadata`) call so constructing a policy does not
-    require the server to already be up — matching ``Gr00tInferenceClient``.
+    require the server to already be up - matching ``Gr00tInferenceClient``.
     """
 
     def __init__(
@@ -102,7 +102,7 @@ class Cosmos3WebsocketClient:
         self.api_key = api_key
         if transport not in (None, "", "raw"):
             logger.warning(
-                "Cosmos3WebsocketClient(transport=%r) is deprecated — the "
+                "Cosmos3WebsocketClient(transport=%r) is deprecated - the "
                 "openpi-client dependency has been removed and the only "
                 "supported transport is the vendored raw msgpack+websockets "
                 "packer. Treating as transport='raw'.",
@@ -167,7 +167,7 @@ class Cosmos3WebsocketClient:
     def reset(self) -> None:
         """Best-effort per-episode reset hint to the server.
 
-        The raw transport is stateless on the client side — reset is a
+        The raw transport is stateless on the client side - reset is a
         soft hint, never a correctness requirement (mirrors
         ``Gr00tPolicy.reset``). Any failure is swallowed.
         """

--- a/strands_robots/policies/cosmos3/embodiments.py
+++ b/strands_robots/policies/cosmos3/embodiments.py
@@ -1,4 +1,4 @@
-"""Cosmos 3 embodiment specs — data-driven action/observation layouts.
+"""Cosmos 3 embodiment specs - data-driven action/observation layouts.
 
 Each embodiment maps a Cosmos 3 ``domain_name`` (the world-model conditioning
 domain) to its raw action dimensionality, default action-chunk size, and the

--- a/strands_robots/policies/cosmos3/policy.py
+++ b/strands_robots/policies/cosmos3/policy.py
@@ -1,14 +1,14 @@
-"""Cosmos 3 policy — NVIDIA omnimodal VLA policy via Cosmos Framework.
+"""Cosmos 3 policy - NVIDIA omnimodal VLA policy via Cosmos Framework.
 
 Implements :class:`~strands_robots.policies.base.Policy` for the Cosmos 3
 **Generator action surface** (``nvidia/Cosmos3-Nano-Policy-DROID`` and friends).
 
 The Cosmos 3 ``policy`` action mode takes ``image + instruction`` and returns an
-``[T, D]`` action chunk + rollout video — a 1:1 match for the robots policy
+``[T, D]`` action chunk + rollout video - a 1:1 match for the robots policy
 contract. We talk to the Cosmos Framework RoboLab WebSocket policy server
 (``cosmos_framework.scripts.action_policy_server_robolab``) over a
 self-contained msgpack+NumPy WebSocket protocol (no ``openpi-client``
-dependency — see ``client.py``), mirroring
+dependency - see ``client.py``), mirroring
 :class:`~strands_robots.policies.groot.Gr00tPolicy` service mode.
 
 Observation flow
@@ -35,8 +35,8 @@ Action flow
 -----------
 The server returns ``{"action": np.ndarray(T, D)}``. Each of the ``D`` columns
 is named by the embodiment's ``action_layout`` (e.g. DROID joint_pos =
-``[joint_0..joint_6, gripper]``). We emit ``list[dict]`` — one dict per
-timestep — optionally remapping column names to robot actuator names via
+``[joint_0..joint_6, gripper]``). We emit ``list[dict]`` - one dict per
+timestep - optionally remapping column names to robot actuator names via
 ``action_mapping``.
 
 Example::
@@ -104,7 +104,7 @@ class Cosmos3Policy(Policy):
             ``"bridge"``). Selects domain, action layout, and defaults.
         host: Policy-server hostname.
         port: Policy-server WebSocket port.
-        action_space: ``"joint_pos"`` or ``"midtrain"`` — must match how the
+        action_space: ``"joint_pos"`` or ``"midtrain"`` - must match how the
             server was launched (DROID default = ``joint_pos``).
         observation_mapping: ``{robot_obs_key: "observation/<server_key>"}``.
             Maps robot camera + state keys onto the server's OpenPI keys.
@@ -113,7 +113,7 @@ class Cosmos3Policy(Policy):
             the embodiment's action-layout columns to robot actuator names.
             Keys are validated against the active layout at construction.
             When ``None``, columns keep their layout names.
-        robot: Convenience — name of a known robot (``"panda"``/``"franka"``)
+        robot: Convenience - name of a known robot (``"panda"``/``"franka"``)
             whose built-in DROID-layout action mapping is applied when
             ``action_mapping`` is not given. Explicit ``action_mapping`` wins.
         prompt: Default instruction used when ``get_actions`` is called with an
@@ -123,7 +123,7 @@ class Cosmos3Policy(Policy):
 
     Notes:
         * This policy needs camera frames **and** robot state in the
-          observation — ``requires_images`` is ``True``.
+          observation - ``requires_images`` is ``True``.
         * Latency is chunked (a diffusion policy), not 500 Hz servo. One
           inference returns a chunk of ~``action_chunk_size`` steps.
     """
@@ -212,7 +212,7 @@ class Cosmos3Policy(Policy):
 
     @property
     def requires_images(self) -> bool:
-        """Cosmos 3 conditions on camera frames — always needs images."""
+        """Cosmos 3 conditions on camera frames - always needs images."""
         return True
 
     def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
@@ -262,7 +262,7 @@ class Cosmos3Policy(Policy):
             instruction: Natural-language task instruction.
 
         Returns:
-            ``list[dict]`` — one action dict per predicted timestep.
+            ``list[dict]`` - one action dict per predicted timestep.
         """
         prompt = instruction or self.default_prompt
         obs = self._build_server_observation(observation_dict, prompt)
@@ -345,7 +345,7 @@ class Cosmos3Policy(Policy):
             if len(non_gripper) >= 8:
                 gripper = float(np.asarray(robot_obs[non_gripper[7]]).reshape(-1)[0])
 
-        # joint_pos requires BOTH joints(7) and gripper — the server applies
+        # joint_pos requires BOTH joints(7) and gripper - the server applies
         # `1 - gripper` and conditions on it. Never fabricate a silent default
         # (AGENTS.md key convention #6); surface a clear, actionable error.
         if "observation/joint_position" not in obs:

--- a/strands_robots/policies/groot/policy.py
+++ b/strands_robots/policies/groot/policy.py
@@ -553,7 +553,7 @@ class Gr00tPolicy(Policy):
         cuDNN benchmark state, etc.) can be re-initialised. Without this
         the server's RNG drifts across calls and produces different
         action chunks for byte-identical inputs across re-runs of the
-        same eval — the #187 success-rate gap.
+        same eval - the #187 success-rate gap.
 
         The standard ``gr00t.eval.run_gr00t_server`` registers a ``reset``
         endpoint that maps to ``policy.reset(options=...)`` (see
@@ -569,7 +569,7 @@ class Gr00tPolicy(Policy):
         runs in the same process as the client.
 
         Best-effort: any failure (server doesn't expose ``reset``,
-        endpoint raises, network timeout) is logged and swallowed —
+        endpoint raises, network timeout) is logged and swallowed -
         ``reset`` is a soft hint to the policy, not a hard requirement.
         Eval correctness is preserved even if reset is a no-op.
 

--- a/strands_robots/policies/lerobot_local/molmoact2.py
+++ b/strands_robots/policies/lerobot_local/molmoact2.py
@@ -26,7 +26,7 @@ API (``lerobot.policies.factory``):
 * ``make_pre_post_processors(cfg)`` dispatches to
   ``make_molmoact2_pre_post_processors(cfg)`` internally and returns the
   pre/post pipelines. The repo ships no ``policy_preprocessor.json``, so the
-  generic ``ProcessorBridge.from_pretrained`` would be a no-op passthrough —
+  generic ``ProcessorBridge.from_pretrained`` would be a no-op passthrough -
   hence we build the processors through the factory instead.
 
 We deliberately go through the factory (not the molmoact2 submodule classes
@@ -156,7 +156,7 @@ def derive_image_keys(image_keys: list[str] | None, embodiment_spec: Any | None)
     input feature to exist BEFORE instantiation. Priority:
       1. Explicit ``image_keys`` argument.
       2. The embodiment spec's ``obs_rename`` *targets* that look like image
-         features (``observation.images.*``) — keeps config aligned with what
+         features (``observation.images.*``) - keeps config aligned with what
          the embodiment will actually feed.
       3. :data:`DEFAULT_IMAGE_KEYS`.
 

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -87,7 +87,7 @@ class LerobotLocalPolicy(Policy):
         # Extra keyword args forwarded verbatim to the underlying LeRobot
         # policy's select_action()/predict_action_chunk() on every inference
         # call. Required by policies that demand a runtime mode selector with
-        # no usable default — e.g. MolmoAct2 needs
+        # no usable default - e.g. MolmoAct2 needs
         # inference_kwargs={"inference_action_mode": "continuous"|"discrete"}
         # (its select_action raises ValueError otherwise). RTC kwargs are
         # handled separately and take precedence on the RTC path.
@@ -149,7 +149,7 @@ class LerobotLocalPolicy(Policy):
         Args:
             seed: Per-episode master seed (added in #187 for the
                 ``Policy.reset(seed=...)`` contract). Currently
-                unused — LeRobot policies don't expose RNG state via a
+                unused - LeRobot policies don't expose RNG state via a
                 seed kwarg, and reproducibility is handled by
                 ``set_eval_seed`` upstream of the call. Reserved for
                 future per-policy RNG plumbing.
@@ -584,7 +584,7 @@ class LerobotLocalPolicy(Policy):
                     dim_policy="pad",
                 )
             else:
-                # No usable declarative info — keep legacy heuristic path.
+                # No usable declarative info - keep legacy heuristic path.
                 self._embodiment = None
                 return
 
@@ -815,7 +815,7 @@ class LerobotLocalPolicy(Policy):
                 # SOLUTION.md bulletproof path: the embodiment map was injected
                 # into the pipeline at load time (rename_map + strands_pack_state
                 # step), so the pipeline itself renames cameras and composes
-                # observation.state. Feed RAW obs straight in — ZERO per-step
+                # observation.state. Feed RAW obs straight in - ZERO per-step
                 # strands-side remapping, no _fixup needed (AddBatchDimension +
                 # Device steps in the pipeline handle shape/device).
                 batch = self._processor_bridge.preprocess(observation, instruction=instruction)

--- a/strands_robots/policies/lerobot_local/processor.py
+++ b/strands_robots/policies/lerobot_local/processor.py
@@ -74,7 +74,7 @@ def _register_policy_processor_steps(policy_type: str | None) -> None:
     (MolmoAct2) need their module imported explicitly.
 
     Best-effort: failures (e.g. heavy optional deps) are logged at DEBUG and the
-    caller proceeds — the pipeline load will then raise a clear error itself.
+    caller proceeds - the pipeline load will then raise a clear error itself.
     """
     if not policy_type:
         return

--- a/strands_robots/registry/__init__.py
+++ b/strands_robots/registry/__init__.py
@@ -1,4 +1,4 @@
-"""Unified Registry — single source of truth for robots and policies.
+"""Unified Registry - single source of truth for robots and policies.
 
 Loads robot definitions and policy provider configs from JSON files.
 
@@ -6,7 +6,7 @@ Features:
     - **One file to edit**: Add a robot → edit robots.json, done.
     - **Hot-reload**: JSON is re-read when the file changes (mtime check).
     - **Self-contained entries**: Each robot/policy owns its aliases,
-      shorthands, and URL patterns — no separate lookup tables.
+      shorthands, and URL patterns - no separate lookup tables.
     - **Validation**: Duplicate aliases, shorthands, and URL patterns
       are caught on load with clear error messages.
 

--- a/strands_robots/registry/policies.py
+++ b/strands_robots/registry/policies.py
@@ -1,4 +1,4 @@
-"""Policy registry — resolve, import, and configure policy providers.
+"""Policy registry - resolve, import, and configure policy providers.
 
 All provider definitions live in policies.json.  This module provides
 the public read API for resolving smart policy strings, importing provider
@@ -63,7 +63,7 @@ def resolve_policy(policy: str, **extra_kwargs) -> tuple[str, dict[str, Any]]:
         5. Fallback to lerobot_local
 
     Args:
-        policy: Smart string — HF model ID, URL, or provider name.
+        policy: Smart string - HF model ID, URL, or provider name.
         **extra_kwargs: Additional kwargs merged into result.
 
     Returns:
@@ -84,7 +84,7 @@ def resolve_policy(policy: str, **extra_kwargs) -> tuple[str, dict[str, Any]]:
     policy = policy.strip()
     kwargs: dict[str, Any] = {}
 
-    # 1. URL pattern matching — check each provider's url_patterns
+    # 1. URL pattern matching - check each provider's url_patterns
     for prov_name, prov_info in providers.items():
         for pattern in prov_info.get("url_patterns", []):
             if re.match(pattern, policy):
@@ -114,7 +114,7 @@ def resolve_policy(policy: str, **extra_kwargs) -> tuple[str, dict[str, Any]]:
                 kwargs.update(extra_kwargs)
                 return prov_name, kwargs
 
-    # 2. Shorthand names — built from each provider's shorthands list
+    # 2. Shorthand names - built from each provider's shorthands list
     alias_map = _build_alias_map()
     if policy.lower() in alias_map:
         kwargs.update(extra_kwargs)

--- a/strands_robots/registry/user_registry.py
+++ b/strands_robots/registry/user_registry.py
@@ -1,4 +1,4 @@
-"""User-local robot registry — runtime registration without editing package JSON.
+"""User-local robot registry - runtime registration without editing package JSON.
 
 Provides ``register_robot()`` and ``unregister_robot()`` for adding custom
 robots that persist across sessions via a ``user_robots.json`` file stored
@@ -13,7 +13,7 @@ Note:
     user registry. Use ``STRANDS_BASE_DIR`` to relocate user metadata.
 
 At load time the user overlay is merged *on top of* the package
-``robots.json`` — user entries win on name collision, so you can also
+``robots.json`` - user entries win on name collision, so you can also
 override built-in robots locally.
 
 Usage::
@@ -176,7 +176,7 @@ def register_robot(
 
             if _pkg_get_robot(name) is not None:
                 logger.info(
-                    "Robot '%s' exists in package registry — user registration will override it.",
+                    "Robot '%s' exists in package registry - user registration will override it.",
                     name,
                 )
         except ImportError:
@@ -189,7 +189,7 @@ def register_robot(
     # This matches how resolve_model_path works: search_dir / asset["dir"] / xml
     dir_name = resolved_dir.name
 
-    # Alias collision detection — warn (don't fail) when a user alias shadows a
+    # Alias collision detection - warn (don't fail) when a user alias shadows a
     # canonical name or another alias.  Doing this at registration surfaces the
     # problem immediately instead of at silent resolution-order time.
     if aliases and not overwrite:
@@ -218,7 +218,7 @@ def register_robot(
                 logger.warning("Alias %r is already used by another robot.", alias)
 
     # Validate model_xml exists.  Previously we only checked when
-    # ``resolved_dir`` existed — which silently accepted registrations for
+    # ``resolved_dir`` existed - which silently accepted registrations for
     # dirs that didn't exist yet and surfaced a confusing error only at
     # ``add_robot()`` time.  Now we fail-closed on both conditions so the
     # user gets an immediate, actionable error at registration time.
@@ -283,7 +283,7 @@ def unregister_robot(name: str) -> bool:
     data = _load_user_registry()
 
     if name not in data.get("robots", {}):
-        logger.info("Robot '%s' not in user registry — nothing to remove.", name)
+        logger.info("Robot '%s' not in user registry - nothing to remove.", name)
         return False
 
     del data["robots"][name]

--- a/strands_robots/robot.py
+++ b/strands_robots/robot.py
@@ -1,4 +1,4 @@
-"""Unified Robot factory — convenience layer over ``strands_robots.simulation``
+"""Unified Robot factory - convenience layer over ``strands_robots.simulation``
 and ``strands_robots.hardware_robot``.
 
 Provides:
@@ -13,7 +13,7 @@ Environment Variables:
 
 Examples::
 
-    # Default: simulation (safe — no physical hardware interaction)
+    # Default: simulation (safe - no physical hardware interaction)
     sim = Robot("so100")
 
     # Explicit real hardware
@@ -69,7 +69,7 @@ def _auto_detect_mode(canonical: str) -> str:
     Priority:
         1. ``STRANDS_ROBOT_MODE`` env var (explicit override)
         2. Robot-specific USB detection (Feetech/Dynamixel servo controllers)
-        3. Default to sim (safest — never accidentally send commands to hardware)
+        3. Default to sim (safest - never accidentally send commands to hardware)
     """
     env_mode = os.getenv("STRANDS_ROBOT_MODE", "").lower().strip()
     if env_mode in ("sim", "real"):
@@ -170,7 +170,7 @@ def Robot(
 ) -> Simulation | HardwareRobot: ...
 
 
-def Robot(  # noqa: N802 — uppercase by design (factory mimicking a class constructor)
+def Robot(  # noqa: N802 - uppercase by design (factory mimicking a class constructor)
     name: str,
     mode: str = "sim",
     backend: str = "mujoco",
@@ -182,10 +182,10 @@ def Robot(  # noqa: N802 — uppercase by design (factory mimicking a class cons
     peer_id: str | None = None,
     **kwargs: Any,
 ) -> Simulation | HardwareRobot:
-    """Create a robot — returns a Simulation or HardwareRobot instance.
+    """Create a robot - returns a Simulation or HardwareRobot instance.
 
     This is a convenience factory, NOT a wrapper class.  You get the real
-    backend instance back — with full access to all its methods.
+    backend instance back - with full access to all its methods.
 
     Defaults to simulation mode so that ``Robot("so100")`` never
     accidentally sends commands to physical hardware.  Use
@@ -194,10 +194,10 @@ def Robot(  # noqa: N802 — uppercase by design (factory mimicking a class cons
     Args:
         name: Robot name ("so100", "aloha", "unitree_g1", "panda", ...)
               Accepts any alias defined in ``registry/robots.json``.
-        mode: "sim" (default — safe), "real" (explicit hardware), or
+        mode: "sim" (default - safe), "real" (explicit hardware), or
               "auto" (probes USB for servo controllers, falls back to sim).
               Case-insensitive; surrounding whitespace ignored.
-        backend: Simulation backend — currently only "mujoco" (CPU).
+        backend: Simulation backend - currently only "mujoco" (CPU).
                  Future: "isaac" (GPU), "newton" (GPU).
                  Only applies to ``mode="sim"``; ignored for ``mode="real"``.
         urdf_path: Explicit path to URDF/MJCF file. If not provided,
@@ -230,7 +230,7 @@ def Robot(  # noqa: N802 — uppercase by design (factory mimicking a class cons
 
     Examples::
 
-        # Simulation (default — safe)
+        # Simulation (default - safe)
         sim = Robot("so100")
 
         # Explicit MJCF model path
@@ -242,7 +242,7 @@ def Robot(  # noqa: N802 — uppercase by design (factory mimicking a class cons
         # Auto-detect (probes USB, falls back to sim)
         robot = Robot("so100", mode="auto")
 
-        # The 5-line promise (defaults to sim — safe, no hardware needed)
+        # The 5-line promise (defaults to sim - safe, no hardware needed)
         from strands_robots import Robot
         from strands import Agent
         robot = Robot("so100")  # mode="sim" (default)
@@ -312,7 +312,7 @@ def Robot(  # noqa: N802 — uppercase by design (factory mimicking a class cons
             raise
 
         # Attach a Zenoh mesh so the Simulation auto-discovers other peers.
-        # Failure to start the mesh must NOT bring down the sim — the user
+        # Failure to start the mesh must NOT bring down the sim - the user
         # explicitly asked for a Simulation, mesh is an enrichment.
         try:
             from strands_robots.mesh import init_mesh
@@ -326,7 +326,7 @@ def Robot(  # noqa: N802 — uppercase by design (factory mimicking a class cons
             if sim_mesh is not None:
                 sim.mesh = sim_mesh
                 sim.peer_id = sim_mesh.peer_id
-        except Exception as exc:  # noqa: BLE001 — mesh enrichment is best-effort
+        except Exception as exc:  # noqa: BLE001 - mesh enrichment is best-effort
             logger.warning("Failed to initialise mesh for %r: %s", canonical, exc)
 
         _attach_device_connect(sim, canonical, mode, peer_id)
@@ -364,7 +364,7 @@ def Robot(  # noqa: N802 — uppercase by design (factory mimicking a class cons
             if hw_mesh is not None:
                 hw.mesh = hw_mesh
                 hw.peer_id = hw_mesh.peer_id
-        except Exception as exc:  # noqa: BLE001 — mesh enrichment is best-effort
+        except Exception as exc:  # noqa: BLE001 - mesh enrichment is best-effort
             logger.warning("Failed to initialise mesh for %r: %s", canonical, exc)
 
         _attach_device_connect(hw, canonical, mode, peer_id)
@@ -388,7 +388,7 @@ def _attach_device_connect(instance: Any, canonical: str, mode: str, peer_id: st
 
 
 def _run_device_connect_foreground(instance: Any) -> None:
-    """Start Device Connect and block — the robot listens for commands.
+    """Start Device Connect and block - the robot listens for commands.
 
     Device Connect is the primary networking layer in server mode, so the
     auto-started built-in mesh (if any) is stopped first to avoid running two
@@ -414,7 +414,7 @@ def _run_device_connect_foreground(instance: Any) -> None:
             peer_id=peer_id,
             peer_type=peer_type,
         )
-    except Exception as e:  # noqa: BLE001 — surface but keep the process alive
+    except Exception as e:  # noqa: BLE001 - surface but keep the process alive
         logger.warning("Device Connect init failed: %s", e)
 
     print(f"🤖 {peer_id} is online. Ctrl+C to stop.")

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 # to break the AST-visible cycle that static analysers flag.
 #
 # Note (#191): we deliberately do NOT import ``OnFrame`` here, even under
-# ``TYPE_CHECKING`` — CodeQL's ``py/unsafe-cyclic-import`` rule walks
+# ``TYPE_CHECKING`` - CodeQL's ``py/unsafe-cyclic-import`` rule walks
 # ``TYPE_CHECKING`` blocks too and would flag the static cycle (
 # policy_runner.py imports SimEngine from base under TYPE_CHECKING,
 # so importing OnFrame from policy_runner here closes the loop in the
@@ -251,7 +251,7 @@ class SimEngine(ABC):
 
         Contract: each call writes actuator/ctrl values and then runs
         ``n_substeps`` physics steps (e.g. mj_step). PolicyRunner.run()
-        relies on this — it calls send_action once per control step and
+        relies on this - it calls send_action once per control step and
         does NOT call sim.step() separately.
 
         Backends are responsible for internal thread-safety (e.g.
@@ -572,7 +572,7 @@ class SimEngine(ABC):
                 ``policy.get_actions(...)`` chunk before re-querying the
                 policy. Default ``8`` matches NVIDIA's upstream
                 GR00T LIBERO eval (``MultiStepWrapper`` with
-                ``n_action_steps=8``) — the policy commits to 8 actions
+                ``n_action_steps=8``) - the policy commits to 8 actions
                 before re-observing, which is what GR00T-N1.7-LIBERO
                 checkpoints were trained against. Set to ``1`` for
                 closed-loop receding-horizon control (re-observe every
@@ -586,7 +586,7 @@ class SimEngine(ABC):
                 immediately after ``sim.send_action``. Use this for
                 synchronous recording or telemetry when the eval is
                 dispatched from a thread distinct from the script main
-                (e.g. Strands ``Agent`` tool dispatch under asyncio) —
+                (e.g. Strands ``Agent`` tool dispatch under asyncio) -
                 the daemon-thread recorder
                 (:meth:`~strands_robots.simulation.mujoco.simulation.Simulation.start_cameras_recording`)
                 races ``mjData`` mutations on the eval thread under that

--- a/strands_robots/simulation/mujoco/recording.py
+++ b/strands_robots/simulation/mujoco/recording.py
@@ -98,7 +98,7 @@ class RecordingMixin:
 
         # Multi-episode append: when NOT overwriting and a dataset already
         # exists on disk, resume it (append new episodes) instead of calling
-        # create() — which hard-fails with FileExistsError (B12). resume() is
+        # create() - which hard-fails with FileExistsError (B12). resume() is
         # the only correct append path in LeRobot 0.5.2+ (the plain constructor
         # is read-only). When overwrite=True, wipe and recreate from scratch.
         resume_existing = (

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -282,7 +282,7 @@ class RenderingMixin:
                 # at a controller-defined rate (e.g. 25 substeps per
                 # policy step at 20 Hz LIBERO control / 500 Hz physics).
                 # When the controller declares ``owns_stepping = True``,
-                # skip the outer ``mj_step`` loop below — the controller
+                # skip the outer ``mj_step`` loop below - the controller
                 # has already advanced ``data.time`` by the full control
                 # timestep. Without this, we'd double-step (the outer
                 # loop would run an extra mj_step on top of the
@@ -678,7 +678,7 @@ class RenderingMixin:
                     self._depth_warn_text = (
                         "⚠️ Depth accuracy limited on this GPU (missing ARB_clip_control). "
                         "Linearized Min/Max are in meters but precision is degraded "
-                        "(especially for far-plane pixels) — treat as approximate."
+                        "(especially for far-plane pixels) - treat as approximate."
                     )
                 else:
                     self._depth_warn_text = ""
@@ -694,7 +694,7 @@ class RenderingMixin:
             #
             # On MuJoCo >= 3.0, `model.vis.map.{znear,zfar}` are fractions of
             # `model.stat.extent` (the model's bounding scale), NOT absolute
-            # meters — multiply by extent to get real clip-plane distances.
+            # meters - multiply by extent to get real clip-plane distances.
             # pyproject.toml pins mujoco>=3.2, so this convention is safe here.
             import numpy as _np
 
@@ -973,7 +973,7 @@ class RenderingMixin:
 
         names, unresolved = self._active_camera_list(cameras)
         # Strict validation: if user specified cameras, error on any unresolved names
-        # (same policy as render() and render_depth() — fail loudly, don't silently drop).
+        # (same policy as render() and render_depth() - fail loudly, don't silently drop).
         # NOTE: `unresolved` contains the raw user inputs that didn't map, so the
         # namespace-suffix resolution path (e.g. 'side' → 'arm0/side') is preserved.
         if cameras is not None and unresolved:
@@ -993,7 +993,7 @@ class RenderingMixin:
 
         # ``ready`` is set by the recorder thread once its GL context is warm
         # and it has entered the capture loop. ``start`` blocks on it below so
-        # that "start returned success" guarantees frames are being captured —
+        # that "start returned success" guarantees frames are being captured -
         # callers that stop after a short sleep (e.g. tests, brief clips) no
         # longer race the ~0.5s fresh-thread EGL warmup and get an empty buffer.
         state = {
@@ -1101,7 +1101,7 @@ class RenderingMixin:
                     cold,
                 )
 
-            # Warmup done (or capped) — capture loop is about to run. Unblock
+            # Warmup done (or capped) - capture loop is about to run. Unblock
             # the caller waiting in start_cameras_recording so the success
             # return coincides with the first captured frame, not the cold
             # thread launch.
@@ -1137,7 +1137,7 @@ class RenderingMixin:
         # capture loop before reporting success. Worst case is the 30-attempt
         # warmup cap (~1s/cam at 64x48, more for larger frames) plus a small
         # margin; the common case is ~0.5s. If warmup somehow stalls we still
-        # return after the timeout rather than blocking forever — the thread
+        # return after the timeout rather than blocking forever - the thread
         # keeps trying and ``get_cameras_recording_status`` exposes errors.
         _ready_timeout = 5.0 + 1.0 * len(names)
         if not state["ready"].wait(timeout=_ready_timeout):
@@ -1192,7 +1192,7 @@ class RenderingMixin:
         Shared by :meth:`stop_cameras_recording` (daemon-thread path) and
         the ``finalize`` callable returned by
         :meth:`start_cameras_recording_synchronous`. ``state`` is mutated
-        in place — ``running`` should already be ``False`` before this
+        in place - ``running`` should already be ``False`` before this
         runs, and the daemon thread (if any) already joined.
 
         Best-effort: per-camera flush failures are reported in the result
@@ -1271,7 +1271,7 @@ class RenderingMixin:
         daemon thread. The eval driver wires ``on_frame`` into
         :meth:`~strands_robots.simulation.SimEngine.evaluate_benchmark`'s
         new ``on_frame=`` kwarg (#191), and rendering happens on the eval
-        thread — eliminating the cross-thread ``mjData`` race the daemon
+        thread - eliminating the cross-thread ``mjData`` race the daemon
         recorder hits under multi-threaded eval (Strands ``Agent`` tool
         dispatch under asyncio, where the eval runs on a worker thread
         distinct from the script main).
@@ -1415,7 +1415,7 @@ class RenderingMixin:
             Returns the same standard result dict as
             :meth:`stop_cameras_recording` so callers can log artifacts
             uniformly. Calling ``finalize()`` after the first call is a
-            no-op success ("Was not recording cameras.") — matching the
+            no-op success ("Was not recording cameras.") - matching the
             ``stop_cameras_recording`` idempotency contract.
             """
             current = getattr(self, "_cams_rec_state", None)

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -174,13 +174,13 @@ class MuJoCoSimEngine(
         self._policy_threads: dict[str, Future] = {}
         self._shutdown_event = threading.Event()
         # ``self._lock`` (RLock) serializes ALL access to MuJoCo
-        # ``model``/``data`` arrays — both reads and writes. MuJoCo arrays
+        # ``model``/``data`` arrays - both reads and writes. MuJoCo arrays
         # are NOT safe for concurrent reads during mutation (a racing
         # mj_step can produce torn/stale values). The lock is acquired:
         #
-        #   * In ``_dispatch_action`` — so every agent-dispatched action
+        #   * In ``_dispatch_action`` - so every agent-dispatched action
         #     (all 37 handlers) is automatically serialized.
-        #   * In ``send_action`` / ``get_observation`` — so the
+        #   * In ``send_action`` / ``get_observation`` - so the
         #     PolicyRunner worker thread is also serialized against the
         #     agent's dispatch thread.
         #   * RLock allows nested acquisition (methods that also acquire
@@ -201,7 +201,7 @@ class MuJoCoSimEngine(
         self._mj = _ensure_mujoco()
         logger.info("MuJoCo simulation tool '%s' initialized", tool_name)
 
-    # Public Properties — read-only introspection.
+    # Public Properties - read-only introspection.
     # WARNING: callers MUST NOT mutate the returned objects without holding
     # self._lock. Prefer using action methods which serialize automatically.
 
@@ -663,7 +663,7 @@ class MuJoCoSimEngine(
 
         When the parent ``Simulation`` is on a Zenoh mesh (``self.mesh`` set
         and ``self.peer_id`` populated), every robot added via ``add_robot``
-        becomes addressable on the mesh in its own right — the agent can
+        becomes addressable on the mesh in its own right - the agent can
         ``robot_mesh tell target=<robot.peer_id>`` instead of having to ask
         the sim container to route by ``robot_name``.
 
@@ -678,7 +678,7 @@ class MuJoCoSimEngine(
         ``remove_robot`` / ``cleanup`` can tear it down later.
         """
         if not self.mesh:
-            # Sim itself isn't on a mesh — nothing to attach to. Stays a
+            # Sim itself isn't on a mesh - nothing to attach to. Stays a
             # no-op so unit tests that construct a bare ``Simulation``
             # without zenoh keep working.
             return
@@ -710,9 +710,9 @@ class MuJoCoSimEngine(
                 # Bridge: give the SimRobot a _world reference so the child
                 # Mesh's _read_state() can extract per-robot joint positions
                 # from the MuJoCo world data (without this, the child mesh
-                # publishes only presence heartbeats — no state topic).
+                # publishes only presence heartbeats - no state topic).
                 robot._world = self._world
-        except Exception as exc:  # noqa: BLE001 — mesh enrichment is best-effort
+        except Exception as exc:  # noqa: BLE001 - mesh enrichment is best-effort
             logger.warning(
                 "Failed to attach robot %r to mesh (sim peer_id=%s): %s",
                 robot.name,
@@ -1448,7 +1448,7 @@ class MuJoCoSimEngine(
         """Destroy the world and release all resources.
 
         Delegates to cleanup() which properly joins running policy Futures
-        before nulling self._world — prevents SIGSEGV from workers holding
+        before nulling self._world - prevents SIGSEGV from workers holding
         stale model/data pointers.
         """
         if self._world is None:
@@ -1944,7 +1944,7 @@ class MuJoCoSimEngine(
         # Concurrent multi-robot policies run on disjoint ctrl slices (physics
         # serialized by _lock). For SYNCHRONIZED multi-robot *recording* (both
         # robots captured in one merged frame per step), use run_multi_policy
-        # instead — independent start_policy threads each step physics and write
+        # instead - independent start_policy threads each step physics and write
         # frames separately, which is correct for live control but interleaves
         # for a shared recorder. start_policy while recording is left to the
         # caller's intent (run_multi_policy is the recommended recording path).
@@ -2024,7 +2024,7 @@ class MuJoCoSimEngine(
                         # keys, finds nothing, and writes all-zero state/action
                         # vectors silently. Prefix scalar obs + action keys to match
                         # the schema. Camera values (ndarray) keep their (already
-                        # namespaced) names — dataset_recorder normalizes '/'→'__'.
+                        # namespaced) names - dataset_recorder normalizes '/'→'__'.
                         if len(world.robots) > 1:
                             obs_keyed = {
                                 (k if isinstance(v, np.ndarray) else f"{robot_name}__{k}"): v
@@ -2109,9 +2109,9 @@ class MuJoCoSimEngine(
 
         This is the correct path for concurrent multi-robot data collection
         (e.g. two SO-100 arms doing a handover, or a bimanual setup). Unlike
-        launching two independent ``start_policy`` threads — which each step
+        launching two independent ``start_policy`` threads - which each step
         physics and call ``add_frame`` separately, so the shared recorder
-        receives interleaved single-robot frames (B4) — this loop:
+        receives interleaved single-robot frames (B4) - this loop:
 
         1. Observes every robot (joints) and renders all cameras ONCE.
         2. Queries each robot's policy for its action.
@@ -2119,7 +2119,7 @@ class MuJoCoSimEngine(
         4. Records ONE frame containing ALL robots' prefixed state/action
            (``alice__shoulder_pan`` …) plus all camera images.
 
-        So a 2-robot dataset has both arms co-observed in every frame — usable
+        So a 2-robot dataset has both arms co-observed in every frame - usable
         for bimanual / multi-agent policy training.
 
         Args:
@@ -2136,7 +2136,7 @@ class MuJoCoSimEngine(
                 execution, mirrors ``run_policy``). Either a single int applied
                 to all robots, or a ``{robot_name: horizon}`` mapping for
                 per-robot control. A robot's policy is only re-queried when its
-                action queue drains — so an expensive VLA emitting a 30-action
+                action queue drains - so an expensive VLA emitting a 30-action
                 chunk with ``action_horizon=30`` runs inference ~once per 30
                 steps instead of every step. Physics still advances ONE step per
                 loop iteration, keeping all robots phase-aligned regardless of
@@ -2226,7 +2226,7 @@ class MuJoCoSimEngine(
         recording = bool(self._world._backend_state.get("recording", False)) and recorder is not None
 
         # Whether ANY policy needs images (renders are expensive; skip if none
-        # need them AND we're not recording — recording always needs frames).
+        # need them AND we're not recording - recording always needs frames).
         any_needs_images = any(getattr(p, "requires_images", True) for p in policies.values())
         skip_images = not (any_needs_images or recording)
 
@@ -2276,7 +2276,7 @@ class MuJoCoSimEngine(
                 # --- 2. Get each robot's action for THIS step.
                 # Re-query a policy ONLY when its action queue is empty (open-loop
                 # chunk execution). Between re-queries we replay the buffered
-                # chunk — so an expensive VLA runs inference once per horizon
+                # chunk - so an expensive VLA runs inference once per horizon
                 # steps, not every step. Observation is still gathered every step
                 # (cheap) so recorded frames carry live state, and the chunk's
                 # first action is computed from a fresh observation.
@@ -2311,7 +2311,7 @@ class MuJoCoSimEngine(
                 with self._lock:
                     mj = self._mj
                     for rname, act in per_robot_action.items():
-                        # write ctrl only (no per-robot mj_step) — we step once
+                        # write ctrl only (no per-robot mj_step) - we step once
                         # after every robot's ctrl is set.
                         robot = self._world.robots[rname]
                         pfx = robot.namespace or ""
@@ -2663,7 +2663,7 @@ class MuJoCoSimEngine(
         # PR #101 follow-up: each robot added via ``add_robot`` may have
         # its own per-peer mesh (see ``_attach_robot_to_mesh``). Stop those
         # FIRST so external peers see them leave before the sim container
-        # itself goes down — leaving the inverse order ("sim drops, robots
+        # itself goes down - leaving the inverse order ("sim drops, robots
         # linger") would create zombie peer entries in remote ``get_peers``
         # results until their heartbeats expire.
         if self._world is not None:

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -62,9 +62,9 @@ def set_eval_seed(seed: int) -> None:
     minus two global side effects that would persist after the eval and
     affect unrelated callers in the same process:
 
-    * ``os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"`` — leaks into
+    * ``os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"`` - leaks into
       every subsequent torch op in the process.
-    * ``torch.use_deterministic_algorithms(True, warn_only=True)`` —
+    * ``torch.use_deterministic_algorithms(True, warn_only=True)`` -
       can break callers downstream that rely on non-deterministic CUDA
       kernels (e.g. some loss functions).
 
@@ -79,10 +79,10 @@ def set_eval_seed(seed: int) -> None:
     * Python ``random.seed``.
     * NumPy ``np.random.seed`` (the legacy global RNG; matches what
       most policies use under the hood).
-    * PyTorch CPU (``torch.manual_seed``) — if torch is importable.
-    * PyTorch CUDA all devices (``torch.cuda.manual_seed_all``) — if
+    * PyTorch CPU (``torch.manual_seed``) - if torch is importable.
+    * PyTorch CUDA all devices (``torch.cuda.manual_seed_all``) - if
       torch is importable AND CUDA is available.
-    * cuDNN ``deterministic=True`` / ``benchmark=False`` — if torch
+    * cuDNN ``deterministic=True`` / ``benchmark=False`` - if torch
       is importable. These are the standard reproducibility knobs and
       are scoped to torch (not the broader environment) so the side
       effect surface is acceptable.
@@ -254,12 +254,12 @@ class PolicyRunner:
         """Physics steps per applied action so a position-servo arm tracks the
         full control period (1/control_frequency), not a single physics dt.
 
-        Identical derivation to :meth:`run` — extracted so the eval paths
+        Identical derivation to :meth:`run` - extracted so the eval paths
         (:meth:`evaluate` / :meth:`_evaluate_with_spec`) step physics for the
         SAME wall-clock period per action. Without this, eval called
         ``send_action`` with the default ``n_substeps=1`` (a single ~2 ms
         ``mj_step``), so the arm integrated ~10% of the way toward each target
-        before the next action overwrote ``ctrl`` — rollouts looked like the
+        before the next action overwrote ``ctrl`` - rollouts looked like the
         policy was a no-op even when commanding valid targets.
         """
         if override is not None:
@@ -394,7 +394,7 @@ class PolicyRunner:
             # each action so the joints actually track the commanded target
             # before the next action overwrites ``ctrl``. With the default
             # 1 substep/action, the arm only integrates one physics dt (~2 ms)
-            # per action and barely moves — the policy looks like a no-op even
+            # per action and barely moves - the policy looks like a no-op even
             # though it is sending valid targets. Derive substeps from the
             # backend's physics timestep; fall back to 1 when unknown.
             if control_substeps is not None:
@@ -682,7 +682,7 @@ class PolicyRunner:
                 expose telemetry hooks). Use this for synchronous
                 recording when the eval runs on a thread distinct from
                 the script main (e.g. Strands ``Agent`` tool dispatch
-                under asyncio) — see #191 and
+                under asyncio) - see #191 and
                 :meth:`~strands_robots.simulation.mujoco.simulation.Simulation.start_cameras_recording_synchronous`.
 
         Returns:
@@ -840,14 +840,14 @@ class PolicyRunner:
         max_steps = spec.max_steps
         results: list[dict[str, Any]] = []
 
-        # #191 — global step counter passed to ``on_frame``. Crosses
+        # #191 - global step counter passed to ``on_frame``. Crosses
         # episode boundaries so consumers that don't track ep ↔ step
         # mappings still get a monotonic index. Callers that need
         # per-episode buckets can read ``info["steps"]`` from the
         # returned per-episode results.
         global_step = 0
 
-        # #187 — fall back to ``spec.instruction`` (default ``""``) when
+        # #187 - fall back to ``spec.instruction`` (default ``""``) when
         # the user didn't pass an explicit instruction. Language-
         # conditioned policies (GR00T, OpenVLA) need the task description
         # or they produce off-task actions; LIBERO/Meta-World/etc. ship
@@ -877,7 +877,7 @@ class PolicyRunner:
             episode_seed = master_rng.randint(0, 2**31 - 1)
             episode_rng = random.Random(episode_seed)
 
-            # #179 — re-seed Python / NumPy / torch / cuDNN at the start
+            # #179 - re-seed Python / NumPy / torch / cuDNN at the start
             # of EACH episode (not just once before the loop). Without
             # the per-episode reseed, every torch op draws from a global
             # RNG state that mutates across episodes, so the diffusion
@@ -892,7 +892,7 @@ class PolicyRunner:
             # (same successes list every run).
             set_eval_seed(episode_seed)
 
-            # #187 — for SERVICE-mode policies (e.g. Gr00tPolicy over
+            # #187 - for SERVICE-mode policies (e.g. Gr00tPolicy over
             # ZMQ), set_eval_seed only seeds the client process. The
             # remote inference server has its own torch/CUDA RNG that
             # drifts across calls. Forward the per-episode seed via
@@ -962,7 +962,7 @@ class PolicyRunner:
                 # #168: consume up to ``action_horizon`` actions
                 # per inference. Default ``action_horizon=8`` matches NVIDIA's
                 # upstream GR00T LIBERO eval (``MultiStepWrapper`` with
-                # ``n_action_steps=8``) — the GR00T-N1.7-LIBERO checkpoints
+                # ``n_action_steps=8``) - the GR00T-N1.7-LIBERO checkpoints
                 # were trained against an 8-step open-loop chunk replay.
                 # The earlier ``=1`` default (closed-loop OpenVLA
                 # convention) put eval out-of-distribution from training
@@ -982,7 +982,7 @@ class PolicyRunner:
                             break
                         action_applied = dict(action_in_chunk)
                         self.sim.send_action(action_applied, robot_name=robot_name, n_substeps=n_substeps)
-                        # #191 — synchronous on_frame hook fires on the
+                        # #191 - synchronous on_frame hook fires on the
                         # eval thread, after send_action + before
                         # on_step's reward bookkeeping. Use this for
                         # synchronous frame recording when the eval is

--- a/strands_robots/simulation/predicates.py
+++ b/strands_robots/simulation/predicates.py
@@ -90,7 +90,7 @@ def _body_position(sim: SimEngine, body: str) -> list[float] | None:
     ``env.objects_dict[name].root_body`` (see
     ``libero/libero/envs/bddl_base_domain.py``). We mirror that with a
     bounded fallback: try the bare name first, then ``<name>_main`` if
-    the bare lookup fails. #176 (sub-task 3d) — without this
+    the bare lookup fails. #176 (sub-task 3d) - without this
     fallback, BDDL goal predicates like ``(On porcelain_mug_1
     plate_1)`` resolve to ``None`` (body not found) → predicate
     silently False even when the mug is physically on the plate.
@@ -364,7 +364,7 @@ def _body_on(
 
     True when ``A.z > B.z + z_offset`` AND horizontal distance ``|A.xy - B.xy|
     < xy_tol``. When ``require_contact=True``, ALSO requires physics
-    contact between A and B via ``sim.get_contacts()`` — matches
+    contact between A and B via ``sim.get_contacts()`` - matches
     upstream LIBERO's ``ObjectState.check_ontop`` which combines a
     geometric check with ``check_contact``. The z-offset parameter
     accounts for B's half-height + a small buffer; tune per scene.
@@ -375,7 +375,7 @@ def _body_on(
     ``require_contact=True`` but the sim engine doesn't expose
     ``get_contacts`` (e.g. test stubs, custom engines), the contact
     check is skipped and only the geometric check fires. This
-    preserves backwards compatibility — engines without contact
+    preserves backwards compatibility - engines without contact
     support get the pre-#171 behaviour. LIBERO benchmarks running on
     ``MuJoCoSimEngine`` (which implements ``get_contacts``) get the
     strict upstream-matching semantics.

--- a/strands_robots/tools/gr00t_inference.py
+++ b/strands_robots/tools/gr00t_inference.py
@@ -965,7 +965,7 @@ def _build_inference_command(
     """
     if protocol == "n1.7":
         # The N1.7 entrypoint (``python -m gr00t.eval.run_gr00t_server``)
-        # does NOT accept a ``--server`` flag — passing it makes ``tyro``
+        # does NOT accept a ``--server`` flag - passing it makes ``tyro``
         # reject the invocation with ``Unrecognized options: --server``
         # and the inference process exits before binding the port. The
         # legacy N1.5/N1.6 ``inference_service.py`` did take ``--server``;

--- a/strands_robots/tools/robot_mesh.py
+++ b/strands_robots/tools/robot_mesh.py
@@ -251,7 +251,7 @@ def _ke_matches(pattern: str, target: str) -> bool:
     if leading_dstar and trailing_dstar:
         middle = pattern[3:-3]  # strip "**/" and "/**"
         if not middle:
-            # pattern was "**/**" — match anything non-empty
+            # pattern was "**/**" - match anything non-empty
             return bool(target)
         # match if target == middle, target ends with /middle, target starts
         # with middle/, or target contains /middle/
@@ -266,7 +266,7 @@ def _ke_matches(pattern: str, target: str) -> bool:
         suffix = pattern[3:]  # strip leading "**/"
         # match suffix exactly (zero leading segments) OR any path ending
         # in /suffix (one or more leading segments). Suffix may itself
-        # contain segment-level wildcards — keep it simple: literal compare.
+        # contain segment-level wildcards - keep it simple: literal compare.
         return target == suffix or target.endswith("/" + suffix)
 
     if trailing_dstar:
@@ -300,7 +300,7 @@ def _interrupt_approves(response: object) -> bool:
 
     The interrupt mechanism returns whatever the operator submitted, which
     is normally a string but the contract is "JSON-serialisable any". We
-    accept the canonical short forms only — defence in depth against
+    accept the canonical short forms only - defence in depth against
     accidental approval from a typo.
     """
     if not isinstance(response, str):
@@ -317,7 +317,7 @@ def _rate_limit_check(action: str) -> str | None:
     that do not require approval).
 
     Splitting check from record means a *declined* HITL approval no
-    longer consumes a slot — without the split, three nuisance LLM
+    longer consumes a slot - without the split, three nuisance LLM
     prompts that an operator declined within a minute would lock the
     agent out of issuing a real ``emergency_stop``. That's the
     opposite of the intended safety property: the rate limit exists
@@ -408,7 +408,7 @@ def _audit_tool_action(action: str, target: str, success: bool, detail: str) -> 
     """Best-effort audit log of every safety-significant tool call.
 
     R7-5: a swallowed exception with no log line means a broken audit
-    path silently disappears. Match the ``core.py:_on_cmd`` pattern —
+    path silently disappears. Match the ``core.py:_on_cmd`` pattern -
     log at DEBUG so operators investigating "why don't I see my LLM
     tool actions in the audit log?" get a breadcrumb without flooding
     production. Audit failures must NEVER propagate up into the safety
@@ -429,7 +429,7 @@ def _audit_tool_action(action: str, target: str, success: bool, detail: str) -> 
                 "detail": detail[:500],
             },
         )
-    except Exception as audit_exc:  # noqa: BLE001 — see docstring
+    except Exception as audit_exc:  # noqa: BLE001 - see docstring
         logger.debug("[robot_mesh] audit log unavailable: %s", audit_exc)
 
 
@@ -452,7 +452,7 @@ def _resolve_mesh(target: str) -> Any | None:
     *different* local mesh as the gateway. Using the target as its own
     gateway triggers ``_on_cmd``'s self-loop drop (``sender_id == peer_id``)
     and the call silently times out. When the target IS the only local mesh,
-    we still return it — the caller will get a timeout, which is the
+    we still return it - the caller will get a timeout, which is the
     expected behaviour for "send to yourself".
     """
     from strands_robots.mesh import get_local_robots
@@ -466,7 +466,7 @@ def _resolve_mesh(target: str) -> Any | None:
         for pid, m in locals_.items():
             if pid != target:
                 return m
-    # Either no target was specified or every local mesh IS the target —
+    # Either no target was specified or every local mesh IS the target -
     # fall back to "any one" (matching the original behaviour for the
     # single-mesh case).
     return next(iter(locals_.values()))
@@ -486,14 +486,14 @@ def _agent_identity() -> str:
     """Return this agent's caller identity for Device Connect RPCs.
 
     Sourced from ``STRANDS_ROBOT_MESH_AGENT_ID`` (falling back to the generic
-    ``DEVICE_CONNECT_CLIENT_ID``). Empty string when unset — in which case the
+    ``DEVICE_CONNECT_CLIENT_ID``). Empty string when unset - in which case the
     agent is an anonymous caller and a device with ``DEVICE_CONNECT_RPC_ALLOW``
     set will (correctly) reject it.
 
     SECURITY: this identity is *self-asserted*. It lets an operator who has
     locked a device's RPC allowlist authorize this agent by id, but it is only
     a trustworthy control when the transport authenticates the sender (mTLS).
-    On an insecure/trusted-LAN D2D link it is advisory — any peer can claim any
+    On an insecure/trusted-LAN D2D link it is advisory - any peer can claim any
     id, so do not rely on it as the sole authorization boundary there.
     """
     return os.environ.get("STRANDS_ROBOT_MESH_AGENT_ID") or os.environ.get("DEVICE_CONNECT_CLIENT_ID") or ""
@@ -536,7 +536,7 @@ def _dc_ensure_connected() -> None:
     # the operator. If they have opted in, surface a warning so it is visible.
     if os.environ.get("DEVICE_CONNECT_ALLOW_INSECURE", "").lower() in ("true", "1", "yes"):
         logger.warning(
-            "DEVICE_CONNECT_ALLOW_INSECURE is enabled — agent-side Device "
+            "DEVICE_CONNECT_ALLOW_INSECURE is enabled - agent-side Device "
             "Connect traffic is unencrypted and unauthenticated. Use only on "
             "a trusted, isolated network."
         )
@@ -563,12 +563,12 @@ def _try_device_connect(
 ) -> dict[str, Any] | None:
     """Dispatch *action* through Device Connect, or return None to fall back.
 
-    Returns None — signalling robot_mesh() to use the built-in mesh — when
+    Returns None - signalling robot_mesh() to use the built-in mesh - when
     Device Connect is unavailable, has discovered no devices, or the action is
     one DC does not handle (subscribe / watch / inbox / unsubscribe).
     """
     if action in ("subscribe", "watch", "inbox", "unsubscribe"):
-        return None  # mesh-only actions — let the built-in mesh handle them
+        return None  # mesh-only actions - let the built-in mesh handle them
     if os.environ.get("STRANDS_ROBOT_MESH_DC", "on").strip().lower() in ("off", "0", "false", "no"):
         return None  # Device Connect dispatch disabled (e.g. hermetic unit tests)
     try:
@@ -577,7 +577,7 @@ def _try_device_connect(
 
         conn = get_connection()
         devices = conn.list_devices()
-    except Exception as exc:  # noqa: BLE001 — DC is optional; fall back to mesh
+    except Exception as exc:  # noqa: BLE001 - DC is optional; fall back to mesh
         logger.debug("Device Connect unavailable, using mesh fallback: %s", exc)
         return None
     # A well-formed connection returns a list of device dicts. Anything else
@@ -632,7 +632,7 @@ def _device_connect_dispatch(
                 icon = {"strands_robot": "robot", "strands_sim": "sim", "reachy_mini": "reachy"}.get(dtype, dtype)
                 status = d.get("status", {})
                 avail = status.get("availability", "?") if isinstance(status, dict) else "?"
-                text += f"  [{icon}] {d['device_id']} — {avail}\n"
+                text += f"  [{icon}] {d['device_id']} - {avail}\n"
                 if action == "peers":
                     funcs = d.get("functions", [])
                     if funcs:
@@ -725,14 +725,14 @@ def _device_connect_dispatch(
                 try:
                     conn.invoke(d["device_id"], "stop", _with_identity({}), timeout=3.0)
                     stopped += 1
-                except Exception:  # noqa: BLE001 — best-effort fan-out
+                except Exception:  # noqa: BLE001 - best-effort fan-out
                     pass
             _audit_tool_action(action, "*", True, f"stopped={stopped}/{len(devices)}")
             return _DCResult(_ok(f"E-STOP: {stopped}/{len(devices)} devices stopped"))
 
         if action == "broadcast":
             # Security hardening: dispatch the *validated* command that the
-            # operator approved at the HITL gate — never re-parse the raw
+            # operator approved at the HITL gate - never re-parse the raw
             # caller-supplied string here (that would allow a payload whose
             # validated form differs from what actually executes).
             if validated_command is None:
@@ -750,7 +750,7 @@ def _device_connect_dispatch(
 
         # subscribe / watch / inbox / unsubscribe → handled by the mesh path
         return None
-    except Exception as exc:  # noqa: BLE001 — never raise out of the dispatcher
+    except Exception as exc:  # noqa: BLE001 - never raise out of the dispatcher
         logger.debug("Device Connect dispatch error for %s: %s", action, exc)
         return _DCResult(_err(f"[{action}] Device Connect error: {exc}"))
 
@@ -839,7 +839,7 @@ def robot_mesh(
     if not interrupt_actions and os.getenv("STRANDS_MESH_HITL_ACTIONS", "").strip().lower() == "none":
         _warn_none_opt_out_once()
 
-    # Check the per-action rate limit before doing any work — but
+    # Check the per-action rate limit before doing any work - but
     # do NOT consume a slot until we know the action is going to run.
     # See _rate_limit_check / _rate_limit_record for rationale.
     rl_err = _rate_limit_check(action)
@@ -953,7 +953,7 @@ def robot_mesh(
             )
         except RuntimeError as exc:
             # ToolContext.interrupt raises RuntimeError when no agent
-            # instance is attached — i.e. the tool is being invoked
+            # instance is attached - i.e. the tool is being invoked
             # outside a Strands agent loop (a direct
             # ``agent.tool.robot_mesh(...)`` call, a unit test that did
             # not wire up the SDK, etc.). In those contexts there is no
@@ -961,7 +961,7 @@ def robot_mesh(
             #
             # NB: the SDK's ``InterruptException`` MUST propagate up to
             # pause the agent loop, so we deliberately do NOT catch
-            # ``Exception`` here — that would swallow the normal
+            # ``Exception`` here - that would swallow the normal
             # interrupt-pause flow and turn every approval into an
             # immediate "interrupt unavailable" error.
             _audit_tool_action(action, target, False, f"interrupt unavailable: {exc}")
@@ -970,7 +970,7 @@ def robot_mesh(
             )
 
         if not _interrupt_approves(response):
-            # Declined approval does NOT consume a rate-limit slot —
+            # Declined approval does NOT consume a rate-limit slot -
             # see _rate_limit_check docstring for the safety rationale.
             #
             # #322: the operator's literal interrupt response is recorded in
@@ -992,7 +992,7 @@ def robot_mesh(
             return _err(rl_race_err)
         _audit_tool_action(action, target, True, f"operator approved: {response!r}")
     else:
-        # No interrupt required for this action — consume the slot
+        # No interrupt required for this action - consume the slot
         # unconditionally (matches the pre-split behaviour for
         # non-fleet-wide actions like ``tell``, ``send``, ``stop``).
         _rate_limit_record(action)
@@ -1193,7 +1193,7 @@ def robot_mesh(
         # allowlist. If an operator extended the allowlist with a wildcard
         # pattern (e.g. ``strands/*/stream`` per the README example), then
         # ``target="*"`` / ``target="**"`` would pass the allowlist match by
-        # equality / trailing-`/**` and reach ``mesh.on_stream("*")`` —
+        # equality / trailing-`/**` and reach ``mesh.on_stream("*")`` -
         # subscribing to every peer's stream (the cross-peer telemetry-leak
         # this surface exists to close). Require a literal peer id BEFORE
         # interpolating, mirroring the ``_REPO_TAG_RE`` shape-validation

--- a/tests/benchmarks/libero/test_bddl_parser.py
+++ b/tests/benchmarks/libero/test_bddl_parser.py
@@ -298,16 +298,16 @@ class TestCompileGoal:
 
     def test_on_libero_tight_thresholds_real_success_state(self):
         """#170: The ``on`` predicate must accept LIBERO's actual at-success
-        geometry — empirically, mug.z is only ~4 mm above plate.z and
+        geometry - empirically, mug.z is only ~4 mm above plate.z and
         mug.xy is ~1 cm off plate.xy at the moment ``env.check_success()``
         returns True on ``libero-10/SCENE5``.
 
         Pre-#170 ``_on_kwargs`` left ``z_offset=0.02`` and ``xy_tol=0.15``
         as the ``_body_on`` defaults. Those tolerances are too LOOSE on
-        xy (15 cm — over-permissive) but too TIGHT on z (2 cm — rejects
+        xy (15 cm - over-permissive) but too TIGHT on z (2 cm - rejects
         a 4 mm gap). At the actual success state, ``z_offset=0.02``
         rejected the predicate as False even though ``env.check_success``
-        was True — the silent counter bug PR #168 round 44 found.
+        was True - the silent counter bug PR #168 round 44 found.
 
         #170 changes ``_on_kwargs`` to pass ``z_offset=0.0,
         xy_tol=0.03`` matching upstream LIBERO's ``ObjectState.check_ontop``
@@ -355,12 +355,12 @@ class TestCompileGoal:
             }
         )
         assert fn(off_to_side) is False, (
-            "5 cm off-center is outside the 3 cm xy tolerance — must reject. "
+            "5 cm off-center is outside the 3 cm xy tolerance - must reject. "
             "If this passes, _on_kwargs may have regressed to the pre-#170 "
             "loose 15 cm xy_tol."
         )
 
-        # Cube 2 cm to the side — should pass (within 3 cm).
+        # Cube 2 cm to the side - should pass (within 3 cm).
         slightly_off = _BodyStateSim(
             {
                 "cube_1": {"position": [0.02, 0.0, 0.10]},
@@ -371,7 +371,7 @@ class TestCompileGoal:
 
     def test_on_libero_z_above_required(self):
         """#170: ``on(A, B)`` requires A.z >= B.z (mug above or at plate
-        level). Pin the directional contract — a body BELOW the
+        level). Pin the directional contract - a body BELOW the
         reference body is not "on" it regardless of xy alignment."""
         text = "(define (problem p) (:goal (on cube_1 plate_1)))"
         problem = parse_bddl(text)
@@ -421,7 +421,7 @@ class TestCompileGoal:
         fn = compile_goal(problem.goal)  # type: ignore[arg-type]
 
         # Geometry passes (cube above plate, xy aligned within 3cm).
-        # But contacts list is EMPTY — engine reports no contact.
+        # But contacts list is EMPTY - engine reports no contact.
         no_contact = _CombinedSim(
             bodies={
                 "cube_1": {"position": [0.0, 0.0, 0.443]},
@@ -447,7 +447,7 @@ class TestCompileGoal:
 
     def test_on_libero_contact_check_matches_either_direction(self):
         """#171 sub-task 3e: contact records may list (cube_geom,
-        plate_geom) or (plate_geom, cube_geom) — both must match the
+        plate_geom) or (plate_geom, cube_geom) - both must match the
         same predicate. Pin the order-insensitivity so a robosuite
         contact-record convention change doesn't silently break us.
         """
@@ -476,7 +476,7 @@ class TestCompileGoal:
         """#171 sub-task 3e: when the sim engine doesn't expose
         ``get_contacts`` (e.g. a custom backend, test stub), the
         contact check is SKIPPED rather than failing. The geometric
-        check alone determines the verdict — preserves pre-#171
+        check alone determines the verdict - preserves pre-#171
         behaviour for engines without contact support.
 
         Without this graceful degradation, every non-mujoco backend

--- a/tests/benchmarks/libero/test_libero_adapter.py
+++ b/tests/benchmarks/libero/test_libero_adapter.py
@@ -669,7 +669,7 @@ class TestPublishCameraDimsToWorld:
         from strands_robots.simulation.models import SimCamera
 
         sim = FakeSim(data_config="panda")
-        # world.cameras starts empty — model-side rename hasn't put
+        # world.cameras starts empty - model-side rename hasn't put
         # anything in the registry yet.
         assert "image" not in sim._world.cameras
 
@@ -689,7 +689,7 @@ class TestPublishCameraDimsToWorld:
         """Round 40 (#168): when ``world.cameras[cam_name]`` is already
         populated (e.g. from a prior episode's publish call, or from
         the user's explicit ``add_camera``), the publish must NOT
-        overwrite it — preserves user-configured pose / FOV /
+        overwrite it - preserves user-configured pose / FOV /
         custom-dim overrides across episodes."""
         from strands_robots.simulation.models import SimCamera
 
@@ -739,7 +739,7 @@ class TestPublishCameraDimsToWorld:
 
         Pre-populate ``world.cameras["image"]`` AS A NON-SIMCAMERA
         VALUE (mimicking the FakeSim's ``add_camera`` adding a raw
-        dict — though real LIBERO would have a model-side rename
+        dict - though real LIBERO would have a model-side rename
         producing nothing in the registry initially). The publish
         path then fires from the skip branch and replaces nothing
         (idempotent), but for ``wrist_image`` (not pre-populated),
@@ -758,7 +758,7 @@ class TestPublishCameraDimsToWorld:
         adapter = LiberoAdapter.from_text(PICK_CUBE_BDDL, init_jitter=0.0)
         adapter.on_episode_start(sim, random.Random(0))
 
-        # 'image' already there — must NOT have been re-added.
+        # 'image' already there - must NOT have been re-added.
         added_names = {name for name, _ in sim._add_camera_calls}
         assert "image" not in added_names
         # The pre-existing 'image' entry stays untouched (idempotent).
@@ -1159,7 +1159,7 @@ class TestAugmentObservation:
         assert adapter.eef_state_site_name == "custom_grip_grip_site"
 
     def test_read_eef_pose_uses_site_when_available(self, libero_scene_xml):
-        """Round 32 (#168) — pin the split-source contract.
+        """Round 32 (#168) - pin the split-source contract.
 
         With a real LIBERO scene compiled into the sim,
         ``_read_eef_pose`` must:
@@ -1226,7 +1226,7 @@ class TestAugmentObservation:
         original bug, so the test is meaningful.
 
         Round 32: also asserts the position we get back matches the
-        site, NOT the body — the round-30 wrong-body bug regression
+        site, NOT the body - the round-30 wrong-body bug regression
         sentinel.
         """
         pytest.importorskip("mujoco")
@@ -1253,7 +1253,7 @@ class TestAugmentObservation:
         body_pos = np.array(sim._world._data.xpos[body_id])  # type: ignore[attr-defined]
         site_pos = np.array(sim._world._data.site_xpos[site_id])  # type: ignore[attr-defined]
 
-        # The two MUST differ — otherwise this scene doesn't exhibit
+        # The two MUST differ - otherwise this scene doesn't exhibit
         # the round-30 bug and the regression test isn't meaningful.
         delta = site_pos - body_pos
         assert np.linalg.norm(delta) > 0.05, (
@@ -1298,7 +1298,7 @@ class TestAugmentObservation:
         # Scene exists, so get_body_state would work for the canonical
         # body if it were resolvable. We rely on FakeSim's
         # get_body_state implementation (returns from self._bodies),
-        # which is empty here — so the fallback returns (None, None).
+        # which is empty here - so the fallback returns (None, None).
         # Round-31 contract: NOT raising, just gracefully degrading.
         pos, quat = adapter._read_eef_pose(sim)
         # FakeSim's get_body_state on a missing body returns "missing"
@@ -1364,11 +1364,11 @@ class TestAugmentObservation:
         assert out["pitch"] == pytest.approx(expected_pitch, abs=1e-6)
         assert out["yaw"] == pytest.approx(expected_yaw, abs=1e-6), (
             f"state.yaw {out['yaw']} != body-derived {expected_yaw}; "
-            f"orientation source may be wrong (site vs body — round-31 had this 90° off)."
+            f"orientation source may be wrong (site vs body - round-31 had this 90° off)."
         )
 
     def test_read_eef_pose_uses_body_xquat_not_site_xmat(self, libero_scene_xml):
-        """Round 32 (#168) — pin the orientation source explicitly.
+        """Round 32 (#168) - pin the orientation source explicitly.
 
         Round 31 read the quaternion from ``site_xmat`` (via
         ``mju_mat2Quat``); round 32 reads it from ``data.xquat[body_id]``.
@@ -1399,18 +1399,18 @@ class TestAugmentObservation:
         if site_id < 0 or body_id < 0:
             pytest.skip("scene XML missing 'gripper0_grip_site' or 'robot0_right_hand'")
 
-        # Body xquat (mujoco wxyz convention) — the round-32 source.
+        # Body xquat (mujoco wxyz convention) - the round-32 source.
         body_quat = np.array(sim._world._data.xquat[body_id])  # type: ignore[attr-defined]
 
         # Site xmat → quat (the round-31 source). Sanity-check the
-        # two are different — otherwise the test isn't meaningful.
+        # two are different - otherwise the test isn't meaningful.
         site_xmat = np.array(sim._world._data.site_xmat[site_id]).reshape(9)  # type: ignore[attr-defined]
         site_quat = np.zeros(4)
         mujoco.mju_mat2Quat(site_quat, site_xmat)
 
         # Round-30 verification observed a 90° yaw offset between
         # site_xmat-derived quat and body xquat. The two MUST differ
-        # by more than the FP tolerance — otherwise the test's
+        # by more than the FP tolerance - otherwise the test's
         # round-32 vs round-31 distinction is moot.
         # Note: quaternions q and -q represent the same rotation, so
         # we measure orientation difference via the dot product
@@ -1464,7 +1464,7 @@ class TestAugmentObservation:
         ]
 
     def test_read_gripper_qpos_returns_both_fingers_with_opposite_signs(self, libero_scene_xml):
-        """Round 33 (#168) — primary regression for the duplicated-finger bug.
+        """Round 33 (#168) - primary regression for the duplicated-finger bug.
 
         With a real LIBERO scene compiled into the sim,
         ``_read_gripper_qpos`` returns
@@ -1518,7 +1518,7 @@ class TestAugmentObservation:
         # Sentinel: round-33 fix means qpos[0] != qpos[1]. Pre-round-33's
         # duplicate packing would always have qpos[0] == qpos[1].
         assert qpos[0] != qpos[1], (
-            f"both fingers reported as {qpos[0]} — round-33 duplicate-packing bug may have regressed"
+            f"both fingers reported as {qpos[0]} - round-33 duplicate-packing bug may have regressed"
         )
 
     def test_read_gripper_qpos_returns_none_when_joints_missing(self, libero_scene_xml):
@@ -1587,14 +1587,14 @@ class TestAugmentObservation:
         assert "gripper" in out
         assert len(out["gripper"]) == 2
 
-        # The two values must be OPPOSITE in sign — that's the
+        # The two values must be OPPOSITE in sign - that's the
         # round-33 contract that distinguishes the fix from pre-fix
         # duplicate-packing. Use a tolerance because the two fingers
         # could be at slightly different magnitudes due to gravity.
         assert out["gripper"][0] == pytest.approx(0.0208, abs=1e-6)
         assert out["gripper"][1] == pytest.approx(-0.0208, abs=1e-6)
         assert out["gripper"][0] != out["gripper"][1], (
-            f"state.gripper {out['gripper']} has duplicated value — round-33 bug regressed"
+            f"state.gripper {out['gripper']} has duplicated value - round-33 bug regressed"
         )
 
 
@@ -1613,7 +1613,7 @@ class TestAugmentObservationImageFlip:
     training (round-39 ``diff_libero_obs.py`` measured
     ``mean |Δ| = 56/255`` raw vs upstream, ``5.40/255`` after V-flip).
 
-    Adapter-side flip means the policy stays generic — its
+    Adapter-side flip means the policy stays generic - its
     ``image_rotation_180`` flag retains its training-pipeline meaning.
     """
 
@@ -1689,7 +1689,7 @@ class TestAugmentObservationImageFlip:
     def test_skips_non_ndarray_values(self):
         """Round 39 (#168): if a backend supplies the image as something
         other than an ndarray (e.g. PIL Image, base64 string), the flip
-        skips silently rather than raising — preserves backend
+        skips silently rather than raising - preserves backend
         flexibility."""
         adapter = LiberoAdapter.from_text(PICK_CUBE_BDDL)
         sim = FakeSim(
@@ -1700,7 +1700,7 @@ class TestAugmentObservationImageFlip:
                 },
             }
         )
-        # Pass a string instead of an ndarray — should pass through unchanged.
+        # Pass a string instead of an ndarray - should pass through unchanged.
         obs = {"finger_joint1": 0.04, "image": "<base64-png-bytes>"}
         out = adapter.augment_observation(sim, obs)
         assert out["image"] == "<base64-png-bytes>"
@@ -1794,14 +1794,14 @@ class TestQuaternionToEuler:
         assert pitch == pytest.approx(math.pi / 2, abs=1e-6)
 
     def test_matches_robosuite_mat2euler_sxyz(self):
-        """Round 46 (#176 sub-task 3d) — pin byte-equivalence to
+        """Round 46 (#176 sub-task 3d) - pin byte-equivalence to
         robosuite's ``mat2euler(R, axes='sxyz')``.
 
         The pre-46 formula derived sin(pitch) = R[0,2] from
         ``R = R_x · R_y · R_z`` (intrinsic XYZ), which produced
         sign-flipped Euler angles for some quaternions vs robosuite.
         E.g. q=(0, 0.7071, 0.7071, 0) → robosuite returns (π, 0, π/2)
-        but pre-46 returned (-π, 0, -π/2) — different yaw direction
+        but pre-46 returned (-π, 0, -π/2) - different yaw direction
         (left vs right twist about z), genuinely different rotation.
 
         This test pins the post-46 formula against pre-computed
@@ -1846,7 +1846,7 @@ class TestQuaternionToEuler:
                 # because asin/atan2 numerical precision dominates.
                 diff = ((ours[axis_idx] - expected_rpy[axis_idx] + math.pi) % (2 * math.pi)) - math.pi
                 # Gimbal-lock case (90° about Y): the (0, π/2, 0)
-                # decomposition isn't unique — roll and yaw both
+                # decomposition isn't unique - roll and yaw both
                 # absorb into a single rotation. Skip the roll/yaw
                 # axis check at exactly pitch=π/2.
                 if abs(expected_rpy[1] - math.pi / 2) < 1e-9 and axis_name in ("roll", "yaw"):
@@ -1859,12 +1859,12 @@ class TestQuaternionToEuler:
                 )
 
     def test_pre_46_sign_flip_regression(self):
-        """Round 46 (#176 sub-task 3d) — explicit pin against the
+        """Round 46 (#176 sub-task 3d) - explicit pin against the
         sign-flip bug that the pre-46 formula introduced.
 
         For ``q = (0, sqrt(2)/2, sqrt(2)/2, 0)`` (180° about (1,1,0)
         axis), the correct sxyz Euler is ``(π, 0, π/2)``. The pre-46
-        formula returned ``(-π, 0, -π/2)`` — same roll modulo 2π but
+        formula returned ``(-π, 0, -π/2)`` - same roll modulo 2π but
         OPPOSITE yaw (which is genuinely a different rotation about
         the world Z axis at this orientation).
 
@@ -1885,7 +1885,7 @@ class TestQuaternionToEuler:
         assert abs(yaw - math.pi / 2) < 1e-5, (
             f"yaw={yaw:.6f}, expected +π/2 ≈ 1.5708. "
             f"Sign-flip bug from pre-46 ``_quat_wxyz_to_rpy_xyz`` may have "
-            f"regressed — would break state.yaw OOD on the policy."
+            f"regressed - would break state.yaw OOD on the policy."
         )
 
 
@@ -3056,8 +3056,8 @@ class TestInstallActionController:
         assert ctrl.eef_site_name == "gripper0_grip_site"
 
     def test_initial_joint_anchored_to_libero_home_pose_not_construction_state(self, libero_scene_xml):
-        """Round 45 (#176): the OSC controller's ``initial_joint`` —
-        the nullspace-bias target — must be the LIBERO-canonical Panda
+        """Round 45 (#176): the OSC controller's ``initial_joint`` -
+        the nullspace-bias target - must be the LIBERO-canonical Panda
         "ready" pose, NOT the joint angles at the moment the controller
         was constructed.
 
@@ -3069,7 +3069,7 @@ class TestInstallActionController:
         once at construction. Without the round-45 swap-and-restore
         around ``controller_factory``, ``initial_joint`` captures the
         perturbed canonical pose instead of the LIBERO
-        ``MountedPanda.init_qpos`` ready pose — the OSC's
+        ``MountedPanda.init_qpos`` ready pose - the OSC's
         ``nullspace_torques`` term ``(initial_joint - joint_pos)``
         then collapses to ~0 instead of producing the ~5 N·m bias
         upstream LIBERO produces (where upstream constructs the
@@ -3089,7 +3089,7 @@ class TestInstallActionController:
         when ``__init__`` ran.
 
         Also verify ``data.qpos`` is restored to the perturbed
-        values after install — the swap is around the
+        values after install - the swap is around the
         ``controller_factory`` call, so the sim's actual state must
         be the canonical state we passed in, not the home pose.
         """
@@ -3228,7 +3228,7 @@ class TestInstallActionController:
             perturbed_qpos,
             atol=1e-9,
             err_msg=(
-                f"data.qpos[arm] not restored after controller install — sim's "
+                f"data.qpos[arm] not restored after controller install - sim's "
                 f"actual state is now the home pose {restored_qpos.tolist()} instead "
                 f"of the canonical {perturbed_qpos.tolist()}. The swap-and-restore "
                 f"contract is broken."
@@ -3240,7 +3240,7 @@ class TestInstallActionController:
         # tolerance), the round-45 fix didn't run.
         assert not np.allclose(captured_init_joint, perturbed_qpos, atol=1e-3), (
             f"initial_joint={captured_init_joint.tolist()} equals perturbed qpos "
-            f"{perturbed_qpos.tolist()} — round-45 swap-and-restore didn't run."
+            f"{perturbed_qpos.tolist()} - round-45 swap-and-restore didn't run."
         )
 
     def test_apply_writes_nonzero_torques_to_data_ctrl(self, libero_scene_xml):
@@ -3550,7 +3550,7 @@ class TestInstallActionController:
 
     def test_controller_physics_substeps_matches_libero_20hz_500hz(self, libero_scene_xml):
         """Round 27 (#168): with the default 0.002s timestep (500 Hz
-        physics), ``physics_substeps_per_control`` should be 25 — i.e.
+        physics), ``physics_substeps_per_control`` should be 25 - i.e.
         ``int(round((1/20) / 0.002)) == 25``. Pin so a future change to
         the default timestep doesn't silently break LIBERO's 20 Hz
         training-data convention.
@@ -3596,7 +3596,7 @@ class TestInstallActionController:
         advances by ``model.opt.timestep`` = 0.002 s only. Post-fix:
         25 ``mj_step`` calls ⇒ 0.05 s. Anything < 0.04 s indicates the
         substep loop didn't run (substeps must be ≥ 20 to be plausible
-        — exact number depends on timestep, but 1 vs 25 is unmistakable).
+        - exact number depends on timestep, but 1 vs 25 is unmistakable).
         """
         pytest.importorskip("mujoco")
         pytest.importorskip("robosuite")
@@ -3665,7 +3665,7 @@ class TestInstallActionController:
 
         from strands_robots.simulation import Simulation
 
-        # Build a minimal Simulation. We don't need a robot — just a
+        # Build a minimal Simulation. We don't need a robot - just a
         # compiled model + data. We sidestep ``add_robot`` (which
         # requires asset downloads) by injecting a minimal robot stub
         # into ``world.robots`` directly. The stub only needs a
@@ -3737,7 +3737,7 @@ class TestInstallActionController:
             f"got {call_count[0]}. Outer mj_step loop in _apply_sim_action may not be skipping."
         )
         # step_count increments by physics_substeps_per_control (7),
-        # NOT by n_substeps (3) — because the controller declared its
+        # NOT by n_substeps (3) - because the controller declared its
         # own substep count.
         delta_step = sim._world.step_count - step_count_before
         assert delta_step == 7, (
@@ -3808,7 +3808,7 @@ class TestInstallActionController:
         finally:
             mujoco.mj_step = original  # type: ignore[assignment]
 
-        # Outer loop fires for n_substeps=3 — the legacy contract.
+        # Outer loop fires for n_substeps=3 - the legacy contract.
         assert call_count[0] == 3, (
             f"expected 3 mj_step calls (outer loop, n_substeps=3) for plain controller "
             f"without owns_stepping, got {call_count[0]}."
@@ -3948,7 +3948,7 @@ class TestInstallActionController:
 
         Pre-fix bug: writing the raw scalar to both fingers meant
         close and open commands didn't actually produce reversed
-        outputs — each had one finger going wrong, making the
+        outputs - each had one finger going wrong, making the
         gripper effectively un-actuable.
 
         Post-fix: opposite signs of (round-41-converted) input produce
@@ -4219,7 +4219,7 @@ class TestInstallActionController:
         ``gripper_current_pre/post``).
 
         Pin so a future refactor that drops the structured log line
-        fails loudly here — the field set is the diagnostic contract
+        fails loudly here - the field set is the diagnostic contract
         for PR #168 round-29."""
         pytest.importorskip("mujoco")
         pytest.importorskip("robosuite")
@@ -4266,7 +4266,7 @@ class TestInstallActionController:
         assert len(action_log_lines) == 1, f"expected exactly 1 ACTION_LOG line, got {len(action_log_lines)}"
 
         msg = action_log_lines[0].getMessage()
-        # Diagnostic-field contract — every name in this list must be
+        # Diagnostic-field contract - every name in this list must be
         # present in every emitted log line. Reviewers grep these.
         for field in [
             "step=0",
@@ -4411,7 +4411,7 @@ class TestInstallActionController:
         if ctrl is None:
             pytest.skip("action_controller install failed")
 
-        # Default fallback — 50.
+        # Default fallback - 50.
         assert ctrl._action_log_max == 50
         warnings = [
             r
@@ -5289,13 +5289,13 @@ class TestPreRegisterDefaultRobot:
     """``LiberoAdapter._register_default_robot`` scans the loaded MJCF for a
     scene-supplied Panda (bodies prefixed with ``robot0_`` per RoboSuite /
     LIBERO convention) and registers a :class:`SimRobot` wrapper directly
-    in ``world.robots`` — *without* recompiling.
+    in ``world.robots`` - *without* recompiling.
 
     Goal: make ``sim.list_robots()`` return ``["robot"]`` BEFORE
     ``super().on_episode_start`` runs, so the base BenchmarkProtocol
     skips its unconditional ``sim.add_robot`` call. That unconditional
     call would otherwise inject a SECOND Panda (the redundant-Panda bug
-    confirmed in #166 round 4 — the second Panda's plastic shells sit
+    confirmed in #166 round 4 - the second Panda's plastic shells sit
     right in front of the ``image`` camera and contaminate every
     real-render frame).
     """
@@ -5359,7 +5359,7 @@ class TestPreRegisterDefaultRobot:
     def test_scene_panda_detected_and_registered(self, tmp_path):
         """When the loaded model has bodies / joints / actuators with the
         canonical ``robot0_`` prefix, the adapter MUST construct a
-        SimRobot wrapper and register it under ``"robot"`` — no
+        SimRobot wrapper and register it under ``"robot"`` - no
         ``sim.add_robot`` call required."""
         adapter = self._scene_path_setup(tmp_path)
         model, mj = self._make_panda_model()
@@ -5438,7 +5438,7 @@ class TestPreRegisterDefaultRobot:
         sim = FakeSim(data_config="panda")
         sim._world.robots["robot"] = _FakeRobot("panda")
 
-        # Don't patch mujoco — if the scan ran, it would fail.
+        # Don't patch mujoco - if the scan ran, it would fail.
         adapter.on_episode_start(sim, random.Random(0))
 
         # Registration unchanged.

--- a/tests/mesh/conftest.py
+++ b/tests/mesh/conftest.py
@@ -70,7 +70,7 @@ def _restore_real_zenoh_module():
     orderings a real ``zenoh`` reference can still be displaced by a
     ``unittest.mock.MagicMock`` that outlives its intended scope. When that
     happens, :func:`strands_robots.mesh.session._build_config` does a fresh
-    ``import zenoh`` and gets the mock — ``zenoh.Config().get_json(...)``
+    ``import zenoh`` and gets the mock - ``zenoh.Config().get_json(...)``
     then returns a ``MagicMock`` and ``json.loads(...)`` raises
     ``TypeError: the JSON object must be str, bytes or bytearray, not
     MagicMock``.

--- a/tests/mesh/test_acl_config.py
+++ b/tests/mesh/test_acl_config.py
@@ -252,7 +252,7 @@ class TestJSON5EndToEnd:
 
 
 class TestJSON5MalformedFailsLoudly:
-    """Operator-friendly diagnostics on malformed input — the json5 dep
+    """Operator-friendly diagnostics on malformed input - the json5 dep
     swap closes the silent-truncation surface the hand-rolled preprocessor
     had on unterminated `/*` blocks.
     """

--- a/tests/mesh/test_acl_shape_validation.py
+++ b/tests/mesh/test_acl_shape_validation.py
@@ -32,7 +32,7 @@ def _write(tmp_path: Path, doc: dict) -> Path:
 
 
 def _valid_skeleton() -> dict:
-    """A minimal valid ACL — used as the base for negative-shape tests."""
+    """A minimal valid ACL - used as the base for negative-shape tests."""
     return {
         "enabled": True,
         "default_permission": "deny",

--- a/tests/mesh/test_bridge_dedup.py
+++ b/tests/mesh/test_bridge_dedup.py
@@ -326,7 +326,7 @@ class TestMonotonicClockR12:
 
 
 class TestStrictDedupModeR15:
-    """the prior fix pin tests — opt-in strict mode dedups payloads with no canonical fields.
+    """the prior fix pin tests - opt-in strict mode dedups payloads with no canonical fields.
 
     Default mode (strict=False): payloads without (sender_id, turn_id, command)
     pass through (preserves heartbeat-style semantics where the same payload

--- a/tests/mesh/test_bridge_transport.py
+++ b/tests/mesh/test_bridge_transport.py
@@ -1,6 +1,6 @@
 """Unit tests for BridgeTransport (Zenoh + IoT fan-out).
 
-No real network — exercises the topic filter logic, suffix matching,
+No real network - exercises the topic filter logic, suffix matching,
 fan-out behaviour, subscription lifecycle, and graceful degradation when
 either side fails.
 """
@@ -162,7 +162,7 @@ class TestEnvPrefixFilter:
         assert _resolve_bridge_prefix_filter() == frozenset({"response"})
 
 
-# _should_bridge — the real fan-out gate
+# _should_bridge - the real fan-out gate
 
 
 class TestShouldBridge:
@@ -186,7 +186,7 @@ class TestShouldBridge:
             ("strands/peer1/camera/wrist", False),
             ("strands/peer1/input/leader", False),
             ("strands/peer1/hand/right/state", False),
-            # Outside the strands/ namespace — never bridges
+            # Outside the strands/ namespace - never bridges
             ("not-strands/foo", False),
         ],
     )
@@ -194,7 +194,7 @@ class TestShouldBridge:
         assert _should_bridge(topic, DEFAULT_BRIDGE_SUFFIXES) is allowed
 
 
-# BridgeTransport behaviour — both transports mocked
+# BridgeTransport behaviour - both transports mocked
 
 
 @pytest.fixture
@@ -252,7 +252,7 @@ class TestBridgeConnectAndClose:
 
 class TestBridgeFanOutPut:
     def test_state_publishes_only_to_zenoh(self, fake_transports):
-        """Default filter excludes ``state`` — must not bridge to MQTT."""
+        """Default filter excludes ``state`` - must not bridge to MQTT."""
         z, i = fake_transports
         b = BridgeTransport(zenoh=z, iot=i)
         b.connect()
@@ -365,7 +365,7 @@ class TestSubHandleIdempotence:
         b.undeclare.assert_called_once()
 
     def test_partial_handles(self):
-        """One side missing — only the present one is undeclared."""
+        """One side missing - only the present one is undeclared."""
         a = MagicMock()
         h = _BridgeSubHandle(a, None)
         h.undeclare()

--- a/tests/mesh/test_deep_mesh.py
+++ b/tests/mesh/test_deep_mesh.py
@@ -1,4 +1,4 @@
-"""Deep autonomous test suite for strands_robots.mesh — PR #101.
+"""Deep autonomous test suite for strands_robots.mesh - PR #101.
 
 This test file exercises every corner of the mesh implementation:
 - Session lifecycle edge cases
@@ -13,7 +13,7 @@ This test file exercises every corner of the mesh implementation:
 - Subscribe/unsubscribe races
 - Emergency stop propagation
 
-NO CODE WILL BE PUSHED — this is a read-only test exploration.
+NO CODE WILL BE PUSHED - this is a read-only test exploration.
 """
 
 from __future__ import annotations
@@ -193,7 +193,7 @@ class TestImportPaths:
         assert hasattr(session, "PeerInfo")
 
     def test_mesh_core_has_put(self):
-        """core.py imports put from session — verify it's accessible."""
+        """core.py imports put from session - verify it's accessible."""
         from strands_robots.mesh import core
 
         assert callable(core.put)

--- a/tests/mesh/test_iot_bootstrap.py
+++ b/tests/mesh/test_iot_bootstrap.py
@@ -42,7 +42,7 @@ class TestLambdaZipBuild:
 
 
 class TestResourceNames:
-    """Lock in the canonical names — changing them is a breaking change."""
+    """Lock in the canonical names - changing them is a breaking change."""
 
     def test_safety_table_name(self):
         assert SAFETY_TABLE_NAME == "strands-mesh-safety-events"
@@ -102,7 +102,7 @@ class TestEnsureSafetyTable:
         assert result == "arn:new"
         ddb.create_table.assert_called_once()
         kwargs = ddb.create_table.call_args.kwargs
-        # Must request KMS encryption — safety audit is a security-sensitive table.
+        # Must request KMS encryption - safety audit is a security-sensitive table.
         assert kwargs["SSESpecification"]["Enabled"] is True
         assert kwargs["SSESpecification"]["SSEType"] == "KMS"
         # Pay-per-request (so test accounts don't get autoscaling surprises).
@@ -236,7 +236,7 @@ class TestGrantIotInvokeLambda:
 
 
 class TestBootstrappedAccountEnv:
-    """Sanity checks — names locked in."""
+    """Sanity checks - names locked in."""
 
     def test_lambda_zip_size_reasonable(self):
         from strands_robots.mesh.iot.bootstrap import _build_lambda_zip

--- a/tests/mesh/test_iot_camera_offload.py
+++ b/tests/mesh/test_iot_camera_offload.py
@@ -1,6 +1,6 @@
 """Unit tests for CameraOffloader and S3 camera offload auto-wiring.
 
-No real S3 — uses MagicMock-backed boto3 client and transport.
+No real S3 - uses MagicMock-backed boto3 client and transport.
 """
 
 from __future__ import annotations
@@ -154,12 +154,12 @@ class TestEnableForMesh:
 
 
 class TestEnableForMeshOffloadWrapper:
-    """White-box tests for camera_offload.enable_for_mesh — exercise the
+    """White-box tests for camera_offload.enable_for_mesh - exercise the
     wrapper that runs inside Mesh._publish_cameras_once when the bucket is set."""
 
     def test_wrapper_skips_when_robot_not_connected(self, monkeypatch):
         """If the underlying robot isn't connected, the offload path
-        returns silently — no S3 call, no exception."""
+        returns silently - no S3 call, no exception."""
         monkeypatch.setenv("STRANDS_MESH_CAMERA_S3_BUCKET", "frames")
         from strands_robots.mesh.iot.camera_offload import enable_for_mesh
 
@@ -189,7 +189,7 @@ class TestEnableForMeshOffloadWrapper:
         ):
             off = enable_for_mesh(mesh)
         assert off is not None
-        # Drive the wrapper — it should call original AND early-return on offload
+        # Drive the wrapper - it should call original AND early-return on offload
         mesh._publish_cameras_once()
         assert original_called == [1]
 
@@ -204,7 +204,7 @@ class TestEnableForMeshOffloadWrapper:
         inner = type("I", (), {})()
         inner.is_connected = True
         inner.config = type("C", (), {"cameras": {"front": {}}})()
-        # get_observation raises — wrapper should bail without raising
+        # get_observation raises - wrapper should bail without raising
         inner.get_observation = MagicMock(side_effect=RuntimeError("camera dead"))
         mesh.robot = type("R", (), {})()
         mesh.robot.robot = inner

--- a/tests/mesh/test_iot_provision.py
+++ b/tests/mesh/test_iot_provision.py
@@ -1,6 +1,6 @@
 """Unit tests for the AWS IoT provisioning module.
 
-These tests use mocked boto3 clients — no real AWS calls are made.
+These tests use mocked boto3 clients - no real AWS calls are made.
 A full end-to-end provision + teardown happens in
 ``tests_integ/test_iot_transport.py`` and in the manually-validated
 ``/tmp/test_magic.py`` smoke run.
@@ -70,7 +70,7 @@ def fake_iot_client():
     iot = MagicMock()
     iot.meta.region_name = "us-west-2"
 
-    # ResourceNotFoundException — exposed at iot.exceptions
+    # ResourceNotFoundException - exposed at iot.exceptions
     class _NotFound(Exception):
         pass
 
@@ -112,7 +112,7 @@ def fake_iot_client():
     return iot
 
 
-# Policy documents — schema sanity checks
+# Policy documents - schema sanity checks
 
 
 class TestPolicyDocuments:
@@ -165,7 +165,7 @@ class TestEnsureThing:
         assert "thing/test-thing" in arn
 
     def test_skips_when_present(self, fake_iot_client):
-        """Existing thing is reused — no CreateThing call."""
+        """Existing thing is reused - no CreateThing call."""
         fake_iot_client.describe_thing.side_effect = None  # found
         fake_iot_client.describe_thing.return_value = {
             "thingArn": "arn:aws:iot:us-west-2:123456789012:thing/existing",
@@ -221,7 +221,7 @@ class TestProvisionRobot:
         assert result.endpoint == "fake-ats.iot.us-west-2.amazonaws.com"
         assert result.cert_path.exists()
         assert result.key_path.exists()
-        # Mode 0o600 — owner R/W only
+        # Mode 0o600 - owner R/W only
         assert oct(result.cert_path.stat().st_mode)[-3:] == "600"
         assert oct(result.key_path.stat().st_mode)[-3:] == "600"
 
@@ -358,7 +358,7 @@ class TestCleanupStaleCerts:
     Regression coverage for the security-relevant bug found in cycle 9 of
     the deep-test sweep: AWS IoT CreateKeysAndCertificate always returns a
     new cert (private keys aren't recoverable post-issuance), so without
-    explicit cleanup a Thing accumulates ACTIVE certs across re-runs —
+    explicit cleanup a Thing accumulates ACTIVE certs across re-runs -
     each one a potential impersonation credential.
     """
 
@@ -401,7 +401,7 @@ class TestCleanupStaleCerts:
         fake_iot_client.list_attached_policies.return_value = {"policies": []}
         fake_iot_client.delete_certificate.side_effect = RuntimeError("cannot delete")
 
-        # Must NOT raise — proceeds to create the new cert.
+        # Must NOT raise - proceeds to create the new cert.
         result = provision_robot("test-thing", cert_dir=tmp_cert_dir)
         assert result.thing_name == "test-thing"
         fake_iot_client.create_keys_and_certificate.assert_called_once()
@@ -483,7 +483,7 @@ class TestValidateThingNameFullmatch:
     ``re.match(r'^[a-zA-Z0-9_-]{1,128}$', s)`` accepts ``'robot\\n'``
     because in non-MULTILINE mode ``$`` matches *just before a trailing
     newline*. The PR description for #228 explicitly claims the regex
-    is "anchored, not just `match`" — these tests pin that contract.
+    is "anchored, not just `match`" - these tests pin that contract.
 
     A bypass surface exists wherever ``thing_name`` is interpolated
     into a filesystem path or an AWS API call (cert files under

--- a/tests/mesh/test_iot_shadow.py
+++ b/tests/mesh/test_iot_shadow.py
@@ -1,6 +1,6 @@
 """Unit tests for ShadowMirror and presence-shadow auto-wiring.
 
-No real AWS — uses MagicMock-backed transports.
+No real AWS - uses MagicMock-backed transports.
 """
 
 from __future__ import annotations
@@ -58,11 +58,11 @@ class TestShadowMirrorUpdate:
         transport.is_alive = MagicMock(return_value=True)
         transport.put.side_effect = RuntimeError("network")
         m = ShadowMirror("so100-01")
-        # Should not raise — shadow updates are best-effort.
+        # Should not raise - shadow updates are best-effort.
         m.update(transport, {"k": 1})
 
 
-# enable_for_mesh — auto-wiring
+# enable_for_mesh - auto-wiring
 
 
 class TestEnableForMesh:

--- a/tests/mesh/test_mesh.py
+++ b/tests/mesh/test_mesh.py
@@ -1,4 +1,4 @@
-"""Tests for strands_robots.mesh — Mesh component, presence + state loops.
+"""Tests for strands_robots.mesh - Mesh component, presence + state loops.
 
 All tests are 100% mocked.  No ``eclipse-zenoh`` install required: a
 ``MagicMock`` session is injected in place of the real Zenoh session by
@@ -113,7 +113,7 @@ def patch_no_session() -> Iterator[None]:
 
 
 class TestLifecycle:
-    """start() / stop() / alive — basic lifecycle invariants."""
+    """start() / stop() / alive - basic lifecycle invariants."""
 
     def test_starts_and_alive(self, patch_session: MagicMock) -> None:
         m = Mesh(_FakeRobot(), peer_id="bot-1")
@@ -181,7 +181,7 @@ class TestLifecycle:
                 assert m.alive is False
                 # release_session called exactly once during start() rollback
                 assert release_mock.call_count == 1
-                # stop() now is a no-op — must NOT call release_session again
+                # stop() now is a no-op - must NOT call release_session again
                 m.stop()
                 assert release_mock.call_count == 1
 
@@ -425,7 +425,7 @@ class TestLoops:
 
 
 # ---------------------------------------------------------------------------
-# init_mesh — the public constructor
+# init_mesh - the public constructor
 # ---------------------------------------------------------------------------
 
 
@@ -457,7 +457,7 @@ class TestInitMesh:
         m = init_mesh(_FakeRobot(tool_name="bot"), peer_id=None)
         assert m is not None
         assert m.peer_id.startswith("bot-")
-        # 8 hex chars (32 bits) — sized to avoid collisions on a busy mesh.
+        # 8 hex chars (32 bits) - sized to avoid collisions on a busy mesh.
         assert len(m.peer_id) == len("bot-") + 8
         # Suffix is hex.
         assert all(c in "0123456789abcdef" for c in m.peer_id.split("-")[-1])

--- a/tests/mesh/test_mesh_audit.py
+++ b/tests/mesh/test_mesh_audit.py
@@ -1,4 +1,4 @@
-"""Tests for strands_robots.mesh_audit — append-only safety audit log."""
+"""Tests for strands_robots.mesh_audit - append-only safety audit log."""
 
 from __future__ import annotations
 

--- a/tests/mesh/test_mesh_robustness.py
+++ b/tests/mesh/test_mesh_robustness.py
@@ -41,7 +41,7 @@ def fake_session(monkeypatch: pytest.MonkeyPatch) -> Iterator[MagicMock]:
 
 
 # ---------------------------------------------------------------------------
-# Issue #1 / #2 — _inbox_lock prevents concurrent-handler corruption.
+# Issue #1 / #2 - _inbox_lock prevents concurrent-handler corruption.
 # ---------------------------------------------------------------------------
 
 
@@ -87,7 +87,7 @@ def test_subscribe_inbox_concurrent_writes(fake_session: MagicMock) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Issue #7 — stop_event wakes the heartbeat / state loops promptly.
+# Issue #7 - stop_event wakes the heartbeat / state loops promptly.
 # ---------------------------------------------------------------------------
 
 
@@ -106,11 +106,11 @@ def test_stop_unblocks_heartbeat_loop_quickly(fake_session: MagicMock) -> None:
     assert not heartbeat.is_alive(), "heartbeat thread did not exit on stop()"
     # 0.5s would be the worst case under time.sleep(period); with the
     # stop_event we expect single-digit milliseconds.
-    assert elapsed < 0.4, f"stop() took {elapsed:.3f}s — stop_event regressed"
+    assert elapsed < 0.4, f"stop() took {elapsed:.3f}s - stop_event regressed"
 
 
 # ---------------------------------------------------------------------------
-# Issue #10 — partial-init failure tears down already-declared subscribers.
+# Issue #10 - partial-init failure tears down already-declared subscribers.
 # ---------------------------------------------------------------------------
 
 
@@ -148,20 +148,20 @@ def test_partial_init_failure_cleans_up_declared_subscribers(
     # Mesh must not be marked alive.
     assert m.alive is False
     # Both successfully-declared subscribers were undeclared.
-    assert all(sub.undeclare.called for sub in declared), "leaked subscribers — Issue #10 regressed"
+    assert all(sub.undeclare.called for sub in declared), "leaked subscribers - Issue #10 regressed"
     # Session reference released.
     assert release_mock.called
 
 
 # ---------------------------------------------------------------------------
-# Issue #5 — invalid STRANDS_MESH_PORT falls back gracefully (no exception).
+# Issue #5 - invalid STRANDS_MESH_PORT falls back gracefully (no exception).
 # ---------------------------------------------------------------------------
 
 
 def test_invalid_mesh_port_falls_back_to_default(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Bad STRANDS_MESH_PORT must warn and fall back to 7447 — never raise."""
+    """Bad STRANDS_MESH_PORT must warn and fall back to 7447 - never raise."""
     # Reset module-level state so get_session re-runs the open path.
     import strands_robots.mesh.session as ms
 
@@ -171,7 +171,7 @@ def test_invalid_mesh_port_falls_back_to_default(
     monkeypatch.setattr(ms, "_SESSION", None)
     monkeypatch.setattr(ms, "_SESSION_REFS", 0)
 
-    # Patch zenoh.open to capture the local_ep that get_session computes —
+    # Patch zenoh.open to capture the local_ep that get_session computes -
     # we don't actually need a real router for this test.
     fake_zenoh = MagicMock()
     fake_zenoh.Config.return_value = MagicMock()
@@ -186,10 +186,10 @@ def test_invalid_mesh_port_falls_back_to_default(
     assert sess is not None or sess is None  # any outcome OK; no exception is the point
     # WARNING about the bad port made it into the log.
     assert any("STRANDS_MESH_PORT" in rec.message for rec in caplog.records), (
-        "expected WARNING about invalid STRANDS_MESH_PORT — Issue #5 regressed"
+        "expected WARNING about invalid STRANDS_MESH_PORT - Issue #5 regressed"
     )
 
-    # Cleanup — close any session we accidentally opened.
+    # Cleanup - close any session we accidentally opened.
     if ms._SESSION is not None:
         try:
             ms.release_session()
@@ -198,7 +198,7 @@ def test_invalid_mesh_port_falls_back_to_default(
 
 
 # ---------------------------------------------------------------------------
-# Issue #4 — current_session does NOT bump the refcount.
+# Issue #4 - current_session does NOT bump the refcount.
 # ---------------------------------------------------------------------------
 
 
@@ -220,18 +220,18 @@ def test_current_session_does_not_change_refcount(
 
 
 # ---------------------------------------------------------------------------
-# Issue #9 — HardwareRobot.cleanup() stops the mesh.
+# Issue #9 - HardwareRobot.cleanup() stops the mesh.
 # ---------------------------------------------------------------------------
 
 
 def test_hardware_robot_cleanup_stops_mesh() -> None:
     """A HardwareRobot with a mesh attached must stop it during cleanup()."""
-    # Import deferred — pulls in lerobot only when actually needed.  Skip
+    # Import deferred - pulls in lerobot only when actually needed.  Skip
     # if lerobot isn't installed.
     pytest.importorskip("lerobot.robots.config", reason="needs lerobot")
     from strands_robots import hardware_robot
 
-    # Build a HardwareRobot without going through the full robot() path —
+    # Build a HardwareRobot without going through the full robot() path -
     # we just need an instance with the .mesh attribute and a cleanup() that
     # works (no real hardware).
     hw = hardware_robot.Robot.__new__(hardware_robot.Robot)
@@ -248,30 +248,30 @@ def test_hardware_robot_cleanup_stops_mesh() -> None:
     hw.peer_id = "fakebot-deadbeef"
 
     hw.cleanup()
-    assert fake_mesh.stop.called, "HardwareRobot.cleanup() must call self.mesh.stop() — Issue #9 regressed"
+    assert fake_mesh.stop.called, "HardwareRobot.cleanup() must call self.mesh.stop() - Issue #9 regressed"
 
 
 # ---------------------------------------------------------------------------
-# Issue #11 — peer_id default has 8 hex chars of entropy.
+# Issue #11 - peer_id default has 8 hex chars of entropy.
 # ---------------------------------------------------------------------------
 
 
 def test_default_peer_id_has_32_bits_of_entropy(fake_session: MagicMock) -> None:
-    """8 hex chars = 32 bits — required for collision-free large meshes."""
+    """8 hex chars = 32 bits - required for collision-free large meshes."""
     seen: set[str] = set()
     for _ in range(256):
         m = init_mesh(_FakeRobot(), peer_id=None)
         assert m is not None
         suffix = m.peer_id.split("-")[-1]
-        assert len(suffix) == 8, f"got {len(suffix)} hex chars — Issue #11 regressed"
+        assert len(suffix) == 8, f"got {len(suffix)} hex chars - Issue #11 regressed"
         seen.add(suffix)
         m.stop()
-    # 256 ids in a 2**32 space — uniqueness is statistically guaranteed.
-    assert len(seen) == 256, "peer_id collisions across 256 ids — entropy regressed"
+    # 256 ids in a 2**32 space - uniqueness is statistically guaranteed.
+    assert len(seen) == 256, "peer_id collisions across 256 ids - entropy regressed"
 
 
 # ---------------------------------------------------------------------------
-# Issue #2 / #3 — concurrent subscribe/stop don't crash.
+# Issue #2 / #3 - concurrent subscribe/stop don't crash.
 # ---------------------------------------------------------------------------
 
 

--- a/tests/mesh/test_mesh_rpc.py
+++ b/tests/mesh/test_mesh_rpc.py
@@ -1,4 +1,4 @@
-"""Tests for strands_robots.mesh — RPC (PR3), streams (PR4), safety (PR5).
+"""Tests for strands_robots.mesh - RPC (PR3), streams (PR4), safety (PR5).
 
 All tests are 100% mocked.  No ``eclipse-zenoh`` install required: a
 ``MagicMock`` session is injected in place of the real Zenoh session by
@@ -124,7 +124,7 @@ def _make_sample(payload: dict[str, Any], key: str = "strands/x/cmd") -> Any:
 
 
 # ---------------------------------------------------------------------------
-# Dispatch — _dispatch routes correctly for every action
+# Dispatch - _dispatch routes correctly for every action
 # ---------------------------------------------------------------------------
 
 
@@ -193,7 +193,7 @@ def test_dispatch_state_falls_back_to_read_state() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Incoming command flow — _on_cmd → _exec_cmd → put(response)
+# Incoming command flow - _on_cmd → _exec_cmd → put(response)
 # ---------------------------------------------------------------------------
 
 
@@ -280,7 +280,7 @@ def test_exec_cmd_string_command_rejected() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Outgoing RPC — send / broadcast / tell
+# Outgoing RPC - send / broadcast / tell
 # ---------------------------------------------------------------------------
 
 
@@ -295,7 +295,7 @@ def test_send_returns_first_response(started_mesh: Mesh, captured_puts) -> None:
                     turn = next(iter(started_mesh._pending.keys()))
                     break
             time.sleep(0.01)
-        else:  # pragma: no cover — defensive
+        else:  # pragma: no cover - defensive
             return
         # Phase-4 / D1: _on_response now requires responder_id to match the
         # target the sender originally addressed (otherwise an
@@ -534,13 +534,13 @@ def test_emergency_stop_audit_log_failure_does_not_raise(started_mesh: Mesh) -> 
         patch.object(started_mesh, "broadcast", return_value=[]),
         patch.object(mesh_mod, "log_safety_event", side_effect=OSError("disk full")),
     ):
-        # Must not raise — audit log failure is non-fatal.
+        # Must not raise - audit log failure is non-fatal.
         out = started_mesh.emergency_stop()
     assert out == []
 
 
 # ---------------------------------------------------------------------------
-# Stop semantics — wakes blocked send/broadcast calls
+# Stop semantics - wakes blocked send/broadcast calls
 # ---------------------------------------------------------------------------
 
 

--- a/tests/mesh/test_mesh_rpc_sim_dispatch.py
+++ b/tests/mesh/test_mesh_rpc_sim_dispatch.py
@@ -7,7 +7,7 @@ object) routes ``execute`` -> ``run_policy`` and ``start`` -> ``start_policy``
 with the issue #300 well-known kwargs (``target_pose`` / ``target_joints`` /
 ``world_update``) forwarded into ``policy_config``.
 
-Tests are 100% mocked — no MuJoCo / Isaac install required. A
+Tests are 100% mocked - no MuJoCo / Isaac install required. A
 ``_FakeSim`` exposes the SimEngine surface duck-typed minimally to what
 ``_dispatch_sim_policy`` needs.
 """
@@ -31,7 +31,7 @@ class _FakeSim:
     def __init__(self, robots: list[str] | None = None) -> None:
         # The mesh dispatcher checks for a non-None ``_world`` to confirm
         # the sim has been initialised. Use a sentinel object, not just
-        # truthy — matches MuJoCoSimEngine's "_world is None" gate.
+        # truthy - matches MuJoCoSimEngine's "_world is None" gate.
         self._world: Any = object()
         self._robots = list(robots if robots is not None else ["so100"])
         self.run_policy_calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
@@ -147,7 +147,7 @@ def test_execute_forwards_constructor_extras_via_policy_config() -> None:
 
 
 def test_execute_requires_robot_name_when_multiple_robots() -> None:
-    """Ambiguous targets must be explicit — silent default to first robot is forbidden."""
+    """Ambiguous targets must be explicit - silent default to first robot is forbidden."""
     sim = _FakeSim(robots=["arm_left", "arm_right"])
     m = Mesh(sim, peer_id="sim-a")
     out = m._dispatch(
@@ -252,7 +252,7 @@ def test_execute_forwards_optional_run_kwargs() -> None:
 def test_hardware_path_unchanged_when_run_policy_absent() -> None:
     """A peer without ``run_policy`` / ``_world`` still hits the HardwareRobot branch.
 
-    Regression guard: the sim branch must be additive — existing
+    Regression guard: the sim branch must be additive - existing
     HardwareRobot peers see no behaviour change.
     """
 

--- a/tests/mesh/test_mesh_session.py
+++ b/tests/mesh/test_mesh_session.py
@@ -1,4 +1,4 @@
-"""Tests for strands_robots.mesh.session — session singleton + peer registry.
+"""Tests for strands_robots.mesh.session - session singleton + peer registry.
 
 All tests mock zenoh so no network or real zenoh install is required.
 """
@@ -284,7 +284,7 @@ class TestSessionLifecycle:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
-                # First call (listener) fails — port taken
+                # First call (listener) fails - port taken
                 raise OSError("Address already in use")
             # Second call (client) succeeds
             return mock_session

--- a/tests/mesh/test_mesh_tell_sim_e2e.py
+++ b/tests/mesh/test_mesh_tell_sim_e2e.py
@@ -3,7 +3,7 @@
 Exercises the full sim dispatch path:
 
 * Stand up a real ``Simulation`` (MuJoCo backend) with a single robot.
-* Wrap it in a ``Mesh`` (no zenoh — we hand-call ``_dispatch`` so the
+* Wrap it in a ``Mesh`` (no zenoh - we hand-call ``_dispatch`` so the
   test stays a unit test, not a full Zenoh integration).
 * Drive ``execute`` via the dispatcher with ``policy_provider="mock"``
   and assert the mock policy actually ran.
@@ -28,7 +28,7 @@ def _build_sim_with_simple_robot():
 
     We avoid ``add_robot`` (which fetches assets from the model registry
     and is heavyweight) and instead hand-build a tiny MJCF with one
-    actuated hinge — enough to exercise ``run_policy`` end-to-end.
+    actuated hinge - enough to exercise ``run_policy`` end-to-end.
     """
     from strands_robots.simulation.mujoco.simulation import Simulation
 

--- a/tests/mesh/test_mesh_wiring.py
+++ b/tests/mesh/test_mesh_wiring.py
@@ -16,7 +16,7 @@ from unittest.mock import patch
 
 import pytest
 
-# Skip the entire module if mujoco is not installed — the Robot()/Simulation
+# Skip the entire module if mujoco is not installed - the Robot()/Simulation
 # wiring depends on a working sim backend.
 pytest.importorskip("mujoco", reason="Robot()/Simulation wiring needs mujoco")
 
@@ -69,13 +69,13 @@ def test_robot_factory_mesh_false_skips_init_mesh(monkeypatch):
     """Robot(..., mesh=False) keeps the sim alive but does not create a mesh."""
     from strands_robots import Robot
 
-    # Make sure mesh would otherwise be enabled — tests run with
+    # Make sure mesh would otherwise be enabled - tests run with
     # STRANDS_MESH=false from conftest by default.
     monkeypatch.delenv("STRANDS_MESH", raising=False)
     # But we must keep init_mesh from spinning up a real zenoh session.
     with patch("strands_robots.mesh.init_mesh", return_value=None) as m:
         sim = Robot("so100", mode="sim", mesh=False)
-        # mesh=False short-circuits before init_mesh — but the factory may
+        # mesh=False short-circuits before init_mesh - but the factory may
         # still call init_mesh(... mesh=False) which returns None either way.
         if m.called:
             assert m.call_args.kwargs.get("mesh") is False
@@ -130,7 +130,7 @@ def test_robot_factory_mesh_init_failure_does_not_break_sim(monkeypatch):
 
     monkeypatch.setattr("strands_robots.mesh.init_mesh", boom)
 
-    # Should NOT raise — the user asked for a sim, mesh is best-effort.
+    # Should NOT raise - the user asked for a sim, mesh is best-effort.
     sim = Robot("so100", mode="sim")
     try:
         # mesh attribute remains the construction-time default (None / falsy).

--- a/tests/mesh/test_robot_mesh_subscribe_allowlist.py
+++ b/tests/mesh/test_robot_mesh_subscribe_allowlist.py
@@ -223,8 +223,8 @@ def test_ke_matches_single_star_rejects_empty_segment():
 @pytest.mark.parametrize(
     "target",
     [
-        "*",  # single Zenoh wildcard — matches strands/*/stream by equality
-        "**",  # double-star wildcard — matches via trailing /** branch
+        "*",  # single Zenoh wildcard - matches strands/*/stream by equality
+        "**",  # double-star wildcard - matches via trailing /** branch
         "*/state",  # embedded wildcard
         "peer-a/state",  # path separator (would broaden the keyexpr)
         "../etc",  # path traversal shape
@@ -254,7 +254,7 @@ def test_watch_rejects_wildcard_targets_even_with_permissive_allowlist(monkeypat
 
 
 def test_watch_rejects_wildcard_even_when_in_hitl_set_and_approved(monkeypatch):
-    """Even an HITL approval cannot legitimise a wildcard target — the HITL
+    """Even an HITL approval cannot legitimise a wildcard target - the HITL
     bypass is for the allowlist gate, not for shape validation. Otherwise the
     operator would be tricked into approving a single-peer-shaped reason
     string while the agent slipped a wildcard past."""

--- a/tests/mesh/test_robot_mesh_tool.py
+++ b/tests/mesh/test_robot_mesh_tool.py
@@ -1,4 +1,4 @@
-"""Tests for strands_robots.tools.robot_mesh — agent-facing dispatcher."""
+"""Tests for strands_robots.tools.robot_mesh - agent-facing dispatcher."""
 
 from __future__ import annotations
 
@@ -229,7 +229,7 @@ def test_actions_without_local_mesh_fail(fake_no_local):
 # Before this fix, when the agent issued ``send/tell/stop`` to a target that
 # matched a *local* peer_id, ``_resolve_mesh`` would return the target's own
 # Mesh as the gateway.  ``Mesh.send`` then published on
-# ``strands/{target}/cmd`` with ``sender_id == target`` — the receiving
+# ``strands/{target}/cmd`` with ``sender_id == target`` - the receiving
 # subscriber drops self-loops, so the call silently timed out.  The fix:
 # pick a *different* local mesh as the gateway whenever one exists.
 # ---------------------------------------------------------------------------
@@ -248,7 +248,7 @@ def test_resolve_mesh_avoids_self_loop_when_alternative_exists():
 
     with patch("strands_robots.mesh.get_local_robots", return_value=locals_):
         gateway = _resolve_mesh("robot-b")
-        # MUST be mesh_a (the OTHER local mesh) — never mesh_b itself,
+        # MUST be mesh_a (the OTHER local mesh) - never mesh_b itself,
         # which would self-loop.
         assert gateway is mesh_a, (
             f"_resolve_mesh returned {gateway.peer_id!r} but should have "
@@ -259,7 +259,7 @@ def test_resolve_mesh_avoids_self_loop_when_alternative_exists():
 def test_resolve_mesh_fallback_when_target_is_only_local():
     """When the target IS the only local mesh, fall back to it.
 
-    The caller will get a timeout (since the message self-drops) — that's
+    The caller will get a timeout (since the message self-drops) - that's
     the expected behaviour for "send to yourself" with no other local
     gateway available.
     """

--- a/tests/mesh/test_safety_audit_v040_followups.py
+++ b/tests/mesh/test_safety_audit_v040_followups.py
@@ -27,7 +27,7 @@ def _isolate_audit_state(tmp_path, monkeypatch):
 
 
 # --------------------------------------------------------------------------- #
-# #324 — NEXT_SEQ_DEGRADED poison record                                       #
+# #324 - NEXT_SEQ_DEGRADED poison record                                       #
 # --------------------------------------------------------------------------- #
 def test_next_seq_non_symlink_failure_writes_poison_record(tmp_path, monkeypatch, caplog):
     """A non-SeqLockSymlinkError failure inside _next_seq must NOT drop the
@@ -72,7 +72,7 @@ def test_seqlock_symlink_still_writes_seq_lock_degraded(tmp_path, monkeypatch):
 
 
 # --------------------------------------------------------------------------- #
-# #324 — NEXT_SEQ_DEGRADED poison survives PSK signing gate                    #
+# #324 - NEXT_SEQ_DEGRADED poison survives PSK signing gate                    #
 # --------------------------------------------------------------------------- #
 def test_next_seq_degraded_poison_survives_psk_signing(tmp_path, monkeypatch, caplog):
     """Regression pin: when STRANDS_MESH_AUDIT_PSK is configured, the

--- a/tests/mesh/test_session_acl_v040_followups.py
+++ b/tests/mesh/test_session_acl_v040_followups.py
@@ -19,7 +19,7 @@ from strands_robots.mesh import _acl_config, _zenoh_config, session
 
 
 # --------------------------------------------------------------------------- #
-# #307 — eviction-order parity                                                 #
+# #307 - eviction-order parity                                                 #
 # --------------------------------------------------------------------------- #
 def test_non_posix_tls_warned_keys_is_ordered_fifo():
     """The TLS-warned bound cache must be an insertion-ordered mapping that
@@ -49,7 +49,7 @@ def test_non_posix_tls_warned_eviction_is_fifo(monkeypatch):
 
 
 # --------------------------------------------------------------------------- #
-# #308 — symmetric total-deny warning                                          #
+# #308 - symmetric total-deny warning                                          #
 # --------------------------------------------------------------------------- #
 def _write_acl(tmp_path: Path, payload: dict) -> Path:
     p = tmp_path / "acl.json"
@@ -94,7 +94,7 @@ def test_deny_with_allow_rule_does_not_warn_total_deny(tmp_path, caplog):
 
 
 # --------------------------------------------------------------------------- #
-# #309 — TLS-bearing scheme allow-list                                         #
+# #309 - TLS-bearing scheme allow-list                                         #
 # --------------------------------------------------------------------------- #
 @pytest.mark.parametrize("scheme", ["tls", "quic", "wss", "unixsock"])
 def test_tls_bearing_schemes_pass_under_mtls(scheme):
@@ -117,7 +117,7 @@ def test_tls_bearing_constant_contains_new_schemes():
 
 
 # --------------------------------------------------------------------------- #
-# #310 — thread snapshot is always None or a 2-tuple                           #
+# #310 - thread snapshot is always None or a 2-tuple                           #
 # --------------------------------------------------------------------------- #
 def test_thread_snapshot_is_always_2tuple_after_set():
     try:

--- a/tests/mesh/test_sim_robot_mesh_attach.py
+++ b/tests/mesh/test_sim_robot_mesh_attach.py
@@ -32,7 +32,7 @@ def test_simrobot_dataclass_has_mesh_and_peer_id_fields():
 
 
 def test_simrobot_mesh_fields_can_be_set():
-    """Round-trip the new fields — required by Simulation.add_robot."""
+    """Round-trip the new fields - required by Simulation.add_robot."""
     fake_mesh = MagicMock(name="Mesh", peer_id="parent-x:so100")
     r = SimRobot(
         name="so100",
@@ -45,7 +45,7 @@ def test_simrobot_mesh_fields_can_be_set():
 
 
 # ---------------------------------------------------------------------------
-# _attach_robot_to_mesh — direct unit tests via a stub Simulation
+# _attach_robot_to_mesh - direct unit tests via a stub Simulation
 # ---------------------------------------------------------------------------
 
 
@@ -68,7 +68,7 @@ class _StubSim:
 
 
 def test_attach_is_noop_when_sim_has_no_mesh():
-    """Off-mesh sims must not call init_mesh — keeps zenoh out of unit tests."""
+    """Off-mesh sims must not call init_mesh - keeps zenoh out of unit tests."""
     attach, _ = _StubSim._import_helpers()
     sim = _StubSim(mesh=None, peer_id="")
     robot = SimRobot(name="r1", urdf_path="/tmp/x.urdf")
@@ -104,7 +104,7 @@ def test_attach_creates_child_peer_when_sim_is_on_mesh():
 
 
 def test_attach_swallows_init_mesh_exceptions():
-    """A mesh failure must not bring down add_robot — best-effort enrichment."""
+    """A mesh failure must not bring down add_robot - best-effort enrichment."""
     attach, _ = _StubSim._import_helpers()
     sim = _StubSim(mesh=MagicMock(), peer_id="parent-x")
     robot = SimRobot(name="r1", urdf_path="/tmp/x.urdf")
@@ -120,7 +120,7 @@ def test_attach_swallows_init_mesh_exceptions():
 
 
 def test_attach_handles_init_mesh_returning_none():
-    """STRANDS_MESH=false case — init_mesh returns None, robot stays off-mesh."""
+    """STRANDS_MESH=false case - init_mesh returns None, robot stays off-mesh."""
     attach, _ = _StubSim._import_helpers()
     sim = _StubSim(mesh=MagicMock(), peer_id="parent-x")
     robot = SimRobot(name="r1", urdf_path="/tmp/x.urdf")

--- a/tests/mesh/test_transport.py
+++ b/tests/mesh/test_transport.py
@@ -1,6 +1,6 @@
 """Unit tests for the MeshTransport abstraction layer.
 
-These tests do NOT touch real AWS or Zenoh — they verify protocol shape,
+These tests do NOT touch real AWS or Zenoh - they verify protocol shape,
 wildcard translation, QoS lookup, topic-filter matching, and ZenohTransport
 delegation. The real AWS-backed integration test lives in
 ``tests_integ/test_iot_transport.py``.
@@ -190,7 +190,7 @@ class TestMqttMatcher:
         assert _mqtt_topic_matches(filter_, topic) is expected
 
 
-# IotMqttTransport — no live broker
+# IotMqttTransport - no live broker
 
 
 class TestIotMqttTransportConfig:
@@ -241,7 +241,7 @@ class TestIotMqttTransportConfig:
         assert t.is_alive() is False
 
 
-# ZenohTransport — delegating to mesh.session
+# ZenohTransport - delegating to mesh.session
 
 
 class TestZenohTransportDelegation:
@@ -269,7 +269,7 @@ class TestZenohTransportDelegation:
                 sess_mod._SESSION = None
                 sess_mod._SESSION_REFS = 0
         t = ZenohTransport()
-        # Should be safe — delegates to session.put which is a no-op.
+        # Should be safe - delegates to session.put which is a no-op.
         t.put("strands/test/state", {"k": 1})
 
     def test_is_alive_false_when_no_session(self):
@@ -290,7 +290,7 @@ class TestZenohTransportDelegation:
         """When session is pre-seeded, connect() takes a ref; close() releases it."""
         from strands_robots.mesh import session as sess_mod
 
-        # Pre-seed: simulate "session already open with 0 refs" — this is
+        # Pre-seed: simulate "session already open with 0 refs" - this is
         # the state right after a get_session→release_session cycle would
         # leave it if it didn't auto-close. We construct it manually here
         # because we don't want this test to require zenoh as a hard dep.
@@ -365,7 +365,7 @@ class TestIotMqttTransportInternals:
         from strands_robots.mesh.transport.iot_transport import IotMqttTransport
 
         t = IotMqttTransport(thing_name="test-thing", endpoint="x.iot")
-        # Pretend connect() succeeded — directly install a fake client + flag.
+        # Pretend connect() succeeded - directly install a fake client + flag.
         t._client = MagicMock()
         t._connected.set()
         return t
@@ -410,7 +410,7 @@ class TestIotMqttTransportInternals:
         from strands_robots.mesh.transport.iot_transport import IotMqttTransport
 
         t = IotMqttTransport(thing_name="x", endpoint="y")
-        # _client is None, _connected not set — must early-return without raising
+        # _client is None, _connected not set - must early-return without raising
         t.put("strands/p/state", {"k": 1})
         # Also when only one of the two is missing
         t._client = MagicMock()
@@ -451,7 +451,7 @@ class TestIotMqttTransportInternals:
     def test_put_swallows_publish_errors(self):
         t = self._make_transport_with_fake_client()
         t._client.publish.side_effect = RuntimeError("network")
-        # Must not raise — preserves Mesh.put() fire-and-forget contract
+        # Must not raise - preserves Mesh.put() fire-and-forget contract
         t.put("strands/p/state", {"k": 1})
 
     def test_unsubscribe_removes_handler_then_unsubscribes_at_broker(self):
@@ -465,12 +465,12 @@ class TestIotMqttTransportInternals:
 
         t._handlers["strands/+/cmd"] = [h1, h2]
 
-        # Removing one handler — broker subscription stays
+        # Removing one handler - broker subscription stays
         t._unsubscribe("strands/+/cmd")
         assert len(t._handlers["strands/+/cmd"]) == 1
         t._client.unsubscribe.assert_not_called()
 
-        # Removing the last handler — broker unsubscribe is sent
+        # Removing the last handler - broker unsubscribe is sent
         t._unsubscribe("strands/+/cmd")
         assert "strands/+/cmd" not in t._handlers
         t._client.unsubscribe.assert_called_once()
@@ -494,7 +494,7 @@ class TestIotMqttTransportInternals:
         t._handlers["strands/+/state"] = [lambda s: seen.append(("a", s.key_expr))]
         t._handlers["strands/+/presence"] = [lambda s: seen.append(("b", s.key_expr))]
 
-        # Build a fake publish_packet — keep awscrt's actual shape (.topic,.payload bytes)
+        # Build a fake publish_packet - keep awscrt's actual shape (.topic,.payload bytes)
         data = MagicMock()
         data.publish_packet.topic = "strands/peer1/state"
         data.publish_packet.payload = b'{"k":1}'
@@ -540,7 +540,7 @@ class TestIotMqttTransportInternals:
         t._handlers["strands/+/cmd"] = [lambda s: None]
         h = _MqttSubHandle(t, "strands/+/cmd")
         h.undeclare()
-        # Second undeclare — guarded by _undeclared flag
+        # Second undeclare - guarded by _undeclared flag
         h.undeclare()
         # Broker unsubscribe should be called exactly once
         assert t._client.unsubscribe.call_count == 1

--- a/tests/mesh/test_validate_command_sim_fields.py
+++ b/tests/mesh/test_validate_command_sim_fields.py
@@ -3,11 +3,11 @@
 The validator at ``strands_robots.mesh.security.validate_command`` now
 admits a small set of sim-peer fields used by ``Mesh._dispatch_sim_policy``:
 
-* ``robot_name`` — disambiguates which robot in a multi-robot sim
-* ``target_pose`` / ``target_joints`` / ``world_update`` — issue #300
+* ``robot_name`` - disambiguates which robot in a multi-robot sim
+* ``target_pose`` / ``target_joints`` / ``world_update`` - issue #300
   well-known per-call kwargs forwarded to planner-style policies
 * ``control_frequency`` / ``action_horizon`` / ``fast_mode`` / ``n_steps``
-  — sim-side runner controls
+  - sim-side runner controls
 
 Each accepts a happy path and a representative rejection path so a
 malicious peer cannot smuggle control-byte robot names, multi-MB
@@ -49,7 +49,7 @@ class TestRobotName:
             sec.validate_command({**_base(), "robot_name": "arm; rm -rf /"})
 
     def test_slash_rejected(self) -> None:
-        # Mirrors the teleop_receive.source_peer_id rule — robot_name is
+        # Mirrors the teleop_receive.source_peer_id rule - robot_name is
         # not a path, so '/' is a wire-side red flag.
         with pytest.raises(sec.ValidationError, match="robot_name"):
             sec.validate_command({**_base(), "robot_name": "ns/arm"})

--- a/tests/policies/cosmos3/test_policy.py
+++ b/tests/policies/cosmos3/test_policy.py
@@ -1,4 +1,4 @@
-"""Unit tests for Cosmos3Policy — no GPU, no server (mocked client)."""
+"""Unit tests for Cosmos3Policy - no GPU, no server (mocked client)."""
 
 import asyncio
 
@@ -11,7 +11,7 @@ from strands_robots.policies.cosmos3.policy import _to_image_uint8
 
 
 class FakeClient:
-    """Stand-in for Cosmos3WebsocketClient — records the obs, returns a chunk."""
+    """Stand-in for Cosmos3WebsocketClient - records the obs, returns a chunk."""
 
     def __init__(self, action: np.ndarray):
         self._action = action
@@ -280,7 +280,7 @@ def test_pretrained_name_or_path_stored_not_dropped():
 
 
 def test_unexpected_kwargs_rejected():
-    """Cosmos3Policy no longer accepts **kwargs — a typo'd kwarg like
+    """Cosmos3Policy no longer accepts **kwargs - a typo'd kwarg like
     actoin_mapping (note the typo) must raise TypeError instead of being
     silently swallowed.
     """

--- a/tests/policies/cosmos3/test_registry.py
+++ b/tests/policies/cosmos3/test_registry.py
@@ -15,7 +15,7 @@ def test_cosmos3_in_registry():
 
 def test_shorthands_resolve_to_cosmos3():
     """The canonical short name is ``cosmos3`` (with ``c3`` alias). The
-    bare ``cosmos`` shorthand was intentionally dropped — it's ambiguous
+    bare ``cosmos`` shorthand was intentionally dropped - it's ambiguous
     against future NVIDIA Cosmos products (Predict, Reason, Transfer, etc.)
     and was a one-way-door if we'd kept it. Pinning the new contract here
     so a future copy-paste cannot silently re-introduce the collision."""
@@ -25,7 +25,7 @@ def test_shorthands_resolve_to_cosmos3():
 
 
 def test_bare_cosmos_shorthand_does_not_resolve_to_cosmos3():
-    """Bare ``cosmos`` must NOT resolve to the cosmos3 provider — it falls
+    """Bare ``cosmos`` must NOT resolve to the cosmos3 provider - it falls
     back to lerobot_local (the unrecognized-policy default) so a future
     NVIDIA Cosmos provider can claim that namespace cleanly."""
     prov, _ = resolve_policy("cosmos")

--- a/tests/policies/groot/test_policy.py
+++ b/tests/policies/groot/test_policy.py
@@ -624,7 +624,7 @@ class TestPolicyReset:
 
     Without this, ``set_eval_seed`` only seeds the client-side process,
     leaving the server's diffusion sampler RNG drifting across calls and
-    breaking reproducibility — same input gives different actions on
+    breaking reproducibility - same input gives different actions on
     successive calls. Pin the surface so future refactors can't silently
     drop the per-episode reset that the bisection plan in #187 confirmed
     is required.
@@ -660,14 +660,14 @@ class TestPolicyReset:
         p._client.call_endpoint.assert_called_once()
         endpoint, payload = p._client.call_endpoint.call_args.args
         assert endpoint == "reset"
-        # When no seed is provided we forward None — lets server use its
+        # When no seed is provided we forward None - lets server use its
         # initial seed (matches "no-op" semantics for servers that don't
         # implement seed-aware reset).
         assert payload is None
 
     def test_service_reset_swallows_server_errors(self, caplog):
         """A server that rejects ``reset`` (older NVIDIA images, wrappers
-        without the patch) must not crash the eval. Reset is best-effort —
+        without the patch) must not crash the eval. Reset is best-effort -
         log INFO and continue.
         """
         import logging as _logging
@@ -1021,7 +1021,7 @@ class TestLocalObsImageRotation180:
         This is the strongest test that the two paths can't drift again.
         Prior to #169, LOCAL skipped rotation while SERVICE applied it,
         so the same observation produced different model inputs depending
-        on transport — exactly the bug class issue #169 covers."""
+        on transport - exactly the bug class issue #169 covers."""
         p_local = self._libero_panda_local_policy()
         p_svc = Gr00tPolicy(data_config="libero_panda", host="localhost", port=19999)
         p_svc._groot_version = "n1.7"
@@ -1116,7 +1116,7 @@ class TestApplyImageRotation180Helper:
         assert obs["video.wrist"] == [1, 2, 3]
 
     def test_skips_dim_lt_3(self):
-        """``(H, W)`` shape (2D) without channel axis is skipped — the
+        """``(H, W)`` shape (2D) without channel axis is skipped - the
         helper only rotates when there are ≥3 dims so the H/W axes are
         unambiguous via negative indexing."""
         from strands_robots.policies.groot.policy import _apply_image_rotation_180_inplace

--- a/tests/policies/groot/test_zmq_wire_roundtrip.py
+++ b/tests/policies/groot/test_zmq_wire_roundtrip.py
@@ -221,7 +221,7 @@ class TestZmqWireRoundTripLiberoPanda:
         # bottom-right (h-1, w-1) after the 180° rotation lands on H/W.
         np.testing.assert_array_equal(wire_image[0, 0, h - 1, w - 1], [123, 45, 67])
         # And NOT at the original top-left position (would mean axes
-        # B/T got flipped instead of H/W — the #169 / #172 bug).
+        # B/T got flipped instead of H/W - the #169 / #172 bug).
         assert not np.array_equal(wire_image[0, 0, 0, 0], [123, 45, 67])
 
     def test_action_chunk_unpacks_to_horizon_dicts_with_libero_keys(self):
@@ -376,13 +376,13 @@ class TestWirePayloadDiagnostic:
             payload = pickle.load(f)
 
         # Schema the bisection plan relies on. If any key here changes,
-        # the offline diff script breaks silently — pin it.
+        # the offline diff script breaks silently - pin it.
         assert payload["mode"] == "service"
         assert payload["call_index"] == 0
         assert payload["groot_version"] == "n1.7"
         assert payload["data_config_name"] == "libero_panda"
         # Observation must be the wire-format dict (flat keys, post
-        # newaxis fanout) — what the user wants to diff against the
+        # newaxis fanout) - what the user wants to diff against the
         # local-mode nested dict.
         assert "video.image" in payload["observation"]
         assert payload["observation"]["video.image"].shape == (1, 1, 64, 64, 3)
@@ -412,7 +412,7 @@ class TestWirePayloadDiagnostic:
         files = sorted(p.name for p in tmp_path.iterdir())
         # Only call0 and call1 should land; call2..call4 hit the cap.
         assert files == ["service_call0000.pkl", "service_call0001.pkl"]
-        # Counter sits exactly at the cap — pinned so a future "off-by-one"
+        # Counter sits exactly at the cap - pinned so a future "off-by-one"
         # refactor that drops one dump or writes one extra is caught.
         assert policy._wire_log_call_count == 2
 

--- a/tests/simulation/mujoco/test_recording_paths.py
+++ b/tests/simulation/mujoco/test_recording_paths.py
@@ -198,9 +198,9 @@ def test_b12_multi_episode_resume_appends(sim_with_two_robots, tmp_path):
     r = sim.stop_recording()
     assert r["status"] == "success", r
 
-    # Episode 2 (append — overwrite=False on existing dir must NOT crash)
+    # Episode 2 (append - overwrite=False on existing dir must NOT crash)
     r = sim.start_recording(repo_id="local/multiep", fps=20, root=root, overwrite=False)
-    assert r["status"] == "success", f"B12 regression — resume failed: {r}"
+    assert r["status"] == "success", f"B12 regression - resume failed: {r}"
     sim.run_policy(
         robot_name="alpha",
         policy_provider="mock",
@@ -221,7 +221,7 @@ def test_b12_multi_episode_resume_appends(sim_with_two_robots, tmp_path):
 
 def test_b4_synchronized_multi_robot_recording(sim_with_two_robots, tmp_path):
     """B4 fix: run_multi_policy drives BOTH robots in one synchronized loop and
-    records them into ONE merged frame per timestep — so every frame co-observes
+    records them into ONE merged frame per timestep - so every frame co-observes
     both arms (the whole point of a multi-robot dataset).
 
     Pre-fix, two independent start_policy threads shared the recorder and
@@ -358,7 +358,7 @@ def test_run_multi_policy_action_horizon_batches_inference(sim_with_two_robots, 
     for i in range(len(ds)):
         ac = np.asarray(ds[i]["action"])
         assert float(np.abs(ac[:half]).sum()) > 1e-6 and float(np.abs(ac[half:]).sum()) > 1e-6, (
-            f"frame {i}: a robot's action is zero — batching broke co-observation"
+            f"frame {i}: a robot's action is zero - batching broke co-observation"
         )
 
 

--- a/tests/simulation/mujoco/test_recording_synchronous.py
+++ b/tests/simulation/mujoco/test_recording_synchronous.py
@@ -1,9 +1,9 @@
-"""#191 — Synchronous-mode camera recording tests.
+"""#191 - Synchronous-mode camera recording tests.
 
 The synchronous recorder (:meth:`Simulation.start_cameras_recording_synchronous`)
 returns ``(on_frame, finalize)`` callables instead of spawning a daemon
 thread. Tests here exercise the full lifecycle without requiring a real
-GL context — ``self.render(...)`` is monkey-patched on the Simulation
+GL context - ``self.render(...)`` is monkey-patched on the Simulation
 instance to return a synthetic PNG-encoded result (the same shape
 ``RenderingMixin.render`` produces). This lets the test run on
 CI/dev-box environments that lack X11/EGL while still hitting the buffer
@@ -64,7 +64,7 @@ def _make_render_result(width: int = 32, height: int = 24, fill: int = 128) -> d
 
     The recorder calls ``_extract_frame_ndarray`` on the result, which
     walks ``content[*]["image"]["source"]["bytes"]`` and PIL-decodes
-    the PNG. So the test fixture has to produce real PNG bytes — a
+    the PNG. So the test fixture has to produce real PNG bytes - a
     bare ``b"png"`` placeholder won't decode and the recorder would
     silently increment ``state["errors"][cam]`` instead of buffering
     a frame.
@@ -117,7 +117,7 @@ class TestStartCamerasRecordingSynchronous:
 
     Pinned so the daemon-thread regressions surfaced in #191
     (2-3% capture rate + greenish gradient artifacts under multi-threaded
-    eval) cannot recur silently — any drift in the synchronous-mode
+    eval) cannot recur silently - any drift in the synchronous-mode
     bookkeeping shows up here.
     """
 
@@ -198,7 +198,7 @@ class TestStartCamerasRecordingSynchronous:
             sim.destroy()
 
     def test_finalize_is_idempotent(self):
-        """Calling ``finalize()`` twice is safe — second call returns
+        """Calling ``finalize()`` twice is safe - second call returns
         ``"Was not recording cameras."`` instead of re-flushing or
         crashing. Matches ``stop_cameras_recording``'s contract.
         """
@@ -222,7 +222,7 @@ class TestStartCamerasRecordingSynchronous:
 
     def test_stop_cameras_recording_also_finalizes_sync_mode(self, tmp_path: Path):
         """``stop_cameras_recording`` works equivalently to ``finalize()``
-        for synchronous-mode recordings — useful for callers that don't
+        for synchronous-mode recordings - useful for callers that don't
         keep the closure handle around (e.g. tool-spec dispatch over
         an agent contract that can't return Python callables).
         """
@@ -248,7 +248,7 @@ class TestStartCamerasRecordingSynchronous:
 
     def test_on_frame_swallows_render_errors_into_state_errors(self):
         """A single failing render call should not crash the eval rollout.
-        It increments ``state["errors"][cam]`` instead — the same policy
+        It increments ``state["errors"][cam]`` instead - the same policy
         the daemon-thread recorder uses.
 
         Pinned so a refactor that promotes per-frame failures to
@@ -300,7 +300,7 @@ class TestStartCamerasRecordingSynchronous:
 
             state = sim._cams_rec_state
             assert len(state["buffers"]["cam_a"]) == 3, "buffer must cap at max_frames_per_camera"
-            # Errors stay zero — the cap is a deliberate skip, not a render failure.
+            # Errors stay zero - the cap is a deliberate skip, not a render failure.
             assert state["errors"]["cam_a"] == 0
         finally:
             sim.destroy()

--- a/tests/simulation/mujoco/test_resolve_robot_structured_error.py
+++ b/tests/simulation/mujoco/test_resolve_robot_structured_error.py
@@ -3,7 +3,7 @@
 Before this fix, calling get_robot_state(), run_policy(), or start_policy()
 with robot_name=None in a multi-robot scene raised a raw ValueError instead
 of returning a structured {"status": "error", ...} dict. This broke the
-agent-tool contract where every method returns a dict — agents caught errors
+agent-tool contract where every method returns a dict - agents caught errors
 by inspecting result["status"], not by catching exceptions.
 
 The describe() note also incorrectly stated that get_robot_state required an

--- a/tests/simulation/test_ax2_describe_discovery.py
+++ b/tests/simulation/test_ax2_describe_discovery.py
@@ -209,7 +209,7 @@ class TestNoAlias:
         import strands_robots.registry as registry
 
         assert not hasattr(registry, "get_robot_info"), (
-            "registry must not export 'get_robot_info' — 'get_robot' is the "
+            "registry must not export 'get_robot_info' - 'get_robot' is the "
             "single canonical name. Agents learn it via the discovery surface, "
             "not by aliasing a wrong guess."
         )

--- a/tests/simulation/test_benchmark_predicates.py
+++ b/tests/simulation/test_benchmark_predicates.py
@@ -199,7 +199,7 @@ class TestBodyPositionPredicates:
         assert pred(sim) is False
 
     def test_body_position_libero_main_suffix_fallback(self):
-        """Round 46 (#176 sub-task 3d) — LIBERO objects' BDDL names
+        """Round 46 (#176 sub-task 3d) - LIBERO objects' BDDL names
         (``porcelain_mug_1``) map to MJCF root bodies suffixed with
         ``_main`` (``porcelain_mug_1_main``). The predicate evaluator
         must transparently retry with the suffix when the bare name

--- a/tests/simulation/test_no_import_cycle.py
+++ b/tests/simulation/test_no_import_cycle.py
@@ -44,7 +44,7 @@ def _is_in_type_checking(tree: ast.AST, target: ast.AST) -> bool:
 def _is_inside_function(tree: ast.Module, target: ast.AST) -> bool:
     """True if target_node is inside a function or method body (lazy import).
 
-    Imports inside function/method bodies are deferred — they execute only
+    Imports inside function/method bodies are deferred - they execute only
     when the function is called, not at module import time. These cannot
     cause import-time cycles and should not be flagged.
     """

--- a/tests/simulation/test_policy_runner_benchmark.py
+++ b/tests/simulation/test_policy_runner_benchmark.py
@@ -726,7 +726,7 @@ class TestEvalSeeding:
         """Round 38 (#168): ``_set_eval_seed`` no-ops the torch branch
         when torch isn't importable (mock-policy / minimal-CI installs).
 
-        Pin so the function works on installs without torch — the
+        Pin so the function works on installs without torch - the
         ``ImportError`` should be swallowed silently."""
         import builtins
         import sys
@@ -788,7 +788,7 @@ class TestEvalSeeding:
         assert spec_a.on_step_calls == spec_b.on_step_calls
 
     def test_set_eval_seed_is_public(self):
-        """#179 — ``set_eval_seed`` is part of the public API surface
+        """#179 - ``set_eval_seed`` is part of the public API surface
         (no leading underscore, exported via ``__all__``).
 
         Pre-#179 the function was named ``_set_eval_seed`` and only
@@ -813,7 +813,7 @@ class TestEvalSeeding:
         assert "set_eval_seed" in policy_runner.__all__
 
     def test_set_eval_seed_torch_reproducibility(self):
-        """#179 — ``set_eval_seed`` seeds torch's CPU + CUDA RNGs and
+        """#179 - ``set_eval_seed`` seeds torch's CPU + CUDA RNGs and
         cuDNN flags so the GR00T diffusion sampler (and any other
         ``torch.randn``-driven policy) draws identical sequences across
         runs.
@@ -836,11 +836,11 @@ class TestEvalSeeding:
         assert torch.backends.cudnn.benchmark is False
 
     def test_evaluate_benchmark_reseeds_per_episode(self):
-        """#179 — ``_evaluate_with_spec`` calls ``set_eval_seed`` at the
+        """#179 - ``_evaluate_with_spec`` calls ``set_eval_seed`` at the
         start of EACH episode, not just once before the loop.
 
         Without per-episode reseeding, every torch op draws from a
-        global RNG state that mutates across episodes — so a
+        global RNG state that mutates across episodes - so a
         diffusion-based policy produces different action chunks per
         re-run even at the same ``seed=42`` because torch's RNG state
         depends on the cumulative number of draws across all preceding
@@ -907,7 +907,7 @@ class TestEvalSeeding:
         # identical draws (they're seeded with different episode_seeds
         # derived from the master seed via ``master_rng.randint``).
         assert run_a_draws[0] != run_a_draws[1], (
-            "consecutive episodes drew identical random values — "
+            "consecutive episodes drew identical random values - "
             "per-episode seeding may have used a constant instead of "
             "the per-episode-derived seed"
         )
@@ -994,7 +994,7 @@ class TestPolicyResetIntegration:
     def test_reset_failure_is_swallowed(self, caplog):
         """If ``policy.reset`` raises (e.g. server timeout, client lost
         connection), the eval continues. The exception is logged as a
-        WARNING but the rollout proceeds — eval correctness is preserved
+        WARNING but the rollout proceeds - eval correctness is preserved
         even if per-episode reseed fails."""
         import logging as _logging
 
@@ -1024,7 +1024,7 @@ class TestSpecInstructionFallback:
     Without this, language-conditioned policies (GR00T, OpenVLA) receive
     an empty string as the task description and produce off-task actions.
     GPU bisection on libero-10/SCENE5 confirmed this was the dominant
-    cause of the success_rate gap (0.40 ZMQ vs 1.00 in-process — same
+    cause of the success_rate gap (0.40 ZMQ vs 1.00 in-process - same
     model, same wire format, same engine, but `policy_obs[\"annotation.\"]`
     was `[\"\"]` on the failing path because robots-sim passes
     `instruction=\"\"` to evaluate_benchmark).
@@ -1079,7 +1079,7 @@ class TestSpecInstructionFallback:
         sim = FakeSim()
         policy = _LangPolicy()
         policy.set_robot_state_keys(sim.robot_joint_names("fake_robot"))
-        # No instruction= argument — falls back to spec.instruction.
+        # No instruction= argument - falls back to spec.instruction.
         PolicyRunner(sim).evaluate("fake_robot", policy, spec=_SpecWithInstruction(), n_episodes=1, seed=42)
         assert captured
         assert all(c == "put the white mug on the left plate" for c in captured), f"got {captured!r}"
@@ -1148,7 +1148,7 @@ class TestOnFrameHookForSpec:
         max_steps=20 = 60 calls, indices run 0..59.
 
         Pinned so callers know they can't assume the counter resets per
-        episode — they must track ep boundaries via the per-episode
+        episode - they must track ep boundaries via the per-episode
         results dict if needed.
         """
         captured_steps: list[int] = []
@@ -1169,7 +1169,7 @@ class TestOnFrameHookForSpec:
 
     def test_on_frame_failures_logged_not_fatal(self, caplog):
         """A raising ``on_frame`` is logged WARNING but the rollout
-        continues. The hook is opt-in telemetry — a broken recorder
+        continues. The hook is opt-in telemetry - a broken recorder
         shouldn't crash a 5-episode eval.
 
         Pinned so a future refactor doesn't accidentally promote hook
@@ -1196,7 +1196,7 @@ class TestOnFrameHookForSpec:
         assert len(warnings) == 20, f"expected 20 warnings, got {len(warnings)}"
 
     def test_on_frame_default_none_is_noop(self):
-        """The default ``on_frame=None`` doesn't change behaviour — the
+        """The default ``on_frame=None`` doesn't change behaviour - the
         eval loop runs identically without the hook. Pinned so the
         plumbing addition is a strict superset.
         """

--- a/tests/simulation/test_video_camera_validation.py
+++ b/tests/simulation/test_video_camera_validation.py
@@ -140,7 +140,7 @@ class TestCamerasRecordingSuffixResolution:
         assert "definitely_not_a_camera" in text
 
     def test_mixed_resolvable_and_bogus(self, sim_with_arm):
-        """If any input doesn't resolve, fail loudly — don't silently shrink."""
+        """If any input doesn't resolve, fail loudly - don't silently shrink."""
         r = sim_with_arm.start_cameras_recording(
             cameras=["side", "nope"],
             fps=5,

--- a/tests/test_customer_workflow_regressions.py
+++ b/tests/test_customer_workflow_regressions.py
@@ -91,7 +91,7 @@ class TestSimulationIsCallable:
         try:
             result = sim(action="")
             assert result["status"] == "error"
-            # No raise — structured error per AgentTool contract.
+            # No raise - structured error per AgentTool contract.
             assert "action" in result["content"][0]["text"].lower()
         finally:
             sim.destroy()
@@ -127,7 +127,7 @@ class TestReadmeParamAliases:
         try:
             # README used camera_names=; canonical is cameras=. The alias must
             # not produce an "unknown parameter" error. (We don't assert the
-            # recording fully succeeds — just that the alias is routed.)
+            # recording fully succeeds - just that the alias is routed.)
             result = sim(action="start_cameras_recording", camera_names=["default"], output_dir=str(tmp_path))
             text = result["content"][0]["text"].lower()
             assert "unknown parameter" not in text, result
@@ -167,7 +167,7 @@ class TestCalibrationAutoMigration:
 
         assert new.is_file(), "legacy cal file should have been copied to new path"
         assert new.read_text() == '{"calib": true}'
-        # Copy, not move — old path still present for old lerobot installs.
+        # Copy, not move - old path still present for old lerobot installs.
         assert old.is_file()
 
     def test_noop_when_new_path_exists(self, tmp_path):

--- a/tests/test_device_connect_all_robots.py
+++ b/tests/test_device_connect_all_robots.py
@@ -541,7 +541,7 @@ class TestEdgeCases:
             assert "metadata" not in result["joints"] or isinstance(result["joints"].get("metadata"), float)
 
     def test_max_joint_robot(self):
-        """unitree_g1 (46 joints) — all joints appear in getState."""
+        """unitree_g1 (46 joints) - all joints appear in getState."""
         info = _REGISTRY["unitree_g1"]
         robot = _make_mock_robot("unitree_g1", info, task_status="running")
         driver = RobotDeviceDriver(robot)
@@ -549,7 +549,7 @@ class TestEdgeCases:
         assert len(result["joints"]) == 46
 
     def test_min_joint_robot(self):
-        """koch (7 joints) — correct joint count."""
+        """koch (7 joints) - correct joint count."""
         info = _REGISTRY["koch"]
         robot = _make_mock_robot("koch", info, task_status="running")
         driver = RobotDeviceDriver(robot)

--- a/tests/test_device_connect_drivers.py
+++ b/tests/test_device_connect_drivers.py
@@ -94,7 +94,7 @@ _mock_keys = (
     "device_connect_edge.device",
 )
 # Also track strands_robots.device_connect submodules that will be imported
-# with the mocked base class — they need to be purged so later tests re-import
+# with the mocked base class - they need to be purged so later tests re-import
 # with the real base class.
 _strands_dc_keys = [k for k in sys.modules if k.startswith("strands_robots.device_connect")]
 for _key in list(_mock_keys) + _strands_dc_keys:
@@ -126,7 +126,7 @@ def teardown_module():
             sys.modules.pop(key, None)
         else:
             sys.modules[key] = original
-    # Purge ALL strands_robots.device_connect submodules — they were imported
+    # Purge ALL strands_robots.device_connect submodules - they were imported
     # with the mock DeviceDriver base class and must be re-imported fresh.
     for key in list(sys.modules):
         if key.startswith("strands_robots.device_connect"):
@@ -763,7 +763,7 @@ class TestRobotMeshToolDeviceConnect(unittest.TestCase):
         # picked up without a re-import. Deleting + re-importing robot_mesh would
         # create a second module object and break sibling test files
         # (test_robot_mesh_tool / _security / deep_mesh) that hold a reference to
-        # the original module — their _resolve_mesh patches would miss.
+        # the original module - their _resolve_mesh patches would miss.
 
     def tearDown(self):
         for mod, saved in self._saved_modules.items():

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -51,7 +51,7 @@ class TestDoctorChecks:
         from strands_robots.doctor import check_cuda
 
         result = check_cuda()
-        # Should be one of PASS, WARN, or FAIL — never crash
+        # Should be one of PASS, WARN, or FAIL - never crash
         assert any(x in result for x in ("PASS", "WARN", "FAIL"))
 
     def test_check_hf_auth_with_token(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_examples_no_lerobot_imports.py
+++ b/tests/test_examples_no_lerobot_imports.py
@@ -5,7 +5,7 @@ strands_robots abstraction, not bypass it. Any ``from lerobot`` or
 ``import lerobot`` at the top-level of an example file is a documentation
 failure: it teaches users to skip the SDK and wire lerobot manually.
 
-Internal helper directories (like examples/lerobot/) are excluded — only
+Internal helper directories (like examples/lerobot/) are excluded - only
 top-level example scripts are checked.
 """
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,4 +1,4 @@
-"""Tests for strands_robots.registry — tests for loader, policies, and robots modules."""
+"""Tests for strands_robots.registry - tests for loader, policies, and robots modules."""
 
 import pytest
 
@@ -21,7 +21,7 @@ from strands_robots.registry.robots import (
 
 
 class TestLoader:
-    """loader.py — JSON loading, caching, hot-reload, and validation."""
+    """loader.py - JSON loading, caching, hot-reload, and validation."""
 
     def test_load_caches_and_returns_same_object(self):
         """Consecutive loads without file change should return cached data."""
@@ -302,7 +302,7 @@ class TestBuildPolicyKwargs:
 
 
 class TestRobotRegistry:
-    """robots.py — resolve, query, filter, and format robot definitions."""
+    """robots.py - resolve, query, filter, and format robot definitions."""
 
     def test_resolve_name_canonical(self):
         assert resolve_name("so100") == "so100"

--- a/tests/test_registry_integrity.py
+++ b/tests/test_registry_integrity.py
@@ -1,4 +1,4 @@
-"""Registry integrity tests — catch silent regressions in robots.json.
+"""Registry integrity tests - catch silent regressions in robots.json.
 
 These tests enforce invariants on the robot registry that prevent classes
 of bugs like the one flagged by @awsarron on PR #84 review (2026-04-21):
@@ -33,9 +33,9 @@ def test_every_robot_declares_auto_download_strategy(registry: dict) -> None:
     """Every robot with an ``asset`` block must declare HOW it gets auto-downloaded.
 
     Valid options (exactly one required):
-        1. ``asset.robot_descriptions_module`` — the robot_descriptions pip module name.
-        2. ``asset.source`` with ``type: "github"`` — custom GitHub source block.
-        3. ``asset.auto_download: false`` — explicit opt-out (user must supply assets).
+        1. ``asset.robot_descriptions_module`` - the robot_descriptions pip module name.
+        2. ``asset.source`` with ``type: "github"`` - custom GitHub source block.
+        3. ``asset.auto_download: false`` - explicit opt-out (user must supply assets).
 
     Without one of these, auto-download silently falls through to the
     naming-convention heuristic, which fails for most robots and only
@@ -45,7 +45,7 @@ def test_every_robot_declares_auto_download_strategy(registry: dict) -> None:
     for name, info in registry.items():
         asset = info.get("asset")
         if not asset:
-            continue  # No asset block — nothing to auto-download.
+            continue  # No asset block - nothing to auto-download.
 
         has_rd = "robot_descriptions_module" in asset
         has_source = isinstance(asset.get("source"), dict) and asset["source"].get("type") == "github"
@@ -103,7 +103,7 @@ def _collect_aliases(registry: dict) -> dict[str, str]:
 
 
 def test_aliases_unique_across_registry(registry: dict) -> None:
-    """No two robots may declare the same alias — last-loaded would silently win."""
+    """No two robots may declare the same alias - last-loaded would silently win."""
     seen: dict[str, str] = {}
     collisions: list[str] = []
     for name, info in registry.items():
@@ -118,7 +118,7 @@ def test_no_alias_shadows_canonical_name(registry: dict) -> None:
     """An alias must not equal the canonical name of another robot.
 
     Shadowing causes resolution order to silently determine the winner, which
-    is fragile — a future reorder of robots.json could flip which robot a
+    is fragile - a future reorder of robots.json could flip which robot a
     name resolves to.
     """
     canonical = _all_canonical_names(registry)
@@ -133,7 +133,7 @@ def test_no_alias_shadows_canonical_name(registry: dict) -> None:
 def test_hardware_only_robots_declare_lerobot_type(registry: dict) -> None:
     """Robots without an ``asset`` block must still declare a LeRobot hardware type.
 
-    Prevents silent typos in ``hardware.lerobot_type`` — catches a misspelled
+    Prevents silent typos in ``hardware.lerobot_type`` - catches a misspelled
     type during registry expansion rather than at teleop time.
     """
     offenders: list[str] = []
@@ -153,7 +153,7 @@ def test_robot_descriptions_module_names_are_import_safe(registry: dict) -> None
 
     Regression: the downloader's validation regex originally was
     ``^[a-z0-9_]+$``, which rejected the legitimate upstream module
-    ``tiago++_mj_description`` ("skipped: invalid module name") — so tiago_dual
+    ``tiago++_mj_description`` ("skipped: invalid module name") - so tiago_dual
     never linked its assets. '+' is now allowed; this guards both the registry
     entries and the regex staying in sync.
     """

--- a/tests/test_robot_factory.py
+++ b/tests/test_robot_factory.py
@@ -1,4 +1,4 @@
-"""Tests for strands_robots.robot — Robot() factory and list_robots()."""
+"""Tests for strands_robots.robot - Robot() factory and list_robots()."""
 
 import importlib
 
@@ -121,7 +121,7 @@ class TestRobotFactory:
         assert not inspect.isclass(Robot)
 
     def test_default_mode_is_sim(self):
-        """Robot() defaults to sim mode — never accidentally sends to hardware."""
+        """Robot() defaults to sim mode - never accidentally sends to hardware."""
         import inspect
 
         sig = inspect.signature(Robot)
@@ -198,7 +198,7 @@ class TestRobotFactory:
 
 
 class TestRobotRealMode:
-    """Tests for mode='real' path (mocked — no physical hardware)."""
+    """Tests for mode='real' path (mocked - no physical hardware)."""
 
     def test_real_mode_requires_lerobot(self):
         """mode='real' imports lerobot hardware classes."""
@@ -212,7 +212,7 @@ class TestRobotRealMode:
                     Robot("so100", mode="real")
                     mock_hw.assert_called_once()
                 except ImportError:
-                    # lerobot not installed — acceptable in unit CI
+                    # lerobot not installed - acceptable in unit CI
                     pass
 
 
@@ -256,7 +256,7 @@ class TestAutoDetectUSB:
         """Robot without hardware support → skips USB scan."""
         from strands_robots.robot import _auto_detect_mode
 
-        # "panda" may not have hardware support — defaults to sim
+        # "panda" may not have hardware support - defaults to sim
         result = _auto_detect_mode("panda")
         assert result == "sim"
 
@@ -265,7 +265,7 @@ class TestModeNormalization:
     """Mode parameter and STRANDS_ROBOT_MODE env var should agree on case/whitespace."""
 
     def test_mode_param_uppercase_accepted(self):
-        """Robot('so100', mode='SIM') should work — env var path is case-insensitive,
+        """Robot('so100', mode='SIM') should work - env var path is case-insensitive,
         the direct param should be too."""
         pytest.importorskip("mujoco")
         sim = Robot("so100", mode="SIM")
@@ -296,7 +296,7 @@ class TestModeNormalization:
         assert _auto_detect_mode("so100") == "sim"
 
     def test_env_var_auto_is_no_op(self, monkeypatch):
-        """STRANDS_ROBOT_MODE=auto means 'do detection' — same as not setting it.
+        """STRANDS_ROBOT_MODE=auto means 'do detection' - same as not setting it.
         Should not warn."""
         from strands_robots.robot import _auto_detect_mode
 
@@ -327,7 +327,7 @@ class TestUnknownNameRejected:
             Robot("definitely_not_a_robot_xyz", mode="real")
 
     def test_unknown_name_with_urdf_path_does_not_raise(self):
-        """Explicit urdf_path bypasses the registry check — user knows what they
+        """Explicit urdf_path bypasses the registry check - user knows what they
         want, we don't second-guess."""
         pytest.importorskip("mujoco")
         # Use a clearly-bogus path so the underlying load fails (as RuntimeError),
@@ -434,7 +434,7 @@ class TestDashedNameAlias:
 
 class TestCameraErrorMessage:
     """The cameras-in-sim error must NOT recommend the private _dispatch_action
-    method — that's been a recurring review request."""
+    method - that's been a recurring review request."""
 
     def test_camera_error_does_not_leak_private_api(self):
         with pytest.raises(ValueError) as excinfo:
@@ -503,7 +503,7 @@ class TestRealModeConfigDiscovery:
         """Some lerobot subpackages register MULTIPLE robot_types (e.g.
         ``hope_jr/`` registers both ``hope_jr_arm`` and ``hope_jr_hand``;
         ``lekiwi/`` registers both ``lekiwi`` and ``lekiwi_client``).
-        pkgutil-walking handles this naturally — a hand-rolled
+        pkgutil-walking handles this naturally - a hand-rolled
         type→module map would have to special-case each."""
         pytest.importorskip("lerobot.robots.hope_jr")
         from lerobot.robots.config import RobotConfig
@@ -518,21 +518,21 @@ class TestRealModeConfigDiscovery:
 
     def test_so101_config_build_uses_RobotConfig_subclass(self):
         """Regression: lerobot 0.5.x's bare ``SOFollowerConfig`` has no
-        ``id`` field — discovery picks the registered ``SOFollowerRobotConfig``
+        ``id`` field - discovery picks the registered ``SOFollowerRobotConfig``
         subclass that does. (Original SO-100/SO-101 real-mode regression.)"""
         pytest.importorskip("lerobot.robots.so_follower")
         from strands_robots.hardware_robot import Robot as HwRobot
 
-        # Build the config directly via the helper — no hardware connect.
+        # Build the config directly via the helper - no hardware connect.
         hw = HwRobot.__new__(HwRobot)
         hw.tool_name_str = "so101_smoke"
         cfg = hw._create_minimal_config("so101_follower", cameras={}, port="/dev/null", use_degrees=True)
         # Must be the registered subclass (has ``id``), not the bare config.
-        assert hasattr(cfg, "id"), "config has no 'id' — used the wrong subclass"
+        assert hasattr(cfg, "id"), "config has no 'id' - used the wrong subclass"
         assert cfg.id == "so101_smoke"
         assert cfg.port == "/dev/null"
         # The registered subclass for so101 inherits both RobotConfig and
-        # SOFollowerConfig — its name typically ends with `RobotConfig`.
+        # SOFollowerConfig - its name typically ends with `RobotConfig`.
         assert "RobotConfig" in type(cfg).__name__
 
     def test_unitree_g1_config_build_via_discovery(self):
@@ -578,7 +578,7 @@ class TestRealModeConfigDiscovery:
 
         hw = HwRobot.__new__(HwRobot)
         hw.tool_name_str = "so101_smoke"
-        # `robot_ip` and `kp` are G1-only — must not raise on so101.
+        # `robot_ip` and `kp` are G1-only - must not raise on so101.
         cfg = hw._create_minimal_config(
             "so101_follower",
             cameras={},
@@ -978,7 +978,7 @@ class TestRealModeConfigDiscovery:
 
 
 class TestHardwareConfigV040Followups:
-    """v0.4.0 hardware_robot follow-up bundle (#389) — PR #276 review trail."""
+    """v0.4.0 hardware_robot follow-up bundle (#389) - PR #276 review trail."""
 
     def test_cross_robot_kwarg_drop_emits_debug_signal(self, caplog):
         """#294/#297: dropping a forwardable kwarg the target dataclass does

--- a/tests/test_user_registry.py
+++ b/tests/test_user_registry.py
@@ -39,7 +39,7 @@ def _isolate_registry(tmp_path, monkeypatch):
 
     ``STRANDS_BASE_DIR`` controls where ``user_robots.json`` lives.
     ``STRANDS_ASSETS_DIR`` controls where robot asset directories live.
-    The two are independent — the base dir is not derived from the assets dir.
+    The two are independent - the base dir is not derived from the assets dir.
     """
     assets_dir = tmp_path / "assets"
     assets_dir.mkdir()
@@ -301,7 +301,7 @@ class TestLoaderMerge:
 class TestStrandsBaseDirIntegration:
     """Registry file location respects STRANDS_BASE_DIR env var.
 
-    STRANDS_ASSETS_DIR intentionally does NOT move the registry — it only
+    STRANDS_ASSETS_DIR intentionally does NOT move the registry - it only
     controls where asset directories live. See utils.get_base_dir() docstring.
     """
 
@@ -350,7 +350,7 @@ class TestGetAssetsDir:
 class TestGetBaseDir:
     """get_base_dir() returns STRANDS_BASE_DIR or ~/.strands_robots/.
 
-    It is independent of STRANDS_ASSETS_DIR by design — the base dir holds
+    It is independent of STRANDS_ASSETS_DIR by design - the base dir holds
     user metadata (user_robots.json) and should not move just because the
     user repoints the asset cache.
     """

--- a/tests/tools/test_gr00t_container_hardening.py
+++ b/tests/tools/test_gr00t_container_hardening.py
@@ -548,7 +548,7 @@ def test_no_agent_controlled_host_exec_or_path_params():
 
 
 # --------------------------------------------------------------------------- #
-# #384 item 2 — symlink (realpath) resolution in volume safety                 #
+# #384 item 2 - symlink (realpath) resolution in volume safety                 #
 # --------------------------------------------------------------------------- #
 def test_check_volume_safety_resolves_symlink_into_protected_dir(tmp_path):
     """A host symlink whose target is a protected dir must be rejected.

--- a/tests/tools/test_gr00t_inference.py
+++ b/tests/tools/test_gr00t_inference.py
@@ -122,7 +122,7 @@ class TestBuildInferenceCommand:
     def test_shared_required_flags_present_on_all_protocols(self):
         for protocol in ("n1.5", "n1.6", "n1.7"):
             cmd = _build_inference_command(**_common_kwargs(protocol=protocol))
-            # ``--server`` is N1.5/N1.6-only — see test_n17_module_entrypoint
+            # ``--server`` is N1.5/N1.6-only - see test_n17_module_entrypoint
             # for the regression detail.
             if protocol in ("n1.5", "n1.6"):
                 assert "--server" in cmd, protocol

--- a/tests/tools/test_gr00t_pentest_regressions.py
+++ b/tests/tools/test_gr00t_pentest_regressions.py
@@ -167,17 +167,17 @@ def test_ke_matches_specific_shapes() -> None:
     """Direct unit tests for the shapes we explicitly support."""
     # exact equality
     assert rm._ke_matches("foo/bar", "foo/bar") is True
-    # leading **/ — zero or more segments before
+    # leading **/ - zero or more segments before
     assert rm._ke_matches("**/presence", "presence") is True
     assert rm._ke_matches("**/presence", "a/presence") is True
     assert rm._ke_matches("**/presence", "a/b/c/presence") is True
     assert rm._ke_matches("**/presence", "presence/x") is False
-    # trailing /** — prefix or any deeper segments
+    # trailing /** - prefix or any deeper segments
     assert rm._ke_matches("a/safety/**", "a/safety") is True
     assert rm._ke_matches("a/safety/**", "a/safety/event") is True
     assert rm._ke_matches("a/safety/**", "a/safety/x/y") is True
     assert rm._ke_matches("a/safety/**", "b/safety") is False
-    # both ends — middle anywhere in the key
+    # both ends - middle anywhere in the key
     assert rm._ke_matches("**/safety/**", "safety") is True
     assert rm._ke_matches("**/safety/**", "a/safety") is True
     assert rm._ke_matches("**/safety/**", "safety/x") is True

--- a/tests_integ/benchmarks/libero/test_upstream_state_parity.py
+++ b/tests_integ/benchmarks/libero/test_upstream_state_parity.py
@@ -11,7 +11,7 @@ server (``state.x/y/z/roll/pitch/yaw/gripper``).
 These are end-to-end ground-truth tests: if any of the round-31/32/33
 fixes regresses (e.g., a refactor accidentally falls back to body
 xpos for position, or starts duplicating one finger qpos), upstream
-LIBERO won't change but our values will diverge — and these tests
+LIBERO won't change but our values will diverge - and these tests
 will fail loudly.
 
 Why ``tests_integ/`` and not ``tests/``: the upstream comparison
@@ -65,7 +65,7 @@ def _angle_diff_mod_2pi(a: float, b: float) -> float:
 def _build_upstream_env():
     """Build an upstream LIBERO OffScreenRenderEnv and its bddl file path.
 
-    Use ``libero_spatial/task_0`` — this is a goal-on-plate task whose
+    Use ``libero_spatial/task_0`` - this is a goal-on-plate task whose
     BDDL uses only ``And`` + ``On`` predicates which our BDDL parser
     fully supports. (``libero_object`` task 0 uses ``In`` which is an
     upstream alias for ``Inside`` not in our parser's vocabulary; not a
@@ -120,7 +120,7 @@ def _build_our_adapter_at_canonical(task_bddl: str, init_state: np.ndarray):
     adapter = LiberoAdapter.from_text(
         bddl_text,
         # The factory auto-resolves eef_body_name to robot0_right_hand
-        # via _register_default_robot — but only when on_episode_start
+        # via _register_default_robot - but only when on_episode_start
         # runs. For a direct state read we set it explicitly.
         eef_body_name="robot0_right_hand",
         # Auto-generate the scene from BDDL via libero (matches what
@@ -146,7 +146,7 @@ def _build_our_adapter_at_canonical(task_bddl: str, init_state: np.ndarray):
 
 @pytest.mark.timeout(180)
 def test_state_parity_at_canonical_init() -> None:
-    """Round 35 (#168) — primary regression test for the state pipeline.
+    """Round 35 (#168) - primary regression test for the state pipeline.
 
     With both upstream LIBERO and our adapter at the SAME canonical
     init state, ``state.x/y/z/roll/pitch/yaw/gripper`` must match
@@ -154,7 +154,7 @@ def test_state_parity_at_canonical_init() -> None:
 
     Tolerances per round-33 verification:
     - position: 5 mm per axis
-    - orientation: 50 mrad (mod 2π) per axis — extrinsic Euler can
+    - orientation: 50 mrad (mod 2π) per axis - extrinsic Euler can
       flip ±π for the same physical rotation
     - gripper: 1 mm per finger (the canonical at-rest values are
       ±0.0208 with millimeter-scale variation between resets)
@@ -180,7 +180,7 @@ def test_state_parity_at_canonical_init() -> None:
                 f"Round-31 site-source fix may have regressed."
             )
 
-        # Orientation — convert upstream's (xyzw) quat to (wxyz) for
+        # Orientation - convert upstream's (xyzw) quat to (wxyz) for
         # our `_quat_wxyz_to_rpy_xyz` helper, then compare per axis.
         ups_quat_xyzw = upstream_obs["robot0_eef_quat"]
         # robosuite returns xyzw; convert to wxyz.
@@ -215,7 +215,7 @@ def test_state_parity_at_canonical_init() -> None:
             f"Round-32 fix (orientation from body xquat, not site_xmat) may have regressed."
         )
 
-        # Gripper — both fingers must match upstream's per-finger qpos.
+        # Gripper - both fingers must match upstream's per-finger qpos.
         ups_gripper = upstream_obs["robot0_gripper_qpos"]
         ours_gripper = ours_state["gripper"]
         assert len(ours_gripper) == 2, f"state.gripper must be 2-element, got {ours_gripper}"
@@ -227,11 +227,11 @@ def test_state_parity_at_canonical_init() -> None:
                 f"Round-33 two-finger fix may have regressed (duplicate-packing bug)."
             )
 
-        # Sentinel — round 33: the two finger qpos values must have
+        # Sentinel - round 33: the two finger qpos values must have
         # OPPOSITE signs at the canonical at-rest pose. If they're the
         # same sign, the duplicate-packing bug is back.
         assert ours_gripper[0] * ours_gripper[1] < 0, (
-            f"state.gripper {ours_gripper} fingers have same sign — round-33 duplicate-packing bug may have regressed"
+            f"state.gripper {ours_gripper} fingers have same sign - round-33 duplicate-packing bug may have regressed"
         )
     finally:
         sim.destroy()
@@ -293,11 +293,11 @@ def test_state_gripper_joint_names_resolve_in_real_libero_scene() -> None:
 
 @pytest.mark.timeout(300)
 def test_state_parity_after_50_steps_zero_action() -> None:
-    """#171 sub-task 3c — Deep-rollout state parity test.
+    """#171 sub-task 3c - Deep-rollout state parity test.
 
     Drives both upstream ``OffScreenRenderEnv`` and our
     ``MuJoCoSimEngine``-backed adapter with the SAME action sequence
-    (50 steps of zero action — gravity + passive dynamics only) and
+    (50 steps of zero action - gravity + passive dynamics only) and
     asserts state stays within tolerance per step.
 
     The existing ``test_state_parity_at_canonical_init`` validates init
@@ -309,7 +309,7 @@ def test_state_parity_after_50_steps_zero_action() -> None:
 
     Uses zero actions because ANY non-trivial action would route
     through the upstream OSC controller (robosuite native) on one side
-    and our ``_LiberoOSCController`` on the other — a separate test
+    and our ``_LiberoOSCController`` on the other - a separate test
     surface (sub-task 3b). Zero-action drift isolates the
     physics-only path: same init state + same dt + (ideally) same
     model = same trajectory.
@@ -370,7 +370,7 @@ def test_state_parity_after_50_steps_zero_action() -> None:
                 f"state.{axis_name} drift after {n_steps} zero-action steps: "
                 f"{delta:.4f} m > 5 cm tolerance. "
                 f"ours={ours_v:.4f}, upstream={ups_v:.4f}. "
-                f"Trajectory diverges beyond physical-plausibility — "
+                f"Trajectory diverges beyond physical-plausibility - "
                 f"likely a scene XML or OSC controller divergence. "
                 f"See #171 sub-tasks 3a/3b."
             )
@@ -425,7 +425,7 @@ def test_osc_torque_parity_at_identical_state() -> None:
     5. Per-joint torque comparison: rel_err <= 5%.
 
     Without the round-45 swap, every joint's rel_err exceeds
-    100% — j5 in particular saw 4800% in pre-fix probe.
+    100% - j5 in particular saw 4800% in pre-fix probe.
     """
     upstream_env, task_bddl, init_state = _build_upstream_env()
     sim, adapter = _build_our_adapter_at_canonical(task_bddl, init_state)
@@ -465,7 +465,7 @@ def test_osc_torque_parity_at_identical_state() -> None:
             np.array(ups_ctrl.initial_joint),
             atol=1e-9,
             err_msg=(
-                "initial_joint diverges between upstream and ours — round-45 "
+                "initial_joint diverges between upstream and ours - round-45 "
                 "swap-and-restore in _LiberoOSCController.from_sim may have regressed."
             ),
         )
@@ -488,7 +488,7 @@ def test_osc_torque_parity_at_identical_state() -> None:
             np.array(ups_ctrl.goal_ori),
             atol=1e-6,
             err_msg=(
-                "goal_ori diverges after set_goal — likely a regression in "
+                "goal_ori diverges after set_goal - likely a regression in "
                 "the round-45 swap-and-restore that captures initial_ee_ori_mat "
                 "from data at home pose."
             ),
@@ -519,7 +519,7 @@ def test_osc_torque_parity_at_identical_state() -> None:
 
 @pytest.mark.timeout(300)
 def test_state_observation_byte_equivalent_at_canonical_init() -> None:
-    """#176 sub-task 3d — pin every state channel to be byte-equivalent
+    """#176 sub-task 3d - pin every state channel to be byte-equivalent
     (within float precision) between ``MuJoCoSimEngine`` and upstream
     ``OffScreenRenderEnv`` at canonical ``init_states[0]`` for
     libero-10/SCENE5.
@@ -568,7 +568,7 @@ def test_state_observation_byte_equivalent_at_canonical_init() -> None:
 
     import random as _random
 
-    # Upstream `OffScreenRenderEnv` — the ground truth.
+    # Upstream `OffScreenRenderEnv` - the ground truth.
     upstream_env = OffScreenRenderEnv(
         bddl_file_name=task_bddl,
         camera_names=["agentview"],
@@ -642,7 +642,7 @@ def test_state_observation_byte_equivalent_at_canonical_init() -> None:
 
 @pytest.mark.timeout(900)
 def test_libero_10_scene5_mujoco_engine_success_rate() -> None:
-    """Round 46 (#176 sub-task 3d) acceptance — MuJoCoSimEngine reaches
+    """Round 46 (#176 sub-task 3d) acceptance - MuJoCoSimEngine reaches
     success_rate > 0 on libero-10/SCENE5 with in-process Gr00tPolicy.
 
     This is the end-to-end integration test that closes out #176
@@ -746,7 +746,7 @@ def test_libero_10_scene5_mujoco_engine_success_rate() -> None:
     successes = []
     try:
         for ep in range(n_episodes):
-            # #179 — seed Python/NumPy/torch/cuDNN per episode so the
+            # #179 - seed Python/NumPy/torch/cuDNN per episode so the
             # GR00T diffusion sampler is reproducible. Without this,
             # ``success_rate`` varies wildly across runs of the same
             # eval (5-ep variance ranged 0.40-1.00 pre-fix). The
@@ -803,6 +803,6 @@ def test_libero_10_scene5_mujoco_engine_success_rate() -> None:
         f"``mj_saveLastXML``); post-#181 the cache uses the pre-compile MJCF which "
         f"preserves ``<compiler>`` attributes, restoring upstream's body inertias and "
         f"closing the parity gap. If this drops below 1.00, the fix may have "
-        f"regressed — re-check ``_extract_compiled_mjcf`` accessor order and "
+        f"regressed - re-check ``_extract_compiled_mjcf`` accessor order and "
         f"``_LIBERO_MJCF_TRANSFORM_VERSION``."
     )

--- a/tests_integ/mesh/test_mesh_e2e.py
+++ b/tests_integ/mesh/test_mesh_e2e.py
@@ -3,7 +3,7 @@
 Requires the ``[mesh]`` extra: ``pip install -e ".[mesh]"``.
 Skipped automatically when ``eclipse-zenoh`` is not installed.
 
-These tests run two ``Mesh`` instances inside the same process — the
+These tests run two ``Mesh`` instances inside the same process - the
 process-wide session refcounting in :mod:`strands_robots.mesh.session`
 already exercises the multi-process discovery path because both meshes
 publish + subscribe through the same Zenoh session.  Real two-process
@@ -27,7 +27,7 @@ def _enable_mesh(monkeypatch):
 
 
 class _FakeRobot:
-    """Tiny duck-typed robot — just exposes tool_name_str."""
+    """Tiny duck-typed robot - just exposes tool_name_str."""
 
     def __init__(self, name: str = "fakebot") -> None:
         self.tool_name_str = name
@@ -59,7 +59,7 @@ def test_two_meshes_discover_each_other():
         a.stop()
         b.stop()
         # Final ref count should be back to zero.
-        assert session_alive() is False or True  # noqa: E712 — defensive
+        assert session_alive() is False or True  # noqa: E712 - defensive
 
 
 def test_two_meshes_rpc_round_trip():

--- a/tests_integ/test_iot_transport.py
+++ b/tests_integ/test_iot_transport.py
@@ -230,7 +230,7 @@ def test_camera_topic_is_dropped_silently():
     sub = operator.declare_subscriber("strands/+/camera/+", on_msg)
     time.sleep(0.5)
 
-    # Robot tries to publish a camera frame — should be dropped client-side
+    # Robot tries to publish a camera frame - should be dropped client-side
     robot.put(
         f"strands/{_ROBOT_THING_A}/camera/wrist",
         {"v": 1, "data": "fake-jpeg-base64", "shape": [480, 640, 3]},


### PR DESCRIPTION
## Summary

Replaces all em-dash (`—`, U+2014) characters with plain ASCII hyphen-minus (`-`) across docs, source, tests, and examples.

- **158 files** touched, pure 1:1 character substitution, no semantic changes.
- Legitimate **en-dash** (`–`, U+2013) ranges are intentionally left untouched (e.g. `5–10s`, `640×480`, `ray–mesh`, `A–B`).

> Replaces #433 (closed due to merge conflicts; this PR is rebased fresh on `main`).

## Motivation

Aligns with the project's ASCII-only string hygiene rule documented in `AGENTS.md`:

> **No emojis in user-facing strings** - plain ASCII only. Agents read these strings programmatically; exotic Unicode just adds tokenizer noise.

Em-dashes in docstrings, log messages, tool result dicts, and error strings add tokenizer noise and can produce inconsistent rendering across terminals.

## Verification

```
grep -rlP '\x{2014}' --include='*.py' --include='*.md' .   # 0 matches
```

No remaining em-dashes; only intentional en-dash ranges persist.

## Test plan

- [ ] CI lint/format clean (no logic changed)
- [ ] Unit tests pass (string-content only changes)
