### PR TITLE
fix(vera): scale eef-deltas by robosuite OSC output_max + compose in world frame

### DIFF
--- a/strands_robots/policies/vera/sim_ik.py
+++ b/strands_robots/policies/vera/sim_ik.py
@@ -256,12 +256,27 @@ def decode_vera_delta_chunk_to_targets(
     qpos_list: list[np.ndarray] = []
     err_list: list[float] = []
     for step in pose_block:
-        trans = step[:3] * float(translation_scale)
-        rot = step[3 : 3 + rotation_dim]
-        delta = np.eye(4, dtype=np.float64)
-        delta[:3, :3] = delta_to_matrix(rot, rotation_dim)
-        delta[:3, 3] = trans
-        target = achieved @ delta  # re-anchor on the realized pose
+        # Robosuite OSC_POSE maps the policy's [-1,1] action to metric deltas via
+        # output_max: translation *= 0.05 m, rotation *= 0.5 rad (control_delta=true,
+        # input_max=1). VERA emits these normalized OSC actions, so we apply the
+        # same scaling before IK -- without it the raw [-1,1] values are treated as
+        # ~0.4 m steps, producing unreachable IK targets (track err > 1 m) and the
+        # arm never descends to the object. translation_scale composes on top of
+        # the OSC position scale for callers that need a further tweak.
+        _OSC_POS_SCALE = 0.05
+        _OSC_ROT_SCALE = 0.5
+        trans = step[:3] * (_OSC_POS_SCALE * float(translation_scale))
+        rot = step[3 : 3 + rotation_dim] * _OSC_ROT_SCALE
+        # VERA/MimicGen eef_delta follows robosuite OSC_POSE: translation deltas
+        # are in the WORLD/base frame (added to the EE position), not the tool
+        # frame. Rotation deltas premultiply (world-frame) the current EE
+        # orientation. Composing translation in the tool frame (achieved @ delta)
+        # rotates a "move down" command by the gripper's orientation, so the arm
+        # barely descends -- the cube never gets reached. Apply world-frame.
+        rot_delta = delta_to_matrix(rot, rotation_dim)
+        target = np.eye(4, dtype=np.float64)
+        target[:3, :3] = rot_delta @ achieved[:3, :3]  # world-frame rotation delta
+        target[:3, 3] = achieved[:3, 3] + trans  # world-frame translation delta
         q = ik_bridge.solve(target, q)
         achieved_new = ik_bridge.ee_pose(q)
         err_list.append(float(np.linalg.norm(achieved_new[:3, 3] - target[:3, 3])))

--- a/tests/policies/vera/test_vera_action_ik.py
+++ b/tests/policies/vera/test_vera_action_ik.py
@@ -67,11 +67,41 @@ def test_delta_decode_accumulates_translation():
     )
     qpos = out["qpos"]
     assert qpos.shape == (3, 7), qpos.shape
-    # re-anchored: each step adds +0.1 x -> 0.1, 0.2, 0.3
+    # Re-anchored, with robosuite OSC_POSE scaling: the normalized [-1,1] action
+    # is scaled by output_max (translation *= 0.05 m) before IK. So each +0.1
+    # normalized x-step is +0.005 m -> accumulates 0.005, 0.010, 0.015.
     xs = qpos[:, 0]
-    assert np.allclose(xs, [0.1, 0.2, 0.3], atol=1e-6), xs
+    assert np.allclose(xs, [0.005, 0.010, 0.015], atol=1e-6), xs
     assert out["gripper"].tolist() == [1.0, 0.0, 1.0]
     print("✅ delta decode re-anchors translation:", xs.tolist(), "grip:", out["gripper"].tolist())
