### PR TITLE
fix(simulation/physics): support MuJoCo 3.10 mj_fullM signature in get_mass_matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: `get_mass_matrix` works across MuJoCo `mj_fullM` signature changes
+
+`PhysicsMixin.get_mass_matrix()` called `mj.mj_fullM(model, M, data.qM)`, the
+pre-3.10 argument order. MuJoCo 3.10 reordered the binding to
+`mj_fullM(model, data, dst)` (the sparse inertia is read from `data` directly),
+so the old call raised `TypeError: mj_fullM(): incompatible function arguments`
+on newer MuJoCo. Because the project pins MuJoCo loosely (`>=3.2.0,<4.0.0`),
+this surfaced as a hard failure once the resolver picked up 3.10+.
+
+- A new module-level helper `_full_mass_matrix(mj, model, data)` probes the
+  modern `(model, data, dst)` signature first, then falls back to the legacy
+  `(model, dst, qM)` orders (1D and `[m, 1]` column variants). The `dst` buffer
+  is always allocated C-contiguous/writeable to satisfy the binding contract.
+- `get_mass_matrix` delegates to the helper; behaviour and JSON payload are
+  unchanged on every supported MuJoCo version. Empty-DoF scenes still return a
+  well-typed `(0, 0)` matrix.
+- Regression tests assert the matrix is symmetric positive-definite, exercise
+  the legacy-signature fallback path, and cover the zero-DoF case.
+
 ### Fixed: numpy scalars no longer dropped from recorded state/action vectors
 
 `DatasetRecorder.add_frame` flattens each observation/action value into the

--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -25,6 +25,52 @@ from strands_robots.simulation.mujoco.backend import _ensure_mujoco
 logger = logging.getLogger(__name__)
 
 
+def _full_mass_matrix(mj: Any, model: Any, data: Any) -> np.ndarray:
+    """Return the dense ``nv x nv`` mass matrix M(q), robust to MuJoCo drift.
+
+    ``mj_fullM`` changed its binding signature across MuJoCo releases:
+
+    - MuJoCo >= 3.10: ``mj_fullM(model, data, dst)`` - the sparse buffer is
+      read from ``data`` internally; ``dst`` must be writeable + C-contiguous.
+    - Older builds: ``mj_fullM(model, dst, qM)`` where ``qM`` is the sparse
+      inertia buffer, accepted either as a 1D array or a 2D ``[m, 1]`` column.
+
+    Probe the modern signature first, then fall back to the legacy orders so
+    the call works regardless of the installed MuJoCo version. ``dst`` is
+    always allocated C-contiguous to satisfy the binding's buffer contract.
+
+    Args:
+        mj: The imported ``mujoco`` module.
+        model: The ``MjModel`` whose DoF count defines the matrix size.
+        data: The ``MjData`` holding the sparse inertia (after a forward pass).
+
+    Returns:
+        A C-contiguous ``(nv, nv)`` float64 array. Empty (``(0, 0)``) when the
+        model has no DoFs.
+
+    Raises:
+        TypeError: If no known ``mj_fullM`` signature accepts the arguments.
+    """
+    nv = model.nv
+    dst = np.zeros((nv, nv), dtype=np.float64, order="C")
+    if nv == 0:
+        return dst
+    try:
+        # MuJoCo >= 3.10: dst is the third positional argument.
+        mj.mj_fullM(model, data, dst)
+        return dst
+    except TypeError:
+        pass
+    # Legacy signature: mj_fullM(model, dst, qM). Some builds require the
+    # sparse buffer as a 2D [m, 1] column; others accept the raw 1D buffer.
+    qm = np.ascontiguousarray(data.qM, dtype=np.float64)
+    try:
+        mj.mj_fullM(model, dst, qm.reshape(-1, 1))
+    except TypeError:
+        mj.mj_fullM(model, dst, qm)
+    return dst
+
+
 class PhysicsMixin:
     """Advanced MuJoCo physics capabilities mixed into ``Simulation``.
 
@@ -437,9 +483,8 @@ class PhysicsMixin:
         with self._lock:
             mj.mj_forward(model, data)
             nv = model.nv
-            M = np.zeros((nv, nv))
+            M = _full_mass_matrix(mj, model, data)
             if nv > 0:
-                mj.mj_fullM(model, M, data.qM)
                 rank = int(np.linalg.matrix_rank(M))
                 cond = float(np.linalg.cond(M)) if rank > 0 else float("inf")
             else:

--- a/tests/simulation/mujoco/test_physics.py
+++ b/tests/simulation/mujoco/test_physics.py
@@ -14,6 +14,7 @@ import pytest
 
 mj = pytest.importorskip("mujoco")
 
+from strands_robots.simulation.mujoco.physics import _full_mass_matrix  # noqa: E402
 from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
 
 ROBOT_XML = """
@@ -198,6 +199,81 @@ class TestMassMatrix:
         result = sim.get_mass_matrix()
         diag = _extract_json_block(result, 1)["diagonal"]
         assert all(d >= 0 for d in diag)
