### PR TITLE
fix(doctor): exit 1 on failure under NO_COLOR / TERM=dumb

### DIFF
--- a/strands_robots/doctor.py
+++ b/strands_robots/doctor.py
@@ -268,7 +268,11 @@ def run_doctor() -> int:
             result = check_fn()
         except Exception as e:
             result = _fail(f"{name}: unexpected error: {e}")
-        if "FAIL" in result and "\033[31m" in result:
+        # Detect failures via the stable text marker, not the ANSI color code:
+        # under NO_COLOR / TERM=dumb the red escape is absent, so gating on it
+        # silently swallowed failures and returned exit 0 in CI. The "  FAIL  "
+        # prefix is emitted by ``_fail`` in both colored and plain output.
+        if "  FAIL  " in result:
             has_fail = True
         print(result)
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -144,3 +144,28 @@ class TestRunDoctor:
         exit_code = run_doctor()
         assert isinstance(exit_code, int)
         assert exit_code in (0, 1)
+
+    def test_run_doctor_returns_1_on_failure_without_color(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A failing check must yield exit 1 even when color is disabled.
+
+        Regression: ``run_doctor`` previously detected failures by looking for
+        the red ANSI escape code in each check's output. Under ``NO_COLOR`` /
+        ``TERM=dumb`` (typical in CI) the color helpers emit plain text with no
+        escape, so a genuine ``FAIL`` was silently ignored and the command
+        exited 0 while printing "All checks passed". This made ``doctor``
+        useless as a scripted setup gate. The exit code must reflect failures
+        regardless of color support.
+        """
+        from strands_robots import doctor
+
+        # Disable color the same way NO_COLOR / TERM=dumb would at import time.
+        monkeypatch.setattr(doctor, "_NO_COLOR", True)
+        # Force one check to fail deterministically, independent of host setup.
+        monkeypatch.setattr(doctor, "check_sim_smoke", lambda: doctor._fail("forced failure"))
+        # Sanity: with color disabled the failure line carries no ANSI escape.
+        failure_line = doctor.check_sim_smoke()
+        assert "\033[31m" not in failure_line
+        assert "  FAIL  " in failure_line
+
+        exit_code = doctor.run_doctor()
+        assert exit_code == 1


### PR DESCRIPTION
## Problem

`run_doctor()` decided whether any check failed by testing for the **red ANSI escape code** in each check's output line:

```python
if "FAIL" in result and "\033[31m" in result:
    has_fail = True
```

The color helpers already degrade gracefully: under `NO_COLOR=1` or `TERM=dumb` (`_NO_COLOR` true), `_red()` returns plain text with **no** escape sequence. That is exactly the environment where `strands-robots doctor` is most useful, scripted as a setup/CI gate. In that mode a genuine `FAIL` carried no red escape, so `has_fail` stayed `False`: the command printed `All checks passed. Ready to use strands-robots.` and **exited 0 despite real failures**, defeating the entire point of a diagnostic gate.

Reproduction (before):

```
NO_COLOR=1 python -c "
from strands_robots import doctor
doctor.check_sim_smoke = lambda: doctor._fail('forced failure')
print('exit', doctor.run_doctor())"
# ...prints 'All checks passed' and 'exit 0' even though a check failed
```

## Change

Gate on the stable `"  FAIL  "` text marker that `_fail()` emits in **both** colored and plain output, instead of the color-dependent escape code. The exit code now reflects failures regardless of color support, so `doctor` works as a gate under `NO_COLOR` / dumb terminals.

## Tests

Adds `test_run_doctor_returns_1_on_failure_without_color`: disables color (`_NO_COLOR=True`), forces one check to fail, asserts the failure line has no ANSI escape, and asserts `run_doctor()` returns `1`. The test **fails on the pre-fix code** (`assert 0 == 1`) and passes after. Full `tests/test_doctor.py` is green (16 passed); ruff check, ruff format, and mypy are clean on the touched files.