### PR TITLE
docs(policies): pin per-tick action value convention in Policy ABC

### DIFF
--- a/docs/policies/custom-policies.md
+++ b/docs/policies/custom-policies.md
@@ -66,6 +66,23 @@ The factory imports lazily on first use.
 | `reset(seed=None)` | no | no-op |
 | `get_actions_sync(...)` | no | sync wrapper |
 
+## Action value convention
+
+`get_actions` returns a `list[dict]` -- one dict per control tick, each mapping a
+robot state key (joint/actuator name) to its **target value** for that tick. The
+value MUST be **JSON / python-native**:
+
+- a python `float` for a single-DOF actuator, or
+- a `list[float]` for a multi-DOF actuator group.
+
+Do **not** return raw `np.ndarray` objects. If your policy computes actions with
+numpy / torch, coerce before returning (`float(v)` for scalars, `v.tolist()` for
+arrays). This lets downstream consumers treat every provider's output uniformly
+(`float(v)` on a scalar, `len(v)` on a group) regardless of the policy's internal
+compute backend. The list length is the action-chunk horizon; consumers execute
+it at a fixed control rate (e.g. 50Hz). See `strands_robots/policies/mock.py` for
+the canonical reference.
+
 ## See also
 
 - [Policy overview](overview.md) - factory, providers.

--- a/strands_robots/policies/base.py
+++ b/strands_robots/policies/base.py
@@ -40,6 +40,13 @@ class Policy(ABC):
     Non-VLA providers typically set :attr:`requires_images` to ``False``
     and read their goal from the well-known ``**kwargs`` keys documented
     on :meth:`get_actions`.
+
+    All providers MUST honour the per-tick **action value convention**
+    documented on :meth:`get_actions`: each action value is a python
+    ``float`` (single-DOF) or ``list[float]`` (multi-DOF group), never a
+    raw ``np.ndarray``, so downstream consumers handle every provider's
+    output uniformly regardless of its internal compute backend. See
+    ``MockPolicy`` for the canonical reference.
     """
 
     @abstractmethod
@@ -79,10 +86,21 @@ class Policy(ABC):
                 raising, so callers can pass shared keys across providers.
 
         Returns:
-            List of action dicts for robot execution.  Each dict maps
-            robot state key (joint name) to the target value for that
-            tick; consumers typically execute the list at a fixed
-            control rate (e.g. 50Hz).
+            List of action dicts for robot execution.  Each dict maps a
+            robot state key (joint/actuator name) to its **target value**
+            for that tick.
+
+            Values MUST be **JSON / python-native**: a python ``float`` for
+            a single-DOF actuator, or a ``list[float]`` for a multi-DOF
+            actuator group.  Implementations MUST NOT return raw
+            ``np.ndarray`` objects -- coerce with ``.tolist()`` /
+            ``float(...)`` before returning -- so downstream consumers can
+            treat every provider's output uniformly (e.g. ``float(v)`` on a
+            scalar, ``len(v)`` on a group) regardless of the policy's
+            internal compute backend.
+
+            The list length is the action-chunk horizon; consumers execute
+            it at a fixed control rate (e.g. 50Hz).
         """
         pass
 

--- a/strands_robots/policies/mock.py
+++ b/strands_robots/policies/mock.py
@@ -32,7 +32,12 @@ class MockPolicy(Policy):
     async def get_actions(
         self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any
     ) -> list[dict[str, Any]]:
-        """Return smooth sinusoidal actions."""
+        """Return smooth sinusoidal actions.
+
+        Canonical reference for the per-tick action value convention
+        documented on :meth:`Policy.get_actions`: every value is a python
+        ``float`` (single-DOF joint target), never a raw ``np.ndarray``.
+        """
         if not self.robot_state_keys:
             if "observation.state" in observation_dict:
                 state = observation_dict["observation.state"]

--- a/tests/policies/test_base.py
+++ b/tests/policies/test_base.py
@@ -7,6 +7,8 @@ fast path and the 'already-in-event-loop' ThreadPoolExecutor fallback.
 from __future__ import annotations
 
 import asyncio
+import inspect
+import json
 from typing import Any
 
 import pytest
