### PR TITLE
fix(simulation): validate start_policy step horizon synchronously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,22 @@ resolves lerobot 0.5.1, which lacks it.
   directly and the git-source step drops away.
 
 
+### Fixed: `start_policy` validates the step horizon synchronously
+
+`start_policy` runs the rollout on a background thread. A malformed step
+horizon (`n_steps <= 0` or `control_frequency <= 0`) was only caught inside
+`run_policy` once the future executed, so the caller received a false
+`status="success"` ("Policy started") while the rollout immediately errored in
+the background - and the robot was left registered as having a running policy,
+wrongly gating the next `start_policy` on that robot as "already running".
+
+- The horizon validation (`n_steps`/legacy `max_steps` -> `duration`, with the
+  non-positive guards) is now a shared `SimEngine._resolve_horizon` helper used
+  by both `run_policy` and the MuJoCo `start_policy` override. `start_policy`
+  calls it synchronously before submitting to the executor, returning the same
+  structured `status="error"` dict and leaving no future registered, so a
+  subsequent well-formed `start_policy` on the same robot succeeds.
+
 ### Added: `WBCPolicy` provider (`wbc`, shorthand `sonic`) - GR00T Whole-Body-Control (SONIC)
 
 A new non-VLA policy provider wrapping NVIDIA's GR00T Whole-Body-Control

--- a/docs/simulation/overview.md
+++ b/docs/simulation/overview.md
@@ -97,6 +97,8 @@ Robot-URDF cameras are auto-discovered on `add_robot`.
 | `run_multi_policy` | `policies={robot: Policy}`, `instructions`, `duration`, `n_steps` |
 | `eval_policy` | `robot_name` (required), `n_episodes=1`, `max_steps=300`, `success_fn=None` |
 
+The step horizon is given either as `duration` (seconds) or as `n_steps` (`duration = n_steps / control_frequency`; `n_steps` wins when both are set, and the legacy `max_steps` is an alias for `n_steps`). A non-positive `n_steps` or `control_frequency` is rejected up front with a structured `status="error"` dict naming the bad parameter - `start_policy` validates synchronously before the background rollout starts, so a malformed horizon never returns a false "started" success.
+
 Pass `seed=` to `run_policy` / `start_policy` for a reproducible single rollout: it reseeds Python / NumPy / torch / cuDNN and forwards `policy.reset(seed=...)`, so a stochastic policy (VLA action-chunk sampling, diffusion noise) produces the same trajectory on re-run of the same scene. Without a seed the rollout draws from the process-global RNG and can differ run to run. `eval_policy` already seeds per episode via the same mechanism.
 | `replay_episode` | `repo_id`, `robot_name=None`, `episode=0` |
 

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -293,6 +293,61 @@ class SimEngine(ABC):
 
     # Policy orchestration (concrete facade, not abstract)
 
