### PR TITLE
test(simulation): drop redundant flag range from emoji regex (clears CodeQL py/overly-large-range on main)

### DIFF
--- a/tests/simulation/test_output_strings_no_emoji.py
+++ b/tests/simulation/test_output_strings_no_emoji.py
@@ -26,16 +26,17 @@ import strands_robots.simulation as sim_pkg
 # Intentionally excludes the Mathematical Operators arrows (U+2190-21FF base
 # arrows are allowed in comments) but DOES include emoji-presentation arrows
 # such as U+25B6 (play) and the U+FE00-FE0F variation selectors that turn a
-# plain glyph into an emoji.
+# plain glyph into an emoji. The regional-indicator (flag) block
+# U+1F1E6-1F1FF is not listed separately: it already falls inside the
+# U+1F000-1FAFF range above, and CodeQL flags the duplicate as overlapping.
 _EMOJI = re.compile(
     "["
-    "\U0001f000-\U0001faff"  # supplemental symbols, pictographs, emoticons
+    "\U0001f000-\U0001faff"  # supplemental symbols, pictographs, emoticons, flags
     "\U00002600-\U000027bf"  # misc symbols + dingbats
     "\U00002300-\U000023ff"  # technical (stopwatch, hourglass, etc.)
     "\U00002b00-\U00002bff"  # arrows/stars emoji block
     "\U000025a0-\U000025ff"  # geometric shapes (play/stop emoji bases)
     "\U0000fe00-\U0000fe0f"  # variation selectors (orphan emoji markers)
-    "\U0001f1e6-\U0001f1ff"  # regional indicators (flags)
     "]"
 )
 


### PR DESCRIPTION
## Problem

CodeQL alert [474](https://github.com/strands-labs/robots/security/code-scanning/474) (`py/overly-large-range`, "Overly permissive regular expression range") is **open on `main`**. It points at the emoji-scan regex in `tests/simulation/test_output_strings_no_emoji.py` (merged in #622):

```python
_EMOJI = re.compile(
    "["
    "\U0001f000-\U0001faff"  # supplemental symbols, pictographs, emoticons
    ...
    "\U0001f1e6-\U0001f1ff"  # regional indicators (flags)  <-- subset of the first range
    "]"
)
```

The regional-indicator (flag) block `U+1F1E6-1F1FF` is entirely contained within the `U+1F000-1FAFF` supplementary range already listed first in the character class, so it is a dead/duplicate range. CodeQL flags the overlap.

This fix was prepared on the #622 branch but landed after #622 was already merged, so the alert persists on `main`. This PR clears it.

## Change

Removes the redundant `U+1F1E6-1F1FF` line and annotates the enclosing range to note it covers flags. No behavior change: a regional-indicator pair (e.g. a flag emoji) is still matched via the `U+1F000-1FAFF` range.

## Verification

```python
# flags still caught (subset of first range)
assert _EMOJI.search("\U0001f1ea\U0001f1fa")   # regional-indicator pair
assert _EMOJI.search("\U0001f9e0")             # brain pictograph
assert not _EMOJI.search("a x b +/-")          # math typography still allowed
```

ruff check + format clean on the touched file.