### PR TITLE
test(training): cover create_trainer auto-discovery fallback

### DIFF
--- a/tests/training/test_factory.py
+++ b/tests/training/test_factory.py
@@ -147,3 +147,53 @@ class TestSpecTolerance:
         """The **kwargs-style tolerance rule: unknown extras are ignored."""
         spec.extra = {"some_future_flag": "value", "another": 123}
         assert create_trainer("mock").validate(spec) == []
+
+
+class TestAutoDiscoveryFallback:
+    """Resolution-order step 2 of ``import_trainer_class``: when a provider has
+    no ``trainer`` block in policies.json, the factory falls back to importing
+    ``strands_robots.training.<provider>`` and resolving a Trainer subclass.
+    """
+
+    def test_resolves_named_provider_trainer_class(self, monkeypatch):
+        """A module exposing ``<Provider>Trainer`` is resolved by name."""
+        import sys
+        import types
+
+        mod = types.ModuleType("strands_robots.training.autoprov")
+
+        class AutoprovTrainer(MockTrainer):
+            pass
+
+        mod.AutoprovTrainer = AutoprovTrainer
+        monkeypatch.setitem(sys.modules, "strands_robots.training.autoprov", mod)
+
+        assert import_trainer_class("autoprov") is AutoprovTrainer
+        assert isinstance(create_trainer("autoprov"), AutoprovTrainer)
+
+    def test_scans_for_first_trainer_subclass_when_name_mismatched(self, monkeypatch):
+        """When no ``<Provider>Trainer`` exists, the first Trainer subclass wins."""
+        import sys
+        import types
+
+        mod = types.ModuleType("strands_robots.training.scanprov")
+
+        class CustomBackendTrainer(MockTrainer):
+            pass
+
+        mod.CustomBackendTrainer = CustomBackendTrainer
+        monkeypatch.setitem(sys.modules, "strands_robots.training.scanprov", mod)
+
+        assert import_trainer_class("scanprov") is CustomBackendTrainer
+
+    def test_importable_module_without_trainer_raises(self, monkeypatch):
+        """A module that imports cleanly but exposes no Trainer subclass still
+        raises ValueError with the available-trainers list (not ImportError)."""
+        import sys
+        import types
+
+        mod = types.ModuleType("strands_robots.training.emptyprov")
+        monkeypatch.setitem(sys.modules, "strands_robots.training.emptyprov", mod)
+
+        with pytest.raises(ValueError, match="No trainer registered"):
+            import_trainer_class("emptyprov")


### PR DESCRIPTION
## What
Pins the second resolution step of `import_trainer_class` in `strands_robots/training/factory.py` with regression tests.

## Why
`import_trainer_class` documents a two-step resolution order:
1. A provider's `trainer` block in `registry/policies.json`.
2. An auto-discovery fallback that imports `strands_robots.training.<provider>` and resolves a `Trainer` subclass - by the `<Provider>Trainer` naming convention, else by scanning for the first `Trainer` subclass in the module.

The existing suite only exercised step 1 (the JSON block) plus the unknown-provider `ValueError`. The documented fallback path (factory.py lines 100-107) had zero coverage, leaving the module at 84%.

## Change
Adds `TestAutoDiscoveryFallback` covering all three fallback branches:
- name-convention match resolves `<Provider>Trainer` and `create_trainer` instantiates it,
- scan-for-first-subclass when the class name does not match the convention,
- an importable-but-empty module (no `Trainer` subclass) still raises `ValueError` with the available-trainers list (not `ImportError`).

Fake provider modules are injected via `monkeypatch.setitem(sys.modules, ...)` so they are cleaned up automatically and never touch disk or the real registry.

## Verification
- Removing the fallback block makes the two positive-branch tests fail (genuine regression guard); they pass with it intact.
- `strands_robots/training/factory.py` line coverage: 84% -> 100%.
- `ruff check`, `ruff format --check`, and `mypy` are clean on the changed file. Full `tests/training/test_factory.py` passes (22 passed).

Test-only change; no library behavior is modified.