### PR TITLE
feat(packaging): add [molmoact2] optional-dependency extra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Added: `[molmoact2]` optional-dependency extra
+
+MolmoAct2 transformers-native VLA checkpoints (e.g. `allenai/MolmoAct2-SO100_101`)
+run through `MolmoAct2Policy`, which shipped in lerobot AFTER the 0.5.1 PyPI
+release (merged in lerobot PR #3604). A plain `pip install strands-robots[lerobot]`
+resolves lerobot 0.5.1, which lacks it.
+
+- New `[molmoact2]` extra layers MolmoAct2's auxiliary deps (`transformers`,
+  `peft`, `scipy`) on top of `[lerobot]`, mirroring lerobot's own `[molmoact2]`
+  extra. PyPI rejects direct git URLs in a published dependency table, so the
+  lerobot-from-source pin stays in the documented install command (same pattern
+  as `[cosmos3-diffusers]`):
+  `uv pip install strands-robots[molmoact2] "lerobot[feetech] @ git+https://github.com/huggingface/lerobot.git"`.
+  Added to `[all]`.
+- The fail-loud `ImportError` raised by the MolmoAct2 load path now names the
+  `strands-robots[molmoact2]` extra and lerobot PR #3604, so a missing lerobot
+  surfaces an actionable install hint instead of a bare import failure.
+- New `molmoact2` pytest marker; README + `docs/policies/lerobot-local.md` +
+  `docs/getting-started/installation.md` document the extra. Once a tagged
+  lerobot >= 0.5.2 is on PyPI the extra can pin `lerobot[feetech]>=0.5.2`
+  directly and the git-source step drops away.
+
+
 ### Added: `WBCPolicy` provider (`wbc`, shorthand `sonic`) - GR00T Whole-Body-Control (SONIC)
 
 A new non-VLA policy provider wrapping NVIDIA's GR00T Whole-Body-Control

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ extras you need:
 |-------|----------|---------|
 | `sim-mujoco` | MuJoCo, robot_descriptions, imageio | Simulation (recommended starting point) |
 | `lerobot` | LeRobot | Real hardware, local VLA inference, dataset recording |
+| `molmoact2` | LeRobot + transformers, peft, scipy | MolmoAct2 transformers-native VLA (needs lerobot from source until PyPI >= 0.5.2) |
 | `groot-service` | pyzmq, msgpack | NVIDIA GR00T inference client |
 | `curobo` | _(empty; install cuRobo from source)_ | In-process collision-aware motion planning (CUDA GPU) |
 | `wbc` | onnxruntime | GR00T Whole-Body-Control (SONIC) humanoid locomotion - in-process ONNX, no GPU |
@@ -123,6 +124,10 @@ uv pip install "strands-robots[sim-mujoco]"
 
 # Real hardware + local policies:
 uv pip install "strands-robots[sim-mujoco,lerobot]"
+
+# MolmoAct2 VLA (lerobot from source until a PyPI >= 0.5.2 ships PR #3604):
+uv pip install "strands-robots[molmoact2]" \
+    "lerobot[feetech] @ git+https://github.com/huggingface/lerobot.git"
 
 # Everything:
 uv pip install "strands-robots[all]"

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -66,8 +66,10 @@ MolmoAct2 checkpoints (e.g. `allenai/MolmoAct2-SO100_101`) require lerobot
 instructions. Quick path:
 
 ```bash
-# Install lerobot from source (skips pyav if it fails on aarch64):
-uv pip install "lerobot[feetech] @ git+https://github.com/huggingface/lerobot.git" --no-build-isolation
+# Install the [molmoact2] extra (transformers, peft, scipy on top of lerobot)
+# plus lerobot from source (skips pyav if it fails on aarch64):
+uv pip install "strands-robots[molmoact2]" \
+    "lerobot[feetech] @ git+https://github.com/huggingface/lerobot.git" --no-build-isolation
 uv pip install torchcodec>=0.7   # video decode backend for aarch64
 ```
 

