### PR TITLE
fix(lerobot_local): resolve policy type from HF model_type / auto_map

### DIFF
--- a/strands_robots/policies/lerobot_local/resolution.py
+++ b/strands_robots/policies/lerobot_local/resolution.py
@@ -263,7 +263,8 @@ def resolve_policy_class_from_hub(pretrained_name_or_path: str) -> tuple[type[An
     if not policy_type:
         raise ValueError(
             f"Could not determine policy type from '{pretrained_name_or_path}'. "
-            f"No 'type' field found in config.json. "
+            f"config.json had no usable 'type', 'model_type', or recognized "
+            f"'auto_map' entry (checked against the known third-party policy map). "
             f"Pass policy_type= explicitly."
         )
 
@@ -404,8 +405,74 @@ def resolve_policy_class_by_name(policy_type: str) -> type[Any]:
     )
 
 
+# Explicit overrides mapping a HuggingFace ``model_type`` (or an
+# ``auto_map`` class name) to the strands_robots/lerobot policy type used
+# for class resolution. Third-party checkpoints distributed in the
+# transformers layout often set ``model_type`` / ``auto_map`` but leave the
+# lerobot ``type`` field unset (``None``); this table bridges that gap.
+# Keyed by lowercase token so both ``model_type`` values and ``auto_map``
+# class-name stems resolve through the same lookup. Grows as new
+# third-party policies land.
+_KNOWN_MODEL_TYPE_MAP: dict[str, str] = {
+    "molmoact2": "molmoact2",
+    "molmoact2forconditionalgeneration": "molmoact2",
+}
+
+
+def _policy_type_from_config(config: dict[str, Any]) -> str | None:
+    """Derive a policy type string from a parsed ``config.json`` mapping.
+
+    Resolution order:
+        1. The lerobot-native ``type`` field (canonical).
+        2. The transformers-native ``model_type`` field, mapped through
+           ``_KNOWN_MODEL_TYPE_MAP`` when a known override exists, otherwise
+           used verbatim.
+        3. ``auto_map`` values (e.g. ``AutoModelForImageTextToText`` ->
+           ``modeling_molmoact2.MolmoAct2ForConditionalGeneration``): both the
+           module stem (``molmoact2``) and the class name are checked against
+           ``_KNOWN_MODEL_TYPE_MAP``.
+
+    Args:
+        config: Parsed ``config.json`` contents.
+
+    Returns:
+        The resolved policy type string, or ``None`` if none could be derived.
+    """
+    # Strategy 1: canonical lerobot ``type`` field.
+    type_field = config.get("type")
+    if type_field:
+        return str(type_field)
+
+    # Strategy 2: transformers-native ``model_type``.
+    model_type = config.get("model_type")
+    if model_type:
+        key = str(model_type).lower()
+        return _KNOWN_MODEL_TYPE_MAP.get(key, str(model_type))
+
+    # Strategy 3: ``auto_map`` class references.
+    auto_map = config.get("auto_map")
+    if isinstance(auto_map, dict):
+        for value in auto_map.values():
+            if not isinstance(value, str):
+                continue
+            # value looks like "modeling_molmoact2.MolmoAct2ForConditionalGeneration"
+            module_part, _, class_name = value.rpartition(".")
+            module_stem = module_part.split(".")[-1].removeprefix("modeling_")
+            for candidate in (module_stem.lower(), class_name.lower()):
+                if candidate in _KNOWN_MODEL_TYPE_MAP:
+                    return _KNOWN_MODEL_TYPE_MAP[candidate]
+
+    return None
+
+
 def _read_policy_type_from_config(pretrained_name_or_path: str) -> str | None:
     """Read policy type from config.json (local or HF Hub).
+
+    Tries the lerobot-native ``type`` field first, then falls back to the
+    transformers-native ``model_type`` and ``auto_map`` fields so that
+    third-party checkpoints (e.g. ``allenai/MolmoAct2-SO100_101``, which sets
+    ``model_type: "molmoact2"`` and an ``auto_map`` but leaves ``type`` unset)
+    resolve without an explicit ``policy_type=``. See ``_policy_type_from_config``.
 
     Args:
         pretrained_name_or_path: Local path or HF model ID.
@@ -418,7 +485,7 @@ def _read_policy_type_from_config(pretrained_name_or_path: str) -> str | None:
     if local_path.is_dir() and (local_path / "config.json").exists():
         with open(local_path / "config.json") as config_file:
             config = json.load(config_file)
-        return config.get("type")
+        return _policy_type_from_config(config)
 
     # Try downloading from HuggingFace Hub
     try:
@@ -427,7 +494,7 @@ def _read_policy_type_from_config(pretrained_name_or_path: str) -> str | None:
         config_path = hf_hub_download(pretrained_name_or_path, "config.json")
         with open(config_path) as config_file:
             config = json.load(config_file)
-        return config.get("type")
+        return _policy_type_from_config(config)
     except (ImportError, OSError, ValueError, KeyError) as exc:
         logger.warning("Could not download config.json: %s", exc)
 

--- a/tests/policies/lerobot_local/test_resolution.py
+++ b/tests/policies/lerobot_local/test_resolution.py
@@ -837,6 +837,86 @@ class TestReadPolicyTypeFromConfig:
 
         assert resolution._read_policy_type_from_config("nonexistent/repo-id") is None
 
+    def test_model_type_known_override_resolves(self, tmp_path):
+        """A config with no ``type`` but a known ``model_type`` (``molmoact2``)
+        resolves through ``_KNOWN_MODEL_TYPE_MAP`` rather than raising."""
+        import json
+
+        from strands_robots.policies.lerobot_local import resolution
+
+        (tmp_path / "config.json").write_text(json.dumps({"model_type": "molmoact2"}))
+
+        assert resolution._read_policy_type_from_config(str(tmp_path)) == "molmoact2"
+
+    def test_model_type_unknown_used_verbatim(self, tmp_path):
+        """An unknown ``model_type`` (no override) is returned as-is so callers
+        can still attempt class resolution by that name."""
+        import json
+
+        from strands_robots.policies.lerobot_local import resolution
+
+        (tmp_path / "config.json").write_text(json.dumps({"model_type": "act"}))
+
+        assert resolution._read_policy_type_from_config(str(tmp_path)) == "act"
+
+    def test_auto_map_class_name_resolves(self, tmp_path):
+        """When only an ``auto_map`` is present, a recognized modeling class
+        (``MolmoAct2ForConditionalGeneration``) maps to its policy type."""
+        import json
+
+        from strands_robots.policies.lerobot_local import resolution
+
+        (tmp_path / "config.json").write_text(
+            json.dumps(
+                {
+                    "auto_map": {
+                        "AutoConfig": "configuration_molmoact2.MolmoAct2Config",
+                        "AutoModelForImageTextToText": ("modeling_molmoact2.MolmoAct2ForConditionalGeneration"),
+                    }
+                }
+            )
+        )
+
+        assert resolution._read_policy_type_from_config(str(tmp_path)) == "molmoact2"
+
+    def test_type_field_wins_over_model_type(self, tmp_path):
+        """The canonical lerobot ``type`` field takes precedence over
+        ``model_type`` when both are present."""
+        import json
+
+        from strands_robots.policies.lerobot_local import resolution
+
+        (tmp_path / "config.json").write_text(json.dumps({"type": "diffusion", "model_type": "molmoact2"}))
+
+        assert resolution._read_policy_type_from_config(str(tmp_path)) == "diffusion"
+
+    def test_no_type_model_type_or_known_auto_map_returns_none(self, tmp_path):
+        """A config with none of ``type``/``model_type`` and only unrecognized
+        ``auto_map`` entries returns ``None`` (caller raises a clear error)."""
+        import json
+
+        from strands_robots.policies.lerobot_local import resolution
+
+        (tmp_path / "config.json").write_text(
+            json.dumps({"auto_map": {"AutoModel": "modeling_unknownthing.UnknownThingModel"}})
+        )
+
+        assert resolution._read_policy_type_from_config(str(tmp_path)) is None
+
+    @pytest.mark.slow
+    def test_real_molmoact2_repo_resolves_model_type(self):
+        """End-to-end against the live HF repo: ``allenai/MolmoAct2-SO100_101``
+        sets ``model_type: molmoact2`` with ``type`` unset, and must resolve.
+
+        Skipped offline (network failure surfaces as ``None`` from the reader's
+        ``OSError`` guard, which would make this a flaky false-negative)."""
+        from strands_robots.policies.lerobot_local import resolution
+
+        result = resolution._read_policy_type_from_config("allenai/MolmoAct2-SO100_101")
+        if result is None:
+            pytest.skip("HF Hub unreachable; cannot exercise live repo")
+        assert result == "molmoact2"
+
 
 class TestResolvePolicyClassByNameFallbackLadder:
     """Behavioral tests for the resolution ladder in


### PR DESCRIPTION
## Problem

`resolve_policy_class_from_hub` raises `ValueError: Could not determine policy type` for third-party checkpoints distributed in the transformers layout. The manual `config.json` fallback (`_read_policy_type_from_config`) only read the lerobot-native `type` field, so a checkpoint that leaves `type` unset and instead declares `model_type` + `auto_map` cannot be resolved without an explicit `policy_type=`.

Concrete example, `allenai/MolmoAct2-SO100_101`, whose `config.json` has:

```json
{
  "type": null,
  "model_type": "molmoact2",
  "auto_map": {
    "AutoConfig": "configuration_molmoact2.MolmoAct2Config",
    "AutoModelForImageTextToText": "modeling_molmoact2.MolmoAct2ForConditionalGeneration"
  }
}
```

Repro:

```python
from strands_robots.policies.lerobot_local.resolution import resolve_policy_class_from_hub
resolve_policy_class_from_hub("allenai/MolmoAct2-SO100_101")
# ValueError: Could not determine policy type ... No 'type' field found in config.json.
```

## Change

Add `_policy_type_from_config(config)` that derives the policy type in order:

1. Canonical lerobot `type` field.
2. transformers-native `model_type`, mapped through a new `_KNOWN_MODEL_TYPE_MAP` override table (falling back to the value verbatim so unknown types can still attempt class resolution by name).
3. `auto_map` class references, matching both the `modeling_*` module stem (`molmoact2`) and the class name (`MolmoAct2ForConditionalGeneration`) against the same table.

`_read_policy_type_from_config` now routes both its local-path and Hub-download branches through this helper. The terminal `ValueError` is updated to name the fallbacks that were tried. `type` still wins when present, so existing behavior is unchanged for standard lerobot checkpoints.

## Tests

Added behavioral unit tests in `TestReadPolicyTypeFromConfig` covering each path with dict-mocked configs:

- known `model_type` override resolves
- unknown `model_type` returned verbatim
- `auto_map` class name resolves
- `type` precedence over `model_type`
- none-present returns `None` (caller raises a clear error)
- a `@pytest.mark.slow` end-to-end test against the live HF repo (skips offline)

The three core tests fail on pre-fix code (`None != "molmoact2"`) and pass after. Full `tests/policies/lerobot_local/test_resolution.py` suite: 27 passed. Lint/format clean; mypy clean on changed files.