### PR TITLE
test(libero/suite): cover package-root discovery + init-state loading branches (75%->100%)

### DIFF
--- a/tests/benchmarks/libero/test_libero_suite.py
+++ b/tests/benchmarks/libero/test_libero_suite.py
@@ -138,3 +138,243 @@ class TestLoadLiberoSuite:
         suite_dir.mkdir()
         registered = load_libero_suite("libero_spatial", bddl_dir=suite_dir)
         assert registered == {}
+
+
+# Package-root resolution (_resolve_libero_root)
+
+
+class _FakeLibero:
+    """Minimal stand-in for the installed ``libero`` package object.
+
+    ``require_optional`` imports ``libero`` and inspects ``__file__`` /
+    ``__path__`` to locate the BDDL tree, so a stub carrying only those
+    attributes is enough to drive every branch of ``_resolve_libero_root``
+    without the real package on disk.
+    """
+
+    def __init__(self, file=None, path=None):
+        if file is not None:
+            self.__file__ = file
+        if path is not None:
+            self.__path__ = path
+
+
+@pytest.fixture
+def _patch_require_optional(monkeypatch):
+    """Return a setter that makes ``_resolve_libero_root`` see a chosen stub.
+
+    ``_resolve_libero_root`` pulls the package via ``require_optional``; patching
+    that single seam keeps the test off the real import system and its cache.
+    """
+
+    def _set(stub):
+        monkeypatch.setattr(
+            "strands_robots.benchmarks.libero.suite.require_optional",
+            lambda *a, **k: stub,
+        )
+
+    return _set
+
+
+class TestResolveLiberoRoot:
+    def test_regular_package_uses_file_grandparent(self, _patch_require_optional):
+        """A normal install (``__file__`` set) roots at the dir above the package."""
+        from strands_robots.benchmarks.libero.suite import _resolve_libero_root
+
+        _patch_require_optional(_FakeLibero(file="/opt/site-packages/libero/__init__.py"))
+        from pathlib import Path
+
+        assert _resolve_libero_root() == Path("/opt/site-packages")
+
+    def test_namespace_package_uses_path_entry_parent(self, _patch_require_optional):
+        """A PEP 420 namespace install (``__file__`` None) roots off ``__path__``."""
+        from strands_robots.benchmarks.libero.suite import _resolve_libero_root
+
+        _patch_require_optional(_FakeLibero(file=None, path=["/checkout/libero"]))
+        from pathlib import Path
+
+        assert _resolve_libero_root() == Path("/checkout")
+
+    def test_no_file_and_empty_path_raises(self, _patch_require_optional):
+        """Neither ``__file__`` nor a usable ``__path__`` is an actionable error."""
+        from strands_robots.benchmarks.libero.suite import _resolve_libero_root
+
+        _patch_require_optional(_FakeLibero(file=None, path=[]))
+        with pytest.raises(RuntimeError, match="neither __file__ nor"):
+            _resolve_libero_root()
+
+
+# BDDL-dir probing fallback (_locate_bddl_dir without override)
+
+
+class TestLocateBddlDirProbe:
+    def test_probes_standard_layout_when_no_override(self, tmp_path, monkeypatch):
+        """With no ``bddl_dir=`` the loader walks the package layout and finds the suite."""
+        # Lay out one of the candidate paths: <root>/libero/bddl_files/<suite>.
+        suite_dir = tmp_path / "libero" / "bddl_files" / "libero_spatial"
+        _write(suite_dir / "pick_cube.bddl", "(define (problem t) (:goal (grasped cube)))")
+        monkeypatch.setattr(
+            "strands_robots.benchmarks.libero.suite._resolve_libero_root",
+            lambda: tmp_path,
+        )
+        registered = load_libero_suite("libero_spatial", load_init_states=False)
+        assert "libero-spatial-pick_cube" in registered
+
+    def test_raises_when_no_candidate_layout_matches(self, tmp_path, monkeypatch):
+        """If none of the probed layouts exist, the error lists what was tried."""
+        from strands_robots.benchmarks.libero.suite import _locate_bddl_dir
+
+        monkeypatch.setattr(
+            "strands_robots.benchmarks.libero.suite._resolve_libero_root",
+            lambda: tmp_path,
+        )
+        with pytest.raises(FileNotFoundError, match="Could not locate BDDL directory"):
+            _locate_bddl_dir("libero_spatial", None)
+
+
+# Init-state loading (_load_init_states_by_bddl) error and happy paths
+
+
+class _FakeTaskSuite:
+    """Stand-in for an instantiated LIBERO benchmark suite object."""
+
+    def __init__(self, bddl_files, init_states, *, bddl_raises=False, num_tasks=None):
+        self._bddl_files = bddl_files
+        self._init_states = init_states
+        self._bddl_raises = bddl_raises
+        self._num_tasks = num_tasks if num_tasks is not None else len(bddl_files)
+
+    def get_num_tasks(self):
+        return self._num_tasks
+
+    def get_task_bddl_files(self):
+        if self._bddl_raises:
+            raise RuntimeError("bddl listing exploded")
+        return self._bddl_files
+
+    def get_task_init_states(self, task_id):
+        states = self._init_states[task_id]
+        if isinstance(states, Exception):
+            raise states
+        return states
+
+
+def _install_fake_libero_benchmark(monkeypatch, get_benchmark_dict):
+    """Register fake ``libero.libero.benchmark`` modules in ``sys.modules``.
+
+    ``_load_init_states_by_bddl`` does ``from libero.libero import benchmark``;
+    seeding the three package levels lets the test drive its branches without
+    the real LIBERO package. ``get_benchmark_dict`` may be a callable or
+    ``None`` to exercise the missing-attribute path.
+    """
+    import sys
+    import types
+
+    pkg = types.ModuleType("libero")
+    pkg.__path__ = []  # mark as package
+    sub = types.ModuleType("libero.libero")
+    sub.__path__ = []
+    bench = types.ModuleType("libero.libero.benchmark")
+    if get_benchmark_dict is not None:
+        bench.get_benchmark_dict = get_benchmark_dict
+    monkeypatch.setitem(sys.modules, "libero", pkg)
+    monkeypatch.setitem(sys.modules, "libero.libero", sub)
+    monkeypatch.setitem(sys.modules, "libero.libero.benchmark", bench)
+
+
+class TestLoadInitStatesByBddl:
+    def test_libero_not_importable_returns_empty(self, monkeypatch):
+        """When ``libero`` cannot be imported the map is empty (adapter falls back)."""
+        import sys
+
+        from strands_robots.benchmarks.libero.suite import _load_init_states_by_bddl
+
+        # Ensure the import fails even if libero is installed in the env.
+        monkeypatch.setitem(sys.modules, "libero.libero", None)
+        assert _load_init_states_by_bddl("libero_spatial") == {}
+
+    def test_missing_get_benchmark_dict_returns_empty(self, monkeypatch):
+        from strands_robots.benchmarks.libero.suite import _load_init_states_by_bddl
+
+        _install_fake_libero_benchmark(monkeypatch, get_benchmark_dict=None)
+        assert _load_init_states_by_bddl("libero_spatial") == {}
+
+    def test_get_benchmark_dict_raising_returns_empty(self, monkeypatch):
+        from strands_robots.benchmarks.libero.suite import _load_init_states_by_bddl
+
+        def _boom():
+            raise RuntimeError("registry init failed")
+
+        _install_fake_libero_benchmark(monkeypatch, get_benchmark_dict=_boom)
+        assert _load_init_states_by_bddl("libero_spatial") == {}
+
+    def test_unknown_suite_returns_empty(self, monkeypatch):
+        from strands_robots.benchmarks.libero.suite import _load_init_states_by_bddl
+
+        _install_fake_libero_benchmark(monkeypatch, get_benchmark_dict=lambda: {})
+        assert _load_init_states_by_bddl("libero_spatial") == {}
+
+    def test_suite_factory_raising_returns_empty(self, monkeypatch):
+        from strands_robots.benchmarks.libero.suite import _load_init_states_by_bddl
+
+        def _factory():
+            raise RuntimeError("cannot build suite")
+
+        _install_fake_libero_benchmark(monkeypatch, get_benchmark_dict=lambda: {"libero_spatial": _factory})
+        assert _load_init_states_by_bddl("libero_spatial") == {}
+
+    def test_get_task_bddl_files_raising_returns_empty(self, monkeypatch):
+        from strands_robots.benchmarks.libero.suite import _load_init_states_by_bddl
+
+        ts = _FakeTaskSuite(bddl_files=["a.bddl"], init_states=[object()], bddl_raises=True)
+        _install_fake_libero_benchmark(monkeypatch, get_benchmark_dict=lambda: {"libero_spatial": lambda: ts})
+        assert _load_init_states_by_bddl("libero_spatial") == {}
+
+    def test_happy_path_keys_on_bare_bddl_filename(self, monkeypatch):
+        """Each task's init states are keyed by the bare BDDL filename."""
+        import numpy as np
+
+        from strands_robots.benchmarks.libero.suite import _load_init_states_by_bddl
+
+        states0 = np.zeros((50, 79), dtype=np.float32)
+        states1 = np.ones((50, 84), dtype=np.float32)
+        ts = _FakeTaskSuite(
+            bddl_files=["/pkg/bddl/pick_cube.bddl", "/pkg/bddl/stack_block.bddl"],
+            init_states=[states0, states1],
+        )
+        _install_fake_libero_benchmark(monkeypatch, get_benchmark_dict=lambda: {"libero_spatial": lambda: ts})
+        out = _load_init_states_by_bddl("libero_spatial")
+        assert set(out) == {"pick_cube.bddl", "stack_block.bddl"}
+        assert out["pick_cube.bddl"].shape == (50, 79)
+        assert out["stack_block.bddl"].shape == (50, 84)
+
+    def test_per_task_init_state_failure_skips_only_that_task(self, monkeypatch):
+        """One task raising in ``get_task_init_states`` must not drop the others."""
+        import numpy as np
+
+        from strands_robots.benchmarks.libero.suite import _load_init_states_by_bddl
+
+        good = np.zeros((50, 79), dtype=np.float32)
+        ts = _FakeTaskSuite(
+            bddl_files=["/pkg/good.bddl", "/pkg/bad.bddl"],
+            init_states=[good, RuntimeError("missing init-state file")],
+        )
+        _install_fake_libero_benchmark(monkeypatch, get_benchmark_dict=lambda: {"libero_spatial": lambda: ts})
+        out = _load_init_states_by_bddl("libero_spatial")
+        assert set(out) == {"good.bddl"}
+
+    def test_task_id_beyond_bddl_files_is_skipped(self, monkeypatch):
+        """A ``num_tasks`` larger than the bddl-file list skips the overflow ids."""
+        import numpy as np
+
+        from strands_robots.benchmarks.libero.suite import _load_init_states_by_bddl
+
+        good = np.zeros((50, 79), dtype=np.float32)
+        ts = _FakeTaskSuite(
+            bddl_files=["/pkg/only_one.bddl"],
+            init_states=[good],
+            num_tasks=3,
+        )
+        _install_fake_libero_benchmark(monkeypatch, get_benchmark_dict=lambda: {"libero_spatial": lambda: ts})
+        out = _load_init_states_by_bddl("libero_spatial")
+        assert set(out) == {"only_one.bddl"}


