### PR TITLE
feat(datasets): streaming read-back + HF Storage Bucket sync (physical-AI data loop)

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,68 @@ from strands_robots import create_policy
 policy = create_policy("lerobot/act_aloha_sim_transfer_cube_human")
 ```
 
+## Recording & streaming datasets
+
+The physical-AI data loop, end to end: **record** a LeRobotDataset from sim or
+hardware, **stream** it straight back for eval/training (no full download), and
+optionally **dump** it to a mutable Hugging Face Storage Bucket. Needs the
+`lerobot` extra (which bundles `datasets` + `av` + `torchcodec`).
+
+```python
+from strands import Agent
+from strands_robots import Robot
+
+sim = Robot("so100", mesh=False)
+agent = Agent(tools=[sim])
+
+# 1. COLLECT — one natural-language prompt drives scene + cameras + policy + record.
+agent(
+    "Create a world with the so100 robot, add a red cube and a front camera, "
+    "start recording (repo_id='local/demo', root='/tmp/demo', fps=30, "
+    "overwrite=True, task='pick up the red cube'), run the mock policy for "
+    "60 steps, then stop recording."
+)
+
+# 2. STREAM — read it back lazily; camera frames decode on the fly from the MP4
+#    shards, state/action from parquet. Nothing is re-materialized to disk.
+reader = sim.stream_dataset("local/demo", root="/tmp/demo", shuffle=False)
+for frame in reader:
+    frame["observation.images.front"]   # (3, H, W) tensor, decoded from video
+    frame["observation.state"]          # joint vector
+    frame["action"]
+    break
+```
+
+`stream_dataset()` is the in-process read counterpart to
+`start_recording`/`stop_recording`. For full training, the upstream trainer uses
+the same engine — `python -m lerobot.scripts.train dataset.repo_id=... dataset.streaming=true`.
+
+**Dump to a Storage Bucket** during collection (mutable, Xet-deduplicated — the
+Phase 1/2 collection target that avoids git-LFS history bloat) with one kwarg:
+
+```python
+sim.stop_recording(bucket="your-org/robot-fave")   # → hf://buckets/your-org/robot-fave/demo
+```
+
+Requires the `hf` CLI (`pip install -U huggingface_hub` + `hf auth login`).
+
+**Proprio-only / no video** (e.g. edge devices without a torchcodec wheel):
+`sim.stream_dataset(repo_id, drop_videos=True)` streams state/action only and
+never touches the video decoder.
+
+> **macOS note (zero-touch).** torchcodec links ffmpeg via `@rpath`, and
+> Homebrew's ffmpeg (`/opt/homebrew/lib`) is not on the default dyld search
+> path — so video decode would normally fail with
+> `Library not loaded: @rpath/libavutil.NN.dylib`. On `import strands_robots`
+> we auto-detect this and put Homebrew's ffmpeg on `DYLD_FALLBACK_LIBRARY_PATH`
+> (re-exec'ing the interpreter once for a plain script run; never inside
+> Jupyter/REPL/pytest, where it just prints the one-line `export` to run). It's
+> a no-op off macOS, without torchcodec, or when the var is already set. Disable
+> with `STRANDS_ROBOTS_NO_DYLD_SHIM=1`. See `examples/06_agent_collect_and_stream.py`.
+
+See also [Recording & datasets](docs/recording.md) for the `DatasetRecorder`
+direct API and append/resume workflow.
+
 ## The `Robot()` factory
 
 `Robot()` is a factory, not a wrapper - you get the real backend instance back
@@ -792,6 +854,7 @@ Install with `uv pip install "strands-robots[mesh-iot]"`. See the
 | `STRANDS_ROBOT_MODE` | `Robot()` factory mode: `sim` / `real` / `auto` | `sim` |
 | `STRANDS_ASSETS_DIR` | Robot model asset cache directory | `~/.strands_robots/assets/` |
 | `STRANDS_TRUST_REMOTE_CODE` | Set `1` to allow HF `trust_remote_code` for `lerobot_local` | unset |
+| `STRANDS_ROBOTS_NO_DYLD_SHIM` | Set `1` to disable the macOS auto-fix that puts Homebrew ffmpeg on the dyld path for torchcodec video streaming (see [Recording & streaming datasets](#recording--streaming-datasets)) | unset |
 | `MUJOCO_GL` | MuJoCo GL backend (`egl`, `osmesa`, `glfw`) | auto |
 | `GROOT_API_TOKEN` | API token for the GR00T inference service | unset |
 | `STRANDS_MESH` | Set `false` to disable Zenoh mesh globally | `true` |

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -70,9 +70,12 @@ recorder.finalize()
 | `save_episode()` | Flush buffer as a new episode |
 | `clear_episode_buffer()` | Discard current episode |
 | `finalize()` | Write metadata, stats, close writers |
-| `push_to_hub(tags=None, private=False)` | Upload to HuggingFace Hub |
+| `push_to_hub(tags=None, private=False)` | Upload to a versioned HF dataset repo |
+| `sync_to_bucket(bucket, run_id=None, private=True)` | Sync to a mutable HF Storage Bucket (`hf://buckets/...`) — Xet-deduped collection target; needs the `hf` CLI. `bucket` (`name` or `org/name`) and `run_id` (single segment) are allowlist-validated (`[A-Za-z0-9._-]`, no traversal) before the sync |
 
 ## Read back
+
+Fully materialized (downloads everything):
 
 ```python
 from lerobot.datasets.lerobot_dataset import LeRobotDataset
@@ -80,6 +83,55 @@ from lerobot.datasets.lerobot_dataset import LeRobotDataset
 ds = LeRobotDataset(repo_id="user/my_dataset", root="/tmp/my_dataset")
 print(len(ds), ds[0].keys())
 ```
+
+## Stream back (no full download)
+
+`sim.stream_dataset()` is the in-process counterpart to `start_recording` /
+`stop_recording` — it reads frames lazily from the Hub (or a local `root`) via
+LeRobot's `StreamingLeRobotDataset`. Camera frames are decoded on the fly from
+the MP4 shards; state/action come from the parquet shards.
+
+```python
+from strands_robots import Robot
+
+sim = Robot("so100")
+reader = sim.stream_dataset(
+    "user/my_dataset",                 # or a local repo_id + root=
+    root="/tmp/my_dataset",
+    delta_timestamps={                 # optional: stacked time windows + *_is_pad masks
+        "observation.state": [-0.0667, -0.0333, 0.0],
+        "action": [0.0, 0.0333, 0.0667],
+    },
+    shuffle=False,                     # chronological for replay/eval
+)
+print(reader.num_episodes, reader.num_frames, reader.fps)
+for frame in reader:
+    ...
+
+# torch DataLoader (shuffles INTERNALLY — do not pass shuffle=True):
+for batch in reader.dataloader(batch_size=64, num_workers=4):
+    ...
+```
+
+Equivalently, the standalone reader: `from strands_robots import StreamingDatasetReader`.
+
+Useful kwargs (forwarded to `StreamingLeRobotDataset`, version-tolerant):
+`episodes=[...]` (subset without download), `buffer_size`, `max_num_shards`,
+`return_uint8=True` (default; halves frame bandwidth), and
+`drop_videos=True` (proprio-only — skips video decode entirely, so it works on
+edge devices without a torchcodec wheel).
+
+For **training**, the upstream trainer uses the same engine:
+
+```bash
+python -m lerobot.scripts.train policy=act \
+  dataset.repo_id=user/my_dataset dataset.streaming=true num_workers=4
+```
+
+> **macOS:** video streaming needs Homebrew ffmpeg on the dyld path. `import
+> strands_robots` auto-fixes this (zero-touch); disable with
+> `STRANDS_ROBOTS_NO_DYLD_SHIM=1`. See the README "Recording & streaming
+> datasets" section.
 
 ## See also
 

