### PR TITLE
feat(sim): first-class multi-episode run_policy(n_episodes=N)

### DIFF
--- a/docs/recording.md
+++ b/docs/recording.md
@@ -19,9 +19,30 @@ sim.stop_recording()
 
 ## Multi-episode recording
 
-A recording session is one dataset; `run_policy` alone does **not** delimit
-episodes. To collect N episodes in one session, call `save_episode()` after each
-rollout to flush it as its own episode:
+A recording session is one dataset. The simplest way to collect N episodes in
+one session is `run_policy(n_episodes=N)` - it runs N rollouts back-to-back,
+flushes a dataset episode boundary after each, and resets the sim between
+episodes for you:
+
+```python
+sim.start_recording(repo_id="user/my_dataset", task="pick up the cube", fps=30)
+sim.run_policy(robot_name="so100", instruction="pick up the cube",
+               policy_provider="mock", n_steps=60, n_episodes=20)
+sim.stop_recording()
+# -> 20 episodes, each with its own episode_index / length / from_index / to_index
+```
+
+`n_steps` (or `duration`) is the per-episode horizon. `reset_between=False`
+chains episodes from the previous end state instead of resetting. When a `seed`
+is given it is offset per episode (`seed + i`) for reproducible-yet-distinct
+rollouts, and a `video={...}` config is written per episode to a path with
+`_ep{i}` inserted before the extension so episodes do not overwrite one another.
+The aggregate result carries `n_episodes_completed`, `episodes_saved`,
+`total_steps`, and a per-episode list in its `{"json": {...}}` block.
+
+If you need full control over each rollout (different instructions, custom
+randomization, conditional logic between episodes), drive the loop yourself and
+call `save_episode()` after each rollout to flush it as its own episode:
 
 ```python
 sim.start_recording(repo_id="user/my_dataset", task="pick up the cube", fps=30)
@@ -31,7 +52,6 @@ for _ in range(20):
                    policy_provider="mock", n_steps=60)
     sim.save_episode()        # flush this rollout as one episode
 sim.stop_recording()          # flushes any trailing rollout automatically
-# -> 20 episodes, each with its own episode_index / length / from_index / to_index
 ```
 
 `save_episode` is idempotent on an empty buffer, so it is safe to call