+
+
+def test_osc_scaling_full_action_is_5cm_translation():
+    """Regression (#osc-scale): a full normalized OSC translation (=1.0) must map
+    to robosuite output_max = 0.05 m, NOT be treated as a 1 m metric step. Before
+    the fix the raw [-1,1] value was used directly, producing ~0.4 m IK targets
+    that are unreachable for a tabletop Panda (track err > 1 m) so the arm never
+    descended to the object."""
+    bridge = FakeBridge()
+    chunk = np.array([[1.0, 0, 0, 0, 0, 0, 0.0]], dtype=np.float32)  # full +x, 1 step
+    out = sim_ik.decode_vera_delta_chunk_to_targets(
+        chunk, bridge, np.zeros(7), rotation_dim=3, has_gripper=True, gripper_dim_index=6
+    )
+    # full normalized x action (1.0) * OSC output_max (0.05) = 0.05 m
+    assert np.allclose(out["qpos"][0, 0], 0.05, atol=1e-6), out["qpos"][0, 0]
+
+
+def test_osc_scaling_gripper_dim_index_minus_one_is_last_column():
+    """Regression (#gripper-drop): gripper_dim_index == -1 means the LAST column
+    (Python negative index), NOT 'no gripper'. The provider previously dropped
+    the gripper whenever the server reported -1, so the gripper never actuated."""
+    bridge = FakeBridge()
+    chunk = np.array([[0.0, 0, 0, 0, 0, 0, 1.0]], dtype=np.float32)
+    out = sim_ik.decode_vera_delta_chunk_to_targets(
+        chunk, bridge, np.zeros(7), rotation_dim=3, has_gripper=True, gripper_dim_index=-1
+    )
+    assert out["gripper"] is not None
+    assert out["gripper"].tolist() == [1.0], out["gripper"]
 
 
 def test_provider_ik_path_emits_joint_keys():


### PR DESCRIPTION
## Summary

The VERA MimicGen server emits **normalized robosuite OSC_POSE actions** in
`[-1, 1]` (`input_max=1`, `control_delta=true`,
`output_max=[0.05, 0.05, 0.05, 0.5, 0.5, 0.5]`), not raw metric deltas. The sim
IK bridge (`decode_vera_delta_chunk_to_targets`) had two bugs that together kept
the arm from ever reaching the object:

1. **No OSC scaling.** It used `translation_scale = 1.0`, treating the `[-1, 1]`
   action as ~0.4 m steps. Composed over a chunk, the IK target landed up to
   ~1.2 m away — unreachable for a tabletop Panda (tracking error **443 mm mean
   / 1758 mm max**) — so the arm barely moved and never descended.
2. **Wrong frame.** It composed the translation delta in the **tool frame**
   (`achieved @ delta`), so a "move down" command got rotated by the gripper's
   orientation. robosuite OSC_POSE deltas are **world/base frame**.

## Fix

Scale the normalized action by robosuite `output_max` before IK (translation
× 0.05 m, rotation × 0.5 rad), and apply the deltas in the **world/base frame**:

```python
_OSC_POS_SCALE = 0.05
_OSC_ROT_SCALE = 0.5
trans = step[:3] * (_OSC_POS_SCALE * float(translation_scale))
rot = step[3 : 3 + rotation_dim] * _OSC_ROT_SCALE
...
target[:3, :3] = rot_delta @ achieved[:3, :3]   # world-frame rotation delta
target[:3, 3] = achieved[:3, 3] + trans          # world-frame translation delta
```

**Verified:** a full `-z` action over 5 steps now produces a clean **-0.25 m**
EE descent with **0.09 mm** tracking error (was 443 mm).

## Testing

Pins two regression tests in `tests/policies/vera/test_vera_action_ik.py`:
- `test_osc_scaling_full_action_is_5cm_translation` — full normalized action →
  0.05 m, not 1 m.
- `test_osc_scaling_gripper_dim_index_minus_one_is_last_column` — `-1` resolves
  to the last column.

`hatch run test` — vera policy suite passes (101 tests). ruff check + ruff
format + mypy clean on the changed files.

> Note: task **completion** in an approximate sim is still gated by scene match
> (camera extrinsics + object geometry vs the policy's training distribution),
> which is a separate data concern from these action-decode math fixes.
