### PR TITLE
feat(tools): add use_lerobot universal LeRobot access tool

### DIFF
--- a/strands_robots/tools/__init__.py
+++ b/strands_robots/tools/__init__.py
@@ -21,6 +21,7 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "pose_tool": (".pose_tool", "pose_tool"),
     "robot_mesh": (".robot_mesh", "robot_mesh"),
     "serial_tool": (".serial_tool", "serial_tool"),
+    "use_lerobot": (".use_lerobot", "use_lerobot"),
 }
 
 __all__ = list(_LAZY_IMPORTS.keys())

--- a/strands_robots/tools/use_lerobot.py
+++ b/strands_robots/tools/use_lerobot.py
@@ -1,0 +1,663 @@
+#!/usr/bin/env python3
+"""
+Universal LeRobot integration - like use_aws wraps boto3.client[*], this wraps lerobot[*].
+
+Instead of hardcoding actions, dynamically access ANY lerobot module, class,
+or function. The agent discovers what's available (including draccus-registered
+robot/teleop/camera/policy configs) and calls it directly.
+
+Highlights
+* **Zero hardcoding** - config choices come from lerobot's own draccus
+  ``ChoiceRegistry.get_known_choices()`` registries, not a static dict.
+* **Full fidelity** - results are serialized without lossy per-item truncation;
+  numpy arrays are summarized structurally and image frames are returned as
+  real Strands ``image`` content blocks (viewable by the model).
+* **Self-describing** - ``__describe__`` introspects any object's signature,
+  methods and docstring.
+
+Usage:
+    # Discover everything (modules + registered robot/teleop/camera/policy choices)
+    use_lerobot(module="__discovery__", method="list_modules")
+
+    # Describe a class (methods + init signature, no call)
+    use_lerobot(module="cameras.opencv.OpenCVCamera", method="__describe__")
+
+    # Find cameras
+    use_lerobot(module="cameras.opencv.OpenCVCamera", method="find_cameras")
+
+    # Get a registered config class by choice name
+    use_lerobot(module="__registry__", method="robots")        # list robot choices
+    use_lerobot(module="__registry__", method="policies")      # list policy choices
+
+    # Get policy class
+    use_lerobot(module="policies.factory", method="get_policy_class",
+                parameters={"name": "act"})
+
+    # Capture a frame -> returned as an IMAGE content block
+    # (instantiate camera elsewhere, or use lerobot_camera tool for full flow)
+"""
+
+import importlib
+import inspect
+import json
+import logging
+import pkgutil
+from typing import Any
+
+from strands import tool
+
+logger = logging.getLogger(__name__)
+
+# Caps chosen to preserve content fully in practice while protecting the
+# context window from pathological blobs. These are deliberately huge compared
+# to the old [:200] - we keep contents "as is" for anything reasonable.
+_MAX_STR = 200_000  # max chars for a single serialized string field
+_MAX_LIST_ITEMS = 1_000  # max items rendered from a list/tuple
+_MAX_DICT_ITEMS = 1_000  # max keys rendered from a dict
+_IMAGE_MAX_DIM = 4096  # arrays larger than this on H or W are still treated as images
+
+
+# Import resolution
+class LeRobotResolveError(Exception):
+    """Raised when a lerobot path cannot be resolved. Carries a hint about
+    whether the path is genuinely missing or failed due to a dependency."""
+
+    def __init__(self, message: str, real_error: Exception | None = None):
+        super().__init__(message)
+        self.real_error = real_error
+
+
+def _import_from_lerobot(module_path: str):
+    """Resolve a dotted path into lerobot to a module / class / function / attr.
+
+    Surfaces the *real* ImportError when a module exists on disk but fails to
+    import (missing optional dep), instead of a misleading generic message.
+    """
+    full_path = f"lerobot.{module_path}" if not module_path.startswith("lerobot.") else module_path
+
+    segments = full_path.split(".")
+    if not segments or segments == [""]:
+        raise LeRobotResolveError(f"Cannot resolve '{module_path}' in lerobot")
+
+    # Walk from the longest importable module prefix down to the shortest. The
+    # first prefix that imports cleanly is the module; remaining segments are
+    # attribute lookups (Class, function, nested attr). If a prefix exists on
+    # disk but its import raises due to a *third-party* dependency, we remember
+    # that real error and surface it rather than a misleading "cannot resolve".
+    last_real_error: Exception | None = None
+    for i in range(len(segments), 0, -1):
+        modname = ".".join(segments[:i])
+        attrs = segments[i:]
+        try:
+            mod = importlib.import_module(modname)
+        except ImportError as e:
+            # Classify: is the *missing* module lerobot's own (genuine not-found)
+            # or a third-party optional dependency (helpful "install extra")?
+            missing = getattr(e, "name", "") or ""
+            is_self_missing = missing == modname or modname.startswith(missing + ".") or missing.startswith("lerobot")
+            if not is_self_missing:
+                # A real third-party dependency is missing -> surface it.
+                last_real_error = e
+            continue
+        except Exception as e:  # non-Import errors during import are real too
+            last_real_error = e
+            continue
+        # Imported OK - now walk attributes
+        obj = mod
+        try:
+            for attr in attrs:
+                obj = getattr(obj, attr)
+            return obj
+        except AttributeError:
+            # Maybe the attr is itself a submodule that needs importing, or the
+            # split point is wrong - keep trying shorter prefixes.
+            continue
+
+    # Nothing resolved. If we saw a real dependency/import error, surface it.
+    if last_real_error is not None:
+        raise LeRobotResolveError(
+            f"'{module_path}' exists but failed to import: {last_real_error}",
+            real_error=last_real_error,
+        )
+    raise LeRobotResolveError(f"Cannot resolve '{module_path}' in lerobot")
+
+
+# Packages whose submodule tree we've already walked this process. The actual
+# module objects are cached by Python in sys.modules; this avoids re-walking the
+# (recursive) package tree on every discovery/registry call.
+_DEEP_IMPORTED: set = set()
+
+
+def _deep_import(pkg_name: str, _seen: set | None = None) -> None:
+    """Recursively import all submodules of a package so that draccus
+    ``register_subclass`` decorators run and populate the choice registries.
+
+    lerobot registers robot/teleop/camera/policy configs lazily at import time,
+    so discovery is empty until the modules are imported. This walks the tree.
+    """
+    _seen = _seen if _seen is not None else _DEEP_IMPORTED
+    if pkg_name in _seen:
+        return
+    _seen.add(pkg_name)
+    try:
+        mod = importlib.import_module(pkg_name)
+    except Exception:
+        return
+    if not hasattr(mod, "__path__"):
+        return
+    for _, sub, _ispkg in pkgutil.iter_modules(mod.__path__):
+        if sub.startswith("_") or sub == "tests":
+            continue
+        _deep_import(f"{pkg_name}.{sub}", _seen)
+
+
+# Registry discovery (the un-hardcoded part)
+# Each entry: choice-name -> (package to deep-import, dotted ChoiceRegistry class)
+_REGISTRIES = {
+    "robots": ("lerobot.robots", "lerobot.robots.config.RobotConfig"),
+    "teleoperators": ("lerobot.teleoperators", "lerobot.teleoperators.config.TeleoperatorConfig"),
+    "cameras": ("lerobot.cameras", "lerobot.cameras.configs.CameraConfig"),
+    "policies": ("lerobot.policies", "lerobot.configs.policies.PreTrainedConfig"),
+}
+
+
+def _get_registry_choices(kind: str) -> dict[str, str]:
+    """Return {choice_name: fully.qualified.ConfigClass} for a registry kind.
+
+    Triggers a deep import first so all subclasses are registered, then reads
+    lerobot's own ``ChoiceRegistry.get_known_choices()`` - no hardcoding.
+    """
+    if kind not in _REGISTRIES:
+        return {}
+    pkg, cls_path = _REGISTRIES[kind]
+    _deep_import(pkg)
+    try:
+        cls = _import_from_lerobot(cls_path)
+    except Exception as e:  # pragma: no cover
+        logger.debug(f"registry {kind}: cannot import {cls_path}: {e}")
+        return {}
+    if not hasattr(cls, "get_known_choices"):
+        return {}
+    out: dict[str, str] = {}
+    try:
+        for name, klass in cls.get_known_choices().items():
+            out[name] = f"{klass.__module__}.{klass.__qualname__}"
+    except Exception as e:  # pragma: no cover
+        logger.debug(f"registry {kind}: get_known_choices failed: {e}")
+    return out
+
+
+def _discover_modules() -> dict[str, Any]:
+    """Discover lerobot submodules and ALL registered config choices dynamically."""
+    try:
+        import lerobot
+    except ImportError:
+        return {"error": "lerobot not installed"}
+
+    result: dict[str, Any] = {"packages": [], "modules": [], "registries": {}}
+
+    for _importer, modname, ispkg in pkgutil.iter_modules(lerobot.__path__):
+        if modname.startswith("_") or modname == "tests":
+            continue
+        (result["packages"] if ispkg else result["modules"]).append(modname)
+
+    # Dynamic registry discovery - this replaces the old hardcoded key_apis
+    for kind in _REGISTRIES:
+        result["registries"][kind] = _get_registry_choices(kind)
+
+    # A few stable, genuinely useful entry points (functions/paths, not configs).
+    # These are call targets, not enumerable via a registry.
+    result["entry_points"] = {
+        "cameras.opencv.OpenCVCamera.find_cameras": "Discover connected cameras",
+        "datasets.lerobot_dataset.LeRobotDataset": "Dataset create/load/push/pull",
+        "datasets.lerobot_dataset.LeRobotDataset.create": "Create a new dataset",
+        "policies.factory.get_policy_class": "Get policy class by registered name",
+        "policies.factory.make_policy": "Build a policy instance from config",
+        "robots.utils.make_robot_from_config": "Instantiate a robot from its config",
+        "teleoperators.utils.make_teleoperator_from_config": "Instantiate a teleoperator",
+        "scripts.lerobot_train.train": "Train a policy on a dataset",
+        "model.kinematics.RobotKinematics": "Forward/inverse kinematics",
+        "envs.factory.make_env": "Create a gym environment",
+        "utils.constants.HF_LEROBOT_CALIBRATION": "Calibration directory path",
+    }
+    return result
+
+
+# Introspection
+def _describe_object(obj) -> dict[str, Any]:
+    """Describe a Python object - methods, signature, docstring (full, untruncated)."""
+    info: dict[str, Any] = {
+        "type": type(obj).__name__,
+        "name": getattr(obj, "__name__", str(obj)),
+    }
+
+    if inspect.isclass(obj):
+        # Use getattr_static so we never trigger descriptor/property side-effects
+        # (some lerobot classes have properties that touch hardware on access).
+        methods, class_methods, properties = [], [], []
+        for m in dir(obj):
+            if m.startswith("_"):
+                continue
+            static_attr = inspect.getattr_static(obj, m, None)
+            if isinstance(static_attr, (classmethod, staticmethod)):
+                class_methods.append(m)
+            elif isinstance(static_attr, property):
+                properties.append(m)
+            elif callable(static_attr):
+                methods.append(m)
+        info["methods"] = methods
+        info["class_methods"] = class_methods
+        if properties:
+            info["properties"] = properties
+        if getattr(obj, "__init__", None) and obj.__init__.__doc__:
+            info["init_doc"] = obj.__init__.__doc__
+        try:
+            sig = inspect.signature(obj.__init__)
+            info["init_params"] = [p for p in sig.parameters if p != "self"]
+        except (ValueError, TypeError):
+            pass
+
+    elif callable(obj):
+        try:
+            sig = inspect.signature(obj)
+            info["params"] = {
+                name: {
+                    "default": (str(p.default) if p.default is not inspect.Parameter.empty else "REQUIRED"),
+                    "annotation": (str(p.annotation) if p.annotation is not inspect.Parameter.empty else None),
+                }
+                for name, p in sig.parameters.items()
+            }
+        except (ValueError, TypeError):
+            pass
+        if obj.__doc__:
+            info["doc"] = obj.__doc__
+
+    elif inspect.ismodule(obj):
+        info["public_names"] = [n for n in dir(obj) if not n.startswith("_")]
+        if obj.__doc__:
+            info["doc"] = obj.__doc__
+
+    else:
+        info["value"] = str(obj)
+
+    return info
+
+
+# Image detection + encoding -> Strands content blocks
+def _is_image_array(arr) -> bool:
+    """Heuristic: is this numpy array an image frame?
+
+    Accepts HxW (grayscale) or HxWxC (C in {1,3,4}) uint8/uint16/float arrays
+    with sane spatial dims.
+    """
+    try:
+        import numpy as np
+    except ImportError:
+        return False
+    if not isinstance(arr, np.ndarray):
+        return False
+    if arr.ndim == 2:
+        h, w = arr.shape
+        c = 1
+    elif arr.ndim == 3:
+        h, w, c = arr.shape
+        if c not in (1, 3, 4):
+            return False
+    else:
+        return False
+    return 2 <= h <= _IMAGE_MAX_DIM and 2 <= w <= _IMAGE_MAX_DIM
+
+
+def _array_to_image_block(arr) -> dict[str, Any] | None:
+    """Encode a numpy image array to a Strands ``image`` content block (PNG/JPEG bytes).
+
+    Returns None if cv2 is unavailable or encoding fails. Assumes RGB input
+    (lerobot cameras default to RGB) and converts to BGR for cv2 encoding.
+    """
+    try:
+        import cv2
+        import numpy as np
+    except ImportError:
+        return None
+
+    try:
+        frame = arr
+        # Normalize float images to uint8
+        if frame.dtype != np.uint8:
+            if np.issubdtype(frame.dtype, np.floating):
+                fmax = float(frame.max()) if frame.size else 1.0
+                scale = 255.0 if fmax <= 1.0 else (255.0 / fmax if fmax > 0 else 1.0)
+                frame = np.clip(frame * scale, 0, 255).astype(np.uint8)
+            else:
+                frame = np.clip(frame, 0, 255).astype(np.uint8)
+
+        # RGB(A)->BGR for cv2
+        if frame.ndim == 3 and frame.shape[2] == 3:
+            enc_src = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
+        elif frame.ndim == 3 and frame.shape[2] == 4:
+            enc_src = cv2.cvtColor(frame, cv2.COLOR_RGBA2BGRA)
+        else:
+            enc_src = frame  # grayscale
+
+        # Choose codec: JPEG for large opaque frames (far smaller in-context),
+        # PNG for small frames, grayscale, or anything with an alpha channel.
+        h, w = enc_src.shape[:2]
+        has_alpha = enc_src.ndim == 3 and enc_src.shape[2] == 4
+        use_jpeg = (not has_alpha) and (h * w) > (320 * 240)
+        if use_jpeg:
+            ok, buf = cv2.imencode(".jpg", enc_src, [cv2.IMWRITE_JPEG_QUALITY, 85])
+            fmt = "jpeg"
+            if not ok:  # fall back to PNG if JPEG encoding refuses
+                ok, buf = cv2.imencode(".png", enc_src)
+                fmt = "png"
+        else:
+            ok, buf = cv2.imencode(".png", enc_src)
+            fmt = "png"
+        if not ok:
+            return None
+        return {"image": {"format": fmt, "source": {"bytes": buf.tobytes()}}}
+    except Exception as e:  # pragma: no cover
+        logger.debug(f"image encode failed: {e}")
+        return None
+
+
+# Result serialization (full fidelity, image-aware)
+def _collect_images(result: Any, _blocks: list[dict[str, Any]], _depth: int = 0) -> None:
+    """Walk a result and collect any image arrays as Strands image content blocks.
+
+    Looks at the top-level value, and one level into lists/tuples/dicts (e.g. a
+    dict of {camera_name: frame} or a list of frames).
+    """
+    if _depth > 2 or len(_blocks) >= 16:
+        return
+    if _is_image_array(result):
+        blk = _array_to_image_block(result)
+        if blk:
+            _blocks.append(blk)
+        return
+    if isinstance(result, (list, tuple)):
+        for item in result[:16]:
+            _collect_images(item, _blocks, _depth + 1)
+    elif isinstance(result, dict):
+        for v in list(result.values())[:16]:
+            _collect_images(v, _blocks, _depth + 1)
+
+
+def _serialize_value(value: Any, _seen: set | None = None, _depth: int = 0) -> Any:
+    """Recursively convert a value to a JSON-friendly structure, full fidelity.
+
+    Unlike the old version, this does NOT truncate individual items to 200 chars.
+    Strings are kept whole (up to a large safety cap); numpy arrays are described
+    structurally (shape/dtype) since raw pixel dumps are useless as text.
+    """
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+
+    # Depth guard - prevent runaway nesting blowing the stack.
+    if _depth > 50:
+        return "...[max depth exceeded]"
+    _seen = _seen if _seen is not None else set()
+    if isinstance(value, str):
+        return value if len(value) <= _MAX_STR else value[:_MAX_STR] + f"...[+{len(value) - _MAX_STR} chars]"
+
+    if isinstance(value, (bytes, bytearray)):
+        return {"__bytes__": True, "length": len(value), "preview_hex": value[:64].hex()}
+
+    # numpy arrays -> structural summary (image bytes handled separately)
+    try:
+        import numpy as np
+
+        if isinstance(value, np.ndarray):
+            summary = {"__ndarray__": True, "shape": list(value.shape), "dtype": str(value.dtype)}
+            if _is_image_array(value):
+                summary["is_image"] = True
+                summary["note"] = "returned as an image content block"
+            elif value.size <= 64:
+                summary["values"] = value.tolist()
+            return summary
+        if isinstance(value, (np.integer,)):
+            return int(value)
+        if isinstance(value, (np.floating,)):
+            return float(value)
+    except ImportError:
+        pass
+
+    if isinstance(value, (list, tuple)):
+        vid = id(value)
+        if vid in _seen:
+            return "...[circular ref]"
+        _seen = _seen | {vid}
+        items = [_serialize_value(v, _seen, _depth + 1) for v in value[:_MAX_LIST_ITEMS]]
+        if len(value) > _MAX_LIST_ITEMS:
+            items.append(f"...[+{len(value) - _MAX_LIST_ITEMS} more items]")
+        return items
+
+    if isinstance(value, dict):
+        vid = id(value)
+        if vid in _seen:
+            return "...[circular ref]"
+        _seen = _seen | {vid}
+        out = {}
+        for i, (k, v) in enumerate(value.items()):
+            if i >= _MAX_DICT_ITEMS:
+                out["__truncated__"] = f"+{len(value) - _MAX_DICT_ITEMS} more keys"
+                break
+            out[str(k)] = _serialize_value(v, _seen, _depth + 1)
+        return out
+
+    # dataclass / config objects -> dict of fields
+    if hasattr(value, "__dataclass_fields__"):
+        try:
+            from dataclasses import asdict
+
+            return {"__dataclass__": type(value).__name__, **_serialize_value(asdict(value), _seen, _depth + 1)}
+        except Exception:
+            pass
+
+    # Fallback: describe objects (classes/instances/functions/modules)
+    if inspect.isclass(value) or inspect.isfunction(value) or inspect.ismethod(value) or inspect.ismodule(value):
+        return _describe_object(value)
+
+    # Last resort - full repr (capped)
+    s = str(value)
+    return s if len(s) <= _MAX_STR else s[:_MAX_STR] + f"...[+{len(s) - _MAX_STR} chars]"
+
+
+def _serialize_result(result: Any) -> str:
+    """Convert any result to a full-fidelity JSON string (no per-item 200-char cap)."""
+    try:
+        return json.dumps(_serialize_value(result), indent=2, default=str)
+    except Exception as e:  # pragma: no cover
+        return f"<unserializable {type(result).__name__}: {e}>"
+
+
+# The tool
+@tool
+def use_lerobot(
+    module: str = "__discovery__",
+    method: str = "list_modules",
+    parameters: dict[str, Any] = None,
+    label: str = "",
+) -> dict[str, Any]:
+    """Universal LeRobot access - call any lerobot module, class, or function dynamically.
+
+    Like use_aws wraps boto3.client[service].operation(**params), this wraps
+    lerobot[module].method(**params). The agent discovers available APIs and
+    registered configs (robots/teleoperators/cameras/policies) directly from
+    lerobot's own draccus registries - nothing is hardcoded.
+
+    Results are serialized at full fidelity (no lossy truncation), and any image
+    frames (numpy HxW / HxWxC arrays) returned by a call are emitted as proper
+    Strands ``image`` content blocks so the model can actually see them.
+
+    Args:
+        module: Dotted path into lerobot (e.g. "cameras.opencv.OpenCVCamera",
+                "datasets.lerobot_dataset.LeRobotDataset", "policies.factory").
+                Special values:
+                  "__discovery__" - explore modules + all registered configs.
+                  "__registry__"  - list a single registry; pass its name as
+                                     ``method`` (robots|teleoperators|cameras|policies).
+        method: Method/function/attribute name to call or read. Special values:
+                  "list_modules" - discovery output (with module="__discovery__").
+                  "__describe__" - inspect the object without calling it.
+        parameters: Dict of kwargs to pass to the method. Omit for no-arg calls.
+        label: Human-readable description of what this call does.
+
+    Returns:
+        Dict with status and content; content may include text + image blocks.
+
+    Examples:
+        # Discover everything (modules + registered choices)
+        use_lerobot(module="__discovery__", method="list_modules")
+
+        # List just the robot choices (dynamic, from registry)
+        use_lerobot(module="__registry__", method="robots")
+
+        # Describe a class
+        use_lerobot(module="cameras.opencv.OpenCVCamera", method="__describe__")
+
+        # Find cameras
+        use_lerobot(module="cameras.opencv.OpenCVCamera", method="find_cameras")
+
+        # Get a policy class
+        use_lerobot(module="policies.factory", method="get_policy_class",
+                    parameters={"name": "act"})
+
+        # Read a calibration path constant
+        use_lerobot(module="utils.constants", method="HF_LEROBOT_CALIBRATION")
+    """
+    params = parameters or {}
+
+    try:
+        # Discovery mode
+        if module == "__discovery__":
+            discovery = _discover_modules()
+            if "error" in discovery:
+                return {"status": "error", "content": [{"text": f"Error: {discovery['error']}"}]}
+
+            lines = ["LeRobot API Discovery\n"]
+            lines.append(f"Packages: {', '.join(discovery['packages'])}")
+            lines.append(f"Modules: {', '.join(discovery['modules'])}")
+
+            for kind, choices in discovery.get("registries", {}).items():
+                lines.append(f"\n{kind} ({len(choices)}):")
+                for name, cls in choices.items():
+                    lines.append(f"  - {name}  ->  {cls}")
+
+            lines.append("\nEntry points (callables / paths):")
+            for path, desc in discovery.get("entry_points", {}).items():
+                lines.append(f"  - lerobot.{path}\n    {desc}")
+
+            lines.append("\nUsage:")
+            lines.append('  use_lerobot(module="__registry__", method="robots")')
+            lines.append('  use_lerobot(module="cameras.opencv.OpenCVCamera", method="find_cameras")')
+            lines.append(
+                '  use_lerobot(module="policies.factory", method="get_policy_class", parameters={"name":"act"})'
+            )
+
+            return {"status": "success", "content": [{"text": "\n".join(lines)}]}
+
+        # Single-registry listing
+        if module == "__registry__":
+            kind = method or "robots"
+            choices = _get_registry_choices(kind)
+            if not choices:
+                return {
+                    "status": "error",
+                    "content": [
+                        {"text": (f"Unknown or empty registry '{kind}'. Valid: {', '.join(_REGISTRIES.keys())}")}
+                    ],
+                }
+            lines = [f"lerobot {kind} registry ({len(choices)} choices):\n"]
+            for name, cls in choices.items():
+                lines.append(f"  - {name}  ->  {cls}")
+            return {"status": "success", "content": [{"text": "\n".join(lines)}]}
+
+        # Resolve the target object
+        target = _import_from_lerobot(module)
+
+        # Describe mode (inspect without calling)
+        if method == "__describe__":
+            info = _describe_object(target)
+            return {"status": "success", "content": [{"text": f"{module}\n{json.dumps(info, indent=2, default=str)}"}]}
+
+        # Get the method/attribute
+        if method:
+            if hasattr(target, method):
+                target = getattr(target, method)
+            else:
+                available = [a for a in dir(target) if not a.startswith("_")]
+                return {
+                    "status": "error",
+                    "content": [{"text": (f"'{method}' not found on {module}\nAvailable: {', '.join(available)}")}],
+                }
+
+        # If target is not callable, just return its value
+        if not callable(target):
+            return {"status": "success", "content": [{"text": f"{module}.{method} = {_serialize_result(target)}"}]}
+
+        # Call it
+        if label:
+            logger.info(f" LeRobot: {label} - {module}.{method}({list(params.keys())})")
+
+        result = target(**params)
+
+        # Collect image blocks (full-frame, model-viewable)
+        image_blocks: list[dict[str, Any]] = []
+        _collect_images(result, image_blocks)
+
+        serialized = _serialize_result(result)
+        content: list[dict[str, Any]] = [{"text": f"{module}.{method}() ->\n{serialized}"}]
+        if image_blocks:
+            content[0]["text"] += f"\n\n({len(image_blocks)} image block(s) attached below)"
+            content.extend(image_blocks)
+
+        return {"status": "success", "content": content}
+
+    except LeRobotResolveError as e:
+        # Distinguish "doesn't exist" from "exists but a dependency is missing".
+        if e.real_error is not None:
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            f"{e}\n\n"
+                            f"This path exists in lerobot but an optional dependency is missing. "
+                            f"Install the relevant extra, e.g.:\n"
+                            f"  uv pip install 'lerobot[dataset]'   # datasets / training\n"
+                            f"  uv pip install 'lerobot[feetech]'   # SO-100/101 motors"
+                        )
+                    }
+                ],
+            }
+        return {
+            "status": "error",
+            "content": [{"text": (f'{e}\n\nTip: use module="__discovery__" to list valid modules and registries.')}],
+        }
+
+    except ImportError as e:
+        return {"status": "error", "content": [{"text": f"Import error: {e}\n\nInstall: pip install lerobot"}]}
+
+    except TypeError as e:
+        try:
+            sig = inspect.signature(target)
+            param_info = {name: str(p) for name, p in sig.parameters.items()}
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            f"TypeError: {e}\n\n"
+                            f"Expected signature for {module}.{method}:\n"
+                            f"{json.dumps(param_info, indent=2)}"
+                        )
+                    }
+                ],
+            }
+        except Exception:
+            return {"status": "error", "content": [{"text": f"TypeError: {e}"}]}
+
+    except Exception as e:
+        logger.error(f"use_lerobot({module}.{method}) failed: {e}", exc_info=True)
+        return {"status": "error", "content": [{"text": f"{type(e).__name__}: {e}"}]}

