### PR TITLE
fix(registry): correct so100/so101 joint count to 6 DOF

### DIFF
--- a/docs/robots/arms.md
+++ b/docs/robots/arms.md
@@ -31,8 +31,8 @@ sim = Robot("so100")            # SO-ARM100 (low-cost Feetech)
 | `panda` | Franka Emika Panda (7-DOF + gripper) | 7 | `bimanual_panda_gripper`, `bimanual_panda_hand`, `franka` |
 | `piper` | AgileX Piper (6-DOF + gripper) | 11 | `agilex_piper` |
 | `sawyer` | Rethink Robotics Sawyer (7-DOF) | 7 | `rethink_sawyer` |
-| `so100` | TrossenRobotics SO-ARM100 (6-DOF, Feetech servos) | 13 | `so100_4cam`, `so100_dualcam`, `so100_follower` |
-| `so101` | RobotStudio SO-101 (6-DOF, upgraded SO-100) | 9 | `robotstudio_so101`, `so101_dualcam`, `so101_follower` |
+| `so100` | TrossenRobotics SO-ARM100 (6-DOF, Feetech servos) | 6 | `so100_4cam`, `so100_dualcam`, `so100_follower` |
+| `so101` | RobotStudio SO-101 (6-DOF, upgraded SO-100) | 6 | `robotstudio_so101`, `so101_dualcam`, `so101_follower` |
 | `ur10e` | Universal Robots UR10e (6-DOF industrial) | 6 | - |
 | `ur5e` | Universal Robots UR5e (6-DOF industrial) | 8 | - |
 | `vx300s` | Trossen ViperX 300s (6-DOF + gripper) | 19 | `oxe_widowx`, `trossen_vx300s`, `viper_x300s` |

