### PR TITLE
fix(lerobot_calibrate): strip emoji + orphan variation selectors from tool output

### DIFF
--- a/strands_robots/tools/lerobot_calibrate.py
+++ b/strands_robots/tools/lerobot_calibrate.py
@@ -398,7 +398,7 @@ def lerobot_calibrate(
                     "status": "success",
                     "content": [
                         {
-                            "text": f"ℹ️ **No calibration files found.**\n\nCalibrations are stored in: `{manager.base_path}`"
+                            "text": f"**No calibration files found.**\n\nCalibrations are stored in: `{manager.base_path}`"
                         }
                     ],
                     "calibrations": structure,
@@ -474,7 +474,7 @@ def lerobot_calibrate(
                     if isinstance(motor_data, dict):
                         content_lines.extend(
                             [
-                                f"### ️ **{motor_name}**",
+                                f"### **{motor_name}**",
                                 f"  - **ID:** {motor_data.get('id', 'N/A')}",
                                 f"  - **Drive Mode:** {motor_data.get('drive_mode', 'N/A')}",
                                 f"  - **Homing Offset:** {motor_data.get('homing_offset', 'N/A')}",
@@ -587,7 +587,7 @@ def lerobot_calibrate(
             if success:
                 return {
                     "status": "success",
-                    "content": [{"text": f"️ **Successfully deleted:** `{device_type}/{device_model}/{device_id}`"}],
+                    "content": [{"text": f"**Successfully deleted:** `{device_type}/{device_model}/{device_id}`"}],
                 }
             else:
                 return {

--- a/tests/tools/test_lerobot_calibrate.py
+++ b/tests/tools/test_lerobot_calibrate.py
@@ -381,3 +381,57 @@ def test_tool_surfaces_validation_errors(tmp_path: Path) -> None:
     result = lerobot_calibrate(action="backup", output_dir="../escape", base_path=str(tmp_path))
     assert result["status"] == "error"
     assert "failed" in result["content"][0]["text"].lower()
+
+
+# --- ASCII-only output contract -------------------------------------------
+# AGENTS.md forbids emojis (and orphan U+FE0F variation selectors left over
+# from emoji sweeps) anywhere in code/logs/error strings. These tests pin the
+# user-facing text of every action that previously carried such characters:
+# the empty-list notice, the per-motor view header, and the delete-success
+# message. They assert the rendered text is pure ASCII so the violation cannot
+# silently reappear.
+
+
+def _assert_ascii(text: str) -> None:
+    """Fail with the offending code points if ``text`` is not pure ASCII."""
+    offenders = [(i, hex(ord(c))) for i, c in enumerate(text) if ord(c) > 127]
+    assert not offenders, f"non-ASCII in tool output at {offenders}: {text!r}"
+
+
+def test_list_empty_notice_is_ascii(tmp_path: Path) -> None:
+    """The empty-tree ``list`` notice carries no emoji/variation-selector."""
+    result = lerobot_calibrate(action="list", base_path=str(tmp_path))
+    assert result["status"] == "success"
+    text = result["content"][0]["text"]
+    _assert_ascii(text)
+    assert "No calibration files found." in text
+
+
+def test_view_motor_header_is_ascii(populated: Path) -> None:
+    """The per-motor ``view`` header carries no orphan variation selector."""
+    result = lerobot_calibrate(
+        action="view",
+        device_type="robots",
+        device_model="so101_follower",
+        device_id="orange_arm",
+        base_path=str(populated),
+    )
+    assert result["status"] == "success"
+    text = result["content"][0]["text"]
+    _assert_ascii(text)
+    assert "shoulder" in text
+
+
+def test_delete_success_message_is_ascii(populated: Path) -> None:
+    """The ``delete`` success message carries no orphan variation selector."""
+    result = lerobot_calibrate(
+        action="delete",
+        device_type="robots",
+        device_model="so101_follower",
+        device_id="green_arm",
+        base_path=str(populated),
+    )
+    assert result["status"] == "success"
+    text = result["content"][0]["text"]
+    _assert_ascii(text)
+    assert "Successfully deleted:" in text


### PR DESCRIPTION
## What
Three user-facing strings in the `lerobot_calibrate` tool carried non-ASCII characters and are now pure ASCII:

| Action | Before (code points) | After |
|---|---|---|
| `list` (empty tree) | `U+2139 U+FE0F` info emoji prefix | plain text |
| `view` per-motor header | orphan `U+FE0F` (no base glyph) | plain text |
| `delete` success message | leading orphan `U+FE0F` | plain text |

## Why
The project bans emojis in code, logs, and output strings (no-emoji convention). The two `view`/`delete` cases are orphan `U+FE0F` variation selectors left behind by an earlier emoji sweep that removed the base glyph but not its trailing selector, so they render as invisible/garbage bytes in agent-facing tool results (e.g. `### \ufe0f **shoulder**`). The `list` notice still carried a full info emoji. None affect logic; they are presentation defects in the dispatcher's returned `text`.

## Change
`strands_robots/tools/lerobot_calibrate.py`: remove the emoji/variation-selector (plus its trailing space) from the empty-list notice, the per-motor `view` header, and the `delete`-success message. No behavioral change.

## Test
Adds three regression tests to `tests/tools/test_lerobot_calibrate.py` asserting the `list`/`view`/`delete` output text contains no code point above `0x7F` (with the offending offsets in the failure message). They fail on the pre-fix strings (`U+2139`/`U+FE0F` detected) and pass after.

## Verification
- `ruff check` + `ruff format --check`: clean.
- `pytest tests/tools/test_lerobot_calibrate.py`: 37 passed (3 new).
- Repo-wide grep for non-ASCII in the module: none remaining.