### PR TITLE
fix(simulation): unify 'no world' guard message + close partial-world gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: unified "no world" guard contract across the simulation facade
+
+Every world-touching method on the MuJoCo `Simulation` facade returns a
+structured error when called before `create_world` (or after a failed
+`load_scene`), but the wording had drifted into three different strings -
+`"No world. Call create_world first."`, `"No world. Use action='create_world'
+first."`, and `"No world. Call create_world (or load_scene) first."` - so an
+agent that learned the message from one action did not recognise it from
+another. Worse, four methods (`send_action`, `replace_scene_mjcf`,
+`patch_scene_mjcf`, `add_robot`) guarded only on `self._world is None` (or
+`_model` alone) and so accepted the *partial* world state that `load_scene`
+leaves behind when its spec compile fails (`_world` set, `_model`/`_data` still
+`None`), then either crashed on a `None` dereference or silently recovered.
+
+- A single module-level `_NO_WORLD_MSG` constant is now the source of truth for
+  the guard text. All 19 inline guards and the `_require_world()` helper (whose
+  docstring already promised a unified message) return that exact string.
+- The four weak guards now check the full `world + _model + _data` predicate,
+  matching every other method, so the partial-world state is reported as the
+  standard no-world error instead of slipping through.
+- Regression tests parametrize all guarded methods over both the no-world and
+  partial-world states and assert the exact unified message; the message-drift
+  and partial-world-slip both fail on pre-fix code.
+
+
 ### Fixed: simulation render output is ASCII-only (no emoji)
 
 The MuJoCo rendering tool methods embedded emoji and non-ASCII symbols in their

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -90,6 +90,12 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Single source of truth for the "no live world" guard message. Every
+# world-touching facade method checks the same condition (world + compiled
+# model + data all present) and returns this exact text, so an agent that
+# learns the string from one action recognises it from all of them.
+_NO_WORLD_MSG = "No world. Call create_world (or load_scene) first."
+
 _TOOL_SPEC_PATH = Path(__file__).parent / "tool_spec.json"
 
 # Tool schema is 357 lines of JSON. `tool_spec` property is on the LLM hot path