--- a/strands_robots/registry/robots.json
+++ b/strands_robots/registry/robots.json
@@ -208,7 +208,7 @@
     "so100": {
       "description": "TrossenRobotics SO-ARM100 (6-DOF, Feetech servos)",
       "category": "arm",
-      "joints": 13,
+      "joints": 6,
       "asset": {
         "dir": "trs_so_arm100",
         "model_xml": "so_arm100.xml",
@@ -230,7 +230,7 @@
     "so101": {
       "description": "RobotStudio SO-101 (6-DOF, upgraded SO-100)",
       "category": "arm",
-      "joints": 9,
+      "joints": 6,
       "asset": {
         "dir": "robotstudio_so101",
         "model_xml": "so101_new_calib.xml",

--- a/tests/registry/test_integrity.py
+++ b/tests/registry/test_integrity.py
@@ -145,3 +145,52 @@ def test_hardware_only_robots_declare_lerobot_type(registry: dict) -> None:
         if not isinstance(lerobot_type, str) or not lerobot_type.strip():
             offenders.append(name)
     assert not offenders, "Hardware-only robots missing 'hardware.lerobot_type': " + ", ".join(offenders)
+
+
+def test_so101_joint_count_matches_canonical_dof(registry: dict) -> None:
+    """``so101`` must declare ``joints: 6`` - its true controllable DOF.
+
+    The SO-101 is a 6-DOF arm (5 body joints + gripper). Both ground-truth
+    sources agree on 6:
+
+    * The MuJoCo asset ``so101_new_calib.xml`` exposes 6 hinge joints / 6
+      position actuators (``njnt == nu == 6``).
+    * The LeRobot ``so101_follower`` driver defines exactly 6 motors
+      (shoulder_pan, shoulder_lift, elbow_flex, wrist_flex, wrist_roll,
+      gripper).
+
+    The value had drifted to 9 by miscounting raw ``<joint>`` XML tags - three
+    of which live inside ``<default>`` class blocks and are not real DOF. That
+    contradicted the entry's own ``description`` ("6-DOF") and any consumer that
+    reads ``joints`` for a SO-101 (e.g. ``format_robot_table``) reported a wrong
+    count. Pin the canonical value so the drift cannot silently return.
+    """
+    assert registry["so101"]["joints"] == 6
+
+
+def test_arm_joint_counts_match_embodiment_state_keys(registry: dict) -> None:
+    """For single-arm robots, ``joints`` must equal the embodiment state dim.
+
+    ``embodiments.json`` is the single source of truth for the ordered joint
+    keys a LeRobot policy reads (``observation.state``). When a robot declares
+    BOTH a registry ``joints`` count AND an embodiment with ``state_keys``, the
+    two must agree for the simple single-arm category - a mismatch means the
+    informational ``joints`` metadata lies about the robot's controllable DOF.
+
+    Scoped to the SO-arm family (``so100``/``so101``), whose registry counts and
+    embodiment ``state_keys`` are both expected to be the 6 controllable DOF.
+    Bi-manual / humanoid / mobile robots intentionally count differently
+    (scene/helper joints, base velocities) and are out of scope here.
+    """
+    from strands_robots.policies.lerobot_local.embodiment import EMBODIMENT_MAP
+
+    mismatches: list[str] = []
+    for name in ("so100", "so101"):
+        info = registry.get(name)
+        emb = EMBODIMENT_MAP.get(name)
+        if info is None or emb is None or not emb.state_keys:
+            continue
+        declared = info.get("joints")
+        if declared != len(emb.state_keys):
+            mismatches.append(f"{name}: registry joints={declared} != embodiment state_keys={len(emb.state_keys)}")
+    assert not mismatches, "Registry joints disagree with embodiment state dim:\n  " + "\n  ".join(mismatches)

--- a/tests/registry/test_public_api.py
+++ b/tests/registry/test_public_api.py
@@ -328,7 +328,7 @@ class TestRobotRegistry:
         robot = get_robot("so100")
         assert robot is not None
         assert robot["category"] == "arm"
-        assert robot["joints"] == 13
+        assert robot["joints"] == 6  # so100 is a 6-DOF arm (5 joints + gripper)
         assert "asset" in robot
         assert "hardware" in robot
 

--- a/tests/test_device_connect_all_robots.py
+++ b/tests/test_device_connect_all_robots.py
@@ -424,7 +424,7 @@ class TestMultiRobotSimulation:
         return robot_data
 
     def test_mixed_joint_counts(self):
-        """so100 (13 joints) + unitree_g1 (46 joints) in one world."""
+        """so100 (6 joints) + unitree_g1 (46 joints) in one world."""
         robots_in_world = {
             "so100": self._make_robot_data(),
             "unitree_g1": self._make_robot_data(),

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -328,7 +328,7 @@ class TestRobotRegistry:
         robot = get_robot("so100")
         assert robot is not None
         assert robot["category"] == "arm"
-        assert robot["joints"] == 13
+        assert robot["joints"] == 6  # so100 is a 6-DOF arm (5 joints + gripper)
         assert "asset" in robot
         assert "hardware" in robot
 


### PR DESCRIPTION
## Problem

The `so100` and `so101` registry entries declare `joints: 13` and `joints: 9` respectively, contradicting their own `description` fields (both say "6-DOF") and the ground truth from both backends.

The SO-100 and SO-101 are 6-DOF arms (5 body joints + gripper). Two independent sources confirm 6:

- **MuJoCo assets** — `so_arm100.xml` and `so101_new_calib.xml` each expose 6 hinge joints and 6 position actuators (`njnt == nu == 6`).
- **LeRobot driver** — `SOFollower` (`so100_follower` / `so101_follower`) defines exactly 6 motors: `shoulder_pan, shoulder_lift, elbow_flex, wrist_flex, wrist_roll, gripper`.

The inflated counts came from naively counting raw `<joint>` XML tags; three of those tags live inside `<default>` class blocks and are not controllable DOF. `joints` is informational metadata (rendered by `format_robot_table` and the docs catalog), so the wrong value misreports the arm's DOF to any consumer that reads it.

This does **not** change the inference state vector: the ordered joint keys a LeRobot policy reads come from the declarative `EmbodimentMap` (`embodiments.json`), which is already the single source of truth and already declares 6 ordered `state_keys` for the SO arms (`['1'..'6']` for sim, `['shoulder_pan.pos'..'gripper.pos']` for hardware). This PR just makes the metadata consistent with that truth.

## Change

- `robots.json`: `so100` `joints: 13 -> 6`, `so101` `joints: 9 -> 6`.
- `docs/robots/arms.md`: update the catalog table to match.
- Two pinned regression tests in `tests/registry/test_integrity.py`:
  - `test_so101_joint_count_matches_canonical_dof` — explicit `so101 == 6`.
  - `test_arm_joint_counts_match_embodiment_state_keys` — cross-checks that the SO-arm family's registry `joints` equals the embodiment map's `state_keys` dim, so the two sources can't silently diverge again.
- Fix the two pre-existing tests that pinned the wrong `so100 == 13` value, and a stale test docstring.

## Tests

Both new tests **fail on pre-fix code** (`assert 9 == 6`; `so100: registry joints=13 != embodiment state_keys=6`, `so101: registry joints=9 != embodiment state_keys=6`) and pass after. Full registry + robot-factory + device-connect suites green (1024 passed). Lint (`ruff check`, `ruff format --check`) clean on changed files; `mypy strands_robots tests tests_integ` introduces no new errors.

## Visual artifact

Mock-policy rollout of the 6-DOF `so101` arm in MuJoCo (headless, `MUJOCO_GL=egl`, default camera), confirming all 6 joints (`1`..`6`) actuate:

![so101 6-DOF rollout](https://github.com/cagataycali/robots/releases/download/artifact-so101-6dof/so101_rollout.gif)

[MP4 version](https://github.com/cagataycali/robots/releases/download/artifact-so101-6dof/so101_rollout.mp4)