### PR TITLE
test(tools): cover lazy-import __getattr__ contract (36%->100%)

### DIFF
--- a/tests/tools/test_tools_lazy_import.py
+++ b/tests/tools/test_tools_lazy_import.py
@@ -1,0 +1,73 @@
+"""Behavior tests for the ``strands_robots.tools`` lazy-import contract.
+
+The tools package defers importing each tool module until first attribute
+access so that ``import strands_robots.tools`` never pulls in numpy, pyserial,
+psutil, and the other heavy per-tool dependencies. These tests pin that public
+contract:
+
+- Every name advertised in ``__all__`` is lazily importable as a real attribute.
+- The first access materializes the tool via ``__getattr__`` and caches it into
+  the package namespace, so a repeat access returns the identical object.
+- An unknown attribute raises ``AttributeError`` naming the package and the
+  missing attribute, matching the standard module-level ``__getattr__`` protocol.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+import strands_robots.tools as tools_pkg
+
+
+def test_all_lists_every_lazy_import_name() -> None:
+    """``__all__`` advertises exactly the lazily-importable tool names."""
+    assert set(tools_pkg.__all__) == set(tools_pkg._LAZY_IMPORTS)
+    # The advertised fleet of tools, so a silent drop is caught here.
+    assert set(tools_pkg.__all__) == {
+        "download_assets",
+        "gr00t_inference",
+        "lerobot_calibrate",
+        "lerobot_camera",
+        "lerobot_teleoperate",
+        "pose_tool",
+        "robot_mesh",
+        "serial_tool",
+    }
+
+
+@pytest.mark.parametrize("name", sorted(tools_pkg._LAZY_IMPORTS))
+def test_each_tool_is_lazily_importable(name: str) -> None:
+    """Each advertised name resolves to the matching object via ``__getattr__``.
+
+    The package caches resolved tools into its namespace, and a prior test (or
+    import) may already have triggered that cache, so first drop any cached
+    binding to force a fresh ``__getattr__`` resolution. Then assert the access
+    materializes the documented target and re-caches it for subsequent reads.
+    """
+    # Force the next access to go through __getattr__ rather than a cached glob.
+    vars(tools_pkg).pop(name, None)
+    assert name not in vars(tools_pkg)
+
+    value = getattr(tools_pkg, name)
+    assert value is not None
+
+    # The lazy target maps to the documented (relative module, attribute) pair.
+    rel_module, attr_name = tools_pkg._LAZY_IMPORTS[name]
+    submodule = importlib.import_module(rel_module, tools_pkg.__name__)
+    assert value is getattr(submodule, attr_name)
+
+    # First access caches into the package namespace; second access is identical.
+    assert name in vars(tools_pkg)
+    assert getattr(tools_pkg, name) is value
+
+
+def test_unknown_attribute_raises_attribute_error() -> None:
+    """An unknown attribute raises ``AttributeError`` naming package + attr."""
+    with pytest.raises(AttributeError) as excinfo:
+        tools_pkg.definitely_not_a_tool  # noqa: B018 - trigger __getattr__
+
+    message = str(excinfo.value)
+    assert "strands_robots.tools" in message
+    assert "definitely_not_a_tool" in message


### PR DESCRIPTION
## What
Adds behavior tests for the `strands_robots.tools` package-level lazy-import contract. `tools/__init__.py` defers importing each tool module until first attribute access (via module-level `__getattr__`) so that `import strands_robots.tools` never pulls in numpy, pyserial, psutil, and the other heavy per-tool dependencies. That `__getattr__` path (the lines that resolve, cache, and reject names) had no direct coverage.

## Tests added (`tests/tools/test_tools_lazy_import.py`)
- `__all__` advertises exactly the set of lazily-importable tool names (catches a silently dropped tool).
- Each advertised name resolves through `__getattr__` to the documented `(module, attribute)` target, then caches into the package namespace so a repeat access returns the identical object. The test pops any pre-cached binding first so it deterministically exercises the lazy path regardless of suite ordering.
- An unknown attribute raises `AttributeError` naming both the package and the missing attribute, matching the standard module `__getattr__` protocol.

## Coverage
`strands_robots/tools/__init__.py`: 36% -> 100% (lines 28-35 of `__getattr__` now exercised).

## Verification
- Regression guard confirmed: dropping a tool from `_LAZY_IMPORTS` makes the contract test fail.
- `ruff check`, `ruff format --check`, `mypy` clean.
- Full `tests/tools/` suite green (377 passed) under `MUJOCO_GL=egl`.

Test-only change; no runtime behavior modified.