### PR TITLE
docs(teleop): document Teleoperator factory + teleoperate() mixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,36 @@ from strands_robots import create_policy
 policy = create_policy("lerobot/act_aloha_sim_transfer_cube_human")
 ```
 
+### Teleoperation (leader arms, gamepads, WASD)
+
+Drive any real robot - or a simulation - from one or more LeRobot
+teleoperators. `Teleoperator()` mirrors the `Robot()` factory; `attach_teleop()`
++ `teleoperate()` run the control loop.
+
+```python
+from strands_robots import Robot, Teleoperator
+
+# Leader arm -> follower arm (both speak {motor}.pos -> zero config)
+follower = Robot("so101", mode="real", port="/dev/ttyACM0")
+follower.attach_teleop("so101_leader", port="/dev/ttyACM1", id="leader")
+follower.teleoperate()                       # Ctrl+C or stop_teleoperate()
+
+# Earth Rover Mini+ with WASD keys (velocity keys -> zero config)
+rover = Robot("earthrover_mini_plus", mode="real", robot_ip="192.168.1.151")
+rover.attach_teleop("keyboard_rover")        # W/A/S/D
+rover.teleoperate(block=True, duration=30)
+
+# Cross-vocabulary or sim teleop -> supply a map_fn(action) -> action
+robot.attach_teleop("keyboard_ee", map_fn=my_ik)   # EE deltas -> joint .pos
+robot.teleoperate(publish=True)              # also stream over the mesh
+```
+
+17 teleoperators (`so100/so101/koch/omx/openarm` leaders, `bi_*` leaders,
+`gamepad`, `keyboard`, `keyboard_ee`, `keyboard_rover`, `phone`,
+`reachy2_teleoperator`, `unitree_g1`, homunculus arm/glove) drive 14 robots.
+Zero-config when action keys match; otherwise pass `map_fn`. Full matrix +
+recipes: [Teleoperation docs](https://strands-labs.github.io/robots/hardware/teleoperation/).
+
 ## Recording & streaming datasets
 
 The physical-AI data loop, end to end: **record** a LeRobotDataset from sim or

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -13,6 +13,7 @@ import strands_robots
 | Symbol | What | More |
 |--------|------|------|
 | `Robot(name, mode='sim', ...)` | Factory → `Simulation` or `HardwareRobot` | [Robot factory](getting-started/robot-factory.md) |
+| `Teleoperator(name, **kwargs)` | Factory → LeRobot teleoperator (leader arm, gamepad, keyboard, …) | [Teleoperation](hardware/teleoperation.md) |
 | `list_robots(category='all')` | Catalog query | [Robot catalog](robots/index.md) |
 | `Policy` | Policy ABC | [Policies](policies/overview.md) |
 | `MockPolicy` | Sinusoidal mock | [Policies](policies/overview.md) |

--- a/docs/hardware/robot-control.md
+++ b/docs/hardware/robot-control.md
@@ -61,7 +61,21 @@ robot.cleanup()
 | `status` | - | - |
 | `stop` | - | - |
 
+## Teleoperation
+
+High-level: attach one or more LeRobot teleoperators and drive this robot
+directly. See **[Teleoperation](teleoperation.md)** for the full API and recipes.
+
+```python
+robot.attach_teleop("so101_leader", port="/dev/ttyACM1", id="leader")
+robot.teleoperate()                       # local drive; stop_teleoperate() to end
+robot.teleoperate(publish=True)           # drive + publish over the mesh
+```
+
 ## Mesh teleop
+
+Low-level transport primitives for streaming teleop actions between peers
+(`teleoperate(publish=True)` builds on `start_teleop_publish`):
 
 ```python
 robot.start_teleop_publish(teleoperator, device_name="leader", method="joint", hz=50)

