### PR TITLE
examples(lerobot): align with hub-to-hardware blog; fix sim render image encoding

### DIFF
--- a/examples/lerobot/README.md
+++ b/examples/lerobot/README.md
@@ -45,19 +45,19 @@ The dataset lands at `https://huggingface.co/datasets/<your_hf_username>/strands
 
 ### LLM
 
-Defaults to **Claude Opus 4.8 on Bedrock** (`us.anthropic.claude-opus-4-8`). The AWS region resolves from your environment (`AWS_REGION` / `AWS_DEFAULT_REGION`, then `~/.aws/config`). Opus 4.8 orchestrates the LeRobot tool surface in 8 to 13 tool calls per recording phase; lower-tier models work but issue more defensive state-querying calls.
+Defaults to **Claude Opus 4.8 on Bedrock** (`global.anthropic.claude-opus-4-8`). The AWS region resolves from your environment (`AWS_REGION` / `AWS_DEFAULT_REGION`, then `~/.aws/config`). Opus 4.8 orchestrates the LeRobot tool surface in 8 to 13 tool calls per recording phase; lower-tier models work but issue more defensive state-querying calls.
 
 Override per-run:
 
 ```bash
 # Different model
-python hub_to_hardware.py --model-id us.anthropic.claude-sonnet-4-6
+python hub_to_hardware.py --model-id global.anthropic.claude-sonnet-4-6
 
 # Different region
 python hub_to_hardware.py --aws-region us-east-1
 
 # Both via env vars
-export STRANDS_BEDROCK_MODEL_ID=us.anthropic.claude-opus-4-8
+export STRANDS_BEDROCK_MODEL_ID=global.anthropic.claude-opus-4-8
 export AWS_REGION=<your-region>     # e.g., us-east-1, us-west-2, eu-central-1
 ```
 

--- a/examples/lerobot/README.md
+++ b/examples/lerobot/README.md
@@ -138,7 +138,6 @@ The calibration files land under `~/.cache/huggingface/lerobot/calibration/` and
 --instruction <text>               Task instruction (default: "pick up the red cube")
 --clean-cache                      Wipe local cache before recording
 --skip-record / --skip-mesh        Skip individual steps
---verbose / -v                     Show prompts, tool calls, dataset state
 ```
 
 Note: `--num-steps` (default 1000) controls the length of the recorded demonstration in Step 2. The Step 3 policy rollout is a fixed 200 steps; those are different knobs.
@@ -223,7 +222,7 @@ A prior run's dataset cache is on disk. Pass `--clean-cache` to wipe it, or pass
 The `Svt[info]:` lines come from the video codec inside LeRobot's `dataset_recorder` and aren't a Python logger we can silence cleanly. They're harmless: one block per camera per encoder init.
 
 **Agent's narration claims things that don't match the tool calls**  
-LLMs sometimes confabulate in narration. The dataset on disk is the ground truth: load it through `LeRobotDataset(...)` to check episode and frame counts. Pass `--verbose` to see the actual tool calls the agent made.
+LLMs sometimes confabulate in narration. The dataset on disk is the ground truth: load it through `LeRobotDataset(...)` to check episode and frame counts.
 
 ## What's next
 

--- a/examples/lerobot/README.md
+++ b/examples/lerobot/README.md
@@ -2,11 +2,11 @@
 
 Runnable companion to *From Hugging Face Hub to robot hardware with Strands Agents and LeRobot*. Demonstrates the full loop: build a Strands agent over the LeRobot AgentTools, record a `LeRobotDataset` in simulation, run a policy on the same robot, optionally deploy the same agent code to a physical SO-101, and broadcast across the Zenoh mesh.
 
-| File | What it is |
-|------|------------|
-| [`hub_to_hardware.py`](./hub_to_hardware.py)   | CLI script with argparse flags. The runnable artefact. |
-| [`hub_to_hardware.ipynb`](./hub_to_hardware.ipynb) | Notebook walkthrough with the same workflow, cell by cell. |
-| `README.md` (this file) | Quick start, configuration, troubleshooting, production patterns. |
+|File                                              |What it is                                                       |
+|--------------------------------------------------|-----------------------------------------------------------------|
+|[`hub_to_hardware.py`](./hub_to_hardware.py)      |CLI script with argparse flags. The runnable artefact.           |
+|[`hub_to_hardware.ipynb`](./hub_to_hardware.ipynb)|Notebook walkthrough with the same workflow, cell by cell.       |
+|`README.md` (this file)                           |Quick start, configuration, troubleshooting, production patterns.|
 
 ## Quick start
 
@@ -25,9 +25,9 @@ The resulting dataset is at:
 
 ```
 ~/.cache/huggingface/lerobot/local/strands-cube-pick/
-├── data/chunk-000/episode_000000.parquet
+├── data/chunk-000/file-000.parquet
 ├── meta/info.json
-└── videos/chunk-000/observation.images.front/episode_000000.mp4
+└── videos/observation.images.front/chunk-000/file-000.mp4
 ```
 
 Open the MP4 to see the recording.
@@ -45,13 +45,13 @@ The dataset lands at `https://huggingface.co/datasets/<your_hf_username>/strands
 
 ### LLM
 
-Defaults to **Claude Opus 4.8 on Bedrock** (`global.anthropic.claude-opus-4-8`). The AWS region resolves from your environment (`AWS_REGION` / `AWS_DEFAULT_REGION`, then `~/.aws/config`). Opus 4.8 orchestrates the LeRobot tool surface in 8–13 tool calls per recording phase; lower-tier models work but issue more defensive state-querying calls.
+Defaults to **Claude Opus 4.8 on Bedrock** (`us.anthropic.claude-opus-4-8`). The AWS region resolves from your environment (`AWS_REGION` / `AWS_DEFAULT_REGION`, then `~/.aws/config`). Opus 4.8 orchestrates the LeRobot tool surface in 8 to 13 tool calls per recording phase; lower-tier models work but issue more defensive state-querying calls.
 
 Override per-run:
 
 ```bash
 # Different model
-python hub_to_hardware.py --model-id global.anthropic.claude-sonnet-4-6
+python hub_to_hardware.py --model-id us.anthropic.claude-sonnet-4-6
 
 # Different region
 python hub_to_hardware.py --aws-region us-east-1
@@ -63,15 +63,15 @@ export AWS_REGION=<your-region>     # e.g., us-east-1, us-west-2, eu-central-1
 
 Verify the exact model ID in your AWS Bedrock console (Model catalog → Anthropic). Cross-region inference profile IDs are prefixed with `us.`, `eu.`, etc.
 
-If `BedrockModel` init fails (model not enabled in your account, wrong region, stale ID), the script logs a warning and falls back to Strands' default model - the workflow still runs.
+If `BedrockModel` init fails (model not enabled in your account, wrong region, stale ID), the script logs a warning and falls back to Strands' default model, and the workflow still runs.
 
 ### Policy provider
 
-| Flag | Requirements | When to use |
-|------|--------------|-------------|
-| `--policy mock` *(default)* | None | Workflow sanity-check. Random/placeholder actions - no real grasp behaviour. |
-| `--policy groot --checkpoint <hf_repo>` | Docker + NVIDIA GPU | NVIDIA GR00T container; brings up a ZMQ inference service alongside the agent. |
-| `--policy lerobot_local --checkpoint <hf_repo>` | GPU + `STRANDS_TRUST_REMOTE_CODE=1` | In-process LeRobot policy (ACT, Pi0, SmolVLA, Diffusion). |
+|Flag                                           |Requirements                       |When to use                                                                                                                                                                                                              |
+|-----------------------------------------------|-----------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|`--policy mock` *(default)*                    |None                               |Workflow sanity-check. Random/placeholder actions, no real grasp behaviour.                                                                                                                                             |
+|`--policy groot --checkpoint <hf_repo>`        |Docker + NVIDIA GPU                |NVIDIA GR00T container; brings up a ZMQ inference service alongside the agent.                                                                                                                                           |
+|`--policy lerobot_local --checkpoint <hf_repo>`|GPU + `STRANDS_TRUST_REMOTE_CODE=1`|In-process LeRobot policy (ACT, Pi0, SmolVLA, Diffusion, MolmoAct2). MolmoAct2 checkpoints (e.g. `allenai/MolmoAct2-SO100_101`) are auto-detected via the checkpoint's `config.json` and routed through the right loader.|
 
 Example with GR00T:
 
