### PR TITLE
fix(lerobot_camera): ASCII-only tool output + report async/warmup state (0%->75%)

### DIFF
--- a/strands_robots/tools/lerobot_camera.py
+++ b/strands_robots/tools/lerobot_camera.py
@@ -288,7 +288,7 @@ def _discover_cameras() -> dict[str, Any]:
             for i, cam in enumerate(opencv_cameras):
                 profile = cam.get("default_stream_profile", {})
                 discovery_info.append(
-                    f"  • **{cam.get('name', 'Unknown')}**\n"
+                    f"  - **{cam.get('name', 'Unknown')}**\n"
                     f"    - ID: `{cam.get('id', 'N/A')}`\n"
                     f"    - Backend: {cam.get('backend_api', 'N/A')}\n"
                     f"    - Resolution: {profile.get('width', '?')}x{profile.get('height', '?')}\n"
@@ -301,7 +301,7 @@ def _discover_cameras() -> dict[str, Any]:
             discovery_info.append(" **RealSense Cameras:**")
             for i, cam in enumerate(realsense_cameras):
                 discovery_info.append(
-                    f"  • **{cam.get('name', 'Unknown')}**\n"
+                    f"  - **{cam.get('name', 'Unknown')}**\n"
                     f"    - Serial: `{cam.get('serial_number', 'N/A')}`\n"
                     f"    - Type: {cam.get('type', 'N/A')}"
                 )
@@ -334,7 +334,7 @@ def _list_camera_details(camera_type: str, camera_id: int | str | None = None) -
             details.append(f"   - Backend: {_get_opencv_backend_name()}")
             details.append(f"   - Version: {cv2.__version__}")
             details.append("   - Available color modes: RGB, BGR")
-            details.append("   - Supported rotations: 0°, 90°, 180°, 270°")
+            details.append("   - Supported rotations: 0, 90, 180, 270 degrees")
             details.append("   - Async reading:  Supported")
             details.append("")
 
@@ -449,7 +449,7 @@ def _capture_single_image(
             f"File size: {file_size:,} bytes",
             f"Connect time: {connect_time:.3f}s",
             f"Capture time: {capture_time:.3f}s",
-            f"Async mode: {'' if async_mode else ''}",
+            f"Async mode: {'on' if async_mode else 'off'}",
             f"Timestamp: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}",
         ]
 
@@ -578,7 +578,7 @@ def _capture_batch_images(
                 f"   - Success: {successful_captures}/{len(camera_ids)} cameras",
                 f"   - Total time: {total_time:.3f}s",
                 f"   - Save path: `{save_path}`",
-                f"   - Async mode: {'' if async_mode else ''}",
+                f"   - Async mode: {'on' if async_mode else 'off'}",
             ]
         )
 
@@ -666,10 +666,10 @@ def _record_video_sequence(
             f"Camera: {camera_type.upper()} @ {camera_id}",
             f"Saved: `{video_path}`",
             f"Resolution: {width}x{height}",
-            f"️  Frames: {frames_captured} @ {fps} FPS",
-            f"️  Duration: {actual_duration:.2f}s (target: {capture_duration:.2f}s)",
+            f"Frames: {frames_captured} @ {fps} FPS",
+            f"Duration: {actual_duration:.2f}s (target: {capture_duration:.2f}s)",
             f"File size: {file_size:,} bytes",
-            f"Async mode: {'' if async_mode else ''}",
+            f"Async mode: {'on' if async_mode else 'off'}",
             f"Completed: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}",
         ]
 