@@ -272,8 +278,8 @@ class MuJoCoSimEngine(
             ``unresolved_keys`` list (and ``applied``) so callers can
             self-correct instead of silently losing commands.
         """
-        if self._world is None or self._world._model is None:
-            return {"status": "error", "content": [{"text": "No world. Call create_world first."}]}
+        if self._world is None or self._world._model is None or self._world._data is None:
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         if robot_name is None:
             if not self._world.robots:
                 return {"status": "error", "content": [{"text": "No robots in the world."}]}
@@ -474,8 +480,8 @@ class MuJoCoSimEngine(
         vocabulary is insufficient. For additive changes, prefer those
         methods - they keep the registry in sync.
         """
-        if self._world is None:
-            return {"status": "error", "content": [{"text": "No world. Use action='create_world' first."}]}
+        if self._world is None or self._world._model is None or self._world._data is None:
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         if err := self._require_no_running_policy("replace_scene_mjcf"):
             return err
 
@@ -517,8 +523,8 @@ class MuJoCoSimEngine(
         edits; use ``replace_scene_mjcf`` when you need to express MJCF
         elements not covered by the supported op vocabulary.
         """
-        if self._world is None:
-            return {"status": "error", "content": [{"text": "No world. Use action='create_world' first."}]}
+        if self._world is None or self._world._model is None or self._world._data is None:
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         if err := self._require_no_running_policy("patch_scene_mjcf"):
             return err
 
@@ -757,8 +763,8 @@ class MuJoCoSimEngine(
         XML.  This preserves previously-created world state (gravity, objects,
         cameras, other robots).
         """
-        if self._world is None:
-            return {"status": "error", "content": [{"text": "No world. Use action='create_world' first."}]}
+        if self._world is None or self._world._model is None or self._world._data is None:
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         if err := self._require_no_running_policy("add_robot"):
             return err
         if name in self._world.robots:
@@ -995,7 +1001,7 @@ class MuJoCoSimEngine(
         response for user display.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
-            return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         if not self._world.robots:
             return {"status": "success", "content": [{"text": "No robots. Use action='add_robot'."}]}
 
@@ -1041,7 +1047,7 @@ class MuJoCoSimEngine(
         accepts ``name`` as an alias (bidirectional) so legacy LLM calls
         keep working, but new tool specs should document only robot_name."""
         if self._world is None or self._world._model is None or self._world._data is None:
-            return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         try:
             robot_name = self._resolve_single_robot(robot_name)
         except ValueError as e:
@@ -1091,7 +1097,7 @@ class MuJoCoSimEngine(
     ) -> dict[str, Any]:
         """Add an object to the simulation."""
         if self._world is None or self._world._model is None or self._world._data is None:
-            return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         if err := self._require_no_running_policy("add_object"):
             return err
         if name in self._world.objects:
@@ -1169,7 +1175,7 @@ class MuJoCoSimEngine(
         self, name: str, position: list[float] | None = None, orientation: list[float] | None = None
     ) -> dict[str, Any]:
         if self._world is None or self._world._model is None or self._world._data is None:
-            return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         if name not in self._world.objects:
             return {"status": "error", "content": [{"text": f"Object '{name}' not found."}]}
         # Guard: move_object writes qpos + calls mj_forward, racing a running policy.
@@ -1194,7 +1200,7 @@ class MuJoCoSimEngine(
 
     def list_objects(self) -> dict[str, Any]:
         if self._world is None or self._world._model is None or self._world._data is None:
-            return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         if not self._world.objects:
             return {"status": "success", "content": [{"text": "No objects."}]}
 
@@ -1235,7 +1241,7 @@ class MuJoCoSimEngine(
         bodies are namespaced ``<robot>/<body>``.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
-            return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         if err := self._require_no_running_policy("add_camera"):
             return err
 
@@ -1365,7 +1371,7 @@ class MuJoCoSimEngine(
 
     def step(self, n_steps: int = 1) -> dict[str, Any]:
         if self._world is None or self._world._model is None or self._world._data is None:
-            return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         # reject negative, accept zero as no-op
         if not isinstance(n_steps, int):
             try:
@@ -1412,7 +1418,7 @@ class MuJoCoSimEngine(
 
     def reset(self) -> dict[str, Any]:
         if self._world is None or self._world._model is None or self._world._data is None:
-            return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         # reset during a running policy races mj_step -> SEGFAULT risk
         if err := self._require_no_running_policy("reset"):
             return err
@@ -1431,7 +1437,7 @@ class MuJoCoSimEngine(
 
     def get_state(self) -> dict[str, Any]:
         if self._world is None or self._world._model is None or self._world._data is None:
-            return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         lines = [
             "Simulation State",
             f"t={self._world.sim_time:.4f}s (step {self._world.step_count})",
@@ -1483,7 +1489,7 @@ class MuJoCoSimEngine(
 
     def set_gravity(self, gravity: list[float] | float | int) -> dict[str, Any]:
         if self._world is None or self._world._model is None or self._world._data is None:
-            return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         # set_gravity during a running policy races the worker thread
         if err := self._require_no_running_policy("set_gravity"):
             return err
@@ -1516,7 +1522,7 @@ class MuJoCoSimEngine(
 
     def set_timestep(self, timestep: float) -> dict[str, Any]:
         if self._world is None or self._world._model is None or self._world._data is None:
-            return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         if err := self._require_no_running_policy("set_timestep"):
             return err
         # reject non-positive; warn on huge values
@@ -1625,7 +1631,7 @@ class MuJoCoSimEngine(
         ``robots`` map is also filtered to just that entry.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
-            return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
 
         mj = self._mj
         model = self._world._model
@@ -1756,17 +1762,18 @@ class MuJoCoSimEngine(
         return "simulation"
 
     def _require_world(self) -> dict[str, Any] | None:
-        """Return unified 'no world' error or None if world is live.
+        """Return the unified 'no world' error, or None if the world is live.
 
-        Replaces scattered ``"No simulation."`` / ``"No world."`` strings. Every
-        action that touches ``self._world`` / ``self._world._model`` /
-        ``self._world._data`` should call this first.
+        The "world is live" predicate is ``self._world`` plus a compiled
+        ``_model`` and allocated ``_data`` - the partial state ``load_scene``
+        leaves behind on a compile failure (``_world`` set, model/data still
+        ``None``) counts as *not* live. Methods that touch model/data inline the
+        same condition for mypy narrowing, but every guard - inline or via this
+        helper - returns the single :data:`_NO_WORLD_MSG` string so the contract
+        reads identically across the facade.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
-            return {
-                "status": "error",
-                "content": [{"text": ("No world. Call create_world (or load_scene) first.")}],
-            }
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         return None
 
     def _prune_done_futures(self) -> None:
@@ -1931,7 +1938,7 @@ class MuJoCoSimEngine(
         alternate horizon specification; run_policy converts to duration.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
-            return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         try:
             robot_name = self._resolve_single_robot(robot_name)
         except ValueError as e:
@@ -2080,7 +2087,7 @@ class MuJoCoSimEngine(
         can specify horizon in steps rather than wall-clock seconds.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
-            return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
 
         try:
             robot_name = self._resolve_single_robot(robot_name)
@@ -2169,7 +2176,7 @@ class MuJoCoSimEngine(
         from strands_robots._async_utils import _resolve_coroutine
 
         if self._world is None or self._world._model is None or self._world._data is None:
-            return {"status": "error", "content": [{"text": "No world. Call create_world first."}]}
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         if not policies:
             return {"status": "error", "content": [{"text": "run_multi_policy: 'policies' is empty."}]}
 

--- a/tests/simulation/mujoco/test_no_world_guard_contract.py
+++ b/tests/simulation/mujoco/test_no_world_guard_contract.py
@@ -1,0 +1,109 @@
+"""Unified "no world" guard contract for the MuJoCo Simulation facade.
+
+Every world-touching facade method must, when called before ``create_world``
+(or after a failed ``load_scene`` that leaves a partial world), return the same
+structured error - never raise and never drift the wording. The canonical text
+lives in ``strands_robots.simulation.mujoco.simulation._NO_WORLD_MSG``; this
+module pins that single string across every guarded method so an agent that
+learns the error from one action recognises it from all of them.
+
+Two states are exercised:
+
+* **No world** - a fresh ``Simulation`` with ``_world is None``.
+* **Partial world** - ``_world`` set but ``_model``/``_data`` still ``None``.
+  This is reachable in production: ``load_scene`` assigns ``self._world =
+  SimWorld()`` before compiling the spec, so a compile failure leaves the
+  partial handle behind. Methods that only checked ``_world is None`` would
+  pass that guard and then dereference a ``None`` model.
+"""
+
+import pytest
+
+from strands_robots.simulation.models import SimWorld
+from strands_robots.simulation.mujoco.simulation import _NO_WORLD_MSG, Simulation
+
+# (method_name, args) for every facade method that guards on a live world.
+# Args are the minimum required positional/keyword params; the guard fires
+# before any of them are used.
+GUARDED_CALLS: list[tuple[str, tuple, dict]] = [
+    ("send_action", ({},), {}),
+    ("replace_scene_mjcf", ("<mujoco/>",), {}),
+    ("patch_scene_mjcf", ([],), {}),
+    ("add_robot", ("r",), {}),
+    ("list_robots_info", (), {}),
+    ("get_robot_state", (), {}),
+    ("add_object", ("o",), {}),
+    ("move_object", ("o",), {}),
+    ("list_objects", (), {}),
+    ("add_camera", ("c",), {}),
+    ("step", (), {}),
+    ("reset", (), {}),
+    ("get_state", (), {}),
+    ("set_gravity", ([0.0, 0.0, -1.0],), {}),
+    ("set_timestep", (0.004,), {}),
+    ("get_features", (), {}),
+    ("start_policy", (), {}),
+    ("run_policy", (), {}),
+    ("run_multi_policy", ({},), {}),
+]
+
+
+def _assert_no_world_error(result: dict, method: str) -> None:
+    assert isinstance(result, dict), f"{method} returned non-dict {type(result)}"
+    assert result.get("status") == "error", f"{method} should error with no world, got {result.get('status')}"
+    text = result["content"][0]["text"]
+    assert text == _NO_WORLD_MSG, f"{method} drifted from the unified guard message: {text!r}"
+
+
+@pytest.fixture
+def no_world_sim():
+    s = Simulation(tool_name="no_world_contract", mesh=False)
+    yield s
+    s.cleanup()
+
+
+@pytest.fixture
+def partial_world_sim():
+    """A sim whose _world is set but model/data are unbuilt (failed-load state)."""
+    s = Simulation(tool_name="partial_world_contract", mesh=False)
+    s._world = SimWorld()  # _model / _data left as None
+    yield s
+    s._world = None
+    s.cleanup()
+
+
+@pytest.mark.parametrize(("method", "args", "kwargs"), GUARDED_CALLS, ids=[c[0] for c in GUARDED_CALLS])
+def test_no_world_returns_unified_error(no_world_sim, method, args, kwargs):
+    """With no world at all, every guarded method returns the exact unified text."""
+    result = getattr(no_world_sim, method)(*args, **kwargs)
+    _assert_no_world_error(result, method)
+
+
+@pytest.mark.parametrize(("method", "args", "kwargs"), GUARDED_CALLS, ids=[c[0] for c in GUARDED_CALLS])
+def test_partial_world_returns_unified_error(partial_world_sim, method, args, kwargs):
+    """A partial world (model/data still None) must NOT slip past the guard.
+
+    Pre-fix, ``send_action``/``replace_scene_mjcf``/``patch_scene_mjcf``/
+    ``add_robot`` only checked ``_world is None`` (or ``_model`` alone) and so
+    accepted this state, then either crashed or silently recovered. They must
+    now report the standard no-world error like every other guarded method.
+    """
+    result = getattr(partial_world_sim, method)(*args, **kwargs)
+    _assert_no_world_error(result, method)
+
+
+def test_require_world_helper_is_wired_to_the_constant(no_world_sim):
+    """The canonical _require_world() helper returns the same unified text."""
+    err = no_world_sim._require_world()
+    assert err is not None
+    assert err["content"][0]["text"] == _NO_WORLD_MSG
+
+
+def test_require_world_passes_when_world_live():
+    """Once a world exists, the guard helper returns None (live)."""
+    s = Simulation(tool_name="live_world_contract", mesh=False)
+    try:
+        s.create_world()
+        assert s._require_world() is None
+    finally:
+        s.cleanup()


### PR DESCRIPTION
## Problem

Every world-touching method on the MuJoCo `Simulation` facade returns a structured error when called before `create_world` (or after a failed `load_scene`). Two issues had crept in:

1. **Message drift.** The guard text had diverged into three different strings:
   - `"No world. Call create_world first."` (`send_action`, `run_multi_policy`)
   - `"No world. Use action='create_world' first."` (`replace_scene_mjcf`, `patch_scene_mjcf`, `add_robot`)
   - `"No world. Call create_world (or load_scene) first."` (everything else, plus the `_require_world()` helper)

   An agent that learns the error from one action does not recognise it from another, which is exactly the kind of inconsistency the existing `TestUnifiedNoWorldMessage` contract was written to prevent - it just never covered most methods.

2. **Partial-world gap.** `load_scene` assigns `self._world = SimWorld()` *before* compiling the spec, so a compile failure leaves a partial handle behind (`_world` set, `_model`/`_data` still `None`). Four methods - `send_action`, `replace_scene_mjcf`, `patch_scene_mjcf`, `add_robot` - guarded only on `self._world is None` (or `_model` alone) and so accepted that state, then either dereferenced a `None` model or silently "recovered" by rebuilding from a 1-body stub. Every other guarded method already checks the full `world + _model + _data` predicate.

The `_require_world()` helper was written to be the canonical guard (its docstring reads "Every action that touches ... should call this first") but was dead code - never called - while the inline guards drifted.

## Change

- Introduce a module-level `_NO_WORLD_MSG` constant as the single source of truth. All 19 inline guards and `_require_world()` now return that exact string.
- Strengthen the four weak guards to the full `world + _model + _data` predicate, matching every other method, so the partial-world state is reported as the standard no-world error instead of slipping through.
- Tighten the `_require_world()` docstring to state the live-world predicate (including the partial-load case) accurately.

Conditions stay inlined per-method (not routed through the helper) to preserve mypy narrowing of `_world._model`/`_world._data`; only the message is single-sourced. No behaviour changes when a world exists.

## Tests

New `tests/simulation/mujoco/test_no_world_guard_contract.py` parametrizes all 19 guarded methods over two states:

- **No world** - fresh `Simulation`, `_world is None`.
- **Partial world** - `_world` set, `_model`/`_data` still `None`.

and asserts each returns the exact `_NO_WORLD_MSG`, plus that `_require_world()` is wired to the constant and returns `None` once a world is live. 40 parametrized cases.

Pre-fix, `test_no_world_returns_unified_error` fails on the 5 drifted methods and `test_partial_world_returns_unified_error` fails where the weak guards let `replace_scene_mjcf`/`patch_scene_mjcf` return `success` for a partial world. Post-fix all 40 pass; the existing `TestUnifiedNoWorldMessage` / `test_agenttool_contract` suite stays green (103 total).

Verified locally headless (`MUJOCO_GL=egl`, py3.12, lerobot from source): ruff check + ruff format clean on `strands_robots tests tests_integ`, mypy clean on the changed files, full `tests/simulation/mujoco` green except two pre-existing `libtorchcodec` env failures unrelated to this change.

This is an error-path/wording consistency fix with no change to simulation, rendering, or policy behaviour, so no rollout artifact applies.