@@ -101,7 +101,7 @@ export STRANDS_MESH_LOCAL_DEV=1
 
 ```bash
 # Or skip the mesh entirely (Step 5 becomes a no-op)
-export STRANDS_MESH=0
+export STRANDS_MESH=false
 ```
 
 ### Hardware
@@ -113,16 +113,14 @@ python hub_to_hardware.py \
     --leader-port /dev/ttyACM1
 ```
 
-Requires a calibrated SO-101 follower and leader. Calibrate once via the agent or directly:
+Requires a calibrated SO-101 follower and leader. Calibrate once per device with LeRobot's CLI:
 
 ```bash
-python -c "
-from strands import Agent
-from strands_robots import lerobot_calibrate
-Agent(tools=[lerobot_calibrate])(
-    'Calibrate the so101_follower on /dev/ttyACM0'
-)"
+lerobot-calibrate --robot.type=so101_follower --robot.id=my_follower
+lerobot-calibrate --robot.type=so101_leader   --robot.id=my_leader
 ```
+
+The calibration files land under `~/.cache/huggingface/lerobot/calibration/` and any Strands code path that touches the hardware reads them from there.
 
 ## CLI reference
 
@@ -143,6 +141,8 @@ Agent(tools=[lerobot_calibrate])(
 --verbose / -v                     Show prompts, tool calls, dataset state
 ```
 
+Note: `--num-steps` (default 1000) controls the length of the recorded demonstration in Step 2. The Step 3 policy rollout is a fixed 200 steps; those are different knobs.
+
 ## Where the dataset lives
 
 LeRobotDatasets sit under the standard Hugging Face cache:
@@ -159,13 +159,13 @@ ds = LeRobotDataset("local/strands-cube-pick")
 print(ds.num_episodes, ds.num_frames, ds.fps, list(ds.features.keys()))
 ```
 
-The same dataset is consumable by upstream LeRobot training scripts (`lerobot/scripts/train.py`) without conversion.
+The same dataset is consumable by the upstream LeRobot training CLI (`lerobot-train`) without conversion.
 
 ## Production patterns
 
-This example records one longer episode per run. That keeps the agent-driven story honest - you tell the agent in English to record a demonstration once and the tool sequence comes out in one shot.
+This example records one longer episode per run. That keeps the agent-driven story honest: you tell the agent in English to record a demonstration once and the tool sequence comes out in one shot.
 
-For production multi-episode collection, wrap the loop in Python and use direct tool dispatch for the per-iteration save:
+For production multi-episode collection, wrap the loop in Python and use direct tool dispatch for each episode boundary. Each episode is a `start_recording` / `run_policy` / `stop_recording` cycle. The first `start_recording` creates the dataset; every later one with `overwrite=False` resumes the existing dataset and appends a new episode (`stop_recording` finalizes and saves the episode internally):
 
 ```python
 from strands_robots import Robot
@@ -176,31 +176,42 @@ agent = Agent(tools=[robot])
 
 # Setup phase via the agent (natural-language scene composition)
 agent(
-    "Add a red cube near the robot and a front camera looking at it. "
-    "Then call start_recording with repo_id='my-dataset' at FPS 30."
+    "Add a red cube near the robot and a front camera looking at it."
 )
 
-# Deterministic per-episode loop (direct dispatch, no LLM variance)
+# Deterministic per-episode loop (direct dispatch, no LLM variance).
+# overwrite=True on the first episode starts fresh; overwrite=False on the
+# rest appends to the same dataset on disk.
 for episode_idx in range(50):
     agent.tool.so100_sim(action="reset")
+    agent.tool.so100_sim(
+        action="start_recording",
+        repo_id="local/my-dataset",
+        fps=30,
+        overwrite=(episode_idx == 0),
+    )
     agent.tool.so100_sim(
         action="run_policy",
         policy_provider="mock",
         instruction="pick up the red cube",
         n_steps=200,
     )
-    agent.tool.so100_sim(action="save_episode")
+    # stop_recording finalizes and saves the episode (encodes video,
+    # writes parquet). There is no separate save_episode action.
+    agent.tool.so100_sim(action="stop_recording")
 
-# Finalize via the agent again
-agent("Stop recording and push the dataset to the Hub.")
+# Push the finished dataset via the agent.
+agent("Push the local/my-dataset dataset to the Hub.")
 ```
 
-The split - agent for setup and finalization, Python loop for the per-episode boundary - pairs the agent's strength (free-form composition) with the determinism a multi-step loop needs.
+> **Note**: The exact kwarg names accepted by `start_recording` and the per-episode append behaviour should be verified against the current SDK before relying on this pattern in production. The shape above is correct in principle but has not been executed end-to-end; treat it as a starting point, not a copy-paste guarantee.
+
+The split (agent for setup and push, a Python loop for the per-episode boundary) pairs the agent's strength in free-form composition with the determinism a multi-step loop needs.
 
 ## Troubleshooting
 
 **`Failed to initialise mesh ... STRANDS_MESH_AUTH_MODE=mtls requires ...`**  
-The mesh subsystem tries mTLS by default. Set `STRANDS_MESH_LOCAL_DEV=1` to use the dev/lab posture, or `STRANDS_MESH=0` to disable the mesh entirely for sim-only runs.
+The mesh subsystem tries mTLS by default. Set `STRANDS_MESH_LOCAL_DEV=1` to use the dev/lab posture, or `STRANDS_MESH=false` to disable the mesh entirely for sim-only runs.
 
 **`BedrockModel(...) init failed`**  
 Common causes: the model isn't enabled in your AWS account, the region doesn't have the model, or the model ID is stale. Check the AWS Bedrock console (Model catalog → Anthropic). The script falls back to Strands' default model and continues, but you'll see degraded tool-orchestration quality.
@@ -209,20 +220,20 @@ Common causes: the model isn't enabled in your AWS account, the region doesn't h
 A prior run's dataset cache is on disk. Pass `--clean-cache` to wipe it, or pass a fresh `--dataset-name`.
 
 **SVT-AV1 encoder output spam**  
-The `Svt[info]:` lines come from the video codec inside LeRobot's `dataset_recorder` and aren't a Python logger we can silence cleanly. They're harmless - one block per camera per encoder init.
+The `Svt[info]:` lines come from the video codec inside LeRobot's `dataset_recorder` and aren't a Python logger we can silence cleanly. They're harmless: one block per camera per encoder init.
 
 **Agent's narration claims things that don't match the tool calls**  
-LLMs sometimes confabulate in narration. The dataset on disk is the ground truth - load it through `LeRobotDataset(...)` to check episode and frame counts. Pass `--verbose` to see the actual tool calls the agent made.
+LLMs sometimes confabulate in narration. The dataset on disk is the ground truth: load it through `LeRobotDataset(...)` to check episode and frame counts. Pass `--verbose` to see the actual tool calls the agent made.
 
 ## What's next
 
-- **Train a policy** on the recorded dataset using upstream LeRobot.
-- **Swap the Mock policy** for a real one - `groot` for the NVIDIA container, `lerobot_local` for ACT/Pi0/SmolVLA/Diffusion checkpoints.
+- **Train a policy** on the recorded dataset using upstream LeRobot's `lerobot-train` CLI.
+- **Swap the Mock policy** for a real one: `groot` for the NVIDIA container, `lerobot_local` for ACT/Pi0/SmolVLA/Diffusion/MolmoAct2 checkpoints.
 - **Run on physical hardware** by flipping `--mode real`.
 - **Read the blog post** for the design background and the full architecture diagram: *From Hugging Face Hub to robot hardware with Strands Agents and LeRobot*.
 
 ## Repository
 
-Strands Robots: https://github.com/strands-labs/robots  
-Heavy simulation backends (Isaac Sim, Newton): https://github.com/strands-labs/robots-sim  
-Upstream LeRobot: https://github.com/huggingface/lerobot
+Strands Robots: <https://github.com/strands-labs/robots>  
+Heavy simulation backends (Isaac Sim, Newton): <https://github.com/strands-labs/robots-sim>  
+Upstream LeRobot: <https://github.com/huggingface/lerobot>

--- a/examples/lerobot/hub_to_hardware.ipynb
+++ b/examples/lerobot/hub_to_hardware.ipynb
@@ -38,7 +38,7 @@
     "export STRANDS_MESH_LOCAL_DEV=1\n",
     "```\n",
     "\n",
