### PR TITLE
fix(sim): surface valid actuator names on action-key errors + propagate failures to run_policy status

### DIFF
--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -412,6 +412,9 @@ class RenderingMixin:
         #367: replaces the prior silent ``continue`` on unresolved action keys.
         De-duplicated via a per-world set so a 50Hz control loop does not spam
         the log -- the operator sees the missing key once and can act on it.
+
+        Includes the actual actuator/joint names from the model so the user
+        knows exactly which keys the scene accepts.
         """
         warned = getattr(self, "_warned_unresolved_keys", None)
         if warned is None:
@@ -421,14 +424,39 @@ class RenderingMixin:
         if dedup in warned:
             return
         warned.add(dedup)
+        # Surface the valid actuator/joint names from the loaded model so
+        # users can self-correct without inspecting the MJCF by hand.
+        valid_names = self._get_valid_action_keys(pfx)
+        hint = f" Valid keys for this robot: {valid_names}" if valid_names else ""
         logger.warning(
-            "[sim] action key %r (prefix=%r) could not be applied: %s. "
-            "The value was dropped. Check the action/joint naming against the "
-            "scene's actuators.",
+            "[sim] action key %r (prefix=%r) could not be applied: %s. The value was dropped.%s",
             key,
             pfx,
             reason,
+            hint,
         )
+
+    def _get_valid_action_keys(self, pfx: str) -> list[str]:
+        """Return actuator names available under the given namespace prefix.
+
+        When ``pfx`` is set (multi-robot), strips the prefix from returned
+        names so the caller sees the short form that ``send_action`` expects.
+        """
+        world = getattr(self, "_world", None)
+        if world is None or getattr(world, "_model", None) is None:
+            return []
+        mj = _ensure_mujoco()
+        model = world._model
+        names: list[str] = []
+        for i in range(model.nu):
+            raw = mj.mj_id2name(model, mj.mjtObj.mjOBJ_ACTUATOR, i)
+            if not raw:
+                continue
+            if pfx and raw.startswith(pfx):
+                names.append(raw[len(pfx) :])
+            elif not pfx:
+                names.append(raw)
+        return names
 
     @staticmethod
     def _actuator_for_joint(model: Any, jnt_id: int, mj: Any) -> int:

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -286,6 +286,10 @@ class MuJoCoSimEngine(
             unresolved = self._unresolved_action_keys
         applied = [k for k in action if k not in unresolved]
         if unresolved:
+            # Surface the actual valid actuator names so the user can
+            # self-correct without inspecting the MJCF by hand.
+            valid_keys = self._get_valid_action_keys(self._world.robots[robot_name].namespace or "")
+            hint = f" Valid keys: {valid_keys}" if valid_keys else ""
             return {
                 "status": "error",
                 "content": [
@@ -294,7 +298,7 @@ class MuJoCoSimEngine(
                             f"Action partially applied: keys {unresolved} could not be "
                             f"resolved to actuators or joints on '{robot_name}'. "
                             f"Applied: {applied}. Use individual joint/actuator names "
-                            f"(e.g. 'shoulder_pan', 'elbow_flex') as dict keys."
+                            f"as dict keys.{hint}"
                         )
                     },
                     {"json": {"unresolved_keys": unresolved, "applied": applied}},

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -414,6 +414,7 @@ class PolicyRunner:
                 control_frequency,
                 n_substeps,
             )
+            _action_errors = 0  # count send_action failures (unresolved keys)
 
             onframe_failure_limit = (
                 max_onframe_failures if max_onframe_failures is not None else _MAX_CONSECUTIVE_ONFRAME_FAILURES
@@ -429,7 +430,9 @@ class PolicyRunner:
                     if step_count >= total_steps:
                         break
 
-                    self.sim.send_action(action_dict, robot_name=robot_name, n_substeps=n_substeps)
+                    _send_result = self.sim.send_action(action_dict, robot_name=robot_name, n_substeps=n_substeps)
+                    if isinstance(_send_result, dict) and _send_result.get("status") == "error":
+                        _action_errors += 1
 
                     if on_frame is not None:
                         try:
@@ -523,6 +526,17 @@ class PolicyRunner:
                     video_path,
                 )
                 text += f"\n⚠️ Video requested but 0 frames captured ({video_path})"
+        # If every send_action call failed (all keys unresolved), the robot
+        # never moved -- report this as an error rather than a false success.
+        if _action_errors > 0 and _action_errors >= step_count and step_count > 0:
+            text += (
+                f"\n\n⚠️ ALL {_action_errors} action steps had unresolved keys "
+                f"-- the robot did not move. Check that the policy's output keys "
+                f"match the robot's actuator names."
+            )
+            return {"status": "error", "content": [{"text": text}]}
+        if _action_errors > 0:
+            text += f"\n\n⚠️ {_action_errors}/{step_count} action steps had unresolved keys."
         return {"status": "success", "content": [{"text": text}]}
 
     # replay(): replay a LeRobotDataset episode

--- a/tests/simulation/mujoco/test_action_key_resolution.py
+++ b/tests/simulation/mujoco/test_action_key_resolution.py
@@ -1,0 +1,140 @@
+"""Regression tests for action key resolution (bugs #2 and #3 from hot-path audit).
+
+Bug #2: When send_action drops ALL action keys (unresolved), run_policy must NOT
+         return status='success'. This catches any policy that produces keys that
+         don't match the robot's actuators.
+
+Bug #3: The error/warning message when action keys are unresolved should enumerate
+         the actual valid actuator names, not hardcoded examples that don't exist
+         on the loaded robot.
+"""
+
+import logging
+from typing import Any
+
+import pytest
+
+from strands_robots.policies.base import Policy
+from strands_robots.simulation.mujoco.simulation import Simulation
+
+
+class _StubbornPolicy(Policy):
+    """A policy that ignores set_robot_state_keys and always emits wrong keys.
+
+    Simulates a misconfigured external policy whose output keys don't match
+    the robot's actuators. This is the failure mode Bug #2 is about.
+    """
+
+    @property
+    def provider_name(self) -> str:
+        return "stubborn_test"
+
+    @property
+    def requires_images(self) -> bool:
+        return False
+
+    def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
+        # Intentionally ignore the correct keys.
+        pass
+
+    async def get_actions(
+        self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any
+    ) -> list[dict[str, Any]]:
+        # Always emit generic keys that don't match so100 actuators.
+        return [{"joint_0": 0.1, "joint_1": 0.2, "joint_2": 0.3, "joint_3": 0.4, "joint_4": 0.5, "joint_5": 0.6}]
+
+
+@pytest.fixture
+def sim():
+    s = Simulation()
+    s.create_world()
+    s.add_robot("so100")
+    return s
+
+
+class TestActionKeyResolution:
+    """Tests that unresolved action keys produce actionable diagnostics."""
+
+    def test_send_action_invalid_keys_returns_error(self, sim):
+        """send_action with keys that don't match any actuator returns error status."""
+        action = {"joint_0": 0.1, "joint_1": 0.2, "joint_2": 0.3}
+        result = sim.send_action(action)
+        assert result["status"] == "error"
+        # All three keys should be unresolved
+        json_block = next((c for c in result["content"] if "json" in c), None)
+        assert json_block is not None
+        assert set(json_block["json"]["unresolved_keys"]) == {"joint_0", "joint_1", "joint_2"}
+
+    def test_send_action_error_shows_valid_keys(self, sim):
+        """The error message should list actual actuator names, not hardcoded examples."""
+        action = {"nonexistent_joint": 1.0}
+        result = sim.send_action(action)
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        # Must NOT contain the old hardcoded examples
+        assert "shoulder_pan" not in text
+        assert "elbow_flex" not in text
+        # Must contain actual so100 actuator names
+        assert "Rotation" in text
+        assert "Pitch" in text
+        assert "Jaw" in text
+
+    def test_send_action_valid_keys_returns_success(self, sim):
+        """send_action with correct actuator names returns success."""
+        action = {"Rotation": 0.5, "Pitch": 0.3}
+        result = sim.send_action(action)
+        assert result["status"] == "success"
+
+    def test_warn_unresolved_includes_valid_names(self, sim, caplog):
+        """The warning log includes valid actuator names for the robot."""
+        with caplog.at_level(logging.WARNING):
+            sim.send_action({"bogus_key": 1.0})
+        # Find the warning about the unresolved key
+        warn_msgs = [r.message for r in caplog.records if "bogus_key" in r.message]
+        assert len(warn_msgs) >= 1
+        msg = warn_msgs[0]
+        # Should list the real actuator names
+        assert "Rotation" in msg
+        assert "Jaw" in msg
+        # Should NOT suggest hardcoded names that don't exist on so100
+        assert "shoulder_pan" not in msg
+        assert "elbow_flex" not in msg
+
+
+class TestPolicyRunnerActionErrors:
+    """Tests that run_policy propagates action-key failures to the final status."""
+
+    def test_stubborn_policy_wrong_keys_reports_error(self, sim):
+        """A policy that ignores set_robot_state_keys must trigger error status."""
+        policy = _StubbornPolicy()
+        result = sim.run_policy(
+            policy_object=policy,
+            duration=0.1,
+            control_frequency=10.0,
+        )
+        # Pre-fix this was "success" (false). Post-fix it must be "error".
+        assert result["status"] == "error"
+        assert "unresolved" in result["content"][0]["text"].lower()
+
+    def test_mock_policy_via_provider_succeeds(self, sim):
+        """MockPolicy via the provider path (keys auto-set) returns success."""
+        result = sim.run_policy(
+            policy_provider="mock",
+            duration=0.1,
+            control_frequency=10.0,
+        )
+        assert result["status"] == "success"
+
+    def test_mock_policy_via_policy_object_succeeds(self, sim):
+        """MockPolicy passed as policy_object (keys auto-set by base) returns success."""
+        from strands_robots.policies.mock import MockPolicy
+
+        policy = MockPolicy()
+        result = sim.run_policy(
+            policy_object=policy,
+            duration=0.1,
+            control_frequency=10.0,
+        )
+        # run_policy calls set_robot_state_keys before the loop, so MockPolicy
+        # gets the correct keys. This must succeed.
+        assert result["status"] == "success"


### PR DESCRIPTION
## Problem

Two related issues in action-key resolution:

1. When `send_action` cannot resolve an action key to an actuator or joint, the error message suggests hardcoded example names (`shoulder_pan`, `elbow_flex`) that **do not exist** on many robots. For example, so100 has `Rotation, Pitch, Elbow, Wrist_Pitch, Wrist_Roll, Jaw` -- the suggested names mislead users into thinking they have the wrong robot loaded rather than wrong key names.

2. `PolicyRunner.run()` discards the return value of `send_action`. When a policy emits action keys that don't match any actuator (e.g. generic `joint_0..joint_5`), every `send_action` call returns `status="error"` but the final `run_policy` result is `status="success"` -- a false positive. The robot does not move, but the caller believes it did.

## Changes

**`rendering.py`** -- `_warn_unresolved_action_key` now queries the MuJoCo model for actual actuator names and includes them in the warning message. New helper `_get_valid_action_keys(pfx)` handles namespace-prefix stripping for multi-robot scenes.

**`simulation.py`** -- The `send_action` error response now includes valid actuator names instead of hardcoded examples.

**`policy_runner.py`** -- `PolicyRunner.run()` tracks how many `send_action` calls returned errors. When ALL actions in a rollout are dropped (zero effective application), the result is `status="error"` with a clear message. Partial failures are noted in the success message.

## Tests

New `tests/simulation/mujoco/test_action_key_resolution.py` with 7 test cases covering:
- Invalid keys return error status with correct unresolved set
- Error message contains actual actuator names, not hardcoded examples
- Valid keys return success
- Warning log includes real actuator names
- A policy that ignores `set_robot_state_keys` triggers error status from `run_policy`
- Normal provider path (keys auto-set) still succeeds
- `policy_object` path (keys auto-set by base) still succeeds

Full suite: 4840 passed, 0 failed (excluding pre-existing torchcodec linkage issues).

## Related

Addresses bugs #2 and #3 from a hot-path audit (action key mismatches in the input-to-action chain).