### PR TITLE
test(training): cover Gr00tTrainer config lowering and in-process launch

### DIFF
--- a/tests/training/test_groot.py
+++ b/tests/training/test_groot.py
@@ -237,7 +237,7 @@ def _install_fake_gr00t(monkeypatch, run_recorder=None):
     exp_mod = _mod("gr00t.experiment.experiment")
 
     ft_mod.FinetuneConfig = _FakeFinetuneConfig
-    base_cfg.get_default_config = lambda: _FakeRunConfig()
+    base_cfg.get_default_config = _FakeRunConfig
     emb_mod.EmbodimentTag = _FakeEmbodimentTag
 
     def _run(config):

--- a/tests/training/test_groot.py
+++ b/tests/training/test_groot.py
@@ -4,7 +4,14 @@ Offline/pure - does not require an Isaac-GR00T checkout to run (uses a fake
 groot_root with a stub launch_finetune.py for the happy-path command tests).
 """
 
+import importlib
 import json
+import os
+import sys
+import types
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -137,3 +144,292 @@ class TestBuildCommand:
         assert "--weight_decay=1e-05" in cmd
         # consumed keys must not leak
         assert not any(c.startswith("--groot_root=") for c in cmd)
+
+
+# ---------------------------------------------------------------------------
+# Fake Isaac-GR00T package tree so the config-lowering + in-process launch
+# paths run with NO checkout, NO GPU, NO real dependency. Mirrors only the
+# narrow surface Gr00tTrainer touches: FinetuneConfig (a dataclass), a default
+# Config with mutable .data/.model/.training bags + .load_dict(), the
+# EmbodimentTag resolver, and experiment.run().
+# ---------------------------------------------------------------------------
+@dataclass
+class _FakeFinetuneConfig:
+    base_model_path: str = ""
+    dataset_path: str = ""
+    embodiment_tag: Any = None
+    output_dir: str = ""
+    max_steps: int = 0
+    global_batch_size: int = 0
+    learning_rate: float = 0.0
+    save_steps: int = 0
+    num_gpus: int = 1
+    tune_llm: bool = False
+    tune_visual: bool = False
+    tune_projector: bool = True
+    tune_diffusion_model: bool = True
+    resume_from_checkpoint: bool = False
+    random_rotation_angle: float = 0.0
+    color_jitter_params: Any = None
+    extra_augmentation_config: str | None = None
+    modality_config_path: str | None = None
+    state_dropout_prob: float = 0.0
+    experiment_name: str = "exp"
+    dataloader_num_workers: int = 4
+    gradient_accumulation_steps: int = 1
+    save_total_limit: int = 3
+    use_wandb: bool = False
+    weight_decay: float = 0.0
+    warmup_ratio: float = 0.0
+    wandb_project: str = "groot"
+    shard_size: int = 1
+    episode_sampling_rate: float = 1.0
+    num_shards_per_epoch: int = 1
+    save_only_model: bool = False
+    skip_weight_loading: bool = False
+    lr_scheduler_type: str = "cosine"  # a real field, for passthrough-allowlist
+
+
+class _Bucket:
+    """Mutable attribute bag; unset attributes read as None."""
+
+    def __getattr__(self, name: str) -> Any:
+        return None
+
+
+class _FakeRunConfig:
+    def __init__(self) -> None:
+        self.data = _Bucket()
+        self.model = _Bucket()
+        self.training = _Bucket()
+        self.load_config_path: Any = "unset"
+        self.loaded_dict: dict[str, Any] | None = None
+
+    def load_dict(self, d: dict[str, Any]) -> "_FakeRunConfig":
+        self.loaded_dict = d
+        return self
+
+
+class _FakeEmbodimentTag:
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+    @classmethod
+    def resolve(cls, tag: Any) -> "_FakeEmbodimentTag":
+        return tag if isinstance(tag, _FakeEmbodimentTag) else cls(str(tag))
+
+
+def _install_fake_gr00t(monkeypatch, run_recorder=None):
+    """Register a fake ``gr00t`` package tree; return the FinetuneConfig class."""
+
+    def _mod(name: str) -> types.ModuleType:
+        m = types.ModuleType(name)
+        monkeypatch.setitem(sys.modules, name, m)
+        return m
+
+    gr00t = _mod("gr00t")
+    _mod("gr00t.configs")
+    ft_mod = _mod("gr00t.configs.finetune_config")
+    base_cfg = _mod("gr00t.configs.base_config")
+    _mod("gr00t.data")
+    emb_mod = _mod("gr00t.data.embodiment_tags")
+    _mod("gr00t.experiment")
+    exp_mod = _mod("gr00t.experiment.experiment")
+
+    ft_mod.FinetuneConfig = _FakeFinetuneConfig
+    base_cfg.get_default_config = lambda: _FakeRunConfig()
+    emb_mod.EmbodimentTag = _FakeEmbodimentTag
+
+    def _run(config):
+        if run_recorder is not None:
+            run_recorder.append(config)
+
+    exp_mod.run = _run
+    return gr00t
+
+
+class TestBuildFinetuneConfig:
+    """build_finetune_config() lowers a TrainSpec into GR00T's FinetuneConfig."""
+
+    def test_core_fields_mapped(self, spec, monkeypatch):
+        _install_fake_gr00t(monkeypatch)
+        ft = Gr00tTrainer().build_finetune_config(spec)
+        assert ft.base_model_path == "nvidia/GR00T-N1.5-3B"
+        assert ft.dataset_path == spec.dataset_root
+        assert ft.embodiment_tag == "GR1"
+        assert ft.max_steps == 500
+        assert ft.global_batch_size == 32
+        assert ft.save_steps == 100
+        # default tune: projector + diffusion on, llm/visual off
+        assert ft.tune_projector is True
+        assert ft.tune_diffusion_model is True
+        assert ft.tune_llm is False
+        assert ft.tune_visual is False
+
+    def test_augmentation_split_into_native_and_extra(self, spec, monkeypatch):
+        _install_fake_gr00t(monkeypatch)
+        spec.augmentation = {
+            "random_rotation_angle": 15,
+            "color_jitter_params": {"brightness": 0.2},
+            "mixup_alpha": 0.4,  # neither native field -> extra_augmentation_config JSON
+        }
+        ft = Gr00tTrainer().build_finetune_config(spec)
+        assert ft.random_rotation_angle == 15
+        assert ft.color_jitter_params == {"brightness": 0.2}
+        assert json.loads(ft.extra_augmentation_config) == {"mixup_alpha": 0.4}
+
+    def test_extra_passthrough_allowlisted_by_dataclass_fields(self, spec, monkeypatch):
+        _install_fake_gr00t(monkeypatch)
+        spec.extra["lr_scheduler_type"] = "linear"  # real FinetuneConfig field
+        spec.extra["not_a_real_field"] = "ignored"  # silently dropped
+        ft = Gr00tTrainer().build_finetune_config(spec)
+        assert ft.lr_scheduler_type == "linear"
+        assert not hasattr(ft, "not_a_real_field")
+
+    def test_modality_config_path_forwarded(self, spec, tmp_path, monkeypatch):
+        _install_fake_gr00t(monkeypatch)
+        mcfg = tmp_path / "modality.py"
+        mcfg.write_text("# modality\n")
+        spec.extra["modality_config_path"] = str(mcfg)
+        ft = Gr00tTrainer().build_finetune_config(spec)
+        assert ft.modality_config_path == str(mcfg)
+
+
+class TestBuildRunConfig:
+    """_build_run_config() lowers a FinetuneConfig into the run Config."""
+
+    def test_dataset_and_embodiment_lowered(self, spec, monkeypatch):
+        _install_fake_gr00t(monkeypatch)
+        t = Gr00tTrainer()
+        ft = t.build_finetune_config(spec)
+        cfg = t._build_run_config(ft)
+        ds = cfg.loaded_dict["data"]["datasets"][0]
+        assert ds["dataset_paths"] == [spec.dataset_root]
+        assert ds["embodiment_tag"] == "GR1"
+        assert cfg.load_config_path is None
+
+    def test_training_knobs_forwarded(self, spec, monkeypatch):
+        _install_fake_gr00t(monkeypatch)
+        t = Gr00tTrainer()
+        cfg = t._build_run_config(t.build_finetune_config(spec))
+        assert cfg.training.max_steps == 500
+        assert cfg.training.global_batch_size == 32
+        assert cfg.training.learning_rate == spec.learning_rate
+        assert cfg.training.start_from_checkpoint == "nvidia/GR00T-N1.5-3B"
+        assert cfg.training.output_dir == spec.output_dir
+
+    def test_multi_path_dataset_split_on_pathsep(self, spec, monkeypatch):
+        _install_fake_gr00t(monkeypatch)
+        t = Gr00tTrainer()
+        ft = t.build_finetune_config(spec)
+        ft.dataset_path = os.pathsep.join(["/a/ds1", "/b/ds2"])
+        cfg = t._build_run_config(ft)
+        assert cfg.loaded_dict["data"]["datasets"][0]["dataset_paths"] == ["/a/ds1", "/b/ds2"]
+
+    def test_extra_augmentation_json_decoded(self, spec, monkeypatch):
+        _install_fake_gr00t(monkeypatch)
+        t = Gr00tTrainer()
+        ft = t.build_finetune_config(spec)
+        ft.extra_augmentation_config = json.dumps({"mixup_alpha": 0.4})
+        cfg = t._build_run_config(ft)
+        assert cfg.model.extra_augmentation_config == {"mixup_alpha": 0.4}
+
+
+class TestLoadModalityConfig:
+    def test_imports_py_module_and_extends_sys_path(self, tmp_path):
+        mod = tmp_path / "my_modality_cfg.py"
+        mod.write_text("LOADED = True\n")
+        Gr00tTrainer._load_modality_config(str(mod))
+        assert str(tmp_path) in sys.path
+        loaded = importlib.import_module("my_modality_cfg")
+        assert loaded.LOADED is True
+
+    def test_missing_path_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            Gr00tTrainer._load_modality_config(str(tmp_path / "nope.py"))
+
+    def test_non_py_suffix_raises(self, tmp_path):
+        bad = tmp_path / "cfg.json"
+        bad.write_text("{}")
+        with pytest.raises(FileNotFoundError):
+            Gr00tTrainer._load_modality_config(str(bad))
+
+
+class TestLatestCheckpoint:
+    def test_none_when_dir_absent(self, tmp_path):
+        assert Gr00tTrainer().latest_checkpoint(str(tmp_path / "missing")) is None
+
+    def test_none_when_no_checkpoints(self, tmp_path):
+        (tmp_path / "logs").mkdir()
+        assert Gr00tTrainer().latest_checkpoint(str(tmp_path)) is None
+
+    def test_picks_highest_step(self, tmp_path):
+        for step in (100, 2000, 500):
+            (tmp_path / f"checkpoint-{step}").mkdir()
+        (tmp_path / "checkpoint-notanumber").mkdir()  # unparsable -> step -1
+        latest = Gr00tTrainer().latest_checkpoint(str(tmp_path))
+        assert latest == str(tmp_path / "checkpoint-2000")
+
+
+class TestTrainInProcess:
+    """train() single-GPU path: validate -> build configs -> call run()."""
+
+    def test_validation_failure_short_circuits(self, spec):
+        spec.embodiment = None  # GR00T requires it
+        result = Gr00tTrainer().train(spec)
+        assert result.status == "error"
+        assert "validation failed" in result.message
+        assert result.job_id == ""
+
+    def test_success_calls_run_and_reports_checkpoint(self, spec, monkeypatch):
+        recorder: list = []
+        _install_fake_gr00t(monkeypatch, run_recorder=recorder)
+        os.makedirs(spec.output_dir, exist_ok=True)
+        (Path(spec.output_dir) / "checkpoint-300").mkdir()
+        result = Gr00tTrainer().train(spec)
+        assert result.status == "success"
+        assert result.job_id.startswith("groot-")
+        assert result.checkpoint_dir == str(Path(spec.output_dir) / "checkpoint-300")
+        assert len(recorder) == 1  # experiment.run() was invoked exactly once
+
+    def test_run_exception_converted_to_error_result(self, spec, monkeypatch):
+        _install_fake_gr00t(monkeypatch)
+        import gr00t.experiment.experiment as exp  # noqa: PLC0415
+
+        def _boom(config):
+            raise RuntimeError("CUDA OOM")
+
+        monkeypatch.setattr(exp, "run", _boom)
+        result = Gr00tTrainer().train(spec)
+        assert result.status == "error"
+        assert "RuntimeError" in result.message
+        assert "CUDA OOM" in result.message
+
+    def test_missing_gr00t_package_returns_install_hint(self, spec, monkeypatch):
+        # Ensure no fake gr00t is registered and a real import fails.
+        for name in list(sys.modules):
+            if name == "gr00t" or name.startswith("gr00t."):
+                monkeypatch.delitem(sys.modules, name, raising=False)
+        monkeypatch.setattr(
+            "strands_robots.training.groot.importlib.import_module",
+            lambda name: (_ for _ in ()).throw(ImportError(f"no {name}")),
+        )
+        result = Gr00tTrainer().train(spec)
+        assert result.status == "error"
+        assert "Isaac-GR00T is not importable" in result.message
+
+
+class TestResolveTune:
+    def test_unknown_keys_ignored(self, spec):
+        spec.tune = {"llm": True, "bogus": True}
+        merged = Gr00tTrainer()._resolve_tune(spec)
+        assert merged["llm"] is True
+        assert "bogus" not in merged
+
+    def test_frozen_backbone_forces_backbone_off(self, spec):
+        spec.method = "frozen_backbone"
+        spec.tune = {"llm": True, "visual": True, "diffusion": True}
+        merged = Gr00tTrainer()._resolve_tune(spec)
+        assert merged["llm"] is False
+        assert merged["visual"] is False
+        assert merged["diffusion"] is True


