### PR TITLE
fix(sim): fail loudly when stop_recording captures no frames

### DIFF
--- a/strands_robots/simulation/mujoco/recording.py
+++ b/strands_robots/simulation/mujoco/recording.py
@@ -284,6 +284,13 @@ class RecordingMixin:
         idempotent - calling when not recording succeeds with a
         'Was not recording' message so callers can safely call it unconditionally.
 
+        Returns a structured ``status="error"`` when the recording captured no
+        frames (the dataset would contain only ``meta/info.json``), rather than
+        silently writing an empty dataset. Only ``run_policy`` feeds the active
+        recorder (via its ``on_frame`` hook); ``eval_policy`` / ``evaluate`` /
+        ``replay_episode`` and bare ``step`` loops do not, so recording around
+        those produces zero frames and is reported as an error.
+
         Args:
             output_path: Unused legacy arg (kept for back-compat).
             push_to_hub: Publish to a versioned HF *dataset* repo (the finished
@@ -303,7 +310,62 @@ class RecordingMixin:
         if recorder is None:
             return {"status": "error", "content": [{"text": "No dataset recorder active."}]}
 
-        recorder.save_episode()
+        # Save the trailing (unsaved) episode, then guard against an empty
+        # dataset. ``episode_frame_count`` is the frames captured since the last
+        # save_episode; ``frame_count`` is the monotonic total across the
+        # dataset. Three cases:
+        #
+        #   1. Unsaved frames pending (episode_frame_count > 0): flush them with
+        #      save_episode. If LeRobot rejects the flush, surface the error.
+        #   2. No pending frames but the dataset already has some (callers that
+        #      save per-episode and call stop_recording last): nothing to flush,
+        #      just finalize - calling save_episode here would hit LeRobot's
+        #      "add frames before add_episode" guard on the empty buffer and
+        #      wrongly fail an otherwise-complete dataset.
+        #   3. Nothing ever captured (frame_count == 0): fail loudly instead of
+        #      writing a 0-frame dataset. This happens when the rollout was
+        #      driven by eval_policy / evaluate / replay_episode or a bare step
+        #      loop - none of which feed the active recorder (only run_policy's
+        #      on_frame hook calls add_frame). Previously stop_recording reported
+        #      success with "0 frames, 0 episode(s)", silently producing a
+        #      dataset with only meta/info.json (no parquet/video).
+        pending = getattr(recorder, "episode_frame_count", 0)
+        captured = getattr(recorder, "frame_count", 0)
+        if pending > 0:
+            save_result = recorder.save_episode()
+            if isinstance(save_result, dict) and save_result.get("status") == "error":
+                self._world._backend_state["dataset_recorder"] = None
+                self._world._backend_state["trajectory"] = []
+                return {
+                    "status": "error",
+                    "content": [
+                        {
+                            "text": (
+                                "stop_recording failed to save the final episode "
+                                f"({pending} pending frames). save_episode: "
+                                f"{save_result.get('message')}"
+                            )
+                        }
+                    ],
+                }
+        elif captured == 0:
+            self._world._backend_state["dataset_recorder"] = None
+            self._world._backend_state["trajectory"] = []
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            "stop_recording captured no frames - dataset would be empty "
+                            "(0 frames). Frames are written only by run_policy(...) while "
+                            "recording is active (its on_frame hook calls add_frame). "
+                            "eval_policy / evaluate / replay_episode and bare step loops do "
+                            "NOT feed the recorder. To record a dataset: start_recording -> "
+                            "run_policy (once per episode) -> stop_recording."
+                        )
+                    }
+                ],
+            }
 
         repo_id = recorder.repo_id
         frame_count = recorder.frame_count

--- a/tests/simulation/mujoco/test_stop_recording_finalize.py
+++ b/tests/simulation/mujoco/test_stop_recording_finalize.py
@@ -28,19 +28,33 @@ from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
 class _FakeRecorder:
     """Minimal stand-in for ``DatasetRecorder`` capturing orchestration order."""
 
