### PR TITLE
test(simulation/mujoco): pin add_camera parent_body discovery error

### DIFF
--- a/tests/simulation/mujoco/test_simulation.py
+++ b/tests/simulation/mujoco/test_simulation.py
@@ -427,6 +427,37 @@ class TestCameraManagement:
         result = sim_with_world.remove_camera("ghost")
         assert result["status"] == "error"
 
+    def test_add_camera_unknown_parent_body_lists_available_bodies(self, sim_with_robot):
+        """Mounting a camera on a non-existent body must fail with a discovery
+        error that names the bodies actually present, so an agent can correct
+        the call without guessing. Robot bodies are namespaced ``<robot>/<body>``.
+        """
+        result = sim_with_robot.add_camera(
+            "wrist",
+            position=[0.2, -0.2, 0.3],
+            target=[0, 0, 0],
+            parent_body="no_such_body",
+        )
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert "no_such_body" in text
+        assert "arm1/base" in text
+        # The failed mount must not leave a dangling registry entry behind.
+        assert "wrist" not in sim_with_robot._world.cameras
+
+    def test_add_camera_valid_parent_body_mounts_and_reports(self, sim_with_robot):
+        """A camera mounted on an existing namespaced body succeeds and the
+        success message names the mount target."""
+        result = sim_with_robot.add_camera(
+            "wrist",
+            position=[0.2, -0.2, 0.3],
+            target=[0, 0, 0],
+            parent_body="arm1/base",
+        )
+        assert result["status"] == "success"
+        assert "arm1/base" in result["content"][0]["text"]
+        assert sim_with_robot._world.cameras["wrist"].parent_body == "arm1/base"
+
 
 # Scene Injection (XML round-trip)
 


### PR DESCRIPTION
## Problem

`Simulation.add_camera(..., parent_body=...)` validates the mount target up front: if the body does not exist it returns a structured error that names the bad body and lists the namespaced bodies actually present (`<robot>/<body>`), so a caller can fix the mount without guessing. That Simulation-level contract had no direct test - the parent-body checks were only covered at the `SpecBuilder` layer, where a bad mount instead surfaces the opaque `spec recompile refused` message with no body list.

## Change

Add two focused tests in `TestCameraManagement` (on a loaded robot scene):

- **unknown `parent_body`** -> `status=error`, the message names the bad body (`no_such_body`) and an available namespaced body (`arm1/base`), and no dangling camera registry entry is left behind.
- **valid namespaced `parent_body`** -> mounts successfully and the success message reports the mount target.

## Regression value

With the up-front validation removed, the unknown-body test fails: the caller gets the generic `Failed to inject camera 'wrist': spec recompile refused.` instead of the actionable body list. The test pins the discovery-error contract so it can't silently regress to the opaque path.

## Verification

- `hatch run lint` clean (ruff check + ruff format --check + mypy: no issues in 400 source files).
- `MUJOCO_GL=egl pytest tests/simulation/mujoco/test_simulation.py`: 118 passed.

Test-only change; no library behavior is modified.