### PR TITLE
fix(dataset_recorder): record numpy-scalar state/action values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: numpy scalars no longer dropped from recorded state/action vectors
+
+`DatasetRecorder.add_frame` flattens each observation/action value into the
+LeRobot `observation.state` / `action` vectors. The value-type dispatch handled
+Python `int`/`float`, 0-dim `np.ndarray`, and list/array sequences, but NOT
+numpy scalar types (`np.float32`, `np.int32`, ...). These are the element type
+you get from indexing a MuJoCo `qpos`/`ctrl` array (`np.asarray(qpos)[i]`) and
+from many policy action paths, so they are extremely common in real recording
+loops. They are neither Python `float` nor `np.ndarray`, so they fell through
+every branch and were silently omitted from the vector.
+
+The result was a corrupted dataset with no error at write time: a column
+dropped to the wrong length (or vanished entirely). On reopen, LeRobot raised a
+confusing downstream `Feature mismatch` error far from the cause.
+
+- `add_frame` now treats `np.generic` scalars (alongside 0-dim `np.ndarray`)
+  as scalar values for both state and action flattening.
+- Regression test feeds `np.float32`/`np.float64`/`np.int32` values and asserts
+  the flattened vectors are present, correctly ordered, and full-length.
+
+
 ### Added: `[molmoact2]` optional-dependency extra
 
 MolmoAct2 transformers-native VLA checkpoints (e.g. `allenai/MolmoAct2-SO100_101`)

--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -429,7 +429,9 @@ class DatasetRecorder:
                     state_vals.append(0.0)
                 elif isinstance(v, (int, float)):
                     state_vals.append(float(v))
-                elif isinstance(v, np.ndarray) and v.ndim == 0:
+                elif isinstance(v, (np.generic, np.ndarray)) and v.ndim == 0:
+                    # numpy scalars (np.float32/np.int32 from indexing a MuJoCo
+                    # qpos/ctrl array) and 0-dim arrays are scalar state values.
                     state_vals.append(float(v))
                 elif isinstance(v, (list, np.ndarray)):
                     arr = np.asarray(v, dtype=np.float32).flatten()
@@ -452,7 +454,9 @@ class DatasetRecorder:
                     action_vals.append(0.0)
                 elif isinstance(v, (int, float)):
                     action_vals.append(float(v))
-                elif isinstance(v, np.ndarray) and v.ndim == 0:
+                elif isinstance(v, (np.generic, np.ndarray)) and v.ndim == 0:
+                    # numpy scalars (np.float32/np.int32) and 0-dim arrays are
+                    # scalar action values - see state branch above.
                     action_vals.append(float(v))
                 elif isinstance(v, (list, np.ndarray)):
                     arr = np.asarray(v, dtype=np.float32).flatten()

--- a/tests/test_dataset_recorder.py
+++ b/tests/test_dataset_recorder.py
@@ -213,6 +213,33 @@ def test_add_frame_flattens_vector_valued_entries():
     assert np.allclose(frame["action"], [0.1, 0.2])
 
 
+def test_add_frame_records_numpy_scalar_state_and_action():
+    """numpy scalars (np.float32 from indexing a qpos/ctrl array) are recorded
+    as scalar columns, not silently dropped.
+
+    MuJoCo observations and policy actions routinely hand back numpy scalar
+    types (the element type you get from ``np.asarray(qpos)[i]``), which are
+    neither Python ``float`` nor 0-dim ``np.ndarray``. They must still land in
+    the flattened state/action vectors - dropping them would record
+    wrong-length (or entirely missing) vectors with no error raised.
+    """
+    ds = _CapturingDataset(_state_action_features(["j1", "j2", "j3"], ["j1", "j2", "j3"]))
+    rec = DatasetRecorder(dataset=ds, task="pick")
+
+    rec.add_frame(
+        observation={"j1": np.float32(1.0), "j2": np.float64(2.0), "j3": np.int32(3)},
+        action={"j1": np.float32(0.1), "j2": np.float32(0.2), "j3": np.float32(0.3)},
+    )
+
+    frame = ds.frames[0]
+    assert "observation.state" in frame, "numpy-scalar state was dropped"
+    assert "action" in frame, "numpy-scalar action was dropped"
+    assert np.allclose(frame["observation.state"], [1.0, 2.0, 3.0])
+    assert np.allclose(frame["action"], [0.1, 0.2, 0.3])
+    assert frame["observation.state"].dtype == np.float32
+    assert frame["action"].dtype == np.float32
+
+
 def test_add_frame_converts_float_images_to_uint8():
     """A float image in [0, 1] is scaled to uint8 HWC for LeRobot."""
     feats = {"observation.images.cam": {"dtype": "video"}}


### PR DESCRIPTION
## Problem

`DatasetRecorder.add_frame` flattens each observation/action value into the LeRobot `observation.state` / `action` vectors. The value-type dispatch handled Python `int`/`float`, 0-dim `np.ndarray`, and list/array sequences, but **not numpy scalar types** (`np.float32`, `np.int32`, ...).

Those scalar types are the element type you get from indexing a MuJoCo `qpos`/`ctrl` array (`np.asarray(qpos)[i]`) and from many policy action paths, so they are extremely common in real recording loops. They are neither a Python `float` nor an `np.ndarray`, so they fell through every branch in the flattening dispatch and were **silently omitted** from the vector.

The result was a corrupted dataset with no error at write time: a state/action column dropped to the wrong length, or vanished entirely. The failure only surfaced later, on reopen, as a confusing LeRobot `Feature mismatch` error far from the cause.

## Change

`add_frame` now treats `np.generic` scalars (alongside 0-dim `np.ndarray`) as scalar values in both the state and action flattening branches. All numpy scalars have `ndim == 0`, so the existing `and v.ndim == 0` guard remains correct.

## Reproduction (record -> reopen round-trip)

Feeding `np.float32`/`np.float64`/`np.int32` joint values (only `np.float64` survives pre-fix, because it subclasses Python `float`):

**Before** — `action` is dropped entirely and `observation.state` collapses to shape `(1,)`; LeRobot rejects the frame:
```
ERROR: ValueError Feature mismatch in `frame` dictionary:
Missing features: {'action'}
The feature 'observation.state' of shape '(1,)' does ...
```

**After** — clean round-trip, full-length vectors with correct values:
```
REOPENED num_frames: 5
state[frame2]:  [0.2, 0.4, 2.0]
action[frame2]: [0.02, 0.04, 0.06]
RESULT: OK
```

Verified end to end on disk: `DatasetRecorder.create(...)` -> 5 `add_frame` calls with numpy-scalar values -> `save_episode` -> `finalize` -> reopen with `LeRobotDataset(repo_id, root=...)` -> `num_frames == 5`, `observation.state`/`action` both shape `(3,)`.

## Tests

Added `test_add_frame_records_numpy_scalar_state_and_action`, which feeds numpy-scalar state/action values and asserts the flattened vectors are present, correctly ordered, and full-length. It fails on the current code (`AssertionError: numpy-scalar action was dropped`) and passes with the fix.

`hatch run lint` clean; `tests/test_dataset_recorder.py` (42) and the recording-path suite pass locally.

CHANGELOG updated under Unreleased.