### PR TITLE
test(lerobot_local): validate ProcessorBridge against real LeRobot pipeline (55%->88%)

### DIFF
--- a/tests/policies/lerobot_local/test_processor_real_pipeline.py
+++ b/tests/policies/lerobot_local/test_processor_real_pipeline.py
@@ -1,0 +1,265 @@
+"""Real-pipeline validation for the LeRobot ProcessorBridge.
+
+These tests exercise :class:`ProcessorBridge` against an ACTUAL LeRobot
+``DataProcessorPipeline`` built directly from processor steps (no network, no
+model download), so the bridge wiring is verified against real LeRobot internals
+rather than mocks. The mock-heavy suite in ``test_policy.py`` covers error paths;
+this file proves the success path against the installed LeRobot version.
+
+Skips cleanly when LeRobot's processor framework is unavailable.
+"""
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+pytest.importorskip("lerobot.processor.pipeline")
+
+from lerobot.processor import IdentityProcessorStep  # noqa: E402
+from lerobot.processor.pipeline import (  # noqa: E402
+    ComplementaryDataProcessorStep,
+    DataProcessorPipeline,
+)
+from lerobot.processor.rename_processor import RenameObservationsProcessorStep  # noqa: E402
+
+from strands_robots.policies.lerobot_local.embodiment import EmbodimentMap  # noqa: E402
+from strands_robots.policies.lerobot_local.processor import ProcessorBridge  # noqa: E402
+
+
+def _real_preprocessor(rename_map: dict[str, str] | None = None) -> DataProcessorPipeline:
+    """Build a real (network-free) preprocessor pipeline with a rename step."""
+    return DataProcessorPipeline(steps=[RenameObservationsProcessorStep(rename_map=dict(rename_map or {}))])
+
+
+def _real_postprocessor() -> DataProcessorPipeline:
+    """Build a real (network-free) postprocessor pipeline (identity action step)."""
+    return DataProcessorPipeline(steps=[IdentityProcessorStep()])
+
+
+class TestApplyEmbodimentRealPipeline:
+    """apply_embodiment against a real DataProcessorPipeline."""
+
+    def test_mutates_existing_rename_step_and_inserts_pack_state(self):
+        pipe = _real_preprocessor()
+        bridge = ProcessorBridge(preprocessor=pipe, device="cpu")
+        em = EmbodimentMap(
+            name="t",
+            obs_rename={"front": "observation.images.top", "wrist": "observation.images.wrist"},
+            state_keys=["1", "2", "3", "4", "5", "6"],
+            action_keys=["1", "2", "3", "4", "5", "6"],
+            dim_policy="pad",
+        )
+        bridge.apply_embodiment(em, input_features={})
+
+        names = [getattr(s, "_registry_name", type(s).__name__) for s in pipe.steps]
+        assert names[0] == "rename_observations_processor"
+        assert names[1] == "strands_pack_state"
+        # rename_map was set on the EXISTING step in place (not a new one prepended).
+        assert pipe.steps[0].rename_map == em.obs_rename
+
+    def test_inserts_rename_step_when_pipeline_has_none(self):
+        # Pipeline with no rename step at all -> bridge must insert one at front.
+        pipe = DataProcessorPipeline(steps=[])
+        bridge = ProcessorBridge(preprocessor=pipe)
+        em = EmbodimentMap(
+            name="t",
+            obs_rename={"front": "observation.images.top"},
+            state_keys=["1", "2"],
+            dim_policy="pad",
+        )
+        bridge.apply_embodiment(em, input_features=None)
+
+        names = [getattr(s, "_registry_name", type(s).__name__) for s in pipe.steps]
+        assert names[0] == "rename_observations_processor"
+        assert names[1] == "strands_pack_state"
+        assert pipe.steps[0].rename_map == em.obs_rename
+
+    def test_idempotent_reapply_keeps_single_pack_state(self):
+        pipe = _real_preprocessor()
+        bridge = ProcessorBridge(preprocessor=pipe)
+        em = EmbodimentMap(name="t", obs_rename={}, state_keys=["1", "2"], dim_policy="pad")
+        bridge.apply_embodiment(em, input_features={})
+        bridge.apply_embodiment(em, input_features={})
+
+        names = [getattr(s, "_registry_name", type(s).__name__) for s in pipe.steps]
+        assert names.count("strands_pack_state") == 1
+
+    def test_no_preprocessor_is_noop(self):
+        bridge = ProcessorBridge()  # passthrough, no pipelines
+        em = EmbodimentMap(name="t", obs_rename={"a": "b"}, state_keys=["1"], dim_policy="pad")
+        # Must not raise; simply does nothing.
+        bridge.apply_embodiment(em, input_features={})
+        assert not bridge.has_preprocessor
+
+    def test_no_state_keys_skips_pack_state(self):
+        pipe = _real_preprocessor()
+        bridge = ProcessorBridge(preprocessor=pipe)
+        em = EmbodimentMap(
+            name="t",
+            obs_rename={"front": "observation.images.top"},
+            state_keys=[],
+            dim_policy="pad",
+        )
+        bridge.apply_embodiment(em, input_features={})
+        names = [getattr(s, "_registry_name", type(s).__name__) for s in pipe.steps]
+        assert "strands_pack_state" not in names
+
+    def test_expected_dim_from_input_features_pads_state(self):
+        # Model declares an 8-dim observation.state; embodiment provides 6 joints
+        # with dim_policy="pad" -> packed state should be padded to 8.
+        pipe = _real_preprocessor({})
+        bridge = ProcessorBridge(preprocessor=pipe)
+        em = EmbodimentMap(
+            name="t",
+            obs_rename={},
+            state_keys=["1", "2", "3", "4", "5", "6"],
+            dim_policy="pad",
+        )
+        input_features = {"observation.state": type("F", (), {"shape": (8,)})()}
+        bridge.apply_embodiment(em, input_features=input_features)
+
+        raw = {str(i): float(i) / 10 for i in range(1, 7)}
+        out = bridge.preprocess(raw)
+        state = np.asarray(out["observation.state"]).ravel().tolist()
+        assert len(state) == 8
+        assert state[:6] == pytest.approx([0.1, 0.2, 0.3, 0.4, 0.5, 0.6])
+        assert state[6:] == [0.0, 0.0]
+
+
+class TestPreprocessRealPipeline:
+    """preprocess against a real DataProcessorPipeline."""
+
+    def test_rename_and_pack_with_instruction(self):
+        pipe = _real_preprocessor()
+        bridge = ProcessorBridge(preprocessor=pipe, device="cpu")
+        em = EmbodimentMap(
+            name="t",
+            obs_rename={"front": "observation.images.top"},
+            state_keys=["1", "2", "3"],
+            dim_policy="pad",
+        )
+        bridge.apply_embodiment(em, input_features={})
+
+        raw = {"front": np.zeros((4, 4, 3), dtype=np.uint8), "1": 0.1, "2": 0.2, "3": 0.3}
+        out = bridge.preprocess(raw, instruction="pick up the cube")
+
+        assert "observation.images.top" in out
+        assert "observation.state" in out
+        assert np.asarray(out["observation.state"]).ravel().tolist() == pytest.approx([0.1, 0.2, 0.3])
+        # instruction surfaced as the LeRobot 'task' key
+        assert out["task"] == "pick up the cube"
+        # raw strands keys are consumed
+        assert "front" not in out and "1" not in out
+
+    def test_no_preprocessor_returns_observation_unchanged(self):
+        bridge = ProcessorBridge()
+        raw = {"front": np.zeros((2, 2, 3), dtype=np.uint8), "1": 0.5}
+        out = bridge.preprocess(raw)
+        assert out is raw
+
+    def test_vla_complementary_data_merged_into_batch(self):
+        """B10 regression: VLA steps that emit model-ready tensors into
+        COMPLEMENTARY_DATA must be merged into the returned flat batch, else the
+        policy's _model_inputs reads an empty dict (StopIteration).
+
+        Simulates MolmoAct2's pack_inputs step with a real
+        ComplementaryDataProcessorStep that injects model-ready keys.
+        """
+
+        class _PackInputsStep(ComplementaryDataProcessorStep):
+            def complementary_data(self, complementary_data: dict[str, Any]) -> dict[str, Any]:
+                out = dict(complementary_data)
+                # Model-ready tensors a VLA packer would emit:
+                out["input_ids"] = [1, 2, 3]
+                out["pixel_values"] = np.zeros((1, 3, 8, 8), dtype=np.float32)
+                return out
+
+            def get_config(self) -> dict[str, Any]:
+                return {}
+
+            def state_dict(self) -> dict[str, Any]:
+                return {}
+
+            def load_state_dict(self, state: dict[str, Any]) -> None:
+                pass
+
+            def transform_features(self, features):
+                return features
+
+        pipe = DataProcessorPipeline(steps=[RenameObservationsProcessorStep(rename_map={}), _PackInputsStep()])
+        bridge = ProcessorBridge(preprocessor=pipe)
+
+        raw = {"observation.state": [0.0, 0.0]}
+        out = bridge.preprocess(raw, instruction="grasp")
+
+        # complementary keys (packed inputs + task) merged into the flat batch
+        assert "input_ids" in out
+        assert "pixel_values" in out
+        assert out["task"] == "grasp"
+        # observation keys still present
+        assert "observation.state" in out
+
+    def test_observation_keys_win_over_complementary_on_conflict(self):
+        """When a key exists in both OBSERVATION and COMPLEMENTARY_DATA, the
+        canonical normalized observation value must win."""
+
+        class _ConflictStep(ComplementaryDataProcessorStep):
+            def complementary_data(self, complementary_data: dict[str, Any]) -> dict[str, Any]:
+                out = dict(complementary_data)
+                out["observation.state"] = "FROM_COMPLEMENTARY"
+                return out
+
+            def get_config(self) -> dict[str, Any]:
+                return {}
+
+            def state_dict(self) -> dict[str, Any]:
+                return {}
+
+            def load_state_dict(self, state: dict[str, Any]) -> None:
+                pass
+
+            def transform_features(self, features):
+                return features
+
+        pipe = DataProcessorPipeline(steps=[RenameObservationsProcessorStep(rename_map={}), _ConflictStep()])
+        bridge = ProcessorBridge(preprocessor=pipe)
+        raw = {"observation.state": [1.0, 2.0]}
+        out = bridge.preprocess(raw, instruction="x")
+        assert out["observation.state"] == [1.0, 2.0]
+
+
+class TestPostprocessRealPipeline:
+    """postprocess against a real DataProcessorPipeline."""
+
+    def test_identity_action_passthrough(self):
+        import torch
+
+        bridge = ProcessorBridge(postprocessor=_real_postprocessor())
+        action = torch.tensor([1.0, 2.0, 3.0])
+        out = bridge.postprocess(action)
+        assert np.asarray(out).ravel().tolist() == pytest.approx([1.0, 2.0, 3.0])
+
+    def test_no_postprocessor_returns_action_unchanged(self):
+        bridge = ProcessorBridge()
+        sentinel = object()
+        assert bridge.postprocess(sentinel) is sentinel
+
+
+class TestBridgeStateRealPipeline:
+    """Diagnostic surface against real pipelines."""
+
+    def test_get_info_and_repr_reflect_loaded_pipelines(self):
+        bridge = ProcessorBridge(preprocessor=_real_preprocessor(), postprocessor=_real_postprocessor())
+        info = bridge.get_info()
+        assert info["has_preprocessor"] is True
+        assert info["has_postprocessor"] is True
+        assert info["is_active"] is True
+        assert "pre=1steps" in info["repr"]
+        assert "post=1steps" in info["repr"]
+
+    def test_reset_propagates_to_both_pipelines(self):
+        # reset() on real pipelines must not raise.
+        bridge = ProcessorBridge(preprocessor=_real_preprocessor(), postprocessor=_real_postprocessor())
+        bridge.reset()
+        assert bridge.is_active


