### PR TITLE
test(simulation): rename internally-numbered sim tests to behavior-descriptive names

### DIFF
--- a/tests/simulation/mujoco/test_robot_name_optional.py
+++ b/tests/simulation/mujoco/test_robot_name_optional.py
@@ -1,16 +1,13 @@
-"""AX-1 regression test: robot_name optional across get_robot_state-family methods.
+"""robot_name is optional and inferred across the get_robot_state family.
 
-This test MUST FAIL before the fix and PASS after it.
+Pins a consistent contract: get_observation, send_action, get_robot_state,
+run_policy, and start_policy all accept ``robot_name=None`` and infer the robot
+when exactly one exists in the world. A caller who learns one signature can
+transfer it to the others.
 
-The inconsistency: get_observation(robot_name=None) works (infers single robot),
-but get_robot_state(robot_name) requires the arg. An agent (or human) who learns
-one signature cannot transfer to the other.
-
-Fix: a shared _resolve_single_robot(robot_name) helper that resolves None when
-exactly one robot exists, and raises ValueError listing candidates when ambiguous.
-
-Applied to: get_robot_state, run_policy, start_policy.
-Already correct: get_observation, send_action (default to None).
+The shared ``_resolve_single_robot(robot_name)`` helper resolves None to the
+sole robot's name and raises ValueError listing candidates when the choice is
+ambiguous (more than one robot) or impossible (no robots).
 """
 
 import os
@@ -25,7 +22,7 @@ def single_robot_sim():
     """Create a sim with exactly ONE robot (so100)."""
     from strands_robots.simulation.mujoco.simulation import MuJoCoSimEngine
 
-    sim = MuJoCoSimEngine(tool_name="test_ax1_single")
+    sim = MuJoCoSimEngine(tool_name="test_single_robot")
     sim.create_world()
     result = sim.add_robot("alice", data_config="so100")
     assert result["status"] == "success", f"add_robot failed: {result}"
@@ -38,7 +35,7 @@ def two_robot_sim():
     """Create a sim with TWO robots (both so100, different names)."""
     from strands_robots.simulation.mujoco.simulation import MuJoCoSimEngine
 
-    sim = MuJoCoSimEngine(tool_name="test_ax1_multi")
+    sim = MuJoCoSimEngine(tool_name="test_two_robots")
     sim.create_world()
     r1 = sim.add_robot("alice", data_config="so100")
     assert r1["status"] == "success", f"add_robot alice failed: {r1}"
@@ -52,7 +49,7 @@ class TestGetRobotStateOptional:
     """get_robot_state() should work without robot_name when exactly one robot."""
 
     def test_single_robot_no_arg(self, single_robot_sim):
-        """Core AX-1: single-robot sim -> get_robot_state() (no arg) succeeds."""
+        """Single-robot sim -> get_robot_state() with no arg succeeds."""
         result = single_robot_sim.get_robot_state()
         assert result["status"] == "success", f"Expected success, got: {result}"
         # Should contain joint state
@@ -118,7 +115,7 @@ class TestStartPolicyOptional:
 
 
 class TestRobotFactoryEntryPoint:
-    """AX-4 verification: Robot("so100", mode="sim") -> get_robot_state() works."""
+    """Robot("so100", mode="sim") -> get_robot_state() works with no arg."""
 
     def test_robot_factory_get_state_no_arg(self):
         """Robot('so100') factory -> get_robot_state() just works."""
@@ -157,7 +154,7 @@ class TestResolveSingleRobotHelper:
         """None + no robots -> ValueError."""
         from strands_robots.simulation.mujoco.simulation import MuJoCoSimEngine
 
-        sim = MuJoCoSimEngine(tool_name="test_ax1_empty")
+        sim = MuJoCoSimEngine(tool_name="test_no_robots")
         sim.create_world()
         try:
             with pytest.raises(ValueError, match="[Nn]o robot"):

--- a/tests/simulation/test_sim_engine_describe_discovery.py
+++ b/tests/simulation/test_sim_engine_describe_discovery.py
@@ -1,8 +1,9 @@
-"""AX-2 regression test: SimEngine.describe() discovery surface.
+"""SimEngine.describe() exposes a single-call discovery surface.
 
-Verifies the discovery surface so agents can learn an engine's contract in a
-single call instead of probe-and-fail. Pre-fix, describe() does not exist and
-these assertions fail with AttributeError.
+Verifies that describe() lets a caller learn an engine's contract in one call
+(its robots, cameras, world state, and the core method set) instead of
+probe-and-fail. Covers the abstract base class via a minimal concrete engine
+and the live MuJoCo engine.
 
 Also pins the no-alias rule: the registry must NOT export a duplicate
 ``get_robot_info`` name. The canonical accessor is ``get_robot``; agents learn


### PR DESCRIPTION
## Problem

Two simulation tests were named after the opaque internal tracking identifiers that prompted them (`ax1`/`ax2`) rather than the behavior they verify. A reader scanning the test tree learns nothing from `test_ax1_*` / `test_ax2_*`, and the names tie the files to a transient backlog instead of to a standing contract.

## Change

Renamed via `git mv` (history preserved):

- `tests/simulation/mujoco/test_ax1_robot_name_optional.py` -> `test_robot_name_optional.py`
- `tests/simulation/test_ax2_describe_discovery.py` -> `test_sim_engine_describe_discovery.py`

Also stripped the change-log style cruft from the module docstrings (the `AX-N` labels, the `MUST FAIL before the fix` note, and `Core AX-1` / `AX-4 verification` mentions) and the matching `tool_name="test_ax1_*"` strings, so each file reads as a standing description of the contract it pins rather than a record of the change that introduced it.

No test logic changed.

## Verification

```
MUJOCO_GL=egl python -m pytest tests/simulation/mujoco/test_robot_name_optional.py \
  tests/simulation/test_sim_engine_describe_discovery.py -q
23 passed
```

`ruff check` + `ruff format --check` clean. Rename-only; no `strands_robots` source or behavior touched, so no visual artifact applies.