--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -57,17 +57,23 @@ LerobotLocalPolicy(
 
 > **Important:** MolmoAct2 requires lerobot installed **from source** (git main).
 > The `MolmoAct2Policy` class was added after lerobot 0.5.1 (the latest PyPI
-> release as of June 2025). A plain `pip install strands-robots[lerobot]` resolves
-> lerobot 0.5.1, which does NOT include MolmoAct2.
+> release as of June 2025; merged in lerobot PR #3604). A plain
+> `pip install strands-robots[lerobot]` resolves lerobot 0.5.1, which does NOT
+> include MolmoAct2.
 
-Install lerobot from source before using MolmoAct2:
+The `[molmoact2]` extra layers the auxiliary deps MolmoAct2's modeling and
+processor code needs on top of lerobot core (`transformers`, `peft`, `scipy`),
+but PyPI rejects direct git URLs in a published package, so you still install
+lerobot itself from source in the same command:
 
 ```bash
 # Standard (x86_64, macOS):
-uv pip install "lerobot[feetech] @ git+https://github.com/huggingface/lerobot.git"
+uv pip install "strands-robots[molmoact2]" \
+    "lerobot[feetech] @ git+https://github.com/huggingface/lerobot.git"
 
 # Jetson / aarch64 (pyav wheel may fail to build - skip it, lerobot uses torchcodec):
-uv pip install "lerobot[feetech] @ git+https://github.com/huggingface/lerobot.git" --no-build-isolation
+uv pip install "strands-robots[molmoact2]" \
+    "lerobot[feetech] @ git+https://github.com/huggingface/lerobot.git" --no-build-isolation
 # If pyav still blocks the install, exclude it and add torchcodec manually:
 uv pip install torchcodec>=0.7
 uv pip install "lerobot[feetech] @ git+https://github.com/huggingface/lerobot.git" --no-deps
@@ -89,8 +95,9 @@ policy = create_policy(
 ```
 
 This requirement will go away once HuggingFace publishes lerobot >= 0.5.2 to PyPI
-(which will include MolmoAct2 natively). At that point the standard
-`pip install strands-robots[lerobot]` path will work.
+(which will include MolmoAct2 natively). At that point the `[molmoact2]` extra can
+pin `lerobot[feetech]>=0.5.2` directly and the git-source step drops away --
+`pip install strands-robots[molmoact2]` alone will suffice.
 
 ## RTC
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,6 +157,26 @@ lerobot = [
     # README Installation section for the Thor/Jetson caveat.
     "torchcodec>=0.7; platform_machine == 'aarch64' and sys_platform == 'linux'",
 ]
+# MolmoAct2 transformers-native VLA (e.g. allenai/MolmoAct2-SO100_101). The
+# MolmoAct2Policy class shipped in lerobot AFTER the 0.5.1 PyPI release (merged
+# in lerobot PR #3604), so a plain `pip install strands-robots[lerobot]`
+# resolves lerobot 0.5.1, which lacks it. Until a lerobot release that contains
+# the PR lands on PyPI, install lerobot FROM SOURCE alongside this extra:
+#   uv pip install strands-robots[molmoact2] \
+#       'lerobot[feetech] @ git+https://github.com/huggingface/lerobot.git'
+# PyPI rejects direct git URLs in a published package's dependency table, so the
+# git pin lives in the install command (same pattern as cosmos3-diffusers), not
+# here. This extra layers the auxiliary deps MolmoAct2's modeling/processor code
+# needs on top of lerobot core -- transformers (Qwen2Tokenizer + the sharded
+# safetensors loader), peft, scipy -- mirroring lerobot's own [molmoact2] extra.
+# Once a tagged lerobot >= 0.5.2 is on PyPI, the first entry can pin
+# `lerobot[feetech]>=0.5.2` directly and the git-source step drops away.
+molmoact2 = [
+    "strands-robots[lerobot]",
+    "transformers>=4.46",
+    "peft>=0.18.0,<1.0.0",
+    "scipy>=1.14.0,<2.0.0",
+]
 sim = [
     "robot_descriptions>=1.11.0,<2.0.0",
 ]
@@ -202,6 +222,7 @@ all = [
     "strands-robots[mesh-iot]",
     "strands-robots[device-connect]",
     "strands-robots[wbc]",
+    "strands-robots[molmoact2]",
 ]
 dev = [
     "pytest>=6.0,<9.0.0",
@@ -426,4 +447,5 @@ markers = [
     "moveit2: requires a running MoveIt2 sidecar (ROS 2 / moveit_py). Run with: pytest -m moveit2",
     "curobo: requires NVIDIA cuRobo + a CUDA-capable GPU. Run with: pytest -m curobo (set CUROBO_LIVE=1)",
     "wbc: requires onnxruntime + a downloaded GR00T-WBC (SONIC) checkpoint + mujoco. Run with: pytest -m wbc (set WBC_LIVE=1)",
+    "molmoact2: requires lerobot >= 0.5.2 (from source) + the [molmoact2] extra (transformers, peft, scipy). Run with: pytest -m molmoact2",
 ]

--- a/strands_robots/policies/lerobot_local/molmoact2.py
+++ b/strands_robots/policies/lerobot_local/molmoact2.py
@@ -231,9 +231,11 @@ def build_policy(
         from lerobot.configs import FeatureType, PolicyFeature
     except ImportError as exc:
         raise ImportError(
-            "MolmoAct2 requires lerobot >= 0.5.2 (from source). The PyPI release "
-            "(0.5.1) does not include MolmoAct2Policy. Install from source:\n"
-            "  uv pip install 'lerobot[feetech] @ git+https://github.com/huggingface/lerobot.git'\n"
+            "MolmoAct2 requires lerobot >= 0.5.2 (PR #3604), which is not yet on "
+            "PyPI (latest release 0.5.1 lacks MolmoAct2Policy). Install the extra "
+            "plus lerobot from source:\n"
+            "  uv pip install 'strands-robots[molmoact2]' "
+            "'lerobot[feetech] @ git+https://github.com/huggingface/lerobot.git'\n"
             "On Jetson/aarch64, add --no-build-isolation if pyav fails to build."
         ) from exc
 
@@ -258,9 +260,11 @@ def build_policy(
         )
     except ImportError as exc:
         raise ImportError(
-            "MolmoAct2 requires lerobot >= 0.5.2 (from source). The PyPI release "
-            "(0.5.1) does not include MolmoAct2Policy. Install from source:\n"
-            "  uv pip install 'lerobot[feetech] @ git+https://github.com/huggingface/lerobot.git'\n"
+            "MolmoAct2 requires lerobot >= 0.5.2 (PR #3604), which is not yet on "
+            "PyPI (latest release 0.5.1 lacks MolmoAct2Policy). Install the extra "
+            "plus lerobot from source:\n"
+            "  uv pip install 'strands-robots[molmoact2]' "
+            "'lerobot[feetech] @ git+https://github.com/huggingface/lerobot.git'\n"
             "On Jetson/aarch64, add --no-build-isolation if pyav fails to build."
         ) from exc
 

--- a/tests/policies/lerobot_local/test_molmoact2.py
+++ b/tests/policies/lerobot_local/test_molmoact2.py
@@ -355,7 +355,7 @@ class TestBuildPolicy:
             return real_import(name, *args, **kwargs)
 
         monkeypatch.setattr(builtins, "__import__", blocked_import)
-        with pytest.raises(ImportError, match="MolmoAct2 requires lerobot"):
+        with pytest.raises(ImportError, match="MolmoAct2 requires lerobot") as excinfo:
             molmoact2.build_policy(
                 "repo",
                 device="cpu",
@@ -364,6 +364,11 @@ class TestBuildPolicy:
                 image_keys=["observation.images.cam"],
                 embodiment_spec=None,
             )
+        # The hint must name the install extra and the upstream lerobot PR so an
+        # operator can act on it without spelunking (issue #52 fail-loud branch).
+        msg = str(excinfo.value)
+        assert "strands-robots[molmoact2]" in msg
+        assert "PR #3604" in msg
 
     def test_missing_lerobot_configs_raises_install_hint(self, monkeypatch):
         """If lerobot.configs is absent, the first import guard raises the hint."""
@@ -378,7 +383,7 @@ class TestBuildPolicy:
             return real_import(name, *args, **kwargs)
 
         monkeypatch.setattr(builtins, "__import__", blocked_import)
-        with pytest.raises(ImportError, match="MolmoAct2 requires lerobot"):
+        with pytest.raises(ImportError, match="MolmoAct2 requires lerobot") as excinfo:
             molmoact2.build_policy(
                 "repo",
                 device="cpu",
@@ -387,3 +392,6 @@ class TestBuildPolicy:
                 image_keys=["observation.images.cam"],
                 embodiment_spec=None,
             )
+        msg = str(excinfo.value)
+        assert "strands-robots[molmoact2]" in msg
+        assert "PR #3604" in msg

--- a/tests/test_customer_workflow_regressions.py
+++ b/tests/test_customer_workflow_regressions.py
@@ -63,6 +63,44 @@ class TestLerobotExtraIncludesFeetech:
         assert "lerobot[feetech]" in joined, f"[lerobot] extra must request lerobot[feetech]; got {lerobot_extra!r}"
 
 
+class TestMolmoact2Extra:
+    """The ``[molmoact2]`` extra must layer MolmoAct2's auxiliary deps on lerobot.
+
+    MolmoAct2Policy shipped in lerobot AFTER the 0.5.1 PyPI release (lerobot
+    PR #3604), so a plain ``[lerobot]`` install cannot run it. The ``[molmoact2]``
+    extra exists to pull the transformers/peft/scipy stack MolmoAct2's modeling
+    and processor code imports, on top of lerobot core. PyPI rejects direct git
+    URLs in a published dependency table, so the lerobot-from-source pin lives in
+    the documented install command, not the extra (issue #52).
+    """
+
+    def _extras(self) -> dict:
+        with open(_REPO_ROOT / "pyproject.toml", "rb") as f:
+            data = tomllib.load(f)
+        return data["project"]["optional-dependencies"]
+
+    def test_molmoact2_extra_exists_and_layers_lerobot(self):
+        extras = self._extras()
+        assert "molmoact2" in extras, "pyproject must declare a [molmoact2] extra"
+        joined = " ".join(extras["molmoact2"])
+        # Builds on the [lerobot] extra (which carries lerobot[feetech]).
+        assert "strands-robots[lerobot]" in joined
+        # The auxiliary deps MolmoAct2 modeling/processor code imports.
+        assert "transformers" in joined
+        assert "peft" in joined
+        assert "scipy" in joined
+
+    def test_molmoact2_extra_has_no_git_url(self):
+        # PyPI rejects direct-reference (git+) deps in a published package's
+        # dependency table; the git-source pin must stay in docs/error hints.
+        joined = " ".join(self._extras()["molmoact2"])
+        assert "git+" not in joined and "@ git" not in joined
+
+    def test_molmoact2_in_all_extra(self):
+        extras = self._extras()
+        assert "strands-robots[molmoact2]" in extras["all"]
+
+
 class TestSimulationIsCallable:
     """The Simulation returned by ``Robot()`` must be callable and dispatch actions."""
 


### PR DESCRIPTION
## Problem

MolmoAct2 transformers-native VLA checkpoints (e.g. `allenai/MolmoAct2-SO100_101`) run through `MolmoAct2Policy`, which shipped in lerobot **after** the 0.5.1 PyPI release (merged in lerobot PR #3604). A plain `pip install strands-robots[lerobot]` resolves lerobot 0.5.1, which lacks it, so MolmoAct2 has no first-class install path and users hit a bare `ImportError` deep in the load path with no actionable hint.

## Change

Adds a `[molmoact2]` optional-dependency extra and makes the existing fail-loud path point at it.

- **New `[molmoact2]` extra** layering MolmoAct2's auxiliary deps (`transformers`, `peft`, `scipy`) on top of `[lerobot]`, mirroring lerobot's own `[molmoact2]` extra (`transformers-dep` + `peft-dep` + `scipy-dep`). PyPI rejects direct `git+` URLs in a published package's dependency table, so the lerobot-from-source pin stays in the documented install command rather than the extra (same precedent as `[cosmos3-diffusers]`):
  ```bash
  uv pip install "strands-robots[molmoact2]" \
      "lerobot[feetech] @ git+https://github.com/huggingface/lerobot.git"
  ```
  Also added to `[all]`.
- **Actionable fail-loud error**: the `ImportError` raised by the MolmoAct2 load path when lerobot is too old now names the `strands-robots[molmoact2]` extra and lerobot PR #3604, instead of a generic from-source hint.
- **`molmoact2` pytest marker** registered; README extras table + install examples, `docs/policies/lerobot-local.md`, and `docs/getting-started/installation.md` updated to document the extra.
- Once a tagged `lerobot >= 0.5.2` lands on PyPI, the extra's first entry can pin `lerobot[feetech]>=0.5.2` directly and the git-source step drops away.

## Tests

Regression tests in `tests/test_customer_workflow_regressions.py::TestMolmoact2Extra` (fail on pre-change `pyproject.toml`, pass after):
- the `[molmoact2]` extra exists, builds on `[lerobot]`, and carries `transformers`/`peft`/`scipy`;
- it contains no `git+`/direct-reference URL (PyPI-publishable);
- it is included in `[all]`.

The existing fail-loud branch tests in `tests/policies/lerobot_local/test_molmoact2.py` now also assert the raised message names `strands-robots[molmoact2]` and `PR #3604`.

Full `pytest` on the affected trees is green: `tests/policies/lerobot_local/`, `tests/test_customer_workflow_regressions.py`, `tests/registry/` (633 passed, 3 skipped); `ruff check`/`ruff format --check` clean; `mypy` clean on all touched files.