### PR DESCRIPTION
## Problem

The `ProcessorBridge` (LeRobot `DataProcessorPipeline` integration in `policies/lerobot_local/processor.py`) sat at 55% coverage. The existing tests in `test_policy.py` are mock-heavy and only exercise error paths -- they assert on `MagicMock` pipelines, so the actual success-path wiring against LeRobot internals (`apply_embodiment` step injection, the VLA complementary-data merge, end-to-end `preprocess`) was never validated against the installed LeRobot version. Mock-only coverage let real integration regressions slip past (e.g. the model-inputs-drop bug where VLA packed tensors landed in complementary_data and were dropped).

## Change

Adds `tests/policies/lerobot_local/test_processor_real_pipeline.py` (14 tests) that build a **real** LeRobot `DataProcessorPipeline` directly from processor steps -- no network, no model download -- and verify the bridge against actual LeRobot internals:

- **apply_embodiment**: mutates an existing `RenameObservationsProcessorStep` in place; inserts one when the pipeline has none; inserts `strands_pack_state` immediately after rename; idempotent re-apply keeps a single pack-state step; skips pack-state when no `state_keys`; pads `observation.state` to the model's declared `input_features` dim under `dim_policy="pad"`.
- **preprocess**: full rename + pack-state transform of a raw observation with the instruction surfaced as the LeRobot `task` key; passthrough when no preprocessor.
- **VLA complementary-data merge (regression)**: a real `ComplementaryDataProcessorStep` emulating a VLA `pack_inputs` step injects model-ready tensors into `COMPLEMENTARY_DATA`; asserts they are merged into the returned flat batch (so the policy's `_model_inputs` does not read an empty dict), and that OBSERVATION keys win on conflict.
- **postprocess / state surface**: identity action passthrough; unchanged action when no postprocessor; `get_info`/`__repr__`/`reset` against real pipelines.

Test-only; no production code changes. Skips cleanly via `pytest.importorskip` when LeRobot's processor framework is unavailable.

## Coverage

`policies/lerobot_local/processor.py`: **55% -> 88%** (61 -> 17 missing lines). Remaining misses are import-error fallbacks and frozen-step edge branches.

## Tests

- New file: 14 passed.
- Full suite green (`MUJOCO_GL=egl`, lerobot from source): 5020 passed, 45 skipped. The 2 failures in `test_recording_paths.py` are a pre-existing environmental torchcodec/CPU-torch issue, unrelated to this change.
- `ruff check` + `ruff format --check` + `mypy`: clean (`hatch run lint` -> no issues).