### PR TITLE
fix(lerobot_local): convert SO-arm degrees<->radians + gripper RANGE_0_100 for sim (MolmoAct2 so101)

### DIFF
--- a/strands_robots/policies/lerobot_local/embodiment.py
+++ b/strands_robots/policies/lerobot_local/embodiment.py
@@ -77,6 +77,58 @@ def reconcile_dim(values: list[float], expected_dim: int, dim_policy: str, *, la
     raise ValueError(f"Unknown dim_policy {dim_policy!r}; expected 'strict'|'pad'|'truncate'.")
 
 
+def _convert_joint_vector(
+    values: list[float],
+    *,
+    to_model: bool,
+    gripper_index: int = -1,
+    gripper_joint_range: list[float] | None = None,
+) -> list[float]:
+    """Convert an ordered joint vector between sim units (radians + gripper joint
+    range) and the LeRobot SO-arm training units (arm degrees, gripper 0..100).
+
+    Shared by :class:`EmbodimentMap` (action side) and ``PackStateProcessorStep``
+    (state side) so both directions use one implementation.
+
+    * ``to_model=True``  sim -> model: arm radians -> degrees; gripper joint
+      radians -> 0..100.
+    * ``to_model=False`` model -> sim: arm degrees -> radians; gripper 0..100 ->
+      joint radians.
+
+    The gripper column (``gripper_index``) maps against ``gripper_joint_range``
+    because the SO-arm gripper uses ``MotorNormMode.RANGE_0_100`` (0..100), not
+    degrees - see ``lerobot/robots/so_follower/so_follower.py``.
+
+    Args:
+        values: Ordered joint values.
+        to_model: Conversion direction (see above).
+        gripper_index: Index of the gripper column, or -1 for none.
+        gripper_joint_range: ``[min, max]`` radians of the sim gripper joint;
+            empty/None treats the gripper like an arm joint (deg<->rad).
+
+    Returns:
+        A new list of converted values (input is not mutated).
+    """
+    out = list(values)
+    rad_per_deg = float(np.pi) / 180.0
+    grange = gripper_joint_range or []
+    for i, v in enumerate(out):
+        if i == gripper_index and len(grange) == 2:
+            lo, hi = float(grange[0]), float(grange[1])
+            span = hi - lo
+            if span == 0.0:
+                continue
+            if to_model:
+                out[i] = (float(v) - lo) / span * 100.0  # joint rad -> 0..100
+            else:
+                out[i] = lo + (float(v) / 100.0) * span  # 0..100 -> joint rad
+        elif to_model:
+            out[i] = float(v) / rad_per_deg  # radians -> degrees
+        else:
+            out[i] = float(v) * rad_per_deg  # degrees -> radians
+    return out
+
+
 # Registered pipeline step: pack scalar joint obs -> observation.state
 
 
@@ -126,6 +178,12 @@ def register_pack_state_step() -> type | None:
         state_keys: list[str] = field(default_factory=list)
         expected_dim: int = 0
         dim_policy: str = "strict"
+        # Sim->model unit conversion (see EmbodimentMap). "degrees" => the sim's
+        # radian joints are converted to the model's training units (arm
+        # degrees, gripper 0..100) before packing observation.state.
+        state_units: str = "native"
+        gripper_index: int = -1
+        gripper_joint_range: list[float] = field(default_factory=list)
 
         def observation(self, observation: dict[str, Any]) -> dict[str, Any]:
             if "observation.state" in observation:
@@ -149,6 +207,18 @@ def register_pack_state_step() -> type | None:
                 # No declared state keys present; leave obs alone so a clearer
                 # downstream error (or a state-less policy) can handle it.
                 return observation
+
+            # Convert sim units (radians + gripper joint range) to the model's
+            # training units (arm degrees, gripper 0..100) BEFORE packing, so the
+            # model conditions on state in the space it was trained on. No-op
+            # unless state_units == "degrees". See so_follower.py MotorNormMode.
+            if self.state_units == "degrees":
+                vals = _convert_joint_vector(
+                    vals,
+                    to_model=True,
+                    gripper_index=self.gripper_index,
+                    gripper_joint_range=self.gripper_joint_range,
+                )
 
             target = self.expected_dim or len(vals)
             vals = reconcile_dim(vals, target, self.dim_policy, label="observation.state")
@@ -197,6 +267,24 @@ class EmbodimentMap:
     state_keys: list[str] = field(default_factory=list)
     action_keys: list[str] = field(default_factory=list)
     dim_policy: str = "strict"
+    # Unit conventions for state/action vectors. The MuJoCo sim expresses
+    # revolute joints in RADIANS, but LeRobot SO-arm checkpoints (so100/so101,
+    # MolmoAct2 etc.) are trained on the driver's MotorNormMode: arm joints in
+    # DEGREES and the gripper in RANGE_0_100. "native" = no conversion (the
+    # default; real-hardware *_real maps already speak the driver units).
+    # "degrees" = arm columns are degrees + the gripper column is 0..100; the
+    # policy converts deg<->rad and 0..100<->the gripper joint range when packing
+    # state (model<-sim) and emitting actions (model->sim). See so_follower.py
+    # (MotorNormMode.DEGREES for the arm, RANGE_0_100 for the gripper).
+    state_units: str = "native"
+    action_units: str = "native"
+    # Index of the gripper column in state_keys/action_keys (RANGE_0_100, not a
+    # degree joint). -1 = no special gripper column. SO arms = 5 (the 6th key).
+    gripper_index: int = -1
+    # The sim gripper joint's [min, max] radians, used to map the model's
+    # 0..100 gripper command onto the joint range (and back). Empty = treat the
+    # gripper like an arm joint (deg<->rad). SO arms: [-0.175, 1.745].
+    gripper_joint_range: list[float] = field(default_factory=list)
 
     def validate(self, input_features: dict[str, Any], output_features: dict[str, Any]) -> None:
         """Fail-fast validation against the model's declared features.
@@ -236,6 +324,55 @@ class EmbodimentMap:
                     f"Embodiment '{self.name}': {len(self.action_keys)} action_keys but model "
                     f"action dim is {adim}. Action mapping would mis-index."
                 )
+
+    def _convert_vector(self, values: list[float], *, to_model: bool) -> list[float]:
+        """Convert an ordered joint vector between sim (radians / sim units) and
+        the model's training units (degrees + gripper RANGE_0_100).
+
+        Applies only when ``units == "degrees"``; otherwise returns ``values``
+        unchanged. Direction:
+
+        * ``to_model=True``  sim -> model: arm radians -> degrees; gripper joint
+          radians -> 0..100.
+        * ``to_model=False`` model -> sim: arm degrees -> radians; gripper 0..100
+          -> joint radians.
+
+        The gripper column (``gripper_index``) is mapped against
+        ``gripper_joint_range`` because the SO-arm gripper uses
+        ``MotorNormMode.RANGE_0_100`` (0..100), not degrees - see
+        ``lerobot/robots/so_follower/so_follower.py``.
+
+        Args:
+            values: Ordered joint values (length matches state_keys/action_keys).
+            to_model: Conversion direction (see above).
+
+        Returns:
+            A new list of converted values (input is not mutated).
+        """
+        return _convert_joint_vector(
+            values,
+            to_model=to_model,
+            gripper_index=self.gripper_index,
+            gripper_joint_range=self.gripper_joint_range,
+        )
+
+    def sim_state_to_model(self, values: list[float]) -> list[float]:
+        """Convert a sim state vector into the model's training units.
+
+        No-op unless ``state_units == "degrees"``.
+        """
+        if self.state_units != "degrees":
+            return list(values)
+        return self._convert_vector(values, to_model=True)
+
+    def model_action_to_sim(self, values: list[float]) -> list[float]:
+        """Convert a model action vector into sim (radian) units.
+
+        No-op unless ``action_units == "degrees"``.
+        """
+        if self.action_units != "degrees":
+            return list(values)
+        return self._convert_vector(values, to_model=False)
 
     def expected_state_dim(self, input_features: dict[str, Any]) -> int:
         """Return the model's declared state dim, or len(state_keys) if absent."""

--- a/strands_robots/policies/lerobot_local/embodiments.json
+++ b/strands_robots/policies/lerobot_local/embodiments.json
@@ -49,7 +49,15 @@
         "5",
         "6"
       ],
