### PR TITLE
test(rendering): cover render_all multi-camera aggregation (82%->88%)

### DIFF
--- a/tests/simulation/mujoco/test_rendering.py
+++ b/tests/simulation/mujoco/test_rendering.py
@@ -725,3 +725,156 @@ def test_recorder_first_frame_is_real_geometry(tmp_path: Path) -> None:
     )
 
     sim.destroy()
+
+
+# render_all() aggregation logic - GL-free coverage.
+#
+# render_all() resolves cameras then delegates the actual pixel grab to
+# render() per camera, aggregating the results into a single multi-view
+# response. The aggregation branches (success vs. failure per camera, the
+# low-variance "empty frame" flag, and the all-failed -> status="error" rule)
+# are pure Python independent of OpenGL, so we drive them by stubbing
+# render() and _active_camera_list() instead of running a real renderer.
+# This keeps the contract pinned on CI, where the GL-backed render_all test
+# is skipped.
+
+
+class _FakeWorld:
+    """Minimal stand-in for SimWorld so render_all's guards and summary pass."""
+
+    def __init__(self) -> None:
+        self._model = object()
+        self._data = object()
+        self.sim_time = 1.5
+
+
+def _make_rendering_mixin(monkeypatch, cameras, render_results):
+    """Build a RenderingMixin bound to a fake world with a scripted render().
+
+    Args:
+        cameras: camera names _active_camera_list should report as resolved.
+        render_results: dict mapping camera name -> the dict render() returns.
+    """
+    from strands_robots.simulation.mujoco.rendering import RenderingMixin
+
+    mixin = RenderingMixin.__new__(RenderingMixin)
+    mixin._world = _FakeWorld()  # type: ignore[assignment]
+
+    monkeypatch.setattr(mixin, "_active_camera_list", lambda c: (list(cameras), []))
+
+    def fake_render(camera_name=None, width=None, height=None):
+        return render_results[camera_name]
+
+    monkeypatch.setattr(mixin, "render", fake_render)
+    return mixin
+
+
+def _image_block(camera_name):
+    return {"status": "success", "content": [{"text": camera_name}, {"image": {"data": b"x"}}]}
+
+
+def _image_block_with_variance(camera_name, variance):
+    return {
+        "status": "success",
+        "content": [{"image": {"data": b"x"}}, {"json": {"pixel_variance": variance}}],
+    }
+
+
+def test_render_all_aggregates_one_image_block_per_camera(monkeypatch) -> None:
+    """Every successfully rendered camera contributes a label + image block,
+    and the summary reports all of them as ok."""
+    cams = ["cam_a", "cam_b"]
+    mixin = _make_rendering_mixin(monkeypatch, cams, {c: _image_block(c) for c in cams})
+    r = mixin.render_all()
+    assert r["status"] == "success"
+    images = [b for b in r["content"] if isinstance(b, dict) and "image" in b]
+    assert len(images) == 2
+    summary = r["content"][0]["text"]
+    assert "2 ok, 0 failed, 2 requested" in summary
+
+
+def test_render_all_flags_low_variance_frame_as_empty(monkeypatch) -> None:
+    """A near-uniform frame (pixel_variance < 1) is flagged inline and counted
+    in the summary's low-variance suffix, without dropping the image."""
+    mixin = _make_rendering_mixin(
+        monkeypatch,
+        ["cam_a"],
+        {"cam_a": _image_block_with_variance("cam_a", 0.2)},
+    )
+    r = mixin.render_all()
+    assert r["status"] == "success"
+    label = next(b["text"] for b in r["content"][1:] if isinstance(b, dict) and "text" in b)
+    assert "image appears empty" in label
+    assert "1 low-variance" in r["content"][0]["text"]
+
+
+def test_render_all_high_variance_frame_not_flagged(monkeypatch) -> None:
+    """A frame with real geometry (pixel_variance >= 1) is not flagged and the
+    summary carries no low-variance suffix."""
+    mixin = _make_rendering_mixin(
+        monkeypatch,
+        ["cam_a"],
+        {"cam_a": _image_block_with_variance("cam_a", 42.0)},
+    )
+    r = mixin.render_all()
+    assert r["status"] == "success"
+    assert "low-variance" not in r["content"][0]["text"]
+
+
+def test_render_all_reports_per_camera_failure_and_succeeds_if_any_ok(monkeypatch) -> None:
+    """A mix of ok + failing cameras: the failing one surfaces its error text,
+    the ok one still ships its image, and overall status stays success."""
+    cams = ["good", "bad"]
+    results = {
+        "good": _image_block("good"),
+        "bad": {"status": "error", "content": [{"text": "render device lost"}]},
+    }
+    mixin = _make_rendering_mixin(monkeypatch, cams, results)
+    r = mixin.render_all()
+    assert r["status"] == "success"
+    texts = " ".join(b["text"] for b in r["content"] if isinstance(b, dict) and "text" in b)
+    assert "render device lost" in texts
+    assert "1 ok, 1 failed, 2 requested" in r["content"][0]["text"]
+
+
+def test_render_all_status_error_when_every_camera_fails(monkeypatch) -> None:
+    """If no camera renders successfully, render_all reports status='error'."""
+    cams = ["bad"]
+    results = {"bad": {"status": "error", "content": [{"text": "boom"}]}}
+    mixin = _make_rendering_mixin(monkeypatch, cams, results)
+    r = mixin.render_all()
+    assert r["status"] == "error"
+    assert "0 ok, 1 failed" in r["content"][0]["text"]
+
+
+def test_render_all_errors_when_no_world() -> None:
+    """Called before create_world (self._world is None) -> error, not a crash."""
+    from strands_robots.simulation.mujoco.rendering import RenderingMixin
+
+    mixin = RenderingMixin.__new__(RenderingMixin)
+    mixin._world = None
+    r = mixin.render_all()
+    assert r["status"] == "error"
+    assert "No world" in r["content"][0]["text"]
+
+
+def test_render_all_errors_when_no_cameras_in_scene(monkeypatch) -> None:
+    """A world with zero cameras -> error with an explanatory message."""
+    mixin = _make_rendering_mixin(monkeypatch, [], {})
+    r = mixin.render_all()
+    assert r["status"] == "error"
+    assert "No cameras in scene" in r["content"][0]["text"]
+
+
+def test_render_all_errors_on_unresolved_requested_cameras(monkeypatch) -> None:
+    """When the caller names cameras that don't resolve, render_all reports the
+    unresolved set rather than silently rendering a subset."""
+    from strands_robots.simulation.mujoco.rendering import RenderingMixin
+
+    mixin = RenderingMixin.__new__(RenderingMixin)
+    mixin._world = _FakeWorld()  # type: ignore[assignment]
+    monkeypatch.setattr(mixin, "_active_camera_list", lambda c: (["cam_a"], ["ghost"]))
+    monkeypatch.setattr(mixin, "_list_camera_names", lambda: ["cam_a"])
+    r = mixin.render_all(cameras=["cam_a", "ghost"])
+    assert r["status"] == "error"
+    assert "ghost" in r["content"][0]["text"]


