### PR TITLE
test(pose_tool): cover hardware fault + smooth-move paths (91%->100%)

### DIFF
--- a/tests/tools/test_pose_tool.py
+++ b/tests/tools/test_pose_tool.py
@@ -687,7 +687,7 @@ def test_pose_tool_reset_to_home_reports_move_failure(cwd_tmp, monkeypatch) -> N
     the connection but the grouped move reports failure), pinning that the tool
     does not claim the arm reached home when it did not.
     """
-    monkeypatch.setattr(serial, "Serial", lambda *a, **k: AlwaysReadingSerial(*a, **k))
+    monkeypatch.setattr(serial, "Serial", AlwaysReadingSerial)
     monkeypatch.setattr(pose_mod.MotorController, "move_multiple_motors", lambda self, positions, smooth=True: False)
     result = pose_tool(action="reset_to_home", robot_id="hw_arm", port="/dev/ttyTEST")
     assert result["status"] == "error"

--- a/tests/tools/test_pose_tool.py
+++ b/tests/tools/test_pose_tool.py
@@ -557,3 +557,245 @@ def test_pose_tool_incremental_move_failure_without_current_position(cwd_tmp, fa
     assert result["status"] == "error"
     _assert_ascii(result)
     assert "Failed to move" in _texts(result)
+
+
+# --------------------------------------------------------------------------- #
+# pose_tool: hardware fault paths (arm unplugged / servo write fails)          #
+#                                                                              #
+# These pin the agent-facing contract that every motor action surfaces an      #
+# error result -- never a false success or an escaped exception -- when the    #
+# bus cannot be opened or a write fails. This is exactly the situation a        #
+# headless agent hits when the arm is unplugged, so the contract must hold.    #
+# --------------------------------------------------------------------------- #
+class WriteFailsSerial(AlwaysReadingSerial):
+    """A serial port that opens and answers reads but fails every write.
+
+    Models a servo bus that connects yet rejects goal-position writes (loose
+    cable, powered-down servo). ``MotorController.move_motor`` /
+    ``read_motor_position`` catch the error and report failure rather than
+    raising, and the tool must turn that into an error result.
+    """
+
+    def write(self, data: bytes) -> None:
+        raise OSError("bus write rejected")
+
+
+@pytest.fixture
+def write_fails_serial(monkeypatch):
+    """Patch ``serial.Serial`` with a port whose writes always fail."""
+    instances: list[WriteFailsSerial] = []
+
+    def _ctor(port: str, baudrate: int, timeout: float = 1.0) -> WriteFailsSerial:
+        fs = WriteFailsSerial(port, baudrate, timeout)
+        instances.append(fs)
+        return fs
+
+    monkeypatch.setattr(serial, "Serial", _ctor)
+    return instances
+
+
+# Every action that needs a live bus, with the minimal args to reach connect().
+_MOTOR_ACTIONS = [
+    ("read_position", {"motor_name": "shoulder_pan"}),
+    ("read_all", {}),
+    ("store_pose", {"pose_name": "grasp"}),
+    ("move_motor", {"motor_name": "shoulder_pan", "position": 10.0}),
+    ("move_multiple", {"positions": {"shoulder_pan": 5.0}}),
+    ("incremental_move", {"motor_name": "shoulder_pan", "delta": 5.0}),
+    ("reset_to_home", {}),
+]
+
+
+@pytest.mark.parametrize("action, kwargs", _MOTOR_ACTIONS)
+def test_pose_tool_motor_action_reports_connection_failure(cwd_tmp, monkeypatch, action, kwargs) -> None:
+    """When the serial bus cannot be opened, every motor action returns an
+    ASCII error result naming the failed port -- not a crash or false success."""
+
+    def _boom(*a, **k):
+        raise OSError("no device on /dev/ttyTEST")
+
+    monkeypatch.setattr(serial, "Serial", _boom)
+    result = pose_tool(action=action, robot_id="hw_arm", port="/dev/ttyTEST", **kwargs)
+    assert result["status"] == "error"
+    _assert_ascii(result)
+    assert "Failed to connect" in _texts(result)
+
+
+def test_pose_tool_load_pose_reports_connection_failure(cwd_tmp, monkeypatch) -> None:
+    """load_pose validates the stored pose first, then fails on a dead bus."""
+    mgr = PoseManager(robot_id="hw_arm")
+    mgr.store_pose("ready", {"shoulder_pan": 10.0}, "ready pose")
+
+    def _boom(*a, **k):
+        raise OSError("no device")
+
+    monkeypatch.setattr(serial, "Serial", _boom)
+    result = pose_tool(action="load_pose", robot_id="hw_arm", port="/dev/ttyTEST", pose_name="ready")
+    assert result["status"] == "error"
+    _assert_ascii(result)
+    assert "Failed to connect" in _texts(result)
+
+
+def test_pose_tool_move_motor_reports_write_failure(cwd_tmp, write_fails_serial) -> None:
+    """A rejected servo write surfaces as an error, never a false 'Moved'."""
+    result = pose_tool(
+        action="move_motor",
+        robot_id="hw_arm",
+        port="/dev/ttyTEST",
+        motor_name="shoulder_pan",
+        position=10.0,
+    )
+    assert result["status"] == "error"
+    _assert_ascii(result)
+    assert "Failed to move shoulder_pan" in _texts(result)
+
+
+def test_pose_tool_move_multiple_reports_write_failure(cwd_tmp, write_fails_serial) -> None:
+    """move_multiple (smooth=False) reports failure when a write is rejected."""
+    result = pose_tool(
+        action="move_multiple",
+        robot_id="hw_arm",
+        port="/dev/ttyTEST",
+        positions={"shoulder_pan": 5.0, "gripper": 25.0},
+        smooth=False,
+    )
+    assert result["status"] == "error"
+    _assert_ascii(result)
+    assert "Failed to move motors" in _texts(result)
+
+
+def test_pose_tool_load_pose_reports_move_failure(cwd_tmp, write_fails_serial) -> None:
+    """load_pose (smooth=False) surfaces a move failure with the pose name."""
+    mgr = PoseManager(robot_id="hw_arm")
+    mgr.store_pose("ready", {"shoulder_pan": 10.0, "gripper": 50.0}, "ready pose")
+    result = pose_tool(
+        action="load_pose",
+        robot_id="hw_arm",
+        port="/dev/ttyTEST",
+        pose_name="ready",
+        smooth=False,
+    )
+    assert result["status"] == "error"
+    _assert_ascii(result)
+    assert "Failed to move to pose 'ready'" in _texts(result)
+
+
+def test_pose_tool_reset_to_home_reports_move_failure(cwd_tmp, monkeypatch) -> None:
+    """reset_to_home surfaces an error if the underlying motor move fails.
+
+    The home move is fault-injected at the controller boundary (the bus accepts
+    the connection but the grouped move reports failure), pinning that the tool
+    does not claim the arm reached home when it did not.
+    """
+    monkeypatch.setattr(serial, "Serial", lambda *a, **k: AlwaysReadingSerial(*a, **k))
+    monkeypatch.setattr(pose_mod.MotorController, "move_multiple_motors", lambda self, positions, smooth=True: False)
+    result = pose_tool(action="reset_to_home", robot_id="hw_arm", port="/dev/ttyTEST")
+    assert result["status"] == "error"
+    _assert_ascii(result)
+    assert "Failed to move to home position" in _texts(result)
+
+
+def test_pose_tool_smooth_move_interpolates_from_current_positions(cwd_tmp, reading_serial) -> None:
+    """move_multiple with smooth=True reads current positions and interpolates.
+
+    Drives the smooth-move path (read current -> compute per-step increments ->
+    step toward the target), which is the default trajectory mode and was
+    otherwise unexercised. The bus answers reads, so increments are computed
+    against real positions and many goal-position writes are emitted."""
+    result = pose_tool(
+        action="move_multiple",
+        robot_id="hw_arm",
+        port="/dev/ttyTEST",
+        positions={"shoulder_pan": 30.0, "gripper": 40.0},
+        smooth=True,
+    )
+    assert result["status"] == "success"
+    _assert_ascii(result)
+    # Smooth move steps 0..20 inclusive over multiple motors -> many writes.
+    assert len(reading_serial[0].writes) > 20
+
+
+def test_pose_tool_delete_pose_requires_pose_name(cwd_tmp) -> None:
+    """delete_pose without a pose_name is a validation error, not a no-op."""
+    result = pose_tool(action="delete_pose", robot_id="hw_arm")
+    assert result["status"] == "error"
+    assert "pose_name required" in _texts(result)
+
+
+def test_pose_tool_load_pose_requires_pose_name(cwd_tmp) -> None:
+    """load_pose without a pose_name is rejected before touching the bus."""
+    result = pose_tool(action="load_pose", robot_id="hw_arm", port="/dev/ttyTEST")
+    assert result["status"] == "error"
+    assert "pose_name required" in _texts(result)
+
+
+def test_pose_tool_list_poses_skips_pose_removed_mid_listing(cwd_tmp, monkeypatch) -> None:
+    """list_poses tolerates a pose vanishing between enumeration and detail read.
+
+    The detailed listing re-fetches each pose by name; if one is deleted in
+    between (a concurrent edit), the listing skips it rather than crashing."""
+    mgr = PoseManager(robot_id="race_arm")
+    mgr.store_pose("keep", {"shoulder_pan": 0.0}, "stays")
+    mgr.store_pose("gone", {"shoulder_pan": 1.0}, "vanishes")
+
+    real_get = PoseManager.get_pose
+
+    def _get(self, name):
+        return None if name == "gone" else real_get(self, name)
+
+    monkeypatch.setattr(pose_mod.PoseManager, "get_pose", _get)
+    result = pose_tool(action="list_poses", robot_id="race_arm")
+    assert result["status"] == "success"
+    _assert_ascii(result)
+    names = [p["name"] for p in result.get("poses", [])]
+    assert "keep" in names
+    assert "gone" not in names
+
+
+def test_pose_manager_save_failure_is_logged_not_raised(cwd_tmp, monkeypatch) -> None:
+    """A write error while persisting poses is logged, never raised to the caller.
+
+    Storing a pose must not crash the agent if the pose file is unwritable; the
+    in-memory pose is still registered."""
+    mgr = PoseManager(robot_id="ro_arm")
+
+    def _no_write(*a, **k):
+        raise OSError("read-only filesystem")
+
+    monkeypatch.setattr("builtins.open", _no_write)
+    # Should not raise despite the save failing.
+    mgr.store_pose("home", {"shoulder_pan": 0.0}, "rest")
+    assert mgr.get_pose("home") is not None
+
+
+def test_pose_tool_surfaces_unexpected_internal_error(cwd_tmp, monkeypatch) -> None:
+    """An unexpected error inside dispatch is caught and returned as an error
+    result (the tool never raises past its dispatcher)."""
+
+    def _boom(*a, **k):
+        raise RuntimeError("controller blew up")
+
+    monkeypatch.setattr(pose_mod, "MotorController", _boom)
+    result = pose_tool(action="connect", robot_id="hw_arm", port="/dev/ttyTEST")
+    assert result["status"] == "error"
+    _assert_ascii(result)
+    assert "Error:" in _texts(result)
+    assert "controller blew up" in _texts(result)
+
+
+def test_read_motor_position_returns_none_on_serial_read_error(fake_serial) -> None:
+    """A serial read that raises is caught: read_motor_position returns None.
+
+    Models a mid-transfer bus fault (cable yanked while reading). The error is
+    logged and swallowed so the higher-level read loop degrades to 'no reading'
+    rather than crashing the whole pose operation."""
+    ctrl = MotorController("/dev/ttyTEST")
+    connected, _ = ctrl.connect()
+    assert connected
+
+    def _boom_read(n: int = 1) -> bytes:
+        raise OSError("read interrupted")
+
+    assert ctrl.serial_conn is not None
+    ctrl.serial_conn.read = _boom_read  # type: ignore[method-assign]
+    assert ctrl.read_motor_position("shoulder_pan") is None


### PR DESCRIPTION
## What
Adds focused, hardware-free behavior tests for `strands_robots/tools/pose_tool.py`, lifting coverage from 91% to 100% (31 previously-uncovered lines now exercised).

## Why
The uncovered lines were almost entirely the agent-facing fault paths a headless caller hits when the arm is unplugged or a servo write is rejected: the per-action connection-failure returns (`read_position`, `read_all`, `store_pose`, `move_motor`, `move_multiple`, `incremental_move`, `reset_to_home`, `load_pose`), the move-failure returns, the default smooth-move interpolation branch, a couple of validation guards, the pose-vanished-mid-listing skip, the persist-failure log path, and the top-level dispatch guard. These are exactly the branches whose contract must not silently drift into a false success or an escaped exception.

## Tests added
- `test_pose_tool_motor_action_reports_connection_failure` (parametrized over all 7 bus-touching actions) - a dead bus yields an ASCII error naming the port, never a crash or false success.
- `test_pose_tool_load_pose_reports_connection_failure` - load_pose validates the stored pose, then fails cleanly on a dead bus.
- `test_pose_tool_move_motor_reports_write_failure` / `..._move_multiple_reports_write_failure` / `..._load_pose_reports_move_failure` - a rejected servo write surfaces as an error, never a false `Moved`.
- `test_pose_tool_reset_to_home_reports_move_failure` - home move failure is reported, not silently claimed.
- `test_pose_tool_smooth_move_interpolates_from_current_positions` - the default smooth trajectory mode reads current positions and emits the interpolated step writes.
- `test_pose_tool_delete_pose_requires_pose_name` / `..._load_pose_requires_pose_name` - missing-arg validation guards.
- `test_pose_tool_list_poses_skips_pose_removed_mid_listing` - a pose deleted between enumeration and detail read is skipped, not crashed on.
- `test_pose_manager_save_failure_is_logged_not_raised` - an unwritable pose file is logged, never raised; the in-memory pose still registers.
- `test_pose_tool_surfaces_unexpected_internal_error` - an unexpected internal error is returned as an error result (no raise past the dispatcher).
- `test_read_motor_position_returns_none_on_serial_read_error` - a mid-transfer read fault degrades to `None`, not a crash.

New `WriteFailsSerial` fake (opens and answers reads but rejects writes) models a connected-but-faulty servo bus. All tests assert observable outputs (status, ASCII-only message content, device release / write emission) rather than internal state, consistent with the existing suite.

## Coverage
`strands_robots/tools/pose_tool.py`: 91% -> 100%.

## Verification
- `ruff check` + `ruff format --check`: clean.
- `mypy`: clean on the changed file.
- `pytest tests/tools/test_pose_tool.py`: 62 passed (was 43).

Test-only change; no library behavior is modified.

---

### Round 1 changelog
- Addressed code-scanning finding (unnecessary lambda) at `tests/tools/test_pose_tool.py:690`: the `serial.Serial` monkeypatch wrapped `AlwaysReadingSerial` in a forwarding lambda. Replaced with a direct class reference, matching the `_ctor`/`_boom` pattern used by every other `serial.Serial` patch in this file. Test-only, no behavior change; 62 passed, `pose_tool.py` still 100%, ruff clean.