### PR TITLE
docs: animated brand SVGs in README + docs, brand-figure CSS treatment

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@
   </p>
 </div>
 
+<p align="center">
+  <img src="docs/assets/hero_loop.svg" alt="Strands Robots - perceive, reason, act, world: the closed control loop around a Strands Agent core" width="100%">
+</p>
+
 `strands-robots` gives a [Strands Agent](https://github.com/strands-agents/harness-sdk)
 hands. One `Robot()` call returns either a **MuJoCo simulation** (default, no GPU,
 no hardware) or a **real hardware robot** - both drivable in natural language,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,6 +4,10 @@ description: One diagram, one source of truth. Module boundaries, ABC contracts,
 
 # Architecture
 
+<figure class="brand-figure" markdown="span">
+  ![Four-layer stack - Agent, Policies, Backends, Robots - with green action signals flowing down and cyan observation signals flowing back up](assets/architecture_flow.svg){ .brand-svg }
+</figure>
+
 ```mermaid
 graph TB
     subgraph user[Your code]

--- a/docs/assets/architecture_flow.svg
+++ b/docs/assets/architecture_flow.svg
@@ -1,0 +1,183 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 560" width="1000" height="560" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <defs>
+    <linearGradient id="ax" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#00FF77"/>
+      <stop offset="0.5" stop-color="#22D3EE"/>
+      <stop offset="1" stop-color="#00FF77"/>
+      <animateTransform attributeName="gradientTransform" type="translate"
+        values="-0.3 0; 0.3 0; -0.3 0" dur="8s" repeatCount="indefinite"/>
+    </linearGradient>
+    <linearGradient id="axTitle" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#7CFFB0"/>
+      <stop offset="0.5" stop-color="#00FF77"/>
+      <stop offset="1" stop-color="#22D3EE"/>
+      <animateTransform attributeName="gradientTransform" type="translate"
+        values="-0.4 0; 0.4 0; -0.4 0" dur="9s" repeatCount="indefinite"/>
+    </linearGradient>
+    <radialGradient id="glowG" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#00FF77" stop-opacity="0.5"/>
+      <stop offset="1" stop-color="#00FF77" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="glowC" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#22D3EE" stop-opacity="0.5"/>
+      <stop offset="1" stop-color="#22D3EE" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <rect x="6" y="6" width="988" height="548" rx="26" fill="#0a0a0a"/>
+  <rect x="6" y="6" width="988" height="548" rx="26" fill="none" stroke="url(#ax)" stroke-opacity="0.25" stroke-width="1.5"/>
+  <!-- animated mesh / network background (soft depth, matches hero) -->
+  <g opacity="0.5">
+    <circle cx="170" cy="120" r="150" fill="url(#glowG)" opacity="0.22"><animateTransform attributeName="transform" type="translate" values="0 0; 38 28; 0 0" dur="22s" repeatCount="indefinite"/></circle>
+    <circle cx="850" cy="450" r="155" fill="url(#glowC)" opacity="0.20"><animateTransform attributeName="transform" type="translate" values="0 0; -38 -30; 0 0" dur="26s" repeatCount="indefinite"/></circle>
+    <line x1="200" y1="67" x2="166" y2="86" stroke="url(#ax)" stroke-width="0.7" stroke-opacity="0.16"><animate attributeName="stroke-opacity" values="0.04;0.28;0.04" dur="6s" begin="0.0s" repeatCount="indefinite"/></line>
+    <line x1="200" y1="67" x2="223" y2="69" stroke="url(#ax)" stroke-width="0.7" stroke-opacity="0.16"><animate attributeName="stroke-opacity" values="0.04;0.28;0.04" dur="7s" begin="0.6s" repeatCount="indefinite"/></line>
+    <line x1="39" y1="41" x2="27" y2="38" stroke="url(#ax)" stroke-width="0.7" stroke-opacity="0.16"><animate attributeName="stroke-opacity" values="0.04;0.28;0.04" dur="8s" begin="1.2s" repeatCount="indefinite"/></line>
+    <line x1="39" y1="41" x2="166" y2="86" stroke="url(#ax)" stroke-width="0.7" stroke-opacity="0.16"><animate attributeName="stroke-opacity" values="0.04;0.28;0.04" dur="9s" begin="1.8s" repeatCount="indefinite"/></line>
+    <line x1="161" y1="191" x2="96" y2="224" stroke="url(#ax)" stroke-width="0.7" stroke-opacity="0.16"><animate attributeName="stroke-opacity" values="0.04;0.28;0.04" dur="10s" begin="2.4s" repeatCount="indefinite"/></line>
+    <line x1="161" y1="191" x2="222" y2="193" stroke="url(#ax)" stroke-width="0.7" stroke-opacity="0.16"><animate attributeName="stroke-opacity" values="0.04;0.28;0.04" dur="11s" begin="0.0s" repeatCount="indefinite"/></line>
+    <line x1="161" y1="191" x2="161" y2="169" stroke="url(#ax)" stroke-width="0.7" stroke-opacity="0.16"><animate attributeName="stroke-opacity" values="0.04;0.28;0.04" dur="12s" begin="0.6s" repeatCount="indefinite"/></line>
+    <line x1="27" y1="38" x2="166" y2="86" stroke="url(#ax)" stroke-width="0.7" stroke-opacity="0.16"><animate attributeName="stroke-opacity" values="0.04;0.28;0.04" dur="6s" begin="1.2s" repeatCount="indefinite"/></line>
+    <line x1="169" y1="114" x2="166" y2="86" stroke="url(#ax)" stroke-width="0.7" stroke-opacity="0.16"><animate attributeName="stroke-opacity" values="0.04;0.28;0.04" dur="7s" begin="1.8s" repeatCount="indefinite"/></line>
+    <line x1="169" y1="114" x2="161" y2="169" stroke="url(#ax)" stroke-width="0.7" stroke-opacity="0.16"><animate attributeName="stroke-opacity" values="0.04;0.28;0.04" dur="8s" begin="2.4s" repeatCount="indefinite"/></line>
+    <line x1="96" y1="224" x2="161" y2="169" stroke="url(#ax)" stroke-width="0.7" stroke-opacity="0.16"><animate attributeName="stroke-opacity" values="0.04;0.28;0.04" dur="9s" begin="0.0s" repeatCount="indefinite"/></line>
+    <line x1="166" y1="86" x2="223" y2="69" stroke="url(#ax)" stroke-width="0.7" stroke-opacity="0.16"><animate attributeName="stroke-opacity" values="0.04;0.28;0.04" dur="10s" begin="0.6s" repeatCount="indefinite"/></line>
+    <line x1="223" y1="69" x2="288" y2="82" stroke="url(#ax)" stroke-width="0.7" stroke-opacity="0.16"><animate attributeName="stroke-opacity" values="0.04;0.28;0.04" dur="11s" begin="1.2s" repeatCount="indefinite"/></line>
+    <line x1="223" y1="69" x2="310" y2="111" stroke="url(#ax)" stroke-width="0.7" stroke-opacity="0.16"><animate attributeName="stroke-opacity" values="0.04;0.28;0.04" dur="12s" begin="1.8s" repeatCount="indefinite"/></line>
+    <line x1="288" y1="82" x2="310" y2="111" stroke="url(#ax)" stroke-width="0.7" stroke-opacity="0.16"><animate attributeName="stroke-opacity" values="0.04;0.28;0.04" dur="6s" begin="2.4s" repeatCount="indefinite"/></line>
+    <line x1="982" y1="551" x2="892" y2="496" stroke="url(#ax)" stroke-width="0.7" stroke-opacity="0.16"><animate attributeName="stroke-opacity" values="0.04;0.28;0.04" dur="7s" begin="0.0s" repeatCount="indefinite"/></line>
+    <line x1="982" y1="551" x2="856" y2="495" stroke="url(#ax)" stroke-width="0.7" stroke-opacity="0.16"><animate attributeName="stroke-opacity" values="0.04;0.28;0.04" dur="8s" begin="0.6s" repeatCount="indefinite"/></line>
+    <line x1="828" y1="474" x2="840" y2="474" stroke="url(#ax)" stroke-width="0.7" stroke-opacity="0.16"><animate attributeName="stroke-opacity" values="0.04;0.28;0.04" dur="9s" begin="1.2s" repeatCount="indefinite"/></line>
+    <line x1="828" y1="474" x2="859" y2="384" stroke="url(#ax)" stroke-width="0.7" stroke-opacity="0.16"><animate attributeName="stroke-opacity" values="0.04;0.28;0.04" dur="10s" begin="1.8s" repeatCount="indefinite"/></line>
+    <line x1="828" y1="474" x2="741" y2="465" stroke="url(#ax)" stroke-width="0.7" stroke-opacity="0.16"><animate attributeName="stroke-opacity" values="0.04;0.28;0.04" dur="11s" begin="2.4s" repeatCount="indefinite"/></line>
+    <line x1="828" y1="474" x2="848" y2="486" stroke="url(#ax)" stroke-width="0.7" stroke-opacity="0.16"><animate attributeName="stroke-opacity" values="0.04;0.28;0.04" dur="12s" begin="0.0s" repeatCount="indefinite"/></line>
+    <line x1="840" y1="474" x2="859" y2="384" stroke="url(#ax)" stroke-width="0.7" stroke-opacity="0.16"><animate attributeName="stroke-opacity" values="0.04;0.28;0.04" dur="6s" begin="0.6s" repeatCount="indefinite"/></line>
+    <line x1="840" y1="474" x2="741" y2="465" stroke="url(#ax)" stroke-width="0.7" stroke-opacity="0.16"><animate attributeName="stroke-opacity" values="0.04;0.28;0.04" dur="7s" begin="1.2s" repeatCount="indefinite"/></line>
+    <line x1="840" y1="474" x2="856" y2="495" stroke="url(#ax)" stroke-width="0.7" stroke-opacity="0.16"><animate attributeName="stroke-opacity" values="0.04;0.28;0.04" dur="8s" begin="1.8s" repeatCount="indefinite"/></line>
+    <line x1="840" y1="474" x2="848" y2="486" stroke="url(#ax)" stroke-width="0.7" stroke-opacity="0.16"><animate attributeName="stroke-opacity" values="0.04;0.28;0.04" dur="9s" begin="2.4s" repeatCount="indefinite"/></line>
+    <line x1="892" y1="496" x2="856" y2="495" stroke="url(#ax)" stroke-width="0.7" stroke-opacity="0.16"><animate attributeName="stroke-opacity" values="0.04;0.28;0.04" dur="10s" begin="0.0s" repeatCount="indefinite"/></line>
+    <line x1="892" y1="496" x2="848" y2="486" stroke="url(#ax)" stroke-width="0.7" stroke-opacity="0.16"><animate attributeName="stroke-opacity" values="0.04;0.28;0.04" dur="11s" begin="0.6s" repeatCount="indefinite"/></line>
+    <line x1="741" y1="465" x2="721" y2="310" stroke="url(#ax)" stroke-width="0.7" stroke-opacity="0.16"><animate attributeName="stroke-opacity" values="0.04;0.28;0.04" dur="12s" begin="1.2s" repeatCount="indefinite"/></line>
+    <line x1="856" y1="495" x2="848" y2="486" stroke="url(#ax)" stroke-width="0.7" stroke-opacity="0.16"><animate attributeName="stroke-opacity" values="0.04;0.28;0.04" dur="6s" begin="1.8s" repeatCount="indefinite"/></line>
+    <line x1="856" y1="495" x2="792" y2="583" stroke="url(#ax)" stroke-width="0.7" stroke-opacity="0.16"><animate attributeName="stroke-opacity" values="0.04;0.28;0.04" dur="7s" begin="2.4s" repeatCount="indefinite"/></line>
+    <line x1="848" y1="486" x2="792" y2="583" stroke="url(#ax)" stroke-width="0.7" stroke-opacity="0.16"><animate attributeName="stroke-opacity" values="0.04;0.28;0.04" dur="8s" begin="0.0s" repeatCount="indefinite"/></line>
+    <line x1="222" y1="193" x2="161" y2="169" stroke="url(#ax)" stroke-width="0.7" stroke-opacity="0.16"><animate attributeName="stroke-opacity" values="0.04;0.28;0.04" dur="9s" begin="0.6s" repeatCount="indefinite"/></line>
+    <line x1="740" y1="150" x2="656" y2="88" stroke="url(#ax)" stroke-width="0.7" stroke-opacity="0.16"><animate attributeName="stroke-opacity" values="0.04;0.28;0.04" dur="10s" begin="1.2s" repeatCount="indefinite"/></line>
+    <line x1="740" y1="150" x2="721" y2="310" stroke="url(#ax)" stroke-width="0.7" stroke-opacity="0.16"><animate attributeName="stroke-opacity" values="0.04;0.28;0.04" dur="11s" begin="1.8s" repeatCount="indefinite"/></line>
+    <line x1="597" y1="373" x2="553" y2="221" stroke="url(#ax)" stroke-width="0.7" stroke-opacity="0.16"><animate attributeName="stroke-opacity" values="0.04;0.28;0.04" dur="12s" begin="2.4s" repeatCount="indefinite"/></line>
+    <line x1="597" y1="373" x2="721" y2="310" stroke="url(#ax)" stroke-width="0.7" stroke-opacity="0.16"><animate attributeName="stroke-opacity" values="0.04;0.28;0.04" dur="6s" begin="0.0s" repeatCount="indefinite"/></line>
+    <line x1="656" y1="88" x2="572" y2="135" stroke="url(#ax)" stroke-width="0.7" stroke-opacity="0.16"><animate attributeName="stroke-opacity" values="0.04;0.28;0.04" dur="7s" begin="0.6s" repeatCount="indefinite"/></line>
+    <line x1="656" y1="88" x2="537" y2="89" stroke="url(#ax)" stroke-width="0.7" stroke-opacity="0.16"><animate attributeName="stroke-opacity" values="0.04;0.28;0.04" dur="8s" begin="1.2s" repeatCount="indefinite"/></line>
+    <line x1="553" y1="221" x2="572" y2="135" stroke="url(#ax)" stroke-width="0.7" stroke-opacity="0.16"><animate attributeName="stroke-opacity" values="0.04;0.28;0.04" dur="9s" begin="1.8s" repeatCount="indefinite"/></line>
+    <line x1="553" y1="221" x2="537" y2="89" stroke="url(#ax)" stroke-width="0.7" stroke-opacity="0.16"><animate attributeName="stroke-opacity" values="0.04;0.28;0.04" dur="10s" begin="2.4s" repeatCount="indefinite"/></line>
+    <line x1="572" y1="135" x2="537" y2="89" stroke="url(#ax)" stroke-width="0.7" stroke-opacity="0.16"><animate attributeName="stroke-opacity" values="0.04;0.28;0.04" dur="11s" begin="0.0s" repeatCount="indefinite"/></line>
+    <circle cx="200" cy="67" r="1.7" fill="#00FF77" opacity="0.5"><animate attributeName="opacity" values="0.12;0.6;0.12" dur="6s" begin="0.0s" repeatCount="indefinite"/></circle>
+    <circle cx="39" cy="41" r="1.7" fill="#00FF77" opacity="0.5"><animate attributeName="opacity" values="0.12;0.6;0.12" dur="7s" begin="0.5s" repeatCount="indefinite"/></circle>
+    <circle cx="161" cy="191" r="1.7" fill="#00FF77" opacity="0.5"><animate attributeName="opacity" values="0.12;0.6;0.12" dur="8s" begin="1.0s" repeatCount="indefinite"/></circle>
+    <circle cx="27" cy="38" r="1.7" fill="#00FF77" opacity="0.5"><animate attributeName="opacity" values="0.12;0.6;0.12" dur="9s" begin="1.5s" repeatCount="indefinite"/></circle>
+    <circle cx="169" cy="114" r="1.7" fill="#00FF77" opacity="0.5"><animate attributeName="opacity" values="0.12;0.6;0.12" dur="10s" begin="2.0s" repeatCount="indefinite"/></circle>
+    <circle cx="96" cy="224" r="1.7" fill="#00FF77" opacity="0.5"><animate attributeName="opacity" values="0.12;0.6;0.12" dur="11s" begin="2.5s" repeatCount="indefinite"/></circle>
+    <circle cx="166" cy="86" r="1.7" fill="#00FF77" opacity="0.5"><animate attributeName="opacity" values="0.12;0.6;0.12" dur="12s" begin="0.0s" repeatCount="indefinite"/></circle>
+    <circle cx="223" cy="69" r="1.7" fill="#00FF77" opacity="0.5"><animate attributeName="opacity" values="0.12;0.6;0.12" dur="6s" begin="0.5s" repeatCount="indefinite"/></circle>
+    <circle cx="288" cy="82" r="1.7" fill="#00FF77" opacity="0.5"><animate attributeName="opacity" values="0.12;0.6;0.12" dur="7s" begin="1.0s" repeatCount="indefinite"/></circle>
+    <circle cx="982" cy="551" r="1.7" fill="#00FF77" opacity="0.5"><animate attributeName="opacity" values="0.12;0.6;0.12" dur="8s" begin="1.5s" repeatCount="indefinite"/></circle>
+    <circle cx="828" cy="474" r="1.7" fill="#00FF77" opacity="0.5"><animate attributeName="opacity" values="0.12;0.6;0.12" dur="9s" begin="2.0s" repeatCount="indefinite"/></circle>
+    <circle cx="840" cy="474" r="1.7" fill="#00FF77" opacity="0.5"><animate attributeName="opacity" values="0.12;0.6;0.12" dur="10s" begin="2.5s" repeatCount="indefinite"/></circle>
+    <circle cx="859" cy="384" r="1.7" fill="#00FF77" opacity="0.5"><animate attributeName="opacity" values="0.12;0.6;0.12" dur="11s" begin="0.0s" repeatCount="indefinite"/></circle>
+    <circle cx="892" cy="496" r="1.7" fill="#00FF77" opacity="0.5"><animate attributeName="opacity" values="0.12;0.6;0.12" dur="12s" begin="0.5s" repeatCount="indefinite"/></circle>
+    <circle cx="741" cy="465" r="1.7" fill="#00FF77" opacity="0.5"><animate attributeName="opacity" values="0.12;0.6;0.12" dur="6s" begin="1.0s" repeatCount="indefinite"/></circle>
+    <circle cx="856" cy="495" r="1.7" fill="#00FF77" opacity="0.5"><animate attributeName="opacity" values="0.12;0.6;0.12" dur="7s" begin="1.5s" repeatCount="indefinite"/></circle>
+    <circle cx="848" cy="486" r="1.7" fill="#00FF77" opacity="0.5"><animate attributeName="opacity" values="0.12;0.6;0.12" dur="8s" begin="2.0s" repeatCount="indefinite"/></circle>
+    <circle cx="792" cy="583" r="1.7" fill="#00FF77" opacity="0.5"><animate attributeName="opacity" values="0.12;0.6;0.12" dur="9s" begin="2.5s" repeatCount="indefinite"/></circle>
+    <circle cx="222" cy="193" r="1.7" fill="#00FF77" opacity="0.5"><animate attributeName="opacity" values="0.12;0.6;0.12" dur="10s" begin="0.0s" repeatCount="indefinite"/></circle>
+    <circle cx="740" cy="150" r="1.7" fill="#00FF77" opacity="0.5"><animate attributeName="opacity" values="0.12;0.6;0.12" dur="11s" begin="0.5s" repeatCount="indefinite"/></circle>
+    <circle cx="161" cy="169" r="1.7" fill="#00FF77" opacity="0.5"><animate attributeName="opacity" values="0.12;0.6;0.12" dur="12s" begin="1.0s" repeatCount="indefinite"/></circle>
+    <circle cx="597" cy="373" r="1.7" fill="#00FF77" opacity="0.5"><animate attributeName="opacity" values="0.12;0.6;0.12" dur="6s" begin="1.5s" repeatCount="indefinite"/></circle>
+    <circle cx="656" cy="88" r="1.7" fill="#00FF77" opacity="0.5"><animate attributeName="opacity" values="0.12;0.6;0.12" dur="7s" begin="2.0s" repeatCount="indefinite"/></circle>
+    <circle cx="310" cy="111" r="1.7" fill="#00FF77" opacity="0.5"><animate attributeName="opacity" values="0.12;0.6;0.12" dur="8s" begin="2.5s" repeatCount="indefinite"/></circle>
+    <circle cx="553" cy="221" r="1.7" fill="#00FF77" opacity="0.5"><animate attributeName="opacity" values="0.12;0.6;0.12" dur="9s" begin="0.0s" repeatCount="indefinite"/></circle>
+    <circle cx="721" cy="310" r="1.7" fill="#00FF77" opacity="0.5"><animate attributeName="opacity" values="0.12;0.6;0.12" dur="10s" begin="0.5s" repeatCount="indefinite"/></circle>
+    <circle cx="572" cy="135" r="1.7" fill="#00FF77" opacity="0.5"><animate attributeName="opacity" values="0.12;0.6;0.12" dur="11s" begin="1.0s" repeatCount="indefinite"/></circle>
+    <circle cx="537" cy="89" r="1.7" fill="#00FF77" opacity="0.5"><animate attributeName="opacity" values="0.12;0.6;0.12" dur="12s" begin="1.5s" repeatCount="indefinite"/></circle>
+  </g>
+
+  <text x="500" y="52" text-anchor="middle" font-size="24" font-weight="700" fill="url(#axTitle)" letter-spacing="-0.5">How strands-robots is layered</text>
+  <text x="500" y="78" text-anchor="middle" font-size="13" fill="#8a8f99">one Python API &#183; one AgentTool &#183; pluggable backends &#183; sim or real</text>
+
+  <!-- Layer 1: Agent / API -->
+  <g>
+    <rect x="80" y="104" width="840" height="74" rx="16" fill="#13161a" stroke="url(#ax)" stroke-width="1.5"/>
+    <text x="104" y="134" font-size="16" font-weight="700" fill="#ffffff">Strands Agent</text>
+    <text x="104" y="156" font-size="12" fill="#8a8f99">Robot(name) factory &#183; natural-language goals &#183; @tool dispatch</text>
+    <g font-size="11.5" font-weight="600" fill="#cfd3da">
+      <rect x="560" y="120" width="100" height="40" rx="10" fill="#ffffff" fill-opacity="0.05" stroke="#00FF77" stroke-opacity="0.4"/><text x="610" y="145" text-anchor="middle">run_policy</text>
+      <rect x="668" y="120" width="100" height="40" rx="10" fill="#ffffff" fill-opacity="0.05" stroke="#00FF77" stroke-opacity="0.4"/><text x="718" y="145" text-anchor="middle">teleoperate</text>
+      <rect x="776" y="120" width="120" height="40" rx="10" fill="#ffffff" fill-opacity="0.05" stroke="#00FF77" stroke-opacity="0.4"/><text x="836" y="145" text-anchor="middle">record dataset</text>
+    </g>
+  </g>
+
+  <!-- Layer 2: Policy providers -->
+  <g>
+    <rect x="80" y="206" width="840" height="74" rx="16" fill="#13161a" stroke="url(#ax)" stroke-width="1.5"/>
+    <text x="104" y="236" font-size="16" font-weight="700" fill="#ffffff">Policy providers</text>
+    <text x="104" y="258" font-size="12" fill="#8a8f99">create_policy(provider) &#183; async get_actions(obs, instruction)</text>
+    <g font-size="11.5" font-weight="600" fill="#cfd3da">
+      <rect x="452" y="222" width="88" height="40" rx="10" fill="#ffffff" fill-opacity="0.05" stroke="#22D3EE" stroke-opacity="0.4"/><text x="496" y="247" text-anchor="middle">Cosmos 3</text>
+      <rect x="546" y="222" width="99" height="40" rx="10" fill="#ffffff" fill-opacity="0.05" stroke="#22D3EE" stroke-opacity="0.4"/><text x="596" y="247" text-anchor="middle">MolmoAct2</text>
+      <rect x="651" y="222" width="111" height="40" rx="10" fill="#ffffff" fill-opacity="0.05" stroke="#22D3EE" stroke-opacity="0.4"/><text x="706" y="247" text-anchor="middle">GR00T N1.7</text>
+      <rect x="768" y="222" width="64" height="40" rx="10" fill="#ffffff" fill-opacity="0.05" stroke="#22D3EE" stroke-opacity="0.4"/><text x="800" y="247" text-anchor="middle">Pi0.6</text>
+      <rect x="838" y="222" width="66" height="40" rx="10" fill="#ffffff" fill-opacity="0.05" stroke="#22D3EE" stroke-opacity="0.4"/><text x="871" y="247" text-anchor="middle">Curobo</text>
+    </g>
+  </g>
+
+  <!-- Layer 3: Simulation backend -->
+  <g>
+    <rect x="80" y="308" width="840" height="74" rx="16" fill="#13161a" stroke="url(#ax)" stroke-width="1.5"/>
+    <text x="104" y="338" font-size="16" font-weight="700" fill="#ffffff">Backends</text>
+    <text x="104" y="360" font-size="12" fill="#8a8f99">SimEngine ABC &#183; step / observe / act &#183; register_backend()</text>
+    <g font-size="11.5" font-weight="600" fill="#cfd3da">
+      <rect x="560" y="324" width="120" height="40" rx="10" fill="#ffffff" fill-opacity="0.05" stroke="#00FF77" stroke-opacity="0.4"/><text x="620" y="349" text-anchor="middle">MuJoCo (EGL)</text>
+      <rect x="688" y="324" width="100" height="40" rx="10" fill="#ffffff" fill-opacity="0.05" stroke="#00FF77" stroke-opacity="0.4"/><text x="738" y="349" text-anchor="middle">LeRobot HW</text>
+      <rect x="796" y="324" width="100" height="40" rx="10" fill="#ffffff" fill-opacity="0.05" stroke="#00FF77" stroke-opacity="0.4"/><text x="846" y="349" text-anchor="middle">Mesh fleet</text>
+    </g>
+  </g>
+
+  <!-- Layer 4: Robots -->
+  <g>
+    <rect x="80" y="410" width="840" height="74" rx="16" fill="#13161a" stroke="url(#ax)" stroke-width="1.5"/>
+    <text x="104" y="440" font-size="16" font-weight="700" fill="#ffffff">40+ robots</text>
+    <text x="104" y="462" font-size="12" fill="#8a8f99">registry/robots.json &#183; arms &#183; hands &#183; humanoids &#183; mobile</text>
+    <g font-size="11.5" font-weight="600" fill="#cfd3da">
+      <rect x="470" y="426" width="86" height="40" rx="10" fill="#ffffff" fill-opacity="0.05" stroke="#22D3EE" stroke-opacity="0.4"/><text x="513" y="451" text-anchor="middle">SO-101</text>
+      <rect x="564" y="426" width="78" height="40" rx="10" fill="#ffffff" fill-opacity="0.05" stroke="#22D3EE" stroke-opacity="0.4"/><text x="603" y="451" text-anchor="middle">Franka</text>
+      <rect x="650" y="426" width="78" height="40" rx="10" fill="#ffffff" fill-opacity="0.05" stroke="#22D3EE" stroke-opacity="0.4"/><text x="689" y="451" text-anchor="middle">ALOHA</text>
+      <rect x="736" y="426" width="92" height="40" rx="10" fill="#ffffff" fill-opacity="0.05" stroke="#22D3EE" stroke-opacity="0.4"/><text x="782" y="451" text-anchor="middle">Unitree G1</text>
+      <rect x="836" y="426" width="60" height="40" rx="10" fill="#ffffff" fill-opacity="0.05" stroke="#22D3EE" stroke-opacity="0.4"/><text x="866" y="451" text-anchor="middle">UR5e</text>
+    </g>
+  </g>
+
+  <!-- left spine: action lanes (green, downward) -->
+  <g stroke="url(#ax)" stroke-opacity="0.32" stroke-width="2" stroke-dasharray="6 8">
+    <line x1="180" y1="178" x2="180" y2="206"><animate attributeName="stroke-dashoffset" values="28;0" dur="1s" repeatCount="indefinite"/></line>
+    <line x1="180" y1="280" x2="180" y2="308"><animate attributeName="stroke-dashoffset" values="28;0" dur="1s" repeatCount="indefinite"/></line>
+    <line x1="180" y1="382" x2="180" y2="410"><animate attributeName="stroke-dashoffset" values="28;0" dur="1s" repeatCount="indefinite"/></line>
+  </g>
+  <g>
+    <circle r="3.6" fill="#00FF77"><animateMotion dur="3s" begin="0.0s" repeatCount="indefinite" path="M162,116 L162,474"/><animate attributeName="opacity" values="0;1;1;0" dur="3s" begin="0.0s" repeatCount="indefinite"/></circle>
+    <circle r="3.6" fill="#00FF77"><animateMotion dur="3s" begin="1.0s" repeatCount="indefinite" path="M180,116 L180,474"/><animate attributeName="opacity" values="0;1;1;0" dur="3s" begin="1.0s" repeatCount="indefinite"/></circle>
+    <circle r="3.6" fill="#00FF77"><animateMotion dur="3s" begin="2.0s" repeatCount="indefinite" path="M198,116 L198,474"/><animate attributeName="opacity" values="0;1;1;0" dur="3s" begin="2.0s" repeatCount="indefinite"/></circle>
+  </g>
+  <!-- right spine: observation lanes (cyan, upward) -->
+  <g stroke="url(#ax)" stroke-opacity="0.32" stroke-width="2" stroke-dasharray="6 8">
+    <line x1="860" y1="410" x2="860" y2="382"><animate attributeName="stroke-dashoffset" values="0;28" dur="1s" repeatCount="indefinite"/></line>
+    <line x1="860" y1="308" x2="860" y2="280"><animate attributeName="stroke-dashoffset" values="0;28" dur="1s" repeatCount="indefinite"/></line>
+    <line x1="860" y1="206" x2="860" y2="178"><animate attributeName="stroke-dashoffset" values="0;28" dur="1s" repeatCount="indefinite"/></line>
+  </g>
+  <g>
+    <circle r="3.6" fill="#22D3EE"><animateMotion dur="3s" begin="0.5s" repeatCount="indefinite" path="M842,474 L842,116"/><animate attributeName="opacity" values="0;1;1;0" dur="3s" begin="0.5s" repeatCount="indefinite"/></circle>
+    <circle r="3.6" fill="#22D3EE"><animateMotion dur="3s" begin="1.5s" repeatCount="indefinite" path="M860,474 L860,116"/><animate attributeName="opacity" values="0;1;1;0" dur="3s" begin="1.5s" repeatCount="indefinite"/></circle>
+    <circle r="3.6" fill="#22D3EE"><animateMotion dur="3s" begin="2.5s" repeatCount="indefinite" path="M878,474 L878,116"/><animate attributeName="opacity" values="0;1;1;0" dur="3s" begin="2.5s" repeatCount="indefinite"/></circle>
+  </g>
+  <text x="150" y="510" font-size="11" font-weight="700" fill="#00FF77" letter-spacing="1">ACTIONS &#8595;</text>
+  <text x="822" y="510" font-size="11" font-weight="700" fill="#22D3EE" letter-spacing="1">&#8593; OBSERVATIONS</text>
+</svg>

--- a/docs/assets/hero_loop.svg
+++ b/docs/assets/hero_loop.svg
@@ -1,0 +1,258 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 620" width="1200" height="620" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <defs>
+    <!-- green brand flow gradient (animated shimmer) -->
+    <linearGradient id="gx" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#00FF77"/>
+      <stop offset="0.5" stop-color="#22D3EE"/>
+      <stop offset="1" stop-color="#00FF77"/>
+      <animateTransform attributeName="gradientTransform" type="translate"
+        values="-0.3 0; 0.3 0; -0.3 0" dur="7s" repeatCount="indefinite"/>
+    </linearGradient>
+    <linearGradient id="gxTitle" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#7CFFB0"/>
+      <stop offset="0.5" stop-color="#00FF77"/>
+      <stop offset="1" stop-color="#22D3EE"/>
+      <animateTransform attributeName="gradientTransform" type="translate"
+        values="-0.4 0; 0.4 0; -0.4 0" dur="9s" repeatCount="indefinite"/>
+    </linearGradient>
+    <radialGradient id="glowG" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#00FF77" stop-opacity="0.55"/>
+      <stop offset="1" stop-color="#00FF77" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="glowC" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#22D3EE" stop-opacity="0.5"/>
+      <stop offset="1" stop-color="#22D3EE" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="coreGlow" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#00FF77" stop-opacity="0.4"/>
+      <stop offset="0.6" stop-color="#00FF77" stop-opacity="0.08"/>
+      <stop offset="1" stop-color="#00FF77" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="blurBig" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="44"/>
+    </filter>
+  </defs>
+
+  <!-- glass panel -->
+  <rect x="8" y="8" width="1184" height="604" rx="30" fill="#0a0a0a"/>
+  <rect x="8" y="8" width="1184" height="604" rx="30" fill="none" stroke="url(#gx)" stroke-opacity="0.28" stroke-width="1.5"/>
+
+  <!-- animated mesh / network background -->
+  <g opacity="0.5">
+    <circle cx="220" cy="160" r="150" fill="url(#glowG)" opacity="0.25"><animateTransform attributeName="transform" type="translate" values="0 0; 40 30; 0 0" dur="24s" repeatCount="indefinite"/></circle>
+    <circle cx="1000" cy="170" r="140" fill="url(#glowC)" opacity="0.22"><animateTransform attributeName="transform" type="translate" values="0 0; -40 40; 0 0" dur="27s" repeatCount="indefinite"/></circle>
+    <line x1="1035" y1="256" x2="1003" y2="163" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="6s" begin="0.0s" repeatCount="indefinite"/></line>
+    <line x1="1035" y1="256" x2="1070" y2="325" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="7s" begin="0.6s" repeatCount="indefinite"/></line>
+    <line x1="1035" y1="256" x2="908" y2="237" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="8s" begin="1.2s" repeatCount="indefinite"/></line>
+    <line x1="1035" y1="256" x2="1140" y2="229" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="9s" begin="1.8s" repeatCount="indefinite"/></line>
+    <line x1="1003" y1="163" x2="1087" y2="90" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="10s" begin="2.4s" repeatCount="indefinite"/></line>
+    <line x1="1003" y1="163" x2="908" y2="237" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="11s" begin="0.0s" repeatCount="indefinite"/></line>
+    <line x1="117" y1="213" x2="170" y2="342" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="12s" begin="0.6s" repeatCount="indefinite"/></line>
+    <line x1="117" y1="213" x2="114" y2="94" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="6s" begin="1.2s" repeatCount="indefinite"/></line>
+    <line x1="117" y1="213" x2="248" y2="202" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="7s" begin="1.8s" repeatCount="indefinite"/></line>
+    <line x1="117" y1="213" x2="192" y2="246" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="8s" begin="2.4s" repeatCount="indefinite"/></line>
+    <line x1="117" y1="213" x2="174" y2="168" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="9s" begin="0.0s" repeatCount="indefinite"/></line>
+    <line x1="1070" y1="325" x2="1154" y2="359" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="10s" begin="0.6s" repeatCount="indefinite"/></line>
+    <line x1="1070" y1="325" x2="1140" y2="229" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="11s" begin="1.2s" repeatCount="indefinite"/></line>
+    <line x1="1087" y1="90" x2="1140" y2="229" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="12s" begin="1.8s" repeatCount="indefinite"/></line>
+    <line x1="123" y1="444" x2="170" y2="342" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="6s" begin="2.4s" repeatCount="indefinite"/></line>
+    <line x1="123" y1="444" x2="99" y2="567" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="7s" begin="0.0s" repeatCount="indefinite"/></line>
+    <line x1="123" y1="444" x2="242" y2="422" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="8s" begin="0.6s" repeatCount="indefinite"/></line>
+    <line x1="348" y1="98" x2="235" y2="41" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="9s" begin="1.2s" repeatCount="indefinite"/></line>
+    <line x1="348" y1="98" x2="248" y2="202" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="10s" begin="1.8s" repeatCount="indefinite"/></line>
+    <line x1="348" y1="98" x2="408" y2="200" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="11s" begin="2.4s" repeatCount="indefinite"/></line>
+    <line x1="348" y1="98" x2="343" y2="170" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="12s" begin="0.0s" repeatCount="indefinite"/></line>
+    <line x1="378" y1="458" x2="298" y2="334" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="6s" begin="0.6s" repeatCount="indefinite"/></line>
+    <line x1="378" y1="458" x2="242" y2="422" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="7s" begin="1.2s" repeatCount="indefinite"/></line>
+    <line x1="798" y1="75" x2="868" y2="48" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="8s" begin="1.8s" repeatCount="indefinite"/></line>
+    <line x1="170" y1="342" x2="192" y2="246" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="9s" begin="2.4s" repeatCount="indefinite"/></line>
+    <line x1="170" y1="342" x2="298" y2="334" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="10s" begin="0.0s" repeatCount="indefinite"/></line>
+    <line x1="170" y1="342" x2="242" y2="422" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="11s" begin="0.6s" repeatCount="indefinite"/></line>
+    <line x1="881" y1="347" x2="908" y2="237" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="12s" begin="1.2s" repeatCount="indefinite"/></line>
+    <line x1="881" y1="347" x2="958" y2="433" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="6s" begin="1.8s" repeatCount="indefinite"/></line>
+    <line x1="881" y1="347" x2="856" y2="432" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="7s" begin="2.4s" repeatCount="indefinite"/></line>
+    <line x1="114" y1="94" x2="235" y2="41" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="8s" begin="0.0s" repeatCount="indefinite"/></line>
+    <line x1="114" y1="94" x2="174" y2="168" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="9s" begin="0.6s" repeatCount="indefinite"/></line>
+    <line x1="235" y1="41" x2="174" y2="168" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="10s" begin="1.2s" repeatCount="indefinite"/></line>
+    <line x1="248" y1="202" x2="192" y2="246" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="11s" begin="1.8s" repeatCount="indefinite"/></line>
+    <line x1="248" y1="202" x2="369" y2="276" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="12s" begin="2.4s" repeatCount="indefinite"/></line>
+    <line x1="248" y1="202" x2="298" y2="334" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="6s" begin="0.0s" repeatCount="indefinite"/></line>
+    <line x1="248" y1="202" x2="343" y2="170" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="7s" begin="0.6s" repeatCount="indefinite"/></line>
+    <line x1="248" y1="202" x2="174" y2="168" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="8s" begin="1.2s" repeatCount="indefinite"/></line>
+    <line x1="192" y1="246" x2="298" y2="334" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="9s" begin="1.8s" repeatCount="indefinite"/></line>
+    <line x1="192" y1="246" x2="174" y2="168" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="10s" begin="2.4s" repeatCount="indefinite"/></line>
+    <line x1="958" y1="433" x2="852" y2="525" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="11s" begin="0.0s" repeatCount="indefinite"/></line>
+    <line x1="958" y1="433" x2="1041" y2="540" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="12s" begin="0.6s" repeatCount="indefinite"/></line>
+    <line x1="958" y1="433" x2="856" y2="432" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="6s" begin="1.2s" repeatCount="indefinite"/></line>
+    <line x1="852" y1="525" x2="856" y2="432" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="7s" begin="1.8s" repeatCount="indefinite"/></line>
+    <line x1="1041" y1="540" x2="1154" y2="538" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="8s" begin="2.4s" repeatCount="indefinite"/></line>
+    <line x1="369" y1="276" x2="298" y2="334" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="9s" begin="0.0s" repeatCount="indefinite"/></line>
+    <line x1="369" y1="276" x2="408" y2="200" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="10s" begin="0.6s" repeatCount="indefinite"/></line>
+    <line x1="369" y1="276" x2="343" y2="170" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="11s" begin="1.2s" repeatCount="indefinite"/></line>
+    <line x1="298" y1="334" x2="242" y2="422" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="12s" begin="1.8s" repeatCount="indefinite"/></line>
+    <line x1="408" y1="200" x2="343" y2="170" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="6s" begin="2.4s" repeatCount="indefinite"/></line>
+    <line x1="1154" y1="359" x2="1140" y2="229" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.18"><animate attributeName="stroke-opacity" values="0.05;0.32;0.05" dur="7s" begin="0.0s" repeatCount="indefinite"/></line>
+    <circle r="1.8" fill="#7CFFB0" opacity="0.9"><animate attributeName="cx" values="1035;1003" dur="2.5s" begin="0.0s" repeatCount="indefinite"/><animate attributeName="cy" values="256;163" dur="2.5s" begin="0.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0;0.9;0" dur="2.5s" begin="0.0s" repeatCount="indefinite"/></circle>
+    <circle r="1.8" fill="#7CFFB0" opacity="0.9"><animate attributeName="cx" values="1035;1070" dur="3.5s" begin="0.4s" repeatCount="indefinite"/><animate attributeName="cy" values="256;325" dur="3.5s" begin="0.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0;0.9;0" dur="3.5s" begin="0.4s" repeatCount="indefinite"/></circle>
+    <circle r="1.8" fill="#7CFFB0" opacity="0.9"><animate attributeName="cx" values="1035;908" dur="4.5s" begin="0.8s" repeatCount="indefinite"/><animate attributeName="cy" values="256;237" dur="4.5s" begin="0.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0;0.9;0" dur="4.5s" begin="0.8s" repeatCount="indefinite"/></circle>
+    <circle r="1.8" fill="#7CFFB0" opacity="0.9"><animate attributeName="cx" values="1035;1140" dur="5.5s" begin="1.2s" repeatCount="indefinite"/><animate attributeName="cy" values="256;229" dur="5.5s" begin="1.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0;0.9;0" dur="5.5s" begin="1.2s" repeatCount="indefinite"/></circle>
+    <circle r="1.8" fill="#7CFFB0" opacity="0.9"><animate attributeName="cx" values="1003;1087" dur="2.5s" begin="1.6s" repeatCount="indefinite"/><animate attributeName="cy" values="163;90" dur="2.5s" begin="1.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0;0.9;0" dur="2.5s" begin="1.6s" repeatCount="indefinite"/></circle>
+    <circle r="1.8" fill="#7CFFB0" opacity="0.9"><animate attributeName="cx" values="1003;908" dur="3.5s" begin="2.0s" repeatCount="indefinite"/><animate attributeName="cy" values="163;237" dur="3.5s" begin="2.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0;0.9;0" dur="3.5s" begin="2.0s" repeatCount="indefinite"/></circle>
+    <circle r="1.8" fill="#7CFFB0" opacity="0.9"><animate attributeName="cx" values="117;170" dur="4.5s" begin="2.4s" repeatCount="indefinite"/><animate attributeName="cy" values="213;342" dur="4.5s" begin="2.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0;0.9;0" dur="4.5s" begin="2.4s" repeatCount="indefinite"/></circle>
+    <circle r="1.8" fill="#7CFFB0" opacity="0.9"><animate attributeName="cx" values="117;114" dur="5.5s" begin="2.8s" repeatCount="indefinite"/><animate attributeName="cy" values="213;94" dur="5.5s" begin="2.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0;0.9;0" dur="5.5s" begin="2.8s" repeatCount="indefinite"/></circle>
+    <circle r="1.8" fill="#7CFFB0" opacity="0.9"><animate attributeName="cx" values="117;248" dur="2.5s" begin="3.2s" repeatCount="indefinite"/><animate attributeName="cy" values="213;202" dur="2.5s" begin="3.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0;0.9;0" dur="2.5s" begin="3.2s" repeatCount="indefinite"/></circle>
+    <circle r="1.8" fill="#7CFFB0" opacity="0.9"><animate attributeName="cx" values="117;192" dur="3.5s" begin="3.6s" repeatCount="indefinite"/><animate attributeName="cy" values="213;246" dur="3.5s" begin="3.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0;0.9;0" dur="3.5s" begin="3.6s" repeatCount="indefinite"/></circle>
+    <circle cx="1035" cy="256" r="2.1" fill="#22D3EE" fill-opacity="0.55"><animate attributeName="fill-opacity" values="0.2;0.7;0.2" dur="3s" begin="0.0s" repeatCount="indefinite"/><animate attributeName="r" values="2.1;3.1;2.1" dur="3s" begin="0.0s" repeatCount="indefinite"/></circle>
+    <circle cx="1003" cy="163" r="2.0" fill="#00FF77" fill-opacity="0.55"><animate attributeName="fill-opacity" values="0.2;0.7;0.2" dur="4s" begin="0.5s" repeatCount="indefinite"/><animate attributeName="r" values="2.0;3.0;2.0" dur="4s" begin="0.5s" repeatCount="indefinite"/></circle>
+    <circle cx="694" cy="551" r="1.4" fill="#00FF77" fill-opacity="0.55"><animate attributeName="fill-opacity" values="0.2;0.7;0.2" dur="5s" begin="1.0s" repeatCount="indefinite"/><animate attributeName="r" values="1.4;2.4;1.4" dur="5s" begin="1.0s" repeatCount="indefinite"/></circle>
+    <circle cx="117" cy="213" r="2.4" fill="#22D3EE" fill-opacity="0.55"><animate attributeName="fill-opacity" values="0.2;0.7;0.2" dur="6s" begin="1.5s" repeatCount="indefinite"/><animate attributeName="r" values="2.4;3.4;2.4" dur="6s" begin="1.5s" repeatCount="indefinite"/></circle>
+    <circle cx="1070" cy="325" r="2.6" fill="#00FF77" fill-opacity="0.55"><animate attributeName="fill-opacity" values="0.2;0.7;0.2" dur="7s" begin="2.0s" repeatCount="indefinite"/><animate attributeName="r" values="2.6;3.6;2.6" dur="7s" begin="2.0s" repeatCount="indefinite"/></circle>
+    <circle cx="1087" cy="90" r="2.6" fill="#00FF77" fill-opacity="0.55"><animate attributeName="fill-opacity" values="0.2;0.7;0.2" dur="3s" begin="2.5s" repeatCount="indefinite"/><animate attributeName="r" values="2.6;3.6;2.6" dur="3s" begin="2.5s" repeatCount="indefinite"/></circle>
+    <circle cx="576" cy="124" r="2.0" fill="#22D3EE" fill-opacity="0.55"><animate attributeName="fill-opacity" values="0.2;0.7;0.2" dur="4s" begin="0.0s" repeatCount="indefinite"/><animate attributeName="r" values="2.0;3.0;2.0" dur="4s" begin="0.0s" repeatCount="indefinite"/></circle>
+    <circle cx="123" cy="444" r="2.1" fill="#00FF77" fill-opacity="0.55"><animate attributeName="fill-opacity" values="0.2;0.7;0.2" dur="5s" begin="0.5s" repeatCount="indefinite"/><animate attributeName="r" values="2.1;3.1;2.1" dur="5s" begin="0.5s" repeatCount="indefinite"/></circle>
+    <circle cx="348" cy="98" r="1.8" fill="#00FF77" fill-opacity="0.55"><animate attributeName="fill-opacity" values="0.2;0.7;0.2" dur="6s" begin="1.0s" repeatCount="indefinite"/><animate attributeName="r" values="1.8;2.8;1.8" dur="6s" begin="1.0s" repeatCount="indefinite"/></circle>
+    <circle cx="378" cy="458" r="1.6" fill="#22D3EE" fill-opacity="0.55"><animate attributeName="fill-opacity" values="0.2;0.7;0.2" dur="7s" begin="1.5s" repeatCount="indefinite"/><animate attributeName="r" values="1.6;2.6;1.6" dur="7s" begin="1.5s" repeatCount="indefinite"/></circle>
+    <circle cx="798" cy="75" r="1.7" fill="#00FF77" fill-opacity="0.55"><animate attributeName="fill-opacity" values="0.2;0.7;0.2" dur="3s" begin="2.0s" repeatCount="indefinite"/><animate attributeName="r" values="1.7;2.7;1.7" dur="3s" begin="2.0s" repeatCount="indefinite"/></circle>
+    <circle cx="170" cy="342" r="1.8" fill="#00FF77" fill-opacity="0.55"><animate attributeName="fill-opacity" values="0.2;0.7;0.2" dur="4s" begin="2.5s" repeatCount="indefinite"/><animate attributeName="r" values="1.8;2.8;1.8" dur="4s" begin="2.5s" repeatCount="indefinite"/></circle>
+    <circle cx="881" cy="347" r="2.1" fill="#22D3EE" fill-opacity="0.55"><animate attributeName="fill-opacity" values="0.2;0.7;0.2" dur="5s" begin="0.0s" repeatCount="indefinite"/><animate attributeName="r" values="2.1;3.1;2.1" dur="5s" begin="0.0s" repeatCount="indefinite"/></circle>
+    <circle cx="114" cy="94" r="2.4" fill="#00FF77" fill-opacity="0.55"><animate attributeName="fill-opacity" values="0.2;0.7;0.2" dur="6s" begin="0.5s" repeatCount="indefinite"/><animate attributeName="r" values="2.4;3.4;2.4" dur="6s" begin="0.5s" repeatCount="indefinite"/></circle>
+    <circle cx="235" cy="41" r="2.3" fill="#00FF77" fill-opacity="0.55"><animate attributeName="fill-opacity" values="0.2;0.7;0.2" dur="7s" begin="1.0s" repeatCount="indefinite"/><animate attributeName="r" values="2.3;3.3;2.3" dur="7s" begin="1.0s" repeatCount="indefinite"/></circle>
+    <circle cx="248" cy="202" r="2.1" fill="#22D3EE" fill-opacity="0.55"><animate attributeName="fill-opacity" values="0.2;0.7;0.2" dur="3s" begin="1.5s" repeatCount="indefinite"/><animate attributeName="r" values="2.1;3.1;2.1" dur="3s" begin="1.5s" repeatCount="indefinite"/></circle>
+    <circle cx="908" cy="237" r="1.5" fill="#00FF77" fill-opacity="0.55"><animate attributeName="fill-opacity" values="0.2;0.7;0.2" dur="4s" begin="2.0s" repeatCount="indefinite"/><animate attributeName="r" values="1.5;2.5;1.5" dur="4s" begin="2.0s" repeatCount="indefinite"/></circle>
+    <circle cx="192" cy="246" r="2.3" fill="#00FF77" fill-opacity="0.55"><animate attributeName="fill-opacity" values="0.2;0.7;0.2" dur="5s" begin="2.5s" repeatCount="indefinite"/><animate attributeName="r" values="2.3;3.3;2.3" dur="5s" begin="2.5s" repeatCount="indefinite"/></circle>
+    <circle cx="958" cy="433" r="2.0" fill="#22D3EE" fill-opacity="0.55"><animate attributeName="fill-opacity" values="0.2;0.7;0.2" dur="6s" begin="0.0s" repeatCount="indefinite"/><animate attributeName="r" values="2.0;3.0;2.0" dur="6s" begin="0.0s" repeatCount="indefinite"/></circle>
+    <circle cx="99" cy="567" r="1.9" fill="#00FF77" fill-opacity="0.55"><animate attributeName="fill-opacity" values="0.2;0.7;0.2" dur="7s" begin="0.5s" repeatCount="indefinite"/><animate attributeName="r" values="1.9;2.9;1.9" dur="7s" begin="0.5s" repeatCount="indefinite"/></circle>
+    <circle cx="852" cy="525" r="2.5" fill="#00FF77" fill-opacity="0.55"><animate attributeName="fill-opacity" values="0.2;0.7;0.2" dur="3s" begin="1.0s" repeatCount="indefinite"/><animate attributeName="r" values="2.5;3.5;2.5" dur="3s" begin="1.0s" repeatCount="indefinite"/></circle>
+    <circle cx="1041" cy="540" r="2.2" fill="#22D3EE" fill-opacity="0.55"><animate attributeName="fill-opacity" values="0.2;0.7;0.2" dur="4s" begin="1.5s" repeatCount="indefinite"/><animate attributeName="r" values="2.2;3.2;2.2" dur="4s" begin="1.5s" repeatCount="indefinite"/></circle>
+    <circle cx="1154" cy="538" r="2.0" fill="#00FF77" fill-opacity="0.55"><animate attributeName="fill-opacity" values="0.2;0.7;0.2" dur="5s" begin="2.0s" repeatCount="indefinite"/><animate attributeName="r" values="2.0;3.0;2.0" dur="5s" begin="2.0s" repeatCount="indefinite"/></circle>
+    <circle cx="369" cy="276" r="2.6" fill="#00FF77" fill-opacity="0.55"><animate attributeName="fill-opacity" values="0.2;0.7;0.2" dur="6s" begin="2.5s" repeatCount="indefinite"/><animate attributeName="r" values="2.6;3.6;2.6" dur="6s" begin="2.5s" repeatCount="indefinite"/></circle>
+    <circle cx="298" cy="334" r="2.1" fill="#22D3EE" fill-opacity="0.55"><animate attributeName="fill-opacity" values="0.2;0.7;0.2" dur="7s" begin="0.0s" repeatCount="indefinite"/><animate attributeName="r" values="2.1;3.1;2.1" dur="7s" begin="0.0s" repeatCount="indefinite"/></circle>
+    <circle cx="868" cy="48" r="2.2" fill="#00FF77" fill-opacity="0.55"><animate attributeName="fill-opacity" values="0.2;0.7;0.2" dur="3s" begin="0.5s" repeatCount="indefinite"/><animate attributeName="r" values="2.2;3.2;2.2" dur="3s" begin="0.5s" repeatCount="indefinite"/></circle>
+    <circle cx="408" cy="200" r="1.8" fill="#00FF77" fill-opacity="0.55"><animate attributeName="fill-opacity" values="0.2;0.7;0.2" dur="4s" begin="1.0s" repeatCount="indefinite"/><animate attributeName="r" values="1.8;2.8;1.8" dur="4s" begin="1.0s" repeatCount="indefinite"/></circle>
+    <circle cx="1154" cy="359" r="2.4" fill="#22D3EE" fill-opacity="0.55"><animate attributeName="fill-opacity" values="0.2;0.7;0.2" dur="5s" begin="1.5s" repeatCount="indefinite"/><animate attributeName="r" values="2.4;3.4;2.4" dur="5s" begin="1.5s" repeatCount="indefinite"/></circle>
+    <circle cx="343" cy="170" r="2.5" fill="#00FF77" fill-opacity="0.55"><animate attributeName="fill-opacity" values="0.2;0.7;0.2" dur="6s" begin="2.0s" repeatCount="indefinite"/><animate attributeName="r" values="2.5;3.5;2.5" dur="6s" begin="2.0s" repeatCount="indefinite"/></circle>
+    <circle cx="242" cy="422" r="2.4" fill="#00FF77" fill-opacity="0.55"><animate attributeName="fill-opacity" values="0.2;0.7;0.2" dur="7s" begin="2.5s" repeatCount="indefinite"/><animate attributeName="r" values="2.4;3.4;2.4" dur="7s" begin="2.5s" repeatCount="indefinite"/></circle>
+    <circle cx="1140" cy="229" r="1.4" fill="#22D3EE" fill-opacity="0.55"><animate attributeName="fill-opacity" values="0.2;0.7;0.2" dur="3s" begin="0.0s" repeatCount="indefinite"/><animate attributeName="r" values="1.4;2.4;1.4" dur="3s" begin="0.0s" repeatCount="indefinite"/></circle>
+    <circle cx="174" cy="168" r="2.0" fill="#00FF77" fill-opacity="0.55"><animate attributeName="fill-opacity" values="0.2;0.7;0.2" dur="4s" begin="0.5s" repeatCount="indefinite"/><animate attributeName="r" values="2.0;3.0;2.0" dur="4s" begin="0.5s" repeatCount="indefinite"/></circle>
+    <circle cx="484" cy="564" r="1.8" fill="#00FF77" fill-opacity="0.55"><animate attributeName="fill-opacity" values="0.2;0.7;0.2" dur="5s" begin="1.0s" repeatCount="indefinite"/><animate attributeName="r" values="1.8;2.8;1.8" dur="5s" begin="1.0s" repeatCount="indefinite"/></circle>
+    <circle cx="856" cy="432" r="1.7" fill="#22D3EE" fill-opacity="0.55"><animate attributeName="fill-opacity" values="0.2;0.7;0.2" dur="6s" begin="1.5s" repeatCount="indefinite"/><animate attributeName="r" values="1.7;2.7;1.7" dur="6s" begin="1.5s" repeatCount="indefinite"/></circle>
+  </g>
+
+  <!-- title -->
+  <text x="600" y="64" text-anchor="middle" font-size="28" font-weight="700" fill="url(#gxTitle)" letter-spacing="-0.5">
+    One agent. Any robot. Closed loop.
+  </text>
+  <text x="600" y="93" text-anchor="middle" font-size="14" fill="#8a8f99" font-weight="500">
+    perceive &#183; reason &#183; act &#183; in MuJoCo sim or on real hardware &#183; 40+ robots
+  </text>
+
+  <!-- ===================== closed control loop ring ===================== -->
+  <!-- loop guide circle centred at (600,360), r=180 -->
+  <circle cx="600" cy="360" r="180" fill="none" stroke="url(#gx)" stroke-opacity="0.18" stroke-width="2"/>
+  <!-- animated dashed flow along the ring (clockwise) -->
+  <circle cx="600" cy="360" r="180" fill="none" stroke="url(#gx)" stroke-width="2.5"
+          stroke-linecap="round" stroke-dasharray="10 18">
+    <animate attributeName="stroke-dashoffset" values="56;0" dur="1.4s" repeatCount="indefinite"/>
+  </circle>
+
+  <!-- traveling signal particles riding the loop -->
+  <g>
+    <circle r="5" fill="#00FF77">
+      <animateMotion dur="6s" repeatCount="indefinite" rotate="auto"
+        path="M600,180 A180,180 0 1,1 599.9,180 Z"/>
+    </circle>
+    <circle r="5" fill="#22D3EE">
+      <animateMotion dur="6s" begin="1.5s" repeatCount="indefinite" rotate="auto"
+        path="M600,180 A180,180 0 1,1 599.9,180 Z"/>
+    </circle>
+    <circle r="5" fill="#7CFFB0">
+      <animateMotion dur="6s" begin="3s" repeatCount="indefinite" rotate="auto"
+        path="M600,180 A180,180 0 1,1 599.9,180 Z"/>
+    </circle>
+    <circle r="5" fill="#22D3EE">
+      <animateMotion dur="6s" begin="4.5s" repeatCount="indefinite" rotate="auto"
+        path="M600,180 A180,180 0 1,1 599.9,180 Z"/>
+    </circle>
+  </g>
+
+  <!-- ===================== central brain core ===================== -->
+  <circle cx="600" cy="360" r="120" fill="url(#coreGlow)">
+    <animate attributeName="opacity" values="0.7;1;0.7" dur="4s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="600" cy="360" r="74" fill="#101012" stroke="url(#gx)" stroke-width="2"/>
+  <text x="600" y="350" text-anchor="middle" font-size="20" font-weight="700" fill="#ffffff">Strands</text>
+  <text x="600" y="374" text-anchor="middle" font-size="20" font-weight="700" fill="#00FF77">Agent</text>
+  <text x="600" y="396" text-anchor="middle" font-size="10.5" fill="#8a8f99">reason &#183; plan &#183; call tools</text>
+
+  <!-- ===================== four loop nodes ===================== -->
+  <!-- TOP: Perceive (12 o'clock, 600,180) -->
+  <ellipse cx="600" cy="180" rx="120" ry="46" fill="url(#glowC)">
+    <animate attributeName="opacity" values="0.55;1;0.55" dur="4s" repeatCount="indefinite"/>
+  </ellipse>
+  <rect x="488" y="152" width="224" height="58" rx="29" fill="#13161a" stroke="url(#gx)" stroke-width="2"/>
+  <text x="600" y="178" text-anchor="middle" font-size="17" font-weight="700" fill="#ffffff">Perceive</text>
+  <text x="600" y="197" text-anchor="middle" font-size="10.5" fill="#8a8f99">cameras &#183; joint state &#183; depth</text>
+
+  <!-- RIGHT: Act (3 o'clock, 780,360) -->
+  <ellipse cx="900" cy="360" rx="118" ry="46" fill="url(#glowG)">
+    <animate attributeName="opacity" values="0.55;1;0.55" dur="4s" begin="1s" repeatCount="indefinite"/>
+  </ellipse>
+  <rect x="792" y="332" width="216" height="58" rx="29" fill="#13161a" stroke="url(#gx)" stroke-width="2"/>
+  <text x="900" y="358" text-anchor="middle" font-size="17" font-weight="700" fill="#ffffff">Act</text>
+  <text x="900" y="377" text-anchor="middle" font-size="10.5" fill="#8a8f99">policy &#183; IK &#183; joint targets</text>
+
+  <!-- BOTTOM: World (6 o'clock, 600,540) -->
+  <ellipse cx="600" cy="540" rx="120" ry="46" fill="url(#glowG)">
+    <animate attributeName="opacity" values="0.55;1;0.55" dur="4s" begin="2s" repeatCount="indefinite"/>
+  </ellipse>
+  <rect x="486" y="512" width="228" height="58" rx="29" fill="#13161a" stroke="url(#gx)" stroke-width="2"/>
+  <text x="600" y="538" text-anchor="middle" font-size="17" font-weight="700" fill="#ffffff">World</text>
+  <text x="600" y="557" text-anchor="middle" font-size="10.5" fill="#8a8f99">MuJoCo physics &#183; real arms</text>
+
+  <!-- LEFT: Tools (9 o'clock, 420,360) -->
+  <ellipse cx="300" cy="360" rx="118" ry="46" fill="url(#glowC)">
+    <animate attributeName="opacity" values="0.55;1;0.55" dur="4s" begin="3s" repeatCount="indefinite"/>
+  </ellipse>
+  <rect x="192" y="332" width="216" height="58" rx="29" fill="#13161a" stroke="url(#gx)" stroke-width="2"/>
+  <text x="300" y="358" text-anchor="middle" font-size="17" font-weight="700" fill="#ffffff">Tools</text>
+  <text x="300" y="377" text-anchor="middle" font-size="10.5" fill="#8a8f99">sim &#183; teleop &#183; record &#183; mesh</text>
+
+  <!-- spokes from core to each node -->
+  <g stroke="url(#gx)" stroke-opacity="0.3" stroke-width="1.4">
+    <line x1="600" y1="286" x2="600" y2="210"/>
+    <line x1="674" y1="360" x2="792" y2="360"/>
+    <line x1="600" y1="434" x2="600" y2="512"/>
+    <line x1="526" y1="360" x2="408" y2="360"/>
+  </g>
+
+  <!-- ===================== left rail: policy providers ===================== -->
+  <g font-size="12.5" font-weight="600" fill="#cfd3da">
+    <text x="80" y="150" font-size="11" font-weight="700" letter-spacing="2" fill="#00FF77">POLICIES</text>
+    <g><rect x="60" y="166" width="150" height="36" rx="18" fill="#ffffff" fill-opacity="0.05" stroke="#00FF77" stroke-opacity="0.4"/><text x="80" y="189">Cosmos 3</text>
+       <animate attributeName="opacity" from="0" to="1" begin="0.1s" dur="0.5s" fill="freeze"/></g>
+    <g><rect x="60" y="212" width="150" height="36" rx="18" fill="#ffffff" fill-opacity="0.05" stroke="#00FF77" stroke-opacity="0.4"/><text x="80" y="235">MolmoAct2</text>
+       <animate attributeName="opacity" from="0" to="1" begin="0.2s" dur="0.5s" fill="freeze"/></g>
+    <g><rect x="60" y="258" width="150" height="36" rx="18" fill="#ffffff" fill-opacity="0.05" stroke="#00FF77" stroke-opacity="0.4"/><text x="80" y="281">GR00T N1.7</text>
+       <animate attributeName="opacity" from="0" to="1" begin="0.3s" dur="0.5s" fill="freeze"/></g>
+    <g><rect x="60" y="304" width="150" height="36" rx="18" fill="#ffffff" fill-opacity="0.05" stroke="#00FF77" stroke-opacity="0.4"/><text x="80" y="327">Pi0.6</text>
+       <animate attributeName="opacity" from="0" to="1" begin="0.4s" dur="0.5s" fill="freeze"/></g>
+    <g><rect x="60" y="350" width="150" height="36" rx="18" fill="#ffffff" fill-opacity="0.05" stroke="#00FF77" stroke-opacity="0.4"/><text x="80" y="373">Curobo</text>
+       <animate attributeName="opacity" from="0" to="1" begin="0.5s" dur="0.5s" fill="freeze"/></g>
+  </g>
+
+  <!-- ===================== right rail: embodiments ===================== -->
+  <g font-size="12.5" font-weight="600" fill="#cfd3da" text-anchor="end">
+    <text x="1120" y="150" font-size="11" font-weight="700" letter-spacing="2" fill="#22D3EE">ROBOTS</text>
+    <g><rect x="990" y="166" width="150" height="36" rx="18" fill="#ffffff" fill-opacity="0.05" stroke="#22D3EE" stroke-opacity="0.4"/><text x="1120" y="189">SO-100 / SO-101</text>
+       <animate attributeName="opacity" from="0" to="1" begin="0.5s" dur="0.5s" fill="freeze"/></g>
+    <g><rect x="990" y="212" width="150" height="36" rx="18" fill="#ffffff" fill-opacity="0.05" stroke="#22D3EE" stroke-opacity="0.4"/><text x="1120" y="235">Franka / UR5e</text>
+       <animate attributeName="opacity" from="0" to="1" begin="0.6s" dur="0.5s" fill="freeze"/></g>
+    <g><rect x="990" y="258" width="150" height="36" rx="18" fill="#ffffff" fill-opacity="0.05" stroke="#22D3EE" stroke-opacity="0.4"/><text x="1120" y="281">ALOHA bimanual</text>
+       <animate attributeName="opacity" from="0" to="1" begin="0.7s" dur="0.5s" fill="freeze"/></g>
+    <g><rect x="990" y="304" width="150" height="36" rx="18" fill="#ffffff" fill-opacity="0.05" stroke="#22D3EE" stroke-opacity="0.4"/><text x="1120" y="327">Unitree G1 / Go2</text>
+       <animate attributeName="opacity" from="0" to="1" begin="0.8s" dur="0.5s" fill="freeze"/></g>
+  </g>
+
+  <!-- ===================== bottom proof ticker ===================== -->
+  <text x="600" y="600" text-anchor="middle" font-size="12" fill="#5f6470" font-weight="600" letter-spacing="1.5">CLOSED LOOP, EVERY TICK</text>
+</svg>

--- a/docs/assets/mesh_network.svg
+++ b/docs/assets/mesh_network.svg
@@ -1,0 +1,157 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 640" width="1200" height="640" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <defs>
+    <linearGradient id="gx" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#00FF77"/><stop offset="0.5" stop-color="#22D3EE"/><stop offset="1" stop-color="#00FF77"/>
+      <animateTransform attributeName="gradientTransform" type="translate" values="-0.3 0; 0.3 0; -0.3 0" dur="7s" repeatCount="indefinite"/>
+    </linearGradient>
+    <linearGradient id="gxTitle" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#7CFFB0"/><stop offset="0.5" stop-color="#00FF77"/><stop offset="1" stop-color="#22D3EE"/>
+      <animateTransform attributeName="gradientTransform" type="translate" values="-0.4 0; 0.4 0; -0.4 0" dur="9s" repeatCount="indefinite"/>
+    </linearGradient>
+    <radialGradient id="nodeGlow" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#00FF77" stop-opacity="0.5"/><stop offset="1" stop-color="#00FF77" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="agentGlow" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#22D3EE" stop-opacity="0.45"/><stop offset="0.6" stop-color="#22D3EE" stop-opacity="0.08"/><stop offset="1" stop-color="#22D3EE" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="bgGlowG" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#00FF77" stop-opacity="0.30"/><stop offset="1" stop-color="#00FF77" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="bgGlowC" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#22D3EE" stop-opacity="0.28"/><stop offset="1" stop-color="#22D3EE" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect x="8" y="8" width="1184" height="624" rx="30" fill="#0a0a0a"/>
+  <rect x="8" y="8" width="1184" height="624" rx="30" fill="none" stroke="url(#gx)" stroke-opacity="0.28" stroke-width="1.5"/>
+  <!-- ambient depth: soft glows + faint network backdrop (matches hero/architecture) -->
+  <g opacity="0.42">
+    <circle cx="240" cy="200" r="170" fill="url(#bgGlowG)"><animateTransform attributeName="transform" type="translate" values="0 0; 40 30; 0 0" dur="24s" repeatCount="indefinite"/></circle>
+    <circle cx="980" cy="470" r="175" fill="url(#bgGlowC)"><animateTransform attributeName="transform" type="translate" values="0 0; -40 -28; 0 0" dur="27s" repeatCount="indefinite"/></circle>
+    <line x1="688" y1="205" x2="525" y2="259" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.12"><animate attributeName="stroke-opacity" values="0.03;0.2;0.03" dur="6s" begin="0.0s" repeatCount="indefinite"/></line>
+    <line x1="688" y1="205" x2="638" y2="279" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.12"><animate attributeName="stroke-opacity" values="0.03;0.2;0.03" dur="7s" begin="0.6s" repeatCount="indefinite"/></line>
+    <line x1="1102" y1="563" x2="795" y2="436" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.12"><animate attributeName="stroke-opacity" values="0.03;0.2;0.03" dur="8s" begin="1.2s" repeatCount="indefinite"/></line>
+    <line x1="1102" y1="563" x2="1013" y2="303" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.12"><animate attributeName="stroke-opacity" values="0.03;0.2;0.03" dur="9s" begin="1.8s" repeatCount="indefinite"/></line>
+    <line x1="565" y1="435" x2="456" y2="341" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.12"><animate attributeName="stroke-opacity" values="0.03;0.2;0.03" dur="10s" begin="2.4s" repeatCount="indefinite"/></line>
+    <line x1="565" y1="435" x2="795" y2="436" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.12"><animate attributeName="stroke-opacity" values="0.03;0.2;0.03" dur="11s" begin="0.0s" repeatCount="indefinite"/></line>
+    <line x1="565" y1="435" x2="497" y2="438" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.12"><animate attributeName="stroke-opacity" values="0.03;0.2;0.03" dur="12s" begin="0.6s" repeatCount="indefinite"/></line>
+    <line x1="292" y1="219" x2="136" y2="205" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.12"><animate attributeName="stroke-opacity" values="0.03;0.2;0.03" dur="6s" begin="1.2s" repeatCount="indefinite"/></line>
+    <line x1="292" y1="219" x2="226" y2="127" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.12"><animate attributeName="stroke-opacity" values="0.03;0.2;0.03" dur="7s" begin="1.8s" repeatCount="indefinite"/></line>
+    <line x1="372" y1="449" x2="289" y2="586" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.12"><animate attributeName="stroke-opacity" values="0.03;0.2;0.03" dur="8s" begin="2.4s" repeatCount="indefinite"/></line>
+    <line x1="372" y1="449" x2="412" y2="422" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.12"><animate attributeName="stroke-opacity" values="0.03;0.2;0.03" dur="9s" begin="0.0s" repeatCount="indefinite"/></line>
+    <line x1="372" y1="449" x2="497" y2="438" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.12"><animate attributeName="stroke-opacity" values="0.03;0.2;0.03" dur="10s" begin="0.6s" repeatCount="indefinite"/></line>
+    <line x1="289" y1="586" x2="180" y2="513" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.12"><animate attributeName="stroke-opacity" values="0.03;0.2;0.03" dur="11s" begin="1.2s" repeatCount="indefinite"/></line>
+    <line x1="136" y1="205" x2="67" y2="337" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.12"><animate attributeName="stroke-opacity" values="0.03;0.2;0.03" dur="12s" begin="1.8s" repeatCount="indefinite"/></line>
+    <line x1="136" y1="205" x2="226" y2="127" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.12"><animate attributeName="stroke-opacity" values="0.03;0.2;0.03" dur="6s" begin="2.4s" repeatCount="indefinite"/></line>
+    <line x1="156" y1="487" x2="180" y2="513" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.12"><animate attributeName="stroke-opacity" values="0.03;0.2;0.03" dur="7s" begin="0.0s" repeatCount="indefinite"/></line>
+    <line x1="156" y1="487" x2="84" y2="455" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.12"><animate attributeName="stroke-opacity" values="0.03;0.2;0.03" dur="8s" begin="0.6s" repeatCount="indefinite"/></line>
+    <line x1="456" y1="341" x2="412" y2="422" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.12"><animate attributeName="stroke-opacity" values="0.03;0.2;0.03" dur="9s" begin="1.2s" repeatCount="indefinite"/></line>
+    <line x1="456" y1="341" x2="470" y2="317" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.12"><animate attributeName="stroke-opacity" values="0.03;0.2;0.03" dur="10s" begin="1.8s" repeatCount="indefinite"/></line>
+    <line x1="412" y1="422" x2="497" y2="438" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.12"><animate attributeName="stroke-opacity" values="0.03;0.2;0.03" dur="11s" begin="2.4s" repeatCount="indefinite"/></line>
+    <line x1="496" y1="212" x2="525" y2="259" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.12"><animate attributeName="stroke-opacity" values="0.03;0.2;0.03" dur="12s" begin="0.0s" repeatCount="indefinite"/></line>
+    <line x1="496" y1="212" x2="470" y2="317" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.12"><animate attributeName="stroke-opacity" values="0.03;0.2;0.03" dur="6s" begin="0.6s" repeatCount="indefinite"/></line>
+    <line x1="525" y1="259" x2="470" y2="317" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.12"><animate attributeName="stroke-opacity" values="0.03;0.2;0.03" dur="7s" begin="1.2s" repeatCount="indefinite"/></line>
+    <line x1="525" y1="259" x2="638" y2="279" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.12"><animate attributeName="stroke-opacity" values="0.03;0.2;0.03" dur="8s" begin="1.8s" repeatCount="indefinite"/></line>
+    <line x1="180" y1="513" x2="84" y2="455" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.12"><animate attributeName="stroke-opacity" values="0.03;0.2;0.03" dur="9s" begin="2.4s" repeatCount="indefinite"/></line>
+    <line x1="795" y1="436" x2="1013" y2="303" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.12"><animate attributeName="stroke-opacity" values="0.03;0.2;0.03" dur="10s" begin="0.0s" repeatCount="indefinite"/></line>
+    <line x1="795" y1="436" x2="638" y2="279" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.12"><animate attributeName="stroke-opacity" values="0.03;0.2;0.03" dur="11s" begin="0.6s" repeatCount="indefinite"/></line>
+    <line x1="67" y1="337" x2="84" y2="455" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.12"><animate attributeName="stroke-opacity" values="0.03;0.2;0.03" dur="12s" begin="1.2s" repeatCount="indefinite"/></line>
+    <line x1="67" y1="337" x2="70" y2="387" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.12"><animate attributeName="stroke-opacity" values="0.03;0.2;0.03" dur="6s" begin="1.8s" repeatCount="indefinite"/></line>
+    <line x1="84" y1="455" x2="70" y2="387" stroke="url(#gx)" stroke-width="0.7" stroke-opacity="0.12"><animate attributeName="stroke-opacity" values="0.03;0.2;0.03" dur="7s" begin="2.4s" repeatCount="indefinite"/></line>
+    <circle cx="688" cy="205" r="1.5" fill="#00FF77" opacity="0.4"><animate attributeName="opacity" values="0.1;0.45;0.1" dur="6s" begin="0.0s" repeatCount="indefinite"/></circle>
+    <circle cx="1102" cy="563" r="1.5" fill="#00FF77" opacity="0.4"><animate attributeName="opacity" values="0.1;0.45;0.1" dur="7s" begin="0.5s" repeatCount="indefinite"/></circle>
+    <circle cx="565" cy="435" r="1.5" fill="#00FF77" opacity="0.4"><animate attributeName="opacity" values="0.1;0.45;0.1" dur="8s" begin="1.0s" repeatCount="indefinite"/></circle>
+    <circle cx="292" cy="219" r="1.5" fill="#00FF77" opacity="0.4"><animate attributeName="opacity" values="0.1;0.45;0.1" dur="9s" begin="1.5s" repeatCount="indefinite"/></circle>
+    <circle cx="372" cy="449" r="1.5" fill="#00FF77" opacity="0.4"><animate attributeName="opacity" values="0.1;0.45;0.1" dur="10s" begin="2.0s" repeatCount="indefinite"/></circle>
+    <circle cx="289" cy="586" r="1.5" fill="#00FF77" opacity="0.4"><animate attributeName="opacity" values="0.1;0.45;0.1" dur="11s" begin="2.5s" repeatCount="indefinite"/></circle>
+    <circle cx="136" cy="205" r="1.5" fill="#00FF77" opacity="0.4"><animate attributeName="opacity" values="0.1;0.45;0.1" dur="12s" begin="0.0s" repeatCount="indefinite"/></circle>
+    <circle cx="156" cy="487" r="1.5" fill="#00FF77" opacity="0.4"><animate attributeName="opacity" values="0.1;0.45;0.1" dur="6s" begin="0.5s" repeatCount="indefinite"/></circle>
+    <circle cx="456" cy="341" r="1.5" fill="#00FF77" opacity="0.4"><animate attributeName="opacity" values="0.1;0.45;0.1" dur="7s" begin="1.0s" repeatCount="indefinite"/></circle>
+    <circle cx="412" cy="422" r="1.5" fill="#00FF77" opacity="0.4"><animate attributeName="opacity" values="0.1;0.45;0.1" dur="8s" begin="1.5s" repeatCount="indefinite"/></circle>
+    <circle cx="496" cy="212" r="1.5" fill="#00FF77" opacity="0.4"><animate attributeName="opacity" values="0.1;0.45;0.1" dur="9s" begin="2.0s" repeatCount="indefinite"/></circle>
+    <circle cx="525" cy="259" r="1.5" fill="#00FF77" opacity="0.4"><animate attributeName="opacity" values="0.1;0.45;0.1" dur="10s" begin="2.5s" repeatCount="indefinite"/></circle>
+    <circle cx="180" cy="513" r="1.5" fill="#00FF77" opacity="0.4"><animate attributeName="opacity" values="0.1;0.45;0.1" dur="11s" begin="0.0s" repeatCount="indefinite"/></circle>
+    <circle cx="795" cy="436" r="1.5" fill="#00FF77" opacity="0.4"><animate attributeName="opacity" values="0.1;0.45;0.1" dur="12s" begin="0.5s" repeatCount="indefinite"/></circle>
+    <circle cx="1013" cy="303" r="1.5" fill="#00FF77" opacity="0.4"><animate attributeName="opacity" values="0.1;0.45;0.1" dur="6s" begin="1.0s" repeatCount="indefinite"/></circle>
+    <circle cx="470" cy="317" r="1.5" fill="#00FF77" opacity="0.4"><animate attributeName="opacity" values="0.1;0.45;0.1" dur="7s" begin="1.5s" repeatCount="indefinite"/></circle>
+    <circle cx="497" cy="438" r="1.5" fill="#00FF77" opacity="0.4"><animate attributeName="opacity" values="0.1;0.45;0.1" dur="8s" begin="2.0s" repeatCount="indefinite"/></circle>
+    <circle cx="67" cy="337" r="1.5" fill="#00FF77" opacity="0.4"><animate attributeName="opacity" values="0.1;0.45;0.1" dur="9s" begin="2.5s" repeatCount="indefinite"/></circle>
+    <circle cx="638" cy="279" r="1.5" fill="#00FF77" opacity="0.4"><animate attributeName="opacity" values="0.1;0.45;0.1" dur="10s" begin="0.0s" repeatCount="indefinite"/></circle>
+    <circle cx="84" cy="455" r="1.5" fill="#00FF77" opacity="0.4"><animate attributeName="opacity" values="0.1;0.45;0.1" dur="11s" begin="0.5s" repeatCount="indefinite"/></circle>
+    <circle cx="70" cy="387" r="1.5" fill="#00FF77" opacity="0.4"><animate attributeName="opacity" values="0.1;0.45;0.1" dur="12s" begin="1.0s" repeatCount="indefinite"/></circle>
+    <circle cx="226" cy="127" r="1.5" fill="#00FF77" opacity="0.4"><animate attributeName="opacity" values="0.1;0.45;0.1" dur="6s" begin="1.5s" repeatCount="indefinite"/></circle>
+  </g>
+  <text x="600" y="60" text-anchor="middle" font-size="28" font-weight="700" fill="url(#gxTitle)" letter-spacing="-0.5">Define a robot. It joins the mesh.</text>
+  <text x="600" y="88" text-anchor="middle" font-size="14" fill="#8a8f99" font-weight="500">every Robot() is a Zenoh peer &#183; auto-discovery &#183; one agent drives the fleet</text>
+  <rect x="70" y="130" width="420" height="250" rx="14" fill="#0d0f12" stroke="#00FF77" stroke-opacity="0.35" stroke-width="1"/>
+  <circle cx="92" cy="152" r="5" fill="#ff5f56"/><circle cx="110" cy="152" r="5" fill="#ffbd2e"/><circle cx="128" cy="152" r="5" fill="#27c93f"/>
+  <text x="474" y="156" text-anchor="end" font-size="11" fill="#8a8f99" font-family="monospace">python</text>
+  <text x="90" y="188" font-family="DejaVu Sans Mono, Menlo, monospace" font-size="15" fill="#8a8f99" opacity="0">from strands_robots import Robot<animate attributeName="opacity" from="0" to="1" begin="0.3s" dur="0.4s" fill="freeze"/></text>
+  <text x="90" y="236" font-family="DejaVu Sans Mono, Menlo, monospace" font-size="15" fill="#00FF77" opacity="0">arm = Robot('so100')   # joins mesh<animate attributeName="opacity" from="0" to="1" begin="1.5s" dur="0.4s" fill="freeze"/></text>
+  <text x="90" y="260" font-family="DejaVu Sans Mono, Menlo, monospace" font-size="15" fill="#00FF77" opacity="0">arm2 = Robot('so101')  # auto-connects<animate attributeName="opacity" from="0" to="1" begin="4.0s" dur="0.4s" fill="freeze"/></text>
+  <text x="90" y="308" font-family="DejaVu Sans Mono, Menlo, monospace" font-size="15" fill="#22D3EE" opacity="0">agent.tool.robot_mesh(<animate attributeName="opacity" from="0" to="1" begin="6.5s" dur="0.4s" fill="freeze"/></text>
+  <text x="90" y="332" font-family="DejaVu Sans Mono, Menlo, monospace" font-size="15" fill="#22D3EE" opacity="0">    action='broadcast',<animate attributeName="opacity" from="0" to="1" begin="6.8s" dur="0.4s" fill="freeze"/></text>
+  <text x="90" y="356" font-family="DejaVu Sans Mono, Menlo, monospace" font-size="15" fill="#22D3EE" opacity="0">    command='{"go_home": true}')<animate attributeName="opacity" from="0" to="1" begin="7.1s" dur="0.4s" fill="freeze"/></text>
+  <g opacity="0"><animate attributeName="opacity" from="0" to="1" begin="6s" dur="0.6s" fill="freeze"/><circle cx="900" cy="250" r="60" fill="url(#agentGlow)"/><circle cx="900" cy="250" r="38" fill="#101012" stroke="url(#gx)" stroke-width="2.5"/><text x="900" y="248" text-anchor="middle" font-size="13" font-weight="700" fill="#e6e8ee">Strands</text><text x="900" y="264" text-anchor="middle" font-size="13" font-weight="700" fill="#00FF77">Agent</text></g>
+  <g opacity="0"><animate attributeName="opacity" from="0" to="1" begin="4.6s" dur="0.6s" fill="freeze"/>
+    <line x1="720" y1="180" x2="1050" y2="200" stroke="#22D3EE" stroke-width="1.5" stroke-opacity="0.35" stroke-dasharray="5 6"><animate attributeName="stroke-dashoffset" values="22;0" dur="1.2s" repeatCount="indefinite"/></line>
+    <circle r="3" fill="#22D3EE"><animate attributeName="cx" values="720;1050" dur="1.6s" begin="4.6s" repeatCount="indefinite"/><animate attributeName="cy" values="180;200" dur="1.6s" begin="4.6s" repeatCount="indefinite"/></circle>
+    <text x="885" y="184" text-anchor="middle" font-size="9" fill="#22D3EE" font-family="monospace">zenoh discover</text>
+  </g>
+  <g opacity="0"><animate attributeName="opacity" from="0" to="1" begin="9.2s" dur="0.6s" fill="freeze"/>
+    <line x1="720" y1="180" x2="760" y2="360" stroke="#22D3EE" stroke-width="1.5" stroke-opacity="0.35" stroke-dasharray="5 6"><animate attributeName="stroke-dashoffset" values="22;0" dur="1.2s" repeatCount="indefinite"/></line>
+    <circle r="3" fill="#22D3EE"><animate attributeName="cx" values="720;760" dur="1.6s" begin="9.2s" repeatCount="indefinite"/><animate attributeName="cy" values="180;360" dur="1.6s" begin="9.2s" repeatCount="indefinite"/></circle>
+  </g>
+  <g opacity="0"><animate attributeName="opacity" from="0" to="1" begin="10.2s" dur="0.6s" fill="freeze"/>
+    <line x1="1050" y1="200" x2="1040" y2="380" stroke="#22D3EE" stroke-width="1.5" stroke-opacity="0.35" stroke-dasharray="5 6"><animate attributeName="stroke-dashoffset" values="22;0" dur="1.2s" repeatCount="indefinite"/></line>
+    <circle r="3" fill="#22D3EE"><animate attributeName="cx" values="1050;1040" dur="1.6s" begin="10.2s" repeatCount="indefinite"/><animate attributeName="cy" values="200;380" dur="1.6s" begin="10.2s" repeatCount="indefinite"/></circle>
+  </g>
+  <g opacity="0"><animate attributeName="opacity" from="0" to="1" begin="10.6s" dur="0.6s" fill="freeze"/>
+    <line x1="760" y1="360" x2="1040" y2="380" stroke="#22D3EE" stroke-width="1.5" stroke-opacity="0.35" stroke-dasharray="5 6"><animate attributeName="stroke-dashoffset" values="22;0" dur="1.2s" repeatCount="indefinite"/></line>
+    <circle r="3" fill="#22D3EE"><animate attributeName="cx" values="760;1040" dur="1.6s" begin="10.6s" repeatCount="indefinite"/><animate attributeName="cy" values="360;380" dur="1.6s" begin="10.6s" repeatCount="indefinite"/></circle>
+  </g>
+  <g opacity="0"><animate attributeName="opacity" from="0" to="1" begin="11.0s" dur="0.6s" fill="freeze"/>
+    <line x1="720" y1="180" x2="1040" y2="380" stroke="#22D3EE" stroke-width="1.5" stroke-opacity="0.35" stroke-dasharray="5 6"><animate attributeName="stroke-dashoffset" values="22;0" dur="1.2s" repeatCount="indefinite"/></line>
+    <circle r="3" fill="#22D3EE"><animate attributeName="cx" values="720;1040" dur="1.6s" begin="11.0s" repeatCount="indefinite"/><animate attributeName="cy" values="180;380" dur="1.6s" begin="11.0s" repeatCount="indefinite"/></circle>
+  </g>
+  <g opacity="0"><animate attributeName="opacity" from="0" to="1" begin="7.2s" dur="0.5s" fill="freeze"/><line x1="900" y1="250" x2="720" y2="180" stroke="#00FF77" stroke-width="1.5" stroke-opacity="0.4"/><circle r="3.5" fill="#7CFFB0"><animate attributeName="cx" values="900;720" dur="1.3s" begin="7.2s" repeatCount="indefinite"/><animate attributeName="cy" values="250;180" dur="1.3s" begin="7.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0;1;0" dur="1.3s" begin="7.2s" repeatCount="indefinite"/></circle></g>
+  <g opacity="0"><animate attributeName="opacity" from="0" to="1" begin="7.4s" dur="0.5s" fill="freeze"/><line x1="900" y1="250" x2="1050" y2="200" stroke="#00FF77" stroke-width="1.5" stroke-opacity="0.4"/><circle r="3.5" fill="#7CFFB0"><animate attributeName="cx" values="900;1050" dur="1.3s" begin="7.4s" repeatCount="indefinite"/><animate attributeName="cy" values="250;200" dur="1.3s" begin="7.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0;1;0" dur="1.3s" begin="7.4s" repeatCount="indefinite"/></circle></g>
+  <g opacity="0"><animate attributeName="opacity" from="0" to="1" begin="9.6s" dur="0.5s" fill="freeze"/><line x1="900" y1="250" x2="760" y2="360" stroke="#00FF77" stroke-width="1.5" stroke-opacity="0.4"/><circle r="3.5" fill="#7CFFB0"><animate attributeName="cx" values="900;760" dur="1.3s" begin="9.6s" repeatCount="indefinite"/><animate attributeName="cy" values="250;360" dur="1.3s" begin="9.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0;1;0" dur="1.3s" begin="9.6s" repeatCount="indefinite"/></circle></g>
+  <g opacity="0"><animate attributeName="opacity" from="0" to="1" begin="10.4s" dur="0.5s" fill="freeze"/><line x1="900" y1="250" x2="1040" y2="380" stroke="#00FF77" stroke-width="1.5" stroke-opacity="0.4"/><circle r="3.5" fill="#7CFFB0"><animate attributeName="cx" values="900;1040" dur="1.3s" begin="10.4s" repeatCount="indefinite"/><animate attributeName="cy" values="250;380" dur="1.3s" begin="10.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0;1;0" dur="1.3s" begin="10.4s" repeatCount="indefinite"/></circle></g>
+  <g opacity="0"><animate attributeName="opacity" from="0" to="1" begin="1.5s" dur="0.5s" fill="freeze"/>
+    <circle cx="720" cy="180" r="10" fill="none" stroke="#00FF77" stroke-width="2" opacity="0"><animate attributeName="r" values="10;48" begin="1.5s" dur="0.8s" fill="freeze"/><animate attributeName="opacity" values="0.9;0" begin="1.5s" dur="0.8s" fill="freeze"/></circle>
+    <circle cx="720" cy="180" r="40" fill="url(#nodeGlow)"/>
+    <circle cx="720" cy="180" r="26" fill="#101012" stroke="#00FF77" stroke-width="2"><animate attributeName="stroke-opacity" values="0.6;1;0.6" dur="3s" repeatCount="indefinite"/></circle>
+    <path d="M712,188 L712,178 L724,172 L730,178" fill="none" stroke="#00FF77" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <circle cx="712" cy="188" r="2.5" fill="#00FF77"/>
+    <text x="720" y="228" text-anchor="middle" font-size="13" font-weight="700" fill="#e6e8ee">so100</text>
+    <text x="720" y="244" text-anchor="middle" font-size="10" fill="#8a8f99">arm · sim</text>
+  </g>
+  <g opacity="0"><animate attributeName="opacity" from="0" to="1" begin="4.0s" dur="0.5s" fill="freeze"/>
+    <circle cx="1050" cy="200" r="10" fill="none" stroke="#00FF77" stroke-width="2" opacity="0"><animate attributeName="r" values="10;48" begin="4.0s" dur="0.8s" fill="freeze"/><animate attributeName="opacity" values="0.9;0" begin="4.0s" dur="0.8s" fill="freeze"/></circle>
+    <circle cx="1050" cy="200" r="40" fill="url(#nodeGlow)"/>
+    <circle cx="1050" cy="200" r="26" fill="#101012" stroke="#00FF77" stroke-width="2"><animate attributeName="stroke-opacity" values="0.6;1;0.6" dur="3s" repeatCount="indefinite"/></circle>
+    <path d="M1042,208 L1042,198 L1054,192 L1060,198" fill="none" stroke="#00FF77" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <circle cx="1042" cy="208" r="2.5" fill="#00FF77"/>
+    <text x="1050" y="248" text-anchor="middle" font-size="13" font-weight="700" fill="#e6e8ee">so101</text>
+    <text x="1050" y="264" text-anchor="middle" font-size="10" fill="#8a8f99">arm · sim</text>
+  </g>
+  <g opacity="0"><animate attributeName="opacity" from="0" to="1" begin="9.0s" dur="0.5s" fill="freeze"/>
+    <circle cx="760" cy="360" r="10" fill="none" stroke="#00FF77" stroke-width="2" opacity="0"><animate attributeName="r" values="10;48" begin="9.0s" dur="0.8s" fill="freeze"/><animate attributeName="opacity" values="0.9;0" begin="9.0s" dur="0.8s" fill="freeze"/></circle>
+    <circle cx="760" cy="360" r="40" fill="url(#nodeGlow)"/>
+    <circle cx="760" cy="360" r="26" fill="#101012" stroke="#00FF77" stroke-width="2"><animate attributeName="stroke-opacity" values="0.6;1;0.6" dur="3s" repeatCount="indefinite"/></circle>
+    <path d="M752,368 L752,358 L764,352 L770,358" fill="none" stroke="#00FF77" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <circle cx="752" cy="368" r="2.5" fill="#00FF77"/>
+    <text x="760" y="408" text-anchor="middle" font-size="13" font-weight="700" fill="#e6e8ee">so101</text>
+    <text x="760" y="424" text-anchor="middle" font-size="10" fill="#8a8f99">teleop</text>
+  </g>
+  <g opacity="0"><animate attributeName="opacity" from="0" to="1" begin="10.0s" dur="0.5s" fill="freeze"/>
+    <circle cx="1040" cy="380" r="10" fill="none" stroke="#00FF77" stroke-width="2" opacity="0"><animate attributeName="r" values="10;48" begin="10.0s" dur="0.8s" fill="freeze"/><animate attributeName="opacity" values="0.9;0" begin="10.0s" dur="0.8s" fill="freeze"/></circle>
+    <circle cx="1040" cy="380" r="40" fill="url(#nodeGlow)"/>
+    <circle cx="1040" cy="380" r="26" fill="#101012" stroke="#00FF77" stroke-width="2"><animate attributeName="stroke-opacity" values="0.6;1;0.6" dur="3s" repeatCount="indefinite"/></circle>
+    <path d="M1032,388 L1032,378 L1044,372 L1050,378" fill="none" stroke="#00FF77" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <circle cx="1032" cy="388" r="2.5" fill="#00FF77"/>
+    <text x="1040" y="428" text-anchor="middle" font-size="13" font-weight="700" fill="#e6e8ee">franka</text>
+    <text x="1040" y="444" text-anchor="middle" font-size="10" fill="#8a8f99">real HW</text>
+  </g>
+  <text x="600" y="610" text-anchor="middle" font-size="12" font-weight="700" fill="#8a8f99" letter-spacing="1">ONE import &#183; ONE mesh &#183; ONE agent commands them all</text>
+</svg>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,9 @@
 # Strands Robots
 
+<figure class="brand-figure" markdown="span">
+  ![Strands Robots: perceive, reason, act, world - the closed control loop around a Strands Agent core](assets/hero_loop.svg){ .brand-svg }
+</figure>
+
 A robot library for [Strands agents](https://strandsagents.com). You name a robot, you get something you can drive - in simulation by default, or on real hardware when you ask for it.
 
 ```python

--- a/docs/mesh.md
+++ b/docs/mesh.md
@@ -4,6 +4,10 @@ description: Two Robot() instances coordinating over the Zenoh mesh - peer disco
 
 # Multi-robot mesh
 
+<figure class="brand-figure" markdown="span">
+  ![Robot peers discovering and coordinating over the Zenoh mesh](assets/mesh_network.svg){ .brand-svg }
+</figure>
+
 Every `Robot()` auto-joins a Zenoh mesh. Peers discover each other on the LAN and can query, command, and e-stop one another.
 
 !!! info "Device Connect is the recommended networking layer"

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -446,3 +446,44 @@ h1 {
     border-radius: 8px;
     border: 1px solid var(--glass-border);
 }
+
+/* ---- Brand figures (animated SVG hero / architecture / mesh) ---- */
+.brand-figure {
+    margin: 1.5rem 0 2rem;
+    text-align: center;
+}
+
+.brand-figure .brand-svg,
+img.brand-svg {
+    width: 100%;
+    max-width: 980px;
+    height: auto;
+    border-radius: 14px;
+    border: 1px solid var(--glass-border);
+    background: #0a0a0a;
+    box-shadow: 0 8px 40px rgba(0, 0, 0, 0.35);
+}
+
+/* The SVGs are authored on true black; in dark mode let them blend into the
+   page with the brand-green edge glow instead of a hard frame. */
+[data-md-color-scheme="slate"] .brand-figure .brand-svg,
+[data-md-color-scheme="slate"] img.brand-svg {
+    border-color: rgba(0, 255, 119, 0.18);
+    box-shadow: 0 0 0 1px rgba(0, 255, 119, 0.06),
+        0 12px 48px rgba(0, 0, 0, 0.5);
+}
+
+.brand-figure figcaption {
+    margin-top: 0.5rem;
+    font-size: 0.82rem;
+    color: var(--fg-muted);
+}
+
+/* Respect reduced-motion: the SVGs use SMIL, which the OS pause cannot stop,
+   so at least keep the surrounding hover/transition still. */
+@media (prefers-reduced-motion: reduce) {
+    .brand-figure .brand-svg,
+    img.brand-svg {
+        transition: none;
+    }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,7 @@ site_description: "Robot control, simulation, and training for Strands Agents"
 repo_url: https://github.com/strands-labs/robots
 repo_name: strands-labs/robots
 extra_css:
-- stylesheets/extra.css?v=1
+- stylesheets/extra.css?v=2
 extra_javascript:
 - https://unpkg.com/mermaid@10/dist/mermaid.min.js
 - assets/mermaid-init.js

--- a/tests/test_docs_brand_visuals.py
+++ b/tests/test_docs_brand_visuals.py
@@ -1,0 +1,73 @@
+"""Repo hygiene: the animated brand SVGs stay wired into the docs and README.
+
+The site and README open with three hand-authored animated SVGs that carry the
+project's visual identity (true-black glassmorphism, brand green ``#00FF77`` +
+cyan ``#22D3EE``):
+
+* ``hero_loop.svg`` - the perceive/reason/act/world control loop, on the docs
+  home page and at the top of the README.
+* ``architecture_flow.svg`` - the four-layer stack with action/observation
+  signal flow, on the architecture page.
+* ``mesh_network.svg`` - peer coordination over the Zenoh mesh, on the mesh
+  page.
+
+Each is surfaced through the ``brand-figure``/``brand-svg`` CSS treatment in
+``docs/stylesheets/extra.css``. This guard fails fast if an asset is deleted,
+an embed is dropped, an SVG stops being valid (or static) XML, or the CSS hook
+disappears - any of which would silently degrade the landing experience.
+"""
+
+from __future__ import annotations
+
+import xml.dom.minidom
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DOCS = REPO_ROOT / "docs"
+ASSETS = DOCS / "assets"
+EXTRA_CSS = DOCS / "stylesheets" / "extra.css"
+README = REPO_ROOT / "README.md"
+
+BRAND_SVGS = ("hero_loop.svg", "architecture_flow.svg", "mesh_network.svg")
+
+
+def test_brand_svg_assets_exist() -> None:
+    """All three animated brand SVGs ship under docs/assets/."""
+    for name in BRAND_SVGS:
+        assert (ASSETS / name).is_file(), f"missing brand asset: docs/assets/{name}"
+
+
+def test_brand_svgs_are_valid_animated_xml() -> None:
+    """Each brand SVG parses as XML and carries SMIL animation (<animate*>)."""
+    for name in BRAND_SVGS:
+        text = (ASSETS / name).read_text(encoding="utf-8")
+        # Raises on malformed XML - the docs build would otherwise serve a broken asset.
+        xml.dom.minidom.parseString(text)
+        assert "<animate" in text, f"{name} lost its SMIL animation"
+
+
+def test_docs_pages_embed_their_brand_svg() -> None:
+    """Home, architecture, and mesh pages each embed their SVG via the brand class."""
+    pairs = {
+        DOCS / "index.md": "hero_loop.svg",
+        DOCS / "architecture.md": "architecture_flow.svg",
+        DOCS / "mesh.md": "mesh_network.svg",
+    }
+    for page, asset in pairs.items():
+        text = page.read_text(encoding="utf-8")
+        assert asset in text, f"{page.name} no longer embeds {asset}"
+        assert "brand-svg" in text, f"{page.name} dropped the brand-svg CSS hook"
+
+
+def test_readme_embeds_hero() -> None:
+    """The README opens with the hero loop banner."""
+    assert "docs/assets/hero_loop.svg" in README.read_text(encoding="utf-8"), (
+        "README no longer embeds the hero_loop.svg banner"
+    )
+
+
+def test_extra_css_defines_brand_figure() -> None:
+    """The active stylesheet defines the brand-figure / brand-svg treatment."""
+    css = EXTRA_CSS.read_text(encoding="utf-8")
+    assert ".brand-figure" in css, "extra.css missing .brand-figure rule"
+    assert ".brand-svg" in css or "img.brand-svg" in css, "extra.css missing .brand-svg rule"


### PR DESCRIPTION
## What

Gives the README and docs a cohesive animated visual identity. Three hand-authored SVGs (true-black glassmorphism, brand green `#00FF77` + cyan `#22D3EE`, matching the existing `extra.css` theme), wired into the pages they describe and surfaced through a shared `.brand-figure` / `.brand-svg` CSS treatment.

## Assets

**`hero_loop.svg`** - robotics is a closed control loop, so the hero is a loop: signal particles orbit a central Strands Agent core through Perceive / Act / World / Tools nodes, with policy and robot rails. Opens the docs home page and the README.

![hero](https://github.com/cagataycali/robots/releases/download/brand-visuals-preview/preview_hero_loop.png)

**`architecture_flow.svg`** - the four-layer Agent / Policies / Backends / Robots stack with green action signals flowing down and cyan observation signals flowing back up. Heads the architecture page, above the existing mermaid diagram.

![architecture](https://github.com/cagataycali/robots/releases/download/brand-visuals-preview/preview_architecture_flow.png)

**`mesh_network.svg`** - robot peers discovering and coordinating over the Zenoh mesh. Heads the mesh page.

![mesh](https://github.com/cagataycali/robots/releases/download/brand-visuals-preview/preview_mesh_network.png)

(Stills above are static raster previews via CairoSVG; the committed SVGs animate via SMIL in the browser.)

## CSS

Adds a `.brand-figure` / `.brand-svg` block to `docs/stylesheets/extra.css`: glass frame, brand-green edge glow in dark (`slate`) mode so the true-black SVGs blend into the page, and a `prefers-reduced-motion` guard. Bumps the `extra.css` cache-buster to `v2`.

## Tests

`tests/test_docs_brand_visuals.py` guards the wiring: assets exist, parse as valid animated SVG (XML + `<animate>`), stay embedded on their pages via the `brand-svg` hook, the README keeps the hero, and the CSS treatment is present. Fails on the pre-change tree (assets absent, no embeds).

## Verification

- `mkdocs build --strict` passes; all three SVGs ship to `site/assets/` and render in the built HTML.
- All three SVGs raster cleanly via CairoSVG and validate as XML.
- `ruff check` / `ruff format` clean on the new test.