### PR TITLE
fix(molmoact2): report all missing auxiliary deps in one error, not just the first

### DIFF
--- a/strands_robots/policies/lerobot_local/molmoact2.py
+++ b/strands_robots/policies/lerobot_local/molmoact2.py
@@ -43,7 +43,7 @@ import json
 import logging
 from typing import Any
 
-from ...utils import require_optional
+from ...utils import require_optionals
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +53,8 @@ MOLMOACT2_TYPE = "molmoact2"
 #: lerobot core. They ship in the ``strands-robots[molmoact2]`` extra. lerobot's
 #: own ``require_package`` raises pointing at ``lerobot[transformers-dep]`` deep
 #: inside model construction, which is a dead end for a strands-robots caller --
-#: guard them up front so the error names the extra actually installed from.
+#: guard them up front (all at once) so the error names the extra actually
+#: installed from and lists EVERY missing dep, not just the first.
 _MOLMOACT2_RUNTIME_DEPS = ("transformers", "peft", "scipy")
 
 # Sensible default camera feature keys (match the ``so_real`` / ``so101``
@@ -235,13 +236,13 @@ def build_policy(
         Tuple ``(policy, preprocessor, postprocessor, config)``.
 
     Raises:
-        ImportError: If an auxiliary MolmoAct2 dep (transformers/peft/scipy) is
-            missing, with an install hint naming the ``strands-robots[molmoact2]``
-            extra (rather than lerobot's internal extra, which a strands-robots
-            caller never installed from).
+        ImportError: If any auxiliary MolmoAct2 dep (transformers/peft/scipy) is
+            missing. The error lists EVERY missing dep at once (not just the
+            first) and names the ``strands-robots[molmoact2]`` extra -- rather
+            than lerobot's internal extra, which a strands-robots caller never
+            installed from -- so a partial env is fixed in one install.
     """
-    for _dep in _MOLMOACT2_RUNTIME_DEPS:
-        require_optional(_dep, extra="molmoact2", purpose="MolmoAct2 inference")
+    require_optionals(_MOLMOACT2_RUNTIME_DEPS, extra="molmoact2", purpose="MolmoAct2 inference")
 
     import torch
 

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -53,6 +53,59 @@ def require_optional(
         raise ImportError("\n".join(parts)) from None
 
 
+def require_optionals(
+    module_names: list[str] | tuple[str, ...],
+    *,
+    extra: str | None = None,
+    purpose: str = "",
+) -> None:
+    """Require several optional dependencies, reporting ALL missing ones at once.
+
+    Unlike calling :func:`require_optional` in a loop -- which raises on the
+    FIRST missing module and hides the rest -- this probes every name and, if
+    any are absent, raises a single ``ImportError`` naming every missing module.
+    That lets a caller in a partially-provisioned environment fix all of them in
+    one install instead of discovering them one reinstall at a time (each retry
+    of a heavy load path is expensive).
+
+    Present modules are imported and cached (same as :func:`require_optional`),
+    so a follow-up ``require_optional`` for any of them is free.
+
+    Args:
+        module_names: Dotted module names to require (e.g. ``("transformers",
+            "peft", "scipy")``).
+        extra: ``pyproject.toml`` extras group naming where the deps ship
+            (e.g. ``"molmoact2"``); shown in the install hint.
+        purpose: Human-readable description shown in the error message.
+
+    Raises:
+        ImportError: If one or more modules are missing, listing every missing
+            module and an actionable install instruction.
+    """
+    missing: list[str] = []
+    for name in module_names:
+        if name in _lazy_modules:
+            continue
+        try:
+            _lazy_modules[name] = importlib.import_module(name)
+        except ImportError:
+            missing.append(name)
+
+    if not missing:
+        return
+
+    joined = ", ".join(f"'{m}'" for m in missing)
+    label = "is required" if len(missing) == 1 else "are required"
+    parts = [f"{joined} {label}"]
+    if purpose:
+        parts[0] += f" for {purpose}"
+    parts.append("Install with:")
+    if extra:
+        parts.append(f"  pip install 'strands-robots[{extra}]'")
+    parts.append(f"  pip install {' '.join(missing)}")
+    raise ImportError("\n".join(parts)) from None
+
+
 #
 # Path resolution - single source of truth for all strands-robots paths
 #

--- a/tests/policies/lerobot_local/test_molmoact2.py
+++ b/tests/policies/lerobot_local/test_molmoact2.py
@@ -399,7 +399,7 @@ class TestBuildPolicy:
 
 class TestBuildPolicyDependencyGuard:
     """``build_policy`` must guard its auxiliary deps up front with an error that
-    names the ``strands-robots[molmoact2]`` extra.
+    names the ``strands-robots[molmoact2]`` extra AND lists every missing dep.
 
     Without the guard the first missing dep (e.g. ``transformers``) only surfaces
     deep inside lerobot's own model construction, where ``require_package``
@@ -407,23 +407,27 @@ class TestBuildPolicyDependencyGuard:
     -- a dead end for a caller who installed ``strands-robots[molmoact2]`` and
     never touched lerobot's extras directly. The guard turns that into an
     actionable, correctly-attributed error before any heavy import runs.
+
+    The guard uses ``require_optionals`` (plural), which probes ALL deps and
+    reports every missing one at once -- so a partially-provisioned env (e.g.
+    transformers present but peft and scipy both absent) is fixed in a single
+    install instead of one reinstall-and-retry per missing dep.
     """
 
     def test_missing_dep_raises_naming_strands_extra(self, monkeypatch):
         """A missing runtime dep aborts with the strands-robots extra in the hint."""
-        called: list[tuple[str, str | None]] = []
+        seen: list[object] = []
 
-        def fake_require_optional(module_name, *, pip_install=None, extra=None, purpose=""):
-            called.append((module_name, extra))
-            if module_name == "transformers":
-                raise ImportError(
-                    f"'{module_name}' is required for {purpose}\n"
-                    "Install with:\n"
-                    f"  pip install 'strands-robots[{extra}]'\n"
-                    f"  pip install {pip_install or module_name}"
-                )
+        def fake_require_optionals(module_names, *, extra=None, purpose=""):
+            seen.append((tuple(module_names), extra))
+            raise ImportError(
+                f"'transformers' is required for {purpose}\n"
+                "Install with:\n"
+                f"  pip install 'strands-robots[{extra}]'\n"
+                "  pip install transformers"
+            )
 
-        monkeypatch.setattr(molmoact2, "require_optional", fake_require_optional)
+        monkeypatch.setattr(molmoact2, "require_optionals", fake_require_optionals)
 
         with pytest.raises(ImportError) as exc:
             molmoact2.build_policy(
@@ -438,20 +442,18 @@ class TestBuildPolicyDependencyGuard:
         msg = str(exc.value)
         assert "strands-robots[molmoact2]" in msg
         assert "transformers" in msg
-        # The guard runs before any heavy torch/lerobot import: transformers is
-        # the first dep checked, so the failure is attributed to it directly.
-        assert called[0] == ("transformers", "molmoact2")
+        # The guard runs before any heavy torch/lerobot import, against the
+        # molmoact2 extra, and covers the full runtime-dep set in one call.
+        assert seen[0] == (molmoact2._MOLMOACT2_RUNTIME_DEPS, "molmoact2")
 
-    def test_all_runtime_deps_are_guarded(self, monkeypatch):
-        """Every auxiliary dep is checked against the molmoact2 extra up front."""
-        checked: list[tuple[str, str | None]] = []
+    def test_all_runtime_deps_guarded_in_one_call(self, monkeypatch):
+        """Every auxiliary dep is gated against the molmoact2 extra in a single call."""
+        seen: list[object] = []
 
-        def fake_require_optional(module_name, *, pip_install=None, extra=None, purpose=""):
-            checked.append((module_name, extra))
-            # Return after recording so the guard loop completes; then stop the
-            # heavy build by failing the first lerobot import deterministically.
+        def fake_require_optionals(module_names, *, extra=None, purpose=""):
+            seen.append((tuple(module_names), extra))
 
-        monkeypatch.setattr(molmoact2, "require_optional", fake_require_optional)
+        monkeypatch.setattr(molmoact2, "require_optionals", fake_require_optionals)
         # Make the post-guard lerobot import fail predictably so the test does
         # not reach real model construction.
         monkeypatch.setattr(molmoact2, "auto_norm_tag", lambda *_a, **_k: (_ for _ in ()).throw(RuntimeError("stop")))
@@ -466,5 +468,46 @@ class TestBuildPolicyDependencyGuard:
                 embodiment_spec=None,
             )
 
-        assert [name for name, _ in checked] == list(molmoact2._MOLMOACT2_RUNTIME_DEPS)
-        assert all(extra == "molmoact2" for _, extra in checked)
+        assert len(seen) == 1, "deps must be gated in one aggregate call, not a loop"
+        names, extra = seen[0]
+        assert names == molmoact2._MOLMOACT2_RUNTIME_DEPS
+        assert extra == "molmoact2"
+
+    def test_reports_every_missing_dep_at_once(self, monkeypatch):
+        """Regression: a partial env (peft + scipy both missing) names BOTH in one error.
+
+        Pre-fix the guard looped ``require_optional`` and raised on the first
+        missing dep only, so a caller fixed peft, re-ran the heavy load path, and
+        only then learned scipy was also missing -- a reinstall treadmill. The
+        aggregate guard must surface every missing dep in a single message.
+        """
+        import strands_robots.utils as u
+
+        absent = {"peft", "scipy"}
+        real_import = u.importlib.import_module
+
+        def fake_import(name, *a, **k):
+            if name.split(".")[0] in absent:
+                raise ImportError(f"no module named {name}")
+            return real_import(name, *a, **k)
+
+        monkeypatch.setattr(u.importlib, "import_module", fake_import)
+        # Drop any cached real peft/scipy so the probe actually fails.
+        for mod in list(u._lazy_modules):
+            if mod in absent:
+                del u._lazy_modules[mod]
+
+        with pytest.raises(ImportError) as exc:
+            molmoact2.build_policy(
+                "allenai/MolmoAct2-SO100_101",
+                device="cpu",
+                norm_tag="t",
+                inference_action_mode="continuous",
+                image_keys=None,
+                embodiment_spec=None,
+            )
+
+        msg = str(exc.value)
+        assert "peft" in msg
+        assert "scipy" in msg
+        assert "strands-robots[molmoact2]" in msg

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from strands_robots.utils import require_optional
+from strands_robots.utils import require_optional, require_optionals
 
 
 class TestRequireOptional:
@@ -103,3 +103,53 @@ class TestGetSearchPaths:
 
         paths = get_search_paths()
         assert len(paths) == len(set(paths))
+
+
+class TestRequireOptionals:
+    """Tests for require_optionals - aggregate multi-dep gate.
+
+    Unlike require_optional in a loop (which raises on the FIRST missing dep and
+    hides the rest), require_optionals reports EVERY missing dep in one error so
+    a partially-provisioned environment is fixed in a single install.
+    """
+
+    def test_all_present_returns_none(self):
+        """When every module is importable the gate passes silently."""
+        assert require_optionals(["json", "os.path"]) is None
+
+    def test_lists_every_missing_module(self):
+        """A single error must name ALL missing deps, not just the first."""
+        with pytest.raises(ImportError) as exc:
+            require_optionals(["nope_aaa_xyz", "nope_bbb_xyz", "nope_ccc_xyz"])
+        msg = str(exc.value)
+        assert "nope_aaa_xyz" in msg
+        assert "nope_bbb_xyz" in msg
+        assert "nope_ccc_xyz" in msg
+
+    def test_reports_only_the_missing_ones(self):
+        """Present deps are not named; only the absent ones surface."""
+        with pytest.raises(ImportError) as exc:
+            require_optionals(["json", "nope_present_mix_xyz"])
+        msg = str(exc.value)
+        assert "nope_present_mix_xyz" in msg
+        assert "json" not in msg
+
+    def test_pip_install_line_lists_all_missing(self):
+        """The bare ``pip install`` hint concatenates every missing module."""
+        with pytest.raises(ImportError, match=r"pip install nope_d1_xyz nope_d2_xyz"):
+            require_optionals(["nope_d1_xyz", "nope_d2_xyz"])
+
+    def test_error_includes_extra_and_purpose(self):
+        """extra and purpose flow into the message like require_optional."""
+        with pytest.raises(ImportError) as exc:
+            require_optionals(["nope_extra_xyz"], extra="my-extra", purpose="testing")
+        msg = str(exc.value)
+        assert "strands-robots[my-extra]" in msg
+        assert "for testing" in msg
+
+    def test_singular_vs_plural_phrasing(self):
+        """One missing dep reads 'is required'; many read 'are required'."""
+        with pytest.raises(ImportError, match="is required"):
+            require_optionals(["nope_single_xyz"])
+        with pytest.raises(ImportError, match="are required"):
+            require_optionals(["nope_two_a_xyz", "nope_two_b_xyz"])


### PR DESCRIPTION
## Problem

`build_policy` in `policies/lerobot_local/molmoact2.py` guarded its three auxiliary runtime deps by looping `require_optional` over `(transformers, peft, scipy)`:

```python
for _dep in _MOLMOACT2_RUNTIME_DEPS:
    require_optional(_dep, extra="molmoact2", purpose="MolmoAct2 inference")
```

Because `require_optional` raises on the first missing module, a partially-provisioned environment only ever learns about ONE missing dep at a time. Concretely: an env with `transformers` present but both `peft` and `scipy` absent gets an error that names `peft` only. The caller installs `peft`, re-triggers the MolmoAct2 load path (a heavy model resolve), and only then discovers `scipy` is also missing — a reinstall treadmill of one round-trip per missing dep, each paid after a slow load attempt.

## Change

Add `require_optionals(module_names, *, extra, purpose)` to `utils.py`: probe every name, then raise a single `ImportError` listing EVERY missing module plus one actionable install line. Switch the MolmoAct2 guard to it so a partial env is fixed in a single install. Present modules are still imported and cached (same contract as `require_optional`), so a later `require_optional` for any of them stays free.

Before (transformers present, peft + scipy missing):
```
'peft' is required for MolmoAct2 inference
Install with:
  pip install 'strands-robots[molmoact2]'
  pip install peft
```

After:
```
'peft', 'scipy' are required for MolmoAct2 inference
Install with:
  pip install 'strands-robots[molmoact2]'
  pip install peft scipy
```

## Tests

- `tests/test_utils.py::TestRequireOptionals` — all-present pass, lists every missing dep, reports only the absent ones, concatenated `pip install` line, extra/purpose propagation, singular vs plural phrasing.
- `tests/policies/lerobot_local/test_molmoact2.py::TestBuildPolicyDependencyGuard` — updated to the aggregate contract plus a new `test_reports_every_missing_dep_at_once` regression that **fails pre-fix** (the looped guard surfaced `peft` only, never `scipy`) and passes after.

Local gate green: `ruff check` / `ruff format --check` clean, `mypy strands_robots tests tests_integ` reports no issues, and `pytest tests/policies tests/test_utils.py` passes (564 passed, 10 env-gated skips). Diagnostics-only change (error message), no behavior change to policy/sim/rendering.
