### PR TITLE
fix(lerobot_local): auto-adopt config.n_action_steps; stop truncating action chunks in PolicyRunner

### DIFF
--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -26,7 +26,7 @@ LerobotLocalPolicy(
     pretrained_name_or_path="",          # HF model_id or local checkpoint dir (required)
     policy_type=None,                    # override auto-detected class
     device=None,                         # "cuda" | "cpu" | "mps"
-    actions_per_step=1,
+    actions_per_step=1,                   # auto-set from config.n_action_steps if left at 1
     use_processor=True,                  # observation/action processor bridge
     processor_overrides=None,
     tokenizer_max_length=48,
@@ -84,8 +84,33 @@ policy = create_policy(
     norm_tag="so101",
     image_keys=["wrist_camera", "front_camera"],
     inference_action_mode="continuous",
+    # actions_per_step is auto-set from config.n_action_steps (30 for the
+    # SO-100/101 checkpoints) when left at the default 1 - so the full
+    # 30-step chunk the model was trained to replay open-loop is consumed
+    # before re-querying vision. Pass an explicit value to override.
 )
 # see examples/molmoact2_so101_pickplace.py
+```
+
+MolmoAct2 SO-100/101 was trained for **30-step open-loop chunk replay**
+(`n_action_steps = 30`). Run it through the sim with an `action_horizon` that
+does not truncate the chunk - the runner clamps the effective horizon up to the
+policy's `actions_per_step`, so passing `action_horizon=8` (or the default) is
+safe, but you can also pin it explicitly:
+
+```python
+sim.run_policy(
+    robot_name="so101_follower",
+    policy_provider="lerobot_local",
+    policy_config={
+        "pretrained_name_or_path": "your-org/molmoact2-so101",
+        "norm_tag": "so101",
+        "inference_action_mode": "continuous",
+        "actions_per_step": 30,   # explicit; matches the trained chunk size
+    },
+    instruction="pick up the cube",
+    action_horizon=30,            # do not truncate the 30-step chunk
+)
 ```
 
 This requirement will go away once HuggingFace publishes lerobot >= 0.5.2 to PyPI

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -45,7 +45,11 @@ class LerobotLocalPolicy(Policy):
         policy_type: Explicit LeRobot policy type (e.g. "act", "diffusion").
             Auto-detected from config.json if not provided.
         device: Target device (e.g. "cuda", "cpu"). Auto-detected if None.
-        actions_per_step: Number of action steps to return per inference call.
+        actions_per_step: Number of action steps to return per inference
+            call. Defaults to 1 (closed-loop). When left at the default,
+            it is auto-set from the loaded model's ``config.n_action_steps``
+            (the model's trained open-loop chunk size) if that exceeds 1;
+            pass an explicit value > 1 to override the auto-detection.
         use_processor: Whether to load the model's processor pipeline.
         processor_overrides: Dict of overrides for processor pipeline steps.
         tokenizer_max_length: Max token length for VLA language tokenization.
@@ -409,6 +413,7 @@ class LerobotLocalPolicy(Policy):
             self._device,
         )
         self._loaded = True
+        self._auto_detect_actions_per_step()
 
         # Auto-detect robot_state_keys from model config if not set
         if not self.robot_state_keys and self._output_features:
@@ -473,6 +478,38 @@ class LerobotLocalPolicy(Policy):
         # Initialize RTC if supported by this policy
         self._init_rtc()
 
+    def _auto_detect_actions_per_step(self) -> None:
+        """Adopt the model's intended open-loop chunk size when left at default.
+
+        Many LeRobot policies declare ``config.n_action_steps`` - the number of
+        actions the model emits per inference call that it was trained to replay
+        open-loop before requerying observation (e.g. MolmoAct2 SO-100/101 = 30,
+        ACT = 100, Diffusion = 32). The default ``actions_per_step=1`` is a
+        closed-loop receding-horizon convention: it returns one action per call
+        and re-queries vision every step. For a model trained on N-step chunk
+        replay, that puts inference out of the training distribution - the policy
+        sees state where its training had it after 1 step, not N - and the
+        distribution shift compounds every chunk.
+
+        When ``actions_per_step`` is still at the default ``1`` and the loaded
+        model exposes ``config.n_action_steps > 1``, adopt that value so the
+        chunk is consumed as trained. An explicit ``actions_per_step > 1`` from
+        the caller is always respected. Logged at INFO so the change is visible.
+        """
+        if self.actions_per_step != 1:
+            return  # caller pinned an explicit horizon - never override it
+        config = getattr(self._policy, "config", None)
+        n_action_steps = getattr(config, "n_action_steps", None)
+        if isinstance(n_action_steps, int) and n_action_steps > 1:
+            self.actions_per_step = n_action_steps
+            logger.info(
+                "lerobot_local: auto-set actions_per_step=%d from "
+                "%s.config.n_action_steps (model's trained open-loop chunk "
+                "size). Pass actions_per_step explicitly to override.",
+                n_action_steps,
+                type(self._policy).__name__,
+            )
+
     def _load_molmoact2_model(self) -> None:
         """Load a transformers-native MolmoAct2 checkpoint via the lerobot wrapper.
 
@@ -524,6 +561,7 @@ class LerobotLocalPolicy(Policy):
             self._device,
         )
         self._loaded = True
+        self._auto_detect_actions_per_step()
 
         # Auto-detect generic state keys from action dim if not set.
         if not self.robot_state_keys and self._output_features:

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -302,7 +302,11 @@ class PolicyRunner:
                 via ``control_frequency``).
             control_frequency: Target Hz for ``policy.get_actions`` calls.
             action_horizon: Max actions consumed per policy call before
-                requerying observation.
+                requerying observation. Clamped up to the policy's own
+                ``actions_per_step`` so a model trained for N-step
+                open-loop chunk replay never has its chunk truncated
+                below N (the effective horizon is
+                ``max(action_horizon, policy.actions_per_step)``).
             fast_mode: If True, skip real-time ``time.sleep`` between steps.
             video: Optional :class:`VideoConfig` - set ``video.path`` to enable
                 MP4 recording via :meth:`SimEngine.render`.
@@ -440,7 +444,15 @@ class PolicyRunner:
                 coro_or_result = policy.get_actions(observation, instruction, **_policy_kwargs)
                 actions = _resolve_coroutine(coro_or_result)
 
-                for action_dict in actions[:action_horizon]:
+                # Never truncate below the policy's own intended chunk size.
+                # A model trained for N-step open-loop replay
+                # (policy.actions_per_step == N) must have its full chunk
+                # consumed; clamping to a smaller action_horizon drops the
+                # tail of every chunk and forces an out-of-distribution
+                # re-query (see LerobotLocalPolicy auto-detect of
+                # config.n_action_steps).
+                _chunk = max(action_horizon, getattr(policy, "actions_per_step", 1))
+                for action_dict in actions[:_chunk]:
                     if step_count >= total_steps:
                         break
 
@@ -1005,7 +1017,8 @@ class PolicyRunner:
                     # Degenerate policy - advance physics so loop terminates.
                     self.sim.step(n_steps=1)
                 else:
-                    for action_in_chunk in actions[:action_horizon]:
+                    _chunk = max(action_horizon, getattr(policy, "actions_per_step", 1))
+                    for action_in_chunk in actions[:_chunk]:
                         if steps >= max_steps:
                             break
                         action_applied = dict(action_in_chunk)

--- a/tests/policies/lerobot_local/test_policy.py
+++ b/tests/policies/lerobot_local/test_policy.py
@@ -98,6 +98,59 @@ class TestLerobotLocalInit:
         assert policy.actions_per_step == 5
 
 
+class TestAutoDetectActionsPerStep:
+    """`_auto_detect_actions_per_step` adopts the model's trained chunk size.
+
+    Regression for the MolmoAct2 chunk-truncation bug: the SO-100/101
+    checkpoints are trained for 30-step open-loop chunk replay
+    (config.n_action_steps == 30), but the default actions_per_step=1 dropped
+    29 of every 30 actions and re-queried vision out-of-distribution.
+    """
+
+    def _policy_with_config(self, n_action_steps):
+        policy = _make_policy()
+        mock_lerobot_policy = MagicMock()
+        mock_lerobot_policy.config = types.SimpleNamespace(n_action_steps=n_action_steps)
+        policy._policy = mock_lerobot_policy
+        return policy
+
+    def test_adopts_config_n_action_steps_when_default(self):
+        """Default actions_per_step=1 + config.n_action_steps=30 -> 30."""
+        policy = self._policy_with_config(30)
+        assert policy.actions_per_step == 1  # default before detection
+        policy._auto_detect_actions_per_step()
+        assert policy.actions_per_step == 30
+
+    def test_does_not_override_explicit_actions_per_step(self):
+        """An explicit actions_per_step > 1 is never overridden."""
+        policy = _make_policy(actions_per_step=4)
+        policy._policy = MagicMock()
+        policy._policy.config = types.SimpleNamespace(n_action_steps=30)
+        policy._auto_detect_actions_per_step()
+        assert policy.actions_per_step == 4
+
+    def test_no_change_when_config_missing_n_action_steps(self):
+        """A model without config.n_action_steps keeps the default 1."""
+        policy = _make_policy()
+        policy._policy = MagicMock()
+        policy._policy.config = types.SimpleNamespace()  # no n_action_steps
+        policy._auto_detect_actions_per_step()
+        assert policy.actions_per_step == 1
+
+    def test_no_change_when_n_action_steps_is_one(self):
+        """n_action_steps == 1 (closed-loop) leaves actions_per_step at 1."""
+        policy = self._policy_with_config(1)
+        policy._auto_detect_actions_per_step()
+        assert policy.actions_per_step == 1
+
+    def test_no_policy_loaded_is_safe(self):
+        """Calling with no loaded policy does not raise and keeps default."""
+        policy = _make_policy()
+        policy._policy = None
+        policy._auto_detect_actions_per_step()
+        assert policy.actions_per_step == 1
+
+
 # (section)
 # Tests: set_robot_state_keys
 # (section)
@@ -1088,6 +1141,7 @@ class TestLoadModelDeviceMove:
         policy._output_features = {}
         policy._input_features = {}
         policy.processor_overrides = {}
+        policy.actions_per_step = 1
 
         mock_policy = _load_model_with_mocks(policy, param_device="meta", bridge_active=False)
 
@@ -1105,6 +1159,7 @@ class TestLoadModelDeviceMove:
         policy._output_features = {}
         policy._input_features = {}
         policy.processor_overrides = {}
+        policy.actions_per_step = 1
 
         mock_policy = _load_model_with_mocks(policy, param_device="cpu", bridge_active=False)
 
@@ -1126,6 +1181,7 @@ class TestLoadModelPostprocessorWarning:
         policy._output_features = {}
         policy._input_features = {}
         policy.processor_overrides = {}
+        policy.actions_per_step = 1
         return policy
 
     def test_warns_without_postprocessor(self, caplog):

--- a/tests/simulation/test_policy_runner.py
+++ b/tests/simulation/test_policy_runner.py
@@ -649,3 +649,59 @@ def test_runner_falls_back_to_one_substep_when_dt_unknown():
 
     PolicyRunner(sim).run("fake_robot", policy, duration=0.2, control_frequency=15.0, fast_mode=True)
     assert all(s == 1 for s in sim.substeps_seen), sim.substeps_seen
+
+
+class TestChunkNotTruncatedBelowActionsPerStep:
+    """The runner must not drop a policy's intended open-loop action chunk.
+
+    Regression for the MolmoAct2 chunk-truncation bug: a policy trained for
+    30-step open-loop chunk replay sets ``actions_per_step = 30`` and returns
+    30 actions per ``get_actions`` call. With the default ``action_horizon=8``
+    the runner used to consume only ``actions[:8]`` and re-query vision -
+    dropping 22 of every 30 actions and forcing an out-of-distribution
+    re-query. The effective horizon must be
+    ``max(action_horizon, policy.actions_per_step)``.
+    """
+
+    class _ChunkPolicy(MockPolicy):
+        """Returns ``chunk_size`` identical actions per call; records call count."""
+
+        def __init__(self, joint_names, chunk_size):
+            super().__init__()
+            self.set_robot_state_keys(list(joint_names))
+            self.actions_per_step = chunk_size
+            self._chunk_size = chunk_size
+            self.get_actions_calls = 0
+            self._joint_names = list(joint_names)
+
+        def get_actions_sync(self, observation_dict, instruction, **kwargs):
+            self.get_actions_calls += 1
+            return [{n: 0.0 for n in self._joint_names} for _ in range(self._chunk_size)]
+
+        async def get_actions(self, observation_dict, instruction, **kwargs):
+            return self.get_actions_sync(observation_dict, instruction, **kwargs)
+
+    def test_full_30_step_chunk_consumed_before_requery(self):
+        """30 actions returned, action_horizon=8 -> all 30 sent in one query."""
+        sim = FakeSim()
+        policy = self._ChunkPolicy(sim.robot_joint_names("fake_robot"), chunk_size=30)
+
+        # 30 control steps total: with truncation to 8 this would need 4
+        # get_actions calls; clamped to actions_per_step=30 it needs exactly 1.
+        result = PolicyRunner(sim).run(
+            "fake_robot",
+            policy,
+            duration=0.6,
+            control_frequency=50.0,  # -> 30 total steps
+            action_horizon=8,
+            fast_mode=True,
+        )
+
+        assert result["status"] == "success"
+        send_actions = [c for c in sim.calls if c[0] == "send_action"]
+        assert len(send_actions) == 30, f"expected 30 actions applied, got {len(send_actions)}"
+        assert policy.get_actions_calls == 1, (
+            f"chunk was truncated below actions_per_step: get_actions called "
+            f"{policy.get_actions_calls}x (expected 1 - the whole 30-step chunk "
+            "should be consumed before re-querying)"
+        )


### PR DESCRIPTION
## Problem

`LerobotLocalPolicy` defaults `actions_per_step=1` (closed-loop receding horizon) and `PolicyRunner.run` / `evaluate` default `action_horizon=8`. But many LeRobot policies declare `config.n_action_steps` - the open-loop chunk size they were *trained* to replay before re-querying observation:

| policy | `config.n_action_steps` |
|---|---|
| MolmoAct2 (SO-100/101) | 30 |
| ACT | 100 (1 when temporal-ensembling) |
| Diffusion | 32 |

With the defaults, a model that emits a 30-step chunk had 22-29 of every 30 actions **dropped**, and vision was re-queried where the training distribution had the policy after only 1-8 steps. The state is out-of-distribution and the shift compounds every chunk - a leading cause of a policy that looks like it is barely tracking or drifting.

## Change

1. **`LerobotLocalPolicy._auto_detect_actions_per_step()`** - when `actions_per_step` is still the default `1` and the loaded model exposes `config.n_action_steps > 1`, adopt that value and log at INFO. An explicit caller value (`actions_per_step > 1`) is always respected. Called from both the generic `_load_model` and the MolmoAct2 load path.
2. **`PolicyRunner.run` and `_evaluate_with_spec`** - consume `actions[:max(action_horizon, getattr(policy, 'actions_per_step', 1))]` so the runner never truncates below the policy's own intended chunk size. `action_horizon` still raises the floor for policies that emit a single action per call.
3. **Docs** - document the auto-detection on `actions_per_step` and add a non-truncating MolmoAct2 sim example (`action_horizon=30`).

## Tests (fail pre-fix, pass post-fix)

- `tests/policies/lerobot_local/test_policy.py::TestAutoDetectActionsPerStep` - default adopt (1 -> 30), explicit value respected, missing `config.n_action_steps` is a no-op, `n_action_steps == 1` stays closed-loop, no-policy-loaded is safe.
- `tests/simulation/test_policy_runner.py::TestChunkNotTruncatedBelowActionsPerStep` - a policy returning a 30-action chunk with `actions_per_step=30` has all 30 applied in a **single** `get_actions` call under the default `action_horizon=8` (pre-fix: 4 calls, chunk truncated to 8).

Verified on pre-fix code: the runner test asserts 1 call but observed 4, and the policy tests fail with `AttributeError` (no `_auto_detect_actions_per_step`). Full local gate green (`ruff check`, `ruff format --check`, `mypy`, `pytest tests/policies tests/simulation`).

## Rollout (MuJoCo sim, headless EGL)

SO-100 arm replaying a 30-step open-loop chunk under the default `action_horizon=8`. 60 control steps @ 50 Hz are consumed in **2** `get_actions` calls (full 30-step chunks), not 8 truncated re-queries.

![chunk replay](https://github.com/cagataycali/robots/releases/download/chunk-replay-demo-54/chunk_replay.gif)

<video src="https://github.com/cagataycali/robots/releases/download/chunk-replay-demo-54/chunk_replay.mp4" controls></video>