+
+    def test_mass_matrix_is_symmetric_positive_definite(self, sim):
+        # M(q) is symmetric PD for any well-formed model; verifying the actual
+        # numbers (not just the shape) guards against a signature fix that
+        # silently returns a wrong/zero matrix.
+        result = sim.get_mass_matrix()
+        data = _extract_json_block(result, 1)
+        nv = data["shape"][0]
+        M = _full_mass_matrix(mj, sim._world._model, sim._world._data)
+        assert M.shape == (nv, nv)
+        assert np.allclose(M, M.T), "mass matrix must be symmetric"
+        eigvals = np.linalg.eigvalsh(M)
+        assert np.all(eigvals > 0), f"mass matrix must be PD, got eigvals {eigvals}"
+
+
+class TestFullMassMatrixSignatureDrift:
+    """Regression: ``mj_fullM`` changed its binding signature across MuJoCo
+    releases. ``_full_mass_matrix`` must work against every variant rather than
+    hard-coding one call order (which crashed the suite under newer MuJoCo).
+    """
+
+    def test_helper_matches_native_call(self, sim):
+        model, data = sim._world._model, sim._world._data
+        mj.mj_forward(model, data)
+        M = _full_mass_matrix(mj, model, data)
+        assert M.flags["C_CONTIGUOUS"]
+        assert M.dtype == np.float64
+        # Cross-check against the diagonal MuJoCo reports for this model.
+        assert M.shape == (model.nv, model.nv)
+        assert np.all(np.diag(M) > 0)
+
+    def test_helper_falls_back_to_legacy_signatures(self, sim):
+        # Simulate an older MuJoCo binding whose mj_fullM rejects the modern
+        # (model, data, dst) order and expects (model, dst, qM). The helper
+        # must transparently fall back and still produce the correct matrix.
+        model, data = sim._world._model, sim._world._data
+        mj.mj_forward(model, data)
+        reference = _full_mass_matrix(mj, model, data)
+
+        real_fullm = mj.mj_fullM
+
+        class _LegacyShim:
+            """Proxy mujoco module exposing only a legacy mj_fullM."""
+
+            def __getattr__(self, attr):
+                return getattr(mj, attr)
+
+            @staticmethod
+            def mj_fullM(m, a, b):
+                # Reject the modern call where the 3rd arg is the dst buffer
+                # (i.e. the 2nd arg is MjData), forcing the legacy path.
+                import mujoco as _mj
+
+                if isinstance(a, _mj.MjData):
+                    raise TypeError("legacy binding: expected (model, dst, qM)")
+                # a is dst, b is qM (1D or [m, 1]) - emulate via the real call.
+                tmp = np.zeros_like(a, order="C")
+                real_fullm(m, data, tmp)
+                a[...] = tmp
+
+        shim = _LegacyShim()
+        M = _full_mass_matrix(shim, model, data)
+        assert np.allclose(M, reference)
+
+    def test_helper_returns_empty_for_zero_dof(self):
+        # A model with no DoFs must return a well-typed (0, 0) array, never
+        # crash in numpy on the empty buffer.
+        model = mj.MjModel.from_xml_string(
+            '<mujoco><worldbody><geom type="plane" size="1 1 0.1"/></worldbody></mujoco>'
+        )
+        mdata = mj.MjData(model)
+        mj.mj_forward(model, mdata)
+        assert model.nv == 0
+        M = _full_mass_matrix(mj, model, mdata)
+        assert M.shape == (0, 0)
 
 
 class TestStateCheckpointing:


### PR DESCRIPTION
## Problem

`PhysicsMixin.get_mass_matrix()` calls `mj.mj_fullM(model, M, data.qM)`. MuJoCo 3.10 reordered the `mj_fullM` binding so the destination buffer is now the **third** positional argument and the sparse inertia is read from `MjData` directly:

```
mj_fullM(m: MjModel, d: MjData, dst: NDArray[float64] "[m, n]", writeable, c_contiguous) -> None
```

The pre-3.10 call order therefore raises `TypeError: mj_fullM(): incompatible function arguments` on newer MuJoCo. Since the project pins MuJoCo loosely (`mujoco>=3.2.0,<4.0.0`), the resolver picks up 3.10+ and `get_mass_matrix()` hard-crashes. The closest covering test (`test_concurrency_lock_audit.py::test_mass_matrix_still_works`) fails on any environment with MuJoCo >= 3.10.

Reproduce on MuJoCo >= 3.10:

```python
import mujoco as mj, numpy as np
m = mj.MjModel.from_xml_string('<mujoco><worldbody><body><freejoint/><geom type="sphere" size="0.1" mass="1"/></body></worldbody></mujoco>')
d = mj.MjData(m); mj.mj_forward(m, d)
M = np.zeros((m.nv, m.nv))
mj.mj_fullM(m, M, d.qM)   # TypeError on 3.10; check help(mj.mj_fullM)
```

## Change

Add a module-level helper `_full_mass_matrix(mj, model, data)` that is robust to the binding drift:

- Probes the modern `mj_fullM(model, data, dst)` signature first.
- Falls back to the legacy `mj_fullM(model, dst, qM)` orders (both the 1D buffer and the `[m, 1]` column variant some builds require).
- Always allocates `dst` C-contiguous + writeable to satisfy the binding's buffer contract.
- Returns a well-typed `(0, 0)` matrix for zero-DoF scenes.

`get_mass_matrix()` now delegates to the helper. Its `status`/JSON payload (`shape`, `rank`, `condition_number`, `diagonal`, `total_mass`) is unchanged on every supported MuJoCo version.

## Tests

- `test_mass_matrix_is_symmetric_positive_definite` - verifies the actual numbers (symmetric + PD eigenvalues), not just the shape, so a wrong/zero matrix can't pass.
- `TestFullMassMatrixSignatureDrift` - covers: native-call equivalence + C-contiguity, a legacy-signature shim forcing the fallback path, and the zero-DoF empty-matrix case.

The pre-existing `test_mass_matrix_still_works` fails on `main` under MuJoCo >= 3.10 and passes with this change. Full `tests/simulation/mujoco/test_physics.py` + `test_concurrency_lock_audit.py` + `test_agenttool_contract.py` pass (126 passed). Ran the MuJoCo suite headless with `MUJOCO_GL=egl`; `ruff check`, `ruff format --check`, and `mypy` are clean on the touched files.

Closes #588.