### PR TITLE
docs(readme): embed architecture_flow + mesh_network brand SVGs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ robot = Robot("so100", mode="real", port="/dev/ttyACM0")
 
 ## How it works
 
+<p align="center">
+  <img src="docs/assets/architecture_flow.svg" alt="Strands Robots architecture - four-layer stack (Agent, Policies, Backends, Robots) with action signals flowing down and observation signals flowing back up" width="100%">
+</p>
+
 ```mermaid
 graph LR
     A[Natural Language<br/>'Pick up the red block'] --> B[Strands Agent]
@@ -720,6 +724,10 @@ requires parameter Y."*, and vectors/dtypes are validated before MuJoCo sees
 them - so the agent learns the contract without crashing the process.
 
 ## Mesh networking
+
+<p align="center">
+  <img src="docs/assets/mesh_network.svg" alt="Strands Robots mesh - robot peers discovering and coordinating over the Zenoh mesh" width="100%">
+</p>
 
 Every `Robot()` and `Simulation()` is automatically a peer on a local Zenoh
 mesh - no setup. Peers on the same LAN discover each other via multicast

--- a/tests/test_docs_brand_visuals.py
+++ b/tests/test_docs_brand_visuals.py
@@ -7,9 +7,9 @@ cyan ``#22D3EE``):
 * ``hero_loop.svg`` - the perceive/reason/act/world control loop, on the docs
   home page and at the top of the README.
 * ``architecture_flow.svg`` - the four-layer stack with action/observation
-  signal flow, on the architecture page.
+  signal flow, on the architecture page and the README "How it works" section.
 * ``mesh_network.svg`` - peer coordination over the Zenoh mesh, on the mesh
-  page.
+  page and the README "Mesh networking" section.
 
 Each is surfaced through the ``brand-figure``/``brand-svg`` CSS treatment in
 ``docs/stylesheets/extra.css``. This guard fails fast if an asset is deleted,
@@ -59,11 +59,17 @@ def test_docs_pages_embed_their_brand_svg() -> None:
         assert "brand-svg" in text, f"{page.name} dropped the brand-svg CSS hook"
 
 
-def test_readme_embeds_hero() -> None:
-    """The README opens with the hero loop banner."""
-    assert "docs/assets/hero_loop.svg" in README.read_text(encoding="utf-8"), (
-        "README no longer embeds the hero_loop.svg banner"
-    )
+def test_readme_embeds_all_brand_svgs() -> None:
+    """The README surfaces all three animated brand SVGs.
+
+    ``hero_loop.svg`` opens the README; ``architecture_flow.svg`` illustrates
+    the "How it works" section and ``mesh_network.svg`` the "Mesh networking"
+    section - matching the docs pages that embed the same assets. Each is
+    referenced by its ``docs/assets/`` repo-relative path so GitHub renders it.
+    """
+    text = README.read_text(encoding="utf-8")
+    for name in BRAND_SVGS:
+        assert f"docs/assets/{name}" in text, f"README no longer embeds {name}"
 
 
 def test_extra_css_defines_brand_figure() -> None:


### PR DESCRIPTION
## Problem

The repo ships three animated brand SVGs under `docs/assets/`. The docs site embeds all three (`index.md` -> `hero_loop.svg`, `architecture.md` -> `architecture_flow.svg`, `mesh.md` -> `mesh_network.svg`), but the **README embedded only `hero_loop.svg`**. The README's "How it works" and "Mesh networking" sections had no banner, so the visual identity shown on the docs site was missing from the GitHub landing page even though both assets already exist and render.

## Change

Embed the two already-shipped SVGs in the README, matching the existing `hero_loop` `<p align="center"><img ...></p>` pattern and repo-relative `docs/assets/` paths:

- `architecture_flow.svg` under **How it works** (above the mermaid flow diagram)
- `mesh_network.svg` under **Mesh networking**

No new assets, no asset edits - purely surfacing existing ones so the README matches the docs.

### How it works -> architecture_flow.svg
<img src="https://raw.githubusercontent.com/cagataycali/robots/docs/readme-brand-svgs/docs/assets/architecture_flow.svg" width="100%">

### Mesh networking -> mesh_network.svg
<img src="https://raw.githubusercontent.com/cagataycali/robots/docs/readme-brand-svgs/docs/assets/mesh_network.svg" width="100%">

## Tests

Generalized the README guard in `tests/test_docs_brand_visuals.py` from hero-only (`test_readme_embeds_hero`) to all three brand SVGs (`test_readme_embeds_all_brand_svgs`, driven by the existing `BRAND_SVGS` tuple). It fails on the pre-change README (`README no longer embeds architecture_flow.svg`) and passes after.

```
5 passed in tests/test_docs_brand_visuals.py
```

`mkdocs build --strict` clean; ruff check + format clean.