### PR TITLE
feat(training): Trainer abstraction — one interface over LeRobot / GR00T / Cosmos3 post-tuning

### DIFF
--- a/docs/training/overview.md
+++ b/docs/training/overview.md
@@ -1,65 +1,176 @@
 ---
-description: Train policies locally via the lerobot_train tool, or upstream with Isaac-GR00T and Cosmos. strands-robots ships data + inference + local fine-tuning.
+description: Post-tune any policy natively with the Trainer abstraction - one interface over LeRobot, Isaac-GR00T, and Cosmos3 pipelines.
 ---
 
 # Training
 
-`strands-robots` ships data collection and policy inference. ACT/diffusion/pi/SmolVLA
-fine-tuning runs locally through the `lerobot_train` tool (a thin wrapper over
-`lerobot-train`); GR00T and Cosmos training run in their upstream frameworks.
-
-| Want to train | Use |
-|---------------|-----|
-| ACT, Pi0, SmolVLA, Diffusion Policy | `lerobot_train` tool (wraps `lerobot-train`) or `lerobot` directly |
-| GR00T fine-tune | `Isaac-GR00T` (NVIDIA) |
-| Cosmos | NVIDIA Cosmos Framework - see [Cosmos3Policy](../policies/cosmos3.md) |
-| Custom architecture | Read LeRobot v3 dataset with `pyarrow` / `datasets` |
-
-## Round-trip
+`strands-robots` post-tunes policies **natively** through the `Trainer`
+abstraction - the training-side peer of [`Policy`](../policies/overview.md)
+(inference). One interface wraps three genuinely different upstream pipelines,
+selected by the **same provider name** you use for inference:
 
 ```python
-# 1. Record
-from strands_robots import Robot
+from strands_robots.training import create_trainer, TrainSpec
 
-sim = Robot("so100")
-sim.start_recording(repo_id="user/my_dataset", task="pick up the cube", fps=30)
-for episode in range(50):
-    sim.reset()
-    sim.randomize(randomize_colors=True)
-    sim.run_policy(robot_name="so100", instruction="pick up the cube",
-                   policy_provider="mock", duration=10.0)
-sim.stop_recording()
-
-# 2. Train locally on the recorded dataset (closes record -> train -> deploy)
-from strands_robots.tools import lerobot_train
-
-# dataset_root is the directory holding meta/info.json
-out = lerobot_train(
-    dataset_root="~/.cache/huggingface/lerobot/user/my_dataset",
-    policy_type="act",
+trainer = create_trainer("lerobot_local")   # same name as create_policy(...)
+spec = TrainSpec(
+    dataset_root="/tmp/my_dataset",          # what Robot.stop_recording() writes
+    base_model="lerobot/act_aloha_sim",
+    output_dir="/tmp/ft_out",
     steps=20000,
-    batch_size=8,
-    val_episodes=5,        # hold out the last 5 episodes for evaluation
-    output_dir="/tmp/train_out/act_cube",
 )
-# Background session: poll progress, then stop or let it finish.
-lerobot_train(action="status", session_name=out["session_name"])
-
-# 3. Infer with the trained checkpoint
-from strands_robots.policies import create_policy
-
-ckpt = "/tmp/train_out/act_cube/checkpoints/last/pretrained_model"
-policy = create_policy("lerobot_local", pretrained_name_or_path=ckpt)
-sim.run_policy(robot_name="so100", instruction="pick up the cube",
-               policy_object=policy, duration=15.0)
-
-# 4. Deploy (HardwareRobot has no run_policy - use start_task)
-real = Robot("so100", mode="real", cameras={...})
-real.start_task(instruction="pick up the cube", policy_port=5555)
+result = trainer.train(spec)                 # -> launches lerobot_train
+# result.checkpoint_dir loads straight back into create_policy(...)
 ```
+
+## Why an abstraction (not just `lerobot train`)
+
+Not everything is LeRobot. Each backend ships its own post-training pipeline,
+and a single `--policy.type` flag can't express them:
+
+| Provider | Upstream entry point | Config surface | Launcher | HW floor |
+|----------|---------------------|----------------|----------|----------|
+| `lerobot_local` | `lerobot.scripts.lerobot_train` | draccus `--dotted.flags` | `python` / `accelerate launch` | 1 consumer GPU |
+| `groot` | Isaac-GR00T `launch_finetune.py` | `FinetuneConfig` (tyro) + `tune_*` flags | `python` / `torchrun` | 1 modern GPU |
+| `cosmos3` | `cosmos_framework.scripts.train` | TOML recipe + Hydra overrides; **DCP convert** + **safetensors export** | `torchrun` (HSDP) | 8×H100 80GB |
+
+The `Trainer` ABC hides all of that behind one lifecycle:
+
+```
+validate()  ->  prepare()  ->  train()  ->  export()
+                   ▲                           ▲
+            (cosmos: DCP convert,        (cosmos: DCP -> safetensors;
+             groot: modality cfg)         lerobot/groot: passthrough)
+```
+
+plus `status()` for a "RUNNING ≠ learning" verdict on an in-flight job.
+
+## The data loop, end to end
+
+```python
+from strands_robots import Robot, MockPolicy, create_policy
+from strands_robots.training import create_trainer, TrainSpec
+
+# 1. RECORD - one episode is enough to smoke-test the loop
+sim = Robot("so100", mesh=False)
+sim.add_camera(name="front", position=[0.5, 0.0, 0.4], target=[0.2, 0, 0.05])
+sim.start_recording(repo_id="local/demo", root="/tmp/demo_ds",
+                    fps=30, task="pick up the red cube", overwrite=True)
+sim.run_policy(robot_name="so100", policy_object=MockPolicy(),
+               instruction="pick up the red cube", n_steps=60)
+sim.stop_recording()        # writes a LeRobotDataset v3 at /tmp/demo_ds
+
+# 2. TRAIN - thin wrapper over lerobot_train; ACT from scratch on CPU
+trainer = create_trainer("lerobot_local", device="cpu")
+spec = TrainSpec(dataset_root="/tmp/demo_ds", base_model="",
+                 output_dir="/tmp/demo_ft", steps=2, save_freq=2,
+                 global_batch_size=2, extra={"policy_type": "act"})
+result = trainer.train(spec)
+
+# 3. EXPORT - loadable artifact (HF-native passthrough for lerobot/groot)
+ckpt = trainer.export(spec, result.checkpoint_dir)
+
+# 4. DEPLOY - load the freshly-trained checkpoint back as a Policy
+policy = create_policy(ckpt, device="cpu")
+sim.run_policy(robot_name="so100", policy_object=policy,
+               instruction="pick up the red cube", n_steps=15)
+```
+
+Swap `create_trainer("lerobot_local")` → `"groot"` or `"cosmos3"` and **only the
+provider string changes** - exactly how `Robot("so100", mode="real")` swaps
+sim↔hardware.
+
+## TrainSpec - one spec, many backends
+
+`TrainSpec` carries provider-agnostic fields; each trainer reads what it
+supports and **ignores the rest** (the same tolerance rule as
+`Policy.get_actions(**kwargs)`). Backend-specific knobs go in `extra`:
+
+| Field | Meaning | Notes |
+|-------|---------|-------|
+| `dataset_root` | LeRobotDataset v3 root | required; has `meta/info.json` |
+| `base_model` | HF id / local ckpt to tune from | required for GR00T & Cosmos |
+| `method` | `full` \| `lora` \| `expert_only` \| `frozen_backbone` | `lora`+`expert_only` are mutually exclusive |
+| `tune` | `{llm,visual,projector,diffusion}` | GR00T only |
+| `val_episodes` | hold out the LAST N episodes | deterministic split |
+| `num_gpus` / `num_nodes` | multi-GPU / multi-node | selects the launcher |
+| `extra["policy_type"]` | lerobot `--policy.type` | act/diffusion/smolvla/pi0/pi05/... |
+| `extra["groot_root"]` | Isaac-GR00T checkout | GR00T |
+| `extra["sft_toml"]` / `extra["cosmos_root"]` | recipe + checkout | Cosmos |
+
+## From an agent (natural language)
+
+The `train_policy` tool exposes the abstraction to a Strands Agent:
+
+```python
+from strands import Agent
+from strands_robots import Robot
+from strands_robots.tools import train_policy
+
+agent = Agent(tools=[Robot("so100", mesh=False), train_policy])
+agent("Record 50 cube-pick episodes, then post-tune lerobot ACT on the dataset "
+      "at /tmp/demo_ds into /tmp/demo_ft, and tell me if it's actually learning.")
+```
+
+`train_policy` actions: `train`, `validate`, `status`, `export`, `list`.
+
+## Provider-specific knobs
+
+### LeRobot (`lerobot_local`)
+
+```python
+TrainSpec(..., method="lora", lora_r=16, extra={"policy_type": "pi05"})
+# -> lerobot_train --peft.method_type=LORA --peft.r=16 --policy.type=pi05
+```
+
+### GR00T (`groot`)
+
+```python
+TrainSpec(..., embodiment="GR1",
+          tune={"llm": False, "visual": False, "projector": True, "diffusion": True},
+          extra={"groot_root": "/path/to/Isaac-GR00T"})
+# -> launch_finetune.py --embodiment_tag=GR1 --tune_projector=true ...
+```
+
+### Cosmos3 (`cosmos3`)
+
+```python
+TrainSpec(..., num_gpus=8,
+          extra={"cosmos_root": "/path/to/cosmos-framework",
+                 "sft_toml": "examples/toml/sft_config/action_policy_droid_repro.toml"})
+# prepare(): convert_model_to_dcp ; train(): torchrun ... --sft-toml=... ;
+# export(): DCP -> safetensors
+```
+
+## Dependencies & extras (per provider)
+
+The base `strands-robots[lerobot]` extra is enough for **ACT / diffusion from
+scratch**, but VLA post-tunes pull in policy-specific stacks. Install the extra
+that matches your `extra["policy_type"]` / provider — verified on an L40S GPU:
+
+| Provider / policy | Install | Notes |
+|---|---|---|
+| `lerobot_local` + ACT / diffusion | `pip install 'strands-robots[lerobot]'` | works out of the box (torch + torchcodec + datasets) |
+| `lerobot_local` + `smolvla` | `pip install 'lerobot[smolvla]==0.5.1'` | **needs `transformers==5.3.0`** (lerobot's pinned `[smolvla]` extra). A newer transformers (e.g. 5.12) crashes smolvla import with `non-default argument 'backbone_cfg' follows default argument`. Pin it. |
+| `lerobot_local` + `pi0` / `pi05` | `pip install 'lerobot[pi]==0.5.1'` | same `transformers==5.3.0` pin via lerobot's `[pi]` extra |
+| `groot` | Isaac-GR00T checkout + its own venv (`omegaconf`, `tyro`, …); point `extra["groot_root"]` / `GR00T_ROOT` at it | launched as a subprocess, so it uses GR00T's interpreter, not ours |
+| `cosmos3` | cosmos-framework checkout (`uv sync --group=cu130-train`); point `extra["cosmos_root"]` / `COSMOS_ROOT` at it | torchrun-driven; same subprocess-interpreter rule |
+
+> **torchcodec / torch ABI:** the lerobot training dataloader decodes video via
+> `torchcodec`, whose compiled `.so` must match the **exact** installed torch
+> build. A torch *nightly* (e.g. `2.12.0.dev`) load-fails a stable-built
+> torchcodec with `undefined symbol: ...MessageLogger` even when ffmpeg is
+> present — and lerobot silently swallows the per-shard decode error, so
+> training fails with a generic non-zero exit. Pin `torch` + `torchcodec`
+> together (verified-good combo: `torch==2.10.0+cu128` + `torchcodec==0.10.0`).
+
+> **Subprocess interpreter:** `LerobotTrainer` / `Gr00tTrainer` / `Cosmos3Trainer`
+> accept a `python_executable=` argument (defaults to `sys.executable`). Set it
+> to a venv that has the provider's deps if your agent process runs in a
+> different environment — the training pipeline runs in that interpreter.
 
 ## See also
 
 - [Recording](../recording.md) - produce the dataset.
-- [LerobotLocalPolicy](../policies/lerobot-local.md) - inference with a trained checkpoint.
-- [Cosmos3Policy](../policies/cosmos3.md) - NVIDIA Cosmos 3 VLA.
+- [Policy Providers](../policies/overview.md) - the inference peer of `Trainer`.
+- [`examples/07_post_tune_any_policy.py`](https://github.com/strands-labs/robots/blob/main/examples/07_post_tune_any_policy.py) - the full loop in one script.

--- a/examples/07_post_tune_any_policy.py
+++ b/examples/07_post_tune_any_policy.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Post-tune any policy natively, then load it back - the full data loop.
+
+Goal: Show the ``Trainer`` abstraction (peer of ``Policy``) closing the
+physical-AI loop in one screen: RECORD a LeRobotDataset in sim, TRAIN a policy
+with ``create_trainer(provider)`` (here lerobot ACT), EXPORT a loadable
+artifact, and DEPLOY it back via ``create_policy`` - all with the SAME provider
+name on both the training and inference sides.
+
+Swap ``PROVIDER`` to "groot" or "cosmos3" and only the provider string changes:
+the lerobot draccus CLI, GR00T's tyro FinetuneConfig, and Cosmos's TOML+DCP
+pipeline all hide behind one ``TrainSpec`` + ``Trainer`` lifecycle.
+
+Dependencies: pip install "strands-robots[sim-mujoco,lerobot]"
+Expected output: a trained ACT checkpoint under /tmp, loaded back as a Policy.
+Runtime: ~30s on CPU (2 training steps - just enough to prove the loop).
+"""
+
+import os
+
+os.environ.setdefault("MUJOCO_GL", "cgl")  # macOS offscreen GL
+
+from strands_robots import MockPolicy, Robot, create_policy
+from strands_robots.training import TrainSpec, create_trainer
+
+PROVIDER = "lerobot_local"      # swap -> "groot" / "cosmos3" (only this changes)
+DATASET_ROOT = "/tmp/strands_post_tune_ds"
+OUTPUT_DIR = "/tmp/strands_post_tune_ft"
+
+# 1. RECORD - drive the sim with a mock policy, capture a LeRobotDataset v3.
+sim = Robot("so100", mesh=False)
+sim.add_camera(name="front", position=[0.5, 0.0, 0.4], target=[0.2, 0, 0.05])
+sim.start_recording(
+    repo_id="local/post_tune_demo", root=DATASET_ROOT,
+    fps=30, task="pick up the red cube", overwrite=True,
+)
+sim.run_policy(
+    robot_name="so100", policy_object=MockPolicy(),
+    instruction="pick up the red cube", n_steps=60,
+)
+sim.stop_recording()
+print(f"Recorded LeRobotDataset -> {DATASET_ROOT}")
+
+# 2. TRAIN - the trainer is selected by the SAME name as the inference policy.
+#    For lerobot this shells out to `python -m lerobot.scripts.lerobot_train`.
+trainer = create_trainer(PROVIDER, device="cpu")
+spec = TrainSpec(
+    dataset_root=DATASET_ROOT,
+    base_model="",                       # ACT from scratch (smallest CPU path)
+    output_dir=OUTPUT_DIR,
+    steps=2, save_freq=2, global_batch_size=2,
+    extra={"policy_type": "act", "num_workers": 0},
+)
+
+problems = trainer.validate(spec)        # pure preflight - launch nothing if bad
+if problems:
+    raise SystemExit("Spec invalid:\n  - " + "\n  - ".join(problems))
+
+result = trainer.train(spec)
+print(f"train status: {result.status} | checkpoint: {result.checkpoint_dir}")
+if result.status != "success":
+    raise SystemExit(result.message)
+
+# 3. EXPORT - a path create_policy can consume (HF-native passthrough here;
+#    Cosmos would convert DCP -> safetensors under the hood).
+exported = trainer.export(spec, result.checkpoint_dir)
+print(f"exported artifact: {exported}")
+
+# 4. DEPLOY - load the freshly-trained checkpoint back as a Policy and run it.
+os.environ.setdefault("STRANDS_TRUST_REMOTE_CODE", "1")
+policy = create_policy(exported, device="cpu")
+print(f"loaded trained policy: {type(policy).__name__} (provider={policy.provider_name})")
+print("\nLoop closed: record -> train -> export -> load. "
+      "Swap PROVIDER to 'groot'/'cosmos3' to retarget the same flow.")

--- a/examples/README.md
+++ b/examples/README.md
@@ -20,6 +20,8 @@ MUJOCO_GL=egl python examples/01_sim_hello_world.py
 | 03 | [`03_record_dataset.py`](03_record_dataset.py) | `start/stop_recording` | No | No |
 | 04 | [`04_mesh_peer_discovery.py`](04_mesh_peer_discovery.py) | `Mesh` + peer discovery | No | No |
 | 05 | [`05_agent_natural_language.py`](05_agent_natural_language.py) | `Agent` + `Robot` tool | No | No (needs LLM API) |
+| 06 | [`06_agent_collect_and_stream.py`](06_agent_collect_and_stream.py) | `Agent` record + `stream_dataset` | No | No (needs LLM API) |
+| 07 | [`07_post_tune_any_policy.py`](07_post_tune_any_policy.py) | `create_trainer` + `TrainSpec` (record→train→load) | No | No |
 
 ## What each example shows vs raw lerobot
 

--- a/strands_robots/registry/policies.json
+++ b/strands_robots/registry/policies.json
@@ -11,7 +11,11 @@
                 "mock",
                 "random",
                 "test"
-            ]
+            ],
+            "trainer": {
+                "module": "strands_robots.training.mock",
+                "class": "MockTrainer"
+            }
         },
         "groot": {
             "module": "strands_robots.policies.groot",
@@ -41,7 +45,11 @@
             "model_id_overrides": [
                 "nvidia/gr00t",
                 "nvidia/groot"
-            ]
+            ],
+            "trainer": {
+                "module": "strands_robots.training.groot",
+                "class": "Gr00tTrainer"
+            }
         },
         "lerobot_local": {
             "module": "strands_robots.policies.lerobot_local",
@@ -67,7 +75,11 @@
                 "lerobot",
                 "allenai"
             ],
-            "is_hf_default": true
+            "is_hf_default": true,
+            "trainer": {
+                "module": "strands_robots.training.lerobot",
+                "class": "LerobotTrainer"
+            }
         },
         "cosmos3": {
             "module": "strands_robots.policies.cosmos3",
@@ -104,7 +116,11 @@
             "model_id_overrides": [
                 "nvidia/cosmos3",
                 "nvidia/cosmos3-nano-policy"
-            ]
+            ],
+            "trainer": {
+                "module": "strands_robots.training.cosmos3",
+                "class": "Cosmos3Trainer"
+            }
         },
         "moveit2": {
             "module": "strands_robots.policies.moveit2",

--- a/strands_robots/tools/__init__.py
+++ b/strands_robots/tools/__init__.py
@@ -21,6 +21,7 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "pose_tool": (".pose_tool", "pose_tool"),
     "robot_mesh": (".robot_mesh", "robot_mesh"),
     "serial_tool": (".serial_tool", "serial_tool"),
+    "train_policy": (".train_policy", "train_policy"),
     "use_lerobot": (".use_lerobot", "use_lerobot"),
 }
 

--- a/strands_robots/tools/train_policy.py
+++ b/strands_robots/tools/train_policy.py
@@ -1,0 +1,223 @@
+"""Train (post-tune) a policy - Strands Agent ``@tool`` wrapper.
+
+Exposes the :class:`~strands_robots.training.base.Trainer` abstraction to an
+agent. One tool, provider-agnostic: the ``provider`` argument selects the
+backend (``lerobot_local`` / ``groot`` / ``cosmos3`` / ``mock``) and the SAME
+arguments map onto each backend's native pipeline via ``create_trainer`` +
+``TrainSpec``.
+
+This closes the physical-AI data loop from natural language:
+
+    record  ->  train_policy(...)  ->  create_policy(<checkpoint>)  ->  run
+
+All training logic lives in ``strands_robots.training``; this file only parses
+agent input and formats output in the Strands ``{status, content:[{text}]}``
+convention.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from strands.tools.decorator import tool
+
+from strands_robots.training import TrainSpec, create_trainer, list_trainers
+
+logger = logging.getLogger(__name__)
+
+
+def _ok(text: str, **extra: Any) -> dict[str, Any]:
+    out = {"status": "success", "content": [{"text": text}]}
+    out.update(extra)
+    return out
+
+
+def _err(text: str) -> dict[str, Any]:
+    return {"status": "error", "content": [{"text": text}]}
+
+
+@tool
+def train_policy(
+    action: str = "train",
+    provider: str = "lerobot_local",
+    dataset_root: str | None = None,
+    base_model: str = "",
+    output_dir: str | None = None,
+    embodiment: str | None = None,
+    steps: int = 10000,
+    batch_size: int = 32,
+    learning_rate: float = 1e-4,
+    save_freq: int = 1000,
+    num_gpus: int = 1,
+    num_nodes: int = 1,
+    resume: bool = False,
+    seed: int | None = None,
+    method: str = "full",
+    lora_r: int | None = None,
+    lora_alpha: int | None = None,
+    lora_target_modules: str | None = None,
+    tune: dict[str, bool] | None = None,
+    val_episodes: int | None = None,
+    augmentation: dict[str, Any] | None = None,
+    fps: int | None = None,
+    extra: dict[str, Any] | None = None,
+    job_id: str | None = None,
+) -> dict[str, Any]:
+    """Post-tune (fine-tune) a robot policy on a recorded LeRobotDataset.
+
+    Provider-agnostic: ``provider`` picks the training backend and the same
+    arguments map onto its native pipeline. Closes the record -> train -> deploy
+    loop - the produced checkpoint loads back via ``create_policy``.
+
+    Args:
+        action: One of:
+            - ``"train"``    : validate + launch training (default).
+            - ``"validate"`` : pure preflight only; report problems, launch nothing.
+            - ``"status"``   : "RUNNING != learning" verdict for a job (needs ``job_id``).
+            - ``"export"``   : produce a loadable artifact from a checkpoint
+                               (needs ``output_dir``; uses the run's last checkpoint).
+            - ``"list"``     : list available training providers.
+        provider: Training backend / policy family - ``"lerobot_local"`` (act,
+            diffusion, smolvla, pi0, pi05, ...), ``"groot"`` (NVIDIA GR00T),
+            ``"cosmos3"`` (NVIDIA Cosmos3), or ``"mock"``. Same name as the
+            inference provider in ``create_policy``.
+        dataset_root: Path to a LeRobotDataset v3 root (has ``meta/info.json``) -
+            exactly what ``Robot.stop_recording`` writes.
+        base_model: HF id or local checkpoint to post-tune from. For GR00T this
+            is required (``--base_model_path``); ACT-from-scratch leaves it "".
+        output_dir: Where checkpoints + logs go.
+        embodiment: Embodiment tag (REQUIRED for GR00T; inferred by lerobot).
+        steps: Total optimizer steps.
+        batch_size: Global batch size (summed across GPUs).
+        learning_rate: Initial LR.
+        save_freq: Checkpoint cadence in steps.
+        num_gpus: GPUs on this node (``>1`` -> accelerate/torchrun multi-GPU).
+        num_nodes: Nodes (Cosmos HSDP / torchrun ``--nnodes``).
+        resume: Resume from the latest checkpoint under ``output_dir``.
+        seed: Master seed.
+        method: Tuning strategy - ``"full"`` | ``"lora"`` | ``"expert_only"`` |
+            ``"frozen_backbone"``. ``lora`` and ``expert_only`` are mutually
+            exclusive.
+        lora_r / lora_alpha / lora_target_modules: LoRA hyperparameters.
+        tune: Fine-grained component toggles for GR00T
+            (``{"llm","visual","projector","diffusion"}``).
+        val_episodes: Hold out the LAST N episodes for validation.
+        augmentation: Backend-specific augmentation dict.
+        fps: Dataset control rate (when a backend needs it).
+        extra: Backend-specific passthrough. lerobot: ``policy_type``,
+            ``job_name``, any ``--key=value``. GR00T: ``groot_root``,
+            ``modality_config_path``. Cosmos: ``cosmos_root``, ``sft_toml``.
+        job_id: Job identifier for ``action="status"``.
+
+    Returns:
+        ``{status, content:[{text}], ...}``. For ``train``: includes
+        ``checkpoint_dir``, ``metrics``, ``job_id``.
+
+    Dependencies (per provider - the base ``[lerobot]`` extra is not always
+    enough):
+        - ``lerobot_local`` + ACT/diffusion: ``pip install 'strands-robots[lerobot]'``.
+        - ``lerobot_local`` + ``smolvla``/``pi0``/``pi05``: needs lerobot's
+          ``[smolvla]``/``[pi]`` extra, which pins ``transformers==5.3.0``. A
+          newer transformers crashes the VLA import (``non-default argument
+          'backbone_cfg' follows default argument``) - pin it.
+        - ``groot``/``cosmos3``: run in their own checkout + venv; point
+          ``extra['groot_root']``/``GR00T_ROOT`` or
+          ``extra['cosmos_root']``/``COSMOS_ROOT`` at it. The trainer launches
+          the native pipeline as a subprocess, so it uses THAT interpreter.
+        - torchcodec's ``.so`` must match the installed torch build exactly; a
+          torch nightly load-fails a stable torchcodec (``undefined symbol``)
+          and lerobot silently yields zero frames. See docs/training/overview.md.
+    """
+    try:
+        if action == "list":
+            return _ok("Available training providers:\n  " + "\n  ".join(list_trainers()))
+
+        if action == "status":
+            if not job_id:
+                return _err("action='status' requires job_id")
+            trainer = create_trainer(provider)
+            res = trainer.status(job_id)
+            return {
+                "status": "success" if res.status != "error" else "error",
+                "content": [
+                    {"text": f"[{provider}] job {job_id}: {res.status}\n{res.message}\nmetrics: {res.metrics}"}
+                ],
+                "metrics": res.metrics,
+            }
+
+        # All remaining actions need a spec.
+        if not dataset_root or not output_dir:
+            return _err("dataset_root and output_dir are required")
+
+        trainer = create_trainer(provider)
+        spec = TrainSpec(
+            dataset_root=dataset_root,
+            base_model=base_model,
+            output_dir=output_dir,
+            embodiment=embodiment,
+            steps=steps,
+            global_batch_size=batch_size,
+            learning_rate=learning_rate,
+            save_freq=save_freq,
+            num_gpus=num_gpus,
+            num_nodes=num_nodes,
+            resume=resume,
+            seed=seed,
+            method=method,
+            lora_r=lora_r,
+            lora_alpha=lora_alpha,
+            lora_target_modules=lora_target_modules,
+            tune=tune or {},
+            val_episodes=val_episodes,
+            augmentation=augmentation,
+            fps=fps,
+            extra=extra or {},
+        )
+
+        if action == "validate":
+            problems = trainer.validate(spec)
+            if problems:
+                return _err("validation problems:\n  - " + "\n  - ".join(problems))
+            return _ok(f"[{provider}] spec is valid and launchable.")
+
+        if action == "export":
+            ckpt = getattr(trainer, "_latest_checkpoint", lambda _o: None)(output_dir)
+            if not ckpt:
+                return _err(f"no checkpoint found under {output_dir} to export")
+            exported = trainer.export(spec, ckpt)
+            return _ok(
+                f"[{provider}] exported loadable artifact:\n{exported}\nLoad it with: create_policy('{exported}')",
+                exported_model=exported,
+            )
+
+        if action == "train":
+            problems = trainer.validate(spec)
+            if problems:
+                return _err("validation problems (nothing launched):\n  - " + "\n  - ".join(problems))
+            res = trainer.train(spec)
+            if res.status == "error":
+                return _err(f"[{provider}] training failed: {res.message}")
+            return {
+                "status": "success",
+                "content": [
+                    {
+                        "text": (
+                            f"[{provider}] {res.message}\n"
+                            f"job_id: {res.job_id}\n"
+                            f"checkpoint_dir: {res.checkpoint_dir}\n"
+                            f"metrics: {res.metrics}\n"
+                            f"Load the result with: create_policy('{res.checkpoint_dir}')"
+                        )
+                    }
+                ],
+                "job_id": res.job_id,
+                "checkpoint_dir": res.checkpoint_dir,
+                "metrics": res.metrics,
+            }
+
+        return _err(f"Unknown action: {action}. Valid: train, validate, status, export, list")
+
+    except Exception as e:  # noqa: BLE001 - tool boundary: report, don't crash the agent
+        logger.exception("train_policy failed")
+        return _err(f"train_policy error: {e}")

--- a/strands_robots/tools/train_policy.py
+++ b/strands_robots/tools/train_policy.py
@@ -200,6 +200,14 @@ def train_policy(
             return _ok(f"[{provider}] spec is valid and launchable.")
 
         if action == "export":
+            # Gate on validate() FIRST, like train/validate - export consumes the
+            # same agent-supplied spec (output_dir + extra reach trainer.export),
+            # so it must not run with unvalidated input (path traversal, a leading
+            # '-', or an arbitrary extra key). validate() runs _security_problems
+            # plus the backend's own spec checks, fail-closed.
+            problems = trainer.validate(spec)
+            if problems:
+                return _err("validation problems (nothing exported):\n  - " + "\n  - ".join(problems))
             ckpt = trainer.latest_checkpoint(output_dir)
             if not ckpt:
                 return _err(f"no checkpoint found under {output_dir} to export")

--- a/strands_robots/tools/train_policy.py
+++ b/strands_robots/tools/train_policy.py
@@ -141,7 +141,15 @@ def train_policy(
             return {
                 "status": "success" if res.status != "error" else "error",
                 "content": [
-                    {"text": f"[{provider}] job {job_id}: {res.status}\n{res.message}\nmetrics: {res.metrics}"}
+                    {"text": f"[{provider}] job {job_id}: {res.status}\n{res.message}\nmetrics: {res.metrics}"},
+                    {
+                        "json": {
+                            "job_id": job_id,
+                            "provider": provider,
+                            "status": res.status,
+                            "metrics": dict(res.metrics),
+                        }
+                    },
                 ],
                 "metrics": res.metrics,
             }
@@ -209,7 +217,17 @@ def train_policy(
                             f"metrics: {res.metrics}\n"
                             f"Load the result with: create_policy('{res.checkpoint_dir}')"
                         )
-                    }
+                    },
+                    {
+                        "json": {
+                            "provider": provider,
+                            "job_id": res.job_id,
+                            "status": res.status,
+                            "checkpoint_dir": res.checkpoint_dir,
+                            "exported_model": res.exported_model,
+                            "metrics": dict(res.metrics),
+                        }
+                    },
                 ],
                 "job_id": res.job_id,
                 "checkpoint_dir": res.checkpoint_dir,

--- a/strands_robots/tools/train_policy.py
+++ b/strands_robots/tools/train_policy.py
@@ -11,8 +11,8 @@ This closes the physical-AI data loop from natural language:
     record  ->  train_policy(...)  ->  create_policy(<checkpoint>)  ->  run
 
 All training logic lives in ``strands_robots.training``; this file only parses
-agent input and formats output in the Strands ``{status, content:[{text}]}``
-convention.
+agent input and formats output in the Strands ``{status, content:[...]}``
+convention (structured fields live in a ``{"json": ...}`` content block).
 """
 
 from __future__ import annotations
@@ -200,7 +200,7 @@ def train_policy(
             return _ok(f"[{provider}] spec is valid and launchable.")
 
         if action == "export":
-            ckpt = getattr(trainer, "_latest_checkpoint", lambda _o: None)(output_dir)
+            ckpt = trainer.latest_checkpoint(output_dir)
             if not ckpt:
                 return _err(f"no checkpoint found under {output_dir} to export")
             exported = trainer.export(spec, ckpt)

--- a/strands_robots/tools/train_policy.py
+++ b/strands_robots/tools/train_policy.py
@@ -27,10 +27,17 @@ from strands_robots.training import TrainSpec, create_trainer, list_trainers
 logger = logging.getLogger(__name__)
 
 
-def _ok(text: str, **extra: Any) -> dict[str, Any]:
-    out = {"status": "success", "content": [{"text": text}]}
-    out.update(extra)
-    return out
+def _ok(text: str, data: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Canonical Strands tool result: ``{status, content:[...]}`` only.
+
+    Structured data goes INSIDE the content list as a ``{"json": ...}`` block -
+    NEVER as a sibling key of ``status``/``content`` (the result dict must not be
+    extended beyond the two-key convention).
+    """
+    content: list[dict[str, Any]] = [{"text": text}]
+    if data is not None:
+        content.append({"json": data})
+    return {"status": "success", "content": content}
 
 
 def _err(text: str) -> dict[str, Any]:
@@ -111,8 +118,11 @@ def train_policy(
         job_id: Job identifier for ``action="status"``.
 
     Returns:
-        ``{status, content:[{text}], ...}``. For ``train``: includes
-        ``checkpoint_dir``, ``metrics``, ``job_id``.
+        Canonical Strands result ``{status, content:[...]}`` (no sibling keys).
+        For ``train``/``status``/``export`` the structured fields
+        (``job_id``, ``checkpoint_dir``, ``exported_model``, ``metrics``) are in
+        a ``{"json": ...}`` block inside ``content``, alongside a human-readable
+        ``{"text": ...}`` block.
 
     Dependencies (per provider - the base ``[lerobot]`` extra is not always
     enough):
@@ -121,10 +131,11 @@ def train_policy(
           ``[smolvla]``/``[pi]`` extra, which pins ``transformers==5.3.0``. A
           newer transformers crashes the VLA import (``non-default argument
           'backbone_cfg' follows default argument``) - pin it.
-        - ``groot``/``cosmos3``: run in their own checkout + venv; point
-          ``extra['groot_root']``/``GR00T_ROOT`` or
-          ``extra['cosmos_root']``/``COSMOS_ROOT`` at it. The trainer launches
-          the native pipeline as a subprocess, so it uses THAT interpreter.
+        - ``groot``/``cosmos3``: install the upstream package into THIS
+          interpreter (the trainer imports it and calls its library functions
+          in-process - no subprocess). Point ``extra['groot_root']``/``GR00T_ROOT``
+          or ``extra['cosmos_root']``/``COSMOS_ROOT`` at the checkout for runtime
+          config/recipe resolution.
         - torchcodec's ``.so`` must match the installed torch build exactly; a
           torch nightly load-fails a stable torchcodec (``undefined symbol``)
           and lerobot silently yields zero frames. See docs/training/overview.md.
@@ -151,7 +162,6 @@ def train_policy(
                         }
                     },
                 ],
-                "metrics": res.metrics,
             }
 
         # All remaining actions need a spec.
@@ -196,7 +206,7 @@ def train_policy(
             exported = trainer.export(spec, ckpt)
             return _ok(
                 f"[{provider}] exported loadable artifact:\n{exported}\nLoad it with: create_policy('{exported}')",
-                exported_model=exported,
+                data={"provider": provider, "exported_model": exported},
             )
 
         if action == "train":
@@ -229,9 +239,6 @@ def train_policy(
                         }
                     },
                 ],
-                "job_id": res.job_id,
-                "checkpoint_dir": res.checkpoint_dir,
-                "metrics": res.metrics,
             }
 
         return _err(f"Unknown action: {action}. Valid: train, validate, status, export, list")

--- a/strands_robots/training/__init__.py
+++ b/strands_robots/training/__init__.py
@@ -1,0 +1,38 @@
+"""Training abstraction - post-tune any policy provider natively.
+
+Peer of ``strands_robots.policies``: where ``Policy`` is inference, ``Trainer``
+is post-tuning. Selected by the SAME provider name via ``create_trainer``.
+
+Usage::
+
+    from strands_robots.training import create_trainer, TrainSpec
+
+    trainer = create_trainer("lerobot_local")
+    spec = TrainSpec(
+        dataset_root="/tmp/my_dataset",
+        base_model="lerobot/act_aloha_sim",
+        output_dir="/tmp/ft_out",
+        steps=20000,
+    )
+    problems = trainer.validate(spec)
+    if not problems:
+        result = trainer.train(spec)
+"""
+
+from strands_robots.training.base import Trainer, TrainResult, TrainSpec
+from strands_robots.training.factory import (
+    create_trainer,
+    import_trainer_class,
+    list_trainers,
+    register_trainer,
+)
+
+__all__ = [
+    "Trainer",
+    "TrainSpec",
+    "TrainResult",
+    "create_trainer",
+    "register_trainer",
+    "list_trainers",
+    "import_trainer_class",
+]

