### PR TITLE
test(mesh/acl): make get_session auth_mode pins zenoh-env-independent

### DIFF
--- a/tests/mesh/test_acl_permissive_detection_and_caching.py
+++ b/tests/mesh/test_acl_permissive_detection_and_caching.py
@@ -681,6 +681,20 @@ def test_get_session_skips_resolve_auth_mode_when_thread_local_set(
 
     monkeypatch.setattr(_session, "_build_config", _short_circuit_build)
 
+    # ``get_session`` does a lazy ``import zenoh`` (session.py:510) and returns
+    # ``None`` early when the wheel is absent, short-circuiting BEFORE the
+    # scheme-selection block this test pins. Inject an importable stub so the
+    # block is reached deterministically whether or not the eclipse-zenoh wheel
+    # is installed in this env -- otherwise the assertion either hard-fails
+    # (no calls observed) or passes by accident (0 == 0). A bare ModuleType is
+    # sufficient and honest: ``_build_config`` is short-circuited above, so no
+    # ``zenoh.*`` attribute is ever touched. monkeypatch restores sys.modules
+    # on teardown.
+    import sys
+    import types
+
+    monkeypatch.setitem(sys.modules, "zenoh", types.ModuleType("zenoh"))
+
     _acl_config._set_thread_snapshot(None, auth_mode="none")
     try:
         try:
@@ -736,6 +750,20 @@ def test_get_session_falls_back_to_resolve_auth_mode_without_thread_local(
         raise sentinel_exc
 
     monkeypatch.setattr(_session, "_build_config", _short_circuit_build)
+
+    # ``get_session`` does a lazy ``import zenoh`` (session.py:510) and returns
+    # ``None`` early when the wheel is absent, short-circuiting BEFORE the
+    # scheme-selection block this test pins. Inject an importable stub so the
+    # block is reached deterministically whether or not the eclipse-zenoh wheel
+    # is installed in this env -- otherwise the assertion either hard-fails
+    # (no calls observed) or passes by accident (0 == 0). A bare ModuleType is
+    # sufficient and honest: ``_build_config`` is short-circuited above, so no
+    # ``zenoh.*`` attribute is ever touched. monkeypatch restores sys.modules
+    # on teardown.
+    import sys
+    import types
+
+    monkeypatch.setitem(sys.modules, "zenoh", types.ModuleType("zenoh"))
 
     try:
         try:


### PR DESCRIPTION
## Summary

The two `get_session` thread-local `auth_mode` pins in `tests/mesh/test_acl_permissive_detection_and_caching.py` are silently environment-dependent on the `eclipse-zenoh` wheel. This converts them into deterministic, environment-independent behavioral pins. **Test-only change** (no production code touched).

## The problem

Both pins call `get_session()` to exercise the scheme-selection block where `resolve_auth_mode` is consulted. But `get_session()` does a lazy `import zenoh` (`session.py:510`) and returns `None` early when the wheel is absent -- short-circuiting **before** that block is ever reached.

This made the pins fragile:

- `test_get_session_skips_resolve_auth_mode_when_thread_local_set` **passed by accident** when the wheel was absent (early return -> 0 calls -> `0 == 0`), never actually verifying the thread-local-skip behaviour.
- `test_get_session_falls_back_to_resolve_auth_mode_without_thread_local` **hard-failed** in any env without the wheel (`0` calls observed, `assert 0 == 1`).

CI installs `[mesh]` (which pulls `eclipse-zenoh`), so both passed there -- but the suite violated the AGENTS.md testing rule against silent env-dependent skips/false-passes.

## The fix

Inject an importable `zenoh` stub via `monkeypatch.setitem(sys.modules, "zenoh", types.ModuleType("zenoh"))` in both tests so the scheme-selection block is reached deterministically whether or not the wheel is installed.

A bare `types.ModuleType` is sufficient and honest: `_build_config` is already short-circuited in both tests, so no `zenoh.*` attribute is ever touched (the first `zenoh.*` access -- `getattr(zenoh, "ZError")` -- sits *after* the `_build_config` call). `monkeypatch` restores `sys.modules` on teardown, and the autouse `_restore_real_zenoh_module` fixture is unaffected: it only evicts `unittest.mock` instances, never a real `ModuleType`.

## Verification

- **Mutation test (proves the pin now bites):** dropping the thread-local guard in `session.py` (`_auth_mode = resolve_auth_mode()` unconditionally) makes the `skips` pin fail (`1 == 0`) as a true regression catch. Pre-change it passed by accident.
- Target file: 25 passed, 1 skipped.
- Full mesh suite: 1554 passed, 7 skipped, 0 failures.
- `ruff check` + `ruff format --check`: clean.

## §13 Changelog

- **Round 1:** initial submission. Test-only; +2 stub injections (one per pin) with rationale comments.