@@ -142,3 +144,49 @@ def test_unknown_kwargs_are_silently_ignored(provider_factory):
         "Policy must return a non-empty action list even when passed an "
         "unknown kwarg; the contract is to ignore, not raise."
     )
+
+
+def test_get_actions_docstring_pins_value_convention():
+    """The Policy.get_actions ``Returns:`` docstring MUST pin the per-tick
+    action value convention: python ``float`` / ``list[float]``, never a raw
+    ``np.ndarray``. This is the contract C2 makes explicit so providers and
+    consumers agree on the value type regardless of compute backend.
+
+    Fails on the pre-C2 docstring, which only described the dict *shape* and
+    left the value type unspecified -- the ambiguity that let providers leak
+    ``np.ndarray`` into action dicts."""
+    doc = inspect.getdoc(Policy.get_actions) or ""
+    assert "float" in doc and "list[float]" in doc, (
+        "get_actions docstring must state values are python float or list[float]"
+    )
+    assert "np.ndarray" in doc, "get_actions docstring must explicitly forbid returning raw np.ndarray"
+
+
+def test_policy_class_docstring_references_value_convention():
+    """The Policy class docstring MUST reference the action value convention
+    so implementers see it before reading the method, satisfying C2's
+    class-level note acceptance criterion."""
+    doc = inspect.getdoc(Policy) or ""
+    assert "value convention" in doc.lower() and "np.ndarray" in doc, (
+        "Policy class docstring must reference the per-tick action value "
+        "convention and that values are not raw np.ndarray"
+    )
+
+
+def test_mock_policy_action_values_are_json_native_floats():
+    """MockPolicy is the canonical reference for the value convention: every
+    action value must be a python ``float`` (not ``np.ndarray`` / numpy
+    scalar), so the action list is JSON-serializable as-is. Pins the
+    behavioural half of the C2 contract against the documented reference."""
+    p = MockPolicy()
+    p.set_robot_state_keys(["j0", "j1", "j2"])
+    actions = p.get_actions_sync({"observation.state": [0.0, 0.0, 0.0]}, instruction="")
+    assert actions, "MockPolicy must return a non-empty action list"
+    for tick in actions:
+        for key, value in tick.items():
+            assert type(value) is float, (
+                f"action value for {key!r} must be a python float per the "
+                f"documented convention, got {type(value).__name__}"
+            )
+    # JSON round-trip is the canonical proof of native-value compliance.
+    json.dumps(actions)


### PR DESCRIPTION
## Problem

`Policy.get_actions() -> list[dict[str, Any]]` documents the action-dict *shape* (a list of per-tick dicts keyed by joint/actuator name) but never specifies the per-tick value *type*. That ambiguity let providers diverge: some return python `float`, others leak raw `np.ndarray` into action dicts. Downstream consumers then cannot treat every provider's output uniformly (`float(v)` on a scalar, `len(v)` on a group) without knowing the policy's internal compute backend.

## Change (documentation only, no behavior change)

Pin the per-tick action value convention in the `Policy` ABC:

- `Policy.get_actions` `Returns:` section now states values MUST be JSON / python-native: a python `float` for a single-DOF actuator, or a `list[float]` for a multi-DOF actuator group, never a raw `np.ndarray` (coerce with `.tolist()` / `float(...)` before returning).
- `Policy` class docstring references the convention and points at `MockPolicy` as the canonical reference.
- `MockPolicy.get_actions` notes it is the canonical native-float reference.
- `docs/policies/custom-policies.md` gains an "Action value convention" section so implementers reading the custom-policy guide see the contract.

## Tests

`tests/policies/test_base.py`:

- `test_get_actions_docstring_pins_value_convention` and `test_policy_class_docstring_references_value_convention` are docstring guards that **fail on the pre-change docstrings** and pass after.
- `test_mock_policy_action_values_are_json_native_floats` pins the behavioural half: every `MockPolicy` action value is a python `float` and the action list is JSON-serializable as-is.

Local gate green: `ruff check` / `ruff format --check` clean, `mypy` clean on changed files, full `tests/policies/` (861 passed, 1 skipped) and docs tests pass.

No `np.ndarray` coercion code is added here; the existing GR00T `.tolist()` path is already consistent with the wording landed in this PR.