### PR TITLE
fix(ux): smooth out first-run paper cuts for strands_robots users

### DIFF
--- a/strands_robots/assets/manager.py
+++ b/strands_robots/assets/manager.py
@@ -181,7 +181,11 @@ def resolve_model_path(
     """
     info = get_robot(name)
     if not info or "asset" not in info:
-        logger.warning("Unknown robot or no asset: %s", name)
+        # DEBUG, not WARNING: resolve_model() probes several candidate names
+        # (incl. suffix-stripped variants) and handles a None return cleanly,
+        # so a miss here is normal control flow -- not something the user
+        # needs to see on every add_robot.
+        logger.debug("Unknown robot or no asset: %s", name)
         return None
 
     asset = info["asset"]

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -490,14 +490,17 @@ class Mesh(SensorLoopsMixin):
             return False
 
         logger.error(
-            "[mesh] %s: PERMISSIVE DEFAULT ACL ACTIVE UNDER MTLS -- "
-            "Mesh NOT STARTED. Any CA-signed peer can publish/subscribe "
-            "on any key. Remediate one of:\n"
-            "  1. Supply STRANDS_MESH_ACL_FILE pointing at a role-separated "
+            "[mesh:%s] Mesh did NOT start: it would accept any TLS-signed peer "
+            "on every topic (no access-control list configured).\n"
+            "  Pick one:\n"
+            "    - Local dev / single machine?  Set STRANDS_MESH_LOCAL_DEV=true "
+            "(turns off mTLS+ACL for localhost experiments).\n"
+            "    - Sharing a trusted lab network?  Set "
+            "STRANDS_MESH_ACCEPT_PERMISSIVE_ACL=1 to accept this posture.\n"
+            "    - Production?  Point STRANDS_MESH_ACL_FILE at a role-separated "
             "ACL (see examples/mesh_acl_example.json5).\n"
-            "  2. Set STRANDS_MESH_ACCEPT_PERMISSIVE_ACL=1 to acknowledge "
-            "the dev/lab posture.\n"
-            "  3. Disable the mesh (do not call Mesh.start()).",
+            "    - Don't need the mesh?  It is OFF by default now -- just drop "
+            "mesh=True (or set STRANDS_MESH=false).",
             self.peer_id,
         )
         return True
@@ -522,12 +525,14 @@ class Mesh(SensorLoopsMixin):
             # (e.g. physical-only recovery) see the warning and accept it.
             if not os.getenv("STRANDS_MESH_OVERRIDE_CODE", "").strip():
                 logger.warning(
-                    "[safety] %s: STRANDS_MESH_OVERRIDE_CODE is not set -- the "
-                    "emergency-stop lockout will be UNRECOVERABLE over the mesh. "
-                    "A single estop broadcast will lock this robot until a "
-                    "physical restart (fleet-wide DoS risk). Set "
-                    "STRANDS_MESH_OVERRIDE_CODE to the same value on every peer "
-                    "to enable remote resume.",
+                    "[safety:%s] No emergency-stop resume code set. If any peer "
+                    "broadcasts an e-stop, this robot stays locked until you "
+                    "physically restart it (one message can freeze the whole "
+                    "fleet).\n"
+                    "  To allow remote resume: set STRANDS_MESH_OVERRIDE_CODE to "
+                    "the SAME value on every peer.\n"
+                    "  Local dev?  STRANDS_MESH_LOCAL_DEV=true is fine to ignore "
+                    "this.",
                     self.peer_id,
                 )
 
@@ -549,13 +554,12 @@ class Mesh(SensorLoopsMixin):
 
             if _zc_bool_env("STRANDS_MESH_MULTICAST", default=False):
                 logger.warning(
-                    "[safety] %s: STRANDS_MESH_MULTICAST=true -- multicast "
-                    "scouting is enabled. Any device on the LAN can attract "
-                    "fleet robots without credentials (unauthenticated UDP "
-                    "224.0.0.224:7446). This is a fleet-takeover risk on "
-                    "untrusted networks. Set STRANDS_MESH_MULTICAST=false "
-                    "(the default) unless operating on a physically isolated "
-                    "network.",
+                    "[safety:%s] Multicast scouting is ON "
+                    "(STRANDS_MESH_MULTICAST=true). Any device on the LAN can "
+                    "discover and attract fleet robots without credentials "
+                    "(open UDP 224.0.0.224:7446).\n"
+                    "  Only use this on a physically isolated / trusted network. "
+                    "Otherwise set STRANDS_MESH_MULTICAST=false (the default).",
                     self.peer_id,
                 )
 
@@ -3277,9 +3281,16 @@ def init_mesh(
 
     Returns None when mesh is disabled (STRANDS_MESH=false or mesh=False).
     """
-    env = os.getenv("STRANDS_MESH", "true").strip().lower()
-    if env == "false":
+    # Mesh now defaults OFF (mesh=False) so a bare ``Robot("so101")`` is quiet
+    # and never spins up Zenoh/ACL/e-stop machinery the user didn't ask for.
+    # The STRANDS_MESH env var is an explicit override in BOTH directions:
+    #   STRANDS_MESH=true  -> force mesh ON  (opt in without code change)
+    #   STRANDS_MESH=false -> force mesh OFF (kill switch, wins over mesh=True)
+    env = os.getenv("STRANDS_MESH", "").strip().lower()
+    if env in ("false", "0", "no"):
         mesh = False
+    elif env in ("true", "1", "yes"):
+        mesh = True
     if not mesh:
         return None
 

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -3279,18 +3279,18 @@ def init_mesh(
 ) -> Mesh | None:
     """Construct and start a Mesh for the given robot.
 
-    Returns None when mesh is disabled (STRANDS_MESH=false or mesh=False).
+    Returns None when mesh is disabled. ``STRANDS_MESH=false`` is a hard kill
+    switch and an explicit ``mesh=False`` both disable mesh; the env var only
+    forces mesh OFF, never ON (so an explicit opt-out is always honoured).
     """
-    # Mesh now defaults OFF (mesh=False) so a bare ``Robot("so101")`` is quiet
-    # and never spins up Zenoh/ACL/e-stop machinery the user didn't ask for.
-    # The STRANDS_MESH env var is an explicit override in BOTH directions:
-    #   STRANDS_MESH=true  -> force mesh ON  (opt in without code change)
-    #   STRANDS_MESH=false -> force mesh OFF (kill switch, wins over mesh=True)
+    # STRANDS_MESH=false is a hard kill switch: it disables mesh regardless of
+    # the ``mesh`` argument. An explicit ``mesh=False`` always wins too -- the
+    # env var only ever forces mesh OFF here, never ON, so a caller that
+    # explicitly opted out is honoured. The opt-in path (a bare ``Robot()``
+    # turning mesh ON via STRANDS_MESH=true) is resolved in the Robot factory.
     env = os.getenv("STRANDS_MESH", "").strip().lower()
     if env in ("false", "0", "no"):
         mesh = False
-    elif env in ("true", "1", "yes"):
-        mesh = True
     if not mesh:
         return None
 

--- a/strands_robots/robot.py
+++ b/strands_robots/robot.py
@@ -178,7 +178,7 @@ def Robot(  # noqa: N802 - uppercase by design (factory mimicking a class constr
     cameras: dict[str, dict[str, Any]] | None = None,
     position: list[float] | None = None,
     data_config: str | None = None,
-    mesh: bool = False,
+    mesh: bool | None = None,
     peer_id: str | None = None,
     **kwargs: Any,
 ) -> Simulation | HardwareRobot:
@@ -215,6 +215,12 @@ def Robot(  # noqa: N802 - uppercase by design (factory mimicking a class constr
         data_config: Data configuration name for observation/action schema.
                      Defaults to the canonical robot name. For multi-camera
                      setups, specify explicitly: ``data_config="so100_dualcam"``.
+        mesh: Attach a Zenoh fleet-coordination mesh. ``None`` (default) keeps
+              mesh OFF for a quiet bare ``Robot(...)`` but honours the
+              ``STRANDS_MESH=true`` opt-in. Pass ``True`` to force it on or
+              ``False`` to force it off; an explicit value always wins over the
+              env default. ``STRANDS_MESH=false`` is a hard kill switch.
+        peer_id: Optional mesh peer identifier. Auto-generated when omitted.
         **kwargs: Forwarded to the underlying backend constructor.
 
     Returns:
@@ -256,6 +262,16 @@ def Robot(  # noqa: N802 - uppercase by design (factory mimicking a class constr
 
     if mode == "auto":
         mode = _auto_detect_mode(canonical)
+
+    # Resolve the mesh opt-in. Mesh is OFF by default so a bare
+    # ``Robot("so100")`` is quiet and never spins up Zenoh/ACL/e-stop
+    # machinery. ``mesh=None`` (the default) means "consult the
+    # STRANDS_MESH env var": STRANDS_MESH=true opts in without a code
+    # change. An explicit ``mesh=True``/``mesh=False`` always wins over
+    # the env default. ``STRANDS_MESH=false`` remains a hard kill switch
+    # enforced in ``init_mesh`` regardless of this resolution.
+    if mesh is None:
+        mesh = os.getenv("STRANDS_MESH", "").strip().lower() in ("true", "1", "yes")
 
     # --- Simulation ---
     if mode == "sim":

--- a/strands_robots/robot.py
+++ b/strands_robots/robot.py
@@ -178,7 +178,7 @@ def Robot(  # noqa: N802 - uppercase by design (factory mimicking a class constr
     cameras: dict[str, dict[str, Any]] | None = None,
     position: list[float] | None = None,
     data_config: str | None = None,
-    mesh: bool = True,
+    mesh: bool = False,
     peer_id: str | None = None,
     **kwargs: Any,
 ) -> Simulation | HardwareRobot:

--- a/strands_robots/simulation/model_registry.py
+++ b/strands_robots/simulation/model_registry.py
@@ -104,8 +104,7 @@ def resolve_model(name: str, prefer_scene: bool = True) -> str | None:
                 found = _try(stripped)
                 if found:
                     logger.info(
-                        "resolve_model: '%s' not found; resolved via stripped "
-                        "name '%s'. Prefer the bare registry key.",
+                        "resolve_model: '%s' not found; resolved via stripped name '%s'. Prefer the bare registry key.",
                         name,
                         stripped,
                     )

--- a/strands_robots/simulation/model_registry.py
+++ b/strands_robots/simulation/model_registry.py
@@ -71,20 +71,45 @@ def resolve_model(name: str, prefer_scene: bool = True) -> str | None:
     3. Asset manager (robot_descriptions - fallback for standard robots)
     """
     _log_configuration_once()
-    # 1+2. Check local/custom paths first (user overrides win)
-    local = resolve_urdf(name)
-    if local:
-        return local
 
-    # 3. Fall back to asset manager
-    if _HAS_ASSET_MANAGER:
-        path = resolve_model_path(name, prefer_scene=prefer_scene)
-        if path and path.exists():
-            return str(path)
-        if prefer_scene:
-            path = resolve_model_path(name, prefer_scene=False)
+    def _try(candidate: str) -> str | None:
+        # 1+2. Check local/custom paths first (user overrides win)
+        local = resolve_urdf(candidate)
+        if local:
+            return local
+        # 3. Fall back to asset manager
+        if _HAS_ASSET_MANAGER:
+            path = resolve_model_path(candidate, prefer_scene=prefer_scene)
             if path and path.exists():
                 return str(path)
+            if prefer_scene:
+                path = resolve_model_path(candidate, prefer_scene=False)
+                if path and path.exists():
+                    return str(path)
+        return None
+
+    found = _try(name)
+    if found:
+        return found
+
+    # Friction fix: callers (and LLMs) frequently guess a decorated variant
+    # like "so101_default", "so101_sim", or "so101_robot" when the registry
+    # key is just "so101". Strip a small set of common trailing qualifiers and
+    # retry once before giving up, so the natural guess resolves instead of
+    # forcing a list_urdfs round-trip.
+    for suffix in ("_default", "_sim", "_robot", "_arm"):
+        if name.endswith(suffix):
+            stripped = name[: -len(suffix)]
+            if stripped:
+                found = _try(stripped)
+                if found:
+                    logger.info(
+                        "resolve_model: '%s' not found; resolved via stripped "
+                        "name '%s'. Prefer the bare registry key.",
+                        name,
+                        stripped,
+                    )
+                    return found
 
     return None
 

--- a/strands_robots/simulation/mujoco/backend.py
+++ b/strands_robots/simulation/mujoco/backend.py
@@ -295,7 +295,9 @@ def filter_mujoco_attach_noise():
                 # Flush C-side then restore the real stderr.
                 try:
                     sys.stderr.flush()
-                except Exception:
+                except (ValueError, OSError):
+                    # Best-effort flush; stderr may already be closed or
+                    # detached during interpreter teardown. Nothing to recover.
                     pass
                 os.dup2(saved_fd, orig_fd)
     finally:
@@ -303,7 +305,9 @@ def filter_mujoco_attach_noise():
         try:
             tmp.seek(0)
             captured = tmp.read().decode(errors="replace")
-        except Exception:
+        except OSError:
+            # Capture file unreadable (closed/truncated); treat as no output
+            # rather than masking the original yielded body with an I/O error.
             captured = ""
         finally:
             tmp.close()
@@ -320,7 +324,9 @@ def filter_mujoco_attach_noise():
                 try:
                     sys.stderr.write("".join(kept))
                     sys.stderr.flush()
-                except Exception:
+                except (ValueError, OSError):
+                    # Best-effort replay of kept lines; if stderr is gone the
+                    # captured noise is simply dropped. Nothing to recover.
                     pass
             if dropped:
                 logger.debug(

--- a/strands_robots/simulation/mujoco/backend.py
+++ b/strands_robots/simulation/mujoco/backend.py
@@ -1,10 +1,15 @@
 """MuJoCo lazy import and GL backend configuration."""
 
+import contextlib
 import ctypes
 import logging
 import os
+import re
 import subprocess
 import sys
+import tempfile
+import threading
+import warnings
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -207,25 +212,23 @@ def _can_render() -> bool:
 # everything else through unchanged, and re-emits any dropped lines at DEBUG
 # level so they are still recoverable with STRANDS_ROBOTS_VERBOSE_MUJOCO=1.
 
-import contextlib as _contextlib
-import os as _os
-import re as _re
-import tempfile as _tempfile
-import threading as _threading
 
 # Lines we consider benign attach/compile chatter. Matched case-insensitively
 # against each captured stderr line.
 _MUJOCO_NOISE_PATTERNS = (
-    _re.compile(r"Attach conflict when attaching", _re.IGNORECASE),
-    _re.compile(r"^(timestep|iterations|ls_iterations|impratio|integrator|cone|"
-                r"jacobian|solver|tolerance|ls_tolerance|noslip_iterations|"
-                r"noslip_tolerance|ccd_iterations|ccd_tolerance|sdf_iterations|"
-                r"sdf_initpoints|gravity|wind|magnetic|density|viscosity):"
-                r".*(parent has|keeping parent value)", _re.IGNORECASE),
-    _re.compile(r"parent has .* child has .* keeping parent value", _re.IGNORECASE),
+    re.compile(r"Attach conflict when attaching", re.IGNORECASE),
+    re.compile(
+        r"^(timestep|iterations|ls_iterations|impratio|integrator|cone|"
+        r"jacobian|solver|tolerance|ls_tolerance|noslip_iterations|"
+        r"noslip_tolerance|ccd_iterations|ccd_tolerance|sdf_iterations|"
+        r"sdf_initpoints|gravity|wind|magnetic|density|viscosity):"
+        r".*(parent has|keeping parent value)",
+        re.IGNORECASE,
+    ),
+    re.compile(r"parent has .* child has .* keeping parent value", re.IGNORECASE),
 )
 
-_noise_lock = _threading.Lock()
+_noise_lock = threading.Lock()
 
 
 def _is_mujoco_noise(line: str) -> bool:
@@ -235,10 +238,7 @@ def _is_mujoco_noise(line: str) -> bool:
     return any(p.search(stripped) for p in _MUJOCO_NOISE_PATTERNS)
 
 
-import warnings as _warnings  # noqa: E402
-
-
-@_contextlib.contextmanager
+@contextlib.contextmanager
 def filter_mujoco_attach_noise():
     """Suppress MuJoCo's benign attach/compile spam.
 
@@ -255,16 +255,18 @@ def filter_mujoco_attach_noise():
     some test/Jupyter setups), or on any failure -- never let log hygiene
     break a working sim.
     """
-    if _os.getenv("STRANDS_ROBOTS_VERBOSE_MUJOCO", "").strip().lower() in (
-        "1", "true", "yes",
+    if os.getenv("STRANDS_ROBOTS_VERBOSE_MUJOCO", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
     ):
         yield
         return
 
     # Layer 1: drop the matching Python UserWarning regardless of fd capture.
-    _wctx = _warnings.catch_warnings()
+    _wctx = warnings.catch_warnings()
     _wctx.__enter__()
-    _warnings.filterwarnings(
+    warnings.filterwarnings(
         "ignore",
         message=r".*Attach conflict when attaching.*",
         category=UserWarning,
@@ -273,7 +275,7 @@ def filter_mujoco_attach_noise():
     # Layer 2: capture raw fd-2 writes. Need a real, dup-able stderr fd.
     try:
         orig_fd = sys.stderr.fileno()
-        saved_fd = _os.dup(orig_fd)
+        saved_fd = os.dup(orig_fd)
     except (AttributeError, OSError, ValueError):
         # No real fd (captured stderr / pytest capsys / Jupyter) -> warning
         # filter still applies; just skip the fd capture.
@@ -283,10 +285,10 @@ def filter_mujoco_attach_noise():
             _wctx.__exit__(None, None, None)
         return
 
-    tmp = _tempfile.TemporaryFile(mode="w+b")
+    tmp = tempfile.TemporaryFile(mode="w+b")
     try:
         with _noise_lock:
-            _os.dup2(tmp.fileno(), orig_fd)
+            os.dup2(tmp.fileno(), orig_fd)
             try:
                 yield
             finally:
@@ -295,7 +297,7 @@ def filter_mujoco_attach_noise():
                     sys.stderr.flush()
                 except Exception:
                     pass
-                _os.dup2(saved_fd, orig_fd)
+                os.dup2(saved_fd, orig_fd)
     finally:
         # Replay captured output, dropping the known-benign noise lines.
         try:
@@ -306,7 +308,7 @@ def filter_mujoco_attach_noise():
         finally:
             tmp.close()
             try:
-                _os.close(saved_fd)
+                os.close(saved_fd)
             except OSError:
                 pass
 

--- a/strands_robots/simulation/mujoco/backend.py
+++ b/strands_robots/simulation/mujoco/backend.py
@@ -314,6 +314,8 @@ def filter_mujoco_attach_noise():
             try:
                 os.close(saved_fd)
             except OSError:
+                # saved_fd may already be closed during teardown; cleanup is
+                # best-effort, so a double-close is safe to ignore.
                 pass
 
         if captured:

--- a/strands_robots/simulation/mujoco/backend.py
+++ b/strands_robots/simulation/mujoco/backend.py
@@ -183,3 +183,149 @@ def _can_render() -> bool:
         )
 
     return _rendering_available  # type: ignore[return-value]
+
+
+# ---------------------------------------------------------------------------
+# MuJoCo stderr-noise suppression
+# ---------------------------------------------------------------------------
+# When two scenes are merged via ``spec.attach()`` / ``spec.compile()`` MuJoCo
+# prints a block of benign "compiler option conflict" lines straight to the C
+# stderr (fd 2) -- e.g.::
+#
+#     WARNING: Attach conflict when attaching 'scene' to 'strands_sim', ...
+#     timestep: parent has 0.002, child has 0.005, keeping parent value
+#     iterations: parent has 100, child has 10, keeping parent value
+#     ...
+#
+# These are not actionable by the user (we intentionally keep the parent's
+# compiler options) and they spam the console on every add_robot / world
+# build. Because they originate in C, Python's ``warnings`` / ``logging`` can't
+# intercept them -- we have to filter the raw file descriptor.
+#
+# ``filter_mujoco_attach_noise()`` is a context manager that captures fd 2 for
+# the duration of the wrapped call, drops the known-benign lines, forwards
+# everything else through unchanged, and re-emits any dropped lines at DEBUG
+# level so they are still recoverable with STRANDS_ROBOTS_VERBOSE_MUJOCO=1.
+
+import contextlib as _contextlib
+import os as _os
+import re as _re
+import tempfile as _tempfile
+import threading as _threading
+
+# Lines we consider benign attach/compile chatter. Matched case-insensitively
+# against each captured stderr line.
+_MUJOCO_NOISE_PATTERNS = (
+    _re.compile(r"Attach conflict when attaching", _re.IGNORECASE),
+    _re.compile(r"^(timestep|iterations|ls_iterations|impratio|integrator|cone|"
+                r"jacobian|solver|tolerance|ls_tolerance|noslip_iterations|"
+                r"noslip_tolerance|ccd_iterations|ccd_tolerance|sdf_iterations|"
+                r"sdf_initpoints|gravity|wind|magnetic|density|viscosity):"
+                r".*(parent has|keeping parent value)", _re.IGNORECASE),
+    _re.compile(r"parent has .* child has .* keeping parent value", _re.IGNORECASE),
+)
+
+_noise_lock = _threading.Lock()
+
+
+def _is_mujoco_noise(line: str) -> bool:
+    stripped = line.strip()
+    if not stripped:
+        return False
+    return any(p.search(stripped) for p in _MUJOCO_NOISE_PATTERNS)
+
+
+import warnings as _warnings  # noqa: E402
+
+
+@_contextlib.contextmanager
+def filter_mujoco_attach_noise():
+    """Suppress MuJoCo's benign attach/compile spam.
+
+    MuJoCo emits "Attach conflict ... keeping parent value" chatter when two
+    scenes are merged. Depending on the MuJoCo build this surfaces either as a
+    Python ``UserWarning`` (from ``spec.to_xml()`` / ``compile()``) OR as raw
+    C-level writes to stderr (fd 2). We suppress BOTH:
+
+    * a ``warnings.catch_warnings`` filter drops the matching ``UserWarning``;
+    * an fd-2 capture drops the matching raw lines and forwards the rest.
+
+    No-op (yields immediately) when STRANDS_ROBOTS_VERBOSE_MUJOCO is truthy,
+    when fd 2 can't be captured (e.g. already redirected, no real stderr in
+    some test/Jupyter setups), or on any failure -- never let log hygiene
+    break a working sim.
+    """
+    if _os.getenv("STRANDS_ROBOTS_VERBOSE_MUJOCO", "").strip().lower() in (
+        "1", "true", "yes",
+    ):
+        yield
+        return
+
+    # Layer 1: drop the matching Python UserWarning regardless of fd capture.
+    _wctx = _warnings.catch_warnings()
+    _wctx.__enter__()
+    _warnings.filterwarnings(
+        "ignore",
+        message=r".*Attach conflict when attaching.*",
+        category=UserWarning,
+    )
+
+    # Layer 2: capture raw fd-2 writes. Need a real, dup-able stderr fd.
+    try:
+        orig_fd = sys.stderr.fileno()
+        saved_fd = _os.dup(orig_fd)
+    except (AttributeError, OSError, ValueError):
+        # No real fd (captured stderr / pytest capsys / Jupyter) -> warning
+        # filter still applies; just skip the fd capture.
+        try:
+            yield
+        finally:
+            _wctx.__exit__(None, None, None)
+        return
+
+    tmp = _tempfile.TemporaryFile(mode="w+b")
+    try:
+        with _noise_lock:
+            _os.dup2(tmp.fileno(), orig_fd)
+            try:
+                yield
+            finally:
+                # Flush C-side then restore the real stderr.
+                try:
+                    sys.stderr.flush()
+                except Exception:
+                    pass
+                _os.dup2(saved_fd, orig_fd)
+    finally:
+        # Replay captured output, dropping the known-benign noise lines.
+        try:
+            tmp.seek(0)
+            captured = tmp.read().decode(errors="replace")
+        except Exception:
+            captured = ""
+        finally:
+            tmp.close()
+            try:
+                _os.close(saved_fd)
+            except OSError:
+                pass
+
+        if captured:
+            kept, dropped = [], []
+            for line in captured.splitlines(keepends=True):
+                (dropped if _is_mujoco_noise(line) else kept).append(line)
+            if kept:
+                try:
+                    sys.stderr.write("".join(kept))
+                    sys.stderr.flush()
+                except Exception:
+                    pass
+            if dropped:
+                logger.debug(
+                    "Suppressed %d benign MuJoCo attach/compile line(s) "
+                    "(set STRANDS_ROBOTS_VERBOSE_MUJOCO=1 to see them):\n%s",
+                    len(dropped),
+                    "".join(dropped).rstrip(),
+                )
+        # Tear down the UserWarning filter last.
+        _wctx.__exit__(None, None, None)

--- a/strands_robots/simulation/mujoco/scene_ops.py
+++ b/strands_robots/simulation/mujoco/scene_ops.py
@@ -30,7 +30,10 @@ import logging
 from typing import Any
 
 from strands_robots.simulation.models import SimCamera, SimObject, SimRobot, SimWorld
-from strands_robots.simulation.mujoco.backend import _ensure_mujoco
+from strands_robots.simulation.mujoco.backend import (
+    _ensure_mujoco,
+    filter_mujoco_attach_noise,
+)
 from strands_robots.simulation.mujoco.spec_builder import SpecBuilder
 
 logger = logging.getLogger(__name__)
@@ -59,7 +62,8 @@ def _recompile_preserving_state(world: SimWorld, spec: Any) -> bool:
     """
     mj = _ensure_mujoco()
     try:
-        new_model, new_data = spec.recompile(world._model, world._data)
+        with filter_mujoco_attach_noise():
+            new_model, new_data = spec.recompile(world._model, world._data)
     except (ValueError, RuntimeError) as e:
         logger.error("spec.recompile failed: %s", e)
         return False
@@ -76,7 +80,8 @@ def _recompile_preserving_state(world: SimWorld, spec: Any) -> bool:
     # Keep the cached XML in sync with the spec for legacy readers (e.g.
     # load_scene + add_robot round-trip).
     try:
-        world._backend_state["xml"] = spec.to_xml()
+        with filter_mujoco_attach_noise():
+            world._backend_state["xml"] = spec.to_xml()
     except Exception as xml_err:
         logger.debug("spec.to_xml() failed: %s", xml_err)
 
@@ -131,7 +136,8 @@ def inject_robot_into_scene(
         return False
 
     try:
-        joint_names = SpecBuilder.attach_robot(spec, robot, robot_xml_path)
+        with filter_mujoco_attach_noise():
+            joint_names = SpecBuilder.attach_robot(spec, robot, robot_xml_path)
         robot.joint_names = joint_names
     except (ValueError, RuntimeError, OSError) as e:
         logger.error("Robot attach failed for '%s': %s", robot.name, e)
@@ -335,7 +341,8 @@ def eject_robot_from_scene(world: SimWorld, robot_name: str) -> bool:
     # already popped from ``world.robots`` by the caller).
     for robot in world.robots.values():
         # Re-discover joint names via the attach - they're stable per URDF.
-        joint_names = SpecBuilder.attach_robot(new_spec, robot, robot.urdf_path)
+        with filter_mujoco_attach_noise():
+            joint_names = SpecBuilder.attach_robot(new_spec, robot, robot.urdf_path)
         robot.joint_names = joint_names
 
     # Step 3: compile fresh and install. No spec.recompile(model, data)
@@ -343,7 +350,8 @@ def eject_robot_from_scene(world: SimWorld, robot_name: str) -> bool:
     # make sense across a scene rebuild, and forcing a fresh compile
     # avoids the attach/delete bug.
     try:
-        new_model = new_spec.compile()
+        with filter_mujoco_attach_noise():
+            new_model = new_spec.compile()
         new_data = mj.MjData(new_model)
     except (ValueError, RuntimeError) as e:
         logger.error("eject_robot: fresh compile failed: %s", e)
@@ -353,7 +361,8 @@ def eject_robot_from_scene(world: SimWorld, robot_name: str) -> bool:
     world._data = new_data
     world._backend_state["spec"] = new_spec
     try:
-        world._backend_state["xml"] = new_spec.to_xml()
+        with filter_mujoco_attach_noise():
+            world._backend_state["xml"] = new_spec.to_xml()
     except Exception as xml_err:
         logger.debug("spec.to_xml() failed: %s", xml_err)
 
@@ -411,7 +420,8 @@ def replace_scene_mjcf(world: SimWorld, xml: str) -> bool:
     new_spec = SpecBuilder.from_mjcf_string(xml)
     # Compile eagerly so malformed XML fails here rather than on the next
     # mj_step.
-    new_model = new_spec.compile()
+    with filter_mujoco_attach_noise():
+        new_model = new_spec.compile()
     new_data = mj.MjData(new_model)
 
     world._backend_state["spec"] = new_spec
@@ -426,7 +436,8 @@ def replace_scene_mjcf(world: SimWorld, xml: str) -> bool:
     mj.mj_forward(new_model, new_data)
 
     try:
-        world._backend_state["xml"] = new_spec.to_xml()
+        with filter_mujoco_attach_noise():
+            world._backend_state["xml"] = new_spec.to_xml()
     except Exception:
         pass
     return True
@@ -610,7 +621,8 @@ def patch_scene_mjcf(world: SimWorld, ops: list[dict[str, Any]]) -> int:
     # MjSpec doesn't expose a cheap deep-copy, but round-tripping through XML
     # is safe: it's the same canonical form used by the compiler.
     try:
-        backup_xml = spec.to_xml()
+        with filter_mujoco_attach_noise():
+            backup_xml = spec.to_xml()
     except Exception as e:  # pragma: no cover - spec.to_xml on brand-new specs is fine
         raise RuntimeError(f"failed to snapshot spec before patch: {e}") from e
 
@@ -633,7 +645,8 @@ def patch_scene_mjcf(world: SimWorld, ops: list[dict[str, Any]]) -> int:
         raise ValueError(f"patch op #{applied + 1} failed: {err}") from err
 
     # One recompile for the whole batch - preserves qpos/qvel for unchanged joints.
-    world._model, world._data = spec.recompile(world._model, world._data)
+    with filter_mujoco_attach_noise():
+        world._model, world._data = spec.recompile(world._model, world._data)
 
     # Forward pass so new bodies' xpos / xquat / cam_xmat are populated for
     # the very next render() or get_body_state() call. Same reasoning as
@@ -642,7 +655,8 @@ def patch_scene_mjcf(world: SimWorld, ops: list[dict[str, Any]]) -> int:
     mj.mj_forward(world._model, world._data)
 
     try:
-        world._backend_state["xml"] = spec.to_xml()
+        with filter_mujoco_attach_noise():
+            world._backend_state["xml"] = spec.to_xml()
     except Exception:
         pass
     return applied

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -814,12 +814,7 @@ class MuJoCoSimEngine(
         # ``add_robot(data_config="so101")`` failed with "requires parameter
         # 'name'". Now the label defaults to the model name (deduped).
         if not name:
-            import os as _os
-            base = (
-                data_config
-                or (_os.path.splitext(_os.path.basename(urdf_path))[0] if urdf_path else None)
-                or "robot"
-            )
+            base = data_config or (os.path.splitext(os.path.basename(urdf_path))[0] if urdf_path else None) or "robot"
             name = base
             i = 2
             while name in self._world.robots:
@@ -830,12 +825,14 @@ class MuJoCoSimEngine(
             taken = ", ".join(sorted(self._world.robots)) or "(none)"
             return {
                 "status": "error",
-                "content": [{
-                    "text": (
-                        f"Robot '{name}' already exists. Pick a different "
-                        f"name, or omit name= to auto-number. Existing: {taken}."
-                    )
-                }],
+                "content": [
+                    {
+                        "text": (
+                            f"Robot '{name}' already exists. Pick a different "
+                            f"name, or omit name= to auto-number. Existing: {taken}."
+                        )
+                    }
+                ],
             }
 
         # Resolution precedence:
@@ -851,9 +848,7 @@ class MuJoCoSimEngine(
             if not resolved_path:
                 return {
                     "status": "error",
-                    "content": [
-                        {"text": self._unknown_model_msg(data_config)}
-                    ],
+                    "content": [{"text": self._unknown_model_msg(data_config)}],
                 }
         elif not resolved_path and name:
             # deprecated fallback - try registry by instance name.

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -68,7 +68,10 @@ from strands_robots.simulation.model_registry import (
     register_urdf as _register_urdf,
 )
 from strands_robots.simulation.models import SimCamera, SimObject, SimRobot, SimStatus, SimWorld
-from strands_robots.simulation.mujoco.backend import _ensure_mujoco
+from strands_robots.simulation.mujoco.backend import (
+    _ensure_mujoco,
+    filter_mujoco_attach_noise,
+)
 from strands_robots.simulation.mujoco.physics import PhysicsMixin
 from strands_robots.simulation.mujoco.randomization import RandomizationMixin
 from strands_robots.simulation.mujoco.recording import RecordingMixin
@@ -420,7 +423,8 @@ class MuJoCoSimEngine(
             # contract produced by _compile_world for fresh worlds.
             spec = SpecBuilder.from_file(scene_path)
             self._world._backend_state["spec"] = spec
-            self._world._model = spec.compile()
+            with filter_mujoco_attach_noise():
+                self._world._model = spec.compile()
             self._world._data = mj.MjData(self._world._model)
             # Forward the freshly-allocated MjData so derived state
             # (xpos / xquat / xmat / sensor data) is populated. Without
@@ -441,7 +445,8 @@ class MuJoCoSimEngine(
 
             # Cache the canonical serialisation; legacy readers use this.
             try:
-                self._world._backend_state["xml"] = spec.to_xml()
+                with filter_mujoco_attach_noise():
+                    self._world._backend_state["xml"] = spec.to_xml()
             except Exception as xml_err:
                 logger.debug("spec.to_xml() on loaded scene failed: %s", xml_err)
 
@@ -565,7 +570,8 @@ class MuJoCoSimEngine(
         assert self._world is not None  # only called after create_world
         spec = SpecBuilder.build(self._world)
         self._world._backend_state["spec"] = spec
-        self._world._model = spec.compile()
+        with filter_mujoco_attach_noise():
+            self._world._model = spec.compile()
         self._world._data = mj.MjData(self._world._model)
         # Forward the freshly-allocated MjData so derived state
         # (xpos / xquat / xmat) is populated - same rationale as in
@@ -574,7 +580,8 @@ class MuJoCoSimEngine(
         # gradient because body transforms are zero-initialised.
         mj.mj_forward(self._world._model, self._world._data)
         try:
-            self._world._backend_state["xml"] = spec.to_xml()
+            with filter_mujoco_attach_noise():
+                self._world._backend_state["xml"] = spec.to_xml()
         except Exception as xml_err:
             # spec.to_xml() is best-effort - if it fails we still have a
             # valid compiled model. The cached XML is a convenience for
@@ -750,9 +757,34 @@ class MuJoCoSimEngine(
             robot.mesh = None
             robot.peer_id = ""
 
+    @staticmethod
+    def _unknown_model_msg(requested: str) -> str:
+        """Build a helpful 'no model found' error with close-match suggestions.
+
+        Friction fix: instead of a bare "use list_urdfs", we name the closest
+        known registry keys (difflib) so the caller can usually fix the typo
+        in-place without a discovery round-trip.
+        """
+        suggestions: list[str] = []
+        try:
+            import difflib
+
+            from strands_robots.registry import list_robots as _list_robots
+
+            known = [r.get("name", "") for r in _list_robots() if r.get("name")]
+            suggestions = difflib.get_close_matches(requested, known, n=3, cutoff=0.4)
+        except Exception:  # noqa: BLE001 - suggestions are best-effort
+            suggestions = []
+
+        msg = f"No model found for '{requested}'."
+        if suggestions:
+            msg += " Did you mean: " + ", ".join(suggestions) + "?"
+        msg += " Use action='list_urdfs' to see all available robots."
+        return msg
+
     def add_robot(
         self,
-        name: str,
+        name: str | None = None,
         urdf_path: str | None = None,
         data_config: str | None = None,
         position: list[float] | None = None,
@@ -764,13 +796,47 @@ class MuJoCoSimEngine(
         robot's bodies, actuators, assets, and sensors into the existing scene
         XML.  This preserves previously-created world state (gravity, objects,
         cameras, other robots).
+
+        ``name`` is the instance label used to address this robot later
+        (``run_policy(robot_name=...)``, ``get_robot_state``, etc.). It is
+        OPTIONAL: when omitted it is auto-derived from ``data_config`` (or the
+        URDF filename), with a numeric suffix appended if that label is already
+        taken -- so ``add_robot(data_config="so101")`` twice yields ``so101``
+        and ``so101_2`` instead of erroring.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         if err := self._require_no_running_policy("add_robot"):
             return err
+
+        # Auto-derive an instance label when the caller didn't supply one.
+        # Friction fix: ``name`` used to be required, so a natural
+        # ``add_robot(data_config="so101")`` failed with "requires parameter
+        # 'name'". Now the label defaults to the model name (deduped).
+        if not name:
+            import os as _os
+            base = (
+                data_config
+                or (_os.path.splitext(_os.path.basename(urdf_path))[0] if urdf_path else None)
+                or "robot"
+            )
+            name = base
+            i = 2
+            while name in self._world.robots:
+                name = f"{base}_{i}"
+                i += 1
+
         if name in self._world.robots:
-            return {"status": "error", "content": [{"text": f"Robot '{name}' already exists."}]}
+            taken = ", ".join(sorted(self._world.robots)) or "(none)"
+            return {
+                "status": "error",
+                "content": [{
+                    "text": (
+                        f"Robot '{name}' already exists. Pick a different "
+                        f"name, or omit name= to auto-number. Existing: {taken}."
+                    )
+                }],
+            }
 
         # Resolution precedence:
         #   1. explicit `urdf_path` (anything on disk).
@@ -786,9 +852,7 @@ class MuJoCoSimEngine(
                 return {
                     "status": "error",
                     "content": [
-                        {
-                            "text": f"No model found for '{data_config}'.\nUse action='list_urdfs' to see available robots"
-                        }
+                        {"text": self._unknown_model_msg(data_config)}
                     ],
                 }
         elif not resolved_path and name:
@@ -1358,7 +1422,8 @@ class MuJoCoSimEngine(
             try:
                 self._world._model, self._world._data = spec.recompile(self._world._model, self._world._data)
                 try:
-                    self._world._backend_state["xml"] = spec.to_xml()
+                    with filter_mujoco_attach_noise():
+                        self._world._backend_state["xml"] = spec.to_xml()
                 except Exception:
                     pass
             except (ValueError, RuntimeError) as e:

--- a/strands_robots/simulation/mujoco/tool_spec.json
+++ b/strands_robots/simulation/mujoco/tool_spec.json
@@ -96,11 +96,11 @@
     },
     "data_config": {
       "type": "string",
-      "description": "Data config name (auto-resolves URDF)"
+      "description": "Robot model registry key for add_robot (e.g. 'so101', 'panda', 'aloha'). Use the BARE name from list_urdfs -- not 'so101_default'/'so101_sim' (those are auto-stripped but the bare key is canonical). Auto-resolves to the MJCF/URDF on disk."
     },
     "name": {
       "type": "string",
-      "description": "Object/camera name"
+      "description": "Instance label. For add_object/add_camera it's the object/camera name. For add_robot it's OPTIONAL -- the label you'll use later in run_policy(robot_name=...); if omitted it's auto-derived from data_config and auto-numbered on collision (so101, so101_2, ...)."
     },
     "shape": {
       "type": "string",

--- a/tests/mesh/test_deep_mesh.py
+++ b/tests/mesh/test_deep_mesh.py
@@ -1060,6 +1060,18 @@ class TestInitMeshFactory:
         result = init_mesh(FakeRobot(), peer_id="explicit-false", mesh=False)
         assert result is None
 
+    def test_env_true_does_not_force_on_over_explicit_false(self, monkeypatch, mock_session):
+        """init_mesh never forces mesh ON via env; explicit mesh=False wins.
+
+        STRANDS_MESH only ever forces mesh OFF inside init_mesh. The opt-in
+        (turning mesh ON from the env) is resolved in the Robot factory, so a
+        caller that explicitly passed mesh=False is always honoured here even
+        when STRANDS_MESH=true is set.
+        """
+        for val in ["true", "1", "yes", "TRUE"]:
+            monkeypatch.setenv("STRANDS_MESH", val)
+            assert init_mesh(FakeRobot(), peer_id="opt-out", mesh=False) is None
+
     def test_auto_peer_id_uniqueness(self, mock_session):
         """Auto-generated peer IDs should be unique across calls."""
         ids = set()

--- a/tests/mesh/test_default_acl_warning.py
+++ b/tests/mesh/test_default_acl_warning.py
@@ -90,11 +90,9 @@ def test_mtls_plus_default_acl_does_not_start(caplog, monkeypatch, stub_robot):
 
     # The operator-facing ERROR IS logged.
     error_msgs = [r.getMessage() for r in records if r.levelname == "ERROR"]
-    assert any("PERMISSIVE DEFAULT ACL ACTIVE UNDER MTLS" in m for m in error_msgs), (
-        f"expected ERROR breadcrumb; saw {error_msgs}"
-    )
+    assert any("Mesh did NOT start" in m for m in error_msgs), f"expected ERROR breadcrumb; saw {error_msgs}"
     # And the actionable paths are spelled out.
-    assert any("Mesh NOT STARTED" in m for m in error_msgs)
+    assert any("no access-control list configured" in m for m in error_msgs)
     assert any("STRANDS_MESH_ACCEPT_PERMISSIVE_ACL=1" in m for m in error_msgs)
 
 
@@ -106,9 +104,7 @@ def test_mtls_plus_default_acl_with_optin_logs_at_info(caplog, monkeypatch, stub
     monkeypatch.setenv("STRANDS_MESH_ACCEPT_PERMISSIVE_ACL", "1")
     records = _start_with_stub_session(stub_robot, caplog, level=logging.INFO)
     error_msgs = [r.getMessage() for r in records if r.levelname == "ERROR"]
-    assert not any("PERMISSIVE DEFAULT ACL ACTIVE" in m for m in error_msgs), (
-        f"opt-in should NOT log ERROR; saw {error_msgs}"
-    )
+    assert not any("Mesh did NOT start" in m for m in error_msgs), f"opt-in should NOT log ERROR; saw {error_msgs}"
     info_msgs = [r.getMessage() for r in records if r.levelname == "INFO"]
     assert any("permissive default ACL active" in m for m in info_msgs), (
         f"expected INFO-level ack on opt-in; saw {info_msgs}"
@@ -234,7 +230,7 @@ class TestF17PreSessionGate:
         assert m._running is False
         # The operator-facing ERROR was logged.
         error_msgs = [r.getMessage() for r in caplog.records if r.levelname == "ERROR"]
-        assert any("PERMISSIVE DEFAULT ACL ACTIVE UNDER MTLS" in msg for msg in error_msgs)
+        assert any("Mesh did NOT start" in msg for msg in error_msgs)
 
     def test_helper_returns_true_under_dangerous_combo(self, monkeypatch, stub_robot):
         """The helper itself returns True under mtls + permissive default

--- a/tests/mesh/test_mesh_wiring.py
+++ b/tests/mesh/test_mesh_wiring.py
@@ -169,6 +169,8 @@ def test_robot_factory_env_opt_in_enables_mesh(monkeypatch):
             try:
                 sim.destroy()
             except Exception:
+                # Best-effort teardown: a destroy() hiccup during cleanup
+                # must not mask the assertion outcome under test.
                 pass
 
 
@@ -188,4 +190,6 @@ def test_robot_factory_explicit_false_beats_env_true(monkeypatch):
             try:
                 sim.destroy()
             except Exception:
+                # Best-effort teardown: a destroy() hiccup during cleanup
+                # must not mask the assertion outcome under test.
                 pass

--- a/tests/mesh/test_mesh_wiring.py
+++ b/tests/mesh/test_mesh_wiring.py
@@ -44,11 +44,14 @@ def patched_init_mesh(monkeypatch):
 
 
 def test_robot_factory_attaches_mesh_in_sim_mode(patched_init_mesh):
-    """Robot() with default mesh=True attaches the mesh produced by init_mesh."""
+    """Robot(..., mesh=True) attaches the mesh produced by init_mesh.
+
+    Mesh defaults to OFF now (quiet-by-default), so opting in is explicit.
+    """
     from strands_robots import Robot
 
     mock_init_mesh, fake_mesh = patched_init_mesh
-    sim = Robot("so100", mode="sim")
+    sim = Robot("so100", mode="sim", mesh=True)
     try:
         # init_mesh was called with the constructed sim and peer_type='sim'.
         assert mock_init_mesh.called

--- a/tests/mesh/test_mesh_wiring.py
+++ b/tests/mesh/test_mesh_wiring.py
@@ -143,3 +143,49 @@ def test_robot_factory_mesh_init_failure_does_not_break_sim(monkeypatch):
             sim.destroy()
         except Exception:
             pass
+
+
+def test_robot_factory_env_opt_in_enables_mesh(monkeypatch):
+    """A bare Robot() honours STRANDS_MESH=true (opt-in without code change).
+
+    mesh defaults to None (quiet), so the factory consults STRANDS_MESH and
+    passes mesh=True down to init_mesh when the env opts in.
+    """
+    from unittest.mock import MagicMock
+
+    from strands_robots import Robot
+
+    monkeypatch.setenv("STRANDS_MESH", "true")
+    fake = MagicMock(name="MockMesh")
+    fake.peer_id = "envbot-test"
+    fake.alive = True
+    with patch("strands_robots.mesh.init_mesh", return_value=fake) as m:
+        sim = Robot("so100", mode="sim")
+        try:
+            assert m.called
+            assert m.call_args.kwargs["mesh"] is True
+            assert sim.mesh is fake
+        finally:
+            try:
+                sim.destroy()
+            except Exception:
+                pass
+
+
+def test_robot_factory_explicit_false_beats_env_true(monkeypatch):
+    """Explicit mesh=False wins even when STRANDS_MESH=true is set."""
+    from strands_robots import Robot
+
+    monkeypatch.setenv("STRANDS_MESH", "true")
+    with patch("strands_robots.mesh.init_mesh", return_value=None) as m:
+        sim = Robot("so100", mode="sim", mesh=False)
+        try:
+            # Factory must forward mesh=False; init_mesh then returns None.
+            if m.called:
+                assert m.call_args.kwargs.get("mesh") is False
+            assert sim.mesh is None
+        finally:
+            try:
+                sim.destroy()
+            except Exception:
+                pass

--- a/tests/mesh/test_multicast_startup_warning.py
+++ b/tests/mesh/test_multicast_startup_warning.py
@@ -68,7 +68,7 @@ def test_multicast_enabled_emits_warning(monkeypatch, caplog):
     multicast_warnings = [r.getMessage() for r in caplog.records if _MULTICAST_MARKER in r.getMessage()]
     assert multicast_warnings, f"expected a multicast WARNING when STRANDS_MESH_MULTICAST=true, got: {caplog.messages}"
     msg = multicast_warnings[0]
-    assert "[safety]" in msg
+    assert "[safety:" in msg
     assert "224.0.0.224:7446" in msg
     assert "mc-on" in msg  # peer_id is interpolated
 

--- a/tests/simulation/mujoco/test_backend.py
+++ b/tests/simulation/mujoco/test_backend.py
@@ -280,3 +280,70 @@ class TestEnsureMujocoViewer:
             assert backend_mod._mujoco_viewer is None
         finally:
             self._restore_globals(saved)
+
+
+class TestMujocoNoiseFilter:
+    """Regression tests for the benign-attach-noise filter.
+
+    ``filter_mujoco_attach_noise`` and ``_is_mujoco_noise`` live in
+    ``strands_robots.simulation.mujoco.backend`` and depend on stdlib modules
+    (``contextlib``, ``os``, ``re``, ``tempfile``, ``threading``, ``warnings``)
+    imported at module top. These tests pin the matching contract and the
+    fd-2 capture round trip so the import wiring cannot silently regress.
+    """
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "Attach conflict when attaching 'scene' to 'strands_sim'",
+            "timestep: parent has 0.002, child has 0.005, keeping parent value",
+            "iterations: parent has 100, child has 10, keeping parent value",
+            "WARNING: parent has 0.002 child has 0.005 keeping parent value",
+        ],
+    )
+    def test_benign_lines_match(self, line):
+        assert backend_mod._is_mujoco_noise(line) is True
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "",
+            "   ",
+            "Segmentation fault in mj_step",
+            "RuntimeError: actuator index out of range",
+        ],
+    )
+    def test_real_errors_do_not_match(self, line):
+        assert backend_mod._is_mujoco_noise(line) is False
+
+    def test_verbose_env_disables_filtering(self, monkeypatch, capfd):
+        """STRANDS_ROBOTS_VERBOSE_MUJOCO=1 must pass all stderr through."""
+        monkeypatch.setenv("STRANDS_ROBOTS_VERBOSE_MUJOCO", "1")
+        with backend_mod.filter_mujoco_attach_noise():
+            print("Attach conflict when attaching scene", file=sys.stderr)
+        captured = capfd.readouterr()
+        assert "Attach conflict" in captured.err
+
+    def test_filter_drops_noise_keeps_real_errors(self, monkeypatch):
+        """End-to-end fd-2 capture: benign lines dropped, real lines kept.
+
+        Uses a real OS-level pipe as stderr so the fd-dup path actually runs
+        (capfd/capsys replace sys.stderr without a dup-able fileno, exercising
+        only the fallback branch).
+        """
+        monkeypatch.delenv("STRANDS_ROBOTS_VERBOSE_MUJOCO", raising=False)
+        r_fd, w_fd = os.pipe()
+        saved_stderr = sys.stderr
+        sys.stderr = os.fdopen(w_fd, "w")
+        try:
+            with backend_mod.filter_mujoco_attach_noise():
+                sys.stderr.write("Attach conflict when attaching scene\n")
+                sys.stderr.write("FATAL: actuator index out of range\n")
+                sys.stderr.flush()
+        finally:
+            sys.stderr.close()
+            sys.stderr = saved_stderr
+        output = os.read(r_fd, 65536).decode()
+        os.close(r_fd)
+        assert "Attach conflict" not in output
+        assert "FATAL: actuator index out of range" in output

--- a/tests/simulation/mujoco/test_simulation.py
+++ b/tests/simulation/mujoco/test_simulation.py
@@ -287,6 +287,34 @@ class TestRobotManagement:
         result = sim_with_world.add_robot("nonexistent_model_xyz")
         assert result["status"] == "error"
 
+    def test_add_robot_name_optional_derives_from_urdf(self, sim_with_world, robot_xml_path):
+        """Friction fix: name= is optional; auto-derived from the URDF filename."""
+        result = sim_with_world.add_robot(urdf_path=robot_xml_path)
+        assert result["status"] == "success"
+        # Label derived from the URDF stem; robot is addressable under it.
+        assert len(sim_with_world._world.robots) == 1
+        derived = next(iter(sim_with_world._world.robots))
+        assert derived  # non-empty label
+
+    def test_add_robot_auto_numbers_on_collision(self, sim_with_world, robot_xml_path):
+        """Two no-name adds of the same model auto-dedupe instead of erroring."""
+        import os
+
+        stem = os.path.splitext(os.path.basename(robot_xml_path))[0]
+        r1 = sim_with_world.add_robot(urdf_path=robot_xml_path)
+        r2 = sim_with_world.add_robot(urdf_path=robot_xml_path)
+        assert r1["status"] == "success"
+        assert r2["status"] == "success"
+        names = set(sim_with_world._world.robots)
+        assert stem in names
+        assert f"{stem}_2" in names
+
+    def test_add_duplicate_explicit_name_lists_existing(self, sim_with_robot, robot_xml_path):
+        """Explicit duplicate name still errors, but names the existing robots."""
+        result = sim_with_robot.add_robot("arm1", urdf_path=robot_xml_path)
+        assert result["status"] == "error"
+        assert "arm1" in result["content"][0]["text"]
+
     def test_list_robots_empty(self, sim_with_world):
         # SimEngine ABC: list[str]
         assert sim_with_world.list_robots() == []

--- a/tests/simulation/test_model_registry.py
+++ b/tests/simulation/test_model_registry.py
@@ -41,6 +41,26 @@ def test_resolve_model_unknown_returns_none():
     assert resolve_model("this_does_not_exist_xyz") is None
 
 
+def test_resolve_model_strips_common_suffix():
+    """Friction fix: 'panda_default'/'panda_sim' should resolve to 'panda'.
+
+    LLMs and humans frequently append a decorative qualifier to the bare
+    registry key. resolve_model() strips a small allow-list of suffixes and
+    retries once before returning None.
+    """
+    pytest.importorskip("mujoco")  # panda requires mujoco_menagerie
+    bare = resolve_model("panda")
+    assert bare is not None
+    for variant in ("panda_default", "panda_sim", "panda_robot", "panda_arm"):
+        assert resolve_model(variant) == bare, f"{variant} should resolve to panda"
+
+
+def test_resolve_model_strip_does_not_overreach():
+    """Stripping must not turn a genuinely-unknown name into a false hit."""
+    # 'this_does_not_exist_xyz_default' strips to a still-unknown base -> None.
+    assert resolve_model("this_does_not_exist_xyz_default") is None
+
+
 def test_resolve_urdf_unknown_returns_none():
     assert resolve_urdf("this_does_not_exist_xyz") is None
 


### PR DESCRIPTION
## Summary

A fresh `Robot("so101")` + a simple agent loop surfaced several rough edges that make the **very first experience noisy and confusing**. This PR addresses all of them so the out-of-box flow is quiet and forgiving.

## What's fixed

### 1. Mesh OFF by default (quiet by default)
- `Robot(...)` no longer spins up Zenoh/ACL/e-stop machinery the user never asked for - the security-warning wall disappears for the common case. The `mesh` argument now defaults to `None` (a sentinel meaning "consult the env").
- `STRANDS_MESH=true` opts a bare `Robot()` in without a code change; `STRANDS_MESH=false` is a hard kill switch. An explicit `mesh=True`/`mesh=False` always wins over the env default - the env var only ever forces mesh OFF inside `init_mesh`, never ON, so an explicit opt-out is always honoured.

### 2. Human-readable mesh safety warnings
- Rewrote the 3 mesh warnings (permissive ACL, e-stop override code, multicast) from jargon walls into plain-language guidance with a clear menu of options, interpolating the peer id into the `[safety:<id>]` / `[mesh:<id>]` prefix.
- Surfaces the `STRANDS_MESH_LOCAL_DEV=true` developer escape hatch (turns off mTLS+ACL for localhost work).

### 3. Suppress benign MuJoCo attach/compile noise
- New `filter_mujoco_attach_noise()` context manager catches both the Python `UserWarning` (`spec.to_xml`) and raw C-level fd-2 spam (`Attach conflict...`, `timestep: parent has...`). Benign lines drop to DEBUG; everything else passes through untouched.
- Opt back in with `STRANDS_ROBOTS_VERBOSE_MUJOCO=1`.
- Wrapped attach/compile/recompile/to_xml hot paths in `scene_ops.py` and `simulation.py`. Demoted `assets/manager` "Unknown robot" log from WARNING to DEBUG (normal `resolve_model` probe control-flow now).

### 4. Forgiving `add_robot` + model resolution
- `add_robot`: `name=` is now OPTIONAL, auto-derived from `data_config` / URDF stem and auto-numbered on collision (`so101`, `so101_2`, ...). Removes the `requires parameter 'name'` first-call failure.
- `resolve_model`: strips common decorative suffixes (`_default`/`_sim`/`_robot`/`_arm`) and retries, so the natural guess `so101_default` resolves to `so101` without a `list_urdfs` round-trip.
- "No model found" now suggests close matches via difflib (`Did you mean: so101, so100?`).
- `tool_spec.json`: clarified `data_config` (bare registry key) and `name` (optional instance label) descriptions.

## Visual artifact (headless MuJoCo rollout)

Mock-policy rollout of the resulting quiet `so101` sim (rendered headless, `MUJOCO_GL=egl`). Demonstrates `Robot("so101")` builds silently, `add_robot(data_config="so101_default")` resolves first try, and `run_policy` steps cleanly with no attach-noise spam:

![so101 quiet rollout](https://github.com/cagataycali/robots/releases/download/harness-artifacts/so101_quiet_rollout.gif)

## Mesh-precedence + test alignment (this revision)

Two correctness follow-ups so the behaviour matches its documented contract and the full suite is green:

- **Mesh precedence**: an earlier revision let `STRANDS_MESH=true` force mesh ON even over an explicit `mesh=False`, contradicting the kill-switch contract (the env var should only force mesh OFF). Fixed: `init_mesh` honours an explicit opt-out unconditionally; the env opt-in for a bare `Robot()` is resolved in the factory via the `mesh=None` sentinel. Regression tests pin both directions (`test_env_true_does_not_force_on_over_explicit_false`, `test_robot_factory_env_opt_in_enables_mesh`, `test_robot_factory_explicit_false_beats_env_true`).
- **Safety-warning tests**: the rewritten permissive-ACL / multicast / e-stop messages changed wording and prefix; updated the assertions in `test_default_acl_warning.py` and `test_multicast_startup_warning.py` to match (e.g. the permissive-ACL refusal now reads `Mesh did NOT start ... no access-control list configured`).
- **E402 hygiene**: hoisted the noise-filter's stdlib imports (`contextlib`/`os`/`re`/`tempfile`/`threading`/`warnings`) to the module top and dropped redundant underscore aliases; added `TestMujocoNoiseFilter` pinning the noise-match contract, the verbose escape hatch, and the fd-2 capture round trip.

## Testing
- `ruff check` + `ruff format --check` clean across `strands_robots tests tests_integ`; `mypy` clean on touched modules.
- Headless (`MUJOCO_GL=egl`): full mesh suite 1713 passed / 2 skipped; backend + simulation + model_registry + robot_name_optional green. CI test-lint green.

## Backwards compatibility
- `mesh=True` still works (explicit opt-in). `STRANDS_MESH=true` restores auto-mesh for a bare `Robot()` without code changes.
- Explicit `add_robot(name=...)` unchanged; duplicate explicit names still error (now with a more helpful message listing existing robots).

---

## Changelog

**Round 2** - CodeQL `py/empty-except` hardening (findings 489-493):
- `simulation/mujoco/backend.py`: narrowed the three best-effort `except` clauses in the stderr noise filter to `(ValueError, OSError)` / `OSError` and documented why each path has nothing to recover (stderr closed/detached during teardown; capture file unreadable).
- `tests/mesh/test_mesh_wiring.py`: documented the two `sim.destroy()` teardown guards so the best-effort intent is explicit (a destroy hiccup must not mask the assertion under test).
- No behaviour change; lint + format clean on touched files.

**Round 3** - CodeQL `py/empty-except` follow-up (finding 489, remaining clause):
- `simulation/mujoco/backend.py`: the final best-effort `except OSError: pass` guarding `os.close(saved_fd)` in the capture-teardown `finally` block still lacked an explanatory comment, unlike its already-annotated siblings. Documented that `saved_fd` may already be closed during interpreter teardown, so the double-close is safe to ignore. No behaviour change; lint + format clean.