### PR TITLE
fix(molmoact2): guard auxiliary deps with an actionable extra hint

### DIFF
--- a/strands_robots/policies/lerobot_local/molmoact2.py
+++ b/strands_robots/policies/lerobot_local/molmoact2.py
@@ -43,9 +43,18 @@ import json
 import logging
 from typing import Any
 
+from ...utils import require_optional
+
 logger = logging.getLogger(__name__)
 
 MOLMOACT2_TYPE = "molmoact2"
+
+#: Auxiliary runtime deps the MolmoAct2 modeling/processor code imports on top of
+#: lerobot core. They ship in the ``strands-robots[molmoact2]`` extra. lerobot's
+#: own ``require_package`` raises pointing at ``lerobot[transformers-dep]`` deep
+#: inside model construction, which is a dead end for a strands-robots caller --
+#: guard them up front so the error names the extra actually installed from.
+_MOLMOACT2_RUNTIME_DEPS = ("transformers", "peft", "scipy")
 
 # Sensible default camera feature keys (match the ``so_real`` / ``so101``
 # embodiments' obs_rename targets). Overridable via ``image_keys=``.
@@ -224,7 +233,16 @@ def build_policy(
 
     Returns:
         Tuple ``(policy, preprocessor, postprocessor, config)``.
+
+    Raises:
+        ImportError: If an auxiliary MolmoAct2 dep (transformers/peft/scipy) is
+            missing, with an install hint naming the ``strands-robots[molmoact2]``
+            extra (rather than lerobot's internal extra, which a strands-robots
+            caller never installed from).
     """
+    for _dep in _MOLMOACT2_RUNTIME_DEPS:
+        require_optional(_dep, extra="molmoact2", purpose="MolmoAct2 inference")
+
     import torch
 
     try:

--- a/tests/policies/lerobot_local/test_molmoact2.py
+++ b/tests/policies/lerobot_local/test_molmoact2.py
@@ -395,3 +395,76 @@ class TestBuildPolicy:
         msg = str(excinfo.value)
         assert "strands-robots[molmoact2]" in msg
         assert "PR #3604" in msg
+
+
+class TestBuildPolicyDependencyGuard:
+    """``build_policy`` must guard its auxiliary deps up front with an error that
+    names the ``strands-robots[molmoact2]`` extra.
+
+    Without the guard the first missing dep (e.g. ``transformers``) only surfaces
+    deep inside lerobot's own model construction, where ``require_package``
+    raises ``'transformers' is required ... pip install 'lerobot[transformers-dep]'``
+    -- a dead end for a caller who installed ``strands-robots[molmoact2]`` and
+    never touched lerobot's extras directly. The guard turns that into an
+    actionable, correctly-attributed error before any heavy import runs.
+    """
+
+    def test_missing_dep_raises_naming_strands_extra(self, monkeypatch):
+        """A missing runtime dep aborts with the strands-robots extra in the hint."""
+        called: list[tuple[str, str | None]] = []
+
+        def fake_require_optional(module_name, *, pip_install=None, extra=None, purpose=""):
+            called.append((module_name, extra))
+            if module_name == "transformers":
+                raise ImportError(
+                    f"'{module_name}' is required for {purpose}\n"
+                    "Install with:\n"
+                    f"  pip install 'strands-robots[{extra}]'\n"
+                    f"  pip install {pip_install or module_name}"
+                )
+
+        monkeypatch.setattr(molmoact2, "require_optional", fake_require_optional)
+
+        with pytest.raises(ImportError) as exc:
+            molmoact2.build_policy(
+                "allenai/MolmoAct2-SO100_101",
+                device="cpu",
+                norm_tag="t",
+                inference_action_mode="continuous",
+                image_keys=None,
+                embodiment_spec=None,
+            )
+
+        msg = str(exc.value)
+        assert "strands-robots[molmoact2]" in msg
+        assert "transformers" in msg
+        # The guard runs before any heavy torch/lerobot import: transformers is
+        # the first dep checked, so the failure is attributed to it directly.
+        assert called[0] == ("transformers", "molmoact2")
+
+    def test_all_runtime_deps_are_guarded(self, monkeypatch):
+        """Every auxiliary dep is checked against the molmoact2 extra up front."""
+        checked: list[tuple[str, str | None]] = []
+
+        def fake_require_optional(module_name, *, pip_install=None, extra=None, purpose=""):
+            checked.append((module_name, extra))
+            # Return after recording so the guard loop completes; then stop the
+            # heavy build by failing the first lerobot import deterministically.
+
+        monkeypatch.setattr(molmoact2, "require_optional", fake_require_optional)
+        # Make the post-guard lerobot import fail predictably so the test does
+        # not reach real model construction.
+        monkeypatch.setattr(molmoact2, "auto_norm_tag", lambda *_a, **_k: (_ for _ in ()).throw(RuntimeError("stop")))
+
+        with pytest.raises((RuntimeError, ImportError)):
+            molmoact2.build_policy(
+                "repo",
+                device="cpu",
+                norm_tag="t",
+                inference_action_mode="continuous",
+                image_keys=None,
+                embodiment_spec=None,
+            )
+
+        assert [name for name, _ in checked] == list(molmoact2._MOLMOACT2_RUNTIME_DEPS)
+        assert all(extra == "molmoact2" for _, extra in checked)


### PR DESCRIPTION
## Problem

`LerobotLocalPolicy` runs `allenai/MolmoAct2-*` checkpoints through `lerobot_local.molmoact2.build_policy`, which builds the policy via lerobot's factory. That code imports the auxiliary MolmoAct2 deps (`transformers`, `peft`, `scipy`) lazily, deep inside lerobot's own model/processor construction. When one is missing, lerobot's internal `require_package` raises:

```
'transformers' is required but not installed. Install it with: pip install 'lerobot[transformers-dep]'
```

That hint is a dead end for a `strands-robots` caller: they installed `strands-robots[molmoact2]` (which already pulls transformers/peft/scipy) and never touched lerobot's extras directly. The message points at the wrong package and the wrong extra, and only fires after a chain of heavy imports.

The wrapper already guards the lerobot *version* up front (clear ImportError if `lerobot.policies.factory` lacks `MolmoAct2Policy`) but never guarded its *deps* — an asymmetry that left this one failure mode unattributed.

## Change

`build_policy` now checks the three auxiliary runtime deps up front via the existing `require_optional(..., extra="molmoact2")` helper, before any heavy torch/lerobot import:

```
'transformers' is required for MolmoAct2 inference
Install with:
  pip install 'strands-robots[molmoact2]'
  pip install transformers
```

The deps are listed in a module constant `_MOLMOACT2_RUNTIME_DEPS = ("transformers", "peft", "scipy")`, mirroring the `[molmoact2]` extra in `pyproject.toml`. No behavior change on the happy path; this only converts an opaque downstream failure into an actionable, correctly-attributed one.

## Tests

Added `TestBuildPolicyDependencyGuard` (2 tests) in `tests/policies/lerobot_local/test_molmoact2.py`:
- a missing dep raises an `ImportError` naming `strands-robots[molmoact2]`, and the guard runs before any heavy import;
- every dep in `_MOLMOACT2_RUNTIME_DEPS` is checked against the `molmoact2` extra.

Both FAIL on pre-fix code (the module had no `require_optional` symbol to guard with) and PASS after. Full suite: `39 passed` across `test_molmoact2.py` + `test_molmoact2_loadpath.py`. Lint/format/mypy clean on `strands_robots tests tests_integ`.

No visual artifact: this is an error-path/ergonomics change with no policy, sim, render, or recording behavior change.