### PR TITLE
fix(simulation): ASCII-only output from the recording lifecycle methods

### DIFF
--- a/strands_robots/simulation/mujoco/recording.py
+++ b/strands_robots/simulation/mujoco/recording.py
@@ -317,7 +317,7 @@ class RecordingMixin:
         if self._world is None:
             return {
                 "status": "success",
-                "content": [{"text": "[no world] Call create_world to start recording."}],
+                "content": [{"text": "No world. Call create_world to start recording."}],
             }
 
         recording = self._world._backend_state.get("recording", False)

--- a/strands_robots/simulation/mujoco/recording.py
+++ b/strands_robots/simulation/mujoco/recording.py
@@ -317,16 +317,16 @@ class RecordingMixin:
         if self._world is None:
             return {
                 "status": "success",
-                "content": [{"text": "⚪ No world - call create_world to start recording."}],
+                "content": [{"text": "[no world] Call create_world to start recording."}],
             }
 
         recording = self._world._backend_state.get("recording", False)
         steps = len(self._world._backend_state.get("trajectory", []))
 
         if recording:
-            text = f"🔴 Recording: {steps} steps captured"
+            text = f"[recording] {steps} steps captured"
         else:
-            text = f"⚪ Not recording (last episode: {steps} steps)"
+            text = f"[idle] Not recording (last episode: {steps} steps)"
 
         return {
             "status": "success",

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -1175,9 +1175,7 @@ class RenderingMixin:
             )
 
         msg = (
-            f"🎬 Recording {len(names)} camera(s) @ {fps} FPS → {out_dir}\n"
-            f"   tag: {tag}\n"
-            f"   cameras: {', '.join(names)}"
+            f"Recording {len(names)} camera(s) @ {fps} FPS -> {out_dir}\n   tag: {tag}\n   cameras: {', '.join(names)}"
         )
         return {"status": "success", "content": [{"text": msg}]}
 
@@ -1240,7 +1238,7 @@ class RenderingMixin:
 
         elapsed = _time.time() - state["started_at"]
         lines = [
-            f"🎬 Stopped '{state['name']}' after {elapsed:.1f}s",
+            f"Stopped '{state['name']}' after {elapsed:.1f}s",
             f"   output_dir: {state['output_dir']}",
         ]
         artifacts = []
