### PR TITLE
test(registry/user_registry): pin alias-collision detection fail-soft path (95%->98%)

### DIFF
--- a/tests/registry/test_user_registry.py
+++ b/tests/registry/test_user_registry.py
@@ -124,6 +124,46 @@ class TestRegisterRobot:
         assert entry["hardware"] == hw
 
 
+class TestRegisterRobotAliasCollisionFailSoft:
+    """Alias-collision detection must degrade gracefully, never block a
+    registration.
+
+    ``register_robot(aliases=...)`` enumerates the package registry to warn
+    when a user alias shadows a canonical name or another alias. That
+    enumeration is best-effort diagnostics, not a precondition: if listing
+    the package registry raises (corrupt/partial install, import-time error
+    in a downstream ``robots.py`` consumer), registration must still succeed
+    with the aliases intact rather than propagating the failure to the
+    caller. This pins the ``except Exception`` fallback that resets the
+    package canonical/alias sets to empty.
+    """
+
+    def test_register_with_aliases_survives_package_enumeration_failure(self, tmp_path):
+        """When list_robots() raises during alias-collision detection, the
+        robot is still registered and its aliases resolve."""
+        robot_dir = _make_robot(tmp_path / "assets")
+
+        # The collision-detection block does a function-local
+        # ``from .robots import list_robots`` then calls it; patch the name
+        # on the robots module so the call raises at enumeration time.
+        with mock.patch(
+            "strands_robots.registry.robots.list_robots",
+            side_effect=RuntimeError("package registry enumeration failed"),
+        ):
+            entry = register_robot(
+                name="failsoft_bot",
+                model_xml="bot.xml",
+                asset_dir=str(robot_dir),
+                aliases=["failsoft_alias"],
+            )
+
+        # Registration succeeded despite the enumeration failure ...
+        assert entry["aliases"] == ["failsoft_alias"]
+        # ... and the robot + its alias are actually persisted/resolvable.
+        assert resolve_name("failsoft_alias") == "failsoft_bot"
+        assert get_user_robots().get("failsoft_bot") is not None
+
+
 class TestRegisterRobotNameNormalization:
     """Names are lower-cased, stripped, and hyphens become underscores."""
 


### PR DESCRIPTION
## Summary

Test-only PR. Pins the fail-soft fallback in `register_robot(aliases=...)`'s alias-collision detection.

`register_robot` enumerates the package registry (`list_robots()`) to warn when a user alias shadows a canonical name or another robot's alias. That enumeration is *best-effort diagnostics*, not a precondition for registration. The code already guards it with an `except Exception` that resets the package canonical/alias sets to empty so registration proceeds. Until now that fallback (lines 204-206) had no coverage: every existing test has an importable, enumerable package registry, so the failure path never ran.

The new test monkeypatches `strands_robots.registry.robots.list_robots` to raise during collision detection and asserts that:
1. `register_robot(..., aliases=[...])` still returns successfully,
2. the aliases survive on the returned entry, and
3. the robot + alias are actually persisted (`resolve_name` + `get_user_robots`).

This pins genuine defensive behavior: a transient/partial-install failure to enumerate the package registry must not block a legitimate user registration.

## Coverage

`strands_robots/registry/user_registry.py`: **95% -> 98%** (closes lines 204-206). The remaining `182-183` (`except ImportError` on the package-exists check) is a separate, harder-to-trigger branch left out of scope to keep this a single-concern diff.

## Testing

- `pytest tests/registry/` -> 452 passed (was 451; +1 new test).
- `ruff check` + `ruff format --check` clean.
- New test is deterministic, no heavy deps (pure registry/monkeypatch), runs in the default CI lane.

## Scope

- Single file: `tests/registry/test_user_registry.py` (+40 lines).
- No production code changes.

---

### Round-N changelog
- Round 1: initial test-only coverage of the alias-collision fail-soft path.