### PR TITLE
feat(sim): add save_episode() for explicit episode boundaries in recording

### DIFF
--- a/docs/recording.md
+++ b/docs/recording.md
@@ -17,11 +17,36 @@ sim.stop_recording()
 
 `start_recording` requires `[lerobot]`. Without it, use `start_cameras_recording` for plain MP4.
 
+## Multi-episode recording
+
+A recording session is one dataset; `run_policy` alone does **not** delimit
+episodes. To collect N episodes in one session, call `save_episode()` after each
+rollout to flush it as its own episode:
+
+```python
+sim.start_recording(repo_id="user/my_dataset", task="pick up the cube", fps=30)
+for _ in range(20):
+    sim.reset()
+    sim.run_policy(robot_name="so100", instruction="pick up the cube",
+                   policy_provider="mock", n_steps=60)
+    sim.save_episode()        # flush this rollout as one episode
+sim.stop_recording()          # flushes any trailing rollout automatically
+# -> 20 episodes, each with its own episode_index / length / from_index / to_index
+```
+
+Without the `save_episode()` call, all 20 rollouts append to the same buffer and
+`stop_recording` flushes them as a single `episode_index=0` (1200 steps in one
+episode). `save_episode` is idempotent on an empty buffer, so it is safe to call
+unconditionally inside a loop. LeRobot computes `stats.json` per episode and then
+aggregates, so per-rollout boundaries keep dataset statistics correct across the
+`reset()` teleport between rollouts.
+
 ## Recording paths
 
 | Method | Extra needed | Output |
 |--------|-------------|--------|
 | `start_recording` / `stop_recording` | `[lerobot]` | LeRobot v3 (parquet + MP4) |
+| `save_episode` | `[lerobot]` | Close current rollout as one episode (call once per `run_policy` for N episodes) |
 | `start_cameras_recording` / `stop_cameras_recording` | `[sim-mujoco]` alone | Plain MP4, no parquet |
 
 ## DatasetRecorder direct API

--- a/docs/simulation/overview.md
+++ b/docs/simulation/overview.md
@@ -107,7 +107,8 @@ Pass `seed=` to `run_policy` / `start_policy` for a reproducible single rollout:
 | Action | Notes |
 |--------|-------|
 | `start_recording(repo_id, task="", fps=30, ...)` | LeRobot v3 (parquet+MP4); requires `[lerobot]` extra |
-| `stop_recording(output_path=None)` | Finalise episode |
+| `save_episode()` | Flush the current rollout as one episode; call once per `run_policy` to record N episodes instead of one merged episode |
+| `stop_recording(output_path=None)` | Finalise dataset (flushes any trailing rollout) |
 | `get_recording_status` | Episode, frame count, output dir |
 | `start_cameras_recording(...)` | Plain MP4 via imageio-ffmpeg; `[sim-mujoco]` only, no lerobot |
 | `stop_cameras_recording` / `get_cameras_recording_status` | - |

--- a/strands_robots/simulation/mujoco/recording.py
+++ b/strands_robots/simulation/mujoco/recording.py
@@ -403,6 +403,106 @@ class RecordingMixin:
 
         return {"status": "success", "content": [{"text": text}]}
 
