### PR TITLE
fix(device_connect): parameterize bare generics in drivers (type-arg)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -405,9 +405,15 @@ ignore_missing_imports = true
 
 # Device Connect drivers - thin wrappers over the untyped device_connect_edge
 # SDK; their RPC handlers return dicts that bubble Any (same posture as tools.*).
+# disallow_untyped_defs stays relaxed because the SDK's @rpc/@emit/@on
+# decorators are themselves untyped (they make decorated methods "untyped" to
+# mypy, which the global config cannot see through). disallow_any_generics is
+# enabled to keep the public dict/list/Callable surfaces fully parameterized
+# rather than silently bare (which a developer's IDE/strict mypy would flag).
 [[tool.mypy.overrides]]
 module = ["strands_robots.device_connect.*"]
 disallow_untyped_defs = false
+disallow_any_generics = true
 warn_return_any = false
 
 # @tool decorator injects runtime signatures mypy cannot check

--- a/strands_robots/device_connect/__init__.py
+++ b/strands_robots/device_connect/__init__.py
@@ -19,6 +19,7 @@ import logging
 import os
 import threading
 import uuid
+from typing import Any
 
 from device_connect_edge import DeviceRuntime
 
@@ -203,7 +204,7 @@ def init_device_connect_sync(
     return runtime
 
 
-def _build_heartbeat(robot, peer_type: str) -> dict:
+def _build_heartbeat(robot: Any, peer_type: str) -> dict[str, Any]:
     """Build heartbeat payload with robot-specific metadata."""
     data = {
         "peer_type": peer_type,

--- a/strands_robots/device_connect/_authz.py
+++ b/strands_robots/device_connect/_authz.py
@@ -130,7 +130,7 @@ def is_authorized_caller(caller: str | None, *, scope: str = "rpc") -> bool:
     return _matches(caller, patterns)
 
 
-def authz_error(caller: str | None, function: str) -> dict:
+def authz_error(caller: str | None, function: str) -> dict[str, str]:
     """Standard structured rejection for an unauthorized RPC call."""
     logger.warning("Rejected unauthorized Device Connect RPC %s from caller=%r", function, caller)
     return {

--- a/strands_robots/device_connect/reachy_mini_driver.py
+++ b/strands_robots/device_connect/reachy_mini_driver.py
@@ -11,6 +11,7 @@ import asyncio
 import logging
 import math
 import re
+from typing import Any
 
 from device_connect_edge.drivers import DeviceDriver, emit, on, rpc
 from device_connect_edge.types import DeviceIdentity, DeviceStatus
@@ -50,8 +51,8 @@ class ReachyMiniDriver(DeviceDriver):
         self._host = host
         self._prefix = prefix
         self._api_port = api_port
-        self._latest_joints: dict | None = None
-        self._latest_imu: dict | None = None
+        self._latest_joints: dict[str, Any] | None = None
+        self._latest_imu: dict[str, Any] | None = None
         self._hw: WebSocketLink | ZenohLink | None = None
 
     @property
@@ -94,7 +95,7 @@ class ReachyMiniDriver(DeviceDriver):
 
     # ── Helpers ────────────────────────────────────────────────
 
-    async def _send_cmd(self, cmd: dict) -> None:
+    async def _send_cmd(self, cmd: dict[str, Any]) -> None:
         """Send a real-time command via the active hardware link."""
         if self._hw is None:
             raise RuntimeError("Reachy Mini hardware link not connected")
@@ -111,7 +112,7 @@ class ReachyMiniDriver(DeviceDriver):
         x: float = 0,
         y: float = 0,
         z: float = 0,
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Set head pose instantly.
 
         Args:
@@ -126,7 +127,7 @@ class ReachyMiniDriver(DeviceDriver):
         return {"status": "success", "pitch": pitch, "roll": roll, "yaw": yaw}
 
     @rpc()
-    async def antennas(self, left: float = 0, right: float = 0) -> dict:
+    async def antennas(self, left: float = 0, right: float = 0) -> dict[str, Any]:
         """Set antenna angles.
 
         Args:
@@ -137,7 +138,7 @@ class ReachyMiniDriver(DeviceDriver):
         return {"status": "success", "left": left, "right": right}
 
     @rpc()
-    async def body(self, yaw: float = 0) -> dict:
+    async def body(self, yaw: float = 0) -> dict[str, Any]:
         """Set body yaw angle.
 
         Args:
@@ -149,7 +150,7 @@ class ReachyMiniDriver(DeviceDriver):
     # ── Sensor RPCs (cached from transport subscription) ───────
 
     @rpc()
-    async def getJoints(self) -> dict:
+    async def getJoints(self) -> dict[str, Any]:
         """Get current joint positions (head + antennas)."""
         d = self._latest_joints
         if d is not None:
@@ -163,7 +164,7 @@ class ReachyMiniDriver(DeviceDriver):
         return {"status": "error", "reason": "no joint data"}
 
     @rpc()
-    async def getImu(self) -> dict:
+    async def getImu(self) -> dict[str, Any]:
         """Get IMU data (accelerometer, gyroscope, quaternion, temperature)."""
         d = self._latest_imu
         if d is not None:
@@ -179,7 +180,7 @@ class ReachyMiniDriver(DeviceDriver):
     # ── Motor RPCs (Zenoh via transport) ───────────────────────
 
     @rpc()
-    async def enableMotors(self, motor_ids: str = "") -> dict:
+    async def enableMotors(self, motor_ids: str = "") -> dict[str, Any]:
         """Enable motors (torque on).
 
         Args:
@@ -190,7 +191,7 @@ class ReachyMiniDriver(DeviceDriver):
         return {"status": "success", "enabled": motor_ids or "all"}
 
     @rpc()
-    async def disableMotors(self, motor_ids: str = "") -> dict:
+    async def disableMotors(self, motor_ids: str = "") -> dict[str, Any]:
         """Disable motors (torque off).
 
         Args:
@@ -203,7 +204,7 @@ class ReachyMiniDriver(DeviceDriver):
     # ── Move RPCs (REST) ──────────────────────────────────────
 
     @rpc()
-    async def playMove(self, move_name: str, library: str = "emotions") -> dict:
+    async def playMove(self, move_name: str, library: str = "emotions") -> dict[str, Any]:
         """Play a recorded move from the HuggingFace library.
 
         Args:
@@ -223,7 +224,7 @@ class ReachyMiniDriver(DeviceDriver):
         return {"status": "success", "move": move_name, "result": result}
 
     @rpc()
-    async def listMoves(self, library: str = "emotions") -> dict:
+    async def listMoves(self, library: str = "emotions") -> dict[str, Any]:
         """List available recorded moves.
 
         Args:
@@ -241,7 +242,7 @@ class ReachyMiniDriver(DeviceDriver):
     # ── Expression RPCs (Zenoh animations via transport) ───────
 
     @rpc()
-    async def nod(self) -> dict:
+    async def nod(self) -> dict[str, Any]:
         """Nod the head (yes gesture)."""
         for _ in range(3):
             await self._send_cmd({"head_pose": rpy_to_pose(15, 0, 0)})
@@ -252,7 +253,7 @@ class ReachyMiniDriver(DeviceDriver):
         return {"status": "success", "expression": "nod"}
 
     @rpc()
-    async def shake(self) -> dict:
+    async def shake(self) -> dict[str, Any]:
         """Shake the head (no gesture)."""
         for _ in range(3):
             await self._send_cmd({"head_pose": rpy_to_pose(0, 0, 25)})
@@ -263,7 +264,7 @@ class ReachyMiniDriver(DeviceDriver):
         return {"status": "success", "expression": "shake"}
 
     @rpc()
-    async def happy(self) -> dict:
+    async def happy(self) -> dict[str, Any]:
         """Happy antenna wiggle expression."""
         for _ in range(4):
             await self._send_cmd({"antennas_joint_positions": [math.radians(60), math.radians(-60)]})
@@ -276,7 +277,7 @@ class ReachyMiniDriver(DeviceDriver):
     # ── Lifecycle RPCs (REST) ─────────────────────────────────
 
     @rpc()
-    async def wakeUp(self) -> dict:
+    async def wakeUp(self) -> dict[str, Any]:
         """Wake up the robot (enable motors + play wake animation)."""
         result = await asyncio.to_thread(
             api,
@@ -288,7 +289,7 @@ class ReachyMiniDriver(DeviceDriver):
         return {"status": "success", "result": result}
 
     @rpc()
-    async def sleep(self) -> dict:
+    async def sleep(self) -> dict[str, Any]:
         """Put robot to sleep (play sleep animation + disable motors)."""
         result = await asyncio.to_thread(
             api,
@@ -300,7 +301,7 @@ class ReachyMiniDriver(DeviceDriver):
         return {"status": "success", "result": result}
 
     @rpc()
-    async def stopMotion(self) -> dict:
+    async def stopMotion(self) -> dict[str, Any]:
         """Stop all current motion."""
         result = await asyncio.to_thread(
             api,
@@ -312,7 +313,7 @@ class ReachyMiniDriver(DeviceDriver):
         return {"status": "success", "result": result}
 
     @rpc()
-    async def getDaemonStatus(self) -> dict:
+    async def getDaemonStatus(self) -> dict[str, Any]:
         """Get daemon status, motor state, and control frequency."""
         result = await asyncio.to_thread(
             api,
@@ -325,7 +326,7 @@ class ReachyMiniDriver(DeviceDriver):
     # ── Events ────────────────────────────────────────────────
 
     @emit()
-    async def emergencyStop(self, reason: str = ""):
+    async def emergencyStop(self, reason: str = "") -> None:
         """Emitted when this device triggers an emergency stop.
 
         Args:
@@ -334,7 +335,7 @@ class ReachyMiniDriver(DeviceDriver):
         pass
 
     @on(event_name="emergencyStop")
-    async def onEmergencyStop(self, device_id: str, event_name: str, payload: dict):
+    async def onEmergencyStop(self, device_id: str, event_name: str, payload: dict[str, Any]) -> None:
         """React to emergencyStop - disable motors and stop motion."""
         logger.warning("Emergency stop received from %s - disabling motors", device_id)
         await self.stopMotion()

--- a/strands_robots/device_connect/reachy_transport.py
+++ b/strands_robots/device_connect/reachy_transport.py
@@ -17,6 +17,10 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+# Sensor callbacks receive a JSON-decoded frame (dict) and return nothing.
+JointsCallback = Callable[[dict[str, Any]], None]
+ImuCallback = Callable[[dict[str, Any]], None]
+
 
 def resolve_host(host: str) -> str:
     """Resolve hostname to IP address."""
@@ -127,7 +131,7 @@ def _emit_insecure_tls_warning(kind: str) -> None:
 # ── REST API ─────────────────────────────────────────────────────
 
 
-def api(host: str, port: int, path: str, method: str = "GET", data: dict | None = None) -> dict:
+def api(host: str, port: int, path: str, method: str = "GET", data: dict[str, Any] | None = None) -> dict[str, Any]:
     """Call Reachy Mini daemon REST API."""
     import urllib.error
     import urllib.request
@@ -161,7 +165,7 @@ def api(host: str, port: int, path: str, method: str = "GET", data: dict | None 
 
 def rpy_to_pose(
     pitch_deg: float, roll_deg: float, yaw_deg: float, x_mm: float = 0, y_mm: float = 0, z_mm: float = 0
-) -> list:
+) -> list[list[float]]:
     """Convert RPY (degrees) + XYZ (mm) to 4x4 pose matrix."""
     p, r, y = math.radians(pitch_deg), math.radians(roll_deg), math.radians(yaw_deg)
     cr, sr = math.cos(r), math.sin(r)
@@ -175,7 +179,7 @@ def rpy_to_pose(
     ]
 
 
-def identity_pose() -> list:
+def identity_pose() -> list[list[float]]:
     """Return a 4x4 identity pose matrix."""
     return [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]
 
@@ -187,7 +191,7 @@ class HardwareLink(ABC):
     """Abstract interface for real-time I/O with Reachy Mini hardware."""
 
     @abstractmethod
-    async def start(self, on_joints: Callable, on_imu: Callable) -> None:
+    async def start(self, on_joints: JointsCallback, on_imu: ImuCallback) -> None:
         """Begin receiving sensor data and enable command sending."""
 
     @abstractmethod
@@ -195,7 +199,7 @@ class HardwareLink(ABC):
         """Tear down the connection."""
 
     @abstractmethod
-    async def send_cmd(self, cmd: dict) -> None:
+    async def send_cmd(self, cmd: dict[str, Any]) -> None:
         """Send a real-time command to the robot."""
 
 
@@ -206,7 +210,7 @@ class ZenohLink(HardwareLink):
         self._transport = transport
         self._prefix = prefix
 
-    async def start(self, on_joints: Callable, on_imu: Callable) -> None:
+    async def start(self, on_joints: JointsCallback, on_imu: ImuCallback) -> None:
         async def _on_joints(data: bytes, _reply=None):
             try:
                 on_joints(json.loads(data.decode()))
@@ -225,7 +229,7 @@ class ZenohLink(HardwareLink):
     async def stop(self) -> None:
         pass  # Transport teardown handled by DeviceRuntime
 
-    async def send_cmd(self, cmd: dict) -> None:
+    async def send_cmd(self, cmd: dict[str, Any]) -> None:
         await self._transport.publish(f"{self._prefix}/command", json.dumps(cmd).encode())
 
 
@@ -243,9 +247,9 @@ class WebSocketLink(HardwareLink):
         self._host = host
         self._port = port
         self._ws: Any = None
-        self._read_task: asyncio.Task | None = None
+        self._read_task: asyncio.Task[None] | None = None
 
-    async def start(self, on_joints: Callable, on_imu: Callable) -> None:
+    async def start(self, on_joints: JointsCallback, on_imu: ImuCallback) -> None:
         import websockets
 
         # Security hardening: authenticate to the daemon when a token is
@@ -271,7 +275,7 @@ class WebSocketLink(HardwareLink):
         self._ws = await websockets.connect(_url, **_connect_kwargs)
         self._read_task = asyncio.create_task(self._read_loop(on_joints, on_imu))
 
-    async def _read_loop(self, on_joints: Callable, on_imu: Callable) -> None:
+    async def _read_loop(self, on_joints: JointsCallback, on_imu: ImuCallback) -> None:
         async for raw in self._ws:
             try:
                 msg = json.loads(raw)
@@ -289,7 +293,7 @@ class WebSocketLink(HardwareLink):
         if self._ws:
             await self._ws.close()
 
-    async def send_cmd(self, cmd: dict) -> None:
+    async def send_cmd(self, cmd: dict[str, Any]) -> None:
         if not self._ws:
             return
         for key, fn in self._WS_CMD_MAP.items():

--- a/strands_robots/device_connect/robot_driver.py
+++ b/strands_robots/device_connect/robot_driver.py
@@ -6,6 +6,7 @@ structured RPCs and events via Device Connect's DeviceDriver interface.
 
 import asyncio
 import logging
+from typing import Any
 
 from device_connect_edge.drivers import (
     DeviceDriver,
@@ -67,7 +68,7 @@ class RobotDeviceDriver(DeviceDriver):
         policy_provider: str = "mock",
         duration: float = 30.0,
         policy_port: int = 0,
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Execute a VLA task instruction on the robot.
 
         Args:
@@ -96,7 +97,7 @@ class RobotDeviceDriver(DeviceDriver):
         )
 
     @rpc()
-    async def stop(self) -> dict:
+    async def stop(self) -> dict[str, Any]:
         """Stop the currently running task."""
         caller = get_rpc_source_device()
         if not is_authorized_caller(caller, scope="rpc"):
@@ -104,12 +105,12 @@ class RobotDeviceDriver(DeviceDriver):
         return self._robot.stop_task()
 
     @rpc()
-    async def getStatus(self) -> dict:
+    async def getStatus(self) -> dict[str, Any]:
         """Get current task execution status."""
         return self._robot.get_task_status()
 
     @rpc()
-    async def getFeatures(self) -> dict:
+    async def getFeatures(self) -> dict[str, Any]:
         """Get robot observation and action features."""
         get_features = getattr(self._robot, "get_features", None)
         if callable(get_features):
@@ -118,7 +119,7 @@ class RobotDeviceDriver(DeviceDriver):
         return {"features": {}, "note": "get_features unavailable on this robot"}
 
     @rpc()
-    async def getState(self) -> dict:
+    async def getState(self) -> dict[str, Any]:
         """Get current robot state (joints, task info).
 
         Returns joint positions and task state if a task is running.
@@ -166,7 +167,7 @@ class RobotDeviceDriver(DeviceDriver):
         pass
 
     @emit()
-    async def streamStep(self, step: int, observation: dict, action: dict):
+    async def streamStep(self, step: int, observation: dict[str, Any], action: dict[str, Any]) -> None:
         """Emitted for each VLA inference step (high frequency).
 
         Args:
@@ -186,7 +187,7 @@ class RobotDeviceDriver(DeviceDriver):
         pass
 
     @on(event_name="emergencyStop")
-    async def onEmergencyStop(self, device_id: str, event_name: str, payload: dict):
+    async def onEmergencyStop(self, device_id: str, event_name: str, payload: dict[str, Any]) -> None:
         """React to emergencyStop from an authorized safety controller.
 
         Security hardening: only act on emergency-stop events whose source is

--- a/strands_robots/device_connect/sim_driver.py
+++ b/strands_robots/device_connect/sim_driver.py
@@ -5,6 +5,7 @@ state as structured RPCs and events via Device Connect's DeviceDriver interface.
 """
 
 import logging
+from typing import Any
 
 from device_connect_edge.drivers import (
     DeviceDriver,
@@ -71,7 +72,7 @@ class SimulationDeviceDriver(DeviceDriver):
         policy_provider: str = "mock",
         duration: float = 30.0,
         robot_name: str = "",
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Execute a policy on a simulated robot.
 
         Args:
@@ -109,7 +110,7 @@ class SimulationDeviceDriver(DeviceDriver):
         )
 
     @rpc()
-    async def stop(self) -> dict:
+    async def stop(self) -> dict[str, Any]:
         """Stop all running policies."""
         caller = get_rpc_source_device()
         if not is_authorized_caller(caller, scope="rpc"):
@@ -122,19 +123,19 @@ class SimulationDeviceDriver(DeviceDriver):
         return {"status": "success", "content": [{"text": "All policies stopped"}]}
 
     @rpc()
-    async def getStatus(self) -> dict:
+    async def getStatus(self) -> dict[str, Any]:
         """Get simulation state and running policies."""
         if hasattr(self._sim, "get_state"):
             return self._sim.get_state()
         return {"status": "idle"}
 
     @rpc()
-    async def getFeatures(self) -> dict:
+    async def getFeatures(self) -> dict[str, Any]:
         """Get simulation features (joints, actuators, cameras)."""
         return self._sim.get_features()
 
     @rpc()
-    async def step(self, n_steps: int = 1) -> dict:
+    async def step(self, n_steps: int = 1) -> dict[str, Any]:
         """Step simulation physics forward.
 
         Args:
@@ -146,7 +147,7 @@ class SimulationDeviceDriver(DeviceDriver):
         return self._sim.step(n_steps)
 
     @rpc()
-    async def reset(self) -> dict:
+    async def reset(self) -> dict[str, Any]:
         """Reset simulation to initial state."""
         caller = get_rpc_source_device()
         if not is_authorized_caller(caller, scope="rpc"):
@@ -187,7 +188,7 @@ class SimulationDeviceDriver(DeviceDriver):
         pass
 
     @on(event_name="emergencyStop")
-    async def onEmergencyStop(self, device_id: str, event_name: str, payload: dict):
+    async def onEmergencyStop(self, device_id: str, event_name: str, payload: dict[str, Any]) -> None:
         """React to emergencyStop from an authorized safety controller.
 
         Security hardening: only act on emergency-stop events whose source is
@@ -243,7 +244,9 @@ class SimulationDeviceDriver(DeviceDriver):
                     logger.debug("observationUpdate skipped for %s: %s", name, e)
 
     @emit()
-    async def stateUpdate(self, sim_time: float = 0.0, step_count: int = 0, running_policies: dict | None = None):
+    async def stateUpdate(
+        self, sim_time: float = 0.0, step_count: int = 0, running_policies: dict[str, Any] | None = None
+    ) -> None:
         """Periodic simulation state update.
 
         Args:
@@ -255,8 +258,8 @@ class SimulationDeviceDriver(DeviceDriver):
 
     @emit()
     async def observationUpdate(
-        self, robot_name: str = "", sim_time: float = 0.0, step_count: int = 0, joints: dict | None = None
-    ):
+        self, robot_name: str = "", sim_time: float = 0.0, step_count: int = 0, joints: dict[str, float] | None = None
+    ) -> None:
         """Periodic per-robot observation with joint positions.
 
         Args:


### PR DESCRIPTION
## Problem
The Device Connect drivers (Reachy Mini, sim, robot) and their shared transport/authz helpers carry bare `dict` / `list` / `Callable` / `asyncio.Task` generics on their public RPC and event surfaces. The project mypy config does not enable `disallow_any_generics`, and the `device_connect.*` override further relaxes `disallow_untyped_defs`, so these never surfaced in CI. But any developer running mypy in strict mode (or an IDE with strict type checking) sees **49 `type-arg` errors** across the package -- 20 in `reachy_mini_driver.py` alone, plus `reachy_transport.py`, `sim_driver.py`, `robot_driver.py`, `__init__.py`, and `_authz.py`.

## Change
Parameterize every bare public generic (annotations only, no behavior change):

- **reachy_transport.py**: `api()` -> `dict[str, Any]`; `rpy_to_pose` / `identity_pose` -> `list[list[float]]`; `HardwareLink` sensor callbacks via new `JointsCallback` / `ImuCallback` aliases; `send_cmd` cmd dicts; `WebSocketLink._read_task` -> `asyncio.Task[None]`.
- **reachy_mini_driver.py**: all `@rpc` returns -> `dict[str, Any]`; cached sensor state, `_send_cmd`, `onEmergencyStop` payload; `emergencyStop` emit return annotation.
- **sim_driver.py / robot_driver.py**: `@rpc` returns + emit payloads (`running_policies`, `joints`, `observation`/`action`, `payload`).
- **__init__.py** `_build_heartbeat`, **_authz.py** `authz_error` return types.

## Regression guard
Enabled `disallow_any_generics = true` on the `device_connect.*` mypy override so these surfaces stay fully parameterized going forward. With the guard in place:
- pre-fix sources: **49 `type-arg` errors**
- post-fix: **clean** (`Success: no issues found in 6 source files`)

`disallow_untyped_defs` stays relaxed on this override because the SDK's `@rpc`/`@emit`/`@on` decorators are themselves untyped (they make decorated methods untyped to mypy, which the global config cannot see through).

## Testing
- `hatch run lint` clean (ruff check + ruff format --check + mypy, 413 source files).
- `hatch run mypy strands_robots/device_connect/` -> clean; reverting only the source files with the guard active reproduces the 49 errors.
- Full `MUJOCO_GL=egl hatch run test`: **6601 passed, 86 skipped**.