### PR TITLE
test(hardware_robot): cover task lifecycle, control loop, and mesh teleop (40% -> 88%)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -345,7 +345,7 @@ warn_return_any = false
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "-v --cov=strands_robots --cov-report=term-missing --strict-markers"
+addopts = "-v --cov=strands_robots --cov-report=term-missing --strict-markers --timeout=120"
 markers = [
     "gpu: requires CUDA GPU and real model weights (run with: pytest -m gpu)",
     "slow: long-running test (deselect with: pytest -m 'not slow')",

--- a/tests/test_hardware_robot_lifecycle.py
+++ b/tests/test_hardware_robot_lifecycle.py
@@ -1,0 +1,678 @@
+"""Behavior tests for the hardware Robot control loop and teleop hot path.
+
+These cover ``strands_robots.hardware_robot.Robot`` without any serial/USB
+hardware: a lightweight in-memory fake stands in for the lerobot robot, and
+the policy is a deterministic stub. The focus is the *hot path* an autonomous
+operator drives -- task lifecycle (start/status/stop), the async execution
+loop (connect -> policy -> observe -> act), the tool ``stream`` dispatch, and
+the mesh teleop publish/receive lifecycle.
+
+A ``Robot`` is built via ``__new__`` + manual attribute wiring (the same
+pattern the existing ``test_robot_factory`` helper tests use) so construction
+never touches ``_initialize_robot``/lerobot hardware drivers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import pytest
+
+from strands_robots.hardware_robot import Robot as HwRobot
+from strands_robots.hardware_robot import RobotTaskState, TaskStatus
+
+
+class _FakeLeRobot:
+    """Minimal stand-in for a connected lerobot Robot.
+
+    Records sent actions and serves a fixed observation. ``is_connected``
+    flips to True on ``connect()`` so the connect path can be exercised
+    without serial traffic.
+    """
+
+    def __init__(self, *, connected: bool = False, calibrated: bool = True) -> None:
+        self.name = "fake_arm"
+        self.robot_type = "fake_arm"
+        self._connected = connected
+        self.is_calibrated = calibrated
+        self.sent_actions: list[dict[str, Any]] = []
+        self.config = type("Cfg", (), {"cameras": {}})()
+
+    @property
+    def is_connected(self) -> bool:
+        return self._connected
+
+    def connect(self, calibrate: bool = False) -> None:
+        self._connected = True
+
+    def disconnect(self) -> None:
+        self._connected = False
+
+    def get_observation(self) -> dict[str, Any]:
+        return {"j0.pos": 0.0, "j1.pos": 0.0}
+
+    def send_action(self, action: dict[str, Any]) -> None:
+        self.sent_actions.append(action)
+
+
+class _StubPolicy:
+    """Deterministic policy: returns a fixed action chunk each step."""
+
+    def __init__(self) -> None:
+        self.state_keys: list[str] | None = None
+
+    def set_robot_state_keys(self, keys: list[str]) -> None:
+        self.state_keys = keys
+
+    async def get_actions(self, observation: dict[str, Any], instruction: str) -> list[dict[str, Any]]:
+        return [{"j0.pos": 0.1}, {"j1.pos": 0.2}]
+
+
+def _make_robot(fake: _FakeLeRobot | None = None, control_frequency: float = 1000.0) -> HwRobot:
+    """Construct a Robot bypassing hardware init."""
+    hw = HwRobot.__new__(HwRobot)
+    hw.tool_name_str = "test_arm"
+    hw.action_horizon = 8
+    hw.data_config = None
+    hw.control_frequency = control_frequency
+    hw.action_sleep_time = 1.0 / control_frequency
+    hw._task_state = RobotTaskState()
+    hw._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="test_arm_executor")
+    hw._shutdown_event = threading.Event()
+    hw.mesh = None
+    hw.peer_id = None
+    hw.robot = fake if fake is not None else _FakeLeRobot()
+    return hw
+
+
+# ---------------------------------------------------------------------------
+# Task lifecycle: start / status / stop state machine
+# ---------------------------------------------------------------------------
+
+
+class TestTaskStatusReporting:
+    def test_idle_status_text(self):
+        hw = _make_robot()
+        result = hw.get_task_status()
+        assert result["status"] == "success"
+        assert "IDLE" in result["content"][0]["text"]
+        hw.cleanup()
+
+    def test_running_status_reports_duration_and_steps(self, monkeypatch):
+        hw = _make_robot()
+        hw._task_state.status = TaskStatus.RUNNING
+        hw._task_state.instruction = "pick cube"
+        hw._task_state.start_time = 100.0
+        hw._task_state.step_count = 7
+        monkeypatch.setattr("strands_robots.hardware_robot.time.time", lambda: 103.5)
+
+        text = hw.get_task_status()["content"][0]["text"]
+        assert "RUNNING" in text
+        assert "pick cube" in text
+        assert "Duration: 3.5s" in text
+        assert "Steps: 7" in text
+        hw.cleanup()
+
+    def test_error_status_includes_error_message(self):
+        hw = _make_robot()
+        hw._task_state.status = TaskStatus.ERROR
+        hw._task_state.error_message = "policy unreachable"
+        text = hw.get_task_status()["content"][0]["text"]
+        assert "ERROR" in text
+        assert "policy unreachable" in text
+        hw.cleanup()
+
+
+class TestStopTask:
+    def test_stop_when_idle_is_noop_success(self):
+        hw = _make_robot()
+        result = hw.stop_task()
+        assert result["status"] == "success"
+        assert "No task running" in result["content"][0]["text"]
+        hw.cleanup()
+
+    def test_stop_running_sets_stopped_and_cancels_future(self):
+        hw = _make_robot()
+        hw._task_state.status = TaskStatus.RUNNING
+        hw._task_state.instruction = "wave"
+
+        cancelled = {"called": False}
+
+        class _Fut:
+            def cancel(self) -> bool:
+                cancelled["called"] = True
+                return True
+
+        hw._task_state.task_future = _Fut()
+        result = hw.stop_task()
+        assert result["status"] == "success"
+        assert hw._task_state.status == TaskStatus.STOPPED
+        assert cancelled["called"] is True
+        hw.cleanup()
+
+
+class TestStartTask:
+    def test_start_when_already_running_returns_error(self):
+        hw = _make_robot()
+        hw._task_state.status = TaskStatus.RUNNING
+        hw._task_state.instruction = "busy"
+        result = hw.start_task("new task", policy_port=5555)
+        assert result["status"] == "error"
+        assert "already running" in result["content"][0]["text"].lower()
+        hw.cleanup()
+
+    def test_start_submits_and_completes(self):
+        fake = _FakeLeRobot()
+        hw = _make_robot(fake)
+
+        captured = {}
+
+        def _fake_sync(instruction, port, host, provider, duration):
+            captured["instruction"] = instruction
+            hw._task_state.status = TaskStatus.COMPLETED
+            return {"status": "success", "content": [{"text": "done"}]}
+
+        hw._execute_task_sync = _fake_sync  # type: ignore[assignment]
+        result = hw.start_task("grab", policy_port=5555, duration=1.0)
+        assert result["status"] == "success"
+        assert "grab" in result["content"][0]["text"]
+        # Wait for the background future to run.
+        hw._task_state.task_future.result(timeout=5)
+        assert captured["instruction"] == "grab"
+        hw.cleanup()
+
+
+# ---------------------------------------------------------------------------
+# Async execution loop: connect -> policy -> observe -> act
+# ---------------------------------------------------------------------------
+
+
+class TestConnectRobot:
+    def test_connect_success_flips_connected(self):
+        fake = _FakeLeRobot(connected=False)
+        hw = _make_robot(fake)
+        ok, err = asyncio.run(hw._connect_robot())
+        assert ok is True
+        assert err == ""
+        assert fake.is_connected is True
+        hw.cleanup()
+
+    def test_connect_already_connected_short_circuits(self):
+        fake = _FakeLeRobot(connected=True)
+        hw = _make_robot(fake)
+        ok, err = asyncio.run(hw._connect_robot())
+        assert ok is True
+        assert err == ""
+        hw.cleanup()
+
+    def test_connect_uncalibrated_returns_error(self):
+        fake = _FakeLeRobot(connected=False, calibrated=False)
+        hw = _make_robot(fake)
+        ok, err = asyncio.run(hw._connect_robot())
+        assert ok is False
+        assert "not calibrated" in err
+        hw.cleanup()
+
+    def test_connect_failure_is_reported(self):
+        fake = _FakeLeRobot(connected=False)
+
+        def _boom(calibrate: bool = False) -> None:
+            raise OSError("port /dev/null busy")
+
+        fake.connect = _boom  # type: ignore[method-assign]
+        hw = _make_robot(fake)
+        ok, err = asyncio.run(hw._connect_robot())
+        assert ok is False
+        assert "connection failed" in err.lower()
+        hw.cleanup()
+
+
+class TestInitializePolicy:
+    def test_filters_camera_keys_from_state_keys(self):
+        fake = _FakeLeRobot()
+        fake.config.cameras = {"wrist": {}}
+
+        def _obs() -> dict[str, Any]:
+            return {"j0.pos": 0.0, "wrist": b"img"}
+
+        fake.get_observation = _obs  # type: ignore[method-assign]
+        hw = _make_robot(fake)
+        policy = _StubPolicy()
+        ok = asyncio.run(hw._initialize_policy(policy))
+        assert ok is True
+        assert policy.state_keys == ["j0.pos"]
+        hw.cleanup()
+
+    def test_returns_false_when_observation_raises(self):
+        fake = _FakeLeRobot()
+
+        def _boom() -> dict[str, Any]:
+            raise RuntimeError("no obs")
+
+        fake.get_observation = _boom  # type: ignore[method-assign]
+        hw = _make_robot(fake)
+        ok = asyncio.run(hw._initialize_policy(_StubPolicy()))
+        assert ok is False
+        hw.cleanup()
+
+
+class TestGetPolicy:
+    def test_missing_port_raises(self):
+        hw = _make_robot()
+        with pytest.raises(ValueError, match="policy_port is required"):
+            asyncio.run(hw._get_policy(policy_port=None))
+        hw.cleanup()
+
+    def test_builds_policy_via_create_policy(self, monkeypatch):
+        hw = _make_robot()
+        hw.data_config = "so101"
+        captured = {}
+
+        def _fake_create(provider, **cfg):
+            captured["provider"] = provider
+            captured["cfg"] = cfg
+            return _StubPolicy()
+
+        monkeypatch.setattr("strands_robots.policies.create_policy", _fake_create)
+        policy = asyncio.run(hw._get_policy(policy_port=5555, policy_host="h", policy_provider="mock"))
+        assert isinstance(policy, _StubPolicy)
+        assert captured["provider"] == "mock"
+        assert captured["cfg"]["port"] == 5555
+        assert captured["cfg"]["host"] == "h"
+        assert captured["cfg"]["data_config"] == "so101"
+        hw.cleanup()
+
+
+class TestExecuteTaskAsync:
+    def test_full_loop_sends_actions_and_completes(self, monkeypatch):
+        fake = _FakeLeRobot(connected=False)
+        hw = _make_robot(fake, control_frequency=1000.0)
+
+        async def _fake_get_policy(*a, **k):
+            return _StubPolicy()
+
+        hw._get_policy = _fake_get_policy  # type: ignore[assignment]
+
+        # Bound the wall-clock loop: first call starts at 0, second exceeds
+        # the 0.05s duration so exactly one iteration of action chunks runs.
+        times = iter([0.0, 0.0, 0.0, 100.0, 100.0, 100.0, 100.0])
+        monkeypatch.setattr(
+            "strands_robots.hardware_robot.time.time",
+            lambda: next(times, 100.0),
+        )
+
+        asyncio.run(hw._execute_task_async("pick", policy_port=5555, duration=0.05))
+        assert hw._task_state.status == TaskStatus.COMPLETED
+        assert len(fake.sent_actions) == 2  # two actions in the policy chunk
+        assert hw._task_state.step_count == 2
+        hw.cleanup()
+
+    def test_connect_failure_sets_error_state(self):
+        fake = _FakeLeRobot(connected=False, calibrated=False)
+        hw = _make_robot(fake)
+        asyncio.run(hw._execute_task_async("pick", policy_port=5555, duration=0.01))
+        assert hw._task_state.status == TaskStatus.ERROR
+        assert "not calibrated" in hw._task_state.error_message
+        hw.cleanup()
+
+    def test_policy_init_failure_sets_error(self, monkeypatch):
+        fake = _FakeLeRobot(connected=True)
+        hw = _make_robot(fake)
+
+        async def _fake_get_policy(*a, **k):
+            return _StubPolicy()
+
+        async def _fail_init(policy):
+            return False
+
+        hw._get_policy = _fake_get_policy  # type: ignore[assignment]
+        hw._initialize_policy = _fail_init  # type: ignore[assignment]
+        asyncio.run(hw._execute_task_async("pick", policy_port=5555, duration=0.01))
+        assert hw._task_state.status == TaskStatus.ERROR
+        assert "Failed to initialize policy" in hw._task_state.error_message
+        hw.cleanup()
+
+
+# ---------------------------------------------------------------------------
+# Tool stream dispatch
+# ---------------------------------------------------------------------------
+
+
+def _drain(agen) -> list:
+    async def _run() -> list:
+        return [ev async for ev in agen]
+
+    return asyncio.run(_run())
+
+
+class TestStreamDispatch:
+    def test_execute_requires_instruction_and_port(self):
+        hw = _make_robot()
+        events = _drain(hw.stream({"toolUseId": "t1", "input": {"action": "execute"}}, {}))
+        result = events[-1].tool_result
+        assert result["status"] == "error"
+        assert "required" in result["content"][0]["text"]
+        hw.cleanup()
+
+    def test_status_action_dispatches(self):
+        hw = _make_robot()
+        events = _drain(hw.stream({"toolUseId": "t2", "input": {"action": "status"}}, {}))
+        result = events[-1].tool_result
+        assert result["status"] == "success"
+        assert "IDLE" in result["content"][0]["text"]
+        hw.cleanup()
+
+    def test_stop_action_dispatches(self):
+        hw = _make_robot()
+        events = _drain(hw.stream({"toolUseId": "t3", "input": {"action": "stop"}}, {}))
+        result = events[-1].tool_result
+        assert result["status"] == "success"
+        hw.cleanup()
+
+    def test_unknown_action_is_error(self):
+        hw = _make_robot()
+        events = _drain(hw.stream({"toolUseId": "t4", "input": {"action": "fly"}}, {}))
+        result = events[-1].tool_result
+        assert result["status"] == "error"
+        assert "Unknown action" in result["content"][0]["text"]
+        hw.cleanup()
+
+    def test_start_action_dispatches_to_start_task(self):
+        hw = _make_robot()
+        captured = {}
+
+        def _fake_start(instruction, port, host, provider, duration):
+            captured["instruction"] = instruction
+            return {"status": "success", "content": [{"text": "started"}]}
+
+        hw.start_task = _fake_start  # type: ignore[assignment]
+        events = _drain(
+            hw.stream(
+                {"toolUseId": "t5", "input": {"action": "start", "instruction": "go", "policy_port": 5555}},
+                {},
+            )
+        )
+        result = events[-1].tool_result
+        assert result["status"] == "success"
+        assert captured["instruction"] == "go"
+        hw.cleanup()
+
+
+# ---------------------------------------------------------------------------
+# Status / spec surface
+# ---------------------------------------------------------------------------
+
+
+class TestStatusSurface:
+    def test_get_status_reports_connection_and_task(self):
+        fake = _FakeLeRobot(connected=True)
+        hw = _make_robot(fake)
+        status = asyncio.run(hw.get_status())
+        assert status["robot_name"] == "test_arm"
+        assert status["is_connected"] is True
+        assert status["task_status"] == "idle"
+        hw.cleanup()
+
+    def test_tool_spec_advertises_actions(self):
+        hw = _make_robot()
+        spec = hw.tool_spec
+        assert spec["name"] == "test_arm"
+        enum = spec["inputSchema"]["json"]["properties"]["action"]["enum"]
+        assert set(enum) == {"execute", "start", "status", "stop"}
+        assert hw.tool_type == "robot"
+        assert hw.tool_name == "test_arm"
+        hw.cleanup()
+
+
+# ---------------------------------------------------------------------------
+# Mesh teleop publish / receive lifecycle
+# ---------------------------------------------------------------------------
+
+
+class _FakeMesh:
+    def __init__(self, alive: bool = True) -> None:
+        self.alive = alive
+
+
+class _FakePublisher:
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+        self.topic = "strands/peer/input/leader"
+        self.started = False
+        self.stopped = False
+        self.stats = {"frames": 42, "hz_actual": 49.5}
+
+    def start(self) -> None:
+        self.started = True
+
+    def stop(self) -> dict[str, Any]:
+        self.stopped = True
+        return {"device": "leader", "frames": 42, "hz_actual": 49.5}
+
+
+class _FakeReceiver:
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+        self.topic = "strands/src/input/leader"
+        self.started = False
+        self.stopped = False
+        self.stats = {"frames_received": 10, "hz_actual": 50.0}
+
+    def start(self) -> None:
+        self.started = True
+
+    def stop(self) -> dict[str, Any]:
+        self.stopped = True
+        return {"source": "src", "frames_received": 10, "hz_actual": 50.0}
+
+
+class TestTeleopPublish:
+    def test_publish_requires_active_mesh(self):
+        hw = _make_robot()
+        hw.mesh = None
+        result = hw.start_teleop_publish(teleoperator=object())
+        assert result["status"] == "error"
+        assert "Mesh not active" in result["content"][0]["text"]
+        hw.cleanup()
+
+    def test_publish_starts_publisher_and_reports_peer(self, monkeypatch):
+        import strands_robots.mesh as mesh_mod
+
+        monkeypatch.setattr(mesh_mod, "InputPublisher", _FakePublisher)
+        hw = _make_robot()
+        hw.mesh = _FakeMesh(alive=True)
+        hw.peer_id = "peer-1"
+        result = hw.start_teleop_publish(teleoperator=object(), device_name="leader", method="arm", hz=50.0)
+        assert result["status"] == "success"
+        assert "peer-1" in result["content"][0]["text"]
+        assert hw._input_publishers["leader"].started is True
+        hw.cleanup()
+
+    def test_publish_twice_stops_prior_publisher(self, monkeypatch):
+        import strands_robots.mesh as mesh_mod
+
+        monkeypatch.setattr(mesh_mod, "InputPublisher", _FakePublisher)
+        hw = _make_robot()
+        hw.mesh = _FakeMesh(alive=True)
+        hw.peer_id = "peer-1"
+        hw.start_teleop_publish(teleoperator=object(), device_name="leader")
+        first = hw._input_publishers["leader"]
+        hw.start_teleop_publish(teleoperator=object(), device_name="leader")
+        assert first.stopped is True
+        assert hw._input_publishers["leader"] is not first
+        hw.cleanup()
+
+
+class TestTeleopReceive:
+    def test_receive_requires_active_mesh(self):
+        hw = _make_robot()
+        hw.mesh = _FakeMesh(alive=False)
+        result = hw.start_teleop_receive(source_peer_id="src")
+        assert result["status"] == "error"
+        assert "Mesh not active" in result["content"][0]["text"]
+        hw.cleanup()
+
+    def test_receive_starts_receiver(self, monkeypatch):
+        import strands_robots.mesh as mesh_mod
+
+        monkeypatch.setattr(mesh_mod, "InputReceiver", _FakeReceiver)
+        hw = _make_robot()
+        hw.mesh = _FakeMesh(alive=True)
+        result = hw.start_teleop_receive(source_peer_id="src", device_name="leader")
+        assert result["status"] == "success"
+        key = "src/leader"
+        assert hw._input_receivers[key].started is True
+        hw.cleanup()
+
+
+class TestTeleopStopAndStatus:
+    def _wire(self, hw):
+        hw._input_publishers = {"leader": _FakePublisher()}
+        hw._input_receivers = {"src/leader": _FakeReceiver()}
+
+    def test_stop_all_clears_publishers_and_receivers(self):
+        hw = _make_robot()
+        self._wire(hw)
+        result = hw.stop_teleop()
+        assert result["status"] == "success"
+        assert hw._input_publishers == {}
+        assert hw._input_receivers == {}
+        hw.cleanup()
+
+    def test_stop_named_device_only(self):
+        hw = _make_robot()
+        hw._input_publishers = {"leader": _FakePublisher(), "gamepad": _FakePublisher()}
+        hw._input_receivers = {}
+        hw.stop_teleop(device_name="leader")
+        assert "leader" not in hw._input_publishers
+        assert "gamepad" in hw._input_publishers
+        hw.cleanup()
+
+    def test_stop_with_no_sessions(self):
+        hw = _make_robot()
+        result = hw.stop_teleop()
+        assert result["status"] == "success"
+        assert "No active teleop" in result["content"][0]["text"]
+        hw.cleanup()
+
+    def test_get_teleop_status_counts_sessions(self):
+        hw = _make_robot()
+        self._wire(hw)
+        result = hw.get_teleop_status()
+        assert result["status"] == "success"
+        assert len(result["publishers"]) == 1
+        assert len(result["receivers"]) == 1
+        assert "Publishers: 1 active" in result["content"][0]["text"]
+        assert "Receivers: 1 active" in result["content"][0]["text"]
+        hw.cleanup()
+
+
+# ---------------------------------------------------------------------------
+# Cleanup / stop
+# ---------------------------------------------------------------------------
+
+
+class TestCleanup:
+    def test_cleanup_stops_running_task_and_mesh(self):
+        hw = _make_robot()
+        hw._task_state.status = TaskStatus.RUNNING
+
+        class _Mesh:
+            def __init__(self) -> None:
+                self.stopped = False
+
+            def stop(self) -> None:
+                self.stopped = True
+
+        mesh = _Mesh()
+        hw.mesh = mesh
+        hw.cleanup()
+        assert mesh.stopped is True
+        assert hw._shutdown_event.is_set()
+
+    def test_cleanup_survives_mesh_stop_error(self, caplog):
+        hw = _make_robot()
+
+        class _BadMesh:
+            def stop(self) -> None:
+                raise RuntimeError("mesh boom")
+
+        hw.mesh = _BadMesh()
+        # Should not raise.
+        hw.cleanup()
+
+    def test_stop_disconnects_robot(self):
+        fake = _FakeLeRobot(connected=True)
+        hw = _make_robot(fake)
+        asyncio.run(hw.stop())
+        assert fake.is_connected is False
+
+
+class TestExecuteTaskSync:
+    def test_sync_runner_no_running_loop_completes(self, monkeypatch):
+        """_execute_task_sync drives the async loop via asyncio.run when no
+        event loop is running, and reports success on completion."""
+        fake = _FakeLeRobot(connected=True)
+        hw = _make_robot(fake)
+
+        async def _ok_async(*a, **k):
+            hw._task_state.status = TaskStatus.COMPLETED
+            hw._task_state.duration = 1.2
+            hw._task_state.step_count = 5
+
+        hw._execute_task_async = _ok_async  # type: ignore[assignment]
+        result = hw._execute_task_sync("pick", policy_port=5555, policy_provider="mock", duration=1.0)
+        assert result["status"] == "success"
+        text = result["content"][0]["text"]
+        assert "completed" in text
+        assert "mock" in text
+        hw.cleanup()
+
+    def test_sync_runner_reports_error_status(self):
+        fake = _FakeLeRobot(connected=True)
+        hw = _make_robot(fake)
+
+        async def _err_async(*a, **k):
+            hw._task_state.status = TaskStatus.ERROR
+            hw._task_state.error_message = "boom"
+
+        hw._execute_task_async = _err_async  # type: ignore[assignment]
+        result = hw._execute_task_sync("pick", policy_port=5555)
+        assert result["status"] == "error"
+        assert "boom" in result["content"][0]["text"]
+        hw.cleanup()
+
+
+class TestStreamExecuteHappyPath:
+    def test_execute_action_runs_task_and_returns_result(self):
+        hw = _make_robot()
+        captured = {}
+
+        def _fake_sync(instruction, port, host, provider, duration):
+            captured["instruction"] = instruction
+            captured["port"] = port
+            return {"status": "success", "content": [{"text": "task done"}]}
+
+        hw._execute_task_sync = _fake_sync  # type: ignore[assignment]
+        events = _drain(
+            hw.stream(
+                {"toolUseId": "e1", "input": {"action": "execute", "instruction": "lift", "policy_port": 5555}},
+                {},
+            )
+        )
+        result = events[-1].tool_result
+        assert result["status"] == "success"
+        assert captured["instruction"] == "lift"
+        assert captured["port"] == 5555
+        hw.cleanup()
+
+    def test_start_action_requires_instruction_and_port(self):
+        hw = _make_robot()
+        events = _drain(hw.stream({"toolUseId": "e2", "input": {"action": "start", "instruction": "go"}}, {}))
+        result = events[-1].tool_result
+        assert result["status"] == "error"
+        assert "required" in result["content"][0]["text"]
+        hw.cleanup()

--- a/tests/test_hardware_robot_lifecycle.py
+++ b/tests/test_hardware_robot_lifecycle.py
@@ -286,23 +286,42 @@ class TestGetPolicy:
         hw.cleanup()
 
 
+@pytest.mark.timeout(30)
 class TestExecuteTaskAsync:
     def test_full_loop_sends_actions_and_completes(self, monkeypatch):
+        """One observe->act iteration runs, then the loop terminates.
+
+        The control loop is bounded by ``while time.time() - start < duration``.
+        Driving that with a hand-counted finite iterator is fragile: it assumes
+        the code reads ``time.time()`` an exact number of times before the loop
+        (connect/policy-init logging, the Python/lerobot build, or any future
+        refactor that adds a clock read would desync the iterator, leave the
+        captured ``start`` pinned to the terminal value, and spin the loop
+        forever). Instead use a stateful clock that advances ONLY when the
+        policy emits its chunk: ``start`` is captured at t=0 regardless of how
+        many intervening reads occur, and the post-chunk jump trips the guard
+        deterministically after exactly one iteration.
+        """
         fake = _FakeLeRobot(connected=False)
         hw = _make_robot(fake, control_frequency=1000.0)
 
-        async def _fake_get_policy(*a, **k):
-            return _StubPolicy()
-
-        hw._get_policy = _fake_get_policy  # type: ignore[assignment]
-
-        # Bound the wall-clock loop: first call starts at 0, second exceeds
-        # the 0.05s duration so exactly one iteration of action chunks runs.
-        times = iter([0.0, 0.0, 0.0, 100.0, 100.0, 100.0, 100.0])
+        clock = {"now": 0.0}
         monkeypatch.setattr(
             "strands_robots.hardware_robot.time.time",
-            lambda: next(times, 100.0),
+            lambda: clock["now"],
         )
+
+        class _ClockAdvancingPolicy(_StubPolicy):
+            async def get_actions(self, observation, instruction):
+                actions = await super().get_actions(observation, instruction)
+                # Jump past the duration so the next guard check exits the loop.
+                clock["now"] += 100.0
+                return actions
+
+        async def _fake_get_policy(*a, **k):
+            return _ClockAdvancingPolicy()
+
+        hw._get_policy = _fake_get_policy  # type: ignore[assignment]
 
         asyncio.run(hw._execute_task_async("pick", policy_port=5555, duration=0.05))
         assert hw._task_state.status == TaskStatus.COMPLETED


### PR DESCRIPTION
## What

`hardware_robot.py` (the universal hardware Robot control tool) had no dedicated test file and sat at **40%** line coverage despite being a hot path: it owns the async task lifecycle, the connect -> policy -> observe -> act control loop, the agent-tool `stream` dispatch, and the mesh teleop publish/receive surface.

This adds `tests/test_hardware_robot_lifecycle.py` (41 behavior tests). Module coverage **40% -> 88%** (271 -> 56 missing lines).

## Hang fix (control-loop test was order-dependent)

The first revision of `test_full_loop_sends_actions_and_completes` bounded the real `while time.time() - start < duration` control loop with a finite, call-count-coupled iterator:

```python
times = iter([0.0, 0.0, 0.0, 100.0, 100.0, 100.0, 100.0])
monkeypatch.setattr("...time.time", lambda: next(times, 100.0))
```

That assumes `_execute_task_async` / `_connect_robot` / `_initialize_policy` read `time.time()` an exact number of times before the loop. When the count shifts -- e.g. INFO logging enabled by a prior test makes `logger.info()` build `LogRecord`s that each call `time.time()`, or a different Python/lerobot build -- the iterator desyncs, the captured `start_time` lands on the terminal `100.0`, the guard `100.0 - 100.0 = 0 < duration` is always true, and the loop spins forever. The test passes in isolation but hangs in the full suite (order/environment dependent), which blocks CI until manual cancellation.

Fix is two parts:

1. Replace the finite iterator with a stateful clock that advances **only when the policy emits its action chunk**: `start_time` is captured at t=0 regardless of how many intervening `time.time()` reads occur, and the post-chunk jump trips the guard deterministically after exactly one iteration. Assertions unchanged (two actions, two steps, `COMPLETED`). Verified robust with INFO logging on (the exact CI condition that desynced the old iterator).
2. Add `--timeout=120` to the unit-suite pytest `addopts` (the integ env already pins `--timeout=300`). The unit suite had no per-test timeout, so any infinite loop blocked CI indefinitely instead of failing fast. `TestExecuteTaskAsync` is also marked `@pytest.mark.timeout(30)` as local defense for the loop-driving tests.

## Coverage

| area | what it pins |
|---|---|
| task state machine | `start_task` (already-running guard + background submit), `get_task_status` (idle/running/error text), `stop_task` (idle no-op + cancel future) |
| control loop | `_connect_robot` (success / already-connected / uncalibrated / connect failure), `_initialize_policy` (camera-key filtering + observation failure), `_get_policy` (missing-port raise + `create_policy` wiring), `_execute_task_async` (full observe->act loop, connect-failure and policy-init-failure error states), `_execute_task_sync` (success + error status) |
| tool stream | `execute`/`start` validation + dispatch, `status`, `stop`, unknown-action error |
| status surface | `get_status`, `tool_spec` action enum |
| mesh teleop | `start_teleop_publish`/`start_teleop_receive` (mesh-inactive guard, start, re-publish stops prior), `stop_teleop` (all / named / none), `get_teleop_status` |
| cleanup | task stop + mesh teardown, mesh-stop error resilience, `stop()` disconnect |

## Approach

Tests build the `Robot` via `__new__` + manual attribute wiring (same pattern as the existing `test_robot_factory` helper tests) so construction never touches `_initialize_robot` / lerobot serial drivers. A lightweight in-memory `_FakeLeRobot` and a deterministic `_StubPolicy` stand in for hardware; teleop tests monkeypatch `InputPublisher`/`InputReceiver` at the `strands_robots.mesh` import site. Tests assert observable outputs (status dicts, sent actions, stats) rather than internal state.

No production code changed; this is test-only. `ruff check`, `ruff format --check`, and `mypy strands_robots tests tests_integ` are clean for the added file.