### PR TITLE
feat(sim): add seed= to run_policy/start_policy for reproducible single rollouts

### DIFF
--- a/docs/simulation/overview.md
+++ b/docs/simulation/overview.md
@@ -90,12 +90,14 @@ Robot-URDF cameras are auto-discovered on `add_robot`.
 
 | Action | Key params |
 |--------|-----------|
-| `run_policy` | `robot_name` (required), `policy_provider="mock"`, `policy_config={}`, `policy_object=None`, `instruction=""`, `duration=10.0`, `control_frequency=50.0`, `action_horizon=8`, `n_steps=None` |
+| `run_policy` | `robot_name` (required), `policy_provider="mock"`, `policy_config={}`, `policy_object=None`, `instruction=""`, `duration=10.0`, `control_frequency=50.0`, `action_horizon=8`, `n_steps=None`, `seed=None` |
 | `start_policy` | same args, async/non-blocking |
 | `stop_policy` | `robot_name` (optional, defaults to `""`) |
 | `list_policies_running` | - |
 | `run_multi_policy` | `policies={robot: Policy}`, `instructions`, `duration`, `n_steps` |
 | `eval_policy` | `robot_name` (required), `n_episodes=1`, `max_steps=300`, `success_fn=None` |
+
+Pass `seed=` to `run_policy` / `start_policy` for a reproducible single rollout: it reseeds Python / NumPy / torch / cuDNN and forwards `policy.reset(seed=...)`, so a stochastic policy (VLA action-chunk sampling, diffusion noise) produces the same trajectory on re-run of the same scene. Without a seed the rollout draws from the process-global RNG and can differ run to run. `eval_policy` already seeds per episode via the same mechanism.
 | `replay_episode` | `repo_id`, `robot_name=None`, `episode=0` |
 
 ## Recording

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -310,6 +310,7 @@ class SimEngine(ABC):
         max_onframe_failures: int | None = None,
         control_substeps: int | None = None,
         policy_kwargs: dict[str, Any] | None = None,
+        seed: int | None = None,
     ) -> dict[str, Any]:
         """Run a policy loop in the simulation (blocking).
 
@@ -342,6 +343,13 @@ class SimEngine(ABC):
                 dataset recording), backends plug into
                 ``PolicyRunner.run``'s ``on_frame`` hook via
                 :meth:`_make_run_policy_hook`.
+            seed: Optional master RNG seed for a reproducible single rollout.
+                When set, reseeds Python / NumPy / torch / cuDNN and forwards
+                ``policy.reset(seed=...)`` so a stochastic policy (VLA action-
+                chunk sampling, diffusion noise) produces the same trajectory
+                on re-run of the same scene. ``None`` (default) leaves RNG
+                state untouched. Mirrors the per-episode reseed in
+                :meth:`eval_policy`.
             policy_kwargs: Optional per-call goal payload forwarded verbatim to
                 every ``policy.get_actions(obs, instruction, **policy_kwargs)``
                 call. Carries the well-known #300 goal keys
@@ -407,6 +415,7 @@ class SimEngine(ABC):
             max_onframe_failures=max_onframe_failures,
             control_substeps=control_substeps,
             policy_kwargs=policy_kwargs,
+            seed=seed,
         )
 
     def start_policy(
@@ -424,6 +433,7 @@ class SimEngine(ABC):
         n_steps: int | None = None,
         max_steps: int | None = None,
         policy_kwargs: dict[str, Any] | None = None,
+        seed: int | None = None,
     ) -> dict[str, Any]:
         """Start policy execution in a background thread (non-blocking).
 
@@ -451,6 +461,7 @@ class SimEngine(ABC):
             n_steps=n_steps,
             max_steps=max_steps,
             policy_kwargs=policy_kwargs,
