### PR TITLE
perf(lerobot_local): cache loaded model across policy instances

### DIFF
--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -41,8 +41,46 @@ LerobotLocalPolicy(
     inference_action_mode="continuous",  # "continuous" | "discrete"
     camera_key_map=None,                 # {robot_cam_name: policy_image_key}
     strict_keys=False,                   # raise instead of positional camera fallback
+    cache_model=True,                    # reuse a process-cached model across instances
 )
 ```
+
+## Model caching
+
+Loading a checkpoint reads its weights from disk and uploads them to the
+device. For a large VLA (MolmoAct2 SO-100/101 ships 1295 weight files) that is
+on the order of a minute or more per load. Eval/rollout drivers that build a
+fresh policy per call - e.g. ``create_policy("lerobot_local", ...)`` inside a
+per-episode loop - would otherwise pay that full load cost every time.
+
+By default (`cache_model=True`) the loaded underlying model is cached at
+process level, keyed by `(pretrained_name_or_path, policy_type, device)` (plus
+the MolmoAct2 normalisation/processor knobs). Re-instantiating the policy for
+the same checkpoint reuses the resident model and skips the weight load:
+
+```python
+from strands_robots.policies import create_policy
+from strands_robots.policies.lerobot_local import clear_model_cache
+
+# First build loads the weights; subsequent builds for the same checkpoint
+# reuse the resident model (no reload).
+p1 = create_policy("lerobot_local", pretrained_name_or_path="allenai/MolmoAct2-SO100_101", device="cuda")
+p2 = create_policy("lerobot_local", pretrained_name_or_path="allenai/MolmoAct2-SO100_101", device="cuda")
+
+clear_model_cache()  # evict cached models and free their GPU/CPU memory
+```
+
+The cached object is the same live module shared by every instance with the
+same key. LeRobot policies carry per-episode state (action queue, temporal
+ensemble buffers) that `Policy.reset()` clears between episodes, so sequential
+reuse - including `Simulation.eval_policy` and per-rollout drivers - is safe.
+Pass `cache_model=False` to force a private load when driving two rollouts of
+the same checkpoint+device concurrently, and call `clear_model_cache()` to
+release the held memory.
+
+For multi-episode evaluation, prefer a single `Simulation.eval_policy(..., 
+n_episodes=N)` (or `run_policy(..., policy_object=loaded)`) call, which loads
+the policy once and reuses it across episodes regardless of this cache.
 
 ## Supported models
 

--- a/strands_robots/policies/lerobot_local/__init__.py
+++ b/strands_robots/policies/lerobot_local/__init__.py
@@ -1,5 +1,5 @@
 """LeRobot Local Policy - Direct HuggingFace model inference (no server needed)."""
 
-from .policy import LerobotLocalPolicy
+from .policy import LerobotLocalPolicy, clear_model_cache
 
-__all__ = ["LerobotLocalPolicy"]
+__all__ = ["LerobotLocalPolicy", "clear_model_cache"]

--- a/strands_robots/policies/lerobot_local/molmoact2.py
+++ b/strands_robots/policies/lerobot_local/molmoact2.py
@@ -272,6 +272,7 @@ def build_policy(
     embodiment_spec: Any | None,
     state_dim: int = 6,
     action_dim: int = 6,
+    prebuilt_policy: Any | None = None,
 ) -> tuple[Any, Any, Any, Any]:
     """Build a MolmoAct2 policy + its pre/post processor pipelines.
 
@@ -284,6 +285,11 @@ def build_policy(
         embodiment_spec: Embodiment spec used to derive image keys when not given.
         state_dim: observation.state dimensionality (SO arms = 6).
         action_dim: action dimensionality (SO arms = 6).
+        prebuilt_policy: An already-loaded MolmoAct2 policy to reuse instead
+            of constructing (and reading the checkpoint weights) again. The
+            cheap config + pre/post processors are still rebuilt fresh so
+            the returned tuple is self-consistent; only the expensive weight
+            load is skipped. Used by LerobotLocalPolicy's model cache.
 
     Returns:
         Tuple ``(policy, preprocessor, postprocessor, config)``.
@@ -361,10 +367,15 @@ def build_policy(
         output_features=output_features,
     )
 
-    policy_cls = get_policy_class(MOLMOACT2_TYPE)
-    policy = policy_cls(cfg)
-    policy.to(resolved_device)
-    policy.eval()
+    if prebuilt_policy is not None:
+        # Reuse the already-resident model; skip the expensive weight load.
+        policy = prebuilt_policy
+        logger.info("molmoact2: reusing prebuilt policy on %s (skipped weight load)", resolved_device)
+    else:
+        policy_cls = get_policy_class(MOLMOACT2_TYPE)
+        policy = policy_cls(cfg)
+        policy.to(resolved_device)
+        policy.eval()
 
     # Public dispatcher -> make_molmoact2_pre_post_processors(cfg) under the hood.
     preprocessor, postprocessor = make_pre_post_processors(cfg)

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -12,6 +12,7 @@ Architecture:
 """
 
 import logging
+import threading
 import time
 from collections import deque
 from typing import Any
@@ -24,6 +25,43 @@ from .processor import ProcessorBridge
 from .resolution import resolve_policy_class_by_name, resolve_policy_class_from_hub
 
 logger = logging.getLogger(__name__)
+
+
+# Process-level cache of loaded underlying models, keyed by the load-determining
+# inputs. Loading a VLA checkpoint (e.g. MolmoAct2 SO-100/101 = 1295 weight
+# files) reads gigabytes from disk and uploads them to the GPU - on the order of
+# 100s per load. Re-instantiating ``LerobotLocalPolicy`` for the same checkpoint
+# (the common multi-episode / per-rollout ``create_policy`` pattern) would pay
+# that cost every time. Caching the built nn.Module here lets repeated
+# instances share one resident model.
+#
+# Contract: the cached object is the SAME live nn.Module shared across every
+# wrapper that requests the same key. LeRobot policies hold per-episode mutable
+# state (action queue, temporal-ensemble buffers) which ``Policy.reset()`` (and
+# thus ``PolicyRunner`` between episodes) clears - so SEQUENTIAL reuse is safe.
+# Two wrappers driving the SAME checkpoint+device CONCURRENTLY would share that
+# state; opt out with ``cache_model=False`` for that (rare) case. Call
+# :func:`clear_model_cache` to evict and free the held GPU/CPU memory.
+_MODEL_CACHE: dict[tuple[Any, ...], Any] = {}
+_MODEL_CACHE_LOCK = threading.Lock()
+
+
+def clear_model_cache() -> int:
+    """Evict all cached lerobot_local models, freeing their held memory.
+
+    Returns:
+        Number of cache entries evicted. Best-effort releases the CUDA caching
+        allocator afterwards so freed GPU memory is returned to the driver.
+    """
+    with _MODEL_CACHE_LOCK:
+        n = len(_MODEL_CACHE)
+        _MODEL_CACHE.clear()
+    try:
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+    except (RuntimeError, AssertionError):
+        pass
+    return n
 
 
 class LerobotLocalPolicy(Policy):
@@ -91,6 +129,7 @@ class LerobotLocalPolicy(Policy):
         inference_action_mode: str = "continuous",
         camera_key_map: dict[str, str] | None = None,
         strict_keys: bool = False,
+        cache_model: bool = True,
         **kwargs,
     ):
         self.pretrained_name_or_path = pretrained_name_or_path
@@ -123,6 +162,12 @@ class LerobotLocalPolicy(Policy):
         # camera_key_map covers them). Defaults to False (positional fallback
         # with a warning), preserving zero-config ergonomics.
         self.strict_keys = strict_keys
+        # When True (default), the loaded underlying model is cached at
+        # process level and shared by later instances with the same load
+        # key (see _MODEL_CACHE). Set False to force a private load (e.g.
+        # concurrent rollouts of the same checkpoint that must not share
+        # per-episode model state).
+        self.cache_model = cache_model
         # MolmoAct2-specific knobs. MolmoAct2 SO-100/101 checkpoints are
         # transformers-native (no lerobot draccus `type`), so they take a
         # dedicated load path (see lerobot_local.molmoact2). These are inert
@@ -347,6 +392,29 @@ class LerobotLocalPolicy(Policy):
 
     # Model loading
 
+    def _model_cache_key(self, namespace: str, *extra: Any) -> tuple[Any, ...] | None:
+        """Build the process-cache key for the underlying model load.
+
+        Returns ``None`` when caching is disabled or there is no checkpoint
+        path to key on (a from-scratch / parameterless policy), which makes the
+        cache a transparent no-op for those cases.
+        """
+        if not self.cache_model or not self.pretrained_name_or_path:
+            return None
+        return (namespace, self.pretrained_name_or_path, self.requested_device, *extra)
+
+    def _cache_get(self, key: tuple[Any, ...] | None) -> Any:
+        if key is None:
+            return None
+        with _MODEL_CACHE_LOCK:
+            return _MODEL_CACHE.get(key)
+
+    def _cache_put(self, key: tuple[Any, ...] | None, value: Any) -> None:
+        if key is None:
+            return
+        with _MODEL_CACHE_LOCK:
+            _MODEL_CACHE[key] = value
+
     def _load_model(self) -> None:
         """Load the LeRobot model from pretrained path.
 
@@ -384,16 +452,31 @@ class LerobotLocalPolicy(Policy):
         logger.info("Loading %s...", self.pretrained_name_or_path)
         start = time.time()
 
-        # Resolve the correct policy class
-        if self.policy_type:
-            PolicyClass = resolve_policy_class_by_name(self.policy_type)
+        # Reuse a process-cached model when one was already built for this
+        # (path, policy_type, device) - skips the expensive from_pretrained
+        # weight read + GPU upload on repeat instantiation. The resolved
+        # policy_type is cached alongside the module so a hit needs no hub call.
+        cache_key = self._model_cache_key("generic", self.policy_type)
+        cached = self._cache_get(cache_key)
+        if cached is not None:
+            self._policy, self.policy_type = cached
+            logger.info(
+                "Reusing cached %s for %s (skipped from_pretrained)",
+                type(self._policy).__name__,
+                self.pretrained_name_or_path,
+            )
         else:
-            PolicyClass, self.policy_type = resolve_policy_class_from_hub(self.pretrained_name_or_path)
+            # Resolve the correct policy class
+            if self.policy_type:
+                PolicyClass = resolve_policy_class_by_name(self.policy_type)
+            else:
+                PolicyClass, self.policy_type = resolve_policy_class_from_hub(self.pretrained_name_or_path)
 
-        self._policy = PolicyClass.from_pretrained(self.pretrained_name_or_path)
-        assert self._policy is not None
+            self._policy = PolicyClass.from_pretrained(self.pretrained_name_or_path)
+            assert self._policy is not None
 
-        self._policy.eval()
+            self._policy.eval()
+            self._cache_put(cache_key, (self._policy, self.policy_type))
 
         # Resolve device: prefer user-requested, then config.device, fallback to first param
         if self.requested_device:
@@ -555,6 +638,23 @@ class LerobotLocalPolicy(Policy):
         logger.info("Loading MolmoAct2 (transformers-native) from %s...", self.pretrained_name_or_path)
         start = time.time()
 
+        # Reuse a process-cached MolmoAct2 model when one was already built for
+        # this checkpoint+device+load-knobs. The model weights (1295 files for
+        # the SO-100/101 checkpoint) are the expensive part; the config and
+        # pre/post processors are rebuilt cheaply so the returned tuple is
+        # self-consistent. norm_tag / inference_action_mode / image_keys /
+        # embodiment / dims are part of the key because they shape the processors
+        # (and thus must match the cached weights' intended pipeline).
+        model_cache_key = self._model_cache_key(
+            "molmoact2",
+            self._molmoact2_norm_tag,
+            self._molmoact2_inference_action_mode,
+            tuple(self._molmoact2_image_keys or ()),
+            repr(self._embodiment_spec),
+            state_dim,
+            action_dim,
+        )
+        cached_model = self._cache_get(model_cache_key)
         policy, preprocessor, postprocessor, cfg = _molmoact2.build_policy(
             self.pretrained_name_or_path,
             device=self.requested_device,
@@ -564,7 +664,10 @@ class LerobotLocalPolicy(Policy):
             embodiment_spec=self._embodiment_spec,
             state_dim=state_dim,
             action_dim=action_dim,
+            prebuilt_policy=cached_model,
         )
+        if cached_model is None:
+            self._cache_put(model_cache_key, policy)
 
         self._policy = policy
         self._device = next(policy.parameters()).device

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -60,6 +60,9 @@ def clear_model_cache() -> int:
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
     except (RuntimeError, AssertionError):
+        # Best-effort GPU memory release: the entries are already evicted, so a
+        # failure here (no live CUDA context, driver hiccup) must not turn a
+        # successful cache clear into an error. Swallow and report the count.
         pass
     return n
 

--- a/tests/policies/lerobot_local/conftest.py
+++ b/tests/policies/lerobot_local/conftest.py
@@ -1,0 +1,21 @@
+"""Shared fixtures for lerobot_local policy tests.
+
+The lerobot_local policy keeps a process-level model cache (see
+``strands_robots.policies.lerobot_local.policy._MODEL_CACHE``) keyed by
+``(checkpoint, type, device)``. Many unit tests reuse the placeholder path
+``"test/model"`` with differently shaped mock models, so the cache must be
+cleared around every test to keep them hermetic.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from strands_robots.policies.lerobot_local.policy import clear_model_cache
+
+
+@pytest.fixture(autouse=True)
+def _clear_lerobot_local_model_cache():
+    clear_model_cache()
+    yield
+    clear_model_cache()

--- a/tests/policies/lerobot_local/test_model_cache.py
+++ b/tests/policies/lerobot_local/test_model_cache.py
@@ -1,0 +1,186 @@
+"""Process-level model cache for LerobotLocalPolicy.
+
+Loading a LeRobot/VLA checkpoint (e.g. MolmoAct2 SO-100/101 = 1295 weight
+files) reads gigabytes from disk and uploads them to the GPU. Re-instantiating
+the policy for the same checkpoint - the common pattern when an eval driver
+calls ``create_policy`` per rollout - used to pay that full load cost every
+time. These tests pin that the heavy load happens ONCE per (checkpoint, type,
+device) and is shared by later instances, that opting out forces a private
+load, and that clearing the cache restores a cold load.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from strands_robots.policies.lerobot_local import molmoact2
+from strands_robots.policies.lerobot_local.policy import (
+    LerobotLocalPolicy,
+    clear_model_cache,
+)
+
+
+def _generic_inner():
+    inner = MagicMock()
+    inner.config = MagicMock(
+        input_features={"observation.state": MagicMock(shape=(6,))},
+        output_features={"action": MagicMock(shape=(6,))},
+        device="cpu",
+    )
+    inner.eval.return_value = None
+    return inner
+
+
+def _load_generic(**kwargs):
+    """Instantiate a generic lerobot_local policy with the weight load stubbed."""
+    mock_cls = MagicMock()
+    mock_cls.from_pretrained.side_effect = lambda _path: _generic_inner()
+    with (
+        patch(
+            "strands_robots.policies.lerobot_local.policy.resolve_policy_class_by_name",
+            return_value=mock_cls,
+        ),
+        patch(
+            "strands_robots.policies.lerobot_local.policy.ProcessorBridge.from_pretrained",
+            return_value=MagicMock(is_active=False),
+        ),
+    ):
+        policy = LerobotLocalPolicy(
+            pretrained_name_or_path="test/model",
+            policy_type="act",
+            device="cpu",
+            **kwargs,
+        )
+    return policy, mock_cls
+
+
+class TestGenericModelCache:
+    def setup_method(self):
+        clear_model_cache()
+
+    def teardown_method(self):
+        clear_model_cache()
+
+    def test_second_instance_reuses_cached_model(self):
+        p1, cls1 = _load_generic()
+        assert cls1.from_pretrained.call_count == 1
+
+        p2, cls2 = _load_generic()
+        # The second instance hits the cache: no new from_pretrained call on
+        # its resolver, and it shares the SAME underlying module as the first.
+        assert cls2.from_pretrained.call_count == 0
+        assert p2._policy is p1._policy
+        assert p1._loaded and p2._loaded
+
+    def test_cache_model_false_forces_private_load(self):
+        p1, _ = _load_generic()
+        p2, cls2 = _load_generic(cache_model=False)
+        # Opt-out instance always loads its own module, never sharing.
+        assert cls2.from_pretrained.call_count == 1
+        assert p2._policy is not p1._policy
+
+    def test_clear_model_cache_restores_cold_load(self):
+        _load_generic()
+        evicted = clear_model_cache()
+        assert evicted >= 1
+        _, cls = _load_generic()
+        # After eviction the next instance must rebuild from scratch.
+        assert cls.from_pretrained.call_count == 1
+
+    def test_distinct_device_keys_do_not_collide(self):
+        p_cpu, _ = _load_generic()  # device="cpu"
+        mock_cls = MagicMock()
+        mock_cls.from_pretrained.side_effect = lambda _path: _generic_inner()
+        with (
+            patch(
+                "strands_robots.policies.lerobot_local.policy.resolve_policy_class_by_name",
+                return_value=mock_cls,
+            ),
+            patch(
+                "strands_robots.policies.lerobot_local.policy.ProcessorBridge.from_pretrained",
+                return_value=MagicMock(is_active=False),
+            ),
+        ):
+            p_other = LerobotLocalPolicy(
+                pretrained_name_or_path="test/model",
+                policy_type="act",
+                device="meta",
+            )
+        # A different requested device is a distinct key -> fresh load.
+        assert mock_cls.from_pretrained.call_count == 1
+        assert p_other._policy is not p_cpu._policy
+
+
+class _FakeConfig:
+    def __init__(self):
+        self.n_action_steps = 30
+        self.input_features = {"observation.state": MagicMock(shape=(6,))}
+        self.output_features = {"action": MagicMock(shape=(6,))}
+
+
+class _FakeParam:
+    def __init__(self, device):
+        self.device = device
+
+
+class _FakePolicy:
+    def __init__(self):
+        self.config = _FakeConfig()
+
+    def parameters(self):
+        return iter([_FakeParam(torch.device("cpu"))])
+
+
+class TestMolmoAct2ModelCache:
+    """The MolmoAct2 transformers-native load path shares the same cache.
+
+    Only the heavy ``policy`` module is cached; ``build_policy`` still rebuilds
+    the cheap config + pre/post processors each time and reuses the model via
+    its ``prebuilt_policy`` parameter, so per-instance processor state is never
+    shared.
+    """
+
+    def setup_method(self):
+        clear_model_cache()
+
+    def teardown_method(self):
+        clear_model_cache()
+
+    def _instantiate(self, build_calls):
+        def fake_build_policy(path, **kwargs):
+            build_calls.append(kwargs.get("prebuilt_policy"))
+            policy = kwargs.get("prebuilt_policy") or _FakePolicy()
+            return policy, None, None, _FakeConfig()
+
+        with (
+            patch.object(molmoact2, "is_molmoact2", return_value=True),
+            patch.object(molmoact2, "build_policy", side_effect=fake_build_policy),
+        ):
+            return LerobotLocalPolicy(
+                pretrained_name_or_path="allenai/MolmoAct2-SO100_101",
+                device="cpu",
+                use_processor=False,
+            )
+
+    def test_weights_built_once_and_shared(self):
+        calls: list = []
+        p1 = self._instantiate(calls)
+        p2 = self._instantiate(calls)
+
+        # First build constructs the model (prebuilt=None); the second receives
+        # the cached model as prebuilt_policy, skipping the weight load.
+        assert calls[0] is None
+        assert calls[1] is p1._policy
+        assert p2._policy is p1._policy
+
+    def test_clear_cache_forces_fresh_molmoact2_build(self):
+        calls: list = []
+        self._instantiate(calls)
+        clear_model_cache()
+        self._instantiate(calls)
+        # Both builds were cold (prebuilt_policy=None) because the cache was
+        # cleared between them.
+        assert calls[0] is None
+        assert calls[1] is None

--- a/tests/policies/lerobot_local/test_policy.py
+++ b/tests/policies/lerobot_local/test_policy.py
@@ -1444,6 +1444,7 @@ class TestLoadModelDeviceMove:
         policy._input_features = {}
         policy.processor_overrides = {}
         policy.actions_per_step = 1
+        policy.cache_model = False
 
         mock_policy = _load_model_with_mocks(policy, param_device="meta", bridge_active=False)
 
@@ -1462,6 +1463,7 @@ class TestLoadModelDeviceMove:
         policy._input_features = {}
         policy.processor_overrides = {}
         policy.actions_per_step = 1
+        policy.cache_model = False
 
         mock_policy = _load_model_with_mocks(policy, param_device="cpu", bridge_active=False)
 
@@ -1484,6 +1486,7 @@ class TestLoadModelPostprocessorWarning:
         policy._input_features = {}
         policy.processor_overrides = {}
         policy.actions_per_step = 1
+        policy.cache_model = False
         return policy
 
     def test_warns_without_postprocessor(self, caplog):


### PR DESCRIPTION
## Problem

`LerobotLocalPolicy` reloads the full model on every instantiation. When an eval/rollout driver builds a fresh policy per episode (the natural `create_policy("lerobot_local", ...)`-in-a-loop pattern), each call re-reads the checkpoint weights from disk and re-uploads them to the device. For a large VLA this dominates wall time: `allenai/MolmoAct2-SO100_101` ships 1295 weight files and takes ~100-130s per load, so a 20-episode loop spends ~40 min purely re-loading the same weights.

## Change

Add a process-level cache of the built underlying model in `lerobot_local`:

- Keyed by `(pretrained_name_or_path, policy_type, device)` for the generic LeRobot path, and by the checkpoint + device + normalisation/processor knobs (`norm_tag`, `inference_action_mode`, `image_keys`, embodiment, dims) for the MolmoAct2 transformers-native path.
- Later instances with the same key reuse the resident module and skip the weight load. The resolved `policy_type` is cached alongside the module so a hit needs no extra hub round-trip.
- `molmoact2.build_policy` gains a `prebuilt_policy` parameter: on a cache hit the cheap config + pre/post processors are still rebuilt fresh (so per-instance processor state is never shared), and only the expensive weight construction is skipped.
- New `cache_model: bool = True` constructor flag and `clear_model_cache()` public helper (exported from `strands_robots.policies.lerobot_local`).

### Sharing contract

The cached object is the same live module shared by every instance with the same key. LeRobot policies hold per-episode mutable state (action queue, temporal-ensemble buffers) that `Policy.reset()` clears between episodes, so **sequential** reuse - including `Simulation.eval_policy(n_episodes=N)` and per-rollout drivers - is safe. For the rare case of driving two rollouts of the same checkpoint+device **concurrently**, pass `cache_model=False` for a private load. `clear_model_cache()` evicts cached models and releases the held GPU/CPU memory (best-effort `torch.cuda.empty_cache()`).

Note: for multi-episode evaluation, `Simulation.eval_policy(..., n_episodes=N)` and `run_policy(..., policy_object=loaded)` already load the policy once and reuse it; this cache additionally protects callers that re-`create_policy` per call.

## Measured effect

Real load on a CUDA host with `lerobot/diffusion_pusht` (generic path):

```
1st create_policy (cold load):  6.24s
2nd create_policy (cache hit):  0.222s
3rd create_policy (cache hit):  0.230s
same underlying module shared:  True
speedup cold/cached:            28x
clear_model_cache() -> reload:  fresh module rebuilt
cache_model=False:              private module (not shared)
```

For a MolmoAct2-scale 130s cold load, a 20-episode re-instantiation loop drops from ~43 min to ~2.4 min.

## Tests

`tests/policies/lerobot_local/test_model_cache.py` pins, for both the generic and MolmoAct2 load paths: heavy load happens once and the module is shared across instances; `cache_model=False` forces a private load; `clear_model_cache()` restores a cold load; distinct device keys do not collide. A `conftest.py` autouse fixture clears the module-level cache around every test in the package so the existing `"test/model"`-placeholder tests stay hermetic. All 295 `lerobot_local` tests pass; `ruff`/`ruff format`/`mypy` clean.

## Changelog

**Round 2** - Address CodeQL 'empty except' finding in `clear_model_cache()`: the swallowed `RuntimeError`/`AssertionError` on the best-effort `torch.cuda.empty_cache()` is intentional (entries are already evicted; a release hiccup must not fail the eviction). Added an explanatory comment documenting that intent. No behavior change.