### PR TITLE
feat(sim): return agent-consumable json block from run_policy

### DIFF
--- a/docs/simulation/overview.md
+++ b/docs/simulation/overview.md
@@ -100,6 +100,8 @@ Robot-URDF cameras are auto-discovered on `add_robot`.
 The step horizon is given either as `duration` (seconds) or as `n_steps` (`duration = n_steps / control_frequency`; `n_steps` wins when both are set, and the legacy `max_steps` is an alias for `n_steps`). A non-positive `n_steps` or `control_frequency` is rejected up front with a structured `status="error"` dict naming the bad parameter - `start_policy` validates synchronously before the background rollout starts, so a malformed horizon never returns a false "started" success.
 
 Pass `seed=` to `run_policy` / `start_policy` for a reproducible single rollout: it reseeds Python / NumPy / torch / cuDNN and forwards `policy.reset(seed=...)`, so a stochastic policy (VLA action-chunk sampling, diffusion noise) produces the same trajectory on re-run of the same scene. Without a seed the rollout draws from the process-global RNG and can differ run to run. `eval_policy` already seeds per episode via the same mechanism.
+
+`run_policy` returns a `{"json": {...}}` content block alongside the human-readable `text`, mirroring `eval_policy`. The json block carries the rollout facts as typed fields - `robot_name`, `policy`, `instruction`, `n_steps`, `elapsed_s`, `stopped_early`, `action_errors`, `video_path` (`None` when no MP4 was written), `video_frames` and `sim_time_s` (when the backend reports it) - so an agent can read the outcome programmatically (did it move? how many steps? where is the video?) without regex-parsing the prose.
 | `replay_episode` | `repo_id`, `robot_name=None`, `episode=0` |
 
 ## Recording

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -416,7 +416,12 @@ class SimEngine(ABC):
                 kwargs per the #300 contract, so forwarding is always safe.
 
         Returns:
-            Standard status dict.
+            Standard status dict with an agent-consumable ``{"json": {...}}``
+            content block alongside the human-readable ``text``. The json block
+            carries the rollout facts as typed fields (``n_steps``,
+            ``elapsed_s``, ``stopped_early``, ``action_errors``, ``video_path``,
+            ``video_frames``, ...) so callers can self-correct programmatically
+            without parsing the text. Mirrors :meth:`eval_policy`.
         """
         from strands_robots.policies import create_policy
 

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -344,7 +344,14 @@ class PolicyRunner:
                 already flows through :meth:`evaluate`'s per-episode reseed.
 
         Returns:
-            ``{"status": "success"|"error", "content": [{"text": ...}]}``.
+            ``{"status": "success"|"error", "content": [{"text": ...},
+            {"json": {...}}]}``. The ``json`` block is agent-consumable and
+            carries the rollout facts as typed fields - ``robot_name``,
+            ``policy``, ``instruction``, ``n_steps``, ``elapsed_s``,
+            ``stopped_early``, ``action_errors``, ``video_path`` (``None`` when
+            no MP4 was written), ``video_frames`` and ``sim_time_s`` (when the
+            backend reports sim time) - so callers can self-correct without
+            regex-parsing the human-readable ``text``.
         """
         # A single rollout draws the policy's stochastic ops (VLA action-
         # chunk sampling, diffusion noise) from the unmanaged global RNG, so the
@@ -578,6 +585,32 @@ class PolicyRunner:
                     video_path,
                 )
                 text += f"\nVideo requested but 0 frames captured ({video_path})"
