### PR TITLE
fix(factory): register sim robot under user's input name, not canonical

### DIFF
--- a/strands_robots/robot.py
+++ b/strands_robots/robot.py
@@ -276,7 +276,7 @@ def Robot(  # noqa: N802 - uppercase by design (factory mimicking a class constr
         from strands_robots.simulation import Simulation
 
         sim = Simulation(
-            tool_name=f"{canonical}_sim",
+            tool_name=f"{name}_sim",
             **kwargs,
         )
 
@@ -288,7 +288,7 @@ def Robot(  # noqa: N802 - uppercase by design (factory mimicking a class constr
                 raise RuntimeError(f"Failed to create sim world for {canonical!r}: {msg}")
 
             add_robot_params: dict[str, Any] = {
-                "robot_name": canonical,
+                "robot_name": name,
                 "data_config": data_config or canonical,
                 "position": position or [0.0, 0.0, 0.0],
             }

--- a/tests/test_robot_factory.py
+++ b/tests/test_robot_factory.py
@@ -1035,3 +1035,82 @@ class TestHardwareConfigV040Followups:
         assert any("torchcodec" in dep and "aarch64" in dep for dep in lerobot_extra), (
             f"[lerobot] extra must pin torchcodec on linux+aarch64 (#378); got {lerobot_extra}"
         )
+
+
+class TestRobotNamePreservesUserInput:
+    """Robot('h1') should register the robot under the user's input name,
+    not the canonical resolved name (unitree_h1). The user should be able
+    to use the name they passed in all subsequent API calls."""
+
+    @pytest.fixture(autouse=True)
+    def _mujoco(self):
+        pytest.importorskip("mujoco")
+
+    def test_alias_preserved_as_instance_name(self):
+        """Robot('h1') registers robot as 'h1', not 'unitree_h1'."""
+        from strands_robots import Robot
+
+        sim = Robot("h1", mesh=False)
+        try:
+            robots = sim.list_robots()
+            assert "h1" in robots, f"Expected 'h1' in {robots}"
+            assert "unitree_h1" not in robots, f"Unexpected 'unitree_h1' in {robots}"
+        finally:
+            sim.destroy()
+
+    def test_get_robot_state_works_with_user_name(self):
+        """get_robot_state(robot_name='h1') succeeds after Robot('h1')."""
+        from strands_robots import Robot
+
+        sim = Robot("h1", mesh=False)
+        try:
+            state = sim.get_robot_state(robot_name="h1")
+            assert state["status"] == "success"
+        finally:
+            sim.destroy()
+
+    def test_robot_joint_names_works_with_user_name(self):
+        """robot_joint_names('g1') returns joints after Robot('g1')."""
+        from strands_robots import Robot
+
+        sim = Robot("g1", mesh=False)
+        try:
+            joints = sim.robot_joint_names("g1")
+            assert len(joints) > 0, "Expected non-empty joint list"
+        finally:
+            sim.destroy()
+
+    def test_canonical_name_still_resolves_model(self):
+        """The model is still loaded from the canonical asset directory."""
+        from strands_robots import Robot
+
+        sim = Robot("go2", mesh=False)
+        try:
+            robots = sim.list_robots()
+            assert "go2" in robots
+            joints = sim.robot_joint_names("go2")
+            assert len(joints) == 12, f"go2 should have 12 joints, got {len(joints)}"
+        finally:
+            sim.destroy()
+
+    def test_so100_unchanged(self):
+        """Robot('so100') still works identically (name == canonical)."""
+        from strands_robots import Robot
+
+        sim = Robot("so100", mesh=False)
+        try:
+            assert "so100" in sim.list_robots()
+            state = sim.get_robot_state(robot_name="so100")
+            assert state["status"] == "success"
+        finally:
+            sim.destroy()
+
+    def test_tool_name_uses_user_input(self):
+        """The tool_name should reflect the user's input, not canonical."""
+        from strands_robots import Robot
+
+        sim = Robot("h1", mesh=False)
+        try:
+            assert sim.tool_name == "h1_sim"
+        finally:
+            sim.destroy()


### PR DESCRIPTION
## Problem

`Robot('h1')` resolves the alias to `unitree_h1` and registers the robot in the simulation under that canonical name. A developer who types `Robot('h1')` then naturally tries `get_robot_state(robot_name='h1')` and gets "not found". They must call `describe()` or `list_robots()` to discover the actual internal name is `unitree_h1`.

Same for `g1` -> `unitree_g1`, `go2` -> `unitree_go2`, etc.

## Fix

Use the user's original input (`name`) as the instance label in the simulation, while continuing to use the canonical name (`canonical`) for `data_config` (model/asset resolution). Two lines changed in `robot.py`:

1. `tool_name=f"{name}_sim"` (was `canonical`)
2. `"robot_name": name` in add_robot_params (was `canonical`)

This means:
- `Robot('h1').list_robots()` -> `['h1']` (was `['unitree_h1']`)
- `get_robot_state(robot_name='h1')` works immediately
- `robot_joint_names('h1')` returns the correct joints
- The correct MJCF assets are still loaded via `data_config='unitree_h1'`

Robots where name == canonical (`so100`, `panda`, `aloha`) are unaffected.

## Tests

6 regression tests added in `TestRobotNamePreservesUserInput` covering:
- Alias preserved as instance name
- get_robot_state with user name
- robot_joint_names with user name  
- Canonical still resolves model correctly
- so100 unchanged
- tool_name reflects user input

Full suite: 4839 passed, 56 skipped, 2 env-only failures (torchcodec/aarch64).