### PR TITLE
feat(policies): add strict_keys to Gr00tPolicy + LerobotLocalPolicy

### DIFF
--- a/docs/policies/groot.md
+++ b/docs/policies/groot.md
@@ -34,8 +34,27 @@ Gr00tPolicy(
     observation_mapping=None,
     action_mapping=None,
     language_key=None,
+    strict_keys=False,             # raise instead of positional key-guessing
 )
 ```
+
+## Strict key matching
+
+When no explicit `observation_mapping`/`action_mapping` is given, GR00T
+auto-infers the robot<->model key mapping: exact name matches first, then
+positional fallback for any leftover keys (with a log line). On a
+multi-camera or multi-DOF rig, positional fallback can silently bind the
+wrong camera or action column. Pass `strict_keys=True` to raise a
+`ValueError` (listing the unmatched robot keys vs available model keys)
+instead of guessing:
+
+```python
+policy = create_policy("groot", data_config="so100_dualcam",
+                       model_path="nvidia/GR00T-N1.6-3B", strict_keys=True)
+```
+
+`strict_keys` defaults to `False` (positional fallback preserved) and is a
+no-op when an explicit mapping is supplied.
 
 ## Versions
 

--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -40,6 +40,7 @@ LerobotLocalPolicy(
     image_keys=None,                     # MolmoAct2 camera key override
     inference_action_mode="continuous",  # "continuous" | "discrete"
     camera_key_map=None,                 # {robot_cam_name: policy_image_key}
+    strict_keys=False,                   # raise instead of positional camera fallback
 )
 ```
 
@@ -165,7 +166,10 @@ policy routes each camera to a declared image slot by, in order:
 1. an explicit `camera_key_map` (`{robot_cam: policy_image_key}`) when provided;
 2. exact name match (`top` -> `observation.images.top`);
 3. positional fallback into remaining slots, with a WARNING so a mismatched
-   wiring is loud rather than silent.
+   wiring is loud rather than silent. Pass `strict_keys=True` to raise a
+   `ValueError` (listing the unmatched cameras vs available image keys)
+   instead of falling back positionally; it defaults to `False` and is a
+   no-op when `camera_key_map` or exact names already resolve every camera.
 
 The declared order follows the model config's `image_keys` list when present
 (e.g. MolmoAct2), otherwise the order of the model's image input features. If

--- a/strands_robots/policies/groot/policy.py
+++ b/strands_robots/policies/groot/policy.py
@@ -154,15 +154,27 @@ class ActionMapping:
 def _auto_infer_observation_mapping(
     data_config: Gr00tDataConfig,
     modality_configs: dict,
+    strict_keys: bool = False,
 ) -> ObservationMapping:
-    """Auto-infer observation mapping from data_config + model config."""
+    """Auto-infer observation mapping from data_config + model config.
+
+    Args:
+        data_config: The robot/sim data configuration.
+        modality_configs: The model's per-modality key configs.
+        strict_keys: When True, raise instead of falling back to positional
+            matching if any key cannot be resolved by exact name.
+
+    Raises:
+        ValueError: If ``strict_keys`` is True and any video/state key needs
+            positional fallback.
+    """
     ours_v = [k.removeprefix("video.") for k in data_config.video_keys]
     model_v = list(modality_configs["video"].modality_keys)
-    video_map = _match_keys(ours_v, model_v, "video")
+    video_map = _match_keys(ours_v, model_v, "video", strict_keys=strict_keys)
 
     ours_s = [k.removeprefix("state.") for k in data_config.state_keys]
     model_s = list(modality_configs["state"].modality_keys)
-    state_map = _match_keys(ours_s, model_s, "state")
+    state_map = _match_keys(ours_s, model_s, "state", strict_keys=strict_keys)
 
     lang = modality_configs["language"].modality_keys[0]
     return ObservationMapping(video=video_map, state=state_map, language_key=lang)
