### PR TITLE
test(policy_runner): cover degenerate empty-actions eval loop + contact/sim_time paths (86%->90%)

### DIFF
--- a/tests/simulation/test_policy_runner_benchmark.py
+++ b/tests/simulation/test_policy_runner_benchmark.py
@@ -1236,3 +1236,150 @@ class TestOnFrameHookForSpec:
         )
         assert result["status"] == "success", result
         assert len(captured) == 20, f"expected 20 calls via evaluate_benchmark plumbing, got {len(captured)}"
+
+
+# Degenerate (empty-actions) policy in the spec-driven eval loop
+
+
+class _EmptyActionsPolicy(MockPolicy):
+    """Policy that returns no actions - models a planner that fails to find a
+    plan or a VLA that emits an empty chunk. The eval loop must still advance
+    physics (``sim.step``) and run the spec's per-step bookkeeping so the
+    episode terminates instead of hanging.
+    """
+
+    async def get_actions(self, observation_dict, instruction, **kwargs):
+        return []
+
+
+class _DegenerateOutcomeBenchmark(BenchmarkProtocol):
+    """Counting benchmark whose success/failure/done can be tripped at a given
+    step. Used to exercise every sub-branch of the empty-actions path.
+    """
+
+    max_steps = 8
+
+    def __init__(self, *, success_after=10**9, fail_after=10**9, done_after=10**9):
+        self.success_after = success_after
+        self.fail_after = fail_after
+        self.done_after = done_after
+        self.on_step_calls = 0
+
+    @property
+    def supported_robots(self) -> list[str]:
+        return []  # empty → compatible with any robot
+
+    @property
+    def default_robot(self) -> str:
+        return "fake_robot"
+
+    def on_step(self, sim, obs, action):
+        self.on_step_calls += 1
+        return StepInfo(reward=1.0, done=self.on_step_calls >= self.done_after)
+
+    def is_success(self, sim):
+        return self.on_step_calls >= self.success_after
+
+    def is_failure(self, sim):
+        return self.on_step_calls >= self.fail_after
+
+
+class TestDegeneratePolicyInBenchmarkLoop:
+    """A policy returning empty actions must not stall the spec eval loop.
+
+    Covers the ``if not actions:`` branch in ``_evaluate_with_spec``: physics
+    is advanced once per step, ``on_step`` still runs, cumulative reward
+    accrues, and success / failure / done all terminate the episode.
+    """
+
+    def test_empty_actions_still_advance_and_run_on_step(self):
+        """No actions → loop runs to max_steps, on_step fires every step, the
+        empty-action path's ``action_applied`` (empty dict) reaches on_step.
+        """
+        sim = FakeSim()
+        policy = _EmptyActionsPolicy()
+        policy.set_robot_state_keys(sim.robot_joint_names("fake_robot"))
+        spec = _DegenerateOutcomeBenchmark()
+
+        result = PolicyRunner(sim).evaluate("fake_robot", policy, spec=spec, n_episodes=1, seed=7)
+
+        assert result["status"] == "success"
+        payload = next(c["json"] for c in result["content"] if "json" in c)
+        ep = payload["episodes"][0]
+        # max_steps=8, +1 reward/step, no early termination → 8 steps, reward 8.
+        assert ep["steps"] == 8
+        assert ep["cumulative_reward"] == pytest.approx(8.0)
+        assert ep["success"] is False
+        assert ep["failure"] is False
+        assert spec.on_step_calls == 8
+
+    def test_empty_actions_success_terminates_episode(self):
+        """``is_success`` tripping inside the empty-action path ends the episode
+        early and marks it successful.
+        """
+        sim = FakeSim()
+        policy = _EmptyActionsPolicy()
+        policy.set_robot_state_keys(sim.robot_joint_names("fake_robot"))
+        spec = _DegenerateOutcomeBenchmark(success_after=3)
+
+        result = PolicyRunner(sim).evaluate("fake_robot", policy, spec=spec, n_episodes=1, seed=7)
+
+        payload = next(c["json"] for c in result["content"] if "json" in c)
+        ep = payload["episodes"][0]
+        assert ep["success"] is True
+        assert ep["failure"] is False
+        assert ep["steps"] == 3
+
+    def test_empty_actions_failure_terminates_episode(self):
+        """``is_failure`` tripping inside the empty-action path ends the episode
+        early and marks it failed.
+        """
+        sim = FakeSim()
+        policy = _EmptyActionsPolicy()
+        policy.set_robot_state_keys(sim.robot_joint_names("fake_robot"))
+        spec = _DegenerateOutcomeBenchmark(fail_after=2)
+
+        result = PolicyRunner(sim).evaluate("fake_robot", policy, spec=spec, n_episodes=1, seed=7)
+
+        payload = next(c["json"] for c in result["content"] if "json" in c)
+        ep = payload["episodes"][0]
+        assert ep["failure"] is True
+        assert ep["success"] is False
+        assert ep["steps"] == 2
+
+    def test_empty_actions_done_terminates_episode(self):
+        """``StepInfo.done`` returned inside the empty-action path breaks the
+        loop without flagging success or failure.
+        """
+        sim = FakeSim()
+        policy = _EmptyActionsPolicy()
+        policy.set_robot_state_keys(sim.robot_joint_names("fake_robot"))
+        spec = _DegenerateOutcomeBenchmark(done_after=4)
+
+        result = PolicyRunner(sim).evaluate("fake_robot", policy, spec=spec, n_episodes=1, seed=7)
+
+        payload = next(c["json"] for c in result["content"] if "json" in c)
+        ep = payload["episodes"][0]
+        assert ep["steps"] == 4
+        assert ep["success"] is False
+        assert ep["failure"] is False
+
+    def test_empty_actions_on_step_error_surfaces_structured(self):
+        """If the spec's ``on_step`` raises in the empty-action path, the run
+        returns a structured error dict (never raises past the loop).
+        """
+
+        class _BoomOnStep(_DegenerateOutcomeBenchmark):
+            def on_step(self, sim, obs, action):
+                raise RuntimeError("on_step boom")
+
+        sim = FakeSim()
+        policy = _EmptyActionsPolicy()
+        policy.set_robot_state_keys(sim.robot_joint_names("fake_robot"))
+        spec = _BoomOnStep()
+
+        result = PolicyRunner(sim).evaluate("fake_robot", policy, spec=spec, n_episodes=1, seed=7)
+
+        assert result["status"] == "error"
+        assert "on_step failed" in result["content"][0]["text"]
+        assert "on_step boom" in result["content"][0]["text"]

