### PR TITLE
test(molmoact2): cover build_policy lerobot factory wiring (77%->100%)

### DIFF
--- a/tests/policies/lerobot_local/test_molmoact2.py
+++ b/tests/policies/lerobot_local/test_molmoact2.py
@@ -18,6 +18,21 @@ import pytest
 from strands_robots.policies.lerobot_local import molmoact2
 
 
+def _require_lerobot_configs_features() -> None:
+    """Skip unless ``lerobot.configs`` exposes the typed-feature API.
+
+    ``build_policy`` imports ``FeatureType``/``PolicyFeature`` from
+    ``lerobot.configs``; those symbols only exist in lerobot >= 0.5.2 (from
+    source). A bare ``importorskip("lerobot")`` passes on the PyPI 0.5.1 wheel,
+    where the import then raises and the test *errors* instead of *skips*. Gate
+    on the symbol the code path actually needs so older lerobot cleanly skips.
+    """
+    pytest.importorskip("lerobot")
+    configs = pytest.importorskip("lerobot.configs")
+    if not hasattr(configs, "FeatureType") or not hasattr(configs, "PolicyFeature"):
+        pytest.skip("lerobot.configs lacks FeatureType/PolicyFeature (needs lerobot >= 0.5.2)")
+
+
 def test_is_molmoact2_explicit_type():
     """Explicit policy_type='molmoact2' short-circuits to True without any I/O."""
     assert molmoact2.is_molmoact2("anything/at-all", "molmoact2") is True
@@ -177,3 +192,198 @@ class TestDeriveImageKeysEmbodimentFallback:
     def test_embodiment_image_targets_none_spec(self):
         """A None spec short-circuits to [] before any import."""
         assert molmoact2._embodiment_image_targets(None) == []
+
+
+class TestBuildPolicy:
+    """``build_policy`` wiring of lerobot's PUBLIC factory contract.
+
+    These tests exercise the load path hardware-free by stubbing the three
+    ``lerobot.policies.factory`` entry points the wrapper rides
+    (``make_policy_config`` / ``get_policy_class`` / ``make_pre_post_processors``)
+    plus the norm-tag/image-key helpers. They pin the kwargs the wrapper hands
+    lerobot so an upstream factory-signature drift is caught here rather than
+    only on a 21GB hardware run.
+    """
+
+    @pytest.fixture
+    def fake_factory(self, monkeypatch):
+        """Stub lerobot's factory + record what build_policy passes through it."""
+        _require_lerobot_configs_features()
+        import lerobot.policies.factory as factory
+
+        calls: dict[str, object] = {}
+
+        class FakePolicy:
+            def __init__(self, cfg):
+                self.cfg = cfg
+                self.to_device = None
+                self.eval_called = False
+
+            def to(self, device):
+                self.to_device = device
+                return self
+
+            def eval(self):
+                self.eval_called = True
+                return self
+
+        def fake_make_policy_config(policy_type, **kwargs):
+            calls["config_type"] = policy_type
+            calls["config_kwargs"] = kwargs
+            return {"_cfg": True, **kwargs}
+
+        def fake_get_policy_class(policy_type):
+            calls["policy_class_type"] = policy_type
+            return FakePolicy
+
+        def fake_make_pre_post(cfg):
+            calls["processors_cfg"] = cfg
+            return ("PRE", "POST")
+
+        monkeypatch.setattr(factory, "make_policy_config", fake_make_policy_config)
+        monkeypatch.setattr(factory, "get_policy_class", fake_get_policy_class)
+        monkeypatch.setattr(factory, "make_pre_post_processors", fake_make_pre_post)
+        # Pin helper outputs so the test asserts wiring, not discovery I/O.
+        monkeypatch.setattr(molmoact2, "auto_norm_tag", lambda _p, tag: tag or "resolved_tag")
+        monkeypatch.setattr(
+            molmoact2,
+            "derive_image_keys",
+            lambda keys, _emb: keys or ["observation.images.cam"],
+        )
+        return calls, FakePolicy
+
+    def test_returns_policy_processors_and_config(self, fake_factory):
+        """build_policy returns the (policy, pre, post, cfg) 4-tuple from the factory."""
+        policy, pre, post, cfg = molmoact2.build_policy(
+            "allenai/MolmoAct2-SO100_101",
+            device="cpu",
+            norm_tag="so100_so101_molmoact2",
+            inference_action_mode="continuous",
+            image_keys=None,
+            embodiment_spec=None,
+        )
+        assert pre == "PRE"
+        assert post == "POST"
+        assert cfg["_cfg"] is True
+        # The policy was instantiated, moved to device, and put in eval mode.
+        assert policy.to_device == "cpu"
+        assert policy.eval_called is True
+
+    def test_passes_checkpoint_and_mode_to_config(self, fake_factory):
+        """The HF repo, resolved norm tag and action mode reach make_policy_config."""
+        calls, _ = fake_factory
+        molmoact2.build_policy(
+            "allenai/MolmoAct2-SO100_101",
+            device="cpu",
+            norm_tag=None,  # -> auto_norm_tag stub yields "resolved_tag"
+            inference_action_mode="discrete",
+            image_keys=None,
+            embodiment_spec=None,
+        )
+        assert calls["config_type"] == molmoact2.MOLMOACT2_TYPE
+        kw = calls["config_kwargs"]
+        assert kw["checkpoint_path"] == "allenai/MolmoAct2-SO100_101"
+        assert kw["norm_tag"] == "resolved_tag"
+        assert kw["inference_action_mode"] == "discrete"
+        assert kw["device"] == "cpu"
+
+    def test_builds_visual_state_and_action_features(self, fake_factory):
+        """Image keys become VISUAL features; state/action features pin the dims."""
+        from lerobot.configs import FeatureType
+
+        calls, _ = fake_factory
+        molmoact2.build_policy(
+            "repo",
+            device="cpu",
+            norm_tag="t",
+            inference_action_mode="continuous",
+            image_keys=["observation.images.top", "observation.images.wrist"],
+            embodiment_spec=None,
+            state_dim=7,
+            action_dim=7,
+        )
+        kw = calls["config_kwargs"]
+        in_feats = kw["input_features"]
+        assert in_feats["observation.images.top"].type == FeatureType.VISUAL
+        assert in_feats["observation.images.top"].shape == (3, 224, 224)
+        assert in_feats["observation.state"].type == FeatureType.STATE
+        assert in_feats["observation.state"].shape == (7,)
+        out_feats = kw["output_features"]
+        assert out_feats["action"].type == FeatureType.ACTION
+        assert out_feats["action"].shape == (7,)
+
+    def test_device_none_resolves_via_torch(self, fake_factory, monkeypatch):
+        """device=None resolves to cpu when CUDA is unavailable (no silent crash)."""
+        import torch
+
+        calls, _ = fake_factory
+        monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+        policy, _pre, _post, _cfg = molmoact2.build_policy(
+            "repo",
+            device=None,
+            norm_tag="t",
+            inference_action_mode="continuous",
+            image_keys=["observation.images.cam"],
+            embodiment_spec=None,
+        )
+        assert calls["config_kwargs"]["device"] == "cpu"
+        assert policy.to_device == "cpu"
+
+    def test_processors_built_from_resolved_config(self, fake_factory):
+        """make_pre_post_processors is dispatched with the config build_policy made."""
+        calls, _ = fake_factory
+        _policy, _pre, _post, cfg = molmoact2.build_policy(
+            "repo",
+            device="cpu",
+            norm_tag="t",
+            inference_action_mode="continuous",
+            image_keys=["observation.images.cam"],
+            embodiment_spec=None,
+        )
+        assert calls["processors_cfg"] is cfg
+
+    def test_missing_lerobot_factory_raises_install_hint(self, monkeypatch):
+        """If lerobot.policies.factory is absent, a clear install hint is raised."""
+        pytest.importorskip("lerobot")
+        import builtins
+
+        real_import = builtins.__import__
+
+        def blocked_import(name, *args, **kwargs):
+            if name == "lerobot.policies.factory":
+                raise ImportError("no factory")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", blocked_import)
+        with pytest.raises(ImportError, match="MolmoAct2 requires lerobot"):
+            molmoact2.build_policy(
+                "repo",
+                device="cpu",
+                norm_tag="t",
+                inference_action_mode="continuous",
+                image_keys=["observation.images.cam"],
+                embodiment_spec=None,
+            )
+
+    def test_missing_lerobot_configs_raises_install_hint(self, monkeypatch):
+        """If lerobot.configs is absent, the first import guard raises the hint."""
+        pytest.importorskip("lerobot")
+        import builtins
+
+        real_import = builtins.__import__
+
+        def blocked_import(name, *args, **kwargs):
+            if name == "lerobot.configs":
+                raise ImportError("no configs")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", blocked_import)
+        with pytest.raises(ImportError, match="MolmoAct2 requires lerobot"):
+            molmoact2.build_policy(
+                "repo",
+                device="cpu",
+                norm_tag="t",
+                inference_action_mode="continuous",
+                image_keys=["observation.images.cam"],
+                embodiment_spec=None,
+            )