--- a/strands_robots/tools/use_lerobot.py
+++ b/strands_robots/tools/use_lerobot.py
@@ -255,6 +255,8 @@ def _describe_object(obj) -> dict[str, Any]:
             sig = inspect.signature(obj.__init__)
             info["init_params"] = [p for p in sig.parameters if p != "self"]
         except (ValueError, TypeError):
+            # Builtins / C-extension types expose no introspectable signature;
+            # skip init_params rather than failing the describe call.
             pass
 
     elif callable(obj):
@@ -268,6 +270,8 @@ def _describe_object(obj) -> dict[str, Any]:
                 for name, p in sig.parameters.items()
             }
         except (ValueError, TypeError):
+            # Builtins / C-extension callables expose no introspectable
+            # signature; describe them without a params map.
             pass
         if obj.__doc__:
             info["doc"] = obj.__doc__
@@ -298,7 +302,6 @@ def _is_image_array(arr) -> bool:
         return False
     if arr.ndim == 2:
         h, w = arr.shape
-        c = 1
     elif arr.ndim == 3:
         h, w, c = arr.shape
         if c not in (1, 3, 4):
@@ -326,7 +329,7 @@ def _array_to_image_block(arr) -> dict[str, Any] | None:
         if frame.dtype != np.uint8:
             if np.issubdtype(frame.dtype, np.floating):
                 fmax = float(frame.max()) if frame.size else 1.0
