### PR TITLE
test(training): pin validate_train_inputs LLM-input-safety boundary

### DIFF
--- a/tests/training/test_validate.py
+++ b/tests/training/test_validate.py
@@ -17,6 +17,8 @@ in the boundary surfaces immediately and independently of any backend.
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from strands_robots.training import TrainSpec
@@ -29,7 +31,7 @@ def _spec(tmp_path, **overrides) -> TrainSpec:
     Defaults resolve to real tmp paths so the audited path check passes,
     letting each test isolate a single vector via ``overrides``.
     """
-    base = {
+    base: dict[str, Any] = {
         "dataset_root": str(tmp_path / "data"),
         "base_model": "lerobot/act_aloha",
         "output_dir": str(tmp_path / "out"),

--- a/tests/training/test_validate.py
+++ b/tests/training/test_validate.py
@@ -1,0 +1,137 @@
+"""Direct regression tests for the training LLM-input-safety gate.
+
+``strands_robots.training._validate.validate_train_inputs`` is the single
+source of input-safety truth for every training backend: each concrete
+:class:`~strands_robots.training.base.Trainer` calls it (fail-closed) before a
+``TrainSpec`` reaches backend config / argv-parity helpers. Per AGENTS.md >
+Review Learnings (#92) > "LLM Input Safety", the path fields and the free-form
+``extra`` dict are untrusted input that reaches backend internals, so this gate
+is a security boundary.
+
+Until now the gate was exercised only *indirectly* (through each backend's
+``Trainer.validate``), and those orchestration tests skip/fail when an optional
+backend dep (e.g. ``lerobot``) is absent. These tests pin each documented
+attack vector directly against the dependency-free validator, so a regression
+in the boundary surfaces immediately and independently of any backend.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from strands_robots.training import TrainSpec
+from strands_robots.training._validate import validate_train_inputs
+
+
+def _spec(tmp_path, **overrides) -> TrainSpec:
+    """A clean, fully-valid TrainSpec with the given fields overridden.
+
+    Defaults resolve to real tmp paths so the audited path check passes,
+    letting each test isolate a single vector via ``overrides``.
+    """
+    base = {
+        "dataset_root": str(tmp_path / "data"),
+        "base_model": "lerobot/act_aloha",
+        "output_dir": str(tmp_path / "out"),
+        "embodiment": "so101",
+    }
+    base.update(overrides)
+    return TrainSpec(**base)
+
+
+class TestCleanSpec:
+    def test_clean_spec_has_no_problems(self, tmp_path):
+        assert validate_train_inputs(_spec(tmp_path)) == []
+
+    def test_optional_fields_unset_is_clean(self, tmp_path):
+        # embodiment is optional (None) and must be skipped, not flagged.
+        spec = _spec(tmp_path, embodiment=None, extra={})
+        assert validate_train_inputs(spec) == []
+
+    def test_dotted_extra_keys_are_clean(self, tmp_path):
+        # The documented escape hatch: dotted/underscored lowercase keys.
+        spec = _spec(
+            tmp_path,
+            extra={"policy_type": "act", "dataset.episodes": [0, 1], "model.x.y": 1},
+        )
+        assert validate_train_inputs(spec) == []
+
+
+class TestPathFields:
+    def test_null_byte_in_path_rejected(self, tmp_path):
+        spec = _spec(tmp_path, dataset_root="/tmp/data\x00/evil")
+        problems = validate_train_inputs(spec)
+        assert len(problems) == 1
+        assert "invalid characters" in problems[0]
+
+    def test_traversal_in_path_rejected(self, tmp_path):
+        spec = _spec(tmp_path, output_dir="../../etc")
+        problems = validate_train_inputs(spec)
+        assert len(problems) == 1
+        assert "traversal" in problems[0]
+
+    def test_protected_system_dir_rejected(self, tmp_path):
+        spec = _spec(tmp_path, dataset_root="/etc/passwd")
+        problems = validate_train_inputs(spec)
+        assert len(problems) == 1
+        assert "protected system directory" in problems[0]
+
+
+class TestFlagBoundDashGuard:
+    @pytest.mark.parametrize("field", ["base_model", "embodiment"])
+    def test_leading_dash_rejected_on_non_path_fields(self, tmp_path, field):
+        # base_model / embodiment are flag-bound but NOT path-checked, so a
+        # leading dash is the only vector and must trip exactly one problem.
+        spec = _spec(tmp_path, **{field: "--config_path=/etc/passwd"})
+        problems = validate_train_inputs(spec)
+        assert len(problems) == 1
+        assert field in problems[0]
+        assert "must not start with '-'" in problems[0]
+
+    def test_path_field_leading_dash_is_dash_only(self, tmp_path):
+        # output_dir is on BOTH the path list and the flag list. A safe value
+        # that merely starts with '-' clears the path check (no null, no '..',
+        # not a protected dir) and trips ONLY the dash check.
+        spec = _spec(tmp_path, output_dir="-o")
+        problems = validate_train_inputs(spec)
+        assert len(problems) == 1
+        assert "output_dir" in problems[0]
+        assert "must not start with '-'" in problems[0]
+
+
+class TestExtraKeyAllowlist:
+    @pytest.mark.parametrize(
+        "key",
+        ["policy_type", "dataset.episodes", "model.x.y", "a", "lr_scheduler"],
+    )
+    def test_allowed_extra_keys(self, tmp_path, key):
+        assert validate_train_inputs(_spec(tmp_path, extra={key: 1})) == []
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "--steps",  # leading dash -> stray flag
+            "Steps",  # uppercase
+            "policy=act",  # embedded '='
+            "my key",  # whitespace
+            "1step",  # leading digit
+            ".leading_dot",  # leading dot
+            "",  # empty
+        ],
+    )
+    def test_rejected_extra_keys(self, tmp_path, key):
+        spec = _spec(tmp_path, extra={key: 1})
+        problems = validate_train_inputs(spec)
+        assert len(problems) == 1
+        assert repr(key) in problems[0]
+        assert "not allowed" in problems[0]
+
+
+class TestAccumulation:
+    def test_independent_problems_accumulate(self, tmp_path):
+        # A bad path AND a bad extra key are independent checks; both report.
+        spec = _spec(tmp_path, dataset_root="/etc/passwd", extra={"--bad": 1})
+        problems = validate_train_inputs(spec)
+        assert len(problems) == 2
+        assert any("protected system directory" in p for p in problems)
+        assert any("not allowed" in p for p in problems)


