### PR TITLE
test(audit): cover rotation symlink-discard and fail-soft cascade branches

### DIFF
--- a/tests/mesh/test_audit_log_rotation.py
+++ b/tests/mesh/test_audit_log_rotation.py
@@ -146,3 +146,110 @@ def test_rotate_cascades_and_discards_past_cap(monkeypatch, tmp_path):
     assert (tmp_path / "mesh_audit.jsonl.2").read_text(encoding="utf-8") == "gen1"
     assert not (tmp_path / "mesh_audit.jsonl.3").exists()
     assert not log.exists()
+
+
+# --- _rotate_log_if_needed: symlink + fail-soft cascade branches -----------
+
+
+def test_rotate_discards_symlinked_overflow_without_following_it(monkeypatch, tmp_path, caplog):
+    """An overflow rotated log that is a SYMLINK is unlinked, never followed.
+
+    When a rotation past ``max_files`` lands on a numbered suffix that an
+    attacker has pre-created as a symlink, the cascade deletes the link inode
+    -- it must not traverse the link and redirect the delete onto the link
+    target (a co-tenant file, ``/dev/null``, etc.). ``Path.unlink`` removes
+    the link rather than following it, so the target survives untouched, and
+    a forensic WARNING records the discard.
+    """
+    monkeypatch.setenv("STRANDS_MESH_AUDIT_MAX_BYTES", "10")
+    monkeypatch.setenv("STRANDS_MESH_AUDIT_MAX_FILES", "1")
+    log = tmp_path / "mesh_audit.jsonl"
+    log.write_text("gen0", encoding="utf-8")
+    # max_files=1: the cascade visits suffix ".1", and since 1 + 1 > 1 that
+    # slot is past the cap and gets discarded. Plant ".1" as a symlink to a
+    # precious co-tenant file to prove the discard never follows the link.
+    precious = tmp_path / "precious_cotenant.txt"
+    precious.write_text("do-not-touch", encoding="utf-8")
+    overflow_link = tmp_path / "mesh_audit.jsonl.1"
+    overflow_link.symlink_to(precious)
+
+    with caplog.at_level("WARNING"):
+        audit._rotate_log_if_needed(log, current_size=1000)
+
+    # The discarded symlink was removed and then recreated as a regular file
+    # by the active-log rename (active -> .1); it must no longer be a symlink.
+    assert not overflow_link.is_symlink()
+    # The link target is fully intact -- the discard deleted the link inode,
+    # never truncated or redirected onto the target.
+    assert precious.exists()
+    assert precious.read_text(encoding="utf-8") == "do-not-touch"
+    assert "discarding symlinked rotated log" in caplog.text
+    # The cascade still completed: active -> .1 (now a regular file).
+    assert overflow_link.is_file()
+    assert overflow_link.read_text(encoding="utf-8") == "gen0"
+    assert not log.exists()
+
+
+def test_rotate_is_failsoft_when_cascade_replace_raises(monkeypatch, tmp_path, caplog):
+    """A mid-cascade ``os.replace`` failure (e.g. EXDEV) is logged, not raised.
+
+    Audit rotation runs on the safety hot path under ``_WRITE_LOCK``; a
+    cross-device-rename or permission error while shuffling numbered suffixes
+    must degrade to a WARNING rather than propagate and crash the writer.
+    """
+    monkeypatch.setenv("STRANDS_MESH_AUDIT_MAX_BYTES", "10")
+    monkeypatch.setenv("STRANDS_MESH_AUDIT_MAX_FILES", "3")
+    log = tmp_path / "mesh_audit.jsonl"
+    log.write_text("gen0", encoding="utf-8")
+    rotated_one = tmp_path / "mesh_audit.jsonl.1"
+    rotated_one.write_text("gen1", encoding="utf-8")
+
+    real_replace = audit.os.replace
+
+    def _replace_fails_on_cascade(src, dst):
+        # Fail the cascade step (.1 -> .2) but let the final active -> .1
+        # rename through so we can prove the function pressed on.
+        if str(src).endswith("mesh_audit.jsonl.1"):
+            raise OSError("simulated EXDEV during cascade")
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(audit.os, "replace", _replace_fails_on_cascade)
+
+    with caplog.at_level("WARNING"):
+        # Must not raise.
+        audit._rotate_log_if_needed(log, current_size=1000)
+
+    assert "rotation cascade failed" in caplog.text
+    # The active log still rotated to .1 despite the cascade hiccup.
+    assert rotated_one.read_text(encoding="utf-8") == "gen0"
+    assert not log.exists()
+
+
+def test_rotate_is_failsoft_when_active_rename_raises(monkeypatch, tmp_path, caplog):
+    """A failure renaming the active log to ``.1`` is logged, not raised.
+
+    The final ``os.replace(active, active.1)`` is the last step of rotation.
+    If it fails (full disk, EACCES) the audit subsystem must stay alive: the
+    next write recreates/appends rather than crashing safety.
+    """
+    monkeypatch.setenv("STRANDS_MESH_AUDIT_MAX_BYTES", "10")
+    monkeypatch.setenv("STRANDS_MESH_AUDIT_MAX_FILES", "3")
+    log = tmp_path / "mesh_audit.jsonl"
+    log.write_text("active-bytes" * 4, encoding="utf-8")
+
+    real_replace = audit.os.replace
+
+    def _replace_fails_on_active(src, dst):
+        if str(src).endswith("mesh_audit.jsonl"):
+            raise OSError("simulated ENOSPC renaming active log")
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(audit.os, "replace", _replace_fails_on_active)
+
+    with caplog.at_level("WARNING"):
+        audit._rotate_log_if_needed(log, current_size=1000)
+
+    assert "could not rotate" in caplog.text
+    # Active log untouched (rename failed) -- no .1 was created.
+    assert log.exists()
+    assert not (tmp_path / "mesh_audit.jsonl.1").exists()


