### PR TITLE
fix(replay): read actions from column store, never decode discarded video

### DIFF
--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -675,9 +675,29 @@ class PolicyRunner:
         frames_applied = 0
         start_time = time.time()
 
+        # Replay only consumes the recorded action vector, which lives in the
+        # dataset's parquet column store. A real LeRobotDataset's __getitem__
+        # decodes every camera's video for the frame - wasted work here (the
+        # decoded frames are discarded), and it raises a raw exception when the
+        # video decoder (torchcodec / pyav) is unavailable or an MP4 is
+        # unreadable, breaking replay()'s documented "returns a status dict"
+        # contract for a dataset whose actions are perfectly readable. Read
+        # from ``ds.hf_dataset`` (columns only, no video decode) when present;
+        # fall back to ``ds[idx]`` for dataset objects without a column store.
+        frame_source: Any = ds
+        hf_dataset = getattr(ds, "hf_dataset", None)
+        if hf_dataset is not None:
+            frame_source = hf_dataset
+
         for frame_idx in range(episode_length):
             step_start = time.time()
-            frame = ds[episode_start + frame_idx]
+            try:
+                frame = frame_source[episode_start + frame_idx]
+            except Exception as e:  # noqa: BLE001 - decoder/library errors are opaque
+                return {
+                    "status": "error",
+                    "content": [{"text": (f"Failed to read frame {episode_start + frame_idx} from '{repo_id}': {e}")}],
+                }
 
             action_vals = frame.get("action") if isinstance(frame, dict) else None
             if action_vals is None:

--- a/tests/simulation/test_policy_runner_paths.py
+++ b/tests/simulation/test_policy_runner_paths.py
@@ -159,7 +159,10 @@ def test_replay_reads_actions_without_video_decode(monkeypatch):
             return 3
 
         def __getitem__(self, idx):
-            raise RuntimeError("Could not load libtorchcodec (video decode failed)")
+            # __getitem__ failing a row lookup raises LookupError (the
+            # standard exception for indexing failures); the real decoder
+            # error is carried in the message. replay() catches it broadly.
+            raise LookupError("Could not load libtorchcodec (video decode failed)")
 
     def loader(repo_id, episode, root):
         return _VideoDecodeBroken(), 0, 3
@@ -186,7 +189,8 @@ def test_replay_frame_read_failure_returns_error_dict(monkeypatch):
             return 2
 
         def __getitem__(self, idx):
-            raise RuntimeError("corrupt frame")
+            # Failed row lookup -> LookupError (standard for __getitem__).
+            raise LookupError("corrupt frame")
 
     def loader(repo_id, episode, root):
         return _NoColumnStoreBroken(), 0, 2

--- a/tests/simulation/test_policy_runner_paths.py
+++ b/tests/simulation/test_policy_runner_paths.py
@@ -131,6 +131,77 @@ def test_replay_with_action_vector_larger_than_joint_count(monkeypatch):
     assert r["status"] == "success"
 
 
+def test_replay_reads_actions_without_video_decode(monkeypatch):
+    """replay() must read actions from the parquet column store, not the full
+    ``__getitem__`` that decodes per-frame video.
+
+    A real ``LeRobotDataset.__getitem__`` decodes every camera's video for the
+    frame; replay only needs the recorded action vector. When the video decoder
+    (torchcodec / pyav) is unavailable, ``ds[idx]`` raises a raw exception even
+    though the action column is perfectly readable -- breaking replay()'s
+    documented "returns a status dict" contract. replay() must prefer
+    ``ds.hf_dataset`` (columns only, no video decode) and succeed.
+    """
+
+    class _VideoDecodeBroken:
+        """ds[idx] raises (video decode), but the action column is readable."""
+
+        fps = 30
+
+        class _Columns:
+            def __getitem__(self, idx):
+                return {"action": [0.1 * idx, 0.2, 0.3]}
+
+        def __init__(self):
+            self.hf_dataset = self._Columns()
+
+        def __len__(self):
+            return 3
+
+        def __getitem__(self, idx):
+            raise RuntimeError("Could not load libtorchcodec (video decode failed)")
+
+    def loader(repo_id, episode, root):
+        return _VideoDecodeBroken(), 0, 3
+
+    sim = _MinimalSim(robots=["r0"])
+
+    import strands_robots.dataset_recorder as dr
+
+    monkeypatch.setattr(dr, "load_lerobot_episode", loader, raising=False)
+
+    r = PolicyRunner(sim).replay(repo_id="fake/brokenvideo", speed=100.0)
+    assert r["status"] == "success"
+    assert r["content"][1]["json"]["frames_applied"] == 3
+
+
+def test_replay_frame_read_failure_returns_error_dict(monkeypatch):
+    """A dataset with no column store whose frame read fails must still return a
+    clean status dict (not raise) per replay()'s documented contract."""
+
+    class _NoColumnStoreBroken:
+        fps = 30
+
+        def __len__(self):
+            return 2
+
+        def __getitem__(self, idx):
+            raise RuntimeError("corrupt frame")
+
+    def loader(repo_id, episode, root):
+        return _NoColumnStoreBroken(), 0, 2
+
+    sim = _MinimalSim(robots=["r0"])
+
+    import strands_robots.dataset_recorder as dr
+
+    monkeypatch.setattr(dr, "load_lerobot_episode", loader, raising=False)
+
+    r = PolicyRunner(sim).replay(repo_id="fake/corrupt", speed=100.0)
+    assert r["status"] == "error"
+    assert "corrupt frame" in r["content"][0]["text"]
+
+
 def test_replay_action_none_advances_physics(monkeypatch):
     """Dataset frames with no 'action' key → physics step, still advance."""
 


