### PR TITLE
test(mesh): cover rate-limit sliding-window expiry pruning

### DIFF
--- a/tests/mesh/test_robot_mesh_security.py
+++ b/tests/mesh/test_robot_mesh_security.py
@@ -354,3 +354,83 @@ class TestDeclineSideChannel322:
         # The operator's literal reply MUST NOT be echoed to the LLM.
         assert secret not in text, "operator's literal decline reply leaked to the LLM result (#322 side-channel)"
         m.emergency_stop.assert_not_called()
+
+
+# --- rate-limit sliding-window expiry -----------------------------------
+
+
+class _FakeClock:
+    """Deterministic stand-in for ``time.monotonic`` used to drive the
+    rate-limit sliding window without sleeping. ``advance`` moves the
+    virtual clock forward so stale bucket entries fall outside the
+    window and get pruned.
+    """
+
+    def __init__(self, start: float = 1000.0) -> None:
+        self._now = start
+
+    def __call__(self) -> float:
+        return self._now
+
+    def advance(self, seconds: float) -> None:
+        self._now += seconds
+
+
+class TestRateLimitWindowExpiry:
+    """The sliding window must *forget* calls older than the configured
+    window. Without expiry, three ``emergency_stop`` calls issued long
+    ago would permanently lock the agent out of ever issuing another -
+    the opposite of the safety property (bound nuisance, never inhibit a
+    genuine emergency). These pin the stale-entry pruning in all three
+    rate-limit helpers.
+    """
+
+    def test_check_clears_after_window_elapses(self, monkeypatch):
+        clock = _FakeClock()
+        monkeypatch.setattr(rmt.time, "monotonic", clock)
+        rmt._reset_rate_limits()
+
+        # Fill emergency_stop (cap 3 / 60s window) at t=0.
+        for _ in range(3):
+            assert rmt._rate_limit_record("emergency_stop") is None
+        # Bucket full: a check (which does not consume) reports rejection.
+        assert rmt._rate_limit_check("emergency_stop") is not None
+
+        # Just before the window closes the slots are still held.
+        clock.advance(59.0)
+        assert rmt._rate_limit_check("emergency_stop") is not None
+
+        # Past the window the stale entries are pruned and a slot frees up.
+        clock.advance(2.0)
+        assert rmt._rate_limit_check("emergency_stop") is None
+
+    def test_record_prunes_stale_entries(self, monkeypatch):
+        clock = _FakeClock()
+        monkeypatch.setattr(rmt.time, "monotonic", clock)
+        rmt._reset_rate_limits()
+
+        for _ in range(3):
+            rmt._rate_limit_record("emergency_stop")
+        assert len(rmt._RATE_HISTORY["emergency_stop"]) == 3
+
+        # After the window elapses, the next record prunes the three stale
+        # timestamps before appending its own, so the bucket holds one entry.
+        clock.advance(61.0)
+        rmt._rate_limit_record("emergency_stop")
+        assert len(rmt._RATE_HISTORY["emergency_stop"]) == 1
+
+    def test_check_and_record_frees_slot_after_window(self, monkeypatch):
+        clock = _FakeClock()
+        monkeypatch.setattr(rmt.time, "monotonic", clock)
+        rmt._reset_rate_limits()
+
+        # Atomically reserve all 3 slots at t=0; the 4th is rejected.
+        for _ in range(3):
+            assert rmt._rate_limit_check_and_record("emergency_stop") is None
+        assert rmt._rate_limit_check_and_record("emergency_stop") is not None
+
+        # Once the window elapses the stale entries are pruned and the
+        # atomic check+record reserves a fresh slot.
+        clock.advance(61.0)
+        assert rmt._rate_limit_check_and_record("emergency_stop") is None
+        assert len(rmt._RATE_HISTORY["emergency_stop"]) == 1


### PR DESCRIPTION
## Problem

The `robot_mesh` per-action rate limiter (`_rate_limit_check`, `_rate_limit_record`, `_rate_limit_check_and_record`) prunes timestamps older than the configured window before evaluating the cap, so calls issued long ago stop counting against the limit. That stale-entry pruning is the load-bearing half of the safety contract: without it, three `emergency_stop` calls would permanently lock the agent out of ever issuing another - inverting the intended property (the rate limit exists to bound LLM-driven nuisance, never to inhibit a genuine emergency).

The existing `TestRateLimit` / `TestRateLimitTOCTOU` cover the cap and the check/record split, but the expiry `popleft` loop in all three helpers was uncovered - a regression that broke window expiry would slip through the suite.

## Change

Add `TestRateLimitWindowExpiry`, driving a deterministic fake `time.monotonic` (no sleeping) so the sliding window can be advanced precisely:

- `test_check_clears_after_window_elapses` - a full bucket still rejects just before the window closes, then frees a slot once it elapses.
- `test_record_prunes_stale_entries` - a record after the window prunes the three stale timestamps before appending, leaving the bucket at one entry.
- `test_check_and_record_frees_slot_after_window` - the atomic check+record reserves a fresh slot post-window.

## Verification

All three tests fail when the expiry loop is removed (verified by mutating the source) and pass with it intact, so they pin real behavior rather than implementation detail. Coverage of `strands_robots/tools/robot_mesh.py` expiry lines goes from uncovered to covered.

Test-only change: `ruff check` / `ruff format --check` clean, `mypy` clean, full `tests/mesh/test_robot_mesh_security.py` suite (27 tests) green.