### PR TITLE
fix(lerobot_local): route cameras by name/config.image_keys, not position

### DIFF
--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -39,6 +39,7 @@ LerobotLocalPolicy(
     norm_tag=None,                       # MolmoAct2 normalisation tag
     image_keys=None,                     # MolmoAct2 camera key override
     inference_action_mode="continuous",  # "continuous" | "discrete"
+    camera_key_map=None,                 # {robot_cam_name: policy_image_key}
 )
 ```
 
@@ -154,6 +155,30 @@ action_unnorm = (clip(action, -1, 1) + 1) * (q99 - q01) / 2 + q01
 
 When a stats file declares multiple embodiment tags, pass `norm_tag=` to select
 one; a single-tag file is auto-detected.
+
+## Camera routing
+
+Robot/sim observations use bare camera names (`top`, `wrist`, `side`); the policy
+declares image inputs under its own keys (`observation.images.top`, ...). The
+policy routes each camera to a declared image slot by, in order:
+
+1. an explicit `camera_key_map` (`{robot_cam: policy_image_key}`) when provided;
+2. exact name match (`top` -> `observation.images.top`);
+3. positional fallback into remaining slots, with a WARNING so a mismatched
+   wiring is loud rather than silent.
+
+The declared order follows the model config's `image_keys` list when present
+(e.g. MolmoAct2), otherwise the order of the model's image input features. If
+the robot supplies fewer cameras than the policy requires, a `ValueError` is
+raised instead of feeding the model a missing or wrong view.
+
+```python
+policy = create_policy(
+    "lerobot_local",
+    pretrained_name_or_path="your-org/molmoact2-so101",
+    camera_key_map={"front": "observation.images.top", "hand": "observation.images.wrist"},
+)
+```
 
 ## RTC
 

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -60,6 +60,11 @@ class LerobotLocalPolicy(Policy):
             guidance. Defaults to model config value or 10.
         rtc_max_guidance_weight: Maximum guidance weight for RTC correction.
             Defaults to model config value or 10.0.
+        camera_key_map: Optional explicit mapping of robot/sim camera name
+            (e.g. "top") to the policy's declared image feature key
+            (e.g. "observation.images.top"). When omitted, cameras are
+            routed by exact short-name match and then by declared order
+            with a warning on mismatch.
     """
 
     def __init__(
@@ -80,6 +85,7 @@ class LerobotLocalPolicy(Policy):
         norm_tag: str | None = None,
         image_keys: list[str] | None = None,
         inference_action_mode: str = "continuous",
+        camera_key_map: dict[str, str] | None = None,
         **kwargs,
     ):
         self.pretrained_name_or_path = pretrained_name_or_path
@@ -103,6 +109,10 @@ class LerobotLocalPolicy(Policy):
         self._embodiment_spec = embodiment
         self._embodiment: Any | None = None
         self.robot_state_keys: list[str] = []
+        # Optional explicit strands-camera-name -> policy-image-key routing.
+        # When None, cameras are matched by exact short name and then by
+        # declared order (see _resolve_camera_targets).
+        self.camera_key_map = dict(camera_key_map) if camera_key_map else None
         # MolmoAct2-specific knobs. MolmoAct2 SO-100/101 checkpoints are
         # transformers-native (no lerobot draccus `type`), so they take a
         # dedicated load path (see lerobot_local.molmoact2). These are inert
@@ -1218,6 +1228,101 @@ class LerobotLocalPolicy(Policy):
 
         return batch
 
+    def _policy_image_keys(self) -> list[str]:
+        """Return the policy's ordered image feature keys.
+
+        Prefers the model config's declared ``image_keys`` - an explicit ordered
+        list used by VLAs such as MolmoAct2 to bind each camera to a fixed model
+        slot. Falls back to the image entries of ``_input_features`` in
+        declaration order when no such list is declared.
+
+        Returns:
+            Ordered list of policy image feature keys (e.g.
+            ``["observation.images.top", "observation.images.wrist"]``).
+        """
+        cfg = getattr(self._policy, "config", None)
+        declared = getattr(cfg, "image_keys", None) if cfg is not None else None
+        if isinstance(declared, (list, tuple)) and declared:
+            return [str(k) for k in declared]
+        return [feat for feat in self._input_features if "image" in feat]
+
+    def _resolve_camera_targets(self, cam_names: list[str]) -> dict[str, str]:
+        """Map robot/sim camera names to the policy's declared image feature keys.
+
+        Routing precedence:
+          1. Explicit ``camera_key_map`` ctor param wins for any name it lists.
+          2. Exact name match: ``top`` -> ``observation.images.top`` (or a
+             directly-declared ``top``) when the policy declares that key.
+          3. Positional fallback: remaining cameras fill the remaining declared
+             image slots in declaration order, with a WARN that the names did
+             not match (so a wrong wiring is loud, not silent).
+
+        Args:
+            cam_names: Camera names present in the observation.
+
+        Returns:
+            Mapping of camera name -> policy image feature key. Cameras beyond
+            what the policy consumes are omitted.
+
+        Raises:
+            ValueError: If an explicit mapping targets an undeclared image key,
+                or the robot supplies fewer cameras than the policy requires.
+        """
+        targets = self._policy_image_keys()
+        result: dict[str, str] = {}
+        used: set[str] = set()
+
+        # 1) Explicit camera_key_map wins.
+        if self.camera_key_map:
+            for cam, feat in self.camera_key_map.items():
+                if targets and feat not in targets:
+                    raise ValueError(
+                        f"camera_key_map routes camera '{cam}' to image key '{feat}', "
+                        f"but the policy does not declare it. Declared image keys: {targets}."
+                    )
+                if cam in cam_names:
+                    result[cam] = feat
+                    used.add(feat)
+
+        # 2) Exact name match for the cameras still needing a target.
+        unmatched: list[str] = []
+        for cam in cam_names:
+            if cam in result:
+                continue
+            short = f"observation.images.{cam}"
+            if short in targets and short not in used:
+                result[cam] = short
+                used.add(short)
+            elif cam in targets and cam not in used:
+                result[cam] = cam
+                used.add(cam)
+            else:
+                unmatched.append(cam)
+
+        # 3) Positional fallback into the remaining declared slots (loud).
+        free = [feat for feat in targets if feat not in used]
+        for cam, feat in zip(unmatched, free):
+            logger.warning(
+                "Camera '%s' does not match any declared policy image key by name; "
+                "routing positionally to '%s'. Pass camera_key_map to bind cameras "
+                "explicitly and silence this warning.",
+                cam,
+                feat,
+            )
+            result[cam] = feat
+            used.add(feat)
+
+        # 4) Hard error if the policy still has image slots the robot cannot fill.
+        unfilled = [feat for feat in targets if feat not in used]
+        if unfilled:
+            raise ValueError(
+                f"Robot supplies {len(cam_names)} camera(s) {cam_names} but the policy "
+                f"requires image input(s) {targets}; unmatched policy keys: {unfilled}. "
+                f"Add the missing camera(s) to the observation or pass camera_key_map."
+            )
+
+        return result
+
     def _build_batch_from_strands_format(
         self, observation_dict: dict[str, Any], batch: dict[str, Any]
     ) -> dict[str, Any]:
@@ -1285,14 +1390,26 @@ class LerobotLocalPolicy(Policy):
                     state_values.extend([0.0] * (expected_dim - len(state_values)))
             batch["observation.state"] = torch.tensor(state_values, dtype=torch.float32).unsqueeze(0).to(self._device)
 
-        # Map camera images to model's image input features.
-        # Non-state ndarray values with ndim >= 2 are assumed to be images.
-        # Each image is matched to the first unoccupied image feature slot
-        # from the model's input_features config.
-        for key, value in observation_dict.items():
-            if key in self.robot_state_keys:
-                continue
-            if isinstance(value, np.ndarray) and value.ndim >= 2:
+        # Map camera images to the model's declared image input features.
+        # Non-state ndarray values with ndim >= 2 are treated as images. Their
+        # routing to policy image keys respects config.image_keys / the explicit
+        # camera_key_map rather than blind positional assignment, so a "side"
+        # camera is never silently fed into the slot a model reserves for a
+        # "wrist" view (see _resolve_camera_targets).
+        cam_items = [
+            (key, value)
+            for key, value in observation_dict.items()
+            if key not in self.robot_state_keys and isinstance(value, np.ndarray) and value.ndim >= 2
+        ]
+        if cam_items:
+            targets = self._resolve_camera_targets([key for key, _ in cam_items])
+            for key, value in cam_items:
+                feat_name = targets.get(key)
+                if feat_name is None:
+                    # Robot supplied more cameras than the policy consumes; the
+                    # extras are intentionally dropped (resolve already errored
+                    # if the policy was instead under-supplied).
+                    continue
                 image_tensor = torch.from_numpy(value.copy()).float()
                 # HWC → CHW: convert from camera output format to model input format
                 if image_tensor.dim() == 3 and image_tensor.shape[-1] in (1, 3, 4):
@@ -1300,11 +1417,7 @@ class LerobotLocalPolicy(Policy):
                 # uint8 [0, 255] → float32 [0, 1]
                 if value.dtype == np.uint8:
                     image_tensor = image_tensor / 255.0
-                # Assign to first available image feature slot
-                for feat_name in self._input_features:
-                    if "image" in feat_name and feat_name not in batch:
-                        batch[feat_name] = image_tensor.unsqueeze(0).to(self._device)
-                        break
+                batch[feat_name] = image_tensor.unsqueeze(0).to(self._device)
 
         return batch
 

--- a/tests/policies/lerobot_local/test_policy.py
+++ b/tests/policies/lerobot_local/test_policy.py
@@ -713,6 +713,103 @@ class TestBuildBatchFromStrandsFormat:
 
 
 # (section)
+# Tests: camera-key routing (config.image_keys / camera_key_map)
+# (section)
+
+
+def _make_two_camera_policy():
+    """Loaded policy whose model declares two image inputs (top, wrist)."""
+    policy = _make_loaded_policy(state_dim=2, include_images=False)
+    policy.set_robot_state_keys(["a", "b"])
+    img = MagicMock(shape=(3, 480, 640))
+    # Declaration order: top before wrist.
+    policy._input_features["observation.images.top"] = img
+    policy._input_features["observation.images.wrist"] = img
+    return policy
+
+
+class TestCameraKeyRouting:
+    def test_exact_name_match_routes_by_name_not_position(self):
+        """A 'wrist' cam must land in the wrist slot even when iterated last."""
+        policy = _make_two_camera_policy()
+        top = np.zeros((480, 640, 3), dtype=np.uint8)
+        wrist = np.ones((480, 640, 3), dtype=np.uint8) * 255
+        # Insertion order deliberately reversed vs declaration order.
+        observation = {"a": 1.0, "b": 2.0, "wrist": wrist, "top": top}
+        batch = policy._build_batch_from_strands_format(observation, {})
+        # wrist (all-255 -> 1.0) must be in the wrist slot, top (zeros) in top.
+        assert float(batch["observation.images.wrist"].max()) == 1.0
+        assert float(batch["observation.images.top"].max()) == 0.0
+
+    def test_config_image_keys_preferred_over_input_features_order(self):
+        """config.image_keys ordering wins over _input_features declaration order."""
+        policy = _make_two_camera_policy()
+        # Reverse the model's declared ordering via config.image_keys.
+        policy._policy.config.image_keys = [
+            "observation.images.wrist",
+            "observation.images.top",
+        ]
+        keys = policy._policy_image_keys()
+        assert keys == ["observation.images.wrist", "observation.images.top"]
+
+    def test_explicit_camera_key_map_overrides_naming(self):
+        """camera_key_map binds a mismatched cam name to the intended slot."""
+        policy = _make_two_camera_policy()
+        policy.camera_key_map = {
+            "front": "observation.images.top",
+            "hand": "observation.images.wrist",
+        }
+        front = np.zeros((480, 640, 3), dtype=np.uint8)
+        hand = np.ones((480, 640, 3), dtype=np.uint8) * 255
+        observation = {"a": 1.0, "b": 2.0, "front": front, "hand": hand}
+        batch = policy._build_batch_from_strands_format(observation, {})
+        assert float(batch["observation.images.top"].max()) == 0.0
+        assert float(batch["observation.images.wrist"].max()) == 1.0
+
+    def test_positional_fallback_warns_on_name_mismatch(self, caplog):
+        """Mismatched cam names fall back positionally but log a WARNING."""
+        import logging
+
+        policy = _make_two_camera_policy()
+        side = np.zeros((480, 640, 3), dtype=np.uint8)
+        other = np.zeros((480, 640, 3), dtype=np.uint8)
+        observation = {"a": 1.0, "b": 2.0, "side": side, "other": other}
+        with caplog.at_level(logging.WARNING):
+            batch = policy._build_batch_from_strands_format(observation, {})
+        assert "observation.images.top" in batch
+        assert "observation.images.wrist" in batch
+        assert any("routing positionally" in r.message for r in caplog.records)
+
+    def test_camera_key_map_to_undeclared_key_raises(self):
+        policy = _make_two_camera_policy()
+        policy.camera_key_map = {"top": "observation.images.nonexistent"}
+        observation = {"a": 1.0, "b": 2.0, "top": np.zeros((480, 640, 3), dtype=np.uint8)}
+        with pytest.raises(ValueError, match="does not declare it"):
+            policy._build_batch_from_strands_format(observation, {})
+
+    def test_fewer_cameras_than_policy_needs_raises(self):
+        """One camera for a two-camera policy is a hard error, not silent."""
+        policy = _make_two_camera_policy()
+        observation = {"a": 1.0, "b": 2.0, "top": np.zeros((480, 640, 3), dtype=np.uint8)}
+        with pytest.raises(ValueError, match="requires image input"):
+            policy._build_batch_from_strands_format(observation, {})
+
+    def test_extra_cameras_are_dropped(self):
+        """A single-cam policy ignores extra cameras the robot provides."""
+        policy = _make_loaded_policy(state_dim=2)  # declares observation.images.top
+        policy.set_robot_state_keys(["a", "b"])
+        observation = {
+            "a": 1.0,
+            "b": 2.0,
+            "top": np.zeros((480, 640, 3), dtype=np.uint8),
+            "extra": np.ones((480, 640, 3), dtype=np.uint8),
+        }
+        batch = policy._build_batch_from_strands_format(observation, {})
+        assert "observation.images.top" in batch
+        assert len([k for k in batch if "image" in k]) == 1
+
+
+# (section)
 # Tests: _tensor_to_action_dicts
 # (section)
 


### PR DESCRIPTION
## Problem

`LerobotLocalPolicy._build_batch_from_strands_format` assigned each camera ndarray to the *first unoccupied* `"image" in feat_name` slot in `_input_features` iteration order. When a robot's camera names and the policy's declared image keys differ in count or ordering, this silently routes the wrong camera to a model slot.

Example: a robot sends `{"top": ..., "side": ...}` and a VLA declares `observation.images.top` + `observation.images.wrist`. Positional assignment shoves `side` into the `wrist` slot, so the model receives the wrong view with no error and no log.

## Change

Route camera images to declared image keys via, in precedence order:
1. an explicit `camera_key_map` ctor param (`{robot_cam_name: policy_image_key}`);
2. exact short-name match (`top` -> `observation.images.top`, or a directly-declared `top`);
3. positional fallback into the remaining declared slots, now emitting a WARNING so a mismatched wiring is loud instead of silent.

The declared key order prefers the model config's `image_keys` list (an explicit ordered list used by MolmoAct2 and most VLAs to bind cameras to fixed slots) and falls back to the image entries of `input_features` in declaration order. A `ValueError` is raised when the robot supplies fewer cameras than the policy requires, or when `camera_key_map` targets an undeclared image key — instead of feeding the model a missing or wrong view.

New helpers: `_policy_image_keys()` (resolves the ordered policy image keys) and `_resolve_camera_targets()` (computes the camera-name -> image-key mapping).

## Tests

Added `TestCameraKeyRouting` in `tests/policies/lerobot_local/test_policy.py`:
- name-based routing lands `wrist` in the wrist slot even when iterated last (fails on pre-fix code);
- `config.image_keys` ordering wins over `input_features` order;
- explicit `camera_key_map` overrides naming;
- positional fallback logs a WARNING on name mismatch;
- under-supply raises `ValueError`;
- `camera_key_map` to an undeclared key raises `ValueError`;
- extra cameras beyond what the policy consumes are dropped.

The core regression (`test_exact_name_match_routes_by_name_not_position`) fails on `main` and passes after the fix. Full module: 84 passed. `ruff check`, `ruff format --check`, and `mypy` clean.

## Docs

`docs/policies/lerobot-local.md`: added `camera_key_map` to the Parameters block and a new Camera routing section documenting the precedence and the under-supply error.

## §13 Changelog

**Rebase onto main** (post-merge of sibling lerobot_local PRs): resolved a docs-only conflict in `docs/policies/lerobot-local.md` by keeping both the newly-merged "Processor bridge and normalization" section and this PR's "Camera routing" section (purely additive, no overlap). `policy.py` and `test_policy.py` auto-merged with no logic changes. Single commit re-applied cleanly; CI re-running. Re-approval needed because the rebase changed the head SHA — no content changed since the prior approval beyond the doc-section coexistence.