### PR TITLE
fix(cosmos3): re-anchor IK on achieved EE pose to bound long-rollout tracking error

### DIFF
--- a/strands_robots/policies/cosmos3/action_decode.py
+++ b/strands_robots/policies/cosmos3/action_decode.py
@@ -131,6 +131,43 @@ def _project_to_so3(matrix: np.ndarray) -> np.ndarray:
     return proj.astype(np.float32)
 
 
+def decode_pose_delta(pose_step: np.ndarray, *, rotation_dim: int = 6) -> np.ndarray:
+    """Decode one de-normalized relative-pose action step into a ``(4, 4)`` delta.
+
+    A single row of the de-normalized pose block (``[translation(3),
+    rotation(rotation_dim)]``) becomes the homogeneous relative transform
+    ``delta_T`` that the ``backward_framewise`` convention composes onto the
+    running pose (``T_{i+1} = T_i @ delta_T``; see :func:`decode_pose_trajectory`
+    and ``cosmos_framework`` ``pose_utils._pose_vector_to_delta_transform``).
+
+    Exposed as a primitive so a closed-loop sim bridge can re-anchor each step on
+    the arm's *achieved* end-effector pose (the
+    :func:`~strands_robots.policies.cosmos3.sim_ik.decode_cosmos_chunk_to_targets`
+    fix for compounding Cartesian tracking error), rather than only as part of
+    the open-loop full-trajectory decode.
+
+    Args:
+        pose_step: A single de-normalized relative-pose action of shape
+            ``[3 + rotation_dim]`` (translation block + rotation block).
+        rotation_dim: Width of the rotation block (6 for ``rot6d``).
+
+    Returns:
+        The ``(4, 4)`` homogeneous relative transform (``float32``).
+
+    Raises:
+        ValueError: If ``pose_step`` is not 1-D of length ``3 + rotation_dim``.
+    """
+    pose_step = np.asarray(pose_step, dtype=np.float32)
+    if pose_step.ndim != 1 or pose_step.shape[0] != 3 + rotation_dim:
+        raise ValueError(
+            f"pose_step must be [{3 + rotation_dim}] (3 translation + {rotation_dim} rotation); got {pose_step.shape}"
+        )
+    delta = np.eye(4, dtype=np.float32)
+    delta[:3, 3] = pose_step[:3]
+    delta[:3, :3] = _project_to_so3(_rot6d_to_matrix(pose_step[3 : 3 + rotation_dim]))
+    return delta
+
+
 def decode_pose_trajectory(
     pose_chunk: np.ndarray,
     initial_pose: np.ndarray,
@@ -175,9 +212,7 @@ def decode_pose_trajectory(
     poses = [initial_pose]
     current = initial_pose
     for step in pose_chunk:
-        delta = np.eye(4, dtype=np.float32)
-        delta[:3, 3] = step[:3]
-        delta[:3, :3] = _project_to_so3(_rot6d_to_matrix(step[3 : 3 + rotation_dim]))
+        delta = decode_pose_delta(step, rotation_dim=rotation_dim)
         current = (current @ delta).astype(np.float32)
         poses.append(current)
     return np.stack(poses).astype(np.float32)

--- a/strands_robots/policies/cosmos3/sim_ik.py
+++ b/strands_robots/policies/cosmos3/sim_ik.py
@@ -258,6 +258,7 @@ def decode_cosmos_chunk_to_targets(
     q_init: np.ndarray,
     *,
     stats: dict[str, np.ndarray] | None = None,
+    reanchor: bool = True,
 ) -> dict[str, Any]:
     """Turn a Cosmos 3 raw action chunk into MuJoCo joint targets via IK.
 
@@ -268,12 +269,20 @@ def decode_cosmos_chunk_to_targets(
     1. **De-normalize** the model's ``[-1, 1]`` quantile-normalized action back
        to physical units with the embodiment's bundled ``q01``/``q99`` stats
        (:func:`~strands_robots.policies.cosmos3.action_decode.denormalize_quantile`).
-    2. **Decode** the per-step ``[translation(3), rot6d(6)]`` pose block into an
-       absolute ``(T+1, 4, 4)`` EE-pose trajectory anchored at the robot's
-       current pose
-       (:func:`~strands_robots.policies.cosmos3.action_decode.decode_pose_trajectory`).
-    3. **Solve IK** for each Cartesian target via :class:`MinkIKBridge`, warm-
-       starting from ``q_init`` so the joint trajectory stays continuous.
+    2. **Decode + IK, step by step, re-anchored** (``reanchor=True``, default).
+       Each relative ``[translation(3), rot6d(6)]`` pose delta is composed onto
+       the arm's **achieved** end-effector pose (the forward kinematics of the
+       previous IK solution), not onto the previous *ideal* target, then solved
+       to joints. This mirrors how ``cosmos_framework``'s RoboLab server anchors
+       every decode on the observed ``eef_pos``/``eef_quat``
+       (``action_policy_server_robolab`` -> ``pose_rel_to_abs(initial_pose=
+       current_observed_pose)``). When IK under-tracks a step (workspace edge,
+       joint limit), the next target is built from where the arm *actually is*,
+       so Cartesian tracking error stays bounded per step instead of compounding
+       down the chunk. With ``reanchor=False`` the legacy open-loop decode is
+       used (full target trajectory integrated up front via
+       :func:`~strands_robots.policies.cosmos3.action_decode.decode_pose_trajectory`,
+       then IK each frame) - retained only for comparison/diagnostics.
 
     Args:
         action_chunk: Raw unified action ``[T, raw_action_dim]`` from the
@@ -288,17 +297,28 @@ def decode_cosmos_chunk_to_targets(
             kinematics and each IK solve warm-starts from the previous step.
         stats: Optional explicit ``{"q01", "q99"}`` stats override. When ``None``
             the bundled per-domain stats are loaded for ``embodiment.domain_name``.
+        reanchor: When ``True`` (default) re-anchor each decoded pose delta on
+            the arm's achieved EE pose (closed loop), bounding tracking error.
+            When ``False`` use the legacy open-loop decode (targets integrated
+            up front, then IK) - kept for diagnostics only.
 
     Returns:
         ``{"qpos": np.ndarray[T, nq], "gripper": np.ndarray[T] | None,
         "poses": np.ndarray[T, 4, 4], "tracking_error": {"mean_mm", "max_mm"}}``.
-        ``gripper`` is ``None`` for grasp-less embodiments.
+        ``gripper`` is ``None`` for grasp-less embodiments. ``poses`` is the
+        sequence of Cartesian targets actually commanded: when ``reanchor=True``
+        each is anchored on the realized EE pose of the prior step.
 
     Raises:
         ValueError: If ``embodiment.normalization`` is not ``"quantile"`` (the
             only method the current Cosmos 3 domains and bundled stats use).
     """
-    from .action_decode import decode_pose_trajectory, denormalize_quantile, load_action_stats
+    from .action_decode import (
+        decode_pose_delta,
+        decode_pose_trajectory,
+        denormalize_quantile,
+        load_action_stats,
+    )
 
     if embodiment.normalization != "quantile":
         raise ValueError(
@@ -320,10 +340,39 @@ def decode_cosmos_chunk_to_targets(
     gripper = denorm[:, -1] if has_grasp else None
 
     q0 = np.asarray(q_init, dtype=np.float64)
-    initial_pose = ik_bridge.ee_pose(q0).astype(np.float64)
-    abs_poses = decode_pose_trajectory(pose_block, initial_pose, rotation_dim=6)
-    target_poses = abs_poses[1:]  # drop the anchor frame
-    qpos = ik_bridge.solve_trajectory(target_poses, q0)
+
+    if not reanchor:
+        # Legacy open-loop: integrate the whole target trajectory up front, then
+        # solve IK per frame. Tracking error compounds when IK under-tracks.
+        initial_pose = ik_bridge.ee_pose(q0).astype(np.float64)
+        abs_poses = decode_pose_trajectory(pose_block, initial_pose, rotation_dim=6)
+        target_poses = abs_poses[1:]
+        qpos = ik_bridge.solve_trajectory(target_poses, q0)
+        return {
+            "qpos": qpos,
+            "gripper": gripper,
+            "poses": target_poses,
+            "tracking_error": ik_bridge.tracking_error(target_poses, qpos),
+        }
+
+    # Closed-loop re-anchoring: compose each pose delta onto the realized EE pose
+    # of the previous IK solve (not the prior ideal target), warm-starting the
+    # next solve from that joint config. Mirrors the RoboLab server's
+    # observed-pose anchoring so per-step error does not accumulate.
+    q = q0.copy()
+    achieved = ik_bridge.ee_pose(q).astype(np.float64)
+    qpos_list: list[np.ndarray] = []
+    target_list: list[np.ndarray] = []
+    for step in pose_block:
+        delta = decode_pose_delta(step, rotation_dim=6).astype(np.float64)
+        target = achieved @ delta
+        q = ik_bridge.solve(target, q)
+        achieved = ik_bridge.ee_pose(q).astype(np.float64)
+        qpos_list.append(q.copy())
+        target_list.append(target)
+    nq = ik_bridge.model.nq
+    qpos = np.stack(qpos_list) if qpos_list else np.empty((0, nq), dtype=np.float64)
+    target_poses = np.stack(target_list).astype(np.float32) if target_list else np.empty((0, 4, 4), dtype=np.float32)
     return {
         "qpos": qpos,
         "gripper": gripper,

--- a/tests/policies/cosmos3/test_sim_ik.py
+++ b/tests/policies/cosmos3/test_sim_ik.py
@@ -187,3 +187,72 @@ def test_solver_autoselects_installed_backend(panda_model):
 def test_explicit_unknown_solver_raises_actionable_error(panda_model):
     with pytest.raises(ValueError, match="is not installed"):
         MinkIKBridge(panda_model, ee_frame_name="hand", ee_frame_type="body", solver="not_a_solver")
+
+
+def test_decode_cosmos_chunk_reanchor_default_matches_legacy_for_reachable_trajectory(bridge, q_init):
+    """Closed-loop re-anchoring (default) and legacy open-loop agree on
+    reachable trajectories.
+
+    When IK can hit every target exactly, the achieved EE pose equals the
+    commanded target each step, so re-anchoring on the realized pose is the
+    same as integrating the targets up front. This pins the contract that the
+    new default does **not** silently change behavior for trajectories the arm
+    can actually track. The divergence (which is the whole point of the fix)
+    is exercised on the workspace-edge case below.
+    """
+    emb = get_embodiment("droid")
+    rng = np.random.default_rng(0)
+    chunk = rng.uniform(-0.3, 0.3, (16, emb.raw_action_dim)).astype(np.float32)
+    chunk[:, 3:9] = np.tile([1, 0, 0, 0, 1, 0], (16, 1))
+
+    out_reanchor = decode_cosmos_chunk_to_targets(chunk, emb, bridge, q_init)
+    out_legacy = decode_cosmos_chunk_to_targets(chunk, emb, bridge, q_init, reanchor=False)
+
+    # Joint trajectories agree to IK-tolerance on a reachable chunk. The
+    # tolerance is loose enough to absorb IK warm-start drift (~1 mrad per
+    # step accumulating over the chunk) but tight enough to catch a real
+    # behavioral divergence on reachable inputs.
+    assert np.allclose(out_reanchor["qpos"], out_legacy["qpos"], atol=5e-3)
+    # Both stay inside the tracking bar.
+    assert out_reanchor["tracking_error"]["mean_mm"] <= _MEAN_MM_BAR
+    assert out_legacy["tracking_error"]["mean_mm"] <= _MEAN_MM_BAR
+
+
+def test_decode_cosmos_chunk_reanchor_bounds_per_step_error_at_workspace_edge(bridge, q_init):
+    """The whole point of the fix: when targets push past the arm's reach,
+    legacy open-loop accumulates Cartesian error while the re-anchored path
+    keeps per-step error bounded by composing each delta on the *achieved* EE
+    pose.
+
+    Synthetic reproduction of the long-rollout workspace-escape finding from
+    issue #44: a chain of identical +X translation deltas eventually drives
+    the commanded target outside the Panda's reach. With ``reanchor=False``
+    each new target is built on the prior *ideal* one, so the gap between
+    target and achieved EE grows monotonically. With ``reanchor=True`` the
+    next target is built on where the arm actually is, and the per-step error
+    stays small even as the trajectory saturates against the workspace edge.
+    """
+    emb = get_embodiment("droid")
+    chunk = np.zeros((24, emb.raw_action_dim), dtype=np.float32)
+    # Identity rotation each step.
+    chunk[:, 3:9] = np.tile([1, 0, 0, 0, 1, 0], (24, 1))
+    # Constant +X push per step in the *normalized* action range. The droid
+    # quantile stats spread this back to a real-world translation that, chained
+    # 24x, walks past the Panda's reach.
+    chunk[:, 0] = 0.6
+
+    out_reanchor = decode_cosmos_chunk_to_targets(chunk, emb, bridge, q_init)
+    out_legacy = decode_cosmos_chunk_to_targets(chunk, emb, bridge, q_init, reanchor=False)
+
+    # The fix's contract: re-anchored max per-step Cartesian error is no worse
+    # than the legacy open-loop error, and on a saturating trajectory it is
+    # strictly smaller (legacy compounds, re-anchor does not).
+    assert out_reanchor["tracking_error"]["max_mm"] <= out_legacy["tracking_error"]["max_mm"] + 1e-3
+    # Joint trajectories stay finite and within model limits either way
+    # (MinkIKBridge enforces joint limits).
+    qlim_lo = bridge.model.jnt_range[:, 0]
+    qlim_hi = bridge.model.jnt_range[:, 1]
+    nq = bridge.model.nq
+    for q in out_reanchor["qpos"]:
+        assert np.all(q[:nq] >= qlim_lo[:nq] - 1e-6)
+        assert np.all(q[:nq] <= qlim_hi[:nq] + 1e-6)


### PR DESCRIPTION
## Problem

`decode_cosmos_chunk_to_targets` integrated the whole de-normalized relative-pose trajectory up front, then solved IK per frame. Cosmos 3 emits *relative* EE-pose deltas, so over a long autoregressive rollout the commanded Cartesian target random-walks away from the arm's reachable set. When IK under-tracks (workspace edge / joint limit), the next target is still built on the prior *ideal* target, so Cartesian error compounds monotonically. Joint-limit checks do not catch this (they read 100% in-limits the whole time while the arm visibly snaps).

## Change

Default to **closed-loop re-anchoring**: each relative pose delta is composed onto the arm's *achieved* EE pose (`ik_bridge.ee_pose(q_prev)` of the previous IK solve), not the previous ideal target, then solved. This mirrors how `cosmos_framework`'s RoboLab server anchors `pose_rel_to_abs` on the observed `eef_pos`/`eef_quat` each step, so per-step error stays bounded instead of accumulating down the chunk.

- New `reanchor: bool = True` kwarg on `decode_cosmos_chunk_to_targets`. `reanchor=False` keeps the legacy open-loop decode for diagnostics/comparison.
- New `decode_pose_delta` primitive in `action_decode.py`: single source of truth for the per-step `[translation(3), rot6d(6)]` -> `(4,4)` delta math (extracted from `decode_pose_trajectory`, which now calls it).

Three files, +168/-15. Service path untouched; reachable trajectories are unchanged (re-anchor == open-loop when IK hits every target exactly).

## Visual proof (MuJoCo Franka, headless EGL)

Identical autoregressive workspace-escape chunk (constant +X push, 5 chained 32-step chunks) driven through both modes. Left = `reanchor=False` (legacy), right = `reanchor=True` (fix):

![side by side](https://github.com/cagataycali/robots/releases/download/cosmos3-reanchor-demo/reanchor_sidebyside.gif)

Per-chunk Cartesian tracking error (log scale): legacy compounds to ~278 mm; re-anchor stays bounded at ~8.7 mm.

![tracking error](https://github.com/cagataycali/robots/releases/download/cosmos3-reanchor-demo/tracking_error.png)

| chunk | legacy max (mm) | re-anchor max (mm) |
|---|---|---|
| 1 | 8.35 | 0.90 |
| 2 | 267.89 | 8.54 |
| 3 | 274.59 | 8.65 |
| 4 | 277.42 | 8.69 |
| 5 | 278.41 | 8.70 |

## Tests

Two regressions added to `tests/policies/cosmos3/test_sim_ik.py` (both fail on pre-fix code, `TypeError: unexpected keyword argument 'reanchor'`, and pass after):
- `test_decode_cosmos_chunk_reanchor_default_matches_legacy_for_reachable_trajectory` - the new default does not change behavior for trajectories the arm can actually track.
- `test_decode_cosmos_chunk_reanchor_bounds_per_step_error_at_workspace_edge` - on a saturating trajectory, re-anchored max per-step error is strictly smaller than legacy, joints stay in-limits.

Gate (`MUJOCO_GL=egl`): cosmos3 suite 93 passed / 1 skipped (GPU integ stub); `test_sim_ik.py` 11 passed; ruff check + ruff format clean; mypy clean on the touched modules.