### PR TITLE
test(vera): cover ee-frame discovery fallback contracts

### DIFF
--- a/tests/policies/vera/test_vera_autoconfig_ik.py
+++ b/tests/policies/vera/test_vera_autoconfig_ik.py
@@ -168,3 +168,64 @@ def test_no_autoconfig_for_joint_position():
     p.set_sim_context(model, "allegro/")
     assert p._ee_frame_name is None, "should NOT auto-config IK for joint_position"
     print("✅ joint_position: no IK auto-config (correct)")
+
+
+def test_discover_without_namespace_scopes_whole_model():
+    """namespace=None discovers across the whole model (unscoped).
+
+    With no namespace the scoping/basename helpers must accept every name as-is,
+    so a TCP-like site is still found in a single-robot world that ships no
+    ``<robot>/`` prefix.
+    """
+    from strands_robots.policies.vera import ee_frame
+
+    bodies = ["world", "link0", "hand"]
+    sites = ["attachment_site"]
+    model = _install_fake_mujoco(bodies, sites, {1: 0, 2: 1})
+    found = ee_frame.discover_ee_frame(model)  # namespace defaults to None
+    assert found == ("attachment_site", "site"), found
+
+
+def test_discover_returns_none_when_mujoco_unimportable(monkeypatch):
+    """When ``mujoco`` is not importable, discovery degrades to None.
+
+    The IK target is only meaningful with the sim stack present; a missing
+    ``mujoco`` must not raise out of discovery — the caller falls back to an
+    explicit frame.
+    """
+    from strands_robots.policies.vera import ee_frame
+
+    monkeypatch.setitem(sys.modules, "mujoco", None)
+    assert ee_frame.discover_ee_frame(object(), "panda/") is None
+
+
+def test_discover_returns_none_when_no_bodies_in_namespace():
+    """No hinted site/body and no in-namespace body -> warn and return None.
+
+    Nothing under the ``panda/`` namespace means the leaf-body fallback has no
+    candidates, so discovery returns None rather than picking an out-of-namespace
+    body.
+    """
+    from strands_robots.policies.vera import ee_frame
+
+    bodies = ["world"]  # only the world body; nothing under 'panda/'
+    sites = []
+    model = _install_fake_mujoco(bodies, sites, {})
+    assert ee_frame.discover_ee_frame(model, "panda/") is None
+
+
+def test_discover_returns_none_when_chain_has_no_leaf():
+    """A cyclic parent chain yields no leaf body -> discovery returns None.
+
+    If every in-namespace body is some other in-namespace body's parent there is
+    no kinematic-chain tail to mount a tool on, so discovery declines instead of
+    guessing.
+    """
+    from strands_robots.policies.vera import ee_frame
+
+    # Two namespaced bodies that are each other's parent: no leaf exists, and
+    # neither name carries a tool/site hint.
+    bodies = ["robot/a", "robot/b"]
+    sites = []
+    model = _install_fake_mujoco(bodies, sites, {0: 1, 1: 0})
+    assert ee_frame.discover_ee_frame(model, "robot/") is None


### PR DESCRIPTION
## What

Adds focused coverage for the untested fallback branches of VERA's end-effector frame auto-discovery (`strands_robots/policies/vera/ee_frame.py`). The existing tests cover the happy paths (site hint, body hint, leaf-body fallback); these add the edge contracts that decide whether `discover_ee_frame` resolves a frame or declines cleanly.

New behavior under test:

- **Unscoped discovery (`namespace=None`)** resolves a TCP-like site across the whole model, exercising the no-namespace branches of the scoping/basename helpers. This is the single-robot case where the model ships no `<robot>/` prefix.
- **`mujoco` not importable** degrades to `None` instead of raising, so a caller in the light base env falls back to an explicit frame rather than crashing.
- **No in-namespace body** (only the world body under the requested namespace) returns `None` — the leaf-body fallback has no candidates and discovery refuses to pick an out-of-namespace body.
- **Cyclic parent chain** (every in-namespace body is another in-namespace body's parent, so no leaf exists) returns `None` rather than guessing a tool-mount link.

The last three are the explicit "decline, don't guess" contracts that keep multi-robot worlds from silently binding IK to the wrong frame.

## Tests

Extends `tests/policies/vera/test_vera_autoconfig_ik.py`, reusing its existing fake-`mujoco` harness and the autouse `sys.modules['mujoco']` save/restore fixture (no real sim stack needed, so these run in the light base env).

Coverage of `ee_frame.py`: 89% -> 100% (closes lines 58, 66, 83-85, 109-114, 137, 148).

Local gate green: `ruff check` / `ruff format --check` clean, `mypy strands_robots tests tests_integ` reports no issues, and the affected suites pass (vera + wbc + cosmos3: 337 passed, 2 skipped) with no cross-test `mujoco` pollution.

Test-only change; no library behavior is modified.