### PR TITLE
fix(device_connect): type WebSocket connect-kwargs as dict[str, Any]

### DIFF
--- a/strands_robots/device_connect/reachy_transport.py
+++ b/strands_robots/device_connect/reachy_transport.py
@@ -258,7 +258,7 @@ class WebSocketLink(HardwareLink):
         _extra_headers = {"Authorization": f"Bearer {_token}"} if _token else None
         if not _token:
             _warn_unauthenticated_once("WebSocket")
-        _connect_kwargs = {}
+        _connect_kwargs: dict[str, Any] = {}
         if _extra_headers:
             # websockets >=12 uses additional_headers; older uses extra_headers.
             try:

--- a/tests/test_reachy_transport_links.py
+++ b/tests/test_reachy_transport_links.py
@@ -18,8 +18,10 @@ import json
 import sys
 import unittest
 import urllib.error
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from strands_robots.device_connect import reachy_transport
 from strands_robots.device_connect.reachy_transport import (
     WebSocketLink,
     ZenohLink,
@@ -259,6 +261,39 @@ class TestRestApiErrorHandling(unittest.TestCase):
         with patch("urllib.request.urlopen", return_value=fake_resp):
             result = api("h", 8000, "/status")
         self.assertEqual(result, {"ok": True})
+
+
+class TestWebSocketLinkConnectKwargsTyping(unittest.TestCase):
+    """The WebSocket connect-kwargs dict must be statically well-typed.
+
+    ``WebSocketLink.start`` builds an untyped ``_connect_kwargs`` mapping and
+    ``**``-unpacks it into ``websockets.connect``. With the inline type stubs
+    shipped by recent ``websockets`` releases, an unannotated ``{}`` literal is
+    inferred as ``dict[str, dict[str, str]]`` (from its first assignment) and
+    fails every ``connect`` overload on the unpack. Annotating the dict as
+    ``dict[str, Any]`` keeps the call type-correct. This pins that contract so a
+    future edit cannot silently reintroduce the over-narrow inference.
+    """
+
+    def test_module_typechecks_against_websockets_stubs(self):
+        import subprocess
+
+        module_path = Path(reachy_transport.__file__)
+        result = subprocess.run(
+            [sys.executable, "-m", "mypy", str(module_path)],
+            capture_output=True,
+            text=True,
+        )
+        arg_type_errors = [
+            line for line in result.stdout.splitlines() if "reachy_transport.py" in line and "[arg-type]" in line
+        ]
+        self.assertEqual(
+            arg_type_errors,
+            [],
+            msg=(
+                "websockets.connect call must type-check cleanly; got arg-type errors:\n" + "\n".join(arg_type_errors)
+            ),
+        )
 
 
 def _restore_env(name, old):


### PR DESCRIPTION
## Problem

`mypy strands_robots tests tests_integ` fails with 11 `[arg-type]` errors, all pointing at one line in `reachy_transport.py`:

```
strands_robots/device_connect/reachy_transport.py:275: error: Argument 2 to "connect" has incompatible type "**dict[str, dict[str, str]]"; expected "Origin | None"  [arg-type]
... (one per connect() overload, 11 total)
```

`WebSocketLink.start` builds an untyped `_connect_kwargs` mapping and `**`-unpacks it into `websockets.connect`:

```python
_connect_kwargs = {}
if _extra_headers:
    _connect_kwargs[_hdr_kw] = _extra_headers   # first concrete write: a dict value
...
_connect_kwargs["ssl"] = _build_ssl_context("WebSocket")
self._ws = await websockets.connect(_url, **_connect_kwargs)
```

Recent `websockets` releases ship inline type stubs (`py.typed`). With those stubs present, mypy infers the unannotated `{}` literal from its first conditional assignment as `dict[str, dict[str, str]]`, then rejects the `**`-unpack against every `connect()` overload (each kwarg expects its own concrete type, not `dict[str, str]`).

This is a forward-compat break that surfaces only once a `websockets` version with bundled stubs is resolved, so it does not reproduce under every pin.

## Change

Annotate the accumulator explicitly:

```python
_connect_kwargs: dict[str, Any] = {}
```

`Any` is already imported in the module. This is a type-only fix; runtime behavior is unchanged.

## Tests

Added `TestWebSocketLinkConnectKwargsTyping` in `tests/test_reachy_transport_links.py`: a mypy static-analysis regression that runs mypy on the module and asserts zero `[arg-type]` errors. It fails on the pre-fix unannotated literal (11 errors) and passes after the annotation.

- `ruff check` + `ruff format --check` clean across `strands_robots tests tests_integ`.
- `mypy strands_robots tests tests_integ`: Success, no issues in 423 source files (was 11 errors).
- `tests/test_reachy_transport_links.py`: 16 passed.