@@ -706,7 +706,7 @@ def _preview_camera_live(
         fps_frame_count = 0
 
         print(f"Starting live preview from {camera_type.upper()} camera {camera_id}")
-        print(f"️  Duration: {preview_duration}s | Press 'q' to quit early")
+        print(f"Duration: {preview_duration}s | Press 'q' to quit early")
 
         try:
             while time.time() - start_time < preview_duration:
@@ -766,11 +766,11 @@ def _preview_camera_live(
             " **Live Preview Complete!**",
             f"Camera: {camera_type.upper()} @ {camera_id}",
             f"Resolution: {width}x{height}",
-            f"️  Frames displayed: {frames_displayed}",
-            f"️  Duration: {actual_duration:.2f}s",
+            f"Frames displayed: {frames_displayed}",
+            f"Duration: {actual_duration:.2f}s",
             f"Average FPS: {avg_fps:.2f}",
             f"Target FPS: {fps}",
-            f"Async mode: {'' if async_mode else ''}",
+            f"Async mode: {'on' if async_mode else 'off'}",
         ]
 
         return {"status": "success", "content": [{"text": "\n".join(result_info)}]}
@@ -854,7 +854,7 @@ def _test_camera_performance(
 
         # Camera properties
         if hasattr(camera, "fps"):
-            test_results.append("️  **Camera Configuration**:")
+            test_results.append("**Camera Configuration**:")
             test_results.append(f"   - Configured FPS: {camera.fps}")
             test_results.append(f"   - Resolution: {camera.width}x{camera.height}")
             test_results.append(f"   - Color mode: {camera.color_mode.value}")
@@ -862,14 +862,13 @@ def _test_camera_performance(
         camera.disconnect()
 
         test_results.append("\n **Performance Summary**:")
-        test_results.append(f"   - Connection: {' Fast' if connect_time < 1.0 else '️ Slow'} ({connect_time:.3f}s)")
-        test_results.append(f"   - Sync capture: {' Good' if avg_sync_time < 0.1 else '️ Slow'} ({avg_sync_time:.3f}s)")
+        test_results.append(f"   - Connection: {'Fast' if connect_time < 1.0 else 'Slow'} ({connect_time:.3f}s)")
+        test_results.append(f"   - Sync capture: {'Good' if avg_sync_time < 0.1 else 'Slow'} ({avg_sync_time:.3f}s)")
         if async_mode:
             test_results.append(
-                f"   - Async capture: {' Better' if avg_async_time < avg_sync_time else ' Worse'}"
-                f"({avg_async_time:.3f}s)"
+                f"   - Async capture: {'Better' if avg_async_time < avg_sync_time else 'Worse'} ({avg_async_time:.3f}s)"
             )
-        test_results.append(f"   - Frame rate: {' Stable' if max_sync_time - min_sync_time < 0.05 else '️ Variable'}")
+        test_results.append(f"   - Frame rate: {'Stable' if max_sync_time - min_sync_time < 0.05 else 'Variable'}")
 
         return {"status": "success", "content": [{"text": "\n".join(test_results)}]}
 
@@ -913,13 +912,13 @@ def _configure_camera_settings(
             actual_config["rotation"] = rotation
 
         config_info = [
-            "️  **Camera Configuration**",
+            "**Camera Configuration**",
             f"Camera: {camera_type.upper()} @ {camera_id}",
             f"Resolution: {actual_config['width']}x{actual_config['height']}",
-            f"️  FPS: {actual_config['fps']}",
+            f"FPS: {actual_config['fps']}",
             f"Color mode: {actual_config['color_mode']}",
             f"Rotation: {actual_config.get('rotation', 'NO_ROTATION')}",
-            f"Warmup: {'' if warmup else ''}",
+            f"Warmup: {'on' if warmup else 'off'}",
         ]
 
         # Save configuration if requested

--- a/tests/tools/test_lerobot_camera.py
+++ b/tests/tools/test_lerobot_camera.py
@@ -1,0 +1,266 @@
+"""Behavior tests for the ``lerobot_camera`` agent tool.
+
+The camera tool wraps LeRobot's OpenCV/RealSense camera classes behind a single
+agent-facing dispatcher. These tests exercise every action branch hardware-free
+by substituting a fake camera, and pin two invariants the tool must uphold:
+
+1. Every user-facing ``text`` field is plain ASCII (the project's no-emoji rule).
+2. Boolean operating state (async read mode, connection warmup) is reported with
+   meaningful on/off words, not rendered as an empty string.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import numpy as np
+import pytest
+
+import strands_robots.tools.lerobot_camera as cam_mod
+from strands_robots.tools.lerobot_camera import lerobot_camera
+
+
+def _texts(result: dict[str, Any]) -> str:
+    """Concatenate all content ``text`` fields from a tool result."""
+    return "\n".join(item.get("text", "") for item in result.get("content", []) if "text" in item)
+
+
+def _assert_ascii(text: str) -> None:
+    """Fail if any character is outside the ASCII range."""
+    offenders = {hex(ord(c)) for c in text if ord(c) > 127}
+    assert not offenders, f"non-ASCII characters in tool output: {offenders}"
+
+
+class FakeCamera:
+    """Minimal stand-in for a LeRobot camera object.
+
+    Records connect/disconnect calls and serves a fixed RGB frame for both the
+    synchronous ``read`` and asynchronous ``async_read`` paths.
+    """
+
+    def __init__(self, width: int = 8, height: int = 6, fps: int = 30) -> None:
+        self.width = width
+        self.height = height
+        self.fps = fps
+        self.color_mode = SimpleNamespace(value="RGB")
+        self.rotation = None
+        self.connected = False
+        self.disconnect_calls = 0
+
+    def connect(self, warmup: bool = True) -> None:
+        self.connected = True
+
+    def read(self) -> np.ndarray:
+        return np.zeros((self.height, self.width, 3), dtype=np.uint8)
+
+    def async_read(self, timeout_ms: float = 1000) -> np.ndarray:
+        return np.zeros((self.height, self.width, 3), dtype=np.uint8)
+
+    def disconnect(self) -> None:
+        self.connected = False
+        self.disconnect_calls += 1
+
+
+@pytest.fixture
+def fake_camera(monkeypatch: pytest.MonkeyPatch) -> FakeCamera:
+    """Patch ``_create_camera`` so every action uses a hardware-free camera."""
+    camera = FakeCamera()
+    monkeypatch.setattr(cam_mod, "_create_camera", lambda *a, **k: camera)
+    return camera
+
+
+# --- dispatcher routing + required-parameter validation -------------------
+
+
+def test_unknown_action_returns_error() -> None:
+    result = lerobot_camera(action="does_not_exist")
+    assert result["status"] == "error"
+    assert "Unknown action" in _texts(result)
+
+
+@pytest.mark.parametrize("action", ["capture", "record", "preview", "test", "configure"])
+def test_actions_requiring_camera_id_error_without_it(action: str) -> None:
+    result = lerobot_camera(action=action)
+    assert result["status"] == "error"
+    body = _texts(result)
+    assert "camera_id required" in body
+    _assert_ascii(body)
+
+
+# --- _frame_to_image_content (pure helper) --------------------------------
+
+
+@pytest.mark.parametrize(
+    "fmt,expected",
+    [("jpg", "jpeg"), ("jpeg", "jpeg"), ("png", "png"), ("bmp", "jpeg")],
+)
+def test_frame_to_image_content_formats(fmt: str, expected: str) -> None:
+    frame = np.zeros((4, 4, 3), dtype=np.uint8)
+    content = cam_mod._frame_to_image_content(frame, fmt)
+    assert content["image"]["format"] == expected
+    assert isinstance(content["image"]["source"]["bytes"], bytes)
+    assert content["image"]["source"]["bytes"]
+
+
+def test_frame_to_image_content_handles_encode_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cam_mod.cv2, "imencode", lambda *a, **k: (False, None))
+    content = cam_mod._frame_to_image_content(np.zeros((4, 4, 3), dtype=np.uint8), "jpg")
+    assert "Failed to encode" in content["text"]
+
+
+# --- _create_camera + backend helper --------------------------------------
+
+
+def test_create_camera_rejects_unknown_type() -> None:
+    with pytest.raises(ValueError, match="Unsupported camera type"):
+        cam_mod._create_camera("nonsense", 0, 640, 480, 30, "RGB", "NO_ROTATION")
+
+
+def test_get_opencv_backend_name_is_ascii() -> None:
+    name = cam_mod._get_opencv_backend_name()
+    assert name
+    _assert_ascii(name)
+
+
+# --- list + discover routing ----------------------------------------------
+
+
+def test_list_opencv_details_ascii() -> None:
+    result = lerobot_camera(action="list", camera_type="opencv")
+    assert result["status"] == "success"
+    body = _texts(result)
+    assert "OpenCV Camera System" in body
+    # rotations spelled out in ASCII, not degree symbols
+    assert "0, 90, 180, 270 degrees" in body
+    _assert_ascii(body)
+
+
+def test_discover_uses_ascii_bullets(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_cams = [
+        {
+            "name": "Cam0",
+            "id": 0,
+            "backend_api": "V4L2",
+            "default_stream_profile": {"width": 640, "height": 480, "fps": 30, "format": "MJPG"},
+        }
+    ]
+    monkeypatch.setattr(cam_mod.OpenCVCamera, "find_cameras", staticmethod(lambda: fake_cams))
+    monkeypatch.setattr(cam_mod, "REALSENSE_AVAILABLE", False)
+    result = lerobot_camera(action="discover")
+    assert result["status"] == "success"
+    body = _texts(result)
+    assert "  - **Cam0**" in body  # ASCII hyphen bullet, not a unicode bullet
+    assert "Total: 1 cameras found" in body
+    _assert_ascii(body)
+
+
+# --- capture / batch / record / preview / test / configure ----------------
+
+
+@pytest.mark.parametrize("async_mode,expected", [(True, "Async mode: on"), (False, "Async mode: off")])
+def test_capture_single_reports_async_state_ascii(
+    fake_camera: FakeCamera, tmp_path, async_mode: bool, expected: str
+) -> None:
+    result = lerobot_camera(
+        action="capture",
+        camera_id=0,
+        save_path=str(tmp_path),
+        async_mode=async_mode,
+    )
+    assert result["status"] == "success"
+    body = _texts(result)
+    # Regression: pre-fix this rendered "Async mode: " with an empty value.
+    assert expected in body
+    _assert_ascii(body)
+    assert fake_camera.disconnect_calls == 1
+    # an image payload accompanies the text summary
+    assert any("image" in item for item in result["content"])
+
+
+def test_capture_batch_reports_async_state_ascii(fake_camera: FakeCamera, tmp_path) -> None:
+    result = lerobot_camera(
+        action="capture_batch",
+        camera_ids=[0, 1],
+        save_path=str(tmp_path),
+        async_mode=True,
+    )
+    assert result["status"] == "success"
+    body = _texts(result)
+    assert "Async mode: on" in body
+    assert "Success: 2/2 cameras" in body
+    _assert_ascii(body)
+
+
+def test_record_video_summary_ascii(fake_camera: FakeCamera, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    writer = SimpleNamespace(write=lambda f: None, release=lambda: None)
+    monkeypatch.setattr(cam_mod.cv2, "VideoWriter", lambda *a, **k: writer)
+    monkeypatch.setattr(cam_mod.cv2, "VideoWriter_fourcc", lambda *a, **k: 0, raising=False)
+    monkeypatch.setattr(cam_mod.os.path, "getsize", lambda p: 1234)
+    result = lerobot_camera(
+        action="record",
+        camera_id=0,
+        save_path=str(tmp_path),
+        fps=2,
+        capture_duration=0.5,
+        async_mode=False,
+    )
+    assert result["status"] == "success"
+    body = _texts(result)
+    # Regression: these lines previously carried an orphan U+FE0F variation selector.
+    assert "Frames:" in body
+    assert "Duration:" in body
+    assert "Async mode: off" in body
+    _assert_ascii(body)
+
+
+def test_preview_summary_ascii(fake_camera: FakeCamera, monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in ("imshow", "putText", "destroyAllWindows"):
+        monkeypatch.setattr(cam_mod.cv2, name, lambda *a, **k: None, raising=False)
+    monkeypatch.setattr(cam_mod.cv2, "waitKey", lambda *a, **k: 0, raising=False)
+    monkeypatch.setattr(cam_mod.time, "sleep", lambda *a, **k: None)
+    result = lerobot_camera(action="preview", camera_id=0, fps=2, preview_duration=0.01)
+    assert result["status"] == "success"
+    body = _texts(result)
+    assert "Live Preview Complete" in body
+    assert "Frames displayed:" in body
+    _assert_ascii(body)
+
+
+def test_performance_summary_uses_ascii_labels(fake_camera: FakeCamera) -> None:
+    result = lerobot_camera(action="test", camera_id=0, async_mode=False)
+    assert result["status"] == "success"
+    body = _texts(result)
+    # Regression: summary labels previously embedded leading-space + U+FE0F markers.
+    assert "Connection:" in body
+    assert ("Fast" in body) or ("Slow" in body)
+    assert "Camera Configuration" in body
+    _assert_ascii(body)
+
+
+@pytest.mark.parametrize("warmup,expected", [(True, "Warmup: on"), (False, "Warmup: off")])
+def test_configure_reports_warmup_state_ascii(fake_camera: FakeCamera, tmp_path, warmup: bool, expected: str) -> None:
+    result = lerobot_camera(
+        action="configure",
+        camera_id=0,
+        save_path=str(tmp_path),
+        warmup=warmup,
+        save_config=True,
+    )
+    assert result["status"] == "success"
+    body = _texts(result)
+    # Regression: pre-fix rendered "Warmup: " with an empty value.
+    assert expected in body
+    assert "Configuration Saved" in body
+    _assert_ascii(body)
+    # config JSON actually written
+    assert list(tmp_path.glob("camera_config_*.json"))
+
+
+def test_module_source_is_ascii_only() -> None:
+    """The whole module must be free of non-ASCII characters (no-emoji rule)."""
+    import inspect
+
+    source = inspect.getsource(cam_mod)
+    offenders = sorted({hex(ord(c)) for c in source if ord(c) > 127})
+    assert not offenders, f"non-ASCII characters in module source: {offenders}"


### PR DESCRIPTION
## Problem

The `lerobot_camera` tool emitted non-ASCII characters in its user-facing text, violating the project's ASCII-only tool-output rule (same class already cleaned up in `serial_tool` and `pose_tool`). A scan of the module found:

- **11 orphan `U+FE0F`** variation selectors left over from a prior emoji removal (e.g. on the record/preview/test/configure summary lines, where they rendered as stray invisible bytes before `Frames:`, `Duration:`, `FPS:`, etc.),
- **4 degree signs** (`0°, 90°, 180°, 270°`),
- **2 unicode bullets** (`•`) in the camera-discovery listing.

Two summary fields were also degenerate. Both branches of the ternaries were empty strings:

```python
f"Async mode: {'' if async_mode else ''}"   # always renders "Async mode: "
f"Warmup: {'' if warmup else ''}"            # always renders "Warmup: "
```

so the tool claimed to report its operating state but the value was always blank. The performance-summary labels had the same issue (`{' Fast' if ... else '\ufe0f Slow'}`).

## Change

- Replace all non-ASCII characters with ASCII equivalents: hyphen bullets, `0, 90, 180, 270 degrees`, and plain `Fast`/`Slow`/`Good`/`Stable`/`Better`/`Worse` labels.
- Make the async-mode and warmup fields report meaningful `on`/`off` values.
- No behavior change to capture/record paths beyond the corrected status text.

## Tests

The module had **no test coverage (0%)**. This adds a hardware-free behavior suite (`tests/tools/test_lerobot_camera.py`, 24 cases) that drives every action branch through a fake camera and the pure helpers, and pins two invariants:

1. every user-facing `text` field is plain ASCII (plus a whole-module source ASCII check), and
2. the async-mode / warmup operating state is reported with real `on`/`off` words.

11 of the new cases fail on the pre-fix code (proving they catch both the empty-state and non-ASCII defects) and all pass after. Module coverage **0% -> 75%**; full suite green (`5311 passed`, total coverage 78% -> 80%).

```
MUJOCO_GL=egl hatch run test   # 5311 passed, 60 skipped
hatch run lint                 # ruff check + format clean on changed files
```