--- a/strands_robots/training/_inproc.py
+++ b/strands_robots/training/_inproc.py
@@ -1,0 +1,154 @@
+"""In-process execution helpers shared by the training backends (no subprocess).
+
+Every backend drives its upstream pipeline by **importing the package and
+calling its own function** - LeRobot's ``train(cfg)``, GR00T's
+``experiment.run(config)``, Cosmos's ``convert_model_to_dcp(args)`` /
+``train.launch(config, args)`` / ``export_model(args)``. None of them shell out
+to a second interpreter or a ``torchrun`` binary.
+
+Two primitives:
+
+* :func:`call_callable` - run a Python callable in THIS interpreter with its
+  stdout/stderr + root-logger output tee'd to a per-run log file (so the
+  trainers can still parse a "RUNNING != learning" verdict, exactly as they did
+  from the old subprocess log).
+
+* :func:`elastic_launch_callable` - multi-GPU single-node launch via torch's
+  programmatic :class:`torch.distributed.launcher.api.elastic_launch` (the same
+  elastic agent ``torchrun`` uses, driven in-process). It spawns one worker per
+  GPU; each worker calls a Python callable with arguments passed as Python
+  objects - there is no command line to assemble or inject into. The worker
+  reads ``RANK`` / ``LOCAL_RANK`` / ``WORLD_SIZE`` that the agent sets, which is
+  exactly what HF ``TrainingArguments`` / lerobot ``accelerate`` /
+  cosmos ``distributed.init()`` expect.
+
+Argument-injection safety for the few remaining string values (upstream config
+flags built partly from the agent-supplied ``TrainSpec.extra``) lives in
+:mod:`strands_robots.training._validate`, called fail-closed from every
+backend's ``validate()``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import logging
+import sys
+from collections.abc import Callable
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class _Tee(io.TextIOBase):
+    """Write-through tee: forwards writes to both a live stream and a log file."""
+
+    def __init__(self, primary: Any, secondary: Any) -> None:
+        self._primary = primary
+        self._secondary = secondary
+
+    def write(self, s: str) -> int:  # type: ignore[override]
+        for stream in (self._primary, self._secondary):
+            try:
+                stream.write(s)
+            except Exception:  # noqa: BLE001 - never let logging break training
+                pass
+        return len(s)
+
+    def flush(self) -> None:  # type: ignore[override]
+        for stream in (self._primary, self._secondary):
+            try:
+                stream.flush()
+            except Exception:  # noqa: BLE001
+                pass
+
+
+class capture_to_file:
+    """Context manager: tee stdout/stderr + root-logger output into ``log_path``.
+
+    ``log_path=None`` is a no-op (used by non-rank-0 workers so only rank 0
+    writes the shared log).
+    """
+
+    def __init__(self, log_path: str | None) -> None:
+        self.log_path = log_path
+        self._stream: io.TextIOBase | None = None
+        self._fh: logging.FileHandler | None = None
+        self._r_out: Any = None
+        self._r_err: Any = None
+
+    def __enter__(self) -> capture_to_file:
+        if not self.log_path:
+            return self
+        self._stream = open(self.log_path, "w", encoding="utf-8")  # noqa: SIM115
+        self._fh = logging.FileHandler(self.log_path)
+        self._fh.setLevel(logging.INFO)
+        self._fh.setFormatter(logging.Formatter("%(message)s"))
+        logging.getLogger().addHandler(self._fh)
+        self._r_out = contextlib.redirect_stdout(_Tee(sys.stdout, self._stream))
+        self._r_err = contextlib.redirect_stderr(_Tee(sys.stderr, self._stream))
+        self._r_out.__enter__()
+        self._r_err.__enter__()
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        try:
+            if self._r_err is not None:
+                self._r_err.__exit__(*exc)
+            if self._r_out is not None:
+                self._r_out.__exit__(*exc)
+        finally:
+            if self._fh is not None:
+                logging.getLogger().removeHandler(self._fh)
+                self._fh.close()
+            if self._stream is not None:
+                self._stream.close()
+
+
+def call_callable(
+    fn: Callable[..., Any],
+    *args: Any,
+    log_path: str | None = None,
+    **kwargs: Any,
+) -> Any:
+    """Call ``fn(*args, **kwargs)`` in-process, output captured to ``log_path``.
+
+    The purest "import the package and use it" path: the caller has already
+    built the upstream's own config object and just needs its function invoked
+    here. No argv, no shell, no nested interpreter.
+    """
+    with capture_to_file(log_path):
+        return fn(*args, **kwargs)
+
+
+def elastic_launch_callable(
+    fn: Callable[..., Any],
+    *,
+    nproc_per_node: int,
+    nnodes: int = 1,
+    rdzv_endpoint: str = "",
+    rdzv_backend: str = "c10d",
+    run_id: str = "",
+    fn_args: tuple[Any, ...] = (),
+) -> Any:
+    """Multi-process launch via torch's programmatic elastic launcher (no torchrun).
+
+    Spawns ``nproc_per_node`` workers with torch's elastic agent (Python
+    multiprocessing) and calls ``fn(*fn_args)`` in each. Arguments are Python
+    objects, so there is no command line to inject into - the shell-free
+    replacement for ``torchrun --nproc_per_node=N``. For ``nnodes > 1`` a shared
+    ``rdzv_endpoint`` (host:port reachable by every node) is required.
+    """
+    from torch.distributed.launcher.api import LaunchConfig, elastic_launch
+
+    config = LaunchConfig(
+        min_nodes=nnodes,
+        max_nodes=nnodes,
+        nproc_per_node=nproc_per_node,
+        run_id=run_id or "strands-train",
+        rdzv_backend=rdzv_backend,
+        rdzv_endpoint=rdzv_endpoint or "localhost:0",
+        max_restarts=0,
+        start_method="spawn",
+    )
+    return elastic_launch(config, fn)(*fn_args)

--- a/strands_robots/training/_validate.py
+++ b/strands_robots/training/_validate.py
@@ -2,19 +2,19 @@
 
 Every concrete :class:`~strands_robots.training.base.Trainer` translates a
 :class:`~strands_robots.training.base.TrainSpec` into its backend's native
-launch (a typed config object built from the spec). The ``train_policy``
-``@tool`` lets an agent (LLM) populate that ``TrainSpec`` directly, so the
-path fields and the free-form ``extra`` dict are *untrusted input that reaches
-a subprocess*. Per ``AGENTS.md`` > Review Learnings (#92) > "LLM Input Safety",
-those values MUST be validated before they can become a config field or a flag
-token: a value beginning with ``-`` could parse as a *new flag* in the
-argv-parity helpers, and an arbitrary ``extra`` key could set an arbitrary
-config attribute / Hydra override.
+config object and runs it IN-PROCESS (imported and called as a library - no
+subprocess). The ``train_policy`` ``@tool`` lets an agent (LLM) populate that
+``TrainSpec`` directly, so the path fields and the free-form ``extra`` dict are
+*untrusted input that reaches backend internals*. Per ``AGENTS.md`` > Review
+Learnings (#92) > "LLM Input Safety", those values MUST be validated before they
+can become a config field, a Hydra override, or a token in a backend's
+argv-parity helper: a value beginning with ``-`` could read as a *new flag*, and
+an arbitrary ``extra`` key could set an arbitrary config attribute / override.
 
 :func:`validate_train_inputs` is the single source of that check. It is invoked
 from every backend's :meth:`Trainer.validate`, which each backend's
-:meth:`Trainer.train` calls (fail-closed) before building any command - so no
-subprocess can launch with unvalidated input regardless of the call path.
+:meth:`Trainer.train` calls (fail-closed) before building any config - so no
+run can start with unvalidated input regardless of the call path.
 """
 
 from __future__ import annotations
@@ -51,7 +51,8 @@ def validate_train_inputs(spec: TrainSpec) -> list[str]:
     """Return a list of input-safety problems for a :class:`TrainSpec`.
 
     An empty list means every agent-supplied value is safe to interpolate into
-    a subprocess argv. Pure and side-effect-free (read-only ``realpath`` only),
+    a backend config / argv-parity helper. Pure and side-effect-free
+    (read-only ``realpath`` only),
     so it is safe to call from :meth:`Trainer.validate`.
     """
     problems: list[str] = []
@@ -69,7 +70,7 @@ def validate_train_inputs(spec: TrainSpec) -> list[str]:
     for label in _FLAG_BOUND_FIELDS:
         val = getattr(spec, label, None)
         if isinstance(val, str) and val.startswith("-"):
-            problems.append(f"{label} must not start with '-' (would inject a subprocess flag)")
+            problems.append(f"{label} must not start with '-' (would parse as a stray flag)")
 
     # ``extra`` keys become backend-native flags - allowlist the key format.
     for key in spec.extra or {}:

--- a/strands_robots/training/_validate.py
+++ b/strands_robots/training/_validate.py
@@ -1,0 +1,84 @@
+"""Shared, defense-in-depth input validation for the training backends.
+
+Every concrete :class:`~strands_robots.training.base.Trainer` translates a
+:class:`~strands_robots.training.base.TrainSpec` into its backend's native
+launch and hands the resulting argv to ``subprocess.run``. The ``train_policy``
+``@tool`` lets an agent (LLM) populate that ``TrainSpec`` directly, so the
+path fields and the free-form ``extra`` dict are *untrusted input that reaches
+a subprocess*. Per ``AGENTS.md`` > Review Learnings (#92) > "LLM Input Safety",
+those values MUST be validated before they can become argv tokens - even in
+list form (no shell), because a value beginning with ``-`` parses as a *new
+flag* and an arbitrary ``extra`` key becomes an arbitrary ``--flag``.
+
+:func:`validate_train_inputs` is the single source of that check. It is invoked
+from every backend's :meth:`Trainer.validate`, which each backend's
+:meth:`Trainer.train` calls (fail-closed) before building any command - so no
+subprocess can launch with unvalidated input regardless of the call path.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+from strands_robots.tools._path_validation import validate_save_path
+
+if TYPE_CHECKING:
+    from strands_robots.training.base import TrainSpec
+
+# ``extra`` keys are interpolated into argv as ``--{key}=...`` (lerobot/groot)
+# or ``{key}=...`` (cosmos hydra). Allowlist the key FORMAT only: lowercase,
+# dotted (lerobot ``dataset.episodes`` / cosmos ``model.x.y``), no leading dash,
+# no ``=``, no whitespace or shell metacharacters. We deliberately do NOT try to
+# enumerate every valid backend flag - that allowlist is impossible to keep
+# current and would break the documented ``extra`` escape hatch.
+_EXTRA_KEY_RE = re.compile(r"^[a-z][a-z0-9_.]*$")
+
+# Scalars that are interpolated as the value of a single argv flag
+# (e.g. ``--dataset.root={dataset_root}``). A leading ``-`` is the injection
+# vector: ``base_model="--config_path=/etc/passwd"`` would otherwise parse as a
+# separate flag. An interior ``=`` is harmless (the token stays single, no
+# shell) and is legitimate for HF revision refs, so it is NOT rejected.
+_FLAG_BOUND_FIELDS = ("dataset_root", "output_dir", "base_model", "embodiment")
+
+# Path-like fields additionally get the audited filesystem check (null bytes,
+# ``..`` traversal, protected system directories).
+_PATH_FIELDS = ("dataset_root", "output_dir")
+
+
+def validate_train_inputs(spec: TrainSpec) -> list[str]:
+    """Return a list of input-safety problems for a :class:`TrainSpec`.
+
+    An empty list means every agent-supplied value is safe to interpolate into
+    a subprocess argv. Pure and side-effect-free (read-only ``realpath`` only),
+    so it is safe to call from :meth:`Trainer.validate`.
+    """
+    problems: list[str] = []
+
+    # Path fields: reuse the audited validator used by the other write-path tools.
+    for label in _PATH_FIELDS:
+        val = getattr(spec, label, None)
+        if val:
+            try:
+                validate_save_path(str(val), label=label)
+            except ValueError as e:
+                problems.append(str(e))
+
+    # Flag-bound scalars must not smuggle an argv flag via a leading dash.
+    for label in _FLAG_BOUND_FIELDS:
+        val = getattr(spec, label, None)
+        if isinstance(val, str) and val.startswith("-"):
+            problems.append(
+                f"{label} must not start with '-' (would inject a subprocess flag)"
+            )
+
+    # ``extra`` keys become backend-native flags - allowlist the key format.
+    for key in spec.extra or {}:
+        if not _EXTRA_KEY_RE.match(str(key)):
+            problems.append(
+                f"extra key {key!r} is not allowed "
+                f"(must match {_EXTRA_KEY_RE.pattern}: lowercase, "
+                f"no leading dash, no '=', no whitespace)"
+            )
+
+    return problems

--- a/strands_robots/training/_validate.py
+++ b/strands_robots/training/_validate.py
@@ -2,13 +2,14 @@
 
 Every concrete :class:`~strands_robots.training.base.Trainer` translates a
 :class:`~strands_robots.training.base.TrainSpec` into its backend's native
-launch and hands the resulting argv to ``subprocess.run``. The ``train_policy``
+launch (a typed config object built from the spec). The ``train_policy``
 ``@tool`` lets an agent (LLM) populate that ``TrainSpec`` directly, so the
 path fields and the free-form ``extra`` dict are *untrusted input that reaches
 a subprocess*. Per ``AGENTS.md`` > Review Learnings (#92) > "LLM Input Safety",
-those values MUST be validated before they can become argv tokens - even in
-list form (no shell), because a value beginning with ``-`` parses as a *new
-flag* and an arbitrary ``extra`` key becomes an arbitrary ``--flag``.
+those values MUST be validated before they can become a config field or a flag
+token: a value beginning with ``-`` could parse as a *new flag* in the
+argv-parity helpers, and an arbitrary ``extra`` key could set an arbitrary
+config attribute / Hydra override.
 
 :func:`validate_train_inputs` is the single source of that check. It is invoked
 from every backend's :meth:`Trainer.validate`, which each backend's

--- a/strands_robots/training/_validate.py
+++ b/strands_robots/training/_validate.py
@@ -68,9 +68,7 @@ def validate_train_inputs(spec: TrainSpec) -> list[str]:
     for label in _FLAG_BOUND_FIELDS:
         val = getattr(spec, label, None)
         if isinstance(val, str) and val.startswith("-"):
-            problems.append(
-                f"{label} must not start with '-' (would inject a subprocess flag)"
-            )
+            problems.append(f"{label} must not start with '-' (would inject a subprocess flag)")
 
     # ``extra`` keys become backend-native flags - allowlist the key format.
     for key in spec.extra or {}:

--- a/strands_robots/training/base.py
+++ b/strands_robots/training/base.py
@@ -35,8 +35,6 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any
 
-from strands_robots.training._validate import validate_train_inputs
-
 
 @dataclass
 class TrainSpec:
@@ -189,7 +187,14 @@ class Trainer(ABC):
         that would smuggle an arbitrary ``--flag``). Concrete :meth:`validate`
         implementations MUST call this first so that the ``# noqa: S603``
         subprocess sites are genuinely fed validated input.
+
+        Imported lazily here (not at module top) to break the
+        ``base ↔ _validate`` cyclic import that CodeQL flagged: ``_validate``
+        references :class:`TrainSpec` only under ``TYPE_CHECKING``, so the
+        runtime cycle is closed by deferring this import until first call.
         """
+        from strands_robots.training._validate import validate_train_inputs
+
         return validate_train_inputs(spec)
 
     def prepare(self, spec: TrainSpec) -> None:

--- a/strands_robots/training/base.py
+++ b/strands_robots/training/base.py
@@ -1,0 +1,248 @@
+"""Trainer abstraction - post-tune ANY policy provider natively.
+
+The :class:`Trainer` ABC is the training-side peer of
+:class:`~strands_robots.policies.base.Policy` (inference). Where ``Policy``
+hides *how a model produces actions*, ``Trainer`` hides *how a model is
+post-tuned* - and those pipelines genuinely differ per provider:
+
+* **LeRobot** - ``python -m lerobot.scripts.lerobot_train`` (draccus CLI),
+  ``accelerate launch`` for multi-GPU. HF-native checkpoints.
+* **GR00T N1.7** - ``gr00t/experiment/launch_finetune.py`` (a ``FinetuneConfig``
+  dataclass via tyro), ``torchrun`` for multi-GPU, ``tune_llm/visual/projector/
+  diffusion`` flags + a modality-config ``.py``.
+* **Cosmos3** - ``torchrun -m cosmos_framework.scripts.train --sft-toml=...``
+  (TOML recipe + Hydra overrides), an explicit **DCP checkpoint conversion**
+  prepare step, and a **DCP -> safetensors** export step. 8xH100 floor.
+
+All three nonetheless converge on:
+
+1. the same **dataset format** - LeRobotDataset v3 (what
+   :class:`~strands_robots.dataset_recorder.DatasetRecorder` already writes), and
+2. the same **lifecycle** - ``validate -> prepare -> train -> export``.
+
+A ``Trainer`` is selected by the SAME provider name as its ``Policy``
+(``groot`` / ``lerobot_local`` / ``cosmos3``), so a single registry identity
+owns both the inference class and the training class. Adding a new policy =
+add a ``Policy`` + a ``Trainer`` under one provider entry.
+
+See :class:`MockTrainer` (``strands_robots/training/mock.py``) for the canonical
+no-dependency reference implementation.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any
+
+from strands_robots.training._validate import validate_train_inputs
+
+
+@dataclass
+class TrainSpec:
+    """Provider-agnostic post-tuning specification.
+
+    Concrete trainers read the fields they support and **ignore the rest** -
+    the same tolerance rule that :meth:`Policy.get_actions` applies to its
+    ``**kwargs``. Backends MUST NOT raise on a field they don't use; new,
+    backend-specific knobs live in :attr:`extra` until >=2 backends share
+    them and they graduate to a first-class field.
+
+    Attributes:
+        dataset_root: Path to a LeRobotDataset v3 root (must contain
+            ``meta/info.json``). This is exactly what
+            :class:`~strands_robots.dataset_recorder.DatasetRecorder` /
+            ``Robot.stop_recording`` produce, so the ``record -> train`` loop
+            needs no conversion layer.
+        base_model: HF model id or local checkpoint path to post-tune *from*.
+        output_dir: Directory for checkpoints, logs, and the final artifact.
+        embodiment: Embodiment tag / robot id. Required by GR00T
+            (``--embodiment_tag``); LeRobot infers it from dataset features;
+            optional elsewhere.
+        steps: Total optimizer steps (maps to lerobot ``--steps`` /
+            GR00T ``max_steps`` / Cosmos ``trainer.max_iter``).
+        global_batch_size: Batch summed across GPUs before grad accumulation.
+        learning_rate: Initial LR.
+        save_freq: Checkpoint cadence in steps.
+        num_gpus: GPUs on this node. ``>1`` selects the multi-GPU launcher
+            (``accelerate`` for lerobot, ``torchrun`` for groot/cosmos).
+        num_nodes: Nodes for multi-node training (Cosmos HSDP /
+            ``torchrun --nnodes``).
+        resume: Resume from the latest checkpoint under ``output_dir`` when
+            one exists.
+        seed: Master seed (best-effort; not all backends expose it).
+        method: Tuning strategy, mapped per-backend:
+            ``"full"`` | ``"lora"`` | ``"expert_only"`` | ``"frozen_backbone"``.
+            ``lora`` and ``expert_only`` are mutually exclusive (both freeze
+            the VLM); a backend MUST reject the combination in
+            :meth:`Trainer.validate`.
+        lora_r / lora_alpha / lora_target_modules: LoRA hyperparameters
+            (used only when ``method == "lora"``). ``lora_target_modules=None``
+            means "use the policy's built-in default targets".
+        tune: Fine-grained component toggles for backends that expose them
+            (GR00T: ``{"llm": bool, "visual": bool, "projector": bool,
+            "diffusion": bool}``). Ignored by backends that don't.
+        val_episodes: Hold out the LAST N episodes as a validation set
+            (deterministic split; lerobot ``--dataset.episodes=[0..total-N-1]``).
+        augmentation: Backend-specific data augmentation (GR00T
+            ``color_jitter_params`` / ``random_rotation_angle``; Cosmos
+            dataset filter dict).
+        fps: Dataset control rate, when a backend needs it explicitly.
+        extra: Raw passthrough. Keys become backend-native flags / overrides
+            (lerobot ``--key=value``; Cosmos Hydra ``key.path=value``). The
+            escape hatch that keeps the ABC stable as backends evolve.
+    """
+
+    # --- universal ---
+    dataset_root: str
+    base_model: str
+    output_dir: str
+    embodiment: str | None = None
+    steps: int = 10_000
+    global_batch_size: int = 32
+    learning_rate: float = 1e-4
+    save_freq: int = 1_000
+    num_gpus: int = 1
+    num_nodes: int = 1
+    resume: bool = False
+    seed: int | None = None
+    # --- tuning strategy ---
+    method: str = "full"
+    lora_r: int | None = None
+    lora_alpha: int | None = None
+    lora_target_modules: str | None = None
+    tune: dict[str, bool] = field(default_factory=dict)
+    # --- data ---
+    val_episodes: int | None = None
+    augmentation: dict[str, Any] | None = None
+    fps: int | None = None
+    # --- escape hatch ---
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class TrainResult:
+    """Outcome of a training lifecycle call.
+
+    Attributes:
+        status: ``"success"`` | ``"running"`` | ``"error"``.
+        job_id: Stable id for this run (used by :meth:`Trainer.status`).
+        checkpoint_dir: Where checkpoints are written (``None`` before any
+            save / on validation failure).
+        exported_model: Final loadable artifact path - a value that
+            ``create_policy(...)`` can consume - once :meth:`Trainer.export`
+            has run. ``None`` otherwise.
+        metrics: Free-form metrics for the "RUNNING != learning" verdict
+            (e.g. ``latest_step``, ``latest_loss``, ``learning``,
+            ``liveness_ok``).
+        message: Human-readable status / error detail.
+    """
+
+    status: str
+    job_id: str
+    checkpoint_dir: str | None = None
+    exported_model: str | None = None
+    metrics: dict[str, Any] = field(default_factory=dict)
+    message: str = ""
+
+
+class Trainer(ABC):
+    """Abstract base class for post-tuning a policy of one provider family.
+
+    Lifecycle: :meth:`validate` (pure preflight) -> :meth:`prepare` (optional
+    one-time setup) -> :meth:`train` (launch + manage) -> :meth:`export`
+    (produce a loadable artifact). :meth:`status` answers
+    "is it *really* learning?" for an in-flight job.
+
+    Concrete trainers are thin adapters that translate a :class:`TrainSpec`
+    into their backend's native launch (a subprocess command, a config object,
+    a TOML recipe) - they do NOT reimplement training.
+    """
+
+    @property
+    @abstractmethod
+    def provider_name(self) -> str:
+        """Provider identity - MUST match the paired ``Policy.provider_name``."""
+
+    @abstractmethod
+    def validate(self, spec: TrainSpec) -> list[str]:
+        """Pure, side-effect-free preflight.
+
+        Return a list of human-readable problems; an empty list means the spec
+        is launchable. Implementations SHOULD check: dataset_root has
+        ``meta/info.json``; :attr:`TrainSpec.method` is supported and not a
+        contradictory combination (``lora`` + ``expert_only``); any
+        backend-required input is present (e.g. a DCP base for Cosmos); and
+        rough hardware feasibility against :attr:`hardware_floor`.
+
+        MUST NOT touch the filesystem beyond read-only stat / config reads,
+        spawn processes, or allocate GPUs - it powers a ``plan`` advisor that
+        runs *before* anything expensive starts.
+        """
+
+    def _security_problems(self, spec: TrainSpec) -> list[str]:
+        """Input-safety preflight shared by every backend (defense-in-depth).
+
+        Returns problems for any agent-supplied value that would be unsafe to
+        interpolate into a subprocess argv (path traversal / protected
+        directories, a leading ``-`` that parses as a flag, or an ``extra`` key
+        that would smuggle an arbitrary ``--flag``). Concrete :meth:`validate`
+        implementations MUST call this first so that the ``# noqa: S603``
+        subprocess sites are genuinely fed validated input.
+        """
+        return validate_train_inputs(spec)
+
+    def prepare(self, spec: TrainSpec) -> None:
+        """Optional one-time setup before :meth:`train`. Default no-op.
+
+        Overridden by backends that need it: Cosmos converts the base
+        checkpoint to PyTorch DCP; GR00T registers a modality-config ``.py``.
+        LeRobot needs nothing here.
+        """
+        return None
+
+    @abstractmethod
+    def train(self, spec: TrainSpec) -> TrainResult:
+        """Build and launch the backend's training, returning a result.
+
+        Responsible for: selecting the launcher (``python`` / ``accelerate
+        launch`` / ``torchrun``), mapping :class:`TrainSpec` to native flags,
+        wiring resume, and surfacing the checkpoint dir + a status. Long runs
+        SHOULD launch detached and return ``status="running"`` with a
+        ``job_id`` that :meth:`status` can poll.
+        """
+
+    def status(self, job_id: str) -> TrainResult:
+        """Return a "RUNNING != learning" verdict for an in-flight job.
+
+        Default implementation returns an ``error`` result indicating the
+        backend does not implement status tracking. Backends override to parse
+        their training logs for ``latest_step`` / ``latest_loss`` / a
+        ``learning`` boolean.
+        """
+        return TrainResult(
+            status="error",
+            job_id=job_id,
+            message=f"{self.provider_name}: status() not implemented",
+        )
+
+    def export(self, spec: TrainSpec, checkpoint_dir: str) -> str:
+        """Produce a loadable artifact from a checkpoint.
+
+        Default returns ``checkpoint_dir`` unchanged - correct for HF-native
+        backends (LeRobot, GR00T) whose checkpoints are directly loadable by
+        ``create_policy(checkpoint_dir)``. Cosmos overrides to convert DCP ->
+        safetensors. The returned path MUST be something ``create_policy``
+        accepts.
+        """
+        return checkpoint_dir
+
+    @property
+    def hardware_floor(self) -> dict[str, Any]:
+        """Advisory minimum hardware, for the ``plan`` advisor.
+
+        Keys: ``min_gpus`` (int), ``min_vram_gb`` (int),
+        ``multinode`` (bool). Defaults to a single 24 GB GPU; backends with a
+        higher floor (e.g. Cosmos: 8x80 GB) override.
+        """
+        return {"min_gpus": 1, "min_vram_gb": 24, "multinode": False}

--- a/strands_robots/training/base.py
+++ b/strands_robots/training/base.py
@@ -5,14 +5,18 @@ The :class:`Trainer` ABC is the training-side peer of
 hides *how a model produces actions*, ``Trainer`` hides *how a model is
 post-tuned* - and those pipelines genuinely differ per provider:
 
-* **LeRobot** - ``python -m lerobot.scripts.lerobot_train`` (draccus CLI),
-  ``accelerate launch`` for multi-GPU. HF-native checkpoints.
-* **GR00T N1.7** - ``gr00t/experiment/launch_finetune.py`` (a ``FinetuneConfig``
-  dataclass via tyro), ``torchrun`` for multi-GPU, ``tune_llm/visual/projector/
-  diffusion`` flags + a modality-config ``.py``.
-* **Cosmos3** - ``torchrun -m cosmos_framework.scripts.train --sft-toml=...``
-  (TOML recipe + Hydra overrides), an explicit **DCP checkpoint conversion**
-  prepare step, and a **DCP -> safetensors** export step. 8xH100 floor.
+* **LeRobot** - build a ``TrainPipelineConfig`` and call
+  ``lerobot.scripts.lerobot_train.train(cfg)`` in-process. HF-native checkpoints.
+* **GR00T N1.7** - build a ``FinetuneConfig`` -> ``Config`` and call
+  ``gr00t.experiment.experiment.run(config)``; ``tune_llm/visual/projector/
+  diffusion`` knobs + a modality-config ``.py``.
+* **Cosmos3** - build the SFT ``Config`` via ``load_experiment_from_toml`` and
+  call ``cosmos_framework.scripts.train.launch(config, args)``; with an explicit
+  **DCP checkpoint conversion** prepare step and a **DCP -> safetensors** export
+  step. 8xH100 floor.
+
+All three run **in-process** (imported and called as libraries, no subprocess);
+multi-GPU goes through torch's programmatic ``elastic_launch``.
 
 All three nonetheless converge on:
 
@@ -62,8 +66,8 @@ class TrainSpec:
         global_batch_size: Batch summed across GPUs before grad accumulation.
         learning_rate: Initial LR.
         save_freq: Checkpoint cadence in steps.
-        num_gpus: GPUs on this node. ``>1`` selects the multi-GPU launcher
-            (``accelerate`` for lerobot, ``torchrun`` for groot/cosmos).
+        num_gpus: GPUs on this node. ``>1`` runs the backend under torch's
+            in-process ``elastic_launch`` (the engine behind ``torchrun``).
         num_nodes: Nodes for multi-node training (Cosmos HSDP /
             ``torchrun --nnodes``).
         resume: Resume from the latest checkpoint under ``output_dir`` when
@@ -148,13 +152,17 @@ class Trainer(ABC):
     """Abstract base class for post-tuning a policy of one provider family.
 
     Lifecycle: :meth:`validate` (pure preflight) -> :meth:`prepare` (optional
-    one-time setup) -> :meth:`train` (launch + manage) -> :meth:`export`
-    (produce a loadable artifact). :meth:`status` answers
-    "is it *really* learning?" for an in-flight job.
+    one-time setup) -> :meth:`train` (run + collect verdict) -> :meth:`export`
+    (produce a loadable artifact). :meth:`latest_checkpoint` discovers the
+    loadable artifact a run produced; :meth:`status` is an optional best-effort
+    verdict for backends that can poll a still-running job.
 
-    Concrete trainers are thin adapters that translate a :class:`TrainSpec`
-    into their backend's native launch (a subprocess command, a config object,
-    a TOML recipe) - they do NOT reimplement training.
+    Concrete trainers are thin adapters that **import the backend package and
+    call its own training function in-process** (LeRobot ``train(cfg)``, GR00T
+    ``experiment.run(config)``, Cosmos ``train.launch(config, args)``) - they do
+    NOT reimplement training and do NOT shell out to a subprocess. Multi-GPU is
+    driven via torch's programmatic ``elastic_launch`` (the engine behind
+    ``torchrun``), still in-process.
     """
 
     @property
@@ -182,11 +190,14 @@ class Trainer(ABC):
         """Input-safety preflight shared by every backend (defense-in-depth).
 
         Returns problems for any agent-supplied value that would be unsafe to
-        interpolate into a subprocess argv (path traversal / protected
-        directories, a leading ``-`` that parses as a flag, or an ``extra`` key
-        that would smuggle an arbitrary ``--flag``). Concrete :meth:`validate`
-        implementations MUST call this first so that the ``# noqa: S603``
-        subprocess sites are genuinely fed validated input.
+        feed into the backend's config (path traversal / protected directories,
+        a leading ``-`` that a backend's argv-parity helper would read as a
+        flag, or an ``extra`` key that would set an arbitrary config attribute /
+        Hydra override). Concrete :meth:`validate` implementations MUST call
+        this first so untrusted ``TrainSpec`` input is checked before any config
+        is built. (Training itself is in-process now - no subprocess argv - but
+        the ``extra`` escape hatch and path fields still reach backend internals,
+        so the gate remains.)
 
         Imported lazily here (not at module top) to break the
         ``base ↔ _validate`` cyclic import that CodeQL flagged: ``_validate``
@@ -208,27 +219,39 @@ class Trainer(ABC):
 
     @abstractmethod
     def train(self, spec: TrainSpec) -> TrainResult:
-        """Build and launch the backend's training, returning a result.
+        """Run the backend's training in-process and return the final result.
 
-        Responsible for: selecting the launcher (``python`` / ``accelerate
-        launch`` / ``torchrun``), mapping :class:`TrainSpec` to native flags,
-        wiring resume, and surfacing the checkpoint dir + a status. Long runs
-        SHOULD launch detached and return ``status="running"`` with a
-        ``job_id`` that :meth:`status` can poll.
+        Responsible for: building the backend's typed config from the
+        :class:`TrainSpec`, wiring resume, selecting single- vs multi-GPU
+        (``elastic_launch`` for ``num_gpus > 1``), invoking the backend's own
+        training function, and surfacing the checkpoint dir + metrics verdict.
+
+        Training is **synchronous**: this call blocks until the run finishes (or
+        raises) and returns a terminal ``TrainResult`` (``success``/``error``)
+        with ``metrics`` already populated - there is no detached job to poll.
+        ``status()`` exists only for backends that CAN report on a separately
+        launched, still-running job; the default returns an informative error.
+        Every implementation MUST call :meth:`validate` first and fail closed.
         """
 
     def status(self, job_id: str) -> TrainResult:
-        """Return a "RUNNING != learning" verdict for an in-flight job.
+        """Optional "RUNNING != learning" verdict for a separately launched job.
 
-        Default implementation returns an ``error`` result indicating the
-        backend does not implement status tracking. Backends override to parse
-        their training logs for ``latest_step`` / ``latest_loss`` / a
+        Because :meth:`train` is synchronous and already returns the full
+        ``metrics`` verdict, this is only meaningful for a job launched OUT of
+        band (e.g. a long cosmos run started under an external launcher) that a
+        caller wants to poll by id. Most backends do not track detached jobs, so
+        the default returns an informative ``error``. Backends that DO override
+        parse their training logs for ``latest_step`` / ``latest_loss`` / a
         ``learning`` boolean.
         """
         return TrainResult(
             status="error",
             job_id=job_id,
-            message=f"{self.provider_name}: status() not implemented",
+            message=(
+                f"{self.provider_name}: status() polling is not supported - "
+                "train() runs synchronously and already returns the metrics verdict."
+            ),
         )
 
     def export(self, spec: TrainSpec, checkpoint_dir: str) -> str:
@@ -241,6 +264,20 @@ class Trainer(ABC):
         accepts.
         """
         return checkpoint_dir
+
+    def latest_checkpoint(self, output_dir: str) -> str | None:
+        """Return the newest loadable checkpoint directory under ``output_dir``.
+
+        A loadable directory is one that ``export``/``create_policy`` can consume
+        (for HF-native backends, the saved model dir). Returns ``None`` when no
+        checkpoint exists yet, or when the backend writes no discoverable
+        checkpoint tree. Powers the ``export`` action (which needs a checkpoint
+        to convert) and resume logic.
+
+        Default returns ``None`` (no discovery). Backends that write a
+        predictable checkpoint layout override this. Pure / read-only (stat only).
+        """
+        return None
 
     @property
     def hardware_floor(self) -> dict[str, Any]:

--- a/strands_robots/training/cosmos3.py
+++ b/strands_robots/training/cosmos3.py
@@ -341,9 +341,7 @@ def _run_cosmos_launch(sft_toml: str, overrides: list[str], *, log_path: str | N
     """
     import argparse
 
-    load_experiment_from_toml = _import_cosmos_module(
-        "configs.toml_config.sft_config"
-    ).load_experiment_from_toml
+    load_experiment_from_toml = _import_cosmos_module("configs.toml_config.sft_config").load_experiment_from_toml
     launch = _import_cosmos_module("scripts.train").launch
 
     config = load_experiment_from_toml(sft_toml, extra_overrides=overrides)

--- a/strands_robots/training/cosmos3.py
+++ b/strands_robots/training/cosmos3.py
@@ -6,11 +6,13 @@ the :class:`Trainer` ABC has optional ``prepare``/``export`` hooks:
 * **prepare()** — the base HF checkpoint MUST be converted to PyTorch DCP
   (``cosmos_framework.scripts.convert_model_to_dcp``) before training.
   LeRobot/GR00T need no such step.
-* **train()** — drives ``cosmos_framework.scripts.train`` via ``torchrun``.
-  A TOML recipe selects a registered experiment + scalar knobs; ``TrainSpec``
-  fields become Hydra ``key.path=value`` tail overrides (which win over the
-  TOML). The ``torchrun`` distributed launcher is invoked from Python via
-  :mod:`torch.distributed.run` (no shell, no extra interpreter).
+* **train()** — builds the cosmos ``Config`` via
+  ``cosmos_framework.configs.toml_config.sft_config.load_experiment_from_toml``
+  (TOML recipe + a Hydra ``key.path=value`` override LIST) and calls
+  ``cosmos_framework.scripts.train.launch(config, args)`` DIRECTLY. (train.py
+  has no reusable ``main()`` — only ``launch`` — verified against upstream.)
+  Multi-GPU uses torch's programmatic ``elastic_launch`` (the engine behind
+  ``torchrun``); each worker calls ``launch`` — no shell, no torchrun binary.
 * **export()** — the trained DCP is converted back to HF safetensors via
   ``cosmos_framework.scripts.export_model`` so ``create_policy`` can consume
   it.
@@ -35,6 +37,7 @@ import os
 import time
 from typing import Any
 
+from strands_robots.training._inproc import call_callable, elastic_launch_callable
 from strands_robots.training.base import Trainer, TrainResult, TrainSpec
 
 logger = logging.getLogger(__name__)
@@ -147,9 +150,12 @@ class Cosmos3Trainer(Trainer):
     def prepare(self, spec: TrainSpec) -> None:
         """Convert the base HF checkpoint to DCP (required before training).
 
-        Skips if the DCP target already exists (idempotent). Drives
-        ``cosmos_framework.scripts.convert_model_to_dcp`` as a Python library
-        — same interpreter, no subprocess.
+        Skips if the DCP target already exists (idempotent). Calls
+        ``cosmos_framework.scripts.convert_model_to_dcp.convert_model_to_dcp``
+        DIRECTLY with a typed ``Args`` object — no subprocess, no argv.
+        Verified against github.com/NVIDIA/cosmos-framework:
+        ``convert_model_to_dcp(Args(checkpoint=CheckpointOverrides(
+        checkpoint_path=<hf>), output_path=<dcp>))``.
         """
         root = self._resolve_cosmos_root(spec)
         if not root:
@@ -159,117 +165,91 @@ class Cosmos3Trainer(Trainer):
             logger.info("Cosmos3 DCP base already present at %s; skipping convert", dcp)
             return
 
+        convert_mod = _import_cosmos_module("scripts.convert_model_to_dcp")
+        CheckpointOverrides = _import_cosmos_module("inference.common.args").CheckpointOverrides
+
         os.makedirs(os.path.dirname(os.path.abspath(dcp)) or ".", exist_ok=True)
-        logger.info("Cosmos3Trainer converting base->DCP: %s -> %s", spec.base_model, dcp)
-        mod = _import_cosmos_module("scripts.convert_model_to_dcp")
-        main = getattr(mod, "main", None) or getattr(mod, "convert", None)
-        if main is None:
-            raise ImportError("cosmos_framework.scripts.convert_model_to_dcp has no main()/convert() entrypoint")
-        prev_cwd = os.getcwd()
-        try:
-            if os.path.isdir(root):
-                os.chdir(root)
-            main([spec.base_model, "-o", dcp])
-        finally:
-            os.chdir(prev_cwd)
-
-    def convert_command(self, spec: TrainSpec) -> list[str]:
-        """Argv parity helper: what ``convert_model_to_dcp`` would be called with.
-
-        Used by parity tests + ``--dry-run`` previews. The trainer no longer
-        spawns a subprocess for the conversion — it imports the module — but
-        keeping a faithful argv lets the parity suite still assert flag drift.
-        """
-        return [
-            "python",
-            "-m",
-            "cosmos_framework.scripts.convert_model_to_dcp",
-            spec.base_model,
-            "-o",
-            self._dcp_path(spec),
-        ]
+        args = convert_mod.Args(
+            checkpoint=CheckpointOverrides(checkpoint_path=spec.base_model),
+            output_path=dcp,
+        )
+        logger.info("Cosmos3Trainer converting base->DCP in-process (library call)")
+        call_callable(convert_mod.convert_model_to_dcp, args)
 
     def build_command(self, spec: TrainSpec) -> list[str]:
-        """Argv for ``cosmos_framework.scripts.train`` (driven via torch.distributed.run).
+        """PURE argv-parity helper — the torchrun CLI the library call maps to.
 
