### PR TITLE
fix(simulation): ASCII-only output from MuJoCo Simulation tool methods

### DIFF
--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -109,7 +109,7 @@ class MuJoCoSimEngine(
     """Programmatic MuJoCo simulation environment as a Strands AgentTool.
 
     Gives AI agents the ability to create, modify, and control MuJoCo
-    simulation environments through natural language → tool actions.
+    simulation environments through natural language -> tool actions.
 
     **Stateful session.** One MuJoCo world per instance; actions form an
     implicit state machine starting with ``create_world``. Tools that mutate
@@ -366,14 +366,14 @@ class MuJoCoSimEngine(
             "content": [
                 {
                     "text": (
-                        "🌍 Simulation world created\n"
-                        f"⚙️ Timestep: {self._world.timestep}s ({1 / self._world.timestep:.0f}Hz physics)\n"
-                        f"🌐 Gravity: {self._world.gravity}\n"
-                        f"📷 Default camera ready\n"
-                        f"🤖 Robot models: {self._cheap_robot_count()} available\n"
-                        "💡 Add robots: action='add_robot' (urdf_path or data_config)\n"
-                        "💡 Add objects: action='add_object'\n"
-                        "💡 List URDFs: action='list_urdfs'"
+                        "Simulation world created\n"
+                        f"Timestep: {self._world.timestep}s ({1 / self._world.timestep:.0f}Hz physics)\n"
+                        f"Gravity: {self._world.gravity}\n"
+                        f"Default camera ready\n"
+                        f"Robot models: {self._cheap_robot_count()} available\n"
+                        "Add robots: action='add_robot' (urdf_path or data_config)\n"
+                        "Add objects: action='add_object'\n"
+                        "List URDFs: action='list_urdfs'"
                     )
                 }
             ],
@@ -445,9 +445,9 @@ class MuJoCoSimEngine(
                 "content": [
                     {
                         "text": (
-                            f"🌍 Scene loaded from {os.path.basename(scene_path)}\n"
-                            f"🦴 Bodies: {self._world._model.nbody}, 🔩 Joints: {self._world._model.njnt}, ⚡ Actuators: {self._world._model.nu}\n"
-                            "💡 Use action='get_state' to inspect, action='step' to simulate"
+                            f"Scene loaded from {os.path.basename(scene_path)}\n"
+                            f"Bodies: {self._world._model.nbody}, Joints: {self._world._model.njnt}, Actuators: {self._world._model.nu}\n"
+                            "Use action='get_state' to inspect, action='step' to simulate"
                         )
                     }
                 ],
@@ -490,9 +490,9 @@ class MuJoCoSimEngine(
             "content": [
                 {
                     "text": (
-                        f"🔄 Scene replaced via raw MJCF\n"
-                        f"🦴 Bodies: {model.nbody}, 🔩 Joints: {model.njnt}, ⚡ Actuators: {model.nu}, 📷 Cameras: {model.ncam}\n"
-                        "⚠️ world.robots / world.objects / world.cameras registries were NOT updated - "
+                        f"Scene replaced via raw MJCF\n"
+                        f"Bodies: {model.nbody}, Joints: {model.njnt}, Actuators: {model.nu}, Cameras: {model.ncam}\n"
+                        "Warning: world.robots / world.objects / world.cameras registries were NOT updated - "
                         "they describe our previous Python-side view of the scene."
                     )
                 }
@@ -533,9 +533,9 @@ class MuJoCoSimEngine(
             "content": [
                 {
                     "text": (
-                        f"🩹 Patched scene: {applied} op(s) applied\n"
-                        f"🦴 Bodies: {model.nbody}, 🔩 Joints: {model.njnt}, ⚡ Actuators: {model.nu}, 📷 Cameras: {model.ncam}\n"
-                        "⚠️ world.robots / world.objects / world.cameras registries were NOT updated."
+                        f"Patched scene: {applied} op(s) applied\n"
+                        f"Bodies: {model.nbody}, Joints: {model.njnt}, Actuators: {model.nu}, Cameras: {model.ncam}\n"
+                        "Warning: world.robots / world.objects / world.cameras registries were NOT updated."
                     )
                 }
             ],
@@ -779,7 +779,7 @@ class MuJoCoSimEngine(
                     "status": "error",
                     "content": [
                         {
-                            "text": f"No model found for '{data_config}'.\n💡 Use action='list_urdfs' to see available robots"
+                            "text": f"No model found for '{data_config}'.\nUse action='list_urdfs' to see available robots"
                         }
                     ],
                 }
@@ -887,23 +887,23 @@ class MuJoCoSimEngine(
             self._attach_robot_to_mesh(robot)
 
             source = f"data_config='{data_config}'" if data_config else os.path.basename(resolved_path)
-            mesh_line = f"\n🌐 Mesh peer: {robot.peer_id}" if robot.peer_id else ""
+            mesh_line = f"\nMesh peer: {robot.peer_id}" if robot.peer_id else ""
             hint = getattr(self, "_add_robot_deprecation_hint", None)
             self._add_robot_deprecation_hint = None
-            hint_line = f"\n⚠️ {hint}" if hint else ""
+            hint_line = f"\nWarning: {hint}" if hint else ""
             return {
                 "status": "success",
                 "content": [
                     {
                         "text": (
-                            f"🤖 Robot '{name}' added to simulation\n"
-                            f"📁 Source: {source} → {os.path.basename(resolved_path)}\n"
-                            f"📍 Position: {robot.position}\n"
-                            f"🔩 Joints: {len(robot.joint_names)} ({', '.join(robot.joint_names[:8])}{'...' if len(robot.joint_names) > 8 else ''})\n"
-                            f"⚡ Actuators: {len(robot.actuator_ids)}\n"
-                            f"📷 Cameras: {list(self._world.cameras.keys())}"
+                            f"Robot '{name}' added to simulation\n"
+                            f"Source: {source} -> {os.path.basename(resolved_path)}\n"
+                            f"Position: {robot.position}\n"
+                            f"Joints: {len(robot.joint_names)} ({', '.join(robot.joint_names[:8])}{'...' if len(robot.joint_names) > 8 else ''})\n"
+                            f"Actuators: {len(robot.actuator_ids)}\n"
+                            f"Cameras: {list(self._world.cameras.keys())}"
                             f"{mesh_line}\n"
-                            f"💡 Run policy: action='run_policy', robot_name='{name}'"
+                            f"Run policy: action='run_policy', robot_name='{name}'"
                             f"{hint_line}"
                         )
                     }
@@ -968,7 +968,7 @@ class MuJoCoSimEngine(
                 "content": [{"text": f"Failed to eject robot '{name}' from scene."}],
             }
 
-        return {"status": "success", "content": [{"text": f"🗑️ Robot '{name}' removed."}]}
+        return {"status": "success", "content": [{"text": f"Robot '{name}' removed."}]}
 
     def list_robots(self) -> list[str]:
         """Return ordered robot names (SimEngine ABC).
@@ -999,11 +999,11 @@ class MuJoCoSimEngine(
         if not self._world.robots:
             return {"status": "success", "content": [{"text": "No robots. Use action='add_robot'."}]}
 
-        lines = ["🤖 Robots in simulation:\n"]
+        lines = ["Robots in simulation:\n"]
         for name, robot in self._world.robots.items():
-            status = "🟢 running" if robot.policy_running else "⚪ idle"
+            status = "running" if robot.policy_running else "idle"
             lines.append(
-                f"  • {name} ({os.path.basename(robot.urdf_path)})\n"
+                f"  - {name} ({os.path.basename(robot.urdf_path)})\n"
                 f"    Position: {robot.position}, Joints: {len(robot.joint_names)}, "
                 f"Config: {robot.data_config or 'direct'}, Status: {status}"
             )
@@ -1068,7 +1068,7 @@ class MuJoCoSimEngine(
                     "velocity": float(data.qvel[model.jnt_dofadr[jnt_id]]),
                 }
 
-        text = f"🤖 '{robot_name}' state (t={self._world.sim_time:.3f}s):\n"
+        text = f"'{robot_name}' state (t={self._world.sim_time:.3f}s):\n"
         for jnt, vals in state.items():
             text += f"{jnt}: pos={vals['position']:.4f}, vel={vals['velocity']:.4f}\n"
 
@@ -1149,7 +1149,7 @@ class MuJoCoSimEngine(
             "status": "success",
             "content": [
                 {
-                    "text": f"📦 '{name}' added: {shape} at {obj.position}, size={obj.size}, {'static' if is_static else f'{mass}kg'}"
+                    "text": f"'{name}' added: {shape} at {obj.position}, size={obj.size}, {'static' if is_static else f'{mass}kg'}"
                 }
             ],
         }
@@ -1163,7 +1163,7 @@ class MuJoCoSimEngine(
         # spec-based path: eject_body_from_scene looks up the body in the
         # live MjSpec, deletes it, and recompiles preserving remaining state.
         eject_body_from_scene(self._world, name)
-        return {"status": "success", "content": [{"text": f"🗑️ '{name}' removed."}]}
+        return {"status": "success", "content": [{"text": f"'{name}' removed."}]}
 
     def move_object(
         self, name: str, position: list[float] | None = None, orientation: list[float] | None = None
@@ -1190,7 +1190,7 @@ class MuJoCoSimEngine(
                 self._world.objects[name].orientation = orientation
             mj.mj_forward(model, data)
 
-        return {"status": "success", "content": [{"text": f"📍 '{name}' moved to {position or 'same'}"}]}
+        return {"status": "success", "content": [{"text": f"'{name}' moved to {position or 'same'}"}]}
 
     def list_objects(self) -> dict[str, Any]:
         if self._world is None or self._world._model is None or self._world._data is None:
@@ -1198,9 +1198,9 @@ class MuJoCoSimEngine(
         if not self._world.objects:
             return {"status": "success", "content": [{"text": "No objects."}]}
 
-        lines = ["📦 Objects:\n"]
+        lines = ["Objects:\n"]
         for name, obj in self._world.objects.items():
-            lines.append(f"  • {name}: {obj.shape} at {obj.position}, {'static' if obj.is_static else f'{obj.mass}kg'}")
+            lines.append(f"  - {name}: {obj.shape} at {obj.position}, {'static' if obj.is_static else f'{obj.mass}kg'}")
         return {"status": "success", "content": [{"text": "\n".join(lines)}]}
 
     # Camera Management
@@ -1325,7 +1325,7 @@ class MuJoCoSimEngine(
             }
 
         mount_note = f" (mounted on '{parent_body}')" if parent_body else ""
-        return {"status": "success", "content": [{"text": f"📷 Camera '{name}' added at {cam.position}{mount_note}"}]}
+        return {"status": "success", "content": [{"text": f"Camera '{name}' added at {cam.position}{mount_note}"}]}
 
     def remove_camera(self, name: str) -> dict[str, Any]:
         """Remove a named camera from the live scene.
@@ -1356,7 +1356,7 @@ class MuJoCoSimEngine(
             except (ValueError, RuntimeError) as e:
                 logger.warning("remove_camera recompile failed: %s", e)
 
-        return {"status": "success", "content": [{"text": f"🗑️ Camera '{name}' removed."}]}
+        return {"status": "success", "content": [{"text": f"Camera '{name}' removed."}]}
 
     # Simulation Control
 
@@ -1381,7 +1381,7 @@ class MuJoCoSimEngine(
             return {
                 "status": "success",
                 "content": [
-                    {"text": f"⏩ +0 steps (no-op) | t={self._world.sim_time:.4f}s | total={self._world.step_count}"}
+                    {"text": f"+0 steps (no-op) | t={self._world.sim_time:.4f}s | total={self._world.step_count}"}
                 ],
             }
         if n_steps > self._MAX_STEPS_PER_CALL:
@@ -1407,9 +1407,7 @@ class MuJoCoSimEngine(
             remaining -= batch
         return {
             "status": "success",
-            "content": [
-                {"text": f"⏩ +{n_steps} steps | t={self._world.sim_time:.4f}s | total={self._world.step_count}"}
-            ],
+            "content": [{"text": f"+{n_steps} steps | t={self._world.sim_time:.4f}s | total={self._world.step_count}"}],
         }
 
     def reset(self) -> dict[str, Any]:
@@ -1429,23 +1427,23 @@ class MuJoCoSimEngine(
             for r in self._world.robots.values():
                 r.policy_running = False
                 r.policy_steps = 0
-        return {"status": "success", "content": [{"text": "🔄 Reset to initial state."}]}
+        return {"status": "success", "content": [{"text": "Reset to initial state."}]}
 
     def get_state(self) -> dict[str, Any]:
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
         lines = [
-            "🌍 Simulation State",
-            f"🕐 t={self._world.sim_time:.4f}s (step {self._world.step_count})",
-            f"⚙️ dt={self._world.timestep}s | 🌐 g={self._world.gravity}",
-            f"🤖 Robots: {len(self._world.robots)} | 📦 Objects: {len(self._world.objects)} | 📷 Cameras: {len(self._world.cameras)}",
+            "Simulation State",
+            f"t={self._world.sim_time:.4f}s (step {self._world.step_count})",
+            f"dt={self._world.timestep}s | g={self._world.gravity}",
+            f"Robots: {len(self._world.robots)} | Objects: {len(self._world.objects)} | Cameras: {len(self._world.cameras)}",
         ]
         if self._world._model:
             lines.append(
-                f"🦴 Bodies: {self._world._model.nbody} | 🔩 Joints: {self._world._model.njnt} | ⚡ Actuators: {self._world._model.nu}"
+                f"Bodies: {self._world._model.nbody} | Joints: {self._world._model.njnt} | Actuators: {self._world._model.nu}"
             )
         if self._world._backend_state.get("recording", False):
-            lines.append(f"🔴 Recording: {len(self._world._backend_state['trajectory'])} steps")
+            lines.append(f"[recording] {len(self._world._backend_state['trajectory'])} steps")
         return {"status": "success", "content": [{"text": "\n".join(lines)}]}
 
     def destroy(self) -> dict[str, Any]:
@@ -1458,7 +1456,7 @@ class MuJoCoSimEngine(
         if self._world is None:
             return {"status": "success", "content": [{"text": "No world to destroy."}]}
         self.cleanup()
-        return {"status": "success", "content": [{"text": "🗑️ World destroyed."}]}
+        return {"status": "success", "content": [{"text": "World destroyed."}]}
 
     def _close_main_thread_renderers(self) -> None:
         """Close any renderers this thread owns and drop the TLS cache.
@@ -1514,7 +1512,7 @@ class MuJoCoSimEngine(
         with self._lock:
             self._world._model.opt.gravity[:] = gravity
             self._world.gravity = gravity
-        return {"status": "success", "content": [{"text": f"🌐 Gravity: {gravity}"}]}
+        return {"status": "success", "content": [{"text": f"Gravity: {gravity}"}]}
 
     def set_timestep(self, timestep: float) -> dict[str, Any]:
         if self._world is None or self._world._model is None or self._world._data is None:
@@ -1536,11 +1534,11 @@ class MuJoCoSimEngine(
             }
         warn = ""
         if timestep > 0.1:
-            warn = f" ⚠️ unusually large timestep (>{0.1}s); physics may be unstable"
+            warn = f" Warning: unusually large timestep (>{0.1}s); physics may be unstable"
         with self._lock:
             self._world._model.opt.timestep = timestep
             self._world.timestep = timestep
-        return {"status": "success", "content": [{"text": f"⏱️ Timestep: {timestep}s ({1 / timestep:.0f}Hz){warn}"}]}
+        return {"status": "success", "content": [{"text": f"Timestep: {timestep}s ({1 / timestep:.0f}Hz){warn}"}]}
 
     # Viewer
 
@@ -1552,10 +1550,10 @@ class MuJoCoSimEngine(
         if _mujoco_viewer is None:
             return {"status": "error", "content": [{"text": "mujoco.viewer not available."}]}
         if self._viewer_handle is not None:
-            return {"status": "success", "content": [{"text": "👁️ Viewer already open."}]}
+            return {"status": "success", "content": [{"text": "Viewer already open."}]}
         try:
             self._viewer_handle = _mujoco_viewer.launch_passive(self._world._model, self._world._data)
-            return {"status": "success", "content": [{"text": "👁️ Interactive viewer opened."}]}
+            return {"status": "success", "content": [{"text": "Interactive viewer opened."}]}
         except Exception as e:
             return {"status": "error", "content": [{"text": f"Viewer failed: {e}"}]}
 
@@ -1569,7 +1567,7 @@ class MuJoCoSimEngine(
 
     def close_viewer(self) -> dict[str, Any]:
         self._close_viewer()
-        return {"status": "success", "content": [{"text": "👁️ Viewer closed."}]}
+        return {"status": "success", "content": [{"text": "Viewer closed."}]}
 
     # URDF Registry
 
@@ -1614,7 +1612,7 @@ class MuJoCoSimEngine(
         resolved = resolve_model(data_config)
         return {
             "status": "success",
-            "content": [{"text": f"📋 Registered '{data_config}' → {urdf_path}\nResolved: {resolved or 'NOT FOUND'}"}],
+            "content": [{"text": f"Registered '{data_config}' -> {urdf_path}\nResolved: {resolved or 'NOT FOUND'}"}],
         }
 
     # Introspection
@@ -1695,16 +1693,14 @@ class MuJoCoSimEngine(
         }
 
         lines = [
-            "🔍 Simulation Features",
-            f"🦴 Joints ({model.njnt}): {', '.join(joint_names[:12])}{'...' if len(joint_names) > 12 else ''}",
-            f"⚡ Actuators ({model.nu}): {', '.join(actuator_names[:12])}{'...' if len(actuator_names) > 12 else ''}",
-            f"📷 Cameras ({model.ncam}): {', '.join(camera_names) if camera_names else 'none (free camera only)'}",
-            f"⏱️ Timestep: {model.opt.timestep}s ({1 / model.opt.timestep:.0f}Hz)",
+            "Simulation Features",
+            f"Joints ({model.njnt}): {', '.join(joint_names[:12])}{'...' if len(joint_names) > 12 else ''}",
+            f"Actuators ({model.nu}): {', '.join(actuator_names[:12])}{'...' if len(actuator_names) > 12 else ''}",
+            f"Cameras ({model.ncam}): {', '.join(camera_names) if camera_names else 'none (free camera only)'}",
+            f"Timestep: {model.opt.timestep}s ({1 / model.opt.timestep:.0f}Hz)",
         ]
         for rname, rinfo in robots_info.items():
-            lines.append(
-                f"🤖 {rname}: {rinfo['n_joints']} joints, {rinfo['n_actuators']} actuators ({rinfo['source']})"
-            )
+            lines.append(f"{rname}: {rinfo['n_joints']} joints, {rinfo['n_actuators']} actuators ({rinfo['source']})")
 
         return {
             "status": "success",
@@ -1859,7 +1855,7 @@ class MuJoCoSimEngine(
                 "is running - stop it first. Create worlds, add robots from URDF "
                 "(direct path or auto-resolve from data_config name), add objects, run VLA policies, "
                 "render cameras, record trajectories, domain randomize. "
-                "Same Policy ABC as real robot control - sim ↔ real with zero code changes. "
+                "Same Policy ABC as real robot control - sim and real with zero code changes. "
                 "Actions (61 total): "
                 "[World] create_world, load_scene, reset, get_state, destroy, export_xml; "
                 "[Robots] add_robot, remove_robot, list_robots, get_robot_state; "
@@ -1975,7 +1971,7 @@ class MuJoCoSimEngine(
 
         return {
             "status": "success",
-            "content": [{"text": f"🚀 Policy started on '{robot_name}' (async)"}],
+            "content": [{"text": f"Policy started on '{robot_name}' (async)"}],
         }
 
     def _make_run_policy_hook(self, robot_name: str, instruction: str):
@@ -2032,7 +2028,7 @@ class MuJoCoSimEngine(
                         # keys, finds nothing, and writes all-zero state/action
                         # vectors silently. Prefix scalar obs + action keys to match
                         # the schema. Camera values (ndarray) keep their (already
-                        # namespaced) names - dataset_recorder normalizes '/'→'__'.
+                        # namespaced) names - dataset_recorder normalizes '/'->'__'.
                         if len(world.robots) > 1:
                             obs_keyed = {
                                 (k if isinstance(v, np.ndarray) else f"{robot_name}__{k}"): v
@@ -2129,7 +2125,7 @@ class MuJoCoSimEngine(
         2. Queries each robot's policy for its action.
         3. Applies every robot's ctrl writes, then steps physics ONCE.
         4. Records ONE frame containing ALL robots' prefixed state/action
-           (``alice__shoulder_pan`` …) plus all camera images.
+           (``alice__shoulder_pan`` ...) plus all camera images.
 
         So a 2-robot dataset has both arms co-observed in every frame - usable
         for bimanual / multi-agent policy training.
@@ -2141,7 +2137,7 @@ class MuJoCoSimEngine(
                 robots, or a ``{robot_name: instruction}`` mapping. The frame's
                 recorded task is the first robot's instruction (LeRobot stores
                 one task per frame).
-            duration: Episode length in seconds (steps = duration × freq).
+            duration: Episode length in seconds (steps = duration x freq).
             control_frequency: Target Hz for policy action queries / physics.
             action_horizon: How many actions to consume from each policy's
                 returned chunk before re-querying it (open-loop chunk
@@ -2619,12 +2615,12 @@ class MuJoCoSimEngine(
         if not active:
             return {
                 "status": "success",
-                "content": [{"text": "⚪ No policies running."}],
+                "content": [{"text": "No policies running."}],
             }
-        robot_lines = "\n".join(f"  • 🟢 {n}" for n in active)
+        robot_lines = "\n".join(f"  - {n}" for n in active)
         return {
             "status": "success",
-            "content": [{"text": f"🟢 Active policies ({len(active)}):\n{robot_lines}"}],
+            "content": [{"text": f"Active policies ({len(active)}):\n{robot_lines}"}],
         }
 
     # Cleanup

--- a/tests/simulation/mujoco/test_agenttool_contract.py
+++ b/tests/simulation/mujoco/test_agenttool_contract.py
@@ -564,7 +564,7 @@ class TestListRobotsPolicyStatus:
         r = sim._dispatch_action("list_robots", {})
         assert r["status"] == "success"
         # No robots added, so we just expect the "No robots" message.
-        assert "No robots" in r["content"][0]["text"] or "🤖" in r["content"][0]["text"]
+        assert "No robots" in r["content"][0]["text"]
 
 
 class TestPolicyHorizonUnification:

--- a/tests/simulation/mujoco/test_input_validation.py
+++ b/tests/simulation/mujoco/test_input_validation.py
@@ -160,7 +160,7 @@ class TestMassAndTimestepValidation:
     def test_set_timestep_large_warns_but_succeeds(self, sim_with_world):
         res = sim_with_world.set_timestep(0.5)
         assert res["status"] == "success"
-        assert "⚠️" in res["content"][0]["text"] or "unusually" in res["content"][0]["text"]
+        assert "Warning:" in res["content"][0]["text"] and "unusually" in res["content"][0]["text"]
 
     def test_set_timestep_nan_errors(self, sim_with_world):
         """NaN must not pass the positivity guard (nan <= 0 is False)."""

--- a/tests/simulation/mujoco/test_simulation.py
+++ b/tests/simulation/mujoco/test_simulation.py
@@ -1043,3 +1043,59 @@ class TestRecordingSafeCameraNames:
         assert r["status"] == "success", r
         # cleanup - don't leave a dangling recorder on the fixture
         sim_with_robot._dispatch_action("stop_recording", {})
+
+
+class TestSimulationOutputIsAscii:
+    """Tool output must be ASCII-only (AGENTS.md: no emojis in code/logs/errors).
+
+    Agent-tool ``text`` payloads are surfaced to the model and into logs;
+    decorative emoji (robot/world glyphs, status dots, bullets) break the
+    project's ASCII-only contract and render inconsistently across terminals.
+    These tests drive the common lifecycle, scene-mutation, physics and
+    policy-listing methods and assert every returned ``text`` is ``isascii()``.
+    """
+
+    @staticmethod
+    def _texts(result):
+        return "".join(item.get("text", "") for item in result.get("content", []))
+
+    def test_create_world_output_is_ascii(self, sim):
+        assert self._texts(sim.create_world()).isascii()
+
+    def test_get_state_output_is_ascii(self, sim_with_world):
+        assert self._texts(sim_with_world.get_state()).isascii()
+
+    def test_reset_output_is_ascii(self, sim_with_world):
+        assert self._texts(sim_with_world.reset()).isascii()
+
+    def test_set_gravity_and_timestep_output_is_ascii(self, sim_with_world):
+        assert self._texts(sim_with_world.set_gravity([0, 0, -3.0])).isascii()
+        # Large timestep takes the warning branch - it too must be ASCII.
+        large = sim_with_world.set_timestep(0.5)
+        text = self._texts(large)
+        assert text.isascii()
+        assert "Warning:" in text and "unusually" in text
+
+    def test_step_output_is_ascii(self, sim_with_world):
+        assert self._texts(sim_with_world.step(0)).isascii()
+        assert self._texts(sim_with_world.step(3)).isascii()
+
+    def test_destroy_output_is_ascii(self, sim_with_world):
+        assert self._texts(sim_with_world.destroy()).isascii()
+
+    def test_add_robot_and_listing_output_is_ascii(self, sim_with_robot):
+        # add_robot text was emitted by the fixture; re-exercise the
+        # introspection surfaces that format robot/joint/camera summaries.
+        assert self._texts(sim_with_robot.list_robots_info()).isascii()
+        assert self._texts(sim_with_robot.get_robot_state("arm1")).isascii()
+        assert self._texts(sim_with_robot.get_features()).isascii()
+
+    def test_object_lifecycle_output_is_ascii(self, sim_with_world):
+        added = sim_with_world.add_object("box1", shape="box", position=[0.3, 0, 0.1])
+        assert self._texts(added).isascii()
+        assert self._texts(sim_with_world.list_objects()).isascii()
+        assert self._texts(sim_with_world.move_object("box1", position=[0.4, 0, 0.1])).isascii()
+        assert self._texts(sim_with_world.remove_object("box1")).isascii()
+
+    def test_list_policies_running_output_is_ascii(self, sim_with_robot):
+        assert self._texts(sim_with_robot.list_policies_running()).isascii()


### PR DESCRIPTION
## Problem
The MuJoCo `Simulation` agent-tool methods emitted decorative emoji (robot/world/camera glyphs, status dots, bullets) plus a few non-ASCII punctuation marks in their returned `text` payloads. Those strings are surfaced to the model and into logs, where emoji render inconsistently across terminals and violate the project's ASCII-only convention - the same one already enforced for the recording lifecycle (#481), `lerobot_camera` (#463), `pose_tool` (#461), `serial_tool` (#451) and `Robot.run` (#478). `simulation.py` was the largest remaining offender (64 occurrences across ~50 output strings).

## Change
Replace the glyphs with plain ASCII, following the established idiom from the prior ASCII PRs:
- status markers -> `[recording]`, `running`/`idle`
- warnings -> `Warning:` prefix
- list bullets -> `- `
- arrows -> `->`

Only the text content changes; status codes, dict structure and control flow are untouched.

### After (sample tool output, now ASCII)
```
Robot 'arm1' added to simulation
Source: data_config='so101' -> scene.xml
Position: [0.0, 0.0, 0.0]
Joints: 6 (1, 2, 3, 4, 5, 6)
Actuators: 6
Cameras: ['default']

Simulation State
t=0.0000s (step 0)
dt=0.002s | g=[0, 0, -9.81]
Robots: 1 | Objects: 0 | Cameras: 1
Bodies: 8 | Joints: 6 | Actuators: 6

Timestep: 0.5s (2Hz) Warning: unusually large timestep (>0.1s); physics may be unstable
```
Before, the same lines were prefixed with robot/world/gear/warning emoji.

## Tests
Added `TestSimulationOutputIsAscii` driving the lifecycle, scene-mutation, physics and policy-listing surfaces and asserting every returned `text` is `isascii()`. The class fails 9/9 on the pre-fix module and passes after. Two existing tests that accepted the emoji as one `or` branch are tightened to the ASCII form.

```
239 passed, 5 deselected   # test_simulation.py + agenttool_contract + input_validation + video_camera_validation
```
Local gate clean: `ruff check`, `ruff format --check`, and the changed module/tests pass under `MUJOCO_GL=egl`.

## Visual proof
Mock-policy rollout on the so101 arm in MuJoCo (headless EGL), confirming the tool surface drives a full sim loop with the new ASCII output:

![rollout](https://github.com/cagataycali/robots/releases/download/ascii-demo-1781885135/ascii_demo.gif)

[mp4](https://github.com/cagataycali/robots/releases/download/ascii-demo-1781885135/ascii_demo.mp4)