### PR TITLE
fix(groot): coerce local-mode action values to python list/float for cross-provider parity

### DIFF
--- a/strands_robots/policies/groot/policy.py
+++ b/strands_robots/policies/groot/policy.py
@@ -239,6 +239,27 @@ def _parse_action_mapping(flat: dict[str, str]) -> ActionMapping:
     return ActionMapping(actions={k.removeprefix("action."): v for k, v in flat.items()})
 
 
+def _coerce_action_row(row: Any) -> float | list[float]:
+    """Coerce a per-timestep action element to a python scalar or list.
+
+    Both the local and service unpack paths emit per-tick actuator dicts that
+    must satisfy the ``Policy.get_actions() -> list[dict]`` contract shared by
+    every provider: per-joint values are python ``float`` (0-D) or
+    ``list[float]`` (vector), never raw ``np.ndarray``. Routing both paths
+    through this single helper guarantees byte-equivalent typed output.
+
+    Args:
+        row: One indexed element of a (horizon, ...) action array - typically a
+            0-D or 1-D ``np.ndarray``, but any value exposing ``tolist`` works.
+
+    Returns:
+        ``float`` for a scalar (0-D) element, ``list[float]`` for a vector.
+    """
+    if hasattr(row, "tolist"):
+        return row.tolist()
+    return float(row) if np.ndim(row) == 0 else list(row)
+
+
 # Gr00tPolicy
 
 
@@ -728,10 +749,10 @@ class Gr00tPolicy(Policy):
             step: dict[str, Any] = {}
             for model_key, robot_key in self._action_mapping.actions.items():
                 if model_key in squeezed:
-                    step[robot_key] = squeezed[model_key][t]
+                    step[robot_key] = _coerce_action_row(squeezed[model_key][t])
             for model_key in squeezed:
                 if model_key not in mapped_keys:
-                    step[f"unmapped.{model_key}"] = squeezed[model_key][t]
+                    step[f"unmapped.{model_key}"] = _coerce_action_row(squeezed[model_key][t])
             actions.append(step)
 
         return actions
@@ -856,12 +877,10 @@ class Gr00tPolicy(Policy):
                 step: dict[str, Any] = {}
                 for model_key, robot_key in self._action_mapping.actions.items():
                     if model_key in normalized:
-                        row = normalized[model_key][t]
-                        step[robot_key] = row.tolist() if hasattr(row, "tolist") else list(row)
+                        step[robot_key] = _coerce_action_row(normalized[model_key][t])
                 for model_key in normalized:
                     if model_key not in mapped_keys:
-                        row = normalized[model_key][t]
-                        step[f"unmapped.{model_key}"] = row.tolist() if hasattr(row, "tolist") else list(row)
+                        step[f"unmapped.{model_key}"] = _coerce_action_row(normalized[model_key][t])
                 actions.append(step)
             return actions
 
@@ -870,8 +889,7 @@ class Gr00tPolicy(Policy):
         for t in range(horizon):
             step = {}
             for k, v in normalized.items():
-                row = v[t]
-                step[k] = row.tolist() if hasattr(row, "tolist") else list(row)
+                step[k] = _coerce_action_row(v[t])
             actions.append(step)
         return actions
 

--- a/tests/policies/groot/test_policy.py
+++ b/tests/policies/groot/test_policy.py
@@ -520,12 +520,42 @@ class TestUnpackActions:
     def test_maps(self):
         p = _make_policy(action_mapping=ActionMapping(actions={"left_arm": "j", "left_hand": "g"}), mmc=GR1_MMC)
         acts = p._unpack_actions({"left_arm": np.ones((1, 16, 7)), "left_hand": np.ones((1, 16, 6))})
-        assert len(acts) == 16 and acts[0]["j"].shape == (7,) and acts[0]["g"].shape == (6,)
+        assert len(acts) == 16
+        # C1: per-tick values are python list[float], never raw np.ndarray, so
+        # they match every other provider and survive cross-provider float()/len().
+        assert acts[0]["j"] == [1.0] * 7 and acts[0]["g"] == [1.0] * 6
+        assert isinstance(acts[0]["j"], list) and isinstance(acts[0]["j"][0], float)
 
     def test_unmapped(self):
         p = _make_policy(action_mapping=ActionMapping(actions={"left_arm": "j"}), mmc=GR1_MMC)
         acts = p._unpack_actions({"left_arm": np.ones((1, 4, 7)), "waist": np.ones((1, 4, 3))})
         assert "unmapped.waist" in acts[0]
