### PR TITLE
feat(training): stream a Hub dataset into the LeRobot trainer (no full download)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Added: stream a Hub dataset into the LeRobot trainer (no full download)
+
+`TrainSpec` and the `train_policy` tool gained a `streaming` flag and a
+`dataset_repo_id` field so a LeRobot post-tune can pull frames on the fly from a
+Hugging Face Hub dataset instead of materializing it locally first. Previously
+the only data source was a local `dataset_root`, so training a large dataset
+(BitRobot / HIW-500, ~50-500 GB) required downloading the whole thing before the
+first forward pass - blowing disk on an edge node and wasting wall-clock.
+
+- `TrainSpec.dataset_repo_id` (`org/name`) is an alternative data source to
+  `dataset_root`; when set, the LeRobot trainer uses it as
+  `DatasetConfig.repo_id` and treats `dataset_root` as an optional local cache.
+- `TrainSpec.streaming=True` selects lerobot's `StreamingLeRobotDataset`
+  (`--dataset.streaming=true`): bounded disk when streaming Hub shards, bounded
+  RAM when streaming a local root.
+- `LerobotTrainer.validate` now accepts either data source and rejects a
+  malformed `dataset_repo_id` (allowlisted `org/name` format) before it reaches
+  a Hub URL. Held-out `val_episodes` splitting is a no-op when streaming a Hub
+  dataset with no local cache (no local `meta/info.json` to count episodes).
+- Other trainers (GR00T, Cosmos3) ignore both fields per the `TrainSpec`
+  tolerance rule. Regression tests pin the argv-parity helper and the typed
+  `TrainPipelineConfig` for Hub-streaming, local-streaming, and local-root
+  paths, and fail on pre-fix code (which hardcoded `repo_id="local"`).
+
 ### Fixed: unified "no world" guard contract across the simulation facade
 
 Every world-touching method on the MuJoCo `Simulation` facade returns a

