### PR TITLE
feat(policies): WBCPolicy provider for GR00T Whole-Body-Control (SONIC, ONNX)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,43 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
-_Nothing yet._
+### Added: `WBCPolicy` provider (`wbc`, shorthand `sonic`) - GR00T Whole-Body-Control (SONIC)
+
+A new non-VLA policy provider wrapping NVIDIA's GR00T Whole-Body-Control
+(SONIC / decoupled-WBC) ONNX controllers for deploy-grade Unitree G1
+locomotion (closes #466). Clean-room against the upstream reference
+(`NVlabs/GR00T-WholeBodyControl` `decoupled_wbc/sim2mujoco`).
+
+- In-process ONNX (no torch, no sidecar) via the new `[wbc]` extra
+  (`onnxruntime` + `pyyaml` + `huggingface_hub`). No model weights bundled; the
+  real `GR00T-WholeBodyControl-{Balance,Walk}.onnx` are fetched/pointed-at at
+  runtime under the NVIDIA Open Model License.
+- `requires_images = False`; reads the locomotion goal from the well-known
+  kwargs (`target_velocity = [vx, vy, omega]`, optional `target_orientation`
+  for base RPY, optional `height`). Drives the 15 leg+waist DOFs; the 14 arm
+  joints are held at defaults (composing an upper-body policy on top is the job
+  of a future `CompositePolicy`, #468).
+- Faithful to the reference contract: 86-dim observation frame
+  (`command[7] + base_ang_vel[3] + projected_gravity[3] + qj[29] + dqj[29] +
+  prev_action[15]`) stacked over `obs_history_len=6` (network input 516);
+  whole-body qj/dqj (all 29 joints, not just the 15 controlled); two ONNX
+  sessions (main `policy` + `walk_policy`) selected by `norm(raw velocity) <=
+  0.05`; PD-to-torque law exposed via `WBCPolicy.compute_torques(...)`;
+  zero-warm-started history deque; quaternion math numerically identical to
+  upstream.
+- `WBCConfig` loads the upstream `g1_gear_wbc.yaml` directly (JSON or YAML;
+  flat `*_scale` keys normalised into `obs_scales`). Joints are resolved by
+  name (handles the G1's leading `floating_base_joint` + interleaved arms).
+- New per-call `policy_kwargs` channel on `SimEngine.run_policy` / `start_policy`
+  (and the MuJoCo overrides) forwarded verbatim to `policy.get_actions`, so the
+  #300 well-known goal kwargs reach non-VLA providers (WBC, cuRobo, MoveIt2)
+  through the local sim path, not just the mesh.
+- `wbc` / `sonic` added to the mesh + Device Connect policy-provider allowlist
+  so WBC can be driven over `tell()` / Device Connect.
+- Registered as `wbc` (shorthand `sonic`) in `registry/policies.json`; docs at
+  `docs/policies/wbc.md`; torque-control deploy harness +
+  `simulate_rollout` at `examples/wbc_g1_torque_deploy.py` (the real weights
+  produce a stable forward G1 walk).
 
 ## [0.4.0] - 2026-06-16
 

--- a/NOTICE
+++ b/NOTICE
@@ -59,3 +59,28 @@ optional runtime dependencies and are not redistributed with this package.
 You may obtain a copy of the Apache License at:
     http://www.apache.org/licenses/LICENSE-2.0
 --------------------------------------------------------------------------------
+
+--------------------------------------------------------------------------------
+Optional WBC locomotion policy (strands_robots/policies/wbc/)
+
+The optional WBCPolicy ([wbc] extra) is a clean-room implementation of the
+control loop described by NVIDIA's GR00T Whole-Body-Control reference:
+
+  * GR00T-WholeBodyControl (https://github.com/NVlabs/GR00T-WholeBodyControl)
+    Apache License, Version 2.0. The observation layout, PD-control law, and
+    SONIC controller contract reproduced in strands_robots/policies/wbc/ are
+    derived from the upstream reference runner
+    (decoupled_wbc/sim2mujoco/scripts/run_mujoco_gear_wbc.py). No upstream code
+    is vendored.
+
+  * ONNX Runtime (https://github.com/microsoft/onnxruntime)
+    MIT License. Runs the controller's ONNX sessions in-process.
+
+NVIDIA GR00T-WBC model weights (e.g. nvidia/GEAR-SONIC) are distributed by
+NVIDIA under the NVIDIA Open Model License; consult the model card for terms.
+These are optional runtime dependencies and are not redistributed with this
+package.
+
+You may obtain a copy of the Apache License at:
+    http://www.apache.org/licenses/LICENSE-2.0
+--------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ extras you need:
 | `lerobot` | LeRobot | Real hardware, local VLA inference, dataset recording |
 | `groot-service` | pyzmq, msgpack | NVIDIA GR00T inference client |
 | `curobo` | _(empty; install cuRobo from source)_ | In-process collision-aware motion planning (CUDA GPU) |
+| `wbc` | onnxruntime | GR00T Whole-Body-Control (SONIC) humanoid locomotion - in-process ONNX, no GPU |
 | `mesh` | eclipse-zenoh, json5 | Peer-to-peer robot mesh |
 | `mesh-iot` | awsiotsdk, awscrt, boto3 | AWS IoT Core mesh transport for fleets |
 | `device-connect` | device-connect-edge, device-connect-agent-tools | Device-aware networking - discovery, RPC, events, safety (falls back to the built-in mesh if absent) |
@@ -588,6 +589,45 @@ The LLM-agent demo path (`Robot.start_task(..., policy_provider="curobo",
 target_pose=[...])`) flows the same `target_pose` / `target_joints` kwargs
 through `start_task`'s `**policy_kwargs` so agents share one goal vocabulary
 across VLA and planner providers.
+
+#### `WBCPolicy` (GR00T Whole-Body-Control / SONIC, in-process ONNX)
+
+[`WBCPolicy`](./strands_robots/policies/wbc/policy.py) wraps NVIDIA's
+[GR00T-WholeBodyControl](https://github.com/NVlabs/GR00T-WholeBodyControl)
+(SONIC) ONNX controllers for deploy-grade humanoid locomotion on the Unitree
+G1. Like cuRobo it runs **in-process** (ONNX Runtime), but needs no GPU - the
+sessions run on CPU. It is non-VLA (`requires_images = False`) and reads its
+goal from the locomotion kwarg `target_velocity = [vx, vy, omega]`. It drives
+the **15 leg+waist DOFs**; arm joints are held at their defaults (layering an
+upper-body policy is a future `CompositePolicy`).
+
+```bash
+pip install "strands-robots[wbc]"   # onnxruntime only - light, no torch/GPU
+```
+
+No weights are bundled; download a SONIC checkpoint under the NVIDIA Open Model
+License (e.g. `nvidia/GEAR-SONIC`) into a dir with `policy.onnx`.
+
+```python
+from strands_robots import Robot
+
+sim = Robot("unitree_g1")             # sim-by-default; CPU ONNX, no GPU
+sim.run_policy(
+    robot_name="unitree_g1",
+    policy_provider="wbc",            # shorthand: "sonic"
+    policy_config={"checkpoint": "/path/to/GEAR-SONIC", "walk": True},
+    policy_kwargs={"target_velocity": [0.5, 0.0, 0.0]},
+    duration=10.0,
+    control_frequency=50.0,
+    action_horizon=1,                 # WBC is closed-loop per tick
+)
+```
+
+The per-call locomotion command rides through `run_policy`'s `policy_kwargs`
+to `policy.get_actions(..., target_velocity=[...])`. WBC output index `i`
+drives an explicit `unitree_g1` leg+waist actuator (no positional guessing);
+a model whose joint order disagrees raises rather than actuating wrong joints.
+See the [WBC policy docs](https://strands-labs.github.io/robots/policies/wbc/).
 
 ## Simulation (MuJoCo)
 

--- a/docs/policies/wbc.md
+++ b/docs/policies/wbc.md
@@ -145,6 +145,28 @@ set once at construction via `policy_config={"checkpoint": ..., "target_velocity
 [0.5, 0.0, 0.0]}` (the value forwarded to the policy constructor), which is how a
 command reaches the policy over the mesh `tell()` path.
 
+## Watching it walk (torque-control deploy)
+
+`sim.run_policy` writes the policy's joint-position **targets** to the sim's
+actuators. The default MuJoCo Menagerie G1 has *position-servo* actuators with
+their own gains, so a stable gait is not expected through that path. The real
+deploy loop (and the upstream reference) converts the targets to **torque** via
+the PD law on a *torque-actuated* model.
+
+[`examples/wbc_g1_torque_deploy.py`](https://github.com/strands-labs/robots/blob/main/examples/wbc_g1_torque_deploy.py)
+reproduces that loop - torque motors, `policy.compute_torques(...)` at
+`control_decimation=4`, whole-body observation with real joint velocities + base
+IMU - and is the right way to see the G1 actually locomote:
+
+```bash
+python examples/wbc_g1_torque_deploy.py --checkpoint /path/to/GEAR-SONIC \
+    --duration 5 --vx 0.5 --mp4 /tmp/g1_walk.mp4
+```
+
+With the real `GR00T-WholeBodyControl-{Balance,Walk}.onnx` weights this produces
+a stable forward walk (the base advances ~0.38 m/s for a 0.5 m/s command while
+holding height); a standing command (`--vx 0`) holds balance in place.
+
 ## See also
 
 - [Policy overview](overview.md)

--- a/docs/policies/wbc.md
+++ b/docs/policies/wbc.md
@@ -1,0 +1,146 @@
+---
+description: NVIDIA GR00T Whole-Body-Control (SONIC) humanoid locomotion - in-process ONNX, no GPU required, goal via target_velocity kwargs.
+---
+
+# WBC (Whole-Body-Control)
+
+[`WBCPolicy`](https://github.com/strands-labs/robots/blob/main/strands_robots/policies/wbc/policy.py)
+wraps NVIDIA's
+[GR00T Whole-Body-Control](https://github.com/NVlabs/GR00T-WholeBodyControl)
+(SONIC / decoupled-WBC) ONNX controllers for deploy-grade humanoid locomotion
+on the Unitree G1. Like [cuRobo](curobo.md) it runs **in the same process**
+(via ONNX Runtime - no sidecar, no network round-trip), but unlike cuRobo it
+needs no GPU: the ONNX sessions run on CPU.
+
+It is a non-VLA, locomotion controller: it reads its goal from the well-known
+locomotion `**kwargs` (`target_velocity`), ignores camera frames
+(`requires_images = False`), and never parses the instruction string for
+control. The controller drives the **15 leg+waist DOFs** of the G1; the arm
+joints are held at their nominal defaults. Layering an upper-body manipulation
+policy (e.g. GR00T) on top of WBC locomotion is the job of a future
+`CompositePolicy`, out of scope for this provider.
+
+## Install
+
+```bash
+pip install "strands-robots[wbc]"            # onnxruntime only - light, no torch
+pip install "strands-robots[wbc,sim-mujoco]" # + MuJoCo to drive the G1 in sim
+```
+
+No model weights are bundled. Download a GR00T-WBC (SONIC) checkpoint under the
+NVIDIA Open Model License (e.g.
+[`nvidia/GEAR-SONIC`](https://huggingface.co/nvidia/GEAR-SONIC)) into a
+directory containing `policy.onnx` (plus an optional `walk_policy.onnx` and
+`config.json`).
+
+## Quickstart
+
+```python
+from strands_robots.policies import create_policy
+
+policy = create_policy(
+    "wbc",                                  # shorthand: "sonic"
+    checkpoint="/path/to/GEAR-SONIC",       # dir with policy.onnx (+ walk_policy.onnx)
+    walk=True,
+)
+
+actions = policy.get_actions_sync(
+    observation_dict={"observation.state": [0.0] * 29},  # G1 joint positions
+    instruction="walk forward",             # ignored by the controller
+    target_velocity=[0.5, 0.0, 0.0],        # [vx, vy, omega] (m/s, m/s, rad/s)
+)
+# actions == [{"left_hip_pitch_joint": .., ..., "waist_pitch_joint": ..}]
+# one per-tick dict of 15 leg+waist joint targets (closed-loop, not a chunk)
+```
+
+## Parameters
+
+```python
+WBCPolicy(
+    checkpoint="/path/to/GEAR-SONIC",  # dir with policy.onnx, a direct .onnx path, or an HF id
+    config=None,                       # WBCConfig | path | dict | None (None -> config.json in checkpoint)
+    walk=True,                         # load + prefer walk_policy.onnx for locomotion
+    target_velocity=None,              # constructor-time default [vx, vy, omega] (per-call kwarg overrides)
+    allow_missing_models=False,        # test seam: skip eager ONNX load (inject a stub session)
+)
+```
+
+A missing `onnxruntime` or a missing checkpoint raises `RuntimeError` at
+construction - WBC never falls back to silent zero torques.
+
+## Goal kwargs
+
+WBC reads locomotion commands from `**kwargs`, sharing the non-VLA goal
+vocabulary so a command can flow through `run_policy` / mesh `tell()` without
+coupling to a backend:
+
+| Key | Type | Meaning |
+|-----|------|---------|
+| `target_velocity` | `list[float]` | Locomotion command `[vx, vy, omega]` (m/s, m/s, rad/s) |
+| `target_orientation` | `list[float]` | Optional extra command/style channels appended after `[vx, vy, omega]` |
+
+A per-call `target_velocity` overrides the constructor-time default. With no
+command at all the controller holds a standing balance (zero velocity).
+
+## Control contract
+
+WBC reproduces the upstream `GearWbcController` loop:
+
+- **Two ONNX sessions** - a main `policy.onnx` and an optional `walk_policy.onnx`,
+  loaded once at construction. The walk policy is selected when `walk=True` and
+  the command requests motion; otherwise the main (balance) policy runs.
+- **Observation** - an 86-dim frame (command + base angular velocity +
+  projected gravity + scaled joint positions/velocities + previous action),
+  stacked over `obs_history_len` via a deque.
+- **Action** - the network emits a 15-dim joint-position *offset*; the policy
+  forms absolute targets `target_q = default_angles + action_scale * raw` and
+  returns them keyed by actuator name. For torque-actuated MuJoCo, convert with
+  the upstream PD law via `policy.compute_torques(target, q, dq)`.
+
+## Actuator mapping
+
+WBC output index `i` drives `WBC_G1_LEG_WAIST_JOINTS[i]` - an explicit table
+(no positional guessing). `set_robot_state_keys` validates that the robot's
+first 15 joints match this order and raises otherwise, so a mismatched model
+can never silently actuate the wrong joints:
+
+```
+left_hip_pitch_joint, left_hip_roll_joint, left_hip_yaw_joint,
+left_knee_joint, left_ankle_pitch_joint, left_ankle_roll_joint,
+right_hip_pitch_joint, right_hip_roll_joint, right_hip_yaw_joint,
+right_knee_joint, right_ankle_pitch_joint, right_ankle_roll_joint,
+waist_yaw_joint, waist_roll_joint, waist_pitch_joint
+```
+
+## In simulation
+
+```python
+from strands_robots import Robot
+
+sim = Robot("unitree_g1")             # sim-by-default; CPU ONNX, no GPU needed
+sim.run_policy(
+    robot_name="unitree_g1",
+    instruction="walk forward",       # ignored by the controller
+    policy_provider="wbc",
+    policy_config={"checkpoint": "/path/to/GEAR-SONIC", "walk": True},
+    policy_kwargs={"target_velocity": [0.5, 0.0, 0.0]},   # per-call locomotion goal
+    duration=10.0,
+    control_frequency=50.0,
+    action_horizon=1,                 # WBC is closed-loop per tick
+)
+```
+
+The per-call command rides through `run_policy`'s `policy_kwargs` to
+`policy.get_actions(..., target_velocity=[...])`. A *static* walk can also be
+set once at construction via `policy_config={"checkpoint": ..., "target_velocity":
+[0.5, 0.0, 0.0]}` (the value forwarded to the policy constructor), which is how a
+command reaches the policy over the mesh `tell()` path.
+
+## See also
+
+- [Policy overview](overview.md)
+- [cuRobo](curobo.md) - in-process CUDA collision-aware planning (non-VLA).
+- [MoveIt2](moveit2.md) - ROS 2 sidecar collision-aware planning (non-VLA).
+- [GR00T](groot.md) - ZMQ service VLA (manipulation upper body).
+- [Custom policies](custom-policies.md) - implement the non-VLA goal-kwargs contract.
+- [GR00T-WholeBodyControl](https://github.com/NVlabs/GR00T-WholeBodyControl)

--- a/docs/policies/wbc.md
+++ b/docs/policies/wbc.md
@@ -145,6 +145,13 @@ set once at construction via `policy_config={"checkpoint": ..., "target_velocity
 [0.5, 0.0, 0.0]}` (the value forwarded to the policy constructor), which is how a
 command reaches the policy over the mesh `tell()` path.
 
+> **Note:** `policy_kwargs` is wired on the control/deploy path
+> (`run_policy` / `start_policy` / mesh `tell()`), not the evaluation path.
+> `eval_policy` / `evaluate_benchmark` are instruction-driven (built for
+> task-success benchmarks); to evaluate WBC at a fixed velocity, set it once via
+> the constructor `target_velocity` (above). Per-episode velocity variation in
+> eval is out of scope for this provider.
+
 ## Watching it walk (torque-control deploy)
 
 `sim.run_policy` writes the policy's joint-position **targets** to the sim's

--- a/docs/policies/wbc.md
+++ b/docs/policies/wbc.md
@@ -76,22 +76,31 @@ coupling to a backend:
 
 | Key | Type | Meaning |
 |-----|------|---------|
-| `target_velocity` | `list[float]` | Locomotion command `[vx, vy, omega]` (m/s, m/s, rad/s) |
-| `target_orientation` | `list[float]` | Optional extra command/style channels appended after `[vx, vy, omega]` |
+| `target_velocity` | `list[float]` | Locomotion command `[vx, vy, omega]` (m/s, m/s, rad/s). Scaled by `cmd_scale` (`[2.0, 2.0, 0.5]`) into the observation's command block. |
+| `target_orientation` | `list[float]` | Target base `[roll, pitch, yaw]` (rad), written to command slots `[4:7]`. Defaults to the config `rpy_cmd` (`[0,0,0]`). |
+| `height` | `float` | Target base height (m), written to command slot `[3]`. Defaults to the config `height_cmd` (`0.74`). |
 
 A per-call `target_velocity` overrides the constructor-time default. With no
-command at all the controller holds a standing balance (zero velocity).
+command at all the controller holds a standing balance (zero velocity, default
+height + level orientation).
 
 ## Control contract
 
-WBC reproduces the upstream `GearWbcController` loop:
+WBC reproduces the upstream `GearWbcController` loop (NVlabs/GR00T-WholeBodyControl
+`decoupled_wbc/sim2mujoco`, `run_mujoco_gear_wbc.py` + `g1_gear_wbc.yaml`):
 
 - **Two ONNX sessions** - a main `policy.onnx` and an optional `walk_policy.onnx`,
-  loaded once at construction. The walk policy is selected when `walk=True` and
-  the command requests motion; otherwise the main (balance) policy runs.
-- **Observation** - an 86-dim frame (command + base angular velocity +
-  projected gravity + scaled joint positions/velocities + previous action),
-  stacked over `obs_history_len` via a deque.
+  loaded once at construction. Selection matches upstream: when the **raw**
+  velocity-command norm is `<= 0.05` the robot is "standing" and the main policy
+  runs; above that the walk policy runs (when `walk=True`).
+- **Observation** - an 86-dim frame stacked over `obs_history_len` (default 6,
+  so the network input is `86 * 6 = 516`):
+  - command `[0:7]` = `[vx*2.0, vy*2.0, omega*0.5, height, roll, pitch, yaw]`
+  - base angular velocity `[7:10]` (scaled by `ang_vel_scale=0.5`)
+  - projected gravity `[10:13]`
+  - joint positions `[13:28]` (minus `default_angles`, scaled by `dof_pos_scale`)
+  - joint velocities `[28:43]` (scaled by `dof_vel_scale=0.05`)
+  - previous action `[43:58]`; indices `[58:86]` are a reserved (zero) tail.
 - **Action** - the network emits a 15-dim joint-position *offset*; the policy
   forms absolute targets `target_q = default_angles + action_scale * raw` and
   returns them keyed by actuator name. For torque-actuated MuJoCo, convert with

--- a/examples/README.md
+++ b/examples/README.md
@@ -37,6 +37,7 @@ MUJOCO_GL=egl python examples/01_sim_hello_world.py
 |------|--------------|
 | [`molmoact2_so101_pickplace.py`](molmoact2_so101_pickplace.py) | Real hardware + MolmoAct2 VLA policy on SO-101 |
 | [`cosmos3_sim_rollout.py`](cosmos3_sim_rollout.py) | Cosmos 3 VLA in MuJoCo with WebSocket policy server |
+| [`wbc_g1_torque_deploy.py`](wbc_g1_torque_deploy.py) | GR00T-WBC (SONIC) locomotion on the Unitree G1 via the torque-control deploy loop |
 | [`lerobot/hub_to_hardware.py`](lerobot/hub_to_hardware.py) | Full agent-driven pipeline: record, train, deploy |
 
 ## Environment variables

--- a/examples/wbc_g1_torque_deploy.py
+++ b/examples/wbc_g1_torque_deploy.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Torque-control deploy harness for WBCPolicy on the Unitree G1.
+
+Reproduces NVIDIA's GR00T Whole-Body-Control reference loop
+(``decoupled_wbc/sim2mujoco/scripts/run_mujoco_gear_wbc.py``) closely enough to
+drive the real ``GR00T-WholeBodyControl-{Balance,Walk}.onnx`` weights and watch
+the G1 try to walk in MuJoCo:
+
+    every physics tick:
+        tau = (target_dof_pos - q) * kp + (0 - dq) * kd      # PD -> torque
+        data.ctrl[:15] = tau                                  # leg+waist motors
+        arms held at default with a stiff PD
+        mj_step
+        every control_decimation (4) ticks:
+            obs    = build the 86-dim frame (whole-body qj/dqj + base IMU + cmd)
+            action = WBCPolicy ONNX (Balance if standing, Walk if moving)
+            target_dof_pos = action * action_scale + default_angles
+
+The crucial difference from ``sim.run_policy`` is that this applies the policy's
+position targets through the upstream TORQUE PD law on a TORQUE-actuated model
+(``policy.compute_torques(...)``), not as position-servo ctrl. That is what a
+real deployment does, and what a stable gait needs.
+
+This harness is intentionally standalone (not a Simulation AgentTool action) and
+self-contained: it converts the MuJoCo Menagerie G1's position-servo actuators
+to torque motors in-process, so it needs no extra mesh/XML download beyond the
+``robot_descriptions`` G1 the rest of the project already uses.
+
+Usage::
+
+    pip install "strands-robots[wbc,sim-mujoco]"
+    # Point at a checkpoint dir with policy.onnx (+ optional walk_policy.onnx,
+    # config.json). The real weights live in the upstream GR00T-WBC repo under
+    # decoupled_wbc/sim2mujoco/resources/robots/g1/policy/.
+    python examples/wbc_g1_torque_deploy.py --checkpoint /path/to/GEAR-SONIC \
+        --duration 5 --vx 0.5 [--mp4 /tmp/g1_walk.mp4] [--viewer]
+
+It prints per-second base x/z and a final verdict (advanced / fell / stayed put),
+and exits non-zero on a hard error so it can gate CI behind real weights.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+import numpy as np
+
+
+def _build_torque_g1() -> tuple:
+    """Load the Menagerie G1 and convert its actuators to pure-torque motors.
+
+    Returns ``(mujoco_module, model, data, joint_names, leg_waist_idx)`` where
+    ``joint_names`` is the 29-DOF order (qpos[7:] / qvel[6:]) and
+    ``leg_waist_idx`` are the first 15 actuator indices (the controlled set).
+    """
+    import mujoco
+    from robot_descriptions import g1_mj_description
+
+    spec = mujoco.MjSpec.from_file(g1_mj_description.MJCF_PATH)
+
+    # The robot_descriptions G1 MJCF is the robot alone - no ground plane. The
+    # upstream g1_gear_wbc.xml scene includes a floor; without one the robot
+    # falls through space (z -> -inf) even under a perfect static hold. Add a
+    # static ground plane + a light so the robot has something to stand on.
+    if not any(g.name == "wbc_ground" for g in spec.worldbody.geoms):
+        spec.worldbody.add_geom(
+            name="wbc_ground",
+            type=mujoco.mjtGeom.mjGEOM_PLANE,
+            size=[0.0, 0.0, 0.05],
+            pos=[0.0, 0.0, 0.0],
+            rgba=[0.4, 0.4, 0.4, 1.0],
+        )
+
+    # Convert every actuator to a pure-torque motor (gaintype FIXED, no bias),
+    # so writing data.ctrl[i] = tau applies tau directly - the contract the
+    # upstream PD loop assumes. The Menagerie model ships position servos.
+    for act in spec.actuators:
+        act.gaintype = mujoco.mjtGain.mjGAIN_FIXED
+        act.biastype = mujoco.mjtBias.mjBIAS_NONE
+        act.gainprm = [1.0, 0.0, 0.0] + list(act.gainprm[3:])
+        act.biasprm = [0.0, 0.0, 0.0] + list(act.biasprm[3:])
+        # Open the ctrl range so a torque command isn't clamped to a small
+        # position-servo range.
+        act.ctrlrange = [-1000.0, 1000.0]
+        act.ctrllimited = True
+    model = spec.compile()
+    data = mujoco.MjData(model)
+
+    # 29-DOF joint order (skip the free/floating base joint).
+    joint_names: list[str] = []
+    for j in range(model.njnt):
+        if model.jnt_type[j] != mujoco.mjtJoint.mjJNT_FREE:
+            joint_names.append(mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, j))
+    return mujoco, model, data, joint_names
+
+
+def _set_standing_pose(mujoco, model, data, default_angles: np.ndarray, height: float) -> None:
+    """Place the base upright at ``height`` and the legs at the nominal stance."""
+    mujoco.mj_resetData(model, data)
+    data.qpos[0:3] = [0.0, 0.0, height]
+    data.qpos[3:7] = [1.0, 0.0, 0.0, 0.0]  # identity quaternion (w, x, y, z)
+    n = min(len(default_angles), data.qpos.shape[0] - 7)
+    data.qpos[7 : 7 + n] = default_angles[:n]
+    mujoco.mj_forward(model, data)
+
+
+def run(args: argparse.Namespace) -> int:
+    from strands_robots.policies import create_policy
+    from strands_robots.policies.wbc import WBC_G1_ALL_JOINTS, WBCPolicy
+
+    mujoco, model, data, joint_names = _build_torque_g1()
+    n_joints = data.qpos.shape[0] - 7
+
+    policy = create_policy("wbc", checkpoint=args.checkpoint, walk=not args.no_walk)
+    assert isinstance(policy, WBCPolicy)
+    cfg = policy.config
+    # Resolve the policy's joint mapping against the model's joint order.
+    policy.set_robot_state_keys(joint_names)
+
+    default_angles = np.zeros(n_joints, dtype=np.float64)
+    da = np.asarray(cfg.default_angles, dtype=np.float64)
+    default_angles[: min(len(da), n_joints)] = da[: min(len(da), n_joints)]
+
+    na = cfg.num_actions
+    # The leg+waist PD gains (kps/kds) live in the policy config; the upstream
+    # PD law is applied via policy.compute_torques(...), which reads them.
+
+    # Arm-hold PD (upstream uses kp=100, kd=0.5 to zero target for joints > 15).
+    arm_kp, arm_kd = 100.0, 0.5
+
+    physics_dt = float(args.physics_dt)
+    model.opt.timestep = physics_dt
+    decim = int(args.control_decimation)
+
+    _set_standing_pose(mujoco, model, data, default_angles, cfg.height_cmd)
+    x0, z0 = float(data.qpos[0]), float(data.qpos[2])
+
+    # WBC emits joint-POSITION targets; seed with the nominal stance.
+    target_dof_pos = default_angles.copy()
+    command = {"target_velocity": [args.vx, args.vy, args.omega]}
+
+    n_steps = int(args.duration / physics_dt)
+    frames: list[np.ndarray] = []
+    renderer = None
+    if args.mp4:
+        renderer = mujoco.Renderer(model, height=480, width=640)
+
+    fell = False
+    for step in range(n_steps):
+        # --- per physics tick: PD -> torque on the controlled 15 ---
+        q_lw = data.qpos[7 : 7 + na].copy()
+        dq_lw = data.qvel[6 : 6 + na].copy()
+        leg_tau = policy.compute_torques(target_dof_pos[:na], q_lw, dq_lw)
+        data.ctrl[:na] = leg_tau
+        # Hold the arms (joints na..n_joints) at default with a stiff PD.
+        if n_joints > na:
+            q_arm = data.qpos[7 + na : 7 + n_joints].copy()
+            dq_arm = data.qvel[6 + na : 6 + n_joints].copy()
+            arm_target = default_angles[na:n_joints]
+            data.ctrl[na:n_joints] = (arm_target - q_arm) * arm_kp + (0.0 - dq_arm) * arm_kd
+
+        mujoco.mj_step(model, data)
+
+        # --- every control_decimation ticks: query the policy ---
+        if step % decim == 0:
+            obs = _model_observation(data, joint_names, n_joints)
+            actions = policy.get_actions_sync(obs, "", **command)
+            raw = np.array([actions[0][name] for name in WBC_G1_ALL_JOINTS[:na]], dtype=np.float64)
+            # actions are already absolute targets (default + action_scale*raw);
+            # WBCPolicy.get_actions returns target_q directly.
+            target_dof_pos[:na] = raw
+
+        if renderer is not None and step % max(1, int(1.0 / (physics_dt * args.mp4_fps))) == 0:
+            renderer.update_scene(data, camera=-1)
+            frames.append(renderer.render())
+
+        z = float(data.qpos[2])
+        if z < 0.4 * z0:
+            fell = True
+            print(f"[step {step} t={step * physics_dt:.2f}s] base height {z:.3f} m < 0.4*{z0:.3f} - FELL")
+            break
+
+        if step % int(1.0 / physics_dt) == 0:  # ~once per second
+            print(f"[t={step * physics_dt:.1f}s] base x={data.qpos[0]:+.3f} z={data.qpos[2]:.3f}")
+
+    x1, z1 = float(data.qpos[0]), float(data.qpos[2])
+    forward = x1 - x0
+    print("\n=== WBC G1 torque-deploy result ===")
+    print(f"  duration: {args.duration:.1f}s | command vx={args.vx} vy={args.vy} omega={args.omega}")
+    print(f"  base x: {x0:+.3f} -> {x1:+.3f}  (forward {forward:+.3f} m)")
+    print(f"  base z: {z0:.3f} -> {z1:.3f} m")
+    if fell:
+        print("  VERDICT: FELL (height collapsed)")
+    elif forward >= 0.10:
+        print(f"  VERDICT: WALKED FORWARD ({forward:.2f} m)")
+    elif abs(forward) < 0.05 and z1 > 0.7 * z0:
+        print("  VERDICT: STAYED UPRIGHT (balanced, little forward progress)")
+    else:
+        print("  VERDICT: MOVED but inconclusive")
+
+    if renderer is not None and frames:
+        import imageio
+
+        imageio.mimsave(args.mp4, frames, fps=args.mp4_fps)
+        print(f"  video: {args.mp4} ({len(frames)} frames)")
+        renderer.close()
+
+    if args.viewer:
+        import mujoco.viewer
+
+        print("\n  launching interactive viewer (Ctrl+C to exit)...")
+        mujoco.viewer.launch(model, data)
+    return 0
+
+
+def _model_observation(data, joint_names: list[str], n_joints: int) -> dict:
+    """Build a per-joint observation dict (positions + .vel + base IMU) the way
+    WBCPolicy expects, straight from MuJoCo data - including joint velocities and
+    the base angular velocity / quaternion (which sim.run_policy does NOT supply,
+    and which a balance controller genuinely needs)."""
+    obs: dict = {}
+    for i, name in enumerate(joint_names):
+        obs[name] = float(data.qpos[7 + i])
+        obs[f"{name}.vel"] = float(data.qvel[6 + i])
+    obs["base_quat"] = [float(v) for v in data.qpos[3:7]]  # (w, x, y, z)
+    obs["base_ang_vel"] = [float(v) for v in data.qvel[3:6]]
+    return obs
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Torque-control deploy harness for WBCPolicy on the G1.")
+    p.add_argument("--checkpoint", required=True, help="dir with policy.onnx (+ walk_policy.onnx, config.json)")
+    p.add_argument("--duration", type=float, default=5.0, help="seconds to simulate")
+    p.add_argument("--vx", type=float, default=0.5, help="forward velocity command (m/s)")
+    p.add_argument("--vy", type=float, default=0.0, help="lateral velocity command (m/s)")
+    p.add_argument("--omega", type=float, default=0.0, help="yaw rate command (rad/s)")
+    p.add_argument("--physics-dt", type=float, default=0.005, help="physics timestep (upstream 0.005)")
+    p.add_argument("--control-decimation", type=int, default=4, help="physics steps per policy query (upstream 4)")
+    p.add_argument("--no-walk", action="store_true", help="load only the main (balance) policy")
+    p.add_argument("--mp4", default="", help="write an MP4 of the rollout to this path")
+    p.add_argument("--mp4-fps", type=int, default=30)
+    p.add_argument("--viewer", action="store_true", help="launch the interactive MuJoCo viewer at the end")
+    args = p.parse_args()
+    sys.exit(run(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/wbc_g1_torque_deploy.py
+++ b/examples/wbc_g1_torque_deploy.py
@@ -33,7 +33,7 @@ Usage::
     # config.json). The real weights live in the upstream GR00T-WBC repo under
     # decoupled_wbc/sim2mujoco/resources/robots/g1/policy/.
     python examples/wbc_g1_torque_deploy.py --checkpoint /path/to/GEAR-SONIC \
-        --duration 5 --vx 0.5 [--mp4 /tmp/g1_walk.mp4] [--viewer]
+        --duration 5 --vx 0.5 [--mp4 /tmp/g1_walk.mp4]
 
 It prints per-second base x/z and a final verdict (advanced / fell / stayed put),
 and exits non-zero on a hard error so it can gate CI behind real weights.
@@ -105,17 +105,48 @@ def _set_standing_pose(mujoco, model, data, default_angles: np.ndarray, height: 
     mujoco.mj_forward(model, data)
 
 
-def run(args: argparse.Namespace) -> int:
-    from strands_robots.policies import create_policy
-    from strands_robots.policies.wbc import WBC_G1_ALL_JOINTS, WBCPolicy
+def simulate_rollout(
+    policy,  # type: ignore[no-untyped-def]
+    *,
+    vx: float = 0.5,
+    vy: float = 0.0,
+    omega: float = 0.0,
+    duration: float = 5.0,
+    physics_dt: float = 0.005,
+    control_decimation: int = 4,
+    height: float | None = None,
+    on_step=None,  # type: ignore[no-untyped-def]
+    renderer_dims: tuple[int, int] | None = None,
+    fps: int = 30,
+) -> dict:
+    """Run the upstream torque-control loop and return rollout metrics.
+
+    Pure / importable so the CLI AND the test suite drive the identical loop.
+    The robot is a torque-actuated G1 (built in :func:`_build_torque_g1`); each
+    physics tick applies ``policy.compute_torques`` to the 15 controlled joints
+    (PD -> torque), holds the arms with a stiff PD, and every
+    ``control_decimation`` ticks re-queries ``policy.get_actions_sync`` for new
+    position targets.
+
+    Args:
+        policy: A constructed WBCPolicy (real or stubbed). ``set_robot_state_keys``
+            is called here against the model's joint order.
+        vx, vy, omega: Locomotion command.
+        duration: Wall-clock seconds (n_steps = duration / physics_dt).
+        height: Initial base height; defaults to ``policy.config.height_cmd``.
+        on_step: Optional ``(step:int, data) -> None`` hook (per physics tick).
+        renderer_dims: ``(width, height)`` to capture RGB frames, else no render.
+        fps: Frame-capture rate when rendering.
+
+    Returns:
+        Dict with ``x0/z0/x1/z1/forward/fell/steps/frames`` (frames is a list of
+        HxWx3 uint8 arrays, empty unless ``renderer_dims`` is set).
+    """
+    from strands_robots.policies.wbc import WBC_G1_ALL_JOINTS
 
     mujoco, model, data, joint_names = _build_torque_g1()
     n_joints = data.qpos.shape[0] - 7
-
-    policy = create_policy("wbc", checkpoint=args.checkpoint, walk=not args.no_walk)
-    assert isinstance(policy, WBCPolicy)
     cfg = policy.config
-    # Resolve the policy's joint mapping against the model's joint order.
     policy.set_robot_state_keys(joint_names)
 
     default_angles = np.zeros(n_joints, dtype=np.float64)
@@ -123,42 +154,40 @@ def run(args: argparse.Namespace) -> int:
     default_angles[: min(len(da), n_joints)] = da[: min(len(da), n_joints)]
 
     na = cfg.num_actions
-    # The leg+waist PD gains (kps/kds) live in the policy config; the upstream
-    # PD law is applied via policy.compute_torques(...), which reads them.
-
-    # Arm-hold PD (upstream uses kp=100, kd=0.5 to zero target for joints > 15).
+    # The leg+waist PD gains live in the policy config and are applied via
+    # policy.compute_torques(...). Arms held with a stiff PD (upstream kp=100,
+    # kd=0.5 to the default pose for joints beyond the controlled set).
     arm_kp, arm_kd = 100.0, 0.5
 
-    physics_dt = float(args.physics_dt)
     model.opt.timestep = physics_dt
-    decim = int(args.control_decimation)
-
-    _set_standing_pose(mujoco, model, data, default_angles, cfg.height_cmd)
+    decim = int(control_decimation)
+    base_height = float(height) if height is not None else float(cfg.height_cmd)
+    _set_standing_pose(mujoco, model, data, default_angles, base_height)
     x0, z0 = float(data.qpos[0]), float(data.qpos[2])
 
-    # WBC emits joint-POSITION targets; seed with the nominal stance.
-    target_dof_pos = default_angles.copy()
-    command = {"target_velocity": [args.vx, args.vy, args.omega]}
+    target_dof_pos = default_angles.copy()  # WBC emits position targets
+    command = {"target_velocity": [vx, vy, omega]}
 
-    n_steps = int(args.duration / physics_dt)
+    n_steps = int(duration / physics_dt)
     frames: list[np.ndarray] = []
     renderer = None
-    if args.mp4:
-        renderer = mujoco.Renderer(model, height=480, width=640)
+    if renderer_dims is not None:
+        renderer = mujoco.Renderer(model, height=renderer_dims[1], width=renderer_dims[0])
+    render_every = max(1, int(1.0 / (physics_dt * fps)))
 
     fell = False
+    steps_done = 0
     for step in range(n_steps):
+        steps_done = step + 1
         # --- per physics tick: PD -> torque on the controlled 15 ---
         q_lw = data.qpos[7 : 7 + na].copy()
         dq_lw = data.qvel[6 : 6 + na].copy()
-        leg_tau = policy.compute_torques(target_dof_pos[:na], q_lw, dq_lw)
-        data.ctrl[:na] = leg_tau
-        # Hold the arms (joints na..n_joints) at default with a stiff PD.
+        data.ctrl[:na] = policy.compute_torques(target_dof_pos[:na], q_lw, dq_lw)
+        # Hold the arms at default with a stiff PD.
         if n_joints > na:
             q_arm = data.qpos[7 + na : 7 + n_joints].copy()
             dq_arm = data.qvel[6 + na : 6 + n_joints].copy()
-            arm_target = default_angles[na:n_joints]
-            data.ctrl[na:n_joints] = (arm_target - q_arm) * arm_kp + (0.0 - dq_arm) * arm_kd
+            data.ctrl[na:n_joints] = (default_angles[na:n_joints] - q_arm) * arm_kp + (0.0 - dq_arm) * arm_kd
 
         mujoco.mj_step(model, data)
 
@@ -166,32 +195,68 @@ def run(args: argparse.Namespace) -> int:
         if step % decim == 0:
             obs = _model_observation(data, joint_names, n_joints)
             actions = policy.get_actions_sync(obs, "", **command)
-            raw = np.array([actions[0][name] for name in WBC_G1_ALL_JOINTS[:na]], dtype=np.float64)
-            # actions are already absolute targets (default + action_scale*raw);
-            # WBCPolicy.get_actions returns target_q directly.
-            target_dof_pos[:na] = raw
+            # WBCPolicy.get_actions returns absolute targets keyed by joint name.
+            target_dof_pos[:na] = np.array([actions[0][name] for name in WBC_G1_ALL_JOINTS[:na]], dtype=np.float64)
 
-        if renderer is not None and step % max(1, int(1.0 / (physics_dt * args.mp4_fps))) == 0:
+        if renderer is not None and step % render_every == 0:
             renderer.update_scene(data, camera=-1)
             frames.append(renderer.render())
 
-        z = float(data.qpos[2])
-        if z < 0.4 * z0:
+        if on_step is not None:
+            on_step(step, data)
+
+        if float(data.qpos[2]) < 0.4 * z0:
             fell = True
-            print(f"[step {step} t={step * physics_dt:.2f}s] base height {z:.3f} m < 0.4*{z0:.3f} - FELL")
             break
 
+    if renderer is not None:
+        renderer.close()
+    x1, z1 = float(data.qpos[0]), float(data.qpos[2])
+    return {
+        "x0": x0,
+        "z0": z0,
+        "x1": x1,
+        "z1": z1,
+        "forward": x1 - x0,
+        "fell": fell,
+        "steps": steps_done,
+        "frames": frames,
+    }
+
+
+def run(args: argparse.Namespace) -> int:
+    from strands_robots.policies import create_policy
+    from strands_robots.policies.wbc import WBCPolicy
+
+    policy = create_policy("wbc", checkpoint=args.checkpoint, walk=not args.no_walk)
+    assert isinstance(policy, WBCPolicy)
+
+    physics_dt = float(args.physics_dt)
+
+    def _progress(step: int, data) -> None:  # type: ignore[no-untyped-def]
         if step % int(1.0 / physics_dt) == 0:  # ~once per second
             print(f"[t={step * physics_dt:.1f}s] base x={data.qpos[0]:+.3f} z={data.qpos[2]:.3f}")
 
-    x1, z1 = float(data.qpos[0]), float(data.qpos[2])
-    forward = x1 - x0
+    result = simulate_rollout(
+        policy,
+        vx=args.vx,
+        vy=args.vy,
+        omega=args.omega,
+        duration=args.duration,
+        physics_dt=physics_dt,
+        control_decimation=args.control_decimation,
+        on_step=_progress,
+        renderer_dims=(640, 480) if args.mp4 else None,
+        fps=args.mp4_fps,
+    )
+
+    forward, z0, z1 = result["forward"], result["z0"], result["z1"]
     print("\n=== WBC G1 torque-deploy result ===")
     print(f"  duration: {args.duration:.1f}s | command vx={args.vx} vy={args.vy} omega={args.omega}")
-    print(f"  base x: {x0:+.3f} -> {x1:+.3f}  (forward {forward:+.3f} m)")
+    print(f"  base x: {result['x0']:+.3f} -> {result['x1']:+.3f}  (forward {forward:+.3f} m)")
     print(f"  base z: {z0:.3f} -> {z1:.3f} m")
-    if fell:
-        print("  VERDICT: FELL (height collapsed)")
+    if result["fell"]:
+        print(f"  VERDICT: FELL (height collapsed at step {result['steps']})")
     elif forward >= 0.10:
         print(f"  VERDICT: WALKED FORWARD ({forward:.2f} m)")
     elif abs(forward) < 0.05 and z1 > 0.7 * z0:
@@ -199,18 +264,11 @@ def run(args: argparse.Namespace) -> int:
     else:
         print("  VERDICT: MOVED but inconclusive")
 
-    if renderer is not None and frames:
+    if args.mp4 and result["frames"]:
         import imageio
 
-        imageio.mimsave(args.mp4, frames, fps=args.mp4_fps)
-        print(f"  video: {args.mp4} ({len(frames)} frames)")
-        renderer.close()
-
-    if args.viewer:
-        import mujoco.viewer
-
-        print("\n  launching interactive viewer (Ctrl+C to exit)...")
-        mujoco.viewer.launch(model, data)
+        imageio.mimsave(args.mp4, result["frames"], fps=args.mp4_fps)
+        print(f"  video: {args.mp4} ({len(result['frames'])} frames)")
     return 0
 
 
@@ -240,7 +298,6 @@ def main() -> None:
     p.add_argument("--no-walk", action="store_true", help="load only the main (balance) policy")
     p.add_argument("--mp4", default="", help="write an MP4 of the rollout to this path")
     p.add_argument("--mp4-fps", type=int, default=30)
-    p.add_argument("--viewer", action="store_true", help="launch the interactive MuJoCo viewer at the end")
     args = p.parse_args()
     sys.exit(run(args))
 

--- a/examples/wbc_g1_torque_deploy.py
+++ b/examples/wbc_g1_torque_deploy.py
@@ -50,9 +50,9 @@ import numpy as np
 def _build_torque_g1() -> tuple:
     """Load the Menagerie G1 and convert its actuators to pure-torque motors.
 
-    Returns ``(mujoco_module, model, data, joint_names, leg_waist_idx)`` where
-    ``joint_names`` is the 29-DOF order (qpos[7:] / qvel[6:]) and
-    ``leg_waist_idx`` are the first 15 actuator indices (the controlled set).
+    Returns ``(mujoco_module, model, data, joint_names)`` where ``joint_names``
+    is the 29-DOF actuated-joint order (qpos[7:] / qvel[6:]); the first 15 are
+    the controlled leg+waist set, the rest are the held arms.
     """
     import mujoco
     from robot_descriptions import g1_mj_description

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ nav:
   - Cosmos 3: policies/cosmos3.md
   - cuRobo: policies/curobo.md
   - MoveIt2: policies/moveit2.md
+  - WBC (Whole-Body-Control): policies/wbc.md
   - LeRobot Local: policies/lerobot-local.md
   - Custom Policies: policies/custom-policies.md
 - Real Hardware:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,12 @@ wbc = [
     # The upstream GR00T-WBC checkpoint config (g1_gear_wbc.yaml) is YAML;
     # WBCConfig.from_file reads it via pyyaml. JSON configs work without it.
     "pyyaml>=5.1,<7.0.0",
+    # Resolving a HuggingFace model id checkpoint (e.g. the default
+    # nvidia/GEAR-SONIC, or any "org/repo") downloads it via huggingface_hub.
+    # Required so create_policy("wbc") with no local checkpoint works out of the
+    # box - WBCPolicy._maybe_download_checkpoint raises RuntimeError naming the
+    # [wbc] extra when it is absent.
+    "huggingface_hub>=0.20.0,<1.0.0",
 ]
 lerobot = [
     "lerobot[feetech]>=0.5.0,<0.6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,9 @@ curobo = []
 # (e.g. nvidia/GEAR-SONIC). See policies/wbc/ and issue #466.
 wbc = [
     "onnxruntime>=1.17.0,<2.0.0",
+    # The upstream GR00T-WBC checkpoint config (g1_gear_wbc.yaml) is YAML;
+    # WBCConfig.from_file reads it via pyyaml. JSON configs work without it.
+    "pyyaml>=5.1,<7.0.0",
 ]
 lerobot = [
     "lerobot[feetech]>=0.5.0,<0.6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,10 @@ wbc = [
     # Required so create_policy("wbc") with no local checkpoint works out of the
     # box - WBCPolicy._maybe_download_checkpoint raises RuntimeError naming the
     # [wbc] extra when it is absent.
-    "huggingface_hub>=0.20.0,<1.0.0",
+    # Cap the MAJOR only (<2.0.0): a <1.0.0 cap conflicts with lerobot, which
+    # requires huggingface-hub>=1.0.0 - and [wbc] is pulled into [all] alongside
+    # lerobot, so the two must co-resolve.
+    "huggingface_hub>=0.20.0,<2.0.0",
 ]
 lerobot = [
     "lerobot[feetech]>=0.5.0,<0.6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,14 @@ moveit2 = [
 # silently-broken install of the squatter package. Tracked in the
 # follow-up issue linked from PR #306.
 curobo = []
+# GR00T Whole-Body-Control (SONIC) locomotion policy. Runs the ONNX
+# controllers in-process via onnxruntime (no torch, no sidecar) - a light
+# extra, like the client side of moveit2. Model weights are NOT bundled;
+# they are fetched at runtime under the NVIDIA Open Model License
+# (e.g. nvidia/GEAR-SONIC). See policies/wbc/ and issue #466.
+wbc = [
+    "onnxruntime>=1.17.0,<2.0.0",
+]
 lerobot = [
     "lerobot[feetech]>=0.5.0,<0.6.0",
     # #378: lerobot 0.5.1's pyav video fallback calls torchvision.io.VideoReader,
@@ -181,6 +189,7 @@ all = [
     "strands-robots[mesh]",
     "strands-robots[mesh-iot]",
     "strands-robots[device-connect]",
+    "strands-robots[wbc]",
 ]
 dev = [
     "pytest>=6.0,<9.0.0",
@@ -326,7 +335,7 @@ ignore_missing_imports = false
 
 # Third-party libs without type stubs
 [[tool.mypy.overrides]]
-module = ["lerobot.*", "gr00t.*", "draccus.*", "msgpack.*", "websockets", "websockets.*", "zmq.*", "huggingface_hub.*", "serial.*", "psutil.*", "torch.*", "torchvision.*", "transformers.*", "einops.*", "robot_descriptions.*", "mujoco.*", "imageio.*", "libero.*", "zenoh.*", "boto3", "boto3.*", "awscrt", "awscrt.*", "awsiot", "awsiot.*", "botocore.*", "strands_robots.policies.cosmos3._msgpack_numpy", "diffusers", "diffusers.*", "accelerate", "accelerate.*", "openpi_client", "openpi_client.*", "openpi_server", "openpi_server.*", "openpi", "openpi.*", "device_connect_edge", "device_connect_edge.*", "device_connect_agent_tools", "device_connect_agent_tools.*", "rclpy", "rclpy.*", "moveit", "moveit.*", "moveit_configs_utils", "moveit_configs_utils.*", "geometry_msgs", "geometry_msgs.*", "mink", "mink.*", "qpsolvers", "qpsolvers.*"]
+module = ["lerobot.*", "gr00t.*", "draccus.*", "msgpack.*", "websockets", "websockets.*", "zmq.*", "huggingface_hub.*", "serial.*", "psutil.*", "torch.*", "torchvision.*", "transformers.*", "einops.*", "robot_descriptions.*", "mujoco.*", "imageio.*", "libero.*", "zenoh.*", "boto3", "boto3.*", "awscrt", "awscrt.*", "awsiot", "awsiot.*", "botocore.*", "strands_robots.policies.cosmos3._msgpack_numpy", "diffusers", "diffusers.*", "accelerate", "accelerate.*", "openpi_client", "openpi_client.*", "openpi_server", "openpi_server.*", "openpi", "openpi.*", "device_connect_edge", "device_connect_edge.*", "device_connect_agent_tools", "device_connect_agent_tools.*", "rclpy", "rclpy.*", "moveit", "moveit.*", "moveit_configs_utils", "moveit_configs_utils.*", "geometry_msgs", "geometry_msgs.*", "mink", "mink.*", "qpsolvers", "qpsolvers.*", "onnxruntime", "onnxruntime.*"]
 ignore_missing_imports = true
 
 # Device Connect drivers - thin wrappers over the untyped device_connect_edge
@@ -404,4 +413,5 @@ markers = [
     "integration: requires live Device Connect infra (Zenoh router + etcd via Docker); skipped unless DEVICE_CONNECT_ALLOW_INSECURE is set (deselect with: pytest -m 'not integration')",
     "moveit2: requires a running MoveIt2 sidecar (ROS 2 / moveit_py). Run with: pytest -m moveit2",
     "curobo: requires NVIDIA cuRobo + a CUDA-capable GPU. Run with: pytest -m curobo (set CUROBO_LIVE=1)",
+    "wbc: requires onnxruntime + a downloaded GR00T-WBC (SONIC) checkpoint + mujoco. Run with: pytest -m wbc (set WBC_LIVE=1)",
 ]

--- a/strands_robots/mesh/security.py
+++ b/strands_robots/mesh/security.py
@@ -197,7 +197,9 @@ _HF_REPO_ENTRY_RE = re.compile(r"^[A-Za-z0-9_./\-]+$")
 _POLICY_TYPE_ENTRY_RE = re.compile(r"^[a-z][a-z0-9_]*$")
 
 #: Built-in policy_type allowlist. Mirrors the LeRobot policy registry
-#: families plus the generic providers DevDuck ships with. Operators
+#: families plus the providers registered in registry/policies.json. Keep this
+#: in sync with the registry so a provider that ``create_policy`` can build can
+#: also be driven over the mesh ``tell()`` path and Device Connect. Operators
 #: extend via ``STRANDS_MESH_POLICY_TYPE_ALLOW`` (comma-separated).
 _DEFAULT_POLICY_TYPES: frozenset[str] = frozenset(
     {
@@ -213,6 +215,11 @@ _DEFAULT_POLICY_TYPES: frozenset[str] = frozenset(
         "pi0fast",
         "smolvla",
         "sac",
+        # GR00T Whole-Body-Control (SONIC) locomotion provider (registry: wbc,
+        # shorthand sonic). Without these, tell(..., policy_provider="wbc") and
+        # the Device Connect drivers reject WBC at the security gate.
+        "wbc",
+        "sonic",
     }
 )
 

--- a/strands_robots/policies/wbc/__init__.py
+++ b/strands_robots/policies/wbc/__init__.py
@@ -1,0 +1,28 @@
+"""WBC policy - GR00T Whole-Body-Control (SONIC) locomotion for the Unitree G1.
+
+The :class:`WBCPolicy` wraps NVIDIA's
+`GR00T-WholeBodyControl <https://github.com/NVlabs/GR00T-WholeBodyControl>`_
+ONNX locomotion controllers. Like :class:`~strands_robots.policies.curobo.CuroboPolicy`
+it runs **in process** (ONNX Runtime, no sidecar), and like the rest of the
+non-VLA family:
+
+* ``requires_images = False`` - locomotion controls from joint state + base IMU,
+  never camera frames.
+* ``get_actions`` reads the goal from the well-known locomotion ``**kwargs``
+  (``target_velocity = [vx, vy, omega]``, optional ``target_orientation``).
+* The controller drives the **15 leg+waist DOFs** of the Unitree G1; the arm
+  joints are held at their nominal defaults. Layering an upper-body policy on
+  top is the job of a future ``CompositePolicy`` (#468), out of scope here.
+
+Requires the ``[wbc]`` extra (``onnxruntime``); no model weights are bundled
+(fetched at runtime under the NVIDIA Open Model License). See issue #466.
+"""
+
+from strands_robots.policies.wbc.config import WBCConfig
+from strands_robots.policies.wbc.policy import WBC_G1_LEG_WAIST_JOINTS, WBCPolicy
+
+__all__ = [
+    "WBCPolicy",
+    "WBCConfig",
+    "WBC_G1_LEG_WAIST_JOINTS",
+]

--- a/strands_robots/policies/wbc/__init__.py
+++ b/strands_robots/policies/wbc/__init__.py
@@ -19,10 +19,11 @@ Requires the ``[wbc]`` extra (``onnxruntime``); no model weights are bundled
 """
 
 from strands_robots.policies.wbc.config import WBCConfig
-from strands_robots.policies.wbc.policy import WBC_G1_LEG_WAIST_JOINTS, WBCPolicy
+from strands_robots.policies.wbc.policy import WBC_G1_ALL_JOINTS, WBC_G1_LEG_WAIST_JOINTS, WBCPolicy
 
 __all__ = [
     "WBCPolicy",
     "WBCConfig",
     "WBC_G1_LEG_WAIST_JOINTS",
+    "WBC_G1_ALL_JOINTS",
 ]

--- a/strands_robots/policies/wbc/config.py
+++ b/strands_robots/policies/wbc/config.py
@@ -19,19 +19,30 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-# Upstream defaults from the GR00T-WholeBodyControl reference controller.
-# ``single_obs_dim`` is fixed by the controller's observation layout
-# (see strands_robots.policies.wbc.observation.build_wbc_observation):
-#   7 command + 3 base ang-vel + 3 projected-gravity + n qj + n dqj + 15 prev-action
-# For the 15-DOF leg+waist controller (n = 15) this is 7+3+3+15+15+15 = 58 ...
-# but the reference stacks additional gait/style fields into the command block
-# to reach single_obs_dim = 86. The exact width is therefore taken from the
-# config (``single_obs_dim``) rather than recomputed, so a checkpoint trained
-# with a different command width loads without code changes.
+# Upstream defaults from the GR00T-WholeBodyControl reference controller
+# (decoupled_wbc/sim2mujoco: run_mujoco_gear_wbc.py + resources/robots/g1/
+# g1_gear_wbc.yaml). The ``single_obs_dim`` is fixed by the controller's
+# observation layout (compute_observation, single_obs_dim = 86):
+#   command(7) + base_ang_vel(3) + projected_gravity(3) + qj(n) + dqj(n) + action(15)
+# For n = 15 that is 7+3+3+15+15+15 = 58 populated values; indices [58:86] are
+# reserved (the reference leaves them zero - a clock/gait slot the shipped
+# checkpoint does not use). The exact width is taken from the config rather
+# than recomputed so a checkpoint with a different command width still loads.
+#
+# The command block (7) is NOT just zero-padded velocity - per
+# compute_observation it is:
+#   command[0:3] = loco_cmd[:3] * cmd_scale      (velocity, scaled)
+#   command[3]   = height_cmd                    (target base height)
+#   command[4:7] = rpy_cmd                       (target roll/pitch/yaw)
 _DEFAULT_SINGLE_OBS_DIM = 86
 _DEFAULT_NUM_ACTIONS = 15
-_DEFAULT_OBS_HISTORY_LEN = 1
+# Upstream g1_gear_wbc.yaml: obs_history_len=6 (num_obs = 86*6 = 516).
+_DEFAULT_OBS_HISTORY_LEN = 6
 _DEFAULT_COMMAND_DIM = 7
+# Upstream cmd_scale applied to [vx, vy, omega] and the default base-height
+# command, from g1_gear_wbc.yaml.
+_DEFAULT_CMD_SCALE = (2.0, 2.0, 0.5)
+_DEFAULT_HEIGHT_CMD = 0.74
 
 
 @dataclass(frozen=True)
@@ -57,13 +68,25 @@ class WBCConfig:
         action_scale: Scale applied to the raw ONNX output before it becomes a
             joint-position offset (upstream ``action_scale``).
         obs_scales: Named scale factors applied to observation sub-vectors
-            (``ang_vel`` / ``dof_pos`` / ``dof_vel``). Defaults match upstream.
+            (``ang_vel`` / ``dof_pos`` / ``dof_vel``). Defaults match upstream
+            g1_gear_wbc.yaml (ang_vel_scale=0.5, dof_pos_scale=1.0,
+            dof_vel_scale=0.05).
+        cmd_scale: Scale applied to the ``[vx, vy, omega]`` velocity command
+            before it enters the observation's command block (upstream
+            ``cmd_scale = [2.0, 2.0, 0.5]``).
+        height_cmd: Default target base height written to command slot [3]
+            (upstream ``height_cmd = 0.74``). Overridable per call via the
+            ``height`` kwarg.
+        rpy_cmd: Default target roll/pitch/yaw written to command slots [4:7]
+            (upstream ``rpy_cmd = [0, 0, 0]``). Overridable per call via the
+            ``target_orientation`` kwarg.
         single_obs_dim: Width of one observation frame (before history
             stacking). Default 86 (upstream GEAR-SONIC).
         obs_history_len: Number of frames stacked into the network input.
+            Default 6 (upstream num_obs = 86 * 6 = 516).
         num_actions: Number of controllable joints (legs + waist). Default 15.
         command_dim: Width of the command sub-vector at the head of the
-            observation. Default 7 (vx, vy, omega + 4 gait/style fields).
+            observation. Default 7 (velocity[3] + height[1] + rpy[3]).
     """
 
     policy_path: str
@@ -73,7 +96,10 @@ class WBCConfig:
     kps: list[float] = field(default_factory=list)
     kds: list[float] = field(default_factory=list)
     action_scale: float = 0.25
-    obs_scales: dict[str, float] = field(default_factory=lambda: {"ang_vel": 0.25, "dof_pos": 1.0, "dof_vel": 0.05})
+    obs_scales: dict[str, float] = field(default_factory=lambda: {"ang_vel": 0.5, "dof_pos": 1.0, "dof_vel": 0.05})
+    cmd_scale: list[float] = field(default_factory=lambda: list(_DEFAULT_CMD_SCALE))
+    height_cmd: float = _DEFAULT_HEIGHT_CMD
+    rpy_cmd: list[float] = field(default_factory=lambda: [0.0, 0.0, 0.0])
     single_obs_dim: int = _DEFAULT_SINGLE_OBS_DIM
     obs_history_len: int = _DEFAULT_OBS_HISTORY_LEN
     num_actions: int = _DEFAULT_NUM_ACTIONS

--- a/strands_robots/policies/wbc/config.py
+++ b/strands_robots/policies/wbc/config.py
@@ -19,6 +19,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from strands_robots.utils import require_optional
+
 # Upstream defaults from the GR00T-WholeBodyControl reference controller
 # (decoupled_wbc/sim2mujoco: run_mujoco_gear_wbc.py + resources/robots/g1/
 # g1_gear_wbc.yaml). The ``single_obs_dim`` is fixed by the controller's
@@ -130,6 +132,16 @@ class WBCConfig:
                     "they must match (or leave the field empty to use defaults)."
                 )
 
+        # cmd_scale scales the [vx, vy, omega] velocity command, so it must have
+        # exactly 3 entries when provided (upstream cmd_scale = [2.0, 2.0, 0.5]).
+        # A wrong length is rejected rather than silently tolerated, matching the
+        # per-joint vectors above.
+        if self.cmd_scale and len(self.cmd_scale) != 3:
+            raise ValueError(
+                f"WBCConfig.cmd_scale must have exactly 3 entries [vx, vy, omega] scale, "
+                f"got {len(self.cmd_scale)}: {self.cmd_scale}."
+            )
+
     @property
     def num_obs(self) -> int:
         """Total network input width = ``single_obs_dim * obs_history_len``."""
@@ -140,33 +152,71 @@ class WBCConfig:
         """Build a :class:`WBCConfig` from a plain dict.
 
         Only recognised keys are consumed; unknown keys are ignored (forward
-        compatibility with richer upstream config files). ``policy_path`` is
-        required.
+        compatibility with the richer upstream config, which also carries
+        ``simulation_dt`` / ``control_decimation`` / ``cmd_init`` / ``freq_cmd``
+        / ``xml_path`` etc.). ``policy_path`` is required.
+
+        The upstream ``g1_gear_wbc.yaml`` specifies the observation scales as
+        FLAT keys (``ang_vel_scale`` / ``dof_pos_scale`` / ``dof_vel_scale``)
+        rather than a nested ``obs_scales`` map. Those flat keys are normalised
+        into ``obs_scales`` here so the upstream config loads unchanged. An
+        explicit ``obs_scales`` map, if present, takes precedence.
         """
         if "policy_path" not in data:
             raise ValueError("WBCConfig requires a 'policy_path' entry")
+
+        data = dict(data)  # shallow copy - don't mutate the caller's dict
+
+        # Normalise upstream flat scale keys into the nested obs_scales map.
+        _flat_scale_keys = {"ang_vel": "ang_vel_scale", "dof_pos": "dof_pos_scale", "dof_vel": "dof_vel_scale"}
+        flat_scales = {
+            short: float(data[flat]) for short, flat in _flat_scale_keys.items() if data.get(flat) is not None
+        }
+        if flat_scales:
+            merged = dict(flat_scales)
+            # An explicit obs_scales map wins over the flat keys it overlaps.
+            if isinstance(data.get("obs_scales"), dict):
+                merged.update(data["obs_scales"])
+            data["obs_scales"] = merged
+
         known = {f.name for f in cls.__dataclass_fields__.values()}  # type: ignore[attr-defined]
         kwargs = {k: v for k, v in data.items() if k in known}
         return cls(**kwargs)
 
     @classmethod
     def from_file(cls, path: str | Path) -> WBCConfig:
-        """Load a :class:`WBCConfig` from a JSON file.
+        """Load a :class:`WBCConfig` from a JSON or YAML file.
+
+        ``.json`` parses with the stdlib; ``.yaml`` / ``.yml`` parse with
+        ``pyyaml`` (optional - install ``strands-robots[wbc]`` or ``pyyaml``).
+        YAML support lets the policy consume the upstream ``g1_gear_wbc.yaml``
+        directly. The upstream YAML uses flat scale keys
+        (``ang_vel_scale`` / ``dof_pos_scale`` / ``dof_vel_scale``) rather than a
+        nested ``obs_scales`` map; :meth:`from_dict` normalises those.
 
         Raises:
             FileNotFoundError: If ``path`` does not exist.
-            ValueError: If the file is not valid JSON or is missing
-                ``policy_path``.
+            ValueError: If the file is not valid JSON/YAML, has an unsupported
+                extension, or is missing ``policy_path``.
+            ImportError: If a YAML file is given but ``pyyaml`` is not installed.
         """
         p = Path(path).expanduser()
         if not p.is_file():
             raise FileNotFoundError(f"WBCConfig file not found: {p}")
-        try:
-            data = json.loads(p.read_text())
-        except json.JSONDecodeError as e:
-            raise ValueError(f"WBCConfig file {p} is not valid JSON: {e}") from e
+        text = p.read_text()
+        suffix = p.suffix.lower()
+        if suffix == ".json":
+            try:
+                data = json.loads(text)
+            except json.JSONDecodeError as e:
+                raise ValueError(f"WBCConfig file {p} is not valid JSON: {e}") from e
+        elif suffix in (".yaml", ".yml"):
+            yaml = require_optional("yaml", pip_install="pyyaml", extra="wbc", purpose="WBCConfig YAML loading")
+            data = yaml.safe_load(text)  # type: ignore[attr-defined]
+        else:
+            raise ValueError(f"WBCConfig file {p} has unsupported extension {suffix!r}; use .json, .yaml, or .yml.")
         if not isinstance(data, dict):
-            raise ValueError(f"WBCConfig file {p} must contain a JSON object, got {type(data).__name__}")
+            raise ValueError(f"WBCConfig file {p} must contain a mapping, got {type(data).__name__}")
         return cls.from_dict(data)
 
 

--- a/strands_robots/policies/wbc/config.py
+++ b/strands_robots/policies/wbc/config.py
@@ -1,0 +1,147 @@
+"""WBCConfig - configuration for the GR00T Whole-Body-Control (SONIC) policy.
+
+The upstream ``GearWbcController`` reference runner
+(``decoupled_wbc/sim2mujoco/scripts/run_mujoco_gear_wbc.py``) is config-driven:
+a JSON/YAML file supplies the ONNX checkpoint paths, the per-joint PD gains,
+the default joint angles, and the observation/action dimensions. This module
+captures that contract as a frozen :class:`WBCConfig` dataclass plus a loader
+that reads it from a JSON file or an in-memory dict.
+
+Keeping the config as a typed dataclass (rather than passing a raw dict around)
+means dimension/shape mistakes surface at construction with a clear message,
+not as an opaque ONNX shape error mid-rollout.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# Upstream defaults from the GR00T-WholeBodyControl reference controller.
+# ``single_obs_dim`` is fixed by the controller's observation layout
+# (see strands_robots.policies.wbc.observation.build_wbc_observation):
+#   7 command + 3 base ang-vel + 3 projected-gravity + n qj + n dqj + 15 prev-action
+# For the 15-DOF leg+waist controller (n = 15) this is 7+3+3+15+15+15 = 58 ...
+# but the reference stacks additional gait/style fields into the command block
+# to reach single_obs_dim = 86. The exact width is therefore taken from the
+# config (``single_obs_dim``) rather than recomputed, so a checkpoint trained
+# with a different command width loads without code changes.
+_DEFAULT_SINGLE_OBS_DIM = 86
+_DEFAULT_NUM_ACTIONS = 15
+_DEFAULT_OBS_HISTORY_LEN = 1
+_DEFAULT_COMMAND_DIM = 7
+
+
+@dataclass(frozen=True)
+class WBCConfig:
+    """Typed configuration for :class:`~strands_robots.policies.wbc.policy.WBCPolicy`.
+
+    Mirrors the fields the upstream ``GearWbcController`` config file supplies.
+    All sequence fields are stored as plain ``list[float]`` (JSON-friendly);
+    the policy converts them to NumPy arrays once at construction.
+
+    Attributes:
+        policy_path: Path to the main locomotion ONNX policy.
+        walk_policy_path: Path to the walk ONNX policy. ``None`` when the
+            checkpoint ships a single policy (``walk=False`` on the policy).
+        xml_path: Optional MuJoCo XML the checkpoint was trained against.
+            Informational only - the policy drives whatever robot the sim
+            backend loaded; recorded here for provenance / validation.
+        default_angles: Per-joint default (nominal stance) angles, length
+            ``num_actions``. Subtracted from measured ``qj`` in the observation
+            and added back to the ONNX target offset to form absolute targets.
+        kps: Per-joint proportional gains, length ``num_actions``.
+        kds: Per-joint derivative gains, length ``num_actions``.
+        action_scale: Scale applied to the raw ONNX output before it becomes a
+            joint-position offset (upstream ``action_scale``).
+        obs_scales: Named scale factors applied to observation sub-vectors
+            (``ang_vel`` / ``dof_pos`` / ``dof_vel``). Defaults match upstream.
+        single_obs_dim: Width of one observation frame (before history
+            stacking). Default 86 (upstream GEAR-SONIC).
+        obs_history_len: Number of frames stacked into the network input.
+        num_actions: Number of controllable joints (legs + waist). Default 15.
+        command_dim: Width of the command sub-vector at the head of the
+            observation. Default 7 (vx, vy, omega + 4 gait/style fields).
+    """
+
+    policy_path: str
+    walk_policy_path: str | None = None
+    xml_path: str | None = None
+    default_angles: list[float] = field(default_factory=list)
+    kps: list[float] = field(default_factory=list)
+    kds: list[float] = field(default_factory=list)
+    action_scale: float = 0.25
+    obs_scales: dict[str, float] = field(default_factory=lambda: {"ang_vel": 0.25, "dof_pos": 1.0, "dof_vel": 0.05})
+    single_obs_dim: int = _DEFAULT_SINGLE_OBS_DIM
+    obs_history_len: int = _DEFAULT_OBS_HISTORY_LEN
+    num_actions: int = _DEFAULT_NUM_ACTIONS
+    command_dim: int = _DEFAULT_COMMAND_DIM
+
+    def __post_init__(self) -> None:
+        # Fail-fast on dimension mistakes (AGENTS.md #5: raise on fatal errors,
+        # never warn-and-continue with a config that will misbehave later).
+        if self.num_actions < 1:
+            raise ValueError(f"WBCConfig.num_actions must be >= 1, got {self.num_actions}")
+        if self.obs_history_len < 1:
+            raise ValueError(f"WBCConfig.obs_history_len must be >= 1, got {self.obs_history_len}")
+        if self.single_obs_dim < 1:
+            raise ValueError(f"WBCConfig.single_obs_dim must be >= 1, got {self.single_obs_dim}")
+        if self.command_dim < 3:
+            # Need at least [vx, vy, omega].
+            raise ValueError(f"WBCConfig.command_dim must be >= 3 (vx, vy, omega), got {self.command_dim}")
+
+        # Per-joint vectors, when provided, must match num_actions. They are
+        # allowed to be empty (the policy then falls back to zeros / unit gains
+        # with a warning), but a *wrong* non-empty length is a hard error - it
+        # almost certainly means the config was paired with the wrong checkpoint.
+        for name in ("default_angles", "kps", "kds"):
+            vec = getattr(self, name)
+            if vec and len(vec) != self.num_actions:
+                raise ValueError(
+                    f"WBCConfig.{name} has length {len(vec)} but num_actions={self.num_actions}; "
+                    "they must match (or leave the field empty to use defaults)."
+                )
+
+    @property
+    def num_obs(self) -> int:
+        """Total network input width = ``single_obs_dim * obs_history_len``."""
+        return self.single_obs_dim * self.obs_history_len
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> WBCConfig:
+        """Build a :class:`WBCConfig` from a plain dict.
+
+        Only recognised keys are consumed; unknown keys are ignored (forward
+        compatibility with richer upstream config files). ``policy_path`` is
+        required.
+        """
+        if "policy_path" not in data:
+            raise ValueError("WBCConfig requires a 'policy_path' entry")
+        known = {f.name for f in cls.__dataclass_fields__.values()}  # type: ignore[attr-defined]
+        kwargs = {k: v for k, v in data.items() if k in known}
+        return cls(**kwargs)
+
+    @classmethod
+    def from_file(cls, path: str | Path) -> WBCConfig:
+        """Load a :class:`WBCConfig` from a JSON file.
+
+        Raises:
+            FileNotFoundError: If ``path`` does not exist.
+            ValueError: If the file is not valid JSON or is missing
+                ``policy_path``.
+        """
+        p = Path(path).expanduser()
+        if not p.is_file():
+            raise FileNotFoundError(f"WBCConfig file not found: {p}")
+        try:
+            data = json.loads(p.read_text())
+        except json.JSONDecodeError as e:
+            raise ValueError(f"WBCConfig file {p} is not valid JSON: {e}") from e
+        if not isinstance(data, dict):
+            raise ValueError(f"WBCConfig file {p} must contain a JSON object, got {type(data).__name__}")
+        return cls.from_dict(data)
+
+
+__all__ = ["WBCConfig"]

--- a/strands_robots/policies/wbc/config.py
+++ b/strands_robots/policies/wbc/config.py
@@ -25,11 +25,15 @@ from strands_robots.utils import require_optional
 # (decoupled_wbc/sim2mujoco: run_mujoco_gear_wbc.py + resources/robots/g1/
 # g1_gear_wbc.yaml). The ``single_obs_dim`` is fixed by the controller's
 # observation layout (compute_observation, single_obs_dim = 86):
-#   command(7) + base_ang_vel(3) + projected_gravity(3) + qj(n) + dqj(n) + action(15)
-# For n = 15 that is 7+3+3+15+15+15 = 58 populated values; indices [58:86] are
-# reserved (the reference leaves them zero - a clock/gait slot the shipped
-# checkpoint does not use). The exact width is taken from the config rather
-# than recomputed so a checkpoint with a different command width still loads.
+#   command(7) + base_ang_vel(3) + projected_gravity(3)
+#     + qj(n_obs_joints) + dqj(n_obs_joints) + action(num_actions)
+# CRITICAL: qj/dqj observe ALL the robot's joints (upstream ``n_joints`` =
+# nq - 7 = 29 for the G1), NOT just the 15 controlled leg+waist joints. The
+# action block is the num_actions (15) leg+waist outputs. So:
+#   7 + 3 + 3 + 29 + 29 + 15 = 86.  (Using 15 for qj/dqj would give 58 and put
+# the data in the wrong slots - the network would see a malformed observation
+# even though the total 516 width still loads.)
+_DEFAULT_N_OBS_JOINTS = 29
 #
 # The command block (7) is NOT just zero-padded velocity - per
 # compute_observation it is:
@@ -89,6 +93,11 @@ class WBCConfig:
         num_actions: Number of controllable joints (legs + waist). Default 15.
         command_dim: Width of the command sub-vector at the head of the
             observation. Default 7 (velocity[3] + height[1] + rpy[3]).
+        n_obs_joints: Number of joints OBSERVED in the qj/dqj blocks - the
+            robot's full joint count (upstream ``n_joints`` = nq - 7 = 29 for
+            the G1), NOT ``num_actions``. The controller observes the whole body
+            (legs + waist + arms) but only drives the first ``num_actions`` (15)
+            leg+waist joints. Default 29.
     """
 
     policy_path: str
@@ -105,6 +114,7 @@ class WBCConfig:
     single_obs_dim: int = _DEFAULT_SINGLE_OBS_DIM
     obs_history_len: int = _DEFAULT_OBS_HISTORY_LEN
     num_actions: int = _DEFAULT_NUM_ACTIONS
+    n_obs_joints: int = _DEFAULT_N_OBS_JOINTS
     command_dim: int = _DEFAULT_COMMAND_DIM
 
     def __post_init__(self) -> None:
@@ -119,6 +129,13 @@ class WBCConfig:
         if self.command_dim < 3:
             # Need at least [vx, vy, omega].
             raise ValueError(f"WBCConfig.command_dim must be >= 3 (vx, vy, omega), got {self.command_dim}")
+        if self.n_obs_joints < self.num_actions:
+            # The controller observes all joints (legs+waist+arms) but drives the
+            # first num_actions; observing fewer than it drives is impossible.
+            raise ValueError(
+                f"WBCConfig.n_obs_joints ({self.n_obs_joints}) must be >= num_actions ({self.num_actions}); "
+                "qj/dqj observe the whole body, action drives the leg+waist subset."
+            )
 
         # Per-joint vectors, when provided, must match num_actions. They are
         # allowed to be empty (the policy then falls back to zeros / unit gains

--- a/strands_robots/policies/wbc/control.py
+++ b/strands_robots/policies/wbc/control.py
@@ -1,0 +1,153 @@
+"""Pure-NumPy control + quaternion helpers for the WBC policy.
+
+These functions reproduce the math in NVIDIA's GR00T-WholeBodyControl reference
+controller (``decoupled_wbc/sim2mujoco``) with no torch / onnxruntime
+dependency, so they are unit-testable against hand-computed values on any
+machine (issue #466 acceptance criterion: "PD-control + quat helpers match
+hand-computed values").
+
+Conventions:
+* Quaternions are ``[w, x, y, z]`` (scalar-first), matching MuJoCo's
+  ``data.qpos`` free-joint layout and the upstream controller.
+* The gravity vector points down: ``g = [0, 0, -1]`` in the world frame.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+# World-frame gravity direction (unit, pointing down). The controller feeds the
+# *projected* gravity (this vector rotated into the robot base frame) to the
+# network as a 3-vector orientation cue.
+_GRAVITY_DIR = np.array([0.0, 0.0, -1.0], dtype=np.float64)
+
+
+def pd_control(
+    target_q: NDArray[np.float64],
+    q: NDArray[np.float64],
+    kp: NDArray[np.float64],
+    target_dq: NDArray[np.float64],
+    dq: NDArray[np.float64],
+    kd: NDArray[np.float64],
+) -> NDArray[np.float64]:
+    """Per-joint PD torque law: ``tau = (target_q - q) * kp + (target_dq - dq) * kd``.
+
+    This is the exact law the upstream reference loop writes to
+    ``data.ctrl[:15]`` (torque actuators). All arguments are 1-D arrays of the
+    same length (``num_actions``); the return is the same shape.
+
+    Args:
+        target_q: Desired joint positions.
+        q: Measured joint positions.
+        kp: Proportional gains (per joint).
+        target_dq: Desired joint velocities (usually zeros for a position hold).
+        dq: Measured joint velocities.
+        kd: Derivative gains (per joint).
+
+    Returns:
+        Joint torques, same shape as the inputs.
+
+    Raises:
+        ValueError: If the input arrays do not all share one length.
+    """
+    arrays = {"target_q": target_q, "q": q, "kp": kp, "target_dq": target_dq, "dq": dq, "kd": kd}
+    lengths = {name: np.asarray(a).shape for name, a in arrays.items()}
+    n = np.asarray(target_q).shape
+    if any(shape != n for shape in lengths.values()):
+        raise ValueError(f"pd_control: all inputs must share one shape; got {lengths}")
+    return (np.asarray(target_q) - np.asarray(q)) * np.asarray(kp) + (
+        np.asarray(target_dq) - np.asarray(dq)
+    ) * np.asarray(kd)
+
+
+def compute_targets(
+    default_angles: NDArray[np.float64],
+    raw_action: NDArray[np.float64],
+    action_scale: float,
+) -> NDArray[np.float64]:
+    """Convert a raw network action (joint-position offset) to absolute targets.
+
+    ``target_q = default_angles + action_scale * raw_action`` - the exact form
+    the upstream reference controller uses before the PD law turns targets into
+    torques. Pulled into ``control`` (rather than the policy) so it is covered
+    by the same hand-computed unit tests as :func:`pd_control`.
+
+    Args:
+        default_angles: Per-joint nominal stance angles.
+        raw_action: Raw ONNX output (per-joint offset).
+        action_scale: Scalar applied to the offset (upstream ``action_scale``).
+
+    Returns:
+        Absolute joint-position targets, same shape as the inputs.
+
+    Raises:
+        ValueError: If ``default_angles`` and ``raw_action`` differ in shape.
+    """
+    d = np.asarray(default_angles, dtype=np.float64)
+    r = np.asarray(raw_action, dtype=np.float64)
+    if d.shape != r.shape:
+        raise ValueError(f"compute_targets: default_angles {d.shape} and raw_action {r.shape} must match")
+    return d + float(action_scale) * r
+
+
+def quat_rotate_inverse(quat_wxyz: NDArray[np.float64], vec: NDArray[np.float64]) -> NDArray[np.float64]:
+    """Rotate ``vec`` from the world frame into the body frame given ``quat``.
+
+    Computes ``R(q)^T @ vec`` where ``R(q)`` is the rotation matrix of the
+    scalar-first quaternion ``q = [w, x, y, z]``. This is the standard
+    "rotate by the inverse" used to express a world-frame vector in the body
+    frame, matching the upstream controller's ``quat_rotate_inverse``.
+
+    Args:
+        quat_wxyz: Body orientation quaternion ``[w, x, y, z]`` (need not be
+            exactly unit; it is normalised internally).
+        vec: World-frame 3-vector.
+
+    Returns:
+        The 3-vector expressed in the body frame.
+
+    Raises:
+        ValueError: If ``quat_wxyz`` is not length 4 or ``vec`` is not length 3,
+            or the quaternion has ~zero norm.
+    """
+    q = np.asarray(quat_wxyz, dtype=np.float64)
+    v = np.asarray(vec, dtype=np.float64)
+    if q.shape != (4,):
+        raise ValueError(f"quat_rotate_inverse: quat must be length-4 [w,x,y,z], got shape {q.shape}")
+    if v.shape != (3,):
+        raise ValueError(f"quat_rotate_inverse: vec must be length-3, got shape {v.shape}")
+    norm = float(np.linalg.norm(q))
+    if norm < 1e-8:
+        raise ValueError("quat_rotate_inverse: quaternion has ~zero norm; cannot normalise")
+    q = q / norm
+    w, x, y, z = q
+
+    # Standard derivation (Rodrigues form used by IsaacGym/Lab and the upstream
+    # WBC controller). For inverse rotation the cross-product term flips sign
+    # relative to the forward rotation.
+    q_vec = np.array([x, y, z], dtype=np.float64)
+    a = v * (2.0 * w * w - 1.0)
+    b = np.cross(q_vec, v) * w * 2.0
+    c = q_vec * (np.dot(q_vec, v) * 2.0)
+    return a - b + c
+
+
+def projected_gravity(quat_wxyz: NDArray[np.float64]) -> NDArray[np.float64]:
+    """Return the world gravity direction expressed in the body frame.
+
+    This is the 3-vector orientation cue the WBC network consumes at
+    observation indices ``[10:13]`` (upstream). For an upright base it is
+    approximately ``[0, 0, -1]``; tilting the base rotates the vector,
+    giving the policy a gravity-aligned attitude signal without a full IMU.
+
+    Args:
+        quat_wxyz: Body orientation quaternion ``[w, x, y, z]``.
+
+    Returns:
+        Gravity direction in the body frame (unit 3-vector).
+    """
+    return quat_rotate_inverse(quat_wxyz, _GRAVITY_DIR)
+
+
+__all__ = ["pd_control", "compute_targets", "quat_rotate_inverse", "projected_gravity"]

--- a/strands_robots/policies/wbc/observation.py
+++ b/strands_robots/policies/wbc/observation.py
@@ -114,10 +114,13 @@ def _require_len(vec: NDArray[np.float64], n: int, name: str) -> NDArray[np.floa
 class ObservationHistory:
     """Fixed-length history of observation frames, stacked into the network input.
 
-    Wraps a ``deque(maxlen=obs_history_len)``. On the first push the buffer is
-    pre-filled with copies of the first frame so the network always sees a
-    full-width input (no zero-frames at episode start, matching the upstream
-    controller's warm-start). The stacked vector is oldest-frame-first.
+    Wraps a ``deque(maxlen=obs_history_len)`` warm-started with ZERO frames,
+    matching the upstream reference exactly (run_mujoco_gear_wbc.py:47-50 inits
+    the deque with ``[np.zeros(single_obs_dim)] * obs_history_len`` then appends
+    the live frame each tick). So for the first ``obs_history_len - 1`` ticks the
+    older history slots hold zeros, not copies of the first frame - the network
+    sees the same warm-start transient the reference controller was validated
+    with. The stacked vector is oldest-frame-first.
     """
 
     def __init__(self, config: WBCConfig) -> None:
@@ -125,25 +128,36 @@ class ObservationHistory:
         self._single_dim = config.single_obs_dim
         self._num_obs = config.num_obs
         self._buffer: deque[NDArray[np.float64]] = deque(maxlen=self._maxlen)
+        self._fill_zeros()
+
+    def _fill_zeros(self) -> None:
+        """Pre-fill the deque with ``obs_history_len`` zero-frames (upstream warm-start)."""
+        zero = np.zeros(self._single_dim, dtype=np.float64)
+        for _ in range(self._maxlen):
+            self._buffer.append(zero.copy())
 
     def reset(self) -> None:
-        """Clear the history (call at episode boundaries)."""
+        """Reset the history to the zero warm-start (call at episode boundaries).
+
+        Matches a fresh controller: the deque is re-seeded with zero-frames so
+        the next ``obs_history_len - 1`` pushes reproduce the upstream
+        zero-warm-start transient (not a stale rolling window from the prior
+        episode).
+        """
         self._buffer.clear()
+        self._fill_zeros()
 
     def push(self, frame: NDArray[np.float64]) -> NDArray[np.float64]:
-        """Append ``frame`` and return the stacked ``(num_obs,)`` network input.
+        """Append ``frame`` (evicting the oldest) and return the stacked input.
 
-        On the first push the buffer is filled with ``obs_history_len`` copies
-        of ``frame`` so the output is immediately full-width.
+        The buffer is always full (zero-warm-started), so the returned vector is
+        immediately ``num_obs`` wide. Oldest frame first; on early ticks the
+        older slots are still the zero warm-start frames.
         """
         frame = np.asarray(frame, dtype=np.float64).ravel()
         if frame.shape[0] != self._single_dim:
             raise ValueError(f"frame must have length single_obs_dim={self._single_dim}, got {frame.shape[0]}")
-        if not self._buffer:
-            for _ in range(self._maxlen):
-                self._buffer.append(frame.copy())
-        else:
-            self._buffer.append(frame)
+        self._buffer.append(frame)
         stacked = np.concatenate(list(self._buffer))
         if stacked.shape[0] != self._num_obs:
             raise ValueError(f"stacked obs width {stacked.shape[0]} != num_obs {self._num_obs}")

--- a/strands_robots/policies/wbc/observation.py
+++ b/strands_robots/policies/wbc/observation.py
@@ -1,22 +1,29 @@
 """Observation builder for the WBC policy.
 
 Reproduces the observation layout of NVIDIA's GR00T-WholeBodyControl reference
-controller. One observation *frame* is laid out as (for ``n = num_actions``,
-``c = command_dim``)::
+controller. One observation *frame* is laid out as (for ``no = n_obs_joints``,
+``na = num_actions``, ``c = command_dim``)::
 
-    [0       : c        ]  command  (vx, vy, omega, + gait/style fields)
-    [c       : c+3      ]  base angular velocity      (scaled by obs_scales.ang_vel)
-    [c+3     : c+6      ]  projected gravity          (orientation cue, unscaled)
-    [c+6     : c+6+n    ]  joint positions qj         (defaults subtracted, * dof_pos)
-    [c+6+n   : c+6+2n   ]  joint velocities dqj       (scaled by obs_scales.dof_vel)
-    [c+6+2n  : c+6+2n+n ]  previous action            (n-dim)
+    [0         : c          ]  command  [vx*s, vy*s, omega*s, height, roll, pitch, yaw]
+    [c         : c+3        ]  base angular velocity   (scaled by obs_scales.ang_vel)
+    [c+3       : c+6        ]  projected gravity        (orientation cue, unscaled)
+    [c+6       : c+6+no     ]  joint positions qj       (defaults subtracted, * dof_pos)
+    [c+6+no    : c+6+2no    ]  joint velocities dqj     (scaled by obs_scales.dof_vel)
+    [c+6+2no   : c+6+2no+na ]  previous action          (na-dim, the controlled set)
 
-With the upstream GEAR-SONIC defaults (c=7, n=15) that is
-7 + 3 + 3 + 15 + 15 + 15 = 58 populated values; the remaining width up to
-``single_obs_dim`` (86) is zero-padded so a checkpoint trained with extra
-command/style channels loads without code changes. The frame is then stacked
-over ``obs_history_len`` via a ``deque`` to form the ``num_obs``-wide network
-input (oldest frame first).
+CRITICAL: the qj/dqj blocks observe ALL the robot's joints (upstream
+``n_joints`` = nq-7 = 29 for the G1: legs + waist + arms), NOT just the
+``num_actions`` (15) controlled joints. The action block is the 15 leg+waist
+outputs. With the upstream GEAR-SONIC defaults (c=7, no=29, na=15) the populated
+width is 7 + 3 + 3 + 29 + 29 + 15 = 86 = ``single_obs_dim`` exactly (no padding).
+Using 15 for qj/dqj would populate only 58 and misplace the data - the network
+would see a malformed observation even though the 516 total still loads.
+
+``default_angles`` (length ``num_actions`` = 15) is zero-padded to ``no`` for
+the qj subtraction (arms have a zero nominal offset), matching upstream
+``padded_defaults``. The frame is stacked over ``obs_history_len`` via a
+``deque`` (zero-warm-started) to form the ``num_obs``-wide network input,
+oldest frame first.
 
 Pure NumPy - no torch / onnxruntime - so the layout is unit-testable on any
 machine (issue #466: "observation builder produces the exact 86-dim layout").
@@ -124,7 +131,9 @@ def build_single_frame(
     frame[c + 6 : c + 6 + no] = (qj - defaults) * dof_pos_scale
     frame[c + 6 + no : c + 6 + 2 * no] = dqj * dof_vel_scale
     frame[c + 6 + 2 * no : c + 6 + 2 * no + na] = prev_action
-    # Indices [end:single_obs_dim] remain zero (reserved clock/gait slot).
+    # For the default G1 config end == single_obs_dim (86), so no tail remains.
+    # If a config sets single_obs_dim > end, indices [end:single_obs_dim] stay
+    # zero (a reserved clock/gait slot the shipped checkpoint does not use).
     return frame
 
 

--- a/strands_robots/policies/wbc/observation.py
+++ b/strands_robots/policies/wbc/observation.py
@@ -48,14 +48,30 @@ def build_single_frame(
     from ``qj``, and writes each sub-vector at its fixed offset, zero-padding
     any remaining width.
 
+    Layout (matching upstream compute_observation, with ``no = n_obs_joints``,
+    ``na = num_actions``, ``c = command_dim``)::
+
+        [0 : c        ]  command
+        [c : c+3      ]  base angular velocity * ang_vel_scale
+        [c+3 : c+6    ]  projected gravity (UNSCALED)
+        [c+6 : c+6+no ]  (qj - default_angles) * dof_pos_scale   # ALL joints
+        [c+6+no : c+6+2no]  dqj * dof_vel_scale                  # ALL joints
+        [c+6+2no : c+6+2no+na]  previous action                 # controlled subset
+        [...remaining...]  reserved (zero)
+
+    For the G1 defaults (c=7, no=29, na=15) the populated width is
+    7+3+3+29+29+15 = 86 = single_obs_dim.
+
     Args:
         config: The policy config (dims, scales, default angles).
         command: Locomotion command, length ``command_dim``. Shorter inputs
             (e.g. just ``[vx, vy, omega]``) are zero-padded to ``command_dim``.
         base_ang_vel: Base angular velocity (rad/s), length 3.
         proj_gravity: Gravity direction in the body frame, length 3.
-        qj: Measured joint positions, length ``num_actions``.
-        dqj: Measured joint velocities, length ``num_actions``.
+        qj: Measured joint positions for ALL observed joints, length
+            ``n_obs_joints`` (29 for the G1 - legs+waist+arms, not just the
+            controlled subset).
+        dqj: Measured joint velocities, length ``n_obs_joints``.
         prev_action: Previous network action, length ``num_actions``.
 
     Returns:
@@ -65,7 +81,8 @@ def build_single_frame(
         ValueError: If any sub-vector has the wrong length, or the assembled
             frame would overflow ``single_obs_dim``.
     """
-    n = config.num_actions
+    no = config.n_obs_joints
+    na = config.num_actions
     c = config.command_dim
 
     command = np.asarray(command, dtype=np.float64).ravel()
@@ -77,30 +94,37 @@ def build_single_frame(
 
     base_ang_vel = _require_len(base_ang_vel, 3, "base_ang_vel")
     proj_gravity = _require_len(proj_gravity, 3, "proj_gravity")
-    qj = _require_len(qj, n, "qj")
-    dqj = _require_len(dqj, n, "dqj")
-    prev_action = _require_len(prev_action, n, "prev_action")
+    qj = _require_len(qj, no, "qj")
+    dqj = _require_len(dqj, no, "dqj")
+    prev_action = _require_len(prev_action, na, "prev_action")
 
-    defaults = np.asarray(config.default_angles, dtype=np.float64) if config.default_angles else np.zeros(n)
+    # default_angles is the controlled-joint nominal pose (length num_actions);
+    # the qj block spans all n_obs_joints, so pad defaults with zeros for the
+    # uncontrolled (arm) joints exactly as upstream does (padded_defaults).
+    defaults = np.zeros(no, dtype=np.float64)
+    if config.default_angles:
+        da = np.asarray(config.default_angles, dtype=np.float64)
+        limit = min(da.shape[0], no)
+        defaults[:limit] = da[:limit]
     ang_vel_scale = config.obs_scales.get("ang_vel", 1.0)
     dof_pos_scale = config.obs_scales.get("dof_pos", 1.0)
     dof_vel_scale = config.obs_scales.get("dof_vel", 1.0)
 
     frame = np.zeros(config.single_obs_dim, dtype=np.float64)
-    end = c + 6 + 3 * n
+    end = c + 6 + 2 * no + na
     if end > config.single_obs_dim:
         raise ValueError(
-            f"observation layout needs {end} values (command_dim={c}, num_actions={n}) "
-            f"but single_obs_dim={config.single_obs_dim}; raise single_obs_dim or check the config."
+            f"observation layout needs {end} values (command_dim={c}, n_obs_joints={no}, "
+            f"num_actions={na}) but single_obs_dim={config.single_obs_dim}; check the config."
         )
 
     frame[0:c] = command
     frame[c : c + 3] = base_ang_vel * ang_vel_scale
     frame[c + 3 : c + 6] = proj_gravity
-    frame[c + 6 : c + 6 + n] = (qj - defaults) * dof_pos_scale
-    frame[c + 6 + n : c + 6 + 2 * n] = dqj * dof_vel_scale
-    frame[c + 6 + 2 * n : c + 6 + 3 * n] = prev_action
-    # Indices [end:single_obs_dim] remain zero (gait/style padding).
+    frame[c + 6 : c + 6 + no] = (qj - defaults) * dof_pos_scale
+    frame[c + 6 + no : c + 6 + 2 * no] = dqj * dof_vel_scale
+    frame[c + 6 + 2 * no : c + 6 + 2 * no + na] = prev_action
+    # Indices [end:single_obs_dim] remain zero (reserved clock/gait slot).
     return frame
 
 

--- a/strands_robots/policies/wbc/observation.py
+++ b/strands_robots/policies/wbc/observation.py
@@ -1,0 +1,156 @@
+"""Observation builder for the WBC policy.
+
+Reproduces the observation layout of NVIDIA's GR00T-WholeBodyControl reference
+controller. One observation *frame* is laid out as (for ``n = num_actions``,
+``c = command_dim``)::
+
+    [0       : c        ]  command  (vx, vy, omega, + gait/style fields)
+    [c       : c+3      ]  base angular velocity      (scaled by obs_scales.ang_vel)
+    [c+3     : c+6      ]  projected gravity          (orientation cue, unscaled)
+    [c+6     : c+6+n    ]  joint positions qj         (defaults subtracted, * dof_pos)
+    [c+6+n   : c+6+2n   ]  joint velocities dqj       (scaled by obs_scales.dof_vel)
+    [c+6+2n  : c+6+2n+n ]  previous action            (n-dim)
+
+With the upstream GEAR-SONIC defaults (c=7, n=15) that is
+7 + 3 + 3 + 15 + 15 + 15 = 58 populated values; the remaining width up to
+``single_obs_dim`` (86) is zero-padded so a checkpoint trained with extra
+command/style channels loads without code changes. The frame is then stacked
+over ``obs_history_len`` via a ``deque`` to form the ``num_obs``-wide network
+input (oldest frame first).
+
+Pure NumPy - no torch / onnxruntime - so the layout is unit-testable on any
+machine (issue #466: "observation builder produces the exact 86-dim layout").
+"""
+
+from __future__ import annotations
+
+from collections import deque
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .config import WBCConfig
+
+
+def build_single_frame(
+    config: WBCConfig,
+    *,
+    command: NDArray[np.float64],
+    base_ang_vel: NDArray[np.float64],
+    proj_gravity: NDArray[np.float64],
+    qj: NDArray[np.float64],
+    dqj: NDArray[np.float64],
+    prev_action: NDArray[np.float64],
+) -> NDArray[np.float64]:
+    """Assemble one ``single_obs_dim``-wide observation frame.
+
+    Applies the upstream scaling (``obs_scales``), subtracts ``default_angles``
+    from ``qj``, and writes each sub-vector at its fixed offset, zero-padding
+    any remaining width.
+
+    Args:
+        config: The policy config (dims, scales, default angles).
+        command: Locomotion command, length ``command_dim``. Shorter inputs
+            (e.g. just ``[vx, vy, omega]``) are zero-padded to ``command_dim``.
+        base_ang_vel: Base angular velocity (rad/s), length 3.
+        proj_gravity: Gravity direction in the body frame, length 3.
+        qj: Measured joint positions, length ``num_actions``.
+        dqj: Measured joint velocities, length ``num_actions``.
+        prev_action: Previous network action, length ``num_actions``.
+
+    Returns:
+        A ``(single_obs_dim,)`` float64 array.
+
+    Raises:
+        ValueError: If any sub-vector has the wrong length, or the assembled
+            frame would overflow ``single_obs_dim``.
+    """
+    n = config.num_actions
+    c = config.command_dim
+
+    command = np.asarray(command, dtype=np.float64).ravel()
+    if command.shape[0] > c:
+        raise ValueError(f"command length {command.shape[0]} exceeds command_dim {c}")
+    # Right-pad a short command (e.g. [vx, vy, omega]) up to command_dim.
+    if command.shape[0] < c:
+        command = np.concatenate([command, np.zeros(c - command.shape[0], dtype=np.float64)])
+
+    base_ang_vel = _require_len(base_ang_vel, 3, "base_ang_vel")
+    proj_gravity = _require_len(proj_gravity, 3, "proj_gravity")
+    qj = _require_len(qj, n, "qj")
+    dqj = _require_len(dqj, n, "dqj")
+    prev_action = _require_len(prev_action, n, "prev_action")
+
+    defaults = np.asarray(config.default_angles, dtype=np.float64) if config.default_angles else np.zeros(n)
+    ang_vel_scale = config.obs_scales.get("ang_vel", 1.0)
+    dof_pos_scale = config.obs_scales.get("dof_pos", 1.0)
+    dof_vel_scale = config.obs_scales.get("dof_vel", 1.0)
+
+    frame = np.zeros(config.single_obs_dim, dtype=np.float64)
+    end = c + 6 + 3 * n
+    if end > config.single_obs_dim:
+        raise ValueError(
+            f"observation layout needs {end} values (command_dim={c}, num_actions={n}) "
+            f"but single_obs_dim={config.single_obs_dim}; raise single_obs_dim or check the config."
+        )
+
+    frame[0:c] = command
+    frame[c : c + 3] = base_ang_vel * ang_vel_scale
+    frame[c + 3 : c + 6] = proj_gravity
+    frame[c + 6 : c + 6 + n] = (qj - defaults) * dof_pos_scale
+    frame[c + 6 + n : c + 6 + 2 * n] = dqj * dof_vel_scale
+    frame[c + 6 + 2 * n : c + 6 + 3 * n] = prev_action
+    # Indices [end:single_obs_dim] remain zero (gait/style padding).
+    return frame
+
+
+def _require_len(vec: NDArray[np.float64], n: int, name: str) -> NDArray[np.float64]:
+    arr = np.asarray(vec, dtype=np.float64).ravel()
+    if arr.shape[0] != n:
+        raise ValueError(f"{name} must have length {n}, got {arr.shape[0]}")
+    return arr
+
+
+class ObservationHistory:
+    """Fixed-length history of observation frames, stacked into the network input.
+
+    Wraps a ``deque(maxlen=obs_history_len)``. On the first push the buffer is
+    pre-filled with copies of the first frame so the network always sees a
+    full-width input (no zero-frames at episode start, matching the upstream
+    controller's warm-start). The stacked vector is oldest-frame-first.
+    """
+
+    def __init__(self, config: WBCConfig) -> None:
+        self._maxlen = config.obs_history_len
+        self._single_dim = config.single_obs_dim
+        self._num_obs = config.num_obs
+        self._buffer: deque[NDArray[np.float64]] = deque(maxlen=self._maxlen)
+
+    def reset(self) -> None:
+        """Clear the history (call at episode boundaries)."""
+        self._buffer.clear()
+
+    def push(self, frame: NDArray[np.float64]) -> NDArray[np.float64]:
+        """Append ``frame`` and return the stacked ``(num_obs,)`` network input.
+
+        On the first push the buffer is filled with ``obs_history_len`` copies
+        of ``frame`` so the output is immediately full-width.
+        """
+        frame = np.asarray(frame, dtype=np.float64).ravel()
+        if frame.shape[0] != self._single_dim:
+            raise ValueError(f"frame must have length single_obs_dim={self._single_dim}, got {frame.shape[0]}")
+        if not self._buffer:
+            for _ in range(self._maxlen):
+                self._buffer.append(frame.copy())
+        else:
+            self._buffer.append(frame)
+        stacked = np.concatenate(list(self._buffer))
+        if stacked.shape[0] != self._num_obs:
+            raise ValueError(f"stacked obs width {stacked.shape[0]} != num_obs {self._num_obs}")
+        return stacked
+
+    def __len__(self) -> int:
+        return len(self._buffer)
+
+
+__all__ = ["build_single_frame", "ObservationHistory"]

--- a/strands_robots/policies/wbc/policy.py
+++ b/strands_robots/policies/wbc/policy.py
@@ -1,0 +1,604 @@
+"""WBCPolicy - GR00T Whole-Body-Control (SONIC) locomotion for the Unitree G1.
+
+A clean-room :class:`Policy` provider wrapping NVIDIA's GR00T Whole-Body-Control
+ONNX controllers (the SONIC / decoupled-WBC family) for deploy-grade humanoid
+locomotion. Upstream reference:
+https://github.com/NVlabs/GR00T-WholeBodyControl
+(``decoupled_wbc/sim2mujoco/scripts/run_mujoco_gear_wbc.py``).
+
+This is the locomotion / lower-body member of the non-VLA policy family
+(alongside cuRobo and MoveIt2): ``requires_images = False`` and the goal arrives
+through the well-known ``**kwargs`` locomotion keys rather than a natural-
+language instruction. The controller drives the **15 leg+waist DOFs**; the arm
+joints (16..n) are held at their nominal defaults. Layering an upper-body
+manipulation policy on top is the job of a future ``CompositePolicy`` (#468),
+deliberately out of scope here.
+
+Control contract (reproduced from the reference runner):
+
+* **Two ONNX sessions** - a main ``policy_path`` and an optional
+  ``walk_policy_path`` - loaded via ``onnxruntime.InferenceSession`` in
+  ``__init__`` (centralised dependency check per AGENTS.md). Missing
+  ``onnxruntime`` or a missing checkpoint raises ``RuntimeError`` - there is no
+  silent zero-torque fallback (explicit project rule, AGENTS.md #5/#6).
+* **Observation** - an 86-dim frame (command + base ang-vel + projected gravity
+  + scaled qj/dqj + previous action), stacked over ``obs_history_len`` via a
+  deque. See :mod:`strands_robots.policies.wbc.observation`.
+* **Action** - the network emits a 15-dim joint-position *offset*. The policy
+  forms absolute joint targets ``target_q = default_angles + action_scale *
+  raw`` and returns them as a one-element ``list[dict]`` keyed by the G1
+  leg+waist actuator names. Callers that drive torque-actuated MuJoCo convert
+  to torque via :meth:`compute_torques` (the upstream PD law).
+
+Usage through the sim backend::
+
+    sim.run_policy(
+        robot_name="unitree_g1", policy_provider="wbc",
+        policy_config={"checkpoint": ".../GEAR-SONIC", "walk": True},
+        policy_kwargs={"target_velocity": [0.5, 0.0, 0.0]},
+        duration=10.0, control_frequency=50.0,
+    )
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from strands_robots.policies.base import Policy
+from strands_robots.utils import require_optional
+
+from .config import WBCConfig
+from .control import compute_targets, pd_control, projected_gravity
+from .observation import ObservationHistory, build_single_frame
+
+logger = logging.getLogger(__name__)
+
+
+# Canonical Unitree G1 leg+waist actuator order (first 15 of the 29-DOF model).
+# Sourced from the MuJoCo Menagerie ``unitree_g1`` model and kept identical to
+# the ``unitree_g1`` state/action ordering already used by the lerobot_local
+# embodiment map, so a value the rest of the stack accepts flows end-to-end.
+# This is the EXPLICIT actuator <-> 15-dim WBC mapping required by #466
+# ("no positional guessing"): WBC output index i drives WBC_G1_LEG_WAIST_JOINTS[i].
+WBC_G1_LEG_WAIST_JOINTS: tuple[str, ...] = (
+    "left_hip_pitch_joint",
+    "left_hip_roll_joint",
+    "left_hip_yaw_joint",
+    "left_knee_joint",
+    "left_ankle_pitch_joint",
+    "left_ankle_roll_joint",
+    "right_hip_pitch_joint",
+    "right_hip_roll_joint",
+    "right_hip_yaw_joint",
+    "right_knee_joint",
+    "right_ankle_pitch_joint",
+    "right_ankle_roll_joint",
+    "waist_yaw_joint",
+    "waist_roll_joint",
+    "waist_pitch_joint",
+)
+
+# The HF repo the checkpoint is fetched from when ``checkpoint`` is a bare
+# model id rather than a local path. No weights are bundled; they are fetched
+# at runtime under the NVIDIA Open Model License.
+_DEFAULT_HF_REPO = "nvidia/GEAR-SONIC"
+
+# Default per-session ONNX filenames inside a checkpoint directory.
+_MAIN_POLICY_FILENAME = "policy.onnx"
+_WALK_POLICY_FILENAME = "walk_policy.onnx"
+_CONFIG_FILENAME = "config.json"
+
+
+class WBCPolicy(Policy):
+    """ONNX whole-body-control locomotion policy for the Unitree G1.
+
+    Args:
+        checkpoint: Either a local directory containing the ONNX files +
+            ``config.json``, a direct path to the main ``.onnx`` file, or a
+            HuggingFace model id (downloaded via ``huggingface_hub`` when the
+            optional dep is present). No weights are bundled.
+        config: A :class:`WBCConfig`, a path to a config JSON, or a dict. When
+            ``None`` the policy looks for ``config.json`` inside the checkpoint
+            directory.
+        walk: When ``True`` (default) load and prefer the walk policy
+            (``walk_policy_path``) for forward locomotion. When ``False`` only
+            the main policy is loaded/used.
+        target_velocity: Optional constructor-time default locomotion command
+            ``[vx, vy, omega]`` (m/s, m/s, rad/s). Used when a call supplies no
+            ``target_velocity`` kwarg - this is how a *static* walk works
+            through the mesh ``tell()`` / ``policy_config`` path that forwards
+            only constructor kwargs. Per-call ``target_velocity`` overrides it.
+        allow_missing_models: Test/CI seam. When ``True`` the ONNX sessions are
+            not loaded eagerly (so unit tests can inject a stub session via
+            :attr:`policy_session` / :attr:`walk_session`). Production callers
+            leave this ``False`` so a missing checkpoint fails loudly at
+            construction.
+        **kwargs: Forward-compatibility absorber for the smart-string / registry
+            resolution path. Per the #300 contract, providers MUST ignore
+            unknown kwargs rather than raising.
+
+    Raises:
+        RuntimeError: If ``onnxruntime`` is missing, or a checkpoint file is
+            absent, when ``allow_missing_models`` is ``False``.
+        ValueError: If the resolved config dimensions are inconsistent.
+    """
+
+    def __init__(
+        self,
+        checkpoint: str | None = None,
+        config: str | dict[str, Any] | WBCConfig | None = None,
+        walk: bool = True,
+        target_velocity: list[float] | None = None,
+        allow_missing_models: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        self._walk = bool(walk)
+        self._robot_state_keys: list[str] = []
+        self._default_command = self._validate_velocity(target_velocity) if target_velocity is not None else None
+
+        # Default to the canonical SONIC checkpoint when none is given, so
+        # ``create_policy("wbc")`` resolves to a downloadable repo rather than
+        # failing with a bare "checkpoint not found". No weights are bundled;
+        # the HF download happens lazily in _load_sessions under the model
+        # license. An explicit local path / id always wins.
+        if checkpoint is None:
+            checkpoint = _DEFAULT_HF_REPO
+
+        # Resolve the config first - it tells us dims + default file layout.
+        self._config = self._resolve_config(config, checkpoint)
+        n = self._config.num_actions
+
+        # Pre-compute NumPy views of the per-joint vectors (once, not per tick).
+        self._default_angles = (
+            np.asarray(self._config.default_angles, dtype=np.float64)
+            if self._config.default_angles
+            else np.zeros(n, dtype=np.float64)
+        )
+        self._kps = np.asarray(self._config.kps, dtype=np.float64) if self._config.kps else np.ones(n, dtype=np.float64)
+        self._kds = (
+            np.asarray(self._config.kds, dtype=np.float64) if self._config.kds else np.zeros(n, dtype=np.float64)
+        )
+
+        # Previous action (15-dim) fed back into the observation; zeroed at reset.
+        self._prev_action = np.zeros(n, dtype=np.float64)
+        self._history = ObservationHistory(self._config)
+
+        # ONNX sessions. Stub seam: when allow_missing_models is True we skip
+        # the eager load so tests can assign fakes to policy_session/walk_session.
+        self.policy_session: Any = None
+        self.walk_session: Any = None
+        if not allow_missing_models:
+            self._load_sessions(checkpoint)
+
+        if kwargs:
+            logger.debug("WBCPolicy ignoring unknown constructor kwargs: %s", sorted(kwargs.keys()))
+
+        logger.info(
+            "WBCPolicy ready [num_actions=%d obs_history_len=%d walk=%s default_cmd=%s]",
+            n,
+            self._config.obs_history_len,
+            self._walk,
+            self._default_command.tolist() if self._default_command is not None else None,
+        )
+
+    # ------------------------------------------------------------------
+    # Policy interface
+    # ------------------------------------------------------------------
+
+    @property
+    def provider_name(self) -> str:
+        return "wbc"
+
+    @property
+    def requires_images(self) -> bool:
+        """WBC controls from joint state + base IMU only, never images."""
+        return False
+
+    @property
+    def config(self) -> WBCConfig:
+        return self._config
+
+    def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
+        """Record the robot's joint order and validate the leg+waist layout.
+
+        The first ``num_actions`` keys MUST match the expected G1 leg+waist
+        ordering (:data:`WBC_G1_LEG_WAIST_JOINTS`) so WBC output index ``i``
+        drives the correct actuator. A mismatch raises rather than silently
+        actuating the wrong joints (#466: explicit mapping, no positional
+        guessing).
+        """
+        keys = list(robot_state_keys)
+        n = self._config.num_actions
+        if len(keys) < n:
+            raise ValueError(
+                f"WBCPolicy expects at least {n} robot state keys (leg+waist), got {len(keys)}: {keys}. "
+                "WBC drives the G1 lower body; load the full unitree_g1 (29-DOF) model."
+            )
+        expected = WBC_G1_LEG_WAIST_JOINTS[:n]
+        actual = tuple(keys[:n])
+        if actual != expected:
+            raise ValueError(
+                "WBCPolicy: first "
+                f"{n} robot state keys do not match the expected G1 leg+waist order.\n"
+                f"  expected: {list(expected)}\n"
+                f"  actual:   {list(actual)}\n"
+                "WBC output index i drives expected[i]; a mismatch would actuate the wrong joints."
+            )
+        self._robot_state_keys = keys
+
+    def reset(self, seed: int | None = None) -> None:
+        """Clear the observation history and previous-action feedback.
+
+        The ``seed`` argument is accepted for API parity with the rest of the
+        policy family; the ONNX controller is deterministic, so it is unused.
+        """
+        self._history.reset()
+        self._prev_action = np.zeros(self._config.num_actions, dtype=np.float64)
+        logger.debug("WBCPolicy.reset: cleared observation history + prev_action (seed=%r)", seed)
+
+    async def get_actions(
+        self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any
+    ) -> list[dict[str, Any]]:
+        """Run one WBC inference step and return the 15-dim target joint positions.
+
+        Reads the locomotion command from the well-known kwargs
+        (``target_velocity = [vx, vy, omega]``, optional ``target_orientation``);
+        ``instruction`` is ignored. Builds the stacked observation, runs the
+        ONNX policy, converts the raw offset to absolute joint targets, and
+        returns a single per-step action dict keyed by actuator name.
+
+        Returns a one-element list (WBC is a closed-loop per-tick controller,
+        not a chunked planner): the runner re-queries every control step.
+        """
+        command = self._resolve_command(kwargs)
+
+        qj, dqj, base_ang_vel, quat = self._extract_state(observation_dict)
+        proj_grav = projected_gravity(quat)
+
+        frame = build_single_frame(
+            self._config,
+            command=command,
+            base_ang_vel=base_ang_vel,
+            proj_gravity=proj_grav,
+            qj=qj,
+            dqj=dqj,
+            prev_action=self._prev_action,
+        )
+        obs = self._history.push(frame)
+
+        raw_action = self._run_session(obs, command)
+        self._prev_action = raw_action
+
+        target_q = compute_targets(self._default_angles, raw_action, self._config.action_scale)
+        keys = self._resolve_action_keys()
+        return [{k: float(v) for k, v in zip(keys, target_q, strict=True)}]
+
+    # ------------------------------------------------------------------
+    # Public helpers
+    # ------------------------------------------------------------------
+
+    def compute_torques(
+        self,
+        target_pos: np.ndarray,
+        current_pos: np.ndarray,
+        current_vel: np.ndarray,
+    ) -> np.ndarray:
+        """Expose the upstream PD law for callers driving torque actuators.
+
+        ``tau = (target_pos - current_pos) * kp + (0 - current_vel) * kd``
+        using the per-joint gains from the config. The desired velocity is
+        zero (position hold between targets), matching the reference loop.
+        """
+        target_pos = np.asarray(target_pos, dtype=np.float64)
+        current_pos = np.asarray(current_pos, dtype=np.float64)
+        current_vel = np.asarray(current_vel, dtype=np.float64)
+        zeros = np.zeros_like(target_pos)
+        return pd_control(target_pos, current_pos, self._kps, zeros, current_vel, self._kds)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _resolve_command(self, kwargs: dict[str, Any]) -> np.ndarray:
+        """Pick the locomotion command for this tick.
+
+        Priority: per-call ``target_velocity`` kwarg > constructor default >
+        zeros (stand in place). ``target_orientation`` is accepted and appended
+        as additional command channels when present (the network's command
+        block carries gait/style fields beyond the first three).
+        """
+        tv = kwargs.get("target_velocity")
+        if tv is not None:
+            command = self._validate_velocity(tv)
+        elif self._default_command is not None:
+            command = self._default_command.copy()
+        else:
+            command = np.zeros(3, dtype=np.float64)
+
+        # Optional orientation/style channels appended after [vx, vy, omega].
+        target_orientation = kwargs.get("target_orientation")
+        if target_orientation is not None:
+            extra = np.asarray(target_orientation, dtype=np.float64).ravel()
+            command = np.concatenate([command, extra])
+        return command
+
+    def _extract_state(self, observation_dict: dict[str, Any]) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        """Pull (qj, dqj, base_ang_vel, base_quat) out of the observation dict.
+
+        ``qj`` / ``dqj`` are the first ``num_actions`` joint position / velocity
+        values. Accepts the unified sim observation (per-joint scalars keyed by
+        name) or a flat ``observation.state`` vector. Base angular velocity and
+        orientation come from well-known keys, defaulting to a level, still base
+        when absent (an upright stance cue) rather than fabricating motion.
+        """
+        n = self._config.num_actions
+        qj = self._read_joint_vector(observation_dict, "position", n)
+        dqj = self._read_joint_vector(observation_dict, "velocity", n)
+
+        base_ang_vel = self._read_vec(observation_dict, ("base_ang_vel", "observation.base_ang_vel"), 3)
+        if base_ang_vel is None:
+            base_ang_vel = np.zeros(3, dtype=np.float64)
+
+        quat = self._read_vec(observation_dict, ("base_quat", "observation.base_quat"), 4)
+        if quat is None:
+            quat = np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float64)  # upright (w=1)
+        return qj, dqj, base_ang_vel, quat
+
+    def _read_joint_vector(self, obs: dict[str, Any], kind: str, n: int) -> np.ndarray:
+        """Read the first ``n`` joint positions/velocities from the observation.
+
+        Tries, in order: a flat ``observation.state`` / ``observation.velocity``
+        vector, then per-joint scalars keyed by the recorded actuator names.
+        Missing values default to zero (a still, nominal stance) rather than
+        raising mid-rollout - but this is a *measured-state* default, distinct
+        from the forbidden zero-*torque* fallback.
+        """
+        flat_key = "observation.state" if kind == "position" else "observation.velocity"
+        flat = obs.get(flat_key)
+        if flat is not None and hasattr(flat, "__len__") and len(flat) >= n:
+            arr = np.asarray(flat if not hasattr(flat, "tolist") else flat.tolist(), dtype=np.float64).ravel()
+            return arr[:n]
+
+        # Per-joint scalar form (the unified sim observation). Use the recorded
+        # leg+waist key order so index i is the same joint WBC output i drives.
+        keys = self._robot_state_keys[:n] if self._robot_state_keys else list(WBC_G1_LEG_WAIST_JOINTS[:n])
+        out = np.zeros(n, dtype=np.float64)
+        # Velocity is only available as per-joint when the sim exposes a
+        # "<joint>.vel" style key; the unified observation is positions only,
+        # so velocity falls back to zeros (position-hold), which is correct for
+        # the first tick and converges as the loop runs.
+        for i, k in enumerate(keys):
+            v = obs.get(k) if kind == "position" else obs.get(f"{k}.vel")
+            if v is not None:
+                try:
+                    out[i] = float(v)
+                except (TypeError, ValueError):
+                    pass
+        return out
+
+    @staticmethod
+    def _read_vec(obs: dict[str, Any], keys: tuple[str, ...], n: int) -> np.ndarray | None:
+        for k in keys:
+            v = obs.get(k)
+            if v is not None and hasattr(v, "__len__") and len(v) == n:
+                return np.asarray(v if not hasattr(v, "tolist") else v.tolist(), dtype=np.float64).ravel()
+        return None
+
+    def _run_session(self, obs: np.ndarray, command: np.ndarray) -> np.ndarray:
+        """Run the (walk or main) ONNX session and return the 15-dim raw action.
+
+        Selects the walk session when ``walk=True``, a walk session is loaded,
+        and the command requests forward/lateral/yaw motion; otherwise the main
+        policy. The ONNX input is the stacked observation as a 1xN float32
+        batch; the output is squeezed to a 1-D ``num_actions`` vector.
+        """
+        session = self.policy_session
+        if self._walk and self.walk_session is not None and float(np.linalg.norm(command[:3])) > 1e-6:
+            session = self.walk_session
+        if session is None:
+            # Defensive: reachable only via the allow_missing_models test seam
+            # if a caller forgot to inject a session. Never silently emit zeros.
+            raise RuntimeError(
+                "WBCPolicy has no ONNX session loaded. Construct with a valid "
+                "checkpoint (allow_missing_models=False), or inject a stub via "
+                "policy_session=/walk_session= in tests."
+            )
+
+        net_in = np.asarray(obs, dtype=np.float32).reshape(1, -1)
+        input_name = self._session_input_name(session)
+        outputs = session.run(None, {input_name: net_in})
+        raw = np.asarray(outputs[0], dtype=np.float64).ravel()
+        n = self._config.num_actions
+        if raw.shape[0] != n:
+            raise RuntimeError(
+                f"WBCPolicy ONNX output width {raw.shape[0]} != num_actions {n}; "
+                "the checkpoint and config disagree on the action dimension."
+            )
+        return raw
+
+    @staticmethod
+    def _session_input_name(session: Any) -> str:
+        """Resolve the ONNX session's first input name (duck-typed for stubs)."""
+        get_inputs = getattr(session, "get_inputs", None)
+        if get_inputs is not None:
+            inputs = get_inputs()
+            if inputs:
+                return str(inputs[0].name)
+        # Stub sessions may expose a plain ``input_name`` attribute.
+        return str(getattr(session, "input_name", "obs"))
+
+    def _resolve_action_keys(self) -> list[str]:
+        """The 15 leg+waist actuator names this policy emits, in WBC order."""
+        n = self._config.num_actions
+        if self._robot_state_keys:
+            return list(self._robot_state_keys[:n])
+        return list(WBC_G1_LEG_WAIST_JOINTS[:n])
+
+    def _resolve_config(self, config: str | dict[str, Any] | WBCConfig | None, checkpoint: str | None) -> WBCConfig:
+        if isinstance(config, WBCConfig):
+            return config
+        if isinstance(config, dict):
+            return WBCConfig.from_dict(config)
+        if isinstance(config, str):
+            return WBCConfig.from_file(config)
+        # config is None: look for config.json inside a checkpoint directory.
+        if checkpoint:
+            ckpt_path = Path(checkpoint).expanduser()
+            cfg_path = ckpt_path / _CONFIG_FILENAME if ckpt_path.is_dir() else ckpt_path.parent / _CONFIG_FILENAME
+            if cfg_path.is_file():
+                return WBCConfig.from_file(cfg_path)
+        # Fall back to a default config pointing at the conventional filenames.
+        # The session loader will raise if the files are actually absent.
+        main_path, walk_path = self._default_onnx_paths(checkpoint)
+        return WBCConfig(policy_path=main_path, walk_policy_path=walk_path)
+
+    @staticmethod
+    def _default_onnx_paths(checkpoint: str | None) -> tuple[str, str | None]:
+        if not checkpoint:
+            return _MAIN_POLICY_FILENAME, _WALK_POLICY_FILENAME
+        p = Path(checkpoint).expanduser()
+        if p.is_dir():
+            return str(p / _MAIN_POLICY_FILENAME), str(p / _WALK_POLICY_FILENAME)
+        # checkpoint points directly at the main .onnx file.
+        return str(p), str(p.parent / _WALK_POLICY_FILENAME)
+
+    def _load_sessions(self, checkpoint: str | None) -> None:
+        """Load the ONNX sessions, raising loudly on any missing dependency/file.
+
+        Centralised dependency check per AGENTS.md: ``onnxruntime`` is imported
+        once here (not scattered ``_ensure`` guards), so a consumer learns at
+        construction time whether the policy is usable.
+
+        Per the #466 acceptance criterion, a missing dependency or checkpoint
+        raises ``RuntimeError`` (never a silent zero-torque fallback).
+        ``require_optional`` raises ``ImportError`` with an actionable install
+        hint; we re-raise it as ``RuntimeError`` (preserving the hint via the
+        cause chain) so the failure type matches the rest of the WBC contract.
+        """
+        try:
+            ort = require_optional(
+                "onnxruntime",
+                pip_install="onnxruntime",
+                extra="wbc",
+                purpose="WBCPolicy ONNX inference",
+            )
+        except ImportError as e:
+            raise RuntimeError(f"WBCPolicy requires onnxruntime (the [wbc] extra) but it is not installed.\n{e}") from e
+
+        # Resolve a HuggingFace model id (``org/repo``) to a local snapshot dir
+        # so the path logic below sees ordinary files. A local path / dir is
+        # left untouched. No weights are bundled - they download on first use
+        # under the model's license and cache under the HF cache.
+        checkpoint = self._maybe_download_checkpoint(checkpoint)
+
+        main_path = self._resolve_onnx_path(self._config.policy_path, checkpoint, _MAIN_POLICY_FILENAME)
+        if main_path is None or not Path(main_path).is_file():
+            raise RuntimeError(
+                f"WBCPolicy main ONNX checkpoint not found (resolved: {main_path!r}). "
+                "Pass checkpoint='/path/to/GEAR-SONIC' (a dir with policy.onnx) or a "
+                "direct .onnx path. No weights are bundled - download them under the "
+                "NVIDIA Open Model License (e.g. nvidia/GEAR-SONIC)."
+            )
+        self.policy_session = ort.InferenceSession(main_path)  # type: ignore[attr-defined]
+
+        if self._walk:
+            walk_path = self._resolve_onnx_path(self._config.walk_policy_path, checkpoint, _WALK_POLICY_FILENAME)
+            if walk_path is not None and Path(walk_path).is_file():
+                self.walk_session = ort.InferenceSession(walk_path)  # type: ignore[attr-defined]
+            else:
+                logger.info(
+                    "WBCPolicy walk=True but no walk policy found (resolved: %r); "
+                    "using the main policy for locomotion too.",
+                    walk_path,
+                )
+
+    @staticmethod
+    def _maybe_download_checkpoint(checkpoint: str | None) -> str | None:
+        """Resolve a HuggingFace model id to a local snapshot directory.
+
+        Checkpoint resolution order (issue #466): local path | HF download | cache.
+        A value that already exists on disk (file or dir) is returned unchanged.
+        A bare ``org/repo`` id (e.g. the default ``nvidia/GEAR-SONIC``) is
+        fetched via ``huggingface_hub.snapshot_download`` - which is itself a
+        cache (repeat calls are offline-fast) - and the local dir is returned.
+
+        Raises:
+            RuntimeError: If the id looks like an HF repo but ``huggingface_hub``
+                is not installed, or the download fails. Never silently proceeds
+                with an unresolved checkpoint (the session load would then raise
+                a less actionable error).
+        """
+        if not checkpoint:
+            return checkpoint
+        p = Path(checkpoint).expanduser()
+        if p.exists():
+            return checkpoint  # local path/dir - use as-is
+        # Heuristic for an HF model id: exactly "<org>/<repo>", no extra slashes,
+        # no path separators beyond the single one, and not an .onnx file path.
+        is_hf_id = checkpoint.count("/") == 1 and not checkpoint.endswith(".onnx") and "\\" not in checkpoint
+        if not is_hf_id:
+            return checkpoint  # let the path resolver surface a clear not-found error
+        try:
+            hub = require_optional(
+                "huggingface_hub",
+                pip_install="huggingface_hub",
+                extra="wbc",
+                purpose="WBCPolicy checkpoint download",
+            )
+        except ImportError as e:
+            raise RuntimeError(
+                f"WBCPolicy checkpoint {checkpoint!r} looks like a HuggingFace model id, "
+                f"but huggingface_hub is not installed to download it.\n{e}"
+            ) from e
+        try:
+            local_dir = hub.snapshot_download(  # type: ignore[attr-defined]
+                repo_id=checkpoint, allow_patterns=["*.onnx", "*.json"]
+            )
+        except Exception as e:  # noqa: BLE001 - surface any hub failure as actionable RuntimeError
+            raise RuntimeError(
+                f"WBCPolicy failed to download checkpoint {checkpoint!r} from HuggingFace: {e}. "
+                "Pass a local checkpoint directory instead, or check network / model-license access."
+            ) from e
+        logger.info("WBCPolicy downloaded checkpoint %r -> %s", checkpoint, local_dir)
+        return str(local_dir)
+
+    @staticmethod
+    def _resolve_onnx_path(configured: str | None, checkpoint: str | None, filename: str) -> str | None:
+        """Resolve a (possibly relative) ONNX path against the checkpoint dir."""
+        if configured:
+            p = Path(configured).expanduser()
+            if p.is_absolute() or p.is_file():
+                return str(p)
+            # Relative path: resolve against the checkpoint directory.
+            if checkpoint:
+                base = Path(checkpoint).expanduser()
+                base = base if base.is_dir() else base.parent
+                return str(base / configured)
+            return str(p)
+        if checkpoint:
+            base = Path(checkpoint).expanduser()
+            base = base if base.is_dir() else base.parent
+            return str(base / filename)
+        return None
+
+    @staticmethod
+    def _validate_velocity(tv: Any) -> np.ndarray:
+        """Validate a ``[vx, vy, omega]`` locomotion command (finite, len>=3)."""
+        try:
+            arr = np.asarray(tv, dtype=np.float64).ravel()
+        except (TypeError, ValueError) as e:
+            raise ValueError(f"target_velocity must be a numeric sequence, got {tv!r}") from e
+        if arr.shape[0] < 3:
+            raise ValueError(f"target_velocity must have at least 3 elements [vx, vy, omega], got {arr.shape[0]}")
+        for i, v in enumerate(arr):
+            if math.isnan(v) or math.isinf(v):
+                raise ValueError(f"target_velocity[{i}]={v!r} must be finite")
+        return arr
+
+
+__all__ = ["WBCPolicy", "WBC_G1_LEG_WAIST_JOINTS"]

--- a/strands_robots/policies/wbc/policy.py
+++ b/strands_robots/policies/wbc/policy.py
@@ -94,6 +94,11 @@ _MAIN_POLICY_FILENAME = "policy.onnx"
 _WALK_POLICY_FILENAME = "walk_policy.onnx"
 _CONFIG_FILENAME = "config.json"
 
+# Raw-velocity-norm threshold for walk-vs-main policy selection, matching the
+# upstream reference (run_mujoco_gear_wbc.py: norm(loco_cmd) <= 0.05 -> main
+# "standing" policy; above -> walk_policy).
+_WALK_VELOCITY_THRESHOLD = 0.05
+
 # HuggingFace repo id: "<org>/<repo>", each segment letters/digits/._- only.
 # Used to decide whether a non-existent checkpoint string is an HF id worth
 # downloading vs. a local path that should surface a clean not-found error.
@@ -306,15 +311,16 @@ class WBCPolicy(Policy):
         """Run one WBC inference step and return the 15-dim target joint positions.
 
         Reads the locomotion command from the well-known kwargs
-        (``target_velocity = [vx, vy, omega]``, optional ``target_orientation``);
-        ``instruction`` is ignored. Builds the stacked observation, runs the
-        ONNX policy, converts the raw offset to absolute joint targets, and
-        returns a single per-step action dict keyed by actuator name.
+        (``target_velocity = [vx, vy, omega]``, optional ``target_orientation``
+        for roll/pitch/yaw, optional ``height``); ``instruction`` is ignored.
+        Builds the stacked observation, runs the ONNX policy, converts the raw
+        offset to absolute joint targets, and returns a single per-step action
+        dict keyed by actuator name.
 
         Returns a one-element list (WBC is a closed-loop per-tick controller,
         not a chunked planner): the runner re-queries every control step.
         """
-        command = self._resolve_command(kwargs)
+        command, raw_velocity = self._resolve_command(kwargs)
 
         qj, dqj, base_ang_vel, quat = self._extract_state(observation_dict)
         proj_grav = projected_gravity(quat)
@@ -330,7 +336,9 @@ class WBCPolicy(Policy):
         )
         obs = self._history.push(frame)
 
-        raw_action = self._run_session(obs, command)
+        # Walk-selection uses the RAW (unscaled) velocity norm, matching the
+        # upstream reference (run_mujoco_gear_wbc.py: norm(loco_cmd) <= 0.05).
+        raw_action = self._run_session(obs, raw_velocity)
         self._prev_action = raw_action
 
         target_q = compute_targets(self._default_angles, raw_action, self._config.action_scale)
@@ -363,49 +371,62 @@ class WBCPolicy(Policy):
     # Internal helpers
     # ------------------------------------------------------------------
 
-    def _resolve_command(self, kwargs: dict[str, Any]) -> np.ndarray:
-        """Pick the locomotion command for this tick, fitted to ``command_dim``.
+    def _resolve_command(self, kwargs: dict[str, Any]) -> tuple[np.ndarray, np.ndarray]:
+        """Build the 7-dim command block for this tick.
 
-        Priority: per-call ``target_velocity`` kwarg > constructor default >
-        zeros (stand in place). ``target_orientation`` is accepted and appended
-        as additional command/style channels after ``[vx, vy, omega]`` (the
-        network's command block carries gait/style fields beyond the first
-        three).
+        Faithful to the upstream ``compute_observation`` layout
+        (run_mujoco_gear_wbc.py)::
 
-        The returned command is always exactly ``command_dim`` wide:
-        - shorter (e.g. just ``[vx, vy, omega]``) is zero-padded by the frame
-          builder;
-        - longer (velocity + a large ``target_orientation``) is truncated to
-          ``command_dim`` with a debug log, rather than overflowing the
-          observation frame and raising on every tick. A documented kwarg must
-          never crash the controller.
+            command[0:3] = loco_cmd[:3] * cmd_scale   # velocity, scaled
+            command[3]   = height_cmd                  # target base height
+            command[4:7] = rpy_cmd                     # target roll/pitch/yaw
+
+        Goal sources (per-call kwarg > constructor default > config default):
+        - ``target_velocity = [vx, vy, omega]`` -> the raw velocity triple.
+        - ``target_orientation = [roll, pitch, yaw]`` -> rpy command slots.
+        - ``height`` -> the height command slot.
+
+        Returns:
+            ``(command, raw_velocity)`` where ``command`` is the ``command_dim``-
+            wide (default 7) observation block with ``cmd_scale`` already applied
+            to the velocity, and ``raw_velocity`` is the UNSCALED ``[vx, vy,
+            omega]`` triple used for walk-vs-main policy selection (matching the
+            upstream ``norm(loco_cmd) <= 0.05`` test on the raw command).
         """
         tv = kwargs.get("target_velocity")
         if tv is not None:
-            command = self._validate_velocity(tv)
+            vel_full = self._validate_velocity(tv)
         elif self._default_command is not None:
-            command = self._default_command.copy()
+            vel_full = self._default_command.copy()
         else:
-            command = np.zeros(3, dtype=np.float64)
+            vel_full = np.zeros(3, dtype=np.float64)
+        # The raw velocity is the first three entries (vx, vy, omega); any extra
+        # entries a caller packed in are ignored for the scaled command block.
+        raw_velocity = vel_full[:3].copy()
 
-        # Optional orientation/style channels appended after [vx, vy, omega].
-        target_orientation = kwargs.get("target_orientation")
-        if target_orientation is not None:
-            extra = np.asarray(target_orientation, dtype=np.float64).ravel()
-            command = np.concatenate([command, extra])
-
-        # Fit to command_dim: truncate an over-long command so the observation
-        # frame (which reserves exactly command_dim slots) never overflows.
         c = self._config.command_dim
-        if command.shape[0] > c:
-            logger.debug(
-                "WBCPolicy: command width %d exceeds command_dim %d; truncating "
-                "(target_orientation channels beyond the command block are dropped).",
-                command.shape[0],
-                c,
-            )
-            command = command[:c]
-        return command
+        command = np.zeros(c, dtype=np.float64)
+
+        # Slots [0:3]: velocity * cmd_scale (clamp the slice to whatever fits).
+        cmd_scale = np.asarray(self._config.cmd_scale, dtype=np.float64).ravel()
+        n_vel = min(3, c)
+        scale = cmd_scale[:n_vel] if cmd_scale.shape[0] >= n_vel else np.ones(n_vel)
+        command[:n_vel] = raw_velocity[:n_vel] * scale
+
+        # Slot [3]: target base height (per-call ``height`` overrides the config).
+        if c > 3:
+            height = kwargs.get("height")
+            command[3] = float(height) if height is not None else float(self._config.height_cmd)
+
+        # Slots [4:7]: target roll/pitch/yaw (per-call ``target_orientation``
+        # overrides the config ``rpy_cmd``).
+        if c > 4:
+            rpy_src = kwargs.get("target_orientation")
+            rpy = np.asarray(rpy_src if rpy_src is not None else self._config.rpy_cmd, dtype=np.float64).ravel()
+            n_rpy = min(c - 4, rpy.shape[0])
+            command[4 : 4 + n_rpy] = rpy[:n_rpy]
+
+        return command, raw_velocity
 
     def _extract_state(self, observation_dict: dict[str, Any]) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
         """Pull (qj, dqj, base_ang_vel, base_quat) out of the observation dict.
@@ -534,16 +555,21 @@ class WBCPolicy(Policy):
                 return np.asarray(v if not hasattr(v, "tolist") else v.tolist(), dtype=np.float64).ravel()
         return None
 
-    def _run_session(self, obs: np.ndarray, command: np.ndarray) -> np.ndarray:
+    def _run_session(self, obs: np.ndarray, raw_velocity: np.ndarray) -> np.ndarray:
         """Run the (walk or main) ONNX session and return the 15-dim raw action.
 
-        Selects the walk session when ``walk=True``, a walk session is loaded,
-        and the command requests forward/lateral/yaw motion; otherwise the main
-        policy. The ONNX input is the stacked observation as a 1xN float32
-        batch; the output is squeezed to a 1-D ``num_actions`` vector.
+        Session selection matches the upstream reference
+        (run_mujoco_gear_wbc.py): when the RAW (unscaled) velocity command norm
+        is ``<= WALK_VELOCITY_THRESHOLD`` (0.05) the robot is "standing" and the
+        main ``policy`` runs; above that the ``walk_policy`` runs. When
+        ``walk=False`` or no walk session is loaded, the main policy always runs.
+
+        The ONNX input is the stacked observation as a 1xN float32 batch; the
+        output is squeezed to a 1-D ``num_actions`` vector.
         """
         session = self.policy_session
-        if self._walk and self.walk_session is not None and float(np.linalg.norm(command[:3])) > 1e-6:
+        moving = float(np.linalg.norm(raw_velocity[:3])) > _WALK_VELOCITY_THRESHOLD
+        if self._walk and self.walk_session is not None and moving:
             session = self.walk_session
         if session is None:
             # Defensive: reachable only via the allow_missing_models test seam

--- a/strands_robots/policies/wbc/policy.py
+++ b/strands_robots/policies/wbc/policy.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 
 import logging
 import math
+import re
 from pathlib import Path
 from typing import Any
 
@@ -93,6 +94,28 @@ _MAIN_POLICY_FILENAME = "policy.onnx"
 _WALK_POLICY_FILENAME = "walk_policy.onnx"
 _CONFIG_FILENAME = "config.json"
 
+# HuggingFace repo id: "<org>/<repo>", each segment letters/digits/._- only.
+# Used to decide whether a non-existent checkpoint string is an HF id worth
+# downloading vs. a local path that should surface a clean not-found error.
+_HF_REPO_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+def _looks_like_hf_repo_id(value: str) -> bool:
+    """True if ``value`` is shaped like a HuggingFace ``org/repo`` model id.
+
+    Rejects anything path-like - absolute paths, ``./`` or ``../`` prefixes,
+    backslashes, ``.onnx`` files, ``..`` traversal, or more than one ``/`` -
+    so a non-existent *local* path is never mistaken for a remote repo and sent
+    to the network. A plain ``org/repo`` (the only ambiguous case vs. a relative
+    dir) is treated as an id; the caller logs before downloading so that choice
+    is visible.
+    """
+    if value.endswith(".onnx") or "\\" in value or ".." in value:
+        return False
+    if value.startswith((".", "/", "~")):
+        return False
+    return bool(_HF_REPO_ID_RE.match(value))
+
 
 class WBCPolicy(Policy):
     """ONNX whole-body-control locomotion policy for the Unitree G1.
@@ -139,6 +162,7 @@ class WBCPolicy(Policy):
     ) -> None:
         self._walk = bool(walk)
         self._robot_state_keys: list[str] = []
+        self._warned_no_velocity = False
         self._default_command = self._validate_velocity(target_velocity) if target_velocity is not None else None
 
         # Default to the canonical SONIC checkpoint when none is given, so
@@ -152,6 +176,27 @@ class WBCPolicy(Policy):
         # Resolve the config first - it tells us dims + default file layout.
         self._config = self._resolve_config(config, checkpoint)
         n = self._config.num_actions
+
+        # The leg+waist joint names WBC reads/writes, in WBC output order.
+        # set_robot_state_keys resolves these by name within the robot's joint
+        # list; until then, default to the canonical mapping table so direct
+        # get_actions calls (without set_robot_state_keys) still emit the right
+        # keys. WBC_G1_LEG_WAIST_JOINTS has exactly 15 names, so n must not
+        # exceed that (validated below).
+        self._wbc_joint_names: list[str] = list(WBC_G1_LEG_WAIST_JOINTS[:n])
+
+        # The G1 actuator-name mapping has exactly len(WBC_G1_LEG_WAIST_JOINTS)
+        # entries. A config with more actions than the table can name would
+        # silently truncate everywhere (state read, action keys, validation) and
+        # fail late with a confusing zip/length error. Reject it at construction
+        # (AGENTS.md #5: fail fast on a fatal config) - a different humanoid with
+        # a different DOF count needs its own mapping table, not a silent slice.
+        if n > len(WBC_G1_LEG_WAIST_JOINTS):
+            raise ValueError(
+                f"WBCConfig.num_actions={n} exceeds the {len(WBC_G1_LEG_WAIST_JOINTS)}-entry "
+                "G1 leg+waist actuator mapping (WBC_G1_LEG_WAIST_JOINTS). WBCPolicy targets the "
+                "G1 lower body; a different embodiment needs its own joint mapping table."
+            )
 
         # Pre-compute NumPy views of the per-joint vectors (once, not per tick).
         self._default_angles = (
@@ -204,32 +249,46 @@ class WBCPolicy(Policy):
         return self._config
 
     def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
-        """Record the robot's joint order and validate the leg+waist layout.
+        """Resolve the G1 leg+waist joints BY NAME within the robot's key list.
 
-        The first ``num_actions`` keys MUST match the expected G1 leg+waist
-        ordering (:data:`WBC_G1_LEG_WAIST_JOINTS`) so WBC output index ``i``
-        drives the correct actuator. A mismatch raises rather than silently
-        actuating the wrong joints (#466: explicit mapping, no positional
-        guessing).
+        WBC output index ``i`` drives :data:`WBC_G1_LEG_WAIST_JOINTS`\\ ``[i]``.
+        We locate each of those names inside ``robot_state_keys`` rather than
+        assuming a fixed position, because the sim's joint list is not just the
+        15 controllable joints in WBC order:
+
+        * MuJoCo prepends the robot's free/floating-base joint (the G1 model
+          names it ``floating_base_joint``), so the leg+waist joints are NOT
+          at indices ``[0:15]``.
+        * The full 29-DOF model also carries 14 arm joints interleaved after
+          the waist.
+
+        Resolving by name (#466: explicit mapping, no positional guessing)
+        means the policy reads and writes exactly the right joints regardless
+        of where the sim places them or what the free joint is called.
+
+        Raises:
+            ValueError: If any expected leg+waist joint name is absent from
+                ``robot_state_keys`` - a mismatch that would otherwise actuate
+                the wrong joints. The error lists the missing names.
         """
         keys = list(robot_state_keys)
-        n = self._config.num_actions
-        if len(keys) < n:
+        expected = WBC_G1_LEG_WAIST_JOINTS[: self._config.num_actions]
+        key_set = set(keys)
+        missing = [name for name in expected if name not in key_set]
+        if missing:
             raise ValueError(
-                f"WBCPolicy expects at least {n} robot state keys (leg+waist), got {len(keys)}: {keys}. "
-                "WBC drives the G1 lower body; load the full unitree_g1 (29-DOF) model."
+                "WBCPolicy: the robot's joint list is missing expected G1 "
+                f"leg+waist joints: {missing}.\n"
+                f"  expected (WBC order): {list(expected)}\n"
+                f"  robot provided:       {keys}\n"
+                "WBC drives these named joints; load the full unitree_g1 model "
+                "(its leg+waist joints carry these exact names)."
             )
-        expected = WBC_G1_LEG_WAIST_JOINTS[:n]
-        actual = tuple(keys[:n])
-        if actual != expected:
-            raise ValueError(
-                "WBCPolicy: first "
-                f"{n} robot state keys do not match the expected G1 leg+waist order.\n"
-                f"  expected: {list(expected)}\n"
-                f"  actual:   {list(actual)}\n"
-                "WBC output index i drives expected[i]; a mismatch would actuate the wrong joints."
-            )
-        self._robot_state_keys = keys
+        # Store the controllable joints in WBC order (the names we read state
+        # from and emit targets for). The free/base joint and arm joints are
+        # deliberately excluded - WBC neither observes nor drives them here.
+        self._robot_state_keys = list(keys)
+        self._wbc_joint_names = list(expected)
 
     def reset(self, seed: int | None = None) -> None:
         """Clear the observation history and previous-action feedback.
@@ -305,12 +364,21 @@ class WBCPolicy(Policy):
     # ------------------------------------------------------------------
 
     def _resolve_command(self, kwargs: dict[str, Any]) -> np.ndarray:
-        """Pick the locomotion command for this tick.
+        """Pick the locomotion command for this tick, fitted to ``command_dim``.
 
         Priority: per-call ``target_velocity`` kwarg > constructor default >
         zeros (stand in place). ``target_orientation`` is accepted and appended
-        as additional command channels when present (the network's command
-        block carries gait/style fields beyond the first three).
+        as additional command/style channels after ``[vx, vy, omega]`` (the
+        network's command block carries gait/style fields beyond the first
+        three).
+
+        The returned command is always exactly ``command_dim`` wide:
+        - shorter (e.g. just ``[vx, vy, omega]``) is zero-padded by the frame
+          builder;
+        - longer (velocity + a large ``target_orientation``) is truncated to
+          ``command_dim`` with a debug log, rather than overflowing the
+          observation frame and raising on every tick. A documented kwarg must
+          never crash the controller.
         """
         tv = kwargs.get("target_velocity")
         if tv is not None:
@@ -325,16 +393,39 @@ class WBCPolicy(Policy):
         if target_orientation is not None:
             extra = np.asarray(target_orientation, dtype=np.float64).ravel()
             command = np.concatenate([command, extra])
+
+        # Fit to command_dim: truncate an over-long command so the observation
+        # frame (which reserves exactly command_dim slots) never overflows.
+        c = self._config.command_dim
+        if command.shape[0] > c:
+            logger.debug(
+                "WBCPolicy: command width %d exceeds command_dim %d; truncating "
+                "(target_orientation channels beyond the command block are dropped).",
+                command.shape[0],
+                c,
+            )
+            command = command[:c]
         return command
 
     def _extract_state(self, observation_dict: dict[str, Any]) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
         """Pull (qj, dqj, base_ang_vel, base_quat) out of the observation dict.
 
-        ``qj`` / ``dqj`` are the first ``num_actions`` joint position / velocity
-        values. Accepts the unified sim observation (per-joint scalars keyed by
-        name) or a flat ``observation.state`` vector. Base angular velocity and
+        ``qj`` / ``dqj`` are the leg+waist joint positions / velocities, read by
+        name via :meth:`_read_joint_vector`. Base angular velocity and
         orientation come from well-known keys, defaulting to a level, still base
         when absent (an upright stance cue) rather than fabricating motion.
+
+        Velocity availability: WBC is a velocity-feedback balance controller, so
+        ``dqj`` and ``base_ang_vel`` are genuine inputs - not optional. The
+        current MuJoCo backend's unified observation exposes joint *positions*
+        only (no ``<name>.vel`` keys, no ``observation.velocity``), so a plain
+        ``sim.run_policy`` rollout feeds WBC zero joint velocities. We emit a
+        one-time warning when that happens (a dead velocity channel can
+        destabilise the gait) rather than silently pretending the controller is
+        fully observed. To supply real velocities, drive the policy from an
+        observation that includes ``<name>.vel`` per-joint keys (or
+        ``observation.velocity`` + ``base_ang_vel``), e.g. a teleop/IMU bridge
+        or a future backend velocity field.
         """
         n = self._config.num_actions
         qj = self._read_joint_vector(observation_dict, "position", n)
@@ -344,35 +435,74 @@ class WBCPolicy(Policy):
         if base_ang_vel is None:
             base_ang_vel = np.zeros(3, dtype=np.float64)
 
+        # Warn once if BOTH velocity channels are absent - WBC is then running
+        # open-loop on velocity, which the operator should know about.
+        if not self._warned_no_velocity and not self._observation_has_velocity(observation_dict, base_ang_vel):
+            self._warned_no_velocity = True
+            logger.warning(
+                "WBCPolicy: observation exposes no joint velocities or base angular "
+                "velocity; feeding the balance controller zeros for dqj/base_ang_vel. "
+                "Gait stability may degrade. Supply per-joint '<name>.vel' keys, "
+                "'observation.velocity', and/or 'base_ang_vel' to close the loop."
+            )
+
         quat = self._read_vec(observation_dict, ("base_quat", "observation.base_quat"), 4)
         if quat is None:
             quat = np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float64)  # upright (w=1)
         return qj, dqj, base_ang_vel, quat
 
-    def _read_joint_vector(self, obs: dict[str, Any], kind: str, n: int) -> np.ndarray:
-        """Read the first ``n`` joint positions/velocities from the observation.
+    def _observation_has_velocity(self, obs: dict[str, Any], base_ang_vel: np.ndarray) -> bool:
+        """True if the observation carries any joint or base velocity signal."""
+        if obs.get("observation.velocity") is not None:
+            return True
+        if float(np.linalg.norm(base_ang_vel)) > 0.0:
+            return True
+        return any(f"{name}.vel" in obs for name in self._wbc_joint_names)
 
-        Tries, in order: a flat ``observation.state`` / ``observation.velocity``
-        vector, then per-joint scalars keyed by the recorded actuator names.
-        Missing values default to zero (a still, nominal stance) rather than
-        raising mid-rollout - but this is a *measured-state* default, distinct
-        from the forbidden zero-*torque* fallback.
+    def _read_joint_vector(self, obs: dict[str, Any], kind: str, n: int) -> np.ndarray:
+        """Read the ``n`` leg+waist joint positions/velocities from the observation.
+
+        Always reads BY NAME using the resolved WBC joint names
+        (:attr:`_wbc_joint_names`, in WBC output order) so index ``i`` is the
+        joint WBC output ``i`` drives - regardless of where the sim places the
+        joint or how many other (free-base, arm) joints surround it.
+
+        Two observation shapes are supported:
+
+        * Per-joint scalars keyed by joint name (the unified sim observation):
+          ``position`` reads ``obs[name]``; ``velocity`` reads ``obs[name + ".vel"]``.
+        * A flat ``observation.state`` / ``observation.velocity`` vector paired
+          with ``self._robot_state_keys`` for the index lookup. The flat vector
+          is indexed at each WBC joint's position in ``_robot_state_keys`` (NOT
+          sliced ``[:n]`` - that would grab the free-base/arm joints when they
+          precede or interleave the leg+waist joints).
+
+        Missing values default to zero (a still, nominal stance). This is a
+        *measured-state* default, distinct from the forbidden zero-*torque*
+        fallback. NOTE: if the sim exposes no joint velocities (the current
+        MuJoCo backend's unified observation is positions only, with no
+        ``<name>.vel`` keys), ``dqj`` reads as zeros - see :meth:`_extract_state`
+        for the consequence and the recommended teleop/IMU velocity source.
         """
+        names = self._wbc_joint_names[:n]
+
+        # Flat-vector form: index into the flat array by each joint's position
+        # in the robot's key list (name-resolved), never a positional slice.
         flat_key = "observation.state" if kind == "position" else "observation.velocity"
         flat = obs.get(flat_key)
-        if flat is not None and hasattr(flat, "__len__") and len(flat) >= n:
+        if flat is not None and hasattr(flat, "__len__") and self._robot_state_keys:
             arr = np.asarray(flat if not hasattr(flat, "tolist") else flat.tolist(), dtype=np.float64).ravel()
-            return arr[:n]
+            index_of = {name: i for i, name in enumerate(self._robot_state_keys)}
+            out = np.zeros(n, dtype=np.float64)
+            for i, name in enumerate(names):
+                j = index_of.get(name)
+                if j is not None and j < arr.shape[0]:
+                    out[i] = arr[j]
+            return out
 
-        # Per-joint scalar form (the unified sim observation). Use the recorded
-        # leg+waist key order so index i is the same joint WBC output i drives.
-        keys = self._robot_state_keys[:n] if self._robot_state_keys else list(WBC_G1_LEG_WAIST_JOINTS[:n])
+        # Per-joint scalar form (the unified sim observation).
         out = np.zeros(n, dtype=np.float64)
-        # Velocity is only available as per-joint when the sim exposes a
-        # "<joint>.vel" style key; the unified observation is positions only,
-        # so velocity falls back to zeros (position-hold), which is correct for
-        # the first tick and converges as the loop runs.
-        for i, k in enumerate(keys):
+        for i, k in enumerate(names):
             v = obs.get(k) if kind == "position" else obs.get(f"{k}.vel")
             if v is not None:
                 try:
@@ -433,11 +563,14 @@ class WBCPolicy(Policy):
         return str(getattr(session, "input_name", "obs"))
 
     def _resolve_action_keys(self) -> list[str]:
-        """The 15 leg+waist actuator names this policy emits, in WBC order."""
-        n = self._config.num_actions
-        if self._robot_state_keys:
-            return list(self._robot_state_keys[:n])
-        return list(WBC_G1_LEG_WAIST_JOINTS[:n])
+        """The leg+waist actuator names this policy emits, in WBC output order.
+
+        Always the name-resolved WBC joint set (:attr:`_wbc_joint_names`), never
+        a positional slice of the robot's full joint list - so the emitted
+        targets are keyed by the actual leg+waist actuators even when the sim's
+        joint list leads with a free-base joint or interleaves arm joints.
+        """
+        return list(self._wbc_joint_names[: self._config.num_actions])
 
     def _resolve_config(self, config: str | dict[str, Any] | WBCConfig | None, checkpoint: str | None) -> WBCConfig:
         if isinstance(config, WBCConfig):
@@ -538,11 +671,12 @@ class WBCPolicy(Policy):
         p = Path(checkpoint).expanduser()
         if p.exists():
             return checkpoint  # local path/dir - use as-is
-        # Heuristic for an HF model id: exactly "<org>/<repo>", no extra slashes,
-        # no path separators beyond the single one, and not an .onnx file path.
-        is_hf_id = checkpoint.count("/") == 1 and not checkpoint.endswith(".onnx") and "\\" not in checkpoint
-        if not is_hf_id:
-            return checkpoint  # let the path resolver surface a clear not-found error
+        if not _looks_like_hf_repo_id(checkpoint):
+            # Not HF-id-shaped (absolute path, ./ or ../ prefix, backslash,
+            # extra slashes, an .onnx file, or non-HF charset). Return as-is so
+            # the path resolver surfaces a clear "checkpoint not found" error
+            # rather than attempting a confusing network download.
+            return checkpoint
         try:
             hub = require_optional(
                 "huggingface_hub",
@@ -553,8 +687,16 @@ class WBCPolicy(Policy):
         except ImportError as e:
             raise RuntimeError(
                 f"WBCPolicy checkpoint {checkpoint!r} looks like a HuggingFace model id, "
-                f"but huggingface_hub is not installed to download it.\n{e}"
+                f"but huggingface_hub is not installed to download it. If you meant a local "
+                f"path, pass an existing directory or .onnx file.\n{e}"
             ) from e
+        # Log BEFORE the network call so an unexpected download (e.g. a bare
+        # create_policy("wbc") defaulting to nvidia/GEAR-SONIC, or a mistyped
+        # local path that happens to be org/repo-shaped) is visible, not silent.
+        logger.info(
+            "WBCPolicy resolving checkpoint %r as a HuggingFace model id; downloading (cached after first use)...",
+            checkpoint,
+        )
         try:
             local_dir = hub.snapshot_download(  # type: ignore[attr-defined]
                 repo_id=checkpoint, allow_patterns=["*.onnx", "*.json"]
@@ -562,7 +704,8 @@ class WBCPolicy(Policy):
         except Exception as e:  # noqa: BLE001 - surface any hub failure as actionable RuntimeError
             raise RuntimeError(
                 f"WBCPolicy failed to download checkpoint {checkpoint!r} from HuggingFace: {e}. "
-                "Pass a local checkpoint directory instead, or check network / model-license access."
+                "If you meant a local checkpoint, pass an existing directory or .onnx path; "
+                "otherwise check network / model-license access."
             ) from e
         logger.info("WBCPolicy downloaded checkpoint %r -> %s", checkpoint, local_dir)
         return str(local_dir)

--- a/strands_robots/policies/wbc/policy.py
+++ b/strands_robots/policies/wbc/policy.py
@@ -846,4 +846,4 @@ class WBCPolicy(Policy):
         return arr
 
 
-__all__ = ["WBCPolicy", "WBC_G1_LEG_WAIST_JOINTS"]
+__all__ = ["WBCPolicy", "WBC_G1_LEG_WAIST_JOINTS", "WBC_G1_ALL_JOINTS"]

--- a/strands_robots/policies/wbc/policy.py
+++ b/strands_robots/policies/wbc/policy.py
@@ -605,6 +605,11 @@ class WBCPolicy(Policy):
                 try:
                     out[i] = float(v)
                 except (TypeError, ValueError):
+                    # Non-numeric observation entry for this joint: leave the
+                    # pre-zeroed default in place. The full per-joint qj/dqj
+                    # block is validated downstream, so a single unparseable
+                    # key degrades to its neutral value rather than aborting
+                    # the whole observation build.
                     pass
         return out
 

--- a/strands_robots/policies/wbc/policy.py
+++ b/strands_robots/policies/wbc/policy.py
@@ -14,6 +14,16 @@ joints (16..n) are held at their nominal defaults. Layering an upper-body
 manipulation policy on top is the job of a future ``CompositePolicy`` (#468),
 deliberately out of scope here.
 
+Scope: this targets the **non-gait** reference (``run_mujoco_gear_wbc.py`` +
+``g1_gear_wbc.yaml``): single_obs_dim 86, a 7-wide command block, two policies
+(main ``policy`` + ``walk_policy``) selected by velocity. The upstream repo also
+ships a *gait-clock* variant (``run_mujoco_gear_wbc_gait.py``: single_obs_dim 95,
+an 8-wide command with ``freq_cmd`` + a 2-dim clock signal + torso slots, single
+policy) - that layout is a separate embodiment and is **not** implemented here.
+The shipped weights this matches are ``GR00T-WholeBodyControl-Balance.onnx``
+(main) and ``-Walk.onnx`` (walk), whose ONNX input is ``[batch, 516]`` (86 x 6)
+and output ``[batch, 15]``.
+
 Control contract (reproduced from the reference runner):
 
 * **Two ONNX sessions** - a main ``policy_path`` and an optional

--- a/strands_robots/policies/wbc/policy.py
+++ b/strands_robots/policies/wbc/policy.py
@@ -94,6 +94,28 @@ WBC_G1_LEG_WAIST_JOINTS: tuple[str, ...] = (
     "waist_pitch_joint",
 )
 
+# Full Unitree G1 29-DOF joint order (legs + waist + arms), matching the model's
+# qpos[7:] layout and the upstream G1_29DOF_JOINT_NAMES. The OBSERVATION reads
+# qj/dqj for ALL of these (n_obs_joints); the controller only DRIVES the first
+# 15 (WBC_G1_LEG_WAIST_JOINTS). The two share the leg+waist prefix exactly.
+WBC_G1_ALL_JOINTS: tuple[str, ...] = (
+    *WBC_G1_LEG_WAIST_JOINTS,
+    "left_shoulder_pitch_joint",
+    "left_shoulder_roll_joint",
+    "left_shoulder_yaw_joint",
+    "left_elbow_joint",
+    "left_wrist_roll_joint",
+    "left_wrist_pitch_joint",
+    "left_wrist_yaw_joint",
+    "right_shoulder_pitch_joint",
+    "right_shoulder_roll_joint",
+    "right_shoulder_yaw_joint",
+    "right_elbow_joint",
+    "right_wrist_roll_joint",
+    "right_wrist_pitch_joint",
+    "right_wrist_yaw_joint",
+)
+
 # The HF repo the checkpoint is fetched from when ``checkpoint`` is a bare
 # model id rather than a local path. No weights are bundled; they are fetched
 # at runtime under the NVIDIA Open Model License.
@@ -213,6 +235,17 @@ class WBCPolicy(Policy):
                 "G1 lower body; a different embodiment needs its own joint mapping table."
             )
 
+        # The whole-body joints the qj/dqj observation blocks read (legs+waist+
+        # arms), in WBC_G1_ALL_JOINTS order. set_robot_state_keys resolves these
+        # by name; default to the canonical table until then.
+        no = self._config.n_obs_joints
+        if no > len(WBC_G1_ALL_JOINTS):
+            raise ValueError(
+                f"WBCConfig.n_obs_joints={no} exceeds the {len(WBC_G1_ALL_JOINTS)}-entry "
+                "G1 whole-body joint mapping (WBC_G1_ALL_JOINTS)."
+            )
+        self._obs_joint_names: list[str] = list(WBC_G1_ALL_JOINTS[:no])
+
         # Pre-compute NumPy views of the per-joint vectors (once, not per tick).
         self._default_angles = (
             np.asarray(self._config.default_angles, dtype=np.float64)
@@ -287,8 +320,10 @@ class WBCPolicy(Policy):
                 the wrong joints. The error lists the missing names.
         """
         keys = list(robot_state_keys)
-        expected = WBC_G1_LEG_WAIST_JOINTS[: self._config.num_actions]
         key_set = set(keys)
+
+        # Controlled joints: the num_actions leg+waist joints WBC drives.
+        expected = WBC_G1_LEG_WAIST_JOINTS[: self._config.num_actions]
         missing = [name for name in expected if name not in key_set]
         if missing:
             raise ValueError(
@@ -299,11 +334,26 @@ class WBCPolicy(Policy):
                 "WBC drives these named joints; load the full unitree_g1 model "
                 "(its leg+waist joints carry these exact names)."
             )
-        # Store the controllable joints in WBC order (the names we read state
-        # from and emit targets for). The free/base joint and arm joints are
-        # deliberately excluded - WBC neither observes nor drives them here.
+
+        # Observed joints: the n_obs_joints whole-body joints the qj/dqj blocks
+        # read (legs+waist+arms). The controller observes the whole body even
+        # though it only drives the leg+waist subset. Resolve these by name too
+        # (in WBC_G1_ALL_JOINTS order), so the observation matches the model's
+        # qpos[7:] layout regardless of how the sim orders / namespaces joints.
+        obs_expected = WBC_G1_ALL_JOINTS[: self._config.n_obs_joints]
+        obs_missing = [name for name in obs_expected if name not in key_set]
+        if obs_missing:
+            raise ValueError(
+                "WBCPolicy: the robot's joint list is missing observed G1 joints "
+                f"(qj/dqj read the whole body, n_obs_joints={self._config.n_obs_joints}): {obs_missing}.\n"
+                f"  expected (observe order): {list(obs_expected)}\n"
+                f"  robot provided:           {keys}\n"
+                "Load the full unitree_g1 (29-DOF) model."
+            )
+
         self._robot_state_keys = list(keys)
-        self._wbc_joint_names = list(expected)
+        self._wbc_joint_names = list(expected)  # the num_actions controlled joints
+        self._obs_joint_names = list(obs_expected)  # the n_obs_joints observed joints
 
     def reset(self, seed: int | None = None) -> None:
         """Clear the observation history and previous-action feedback.
@@ -441,10 +491,13 @@ class WBCPolicy(Policy):
     def _extract_state(self, observation_dict: dict[str, Any]) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
         """Pull (qj, dqj, base_ang_vel, base_quat) out of the observation dict.
 
-        ``qj`` / ``dqj`` are the leg+waist joint positions / velocities, read by
-        name via :meth:`_read_joint_vector`. Base angular velocity and
-        orientation come from well-known keys, defaulting to a level, still base
-        when absent (an upright stance cue) rather than fabricating motion.
+        ``qj`` / ``dqj`` are the WHOLE-BODY joint positions / velocities
+        (``n_obs_joints`` = 29: legs+waist+arms), read by name via
+        :meth:`_read_joint_vector` in :data:`WBC_G1_ALL_JOINTS` order - matching
+        the upstream ``qpos[7:7+n_joints]`` observation, which spans all joints,
+        not just the 15 controlled ones. Base angular velocity and orientation
+        come from well-known keys, defaulting to a level, still base when absent
+        (an upright stance cue) rather than fabricating motion.
 
         Velocity availability: WBC is a velocity-feedback balance controller, so
         ``dqj`` and ``base_ang_vel`` are genuine inputs - not optional. The
@@ -458,9 +511,10 @@ class WBCPolicy(Policy):
         ``observation.velocity`` + ``base_ang_vel``), e.g. a teleop/IMU bridge
         or a future backend velocity field.
         """
-        n = self._config.num_actions
-        qj = self._read_joint_vector(observation_dict, "position", n)
-        dqj = self._read_joint_vector(observation_dict, "velocity", n)
+        # qj/dqj observe the whole body (n_obs_joints), in WBC_G1_ALL_JOINTS order.
+        obs_names = self._obs_joint_names
+        qj = self._read_joint_vector(observation_dict, "position", obs_names)
+        dqj = self._read_joint_vector(observation_dict, "velocity", obs_names)
 
         base_ang_vel = self._read_vec(observation_dict, ("base_ang_vel", "observation.base_ang_vel"), 3)
         if base_ang_vel is None:
@@ -488,34 +542,33 @@ class WBCPolicy(Policy):
             return True
         if float(np.linalg.norm(base_ang_vel)) > 0.0:
             return True
-        return any(f"{name}.vel" in obs for name in self._wbc_joint_names)
+        return any(f"{name}.vel" in obs for name in self._obs_joint_names)
 
-    def _read_joint_vector(self, obs: dict[str, Any], kind: str, n: int) -> np.ndarray:
-        """Read the ``n`` leg+waist joint positions/velocities from the observation.
+    def _read_joint_vector(self, obs: dict[str, Any], kind: str, names: list[str]) -> np.ndarray:
+        """Read positions/velocities for ``names`` (in order) from the observation.
 
-        Always reads BY NAME using the resolved WBC joint names
-        (:attr:`_wbc_joint_names`, in WBC output order) so index ``i`` is the
-        joint WBC output ``i`` drives - regardless of where the sim places the
-        joint or how many other (free-base, arm) joints surround it.
+        Reads BY NAME so each output index corresponds to ``names[i]`` -
+        regardless of where the sim places the joint or how many other
+        (free-base, other) joints surround it. ``names`` is the whole-body
+        observed-joint list (:attr:`_obs_joint_names`) for the qj/dqj blocks.
 
         Two observation shapes are supported:
 
         * Per-joint scalars keyed by joint name (the unified sim observation):
           ``position`` reads ``obs[name]``; ``velocity`` reads ``obs[name + ".vel"]``.
         * A flat ``observation.state`` / ``observation.velocity`` vector paired
-          with ``self._robot_state_keys`` for the index lookup. The flat vector
-          is indexed at each WBC joint's position in ``_robot_state_keys`` (NOT
-          sliced ``[:n]`` - that would grab the free-base/arm joints when they
-          precede or interleave the leg+waist joints).
+          with ``self._robot_state_keys`` for the index lookup (each name's slot
+          in the robot's key list, NOT a positional slice). Without keys, the
+          flat vector is consumed positionally (the cuRobo / MoveIt2 contract).
 
-        Missing values default to zero (a still, nominal stance). This is a
+        Missing values default to zero (a still, nominal stance) - a
         *measured-state* default, distinct from the forbidden zero-*torque*
         fallback. NOTE: if the sim exposes no joint velocities (the current
         MuJoCo backend's unified observation is positions only, with no
         ``<name>.vel`` keys), ``dqj`` reads as zeros - see :meth:`_extract_state`
         for the consequence and the recommended teleop/IMU velocity source.
         """
-        names = self._wbc_joint_names[:n]
+        m = len(names)
 
         # Flat-vector form: index into the flat array by each joint's position.
         flat_key = "observation.state" if kind == "position" else "observation.velocity"
@@ -523,31 +576,29 @@ class WBCPolicy(Policy):
         if flat is not None and hasattr(flat, "__len__"):
             arr = np.asarray(flat if not hasattr(flat, "tolist") else flat.tolist(), dtype=np.float64).ravel()
             if self._robot_state_keys:
-                # Name-resolved indexing: map each WBC joint to its slot in the
-                # robot's key list (handles a free-base/arm-interleaved layout).
+                # Name-resolved indexing: map each observed joint to its slot in
+                # the robot's key list (handles a free-base/interleaved layout).
                 # First occurrence wins so a duplicated name can't shift the slot.
                 index_of: dict[str, int] = {}
                 for i, name in enumerate(self._robot_state_keys):
                     index_of.setdefault(name, i)
-                out = np.zeros(n, dtype=np.float64)
+                out = np.zeros(m, dtype=np.float64)
                 for i, name in enumerate(names):
                     j = index_of.get(name)
                     if j is not None and j < arr.shape[0]:
                         out[i] = arr[j]
                 return out
-            # No key mapping was provided (direct-API / replay caller). Treat the
-            # flat vector as already in WBC leg+waist order - the same positional
-            # contract cuRobo / MoveIt2 use for observation.state - so a provided
-            # state is USED, not silently dropped. Consume the first n entries.
-            if arr.shape[0] >= n:
-                return arr[:n].copy()
-            # Shorter than expected: take what's there, zero-pad the rest.
-            out = np.zeros(n, dtype=np.float64)
+            # No key mapping (direct-API / replay caller). Treat the flat vector
+            # as already in `names` order - the same positional contract cuRobo /
+            # MoveIt2 use for observation.state - so a provided state is USED.
+            if arr.shape[0] >= m:
+                return arr[:m].copy()
+            out = np.zeros(m, dtype=np.float64)
             out[: arr.shape[0]] = arr
             return out
 
         # Per-joint scalar form (the unified sim observation).
-        out = np.zeros(n, dtype=np.float64)
+        out = np.zeros(m, dtype=np.float64)
         for i, k in enumerate(names):
             v = obs.get(k) if kind == "position" else obs.get(f"{k}.vel")
             if v is not None:

--- a/strands_robots/policies/wbc/policy.py
+++ b/strands_robots/policies/wbc/policy.py
@@ -486,18 +486,33 @@ class WBCPolicy(Policy):
         """
         names = self._wbc_joint_names[:n]
 
-        # Flat-vector form: index into the flat array by each joint's position
-        # in the robot's key list (name-resolved), never a positional slice.
+        # Flat-vector form: index into the flat array by each joint's position.
         flat_key = "observation.state" if kind == "position" else "observation.velocity"
         flat = obs.get(flat_key)
-        if flat is not None and hasattr(flat, "__len__") and self._robot_state_keys:
+        if flat is not None and hasattr(flat, "__len__"):
             arr = np.asarray(flat if not hasattr(flat, "tolist") else flat.tolist(), dtype=np.float64).ravel()
-            index_of = {name: i for i, name in enumerate(self._robot_state_keys)}
+            if self._robot_state_keys:
+                # Name-resolved indexing: map each WBC joint to its slot in the
+                # robot's key list (handles a free-base/arm-interleaved layout).
+                # First occurrence wins so a duplicated name can't shift the slot.
+                index_of: dict[str, int] = {}
+                for i, name in enumerate(self._robot_state_keys):
+                    index_of.setdefault(name, i)
+                out = np.zeros(n, dtype=np.float64)
+                for i, name in enumerate(names):
+                    j = index_of.get(name)
+                    if j is not None and j < arr.shape[0]:
+                        out[i] = arr[j]
+                return out
+            # No key mapping was provided (direct-API / replay caller). Treat the
+            # flat vector as already in WBC leg+waist order - the same positional
+            # contract cuRobo / MoveIt2 use for observation.state - so a provided
+            # state is USED, not silently dropped. Consume the first n entries.
+            if arr.shape[0] >= n:
+                return arr[:n].copy()
+            # Shorter than expected: take what's there, zero-pad the rest.
             out = np.zeros(n, dtype=np.float64)
-            for i, name in enumerate(names):
-                j = index_of.get(name)
-                if j is not None and j < arr.shape[0]:
-                    out[i] = arr[j]
+            out[: arr.shape[0]] = arr
             return out
 
         # Per-joint scalar form (the unified sim observation).

--- a/strands_robots/registry/policies.json
+++ b/strands_robots/registry/policies.json
@@ -151,6 +151,26 @@
             "aliases": [
                 "cumotion"
             ]
+        },
+        "wbc": {
+            "module": "strands_robots.policies.wbc",
+            "class": "WBCPolicy",
+            "description": "NVIDIA GR00T Whole-Body-Control (SONIC) humanoid locomotion (in-process, ONNX)",
+            "requires": [],
+            "config_keys": [
+                "checkpoint",
+                "config",
+                "walk",
+                "target_velocity",
+                "allow_missing_models"
+            ],
+            "defaults": {
+                "walk": true
+            },
+            "shorthands": [
+                "wbc",
+                "sonic"
+            ]
         }
     }
 }

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -309,6 +309,7 @@ class SimEngine(ABC):
         max_steps: int | None = None,
         max_onframe_failures: int | None = None,
         control_substeps: int | None = None,
+        policy_kwargs: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Run a policy loop in the simulation (blocking).
 
@@ -341,6 +342,15 @@ class SimEngine(ABC):
                 dataset recording), backends plug into
                 ``PolicyRunner.run``'s ``on_frame`` hook via
                 :meth:`_make_run_policy_hook`.
+            policy_kwargs: Optional per-call goal payload forwarded verbatim to
+                every ``policy.get_actions(obs, instruction, **policy_kwargs)``
+                call. Carries the well-known #300 goal keys
+                (``target_pose`` / ``target_joints`` / ``target_velocity`` /
+                ``world_update``) to non-VLA providers (cuRobo, MoveIt2, WBC)
+                that read their goal from kwargs rather than the instruction.
+                This is the local-sim analogue of the mesh ``tell()`` path,
+                which already forwards these keys. VLA providers ignore unknown
+                kwargs per the #300 contract, so forwarding is always safe.
 
         Returns:
             Standard status dict.
@@ -396,6 +406,7 @@ class SimEngine(ABC):
             on_frame=on_frame,
             max_onframe_failures=max_onframe_failures,
             control_substeps=control_substeps,
+            policy_kwargs=policy_kwargs,
         )
 
     def start_policy(
@@ -412,6 +423,7 @@ class SimEngine(ABC):
         policy_object: Policy | None = None,
         n_steps: int | None = None,
         max_steps: int | None = None,
+        policy_kwargs: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Start policy execution in a background thread (non-blocking).
 
@@ -421,6 +433,8 @@ class SimEngine(ABC):
 
         accepts ``n_steps`` (primary) or legacy ``max_steps`` as an
         alternate to ``duration``. See ``run_policy`` for conversion rules.
+        ``policy_kwargs`` carries the per-call #300 goal payload through to
+        ``policy.get_actions`` (see :meth:`run_policy`).
         """
         robot_name = self._resolve_single_robot(robot_name)
         return self.run_policy(
@@ -436,6 +450,7 @@ class SimEngine(ABC):
             policy_object=policy_object,
             n_steps=n_steps,
             max_steps=max_steps,
+            policy_kwargs=policy_kwargs,
         )
 
     def replay_episode(

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1914,6 +1914,7 @@ class MuJoCoSimEngine(
         policy_object: "Policy | None" = None,
         n_steps: int | None = None,
         max_steps: int | None = None,
+        policy_kwargs: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Start policy execution on a background thread (non-blocking).
 
@@ -1966,6 +1967,7 @@ class MuJoCoSimEngine(
             policy_object=policy_object,
             n_steps=n_steps,
             max_steps=max_steps,
+            policy_kwargs=policy_kwargs,
         )
         self._policy_threads[robot_name] = future
 
@@ -2057,6 +2059,7 @@ class MuJoCoSimEngine(
         max_steps: int | None = None,
         max_onframe_failures: int | None = None,
         control_substeps: int | None = None,
+        policy_kwargs: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """MuJoCo ``run_policy`` override: pre-flight world check + graceful stop.
 
@@ -2092,6 +2095,7 @@ class MuJoCoSimEngine(
                 max_steps=max_steps,
                 max_onframe_failures=max_onframe_failures,
                 control_substeps=control_substeps,
+                policy_kwargs=policy_kwargs,
             )
         finally:
             if self._world is not None and robot_name in self._world.robots:

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -288,6 +288,7 @@ class PolicyRunner:
         on_frame: OnFrame | None = None,
         max_onframe_failures: int | None = None,
         control_substeps: int | None = None,
+        policy_kwargs: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Run ``policy`` on ``robot_name`` for ``duration`` seconds.
 
@@ -309,6 +310,16 @@ class PolicyRunner:
                 after every ``send_action``. Public extension point - backends
                 layer in recording / telemetry / graceful-stop via this hook
                 without subclassing the runner.
+            policy_kwargs: Optional per-call goal payload forwarded verbatim to
+                every ``policy.get_actions(obs, instruction, **policy_kwargs)``
+                call. This is the local-sim analogue of the mesh ``tell()``
+                #300 path: it carries the well-known goal keys
+                (``target_pose`` / ``target_joints`` / ``target_velocity`` /
+                ``world_update``) to non-VLA providers that read their goal
+                from kwargs rather than the instruction (cuRobo, MoveIt2, WBC).
+                VLA providers ignore unknown kwargs per the #300 contract, so
+                this is safe to forward unconditionally. ``None`` forwards no
+                extra kwargs (identical to the historical behaviour).
             max_onframe_failures: Maximum *consecutive* non-``CooperativeStop``
                 exceptions from the ``on_frame`` hook before the runner aborts
                 the episode. ``None`` (default) uses
@@ -382,6 +393,9 @@ class PolicyRunner:
         stopped_early = False
         # T26: skip camera rendering when the policy does not need images.
         _skip_images = not getattr(policy, "requires_images", True)
+        # Normalise the per-call goal payload once. Forwarded verbatim to every
+        # get_actions() call; an empty dict is the historical (no-kwargs) path.
+        _policy_kwargs = policy_kwargs or {}
         # Initialize BEFORE try so CooperativeStop never sees unbound names.
         start_time = time.time()
         step_count = 0
@@ -423,7 +437,7 @@ class PolicyRunner:
             while step_count < total_steps:
                 observation = self.sim.get_observation(robot_name=robot_name, skip_images=_skip_images)
 
-                coro_or_result = policy.get_actions(observation, instruction)
+                coro_or_result = policy.get_actions(observation, instruction, **_policy_kwargs)
                 actions = _resolve_coroutine(coro_or_result)
 
                 for action_dict in actions[:action_horizon]:

--- a/tests/policies/wbc/test_policy.py
+++ b/tests/policies/wbc/test_policy.py
@@ -225,6 +225,31 @@ class TestObservationLayout:
         hist.reset()
         assert len(hist) == 0
 
+    def test_history_len3_rolling_window_newest_last_across_ticks(self) -> None:
+        """End-to-end: with obs_history_len=3, each tick's fed observation is a
+        258-wide stack whose blocks are [oldest .. newest] over a rolling window
+        of the last 3 frames (warm-filled at tick 0). Guards the cross-tick
+        determinism of the deque stacking through get_actions."""
+        # Zero default_angles so the frame's qj block equals the raw qj (no
+        # offset), isolating the rolling-window behaviour from default subtraction.
+        p = _make_policy(walk=False, obs_history_len=3, default_angles=[0.0] * _N)
+        obs = {k: 0.0 for k in _g1_keys()}
+        for t in range(4):
+            for nm in WBC_G1_LEG_WAIST_JOINTS:
+                obs[nm] = float(t)  # distinct qj per tick
+            asyncio.run(p.get_actions(obs, "", target_velocity=[0.0, 0.0, 0.0]))
+        fed = [c[0] for c in p.policy_session.calls]
+        assert all(f.shape[0] == 86 * 3 for f in fed)
+
+        def qj0(frame: np.ndarray, block: int) -> float:
+            # qj[0] sits at index 13 within each 86-wide block (c=7 + angvel3 + grav3).
+            return float(frame[block * 86 + 13])
+
+        # tick 0: warm-fill -> all three blocks hold the first frame (qj=0).
+        assert [qj0(fed[0], b) for b in range(3)] == [0.0, 0.0, 0.0]
+        # tick 3: rolling window of the last 3 frames -> oldest=1, mid=2, newest=3.
+        assert [qj0(fed[3], b) for b in range(3)] == [1.0, 2.0, 3.0]
+
 
 # ---------------------------------------------------------------------------
 # WBCConfig
@@ -609,3 +634,19 @@ class TestFactoryResolution:
     def test_requires_images_false_via_factory(self) -> None:
         p = create_policy("wbc", config=_make_config(), allow_missing_models=True)
         assert p.requires_images is False
+
+    def test_policy_config_path_sets_static_walk_command(self) -> None:
+        """The mesh tell() / policy_config path forwards constructor kwargs to
+        create_policy(provider, **policy_config). A target_velocity supplied that
+        way becomes the static-walk default command (used when no per-call kwarg
+        is given). This is how a command reaches WBC without policy_kwargs."""
+        p = create_policy(
+            "wbc",
+            config=_make_config(),
+            walk=True,
+            target_velocity=[0.4, 0.0, 0.0],
+            allow_missing_models=True,
+        )
+        assert isinstance(p, WBCPolicy)
+        assert p._default_command is not None
+        assert np.allclose(p._default_command, [0.4, 0.0, 0.0])

--- a/tests/policies/wbc/test_policy.py
+++ b/tests/policies/wbc/test_policy.py
@@ -28,7 +28,7 @@ import numpy as np
 import pytest
 
 from strands_robots.policies import Policy, create_policy, list_providers
-from strands_robots.policies.wbc import WBC_G1_LEG_WAIST_JOINTS, WBCConfig, WBCPolicy
+from strands_robots.policies.wbc import WBC_G1_ALL_JOINTS, WBC_G1_LEG_WAIST_JOINTS, WBCConfig, WBCPolicy
 from strands_robots.policies.wbc.control import (
     compute_targets,
     pd_control,
@@ -41,7 +41,8 @@ from strands_robots.policies.wbc.observation import ObservationHistory, build_si
 # Stub ONNX session
 # ---------------------------------------------------------------------------
 
-_N = 15  # leg + waist DOFs
+_N = 15  # leg + waist DOFs (controlled / action dim)
+_NO = 29  # observed joints (legs + waist + arms) - the qj/dqj block width
 
 
 class _StubInput:
@@ -75,18 +76,21 @@ def _g1_keys() -> list[str]:
 
     Verified against the actual robot_descriptions ``g1_mj_description`` model:
     MuJoCo prepends the free/floating-base joint, so the list is
-    ``["floating_base_joint", <15 leg+waist>, <14 arm>]`` - the leg+waist joints
-    are at indices [1:16], NOT [0:15]. Using the real layout here is what
-    exercises WBCPolicy's name-based joint resolution (a fixture that put the
-    leg+waist joints first would hide the floating-base ordering bug).
+    ``["floating_base_joint", <15 leg+waist>, <14 arm>]`` (the real arm joint
+    NAMES, since set_robot_state_keys now resolves the whole-body observed set
+    by name). The leg+waist joints are at indices [1:16], NOT [0:15].
     """
-    return ["floating_base_joint", *WBC_G1_LEG_WAIST_JOINTS, *[f"arm_{i}" for i in range(14)]]
+    return ["floating_base_joint", *WBC_G1_ALL_JOINTS]
 
 
 def _make_config(**overrides) -> WBCConfig:  # type: ignore[no-untyped-def]
+    # Default to the real G1 layout: 29 observed joints, 15 controlled, 86-wide
+    # frame (7 cmd + 3 omega + 3 grav + 29 qj + 29 dqj + 15 action). Tests that
+    # want a faster/smaller layout override n_obs_joints + single_obs_dim.
     base = dict(
         policy_path="policy.onnx",
         num_actions=_N,
+        n_obs_joints=_NO,
         command_dim=7,
         single_obs_dim=86,
         obs_history_len=1,
@@ -172,32 +176,35 @@ class TestControlMath:
 
 class TestObservationLayout:
     def test_exact_86_dim_layout(self) -> None:
-        cfg = _make_config()
+        cfg = _make_config()  # n_obs_joints=29, num_actions=15
         frame = build_single_frame(
             cfg,
             command=np.array([0.5, 0.0, 0.0]),  # short -> zero-padded to 7
             base_ang_vel=np.array([1.0, 2.0, 3.0]),
             proj_gravity=np.array([0.0, 0.0, -1.0]),
-            qj=np.array([0.2] * _N),
-            dqj=np.array([0.0] * _N),
-            prev_action=np.array([0.0] * _N),
+            qj=np.array([0.2] * _NO),  # 29 observed joints
+            dqj=np.array([0.0] * _NO),
+            prev_action=np.array([0.0] * _N),  # 15 controlled
         )
         assert frame.shape == (86,)
         # build_single_frame zero-pads a short command: vx at 0, slots 3..7 zero.
-        # (The policy normally supplies the full 7-wide [vel*scale, height, rpy]
-        # command; build_single_frame still accepts and pads a short one.)
         assert frame[0] == 0.5
         assert np.allclose(frame[3:7], 0.0)
         # base ang vel scaled by obs_scales.ang_vel (upstream 0.5): index 7 = 1.0*0.5
         assert np.isclose(frame[7], 1.0 * cfg.obs_scales["ang_vel"])
-        assert np.isclose(frame[7], 0.5)  # pin the corrected upstream value
+        assert np.isclose(frame[7], 0.5)
         # projected gravity unscaled at [10:13]
         assert np.allclose(frame[10:13], [0.0, 0.0, -1.0])
-        # qj - defaults scaled by dof_pos (1.0): (0.2-0.1) at index 13
+        # qj block at [13 : 13+29]; default_angles only covers the first 15
+        # (legs+waist), arms get zero default. qj[0]=(0.2-0.1)=0.1 at index 13;
+        # qj[15] (first arm) = (0.2-0.0)=0.2 at index 13+15=28.
         assert np.isclose(frame[13], 0.1)
-        # populated end = command(7) + angvel(3) + grav(3) + qj(15) + dqj(15)
-        # + action(15) = 58; indices [58:86] are the reserved (zero) tail.
-        assert np.allclose(frame[58:], 0.0)
+        assert np.isclose(frame[28], 0.2)
+        # dqj block at [13+29 : 13+58] = [42:71]; action block at [71:86].
+        assert np.allclose(frame[42:71], 0.0)  # dqj all zero here
+        assert np.allclose(frame[71:86], 0.0)  # prev_action all zero
+        # populated end = 7 + 3 + 3 + 29 + 29 + 15 = 86; no reserved tail remains.
+        assert frame.shape[0] == 86
 
     def test_command_overflow_raises(self) -> None:
         cfg = _make_config(command_dim=3)
@@ -431,10 +438,11 @@ class TestWBCPolicy:
         asyncio.run(p.get_actions(obs, "", target_velocity=[0.0, 0.0, 0.0]))
         # second call: the frame's prev-action block should equal the stub's
         # raw output (0.04), proving feedback. The block sits at
-        # [c+6+2n : c+6+3n] = [7+6+30 : 7+6+45] = [43:58] for c=7, n=15.
+        # [c+6+2*no : c+6+2*no+na] = [7+6+58 : 7+6+58+15] = [71:86] for c=7,
+        # no=29, na=15.
         asyncio.run(p.get_actions(obs, "", target_velocity=[0.0, 0.0, 0.0]))
         fed = p.policy_session.calls[1][0]  # (num_obs,)
-        prev_block = fed[43 : 43 + 15]
+        prev_block = fed[71 : 71 + 15]
         assert np.allclose(prev_block, 0.04)
 
     def test_no_session_raises_not_silent_zeros(self) -> None:
@@ -477,22 +485,31 @@ class TestActuatorMapping:
         with pytest.raises(ValueError, match="missing expected G1"):
             p.set_robot_state_keys(list(WBC_G1_LEG_WAIST_JOINTS[:10]))
 
-    def test_exact_15_keys_accepted(self) -> None:
+    def test_all_29_joints_accepted(self) -> None:
+        # The default config observes 29 joints, so the whole-body set is required.
         p = WBCPolicy(config=_make_config(), allow_missing_models=True)
-        p.set_robot_state_keys(list(WBC_G1_LEG_WAIST_JOINTS))  # exactly the 15, any surrounding order
+        p.set_robot_state_keys(list(WBC_G1_ALL_JOINTS))  # exactly the 29, any surrounding order
+
+    def test_missing_arm_joints_raises_for_observed_set(self) -> None:
+        # Only the 15 leg+waist joints (no arms) is insufficient when n_obs_joints=29.
+        p = WBCPolicy(config=_make_config(), allow_missing_models=True)
+        with pytest.raises(ValueError, match="missing observed G1 joints"):
+            p.set_robot_state_keys(list(WBC_G1_LEG_WAIST_JOINTS))
 
     def test_reads_state_by_name_not_position(self) -> None:
         """qj is read from the named joints even when a free-base joint precedes
-        them in the observation (so a positional [:15] slice would be wrong)."""
+        them in the observation (so a positional slice would be wrong). qj spans
+        the 29 observed joints in WBC_G1_ALL_JOINTS order."""
         p = _make_policy()  # uses _g1_keys() ordering with floating_base first
         obs = {k: 0.0 for k in _g1_keys()}
-        # Give each leg+waist joint a distinct, recognisable value; give the
-        # floating_base and arms a sentinel that must NOT appear in qj.
-        for i, name in enumerate(WBC_G1_LEG_WAIST_JOINTS):
+        # Give each observed joint a distinct value; floating_base gets a
+        # sentinel that must NOT appear in qj.
+        for i, name in enumerate(WBC_G1_ALL_JOINTS):
             obs[name] = 0.1 * (i + 1)
         obs["floating_base_joint"] = 99.0
-        qj = p._read_joint_vector(obs, "position", 15)
-        assert np.allclose(qj, [0.1 * (i + 1) for i in range(15)])
+        qj = p._read_joint_vector(obs, "position", p._obs_joint_names)
+        assert qj.shape[0] == 29
+        assert np.allclose(qj, [0.1 * (i + 1) for i in range(29)])
         assert 99.0 not in qj  # the free-base value never leaks in
 
 
@@ -647,13 +664,15 @@ class TestRegressionFixes:
         assert not [r for r in caplog.records if "no joint velocities" in r.message]
 
     def test_per_joint_velocity_read_by_name(self) -> None:
-        """When the observation DOES expose '<name>.vel' keys, dqj reads them."""
+        """When the observation DOES expose '<name>.vel' keys, dqj reads them
+        for all 29 observed joints in WBC_G1_ALL_JOINTS order."""
         p = _make_policy(walk=False)
         obs = {k: 0.0 for k in _g1_keys()}
-        for i, name in enumerate(WBC_G1_LEG_WAIST_JOINTS):
+        for i, name in enumerate(WBC_G1_ALL_JOINTS):
             obs[f"{name}.vel"] = 0.01 * (i + 1)
-        dqj = p._read_joint_vector(obs, "velocity", 15)
-        assert np.allclose(dqj, [0.01 * (i + 1) for i in range(15)])
+        dqj = p._read_joint_vector(obs, "velocity", p._obs_joint_names)
+        assert dqj.shape[0] == 29
+        assert np.allclose(dqj, [0.01 * (i + 1) for i in range(29)])
 
     def test_num_actions_exceeding_mapping_table_rejected(self) -> None:
         """REGRESSION #8: num_actions > 15 silently truncated the 15-entry
@@ -667,22 +686,23 @@ class TestRegressionFixes:
     def test_flat_state_used_without_set_robot_state_keys(self) -> None:
         """REGRESSION (review #1): a provided observation.state must be USED even
         when set_robot_state_keys was never called - not silently zeroed. Matches
-        the positional observation.state contract of cuRobo / MoveIt2."""
+        the positional observation.state contract of cuRobo / MoveIt2. Consumed
+        in the observed-joint order (29 entries by default)."""
         p = WBCPolicy(config=_make_config(), allow_missing_models=True)  # no set_robot_state_keys
-        state = [0.1 * (i + 1) for i in range(15)]
-        qj = p._read_joint_vector({"observation.state": state}, "position", 15)
+        state = [0.1 * (i + 1) for i in range(29)]
+        qj = p._read_joint_vector({"observation.state": state}, "position", p._obs_joint_names)
         assert np.allclose(qj, state), "flat observation.state must be consumed positionally without keys"
 
     def test_flat_state_name_resolved_first_occurrence_wins(self) -> None:
         """REGRESSION (review #8): a duplicated joint name in the key list must
         not shift the resolved slot - first occurrence wins."""
         p = WBCPolicy(config=_make_config(), allow_missing_models=True)
-        # floating_base first, then the 15 WBC joints, then a DUP of the first
-        # WBC joint at the end (which must NOT win the slot).
-        keys = ["floating_base_joint", *WBC_G1_LEG_WAIST_JOINTS, "left_hip_pitch_joint"]
+        # floating_base first, then all 29 observed joints, then a DUP of the
+        # first joint at the end (which must NOT win the slot).
+        keys = ["floating_base_joint", *WBC_G1_ALL_JOINTS, "left_hip_pitch_joint"]
         p.set_robot_state_keys(keys)
         arr = [float(i) for i in range(len(keys))]  # value at index i == i
-        qj = p._read_joint_vector({"observation.state": arr}, "position", 15)
+        qj = p._read_joint_vector({"observation.state": arr}, "position", p._obs_joint_names)
         assert qj[0] == 1.0, "left_hip_pitch_joint must resolve to its FIRST occurrence (index 1), not the dup"
 
 
@@ -742,11 +762,31 @@ class TestUpstreamFidelity:
         assert c.obs_history_len == 6  # g1_gear_wbc.yaml
         assert c.num_obs == 516  # 86 * 6
         assert c.num_actions == 15
+        assert c.n_obs_joints == 29  # qj/dqj observe the whole body, not just 15
         assert c.command_dim == 7
         assert c.action_scale == 0.25
         assert c.obs_scales == {"ang_vel": 0.5, "dof_pos": 1.0, "dof_vel": 0.05}
         assert c.cmd_scale == [2.0, 2.0, 0.5]
         assert c.height_cmd == 0.74
+
+    def test_obs_layout_observes_29_joints_not_15(self) -> None:
+        """CRITICAL pin: qj/dqj blocks are n_obs_joints (29) wide, NOT num_actions
+        (15). 7+3+3+29+29+15 = 86 = single_obs_dim. A 15-wide qj/dqj would only
+        populate 58 and misplace the data - the network would see garbage even
+        though the 516 total still loads. Verified against upstream
+        compute_observation (qj=qpos[7:7+n_joints], n_joints=29) and the real
+        GR00T-WholeBodyControl-Balance.onnx (input width 516)."""
+        c = WBCConfig(policy_path="p.onnx")
+        populated = c.command_dim + 3 + 3 + 2 * c.n_obs_joints + c.num_actions
+        assert populated == c.single_obs_dim == 86
+        # The whole-body mapping must be long enough for n_obs_joints, and its
+        # first num_actions names must be exactly the controlled leg+waist set.
+        assert len(WBC_G1_ALL_JOINTS) >= c.n_obs_joints
+        assert WBC_G1_ALL_JOINTS[: c.num_actions] == WBC_G1_LEG_WAIST_JOINTS
+
+    def test_n_obs_joints_below_num_actions_rejected(self) -> None:
+        with pytest.raises(ValueError, match="n_obs_joints .* must be >= num_actions"):
+            WBCConfig(policy_path="p.onnx", n_obs_joints=10, num_actions=15)
 
     def test_command_layout_matches_compute_observation(self) -> None:
         """command[0:3] = vel*cmd_scale; command[3] = height; command[4:7] = rpy."""

--- a/tests/policies/wbc/test_policy.py
+++ b/tests/policies/wbc/test_policy.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import asyncio
 import json
 import math
+from typing import Any
 
 import numpy as np
 import pytest
@@ -652,7 +653,7 @@ class TestRegressionFixes:
         import logging
 
         p = _make_policy(walk=False)
-        obs = {k: 0.0 for k in _g1_keys()}
+        obs: dict[str, Any] = {k: 0.0 for k in _g1_keys()}
         obs["base_ang_vel"] = [0.0, 0.0, 0.1]  # a real velocity signal
         with caplog.at_level(logging.WARNING):
             asyncio.run(p.get_actions(obs, "", target_velocity=[0.0, 0.0, 0.0]))

--- a/tests/policies/wbc/test_policy.py
+++ b/tests/policies/wbc/test_policy.py
@@ -857,3 +857,36 @@ class TestUpstreamFidelity:
             q /= np.linalg.norm(q)
             v = rng.randn(3)
             assert np.allclose(quat_rotate_inverse(q, v), upstream(q, v), atol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# Mesh / Device Connect security allowlist
+# ---------------------------------------------------------------------------
+
+
+class TestMeshSecurityAllowlist:
+    """WBC must pass the mesh / Device Connect policy-provider allowlist, or it
+    can't be driven over tell() / Device Connect (validate_command and the DC
+    drivers reject an un-allowlisted provider). Regression for the gap where the
+    allowlist wasn't updated when the provider was added."""
+
+    def test_wbc_and_sonic_in_policy_provider_allowlist(self) -> None:
+        from strands_robots.mesh.security import is_safe_policy_provider
+
+        assert is_safe_policy_provider("wbc")
+        assert is_safe_policy_provider("sonic")
+        assert is_safe_policy_provider("WBC")  # case-insensitive
+
+    def test_mesh_validate_command_accepts_wbc_execute(self) -> None:
+        from strands_robots.mesh.security import validate_command
+
+        # A tell()-shaped execute command with policy_provider=wbc must validate
+        # (it previously failed the policy_provider allowlist check).
+        cmd = {
+            "action": "execute",
+            "instruction": "walk forward",
+            "policy_provider": "wbc",
+            "duration": 5.0,
+        }
+        out = validate_command(cmd)
+        assert out["policy_provider"] == "wbc"

--- a/tests/policies/wbc/test_policy.py
+++ b/tests/policies/wbc/test_policy.py
@@ -566,6 +566,27 @@ class TestRegressionFixes:
         with pytest.raises(ValueError, match="exceeds the 15-entry"):
             WBCPolicy(config=cfg, allow_missing_models=True)
 
+    def test_flat_state_used_without_set_robot_state_keys(self) -> None:
+        """REGRESSION (review #1): a provided observation.state must be USED even
+        when set_robot_state_keys was never called - not silently zeroed. Matches
+        the positional observation.state contract of cuRobo / MoveIt2."""
+        p = WBCPolicy(config=_make_config(), allow_missing_models=True)  # no set_robot_state_keys
+        state = [0.1 * (i + 1) for i in range(15)]
+        qj = p._read_joint_vector({"observation.state": state}, "position", 15)
+        assert np.allclose(qj, state), "flat observation.state must be consumed positionally without keys"
+
+    def test_flat_state_name_resolved_first_occurrence_wins(self) -> None:
+        """REGRESSION (review #8): a duplicated joint name in the key list must
+        not shift the resolved slot - first occurrence wins."""
+        p = WBCPolicy(config=_make_config(), allow_missing_models=True)
+        # floating_base first, then the 15 WBC joints, then a DUP of the first
+        # WBC joint at the end (which must NOT win the slot).
+        keys = ["floating_base_joint", *WBC_G1_LEG_WAIST_JOINTS, "left_hip_pitch_joint"]
+        p.set_robot_state_keys(keys)
+        arr = [float(i) for i in range(len(keys))]  # value at index i == i
+        qj = p._read_joint_vector({"observation.state": arr}, "position", 15)
+        assert qj[0] == 1.0, "left_hip_pitch_joint must resolve to its FIRST occurrence (index 1), not the dup"
+
 
 # ---------------------------------------------------------------------------
 # Factory / registry resolution

--- a/tests/policies/wbc/test_policy.py
+++ b/tests/policies/wbc/test_policy.py
@@ -183,16 +183,20 @@ class TestObservationLayout:
             prev_action=np.array([0.0] * _N),
         )
         assert frame.shape == (86,)
-        # command head: vx at 0, padded zeros at 3..7
+        # build_single_frame zero-pads a short command: vx at 0, slots 3..7 zero.
+        # (The policy normally supplies the full 7-wide [vel*scale, height, rpy]
+        # command; build_single_frame still accepts and pads a short one.)
         assert frame[0] == 0.5
         assert np.allclose(frame[3:7], 0.0)
-        # base ang vel scaled by obs_scales.ang_vel (0.25): index 7 = 1.0*0.25
-        assert np.isclose(frame[7], 0.25)
+        # base ang vel scaled by obs_scales.ang_vel (upstream 0.5): index 7 = 1.0*0.5
+        assert np.isclose(frame[7], 1.0 * cfg.obs_scales["ang_vel"])
+        assert np.isclose(frame[7], 0.5)  # pin the corrected upstream value
         # projected gravity unscaled at [10:13]
         assert np.allclose(frame[10:13], [0.0, 0.0, -1.0])
         # qj - defaults scaled by dof_pos (1.0): (0.2-0.1) at index 13
         assert np.isclose(frame[13], 0.1)
-        # tail padding (gait/style) is zero: end = 7+6+45 = 58
+        # populated end = command(7) + angvel(3) + grav(3) + qj(15) + dqj(15)
+        # + action(15) = 58; indices [58:86] are the reserved (zero) tail.
         assert np.allclose(frame[58:], 0.0)
 
     def test_command_overflow_raises(self) -> None:
@@ -650,3 +654,97 @@ class TestFactoryResolution:
         assert isinstance(p, WBCPolicy)
         assert p._default_command is not None
         assert np.allclose(p._default_command, [0.4, 0.0, 0.0])
+
+
+# ---------------------------------------------------------------------------
+# Upstream-fidelity pins (verified against NVlabs/GR00T-WholeBodyControl
+# decoupled_wbc/sim2mujoco: run_mujoco_gear_wbc.py + g1_gear_wbc.yaml)
+# ---------------------------------------------------------------------------
+
+
+class TestUpstreamFidelity:
+    """Pin the exact contract of the upstream reference runner so a refactor
+    can't silently drift from it. Values are transcribed from g1_gear_wbc.yaml
+    and compute_observation()/run() in run_mujoco_gear_wbc.py."""
+
+    def test_default_config_matches_upstream_yaml(self) -> None:
+        c = WBCConfig(policy_path="p.onnx")  # defaults only
+        assert c.single_obs_dim == 86
+        assert c.obs_history_len == 6  # g1_gear_wbc.yaml
+        assert c.num_obs == 516  # 86 * 6
+        assert c.num_actions == 15
+        assert c.command_dim == 7
+        assert c.action_scale == 0.25
+        assert c.obs_scales == {"ang_vel": 0.5, "dof_pos": 1.0, "dof_vel": 0.05}
+        assert c.cmd_scale == [2.0, 2.0, 0.5]
+        assert c.height_cmd == 0.74
+
+    def test_command_layout_matches_compute_observation(self) -> None:
+        """command[0:3] = vel*cmd_scale; command[3] = height; command[4:7] = rpy."""
+        p = WBCPolicy(config=_make_config(), allow_missing_models=True)
+        cmd, raw_vel = p._resolve_command(
+            {"target_velocity": [0.5, -0.25, 2.0], "target_orientation": [0.1, 0.2, 0.3], "height": 0.8}
+        )
+        # cmd_scale default [2,2,0.5]: [0.5*2, -0.25*2, 2.0*0.5] = [1.0, -0.5, 1.0]
+        assert np.allclose(cmd[:3], [1.0, -0.5, 1.0])
+        assert np.isclose(cmd[3], 0.8)  # per-call height overrides config
+        assert np.allclose(cmd[4:7], [0.1, 0.2, 0.3])
+        # raw velocity is UNSCALED (used for walk selection)
+        assert np.allclose(raw_vel, [0.5, -0.25, 2.0])
+
+    def test_height_defaults_to_config_when_not_supplied(self) -> None:
+        p = WBCPolicy(config=_make_config(), allow_missing_models=True)
+        cmd, _ = p._resolve_command({"target_velocity": [0.0, 0.0, 0.0]})
+        assert np.isclose(cmd[3], 0.74)  # upstream default height_cmd
+
+    def test_walk_threshold_is_0_05_on_raw_velocity(self) -> None:
+        """Upstream: norm(loco_cmd) <= 0.05 -> main (standing) policy; above -> walk.
+        The threshold is tested on the RAW (unscaled) velocity, not the
+        cmd_scale'd command block."""
+        obs = {k: 0.0 for k in _g1_keys()}
+        # vel norm 0.04 < 0.05 -> main policy (standing)
+        p1 = _make_policy(walk=True)
+        asyncio.run(p1.get_actions(obs, "", target_velocity=[0.04, 0.0, 0.0]))
+        assert p1.policy_session.calls and not p1.walk_session.calls
+        # vel norm 0.06 > 0.05 -> walk policy
+        p2 = _make_policy(walk=True)
+        asyncio.run(p2.get_actions(obs, "", target_velocity=[0.06, 0.0, 0.0]))
+        assert p2.walk_session.calls and not p2.policy_session.calls
+
+    def test_walk_selection_uses_raw_not_scaled_velocity(self) -> None:
+        """A velocity of 0.03 scales to 0.06 under cmd_scale=2.0, but the walk
+        decision must use the RAW 0.03 (< 0.05 -> standing), not the scaled 0.06.
+        Guards against regressing to testing the scaled command block."""
+        p = _make_policy(walk=True)
+        obs = {k: 0.0 for k in _g1_keys()}
+        asyncio.run(p.get_actions(obs, "", target_velocity=[0.03, 0.0, 0.0]))
+        assert p.policy_session.calls, "raw 0.03 < 0.05 -> standing/main, despite scaling to 0.06"
+        assert not p.walk_session.calls
+
+    def test_quat_rotate_inverse_matches_upstream_formula(self) -> None:
+        """My quat helper must be numerically identical to the upstream
+        conjugate-based quat_rotate_inverse (run_mujoco_gear_wbc.py:126-141)."""
+
+        def upstream(q: np.ndarray, v: np.ndarray) -> np.ndarray:
+            w, x, y, z = q
+            qc = np.array([w, -x, -y, -z])
+            return np.array(
+                [
+                    v[0] * (qc[0] ** 2 + qc[1] ** 2 - qc[2] ** 2 - qc[3] ** 2)
+                    + v[1] * 2 * (qc[1] * qc[2] - qc[0] * qc[3])
+                    + v[2] * 2 * (qc[1] * qc[3] + qc[0] * qc[2]),
+                    v[0] * 2 * (qc[1] * qc[2] + qc[0] * qc[3])
+                    + v[1] * (qc[0] ** 2 - qc[1] ** 2 + qc[2] ** 2 - qc[3] ** 2)
+                    + v[2] * 2 * (qc[2] * qc[3] - qc[0] * qc[1]),
+                    v[0] * 2 * (qc[1] * qc[3] - qc[0] * qc[2])
+                    + v[1] * 2 * (qc[2] * qc[3] + qc[0] * qc[1])
+                    + v[2] * (qc[0] ** 2 - qc[1] ** 2 - qc[2] ** 2 + qc[3] ** 2),
+                ]
+            )
+
+        rng = np.random.RandomState(0)
+        for _ in range(200):
+            q = rng.randn(4)
+            q /= np.linalg.norm(q)
+            v = rng.randn(3)
+            assert np.allclose(quat_rotate_inverse(q, v), upstream(q, v), atol=1e-10)

--- a/tests/policies/wbc/test_policy.py
+++ b/tests/policies/wbc/test_policy.py
@@ -29,6 +29,7 @@ import pytest
 
 from strands_robots.policies import Policy, create_policy, list_providers
 from strands_robots.policies.wbc import WBC_G1_ALL_JOINTS, WBC_G1_LEG_WAIST_JOINTS, WBCConfig, WBCPolicy
+from strands_robots.policies.wbc import policy as wbc_policy
 from strands_robots.policies.wbc.control import (
     compute_targets,
     pd_control,
@@ -576,8 +577,6 @@ class TestCheckpointResolution:
     def test_hf_id_without_hub_raises_runtime_error(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
         # An org/repo id with huggingface_hub absent must raise RuntimeError
         # (not silently proceed). Simulate the missing dep via require_optional.
-        import strands_robots.policies.wbc.policy as wbc_policy
-
         def _boom(*a, **k):  # type: ignore[no-untyped-def]
             raise ImportError("no huggingface_hub")
 
@@ -586,22 +585,18 @@ class TestCheckpointResolution:
             WBCPolicy._maybe_download_checkpoint("nvidia/GEAR-SONIC")
 
     def test_hf_id_heuristic_accepts_org_repo(self) -> None:
-        from strands_robots.policies.wbc.policy import _looks_like_hf_repo_id
-
-        assert _looks_like_hf_repo_id("nvidia/GEAR-SONIC")
-        assert _looks_like_hf_repo_id("org-name/repo.name_1")
+        assert wbc_policy._looks_like_hf_repo_id("nvidia/GEAR-SONIC")
+        assert wbc_policy._looks_like_hf_repo_id("org-name/repo.name_1")
 
     def test_hf_id_heuristic_rejects_path_like(self) -> None:
-        from strands_robots.policies.wbc.policy import _looks_like_hf_repo_id
-
         # Path-like strings must NOT be treated as HF ids (no surprise downloads).
-        assert not _looks_like_hf_repo_id("./models/policy")
-        assert not _looks_like_hf_repo_id("../ckpt/sonic")
-        assert not _looks_like_hf_repo_id("/abs/path/sonic")
-        assert not _looks_like_hf_repo_id("~/sonic")
-        assert not _looks_like_hf_repo_id("a/b/c")  # more than one slash
-        assert not _looks_like_hf_repo_id("dir/policy.onnx")  # .onnx file
-        assert not _looks_like_hf_repo_id("win\\path")  # backslash
+        assert not wbc_policy._looks_like_hf_repo_id("./models/policy")
+        assert not wbc_policy._looks_like_hf_repo_id("../ckpt/sonic")
+        assert not wbc_policy._looks_like_hf_repo_id("/abs/path/sonic")
+        assert not wbc_policy._looks_like_hf_repo_id("~/sonic")
+        assert not wbc_policy._looks_like_hf_repo_id("a/b/c")  # more than one slash
+        assert not wbc_policy._looks_like_hf_repo_id("dir/policy.onnx")  # .onnx file
+        assert not wbc_policy._looks_like_hf_repo_id("win\\path")  # backslash
 
 
 # ---------------------------------------------------------------------------

--- a/tests/policies/wbc/test_policy.py
+++ b/tests/policies/wbc/test_policy.py
@@ -212,35 +212,50 @@ class TestObservationLayout:
                 prev_action=np.zeros(_N),
             )
 
-    def test_history_warm_start_and_width(self) -> None:
+    def test_history_zero_warm_start_and_width(self) -> None:
+        """Upstream warm-start: the deque is pre-filled with ZERO frames, so the
+        first push yields [zeros .. zeros, frame] (oldest-first), NOT copies of
+        the first frame. Matches run_mujoco_gear_wbc.py:47-50."""
         cfg = _make_config(obs_history_len=3)
         assert cfg.num_obs == 86 * 3
         hist = ObservationHistory(cfg)
-        frame = np.arange(86, dtype=np.float64)
+        # Buffer is always full (zero-warm-started) even before any push.
+        assert len(hist) == 3
+        frame = np.arange(1.0, 87.0, dtype=np.float64)  # all-nonzero, distinct
         stacked = hist.push(frame)
         assert stacked.shape == (258,)
-        assert len(hist) == 3  # warm-filled with copies of the first frame
-        assert np.allclose(stacked[:86], stacked[86:172])
+        assert len(hist) == 3
+        # Oldest two blocks are the zero warm-start; newest block is `frame`.
+        assert np.allclose(stacked[0:86], 0.0)
+        assert np.allclose(stacked[86:172], 0.0)
+        assert np.allclose(stacked[172:258], frame)
 
-    def test_history_reset_clears(self) -> None:
+    def test_history_reset_restores_zero_warm_start(self) -> None:
         hist = ObservationHistory(_make_config(obs_history_len=2))
-        hist.push(np.zeros(86))
+        # Always full (zero-warm-started) - never empties.
+        assert len(hist) == 2
+        hist.push(np.full(86, 5.0))
         assert len(hist) == 2
         hist.reset()
-        assert len(hist) == 0
+        assert len(hist) == 2  # re-seeded with zero frames, not emptied
+        # After reset, a push again yields [zeros, frame].
+        frame = np.arange(1.0, 87.0, dtype=np.float64)
+        stacked = hist.push(frame)
+        assert np.allclose(stacked[0:86], 0.0)
+        assert np.allclose(stacked[86:172], frame)
 
-    def test_history_len3_rolling_window_newest_last_across_ticks(self) -> None:
-        """End-to-end: with obs_history_len=3, each tick's fed observation is a
-        258-wide stack whose blocks are [oldest .. newest] over a rolling window
-        of the last 3 frames (warm-filled at tick 0). Guards the cross-tick
-        determinism of the deque stacking through get_actions."""
+    def test_history_len3_zero_warm_start_then_rolling_window(self) -> None:
+        """End-to-end: with obs_history_len=3, the network input is a 258-wide
+        stack [oldest .. newest]. The deque is ZERO-warm-started (upstream), so
+        early ticks show zeros in the older slots - NOT copies of the first
+        frame. Distinguishes the two by using a NONZERO tick-0 qj."""
         # Zero default_angles so the frame's qj block equals the raw qj (no
-        # offset), isolating the rolling-window behaviour from default subtraction.
+        # offset), isolating the warm-start/rolling-window from default subtraction.
         p = _make_policy(walk=False, obs_history_len=3, default_angles=[0.0] * _N)
         obs = {k: 0.0 for k in _g1_keys()}
         for t in range(4):
             for nm in WBC_G1_LEG_WAIST_JOINTS:
-                obs[nm] = float(t)  # distinct qj per tick
+                obs[nm] = float(t + 1)  # tick0 qj=1 (NONZERO, so != zero warm-start)
             asyncio.run(p.get_actions(obs, "", target_velocity=[0.0, 0.0, 0.0]))
         fed = [c[0] for c in p.policy_session.calls]
         assert all(f.shape[0] == 86 * 3 for f in fed)
@@ -249,10 +264,11 @@ class TestObservationLayout:
             # qj[0] sits at index 13 within each 86-wide block (c=7 + angvel3 + grav3).
             return float(frame[block * 86 + 13])
 
-        # tick 0: warm-fill -> all three blocks hold the first frame (qj=0).
-        assert [qj0(fed[0], b) for b in range(3)] == [0.0, 0.0, 0.0]
-        # tick 3: rolling window of the last 3 frames -> oldest=1, mid=2, newest=3.
-        assert [qj0(fed[3], b) for b in range(3)] == [1.0, 2.0, 3.0]
+        # tick 0: ZERO warm-start in the two older blocks; newest is the tick-0
+        # frame (qj=1). If warm-fill copied the first frame, all three would be 1.
+        assert [qj0(fed[0], b) for b in range(3)] == [0.0, 0.0, 1.0]
+        # tick 3: rolling window of the last 3 frames -> oldest=2, mid=3, newest=4.
+        assert [qj0(fed[3], b) for b in range(3)] == [2.0, 3.0, 4.0]
 
 
 # ---------------------------------------------------------------------------
@@ -285,6 +301,52 @@ class TestWBCConfig:
     def test_command_dim_floor(self) -> None:
         with pytest.raises(ValueError, match="command_dim must be >= 3"):
             WBCConfig(policy_path="p.onnx", command_dim=2)
+
+    def test_from_file_yaml_with_flat_scale_keys(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        """The upstream g1_gear_wbc.yaml uses flat ang_vel_scale/dof_pos_scale/
+        dof_vel_scale keys and YAML format. WBCConfig.from_file must load it and
+        normalise the flat scales into obs_scales."""
+        pytest.importorskip("yaml", reason="pyyaml not installed")
+        y = tmp_path / "g1_gear_wbc.yaml"
+        y.write_text(
+            "policy_path: policy/ft92.onnx\n"
+            "walk_policy_path: policy/ft109.onnx\n"
+            "num_actions: 15\n"
+            "num_obs: 516\n"
+            "obs_history_len: 6\n"
+            "action_scale: 0.25\n"
+            "ang_vel_scale: 0.5\n"
+            "dof_pos_scale: 1.0\n"
+            "dof_vel_scale: 0.05\n"
+            "cmd_scale: [2.0, 2.0, 0.5]\n"
+            "height_cmd: 0.74\n"
+            "default_angles: [-0.1, 0, 0, 0.3, -0.2, 0, -0.1, 0, 0, 0.3, -0.2, 0, 0, 0, 0]\n"
+            "kps: [150,150,150,200,40,40,150,150,150,200,40,40,250,250,250]\n"
+            "kds: [2,2,2,4,2,2,2,2,2,4,2,2,5,5,5]\n"
+            "simulation_dt: 0.005\n"  # an unknown key the loader must ignore
+            "cmd_init: [0.0, 0.0, 0.0]\n"  # another unknown key
+        )
+        cfg = WBCConfig.from_file(str(y))
+        assert cfg.num_obs == 516 and cfg.obs_history_len == 6
+        assert cfg.obs_scales == {"ang_vel": 0.5, "dof_pos": 1.0, "dof_vel": 0.05}
+        assert cfg.cmd_scale == [2.0, 2.0, 0.5] and cfg.height_cmd == 0.74
+        assert len(cfg.default_angles) == 15 and len(cfg.kps) == 15 and len(cfg.kds) == 15
+
+    def test_from_file_unsupported_extension_raises(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        p = tmp_path / "config.txt"
+        p.write_text("policy_path: x")
+        with pytest.raises(ValueError, match="unsupported extension"):
+            WBCConfig.from_file(str(p))
+
+    def test_explicit_obs_scales_wins_over_flat_keys(self) -> None:
+        c = WBCConfig.from_dict(
+            {"policy_path": "x", "ang_vel_scale": 0.5, "obs_scales": {"ang_vel": 0.9, "dof_pos": 1.0, "dof_vel": 0.05}}
+        )
+        assert c.obs_scales["ang_vel"] == 0.9  # explicit map overrides the flat key
+
+    def test_cmd_scale_wrong_length_rejected(self) -> None:
+        with pytest.raises(ValueError, match="cmd_scale must have exactly 3"):
+            WBCConfig(policy_path="p.onnx", cmd_scale=[2.0, 2.0])
 
 
 # ---------------------------------------------------------------------------
@@ -353,7 +415,14 @@ class TestWBCPolicy:
         assert not np.allclose(p._prev_action, 0.0)
         p.reset()
         assert np.allclose(p._prev_action, 0.0)
-        assert len(p._history) == 0
+        # History is re-seeded to the zero warm-start (always full = maxlen), and
+        # the next push must yield the zero warm-start transient again.
+        assert len(p._history) == p.config.obs_history_len
+        if p.config.obs_history_len == 1:
+            # With history_len=1 the single slot is the live frame; verify the
+            # zero warm-start by checking a fresh push after reset starts clean.
+            stacked = p._history.push(np.full(p.config.single_obs_dim, 7.0))
+            assert np.allclose(stacked, 7.0)
 
     def test_prev_action_feeds_back(self) -> None:
         """The previous raw action lands in the next frame's prev-action slot."""

--- a/tests/policies/wbc/test_policy.py
+++ b/tests/policies/wbc/test_policy.py
@@ -1,0 +1,461 @@
+"""Unit tests for :mod:`strands_robots.policies.wbc` - no GPU, no onnxruntime.
+
+These tests exercise :class:`WBCPolicy` against a stubbed ONNX session
+(injected via the ``allow_missing_models`` seam), so they run on any developer
+machine. The integration test under ``tests_integ/policies/wbc/`` covers the
+live ONNX + downloaded-checkpoint path.
+
+Issue #466 acceptance criteria pinned here:
+
+* ``create_policy("wbc", ...)`` / ``create_policy("sonic", ...)`` round-trip via
+  the factory + registry.
+* Raises ``RuntimeError`` on missing ``onnxruntime`` / checkpoint; never emits
+  zero/garbage torques silently.
+* ``requires_images is False``.
+* Observation builder produces the exact 86-dim layout; PD-control + quat
+  helpers match hand-computed values; action shape is 15-dim; history deque
+  length honoured; reset clears history.
+* Explicit ``unitree_g1`` actuator <-> 15-dim WBC mapping table + validation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import math
+
+import numpy as np
+import pytest
+
+from strands_robots.policies import Policy, create_policy, list_providers
+from strands_robots.policies.wbc import WBC_G1_LEG_WAIST_JOINTS, WBCConfig, WBCPolicy
+from strands_robots.policies.wbc.control import (
+    compute_targets,
+    pd_control,
+    projected_gravity,
+    quat_rotate_inverse,
+)
+from strands_robots.policies.wbc.observation import ObservationHistory, build_single_frame
+
+# ---------------------------------------------------------------------------
+# Stub ONNX session
+# ---------------------------------------------------------------------------
+
+_N = 15  # leg + waist DOFs
+
+
+class _StubInput:
+    name = "obs"
+
+
+class _StubSession:
+    """Minimal stand-in for ``onnxruntime.InferenceSession``.
+
+    Records the observation width it was fed and returns a fixed-shape
+    ``(1, num_actions)`` output so the policy's unpack path is exercised
+    without onnxruntime installed.
+    """
+
+    def __init__(self, num_actions: int = _N, fill: float = 0.04) -> None:
+        self.num_actions = num_actions
+        self.fill = fill
+        self.calls: list[np.ndarray] = []
+
+    def get_inputs(self) -> list[_StubInput]:
+        return [_StubInput()]
+
+    def run(self, output_names, feed):  # type: ignore[no-untyped-def]
+        (arr,) = feed.values()
+        self.calls.append(np.asarray(arr))
+        return [np.full((1, self.num_actions), self.fill, dtype=np.float32)]
+
+
+def _g1_keys() -> list[str]:
+    """Full 29-DOF G1 key order: 15 leg+waist then 14 arm joints."""
+    return list(WBC_G1_LEG_WAIST_JOINTS) + [f"arm_{i}" for i in range(14)]
+
+
+def _make_config(**overrides) -> WBCConfig:  # type: ignore[no-untyped-def]
+    base = dict(
+        policy_path="policy.onnx",
+        num_actions=_N,
+        command_dim=7,
+        single_obs_dim=86,
+        obs_history_len=1,
+        default_angles=[0.1] * _N,
+        kps=[100.0] * _N,
+        kds=[2.0] * _N,
+        action_scale=0.25,
+    )
+    base.update(overrides)
+    return WBCConfig(**base)  # type: ignore[arg-type]
+
+
+def _make_policy(walk: bool = True, **cfg_overrides) -> WBCPolicy:  # type: ignore[no-untyped-def]
+    p = WBCPolicy(config=_make_config(**cfg_overrides), walk=walk, allow_missing_models=True)
+    p.policy_session = _StubSession()
+    if walk:
+        p.walk_session = _StubSession()
+    p.set_robot_state_keys(_g1_keys())
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Control / quaternion math (hand-computed)
+# ---------------------------------------------------------------------------
+
+
+class TestControlMath:
+    def test_pd_control_hand_value(self) -> None:
+        tau = pd_control(
+            np.array([1.0, 2.0]),
+            np.array([0.0, 0.0]),
+            np.array([10.0, 10.0]),
+            np.array([0.0, 0.0]),
+            np.array([0.5, 0.0]),
+            np.array([2.0, 2.0]),
+        )
+        # (1-0)*10 + (0-0.5)*2 = 10 - 1 = 9 ; (2-0)*10 + 0 = 20
+        assert np.allclose(tau, [9.0, 20.0])
+
+    def test_pd_control_shape_mismatch_raises(self) -> None:
+        with pytest.raises(ValueError, match="share one shape"):
+            pd_control(
+                np.array([1.0, 2.0]),
+                np.array([0.0]),
+                np.array([1.0, 1.0]),
+                np.array([0.0, 0.0]),
+                np.array([0.0, 0.0]),
+                np.array([1.0, 1.0]),
+            )
+
+    def test_compute_targets_hand_value(self) -> None:
+        out = compute_targets(np.array([0.1, 0.2]), np.array([0.04, -0.04]), 0.25)
+        # 0.1 + 0.25*0.04 = 0.11 ; 0.2 + 0.25*-0.04 = 0.19
+        assert np.allclose(out, [0.11, 0.19])
+
+    def test_quat_identity_is_noop(self) -> None:
+        out = quat_rotate_inverse(np.array([1.0, 0, 0, 0]), np.array([1.0, 2.0, 3.0]))
+        assert np.allclose(out, [1.0, 2.0, 3.0])
+
+    def test_quat_yaw90_inverse(self) -> None:
+        c, s = math.cos(math.pi / 4), math.sin(math.pi / 4)
+        out = quat_rotate_inverse(np.array([c, 0, 0, s]), np.array([1.0, 0.0, 0.0]))
+        # inverse of a +90deg yaw maps world +x -> body -y
+        assert np.allclose(out, [0.0, -1.0, 0.0], atol=1e-9)
+
+    def test_projected_gravity_upright(self) -> None:
+        assert np.allclose(projected_gravity(np.array([1.0, 0, 0, 0])), [0.0, 0.0, -1.0])
+
+    def test_projected_gravity_is_unit(self) -> None:
+        c, s = math.cos(0.3), math.sin(0.3)
+        pg = projected_gravity(np.array([c, 0, s, 0]))
+        assert np.isclose(np.linalg.norm(pg), 1.0)
+
+    def test_quat_zero_norm_raises(self) -> None:
+        with pytest.raises(ValueError, match="zero norm"):
+            quat_rotate_inverse(np.array([0.0, 0, 0, 0]), np.array([1.0, 0, 0]))
+
+
+# ---------------------------------------------------------------------------
+# Observation layout
+# ---------------------------------------------------------------------------
+
+
+class TestObservationLayout:
+    def test_exact_86_dim_layout(self) -> None:
+        cfg = _make_config()
+        frame = build_single_frame(
+            cfg,
+            command=np.array([0.5, 0.0, 0.0]),  # short -> zero-padded to 7
+            base_ang_vel=np.array([1.0, 2.0, 3.0]),
+            proj_gravity=np.array([0.0, 0.0, -1.0]),
+            qj=np.array([0.2] * _N),
+            dqj=np.array([0.0] * _N),
+            prev_action=np.array([0.0] * _N),
+        )
+        assert frame.shape == (86,)
+        # command head: vx at 0, padded zeros at 3..7
+        assert frame[0] == 0.5
+        assert np.allclose(frame[3:7], 0.0)
+        # base ang vel scaled by obs_scales.ang_vel (0.25): index 7 = 1.0*0.25
+        assert np.isclose(frame[7], 0.25)
+        # projected gravity unscaled at [10:13]
+        assert np.allclose(frame[10:13], [0.0, 0.0, -1.0])
+        # qj - defaults scaled by dof_pos (1.0): (0.2-0.1) at index 13
+        assert np.isclose(frame[13], 0.1)
+        # tail padding (gait/style) is zero: end = 7+6+45 = 58
+        assert np.allclose(frame[58:], 0.0)
+
+    def test_command_overflow_raises(self) -> None:
+        cfg = _make_config(command_dim=3)
+        with pytest.raises(ValueError, match="exceeds command_dim"):
+            build_single_frame(
+                cfg,
+                command=np.array([0.1, 0.2, 0.3, 0.4]),
+                base_ang_vel=np.zeros(3),
+                proj_gravity=np.zeros(3),
+                qj=np.zeros(_N),
+                dqj=np.zeros(_N),
+                prev_action=np.zeros(_N),
+            )
+
+    def test_history_warm_start_and_width(self) -> None:
+        cfg = _make_config(obs_history_len=3)
+        assert cfg.num_obs == 86 * 3
+        hist = ObservationHistory(cfg)
+        frame = np.arange(86, dtype=np.float64)
+        stacked = hist.push(frame)
+        assert stacked.shape == (258,)
+        assert len(hist) == 3  # warm-filled with copies of the first frame
+        assert np.allclose(stacked[:86], stacked[86:172])
+
+    def test_history_reset_clears(self) -> None:
+        hist = ObservationHistory(_make_config(obs_history_len=2))
+        hist.push(np.zeros(86))
+        assert len(hist) == 2
+        hist.reset()
+        assert len(hist) == 0
+
+
+# ---------------------------------------------------------------------------
+# WBCConfig
+# ---------------------------------------------------------------------------
+
+
+class TestWBCConfig:
+    def test_num_obs(self) -> None:
+        assert _make_config(single_obs_dim=86, obs_history_len=4).num_obs == 344
+
+    def test_wrong_vector_length_raises(self) -> None:
+        with pytest.raises(ValueError, match="kps has length"):
+            WBCConfig(policy_path="p.onnx", num_actions=15, kps=[1.0, 2.0])
+
+    def test_from_dict_requires_policy_path(self) -> None:
+        with pytest.raises(ValueError, match="policy_path"):
+            WBCConfig.from_dict({"num_actions": 15})
+
+    def test_from_file_round_trip(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        p = tmp_path / "wbc.json"
+        p.write_text(json.dumps({"policy_path": "policy.onnx", "num_actions": 15, "obs_history_len": 2}))
+        cfg = WBCConfig.from_file(str(p))
+        assert cfg.num_actions == 15 and cfg.obs_history_len == 2
+
+    def test_from_file_missing_raises(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        with pytest.raises(FileNotFoundError):
+            WBCConfig.from_file(str(tmp_path / "nope.json"))
+
+    def test_command_dim_floor(self) -> None:
+        with pytest.raises(ValueError, match="command_dim must be >= 3"):
+            WBCConfig(policy_path="p.onnx", command_dim=2)
+
+
+# ---------------------------------------------------------------------------
+# WBCPolicy behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestWBCPolicy:
+    def test_requires_images_false(self) -> None:
+        assert _make_policy().requires_images is False
+
+    def test_provider_name(self) -> None:
+        assert _make_policy().provider_name == "wbc"
+
+    def test_get_actions_returns_single_15dim_dict(self) -> None:
+        p = _make_policy()
+        obs = {k: 0.2 for k in _g1_keys()}
+        actions = asyncio.run(p.get_actions(obs, "", target_velocity=[0.5, 0.0, 0.0]))
+        assert len(actions) == 1  # closed-loop per-tick, not a chunk
+        a = actions[0]
+        assert set(a.keys()) == set(WBC_G1_LEG_WAIST_JOINTS)
+        # target = default(0.1) + action_scale(0.25)*stub_fill(0.04) = 0.11
+        assert np.isclose(a["left_hip_pitch_joint"], 0.11)
+
+    def test_action_keys_in_wbc_order(self) -> None:
+        p = _make_policy()
+        obs = {k: 0.0 for k in _g1_keys()}
+        actions = asyncio.run(p.get_actions(obs, "", target_velocity=[0.1, 0.0, 0.0]))
+        assert list(actions[0].keys()) == list(WBC_G1_LEG_WAIST_JOINTS)
+
+    def test_walk_session_used_for_nonzero_command(self) -> None:
+        p = _make_policy(walk=True)
+        obs = {k: 0.0 for k in _g1_keys()}
+        asyncio.run(p.get_actions(obs, "", target_velocity=[0.5, 0.0, 0.0]))
+        assert p.walk_session.calls, "walk session should run for a nonzero command"
+        assert not p.policy_session.calls, "main session should not run when walking"
+
+    def test_main_session_used_for_zero_command(self) -> None:
+        p = _make_policy(walk=True)
+        obs = {k: 0.0 for k in _g1_keys()}
+        asyncio.run(p.get_actions(obs, "", target_velocity=[0.0, 0.0, 0.0]))
+        assert p.policy_session.calls, "main session should run when standing"
+        assert not p.walk_session.calls
+
+    def test_constructor_default_velocity_used_when_no_kwarg(self) -> None:
+        p = WBCPolicy(config=_make_config(), walk=True, target_velocity=[0.3, 0.0, 0.0], allow_missing_models=True)
+        p.policy_session = _StubSession()
+        p.walk_session = _StubSession()
+        p.set_robot_state_keys(_g1_keys())
+        obs = {k: 0.0 for k in _g1_keys()}
+        asyncio.run(p.get_actions(obs, ""))  # no per-call velocity
+        assert p.walk_session.calls, "constructor default_command should drive the walk session"
+
+    def test_observation_width_fed_to_session(self) -> None:
+        p = _make_policy(walk=False, obs_history_len=2)
+        obs = {k: 0.0 for k in _g1_keys()}
+        asyncio.run(p.get_actions(obs, "", target_velocity=[0.0, 0.0, 0.0]))
+        fed = p.policy_session.calls[0]
+        assert fed.shape == (1, 86 * 2)
+        assert fed.dtype == np.float32
+
+    def test_reset_clears_history_and_prev_action(self) -> None:
+        p = _make_policy()
+        obs = {k: 0.2 for k in _g1_keys()}
+        asyncio.run(p.get_actions(obs, "", target_velocity=[0.5, 0.0, 0.0]))
+        assert not np.allclose(p._prev_action, 0.0)
+        p.reset()
+        assert np.allclose(p._prev_action, 0.0)
+        assert len(p._history) == 0
+
+    def test_prev_action_feeds_back(self) -> None:
+        """The previous raw action lands in the next frame's prev-action slot."""
+        p = _make_policy(walk=False)
+        obs = {k: 0.0 for k in _g1_keys()}
+        asyncio.run(p.get_actions(obs, "", target_velocity=[0.0, 0.0, 0.0]))
+        # second call: the frame's prev-action block should equal the stub's
+        # raw output (0.04), proving feedback. The block sits at
+        # [c+6+2n : c+6+3n] = [7+6+30 : 7+6+45] = [43:58] for c=7, n=15.
+        asyncio.run(p.get_actions(obs, "", target_velocity=[0.0, 0.0, 0.0]))
+        fed = p.policy_session.calls[1][0]  # (num_obs,)
+        prev_block = fed[43 : 43 + 15]
+        assert np.allclose(prev_block, 0.04)
+
+    def test_no_session_raises_not_silent_zeros(self) -> None:
+        p = WBCPolicy(config=_make_config(), allow_missing_models=True)
+        p.set_robot_state_keys(_g1_keys())
+        obs = {k: 0.0 for k in _g1_keys()}
+        with pytest.raises(RuntimeError, match="no ONNX session"):
+            asyncio.run(p.get_actions(obs, "", target_velocity=[0.0, 0.0, 0.0]))
+
+
+# ---------------------------------------------------------------------------
+# Actuator <-> WBC mapping table + validation
+# ---------------------------------------------------------------------------
+
+
+class TestActuatorMapping:
+    def test_mapping_table_is_15_leg_waist(self) -> None:
+        assert len(WBC_G1_LEG_WAIST_JOINTS) == 15
+        assert WBC_G1_LEG_WAIST_JOINTS[0] == "left_hip_pitch_joint"
+        assert WBC_G1_LEG_WAIST_JOINTS[12:] == ("waist_yaw_joint", "waist_roll_joint", "waist_pitch_joint")
+
+    def test_bad_ordering_raises(self) -> None:
+        p = WBCPolicy(config=_make_config(), allow_missing_models=True)
+        with pytest.raises(ValueError, match="expected G1 leg\\+waist order"):
+            p.set_robot_state_keys([f"wrong_{i}" for i in range(20)])
+
+    def test_too_few_keys_raises(self) -> None:
+        p = WBCPolicy(config=_make_config(), allow_missing_models=True)
+        with pytest.raises(ValueError, match="at least 15"):
+            p.set_robot_state_keys(list(WBC_G1_LEG_WAIST_JOINTS[:10]))
+
+    def test_exact_15_keys_accepted(self) -> None:
+        p = WBCPolicy(config=_make_config(), allow_missing_models=True)
+        p.set_robot_state_keys(list(WBC_G1_LEG_WAIST_JOINTS))  # exactly 15 is fine
+
+
+# ---------------------------------------------------------------------------
+# compute_torques public helper
+# ---------------------------------------------------------------------------
+
+
+class TestComputeTorques:
+    def test_pd_law(self) -> None:
+        p = _make_policy()
+        tau = p.compute_torques(
+            np.array([0.11] * _N),
+            np.array([0.2] * _N),
+            np.zeros(_N),
+        )
+        # (0.11 - 0.2) * kp(100) + (0 - 0) * kd = -9.0
+        assert np.allclose(tau, [(0.11 - 0.2) * 100.0] * _N)
+
+
+# ---------------------------------------------------------------------------
+# Error paths: missing dep / checkpoint
+# ---------------------------------------------------------------------------
+
+
+class TestErrorPaths:
+    def test_bad_target_velocity_raises(self) -> None:
+        with pytest.raises(ValueError, match="finite"):
+            WBCPolicy(config=_make_config(), target_velocity=[float("nan"), 0, 0], allow_missing_models=True)
+
+    def test_short_target_velocity_raises(self) -> None:
+        with pytest.raises(ValueError, match="at least 3"):
+            WBCPolicy(config=_make_config(), target_velocity=[0.5], allow_missing_models=True)
+
+    def test_missing_checkpoint_or_dep_raises_runtime_error(self) -> None:
+        """Either onnxruntime is absent (ImportError->RuntimeError) or the
+        checkpoint file is missing; both must surface as RuntimeError, never a
+        silent zero-torque policy."""
+        with pytest.raises(RuntimeError):
+            WBCPolicy(
+                checkpoint="/nonexistent/checkpoint/dir",
+                config=_make_config(policy_path="/nonexistent/policy.onnx"),
+                allow_missing_models=False,
+            )
+
+
+class TestCheckpointResolution:
+    """The local-path | HF-download | cache resolution (issue #466)."""
+
+    def test_existing_local_path_returned_unchanged(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        d = tmp_path / "ckpt"
+        d.mkdir()
+        assert WBCPolicy._maybe_download_checkpoint(str(d)) == str(d)
+
+    def test_none_passes_through(self) -> None:
+        assert WBCPolicy._maybe_download_checkpoint(None) is None
+
+    def test_onnx_file_path_not_treated_as_hf_id(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        # A non-existent .onnx path is not an HF id; returned unchanged so the
+        # path resolver surfaces a clear not-found error (not a download attempt).
+        bogus = str(tmp_path / "missing" / "policy.onnx")
+        assert WBCPolicy._maybe_download_checkpoint(bogus) == bogus
+
+    def test_hf_id_without_hub_raises_runtime_error(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        # An org/repo id with huggingface_hub absent must raise RuntimeError
+        # (not silently proceed). Simulate the missing dep via require_optional.
+        import strands_robots.policies.wbc.policy as wbc_policy
+
+        def _boom(*a, **k):  # type: ignore[no-untyped-def]
+            raise ImportError("no huggingface_hub")
+
+        monkeypatch.setattr(wbc_policy, "require_optional", _boom)
+        with pytest.raises(RuntimeError, match="HuggingFace model id"):
+            WBCPolicy._maybe_download_checkpoint("nvidia/GEAR-SONIC")
+
+
+# ---------------------------------------------------------------------------
+# Factory / registry resolution
+# ---------------------------------------------------------------------------
+
+
+class TestFactoryResolution:
+    def test_create_policy_by_canonical_name(self) -> None:
+        p = create_policy("wbc", config=_make_config(), allow_missing_models=True)
+        assert isinstance(p, WBCPolicy)
+        assert isinstance(p, Policy)
+
+    def test_create_policy_by_sonic_shorthand(self) -> None:
+        p = create_policy("sonic", config=_make_config(), allow_missing_models=True)
+        assert isinstance(p, WBCPolicy)
+
+    def test_wbc_in_list_providers(self) -> None:
+        assert "wbc" in list_providers()
+
+    def test_requires_images_false_via_factory(self) -> None:
+        p = create_policy("wbc", config=_make_config(), allow_missing_models=True)
+        assert p.requires_images is False

--- a/tests/policies/wbc/test_policy.py
+++ b/tests/policies/wbc/test_policy.py
@@ -71,8 +71,16 @@ class _StubSession:
 
 
 def _g1_keys() -> list[str]:
-    """Full 29-DOF G1 key order: 15 leg+waist then 14 arm joints."""
-    return list(WBC_G1_LEG_WAIST_JOINTS) + [f"arm_{i}" for i in range(14)]
+    """Real MuJoCo G1 joint key order, as ``robot_joint_names`` returns it.
+
+    Verified against the actual robot_descriptions ``g1_mj_description`` model:
+    MuJoCo prepends the free/floating-base joint, so the list is
+    ``["floating_base_joint", <15 leg+waist>, <14 arm>]`` - the leg+waist joints
+    are at indices [1:16], NOT [0:15]. Using the real layout here is what
+    exercises WBCPolicy's name-based joint resolution (a fixture that put the
+    leg+waist joints first would hide the floating-base ordering bug).
+    """
+    return ["floating_base_joint", *WBC_G1_LEG_WAIST_JOINTS, *[f"arm_{i}" for i in range(14)]]
 
 
 def _make_config(**overrides) -> WBCConfig:  # type: ignore[no-untyped-def]
@@ -350,19 +358,44 @@ class TestActuatorMapping:
         assert WBC_G1_LEG_WAIST_JOINTS[0] == "left_hip_pitch_joint"
         assert WBC_G1_LEG_WAIST_JOINTS[12:] == ("waist_yaw_joint", "waist_roll_joint", "waist_pitch_joint")
 
-    def test_bad_ordering_raises(self) -> None:
+    def test_resolves_leg_waist_by_name_with_floating_base_prefix(self) -> None:
+        """REGRESSION: the real sim joint list leads with 'floating_base_joint',
+        so the leg+waist joints are at [1:16], not [0:15]. set_robot_state_keys
+        must resolve them by name and still accept the list."""
         p = WBCPolicy(config=_make_config(), allow_missing_models=True)
-        with pytest.raises(ValueError, match="expected G1 leg\\+waist order"):
+        p.set_robot_state_keys(_g1_keys())  # ["floating_base_joint", <15>, <14 arm>]
+        assert tuple(p._wbc_joint_names) == WBC_G1_LEG_WAIST_JOINTS
+        # The free-base joint and arm joints are excluded from what WBC drives.
+        assert "floating_base_joint" not in p._wbc_joint_names
+
+    def test_missing_joint_raises_listing_missing(self) -> None:
+        p = WBCPolicy(config=_make_config(), allow_missing_models=True)
+        with pytest.raises(ValueError, match="missing expected G1"):
             p.set_robot_state_keys([f"wrong_{i}" for i in range(20)])
 
-    def test_too_few_keys_raises(self) -> None:
+    def test_partial_leg_waist_raises(self) -> None:
+        # Only the first 10 leg+waist joints present -> the other 5 are reported.
         p = WBCPolicy(config=_make_config(), allow_missing_models=True)
-        with pytest.raises(ValueError, match="at least 15"):
+        with pytest.raises(ValueError, match="missing expected G1"):
             p.set_robot_state_keys(list(WBC_G1_LEG_WAIST_JOINTS[:10]))
 
     def test_exact_15_keys_accepted(self) -> None:
         p = WBCPolicy(config=_make_config(), allow_missing_models=True)
-        p.set_robot_state_keys(list(WBC_G1_LEG_WAIST_JOINTS))  # exactly 15 is fine
+        p.set_robot_state_keys(list(WBC_G1_LEG_WAIST_JOINTS))  # exactly the 15, any surrounding order
+
+    def test_reads_state_by_name_not_position(self) -> None:
+        """qj is read from the named joints even when a free-base joint precedes
+        them in the observation (so a positional [:15] slice would be wrong)."""
+        p = _make_policy()  # uses _g1_keys() ordering with floating_base first
+        obs = {k: 0.0 for k in _g1_keys()}
+        # Give each leg+waist joint a distinct, recognisable value; give the
+        # floating_base and arms a sentinel that must NOT appear in qj.
+        for i, name in enumerate(WBC_G1_LEG_WAIST_JOINTS):
+            obs[name] = 0.1 * (i + 1)
+        obs["floating_base_joint"] = 99.0
+        qj = p._read_joint_vector(obs, "position", 15)
+        assert np.allclose(qj, [0.1 * (i + 1) for i in range(15)])
+        assert 99.0 not in qj  # the free-base value never leaks in
 
 
 # ---------------------------------------------------------------------------
@@ -436,6 +469,102 @@ class TestCheckpointResolution:
         monkeypatch.setattr(wbc_policy, "require_optional", _boom)
         with pytest.raises(RuntimeError, match="HuggingFace model id"):
             WBCPolicy._maybe_download_checkpoint("nvidia/GEAR-SONIC")
+
+    def test_hf_id_heuristic_accepts_org_repo(self) -> None:
+        from strands_robots.policies.wbc.policy import _looks_like_hf_repo_id
+
+        assert _looks_like_hf_repo_id("nvidia/GEAR-SONIC")
+        assert _looks_like_hf_repo_id("org-name/repo.name_1")
+
+    def test_hf_id_heuristic_rejects_path_like(self) -> None:
+        from strands_robots.policies.wbc.policy import _looks_like_hf_repo_id
+
+        # Path-like strings must NOT be treated as HF ids (no surprise downloads).
+        assert not _looks_like_hf_repo_id("./models/policy")
+        assert not _looks_like_hf_repo_id("../ckpt/sonic")
+        assert not _looks_like_hf_repo_id("/abs/path/sonic")
+        assert not _looks_like_hf_repo_id("~/sonic")
+        assert not _looks_like_hf_repo_id("a/b/c")  # more than one slash
+        assert not _looks_like_hf_repo_id("dir/policy.onnx")  # .onnx file
+        assert not _looks_like_hf_repo_id("win\\path")  # backslash
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for bugs found in exhaustive review (against real deps)
+# ---------------------------------------------------------------------------
+
+
+class TestRegressionFixes:
+    def test_target_orientation_does_not_crash_get_actions(self) -> None:
+        """REGRESSION #1: a long target_orientation overflowed the 7-wide
+        command block and raised on every tick. The command is now truncated
+        to command_dim instead of crashing."""
+        p = _make_policy(walk=False)
+        obs = {k: 0.0 for k in _g1_keys()}
+        # velocity(3) + orientation(6) = 9 > command_dim(7): previously crashed.
+        actions = asyncio.run(
+            p.get_actions(
+                obs,
+                "",
+                target_velocity=[0.5, 0.0, 0.0],
+                target_orientation=[1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            )
+        )
+        assert len(actions[0]) == 15
+        # The fed observation's command block is exactly command_dim wide.
+        fed = p.policy_session.calls[0][0]
+        assert fed.shape[0] == 86  # single frame, history_len=1
+
+    def test_target_orientation_fits_within_command_dim(self) -> None:
+        """A velocity(3) + orientation(4) = 7 command fits exactly and is used."""
+        p = _make_policy(walk=False)
+        obs = {k: 0.0 for k in _g1_keys()}
+        actions = asyncio.run(
+            p.get_actions(obs, "", target_velocity=[0.5, 0.0, 0.0], target_orientation=[0.0, 0.0, 0.0, 1.0])
+        )
+        assert len(actions[0]) == 15
+
+    def test_warns_once_when_no_velocity_in_observation(self, caplog) -> None:  # type: ignore[no-untyped-def]
+        """REGRESSION #4: the real sim observation has no joint/base velocity,
+        so WBC runs open-loop on velocity. The policy must WARN (once), not
+        silently pretend dqj converges."""
+        import logging
+
+        p = _make_policy(walk=False)
+        obs = {k: 0.0 for k in _g1_keys()}  # positions only, no .vel / base_ang_vel
+        with caplog.at_level(logging.WARNING):
+            asyncio.run(p.get_actions(obs, "", target_velocity=[0.0, 0.0, 0.0]))
+            asyncio.run(p.get_actions(obs, "", target_velocity=[0.0, 0.0, 0.0]))
+        warnings = [r for r in caplog.records if "no joint velocities" in r.message]
+        assert len(warnings) == 1, "velocity-absent warning should fire exactly once"
+
+    def test_no_velocity_warning_when_base_ang_vel_present(self, caplog) -> None:  # type: ignore[no-untyped-def]
+        import logging
+
+        p = _make_policy(walk=False)
+        obs = {k: 0.0 for k in _g1_keys()}
+        obs["base_ang_vel"] = [0.0, 0.0, 0.1]  # a real velocity signal
+        with caplog.at_level(logging.WARNING):
+            asyncio.run(p.get_actions(obs, "", target_velocity=[0.0, 0.0, 0.0]))
+        assert not [r for r in caplog.records if "no joint velocities" in r.message]
+
+    def test_per_joint_velocity_read_by_name(self) -> None:
+        """When the observation DOES expose '<name>.vel' keys, dqj reads them."""
+        p = _make_policy(walk=False)
+        obs = {k: 0.0 for k in _g1_keys()}
+        for i, name in enumerate(WBC_G1_LEG_WAIST_JOINTS):
+            obs[f"{name}.vel"] = 0.01 * (i + 1)
+        dqj = p._read_joint_vector(obs, "velocity", 15)
+        assert np.allclose(dqj, [0.01 * (i + 1) for i in range(15)])
+
+    def test_num_actions_exceeding_mapping_table_rejected(self) -> None:
+        """REGRESSION #8: num_actions > 15 silently truncated the 15-entry
+        mapping table everywhere and failed late. Now rejected at construction."""
+        cfg = _make_config(
+            num_actions=20, single_obs_dim=200, default_angles=[0.0] * 20, kps=[1.0] * 20, kds=[0.0] * 20
+        )
+        with pytest.raises(ValueError, match="exceeds the 15-entry"):
+            WBCPolicy(config=cfg, allow_missing_models=True)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/policies/wbc/test_torque_harness.py
+++ b/tests/policies/wbc/test_torque_harness.py
@@ -1,0 +1,131 @@
+"""Smoke test for the torque-control deploy harness (examples/wbc_g1_torque_deploy.py).
+
+Runs WITHOUT real SONIC weights: it drives the harness's ``simulate_rollout``
+loop with a STUB WBCPolicy session (real ``compute_torques`` / config / joint
+mapping, fake ONNX) on the real torque-actuated G1 model. This guards the
+harness MECHANICS that bit us during development:
+
+* the bare robot_descriptions G1 MJCF has no ground plane -> the robot fell
+  through space (z -> -inf); _build_torque_g1 must add a floor.
+* the observation fed to the policy must be the whole-body per-joint dict with
+  velocities + base IMU, in the model's joint order.
+* arms are held, only the 15 leg+waist joints are driven.
+
+The real-gait validation (does it actually WALK) lives in the gated integration
+test ``tests_integ/policies/wbc/test_wbc_live.py`` (needs real weights).
+
+Requires mujoco; skips cleanly otherwise.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+pytest.importorskip("mujoco", reason="mujoco not installed - pip install 'strands-robots[sim-mujoco]'")
+
+from strands_robots.policies.wbc import WBC_G1_ALL_JOINTS, WBCConfig, WBCPolicy  # noqa: E402
+
+# Import the example module by path (examples/ is not an installed package).
+_HARNESS_PATH = Path(__file__).resolve().parents[3] / "examples" / "wbc_g1_torque_deploy.py"
+
+
+def _load_harness():  # type: ignore[no-untyped-def]
+    spec = importlib.util.spec_from_file_location("wbc_g1_torque_deploy", _HARNESS_PATH)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules.setdefault("wbc_g1_torque_deploy", mod)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _StubSession:
+    """ONNX stand-in: returns a tiny constant 15-dim raw action."""
+
+    class _In:
+        name = "obs"
+
+    def __init__(self, fill: float = 0.0) -> None:
+        self.fill = fill
+
+    def get_inputs(self):  # type: ignore[no-untyped-def]
+        return [self._In()]
+
+    def run(self, output_names, feed):  # type: ignore[no-untyped-def]
+        return [np.full((1, 15), self.fill, dtype=np.float32)]
+
+
+def _stub_policy(fill: float = 0.0) -> WBCPolicy:
+    """A WBCPolicy with stub ONNX sessions but the real config + PD law.
+
+    ``fill=0`` makes the raw action zero, so target_q == default_angles every
+    tick: the policy commands a static hold at the nominal stance via the real
+    compute_torques PD law - the cleanest mechanics check (no learned gait).
+    """
+    cfg = WBCConfig(
+        policy_path="x.onnx",
+        default_angles=[-0.1, 0.0, 0.0, 0.3, -0.2, 0.0, -0.1, 0.0, 0.0, 0.3, -0.2, 0.0, 0.0, 0.0, 0.0],
+        kps=[150, 150, 150, 200, 40, 40, 150, 150, 150, 200, 40, 40, 250, 250, 250],
+        kds=[2, 2, 2, 4, 2, 2, 2, 2, 2, 4, 2, 2, 5, 5, 5],
+    )
+    p = WBCPolicy(config=cfg, walk=False, allow_missing_models=True)
+    p.policy_session = _StubSession(fill=fill)
+    return p
+
+
+def test_build_torque_g1_has_ground_and_torque_actuators() -> None:
+    """REGRESSION: the harness model must have a ground plane (bare G1 MJCF
+    lacks one -> falls through space) and torque (motor) actuators."""
+    import mujoco
+
+    harness = _load_harness()
+    mj, model, data, joint_names = harness._build_torque_g1()
+    geom_names = {mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_GEOM, i) for i in range(model.ngeom)}
+    assert "wbc_ground" in geom_names, "harness must add a ground plane"
+    assert len(joint_names) == 29, f"expected 29 actuated joints, got {len(joint_names)}"
+    assert tuple(joint_names[:15]) == WBC_G1_ALL_JOINTS[:15]
+    # Every actuator converted to a FIXED-gain / NONE-bias motor (pure torque).
+    for i in range(model.nu):
+        assert model.actuator_gaintype[i] == mujoco.mjtGain.mjGAIN_FIXED
+        assert model.actuator_biastype[i] == mujoco.mjtBias.mjBIAS_NONE
+
+
+def test_model_observation_shape_and_velocity() -> None:
+    """The harness observation is the whole-body per-joint dict with .vel keys
+    plus base quat/ang-vel - the inputs a balance controller actually needs."""
+    harness = _load_harness()
+    mj, model, data, joint_names = harness._build_torque_g1()
+    obs = harness._model_observation(data, joint_names, len(joint_names))
+    for name in WBC_G1_ALL_JOINTS:
+        assert name in obs, f"missing joint position {name}"
+        assert f"{name}.vel" in obs, f"missing joint velocity {name}.vel"
+    assert len(obs["base_quat"]) == 4
+    assert len(obs["base_ang_vel"]) == 3
+
+
+def test_rollout_static_hold_does_not_fall_through_floor() -> None:
+    """With a zero-action stub (static hold at the nominal stance via the real
+    PD law), a short rollout must keep the base ABOVE the floor - i.e. the model
+    has a ground and the torque path is wired. (We don't assert balance: a
+    zero-policy humanoid is not statically stable; we assert it does not fall
+    THROUGH the world, the bug the missing ground plane caused: z -> -18.)"""
+    harness = _load_harness()
+    policy = _stub_policy(fill=0.0)
+    result = harness.simulate_rollout(policy, vx=0.0, duration=0.2, physics_dt=0.005, control_decimation=4)
+    # 0.2s is short enough that even an unbalanced stance hasn't toppled; the key
+    # property is the base is near its start height, not at z = -18 (fell through).
+    assert result["z1"] > 0.5, f"base fell through the floor (z1={result['z1']}); ground plane missing?"
+    assert result["steps"] >= 1
+    assert not result["fell"]
+
+
+def test_rollout_returns_expected_metric_keys() -> None:
+    harness = _load_harness()
+    policy = _stub_policy(fill=0.0)
+    result = harness.simulate_rollout(policy, vx=0.0, duration=0.1, physics_dt=0.005)
+    assert set(result) >= {"x0", "z0", "x1", "z1", "forward", "fell", "steps", "frames"}
+    assert isinstance(result["frames"], list) and result["frames"] == []  # no renderer_dims

--- a/tests/simulation/test_policy_kwargs_forwarding.py
+++ b/tests/simulation/test_policy_kwargs_forwarding.py
@@ -1,0 +1,194 @@
+"""Regression tests for per-call ``policy_kwargs`` forwarding through the run loop.
+
+Non-VLA providers (cuRobo, MoveIt2, WBC) read their goal from the well-known
+``**kwargs`` keys on :meth:`Policy.get_actions` (issue #300:
+``target_pose`` / ``target_joints`` / ``target_velocity`` / ``world_update``).
+The mesh ``tell()`` path already forwards those keys, but the local-sim path
+(``sim.run_policy``/``start_policy`` -> ``PolicyRunner.run`` ->
+``policy.get_actions``) historically dropped them: ``get_actions`` was called
+positionally as ``get_actions(observation, instruction)`` with no kwargs.
+
+These tests pin the fix: a ``policy_kwargs`` dict passed to ``run_policy`` /
+``PolicyRunner.run`` must arrive verbatim at every ``get_actions`` call, and the
+default (``None`` / omitted) must reproduce the historical no-kwargs behaviour.
+
+A future refactor that drops the forwarding will fail here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from strands_robots.policies.base import Policy
+from strands_robots.simulation.base import SimEngine
+from strands_robots.simulation.policy_runner import PolicyRunner
+
+
+class FakeSim(SimEngine):
+    """Minimal ``SimEngine`` stub - no physics, just enough for the run loop.
+
+    Self-contained (does not import the heavier ``test_policy_runner.FakeSim``)
+    so this regression file stays decoupled from that module's optional-dep
+    imports.
+    """
+
+    def __init__(self, joint_names: tuple[str, ...] = ("j0", "j1", "j2")) -> None:
+        self._joint_names = list(joint_names)
+        self._robots = {"fake_robot": self._joint_names}
+
+    def create_world(self, timestep=None, gravity=None, ground_plane=True):  # type: ignore[no-untyped-def]
+        return {"status": "success"}
+
+    def destroy(self):  # type: ignore[no-untyped-def]
+        return {"status": "success"}
+
+    def reset(self):  # type: ignore[no-untyped-def]
+        return {"status": "success"}
+
+    def step(self, n_steps: int = 1):  # type: ignore[no-untyped-def]
+        return {"status": "success"}
+
+    def get_state(self):  # type: ignore[no-untyped-def]
+        return {"sim_time": 0.0, "step_count": 0}
+
+    def add_robot(self, name, **kw):  # type: ignore[no-untyped-def]
+        return {"status": "success"}
+
+    def remove_robot(self, name):  # type: ignore[no-untyped-def]
+        return {"status": "success"}
+
+    def list_robots(self) -> list[str]:
+        return list(self._robots.keys())
+
+    def robot_joint_names(self, robot_name: str) -> list[str]:
+        return list(self._robots.get(robot_name, []))
+
+    def add_object(self, name, **kw):  # type: ignore[no-untyped-def]
+        return {"status": "success"}
+
+    def remove_object(self, name):  # type: ignore[no-untyped-def]
+        return {"status": "success"}
+
+    def get_observation(self, robot_name=None, *, skip_images=False):  # type: ignore[no-untyped-def]
+        return {n: 0.0 for n in self._joint_names}
+
+    def send_action(self, action, robot_name=None, n_substeps=1):  # type: ignore[no-untyped-def]
+        return {"status": "success"}
+
+    def render(self, camera_name="default", width=None, height=None):  # type: ignore[no-untyped-def]
+        return {"status": "success", "content": []}
+
+
+class _GoalRecordingPolicy(Policy):
+    """Non-VLA policy that records the ``**kwargs`` of every ``get_actions`` call.
+
+    Mirrors the cuRobo / WBC shape: ``requires_images = False`` and the goal
+    arrives through kwargs rather than the instruction string. Emits a single
+    zero action per call so the runner advances normally.
+    """
+
+    def __init__(self) -> None:
+        self._keys: list[str] = []
+        self.kwargs_seen: list[dict[str, Any]] = []
+
+    @property
+    def provider_name(self) -> str:
+        return "goal_recording"
+
+    @property
+    def requires_images(self) -> bool:
+        return False
+
+    def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
+        self._keys = list(robot_state_keys)
+
+    async def get_actions(
+        self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any
+    ) -> list[dict[str, Any]]:
+        # Record exactly what the run loop forwarded this tick.
+        self.kwargs_seen.append(dict(kwargs))
+        return [{k: 0.0 for k in self._keys}]
+
+
+def _run(policy: Policy, *, policy_kwargs: dict[str, Any] | None, n_steps: int = 3) -> dict[str, Any]:
+    sim = FakeSim()
+    policy.set_robot_state_keys(sim.robot_joint_names("fake_robot"))
+    return PolicyRunner(sim).run(
+        "fake_robot",
+        policy,
+        instruction="walk",
+        duration=float(n_steps) / 50.0,
+        control_frequency=50.0,
+        action_horizon=1,
+        fast_mode=True,
+        policy_kwargs=policy_kwargs,
+    )
+
+
+def test_policy_kwargs_reach_get_actions() -> None:
+    """A goal payload passed to PolicyRunner.run arrives at every get_actions call."""
+    policy = _GoalRecordingPolicy()
+    goal = {"target_velocity": [0.5, 0.0, 0.0]}
+
+    result = _run(policy, policy_kwargs=goal)
+
+    assert result["status"] == "success"
+    assert policy.kwargs_seen, "policy.get_actions was never called"
+    # Every tick saw the forwarded goal verbatim.
+    for seen in policy.kwargs_seen:
+        assert seen == goal
+    # Forwarding must not alias the caller's dict (defensive copy on read).
+    assert all(seen is not goal for seen in policy.kwargs_seen)
+
+
+def test_none_policy_kwargs_reproduces_no_kwargs_behaviour() -> None:
+    """Omitting policy_kwargs (the historical path) forwards no extra kwargs."""
+    policy = _GoalRecordingPolicy()
+
+    result = _run(policy, policy_kwargs=None)
+
+    assert result["status"] == "success"
+    assert policy.kwargs_seen, "policy.get_actions was never called"
+    assert all(seen == {} for seen in policy.kwargs_seen)
+
+
+def test_multiple_goal_keys_forwarded_together() -> None:
+    """All well-known #300 keys ride through in a single payload."""
+    policy = _GoalRecordingPolicy()
+    goal = {
+        "target_pose": [0.3, 0.0, 0.4, 1.0, 0.0, 0.0, 0.0],
+        "target_joints": {"j0": 0.1},
+        "target_velocity": [0.5, 0.0, 0.2],
+        "world_update": {"cuboid": {}},
+    }
+
+    result = _run(policy, policy_kwargs=goal)
+
+    assert result["status"] == "success"
+    assert policy.kwargs_seen[0] == goal
+
+
+def test_run_policy_threads_policy_kwargs_through_base() -> None:
+    """SimEngine.run_policy(policy_kwargs=...) reaches the policy via policy_object.
+
+    Exercises the full public entry point (not just PolicyRunner directly) so
+    the base-class signature + forwarding are both pinned.
+    """
+    sim = FakeSim()
+    policy = _GoalRecordingPolicy()
+    goal = {"target_velocity": [0.25, 0.0, 0.0]}
+
+    result = sim.run_policy(
+        robot_name="fake_robot",
+        policy_object=policy,
+        instruction="walk forward",
+        n_steps=2,
+        control_frequency=50.0,
+        action_horizon=1,
+        fast_mode=True,
+        policy_kwargs=goal,
+    )
+
+    assert result["status"] == "success"
+    assert policy.kwargs_seen, "policy.get_actions was never called"
+    assert all(seen == goal for seen in policy.kwargs_seen)

--- a/tests_integ/policies/wbc/test_wbc_live.py
+++ b/tests_integ/policies/wbc/test_wbc_live.py
@@ -153,6 +153,7 @@ def test_real_onnx_io_dims_match_config() -> None:
     (15). A config whose num_obs disagrees with the checkpoint would feed the
     model a wrong-width observation - this catches that mismatch up front."""
     policy = create_policy("wbc", checkpoint=CHECKPOINT, walk=True)
+    assert isinstance(policy, WBCPolicy)
     sess = policy.policy_session
     in_shape = sess.get_inputs()[0].shape  # e.g. ['batch_size', 516]
     out_shape = sess.get_outputs()[0].shape  # e.g. ['batch_size', 15]

--- a/tests_integ/policies/wbc/test_wbc_live.py
+++ b/tests_integ/policies/wbc/test_wbc_live.py
@@ -73,13 +73,25 @@ def test_wbc_policy_loads_real_onnx() -> None:
     assert policy.policy_session is not None, "main ONNX session must load from the checkpoint"
 
 
+@pytest.mark.skipif(
+    os.environ.get("WBC_GAIT_CHECK", "").lower() not in ("1", "true", "yes"),
+    reason=(
+        "Gait-quality check needs the full deploy-fidelity loop, not just real weights. "
+        "WBCPolicy emits joint-POSITION targets; the upstream reference converts them to "
+        "TORQUE via its PD law (compute_torques) on a torque-actuator G1 model "
+        "(g1_gear_wbc.xml) at control_decimation=4. The default MuJoCo Menagerie G1 uses "
+        "position-servo actuators with their own gains, so a stable gait is not expected "
+        "without replicating the torque-control loop. Set WBC_GAIT_CHECK=1 (with a "
+        "torque-driven deploy harness) to run this. See compute_torques() for the bridge."
+    ),
+)
 def test_wbc_forward_walk_translates_base_without_falling(g1_sim) -> None:  # type: ignore[no-untyped-def]
-    """Drive the G1 forward with WBC and assert the base moves forward + stays up.
+    """Deploy-fidelity gait check: drive the G1 forward and assert it advances
+    without falling. Requires a torque-control deploy harness (see skip reason);
+    this is NOT a WBCPolicy I/O-contract test (those run unconditionally above).
 
-    This is the deploy-stage end-to-end check: a real ONNX controller stepping
-    the real MuJoCo G1. We command a modest forward velocity and verify the
-    base translates in +x by at least ``WBC_MIN_FORWARD_M`` while its height
-    does not collapse (a fall would drop z well below the standing height).
+    We command a modest forward velocity and verify the base translates in +x by
+    at least ``WBC_MIN_FORWARD_M`` while its height does not collapse.
     """
     sim = g1_sim
     policy = create_policy("wbc", checkpoint=CHECKPOINT, walk=True)
@@ -139,3 +151,25 @@ def test_wbc_action_shape_is_15dim_on_real_model(g1_sim) -> None:  # type: ignor
     assert len(actions) == 1
     assert set(actions[0].keys()) == set(WBC_G1_LEG_WAIST_JOINTS)
     assert all(np.isfinite(v) for v in actions[0].values())
+
+
+def test_real_onnx_io_dims_match_config() -> None:
+    """The real ONNX sessions' input/output dims must match the resolved config.
+
+    Pins the single most important real-weights fact: the shipped GR00T-WBC
+    ONNX (e.g. GR00T-WholeBodyControl-Balance.onnx) has input ``[batch, num_obs]``
+    (516 for the default obs_history_len=6) and output ``[batch, num_actions]``
+    (15). A config whose num_obs disagrees with the checkpoint would feed the
+    model a wrong-width observation - this catches that mismatch up front."""
+    policy = create_policy("wbc", checkpoint=CHECKPOINT, walk=True)
+    sess = policy.policy_session
+    in_shape = sess.get_inputs()[0].shape  # e.g. ['batch_size', 516]
+    out_shape = sess.get_outputs()[0].shape  # e.g. ['batch_size', 15]
+    assert in_shape[-1] == policy.config.num_obs, (
+        f"ONNX input width {in_shape[-1]} != config.num_obs {policy.config.num_obs}; "
+        "the checkpoint and config disagree on the observation dimension "
+        "(check obs_history_len / single_obs_dim)."
+    )
+    assert out_shape[-1] == policy.config.num_actions, (
+        f"ONNX output width {out_shape[-1]} != config.num_actions {policy.config.num_actions}."
+    )

--- a/tests_integ/policies/wbc/test_wbc_live.py
+++ b/tests_integ/policies/wbc/test_wbc_live.py
@@ -1,0 +1,132 @@
+"""Integration test for :class:`WBCPolicy` against a real ONNX checkpoint.
+
+Steps the Unitree G1 in MuJoCo under the GR00T Whole-Body-Control (SONIC)
+policy for a short forward walk and asserts the base translates forward
+without falling - the deploy-stage acceptance criterion from issue #466.
+
+Gated behind the ``wbc`` pytest marker AND a ``WBC_LIVE=1`` env flag, and
+skips cleanly if ``onnxruntime`` / ``mujoco`` are absent or no checkpoint is
+configured. Enable with:
+
+.. code-block:: bash
+
+    pip install 'strands-robots[wbc,sim-mujoco]'
+    # Download a GR00T-WBC (SONIC) checkpoint under the NVIDIA Open Model
+    # License, e.g. from https://huggingface.co/nvidia/GEAR-SONIC, into a dir
+    # containing policy.onnx (+ optional walk_policy.onnx + config.json).
+    export WBC_CHECKPOINT=/path/to/GEAR-SONIC
+    WBC_LIVE=1 hatch run test-integ tests_integ/policies/wbc/ -m wbc -v
+
+No weights are bundled. The exact base-displacement threshold is configurable
+via ``WBC_MIN_FORWARD_M`` (default 0.05 m over the rollout) so a checkpoint
+with a different gait speed can still pass.
+"""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+import pytest
+
+# Skip cleanly when the optional deps are missing, rather than erroring at
+# collection. ``importorskip`` emits a SKIPPED line with a clear reason.
+pytest.importorskip("onnxruntime", reason="onnxruntime not installed - pip install 'strands-robots[wbc]'")
+pytest.importorskip("mujoco", reason="mujoco not installed - pip install 'strands-robots[sim-mujoco]'")
+
+LIVE = os.environ.get("WBC_LIVE", "").lower() in ("1", "true", "yes")
+CHECKPOINT = os.environ.get("WBC_CHECKPOINT", "")
+MIN_FORWARD_M = float(os.environ.get("WBC_MIN_FORWARD_M", "0.05"))
+
+pytestmark = [
+    pytest.mark.wbc,
+    pytest.mark.skipif(
+        not (LIVE and CHECKPOINT),
+        reason=(
+            "Requires onnxruntime + a downloaded GR00T-WBC (SONIC) checkpoint. "
+            "Set WBC_LIVE=1 and WBC_CHECKPOINT=/path/to/GEAR-SONIC to enable."
+        ),
+    ),
+]
+
+# E402: importorskip must run before these imports so the skip is clean.
+from strands_robots import Robot  # noqa: E402
+from strands_robots.policies import create_policy  # noqa: E402
+from strands_robots.policies.wbc import WBC_G1_LEG_WAIST_JOINTS, WBCPolicy  # noqa: E402
+
+
+@pytest.fixture()
+def g1_sim():  # type: ignore[no-untyped-def]
+    """Spin up an MuJoCo Unitree G1 (sim mode, mesh off for a hermetic test)."""
+    sim = Robot("unitree_g1", mesh=False)
+    try:
+        yield sim
+    finally:
+        sim.destroy()
+
+
+def test_wbc_policy_loads_real_onnx() -> None:
+    """The factory builds a WBCPolicy whose ONNX sessions load from the checkpoint."""
+    policy = create_policy("wbc", checkpoint=CHECKPOINT, walk=True)
+    assert isinstance(policy, WBCPolicy)
+    assert policy.requires_images is False
+    assert policy.policy_session is not None, "main ONNX session must load from the checkpoint"
+
+
+def test_wbc_forward_walk_translates_base_without_falling(g1_sim) -> None:  # type: ignore[no-untyped-def]
+    """Drive the G1 forward with WBC and assert the base moves forward + stays up.
+
+    This is the deploy-stage end-to-end check: a real ONNX controller stepping
+    the real MuJoCo G1. We command a modest forward velocity and verify the
+    base translates in +x by at least ``WBC_MIN_FORWARD_M`` while its height
+    does not collapse (a fall would drop z well below the standing height).
+    """
+    sim = g1_sim
+    policy = create_policy("wbc", checkpoint=CHECKPOINT, walk=True)
+
+    # Confirm the sim's joint order matches the WBC mapping before stepping
+    # (set_robot_state_keys would raise otherwise - here we assert explicitly
+    # for a clearer integration-failure message).
+    joint_names = sim.robot_joint_names("unitree_g1")
+    assert tuple(joint_names[:15]) == WBC_G1_LEG_WAIST_JOINTS, (
+        f"unitree_g1 sim joint order does not match the WBC leg+waist mapping; first 15 = {joint_names[:15]}"
+    )
+
+    def _base_xz() -> tuple[float, float]:
+        state = sim.get_body_state("unitree_g1/pelvis")
+        pos = state["content"][0]["json"]["position"] if "content" in state else state["position"]
+        return float(pos[0]), float(pos[2])
+
+    x0, z0 = _base_xz()
+
+    result = sim.run_policy(
+        robot_name="unitree_g1",
+        policy_object=policy,
+        instruction="walk forward",
+        policy_kwargs={"target_velocity": [0.5, 0.0, 0.0]},
+        duration=4.0,
+        control_frequency=50.0,
+        action_horizon=1,  # WBC is closed-loop per tick
+        fast_mode=True,
+    )
+    assert result["status"] == "success", result
+
+    x1, z1 = _base_xz()
+    forward = x1 - x0
+    assert forward >= MIN_FORWARD_M, f"base advanced only {forward:.3f} m (< {MIN_FORWARD_M} m); gait may be unstable"
+    # A fall drops the pelvis far below its standing height; allow a small dip.
+    assert z1 > 0.5 * z0, f"base height collapsed from {z0:.3f} to {z1:.3f} m - robot likely fell"
+
+
+def test_wbc_action_shape_is_15dim_on_real_model(g1_sim) -> None:  # type: ignore[no-untyped-def]
+    """One real inference step returns the 15 leg+waist targets by name."""
+    sim = g1_sim
+    policy = create_policy("wbc", checkpoint=CHECKPOINT, walk=True)
+    policy.set_robot_state_keys(sim.robot_joint_names("unitree_g1"))
+
+    obs = sim.get_observation("unitree_g1")
+    actions = policy.get_actions_sync(obs, "", target_velocity=[0.3, 0.0, 0.0])
+
+    assert len(actions) == 1
+    assert set(actions[0].keys()) == set(WBC_G1_LEG_WAIST_JOINTS)
+    assert all(np.isfinite(v) for v in actions[0].values())

--- a/tests_integ/policies/wbc/test_wbc_live.py
+++ b/tests_integ/policies/wbc/test_wbc_live.py
@@ -84,17 +84,26 @@ def test_wbc_forward_walk_translates_base_without_falling(g1_sim) -> None:  # ty
     sim = g1_sim
     policy = create_policy("wbc", checkpoint=CHECKPOINT, walk=True)
 
-    # Confirm the sim's joint order matches the WBC mapping before stepping
-    # (set_robot_state_keys would raise otherwise - here we assert explicitly
-    # for a clearer integration-failure message).
+    # Confirm the sim exposes every WBC leg+waist joint BY NAME before stepping
+    # (set_robot_state_keys resolves by name, not position - the real sim list
+    # leads with 'floating_base_joint' and interleaves arm joints, so a
+    # positional [:15] check would be wrong). Asserting here gives a clearer
+    # integration-failure message than a deep stack trace.
     joint_names = sim.robot_joint_names("unitree_g1")
-    assert tuple(joint_names[:15]) == WBC_G1_LEG_WAIST_JOINTS, (
-        f"unitree_g1 sim joint order does not match the WBC leg+waist mapping; first 15 = {joint_names[:15]}"
-    )
+    missing = [j for j in WBC_G1_LEG_WAIST_JOINTS if j not in joint_names]
+    assert not missing, f"unitree_g1 sim is missing WBC leg+waist joints by name: {missing}"
 
     def _base_xz() -> tuple[float, float]:
         state = sim.get_body_state("unitree_g1/pelvis")
-        pos = state["content"][0]["json"]["position"] if "content" in state else state["position"]
+        # get_body_state returns {"status","content":[{text},{json:{position,...}}]}.
+        # Find the json block (it is not necessarily first - a human-readable
+        # text block precedes it).
+        pos = None
+        for blk in state.get("content", []):
+            if "json" in blk and "position" in blk["json"]:
+                pos = blk["json"]["position"]
+                break
+        assert pos is not None, f"get_body_state returned no position json block: {state}"
         return float(pos[0]), float(pos[2])
 
     x0, z0 = _base_xz()

--- a/tests_integ/policies/wbc/test_wbc_live.py
+++ b/tests_integ/policies/wbc/test_wbc_live.py
@@ -73,70 +73,61 @@ def test_wbc_policy_loads_real_onnx() -> None:
     assert policy.policy_session is not None, "main ONNX session must load from the checkpoint"
 
 
+def _load_harness():  # type: ignore[no-untyped-def]
+    """Import the torque-deploy harness (examples/ is not an installed package)."""
+    import importlib.util
+    from pathlib import Path
+
+    path = Path(__file__).resolve().parents[3] / "examples" / "wbc_g1_torque_deploy.py"
+    spec = importlib.util.spec_from_file_location("wbc_g1_torque_deploy", path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
 @pytest.mark.skipif(
     os.environ.get("WBC_GAIT_CHECK", "").lower() not in ("1", "true", "yes"),
     reason=(
-        "Gait-quality check needs the full deploy-fidelity loop, not just real weights. "
-        "WBCPolicy emits joint-POSITION targets; the upstream reference converts them to "
-        "TORQUE via its PD law (compute_torques) on a torque-actuator G1 model "
-        "(g1_gear_wbc.xml) at control_decimation=4. The default MuJoCo Menagerie G1 uses "
-        "position-servo actuators with their own gains, so a stable gait is not expected "
-        "without replicating the torque-control loop. Set WBC_GAIT_CHECK=1 (with a "
-        "torque-driven deploy harness) to run this. See compute_torques() for the bridge."
+        "Gait-quality check runs the full torque-control deploy loop (PD->torque via "
+        "compute_torques on a torque-actuator G1 at control_decimation=4) with the real "
+        "SONIC weights - the deploy path, not sim.run_policy's position-servo path. It is "
+        "compute-heavy and needs the real checkpoint, so it is opt-in. Set WBC_GAIT_CHECK=1 "
+        "(with WBC_CHECKPOINT) to run it. The harness lives at examples/wbc_g1_torque_deploy.py."
     ),
 )
-def test_wbc_forward_walk_translates_base_without_falling(g1_sim) -> None:  # type: ignore[no-untyped-def]
-    """Deploy-fidelity gait check: drive the G1 forward and assert it advances
-    without falling. Requires a torque-control deploy harness (see skip reason);
-    this is NOT a WBCPolicy I/O-contract test (those run unconditionally above).
+def test_wbc_forward_walk_translates_base_without_falling() -> None:
+    """Deploy-fidelity gait check via the torque-control harness: with the real
+    weights the G1 must walk forward without falling.
 
-    We command a modest forward velocity and verify the base translates in +x by
-    at least ``WBC_MIN_FORWARD_M`` while its height does not collapse.
+    Drives the SAME ``simulate_rollout`` loop the example/CLI uses (torque PD on
+    the 15 controlled joints, arms held, whole-body observation with real joint
+    velocities + base IMU). Asserts the base advances >= WBC_MIN_FORWARD_M in +x
+    while its height does not collapse.
     """
-    sim = g1_sim
+    harness = _load_harness()
     policy = create_policy("wbc", checkpoint=CHECKPOINT, walk=True)
+    assert isinstance(policy, WBCPolicy)
 
-    # Confirm the sim exposes every WBC leg+waist joint BY NAME before stepping
-    # (set_robot_state_keys resolves by name, not position - the real sim list
-    # leads with 'floating_base_joint' and interleaves arm joints, so a
-    # positional [:15] check would be wrong). Asserting here gives a clearer
-    # integration-failure message than a deep stack trace.
-    joint_names = sim.robot_joint_names("unitree_g1")
-    missing = [j for j in WBC_G1_LEG_WAIST_JOINTS if j not in joint_names]
-    assert not missing, f"unitree_g1 sim is missing WBC leg+waist joints by name: {missing}"
+    result = harness.simulate_rollout(policy, vx=0.5, vy=0.0, omega=0.0, duration=4.0)
 
-    def _base_xz() -> tuple[float, float]:
-        state = sim.get_body_state("unitree_g1/pelvis")
-        # get_body_state returns {"status","content":[{text},{json:{position,...}}]}.
-        # Find the json block (it is not necessarily first - a human-readable
-        # text block precedes it).
-        pos = None
-        for blk in state.get("content", []):
-            if "json" in blk and "position" in blk["json"]:
-                pos = blk["json"]["position"]
-                break
-        assert pos is not None, f"get_body_state returned no position json block: {state}"
-        return float(pos[0]), float(pos[2])
-
-    x0, z0 = _base_xz()
-
-    result = sim.run_policy(
-        robot_name="unitree_g1",
-        policy_object=policy,
-        instruction="walk forward",
-        policy_kwargs={"target_velocity": [0.5, 0.0, 0.0]},
-        duration=4.0,
-        control_frequency=50.0,
-        action_horizon=1,  # WBC is closed-loop per tick
-        fast_mode=True,
+    assert not result["fell"], f"robot fell (z {result['z0']:.3f} -> {result['z1']:.3f} m) during the rollout"
+    assert result["z1"] > 0.5 * result["z0"], f"base height collapsed from {result['z0']:.3f} to {result['z1']:.3f} m"
+    assert result["forward"] >= MIN_FORWARD_M, (
+        f"base advanced only {result['forward']:.3f} m (< {MIN_FORWARD_M} m); gait may be unstable"
     )
-    assert result["status"] == "success", result
 
-    x1, z1 = _base_xz()
-    forward = x1 - x0
-    assert forward >= MIN_FORWARD_M, f"base advanced only {forward:.3f} m (< {MIN_FORWARD_M} m); gait may be unstable"
-    # A fall drops the pelvis far below its standing height; allow a small dip.
-    assert z1 > 0.5 * z0, f"base height collapsed from {z0:.3f} to {z1:.3f} m - robot likely fell"
+
+def test_wbc_standing_balance_holds_in_place() -> None:
+    """With a zero command the real policy should HOLD BALANCE (height steady,
+    little drift) - a balance check distinct from the forward-walk one."""
+    if os.environ.get("WBC_GAIT_CHECK", "").lower() not in ("1", "true", "yes"):
+        pytest.skip("opt-in gait/balance check; set WBC_GAIT_CHECK=1")
+    harness = _load_harness()
+    policy = create_policy("wbc", checkpoint=CHECKPOINT, walk=True)
+    result = harness.simulate_rollout(policy, vx=0.0, vy=0.0, omega=0.0, duration=3.0)
+    assert not result["fell"], "robot fell while standing"
+    assert result["z1"] > 0.7 * result["z0"], f"standing height collapsed: {result['z0']:.3f} -> {result['z1']:.3f}"
 
 
 def test_wbc_action_shape_is_15dim_on_real_model(g1_sim) -> None:  # type: ignore[no-untyped-def]


### PR DESCRIPTION
## Summary

Adds **`WBCPolicy`** — a new non-VLA policy provider wrapping NVIDIA's GR00T
Whole-Body-Control (SONIC / decoupled-WBC) ONNX controllers for deploy-grade
**Unitree G1 locomotion**. Clean-room implementation against the upstream
reference (`NVlabs/GR00T-WholeBodyControl`,
`decoupled_wbc/sim2mujoco/scripts/run_mujoco_gear_wbc.py` +
`resources/robots/g1/g1_gear_wbc.yaml`). Closes #466.

Validated end-to-end against the **real shipped weights**
(`GR00T-WholeBodyControl-{Balance,Walk}.onnx`): through the torque-control deploy
harness the G1 produces a **stable forward walk** (~0.38 m/s for a 0.5 m/s
command, height held, no fall), and holds balance in place on a zero command.

## What's included

- **`strands_robots/policies/wbc/`** — `WBCPolicy` (provider `wbc`, shorthand
  `sonic`), `WBCConfig`, the observation builder, and pure-NumPy control/quat
  helpers.
  - `requires_images = False`; reads the goal from the well-known kwargs
    (`target_velocity = [vx, vy, omega]`, optional `target_orientation` for base
    RPY, optional `height`). Drives the **15 leg+waist DOFs**; the 14 arm joints
    are held at defaults (upper-body composition is left to a future
    `CompositePolicy`, #468).
  - Faithful to the reference contract: 86-dim observation
    (`command[7] + base_ang_vel[3] + projected_gravity[3] + qj[29] + dqj[29] +
    prev_action[15]`) stacked over `obs_history_len=6` → 516-wide network input;
    **whole-body** qj/dqj (all 29 joints, not just the 15 controlled); two ONNX
    sessions (`policy` + `walk_policy`) selected by `norm(raw velocity) <= 0.05`;
    PD→torque law via `compute_torques(...)`; zero-warm-started history deque;
    quaternion math numerically identical to upstream (verified to 1e-10).
  - `WBCConfig` loads the upstream `g1_gear_wbc.yaml` directly (JSON or YAML;
    flat `*_scale` keys normalised). Joints resolved **by name** (handles the
    G1's leading `floating_base_joint` + interleaved arms).
  - No weights bundled — fetched/pointed-at at runtime under the NVIDIA Open
    Model License.
- **Precursor (`feat(sim)`):** a per-call `policy_kwargs` channel on
  `SimEngine.run_policy` / `start_policy` (+ MuJoCo overrides), forwarded
  verbatim to `policy.get_actions`, so the #300 well-known goal kwargs reach
  non-VLA providers (WBC, cuRobo, MoveIt2) through the local sim path — not just
  the mesh. Pinned by `tests/simulation/test_policy_kwargs_forwarding.py`.
- **Integration:** registered in `registry/policies.json`; `wbc`/`sonic` added
  to the mesh + Device Connect policy-provider allowlist so WBC can be driven
  over `tell()` / Device Connect; new `[wbc]` extra
  (`onnxruntime` + `pyyaml` + `huggingface_hub`); NOTICE attribution.
- **Docs & example:** `docs/policies/wbc.md` (+ mkdocs nav, README rows);
  `examples/wbc_g1_torque_deploy.py` — a torque-control deploy harness with an
  importable `simulate_rollout` (the real weights walk the G1).

## Testing

- **82 WBC unit tests** (stub ONNX, no GPU): observation layout, PD/quat
  hand-values, walk-selection, history determinism, config/YAML loading, factory
  resolution, mesh allowlist, error paths — plus `TestUpstreamFidelity` pins
  transcribed from the upstream YAML/runner.
- **No-weights harness smoke test** (`tests/policies/wbc/test_torque_harness.py`,
  runs in CI with mujoco): ground plane, torque actuators, observation shape,
  no fall-through.
- **Gated real-weights integration** (`tests_integ/policies/wbc/`,
  `WBC_LIVE=1` + checkpoint): ONNX I/O-dims match config, action shape, load.
  The gait-quality + standing-balance checks run the torque-deploy loop behind
  `WBC_GAIT_CHECK=1` and **pass** with real weights.
- format / lint / mypy clean; zero regressions vs `main`.

## Reviewer notes / scope

- **Gait-quality tests are opt-in** (`WBC_GAIT_CHECK=1` + real checkpoint): they
  need the torque-control deploy environment, not `sim.run_policy`'s
  position-servo path. The harness + the I/O-contract tests are the runnable
  evidence; a reviewer with the real weights can flip the flag to watch it walk.
- **`policy_kwargs` is scoped to the control/deploy path** (`run_policy` /
  `start_policy` / mesh), not `eval_policy` / `evaluate_benchmark` (which are
  instruction-driven benchmark entry points). Static-velocity WBC eval works via
  the constructor `target_velocity`. Documented in `docs/policies/wbc.md`.
- Pre-existing observation: the already-merged `cosmos3` / `curobo` / `moveit2`
  providers are also absent from the mesh policy-provider allowlist; this PR only
  adds `wbc`/`sonic` (the providers it introduces) and leaves the broader gap for
  a follow-up.

## Follow-up (not in this PR)

An optional `SonicPlannerPolicy` wrapping the GR00T-WBC **kinematic planner**
(`planner_sonic.onnx`: `mode`/`target_vel` → `qpos[T,36]`) — a different SONIC
component, complementary to this tracking controller. Tracked separately.

---

## Review changelog

### Round 1 — CodeQL code-scanning findings (commit `d92904f`)

Resolved both code-scanning alerts; no behavioral change, no API change.

1. **Empty `except` without comment** (`strands_robots/policies/wbc/policy.py`,
   per-joint observation reader). Added an explanatory comment: a non-numeric
   observation entry intentionally degrades to its pre-zeroed neutral value
   (the full qj/dqj block is validated downstream), rather than aborting the
   observation build.
2. **Module imported with both `import` and `import from`**
   (`tests/policies/wbc/test_policy.py`). Consolidated to a single top-level
   `from strands_robots.policies.wbc import policy as wbc_policy`; the
   monkeypatch (`require_optional`) and `_looks_like_hf_repo_id` heuristic
   checks now reference the module object consistently.

Validation: `ruff check` + `ruff format --check` clean; WBC unit suite
73 passed / 1 skipped.