+        # Agent-consumable structured payload mirroring eval_policy()'s
+        # ``{"json": {...}}`` block. Without this an agent driving run_policy has
+        # to regex-parse the human-readable text to learn how many steps ran,
+        # whether a video was written, or whether the rollout actually moved the
+        # robot -- brittle and a documented AX friction point. The text block is
+        # retained verbatim for humans; the json block carries the same facts as
+        # typed fields for programmatic self-correction (deploy -> observe ->
+        # re-tune loops). Keys are stable: callers can rely on them.
+        payload: dict[str, Any] = {
+            "robot_name": robot_name,
+            "policy": type(policy).__name__,
+            "instruction": instruction,
+            "n_steps": step_count,
+            "elapsed_s": round(elapsed, 3),
+            "stopped_early": stopped_early,
+            "action_errors": _action_errors,
+            "video_path": None,
+            "video_frames": 0,
+        }
+        if sim_time is not None:
+            payload["sim_time_s"] = round(sim_time, 3)
+        if writer is not None and video is not None and video_path is not None:
+            wrote_video = frame_count > 0 and os.path.exists(video_path)
+            payload["video_path"] = video_path if wrote_video else None
+            payload["video_frames"] = frame_count
+
         # If every send_action call failed (all keys unresolved), the robot
         # never moved -- report this as an error rather than a false success.
         if _action_errors > 0 and _action_errors >= step_count and step_count > 0:
@@ -586,10 +619,10 @@ class PolicyRunner:
                 f"-- the robot did not move. Check that the policy's output keys "
                 f"match the robot's actuator names."
             )
-            return {"status": "error", "content": [{"text": text}]}
+            return {"status": "error", "content": [{"text": text}, {"json": payload}]}
         if _action_errors > 0:
             text += f"\n\n{_action_errors}/{step_count} action steps had unresolved keys."
-        return {"status": "success", "content": [{"text": text}]}
+        return {"status": "success", "content": [{"text": text}, {"json": payload}]}
 
     # replay(): replay a LeRobotDataset episode
 

--- a/tests/simulation/test_policy_runner_behaviour.py
+++ b/tests/simulation/test_policy_runner_behaviour.py
@@ -519,3 +519,94 @@ class TestVideoFinalization:
         assert "frames" in text
         assert "30fps" in text
         assert video_path.exists() and video_path.stat().st_size > 0
+
+
+def _json_block(result: dict) -> dict:
+    """Extract the agent-consumable ``{"json": {...}}`` content block."""
+    return next(c["json"] for c in result["content"] if isinstance(c, dict) and "json" in c)
+
+
+class TestRunPolicyStructuredResult:
+    """run_policy / PolicyRunner.run must return an agent-consumable
+    ``{"json": {...}}`` content block alongside the human-readable text, so a
+    caller can read n_steps / video_path / action_errors as typed fields
+    instead of regex-parsing prose. Mirrors eval_policy()'s json block.
+    """
+
+    def test_run_emits_structured_json_block(self, sim_with_robot):
+        policy = MockPolicy()
+        policy.set_robot_state_keys(sim_with_robot.robot_joint_names("alice"))
+        runner = PolicyRunner(sim_with_robot)
+        result = runner.run(
+            "alice",
+            policy,
+            instruction="pick up cube",
+            duration=0.1,
+            control_frequency=50,
+            fast_mode=True,
+        )
+        assert result["status"] == "success", result
+        payload = _json_block(result)
+        assert payload["robot_name"] == "alice"
+        assert payload["policy"] == "MockPolicy"
+        assert payload["instruction"] == "pick up cube"
+        # 0.1s @ 50 Hz -> 5 control steps.
+        assert payload["n_steps"] == 5
+        assert payload["action_errors"] == 0
+        assert payload["stopped_early"] is False
+        assert payload["elapsed_s"] >= 0.0
+        # No video requested -> path is None, zero frames.
+        assert payload["video_path"] is None
+        assert payload["video_frames"] == 0
+
+    def test_json_reports_written_video_path(self, sim_with_robot, tmp_path, monkeypatch):
+        policy = MockPolicy()
+        policy.set_robot_state_keys(sim_with_robot.robot_joint_names("alice"))
+        monkeypatch.setattr(
+            sim_with_robot,
+            "render",
+            lambda *a, **k: TestVideoFinalization._png_render_result(),
+        )
+        video_path = tmp_path / "rollout.mp4"
+        runner = PolicyRunner(sim_with_robot)
+        result = runner.run(
+            "alice",
+            policy,
+            duration=0.2,
+            control_frequency=50,
+            fast_mode=True,
+            video=VideoConfig(path=str(video_path), fps=30, width=16, height=16),
+        )
+        assert result["status"] == "success", result
+        payload = _json_block(result)
+        assert payload["video_path"] == str(video_path)
+        assert payload["video_frames"] > 0
+
+    def test_json_video_path_none_when_no_frames(self, sim_with_robot, tmp_path, monkeypatch):
+        policy = MockPolicy()
+        policy.set_robot_state_keys(sim_with_robot.robot_joint_names("alice"))
+        # Probe passes but in-loop frames never decode -> 0 frames written.
+        calls = {"n": 0}
+
+        def render(*a, **k):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return TestVideoFinalization._png_render_result()
+            return {"status": "success", "content": [{"text": "no image"}]}
+
+        monkeypatch.setattr(sim_with_robot, "render", render)
+        video_path = tmp_path / "empty.mp4"
+        runner = PolicyRunner(sim_with_robot)
+        result = runner.run(
+            "alice",
+            policy,
+            duration=0.1,
+            control_frequency=50,
+            fast_mode=True,
+            video=VideoConfig(path=str(video_path), fps=30, width=16, height=16),
+        )
+        assert result["status"] == "success", result
+        payload = _json_block(result)
+        # Recording was requested but produced no frames -> path None.
+        assert payload["video_path"] is None
+        assert payload["video_frames"] == 0