-      "dim_policy": "pad"
+      "dim_policy": "pad",
+      "state_units": "degrees",
+      "action_units": "degrees",
+      "gripper_index": 5,
+      "gripper_joint_range": [
+        -0.175,
+        1.745
+      ],
+      "__units_note__": "SO-arm checkpoints (MolmoAct2 etc.) emit arm joints in DEGREES + gripper RANGE_0_100 (lerobot so_follower MotorNormMode); the MuJoCo sim joints are RADIANS, so the policy converts deg<->rad and 0..100<->gripper joint range. gripper_joint_range is the sim joint6 [min,max] rad."
     },
     "so100": {
       "__note__": "SIM: trs_so_arm100/so_arm100.xml uses capitalized named joints (NOT 1..6 like so101).",
@@ -73,7 +81,15 @@
         "Wrist_Roll",
         "Jaw"
       ],
-      "dim_policy": "pad"
+      "dim_policy": "pad",
+      "state_units": "degrees",
+      "action_units": "degrees",
+      "gripper_index": 5,
+      "gripper_joint_range": [
+        -0.175,
+        1.745
+      ],
+      "__units_note__": "SO-arm checkpoints (MolmoAct2 etc.) emit arm joints in DEGREES + gripper RANGE_0_100 (lerobot so_follower MotorNormMode); the MuJoCo sim joints are RADIANS, so the policy converts deg<->rad and 0..100<->gripper joint range. gripper_joint_range is the sim joint6 [min,max] rad."
     },
     "so_real": {
       "__note__": "REAL hardware: lerobot SOFollower (so100_follower/so101_follower). _motors_ft -> '<motor>.pos'. Applies to both so100 & so101 physical arms (identical motor set).",

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -1619,11 +1619,24 @@ class LerobotLocalPolicy(Policy):
                 "Call set_robot_state_keys() before inference."
             )
 