+    @staticmethod
+    def _resolve_horizon(
+        n_steps: int | None,
+        max_steps: int | None,
+        control_frequency: float,
+        duration: float,
+    ) -> tuple[float, int | None, dict[str, Any] | None]:
+        """Resolve a step horizon into a wall-clock duration.
+
+        ``n_steps`` (primary) or the legacy ``max_steps`` alias specify the
+        rollout length as a step count; ``duration = n_steps / control_frequency``.
+        ``n_steps`` wins when both are passed. The inputs are validated before
+        the division so a non-positive horizon or frequency is reported as a
+        caller error rather than silently producing a no-op, a negative
+        duration, or a ``ZeroDivisionError``.
+
+        Args:
+            n_steps: Primary step-count horizon, or ``None``.
+            max_steps: Legacy alias, normalized to ``n_steps`` when ``n_steps``
+                is ``None``.
+            control_frequency: Target control-loop frequency in Hz.
+            duration: Fallback wall-clock duration used when no step horizon
+                is given.
+
+        Returns:
+            A ``(duration, n_steps, error)`` tuple. When ``error`` is non-None
+            it is a structured ``{"status": "error", ...}`` dict and the other
+            fields must be ignored. Otherwise ``duration`` is the resolved
+            wall-clock duration (recomputed from the horizon when one was
+            given) and ``n_steps`` is the normalized step count (or ``None``).
+        """
+        if n_steps is None and max_steps is not None:
+            n_steps = int(max_steps)
+        if n_steps is not None:
+            if n_steps <= 0:
+                return (
+                    duration,
+                    n_steps,
+                    {
+                        "status": "error",
+                        "content": [{"text": f"run_policy: n_steps must be > 0, got {n_steps}."}],
+                    },
+                )
+            if control_frequency <= 0:
+                return (
+                    duration,
+                    n_steps,
+                    {
+                        "status": "error",
+                        "content": [{"text": "run_policy: control_frequency must be > 0 when n_steps is used."}],
+                    },
+                )
+            duration = float(n_steps) / float(control_frequency)
+        return duration, n_steps, None
+
     def run_policy(
         self,
         robot_name: str | None = None,
@@ -370,20 +425,9 @@ class SimEngine(ABC):
         # accept n_steps (or legacy max_steps) as an alternate horizon
         # specification. duration = n_steps / control_frequency. If both
         # are passed, n_steps wins (primary per DoD).
-        if n_steps is None and max_steps is not None:
-            n_steps = int(max_steps)
-        if n_steps is not None:
-            if n_steps <= 0:
-                return {
-                    "status": "error",
-                    "content": [{"text": f"run_policy: n_steps must be > 0, got {n_steps}."}],
-                }
-            if control_frequency <= 0:
-                return {
-                    "status": "error",
-                    "content": [{"text": "run_policy: control_frequency must be > 0 when n_steps is used."}],
-                }
-            duration = float(n_steps) / float(control_frequency)
+        duration, n_steps, horizon_error = self._resolve_horizon(n_steps, max_steps, control_frequency, duration)
+        if horizon_error is not None:
+            return horizon_error
 
         if robot_name not in self.list_robots():
             return {

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1943,6 +1943,15 @@ class MuJoCoSimEngine(
         if err := self._require_no_running_policy("start_policy", robot_name=robot_name):
             return err
 
+        # Validate the step horizon synchronously, before submitting to the
+        # executor. run_policy runs on a background thread, so a malformed
+        # horizon (n_steps <= 0, control_frequency <= 0) would otherwise be
+        # reported only inside the future - the caller would receive a false
+        # "started" success and the robot would be left marked as running.
+        _, _, horizon_error = self._resolve_horizon(n_steps, max_steps, control_frequency, duration)
+        if horizon_error is not None:
+            return horizon_error
+
         # Concurrent multi-robot policies run on disjoint ctrl slices (physics
         # serialized by _lock). For SYNCHRONIZED multi-robot *recording* (both
         # robots captured in one merged frame per step), use run_multi_policy

--- a/tests/simulation/test_run_policy_horizon_validation.py
+++ b/tests/simulation/test_run_policy_horizon_validation.py
@@ -1,0 +1,125 @@
+"""Validation contracts for run_policy / start_policy / eval_policy horizons.
+
+These public Simulation methods accept a step-horizon (`n_steps`, with legacy
+`max_steps`) and a target `control_frequency`. The horizon is converted to a
+wall-clock `duration` via ``duration = n_steps / control_frequency``, so the
+inputs must be guarded before that division: a non-positive horizon or a
+non-positive frequency is a caller error, not a silent no-op or a ZeroDivision.
+
+Per the agent-tool contract every method returns a structured
+``{"status": ..., "content": [...]}`` dict rather than raising past dispatch,
+so each guard is asserted to return ``status="error"`` with an actionable,
+ASCII-only message naming the offending parameter. The legacy ``max_steps``
+alias is asserted to behave identically to ``n_steps`` (it is normalized to
+``n_steps`` before the guards run).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from strands_robots.simulation import create_simulation
+
+
+@pytest.fixture
+def sim():
+    s = create_simulation()
+    s.create_world()
+    s.add_robot("arm1", data_config="so100")
+    yield s
+    s.cleanup()
+
+
+@pytest.fixture
+def empty_sim():
+    s = create_simulation()
+    s.create_world()
+    yield s
+    s.cleanup()
+
+
+def _err_text(result: dict) -> str:
+    assert result["status"] == "error", result
+    return result["content"][0]["text"]
+
+
+class TestRunPolicyHorizonGuards:
+    """run_policy must reject malformed step horizons before stepping physics."""
+
+    @pytest.mark.parametrize("bad", [0, -1, -50])
+    def test_non_positive_n_steps_errors(self, sim, bad):
+        text = _err_text(sim.run_policy("arm1", n_steps=bad))
+        assert "n_steps must be > 0" in text
+        assert str(bad) in text
+
+    @pytest.mark.parametrize("bad_freq", [0, -10.0])
+    def test_non_positive_control_frequency_errors(self, sim, bad_freq):
+        # control_frequency is only validated on the n_steps path (it divides
+        # n_steps to produce a duration); a bad frequency there would otherwise
+        # raise ZeroDivisionError or yield a negative duration.
+        text = _err_text(sim.run_policy("arm1", n_steps=5, control_frequency=bad_freq))
+        assert "control_frequency must be > 0" in text
+
+    def test_legacy_max_steps_alias_is_validated_like_n_steps(self, sim):
+        # max_steps is normalized to n_steps before the guards, so a
+        # non-positive max_steps surfaces the same n_steps error.
+        text = _err_text(sim.run_policy("arm1", max_steps=0))
+        assert "n_steps must be > 0" in text
+
+    def test_error_message_is_ascii(self, sim):
+        text = _err_text(sim.run_policy("arm1", n_steps=-1))
+        text.encode("ascii")  # raises UnicodeEncodeError if any non-ASCII leaks
+
+    def test_guard_runs_before_robot_lookup(self, sim):
+        # A non-positive horizon is reported even when the robot name is also
+        # wrong: the horizon guard short-circuits ahead of the robot lookup,
+        # so the caller sees the horizon problem first.
+        text = _err_text(sim.run_policy("ghost", n_steps=0))
+        assert "n_steps must be > 0" in text
+
+
+class TestStartPolicyHorizonGuards:
+    """start_policy must validate the horizon synchronously.
+
+    start_policy runs the rollout on a background thread, so a malformed
+    horizon must be caught before submission. Otherwise the caller receives
+    a false "started" success while the rollout silently errors in the
+    future, and the robot is left marked as running.
+    """
+
+    def test_non_positive_n_steps_errors_synchronously(self, sim):
+        text = _err_text(sim.start_policy("arm1", n_steps=-1))
+        assert "n_steps must be > 0" in text
+
+    def test_non_positive_control_frequency_errors_synchronously(self, sim):
+        text = _err_text(sim.start_policy("arm1", n_steps=5, control_frequency=0))
+        assert "control_frequency must be > 0" in text
+
+    def test_rejected_start_does_not_mark_robot_running(self, sim):
+        # A rejected start must not leave a future registered for the robot,
+        # otherwise a subsequent valid start_policy is wrongly gated as
+        # "already running".
+        result = sim.start_policy("arm1", n_steps=0)
+        assert result["status"] == "error"
+        assert "arm1" not in sim._policy_threads
+        # A well-formed start on the same robot now succeeds.
+        ok = sim.start_policy("arm1", n_steps=2, control_frequency=50.0, fast_mode=True)
+        assert ok["status"] == "success", ok
+        sim.stop_policy("arm1")
+
+
+class TestEvalPolicyResolution:
+    """eval_policy requires an explicit, existing robot (no silent first-pick)."""
+
+    def test_missing_robot_name_errors(self, sim):
+        text = _err_text(sim.eval_policy())
+        assert "robot_name" in text
+
+    def test_unknown_robot_name_errors(self, sim):
+        text = _err_text(sim.eval_policy(robot_name="ghost"))
+        assert "ghost" in text
+        assert "not found" in text
+
+    def test_empty_world_reports_no_robots(self, empty_sim):
+        text = _err_text(empty_sim.eval_policy(robot_name="arm1"))
+        assert "No robots" in text


### PR DESCRIPTION
## What
`start_policy` now validates the step horizon synchronously, before the background rollout starts, so a malformed horizon can no longer return a false "started" success.

## Why
`start_policy` submits the rollout to a background `ThreadPoolExecutor` and returns immediately. The horizon validation (`n_steps`/legacy `max_steps` -> `duration`, with the non-positive guards) lived only in `run_policy`, which executes inside the future. So calling:

```python
sim.start_policy("arm1", n_steps=0)
```

returned `{"status": "success", "content": [{"text": "Policy started on 'arm1' (async)"}]}` to the caller, while the rollout immediately errored inside the future (`run_policy: n_steps must be > 0, got 0`). Worse, the robot was left registered in `_policy_threads`, so the per-robot gate then rejected the next `start_policy` on that robot as "already running" - a wedged robot from a call that looked like it succeeded.

## Change
- Extract the horizon resolution + validation into a shared `SimEngine._resolve_horizon(n_steps, max_steps, control_frequency, duration)` helper (`(duration, n_steps, error)` tuple). `run_policy` now calls it instead of inlining the logic - behavior is identical.
- The MuJoCo `start_policy` override calls `_resolve_horizon` synchronously after the robot-resolution checks and before submitting to the executor, returning the same structured `status="error"` dict and leaving no future registered. A subsequent well-formed `start_policy` on the same robot then succeeds.

No change to the happy path or to `run_policy`'s contract; the error text is unchanged.

## Tests
New `tests/simulation/test_run_policy_horizon_validation.py` covering the horizon and robot-resolution contracts for `run_policy`, `start_policy`, and `eval_policy`. The three `start_policy` synchronous-validation tests fail on pre-fix code (false `success`, robot left registered) and pass after. Asserts observable outputs only (status, message text, ASCII-only, `_policy_threads` membership), consistent with the existing suite.

## Verification
- `ruff check` + `ruff format --check` (`strands_robots tests tests_integ`): clean.
- `mypy` on the changed modules: clean.
- `MUJOCO_GL=egl pytest tests/simulation/`: 938 passed, 35 skipped.

## Rollout (MuJoCo sim, headless)
Happy path intact - a valid `n_steps=150 @ 50 Hz` rollout resolves to a 3 s duration and records a 90-frame video (mock policy, so100 arm):

![start_policy horizon rollout](https://github.com/cagataycali/robots/releases/download/demo-start-policy-horizon/start_policy_horizon_demo.gif)

MP4: https://github.com/cagataycali/robots/releases/download/demo-start-policy-horizon/start_policy_horizon_demo.mp4