### PR TITLE
test(simulation/base): cover SimEngine facade guardrail + error-dispatch paths

### DIFF
--- a/tests/simulation/test_simengine_facade_guardrails.py
+++ b/tests/simulation/test_simengine_facade_guardrails.py
@@ -219,6 +219,7 @@ def test_start_policy_resolves_single_robot_when_unspecified():
 
 def test_del_swallows_cleanup_errors(caplog):
     """A failing cleanup during GC is logged, not raised (CPython __del__)."""
+    import gc
     import logging
 
     class Exploding(FakeSim):
@@ -227,5 +228,10 @@ def test_del_swallows_cleanup_errors(caplog):
 
     sim = Exploding()
     with caplog.at_level(logging.WARNING):
-        sim.__del__()
+        # Drive finalization through real garbage collection rather than an
+        # explicit dunder call: dropping the last reference triggers prompt
+        # refcount-based finalization under CPython, with gc.collect() covering
+        # any reference-cycle case. This exercises the genuine destructor path.
+        del sim
+        gc.collect()
     assert any("Cleanup error during __del__" in rec.message for rec in caplog.records)

--- a/tests/simulation/test_simengine_facade_guardrails.py
+++ b/tests/simulation/test_simengine_facade_guardrails.py
@@ -1,0 +1,231 @@
+"""Behavioural tests for the backend-agnostic ``SimEngine`` facade guardrails.
+
+These pin the agent-facing validation and error-reporting contract that the
+concrete facades on :class:`strands_robots.simulation.base.SimEngine` promise:
+
+* ``eval_policy`` accepts a pre-built ``policy_object`` and runs it.
+* ``evaluate_benchmark`` returns structured error dicts (never raises) when the
+  sim has no robots or when the robot is ambiguous in a multi-robot scene.
+* ``register_benchmark_from_file`` validates its arguments and converts loader
+  exceptions into structured error dicts rather than propagating them.
+* ``start_policy`` transparently passes through to ``run_policy``.
+* ``__del__`` swallows (and logs) cleanup failures during GC.
+
+All run against a pure-Python fake engine - no MuJoCo, no GPU.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from strands_robots.policies.mock import MockPolicy
+from strands_robots.simulation.base import SimEngine
+
+
+class FakeSim(SimEngine):
+    """Minimal in-memory ``SimEngine`` with a configurable robot set."""
+
+    def __init__(self, robots: tuple[str, ...] = ("fake_robot",)) -> None:
+        self._joint_names = ["j0", "j1", "j2"]
+        self._robots = {name: self._joint_names for name in robots}
+
+    def create_world(self, timestep=None, gravity=None, ground_plane=True):
+        return {"status": "success"}
+
+    def destroy(self):
+        return {"status": "success"}
+
+    def reset(self):
+        return {"status": "success"}
+
+    def step(self, n_steps: int = 1):
+        return {"status": "success"}
+
+    def get_state(self):
+        return {"sim_time": 0.0, "step_count": 0}
+
+    def add_robot(self, name, **kw):
+        return {"status": "success"}
+
+    def remove_robot(self, name):
+        return {"status": "success"}
+
+    def list_robots(self) -> list[str]:
+        return list(self._robots.keys())
+
+    def robot_joint_names(self, robot_name: str) -> list[str]:
+        return list(self._robots.get(robot_name, []))
+
+    def add_object(self, name, **kw):
+        return {"status": "success"}
+
+    def remove_object(self, name):
+        return {"status": "success"}
+
+    def get_observation(self, robot_name=None, *, skip_images=False):
+        return {n: 0.0 for n in self._joint_names}
+
+    def send_action(self, action, robot_name=None, n_substeps=1):
+        return {"status": "success"}
+
+    def render(self, camera_name="default", width=None, height=None):
+        return {"image": np.zeros((height or 48, width or 64, 3), dtype=np.uint8)}
+
+
+# eval_policy
+
+
+def test_eval_policy_requires_robot_name():
+    """Empty robot_name is rejected with a structured error, never a guess."""
+    result = FakeSim().eval_policy(robot_name="")
+    assert result["status"] == "error"
+    assert "robot_name" in result["content"][0]["text"]
+
+
+def test_eval_policy_unknown_robot_reports_not_found():
+    result = FakeSim().eval_policy(robot_name="ghost")
+    assert result["status"] == "error"
+    assert "ghost" in result["content"][0]["text"]
+
+
+def test_eval_policy_runs_prebuilt_policy_object():
+    """A caller-supplied policy_object is used directly (skips create_policy)."""
+    sim = FakeSim()
+    policy = MockPolicy()
+    result = sim.eval_policy(
+        robot_name="fake_robot",
+        policy_object=policy,
+        n_episodes=1,
+        max_steps=2,
+        control_frequency=10.0,
+    )
+    assert result["status"] == "success"
+    json_blocks = [c["json"] for c in result["content"] if "json" in c]
+    assert json_blocks and "success_rate" in json_blocks[0]
+
+
+# evaluate_benchmark
+
+
+def test_evaluate_benchmark_no_robots_is_structured_error(monkeypatch):
+    """A valid benchmark with an empty sim returns an error, not a traceback."""
+    import strands_robots.simulation.benchmark as bench
+
+    monkeypatch.setattr(bench, "get_benchmark", lambda name: object())
+    result = FakeSim(robots=()).evaluate_benchmark("any_bench")
+    assert result["status"] == "error"
+    assert "No robots" in result["content"][0]["text"]
+
+
+def test_evaluate_benchmark_ambiguous_multi_robot_requires_name(monkeypatch):
+    """Multi-robot scene + no robot_name -> error listing the candidates."""
+    import strands_robots.simulation.benchmark as bench
+
+    monkeypatch.setattr(bench, "get_benchmark", lambda name: object())
+    result = FakeSim(robots=("arm_a", "arm_b")).evaluate_benchmark("any_bench")
+    assert result["status"] == "error"
+    text = result["content"][0]["text"]
+    assert "robot_name" in text
+    assert "arm_a" in text and "arm_b" in text
+
+
+def test_evaluate_benchmark_unknown_name_lists_registered():
+    """An unregistered benchmark name surfaces the available set."""
+    result = FakeSim().evaluate_benchmark("does_not_exist")
+    assert result["status"] == "error"
+    assert "does_not_exist" in result["content"][0]["text"]
+
+
+# register_benchmark_from_file
+
+
+def test_register_benchmark_from_file_rejects_empty_spec_path():
+    result = FakeSim().register_benchmark_from_file("bench", "")
+    assert result["status"] == "error"
+    assert "spec_path" in result["content"][0]["text"]
+
+
+def test_register_benchmark_from_file_rejects_empty_name():
+    result = FakeSim().register_benchmark_from_file("", "/tmp/x.yaml")
+    assert result["status"] == "error"
+    assert "benchmark_name" in result["content"][0]["text"]
+
+
+def test_register_benchmark_from_file_import_error_surfaces_hint(monkeypatch):
+    """A missing optional dep (ImportError) is reported verbatim, not raised."""
+    import strands_robots.simulation.benchmark_spec as spec_mod
+
+    def _boom(name, path):
+        raise ImportError("pyyaml is required for YAML benchmark specs")
+
+    monkeypatch.setattr(spec_mod, "register_benchmark_from_file", _boom)
+    result = FakeSim().register_benchmark_from_file("bench", "/tmp/spec.yaml")
+    assert result["status"] == "error"
+    assert "pyyaml" in result["content"][0]["text"]
+
+
+def test_register_benchmark_from_file_unexpected_error_is_wrapped(monkeypatch):
+    """An unforeseen loader failure is wrapped, not propagated past dispatch."""
+    import strands_robots.simulation.benchmark_spec as spec_mod
+
+    def _boom(name, path):
+        raise RuntimeError("disk gremlin")
+
+    monkeypatch.setattr(spec_mod, "register_benchmark_from_file", _boom)
+    result = FakeSim().register_benchmark_from_file("bench", "/tmp/spec.yaml")
+    assert result["status"] == "error"
+    assert "unexpected error" in result["content"][0]["text"]
+    assert "disk gremlin" in result["content"][0]["text"]
+
+
+# start_policy passthrough
+
+
+def test_start_policy_passes_through_to_run_policy():
+    """The default start_policy is a synchronous run_policy passthrough."""
+    sim = FakeSim()
+    captured: dict[str, Any] = {}
+
+    def fake_run_policy(robot_name=None, **kwargs):
+        captured["robot_name"] = robot_name
+        captured["kwargs"] = kwargs
+        return {"status": "success", "content": [{"text": "ran"}]}
+
+    sim.run_policy = fake_run_policy  # type: ignore[method-assign]
+    result = sim.start_policy(robot_name="fake_robot", instruction="pick")
+    assert result["status"] == "success"
+    assert captured["robot_name"] == "fake_robot"
+    assert captured["kwargs"]["instruction"] == "pick"
+
+
+def test_start_policy_resolves_single_robot_when_unspecified():
+    """start_policy(None) resolves to the lone robot before delegating."""
+    sim = FakeSim()
+    captured: dict[str, Any] = {}
+
+    def fake_run_policy(robot_name=None, **kwargs):
+        captured["robot_name"] = robot_name
+        return {"status": "success", "content": [{"text": "ran"}]}
+
+    sim.run_policy = fake_run_policy  # type: ignore[method-assign]
+    sim.start_policy()
+    assert captured["robot_name"] == "fake_robot"
+
+
+# __del__ cleanup robustness
+
+
+def test_del_swallows_cleanup_errors(caplog):
+    """A failing cleanup during GC is logged, not raised (CPython __del__)."""
+    import logging
+
+    class Exploding(FakeSim):
+        def cleanup(self) -> None:
+            raise RuntimeError("cleanup blew up")
+
+    sim = Exploding()
+    with caplog.at_level(logging.WARNING):
+        sim.__del__()
+    assert any("Cleanup error during __del__" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary

Test-only PR pinning the agent-facing contract of the backend-agnostic `SimEngine` facades in `strands_robots/simulation/base.py` that delegate to `PolicyRunner`. These concrete facades promise structured error dicts (never raised exceptions) on bad input and a clean passthrough/cleanup story, but several of those guardrail branches were uncovered. This locks them in against future refactors.

Adds `tests/simulation/test_simengine_facade_guardrails.py` (13 tests) running entirely against a pure-Python fake engine, so no MuJoCo or GPU is required.

## What it covers

- **`eval_policy`**: rejects empty and unknown `robot_name` with a structured error (no silent first-robot guess) and runs a caller-supplied `policy_object` directly, skipping `create_policy`.
- **`evaluate_benchmark`**: returns structured error dicts rather than raising for an empty sim and for an ambiguous multi-robot scene (error lists the candidate robots), and surfaces the registered set on an unknown benchmark name.
- **`register_benchmark_from_file`**: validates empty `benchmark_name` / `spec_path`, reports a missing optional dependency (`ImportError`) verbatim, and wraps an unexpected loader failure as an error dict instead of propagating past dispatch.
- **`start_policy`**: synchronous passthrough to `run_policy`, resolving the lone robot when `robot_name` is omitted.
- **`__del__`**: swallows and logs cleanup failures during GC (exceptions cannot propagate from `__del__`).

This raises `simulation/base.py` line coverage by exercising the previously-uncovered branches at lines 493-494, 588, 704, 725, 793, 803-807, and 907-910.

## Verification

- `ruff check` / `ruff format --check` clean; `mypy` clean on the new file.
- All 13 new tests pass. Tests assert outputs (the status/error text and result payload), not internal state, per the repo test conventions; no host paths, no emojis, no source changes.

## §13 Changelog

**Round 1** — addressed review feedback:
- The `__del__` cleanup test previously called `sim.__del__()` explicitly, which tripped a code-scanning finding (explicit dunder invocation). Replaced it with `del sim` + `gc.collect()` so finalization runs through real refcount-based garbage collection. This both clears the finding and, as a side benefit, exercises the genuine destructor path rather than the method in isolation. Test remains pure-Python and deterministic under CPython prompt finalization (verified across repeated runs); behaviour and assertion are unchanged.