### PR TITLE
test(registry): isolate registry tests from the on-disk user overlay

### DIFF
--- a/tests/registry/conftest.py
+++ b/tests/registry/conftest.py
@@ -1,0 +1,39 @@
+"""Isolation fixtures shared by every ``tests/registry`` module.
+
+The registry read API (``list_robots``, ``format_robot_table``,
+``resolve_name``, ``get_robot``) merges the user-local overlay
+(``$STRANDS_BASE_DIR/user_robots.json``, defaulting to
+``~/.strands_robots/user_robots.json``) on top of the package
+``robots.json`` - see ``loader._merge_user_robots``. Registering a custom
+robot is an explicitly supported, documented workflow, so a developer's
+machine may legitimately hold user robots whose descriptions contain
+non-ASCII text or extra entries.
+
+Without isolation those host robots leak into assertions like
+``format_robot_table().isascii()`` or exact registry counts, making the
+suite pass on clean CI yet fail locally. Worse, any test that calls
+``register_robot`` / ``unregister_robot`` would mutate the real user home.
+
+This autouse fixture repoints both ``STRANDS_BASE_DIR`` (user registry +
+metadata) and ``STRANDS_ASSETS_DIR`` (asset cache) at per-test temp dirs and
+invalidates the loader cache on entry and exit, so every registry test sees
+the package registry plus only the robots it registers itself.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from strands_robots.registry.user_registry import _invalidate_cache
+
+
+@pytest.fixture(autouse=True)
+def _isolate_user_registry(tmp_path, monkeypatch):
+    """Point user-registry + asset paths at temp dirs for every registry test."""
+    assets_dir = tmp_path / "assets"
+    assets_dir.mkdir()
+    monkeypatch.setenv("STRANDS_BASE_DIR", str(tmp_path))
+    monkeypatch.setenv("STRANDS_ASSETS_DIR", str(assets_dir))
+    _invalidate_cache()
+    yield
+    _invalidate_cache()

--- a/tests/registry/test_user_overlay_isolation.py
+++ b/tests/registry/test_user_overlay_isolation.py
@@ -1,0 +1,57 @@
+"""Registry read tests must not observe the host's on-disk user overlay.
+
+The registry read API merges ``$STRANDS_BASE_DIR/user_robots.json`` on top of
+the package ``robots.json``. Because registering a custom robot is a supported
+workflow, a contributor's machine can hold user robots whose descriptions
+contain non-ASCII text - which would silently leak into assertions such as
+``format_robot_table().isascii()`` or exact registry counts. The package-level
+``conftest`` isolates ``STRANDS_BASE_DIR`` per test; these tests pin that
+guarantee so the suite stays deterministic regardless of the host.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from strands_robots.registry import (
+    format_robot_table,
+    list_robots,
+    register_robot,
+)
+from strands_robots.utils import get_assets_dir, get_base_dir
+
+_MINIMAL_MJCF = '<mujoco><worldbody><body><geom size="0.1"/></body></worldbody></mujoco>'
+
+
+def test_base_dir_is_isolated_from_real_home():
+    """The user-registry base dir must point at a per-test temp area, not the
+    real ``~/.strands_robots`` (where host-registered robots live)."""
+    base = get_base_dir()
+    real_home_registry = Path.home() / ".strands_robots"
+    assert base != real_home_registry
+
+
+def test_host_user_robots_do_not_leak_into_table():
+    """A non-ASCII user description registered *inside* a test stays confined
+    to that test rather than leaking from (or into) the shared real home.
+
+    This reproduces the exact entry that previously broke
+    ``test_table_is_pure_ascii`` when the suite read the host overlay."""
+    asset_dir = get_assets_dir() / "iso_probe_bot"
+    asset_dir.mkdir(parents=True, exist_ok=True)
+    (asset_dir / "iso_probe_bot.xml").write_text(_MINIMAL_MJCF)
+
+    register_robot(
+        name="iso_probe_bot",
+        model_xml="iso_probe_bot.xml",
+        description="probe \u2014 em-dash description",
+        category="arm",
+        joints=6,
+    )
+    table = format_robot_table(max_width=1000)
+    # Inside this test the registered robot is visible (proves the merge path)...
+    assert "iso_probe_bot" in table
+    assert not table.isascii()
+    # ...and it is the overlay entry, not something baked into the package JSON.
+    names = {r["name"] for r in list_robots()}
+    assert "iso_probe_bot" in names