-                scale = 255.0 if fmax <= 1.0 else (255.0 / fmax if fmax > 0 else 1.0)
+                scale = 255.0 if fmax <= 1.0 else 255.0 / fmax
                 frame = np.clip(frame * scale, 0, 255).astype(np.uint8)
             else:
                 frame = np.clip(frame, 0, 255).astype(np.uint8)
@@ -420,6 +423,7 @@ def _serialize_value(value: Any, _seen: set | None = None, _depth: int = 0) -> A
         if isinstance(value, (np.floating,)):
             return float(value)
     except ImportError:
+        # numpy absent: fall through to the plain-Python serialization below.
         pass
 
     if isinstance(value, (list, tuple)):
@@ -476,7 +480,7 @@ def _serialize_result(result: Any) -> str:
 def use_lerobot(
     module: str = "__discovery__",
     method: str = "list_modules",
-    parameters: dict[str, Any] = None,
+    parameters: dict[str, Any] | None = None,
     label: str = "",
 ) -> dict[str, Any]:
     """Universal LeRobot access - call any lerobot module, class, or function dynamically.

--- a/tests/tools/test_tools_lazy_import.py
+++ b/tests/tools/test_tools_lazy_import.py
@@ -35,6 +35,7 @@ def test_all_lists_every_lazy_import_name() -> None:
         "pose_tool",
         "robot_mesh",
         "serial_tool",
+        "use_lerobot",
     }
 
 

--- a/tests/tools/test_use_lerobot.py
+++ b/tests/tools/test_use_lerobot.py
@@ -29,10 +29,9 @@ import numpy as np
 import pytest
 
 import strands_robots.tools.use_lerobot as M
-from strands_robots.tools.use_lerobot import use_lerobot
 
 # The tool is wrapped by the Strands @tool decorator; call the raw function.
-_fn = use_lerobot.__wrapped__
+_fn = getattr(M.use_lerobot, "__wrapped__", None) or M.use_lerobot
 
 pytest.importorskip("lerobot", reason="use_lerobot requires the lerobot package")
 
@@ -221,6 +220,7 @@ def test_serializer_handles_numpy_scalars() -> None:
 
 def test_serializer_summarizes_large_arrays_structurally() -> None:
     out = M._serialize_value(np.zeros((2, 3, 64, 64)))
+    assert isinstance(out, dict)
     assert out["__ndarray__"] is True
     assert out["shape"] == [2, 3, 64, 64]
     # A 4D tensor is not pixel-dumped as text.
@@ -283,8 +283,12 @@ def test_small_frame_and_alpha_use_png() -> None:
     pytest.importorskip("cv2")
     small = (np.random.rand(100, 100, 3) * 255).astype(np.uint8)
     rgba = (np.random.rand(480, 640, 4) * 255).astype(np.uint8)
-    assert M._array_to_image_block(small)["image"]["format"] == "png"
-    assert M._array_to_image_block(rgba)["image"]["format"] == "png"
+    small_block = M._array_to_image_block(small)
+    rgba_block = M._array_to_image_block(rgba)
+    assert small_block is not None
+    assert rgba_block is not None
+    assert small_block["image"]["format"] == "png"
+    assert rgba_block["image"]["format"] == "png"
 
 
 def test_collect_images_finds_frames_in_dict() -> None:

--- a/tests/tools/test_use_lerobot.py
+++ b/tests/tools/test_use_lerobot.py
@@ -1,0 +1,313 @@
+"""Behavior tests for the ``use_lerobot`` universal LeRobot access tool.
+
+``use_lerobot`` is to ``lerobot`` what ``use_aws`` is to boto3: a single
+dispatcher that resolves any dotted path into the lerobot package and either
+describes or calls it, with config choices discovered dynamically from
+lerobot's own draccus ``ChoiceRegistry`` registries (never hardcoded).
+
+These tests pin the contracts that make the tool trustworthy:
+
+1. Every user-facing ``text`` field is plain ASCII (the project's no-emoji rule).
+2. Import resolution distinguishes three failure modes precisely:
+   genuinely-missing paths, paths that exist but need an optional dependency,
+   and attribute-not-found on a resolved object.
+3. The serializer is total -- it never raises on circular references, runaway
+   nesting, bytes, numpy scalars/arrays, or objects with a hostile ``__repr__``.
+4. Introspection never triggers descriptor/property side effects.
+5. Image arrays become real Strands ``image`` content blocks with a sane codec.
+
+All tests are hardware-free and do not require the optional ``lerobot[dataset]``
+extra; the missing-dependency path is asserted precisely *because* it is absent.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+import numpy as np
+import pytest
+
+import strands_robots.tools.use_lerobot as M
+from strands_robots.tools.use_lerobot import use_lerobot
+
+# The tool is wrapped by the Strands @tool decorator; call the raw function.
+_fn = use_lerobot.__wrapped__
+
+pytest.importorskip("lerobot", reason="use_lerobot requires the lerobot package")
+
+
+# ----------------------------------------------------------------------------
+# helpers
+# ----------------------------------------------------------------------------
+def _texts(result: dict[str, Any]) -> str:
+    """Concatenate all content ``text`` fields from a tool result."""
+    return "\n".join(item.get("text", "") for item in result.get("content", []) if "text" in item)
+
+
+def _assert_ascii(text: str) -> None:
+    """Fail if any character is outside the ASCII range."""
+    offenders = {hex(ord(c)) for c in text if ord(c) > 127}
+    assert not offenders, f"non-ASCII characters in tool output: {offenders}"
+
+
+def _images(result: dict[str, Any]) -> list[dict[str, Any]]:
+    return [item["image"] for item in result.get("content", []) if "image" in item]
+
+
+# ----------------------------------------------------------------------------
+# discovery + registries
+# ----------------------------------------------------------------------------
+def test_discovery_lists_packages_and_registries() -> None:
+    """Discovery enumerates packages and at least the four config registries."""
+    result = _fn(module="__discovery__", method="list_modules")
+    assert result["status"] == "success"
+    text = _texts(result)
+    _assert_ascii(text)
+    assert "LeRobot API Discovery" in text
+    for kind in ("robots", "teleoperators", "cameras", "policies"):
+        assert kind in text
+
+
+def test_registry_listing_is_dynamic_not_hardcoded() -> None:
+    """A registry listing reflects lerobot's own registered choices."""
+    result = _fn(module="__registry__", method="robots")
+    assert result["status"] == "success"
+    text = _texts(result)
+    _assert_ascii(text)
+    assert "registry" in text
+    # so100/so101 are stable, long-lived SO-arm choices.
+    assert "so100_follower" in text or "so101_follower" in text
+
+
+def test_unknown_registry_reports_valid_kinds() -> None:
+    result = _fn(module="__registry__", method="totally_not_a_registry")
+    assert result["status"] == "error"
+    text = _texts(result)
+    _assert_ascii(text)
+    assert "Valid:" in text
+    assert "robots" in text and "policies" in text
+
+
+def test_empty_registry_method_defaults_to_robots() -> None:
+    """An empty registry method falls back to the robots registry."""
+    result = _fn(module="__registry__", method="")
+    assert result["status"] == "success"
+    assert "robots" in _texts(result)
+
+
+# ----------------------------------------------------------------------------
+# import resolution -- the three failure modes
+# ----------------------------------------------------------------------------
+def test_genuinely_missing_path_is_cannot_resolve() -> None:
+    """A path with no lerobot module behind it -> 'Cannot resolve' + a tip."""
+    result = _fn(module="does.not.exist", method="foo")
+    assert result["status"] == "error"
+    text = _texts(result)
+    _assert_ascii(text)
+    assert "Cannot resolve" in text
+    assert "__discovery__" in text  # actionable tip
+    # Must NOT misdirect the user to install an optional extra.
+    assert "lerobot[dataset]" not in text
+
+
+def test_fake_lerobot_submodule_is_cannot_resolve() -> None:
+    result = _fn(module="robots.totally_fake_robot", method="x")
+    assert result["status"] == "error"
+    assert "Cannot resolve" in _texts(result)
+
+
+def test_missing_optional_dependency_surfaces_real_error() -> None:
+    """A real path needing an absent extra surfaces the dependency, not a
+    misleading 'cannot resolve'. ``datasets`` is intentionally not installed."""
+    if importlib.util.find_spec("datasets") is not None:
+        pytest.skip("datasets extra is installed; cannot assert the missing-dep path")
+    result = _fn(module="datasets.lerobot_dataset.LeRobotDataset", method="__describe__")
+    assert result["status"] == "error"
+    text = _texts(result)
+    _assert_ascii(text)
+    assert "exists but failed to import" in text
+    assert "lerobot[dataset]" in text  # the actionable extra
+
+
+def test_attribute_not_found_lists_available() -> None:
+    """A bad method on a resolved module lists real alternatives."""
+    result = _fn(module="policies.factory", method="definitely_not_here")
+    assert result["status"] == "error"
+    text = _texts(result)
+    _assert_ascii(text)
+    assert "not found" in text
+    assert "Available:" in text
+
+
+# ----------------------------------------------------------------------------
+# calling + signatures
+# ----------------------------------------------------------------------------
+def test_call_with_params_succeeds() -> None:
+    result = _fn(
+        module="policies.factory",
+        method="get_policy_class",
+        parameters={"name": "act"},
+    )
+    assert result["status"] == "success"
+    _assert_ascii(_texts(result))
+
+
+def test_missing_required_arg_reports_signature() -> None:
+    """A TypeError from a bad call surfaces the expected signature."""
+    result = _fn(module="policies.factory", method="get_policy_class")
+    assert result["status"] == "error"
+    text = _texts(result)
+    _assert_ascii(text)
+    assert "TypeError" in text
+    assert "name" in text  # the missing parameter is named
+
+
+def test_read_constant_attribute() -> None:
+    result = _fn(module="utils.constants", method="HF_LEROBOT_CALIBRATION")
+    assert result["status"] == "success"
+    _assert_ascii(_texts(result))
+
+
+# ----------------------------------------------------------------------------
+# introspection -- describe without side effects
+# ----------------------------------------------------------------------------
+def test_describe_separates_properties_from_methods() -> None:
+    """``__describe__`` classifies properties, class methods, and instance
+    methods distinctly, using static lookup (no descriptor side effects)."""
+    import json
+
+    result = _fn(module="cameras.opencv.OpenCVCamera", method="__describe__")
+    assert result["status"] == "success"
+    text = _texts(result)
+    _assert_ascii(text)
+    info = json.loads(text.split("\n", 1)[1])
+    # is_connected is a property on the camera class, not a callable method.
+    assert "is_connected" in info.get("properties", [])
+    assert "is_connected" not in info.get("methods", [])
+    # find_cameras is a classmethod; it should not be double-listed as a method.
+    assert "find_cameras" in info.get("class_methods", [])
+    assert "find_cameras" not in info.get("methods", [])
+
+
+# ----------------------------------------------------------------------------
+# serializer -- totality under hostile input
+# ----------------------------------------------------------------------------
+def test_serializer_handles_circular_dict() -> None:
+    d: dict[str, Any] = {}
+    d["self"] = d
+    out = M._serialize_result(d)
+    assert "circular ref" in out
+
+
+def test_serializer_handles_circular_list() -> None:
+    lst: list[Any] = []
+    lst.append(lst)
+    assert "circular ref" in M._serialize_result(lst)
+
+
+def test_serializer_handles_bytes_structurally() -> None:
+    out = M._serialize_value(b"\x00\x01\x02hello")
+    assert out["__bytes__"] is True
+    assert out["length"] == 8
+    assert out["preview_hex"].startswith("000102")
+
+
+def test_serializer_handles_numpy_scalars() -> None:
+    out = M._serialize_value({"i": np.int64(5), "f": np.float32(1.5)})
+    assert out["i"] == 5
+    assert out["f"] == pytest.approx(1.5)
+
+
+def test_serializer_summarizes_large_arrays_structurally() -> None:
+    out = M._serialize_value(np.zeros((2, 3, 64, 64)))
+    assert out["__ndarray__"] is True
+    assert out["shape"] == [2, 3, 64, 64]
+    # A 4D tensor is not pixel-dumped as text.
+    assert "values" not in out
+
+
+def test_serializer_survives_hostile_repr() -> None:
+    class Hostile:
+        def __repr__(self) -> str:
+            raise RuntimeError("boom")
+
+    # Must not raise -- the tool stays alive even on pathological objects.
+    out = M._serialize_result({"x": Hostile()})
+    assert isinstance(out, str)
+
+
+def test_serializer_depth_guard() -> None:
+    """Deeply nested structures terminate rather than blowing the stack."""
+    node: dict[str, Any] = {}
+    cur = node
+    for _ in range(200):
+        nxt: dict[str, Any] = {}
+        cur["next"] = nxt
+        cur = nxt
+    out = M._serialize_result(node)
+    assert "max depth exceeded" in out
+
+
+# ----------------------------------------------------------------------------
+# image detection + encoding
+# ----------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "shape,expected",
+    [
+        ((100, 100, 3), True),  # RGB
+        ((100, 100), True),  # grayscale
+        ((100, 100, 4), True),  # RGBA
+        ((1, 1, 3), False),  # too small
+        ((10, 10, 2), False),  # invalid channel count
+        ((2, 3, 64, 64), False),  # 4D tensor, not an image
+    ],
+)
+def test_image_detection_heuristic(shape: tuple[int, ...], expected: bool) -> None:
+    arr = np.zeros(shape, dtype=np.uint8)
+    assert M._is_image_array(arr) is expected
+
+
+def test_large_rgb_frame_encodes_as_jpeg() -> None:
+    """Large opaque frames use JPEG (compact in-context)."""
+    pytest.importorskip("cv2")
+    frame = (np.random.rand(480, 640, 3) * 255).astype(np.uint8)
+    block = M._array_to_image_block(frame)
+    assert block is not None
+    assert block["image"]["format"] == "jpeg"
+    assert block["image"]["source"]["bytes"]
+
+
+def test_small_frame_and_alpha_use_png() -> None:
+    """Small frames and anything with alpha stay PNG (lossless / alpha-safe)."""
+    pytest.importorskip("cv2")
+    small = (np.random.rand(100, 100, 3) * 255).astype(np.uint8)
+    rgba = (np.random.rand(480, 640, 4) * 255).astype(np.uint8)
+    assert M._array_to_image_block(small)["image"]["format"] == "png"
+    assert M._array_to_image_block(rgba)["image"]["format"] == "png"
+
+
+def test_collect_images_finds_frames_in_dict() -> None:
+    """Images nested one level inside a dict (camera_name -> frame) are found."""
+    pytest.importorskip("cv2")
+    frames = {
+        "front": (np.random.rand(64, 64, 3) * 255).astype(np.uint8),
+        "wrist": (np.random.rand(64, 64, 3) * 255).astype(np.uint8),
+        "meta": "not an image",
+    }
+    blocks: list[dict[str, Any]] = []
+    M._collect_images(frames, blocks)
+    assert len(blocks) == 2
+
+
+# ----------------------------------------------------------------------------
+# deep-import cache
+# ----------------------------------------------------------------------------
+def test_deep_import_is_cached() -> None:
+    """A second deep import of the same package is a no-op (cache hit)."""
+    M._DEEP_IMPORTED.discard("lerobot.policies")
+    M._deep_import("lerobot.policies")
+    assert "lerobot.policies" in M._DEEP_IMPORTED
+    # Idempotent: calling again must not raise and the marker persists.
+    M._deep_import("lerobot.policies")
+    assert "lerobot.policies" in M._DEEP_IMPORTED


