### PR TITLE
fix(doctor): report real package versions via importlib.metadata

### DIFF
--- a/strands_robots/doctor.py
+++ b/strands_robots/doctor.py
@@ -108,7 +108,7 @@ def check_python_version() -> str:
 def check_strands_robots_version() -> str:
     """strands-robots importable and version."""
     try:
-        import strands_robots  # noqa: F401
+        importlib.import_module("strands_robots")
     except ImportError as e:
         return _fail(f"strands-robots not importable: {e}", fix='uv pip install "strands-robots[sim-mujoco]"')
     return _pass(f"strands-robots {_resolve_version('strands_robots', 'strands-robots')}")

--- a/strands_robots/doctor.py
+++ b/strands_robots/doctor.py
@@ -12,6 +12,7 @@ Usage:
 
 from __future__ import annotations
 
+import importlib
 import logging
 import os
 import platform
@@ -62,6 +63,37 @@ def _skip(msg: str) -> str:
     return f"  SKIP  {msg}"
 
 
+def _resolve_version(import_name: str, dist_name: str) -> str:
+    """Resolve a package version, preferring installed distribution metadata.
+
+    Neither ``strands_robots`` nor ``strands`` exposes a module-level
+    ``__version__`` attribute, so reading ``module.__version__`` yields a
+    useless placeholder. The authoritative version lives in the installed
+    distribution metadata (``pyproject.toml`` -> wheel/egg-info), which
+    ``importlib.metadata.version`` reads. Fall back to a module ``__version__``
+    attribute only if metadata lookup fails (e.g. running from a source tree
+    that was never installed).
+
+    Args:
+        import_name: Importable module name (e.g. ``"strands_robots"``).
+        dist_name: Installed distribution name (e.g. ``"strands-robots"``).
+
+    Returns:
+        A version string, or ``"unknown"`` if neither source resolves one.
+    """
+    from importlib.metadata import PackageNotFoundError, version
+
+    try:
+        return version(dist_name)
+    except PackageNotFoundError:
+        pass
+    try:
+        module = importlib.import_module(import_name)
+    except ImportError:
+        return "unknown"
+    return str(getattr(module, "__version__", "unknown"))
+
+
 def check_python_version() -> str:
     """Python >= 3.12 required."""
     v = sys.version_info
@@ -76,12 +108,10 @@ def check_python_version() -> str:
 def check_strands_robots_version() -> str:
     """strands-robots importable and version."""
     try:
-        import strands_robots
-
-        ver = getattr(strands_robots, "__version__", "unknown")
-        return _pass(f"strands-robots {ver}")
+        import strands_robots  # noqa: F401
     except ImportError as e:
         return _fail(f"strands-robots not importable: {e}", fix='uv pip install "strands-robots[sim-mujoco]"')
+    return _pass(f"strands-robots {_resolve_version('strands_robots', 'strands-robots')}")
 
 
 def check_mujoco() -> str:
@@ -224,12 +254,10 @@ def check_sim_smoke() -> str:
 def check_strands_agents() -> str:
     """strands-agents importable (needed for Agent(tools=[robot]))."""
     try:
-        import strands
-
-        ver = getattr(strands, "__version__", "?")
-        return _pass(f"strands-agents {ver}")
+        import strands  # noqa: F401
     except ImportError:
         return _fail("strands-agents not importable", fix='uv pip install "strands-agents>=1.0"')
+    return _pass(f"strands-agents {_resolve_version('strands', 'strands-agents')}")
 
 
 def check_mesh() -> str:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -444,3 +444,46 @@ class TestDoctorSerialPermissions:
         result = check_serial_permissions()
         # User is a listed member, so this still passes despite the probe error.
         assert "  PASS  " in result
