### PR TITLE
fix(molmoact2): pin transformers to match lerobot's molmoact2 floor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,7 +192,13 @@ lerobot = [
 # `lerobot[feetech]>=0.5.2` directly and the git-source step drops away.
 molmoact2 = [
     "strands-robots[lerobot]",
-    "transformers>=4.46",
+    # Mirror lerobot's own [molmoact2] dep pins exactly. The transformers
+    # floor MUST match lerobot[transformers-dep] (>=5.4.0,<5.6.0): MolmoAct2's
+    # modeling/processor code uses transformers 5.4+ APIs, and a looser floor
+    # (e.g. >=4.46) lets a resolver pick an incompatible transformers that
+    # imports fine -- passing the importability guard in molmoact2.build_policy
+    # -- then dead-ends deep inside lerobot model construction.
+    "transformers>=5.4.0,<5.6.0",
     "peft>=0.18.0,<1.0.0",
     "scipy>=1.14.0,<2.0.0",
 ]

--- a/tests/test_customer_workflow_regressions.py
+++ b/tests/test_customer_workflow_regressions.py
@@ -98,6 +98,39 @@ class TestMolmoact2Extra:
         assert "peft" in joined
         assert "scipy" in joined
 
+    def test_molmoact2_transformers_pin_matches_lerobot(self):
+        """The transformers pin must match lerobot's [transformers-dep] floor.
+
+        MolmoAct2's modeling/processor code uses transformers 5.4+ APIs.
+        ``molmoact2.build_policy`` guards the dep with an importability-only
+        check (``require_optional``), which a too-loose floor (e.g. the old
+        ``>=4.46``) silently defeats: a resolver can pick transformers 4.x,
+        the import succeeds, the guard passes, then model construction dead-ends
+        deep inside lerobot. The pin must therefore carry lerobot's own floor
+        (``>=5.4.0``) and an upper bound so a future incompatible major cannot
+        slip through.
+        """
+        from packaging.requirements import Requirement
+        from packaging.version import Version
+
+        specs = self._extras()["molmoact2"]
+        transformers_req = next(
+            (Requirement(s) for s in specs if Requirement(s).name == "transformers"),
+            None,
+        )
+        assert transformers_req is not None, "[molmoact2] must pin transformers"
+        spec = transformers_req.specifier
+        # Floor must be at least lerobot's transformers-dep floor (5.4.0).
+        assert not spec.contains(Version("4.46")), (
+            f"transformers floor too loose: {spec} admits 4.46, which lacks the "
+            "transformers 5.4+ APIs MolmoAct2 needs (matches lerobot[transformers-dep])"
+        )
+        assert spec.contains(Version("5.4.0")), f"transformers pin {spec} must admit 5.4.0 (lerobot's molmoact2 floor)"
+        # An upper bound must exist so an incompatible future major is excluded.
+        assert any(s.operator in ("<", "<=", "==", "~=") for s in spec), (
+            f"transformers pin {spec} must carry an upper bound"
+        )
+
     def test_molmoact2_extra_has_no_git_url(self):
         # PyPI rejects direct-reference (git+) deps in a published package's
         # dependency table; the git-source pin must stay in docs/error hints.


### PR DESCRIPTION
## Problem
The `[molmoact2]` optional-dependency extra pins `transformers>=4.46` with no upper bound, but MolmoAct2's modeling/processor code (reached through lerobot) requires `transformers>=5.4.0,<5.6.0` — exactly what `lerobot[transformers-dep]` declares.

`molmoact2.build_policy` guards the auxiliary deps with `require_optional`, which only checks **importability**, not version. So a resolver installing `strands-robots[molmoact2]` against lerobot-from-source can pick a transformers that satisfies the loose `>=4.46` floor (or a future `5.6+` major, since there is no cap), the import succeeds, the guard passes, and then model construction dead-ends deep inside lerobot with an opaque error like:

```
'transformers' is required but not installed. Install it with: pip install 'lerobot[molmoact2]'
```

That lerobot-internal hint is a dead end for a caller who installed `strands-robots[molmoact2]`, and the failure surfaces only at load time rather than at resolution time.

## Change
Align the `transformers` pin in `[molmoact2]` with lerobot's own `[transformers-dep]` floor:

```diff
-    "transformers>=4.46",
+    "transformers>=5.4.0,<5.6.0",
```

`peft` and `scipy` already matched lerobot's `[peft-dep]` / `[scipy-dep]` pins exactly; only `transformers` had drifted. With the floor aligned, a compatible transformers resolves and the real MolmoAct2 policy loads instead of dead-ending.

## Test
Adds `TestMolmoact2Extra::test_molmoact2_transformers_pin_matches_lerobot`, which parses the extra and asserts the `transformers` specifier rejects `4.46`, admits `5.4.0`, and carries an upper bound. It FAILS on the old `>=4.46` pin and PASSES after.

```
tests/test_customer_workflow_regressions.py::TestMolmoact2Extra  18 passed
```
Lint + mypy clean on the touched files (`ruff check`, `ruff format --check`, `mypy strands_robots tests tests_integ`).

## Visual proof — real MolmoAct2 rollout in MuJoCo sim (headless)
With the aligned pin the real `lerobot_local` provider loads `allenai/MolmoAct2-SO100_101` (weights + processors) and produces actions stepping the `so101` arm in sim — no fallback to mock:

![MolmoAct2 so101 rollout](https://github.com/cagataycali/robots/releases/download/molmoact2-transformers-pin-artifact/molmoact2_so101.gif)

```
LerobotLocalPolicy | pick up the cube
20 steps | sim_t=2.000s | 20 frames, 10fps, 640x480
```

<video src="https://github.com/cagataycali/robots/releases/download/molmoact2-transformers-pin-artifact/molmoact2_so101.mp4"></video>