-        Kept as an argv list for parity tests and dry-run preview; at run
-        time we invoke :mod:`torch.distributed.run` from Python instead of
-        spawning a ``torchrun`` subprocess.
+        NOT used to launch training (``train()`` builds the cosmos ``Config`` via
+        ``load_experiment_from_toml`` and calls ``train.launch(config, args)``
+        directly, under ``elastic_launch`` for multi-GPU). Retained so
+        ``test_native_parity`` can assert ``--sft-toml`` + module path against
+        the real cosmos ``train.py``, and as a human-readable description.
         """
         nproc = self._nproc(spec)
-        launcher = [
+        cmd = [
             "torchrun",
             f"--nproc_per_node={nproc}",
             f"--nnodes={max(1, spec.num_nodes)}",
             "-m",
             "cosmos_framework.scripts.train",
+            f"--sft-toml={spec.extra['sft_toml']}",
+            "--",
+            *self.build_overrides(spec),
         ]
-        cmd = [*launcher, f"--sft-toml={spec.extra['sft_toml']}"]
+        return cmd
 
-        # Everything after `--` is a Hydra tail override (wins over the TOML).
-        tail: list[str] = ["--"]
-        tail.append(f"trainer.max_iter={spec.steps}")
-        tail.append(f"checkpoint.save_iter={spec.save_freq}")
-        tail.append(f"optimizer.lr={spec.learning_rate}")
-        tail.append(f"checkpoint.load_path={self._dcp_path(spec)}")
-        tail.append(f"dataloader_train.max_samples_per_batch={spec.global_batch_size}")
+    def build_overrides(self, spec: TrainSpec) -> list[str]:
+        """Hydra ``key.path=value`` override LIST passed to load_experiment_from_toml.
+
+        A LIST of ``key=value`` strings (NOT argv flags / a shell line), applied
+        after the TOML so they win. Caller ``extra.*`` keys are gated by
+        ``validate()``'s allowlist so a stray entry can't inject tokens.
+        """
+        overrides = [
+            f"trainer.max_iter={spec.steps}",
+            f"checkpoint.save_iter={spec.save_freq}",
+            f"optimizer.lr={spec.learning_rate}",
+            f"checkpoint.load_path={self._dcp_path(spec)}",
+            f"dataloader_train.max_samples_per_batch={spec.global_batch_size}",
+        ]
         if spec.num_nodes > 1:
-            tail.append(f"model.config.parallelism.data_parallel_replicate_degree={spec.num_nodes}")
+            overrides.append(f"model.config.parallelism.data_parallel_replicate_degree={spec.num_nodes}")
         if spec.seed is not None:
-            tail.append(f"trainer.seed={spec.seed}")
-
-        _consumed = {"cosmos_root", "sft_toml", "dcp_path"}
+            overrides.append(f"trainer.seed={spec.seed}")
+        _consumed = {"cosmos_root", "sft_toml", "dcp_path", "export_dir", "rdzv_endpoint"}
         for key, value in spec.extra.items():
             if key in _consumed:
                 continue
-            tail.append(f"{key}={value}")
-
-        cmd.extend(tail)
-        return cmd
+            overrides.append(f"{key}={value}")
+        return overrides
 
     def export(self, spec: TrainSpec, checkpoint_dir: str) -> str:
-        """Convert the trained DCP checkpoint back to HF safetensors.
+        """Convert the trained DCP back to HF safetensors (in-process library call).
 
-        Drives ``cosmos_framework.scripts.export_model`` as a Python library.
-        Falls back to the input ``checkpoint_dir`` (default passthrough) if
-        ``cosmos_root`` is unavailable.
+        Calls ``cosmos_framework.scripts.export_model.export_model`` DIRECTLY
+        with a typed ``Args`` object. Verified against upstream:
+        ``export_model(Args(checkpoint=CheckpointOverrides(checkpoint_path=<dcp>),
+        output_dir=<hf>))``. Falls back to the passthrough if cosmos_root absent.
         """
         root = self._resolve_cosmos_root(spec)
         out: str = str(spec.extra.get("export_dir") or os.path.join(spec.output_dir, "_exported"))
         if not root:
             return checkpoint_dir
         os.makedirs(os.path.dirname(os.path.abspath(out)) or ".", exist_ok=True)
-        logger.info("Cosmos3Trainer exporting DCP->safetensors: %s -> %s", checkpoint_dir, out)
         try:
-            mod = _import_cosmos_module("scripts.export_model")
-            main = getattr(mod, "main", None) or getattr(mod, "export", None)
-            if main is None:
-                logger.warning(
-                    "cosmos_framework.scripts.export_model has no main()/export() entrypoint; "
-                    "falling back to checkpoint_dir"
-                )
-                return checkpoint_dir
-            prev_cwd = os.getcwd()
-            try:
-                if os.path.isdir(root):
-                    os.chdir(root)
-                main([f"--checkpoint-path={checkpoint_dir}", f"--output-dir={out}"])
-            finally:
-                os.chdir(prev_cwd)
-        except Exception as e:  # noqa: BLE001 — best-effort export; surface in log
-            logger.warning("Cosmos3 export failed: %s; falling back to %s", e, checkpoint_dir)
+            export_mod = _import_cosmos_module("scripts.export_model")
+            CheckpointOverrides = _import_cosmos_module("inference.common.args").CheckpointOverrides
+
+            args = export_mod.Args(
+                checkpoint=CheckpointOverrides(checkpoint_path=checkpoint_dir),
+                output_dir=out,
+            )
+            logger.info("Cosmos3Trainer exporting DCP->safetensors in-process (library call)")
+            call_callable(export_mod.export_model, args)
+        except BaseException as e:  # noqa: BLE001 - export is best-effort; fall back
+            logger.error("Cosmos3 export failed (%s); returning DCP checkpoint dir", e)
             return checkpoint_dir
         return out
-
-    def export_command(self, spec: TrainSpec, checkpoint_dir: str, out: str) -> list[str]:
-        """Argv parity helper for ``export_model`` (see :meth:`build_command`)."""
-        return [
-            "python",
-            "-m",
-            "cosmos_framework.scripts.export_model",
-            f"--checkpoint-path={checkpoint_dir}",
-            f"--output-dir={out}",
-        ]
 
     def train(self, spec: TrainSpec) -> TrainResult:
         problems = self.validate(spec)
@@ -283,122 +263,109 @@ class Cosmos3Trainer(Trainer):
         parent = os.path.dirname(os.path.abspath(spec.output_dir)) or "."
         os.makedirs(parent, exist_ok=True)
 
-        # prepare(): convert base -> DCP (idempotent), as a Python library call.
+        # prepare(): convert base -> DCP (idempotent, in-process library call).
         try:
             self.prepare(spec)
-        except ImportError as e:
-            return TrainResult(
-                status="error",
-                job_id="",
-                message=f"DCP conversion (prepare) failed: {e}",
-            )
-        except Exception as e:  # noqa: BLE001 — prepare is user-library code
+        except BaseException as e:  # noqa: BLE001 - surface convert failure as result
             return TrainResult(
                 status="error",
                 job_id="",
                 message=f"DCP conversion (prepare) failed: {e}",
             )
 
-        job_id = f"cosmos3-{int(time.time())}"
-        log_path = os.path.join(parent, f"{os.path.basename(spec.output_dir)}.{job_id}.log")
-        root = self._resolve_cosmos_root(spec)
-
-        # Verify the train entrypoint is importable BEFORE we spin up torchrun.
+        # Verify the train entrypoint imports BEFORE spinning up workers.
         try:
             _import_cosmos_module("scripts.train")
         except ImportError as e:
-            return TrainResult(
-                status="error",
-                job_id=job_id,
-                message=str(e),
-            )
+            return TrainResult(status="error", job_id=f"cosmos3-{int(time.time())}", message=str(e))
 
-        # Build the argv that torch.distributed.run will execute as if from a shell.
-        train_argv = self._distributed_argv(spec)
+        sft_toml = str(spec.extra["sft_toml"])
+        overrides = self.build_overrides(spec)
+        job_id = f"cosmos3-{int(time.time())}"
+        log_path = os.path.join(parent, f"{os.path.basename(spec.output_dir)}.{job_id}.log")
+        nproc = self._nproc(spec)
 
-        logger.info("Cosmos3Trainer launching (torch.distributed.run): %s", " ".join(train_argv))
-        prev_env = {k: os.environ.get(k) for k in ("PYTHONUNBUFFERED",)}
-        os.environ["PYTHONUNBUFFERED"] = "1"
-        prev_cwd = os.getcwd()
-        rc = 0
+        logger.info(
+            "Cosmos3Trainer launching train.launch() in-process: nproc=%d nnodes=%d steps=%d",
+            nproc,
+            max(1, spec.num_nodes),
+            spec.steps,
+        )
+
+        train_error: BaseException | None = None
         try:
-            if root and os.path.isdir(root):
-                os.chdir(root)
-            # Redirect stdout/stderr to log_path while torch.distributed.run executes.
-            with open(log_path, "w", encoding="utf-8") as logf:
-                import contextlib
-
-                from torch.distributed import run as torch_run
-
-                with contextlib.redirect_stdout(logf), contextlib.redirect_stderr(logf):
-                    try:
-                        torch_run.main(train_argv)
-                    except SystemExit as se:
-                        rc = int(se.code) if se.code is not None else 0
-        except ImportError as e:
-            return TrainResult(
-                status="error",
-                job_id=job_id,
-                message=f"torch.distributed.run not available ({e}); install torch with distributed support",
-            )
-        except Exception as e:  # noqa: BLE001 — surface launcher errors
-            return TrainResult(
-                status="error",
-                job_id=job_id,
-                message=f"cosmos_framework.scripts.train raised: {e}; see {log_path}",
-            )
-        finally:
-            os.chdir(prev_cwd)
-            for k, v in prev_env.items():
-                if v is None:
-                    os.environ.pop(k, None)
-                else:
-                    os.environ[k] = v
+            if nproc > 1 or spec.num_nodes > 1:
+                # Multi-GPU/-node: torch elastic agent spawns workers; each builds
+                # the cosmos Config and calls train.launch() — Python objects, no
+                # argv, no torchrun binary.
+                rdzv = str(spec.extra.get("rdzv_endpoint", "")) if spec.num_nodes > 1 else ""
+                elastic_launch_callable(
+                    _cosmos_worker,
+                    nproc_per_node=nproc,
+                    nnodes=max(1, spec.num_nodes),
+                    rdzv_endpoint=rdzv,
+                    run_id=job_id,
+                    fn_args=(sft_toml, overrides, log_path),
+                )
+            else:
+                _run_cosmos_launch(sft_toml, overrides, log_path=log_path)
+        except BaseException as e:  # noqa: BLE001 - convert ANY failure to a result
+            train_error = e
+            logger.error("Cosmos3Trainer in-process train failed: %s", e)
 
         ckpt = spec.output_dir
-        if rc != 0:
+        if train_error is not None:
             return TrainResult(
                 status="error",
                 job_id=job_id,
                 checkpoint_dir=ckpt,
-                message=f"cosmos_framework.scripts.train exited {rc}; see {log_path}",
+                message=f"cosmos_framework train.launch() raised {type(train_error).__name__}: {train_error}; see {log_path}",
             )
         return TrainResult(
             status="success",
             job_id=job_id,
             checkpoint_dir=ckpt,
-            message=f"Cosmos3 SFT complete; log: {log_path}",
+            message=f"Cosmos3 SFT complete (in-process); log: {log_path}",
         )
 
-    def _distributed_argv(self, spec: TrainSpec) -> list[str]:
-        """Build the argv for :func:`torch.distributed.run.main`.
 
-        Equivalent to the ``torchrun --nproc_per_node=N --nnodes=M -m
-        cosmos_framework.scripts.train ...`` argv, but consumed by
-        :mod:`torch.distributed.run` in-process (no subprocess for ``torchrun``
-        itself; it still spawns worker processes as torch.distributed requires).
-        """
-        nproc = self._nproc(spec)
-        argv: list[str] = [
-            f"--nproc_per_node={nproc}",
-            f"--nnodes={max(1, spec.num_nodes)}",
-            "-m",
-            "cosmos_framework.scripts.train",
-            f"--sft-toml={spec.extra['sft_toml']}",
-            "--",
-            f"trainer.max_iter={spec.steps}",
-            f"checkpoint.save_iter={spec.save_freq}",
-            f"optimizer.lr={spec.learning_rate}",
-            f"checkpoint.load_path={self._dcp_path(spec)}",
-            f"dataloader_train.max_samples_per_batch={spec.global_batch_size}",
-        ]
-        if spec.num_nodes > 1:
-            argv.append(f"model.config.parallelism.data_parallel_replicate_degree={spec.num_nodes}")
-        if spec.seed is not None:
-            argv.append(f"trainer.seed={spec.seed}")
-        _consumed = {"cosmos_root", "sft_toml", "dcp_path"}
-        for key, value in spec.extra.items():
-            if key in _consumed:
-                continue
-            argv.append(f"{key}={value}")
-        return argv
+def _run_cosmos_launch(sft_toml: str, overrides: list[str], *, log_path: str | None = None) -> None:
+    """Build the cosmos Config from TOML + overrides and call train.launch(config, args).
+
+    Mirrors ``cosmos_framework/scripts/train.py``'s ``__main__`` (which has NO
+    reusable ``main()``): it builds ``config`` via ``load_experiment_from_toml``
+    and calls ``launch(config, args)``. We construct the same argparse-shaped
+    ``args`` namespace with the non-deterministic, non-debug defaults the script
+    uses for a real run, so calling ``launch`` is behaviourally identical to the
+    CLI — minus the process spawn and argv parse.
+    """
+    import argparse
+
+    load_experiment_from_toml = _import_cosmos_module(
+        "configs.toml_config.sft_config"
+    ).load_experiment_from_toml
+    launch = _import_cosmos_module("scripts.train").launch
+
+    config = load_experiment_from_toml(sft_toml, extra_overrides=overrides)
+    args = argparse.Namespace(
+        sft_toml=sft_toml,
+        opts=list(overrides),
+        deterministic=False,
+        attach_vscode_debugger=False,
+        dryrun=False,
+        config=sft_toml,
+    )
+    call_callable(launch, config, args, log_path=log_path)
+
+
+def _cosmos_worker(sft_toml: str, overrides: list[str], log_path: str) -> None:
+    """elastic_launch worker: build the cosmos Config and call train.launch() here.
+
+    Runs in a torch-spawned worker (one per GPU). torch sets RANK / LOCAL_RANK /
+    WORLD_SIZE; cosmos's distributed.init() reads them. Only local rank 0 tees to
+    the shared log file to avoid interleaved writes.
+    """
+    import os as _os
+
+    is_rank0 = _os.environ.get("LOCAL_RANK", "0") == "0"
+    _run_cosmos_launch(sft_toml, overrides, log_path=log_path if is_rank0 else None)

--- a/strands_robots/training/cosmos3.py
+++ b/strands_robots/training/cosmos3.py
@@ -49,7 +49,7 @@ _INSTALL_HINT = (
 )
 
 
-def _import_cosmos_module(qualname: str):
+def _import_cosmos_module(qualname: str) -> Any:
     """Import ``cosmos_framework.<qualname>`` or raise a helpful ImportError.
 
     ``qualname`` is e.g. ``scripts.convert_model_to_dcp`` /
@@ -235,7 +235,7 @@ class Cosmos3Trainer(Trainer):
         ``cosmos_root`` is unavailable.
         """
         root = self._resolve_cosmos_root(spec)
-        out = spec.extra.get("export_dir", os.path.join(spec.output_dir, "_exported"))
+        out: str = str(spec.extra.get("export_dir") or os.path.join(spec.output_dir, "_exported"))
         if not root:
             return checkpoint_dir
         os.makedirs(os.path.dirname(os.path.abspath(out)) or ".", exist_ok=True)

--- a/strands_robots/training/cosmos3.py
+++ b/strands_robots/training/cosmos3.py
@@ -246,7 +246,7 @@ class Cosmos3Trainer(Trainer):
             )
             logger.info("Cosmos3Trainer exporting DCP->safetensors in-process (library call)")
             call_callable(export_mod.export_model, args)
-        except BaseException as e:  # noqa: BLE001 - export is best-effort; fall back
+        except Exception as e:  # noqa: BLE001 - export is best-effort; fall back
             logger.error("Cosmos3 export failed (%s); returning DCP checkpoint dir", e)
             return checkpoint_dir
         return out
@@ -266,7 +266,7 @@ class Cosmos3Trainer(Trainer):
         # prepare(): convert base -> DCP (idempotent, in-process library call).
         try:
             self.prepare(spec)
-        except BaseException as e:  # noqa: BLE001 - surface convert failure as result
+        except Exception as e:  # noqa: BLE001 - surface convert failure as result
             return TrainResult(
                 status="error",
                 job_id="",
@@ -292,7 +292,7 @@ class Cosmos3Trainer(Trainer):
             spec.steps,
         )
 
-        train_error: BaseException | None = None
+        train_error: Exception | None = None
         try:
             if nproc > 1 or spec.num_nodes > 1:
                 # Multi-GPU/-node: torch elastic agent spawns workers; each builds
@@ -309,7 +309,7 @@ class Cosmos3Trainer(Trainer):
                 )
             else:
                 _run_cosmos_launch(sft_toml, overrides, log_path=log_path)
-        except BaseException as e:  # noqa: BLE001 - convert ANY failure to a result
+        except Exception as e:  # noqa: BLE001 - convert ANY failure to a result
             train_error = e
             logger.error("Cosmos3Trainer in-process train failed: %s", e)
 

--- a/strands_robots/training/cosmos3.py
+++ b/strands_robots/training/cosmos3.py
@@ -119,10 +119,7 @@ class Cosmos3Trainer(Trainer):
             return None
         # Anything other than our own _dcp_base / _exported scratch dirs means
         # training has written checkpoint state here.
-        entries = [
-            e for e in os.listdir(output_dir)
-            if e not in ("_dcp_base", "_exported") and not e.endswith(".log")
-        ]
+        entries = [e for e in os.listdir(output_dir) if e not in ("_dcp_base", "_exported") and not e.endswith(".log")]
         return output_dir if entries else None
 
     def validate(self, spec: TrainSpec) -> list[str]:

--- a/strands_robots/training/cosmos3.py
+++ b/strands_robots/training/cosmos3.py
@@ -72,9 +72,7 @@ class Cosmos3Trainer(Trainer):
 
     def _dcp_path(self, spec: TrainSpec) -> str:
         """Where prepare() writes (and train() reads) the DCP base checkpoint."""
-        return spec.extra.get(
-            "dcp_path", os.path.join(spec.output_dir, "_dcp_base")
-        )
+        return str(spec.extra.get("dcp_path", os.path.join(spec.output_dir, "_dcp_base")))
 
     def _nproc(self, spec: TrainSpec) -> int:
         return max(1, spec.num_gpus)
@@ -99,8 +97,7 @@ class Cosmos3Trainer(Trainer):
 
         if spec.method not in _SUPPORTED_METHODS:
             problems.append(
-                f"unsupported method '{spec.method}' for Cosmos3 "
-                f"(expected one of {sorted(_SUPPORTED_METHODS)})"
+                f"unsupported method '{spec.method}' for Cosmos3 (expected one of {sorted(_SUPPORTED_METHODS)})"
             )
         if spec.steps <= 0:
             problems.append(f"steps must be > 0, got {spec.steps}")
@@ -116,8 +113,7 @@ class Cosmos3Trainer(Trainer):
         root = self._resolve_cosmos_root(spec)
         if not root:
             problems.append(
-                "cosmos-framework checkout not found; set COSMOS_ROOT, pass "
-                "cosmos_root=..., or extra['cosmos_root']"
+                "cosmos-framework checkout not found; set COSMOS_ROOT, pass cosmos_root=..., or extra['cosmos_root']"
             )
         elif not os.path.isdir(os.path.join(root, "cosmos_framework")):
             problems.append(f"cosmos_framework package not found under cosmos_root={root}")
@@ -148,10 +144,12 @@ class Cosmos3Trainer(Trainer):
     def convert_command(self, spec: TrainSpec) -> list[str]:
         """python -m cosmos_framework.scripts.convert_model_to_dcp <ckpt> -o <dcp>."""
         return [
-            self.python_executable, "-m",
+            self.python_executable,
+            "-m",
             "cosmos_framework.scripts.convert_model_to_dcp",
             spec.base_model,
-            "-o", self._dcp_path(spec),
+            "-o",
+            self._dcp_path(spec),
         ]
 
     def build_command(self, spec: TrainSpec) -> list[str]:
@@ -161,7 +159,8 @@ class Cosmos3Trainer(Trainer):
             "torchrun",
             f"--nproc_per_node={nproc}",
             f"--nnodes={max(1, spec.num_nodes)}",
-            "-m", "cosmos_framework.scripts.train",
+            "-m",
+            "cosmos_framework.scripts.train",
         ]
         cmd = [*launcher, f"--sft-toml={spec.extra['sft_toml']}"]
 
@@ -175,9 +174,7 @@ class Cosmos3Trainer(Trainer):
         tail.append(f"dataloader_train.max_samples_per_batch={spec.global_batch_size}")
         # Multi-node HSDP: replicate degree = number of nodes.
         if spec.num_nodes > 1:
-            tail.append(
-                f"model.config.parallelism.data_parallel_replicate_degree={spec.num_nodes}"
-            )
+            tail.append(f"model.config.parallelism.data_parallel_replicate_degree={spec.num_nodes}")
         if spec.seed is not None:
             tail.append(f"trainer.seed={spec.seed}")
 
@@ -199,9 +196,7 @@ class Cosmos3Trainer(Trainer):
         unavailable, falls back to the default passthrough.
         """
         root = self._resolve_cosmos_root(spec)
-        out = spec.extra.get(
-            "export_dir", os.path.join(spec.output_dir, "_exported")
-        )
+        out = spec.extra.get("export_dir", os.path.join(spec.output_dir, "_exported"))
         if not root:
             return checkpoint_dir
         cmd = self.export_command(spec, checkpoint_dir, out)
@@ -215,7 +210,8 @@ class Cosmos3Trainer(Trainer):
     def export_command(self, spec: TrainSpec, checkpoint_dir: str, out: str) -> list[str]:
         """python -m cosmos_framework.scripts.export_model (DCP -> safetensors)."""
         return [
-            self.python_executable, "-m",
+            self.python_executable,
+            "-m",
             "cosmos_framework.scripts.export_model",
             f"--checkpoint-path={checkpoint_dir}",
             f"--output-dir={out}",
@@ -225,7 +221,8 @@ class Cosmos3Trainer(Trainer):
         problems = self.validate(spec)
         if problems:
             return TrainResult(
-                status="error", job_id="",
+                status="error",
+                job_id="",
                 message="validation failed: " + "; ".join(problems),
             )
 
@@ -237,7 +234,8 @@ class Cosmos3Trainer(Trainer):
             self.prepare(spec)
         except subprocess.CalledProcessError as e:
             return TrainResult(
-                status="error", job_id="",
+                status="error",
+                job_id="",
                 message=f"DCP conversion (prepare) failed: {e}",
             )
 
@@ -253,22 +251,31 @@ class Cosmos3Trainer(Trainer):
         try:
             with open(log_path, "w", encoding="utf-8") as logf:
                 proc = subprocess.run(  # noqa: S603 - argv values validated by validate()/_security_problems before train() builds the command; list form, no shell
-                    cmd, cwd=root, env=env,
-                    stdout=logf, stderr=subprocess.STDOUT, check=False,
+                    cmd,
+                    cwd=root,
+                    env=env,
+                    stdout=logf,
+                    stderr=subprocess.STDOUT,
+                    check=False,
                 )
         except FileNotFoundError as e:
             return TrainResult(
-                status="error", job_id=job_id,
+                status="error",
+                job_id=job_id,
                 message=f"torchrun not found ({e}); is cosmos-framework's train env active?",
             )
 
         ckpt = spec.output_dir
         if proc.returncode != 0:
             return TrainResult(
-                status="error", job_id=job_id, checkpoint_dir=ckpt,
+                status="error",
+                job_id=job_id,
+                checkpoint_dir=ckpt,
                 message=f"cosmos_framework.scripts.train exited {proc.returncode}; see {log_path}",
             )
         return TrainResult(
-            status="success", job_id=job_id, checkpoint_dir=ckpt,
+            status="success",
+            job_id=job_id,
+            checkpoint_dir=ckpt,
             message=f"Cosmos3 SFT complete; log: {log_path}",
         )

--- a/strands_robots/training/cosmos3.py
+++ b/strands_robots/training/cosmos3.py
@@ -1,33 +1,37 @@
-"""Cosmos3 trainer - wrapper over cosmos_framework's SFT pipeline.
+"""Cosmos3 trainer — wrapper over cosmos_framework's SFT pipeline.
 
 Cosmos3 has the most distinct pipeline of the three backends, and is the reason
 the :class:`Trainer` ABC has optional ``prepare``/``export`` hooks:
 
-* **prepare()** - the base HF checkpoint MUST be converted to PyTorch DCP
-  (``python -m cosmos_framework.scripts.convert_model_to_dcp <ckpt> -o <dcp>``)
-  before training. LeRobot/GR00T need no such step.
-* **train()** - ``torchrun --nproc_per_node=N -m cosmos_framework.scripts.train
-  --sft-toml=<recipe.toml> -- <Hydra tail overrides>``. The TOML recipe selects
-  a registered experiment + scalar knobs; ``TrainSpec`` fields become Hydra
-  ``key.path=value`` tail overrides (which win over the TOML).
-* **export()** - the trained DCP is converted back to HF safetensors
-  (``python -m cosmos_framework.scripts.export_model``) so ``create_policy`` can
-  consume it.
+* **prepare()** — the base HF checkpoint MUST be converted to PyTorch DCP
+  (``cosmos_framework.scripts.convert_model_to_dcp``) before training.
+  LeRobot/GR00T need no such step.
+* **train()** — drives ``cosmos_framework.scripts.train`` via ``torchrun``.
+  A TOML recipe selects a registered experiment + scalar knobs; ``TrainSpec``
+  fields become Hydra ``key.path=value`` tail overrides (which win over the
+  TOML). The ``torchrun`` distributed launcher is invoked from Python via
+  :mod:`torch.distributed.run` (no shell, no extra interpreter).
+* **export()** — the trained DCP is converted back to HF safetensors via
+  ``cosmos_framework.scripts.export_model`` so ``create_policy`` can consume
+  it.
 
-Multi-node HSDP maps ``num_nodes`` ->
+Multi-node HSDP maps ``num_nodes`` →
 ``model.config.parallelism.data_parallel_replicate_degree`` (intra-node shard
-stays at ``nproc_per_node``). 8xH100 80GB is the tested floor.
+stays at ``nproc_per_node``). 8×H100 80 GB is the tested floor.
 
 The cosmos_framework checkout is resolved from ``COSMOS_ROOT`` env var or
 ``extra['cosmos_root']``; the SFT recipe TOML from ``extra['sft_toml']``.
+
+Install cosmos-framework from source (per its README) and ensure
+``cosmos_framework`` is importable in the active Python — this trainer drives
+it as a Python library, NOT as a subprocess invoking another interpreter.
 """
 
 from __future__ import annotations
 
+import importlib
 import logging
 import os
-import subprocess
-import sys
 import time
 from typing import Any
 
@@ -37,24 +41,48 @@ logger = logging.getLogger(__name__)
 
 _SUPPORTED_METHODS = {"full", "lora"}
 
+_INSTALL_HINT = (
+    "cosmos-framework is not importable from this interpreter. "
+    "Install it from source (see https://github.com/nvidia-cosmos/cosmos-framework "
+    "or the path passed via cosmos_root / COSMOS_ROOT) into the *same* Python "
+    "that imports strands_robots — e.g. `pip install -e $COSMOS_ROOT`."
+)
+
+
+def _import_cosmos_module(qualname: str):
+    """Import ``cosmos_framework.<qualname>`` or raise a helpful ImportError.
+
+    ``qualname`` is e.g. ``scripts.convert_model_to_dcp`` /
+    ``scripts.train`` / ``scripts.export_model``. We resolve as a Python
+    library so the trainer runs in-process — no nested ``python`` invocation.
+    """
+    full = f"cosmos_framework.{qualname}"
+    try:
+        return importlib.import_module(full)
+    except ImportError as e:  # pragma: no cover - exercised in integration
+        raise ImportError(f"{_INSTALL_HINT} (failed to import {full})") from e
+
 
 class Cosmos3Trainer(Trainer):
     """Post-tune an NVIDIA Cosmos3 policy via cosmos_framework SFT.
 
     Args:
-        cosmos_root: Path to the cosmos-framework checkout. Falls back to the
-            ``COSMOS_ROOT`` env var, then ``TrainSpec.extra['cosmos_root']``.
-        python_executable: Interpreter for subprocesses (default current).
+        cosmos_root: Path to the cosmos-framework checkout (used for
+            ``torchrun``'s ``cwd`` so relative recipe/config paths resolve).
+            Falls back to the ``COSMOS_ROOT`` env var, then
+            ``TrainSpec.extra['cosmos_root']``. The package itself is loaded
+            as a Python library via :func:`importlib.import_module` from the
+            active interpreter — install from source per cosmos-framework's
+            README; ``COSMOS_ROOT`` is for runtime config resolution, not the
+            interpreter path.
     """
 
     def __init__(
         self,
         cosmos_root: str | None = None,
-        python_executable: str | None = None,
         **kwargs: Any,
     ) -> None:
         self.cosmos_root = cosmos_root or os.environ.get("COSMOS_ROOT")
-        self.python_executable = python_executable or sys.executable
 
     @property
     def provider_name(self) -> str:
@@ -65,8 +93,6 @@ class Cosmos3Trainer(Trainer):
         # SFT tested on 8xH100 80GB; HSDP multi-node beyond.
         return {"min_gpus": 8, "min_vram_gb": 80, "multinode": True}
 
-    # ---- helpers -----------------------------------------------------------
-
     def _resolve_cosmos_root(self, spec: TrainSpec) -> str | None:
         return self.cosmos_root or spec.extra.get("cosmos_root")
 
@@ -76,8 +102,6 @@ class Cosmos3Trainer(Trainer):
 
     def _nproc(self, spec: TrainSpec) -> int:
         return max(1, spec.num_gpus)
-
-    # ---- ABC ---------------------------------------------------------------
 
     def validate(self, spec: TrainSpec) -> list[str]:
         problems: list[str] = self._security_problems(spec)
@@ -123,8 +147,9 @@ class Cosmos3Trainer(Trainer):
     def prepare(self, spec: TrainSpec) -> None:
         """Convert the base HF checkpoint to DCP (required before training).
 
-        Skips if the DCP target already exists (idempotent). Honored only when
-        a cosmos_root is resolvable; otherwise train()'s validate() reports it.
+        Skips if the DCP target already exists (idempotent). Drives
+        ``cosmos_framework.scripts.convert_model_to_dcp`` as a Python library
+        — same interpreter, no subprocess.
         """
         root = self._resolve_cosmos_root(spec)
         if not root:
@@ -134,17 +159,29 @@ class Cosmos3Trainer(Trainer):
             logger.info("Cosmos3 DCP base already present at %s; skipping convert", dcp)
             return
 
-        cmd = self.convert_command(spec)
         os.makedirs(os.path.dirname(os.path.abspath(dcp)) or ".", exist_ok=True)
-        logger.info("Cosmos3Trainer converting base->DCP: %s", " ".join(cmd))
-        env = dict(os.environ)
-        env.setdefault("PYTHONUNBUFFERED", "1")
-        subprocess.run(cmd, cwd=root, env=env, check=True)  # noqa: S603 - argv values validated by validate()/_security_problems before train() builds the command; list form, no shell
+        logger.info("Cosmos3Trainer converting base->DCP: %s -> %s", spec.base_model, dcp)
+        mod = _import_cosmos_module("scripts.convert_model_to_dcp")
+        main = getattr(mod, "main", None) or getattr(mod, "convert", None)
+        if main is None:
+            raise ImportError("cosmos_framework.scripts.convert_model_to_dcp has no main()/convert() entrypoint")
+        prev_cwd = os.getcwd()
+        try:
+            if os.path.isdir(root):
+                os.chdir(root)
+            main([spec.base_model, "-o", dcp])
+        finally:
+            os.chdir(prev_cwd)
 
     def convert_command(self, spec: TrainSpec) -> list[str]:
-        """python -m cosmos_framework.scripts.convert_model_to_dcp <ckpt> -o <dcp>."""
+        """Argv parity helper: what ``convert_model_to_dcp`` would be called with.
+
+        Used by parity tests + ``--dry-run`` previews. The trainer no longer
+        spawns a subprocess for the conversion — it imports the module — but
+        keeping a faithful argv lets the parity suite still assert flag drift.
+        """
         return [
-            self.python_executable,
+            "python",
             "-m",
             "cosmos_framework.scripts.convert_model_to_dcp",
             spec.base_model,
@@ -153,7 +190,12 @@ class Cosmos3Trainer(Trainer):
         ]
 
     def build_command(self, spec: TrainSpec) -> list[str]:
