### PR TITLE
fix(vera): apply gripper command (gripper_dim_index=-1 means last column, not absent)

### DIFF
--- a/strands_robots/policies/vera/docker/Dockerfile
+++ b/strands_robots/policies/vera/docker/Dockerfile
@@ -116,14 +116,19 @@ COPY strands_robots/policies/vera/docker/launch_server.py /opt/launch_server.py
 ENV PYTHONPATH=/opt:${PYTHONPATH}
 
 # PushT sim deps (Wave-1): lightweight, all on PyPI. The MimicGen sim stack
-# (robomimic/robosuite/mimicgen) is heavier and robomimic 0.5.0 is git-only, so
+# (robomimic/robosuite/mimicgen) is heavier and robomimic 0.5.0 is git-only AND
+# hard-pins huggingface_hub/transformers/diffusers to versions that break the
+# NGC base + WAN planner — so install it --no-deps + only its missing runtime deps. So
 # it is opt-in via --build-arg INSTALL_MIMICGEN_SIM=1.
 RUN pip install "gymnasium==0.29.1" "gym-pusht==0.1.5" "mujoco>=3.5.0" imageio imageio-ffmpeg
 
 ARG INSTALL_MIMICGEN_SIM=0
 RUN if [ "${INSTALL_MIMICGEN_SIM}" = "1" ]; then \
-        pip install "robosuite==1.4.1" "mimicgen==1.0.0" && \
-        pip install "git+https://github.com/ARISE-Initiative/robomimic.git@v0.3.0" ; \
+        pip install "robosuite==1.4.1" && \
+        pip install --no-deps "git+https://github.com/ARISE-Initiative/robomimic.git@v0.5.0" && \
+        git clone --depth 1 -b v1.0.0 https://github.com/NVlabs/mimicgen.git /opt/mimicgen-src && \
+        pip install --no-deps -e /opt/mimicgen-src && \
+        pip install egl_probe tensorboard tensorboardX "mujoco==3.5.0" ; \
     else \
         echo "skipping MimicGen sim stack (set --build-arg INSTALL_MIMICGEN_SIM=1 to include)" ; \
     fi

--- a/strands_robots/policies/vera/provider.py
+++ b/strands_robots/policies/vera/provider.py
@@ -629,14 +629,21 @@ class VeraPolicy(Policy):
         bridge = self._ensure_ik_bridge(mj_model, ee_frame)
         from .sim_ik import decode_vera_delta_chunk_to_targets
 
-        has_gripper = gripper_idx is not None and gripper_idx >= 0
+        # Gripper presence: VERA uses gripper_dim_index == -1 to mean "the gripper
+        # is the LAST column" (Python-style index), NOT "no gripper". Detect a
+        # gripper column from the chunk width vs the pose dims (3 trans + rot):
+        # any trailing column beyond the pose block is the gripper.
+        pose_dims = 3 + self._rotation_dim
+        chunk_dim = int(chunk.shape[1]) if chunk.ndim == 2 else len(chunk)
+        has_gripper = chunk_dim > pose_dims
+        eff_gripper_idx = gripper_idx if (gripper_idx is not None and gripper_idx >= 0) else (chunk_dim - 1)
         result = decode_vera_delta_chunk_to_targets(
             chunk,
             bridge,
             q_init,
             rotation_dim=self._rotation_dim,
             has_gripper=has_gripper,
-            gripper_dim_index=gripper_idx if has_gripper else -1,
+            gripper_dim_index=eff_gripper_idx if has_gripper else -1,
             translation_scale=self._translation_scale,
         )
         qpos = np.asarray(result["qpos"], dtype=np.float32)  # [T, nq]


### PR DESCRIPTION
## Summary

The VERA MimicGen/DROID policy server reports `gripper_dim_index = -1` to mean
"the gripper is the **last** action column" (a Python negative index), but the
provider read `gripper_idx >= 0` as the only "has gripper" signal and therefore
**dropped the gripper command entirely** whenever the server said `-1`.

Result: the Panda gripper never actuated, so the policy could never grasp —
0% manipulation success even though the WAN video planner dreamed a correct
approach → grasp → lift → place.

## Fix

In `VeraPolicy._infer_eef_delta` (`strands_robots/policies/vera/provider.py`),
detect the gripper by the chunk width vs the pose dims (`3 + rotation_dim`) and
resolve `-1` to the last column:

```python
pose_dims = 3 + self._rotation_dim
chunk_dim = int(chunk.shape[1]) if chunk.ndim == 2 else len(chunk)
has_gripper = chunk_dim > pose_dims
eff_gripper_idx = gripper_idx if (gripper_idx is not None and gripper_idx >= 0) else (chunk_dim - 1)
```

**Verified:** with the fix the Panda `finger_joint` targets span 0.0 → 1.0
(full open ↔ close); before the fix the range was 0 (command dropped).

## Also

`docker/Dockerfile`: install `robomimic 0.5.0` + `mimicgen 1.0.0` with
`--no-deps` so their hard pins on `huggingface_hub`/`transformers`/`diffusers`
don't clobber the NGC base + WAN planner; add the missing runtime deps
explicitly (`egl_probe`, `tensorboard`, `mujoco==3.5.0`).

## Testing

`hatch run test` — vera policy suite passes (99 tests on this branch).
ruff check + ruff format + mypy clean on the changed files.

Found while running the real `Cosmos3-Nano-Policy-DROID` reasoner over a VERA
rollout: the dream was coherent but execution showed "gripper open, not holding
any block" — which localised the bug to the dream→action gripper path.
