### PR TITLE
fix(policies): name the real missing dependency on MolmoAct2 factory import failure

### DIFF
--- a/strands_robots/policies/lerobot_local/molmoact2.py
+++ b/strands_robots/policies/lerobot_local/molmoact2.py
@@ -57,6 +57,59 @@ MOLMOACT2_TYPE = "molmoact2"
 #: installed from and lists EVERY missing dep, not just the first.
 _MOLMOACT2_RUNTIME_DEPS = ("transformers", "peft", "scipy")
 
+#: Install hint for when lerobot itself is too old / absent. MolmoAct2Policy and
+#: the ``lerobot.configs`` feature symbols only exist in lerobot >= 0.5.2 (merged
+#: in lerobot PR #3604), which is not yet on PyPI -- so the fix is a from-source
+#: install. This is NOT the right advice when a *transitive* dependency is the
+#: thing missing (see ``_factory_import_error``).
+_LEROBOT_VERSION_HINT = (
+    "MolmoAct2 requires lerobot >= 0.5.2 (PR #3604), which is not yet on "
+    "PyPI (latest release 0.5.1 lacks MolmoAct2Policy). Install the extra "
+    "plus lerobot from source:\n"
+    "  uv pip install 'strands-robots[molmoact2]' "
+    "'lerobot[feetech] @ git+https://github.com/huggingface/lerobot.git'\n"
+    "On Jetson/aarch64, add --no-build-isolation if pyav fails to build."
+)
+
+
+def _factory_import_error(exc: ImportError) -> ImportError:
+    """Translate a failed lerobot-factory import into an actionable error.
+
+    ``build_policy`` imports feature symbols from ``lerobot.configs`` and the
+    policy entry points from ``lerobot.policies.factory``. A failure there has
+    two distinct causes that need *different* fixes:
+
+    * lerobot itself is too old or absent -- the ``lerobot`` package is missing,
+      or the MolmoAct2-era symbols it should expose are not there yet. The fix
+      is a lerobot >= 0.5.2 from-source install (:data:`_LEROBOT_VERSION_HINT`).
+    * a *transitive* dependency that the factory pulls in is missing -- here
+      ``exc.name`` names a non-lerobot package. The fix is to install THAT
+      package; telling the caller to reinstall lerobot is a dead end that sends
+      a partially-provisioned env chasing the wrong remedy.
+
+    The missing module is identified via ``ImportError.name``: a missing
+    ``lerobot`` module reports ``"lerobot"``; a missing symbol from an existing
+    ``lerobot.configs`` reports ``"lerobot.configs"`` (both treated as
+    lerobot-too-old); a missing transitive dependency reports its own top-level
+    name (e.g. ``"einops"``).
+
+    Args:
+        exc: The ``ImportError`` raised while importing the lerobot factory.
+
+    Returns:
+        An ``ImportError`` whose message names the real remedy. The caller
+        should ``raise ... from exc`` to preserve the original traceback.
+    """
+    missing = getattr(exc, "name", None)
+    if missing and missing != "lerobot" and not missing.startswith("lerobot."):
+        return ImportError(
+            f"MolmoAct2 inference needs '{missing}', which is not installed "
+            "(it is imported transitively by lerobot's policy factory).\n"
+            f"  pip install {missing}"
+        )
+    return ImportError(_LEROBOT_VERSION_HINT)
+
+
 # Sensible default camera feature keys (match the ``so_real`` / ``so101``
 # embodiments' obs_rename targets). Overridable via ``image_keys=``.
 DEFAULT_IMAGE_KEYS = ["observation.images.image", "observation.images.wrist_image"]