### PR DESCRIPTION
## Summary

`_rotate_log_if_needed` (in `strands_robots/mesh/audit.py`) bounds audit-log disk usage by cascading numbered suffixes (`.1` .. `.N`) and discarding history past `max_files`. Three branches of that cascade were untested:

1. **Symlinked overflow discard** -- when a rotation slot past the cap is a symlink (attacker pre-creates `mesh_audit.jsonl.N` pointing at a co-tenant file or `/dev/null`), the discard must delete the link inode and never follow it onto the target. A forensic WARNING records the event.
2. **Cascade `os.replace` fail-soft** -- a mid-cascade rename failure (EXDEV cross-device, EACCES) must degrade to a WARNING, not propagate. Rotation runs on the safety hot path under `_WRITE_LOCK`; an `OSError` escaping here would crash the audit writer.
3. **Active-log rename fail-soft** -- the final `os.replace(active, active.1)` failing (ENOSPC, EACCES) must likewise log and return, leaving the active log in place for the next write rather than crashing safety.

## Change

Adds three regression tests to `tests/mesh/test_audit_log_rotation.py`, extending the existing rotation coverage. No production code changes.

Each test was verified to FAIL when its guarded branch is removed:
- dropping the `src_p.is_symlink()` discard guard -> symlink-discard test fails (no WARNING)
- turning the cascade `except OSError` into a re-raise -> cascade fail-soft test fails (OSError escapes)
- turning the final-rename `except OSError` into a re-raise -> active-rename fail-soft test fails (OSError escapes)

The symlink test also asserts the link target is byte-for-byte intact after rotation, proving the discard removed the link rather than redirecting onto the target.

## Coverage

`tests/mesh/test_audit_log_rotation.py` goes 14 -> 17 tests. The previously-uncovered cascade lines in `audit._rotate_log_if_needed` (the symlink-discard guard and both fail-soft `OSError` handlers) are now exercised.

## Verification

- `ruff check` + `ruff format --check` clean on the changed file
- `mypy tests/mesh/test_audit_log_rotation.py` -- no issues
- `MUJOCO_GL=egl pytest tests/mesh/` -- 1695 passed (env-local `awsiot`/IoT-transport collection errors are unrelated optional-dep gaps)
- `pytest tests/mesh/test_audit_log_rotation.py` -- 17 passed