### PR TITLE
fix(cosmos3): validate full embodiment camera set client-side

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,6 +534,25 @@ chunk = policy.get_actions_sync(observation, "pick up the cube")
 # chunk == [{"joint_0": .., ..., "gripper": ..}, ...]  (one dict per timestep)
 ```
 
+The `droid` embodiment (`joint_pos`/RoboArena) conditions on **all three**
+camera views and the server rejects a partial observation. Your
+`observation_mapping` must map a sim/robot camera onto each of
+`observation/wrist_image_left`, `observation/exterior_image_1_left`, and
+`observation/exterior_image_2_left`; an incomplete mapping raises an actionable
+client-side `ValueError` naming the missing keys before any request is sent
+(other embodiments such as `umi`/`av`/`bridge` need only `observation/image`):
+
+```python
+policy = create_policy(
+    "cosmos3", embodiment="droid", port=8000,
+    observation_mapping={
+        "wrist":     "observation/wrist_image_left",
+        "exterior":  "observation/exterior_image_1_left",
+        "exterior2": "observation/exterior_image_2_left",
+    },
+)
+```
+
 **4. Roll out in MuJoCo** - the `droid` embodiment drives a Franka/DROID-class
 arm, so use the `franka` (or `panda`) sim asset:
 

--- a/strands_robots/policies/cosmos3/policy.py
+++ b/strands_robots/policies/cosmos3/policy.py
@@ -112,6 +112,16 @@ class Cosmos3Policy(Policy):
         observation_mapping: ``{robot_obs_key: "observation/<server_key>"}``.
             Maps robot camera + state keys onto the server's OpenPI keys.
             When ``None``, a default mapping is used (see :meth:`_default_obs_mapping`).
+            The mapping MUST cover the embodiment's **full** camera set
+            (:attr:`Cosmos3Embodiment.camera_keys`): the RoboLab server composes
+            its conditioning from all declared views and rejects a partial
+            observation. For the DROID embodiment (``joint_pos``/RoboArena) that
+            is all three keys - ``observation/wrist_image_left``,
+            ``observation/exterior_image_1_left``, and
+            ``observation/exterior_image_2_left``. A mapping that omits any
+            required key (or whose source camera is absent at runtime) raises a
+            client-side ``ValueError`` naming the missing keys, before any
+            request reaches the server.
         action_mapping: ``{action_column_name: robot_actuator_name}``. Renames
             the embodiment's action-layout columns to robot actuator names.
             Keys are validated against the active layout at construction.
@@ -146,7 +156,10 @@ class Cosmos3Policy(Policy):
 
     Notes:
         * This policy needs camera frames **and** robot state in the
-          observation - ``requires_images`` is ``True``.
+          observation - ``requires_images`` is ``True``. Every camera key in
+          the embodiment's :attr:`~Cosmos3Embodiment.camera_keys` must be
+          mapped and present (the DROID embodiment requires all three RoboArena
+          views); a partial set fails fast client-side.
         * Latency is chunked (a diffusion policy), not 500 Hz servo. One
           inference returns a chunk of ~``action_chunk_size`` steps.
         * The predicted world video/sound (diffusers backend) are surfaced on
@@ -403,11 +416,31 @@ class Cosmos3Policy(Policy):
         if self.action_space == "joint_pos":
             self._attach_joint_state(robot_obs, obs)
 
-        # requires_images guard: Cosmos 3 conditions on at least one camera
-        # frame. If the obs_mapping named cameras but none were present in the
-        # runtime observation, fail fast with an actionable message instead of
-        # sending an image-less request the server will reject opaquely.
-        if not any(k.startswith("observation/") and _is_image_key(k) for k in obs):
+        # Camera-set guard: the served embodiment conditions on a fixed set of
+        # camera frames, and the RoboLab server hard-requires the *full* set -
+        # e.g. the DROID joint_pos / RoboArena path composes its views from all
+        # three keys (wrist_image_left + exterior_image_1_left +
+        # exterior_image_2_left) and rejects a partial observation server-side
+        # with an opaque error. Validate every required key is present *before*
+        # sending so a partial observation_mapping (or a camera missing at
+        # runtime) fails fast client-side, naming exactly which keys are missing
+        # instead of an opaque server-side rejection (AGENTS.md key convention
+        # #6: no opaque server-side failures; fail fast with a clear message).
+        required = list(self.embodiment.camera_keys)
+        if required:
+            missing = [k for k in required if k not in obs]
+            if missing:
+                covered = sorted({v for v in self._obs_mapping.values() if _is_image_key(v)})
+                raise ValueError(
+                    f"Cosmos3Policy(embodiment={self.embodiment.name!r}, "
+                    f"action_space={self.action_space!r}) requires camera frames "
+                    f"for: {required}. Missing: {missing}. observation_mapping "
+                    f"covered: {covered}. Available observation keys: "
+                    f"{sorted(robot_obs)}. Map a sim camera to each required key."
+                )
+        elif not any(k.startswith("observation/") and _is_image_key(k) for k in obs):
+            # Degenerate embodiment with no declared camera_keys: still enforce
+            # requires_images (always True) - at least one camera frame.
             raise ValueError(
                 "Cosmos3Policy requires at least one camera frame, but none of the "
                 f"mapped camera keys {sorted(self._obs_mapping)} were found in the "

--- a/tests/policies/cosmos3/test_policy.py
+++ b/tests/policies/cosmos3/test_policy.py
@@ -215,8 +215,78 @@ def test_requires_images_guard_raises_without_camera():
     p.set_robot_state_keys([f"joint_{i}" for i in range(7)] + ["gripper"])
     obs = {f"joint_{i}": 0.1 * i for i in range(7)}
     obs["gripper"] = 0.5  # state only, no camera
-    with pytest.raises(ValueError, match="requires at least one camera"):
+    with pytest.raises(ValueError, match="requires camera frames for"):
         asyncio.run(p.get_actions(obs, "go"))
+
+
+def test_partial_camera_mapping_raises_client_side():
+    """A partial observation_mapping (2 of DROID's 3 views) must fail fast
+    client-side naming the missing key - not send a partial obs that the
+    RoboLab server rejects with an opaque RuntimeError."""
+    client = FakeClient(_droid_chunk())
+    p = Cosmos3Policy(
+        embodiment="droid",
+        client=client,
+        observation_mapping={
+            "front": "observation/wrist_image_left",
+            "exterior": "observation/exterior_image_1_left",
+            # observation/exterior_image_2_left intentionally unmapped
+        },
+    )
+    p.set_robot_state_keys([f"joint_{i}" for i in range(7)] + ["gripper"])
+    img = np.zeros((360, 640, 3), dtype=np.uint8)
+    obs = {"front": img, "exterior": img}
+    for i in range(7):
+        obs[f"joint_{i}"] = 0.1 * i
+    obs["gripper"] = 0.5
+    with pytest.raises(ValueError) as exc:
+        asyncio.run(p.get_actions(obs, "pick up the red cube"))
+    msg = str(exc.value)
+    # Names the missing key explicitly and reports the action space.
+    assert "observation/exterior_image_2_left" in msg
+    assert "Missing:" in msg
+    assert "joint_pos" in msg
+    # The partial obs was NOT forwarded to the server.
+    assert client.last_obs is None
+
+
+def test_camera_present_in_mapping_but_absent_at_runtime_raises():
+    """All three views are mapped, but one source camera is missing from the
+    runtime observation - still fails fast naming the missing server key."""
+    client = FakeClient(_droid_chunk())
+    p = Cosmos3Policy(
+        embodiment="droid",
+        client=client,
+        observation_mapping={
+            "wrist": "observation/wrist_image_left",
+            "ext1": "observation/exterior_image_1_left",
+            "ext2": "observation/exterior_image_2_left",
+        },
+    )
+    p.set_robot_state_keys([f"joint_{i}" for i in range(7)] + ["gripper"])
+    img = np.zeros((360, 640, 3), dtype=np.uint8)
+    obs = {"wrist": img, "ext1": img}  # ext2 camera absent at runtime
+    for i in range(7):
+        obs[f"joint_{i}"] = 0.1 * i
+    obs["gripper"] = 0.5
+    with pytest.raises(ValueError, match="observation/exterior_image_2_left"):
+        asyncio.run(p.get_actions(obs, "go"))
+    assert client.last_obs is None
+
+
+def test_full_camera_set_passes():
+    """The full DROID camera triple satisfies the guard and reaches the server."""
+    client = FakeClient(_droid_chunk())
+    p = Cosmos3Policy(embodiment="droid", client=client)
+    p.set_robot_state_keys([f"joint_{i}" for i in range(7)] + ["gripper"])
+    asyncio.run(p.get_actions(_obs_with_state_and_images(), "go"))
+    assert client.last_obs is not None
+    for key in (
+        "observation/wrist_image_left",
+        "observation/exterior_image_1_left",
+        "observation/exterior_image_2_left",
+    ):
+        assert key in client.last_obs
 
 
 def test_robot_panda_sugar_applies_builtin_mapping():


### PR DESCRIPTION
## Problem

`Cosmos3Policy(backend="service")` accepts an observation that maps only a subset of the embodiment's camera keys, then fails **server-side** with an opaque error instead of failing fast in the client. The `_build_server_observation` guard only checked that **at least one** camera frame was present:

```python
if not any(k.startswith("observation/") and _is_image_key(k) for k in obs):
    raise ValueError("Cosmos3Policy requires at least one camera frame, ...")
