### PR TITLE
test(package): cover lazy-import __getattr__ contract in strands_robots root

### DIFF
--- a/tests/test_package_lazy_imports.py
+++ b/tests/test_package_lazy_imports.py
@@ -1,0 +1,104 @@
+"""Tests for the package-root lazy-import contract in ``strands_robots/__init__.py``.
+
+``import strands_robots`` must stay cheap: heavy symbols (Robot, Simulation,
+Gr00tPolicy, tools, ...) are resolved on first attribute access via PEP 562
+``__getattr__``, while light symbols (Policy, MockPolicy, create_policy) import
+eagerly. These tests pin the observable behavior of that loader:
+
+- light symbols are importable with no extra dependencies,
+- lazy symbols resolve, get cached, and return a stable identity,
+- an unknown attribute raises ``AttributeError`` with the standard message,
+- a lazy symbol whose backing module is missing warns and raises
+  ``AttributeError`` chained from the original ``ImportError`` (so callers
+  without an optional extra get a clear, recoverable failure).
+"""
+
+import warnings
+
+import pytest
+
+import strands_robots
+
+
+class TestEagerLightSymbols:
+    """Light-weight policy symbols import without torch/lerobot/mujoco."""
+
+    def test_policy_symbols_available_immediately(self):
+        # These are real top-level imports, not lazy entries.
+        assert "Policy" in strands_robots.__all__
+        assert isinstance(strands_robots.MockPolicy, type)
+        assert callable(strands_robots.create_policy)
+
+    def test_light_symbols_are_not_lazy_entries(self):
+        for name in ("Policy", "MockPolicy", "create_policy"):
+            assert name not in strands_robots._LAZY_IMPORTS
+
+
+class TestLazyResolution:
+    """First attribute access resolves, caches, and returns stable identity."""
+
+    def test_lazy_symbol_resolves_and_caches(self):
+        # list_robots is registry-backed (no torch) so it always resolves.
+        assert "list_robots" in strands_robots._LAZY_IMPORTS
+
+        resolved = strands_robots.list_robots
+        assert callable(resolved)
+
+        # After first access the name is cached in the module dict so
+        # __getattr__ is not invoked again.
+        assert "list_robots" in vars(strands_robots)
+
+        # Subsequent access returns the same object identity.
+        assert strands_robots.list_robots is resolved
+
+    def test_every_lazy_name_is_exported(self):
+        # __all__ and _LAZY_IMPORTS must not drift apart: every lazy symbol
+        # is part of the public surface.
+        for name in strands_robots._LAZY_IMPORTS:
+            assert name in strands_robots.__all__
+
+
+class TestUnknownAttribute:
+    """Unknown attributes raise AttributeError with the standard message."""
+
+    def test_unknown_attribute_raises(self):
+        with pytest.raises(AttributeError, match="has no attribute 'does_not_exist'"):
+            strands_robots.does_not_exist
+
+    def test_dunder_attribute_raises_attributeerror(self):
+        # Spurious dunder lookups (e.g. by copy/pickle) must not be swallowed.
+        with pytest.raises(AttributeError):
+            strands_robots.__wrapped__
+
+
+class TestMissingDependencyContract:
+    """A lazy symbol backed by an unimportable module warns then raises.
+
+    Simulates the "optional extra not installed" path without uninstalling
+    anything: register a temporary lazy entry pointing at a non-existent
+    module, then assert the warn-and-raise contract.
+    """
+
+    def test_missing_module_warns_and_raises_chained_attributeerror(self):
+        sentinel = "FakeMissingSymbolForTest"
+        strands_robots._LAZY_IMPORTS[sentinel] = (
+            "strands_robots._this_module_does_not_exist",
+            "Thing",
+        )
+        try:
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                with pytest.raises(AttributeError) as excinfo:
+                    getattr(strands_robots, sentinel)
+
+            # AttributeError carries the requested name and is chained from
+            # the underlying ImportError so callers can introspect the cause.
+            assert excinfo.value.args[0] == sentinel
+            assert isinstance(excinfo.value.__cause__, ImportError)
+
+            messages = [str(w.message) for w in caught]
+            assert any(f"{sentinel} not available (missing dependencies)" in m for m in messages)
+        finally:
+            strands_robots._LAZY_IMPORTS.pop(sentinel, None)
+            # The failed access must not leave a cached entry behind.
+            assert sentinel not in vars(strands_robots)


### PR DESCRIPTION
## Problem

The package root (`strands_robots/__init__.py`) resolves heavy symbols (`Robot`, `Simulation`, `Gr00tPolicy`, the tools, ...) lazily via PEP 562 `__getattr__` so `import strands_robots` stays cheap when torch/lerobot/mujoco are installed but unused. Light policy symbols (`Policy`, `MockPolicy`, `create_policy`) import eagerly.

The loader's failure contract was entirely untested: an unknown attribute raising `AttributeError`, and a lazy symbol whose optional-extra backing module is missing warning then raising an `AttributeError` chained from the original `ImportError`. That branch (the warn + chained-raise path) was uncovered, so a regression that swallowed the cause or stopped warning would slip through.

## Change

Adds `tests/test_package_lazy_imports.py` pinning the observable behavior of the loader:

- eager light symbols (`Policy`/`MockPolicy`/`create_policy`) resolve with no optional extras and are not lazy entries;
- a lazy symbol (`list_robots`, registry-backed, no torch) resolves, caches into the module dict, and keeps a stable object identity on re-access;
- `__all__` and `_LAZY_IMPORTS` stay in sync (every lazy name is part of the public surface);
- unknown and dunder attributes raise `AttributeError` with the standard message;
- a lazy entry pointing at a non-existent module warns `"<name> not available (missing dependencies)"` and raises `AttributeError` chained from `ImportError`, leaving no cached entry behind. This simulates the "optional extra not installed" path without uninstalling anything.

## Tests

```
pytest tests/test_package_lazy_imports.py -v   # 7 passed
```

The missing-dependency test fails against any implementation that drops the warning or the `ImportError` chaining (verified by temporarily reverting the warn/raise to confirm it exercises the previously-uncovered lines).

Coverage of `strands_robots/__init__.py`: 77% -> 87% (the remaining uncovered lines are environment-dependent eager-import guards). Full suite green locally: 6628 passed (the 2 unrelated failures are a torchcodec/libc10_cuda load issue in the local env, not touched here).