### PR DESCRIPTION
## Summary

Adds direct regression tests for `strands_robots/training/_validate.py::validate_train_inputs` — the single source of input-safety truth that every backend `Trainer.validate` calls fail-closed before a `TrainSpec` reaches backend config or argv-parity helpers.

Per the LLM Input Safety review learning (#92), the `TrainSpec` path fields and the free-form `extra` dict are untrusted input that reaches backend internals, so this validator is a security boundary. Until now it was exercised **only indirectly** through each backend's orchestration path — and those tests skip or fail when an optional backend dependency (e.g. `lerobot`) is absent. This converts the boundary into a direct, fast, dependency-free regression suite.

## What this pins

- **Path fields** (`dataset_root` / `output_dir`): null byte, `..` traversal, and protected-system-directory rejection (delegated to `validate_save_path`).
- **Flag-bound scalars** (`base_model` / `embodiment`): leading-dash stray-flag guard — `base_model="--config_path=/etc/passwd"` must not parse as a separate flag.
- **Dual-checked field**: `output_dir` is on both the path list and the flag list; a value that merely starts with `-` clears the path check and trips **only** the dash check (pins that the loops do not double-report or mis-order).
- **`extra`-key allowlist** (`^[a-z][a-z0-9_.]*$`): dotted/underscored lowercase keys accepted (the documented escape hatch); leading dash, uppercase, embedded `=`, whitespace, leading digit/dot, and empty key rejected.
- **Accumulation**: independent problems (bad path + bad extra key) both report.
- **Clean-spec anchor**: a fully-valid spec yields `[]`, so tightening the regex in a way that breaks the documented `extra` escape hatch fails loudly.

## Scope

Test-only; **no source changes**. Cross-platform (substring assertions, no `sys.platform` guards). `_validate.py` reaches 100% line coverage; suite runs in ~1.4s with no optional deps installed. Deliberately does not re-test `_path_validation.py`'s own matrix — that is a separate module with its own tests; this asserts only the delegated behavior surfacing through the gate.

## Verification

```
$ python -m pytest tests/training/test_validate.py -q
22 passed in 1.36s
$ python -m ruff check tests/training/test_validate.py   # All checks passed!
$ python -m ruff format --check tests/training/test_validate.py  # clean
```

## Review iterations

**Round 1** (CI feedback): mypy in `call-test-lint` rejected the `TrainSpec(**base)` splat in the `_spec` helper. The defaults dict was built from string literals, so mypy inferred `dict[str, str]` and flagged every non-str `TrainSpec` field (`int`/`float`/`bool`/`dict`) on the splat (7 errors, all line 39). Annotated `base: dict[str, Any]` so overrides of typed fields type-check, matching how `TrainSpec` accepts heterogeneous kwargs. Still test-only; no production behavior change. Locally re-verified: `mypy` clean, `ruff` clean, 22 passed.