-    def __init__(self, *, sync_result=None, push_result=None):
+    def __init__(
+        self,
+        *,
+        sync_result=None,
+        push_result=None,
+        save_result=None,
+        frame_count=7,
+        episode_frame_count=7,
+    ):
         self.repo_id = "local/finalize_test"
-        self.frame_count = 7
+        self.frame_count = frame_count
+        # Frames captured since the last save_episode (the pending trailing
+        # episode). stop_recording only flushes a final save_episode when this
+        # is > 0; see RecordingMixin.stop_recording.
+        self.episode_frame_count = episode_frame_count
         self.episode_count = 1
         self.root = "/tmp/finalize_test"
         self.calls: list[str] = []
         self._sync_result = sync_result
         self._push_result = push_result
+        self._save_result = save_result
         self.sync_args: tuple | None = None
         self.push_tags = None
 
     def save_episode(self):
         self.calls.append("save_episode")
+        return self._save_result
 
     def finalize(self):
         self.calls.append("finalize")
@@ -139,3 +153,91 @@ class TestStopRecordingFinalize:
         result = recording_sim.stop_recording(push_to_hub=True)
         assert result["status"] == "success"
         assert "push_to_hub FAILED: auth denied" in result["content"][0]["text"]
+
+
+class TestStopRecordingEmptyDataset:
+    """stop_recording must fail loudly when no frames were captured, but must
+    NOT fail a dataset that was filled via per-episode save_episode.
+
+    Regression for the silent empty-dataset bug. A recording driven by a path
+    that never feeds the dataset recorder (eval_policy / evaluate /
+    replay_episode / a bare step loop - only run_policy's on_frame hook calls
+    add_frame) leaves the recorder with zero frames. Previously stop_recording
+    called save_episode unconditionally, discarded its error return, and
+    reported success with "0 frames, 0 episode(s)", producing a dataset with
+    only meta/info.json (no parquet/video).
+
+    The fix distinguishes three cases by frame counters:
+      1. pending unsaved frames -> flush them (save_episode), surface errors;
+      2. no pending frames but dataset non-empty -> finalize only (do not
+         re-call save_episode on an empty buffer);
+      3. nothing ever captured -> structured error, no empty dataset.
+    """
+
+    def test_empty_recording_reports_error(self, recording_sim):
+        # frame_count == 0 and no pending frames -> loud empty-dataset error.
+        rec = _FakeRecorder(frame_count=0, episode_frame_count=0)
+        _arm(recording_sim, rec)
+        result = recording_sim.stop_recording()
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert "captured no frames" in text
+        assert "0 frames" in text
+        # actionable guidance: point to the only path that records frames.
+        assert "run_policy" in text
+        # save_episode must NOT be called on the empty buffer.
+        assert rec.calls == []
+
+    def test_empty_recording_does_not_finalize_or_upload(self, recording_sim):
+        rec = _FakeRecorder(
+            frame_count=0,
+            episode_frame_count=0,
+            push_result={"status": "success"},
+        )
+        _arm(recording_sim, rec, push_to_hub=True)
+        result = recording_sim.stop_recording(push_to_hub=True)
+        assert result["status"] == "error"
+        # No finalize / no upload after an empty recording.
+        assert rec.calls == []
+        assert "finalize" not in rec.calls
+        assert "push_to_hub" not in rec.calls
+
+    def test_empty_recording_clears_state_for_clean_retry(self, recording_sim):
+        rec = _FakeRecorder(frame_count=0, episode_frame_count=0)
+        _arm(recording_sim, rec)
+        recording_sim.stop_recording()
+        # Recorder + buffer cleared so a subsequent stop is the idempotent no-op.
+        assert recording_sim._world._backend_state["dataset_recorder"] is None
+        assert recording_sim._world._backend_state["recording"] is False
+        second = recording_sim.stop_recording()
+        assert second["status"] == "success"
+        assert "Was not recording" in second["content"][0]["text"]
+
+    def test_trailing_save_episode_failure_is_surfaced(self, recording_sim):
+        # Pending frames exist but the final save_episode flush fails.
+        rec = _FakeRecorder(
+            frame_count=12,
+            episode_frame_count=12,
+            save_result={"status": "error", "message": "writer broke"},
+        )
+        _arm(recording_sim, rec)
+        result = recording_sim.stop_recording()
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert "final episode" in text
+        assert "writer broke" in text
+        # Flush was attempted; no finalize/upload after a failed flush.
+        assert rec.calls == ["save_episode"]
+
+    def test_dataset_filled_per_episode_finalizes_without_re_saving(self, recording_sim):
+        # Caller saved each episode already (episode_frame_count == 0) and the
+        # dataset has frames. stop_recording must finalize WITHOUT calling
+        # save_episode again - the previous bug re-saved the empty buffer and
+        # wrongly errored an otherwise-complete dataset.
+        rec = _FakeRecorder(frame_count=90, episode_frame_count=0)
+        _arm(recording_sim, rec)
+        result = recording_sim.stop_recording()
+        assert result["status"] == "success"
+        assert rec.calls == ["finalize"]
+        assert "save_episode" not in rec.calls
+        assert "90 frames" in result["content"][0]["text"]