### PR DESCRIPTION
## Summary
Adds seven hardware-free behavior tests pinning `molmoact2.build_policy`, the previously-untested MolmoAct2 load path (`strands_robots/policies/lerobot_local/molmoact2.py`). Coverage of that module goes from 77% to 100% (the `build_policy` body, lines ~228-308, plus the two import guards, had no direct coverage and was deferred to a 21GB hardware/e2e run).

`build_policy` is the wrapper that rides lerobot's PUBLIC factory contract (`make_policy_config` / `get_policy_class` / `make_pre_post_processors`) to load transformers-native MolmoAct2 SO-100/101 checkpoints. Because it depends on that factory signature, an upstream lerobot drift previously could only surface on a full hardware load. These tests stub the three factory entry points (imported at call time) and assert the exact wiring, so a signature/dispatch drift is now caught in CI.

## What the tests pin
- Returns the `(policy, preprocessor, postprocessor, config)` 4-tuple; the policy is instantiated, moved to the resolved device, and put in `eval()` mode.
- The HF repo, resolved norm tag, and `inference_action_mode` reach `make_policy_config` with the blessed `molmoact2` type.
- Image keys become `VISUAL` features at `(3, 224, 224)`; `observation.state` / `action` features pin the SO-arm dims (parametrized to 7 to prove dims flow through).
- `device=None` resolves via torch (cpu when CUDA unavailable) without a silent crash.
- `make_pre_post_processors` is dispatched with the exact config object `build_policy` built.
- Both import guards (`lerobot.configs` and `lerobot.policies.factory` missing) raise the documented install hint.

## Testing
- `MUJOCO_GL=egl pytest tests/policies/lerobot_local/test_molmoact2.py` -> 29 passed.
- Full suite green (pre-existing torchcodec-on-CPU recording failures unrelated).
- Drift check: temporarily breaking the `checkpoint_path` kwarg in `build_policy` makes `test_passes_checkpoint_and_mode_to_config` fail, confirming the test catches real contract drift.
- Pure test addition (+195/-0, one file); no library code touched, ASCII-only, `monkeypatch`/`tmp_path` fixtures, no host paths.