### PR TITLE
fix(tools): emit ASCII-only strings from serial_tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable behavioural changes to `strands-robots` are logged here. Follows
 [Keep a Changelog](https://keepachangelog.com/) conventions.
 
+## Unreleased - serial_tool ASCII output
+
+### Fixed: emojis in ``serial_tool`` result strings
+
+The ``serial_tool`` agent tool emitted emojis in its result ``text`` fields
+(port listings, read/send summaries, Feetech servo responses, monitor output),
+violating the project's "no emojis in user-facing strings" rule -- agents read
+these strings programmatically, so the glyphs are pure tokenizer noise. All
+result strings are now plain ASCII (``->`` instead of the arrow glyph, ``deg``
+instead of the degree sign). Also removed a dead unused inner helper
+(``send_serial_data``). Behavior tests cover every action branch and pin the
+ASCII-only contract.
+
 ## Unreleased - #385 (Mesh + IoT safety/control-surface hardening)
 
 ### Added: mesh control-surface hardening

--- a/strands_robots/tools/serial_tool.py
+++ b/strands_robots/tools/serial_tool.py
@@ -71,13 +71,6 @@ def serial_tool(
         packet.append(checksum)
         return bytes(packet)
 
-    def send_serial_data(ser: serial.Serial, data_to_send: str | bytes) -> None:
-        """Send data over serial connection."""
-        if isinstance(data_to_send, str):
-            ser.write(data_to_send.encode())
-        else:
-            ser.write(data_to_send)
-
     try:
         if action == "list_ports":
             ports = list_serial_ports()
@@ -85,8 +78,8 @@ def serial_tool(
                 "status": "success",
                 "content": [
                     {
-                        "text": f"📡 Found {len(ports)} serial ports:\n"
-                        + "\n".join([f"• {p['device']} - {p['description']}" for p in ports])
+                        "text": f"Found {len(ports)} serial ports:\n"
+                        + "\n".join([f"- {p['device']} - {p['description']}" for p in ports])
                     }
                 ],
                 "ports": ports,
@@ -124,7 +117,7 @@ def serial_tool(
 
             return {
                 "status": "success",
-                "content": [{"text": f"📥 Read {len(read_data)} bytes:\nHex: {hex_str}\nASCII: {ascii_str}"}],
+                "content": [{"text": f"Read {len(read_data)} bytes:\nHex: {hex_str}\nASCII: {ascii_str}"}],
                 "raw_data": read_data.hex(),
                 "length": len(read_data),
             }
@@ -152,9 +145,7 @@ def serial_tool(
 
             return {
                 "status": "success",
-                "content": [
-                    {"text": f"📤 {sent_text}\n📥 Read {len(read_data)} bytes:\nHex: {hex_str}\nASCII: {ascii_str}"}
-                ],
+                "content": [{"text": f"{sent_text}\nRead {len(read_data)} bytes:\nHex: {hex_str}\nASCII: {ascii_str}"}],
             }
 
         elif action == "feetech_position":
@@ -171,7 +162,7 @@ def serial_tool(
             return {
                 "status": "success",
                 "content": [
-                    {"text": f"🤖 Feetech Motor {motor_id} → Position {position} ({position / 4095 * 360:.1f}°)"}
+                    {"text": f"Feetech Motor {motor_id} -> Position {position} ({position / 4095 * 360:.1f} deg)"}
                 ],
             }
 
@@ -186,7 +177,7 @@ def serial_tool(
             ser.write(packet)
             ser.close()
 
-            return {"status": "success", "content": [{"text": f"🤖 Feetech Motor {motor_id} → Velocity {velocity}"}]}
+            return {"status": "success", "content": [{"text": f"Feetech Motor {motor_id} -> Velocity {velocity}"}]}
 
         elif action == "feetech_ping":
             if motor_id is None:
@@ -204,10 +195,10 @@ def serial_tool(
             if len(response) >= 6:
                 return {
                     "status": "success",
-                    "content": [{"text": f"🟢 Feetech Motor {motor_id} responded: {response.hex().upper()}"}],
+                    "content": [{"text": f"Feetech Motor {motor_id} responded: {response.hex().upper()}"}],
                 }
             else:
-                return {"status": "error", "content": [{"text": f"🔴 Feetech Motor {motor_id} no response"}]}
+                return {"status": "error", "content": [{"text": f"Feetech Motor {motor_id} no response"}]}
 
         elif action == "monitor":
             # Continuous monitoring (limited time for safety)
@@ -230,7 +221,7 @@ def serial_tool(
 
             return {
                 "status": "success",
-                "content": [{"text": f"📊 Monitored {len(monitor_data)} data chunks in 5 seconds"}],
+                "content": [{"text": f"Monitored {len(monitor_data)} data chunks in 5 seconds"}],
                 "monitor_data": monitor_data,
             }
 

--- a/tests/tools/test_serial_tool.py
+++ b/tests/tools/test_serial_tool.py
@@ -1,0 +1,269 @@
+"""Behavior tests for the ``serial_tool`` agent tool.
+
+Covers every action branch (``list_ports``, ``send``, ``read``, ``send_read``,
+the Feetech servo commands, ``monitor``) plus the error paths, with the serial
+layer mocked so the tests run hardware-free. Also pins the project's
+"no emojis in user-facing strings" rule for this tool: every returned ``text``
+must be plain ASCII.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import serial
+
+from strands_robots.tools.serial_tool import serial_tool
+
+
+def _texts(result: dict[str, Any]) -> str:
+    """Concatenate all content ``text`` fields from a tool result."""
+    return "\n".join(item.get("text", "") for item in result.get("content", []))
+
+
+class FakeSerial:
+    """Minimal stand-in for ``serial.Serial`` recording writes and serving reads."""
+
+    def __init__(self, port: str, baudrate: int, timeout: float = 1.0) -> None:
+        self.port = port
+        self.baudrate = baudrate
+        self.timeout = timeout
+        self.writes: list[bytes] = []
+        self.closed = False
+        self._read_queue: list[bytes] = []
+        self.in_waiting = 0
+
+    def queue_read(self, data: bytes) -> None:
+        self._read_queue.append(data)
+
+    def write(self, data: bytes) -> None:
+        self.writes.append(bytes(data))
+
+    def read(self, n: int = 1) -> bytes:
+        if self._read_queue:
+            return self._read_queue.pop(0)
+        return b""
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture
+def fake_serial_factory(monkeypatch):
+    """Patch ``serial.Serial`` to return a configurable FakeSerial instance."""
+    created: list[FakeSerial] = []
+
+    def _make(reads: list[bytes] | None = None, in_waiting: int = 0):
+        def _ctor(port, baudrate, timeout=1.0):
+            inst = FakeSerial(port, baudrate, timeout)
+            for chunk in reads or []:
+                inst.queue_read(chunk)
+            inst.in_waiting = in_waiting
+            created.append(inst)
+            return inst
+
+        monkeypatch.setattr(serial, "Serial", _ctor)
+        return created
+
+    return _make
+
+
+def test_list_ports_formats_discovered_ports(monkeypatch):
+    port = SimpleNamespace(
+        device="/dev/ttyACM0",
+        name="ttyACM0",
+        description="SO-100 arm",
+        manufacturer="1a86",
+        vid=0x1A86,
+        pid=0x7523,
+        serial_number="5AB0181806",
+    )
+    monkeypatch.setattr(serial.tools.list_ports, "comports", lambda: [port])
+
+    result = serial_tool(action="list_ports")
+
+    assert result["status"] == "success"
+    assert result["ports"][0]["device"] == "/dev/ttyACM0"
+    text = _texts(result)
+    assert "Found 1 serial ports" in text
+    assert "/dev/ttyACM0" in text
+    assert text.isascii()
+
+
+def test_missing_port_returns_error():
+    result = serial_tool(action="send", data="hello")
+    assert result["status"] == "error"
+    assert "Port parameter required" in _texts(result)
+
+
+def test_send_hex_data(fake_serial_factory):
+    created = fake_serial_factory()
+    result = serial_tool(action="send", port="/dev/ttyACM0", hex_data="FF FF 01 04")
+    assert result["status"] == "success"
+    assert created[0].writes == [bytes.fromhex("FFFF0104")]
+    assert created[0].closed
+    assert _texts(result).isascii()
+
+
+def test_send_string_data(fake_serial_factory):
+    created = fake_serial_factory()
+    result = serial_tool(action="send", port="/dev/ttyACM0", data="PING")
+    assert result["status"] == "success"
+    assert created[0].writes == [b"PING"]
+
+
+def test_send_without_payload_errors(fake_serial_factory):
+    created = fake_serial_factory()
+    result = serial_tool(action="send", port="/dev/ttyACM0")
+    assert result["status"] == "error"
+    assert "No data or hex_data" in _texts(result)
+    assert created[0].closed
+
+
+def test_read_formats_hex_and_ascii(fake_serial_factory):
+    created = fake_serial_factory(reads=[b"AB\x01"])
+    result = serial_tool(action="read", port="/dev/ttyACM0", read_bytes=8)
+    assert result["status"] == "success"
+    assert result["length"] == 3
+    assert result["raw_data"] == b"AB\x01".hex()
+    text = _texts(result)
+    assert "41 42 01" in text
+    assert "AB\\x01" in text
+    assert text.isascii()
+    assert created[0].closed
+
+
+def test_send_read_round_trip(fake_serial_factory, monkeypatch):
+    monkeypatch.setattr("strands_robots.tools.serial_tool.time.sleep", lambda *_: None)
+    created = fake_serial_factory(reads=[b"OK"])
+    result = serial_tool(action="send_read", port="/dev/ttyACM0", data="Q")
+    assert result["status"] == "success"
+    assert created[0].writes == [b"Q"]
+    text = _texts(result)
+    assert "Sent string: Q" in text
+    assert "4F 4B" in text
+    assert text.isascii()
+
+
+def test_send_read_hex_and_missing_payload(fake_serial_factory, monkeypatch):
+    monkeypatch.setattr("strands_robots.tools.serial_tool.time.sleep", lambda *_: None)
+    created = fake_serial_factory(reads=[b""])
+    ok = serial_tool(action="send_read", port="/dev/ttyACM0", hex_data="01 02")
+    assert ok["status"] == "success"
+    assert created[0].writes == [bytes.fromhex("0102")]
+
+    fake_serial_factory()
+    err = serial_tool(action="send_read", port="/dev/ttyACM0")
+    assert err["status"] == "error"
+    assert "No data to send" in _texts(err)
+
+
+def test_feetech_position_builds_packet(fake_serial_factory):
+    created = fake_serial_factory()
+    result = serial_tool(action="feetech_position", port="/dev/ttyACM0", motor_id=1, position=2048)
+    assert result["status"] == "success"
+    packet = created[0].writes[0]
+    # Header, motor id, instruction WRITE (0x03), Goal_Position addr (0x2A)
+    assert packet[:3] == bytes([0xFF, 0xFF, 0x01])
+    assert packet[4] == 0x03
+    assert packet[5] == 0x2A
+    # Checksum is the last byte and validates the packet body.
+    assert packet[-1] == (~sum(packet[2:-1]) & 0xFF)
+    text = _texts(result)
+    assert "deg" in text
+    assert text.isascii()
+
+
+def test_feetech_position_requires_args(fake_serial_factory):
+    created = fake_serial_factory()
+    result = serial_tool(action="feetech_position", port="/dev/ttyACM0", motor_id=1)
+    assert result["status"] == "error"
+    assert "motor_id and position required" in _texts(result)
+    assert created[0].closed
+
+
+def test_feetech_velocity_builds_packet(fake_serial_factory):
+    created = fake_serial_factory()
+    result = serial_tool(action="feetech_velocity", port="/dev/ttyACM0", motor_id=2, velocity=100)
+    assert result["status"] == "success"
+    packet = created[0].writes[0]
+    assert packet[5] == 0x2E  # Goal_Velocity address
+    assert _texts(result).isascii()
+
+
+def test_feetech_velocity_requires_args(fake_serial_factory):
+    fake_serial_factory()
+    result = serial_tool(action="feetech_velocity", port="/dev/ttyACM0", velocity=100)
+    assert result["status"] == "error"
+    assert "motor_id and velocity required" in _texts(result)
+
+
+def test_feetech_ping_success(fake_serial_factory, monkeypatch):
+    monkeypatch.setattr("strands_robots.tools.serial_tool.time.sleep", lambda *_: None)
+    fake_serial_factory(reads=[bytes([0xFF, 0xFF, 0x01, 0x02, 0x00, 0x00])])
+    result = serial_tool(action="feetech_ping", port="/dev/ttyACM0", motor_id=1)
+    assert result["status"] == "success"
+    assert "responded" in _texts(result)
+    assert _texts(result).isascii()
+
+
+def test_feetech_ping_no_response(fake_serial_factory, monkeypatch):
+    monkeypatch.setattr("strands_robots.tools.serial_tool.time.sleep", lambda *_: None)
+    fake_serial_factory(reads=[b"\x00"])
+    result = serial_tool(action="feetech_ping", port="/dev/ttyACM0", motor_id=1)
+    assert result["status"] == "error"
+    assert "no response" in _texts(result)
+    assert _texts(result).isascii()
+
+
+def test_feetech_ping_requires_motor_id(fake_serial_factory):
+    created = fake_serial_factory()
+    result = serial_tool(action="feetech_ping", port="/dev/ttyACM0")
+    assert result["status"] == "error"
+    assert "motor_id required" in _texts(result)
+    assert created[0].closed
+
+
+def test_monitor_collects_chunks(fake_serial_factory, monkeypatch):
+    monkeypatch.setattr("strands_robots.tools.serial_tool.time.sleep", lambda *_: None)
+    times = iter([0.0, 0.0, 1.0, 10.0, 10.0])
+    monkeypatch.setattr("strands_robots.tools.serial_tool.time.time", lambda: next(times))
+    created = fake_serial_factory(reads=[b"hi"], in_waiting=2)
+    result = serial_tool(action="monitor", port="/dev/ttyACM0")
+    assert result["status"] == "success"
+    assert len(result["monitor_data"]) == 1
+    assert result["monitor_data"][0]["data"] == b"hi".hex()
+    assert _texts(result).isascii()
+    assert created[0].closed
+
+
+def test_unknown_action_returns_error(fake_serial_factory):
+    created = fake_serial_factory()
+    result = serial_tool(action="bogus", port="/dev/ttyACM0")
+    assert result["status"] == "error"
+    text = _texts(result)
+    assert "Unknown action: bogus" in text
+    assert "list_ports" in text
+    assert created[0].closed
+
+
+def test_serial_exception_is_caught(monkeypatch):
+    def _raise(*_a, **_k):
+        raise serial.SerialException("port busy")
+
+    monkeypatch.setattr(serial, "Serial", _raise)
+    result = serial_tool(action="send", port="/dev/ttyACM0", data="x")
+    assert result["status"] == "error"
+    assert "Serial error: port busy" in _texts(result)
+
+
+def test_generic_exception_is_caught(monkeypatch):
+    def _raise(*_a, **_k):
+        raise ValueError("boom")
+
+    monkeypatch.setattr(serial, "Serial", _raise)
+    result = serial_tool(action="send", port="/dev/ttyACM0", data="x")
+    assert result["status"] == "error"
+    assert "Error: boom" in _texts(result)


### PR DESCRIPTION
## Problem

The `serial_tool` agent tool (`strands_robots/tools/serial_tool.py`) returned **emojis in its result `text` fields** across nearly every action: the `list_ports` summary, `read`/`send_read` byte reports, the Feetech servo position/velocity/ping responses, and the `monitor` summary. It also used a non-ASCII arrow glyph and a degree sign in the Feetech position string.

This violates the documented project rule (`AGENTS.md`, "Unicode & String Hygiene"): no emojis in user-facing strings. Tool result dicts are read programmatically by agents, so the glyphs are pure tokenizer noise and can leave orphan combining marks behind. The tool had **0% test coverage**, so nothing pinned the contract.

## Change

- Replace every emoji / non-ASCII glyph in `serial_tool` result strings with plain ASCII (`->` for the arrow, `deg` for the degree sign, `-` for the bullet). No behavioral change beyond the string content; packet building and serial I/O are untouched.
- Remove a dead, never-called inner helper (`send_serial_data`).
- Add `tests/tools/test_serial_tool.py`: 19 behavior tests with the serial layer mocked (hardware- and network-free) covering every action branch (`list_ports`, `send`, `read`, `send_read`, `feetech_position`, `feetech_velocity`, `feetech_ping`, `monitor`) plus the required-arg, unknown-action, and exception paths. Tests assert outputs (packet bytes, hex/ascii formatting, result status) and pin the ASCII-only contract with `text.isascii()`.

## Regression evidence

Run against the pre-fix (emoji) code, the `isascii()` assertions fail (8 failed, 11 passed). After the fix, all 19 pass.

## Coverage

`strands_robots/tools/serial_tool.py`: **0% -> 100%**.

## Tests

19 new tests pass. `ruff check`, `ruff format --check`, and `mypy` are clean for the touched files. CHANGELOG updated. No hardware required.