```

But the DROID embodiment declares all three RoboArena views, and the RoboLab `joint_pos` server composes its conditioning from **all three** and rejects a partial observation. A natural mistake (a single-arm sim with one wrist + one exterior cam) maps only two of the three keys and the client happily sends a 2-image obs that the server rejects with an opaque `RuntimeError` from `_extract_observation_image`.

## Change

Replace the at-least-one-camera guard in `_build_server_observation` with an embodiment-driven **required-set** check: every key in `Cosmos3Embodiment.camera_keys` must be present in the built observation before sending. On a miss, raise an actionable `ValueError` naming the embodiment, action space, the full required set, exactly which keys are missing, and what the `observation_mapping` covered:

```
Cosmos3Policy(embodiment='droid', action_space='joint_pos') requires camera frames
for: ['observation/wrist_image_left', 'observation/exterior_image_1_left',
'observation/exterior_image_2_left']. Missing: ['observation/exterior_image_2_left'].
observation_mapping covered: [...]. Available observation keys: [...].
Map a sim camera to each required key.
```

This catches two failure modes client-side: an incomplete `observation_mapping`, and a mapped camera that is absent from the runtime observation. Single-camera embodiments (`umi`/`av`/`bridge`) require only `observation/image`; a degenerate embodiment with no declared `camera_keys` still enforces `requires_images` (at least one frame). Consistent with the key convention: no opaque server-side failures; fail fast with a clear message.

## Docs

- `Cosmos3Policy` docstring (`observation_mapping` arg + Notes) documents the full-camera-set requirement.
- README cosmos3 section gains a note + a complete 3-camera `observation_mapping` example for DROID.

## Tests

`tests/policies/cosmos3/test_policy.py`:
- `test_partial_camera_mapping_raises_client_side` - 2-of-3 mapping raises a client-side `ValueError` naming the missing key, action space, and `Missing:`; asserts the partial obs was **not** forwarded to the server.
- `test_camera_present_in_mapping_but_absent_at_runtime_raises` - all three mapped but one source camera missing at runtime still fails fast.
- `test_full_camera_set_passes` - the full DROID triple satisfies the guard and reaches the server.
- Updated `test_requires_images_guard_raises_without_camera` for the new message.

All three new/updated assertions fail on pre-fix code and pass after. Full cosmos3 suite: 155 passed. `ruff check`, `ruff format --check`, and `mypy` clean across 469 source files.

Note on visual artifact: this is a client-side pre-flight validation guard; it does not change policy action output, rendering, or recording, so a rollout video is not applicable (and the service backend requires a live RoboLab GPU server). The proof is the regression tests demonstrating the fail-fast.

Fixes the opaque-server-rejection ergonomics for partial camera mappings on the Cosmos 3 service backend.