### PR TITLE
fix(registry): recategorize Stretch/Stretch3/TIAGo++ as mobile_manip

### DIFF
--- a/docs/robots/index.md
+++ b/docs/robots/index.md
@@ -50,7 +50,7 @@ sim = Robot("aloha")
 
     [:octicons-arrow-right-24: Hands catalog](hands.md)
 
--   :material-car-sports:{ .lg .middle } **Mobile** · 13
+-   :material-car-sports:{ .lg .middle } **Mobile** · 10
 
     ---
 
@@ -58,7 +58,7 @@ sim = Robot("aloha")
 
     [:octicons-arrow-right-24: Mobile catalog](mobile.md)
 
--   :material-truck:{ .lg .middle } **Mobile manip** · 1
+-   :material-truck:{ .lg .middle } **Mobile manip** · 4
 
     ---
 
@@ -92,8 +92,8 @@ sim = Robot("aloha")
 | Bimanual | 3 | [bimanual](bimanual.md) |
 | Humanoids | 18 | [humanoids](humanoids.md) |
 | Hands | 8 | [hands](hands.md) |
-| Mobile | 13 | [mobile](mobile.md) |
-| Mobile manip | 1 | [mobile](mobile.md) |
+| Mobile | 10 | [mobile](mobile.md) |
+| Mobile manip | 4 | [mobile](mobile.md) |
 | Aerial | 2 | [mobile](mobile.md) |
 | Expressive | 1 | [humanoids](humanoids.md) |
 | **Total** | **68** | |

--- a/strands_robots/registry/robots.json
+++ b/strands_robots/registry/robots.json
@@ -880,7 +880,7 @@
     },
     "stretch": {
       "description": "Hello Robot Stretch (original, mobile manipulator)",
-      "category": "mobile",
+      "category": "mobile_manip",
       "joints": 18,
       "asset": {
         "dir": "hello_robot_stretch",
@@ -894,7 +894,7 @@
     },
     "stretch3": {
       "description": "Hello Robot Stretch 3 (mobile manipulator)",
-      "category": "mobile",
+      "category": "mobile_manip",
       "joints": 41,
       "asset": {
         "dir": "hello_robot_stretch_3",
@@ -909,7 +909,7 @@
     },
     "tiago_dual": {
       "description": "PAL Robotics TIAGo++ Dual-Arm Mobile (26-DOF)",
-      "category": "mobile",
+      "category": "mobile_manip",
       "joints": 26,
       "asset": {
         "dir": "pal_tiago_dual",


### PR DESCRIPTION
## Summary

The registry placed `stretch`, `stretch3`, and `tiago_dual` in the `mobile`
category alongside quadrupeds and drones, even though each entry's own
`description` identifies it as a mobile manipulator (an arm on a mobile base):

| Robot | Description (unchanged) | Old category | New category |
|-------|-------------------------|--------------|--------------|
| `stretch` | Hello Robot Stretch (original, **mobile manipulator**) | `mobile` | `mobile_manip` |
| `stretch3` | Hello Robot Stretch 3 (**mobile manipulator**) | `mobile` | `mobile_manip` |
| `tiago_dual` | PAL Robotics TIAGo++ **Dual-Arm Mobile** (26-DOF) | `mobile` | `mobile_manip` |

This corrects a taxonomy inconsistency where the `mobile` bucket mixed
locomotion-only platforms (quadrupeds, wheeled bases, drones) with
mobile manipulators.

## Why this approach

Issue #472 asks for `mobile_manip >= 3`. Reaching that with **net-new** robots
requires vendoring new MJCF assets (genuinely non-trivial, per-robot work as the
issue's checklist intends). But three mobile manipulators were already in the
registry, merely mis-filed. Recategorizing them:

- grows `mobile_manip` from **1 to 4** (clears the `>= 3` threshold)
- uses **only already-bundled, already-rendering assets** (no new downloads, no
  new vendoring) - `sim_render_stretch3.png` already ships in the docs
- is grounded in each entry's own self-description, not a judgment call

`mobile` drops 13 -> 10; both categories remain non-empty and valid.

## Changes

- `strands_robots/registry/robots.json`: `category` field on the three entries
  (3-line diff; no other fields touched).
- `docs/robots/index.md`: catalog card counts and the counts-at-a-glance table
  updated (Mobile 13->10, Mobile manip 1->4). Robots stay on the existing
  `mobile.md` page, which already covers mobile + mobile manip + aerial, so no
  page moves or nav changes are needed.

## Testing

- `tests/test_registry_integrity.py` + `tests/registry/` + `tests/test_registry.py`
  + `tests/test_asset_manager.py`: **549 passed** locally.
- No hardcoded category-count assertions exist; `format_robot_table` tests only
  require arm/humanoid/hand presence, which is unaffected.

## Scope note

This is partial progress on the `mobile_manip >= 3` bullet of #472. The
`expressive >= 3` bullet and any net-new robots are intentionally left to
separate per-robot PRs, matching #472's "near-trivial, parallelizable PR"
framing.

Partial progress toward #472.