### PR TITLE
test(mesh/security): cover is_safe_server_address port + IPv6 branches (83%->86%)

### DIFF
--- a/tests/mesh/test_server_address_port_ipv6.py
+++ b/tests/mesh/test_server_address_port_ipv6.py
@@ -1,0 +1,110 @@
+"""Branch coverage for :func:`strands_robots.mesh.security.is_safe_server_address`.
+
+``server_address`` is the operator-facing knob that points a robot at a remote
+VLA policy server. The composite parser strips an optional ``scheme://`` and
+``/path``, then resolves the host through three shapes: bracketed IPv6
+(``[host]`` / ``[host]:port``), a single-colon ``host:port``, and a bare host
+that may itself be an unbracketed IPv6 literal. Each shape has its own
+port-validation and malformed-input rejection branches; those rejection paths
+are the security boundary (a bad port or malformed bracket must fail closed,
+never fall through to ``is_safe_policy_host`` with a half-parsed host).
+
+These tests pin every accept/reject branch of the host-resolution ladder.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from strands_robots.mesh import security as sec
+
+
+class TestBracketedIPv6:
+    """``[host]`` / ``[host]:port`` parsing branch."""
+
+    def test_loopback_no_port_allowed(self) -> None:
+        assert sec.is_safe_server_address("[::1]") is True
+
+    def test_loopback_valid_port_allowed(self) -> None:
+        assert sec.is_safe_server_address("[::1]:8080") is True
+
+    def test_missing_closing_bracket_rejected(self) -> None:
+        # No ']' at all -> malformed bracketed address, fail closed.
+        assert sec.is_safe_server_address("[::1") is False
+
+    def test_trailing_garbage_after_bracket_rejected(self) -> None:
+        # Remainder after ']' that is not ":port" is malformed.
+        assert sec.is_safe_server_address("[::1]x") is False
+
+    def test_empty_port_after_bracket_rejected(self) -> None:
+        assert sec.is_safe_server_address("[::1]:") is False
+
+    def test_non_digit_port_rejected(self) -> None:
+        assert sec.is_safe_server_address("[::1]:abc") is False
+
+    @pytest.mark.parametrize("port", ["0", "70000"])
+    def test_out_of_range_port_rejected(self, port: str) -> None:
+        assert sec.is_safe_server_address(f"[::1]:{port}") is False
+
+    def test_unallowed_host_with_valid_port_rejected(self) -> None:
+        # Valid bracket + valid port, but host not on the default loopback
+        # allowlist -> rejected by is_safe_policy_host, not by the parser.
+        assert sec.is_safe_server_address("[2001:db8::1]:8080") is False
+
+
+class TestSingleColonHostPort:
+    """``host:port`` parsing branch (exactly one colon)."""
+
+    def test_loopback_valid_port_allowed(self) -> None:
+        assert sec.is_safe_server_address("localhost:65535") is True
+
+    def test_non_digit_port_rejected(self) -> None:
+        assert sec.is_safe_server_address("localhost:abc") is False
+
+    @pytest.mark.parametrize("port", ["0", "70000"])
+    def test_out_of_range_port_rejected(self, port: str) -> None:
+        assert sec.is_safe_server_address(f"localhost:{port}") is False
+
+
+class TestUnbracketedHost:
+    """Bare host: no colon, or two-plus colons (unbracketed IPv6 literal)."""
+
+    def test_bare_loopback_hostname_allowed(self) -> None:
+        assert sec.is_safe_server_address("localhost") is True
+
+    def test_bare_loopback_ipv6_literal_allowed(self) -> None:
+        # No brackets, multiple colons -> parsed as an IPv6 literal; ::1 is
+        # on the default loopback allowlist.
+        assert sec.is_safe_server_address("::1") is True
+
+    def test_bare_unallowed_ipv6_literal_rejected(self) -> None:
+        assert sec.is_safe_server_address("2001:db8::1") is False
+
+    def test_multi_colon_non_ipv6_rejected(self) -> None:
+        # Two-plus colons that are not a valid IPv6 literal must fail closed
+        # rather than being mis-split into host/port.
+        assert sec.is_safe_server_address("foo:bar:baz") is False
+
+
+class TestSchemeAndPathStripping:
+    """Scheme prefix and trailing path are stripped before host resolution."""
+
+    def test_scheme_bracketed_ipv6_and_path_stripped(self) -> None:
+        assert sec.is_safe_server_address("tcp://[::1]:5555/model") is True
+
+    def test_empty_and_non_string_rejected(self) -> None:
+        assert sec.is_safe_server_address("") is False
+        assert sec.is_safe_server_address(None) is False  # type: ignore[arg-type]
+
+
+class TestOperatorCidrAllowlist:
+    """A CIDR entry in STRANDS_MESH_POLICY_HOST_ALLOW admits matching IPv6."""
+
+    def test_cidr_admits_bare_and_bracketed_ipv6(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("STRANDS_MESH_POLICY_HOST_ALLOW", "2001:db8::/32")
+        sec._clear_security_caches_for_tests()
+        try:
+            assert sec.is_safe_server_address("2001:db8::1") is True
+            assert sec.is_safe_server_address("[2001:db8::1]:8080") is True
+        finally:
+            sec._clear_security_caches_for_tests()


### PR DESCRIPTION
## What

Pin branch coverage for `is_safe_server_address` in `strands_robots/mesh/security.py`. This composite parser is the gate that points a robot at a remote VLA policy server, so its reject paths are a security boundary: a malformed bracket or out-of-range port must fail closed, never fall through to `is_safe_policy_host` with a half-parsed host.

The existing suite covered the happy paths (scheme/port strip, bracketed loopback, one unallowed IPv6) but left every port-validation and malformed-input rejection branch untested.

## Coverage

`strands_robots/mesh/security.py`: **83% -> 86%** (14 lines, all in the `server_address` host-resolution ladder: lines 577, 592, 600, 603, 606, 609, 618, 625, 628, 634-640).

## Tests added

`tests/mesh/test_server_address_port_ipv6.py` (20 cases), grouped by parse shape:

- **Bracketed IPv6** `[host]` / `[host]:port`: loopback accept (with/without port), missing closing bracket, trailing garbage after `]`, empty port, non-digit port, out-of-range port (0 / 70000), and a valid bracket+port whose host is off-allowlist (rejected by the host check, not the parser).
- **Single-colon `host:port`**: valid port accept, non-digit port, out-of-range port.
- **Unbracketed host**: bare hostname, bare IPv6 literal `::1` on the default loopback allowlist, an unallowed bare IPv6 literal, and a multi-colon non-IPv6 string that must fail closed rather than mis-split.
- **Scheme + path stripping**: `tcp://[::1]:5555/model`, plus empty / non-string rejection.
- **Operator CIDR allowlist**: a `STRANDS_MESH_POLICY_HOST_ALLOW=2001:db8::/32` entry admits both the bare and bracketed forms (caches cleared in a `try/finally`).

Behavior-only: no production code changed. `ruff check` / `ruff format` clean; full `tests/mesh/` suite passes (1596 passed, 2 skipped).