### PR DESCRIPTION
## Summary

Test-only PR adding eight hardware-free behavior tests for `Simulation.render_all()`, lifting `simulation/mujoco/rendering.py` coverage from 82% to 88% (105 -> 73 missing lines) under CI conditions.

`render_all()` resolves the requested camera set, then delegates the actual per-camera pixel capture to `render()`, aggregating the results into a single multi-view response. Its aggregation logic is pure Python, independent of OpenGL:

- per-camera success/failure counting and summary line,
- the low-variance empty-frame flag (`pixel_variance < 1`),
- the all-failed -> `status="error"` rule (success only when at least one camera renders),
- the no-world, no-cameras-in-scene, and unresolved-requested-camera guards.

This logic was previously exercised only by the GL-backed `render_all` test, which is skipped in CI (`requires OpenGL; opt-in via ROBOT_TEST_MUJOCO=1`). That left the entire aggregation block (source lines around 909, 916-951) uncovered on every CI run.

## What the tests pin

Each test drives a `render_all` branch by stubbing `render()` and `_active_camera_list()` on a freshly-constructed `RenderingMixin` bound to a minimal fake world, asserting observable outputs rather than internal state:

- aggregates one label+image block per camera and reports `N ok, 0 failed, N requested`,
- flags a near-uniform frame inline (`image appears empty`) and adds the `low-variance` summary suffix without dropping the image,
- does NOT flag a high-variance (real-geometry) frame,
- on a mixed ok/failing set, surfaces the failing camera's error text, still ships the ok image, and keeps overall `status=success`,
- returns `status=error` when every camera fails,
- returns `status=error` (not a crash) when called before `create_world()` (no world),
- returns `status=error` when the scene has zero cameras,
- returns `status=error` naming the unresolved set when the caller requests cameras that do not resolve.

## Verification

Coverage measured with the GL-backed test skipped (matching CI):

```
before: rendering.py  586  105  82%
after:  rendering.py  586   73  88%
```

`tests/simulation/mujoco/test_rendering.py`: 17 passed, 11 skipped (GL-backed). No source changes; ASCII-only assertions; no host paths; `monkeypatch` only.