### PR TITLE
test(libero): cover OSC controller-install error classification branches

### DIFF
--- a/tests/benchmarks/libero/test_libero_adapter.py
+++ b/tests/benchmarks/libero/test_libero_adapter.py
@@ -3436,6 +3436,113 @@ class TestInstallActionController:
         assert adapter._action_controller_error is not None
         assert "action_controller" not in sim._world._backend_state
 
+    def test_nonclash_import_error_degrades_even_in_strict_mode(self, caplog, monkeypatch):
+        """#522: A NON-clash ``ImportError``/``AttributeError`` that escapes
+        ``from_sim``'s own classification (e.g. a missing native library such
+        as ``libcuda.so.1`` surfacing as an ``ImportError``) is treated as an
+        absent optional dependency, NOT the fixable numba/coverage clash. It
+        degrades gracefully even when ``strict_action_controller=True`` (the
+        default): records ``_action_controller_error``, logs a WARNING, and
+        returns without raising. Requiring robosuite/EGL as a hard dependency
+        would break installs without the optional extras."""
+        import logging
+
+        from strands_robots.benchmarks.libero.adapter import _LiberoOSCController
+
+        pytest.importorskip("mujoco")
+        adapter = LiberoAdapter.from_text(
+            PICK_CUBE_BDDL,
+            scene_path="/some/scene.xml",
+            install_cameras=False,
+            auto_generate_scene=False,
+            # Strict mode (default): a degrade condition must STILL not raise.
+        )
+        sim = FakeSim(data_config="panda")
+
+        def _boom(*_args, **_kwargs):
+            raise ImportError("libcuda.so.1: cannot open shared object file")
+
+        monkeypatch.setattr(_LiberoOSCController, "from_sim", staticmethod(_boom))
+
+        with caplog.at_level(logging.WARNING, logger="strands_robots.benchmarks.libero.adapter"):
+            adapter._install_action_controller(sim)  # must NOT raise
+
+        assert adapter._action_controller_error is not None
+        assert "dependencies unavailable" in adapter._action_controller_error
+        warned = any("_install_action_controller" in r.message and "no-op" in r.message for r in caplog.records)
+        assert warned, f"expected degrade WARNING; got {[r.message for r in caplog.records]}"
+        assert "action_controller" not in sim._world._backend_state
+
+    def test_unexpected_install_error_raises_in_strict_mode(self, monkeypatch):
+        """#522: An UNEXPECTED exception class (neither Import/Attribute nor a
+        ``_ControllerDependencyMissing``/``_ControllerInstallError``) escaping
+        ``from_sim`` is treated like a fixable install failure:
+        ``strict_action_controller`` (the default) re-raises it as a
+        ``_ControllerInstallError`` so the eval surfaces a structured error
+        instead of silently scoring ``success_rate=0`` with every action
+        dropped."""
+        from strands_robots.benchmarks.libero.adapter import (
+            _ControllerInstallError,
+            _LiberoOSCController,
+        )
+
+        pytest.importorskip("mujoco")
+        adapter = LiberoAdapter.from_text(
+            PICK_CUBE_BDDL,
+            scene_path="/some/scene.xml",
+            install_cameras=False,
+            auto_generate_scene=False,
+        )
+        sim = FakeSim(data_config="panda")
+
+        def _boom(*_args, **_kwargs):
+            raise RuntimeError("OSC controller_factory exploded unexpectedly")
+
+        monkeypatch.setattr(_LiberoOSCController, "from_sim", staticmethod(_boom))
+
+        with pytest.raises(_ControllerInstallError) as excinfo:
+            adapter._install_action_controller(sim)
+
+        # The original exception type is preserved in the surfaced message.
+        assert "unexpected OSC controller install failure" in str(excinfo.value)
+        assert "RuntimeError" in str(excinfo.value)
+        assert adapter._action_controller_error is not None
+        assert "action_controller" not in sim._world._backend_state
+
+    def test_unexpected_install_error_degrades_in_non_strict_mode(self, caplog, monkeypatch):
+        """#522: The same unexpected exception class with
+        ``strict_action_controller=False`` records the failure on
+        ``_action_controller_error``, logs a WARNING, and returns without
+        raising - the opt-out best-effort path for callers that accept
+        no-op'd actions over an aborted eval."""
+        import logging
+
+        from strands_robots.benchmarks.libero.adapter import _LiberoOSCController
+
+        pytest.importorskip("mujoco")
+        adapter = LiberoAdapter.from_text(
+            PICK_CUBE_BDDL,
+            scene_path="/some/scene.xml",
+            install_cameras=False,
+            auto_generate_scene=False,
+            strict_action_controller=False,
+        )
+        sim = FakeSim(data_config="panda")
+
+        def _boom(*_args, **_kwargs):
+            raise RuntimeError("OSC controller_factory exploded unexpectedly")
+
+        monkeypatch.setattr(_LiberoOSCController, "from_sim", staticmethod(_boom))
+
+        with caplog.at_level(logging.WARNING, logger="strands_robots.benchmarks.libero.adapter"):
+            adapter._install_action_controller(sim)  # must NOT raise
+
+        assert adapter._action_controller_error is not None
+        assert "unexpected OSC controller install failure" in adapter._action_controller_error
+        warned = any("_install_action_controller" in r.message and "no-op" in r.message for r in caplog.records)
+        assert warned, f"expected WARNING; got {[r.message for r in caplog.records]}"
+        assert "action_controller" not in sim._world._backend_state
+
     def test_is_numba_coverage_clash_detection(self):
         """#522: ``_is_numba_coverage_clash`` recognises the coverage>=7
         signature both directly and through the exception chain (the


### PR DESCRIPTION
## What

Adds three focused behavior tests for `LiberoAdapter._install_action_controller`, closing the two error-classification branches that were uncovered: the non-clash import/attribute degrade path and the generic unexpected-exception path. These pin the strict/non-strict contract (#522) so a regression in the branching is caught instead of silently dropping every GR00T action.

## Branches covered

`_install_action_controller` classifies failures from `_LiberoOSCController.from_sim` into four buckets. Two were exercised; two were not:

- Non-clash `ImportError`/`AttributeError` (e.g. a missing native library such as `libcuda.so.1` surfacing as an `ImportError`) is treated as an absent optional dependency and degrades gracefully even when `strict_action_controller=True` (warns, records `_action_controller_error`, no raise) rather than being misclassified as the fixable numba/coverage clash.
- An unexpected exception class re-raises as `_ControllerInstallError` in strict mode so the eval surfaces a structured error instead of scoring `success_rate=0` with every action dropped, and degrades with a WARNING in non-strict mode.

## Tests

- `test_nonclash_import_error_degrades_even_in_strict_mode`
- `test_unexpected_install_error_raises_in_strict_mode`
- `test_unexpected_install_error_degrades_in_non_strict_mode`

Each monkeypatches `from_sim` to raise the target exception and asserts the observable behavior (raise vs. degrade, recorded `_action_controller_error`, WARNING emitted, no controller installed) — behavior, not implementation.

## Coverage

`benchmarks/libero/adapter.py`: closes the previously-missing lines 2361-2364 and 2393-2407. Test-only change; no source modified.

## Validation

- `ruff check` / `ruff format --check`: clean
- `mypy strands_robots tests tests_integ`: no issues
- `MUJOCO_GL=egl pytest tests/benchmarks/libero/`: 365 passed, 28 skipped (362 prior + 3 new)