### PR TITLE
docs: show left navigation on the home page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,3 @@
----
-hide:
-  - navigation
----
-
 # Strands Robots
 
 A robot library for [Strands agents](https://strandsagents.com). You name a robot, you get something you can drive - in simulation by default, or on real hardware when you ask for it.

--- a/tests/test_docs_home_navigation.py
+++ b/tests/test_docs_home_navigation.py
@@ -1,0 +1,66 @@
+"""Repo hygiene: keep the docs home page's left navigation enabled.
+
+The MkDocs Material site enables the global navigation sidebar via
+``theme.features`` (``navigation.sections``/``navigation.expand``) in
+``mkdocs.yml``. A page can opt out of that sidebar with a YAML front matter
+block::
+
+    ---
+    hide:
+      - navigation
+    ---
+
+When the home page (``docs/index.md``) carries ``hide: navigation`` the landing
+page renders with no left navigation, so a first-time visitor lands on the site
+with no visible way to browse the rest of the docs. The sidebar is present in
+the built HTML but flagged ``hidden``; every other page shows it.
+
+This guard parses the home page front matter and fails fast if ``navigation``
+is ever re-added to its ``hide`` list. Other pages may legitimately hide
+navigation; this guard is scoped to the landing page only.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HOME_PAGE = REPO_ROOT / "docs" / "index.md"
+
+
+def _hidden_items(md_path: Path) -> list[str]:
+    """Return the ``hide:`` list from a Markdown file's YAML front matter.
+
+    Parses the leading ``---`` fenced block without a YAML dependency: it reads
+    the ``hide:`` key and collects its ``- item`` list entries. Returns an empty
+    list when the file has no front matter or no ``hide`` key.
+    """
+    text = md_path.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        return []
+    end = text.find("\n---", 3)
+    if end == -1:
+        return []
+    items: list[str] = []
+    in_hide = False
+    for raw in text[3:end].splitlines():
+        line = raw.rstrip()
+        if not line:
+            continue
+        if not line.startswith((" ", "\t", "-")):
+            # A new top-level key ends any open ``hide:`` block.
+            in_hide = line.split(":", 1)[0].strip() == "hide"
+            continue
+        if in_hide and line.lstrip().startswith("-"):
+            items.append(line.lstrip()[1:].strip())
+    return items
+
+
+def test_home_page_does_not_hide_navigation() -> None:
+    """docs/index.md must not hide the left navigation sidebar."""
+    assert HOME_PAGE.exists(), f"missing docs home page: {HOME_PAGE}"
+    assert "navigation" not in _hidden_items(HOME_PAGE), (
+        "docs/index.md hides the left navigation via front matter "
+        "(hide: [navigation]); the home page would render with no sidebar to "
+        "browse the rest of the docs. Remove 'navigation' from its hide list."
+    )


### PR DESCRIPTION
## Problem
The MkDocs Material site enables the global navigation sidebar via `theme.features` (`navigation.sections` / `navigation.expand`) in `mkdocs.yml`, so every docs page shows a left navigation tree. The home page is the exception: `docs/index.md` carried a front matter block

```yaml
---
hide:
  - navigation
---
```

which opts the landing page out of that sidebar. A first-time visitor lands on the site with no visible way to browse the rest of the docs. In the built HTML the home page's primary sidebar `div` carries a `hidden` attribute while every other page does not.

## Change
Remove the `hide: [navigation]` front matter from `docs/index.md` so the home page renders the same left navigation as every other page.

## Verification
Strict build (`mkdocs build --strict`) before vs after. The home page's primary sidebar element:

- before: `<div class="md-sidebar md-sidebar--primary" data-md-component="sidebar" data-md-type="navigation" hidden>`
- after:  `<div class="md-sidebar md-sidebar--primary" data-md-component="sidebar" data-md-type="navigation" >`

The `hidden` attribute is gone, matching the rest of the site. Rendered home page before/after:

![home page before vs after](https://github.com/cagataycali/robots/releases/download/docs-home-nav-artifacts/home_nav_compare.png)

## Regression guard
Adds `tests/test_docs_home_navigation.py`, which parses the home page front matter and fails if `navigation` is re-added to its `hide` list. The test fails on the pre-fix file and passes after. Other pages may legitimately hide navigation; the guard is scoped to the landing page only.

Local gate: `ruff check`, `ruff format --check`, `mypy strands_robots tests tests_integ` clean (no new errors), `mkdocs build --strict` succeeds, new test passes.