### PR TITLE
test(mesh): rename version-tied test files to behavior-descriptive names

### DIFF
--- a/tests/mesh/test_safety_audit_poison_records.py
+++ b/tests/mesh/test_safety_audit_poison_records.py
@@ -1,7 +1,11 @@
-"""v0.4.0 mesh safety+audit follow-up pins (#386), from the #221/#225 R12 trail.
+"""Mesh audit poison-record behaviour on sequence-counter failures.
 
-- #324: a non-symlink _next_seq failure writes a NEXT_SEQ_DEGRADED poison
-  record (symmetry with SEQ_LOCK_DEGRADED) instead of dropping the record.
+Pins that audit-log sequence failures never silently drop a record:
+- A non-symlink failure inside ``_next_seq`` writes a NEXT_SEQ_DEGRADED poison
+  record (symmetric with the SEQ_LOCK_DEGRADED path) so a verifier can attribute
+  the resulting sequence gap.
+- The pre-existing SEQ_LOCK_DEGRADED symlink-failure path stays unchanged.
+- A NEXT_SEQ_DEGRADED poison record survives the PSK signing gate.
 """
 
 from __future__ import annotations

--- a/tests/mesh/test_session_acl_scoping.py
+++ b/tests/mesh/test_session_acl_scoping.py
@@ -1,10 +1,13 @@
-"""Regression pins for the v0.4.0 mesh session+ACL follow-up bundle (#387).
+"""Mesh session/ACL scoping and bounded-cache invariants.
 
-Covers PR #224 review follow-ups:
-- #307: eviction-order parity between _ACL_CACHE and _NON_POSIX_TLS_WARNED_KEYS.
-- #308: symmetric total-deny ACL warning.
-- #309: TLS-bearing scheme allow-list widened to wss + unixsock.
-- #310: thread-snapshot value is always None or a 2-tuple.
+Pins the behavioural contract of the Zenoh session ACL layer:
+- The TLS-warned key cache evicts FIFO, matching the ACL cache eviction order
+  so both bounded caches drop their oldest entry first under pressure.
+- A total-deny ACL shape warns, while a deny rule paired with an allow rule
+  does not trip the total-deny warning.
+- The TLS-bearing scheme allow-list accepts wss + unixsock under mTLS and
+  still rejects non-TLS schemes.
+- The per-thread session snapshot is always None or a 2-tuple, never a partial.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Problem

Two mesh regression test files were named after the release bundle that introduced them rather than the behavior they verify:

- `tests/mesh/test_session_acl_v040_followups.py`
- `tests/mesh/test_safety_audit_v040_followups.py`

A test name should describe the contract it pins, not the version or PR series that birthed it. `_v040_followups` is undiscoverable (you cannot guess it covers ACL scoping or audit poison records) and ties the file identity to a release that is now history, so the name only ages worse.

## Change

Rename via `git mv` (history preserved) and rewrite each module docstring to lead with the behavioural contract:

| Before | After |
| --- | --- |
| `test_session_acl_v040_followups.py` | `test_session_acl_scoping.py` |
| `test_safety_audit_v040_followups.py` | `test_safety_audit_poison_records.py` |

`test_session_acl_scoping.py` pins the Zenoh session ACL layer: FIFO eviction parity between the TLS-warned key cache and the ACL cache, the total-deny warning shape, the TLS-bearing scheme allow-list (wss + unixsock under mTLS), and the per-thread session snapshot invariant (always None or a 2-tuple).

`test_safety_audit_poison_records.py` pins that audit-log sequence-counter failures never silently drop a record: a non-symlink `_next_seq` failure writes a NEXT_SEQ_DEGRADED poison record (symmetric with SEQ_LOCK_DEGRADED), the existing symlink-failure path is unchanged, and the poison record survives the PSK signing gate.

## Scope

Pure rename + docstring rewrite. No test bodies change; the 15 assertions are untouched. Issue references are kept inline as provenance instead of as the file identity.

## Verification

- `git mv` recorded both as renames (history preserved).
- `ruff check` / `ruff format --check` clean on `strands_robots tests tests_integ`.
- `pytest tests/mesh/` -> 1460 passed, 2 skipped; the 15 renamed assertions pass.
- No references to the old filenames anywhere in the tree (grepped `.py`/`.md`/`.toml`/`.cfg`).