### PR TITLE
test(_rng): cover torch CPU/CUDA reseed + missing-torch + best-effort branches (77%->100%)

### DIFF
--- a/tests/policies/test_rng_parity.py
+++ b/tests/policies/test_rng_parity.py
@@ -65,3 +65,81 @@ def test_both_providers_route_reset_through_shared_helper():
     assert "np.random.seed(seed)" not in cosmos_src, (
         "Cosmos3Policy.reset must not reseed only the global NumPy RNG anymore (#331)"
     )
+
+
+def test_reseed_seeds_torch_cpu_and_cuda_when_available(monkeypatch):
+    """When torch is importable and reports CUDA, the helper must seed the CPU
+    and CUDA generators and pin cuDNN into deterministic mode -- the per-episode
+    reproducibility contract on GPU hosts (#331)."""
+    import sys
+    import types
+
+    calls: dict[str, object] = {}
+    fake_torch = types.ModuleType("torch")
+    fake_torch.manual_seed = lambda s: calls.__setitem__("manual_seed", s)
+    fake_cuda = types.SimpleNamespace(
+        is_available=lambda: True,
+        manual_seed_all=lambda s: calls.__setitem__("manual_seed_all", s),
+    )
+    fake_torch.cuda = fake_cuda
+    fake_torch.backends = types.SimpleNamespace(cudnn=types.SimpleNamespace(deterministic=False, benchmark=True))
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+
+    reseed_client_rngs(99)
+
+    assert calls["manual_seed"] == 99, "torch CPU generator must be seeded"
+    assert calls["manual_seed_all"] == 99, "CUDA generators must be seeded when CUDA is available"
+    assert fake_torch.backends.cudnn.deterministic is True, "cuDNN must be pinned deterministic"
+    assert fake_torch.backends.cudnn.benchmark is False, "cuDNN autotuner must be disabled for determinism"
+
+
+def test_reseed_skips_cuda_when_unavailable(monkeypatch):
+    """On a CPU-only host the CUDA reseed must be skipped, not attempted."""
+    import sys
+    import types
+
+    calls: dict[str, object] = {}
+    fake_torch = types.ModuleType("torch")
+    fake_torch.manual_seed = lambda s: calls.__setitem__("manual_seed", s)
+
+    def _boom(_s):
+        raise AssertionError("manual_seed_all must not be called when CUDA is unavailable")
+
+    fake_torch.cuda = types.SimpleNamespace(is_available=lambda: False, manual_seed_all=_boom)
+    fake_torch.backends = types.SimpleNamespace(cudnn=types.SimpleNamespace(deterministic=False, benchmark=True))
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+
+    reseed_client_rngs(5)
+
+    assert calls["manual_seed"] == 5
+    assert fake_torch.backends.cudnn.deterministic is True
+
+
+def test_reseed_tolerates_missing_torch(monkeypatch):
+    """torch is an optional dependency; a service-only / mock install without it
+    must reseed Python + NumPy and silently skip torch (no ImportError leak)."""
+    import sys
+
+    monkeypatch.setitem(sys.modules, "torch", None)  # makes `import torch` raise ImportError
+
+    reseed_client_rngs(11)
+    a = np.random.rand(3).tolist()
+    reseed_client_rngs(11)
+    b = np.random.rand(3).tolist()
+    assert a == b, "Python+NumPy reseed must still be deterministic without torch"
+
+
+def test_reseed_swallows_unexpected_failures(monkeypatch, caplog):
+    """reset() is a soft reproducibility hint: an unexpected reseed failure must
+    be logged and swallowed, never propagated to the caller."""
+    import logging
+
+    def _boom(_seed):
+        raise RuntimeError("rng backend exploded")
+
+    monkeypatch.setattr(np.random, "seed", _boom)
+
+    with caplog.at_level(logging.INFO, logger="strands_robots.policies._rng"):
+        reseed_client_rngs(3)  # must not raise
+
+    assert any("reseed failed" in r.message for r in caplog.records), "the swallowed failure must be logged"


### PR DESCRIPTION
## What
Adds four hardware-free behavior tests for `strands_robots/policies/_rng.py`, lifting its coverage from 77% to 100% (5 previously-uncovered lines now exercised).

## Why
`reseed_client_rngs` is the single source of truth for client-side per-episode RNG reseeding shared by `Gr00tPolicy.reset` and `Cosmos3Policy.reset` (#331, #187 reproducibility). The torch branch was entirely untested: the CUDA-available reseed path, the optional-torch `ImportError` skip, and the outer best-effort `except` were all uncovered. These are exactly the paths whose contract must not silently drift -- a GPU host expects deterministic CUDA seeding, a mock/service-only install without torch must not crash, and a soft reseed must never propagate a failure to `reset()`.

## Tests added
All run without torch or hardware by substituting a fake torch module / monkeypatching the RNG:
- `test_reseed_seeds_torch_cpu_and_cuda_when_available` - a torch reporting CUDA gets its CPU and CUDA generators seeded and cuDNN pinned deterministic (`deterministic=True`, `benchmark=False`).
- `test_reseed_skips_cuda_when_unavailable` - on a CPU-only host the CUDA reseed is skipped, not attempted (the `manual_seed_all` fake raises if called).
- `test_reseed_tolerates_missing_torch` - with `torch` absent (`sys.modules["torch"]=None`), Python+NumPy reseed stays deterministic and the `ImportError` is swallowed.
- `test_reseed_swallows_unexpected_failures` - an unexpected reseed failure (e.g. a broken NumPy backend) is logged and swallowed, never raised, because `reset()` is a soft reproducibility hint.

Tests assert observable outputs (which generators were seeded, determinism of the resulting stream, that no exception escapes, that the failure is logged) rather than internal state, consistent with the existing suite in this file.

## Coverage
`strands_robots/policies/_rng.py`: 77% -> 100% (lines 46, 49-54 now covered).

## Verification
- `ruff check` + `ruff format --check`: clean on the changed file.
- `mypy`: no new errors introduced.
- `pytest tests/policies/test_rng_parity.py`: 8 passed.

Test-only change; no library behavior is modified.