+        # Convert the model's action units to sim units when the embodiment
+        # declares them. SO-arm checkpoints (so100/so101, MolmoAct2) emit joint
+        # targets in the LeRobot driver convention (arm DEGREES + gripper
+        # RANGE_0_100), but the MuJoCo sim joints are RADIANS -- feeding the raw
+        # degree values straight in saturates the radian joint limits and the
+        # arm freezes. EmbodimentMap.model_action_to_sim is a no-op when
+        # action_units == "native" (the default / real-hardware path).
+        emb = self._embodiment
+        convert = emb is not None and getattr(emb, "action_units", "native") != "native"
+
         result = []
         for action_values in actions_list:
-            action_dict = {}
-            for index, key in enumerate(self.robot_state_keys):
-                action_dict[key] = float(action_values[index]) if index < len(action_values) else 0.0
+            vals = [
+                float(action_values[i]) if i < len(action_values) else 0.0 for i in range(len(self.robot_state_keys))
+            ]
+            if convert:
+                vals = emb.model_action_to_sim(vals)
+            action_dict = {key: vals[index] for index, key in enumerate(self.robot_state_keys)}
             result.append(action_dict)
 
         return result

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -1634,7 +1634,9 @@ class LerobotLocalPolicy(Policy):
             vals = [
                 float(action_values[i]) if i < len(action_values) else 0.0 for i in range(len(self.robot_state_keys))
             ]
-            if convert:
+            # `convert` already implies `emb is not None`; the explicit guard lets
+            # the type checker narrow `emb` from `EmbodimentMap | None` at the call.
+            if convert and emb is not None:
                 vals = emb.model_action_to_sim(vals)
             action_dict = {key: vals[index] for index, key in enumerate(self.robot_state_keys)}
             result.append(action_dict)

--- a/strands_robots/policies/lerobot_local/processor.py
+++ b/strands_robots/policies/lerobot_local/processor.py
@@ -345,6 +345,9 @@ class ProcessorBridge:
                     state_keys=list(embodiment.state_keys),
                     expected_dim=expected_dim,
                     dim_policy=embodiment.dim_policy,
+                    state_units=embodiment.state_units,
+                    gripper_index=embodiment.gripper_index,
+                    gripper_joint_range=list(embodiment.gripper_joint_range),
                 ),
             )
 

