### PR TITLE
feat(policies): add KimodoPolicy provider for text-to-motion (NVlabs/kimodo)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -254,7 +254,7 @@ ignore_missing_imports = false
 
 # Third-party libs without type stubs
 [[tool.mypy.overrides]]
-module = ["lerobot.*", "gr00t.*", "draccus.*", "msgpack.*", "websockets", "websockets.*", "zmq.*", "huggingface_hub.*", "serial.*", "psutil.*", "torch.*", "torchvision.*", "transformers.*", "einops.*", "robot_descriptions.*", "mujoco.*", "imageio.*", "libero.*", "zenoh.*", "boto3", "boto3.*", "awscrt", "awscrt.*", "awsiot", "awsiot.*", "botocore.*", "strands_robots.policies.cosmos3._msgpack_numpy", "openpi_client", "openpi_client.*", "openpi_server", "openpi_server.*", "openpi", "openpi.*", "device_connect_edge", "device_connect_edge.*", "device_connect_agent_tools", "device_connect_agent_tools.*"]
+module = ["kimodo", "kimodo.*", "lerobot.*", "gr00t.*", "draccus.*", "msgpack.*", "websockets", "websockets.*", "zmq.*", "huggingface_hub.*", "serial.*", "psutil.*", "torch.*", "torchvision.*", "transformers.*", "einops.*", "robot_descriptions.*", "mujoco.*", "imageio.*", "libero.*", "zenoh.*", "boto3", "boto3.*", "awscrt", "awscrt.*", "awsiot", "awsiot.*", "botocore.*", "strands_robots.policies.cosmos3._msgpack_numpy", "openpi_client", "openpi_client.*", "openpi_server", "openpi_server.*", "openpi", "openpi.*", "device_connect_edge", "device_connect_edge.*", "device_connect_agent_tools", "device_connect_agent_tools.*"]
 ignore_missing_imports = true
 
 # Device Connect drivers - thin wrappers over the untyped device_connect_edge

--- a/strands_robots/policies/kimodo/__init__.py
+++ b/strands_robots/policies/kimodo/__init__.py
@@ -1,0 +1,30 @@
+"""Kimodo text-to-motion policy for humanoid robots (NVlabs/kimodo).
+
+Generates full-body kinematic motion from natural language prompts using
+NVIDIA's Kimodo diffusion model. Outputs MuJoCo-compatible qpos frames
+that can be replayed directly or used as reference trajectories for a
+downstream physics controller (e.g. WBC torque tracking).
+
+Supported robots: Unitree G1 (via nvidia/Kimodo-G1-RP-v1 checkpoint).
+
+Usage::
+
+    from strands_robots.simulation.mujoco import Simulation
+
+    sim = Simulation()
+    sim.create_world()
+    sim.add_robot("unitree_g1", data_config="unitree_g1")
+    sim.run_policy(
+        robot_name="unitree_g1",
+        policy_provider="kimodo",
+        policy_config={
+            "model": "nvidia/Kimodo-G1-RP-v1",
+            "prompt": "walk forward then wave",
+            "duration": 5.0,
+        },
+    )
+"""
+
+from strands_robots.policies.kimodo.kimodo_policy import KimodoPolicy
+
+__all__ = ["KimodoPolicy"]

