### PR TITLE
test(hardware_robot): cover camera dict -> OpenCVCameraConfig conversion (88%->89%)

### DIFF
--- a/tests/test_robot_factory.py
+++ b/tests/test_robot_factory.py
@@ -594,6 +594,68 @@ class TestRealModeConfigDiscovery:
         assert not hasattr(cfg, "robot_ip")
         assert not hasattr(cfg, "kp")
 
+    def test_cameras_dict_converted_to_opencv_config_with_defaults(self):
+        """Camera dicts are converted to lerobot ``OpenCVCameraConfig`` objects.
+
+        ``_create_minimal_config`` accepts a plain ``cameras`` dict (the shape an
+        agent/tool passes) and must turn each ``opencv`` entry into a real
+        ``lerobot.cameras.opencv.OpenCVCameraConfig`` on the resolved robot
+        config. Only ``index_or_path`` is required; ``fps``/``width``/``height``/
+        ``rotation``/``color_mode`` default. Pre-fix this conversion branch was
+        never exercised (every config test passed ``cameras={}``), so a
+        regression in the dict->config mapping would go unnoticed.
+        """
+        pytest.importorskip("lerobot.robots.so_follower")
+        from lerobot.cameras.opencv.configuration_opencv import OpenCVCameraConfig
+
+        from strands_robots.hardware_robot import Robot as HwRobot
+
+        hw = HwRobot.__new__(HwRobot)
+        hw.tool_name_str = "so101_cam"
+        cfg = hw._create_minimal_config(
+            "so101_follower",
+            cameras={
+                "wrist": {"type": "opencv", "index_or_path": 0},
+                "front": {
+                    "index_or_path": "/dev/video2",
+                    "fps": 60,
+                    "width": 1280,
+                    "height": 720,
+                },
+            },
+            port="/dev/null",
+        )
+        assert set(cfg.cameras) == {"wrist", "front"}
+        wrist = cfg.cameras["wrist"]
+        assert isinstance(wrist, OpenCVCameraConfig)
+        assert wrist.index_or_path == 0
+        # Unspecified fields fall back to the documented defaults.
+        assert (wrist.fps, wrist.width, wrist.height) == (30, 640, 480)
+        # Explicit overrides are forwarded verbatim.
+        front = cfg.cameras["front"]
+        assert front.index_or_path == "/dev/video2"
+        assert (front.fps, front.width, front.height) == (60, 1280, 720)
+
+    def test_unsupported_camera_type_raises_value_error(self):
+        """A non-opencv camera ``type`` is rejected with an actionable error.
+
+        ``opencv`` is the only backend ``_create_minimal_config`` knows how to
+        build; any other ``type`` (e.g. a typo or an unimplemented backend) must
+        fail loudly at config-build time rather than be silently dropped, so the
+        operator learns immediately the camera will not be wired up.
+        """
+        pytest.importorskip("lerobot.robots.so_follower")
+        from strands_robots.hardware_robot import Robot as HwRobot
+
+        hw = HwRobot.__new__(HwRobot)
+        hw.tool_name_str = "so101_badcam"
+        with pytest.raises(ValueError, match="Unsupported camera type: realsense"):
+            hw._create_minimal_config(
+                "so101_follower",
+                cameras={"depth": {"type": "realsense", "index_or_path": 0}},
+                port="/dev/null",
+            )
+
     def test_mesh_attrs_set_before_initialize_robot_no_attribute_error_in_cleanup(self, caplog):
         """Pin the cleanup-AttributeError fix with the actual symptom.
 


### PR DESCRIPTION
## What
Add regression coverage for the camera-conversion branch of `HardwareRobot._create_minimal_config`, which turns a plain `cameras` dict (the shape an agent/tool passes) into lerobot `OpenCVCameraConfig` objects on the resolved robot config.

## Why
Every existing `_create_minimal_config` test passed `cameras={}`, so the dict -> `OpenCVCameraConfig` mapping and the unsupported-type guard (`hardware_robot.py` lines 412-424) had **zero** regression coverage. A silent regression in the field mapping (wrong default fps/width/height, a dropped override, or a swallowed bad camera type) would have shipped unnoticed.

## Tests
Two focused tests added to `TestRealModeConfigDiscovery` (reusing its autouse registry cache-clear fixture, `importorskip("lerobot.robots.so_follower")`):

- `test_cameras_dict_converted_to_opencv_config_with_defaults` - a two-camera dict asserting opencv entries become real `OpenCVCameraConfig` instances, that omitted fields fall back to the documented defaults (`fps=30`, `width=640`, `height=480`), and that explicit overrides (`index_or_path`, `fps`, `width`, `height`) are forwarded verbatim.
- `test_unsupported_camera_type_raises_value_error` - a non-opencv `type` raises `ValueError` with an actionable message, pinning the fail-loud (not silent-drop) contract.

Behavior-guard check: mutating the source default `fps=30` -> `fps=99` makes the first test fail, confirming it asserts real behavior rather than implementation detail.

## Coverage
`strands_robots/hardware_robot.py`: 88% -> 89% (lines 412-424 now covered). Full `tests/test_robot_factory.py` green: 76 passed, 1 skipped. Test-only change; no production code touched.