--- a/docs/training/overview.md
+++ b/docs/training/overview.md
@@ -88,7 +88,9 @@ supports and **ignores the rest** (the same tolerance rule as
 
 | Field | Meaning | Notes |
 |-------|---------|-------|
-| `dataset_root` | LeRobotDataset v3 root | required; has `meta/info.json` |
+| `dataset_root` | LeRobotDataset v3 root | a data source; has `meta/info.json` (optional when `dataset_repo_id` is set) |
+| `dataset_repo_id` | Hub dataset id `org/name` | alternative data source; train from the Hub (lerobot) |
+| `streaming` | stream frames, no full materialize | lerobot `StreamingLeRobotDataset`; bounded disk (Hub) / RAM (local) |
 | `base_model` | HF id / local ckpt to tune from | required for GR00T & Cosmos |
 | `method` | `full` \| `lora` \| `expert_only` \| `frozen_backbone` | `lora`+`expert_only` are mutually exclusive |
 | `tune` | `{llm,visual,projector,diffusion}` | GR00T only |
@@ -122,6 +124,30 @@ agent("Record 50 cube-pick episodes, then post-tune lerobot ACT on the dataset "
 TrainSpec(..., method="lora", lora_r=16, extra={"policy_type": "pi05"})
 # -> lerobot_train --peft.method_type=LORA --peft.r=16 --policy.type=pi05
 ```
+
+#### Streaming a large Hub dataset (no full download)
+
+Real datasets (BitRobot / HIW-500, ~50-500 GB) do not fit on a single edge node.
+Point the trainer at a Hub dataset id and stream it - lerobot pulls shards on
+the fly via `StreamingLeRobotDataset`, so disk stays bounded and the first
+forward pass starts without waiting for a full download:
+
+```python
+TrainSpec(
+    dataset_repo_id="org/hiw_500",   # train from the Hub, not a local root
+    streaming=True,                  # -> --dataset.streaming=true
+    base_model="lerobot/act_aloha_sim",
+    output_dir="/tmp/ft_out",
+    extra={"policy_type": "act"},
+)
+# -> lerobot_train --dataset.repo_id=org/hiw_500 --dataset.streaming=true ...
+```
+
+`dataset_root` is optional here - if given it is used as a local cache root.
+`streaming=True` also works with a local `dataset_root` (streams from disk with
+bounded RAM). Held-out `val_episodes` splitting needs a local `meta/info.json`
+to count episodes, so it is a no-op when streaming a Hub dataset with no local
+cache (the full Hub dataset is used).
 
 ### GR00T (`groot`)
 

--- a/strands_robots/tools/train_policy.py
+++ b/strands_robots/tools/train_policy.py
@@ -49,6 +49,8 @@ def train_policy(
     action: str = "train",
     provider: str = "lerobot_local",
     dataset_root: str | None = None,
+    dataset_repo_id: str | None = None,
+    streaming: bool = False,
     base_model: str = "",
     output_dir: str | None = None,
     embodiment: str | None = None,
@@ -90,7 +92,15 @@ def train_policy(
             ``"cosmos3"`` (NVIDIA Cosmos3), or ``"mock"``. Same name as the
             inference provider in ``create_policy``.
         dataset_root: Path to a LeRobotDataset v3 root (has ``meta/info.json``) -
-            exactly what ``Robot.stop_recording`` writes.
+            exactly what ``Robot.stop_recording`` writes. Optional when
+            ``dataset_repo_id`` is set (then it is the local cache root).
+        dataset_repo_id: Hugging Face Hub dataset id (``org/name``) to train from
+            the Hub instead of a local root - required to ``streaming`` a large
+            (50-500 GB) Hub dataset without downloading it in full. lerobot only.
+        streaming: Stream frames instead of materializing the dataset (lerobot
+            ``StreamingLeRobotDataset``). With ``dataset_repo_id`` this streams
+            Hub shards with bounded disk; with a local ``dataset_root`` it
+            streams from disk with bounded RAM. lerobot only; ignored elsewhere.
         base_model: HF id or local checkpoint to post-tune from. For GR00T this
             is required (``--base_model_path``); ACT-from-scratch leaves it "".
         output_dir: Where checkpoints + logs go.
@@ -165,14 +175,16 @@ def train_policy(
             }
 
         # All remaining actions need a spec.
-        if not dataset_root or not output_dir:
-            return _err("dataset_root and output_dir are required")
+        if not (dataset_root or dataset_repo_id) or not output_dir:
+            return _err("a data source (dataset_root or dataset_repo_id) and output_dir are required")
 
         trainer = create_trainer(provider)
         spec = TrainSpec(
-            dataset_root=dataset_root,
+            dataset_root=dataset_root or "",
+            dataset_repo_id=dataset_repo_id,
+            streaming=streaming,
             base_model=base_model,
-            output_dir=output_dir,
+            output_dir=output_dir or "",
             embodiment=embodiment,
             steps=steps,
             global_batch_size=batch_size,

--- a/strands_robots/training/_validate.py
+++ b/strands_robots/training/_validate.py
@@ -40,7 +40,7 @@ _EXTRA_KEY_RE = re.compile(r"^[a-z][a-z0-9_.]*$")
 # vector: ``base_model="--config_path=/etc/passwd"`` would otherwise parse as a
 # separate flag. An interior ``=`` is harmless (the token stays single, no
 # shell) and is legitimate for HF revision refs, so it is NOT rejected.
-_FLAG_BOUND_FIELDS = ("dataset_root", "output_dir", "base_model", "embodiment")
+_FLAG_BOUND_FIELDS = ("dataset_root", "output_dir", "base_model", "embodiment", "dataset_repo_id")
 
 # Path-like fields additionally get the audited filesystem check (null bytes,
 # ``..`` traversal, protected system directories).

--- a/strands_robots/training/base.py
+++ b/strands_robots/training/base.py
@@ -55,7 +55,22 @@ class TrainSpec:
             ``meta/info.json``). This is exactly what
             :class:`~strands_robots.dataset_recorder.DatasetRecorder` /
             ``Robot.stop_recording`` produce, so the ``record -> train`` loop
-            needs no conversion layer.
+            needs no conversion layer. When :attr:`dataset_repo_id` is set this
+            is optional and, if given, acts as a local cache root for the Hub
+            dataset (lerobot ``DatasetConfig.root``).
+        dataset_repo_id: Hugging Face Hub dataset id (``org/name``) to train
+            *from the Hub* instead of a local root. Required for
+            :attr:`streaming` of a Hub dataset (the 50-500 GB case that would
+            otherwise have to download in full first). When set, the backend
+            uses it as lerobot's ``DatasetConfig.repo_id`` and leaves
+            ``dataset_root`` as an optional local cache. Mutually sufficient
+            with ``dataset_root`` - supply exactly one as the data source.
+        streaming: Stream frames from the dataset instead of materializing it
+            (lerobot ``DatasetConfig.streaming`` -> ``StreamingLeRobotDataset``).
+            With :attr:`dataset_repo_id` this streams shards from the Hub with no
+            full download (bounded disk); with a local ``dataset_root`` it
+            streams from disk (bounded RAM). LeRobot-only; other backends ignore
+            it (tolerance rule).
         base_model: HF model id or local checkpoint path to post-tune *from*.
         output_dir: Directory for checkpoints, logs, and the final artifact.
         embodiment: Embodiment tag / robot id. Required by GR00T
@@ -96,9 +111,10 @@ class TrainSpec:
     """
 
     # --- universal ---
-    dataset_root: str
-    base_model: str
-    output_dir: str
+    dataset_root: str = ""
+    base_model: str = ""
+    output_dir: str = ""
+    dataset_repo_id: str | None = None
     embodiment: str | None = None
     steps: int = 10_000
     global_batch_size: int = 32
@@ -118,6 +134,7 @@ class TrainSpec:
     val_episodes: int | None = None
     augmentation: dict[str, Any] | None = None
     fps: int | None = None
+    streaming: bool = False
     # --- escape hatch ---
     extra: dict[str, Any] = field(default_factory=dict)
 

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -38,6 +38,7 @@ import contextlib
 import json
 import logging
 import os
+import re
 import shutil
 import time
 from typing import TYPE_CHECKING, Any
@@ -66,6 +67,11 @@ _LEROBOT_POLICY_TYPES = {
 }
 
 _SUPPORTED_METHODS = {"full", "lora", "expert_only"}
+
+# Hugging Face Hub dataset id: ``org/name`` (each segment alnum plus ._-). Used
+# to gate the agent-supplied ``dataset_repo_id`` before it becomes lerobot's
+# ``DatasetConfig.repo_id`` (which load_dataset/HfApi feed to a Hub URL).
+_HUB_REPO_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$")
 
 
 class LerobotTrainer(Trainer):
@@ -141,9 +147,32 @@ class LerobotTrainer(Trainer):
         cfg_file = self._resume_config_path(output_dir)
         return os.path.dirname(cfg_file) if cfg_file else None
 
+    def _dataset_source(self, spec: TrainSpec) -> tuple[str, str | None]:
+        """Resolve (repo_id, root) for lerobot's ``DatasetConfig``.
+
+        Two mutually sufficient data sources, mirroring lerobot's own model:
+
+        * Hub dataset (``spec.dataset_repo_id`` set) -> ``repo_id`` is the Hub
+          id; ``root`` is the optional local cache dir (``spec.dataset_root`` or
+          ``None``). With ``streaming=True`` lerobot streams shards from the Hub
+          without a full download - the 50-500 GB disk-blowup fix.
+        * Local v3 root (``spec.dataset_root`` only) -> ``repo_id="local"`` and
+          ``root`` is the dataset path, unchanged from the record->train loop.
+        """
+        if spec.dataset_repo_id:
+            return spec.dataset_repo_id, (spec.dataset_root or None)
+        return "local", spec.dataset_root
+
     def _val_split_episodes(self, spec: TrainSpec) -> list[int] | None:
-        """Held-out validation split: train on the FIRST (total - N) episodes."""
+        """Held-out validation split: train on the FIRST (total - N) episodes.
+
+        Requires a local ``meta/info.json`` to know the episode count, so it is
+        a no-op for a Hub dataset with no local cache (``dataset_repo_id`` set,
+        ``dataset_root`` empty) - the full Hub dataset is used in that case.
+        """
         if spec.val_episodes is None:
+            return None
+        if not spec.dataset_root:
             return None
         total = self._dataset_total_episodes(spec.dataset_root)
         if total is not None and 0 < spec.val_episodes < total:
@@ -155,8 +184,18 @@ class LerobotTrainer(Trainer):
     def validate(self, spec: TrainSpec) -> list[str]:
         problems: list[str] = self._security_problems(spec)
 
-        if not spec.dataset_root:
-            problems.append("dataset_root is required")
+        # Data source: either a local v3 root, or a Hub repo id (streaming the
+        # 50-500 GB case without a full download). Exactly one must be present.
+        if spec.dataset_repo_id:
+            if not _HUB_REPO_ID_RE.match(spec.dataset_repo_id):
+                problems.append(
+                    f"dataset_repo_id '{spec.dataset_repo_id}' is not a valid Hub id "
+                    "(expected 'org/name', alnum/._- segments)"
+                )
+            # dataset_root is optional here (local cache root); if given, it need
+            # not yet contain meta/info.json (the Hub provides metadata).
+        elif not spec.dataset_root:
+            problems.append("a data source is required: set dataset_root (local v3) or dataset_repo_id (Hub)")
         elif not os.path.isfile(os.path.join(spec.dataset_root, "meta", "info.json")):
             problems.append(
                 f"dataset_root is not a LeRobotDataset v3 root "
@@ -211,10 +250,10 @@ class LerobotTrainer(Trainer):
         human-readable description of the equivalent command.
         """
         ptype = self._resolve_policy_type(spec)
+        repo_id, root = self._dataset_source(spec)
         cmd = [
             "lerobot.scripts.lerobot_train",
-            "--dataset.repo_id=local",
-            f"--dataset.root={spec.dataset_root}",
+            f"--dataset.repo_id={repo_id}",
             f"--policy.type={ptype}",
             f"--policy.device={self.device}",
             "--policy.push_to_hub=false",
@@ -225,6 +264,10 @@ class LerobotTrainer(Trainer):
             f"--save_freq={spec.save_freq}",
             "--wandb.enable=false",
         ]
+        if root:
+            cmd.insert(2, f"--dataset.root={root}")
+        if spec.streaming:
+            cmd.append("--dataset.streaming=true")
         if spec.base_model:
             cmd.append(f"--policy.pretrained_path={spec.base_model}")
         if spec.seed is not None:
@@ -277,11 +320,15 @@ class LerobotTrainer(Trainer):
         if spec.method == "expert_only" and hasattr(policy_cfg, "train_expert_only"):
             policy_cfg.train_expert_only = True
 
-        dataset_cfg = DatasetConfig(
-            repo_id="local",
-            root=spec.dataset_root,
-            episodes=self._val_split_episodes(spec),
-        )
+        repo_id, root = self._dataset_source(spec)
+        dataset_kwargs: dict[str, Any] = {
+            "repo_id": repo_id,
+            "root": root,
+            "episodes": self._val_split_episodes(spec),
+        }
+        if spec.streaming:
+            dataset_kwargs["streaming"] = True
+        dataset_cfg = DatasetConfig(**dataset_kwargs)
 
         peft_cfg = None
         if spec.method == "lora":

--- a/tests/training/test_lerobot.py
+++ b/tests/training/test_lerobot.py
@@ -266,7 +266,7 @@ class TestValidateAdditionalBranches:
     def test_missing_dataset_root(self, spec):
         spec.dataset_root = ""
         problems = LerobotTrainer().validate(spec)
-        assert any("dataset_root is required" in p for p in problems)
+        assert any("a data source is required" in p for p in problems)
 
     def test_dataset_root_not_v3(self, spec, tmp_path):
         spec.dataset_root = str(tmp_path / "empty")
@@ -580,3 +580,131 @@ class TestTrainOrchestration:
         result = trainer.train(spec)
         assert calls["nproc_per_node"] == 2
         assert result.status == "success"
+
+
+class TestStreamingAndHubSource:
+    """Hub-repo + streaming data source (the 50-500 GB no-download fix).
+
+    A LeRobotDataset can be trained either from a local v3 root (the
+    record->train loop) OR streamed from the Hub by ``dataset_repo_id`` without
+    a full local download. ``streaming`` selects lerobot's
+    ``StreamingLeRobotDataset``. These tests pin both the argv-parity helper and
+    the typed-config path against real lerobot.
+    """
+
+    def test_hub_repo_id_validates_without_local_root(self, tmp_path):
+        # No local v3 root present; a Hub repo id is a sufficient data source.
+        spec = TrainSpec(
+            dataset_root="",
+            dataset_repo_id="lerobot/aloha_sim_transfer_cube_human",
+            base_model="",
+            output_dir=str(tmp_path / "out"),
+            streaming=True,
+            extra={"policy_type": "act"},
+        )
+        assert LerobotTrainer().validate(spec) == []
+
+    def test_invalid_hub_repo_id_rejected(self, tmp_path):
+        spec = TrainSpec(
+            dataset_repo_id="not a repo id!!",
+            base_model="",
+            output_dir=str(tmp_path / "out"),
+            extra={"policy_type": "act"},
+        )
+        problems = LerobotTrainer().validate(spec)
+        assert any("not a valid Hub id" in p for p in problems)
+
+    def test_no_data_source_is_rejected(self, tmp_path):
+        spec = TrainSpec(
+            dataset_root="",
+            base_model="",
+            output_dir=str(tmp_path / "out"),
+            extra={"policy_type": "act"},
+        )
+        problems = LerobotTrainer().validate(spec)
+        assert any("a data source is required" in p for p in problems)
+
+    def test_build_command_streams_from_hub(self, tmp_path):
+        spec = TrainSpec(
+            dataset_root="",
+            dataset_repo_id="lerobot/aloha_sim_transfer_cube_human",
+            base_model="",
+            output_dir=str(tmp_path / "out"),
+            streaming=True,
+            extra={"policy_type": "act"},
+        )
+        cmd = LerobotTrainer(device="cpu").build_command(spec)
+        assert "--dataset.repo_id=lerobot/aloha_sim_transfer_cube_human" in cmd
+        # No local root flag when streaming purely from the Hub.
+        assert not any(c.startswith("--dataset.root=") for c in cmd)
+        assert "--dataset.streaming=true" in cmd
+
+    def test_build_command_local_root_keeps_repo_id_local(self, dataset_root, tmp_path):
+        spec = TrainSpec(
+            dataset_root=dataset_root,
+            base_model="",
+            output_dir=str(tmp_path / "out"),
+            extra={"policy_type": "act"},
+        )
+        cmd = LerobotTrainer(device="cpu").build_command(spec)
+        assert "--dataset.repo_id=local" in cmd
+        assert f"--dataset.root={dataset_root}" in cmd
+        # streaming defaults off -> no flag.
+        assert not any("streaming" in c for c in cmd)
+
+    def test_build_config_streams_from_hub(self, tmp_path):
+        pytest.importorskip("lerobot")
+        spec = TrainSpec(
+            dataset_root="",
+            dataset_repo_id="lerobot/aloha_sim_transfer_cube_human",
+            base_model="",
+            output_dir=str(tmp_path / "out"),
+            streaming=True,
+            extra={"policy_type": "act"},
+        )
+        cfg = LerobotTrainer(device="cpu").build_config(spec)
+        assert cfg.dataset.repo_id == "lerobot/aloha_sim_transfer_cube_human"
+        assert cfg.dataset.root is None
+        assert cfg.dataset.streaming is True
+
+    def test_build_config_local_streaming(self, dataset_root, tmp_path):
+        pytest.importorskip("lerobot")
+        spec = TrainSpec(
+            dataset_root=dataset_root,
+            base_model="",
+            output_dir=str(tmp_path / "out"),
+            streaming=True,
+            extra={"policy_type": "act"},
+        )
+        cfg = LerobotTrainer(device="cpu").build_config(spec)
+        assert cfg.dataset.repo_id == "local"
+        assert cfg.dataset.root == dataset_root
+        assert cfg.dataset.streaming is True
+
+    def test_local_cache_root_with_hub_repo_id(self, tmp_path):
+        # Hub id + a local cache root: repo_id is the Hub id, root is the cache.
+        cache = str(tmp_path / "cache")
+        spec = TrainSpec(
+            dataset_root=cache,
+            dataset_repo_id="lerobot/aloha_sim_transfer_cube_human",
+            base_model="",
+            output_dir=str(tmp_path / "out"),
+            streaming=True,
+            extra={"policy_type": "act"},
+        )
+        repo_id, root = LerobotTrainer()._dataset_source(spec)
+        assert repo_id == "lerobot/aloha_sim_transfer_cube_human"
+        assert root == cache
+
+    def test_val_episodes_noop_without_local_root(self, tmp_path):
+        # No local meta/info.json to count episodes -> use the full Hub dataset.
+        spec = TrainSpec(
+            dataset_root="",
+            dataset_repo_id="lerobot/aloha_sim_transfer_cube_human",
+            base_model="",
+            output_dir=str(tmp_path / "out"),
+            streaming=True,
+            val_episodes=2,
+            extra={"policy_type": "act"},
+        )
+        assert LerobotTrainer()._val_split_episodes(spec) is None


### PR DESCRIPTION
## Problem

The LeRobot post-tune backend (`LerobotTrainer`) had exactly one data source: a fully-downloaded local `dataset_root`. `build_command`/`build_config` hardcoded `DatasetConfig.repo_id="local"` + a local `root`, so training a large dataset (BitRobot / HIW-500, ~50-500 GB) required downloading the whole thing first. On a constrained node this blows disk before the first forward pass and wastes wall-clock, even though lerobot 0.5.x already ships `DatasetConfig.streaming` -> `StreamingLeRobotDataset`.

## Change

Add a streaming data path so a LeRobot fine-tune can pull frames on the fly from the Hub instead of materializing the dataset locally.

- **`TrainSpec.dataset_repo_id`** (`org/name`): an alternative data source to `dataset_root`. When set, the trainer uses it as lerobot's `DatasetConfig.repo_id` and treats `dataset_root` as an optional local cache root.
- **`TrainSpec.streaming`**: selects `StreamingLeRobotDataset` (`--dataset.streaming=true`). Bounded disk when streaming Hub shards; bounded RAM when streaming a local root.
- **`LerobotTrainer.validate`** accepts either data source and rejects a malformed `dataset_repo_id` (allowlisted `org/name`) before it can reach a Hub URL. The defense-in-depth flag-bound input check (`_validate.py`) covers `dataset_repo_id` too. Held-out `val_episodes` splitting is a no-op when streaming a Hub dataset with no local cache (there is no local `meta/info.json` to count episodes), so the full Hub dataset is used in that case.
- **`train_policy` tool** exposes both via new `dataset_repo_id` + `streaming` parameters.
- Other trainers (GR00T, Cosmos3) ignore both new fields per the documented `TrainSpec` tolerance rule.

```python
TrainSpec(
    dataset_repo_id="org/hiw_500",   # train from the Hub, not a local root
    streaming=True,                  # -> --dataset.streaming=true
    base_model="lerobot/act_aloha_sim",
    output_dir="/tmp/ft_out",
    extra={"policy_type": "act"},
)
# -> lerobot_train --dataset.repo_id=org/hiw_500 --dataset.streaming=true ...
```

## Tests

New `TestStreamingAndHubSource` pins both the argv-parity helper (`build_command`) and the typed `TrainPipelineConfig` (`build_config`) against real lerobot for three paths: Hub-streaming (no local root), local-streaming (root + streaming), and the unchanged local-root path. It also covers `dataset_repo_id` validation (valid id, malformed id rejected, no-source rejected) and the `val_episodes` no-op when streaming from the Hub. All 8 new assertions fail on pre-fix code (which raised `TypeError` on the new fields / hardcoded `repo_id="local"`); the unchanged local-root behavior stays green.

`tests/training/` full suite: 206 passed, 4 skipped locally (lerobot 0.5.2 from source). `ruff check`, `ruff format --check`, and `mypy` clean on all changed files.

Grounded against lerobot 0.5.x `DatasetConfig` (`streaming` field) / `StreamingLeRobotDataset`. Docs (`docs/training/overview.md`) + `CHANGELOG.md` updated in the same change.