### PR TITLE
fix(lerobot_local): route MolmoAct2 through predict_action_chunk

### DIFF
--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -844,11 +844,17 @@ class LerobotLocalPolicy(Policy):
                 # with prev_chunk for temporal blending. Used only for flow-matching
                 # policies that support rtc_config.
                 action_tensor = self._predict_with_rtc(batch)
-            elif self.actions_per_step > 1:
+            elif self.actions_per_step > 1 or self._requires_action_chunk():
                 # Multi-step path: call predict_action_chunk() directly to get the
                 # full action horizon, then slice in _tensor_to_action_dicts().
                 # select_action() uses an internal queue and returns only 1 action
                 # at a time, so it can't return multiple steps per call.
+                #
+                # Some policies (e.g. MolmoAct2) must ALWAYS take this path even at
+                # actions_per_step=1: their select_action() raises AssertionError
+                # when the checkpoint's rtc_config is enabled, and otherwise still
+                # serves only a single action per call. _requires_action_chunk()
+                # detects them so they never hit the crashing select_action() below.
                 action_tensor = self._policy.predict_action_chunk(batch, **self.inference_kwargs)
             else:
                 # Default single-step path: delegates to LeRobot's select_action()
@@ -1265,6 +1271,34 @@ class LerobotLocalPolicy(Policy):
         return batch
 
     # Action conversion
