### PR TITLE
test(cli): cover __main__ dispatcher and _async_utils resolver

### DIFF
--- a/tests/test_async_utils.py
+++ b/tests/test_async_utils.py
@@ -1,0 +1,77 @@
+"""Tests for ``strands_robots._async_utils._resolve_coroutine``.
+
+The helper bridges async results into sync call sites and has three
+branches:
+
+    1. plain (non-coroutine) value -> returned unchanged
+    2. coroutine, no running event loop -> ``asyncio.run``
+    3. coroutine, inside a running event loop -> offloaded to the reused
+       single-worker thread executor
+
+Branch 3 (the running-loop offload) was previously uncovered. These
+tests pin all three deterministically without touching any robot or
+simulation surface.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from strands_robots._async_utils import _resolve_coroutine
+
+
+class TestResolveCoroutine:
+    """_resolve_coroutine() - the three resolution branches."""
+
+    def test_plain_value_returned_unchanged(self) -> None:
+        """A non-coroutine value is passed straight through."""
+        sentinel = object()
+        assert _resolve_coroutine(sentinel) is sentinel
+
+    def test_plain_falsy_value_passthrough(self) -> None:
+        """Falsy non-coroutine values must not be mistaken for 'no result'."""
+        assert _resolve_coroutine(0) == 0
+        assert _resolve_coroutine(None) is None
+        assert _resolve_coroutine("") == ""
+
+    def test_coroutine_no_running_loop_uses_asyncio_run(self) -> None:
+        """With no running loop, the coroutine is resolved via asyncio.run."""
+
+        async def produce() -> str:
+            return "resolved-sync"
+
+        assert _resolve_coroutine(produce()) == "resolved-sync"
+
+    def test_coroutine_inside_running_loop_offloads_to_thread(self) -> None:
+        """Inside a running loop, resolution is offloaded to the executor thread.
+
+        Calling asyncio.run() directly here would raise 'cannot be called
+        from a running event loop'; the helper must instead run the
+        coroutine on its worker thread and return the value synchronously.
+        """
+
+        async def inner() -> int:
+            return 42
+
+        async def driver() -> int:
+            # We are inside a running loop here, so this exercises the
+            # get_running_loop()-succeeds (offload) branch.
+            return _resolve_coroutine(inner())
+
+        assert asyncio.run(driver()) == 42
+
+    def test_coroutine_inside_running_loop_propagates_exception(self) -> None:
+        """Exceptions raised inside the offloaded coroutine surface to the caller."""
+
+        async def boom() -> None:
+            raise ValueError("kaboom")
+
+        async def driver() -> None:
+            return _resolve_coroutine(boom())
+
+        try:
+            asyncio.run(driver())
+        except ValueError as exc:
+            assert str(exc) == "kaboom"
+        else:  # pragma: no cover - explicit failure if no exception
+            raise AssertionError("expected ValueError to propagate")

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -1,0 +1,75 @@
+"""Tests for the ``python -m strands_robots <command>`` entry point.
+
+Covers the top-level CLI dispatcher in ``strands_robots/__main__.py``:
+argv handling, the ``doctor`` sub-command hand-off, unknown-command and
+no-command error paths, and their exit codes. The dispatcher is pure
+argv plumbing, so every branch is exercised by monkeypatching ``sys.argv``
+and stubbing the ``doctor`` entry point - no real diagnostics run.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from strands_robots.__main__ import main
+
+
+class TestMainDispatch:
+    """main() - command routing and argv normalisation."""
+
+    def test_no_command_prints_usage_and_exits_1(self, monkeypatch, capsys) -> None:
+        """Bare ``python -m strands_robots`` should print usage and exit 1."""
+        monkeypatch.setattr("sys.argv", ["strands_robots"])
+
+        with pytest.raises(SystemExit) as exc:
+            main()
+
+        assert exc.value.code == 1
+        out = capsys.readouterr().out
+        assert "Usage: python -m strands_robots <command>" in out
+        assert "doctor" in out
+
+    def test_unknown_command_prints_error_and_exits_1(self, monkeypatch, capsys) -> None:
+        """An unrecognised command should report it and exit 1."""
+        monkeypatch.setattr("sys.argv", ["strands_robots", "bogus"])
+
+        with pytest.raises(SystemExit) as exc:
+            main()
+
+        assert exc.value.code == 1
+        out = capsys.readouterr().out
+        assert "Unknown command: bogus" in out
+        assert "Available commands: doctor" in out
+
+    def test_doctor_command_dispatches_to_doctor_main(self, monkeypatch) -> None:
+        """``doctor`` should call doctor.main() exactly once."""
+        calls: list[bool] = []
+        monkeypatch.setattr(
+            "strands_robots.doctor.main",
+            lambda: calls.append(True),
+        )
+        monkeypatch.setattr("sys.argv", ["strands_robots", "doctor"])
+
+        main()
+
+        assert calls == [True]
+
+    def test_doctor_command_strips_subcommand_from_argv(self, monkeypatch) -> None:
+        """The dispatched command name must be removed so sub-parsers see clean args.
+
+        After dispatch, argv[0] is preserved and the ``doctor`` token is gone,
+        with any trailing flags forwarded to the sub-command intact.
+        """
+        seen_argv: list[list[str]] = []
+
+        def fake_doctor_main() -> None:
+            import sys
+
+            seen_argv.append(list(sys.argv))
+
+        monkeypatch.setattr("strands_robots.doctor.main", fake_doctor_main)
+        monkeypatch.setattr("sys.argv", ["strands_robots", "doctor", "--verbose", "extra"])
+
+        main()
+
+        assert seen_argv == [["strands_robots", "--verbose", "extra"]]