-        """torchrun -m cosmos_framework.scripts.train --sft-toml=... -- <overrides>."""
+        """Argv for ``cosmos_framework.scripts.train`` (driven via torch.distributed.run).
+
+        Kept as an argv list for parity tests and dry-run preview; at run
+        time we invoke :mod:`torch.distributed.run` from Python instead of
+        spawning a ``torchrun`` subprocess.
+        """
         nproc = self._nproc(spec)
         launcher = [
             "torchrun",
@@ -170,20 +212,16 @@ class Cosmos3Trainer(Trainer):
         tail.append(f"checkpoint.save_iter={spec.save_freq}")
         tail.append(f"optimizer.lr={spec.learning_rate}")
         tail.append(f"checkpoint.load_path={self._dcp_path(spec)}")
-        # Per-step batch lives in the experiment; expose the count knob.
         tail.append(f"dataloader_train.max_samples_per_batch={spec.global_batch_size}")
-        # Multi-node HSDP: replicate degree = number of nodes.
         if spec.num_nodes > 1:
             tail.append(f"model.config.parallelism.data_parallel_replicate_degree={spec.num_nodes}")
         if spec.seed is not None:
             tail.append(f"trainer.seed={spec.seed}")
 
-        # Extra Hydra overrides passthrough (skip consumed keys).
         _consumed = {"cosmos_root", "sft_toml", "dcp_path"}
         for key, value in spec.extra.items():
             if key in _consumed:
                 continue
-            # Dotted keys are treated as Hydra overrides verbatim.
             tail.append(f"{key}={value}")
 
         cmd.extend(tail)
@@ -192,25 +230,41 @@ class Cosmos3Trainer(Trainer):
     def export(self, spec: TrainSpec, checkpoint_dir: str) -> str:
         """Convert the trained DCP checkpoint back to HF safetensors.
 
-        Returns a directory that ``create_policy`` can load. If cosmos_root is
-        unavailable, falls back to the default passthrough.
+        Drives ``cosmos_framework.scripts.export_model`` as a Python library.
+        Falls back to the input ``checkpoint_dir`` (default passthrough) if
+        ``cosmos_root`` is unavailable.
         """
         root = self._resolve_cosmos_root(spec)
         out = spec.extra.get("export_dir", os.path.join(spec.output_dir, "_exported"))
         if not root:
             return checkpoint_dir
-        cmd = self.export_command(spec, checkpoint_dir, out)
         os.makedirs(os.path.dirname(os.path.abspath(out)) or ".", exist_ok=True)
-        logger.info("Cosmos3Trainer exporting DCP->safetensors: %s", " ".join(cmd))
-        env = dict(os.environ)
-        env.setdefault("PYTHONUNBUFFERED", "1")
-        proc = subprocess.run(cmd, cwd=root, env=env, check=False)  # noqa: S603 - argv values validated by validate()/_security_problems before train() builds the command; list form, no shell
-        return out if proc.returncode == 0 else checkpoint_dir
+        logger.info("Cosmos3Trainer exporting DCP->safetensors: %s -> %s", checkpoint_dir, out)
+        try:
+            mod = _import_cosmos_module("scripts.export_model")
+            main = getattr(mod, "main", None) or getattr(mod, "export", None)
+            if main is None:
+                logger.warning(
+                    "cosmos_framework.scripts.export_model has no main()/export() entrypoint; "
+                    "falling back to checkpoint_dir"
+                )
+                return checkpoint_dir
+            prev_cwd = os.getcwd()
+            try:
+                if os.path.isdir(root):
+                    os.chdir(root)
+                main([f"--checkpoint-path={checkpoint_dir}", f"--output-dir={out}"])
+            finally:
+                os.chdir(prev_cwd)
+        except Exception as e:  # noqa: BLE001 — best-effort export; surface in log
+            logger.warning("Cosmos3 export failed: %s; falling back to %s", e, checkpoint_dir)
+            return checkpoint_dir
+        return out
 
     def export_command(self, spec: TrainSpec, checkpoint_dir: str, out: str) -> list[str]:
-        """python -m cosmos_framework.scripts.export_model (DCP -> safetensors)."""
+        """Argv parity helper for ``export_model`` (see :meth:`build_command`)."""
         return [
-            self.python_executable,
+            "python",
             "-m",
             "cosmos_framework.scripts.export_model",
             f"--checkpoint-path={checkpoint_dir}",
@@ -229,49 +283,85 @@ class Cosmos3Trainer(Trainer):
         parent = os.path.dirname(os.path.abspath(spec.output_dir)) or "."
         os.makedirs(parent, exist_ok=True)
 
-        # prepare(): convert base -> DCP (idempotent).
+        # prepare(): convert base -> DCP (idempotent), as a Python library call.
         try:
             self.prepare(spec)
-        except subprocess.CalledProcessError as e:
+        except ImportError as e:
+            return TrainResult(
+                status="error",
+                job_id="",
+                message=f"DCP conversion (prepare) failed: {e}",
+            )
+        except Exception as e:  # noqa: BLE001 — prepare is user-library code
             return TrainResult(
                 status="error",
                 job_id="",
                 message=f"DCP conversion (prepare) failed: {e}",
             )
 
-        cmd = self.build_command(spec)
         job_id = f"cosmos3-{int(time.time())}"
         log_path = os.path.join(parent, f"{os.path.basename(spec.output_dir)}.{job_id}.log")
         root = self._resolve_cosmos_root(spec)
 
-        env = dict(os.environ)
-        env.setdefault("PYTHONUNBUFFERED", "1")
-
-        logger.info("Cosmos3Trainer launching: %s", " ".join(cmd))
+        # Verify the train entrypoint is importable BEFORE we spin up torchrun.
         try:
-            with open(log_path, "w", encoding="utf-8") as logf:
-                proc = subprocess.run(  # noqa: S603 - argv values validated by validate()/_security_problems before train() builds the command; list form, no shell
-                    cmd,
-                    cwd=root,
-                    env=env,
-                    stdout=logf,
-                    stderr=subprocess.STDOUT,
-                    check=False,
-                )
-        except FileNotFoundError as e:
+            _import_cosmos_module("scripts.train")
+        except ImportError as e:
             return TrainResult(
                 status="error",
                 job_id=job_id,
-                message=f"torchrun not found ({e}); is cosmos-framework's train env active?",
+                message=str(e),
             )
 
+        # Build the argv that torch.distributed.run will execute as if from a shell.
+        train_argv = self._distributed_argv(spec)
+
+        logger.info("Cosmos3Trainer launching (torch.distributed.run): %s", " ".join(train_argv))
+        prev_env = {k: os.environ.get(k) for k in ("PYTHONUNBUFFERED",)}
+        os.environ["PYTHONUNBUFFERED"] = "1"
+        prev_cwd = os.getcwd()
+        rc = 0
+        try:
+            if root and os.path.isdir(root):
+                os.chdir(root)
+            # Redirect stdout/stderr to log_path while torch.distributed.run executes.
+            with open(log_path, "w", encoding="utf-8") as logf:
+                import contextlib
+
+                from torch.distributed import run as torch_run
+
+                with contextlib.redirect_stdout(logf), contextlib.redirect_stderr(logf):
+                    try:
+                        torch_run.main(train_argv)
+                    except SystemExit as se:
+                        rc = int(se.code) if se.code is not None else 0
+        except ImportError as e:
+            return TrainResult(
+                status="error",
+                job_id=job_id,
+                message=f"torch.distributed.run not available ({e}); install torch with distributed support",
+            )
+        except Exception as e:  # noqa: BLE001 — surface launcher errors
+            return TrainResult(
+                status="error",
+                job_id=job_id,
+                message=f"cosmos_framework.scripts.train raised: {e}; see {log_path}",
+            )
+        finally:
+            os.chdir(prev_cwd)
+            for k, v in prev_env.items():
+                if v is None:
+                    os.environ.pop(k, None)
+                else:
+                    os.environ[k] = v
+
         ckpt = spec.output_dir
-        if proc.returncode != 0:
+        if rc != 0:
             return TrainResult(
                 status="error",
                 job_id=job_id,
                 checkpoint_dir=ckpt,
-                message=f"cosmos_framework.scripts.train exited {proc.returncode}; see {log_path}",
+                message=f"cosmos_framework.scripts.train exited {rc}; see {log_path}",
             )
         return TrainResult(
             status="success",
@@ -279,3 +369,36 @@ class Cosmos3Trainer(Trainer):
             checkpoint_dir=ckpt,
             message=f"Cosmos3 SFT complete; log: {log_path}",
         )
+
+    def _distributed_argv(self, spec: TrainSpec) -> list[str]:
+        """Build the argv for :func:`torch.distributed.run.main`.
+
+        Equivalent to the ``torchrun --nproc_per_node=N --nnodes=M -m
+        cosmos_framework.scripts.train ...`` argv, but consumed by
+        :mod:`torch.distributed.run` in-process (no subprocess for ``torchrun``
+        itself; it still spawns worker processes as torch.distributed requires).
+        """
+        nproc = self._nproc(spec)
+        argv: list[str] = [
+            f"--nproc_per_node={nproc}",
+            f"--nnodes={max(1, spec.num_nodes)}",
+            "-m",
+            "cosmos_framework.scripts.train",
+            f"--sft-toml={spec.extra['sft_toml']}",
+            "--",
+            f"trainer.max_iter={spec.steps}",
+            f"checkpoint.save_iter={spec.save_freq}",
+            f"optimizer.lr={spec.learning_rate}",
+            f"checkpoint.load_path={self._dcp_path(spec)}",
+            f"dataloader_train.max_samples_per_batch={spec.global_batch_size}",
+        ]
+        if spec.num_nodes > 1:
+            argv.append(f"model.config.parallelism.data_parallel_replicate_degree={spec.num_nodes}")
+        if spec.seed is not None:
+            argv.append(f"trainer.seed={spec.seed}")
+        _consumed = {"cosmos_root", "sft_toml", "dcp_path"}
+        for key, value in spec.extra.items():
+            if key in _consumed:
+                continue
+            argv.append(f"{key}={value}")
+        return argv

--- a/strands_robots/training/cosmos3.py
+++ b/strands_robots/training/cosmos3.py
@@ -1,0 +1,274 @@
+"""Cosmos3 trainer - wrapper over cosmos_framework's SFT pipeline.
+
+Cosmos3 has the most distinct pipeline of the three backends, and is the reason
+the :class:`Trainer` ABC has optional ``prepare``/``export`` hooks:
+
+* **prepare()** - the base HF checkpoint MUST be converted to PyTorch DCP
+  (``python -m cosmos_framework.scripts.convert_model_to_dcp <ckpt> -o <dcp>``)
+  before training. LeRobot/GR00T need no such step.
+* **train()** - ``torchrun --nproc_per_node=N -m cosmos_framework.scripts.train
+  --sft-toml=<recipe.toml> -- <Hydra tail overrides>``. The TOML recipe selects
+  a registered experiment + scalar knobs; ``TrainSpec`` fields become Hydra
+  ``key.path=value`` tail overrides (which win over the TOML).
+* **export()** - the trained DCP is converted back to HF safetensors
+  (``python -m cosmos_framework.scripts.export_model``) so ``create_policy`` can
+  consume it.
+
+Multi-node HSDP maps ``num_nodes`` ->
+``model.config.parallelism.data_parallel_replicate_degree`` (intra-node shard
+stays at ``nproc_per_node``). 8xH100 80GB is the tested floor.
+
+The cosmos_framework checkout is resolved from ``COSMOS_ROOT`` env var or
+``extra['cosmos_root']``; the SFT recipe TOML from ``extra['sft_toml']``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import sys
+import time
+from typing import Any
+
+from strands_robots.training.base import Trainer, TrainResult, TrainSpec
+
+logger = logging.getLogger(__name__)
+
+_SUPPORTED_METHODS = {"full", "lora"}
+
+
+class Cosmos3Trainer(Trainer):
+    """Post-tune an NVIDIA Cosmos3 policy via cosmos_framework SFT.
+
+    Args:
+        cosmos_root: Path to the cosmos-framework checkout. Falls back to the
+            ``COSMOS_ROOT`` env var, then ``TrainSpec.extra['cosmos_root']``.
+        python_executable: Interpreter for subprocesses (default current).
+    """
+
+    def __init__(
+        self,
+        cosmos_root: str | None = None,
+        python_executable: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self.cosmos_root = cosmos_root or os.environ.get("COSMOS_ROOT")
+        self.python_executable = python_executable or sys.executable
+
+    @property
+    def provider_name(self) -> str:
+        return "cosmos3"
+
+    @property
+    def hardware_floor(self) -> dict[str, Any]:
+        # SFT tested on 8xH100 80GB; HSDP multi-node beyond.
+        return {"min_gpus": 8, "min_vram_gb": 80, "multinode": True}
+
+    # ---- helpers -----------------------------------------------------------
+
+    def _resolve_cosmos_root(self, spec: TrainSpec) -> str | None:
+        return self.cosmos_root or spec.extra.get("cosmos_root")
+
+    def _dcp_path(self, spec: TrainSpec) -> str:
+        """Where prepare() writes (and train() reads) the DCP base checkpoint."""
+        return spec.extra.get(
+            "dcp_path", os.path.join(spec.output_dir, "_dcp_base")
+        )
+
+    def _nproc(self, spec: TrainSpec) -> int:
+        return max(1, spec.num_gpus)
+
+    # ---- ABC ---------------------------------------------------------------
+
+    def validate(self, spec: TrainSpec) -> list[str]:
+        problems: list[str] = self._security_problems(spec)
+
+        if not spec.dataset_root:
+            problems.append("dataset_root is required")
+        elif not os.path.isfile(os.path.join(spec.dataset_root, "meta", "info.json")):
+            problems.append(
+                f"dataset_root is not a LeRobotDataset v3 root "
+                f"(missing {os.path.join(spec.dataset_root, 'meta', 'info.json')})"
+            )
+
+        if not spec.base_model:
+            problems.append("base_model is required (HF checkpoint to convert to DCP)")
+        if not spec.output_dir:
+            problems.append("output_dir is required")
+
+        if spec.method not in _SUPPORTED_METHODS:
+            problems.append(
+                f"unsupported method '{spec.method}' for Cosmos3 "
+                f"(expected one of {sorted(_SUPPORTED_METHODS)})"
+            )
+        if spec.steps <= 0:
+            problems.append(f"steps must be > 0, got {spec.steps}")
+
+        if not spec.extra.get("sft_toml"):
+            problems.append(
+                "Cosmos3 needs a recipe TOML; pass extra['sft_toml']=<path> "
+                "(selects the registered experiment + scalar knobs)"
+            )
+        elif not os.path.isfile(spec.extra["sft_toml"]):
+            problems.append(f"sft_toml does not exist: {spec.extra['sft_toml']}")
+
+        root = self._resolve_cosmos_root(spec)
+        if not root:
+            problems.append(
+                "cosmos-framework checkout not found; set COSMOS_ROOT, pass "
+                "cosmos_root=..., or extra['cosmos_root']"
+            )
+        elif not os.path.isdir(os.path.join(root, "cosmos_framework")):
+            problems.append(f"cosmos_framework package not found under cosmos_root={root}")
+
+        return problems
+
+    def prepare(self, spec: TrainSpec) -> None:
+        """Convert the base HF checkpoint to DCP (required before training).
+
+        Skips if the DCP target already exists (idempotent). Honored only when
+        a cosmos_root is resolvable; otherwise train()'s validate() reports it.
+        """
+        root = self._resolve_cosmos_root(spec)
+        if not root:
+            return
+        dcp = self._dcp_path(spec)
+        if os.path.isdir(os.path.join(dcp, "model")):
+            logger.info("Cosmos3 DCP base already present at %s; skipping convert", dcp)
+            return
+
+        cmd = self.convert_command(spec)
+        os.makedirs(os.path.dirname(os.path.abspath(dcp)) or ".", exist_ok=True)
+        logger.info("Cosmos3Trainer converting base->DCP: %s", " ".join(cmd))
+        env = dict(os.environ)
+        env.setdefault("PYTHONUNBUFFERED", "1")
+        subprocess.run(cmd, cwd=root, env=env, check=True)  # noqa: S603 - argv values validated by validate()/_security_problems before train() builds the command; list form, no shell
+
+    def convert_command(self, spec: TrainSpec) -> list[str]:
+        """python -m cosmos_framework.scripts.convert_model_to_dcp <ckpt> -o <dcp>."""
+        return [
+            self.python_executable, "-m",
+            "cosmos_framework.scripts.convert_model_to_dcp",
+            spec.base_model,
+            "-o", self._dcp_path(spec),
+        ]
+
+    def build_command(self, spec: TrainSpec) -> list[str]:
+        """torchrun -m cosmos_framework.scripts.train --sft-toml=... -- <overrides>."""
+        nproc = self._nproc(spec)
+        launcher = [
+            "torchrun",
+            f"--nproc_per_node={nproc}",
+            f"--nnodes={max(1, spec.num_nodes)}",
+            "-m", "cosmos_framework.scripts.train",
+        ]
+        cmd = [*launcher, f"--sft-toml={spec.extra['sft_toml']}"]
+
+        # Everything after `--` is a Hydra tail override (wins over the TOML).
+        tail: list[str] = ["--"]
+        tail.append(f"trainer.max_iter={spec.steps}")
+        tail.append(f"checkpoint.save_iter={spec.save_freq}")
+        tail.append(f"optimizer.lr={spec.learning_rate}")
+        tail.append(f"checkpoint.load_path={self._dcp_path(spec)}")
+        # Per-step batch lives in the experiment; expose the count knob.
+        tail.append(f"dataloader_train.max_samples_per_batch={spec.global_batch_size}")
+        # Multi-node HSDP: replicate degree = number of nodes.
+        if spec.num_nodes > 1:
+            tail.append(
+                f"model.config.parallelism.data_parallel_replicate_degree={spec.num_nodes}"
+            )
+        if spec.seed is not None:
+            tail.append(f"trainer.seed={spec.seed}")
+
+        # Extra Hydra overrides passthrough (skip consumed keys).
+        _consumed = {"cosmos_root", "sft_toml", "dcp_path"}
+        for key, value in spec.extra.items():
+            if key in _consumed:
+                continue
+            # Dotted keys are treated as Hydra overrides verbatim.
+            tail.append(f"{key}={value}")
+
+        cmd.extend(tail)
+        return cmd
+
+    def export(self, spec: TrainSpec, checkpoint_dir: str) -> str:
+        """Convert the trained DCP checkpoint back to HF safetensors.
+
+        Returns a directory that ``create_policy`` can load. If cosmos_root is
+        unavailable, falls back to the default passthrough.
+        """
+        root = self._resolve_cosmos_root(spec)
+        out = spec.extra.get(
+            "export_dir", os.path.join(spec.output_dir, "_exported")
+        )
+        if not root:
+            return checkpoint_dir
+        cmd = self.export_command(spec, checkpoint_dir, out)
+        os.makedirs(os.path.dirname(os.path.abspath(out)) or ".", exist_ok=True)
+        logger.info("Cosmos3Trainer exporting DCP->safetensors: %s", " ".join(cmd))
+        env = dict(os.environ)
+        env.setdefault("PYTHONUNBUFFERED", "1")
+        proc = subprocess.run(cmd, cwd=root, env=env, check=False)  # noqa: S603 - argv values validated by validate()/_security_problems before train() builds the command; list form, no shell
+        return out if proc.returncode == 0 else checkpoint_dir
+
+    def export_command(self, spec: TrainSpec, checkpoint_dir: str, out: str) -> list[str]:
+        """python -m cosmos_framework.scripts.export_model (DCP -> safetensors)."""
+        return [
+            self.python_executable, "-m",
+            "cosmos_framework.scripts.export_model",
+            f"--checkpoint-path={checkpoint_dir}",
+            f"--output-dir={out}",
+        ]
+
+    def train(self, spec: TrainSpec) -> TrainResult:
+        problems = self.validate(spec)
+        if problems:
+            return TrainResult(
+                status="error", job_id="",
+                message="validation failed: " + "; ".join(problems),
+            )
+
+        parent = os.path.dirname(os.path.abspath(spec.output_dir)) or "."
+        os.makedirs(parent, exist_ok=True)
+
+        # prepare(): convert base -> DCP (idempotent).
+        try:
+            self.prepare(spec)
+        except subprocess.CalledProcessError as e:
+            return TrainResult(
+                status="error", job_id="",
+                message=f"DCP conversion (prepare) failed: {e}",
+            )
+
+        cmd = self.build_command(spec)
+        job_id = f"cosmos3-{int(time.time())}"
+        log_path = os.path.join(parent, f"{os.path.basename(spec.output_dir)}.{job_id}.log")
+        root = self._resolve_cosmos_root(spec)
+
+        env = dict(os.environ)
+        env.setdefault("PYTHONUNBUFFERED", "1")
+
+        logger.info("Cosmos3Trainer launching: %s", " ".join(cmd))
+        try:
+            with open(log_path, "w", encoding="utf-8") as logf:
+                proc = subprocess.run(  # noqa: S603 - argv values validated by validate()/_security_problems before train() builds the command; list form, no shell
+                    cmd, cwd=root, env=env,
+                    stdout=logf, stderr=subprocess.STDOUT, check=False,
+                )
+        except FileNotFoundError as e:
+            return TrainResult(
+                status="error", job_id=job_id,
+                message=f"torchrun not found ({e}); is cosmos-framework's train env active?",
+            )
+
+        ckpt = spec.output_dir
+        if proc.returncode != 0:
+            return TrainResult(
+                status="error", job_id=job_id, checkpoint_dir=ckpt,
+                message=f"cosmos_framework.scripts.train exited {proc.returncode}; see {log_path}",
+            )
+        return TrainResult(
+            status="success", job_id=job_id, checkpoint_dir=ckpt,
+            message=f"Cosmos3 SFT complete; log: {log_path}",
+        )

--- a/strands_robots/training/cosmos3.py
+++ b/strands_robots/training/cosmos3.py
@@ -106,6 +106,25 @@ class Cosmos3Trainer(Trainer):
     def _nproc(self, spec: TrainSpec) -> int:
         return max(1, spec.num_gpus)
 
+    def latest_checkpoint(self, output_dir: str) -> str | None:
+        """Return the trained DCP checkpoint directory, or None.
+
+        cosmos_framework writes its training output (DCP shards) under
+        ``output_dir``; that directory is what ``export`` converts to HF
+        safetensors. We treat ``output_dir`` as the checkpoint once it exists
+        and is non-empty (the DCP base lives in the ``_dcp_base`` sibling, which
+        we exclude). Returns None before any training output appears.
+        """
+        if not os.path.isdir(output_dir):
+            return None
+        # Anything other than our own _dcp_base / _exported scratch dirs means
+        # training has written checkpoint state here.
+        entries = [
+            e for e in os.listdir(output_dir)
+            if e not in ("_dcp_base", "_exported") and not e.endswith(".log")
+        ]
+        return output_dir if entries else None
+
     def validate(self, spec: TrainSpec) -> list[str]:
         problems: list[str] = self._security_problems(spec)
 

--- a/strands_robots/training/factory.py
+++ b/strands_robots/training/factory.py
@@ -1,0 +1,141 @@
+"""Trainer factory - create_trainer() and runtime registration.
+
+Mirrors ``strands_robots.policies.factory`` exactly, but resolves the
+*training* class for a provider. A provider's trainer is declared in
+``registry/policies.json`` under a ``"trainer"`` block alongside its policy::
+
+    "lerobot_local": {
+        "module": "strands_robots.policies.lerobot_local",
+        "class": "LerobotLocalPolicy",
+        "trainer": {
+            "module": "strands_robots.training.lerobot",
+            "class": "LerobotTrainer"
+        },
+        ...
+    }
+
+so a single provider name owns BOTH the inference class
+(``create_policy("lerobot_local")``) and the training class
+(``create_trainer("lerobot_local")``).
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from collections.abc import Callable
+
+from strands_robots.registry.policies import get_policy_provider, list_policy_providers
+from strands_robots.training.base import Trainer
+
+logger = logging.getLogger(__name__)
+
+# Runtime registration (for user-defined trainers not in JSON)
+_runtime_registry: dict[str, Callable[[], type[Trainer]]] = {}
+_runtime_aliases: dict[str, str] = {}
+
+
+def register_trainer(
+    name: str,
+    loader: Callable[[], type[Trainer]],
+    aliases: list[str] | None = None,
+) -> None:
+    """Register a custom trainer provider at runtime.
+
+    Use this to add training backends without editing policies.json.
+
+    Example::
+
+        from strands_robots.training import register_trainer
+
+        register_trainer("my_vla", lambda: MyTrainer, aliases=["mv"])
+        trainer = create_trainer("my_vla")
+
+    Args:
+        name: Provider name.
+        loader: Zero-arg callable returning the :class:`Trainer` subclass
+            (deferred import so heavy deps load only on use).
+        aliases: Optional alternate names.
+    """
+    _runtime_registry[name] = loader
+    if aliases:
+        for alias in aliases:
+            _runtime_aliases[alias] = name
+
+
+def list_trainers() -> list[str]:
+    """List provider names that have a trainer (JSON ``trainer`` block + runtime)."""
+    names: list[str] = list(_runtime_registry.keys())
+    names.extend(_runtime_aliases.keys())
+    for provider in list_policy_providers():
+        cfg = get_policy_provider(provider)
+        if cfg and "trainer" in cfg:
+            names.append(provider)
+    return sorted(set(names))
+
+
+def import_trainer_class(provider: str) -> type[Trainer]:
+    """Import and return the :class:`Trainer` subclass for a provider.
+
+    Resolution order:
+      1. The provider's ``"trainer"`` block in policies.json.
+      2. Auto-discovery fallback: ``strands_robots.training.<provider>`` with a
+         class named ``<Provider>Trainer`` or the first ``Trainer`` subclass.
+
+    Raises:
+        ValueError: If no trainer can be resolved for the provider.
+        ImportError: If the declared module can't be imported.
+    """
+    cfg = get_policy_provider(provider)
+    if cfg and "trainer" in cfg:
+        tcfg = cfg["trainer"]
+        mod = importlib.import_module(tcfg["module"])
+        return getattr(mod, tcfg["class"])
+
+    # Auto-discovery fallback: strands_robots.training.<provider>
+    try:
+        mod = importlib.import_module(f"strands_robots.training.{provider}")
+        class_name = f"{provider.capitalize()}Trainer"
+        if hasattr(mod, class_name):
+            return getattr(mod, class_name)
+        for attr_name in dir(mod):
+            attr = getattr(mod, attr_name)
+            if isinstance(attr, type) and issubclass(attr, Trainer) and attr is not Trainer:
+                return attr
+    except ImportError:
+        # No strands_robots.training.<provider> module; fall through to the
+        # ValueError below so the caller gets the full "available trainers" list.
+        pass
+
+    raise ValueError(
+        f"No trainer registered for provider '{provider}'. "
+        f"Available trainers: {list_trainers()}"
+    )
+
+
+def create_trainer(provider: str, **kwargs) -> Trainer:
+    """Create a :class:`Trainer` for a policy provider.
+
+    The training-side peer of ``create_policy``. The provider name is the SAME
+    one used for inference, so ``create_policy("groot")`` and
+    ``create_trainer("groot")`` address one family.
+
+    Args:
+        provider: Provider name or alias (``"lerobot_local"``, ``"groot"``,
+            ``"cosmos3"``, or a runtime-registered name).
+        **kwargs: Forwarded to the trainer constructor.
+
+    Returns:
+        A ready :class:`Trainer` instance.
+
+    Raises:
+        ValueError: If no trainer is registered for the provider.
+    """
+    # 1. Runtime registry first (user-registered trainers).
+    resolved = _runtime_aliases.get(provider, provider)
+    if resolved in _runtime_registry:
+        return _runtime_registry[resolved]()(**kwargs)
+
+    # 2. Registry / auto-discovery.
+    TrainerClass = import_trainer_class(provider)
+    return TrainerClass(**kwargs)

--- a/strands_robots/training/factory.py
+++ b/strands_robots/training/factory.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import importlib
 import logging
 from collections.abc import Callable
+from typing import Any
 
 from strands_robots.registry.policies import get_policy_provider, list_policy_providers
 from strands_robots.training.base import Trainer
@@ -90,14 +91,16 @@ def import_trainer_class(provider: str) -> type[Trainer]:
     if cfg and "trainer" in cfg:
         tcfg = cfg["trainer"]
         mod = importlib.import_module(tcfg["module"])
-        return getattr(mod, tcfg["class"])
+        cls: type[Trainer] = getattr(mod, tcfg["class"])
+        return cls
 
     # Auto-discovery fallback: strands_robots.training.<provider>
     try:
         mod = importlib.import_module(f"strands_robots.training.{provider}")
         class_name = f"{provider.capitalize()}Trainer"
         if hasattr(mod, class_name):
-            return getattr(mod, class_name)
+            cls = getattr(mod, class_name)
+            return cls
         for attr_name in dir(mod):
             attr = getattr(mod, attr_name)
             if isinstance(attr, type) and issubclass(attr, Trainer) and attr is not Trainer:
@@ -107,13 +110,10 @@ def import_trainer_class(provider: str) -> type[Trainer]:
         # ValueError below so the caller gets the full "available trainers" list.
         pass
 
-    raise ValueError(
-        f"No trainer registered for provider '{provider}'. "
-        f"Available trainers: {list_trainers()}"
-    )
+    raise ValueError(f"No trainer registered for provider '{provider}'. Available trainers: {list_trainers()}")
 
 
-def create_trainer(provider: str, **kwargs) -> Trainer:
+def create_trainer(provider: str, **kwargs: Any) -> Trainer:
     """Create a :class:`Trainer` for a policy provider.
 
     The training-side peer of ``create_policy``. The provider name is the SAME

--- a/strands_robots/training/groot.py
+++ b/strands_robots/training/groot.py
@@ -62,7 +62,7 @@ _INSTALL_HINT = (
 )
 
 
-def _import_groot_module(qualname: str):
+def _import_groot_module(qualname: str) -> Any:
     """Import ``gr00t.<qualname>`` or raise a helpful ImportError."""
     full = f"gr00t.{qualname}"
     try:

--- a/strands_robots/training/groot.py
+++ b/strands_robots/training/groot.py
@@ -88,8 +88,7 @@ class Gr00tTrainer(Trainer):
 
     def _resolve_tune(self, spec: TrainSpec) -> dict[str, bool]:
         merged = dict(_DEFAULT_TUNE)
-        merged.update({k: bool(v) for k, v in (spec.tune or {}).items()
-                       if k in _DEFAULT_TUNE})
+        merged.update({k: bool(v) for k, v in (spec.tune or {}).items() if k in _DEFAULT_TUNE})
         # method=frozen_backbone => freeze llm+visual, keep projector/diffusion.
         if spec.method == "frozen_backbone":
             merged["llm"] = False
@@ -128,13 +127,11 @@ class Gr00tTrainer(Trainer):
         root = self._resolve_groot_root(spec)
         if not root:
             problems.append(
-                "Isaac-GR00T checkout not found; set GR00T_ROOT, pass "
-                "groot_root=..., or extra['groot_root']"
+                "Isaac-GR00T checkout not found; set GR00T_ROOT, pass groot_root=..., or extra['groot_root']"
             )
         elif not os.path.isfile(self._launch_script(root)):
             problems.append(
-                f"launch_finetune.py not found under groot_root={root} "
-                f"(expected {self._launch_script(root)})"
+                f"launch_finetune.py not found under groot_root={root} (expected {self._launch_script(root)})"
             )
 
         mcfg = spec.extra.get("modality_config_path")
@@ -184,9 +181,7 @@ class Gr00tTrainer(Trainer):
                 cmd.append(f"--random_rotation_angle={spec.augmentation['random_rotation_angle']}")
             if "color_jitter_params" in spec.augmentation:
                 # tyro takes color_jitter as nested; pass as JSON via extra config instead
-                cmd.append(
-                    f"--extra_augmentation_config={json.dumps(spec.augmentation)}"
-                )
+                cmd.append(f"--extra_augmentation_config={json.dumps(spec.augmentation)}")
 
         # Modality config (.py) registration.
         mcfg = spec.extra.get("modality_config_path")
@@ -209,7 +204,8 @@ class Gr00tTrainer(Trainer):
         problems = self.validate(spec)
         if problems:
             return TrainResult(
-                status="error", job_id="",
+                status="error",
+                job_id="",
                 message="validation failed: " + "; ".join(problems),
             )
 
@@ -232,23 +228,32 @@ class Gr00tTrainer(Trainer):
         try:
             with open(log_path, "w", encoding="utf-8") as logf:
                 proc = subprocess.run(  # noqa: S603 - argv values validated by validate()/_security_problems before train() builds the command; list form, no shell
-                    cmd, cwd=parent, env=env,
-                    stdout=logf, stderr=subprocess.STDOUT, check=False,
+                    cmd,
+                    cwd=parent,
+                    env=env,
+                    stdout=logf,
+                    stderr=subprocess.STDOUT,
+                    check=False,
                 )
         except FileNotFoundError as e:
             return TrainResult(
-                status="error", job_id=job_id,
+                status="error",
+                job_id=job_id,
                 message=f"launcher not found ({e}); is torchrun/python + Isaac-GR00T present?",
             )
 
         ckpt = self._latest_checkpoint(spec.output_dir)
         if proc.returncode != 0:
             return TrainResult(
-                status="error", job_id=job_id, checkpoint_dir=ckpt,
+                status="error",
+                job_id=job_id,
+                checkpoint_dir=ckpt,
                 message=f"launch_finetune.py exited {proc.returncode}; see {log_path}",
             )
         return TrainResult(
-            status="success", job_id=job_id, checkpoint_dir=ckpt,
+            status="success",
+            job_id=job_id,
+            checkpoint_dir=ckpt,
             message=f"GR00T fine-tune complete; log: {log_path}",
         )
 
@@ -257,17 +262,19 @@ class Gr00tTrainer(Trainer):
         if not os.path.isdir(output_dir):
             return None
         ckpts = [
-            d for d in os.listdir(output_dir)
-            if d.startswith("checkpoint-")
-            and os.path.isdir(os.path.join(output_dir, d))
+            d
+            for d in os.listdir(output_dir)
+            if d.startswith("checkpoint-") and os.path.isdir(os.path.join(output_dir, d))
         ]
         if not ckpts:
             return None
+
         # Highest step number wins.
         def _step(name: str) -> int:
             try:
                 return int(name.split("-", 1)[1])
             except (IndexError, ValueError):
                 return -1
+
         best = max(ckpts, key=_step)
         return os.path.join(output_dir, best)

--- a/strands_robots/training/groot.py
+++ b/strands_robots/training/groot.py
@@ -223,7 +223,7 @@ class Gr00tTrainer(Trainer):
 
         return cmd
 
-    def build_finetune_config(self, spec: TrainSpec):
+    def build_finetune_config(self, spec: TrainSpec) -> Any:
         """Build GR00T's own ``FinetuneConfig`` object from a TrainSpec (pure).
 
         Returns an instance of ``gr00t.configs.finetune_config.FinetuneConfig``
@@ -258,9 +258,7 @@ class Gr00tTrainer(Trainer):
             if "color_jitter_params" in spec.augmentation:
                 kwargs["color_jitter_params"] = spec.augmentation["color_jitter_params"]
             extra_aug = {
-                k: v
-                for k, v in spec.augmentation.items()
-                if k not in ("random_rotation_angle", "color_jitter_params")
+                k: v for k, v in spec.augmentation.items() if k not in ("random_rotation_angle", "color_jitter_params")
             }
             if extra_aug:
                 kwargs["extra_augmentation_config"] = json.dumps(extra_aug)
@@ -280,7 +278,7 @@ class Gr00tTrainer(Trainer):
                 logger.warning("Gr00tTrainer: ignoring extra '%s' (not a FinetuneConfig field).", key)
         return FinetuneConfig(**kwargs)
 
-    def _build_run_config(self, ft_config):
+    def _build_run_config(self, ft_config: Any) -> Any:
         """Lower a ``FinetuneConfig`` into the ``Config`` ``experiment.run`` consumes.
 
         Mirrors the body of ``launch_finetune.py``'s ``__main__`` exactly

--- a/strands_robots/training/groot.py
+++ b/strands_robots/training/groot.py
@@ -1,41 +1,46 @@
-"""GR00T trainer - wrapper over Isaac-GR00T's ``launch_finetune.py``.
+"""GR00T trainer — wrapper over Isaac-GR00T's ``launch_finetune``.
 
 GR00T N1.7 ships its own post-training pipeline (NOT lerobot): a
 ``FinetuneConfig`` dataclass driven via tyro through
-``gr00t/experiment/launch_finetune.py``, launched with plain ``python`` on a
-single GPU (``CUDA_VISIBLE_DEVICES=0`` to avoid HF Trainer's DataParallel
-wrap) or ``torchrun --nproc_per_node`` for multi-GPU - mirroring
-``examples/finetune.sh``.
+``gr00t.experiment.launch_finetune``. We drive it as a Python library
+(``importlib.import_module(...).main(argv)``) — same interpreter, no nested
+``python`` invocation. Multi-GPU goes through :mod:`torch.distributed.run`
+(the same engine ``torchrun`` is), also invoked in-process — mirroring
+``examples/finetune.sh`` semantically without shell calls.
 
 This adapter translates a provider-agnostic
-:class:`~strands_robots.training.base.TrainSpec` into the ``launch_finetune.py``
+:class:`~strands_robots.training.base.TrainSpec` into the ``launch_finetune``
 argv. Mapping highlights:
 
-* ``base_model``        -> ``--base_model_path``
-* ``dataset_root``      -> ``--dataset_path``
-* ``embodiment``        -> ``--embodiment_tag`` (REQUIRED by GR00T)
-* ``steps``             -> ``--max_steps``
-* ``global_batch_size`` -> ``--global_batch_size``
-* ``learning_rate``     -> ``--learning_rate``
-* ``save_freq``         -> ``--save_steps``
-* ``resume``            -> ``--resume_from_checkpoint``
-* ``tune`` dict         -> ``--tune_llm/--tune_visual/--tune_projector/--tune_diffusion_model``
-* ``augmentation``      -> ``--random_rotation_angle`` / ``--color_jitter_params``
-                           / ``--extra_augmentation_config`` (JSON)
-* ``extra['modality_config_path']`` -> ``--modality_config_path``
+* ``base_model``        → ``--base_model_path``
+* ``dataset_root``      → ``--dataset_path``
+* ``embodiment``        → ``--embodiment_tag`` (REQUIRED by GR00T)
+* ``steps``             → ``--max_steps``
+* ``global_batch_size`` → ``--global_batch_size``
+* ``learning_rate``     → ``--learning_rate``
+* ``save_freq``         → ``--save_steps``
+* ``resume``            → ``--resume_from_checkpoint``
+* ``tune`` dict         → ``--tune_llm/--tune_visual/--tune_projector/--tune_diffusion_model``
+* ``augmentation``      → ``--random_rotation_angle`` / ``--color_jitter_params``
+                          / ``--extra_augmentation_config`` (JSON)
+* ``extra['modality_config_path']`` → ``--modality_config_path``
 
 GR00T checkpoints are HF-native, so :meth:`export` is the default passthrough.
-The script path is resolved from the ``GR00T_ROOT`` env var (the Isaac-GR00T
-checkout) or ``extra['groot_root']``.
+The Isaac-GR00T checkout is resolved from the ``GR00T_ROOT`` env var or
+``extra['groot_root']`` — needed so we can ``chdir`` there for relative configs.
+Install Isaac-GR00T from source (per its README) and ensure ``gr00t`` is
+importable from the active interpreter; this trainer drives it as a Python
+library, NOT by invoking another interpreter.
 """
 
 from __future__ import annotations
 
+import contextlib
+import importlib
+import importlib.util
 import json
 import logging
 import os
-import subprocess
-import sys
 import time
 from typing import Any
 
@@ -43,31 +48,48 @@ from strands_robots.training.base import Trainer, TrainResult, TrainSpec
 
 logger = logging.getLogger(__name__)
 
-# GR00T's tune flags - the model-tuning surface that lerobot does NOT have.
+# GR00T's tune flags — the model-tuning surface lerobot does NOT have.
 # Sensible default mirrors FinetuneConfig defaults (projector + diffusion on).
 _DEFAULT_TUNE = {"llm": False, "visual": False, "projector": True, "diffusion": True}
 
 _SUPPORTED_METHODS = {"full", "frozen_backbone", "expert_only"}
 
+_INSTALL_HINT = (
+    "Isaac-GR00T is not importable from this interpreter. Install it from source "
+    "(see https://github.com/NVIDIA/Isaac-GR00T or the path passed via "
+    "groot_root / GR00T_ROOT) into the *same* Python that imports strands_robots "
+    "— e.g. `pip install -e $GR00T_ROOT`."
+)
+
+
+def _import_groot_module(qualname: str):
+    """Import ``gr00t.<qualname>`` or raise a helpful ImportError."""
+    full = f"gr00t.{qualname}"
+    try:
+        return importlib.import_module(full)
+    except ImportError as e:  # pragma: no cover — exercised in integration
+        raise ImportError(f"{_INSTALL_HINT} (failed to import {full})") from e
+
 
 class Gr00tTrainer(Trainer):
-    """Post-tune an NVIDIA GR00T N1.x policy via Isaac-GR00T launch_finetune.py.
+    """Post-tune an NVIDIA GR00T N1.x policy via Isaac-GR00T launch_finetune.
 
     Args:
-        groot_root: Path to the Isaac-GR00T checkout (contains
-            ``gr00t/experiment/launch_finetune.py``). Falls back to the
-            ``GR00T_ROOT`` env var, then ``TrainSpec.extra['groot_root']``.
-        python_executable: Interpreter for the subprocess (default current).
+        groot_root: Path to the Isaac-GR00T checkout (used to ``chdir`` so
+            relative configs/datasets resolve, and as the validation target
+            for ``launch_finetune.py``). Falls back to the ``GR00T_ROOT`` env
+            var, then ``TrainSpec.extra['groot_root']``. The package itself
+            is loaded via :func:`importlib.import_module` from the active
+            interpreter — install from source; ``GR00T_ROOT`` is for runtime
+            config resolution, not the interpreter path.
     """
 
     def __init__(
         self,
         groot_root: str | None = None,
-        python_executable: str | None = None,
         **kwargs: Any,
     ) -> None:
         self.groot_root = groot_root or os.environ.get("GR00T_ROOT")
-        self.python_executable = python_executable or sys.executable
 
     @property
     def provider_name(self) -> str:
@@ -77,8 +99,6 @@ class Gr00tTrainer(Trainer):
     def hardware_floor(self) -> dict[str, Any]:
         # N1.x fine-tune fits one modern GPU (lite); multi-GPU recommended.
         return {"min_gpus": 1, "min_vram_gb": 24, "multinode": False}
-
-    # ---- helpers -----------------------------------------------------------
 
     def _resolve_groot_root(self, spec: TrainSpec) -> str | None:
         return self.groot_root or spec.extra.get("groot_root")
@@ -94,8 +114,6 @@ class Gr00tTrainer(Trainer):
             merged["llm"] = False
             merged["visual"] = False
         return merged
-
-    # ---- ABC ---------------------------------------------------------------
 
     def validate(self, spec: TrainSpec) -> list[str]:
         problems: list[str] = self._security_problems(spec)
@@ -141,7 +159,13 @@ class Gr00tTrainer(Trainer):
         return problems
 
     def build_command(self, spec: TrainSpec) -> list[str]:
-        """Translate a TrainSpec into the launch_finetune.py argv (pure)."""
+        """Translate a TrainSpec into the launch_finetune argv (pure).
+
+        Returned as a faithful argv list so the parity tests can assert flag
+        drift against the real ``FinetuneConfig``; at run time we hand the
+        same tail (the script + flags) to :mod:`torch.distributed.run` /
+        ``gr00t.experiment.launch_finetune.main`` in-process.
+        """
         root = self._resolve_groot_root(spec)
         script = self._launch_script(root) if root else "launch_finetune.py"
 
@@ -153,7 +177,7 @@ class Gr00tTrainer(Trainer):
                 script,
             ]
         else:
-            launcher = [self.python_executable, script]
+            launcher = ["python", script]
 
         cmd = [
             *launcher,
@@ -168,22 +192,18 @@ class Gr00tTrainer(Trainer):
             f"--num_gpus={spec.num_gpus}",
         ]
 
-        # Tune flags (the GR00T-specific surface).
         tune = self._resolve_tune(spec)
         cmd.append(f"--tune_llm={'true' if tune['llm'] else 'false'}")
         cmd.append(f"--tune_visual={'true' if tune['visual'] else 'false'}")
         cmd.append(f"--tune_projector={'true' if tune['projector'] else 'false'}")
         cmd.append(f"--tune_diffusion_model={'true' if tune['diffusion'] else 'false'}")
 
-        # Augmentation.
         if spec.augmentation:
             if "random_rotation_angle" in spec.augmentation:
                 cmd.append(f"--random_rotation_angle={spec.augmentation['random_rotation_angle']}")
             if "color_jitter_params" in spec.augmentation:
-                # tyro takes color_jitter as nested; pass as JSON via extra config instead
                 cmd.append(f"--extra_augmentation_config={json.dumps(spec.augmentation)}")
 
-        # Modality config (.py) registration.
         mcfg = spec.extra.get("modality_config_path")
         if mcfg:
             cmd.append(f"--modality_config_path={mcfg}")
@@ -200,6 +220,19 @@ class Gr00tTrainer(Trainer):
 
         return cmd
 
+    def _launch_argv(self, spec: TrainSpec) -> list[str]:
+        """Argv passed directly to ``launch_finetune.main`` (script arg stripped)."""
+        # ``build_command`` prepends either ['torchrun', ..., script] (multi-GPU)
+        # or ['python', script] (single-GPU); strip the launcher + script tokens
+        # to leave just the flags ``launch_finetune.main`` parses.
+        full = self.build_command(spec)
+        # Find the script token (ends with launch_finetune.py).
+        for i, tok in enumerate(full):
+            if tok.endswith("launch_finetune.py"):
+                return list(full[i + 1 :])
+        # Fallback: assume single-GPU layout [python, script, *flags].
+        return list(full[2:])
+
     def train(self, spec: TrainSpec) -> TrainResult:
         problems = self.validate(spec)
         if problems:
@@ -213,42 +246,111 @@ class Gr00tTrainer(Trainer):
         parent = os.path.dirname(os.path.abspath(spec.output_dir)) or "."
         os.makedirs(parent, exist_ok=True)
 
-        cmd = self.build_command(spec)
         job_id = f"groot-{int(time.time())}"
         log_path = os.path.join(parent, f"{os.path.basename(spec.output_dir)}.{job_id}.log")
+        root = self._resolve_groot_root(spec)
 
-        env = dict(os.environ)
-        env.setdefault("PYTHONUNBUFFERED", "1")
         # Single-GPU: pin one device so HF Trainer doesn't wrap in DataParallel
         # (the StopIteration crash documented in examples/finetune.sh).
+        prev_env: dict[str, str | None] = {
+            "PYTHONUNBUFFERED": os.environ.get("PYTHONUNBUFFERED"),
+            "CUDA_VISIBLE_DEVICES": os.environ.get("CUDA_VISIBLE_DEVICES"),
+        }
+        os.environ["PYTHONUNBUFFERED"] = "1"
         if spec.num_gpus <= 1:
-            env.setdefault("CUDA_VISIBLE_DEVICES", env.get("CUDA_VISIBLE_DEVICES", "0"))
+            os.environ.setdefault("CUDA_VISIBLE_DEVICES", "0")
 
-        logger.info("Gr00tTrainer launching: %s", " ".join(cmd))
+        argv = self._launch_argv(spec)
+        prev_cwd = os.getcwd()
+        rc = 0
         try:
-            with open(log_path, "w", encoding="utf-8") as logf:
-                proc = subprocess.run(  # noqa: S603 - argv values validated by validate()/_security_problems before train() builds the command; list form, no shell
-                    cmd,
-                    cwd=parent,
-                    env=env,
-                    stdout=logf,
-                    stderr=subprocess.STDOUT,
-                    check=False,
-                )
-        except FileNotFoundError as e:
+            if root and os.path.isdir(root):
+                os.chdir(root)
+
+            with (
+                open(log_path, "w", encoding="utf-8") as logf,
+                contextlib.redirect_stdout(logf),
+                contextlib.redirect_stderr(logf),
+            ):
+                if spec.num_gpus > 1:
+                    # Multi-GPU: drive torch.distributed.run in-process — the same
+                    # engine torchrun uses, no subprocess for the launcher itself.
+                    from torch.distributed import run as torch_run
+
+                    distributed_argv = [
+                        f"--nproc_per_node={spec.num_gpus}",
+                        f"--master_port={spec.extra.get('master_port', 29500)}",
+                        self._launch_script(root) if root else "launch_finetune.py",
+                        *argv,
+                    ]
+                    try:
+                        torch_run.main(distributed_argv)
+                    except SystemExit as se:
+                        rc = int(se.code) if se.code is not None else 0
+                else:
+                    # Single-GPU: import and call gr00t.experiment.launch_finetune
+                    # directly — no subprocess, no nested interpreter.
+                    mod = _import_groot_module("experiment.launch_finetune")
+                    main = getattr(mod, "main", None)
+                    if main is None:
+                        # Some Isaac-GR00T revisions name it differently; fall
+                        # back to running the module's __main__ block.
+                        spec_obj = importlib.util.find_spec("gr00t.experiment.launch_finetune")
+                        if spec_obj is None:
+                            raise ImportError(
+                                "gr00t.experiment.launch_finetune is not importable; "
+                                "is Isaac-GR00T installed in this interpreter?"
+                            )
+                        runpy = importlib.import_module("runpy")
+                        try:
+                            runpy.run_module(
+                                "gr00t.experiment.launch_finetune",
+                                run_name="__main__",
+                                alter_sys=True,
+                            )
+                        except SystemExit as se:
+                            rc = int(se.code) if se.code is not None else 0
+                    else:
+                        try:
+                            # tyro-driven entrypoints typically read sys.argv;
+                            # rewrite it for the duration of the call.
+                            import sys as _sys
+
+                            _saved = _sys.argv
+                            _sys.argv = ["launch_finetune", *argv]
+                            try:
+                                main()
+                            finally:
+                                _sys.argv = _saved
+                        except SystemExit as se:
+                            rc = int(se.code) if se.code is not None else 0
+        except ImportError as e:
             return TrainResult(
                 status="error",
                 job_id=job_id,
-                message=f"launcher not found ({e}); is torchrun/python + Isaac-GR00T present?",
+                message=str(e),
             )
+        except Exception as e:  # noqa: BLE001 — surface launcher errors
+            return TrainResult(
+                status="error",
+                job_id=job_id,
+                message=f"launch_finetune raised: {e}; see {log_path}",
+            )
+        finally:
+            os.chdir(prev_cwd)
+            for k, v in prev_env.items():
+                if v is None:
+                    os.environ.pop(k, None)
+                else:
+                    os.environ[k] = v
 
         ckpt = self._latest_checkpoint(spec.output_dir)
-        if proc.returncode != 0:
+        if rc != 0:
             return TrainResult(
                 status="error",
                 job_id=job_id,
                 checkpoint_dir=ckpt,
-                message=f"launch_finetune.py exited {proc.returncode}; see {log_path}",
+                message=f"launch_finetune exited {rc}; see {log_path}",
             )
         return TrainResult(
             status="success",
@@ -269,7 +371,6 @@ class Gr00tTrainer(Trainer):
         if not ckpts:
             return None
 
-        # Highest step number wins.
         def _step(name: str) -> int:
             try:
                 return int(name.split("-", 1)[1])

--- a/strands_robots/training/groot.py
+++ b/strands_robots/training/groot.py
@@ -144,6 +144,13 @@ class Gr00tTrainer(Trainer):
         if spec.steps <= 0:
             problems.append(f"steps must be > 0, got {spec.steps}")
 
+        if spec.num_nodes > 1:
+            problems.append(
+                f"num_nodes={spec.num_nodes}: multi-node GR00T needs a per-node "
+                "rendezvous launcher; this in-process trainer runs single-node only. "
+                "Run one Gr00tTrainer per node under your own launcher, or use num_nodes=1."
+            )
+
         root = self._resolve_groot_root(spec)
         if not root:
             problems.append(
@@ -424,7 +431,7 @@ class Gr00tTrainer(Trainer):
             train_error = e
             logger.error("Gr00tTrainer in-process run failed: %s", e)
 
-        ckpt = self._latest_checkpoint(spec.output_dir)
+        ckpt = self.latest_checkpoint(spec.output_dir)
         if train_error is not None:
             return TrainResult(
                 status="error",
@@ -439,7 +446,7 @@ class Gr00tTrainer(Trainer):
             message=f"GR00T fine-tune complete (in-process); log: {log_path}",
         )
 
-    def _latest_checkpoint(self, output_dir: str) -> str | None:
+    def latest_checkpoint(self, output_dir: str) -> str | None:
         """GR00T (HF Trainer) writes ``checkpoint-<step>`` dirs in output_dir."""
         if not os.path.isdir(output_dir):
             return None

--- a/strands_robots/training/groot.py
+++ b/strands_robots/training/groot.py
@@ -1,0 +1,273 @@
+"""GR00T trainer - wrapper over Isaac-GR00T's ``launch_finetune.py``.
+
+GR00T N1.7 ships its own post-training pipeline (NOT lerobot): a
+``FinetuneConfig`` dataclass driven via tyro through
+``gr00t/experiment/launch_finetune.py``, launched with plain ``python`` on a
+single GPU (``CUDA_VISIBLE_DEVICES=0`` to avoid HF Trainer's DataParallel
+wrap) or ``torchrun --nproc_per_node`` for multi-GPU - mirroring
+``examples/finetune.sh``.
+
+This adapter translates a provider-agnostic
+:class:`~strands_robots.training.base.TrainSpec` into the ``launch_finetune.py``
+argv. Mapping highlights:
+
+* ``base_model``        -> ``--base_model_path``
+* ``dataset_root``      -> ``--dataset_path``
+* ``embodiment``        -> ``--embodiment_tag`` (REQUIRED by GR00T)
+* ``steps``             -> ``--max_steps``
+* ``global_batch_size`` -> ``--global_batch_size``
+* ``learning_rate``     -> ``--learning_rate``
+* ``save_freq``         -> ``--save_steps``
+* ``resume``            -> ``--resume_from_checkpoint``
+* ``tune`` dict         -> ``--tune_llm/--tune_visual/--tune_projector/--tune_diffusion_model``
+* ``augmentation``      -> ``--random_rotation_angle`` / ``--color_jitter_params``
+                           / ``--extra_augmentation_config`` (JSON)
+* ``extra['modality_config_path']`` -> ``--modality_config_path``
+
+GR00T checkpoints are HF-native, so :meth:`export` is the default passthrough.
+The script path is resolved from the ``GR00T_ROOT`` env var (the Isaac-GR00T
+checkout) or ``extra['groot_root']``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import sys
+import time
+from typing import Any
+
+from strands_robots.training.base import Trainer, TrainResult, TrainSpec
+
+logger = logging.getLogger(__name__)
+
+# GR00T's tune flags - the model-tuning surface that lerobot does NOT have.
+# Sensible default mirrors FinetuneConfig defaults (projector + diffusion on).
+_DEFAULT_TUNE = {"llm": False, "visual": False, "projector": True, "diffusion": True}
+
+_SUPPORTED_METHODS = {"full", "frozen_backbone", "expert_only"}
+
+
+class Gr00tTrainer(Trainer):
+    """Post-tune an NVIDIA GR00T N1.x policy via Isaac-GR00T launch_finetune.py.
+
+    Args:
+        groot_root: Path to the Isaac-GR00T checkout (contains
+            ``gr00t/experiment/launch_finetune.py``). Falls back to the
+            ``GR00T_ROOT`` env var, then ``TrainSpec.extra['groot_root']``.
+        python_executable: Interpreter for the subprocess (default current).
+    """
+
+    def __init__(
+        self,
+        groot_root: str | None = None,
+        python_executable: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self.groot_root = groot_root or os.environ.get("GR00T_ROOT")
+        self.python_executable = python_executable or sys.executable
+
+    @property
+    def provider_name(self) -> str:
+        return "groot"
+
+    @property
+    def hardware_floor(self) -> dict[str, Any]:
+        # N1.x fine-tune fits one modern GPU (lite); multi-GPU recommended.
+        return {"min_gpus": 1, "min_vram_gb": 24, "multinode": False}
+
+    # ---- helpers -----------------------------------------------------------
+
+    def _resolve_groot_root(self, spec: TrainSpec) -> str | None:
+        return self.groot_root or spec.extra.get("groot_root")
+
+    def _launch_script(self, root: str) -> str:
+        return os.path.join(root, "gr00t", "experiment", "launch_finetune.py")
+
+    def _resolve_tune(self, spec: TrainSpec) -> dict[str, bool]:
+        merged = dict(_DEFAULT_TUNE)
+        merged.update({k: bool(v) for k, v in (spec.tune or {}).items()
+                       if k in _DEFAULT_TUNE})
+        # method=frozen_backbone => freeze llm+visual, keep projector/diffusion.
+        if spec.method == "frozen_backbone":
+            merged["llm"] = False
+            merged["visual"] = False
+        return merged
+
+    # ---- ABC ---------------------------------------------------------------
+
+    def validate(self, spec: TrainSpec) -> list[str]:
+        problems: list[str] = self._security_problems(spec)
+
+        if not spec.dataset_root:
+            problems.append("dataset_root is required")
+        elif not os.path.isfile(os.path.join(spec.dataset_root, "meta", "info.json")):
+            problems.append(
+                f"dataset_root is not a LeRobotDataset v3 root "
+                f"(missing {os.path.join(spec.dataset_root, 'meta', 'info.json')})"
+            )
+
+        if not spec.base_model:
+            problems.append("base_model is required (--base_model_path)")
+        if not spec.output_dir:
+            problems.append("output_dir is required")
+        if not spec.embodiment:
+            problems.append("embodiment is required for GR00T (--embodiment_tag)")
+
+        if spec.method not in _SUPPORTED_METHODS:
+            problems.append(
+                f"unsupported method '{spec.method}' for GR00T "
+                f"(expected one of {sorted(_SUPPORTED_METHODS)}); "
+                f"use tune={{...}} for fine-grained control"
+            )
+        if spec.steps <= 0:
+            problems.append(f"steps must be > 0, got {spec.steps}")
+
+        root = self._resolve_groot_root(spec)
+        if not root:
+            problems.append(
+                "Isaac-GR00T checkout not found; set GR00T_ROOT, pass "
+                "groot_root=..., or extra['groot_root']"
+            )
+        elif not os.path.isfile(self._launch_script(root)):
+            problems.append(
+                f"launch_finetune.py not found under groot_root={root} "
+                f"(expected {self._launch_script(root)})"
+            )
+
+        mcfg = spec.extra.get("modality_config_path")
+        if mcfg and not os.path.isfile(mcfg):
+            problems.append(f"modality_config_path does not exist: {mcfg}")
+
+        return problems
+
+    def build_command(self, spec: TrainSpec) -> list[str]:
+        """Translate a TrainSpec into the launch_finetune.py argv (pure)."""
+        root = self._resolve_groot_root(spec)
+        script = self._launch_script(root) if root else "launch_finetune.py"
+
+        if spec.num_gpus > 1:
+            launcher = [
+                "torchrun",
+                f"--nproc_per_node={spec.num_gpus}",
+                f"--master_port={spec.extra.get('master_port', 29500)}",
+                script,
+            ]
+        else:
+            launcher = [self.python_executable, script]
+
+        cmd = [
+            *launcher,
+            f"--base_model_path={spec.base_model}",
+            f"--dataset_path={spec.dataset_root}",
+            f"--embodiment_tag={spec.embodiment}",
+            f"--output_dir={spec.output_dir}",
+            f"--max_steps={spec.steps}",
+            f"--global_batch_size={spec.global_batch_size}",
+            f"--learning_rate={spec.learning_rate}",
+            f"--save_steps={spec.save_freq}",
+            f"--num_gpus={spec.num_gpus}",
+        ]
+
+        # Tune flags (the GR00T-specific surface).
+        tune = self._resolve_tune(spec)
+        cmd.append(f"--tune_llm={'true' if tune['llm'] else 'false'}")
+        cmd.append(f"--tune_visual={'true' if tune['visual'] else 'false'}")
+        cmd.append(f"--tune_projector={'true' if tune['projector'] else 'false'}")
+        cmd.append(f"--tune_diffusion_model={'true' if tune['diffusion'] else 'false'}")
+
+        # Augmentation.
+        if spec.augmentation:
+            if "random_rotation_angle" in spec.augmentation:
+                cmd.append(f"--random_rotation_angle={spec.augmentation['random_rotation_angle']}")
+            if "color_jitter_params" in spec.augmentation:
+                # tyro takes color_jitter as nested; pass as JSON via extra config instead
+                cmd.append(
+                    f"--extra_augmentation_config={json.dumps(spec.augmentation)}"
+                )
+
+        # Modality config (.py) registration.
+        mcfg = spec.extra.get("modality_config_path")
+        if mcfg:
+            cmd.append(f"--modality_config_path={mcfg}")
+
+        if spec.resume:
+            cmd.append("--resume_from_checkpoint")
+
+        # Passthrough: remaining extra.* as --key=value (skip consumed keys).
+        _consumed = {"groot_root", "modality_config_path", "master_port"}
+        for key, value in spec.extra.items():
+            if key in _consumed:
+                continue
+            cmd.append(f"--{key}={value}")
+
+        return cmd
+
+    def train(self, spec: TrainSpec) -> TrainResult:
+        problems = self.validate(spec)
+        if problems:
+            return TrainResult(
+                status="error", job_id="",
+                message="validation failed: " + "; ".join(problems),
+            )
+
+        self.prepare(spec)
+        parent = os.path.dirname(os.path.abspath(spec.output_dir)) or "."
+        os.makedirs(parent, exist_ok=True)
+
+        cmd = self.build_command(spec)
+        job_id = f"groot-{int(time.time())}"
+        log_path = os.path.join(parent, f"{os.path.basename(spec.output_dir)}.{job_id}.log")
+
+        env = dict(os.environ)
+        env.setdefault("PYTHONUNBUFFERED", "1")
+        # Single-GPU: pin one device so HF Trainer doesn't wrap in DataParallel
+        # (the StopIteration crash documented in examples/finetune.sh).
+        if spec.num_gpus <= 1:
+            env.setdefault("CUDA_VISIBLE_DEVICES", env.get("CUDA_VISIBLE_DEVICES", "0"))
+
+        logger.info("Gr00tTrainer launching: %s", " ".join(cmd))
+        try:
+            with open(log_path, "w", encoding="utf-8") as logf:
+                proc = subprocess.run(  # noqa: S603 - argv values validated by validate()/_security_problems before train() builds the command; list form, no shell
+                    cmd, cwd=parent, env=env,
+                    stdout=logf, stderr=subprocess.STDOUT, check=False,
+                )
+        except FileNotFoundError as e:
+            return TrainResult(
+                status="error", job_id=job_id,
+                message=f"launcher not found ({e}); is torchrun/python + Isaac-GR00T present?",
+            )
+
+        ckpt = self._latest_checkpoint(spec.output_dir)
+        if proc.returncode != 0:
+            return TrainResult(
+                status="error", job_id=job_id, checkpoint_dir=ckpt,
+                message=f"launch_finetune.py exited {proc.returncode}; see {log_path}",
+            )
+        return TrainResult(
+            status="success", job_id=job_id, checkpoint_dir=ckpt,
+            message=f"GR00T fine-tune complete; log: {log_path}",
+        )
+
+    def _latest_checkpoint(self, output_dir: str) -> str | None:
+        """GR00T (HF Trainer) writes ``checkpoint-<step>`` dirs in output_dir."""
+        if not os.path.isdir(output_dir):
+            return None
+        ckpts = [
+            d for d in os.listdir(output_dir)
+            if d.startswith("checkpoint-")
+            and os.path.isdir(os.path.join(output_dir, d))
+        ]
+        if not ckpts:
+            return None
+        # Highest step number wins.
+        def _step(name: str) -> int:
+            try:
+                return int(name.split("-", 1)[1])
+            except (IndexError, ValueError):
+                return -1
+        best = max(ckpts, key=_step)
+        return os.path.join(output_dir, best)

--- a/strands_robots/training/groot.py
+++ b/strands_robots/training/groot.py
@@ -1,12 +1,14 @@
 """GR00T trainer — wrapper over Isaac-GR00T's ``launch_finetune``.
 
 GR00T N1.7 ships its own post-training pipeline (NOT lerobot): a
-``FinetuneConfig`` dataclass driven via tyro through
-``gr00t.experiment.launch_finetune``. We drive it as a Python library
-(``importlib.import_module(...).main(argv)``) — same interpreter, no nested
-``python`` invocation. Multi-GPU goes through :mod:`torch.distributed.run`
-(the same engine ``torchrun`` is), also invoked in-process — mirroring
-``examples/finetune.sh`` semantically without shell calls.
+``FinetuneConfig`` dataclass. ``launch_finetune.py`` is only a thin
+``__main__`` shim (build ``FinetuneConfig`` via tyro → lower to a ``Config``
+→ call ``experiment.run(config)``); it has NO reusable function. So we
+reproduce that translation here and call ``gr00t.experiment.experiment.run``
+DIRECTLY as a library — same interpreter, no argv, no nested ``python``.
+Multi-GPU uses torch's programmatic ``elastic_launch`` (the engine behind
+``torchrun``); each worker builds the ``Config`` and calls ``run`` — no
+``torchrun`` binary, no shell.
 
 This adapter translates a provider-agnostic
 :class:`~strands_robots.training.base.TrainSpec` into the ``launch_finetune``
@@ -35,7 +37,6 @@ library, NOT by invoking another interpreter.
 
 from __future__ import annotations
 
-import contextlib
 import importlib
 import importlib.util
 import json
@@ -44,6 +45,7 @@ import os
 import time
 from typing import Any
 
+from strands_robots.training._inproc import call_callable, elastic_launch_callable
 from strands_robots.training.base import Trainer, TrainResult, TrainSpec
 
 logger = logging.getLogger(__name__)
@@ -159,12 +161,13 @@ class Gr00tTrainer(Trainer):
         return problems
 
     def build_command(self, spec: TrainSpec) -> list[str]:
-        """Translate a TrainSpec into the launch_finetune argv (pure).
+        """PURE argv-parity helper — the launch_finetune CLI the config maps to.
 
-        Returned as a faithful argv list so the parity tests can assert flag
-        drift against the real ``FinetuneConfig``; at run time we hand the
-        same tail (the script + flags) to :mod:`torch.distributed.run` /
-        ``gr00t.experiment.launch_finetune.main`` in-process.
+        NOT used to launch training (``train()`` builds a ``FinetuneConfig`` +
+        ``Config`` and calls ``gr00t.experiment.experiment.run`` directly).
+        Retained so ``test_native_parity`` can assert our flag mapping against
+        the real ``FinetuneConfig`` dataclass fields, and as a readable
+        description of the equivalent command.
         """
         root = self._resolve_groot_root(spec)
         script = self._launch_script(root) if root else "launch_finetune.py"
@@ -220,18 +223,155 @@ class Gr00tTrainer(Trainer):
 
         return cmd
 
-    def _launch_argv(self, spec: TrainSpec) -> list[str]:
-        """Argv passed directly to ``launch_finetune.main`` (script arg stripped)."""
-        # ``build_command`` prepends either ['torchrun', ..., script] (multi-GPU)
-        # or ['python', script] (single-GPU); strip the launcher + script tokens
-        # to leave just the flags ``launch_finetune.main`` parses.
-        full = self.build_command(spec)
-        # Find the script token (ends with launch_finetune.py).
-        for i, tok in enumerate(full):
-            if tok.endswith("launch_finetune.py"):
-                return list(full[i + 1 :])
-        # Fallback: assume single-GPU layout [python, script, *flags].
-        return list(full[2:])
+    def build_finetune_config(self, spec: TrainSpec):
+        """Build GR00T's own ``FinetuneConfig`` object from a TrainSpec (pure).
+
+        Returns an instance of ``gr00t.configs.finetune_config.FinetuneConfig``
+        — the SAME typed object ``launch_finetune.py`` builds via tyro, but
+        constructed directly from Python values (no argv). Requires the gr00t
+        package importable.
+        """
+        FinetuneConfig = _import_groot_module("configs.finetune_config").FinetuneConfig
+
+        import dataclasses
+
+        tune = self._resolve_tune(spec)
+        kwargs: dict[str, Any] = {
+            "base_model_path": spec.base_model,
+            "dataset_path": spec.dataset_root,
+            "embodiment_tag": spec.embodiment,
+            "output_dir": spec.output_dir,
+            "max_steps": spec.steps,
+            "global_batch_size": spec.global_batch_size,
+            "learning_rate": spec.learning_rate,
+            "save_steps": spec.save_freq,
+            "num_gpus": spec.num_gpus,
+            "tune_llm": tune["llm"],
+            "tune_visual": tune["visual"],
+            "tune_projector": tune["projector"],
+            "tune_diffusion_model": tune["diffusion"],
+            "resume_from_checkpoint": spec.resume,
+        }
+        if spec.augmentation:
+            if "random_rotation_angle" in spec.augmentation:
+                kwargs["random_rotation_angle"] = spec.augmentation["random_rotation_angle"]
+            if "color_jitter_params" in spec.augmentation:
+                kwargs["color_jitter_params"] = spec.augmentation["color_jitter_params"]
+            extra_aug = {
+                k: v
+                for k, v in spec.augmentation.items()
+                if k not in ("random_rotation_angle", "color_jitter_params")
+            }
+            if extra_aug:
+                kwargs["extra_augmentation_config"] = json.dumps(extra_aug)
+        if spec.extra.get("modality_config_path"):
+            kwargs["modality_config_path"] = spec.extra["modality_config_path"]
+
+        # Passthrough: any other extra.* that is a REAL FinetuneConfig field
+        # (typed allowlist — an unknown key can never set an attribute).
+        valid_fields = {f.name for f in dataclasses.fields(FinetuneConfig)}
+        _consumed = {"groot_root", "master_port", "modality_config_path"}
+        for key, value in spec.extra.items():
+            if key in _consumed or key in kwargs:
+                continue
+            if key in valid_fields:
+                kwargs[key] = value
+            else:
+                logger.warning("Gr00tTrainer: ignoring extra '%s' (not a FinetuneConfig field).", key)
+        return FinetuneConfig(**kwargs)
+
+    def _build_run_config(self, ft_config):
+        """Lower a ``FinetuneConfig`` into the ``Config`` ``experiment.run`` consumes.
+
+        Mirrors the body of ``launch_finetune.py``'s ``__main__`` exactly
+        (verified against the Isaac-GR00T checkout), so calling ``run(config)``
+        is behaviourally identical to launching the script — minus the process
+        spawn and the tyro argv parse.
+        """
+        get_default_config = _import_groot_module("configs.base_config").get_default_config
+        EmbodimentTag = _import_groot_module("data.embodiment_tags").EmbodimentTag
+
+        ft_config.embodiment_tag = EmbodimentTag.resolve(ft_config.embodiment_tag)
+        embodiment_tag = ft_config.embodiment_tag.value
+
+        if ft_config.modality_config_path is not None:
+            self._load_modality_config(ft_config.modality_config_path)
+
+        dataset_paths = [p for p in ft_config.dataset_path.split(os.pathsep) if p]
+
+        config = get_default_config().load_dict(
+            {
+                "data": {
+                    "download_cache": False,
+                    "datasets": [
+                        {
+                            "dataset_paths": dataset_paths,
+                            "mix_ratio": 1.0,
+                            "embodiment_tag": embodiment_tag,
+                        }
+                    ],
+                }
+            }
+        )
+        config.load_config_path = None
+
+        config.model.tune_llm = ft_config.tune_llm
+        config.model.tune_visual = ft_config.tune_visual
+        config.model.tune_projector = ft_config.tune_projector
+        config.model.tune_diffusion_model = ft_config.tune_diffusion_model
+        config.model.state_dropout_prob = ft_config.state_dropout_prob
+        config.model.random_rotation_angle = ft_config.random_rotation_angle
+        config.model.color_jitter_params = ft_config.color_jitter_params
+        config.model.extra_augmentation_config = (
+            json.loads(ft_config.extra_augmentation_config) if ft_config.extra_augmentation_config else None
+        )
+        config.model.load_bf16 = False
+        config.model.reproject_vision = False
+        config.model.model_name = "nvidia/Cosmos-Reason2-2B"
+        config.model.backbone_trainable_params_fp32 = True
+        config.model.use_relative_action = True
+
+        config.training.experiment_name = ft_config.experiment_name
+        config.training.start_from_checkpoint = ft_config.base_model_path
+        config.training.optim = "adamw_torch"
+        config.training.global_batch_size = ft_config.global_batch_size
+        config.training.dataloader_num_workers = ft_config.dataloader_num_workers
+        config.training.learning_rate = ft_config.learning_rate
+        config.training.gradient_accumulation_steps = ft_config.gradient_accumulation_steps
+        config.training.output_dir = ft_config.output_dir
+        config.training.save_steps = ft_config.save_steps
+        config.training.save_total_limit = ft_config.save_total_limit
+        config.training.num_gpus = ft_config.num_gpus
+        config.training.use_wandb = ft_config.use_wandb
+        config.training.max_steps = ft_config.max_steps
+        config.training.weight_decay = ft_config.weight_decay
+        config.training.warmup_ratio = ft_config.warmup_ratio
+        config.training.wandb_project = ft_config.wandb_project
+
+        config.data.shard_size = ft_config.shard_size
+        config.data.episode_sampling_rate = ft_config.episode_sampling_rate
+        config.data.num_shards_per_epoch = ft_config.num_shards_per_epoch
+
+        config.training.save_only_model = ft_config.save_only_model
+        config.training.resume_from_checkpoint = ft_config.resume_from_checkpoint
+        config.training.skip_weight_loading = ft_config.skip_weight_loading
+
+        return config
+
+    @staticmethod
+    def _load_modality_config(modality_config_path: str) -> None:
+        """Register a user modality config (.py), mirroring launch_finetune.py."""
+        import sys
+        from pathlib import Path
+
+        path = Path(modality_config_path)
+        if path.exists() and path.suffix == ".py":
+            if str(path.parent) not in sys.path:
+                sys.path.append(str(path.parent))
+            importlib.import_module(path.stem)
+            logger.info("Loaded modality config: %s", path)
+        else:
+            raise FileNotFoundError(f"Modality config path does not exist: {modality_config_path}")
 
     def train(self, spec: TrainSpec) -> TrainResult:
         problems = self.validate(spec)
@@ -248,115 +388,57 @@ class Gr00tTrainer(Trainer):
 
         job_id = f"groot-{int(time.time())}"
         log_path = os.path.join(parent, f"{os.path.basename(spec.output_dir)}.{job_id}.log")
-        root = self._resolve_groot_root(spec)
 
-        # Single-GPU: pin one device so HF Trainer doesn't wrap in DataParallel
+        # Single-GPU: pin one device so HF Trainer doesn't DataParallel-wrap
         # (the StopIteration crash documented in examples/finetune.sh).
-        prev_env: dict[str, str | None] = {
-            "PYTHONUNBUFFERED": os.environ.get("PYTHONUNBUFFERED"),
-            "CUDA_VISIBLE_DEVICES": os.environ.get("CUDA_VISIBLE_DEVICES"),
-        }
-        os.environ["PYTHONUNBUFFERED"] = "1"
         if spec.num_gpus <= 1:
-            os.environ.setdefault("CUDA_VISIBLE_DEVICES", "0")
+            os.environ.setdefault("CUDA_VISIBLE_DEVICES", os.environ.get("CUDA_VISIBLE_DEVICES", "0"))
+        os.environ.setdefault("LOGURU_LEVEL", "INFO")
 
-        argv = self._launch_argv(spec)
-        prev_cwd = os.getcwd()
-        rc = 0
+        logger.info(
+            "Gr00tTrainer launching GR00T experiment.run() in-process: num_gpus=%d steps=%d",
+            spec.num_gpus,
+            spec.steps,
+        )
+
+        train_error: BaseException | None = None
         try:
-            if root and os.path.isdir(root):
-                os.chdir(root)
-
-            with (
-                open(log_path, "w", encoding="utf-8") as logf,
-                contextlib.redirect_stdout(logf),
-                contextlib.redirect_stderr(logf),
-            ):
-                if spec.num_gpus > 1:
-                    # Multi-GPU: drive torch.distributed.run in-process — the same
-                    # engine torchrun uses, no subprocess for the launcher itself.
-                    from torch.distributed import run as torch_run
-
-                    distributed_argv = [
-                        f"--nproc_per_node={spec.num_gpus}",
-                        f"--master_port={spec.extra.get('master_port', 29500)}",
-                        self._launch_script(root) if root else "launch_finetune.py",
-                        *argv,
-                    ]
-                    try:
-                        torch_run.main(distributed_argv)
-                    except SystemExit as se:
-                        rc = int(se.code) if se.code is not None else 0
-                else:
-                    # Single-GPU: import and call gr00t.experiment.launch_finetune
-                    # directly — no subprocess, no nested interpreter.
-                    mod = _import_groot_module("experiment.launch_finetune")
-                    main = getattr(mod, "main", None)
-                    if main is None:
-                        # Some Isaac-GR00T revisions name it differently; fall
-                        # back to running the module's __main__ block.
-                        spec_obj = importlib.util.find_spec("gr00t.experiment.launch_finetune")
-                        if spec_obj is None:
-                            raise ImportError(
-                                "gr00t.experiment.launch_finetune is not importable; "
-                                "is Isaac-GR00T installed in this interpreter?"
-                            )
-                        runpy = importlib.import_module("runpy")
-                        try:
-                            runpy.run_module(
-                                "gr00t.experiment.launch_finetune",
-                                run_name="__main__",
-                                alter_sys=True,
-                            )
-                        except SystemExit as se:
-                            rc = int(se.code) if se.code is not None else 0
-                    else:
-                        try:
-                            # tyro-driven entrypoints typically read sys.argv;
-                            # rewrite it for the duration of the call.
-                            import sys as _sys
-
-                            _saved = _sys.argv
-                            _sys.argv = ["launch_finetune", *argv]
-                            try:
-                                main()
-                            finally:
-                                _sys.argv = _saved
-                        except SystemExit as se:
-                            rc = int(se.code) if se.code is not None else 0
+            if spec.num_gpus and spec.num_gpus > 1:
+                # Multi-GPU: torch elastic agent spawns workers; each builds the
+                # FinetuneConfig + Config and calls experiment.run() — Python
+                # objects, no argv, no torchrun binary.
+                groot_root = self._resolve_groot_root(spec)
+                elastic_launch_callable(
+                    _groot_worker,
+                    nproc_per_node=spec.num_gpus,
+                    nnodes=1,
+                    run_id=job_id,
+                    fn_args=(groot_root, spec, log_path),
+                )
+            else:
+                ft_config = self.build_finetune_config(spec)
+                run_config = self._build_run_config(ft_config)
+                run = _import_groot_module("experiment.experiment").run
+                call_callable(run, run_config, log_path=log_path)
         except ImportError as e:
-            return TrainResult(
-                status="error",
-                job_id=job_id,
-                message=str(e),
-            )
-        except Exception as e:  # noqa: BLE001 — surface launcher errors
-            return TrainResult(
-                status="error",
-                job_id=job_id,
-                message=f"launch_finetune raised: {e}; see {log_path}",
-            )
-        finally:
-            os.chdir(prev_cwd)
-            for k, v in prev_env.items():
-                if v is None:
-                    os.environ.pop(k, None)
-                else:
-                    os.environ[k] = v
+            return TrainResult(status="error", job_id=job_id, message=str(e))
+        except BaseException as e:  # noqa: BLE001 — convert ANY failure to a result
+            train_error = e
+            logger.error("Gr00tTrainer in-process run failed: %s", e)
 
         ckpt = self._latest_checkpoint(spec.output_dir)
-        if rc != 0:
+        if train_error is not None:
             return TrainResult(
                 status="error",
                 job_id=job_id,
                 checkpoint_dir=ckpt,
-                message=f"launch_finetune exited {rc}; see {log_path}",
+                message=f"GR00T experiment.run() raised {type(train_error).__name__}: {train_error}; see {log_path}",
             )
         return TrainResult(
             status="success",
             job_id=job_id,
             checkpoint_dir=ckpt,
-            message=f"GR00T fine-tune complete; log: {log_path}",
+            message=f"GR00T fine-tune complete (in-process); log: {log_path}",
         )
 
     def _latest_checkpoint(self, output_dir: str) -> str | None:
@@ -379,3 +461,22 @@ class Gr00tTrainer(Trainer):
 
         best = max(ckpts, key=_step)
         return os.path.join(output_dir, best)
+
+
+def _groot_worker(groot_root: str | None, spec: TrainSpec, log_path: str) -> None:
+    """elastic_launch worker: build the GR00T Config and call run() in this worker.
+
+    Runs in a torch-spawned worker (one per GPU). torch sets RANK / LOCAL_RANK /
+    WORLD_SIZE; GR00T's experiment.run() + HF Trainer read those to shard. We do
+    NOT pin CUDA_VISIBLE_DEVICES here — each worker sees all devices and selects
+    by LOCAL_RANK. Only local rank 0 tees to the shared log file.
+    """
+    import os as _os
+
+    trainer = Gr00tTrainer(groot_root=groot_root)
+    ft_config = trainer.build_finetune_config(spec)
+    run_config = trainer._build_run_config(ft_config)
+    run = _import_groot_module("experiment.experiment").run
+
+    is_rank0 = _os.environ.get("LOCAL_RANK", "0") == "0"
+    call_callable(run, run_config, log_path=log_path if is_rank0 else None)

--- a/strands_robots/training/groot.py
+++ b/strands_robots/training/groot.py
@@ -399,7 +399,7 @@ class Gr00tTrainer(Trainer):
             spec.steps,
         )
 
-        train_error: BaseException | None = None
+        train_error: Exception | None = None
         try:
             if spec.num_gpus and spec.num_gpus > 1:
                 # Multi-GPU: torch elastic agent spawns workers; each builds the
@@ -420,7 +420,7 @@ class Gr00tTrainer(Trainer):
                 call_callable(run, run_config, log_path=log_path)
         except ImportError as e:
             return TrainResult(status="error", job_id=job_id, message=str(e))
-        except BaseException as e:  # noqa: BLE001 — convert ANY failure to a result
+        except Exception as e:  # noqa: BLE001 — convert ANY failure to a result
             train_error = e
             logger.error("Gr00tTrainer in-process run failed: %s", e)
 

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -357,7 +357,7 @@ class LerobotTrainer(Trainer):
             spec.num_gpus,
         )
 
-        train_error: BaseException | None = None
+        train_error: Exception | None = None
         try:
             if spec.num_gpus and spec.num_gpus > 1:
                 elastic_launch_callable(
@@ -371,7 +371,7 @@ class LerobotTrainer(Trainer):
                 from lerobot.scripts.lerobot_train import train as lerobot_train
 
                 call_callable(lerobot_train, cfg, log_path=log_path)
-        except BaseException as e:  # noqa: BLE001 - convert ANY failure to a result
+        except Exception as e:  # noqa: BLE001 - convert ANY failure to a result
             train_error = e
             logger.error("LerobotTrainer in-process train failed: %s", e)
 

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -1,0 +1,389 @@
+"""LeRobot trainer - thin wrapper over ``lerobot.scripts.lerobot_train``.
+
+Builds and launches the LeRobot training CLI for any LeRobot-native policy
+type (act, diffusion, smolvla, pi0, pi05, ...). The training *logic* is
+entirely lerobot's; this adapter only translates a provider-agnostic
+:class:`~strands_robots.training.base.TrainSpec` into the correct draccus
+command + launcher, manages resume, and parses the run for a status verdict.
+
+Grounded against lerobot 0.5.x ``TrainPipelineConfig`` (the draccus config
+``lerobot_train`` parses):
+    --dataset.repo_id / --dataset.root / --dataset.episodes
+    --policy.type / --policy.device / --policy.push_to_hub / --policy.pretrained_path
+    --output_dir / --job_name / --steps / --batch_size / --save_freq
+    --resume / --seed / --wandb.enable
+    --peft.method_type / --peft.r / --peft.target_modules   (LoRA)
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import time
+from typing import Any
+
+from strands_robots.training.base import Trainer, TrainResult, TrainSpec
+
+logger = logging.getLogger(__name__)
+
+# LeRobot-native policy types (draccus --policy.type values). Mirrors the
+# verified vla-ft POLICY_MAP; values pass straight through to lerobot.
+_LEROBOT_POLICY_TYPES = {
+    "act",
+    "diffusion",
+    "vqbet",
+    "tdmpc",
+    "smolvla",
+    "pi0",
+    "pi05",
+    "pi0_fast",
+    "groot",
+    "xvla",
+}
+
+_SUPPORTED_METHODS = {"full", "lora", "expert_only"}
+
+
+class LerobotTrainer(Trainer):
+    """Post-tune a LeRobot-native policy via ``lerobot.scripts.lerobot_train``.
+
+    Args:
+        policy_type: LeRobot ``--policy.type`` (default ``"act"``). Resolved
+            from ``TrainSpec.extra['policy_type']`` if present, else this.
+        device: ``--policy.device`` (default auto: cuda > mps > cpu).
+        python_executable: Interpreter for the subprocess (default current).
+    """
+
+    def __init__(
+        self,
+        policy_type: str = "act",
+        device: str | None = None,
+        python_executable: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self.policy_type = policy_type
+        self.device = device or _auto_device()
+        self.python_executable = python_executable or sys.executable
+
+    @property
+    def provider_name(self) -> str:
+        return "lerobot_local"
+
+    @property
+    def hardware_floor(self) -> dict[str, Any]:
+        # ACT fits a consumer GPU; large VLAs (pi05) want an L40S. Advisory.
+        return {"min_gpus": 1, "min_vram_gb": 8, "multinode": False}
+
+    # ---- helpers -----------------------------------------------------------
+
+    def _resolve_policy_type(self, spec: TrainSpec) -> str:
+        return str(spec.extra.get("policy_type", self.policy_type))
+
+    def _dataset_total_episodes(self, dataset_root: str) -> int | None:
+        info = os.path.join(dataset_root, "meta", "info.json")
+        try:
+            with open(info, encoding="utf-8") as f:
+                return int(json.load(f).get("total_episodes"))
+        except (OSError, ValueError, TypeError, json.JSONDecodeError):
+            return None
+
+    def _latest_checkpoint(self, output_dir: str) -> str | None:
+        """Return the resumable ``train_config.json`` path, or None.
+
+        lerobot writes checkpoints to ``<output_dir>/checkpoints/<step|last>/
+        pretrained_model/train_config.json`` and validate() needs the FILE
+        path on resume (it derives policy_dir/checkpoint_path from it).
+        """
+        ckpts = os.path.join(output_dir, "checkpoints")
+        if not os.path.isdir(ckpts):
+            return None
+        # Prefer 'last', else the highest-numbered checkpoint dir.
+        candidates = []
+        last = os.path.join(ckpts, "last", "pretrained_model", "train_config.json")
+        if os.path.isfile(last):
+            return last
+        for name in sorted(os.listdir(ckpts)):
+            cfg = os.path.join(ckpts, name, "pretrained_model", "train_config.json")
+            if os.path.isfile(cfg):
+                candidates.append(cfg)
+        return candidates[-1] if candidates else None
+
+    # ---- ABC ---------------------------------------------------------------
+
+    def validate(self, spec: TrainSpec) -> list[str]:
+        problems: list[str] = self._security_problems(spec)
+
+        if not spec.dataset_root:
+            problems.append("dataset_root is required")
+        elif not os.path.isfile(os.path.join(spec.dataset_root, "meta", "info.json")):
+            problems.append(
+                f"dataset_root is not a LeRobotDataset v3 root "
+                f"(missing {os.path.join(spec.dataset_root, 'meta', 'info.json')})"
+            )
+
+        if not spec.output_dir:
+            problems.append("output_dir is required")
+
+        ptype = self._resolve_policy_type(spec)
+        if ptype not in _LEROBOT_POLICY_TYPES:
+            problems.append(
+                f"policy_type '{ptype}' is not LeRobot-native "
+                f"(expected one of {sorted(_LEROBOT_POLICY_TYPES)})"
+            )
+
+        if spec.method not in _SUPPORTED_METHODS:
+            problems.append(
+                f"unsupported method '{spec.method}' "
+                f"(expected one of {sorted(_SUPPORTED_METHODS)})"
+            )
+        if spec.method == "lora" and spec.tune.get("expert_only"):
+            problems.append("lora and expert_only are mutually exclusive (both freeze the VLM)")
+
+        if spec.steps <= 0:
+            problems.append(f"steps must be > 0, got {spec.steps}")
+
+        if spec.val_episodes is not None and spec.dataset_root:
+            total = self._dataset_total_episodes(spec.dataset_root)
+            if total is not None and spec.val_episodes >= total:
+                problems.append(
+                    f"val_episodes={spec.val_episodes} >= total_episodes={total}"
+                )
+
+        # lerobot must be importable to actually train.
+        try:
+            import importlib.util
+
+            if importlib.util.find_spec("lerobot.scripts.lerobot_train") is None:
+                problems.append("lerobot is not installed (no lerobot.scripts.lerobot_train)")
+        except Exception:  # noqa: BLE001
+            problems.append("lerobot is not installed")
+
+        return problems
+
+    def build_command(self, spec: TrainSpec) -> list[str]:
+        """Translate a TrainSpec into the lerobot_train argv (pure, testable)."""
+        ptype = self._resolve_policy_type(spec)
+
+        if spec.num_gpus > 1:
+            launcher = [
+                "accelerate", "launch",
+                "--multi_gpu",
+                f"--num_processes={spec.num_gpus}",
+                "--num_machines=1",
+                "--mixed_precision=bf16",
+                "-m", "lerobot.scripts.lerobot_train",
+            ]
+        else:
+            launcher = [self.python_executable, "-m", "lerobot.scripts.lerobot_train"]
+
+        cmd = [
+            *launcher,
+            "--dataset.repo_id=local",
+            f"--dataset.root={spec.dataset_root}",
+            f"--policy.type={ptype}",
+            f"--policy.device={self.device}",
+            "--policy.push_to_hub=false",
+            f"--output_dir={spec.output_dir}",
+            f"--job_name={spec.extra.get('job_name', 'strands_ft')}",
+            f"--steps={spec.steps}",
+            f"--batch_size={spec.global_batch_size}",
+            f"--save_freq={spec.save_freq}",
+            "--wandb.enable=false",
+        ]
+
+        if spec.base_model:
+            cmd.append(f"--policy.pretrained_path={spec.base_model}")
+        if spec.seed is not None:
+            cmd.append(f"--seed={spec.seed}")
+
+        # Tuning strategy.
+        if spec.method == "lora":
+            cmd.append("--peft.method_type=LORA")
+            if spec.lora_r is not None:
+                cmd.append(f"--peft.r={spec.lora_r}")
+            if spec.lora_target_modules is not None:
+                cmd.append(f"--peft.target_modules={spec.lora_target_modules}")
+        elif spec.method == "expert_only":
+            cmd.append("--policy.train_expert_only=true")
+
+        # Held-out validation split: train on the FIRST (total - N) episodes.
+        if spec.val_episodes is not None:
+            total = self._dataset_total_episodes(spec.dataset_root)
+            if total is not None and 0 < spec.val_episodes < total:
+                train_eps = list(range(0, total - spec.val_episodes))
+                cmd.append(f"--dataset.episodes=[{', '.join(map(str, train_eps))}]")
+
+        # Resume: needs BOTH --resume=true AND --config_path=<ckpt>/train_config.json
+        if spec.resume:
+            ckpt_cfg = self._latest_checkpoint(spec.output_dir)
+            if ckpt_cfg:
+                cmd.append("--resume=true")
+                cmd.append(f"--config_path={ckpt_cfg}")
+
+        # Passthrough: any remaining extra.* as --key=value (skip consumed keys).
+        _consumed = {"policy_type", "job_name"}
+        for key, value in spec.extra.items():
+            if key in _consumed:
+                continue
+            cmd.append(f"--{key}={value}")
+
+        return cmd
+
+    def train(self, spec: TrainSpec) -> TrainResult:
+        problems = self.validate(spec)
+        if problems:
+            return TrainResult(
+                status="error", job_id="",
+                message="validation failed: " + "; ".join(problems),
+            )
+
+        self.prepare(spec)
+
+        # lerobot's validate() REFUSES a pre-existing output_dir unless
+        # resume=True (it creates the dir itself). So we must NOT pre-create
+        # output_dir. We only ensure its PARENT exists, and we write our log
+        # NEXT TO output_dir (not inside it) so the log file doesn't trip the
+        # "already exists" guard either.
+        parent = os.path.dirname(os.path.abspath(spec.output_dir)) or "."
+        os.makedirs(parent, exist_ok=True)
+
+        # Fresh-start hygiene: if NOT resuming and output_dir exists with no
+        # resumable checkpoint, clear it so lerobot's guard doesn't crash a
+        # rerun (the vla-ft reclaim-before-first-save failure mode).
+        if not spec.resume and os.path.isdir(spec.output_dir):
+            if self._latest_checkpoint(spec.output_dir) is None:
+                shutil.rmtree(spec.output_dir, ignore_errors=True)
+
+        cmd = self.build_command(spec)
+        job_id = f"lerobot-{int(time.time())}"
+        log_path = os.path.join(parent, f"{os.path.basename(spec.output_dir)}.{job_id}.log")
+
+        logger.info("LerobotTrainer launching: %s", " ".join(cmd))
+        env = dict(os.environ)
+        env.setdefault("PYTHONUNBUFFERED", "1")
+        env.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+        try:
+            with open(log_path, "w", encoding="utf-8") as logf:
+                proc = subprocess.run(  # noqa: S603 - argv values validated by validate()/_security_problems before train() builds the command; list form, no shell
+                    cmd, cwd=parent, env=env,
+                    stdout=logf, stderr=subprocess.STDOUT, check=False,
+                )
+        except FileNotFoundError as e:
+            return TrainResult(
+                status="error", job_id=job_id,
+                message=f"launcher not found ({e}); is lerobot/accelerate installed?",
+            )
+
+        ckpt_dir = self._latest_checkpoint(spec.output_dir)
+        ckpt_model_dir = (
+            os.path.dirname(ckpt_dir) if ckpt_dir else None  # .../pretrained_model
+        )
+        metrics = self._parse_log(log_path)
+
+        if proc.returncode != 0:
+            return TrainResult(
+                status="error", job_id=job_id,
+                checkpoint_dir=ckpt_model_dir, metrics=metrics,
+                message=f"lerobot_train exited {proc.returncode}; see {log_path}",
+            )
+
+        return TrainResult(
+            status="success", job_id=job_id,
+            checkpoint_dir=ckpt_model_dir, metrics=metrics,
+            message=f"lerobot_train complete; log: {log_path}",
+        )
+
+    def _parse_log(self, log_path: str) -> dict[str, Any]:
+        """Extract a 'RUNNING != learning' verdict from the train log.
+
+        Parses lerobot's MetricsTracker line, whose exact format (verified vs
+        lerobot 0.5.x ``utils/logging_utils.py::MetricsTracker.__str__``) is::
+
+            step:1.2K smpl:4.9K ep:8 epch:2.00 loss:0.123 ...
+
+        - ``step`` / ``smpl`` / ``ep`` are run through ``format_big_number`` so
+          they carry K/M/B/T/Q suffixes (``step:1.2K``); we expand them back.
+        - ``loss`` is the AverageMeter avg, formatted ``:.3f``.
+
+        We take the LAST occurrence of each (newest). ``learning`` is True when
+        we saw a finite loss; ``liveness_ok`` is True when we saw a step line at
+        all (the booted-but-idle job that the vla-ft MCP flags returns False).
+        Best-effort; returns ``{}`` if the log is unreadable.
+        """
+        latest_step: int | None = None
+        latest_loss: float | None = None
+        latest_epoch: float | None = None
+        try:
+            with open(log_path, encoding="utf-8", errors="ignore") as f:
+                for line in f:
+                    if "step:" not in line:
+                        continue
+                    for tok in line.split():
+                        key, _, val = tok.partition(":")
+                        if not val:
+                            continue
+                        if key == "step":
+                            n = _expand_big_number(val)
+                            if n is not None:
+                                latest_step = int(n)
+                        elif key == "loss":
+                            with contextlib.suppress(ValueError):  # non-numeric loss token -> skip
+                                latest_loss = float(val)
+                        elif key == "epch":
+                            with contextlib.suppress(ValueError):  # non-numeric epoch token -> skip
+                                latest_epoch = float(val)
+        except OSError:
+            return {}
+
+        metrics: dict[str, Any] = {}
+        if latest_step is not None:
+            metrics["latest_step"] = latest_step
+        if latest_epoch is not None:
+            metrics["latest_epoch"] = latest_epoch
+        if latest_loss is not None:
+            import math
+
+            metrics["latest_loss"] = latest_loss
+            metrics["learning"] = math.isfinite(latest_loss)
+        metrics["liveness_ok"] = latest_step is not None
+        return metrics
+
+
+def _expand_big_number(token: str) -> float | None:
+    """Invert lerobot's ``format_big_number`` (e.g. ``"1.2K" -> 1200``).
+
+    Suffixes (lerobot ``utils.py``): "" K M B T Q (powers of 1000). Returns the
+    numeric value, or None if the token isn't a recognised big-number string.
+    """
+    suffixes = {"": 1, "K": 1e3, "M": 1e6, "B": 1e9, "T": 1e12, "Q": 1e15}
+    token = token.strip()
+    if not token:
+        return None
+    suffix = token[-1].upper()
+    if suffix in suffixes and suffix != "" and not token[-1].isdigit():
+        body, mult = token[:-1], suffixes[suffix]
+    else:
+        body, mult = token, 1
+    try:
+        return float(body) * mult
+    except ValueError:
+        return None
+
+
+def _auto_device() -> str:
+    try:
+        import torch
+
+        if torch.cuda.is_available():
+            return "cuda"
+        if getattr(torch.backends, "mps", None) and torch.backends.mps.is_available():
+            return "mps"
+    except Exception:  # noqa: BLE001
+        pass
+    return "cpu"

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -108,11 +108,14 @@ class LerobotTrainer(Trainer):
         except (OSError, ValueError, TypeError, json.JSONDecodeError):
             return None
 
-    def _latest_checkpoint(self, output_dir: str) -> str | None:
-        """Return the resumable ``train_config.json`` path, or None.
+    def _resume_config_path(self, output_dir: str) -> str | None:
+        """Return the resumable ``train_config.json`` FILE path, or None.
 
         lerobot writes checkpoints to ``<output_dir>/checkpoints/<step|last>/
-        pretrained_model/train_config.json``; resume needs the FILE path.
+        pretrained_model/train_config.json``; resume needs the FILE path (it
+        derives policy_dir/checkpoint_path from it). This is the resume-wiring
+        counterpart of the public :meth:`latest_checkpoint` (which returns the
+        loadable DIRECTORY for ``export``/``create_policy``).
         """
         ckpts = os.path.join(output_dir, "checkpoints")
         if not os.path.isdir(ckpts):
@@ -126,6 +129,17 @@ class LerobotTrainer(Trainer):
             if os.path.isfile(cfg):
                 candidates.append(cfg)
         return candidates[-1] if candidates else None
+
+    def latest_checkpoint(self, output_dir: str) -> str | None:
+        """Return the newest loadable ``pretrained_model`` directory, or None.
+
+        ABC contract: a directory ``create_policy``/``export`` can consume.
+        lerobot's loadable artifact is the ``pretrained_model`` dir that holds
+        ``model.safetensors`` + ``train_config.json``; we locate it from the
+        resume config file's parent.
+        """
+        cfg_file = self._resume_config_path(output_dir)
+        return os.path.dirname(cfg_file) if cfg_file else None
 
     def _val_split_episodes(self, spec: TrainSpec) -> list[int] | None:
         """Held-out validation split: train on the FIRST (total - N) episodes."""
@@ -227,7 +241,7 @@ class LerobotTrainer(Trainer):
         if eps is not None:
             cmd.append(f"--dataset.episodes=[{', '.join(map(str, eps))}]")
         if spec.resume:
-            ckpt_cfg = self._latest_checkpoint(spec.output_dir)
+            ckpt_cfg = self._resume_config_path(spec.output_dir)
             if ckpt_cfg:
                 cmd.append("--resume=true")
                 cmd.append(f"--config_path={ckpt_cfg}")
@@ -297,7 +311,7 @@ class LerobotTrainer(Trainer):
         if hasattr(cfg, "wandb") and hasattr(cfg.wandb, "enable"):
             cfg.wandb.enable = False
         if spec.resume:
-            ckpt_cfg = self._latest_checkpoint(spec.output_dir)
+            ckpt_cfg = self._resume_config_path(spec.output_dir)
             if ckpt_cfg:
                 cfg.checkpoint_path = Path(ckpt_cfg).parent.parent
 
@@ -333,7 +347,7 @@ class LerobotTrainer(Trainer):
 
         # Fresh-start hygiene: clear a stale output_dir with no resumable ckpt.
         if not spec.resume and os.path.isdir(spec.output_dir):
-            if self._latest_checkpoint(spec.output_dir) is None:
+            if self.latest_checkpoint(spec.output_dir) is None:
                 shutil.rmtree(spec.output_dir, ignore_errors=True)
 
         job_id = f"lerobot-{int(time.time())}"
@@ -375,8 +389,7 @@ class LerobotTrainer(Trainer):
             train_error = e
             logger.error("LerobotTrainer in-process train failed: %s", e)
 
-        ckpt_dir = self._latest_checkpoint(spec.output_dir)
-        ckpt_model_dir = os.path.dirname(ckpt_dir) if ckpt_dir else None  # .../pretrained_model
+        ckpt_model_dir = self.latest_checkpoint(spec.output_dir)  # loadable pretrained_model dir
         metrics = self._parse_log(log_path)
 
         if train_error is not None:

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -1,18 +1,35 @@
-"""LeRobot trainer - thin wrapper over ``lerobot.scripts.lerobot_train``.
+"""LeRobot trainer - drives ``lerobot.scripts.lerobot_train.train`` AS A LIBRARY.
 
-Builds and launches the LeRobot training CLI for any LeRobot-native policy
-type (act, diffusion, smolvla, pi0, pi05, ...). The training *logic* is
+Builds a typed :class:`lerobot.configs.train.TrainPipelineConfig` and calls
+lerobot's ``train(cfg)`` **directly in this interpreter** for any LeRobot-native
+policy type (act, diffusion, smolvla, pi0, pi05, ...). The training *logic* is
 entirely lerobot's; this adapter only translates a provider-agnostic
-:class:`~strands_robots.training.base.TrainSpec` into the correct draccus
-command + launcher, manages resume, and parses the run for a status verdict.
+:class:`~strands_robots.training.base.TrainSpec` into the config object, manages
+resume, and parses the run for a status verdict.
 
-Grounded against lerobot 0.5.x ``TrainPipelineConfig`` (the draccus config
-``lerobot_train`` parses):
-    --dataset.repo_id / --dataset.root / --dataset.episodes
-    --policy.type / --policy.device / --policy.push_to_hub / --policy.pretrained_path
-    --output_dir / --job_name / --steps / --batch_size / --save_freq
-    --resume / --seed / --wandb.enable
-    --peft.method_type / --peft.r / --peft.target_modules   (LoRA)
+Why in-process (no ``subprocess``)
+----------------------------------
+lerobot's entry point is a plain function ``train(cfg)`` whose ``@parser.wrap()``
+decorator (lerobot ``configs/parser.py``) short-circuits when the first
+positional arg is **already** a ``TrainPipelineConfig`` instance - it uses that
+object verbatim and never reads ``sys.argv``. So we build the config as typed
+Python objects (``make_policy_config`` + ``DatasetConfig`` + ``PeftConfig``) and
+hand it straight to ``train(cfg)``. No shell, no argv, no second interpreter.
+
+Launcher selection (still no shell):
+    * 1 GPU / CPU    -> call ``train(cfg)`` directly in-process.
+    * >1 GPU, 1 node -> ``elastic_launch`` (torch's programmatic launcher, the
+      engine behind ``torchrun``); each worker builds the cfg and calls
+      ``train(cfg)``. lerobot creates its own ``Accelerator`` inside, which picks
+      up the worker's distributed env. No ``accelerate``/``torchrun`` binary.
+    * multi-node     -> rejected in ``validate()`` (needs a per-node launcher).
+
+:meth:`build_command` is retained as a PURE argv-parity helper - it documents
+the exact draccus CLI the typed config corresponds to and powers the
+``test_native_parity`` drift check. It is NOT used to launch anything.
+
+Grounded against lerobot 0.5.x ``TrainPipelineConfig`` / ``DatasetConfig`` /
+``PeftConfig``.
 """
 
 from __future__ import annotations
@@ -22,17 +39,19 @@ import json
 import logging
 import os
 import shutil
-import subprocess
-import sys
 import time
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
+from strands_robots.training._inproc import call_callable, elastic_launch_callable
 from strands_robots.training.base import Trainer, TrainResult, TrainSpec
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from lerobot.configs.train import TrainPipelineConfig
 
 logger = logging.getLogger(__name__)
 
-# LeRobot-native policy types (draccus --policy.type values). Mirrors the
-# verified vla-ft POLICY_MAP; values pass straight through to lerobot.
+# LeRobot-native policy types (draccus --policy.type values / make_policy_config
+# keys). Mirrors the verified vla-ft POLICY_MAP; values pass straight through.
 _LEROBOT_POLICY_TYPES = {
     "act",
     "diffusion",
@@ -50,25 +69,22 @@ _SUPPORTED_METHODS = {"full", "lora", "expert_only"}
 
 
 class LerobotTrainer(Trainer):
-    """Post-tune a LeRobot-native policy via ``lerobot.scripts.lerobot_train``.
+    """Post-tune a LeRobot-native policy by calling ``lerobot`` train in-process.
 
     Args:
-        policy_type: LeRobot ``--policy.type`` (default ``"act"``). Resolved
-            from ``TrainSpec.extra['policy_type']`` if present, else this.
-        device: ``--policy.device`` (default auto: cuda > mps > cpu).
-        python_executable: Interpreter for the subprocess (default current).
+        policy_type: LeRobot policy type (default ``"act"``). Resolved from
+            ``TrainSpec.extra['policy_type']`` if present, else this.
+        device: Torch device string (default auto: cuda > mps > cpu).
     """
 
     def __init__(
         self,
         policy_type: str = "act",
         device: str | None = None,
-        python_executable: str | None = None,
         **kwargs: Any,
     ) -> None:
         self.policy_type = policy_type
         self.device = device or _auto_device()
-        self.python_executable = python_executable or sys.executable
 
     @property
     def provider_name(self) -> str:
@@ -96,22 +112,29 @@ class LerobotTrainer(Trainer):
         """Return the resumable ``train_config.json`` path, or None.
 
         lerobot writes checkpoints to ``<output_dir>/checkpoints/<step|last>/
-        pretrained_model/train_config.json`` and validate() needs the FILE
-        path on resume (it derives policy_dir/checkpoint_path from it).
+        pretrained_model/train_config.json``; resume needs the FILE path.
         """
         ckpts = os.path.join(output_dir, "checkpoints")
         if not os.path.isdir(ckpts):
             return None
-        # Prefer 'last', else the highest-numbered checkpoint dir.
-        candidates = []
         last = os.path.join(ckpts, "last", "pretrained_model", "train_config.json")
         if os.path.isfile(last):
             return last
+        candidates = []
         for name in sorted(os.listdir(ckpts)):
             cfg = os.path.join(ckpts, name, "pretrained_model", "train_config.json")
             if os.path.isfile(cfg):
                 candidates.append(cfg)
         return candidates[-1] if candidates else None
+
+    def _val_split_episodes(self, spec: TrainSpec) -> list[int] | None:
+        """Held-out validation split: train on the FIRST (total - N) episodes."""
+        if spec.val_episodes is None:
+            return None
+        total = self._dataset_total_episodes(spec.dataset_root)
+        if total is not None and 0 < spec.val_episodes < total:
+            return list(range(0, total - spec.val_episodes))
+        return None
 
     # ---- ABC ---------------------------------------------------------------
 
@@ -143,6 +166,12 @@ class LerobotTrainer(Trainer):
         if spec.steps <= 0:
             problems.append(f"steps must be > 0, got {spec.steps}")
 
+        if spec.num_nodes > 1:
+            problems.append(
+                f"num_nodes={spec.num_nodes}: multi-node lerobot needs a per-node "
+                "launcher and cannot run in-process; use num_nodes=1."
+            )
+
         if spec.val_episodes is not None and spec.dataset_root:
             total = self._dataset_total_episodes(spec.dataset_root)
             if total is not None and spec.val_episodes >= total:
@@ -160,25 +189,16 @@ class LerobotTrainer(Trainer):
         return problems
 
     def build_command(self, spec: TrainSpec) -> list[str]:
-        """Translate a TrainSpec into the lerobot_train argv (pure, testable)."""
+        """PURE argv-parity helper - the draccus CLI the typed config maps to.
+
+        NOT used to launch training (``train()`` builds a typed config and calls
+        lerobot's ``train(cfg)`` directly). Retained so ``test_native_parity``
+        can assert our field mapping matches lerobot's real CLI, and as a
+        human-readable description of the equivalent command.
+        """
         ptype = self._resolve_policy_type(spec)
-
-        if spec.num_gpus > 1:
-            launcher = [
-                "accelerate",
-                "launch",
-                "--multi_gpu",
-                f"--num_processes={spec.num_gpus}",
-                "--num_machines=1",
-                "--mixed_precision=bf16",
-                "-m",
-                "lerobot.scripts.lerobot_train",
-            ]
-        else:
-            launcher = [self.python_executable, "-m", "lerobot.scripts.lerobot_train"]
-
         cmd = [
-            *launcher,
+            "lerobot.scripts.lerobot_train",
             "--dataset.repo_id=local",
             f"--dataset.root={spec.dataset_root}",
             f"--policy.type={ptype}",
@@ -191,13 +211,10 @@ class LerobotTrainer(Trainer):
             f"--save_freq={spec.save_freq}",
             "--wandb.enable=false",
         ]
-
         if spec.base_model:
             cmd.append(f"--policy.pretrained_path={spec.base_model}")
         if spec.seed is not None:
             cmd.append(f"--seed={spec.seed}")
-
-        # Tuning strategy.
         if spec.method == "lora":
             cmd.append("--peft.method_type=LORA")
             if spec.lora_r is not None:
@@ -206,29 +223,97 @@ class LerobotTrainer(Trainer):
                 cmd.append(f"--peft.target_modules={spec.lora_target_modules}")
         elif spec.method == "expert_only":
             cmd.append("--policy.train_expert_only=true")
-
-        # Held-out validation split: train on the FIRST (total - N) episodes.
-        if spec.val_episodes is not None:
-            total = self._dataset_total_episodes(spec.dataset_root)
-            if total is not None and 0 < spec.val_episodes < total:
-                train_eps = list(range(0, total - spec.val_episodes))
-                cmd.append(f"--dataset.episodes=[{', '.join(map(str, train_eps))}]")
-
-        # Resume: needs BOTH --resume=true AND --config_path=<ckpt>/train_config.json
+        eps = self._val_split_episodes(spec)
+        if eps is not None:
+            cmd.append(f"--dataset.episodes=[{', '.join(map(str, eps))}]")
         if spec.resume:
             ckpt_cfg = self._latest_checkpoint(spec.output_dir)
             if ckpt_cfg:
                 cmd.append("--resume=true")
                 cmd.append(f"--config_path={ckpt_cfg}")
-
-        # Passthrough: any remaining extra.* as --key=value (skip consumed keys).
         _consumed = {"policy_type", "job_name"}
         for key, value in spec.extra.items():
             if key in _consumed:
                 continue
             cmd.append(f"--{key}={value}")
-
         return cmd
+
+    def build_config(self, spec: TrainSpec) -> TrainPipelineConfig:
+        """Build lerobot's typed ``TrainPipelineConfig`` from a TrainSpec (pure).
+
+        The in-process equivalent of :meth:`build_command`: constructs the
+        dataclass tree ``train(cfg)`` consumes directly (no argv).
+        """
+        from pathlib import Path
+
+        from lerobot.configs.default import DatasetConfig, PeftConfig
+        from lerobot.configs.train import TrainPipelineConfig
+        from lerobot.policies.factory import make_policy_config
+
+        ptype = self._resolve_policy_type(spec)
+
+        policy_cfg = make_policy_config(ptype)
+        if hasattr(policy_cfg, "device"):
+            policy_cfg.device = self.device
+        if hasattr(policy_cfg, "push_to_hub"):
+            policy_cfg.push_to_hub = False
+        if spec.base_model:
+            policy_cfg.pretrained_path = Path(spec.base_model)
+        if spec.method == "expert_only" and hasattr(policy_cfg, "train_expert_only"):
+            policy_cfg.train_expert_only = True
+
+        dataset_cfg = DatasetConfig(
+            repo_id="local",
+            root=spec.dataset_root,
+            episodes=self._val_split_episodes(spec),
+        )
+
+        peft_cfg = None
+        if spec.method == "lora":
+            peft_kwargs: dict[str, Any] = {"method_type": "LORA"}
+            if spec.lora_r is not None:
+                peft_kwargs["r"] = spec.lora_r
+            if spec.lora_alpha is not None:
+                peft_kwargs["lora_alpha"] = spec.lora_alpha
+            if spec.lora_target_modules is not None:
+                peft_kwargs["target_modules"] = spec.lora_target_modules
+            peft_cfg = PeftConfig(**peft_kwargs)
+            if hasattr(policy_cfg, "use_peft"):
+                policy_cfg.use_peft = True
+
+        cfg = TrainPipelineConfig(
+            dataset=dataset_cfg,
+            policy=policy_cfg,
+            output_dir=Path(spec.output_dir) if spec.output_dir else None,
+            job_name=str(spec.extra.get("job_name", "strands_ft")),
+            steps=spec.steps,
+            batch_size=spec.global_batch_size,
+            save_freq=spec.save_freq,
+            resume=spec.resume,
+            peft=peft_cfg,
+        )
+        if spec.seed is not None:
+            cfg.seed = spec.seed
+        if hasattr(cfg, "wandb") and hasattr(cfg.wandb, "enable"):
+            cfg.wandb.enable = False
+        if spec.resume:
+            ckpt_cfg = self._latest_checkpoint(spec.output_dir)
+            if ckpt_cfg:
+                cfg.checkpoint_path = Path(ckpt_cfg).parent.parent
+
+        # Typed passthrough for remaining extra.* (gated by validate()'s key
+        # allowlist). Only set attributes that exist on the typed config tree;
+        # unknown keys are ignored (never become an arbitrary flag).
+        _consumed = {"policy_type", "job_name"}
+        for key, value in spec.extra.items():
+            if key in _consumed:
+                continue
+            target, attr = _resolve_dotted(cfg, key)
+            if target is not None and hasattr(target, attr):
+                setattr(target, attr, value)
+            else:
+                logger.warning("LerobotTrainer: ignoring extra '%s' (no matching config field).", key)
+        return cfg
 
     def train(self, spec: TrainSpec) -> TrainResult:
         problems = self.validate(spec)
@@ -242,85 +327,74 @@ class LerobotTrainer(Trainer):
         self.prepare(spec)
 
         # lerobot's validate() REFUSES a pre-existing output_dir unless
-        # resume=True (it creates the dir itself). So we must NOT pre-create
-        # output_dir. We only ensure its PARENT exists, and we write our log
-        # NEXT TO output_dir (not inside it) so the log file doesn't trip the
-        # "already exists" guard either.
+        # resume=True. Don't pre-create output_dir; write our log NEXT TO it.
         parent = os.path.dirname(os.path.abspath(spec.output_dir)) or "."
         os.makedirs(parent, exist_ok=True)
 
-        # Fresh-start hygiene: if NOT resuming and output_dir exists with no
-        # resumable checkpoint, clear it so lerobot's guard doesn't crash a
-        # rerun (the vla-ft reclaim-before-first-save failure mode).
+        # Fresh-start hygiene: clear a stale output_dir with no resumable ckpt.
         if not spec.resume and os.path.isdir(spec.output_dir):
             if self._latest_checkpoint(spec.output_dir) is None:
                 shutil.rmtree(spec.output_dir, ignore_errors=True)
 
-        cmd = self.build_command(spec)
         job_id = f"lerobot-{int(time.time())}"
         log_path = os.path.join(parent, f"{os.path.basename(spec.output_dir)}.{job_id}.log")
-
-        logger.info("LerobotTrainer launching: %s", " ".join(cmd))
-        env = dict(os.environ)
-        env.setdefault("PYTHONUNBUFFERED", "1")
-        env.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+        os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
 
         try:
-            with open(log_path, "w", encoding="utf-8") as logf:
-                proc = subprocess.run(  # noqa: S603 - argv values validated by validate()/_security_problems before train() builds the command; list form, no shell
-                    cmd,
-                    cwd=parent,
-                    env=env,
-                    stdout=logf,
-                    stderr=subprocess.STDOUT,
-                    check=False,
-                )
-        except FileNotFoundError as e:
+            cfg = self.build_config(spec)
+        except Exception as e:  # noqa: BLE001 - config build is the typed boundary
             return TrainResult(
-                status="error",
-                job_id=job_id,
-                message=f"launcher not found ({e}); is lerobot/accelerate installed?",
+                status="error", job_id=job_id,
+                message=f"failed to build lerobot TrainPipelineConfig: {e}",
             )
 
-        ckpt_dir = self._latest_checkpoint(spec.output_dir)
-        ckpt_model_dir = (
-            os.path.dirname(ckpt_dir) if ckpt_dir else None  # .../pretrained_model
+        logger.info(
+            "LerobotTrainer launching in-process: policy=%s device=%s steps=%d num_gpus=%d",
+            self._resolve_policy_type(spec), self.device, spec.steps, spec.num_gpus,
         )
+
+        train_error: BaseException | None = None
+        try:
+            if spec.num_gpus and spec.num_gpus > 1:
+                elastic_launch_callable(
+                    _lerobot_worker,
+                    nproc_per_node=spec.num_gpus,
+                    nnodes=1,
+                    run_id=job_id,
+                    fn_args=(self.policy_type, self.device, spec, log_path),
+                )
+            else:
+                from lerobot.scripts.lerobot_train import train as lerobot_train
+
+                call_callable(lerobot_train, cfg, log_path=log_path)
+        except BaseException as e:  # noqa: BLE001 - convert ANY failure to a result
+            train_error = e
+            logger.error("LerobotTrainer in-process train failed: %s", e)
+
+        ckpt_dir = self._latest_checkpoint(spec.output_dir)
+        ckpt_model_dir = os.path.dirname(ckpt_dir) if ckpt_dir else None  # .../pretrained_model
         metrics = self._parse_log(log_path)
 
-        if proc.returncode != 0:
+        if train_error is not None:
             return TrainResult(
-                status="error",
-                job_id=job_id,
-                checkpoint_dir=ckpt_model_dir,
-                metrics=metrics,
-                message=f"lerobot_train exited {proc.returncode}; see {log_path}",
+                status="error", job_id=job_id,
+                checkpoint_dir=ckpt_model_dir, metrics=metrics,
+                message=f"lerobot train raised {type(train_error).__name__}: {train_error}; see {log_path}",
             )
 
         return TrainResult(
-            status="success",
-            job_id=job_id,
-            checkpoint_dir=ckpt_model_dir,
-            metrics=metrics,
-            message=f"lerobot_train complete; log: {log_path}",
+            status="success", job_id=job_id,
+            checkpoint_dir=ckpt_model_dir, metrics=metrics,
+            message=f"lerobot train complete (in-process); log: {log_path}",
         )
 
     def _parse_log(self, log_path: str) -> dict[str, Any]:
-        """Extract a 'RUNNING != learning' verdict from the train log.
+        """Extract a 'RUNNING != learning' verdict from the captured train log.
 
-        Parses lerobot's MetricsTracker line, whose exact format (verified vs
-        lerobot 0.5.x ``utils/logging_utils.py::MetricsTracker.__str__``) is::
+        Parses lerobot's MetricsTracker line (verified vs lerobot 0.5.x
+        ``utils/logging_utils.py::MetricsTracker.__str__``)::
 
             step:1.2K smpl:4.9K ep:8 epch:2.00 loss:0.123 ...
