### PR TITLE
harden(mesh): warn on multicast scouting + reject stale teleop frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -751,7 +751,7 @@ Install with `uv pip install "strands-robots[mesh-iot]"`. See the
 | `STRANDS_MESH_CA_PINS` | Additional SHA-256 CA pins (comma-separated 64-char hex) | unset |
 | `STRANDS_MESH_DISABLE_CA_PIN` | Skip CA pin check on download path (break-glass) | `false` |
 | `STRANDS_MESH_CAMERA_PRESIGN_TTL` | TTL (s) for S3 presigned camera URLs; capped at 3600 | `60` |
-| `STRANDS_MESH_ACL_FILE` | Path to a JSON5 Zenoh ACL file; unset = permissive default. See `examples/mesh_acl_example.json5` (role-scoped) and `examples/mesh_acl_strict_per_peer.json5` (per-peer) | unset |
+| `STRANDS_MESH_ACL_FILE` | Path to a JSON5 Zenoh ACL file; unset = permissive default. See `examples/mesh_acl_example.json5` (role-scoped) and `examples/mesh_acl_strict_per_peer.json5` (per-peer). **⚠️ Required on any WAN/cloud router: mTLS gives identity, not least-privilege — without a topic-level ACL one device cert can read all fleet traffic and command any robot. See [security docs](docs/security.md#production-posture-required-off-trusted-networks).** | unset |
 | `STRANDS_MESH_POLICY_HOST_ALLOW` | Comma-separated allowlist of VLA policy-server hosts/CIDRs for inference | loopback only |
 | `STRANDS_MESH_HITL_ACTIONS` | `robot_mesh` actions needing a human-in-the-loop interrupt: `all` / `none` / subset of `emergency_stop,broadcast,tell,send,stop,subscribe,watch` | actuation default |
 | `STRANDS_MESH_SUBSCRIBE_ALLOW` | Extra Zenoh key-expr patterns the `robot_mesh` `subscribe` action may target, beyond the built-in low-impact set | shared classes only |

--- a/docs/security.md
+++ b/docs/security.md
@@ -56,6 +56,24 @@ mTLS alone is not sufficient - pair it with an access-control list:
 - Supply an operator ACL via `STRANDS_MESH_ACL_FILE` that enumerates each peer's certificate CN and the key expressions it may use. See [`examples/mesh_acl_example.json5`](https://github.com/strands-labs/robots/blob/main/examples/mesh_acl_example.json5) and [`examples/mesh_acl_strict_per_peer.json5`](https://github.com/strands-labs/robots/blob/main/examples/mesh_acl_strict_per_peer.json5).
 - `STRANDS_MESH_ACCEPT_PERMISSIVE_ACL=1` exists only to silence the permissive-ACL warning when you have deliberately accepted it (e.g. a closed lab). Do not set it in production - it does not make the mesh safer, it only quiets the reminder that it is not.
 
+> ⚠️ **WAN/cloud Zenoh routers MUST deploy a topic-level ACL.**
+> mTLS authenticates *who* a device is; it does **not** restrict *what* topics
+> that device may touch. A cloud/WAN Zenoh router with mTLS but no topic-level
+> ACL grants every authenticated device cert ambient authority over the whole
+> fleet: any one cert can subscribe to `**` (all devices' state, camera, and
+> input streams) and publish to any device's `cmd` topic. A single
+> compromised or stolen device certificate then becomes full read/write
+> control of every robot: one cert can subscribe to and command the entire
+> fleet.
+>
+> mTLS gives you **identity**; the ACL gives you **least privilege**. You need
+> both. Adapt [`examples/mesh_acl_strict_per_peer.json5`](https://github.com/strands-labs/robots/blob/main/examples/mesh_acl_strict_per_peer.json5)
+> to your fleet (it pins each peer's certificate CN to the exact key
+> expressions it may publish/subscribe) and deploy it on **every
+> internet-facing router**, not just on LAN peers. Without it, an
+> internet-reachable router is an unauthorized-fleet-control surface even
+> with mTLS enforced.
+
 ### Cross-network fleets (AWS IoT Core)
 
 Adding the `[mesh-iot]` extra routes traffic through AWS IoT Core (MQTT5 with mTLS), and a `BridgeTransport` keeps high-rate topics local while bridging presence, health, and safety to the cloud. When you use this path, the IoT device certificates and provisioning material become production secrets - provision them per-device, scope their IoT policies to the minimum topic set, and rotate/revoke them like any other fleet credential.

--- a/strands_robots/device_connect/GUIDE.md
+++ b/strands_robots/device_connect/GUIDE.md
@@ -294,6 +294,18 @@ All the options above (A–B) work identically with full infrastructure - the on
 > - **Cross-network routing** - the Zenoh router (or NATS broker) enables communication across subnets and sites, not just the local LAN.
 > - **Authentication & authorization** - mTLS ensures only devices with certificates signed by the trusted CA can exchange data. Full authorization (per-device permissions, topic-level ACLs, certificate revocation) requires the router/registry infrastructure.
 
+> ⚠️ **Security: an internet-facing Zenoh router MUST deploy a topic-level ACL.**
+> The brokered/cloud router gives you mTLS (device *identity*), but mTLS alone
+> does not restrict *which topics* a device may use. Without a topic-level ACL,
+> any authenticated device cert can subscribe to every device's state, camera,
+> and input streams and publish to any device's `cmd` topic — so one
+> compromised or stolen cert becomes full read/write control of the entire
+> fleet.
+> Adapt [`examples/mesh_acl_strict_per_peer.json5`](https://github.com/strands-labs/robots/blob/main/examples/mesh_acl_strict_per_peer.json5)
+> to your fleet and deploy it on the router. See the
+> [security considerations](https://github.com/strands-labs/robots/blob/main/docs/security.md#production-posture-required-off-trusted-networks)
+> page for details.
+
 > **Per-caller RPC allowlist (`DEVICE_CONNECT_RPC_ALLOW` / `DEVICE_CONNECT_ESTOP_ALLOW`).**
 > Devices can restrict which callers may invoke state-mutating RPCs (`execute` /
 > `stop` / `step` / `reset`) and `emergencyStop`, matched against the RPC's

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -531,7 +531,35 @@ class Mesh(SensorLoopsMixin):
                     self.peer_id,
                 )
 
-            # Issue #218 / R3: refuse-to-start gate when mtls is configured
+            # Multicast-scouting fleet-takeover warning.
+            # Twin of the H-1 override-code warning above. STRANDS_MESH_MULTICAST
+            # defaults to false (gossip-only scouting). When an operator opts
+            # INTO multicast, any device on the LAN can attract the entire fleet
+            # in ~15s with zero credentials (unauthenticated UDP 224.0.0.224:7446
+            # -- it operates below the mTLS/ACL layer.
+            # This is a deliberate "operator opts into a
+            # dangerous posture" choice with fleet-level impact, so we emit a
+            # loud, logged WARNING that turns a silent footgun into an explicit
+            # decision. We read the flag through the SAME _bool_env helper that
+            # _scouting_config() uses so the warning can never disagree with the
+            # value actually applied to the Zenoh session.
+            from strands_robots.mesh._zenoh_config import (  # type: ignore[import-untyped]
+                _bool_env as _zc_bool_env,
+            )
+
+            if _zc_bool_env("STRANDS_MESH_MULTICAST", default=False):
+                logger.warning(
+                    "[safety] %s: STRANDS_MESH_MULTICAST=true -- multicast "
+                    "scouting is enabled. Any device on the LAN can attract "
+                    "fleet robots without credentials (unauthenticated UDP "
+                    "224.0.0.224:7446). This is a fleet-takeover risk on "
+                    "untrusted networks. Set STRANDS_MESH_MULTICAST=false "
+                    "(the default) unless operating on a physically isolated "
+                    "network.",
+                    self.peer_id,
+                )
+
+            # Refuse-to-start gate when mtls is configured
             # but the ACL is permissive-by-shape (built-in default OR
             # operator file with default_permission=allow). The gate
             # closes the "fleet thinks mTLS protects them, but ACL is
@@ -539,7 +567,7 @@ class Mesh(SensorLoopsMixin):
             # explicitly accept the dev/lab posture set
             # STRANDS_MESH_ACCEPT_PERMISSIVE_ACL=1.
             #
-            # Review thread core.py:189 -- the gate stashes a thread-local
+            # The gate stashes a thread-local
             # snapshot via ``_set_thread_snapshot`` (called inside
             # ``_refuse_under_permissive_default_acl``) BEFORE deciding
             # whether to refuse. Wrap both the gate and ``get_session()``

--- a/strands_robots/mesh/input.py
+++ b/strands_robots/mesh/input.py
@@ -354,6 +354,48 @@ class InputReceiver:
                     self.source_peer_id,
                 )
             return
+
+        # Cross-session teleop replay defence. The CMD path got
+        # (sender, turn_id) replay dedup and presence got freshness,
+        # but this streaming input path had NO freshness check: an attacker who
+        # eavesdrops a teleop stream can store frames and replay them hours/days
+        # later (different session/ZID, stale timestamps) and the follower
+        # repeats the captured motion -- the rate cap (100Hz) and value bound
+        # (4pi) still pass because the replayed frames are legitimate-shaped.
+        # Every frame already carries a wall-clock ``t`` (set by
+        # InputPublisher._publish_loop), so we just have to CHECK it. We reuse
+        # the same freshness/forward-skew env knobs as the resume/e-stop replay
+        # defence so operators tune one set of clock-drift bounds for the
+        # whole mesh. Frames with a missing/non-numeric ``t`` are rejected too
+        # (the publisher always sets it; absence means malformed or a
+        # hand-crafted replay envelope) -- identical posture to M-3. Dropped
+        # frames are counted + rate-limited-logged, never raised, because this
+        # is a 50Hz+ hot loop.
+        from strands_robots.mesh.core import (
+            _resume_forward_skew_s,
+            _resume_freshness_window_s,
+        )
+
+        _frame_t = data.get("t")
+        if not isinstance(_frame_t, (int, float)) or isinstance(_frame_t, bool):
+            self._rejected = getattr(self, "_rejected", 0) + 1
+            if self._rejected <= 5:
+                logger.warning(
+                    "[mesh] input frame rejected (missing/invalid timestamp) from %s",
+                    self.source_peer_id,
+                )
+            return
+        _age = time.time() - float(_frame_t)
+        if _age > _resume_freshness_window_s() or _age < -_resume_forward_skew_s():
+            self._rejected = getattr(self, "_rejected", 0) + 1
+            if self._rejected <= 5:
+                logger.warning(
+                    "[mesh] input frame rejected (stale/future t=%.1fs) from %s",
+                    _age,
+                    self.source_peer_id,
+                )
+            return
+
         try:
             action = data.get("action")
             if action is None:

--- a/tests/mesh/test_deep_mesh.py
+++ b/tests/mesh/test_deep_mesh.py
@@ -833,8 +833,12 @@ class TestInputPublisherReceiver:
         _os.environ["STRANDS_MESH_INPUT_MAX_HZ"] = "0"
         try:
             # Simulate incoming data
-            recv._on_input("strands/leader-1/input/leader", {"action": {"j0": 0.5, "j1": 0.3}, "seq": 0})
-            recv._on_input("strands/leader-1/input/leader", {"action": {"j0": 0.6, "j1": 0.4}, "seq": 1})
+            recv._on_input(
+                "strands/leader-1/input/leader", {"action": {"j0": 0.5, "j1": 0.3}, "seq": 0, "t": time.time()}
+            )
+            recv._on_input(
+                "strands/leader-1/input/leader", {"action": {"j0": 0.6, "j1": 0.4}, "seq": 1, "t": time.time()}
+            )
         finally:
             _os.environ.pop("STRANDS_MESH_INPUT_MAX_HZ", None)
 
@@ -856,8 +860,8 @@ class TestInputPublisherReceiver:
         recv.start()
 
         # Seq 0 → 5 (skip 1,2,3,4)
-        recv._on_input("topic", {"action": {"j0": 0.1}, "seq": 0})
-        recv._on_input("topic", {"action": {"j0": 0.2}, "seq": 5})
+        recv._on_input("topic", {"action": {"j0": 0.1}, "seq": 0, "t": time.time()})
+        recv._on_input("topic", {"action": {"j0": 0.2}, "seq": 5, "t": time.time()})
 
         stats = recv.stop()
         assert stats["drops"] == 4

--- a/tests/mesh/test_input_validation.py
+++ b/tests/mesh/test_input_validation.py
@@ -9,6 +9,7 @@ malformed values.
 from __future__ import annotations
 
 import math
+import time
 
 import pytest
 
@@ -89,7 +90,7 @@ def _make_receiver():
 
 def test_on_input_applies_valid_frame():
     recv, applied = _make_receiver()
-    recv._on_input(recv.topic, {"action": {"j0": 0.1, "j1": 0.2}, "seq": 0})
+    recv._on_input(recv.topic, {"action": {"j0": 0.1, "j1": 0.2}, "seq": 0, "t": time.time()})
     assert applied == [{"j0": 0.1, "j1": 0.2}]
     assert recv._frame_count == 1
     assert recv._rejected == 0
@@ -98,7 +99,7 @@ def test_on_input_applies_valid_frame():
 def test_on_input_rejects_malicious_frame():
     recv, applied = _make_receiver()
     # non-finite value would otherwise reach send_action()
-    recv._on_input(recv.topic, {"action": {"j0": math.inf}, "seq": 0})
+    recv._on_input(recv.topic, {"action": {"j0": math.inf}, "seq": 0, "t": time.time()})
     assert applied == []  # never applied
     assert recv._frame_count == 0
     assert recv._rejected == 1
@@ -107,6 +108,60 @@ def test_on_input_rejects_malicious_frame():
 def test_on_input_rejects_giant_frame():
     recv, applied = _make_receiver()
     giant = {f"j{i}": 0.0 for i in range(security.MAX_INPUT_FRAME_KEYS + 5)}
-    recv._on_input(recv.topic, {"action": giant, "seq": 0})
+    recv._on_input(recv.topic, {"action": giant, "seq": 0, "t": time.time()})
     assert applied == []
     assert recv._rejected == 1
+
+
+# --- cross-session teleop replay / freshness -----------------------------
+
+
+def test_on_input_rejects_stale_frame():
+    """A frame with a timestamp older than the freshness window (default 60s)
+    is a cross-session replay and must be dropped before reaching the robot."""
+    recv, applied = _make_receiver()
+    stale_t = time.time() - 3600.0  # 1 hour old
+    recv._on_input(recv.topic, {"action": {"j0": 0.1}, "seq": 0, "t": stale_t})
+    assert applied == []
+    assert recv._frame_count == 0
+    assert recv._rejected == 1
+
+
+def test_on_input_rejects_future_frame():
+    """A frame skewed far into the future (beyond forward-skew tolerance) is
+    rejected -- protects against clock-spoofed envelopes."""
+    recv, applied = _make_receiver()
+    future_t = time.time() + 3600.0  # 1 hour ahead
+    recv._on_input(recv.topic, {"action": {"j0": 0.1}, "seq": 0, "t": future_t})
+    assert applied == []
+    assert recv._frame_count == 0
+    assert recv._rejected == 1
+
+
+def test_on_input_rejects_missing_timestamp():
+    """The publisher always sets ``t``; a frame without it is malformed or a
+    hand-crafted replay envelope and must be rejected (matches presence M-3)."""
+    recv, applied = _make_receiver()
+    recv._on_input(recv.topic, {"action": {"j0": 0.1}, "seq": 0})
+    assert applied == []
+    assert recv._frame_count == 0
+    assert recv._rejected == 1
+
+
+@pytest.mark.parametrize("bad_t", [True, False, "now", None, [1], {"t": 1}])
+def test_on_input_rejects_non_numeric_timestamp(bad_t):
+    """Non-numeric (incl. bool) ``t`` values are treated as missing -> rejected."""
+    recv, applied = _make_receiver()
+    recv._on_input(recv.topic, {"action": {"j0": 0.1}, "seq": 0, "t": bad_t})
+    assert applied == []
+    assert recv._rejected == 1
+
+
+def test_on_input_accepts_fresh_frame_within_skew():
+    """A frame slightly in the future but within the forward-skew tolerance
+    (default 5s) is accepted -- legitimate clock drift must not be rejected."""
+    recv, applied = _make_receiver()
+    recv._on_input(recv.topic, {"action": {"j0": 0.1}, "seq": 0, "t": time.time() + 1.0})
+    assert applied == [{"j0": 0.1}]
+    assert recv._frame_count == 1
+    assert recv._rejected == 0

--- a/tests/mesh/test_mesh_safety_hardening.py
+++ b/tests/mesh/test_mesh_safety_hardening.py
@@ -62,7 +62,7 @@ class TestC1InputLockout:
         robot = _RecordingRobot()
         rx = InputReceiver(mesh, robot, source_peer_id="leader")
         rx._running = True
-        rx._on_input(rx.topic, {"action": {"j0": 0.5}, "seq": 0})
+        rx._on_input(rx.topic, {"action": {"j0": 0.5}, "seq": 0, "t": time.time()})
         assert len(robot.actions) == 1
 
 
@@ -91,8 +91,8 @@ class TestH2TeleopBoundAndRate:
         rx = InputReceiver(mesh, robot, source_peer_id="leader")
         rx._running = True
         # Two synchronous frames microseconds apart: 2nd exceeds 50Hz.
-        rx._on_input(rx.topic, {"action": {"j0": 0.1}, "seq": 0})
-        rx._on_input(rx.topic, {"action": {"j0": 0.2}, "seq": 1})
+        rx._on_input(rx.topic, {"action": {"j0": 0.1}, "seq": 0, "t": time.time()})
+        rx._on_input(rx.topic, {"action": {"j0": 0.2}, "seq": 1, "t": time.time()})
         assert len(robot.actions) == 1
         assert rx.stats["rate_dropped"] >= 1
 
@@ -300,6 +300,6 @@ class TestM5SuccessAudit:
         rx = inp.InputReceiver(mesh, robot, source_peer_id="leader")
         rx._running = True
         for i in range(5):
-            rx._on_input(rx.topic, {"action": {"j0": 0.1 * i}, "seq": i})
+            rx._on_input(rx.topic, {"action": {"j0": 0.1 * i}, "seq": i, "t": time.time()})
         # 5th applied frame triggers one sampled audit.
         assert events.count("input_stream_applied") == 1

--- a/tests/mesh/test_multicast_startup_warning.py
+++ b/tests/mesh/test_multicast_startup_warning.py
@@ -1,0 +1,99 @@
+"""Mesh.start() must emit a loud WARNING when multicast scouting
+is enabled via STRANDS_MESH_MULTICAST=true.
+
+Multicast scouting operates below the mTLS/ACL layer: any device on the LAN can
+attract the entire fleet without credentials. The default is
+gossip-only (MULTICAST=false), which is safe and silent. When an operator opts
+into the dangerous posture we want an explicit, logged signal.
+
+These tests drive the full Mesh.start() flow with stubbed session/loops (same
+harness as test_acl_snapshot_toctou) and assert on caplog.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from strands_robots.mesh import Mesh
+from strands_robots.mesh import core as mesh_core
+
+_MULTICAST_MARKER = "STRANDS_MESH_MULTICAST=true"
+
+
+class _StubDecl:
+    def undeclare(self) -> None:
+        pass
+
+
+class _StubSession:
+    def declare_subscriber(self, *args, **kwargs):
+        return _StubDecl()
+
+
+def _make_mesh(peer_id: str) -> Mesh:
+    robot = SimpleNamespace(
+        tool_name_str=peer_id,
+        robot=SimpleNamespace(
+            is_connected=True,
+            name=f"{peer_id}_test",
+            config=SimpleNamespace(cameras={}),
+            get_observation=MagicMock(return_value={}),
+        ),
+    )
+    return Mesh(robot, peer_id=peer_id, peer_type="robot")
+
+
+def _run_start(mesh: Mesh, caplog: pytest.LogCaptureFixture) -> None:
+    with patch.object(mesh_core, "get_session", return_value=_StubSession()):
+        with patch.object(mesh_core, "release_session"):
+            with patch.object(mesh, "_heartbeat_loop"), patch.object(mesh, "_state_loop"):
+                with caplog.at_level(logging.WARNING, logger="strands_robots.mesh.core"):
+                    mesh.start()
+                mesh.stop()
+
+
+def test_multicast_enabled_emits_warning(monkeypatch, caplog):
+    """STRANDS_MESH_MULTICAST=true -> a WARNING naming the flag is emitted."""
+    monkeypatch.setenv("STRANDS_MESH_MULTICAST", "true")
+    # Keep the H-1 override-code warning out of the way so we assert only ours.
+    monkeypatch.setenv("STRANDS_MESH_OVERRIDE_CODE", "1234")
+
+    mesh = _make_mesh("mc-on")
+    _run_start(mesh, caplog)
+
+    multicast_warnings = [r.getMessage() for r in caplog.records if _MULTICAST_MARKER in r.getMessage()]
+    assert multicast_warnings, f"expected a multicast WARNING when STRANDS_MESH_MULTICAST=true, got: {caplog.messages}"
+    msg = multicast_warnings[0]
+    assert "[safety]" in msg
+    assert "224.0.0.224:7446" in msg
+    assert "mc-on" in msg  # peer_id is interpolated
+
+
+def test_multicast_default_is_silent(monkeypatch, caplog):
+    """Default (flag unset) -> no multicast warning (safe posture stays quiet)."""
+    monkeypatch.delenv("STRANDS_MESH_MULTICAST", raising=False)
+    monkeypatch.setenv("STRANDS_MESH_OVERRIDE_CODE", "1234")
+
+    mesh = _make_mesh("mc-default")
+    _run_start(mesh, caplog)
+
+    assert not any(_MULTICAST_MARKER in m for m in caplog.messages), (
+        f"multicast warning fired with the flag unset (default should be silent): {caplog.messages}"
+    )
+
+
+def test_multicast_false_is_silent(monkeypatch, caplog):
+    """Explicit STRANDS_MESH_MULTICAST=false -> no warning."""
+    monkeypatch.setenv("STRANDS_MESH_MULTICAST", "false")
+    monkeypatch.setenv("STRANDS_MESH_OVERRIDE_CODE", "1234")
+
+    mesh = _make_mesh("mc-off")
+    _run_start(mesh, caplog)
+
+    assert not any(_MULTICAST_MARKER in m for m in caplog.messages), (
+        f"multicast warning fired with STRANDS_MESH_MULTICAST=false: {caplog.messages}"
+    )


### PR DESCRIPTION
## Summary

Three small mesh-hardening improvements plus tests. No dependency or lockfile changes.

### 1. Multicast scouting startup warning (`strands_robots/mesh/core.py`)
`STRANDS_MESH_MULTICAST` defaults to `false` (gossip-only scouting). When an operator opts **into** multicast, `Mesh.start()` now emits a `[safety]` WARNING so the choice is explicit and logged rather than silent. The flag is read through the same `_bool_env` helper that the scouting config uses, so the warning can never disagree with the value actually applied to the Zenoh session. The safe default stays completely silent. This mirrors the existing override-code startup warning.

### 2. Teleop frame freshness check (`strands_robots/mesh/input.py`)
`InputReceiver._on_input` now validates the wall-clock timestamp (`t`) that the publisher already includes on every frame. Frames that are stale, skewed too far into the future, or carry a missing/non-numeric `t` are dropped before they reach the robot. This closes a cross-session replay gap on the streaming input path (the command path and presence path already had equivalent protection). It reuses the existing freshness / forward-skew env knobs so operators tune one set of clock-drift bounds for the whole mesh. Dropped frames are counted and rate-limited in the logs and never raise — the check sits in a 50Hz+ hot loop.

### 3. Topic-level ACL documentation (`README.md`, `docs/security.md`, `strands_robots/device_connect/GUIDE.md`)
Adds a prominent callout that WAN/cloud Zenoh routers must deploy a topic-level ACL. mTLS provides device **identity**; the ACL provides **least privilege** — both are required when running off a trusted network. Points operators to the existing `examples/mesh_acl_strict_per_peer.json5` template.

## Tests
- New `tests/mesh/test_multicast_startup_warning.py`: warning fires when the flag is enabled; default and explicit-`false` stay silent (full `Mesh.start()` harness with stubbed session).
- Extended `tests/mesh/test_input_validation.py`: stale, future, missing, and non-numeric timestamp rejections, plus a within-skew accept.
- Updated existing teleop tests to include the now-required `t` field.

`103 passed` across the touched mesh test modules.

## Scope
- 9 files changed, +272 / -14.
- No changes to `pyproject.toml` or `uv.lock`.