### PR TITLE
feat(sim): add list_bodies to discover camera mount points

### DIFF
--- a/docs/simulation/world-building.md
+++ b/docs/simulation/world-building.md
@@ -44,6 +44,17 @@ for i in range(5):
 
 Free cameras look from `position` toward `target` (`fov=60.0`, `width=640`, `height=480`). Robot-URDF cameras (wrist, etc.) are auto-discovered on `add_robot` - no `add_camera` needed.
 
+To mount a camera ON a moving body (a realistic wrist/gripper view that rides with the arm), pass `parent_body`. Body names are namespaced `<robot>/<body>`; discover the exact mount point with `list_bodies` instead of guessing:
+
+```python
+bodies = sim.list_bodies(robot_name="so101")["content"][1]["json"]
+mount = bodies["gripper_body"]          # e.g. "so101/gripper" -- the wrist mount
+sim.add_camera(name="wrist", parent_body=mount,
+               position=[0.0, 0.0, 0.05], target=[0.0, 0.0, 0.1])  # local frame
+```
+
+`list_bodies()` (no `robot_name`) lists every body in the world; with `robot_name` it scopes to that robot and also returns `gripper_body`, the best-guess end-effector mount.
+
 ## Multi-robot policies
 
 ```python

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1095,6 +1095,17 @@ class MuJoCoSimEngine(
                     cameras.append(cam_name)
         base["cameras"] = cameras
 
+        bodies: list[str] = []
+        if self._world is not None and self._world._model is not None:
+            mj = self._mj
+            model = self._world._model
+            for i in range(model.nbody):
+                body_name = mj.mj_id2name(model, mj.mjtObj.mjOBJ_BODY, i)
+                if body_name:
+                    bodies.append(body_name)
+        base["bodies"] = bodies
+        base["methods"]["list_bodies"] = "(robot_name: str | None = None) -> dict (camera mount points)"
+
         if self._world is not None:
             base["sim_time"] = self._world.sim_time
             base["world_created"] = True
@@ -1140,6 +1151,77 @@ class MuJoCoSimEngine(
             text += f"{jnt}: pos={vals['position']:.4f}, vel={vals['velocity']:.4f}\n"
 
         return {"status": "success", "content": [{"text": text}, {"json": {"state": state}}]}
+
+    def list_bodies(self, robot_name: str | None = None) -> dict[str, Any]:
+        """List MuJoCo body names available as camera/sensor mount points.
+
+        This is the discovery surface for ``add_camera(parent_body=...)``.
+        Robot bodies are namespaced ``<robot>/<body>`` (e.g. ``so101/gripper``
+        is the canonical wrist-camera mount for SO101/SO100 arms). Without this
+        action an agent has to guess the body name, mount a camera against a
+        non-existent body, read the failure, and retry -- a wasted turn. Call
+        ``list_bodies`` first to resolve the exact mount point deterministically.
+
+        Args:
+            robot_name: When set, return only that robot's bodies (its
+                namespace prefix). When omitted, return every body in the
+                world (the global ``world`` body plus all robots/objects).
+
+        Returns:
+            ``{"status", "content": [{"text"}, {"json": {"bodies": [...]}}]}``.
+            ``bodies`` is the ordered list of body names; the ``text`` block
+            mirrors it for human display. When ``robot_name`` is given the
+            json also carries ``"gripper_body"`` -- the best-guess gripper/
+            end-effector mount (a body whose short name contains ``gripper``,
+            ``hand``, ``ee``, or ``tool``), or ``null`` if none matches.
+        """
+        if self._world is None or self._world._model is None or self._world._data is None:
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
+
+        mj = self._mj
+        model = self._world._model
+
+        prefix = ""
+        if robot_name is not None:
+            if robot_name not in self._world.robots:
+                return {
+                    "status": "error",
+                    "content": [
+                        {
+                            "text": (
+                                f"list_bodies: robot '{robot_name}' not found. "
+                                f"Known robots: {list(self._world.robots.keys())}"
+                            )
+                        }
+                    ],
+                }
+            prefix = self._world.robots[robot_name].namespace or ""
+
+        bodies = [
+            name
+            for i in range(model.nbody)
+            if (name := mj.mj_id2name(model, mj.mjtObj.mjOBJ_BODY, i)) and (not prefix or name.startswith(prefix))
+        ]
+
+        json_payload: dict[str, Any] = {"bodies": bodies}
+        if robot_name is not None:
+            gripper_body: str | None = None
+            for name in bodies:
+                short = name.rsplit("/", 1)[-1].lower()
+                if any(tok in short for tok in ("gripper", "hand", "ee", "tool")):
+                    gripper_body = name
+                    break
+            json_payload["gripper_body"] = gripper_body
+
+        text = (
+            f"Bodies ({len(bodies)}): {bodies}\n"
+            "Use any of these as add_camera(parent_body=...) to mount a "
+            "wrist/gripper camera."
+        )
+        if robot_name is not None and json_payload.get("gripper_body"):
+            text += f"\nGripper/EEF mount: '{json_payload['gripper_body']}'"
+
+        return {"status": "success", "content": [{"text": text}, {"json": json_payload}]}
 
     # Object Management
 
@@ -1297,9 +1379,10 @@ class MuJoCoSimEngine(
         gripper such as ``"so101/gripper"``), the camera is attached TO that
         body and rides along with it -- this is how a realistic wrist/gripper
         camera is modelled for SO101/SO100-style data collection. In this
-        mode ``position`` and ``target`` are in the body's LOCAL frame. Use
-        ``list_robots`` / ``get_robot_state`` to discover body names; robot
-        bodies are namespaced ``<robot>/<body>``.
+        mode ``position`` and ``target`` are in the body's LOCAL frame. Call
+        ``list_bodies`` (optionally with ``robot_name``) to discover valid
+        mount points before placing a camera; robot bodies are namespaced
+        ``<robot>/<body>`` (e.g. ``so101/gripper`` is the SO101 wrist mount).
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
@@ -1358,7 +1441,8 @@ class MuJoCoSimEngine(
                         {
                             "text": (
                                 f"add_camera: parent_body '{parent_body}' not found. "
-                                f"Robot bodies are namespaced '<robot>/<body>'. Available bodies: {available}"
+                                f"Robot bodies are namespaced '<robot>/<body>'. "
+                                f"Call list_bodies to discover mount points. Available bodies: {available}"
                             )
                         }
                     ],
@@ -1925,9 +2009,9 @@ class MuJoCoSimEngine(
                 "(direct path or auto-resolve from data_config name), add objects, run VLA policies, "
                 "render cameras, record trajectories, domain randomize. "
                 "Same Policy ABC as real robot control - sim and real with zero code changes. "
-                "Actions (61 total): "
+                "Actions (62 total): "
                 "[World] create_world, load_scene, reset, get_state, destroy, export_xml; "
-                "[Robots] add_robot, remove_robot, list_robots, get_robot_state; "
+                "[Robots] add_robot, remove_robot, list_robots, get_robot_state, list_bodies; "
                 "[Objects] add_object, remove_object, move_object, list_objects; "
                 "[Cameras] add_camera, remove_camera; "
                 "[Policy] run_policy, start_policy, stop_policy, eval_policy, replay_episode, list_policies_running; "

--- a/strands_robots/simulation/mujoco/tool_spec.json
+++ b/strands_robots/simulation/mujoco/tool_spec.json
@@ -16,6 +16,7 @@
         "remove_robot",
         "list_robots",
         "get_robot_state",
+        "list_bodies",
         "add_object",
         "remove_object",
         "move_object",

--- a/tests/simulation/mujoco/test_simulation.py
+++ b/tests/simulation/mujoco/test_simulation.py
@@ -487,6 +487,75 @@ class TestCameraManagement:
         assert sim_with_robot._world.cameras["wrist"].parent_body == "arm1/base"
 
 
+class TestListBodies:
+    """list_bodies is the discovery surface for add_camera(parent_body=...).
+
+    Before it existed, the add_camera docstring pointed agents at list_robots
+    / get_robot_state to find mount points -- but those return robot names and
+    joint names, never body names. An agent had to guess a body (e.g.
+    ``Fixed_Jaw``), mount against a non-existent body, read the failure, and
+    retry. These tests pin the deterministic discovery path that removes the
+    wasted turn.
+    """
+
+    def test_list_bodies_no_world_errors(self, sim):
+        result = sim.list_bodies()
+        assert result["status"] == "error"
+        assert "No world" in result["content"][0]["text"]
+
+    def test_list_bodies_global_lists_every_body(self, sim_with_robot):
+        result = sim_with_robot.list_bodies()
+        assert result["status"] == "success"
+        bodies = result["content"][1]["json"]["bodies"]
+        # world body + the robot's namespaced bodies are all present.
+        assert "world" in bodies
+        assert "arm1/base" in bodies
+        assert "arm1/link1" in bodies
+
+    def test_list_bodies_scoped_to_robot_excludes_world(self, sim_with_robot):
+        result = sim_with_robot.list_bodies(robot_name="arm1")
+        assert result["status"] == "success"
+        payload = result["content"][1]["json"]
+        bodies = payload["bodies"]
+        assert "world" not in bodies
+        assert all(b.startswith("arm1/") for b in bodies)
+        # gripper_body is reported (None here -- the test arm has no gripper-like body).
+        assert "gripper_body" in payload
+
+    def test_list_bodies_unknown_robot_errors_with_known_names(self, sim_with_robot):
+        result = sim_with_robot.list_bodies(robot_name="ghost")
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert "ghost" in text
+        assert "arm1" in text
+
+    def test_discovered_body_mounts_camera_without_guessing(self, sim_with_robot):
+        """End-to-end: list_bodies -> pick a body -> add_camera succeeds on the
+        first attempt, with no failed-then-recovered round trip."""
+        bodies = sim_with_robot.list_bodies(robot_name="arm1")["content"][1]["json"]["bodies"]
+        mount = bodies[0]
+        result = sim_with_robot.add_camera(
+            "wrist",
+            position=[0.0, 0.0, 0.1],
+            target=[0.0, 0.0, 0.0],
+            parent_body=mount,
+        )
+        assert result["status"] == "success"
+        assert sim_with_robot._world.cameras["wrist"].parent_body == mount
+
+    def test_list_bodies_dispatches_via_action_string(self, sim_with_robot):
+        """The action is wired through the agent-tool dispatcher, not just the
+        Python method."""
+        result = sim_with_robot(action="list_bodies", robot_name="arm1")
+        assert result["status"] == "success"
+        assert "arm1/base" in result["content"][1]["json"]["bodies"]
+
+    def test_describe_advertises_bodies_and_list_bodies_method(self, sim_with_robot):
+        described = sim_with_robot.describe()
+        assert "arm1/base" in described["bodies"]
+        assert "list_bodies" in described["methods"]
+
+
 # Scene Injection (XML round-trip)
 
 


### PR DESCRIPTION
## Problem

`add_camera(parent_body=...)` mounts a camera ON a moving body so it rides with the arm (a realistic wrist/gripper view for SO101/SO100-style data collection). But there was no way to discover valid body names *before* the call. Both the `add_camera` docstring and its not-found error pointed at `list_robots` / `get_robot_state` to "discover body names" -- yet those return **robot names** and **joint names**, never body names.

With no discovery surface, an agent guesses a body (e.g. `so101/Fixed_Jaw`, which does not exist), mounts a camera against it, reads the failure, and retries on the real `so101/gripper`. That failed-then-recovered round trip costs a turn and leaves a spurious-looking error in transcripts.

## Change

Add a `list_bodies(robot_name=None)` action -- the discovery surface for `add_camera(parent_body=...)`:

- no `robot_name` -> every body in the world (the `world` body plus all robots/objects)
- with `robot_name` -> that robot's namespaced bodies, plus `gripper_body`: the best-guess end-effector mount (short name contains `gripper`/`hand`/`ee`/`tool`), or `null` if none matches.

Supporting changes so the path is self-describing:
- `add_camera` docstring + not-found error now point at `list_bodies` (and name `so101/gripper` as the SO101 wrist mount).
- `list_bodies` registered in `tool_spec.json`.
- MuJoCo `describe()` now surfaces `bodies` and the `list_bodies` method, so an agent resolves the mount in one discovery call.

Result: discover -> mount succeeds on the first attempt.

```python
bodies = sim.list_bodies(robot_name="so101")["content"][1]["json"]
sim.add_camera(name="wrist", parent_body=bodies["gripper_body"],  # "so101/gripper"
               position=[0.0, 0.05, 0.0], target=[0.0, 0.2, 0.0])  # local frame
```

## Tests

New `TestListBodies` (7 cases): no-world error, global listing, robot-scoped listing (excludes `world`), `gripper_body` detection, unknown-robot error naming known robots, action-string dispatch, `describe()` advertisement, and an end-to-end discover-then-mount that succeeds first try. All 7 fail on pre-fix code (`AttributeError: 'MuJoCoSimEngine' object has no attribute 'list_bodies'`) and pass after.

## Visual artifact

Wrist camera discovered via `list_bodies` -> `gripper_body` (`so101/gripper`), mounted, and rendered in MuJoCo (headless EGL) while the SO101 arm sweeps. The view rides with the gripper:

![wrist-mounted camera rollout](https://github.com/cagataycali/robots/releases/download/artifact-list-bodies-wrist-cam/wrist_mount_demo.gif)

(MP4: https://github.com/cagataycali/robots/releases/download/artifact-list-bodies-wrist-cam/wrist_mount_demo.mp4 )

Local gate: `ruff check` + `ruff format` clean; `TestListBodies` 7/7 pass; full `test_simulation.py` passes except one pre-existing recording test that depends on the `lerobot` extra (fails identically on baseline, unrelated to this change).