+    def save_episode(self) -> dict[str, Any]:
+        """Close the current episode and start a fresh one in the same session.
+
+        This is the explicit episode-boundary primitive for multi-episode
+        recording. The documented collection workflow is one ``run_policy``
+        call per episode:
+
+            sim.start_recording(repo_id=..., task=...)
+            for _ in range(n_episodes):
+                sim.run_policy(robot_name=..., n_steps=...)
+                sim.save_episode()   # flush this rollout as its own episode
+            sim.stop_recording()
+
+        Without this call, every ``run_policy`` rollout in a session appends to
+        the SAME buffer, so ``stop_recording`` flushes them as a single
+        ``episode_index=0`` (1200 steps land in one episode instead of N). Each
+        ``save_episode`` writes the buffered frames as a distinct episode with
+        its own ``episode_index`` / ``length`` / ``from_index`` / ``to_index``
+        and resets the per-episode frame buffer; ``stop_recording`` flushes any
+        trailing rollout automatically, so a final ``save_episode`` is optional.
+
+        Per-episode stats (LeRobot computes ``stats.json`` per episode, then
+        aggregates) stay correct because each rollout's frames are isolated to
+        their own episode rather than being mixed across mid-session
+        ``reset()`` teleports.
+
+        Idempotent on an empty buffer: when no frames have been captured since
+        the last boundary (or since ``start_recording``), it succeeds with a
+        "no frames to flush" message rather than tripping LeRobot's
+        "add frames before add_episode" guard, so callers can invoke it
+        unconditionally inside a loop.
+
+        Returns:
+            Standard status dict. On success the ``content`` text reports the
+            episode index and frame count; a structured ``status="error"`` is
+            returned when no recording is active or the underlying flush fails.
+        """
+        if self._world is None or not self._world._backend_state.get("recording", False):
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            "save_episode: not recording. Call start_recording first, "
+                            "then run_policy (once per episode) -> save_episode -> stop_recording."
+                        )
+                    }
+                ],
+            }
+
+        recorder = self._world._backend_state.get("dataset_recorder", None)
+        if recorder is None:
+            return {"status": "error", "content": [{"text": "No dataset recorder active."}]}
+
+        pending = getattr(recorder, "episode_frame_count", 0)
+        if pending <= 0:
+            return {
+                "status": "success",
+                "content": [
+                    {
+                        "text": (
+                            "save_episode: no frames to flush (buffer empty). Run a policy "
+                            "while recording before closing an episode."
+                        )
+                    }
+                ],
+            }
+
+        save_result = recorder.save_episode()
+        if isinstance(save_result, dict) and save_result.get("status") == "error":
+            # The recorder marks itself closed on a failed flush (the LeRobot
+            # episode buffer is in an undefined state); drop it so callers do
+            # not keep appending into a poisoned recorder.
+            self._world._backend_state["recording"] = False
+            self._world._backend_state["dataset_recorder"] = None
+            self._world._backend_state["trajectory"] = []
+            return {
+                "status": "error",
+                "content": [{"text": f"save_episode failed: {save_result.get('message')}"}],
+            }
+
+        # Reset the in-memory trajectory mirror so get_recording_status reports
+        # the NEXT episode from zero (matching the recorder's per-episode reset).
+        self._world._backend_state["trajectory"] = []
+
+        episode = save_result.get("episode")
+        ep_frames = save_result.get("episode_frames")
+        total = save_result.get("total_frames")
+        return {
+            "status": "success",
+            "content": [
+                {
+                    "text": (
+                        f"Episode {episode} saved -- {ep_frames} frames "
+                        f"({total} total across dataset). Buffer reset for the next episode."
+                    )
+                }
+            ],
+        }
+
     def stream_dataset(self, repo_id: str, **kwargs):
         """Open a streaming reader for a LeRobotDataset — read frames straight
         from the Hub (or a local root) with no full materialization.

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1105,6 +1105,20 @@ class MuJoCoSimEngine(
                     bodies.append(body_name)
         base["bodies"] = bodies
         base["methods"]["list_bodies"] = "(robot_name: str | None = None) -> dict (camera mount points)"
+        # Recording / dataset-collection surface (LeRobotDataset, [lerobot] extra).
+        # Exposed here so agents discover the explicit episode-boundary workflow
+        # (start_recording -> run_policy + save_episode per episode -> stop_recording)
+        # instead of guessing method names.
+        base["methods"]["start_recording"] = (
+            "(repo_id='local/sim_recording', task='', fps=30, root=None, "
+            "push_to_hub=False, vcodec='libsvtav1', overwrite=False) -> dict"
+        )
+        base["methods"]["save_episode"] = (
+            "() -> dict  (flush current rollout as one episode; call once per "
+            "run_policy to get N episodes instead of one merged episode)"
+        )
+        base["methods"]["stop_recording"] = "(push_to_hub=False, bucket=None, run_id=None) -> dict"
+        base["methods"]["get_recording_status"] = "() -> dict"
 
         if self._world is not None:
             base["sim_time"] = self._world.sim_time
@@ -2021,7 +2035,7 @@ class MuJoCoSimEngine(
                 "get_total_mass, get_sensor_data, get_jacobian, get_mass_matrix, inverse_dynamics, "
                 "forward_kinematics, save_state, load_state, set_body_properties, set_geom_properties; "
                 "[Scene MJCF] replace_scene_mjcf, patch_scene_mjcf, raycast, multi_raycast; "
-                "[Recording] start_recording, stop_recording, get_recording_status, "
+                "[Recording] start_recording, save_episode, stop_recording, get_recording_status, "
                 "start_cameras_recording, stop_cameras_recording, get_cameras_recording_status; "
                 "[Randomize] randomize; "
                 "[Registry] list_urdfs, register_urdf, get_features. "

--- a/tests/simulation/mujoco/test_recording_paths.py
+++ b/tests/simulation/mujoco/test_recording_paths.py
@@ -591,3 +591,132 @@ def test_start_recording_recorder_init_failure_clears_recording_flag(sim_with_tw
     assert r["status"] == "error"
     assert "codec unavailable" in r["content"][0]["text"]
     assert sim_with_two_robots._world._backend_state.get("recording") is False
+
+
+@pytest.fixture
+def sim_with_one_robot():
+    """Single-robot sim for episode-boundary tests (clean, unprefixed joints)."""
+    from strands_robots.simulation import Simulation
+
+    tmpdir = tempfile.mkdtemp()
+    path = os.path.join(tmpdir, "test_arm.xml")
+    with open(path, "w") as f:
+        f.write(_ROBOT_XML)
+
+    s = Simulation()
+    s.create_world()
+    s.add_robot("arm", urdf_path=path)
+    s.step(5)
+    yield s
+    s.destroy()
+    shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_save_episode_delimits_one_episode_per_rollout(sim_with_one_robot, tmp_path):
+    """Episode-boundary regression: ``save_episode`` after each ``run_policy``
+    rollout produces one LeRobotDataset episode per rollout.
+
+    Pre-fix the Simulation facade had no public episode-boundary primitive, so
+    N ``run_policy`` calls in a single recording session all appended into the
+    SAME buffer and ``stop_recording`` flushed them as a single
+    ``episode_index=0`` (e.g. 3 rollouts -> 1 long episode). Calling
+    ``save_episode`` between rollouts now writes each rollout as its own
+    episode with a distinct ``episode_index`` / length.
+    """
+    from strands_robots.dataset_recorder import has_lerobot_dataset
+
+    if not has_lerobot_dataset():
+        pytest.skip("lerobot not installed")
+
+    sim = sim_with_one_robot
+    root = str(tmp_path / "perep")
+    r = sim.start_recording(repo_id="local/perep", fps=20, root=root, overwrite=True)
+    assert r["status"] == "success", r
+
+    n_episodes = 3
+    for i in range(n_episodes):
+        rp = sim.run_policy(
+            robot_name="arm",
+            policy_provider="mock",
+            instruction=f"ep{i}",
+            n_steps=5,
+            control_frequency=20.0,
+            fast_mode=True,
+        )
+        assert rp["status"] == "success", rp
+        se = sim.save_episode()
+        assert se["status"] == "success", se
+        assert f"Episode {i + 1} saved" in se["content"][0]["text"]
+
+    r = sim.stop_recording()
+    assert r["status"] == "success", r
+
+    from lerobot.datasets.lerobot_dataset import LeRobotDataset
+
+    ds = LeRobotDataset(repo_id="local/perep", root=root)
+    assert ds.meta.total_episodes == n_episodes, f"expected {n_episodes} episodes, got {ds.meta.total_episodes}"
+    # Each episode carries its own length and the frames partition cleanly.
+    lengths = [ds.meta.episodes[ep]["length"] for ep in range(n_episodes)]
+    assert all(length == 5 for length in lengths), f"episode lengths: {lengths}"
+    assert ds.meta.total_frames == sum(lengths) == n_episodes * 5
+
+
+def test_without_save_episode_rollouts_collapse_into_one_episode(sim_with_one_robot, tmp_path):
+    """Documents the contrast: WITHOUT ``save_episode`` between rollouts, all
+    frames land in a single episode. This pins the exact behaviour the boundary
+    primitive fixes - run_policy alone does not delimit episodes.
+    """
+    from strands_robots.dataset_recorder import has_lerobot_dataset
+
+    if not has_lerobot_dataset():
+        pytest.skip("lerobot not installed")
+
+    sim = sim_with_one_robot
+    root = str(tmp_path / "collapsed")
+    assert sim.start_recording(repo_id="local/collapsed", fps=20, root=root, overwrite=True)["status"] == "success"
+
+    for i in range(3):
+        sim.run_policy(
+            robot_name="arm",
+            policy_provider="mock",
+            instruction=f"ep{i}",
+            n_steps=5,
+            control_frequency=20.0,
+            fast_mode=True,
+        )
+    assert sim.stop_recording()["status"] == "success"
+
+    from lerobot.datasets.lerobot_dataset import LeRobotDataset
+
+    ds = LeRobotDataset(repo_id="local/collapsed", root=root)
+    assert ds.meta.total_episodes == 1
+    assert ds.meta.total_frames == 15
+
+
+def test_save_episode_without_recording_is_graceful_error(sim_with_one_robot):
+    """save_episode outside an active recording session returns a structured
+    error (not a raise), pointing at the correct workflow."""
+    r = sim_with_one_robot.save_episode()
+    assert r["status"] == "error"
+    assert "not recording" in r["content"][0]["text"]
+
+
+def test_save_episode_empty_buffer_is_idempotent(sim_with_one_robot, tmp_path):
+    """Calling save_episode with no frames captured since the last boundary
+    succeeds with a 'no frames' message instead of tripping LeRobot's
+    'add frames before add_episode' guard - so loops can call it safely."""
+    from strands_robots.dataset_recorder import has_lerobot_dataset
+
+    if not has_lerobot_dataset():
+        pytest.skip("lerobot not installed")
+
+    sim = sim_with_one_robot
+    root = str(tmp_path / "empty")
+    assert sim.start_recording(repo_id="local/empty", fps=20, root=root, overwrite=True)["status"] == "success"
+
+    # No run_policy yet -> nothing buffered.
+    r = sim.save_episode()
+    assert r["status"] == "success"
+    assert "no frames" in r["content"][0]["text"]
+
+    sim.stop_recording()


### PR DESCRIPTION
## Problem

A recording session writes one LeRobotDataset, but the `Simulation` facade had no public primitive to delimit episodes *within* a session. Every `run_policy` rollout appends to the same frame buffer, so `stop_recording` flushes all of them as a single `episode_index=0`.

Concretely, the natural multi-episode collection loop silently produces one giant episode:

```python
sim.start_recording(repo_id="user/data", task="reach")
for _ in range(20):
    sim.reset()
    sim.run_policy(robot_name="so101", n_steps=60)   # 20 rollouts
sim.stop_recording()
# -> total_episodes == 1, total_frames == 1200   (NOT 20 episodes)
```

`DatasetRecorder.save_episode()` already existed and does the right thing, but it was buried in `_world._backend_state["dataset_recorder"]` and unreachable through the public API. This silently corrupts every downstream training job that assumes per-rollout episode boundaries (per-episode stats, episode sampling, success labelling).

## Change

Add `Simulation.save_episode()` -- the explicit episode-boundary primitive. It flushes the current rollout as its own episode and resets the per-episode buffer. The collection workflow becomes:

```python
sim.start_recording(repo_id="user/data", task="reach")
for _ in range(20):
    sim.reset()
    sim.run_policy(robot_name="so101", n_steps=60)
    sim.save_episode()        # flush this rollout as one episode
sim.stop_recording()          # flushes any trailing rollout automatically
# -> total_episodes == 20, each with its own episode_index / length / from_index / to_index
```

Properties:
- `stop_recording` still flushes the trailing rollout, so a final `save_episode` is optional.
- Idempotent on an empty buffer (returns success with a "no frames" message instead of tripping LeRobot's "add frames before add_episode" guard), so loops can call it unconditionally.
- On a failed underlying flush it drops the poisoned recorder and returns a structured `status="error"` (no silent corruption, no raise past dispatch).
- Per-episode `stats.json` stays correct: LeRobot computes stats per episode then aggregates, so isolating each rollout to its own episode avoids mixing frames across the `reset()` teleport between rollouts.

Also surfaces the recording methods (`start_recording` / `save_episode` / `stop_recording` / `get_recording_status`) in `describe()` so the workflow is discoverable without guessing method names. The method auto-dispatches through the existing agent-tool router (no required params, no alias needed).

## Tests

`tests/simulation/mujoco/test_recording_paths.py`:
- `test_save_episode_delimits_one_episode_per_rollout` -- 3 rollouts + `save_episode` each -> 3 episodes of equal length, frames partition cleanly. **Fails pre-fix** (`AttributeError: 'MuJoCoSimEngine' object has no attribute 'save_episode'`).
- `test_without_save_episode_rollouts_collapse_into_one_episode` -- pins the contrasting current behaviour (3 rollouts with no boundary -> 1 episode of 15 frames).
- `test_save_episode_without_recording_is_graceful_error` -- structured error, not a raise.
- `test_save_episode_empty_buffer_is_idempotent` -- empty-buffer flush succeeds with a "no frames" message.

Full recording suite green locally (76 passed): `test_recording_paths.py`, `test_stop_recording_finalize.py`, `test_dataset_recorder.py`. Lint clean (`ruff check`, `ruff format --check`, `mypy strands_robots tests tests_integ` -> no issues).

## Visual artifact

Rollout in MuJoCo sim (headless EGL): 4 rollouts recorded into one session with `save_episode()` after each -> a 4-episode LeRobotDataset (160 frames, 40/episode). Round-trip verified by reopening with `LeRobotDataset` (`total_episodes == 4`, lengths `[40, 40, 40, 40]`). Below is the recorded per-camera stream (`observation.images.default`, 640x480, 160 frames) the dataset wrote:

![save_episode multi-episode rollout](https://github.com/cagataycali/robots/releases/download/artifact-save-episode/save_episode_demo.gif)

MP4: https://github.com/cagataycali/robots/releases/download/artifact-save-episode/save_episode_demo.mp4

## Docs

`docs/recording.md` gains a "Multi-episode recording" section; `docs/recording.md` and `docs/simulation/overview.md` method tables list `save_episode`.