-    "AWS Bedrock access for Claude Opus 4.8 (`us.anthropic.claude-opus-4-8`). If your access is in a different region or account, override `MODEL_ID` and `AWS_REGION` in the next cell."
+    "AWS Bedrock access for Claude Opus 4.8 (`global.anthropic.claude-opus-4-8`). If your access is in a different region or account, override `MODEL_ID` and `AWS_REGION` in the next cell."
    ]
   },
   {
@@ -59,7 +59,7 @@
     "# Bedrock model + region. Verify the exact ID in your AWS Bedrock console.\n",
     "# AWS_REGION resolves from your AWS environment; set it explicitly here\n",
     "# (e.g. \"us-east-1\") if you need to override.\n",
-    "MODEL_ID = \"us.anthropic.claude-opus-4-8\"\n",
+    "MODEL_ID = \"global.anthropic.claude-opus-4-8\"\n",
     "AWS_REGION = os.environ.get(\"AWS_REGION\") or os.environ.get(\"AWS_DEFAULT_REGION\")\n",
     "\n",
     "# Recording target. Set HF_USER to push the dataset to your Hub account.\n",

--- a/examples/lerobot/hub_to_hardware.ipynb
+++ b/examples/lerobot/hub_to_hardware.ipynb
@@ -2,7 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "7fb27b941602401d91542211134fc71a",
    "metadata": {},
    "source": [
     "# From Hugging Face Hub to robot hardware\n",
@@ -15,7 +14,7 @@
     "4. (Reference only) Deploy the same agent code to a physical SO-101 by flipping `mode='real'`.\n",
     "5. Broadcast a command to every peer on the local Zenoh mesh.\n",
     "\n",
-    "The defaults run fully in simulation with the Mock policy - no GPU, no Docker, no Hub credentials required. To use a trained policy or push to your Hub account, see the notes in the relevant cells.\n",
+    "The defaults run fully in simulation with the Mock policy: no GPU, no Docker, no Hub credentials required. To use a trained policy or push to your Hub account, see the notes in the relevant cells.\n",
     "\n",
     "**Repository:** https://github.com/strands-labs/robots  \n",
     "**Blog post:** *From Hugging Face Hub to robot hardware with Strands Agents and LeRobot*"
@@ -23,7 +22,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "acae54e37e7d407bbb7b55eff062a284",
    "metadata": {},
    "source": [
     "## Prerequisites\n",
@@ -40,13 +38,12 @@
     "export STRANDS_MESH_LOCAL_DEV=1\n",
     "```\n",
     "\n",
-    "AWS Bedrock access for Claude Opus 4.8 (`global.anthropic.claude-opus-4-8`). If your access is in a different region or account, override `MODEL_ID` and `AWS_REGION` in the next cell."
+    "AWS Bedrock access for Claude Opus 4.8 (`us.anthropic.claude-opus-4-8`). If your access is in a different region or account, override `MODEL_ID` and `AWS_REGION` in the next cell."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9a63283cbaf04dbcab1f6479b197f3a8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -60,9 +57,9 @@
     "os.environ.setdefault(\"STRANDS_MESH_LOCAL_DEV\", \"1\")\n",
     "\n",
     "# Bedrock model + region. Verify the exact ID in your AWS Bedrock console.\n",
-    "# AWS_REGION resolves from your AWS environment - set it explicitly here\n",
+    "# AWS_REGION resolves from your AWS environment; set it explicitly here\n",
     "# (e.g. \"us-east-1\") if you need to override.\n",
-    "MODEL_ID = \"global.anthropic.claude-opus-4-8\"\n",
+    "MODEL_ID = \"us.anthropic.claude-opus-4-8\"\n",
     "AWS_REGION = os.environ.get(\"AWS_REGION\") or os.environ.get(\"AWS_DEFAULT_REGION\")\n",
     "\n",
     "# Recording target. Set HF_USER to push the dataset to your Hub account.\n",
@@ -75,43 +72,39 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8dd0d8092fe74a7c96281538738b07e2",
    "metadata": {},
    "source": [
-    "## Step 1 - Build the agent\n",
+    "## Step 1: Build the agent\n",
     "\n",
-    "One `Robot('so100')` call returns a MuJoCo simulation by default. Pass `mode='real'` to get a hardware-backed robot driven by LeRobot - the rest of the workflow is identical.\n",
+    "One `Robot('so100')` call returns a MuJoCo simulation by default. Pass `mode='real'` to get a hardware-backed robot driven by LeRobot, and the rest of the workflow is identical.\n",
     "\n",
-    "The agent gets four tools: the `Robot` itself (the simulation), `lerobot_teleoperate` (leader-arm capture for hardware), `lerobot_calibrate` (one-time joint calibration), and `robot_mesh` (peer-to-peer fleet messaging)."
+    "The agent gets two tools: the `Robot` itself (handles simulation or hardware uniformly) and `robot_mesh` (peer-to-peer fleet messaging). LeRobot's CLIs handle calibration and hardware teleop outside this notebook."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72eea5119410473aa328ad9291626812",
    "metadata": {},
    "outputs": [],
    "source": [
     "from strands import Agent\n",
     "from strands.models import BedrockModel\n",
-    "\n",
-    "from strands_robots import Robot, lerobot_calibrate, lerobot_teleoperate, robot_mesh\n",
+    "from strands_robots import Robot, robot_mesh\n",
     "\n",
     "model = BedrockModel(model_id=MODEL_ID, region_name=AWS_REGION) if AWS_REGION else BedrockModel(model_id=MODEL_ID)\n",
     "robot = Robot(\"so100\", data_config=\"so100_dualcam\")  # sim by default\n",
     "\n",
     "agent = Agent(\n",
     "    model=model,\n",
-    "    tools=[robot, lerobot_teleoperate, lerobot_calibrate, robot_mesh],\n",
+    "    tools=[robot, robot_mesh],\n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "8edb47106e1a46a883d545849b8ab81b",
    "metadata": {},
    "source": [
-    "## Step 2 - Record a demonstration\n",
+    "## Step 2: Record a demonstration\n",
     "\n",
     "One agent prompt → one tool sequence → one `LeRobotDataset` episode. The agent composes the scene (red cube + front camera), starts recording, runs the Mock policy, and finalizes the episode with `stop_recording`.\n",
     "\n",
@@ -121,14 +114,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10185d26023b46108eb7d9f57d49d2b3",
    "metadata": {},
    "outputs": [],
    "source": [
     "NUM_STEPS = 1000  # ≈ 33s of data at 30fps\n",
     "\n",
     "push_clause = (\n",
-    "    f\"Push the result to {REPO_ID} when done.\" if PUSH_TO_HUB else \"Keep the dataset local - do not push to the Hub.\"\n",
+    "    f\"Push the result to {REPO_ID} when done.\"\n",
+    "    if PUSH_TO_HUB\n",
+    "    else \"Keep the dataset local; do not push to the Hub.\"\n",
     ")\n",
     "\n",
     "prompt = (\n",
@@ -151,7 +145,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8763a12b2bbd4a93a75aff182afb95dc",
    "metadata": {},
    "source": [
     "### Verify the recording\n",
@@ -162,7 +155,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7623eae2785240b9bd12b16a66d81610",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -181,26 +173,24 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7cdc8c89c7104fffa095e18ddfef8986",
    "metadata": {},
    "source": [
     "Inside the cache directory you'll find:\n",
     "\n",
-    "- `data/chunk-000/episode_000000.parquet` - joint states and actions\n",
-    "- `videos/chunk-000/observation.images.front/episode_000000.mp4` - the recording\n",
-    "- `meta/` - schema and episode metadata\n",
+    "- `data/chunk-000/file-000.parquet` holds joint states and actions\n",
+    "- `videos/observation.images.front/chunk-000/file-000.mp4` is the recording\n",
+    "- `meta/` holds schema and episode metadata\n",
     "\n",
     "Open the MP4 in QuickTime/VLC to see the recorded rollout."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "b118ea5561624da68c537baed56e602f",
    "metadata": {},
    "source": [
-    "## Step 3 - Run a policy on the robot\n",
+    "## Step 3: Run a policy on the robot\n",
     "\n",
-    "The same agent now drives the policy. With the Mock policy (the default), this is purely a workflow sanity-check - the arm moves through placeholder actions rather than executing a trained grasp.\n",
+    "The same agent now drives the policy. With the Mock policy (the default), this is purely a workflow sanity-check: the arm moves through placeholder actions rather than executing a trained grasp.\n",
     "\n",
     "For real cube-picking behaviour, switch the prompt to drive `gr00t_inference` (NVIDIA GR00T container, requires Docker + GPU) or `create_policy('lerobot_local', ...)` with a checkpoint trained for the task. See this folder's README for the exact wiring."
    ]
@@ -208,19 +198,20 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "938c804e27f84196a10c8828c723f798",
    "metadata": {},
    "outputs": [],
    "source": [
-    "agent(f\"Run the Mock policy on the robot for 200 steps with the instruction '{TASK}'. Render the final frame.\")"
+    "agent(\n",
+    "    f\"Run the Mock policy on the robot for 200 steps with the instruction \"\n",
+    "    f\"'{TASK}'. Render the final frame.\"\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "504fb2a444614c0babb325280ed9130a",
    "metadata": {},
    "source": [
-    "## Step 4 - Deploy to physical hardware (reference)\n",
+    "## Step 4: Deploy to physical hardware (reference)\n",
     "\n",
     "Switching from simulation to a physical SO-101 is one flag at construction time:\n",
     "\n",
@@ -237,17 +228,16 @@
     ")\n",
     "```\n",
     "\n",
-    "The rest of the code - `Agent(tools=[robot, ...])`, the recording prompt, the policy prompt - is unchanged. The same `LeRobotDataset` writer handles real-camera frames and hardware joint reads through `lerobot_teleoperate`.\n",
+    "The rest of the code (`Agent(tools=[robot, ...])`, the recording prompt, the policy prompt) is unchanged. The same `LeRobotDataset` writer handles real-camera frames and hardware joint reads through LeRobot's driver layer.\n",
     "\n",
     "(Skipped in this notebook because hardware isn't typically attached to a Jupyter kernel.)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "59bbdb311c014d738909a11f9e486628",
    "metadata": {},
    "source": [
-    "## Step 5 - Mesh broadcast\n",
+    "## Step 5: Mesh broadcast\n",
     "\n",
     "Every `Robot()` auto-joins a local Zenoh mesh, so fleets coordinate out of the box. The agent uses the `robot_mesh` tool to enumerate peers and send commands.\n",
     "\n",
@@ -257,7 +247,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b43b363d81ae4b689946ece5c682cd59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -269,7 +258,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8a65eabff63a45729fe45fb5ade58bdc",
    "metadata": {},
    "source": [
     "## Cleanup\n",
@@ -285,9 +273,9 @@
     "## Next steps\n",
     "\n",
     "- **Push to the Hub.** Set `HF_USER` in the second cell, export `HF_TOKEN=hf_...` with write scope, and re-run from Step 2.\n",
-    "- **Train on the dataset.** The `LeRobotDataset` you just produced is byte-compatible with the upstream LeRobot training scripts - `lerobot/scripts/train.py` will consume it directly.\n",
+    "- **Train on the dataset.** The `LeRobotDataset` you just produced is in the same on-disk format the upstream LeRobot training CLI expects; `lerobot-train` consumes it directly.\n",
     "- **Use a real trained policy.** Swap the Mock prompt in Step 3 for a `lerobot_local` or `groot` checkpoint. See this folder's `README.md`.\n",
-    "- **Run on physical hardware.** Calibrate your SO-101 once (`agent('Calibrate the so101_follower on /dev/ttyACM0')`), then re-run Step 1 with `mode='real'`."
+    "- **Run on physical hardware.** Calibrate your SO-101 once on the shell with `lerobot-calibrate --robot.type=so101_follower --robot.id=my_follower`, then re-run Step 1 with `mode='real'`."
    ]
   }
  ],

--- a/examples/lerobot/hub_to_hardware.py
+++ b/examples/lerobot/hub_to_hardware.py
@@ -64,12 +64,6 @@ demonstration once, and the tool sequence comes out in one shot.
 Production multi-episode collection wraps the loop in Python; that
 pattern lives in this folder's README under "Production patterns."
 
-Debugging: pass --verbose to surface the full prompt the agent receives,
-every tool call the agent makes (with arguments), and before/after
-dataset state. By default the script logs only step banners, the agent's
-natural-language responses, and a one-line dataset summary at the end of
-each phase.
-
 Repository: https://github.com/strands-labs/robots
 """
 
@@ -82,12 +76,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
-# Two loggers: ``logger`` is always shown; ``diag_logger`` is gated by
-# --verbose (set to WARNING by default, INFO when verbose is on). This
-# keeps the default output focused on the agent's narration and the final
-# summary, with debug traces available on demand.
 logger = logging.getLogger("hub_to_hardware")
-diag_logger = logging.getLogger("hub_to_hardware.diag")
 
 
 # ---------------------------------------------------------------------------
@@ -106,150 +95,6 @@ DEFAULT_MODEL_ID = "global.anthropic.claude-opus-4-8"  # ← verify in AWS conso
 # Region is intentionally not defaulted in code. It resolves from the
 # --aws-region CLI flag, then AWS_REGION / AWS_DEFAULT_REGION env vars,
 # then boto3's standard chain (~/.aws/config, instance metadata).
-
-
-# ---------------------------------------------------------------------------
-# Dataset location + state helpers
-# ---------------------------------------------------------------------------
-
-def _lerobot_cache_root(repo_id: str) -> Path:
-    """Return the on-disk LeRobotDataset cache directory for ``repo_id``."""
-    return Path.home() / ".cache" / "huggingface" / "lerobot" / repo_id
-
-
-def _read_dataset_state(repo_id: str) -> dict[str, Any]:
-    """Read the LeRobotDataset's state via the LeRobot API.
-
-    Using ``LeRobotDataset(...)`` directly (rather than poking at specific
-    metadata files) keeps the diagnostic in sync with whatever metadata
-    layout your installed LeRobot version expects.
-
-    Returns a dict with one of these statuses:
-      * ``missing``        - cache dir doesn't exist
-      * ``ready``          - dataset loaded, counts populated
-      * ``not_finalized``  - cache exists but isn't a complete dataset yet
-      * ``error``          - load failed for another reason
-    """
-    cache_root = _lerobot_cache_root(repo_id)
-    result: dict[str, Any] = {"cache_path": str(cache_root)}
-
-    if not cache_root.exists():
-        result["status"] = "missing"
-        return result
-
-    try:
-        from lerobot.datasets.lerobot_dataset import LeRobotDataset
-        ds = LeRobotDataset(repo_id)
-        result["status"] = "ready"
-        result["num_episodes"] = int(getattr(ds, "num_episodes", 0))
-        result["total_frames"] = int(getattr(ds, "num_frames", 0))
-        result["fps"] = int(ds.fps) if getattr(ds, "fps", None) else None
-        return result
-    except FileNotFoundError as exc:
-        result["status"] = "not_finalized"
-        result["error"] = str(exc)
-        return result
-    except Exception as exc:  # noqa: BLE001 - want to capture any load failure
-        result["status"] = "error"
-        result["error"] = f"{type(exc).__name__}: {exc}"
-        return result
-
-
-def _log_dataset_summary(repo_id: str) -> None:
-    """Print a one-line, user-facing summary of the dataset's state."""
-    state = _read_dataset_state(repo_id)
-    status = state["status"]
-
-    if status == "ready":
-        logger.info(
-            "✅ Dataset ready: %d episode(s), %d frame(s) → %s",
-            state["num_episodes"], state["total_frames"], state["cache_path"],
-        )
-    elif status == "missing":
-        logger.warning(
-            "❌ No dataset cache at %s - start_recording may have been skipped",
-            state["cache_path"],
-        )
-    elif status == "not_finalized":
-        logger.warning(
-            "❌ Cache at %s isn't a complete dataset (%s) - "
-            "stop_recording may not have run",
-            state["cache_path"], state["error"],
-        )
-    else:
-        logger.warning("❌ Dataset check failed: %s", state["error"])
-
-
-# ---------------------------------------------------------------------------
-# Diagnostic tool-call capture (verbose mode only)
-# ---------------------------------------------------------------------------
-
-def _get(obj: Any, key: str, default: Any = None) -> Any:
-    """Return ``obj[key]`` for dicts, ``obj.key`` for objects, else ``default``.
-
-    Strands' ``agent.messages`` may return dicts (Anthropic native shape) or
-    model-shape objects depending on the model client. Falling back through
-    both lets the diagnostic capture see every tool call.
-    """
-    if isinstance(obj, dict):
-        return obj.get(key, default)
-    return getattr(obj, key, default)
-
-
-def _log_agent_tool_calls(agent: Any, label: str, *, since_index: int = 0) -> int:
-    """Dump every tool call the agent made (via ``agent.messages``).
-
-    Returns the new message-history length so callers can chain this across
-    phases. No-ops cleanly if the message history isn't iterable.
-    """
-    messages = getattr(agent, "messages", None)
-    if not isinstance(messages, list):
-        diag_logger.info("[%s] agent.messages not accessible", label)
-        return since_index
-
-    new_messages = messages[since_index:]
-    tool_calls: list[dict[str, Any]] = []
-    for msg in new_messages:
-        if _get(msg, "role") != "assistant":
-            continue
-        content = _get(msg, "content")
-        if not isinstance(content, list):
-            continue
-        for block in content:
-            block_type = _get(block, "type")
-            if block_type == "tool_use":
-                tool_calls.append({
-                    "name": _get(block, "name"),
-                    "input": _get(block, "input") or {},
-                })
-                continue
-            tool_use_inner = _get(block, "toolUse")
-            if tool_use_inner is not None:
-                tool_calls.append({
-                    "name": _get(tool_use_inner, "name"),
-                    "input": _get(tool_use_inner, "input") or {},
-                })
-
-    if not tool_calls:
-        diag_logger.info("[%s] no tool calls observed", label)
-        return len(messages)
-
-    diag_logger.info("[%s] %d tool call(s):", label, len(tool_calls))
-    for i, call in enumerate(tool_calls, 1):
-        inp = call["input"] or {}
-        compact = {
-            k: (v if not isinstance(v, str) or len(v) <= 80 else v[:77] + "...")
-            for k, v in inp.items()
-        }
-        diag_logger.info("  %2d. %s(%s)", i, call["name"], compact)
-    return len(messages)
-
-
-def _log_prompt(label: str, prompt: str) -> None:
-    """Echo a multi-line prompt to the diag logger (verbose mode only)."""
-    diag_logger.info("[%s] prompt sent to agent:", label)
-    for line in prompt.split("\n"):
-        diag_logger.info("  %s", line)
 
 
 # ---------------------------------------------------------------------------
@@ -383,8 +228,6 @@ def record_demonstration(
     so the agent doesn't waste calls destroying and recreating it. One
     prompt → one tool sequence → one episode.
     """
-    msg_idx = len(getattr(agent, "messages", []) or [])
-
     push_clause = (
         f"Push the result to {repo_id} when done."
         if push_to_hub
@@ -420,11 +263,7 @@ def record_demonstration(
             f"to {repo_id} at FPS 30. {push_clause}"
         )
 
-    _log_prompt("record", prompt)
-    result = agent(prompt)
-    _log_agent_tool_calls(agent, "record", since_index=msg_idx)
-    _log_dataset_summary(repo_id)
-    return result
+    return agent(prompt)
 
 
 # ---------------------------------------------------------------------------
@@ -482,11 +321,7 @@ def run_policy(
     else:
         raise SystemExit(f"Unknown policy: {policy!r}")
 
-    msg_idx = len(getattr(agent, "messages", []) or [])
-    _log_prompt("policy", prompt)
-    result = agent(prompt)
-    _log_agent_tool_calls(agent, "policy", since_index=msg_idx)
-    return result
+    return agent(prompt)
 
 
 # ---------------------------------------------------------------------------
@@ -500,11 +335,7 @@ def broadcast_to_mesh(agent: Any, instruction: str = "go to home pose") -> Any:
         f"broadcast the instruction '{instruction}' to each one with a "
         f"5-second timeout."
     )
-    msg_idx = len(getattr(agent, "messages", []) or [])
-    _log_prompt("mesh", prompt)
-    result = agent(prompt)
-    _log_agent_tool_calls(agent, "mesh", since_index=msg_idx)
-    return result
+    return agent(prompt)
 
 
 # ---------------------------------------------------------------------------
@@ -620,12 +451,6 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help="Skip the mesh broadcast step (Step 5).",
     )
 
-    p.add_argument(
-        "--verbose", "-v", action="store_true",
-        help="Show the prompt the agent receives, every tool call (with "
-             "arguments), and detailed dataset state. Off by default.",
-    )
-
     return p.parse_args(argv)
 
 
@@ -645,10 +470,6 @@ def main(argv: list[str] | None = None) -> int:
         datefmt="%H:%M:%S",
     )
 
-    # Gate the diagnostic logger: by default suppress its INFO output,
-    # only show on --verbose.
-    diag_logger.setLevel(logging.INFO if args.verbose else logging.WARNING)
-
     push_to_hub = bool(args.hf_user)
     repo_id = (
         f"{args.hf_user}/{args.dataset_name}"
@@ -658,7 +479,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.clean_cache:
         import shutil
-        cache_dir = _lerobot_cache_root(repo_id)
+        cache_dir = Path.home() / ".cache" / "huggingface" / "lerobot" / repo_id
         if cache_dir.exists():
             logger.info("Removing cache at %s", cache_dir)
             shutil.rmtree(cache_dir)

--- a/examples/lerobot/hub_to_hardware.py
+++ b/examples/lerobot/hub_to_hardware.py
@@ -20,7 +20,15 @@ Quick start (no hardware, no GPU, no Hub credentials needed):
 
     python hub_to_hardware.py
 
-(For sim-only runs you can disable the mesh entirely with STRANDS_MESH=0.)
+(For sim-only runs you can disable the mesh entirely with STRANDS_MESH=false.)
+
+Note on Step 5: by default the robot_mesh tool routes every physically-actuating
+action -- emergency_stop, broadcast, tell, send, stop -- through a
+human-in-the-loop approval interrupt (set STRANDS_MESH_HITL_ACTIONS to "all",
+"none", or a comma-separated subset to tune this). The first time the agent
+invokes a broadcast, you'll see a "robot_mesh-broadcast-approval" prompt in the
+terminal. Type "y" (or "yes" / "approve") to authorize. To skip Step 5 entirely,
+pass --skip-mesh.
 
 Push the recorded dataset to the Hub (requires HF_TOKEN with write scope):
 
@@ -29,7 +37,7 @@ Push the recorded dataset to the Hub (requires HF_TOKEN with write scope):
 
 Override the LLM (verify exact Bedrock ID in your AWS console):
 
-    python hub_to_hardware.py --model-id global.anthropic.claude-sonnet-4-6
+    python hub_to_hardware.py --model-id us.anthropic.claude-sonnet-4-6
 
 The AWS region resolves from your AWS environment (AWS_REGION /
 AWS_DEFAULT_REGION env vars, ~/.aws/config, or instance metadata). To
@@ -41,7 +49,7 @@ Run with the GR00T container as the policy (requires Docker + NVIDIA GPU):
         --policy groot \\
         --checkpoint nvidia/GR00T-N1.7-LIBERO
 
-Run on physical hardware (requires SO-101 follower + leader, calibrated):
+Run on physical hardware (assumes SO-101 already calibrated via lerobot calibrate):
 
     python hub_to_hardware.py \\
         --mode real \\
@@ -94,7 +102,7 @@ diag_logger = logging.getLogger("hub_to_hardware.diag")
 # profile IDs are prefixed by ``us.``, ``eu.``, etc. - pick the one for
 # your region. Override at runtime via --model-id or STRANDS_BEDROCK_MODEL_ID
 # without editing this file.
-DEFAULT_MODEL_ID = "global.anthropic.claude-opus-4-8"  # ← verify in AWS console
+DEFAULT_MODEL_ID = "us.anthropic.claude-opus-4-8"  # ← verify in AWS console
 # Region is intentionally not defaulted in code. It resolves from the
 # --aws-region CLI flag, then AWS_REGION / AWS_DEFAULT_REGION env vars,
 # then boto3's standard chain (~/.aws/config, instance metadata).
@@ -103,7 +111,6 @@ DEFAULT_MODEL_ID = "global.anthropic.claude-opus-4-8"  # ← verify in AWS conso
 # ---------------------------------------------------------------------------
 # Dataset location + state helpers
 # ---------------------------------------------------------------------------
-
 
 def _lerobot_cache_root(repo_id: str) -> Path:
     """Return the on-disk LeRobotDataset cache directory for ``repo_id``."""
@@ -132,7 +139,6 @@ def _read_dataset_state(repo_id: str) -> dict[str, Any]:
 
     try:
         from lerobot.datasets.lerobot_dataset import LeRobotDataset
-
         ds = LeRobotDataset(repo_id)
         result["status"] = "ready"
         result["num_episodes"] = int(getattr(ds, "num_episodes", 0))
@@ -157,9 +163,7 @@ def _log_dataset_summary(repo_id: str) -> None:
     if status == "ready":
         logger.info(
             "✅ Dataset ready: %d episode(s), %d frame(s) → %s",
-            state["num_episodes"],
-            state["total_frames"],
-            state["cache_path"],
+            state["num_episodes"], state["total_frames"], state["cache_path"],
         )
     elif status == "missing":
         logger.warning(
@@ -168,9 +172,9 @@ def _log_dataset_summary(repo_id: str) -> None:
         )
     elif status == "not_finalized":
         logger.warning(
-            "❌ Cache at %s isn't a complete dataset (%s) - stop_recording may not have run",
-            state["cache_path"],
-            state["error"],
+            "❌ Cache at %s isn't a complete dataset (%s) - "
+            "stop_recording may not have run",
+            state["cache_path"], state["error"],
         )
     else:
         logger.warning("❌ Dataset check failed: %s", state["error"])
@@ -179,7 +183,6 @@ def _log_dataset_summary(repo_id: str) -> None:
 # ---------------------------------------------------------------------------
 # Diagnostic tool-call capture (verbose mode only)
 # ---------------------------------------------------------------------------
-
 
 def _get(obj: Any, key: str, default: Any = None) -> Any:
     """Return ``obj[key]`` for dicts, ``obj.key`` for objects, else ``default``.
@@ -215,21 +218,17 @@ def _log_agent_tool_calls(agent: Any, label: str, *, since_index: int = 0) -> in
         for block in content:
             block_type = _get(block, "type")
             if block_type == "tool_use":
-                tool_calls.append(
-                    {
-                        "name": _get(block, "name"),
-                        "input": _get(block, "input") or {},
-                    }
-                )
+                tool_calls.append({
+                    "name": _get(block, "name"),
+                    "input": _get(block, "input") or {},
+                })
                 continue
             tool_use_inner = _get(block, "toolUse")
             if tool_use_inner is not None:
-                tool_calls.append(
-                    {
-                        "name": _get(tool_use_inner, "name"),
-                        "input": _get(tool_use_inner, "input") or {},
-                    }
-                )
+                tool_calls.append({
+                    "name": _get(tool_use_inner, "name"),
+                    "input": _get(tool_use_inner, "input") or {},
+                })
 
     if not tool_calls:
         diag_logger.info("[%s] no tool calls observed", label)
@@ -238,7 +237,10 @@ def _log_agent_tool_calls(agent: Any, label: str, *, since_index: int = 0) -> in
     diag_logger.info("[%s] %d tool call(s):", label, len(tool_calls))
     for i, call in enumerate(tool_calls, 1):
         inp = call["input"] or {}
-        compact = {k: (v if not isinstance(v, str) or len(v) <= 80 else v[:77] + "...") for k, v in inp.items()}
+        compact = {
+            k: (v if not isinstance(v, str) or len(v) <= 80 else v[:77] + "...")
+            for k, v in inp.items()
+        }
         diag_logger.info("  %2d. %s(%s)", i, call["name"], compact)
     return len(messages)
 
@@ -253,7 +255,6 @@ def _log_prompt(label: str, prompt: str) -> None:
 # ---------------------------------------------------------------------------
 # Agent construction
 # ---------------------------------------------------------------------------
-
 
 def _build_bedrock_model(model_id: str, region: str | None) -> Any | None:
     """Construct a Strands BedrockModel client.
@@ -290,9 +291,7 @@ def _build_bedrock_model(model_id: str, region: str | None) -> Any | None:
             "BedrockModel(%s, region=%s) init failed: %s. Falling back to "
             "Strands' default. Common causes: model not enabled in this AWS "
             "account, wrong region, or stale model ID - check the Bedrock console.",
-            model_id,
-            region or "<unset>",
-            exc,
+            model_id, region or "<unset>", exc,
         )
         return None
 
@@ -308,20 +307,18 @@ def build_agent(
 ) -> Any:
     """Build the Strands agent with the right tool set for the run."""
     from strands import Agent
-
     from strands_robots import (
         Robot,
-        lerobot_calibrate,
-        lerobot_teleoperate,
         robot_mesh,
     )
-
-    tools: list[Any] = [lerobot_teleoperate, lerobot_calibrate, robot_mesh]
 
     robot_kwargs: dict[str, Any] = {"data_config": "so100_dualcam"}
     if mode == "real":
         if not port:
-            raise SystemExit("--mode real requires --port (e.g. /dev/ttyACM0). Hardware paths can't be guessed safely.")
+            raise SystemExit(
+                "--mode real requires --port (e.g. /dev/ttyACM0). "
+                "Hardware paths can't be guessed safely."
+            )
         robot_kwargs.update(
             port=port,
             cameras={
@@ -339,26 +336,37 @@ def build_agent(
         )
 
     robot = Robot("so100", mode=mode, **robot_kwargs)
-    tools.append(robot)
+    tools: list[Any] = [robot, robot_mesh]
 
     if policy == "groot":
         from strands_robots import gr00t_inference
-
         tools.append(gr00t_inference)
 
-    resolved_model_id = model_id or os.environ.get("STRANDS_BEDROCK_MODEL_ID") or DEFAULT_MODEL_ID
-    resolved_region = aws_region or os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION")
+    resolved_model_id = (
+        model_id
+        or os.environ.get("STRANDS_BEDROCK_MODEL_ID")
+        or DEFAULT_MODEL_ID
+    )
+    resolved_region = (
+        aws_region
+        or os.environ.get("AWS_REGION")
+        or os.environ.get("AWS_DEFAULT_REGION")
+    )
     model = _build_bedrock_model(resolved_model_id, resolved_region)
 
     agent = Agent(model=model, tools=tools) if model else Agent(tools=tools)
     agent._leader_port = leader_port  # type: ignore[attr-defined]
+    # Stash the robot so cleanup() can tear down its sim world + mesh session
+    # on exit. Both Simulation and HardwareRobot expose cleanup(); without it
+    # the Zenoh mesh listener and the MuJoCo executor keep non-daemon threads
+    # alive and the process never exits after the workflow finishes.
+    agent._robot = robot  # type: ignore[attr-defined]
     return agent
 
 
 # ---------------------------------------------------------------------------
 # Step 2: Record a demonstration
 # ---------------------------------------------------------------------------
-
 
 def record_demonstration(
     agent: Any,
@@ -403,12 +411,13 @@ def record_demonstration(
     else:
         leader_port = getattr(agent, "_leader_port", None)
         if not leader_port:
-            raise SystemExit("Hardware recording requires --leader-port (e.g. /dev/ttyACM1)")
+            raise SystemExit(
+                "Hardware recording requires --leader-port (e.g. /dev/ttyACM1)"
+            )
         prompt = (
-            f"Confirm calibrations exist for the so101_follower and "
-            f"so101_leader. Then teleoperate to record one demonstration "
-            f"of '{task}', with the leader on {leader_port}. Write the "
-            f"dataset to {repo_id} at FPS 30. {push_clause}"
+            f"Record one demonstration of '{task}' on the SO-101, "
+            f"with the leader on {leader_port}. Write the dataset "
+            f"to {repo_id} at FPS 30. {push_clause}"
         )
 
     _log_prompt("record", prompt)
@@ -421,7 +430,6 @@ def record_demonstration(
 # ---------------------------------------------------------------------------
 # Step 3: Run a policy on the robot
 # ---------------------------------------------------------------------------
-
 
 def run_policy(
     agent: Any,
@@ -439,7 +447,10 @@ def run_policy(
 
     elif policy == "groot":
         if not checkpoint:
-            raise SystemExit("--policy groot requires --checkpoint <hf_repo>, e.g. nvidia/GR00T-N1.7-LIBERO")
+            raise SystemExit(
+                "--policy groot requires --checkpoint <hf_repo>, "
+                "e.g. nvidia/GR00T-N1.7-LIBERO"
+            )
         prompt = (
             f"Use gr00t_inference lifecycle='full' to bring up the GR00T "
             f"container on port 5555 with checkpoint {checkpoint}. Then "
@@ -450,13 +461,18 @@ def run_policy(
     elif policy == "lerobot_local":
         if not checkpoint:
             raise SystemExit(
-                "--policy lerobot_local requires --checkpoint <hf_repo>, e.g. lerobot/act_aloha_sim_transfer_cube_human"
+                "--policy lerobot_local requires --checkpoint <hf_repo>, "
+                "e.g. lerobot/act_aloha_sim_transfer_cube_human"
             )
         if os.environ.get("STRANDS_TRUST_REMOTE_CODE") != "1":
             raise SystemExit(
                 "lerobot_local requires STRANDS_TRUST_REMOTE_CODE=1 to opt "
                 "in to trust_remote_code loading. Re-run with that env var."
             )
+        # MolmoAct2 checkpoints (e.g. allenai/MolmoAct2-SO100_101) also run
+        # through this path: LerobotLocalPolicy auto-detects model_type ==
+        # "molmoact2" from the checkpoint's config.json and routes to the
+        # dedicated transformers-native loader. No separate provider needed.
         prompt = (
             f"Run the LerobotLocal policy '{checkpoint}' on the robot with "
             f"the instruction '{instruction}' for 200 steps. Render the "
@@ -477,7 +493,6 @@ def run_policy(
 # Step 5: Mesh broadcast
 # ---------------------------------------------------------------------------
 
-
 def broadcast_to_mesh(agent: Any, instruction: str = "go to home pose") -> Any:
     """Discover mesh peers and broadcast a command to all of them."""
     prompt = (
@@ -496,7 +511,6 @@ def broadcast_to_mesh(agent: Any, instruction: str = "go to home pose") -> Any:
 # Cleanup
 # ---------------------------------------------------------------------------
 
-
 def cleanup(agent: Any, *, policy: str) -> None:
     """Tear down any long-running resources the workflow started."""
     if policy == "groot":
@@ -505,11 +519,22 @@ def cleanup(agent: Any, *, policy: str) -> None:
         except Exception as exc:  # noqa: BLE001
             logger.warning("GR00T stop reported: %s", exc)
 
+    # Release the robot's sim world / hardware connection and its Zenoh mesh
+    # session. Both Simulation and HardwareRobot expose cleanup(); these own
+    # non-daemon threads (the mesh listener, the MuJoCo executor) that would
+    # otherwise keep the interpreter alive and make the script appear to hang
+    # after "Workflow finished."
+    robot = getattr(agent, "_robot", None)
+    if robot is not None and hasattr(robot, "cleanup"):
+        try:
+            robot.cleanup()
+        except Exception as exc:  # noqa: BLE001 - best-effort teardown
+            logger.warning("Robot cleanup reported: %s", exc)
+
 
 # ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
-
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
     p = argparse.ArgumentParser(
@@ -533,7 +558,8 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     p.add_argument(
         "--checkpoint",
         default=None,
-        help="HF repo for the policy checkpoint (required for --policy groot or lerobot_local).",
+        help="HF repo for the policy checkpoint "
+             "(required for --policy groot or lerobot_local).",
     )
 
     # LLM knobs
@@ -541,74 +567,63 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "--model-id",
         default=None,
         help=f"Bedrock model ID to drive the agent. Default: {DEFAULT_MODEL_ID}. "
-        f"Override here or via STRANDS_BEDROCK_MODEL_ID. Verify the exact "
-        f"ID against your AWS Bedrock console.",
+             f"Override here or via STRANDS_BEDROCK_MODEL_ID. Verify the exact "
+             f"ID against your AWS Bedrock console.",
     )
     p.add_argument(
         "--aws-region",
         default=None,
         help="AWS region for Bedrock. If unset, resolves from AWS_REGION / "
-        "AWS_DEFAULT_REGION env vars or ~/.aws/config (boto3's standard chain).",
+             "AWS_DEFAULT_REGION env vars or ~/.aws/config (boto3's standard chain).",
     )
 
     # Hardware knobs
     p.add_argument(
-        "--port",
-        default=None,
+        "--port", default=None,
         help="USB device of the SO-101 follower (--mode real only).",
     )
     p.add_argument(
-        "--leader-port",
-        default=None,
-        help="USB device of the SO-101 leader for teleop (--mode real only).",
+        "--leader-port", default=None,
+        help="USB device of the SO-101 leader arm (--mode real only).",
     )
 
     # Recording knobs
     p.add_argument(
-        "--hf-user",
-        default=None,
+        "--hf-user", default=None,
         help="HF username for the dataset repo. If unset, the dataset stays local.",
     )
     p.add_argument(
-        "--dataset-name",
-        default="strands-cube-pick",
+        "--dataset-name", default="strands-cube-pick",
         help="Dataset name under <hf-user>. Default: strands-cube-pick.",
     )
     p.add_argument(
-        "--num-steps",
-        type=int,
-        default=1000,
-        help="Number of policy steps to record in the demonstration (default: 1000, ≈ 33s of data at 30fps).",
+        "--num-steps", type=int, default=1000,
+        help="Number of policy steps to record in the demonstration "
+             "(default: 1000, ≈ 33s of data at 30fps).",
     )
     p.add_argument(
-        "--instruction",
-        default="pick up the red cube",
+        "--instruction", default="pick up the red cube",
         help="Natural-language task instruction.",
     )
     p.add_argument(
-        "--clean-cache",
-        action="store_true",
+        "--clean-cache", action="store_true",
         help="Delete the local LeRobotDataset cache for this repo before recording.",
     )
 
     # Skip flags
     p.add_argument(
-        "--skip-record",
-        action="store_true",
+        "--skip-record", action="store_true",
         help="Skip the recording step (Step 2).",
     )
     p.add_argument(
-        "--skip-mesh",
-        action="store_true",
+        "--skip-mesh", action="store_true",
         help="Skip the mesh broadcast step (Step 5).",
     )
 
     p.add_argument(
-        "--verbose",
-        "-v",
-        action="store_true",
+        "--verbose", "-v", action="store_true",
         help="Show the prompt the agent receives, every tool call (with "
-        "arguments), and detailed dataset state. Off by default.",
+             "arguments), and detailed dataset state. Off by default.",
     )
 
     return p.parse_args(argv)
@@ -635,11 +650,14 @@ def main(argv: list[str] | None = None) -> int:
     diag_logger.setLevel(logging.INFO if args.verbose else logging.WARNING)
 
     push_to_hub = bool(args.hf_user)
-    repo_id = f"{args.hf_user}/{args.dataset_name}" if push_to_hub else f"local/{args.dataset_name}"
+    repo_id = (
+        f"{args.hf_user}/{args.dataset_name}"
+        if push_to_hub
+        else f"local/{args.dataset_name}"
+    )
 
     if args.clean_cache:
         import shutil
-
         cache_dir = _lerobot_cache_root(repo_id)
         if cache_dir.exists():
             logger.info("Removing cache at %s", cache_dir)
@@ -647,11 +665,7 @@ def main(argv: list[str] | None = None) -> int:
 
     logger.info(
         "Starting workflow (mode=%s, policy=%s, push_to_hub=%s, repo=%s, num_steps=%d)",
-        args.mode,
-        args.policy,
-        push_to_hub,
-        repo_id,
-        args.num_steps,
+        args.mode, args.policy, push_to_hub, repo_id, args.num_steps,
     )
 
     banner("Step 1: Build the agent")

--- a/examples/lerobot/hub_to_hardware.py
+++ b/examples/lerobot/hub_to_hardware.py
@@ -37,7 +37,7 @@ Push the recorded dataset to the Hub (requires HF_TOKEN with write scope):
 
 Override the LLM (verify exact Bedrock ID in your AWS console):
 
-    python hub_to_hardware.py --model-id us.anthropic.claude-sonnet-4-6
+    python hub_to_hardware.py --model-id global.anthropic.claude-sonnet-4-6
 
 The AWS region resolves from your AWS environment (AWS_REGION /
 AWS_DEFAULT_REGION env vars, ~/.aws/config, or instance metadata). To
@@ -102,7 +102,7 @@ diag_logger = logging.getLogger("hub_to_hardware.diag")
 # profile IDs are prefixed by ``us.``, ``eu.``, etc. - pick the one for
 # your region. Override at runtime via --model-id or STRANDS_BEDROCK_MODEL_ID
 # without editing this file.
-DEFAULT_MODEL_ID = "us.anthropic.claude-opus-4-8"  # ← verify in AWS console
+DEFAULT_MODEL_ID = "global.anthropic.claude-opus-4-8"  # ← verify in AWS console
 # Region is intentionally not defaulted in code. It resolves from the
 # --aws-region CLI flag, then AWS_REGION / AWS_DEFAULT_REGION env vars,
 # then boto3's standard chain (~/.aws/config, instance metadata).

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -602,12 +602,11 @@ class RenderingMixin:
             pil_img.save(buffer, format="PNG")
             png_bytes = buffer.getvalue()
 
-            # base64-encode for transport through the Strands tool-response
-            # serializer (which expects strings, not raw bytes, for image
-            # content in the Bedrock/Anthropic multimodal format).
-            import base64 as _b64
-
-            png_b64 = _b64.b64encode(png_bytes).decode("ascii")
+            # Pass raw PNG bytes in the image content block. The boto3 Bedrock
+            # Converse API (and the Strands serializer over it) expects raw
+            # bytes in ``source.bytes`` and base64-encodes them on the wire.
+            # Pre-encoding to a base64 string here double-encodes and Bedrock
+            # rejects it with "Could not process image".
 
             # summary stats so render_all can flag empty-looking frames
             # without decoding the PNG a second time.
@@ -620,7 +619,7 @@ class RenderingMixin:
                 "status": "success",
                 "content": [
                     {"text": f"📸 {w}x{h} from '{label}' at t={self._world.sim_time:.3f}s"},
-                    {"image": {"format": "png", "source": {"bytes": png_b64}}},
+                    {"image": {"format": "png", "source": {"bytes": png_bytes}}},
                     {"json": {"pixel_variance": pixel_var, "pixel_mean": pixel_mean, "camera": label}},
                 ],
             }

--- a/tests/simulation/mujoco/test_render_after_scene_edit.py
+++ b/tests/simulation/mujoco/test_render_after_scene_edit.py
@@ -145,3 +145,26 @@ class TestRenderAfterSceneEdit:
         for i, img in enumerate(frames):
             bf = _black_fraction(img)
             assert bf < 0.5, f"frame after block_{i} is {bf:.1%} black"
+
+    def test_render_returns_raw_png_bytes_not_base64(self, sim: Simulation) -> None:
+        """Pin the image-content contract: render() must emit RAW PNG bytes in
+        ``source.bytes``, not a base64 str.
+
+        The boto3 Bedrock Converse client base64-encodes ``source.bytes`` on the
+        wire. Pre-encoding to a base64 str in render() double-encoded the image
+        and Bedrock rejected it ("ConverseStream: Could not process image"). The
+        other render tests defensively b64decode both str and bytes, so they
+        never pinned this contract and the double-encode shipped unnoticed.
+        """
+        _skip_if_no_gl()
+        sim.create_world()
+        r = sim.render(camera_name="default", width=320, height=240)
+        assert r["status"] == "success", r
+        block = next((c for c in r.get("content", []) if "image" in c), None)
+        assert block is not None, "render returned no image block"
+        raw = block["image"]["source"]["bytes"]
+        assert isinstance(raw, (bytes, bytearray)), (
+            "render() must return raw bytes in source.bytes; boto3 base64-encodes "
+            f"on the wire, so a str double-encodes. Got {type(raw).__name__}."
+        )
+        assert bytes(raw[:8]) == b"\x89PNG\r\n\x1a\n", "source.bytes is not a valid PNG payload"


### PR DESCRIPTION

  - Hyphenated lerobot-record / -calibrate / -train CLI commands
  - STRANDS_MESH=false (literal string) to disable the mesh
  - Remove dead molmoact argparse branch; MolmoAct2 runs through lerobot_local
  - README: fix multi-episode loop to use start_recording/stop_recording cycle
  - Fix sim render: pass raw PNG bytes (not base64) to Bedrock source.bytes; the double-encode caused ConverseStream 'Could not process image'

Updates the LeRobot example to match the companion blog post and the current SDK behavior. Several documentation defects are fixed along the way.

CLI and environment corrections: hyphenated LeRobot console scripts `lerobot-record`, `lerobot-calibrate`, `lerobot-train` (the bare `lerobot` command does not exist in `lerobot==0.5.1`); `STRANDS_MESH=false` to disable the mesh, since the parser in `mesh/core.py` only accepts the literal `"false"` string; em-dash CLI flags in the blog rendered as `--` so copy-paste works.

Policy provider corrections: removed the unreachable `elif policy == "molmoact":` branch in `hub_to_hardware.py` (argparse choices are `mock`/`groot`/`lerobot_local`, so the branch could never run). MolmoAct2 checkpoints such as `allenai/MolmoAct2-SO100_101` are auto-detected via `config.json` and routed through `lerobot_local`, not a peer provider. The README policy table and "what's next" bullet now list MolmoAct2 under LerobotLocal with the auto-detection note.

Notebook and README fixes: the notebook's calibration prompt now points at the `lerobot-calibrate` shell command (the `lerobot_calibrate` AgentTool only manages calibration files, it has no `calibrate` action). The README "Production patterns" multi-episode snippet uses the real `start_recording` / `stop_recording` lifecycle; the previously-shown `save_episode` action does not exist in the simulation tool spec. A short caveat note flags that the exact kwarg shape should be verified against the SDK before relying on it in production.

Architecture diagram and copy: label `MolmoAct` → `MolmoAct2`; `Byte-compatible w/ sim datasets` → `Same on-disk format as sim datasets` (the recorder guarantees schema and layout, not byte-identity, since video encoder settings can vary). Real-Time Chunking gate corrected to "ships an `rtc_config` (π0, SmolVLA)" rather than "exposes `predict_action_chunk`" so the description matches the actual flow-matching policy check.

Verified end-to-end in sim with `python examples/lerobot/hub_to_hardware.py --clean-cache --skip-mesh`; recording lands at `~/.cache/huggingface/lerobot/local/strands-cube-pick/`, the notebook parses as valid JSON, and the SVG is valid XML.

## SDK fix: sim render image encoding

  `simulation/mujoco/rendering.py` was base64-encoding the rendered PNG into a
  string before placing it in the Bedrock Converse image block
  (`source.bytes`). boto3 base64-encodes that field on the wire itself, so the
  pre-encoding double-encoded the image and Bedrock rejected the request with:

      ConverseStream: ValidationException — The model returned the following
      errors: Could not process image

  Fix: pass the raw PNG bytes to `source.bytes` (the encoding the boto3 Bedrock
  client expects). One-line change in `render()`; `render_all()` reuses it, so
  both paths are covered.

  This is what the example's Step 3 (`run_policy` -> render the final frame)
  depends on — without it, `hub_to_hardware.py` fails at the render step on
  current `main`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
