### PR TITLE
test(device_connect/robot_driver): cover get_features fallback, event bodies, periodic publisher (90%->100%)

### DIFF
--- a/tests/test_device_connect_drivers.py
+++ b/tests/test_device_connect_drivers.py
@@ -303,6 +303,56 @@ class TestRobotDeviceDriver(unittest.TestCase):
         asyncio.run(driver.onEmergencyStop("other-robot", "emergencyStop", {"reason": "test"}))
         robot.stop_task.assert_called_once()
 
+    def test_get_features_falls_back_when_robot_lacks_get_features(self):
+        """Main's HardwareRobot does not expose get_features(); the driver must
+        degrade to an empty-features payload with a note rather than raise."""
+        robot = _make_mock_robot()
+        # Remove the get_features attribute entirely so getattr returns None.
+        del robot.get_features
+        driver = RobotDeviceDriver(robot)
+        result = asyncio.run(driver.getFeatures())
+        self.assertEqual(result["features"], {})
+        self.assertIn("get_features unavailable", result["note"])
+
+    def test_get_features_falls_back_when_get_features_not_callable(self):
+        """A non-callable get_features attribute must also trigger the fallback."""
+        robot = _make_mock_robot()
+        robot.get_features = "not-callable"
+        driver = RobotDeviceDriver(robot)
+        result = asyncio.run(driver.getFeatures())
+        self.assertEqual(result["features"], {})
+
+    def test_event_emitters_run_their_bodies(self):
+        """The @emit-decorated declarations are callable no-op bodies; invoking
+        them must not raise (they only declare the event payload shape)."""
+        driver = RobotDeviceDriver(_make_mock_robot())
+        asyncio.run(driver.taskStarted("pick up cube", "mock"))
+        asyncio.run(driver.taskComplete("pick up cube", 42, 3.5))
+        asyncio.run(driver.streamStep(1, {"j1": 0.1}, {"j1": 0.2}))
+        asyncio.run(driver.emergencyStop("operator request"))
+        asyncio.run(driver.stateUpdate(task_status="running", instruction="pick", step_count=5))
+
+    def test_publish_state_emits_when_task_running(self):
+        """The 10Hz publisher emits a state update for a running task, carrying
+        the task status, instruction, and step count."""
+        robot = _make_mock_robot(task_status="running")
+        driver = RobotDeviceDriver(robot)
+        driver.stateUpdate = AsyncMock()
+        asyncio.run(driver._publishState())
+        driver.stateUpdate.assert_awaited_once_with(
+            task_status="running",
+            instruction="pick up the cube",
+            step_count=42,
+        )
+
+    def test_publish_state_silent_when_no_task_running(self):
+        """An idle task (or no task) must emit nothing from the periodic publisher."""
+        robot = _make_mock_robot(task_status="idle")
+        driver = RobotDeviceDriver(robot)
+        driver.stateUpdate = AsyncMock()
+        asyncio.run(driver._publishState())
+        driver.stateUpdate.assert_not_called()
+
 
 # ── TestSimulationDeviceDriver ────────────────────────────────────
 


### PR DESCRIPTION
## What

Pin coverage for the four untested behaviors in `strands_robots/device_connect/robot_driver.py` (`RobotDeviceDriver`, the Device Connect adapter that exposes a robot's task RPCs/events on the mesh). These were the module's only uncovered lines.

## Coverage

`strands_robots/device_connect/robot_driver.py`: **90% -> 100%** (9 lines: 118, 155, 166, 177, 186, 207-209, 224).

## Tests added

Five cases in `TestRobotDeviceDriver` (`tests/test_device_connect_drivers.py`):

- **`getFeatures` graceful fallback** (line 118): when the wrapped robot has no `get_features` attribute (main's `HardwareRobot`) or exposes a non-callable one, the RPC must return `{"features": {}, "note": ...}` rather than raise. Two cases cover the missing-attribute and non-callable branches.
- **`@emit` event bodies** (lines 155/166/177/186/224): `taskStarted`, `taskComplete`, `streamStep`, `emergencyStop`, and `stateUpdate` are declaration-only no-op coroutines that build the event payload shape. Invoking each must not raise.
- **`_publishState` periodic publisher** (lines 207-209): with a running task the 10Hz publisher emits exactly one `stateUpdate` carrying task status, instruction, and step count; with an idle task it emits nothing.

Behavior-only: no production code changed. `ruff check` / `ruff format` clean; the full Device Connect suite passes (1134 passed, 7 skipped) and the module reports 100% line coverage.