@@ -56,7 +76,7 @@ sim.stop_recording()          # flushes any trailing rollout automatically
 # -> 20 episodes
 ```
 
-Without either an explicit `save_episode()` or a `reset()` between rollouts, all
+Without `n_episodes`, an explicit `save_episode()`, or a `reset()` between rollouts, all
 20 rollouts append to the same buffer and `stop_recording` flushes them as a
 single `episode_index=0` (1200 steps in one episode). To DISCARD a partial
 rollout instead of flushing it on the next `reset()`, call

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -19,6 +19,7 @@ Usage::
 from __future__ import annotations
 
 import logging
+import os
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
@@ -377,6 +378,8 @@ class SimEngine(ABC):
         control_substeps: int | None = None,
         policy_kwargs: dict[str, Any] | None = None,
         seed: int | None = None,
+        n_episodes: int = 1,
+        reset_between: bool = True,
     ) -> dict[str, Any]:
         """Run a policy loop in the simulation (blocking).
 
@@ -425,6 +428,24 @@ class SimEngine(ABC):
                 This is the local-sim analogue of the mesh ``tell()`` path,
                 which already forwards these keys. VLA providers ignore unknown
                 kwargs per the #300 contract, so forwarding is always safe.
+            n_episodes: Number of sequential episode rollouts to run in this
+                single call (default ``1`` - the historical single-rollout
+                behaviour, unchanged). When ``> 1``, each episode runs one
+                rollout for the configured horizon, then a dataset episode
+                boundary is flushed via :meth:`save_episode` (only when a
+                recording is active) so the dataset ends up with N correctly
+                delimited episodes instead of one merged episode. This is the
+                first-class multi-episode collection API; it removes the need
+                for a manual ``for _ in range(n): run_policy(); save_episode();
+                reset()`` loop. ``seed`` (when set) is offset per episode
+                (``seed + i``) for reproducible-yet-distinct rollouts, and
+                ``video`` (when set) is written per episode to a path with
+                ``_ep{i}`` inserted before the extension so episodes do not
+                overwrite one another.
+            reset_between: When running multiple episodes, reset the sim to its
+                initial state between episodes (default ``True``). The reset
+                never fires after the final episode. Set ``False`` to chain
+                episodes from the end state of the previous one.
 
         Returns:
             Standard status dict with an agent-consumable ``{"json": {...}}``
@@ -445,6 +466,12 @@ class SimEngine(ABC):
         if horizon_error is not None:
             return horizon_error
 
+        if not isinstance(n_episodes, int) or n_episodes < 1:
+            return {
+                "status": "error",
+                "content": [{"text": f"run_policy: n_episodes must be a positive integer, got {n_episodes!r}."}],
+            }
+
         if robot_name not in self.list_robots():
             return {
                 "status": "error",
@@ -461,9 +488,35 @@ class SimEngine(ABC):
         policy.set_robot_state_keys(self.robot_joint_names(robot_name))
         self.bind_policy_sim_context(policy, robot_name)
 
-        on_frame = self._make_run_policy_hook(robot_name, instruction)
+        runner = PolicyRunner(self)
 
-        return PolicyRunner(self).run(
+        # Single-episode fast path: byte-for-byte the historical behaviour
+        # (no reset, no episode-boundary flush). n_episodes defaults to 1 so
+        # existing callers are completely unaffected.
+        if n_episodes == 1:
+            on_frame = self._make_run_policy_hook(robot_name, instruction)
+            return runner.run(
+                robot_name,
+                policy,
+                instruction=instruction,
+                duration=duration,
+                control_frequency=control_frequency,
+                action_horizon=action_horizon,
+                fast_mode=fast_mode,
+                video=VideoConfig.from_dict(video),
+                on_frame=on_frame,
+                max_onframe_failures=max_onframe_failures,
+                control_substeps=control_substeps,
+                policy_kwargs=policy_kwargs,
+                seed=seed,
+            )
+
+        # Multi-episode path: one rollout per episode, flushing a dataset
+        # episode boundary (save_episode) when recording and resetting between
+        # episodes. Replaces the brittle manual
+        # ``for _ in range(n): run_policy(); save_episode(); reset()`` loop.
+        return self._run_episodes(
+            runner,
             robot_name,
             policy,
             instruction=instruction,
@@ -471,13 +524,209 @@ class SimEngine(ABC):
             control_frequency=control_frequency,
             action_horizon=action_horizon,
             fast_mode=fast_mode,
-            video=VideoConfig.from_dict(video),
-            on_frame=on_frame,
+            video=video,
             max_onframe_failures=max_onframe_failures,
             control_substeps=control_substeps,
             policy_kwargs=policy_kwargs,
             seed=seed,
+            n_episodes=n_episodes,
+            reset_between=reset_between,
         )
+
+    def _run_episodes(
+        self,
+        runner: PolicyRunner,
+        robot_name: str,
+        policy: Policy,
+        *,
+        instruction: str,
+        duration: float,
+        control_frequency: float,
+        action_horizon: int,
+        fast_mode: bool,
+        video: dict[str, Any] | None,
+        max_onframe_failures: int | None,
+        control_substeps: int | None,
+        policy_kwargs: dict[str, Any] | None,
+        seed: int | None,
+        n_episodes: int,
+        reset_between: bool,
+    ) -> dict[str, Any]:
+        """Run ``n_episodes`` sequential rollouts; shared multi-episode driver.
+
+        Behind :meth:`run_policy` when ``n_episodes > 1``. Per episode it:
+        (1) runs one rollout for the configured horizon, (2) flushes a dataset
+        episode boundary via :meth:`save_episode` when a recording is active,
+        and (3) resets the sim between episodes unless ``reset_between`` is
+        ``False`` - so a single call yields N correctly delimited dataset
+        episodes instead of one merged episode. Aborts early (returning a
+        structured error with the episodes completed so far) if a rollout, an
+        episode flush, or a reset fails.
+        """
+        episodes: list[dict[str, Any]] = []
+        episodes_saved = 0
+        total_steps = 0
+        for ep in range(n_episodes):
+            ep_seed = None if seed is None else seed + ep
+            ep_video = self._episode_video_config(video, ep)
+            on_frame = self._make_run_policy_hook(robot_name, instruction)
+            result = runner.run(
+                robot_name,
+                policy,
+                instruction=instruction,
+                duration=duration,
+                control_frequency=control_frequency,
+                action_horizon=action_horizon,
+                fast_mode=fast_mode,
+                video=ep_video,
+                on_frame=on_frame,
+                max_onframe_failures=max_onframe_failures,
+                control_substeps=control_substeps,
+                policy_kwargs=policy_kwargs,
+                seed=ep_seed,
+            )
+            ep_json = self._extract_json_payload(result)
+            ep_record: dict[str, Any] = {"episode": ep, **ep_json}
+            total_steps += int(ep_json.get("n_steps", 0) or 0)
+
+            if result.get("status") == "error":
+                ep_record["status"] = "error"
+                episodes.append(ep_record)
+                return self._episodes_result(
+                    episodes,
+                    episodes_saved,
+                    total_steps,
+                    n_episodes,
+                    status="error",
+                    extra=(
+                        f"Episode {ep} rollout failed; aborting remaining "
+                        f"{n_episodes - ep - 1} episode(s). {self._first_text(result)}"
+                    ),
+                )
+
+            # Flush this rollout as its own dataset episode when recording.
+            if self._is_recording():
+                save = self.save_episode()
+                if save.get("status") == "error":
+                    ep_record["save_episode_error"] = self._first_text(save)
+                    episodes.append(ep_record)
+                    return self._episodes_result(
+                        episodes,
+                        episodes_saved,
+                        total_steps,
+                        n_episodes,
+                        status="error",
+                        extra=f"save_episode failed after episode {ep}: {self._first_text(save)}",
+                    )
+                episodes_saved += 1
+                ep_record["saved"] = True
+
+            episodes.append(ep_record)
+
+            # Reset between episodes - never after the last one.
+            if reset_between and ep < n_episodes - 1:
+                reset_result = self.reset()
+                if reset_result.get("status") == "error":
+                    return self._episodes_result(
+                        episodes,
+                        episodes_saved,
+                        total_steps,
+                        n_episodes,
+                        status="error",
+                        extra=f"reset() failed after episode {ep}: {self._first_text(reset_result)}",
+                    )
+
+        return self._episodes_result(episodes, episodes_saved, total_steps, n_episodes, status="success")
+
+    @staticmethod
+    def _first_text(result: dict[str, Any]) -> str:
+        """First human-readable ``text`` block from a status dict ("" if none)."""
+        for blk in result.get("content", []) or []:
+            if isinstance(blk, dict):
+                text = blk.get("text")
+                if isinstance(text, str):
+                    return text
+        return ""
+
+    @staticmethod
+    def _extract_json_payload(result: dict[str, Any]) -> dict[str, Any]:
+        """First agent-consumable ``{"json": {...}}`` block ({} if none)."""
+        for blk in result.get("content", []) or []:
+            if isinstance(blk, dict) and isinstance(blk.get("json"), dict):
+                return dict(blk["json"])
+        return {}
+
+    @staticmethod
+    def _episode_video_config(video: dict[str, Any] | None, episode: int) -> VideoConfig | None:
+        """Per-episode :class:`VideoConfig` with ``_ep{i}`` in the filename.
+
+        Multi-episode runs reuse one ``video`` config; without templating every
+        episode would overwrite the same MP4. Inserts ``_ep{episode}`` before
+        the extension so each episode gets a distinct file. Passes through
+        unchanged when no video path is set.
+        """
+        if not video or not video.get("path"):
+            return VideoConfig.from_dict(video)
+        templated = dict(video)
+        root, ext = os.path.splitext(str(video["path"]))
+        templated["path"] = f"{root}_ep{episode}{ext or '.mp4'}"
+        return VideoConfig.from_dict(templated)
+
+    def _episodes_result(
+        self,
+        episodes: list[dict[str, Any]],
+        episodes_saved: int,
+        total_steps: int,
+        n_episodes: int,
+        *,
+        status: str,
+        extra: str = "",
+    ) -> dict[str, Any]:
+        """Aggregate per-episode records into one ``run_policy`` status dict.
+
+        Mirrors the single-rollout result shape: a human-readable ``text``
+        block plus an agent-consumable ``{"json": {...}}`` block carrying typed
+        aggregate fields (``n_episodes_completed``, ``episodes_saved``,
+        ``total_steps``, per-episode list, ``video_paths``).
+        """
+        completed = len(episodes)
+        video_paths = [e["video_path"] for e in episodes if e.get("video_path")]
+        text = (
+            f"Multi-episode run_policy: {completed}/{n_episodes} episode(s) completed, "
+            f"{episodes_saved} flushed to dataset, {total_steps} total steps."
+        )
+        if extra:
+            text += f"\n{extra}"
+        payload: dict[str, Any] = {
+            "n_episodes_requested": n_episodes,
+            "n_episodes_completed": completed,
+            "episodes_saved": episodes_saved,
+            "total_steps": total_steps,
+            "episodes": episodes,
+            "video_paths": video_paths,
+        }
+        return {"status": status, "content": [{"text": text}, {"json": payload}]}
+
+    def _is_recording(self) -> bool:
+        """Whether a dataset-recording session is active.
+
+        Backends that support LeRobot dataset recording override this; the base
+        returns ``False`` so the multi-episode :meth:`run_policy` loop only
+        flushes episode boundaries on backends that actually record.
+        """
+        return False
+
+    def save_episode(self) -> dict[str, Any]:
+        """Flush the current recording episode and begin a fresh one.
+
+        Backends that support dataset recording override this (see the MuJoCo
+        ``RecordingMixin``). The base has no recorder, so it returns a
+        structured error rather than pretending to flush.
+        """
+        return {
+            "status": "error",
+            "content": [{"text": "save_episode: this backend does not support dataset recording."}],
+        }
 
     def start_policy(
         self,
@@ -895,7 +1144,7 @@ class SimEngine(ABC):
                 "get_robot_state": "(robot_name: str) -> dict",
                 "get_observation": "(robot_name: str | None = None, *, skip_images: bool = False) -> dict",
                 "send_action": "(action: dict, robot_name: str | None = None, n_substeps: int = 1) -> dict",
-                "run_policy": "(robot_name: str, policy_provider='mock', ...) -> dict",
+                "run_policy": "(robot_name: str, policy_provider='mock', n_episodes=1, reset_between=True, ...) -> dict",
                 "start_policy": "(robot_name: str, policy_provider='mock', ...) -> dict",
                 "list_robots": "() -> list[str]",
                 "render": "(camera_name='default', width=None, height=None) -> dict",

--- a/strands_robots/simulation/mujoco/recording.py
+++ b/strands_robots/simulation/mujoco/recording.py
@@ -32,6 +32,15 @@ class RecordingMixin:
         default_width: int
         default_height: int
 
+    def _is_recording(self) -> bool:
+        """True when a dataset-recording session is active.
+
+        Overrides :meth:`SimEngine._is_recording` so the multi-episode
+        ``run_policy`` loop flushes an episode boundary after each rollout
+        only while a recording is open.
+        """
+        return self._world is not None and bool(self._world._backend_state.get("recording", False))
+
     def start_recording(
         self,
         repo_id: str = "local/sim_recording",

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1136,7 +1136,9 @@ class MuJoCoSimEngine(
         )
         base["methods"]["save_episode"] = (
             "() -> dict  (flush current rollout as one episode; call once per "
-            "run_policy to get N episodes instead of one merged episode)"
+            "run_policy to get N episodes instead of one merged episode. For "
+            "the common case prefer run_policy(n_episodes=N) which flushes a "
+            "boundary per episode automatically)"
         )
         base["methods"]["stop_recording"] = "(push_to_hub=False, bucket=None, run_id=None) -> dict"
         base["methods"]["get_recording_status"] = "() -> dict"
@@ -2283,6 +2285,8 @@ class MuJoCoSimEngine(
         control_substeps: int | None = None,
         policy_kwargs: dict[str, Any] | None = None,
         seed: int | None = None,
+        n_episodes: int = 1,
+        reset_between: bool = True,
     ) -> dict[str, Any]:
         """MuJoCo ``run_policy`` override: pre-flight world check + graceful stop.
 
@@ -2293,6 +2297,12 @@ class MuJoCoSimEngine(
 
         forwards ``n_steps`` / ``max_steps`` to the base so LLM callers
         can specify horizon in steps rather than wall-clock seconds.
+
+        ``n_episodes`` / ``reset_between`` are forwarded to
+        :meth:`SimEngine.run_policy` for first-class multi-episode dataset
+        collection: ``n_episodes > 1`` runs that many rollouts back-to-back,
+        flushing a ``save_episode`` boundary after each (when recording) and
+        resetting between episodes. See :meth:`SimEngine.run_policy`.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
@@ -2320,6 +2330,8 @@ class MuJoCoSimEngine(
                 control_substeps=control_substeps,
                 policy_kwargs=policy_kwargs,
                 seed=seed,
+                n_episodes=n_episodes,
+                reset_between=reset_between,
             )
         finally:
             if self._world is not None and robot_name in self._world.robots:

--- a/tests/simulation/test_run_policy_multi_episode.py
+++ b/tests/simulation/test_run_policy_multi_episode.py
@@ -1,0 +1,224 @@
+"""Multi-episode contract for ``run_policy(n_episodes=N)``.
+
+``run_policy`` historically ran exactly one rollout. Collecting an N-episode
+dataset therefore forced callers into a brittle manual
+``for _ in range(N): run_policy(); save_episode(); reset()`` loop - and
+forgetting the per-iteration ``save_episode`` silently merged every rollout
+into a single ``episode_index=0`` (the dataset reported ``total_episodes=1``
+no matter how many rollouts ran).
+
+These tests pin the first-class multi-episode API:
+
+* ``n_episodes`` (default ``1``) runs that many sequential rollouts in one call.
+* ``n_episodes == 1`` is byte-for-byte the historical single-rollout result
+  shape (no aggregate wrapper), so existing callers are unaffected.
+* A malformed ``n_episodes`` is rejected with a structured ASCII error.
+* When a recording is active, each rollout is flushed as its OWN dataset
+  episode (the data-correctness fix: ``total_episodes == n_episodes``).
+* ``reset_between`` controls the inter-episode reset; the final episode never
+  triggers a reset.
+* A reused ``video`` config is templated per episode (``_ep{i}``) so episodes
+  do not overwrite the same MP4.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+os.environ.setdefault("MUJOCO_GL", "egl")
+
+from strands_robots.simulation import create_simulation  # noqa: E402
+from strands_robots.simulation.base import SimEngine  # noqa: E402
+
+
+@pytest.fixture
+def sim():
+    s = create_simulation()
+    s.create_world()
+    s.add_robot("arm1", data_config="so100")
+    yield s
+    s.cleanup()
+
+
+class _RecordinglessEngine(SimEngine):
+    """Minimal concrete SimEngine that does not support recording.
+
+    Implements the abstract surface as no-ops so the base ``_is_recording`` /
+    ``save_episode`` hooks (which backends like MuJoCo override) can be
+    exercised directly.
+    """
+
+    def create_world(self, *a, **k):  # type: ignore[no-untyped-def]
+        return {"status": "success", "content": []}
+
+    def destroy(self):  # type: ignore[no-untyped-def]
+        return {"status": "success", "content": []}
+
+    def reset(self):  # type: ignore[no-untyped-def]
+        return {"status": "success", "content": []}
+
+    def step(self, n_steps: int = 1):  # type: ignore[no-untyped-def]
+        return {"status": "success", "content": []}
+
+    def get_state(self):  # type: ignore[no-untyped-def]
+        return {"status": "success", "content": []}
+
+    def add_robot(self, *a, **k):  # type: ignore[no-untyped-def]
+        return {"status": "success", "content": []}
+
+    def remove_robot(self, *a, **k):  # type: ignore[no-untyped-def]
+        return {"status": "success", "content": []}
+
+    def list_robots(self):  # type: ignore[no-untyped-def]
+        return []
+
+    def robot_joint_names(self, robot_name):  # type: ignore[no-untyped-def]
+        return []
+
+    def add_object(self, *a, **k):  # type: ignore[no-untyped-def]
+        return {"status": "success", "content": []}
+
+    def remove_object(self, *a, **k):  # type: ignore[no-untyped-def]
+        return {"status": "success", "content": []}
+
+    def get_observation(self, robot_name=None, skip_images=False):  # type: ignore[no-untyped-def]
+        return {"status": "success", "content": []}
+
+    def send_action(self, action, robot_name=None, n_substeps=1):  # type: ignore[no-untyped-def]
+        return {"status": "success", "content": []}
+
+    def physics_timestep(self):  # type: ignore[no-untyped-def]
+        return 0.002
+
+    def render(self, camera_name="default", width=None, height=None):  # type: ignore[no-untyped-def]
+        return {"status": "success", "content": []}
+
+
+def _json(result: dict) -> dict:
+    for blk in result["content"]:
+        if isinstance(blk, dict) and isinstance(blk.get("json"), dict):
+            return blk["json"]
+    raise AssertionError(f"no json block in result: {result}")
+
+
+class TestMultiEpisodeRollout:
+    def test_n_episodes_runs_multiple_rollouts(self, sim):
+        result = sim.run_policy("arm1", n_steps=5, n_episodes=3, control_frequency=50.0)
+        assert result["status"] == "success", result
+        payload = _json(result)
+        assert payload["n_episodes_requested"] == 3
+        assert payload["n_episodes_completed"] == 3
+        assert len(payload["episodes"]) == 3
+        # Each episode ran the configured per-episode horizon.
+        assert [e["n_steps"] for e in payload["episodes"]] == [5, 5, 5]
+        assert payload["total_steps"] == 15
+        # No recorder attached -> nothing flushed.
+        assert payload["episodes_saved"] == 0
+
+    def test_single_episode_keeps_historical_result_shape(self, sim):
+        # Default n_episodes=1 must NOT wrap the result in the multi-episode
+        # aggregate; it stays the single-rollout payload existing callers parse.
+        result = sim.run_policy("arm1", n_steps=5)
+        assert result["status"] == "success"
+        payload = _json(result)
+        assert payload["n_steps"] == 5
+        assert "n_episodes_requested" not in payload
+        assert "episodes" not in payload
+
+    def test_explicit_n_episodes_one_matches_single(self, sim):
+        result = sim.run_policy("arm1", n_steps=4, n_episodes=1)
+        payload = _json(result)
+        assert payload["n_steps"] == 4
+        assert "episodes" not in payload
+
+
+class TestMultiEpisodeValidation:
+    @pytest.mark.parametrize("bad", [0, -1, -10])
+    def test_non_positive_n_episodes_rejected(self, sim, bad):
+        result = sim.run_policy("arm1", n_steps=5, n_episodes=bad)
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert "n_episodes must be a positive integer" in text
+        assert str(bad) in text
+        text.encode("ascii")  # ASCII-only contract
+
+    def test_non_int_n_episodes_rejected(self, sim):
+        result = sim.run_policy("arm1", n_steps=5, n_episodes=2.5)  # type: ignore[arg-type]
+        assert result["status"] == "error"
+        assert "n_episodes must be a positive integer" in result["content"][0]["text"]
+
+
+class TestEpisodeBoundaryFlush:
+    """The data-correctness fix: each rollout becomes its own dataset episode."""
+
+    def test_recording_flushes_one_episode_per_rollout(self, tmp_path, sim):
+        pytest.importorskip("lerobot")
+        repo_id = "local/multi_ep_test"
+        root = str(tmp_path / "ds")
+        assert sim.start_recording(repo_id=repo_id, task="pick", fps=30, root=root)["status"] == "success"
+        assert sim._is_recording() is True
+
+        result = sim.run_policy("arm1", n_steps=6, n_episodes=4, control_frequency=30.0)
+        assert result["status"] == "success", result
+        payload = _json(result)
+        # The whole point of #98: N rollouts -> N flushed episodes, not 1 merged.
+        assert payload["episodes_saved"] == 4
+        assert all(e.get("saved") for e in payload["episodes"])
+
+        assert sim.stop_recording()["status"] == "success"
+
+        from lerobot.datasets.lerobot_dataset import LeRobotDataset
+
+        ds = LeRobotDataset(repo_id, root=root)
+        assert ds.meta.total_episodes == 4
+        assert ds.meta.total_frames == 24
+
+    def test_no_recording_skips_flush(self, sim):
+        # Without start_recording, the loop must not attempt save_episode.
+        assert sim._is_recording() is False
+        payload = _json(sim.run_policy("arm1", n_steps=3, n_episodes=2))
+        assert payload["episodes_saved"] == 0
+
+
+class TestResetBetween:
+    def test_reset_between_false_chains_episodes(self, sim):
+        # reset_between=False must still run all episodes successfully (the
+        # sim simply continues from the previous end state).
+        result = sim.run_policy("arm1", n_steps=4, n_episodes=3, reset_between=False)
+        assert result["status"] == "success"
+        assert _json(result)["n_episodes_completed"] == 3
+
+
+class TestEpisodeVideoTemplating:
+    """A reused video config must not let episodes overwrite one MP4."""
+
+    def test_video_path_templated_per_episode(self):
+        cfg0 = SimEngine._episode_video_config({"path": "/tmp/out.mp4", "fps": 30}, 0)
+        cfg2 = SimEngine._episode_video_config({"path": "/tmp/out.mp4", "fps": 30}, 2)
+        assert cfg0 is not None and cfg2 is not None
+        assert cfg0.path == "/tmp/out_ep0.mp4"
+        assert cfg2.path == "/tmp/out_ep2.mp4"
+        # Non-path keys pass through.
+        assert cfg0.fps == 30
+
+    def test_no_video_passes_through(self):
+        assert SimEngine._episode_video_config(None, 0) is None
+        assert SimEngine._episode_video_config({}, 0) is None
+
+
+class TestBaseHooks:
+    """A backend with no recording support inherits safe base hooks."""
+
+    def test_base_hooks_on_recordingless_backend(self):
+        # A minimal SimEngine subclass that does NOT mix in RecordingMixin must
+        # report no recording and refuse save_episode with a structured error,
+        # so the multi-episode loop never tries to flush on such a backend.
+        engine = _RecordinglessEngine()
+        assert engine._is_recording() is False
+        result = engine.save_episode()
+        assert result["status"] == "error"
+        assert "does not support dataset recording" in result["content"][0]["text"]


### PR DESCRIPTION
## Problem

`run_policy` ran exactly one rollout, so collecting an N-episode dataset forced callers into a manual loop:

```python
sim.start_recording(repo_id="user/data", task="pick", fps=30)
for _ in range(20):
    sim.reset()
    sim.run_policy(robot_name="so100", n_steps=60)
    sim.save_episode()      # easy to forget