--- a/examples/06_agent_collect_and_stream.py
+++ b/examples/06_agent_collect_and_stream.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Agent-driven data collection + native streaming read-back.
+
+The physical-AI data loop in one screen: a Strands Agent records a
+LeRobotDataset from one natural-language prompt, then we stream it straight
+back with ``sim.stream_dataset(...)`` — no torchcodec/av plumbing in user code
+(it's a declared dependency of the ``[lerobot]`` extra).
+
+Run:
+    MUJOCO_GL=cgl python examples/06_agent_collect_and_stream.py
+
+Dependencies:
+    pip install "strands-robots[sim-mujoco,lerobot]" strands-agents
+    AWS credentials for Bedrock (or any strands-agents model provider).
+"""
+
+import os
+
+os.environ.setdefault("MUJOCO_GL", "cgl")  # macOS offscreen GL
+
+from strands import Agent
+
+from strands_robots import Robot
+
+DATASET_ROOT = "/tmp/strands_agent_dataset"
+REPO_ID = "local/agent_demo"
+
+# Robot() is a Strands AgentTool — hand it straight to an Agent.
+sim = Robot("so100", mesh=False)
+agent = Agent(tools=[sim])
+
+# 1. COLLECT — one prompt drives scene + cameras + policy + recording.
+agent(
+    f"Create a world with the so100 robot. Add a red cube at [0.2, 0.0, 0.05] "
+    f"and a blue cube at [0.25, 0.05, 0.05]. Add a front camera looking at them. "
+    f"Start recording a LeRobot dataset (repo_id='{REPO_ID}', root='{DATASET_ROOT}', "
+    f"fps=30, overwrite=True, task='pick up the red cube'). Run the mock policy "
+    f"for 60 steps with instruction 'pick up the red cube'. Stop recording."
+)
+
+# 2. STREAM — read the dataset back lazily (Phase 3). Native facade method,
+#    same object that recorded it. Camera frames are decoded on the fly from
+#    the MP4 shards (torchcodec, shipped by the [lerobot] extra); state/action
+#    come from the parquet shards. Nothing is re-materialized to disk.
+reader = sim.stream_dataset(
+    REPO_ID,
+    root=DATASET_ROOT,
+    shuffle=False,
+)
+
+print(f"\nStreaming {reader.num_episodes} episode(s), "
+      f"{reader.num_frames} frames @ {reader.fps} fps")
+print(f"cameras: {reader.meta.video_keys}")
+for i, frame in enumerate(reader):
+    cams = {k: tuple(frame[k].shape) for k in frame if k.startswith("observation.images.")}
+    print(f"  frame {i}: state{tuple(frame['observation.state'].shape)} "
+          f"action{tuple(frame['action'].shape)} cams={cams}")
+    if i >= 2:
+        break
+
+# 3. (Optional) Dump to a mutable HF Storage Bucket during collection —
+#    Xet-deduped, overwrite-in-place (Phase 1/2). One kwarg on stop_recording:
+#    sim.stop_recording(bucket="your-org/robot-fave")
+print("\nDone. To dump to an HF Storage Bucket: stop_recording(bucket='org/name')")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,26 @@ wbc = [
     "huggingface_hub>=0.20.0,<2.0.0",
 ]
 lerobot = [
-    "lerobot[feetech]>=0.5.0,<0.6.0",
+    # [dataset] bundles the read-back stack the streaming data loop needs:
+    # datasets + pandas + pyarrow (parquet streaming) + av + torchcodec
+    # (remote video decode for StreamingLeRobotDataset / StreamingDatasetReader).
+    # Declaring it here makes `sim.stream_dataset(...)` work out of the box
+    # instead of pushing torchcodec/av plumbing onto user code. See
+    # reports/STREAMING_DATA_LOOP_DEEP_DIVE.md Appendix C.
+    "lerobot[feetech,dataset]>=0.5.0,<0.6.0",
+    # torchcodec wheels are built against a specific torch C++ ABI, so the
+    # version MUST track the resolved torch:
+    #   torch 2.9  -> torchcodec 0.7
+    #   torch 2.10 -> torchcodec 0.10  (verified working on macOS arm64 +
+    #                 system ffmpeg via /opt/homebrew/lib; 0.10 == "system-wide
+    #                 ffmpeg support" per lerobot's matrix note)
+    #   torch 2.11 -> torchcodec 0.11   torch 2.12 -> torchcodec 0.12
+    # lerobot's own marker only special-cases aarch64; on macOS arm64 a plain
+    # `pip install strands-robots[lerobot]` resolves torch 2.10, which needs
+    # torchcodec 0.10 (0.7/0.8 mismatch the c10 ABI -> dlopen "Symbol not found:
+    # c10::MessageLogger"). Pin the matching minor on darwin arm64 so video
+    # streaming read-back works without manual intervention.
+    "torchcodec>=0.10,<0.11; sys_platform == 'darwin' and platform_machine == 'arm64'",
     # #378: lerobot 0.5.1's pyav video fallback calls torchvision.io.VideoReader,
     # which torchvision 0.26 (resolved on linux+aarch64 via the torch 2.11 Thor
     # override below) removed -- crashing dataset video read-back. lerobot's own
@@ -155,7 +174,7 @@ lerobot = [
     # NOTE: torchcodec ships as +cuXXX wheels resolved by UV_TORCH_BACKEND; a
     # plain `pip install` on Thor may need the matching CUDA index -- see the
     # README Installation section for the Thor/Jetson caveat.
-    "torchcodec>=0.7; platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "torchcodec>=0.11; platform_machine == 'aarch64' and sys_platform == 'linux'",
 ]
 # MolmoAct2 transformers-native VLA (e.g. allenai/MolmoAct2-SO100_101). The
 # MolmoAct2Policy class shipped in lerobot AFTER the 0.5.1 PyPI release (merged

--- a/strands_robots/__init__.py
+++ b/strands_robots/__init__.py
@@ -50,6 +50,7 @@ if TYPE_CHECKING:
         list_backends,
         register_backend,
     )
+    from strands_robots.streaming_dataset import StreamingDatasetReader
     from strands_robots.tools.gr00t_inference import gr00t_inference
     from strands_robots.tools.lerobot_calibrate import lerobot_calibrate
     from strands_robots.tools.lerobot_camera import lerobot_camera
@@ -98,6 +99,7 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "RobotDeviceDriver": ("strands_robots.device_connect", "RobotDeviceDriver"),
     "SimulationDeviceDriver": ("strands_robots.device_connect", "SimulationDeviceDriver"),
     "ReachyMiniDriver": ("strands_robots.device_connect", "ReachyMiniDriver"),
+    "StreamingDatasetReader": ("strands_robots.streaming_dataset", "StreamingDatasetReader"),
 }
 
 __all__ = [
@@ -130,6 +132,7 @@ __all__ = [
     "RobotDeviceDriver",
     "SimulationDeviceDriver",
     "ReachyMiniDriver",
+    "StreamingDatasetReader",
 ]
 
 
@@ -156,6 +159,19 @@ if _importlib_util.find_spec("mujoco") is not None:
         _configure_gl_backend()
     except (ImportError, AttributeError, OSError):
         pass
+
+
+# Auto-configure the macOS dyld search path so torchcodec can find Homebrew's
+# ffmpeg with zero user setup — making ``sim.stream_dataset(...)`` video decode
+# work out of the box. No-op off macOS, without torchcodec, or when already set.
+# May re-exec the interpreter ONCE on a plain script run (guarded; never in
+# Jupyter/REPL/pytest). Opt out with STRANDS_ROBOTS_NO_DYLD_SHIM=1. See _dyld.py.
+try:
+    from strands_robots._dyld import ensure_ffmpeg_on_dyld_path
+
+    ensure_ffmpeg_on_dyld_path()
+except Exception:  # noqa: BLE001 - never let the shim block import
+    pass
 
 
 def __getattr__(name: str) -> Any:  # noqa: N807

--- a/strands_robots/_dyld.py
+++ b/strands_robots/_dyld.py
@@ -1,0 +1,159 @@
+"""macOS dyld shim so torchcodec finds Homebrew's ffmpeg with zero user setup.
+
+The problem
+-----------
+torchcodec ships ``libtorchcodec_coreN.dylib`` linked against ffmpeg via
+``@rpath/libavutil.NN.dylib`` etc. On macOS those ffmpeg dylibs live in the
+Homebrew prefix (``/opt/homebrew/lib`` on Apple Silicon), which is NOT on the
+default dyld search path. So ``import torchcodec`` fails with
+``Library not loaded: @rpath/libavutil.59.dylib`` and
+``StreamingLeRobotDataset`` cannot decode video frames.
+
+Why ``os.environ`` mid-process does NOT fix it
+----------------------------------------------
+dyld snapshots ``DYLD_*`` env vars at process launch. Setting
+``os.environ["DYLD_FALLBACK_LIBRARY_PATH"]`` after the interpreter has started
+has no effect on subsequent ``dlopen`` of torchcodec (verified). Preloading the
+ffmpeg dylibs with ``ctypes.CDLL(..., RTLD_GLOBAL)`` also does not satisfy
+torchcodec's ``@rpath`` lookups on macOS.
+
+The fix (zero-touch, idempotent)
+--------------------------------
+``ensure_ffmpeg_on_dyld_path()`` runs eagerly at ``import strands_robots``:
+
+1. No-op unless we're on macOS arm64/x86_64 AND a Homebrew ffmpeg lib dir
+   containing ``libavutil.*.dylib`` exists AND torchcodec is installed.
+2. Set ``DYLD_FALLBACK_LIBRARY_PATH`` to include the ffmpeg lib dir. This makes
+   child processes (DataLoader workers with ``num_workers>0``, subprocess
+   training) inherit a correct environment immediately.
+3. For the CURRENT process, dyld already snapshotted its env — so if (and only
+   if) the env var was not already correct, re-exec the interpreter ONCE with
+   the augmented environment. A guard env var prevents an exec loop.
+
+Re-exec is gated tightly: it only fires when torchcodec is importable, ffmpeg is
+present, and the var was missing — i.e. exactly the case where video streaming
+would otherwise crash. Headless/Linux/Jetson and torchcodec-less installs never
+re-exec. Opt out entirely with ``STRANDS_ROBOTS_NO_DYLD_SHIM=1``.
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+import sys
+
+_GUARD_ENV = "_STRANDS_ROBOTS_DYLD_REEXEC"
+_OPT_OUT_ENV = "STRANDS_ROBOTS_NO_DYLD_SHIM"
+_DYLD_VAR = "DYLD_FALLBACK_LIBRARY_PATH"
+
+# Homebrew lib dirs to probe, in priority order (Apple Silicon, then Intel).
+_CANDIDATE_LIB_DIRS = ("/opt/homebrew/lib", "/usr/local/lib")
+
+
+def _find_ffmpeg_lib_dir() -> str | None:
+    """Return a dir containing ffmpeg's ``libavutil.*.dylib``, or ``None``.
+
+    Honors ``HOMEBREW_PREFIX`` (so non-standard Homebrew installs work) before
+    falling back to the canonical Apple-Silicon / Intel prefixes.
+    """
+    dirs: list[str] = []
+    brew_prefix = os.environ.get("HOMEBREW_PREFIX")
+    if brew_prefix:
+        dirs.append(os.path.join(brew_prefix, "lib"))
+    dirs.extend(_CANDIDATE_LIB_DIRS)
+
+    for d in dirs:
+        # The versioned soname (libavutil.59.dylib) is what torchcodec's
+        # @rpath entry resolves against; a bare libavutil.dylib alone is not
+        # enough, so require at least one versioned match.
+        if glob.glob(os.path.join(d, "libavutil.*.dylib")):
+            return d
+    return None
+
+
+def _torchcodec_installed() -> bool:
+    import importlib.util
+
+    return importlib.util.find_spec("torchcodec") is not None
+
+
+def _is_safe_to_reexec() -> bool:
+    """True only for plain ``python script.py`` / ``python -m`` execution.
+
+    Re-exec'ing replaces the process image — fine for a script, catastrophic
+    inside a Jupyter kernel, an IPython REPL, a pytest run, or an embedding
+    host. Detect those and refuse to re-exec there (we still export the env var
+    for child processes and warn the user how to fix the current one).
+    """
+    # Interactive interpreter (python -i, plain REPL).
+    if hasattr(sys, "ps1") or sys.flags.interactive:
+        return False
+    # Jupyter / IPython kernels.
+    if "ipykernel" in sys.modules or "IPython" in sys.modules:
+        return False
+    # Test runners — re-exec would detach from the collector.
+    if "pytest" in sys.modules or "PYTEST_CURRENT_TEST" in os.environ:
+        return False
+    # ``python -c '...'`` sets argv[0] to '-c'; nothing safe to re-run.
+    argv0 = sys.argv[0] if sys.argv else ""
+    if argv0 in ("", "-c"):
+        return False
+    return True
+
+
+def ensure_ffmpeg_on_dyld_path() -> bool:
+    """Ensure Homebrew ffmpeg is on the dyld search path for torchcodec.
+
+    Returns:
+        True if the environment was already correct (or we just set it for
+        child processes without needing a re-exec); the function may not return
+        at all if it re-execs the current process.
+    """
+    # Opt-out / non-macOS / already-guarded fast paths.
+    if os.environ.get(_OPT_OUT_ENV):
+        return False
+    if sys.platform != "darwin":
+        return False
+    if _torchcodec_installed() is False:
+        # No torchcodec → nothing to fix (proprio-only streaming still works).
+        return False
+
+    ffmpeg_dir = _find_ffmpeg_lib_dir()
+    if ffmpeg_dir is None:
+        # No Homebrew ffmpeg found; let torchcodec raise its own clear error
+        # if/when the user tries to decode video.
+        return False
+
+    current = os.environ.get(_DYLD_VAR, "")
+    parts = [p for p in current.split(":") if p]
+    already = ffmpeg_dir in parts
+
+    # Always export for CHILD processes (DataLoader workers, subprocess train).
+    if not already:
+        os.environ[_DYLD_VAR] = ":".join([*parts, ffmpeg_dir])
+
+    if already or os.environ.get(_GUARD_ENV):
+        return True
+
+    # The CURRENT process needs the var set at launch (dyld snapshot). Re-exec
+    # once — but ONLY when it's safe (plain script run, not Jupyter/REPL/pytest).
+    if _is_safe_to_reexec():
+        os.environ[_GUARD_ENV] = "1"
+        try:
+            os.execv(sys.executable, [sys.executable, *sys.argv])
+        except Exception:
+            return False  # fall through; children still benefit
+    else:
+        # Interactive/embedded: don't nuke the host. Warn once with the fix.
+        import warnings
+
+        warnings.warn(
+            "strands_robots: torchcodec needs Homebrew ffmpeg on the dyld path "
+            f"to decode video. Set it before launching Python:\n"
+            f"    export {_DYLD_VAR}={ffmpeg_dir}\n"
+            "(child processes already inherit it; proprio-only streaming via "
+            "drop_videos=True needs no ffmpeg).",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+    return False

--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -22,12 +22,24 @@ Usage:
 
 import functools
 import logging
+import re
 import sys
 from typing import Any
 
 import numpy as np
 
 logger = logging.getLogger(__name__)
+
+# Allowlist patterns for HF Storage Bucket sync targets. Both `bucket` and
+# `run_id` reach the `hf` CLI argv and the `hf://buckets/...` URI; they are
+# agent-reachable via stop_recording(bucket=, run_id=) dispatched through the
+# simulation action layer, so they MUST be validated before any subprocess /
+# URI interpolation (AGENTS.md > LLM Input Safety). `bucket` is "name" or
+# "org/name"; `run_id` is a single path segment. Neither may contain shell
+# metacharacters, path-traversal (".."), or separators beyond the one allowed
+# bucket "org/name" slash.
+_BUCKET_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*(/[A-Za-z0-9][A-Za-z0-9._-]*)?$")
+_RUN_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 
 # Lazy check for LeRobot availability
 # We must NOT import lerobot at module level because it pulls in
@@ -630,6 +642,101 @@ class DatasetRecorder:
         except Exception as e:
             logger.error("push_to_hub failed: %s", e)
             return {"status": "error", "message": str(e)}
+
+    def sync_to_bucket(
+        self,
+        bucket: str,  # "my-org/robot-fave"
+        run_id: str | None = None,  # subpath; defaults to dataset name
+        *,
+        create: bool = True,
+        private: bool = True,
+        delete: bool = False,
+    ) -> dict[str, Any]:
+        """Sync the on-disk LeRobotDataset into an HF Storage Bucket (Phase 1/2).
+
+        Mutable, Xet-deduplicated dump target for COLLECTION — avoids git-LFS
+        history bloat of push_to_hub during recording. Daily re-sync uploads
+        only changed chunks (content-defined chunking). Requires the ``hf`` CLI
+        (huggingface_hub>=1.x) and ``hf auth login``.
+
+        ``bucket`` and ``run_id`` are validated against an allowlist before any
+        subprocess or URI interpolation: ``bucket`` must be ``"name"`` or
+        ``"org/name"`` and ``run_id`` a single path segment, both restricted to
+        ``[A-Za-z0-9._-]`` (no path traversal or shell metacharacters). This
+        path is agent-reachable via ``stop_recording(bucket=, run_id=)``. A
+        rejected value returns ``{"status": "error", ...}`` without running ``hf``.
+
+        See reports/STREAMING_DATA_LOOP_DEEP_DIVE.md Appendix A.1 (shard layout
+        is already Xet/bucket-friendly at the 100 MB default) and F.2 (meta/
+        MUST ship or downstream loses normalization stats).
+        """
+        import shutil
+        import subprocess
+        from pathlib import Path
+
+        if shutil.which("hf") is None:
+            return {
+                "status": "error",
+                "message": "`hf` CLI not found. pip install -U huggingface_hub (>=1.x) and run `hf auth login`.",
+            }
+
+        if not _BUCKET_RE.match(bucket):
+            return {
+                "status": "error",
+                "message": f"invalid bucket {bucket!r}: must match "
+                "'name' or 'org/name' using [A-Za-z0-9._-] (no path traversal "
+                "or shell metacharacters).",
+            }
+
+        local_root = str(self.dataset.root)
+        # meta/ must ship or downstream loses normalization stats (App. F.2).
+        if not (Path(local_root) / "meta").exists():
+            return {
+                "status": "error",
+                "message": f"No meta/ under {local_root}; call finalize() before "
+                "sync_to_bucket (stats/info required for streaming/training).",
+            }
+
+        run_id = run_id or self.dataset.repo_id.split("/")[-1]
+        if not _RUN_ID_RE.match(run_id):
+            return {
+                "status": "error",
+                "message": f"invalid run_id {run_id!r}: must be a single path "
+                "segment using [A-Za-z0-9._-] (no '/', path traversal, or shell "
+                "metacharacters).",
+            }
+        dest = f"hf://buckets/{bucket}/{run_id}"
+
+        if create:
+            cp = subprocess.run(
+                ["hf", "buckets", "create", bucket] + (["--private"] if private else []),
+                capture_output=True,
+                text=True,
+            )
+            blob = (cp.stderr + cp.stdout).lower()
+            if cp.returncode != 0 and "exist" not in blob:
+                return {
+                    "status": "error",
+                    "message": f"bucket create failed: {cp.stderr.strip()}",
+                }
+
+        cmd = ["hf", "sync", local_root, dest]
+        if delete:
+            cmd.append("--delete")
+        logger.info("Syncing %s -> %s", local_root, dest)
+        proc = subprocess.run(cmd, capture_output=True, text=True)
+        if proc.returncode != 0:
+            return {
+                "status": "error",
+                "message": proc.stderr.strip() or proc.stdout.strip(),
+            }
+
+        return {
+            "status": "success",
+            "bucket_uri": dest,
+            "episodes": self.episode_count,
+            "frames": self.frame_count,
+        }
 
     @property
     def repo_id(self) -> str:

--- a/strands_robots/simulation/mujoco/recording.py
+++ b/strands_robots/simulation/mujoco/recording.py
@@ -271,11 +271,28 @@ class RecordingMixin:
                 + "\n  - ".join(diffs)
             )
 
-    def stop_recording(self, output_path: str | None = None) -> dict[str, Any]:
+    def stop_recording(
+        self,
+        output_path: str | None = None,
+        *,
+        push_to_hub: bool = False,
+        bucket: str | None = None,
+        run_id: str | None = None,
+    ) -> dict[str, Any]:
         """Stop recording and save episode to LeRobotDataset.
 
         idempotent - calling when not recording succeeds with a
         'Was not recording' message so callers can safely call it unconditionally.
+
+        Args:
+            output_path: Unused legacy arg (kept for back-compat).
+            push_to_hub: Publish to a versioned HF *dataset* repo (the finished
+                artifact). Overrides the ``push_to_hub`` set at start_recording.
+            bucket: If set (e.g. ``"my-org/robot-fave"``), sync the dataset into
+                a mutable HF Storage Bucket instead of/in addition to the dataset
+                repo — the Phase 1/2 collection target (Xet-deduped, overwrite in
+                place). See reports/STREAMING_DATA_LOOP_DEEP_DIVE.md §2.4 / App. A.
+            run_id: Optional subpath inside the bucket (defaults to dataset name).
         """
         if self._world is None or not self._world._backend_state.get("recording", False):
             return {"status": "success", "content": [{"text": "Was not recording."}]}
@@ -287,28 +304,78 @@ class RecordingMixin:
             return {"status": "error", "content": [{"text": "No dataset recorder active."}]}
 
         recorder.save_episode()
-        push_result = None
-        if self._world._backend_state.get("push_to_hub", False):
-            push_result = recorder.push_to_hub(tags=["strands-robots", "sim"])
 
         repo_id = recorder.repo_id
         frame_count = recorder.frame_count
         episode_count = recorder.episode_count
         root = recorder.root
 
+        # Finalize FIRST so meta/ (stats/info) is written before any bucket sync
+        # — streaming/training downstream needs it (App. F.2).
         recorder.finalize()
+
+        extra = ""
+        # Bucket sync (Phase 1/2): mutable, Xet-deduped collection dump.
+        if bucket:
+            sync_result = recorder.sync_to_bucket(bucket, run_id=run_id)
+            if sync_result.get("status") == "success":
+                extra += f"\nSynced to bucket: {sync_result['bucket_uri']}"
+            else:
+                extra += f"\nBucket sync FAILED: {sync_result.get('message')}"
+        # Versioned dataset-repo publish (Phase 4 hand-off).
+        if push_to_hub or self._world._backend_state.get("push_to_hub", False):
+            push_result = recorder.push_to_hub(tags=["strands-robots", "sim"])
+            if push_result and push_result.get("status") == "success":
+                extra += "\nPushed to HuggingFace Hub"
+            elif push_result:
+                extra += f"\npush_to_hub FAILED: {push_result.get('message')}"
+
         self._world._backend_state["dataset_recorder"] = None
         self._world._backend_state["trajectory"] = []
 
         text = (
             f"Episode saved to LeRobotDataset\n"
             f"{repo_id} -- {frame_count} frames, {episode_count} episode(s)\n"
-            f"Local: {root}"
+            f"Local: {root}{extra}"
         )
-        if push_result and push_result.get("status") == "success":
-            text += "\nPushed to HuggingFace Hub"
 
         return {"status": "success", "content": [{"text": text}]}
+
+    def stream_dataset(self, repo_id: str, **kwargs):
+        """Open a streaming reader for a LeRobotDataset — read frames straight
+        from the Hub (or a local root) with no full materialization.
+
+        This is the in-process counterpart to ``start_recording`` /
+        ``stop_recording``: where those WRITE a dataset, ``stream_dataset``
+        READS one back lazily for eval / replay / inspection (Phase 3 of the
+        physical-AI data loop). Training scripts can instead use
+        ``python -m lerobot.scripts.train dataset.streaming=true`` which uses
+        the same underlying StreamingLeRobotDataset (deep-dive Appendix D).
+
+        Args:
+            repo_id: HF dataset id (e.g. ``"lerobot/svla_so100_pickplace"``) or
+                a local repo_id paired with ``root=``.
+            **kwargs: Forwarded to
+                :meth:`StreamingDatasetReader.open` — e.g. ``root``,
+                ``delta_timestamps``, ``episodes``, ``shuffle``, ``buffer_size``,
+                ``max_num_shards``, ``drop_videos`` (proprio-only, torchcodec-free).
+
+        Returns:
+            A :class:`~strands_robots.streaming_dataset.StreamingDatasetReader`.
+
+        Example:
+            reader = sim.stream_dataset(
+                "local/agent_demo", root="/tmp/strands_agent_dataset",
+                delta_timestamps={"observation.state": [-0.0667, 0.0],
+                                  "action": [0.0, 0.0667]},
+                shuffle=False,
+            )
+            for frame in reader:
+                ...
+        """
+        from strands_robots.streaming_dataset import StreamingDatasetReader
+
+        return StreamingDatasetReader.open(repo_id, **kwargs)
 
     def get_recording_status(self) -> dict[str, Any]:
         """Returns success in every lifecycle state (no world / not

--- a/strands_robots/streaming_dataset.py
+++ b/strands_robots/streaming_dataset.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Streaming read-back for LeRobotDataset — read frames directly from the Hub.
+
+Primary use: in-process eval / replay / notebooks / agent loops (NOT a
+precondition for streamed *training* — ``python -m lerobot.scripts.train
+dataset.streaming=true`` already uses StreamingLeRobotDataset via
+``lerobot.datasets.factory.make_dataset``; see
+reports/STREAMING_DATA_LOOP_DEEP_DIVE.md Appendix D).
+
+Design mirrors ``dataset_recorder.py``:
+  * lerobot is NEVER imported at module top-level (numpy/pandas ABI safety on
+    Jetson; see dataset_recorder.py header).
+  * Constructor kwargs are forwarded via ``inspect.signature`` introspection so
+    a lerobot version bump can't break us (lerobot's dataset API drifted across
+    0.5.0->0.5.2; streaming is newer and still changing — upstream has a
+    multi-thread prefetch TODO).
+"""
+
+from __future__ import annotations
+
+import functools
+import inspect
+import logging
+import sys
+from collections.abc import Callable
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@functools.lru_cache(maxsize=1)
+def has_streaming_dataset() -> bool:
+    """True if lerobot's StreamingLeRobotDataset is importable. Cached."""
+    try:
+        from lerobot.datasets import StreamingLeRobotDataset  # noqa: F401
+
+        return True
+    except (ImportError, ValueError, RuntimeError) as exc:
+        logger.debug("StreamingLeRobotDataset unavailable: %s", exc)
+        return False
+
+
+def _get_streaming_cls() -> Any:
+    """Return StreamingLeRobotDataset, honoring a test-injected module override."""
+    this_module = sys.modules[__name__]
+    mock_cls = getattr(this_module, "StreamingLeRobotDataset", None)
+    if mock_cls is not None:
+        return mock_cls
+    try:
+        from lerobot.datasets import StreamingLeRobotDataset
+
+        return StreamingLeRobotDataset
+    except (ImportError, ValueError, RuntimeError) as exc:
+        raise ImportError(
+            f"StreamingLeRobotDataset unavailable ({exc}). "
+            "Install with: pip install 'strands-robots[lerobot]' "
+            "(needs torchcodec for video keys; on aarch64/Jetson that means "
+            "torch>=2.11 + torchcodec>=0.11 — see deep-dive Appendix C). "
+            "For proprio-only streaming without torchcodec, use drop_videos=True."
+        ) from exc
+
+
+class StreamingDatasetReader:
+    """Version-tolerant wrapper over lerobot's StreamingLeRobotDataset.
+
+    Example (in-process eval / replay):
+        reader = StreamingDatasetReader.open(
+            "strands-robots/pick-place",
+            delta_timestamps={"observation.images.front": [-0.2, -0.1, 0.0],
+                              "action": [0.0, 0.1, 0.2]},
+            shuffle=False,            # chronological for replay/eval
+        )
+        for frame in reader:
+            ...  # raw tensors; normalize via reader.meta.stats if needed
+    """
+
+    def __init__(self, dataset: Any) -> None:
+        self.dataset = dataset
+
+    @classmethod
+    def open(
+        cls,
+        repo_id: str,
+        *,
+        root: str | None = None,
+        episodes: list[int] | None = None,
+        delta_timestamps: dict[str, list[float]] | None = None,
+        image_transforms: Callable | None = None,
+        tolerance_s: float = 1e-4,
+        revision: str | None = None,
+        streaming: bool = True,
+        buffer_size: int = 1000,
+        max_num_shards: int = 16,
+        seed: int = 42,
+        shuffle: bool = True,
+        return_uint8: bool = True,  # halves frame bandwidth; policies normalize
+        validate_deltas: bool = True,  # parity with materialized path (App. A.2)
+        drop_videos: bool = False,  # proprio-only streaming (no torchcodec)
+    ) -> StreamingDatasetReader:
+        StreamingCls = _get_streaming_cls()
+        init_sig = inspect.signature(StreamingCls).parameters
+        # If the constructor accepts **kwargs, every candidate is forwardable.
+        accepts_var_kw = any(p.kind is inspect.Parameter.VAR_KEYWORD for p in init_sig.values())
+
+        # Proprio-only: strip video keys from delta_timestamps so video decode
+        # (torchcodec) is never invoked — lets constrained edge devices stream
+        # state/action without a torchcodec wheel (App. C.2).
+        if drop_videos and delta_timestamps:
+            delta_timestamps = {
+                k: v for k, v in delta_timestamps.items() if not k.startswith("observation.images.")
+            } or None
+
+        kwargs: dict[str, Any] = {"repo_id": repo_id}
+        candidate = dict(
+            root=root,
+            episodes=episodes,
+            delta_timestamps=delta_timestamps,
+            image_transforms=image_transforms,
+            tolerance_s=tolerance_s,
+            revision=revision,
+            streaming=streaming,
+            buffer_size=buffer_size,
+            max_num_shards=max_num_shards,
+            seed=seed,
+            shuffle=shuffle,
+            return_uint8=return_uint8,
+        )
+        for k, v in candidate.items():
+            if not (accepts_var_kw or k in init_sig):
+                continue
+            if k in ("streaming", "shuffle", "return_uint8") or v is not None:
+                kwargs[k] = v
+
+        logger.info(
+            "Opening StreamingLeRobotDataset: %s (streaming=%s, buffer=%d, shards=%d)",
+            repo_id,
+            streaming,
+            buffer_size,
+            max_num_shards,
+        )
+        ds = StreamingCls(**kwargs)
+
+        # Tolerance grid-check — the streaming path skips check_delta_timestamps
+        # (App. A.2); replicate it for parity with the materialized dataset.
+        if delta_timestamps and validate_deltas:
+            try:
+                from lerobot.datasets.feature_utils import check_delta_timestamps
+
+                check_delta_timestamps(delta_timestamps, ds.fps, tolerance_s, raise_value_error=True)
+            except ImportError:
+                logger.debug("check_delta_timestamps unavailable; skipping grid check")
+
+        return cls(ds)
+
+    def dataloader(self, batch_size: int = 64, num_workers: int = 0, **kw: Any) -> Any:
+        """torch DataLoader over the streamed (Iterable) dataset.
+
+        WARNING (verified upstream): StreamingLeRobotDataset is an
+        IterableDataset that shuffles INTERNALLY (reservoir buffer). Do NOT pass
+        shuffle=True here. With num_workers>0, video decode parallelizes across
+        worker processes — the documented mitigation for the single-thread
+        bottleneck (streaming_dataset.py ~L312 TODO). Never decode video in the
+        main process while workers>0 (segfault — _query_videos docstring).
+
+        Note: lerobot's make_dataset couples max_num_shards = num_workers
+        (factory.py). If you need that coupling, pass the same N to
+        open(max_num_shards=N) and here num_workers=N.
+        """
+        import torch
+
+        if kw.pop("shuffle", None):
+            logger.warning("Ignoring shuffle=True: streaming shuffles internally.")
+        return torch.utils.data.DataLoader(self.dataset, batch_size=batch_size, num_workers=num_workers, **kw)
+
+    @property
+    def num_frames(self) -> Any:
+        return self.dataset.num_frames
+
+    @property
+    def num_episodes(self) -> Any:
+        return self.dataset.num_episodes
+
+    @property
+    def fps(self) -> Any:
+        return self.dataset.fps
+
+    @property
+    def meta(self) -> Any:
+        """Dataset metadata (incl. .stats for normalization). Always local."""
+        return self.dataset.meta
+
+    def __iter__(self) -> Any:
+        return iter(self.dataset)

--- a/tests/test_customer_workflow_regressions.py
+++ b/tests/test_customer_workflow_regressions.py
@@ -15,6 +15,7 @@ The localhost mesh dev preset (``STRANDS_MESH_LOCAL_DEV``) is covered in
 
 from __future__ import annotations
 
+import re
 import tomllib
 from pathlib import Path
 
@@ -57,10 +58,17 @@ class TestLerobotExtraIncludesFeetech:
         with open(_REPO_ROOT / "pyproject.toml", "rb") as f:
             data = tomllib.load(f)
         lerobot_extra = data["project"]["optional-dependencies"]["lerobot"]
-        # Exactly one lerobot pin, and it must carry the [feetech] marker so
-        # scservo_sdk is installed for Feetech-based customers' first run.
-        joined = " ".join(lerobot_extra)
-        assert "lerobot[feetech]" in joined, f"[lerobot] extra must request lerobot[feetech]; got {lerobot_extra!r}"
+        # The lerobot pin must carry the `feetech` extra so scservo_sdk is
+        # installed for Feetech-based customers' first run. The pin may co-list
+        # other extras (e.g. `lerobot[feetech,dataset]` for the streaming data
+        # loop), so assert `feetech` is a member of the extras set rather than
+        # matching the brittle literal `lerobot[feetech]`.
+        markers = re.findall(r"lerobot\[([^\]]+)\]", " ".join(lerobot_extra))
+        assert markers, f"[lerobot] extra must pin lerobot[...]; got {lerobot_extra!r}"
+        extras = {e.strip() for marker in markers for e in marker.split(",")}
+        assert "feetech" in extras, (
+            f"[lerobot] extra must request the `feetech` extra (scservo_sdk); got {lerobot_extra!r}"
+        )
 
 
 class TestMolmoact2Extra:

--- a/tests/test_streaming_dataset.py
+++ b/tests/test_streaming_dataset.py
@@ -1,0 +1,335 @@
+"""Unit tests for ``strands_robots.streaming_dataset.StreamingDatasetReader``
+and ``DatasetRecorder.sync_to_bucket``.
+
+Mirrors test_dataset_recorder.py: inject fakes so tests run WITHOUT lerobot or
+the ``hf`` CLI installed. Covers version-tolerant kwarg forwarding, the
+proprio-only ``drop_videos`` path, delta-grid validation, and the bucket-sync
+CLI construction + meta/ guard.
+"""
+
+import os
+import subprocess
+
+import pytest
+
+import strands_robots.streaming_dataset as sd
+from strands_robots.dataset_recorder import DatasetRecorder
+
+
+class _FakeStreaming:
+    """Fake StreamingLeRobotDataset capturing the kwargs it was built with."""
+
+    def __init__(self, repo_id, **kw):
+        self.repo_id = repo_id
+        self.kw = kw
+        self.num_frames = 1000
+        self.num_episodes = 10
+        self.fps = 30
+
+    def __iter__(self):
+        yield {"observation.state": [0.0], "action": [0.0], "task": "t"}
+
+
+def test_open_forwards_supported_kwargs(monkeypatch):
+    monkeypatch.setattr(sd, "StreamingLeRobotDataset", _FakeStreaming, raising=False)
+    r = sd.StreamingDatasetReader.open(
+        "org/ds",
+        buffer_size=256,
+        shuffle=False,
+        max_num_shards=8,
+        validate_deltas=False,
+    )
+    assert r.dataset.repo_id == "org/ds"
+    assert r.dataset.kw["buffer_size"] == 256
+    assert r.dataset.kw["shuffle"] is False
+    assert r.dataset.kw["max_num_shards"] == 8
+    assert r.num_episodes == 10
+    assert r.fps == 30
+
+
+def test_open_drops_unknown_kwargs(monkeypatch):
+    """A narrow constructor (only repo_id) must not raise on extra kwargs."""
+
+    class _Narrow:
+        def __init__(self, repo_id):
+            self.repo_id = repo_id
+            self.num_frames = self.num_episodes = self.fps = 0
+
+        def __iter__(self):
+            yield {}
+
+    monkeypatch.setattr(sd, "StreamingLeRobotDataset", _Narrow, raising=False)
+    r = sd.StreamingDatasetReader.open("org/ds", buffer_size=999, shuffle=True, validate_deltas=False)
+    assert r.dataset.repo_id == "org/ds"
+
+
+def test_drop_videos_strips_camera_deltas(monkeypatch):
+    monkeypatch.setattr(sd, "StreamingLeRobotDataset", _FakeStreaming, raising=False)
+    r = sd.StreamingDatasetReader.open(
+        "org/ds",
+        delta_timestamps={
+            "observation.images.front": [-0.1, 0.0],
+            "observation.state": [0.0],
+            "action": [0.0],
+        },
+        drop_videos=True,
+        validate_deltas=False,
+    )
+    dt = r.dataset.kw["delta_timestamps"]
+    assert "observation.images.front" not in dt
+    assert "observation.state" in dt and "action" in dt
+
+
+def test_drop_videos_all_camera_keys_yields_none(monkeypatch):
+    monkeypatch.setattr(sd, "StreamingLeRobotDataset", _FakeStreaming, raising=False)
+    r = sd.StreamingDatasetReader.open(
+        "org/ds",
+        delta_timestamps={"observation.images.front": [-0.1, 0.0]},
+        drop_videos=True,
+        validate_deltas=False,
+    )
+    # All keys were camera keys → delta_timestamps drops out entirely.
+    assert "delta_timestamps" not in r.dataset.kw
+
+
+def test_dataloader_ignores_shuffle(monkeypatch):
+    monkeypatch.setattr(sd, "StreamingLeRobotDataset", _FakeStreaming, raising=False)
+    r = sd.StreamingDatasetReader.open("org/ds", validate_deltas=False)
+
+    captured = {}
+
+    class _FakeDataLoader:
+        def __init__(self, dataset, batch_size, num_workers, **kw):
+            captured["shuffle_in_kw"] = "shuffle" in kw
+            captured["batch_size"] = batch_size
+
+    class _FakeTorchUtilsData:
+        DataLoader = _FakeDataLoader
+
+    class _FakeTorch:
+        utils = type("u", (), {"data": _FakeTorchUtilsData})
+
+    import sys
+
+    monkeypatch.setitem(sys.modules, "torch", _FakeTorch)
+    r.dataloader(batch_size=32, shuffle=True)  # shuffle must be swallowed
+    assert captured["shuffle_in_kw"] is False
+    assert captured["batch_size"] == 32
+
+
+# ── sync_to_bucket ─────────────────────────────────────────────────────────
+
+
+class _FakeDataset:
+    def __init__(self, root):
+        self.repo_id = "org/pick"
+        self.root = root
+
+
+def _recorder(tmp_path):
+    rec = DatasetRecorder(dataset=_FakeDataset(str(tmp_path)))
+    rec.episode_count = 3
+    rec.frame_count = 300
+    return rec
+
+
+def test_sync_to_bucket_builds_cli(tmp_path, monkeypatch):
+    (tmp_path / "meta").mkdir()  # satisfy the meta/ guard
+    rec = _recorder(tmp_path)
+
+    import shutil
+
+    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/hf")
+
+    calls = []
+
+    def fake_run(cmd, capture_output=True, text=True):
+        calls.append(cmd)
+
+        class R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return R()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    res = rec.sync_to_bucket("my-org/robot-fave", run_id="run-021")
+    assert res["status"] == "success"
+    assert res["bucket_uri"] == "hf://buckets/my-org/robot-fave/run-021"
+    assert any(c[:3] == ["hf", "buckets", "create"] for c in calls)
+    assert any(c[:2] == ["hf", "sync"] and c[-1].startswith("hf://buckets/") for c in calls)
+
+
+def test_sync_to_bucket_requires_meta(tmp_path, monkeypatch):
+    rec = _recorder(tmp_path)  # NO meta/ dir
+    import shutil
+
+    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/hf")
+    res = rec.sync_to_bucket("my-org/robot-fave")
+    assert res["status"] == "error"
+    assert "meta/" in res["message"]
+
+
+def test_sync_to_bucket_missing_hf_cli(tmp_path, monkeypatch):
+    (tmp_path / "meta").mkdir()
+    rec = _recorder(tmp_path)
+    import shutil
+
+    monkeypatch.setattr(shutil, "which", lambda _: None)
+    res = rec.sync_to_bucket("my-org/robot-fave")
+    assert res["status"] == "error"
+    assert "hf` CLI" in res["message"] or "hf CLI" in res["message"]
+
+
+def _guard_recorder(tmp_path, monkeypatch):
+    """Recorder whose hf CLI + meta/ guards pass, so validation runs and any
+    subprocess call would be a security regression (the fake raises)."""
+    (tmp_path / "meta").mkdir()
+    rec = _recorder(tmp_path)
+    import shutil
+
+    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/hf")
+
+    def boom(*a, **k):  # subprocess must never run with a rejected target
+        raise AssertionError(f"subprocess.run reached with {a!r}")
+
+    monkeypatch.setattr(subprocess, "run", boom)
+    return rec
+
+
+@pytest.mark.parametrize(
+    "bucket",
+    [
+        "../escape",
+        "org/../escape",
+        "my-org/robot;rm -rf /",
+        "my-org/robot fave",
+        "a/b/c",  # too many path segments
+        "$(whoami)",
+        "-leading-dash",
+        "",
+    ],
+)
+def test_sync_to_bucket_rejects_unsafe_bucket(tmp_path, monkeypatch, bucket):
+    """Agent-reachable bucket names with traversal / metacharacters / extra
+    segments must be rejected before any `hf` subprocess (LLM input safety)."""
+    rec = _guard_recorder(tmp_path, monkeypatch)
+    res = rec.sync_to_bucket(bucket)
+    assert res["status"] == "error"
+    assert "bucket" in res["message"]
+
+
+@pytest.mark.parametrize(
+    "run_id",
+    [
+        "../escape",
+        "sub/dir",
+        "run;rm -rf /",
+        "run id",
+        "$(id)",
+    ],
+)
+def test_sync_to_bucket_rejects_unsafe_run_id(tmp_path, monkeypatch, run_id):
+    """run_id reaches the hf:// URI + argv; reject traversal/metacharacters
+    and any path separator before constructing the destination."""
+    rec = _guard_recorder(tmp_path, monkeypatch)
+    res = rec.sync_to_bucket("my-org/robot-fave", run_id=run_id)
+    assert res["status"] == "error"
+    assert "run_id" in res["message"]
+
+
+# ── stream_dataset facade ──────────────────────────────────────────────────
+
+
+def test_recording_mixin_stream_dataset_delegates(monkeypatch):
+    """sim.stream_dataset(...) must delegate to StreamingDatasetReader.open,
+    keeping streaming a native facade method (not user-side plumbing)."""
+    from strands_robots.simulation.mujoco.recording import RecordingMixin
+
+    captured = {}
+
+    def fake_open(repo_id, **kw):
+        captured["repo_id"] = repo_id
+        captured["kw"] = kw
+        return "READER"
+
+    monkeypatch.setattr(sd.StreamingDatasetReader, "open", staticmethod(fake_open), raising=True)
+
+    mixin = RecordingMixin()
+    out = mixin.stream_dataset("org/ds", root="/tmp/x", shuffle=False, drop_videos=True)
+    assert out == "READER"
+    assert captured["repo_id"] == "org/ds"
+    assert captured["kw"]["root"] == "/tmp/x"
+    assert captured["kw"]["shuffle"] is False
+    assert captured["kw"]["drop_videos"] is True
+
+
+# ── macOS dyld shim ────────────────────────────────────────────────────────
+
+
+def test_dyld_shim_noop_off_macos(monkeypatch):
+    """On non-macOS the shim is a pure no-op (returns False, no env change)."""
+    from strands_robots import _dyld
+
+    monkeypatch.setattr(_dyld.sys, "platform", "linux")
+    monkeypatch.delenv(_dyld._DYLD_VAR, raising=False)
+    assert _dyld.ensure_ffmpeg_on_dyld_path() is False
+    assert _dyld._DYLD_VAR not in os.environ
+
+
+def test_dyld_shim_opt_out(monkeypatch):
+    from strands_robots import _dyld
+
+    monkeypatch.setattr(_dyld.sys, "platform", "darwin")
+    monkeypatch.setenv(_dyld._OPT_OUT_ENV, "1")
+    assert _dyld.ensure_ffmpeg_on_dyld_path() is False
+
+
+def test_dyld_shim_noop_without_torchcodec(monkeypatch):
+    from strands_robots import _dyld
+
+    monkeypatch.setattr(_dyld.sys, "platform", "darwin")
+    monkeypatch.delenv(_dyld._OPT_OUT_ENV, raising=False)
+    monkeypatch.setattr(_dyld, "_torchcodec_installed", lambda: False)
+    assert _dyld.ensure_ffmpeg_on_dyld_path() is False
+
+
+def test_dyld_shim_sets_env_and_skips_reexec_when_unsafe(monkeypatch, tmp_path):
+    """When torchcodec + ffmpeg are present but it's NOT safe to re-exec
+    (e.g. under pytest), the shim sets DYLD for child procs and does NOT
+    re-exec — it warns instead."""
+    from strands_robots import _dyld
+
+    monkeypatch.setattr(_dyld.sys, "platform", "darwin")
+    monkeypatch.delenv(_dyld._OPT_OUT_ENV, raising=False)
+    monkeypatch.delenv(_dyld._GUARD_ENV, raising=False)
+    monkeypatch.delenv(_dyld._DYLD_VAR, raising=False)
+    monkeypatch.setattr(_dyld, "_torchcodec_installed", lambda: True)
+    monkeypatch.setattr(_dyld, "_find_ffmpeg_lib_dir", lambda: str(tmp_path))
+    # Under pytest, _is_safe_to_reexec() is False → must NOT call os.execv.
+    called = {"execv": False}
+    monkeypatch.setattr(_dyld.os, "execv", lambda *a: called.__setitem__("execv", True))
+
+    with pytest.warns(RuntimeWarning):
+        result = _dyld.ensure_ffmpeg_on_dyld_path()
+
+    assert result is False
+    assert called["execv"] is False  # never re-exec under pytest
+    # but child-process env IS set
+    assert str(tmp_path) in os.environ[_dyld._DYLD_VAR]
+
+
+def test_dyld_shim_noop_when_already_set(monkeypatch, tmp_path):
+    from strands_robots import _dyld
+
+    monkeypatch.setattr(_dyld.sys, "platform", "darwin")
+    monkeypatch.delenv(_dyld._OPT_OUT_ENV, raising=False)
+    monkeypatch.setattr(_dyld, "_torchcodec_installed", lambda: True)
+    monkeypatch.setattr(_dyld, "_find_ffmpeg_lib_dir", lambda: str(tmp_path))
+    monkeypatch.setenv(_dyld._DYLD_VAR, str(tmp_path))  # already present
+    called = {"execv": False}
+    monkeypatch.setattr(_dyld.os, "execv", lambda *a: called.__setitem__("execv", True))
+    assert _dyld.ensure_ffmpeg_on_dyld_path() is True
+    assert called["execv"] is False


### PR DESCRIPTION
## Summary

Integrates the LeRobot **streaming data loop** and **Hugging Face Storage Buckets** into strands-robots dataset collection — closing the physical-AI data loop: **collect → bucket → stream-to-train (no download) → deploy** back to hardware.

Today strands-robots can record a `LeRobotDataset` (sim + hardware) and `push_to_hub()` to a versioned repo, but it has **no streaming read-back** and **no bucket-write** path. This PR adds both, natively.

> Single clean commit on top of `main`. Supersedes #606 (which carried merge noise from concurrent main updates).

## What's new

### Native API (no library internals leaking into user code)
- **`Robot().stream_dataset(repo_id, **kw)`** — in-process streaming read-back, the counterpart to `start_recording`/`stop_recording`. The same `Robot()` that records can stream; camera frames decode on the fly from the MP4 shards.
- **`stop_recording(..., bucket=, run_id=)`** — one kwarg syncs the finalized episode into a mutable, Xet-deduped HF Storage Bucket (`hf://buckets/...`). Finalizes first so `meta/` (stats/info) ships for downstream normalization.
- **`DatasetRecorder.sync_to_bucket(bucket, run_id=None)`** — the underlying sync via the `hf` CLI (graceful error if CLI/login missing).
- **`StreamingDatasetReader`** (`strands_robots.streaming_dataset`) — version-tolerant wrapper over lerobot's `StreamingLeRobotDataset`: lazy import, `**kwargs` introspection, delta-grid validation parity, and a `drop_videos` proprio-only path for edge devices without a torchcodec wheel. Lazily exported from the package root.

### Dependencies (the `[lerobot]` extra is now self-sufficient for the data loop)
- `lerobot[feetech,dataset]` — pulls `datasets` + `pandas` + `pyarrow` + `av` + `torchcodec` so streaming video decode works out of the box.
- `torchcodec` pinned to track the resolved torch C++ ABI: `0.10` on darwin/arm64 (torch 2.10), `0.11` on linux/aarch64 (torch 2.11). Fixes the `dlopen "Symbol not found: c10::MessageLogger"` mismatch that 0.7/0.8 hit against torch 2.10.
- `test_customer_workflow_regressions` updated to assert `feetech` is a **member** of the lerobot extras set (so `lerobot[feetech,dataset]` passes) instead of matching the brittle literal `lerobot[feetech]`.

### macOS zero-touch dyld shim (`strands_robots/_dyld.py`)
torchcodec links ffmpeg via `@rpath`, but Homebrew's ffmpeg (`/opt/homebrew/lib`) isn't on the default dyld search path → `import torchcodec` fails with `Library not loaded: @rpath/libavutil.59.dylib`. `os.environ` mid-process can't fix it (dyld snapshots `DYLD_*` at launch) and `ctypes` preload doesn't satisfy `@rpath` on macOS. So `ensure_ffmpeg_on_dyld_path()` runs eagerly at `import strands_robots`:
- No-op unless macOS + Homebrew ffmpeg present + torchcodec installed + var not already set.
- Exports `DYLD_FALLBACK_LIBRARY_PATH` so **child processes** (DataLoader workers, subprocess training) inherit it.
- **Re-execs the interpreter once** (guarded against loops) for the current process — but **only when safe**: refuses inside Jupyter / IPython / pytest / REPL / `python -c`, where it warns with the one-line `export` instead.
- Opt out with `STRANDS_ROBOTS_NO_DYLD_SHIM=1`.

### Example + docs
- `examples/06_agent_collect_and_stream.py` — a Strands `Agent` records a dataset from one NL prompt, then `sim.stream_dataset()` reads it back with full camera decode (~50 lines, no torchcodec/av plumbing).
- README: new **"Recording & streaming datasets"** section + the macOS note + `STRANDS_ROBOTS_NO_DYLD_SHIM` env var.
- `docs/recording.md`: `sync_to_bucket` in the methods table + a **"Stream back (no full download)"** section.

## Verification (local, uv + py3.12, lerobot 0.5.2, torch 2.10 + torchcodec 0.10, `MUJOCO_GL=cgl`)
- Agent-driven sim recording: 60 frames / 1 episode, 2 cameras, `libsvtav1`.
- `sim.stream_dataset()` yields `state(6,)` + `action(6,)` + **decoded** camera tensors `(3, 480, 640)` straight from MP4 shards — zero re-download.
- Zero-touch confirmed: `env -u DYLD_FALLBACK_LIBRARY_PATH python examples/06_*.py` streams video with no manual setup.
- **86 tests pass** (streaming/shim/facade + recorder + customer-workflow). pytest correctly does **not** re-exec.

## Notes / scope
- For full **training**, the upstream trainer already uses the same engine via `python -m lerobot.scripts.train dataset.streaming=true` — no new code needed there; `StreamingDatasetReader`'s home is in-process eval/replay/inspection.
- True `hf://buckets/...` **streaming** (vs collection-time sync) needs a small upstream lerobot change to `LeRobotDatasetMetadata.url_root`; the recommended path today is collect→bucket + stream from a published dataset repo (near-instant server-side `hf buckets cp`). Tracked as a follow-up.
- Backward compatible: all additions; `stop_recording()`'s new args are keyword-only with prior defaults.

## Files (11)
```
 strands_robots/streaming_dataset.py            +193  (new)
 strands_robots/_dyld.py                         +159  (new)
 strands_robots/dataset_recorder.py             +107  (sync_to_bucket + push_to_hub kwargs)
 strands_robots/simulation/mujoco/recording.py   +81  (stream_dataset, bucket=)
 strands_robots/__init__.py                       +16  (lazy export + shim)
 pyproject.toml                                   +23  (lerobot[dataset] + torchcodec)
 examples/06_agent_collect_and_stream.py          +64  (new)
 tests/test_streaming_dataset.py                 +335  (new)
 tests/test_customer_workflow_regressions.py      +16  (feetech-as-member assertion)
 README.md                                        +63
 docs/recording.md                                +54
```

🤖 Authored with assistance from DevDuck.