### PR TITLE
feat(tools): add lerobot_train tool wrapping lerobot-train

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -129,7 +129,7 @@ from strands_robots.policies.cosmos3 import Cosmos3Policy
 ```python
 from strands_robots.tools import (
     download_assets, gr00t_inference, lerobot_calibrate, lerobot_camera,
-    lerobot_teleoperate, pose_tool, serial_tool, robot_mesh,
+    lerobot_teleoperate, lerobot_train, pose_tool, serial_tool, robot_mesh,
 )
 # All return {"status": "...", "content": [{"text": "..."}]}
 ```

--- a/docs/hardware/tools.md
+++ b/docs/hardware/tools.md
@@ -1,12 +1,12 @@
 ---
-description: Eight Strands @tool helpers for hardware bring-up - calibrate, camera, teleop, pose, serial, gr00t inference, mesh, download assets.
+description: Strands @tool helpers for hardware bring-up - calibrate, camera, teleop, train, pose, serial, gr00t inference, mesh, download assets.
 ---
 
 # Hardware tools
 
 ```python
 from strands_robots.tools import (
-    lerobot_calibrate, lerobot_camera, lerobot_teleoperate,
+    lerobot_calibrate, lerobot_camera, lerobot_teleoperate, lerobot_train,
     pose_tool, serial_tool, download_assets,
     gr00t_inference,   # see GR00T page
     robot_mesh,        # see multi-robot page
@@ -21,6 +21,7 @@ from strands_robots.tools import (
 | `lerobot_calibrate` | `"list"`, `"info"`, `"search"`, `"compare"`, `"backup"` | Manage existing calibration JSONs under `~/.cache/huggingface/lerobot/calibration/` (this tool inspects/organizes - actual calibration is run via the LeRobot CLI) |
 | `lerobot_camera` | `"list"`, `"test"`, `"stream"` | Enumerate, test, stream connected cameras |
 | `lerobot_teleoperate` | `"start"`, `"stop"`, `"status"` | Leader-follower teleop session |
+| `lerobot_train` | `"start"`, `"status"`, `"stop"`, `"list"` | Fine-tune a policy on a local dataset via `lerobot-train` |
 | `pose_tool` | `"fk"`, `"ik"`, `"set_gripper"` | Forward/inverse kinematics, gripper control |
 | `serial_tool` | `"list"`, `"send"` | Enumerate serial ports, send raw commands |
 | `download_assets` | - | Pre-fetch MJCF assets to `~/.strands_robots/assets/` |

--- a/docs/training/overview.md
+++ b/docs/training/overview.md
@@ -1,14 +1,16 @@
 ---
-description: Where training lives - upstream LeRobot, Isaac-GR00T, Cosmos. strands-robots ships data + inference.
+description: Train policies locally via the lerobot_train tool, or upstream with Isaac-GR00T and Cosmos. strands-robots ships data + inference + local fine-tuning.
 ---
 
 # Training
 
-`strands-robots` ships data collection and policy inference. Training runs upstream.
+`strands-robots` ships data collection and policy inference. ACT/diffusion/pi/SmolVLA
+fine-tuning runs locally through the `lerobot_train` tool (a thin wrapper over
+`lerobot-train`); GR00T and Cosmos training run in their upstream frameworks.
 
 | Want to train | Use |
 |---------------|-----|
-| ACT, Pi0, SmolVLA, Diffusion Policy | `lerobot` - `python -m lerobot.scripts.train` |
+| ACT, Pi0, SmolVLA, Diffusion Policy | `lerobot_train` tool (wraps `lerobot-train`) or `lerobot` directly |
 | GR00T fine-tune | `Isaac-GR00T` (NVIDIA) |
 | Cosmos | NVIDIA Cosmos Framework - see [Cosmos3Policy](../policies/cosmos3.md) |
 | Custom architecture | Read LeRobot v3 dataset with `pyarrow` / `datasets` |
@@ -28,14 +30,26 @@ for episode in range(50):
                    policy_provider="mock", duration=10.0)
 sim.stop_recording()
 
-# 2. Train upstream
-# uv pip install lerobot
-# python -m lerobot.scripts.train policy=act dataset.root=/tmp/my_dataset
+# 2. Train locally on the recorded dataset (closes record -> train -> deploy)
+from strands_robots.tools import lerobot_train
 
-# 3. Infer with checkpoint
+# dataset_root is the directory holding meta/info.json
+out = lerobot_train(
+    dataset_root="~/.cache/huggingface/lerobot/user/my_dataset",
+    policy_type="act",
+    steps=20000,
+    batch_size=8,
+    val_episodes=5,        # hold out the last 5 episodes for evaluation
+    output_dir="/tmp/train_out/act_cube",
+)
+# Background session: poll progress, then stop or let it finish.
+lerobot_train(action="status", session_name=out["session_name"])
+
+# 3. Infer with the trained checkpoint
 from strands_robots.policies import create_policy
 
-policy = create_policy("lerobot_local", pretrained_name_or_path="path/to/checkpoint")
+ckpt = "/tmp/train_out/act_cube/checkpoints/last/pretrained_model"
+policy = create_policy("lerobot_local", pretrained_name_or_path=ckpt)
 sim.run_policy(robot_name="so100", instruction="pick up the cube",
                policy_object=policy, duration=15.0)
 

--- a/strands_robots/__init__.py
+++ b/strands_robots/__init__.py
@@ -54,6 +54,7 @@ if TYPE_CHECKING:
     from strands_robots.tools.lerobot_calibrate import lerobot_calibrate
     from strands_robots.tools.lerobot_camera import lerobot_camera
     from strands_robots.tools.lerobot_teleoperate import lerobot_teleoperate
+    from strands_robots.tools.lerobot_train import lerobot_train
     from strands_robots.tools.pose_tool import pose_tool
     from strands_robots.tools.robot_mesh import robot_mesh
     from strands_robots.tools.serial_tool import serial_tool
@@ -88,6 +89,7 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "lerobot_calibrate": ("strands_robots.tools.lerobot_calibrate", "lerobot_calibrate"),
     "lerobot_camera": ("strands_robots.tools.lerobot_camera", "lerobot_camera"),
     "lerobot_teleoperate": ("strands_robots.tools.lerobot_teleoperate", "lerobot_teleoperate"),
+    "lerobot_train": ("strands_robots.tools.lerobot_train", "lerobot_train"),
     "pose_tool": ("strands_robots.tools.pose_tool", "pose_tool"),
     "serial_tool": ("strands_robots.tools.serial_tool", "serial_tool"),
     # Robot mesh coordination tool (Device Connect dispatch + mesh fallback)
@@ -121,6 +123,7 @@ __all__ = [
     "gr00t_inference",
     "lerobot_camera",
     "lerobot_teleoperate",
+    "lerobot_train",
     "lerobot_calibrate",
     "serial_tool",
     "pose_tool",

--- a/strands_robots/tools/__init__.py
+++ b/strands_robots/tools/__init__.py
@@ -17,6 +17,7 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "lerobot_calibrate": (".lerobot_calibrate", "lerobot_calibrate"),
     "lerobot_camera": (".lerobot_camera", "lerobot_camera"),
     "lerobot_teleoperate": (".lerobot_teleoperate", "lerobot_teleoperate"),
+    "lerobot_train": (".lerobot_train", "lerobot_train"),
     "pose_tool": (".pose_tool", "pose_tool"),
     "robot_mesh": (".robot_mesh", "robot_mesh"),
     "serial_tool": (".serial_tool", "serial_tool"),

--- a/strands_robots/tools/lerobot_train.py
+++ b/strands_robots/tools/lerobot_train.py
@@ -1,0 +1,578 @@
+#!/usr/bin/env python3
+"""LeRobot training tool: a thin local wrapper over ``lerobot-train``.
+
+This tool closes the strands-robots data loop locally: record a LeRobot v3
+dataset (see ``lerobot_teleoperate`` or ``Robot.start_recording``), then
+fine-tune a policy on it here, then deploy the resulting checkpoint with
+``create_policy("lerobot_local", ...)``. No cloud orchestration is involved;
+the command this builds is the same ``python -m lerobot.scripts.lerobot_train``
+invocation a user would run by hand, plus a few ergonomic guardrails.
+
+Process lifecycle mirrors ``lerobot_teleoperate``: ``start`` launches a detached
+background process tracked in an on-disk session store, and ``status``/``stop``/
+``list`` manage it.
+"""
+
+import json
+import logging
+import os
+import shutil
+import signal
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+import psutil
+from strands import tool
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Reuse the teleoperate session store so all robot sessions live together.
+SESSION_DIR = Path.cwd() / ".strands_robots/.sessions"
+SESSION_DIR.mkdir(parents=True, exist_ok=True)
+
+# Policy families that train an action expert on top of a frozen VLM. Only these
+# accept ``--policy.train_expert_only``; emitting it elsewhere is a hard error in
+# lerobot, so callers that pass it on an unsupported policy should be told why.
+_EXPERT_ONLY_POLICIES = {"pi0", "pi05", "pi0_fast", "smolvla"}
+
+
+class SessionManager:
+    """Track detached training sessions with on-disk persistence.
+
+    Sessions are keyed by name and stored as JSON. Dead processes are pruned on
+    every load so ``list``/``status`` never report a stale PID as running.
+    """
+
+    def __init__(self) -> None:
+        self.sessions_file = SESSION_DIR / "active_sessions.json"
+
+    def _load_sessions(self) -> dict[str, Any]:
+        if not self.sessions_file.exists():
+            return {}
+        try:
+            with open(self.sessions_file) as f:
+                sessions = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            logger.error(f"Error loading sessions: {e}")
+            return {}
+
+        active: dict[str, Any] = {}
+        for name, info in sessions.items():
+            pid = info.get("pid")
+            if pid and psutil.pid_exists(pid):
+                try:
+                    if psutil.Process(pid).is_running():
+                        active[name] = info
+                except (psutil.NoSuchProcess, psutil.AccessDenied):
+                    pass
+            else:
+                # Keep finished training sessions so status can report the
+                # final log tail; only the running flag is derived from the PID.
+                active[name] = info
+        return active
+
+    def _save_sessions(self, sessions: dict[str, Any]) -> None:
+        try:
+            with open(self.sessions_file, "w") as f:
+                json.dump(sessions, f, indent=2)
+        except OSError as e:
+            logger.error(f"Error saving sessions: {e}")
+
+    def add_session(self, name: str, info: dict[str, Any]) -> None:
+        sessions = self._load_sessions()
+        sessions[name] = info
+        self._save_sessions(sessions)
+
+    def remove_session(self, name: str) -> None:
+        sessions = self._load_sessions()
+        if name in sessions:
+            del sessions[name]
+            self._save_sessions(sessions)
+
+    def get_session(self, name: str) -> dict[str, Any] | None:
+        return self._load_sessions().get(name)
+
+    def list_sessions(self) -> dict[str, Any]:
+        return self._load_sessions()
+
+
+def _read_total_episodes(dataset_root: str) -> int:
+    """Return ``total_episodes`` from a LeRobot v3 dataset's ``meta/info.json``.
+
+    Raises:
+        FileNotFoundError: if ``<dataset_root>/meta/info.json`` does not exist.
+        ValueError: if the file lacks a positive integer ``total_episodes``.
+    """
+    info_path = Path(dataset_root) / "meta" / "info.json"
+    if not info_path.exists():
+        raise FileNotFoundError(f"Dataset metadata not found: {info_path}")
+    with open(info_path) as f:
+        info = json.load(f)
+    total = info.get("total_episodes")
+    if not isinstance(total, int) or total <= 0:
+        raise ValueError(f"info.json has no usable 'total_episodes' (got {total!r})")
+    return total
+
+
+def _has_resumable_checkpoint(output_dir: str) -> Path | None:
+    """Return the ``train_config.json`` to resume from, or None if none exists.
+
+    lerobot writes checkpoints under ``<output_dir>/checkpoints/`` with a ``last``
+    symlink to the newest one; the resumable config lives at
+    ``checkpoints/last/pretrained_model/train_config.json``. Resuming requires
+    pointing ``--config_path`` at that FILE (not the directory).
+    """
+    last = Path(output_dir) / "checkpoints" / "last" / "pretrained_model" / "train_config.json"
+    return last if last.exists() else None
+
+
+def build_train_command(
+    dataset_root: str,
+    policy_type: str = "act",
+    pretrained_path: str | None = None,
+    output_dir: str | None = None,
+    job_name: str = "strands_ft",
+    steps: int = 20000,
+    batch_size: int = 8,
+    save_freq: int = 5000,
+    device: str = "cuda",
+    dtype: str = "bfloat16",
+    gradient_checkpointing: bool = False,
+    lora: bool = False,
+    lora_r: int | None = None,
+    lora_alpha: int | None = None,
+    lora_target_modules: str | None = None,
+    train_expert_only: bool = False,
+    val_episodes: int | None = None,
+    num_gpus: int = 1,
+    push_to_hub: bool = False,
+    resume: bool = False,
+    extra_flags: dict[str, Any] | None = None,
+) -> list[str]:
+    """Build the ``lerobot-train`` argv for the given arguments.
+
+    Single-GPU runs invoke ``python -m lerobot.scripts.lerobot_train``;
+    ``num_gpus > 1`` prepends ``accelerate launch --multi_gpu`` and runs the
+    module via ``-m``. Resuming from a checkpoint emits the two-flag
+    ``--config_path=<ckpt>/train_config.json --resume=true`` form lerobot's
+    validate() requires, instead of the from-scratch flags.
+
+    Raises:
+        ValueError: if ``lora`` and ``train_expert_only`` are both set (both
+            freeze the VLM and are mutually exclusive), if ``train_expert_only``
+            is requested for a non-expert policy, or if ``num_gpus < 1``.
+    """
+    if lora and train_expert_only:
+        raise ValueError(
+            "lora and train_expert_only are mutually exclusive (both freeze the VLM). Pick one fine-tuning strategy."
+        )
+    if train_expert_only and policy_type not in _EXPERT_ONLY_POLICIES:
+        raise ValueError(
+            f"train_expert_only is only valid for {sorted(_EXPERT_ONLY_POLICIES)} policies, not '{policy_type}'."
+        )
+    if num_gpus < 1:
+        raise ValueError(f"num_gpus must be >= 1, got {num_gpus}")
+
+    resume_config = _has_resumable_checkpoint(output_dir) if (resume and output_dir) else None
+
+    # Launcher prefix: multi-GPU goes through accelerate, single-GPU runs the
+    # module directly. Both end at the lerobot_train entrypoint.
+    if num_gpus > 1:
+        cmd = [
+            "accelerate",
+            "launch",
+            "--multi_gpu",
+            f"--num_processes={num_gpus}",
+            "--num_machines=1",
+            "--mixed_precision=bf16",
+            "-m",
+            "lerobot.scripts.lerobot_train",
+        ]
+    else:
+        cmd = ["python", "-m", "lerobot.scripts.lerobot_train"]
+
+    if resume_config is not None:
+        # Resume path: lerobot loads the full config from the checkpoint file and
+        # only honors --config_path + --resume. Other flags are ignored on resume.
+        cmd.extend([f"--config_path={resume_config}", "--resume=true"])
+        return cmd
+
+    # Fresh-run flags.
+    cmd.extend(
+        [
+            "--dataset.repo_id=local",
+            f"--dataset.root={dataset_root}",
+            f"--policy.type={policy_type}",
+            f"--policy.device={device}",
+            f"--policy.push_to_hub={str(push_to_hub).lower()}",
+            f"--job_name={job_name}",
+            "--wandb.enable=false",
+        ]
+    )
+    if output_dir:
+        cmd.append(f"--output_dir={output_dir}")
+    if pretrained_path:
+        cmd.append(f"--policy.pretrained_path={pretrained_path}")
+    if steps is not None:
+        cmd.append(f"--steps={steps}")
+    if batch_size is not None:
+        cmd.append(f"--batch_size={batch_size}")
+    if save_freq is not None:
+        cmd.append(f"--save_freq={save_freq}")
+    if dtype:
+        cmd.append(f"--policy.dtype={dtype}")
+    if gradient_checkpointing:
+        cmd.append("--policy.gradient_checkpointing=true")
+    if train_expert_only:
+        cmd.append("--policy.train_expert_only=true")
+
+    if lora:
+        cmd.append("--peft.method_type=LORA")
+        if lora_r is not None:
+            cmd.append(f"--peft.r={lora_r}")
+        if lora_alpha is not None:
+            cmd.append(f"--peft.lora_alpha={lora_alpha}")
+        if lora_target_modules:
+            cmd.append(f"--peft.target_modules={lora_target_modules}")
+
+    if val_episodes is not None:
+        if val_episodes <= 0:
+            raise ValueError(f"val_episodes must be positive, got {val_episodes}")
+        total = _read_total_episodes(dataset_root)
+        if val_episodes >= total:
+            raise ValueError(
+                f"val_episodes={val_episodes} leaves no training data (dataset has {total} episodes); reserve fewer."
+            )
+        train_eps = list(range(total - val_episodes))
+        episodes_arg = "[" + ",".join(str(e) for e in train_eps) + "]"
+        cmd.append(f"--dataset.episodes={episodes_arg}")
+
+    if extra_flags:
+        for key, value in extra_flags.items():
+            flag = key if key.startswith("--") else f"--{key}"
+            cmd.append(f"{flag}={value}")
+
+    return cmd
+
+
+@tool
+def lerobot_train(
+    dataset_root: str,
+    policy_type: str = "act",
+    pretrained_path: str | None = None,
+    output_dir: str | None = None,
+    job_name: str = "strands_ft",
+    steps: int = 20000,
+    batch_size: int = 8,
+    save_freq: int = 5000,
+    device: str = "cuda",
+    dtype: str = "bfloat16",
+    gradient_checkpointing: bool = False,
+    lora: bool = False,
+    lora_r: int | None = None,
+    lora_alpha: int | None = None,
+    lora_target_modules: str | None = None,
+    train_expert_only: bool = False,
+    val_episodes: int | None = None,
+    num_gpus: int = 1,
+    push_to_hub: bool = False,
+    resume: bool = False,
+    action: str = "start",
+    session_name: str | None = None,
+    extra_flags: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Fine-tune a LeRobot policy on a local dataset by wrapping ``lerobot-train``.
+
+    This closes the local record -> train -> deploy loop. After recording a
+    LeRobot v3 dataset, call this with ``dataset_root`` pointing at the dataset
+    directory (the one containing ``meta/info.json``). On ``start`` it launches
+    ``python -m lerobot.scripts.lerobot_train`` (or ``accelerate launch`` for
+    ``num_gpus > 1``) as a detached background process and tracks it in the same
+    on-disk session store used by ``lerobot_teleoperate``.
+
+    Memory-fit levers:
+        ``lora`` and ``train_expert_only`` both freeze the VLM and are mutually
+        exclusive; setting both fails fast. ``lora`` emits ``--peft.method_type=LORA``
+        plus the supplied ``--peft.*`` overrides. ``train_expert_only`` only
+        applies to pi0/pi05/pi0_fast/smolvla.
+
+    Overfit guard:
+        ``val_episodes=N`` reserves the LAST N episodes for evaluation by training
+        only on episodes ``[0 .. total-N-1]`` via ``--dataset.episodes``. The total
+        is read from ``meta/info.json``.
+
+    Resume:
+        ``resume=True`` emits ``--config_path=<ckpt>/train_config.json --resume=true``
+        only when a checkpoint exists under ``<output_dir>/checkpoints/last``. If no
+        resumable checkpoint exists, a fresh run starts and a stale empty
+        ``output_dir`` is cleared so lerobot's "already exists" guard does not trip.
+
+    Actions:
+        start: launch a new training run (default).
+        status: report a run's PID, uptime, running flag, and recent log tail.
+        stop: terminate a running session by name (SIGTERM then SIGKILL).
+        list: list tracked training sessions.
+
+    Args:
+        dataset_root: Local LeRobot v3 dataset directory (must contain meta/info.json).
+        policy_type: Policy architecture (act, diffusion, vqbet, tdmpc, smolvla,
+            pi0, pi05, pi0_fast, groot, xvla, ...).
+        pretrained_path: HF id or local path to initialize weights from (gated
+            checkpoints need HF_TOKEN in the environment).
+        output_dir: Where to write run outputs; defaults to
+            ``<dataset_root>/../train_out/<job_name>``.
+        job_name: Run name used in the default output_dir and lerobot logs.
+        steps: Number of training steps.
+        batch_size: Training batch size.
+        save_freq: Checkpoint save frequency in steps.
+        device: Torch device (cuda, cuda:0, cpu, mps).
+        dtype: Policy dtype (bfloat16, float32).
+        gradient_checkpointing: Trade compute for memory on supported policies.
+        lora: Enable LoRA/PEFT fine-tuning (full-VLM fit on one GPU).
+        lora_r: LoRA rank.
+        lora_alpha: LoRA alpha (scaling = lora_alpha / r).
+        lora_target_modules: PEFT target module spec (e.g. "all-linear").
+        train_expert_only: Freeze the VLM, train only the action expert (pi-family).
+        val_episodes: Reserve the LAST N episodes as a held-out validation split.
+        num_gpus: Number of GPUs; >1 launches via accelerate --multi_gpu.
+        push_to_hub: Push the trained checkpoint to the HF Hub at the end.
+        resume: Resume from the latest checkpoint under output_dir when present.
+        action: One of start, status, stop, list.
+        session_name: Session identifier (auto-generated on start; required for
+            status/stop).
+        extra_flags: Passthrough dict of additional lerobot-train flags, e.g.
+            ``{"policy.optimizer_lr": 1e-4}`` -> ``--policy.optimizer_lr=0.0001``.
+
+    Returns:
+        Dict with ``status`` ("success" or "error") and a ``content`` list of
+        ``{"text": ...}`` items, plus action-specific keys (``session_name``,
+        ``pid``, ``command``, ``log_file``, ``output_dir``, ``sessions``,
+        ``is_running``, ``uptime``).
+    """
+    session_manager = SessionManager()
+
+    try:
+        if action == "start":
+            # Preflight: lerobot must be importable and the dataset must exist.
+            try:
+                import lerobot  # noqa: F401
+            except ImportError as e:
+                return {
+                    "status": "error",
+                    "content": [{"text": f"lerobot is not importable: {e}. Install it to train."}],
+                }
+
+            info_path = Path(dataset_root) / "meta" / "info.json"
+            if not info_path.exists():
+                return {
+                    "status": "error",
+                    "content": [
+                        {
+                            "text": f"Dataset metadata not found: {info_path}. "
+                            "dataset_root must point at a LeRobot v3 dataset directory."
+                        }
+                    ],
+                }
+
+            if not session_name:
+                session_name = f"train_{int(time.time())}"
+            if session_manager.get_session(session_name):
+                return {
+                    "status": "error",
+                    "content": [{"text": f"Session '{session_name}' already exists"}],
+                }
+
+            # Default output_dir lives next to the dataset so artifacts are colocated.
+            resolved_output_dir = output_dir or str(Path(dataset_root).resolve().parent / "train_out" / job_name)
+
+            # Clear a stale EMPTY output_dir on a fresh (non-resumable) start so
+            # lerobot's "already exists" guard does not crash. Never delete a dir
+            # that holds checkpoints.
+            out_path = Path(resolved_output_dir)
+            if out_path.is_dir() and not _has_resumable_checkpoint(resolved_output_dir):
+                if not any(out_path.iterdir()):
+                    shutil.rmtree(out_path, ignore_errors=True)
+
+            try:
+                cmd = build_train_command(
+                    dataset_root=dataset_root,
+                    policy_type=policy_type,
+                    pretrained_path=pretrained_path,
+                    output_dir=resolved_output_dir,
+                    job_name=job_name,
+                    steps=steps,
+                    batch_size=batch_size,
+                    save_freq=save_freq,
+                    device=device,
+                    dtype=dtype,
+                    gradient_checkpointing=gradient_checkpointing,
+                    lora=lora,
+                    lora_r=lora_r,
+                    lora_alpha=lora_alpha,
+                    lora_target_modules=lora_target_modules,
+                    train_expert_only=train_expert_only,
+                    val_episodes=val_episodes,
+                    num_gpus=num_gpus,
+                    push_to_hub=push_to_hub,
+                    resume=resume,
+                    extra_flags=extra_flags,
+                )
+            except (ValueError, FileNotFoundError) as e:
+                return {"status": "error", "content": [{"text": f"Command build failed: {e}"}]}
+
+            env = os.environ.copy()
+            env["PYTHONUNBUFFERED"] = "1"
+            env["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
+
+            log_file = SESSION_DIR / f"{session_name}.log"
+            with open(log_file, "w") as f:
+                proc = subprocess.Popen(
+                    cmd,
+                    stdout=f,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    start_new_session=True,
+                    env=env,
+                )
+
+            session_info: dict[str, Any] = {
+                "action": "train",
+                "pid": proc.pid,
+                "command": " ".join(cmd),
+                "log_file": str(log_file),
+                "start_time": time.time(),
+                "policy_type": policy_type,
+                "dataset_root": dataset_root,
+                "output_dir": resolved_output_dir,
+            }
+            session_manager.add_session(session_name, session_info)
+
+            return {
+                "status": "success",
+                "content": [
+                    {
+                        "text": f"**Training Session Started**\n"
+                        f"Session: `{session_name}`\n"
+                        f"Process ID: {proc.pid}\n"
+                        f"Policy: {policy_type}\n"
+                        f"Output dir: `{resolved_output_dir}`\n"
+                        f"Command: `{' '.join(cmd)}`\n"
+                        f"Log file: `{log_file}`\n"
+                        f"Running in background"
+                    }
+                ],
+                "session_name": session_name,
+                "pid": proc.pid,
+                "command": " ".join(cmd),
+                "log_file": str(log_file),
+                "output_dir": resolved_output_dir,
+            }
+
+        elif action == "stop":
+            if not session_name:
+                return {"status": "error", "content": [{"text": "Session name required for stop action"}]}
+            session_info = session_manager.get_session(session_name)  # type: ignore[assignment]  # narrow Optional
+            if not session_info:
+                return {"status": "error", "content": [{"text": f"Session '{session_name}' not found"}]}
+            pid = session_info.get("pid")
+            if not pid:
+                return {"status": "error", "content": [{"text": f"No PID found for session '{session_name}'"}]}
+
+            pid_int = int(pid)
+            try:
+                os.kill(pid_int, signal.SIGTERM)
+                time.sleep(2)
+                if psutil.pid_exists(pid_int):
+                    os.kill(pid_int, signal.SIGKILL)
+                session_manager.remove_session(session_name)
+                return {
+                    "status": "success",
+                    "content": [{"text": f"**Session Stopped**\nSession: `{session_name}`\nPID: {pid}"}],
+                    "session_name": session_name,
+                    "session_info": session_info,
+                }
+            except ProcessLookupError:
+                session_manager.remove_session(session_name)
+                return {
+                    "status": "success",
+                    "content": [{"text": f"Session '{session_name}' was already stopped"}],
+                    "session_name": session_name,
+                }
+
+        elif action == "list":
+            sessions = session_manager.list_sessions()
+            lines = [f"**Active Training Sessions** ({len(sessions)})", ""]
+            if sessions:
+                for name, info in sessions.items():
+                    uptime_min = (time.time() - info.get("start_time", 0)) / 60
+                    pid = info.get("pid")
+                    is_running = bool(pid and psutil.pid_exists(pid))
+                    lines.extend(
+                        [
+                            f"**{name}**",
+                            f"   - Action: {info.get('action', 'Unknown')}",
+                            f"   - PID: {pid}",
+                            f"   - Uptime: {uptime_min:.1f} min",
+                            f"   - Status: {'Running' if is_running else 'Stopped'}",
+                            f"   - Policy: {info.get('policy_type', 'Unknown')}",
+                            f"   - Output: {info.get('output_dir', 'Unknown')}",
+                            "",
+                        ]
+                    )
+            else:
+                lines.append("No active sessions")
+            return {
+                "status": "success",
+                "content": [{"text": "\n".join(lines)}],
+                "sessions": sessions,
+                "count": len(sessions),
+            }
+
+        elif action == "status":
+            if not session_name:
+                return {"status": "error", "content": [{"text": "Session name required for status action"}]}
+            session_info = session_manager.get_session(session_name)  # type: ignore[assignment]  # narrow Optional
+            if not session_info:
+                return {"status": "error", "content": [{"text": f"Session '{session_name}' not found"}]}
+
+            pid = session_info.get("pid")
+            uptime = time.time() - float(session_info.get("start_time") or 0)
+            is_running = bool(pid and psutil.pid_exists(int(pid)))
+            lines = [
+                f"**Session Status: `{session_name}`**",
+                f"PID: {pid}",
+                f"Action: {session_info.get('action', 'Unknown')}",
+                f"Uptime: {uptime / 60:.1f} min",
+                f"Status: {'Running' if is_running else 'Stopped'}",
+                f"Policy: {session_info.get('policy_type', 'Unknown')}",
+                f"Output dir: {session_info.get('output_dir', 'Unknown')}",
+            ]
+            log_file_path = session_info.get("log_file")
+            if log_file_path and Path(str(log_file_path)).exists():
+                lines.append(f"Log file: `{log_file_path}`")
+                try:
+                    with open(str(log_file_path)) as f:
+                        tail = f.readlines()[-15:]
+                    if tail:
+                        lines.extend(["", "**Recent Log Output:**", "```", "".join(tail).strip(), "```"])
+                except OSError as e:
+                    lines.append(f"Error reading log: {e}")
+            return {
+                "status": "success",
+                "content": [{"text": "\n".join(lines)}],
+                "session_name": session_name,
+                "pid": pid,
+                "uptime": uptime,
+                "is_running": is_running,
+                **session_info,
+            }
+
+        else:
+            return {"status": "error", "content": [{"text": f"Unknown action: {action}"}]}
+
+    except Exception as e:
+        logger.error(f"LeRobot train error: {e}")
+        return {"status": "error", "content": [{"text": f"Tool execution failed: {e}"}]}

--- a/tests/tools/test_lerobot_train.py
+++ b/tests/tools/test_lerobot_train.py
@@ -1,0 +1,327 @@
+"""Behavior tests for the ``lerobot_train`` agent tool.
+
+The train tool wraps LeRobot's ``lerobot-train`` script behind a single
+agent-facing dispatcher with on-disk session tracking, mirroring
+``lerobot_teleoperate``. These tests run hardware- and GPU-free by exercising
+the pure command builder directly and by substituting fakes for ``subprocess``
+and ``psutil`` in the session lifecycle. They pin:
+
+1. The command builder maps each arg set to the correct ``lerobot-train`` argv
+   (single-GPU, multi-GPU accelerate, LoRA, held-out val split, resume).
+2. The mutual-exclusion / preflight guards fail with clear errors instead of
+   launching a doomed run.
+3. The session lifecycle (start -> list -> status -> stop) round-trips through
+   the persisted session store.
+4. Every user-facing ``text`` field is plain ASCII (the project's no-emoji rule).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import strands_robots.tools.lerobot_train as train_mod
+
+build_train_command = train_mod.build_train_command
+lerobot_train = train_mod.lerobot_train
+SessionManager = train_mod.SessionManager
+
+
+def _texts(result: dict[str, Any]) -> str:
+    return "\n".join(item.get("text", "") for item in result.get("content", []) if "text" in item)
+
+
+def _assert_ascii(text: str) -> None:
+    offenders = {hex(ord(c)) for c in text if ord(c) > 127}
+    assert not offenders, f"non-ASCII characters in tool output: {offenders}"
+
+
+def _write_dataset(root: Path, total_episodes: int = 10) -> Path:
+    """Create a minimal LeRobot v3 dataset stub with meta/info.json."""
+    meta = root / "meta"
+    meta.mkdir(parents=True, exist_ok=True)
+    (meta / "info.json").write_text(json.dumps({"total_episodes": total_episodes}))
+    return root
+
+
+@pytest.fixture(autouse=True)
+def _isolate_session_dir(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    session_dir = tmp_path / ".sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(train_mod, "SESSION_DIR", session_dir)
+    return session_dir
+
+
+class _FakeProc:
+    def __init__(self, pid: int = 4242) -> None:
+        self.pid = pid
+
+
+# ---------------------------------------------------------------------------
+# build_train_command - argv mapping
+# ---------------------------------------------------------------------------
+def test_build_single_gpu_command_emits_core_flags() -> None:
+    cmd = build_train_command(
+        dataset_root="/data/cubes",
+        policy_type="act",
+        output_dir="/out/act",
+        job_name="cube_ft",
+        steps=5000,
+        batch_size=16,
+        save_freq=1000,
+        device="cuda",
+        dtype="bfloat16",
+    )
+    assert cmd[:3] == ["python", "-m", "lerobot.scripts.lerobot_train"]
+    assert "--dataset.repo_id=local" in cmd
+    assert "--dataset.root=/data/cubes" in cmd
+    assert "--policy.type=act" in cmd
+    assert "--policy.device=cuda" in cmd
+    assert "--policy.push_to_hub=false" in cmd
+    assert "--output_dir=/out/act" in cmd
+    assert "--job_name=cube_ft" in cmd
+    assert "--wandb.enable=false" in cmd
+    assert "--steps=5000" in cmd
+    assert "--batch_size=16" in cmd
+    assert "--save_freq=1000" in cmd
+    assert "--policy.dtype=bfloat16" in cmd
+    # No accelerate prefix on a single-GPU run.
+    assert "accelerate" not in cmd
+
+
+def test_build_multi_gpu_command_prepends_accelerate_launch() -> None:
+    cmd = build_train_command(
+        dataset_root="/data/cubes",
+        policy_type="act",
+        output_dir="/out/act",
+        num_gpus=4,
+    )
+    assert cmd[:2] == ["accelerate", "launch"]
+    assert "--multi_gpu" in cmd
+    assert "--num_processes=4" in cmd
+    assert "--num_machines=1" in cmd
+    assert "--mixed_precision=bf16" in cmd
+    # The module is launched via -m after the accelerate flags.
+    assert cmd[cmd.index("-m") + 1] == "lerobot.scripts.lerobot_train"
+    # Core training flags still present downstream.
+    assert "--dataset.root=/data/cubes" in cmd
+    assert "--policy.type=act" in cmd
+
+
+def test_build_lora_command_emits_peft_flags() -> None:
+    cmd = build_train_command(
+        dataset_root="/data/cubes",
+        policy_type="smolvla",
+        output_dir="/out/smolvla",
+        lora=True,
+        lora_r=32,
+        lora_alpha=64,
+        lora_target_modules="all-linear",
+    )
+    assert "--peft.method_type=LORA" in cmd
+    assert "--peft.r=32" in cmd
+    assert "--peft.lora_alpha=64" in cmd
+    assert "--peft.target_modules=all-linear" in cmd
+
+
+def test_build_expert_only_emits_flag_for_pi_family() -> None:
+    cmd = build_train_command(
+        dataset_root="/data/cubes",
+        policy_type="pi05",
+        output_dir="/out/pi05",
+        train_expert_only=True,
+    )
+    assert "--policy.train_expert_only=true" in cmd
+
+
+def test_lora_and_expert_only_are_mutually_exclusive() -> None:
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        build_train_command(
+            dataset_root="/data/cubes",
+            policy_type="pi05",
+            lora=True,
+            train_expert_only=True,
+        )
+
+
+def test_expert_only_rejected_for_non_expert_policy() -> None:
+    with pytest.raises(ValueError, match="train_expert_only is only valid"):
+        build_train_command(
+            dataset_root="/data/cubes",
+            policy_type="act",
+            train_expert_only=True,
+        )
+
+
+def test_val_episodes_reserves_last_n_episodes(tmp_path: Path) -> None:
+    root = _write_dataset(tmp_path / "ds", total_episodes=10)
+    cmd = build_train_command(
+        dataset_root=str(root),
+        policy_type="act",
+        output_dir=str(tmp_path / "out"),
+        val_episodes=3,
+    )
+    # 10 total, reserve last 3 -> train on 0..6.
+    assert "--dataset.episodes=[0,1,2,3,4,5,6]" in cmd
+
+
+def test_val_episodes_rejects_reserving_whole_dataset(tmp_path: Path) -> None:
+    root = _write_dataset(tmp_path / "ds", total_episodes=3)
+    with pytest.raises(ValueError, match="leaves no training data"):
+        build_train_command(
+            dataset_root=str(root),
+            policy_type="act",
+            val_episodes=3,
+        )
+
+
+def test_resume_emits_two_flag_form_when_checkpoint_exists(tmp_path: Path) -> None:
+    out = tmp_path / "out"
+    ckpt = out / "checkpoints" / "last" / "pretrained_model"
+    ckpt.mkdir(parents=True)
+    (ckpt / "train_config.json").write_text("{}")
+
+    cmd = build_train_command(
+        dataset_root="/data/cubes",
+        policy_type="act",
+        output_dir=str(out),
+        resume=True,
+    )
+    assert f"--config_path={ckpt / 'train_config.json'}" in cmd
+    assert "--resume=true" in cmd
+    # Resume path ignores the from-scratch flags.
+    assert "--dataset.repo_id=local" not in cmd
+    assert "--policy.type=act" not in cmd
+
+
+def test_resume_without_checkpoint_starts_fresh(tmp_path: Path) -> None:
+    out = tmp_path / "out"  # no checkpoints dir
+    cmd = build_train_command(
+        dataset_root="/data/cubes",
+        policy_type="act",
+        output_dir=str(out),
+        resume=True,
+    )
+    # No resumable checkpoint -> normal fresh-run flags, no --config_path.
+    assert not any(c.startswith("--config_path=") for c in cmd)
+    assert "--dataset.repo_id=local" in cmd
+    assert "--policy.type=act" in cmd
+
+
+def test_extra_flags_passthrough_normalizes_leading_dashes() -> None:
+    cmd = build_train_command(
+        dataset_root="/data/cubes",
+        policy_type="act",
+        output_dir="/out",
+        extra_flags={"policy.optimizer_lr": "1e-4", "--num_workers": 8},
+    )
+    assert "--policy.optimizer_lr=1e-4" in cmd
+    assert "--num_workers=8" in cmd
+
+
+def test_push_to_hub_true_sets_flag() -> None:
+    cmd = build_train_command(
+        dataset_root="/data/cubes",
+        policy_type="act",
+        output_dir="/out",
+        push_to_hub=True,
+    )
+    assert "--policy.push_to_hub=true" in cmd
+
+
+def test_num_gpus_zero_rejected() -> None:
+    with pytest.raises(ValueError, match="num_gpus must be >= 1"):
+        build_train_command(dataset_root="/data/cubes", num_gpus=0)
+
+
+# ---------------------------------------------------------------------------
+# Preflight (start action)
+# ---------------------------------------------------------------------------
+def test_start_errors_when_dataset_missing_info(tmp_path: Path) -> None:
+    # Directory exists but has no meta/info.json.
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    result = lerobot_train(action="start", dataset_root=str(empty))
+    assert result["status"] == "error"
+    text = _texts(result)
+    assert "info.json" in text
+    _assert_ascii(text)
+
+
+# ---------------------------------------------------------------------------
+# Session lifecycle: start -> list -> status -> stop
+# ---------------------------------------------------------------------------
+def test_session_lifecycle_round_trips(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root = _write_dataset(tmp_path / "ds", total_episodes=8)
+
+    # Fake Popen so no real training process spawns.
+    def _fake_popen(cmd, **kwargs):  # noqa: ANN001
+        return _FakeProc(pid=9999)
+
+    monkeypatch.setattr(train_mod.subprocess, "Popen", _fake_popen)
+    # Report the fake PID as a live, running process.
+    monkeypatch.setattr(train_mod.psutil, "pid_exists", lambda pid: True)
+
+    class _FakeProcess:
+        def __init__(self, pid: int) -> None:
+            self.pid = pid
+
+        def is_running(self) -> bool:
+            return True
+
+    monkeypatch.setattr(train_mod.psutil, "Process", _FakeProcess)
+
+    start = lerobot_train(
+        action="start",
+        dataset_root=str(root),
+        policy_type="act",
+        output_dir=str(tmp_path / "out"),
+        session_name="t1",
+    )
+    assert start["status"] == "success"
+    assert start["session_name"] == "t1"
+    assert start["pid"] == 9999
+    _assert_ascii(_texts(start))
+
+    listed = lerobot_train(action="list", dataset_root=str(root))
+    assert listed["status"] == "success"
+    assert "t1" in listed["sessions"]
+    _assert_ascii(_texts(listed))
+
+    status = lerobot_train(action="status", dataset_root=str(root), session_name="t1")
+    assert status["status"] == "success"
+    assert status["is_running"] is True
+    assert status["pid"] == 9999
+    _assert_ascii(_texts(status))
+
+    # Stop: capture the kill calls instead of touching a real process.
+    killed: list[int] = []
+    monkeypatch.setattr(train_mod.os, "kill", lambda pid, sig: killed.append(pid))
+    # After SIGTERM the process is gone.
+    monkeypatch.setattr(train_mod.psutil, "pid_exists", lambda pid: False)
+
+    stop = lerobot_train(action="stop", dataset_root=str(root), session_name="t1")
+    assert stop["status"] == "success"
+    assert 9999 in killed
+    _assert_ascii(_texts(stop))
+
+    # Session store no longer tracks it.
+    gone = lerobot_train(action="status", dataset_root=str(root), session_name="t1")
+    assert gone["status"] == "error"
+
+
+def test_status_requires_session_name(tmp_path: Path) -> None:
+    root = _write_dataset(tmp_path / "ds")
+    result = lerobot_train(action="status", dataset_root=str(root))
+    assert result["status"] == "error"
+    _assert_ascii(_texts(result))
+
+
+def test_unknown_action_errors(tmp_path: Path) -> None:
+    root = _write_dataset(tmp_path / "ds")
+    result = lerobot_train(action="frobnicate", dataset_root=str(root))
+    assert result["status"] == "error"
+    assert "Unknown action" in _texts(result)

--- a/tests/tools/test_tools_lazy_import.py
+++ b/tests/tools/test_tools_lazy_import.py
@@ -31,6 +31,7 @@ def test_all_lists_every_lazy_import_name() -> None:
         "lerobot_calibrate",
         "lerobot_camera",
         "lerobot_teleoperate",
+        "lerobot_train",
         "pose_tool",
         "robot_mesh",
         "serial_tool",


### PR DESCRIPTION
## What

Add a `lerobot_train` agent `@tool` that closes the local **record -> train -> deploy** loop without any cloud dependency. It is the symmetric counterpart to `lerobot_teleoperate` (which shells out to `lerobot_record`): it builds and runs `python -m lerobot.scripts.lerobot_train` and manages the run as a detached background session through the same `SessionManager` lifecycle (`start`/`status`/`stop`/`list`).

## Why

`strands-robots` already records LeRobot v3 datasets but stops at the dataset. Users then have to hand-assemble a `lerobot-train` command and remember the non-obvious flag forms (resume needs a config file path, PEFT vs expert-only conflict, held-out splits via `--dataset.episodes`). This tool encodes those rules once so the data loop is closeable from the same agent surface that recorded the data.

## Behavior

- **Single vs multi-GPU**: `num_gpus=1` runs `python -m lerobot.scripts.lerobot_train`; `num_gpus>1` prepends `accelerate launch --multi_gpu --num_processes=N --num_machines=1 --mixed_precision=bf16 -m lerobot.scripts.lerobot_train`.
- **Memory-fit levers**: `lora` and `train_expert_only` both freeze the VLM and are mutually exclusive -> fail fast. `lora` emits `--peft.method_type=LORA` plus the supplied `--peft.r/--peft.lora_alpha/--peft.target_modules`. `train_expert_only` is only valid for pi0/pi05/pi0_fast/smolvla and is rejected otherwise (it maps to `--policy.train_expert_only=true`, a policy-level config field).
- **Held-out val split**: `val_episodes=N` reads `total_episodes` from `<dataset_root>/meta/info.json` and trains only on episodes `[0 .. total-N-1]` via `--dataset.episodes=[...]`, deterministically reserving the LAST N.
- **Resume**: `resume=True` emits the two-flag `--config_path=<output_dir>/checkpoints/last/pretrained_model/train_config.json --resume=true` form (lerobot's `validate()` needs the config FILE) **only when** that checkpoint exists; otherwise a fresh run starts and a stale EMPTY `output_dir` is cleared so lerobot's already-exists guard does not trip.
- **Preflight**: verifies `lerobot` is importable and `<dataset_root>/meta/info.json` exists; returns a clear error instead of launching a doomed run.
- **Passthrough**: `extra_flags={"key": value}` -> `--key=value` so any lerobot-train flag works without code changes.
- Sets `PYTHONUNBUFFERED=1` and `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` on the child process.

The checkpoint path lerobot writes (`<output_dir>/checkpoints/last/pretrained_model`) is directly loadable by `create_policy("lerobot_local", pretrained_name_or_path=...)`, so the loop deploys cleanly.

## Tests

`tests/tools/test_lerobot_train.py` (17 cases): command builder for single-GPU, multi-GPU accelerate, LoRA `--peft.*`, expert-only flag + the two guard-rail errors, val-split episode list, resume two-flag form (present with checkpoint, absent without), `extra_flags` normalization, `push_to_hub`, `num_gpus<1` reject, the missing-`info.json` preflight error, and the `start -> list -> status -> stop` session round-trip (subprocess/psutil faked). All user-facing text asserted ASCII-only.

Updated `tests/tools/test_tools_lazy_import.py` to include the new tool in the advertised `__all__` set.

## Docs

`docs/training/overview.md` rewired to show the full `start_recording -> stop_recording -> lerobot_train -> create_policy(<ckpt>)` loop; `lerobot_train` added to `docs/api-reference.md` and `docs/hardware/tools.md` tool tables.

Green locally: `ruff check` / `ruff format --check` clean, `mypy` introduces no new errors (the only mypy errors in scope are pre-existing in `device_connect/reachy_transport.py`), and `pytest tests/tools/` passes (460 tests).