+        assert acts[0]["unmapped.waist"] == [1.0, 1.0, 1.0]
+        assert isinstance(acts[0]["unmapped.waist"], list)
+
+    def test_scalar_dof_becomes_python_float(self):
+        # A 1-element per-DOF vector stays a 1-element list (vectors never collapse
+        # to a bare scalar); a genuinely 0-D element coerces to a python float.
+        p = _make_policy(action_mapping=ActionMapping(actions={"single_arm": "arm"}))
+        acts = p._unpack_actions({"single_arm": np.ones((1, 3, 1))})
+        assert acts[0]["arm"] == [1.0] and isinstance(acts[0]["arm"], list)
+
+    def test_local_service_parity(self):
+        # C1 acceptance: feed an identical raw action chunk through both the LOCAL
+        # (_unpack_actions) and SERVICE (_unpack_service_actions) paths and assert
+        # byte-equivalent python-typed output.
+        p = _make_policy(action_mapping=ActionMapping(actions={"left_arm": "j", "left_hand": "g"}), mmc=GR1_MMC)
+        chunk = {
+            "left_arm": np.arange(2 * 7, dtype=np.float64).reshape(1, 2, 7),
+            "left_hand": np.arange(2 * 6, dtype=np.float64).reshape(1, 2, 6),
+            "waist": np.arange(2 * 3, dtype=np.float64).reshape(1, 2, 3),
+        }
+        local = p._unpack_actions(chunk)
+        service = p._unpack_service_actions(chunk)
+        assert local == service
+        for step in local:
+            for v in step.values():
+                assert isinstance(v, list) and all(isinstance(x, float) for x in v)
 
     def test_empty(self):
         assert _make_policy(action_mapping=ActionMapping())._unpack_actions({}) == []


### PR DESCRIPTION
## Problem

`Gr00tPolicy` returned different per-tick value types depending on inference mode, breaking the cross-provider uniformity of the `Policy.get_actions() -> list[dict]` contract:

- **LOCAL** (`_unpack_actions`): per-tick dict values were raw `np.ndarray` elements (`step[robot_key] = squeezed[model_key][t]`).
- **SERVICE** (`_unpack_service_actions`): per-tick values were coerced to python `list`/`float` via `.tolist()`.

Every other provider (`mock`, `cosmos3`, `wbc`, `moveit2`, `curobo`, `lerobot_local`) emits python `float`/`list`. A consumer doing `float(v)` on a per-joint value works everywhere except GR00T local mode, where a multi-element ndarray raises `ValueError: truth value of an array ... is ambiguous`.

## Change

Introduce a single module-level `_coerce_action_row(row)` helper and route **both** unpack paths through it, so the typed output is guaranteed byte-equivalent by construction (one source of truth rather than two copies of the coercion logic):

- 0-D element -> python `float`
- vector element -> `list[float]`

LOCAL now matches SERVICE. SERVICE output is unchanged: the helper reproduces the prior `row.tolist() if hasattr(row, "tolist") else list(row)` behavior for the array path. The `STRANDS_GROOT_WIRE_LOG` diagnostic is untouched (it dumps pre-unpack data).

## Tests

`tests/policies/groot/test_policy.py::TestUnpackActions`:

- `test_local_service_parity` (new): feeds an identical raw action chunk (mapped + unmapped keys) through both `_unpack_actions` and `_unpack_service_actions` and asserts `local == service`, plus every value is `list[float]`.
- `test_scalar_dof_becomes_python_float` (new): a 1-element per-DOF vector stays a 1-element list; values are python-typed.
- `test_maps` / `test_unmapped` updated to assert the python-typed contract instead of `.shape` on ndarrays.

These fail on the pre-fix code (4 failed: `ValueError` on the ndarray-truth comparisons and `isinstance(..., list)` assertions) and pass after. Full GR00T suite: 178 passed. `ruff check`, `ruff format --check`, and `mypy` all clean.

## Acceptance criteria

- [x] LOCAL-mode `get_actions` returns dicts whose values are python `float`/`list[float]`, never raw `np.ndarray`.
- [x] LOCAL and SERVICE produce equal results for the same model output (parity test added).
- [x] Existing GR00T tests still pass; the wire-log diagnostic is unaffected.
- [x] No behavior change for SERVICE mode.