### PR DESCRIPTION
## Problem

`strands_robots/training/groot.py` carried only 38% test coverage. The existing `tests/training/test_groot.py` covered factory wiring, `validate()`, and the pure `build_command()` argv-parity helper — but the parts that actually run a fine-tune were untested:

- `build_finetune_config()` — lowering a `TrainSpec` into GR00T's own `FinetuneConfig` (tune-flag resolution, augmentation split into native fields vs. `extra_augmentation_config` JSON, dataclass-field-allowlisted `extra` passthrough, modality-config forwarding).
- `_build_run_config()` — lowering a `FinetuneConfig` into the run `Config` (dataset/embodiment dict, `os.pathsep`-split multi-path datasets, training-knob forwarding, augmentation JSON decode).
- `_load_modality_config()` — the user `.py` modality-config loader.
- `latest_checkpoint()` — `checkpoint-<step>` discovery and highest-step selection.
- `train()` — the single-GPU orchestration: validation short-circuit, success path invoking `experiment.run()`, backend-exception-to-error-result conversion, and the missing-`gr00t`-package install hint.

These paths only ran with an Isaac-GR00T checkout + GPU, so they were never exercised in CI.

## Change

Adds offline unit tests that install a fake `gr00t` package tree into `sys.modules` (a `FinetuneConfig` dataclass, a default run `Config` with mutable `.data`/`.model`/`.training` bags + `load_dict()`, an `EmbodimentTag` resolver, and `experiment.run`). This lets the full config-lowering and single-GPU launch path run with no checkout, no GPU, and no heavy dependency — pure and fast (<0.2s).

No production code changes; tests only.

## Coverage

`strands_robots/training/groot.py`: **38% -> 91%** (140 -> 21 missing lines). 14 -> 34 tests in `tests/training/test_groot.py`, all passing.

## Testing

```
python -m pytest tests/training/test_groot.py -q   # 34 passed
ruff check / ruff format --check                    # clean
mypy strands_robots/ tests/                         # clean
```

## Changelog

### Round 2
- Replaced the `get_default_config = lambda: _FakeRunConfig()` fake with a direct `get_default_config = _FakeRunConfig` class assignment to clear a code-scanning finding (unnecessary lambda wrapper). `_FakeRunConfig` is a no-arg callable, so each call still constructs a fresh instance — behavior is identical. All 34 tests remain green; the scanning thread is resolved.