### PR TITLE
test(mesh/sensors): cover reader fail-soft branches on provider faults

### DIFF
--- a/tests/mesh/test_sensor_readers.py
+++ b/tests/mesh/test_sensor_readers.py
@@ -402,12 +402,59 @@ def test_sensor_loop_reraises_not_implemented(
 
 
 class _FaultyRobot:
-    """Robot whose every attribute access raises, simulating a driver/bus
-    fault on sensor read. Stands in for a property or ``__getattr__`` provider
-    that throws mid-tick."""
+    """Robot whose sensor-provider accessors raise, simulating a driver/bus
+    fault on sensor read (a property that throws mid-tick).
 
-    def __getattr__(self, name: str) -> Any:
-        raise RuntimeError(f"sensor bus fault reading {name!r}")
+    Each provider attribute the readers consult (``_pose``, ``_battery``,
+    ``_temps``, ``_imu``, ``robot``, ``_odom``, ``_lidar_summary``,
+    ``_lidar_state``, ``_hands``, ``_map_info``) is a property that raises
+    ``RuntimeError`` -- a non-``AttributeError`` fault. This is deliberate:
+    the readers fetch providers via ``getattr(r, name, None)``, which would
+    *silently swallow* an ``AttributeError`` (returning the default before the
+    reader's own ``try/except`` runs), so an ``AttributeError`` fixture would
+    never exercise the inner fail-soft guard. A ``RuntimeError`` is not
+    suppressed by ``getattr``'s default and therefore propagates into the
+    guard under test."""
+
+    @property
+    def _pose(self) -> Any:
+        raise RuntimeError("sensor bus fault reading '_pose'")
+
+    @property
+    def _battery(self) -> Any:
+        raise RuntimeError("sensor bus fault reading '_battery'")
+
+    @property
+    def _temps(self) -> Any:
+        raise RuntimeError("sensor bus fault reading '_temps'")
+
+    @property
+    def _imu(self) -> Any:
+        raise RuntimeError("sensor bus fault reading '_imu'")
+
+    @property
+    def robot(self) -> Any:
+        raise RuntimeError("sensor bus fault reading 'robot'")
+
+    @property
+    def _odom(self) -> Any:
+        raise RuntimeError("sensor bus fault reading '_odom'")
+
+    @property
+    def _lidar_summary(self) -> Any:
+        raise RuntimeError("sensor bus fault reading '_lidar_summary'")
+
+    @property
+    def _lidar_state(self) -> Any:
+        raise RuntimeError("sensor bus fault reading '_lidar_state'")
+
+    @property
+    def _hands(self) -> Any:
+        raise RuntimeError("sensor bus fault reading '_hands'")
+
+    @property
+    def _map_info(self) -> Any:
+        raise RuntimeError("sensor bus fault reading '_map_info'")
 
 
 def _faulty_host() -> _Host:

--- a/tests/mesh/test_sensor_readers.py
+++ b/tests/mesh/test_sensor_readers.py
@@ -388,3 +388,80 @@ def test_sensor_loop_reraises_not_implemented(
 
     with pytest.raises(NotImplementedError):
         getattr(host, loop_name)()
+
+
+# reader fault resilience ---------------------------------------------------
+#
+# Each ``_read_*`` wraps its provider access in a fail-soft ``try/except`` so a
+# robot whose sensor accessor raises (e.g. a driver probing a disconnected
+# bus, a property that throws mid-read) degrades to "no sample this tick"
+# rather than propagating. This is distinct from the loop-level swallowing
+# above: here the *provider attribute access itself* raises, exercising the
+# inner guard inside each reader. Without it a single faulty sensor accessor
+# would crash the publish loop and silence the topic.
+
+
+class _FaultyRobot:
+    """Robot whose every attribute access raises, simulating a driver/bus
+    fault on sensor read. Stands in for a property or ``__getattr__`` provider
+    that throws mid-tick."""
+
+    def __getattr__(self, name: str) -> Any:
+        raise RuntimeError(f"sensor bus fault reading {name!r}")
+
+
+def _faulty_host() -> _Host:
+    return _Host(_FaultyRobot())
+
+
+@pytest.mark.parametrize(
+    "reader",
+    [
+        "_read_pose",
+        "_read_imu",
+        "_read_odom",
+        "_read_lidar_summary",
+        "_read_lidar_state",
+        "_read_hands",
+        "_read_map_info",
+    ],
+)
+def test_reader_returns_none_when_provider_access_raises(reader: str) -> None:
+    """A provider whose attribute access throws yields ``None`` (no sample),
+    never a propagated exception, so the publish loop survives the fault."""
+    host = _faulty_host()
+    assert getattr(host, reader)() is None
+
+
+def test_read_health_degrades_when_robot_and_system_sources_fail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the robot's battery/temps accessors raise AND every system-stat
+    source (loadavg, disk, /proc) is unavailable, ``_read_health`` collects no
+    data and returns ``None`` instead of an empty-but-truthy payload or a
+    crash."""
+    import builtins
+    import os
+    import shutil
+
+    def _raise_os(*_a: Any, **_k: Any) -> Any:
+        raise OSError("source unavailable")
+
+    monkeypatch.setattr(os, "getloadavg", _raise_os)
+    monkeypatch.setattr(shutil, "disk_usage", _raise_os)
+    monkeypatch.setattr(builtins, "open", _raise_os)  # blocks /proc/meminfo + /proc/uptime
+
+    assert _faulty_host()._read_health() is None
+
+
+def test_read_health_aggregates_system_stats_despite_faulty_robot() -> None:
+    """Even when the robot's own providers (battery/temps) raise, the
+    system-stat sources still populate health: the per-source guards isolate
+    the robot fault from the host metrics so partial data is published."""
+    health = _faulty_host()._read_health()
+    # On a normal host at least one of loadavg / disk / meminfo / uptime
+    # resolves, so health is a populated payload (not None) and carries no
+    # robot-provided battery field (that source faulted).
+    assert health is not None
+    assert "battery_pct" not in health
+    assert health["peer_id"] == "peer-1"


### PR DESCRIPTION
## What

Adds focused unit coverage for the per-reader fail-soft guards in `SensorLoopsMixin` (`strands_robots/mesh/sensors.py`), raising the module from 93% to **100%** with no source change.

## Why

Each `_read_*` sensor reader wraps its provider access in a fail-soft `try/except` so a robot whose sensor accessor raises mid-read (a driver probing a disconnected bus, a property that throws) degrades to *no sample this tick* rather than propagating and killing the publish loop that owns the topic.

The existing tests only exercise the loop-level swallowing (a raising reader *callable*). The inner per-reader guards — fired when the *provider attribute access itself* raises — were untested, so a regression that let a sensor fault escape `_read_*` would not have been caught.

## Change

A `_FaultyRobot` fixture whose provider accessors raise, and assertions that:

- every `_read_*` (`pose`, `imu`, `odom`, `lidar_summary`, `lidar_state`, `hands`, `map_info`) returns `None` instead of propagating;
- `_read_health` returns `None` when the robot's battery/temps accessors raise **and** every system-stat source (`os.getloadavg`, `shutil.disk_usage`, `/proc/meminfo`, `/proc/uptime`) is unavailable;
- `_read_health` still aggregates host metrics when only the robot providers fault — the per-source guards isolate the robot fault from host telemetry so partial data is published.

Tests assert on reader outputs (the fail-soft contract), not implementation details.

## Validation

- `strands_robots.mesh.sensors` coverage 93% -> 100%.
- Full `tests/mesh/` suite green (1633 passed, 2 skipped).
- `ruff check` / `ruff format --check` clean; `mypy` clean on the changed file.
- Test-only change; no behavior change, no public API touched.

## §13 Changelog

**Round 1** (b1742e3): Replaced `_FaultyRobot.__getattr__` (which raised `RuntimeError`) with explicit raising properties for each provider attribute the readers consult. Resolves a code-scanning alert (non-standard exception in a special method) without weakening the test. `AttributeError` was not a viable substitute: readers fetch providers via `getattr(r, name, None)`, which would silently swallow an `AttributeError` and bypass the inner fail-soft guard the test targets. Fault semantics, assertions, and 100% coverage are unchanged.