@@ -1261,8 +1259,8 @@ class RenderingMixin:
                 if _os.path.exists(path):
                     size_kb = _os.path.getsize(path) / 1024
             lines.append(
-                f"   📹 {cam:20s} {frames_written:>5d} frames  {size_kb:>7.1f} KB  "
-                f"({errors} errors)  → {_os.path.basename(path)}"
+                f"   {cam:20s} {frames_written:>5d} frames  {size_kb:>7.1f} KB  "
+                f"({errors} errors)  -> {_os.path.basename(path)}"
             )
             artifacts.append(
                 {
@@ -1454,7 +1452,7 @@ class RenderingMixin:
             return result
 
         msg = (
-            f"🎬 Recording {len(names)} camera(s) @ {fps} FPS → {out_dir} (synchronous mode)\n"
+            f"Recording {len(names)} camera(s) @ {fps} FPS -> {out_dir} (synchronous mode)\n"
             f"   tag: {tag}\n"
             f"   cameras: {', '.join(names)}\n"
             "   wire on_frame= into evaluate_benchmark / PolicyRunner.evaluate"
@@ -1473,11 +1471,11 @@ class RenderingMixin:
 
         state = getattr(self, "_cams_rec_state", None)
         if not state or not state.get("running"):
-            return {"status": "success", "content": [{"text": "⚪ No active camera recording."}]}
+            return {"status": "success", "content": [{"text": "[idle] No active camera recording."}]}
 
         elapsed = _time.time() - state["started_at"]
-        lines = [f"🟢 Recording '{state['name']}' for {elapsed:.1f}s  @ {state['fps']} FPS"]
+        lines = [f"[recording] '{state['name']}' for {elapsed:.1f}s  @ {state['fps']} FPS"]
         for cam in state["cameras"]:
             frames = len(state["buffers"][cam])
-            lines.append(f"   📹 {cam:20s} {frames:>5d} frames  ({state['errors'][cam]} errors)")
+            lines.append(f"   {cam:20s} {frames:>5d} frames  ({state['errors'][cam]} errors)")
         return {"status": "success", "content": [{"text": "\n".join(lines)}]}

--- a/tests/simulation/mujoco/test_recording_paths.py
+++ b/tests/simulation/mujoco/test_recording_paths.py
@@ -474,7 +474,8 @@ def test_get_recording_status_text_is_ascii_no_world():
     assert r["status"] == "success"
     text = r["content"][0]["text"]
     assert [ch for ch in text if ord(ch) > 127] == [], f"non-ASCII in text: {text!r}"
-    assert "[no world]" in text
+    # Uses the canonical world-less message shared by every action.
+    assert "No world" in text
     s.destroy()
 
 

--- a/tests/simulation/mujoco/test_recording_paths.py
+++ b/tests/simulation/mujoco/test_recording_paths.py
@@ -368,6 +368,10 @@ def test_run_multi_policy_raises_on_empty_action_chunk(sim_with_two_robots, tmp_
     on failure): pre-fix, an empty deque popleft fell back to ``{}`` -> all-zero
     ctrl -> dead frames in the dataset with no error.
     """
+    from strands_robots.dataset_recorder import has_lerobot_dataset
+
+    if not has_lerobot_dataset():
+        pytest.skip("lerobot not installed")
     from strands_robots.policies.base import Policy
 
     class _EmptyChunkPolicy(Policy):

--- a/tests/simulation/mujoco/test_recording_paths.py
+++ b/tests/simulation/mujoco/test_recording_paths.py
@@ -457,3 +457,47 @@ def test_run_multi_policy_discards_partial_episode_on_empty_chunk(sim_with_two_r
         f"partial episode not discarded: {recorder.episode_frame_count} frames left in the open buffer"
     )
     sim.stop_recording()
+
+
+def test_get_recording_status_text_is_ascii_no_world():
+    """``get_recording_status`` with no world emits ASCII-only text.
+
+    Previously the no-world branch returned a Unicode status-dot prefix
+    ("\\u26aa No world..."), violating the project ASCII-only output
+    contract. This needs no lerobot extra - it exercises the world-less
+    branch directly.
+    """
+    from strands_robots.simulation import Simulation
+
+    s = Simulation()
+    r = s.get_recording_status()
+    assert r["status"] == "success"
+    text = r["content"][0]["text"]
+    assert [ch for ch in text if ord(ch) > 127] == [], f"non-ASCII in text: {text!r}"
+    assert "[no world]" in text
+    s.destroy()
+
+
+def test_get_recording_status_text_is_ascii_idle_and_recording(sim_with_two_robots):
+    """``get_recording_status`` idle + active branches emit ASCII-only text.
+
+    Drives the ``_backend_state`` recording flag directly so the assertion
+    runs without the lerobot dataset stack. Both the idle and recording
+    branches previously carried emoji status dots.
+    """
+    sim = sim_with_two_robots
+
+    # Idle branch.
+    r = sim.get_recording_status()
+    text = r["content"][0]["text"]
+    assert [ch for ch in text if ord(ch) > 127] == [], f"non-ASCII in idle text: {text!r}"
+    assert "[idle]" in text
+
+    # Active branch - flip the flag + seed a trajectory buffer directly.
+    sim._world._backend_state["recording"] = True
+    sim._world._backend_state["trajectory"] = [object(), object(), object()]
+    r = sim.get_recording_status()
+    text = r["content"][0]["text"]
+    assert [ch for ch in text if ord(ch) > 127] == [], f"non-ASCII in recording text: {text!r}"
+    assert "[recording]" in text and "3 steps" in text
+    sim._world._backend_state["recording"] = False

--- a/tests/simulation/mujoco/test_recording_synchronous.py
+++ b/tests/simulation/mujoco/test_recording_synchronous.py
@@ -357,3 +357,76 @@ class TestStartCamerasRecordingSynchronous:
             assert sim._cams_rec_state["thread"] is None
         finally:
             sim.destroy()
+
+
+def _all_text(result: dict[str, Any]) -> str:
+    """Concatenate every ``content[*]["text"]`` block in a tool result."""
+    return "\n".join(c["text"] for c in result.get("content", []) if "text" in c)
+
+
+def _non_ascii(text: str) -> list[str]:
+    """Return the list of non-ASCII characters in ``text`` (empty if clean)."""
+    return [ch for ch in text if ord(ch) > 127]
+
+
+class TestCamerasRecordingOutputIsAscii:
+    """The camera-recording lifecycle emits ASCII-only user-facing text.
+
+    ``start_cameras_recording*`` / ``stop_cameras_recording`` /
+    ``_flush_cameras_recording_state`` / ``get_cameras_recording_status``
+    previously decorated their ``content[*]["text"]`` with emoji (clapper,
+    video-camera, status dots) plus a Unicode right-arrow. Those render as
+    mojibake or stray glyphs in non-emoji terminals and log pipelines and
+    violate the project ASCII-only output contract. Each assertion below
+    fails against the pre-fix emoji output and passes after the strip.
+    """
+
+    def test_start_synchronous_text_is_ascii(self):
+        sim = _make_sim_with_fake_render()
+        try:
+            result = sim.start_cameras_recording_synchronous(cameras=["cam_a"], fps=15, name="ascii_sync")
+            text = _all_text(result)
+            assert _non_ascii(text) == [], f"non-ASCII in start text: {_non_ascii(text)}"
+            assert "Recording" in text and "->" in text
+        finally:
+            sim.destroy()
+
+    def test_finalize_text_is_ascii(self, tmp_path: Path):
+        sim = _make_sim_with_fake_render()
+        try:
+            result = sim.start_cameras_recording_synchronous(
+                cameras=["cam_a", "cam_b"], output_dir=str(tmp_path), fps=15, name="ascii_final"
+            )
+            json_block = next(c["json"] for c in result["content"] if "json" in c)
+            on_frame, finalize = json_block["on_frame"], json_block["finalize"]
+            for step in range(3):
+                on_frame(step, {}, {})
+            final = finalize()
+            text = _all_text(final)
+            assert _non_ascii(text) == [], f"non-ASCII in finalize text: {_non_ascii(text)}"
+            assert "Stopped" in text and "->" in text
+        finally:
+            sim.destroy()
+
+    def test_status_active_text_is_ascii(self):
+        sim = _make_sim_with_fake_render()
+        try:
+            result = sim.start_cameras_recording_synchronous(cameras=["cam_a", "cam_b"], fps=15, name="ascii_status")
+            on_frame = next(c["json"] for c in result["content"] if "json" in c)["on_frame"]
+            on_frame(0, {}, {})
+            status = sim.get_cameras_recording_status()
+            text = _all_text(status)
+            assert _non_ascii(text) == [], f"non-ASCII in active status text: {_non_ascii(text)}"
+            assert "[recording]" in text
+        finally:
+            sim.destroy()
+
+    def test_status_idle_text_is_ascii(self):
+        sim = _make_sim_with_fake_render()
+        try:
+            status = sim.get_cameras_recording_status()
+            text = _all_text(status)
+            assert _non_ascii(text) == [], f"non-ASCII in idle status text: {_non_ascii(text)}"
+            assert "[idle]" in text
+        finally:
+            sim.destroy()

--- a/tests/simulation/mujoco/test_rendering.py
+++ b/tests/simulation/mujoco/test_rendering.py
@@ -74,7 +74,9 @@ def test_start_stop_cameras_recording_writes_one_mp4_per_camera(tmp_path: Path) 
 
     status = sim.get_cameras_recording_status()
     assert status["status"] == "success"
-    assert "🟢" in status["content"][0]["text"]
+    # ASCII-only output contract: active recording is flagged with the
+    # "[recording]" marker, never an emoji.
+    assert "[recording]" in status["content"][0]["text"]
 
     stop = sim.stop_cameras_recording()
     assert stop["status"] == "success"
@@ -113,7 +115,9 @@ def test_status_when_idle_is_success() -> None:
     sim.create_world()
     r = sim.get_cameras_recording_status()
     assert r["status"] == "success"
-    assert "⚪" in r["content"][0]["text"]
+    # ASCII-only output contract: the idle state is flagged with the
+    # "[idle]" marker, never an emoji.
+    assert "[idle]" in r["content"][0]["text"]
 
 
 # Render-time scene_option pass-through (#168 round 9 bug E)


### PR DESCRIPTION
## Problem

The MuJoCo recording lifecycle emitted decorative emoji in its user-facing `content[*]["text"]`, violating the project ASCII-only output contract (the same class fixed recently for `lerobot_camera`, `pose_tool`, `lerobot_teleoperate`, and the `Robot().run()` device-connect loop). Offenders:

- `RecordingMixin.get_recording_status` (`simulation/mujoco/recording.py`) - status dots `U+26AA` / `U+1F534` on the no-world / idle / recording branches.
- The camera-recording surface in `simulation/mujoco/rendering.py`: `start_cameras_recording`, `start_cameras_recording_synchronous`, `stop_cameras_recording` / `_flush_cameras_recording_state`, and `get_cameras_recording_status` - clapper `U+1F3AC`, video-camera `U+1F4F9`, status dots `U+26AA` / `U+1F7E2`, plus a Unicode right-arrow `U+2192` in the output-dir lines.

These render as mojibake or stray glyphs in non-emoji terminals and log pipelines.

## Change

Replace the emoji with plain ASCII bracketed labels - `[recording]` / `[idle]` / `[no world]`, matching the existing `[OK]` / `[MISSING]` convention in `simulation/model_registry.py` - and the arrow with `->`. All markdown structure and every reported field (frame counts, sizes, error counts, output paths) is preserved.

## Tests

Adds behavior regression tests asserting plain-ASCII output across both surfaces:

- `tests/simulation/mujoco/test_recording_paths.py` - `get_recording_status` no-world / idle / recording branches (drives `_backend_state` directly, no lerobot extra needed).
- `tests/simulation/mujoco/test_recording_synchronous.py::TestCamerasRecordingOutputIsAscii` - synchronous start, finalize, and active/idle status output, reusing the existing GL-free fake-render fixture.

Each assertion fails against the pre-fix emoji output (verified by reverting the source: 6 fail) and passes after. Full recording suite green locally (headless EGL):

```
tests/simulation/mujoco/test_recording_synchronous.py
tests/simulation/mujoco/test_recording_paths.py
tests/simulation/mujoco/test_recording_backends.py
29 passed, 1 skipped
```

`ruff check` + `ruff format --check`: clean. Output-only change; no recording behavior, schema, or MP4 encoding path is altered.

## Visual artifact

Headless MuJoCo (EGL) synchronous camera recording of an SO-101 arm sweep - 50 frames captured, MP4 written - showing the ASCII-clean lifecycle output:

```
STATUS (idle): [idle] No active camera recording.
START:
Recording 1 camera(s) @ 20 FPS -> /tmp (synchronous mode)
   tag: recording_lifecycle_demo
   cameras: demo_cam
STATUS (active):
[recording] 'recording_lifecycle_demo' for 1.1s  @ 20 FPS
   demo_cam                50 frames  (0 errors)
FINALIZE:
Stopped 'recording_lifecycle_demo' after 1.1s
   output_dir: /tmp
   demo_cam                50 frames     57.4 KB  (0 errors)  -> recording_lifecycle_demo__demo_cam.mp4
```

![recording lifecycle demo](https://github.com/cagataycali/robots/releases/download/recording-ascii-demo-1781640731/recording_lifecycle_demo.gif)

[MP4 source](https://github.com/cagataycali/robots/releases/download/recording-ascii-demo-1781640731/recording_lifecycle_demo__demo_cam.mp4)

---

## §13 Review Rounds

| Round | Concern | Fix Commit | Pin Test |
|-------|---------|-----------|----------|
| R1 | CI failure: `test_run_multi_policy_raises_on_empty_action_chunk` missing `has_lerobot_dataset()` skip guard (pre-existing; every other lerobot-dependent test in the file has it) | `67027fb` | `tests/simulation/mujoco/test_recording_paths.py::test_run_multi_policy_raises_on_empty_action_chunk` (now properly skips when lerobot unavailable) |