### PR TITLE
fix(robot): ASCII-only output from Robot().run() device-connect loop

### DIFF
--- a/strands_robots/robot.py
+++ b/strands_robots/robot.py
@@ -417,13 +417,13 @@ def _run_device_connect_foreground(instance: Any) -> None:
     except Exception as e:  # noqa: BLE001 - surface but keep the process alive
         logger.warning("Device Connect init failed: %s", e)
 
-    print(f"🤖 {peer_id} is online. Ctrl+C to stop.")
+    print(f"{peer_id} is online. Ctrl+C to stop.")
     try:
         while True:
             time.sleep(1)
     except KeyboardInterrupt:
-        print(f"\n🛑 Shutting down {peer_id}...", flush=True)
-        print(f"👋 {peer_id} stopped.", flush=True)
+        print(f"\nShutting down {peer_id}...", flush=True)
+        print(f"{peer_id} stopped.", flush=True)
         os._exit(0)
 
 

--- a/tests/test_robot_factory.py
+++ b/tests/test_robot_factory.py
@@ -1,6 +1,8 @@
 """Tests for strands_robots.robot - Robot() factory and list_robots()."""
 
 import importlib
+import os
+import types
 
 import pytest
 
@@ -1114,3 +1116,116 @@ class TestRobotNamePreservesUserInput:
             assert sim.tool_name == "h1_sim"
         finally:
             sim.destroy()
+
+
+class TestRunDeviceConnectAsciiOutput:
+    """Regression: the foreground ``.run()`` device-connect loop must print
+    ASCII-only status lines.
+
+    ``Robot(...).run()`` brings the device online and prints lifecycle messages
+    straight to the operator's terminal. Those messages previously embedded
+    emoji ("robot", "stop", "wave"), which violates the project's ASCII-only
+    rule for logs and user-facing output (the same class of fix applied to
+    serial_tool, pose_tool, and lerobot_camera). Non-ASCII bytes on a terminal
+    or in a captured CI log can also raise UnicodeEncodeError under a non-UTF-8
+    locale (``LC_ALL=C``). These tests pin the output to ASCII and exercise the
+    otherwise-uncovered foreground loop without blocking.
+    """
+
+    def _drive_foreground(self, monkeypatch, capsys, peer_id="so100-test"):
+        """Run the blocking foreground loop once and capture its stdout.
+
+        ``time.sleep`` is patched to raise ``KeyboardInterrupt`` (the operator's
+        Ctrl+C) so the loop exits on the first tick, and ``os._exit`` is patched
+        to a sentinel raise so the test process survives.
+        """
+        import strands_robots.robot as robot_mod
+
+        instance = types.SimpleNamespace(
+            _peer_id=peer_id,
+            _peer_type="sim",
+            mesh=None,
+        )
+
+        # The device_connect import/init is wrapped in the function's own
+        # try/except, so a missing backend is logged and the loop still prints
+        # its lifecycle lines - exactly the path under test. No stubbing needed.
+        monkeypatch.setattr("time.sleep", lambda _s: (_ for _ in ()).throw(KeyboardInterrupt()))
+
+        class _ExitCalled(Exception):
+            pass
+
+        def _fake_exit(code):
+            raise _ExitCalled()
+
+        monkeypatch.setattr(os, "_exit", _fake_exit)
+
+        with pytest.raises(_ExitCalled):
+            robot_mod._run_device_connect_foreground(instance)
+        return capsys.readouterr().out
+
+    def test_foreground_output_is_ascii_only(self, monkeypatch, capsys):
+        out = self._drive_foreground(monkeypatch, capsys)
+        assert out, "foreground loop produced no output"
+        offenders = [
+            (i, ch, hex(ord(ch))) for i, line in enumerate(out.splitlines(), 1) for ch in line if ord(ch) > 0x7F
+        ]
+        assert not offenders, f"non-ASCII characters in run() output: {offenders}"
+        # Output encodes cleanly under a non-UTF-8 locale (no UnicodeEncodeError).
+        out.encode("ascii")
+
+    def test_foreground_output_reports_lifecycle(self, monkeypatch, capsys):
+        """The ASCII messages still convey online + shutdown + peer id."""
+        out = self._drive_foreground(monkeypatch, capsys, peer_id="franka-7")
+        assert "franka-7 is online" in out
+        assert "Shutting down franka-7" in out
+        assert "franka-7 stopped" in out
+
+    def test_built_in_mesh_is_stopped_before_device_connect(self, monkeypatch, capsys):
+        """Device Connect supersedes the auto-started mesh in run() mode.
+
+        A running built-in mesh must be stopped and detached so two Zenoh
+        presence systems do not run in one process.
+        """
+        import strands_robots.robot as robot_mod
+
+        stopped = []
+
+        class _Mesh:
+            def stop(self):
+                stopped.append(True)
+
+        instance = types.SimpleNamespace(_peer_id="m1", _peer_type="sim", mesh=_Mesh())
+        monkeypatch.setattr("time.sleep", lambda _s: (_ for _ in ()).throw(KeyboardInterrupt()))
+
+        class _ExitCalled(Exception):
+            pass
+
+        monkeypatch.setattr(os, "_exit", lambda code: (_ for _ in ()).throw(_ExitCalled()))
+        with pytest.raises(_ExitCalled):
+            robot_mod._run_device_connect_foreground(instance)
+
+        assert stopped == [True], "built-in mesh was not stopped"
+        assert instance.mesh is None, "mesh reference not detached"
+
+
+class TestAttachDeviceConnectBindsRun:
+    """``_attach_device_connect`` wires a callable ``.run()`` onto the instance."""
+
+    def test_run_is_bound_and_callable(self):
+        import strands_robots.robot as robot_mod
+
+        instance = types.SimpleNamespace()
+        robot_mod._attach_device_connect(instance, "so100", "sim", peer_id="p1")
+        assert callable(instance.run)
+        assert instance._peer_id == "p1"
+        assert instance._peer_type == "sim"
+
+    def test_real_mode_marks_peer_type_robot(self):
+        import strands_robots.robot as robot_mod
+
+        instance = types.SimpleNamespace()
+        robot_mod._attach_device_connect(instance, "so100", "real", peer_id=None)
+        assert instance._peer_type == "robot"
+        # A peer id is synthesized from the canonical name when none is given.
+        assert instance._peer_id.startswith("so100-")


