### PR TITLE
fix(mesh): route teleop InputPublisher through Mesh.publish() chokepoint

### DIFF
--- a/strands_robots/mesh/input.py
+++ b/strands_robots/mesh/input.py
@@ -26,7 +26,6 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from strands_robots.mesh.security import ValidationError, validate_input_frame
-from strands_robots.mesh.session import put
 
 _log_safety_event: Callable[..., None] | None
 try:  # audit is best-effort; never let an import issue break teleop apply
@@ -207,7 +206,12 @@ class InputPublisher:
                     "action": action_dict,
                     "events": events,
                 }
-                put(self.topic, payload)
+                # Route through Mesh.publish() -- the documented single
+                # publish chokepoint -- so this teleop actuation stream is
+                # covered by any audit/telemetry/compression hook landing
+                # there, exactly like sensor/state/command publishers. The
+                # receiver side already goes through self.mesh.subscribe().
+                self.mesh.publish(self.topic, payload)
                 self._seq += 1
                 self._frame_count += 1
             except Exception as exc:

--- a/tests/mesh/test_input_publisher_chokepoint.py
+++ b/tests/mesh/test_input_publisher_chokepoint.py
@@ -1,0 +1,80 @@
+"""InputPublisher must publish teleop frames through Mesh.publish().
+
+Mesh.publish() is documented as the single publish chokepoint so a future
+audit / telemetry / compression hook lands in one place. Every publisher
+(sensors, state, presence, cameras, commands) routes through it. The teleop
+input stream -- remote joint actuation, the most safety-critical publish path
+-- must not be the lone exception that bypasses the chokepoint by calling the
+module-level session.put() directly. These tests pin that contract: a hook on
+Mesh.publish() observes outbound teleop frames.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+from unittest.mock import MagicMock
+
+from strands_robots.mesh.input import InputPublisher
+
+
+class _FakeMesh:
+    """Minimal mesh exposing the publish chokepoint and a peer_id.
+
+    Records every (key, payload) handed to publish() so the test can assert
+    teleop frames went through the chokepoint rather than around it.
+    """
+
+    def __init__(self, peer_id: str = "pub-chokepoint") -> None:
+        self.peer_id = peer_id
+        self.alive = True
+        self.published: list[tuple[str, dict[str, Any]]] = []
+
+    def publish(self, key: str, payload: dict[str, Any]) -> None:
+        self.published.append((key, payload))
+
+
+def _run_publisher(mesh: _FakeMesh, teleop: Any, hz: float = 200.0) -> dict[str, Any]:
+    pub = InputPublisher(mesh, teleop, device_name="leader", method="arm", hz=hz)  # type: ignore[arg-type]
+    pub.start()
+    # Spin until at least one frame is published or a short deadline elapses.
+    deadline = time.time() + 1.0
+    while not mesh.published and time.time() < deadline:
+        time.sleep(0.005)
+    return pub.stop()
+
+
+def test_publisher_routes_frames_through_mesh_publish() -> None:
+    """Frames reach Mesh.publish() on the canonical input topic."""
+    teleop = MagicMock()
+    teleop.get_action.return_value = {"j0": 0.1, "j1": -0.2}
+
+    mesh = _FakeMesh(peer_id="pub-1")
+    stats = _run_publisher(mesh, teleop)
+
+    assert stats["frames"] > 0
+    # The chokepoint -- not the raw module put() -- carried the frames.
+    assert mesh.published, "teleop frames bypassed Mesh.publish() chokepoint"
+    topic, payload = mesh.published[0]
+    assert topic == "strands/pub-1/input/leader"
+    assert payload["peer_id"] == "pub-1"
+    assert payload["device"] == "leader"
+    assert payload["action"] == {"j0": 0.1, "j1": -0.2}
+
+
+def test_publisher_frame_count_matches_chokepoint_calls() -> None:
+    """Every counted frame corresponds to a chokepoint publish (no leakage)."""
+    teleop = MagicMock()
+    teleop.get_action.return_value = {"shoulder_pan": 0.0}
+
+    mesh = _FakeMesh(peer_id="pub-2")
+    pub = InputPublisher(mesh, teleop, device_name="gamepad", method="gamepad", hz=200.0)  # type: ignore[arg-type]
+    pub.start()
+    deadline = time.time() + 1.0
+    while len(mesh.published) < 3 and time.time() < deadline:
+        time.sleep(0.005)
+    stats = pub.stop()
+
+    # Frames the publisher claims it sent all went through the chokepoint.
+    assert stats["frames"] == len(mesh.published)
+    assert all(k == "strands/pub-2/input/gamepad" for k, _ in mesh.published)


### PR DESCRIPTION
## Problem

`Mesh.publish()` is documented as the single publish chokepoint:

> This method simply forwards to `put()` -- it stays as a single chokepoint so a future hook (audit, telemetry, compression) can land in one place.

Every publisher in the mesh routes through it: the sensor loops (pose, health, imu, odom, lidar, hand, map), state/presence, camera frames, and the command/broadcast paths. The one exception is `InputPublisher._publish_loop` in `mesh/input.py`, which called the module-level `session.put()` directly, bypassing the chokepoint.

That exception is the teleop input stream -- remote joint actuation streamed at 50Hz+ and applied to follower hardware via `send_action()`. It is the most safety-critical publish path in the system, yet it was the lone publisher that escaped the very chokepoint intended to give audit/telemetry/compression a single place to observe outbound traffic. A hook added to `Mesh.publish()` today would cover sensors and commands but silently miss live teleop actuation.

## Change

`InputPublisher._publish_loop` now publishes via `self.mesh.publish(self.topic, payload)` instead of the raw module-level `put()`. The publisher is already handed the `Mesh` object (it reads `mesh.peer_id` for the topic), and `InputReceiver` already goes through `self.mesh.subscribe()` / `unsubscribe()`, so this also restores publish/subscribe symmetry across the pair.

This is behavior-preserving on the wire: same topic (`strands/{peer_id}/input/{device}`), same payload, same underlying transport (`Mesh.publish` forwards to the same `put()`). What changes is that the teleop stream now flows through the uniform chokepoint. The now-unused `from ...session import put` import is dropped.

## Tests

Adds `tests/mesh/test_input_publisher_chokepoint.py` pinning the contract: a hook on `Mesh.publish()` observes outbound teleop frames on the canonical input topic, and the publisher's frame count matches the number of chokepoint publishes (no leakage around it).

Verified the regression test fails on pre-fix code:

```
FAILED test_publisher_routes_frames_through_mesh_publish - AssertionError: teleop frames bypassed Mesh.publish() chokepoint
FAILED test_publisher_frame_count_matches_chokepoint_calls - assert 198 == 0
```

and passes after. Full mesh suite green: `1447 passed, 2 skipped`. Lint + mypy clean on the changed files.