--- a/tests/simulation/test_policy_runner_paths.py
+++ b/tests/simulation/test_policy_runner_paths.py
@@ -7,7 +7,9 @@ Covers:
 * ``replay()`` with actions that have ``.numpy()`` and ``.tolist()`` methods
   (tensor-backed dataset frames)
 * ``_extract_frame_ndarray`` handles render blocks without images
-* ``_resolve_success_fn`` "contact" with backend that raises NotImplementedError
+* ``_resolve_success_fn`` "contact" - raise, missing-hook, and positive
+  (n_contacts / contacts-list) detection paths
+* ``_maybe_sim_time`` get_state() fallback (nested ``content[].json.sim_time``)
 * ``evaluate()`` "never-succeeds" default path (no success_fn)
 """
 
@@ -225,3 +227,78 @@ def test_evaluate_none_success_fn_gives_zero_success_rate():
         if isinstance(c, dict) and "json" in c:
             assert c["json"]["success_rate"] == 0.0
             break
+
+
+# ── _maybe_sim_time get_state() fallback ─────────────────────────────
+
+
+def test_maybe_sim_time_reads_from_get_state_content_json():
+    """Backends with no structured ``_world`` expose sim time via the
+    status-dict ``content[].json.sim_time`` shape. ``_maybe_sim_time`` must
+    dig it out of that nested block.
+    """
+
+    class _StatusDictSim(_MinimalSim):
+        # No ``_world`` attr → forces the get_state() fallback path.
+        _world = None
+
+        def get_state(self):
+            return {"content": [{"text": "ok"}, {"json": {"sim_time": 1.25}}]}
+
+    t = PolicyRunner(_StatusDictSim(robots=["r0"]))._maybe_sim_time()
+    assert t == 1.25
+
+
+def test_maybe_sim_time_get_state_without_sim_time_returns_none():
+    """A status dict with no ``sim_time`` anywhere yields None (not a crash)."""
+
+    class _NoTimeSim(_MinimalSim):
+        _world = None
+
+        def get_state(self):
+            return {"content": [{"json": {"step_count": 3}}]}
+
+    assert PolicyRunner(_NoTimeSim(robots=["r0"]))._maybe_sim_time() is None
+
+
+# ── _resolve_success_fn "contact" positive detection ─────────────────
+
+
+def test_contact_success_fn_true_on_n_contacts():
+    """``success_fn="contact"`` reports success when the backend's
+    ``get_contacts`` returns a positive ``n_contacts`` count.
+    """
+
+    class _ContactSim(_MinimalSim):
+        def get_contacts(self):
+            return {"n_contacts": 2}
+
+    sim = _ContactSim(robots=["r0"])
+    fn = PolicyRunner(sim)._resolve_success_fn("contact")
+    assert fn is not None
+    assert fn({}) is True
+
+
+def test_contact_success_fn_true_on_contacts_list():
+    """``success_fn="contact"`` also accepts the ``{"contacts": [...]}`` shape."""
+
+    class _ContactListSim(_MinimalSim):
+        def get_contacts(self):
+            return {"contacts": [{"a": "hand", "b": "cube"}]}
+
+    sim = _ContactListSim(robots=["r0"])
+    fn = PolicyRunner(sim)._resolve_success_fn("contact")
+    assert fn({}) is True
+
+
+def test_contact_success_fn_false_when_no_get_contacts():
+    """When the backend has no ``get_contacts`` at all, contact detection is
+    a safe no-op returning False (rather than AttributeError).
+    """
+
+    class _NoContactsSim(_MinimalSim):
+        get_contacts = None
+
+    sim = _NoContactsSim(robots=["r0"])
+    fn = PolicyRunner(sim)._resolve_success_fn("contact")
+    assert fn({}) is False


### PR DESCRIPTION
## What
Adds focused tests for previously-untested behaviour in `PolicyRunner`'s spec-driven `evaluate` loop and two adjacent helper paths. No production code changes.

### Degenerate (empty-actions) policy in the benchmark eval loop
When a policy returns an empty action list (a motion planner that finds no plan, or a VLA that emits an empty chunk), the eval loop's `if not actions:` branch was uncovered. The new `TestDegeneratePolicyInBenchmarkLoop` pins that physics still advances and the spec's per-step bookkeeping runs so the episode terminates instead of hanging:
- runs to `max_steps` with `on_step` firing each step and cumulative reward accruing;
- `is_success` / `is_failure` / `StepInfo.done` each terminate the episode early from inside the empty-action path;
- an `on_step` exception in that path surfaces as a structured error dict rather than propagating.

### Adjacent helper gaps (same module)
- `_maybe_sim_time` get_state() fallback that reads sim time from the nested `content[].json.sim_time` status-dict shape (backends without a structured `_world`).
- `_resolve_success_fn("contact")` positive detection for both `{n_contacts: int}` and `{contacts: [...]}` result shapes, plus the missing-`get_contacts` no-op (previously only the raise path was covered).

## Coverage
`strands_robots/simulation/policy_runner.py`: 86% -> 90% (61 -> ~40 missing lines). Remaining misses are defensive `except Exception` / final-fallthrough returns.

## Verification
- All 4 policy_runner test files green locally: 123 passed, 2 skipped (`MUJOCO_GL=egl`).
- Regression-proofed: removing the empty-action branch's success check makes `test_empty_actions_success_terminates_episode` fail, confirming the test guards real behaviour rather than asserting vacuously.
- `ruff check` / `ruff format --check` clean; `mypy` clean on the changed files.

Test-only PR (no behavior change), so no visual artifact applies.