+            seed=seed,
         )
 
     def replay_episode(

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1915,6 +1915,7 @@ class MuJoCoSimEngine(
         n_steps: int | None = None,
         max_steps: int | None = None,
         policy_kwargs: dict[str, Any] | None = None,
+        seed: int | None = None,
     ) -> dict[str, Any]:
         """Start policy execution on a background thread (non-blocking).
 
@@ -1968,6 +1969,7 @@ class MuJoCoSimEngine(
             n_steps=n_steps,
             max_steps=max_steps,
             policy_kwargs=policy_kwargs,
+            seed=seed,
         )
         self._policy_threads[robot_name] = future
 
@@ -2060,6 +2062,7 @@ class MuJoCoSimEngine(
         max_onframe_failures: int | None = None,
         control_substeps: int | None = None,
         policy_kwargs: dict[str, Any] | None = None,
+        seed: int | None = None,
     ) -> dict[str, Any]:
         """MuJoCo ``run_policy`` override: pre-flight world check + graceful stop.
 
@@ -2096,6 +2099,7 @@ class MuJoCoSimEngine(
                 max_onframe_failures=max_onframe_failures,
                 control_substeps=control_substeps,
                 policy_kwargs=policy_kwargs,
+                seed=seed,
             )
         finally:
             if self._world is not None and robot_name in self._world.robots:

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -289,6 +289,7 @@ class PolicyRunner:
         max_onframe_failures: int | None = None,
         control_substeps: int | None = None,
         policy_kwargs: dict[str, Any] | None = None,
+        seed: int | None = None,
     ) -> dict[str, Any]:
         """Run ``policy`` on ``robot_name`` for ``duration`` seconds.
 
@@ -327,10 +328,37 @@ class PolicyRunner:
                 broken recording hook otherwise silently produces empty
                 datasets - see GH #117. Non-consecutive failures reset the
                 counter.
+            seed: Optional master RNG seed for a reproducible single rollout.
+                When set, ``set_eval_seed`` reseeds Python / NumPy / torch /
+                cuDNN and ``policy.reset(seed=...)`` is forwarded so the
+                policy's stochastic ops (VLA action-chunk sampling, diffusion
+                noise, attention dropout) draw from a deterministic state.
+                Without this, a single ``run`` draws from the unmanaged global
+                RNG, so the same scene + policy can grasp on one run and miss
+                on the next. ``None`` (default) leaves RNG state untouched,
+                preserving historical behaviour. Multi-episode reproducibility
+                already flows through :meth:`evaluate`'s per-episode reseed.
 
         Returns:
             ``{"status": "success"|"error", "content": [{"text": ...}]}``.
         """
+        # A single rollout draws the policy's stochastic ops (VLA action-
+        # chunk sampling, diffusion noise) from the unmanaged global RNG, so the
+        # same scene + policy grasps on one run and misses on the next. When a
+        # seed is given, reseed the client RNGs once and forward it to the policy
+        # (mirrors the per-episode reseed in evaluate()). Default None leaves RNG
+        # state untouched, preserving historical behaviour.
+        if seed is not None:
+            set_eval_seed(seed)
+            try:
+                policy.reset(seed=seed)
+            except Exception as e:  # noqa: BLE001 - reset is best-effort
+                logger.warning(
+                    "policy.reset(seed=%d) raised %s; continuing without policy-side reseed",
+                    seed,
+                    e,
+                )
+
         # Lazy optional import - only imageio is optional.
         writer = None
         frame_count = 0

--- a/tests/simulation/test_run_policy_seed_reproducibility.py
+++ b/tests/simulation/test_run_policy_seed_reproducibility.py
@@ -1,0 +1,114 @@
+"""Single-rollout reproducibility via ``run_policy(seed=...)``.
+
+A single ``PolicyRunner.run`` / ``SimEngine.run_policy`` rollout drives a
+stochastic policy (VLA action-chunk sampling, diffusion noise) from the
+process-global RNG. Without an explicit seed, the same scene + policy produces
+a different trajectory on every run - so a manipulation policy can grasp on one
+run and miss on the next with no scene change. Multi-episode ``evaluate`` already
+seeds per episode; this pins the same reproducibility contract for the
+single-rollout path.
+
+Regression for the no-grasp-on-re-run report: identical seed -> identical
+trajectory; the seed is forwarded to ``policy.reset(seed=...)``.
+"""
+
+from __future__ import annotations
+
+import random
+from typing import Any
+
+import numpy as np
+
+from strands_robots.policies.base import Policy
+from strands_robots.simulation.policy_runner import PolicyRunner
+
+from .test_policy_runner import FakeSim
+
+
+class StochasticPolicy(Policy):
+    """Policy whose actions are drawn from the global Python/NumPy RNGs.
+
+    Stands in for a real VLA whose action-chunk sampling is stochastic. The
+    per-step draw is recorded so two rollouts can be compared bit-for-bit.
+    Also records the seed passed to :meth:`reset` so the forwarding contract
+    can be asserted.
+    """
+
+    def __init__(self) -> None:
+        self.robot_state_keys: list[str] = []
+        self.draws: list[float] = []
+        self.reset_seeds: list[int | None] = []
+
+    @property
+    def provider_name(self) -> str:
+        return "stochastic"
+
+    @property
+    def requires_images(self) -> bool:
+        return False
+
+    def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
+        self.robot_state_keys = robot_state_keys
+
+    def reset(self, seed: int | None = None) -> None:
+        self.reset_seeds.append(seed)
+
+    async def get_actions(
+        self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any
+    ) -> list[dict[str, Any]]:
+        # Draw from BOTH global RNGs so the test exercises the python+numpy
+        # seeding that set_eval_seed performs.
+        draw = random.random() + float(np.random.random())
+        self.draws.append(draw)
+        return [{k: draw for k in self.robot_state_keys}]
+
+
+def _run_once(seed: int | None) -> StochasticPolicy:
+    sim = FakeSim()
+    policy = StochasticPolicy()
+    policy.set_robot_state_keys(sim.robot_joint_names("fake_robot"))
+    result = PolicyRunner(sim).run(
+        "fake_robot",
+        policy,
+        duration=0.5,
+        control_frequency=10.0,  # -> 5 steps
+        action_horizon=1,
+        fast_mode=True,
+        seed=seed,
+    )
+    assert result["status"] == "success"
+    return policy
+
+
+def test_same_seed_same_trajectory():
+    """Two single rollouts at the same seed draw identical action sequences."""
+    a = _run_once(seed=1234)
+    b = _run_once(seed=1234)
+
+    assert a.draws, "policy produced no action draws"
+    assert a.draws == b.draws, (
+        "run_policy(seed=...) is not reproducible: identical seed produced "
+        f"different trajectories\n  run A: {a.draws}\n  run B: {b.draws}"
+    )
+
+
+def test_different_seed_different_trajectory():
+    """Different seeds diverge - the seed actually drives sampling."""
+    a = _run_once(seed=1234)
+    b = _run_once(seed=5678)
+    assert a.draws != b.draws
+
+
+def test_seed_forwarded_to_policy_reset():
+    """The master seed is forwarded to ``policy.reset(seed=...)`` so service-mode
+    policies (e.g. a remote VLA server) can re-init their own RNG."""
+    policy = _run_once(seed=42)
+    assert 42 in policy.reset_seeds
+
+
+def test_no_seed_leaves_reset_untouched():
+    """Default (seed=None) preserves historical behaviour: reset is not forced."""
+    policy = _run_once(seed=None)
+    assert policy.reset_seeds == [], (
+        f"run_policy with no seed should not call policy.reset(seed=...); got {policy.reset_seeds}"
+    )