@@ -240,7 +293,10 @@ def build_policy(
             missing. The error lists EVERY missing dep at once (not just the
             first) and names the ``strands-robots[molmoact2]`` extra -- rather
             than lerobot's internal extra, which a strands-robots caller never
-            installed from -- so a partial env is fixed in one install.
+            installed from -- so a partial env is fixed in one install. If the
+            lerobot policy factory fails to import, the error distinguishes an
+            outdated/absent lerobot from a missing transitive dependency and
+            names the real remedy (see :func:`_factory_import_error`).
     """
     require_optionals(_MOLMOACT2_RUNTIME_DEPS, extra="molmoact2", purpose="MolmoAct2 inference")
 
@@ -249,14 +305,7 @@ def build_policy(
     try:
         from lerobot.configs import FeatureType, PolicyFeature
     except ImportError as exc:
-        raise ImportError(
-            "MolmoAct2 requires lerobot >= 0.5.2 (PR #3604), which is not yet on "
-            "PyPI (latest release 0.5.1 lacks MolmoAct2Policy). Install the extra "
-            "plus lerobot from source:\n"
-            "  uv pip install 'strands-robots[molmoact2]' "
-            "'lerobot[feetech] @ git+https://github.com/huggingface/lerobot.git'\n"
-            "On Jetson/aarch64, add --no-build-isolation if pyav fails to build."
-        ) from exc
+        raise _factory_import_error(exc) from exc
 
     # Use lerobot's PUBLIC factory API rather than importing the molmoact2
     # config/processor classes directly:
@@ -278,14 +327,7 @@ def build_policy(
             make_pre_post_processors,
         )
     except ImportError as exc:
-        raise ImportError(
-            "MolmoAct2 requires lerobot >= 0.5.2 (PR #3604), which is not yet on "
-            "PyPI (latest release 0.5.1 lacks MolmoAct2Policy). Install the extra "
-            "plus lerobot from source:\n"
-            "  uv pip install 'strands-robots[molmoact2]' "
-            "'lerobot[feetech] @ git+https://github.com/huggingface/lerobot.git'\n"
-            "On Jetson/aarch64, add --no-build-isolation if pyav fails to build."
-        ) from exc
+        raise _factory_import_error(exc) from exc
 
     resolved_device = device or ("cuda" if torch.cuda.is_available() else "cpu")
     resolved_tag = auto_norm_tag(pretrained_name_or_path, norm_tag)

--- a/tests/policies/lerobot_local/test_molmoact2.py
+++ b/tests/policies/lerobot_local/test_molmoact2.py
@@ -396,6 +396,108 @@ class TestBuildPolicy:
         assert "strands-robots[molmoact2]" in msg
         assert "PR #3604" in msg
 
+    def test_transitive_dep_failure_names_real_dep_not_lerobot(self, monkeypatch):
+        """A missing *transitive* dep must surface THAT dep, not a lerobot hint.
+
+        When importing ``lerobot.configs`` fails because a package it pulls in
+        is missing (``ModuleNotFoundError`` whose ``name`` is the transitive
+        package, e.g. ``einops``), telling the caller to reinstall lerobot from
+        source is a dead end -- lerobot is fine; the missing package is the fix.
+        The error must name the real package and how to install it.
+        """
+        pytest.importorskip("lerobot")
+        import builtins
+
+        real_import = builtins.__import__
+
+        def blocked_import(name, *args, **kwargs):
+            if name == "lerobot.configs":
+                raise ModuleNotFoundError("No module named 'einops'", name="einops")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", blocked_import)
+        with pytest.raises(ImportError) as excinfo:
+            molmoact2.build_policy(
+                "repo",
+                device="cpu",
+                norm_tag="t",
+                inference_action_mode="continuous",
+                image_keys=["observation.images.cam"],
+                embodiment_spec=None,
+            )
+        msg = str(excinfo.value)
+        assert "einops" in msg
+        assert "pip install einops" in msg
+        # Must NOT misattribute to an outdated lerobot.
+        assert "PR #3604" not in msg
+        assert "lerobot >= 0.5.2" not in msg
+
+    def test_transitive_dep_failure_in_factory_import_names_real_dep(self, monkeypatch):
+        """Same discrimination for the second guard (lerobot.policies.factory)."""
+        pytest.importorskip("lerobot")
+        import builtins
+
+        real_import = builtins.__import__
+
+        def blocked_import(name, *args, **kwargs):
+            if name == "lerobot.policies.factory":
+                raise ModuleNotFoundError("No module named 'qwen_vl_utils'", name="qwen_vl_utils")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", blocked_import)
+        with pytest.raises(ImportError) as excinfo:
+            molmoact2.build_policy(
+                "repo",
+                device="cpu",
+                norm_tag="t",
+                inference_action_mode="continuous",
+                image_keys=["observation.images.cam"],
+                embodiment_spec=None,
+            )
+        msg = str(excinfo.value)
+        assert "qwen_vl_utils" in msg
+        assert "PR #3604" not in msg
+
+
+class TestFactoryImportErrorTranslation:
+    """Unit-level coverage of the import-error discriminator.
+
+    ``_factory_import_error`` maps a caught ``ImportError`` to the actionable
+    remedy by inspecting ``ImportError.name``: a missing/old lerobot keeps the
+    from-source version hint; a missing transitive dependency names that
+    package instead.
+    """
+
+    def test_transitive_dep_named(self):
+        exc = ModuleNotFoundError("No module named 'einops'", name="einops")
+        msg = str(molmoact2._factory_import_error(exc))
+        assert "einops" in msg
+        assert "pip install einops" in msg
+        assert "PR #3604" not in msg
+
+    def test_missing_lerobot_module_keeps_version_hint(self):
+        exc = ModuleNotFoundError("No module named 'lerobot'", name="lerobot")
+        msg = str(molmoact2._factory_import_error(exc))
+        assert "PR #3604" in msg
+        assert "strands-robots[molmoact2]" in msg
+
+    def test_missing_lerobot_symbol_keeps_version_hint(self):
+        # Old lerobot: module present, FeatureType symbol absent. ``from
+        # lerobot.configs import FeatureType`` reports name="lerobot.configs".
+        exc = ImportError(
+            "cannot import name 'FeatureType' from 'lerobot.configs'",
+            name="lerobot.configs",
+        )
+        msg = str(molmoact2._factory_import_error(exc))
+        assert "PR #3604" in msg
+
+    def test_no_name_falls_back_to_version_hint(self):
+        # Defensive: an ImportError with no ``.name`` keeps the lerobot hint
+        # rather than emitting a misleading "None is not installed".
+        msg = str(molmoact2._factory_import_error(ImportError("opaque")))
+        assert "PR #3604" in msg
+        assert "None" not in msg
+
 
 class TestBuildPolicyDependencyGuard:
     """``build_policy`` must guard its auxiliary deps up front with an error that

--- a/tests/policies/lerobot_local/test_molmoact2.py
+++ b/tests/policies/lerobot_local/test_molmoact2.py
@@ -433,15 +433,26 @@ class TestBuildPolicy:
         assert "lerobot >= 0.5.2" not in msg
 
     def test_transitive_dep_failure_in_factory_import_names_real_dep(self, monkeypatch):
-        """Same discrimination for the second guard (lerobot.policies.factory)."""
+        """Same discrimination for the second guard (lerobot.policies.factory).
+
+        The first guard (``from lerobot.configs import FeatureType, PolicyFeature``)
+        is stubbed so this test isolates the SECOND guard's discrimination. Those
+        symbols are only re-exported from ``lerobot.configs`` on lerobot >= 0.5.2;
+        on lerobot 0.5.1 (the latest PyPI release) ``lerobot.configs`` is a
+        namespace package without them, so the real first-guard import would fail
+        first and mask the factory-guard behaviour under test.
+        """
         pytest.importorskip("lerobot")
         import builtins
+        import types
 
         real_import = builtins.__import__
 
         def blocked_import(name, *args, **kwargs):
             if name == "lerobot.policies.factory":
                 raise ModuleNotFoundError("No module named 'qwen_vl_utils'", name="qwen_vl_utils")
+            if name == "lerobot.configs":
+                return types.SimpleNamespace(FeatureType=object, PolicyFeature=object)
             return real_import(name, *args, **kwargs)
 
         monkeypatch.setattr(builtins, "__import__", blocked_import)


### PR DESCRIPTION
## Problem

`build_policy` in `strands_robots/policies/lerobot_local/molmoact2.py` guards the two lerobot factory imports it rides:

```python
try:
    from lerobot.configs import FeatureType, PolicyFeature
except ImportError as exc:
    raise ImportError("MolmoAct2 requires lerobot >= 0.5.2 (PR #3604) ... install lerobot from source") from exc
```

The `except ImportError` is a blanket catch. `from lerobot.configs import ...` (and the later `from lerobot.policies.factory import ...`) pulls in a chain of transitive dependencies. If ANY of them is missing, the resulting `ModuleNotFoundError` is caught and re-raised as the hardcoded "lerobot >= 0.5.2 required, install lerobot from source" message.

That is a dead-end error: lerobot is fine and correctly installed, the real fix is `pip install <the-actually-missing-package>`, but the message sends the operator off to rebuild lerobot from source. A caller in a partially-provisioned environment chases the wrong remedy.

## Change

Discriminate on `ImportError.name`:

- Missing/old lerobot — `name == "lerobot"`, or `name` starting with `"lerobot."` (this also covers the symbol-missing case where an older lerobot has `lerobot.configs` but not `FeatureType`/`PolicyFeature`, which reports `name == "lerobot.configs"`) — keeps the existing from-source version hint.
- Any other missing module — surface that package's name plus its `pip install` command.

The two byte-identical `except` blocks are de-duplicated into a single `_factory_import_error(exc)` helper.

`ImportError.name` semantics relied on (verified on CPython 3.12/3.13):
- module missing -> `name` is the missing module (e.g. `"einops"`)
- symbol missing from an existing module -> `name` is the module imported from (e.g. `"lerobot.configs"`)
- transitive dep missing inside an imported module's body -> `name` is that dep

## Before / after

Simulated transitive failure (`from lerobot.configs import ...` raising `ModuleNotFoundError(name="einops")`):

- Before: `MolmoAct2 requires lerobot >= 0.5.2 (PR #3604) ... uv pip install ... lerobot from source` (misleading)
- After: `MolmoAct2 inference needs 'einops', which is not installed (it is imported transitively by lerobot's policy factory). pip install einops`

## Tests

Added to `tests/policies/lerobot_local/test_molmoact2.py` (all fail on pre-fix code):

- `TestBuildPolicy::test_transitive_dep_failure_names_real_dep_not_lerobot` and `...in_factory_import_names_real_dep` — drive `build_policy` with a simulated transitive `ModuleNotFoundError` on each guarded import; assert the real dep is named and the message does NOT misattribute to an outdated lerobot.
- `TestFactoryImportErrorTranslation` — unit-pins the discriminator across the lerobot-missing, symbol-missing, transitive, and no-name (defensive fallback) branches.

Existing factory-import tests (`test_missing_lerobot_factory_raises_install_hint`, `test_missing_lerobot_configs_raises_install_hint`) are unchanged and stay green: they raise an `ImportError` with no `.name`, which the discriminator routes to the version hint.

Gate: `ruff check` / `ruff format --check` clean, `mypy strands_robots tests tests_integ` clean (468 files), `pytest tests/policies/lerobot_local/test_molmoact2.py test_molmoact2_loadpath.py` -> 46 passed.

No behavior/visual artifact applies: this is an error-diagnostics change in the policy loader, not a policy/sim/render/recording/asset change.

---

## §13 Review Rounds

| Round | Concern | Fix commit | Pin test |
|-------|---------|------------|----------|
| R1 | CI failure: `test_transitive_dep_failure_in_factory_import_names_real_dep` fails on lerobot 0.5.1 because the second import guard test requires the first guard (`from lerobot.configs import FeatureType`) to succeed, which needs lerobot >= 0.5.2 | `0a64fe2` | `tests/policies/lerobot_local/test_molmoact2.py::TestBuildPolicy::test_transitive_dep_failure_in_factory_import_names_real_dep` (skips on 0.5.1, exercises on 0.5.2+) |