### PR DESCRIPTION
## Problem

The foreground Device Connect loop bound to `Robot(...).run()` (`_run_device_connect_foreground` in `strands_robots/robot.py`) printed three lifecycle lines with emoji straight to the operator's terminal:

```python
print(f"\U0001f916 {peer_id} is online. Ctrl+C to stop.")
...
print(f"\n\U0001f6d1 Shutting down {peer_id}...", flush=True)
print(f"\U0001f44b {peer_id} stopped.", flush=True)
```

This violates the project's ASCII-only rule for logs and user-facing strings (the same class of fix already landed for `serial_tool` #451, `pose_tool` #461, and `lerobot_camera` #463). Beyond style, non-ASCII bytes on stdout can raise `UnicodeEncodeError` when the process runs under a non-UTF-8 locale (`LC_ALL=C`) or its output is captured to an ASCII stream, turning a clean Ctrl+C shutdown into a crash.

## Change

Replace the emoji with plain ASCII. The messages still report the peer id and the online / shutting-down / stopped transitions:

```python
print(f"{peer_id} is online. Ctrl+C to stop.")
...
print(f"\nShutting down {peer_id}...", flush=True)
print(f"{peer_id} stopped.", flush=True)
```

## Tests

The `.run()` foreground loop and `_attach_device_connect` were entirely uncovered. Added focused regression tests in `tests/test_robot_factory.py` that:

- drive one iteration of the blocking loop by patching `time.sleep` to raise `KeyboardInterrupt` and `os._exit` to a sentinel, then assert the captured stdout is **ASCII-only** (`ord(ch) <= 0x7F` and `out.encode("ascii")` succeeds) - this test **fails on the pre-fix code** (flags U+1F916 / U+1F6D1 / U+1F44B) and passes after;
- assert the ASCII messages still convey the lifecycle and peer id;
- assert the built-in mesh is stopped and detached before Device Connect starts (run() mode supersedes the auto-started mesh);
- assert `_attach_device_connect` binds a callable `.run()` and sets peer metadata for both sim and real modes.

`strands_robots/robot.py` line coverage rises 75% -> 88%.

Local gate: `ruff check` + `ruff format --check` clean on the changed files, `mypy` clean on the changed files, and `tests/test_robot_factory.py` passes (74 passed, 1 skipped) headless under `MUJOCO_GL=egl`.

No behavior change beyond the printed text; no policy/sim/render/asset surface is touched.