-
-        - ``step`` / ``smpl`` / ``ep`` are run through ``format_big_number`` so
-          they carry K/M/B/T/Q suffixes (``step:1.2K``); we expand them back.
-        - ``loss`` is the AverageMeter avg, formatted ``:.3f``.
-
-        We take the LAST occurrence of each (newest). ``learning`` is True when
-        we saw a finite loss; ``liveness_ok`` is True when we saw a step line at
-        all (the booted-but-idle job that the vla-ft MCP flags returns False).
-        Best-effort; returns ``{}`` if the log is unreadable.
         """
         latest_step: int | None = None
         latest_loss: float | None = None
@@ -339,10 +413,10 @@ class LerobotTrainer(Trainer):
                             if n is not None:
                                 latest_step = int(n)
                         elif key == "loss":
-                            with contextlib.suppress(ValueError):  # non-numeric loss token -> skip
+                            with contextlib.suppress(ValueError):
                                 latest_loss = float(val)
                         elif key == "epch":
-                            with contextlib.suppress(ValueError):  # non-numeric epoch token -> skip
+                            with contextlib.suppress(ValueError):
                                 latest_epoch = float(val)
         except OSError:
             return {}
@@ -361,12 +435,36 @@ class LerobotTrainer(Trainer):
         return metrics
 
 
-def _expand_big_number(token: str) -> float | None:
-    """Invert lerobot's ``format_big_number`` (e.g. ``"1.2K" -> 1200``).
+def _resolve_dotted(cfg: Any, key: str):
+    """Map a (optionally dotted) extra key to (obj, attr) on the config tree."""
+    if "." not in key:
+        return cfg, key
+    head, _, tail = key.partition(".")
+    sub = getattr(cfg, head, None)
+    if sub is None or "." in tail:
+        return None, tail
+    return sub, tail
 
