### PR TITLE
chore(simulation): strip emoji from tool-output and log strings

### DIFF
--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -814,7 +814,7 @@ class SimEngine(ABC):
             "content": [
                 {
                     "text": (
-                        f"📋 Registered benchmark '{benchmark_name}' from {spec_path}\n"
+                        f"Registered benchmark '{benchmark_name}' from {spec_path}\n"
                         f"  class: {type(benchmark).__name__}\n"
                         f"  supported_robots: {benchmark.supported_robots or 'any'}\n"
                         f"  default_robot: {benchmark.default_robot}\n"

--- a/strands_robots/simulation/benchmark.py
+++ b/strands_robots/simulation/benchmark.py
@@ -309,7 +309,7 @@ def register_benchmark(name: str, benchmark: BenchmarkProtocol) -> None:
         if name in _BENCHMARK_REGISTRY:
             logger.warning("Overwriting existing benchmark registration: %s", name)
         _BENCHMARK_REGISTRY[name] = benchmark
-        logger.info("📋 Registered benchmark '%s' (%s)", name, type(benchmark).__name__)
+        logger.info("Registered benchmark '%s' (%s)", name, type(benchmark).__name__)
 
 
 def unregister_benchmark(name: str) -> BenchmarkProtocol | None:

--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -133,7 +133,7 @@ class PhysicsMixin:
             "content": [
                 {
                     "text": (
-                        f"💾 State '{name}' saved\n"
+                        f"State '{name}' saved\n"
                         f"  t={self._world.sim_time:.4f}s, step={self._world.step_count}\n"
                         f"State vector: {state_size} floats\n"
                         f"Checkpoints: {list(self._world._checkpoints.keys())}"
@@ -172,7 +172,7 @@ class PhysicsMixin:
         return {
             "status": "success",
             "content": [
-                {"text": f"📂 State '{name}' restored (t={self._world.sim_time:.4f}s, step={self._world.step_count})"}
+                {"text": f"State '{name}' restored (t={self._world.sim_time:.4f}s, step={self._world.step_count})"}
             ],
         }
 
@@ -256,7 +256,7 @@ class PhysicsMixin:
             "content": [
                 {
                     "text": (
-                        f"💨 Force applied to '{body_name}' (body {body_id})\n"
+                        f"Force applied to '{body_name}' (body {body_id})\n"
                         f"Force: {f.tolist()} N\n"
                         f"Torque: {t.tolist()} N·m\n"
                         f"Point: {p.tolist()}"
@@ -378,9 +378,9 @@ class PhysicsMixin:
         }
 
         if hit:
-            text = f"🎯 Ray hit '{geom_name or geomid[0]}' at dist={dist:.4f}m, point={result['hit_point']}"
+            text = f"Ray hit '{geom_name or geomid[0]}' at dist={dist:.4f}m, point={result['hit_point']}"
         else:
-            text = "🎯 Ray: no intersection"
+            text = "Ray: no intersection"
 
         return {"status": "success", "content": [{"text": text}, {"json": result}]}
 
@@ -433,7 +433,7 @@ class PhysicsMixin:
         return {
             "status": "success",
             "content": [
-                {"text": f"🧮 Jacobian for {label}: pos={jacp.shape}, rot={jacr.shape}, nv={model.nv}"},
+                {"text": f"Jacobian for {label}: pos={jacp.shape}, rot={jacr.shape}, nv={model.nv}"},
                 {"json": {"jacp": jacp.tolist(), "jacr": jacr.tolist(), "nv": model.nv}},
             ],
         }
@@ -458,7 +458,7 @@ class PhysicsMixin:
         return {
             "status": "success",
             "content": [
-                {"text": f"⚡ Energy: potential={potential:.4f}J, kinetic={kinetic:.4f}J, total={total:.4f}J"},
+                {"text": f"Energy: potential={potential:.4f}J, kinetic={kinetic:.4f}J, total={total:.4f}J"},
                 {"json": {"potential": potential, "kinetic": kinetic, "total": total}},
             ],
         }
@@ -496,7 +496,7 @@ class PhysicsMixin:
         return {
             "status": "success",
             "content": [
-                {"text": f"🧮 Mass matrix: {nv}×{nv}, rank={rank}, cond={cond:.2e}"},
+                {"text": f"Mass matrix: {nv}×{nv}, rank={rank}, cond={cond:.2e}"},
                 {
                     "json": {
                         "shape": [nv, nv],
@@ -536,7 +536,7 @@ class PhysicsMixin:
         return {
             "status": "success",
             "content": [
-                {"text": f"🔄 Inverse dynamics: {len(forces)} joint forces computed"},
+                {"text": f"Inverse dynamics: {len(forces)} joint forces computed"},
                 {"json": {"qfrc_inverse": forces}},
             ],
         }
@@ -588,7 +588,7 @@ class PhysicsMixin:
         }
 
         text = (
-            f"🏷️ Body '{body_name}' (id={body_id}):\n"
+            f"Body '{body_name}' (id={body_id}):\n"
             f"  pos: [{pos[0]:.4f}, {pos[1]:.4f}, {pos[2]:.4f}]\n"
             f"  quat: [{quat[0]:.4f}, {quat[1]:.4f}, {quat[2]:.4f}, {quat[3]:.4f}]\n"
             f"  linvel: [{linvel[0]:.4f}, {linvel[1]:.4f}, {linvel[2]:.4f}]\n"
@@ -703,7 +703,7 @@ class PhysicsMixin:
 
             mj.mj_forward(model, data)
 
-        msg = f"🎯 Set {set_count}/{len(positions)} joint positions, FK updated"
+        msg = f"Set {set_count}/{len(positions)} joint positions, FK updated"
         if ignored:
             msg += f" (ignored: {ignored})"
         return {
@@ -799,7 +799,7 @@ class PhysicsMixin:
                 else:
                     ignored.append(jnt_name)
 
-        msg = f"💨 Set {set_count}/{len(velocities)} joint velocities"
+        msg = f"Set {set_count}/{len(velocities)} joint velocities"
         if ignored:
             msg += f" (ignored: {ignored})"
         return {
@@ -831,7 +831,7 @@ class PhysicsMixin:
                     "status": "error",
                     "content": [{"text": f"Sensor '{sensor_name}' not found. Model has no sensors."}],
                 }
-            return {"status": "success", "content": [{"text": "📡 No sensors in model."}]}
+            return {"status": "success", "content": [{"text": "No sensors in model."}]}
 
         # Lock while running mj_forward + reading sensordata so a policy
         # thread's mj_step can't mutate data between our forward pass and
@@ -864,7 +864,7 @@ class PhysicsMixin:
         if sensor_name and sensor_name not in sensors:
             return {"status": "error", "content": [{"text": f"Sensor '{sensor_name}' not found."}]}
 
-        lines = [f"📡 Sensors ({len(sensors)}/{model.nsensor}):"]
+        lines = [f"Sensors ({len(sensors)}/{model.nsensor}):"]
         for name, info in sensors.items():
             lines.append(f"{name}: {info['values']} (dim={info['dim']})")
 
@@ -919,7 +919,7 @@ class PhysicsMixin:
 
         return {
             "status": "success",
-            "content": [{"text": f"🔧 Body '{body_name}': {', '.join(changes)}"}],
+            "content": [{"text": f"Body '{body_name}': {', '.join(changes)}"}],
         }
 
     def set_geom_properties(
@@ -972,7 +972,7 @@ class PhysicsMixin:
 
         return {
             "status": "success",
-            "content": [{"text": f"🔧 Geom '{label}': {', '.join(changes)}"}],
+            "content": [{"text": f"Geom '{label}': {', '.join(changes)}"}],
         }
 
     # Contact Force Analysis
@@ -1013,9 +1013,9 @@ class PhysicsMixin:
                 )
 
         if not contacts:
-            return {"status": "success", "content": [{"text": "💥 No active contacts."}]}
+            return {"status": "success", "content": [{"text": "No active contacts."}]}
 
-        lines = [f"💥 {len(contacts)} contacts:"]
+        lines = [f"{len(contacts)} contacts:"]
         for c in contacts[:15]:
             lines.append(f"{c['geom1']} ↔ {c['geom2']}: normal={c['normal_force']:.3f}N, dist={c['distance']:.4f}m")
         if len(contacts) > 15:
@@ -1093,7 +1093,7 @@ class PhysicsMixin:
         return {
             "status": "success",
             "content": [
-                {"text": f"🎯 Multi-ray: {hit_count}/{len(directions)} hits from {origin}"},
+                {"text": f"Multi-ray: {hit_count}/{len(directions)} hits from {origin}"},
                 {"json": {"rays": results}},
             ],
         }
@@ -1132,7 +1132,7 @@ class PhysicsMixin:
                 return {
                     "status": "success",
                     "content": [
-                        {"text": f"🦴 FK for '{body_name}': pos={body_payload['position']}"},
+                        {"text": f"FK for '{body_name}': pos={body_payload['position']}"},
                         {"json": {"body": body_name, **body_payload}},
                     ],
                 }
@@ -1148,7 +1148,7 @@ class PhysicsMixin:
         return {
             "status": "success",
             "content": [
-                {"text": f"🦴 FK computed for {model.nbody} bodies"},
+                {"text": f"FK computed for {model.nbody} bodies"},
                 {"json": {"bodies": bodies}},
             ],
         }
@@ -1174,7 +1174,7 @@ class PhysicsMixin:
         return {
             "status": "success",
             "content": [
-                {"text": f"⚖️ Total mass: {total:.4f}kg ({len(bodies)} bodies with mass)"},
+                {"text": f"Total mass: {total:.4f}kg ({len(bodies)} bodies with mass)"},
                 {"json": {"total_mass": total, "bodies": bodies}},
             ],
         }
@@ -1212,9 +1212,9 @@ class PhysicsMixin:
         if output_path:
             with open(output_path, "w") as f:
                 f.write(xml)
-            return {"status": "success", "content": [{"text": f"📄 Model exported to {output_path}"}]}
+            return {"status": "success", "content": [{"text": f"Model exported to {output_path}"}]}
 
         return {
             "status": "success",
-            "content": [{"text": f"📄 Model XML ({len(xml)} chars):\n{xml[:2000]}{'...' if len(xml) > 2000 else ''}"}],
+            "content": [{"text": f"Model XML ({len(xml)} chars):\n{xml[:2000]}{'...' if len(xml) > 2000 else ''}"}],
         }

--- a/strands_robots/simulation/mujoco/randomization.py
+++ b/strands_robots/simulation/mujoco/randomization.py
@@ -91,13 +91,13 @@ class RandomizationMixin:
                     geom_name = mj.mj_id2name(model, mj.mjtObj.mjOBJ_GEOM, i)
                     if geom_name and geom_name != "ground":
                         model.geom_rgba[i, :3] = rng.uniform(color_range[0], color_range[1], size=3)
-                changes.append(f"🎨 Colors: {model.ngeom} geoms randomized")
+                changes.append(f"Colors: {model.ngeom} geoms randomized")
 
             if randomize_lighting:
                 for i in range(model.nlight):
                     model.light_pos[i] += rng.uniform(-0.5, 0.5, size=3)
                     model.light_diffuse[i] = rng.uniform(0.3, 1.0, size=3)
-                changes.append(f"💡 Lighting: {model.nlight} lights randomized")
+                changes.append(f"Lighting: {model.nlight} lights randomized")
 
             if randomize_physics:
                 friction_scales = {}
@@ -114,7 +114,7 @@ class RandomizationMixin:
                         model.body_mass[i] *= s
                         mass_scales[bn] = s
                 changes.append(
-                    f"⚙️ Physics: {len(friction_scales)} geoms friction-scaled, {len(mass_scales)} bodies mass-scaled"
+                    f"Physics: {len(friction_scales)} geoms friction-scaled, {len(mass_scales)} bodies mass-scaled"
                 )
                 changes.append(f"   friction_scales={friction_scales}")
                 changes.append(f"   mass_scales={mass_scales}")
@@ -129,9 +129,9 @@ class RandomizationMixin:
                             noise = rng.uniform(-position_noise, position_noise, size=3)
                             data.qpos[qpos_addr : qpos_addr + 3] += noise
                 mj.mj_forward(model, data)
-                changes.append(f"📍 Positions: ±{position_noise}m noise on dynamic objects")
+                changes.append(f"Positions: ±{position_noise}m noise on dynamic objects")
 
         return {
             "status": "success",
-            "content": [{"text": "🎲 Domain Randomization applied:\n" + "\n".join(changes)}],
+            "content": [{"text": "Domain Randomization applied:\n" + "\n".join(changes)}],
         }

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -552,21 +552,19 @@ class PolicyRunner:
         sim_time = self._maybe_sim_time()
         prefix = "Policy stopped" if stopped_early else "Policy complete"
         text = (
-            f"{prefix} on '{robot_name}'\n"
-            f"🧠 {type(policy).__name__} | 🎯 {instruction}\n"
-            f"⏱️ {elapsed:.1f}s | 📊 {step_count} steps"
+            f"{prefix} on '{robot_name}'\n{type(policy).__name__} | {instruction}\n{elapsed:.1f}s | {step_count} steps"
         )
         if sim_time is not None:
-            text += f" | 🕐 sim_t={sim_time:.3f}s"
+            text += f" | sim_t={sim_time:.3f}s"
         if writer is not None:
             assert video is not None and video_path is not None
             writer.close()
             if frame_count > 0 and os.path.exists(video_path):
                 file_kb = os.path.getsize(video_path) / 1024
                 text += (
-                    f"\n🎬 Video: {video_path}\n"
-                    f"📹 {frame_count} frames, {video.fps}fps, "
-                    f"{video.width}x{video.height} | 💾 {file_kb:.0f} KB"
+                    f"\nVideo: {video_path}\n"
+                    f"{frame_count} frames, {video.fps}fps, "
+                    f"{video.width}x{video.height} | {file_kb:.0f} KB"
                 )
             else:
                 # Log a loud warning so the user isn't blindsided by a silent
@@ -579,18 +577,18 @@ class PolicyRunner:
                     "remained valid throughout the rollout.",
                     video_path,
                 )
-                text += f"\n⚠️ Video requested but 0 frames captured ({video_path})"
+                text += f"\nVideo requested but 0 frames captured ({video_path})"
         # If every send_action call failed (all keys unresolved), the robot
         # never moved -- report this as an error rather than a false success.
         if _action_errors > 0 and _action_errors >= step_count and step_count > 0:
             text += (
-                f"\n\n⚠️ ALL {_action_errors} action steps had unresolved keys "
+                f"\n\nALL {_action_errors} action steps had unresolved keys "
                 f"-- the robot did not move. Check that the policy's output keys "
                 f"match the robot's actuator names."
             )
             return {"status": "error", "content": [{"text": text}]}
         if _action_errors > 0:
-            text += f"\n\n⚠️ {_action_errors}/{step_count} action steps had unresolved keys."
+            text += f"\n\n{_action_errors}/{step_count} action steps had unresolved keys."
         return {"status": "success", "content": [{"text": text}]}
 
     # replay(): replay a LeRobotDataset episode
@@ -678,7 +676,7 @@ class PolicyRunner:
             "content": [
                 {
                     "text": (
-                        f"▶️ Replayed episode {episode} from {repo_id} on '{resolved_robot}'\n"
+                        f"Replayed episode {episode} from {repo_id} on '{resolved_robot}'\n"
                         f"Frames: {frames_applied}/{episode_length} | "
                         f"Duration: {duration:.1f}s | Speed: {speed}x"
                     )
@@ -830,7 +828,7 @@ class PolicyRunner:
             "content": [
                 {
                     "text": (
-                        f"📊 Evaluation: {type(policy).__name__} on '{robot_name}'\n"
+                        f"Evaluation: {type(policy).__name__} on '{robot_name}'\n"
                         f"Episodes: {n_episodes} | Success: {n_success}/{n_episodes} "
                         f"({success_rate:.1%})\n"
                         f"Avg steps: {avg_steps:.0f}/{max_steps}"
@@ -1147,7 +1145,7 @@ class PolicyRunner:
             "content": [
                 {
                     "text": (
-                        f"📊 Benchmark: {spec_name} | policy {type(policy).__name__} on '{robot_name}'\n"
+                        f"Benchmark: {spec_name} | policy {type(policy).__name__} on '{robot_name}'\n"
                         f"Episodes: {n_episodes} | Success: {n_success} | Failure: {n_failure} "
                         f"({success_rate:.1%} success)\n"
                         f"Avg reward: {avg_reward:.2f} | Avg steps: {avg_steps:.0f}/{max_steps}"

--- a/tests/simulation/test_output_strings_no_emoji.py
+++ b/tests/simulation/test_output_strings_no_emoji.py
@@ -1,0 +1,67 @@
+"""Regression: the simulation package must not embed emoji in source strings.
+
+AGENTS.md forbids emoji in user-facing strings (tool-result ``text`` payloads,
+log messages, error messages): agents read these strings programmatically, and
+emoji are tokenizer noise that render inconsistently across terminals.
+
+These ``content`` ``text`` payloads and ``logger`` calls historically carried
+decorative glyphs (floppy disk, brain, dart, chart, etc.) plus their orphan
+``U+FE0F`` variation selectors. This test scans the simulation source modules
+for any pictograph / dingbat / symbol-emoji codepoint (and stray variation
+selectors) so the regression cannot silently reappear.
+
+It deliberately does NOT require pure ASCII: the modules legitimately use math
+typography (``+/-``, multiplication sign, arrows) in comments and numeric
+output. Only emoji codepoints are rejected.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import strands_robots.simulation as sim_pkg
+
+# Emoji / pictograph / dingbat / symbol ranges plus variation selectors.
+# Intentionally excludes the Mathematical Operators arrows (U+2190-21FF base
+# arrows are allowed in comments) but DOES include emoji-presentation arrows
+# such as U+25B6 (play) and the U+FE00-FE0F variation selectors that turn a
+# plain glyph into an emoji.
+_EMOJI = re.compile(
+    "["
+    "\U0001f000-\U0001faff"  # supplemental symbols, pictographs, emoticons
+    "\U00002600-\U000027bf"  # misc symbols + dingbats
+    "\U00002300-\U000023ff"  # technical (stopwatch, hourglass, etc.)
+    "\U00002b00-\U00002bff"  # arrows/stars emoji block
+    "\U000025a0-\U000025ff"  # geometric shapes (play/stop emoji bases)
+    "\U0000fe00-\U0000fe0f"  # variation selectors (orphan emoji markers)
+    "\U0001f1e6-\U0001f1ff"  # regional indicators (flags)
+    "]"
+)
+
+_PACKAGE_DIR = Path(sim_pkg.__file__).resolve().parent
+
+
+def _python_sources() -> list[Path]:
+    return sorted(p for p in _PACKAGE_DIR.rglob("*.py") if "__pycache__" not in p.parts)
+
+
+def test_simulation_sources_discovered() -> None:
+    """Guard: the scan actually walked a non-trivial set of modules."""
+    sources = _python_sources()
+    assert len(sources) > 5
+    names = {p.name for p in sources}
+    assert {"policy_runner.py", "base.py", "benchmark.py"} <= names
+
+
+def test_no_emoji_in_simulation_sources() -> None:
+    """No simulation module may embed emoji codepoints or variation selectors."""
+    offenders: list[str] = []
+    for path in _python_sources():
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            for match in _EMOJI.finditer(line):
+                cp = match.group()
+                offenders.append(
+                    f"{path.relative_to(_PACKAGE_DIR.parent)}:{lineno}: U+{ord(cp[0]):04X} {line.strip()[:80]!r}"
+                )
+    assert not offenders, "emoji found in simulation sources:\n" + "\n".join(offenders)


### PR DESCRIPTION
## Problem

The simulation package embedded decorative emoji in agent-facing strings: tool-result `text` payloads (surfaced to the model) and `logger` calls across `base.py`, `benchmark.py`, `policy_runner.py`, `mujoco/physics.py` and `mujoco/randomization.py`. AGENTS.md forbids emoji in user-facing strings - agents read these payloads programmatically, and emoji are tokenizer noise that render inconsistently across terminals. Several lines also carried orphan `U+FE0F` variation selectors (e.g. the stopwatch glyph is `U+23F1` + `U+FE0F`), which survive a naive base-glyph strip.

42 emoji occurrences across 5 modules, for example:

```
policy_runner.py:  f"\U0001f9e0 {policy} | \U0001f3af {instruction}"   # brain | dart
physics.py:        {"text": "\U0001f4be State '{name}' saved"}          # floppy disk
randomization.py:  "\U0001f3b2 Domain Randomization applied:"            # die
```

## Change

Removes the glyphs (plus their trailing space and any variation selector) while preserving the message text and legitimate math typography (`+/-`, the multiplication sign, and arrows used in comments / numeric output - those are informative, not decorative emoji). No behavior change beyond the string contents.

Before -> after for a `run_policy` rollout summary:

```
- \U0001f9e0 MockPolicy | \U0001f3af wave arm
- \u23f1\ufe0f 3.4s | \U0001f4ca 60 steps | \U0001f550 sim_t=2.040s
+ MockPolicy | wave arm
+ 3.4s | 60 steps | sim_t=2.040s
```

## Tests

Adds `tests/simulation/test_output_strings_no_emoji.py`, which scans every module in the simulation package for emoji codepoints (pictograph / dingbat / symbol / geometric-shape ranges plus `U+FE00-FE0F` variation selectors). It deliberately does **not** require pure ASCII, so legitimate math symbols are allowed. The test fails on the pre-change source (reports all 42 offenders with file:line and codepoint) and passes after the sweep.

Full `MUJOCO_GL=egl` simulation suite (118 tests) passes; ruff check + format and mypy are clean on the touched files.

## Visual artifact

Headless MuJoCo rollout (`run_policy`, SO-101, mock policy, EGL) confirming the cleaned ASCII-only output text shown above:

![rollout](https://github.com/cagataycali/robots/releases/download/harness-artifacts/sim-emoji-strip-rollout.gif)

[MP4](https://github.com/cagataycali/robots/releases/download/harness-artifacts/sim-emoji-strip-rollout.mp4) - 60 frames, 30fps, 480x360. The `run_policy` summary it printed was `isascii() == True`.