+
+
+class TestDoctorVersionResolution:
+    """Version checks must report the real installed version, not a placeholder.
+
+    Regression: ``check_strands_robots_version``/``check_strands_agents`` read a
+    module-level ``__version__`` that neither package defines, so they emitted
+    ``strands-robots unknown`` / ``strands-agents ?`` even when the package was
+    correctly installed - making the first diagnostic a new user runs useless.
+    """
+
+    def test_strands_robots_version_matches_metadata(self) -> None:
+        from importlib.metadata import version
+
+        from strands_robots.doctor import check_strands_robots_version
+
+        result = check_strands_robots_version()
+        assert "PASS" in result
+        assert version("strands-robots") in result
+        assert "unknown" not in result
+
+    def test_strands_agents_version_matches_metadata(self) -> None:
+        from importlib.metadata import version
+
+        from strands_robots.doctor import check_strands_agents
+
+        result = check_strands_agents()
+        assert "PASS" in result
+        assert version("strands-agents") in result
+        assert "strands-agents ?" not in result
+
+    def test_resolve_version_prefers_distribution_metadata(self) -> None:
+        from importlib.metadata import version
+
+        from strands_robots.doctor import _resolve_version
+
+        assert _resolve_version("strands_robots", "strands-robots") == version("strands-robots")
+
+    def test_resolve_version_unknown_when_absent(self) -> None:
+        from strands_robots.doctor import _resolve_version
+
+        # Neither an installed distribution nor an importable module exists.
+        assert _resolve_version("strands_robots_nope_xyz", "strands-robots-nope-xyz") == "unknown"

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -181,8 +181,16 @@ class TestDoctorDegradedPaths:
 
     @staticmethod
     def _block_imports(monkeypatch: pytest.MonkeyPatch, *blocked: str) -> None:
-        """Make ``import <name>`` raise ImportError for the named modules."""
+        """Simulate the named modules being uninstalled.
+
+        Blocks both ``import <name>`` and ``importlib.import_module(<name>)``:
+        the ``__import__`` hook covers the statement form, while evicting any
+        cached entry from ``sys.modules`` forces ``import_module`` (which
+        returns a live cached module without re-invoking ``__import__``) to
+        re-import and hit the hook too.
+        """
         import builtins
+        import sys
 
         real_import = builtins.__import__
 
@@ -190,6 +198,10 @@ class TestDoctorDegradedPaths:
             if name in blocked or any(name.startswith(f"{b}.") for b in blocked):
                 raise ImportError(f"blocked for test: {name}")
             return real_import(name, *args, **kwargs)  # type: ignore[arg-type]
+
+        for name in list(sys.modules):
+            if name in blocked or any(name.startswith(f"{b}.") for b in blocked):
+                monkeypatch.delitem(sys.modules, name, raising=False)
 
         monkeypatch.setattr(builtins, "__import__", fake_import)
 


### PR DESCRIPTION
## Problem

`strands-robots doctor` is the first command a new user runs to diagnose setup issues, and its output is what they paste into bug reports. But two of its checks print a useless placeholder instead of the real version:

```
  PASS  strands-robots unknown
  PASS  strands-agents ?
```

This happens even on a correct, fully-working install. The cause: `check_strands_robots_version()` and `check_strands_agents()` read a module-level `__version__` attribute that neither `strands_robots` nor `strands` actually defines, so `getattr(module, "__version__", default)` always falls through to the `"unknown"` / `"?"` default. The authoritative version lives only in the installed distribution metadata.

## Change

Add a small `_resolve_version(import_name, dist_name)` helper that resolves the version from `importlib.metadata.version(dist_name)` (the source of truth, populated from `pyproject.toml`), falling back to a module `__version__` for an uninstalled source tree and to `"unknown"` only when neither resolves. Both version checks now use it:

```
  PASS  strands-robots 0.4.1.dev111+g06f400e80
  PASS  strands-agents 1.44.0
```

## Tests

Adds `TestDoctorVersionResolution` with regression coverage that fails on the pre-fix code:
- reported version matches `importlib.metadata.version(...)` and is never the old `unknown` / `strands-agents ?` placeholder (both version checks);
- `_resolve_version` prefers distribution metadata;
- `_resolve_version` returns `"unknown"` when neither a distribution nor an importable module exists.

Full `tests/test_doctor.py` passes (41 tests). `ruff check`, `ruff format --check`, and `mypy strands_robots tests tests_integ` are clean for the touched files (pre-existing `reachy_transport.py` mypy errors from a websockets stub drift are unrelated and untouched).

## Changelog

### Round 1 (review feedback)
- Addressed the CodeQL code-scanning finding (mixed import-style: `strands_robots` was imported both as a bare `import` statement in `check_strands_robots_version` and via `from strands_robots import Robot` in the sim smoke test). The importability probe now uses `importlib.import_module("strands_robots")` (`importlib` is already a module-level import), so the bare statement form is gone. Behavior is unchanged: `ImportError` is still raised and surfaced as a FAIL row when the package is not installed.
- Hardened the `_block_imports` test helper to evict blocked modules from `sys.modules` in addition to patching `__import__`. `importlib.import_module` returns a cached module without re-invoking `__import__`, so the eviction is required for `test_strands_robots_not_importable_fails` to keep faithfully simulating an uninstalled module under the new probe. Regression suite still green (the importability-fail and version-resolution cases pass).