### PR TITLE
feat(simulation): support entry-point-based backend discovery (closes #131)

### DIFF
--- a/README.md
+++ b/README.md
@@ -785,6 +785,26 @@ for action Y. Valid: [...]"*, missing required params produce *"Action X
 requires parameter Y."*, and vectors/dtypes are validated before MuJoCo sees
 them - so the agent learns the contract without crashing the process.
 
+**Third-party backends.** `create_simulation(name)` discovers backends beyond
+the built-in `mujoco`/`newton` registry via Python
+[entry points](https://packaging.python.org/en/latest/specifications/entry-points/).
+A sibling package - e.g. [`strands-robots-sim`](https://github.com/strands-labs/robots-sim),
+which ships the heavy Isaac Sim and Newton backends out-of-tree - registers its
+`SimEngine` subclasses under the `strands_robots.backends` group in its
+`pyproject.toml`, and they become available on `pip install` without patching
+this package:
+
+```toml
+[project.entry-points."strands_robots.backends"]
+isaac = "strands_robots_sim.isaac.simulation:IsaacSimulation"
+newton = "strands_robots_sim.newton.simulation:NewtonSimulation"
+warp = "strands_robots_sim.newton.simulation:NewtonSimulation"
+```
+
+Built-in backends always take precedence over plugins of the same name, plugin
+discovery is lazy (it never slows cold import), and `list_backends()` returns
+the merged builtin + plugin set.
+
 ## Mesh networking
 
 <p align="center">

--- a/strands_robots/simulation/factory.py
+++ b/strands_robots/simulation/factory.py
@@ -21,6 +21,9 @@ Usage::
     from strands_robots.simulation.factory import register_backend
     register_backend("my_sim", lambda: MySimBackend, aliases=["custom"])
     sim = create_simulation("custom")
+
+Third-party packages may also register backends out-of-tree via the
+``strands_robots.backends`` entry-point group (see ``create_simulation``).
 """
 
 from __future__ import annotations
@@ -28,11 +31,16 @@ from __future__ import annotations
 import importlib
 import logging
 from collections.abc import Callable
+from importlib.metadata import entry_points
 from typing import Any
 
 from strands_robots.simulation.base import SimEngine
 
 logger = logging.getLogger(__name__)
+
+# Entry-point group third-party packages declare to register simulation
+# backends without patching this module. See ``_load_plugin_backends``.
+_ENTRY_POINT_GROUP = "strands_robots.backends"
 
 # Built-in backend registry (lazy loaders - no imports at module load)
 
@@ -61,10 +69,56 @@ _BUILTIN_ALIASES: dict[str, str] = {
 
 DEFAULT_BACKEND = "mujoco"
 
+# Suggested ``pip install`` hints surfaced in the "unknown backend" error so
+# users discover that heavy out-of-tree backends ship in the sibling
+# ``strands-robots-sim`` plugin package. Keyed by the entry-point name a
+# plugin is expected to register.
+_PLUGIN_INSTALL_HINTS: dict[str, str] = {
+    "isaac": "pip install 'strands-robots-sim[isaac]'",
+    "newton": "pip install 'strands-robots-sim[newton]'",
+    "warp": "pip install 'strands-robots-sim[newton]'",
+}
+
+# Plugin backends discovered via importlib.metadata entry points. Populated
+# lazily on the first ``create_simulation`` / ``list_backends`` call (NOT at
+# import time) so installing a plugin never slows cold ``import
+# strands_robots.simulation``. ``None`` means "not yet discovered".
+_PLUGIN_BACKENDS_CACHE: dict[str, type[SimEngine]] | None = None
+
 # Runtime registration (for user-defined backends not in built-ins)
 
 _runtime_registry: dict[str, Callable[[], type[SimEngine]]] = {}
 _runtime_aliases: dict[str, str] = {}
+
+
+def _load_plugin_backends() -> dict[str, type[SimEngine]]:
+    """Discover third-party backends registered via entry points.
+
+    Walks the ``strands_robots.backends`` entry-point group and loads each
+    advertised class. Results are cached after the first call so the
+    ``importlib.metadata`` scan and the plugin module imports happen at most
+    once per process (one-time lazy cache - no hot-reload after install).
+
+    A plugin that fails to import (missing heavy dependency, broken install)
+    is logged and skipped rather than crashing the factory, so a single bad
+    plugin can't take down ``create_simulation`` for the working backends.
+
+    Returns:
+        Mapping of entry-point name -> backend class. Aliases are expressed
+        as multiple entry-point names pointing at the same class (e.g.
+        ``newton`` and ``warp`` both resolve to ``NewtonSimulation``); no
+        dedup is applied so whichever requested name resolves cleanly.
+    """
+    global _PLUGIN_BACKENDS_CACHE
+    if _PLUGIN_BACKENDS_CACHE is None:
+        cache: dict[str, type[SimEngine]] = {}
+        for ep in entry_points(group=_ENTRY_POINT_GROUP):
+            try:
+                cache[ep.name] = ep.load()
+            except Exception as exc:  # noqa: BLE001 - one bad plugin must not break the factory
+                logger.warning("Failed to load simulation backend plugin %r: %s", ep.name, exc)
+        _PLUGIN_BACKENDS_CACHE = cache
+    return _PLUGIN_BACKENDS_CACHE
 
 
 def register_backend(
@@ -131,7 +185,13 @@ def register_backend(
 
 
 def list_backends() -> list[str]:
-    """List all available backend names (built-in + runtime-registered).
+    """List all available backend names (built-in + plugin + runtime).
+
+    Merges the built-in registry (and its aliases), entry-point plugin
+    backends discovered via ``importlib.metadata`` (see
+    ``create_simulation``), and any runtime-registered backends/aliases.
+    Discovering plugins triggers a one-time lazy scan of the
+    ``strands_robots.backends`` entry-point group.
 
     Returns:
         Sorted list of unique backend identifiers and aliases.
@@ -144,6 +204,7 @@ def list_backends() -> list[str]:
     names: set[str] = set()
     names.update(_BUILTIN_BACKENDS.keys())
     names.update(_BUILTIN_ALIASES.keys())
+    names.update(_load_plugin_backends().keys())
     names.update(_runtime_registry.keys())
     names.update(_runtime_aliases.keys())
     return sorted(names)
@@ -190,7 +251,19 @@ def _import_backend_class(name: str) -> type[SimEngine]:
         logger.debug("Loaded built-in backend: %s → %s.%s", name, module_path, class_name)
         return backend_cls
 
-    raise ValueError(f"Unknown simulation backend: {name!r}. Available: {', '.join(list_backends())}")
+    # 3. Entry-point plugins (third-party packages, e.g. strands-robots-sim).
+    #    Built-ins win over plugins of the same name (checked above), so a
+    #    conflicting plugin can never shadow "mujoco".
+    plugins = _load_plugin_backends()
+    if name in plugins:
+        plugin_cls = plugins[name]
+        logger.debug("Loaded plugin backend: %s → %s", name, plugin_cls.__name__)
+        return plugin_cls
+
+    available = ", ".join(list_backends())
+    hint = _PLUGIN_INSTALL_HINTS.get(name)
+    suffix = f" To install it: {hint}." if hint else ""
+    raise ValueError(f"Unknown simulation backend: {name!r}. Available: {available}.{suffix}")
 
 
 def create_simulation(
@@ -202,9 +275,36 @@ def create_simulation(
     This is the primary entry point for creating simulations.
     Backend classes are lazy-loaded on first call.
 
+    Resolution order for ``backend``:
+
+    1. Runtime-registered backends (see ``register_backend``).
+    2. Built-in backends (currently ``mujoco``, ``newton``). Built-ins always
+       win over entry-point plugins of the same name, so a third-party
+       plugin can never accidentally shadow a built-in backend.
+    3. Entry-point plugins. Third-party packages (e.g.
+       `strands-robots-sim <https://github.com/strands-labs/robots-sim>`_)
+       register heavy out-of-tree backends - Isaac Sim, Newton - by declaring
+       them under the ``strands_robots.backends`` entry-point group in their
+       ``pyproject.toml``::
+
+           [project.entry-points."strands_robots.backends"]
+           isaac = "strands_robots_sim.isaac.simulation:IsaacSimulation"
+           newton = "strands_robots_sim.newton.simulation:NewtonSimulation"
+           warp = "strands_robots_sim.newton.simulation:NewtonSimulation"
+
+       so they can be discovered on ``pip install`` without patching this
+       package. A plugin may map several entry-point names to the same class
+       (``newton`` and ``warp`` above) - whichever name is requested resolves
+       cleanly. Plugins are discovered lazily on the first
+       ``create_simulation`` / ``list_backends`` call (not at import time),
+       and a plugin that fails to import is logged and skipped rather than
+       crashing the factory. See the Python packaging spec for details:
+       https://packaging.python.org/en/latest/specifications/entry-points/
+
     Args:
         backend: Backend name or alias. Defaults to ``"mujoco"``.
             Built-in: ``"mujoco"`` (aliases: ``"mj"``, ``"mjc"``, ``"mjx"``).
+            May also be any entry-point plugin name (see above).
         **kwargs: Backend-specific keyword arguments passed to the
             constructor (e.g., ``tool_name``, ``timestep``).
 
@@ -212,7 +312,9 @@ def create_simulation(
         A ``SimEngine`` instance ready for ``create_world()``.
 
     Raises:
-        ValueError: If the backend name is not recognized.
+        ValueError: If the backend name is not recognized. The message lists
+            all available backends (built-in + plugin) and, for known
+            out-of-tree backends, a ``pip install`` hint.
         ImportError: If the backend's dependencies are missing
             (e.g., ``pip install mujoco``).
 
@@ -228,6 +330,9 @@ def create_simulation(
 
         # Pass kwargs to backend constructor
         sim = create_simulation("mujoco", tool_name="my_sim")
+
+        # Entry-point plugin (requires strands-robots-sim installed)
+        sim = create_simulation("isaac", gpu_id=0)
     """
     canonical = _resolve_name(backend)
     logger.info("Creating simulation: %s (resolved from %r)", canonical, backend)

--- a/tests/simulation/test_factory.py
+++ b/tests/simulation/test_factory.py
@@ -17,12 +17,14 @@ from strands_robots.simulation.factory import (
 
 @pytest.fixture(autouse=True)
 def _clear_runtime():
-    """Each test starts with a clean runtime registry."""
+    """Each test starts with a clean runtime registry and plugin cache."""
     factory._runtime_registry.clear()
     factory._runtime_aliases.clear()
+    factory._PLUGIN_BACKENDS_CACHE = None
     yield
     factory._runtime_registry.clear()
     factory._runtime_aliases.clear()
+    factory._PLUGIN_BACKENDS_CACHE = None
 
 
 class _FakeSim:
@@ -172,3 +174,137 @@ class TestNewtonBackendRegistration:
         )
         with pytest.raises(ImportError, match="sim-newton"):
             create_simulation("newton")
+
+
+class _FakeEntryPoint:
+    """Minimal stand-in for an importlib.metadata.EntryPoint.
+
+    ``entry_points(group=...)`` returns objects with ``.name`` and ``.load()``;
+    that is the entire surface the factory touches, so we mock just those.
+    """
+
+    def __init__(self, name, target, *, raises=None):
+        self.name = name
+        self._target = target
+        self._raises = raises
+
+    def load(self):
+        if self._raises is not None:
+            raise self._raises
+        return self._target
+
+
+def _patch_entry_points(monkeypatch, eps):
+    """Patch the factory's ``entry_points`` to return ``eps`` for our group."""
+
+    def _fake_entry_points(*, group):
+        assert group == factory._ENTRY_POINT_GROUP
+        return list(eps)
+
+    monkeypatch.setattr(factory, "entry_points", _fake_entry_points)
+
+
+class _PluginSimA(_FakeSim):
+    pass
+
+
+class _PluginSimB(_FakeSim):
+    pass
+
+
+class TestEntryPointDiscovery:
+    def test_create_resolves_via_entry_point(self, monkeypatch):
+        _patch_entry_points(monkeypatch, [_FakeEntryPoint("plugin_sim", _PluginSimA)])
+        sim = create_simulation("plugin_sim", gpu_id=3)
+        assert isinstance(sim, _PluginSimA)
+        assert sim.kwargs == {"gpu_id": 3}
+
+    def test_list_backends_includes_plugins(self, monkeypatch):
+        _patch_entry_points(monkeypatch, [_FakeEntryPoint("plugin_sim", _PluginSimA)])
+        backends = list_backends()
+        assert "plugin_sim" in backends
+        assert "mujoco" in backends
+        assert backends == sorted(set(backends))
+
+    def test_aliases_via_multiple_entry_points(self, monkeypatch):
+        """Two entry-point names may point at the same class (newton/warp)."""
+        _patch_entry_points(
+            monkeypatch,
+            [
+                _FakeEntryPoint("newton_plugin", _PluginSimB),
+                _FakeEntryPoint("warp_plugin", _PluginSimB),
+            ],
+        )
+        assert isinstance(create_simulation("newton_plugin"), _PluginSimB)
+        assert isinstance(create_simulation("warp_plugin"), _PluginSimB)
+
+    def test_builtin_wins_over_plugin_of_same_name(self, monkeypatch):
+        """A plugin named ``mujoco`` must not shadow the built-in backend."""
+        pytest.importorskip("mujoco")
+        _patch_entry_points(monkeypatch, [_FakeEntryPoint("mujoco", _PluginSimA)])
+        sim = create_simulation("mujoco")
+        # Built-in resolves, not the plugin stand-in.
+        assert type(sim).__name__ == "MuJoCoSimEngine"
+        assert not isinstance(sim, _PluginSimA)
+        sim.cleanup()
+
+    def test_broken_plugin_is_skipped_not_fatal(self, monkeypatch):
+        """A plugin that fails to import is logged and skipped, others work."""
+        _patch_entry_points(
+            monkeypatch,
+            [
+                _FakeEntryPoint("broken", None, raises=RuntimeError("boom")),
+                _FakeEntryPoint("good", _PluginSimA),
+            ],
+        )
+        # Good plugin still resolves despite the broken sibling.
+        assert isinstance(create_simulation("good"), _PluginSimA)
+        # Broken one is simply absent.
+        assert "broken" not in factory._load_plugin_backends()
+
+    def test_discovery_is_cached(self, monkeypatch):
+        """Entry points are scanned at most once per process."""
+        calls = {"n": 0}
+
+        def _counting_entry_points(*, group):
+            calls["n"] += 1
+            return [_FakeEntryPoint("plugin_sim", _PluginSimA)]
+
+        monkeypatch.setattr(factory, "entry_points", _counting_entry_points)
+        list_backends()
+        list_backends()
+        create_simulation("plugin_sim")
+        assert calls["n"] == 1
+
+    def test_unknown_backend_lists_plugins_in_error(self, monkeypatch):
+        _patch_entry_points(monkeypatch, [_FakeEntryPoint("plugin_sim", _PluginSimA)])
+        with pytest.raises(ValueError) as exc_info:
+            create_simulation("nope_xyz")
+        msg = str(exc_info.value)
+        assert "mujoco" in msg
+        assert "plugin_sim" in msg
+
+    def test_unknown_known_plugin_name_suggests_install(self, monkeypatch):
+        """Known out-of-tree names surface a pip install hint when absent."""
+        _patch_entry_points(monkeypatch, [])
+        with pytest.raises(ValueError, match="strands-robots-sim") as exc_info:
+            create_simulation("isaac")
+        assert "pip install" in str(exc_info.value)
+
+
+class TestEntryPointLazyImport:
+    def test_no_eager_plugin_scan_on_import(self):
+        """Importing strands_robots.simulation must not scan entry points.
+
+        The plugin cache stays ``None`` until the first ``create_simulation``
+        / ``list_backends`` call, so installing a plugin never slows cold
+        ``import strands_robots.simulation``.
+        """
+        import importlib as _importlib
+
+        mod = _importlib.import_module("strands_robots.simulation.factory")
+        mod = _importlib.reload(mod)
+        try:
+            assert mod._PLUGIN_BACKENDS_CACHE is None
+        finally:
+            mod._PLUGIN_BACKENDS_CACHE = None


### PR DESCRIPTION
## What

Extend `strands_robots.simulation.factory` to discover third-party `SimEngine`
subclasses via `importlib.metadata.entry_points(group="strands_robots.backends")`,
in addition to the existing `_BUILTIN_BACKENDS` registry and runtime
`register_backend()` API.

Closes #131.

## Why

Isaac Sim (~30 GB) and Newton (CUDA-only) are too heavy to live in
`strands-robots` directly and are moving to the sibling plugin repo
[`strands-labs/robots-sim`](https://github.com/strands-labs/robots-sim). That
repo needs to register `IsaacSimulation` / `NewtonSimulation` with this factory
on `pip install` — without importing `strands_robots` at registration time and
without monkey-patching the built-in registry. The standard Python packaging
answer is `[project.entry-points]`, so plugins declare:

```toml
[project.entry-points."strands_robots.backends"]
isaac = "strands_robots_sim.isaac.simulation:IsaacSimulation"
newton = "strands_robots_sim.newton.simulation:NewtonSimulation"
warp = "strands_robots_sim.newton.simulation:NewtonSimulation"
```

This PR makes `create_simulation(name)` walk those entry points. Unblocks
[`strands-labs/robots-sim#13`](https://github.com/strands-labs/robots-sim/issues/13).

## How

- `_load_plugin_backends()` walks the `strands_robots.backends` entry-point
  group with a **one-time lazy cache** (`_PLUGIN_BACKENDS_CACHE`), so installing
  a plugin never slows cold `import strands_robots.simulation`. A plugin that
  fails to import is logged via `logger.warning` and skipped rather than
  crashing the factory for the working backends.
- **Resolution order**: runtime registry → built-ins → plugins. Built-ins win
  over plugins of the same name, so a conflicting plugin can never shadow
  `mujoco`/`newton`.
- **Aliases** are expressed as multiple entry-point names pointing at the same
  class (`newton`/`warp`); no dedup logic — whichever requested name resolves
  cleanly.
- The unknown-backend `ValueError` lists builtin + plugin backends and appends a
  `pip install` hint for known out-of-tree names (`isaac`/`newton`/`warp`).
- `list_backends()` merges builtin + plugin + runtime names, sorted.
- `create_simulation` docstring documents the entry-point mechanism and links
  the [Python packaging spec](https://packaging.python.org/en/latest/specifications/entry-points/);
  README gains a "Third-party backends" paragraph under Simulation.

## Test surface

`tests/simulation/test_factory.py` (`TestEntryPointDiscovery`,
`TestEntryPointLazyImport`) — uses a fake `EntryPoint` stand-in patched onto
`factory.entry_points`:

- `create_simulation("plugin_sim")` resolves via entry points (+ kwargs forwarded)
- `list_backends()` includes plugin names, merged + sorted
- two entry-point names → same class (newton/warp aliasing)
- built-in `mujoco` wins over a plugin named `mujoco`
- broken plugin is skipped (logged), siblings still resolve
- discovery scans entry points **at most once** (cache)
- unknown-name `ValueError` lists both builtin + plugin backends
- unknown known-out-of-tree name surfaces the `pip install 'strands-robots-sim[...]'` hint
- no eager plugin scan at import (`_PLUGIN_BACKENDS_CACHE is None` after import)

`hatch run format` + `hatch run lint` clean; the targeted factory/facade
suites pass (45 passed). The full-suite run hits the **pre-existing**
OpenGL/X11 rendering crashes (`test_sim_camera_mesh_publish.py`,
`test_load_scene_interaction.py`, `test_rendering.py`) on this headless dev box
— verified they fail/segfault on `upstream/main` without this change too. No
new failures introduced.

## Acceptance criteria (from #131)

- [x] `create_simulation("some_plugin_backend")` resolves via entry points
- [x] Builtin backends still work and take precedence over plugins of the same name
- [x] Unknown name raises a helpful `ValueError` listing builtin + plugin backends + install hints
- [x] `list_backends()` returns builtin + plugin names merged and sorted
- [x] New test using a fake entry point verifies discovery
- [x] No eager import of plugin modules at `import strands_robots.simulation` time
- [x] Docstring on `create_simulation` documents the mechanism + packaging-docs link
- [x] One-paragraph README note under "Simulation"

## Notes / scope

- The existing factory already had a richer surface than the issue sketch
  (runtime `register_backend()` + builtin aliases). This PR integrates
  entry-point discovery into that existing structure rather than replacing it,
  keeping `register_backend`/alias behaviour intact.
- Non-goals (per issue) honoured: no GUI/admin listing beyond `list_backends()`,
  no ABC version negotiation, no hot-reload/re-discovery after install.

This issue is on the [Strands Labs - Robots board](https://github.com/orgs/strands-labs/projects/2);
please move it to **In review**.