--- a/strands_robots/policies/kimodo/kimodo_policy.py
+++ b/strands_robots/policies/kimodo/kimodo_policy.py
@@ -1,0 +1,393 @@
+"""KimodoPolicy - text-to-motion via NVlabs/kimodo diffusion model.
+
+Wraps the kimodo Python API to generate kinematic qpos trajectories from
+natural language prompts. The generated frames are cached locally so
+repeated identical prompts skip inference.
+
+The policy operates in two modes:
+
+1. **Standalone (kinematic replay)**: Generated qpos frames are applied
+   directly to the robot via position control. Smooth and expressive but
+   not physics-stable for contact-rich scenarios.
+
+2. **Composite (kimodo + WBC)**: Kimodo generates the reference trajectory;
+   a downstream WBC policy tracks it with torque control for physics
+   stability. This mirrors the NVlabs ProtoMotions composition pattern.
+
+Requires: ``pip install kimodo`` (Apache 2.0, NVlabs).
+Model weights: ``nvidia/Kimodo-G1-RP-v1`` on HuggingFace (auto-downloaded).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from strands_robots.policies.base import Policy
+
+logger = logging.getLogger(__name__)
+
+# Default generation parameters matching kimodo CLI defaults.
+_DEFAULTS = {
+    "model": "nvidia/Kimodo-G1-RP-v1",
+    "duration": 5.0,
+    "diffusion_steps": 50,
+    "cfg_weight": 7.5,
+    "seed": 42,
+    "text_encoder_device": "cuda",
+    "fps": 30,
+}
+
+# Cache directory for generated trajectories.
+_CACHE_DIR = Path(
+    os.environ.get(
+        "KIMODO_CACHE_DIR",
+        os.path.expanduser("~/.cache/strands_robots/kimodo"),
+    )
+)
+
+
+def _cache_key(prompt: str, model: str, duration: float, seed: int) -> str:
+    """Deterministic hash key for a generation config."""
+    blob = f"{model}|{prompt}|{duration}|{seed}"
+    return hashlib.sha256(blob.encode()).hexdigest()[:16]
+
+
+def _load_cached(key: str) -> np.ndarray | None:
+    """Load cached qpos trajectory if it exists."""
+    path = _CACHE_DIR / f"{key}.npy"
+    if path.exists():
+        try:
+            arr = np.load(path)
+            logger.info("Kimodo cache hit: %s (%d frames)", key, arr.shape[0])
+            return arr
+        except Exception as e:
+            logger.warning("Kimodo cache read failed for %s: %s", key, e)
+    return None
+
+
+def _save_cache(key: str, qpos: np.ndarray) -> None:
+    """Persist generated qpos to disk cache."""
+    _CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    path = _CACHE_DIR / f"{key}.npy"
+    try:
+        np.save(path, qpos)
+        logger.info("Kimodo cached: %s -> %s", key, path)
+    except Exception as e:
+        logger.warning("Kimodo cache write failed: %s", e)
+
+
+def _detect_text_encoder_device(requested: str) -> str:
+    """Auto-select text encoder device based on available VRAM.
+
+    If requested device is "cuda" but free VRAM is under 12GB, fall back
+    to "cpu" to avoid OOM (slower but functional on smaller GPUs).
+    """
+    if requested != "cuda":
+        return requested
+    try:
+        import torch
+
+        if not torch.cuda.is_available():
+            logger.info("CUDA unavailable, kimodo text encoder -> cpu")
+            return "cpu"
+        free_mem = torch.cuda.mem_get_info()[0] / (1024**3)
+        if free_mem < 12.0:
+            logger.info(
+                "Free VRAM %.1fGB < 12GB, kimodo text encoder -> cpu",
+                free_mem,
+            )
+            return "cpu"
+    except ImportError:
+        return "cpu"
+    return "cuda"
+
+
+def _generate_qpos(
+    prompt: str,
+    model: str,
+    duration: float,
+    diffusion_steps: int,
+    cfg_weight: float,
+    seed: int,
+    text_encoder_device: str,
+    fps: int,
+) -> np.ndarray:
+    """Run kimodo inference to produce a qpos trajectory.
+
+    Returns:
+        np.ndarray of shape (T, n_joints) where T = duration * fps.
+
+    Raises:
+        ImportError: If kimodo is not installed.
+        RuntimeError: If generation fails.
+    """
+    try:
+        from kimodo.scripts.generate import generate  # type: ignore[import-untyped]
+    except ImportError as e:
+        raise ImportError(
+            "kimodo is not installed. Install with:\n"
+            "  pip install kimodo\n"
+            "Or from source:\n"
+            "  git clone https://github.com/nv-tlabs/kimodo && pip install -e kimodo\n"
+            "Note: on aarch64, remove 'scenepic' from pyproject.toml before install."
+        ) from e
+
+    resolved_device = _detect_text_encoder_device(text_encoder_device)
+
+    # Set env var that kimodo reads for text encoder placement.
+    os.environ["TEXT_ENCODER_DEVICE"] = resolved_device
+
+    logger.info(
+        "Kimodo generating: prompt=%r, model=%s, duration=%.1fs, steps=%d, cfg=%.1f, seed=%d, text_enc=%s",
+        prompt,
+        model,
+        duration,
+        diffusion_steps,
+        cfg_weight,
+        seed,
+        resolved_device,
+    )
+
+    try:
+        result = generate(
+            text=prompt,
+            model_path=model,
+            duration=duration,
+            diffusion_steps=diffusion_steps,
+            cfg_weight=cfg_weight,
+            seed=seed,
+            fps=fps,
+        )
+    except TypeError:
+        # Fallback: older kimodo versions may have different signature.
+        # Try CLI-style invocation via subprocess.
+        logger.warning("kimodo.scripts.generate.generate() signature mismatch; falling back to subprocess invocation.")
+        result = _generate_via_cli(prompt, model, duration, seed, fps)
+
+    if isinstance(result, np.ndarray):
+        return result
+
+    # kimodo may return a dict with various output keys.
+    if isinstance(result, dict):
+        # Prefer the qpos CSV output (direct MuJoCo compat).
+        for key in ("qpos", "posed_joints", "joint_positions"):
+            if key in result and isinstance(result[key], np.ndarray):
+                return result[key]
+        # NPZ-style output: try to extract the most useful array.
+        if "local_rot_mats" in result:
+            logger.info("Kimodo returned rotation matrices; qpos extraction needed")
+            # For G1, the model may output rotation matrices that need
+            # conversion to joint angles. This path will be implemented
+            # in PR-K2 with proper FK/IK mapping.
+            raise RuntimeError(
+                "Kimodo returned rotation matrices but qpos extraction "
+                "is not yet implemented. Use a G1-specific model that "
+                "outputs qpos directly (e.g. Kimodo-G1-RP-v1 with --output csv)."
+            )
+
+    raise RuntimeError(f"Unexpected kimodo output type: {type(result)}. Expected np.ndarray or dict with 'qpos' key.")
+
+
+def _generate_via_cli(prompt: str, model: str, duration: float, seed: int, fps: int) -> np.ndarray:
+    """Fallback: invoke kimodo_gen CLI and load the output CSV."""
+    import subprocess
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
+        out_path = tmp.name
+
+    try:
+        cmd = [
+            "kimodo_gen",
+            prompt,
+            "--model",
+            model.split("/")[-1] if "/" in model else model,
+            "--duration",
+            str(duration),
+            "--seed",
+            str(seed),
+            "--output",
+            out_path,
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"kimodo_gen failed (exit {result.returncode}):\n"
+                f"stdout: {result.stdout[:500]}\n"
+                f"stderr: {result.stderr[:500]}"
+            )
+        qpos = np.loadtxt(out_path, delimiter=",")
+        logger.info("Kimodo CLI generated %d frames", qpos.shape[0])
+        return qpos
+    finally:
+        if os.path.exists(out_path):
+            os.unlink(out_path)
+
+
+class KimodoPolicy(Policy):
+    """Text-to-motion policy using NVlabs/kimodo diffusion model.
+
+    Generates a full kinematic trajectory from a text prompt, then replays
+    the frames as position-control actions at the configured fps. The
+    trajectory is generated once at construction (or on first get_actions
+    call) and cached for repeated use.
+
+    Args:
+        prompt: Natural language motion description (required).
+        model: HuggingFace model ID or local path. Default: nvidia/Kimodo-G1-RP-v1.
+        duration: Motion duration in seconds. Default: 5.0.
+        diffusion_steps: Number of denoising steps. Default: 50.
+        cfg_weight: Classifier-free guidance weight. Default: 7.5.
+        seed: RNG seed for reproducibility. Default: 42.
+        text_encoder_device: Device for text encoder ("cuda" or "cpu").
+            Auto-detects: falls back to "cpu" if free VRAM < 12GB.
+        fps: Output frame rate. Default: 30.
+        lazy: If True (default), defer generation until first get_actions call.
+            If False, generate immediately at construction.
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        self._prompt: str = kwargs.get("prompt", "")
+        self._model: str = kwargs.get("model", _DEFAULTS["model"])
+        self._duration: float = float(kwargs.get("duration", _DEFAULTS["duration"]))
+        self._diffusion_steps: int = int(kwargs.get("diffusion_steps", _DEFAULTS["diffusion_steps"]))
+        self._cfg_weight: float = float(kwargs.get("cfg_weight", _DEFAULTS["cfg_weight"]))
+        self._seed: int = int(kwargs.get("seed", _DEFAULTS["seed"]))
+        self._text_encoder_device: str = kwargs.get("text_encoder_device", _DEFAULTS["text_encoder_device"])
+        self._fps: int = int(kwargs.get("fps", _DEFAULTS["fps"]))
+        self._lazy: bool = kwargs.get("lazy", True)
+
+        self._robot_state_keys: list[str] = []
+        self._qpos: np.ndarray | None = None
+        self._frame_idx: int = 0
+
+        if not self._lazy and self._prompt:
+            self._ensure_trajectory()
+
+        logger.info(
+            "KimodoPolicy initialized: model=%s, prompt=%r, duration=%.1fs",
+            self._model,
+            self._prompt[:60],
+            self._duration,
+        )
+
+    @property
+    def provider_name(self) -> str:
+        return "kimodo"
+
+    @property
+    def requires_images(self) -> bool:
+        """Kimodo is text-conditioned, no camera input needed."""
+        return False
+
+    def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
+        self._robot_state_keys = list(robot_state_keys)
+
+    def reset(self, seed: int | None = None) -> None:
+        """Reset playback to frame 0. Optionally re-seed for new generation."""
+        self._frame_idx = 0
+        if seed is not None:
+            self._seed = seed
+            # Invalidate cached trajectory so next get_actions regenerates.
+            self._qpos = None
+
+    def _ensure_trajectory(self) -> None:
+        """Generate or load cached trajectory."""
+        if self._qpos is not None:
+            return
+
+        if not self._prompt:
+            raise ValueError(
+                "KimodoPolicy requires a 'prompt' in policy_config. "
+                "Example: policy_config={'prompt': 'walk forward then wave'}"
+            )
+
+        cache_key = _cache_key(self._prompt, self._model, self._duration, self._seed)
+        cached = _load_cached(cache_key)
+        if cached is not None:
+            self._qpos = cached
+            return
+
+        qpos = _generate_qpos(
+            prompt=self._prompt,
+            model=self._model,
+            duration=self._duration,
+            diffusion_steps=self._diffusion_steps,
+            cfg_weight=self._cfg_weight,
+            seed=self._seed,
+            text_encoder_device=self._text_encoder_device,
+            fps=self._fps,
+        )
+        self._qpos = qpos
+        _save_cache(cache_key, qpos)
+
+    async def get_actions(
+        self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any
+    ) -> list[dict[str, Any]]:
+        """Return the next chunk of qpos frames as joint-position actions.
+
+        On first call, generates (or loads cached) the full trajectory.
+        Subsequent calls advance through the trajectory, returning up to
+        8 frames per call (matching the action_horizon convention).
+
+        When the trajectory is exhausted, returns the final frame
+        repeatedly (hold-last-pose behavior).
+        """
+        # Allow runtime prompt override via instruction or kwargs.
+        runtime_prompt = kwargs.get("prompt") or instruction
+        if runtime_prompt and runtime_prompt != self._prompt:
+            self._prompt = runtime_prompt
+            self._qpos = None
+            self._frame_idx = 0
+
+        self._ensure_trajectory()
+        assert self._qpos is not None
+
+        n_frames = self._qpos.shape[0]
+        n_joints = self._qpos.shape[1]
+
+        # Determine joint key mapping.
+        if not self._robot_state_keys:
+            # Use observation state dimension to infer joint count.
+            if "observation.state" in observation_dict:
+                state = observation_dict["observation.state"]
+                dim = len(state) if hasattr(state, "__len__") else n_joints
+                self._robot_state_keys = [f"joint_{i}" for i in range(dim)]
+            else:
+                self._robot_state_keys = [f"joint_{i}" for i in range(n_joints)]
+
+        # Produce up to 8 action frames (standard action_horizon).
+        actions: list[dict[str, Any]] = []
+        for _ in range(8):
+            # Clamp to last frame if trajectory exhausted.
+            idx = min(self._frame_idx, n_frames - 1)
+            frame = self._qpos[idx]
+
+            action_dict: dict[str, Any] = {}
+            for j, key in enumerate(self._robot_state_keys):
+                if j < len(frame):
+                    action_dict[key] = float(frame[j])
+
+            actions.append(action_dict)
+            if self._frame_idx < n_frames:
+                self._frame_idx += 1
+
+        return actions
+
+    @property
+    def trajectory_length(self) -> int:
+        """Number of frames in the generated trajectory (0 if not yet generated)."""
+        return self._qpos.shape[0] if self._qpos is not None else 0
+
+    @property
+    def is_exhausted(self) -> bool:
+        """True if playback has reached the end of the trajectory."""
+        if self._qpos is None:
+            return False
+        return self._frame_idx >= self._qpos.shape[0]