--- a/tests/policies/lerobot_local/test_so_arm_units.py
+++ b/tests/policies/lerobot_local/test_so_arm_units.py
@@ -1,0 +1,99 @@
+"""Regression tests for the SO-arm degrees<->radians units conversion.
+
+MolmoAct2 SO-100/101 (and other lerobot SO-arm checkpoints) emit joint actions
+in the driver's MotorNormMode: arm joints in DEGREES, gripper in RANGE_0_100
+(see lerobot/robots/so_follower/so_follower.py). The MuJoCo sim joints are
+RADIANS. Without conversion the raw degree values saturate the radian joint
+limits and the arm freezes -- this pins the fix.
+"""
+
+import math
+
+import numpy as np
+
+from strands_robots.policies.lerobot_local.embodiment import (
+    EmbodimentMap,
+    _convert_joint_vector,
+    load_embodiment,
+)
+
+# so101 sim gripper joint range (robotstudio_so101/so101_new_calib.xml joint 6).
+GRIPPER_RANGE = [-0.175, 1.745]
+
+
+def _so_arm_map() -> EmbodimentMap:
+    return EmbodimentMap(
+        name="test_so",
+        state_keys=["1", "2", "3", "4", "5", "6"],
+        action_keys=["1", "2", "3", "4", "5", "6"],
+        state_units="degrees",
+        action_units="degrees",
+        gripper_index=5,
+        gripper_joint_range=GRIPPER_RANGE,
+    )
+
+
+def test_action_degrees_to_radians_arm():
+    emb = _so_arm_map()
+    # 90 deg arm joints -> pi/2 rad; gripper handled separately below.
+    out = emb.model_action_to_sim([90.0, 90.0, 90.0, 90.0, 90.0, 50.0])
+    for v in out[:5]:
+        assert math.isclose(v, math.pi / 2, abs_tol=1e-6), out
+
+
+def test_action_gripper_range_0_100_to_joint():
+    emb = _so_arm_map()
+    lo, hi = GRIPPER_RANGE
+    # 0 -> lo, 100 -> hi, 50 -> midpoint.
+    assert math.isclose(emb.model_action_to_sim([0, 0, 0, 0, 0, 0])[5], lo, abs_tol=1e-6)
+    assert math.isclose(emb.model_action_to_sim([0, 0, 0, 0, 0, 100])[5], hi, abs_tol=1e-6)
+    assert math.isclose(emb.model_action_to_sim([0, 0, 0, 0, 0, 50])[5], (lo + hi) / 2, abs_tol=1e-6)
+
+
+def test_state_radians_to_degrees_round_trip():
+    emb = _so_arm_map()
+    sim_state = [0.5, -1.0, 1.2, -0.3, 2.0, 0.4]
+    to_model = emb.sim_state_to_model(sim_state)
+    back = emb.model_action_to_sim(to_model)
+    assert np.allclose(back, sim_state, atol=1e-6), (back, sim_state)
+
+
+def test_native_units_is_noop():
+    emb = EmbodimentMap(name="t", action_units="native", state_units="native")
+    vals = [125.0, -270.0, 10.0]
+    assert emb.model_action_to_sim(vals) == vals
+    assert emb.sim_state_to_model(vals) == vals
+
+
+def test_degree_action_stays_in_so101_joint_range():
+    """A realistic MolmoAct2 degree action (mean joint2 ~125 deg) must land
+    inside the so101 radian joint limits after conversion -- the whole point of
+    the fix (raw degrees saturate; converted radians fit)."""
+    emb = _so_arm_map()
+    # so101 joint ranges (rad): 1:+/-1.92 2:+/-1.745 3:[-1.745,1.571] 4:+/-1.658 5:+/-2.793
+    deg_action = [40.0, 95.0, 80.0, 50.0, -60.0, 50.0]  # within trained quantiles + joint limits
+    rad = emb.model_action_to_sim(deg_action)
+    limits = [(-1.92, 1.92), (-1.745, 1.745), (-1.745, 1.571), (-1.658, 1.658), (-2.793, 2.793), tuple(GRIPPER_RANGE)]
+    for v, (lo, hi) in zip(rad, limits, strict=True):
+        assert lo - 1e-6 <= v <= hi + 1e-6, (v, lo, hi)
+
+
+def test_so101_embodiment_declares_degrees():
+    emb = load_embodiment("so101")
+    assert emb.state_units == "degrees"
+    assert emb.action_units == "degrees"
+    assert emb.gripper_index == 5
+    assert emb.gripper_joint_range == [-0.175, 1.745]
+
+
+def test_so_real_embodiment_stays_native():
+    """Real hardware speaks the driver units already -- must NOT double-convert."""
+    emb = load_embodiment("so_real")
+    assert emb.state_units == "native"
+    assert emb.action_units == "native"
+
+
+def test_convert_helper_does_not_mutate_input():
+    src = [10.0, 20.0, 30.0]
+    _convert_joint_vector(src, to_model=False)
+    assert src == [10.0, 20.0, 30.0]