--- a/tests/registry/test_user_registry.py
+++ b/tests/registry/test_user_registry.py
@@ -17,7 +17,6 @@ import pytest
 from strands_robots.registry import get_robot, list_robots, resolve_name
 from strands_robots.registry.user_registry import (
     _get_user_registry_path,
-    _invalidate_cache,
     _load_user_registry,
     get_user_robots,
     list_user_robots,
@@ -31,23 +30,6 @@ from strands_robots.utils import get_assets_dir, get_base_dir, resolve_asset_pat
 # (section)
 
 _MINIMAL_MJCF = '<mujoco><worldbody><body><geom size="0.1"/></body></worldbody></mujoco>'
-
-
-@pytest.fixture(autouse=True)
-def _isolate_registry(tmp_path, monkeypatch):
-    """Point STRANDS_BASE_DIR + STRANDS_ASSETS_DIR to temp dirs for every test.
-
-    ``STRANDS_BASE_DIR`` controls where ``user_robots.json`` lives.
-    ``STRANDS_ASSETS_DIR`` controls where robot asset directories live.
-    The two are independent - the base dir is not derived from the assets dir.
-    """
-    assets_dir = tmp_path / "assets"
-    assets_dir.mkdir()
-    monkeypatch.setenv("STRANDS_BASE_DIR", str(tmp_path))
-    monkeypatch.setenv("STRANDS_ASSETS_DIR", str(assets_dir))
-    _invalidate_cache()
-    yield
-    _invalidate_cache()
 
 
 def _make_robot(parent: Path, name: str = "test_bot", xml_name: str = "bot.xml") -> Path:


### PR DESCRIPTION
## What

Make the `tests/registry` suite deterministic regardless of the developer's machine by isolating it from the on-disk user-robot overlay. Adds a package-scoped autouse `conftest` fixture, removes a now-redundant duplicate local fixture, and pins the guarantee with a focused regression test. Tests-only - no production code changes.

## Why

The registry read API (`list_robots`, `format_robot_table`, `resolve_name`, `get_robot`) merges the user-local overlay `$STRANDS_BASE_DIR/user_robots.json` (default `~/.strands_robots/user_robots.json`) on top of the package `robots.json` via `loader._merge_user_robots`. Registering a custom robot is an explicitly supported, documented workflow (`register_robot`), so a contributor's machine can legitimately hold user robots whose descriptions contain non-ASCII text or extra entries.

The `tests/registry` suite read that merged view without isolation, so it was non-deterministic:

- A locally-registered robot with a non-ASCII description (e.g. an em-dash) makes `format_robot_table()` no longer pure-ASCII, breaking `test_table_is_pure_ascii`.
- Any exact registry-count assertion drifts by the number of user robots.
- Tests that call `register_robot` / `unregister_robot` without isolation would mutate the real user home.

The suite stays green on clean CI (no user overlay) but fails on a real workstation that has used the documented registration feature - exactly the kind of false negative that erodes trust in the suite.

## Change

- Add `tests/registry/conftest.py` with an autouse fixture that repoints `STRANDS_BASE_DIR` (user registry + metadata) and `STRANDS_ASSETS_DIR` (asset cache) at per-test temp dirs and invalidates the loader cache on entry/exit. Every registry test now sees the package registry plus only the robots it registers itself.
- Remove the identical local `_isolate_registry` fixture from `test_user_registry.py` now that the package conftest provides it (single source of truth - no duplicate fixture).
- Add `tests/registry/test_user_overlay_isolation.py` pinning the invariant: the user-registry base dir must not resolve to the real `~/.strands_robots`, and a non-ASCII robot registered inside a test is confined to that test (proving the merge path works yet stays isolated).

## Tests

The two new isolation tests fail against the pre-change tree (base dir resolves to the real home; a registered non-ASCII robot leaks into the rendered table) and pass after. Full `tests/registry` package: 456 passed. Full unit suite (`MUJOCO_GL=egl`, excluding gpu/slow/integration/moveit2/Rendering): 6910 passed, only the 2 pre-existing `libtorchcodec`-load failures in `test_recording_paths.py` remain, unrelated to this change. Lint clean: `ruff check`, `ruff format --check`, and `mypy` over `strands_robots tests tests_integ` all pass.