### PR DESCRIPTION
## Problem

A single `run_policy` / `PolicyRunner.run` rollout drives the policy's stochastic ops (VLA action-chunk sampling, diffusion noise, attention dropout) from the **process-global RNG**. With no explicit seed, the same scene + the same policy produces a different trajectory on every run.

This is invisible for `mock` policies but bites real manipulation VLAs: a pick-and-place policy can grasp on one rollout and miss on the very next with **zero scene change** — the only difference is unmanaged RNG state that drifted between calls. Reproducing or bisecting such a result is impossible because there is no knob to pin the run.

The multi-episode path already solved this: `eval_policy` / `PolicyRunner.evaluate` seed per episode via `set_eval_seed` (Python/NumPy/torch/cuDNN) and forward `policy.reset(seed=...)`. The single-rollout path had no equivalent.

## Change

Add an optional `seed: int | None = None` parameter, threaded through:

- `PolicyRunner.run`
- `SimEngine.run_policy` / `SimEngine.start_policy`
- the MuJoCo `Simulation.run_policy` / `start_policy` overrides

When `seed` is set, `run` reseeds the client RNGs once via the existing `set_eval_seed` helper and forwards `policy.reset(seed=...)` (best-effort, mirroring `evaluate`) so service-mode policies (e.g. a remote VLA server) can re-init their own RNG. `seed=None` (default) leaves RNG state untouched — historical behaviour is preserved exactly.

The agent `tool_spec.json` already declares a `seed` integer param, so the `run_policy` / `start_policy` agent actions pick it up automatically through the signature-introspecting dispatcher — no schema change needed.

## Tests

New `tests/simulation/test_run_policy_seed_reproducibility.py` (a `StochasticPolicy` drawing actions from the global Python+NumPy RNGs):

- `test_same_seed_same_trajectory` — identical seed → bit-identical action sequence
- `test_different_seed_different_trajectory` — different seed → divergent
- `test_seed_forwarded_to_policy_reset` — master seed reaches `policy.reset(seed=...)`
- `test_no_seed_leaves_reset_untouched` — default path does not force a reset

All four FAIL on pre-fix code (`TypeError: PolicyRunner.run() got an unexpected keyword argument 'seed'`) and pass after. Full `tests/simulation` suite green locally (the 2 `libtorchcodec`/CUDA recording failures are pre-existing environmental issues, unrelated to this change).

## Visual proof (MuJoCo headless, EGL)

Real SO-101 sim rollout, stochastic policy, 60 control steps. Final joint vector across three runs:

```
seed=123 run A: [0.205761, 0.291052, 0.237112, 0.280182, 0.279738, 0.296067]
seed=123 run B: [0.205761, 0.291052, 0.237112, 0.280182, 0.279738, 0.296067]   # == A
seed=999      : [0.190908, 0.288224, 0.241596, 0.281837, 0.30345,  0.264769]   # != A
```

Same seed reproduces bit-for-bit; a different seed diverges; no seed draws from the global RNG and varies run to run.

![seeded rollout](https://github.com/cagataycali/robots/releases/download/seed-repro-artifact/seed_rollout.gif)

[MP4](https://github.com/cagataycali/robots/releases/download/seed-repro-artifact/seed_rollout.mp4) (640x480, 60 frames @ 20 Hz, rendered headless via `run_policy(..., video=..., seed=123)`).

## Docs

`docs/simulation/overview.md`: `seed=None` added to the `run_policy` param row plus a short note on single-rollout reproducibility.