### PR DESCRIPTION
## Summary

Adds `use_lerobot` — a single dispatcher tool that resolves any dotted path into the `lerobot` package and either **describes** or **calls** it. It's the LeRobot analogue of `use_aws` for boto3.

Config choices (robots / teleoperators / cameras / policies) are discovered dynamically from lerobot's own draccus `ChoiceRegistry` registries, so **nothing is hardcoded** — the tool stays correct as lerobot adds new hardware/policies upstream.

## Highlights

- **Zero hardcoding** — registries read from `get_known_choices()` at runtime.
- **Precise import resolution** — distinguishes genuinely-missing paths from paths that exist but need an optional extra (e.g. `lerobot[dataset]`), surfacing the real dependency error instead of a misleading "not found".
- **Total serializer** — never raises on circular refs, deep nesting, bytes, numpy scalars/arrays, or hostile `__repr__`. Image frames become real Strands image content blocks (JPEG for large opaque frames, PNG for small/grayscale/alpha).
- **Side-effect-free introspection** via `getattr_static` (won't trigger hardware-touching properties); separates properties / classmethods.
- **Process-level deep-import cache** — discovery/registry calls are O(1) on repeat.
- **ASCII-only** output and source, matching the project no-emoji rule.

## Tests

29 hardware-free behavior tests covering:
- dynamic discovery from registries
- the three import-failure modes (missing path, missing extra, genuine error)
- serializer totality (cycles, bytes, numpy, bad `__repr__`)
- side-effect-free introspection
- image codec selection (JPEG vs PNG)

Lazy-import roster contract (`test_tools_lazy_import.py`) updated for the new tool.

## Quality gate

- `ruff check` — passed
- `ruff format --check` — clean
- full tool test suite — **30 passed**

## Files

| File | Change |
|------|--------|
| `strands_robots/tools/use_lerobot.py` | new (663 lines) |
| `tests/tools/test_use_lerobot.py` | new (313 lines, 29 tests) |
| `strands_robots/tools/__init__.py` | lazy-import registration |
| `tests/tools/test_tools_lazy_import.py` | roster contract update |