### PR DESCRIPTION
## Problem

`PolicyRunner.replay` (the engine behind `sim.replay_episode`) only consumes the recorded **action** vector, but it read each frame via `LeRobotDataset.__getitem__`:

```python
frame = ds[episode_start + frame_idx]
action_vals = frame.get("action")
```

`LeRobotDataset.__getitem__` decodes **every camera's video** for that frame. Replay throws those decoded images away, so this is wasted decode work on every frame. Worse, it makes replay fail on datasets whose actions are perfectly readable:

- When the video decoder (torchcodec / pyav) is unavailable or an MP4 is unreadable, `ds[idx]` raises a raw exception.
- `replay()` documents `Returns: Standard status dict with per-frame stats`, but that exception escapes uncaught, so a caller gets a traceback instead of `{"status": "error", ...}`.

The loader was already wrapped to return a clean error dict; only the per-frame access in the loop was unguarded, and it decoded video that replay never uses.

## Change

Read actions from `ds.hf_dataset` (the parquet column store) when present, which returns the `action` column with **no video decode**. Fall back to `ds[idx]` for dataset objects that do not expose a column store (preserves existing behavior for custom/duck-typed datasets). Per-frame reads are wrapped so any opaque decoder/library error returns a clean status dict instead of escaping.

This is both a robustness fix (honors the documented contract; replay no longer depends on a working video decoder it doesn't need) and a performance fix (no per-frame video decode for action-only replay).

## Tests

Added to `tests/simulation/test_policy_runner_paths.py`:

- `test_replay_reads_actions_without_video_decode` - a dataset whose `__getitem__` raises on video decode but whose action column is readable now replays successfully (`frames_applied == 3`). Fails on pre-fix code (raw exception).
- `test_replay_frame_read_failure_returns_error_dict` - a dataset with no column store whose frame read fails returns `{"status": "error"}` with the cause in the message, instead of raising.

Full `tests/simulation/test_policy_runner_paths.py` + `test_policy_runner.py` pass (50 passed, 2 skipped); ruff + mypy clean on touched files.

## Visual proof (MuJoCo sim, headless EGL)

Recorded an SO-100 episode to a LeRobotDataset, then replayed it through the fixed path (actions read from the column store, no video decode) and rendered the front camera:

![so100 replay rollout](https://raw.githubusercontent.com/cagataycali/robots/media/replay_demo.gif)

End-to-end on an environment with a broken video decoder: pre-fix `sim.replay_episode(...)` raised `RuntimeError: Could not load libtorchcodec`; post-fix it returns `status=success`, `frames_applied=100/100`.

## Changelog

**Round 2** - Address CodeQL 'non-standard exception in special method' findings: the two replay test doubles modelled dataset row-read failures by raising `RuntimeError` from `__getitem__`; switched to `LookupError` (the standard exception for an indexing/lookup failure), preserving the realistic decoder/corruption message in the args. `replay()` catches it via its broad except, so the exercised path and assertions are unchanged (both tests still pass).