-    Suffixes (lerobot ``utils.py``): "" K M B T Q (powers of 1000). Returns the
-    numeric value, or None if the token isn't a recognised big-number string.
+
+def _lerobot_worker(policy_type: str, device: str, spec: TrainSpec, log_path: str) -> None:
+    """elastic_launch worker: build the cfg and call lerobot train() in this worker.
+
+    Runs in a torch-spawned worker (one per GPU). torch sets RANK / LOCAL_RANK /
+    WORLD_SIZE; lerobot's Accelerator picks them up. Only local rank 0 tees to
+    the shared log to avoid interleaved writes.
     """
+    import os as _os
+
+    trainer = LerobotTrainer(policy_type=policy_type, device=device)
+    cfg = trainer.build_config(spec)
+    from lerobot.scripts.lerobot_train import train as lerobot_train
+
+    is_rank0 = _os.environ.get("LOCAL_RANK", "0") == "0"
+    call_callable(lerobot_train, cfg, log_path=log_path if is_rank0 else None)
+
+
+def _expand_big_number(token: str) -> float | None:
+    """Invert lerobot's ``format_big_number`` (e.g. ``"1.2K" -> 1200``)."""
     suffixes = {"": 1, "K": 1e3, "M": 1e6, "B": 1e9, "T": 1e12, "Q": 1e15}
     token = token.strip()
     if not token:

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -344,13 +344,17 @@ class LerobotTrainer(Trainer):
             cfg = self.build_config(spec)
         except Exception as e:  # noqa: BLE001 - config build is the typed boundary
             return TrainResult(
-                status="error", job_id=job_id,
+                status="error",
+                job_id=job_id,
                 message=f"failed to build lerobot TrainPipelineConfig: {e}",
             )
 
         logger.info(
             "LerobotTrainer launching in-process: policy=%s device=%s steps=%d num_gpus=%d",
-            self._resolve_policy_type(spec), self.device, spec.steps, spec.num_gpus,
+            self._resolve_policy_type(spec),
+            self.device,
+            spec.steps,
+            spec.num_gpus,
         )
 
         train_error: BaseException | None = None
