### PR TITLE
test(simulation/physics): make mj_fullM drift test portable across MuJoCo bindings

### DIFF
--- a/tests/simulation/mujoco/test_physics.py
+++ b/tests/simulation/mujoco/test_physics.py
@@ -234,11 +234,16 @@ class TestFullMassMatrixSignatureDrift:
         # Simulate an older MuJoCo binding whose mj_fullM rejects the modern
         # (model, data, dst) order and expects (model, dst, qM). The helper
         # must transparently fall back and still produce the correct matrix.
+        #
+        # The legacy emulation must not delegate to the installed mj_fullM in a
+        # fixed argument order: the installed binding may itself be the legacy
+        # one (mujoco < 3.10), so a hard-coded modern call would raise and make
+        # this drift test non-portable across the very signatures it covers.
+        # Instead it fills dst from the precomputed reference, asserting only
+        # the legacy (model, dst, qM) call contract.
         model, data = sim._world._model, sim._world._data
         mj.mj_forward(model, data)
         reference = _full_mass_matrix(mj, model, data)
-
-        real_fullm = mj.mj_fullM
 
         class _LegacyShim:
             """Proxy mujoco module exposing only a legacy mj_fullM."""
@@ -254,10 +259,15 @@ class TestFullMassMatrixSignatureDrift:
 
                 if isinstance(a, _mj.MjData):
                     raise TypeError("legacy binding: expected (model, dst, qM)")
-                # a is dst, b is qM (1D or [m, 1]) - emulate via the real call.
-                tmp = np.zeros_like(a, order="C")
-                real_fullm(m, data, tmp)
-                a[...] = tmp
+                # Legacy contract: a is the dense dst buffer, b is the sparse
+                # inertia qM (1D or [m, 1]). Validate that contract, then fill
+                # dst from the known-correct reference (version-independent, so
+                # the emulation works whatever signature the installed mujoco
+                # binding actually uses).
+                assert isinstance(a, np.ndarray) and a.flags["WRITEABLE"]
+                qm = np.asarray(b).reshape(-1)
+                assert qm.shape[0] == data.qM.shape[0]
+                a[...] = reference
 
         shim = _LegacyShim()
         M = _full_mass_matrix(shim, model, data)


### PR DESCRIPTION
## Problem

`TestFullMassMatrixSignatureDrift::test_helper_falls_back_to_legacy_signatures` guards `_full_mass_matrix` against `mj_fullM` binding drift across MuJoCo releases. The signature changed between versions:

- MuJoCo >= 3.10: `mj_fullM(model, data, dst)` (modern)
- MuJoCo < 3.10: `mj_fullM(model, dst, qM)` (legacy)

The test emulated a legacy binding via a `_LegacyShim`, but the shim's internal fill delegated back to the *installed* `mj_fullM` using a hard-coded **modern** `(model, data, dst)` argument order:

```python
tmp = np.zeros_like(a, order="C")
real_fullm(m, data, tmp)   # assumes modern signature
a[...] = tmp
```

On any installed MuJoCo whose binding is itself the legacy `(model, dst, qM)` form, that internal call raises `TypeError`. Since the project declares `mujoco>=3.2.0,<4.0.0`, this includes supported, in-bounds versions (e.g. 3.9.x). The result: the test meant to verify signature-drift portability was itself non-portable, and failed on legacy MuJoCo builds:

```
TypeError: mj_fullM(): incompatible function arguments. The following argument types are supported:
    1. (m: MjModel, dst: NDArray[float64], M: NDArray[float64]) -> None
Invoked with: <MjModel>, <MjData>, array([[0., 0., ...]])
```

Reproduced under mujoco 3.9.0; passes only on builds with the modern signature (e.g. 3.10.x in CI).

## Change

Make the legacy emulation version-independent. The shim no longer delegates to the installed `mj_fullM` in a fixed argument order. Instead it validates the legacy `(model, dst, qM)` call contract (writeable dense `dst`, sparse `qM` of length `model.nM`) and fills `dst` from the reference matrix computed by the production helper. This keeps the test focused on what it actually verifies (that `_full_mass_matrix` falls back to the legacy call order when the modern order raises) without coupling the emulation to whatever binding the running MuJoCo happens to expose.

Production `_full_mass_matrix` was already correct on both bindings; this is a test-only fix.

## Tests

`tests/simulation/mujoco/test_physics.py::TestFullMassMatrixSignatureDrift` (3 tests) now passes on both bindings:

- mujoco 3.9.0 (legacy `(model, dst, qM)`): pre-fix FAILED, post-fix PASSES
- mujoco 3.10.0 (modern `(model, data, dst)`): PASSES

Full `tests/simulation/mujoco/test_physics.py` (58 tests) green; `ruff check`, `ruff format --check`, and `mypy` clean.