sim.stop_recording()
```

Passing `n_episodes` (or `num_episodes`) was rejected as an unknown kwarg. Worse, forgetting the per-iteration `save_episode()` silently merged every rollout into a single `episode_index=0` — the dataset reported `total_episodes=1` no matter how many rollouts ran, corrupting per-episode stats.

## Change

Add `n_episodes` (default `1`) and `reset_between` (default `True`) to `run_policy`. When `n_episodes > 1`, the shared `SimEngine` driver runs that many rollouts back-to-back, flushes a dataset episode boundary via `save_episode` after each rollout **when a recording is active**, and resets the sim between episodes:

```python
sim.start_recording(repo_id="user/data", task="pick", fps=30)
sim.run_policy(robot_name="so100", n_steps=60, n_episodes=20)
sim.stop_recording()
# -> 20 episodes, each with its own episode_index / length / from_index / to_index
```

A single call now yields N correctly delimited dataset episodes. `n_episodes=1` is byte-for-byte the historical single-rollout path and result shape, so existing callers are unaffected.

Behavior details:
- `n_steps` (or `duration`) is the per-episode horizon.
- `seed` (when set) is offset per episode (`seed + i`) for reproducible-yet-distinct rollouts, mirroring `eval_policy`'s per-episode reseed.
- `video` (when set) is templated per episode (`_ep{i}` before the extension) so episodes do not overwrite one MP4.
- Backend-agnostic via two overridable `SimEngine` hooks: `_is_recording()` (default `False`) and `save_episode()` (default structured "unsupported" error); the MuJoCo `RecordingMixin` overrides both.
- The aggregate result carries `n_episodes_completed`, `episodes_saved`, `total_steps`, a per-episode list, and `video_paths` in its `{"json": {...}}` block; it aborts early with partial results if a rollout, flush, or reset fails.
- `describe()` now advertises `run_policy(n_episodes=N)` as the preferred multi-episode path.

## Tests

New `tests/simulation/test_run_policy_multi_episode.py` (fails pre-change — `run_policy` rejected `n_episodes`):
- multi-episode rollout aggregation and per-episode horizon
- single-episode result shape preservation (no aggregate wrapper)
- `n_episodes` validation (non-positive / non-int -> structured ASCII error)
- **per-rollout dataset episode flush: `total_episodes == n_episodes`, `total_frames == n_episodes * n_steps`** (the data-correctness fix)
- `reset_between=False` chaining
- per-episode video path templating
- recording-less backend inherits safe base hooks

Full `MUJOCO_GL=egl` simulation suite + `mypy strands_robots tests` clean. Docs updated in `docs/recording.md`.

## Visual artifact

Three-episode `run_policy(n_episodes=3, video=...)` rollout in MuJoCo (headless EGL), confirming per-episode MP4 templating (`_ep0.mp4`, `_ep1.mp4`, `_ep2.mp4`):

![multi-episode rollout](https://github.com/cagataycali/robots/releases/download/artifact-multiep-rollout/multiep_demo.gif)
