### PR TITLE
fix(teleop): normalize scalar/0-d array actions without crashing the loop

### DIFF
--- a/strands_robots/mesh/input.py
+++ b/strands_robots/mesh/input.py
@@ -238,8 +238,14 @@ class InputPublisher:
                     result[k] = float(v)
             return result
         elif hasattr(action, "tolist"):
+            # A numpy/torch scalar or 0-d array returns a bare Python number
+            # from ``tolist()`` (not a list); enumerating it raises
+            # ``'float' object is not iterable``. Treat a non-list result as a
+            # single-DOF scalar so a 1-DOF leader does not crash the stream.
             arr = action.tolist()
-            return {f"j{i}": float(v) for i, v in enumerate(arr)}
+            if isinstance(arr, list):
+                return {f"j{i}": float(v) for i, v in enumerate(arr)}
+            return {"raw": float(arr)}
         else:
             return {"raw": float(action)}
 

--- a/strands_robots/teleop_mixin.py
+++ b/strands_robots/teleop_mixin.py
@@ -563,8 +563,15 @@ def _normalize_action(action: Any) -> ActionDict:
                 result[k] = float(v)
         return result
     if hasattr(action, "tolist"):
+        # ``tolist()`` flattens an ndarray/tensor to nested Python lists, but a
+        # numpy/torch *scalar* or 0-d array returns a bare Python number, not a
+        # list -- enumerating that raises ``'float' object is not iterable``.
+        # Treat a non-list result as a single-DOF scalar so a 1-DOF leader does
+        # not crash the teleop loop.
         arr = action.tolist()
-        return {f"j{i}": float(v) for i, v in enumerate(arr)}
+        if isinstance(arr, list):
+            return {f"j{i}": float(v) for i, v in enumerate(arr)}
+        return {"raw": float(arr)}
     return {"raw": float(action)}
 
 

--- a/tests/mesh/test_input_publisher_chokepoint.py
+++ b/tests/mesh/test_input_publisher_chokepoint.py
@@ -78,3 +78,36 @@ def test_publisher_frame_count_matches_chokepoint_calls() -> None:
     # Frames the publisher claims it sent all went through the chokepoint.
     assert stats["frames"] == len(mesh.published)
     assert all(k == "strands/pub-2/input/gamepad" for k, _ in mesh.published)
+
+
+def test_normalize_action_dict_floats_each_value() -> None:
+    """A dict action keeps its keys, coercing every value to float."""
+    import numpy as np
+
+    out = InputPublisher._normalize_action({"shoulder.pos": np.float32(1.5), "j0": 2})
+    assert out == {"shoulder.pos": 1.5, "j0": 2.0}
+
+
+def test_normalize_action_array_becomes_positional_keys() -> None:
+    """A 1-D array action becomes positional ``jN`` keys."""
+    import numpy as np
+
+    assert InputPublisher._normalize_action(np.array([1.0, 2.0, 3.0])) == {
+        "j0": 1.0,
+        "j1": 2.0,
+        "j2": 3.0,
+    }
+
+
+def test_normalize_action_scalar_does_not_crash() -> None:
+    """A numpy/torch scalar or 0-d array exposes ``tolist()`` that returns a
+    bare Python number, not a list. Enumerating it raises
+    ``'float' object is not iterable``; a 1-DOF leader must not crash the
+    input stream. Such a value normalizes to the single-DOF ``{"raw": ...}``
+    shape, matching the plain-Python-scalar fallback.
+    """
+    import numpy as np
+
+    assert InputPublisher._normalize_action(2.0) == {"raw": 2.0}
+    assert InputPublisher._normalize_action(np.float32(1.5)) == {"raw": 1.5}
+    assert InputPublisher._normalize_action(np.array(1.5)) == {"raw": 1.5}

--- a/tests/test_teleop.py
+++ b/tests/test_teleop.py
@@ -155,6 +155,32 @@ def test_infer_method():
     assert _infer_method("phone") == "phone"
 
 
+def test_normalize_action_dict_and_array():
+    """Dict values are floated per-key; an array becomes positional j-keys."""
+    import numpy as np
+
+    from strands_robots.teleop_mixin import _normalize_action
+
+    assert _normalize_action({"shoulder.pos": np.float32(1.5)}) == {"shoulder.pos": 1.5}
+    assert _normalize_action(np.array([1.0, 2.0, 3.0])) == {"j0": 1.0, "j1": 2.0, "j2": 3.0}
+
+
+def test_normalize_action_scalar_does_not_crash():
+    """A numpy/torch scalar or 0-d array exposes ``tolist()`` that returns a
+    bare Python number, not a list. Enumerating that raises
+    ``'float' object is not iterable`` -- a 1-DOF leader must not crash the
+    teleop loop. Such a value normalizes to the single-DOF ``{"raw": ...}``
+    shape, matching the plain-Python-scalar fallback.
+    """
+    import numpy as np
+
+    from strands_robots.teleop_mixin import _normalize_action
+
+    assert _normalize_action(2.0) == {"raw": 2.0}
+    assert _normalize_action(np.float32(1.5)) == {"raw": 1.5}
+    assert _normalize_action(np.array(1.5)) == {"raw": 1.5}
+
+
 # ---------------------------------------------------------------------------
 # teleoperate loop
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem
Both teleop action normalizers crash when a teleoperator returns a single-DOF action as a numpy/torch scalar or 0-d array.

`TeleopMixin._normalize_action` (`strands_robots/teleop_mixin.py`) and `InputPublisher._normalize_action` (`strands_robots/mesh/input.py`) route any object exposing `tolist()` through the array branch and enumerate the result:

```python
if hasattr(action, "tolist"):
    arr = action.tolist()
    return {f"j{i}": float(v) for i, v in enumerate(arr)}
```

But `tolist()` on a numpy/torch **scalar or 0-d array** returns a bare Python number, not a list, so `enumerate()` raises:

```
TypeError: 'float' object is not iterable
```

A 1-DOF leader (e.g. a gripper-only or single-joint device) that emits `np.float32(x)` or `np.array(x)` therefore crashes the hot teleop loop / mesh input stream rather than actuating. The two functions are documented to mirror each other, so the bug is duplicated in both the local and mesh paths.

## Change
After calling `tolist()`, only enumerate when the result is actually a `list`; otherwise treat it as a single-DOF scalar and normalize to the `{"raw": float}` shape that already handles plain Python scalars. Applied to both normalizers so the local and mesh wire shapes stay in agreement.

## Behavior
| input | before | after |
|---|---|---|
| `{"shoulder.pos": np.float32(1.5)}` | `{"shoulder.pos": 1.5}` | `{"shoulder.pos": 1.5}` |
| `np.array([1.0, 2.0, 3.0])` | `{"j0": 1.0, "j1": 2.0, "j2": 3.0}` | unchanged |
| `2.0` | `{"raw": 2.0}` | unchanged |
| `np.float32(1.5)` | **TypeError** | `{"raw": 1.5}` |
| `np.array(1.5)` | **TypeError** | `{"raw": 1.5}` |

## Tests
Regression tests pinned in both code paths (`tests/test_teleop.py`, `tests/mesh/test_input_publisher_chokepoint.py`); each fails pre-fix with the exact `TypeError` and passes after. Full teleop + mesh + hardware-lifecycle suites green (1796 passed). Lint/format/mypy clean over `strands_robots tests tests_integ`.

Pure logic fix on the action-normalization path; no policy, sim, render, recording, or asset behavior changes.