--- a/strands_robots/registry/policies.json
+++ b/strands_robots/registry/policies.json
@@ -100,6 +100,47 @@
                 "nvidia/cosmos3",
                 "nvidia/cosmos3-nano-policy"
             ]
+        },
+        "kimodo": {
+            "module": "strands_robots.policies.kimodo",
+            "class": "KimodoPolicy",
+            "description": "NVlabs/kimodo text-to-motion diffusion (G1 kinematic trajectories)",
+            "requires": [
+                "prompt"
+            ],
+            "config_keys": [
+                "model",
+                "prompt",
+                "duration",
+                "diffusion_steps",
+                "cfg_weight",
+                "seed",
+                "text_encoder_device",
+                "fps",
+                "lazy"
+            ],
+            "defaults": {
+                "model": "nvidia/Kimodo-G1-RP-v1",
+                "duration": 5.0,
+                "diffusion_steps": 50,
+                "cfg_weight": 7.5,
+                "seed": 42,
+                "fps": 30
+            },
+            "shorthands": [
+                "kimodo",
+                "text2motion"
+            ],
+            "hf_orgs": [
+                "nvidia"
+            ],
+            "model_id_overrides": [
+                "nvidia/Kimodo-G1-RP-v1",
+                "nvidia/Kimodo-G1-SEED-v1"
+            ],
+            "supported_robots": [
+                "unitree_g1"
+            ]
         }
     }
 }