@@ -377,14 +381,18 @@ class LerobotTrainer(Trainer):
 
         if train_error is not None:
             return TrainResult(
-                status="error", job_id=job_id,
-                checkpoint_dir=ckpt_model_dir, metrics=metrics,
+                status="error",
+                job_id=job_id,
+                checkpoint_dir=ckpt_model_dir,
+                metrics=metrics,
                 message=f"lerobot train raised {type(train_error).__name__}: {train_error}; see {log_path}",
             )
 
         return TrainResult(
-            status="success", job_id=job_id,
-            checkpoint_dir=ckpt_model_dir, metrics=metrics,
+            status="success",
+            job_id=job_id,
+            checkpoint_dir=ckpt_model_dir,
+            metrics=metrics,
             message=f"lerobot train complete (in-process); log: {log_path}",
         )
 
@@ -435,7 +443,7 @@ class LerobotTrainer(Trainer):
         return metrics
 
 
-def _resolve_dotted(cfg: Any, key: str):
+def _resolve_dotted(cfg: Any, key: str) -> tuple[Any, str]:
     """Map a (optionally dotted) extra key to (obj, attr) on the config tree."""
     if "." not in key:
         return cfg, key

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -132,15 +132,11 @@ class LerobotTrainer(Trainer):
         ptype = self._resolve_policy_type(spec)
         if ptype not in _LEROBOT_POLICY_TYPES:
             problems.append(
-                f"policy_type '{ptype}' is not LeRobot-native "
-                f"(expected one of {sorted(_LEROBOT_POLICY_TYPES)})"
+                f"policy_type '{ptype}' is not LeRobot-native (expected one of {sorted(_LEROBOT_POLICY_TYPES)})"
             )
 
         if spec.method not in _SUPPORTED_METHODS:
-            problems.append(
-                f"unsupported method '{spec.method}' "
-                f"(expected one of {sorted(_SUPPORTED_METHODS)})"
-            )
+            problems.append(f"unsupported method '{spec.method}' (expected one of {sorted(_SUPPORTED_METHODS)})")
         if spec.method == "lora" and spec.tune.get("expert_only"):
             problems.append("lora and expert_only are mutually exclusive (both freeze the VLM)")
 
@@ -150,9 +146,7 @@ class LerobotTrainer(Trainer):
         if spec.val_episodes is not None and spec.dataset_root:
             total = self._dataset_total_episodes(spec.dataset_root)
             if total is not None and spec.val_episodes >= total:
-                problems.append(
-                    f"val_episodes={spec.val_episodes} >= total_episodes={total}"
-                )
+                problems.append(f"val_episodes={spec.val_episodes} >= total_episodes={total}")
 
         # lerobot must be importable to actually train.
         try:
@@ -171,12 +165,14 @@ class LerobotTrainer(Trainer):
 
         if spec.num_gpus > 1:
             launcher = [
-                "accelerate", "launch",
+                "accelerate",
+                "launch",
                 "--multi_gpu",
                 f"--num_processes={spec.num_gpus}",
                 "--num_machines=1",
                 "--mixed_precision=bf16",
-                "-m", "lerobot.scripts.lerobot_train",
+                "-m",
+                "lerobot.scripts.lerobot_train",
             ]
         else:
             launcher = [self.python_executable, "-m", "lerobot.scripts.lerobot_train"]
@@ -238,7 +234,8 @@ class LerobotTrainer(Trainer):
         problems = self.validate(spec)
         if problems:
             return TrainResult(
-                status="error", job_id="",
+                status="error",
+                job_id="",
                 message="validation failed: " + "; ".join(problems),
             )
 
@@ -271,12 +268,17 @@ class LerobotTrainer(Trainer):
         try:
             with open(log_path, "w", encoding="utf-8") as logf:
                 proc = subprocess.run(  # noqa: S603 - argv values validated by validate()/_security_problems before train() builds the command; list form, no shell
-                    cmd, cwd=parent, env=env,
-                    stdout=logf, stderr=subprocess.STDOUT, check=False,
+                    cmd,
+                    cwd=parent,
+                    env=env,
+                    stdout=logf,
+                    stderr=subprocess.STDOUT,
+                    check=False,
                 )
         except FileNotFoundError as e:
             return TrainResult(
-                status="error", job_id=job_id,
+                status="error",
+                job_id=job_id,
                 message=f"launcher not found ({e}); is lerobot/accelerate installed?",
             )
 
@@ -288,14 +290,18 @@ class LerobotTrainer(Trainer):
 
         if proc.returncode != 0:
             return TrainResult(
-                status="error", job_id=job_id,
-                checkpoint_dir=ckpt_model_dir, metrics=metrics,
+                status="error",
+                job_id=job_id,
+                checkpoint_dir=ckpt_model_dir,
+                metrics=metrics,
                 message=f"lerobot_train exited {proc.returncode}; see {log_path}",
             )
 
         return TrainResult(
-            status="success", job_id=job_id,
-            checkpoint_dir=ckpt_model_dir, metrics=metrics,
+            status="success",
+            job_id=job_id,
+            checkpoint_dir=ckpt_model_dir,
+            metrics=metrics,
             message=f"lerobot_train complete; log: {log_path}",
         )
 

--- a/strands_robots/training/mock.py
+++ b/strands_robots/training/mock.py
@@ -36,10 +36,7 @@ class MockTrainer(Trainer):
         else:
             info = os.path.join(spec.dataset_root, "meta", "info.json")
             if not os.path.isfile(info):
-                problems.append(
-                    f"dataset_root is not a LeRobotDataset v3 root "
-                    f"(missing {info})"
-                )
+                problems.append(f"dataset_root is not a LeRobotDataset v3 root (missing {info})")
 
         if not spec.base_model:
             problems.append("base_model is required")
@@ -47,10 +44,7 @@ class MockTrainer(Trainer):
             problems.append("output_dir is required")
 
         if spec.method not in _SUPPORTED_METHODS:
-            problems.append(
-                f"unsupported method '{spec.method}' "
-                f"(expected one of {sorted(_SUPPORTED_METHODS)})"
-            )
+            problems.append(f"unsupported method '{spec.method}' (expected one of {sorted(_SUPPORTED_METHODS)})")
         if spec.method == "lora" and spec.tune.get("expert_only"):
             problems.append("lora and expert_only are mutually exclusive")
 

--- a/strands_robots/training/mock.py
+++ b/strands_robots/training/mock.py
@@ -56,6 +56,11 @@ class MockTrainer(Trainer):
     def _job_path(self, output_dir: str) -> str:
         return os.path.join(output_dir, "mock_job.json")
 
+    def latest_checkpoint(self, output_dir: str) -> str | None:
+        """Return the simulated checkpoint dir (``checkpoints/last``), or None."""
+        ckpt = os.path.join(output_dir, "checkpoints", "last")
+        return ckpt if os.path.isdir(ckpt) else None
+
     def train(self, spec: TrainSpec) -> TrainResult:
         """Simulate a training run: write a checkpoint stub + job record."""
         problems = self.validate(spec)

--- a/strands_robots/training/mock.py
+++ b/strands_robots/training/mock.py
@@ -1,0 +1,117 @@
+"""Mock trainer - the canonical no-dependency reference implementation.
+
+Mirrors :class:`~strands_robots.policies.mock.MockPolicy`: zero heavy deps,
+deterministic, used in tests and as the worked example of the :class:`Trainer`
+contract. It does NOT launch any real training - ``train`` simulates a run by
+writing a tiny checkpoint stub and a job record, so the full lifecycle
+(``validate -> prepare -> train -> status -> export``) is exercisable on any
+machine.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from typing import Any
+
+from strands_robots.training.base import Trainer, TrainResult, TrainSpec
+
+_SUPPORTED_METHODS = {"full", "lora", "expert_only", "frozen_backbone"}
+
+
+class MockTrainer(Trainer):
+    """Reference :class:`Trainer` that simulates a training run (no deps)."""
+
+    @property
+    def provider_name(self) -> str:
+        return "mock"
+
+    def validate(self, spec: TrainSpec) -> list[str]:
+        """Pure preflight: dataset presence, method sanity, lora/expert clash."""
+        problems: list[str] = self._security_problems(spec)
+
+        if not spec.dataset_root:
+            problems.append("dataset_root is required")
+        else:
+            info = os.path.join(spec.dataset_root, "meta", "info.json")
+            if not os.path.isfile(info):
+                problems.append(
+                    f"dataset_root is not a LeRobotDataset v3 root "
+                    f"(missing {info})"
+                )
+
+        if not spec.base_model:
+            problems.append("base_model is required")
+        if not spec.output_dir:
+            problems.append("output_dir is required")
+
+        if spec.method not in _SUPPORTED_METHODS:
+            problems.append(
+                f"unsupported method '{spec.method}' "
+                f"(expected one of {sorted(_SUPPORTED_METHODS)})"
+            )
+        if spec.method == "lora" and spec.tune.get("expert_only"):
+            problems.append("lora and expert_only are mutually exclusive")
+
+        if spec.steps <= 0:
+            problems.append(f"steps must be > 0, got {spec.steps}")
+
+        return problems
+
+    def _job_path(self, output_dir: str) -> str:
+        return os.path.join(output_dir, "mock_job.json")
+
+    def train(self, spec: TrainSpec) -> TrainResult:
+        """Simulate a training run: write a checkpoint stub + job record."""
+        problems = self.validate(spec)
+        if problems:
+            return TrainResult(
+                status="error",
+                job_id="",
+                message="validation failed: " + "; ".join(problems),
+            )
+
+        self.prepare(spec)
+
+        job_id = f"mock-{int(time.time())}"
+        ckpt_dir = os.path.join(spec.output_dir, "checkpoints", "last")
+        os.makedirs(ckpt_dir, exist_ok=True)
+
+        # Minimal checkpoint stub so export() has something to return.
+        with open(os.path.join(ckpt_dir, "config.json"), "w", encoding="utf-8") as f:
+            json.dump(
+                {"provider": "mock", "base_model": spec.base_model, "steps": spec.steps},
+                f,
+            )
+
+        record: dict[str, Any] = {
+            "job_id": job_id,
+            "status": "success",
+            "checkpoint_dir": ckpt_dir,
+            "metrics": {
+                "latest_step": spec.steps,
+                "latest_loss": 0.0,
+                "learning": True,
+                "liveness_ok": True,
+            },
+        }
+        with open(self._job_path(spec.output_dir), "w", encoding="utf-8") as f:
+            json.dump(record, f)
+
+        return TrainResult(
+            status="success",
+            job_id=job_id,
+            checkpoint_dir=ckpt_dir,
+            metrics=record["metrics"],
+            message=f"mock training complete ({spec.steps} steps simulated)",
+        )
+
+    def status(self, job_id: str) -> TrainResult:
+        """Mock status is always 'learning' for a known job id format."""
+        return TrainResult(
+            status="success",
+            job_id=job_id,
+            metrics={"learning": True, "liveness_ok": True, "latest_loss": 0.0},
+            message="mock job is (always) learning",
+        )

--- a/tests/tools/test_tools_lazy_import.py
+++ b/tests/tools/test_tools_lazy_import.py
@@ -35,6 +35,7 @@ def test_all_lists_every_lazy_import_name() -> None:
         "pose_tool",
         "robot_mesh",
         "serial_tool",
+        "train_policy",
         "use_lerobot",
     }
 

--- a/tests/training/test_cosmos3.py
+++ b/tests/training/test_cosmos3.py
@@ -78,13 +78,31 @@ class TestValidate:
         assert any("cosmos-framework checkout not found" in p for p in problems)
 
 
-class TestConvertCommand:
-    def test_dcp_convert(self, spec):
-        cmd = Cosmos3Trainer().convert_command(spec)
-        joined = " ".join(cmd)
-        assert "cosmos_framework.scripts.convert_model_to_dcp" in joined
-        assert "nvidia/Cosmos3-Nano" in cmd
-        assert "-o" in cmd
+class TestBuildOverrides:
+    """build_overrides() yields the Hydra key=value LIST (no launcher/argv).
+
+    prepare()/export() now call cosmos_framework's convert_model_to_dcp() /
+    export_model() DIRECTLY with typed Args objects (verified against upstream),
+    so there is no convert_command/export_command argv to assert anymore.
+    """
+
+    def test_core_overrides(self, spec):
+        ov = Cosmos3Trainer().build_overrides(spec)
+        assert all("=" in o and not o.startswith("-") for o in ov)
+        assert "trainer.max_iter=1000" in ov
+        assert "checkpoint.save_iter=500" in ov
+        assert "optimizer.lr=0.0002" in ov
+        assert any(o.startswith("checkpoint.load_path=") for o in ov)
+        assert "dataloader_train.max_samples_per_batch=8" in ov
+
+    def test_consumed_keys_not_leaked(self, spec):
+        spec.extra["dcp_path"] = "/tmp/dcp"
+        spec.extra["export_dir"] = "/tmp/exp"
+        ov = Cosmos3Trainer().build_overrides(spec)
+        assert not any(o.startswith("cosmos_root=") for o in ov)
+        assert not any(o.startswith("sft_toml=") for o in ov)
+        assert not any(o.startswith("dcp_path=") for o in ov)
+        assert not any(o.startswith("export_dir=") for o in ov)
 
 
 class TestBuildCommand:
@@ -116,13 +134,3 @@ class TestBuildCommand:
         cmd = Cosmos3Trainer().build_command(spec)
         tail = cmd[cmd.index("--") + 1 :]
         assert any("use_filter_dict=True" in t for t in tail)
-
-
-class TestExportCommand:
-    def test_dcp_to_safetensors(self, spec, tmp_path):
-        out = str(tmp_path / "exported")
-        cmd = Cosmos3Trainer().export_command(spec, str(tmp_path / "ckpt"), out)
-        joined = " ".join(cmd)
-        assert "cosmos_framework.scripts.export_model" in joined
-        assert any(c.startswith("--checkpoint-path=") for c in cmd)
-        assert any(c.startswith("--output-dir=") for c in cmd)

--- a/tests/training/test_cosmos3.py
+++ b/tests/training/test_cosmos3.py
@@ -1,0 +1,128 @@
+"""Tests for Cosmos3Trainer: factory wiring, validate, prepare/train/export cmds.
+
+Offline/pure - uses a fake cosmos_root + fake sft_toml; does not require the
+cosmos-framework env. Verifies the DCP-convert (prepare) and DCP->safetensors
+(export) command construction that distinguish Cosmos3 from the other backends.
+"""
+
+import json
+
+import pytest
+
+from strands_robots.training import TrainSpec, create_trainer
+from strands_robots.training.cosmos3 import Cosmos3Trainer
+
+
+@pytest.fixture
+def dataset_root(tmp_path):
+    meta = tmp_path / "meta"
+    meta.mkdir()
+    (meta / "info.json").write_text(json.dumps({"total_episodes": 8}))
+    return str(tmp_path)
+
+
+@pytest.fixture
+def fake_cosmos_root(tmp_path):
+    (tmp_path / "cosmos_framework").mkdir()
+    return str(tmp_path)
+
+
+@pytest.fixture
+def sft_toml(tmp_path):
+    f = tmp_path / "recipe.toml"
+    f.write_text("[job]\nexperiment = 'action_policy_droid_nano'\n")
+    return str(f)
+
+
+@pytest.fixture
+def spec(dataset_root, tmp_path, fake_cosmos_root, sft_toml):
+    return TrainSpec(
+        dataset_root=dataset_root,
+        base_model="nvidia/Cosmos3-Nano",
+        output_dir=str(tmp_path / "out"),
+        steps=1000,
+        global_batch_size=8,
+        learning_rate=2e-4,
+        save_freq=500,
+        num_gpus=8,
+        extra={"cosmos_root": fake_cosmos_root, "sft_toml": sft_toml},
+    )
+
+
+class TestFactoryWiring:
+    def test_resolves_from_registry(self):
+        t = create_trainer("cosmos3")
+        assert isinstance(t, Cosmos3Trainer)
+        assert t.provider_name == "cosmos3"
+
+    def test_hardware_floor_is_8xh100(self):
+        floor = create_trainer("cosmos3").hardware_floor
+        assert floor["min_gpus"] == 8
+        assert floor["min_vram_gb"] == 80
+        assert floor["multinode"] is True
+
+
+class TestValidate:
+    def test_clean(self, spec):
+        assert Cosmos3Trainer().validate(spec) == []
+
+    def test_sft_toml_required(self, spec):
+        spec.extra.pop("sft_toml")
+        problems = Cosmos3Trainer().validate(spec)
+        assert any("needs a recipe TOML" in p for p in problems)
+
+    def test_missing_cosmos_root(self, spec, monkeypatch):
+        monkeypatch.delenv("COSMOS_ROOT", raising=False)
+        spec.extra.pop("cosmos_root")
+        problems = Cosmos3Trainer().validate(spec)
+        assert any("cosmos-framework checkout not found" in p for p in problems)
+
+
+class TestConvertCommand:
+    def test_dcp_convert(self, spec):
+        cmd = Cosmos3Trainer().convert_command(spec)
+        joined = " ".join(cmd)
+        assert "cosmos_framework.scripts.convert_model_to_dcp" in joined
+        assert "nvidia/Cosmos3-Nano" in cmd
+        assert "-o" in cmd
+
+
+class TestBuildCommand:
+    def test_torchrun_and_sft_toml(self, spec):
+        cmd = Cosmos3Trainer().build_command(spec)
+        assert cmd[0] == "torchrun"
+        assert "--nproc_per_node=8" in cmd
+        assert "-m" in cmd and "cosmos_framework.scripts.train" in cmd
+        assert any(c.startswith("--sft-toml=") for c in cmd)
+
+    def test_hydra_tail_overrides_after_dashdash(self, spec):
+        cmd = Cosmos3Trainer().build_command(spec)
+        assert "--" in cmd
+        tail = cmd[cmd.index("--") + 1 :]
+        assert "trainer.max_iter=1000" in tail
+        assert "checkpoint.save_iter=500" in tail
+        assert "optimizer.lr=0.0002" in tail
+        assert any(t.startswith("checkpoint.load_path=") for t in tail)
+        assert "dataloader_train.max_samples_per_batch=8" in tail
+
+    def test_multinode_hsdp_override(self, spec):
+        spec.num_nodes = 4
+        cmd = Cosmos3Trainer().build_command(spec)
+        tail = cmd[cmd.index("--") + 1 :]
+        assert "model.config.parallelism.data_parallel_replicate_degree=4" in tail
+
+    def test_extra_hydra_passthrough(self, spec):
+        spec.extra["dataloader_train.dataloader.datasets.droid.dataset.use_filter_dict"] = "True"
+        cmd = Cosmos3Trainer().build_command(spec)
+        tail = cmd[cmd.index("--") + 1 :]
+        assert any("use_filter_dict=True" in t for t in tail)
+
+
+class TestExportCommand:
+    def test_dcp_to_safetensors(self, spec, tmp_path):
+        out = str(tmp_path / "exported")
+        cmd = Cosmos3Trainer().export_command(spec, str(tmp_path / "ckpt"), out)
+        joined = " ".join(cmd)
+        assert "cosmos_framework.scripts.export_model" in joined
+        assert any(c.startswith("--checkpoint-path=") for c in cmd)
+        assert any(c.startswith("--output-dir=") for c in cmd)

--- a/tests/training/test_factory.py
+++ b/tests/training/test_factory.py
@@ -1,0 +1,139 @@
+"""Tests for the Trainer abstraction: ABC contract, factory, mock lifecycle."""
+
+import json
+import os
+
+import pytest
+
+from strands_robots.training import (
+    Trainer,
+    TrainResult,
+    TrainSpec,
+    create_trainer,
+    import_trainer_class,
+    list_trainers,
+    register_trainer,
+)
+from strands_robots.training.mock import MockTrainer
+
+
+@pytest.fixture
+def dataset_root(tmp_path):
+    """A minimal LeRobotDataset v3 root (just meta/info.json)."""
+    meta = tmp_path / "meta"
+    meta.mkdir()
+    (meta / "info.json").write_text(json.dumps({"total_episodes": 5}))
+    return str(tmp_path)
+
+
+@pytest.fixture
+def spec(dataset_root, tmp_path):
+    out = tmp_path / "ft_out"
+    return TrainSpec(
+        dataset_root=dataset_root,
+        base_model="mock/base",
+        output_dir=str(out),
+        steps=100,
+    )
+
+
+class TestFactory:
+    def test_create_from_registry(self):
+        """`mock` resolves via its policies.json trainer block."""
+        t = create_trainer("mock")
+        assert isinstance(t, MockTrainer)
+        assert t.provider_name == "mock"
+
+    def test_list_trainers_includes_mock(self):
+        assert "mock" in list_trainers()
+
+    def test_import_trainer_class(self):
+        assert import_trainer_class("mock") is MockTrainer
+
+    def test_unknown_provider_raises(self):
+        with pytest.raises(ValueError, match="No trainer registered"):
+            create_trainer("does_not_exist_xyz")
+
+    def test_runtime_register_and_alias(self):
+        register_trainer("custom_x", lambda: MockTrainer, aliases=["cx"])
+        assert isinstance(create_trainer("custom_x"), MockTrainer)
+        assert isinstance(create_trainer("cx"), MockTrainer)
+        assert "custom_x" in list_trainers()
+
+    def test_trainer_is_subclass(self):
+        assert issubclass(MockTrainer, Trainer)
+
+
+class TestValidate:
+    def test_clean_spec_has_no_problems(self, spec):
+        assert create_trainer("mock").validate(spec) == []
+
+    def test_missing_dataset_reported(self, tmp_path):
+        t = create_trainer("mock")
+        s = TrainSpec(
+            dataset_root=str(tmp_path / "nope"),
+            base_model="m",
+            output_dir=str(tmp_path / "o"),
+        )
+        problems = t.validate(s)
+        assert any("LeRobotDataset v3" in p for p in problems)
+
+    def test_bad_method_reported(self, spec):
+        spec.method = "banana"
+        problems = create_trainer("mock").validate(spec)
+        assert any("unsupported method" in p for p in problems)
+
+    def test_lora_expert_only_mutually_exclusive(self, spec):
+        spec.method = "lora"
+        spec.tune = {"expert_only": True}
+        problems = create_trainer("mock").validate(spec)
+        assert any("mutually exclusive" in p for p in problems)
+
+    def test_nonpositive_steps_reported(self, spec):
+        spec.steps = 0
+        problems = create_trainer("mock").validate(spec)
+        assert any("steps must be > 0" in p for p in problems)
+
+
+class TestLifecycle:
+    def test_train_writes_checkpoint_and_succeeds(self, spec):
+        t = create_trainer("mock")
+        res = t.train(spec)
+        assert isinstance(res, TrainResult)
+        assert res.status == "success"
+        assert res.job_id
+        assert res.checkpoint_dir and os.path.isfile(
+            os.path.join(res.checkpoint_dir, "config.json")
+        )
+        assert res.metrics["learning"] is True
+
+    def test_train_refuses_invalid_spec(self, tmp_path):
+        t = create_trainer("mock")
+        bad = TrainSpec(dataset_root="/nope", base_model="", output_dir="", steps=0)
+        res = t.train(bad)
+        assert res.status == "error"
+        assert "validation failed" in res.message
+
+    def test_export_default_is_passthrough(self, spec):
+        t = create_trainer("mock")
+        res = t.train(spec)
+        assert t.export(spec, res.checkpoint_dir) == res.checkpoint_dir
+
+    def test_status_reports_learning(self, spec):
+        t = create_trainer("mock")
+        res = t.train(spec)
+        st = t.status(res.job_id)
+        assert st.status == "success"
+        assert st.metrics["learning"] is True
+
+    def test_hardware_floor_default(self):
+        floor = create_trainer("mock").hardware_floor
+        assert floor["min_gpus"] == 1
+        assert floor["multinode"] is False
+
+
+class TestSpecTolerance:
+    def test_unknown_extra_keys_do_not_break_validate(self, spec):
+        """The **kwargs-style tolerance rule: unknown extras are ignored."""
+        spec.extra = {"some_future_flag": "value", "another": 123}
+        assert create_trainer("mock").validate(spec) == []

--- a/tests/training/test_factory.py
+++ b/tests/training/test_factory.py
@@ -117,6 +117,18 @@ class TestLifecycle:
         res = t.train(spec)
         assert t.export(spec, res.checkpoint_dir) == res.checkpoint_dir
 
+    def test_latest_checkpoint_after_train(self, spec):
+        # MockTrainer writes checkpoints/last; latest_checkpoint must find it.
+        t = create_trainer("mock")
+        res = t.train(spec)
+        ckpt = t.latest_checkpoint(spec.output_dir)
+        assert ckpt is not None
+        assert ckpt == res.checkpoint_dir
+
+    def test_latest_checkpoint_none_before_train(self, tmp_path):
+        t = create_trainer("mock")
+        assert t.latest_checkpoint(str(tmp_path / "never_trained")) is None
+
     def test_status_reports_learning(self, spec):
         t = create_trainer("mock")
         res = t.train(spec)

--- a/tests/training/test_factory.py
+++ b/tests/training/test_factory.py
@@ -102,9 +102,7 @@ class TestLifecycle:
         assert isinstance(res, TrainResult)
         assert res.status == "success"
         assert res.job_id
-        assert res.checkpoint_dir and os.path.isfile(
-            os.path.join(res.checkpoint_dir, "config.json")
-        )
+        assert res.checkpoint_dir and os.path.isfile(os.path.join(res.checkpoint_dir, "config.json"))
         assert res.metrics["learning"] is True
 
     def test_train_refuses_invalid_spec(self, tmp_path):

--- a/tests/training/test_groot.py
+++ b/tests/training/test_groot.py
@@ -1,0 +1,134 @@
+"""Tests for Gr00tTrainer: factory wiring, validate, command building.
+
+Offline/pure - does not require an Isaac-GR00T checkout to run (uses a fake
+groot_root with a stub launch_finetune.py for the happy-path command tests).
+"""
+
+import json
+
+import pytest
+
+from strands_robots.training import TrainSpec, create_trainer
+from strands_robots.training.groot import Gr00tTrainer
+
+
+@pytest.fixture
+def dataset_root(tmp_path):
+    meta = tmp_path / "meta"
+    meta.mkdir()
+    (meta / "info.json").write_text(json.dumps({"total_episodes": 10}))
+    return str(tmp_path)
+
+
+@pytest.fixture
+def fake_groot_root(tmp_path):
+    """A fake Isaac-GR00T checkout with a stub launch_finetune.py."""
+    script = tmp_path / "gr00t" / "experiment" / "launch_finetune.py"
+    script.parent.mkdir(parents=True)
+    script.write_text("# stub\n")
+    return str(tmp_path)
+
+
+@pytest.fixture
+def spec(dataset_root, tmp_path, fake_groot_root):
+    return TrainSpec(
+        dataset_root=dataset_root,
+        base_model="nvidia/GR00T-N1.5-3B",
+        output_dir=str(tmp_path / "out"),
+        embodiment="GR1",
+        steps=500,
+        global_batch_size=32,
+        learning_rate=1e-4,
+        save_freq=100,
+        extra={"groot_root": fake_groot_root},
+    )
+
+
+class TestFactoryWiring:
+    def test_resolves_from_registry(self):
+        t = create_trainer("groot")
+        assert isinstance(t, Gr00tTrainer)
+        assert t.provider_name == "groot"
+
+    def test_hardware_floor(self):
+        assert create_trainer("groot").hardware_floor["min_gpus"] == 1
+
+
+class TestValidate:
+    def test_clean(self, spec):
+        assert Gr00tTrainer().validate(spec) == []
+
+    def test_embodiment_required(self, spec):
+        spec.embodiment = None
+        problems = Gr00tTrainer().validate(spec)
+        assert any("embodiment is required" in p for p in problems)
+
+    def test_missing_groot_root(self, spec, monkeypatch):
+        monkeypatch.delenv("GR00T_ROOT", raising=False)
+        spec.extra.pop("groot_root")
+        problems = Gr00tTrainer().validate(spec)
+        assert any("Isaac-GR00T checkout not found" in p for p in problems)
+
+    def test_bad_modality_config_path(self, spec):
+        spec.extra["modality_config_path"] = "/does/not/exist.py"
+        problems = Gr00tTrainer().validate(spec)
+        assert any("modality_config_path does not exist" in p for p in problems)
+
+
+class TestBuildCommand:
+    def test_single_gpu_core_flags(self, spec):
+        cmd = Gr00tTrainer().build_command(spec)
+        joined = " ".join(cmd)
+        assert "launch_finetune.py" in joined
+        assert "--base_model_path=nvidia/GR00T-N1.5-3B" in cmd
+        assert f"--dataset_path={spec.dataset_root}" in cmd
+        assert "--embodiment_tag=GR1" in cmd
+        assert "--max_steps=500" in cmd
+        assert "--global_batch_size=32" in cmd
+        assert "--save_steps=100" in cmd
+        assert "--num_gpus=1" in cmd
+
+    def test_default_tune_flags(self, spec):
+        cmd = Gr00tTrainer().build_command(spec)
+        assert "--tune_llm=false" in cmd
+        assert "--tune_visual=false" in cmd
+        assert "--tune_projector=true" in cmd
+        assert "--tune_diffusion_model=true" in cmd
+
+    def test_custom_tune_dict(self, spec):
+        spec.tune = {"llm": True, "visual": True, "projector": False, "diffusion": False}
+        cmd = Gr00tTrainer().build_command(spec)
+        assert "--tune_llm=true" in cmd
+        assert "--tune_visual=true" in cmd
+        assert "--tune_projector=false" in cmd
+        assert "--tune_diffusion_model=false" in cmd
+
+    def test_frozen_backbone_method(self, spec):
+        spec.method = "frozen_backbone"
+        spec.tune = {"llm": True, "visual": True}  # should be forced off
+        cmd = Gr00tTrainer().build_command(spec)
+        assert "--tune_llm=false" in cmd
+        assert "--tune_visual=false" in cmd
+
+    def test_multi_gpu_uses_torchrun(self, spec):
+        spec.num_gpus = 4
+        cmd = Gr00tTrainer().build_command(spec)
+        assert cmd[0] == "torchrun"
+        assert "--nproc_per_node=4" in cmd
+        assert "--num_gpus=4" in cmd
+
+    def test_resume_flag(self, spec):
+        spec.resume = True
+        cmd = Gr00tTrainer().build_command(spec)
+        assert "--resume_from_checkpoint" in cmd
+
+    def test_modality_config_and_passthrough(self, spec, tmp_path):
+        mcfg = tmp_path / "modality.py"
+        mcfg.write_text("# modality\n")
+        spec.extra["modality_config_path"] = str(mcfg)
+        spec.extra["weight_decay"] = 1e-5
+        cmd = Gr00tTrainer().build_command(spec)
+        assert f"--modality_config_path={mcfg}" in cmd
+        assert "--weight_decay=1e-05" in cmd
+        # consumed keys must not leak
+        assert not any(c.startswith("--groot_root=") for c in cmd)

--- a/tests/training/test_groot.py
+++ b/tests/training/test_groot.py
@@ -58,6 +58,11 @@ class TestValidate:
     def test_clean(self, spec):
         assert Gr00tTrainer().validate(spec) == []
 
+    def test_multi_node_rejected(self, spec):
+        spec.num_nodes = 2
+        problems = Gr00tTrainer().validate(spec)
+        assert any("multi-node" in p for p in problems)
+
     def test_embodiment_required(self, spec):
         spec.embodiment = None
         problems = Gr00tTrainer().validate(spec)

--- a/tests/training/test_lerobot.py
+++ b/tests/training/test_lerobot.py
@@ -69,8 +69,9 @@ class TestValidate:
 class TestBuildCommand:
     def test_single_gpu_core_flags(self, spec):
         cmd = LerobotTrainer(device="cpu").build_command(spec)
-        joined = " ".join(cmd)
-        assert "-m lerobot.scripts.lerobot_train" in joined
+        # build_command is now a PURE argv-parity helper (no launcher prefix);
+        # the module path is the first token.
+        assert cmd[0] == "lerobot.scripts.lerobot_train"
         assert "--dataset.repo_id=local" in cmd
         assert f"--dataset.root={spec.dataset_root}" in cmd
         assert "--policy.type=act" in cmd
@@ -82,13 +83,15 @@ class TestBuildCommand:
         assert "--wandb.enable=false" in cmd
         assert "--policy.pretrained_path=lerobot/act_aloha_sim" in cmd
 
-    def test_multi_gpu_uses_accelerate(self, spec):
+    def test_build_command_is_launcher_free(self, spec):
+        # build_command is parity-only: it never prepends accelerate/torchrun/
+        # python. Multi-GPU is driven by elastic_launch in train(), not here.
         spec.num_gpus = 4
         cmd = LerobotTrainer(device="cuda").build_command(spec)
-        assert cmd[0] == "accelerate"
-        assert "--multi_gpu" in cmd
-        assert "--num_processes=4" in cmd
-        assert "-m" in cmd and "lerobot.scripts.lerobot_train" in cmd
+        assert cmd[0] == "lerobot.scripts.lerobot_train"
+        assert "accelerate" not in cmd
+        assert "torchrun" not in cmd
+        assert "python" not in cmd
 
     def test_lora_flags(self, spec):
         spec.method = "lora"
@@ -122,6 +125,43 @@ class TestBuildCommand:
         # consumed keys must NOT leak as flags
         assert not any(c.startswith("--policy_type=") for c in cmd)
         assert not any(c.startswith("--job_name=strands_ft") for c in cmd)
+
+
+class TestBuildConfig:
+    """build_config() yields lerobot's typed TrainPipelineConfig (the real lib path)."""
+
+    def test_builds_typed_config(self, spec):
+        pytest.importorskip("lerobot")
+        cfg = LerobotTrainer(device="cpu").build_config(spec)
+        assert cfg.dataset.repo_id == "local"
+        assert cfg.dataset.root == spec.dataset_root
+        assert cfg.policy.type == "act"
+        assert cfg.policy.device == "cpu"
+        assert cfg.policy.push_to_hub is False
+        assert str(cfg.policy.pretrained_path) == "lerobot/act_aloha_sim"
+        assert cfg.steps == 200
+        assert cfg.batch_size == 8
+        assert cfg.save_freq == 100
+        assert cfg.wandb.enable is False
+        assert cfg.peft is None
+
+    def test_lora_builds_peft(self, spec):
+        pytest.importorskip("lerobot")
+        spec.method = "lora"
+        spec.lora_r = 16
+        spec.lora_target_modules = "q_proj,v_proj"
+        cfg = LerobotTrainer(device="cpu").build_config(spec)
+        assert cfg.peft is not None
+        assert cfg.peft.method_type == "LORA"
+        assert cfg.peft.r == 16
+        assert cfg.peft.target_modules == "q_proj,v_proj"
+        assert cfg.policy.use_peft is True
+
+    def test_val_split_episodes(self, spec):
+        pytest.importorskip("lerobot")
+        spec.val_episodes = 2  # total 10 -> [0..7]
+        cfg = LerobotTrainer(device="cpu").build_config(spec)
+        assert cfg.dataset.episodes == [0, 1, 2, 3, 4, 5, 6, 7]
 
 
 class TestParseLog:

--- a/tests/training/test_lerobot.py
+++ b/tests/training/test_lerobot.py
@@ -129,6 +129,7 @@ class TestParseLog:
 
     def test_expand_big_number(self):
         from strands_robots.training.lerobot import _expand_big_number
+
         assert _expand_big_number("1.2K") == 1200.0
         assert _expand_big_number("2") == 2.0
         assert _expand_big_number("3M") == 3_000_000.0