### PR DESCRIPTION
## What
Adds focused, dependency-free behavior tests for `strands_robots/benchmarks/libero/suite.py`, lifting its coverage from 75% to 100% (30 previously-uncovered lines now exercised). Test-only; no library behavior is modified.

## Why
Two whole helpers in this module were untested:

- `_resolve_libero_root` - locates the installed LIBERO package's filesystem root, handling both a regular install (`__file__` set) and a PEP 420 namespace install (`__file__` None, root pulled from `__path__`, e.g. NVIDIA's symlinked `setup_libero.sh` layout). The namespace branch and the both-missing error path had zero coverage.
- `_load_init_states_by_bddl` - pulls per-task LIBERO init states. Every defensive branch (libero not importable, missing `get_benchmark_dict`, factory/instantiation raising, unknown suite, `get_task_bddl_files` raising, per-task `get_task_init_states` raising, task-id overflow) decides whether a suite registers with real init states or silently falls back to snapshot-and-restore. Those fallbacks are exactly the contract that must not drift: a wrong turn there collapses LIBERO success rate to 0 (the qpos=0 vs canonical-ready-pose bug this code guards against).
- The probe fallback in `_locate_bddl_dir` (no `bddl_dir=` override) was only covered indirectly; it is now driven directly.

## Tests added
All run without the `libero` package by faking it: `_resolve_libero_root` is driven through a patched `require_optional` returning a stub carrying only `__file__`/`__path__`; `_load_init_states_by_bddl` is driven by seeding fake `libero.libero.benchmark` modules in `sys.modules` (via `monkeypatch.setitem`) plus a small fake task-suite object.

- `TestResolveLiberoRoot` - regular-package grandparent rooting, namespace-package `__path__` rooting, and the neither-`__file__`-nor-`__path__` `RuntimeError`.
- `TestLocateBddlDirProbe` - probing the standard `<root>/libero/bddl_files/<suite>` layout when no override is given, and the no-layout-matches `FileNotFoundError` (which lists the paths tried).
- `TestLoadInitStatesByBddl` - the seven defensive empty-dict branches, the happy path (init states keyed by bare BDDL filename, correct per-task widths), per-task failure isolating only the bad task, and task-id-beyond-bddl-files overflow skipping.

Tests assert observable outputs (returned maps, raised errors, registered keys) rather than internal state, consistent with the existing suite in this file, and use `monkeypatch`/`tmp_path` only (no host paths, no `os.environ` mutation).

## Coverage
`strands_robots/benchmarks/libero/suite.py`: 75% -> 100%.

## Verification
- `ruff check` + `ruff format --check`: clean.
- `mypy` on the changed test file: clean.
- `pytest tests/benchmarks/libero/`: 277 passed, 28 skipped.