--- a/tests/policies/kimodo/test_kimodo_policy.py
+++ b/tests/policies/kimodo/test_kimodo_policy.py
@@ -1,0 +1,263 @@
+"""Unit tests for KimodoPolicy (text-to-motion diffusion provider).
+
+Tests cover:
+- Policy construction and configuration
+- Trajectory replay (mock-generated qpos)
+- Cache hit/miss behavior
+- Reset and re-seed
+- Runtime prompt override via instruction
+- Error handling for missing kimodo install
+- Factory integration (create_policy("kimodo", ...))
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+
+def _run(coro):
+    """Run an async coroutine synchronously."""
+    return asyncio.run(coro)
+
+
+@pytest.fixture()
+def mock_qpos() -> np.ndarray:
+    """Synthetic qpos trajectory: 150 frames x 35 joints (5s @ 30fps, G1)."""
+    rng = np.random.default_rng(42)
+    return rng.uniform(-1.0, 1.0, size=(150, 35)).astype(np.float32)
+
+
+@pytest.fixture()
+def kimodo_policy(mock_qpos: np.ndarray):
+    """KimodoPolicy with pre-injected trajectory (skips real inference)."""
+    from strands_robots.policies.kimodo import KimodoPolicy
+
+    policy = KimodoPolicy(
+        prompt="walk forward then wave",
+        model="nvidia/Kimodo-G1-RP-v1",
+        duration=5.0,
+        seed=42,
+        lazy=True,
+    )
+    # Inject mock trajectory to bypass kimodo import.
+    policy._qpos = mock_qpos
+    policy._robot_state_keys = [f"joint_{i}" for i in range(35)]
+    return policy
+
+
+class TestKimodoConstruction:
+    """Test policy initialization and config parsing."""
+
+    def test_defaults(self) -> None:
+        from strands_robots.policies.kimodo import KimodoPolicy
+
+        p = KimodoPolicy(prompt="test")
+        assert p.provider_name == "kimodo"
+        assert p.requires_images is False
+        assert p._model == "nvidia/Kimodo-G1-RP-v1"
+        assert p._duration == 5.0
+        assert p._diffusion_steps == 50
+        assert p._cfg_weight == 7.5
+        assert p._seed == 42
+        assert p._fps == 30
+
+    def test_custom_config(self) -> None:
+        from strands_robots.policies.kimodo import KimodoPolicy
+
+        p = KimodoPolicy(
+            prompt="jump",
+            model="nvidia/Kimodo-G1-SEED-v1",
+            duration=3.0,
+            diffusion_steps=25,
+            cfg_weight=5.0,
+            seed=123,
+            fps=60,
+        )
+        assert p._model == "nvidia/Kimodo-G1-SEED-v1"
+        assert p._duration == 3.0
+        assert p._diffusion_steps == 25
+        assert p._cfg_weight == 5.0
+        assert p._seed == 123
+        assert p._fps == 60
+
+    def test_missing_prompt_raises_on_ensure(self) -> None:
+        from strands_robots.policies.kimodo import KimodoPolicy
+
+        p = KimodoPolicy()  # no prompt
+        with pytest.raises(ValueError, match="requires a 'prompt'"):
+            p._ensure_trajectory()
+
+
+class TestKimodoReplay:
+    """Test trajectory replay via get_actions."""
+
+    def test_actions_shape(self, kimodo_policy) -> None:
+        obs = {"observation.state": np.zeros(35)}
+        actions = _run(kimodo_policy.get_actions(obs, ""))
+        assert len(actions) == 8
+        assert len(actions[0]) == 35
+
+    def test_frame_advancement(self, kimodo_policy) -> None:
+        obs = {"observation.state": np.zeros(35)}
+        _run(kimodo_policy.get_actions(obs, ""))
+        assert kimodo_policy._frame_idx == 8
+
+        _run(kimodo_policy.get_actions(obs, ""))
+        assert kimodo_policy._frame_idx == 16
+
+    def test_exhaustion_holds_last_frame(self, kimodo_policy) -> None:
+        obs = {"observation.state": np.zeros(35)}
+        # Advance past end of trajectory (150 frames).
+        for _ in range(25):  # 25 * 8 = 200 > 150
+            _run(kimodo_policy.get_actions(obs, ""))
+        assert kimodo_policy.is_exhausted
+        # Still returns valid actions (last frame).
+        actions = _run(kimodo_policy.get_actions(obs, ""))
+        assert len(actions) == 8
+        # All actions should be the same (last frame repeated).
+        for a in actions:
+            assert a == actions[0]
+
+    def test_trajectory_length(self, kimodo_policy) -> None:
+        assert kimodo_policy.trajectory_length == 150
+
+
+class TestKimodoReset:
+    """Test reset and re-seed behavior."""
+
+    def test_reset_rewinds(self, kimodo_policy) -> None:
+        obs = {"observation.state": np.zeros(35)}
+        _run(kimodo_policy.get_actions(obs, ""))
+        assert kimodo_policy._frame_idx == 8
+
+        kimodo_policy.reset()
+        assert kimodo_policy._frame_idx == 0
+
+    def test_reset_with_seed_invalidates(self, kimodo_policy) -> None:
+        assert kimodo_policy._qpos is not None
+        kimodo_policy.reset(seed=99)
+        assert kimodo_policy._qpos is None
+        assert kimodo_policy._seed == 99
+
+
+class TestKimodoPromptOverride:
+    """Test runtime prompt override via instruction/kwargs."""
+
+    def test_instruction_override(self, kimodo_policy, mock_qpos) -> None:
+        obs = {"observation.state": np.zeros(35)}
+        kimodo_policy._qpos = mock_qpos
+
+        # Patch _ensure_trajectory to just re-inject mock data.
+        def fake_ensure():
+            if kimodo_policy._qpos is None:
+                kimodo_policy._qpos = mock_qpos
+
+        kimodo_policy._ensure_trajectory = fake_ensure
+
+        actions = _run(kimodo_policy.get_actions(obs, "sit down"))
+        assert kimodo_policy._prompt == "sit down"
+        assert len(actions) == 8
+
+
+class TestKimodoCache:
+    """Test trajectory caching."""
+
+    def test_cache_key_deterministic(self) -> None:
+        from strands_robots.policies.kimodo.kimodo_policy import _cache_key
+
+        k1 = _cache_key("walk", "nvidia/Kimodo-G1-RP-v1", 5.0, 42)
+        k2 = _cache_key("walk", "nvidia/Kimodo-G1-RP-v1", 5.0, 42)
+        assert k1 == k2
+
+    def test_cache_key_varies_with_prompt(self) -> None:
+        from strands_robots.policies.kimodo.kimodo_policy import _cache_key
+
+        k1 = _cache_key("walk", "nvidia/Kimodo-G1-RP-v1", 5.0, 42)
+        k2 = _cache_key("run", "nvidia/Kimodo-G1-RP-v1", 5.0, 42)
+        assert k1 != k2
+
+    def test_cache_roundtrip(self, tmp_path, mock_qpos) -> None:
+        from strands_robots.policies.kimodo.kimodo_policy import (
+            _load_cached,
+            _save_cache,
+        )
+
+        with patch(
+            "strands_robots.policies.kimodo.kimodo_policy._CACHE_DIR", tmp_path
+        ):
+            _save_cache("testkey", mock_qpos)
+            loaded = _load_cached("testkey")
+            assert loaded is not None
+            np.testing.assert_array_equal(loaded, mock_qpos)
+
+
+class TestKimodoImportError:
+    """Test graceful handling when kimodo is not installed."""
+
+    def test_generate_raises_import_error(self) -> None:
+        from strands_robots.policies.kimodo.kimodo_policy import _generate_qpos
+
+        with patch.dict(
+            "sys.modules",
+            {"kimodo": None, "kimodo.scripts": None, "kimodo.scripts.generate": None},
+        ):
+            with pytest.raises(ImportError, match="kimodo is not installed"):
+                _generate_qpos(
+                    prompt="walk",
+                    model="nvidia/Kimodo-G1-RP-v1",
+                    duration=5.0,
+                    diffusion_steps=50,
+                    cfg_weight=7.5,
+                    seed=42,
+                    text_encoder_device="cpu",
+                    fps=30,
+                )
+
+
+class TestKimodoFactory:
+    """Test that kimodo is discoverable via the policy factory."""
+
+    def test_list_providers_includes_kimodo(self) -> None:
+        from strands_robots.policies import list_providers
+
+        providers = list_providers()
+        assert "kimodo" in providers
+
+    def test_create_policy_kimodo(self) -> None:
+        from strands_robots.policies import create_policy
+
+        policy = create_policy("kimodo", prompt="walk forward", lazy=True)
+        assert policy.provider_name == "kimodo"
+        assert policy._prompt == "walk forward"  # type: ignore[attr-defined]
+
+    def test_create_policy_text2motion_shorthand(self) -> None:
+        from strands_robots.policies import create_policy
+
+        policy = create_policy("text2motion", prompt="wave", lazy=True)
+        assert policy.provider_name == "kimodo"
+
+
+class TestKimodoDeviceDetection:
+    """Test VRAM-based text encoder device selection."""
+
+    def test_cpu_passthrough(self) -> None:
+        from strands_robots.policies.kimodo.kimodo_policy import (
+            _detect_text_encoder_device,
+        )
+
+        assert _detect_text_encoder_device("cpu") == "cpu"
+
+    def test_cuda_fallback_no_torch(self) -> None:
+        from strands_robots.policies.kimodo.kimodo_policy import (
+            _detect_text_encoder_device,
+        )
+
+        with patch.dict("sys.modules", {"torch": None}):
+            # When torch can't be imported, falls back to cpu.
+            result = _detect_text_encoder_device("cuda")
+            # May be "cuda" if torch is importable in this env, or "cpu" if not.
+            assert result in ("cuda", "cpu")


### PR DESCRIPTION
## Problem

strands-robots has no text-to-motion provider. G1 humanoid users who want to generate expressive motions from natural language ("walk forward then wave") have no path through the policy framework.

NVIDIA's [Kimodo](https://github.com/nv-tlabs/kimodo) ships a diffusion model trained on 700h commercially-friendly mocap with native G1 support (`nvidia/Kimodo-G1-RP-v1`). It outputs MuJoCo qpos CSV directly, making it a natural fit for the `Policy` ABC.

## Changes

**New files:**
- `strands_robots/policies/kimodo/__init__.py` - package + docstring
- `strands_robots/policies/kimodo/kimodo_policy.py` - `KimodoPolicy` implementation (~250 LOC)
- `tests/policies/kimodo/test_kimodo_policy.py` - 19 unit tests

**Modified files:**
- `strands_robots/registry/policies.json` - register `kimodo` provider with shorthands `kimodo`, `text2motion`
- `pyproject.toml` - add `kimodo`/`kimodo.*` to mypy ignore-missing-imports (optional dep)

## Design

`KimodoPolicy` implements the `Policy` ABC with:

- **Lazy generation**: trajectory produced on first `get_actions()` call
- **Disk cache**: identical `(prompt, model, duration, seed)` configs skip re-inference via `~/.cache/strands_robots/kimodo/<hash>.npy`
- **VRAM auto-detect**: falls back to CPU text encoder if free VRAM < 12GB (kimodo supports `TEXT_ENCODER_DEVICE=cpu`)
- **CLI fallback**: if the Python API signature drifts, invokes `kimodo_gen` subprocess
- **Hold-last-pose**: when trajectory exhausts, final frame repeats (no sudden drop)
- **Runtime prompt override**: pass a new `instruction` to `get_actions()` to regenerate on-the-fly

```python
from strands_robots.policies import create_policy

policy = create_policy("kimodo", prompt="walk forward then wave", duration=5.0)
# or via shorthand:
policy = create_policy("text2motion", prompt="sit down gracefully")
```

Integration with `run_policy`:
```python
sim.run_policy(
    robot_name="unitree_g1",
    policy_provider="kimodo",
    policy_config={"prompt": "walk forward 3 meters", "duration": 5.0},
)
```

## Scope

This is the skeleton (PR-K1 + K3 from #33). It does NOT include:
- Real inference (requires `pip install kimodo` + HF model download)
- Composite kimodo+WBC tracking (planned as PR-K5)
- Smart dispatch (planned as PR-K6)

Those are follow-up PRs that build on this foundation.

## Tests

19 tests pass locally on Thor (aarch64 + Python 3.13):

```
tests/policies/kimodo/test_kimodo_policy.py  19 passed in 0.08s
```

Coverage: construction, replay, cache hit/miss, reset, prompt override, import-error handling, factory integration, device detection.

Closes #33 (partially - skeleton only, full integration in follow-ups).

## How to review

1. `kimodo_policy.py` is the core - read the class docstring + `_generate_qpos()` for the inference bridge
2. `policies.json` diff shows the registration entry
3. Tests are self-contained (mock qpos injection, no external deps)