### PR DESCRIPTION
## Problem

`Simulation.stop_recording` called `recorder.save_episode()` unconditionally, discarded its return value, and reported `status="success"` with `"0 frames, 0 episode(s)"` even when LeRobot rejected the empty episode buffer (`You must add one or several frames with add_frame before calling add_episode`). The result is a dataset directory containing only `meta/info.json` (`total_episodes=0`, `total_frames=0`) - no `data/*.parquet`, no `videos/*.mp4` - with no signal to the caller until training time.

The trigger: only `run_policy` feeds the active dataset recorder (its `on_frame` hook calls `add_frame`). `eval_policy` / `evaluate` / `replay_episode` and bare `step` loops step the sim directly and never reach the recorder. So a `start_recording -> eval_policy -> stop_recording` sequence silently produced an empty dataset.

## Reproduction

```python
sim.create_world(); sim.add_robot("so100")
sim.start_recording(repo_id="local/x", task="pick", root=d, overwrite=True)
sim.eval_policy(robot_name="so100", policy_provider="mock", n_episodes=2, max_steps=10)
sim.stop_recording()   # BEFORE: status=success, 0 frames, empty dataset on disk
```

## Change

`stop_recording` now distinguishes three cases by the recorder's frame counters:

1. **Pending unsaved frames** (`episode_frame_count > 0`): flush via `save_episode`; surface any failure as a structured `status="error"`.
2. **No pending frames but dataset non-empty** (caller saved per-episode and calls `stop_recording` last): finalize only, without re-calling `save_episode` on the empty buffer - which would otherwise hit LeRobot's `add frames before add_episode` guard and wrongly fail a complete dataset.
3. **Nothing ever captured** (`frame_count == 0`): return `status="error"` with guidance to record via `run_policy`, instead of writing an empty dataset.

This aligns with the library convention of raising/erroring on fatal conditions rather than warn-and-continue with a silent empty artifact.

## Tests

`tests/simulation/mujoco/test_stop_recording_finalize.py::TestStopRecordingEmptyDataset` adds 5 cases covering all three paths. The empty-dataset and per-episode-save cases fail on the pre-fix code (4/5 fail before, all pass after). Drives a fake recorder so the contract is pinned without the `lerobot` extra. Full file: 13 passed. Existing recording/dataset suites: 147 passed, 1 skipped.

## Validation (MuJoCo sim, headless EGL)

Three live scenarios after the fix:
- `eval_policy` empty recording -> `status=error` (no empty dataset written)
- per-episode `save_episode` x3 (60 frames) -> `success`, `total_episodes=3`, `total_frames=60`
- single `run_policy` (15 frames) -> `success`, trailing episode auto-flushed

Rollout video from `run_policy(..., video=...)` round-tripped through the recorder (90 frames -> 1 episode, parquet + MP4 on disk):

![rollout](https://github.com/cagataycali/robots/releases/download/artifact-stop-recording-empty/rollout80.gif)

MP4: https://github.com/cagataycali/robots/releases/download/artifact-stop-recording-empty/rollout80.mp4