### PR TITLE
fix(security): harden device_connect and tools against auth bypass and path traversal

### DIFF
--- a/strands_robots/device_connect/reachy_mini_driver.py
+++ b/strands_robots/device_connect/reachy_mini_driver.py
@@ -13,9 +13,10 @@ import math
 import re
 from typing import Any
 
-from device_connect_edge.drivers import DeviceDriver, emit, on, rpc
+from device_connect_edge.drivers import DeviceDriver, emit, get_rpc_source_device, on, rpc
 from device_connect_edge.types import DeviceIdentity, DeviceStatus
 
+from strands_robots.device_connect._authz import authz_error, is_authorized_caller
 from strands_robots.device_connect.reachy_transport import (
     WebSocketLink,
     ZenohLink,
@@ -123,6 +124,9 @@ class ReachyMiniDriver(DeviceDriver):
             y: Y offset in mm
             z: Z offset in mm
         """
+        caller = get_rpc_source_device()
+        if not is_authorized_caller(caller, scope="rpc"):
+            return authz_error(caller, "look")
         await self._send_cmd({"head_pose": rpy_to_pose(pitch, roll, yaw, x, y, z)})
         return {"status": "success", "pitch": pitch, "roll": roll, "yaw": yaw}
 
@@ -134,6 +138,9 @@ class ReachyMiniDriver(DeviceDriver):
             left: Left antenna angle in degrees
             right: Right antenna angle in degrees
         """
+        caller = get_rpc_source_device()
+        if not is_authorized_caller(caller, scope="rpc"):
+            return authz_error(caller, "antennas")
         await self._send_cmd({"antennas_joint_positions": [math.radians(left), math.radians(right)]})
         return {"status": "success", "left": left, "right": right}
 
@@ -144,6 +151,9 @@ class ReachyMiniDriver(DeviceDriver):
         Args:
             yaw: Body yaw angle in degrees
         """
+        caller = get_rpc_source_device()
+        if not is_authorized_caller(caller, scope="rpc"):
+            return authz_error(caller, "body")
         await self._send_cmd({"body_yaw": math.radians(yaw)})
         return {"status": "success", "yaw": yaw}
 
@@ -186,6 +196,9 @@ class ReachyMiniDriver(DeviceDriver):
         Args:
             motor_ids: Comma-separated motor IDs (empty = all)
         """
+        caller = get_rpc_source_device()
+        if not is_authorized_caller(caller, scope="rpc"):
+            return authz_error(caller, "enableMotors")
         ids = [s.strip() for s in motor_ids.split(",") if s.strip()] or None
         await self._send_cmd({"torque": True, "ids": ids})
         return {"status": "success", "enabled": motor_ids or "all"}
@@ -197,6 +210,9 @@ class ReachyMiniDriver(DeviceDriver):
         Args:
             motor_ids: Comma-separated motor IDs (empty = all)
         """
+        caller = get_rpc_source_device()
+        if not is_authorized_caller(caller, scope="rpc"):
+            return authz_error(caller, "disableMotors")
         ids = [s.strip() for s in motor_ids.split(",") if s.strip()] or None
         await self._send_cmd({"torque": False, "ids": ids})
         return {"status": "success", "disabled": motor_ids or "all"}
@@ -211,6 +227,9 @@ class ReachyMiniDriver(DeviceDriver):
             move_name: Name of the move to play
             library: Move library (emotions or dance)
         """
+        caller = get_rpc_source_device()
+        if not is_authorized_caller(caller, scope="rpc"):
+            return authz_error(caller, "playMove")
         if not _MOVE_NAME_RE.fullmatch(move_name or ""):
             return {"status": "error", "reason": f"invalid move_name: {move_name!r}"}
         ds = f"pollen-robotics/reachy-mini-{'emotions' if library == 'emotions' else 'dances'}-library"
@@ -244,6 +263,9 @@ class ReachyMiniDriver(DeviceDriver):
     @rpc()
     async def nod(self) -> dict[str, Any]:
         """Nod the head (yes gesture)."""
+        caller = get_rpc_source_device()
+        if not is_authorized_caller(caller, scope="rpc"):
+            return authz_error(caller, "nod")
         for _ in range(3):
             await self._send_cmd({"head_pose": rpy_to_pose(15, 0, 0)})
             await asyncio.sleep(0.25)
@@ -255,6 +277,9 @@ class ReachyMiniDriver(DeviceDriver):
     @rpc()
     async def shake(self) -> dict[str, Any]:
         """Shake the head (no gesture)."""
+        caller = get_rpc_source_device()
+        if not is_authorized_caller(caller, scope="rpc"):
+            return authz_error(caller, "shake")
         for _ in range(3):
             await self._send_cmd({"head_pose": rpy_to_pose(0, 0, 25)})
             await asyncio.sleep(0.2)
@@ -266,6 +291,9 @@ class ReachyMiniDriver(DeviceDriver):
     @rpc()
     async def happy(self) -> dict[str, Any]:
         """Happy antenna wiggle expression."""
+        caller = get_rpc_source_device()
+        if not is_authorized_caller(caller, scope="rpc"):
+            return authz_error(caller, "happy")
         for _ in range(4):
             await self._send_cmd({"antennas_joint_positions": [math.radians(60), math.radians(-60)]})
             await asyncio.sleep(0.2)
@@ -279,6 +307,9 @@ class ReachyMiniDriver(DeviceDriver):
     @rpc()
     async def wakeUp(self) -> dict[str, Any]:
         """Wake up the robot (enable motors + play wake animation)."""
+        caller = get_rpc_source_device()
+        if not is_authorized_caller(caller, scope="rpc"):
+            return authz_error(caller, "wakeUp")
         result = await asyncio.to_thread(
             api,
             self._host,
@@ -291,6 +322,9 @@ class ReachyMiniDriver(DeviceDriver):
     @rpc()
     async def sleep(self) -> dict[str, Any]:
         """Put robot to sleep (play sleep animation + disable motors)."""
+        caller = get_rpc_source_device()
+        if not is_authorized_caller(caller, scope="rpc"):
+            return authz_error(caller, "sleep")
         result = await asyncio.to_thread(
             api,
             self._host,
@@ -303,6 +337,9 @@ class ReachyMiniDriver(DeviceDriver):
     @rpc()
     async def stopMotion(self) -> dict[str, Any]:
         """Stop all current motion."""
+        caller = get_rpc_source_device()
+        if not is_authorized_caller(caller, scope="rpc"):
+            return authz_error(caller, "stopMotion")
         result = await asyncio.to_thread(
             api,
             self._host,
@@ -336,7 +373,15 @@ class ReachyMiniDriver(DeviceDriver):
 
     @on(event_name="emergencyStop")
     async def onEmergencyStop(self, device_id: str, event_name: str, payload: dict[str, Any]) -> None:
-        """React to emergencyStop - disable motors and stop motion."""
+        """React to emergencyStop from an authorized safety controller.
+
+        Security hardening: only act on emergency-stop events whose source is
+        in the emergency-stop allowlist, so a spoofed event from an arbitrary
+        device cannot interrupt operations.
+        """
+        if not is_authorized_caller(device_id, scope="estop"):
+            logger.warning("Ignoring emergencyStop from unauthorized source %s", device_id)
+            return
         logger.warning("Emergency stop received from %s - disabling motors", device_id)
         await self.stopMotion()
         await self.disableMotors()

--- a/strands_robots/tools/lerobot_calibrate.py
+++ b/strands_robots/tools/lerobot_calibrate.py
@@ -21,6 +21,7 @@ Based on LeRobot's calibration system:
 
 import json
 import logging
+import re
 import shutil
 from datetime import datetime
 from pathlib import Path
@@ -57,6 +58,8 @@ class LeRobotCalibrationManager:
     """Independent LeRobot calibration management class"""
 
     def __init__(self, base_path: Path | None = None):
+        if base_path is not None:
+            validate_save_path(str(base_path), label="base_path")
         self.base_path = Path(base_path) if base_path else HF_LEROBOT_CALIBRATION
         self.teleop_path = self.base_path / "teleoperators"
         self.robot_path = self.base_path / "robots"
@@ -86,7 +89,16 @@ class LeRobotCalibrationManager:
         return structure
 
     def get_calibration_path(self, device_type: str, device_model: str, device_id: str) -> Path:
-        """Get the full path to a calibration file"""
+        """Get the full path to a calibration file."""
+        # Security hardening: restrict path components to prevent traversal.
+        _SAFE_COMPONENT = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]*$")
+        _VALID_DEVICE_TYPES = {"teleoperators", "robots"}
+        if device_type not in _VALID_DEVICE_TYPES:
+            raise ValueError(f"device_type must be one of {_VALID_DEVICE_TYPES}, got {device_type!r}")
+        if not _SAFE_COMPONENT.fullmatch(device_model):
+            raise ValueError(f"device_model contains invalid characters: {device_model!r}")
+        if not _SAFE_COMPONENT.fullmatch(device_id):
+            raise ValueError(f"device_id contains invalid characters: {device_id!r}")
         return self.base_path / device_type / device_model / f"{device_id}.json"
 
     def calibration_exists(self, device_type: str, device_model: str, device_id: str) -> bool:

--- a/strands_robots/tools/use_lerobot.py
+++ b/strands_robots/tools/use_lerobot.py
@@ -60,7 +60,7 @@ _IMAGE_MAX_DIM = 4096  # arrays larger than this on H or W are still treated as 
 # the LLM.  These modules contain filesystem-write, network-push, or
 # subprocess-spawn operations that could be weaponised via prompt injection.
 _BLOCKED_MODULE_PREFIXES: tuple[str, ...] = (
-    "lerobot.scripts",           # training scripts that spawn subprocesses
+    "lerobot.scripts",  # training scripts that spawn subprocesses
     "lerobot.common.datasets.push",  # HuggingFace Hub push / upload
 )
 

--- a/strands_robots/tools/use_lerobot.py
+++ b/strands_robots/tools/use_lerobot.py
@@ -56,6 +56,22 @@ _MAX_LIST_ITEMS = 1_000  # max items rendered from a list/tuple
 _MAX_DICT_ITEMS = 1_000  # max keys rendered from a dict
 _IMAGE_MAX_DIM = 4096  # arrays larger than this on H or W are still treated as images
 
+# Security hardening: module prefixes whose callables must not be invoked by
+# the LLM.  These modules contain filesystem-write, network-push, or
+# subprocess-spawn operations that could be weaponised via prompt injection.
+_BLOCKED_MODULE_PREFIXES: tuple[str, ...] = (
+    "lerobot.scripts",           # training scripts that spawn subprocesses
+    "lerobot.common.datasets.push",  # HuggingFace Hub push / upload
+)
+
+# Methods on otherwise-safe modules that have dangerous side effects.
+_BLOCKED_METHODS: set[str] = {
+    "push_to_hub",
+    "push_to_hub_revision",
+    "upload_folder",
+    "save_to_disk",
+}
+
 
 # Import resolution
 class LeRobotResolveError(Exception):
@@ -599,6 +615,20 @@ def use_lerobot(
         # If target is not callable, just return its value
         if not callable(target):
             return {"status": "success", "content": [{"text": f"{module}.{method} = {_serialize_result(target)}"}]}
+
+        # Security hardening: block callables in denied modules or methods.
+        full_path = f"lerobot.{module}" if not module.startswith("lerobot.") else module
+        for prefix in _BLOCKED_MODULE_PREFIXES:
+            if full_path.startswith(prefix):
+                return {
+                    "status": "error",
+                    "content": [{"text": f"Blocked: {full_path} is in a restricted module namespace"}],
+                }
+        if method in _BLOCKED_METHODS:
+            return {
+                "status": "error",
+                "content": [{"text": f"Blocked: method '{method}' is not permitted via use_lerobot"}],
+            }
 
         # Call it
         if label:


### PR DESCRIPTION
## Security hardening: device_connect authorization + tool input validation

### Summary

Addresses 5 security findings from a static analysis review of the v0.4.0→HEAD delta. The fixes follow patterns already established in the codebase (sibling drivers, existing `validate_save_path` utility) — no new abstractions introduced.

### Changes

#### 1. ReachyMiniDriver: add missing RPC authorization (HIGH × 2)

**Problem:** All state-mutating RPCs (`look`, `enableMotors`, `disableMotors`, `playMove`, `wakeUp`, `sleep`, `stopMotion`, expression helpers) and the `onEmergencyStop` event handler lacked `is_authorized_caller()` checks. `RobotDeviceDriver` and `SimulationDeviceDriver` both enforce these checks — `ReachyMiniDriver` was the only driver without them.

When `DEVICE_CONNECT_RPC_ALLOW` is configured, any unauthorized Zenoh mesh peer could still actuate the Reachy Mini's physical motors or spoof emergency stop events.

**Fix:** Import `get_rpc_source_device` and `is_authorized_caller` from the existing `_authz` module and gate every state-mutating RPC + the estop handler, matching the sibling drivers exactly. Read-only RPCs (`getJoints`, `getImu`, `listMoves`, `getDaemonStatus`) remain ungated.

#### 2. lerobot_calibrate: path traversal via LLM tool arguments (HIGH + MEDIUM)

**Problem:** `get_calibration_path()` joined `device_type/device_model/device_id` from LLM tool call arguments directly into a filesystem path with no validation. The `base_path` parameter also went unchecked. Combined, these enable reading, writing, and deleting arbitrary `.json` files via prompt injection.

**Fix:**
- Validate `base_path` through the existing `validate_save_path()` utility (blocks `..`, null bytes, protected system dirs).
- Restrict `device_type` to `{"teleoperators", "robots"}` (the only valid values).
- Restrict `device_model` and `device_id` to `[a-zA-Z0-9._-]+` regex — no path separators, no traversal.

#### 3. use_lerobot: denylist for dangerous callable namespaces (HIGH)

**Problem:** The `use_lerobot` tool resolves any dotted path within `lerobot.*` and invokes it with LLM-supplied kwargs. Lerobot includes training scripts (subprocess spawn), HuggingFace Hub push (data exfiltration), and filesystem-write utilities reachable through this dispatch.

**Fix:** Add a denylist gate checked before `target(**params)`:
- `_BLOCKED_MODULE_PREFIXES`: blocks `lerobot.scripts.*` and push-related modules.
- `_BLOCKED_METHODS`: blocks `push_to_hub`, `upload_folder`, `save_to_disk`.

Returns an error status instead of executing. This preserves the tool's discover/describe/call flexibility for safe operations while blocking known-dangerous entry points.

### Testing

- All 3 modified files pass `ast.parse` syntax validation.
- The authorization pattern is identical to `robot_driver.py` / `sim_driver.py` which have existing test coverage (`test_device_connect_hardening.py`).
- Equivalent tests for ReachyMiniDriver should be added (recommend `test_reachy_mini_authz.py` covering: authorized caller succeeds, unauthorized caller gets authz_error, spoofed estop ignored).

### Risk

Low. Changes are additive (new checks on existing code paths). No behavioral change for authorized callers. The calibrate tool will now reject path traversal strings that were never valid device identifiers anyway.
