### PR TITLE
fix(dataset): refuse to push an empty LeRobotDataset to the Hub

### DIFF
--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -627,9 +627,27 @@ class DatasetRecorder:
             tags: Optional tags for the dataset
             private: Upload as private dataset
 
+        Refuses to publish an empty dataset (no frames written or no episode
+        saved). Pushing then would create a Hub repo containing only
+        ``meta/info.json`` (no parquet, no video) and silently pollute the
+        namespace. The ``stop_recording`` facade has its own empty-dataset
+        guard; this protects the direct-API path (and any caller that reaches
+        ``push_to_hub`` after a rollout that never fed the recorder).
+
         Returns:
-            Dict with push status
+            Dict with push status. ``status="error"`` (no Hub call made) when
+            the dataset is empty.
         """
+        if self.frame_count == 0 or self.episode_count == 0:
+            msg = (
+                f"refusing to push empty dataset {self.dataset.repo_id} "
+                f"({self.frame_count} frames, {self.episode_count} episodes) - "
+                "would create a Hub repo with only meta/info.json. Record frames "
+                "with add_frame and flush at least one episode with save_episode "
+                "before push_to_hub."
+            )
+            logger.error("push_to_hub aborted: %s", msg)
+            return {"status": "error", "message": msg}
         try:
             self.dataset.push_to_hub(tags=tags, private=private)
             logger.info("Dataset pushed to hub: %s", self.dataset.repo_id)

--- a/tests/test_dataset_recorder.py
+++ b/tests/test_dataset_recorder.py
@@ -395,9 +395,43 @@ def test_push_to_hub_success_and_failure():
             raise RuntimeError("network down")
 
     bad = DatasetRecorder(dataset=_BadPush(_state_action_features(["j1"], ["j1"])))
+    bad.episode_count = 1
+    bad.frame_count = 10
     err = bad.push_to_hub()
     assert err["status"] == "error"
     assert "network down" in err["message"]
+
+
+def test_push_to_hub_refuses_empty_dataset_no_frames():
+    """A recorder that captured no frames must not hit the Hub.
+
+    Regression: push_to_hub used to publish unconditionally, so a rollout that
+    never fed the recorder (e.g. driven by eval_policy / a bare step loop)
+    produced a Hub repo containing only meta/info.json. The guard now returns a
+    structured error and makes no Hub call.
+    """
+    ds = _CapturingDataset(_state_action_features(["j1"], ["j1"]))
+    rec = DatasetRecorder(dataset=ds)
+    # frame_count and episode_count are 0 by construction.
+    result = rec.push_to_hub(tags=["sim"])
+
+    assert result["status"] == "error"
+    assert "empty dataset" in result["message"]
+    assert ds.pushed is None  # the underlying dataset.push_to_hub was never called
+
+
+def test_push_to_hub_refuses_frames_without_saved_episode():
+    """Frames buffered but no episode flushed is still an empty dataset on disk."""
+    ds = _CapturingDataset(_state_action_features(["j1"], ["j1"]))
+    rec = DatasetRecorder(dataset=ds)
+    rec.frame_count = 30
+    rec.episode_count = 0  # save_episode was never called (or it failed)
+
+    result = rec.push_to_hub()
+
+    assert result["status"] == "error"
+    assert "empty dataset" in result["message"]
+    assert ds.pushed is None
 
 
 def test_repo_id_root_and_repr_properties():


### PR DESCRIPTION
## Problem

`DatasetRecorder.push_to_hub()` published unconditionally. When a rollout never fed the recorder — e.g. it was driven by `eval_policy` / `evaluate` / `replay_episode` or a bare `step` loop (only `run_policy`'s `on_frame` hook calls `add_frame`), or a `save_episode()` failed — the recorder ends up with `frame_count == 0` / `episode_count == 0`. Calling `push_to_hub()` then created a Hub dataset repo containing only `meta/info.json` (no parquet, no video), silently polluting the namespace.

`stop_recording` already guards the facade path against an empty dataset, but the public direct-API path (`DatasetRecorder.push_to_hub`) did not, so any caller reaching it after a frameless rollout still pushed an empty dataset.

## Change

Guard `push_to_hub`: when `frame_count == 0` or `episode_count == 0`, return a structured `status="error"` with an actionable message and make **no** Hub call, instead of publishing an empty dataset. The error explains that frames are written by `add_frame` and an episode must be flushed with `save_episode` before pushing.

## Tests

Two regression tests in `tests/test_dataset_recorder.py` (both FAIL on pre-fix code, PASS after):
- `test_push_to_hub_refuses_empty_dataset_no_frames` — fresh recorder, 0 frames: returns error, underlying `dataset.push_to_hub` never called.
- `test_push_to_hub_refuses_frames_without_saved_episode` — frames buffered but `episode_count == 0` (episode never flushed): refused.

The existing `test_push_to_hub_success_and_failure` was updated to set non-empty counts so its network-failure path still exercises the real push branch.

Full `tests/test_dataset_recorder.py` (44 tests) green; ruff check/format clean; mypy clean on `strands_robots tests tests_integ`.

## Round-trip verification (MuJoCo, headless EGL)

Real sim record round-trip on `so101` + mock policy, 60 control steps:

```
start_recording: success
run_policy: success
stop_recording: success  -> local/guard-demo -- 60 frames, 1 episode(s)
reopen meta/info.json    -> total_episodes=1 total_frames=60   (non-empty, push allowed)
empty recorder           -> push_to_hub: error, no Hub call    (push blocked)
```

Rollout recorded headless and rendered from the front camera:

![rollout](https://github.com/cagataycali/robots/releases/download/artifact-push-guard/artifact_rollout.gif)

<video src="https://github.com/cagataycali/robots/releases/download/artifact-push-guard/artifact_rollout.mp4" controls></video>