--- a/docs/hardware/teleoperation.md
+++ b/docs/hardware/teleoperation.md
@@ -1,0 +1,240 @@
+---
+description: Teleoperation - drive any robot or simulation from one or more LeRobot teleoperators via the Teleoperator() factory and the attach_teleop()/teleoperate() mixin.
+---
+
+# Teleoperation
+
+Drive any `Robot` (real **or** simulated) from one or more LeRobot
+teleoperators - leader arms, gamepads, keyboards, phones - through a single
+high-level API.
+
+Two pieces:
+
+- **`Teleoperator(name, **kwargs)`** - a factory that mirrors the
+  [`Robot()`](../getting-started/robot-factory.md) factory, exposing every
+  teleoperator registered with LeRobot.
+- **`attach_teleop()` / `teleoperate()`** - mixin methods present on every
+  hardware `Robot` and every `Simulation` host. They poll each attached
+  device's `get_action()`, optionally remap it, merge the results, and apply
+  the merged action via the host's `send_action()`.
+
+```python
+from strands_robots import Robot, Teleoperator
+
+follower = Robot("so101", mode="real", port="/dev/ttyACM0")
+follower.attach_teleop("so101_leader", port="/dev/ttyACM1", id="leader")
+follower.teleoperate()          # Ctrl+C or stop_teleoperate() to stop
+```
+
+## The `Teleoperator()` factory
+
+```python
+from strands_robots import Teleoperator
+
+leader = Teleoperator("so101_leader", port="/dev/ttyACM1", id="leader")
+```
+
+`name` is any LeRobot-registered teleoperator type. `**kwargs` are forwarded to
+that teleoperator's config (`port`, `id`, `left_port`, …) and validated -
+unknown kwargs raise immediately so typos surface fast.
+
+### Available teleoperators
+
+| Teleoperator | Emits (action keys) |
+|--------------|---------------------|
+| `so100_leader`, `so101_leader` | `{motor}.pos` |
+| `koch_leader`, `omx_leader`, `openarm_leader`, `openarm_mini` | `{motor}.pos` |
+| `bi_so_leader`, `bi_openarm_leader` | `{motor}.pos` (dual-arm) |
+| `keyboard` | joint deltas |
+| `keyboard_ee` | end-effector deltas |
+| `keyboard_rover` | `{linear_velocity, angular_velocity}` (WASD) |
+| `gamepad` | base/EE velocities |
+| `phone` | pose / EE stream |
+| `homunculus_arm`, `homunculus_glove` | hand/arm joints |
+| `reachy2_teleoperator` | Reachy2 joints |
+| `unitree_g1` | humanoid joints |
+
+Run `Teleoperator` against the live registry to confirm what your LeRobot
+install ships:
+
+```python
+from lerobot.teleoperators.config import TeleoperatorConfig
+from strands_robots.teleoperator import _ensure_lerobot_teleoperators_registered
+_ensure_lerobot_teleoperators_registered()
+print(sorted(TeleoperatorConfig.get_known_choices()))
+```
+
+## Mixin API
+
+Every hardware `Robot` and `Simulation` host exposes:
+
+| Method | What |
+|--------|------|
+| `attach_teleop(device_or_spec, *, name=None, method=None, map_fn=None, **kwargs)` | Register an input stream (lazy - no hardware touched). `device_or_spec` is a built teleop instance **or** a type string built via `Teleoperator(**kwargs)`. |
+| `teleoperate(*, names=None, robot_name=None, hz=50.0, publish=False, block=False, duration=None)` | Run the control loop. |
+| `detach_teleop(name=None)` | Remove one (or all) attached streams. |
+| `stop_teleoperate()` | Stop the loop, any mesh publishers, and disconnect devices. |
+
+### `attach_teleop`
+
+- **`name`** - stable key for this stream (used in `teleoperate(names=[...])`,
+  mesh topics, `detach_teleop`). Defaults to the device's `id`, else type.
+- **`method`** - input-method label (`"arm"`, `"gamepad"`, `"keyboard"`,
+  `"phone"`); auto-derived from the type when omitted.
+- **`map_fn`** - optional `(action: dict) -> dict` applied **before**
+  `send_action`. The bridge for cross-vocabulary teleop (e.g. EE deltas →
+  joint `.pos`, or leader joint names → sim actuator names). Identity by
+  default.
+
+### `teleoperate`
+
+- **`names`** - subset of attached streams to run (default: all).
+- **`robot_name`** - target robot in a multi-robot simulation world.
+- **`hz`** - control-loop rate (default `50.0`).
+- **`publish`** - also publish each device to the mesh via the host's
+  `start_teleop_publish` so remote peers can follow. Requires a hardware
+  `Robot` host.
+- **`block`** - run inline until `duration` elapses / Ctrl+C (`True`) vs
+  background thread (`False`, default).
+- **`duration`** - auto-stop after N seconds (`None` = until stopped).
+
+Each tick: poll every selected device's `get_action()` → apply its `map_fn` →
+**merge** (last-wins on key conflict, with a one-time warning) → apply via
+`self.send_action(merged, robot_name=...)`.
+
+## Action-key compatibility
+
+A pairing is **zero-config** only when the teleop's action keys match what the
+robot's `send_action` consumes:
+
+| Teleop | Robot | Keys | Config |
+|--------|-------|------|--------|
+| `so101_leader` | `so101_follower` | `{motor}.pos` | identity ✅ |
+| `keyboard_rover` | `earthrover_mini_plus` | `linear_velocity`, `angular_velocity` | identity ✅ |
+| `gamepad` | `lekiwi` | base velocities | identity ✅ |
+| `keyboard_ee` | `so101` (joint) | EE deltas → `.pos` | needs `map_fn` ⚠️ |
+| `so101_leader` | `earthrover` | `.pos` → velocity | needs `map_fn` ⚠️ |
+
+The merge does **not** auto-convert `.pos` ↔ `velocity`. Cross-vocabulary
+pairings supply a `map_fn` - that hook exists exactly for this.
+
+> For a wheeled rover use **`keyboard_rover`** (WASD → velocity).
+> Plain `keyboard` / `keyboard_ee` emit joint / EE deltas, not base velocities.
+
+## Recipes
+
+### Leader arm → follower arm
+
+```python
+from strands_robots import Robot
+
+follower = Robot("so101", mode="real", port="/dev/ttyACM0")
+follower.attach_teleop("so101_leader", port="/dev/ttyACM1", id="leader")
+follower.teleoperate()
+```
+
+### Earth Rover Mini+ with WASD keys
+
+```python
+rover = Robot("earthrover_mini_plus", mode="real", robot_ip="192.168.1.151")
+rover.attach_teleop("keyboard_rover")              # W/A/S/D
+rover.teleoperate(block=True, duration=30)         # drive 30 s, then teardown
+```
+
+### Gamepad / phone → mobile base
+
+```python
+base = Robot("lekiwi", mode="real", robot_ip="192.168.1.42")
+base.attach_teleop("gamepad")                      # or "phone"
+base.teleoperate()
+```
+
+### Pre-built teleop instance + explicit method
+
+```python
+from strands_robots import Robot, Teleoperator
+
+leader = Teleoperator("koch_leader", port="/dev/ttyACM1")
+follower = Robot("koch", mode="real", port="/dev/ttyACM0")
+follower.attach_teleop(leader, name="leader", method="arm")
+follower.teleoperate()
+```
+
+### Cross-vocabulary via `map_fn`
+
+```python
+def ee_to_joints(action: dict) -> dict:
+    return my_ik(action)        # {dx,dy,dz,dgrip} -> {shoulder.pos, ...}
+
+robot = Robot("so101", mode="real", port="/dev/ttyACM0")
+robot.attach_teleop("keyboard_ee", map_fn=ee_to_joints)
+robot.teleoperate()
+```
+
+### Multi-device teleop (merge inputs)
+
+```python
+robot.attach_teleop("so101_leader", port="/dev/ttyACM1", name="arm")
+robot.attach_teleop("gamepad", name="base")        # different key namespace
+robot.teleoperate(names=["arm", "base"])           # both stream into send_action
+```
+
+### Bimanual leader → follower
+
+```python
+bi = Robot("bi_so", mode="real", left_port="/dev/ttyACM0", right_port="/dev/ttyACM1")
+bi.attach_teleop("bi_so_leader", left_port="/dev/ttyACM2", right_port="/dev/ttyACM3")
+bi.teleoperate()
+```
+
+### Teleoperate a simulation (MuJoCo)
+
+```python
+from strands_robots import Simulation
+
+sim = Simulation(...)
+sim.attach_teleop(
+    "so101_leader",
+    port="/dev/ttyACM1",
+    map_fn=lambda a: {f"sim/{k}": v for k, v in a.items()},
+    robot_name="arm0",
+)
+sim.teleoperate(robot_name="arm0")
+```
+
+### Teleop + mesh publish (remote followers mirror)
+
+```python
+leader_host.attach_teleop("so101_leader", port="/dev/ttyACM1")
+leader_host.teleoperate(publish=True)   # local drive + publish over the mesh
+```
+
+The actuation stream rides the documented [`Mesh.publish()`](../mesh.md)
+chokepoint via `start_teleop_publish`. Remote followers consume it with
+`start_teleop_receive` (see [Mesh teleop](robot-control.md#mesh-teleop)).
+
+### Time-boxed / clean teardown
+
+```python
+robot.attach_teleop("so101_leader", port="/dev/ttyACM1")
+robot.teleoperate(block=True, duration=60)   # 60 s then stop + disconnect
+# non-block mode:
+robot.teleoperate()
+...
+robot.stop_teleoperate()                     # stop loop + publishers + disconnect
+```
+
+## How it relates to mesh teleop
+
+`teleoperate()` is the **local** driver: read teleop → apply to the host.
+[Mesh teleop](robot-control.md#mesh-teleop) (`start_teleop_publish` /
+`start_teleop_receive`) is the **transport** for streaming actions between
+peers. `teleoperate(publish=True)` composes the two: drive locally **and**
+publish so remote followers mirror.
+
+## See also
+
+- [Robot factory](../getting-started/robot-factory.md) - every `Robot()` kwarg.
+- [Robot control](robot-control.md) - hardware lifecycle + mesh teleop primitives.
+- [Hardware tools](tools.md) - `lerobot_teleoperate` @tool for agent-driven sessions.
+- [Mesh networking](../mesh.md) - the transport layer.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ nav:
   - Custom Policies: policies/custom-policies.md
 - Real Hardware:
   - Robot Control: hardware/robot-control.md
+  - Teleoperation: hardware/teleoperation.md
   - Tools: hardware/tools.md
 - Training:
   - Overview: training/overview.md


### PR DESCRIPTION
## Summary

Documentation for the merged **teleoperation** feature (`Teleoperator()` factory + `attach_teleop()`/`teleoperate()` mixin). No code changes — docs only.

Rebased on fresh `strands-labs/robots@main`. `mkdocs build --strict` passes.

## Changes

| File | Change |
|------|--------|
| **`docs/hardware/teleoperation.md`** | **NEW** full page (240 lines) |
| `mkdocs.yml` | Add **Teleoperation** to the *Real Hardware* nav section (between Robot Control and Tools) |
| `docs/api-reference.md` | Add `Teleoperator(name, **kwargs)` to the `strands_robots` symbol table |
| `docs/hardware/robot-control.md` | New high-level **Teleoperation** section; reframe **Mesh teleop** as the transport primitives `teleoperate(publish=True)` builds on |
| `README.md` | **Teleoperation** quick-start under *Quick starts* (leader→follower, WASD rover, `map_fn`) |

## New page covers

- **`Teleoperator()` factory** — mirrors `Robot()`; kwargs forwarded + validated.
- **Available teleoperators table** — 17 types with their emitted action-key shapes.
- **Mixin API** — `attach_teleop` / `teleoperate` / `detach_teleop` / `stop_teleoperate` with every parameter (`name`, `method`, `map_fn`, `names`, `robot_name`, `hz`, `publish`, `block`, `duration`).
- **Action-key compatibility matrix** — which pairings are zero-config vs need a `map_fn` (the `.pos` ↔ `velocity` caveat).
- **10 recipes** — leader→follower, WASD Earth Rover, gamepad/phone→base, pre-built instance, cross-vocabulary `map_fn`, multi-device merge, bimanual, MuJoCo sim teleop, mesh publish, time-boxed/clean teardown.
- **Relation to mesh teleop** — local driver vs transport; `publish=True` composes them.

## Accuracy

Every snippet + signature verified against the merged source (`teleoperator.py`, `teleop_mixin.py`, hardware `Robot.send_action`) and the live LeRobot registry — not invented. Action-key shapes (`keyboard_rover` → `{linear_velocity, angular_velocity}`, `so101_leader` → `{motor}.pos`) confirmed against lerobot source.

## Test plan
- [x] `mkdocs build --strict` — clean (no broken nav/links)
- [x] All internal doc links resolve
- [x] Snippets match the merged public API