### PR DESCRIPTION
## Problem

`run_policy` (and the backend-agnostic `PolicyRunner.run` it delegates to) returned only a human-readable `text` content block:

```
Policy complete on 'arm'
MockPolicy | wave the arm
1.3s | 60 steps | sim_t=2.040s
Video: /tmp/rollout.mp4
60 frames, 30fps, 640x480 | 166 KB
```

A caller that wants to act on a rollout - read how many steps ran, find the written video path, detect that the robot never actually moved - has to regex-parse this prose. That is brittle (format drift silently breaks parsers) and inconsistent with the sibling `eval_policy`, which already returns a structured `{"json": {...}}` block next to its text.

## Change

`run_policy` / `PolicyRunner.run` now emit a `{"json": {...}}` content block alongside the text, mirroring `eval_policy`. Fields are stable typed keys:

```json
{
  "robot_name": "arm",
  "policy": "MockPolicy",
  "instruction": "wave the arm",
  "n_steps": 60,
  "elapsed_s": 1.26,
  "stopped_early": false,
  "action_errors": 0,
  "video_path": "/tmp/rollout.mp4",
  "video_frames": 60,
  "sim_time_s": 2.04
}
```

- `video_path` is `None` when no MP4 was written (recording disabled, or requested but zero frames captured); `video_frames` reports the count.
- `action_errors` lets a caller detect the "all actions had unresolved keys, robot never moved" case programmatically instead of scanning the text.
- The text block is retained verbatim for humans. Both the success path and the all-actions-failed error path carry the json block.
- The MuJoCo backend's `run_policy` override delegates to `super().run_policy(...)`, so it inherits the block with no extra change.

## Visual artifact

Headless MuJoCo rollout (`MUJOCO_GL=egl`) of the mock policy on an SO-100 arm, recorded via `video={...}` in the same `run_policy` call that produced the json block above:

![rollout](https://github.com/cagataycali/robots/releases/download/artifact-run-policy-json/rollout_structured.gif)

MP4: https://github.com/cagataycali/robots/releases/download/artifact-run-policy-json/rollout_structured.mp4

## Tests

Adds `TestRunPolicyStructuredResult` in `tests/simulation/test_policy_runner_behaviour.py` (3 tests, all fail pre-change with `StopIteration` because no json block exists):
- structured payload fields on a plain rollout (n_steps, action_errors, stopped_early, video None);
- `video_path` populated when frames are written;
- `video_path` None when recording is requested but zero frames decode.

Local gate on Thor (headless): `ruff check` + `ruff format --check` + `mypy strands_robots tests tests_integ` clean (450 files); full `tests/simulation/` suite 1157 passed, 22 skipped.

## Docs

`docs/simulation/overview.md` and both `run_policy` docstrings document the json block and its fields.