--- a/tests/training/test_lerobot.py
+++ b/tests/training/test_lerobot.py
@@ -1,0 +1,168 @@
+"""Tests for LerobotTrainer: factory wiring, validate, and command building.
+
+These are pure/offline (no GPU, no actual lerobot_train launch). The real
+end-to-end sim->train->load is exercised separately.
+"""
+
+import json
+
+import pytest
+
+from strands_robots.training import TrainSpec, create_trainer
+from strands_robots.training.lerobot import LerobotTrainer
+
+
+@pytest.fixture
+def dataset_root(tmp_path):
+    meta = tmp_path / "meta"
+    meta.mkdir()
+    (meta / "info.json").write_text(json.dumps({"total_episodes": 10}))
+    return str(tmp_path)
+
+
+@pytest.fixture
+def spec(dataset_root, tmp_path):
+    return TrainSpec(
+        dataset_root=dataset_root,
+        base_model="lerobot/act_aloha_sim",
+        output_dir=str(tmp_path / "out"),
+        steps=200,
+        global_batch_size=8,
+        save_freq=100,
+        extra={"policy_type": "act"},
+    )
+
+
+class TestFactoryWiring:
+    def test_resolves_from_registry(self):
+        t = create_trainer("lerobot_local")
+        assert isinstance(t, LerobotTrainer)
+        assert t.provider_name == "lerobot_local"
+
+    def test_alias_resolves(self):
+        # 'lerobot' is a policies.json alias of lerobot_local
+        t = create_trainer("lerobot")
+        assert isinstance(t, LerobotTrainer)
+
+
+class TestValidate:
+    def test_clean(self, spec):
+        assert LerobotTrainer().validate(spec) == []
+
+    def test_non_native_policy_type(self, spec):
+        spec.extra["policy_type"] = "openvla"
+        problems = LerobotTrainer().validate(spec)
+        assert any("not LeRobot-native" in p for p in problems)
+
+    def test_lora_expert_clash(self, spec):
+        spec.method = "lora"
+        spec.tune = {"expert_only": True}
+        problems = LerobotTrainer().validate(spec)
+        assert any("mutually exclusive" in p for p in problems)
+
+    def test_val_episodes_too_large(self, spec):
+        spec.val_episodes = 99  # total is 10
+        problems = LerobotTrainer().validate(spec)
+        assert any("val_episodes" in p for p in problems)
+
+
+class TestBuildCommand:
+    def test_single_gpu_core_flags(self, spec):
+        cmd = LerobotTrainer(device="cpu").build_command(spec)
+        joined = " ".join(cmd)
+        assert "-m lerobot.scripts.lerobot_train" in joined
+        assert "--dataset.repo_id=local" in cmd
+        assert f"--dataset.root={spec.dataset_root}" in cmd
+        assert "--policy.type=act" in cmd
+        assert "--policy.device=cpu" in cmd
+        assert "--policy.push_to_hub=false" in cmd
+        assert "--steps=200" in cmd
+        assert "--batch_size=8" in cmd
+        assert "--save_freq=100" in cmd
+        assert "--wandb.enable=false" in cmd
+        assert "--policy.pretrained_path=lerobot/act_aloha_sim" in cmd
+
+    def test_multi_gpu_uses_accelerate(self, spec):
+        spec.num_gpus = 4
+        cmd = LerobotTrainer(device="cuda").build_command(spec)
+        assert cmd[0] == "accelerate"
+        assert "--multi_gpu" in cmd
+        assert "--num_processes=4" in cmd
+        assert "-m" in cmd and "lerobot.scripts.lerobot_train" in cmd
+
+    def test_lora_flags(self, spec):
+        spec.method = "lora"
+        spec.lora_r = 16
+        spec.lora_target_modules = "q_proj,v_proj"
+        cmd = LerobotTrainer(device="cpu").build_command(spec)
+        assert "--peft.method_type=LORA" in cmd
+        assert "--peft.r=16" in cmd
+        assert "--peft.target_modules=q_proj,v_proj" in cmd
+
+    def test_expert_only_flag(self, spec):
+        spec.method = "expert_only"
+        cmd = LerobotTrainer(device="cpu").build_command(spec)
+        assert "--policy.train_expert_only=true" in cmd
+
+    def test_val_split_episodes_flag(self, spec):
+        spec.val_episodes = 2  # total 10 -> train on [0..7]
+        cmd = LerobotTrainer(device="cpu").build_command(spec)
+        ep_flags = [c for c in cmd if c.startswith("--dataset.episodes=")]
+        assert ep_flags
+        assert ep_flags[0] == "--dataset.episodes=[0, 1, 2, 3, 4, 5, 6, 7]"
+
+    def test_seed_and_jobname_and_passthrough(self, spec):
+        spec.seed = 42
+        spec.extra["job_name"] = "my_run"
+        spec.extra["num_workers"] = 4  # arbitrary passthrough
+        cmd = LerobotTrainer(device="cpu").build_command(spec)
+        assert "--seed=42" in cmd
+        assert "--job_name=my_run" in cmd
+        assert "--num_workers=4" in cmd
+        # consumed keys must NOT leak as flags
+        assert not any(c.startswith("--policy_type=") for c in cmd)
+        assert not any(c.startswith("--job_name=strands_ft") for c in cmd)
+
+
+class TestParseLog:
+    """_parse_log against lerobot's real MetricsTracker line format."""
+
+    def test_expand_big_number(self):
+        from strands_robots.training.lerobot import _expand_big_number
+        assert _expand_big_number("1.2K") == 1200.0
+        assert _expand_big_number("2") == 2.0
+        assert _expand_big_number("3M") == 3_000_000.0
+        assert _expand_big_number("1.5B") == 1.5e9
+        assert _expand_big_number("nope") is None
+        assert _expand_big_number("") is None
+
+    def test_parses_real_metricstracker_line(self, tmp_path):
+        log = tmp_path / "run.log"
+        log.write_text(
+            "INFO 2026-06-23 ot_train.py:419 Start offline training\n"
+            "step:1.2K smpl:4.9K ep:8 epch:2.00 loss:0.123\n"
+            "step:1.3K smpl:5.0K ep:9 epch:2.10 loss:0.087\n"
+        )
+        m = LerobotTrainer(device="cpu")._parse_log(str(log))
+        assert m["latest_step"] == 1300  # newest, K-expanded
+        assert abs(m["latest_loss"] - 0.087) < 1e-9
+        assert m["latest_epoch"] == 2.10
+        assert m["learning"] is True
+        assert m["liveness_ok"] is True
+
+    def test_plain_integer_step(self, tmp_path):
+        log = tmp_path / "run.log"
+        log.write_text("step:2 smpl:4 ep:1 epch:1.00 loss:0.5\n")
+        m = LerobotTrainer(device="cpu")._parse_log(str(log))
+        assert m["latest_step"] == 2
+        assert m["latest_loss"] == 0.5
+
+    def test_no_metrics_line_means_not_live(self, tmp_path):
+        log = tmp_path / "run.log"
+        log.write_text("INFO booting...\nCreating dataset\n")
+        m = LerobotTrainer(device="cpu")._parse_log(str(log))
+        assert m["liveness_ok"] is False
+        assert "latest_step" not in m
+
+    def test_unreadable_log_returns_empty(self):
+        assert LerobotTrainer(device="cpu")._parse_log("/no/such/log") == {}

--- a/tests/training/test_lerobot_e2e.py
+++ b/tests/training/test_lerobot_e2e.py
@@ -1,0 +1,78 @@
+"""End-to-end: LerobotTrainer trains a real ACT checkpoint from a recorded
+LeRobotDataset, and the result is loadable via create_policy.
+
+Slow + requires lerobot + mujoco. Skipped automatically if either is absent.
+Runs CPU-only, 2 steps - just enough to prove the record->train->load loop.
+"""
+
+import os
+
+import pytest
+
+lerobot = pytest.importorskip("lerobot")
+pytest.importorskip("mujoco")
+
+from strands_robots.training import TrainSpec, create_trainer  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def recorded_dataset(tmp_path_factory):
+    """Record a tiny dataset in MuJoCo sim (one short episode)."""
+    os.environ.setdefault("MUJOCO_GL", "cgl")
+    from strands_robots import MockPolicy, Robot
+
+    root = str(tmp_path_factory.mktemp("e2e_ds"))
+    sim = Robot("so100", mesh=False)
+    sim.add_camera(name="front", position=[0.5, 0.0, 0.4], target=[0.2, 0, 0.05])
+    start = sim.start_recording(
+        repo_id="local/e2e",
+        root=root,
+        fps=30,
+        task="pick up the red cube",
+        overwrite=True,
+    )
+    assert start["status"] == "success", start
+    sim.run_policy(
+        robot_name="so100",
+        policy_object=MockPolicy(),
+        instruction="pick up the red cube",
+        n_steps=20,
+    )
+    stop = sim.stop_recording()
+    assert stop["status"] == "success", stop
+    assert os.path.isfile(os.path.join(root, "meta", "info.json"))
+    return root
+
+
+@pytest.mark.slow
+def test_record_train_load_loop(recorded_dataset, tmp_path):
+    out = str(tmp_path / "e2e_out")
+    trainer = create_trainer("lerobot_local", device="cpu")
+
+    spec = TrainSpec(
+        dataset_root=recorded_dataset,
+        base_model="",  # ACT from scratch - smallest CPU path
+        output_dir=out,
+        steps=2,
+        save_freq=2,
+        global_batch_size=2,
+        extra={"policy_type": "act", "num_workers": 0},
+    )
+
+    assert trainer.validate(spec) == []
+
+    result = trainer.train(spec)
+    assert result.status == "success", result.message
+    assert result.checkpoint_dir and os.path.isdir(result.checkpoint_dir)
+    assert os.path.isfile(os.path.join(result.checkpoint_dir, "model.safetensors"))
+
+    # export() returns a create_policy-loadable path (default passthrough).
+    exported = trainer.export(spec, result.checkpoint_dir)
+    assert os.path.isdir(exported)
+
+    # The trained checkpoint loads back as a Policy - loop closed.
+    os.environ.setdefault("STRANDS_TRUST_REMOTE_CODE", "1")
+    from strands_robots import create_policy
+
+    policy = create_policy(exported, device="cpu")
+    assert policy.provider_name == "lerobot_local"

--- a/tests/training/test_native_parity.py
+++ b/tests/training/test_native_parity.py
@@ -1,0 +1,105 @@
+"""Native-pipeline argv parity tests (run only where the real checkouts exist).
+
+These assert that every ``--flag`` our trainers emit in ``build_command`` is a
+flag the *real* native pipeline actually accepts -- catching drift between our
+wrapper and Isaac-GR00T / cosmos-framework without launching a full finetune.
+
+Skipped automatically unless GR00T_ROOT / COSMOS_ROOT point at real checkouts
+(set by CI on a GPU box; absent on laptops -> skipped, never failing).
+"""
+
+import ast
+import os
+import re
+
+import pytest
+
+from strands_robots.training import TrainSpec, create_trainer
+
+GR00T_ROOT = os.environ.get("GR00T_ROOT")
+COSMOS_ROOT = os.environ.get("COSMOS_ROOT")
+
+
+def _flag_names(cmd):
+    """Extract the set of --flag names (without =value) from an argv list."""
+    names = set()
+    for tok in cmd:
+        m = re.match(r"^--([a-zA-Z0-9_\-]+)=", tok)
+        if m:
+            names.add(m.group(1))
+        elif tok.startswith("--"):
+            names.add(tok[2:])
+    return names
+
+
+@pytest.mark.skipif(
+    not (GR00T_ROOT and os.path.isfile(os.path.join(GR00T_ROOT, "gr00t", "configs", "finetune_config.py"))),
+    reason="GR00T_ROOT not set to a real Isaac-GR00T checkout",
+)
+def test_groot_flags_match_real_finetune_config():
+    """Every --flag we emit must be a real FinetuneConfig dataclass field."""
+    cfg_path = os.path.join(GR00T_ROOT, "gr00t", "configs", "finetune_config.py")
+    with open(cfg_path) as f:
+        src = f.read()
+    tree = ast.parse(src)
+    fields = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "FinetuneConfig":
+            for stmt in node.body:
+                if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+                    fields.add(stmt.target.id)
+    assert fields, "could not parse FinetuneConfig fields"
+
+    spec = TrainSpec(
+        dataset_root="/tmp/ds",
+        base_model="nvidia/GR00T-N1.5-3B",
+        output_dir="/tmp/out",
+        embodiment="GR1",
+        steps=500,
+        save_freq=250,
+        global_batch_size=8,
+        learning_rate=1e-4,
+        extra={"groot_root": GR00T_ROOT},
+    )
+    cmd = create_trainer("groot").build_command(spec)
+    emitted = _flag_names(cmd)
+    # Drop the torchrun/launcher meta-flags that aren't FinetuneConfig fields.
+    emitted -= {"nproc_per_node", "master_port"}
+    unknown = emitted - fields
+    assert not unknown, f"flags not in real FinetuneConfig: {sorted(unknown)}"
+
+
+@pytest.mark.skipif(
+    not (COSMOS_ROOT and os.path.isfile(os.path.join(COSMOS_ROOT, "cosmos_framework", "scripts", "train.py"))),
+    reason="COSMOS_ROOT not set to a real cosmos-framework checkout",
+)
+def test_cosmos_train_accepts_sft_toml():
+    """The real cosmos train.py must accept --sft-toml (our sole driver flag)."""
+    train_py = os.path.join(COSMOS_ROOT, "cosmos_framework", "scripts", "train.py")
+    with open(train_py) as f:
+        src = f.read()
+    assert '"--sft-toml"' in src or "'--sft-toml'" in src, "real cosmos train.py no longer accepts --sft-toml"
+
+    spec = TrainSpec(
+        dataset_root="/tmp/ds",
+        base_model="nvidia/Cosmos3",
+        output_dir="/tmp/out",
+        steps=10,
+        save_freq=5,
+        global_batch_size=1,
+        extra={"cosmos_root": COSMOS_ROOT, "sft_toml": train_py},  # any real file
+    )
+    cmd = create_trainer("cosmos3").build_command(spec)
+    assert any(t.startswith("--sft-toml=") for t in cmd), cmd
+    assert "cosmos_framework.scripts.train" in cmd
+
+
+@pytest.mark.skipif(
+    not (COSMOS_ROOT and os.path.isdir(os.path.join(COSMOS_ROOT, "cosmos_framework", "scripts"))),
+    reason="COSMOS_ROOT not set to a real cosmos-framework checkout",
+)
+def test_cosmos_convert_and_export_scripts_exist():
+    """prepare()/export() target real cosmos scripts that still exist."""
+    scripts = os.path.join(COSMOS_ROOT, "cosmos_framework", "scripts")
+    assert os.path.isfile(os.path.join(scripts, "convert_model_to_dcp.py"))
+    assert os.path.isfile(os.path.join(scripts, "export_model.py"))

--- a/tests/training/test_tool.py
+++ b/tests/training/test_tool.py
@@ -101,12 +101,19 @@ class TestActions:
         # it. It now uses the public latest_checkpoint() ABC method.
         out = str(tmp_path / "out")
         train_policy(
-            action="train", provider="mock", dataset_root=dataset_root,
-            base_model="mock/base", output_dir=out, steps=10,
+            action="train",
+            provider="mock",
+            dataset_root=dataset_root,
+            base_model="mock/base",
+            output_dir=out,
+            steps=10,
         )
         res = train_policy(
-            action="export", provider="mock", dataset_root=dataset_root,
-            base_model="mock/base", output_dir=out,
+            action="export",
+            provider="mock",
+            dataset_root=dataset_root,
+            base_model="mock/base",
+            output_dir=out,
         )
         assert res["status"] == "success", _text(res)
         assert _json(res)["exported_model"]
@@ -114,8 +121,11 @@ class TestActions:
 
     def test_export_without_checkpoint_errors(self, dataset_root, tmp_path):
         res = train_policy(
-            action="export", provider="mock", dataset_root=dataset_root,
-            base_model="mock/base", output_dir=str(tmp_path / "never"),
+            action="export",
+            provider="mock",
+            dataset_root=dataset_root,
+            base_model="mock/base",
+            output_dir=str(tmp_path / "never"),
         )
         assert res["status"] == "error"
         assert "no checkpoint" in _text(res)

--- a/tests/training/test_tool.py
+++ b/tests/training/test_tool.py
@@ -36,18 +36,24 @@ class TestActions:
 
     def test_validate_clean(self, dataset_root, tmp_path):
         res = train_policy(
-            action="validate", provider="mock",
-            dataset_root=dataset_root, base_model="m",
-            output_dir=str(tmp_path / "o"), steps=10,
+            action="validate",
+            provider="mock",
+            dataset_root=dataset_root,
+            base_model="m",
+            output_dir=str(tmp_path / "o"),
+            steps=10,
         )
         assert res["status"] == "success"
         assert "valid and launchable" in _text(res)
 
     def test_validate_reports_problems(self, tmp_path):
         res = train_policy(
-            action="validate", provider="mock",
-            dataset_root=str(tmp_path / "nope"), base_model="m",
-            output_dir=str(tmp_path / "o"), steps=0,
+            action="validate",
+            provider="mock",
+            dataset_root=str(tmp_path / "nope"),
+            base_model="m",
+            output_dir=str(tmp_path / "o"),
+            steps=0,
         )
         assert res["status"] == "error"
         assert "validation problems" in _text(res)
@@ -60,9 +66,12 @@ class TestActions:
     def test_train_mock_full_loop(self, dataset_root, tmp_path):
         out = str(tmp_path / "out")
         res = train_policy(
-            action="train", provider="mock",
-            dataset_root=dataset_root, base_model="mock/base",
-            output_dir=out, steps=50,
+            action="train",
+            provider="mock",
+            dataset_root=dataset_root,
+            base_model="mock/base",
+            output_dir=out,
+            steps=50,
         )
         assert res["status"] == "success", _text(res)
         assert res["job_id"]
@@ -82,8 +91,10 @@ class TestActions:
 
     def test_unknown_action(self, dataset_root, tmp_path):
         res = train_policy(
-            action="frobnicate", provider="mock",
-            dataset_root=dataset_root, base_model="m",
+            action="frobnicate",
+            provider="mock",
+            dataset_root=dataset_root,
+            base_model="m",
             output_dir=str(tmp_path / "o"),
         )
         assert res["status"] == "error"
@@ -94,9 +105,12 @@ class TestProviderRouting:
     def test_lerobot_validate_routes_to_lerobot(self, dataset_root, tmp_path):
         # non-native policy_type -> lerobot-specific validation message
         res = train_policy(
-            action="validate", provider="lerobot_local",
-            dataset_root=dataset_root, base_model="",
-            output_dir=str(tmp_path / "o"), steps=10,
+            action="validate",
+            provider="lerobot_local",
+            dataset_root=dataset_root,
+            base_model="",
+            output_dir=str(tmp_path / "o"),
+            steps=10,
             extra={"policy_type": "openvla"},
         )
         assert res["status"] == "error"
@@ -104,9 +118,12 @@ class TestProviderRouting:
 
     def test_groot_requires_embodiment(self, dataset_root, tmp_path):
         res = train_policy(
-            action="validate", provider="groot",
-            dataset_root=dataset_root, base_model="nvidia/GR00T-N1.5-3B",
-            output_dir=str(tmp_path / "o"), steps=10,
+            action="validate",
+            provider="groot",
+            dataset_root=dataset_root,
+            base_model="nvidia/GR00T-N1.5-3B",
+            output_dir=str(tmp_path / "o"),
+            steps=10,
             extra={"groot_root": "/tmp"},  # missing launch script -> also errors, but embodiment first
         )
         assert res["status"] == "error"
@@ -125,9 +142,12 @@ class TestInputSafety:
 
     def test_extra_flag_key_rejected(self, dataset_root, tmp_path):
         res = train_policy(
-            action="validate", provider="mock",
-            dataset_root=dataset_root, base_model="m",
-            output_dir=str(tmp_path / "o"), steps=10,
+            action="validate",
+            provider="mock",
+            dataset_root=dataset_root,
+            base_model="m",
+            output_dir=str(tmp_path / "o"),
+            steps=10,
             extra={"--evil-flag": "x"},
         )
         assert res["status"] == "error"
@@ -135,27 +155,36 @@ class TestInputSafety:
 
     def test_base_model_leading_dash_rejected(self, dataset_root, tmp_path):
         res = train_policy(
-            action="validate", provider="mock",
-            dataset_root=dataset_root, base_model="--config_path=/etc/passwd",
-            output_dir=str(tmp_path / "o"), steps=10,
+            action="validate",
+            provider="mock",
+            dataset_root=dataset_root,
+            base_model="--config_path=/etc/passwd",
+            output_dir=str(tmp_path / "o"),
+            steps=10,
         )
         assert res["status"] == "error"
         assert "must not start with '-'" in _text(res)
 
     def test_output_dir_protected_path_rejected(self, dataset_root):
         res = train_policy(
-            action="validate", provider="mock",
-            dataset_root=dataset_root, base_model="m",
-            output_dir="/etc/cron.d/evil", steps=10,
+            action="validate",
+            provider="mock",
+            dataset_root=dataset_root,
+            base_model="m",
+            output_dir="/etc/cron.d/evil",
+            steps=10,
         )
         assert res["status"] == "error"
         assert "protected system directory" in _text(res)
 
     def test_dataset_root_traversal_rejected(self, tmp_path):
         res = train_policy(
-            action="validate", provider="mock",
-            dataset_root="../../etc", base_model="m",
-            output_dir=str(tmp_path / "o"), steps=10,
+            action="validate",
+            provider="mock",
+            dataset_root="../../etc",
+            base_model="m",
+            output_dir=str(tmp_path / "o"),
+            steps=10,
         )
         assert res["status"] == "error"
         assert "path traversal" in _text(res)
@@ -163,9 +192,12 @@ class TestInputSafety:
     def test_legitimate_dotted_extra_key_allowed(self, dataset_root, tmp_path):
         # lerobot dotted flags / cosmos hydra paths must still pass the allowlist.
         res = train_policy(
-            action="validate", provider="mock",
-            dataset_root=dataset_root, base_model="m",
-            output_dir=str(tmp_path / "o"), steps=10,
+            action="validate",
+            provider="mock",
+            dataset_root=dataset_root,
+            base_model="m",
+            output_dir=str(tmp_path / "o"),
+            steps=10,
             extra={"dataset.episodes": "1", "num_workers": "4"},
         )
         assert res["status"] == "success", _text(res)

--- a/tests/training/test_tool.py
+++ b/tests/training/test_tool.py
@@ -95,6 +95,31 @@ class TestActions:
         # the result dict must NOT be extended beyond {status, content}
         assert set(res.keys()) == {"status", "content"}
 
+    def test_export_after_train_succeeds(self, dataset_root, tmp_path):
+        # Regression: export action used to reach a private _latest_checkpoint
+        # via getattr and silently fail for providers (mock/cosmos) that lacked
+        # it. It now uses the public latest_checkpoint() ABC method.
+        out = str(tmp_path / "out")
+        train_policy(
+            action="train", provider="mock", dataset_root=dataset_root,
+            base_model="mock/base", output_dir=out, steps=10,
+        )
+        res = train_policy(
+            action="export", provider="mock", dataset_root=dataset_root,
+            base_model="mock/base", output_dir=out,
+        )
+        assert res["status"] == "success", _text(res)
+        assert _json(res)["exported_model"]
+        assert set(res.keys()) == {"status", "content"}
+
+    def test_export_without_checkpoint_errors(self, dataset_root, tmp_path):
+        res = train_policy(
+            action="export", provider="mock", dataset_root=dataset_root,
+            base_model="mock/base", output_dir=str(tmp_path / "never"),
+        )
+        assert res["status"] == "error"
+        assert "no checkpoint" in _text(res)
+
     def test_status_requires_job_id(self):
         res = train_policy(action="status", provider="mock")
         assert res["status"] == "error"

--- a/tests/training/test_tool.py
+++ b/tests/training/test_tool.py
@@ -1,0 +1,171 @@
+"""Tests for the train_policy agent tool (Strands @tool wrapper)."""
+
+import importlib
+import json
+
+import pytest
+
+# ``from strands_robots.tools import train_policy`` resolves via the package's
+# lazy __getattr__ (tools/__init__.py) to the *tool object* (a
+# DecoratedFunctionTool), which CodeQL's points-to treats as a non-callable
+# class instance, flagging every ``train_policy(...)`` call. import_module
+# returns the module and we bind the callable via attribute access -- the same
+# idiom used by tests/tools/test_gr00t_container_hardening.py.
+_tp = importlib.import_module("strands_robots.tools.train_policy")
+train_policy = _tp.train_policy
+
+
+def _text(res):
+    return res["content"][0]["text"]
+
+
+@pytest.fixture
+def dataset_root(tmp_path):
+    meta = tmp_path / "meta"
+    meta.mkdir()
+    (meta / "info.json").write_text(json.dumps({"total_episodes": 5}))
+    return str(tmp_path)
+
+
+class TestActions:
+    def test_list(self):
+        res = train_policy(action="list")
+        assert res["status"] == "success"
+        for p in ("mock", "lerobot_local", "groot", "cosmos3"):
+            assert p in _text(res)
+
+    def test_validate_clean(self, dataset_root, tmp_path):
+        res = train_policy(
+            action="validate", provider="mock",
+            dataset_root=dataset_root, base_model="m",
+            output_dir=str(tmp_path / "o"), steps=10,
+        )
+        assert res["status"] == "success"
+        assert "valid and launchable" in _text(res)
+
+    def test_validate_reports_problems(self, tmp_path):
+        res = train_policy(
+            action="validate", provider="mock",
+            dataset_root=str(tmp_path / "nope"), base_model="m",
+            output_dir=str(tmp_path / "o"), steps=0,
+        )
+        assert res["status"] == "error"
+        assert "validation problems" in _text(res)
+
+    def test_missing_required_args(self):
+        res = train_policy(action="train", provider="mock")
+        assert res["status"] == "error"
+        assert "required" in _text(res)
+
+    def test_train_mock_full_loop(self, dataset_root, tmp_path):
+        out = str(tmp_path / "out")
+        res = train_policy(
+            action="train", provider="mock",
+            dataset_root=dataset_root, base_model="mock/base",
+            output_dir=out, steps=50,
+        )
+        assert res["status"] == "success", _text(res)
+        assert res["job_id"]
+        assert res["checkpoint_dir"]
+        assert res["metrics"]["learning"] is True
+        assert "create_policy(" in _text(res)
+
+    def test_status_requires_job_id(self):
+        res = train_policy(action="status", provider="mock")
+        assert res["status"] == "error"
+        assert "job_id" in _text(res)
+
+    def test_status_verdict(self):
+        res = train_policy(action="status", provider="mock", job_id="mock-123")
+        assert res["status"] == "success"
+        assert res["metrics"]["learning"] is True
+
+    def test_unknown_action(self, dataset_root, tmp_path):
+        res = train_policy(
+            action="frobnicate", provider="mock",
+            dataset_root=dataset_root, base_model="m",
+            output_dir=str(tmp_path / "o"),
+        )
+        assert res["status"] == "error"
+        assert "Unknown action" in _text(res)
+
+
+class TestProviderRouting:
+    def test_lerobot_validate_routes_to_lerobot(self, dataset_root, tmp_path):
+        # non-native policy_type -> lerobot-specific validation message
+        res = train_policy(
+            action="validate", provider="lerobot_local",
+            dataset_root=dataset_root, base_model="",
+            output_dir=str(tmp_path / "o"), steps=10,
+            extra={"policy_type": "openvla"},
+        )
+        assert res["status"] == "error"
+        assert "not LeRobot-native" in _text(res)
+
+    def test_groot_requires_embodiment(self, dataset_root, tmp_path):
+        res = train_policy(
+            action="validate", provider="groot",
+            dataset_root=dataset_root, base_model="nvidia/GR00T-N1.5-3B",
+            output_dir=str(tmp_path / "o"), steps=10,
+            extra={"groot_root": "/tmp"},  # missing launch script -> also errors, but embodiment first
+        )
+        assert res["status"] == "error"
+        assert "embodiment is required" in _text(res)
+
+
+class TestInputSafety:
+    """Pin: agent-supplied values cannot smuggle subprocess flags or escape paths.
+
+    ``train_policy`` is an agent ``@tool``; every value reaches a trainer's
+    ``build_command`` -> ``subprocess.run`` argv. ``validate()`` /
+    ``_security_problems`` must reject the injection vectors up front (AGENTS.md
+    Review Learnings #92, "LLM Input Safety"). These fail on pre-fix code where
+    the ``extra`` keys and path fields were interpolated raw.
+    """
+
+    def test_extra_flag_key_rejected(self, dataset_root, tmp_path):
+        res = train_policy(
+            action="validate", provider="mock",
+            dataset_root=dataset_root, base_model="m",
+            output_dir=str(tmp_path / "o"), steps=10,
+            extra={"--evil-flag": "x"},
+        )
+        assert res["status"] == "error"
+        assert "not allowed" in _text(res)
+
+    def test_base_model_leading_dash_rejected(self, dataset_root, tmp_path):
+        res = train_policy(
+            action="validate", provider="mock",
+            dataset_root=dataset_root, base_model="--config_path=/etc/passwd",
+            output_dir=str(tmp_path / "o"), steps=10,
+        )
+        assert res["status"] == "error"
+        assert "must not start with '-'" in _text(res)
+
+    def test_output_dir_protected_path_rejected(self, dataset_root):
+        res = train_policy(
+            action="validate", provider="mock",
+            dataset_root=dataset_root, base_model="m",
+            output_dir="/etc/cron.d/evil", steps=10,
+        )
+        assert res["status"] == "error"
+        assert "protected system directory" in _text(res)
+
+    def test_dataset_root_traversal_rejected(self, tmp_path):
+        res = train_policy(
+            action="validate", provider="mock",
+            dataset_root="../../etc", base_model="m",
+            output_dir=str(tmp_path / "o"), steps=10,
+        )
+        assert res["status"] == "error"
+        assert "path traversal" in _text(res)
+
+    def test_legitimate_dotted_extra_key_allowed(self, dataset_root, tmp_path):
+        # lerobot dotted flags / cosmos hydra paths must still pass the allowlist.
+        res = train_policy(
+            action="validate", provider="mock",
+            dataset_root=dataset_root, base_model="m",
+            output_dir=str(tmp_path / "o"), steps=10,
+            extra={"dataset.episodes": "1", "num_workers": "4"},
+        )
+        assert res["status"] == "success", _text(res)

--- a/tests/training/test_tool.py
+++ b/tests/training/test_tool.py
@@ -19,6 +19,19 @@ def _text(res):
     return res["content"][0]["text"]
 
 
+def _json(res):
+    """Extract the structured ``{"json": ...}`` content block.
+
+    The tool returns the canonical ``{status, content:[...]}`` only — structured
+    fields (job_id / checkpoint_dir / metrics / exported_model) live in a json
+    content block, NOT as sibling keys of the result dict.
+    """
+    for block in res["content"]:
+        if "json" in block:
+            return block["json"]
+    raise AssertionError(f"no json content block in result: {res}")
+
+
 @pytest.fixture
 def dataset_root(tmp_path):
     meta = tmp_path / "meta"
@@ -74,10 +87,13 @@ class TestActions:
             steps=50,
         )
         assert res["status"] == "success", _text(res)
-        assert res["job_id"]
-        assert res["checkpoint_dir"]
-        assert res["metrics"]["learning"] is True
+        data = _json(res)
+        assert data["job_id"]
+        assert data["checkpoint_dir"]
+        assert data["metrics"]["learning"] is True
         assert "create_policy(" in _text(res)
+        # the result dict must NOT be extended beyond {status, content}
+        assert set(res.keys()) == {"status", "content"}
 
     def test_status_requires_job_id(self):
         res = train_policy(action="status", provider="mock")
@@ -87,7 +103,8 @@ class TestActions:
     def test_status_verdict(self):
         res = train_policy(action="status", provider="mock", job_id="mock-123")
         assert res["status"] == "success"
-        assert res["metrics"]["learning"] is True
+        assert _json(res)["metrics"]["learning"] is True
+        assert set(res.keys()) == {"status", "content"}
 
     def test_unknown_action(self, dataset_root, tmp_path):
         res = train_policy(

--- a/tests/training/test_tool.py
+++ b/tests/training/test_tool.py
@@ -186,11 +186,39 @@ class TestInputSafety:
     """Pin: agent-supplied values cannot smuggle subprocess flags or escape paths.
 
     ``train_policy`` is an agent ``@tool``; every value reaches a trainer's
-    ``build_command`` -> ``subprocess.run`` argv. ``validate()`` /
-    ``_security_problems`` must reject the injection vectors up front (AGENTS.md
-    Review Learnings #92, "LLM Input Safety"). These fail on pre-fix code where
-    the ``extra`` keys and path fields were interpolated raw.
+    native config / argv-parity helper (training runs in-process now, not via
+    subprocess). ``validate()`` / ``_security_problems`` must reject the
+    injection vectors up front (AGENTS.md Review Learnings #92, "LLM Input
+    Safety") for EVERY spec-consuming action, including export.
     """
+
+    def test_export_rejects_unsafe_extra_key(self, dataset_root, tmp_path):
+        # Regression: the export action must gate on validate() before calling
+        # trainer.export(spec, ...) - it consumes the same agent-supplied spec.
+        res = train_policy(
+            action="export",
+            provider="mock",
+            dataset_root=dataset_root,
+            base_model="m",
+            output_dir=str(tmp_path / "o"),
+            steps=10,
+            extra={"--evil-flag": "x"},
+        )
+        assert res["status"] == "error"
+        assert "not allowed" in _text(res)
+
+    def test_export_rejects_output_dir_traversal(self, dataset_root):
+        res = train_policy(
+            action="export",
+            provider="mock",
+            dataset_root=dataset_root,
+            base_model="m",
+            output_dir="../../etc/evil",
+            steps=10,
+        )
+        assert res["status"] == "error"
+        # path traversal / protected-dir check fires before any export work.
+        assert "validation problems" in _text(res)
 
     def test_extra_flag_key_rejected(self, dataset_root, tmp_path):
         res = train_policy(


### PR DESCRIPTION
## What

Adds a `Trainer` abstraction — the **training-side peer of `Policy`** — that post-tunes a policy through one provider-agnostic interface and produces a checkpoint that loads straight back via `create_policy`. The same provider name selects both the trainer and the inference policy, so the **record → train → export → deploy** loop closes with a single string swap.

```python
from strands_robots.training import create_trainer, TrainSpec

trainer = create_trainer("lerobot_local")        # same name as create_policy(...)
spec = TrainSpec(dataset_root="/tmp/ds", base_model="lerobot/smolvla_base",
                 output_dir="/tmp/ft", steps=20000, extra={"policy_type": "smolvla"})
result = trainer.train(spec)
policy = create_policy(result.checkpoint_dir)     # loop closed
```

One interface wraps three genuinely different upstream pipelines, each driven **as a native Python library, in-process** (no `subprocess`, no `torchrun` binary, no `python_executable`, no argv):

| Provider | Native pipeline driven (library call) |
|---|---|
| `lerobot_local` | `lerobot.scripts.lerobot_train.train(cfg)` with a typed `TrainPipelineConfig` |
| `groot` | `gr00t.experiment.experiment.run(config)` (real `FinetuneConfig` → `Config`) |
| `cosmos3` | `convert_model_to_dcp(Args)` → `train.launch(config, args)` → `export_model(Args)` |
| `mock` | in-proc, dep-free (for tests) |

Multi-GPU single-node uses `torch.distributed.launcher.api.elastic_launch` (the programmatic engine behind `torchrun`) calling a Python worker callable. A new `training/_inproc.py` holds the shared in-process + elastic-launch primitives. Replaces the old `tools/lerobot_train.py` with the provider-agnostic `tools/train_policy.py` agent tool (`train`/`validate`/`status`/`export`/`list`).

## Interface correctness (from code review)

- **`latest_checkpoint()` is a public ABC method** (default `None`), implemented by all four backends — the `export` action uses it instead of duck-typing a private `_latest_checkpoint` (which silently failed for cosmos3/mock). lerobot splits the loadable-dir (`latest_checkpoint`) from the resume-config-file (`_resume_config_path`).
- **`num_nodes > 1` rejected** in both lerobot and GR00T `validate()` (single-node in-process trainers); cosmos3 honors it via HSDP.
- **synchronous `train()` contract**: `train()` blocks and returns the full metrics verdict, so the docstrings + default `status()` are honest about there being no detached job to poll.
- **`train_policy` tool result is strictly `{status, content:[...]}`** — structured fields (`job_id`/`checkpoint_dir`/`metrics`/`exported_model`) live in a `{"json": ...}` content block, never as sibling keys.

## Input safety

`training/_validate.py::validate_train_inputs(spec)` rejects path traversal / protected dirs (audited `validate_save_path`), a leading `-` on flag-bound scalars, and `extra` keys outside `^[a-z][a-z0-9_.]*$`. `Trainer._security_problems()` on the ABC is the single source; every backend's `validate()` opens with it and `train()` fails closed before building any config. Path-typed `extra` VALUES that reach a backend write path (`export_dir` → `export()`, `dcp_path` → `prepare()`, both `os.makedirs` targets) are additionally run through `validate_save_path`; read-only path extras are excluded since the protected-dir block is a write guard.

## Verified

- Native-symbol parity validated against the **real upstream source** of all three (lerobot local checkout, `github.com/NVIDIA/Isaac-GR00T`, `github.com/NVIDIA/cosmos-framework`): every `FinetuneConfig` field, cosmos `Args`/`CheckpointOverrides`, and `train.launch` arg the trainers touch exists upstream.
- `tests/training/`: full suite green incl. the slow lerobot `record→train→load` MuJoCo E2E + 3 native-parity tests (skip cleanly without `GR00T_ROOT`/`COSMOS_ROOT`).
- **`hatch run lint` clean**: `ruff check` + `ruff format --check` + `mypy` all pass on `strands_robots tests tests_integ` (437 files).

## Test plan

```bash
hatch run lint                                  # ruff + mypy
hatch run test                                  # unit (parity auto-skips)
export GR00T_ROOT=... COSMOS_ROOT=...
MUJOCO_GL=egl pytest tests/training/ -m slow    # record->train->load E2E
```

## §13 Review changelog

**Round 2** — input-safety hardening of write-target `extra` values
- The `extra`-key allowlist guarded only the key FORMAT (`^[a-z][a-z0-9_.]*$`), not the path VALUE. An agent-supplied `extra["export_dir"]` / `extra["dcp_path"]` therefore reached `os.makedirs` in the cosmos `export()` / `prepare()` write paths with the protected-dir and `..`-traversal guard turned off.
- Added `_PATH_VALUE_EXTRA_KEYS = ("export_dir", "dcp_path")` and run the audited `validate_save_path` on those values in the centralized `validate_train_inputs`, matching the existing `_PATH_FIELDS` guard. Read-only path extras (`cosmos_root`/`groot_root`/`sft_toml`/`modality_config_path`) stay excluded because the protected-dir block is a write guard and would reject legitimate reads.
- Pinned regression tests in `tests/training/test_cosmos3.py::TestValidate`: protected-dir rejection for both keys (`/etc/cron.d`, `/var/spool/cron`, `/usr/lib`, `/etc`), `..`-traversal rejection, and a happy-path assertion that legitimate temp dirs validate clean.

**Round 1** — `export` action now gates on `validate()` before `latest_checkpoint()`/`export()`, matching the `train` branch; `train_policy` registered in the lazy-import test.