### PR TITLE
fix(simulation/rendering): emit ASCII-only text in render/contacts output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: simulation render output is ASCII-only (no emoji)
+
+The MuJoCo rendering tool methods embedded emoji and non-ASCII symbols in their
+agent-facing text payloads: `render` / `render_depth` prefixed summaries with a
+camera emoji, `render_depth` raised a degraded-accuracy warning with a warning
+emoji, `render_all` labelled each camera and its empty-frame warning with the
+same emoji, and `get_contacts` used a burst emoji plus `bullet`/`<->` arrow
+symbols in its per-pair lines. Emoji in tool output corrupts logs and trips
+downstream ASCII parsers, and the project contract is ASCII-only for code,
+logs, and tool text.
+
+- `render`, `render_depth`, `render_all`, and `get_contacts` now emit plain
+  ASCII text. Image/JSON blocks and all numeric values are unchanged; only the
+  decorative text prefixes/separators changed (e.g. the contact list now reads
+  `ground <-> cube_geom`, the depth warning starts with `Warning:`).
+- Regression tests render real frames headlessly and assert every text block of
+  `render`, `render_depth` (including the ARB_clip_control warning branch),
+  `render_all`, and `get_contacts` (with active contacts) is ASCII-only.
+
+
 ### Fixed: `get_mass_matrix` works across MuJoCo `mj_fullM` signature changes
 
 `PhysicsMixin.get_mass_matrix()` called `mj.mj_fullM(model, M, data.qM)`, the

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -618,7 +618,7 @@ class RenderingMixin:
             return {
                 "status": "success",
                 "content": [
-                    {"text": f"📸 {w}x{h} from '{label}' at t={self._world.sim_time:.3f}s"},
+                    {"text": f"{w}x{h} from '{label}' at t={self._world.sim_time:.3f}s"},
                     {"image": {"format": "png", "source": {"bytes": png_bytes}}},
                     {"json": {"pixel_variance": pixel_var, "pixel_mean": pixel_mean, "camera": label}},
                 ],
@@ -696,14 +696,14 @@ class RenderingMixin:
                     except Exception:
                         pass
                 if "ARB_clip_control" in captured:
-                    # ARB_clip_control missing → OpenGL depth buffer uses
+                    # ARB_clip_control missing -> OpenGL depth buffer uses
                     # default [0,1] range with compressed far-plane precision.
                     # After linearization below, Min/Max are still in meters,
                     # but their precision (especially for distant pixels) is
                     # degraded vs. a GPU with ARB_clip_control. Downstream
                     # consumers should treat these values as approximate.
                     self._depth_warn_text = (
-                        "⚠️ Depth accuracy limited on this GPU (missing ARB_clip_control). "
+                        "Warning: Depth accuracy limited on this GPU (missing ARB_clip_control). "
                         "Linearized Min/Max are in meters but precision is degraded "
                         "(especially for far-plane pixels) - treat as approximate."
                     )
@@ -732,12 +732,10 @@ class RenderingMixin:
             denom = zfar - depth * (zfar - znear)
             denom = _np.where(denom == 0, 1e-10, denom)
             depth_m = znear * zfar / denom
-            # Clamp: pixels at far plane (depth==1) → zfar
+            # Clamp: pixels at far plane (depth==1) -> zfar
             depth_m = _np.clip(depth_m, znear, zfar)
 
-            text = (
-                f"📸 Depth {w}x{h} from '{label}'\nMin: {float(depth_m.min()):.4f}m, Max: {float(depth_m.max()):.4f}m"
-            )
+            text = f"Depth {w}x{h} from '{label}'\nMin: {float(depth_m.min()):.4f}m, Max: {float(depth_m.max()):.4f}m"
             if clip_warn:
                 text += f"\n{clip_warn}"
             return {
@@ -818,10 +816,10 @@ class RenderingMixin:
             g2 = _resolve_geom(c["geom2"])
             contacts.append({"geom1": g1, "geom2": g2, "dist": c["dist"], "pos": c["pos"]})
 
-        text = f"💥 {len(contacts)} contacts" if contacts else "No contacts."
+        text = f"{len(contacts)} contacts" if contacts else "No contacts."
         if contacts:
             for c in contacts[:10]:
-                text += f"\n  • {c['geom1']} ↔ {c['geom2']} (d={c['dist']:.4f})"
+                text += f"\n  - {c['geom1']} <-> {c['geom2']} (d={c['dist']:.4f})"
 
         return {
             "status": "success",
@@ -874,7 +872,7 @@ class RenderingMixin:
             if c in all_cams:
                 resolved.append(c)
             else:
-                # Try suffix match: 'side' → 'arm0/side'
+                # Try suffix match: 'side' -> 'arm0/side'
                 matches = [ac for ac in all_cams if ac.endswith("/" + c)]
                 if len(matches) == 1:
                     resolved.append(matches[0])
@@ -902,8 +900,8 @@ class RenderingMixin:
 
         Returns:
             ``{"status", "content": [{"text": summary},
-                                     {"text": "📸 cam1"}, {"image": {...}},
-                                     {"text": "📸 cam2"}, {"image": {...}}, ...]}``
+                                     {"text": "cam1"}, {"image": {...}},
+                                     {"text": "cam2"}, {"image": {...}}, ...]}``
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
@@ -931,10 +929,10 @@ class RenderingMixin:
                         if "json" in block and stats is None:
                             stats = block["json"]
                 if img_block is not None:
-                    label = f"📸 {cam_name}"
+                    label = cam_name
                     # flag near-uniform frames (all black / all clear).
                     if stats and float(stats.get("pixel_variance", 99)) < 1.0:
-                        warn = f"⚠️ camera '{cam_name}': image appears empty (variance < 1)"
+                        warn = f"Warning: camera '{cam_name}': image appears empty (variance < 1)"
                         label = f"{label}  {warn}"
                         low_var_warnings.append(warn)
                     content.append({"text": label})
@@ -945,7 +943,7 @@ class RenderingMixin:
                 content.append({"text": f"{cam_name}: {err}"})
         warn_suffix = f", {len(low_var_warnings)} low-variance" if low_var_warnings else ""
         summary = (
-            f"📸 Multi-camera snapshot at t={self._world.sim_time:.3f}s: "
+            f"Multi-camera snapshot at t={self._world.sim_time:.3f}s: "
             f"{ok} ok, {failed} failed, {len(names)} requested{warn_suffix}"
         )
         return {
@@ -1002,7 +1000,7 @@ class RenderingMixin:
         # Strict validation: if user specified cameras, error on any unresolved names
         # (same policy as render() and render_depth() - fail loudly, don't silently drop).
         # NOTE: `unresolved` contains the raw user inputs that didn't map, so the
-        # namespace-suffix resolution path (e.g. 'side' → 'arm0/side') is preserved.
+        # namespace-suffix resolution path (e.g. 'side' -> 'arm0/side') is preserved.
         if cameras is not None and unresolved:
             return {
                 "status": "error",
@@ -1189,9 +1187,9 @@ class RenderingMixin:
         Idempotent and safe whichever ``start_cameras_recording*`` variant
         was used:
 
-        * Daemon-thread (``start_cameras_recording``) → flips
+        * Daemon-thread (``start_cameras_recording``) -> flips
           ``state["running"] = False``, joins the thread, then flushes.
-        * Synchronous (``start_cameras_recording_synchronous``) → no
+        * Synchronous (``start_cameras_recording_synchronous``) -> no
           thread to join; the ``finalize`` callable returned alongside
           ``on_frame`` is the preferred entry point but
           ``stop_cameras_recording`` works equivalently for callers that

--- a/tests/simulation/mujoco/test_recording_synchronous.py
+++ b/tests/simulation/mujoco/test_recording_synchronous.py
@@ -75,7 +75,7 @@ def _make_render_result(width: int = 32, height: int = 24, fill: int = 128) -> d
     return {
         "status": "success",
         "content": [
-            {"text": f"📸 {width}x{height}"},
+            {"text": f"{width}x{height}"},
             {"image": {"format": "png", "source": {"bytes": _png_bytes(arr)}}},
         ],
     }

--- a/tests/simulation/mujoco/test_rendering.py
+++ b/tests/simulation/mujoco/test_rendering.py
@@ -1052,3 +1052,87 @@ def test_render_depth_no_renderer_returns_opengl_hint(monkeypatch) -> None:
         assert "OpenGL" in r["content"][0]["text"]
     finally:
         sim.destroy()
+
+
+def _iter_text_blocks(result):
+    """Yield every user-facing text string in a tool result's content list."""
+    for block in result.get("content", []):
+        if isinstance(block, dict) and "text" in block:
+            yield block["text"]
+
+
+def test_get_contacts_output_is_ascii_only() -> None:
+    """get_contacts() summary + per-pair lines must be ASCII (no emoji/symbols).
+
+    Agent-facing tool output is ASCII-only: emoji and orphan variation
+    selectors corrupt logs and downstream parsers. A box is dropped onto the
+    ground plane so active contacts exist, exercising the count summary and
+    per-pair "geom1 <-> geom2" lines that previously embedded emoji/arrows.
+    """
+    from strands_robots.simulation import Simulation
+
+    sim = Simulation()
+    sim.create_world()
+    sim.add_object("cube", shape="box", position=[0.0, 0.0, 0.02], size=[0.02, 0.02, 0.02], mass=0.1)
+    sim.step(n_steps=300)
+    try:
+        r = sim.get_contacts()
+        assert r["status"] == "success", r
+        assert r["content"][1]["json"]["contacts"], "expected active contacts for this regression"
+        for text in _iter_text_blocks(r):
+            assert text.isascii(), f"non-ASCII in get_contacts output: {text!r}"
+    finally:
+        sim.destroy()
+
+
+def test_render_depth_output_is_ascii_only(monkeypatch) -> None:
+    """render_depth() summary + ARB_clip_control warning must be ASCII.
+
+    Drives the GPU-warning branch (enable_depth_rendering emits the
+    ARB_clip_control stderr marker) so the warning text is included and
+    asserted ASCII-only - that path previously carried a warning emoji.
+    """
+    np = pytest.importorskip("numpy")
+    sim = _depth_world()
+    try:
+        depth = np.full((2, 2), 0.5, dtype=np.float32)
+        fake = _FakeDepthRenderer(depth, stderr_text="ARB_clip_control not available\n")
+        monkeypatch.setattr(sim, "_get_renderer", lambda w, h: fake)
+        r = sim.render_depth(camera_name="cam_a", width=2, height=2)
+        assert r["status"] == "success", r
+        texts = list(_iter_text_blocks(r))
+        assert any("Depth" in t for t in texts)
+        for text in texts:
+            assert text.isascii(), f"non-ASCII in render_depth output: {text!r}"
+    finally:
+        sim.destroy()
+
+
+@_requires_mujoco
+def test_render_and_render_all_output_is_ascii_only() -> None:
+    """render() + render_all() summaries (incl. low-variance warning) are ASCII.
+
+    Renders real frames headlessly so the camera labels, snapshot summary,
+    and the empty-frame "Warning:" branch are exercised and asserted
+    ASCII-only - these strings previously embedded camera/warning emoji.
+    """
+    os.environ.setdefault("MUJOCO_GL", "glfw")
+    from strands_robots.simulation import Simulation
+
+    sim = Simulation()
+    sim.create_world()
+    sim.add_robot("arm", data_config="so101", position=[0.0, 0.0, 0.0])
+    sim.add_camera("cam_a", position=[-0.3, -0.3, 0.4], target=[0.0, 0.0, 0.1])
+    sim.step(n_steps=2)
+    try:
+        single = sim.render(camera_name="cam_a", width=64, height=48)
+        assert single["status"] == "success", single
+        for text in _iter_text_blocks(single):
+            assert text.isascii(), f"non-ASCII in render output: {text!r}"
+
+        multi = sim.render_all(width=64, height=48)
+        assert multi["status"] == "success", multi
+        for text in _iter_text_blocks(multi):
+            assert text.isascii(), f"non-ASCII in render_all output: {text!r}"
+    finally:
+        sim.destroy()

--- a/tests/simulation/test_policy_runner.py
+++ b/tests/simulation/test_policy_runner.py
@@ -327,7 +327,7 @@ def test_extract_frame_ndarray_handles_render_shape() -> None:
     result_bytes = {
         "status": "success",
         "content": [
-            {"text": "📸 8x8 from 'cam'"},
+            {"text": "8x8 from 'cam'"},
             {"image": {"format": "png", "source": {"bytes": png_bytes}}},
         ],
     }


### PR DESCRIPTION
## Problem

The MuJoCo rendering tool methods embedded emoji and non-ASCII glyphs in their agent-facing text payloads:

- `render` / `render_depth` prefixed their summary text with a camera emoji.
- `render_depth` raised the degraded-accuracy warning with a warning emoji.
- `render_all` labelled each camera and its empty-frame warning with the camera/warning emoji.
- `get_contacts` used a burst emoji and `bullet` / arrow glyphs in its per-pair lines.

Emoji in tool output corrupts logs and breaks downstream ASCII parsers, and the contract for this codebase is ASCII-only in code, logs, and tool text (the same reason emoji were stripped from `lerobot_calibrate` output previously).

## Change

`render`, `render_depth`, `render_all`, and `get_contacts` now emit plain ASCII. Image and JSON blocks and every numeric value are unchanged - only the decorative prefixes/separators changed:

- contact pairs now read `ground <-> cube_geom`
- the depth-accuracy warning now starts with `Warning:`
- camera/snapshot summaries drop the leading emoji

Two pre-existing test fixtures that mocked the old emoji-prefixed render text are updated to the ASCII form.

## Tests

Added regression tests in `tests/simulation/mujoco/test_rendering.py` that render real frames headlessly (EGL) and assert every text block of `render`, `render_depth` (including the `ARB_clip_control` warning branch via a scripted depth renderer), `render_all`, and `get_contacts` (with a box dropped onto the ground plane so active contacts exist) is ASCII-only. They fail on the pre-fix strings and pass after.

Local gate: `ruff check` / `ruff format --check` clean, mypy clean on the changed module, and the rendering + policy_runner + synchronous-recording suites pass (85 passed) under `MUJOCO_GL=egl`.

## Visual artifact

Rollout still rendered in MuJoCo (headless EGL) at 640x480 from the `hero` camera, with the ASCII summary `640x480 from 'hero' at t=0.160s`:

![so101 render still](https://github.com/cagataycali/robots/releases/download/artifact-render-ascii/so101_render_still_640x480.png)

The same scene's `get_contacts` now returns `4 contacts` / `ground <-> cube_geom (...)` and `render_all` returns `Multi-camera snapshot at t=0.160s: 2 ok, 0 failed, 2 requested` - all ASCII.