### PR TITLE
fix(newton): guard look-at camera quaternion against parallel up vector

### DIFF
--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -577,6 +577,11 @@ class NewtonSimEngine(SimEngine):
 
         Uses an OpenGL-style camera frame (camera looks down its local -Z).
 
+        When ``up`` is parallel to the view axis (e.g. a top-down camera
+        directly above its target with the default world-up), an alternate up
+        vector is chosen so the basis stays well-defined instead of producing a
+        NaN quaternion.
+
         Args:
             eye: Camera position.
             target: Point the camera looks at.
@@ -584,14 +589,29 @@ class NewtonSimEngine(SimEngine):
 
         Returns:
             Quaternion as ``(x, y, z, w)`` for ``warp.quatf``.
+
+        Raises:
+            ValueError: If ``eye`` and ``target`` coincide, leaving the view
+                direction undefined.
         """
         e = np.asarray(eye, dtype=np.float64)
         t = np.asarray(target, dtype=np.float64)
         u = np.asarray(up, dtype=np.float64)
         f = t - e
-        f /= np.linalg.norm(f)
+        f_norm = np.linalg.norm(f)
+        if f_norm < 1e-9:
+            raise ValueError(f"look_at: eye and target coincide ({eye!r}); camera direction is undefined.")
+        f /= f_norm
         z = -f
         x = np.cross(u, z)
+        # When ``up`` is (near-)parallel to the view axis -- e.g. a top-down
+        # camera placed directly above its target with the default world-up --
+        # ``cross(up, z)`` collapses to ~0 and normalising it would yield a
+        # NaN quaternion (a silently garbage camera pose). Fall back to an
+        # alternate up vector that is guaranteed non-parallel to ``z``.
+        if np.linalg.norm(x) < 1e-6:
+            alt_up = np.array([1.0, 0.0, 0.0]) if abs(z[0]) < 0.9 else np.array([0.0, 1.0, 0.0])
+            x = np.cross(alt_up, z)
         x /= np.linalg.norm(x)
         y = np.cross(z, x)
         r = np.stack([x, y, z], axis=1)

--- a/tests/simulation/newton/test_camera_lookat_quat.py
+++ b/tests/simulation/newton/test_camera_lookat_quat.py
@@ -1,0 +1,108 @@
+"""Camera look-at quaternion math for the Newton backend.
+
+These exercise the pure-math camera-orientation helpers
+(``_look_at_quat`` / ``_quat_from_matrix``) directly. They need neither the
+optional ``newton``/``warp`` packages nor a GPU, since the helpers operate only
+on NumPy arrays, so they run in every environment.
+"""
+
+from __future__ import annotations
+
+import types
+
+import numpy as np
+import pytest
+
+from strands_robots.simulation.newton.simulation import (
+    NewtonSimEngine,
+    _short_joint_name,
+)
+
+
+def _look_at(eye, target, up=(0.0, 0.0, 1.0)):
+    """Call the instance method without constructing a full engine.
+
+    ``_look_at_quat`` only reads ``self`` to reach the ``_quat_from_matrix``
+    static helper, so a tiny stand-in carrying that attribute is enough and
+    avoids importing newton/warp (or touching a GPU).
+    """
+    stub = types.SimpleNamespace(_quat_from_matrix=NewtonSimEngine._quat_from_matrix)
+    return NewtonSimEngine._look_at_quat(stub, eye, target, up)
+
+
+def _quat_to_matrix(q):
+    """Rotation matrix from an (x, y, z, w) quaternion."""
+    x, y, z, w = q
+    return np.array(
+        [
+            [1 - 2 * (y * y + z * z), 2 * (x * y - z * w), 2 * (x * z + y * w)],
+            [2 * (x * y + z * w), 1 - 2 * (x * x + z * z), 2 * (y * z - x * w)],
+            [2 * (x * z - y * w), 2 * (y * z + x * w), 1 - 2 * (x * x + y * y)],
+        ]
+    )
+
+
+class TestShortJointName:
+    def test_strips_hierarchical_path(self):
+        assert _short_joint_name("so_arm100/worldbody/Base/Rotation") == "Rotation"
+
+    def test_plain_name_unchanged(self):
+        assert _short_joint_name("Jaw") == "Jaw"
+
+
+class TestQuatFromMatrix:
+    def test_identity_is_unit_quaternion(self):
+        q = NewtonSimEngine._quat_from_matrix(np.eye(3))
+        assert q == pytest.approx((0.0, 0.0, 0.0, 1.0))
+
+    @pytest.mark.parametrize("axis", [0, 1, 2])
+    def test_180_degree_rotations_round_trip(self, axis):
+        # A 180-degree rotation drives the trace negative, exercising each of
+        # the three "largest diagonal" branches of the conversion.
+        r = -np.eye(3)
+        r[axis, axis] = 1.0
+        q = NewtonSimEngine._quat_from_matrix(r)
+        assert np.all(np.isfinite(q))
+        assert np.linalg.norm(q) == pytest.approx(1.0)
+        assert np.allclose(_quat_to_matrix(q), r, atol=1e-6)
+
+
+class TestLookAtQuat:
+    def test_oblique_view_points_camera_at_target(self):
+        eye, target = (0.6, 0.6, 0.5), (0.0, 0.0, 0.15)
+        q = _look_at(eye, target)
+        assert np.all(np.isfinite(q))
+        assert np.linalg.norm(q) == pytest.approx(1.0)
+        # OpenGL convention: the camera looks down its local -Z, so -Z in world
+        # space must equal the normalised eye->target direction.
+        view = np.asarray(target) - np.asarray(eye)
+        view /= np.linalg.norm(view)
+        cam_neg_z = -_quat_to_matrix(q)[:, 2]
+        assert np.allclose(cam_neg_z, view, atol=1e-6)
+
+    def test_top_down_view_with_parallel_up_is_finite(self):
+        # Regression: a camera directly above its target with the default
+        # world-up has a view axis parallel to ``up``; cross(up, z) collapses
+        # to ~0 and the old code normalised it into an all-NaN quaternion.
+        q = _look_at((0.0, 0.0, 1.0), (0.0, 0.0, 0.0))
+        assert np.all(np.isfinite(q)), "top-down look-at must not produce NaNs"
+        assert np.linalg.norm(q) == pytest.approx(1.0)
+        cam_neg_z = -_quat_to_matrix(q)[:, 2]
+        assert np.allclose(cam_neg_z, (0.0, 0.0, -1.0), atol=1e-6)
+
+    def test_bottom_up_view_with_parallel_up_is_finite(self):
+        q = _look_at((0.0, 0.0, -1.0), (0.0, 0.0, 0.0))
+        assert np.all(np.isfinite(q))
+        cam_neg_z = -_quat_to_matrix(q)[:, 2]
+        assert np.allclose(cam_neg_z, (0.0, 0.0, 1.0), atol=1e-6)
+
+    def test_coincident_eye_and_target_raises(self):
+        with pytest.raises(ValueError, match="coincide"):
+            _look_at((1.0, 1.0, 1.0), (1.0, 1.0, 1.0))
+
+    def test_explicit_parallel_up_falls_back(self):
+        # Even when the caller explicitly passes an up vector parallel to the
+        # view axis, the basis stays well-defined.
+        q = _look_at((0.0, 0.0, 2.0), (0.0, 0.0, 0.0), up=(0.0, 0.0, 1.0))
+        assert np.all(np.isfinite(q))
+        assert np.linalg.norm(q) == pytest.approx(1.0)


### PR DESCRIPTION
## Problem

The Newton backend builds its headless render camera with `_look_at_quat(eye, target, up=(0,0,1))`. When the camera sits directly above (or below) its target, the view axis is parallel to the world-up vector, so `cross(up, z)` collapses to the zero vector. Normalising that zero vector produced an **all-NaN quaternion** -- a silently invalid camera pose handed to Newton's `SensorTiledCamera`. Top-down framing is a perfectly ordinary view, so this degenerate case is easy to hit.

Reproduction (pure math, no GPU needed):

```python
import numpy as np, types
from strands_robots.simulation.newton.simulation import NewtonSimEngine
stub = types.SimpleNamespace(_quat_from_matrix=NewtonSimEngine._quat_from_matrix)
q = NewtonSimEngine._look_at_quat(stub, (0, 0, 1), (0, 0, 0))
assert np.all(np.isfinite(q))   # fails on main: q == (nan, nan, nan, nan)
```

## Change

- Detect the degenerate basis (`|cross(up, z)| ~ 0`) and fall back to an alternate up vector guaranteed non-parallel to the view axis, keeping the orthonormal camera frame well-defined.
- Raise a clear `ValueError` when `eye` and `target` coincide (view direction undefined) instead of dividing by zero.
- No behaviour change for non-degenerate (oblique) views: the camera still looks down its local -Z toward the target.

## Visual

Camera basis for the top-down case (`eye=(0,0,1)`, `target=(0,0,0)`), before vs after. Before: no valid frame (NaN quaternion); after: a proper orthonormal basis and unit quaternion.

![newton look-at top-down camera before/after](https://github.com/cagataycali/robots/releases/download/harness-artifacts/newton_lookat_parallel_up_fix.png)

## Tests

New `tests/simulation/newton/test_camera_lookat_quat.py` covers the camera-orientation math directly. The helpers operate only on NumPy arrays, so the tests run without the optional `newton`/`warp` packages or a GPU:

- oblique view -> camera -Z matches the normalised eye->target direction
- top-down and bottom-up views (parallel up) -> finite unit quaternion, correct -Z
- coincident eye/target -> `ValueError`
- explicit parallel up vector -> alternate-up fallback
- `_quat_from_matrix` identity + all three 180-degree branches round-trip

The parallel-up and coincident cases fail on `main` (NaN / no raise) and pass with this change.

Local gate: `ruff check` + `ruff format --check` clean; `mypy strands_robots` clean on the touched files; the new tests pass and the existing Newton suite is unaffected.