@@ -171,8 +183,20 @@ def _auto_infer_observation_mapping(
 def _auto_infer_action_mapping(
     data_config: Gr00tDataConfig,
     modality_configs: dict,
+    strict_keys: bool = False,
 ) -> ActionMapping:
-    """Auto-infer action mapping from data_config + model config."""
+    """Auto-infer action mapping from data_config + model config.
+
+    Args:
+        data_config: The robot/sim data configuration.
+        modality_configs: The model's per-modality key configs.
+        strict_keys: When True, raise instead of falling back to positional
+            matching if any action key cannot be resolved by exact name.
+
+    Raises:
+        ValueError: If ``strict_keys`` is True and any action key needs
+            positional fallback.
+    """
     ours = [k.removeprefix("action.") for k in data_config.action_keys]
     model = list(modality_configs["action"].modality_keys)
     model_set = set(model)
@@ -185,14 +209,34 @@ def _auto_infer_action_mapping(
             used.add(k)
     remaining_ours = [k for k in ours if k not in actions.values()]
     remaining_model = [k for k in model if k not in used]
+    if strict_keys and remaining_ours and remaining_model:
+        raise ValueError(
+            "strict_keys=True: cannot resolve action keys by exact name. "
+            f"Unmatched robot keys: {sorted(remaining_ours)}; "
+            f"available model keys: {sorted(remaining_model)}. "
+            "Provide an explicit mapping (action_mapping) "
+            "or set strict_keys=False to allow positional fallback."
+        )
     for mdl, our in zip(remaining_model, remaining_ours):
         actions[mdl] = our
         logger.info("Auto-mapped action: model '%s' → robot '%s' (positional)", mdl, our)
     return ActionMapping(actions=actions)
 
 
-def _match_keys(ours: list[str], model: list[str], label: str) -> dict[str, str]:
-    """Match our keys to model keys: exact first, positional fallback."""
+def _match_keys(ours: list[str], model: list[str], label: str, strict_keys: bool = False) -> dict[str, str]:
+    """Match our keys to model keys: exact first, positional fallback.
+
+    Args:
+        ours: Robot/sim key names to map.
+        model: The model's declared key names.
+        label: Human-readable label for logs/errors (e.g. ``"video"``).
+        strict_keys: When True, raise instead of falling back to positional
+            matching if any key cannot be resolved by exact name.
+
+    Raises:
+        ValueError: If ``strict_keys`` is True and any key needs positional
+            fallback.
+    """
     model_set = set(model)
     mapping: dict[str, str] = {}
     used: set = set()
@@ -202,6 +246,14 @@ def _match_keys(ours: list[str], model: list[str], label: str) -> dict[str, str]
             used.add(k)
     remaining_ours = [k for k in ours if k not in mapping]
     remaining_model = [k for k in model if k not in used]
+    if strict_keys and remaining_ours and remaining_model:
+        raise ValueError(
+            f"strict_keys=True: cannot resolve {label} keys by exact name. "
+            f"Unmatched robot keys: {sorted(remaining_ours)}; "
+            f"available model keys: {sorted(remaining_model)}. "
+            "Provide an explicit mapping (observation_mapping/action_mapping) "
+            "or set strict_keys=False to allow positional fallback."
+        )
     for our, mdl in zip(remaining_ours, remaining_model):
         mapping[our] = mdl
         logger.info("Auto-mapped %s: '%s' → '%s' (positional)", label, our, mdl)
@@ -284,6 +336,10 @@ class Gr00tPolicy(Policy):
         observation_mapping: ``{robot_key: "video.X" | "state.X"}``.
         action_mapping: ``{"action.X": "robot_key"}``.
         language_key: Override the model's language key.
+        strict_keys: When True, raise (instead of warning + positional fallback)
+            if auto-inferred observation/action keys cannot be matched to the
+            model by exact name. Defaults to False (positional fallback). Ignored
+            when explicit ``observation_mapping``/``action_mapping`` are provided.
 
     Examples::
 
@@ -318,6 +374,7 @@ class Gr00tPolicy(Policy):
         observation_mapping: dict[str, str] | None = None,
         action_mapping: dict[str, str] | None = None,
         language_key: str | None = None,
+        strict_keys: bool = False,
         **kwargs,
     ):
         self.data_config = load_data_config(data_config)
@@ -335,6 +392,7 @@ class Gr00tPolicy(Policy):
         self._raw_obs_mapping = observation_mapping
         self._raw_action_mapping = action_mapping
         self._language_key_override = language_key
+        self._strict_keys = strict_keys
 
         # Resolved mappings
         self._obs_mapping: ObservationMapping | None = None
@@ -390,7 +448,7 @@ class Gr00tPolicy(Policy):
         if self._raw_obs_mapping is not None:
             self._obs_mapping = _parse_observation_mapping(self._raw_obs_mapping, mmc)
         else:
-            self._obs_mapping = _auto_infer_observation_mapping(self.data_config, mmc)
+            self._obs_mapping = _auto_infer_observation_mapping(self.data_config, mmc, strict_keys=self._strict_keys)
 
         if self._language_key_override:
             self._obs_mapping = ObservationMapping(
@@ -405,7 +463,7 @@ class Gr00tPolicy(Policy):
         if self._raw_action_mapping is not None:
             self._action_mapping = _parse_action_mapping(self._raw_action_mapping)
         else:
-            self._action_mapping = _auto_infer_action_mapping(self.data_config, mmc)
+            self._action_mapping = _auto_infer_action_mapping(self.data_config, mmc, strict_keys=self._strict_keys)
 
         self._action_mapping.validate(mmc)
 

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -65,6 +65,10 @@ class LerobotLocalPolicy(Policy):
             (e.g. "observation.images.top"). When omitted, cameras are
             routed by exact short-name match and then by declared order
             with a warning on mismatch.
+        strict_keys: When True, raise (instead of warning + positional
+            fallback) if any camera name cannot be matched to a declared
+            policy image key by exact name and no ``camera_key_map`` covers
+            it. Defaults to False (positional fallback).
     """
 
     def __init__(
@@ -86,6 +90,7 @@ class LerobotLocalPolicy(Policy):
         image_keys: list[str] | None = None,
         inference_action_mode: str = "continuous",
         camera_key_map: dict[str, str] | None = None,
+        strict_keys: bool = False,
         **kwargs,
     ):
         self.pretrained_name_or_path = pretrained_name_or_path
@@ -113,6 +118,11 @@ class LerobotLocalPolicy(Policy):
         # When None, cameras are matched by exact short name and then by
         # declared order (see _resolve_camera_targets).
         self.camera_key_map = dict(camera_key_map) if camera_key_map else None
+        # When True, raise instead of routing cameras positionally if their
+        # names cannot be matched to the policy's declared image keys (and no
+        # camera_key_map covers them). Defaults to False (positional fallback
+        # with a warning), preserving zero-config ergonomics.
+        self.strict_keys = strict_keys
         # MolmoAct2-specific knobs. MolmoAct2 SO-100/101 checkpoints are
         # transformers-native (no lerobot draccus `type`), so they take a
         # dedicated load path (see lerobot_local.molmoact2). These are inert
@@ -1023,6 +1033,14 @@ class LerobotLocalPolicy(Policy):
                 unmatched_imgs.append((k, v))
         # Fill any remaining declared image slots, in declaration order.
         free_feats = [f for f in declared_img_feats if f not in used_feats]
+        if self.strict_keys and unmatched_imgs and free_feats:
+            raise ValueError(
+                "strict_keys=True: cannot resolve camera keys by exact name. "
+                f"Unmatched robot keys: {sorted(k for k, _ in unmatched_imgs)}; "
+                f"available model keys: {sorted(free_feats)}. "
+                "Provide an explicit mapping (camera_key_map) "
+                "or set strict_keys=False to allow positional fallback."
+            )
         for (k, v), feat in zip(unmatched_imgs, free_feats):
             out[feat] = v
             used_feats.add(feat)
@@ -1301,6 +1319,14 @@ class LerobotLocalPolicy(Policy):
 
         # 3) Positional fallback into the remaining declared slots (loud).
         free = [feat for feat in targets if feat not in used]
+        if self.strict_keys and unmatched and free:
+            raise ValueError(
+                "strict_keys=True: cannot resolve camera keys by exact name. "
+                f"Unmatched robot keys: {sorted(unmatched)}; "
+                f"available model keys: {sorted(free)}. "
+                "Provide an explicit mapping (camera_key_map) "
+                "or set strict_keys=False to allow positional fallback."
+            )
         for cam, feat in zip(unmatched, free):
             logger.warning(
                 "Camera '%s' does not match any declared policy image key by name; "

--- a/strands_robots/registry/policies.json
+++ b/strands_robots/registry/policies.json
@@ -23,7 +23,8 @@
             "config_keys": [
                 "port",
                 "host",
-                "data_config"
+                "data_config",
+                "strict_keys"
             ],
             "defaults": {
                 "host": "localhost"
@@ -55,7 +56,8 @@
                 "norm_tag",
                 "image_keys",
                 "inference_action_mode",
-                "embodiment"
+                "embodiment",
+                "strict_keys"
             ],
             "defaults": {},
             "aliases": [

--- a/tests/policies/groot/test_policy.py
+++ b/tests/policies/groot/test_policy.py
@@ -21,6 +21,7 @@ from strands_robots.policies.groot.policy import (  # noqa: E402
     _auto_infer_action_mapping,
     _auto_infer_observation_mapping,
     _detect_groot_version,
+    _match_keys,
     _parse_action_mapping,
     _parse_observation_mapping,
     _reference_video_shape,
@@ -403,6 +404,57 @@ class TestAutoInfer:
     def test_action_exact(self):
         m = _auto_infer_action_mapping(DATA_CONFIG_MAP["so100"], SO100_MMC)
         assert m.actions["single_arm"] == "single_arm"
+
+
+class TestStrictKeys:
+    """strict_keys=True raises instead of positional-guessing on name mismatch.
+
+    Covers _match_keys (obs video/state) and _auto_infer_action_mapping. The
+    "so100" data config declares a single "webcam" video key; GR1_MMC declares
+    a differently-named video key, so exact matching fails and the default path
+    falls back positionally. strict_keys=True must raise instead.
+    """
+
+    def test_obs_strict_raises_on_mismatch(self):
+        with pytest.raises(ValueError, match="strict_keys=True: cannot resolve video keys"):
+            _auto_infer_observation_mapping(DATA_CONFIG_MAP["so100"], GR1_MMC, strict_keys=True)
+
+    def test_obs_strict_error_lists_keys(self):
+        with pytest.raises(ValueError) as exc:
+            _auto_infer_observation_mapping(DATA_CONFIG_MAP["so100"], GR1_MMC, strict_keys=True)
+        msg = str(exc.value)
+        assert "webcam" in msg  # unmatched robot key
+        assert "ego_view_bg_crop_pad_res256_freq20" in msg  # available model key
+
+    def test_action_strict_raises_on_mismatch(self):
+        # so100 action keys (single_arm, gripper) vs GR1 action keys -> mismatch.
+        with pytest.raises(ValueError, match="strict_keys=True: cannot resolve action keys"):
+            _auto_infer_action_mapping(DATA_CONFIG_MAP["so100"], GR1_MMC, strict_keys=True)
+
+    def test_obs_nonstrict_maps_positionally_and_warns(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.INFO):
+            m = _auto_infer_observation_mapping(DATA_CONFIG_MAP["so100"], GR1_MMC, strict_keys=False)
+        assert m.video.get("webcam") == "ego_view_bg_crop_pad_res256_freq20"
+        assert any("positional" in r.message for r in caplog.records)
+
+    def test_obs_exact_match_never_raises_in_strict_mode(self):
+        # so100 <-> SO100_MMC matches by exact name, so strict_keys=True is a no-op.
+        m = _auto_infer_observation_mapping(DATA_CONFIG_MAP["so100"], SO100_MMC, strict_keys=True)
+        assert m.video == {"webcam": "webcam"}
+        assert m.state["single_arm"] == "single_arm"
+
+    def test_action_exact_match_never_raises_in_strict_mode(self):
+        m = _auto_infer_action_mapping(DATA_CONFIG_MAP["so100"], SO100_MMC, strict_keys=True)
+        assert m.actions["single_arm"] == "single_arm"
+
+    def test_match_keys_strict_raises(self):
+        with pytest.raises(ValueError, match="cannot resolve color keys"):
+            _match_keys(["a"], ["b"], "color", strict_keys=True)
+
+    def test_match_keys_strict_exact_ok(self):
+        assert _match_keys(["a"], ["a"], "color", strict_keys=True) == {"a": "a"}
 
 
 # (section)

--- a/tests/policies/lerobot_local/test_policy.py
+++ b/tests/policies/lerobot_local/test_policy.py
@@ -875,6 +875,80 @@ class TestCameraKeyRouting:
         assert len([k for k in batch if "image" in k]) == 1
 
 
+class TestStrictKeysCameraRouting:
+    """strict_keys=True raises instead of routing cameras positionally.
+
+    Default (strict_keys=False) keeps the positional-fallback-with-warning
+    behavior unchanged; strict_keys=True turns an unresolved camera name into
+    a hard ValueError naming the unmatched vs available keys.
+    """
+
+    def test_strict_raises_on_name_mismatch(self):
+        policy = _make_two_camera_policy()
+        policy.strict_keys = True
+        side = np.zeros((480, 640, 3), dtype=np.uint8)
+        other = np.zeros((480, 640, 3), dtype=np.uint8)
+        observation = {"a": 1.0, "b": 2.0, "side": side, "other": other}
+        with pytest.raises(ValueError, match="strict_keys=True: cannot resolve camera keys"):
+            policy._build_batch_from_strands_format(observation, {})
+
+    def test_strict_error_lists_keys(self):
+        policy = _make_two_camera_policy()
+        policy.strict_keys = True
+        observation = {
+            "a": 1.0,
+            "b": 2.0,
+            "side": np.zeros((480, 640, 3), dtype=np.uint8),
+            "other": np.zeros((480, 640, 3), dtype=np.uint8),
+        }
+        with pytest.raises(ValueError) as exc:
+            policy._build_batch_from_strands_format(observation, {})
+        msg = str(exc.value)
+        assert "side" in msg and "other" in msg  # unmatched robot keys
+        assert "observation.images.top" in msg  # available model key
+
+    def test_nonstrict_default_still_maps_positionally_and_warns(self, caplog):
+        import logging
+
+        policy = _make_two_camera_policy()
+        assert policy.strict_keys is False  # default
+        observation = {
+            "a": 1.0,
+            "b": 2.0,
+            "side": np.zeros((480, 640, 3), dtype=np.uint8),
+            "other": np.zeros((480, 640, 3), dtype=np.uint8),
+        }
+        with caplog.at_level(logging.WARNING):
+            batch = policy._build_batch_from_strands_format(observation, {})
+        assert "observation.images.top" in batch
+        assert "observation.images.wrist" in batch
+        assert any("routing positionally" in r.message for r in caplog.records)
+
+    def test_strict_exact_name_match_never_raises(self):
+        policy = _make_two_camera_policy()
+        policy.strict_keys = True
+        top = np.zeros((480, 640, 3), dtype=np.uint8)
+        wrist = np.ones((480, 640, 3), dtype=np.uint8) * 255
+        observation = {"a": 1.0, "b": 2.0, "top": top, "wrist": wrist}
+        batch = policy._build_batch_from_strands_format(observation, {})
+        assert float(batch["observation.images.wrist"].max()) == 1.0
+        assert float(batch["observation.images.top"].max()) == 0.0
+
+    def test_strict_camera_key_map_satisfies_routing(self):
+        policy = _make_two_camera_policy()
+        policy.strict_keys = True
+        policy.camera_key_map = {
+            "front": "observation.images.top",
+            "hand": "observation.images.wrist",
+        }
+        front = np.zeros((480, 640, 3), dtype=np.uint8)
+        hand = np.ones((480, 640, 3), dtype=np.uint8) * 255
+        observation = {"a": 1.0, "b": 2.0, "front": front, "hand": hand}
+        batch = policy._build_batch_from_strands_format(observation, {})
+        assert float(batch["observation.images.top"].max()) == 0.0
+        assert float(batch["observation.images.wrist"].max()) == 1.0
+
+
 # (section)
 # Tests: _tensor_to_action_dicts
 # (section)


### PR DESCRIPTION
## Problem

When a policy's declared keys don't exactly match the robot/sim keys, `Gr00tPolicy` and `LerobotLocalPolicy` silently fall back to positional `zip` matching with only a log line. On a multi-camera / multi-DOF rig this can map the wrong camera to a feature or the wrong action column to a joint -- a silent, hard-to-debug correctness bug. For production rollouts an opt-in strict mode that raises is safer than guessing.

## Change

Add a `strict_keys: bool = False` constructor kwarg to both policies, threaded through their mapping/camera-resolution helpers:

- `strict_keys=False` (default): unchanged positional-fallback-with-warning -- preserves zero-config ergonomics, byte-identical behavior.
- `strict_keys=True`: when exact-name matching leaves any key unresolved, raise a `ValueError` instead of positional-guessing. The message lists the unmatched robot keys vs the available model keys, mirroring the existing `ObservationMapping.validate` / `ActionMapping.validate` errors.

**GR00T** (`policies/groot/policy.py`): threads `strict_keys` through `_match_keys` (observation video/state) and `_auto_infer_action_mapping`, wired from `Gr00tPolicy.__init__` via `_init_mappings`. Ignored when an explicit `observation_mapping`/`action_mapping` is supplied.

**LeRobot Local** (`policies/lerobot_local/policy.py`): applies on both unresolved-camera paths -- `_resolve_camera_targets` (the documented camera-routing fallback) and the legacy `_to_lerobot_observation` remap, which had the same positional fill. `camera_key_map` and exact-name matches still satisfy strict mode.

`strict_keys` is added to `config_keys` for both providers in `registry/policies.json`, so `create_policy("groot", strict_keys=True)` / `create_policy("lerobot_local", strict_keys=True)` resolve.

Example error:
```
strict_keys=True: cannot resolve video keys by exact name. Unmatched robot keys: ['webcam']; available model keys: ['ego_view_bg_crop_pad_res256_freq20']. Provide an explicit mapping (observation_mapping/action_mapping) or set strict_keys=False to allow positional fallback.
```

## Tests

New `TestStrictKeys` (groot) and `TestStrictKeysCameraRouting` (lerobot_local), 13 cases total, covering:
- strict raises on a deliberate name mismatch, with unmatched-vs-available keys in the message;
- non-strict default still maps positionally + warns (behavior unchanged);
- exact-name matches never raise in either mode;
- `camera_key_map` satisfies strict routing.

All 13 fail on pre-fix code and pass after. Full policy suite (467 tests) and registry suite (454 tests) green; lint + format clean; the two changed modules are mypy-clean.

## Docs

Updated `docs/policies/groot.md` (new "Strict key matching" section) and `docs/policies/lerobot-local.md` (camera routing note) with the new kwarg.

No behavior change at the default, so no rollout artifact applies; this is a pure correctness/validation guard on the in-process key-mapping path.