### PR DESCRIPTION
## What & Why

Two small pure-Python utility modules carried no (or partial) dedicated unit coverage. This adds hermetic, GPU-less tests that pin their behaviour, matching the recent coverage-hardening pattern (#441, #444, #445, #446).

| Module | Before | After | Notes |
|---|---|---|---|
| `strands_robots/__main__.py` | 0% | 94% | only the `if __name__ == "__main__"` guard (line 29) remains uncovered |
| `strands_robots/_async_utils.py` | 36% | 100% | |

## What is pinned

**`tests/test_main_cli.py`** - the `python -m strands_robots <command>` dispatcher:
- bare invocation prints usage and exits 1
- unknown command reports it and exits 1
- `doctor` hands off to `doctor.main()` exactly once
- argv normalisation: the subcommand token is stripped while `argv[0]` and trailing flags are forwarded to the sub-command intact

**`tests/test_async_utils.py`** - all three branches of `_resolve_coroutine`:
- plain (non-coroutine) passthrough, including the falsy values `0` / `None` / `""` (guards against a "falsy means no result" regression)
- coroutine with **no** running loop -> `asyncio.run`
- coroutine **inside** a running loop -> offloaded to the reused single-worker thread executor (the previously-uncovered branch), plus exception propagation through that offload

## Why these tests are safe

Both modules are pure argv / async plumbing. Tests are hermetic: `__main__` tests monkeypatch `sys.argv` and stub the `doctor` entry point (no real diagnostics run); `_async_utils` tests use only `asyncio`. No optional extras (mujoco / lerobot / device-connect), no robot or simulation surface, no GPU.

## Validation

```
ruff check tests/test_main_cli.py tests/test_async_utils.py      # All checks passed
ruff format --check tests/test_main_cli.py tests/test_async_utils.py  # formatted
pytest tests/test_main_cli.py tests/test_async_utils.py          # 9 passed

coverage (target modules only):
  strands_robots/__main__.py        17    1   94%   29
  strands_robots/_async_utils.py    11    0  100%
```

No production code changes - tests only.

## Scope

Deliberately small and single-purpose: one coherent diff, two test files, two adjacent utility modules. No follow-ups required.