### PR TITLE
fix(recording): flush buffered rollout as an episode on reset()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: `reset()` during recording flushes the buffered rollout as an episode
+
+A `run_policy` + `reset` data-collection loop silently merged every rollout into
+a single `episode_index=0`: `meta/info.json` reported `total_episodes: 1` and the
+episodes parquet held one row even after N distinct rollouts, because the
+recorder buffered all rollouts together and only `stop_recording` flushed them.
+Downstream training/eval that slices by episode then saw one giant episode
+instead of N. `run_policy` alone does not delimit episodes, and `reset` (the
+natural between-rollout boundary, since `n_episodes` is an `eval_policy` param,
+not a `run_policy` one) did not either.
+
+- `Simulation.reset()` now flushes a pending recording episode before
+  re-initializing the world: when a recording is active and the recorder has
+  buffered frames, `reset` calls `save_episode()` first and reports the saved
+  episode in its result text. This mirrors `stop_recording`, which already
+  auto-flushes the trailing episode.
+- `save_episode()` remains the explicit boundary primitive; it is a no-op on an
+  empty buffer, so `reset` calls that are not preceded by recorded frames (two
+  resets in a row, a reset right after `start_recording`, or `eval_policy`'s
+  internal per-episode resets, which do not feed the recorder) create no
+  spurious empty episodes.
+- To DISCARD a partial rollout instead of flushing it, call
+  `clear_episode_buffer()` before `reset()`.
+- Regression tests pin one-episode-per-rollout for a `run_policy` + `reset`
+  loop, the empty-buffer no-op, and the unchanged non-recording reset path; they
+  fail on pre-fix code (`total_episodes == 1`).
+
+
 ### Added: stream a Hub dataset into the LeRobot trainer (no full download)
 
 `TrainSpec` and the `train_policy` tool gained a `streaming` flag and a

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -34,12 +34,33 @@ sim.stop_recording()          # flushes any trailing rollout automatically
 # -> 20 episodes, each with its own episode_index / length / from_index / to_index
 ```
 
-Without the `save_episode()` call, all 20 rollouts append to the same buffer and
-`stop_recording` flushes them as a single `episode_index=0` (1200 steps in one
-episode). `save_episode` is idempotent on an empty buffer, so it is safe to call
+`save_episode` is idempotent on an empty buffer, so it is safe to call
 unconditionally inside a loop. LeRobot computes `stats.json` per episode and then
 aggregates, so per-rollout boundaries keep dataset statistics correct across the
 `reset()` teleport between rollouts.
+
+`reset()` is itself an episode boundary during a recording: if frames are
+buffered when you call it, `reset()` flushes them as their own episode before
+re-initializing the world (it reports the saved episode in its result text).
+This means a bare `run_policy` + `reset` collection loop already produces one
+episode per rollout - the explicit `save_episode()` is optional when you reset
+between rollouts:
+
+```python
+sim.start_recording(repo_id="user/my_dataset", task="pick up the cube", fps=30)
+for _ in range(20):
+    sim.run_policy(robot_name="so100", instruction="pick up the cube",
+                   policy_provider="mock", n_steps=60)
+    sim.reset()               # flushes this rollout as one episode, then resets
+sim.stop_recording()          # flushes any trailing rollout automatically
+# -> 20 episodes
+```
+
+Without either an explicit `save_episode()` or a `reset()` between rollouts, all
+20 rollouts append to the same buffer and `stop_recording` flushes them as a
+single `episode_index=0` (1200 steps in one episode). To DISCARD a partial
+rollout instead of flushing it on the next `reset()`, call
+`clear_episode_buffer()` first.
 
 ## Recording paths
 

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -899,7 +899,7 @@ class SimEngine(ABC):
                 "start_policy": "(robot_name: str, policy_provider='mock', ...) -> dict",
                 "list_robots": "() -> list[str]",
                 "render": "(camera_name='default', width=None, height=None) -> dict",
-                "reset": "() -> dict",
+                "reset": "() -> dict  # during recording, flushes the buffered rollout as one episode before resetting",
                 "step": "(n_steps: int = 1) -> dict",
             },
             "note": (

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1603,6 +1603,33 @@ class MuJoCoSimEngine(
         # reset during a running policy races mj_step -> SEGFAULT risk
         if err := self._require_no_running_policy("reset"):
             return err
+
+        # A reset re-initializes the world, which is the start of a new
+        # rollout. If a recording is active with buffered (unsaved) frames,
+        # flush them as their own episode BEFORE the teleport mixes the next
+        # rollout into the same buffer. Without this, a run_policy + reset
+        # collection loop silently merges every rollout into a single
+        # episode_index=0 (total_episodes stuck at 1) - a data-integrity bug
+        # for downstream training/eval that slices by episode. This mirrors
+        # stop_recording, which already auto-flushes the trailing episode.
+        # save_episode() is a no-op on an empty buffer, so resets that are not
+        # preceded by recorded frames (e.g. eval_policy's internal per-episode
+        # resets, which do not feed the recorder) are unaffected. To DISCARD a
+        # partial rollout instead of flushing it, call clear_episode_buffer()
+        # before reset().
+        flush_note = ""
+        if self._world._backend_state.get("recording", False):
+            recorder = self._world._backend_state.get("dataset_recorder")
+            pending = getattr(recorder, "episode_frame_count", 0) if recorder is not None else 0
+            if pending > 0:
+                save_result = self.save_episode()
+                if save_result.get("status") != "success":
+                    # save_episode failed -> the recorder poisoned itself and
+                    # the facade already cleared the recording flag. Surface
+                    # the failure rather than resetting into an undefined state.
+                    return save_result
+                flush_note = save_result["content"][0]["text"] + " "
+
         mj = self._mj
         with self._lock:
             mj.mj_resetData(self._world._model, self._world._data)
@@ -1614,7 +1641,7 @@ class MuJoCoSimEngine(
             for r in self._world.robots.values():
                 r.policy_running = False
                 r.policy_steps = 0
-        return {"status": "success", "content": [{"text": "Reset to initial state."}]}
+        return {"status": "success", "content": [{"text": f"{flush_note}Reset to initial state."}]}
 
     def get_state(self) -> dict[str, Any]:
         if self._world is None or self._world._model is None or self._world._data is None:

--- a/tests/simulation/mujoco/test_recording_paths.py
+++ b/tests/simulation/mujoco/test_recording_paths.py
@@ -720,3 +720,117 @@ def test_save_episode_empty_buffer_is_idempotent(sim_with_one_robot, tmp_path):
     assert "no frames" in r["content"][0]["text"]
 
     sim.stop_recording()
+
+
+def test_reset_flushes_pending_recording_episode(sim_with_one_robot, tmp_path):
+    """Episode-boundary regression: ``reset()`` during an active recording
+    flushes the buffered rollout as its own episode.
+
+    A ``run_policy`` + ``reset`` collection loop (the natural multi-episode
+    pattern, since ``n_episodes`` is an ``eval_policy`` param, not a
+    ``run_policy`` one) must not silently merge every rollout into a single
+    ``episode_index=0``. Pre-fix the recorder buffered all N rollouts together
+    and ``stop_recording`` flushed them as ONE giant episode
+    (``total_episodes == 1`` for 20 rollouts). ``reset()`` now flushes the
+    pending frames as an episode boundary first, so the dataset records one
+    episode per rollout with clean ``from_index``/``to_index`` ranges.
+    """
+    from strands_robots.dataset_recorder import has_lerobot_dataset
+
+    if not has_lerobot_dataset():
+        pytest.skip("lerobot not installed")
+
+    sim = sim_with_one_robot
+    root = str(tmp_path / "reset_flush")
+    r = sim.start_recording(repo_id="local/reset_flush", fps=20, root=root, overwrite=True)
+    assert r["status"] == "success", r
+
+    n_episodes = 4
+    for i in range(n_episodes):
+        rp = sim.run_policy(
+            robot_name="arm",
+            policy_provider="mock",
+            instruction=f"ep{i}",
+            n_steps=5,
+            control_frequency=20.0,
+            fast_mode=True,
+        )
+        assert rp["status"] == "success", rp
+        # reset() between rollouts is the episode boundary - it flushes the
+        # buffered frames and reports the saved episode in its message.
+        rr = sim.reset()
+        assert rr["status"] == "success", rr
+        assert f"Episode {i + 1} saved" in rr["content"][0]["text"]
+
+    # The final reset already flushed the last rollout, so stop_recording has
+    # nothing left to flush and just finalizes.
+    r = sim.stop_recording()
+    assert r["status"] == "success", r
+
+    from lerobot.datasets.lerobot_dataset import LeRobotDataset
+
+    ds = LeRobotDataset(repo_id="local/reset_flush", root=root)
+    assert ds.meta.total_episodes == n_episodes, f"expected {n_episodes} episodes, got {ds.meta.total_episodes}"
+    lengths = [ds.meta.episodes[ep]["length"] for ep in range(n_episodes)]
+    assert all(length == 5 for length in lengths), f"episode lengths: {lengths}"
+    assert ds.meta.total_frames == sum(lengths) == n_episodes * 5
+
+
+def test_reset_without_recording_does_not_flush(sim_with_one_robot):
+    """``reset()`` outside an active recording session behaves exactly as
+    before - a plain world reset with no episode-flush note. Guards against the
+    auto-flush leaking into the non-recording path.
+    """
+    sim = sim_with_one_robot
+    sim.run_policy(
+        robot_name="arm",
+        policy_provider="mock",
+        n_steps=3,
+        control_frequency=20.0,
+        fast_mode=True,
+    )
+    r = sim.reset()
+    assert r["status"] == "success", r
+    assert r["content"][0]["text"] == "Reset to initial state."
+
+
+def test_reset_empty_buffer_during_recording_does_not_create_episode(sim_with_one_robot, tmp_path):
+    """A ``reset()`` while recording but with NO buffered frames (e.g. two
+    resets in a row, or a reset right after start_recording) must not flush a
+    spurious empty episode - save_episode is a no-op on an empty buffer.
+    """
+    from strands_robots.dataset_recorder import has_lerobot_dataset
+
+    if not has_lerobot_dataset():
+        pytest.skip("lerobot not installed")
+
+    sim = sim_with_one_robot
+    root = str(tmp_path / "reset_empty")
+    assert sim.start_recording(repo_id="local/reset_empty", fps=20, root=root, overwrite=True)["status"] == "success"
+
+    # reset with empty buffer -> plain reset, no flush note.
+    r1 = sim.reset()
+    assert r1["status"] == "success"
+    assert r1["content"][0]["text"] == "Reset to initial state."
+
+    sim.run_policy(
+        robot_name="arm",
+        policy_provider="mock",
+        n_steps=5,
+        control_frequency=20.0,
+        fast_mode=True,
+    )
+    # First reset after a rollout flushes episode 1.
+    r2 = sim.reset()
+    assert "Episode 1 saved" in r2["content"][0]["text"]
+    # Second consecutive reset has nothing buffered -> no new episode.
+    r3 = sim.reset()
+    assert r3["content"][0]["text"] == "Reset to initial state."
+
+    assert sim.stop_recording()["status"] == "success"
+
+    from lerobot.datasets.lerobot_dataset import LeRobotDataset
+
+    ds = LeRobotDataset(repo_id="local/reset_empty", root=root)
+    assert ds.meta.total_episodes == 1, f"expected 1 episode, got {ds.meta.total_episodes}"
+    assert ds.meta.total_frames == 5


### PR DESCRIPTION
## Problem

A `run_policy` + `reset` data-collection loop silently merges every rollout into a single `episode_index=0`. After driving N distinct rollouts, the dataset reports:

```
meta/info.json:  total_episodes: 1   total_frames: 1140
meta/episodes/chunk-000/file-000.parquet:  1 row
data/chunk-000/file-000.parquet:  1140 rows
```

instead of the expected `total_episodes: N` with one episodes-parquet row per rollout (each with its own `from_index`/`to_index`). Downstream training/eval that slices by episode then sees one giant episode instead of N.

The cause: `run_policy` alone does not delimit episodes, and `reset` -- the natural between-rollout boundary, since `n_episodes` is an `eval_policy` parameter, not a `run_policy` one -- did not flush either. The recorder buffered all rollouts together and only `stop_recording` flushed them, as a single episode.

## Change

`Simulation.reset()` now flushes a pending recording episode before re-initializing the world: when a recording is active and the recorder has buffered frames, `reset` calls `save_episode()` first and reports the saved episode in its result text. This mirrors `stop_recording`, which already auto-flushes the trailing episode.

- `save_episode()` remains the explicit boundary primitive; it is a no-op on an empty buffer, so resets not preceded by recorded frames create no spurious empty episodes. This covers two consecutive resets, a reset right after `start_recording`, and `eval_policy`/`evaluate_benchmark`'s internal per-episode resets (which do not feed the recorder).
- To DISCARD a partial rollout instead of flushing it, call `clear_episode_buffer()` before `reset()`.
- `describe()` and `docs/recording.md` document the boundary behavior; `CHANGELOG` updated.

## Tests

New regression tests in `tests/simulation/mujoco/test_recording_paths.py`:
- `test_reset_flushes_pending_recording_episode`: a `run_policy` + `reset` loop produces one episode per rollout (`total_episodes == N`, clean per-episode lengths). Fails pre-fix (`total_episodes == 1`).
- `test_reset_empty_buffer_during_recording_does_not_create_episode`: consecutive/empty-buffer resets create no spurious episodes.
- `test_reset_without_recording_does_not_flush`: the non-recording reset path is unchanged.

Full lint (ruff + mypy) clean; `tests/simulation/mujoco/test_recording_paths.py` and `test_stop_recording_finalize.py` pass (37 tests) headless under `MUJOCO_GL=egl`.

## Visual artifact

Multi-episode rollout recorded in MuJoCo sim (headless), then the dataset reopened to confirm boundaries: `total_episodes=3`, `total_frames=60`, episode lengths `[20, 20, 20]`. The per-camera rollout video produced by the recording:

![reset-flush rollout](https://github.com/cagataycali/robots/releases/download/artifact-reset-flush-1782460394/reset_flush_demo.gif)

MP4: https://github.com/cagataycali/robots/releases/download/artifact-reset-flush-1782460394/reset_flush_rollout.mp4