### PR DESCRIPTION
## Summary

MolmoAct2 SO-100/101 (and other LeRobot SO-arm checkpoints) emit joint actions
in the driver's `MotorNormMode`: **arm joints in DEGREES, gripper in
RANGE_0_100** (see `lerobot/robots/so_follower/so_follower.py`:
`MotorNormMode.DEGREES` for the arm, `RANGE_0_100` for the gripper). The
`MolmoAct2-SO100_101` `norm_stats` confirm it — action ranges span roughly
**-270..+270** (mean joint2 ~125).

But the MuJoCo `so101`/`so100` sim joints are **RADIANS** (limits ~±1.75). The
local policy's `_tensor_to_action_dicts` mapped action values **directly** onto
sim joints with **no unit conversion**, so a ~95-125 (degrees) value was fed to
a joint clamped at ±1.745 rad → **instant saturation → the arm froze**. This is
the same *units-mismatch* class as the VERA OSC-scaling fix.

## Fix

Declarative, opt-in unit handling on the `lerobot_local` embodiment map:

- New `EmbodimentMap` fields: `state_units` / `action_units` (default
  `"native"`; `"degrees"` for the `so100`/`so101` **sim** maps),
  `gripper_index`, `gripper_joint_range`.
- A shared `_convert_joint_vector` does **deg↔rad** for the arm and
  **0..100↔joint-range** for the gripper (the gripper uses `RANGE_0_100`, not
  degrees).
- Honored in two places:
  - `PackStateProcessorStep` — sim radians → model units before the model sees
    `observation.state`.
  - `_tensor_to_action_dicts` — model action units → sim radians before driving
    joints.
- `*_real` maps stay `"native"` (real hardware already speaks the driver units;
  no double-conversion).

## Verification

- A degree action `[10, 95, 80, 40, -50, 20]` converts to in-range radians
  `{1:0.175, 2:1.658, 3:1.396, 4:0.698, 5:-0.873, 6:0.209}` and the `so101` sim
  arm **tracks** them (was: saturated/frozen at the joint limits).
- Round-trip `sim_state→model→sim` is identity.

## Testing

Pins 8 regression tests in `tests/policies/lerobot_local/test_so_arm_units.py`:
deg→rad arm, gripper 0..100 mapping, round-trip, native no-op, joint-limit
containment, `so101` declares degrees, `so_real` stays native, no input
mutation.

`hatch run test` — `lerobot_local` suite passes (286 passed; the 4 pre-existing
`test_molmoact2.py::TestBuildPolicy` import-hint failures are unrelated to this
change — they fail identically on pristine `main` because they mock a missing
`lerobot` in an env where lerobot is installed). ruff check + ruff format + mypy
clean on the changed files.

---

## Round 1 changelog

- Fix CI test-lint failure: a single mypy `union-attr` error at
  `policy.py:1638` (`Item "None" of "Any | None" has no attribute
  "model_action_to_sim"`). The precomputed `convert` flag already implies
  `emb is not None`, but mypy cannot propagate that narrowing through a local
  boolean, so it still saw `EmbodimentMap | None` at the call site. Added an
  explicit `emb is not None` guard at the call (`if convert and emb is not
  None:`) to restore narrowing. No behavior change — `convert` is only ever
  true when `emb` is non-None. ruff + format + mypy now clean.