+
+    def _requires_action_chunk(self) -> bool:
+        """Whether the loaded policy must be driven via ``predict_action_chunk``.
+
+        Some LeRobot policies cannot serve single actions through
+        ``select_action``. MolmoAct2 is the canonical case: its
+        ``select_action`` raises ``AssertionError`` whenever the checkpoint's
+        ``rtc_config`` is enabled (it only supports RTC via
+        ``predict_action_chunk``), and even with RTC off it returns just one
+        action per call. Routing such policies through ``predict_action_chunk``
+        avoids the crash and lets ``actions_per_step`` slice the full chunk.
+
+        Detection is by policy name -- LeRobot sets
+        ``PreTrainedPolicy.name = "molmoact2"`` -- with a class-name fallback for
+        stubbed/mocked policies that do not set ``name``.
+
+        Returns:
+            True if the policy must use ``predict_action_chunk`` instead of
+            ``select_action``; False otherwise (including when no policy is
+            loaded).
+        """
+        policy = self._policy
+        if policy is None:
+            return False
+        name = getattr(policy, "name", None)
+        if isinstance(name, str) and name.lower() == "molmoact2":
+            return True
+        return type(policy).__name__ == "MolmoAct2Policy"
 
     def _tensor_to_action_dicts(self, action_tensor: torch.Tensor) -> list[dict[str, Any]]:
         """Convert action tensor to list of robot action dicts.

--- a/tests/policies/lerobot_local/test_policy.py
+++ b/tests/policies/lerobot_local/test_policy.py
@@ -457,6 +457,71 @@ class TestGetActions:
         policy._policy.select_action.assert_called_once()
         assert len(actions) == 1
 
+    def test_molmoact2_bypasses_select_action_at_single_step(self):
+        """MolmoAct2 must use predict_action_chunk even at actions_per_step=1.
+
+        Its select_action() raises AssertionError when the checkpoint's
+        rtc_config is enabled, so routing single-step inference through it would
+        crash. Detection is by the LeRobot policy ``name`` attribute.
+        """
+        policy = _make_loaded_policy(action_dim=3, include_images=False)
+        policy.set_robot_state_keys(["a", "b", "c"])
+        policy.actions_per_step = 1
+        # LeRobot sets PreTrainedPolicy.name = "molmoact2".
+        policy._policy.name = "molmoact2"
+        # If select_action were called it would crash, mirroring the real policy.
+        policy._policy.select_action.side_effect = AssertionError(
+            "RTC is not supported for select_action, use it with predict_action_chunk"
+        )
+        policy._policy.predict_action_chunk.return_value = torch.zeros(1, 8, 3)
+
+        actions = policy.get_actions_sync({}, "test")
+
+        policy._policy.predict_action_chunk.assert_called_once()
+        policy._policy.select_action.assert_not_called()
+        assert len(actions) == 1
+
+    def test_molmoact2_detected_by_class_name_fallback(self):
+        """A stub without a ``name`` attr is detected by its class name."""
+        policy = _make_loaded_policy(action_dim=3, include_images=False)
+        policy.set_robot_state_keys(["a", "b", "c"])
+        policy.actions_per_step = 1
+
+        class MolmoAct2Policy:
+            def __init__(self):
+                self.predict_action_chunk = MagicMock(return_value=torch.zeros(1, 8, 3))
+                self.select_action = MagicMock(side_effect=AssertionError("RTC is not supported for select_action"))
+
+            def eval(self):
+                return self
+
+        stub = MolmoAct2Policy()
+        policy._policy = stub
+
+        actions = policy.get_actions_sync({}, "test")
+
+        stub.predict_action_chunk.assert_called_once()
+        stub.select_action.assert_not_called()
+        assert len(actions) == 1
+
+    def test_requires_action_chunk_false_without_policy(self):
+        """No loaded policy -> not chunk-required (no crash)."""
+        policy = LerobotLocalPolicy()
+        assert policy._requires_action_chunk() is False
+
+    def test_non_molmoact2_single_step_still_uses_select_action(self):
+        """A regular policy at actions_per_step=1 keeps the select_action path."""
+        policy = _make_loaded_policy(action_dim=3, include_images=False)
+        policy.set_robot_state_keys(["a", "b", "c"])
+        policy.actions_per_step = 1
+        policy._policy.name = "act"
+
+        actions = policy.get_actions_sync({}, "test")
+
+        policy._policy.select_action.assert_called_once()
+        policy._policy.predict_action_chunk.assert_not_called()
+        assert len(actions) == 1
+
     def test_processor_bridge_preprocess_bypasses_batch_builder(self):
         policy = _make_loaded_policy(action_dim=3)
         policy.set_robot_state_keys(["a", "b", "c"])


### PR DESCRIPTION
## Problem

`MolmoAct2Policy.select_action` raises `AssertionError` whenever the checkpoint's `rtc_config` is enabled:

```python
def select_action(self, batch, **kwargs):
    if self._rtc_enabled():
        raise AssertionError("RTC is not supported for select_action, use it with predict_action_chunk")
```

`LerobotLocalPolicy.get_actions` dispatches single-step inference (the default `actions_per_step=1`) to `select_action`. For a MolmoAct2 checkpoint that ships `rtc_config.enabled=True`, that path crashes immediately. Even with RTC off, `select_action` only returns one action per call, so the model's full predicted chunk is wasted.

## Change

Add `LerobotLocalPolicy._requires_action_chunk()` which detects policies that cannot be driven via `select_action` and routes them through `predict_action_chunk` regardless of `actions_per_step`. `predict_action_chunk` handles both the RTC and non-RTC branches internally, and the returned chunk is sliced by `_tensor_to_action_dicts` as before.

Detection is by `PreTrainedPolicy.name == "molmoact2"` (the canonical case), with a `type(policy).__name__ == "MolmoAct2Policy"` fallback for cases where `name` is unset. Regular policies (ACT, diffusion, etc.) are unaffected and keep the `select_action` temporal-ensemble path at single step.

## Tests

New regression tests in `tests/policies/lerobot_local/test_policy.py` (fail on pre-fix code, pass after):
- `test_molmoact2_bypasses_select_action_at_single_step` - MolmoAct2 (detected by `name`) at `actions_per_step=1` calls `predict_action_chunk`, never `select_action` (whose mock raises the real `AssertionError`).
- `test_molmoact2_detected_by_class_name_fallback` - a stub without `name` is detected by class name.
- `test_requires_action_chunk_false_without_policy` - no loaded policy is not chunk-required.
- `test_non_molmoact2_single_step_still_uses_select_action` - regular policies keep the `select_action` path.

Full `tests/policies/` suite: 654 passed, 4 skipped. `ruff check`, `ruff format --check`, and `mypy` clean on the changed files.