### PR TITLE
test(vera): run sim_ik dependency-free contracts in CI (55% -> 100%)

### DIFF
--- a/tests/policies/vera/test_sim_ik_bridge_solve_loop.py
+++ b/tests/policies/vera/test_sim_ik_bridge_solve_loop.py
@@ -1,0 +1,186 @@
+"""Dependency-free coverage of the VERA eef-delta -> MuJoCo IK bridge solve loop.
+
+The real-solver accuracy regression in ``test_vera_sim_ik_solver.py``
+``importorskip``s on the ``sim-mujoco`` extra (``mink`` + ``mujoco`` +
+``qpsolvers``), so on the default clean-install image the whole
+:class:`~strands_robots.policies.vera.sim_ik.MinkIKBridge` body is skipped - the
+construction, forward kinematics, and the damped-least-squares solve loop.
+
+The bridge only ever calls a small, *duck-typed* slice of ``mink``
+(``Configuration`` / ``FrameTask`` / ``PostureTask`` / ``SE3`` / ``solve_ik``),
+so the full solve loop is driven here against a fake ``mink`` module that models
+a single-step exact solver. No ``mink``, ``mujoco`` or ``qpsolvers`` need be
+installed - these contracts execute in plain CI and guard what a clean-install
+user hits first:
+
+* construction wires the frame + posture tasks and resolves the QP backend;
+* ``ee_pose`` runs forward kinematics through the configuration;
+* ``solve`` warm-starts at the seed, iterates ``solve_ik`` -> ``integrate`` and
+  *breaks early* once both position and orientation error fall under threshold,
+  and otherwise runs the full ``max_iters`` budget.
+"""
+
+import sys
+import types
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.vera import sim_ik
+
+
+class _FakeTransform:
+    """Stand-in for a ``mink`` frame transform; ``as_matrix`` returns the pose."""
+
+    def __init__(self, matrix: np.ndarray):
+        self._m = np.asarray(matrix, dtype=float)
+
+    def as_matrix(self) -> np.ndarray:
+        return self._m
+
+
+class _FakeSE3:
+    """Minimal ``mink.SE3`` carrying the target homogeneous matrix."""
+
+    def __init__(self, matrix: np.ndarray):
+        self.matrix = np.asarray(matrix, dtype=float)
+
+    @classmethod
+    def from_matrix(cls, m: np.ndarray) -> "_FakeSE3":
+        return cls(m)
+
+
+class _FakeConfiguration:
+    """A ``mink.Configuration`` whose EE translation is simply ``q[:3]``.
+
+    Makes forward kinematics deterministic and testable: ``ee_pose(q)`` returns
+    an identity-rotation pose translated to the first three joint values. Counts
+    ``integrate_inplace`` calls so the solve loop's iteration budget is
+    observable.
+    """
+
+    def __init__(self, model):
+        self.model = model
+        self.q = np.zeros(model.nq, dtype=float)
+        self.integrate_calls = 0
+
+    def update(self, q: np.ndarray) -> None:
+        self.q = np.asarray(q, dtype=float).copy()
+
+    def get_transform_frame_to_world(self, name: str, ftype: str) -> _FakeTransform:
+        m = np.eye(4)
+        m[:3, 3] = self.q[:3]
+        return _FakeTransform(m)
+
+    def integrate_inplace(self, velocity: np.ndarray, dt: float) -> None:
+        self.integrate_calls += 1
+        self.q = self.q + np.asarray(velocity, dtype=float) * dt
+
+
+class _FakeFrameTask:
+    """Cartesian frame task; ``compute_error`` is the target-minus-achieved delta."""
+
+    def __init__(self, frame_name, frame_type, position_cost, orientation_cost, lm_damping):
+        self.frame_name = frame_name
+        self.frame_type = frame_type
+        self.target = None
+
+    def set_target(self, target: _FakeSE3) -> None:
+        self.target = np.asarray(target.matrix, dtype=float)
+
+    def compute_error(self, config: _FakeConfiguration) -> np.ndarray:
+        pos_err = self.target[:3, 3] - config.q[:3]
+        return np.concatenate([pos_err, np.zeros(3)])  # orientation already aligned.
+
+
+class _FakePostureTask:
+    def __init__(self, model, cost):
+        self.target = None
+
+    def set_target(self, q: np.ndarray) -> None:
+        self.target = np.asarray(q, dtype=float)
+
+
+def _solve_ik(config, tasks, dt, solver, damping):
+    """A one-step exact solver: velocity drives ``q[:3]`` onto the frame target."""
+    frame_task = tasks[0]
+    tgt = frame_task.target[:3, 3]
+    v = np.zeros(config.model.nq, dtype=float)
+    v[:3] = (tgt - config.q[:3]) / dt  # integrate adds v*dt -> reaches target exactly.
+    return v
+
+
+@pytest.fixture
+def fake_mink(monkeypatch):
+    """Install a fake ``mink`` module plus a stub ``qpsolvers`` for the bridge."""
+    mod = types.ModuleType("mink")
+    mod.Configuration = _FakeConfiguration
+    mod.FrameTask = _FakeFrameTask
+    mod.PostureTask = _FakePostureTask
+    mod.SE3 = _FakeSE3
+    mod.solve_ik = _solve_ik
+    monkeypatch.setitem(sys.modules, "mink", mod)
+
+    qp = types.ModuleType("qpsolvers")
+    qp.available_solvers = ["quadprog"]
+    monkeypatch.setitem(sys.modules, "qpsolvers", qp)
+    return mod
+
+
+def _model(nq: int = 7):
+    return types.SimpleNamespace(nq=nq)
+
+
+def _target_pose(xyz) -> np.ndarray:
+    pose = np.eye(4)
+    pose[:3, 3] = xyz
+    return pose
+
+
+def _make_bridge(fake_mink, **kw):
+    return sim_ik.MinkIKBridge(model=_model(), ee_frame_name="gripper", solver="quadprog", **kw)
+
+
+def test_construction_wires_tasks_and_resolves_solver(fake_mink):
+    """The bridge builds its frame + posture tasks and resolves the QP backend."""
+    bridge = _make_bridge(fake_mink)
+
+    assert bridge.solver == "quadprog"
+    assert bridge.ee_frame_name == "gripper"
+    assert isinstance(bridge._frame_task, _FakeFrameTask)
+    assert isinstance(bridge._posture_task, _FakePostureTask)
+    assert bridge._tasks == [bridge._frame_task, bridge._posture_task]
+
+
+def test_ee_pose_runs_forward_kinematics_through_configuration(fake_mink):
+    """``ee_pose`` returns the configuration's frame transform for the given q."""
+    bridge = _make_bridge(fake_mink)
+    q = np.array([0.1, 0.2, 0.3, 0, 0, 0, 0], dtype=float)
+
+    pose = bridge.ee_pose(q)
+
+    assert pose.shape == (4, 4)
+    np.testing.assert_allclose(pose[:3, 3], [0.1, 0.2, 0.3], atol=1e-6)
+
+
+def test_solve_breaks_early_once_under_threshold(fake_mink):
+    """The exact one-step solver converges, so the loop breaks after one iter."""
+    bridge = _make_bridge(fake_mink, max_iters=20)
+    target = _target_pose([0.4, -0.1, 0.25])
+
+    q = bridge.solve(target, q_init=np.zeros(7))
+
+    # Reached the commanded Cartesian target ...
+    np.testing.assert_allclose(q[:3], [0.4, -0.1, 0.25], atol=1e-6)
+    # ... and stopped after a single integrate rather than burning all 20 iters.
+    assert bridge._configuration.integrate_calls == 1
+
+
+def test_solve_runs_full_iteration_budget_when_never_converged(fake_mink):
+    """An impossible threshold means the break never fires; all iters run."""
+    bridge = _make_bridge(fake_mink, max_iters=5, pos_threshold=-1.0)
+    target = _target_pose([0.4, 0.0, 0.3])
+
+    bridge.solve(target, q_init=np.zeros(7))
+
+    assert bridge._configuration.integrate_calls == 5

--- a/tests/policies/vera/test_sim_ik_solver_selection.py
+++ b/tests/policies/vera/test_sim_ik_solver_selection.py
@@ -1,0 +1,149 @@
+"""Dependency-free contract tests for the VERA eef-delta -> MuJoCo IK bridge.
+
+The real-solver accuracy regression in ``test_vera_sim_ik_solver.py``
+``importorskip``s on ``mink`` + ``qpsolvers`` (the ``sim-mujoco`` extra), so the
+whole module is skipped wherever that stack is absent - which is the default CI
+image. That leaves the bridge's *dependency-free* surface untested even though
+it is the part most likely to break on a clean install:
+
+* :func:`~strands_robots.policies.vera.sim_ik._resolve_qp_solver` - the QP
+  backend auto-selection that lets the bridge run on ``daqp`` or ``quadprog``
+  (or whatever ``qpsolvers`` reports), and the actionable errors it raises when
+  a requested backend is missing or none is installed.
+* :func:`~strands_robots.policies.vera.sim_ik._install_hint` - the actionable
+  message naming the extra and what it pulls.
+* :class:`~strands_robots.policies.vera.sim_ik.MinkIKBridge` construction
+  failing with the install hint when ``mink`` is not importable.
+* :func:`~strands_robots.policies.vera.sim_ik.delta_to_matrix` rotation-encoding
+  dispatch (rot6d / axis-angle) and its rejection of unsupported dims.
+* :func:`~strands_robots.policies.vera.sim_ik.decode_vera_delta_chunk_to_targets`
+  input validation (action-chunk rank, pose-dim sufficiency) that runs *before*
+  any sim dependency is touched.
+
+These paths need no ``mink``/``mujoco``/``qpsolvers`` actually installed - the
+solver selection is driven with a stub ``qpsolvers`` module - so they execute in
+plain CI and guard the contracts a clean-install user hits first.
+"""
+
+import sys
+import types
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.vera import sim_ik
+
+
+@pytest.fixture
+def fake_qpsolvers(monkeypatch):
+    """Install a stub ``qpsolvers`` module with a settable solver list.
+
+    Returns the stub so a test can mutate ``available_solvers`` to drive each
+    branch of :func:`_resolve_qp_solver` without depending on which QP backends
+    happen to be installed on the host.
+    """
+    stub = types.ModuleType("qpsolvers")
+    stub.available_solvers = ["quadprog", "osqp"]
+    monkeypatch.setitem(sys.modules, "qpsolvers", stub)
+    return stub
+
+
+class TestResolveQpSolver:
+    """The QP-backend auto-selection contract (no real qpsolvers needed)."""
+
+    def test_prefers_daqp_when_available(self, fake_qpsolvers):
+        fake_qpsolvers.available_solvers = ["quadprog", "daqp", "osqp"]
+        assert sim_ik._resolve_qp_solver(None) == "daqp"
+
+    def test_prefers_quadprog_when_daqp_absent(self, fake_qpsolvers):
+        fake_qpsolvers.available_solvers = ["osqp", "quadprog"]
+        assert sim_ik._resolve_qp_solver(None) == "quadprog"
+
+    def test_falls_back_to_first_available_when_none_preferred(self, fake_qpsolvers):
+        # No name from the preferred list is installed -> first reported wins.
+        fake_qpsolvers.available_solvers = ["gurobi", "highs"]
+        assert sim_ik._resolve_qp_solver(None) == "gurobi"
+
+    def test_honours_explicit_requested_solver(self, fake_qpsolvers):
+        fake_qpsolvers.available_solvers = ["quadprog", "osqp"]
+        assert sim_ik._resolve_qp_solver("osqp") == "osqp"
+
+    def test_requested_solver_not_installed_raises_valueerror(self, fake_qpsolvers):
+        fake_qpsolvers.available_solvers = ["quadprog"]
+        with pytest.raises(ValueError, match="daqp"):
+            sim_ik._resolve_qp_solver("daqp")
+
+    def test_no_backend_installed_raises_runtimeerror(self, fake_qpsolvers):
+        fake_qpsolvers.available_solvers = []
+        with pytest.raises(RuntimeError, match="sim-mujoco"):
+            sim_ik._resolve_qp_solver(None)
+
+    def test_qpsolvers_absent_raises_importerror_with_hint(self, monkeypatch):
+        # Force the ``import qpsolvers`` inside _resolve_qp_solver to fail.
+        monkeypatch.setitem(sys.modules, "qpsolvers", None)
+        with pytest.raises(ImportError, match="sim-mujoco"):
+            sim_ik._resolve_qp_solver(None)
+
+
+class TestInstallHint:
+    """The actionable install message must name the extra and what it pulls."""
+
+    def test_names_extra_and_dependencies(self):
+        hint = sim_ik._install_hint()
+        assert "sim-mujoco" in hint
+        assert "mink" in hint
+
+
+class TestMinkIKBridgeImportGuard:
+    """Constructing the bridge without ``mink`` fails with the install hint."""
+
+    def test_missing_mink_raises_importerror_with_hint(self, monkeypatch):
+        monkeypatch.setitem(sys.modules, "mink", None)
+        with pytest.raises(ImportError, match="sim-mujoco"):
+            sim_ik.MinkIKBridge(model=object(), ee_frame_name="hand")
+
+
+class TestDeltaToMatrix:
+    """Rotation-delta encoding dispatch is selected by ``rotation_dim``."""
+
+    def test_rot6d_dim_six_dispatches_to_gram_schmidt(self):
+        # Canonical 6D rep (first two columns of identity) -> identity matrix.
+        R = sim_ik.delta_to_matrix(np.array([1, 0, 0, 0, 1, 0], dtype=np.float64), 6)
+        np.testing.assert_allclose(R, np.eye(3), atol=1e-6)
+
+    def test_axis_angle_dim_three_dispatches_to_rodrigues(self):
+        # 90 deg about z.
+        R = sim_ik.delta_to_matrix(np.array([0, 0, np.pi / 2], dtype=np.float64), 3)
+        np.testing.assert_allclose(R, [[0, -1, 0], [1, 0, 0], [0, 0, 1]], atol=1e-6)
+
+    def test_unsupported_rotation_dim_raises(self):
+        with pytest.raises(ValueError, match="unsupported rotation_dim"):
+            sim_ik.delta_to_matrix(np.zeros(4), 4)
+
+
+class TestDecodeInputValidation:
+    """``decode_vera_delta_chunk_to_targets`` validates before touching the sim.
+
+    Both guards fire before ``ik_bridge`` is ever referenced, so a sentinel
+    object that would explode if called proves the validation is up front.
+    """
+
+    def test_non_2d_action_chunk_raises(self):
+        with pytest.raises(ValueError, match=r"\[T, D\]"):
+            sim_ik.decode_vera_delta_chunk_to_targets(
+                np.zeros((2, 3, 7), dtype=np.float64),
+                ik_bridge=object(),
+                q_init=np.zeros(7),
+            )
+
+    def test_short_pose_block_raises(self):
+        # rotation_dim=6 needs >= 9 pose dims; a 4-wide chunk (3 pose + gripper)
+        # is short after the gripper column is removed.
+        with pytest.raises(ValueError, match="pose dims"):
+            sim_ik.decode_vera_delta_chunk_to_targets(
+                np.zeros((2, 4), dtype=np.float64),
+                ik_bridge=object(),
+                q_init=np.zeros(7),
+                rotation_dim=6,
+                has_gripper=True,
+            )

--- a/tests/policies/vera/test_vera_sim_ik_solver.py
+++ b/tests/policies/vera/test_vera_sim_ik_solver.py
@@ -1,16 +1,18 @@
-"""Real-solver coverage for the VERA eef-delta IK bridge (``sim_ik``).
+"""Real-solver accuracy regression for the VERA eef-delta IK bridge (``sim_ik``).
 
-The other VERA IK tests deliberately use a ``FakeBridge`` + fake ``mujoco`` so
-they run in the light base env. That leaves the actual closed-loop kinematics
-untested: ``MinkIKBridge`` (mink + mujoco construction, forward kinematics, and
-the differential-IK solve loop), the ``qpsolvers`` backend auto-selection, and
-the chunk decoder driving a *real* solver. These tests build a minimal 3-DoF
-planar arm with ``mujoco`` and exercise that real path end to end, so a
-regression in the solver math, frame-task wiring, or solver-resolution contract
-is caught locally instead of only on hardware.
+This module exercises the *real* closed-loop kinematics that only run with the
+``sim-mujoco`` extra installed: :class:`MinkIKBridge` forward kinematics and the
+differential-IK solve loop against a genuine ``mink`` + ``mujoco`` stack, plus
+the chunk decoder driving that real solver. It ``importorskip``s on ``mujoco`` /
+``mink`` / ``qpsolvers`` so it skips cleanly on a clean-install image.
+
+The bridge's *dependency-free* surface (QP-backend selection, the install hint,
+the missing-``mink`` import guard, ``delta_to_matrix`` dispatch, and the decoder
+input validation) is covered without any sim stack in
+``test_sim_ik_solver_selection.py`` and ``test_sim_ik_bridge_solve_loop.py``, so
+those contracts are guarded in plain CI; here we pin the geometry that needs the
+real solver.
 """
-
-import sys
 
 import numpy as np
 import pytest
@@ -100,58 +102,3 @@ def test_decode_chunk_through_real_bridge_tracks_closed_loop(bridge):
     assert track["max_mm"] >= track["mean_mm"] >= 0.0
     # A real, non-singular arm tracks 1 cm steps to well under a millimetre.
     assert track["max_mm"] < 2.0, track
-
-
-def test_resolve_qp_solver_auto_and_explicit():
-    """Auto-selection returns an installed backend; an explicitly requested,
-    installed backend is honoured verbatim."""
-    auto = sim_ik._resolve_qp_solver(None)
-    from qpsolvers import available_solvers
-
-    assert auto in available_solvers
-    # daqp is pinned by mink and present in the sim extra.
-    assert sim_ik._resolve_qp_solver("daqp") == "daqp"
-
-
-def test_resolve_qp_solver_rejects_uninstalled_backend():
-    """An explicit, not-installed backend fails loudly (no silent fallback)."""
-    with pytest.raises(ValueError, match="not installed"):
-        sim_ik._resolve_qp_solver("definitely-not-a-real-solver")
-
-
-def test_resolve_qp_solver_raises_when_no_backend_available(monkeypatch):
-    """When qpsolvers reports zero backends, the bridge refuses to proceed."""
-    monkeypatch.setattr("qpsolvers.available_solvers", [])
-    with pytest.raises(RuntimeError, match="No qpsolvers backend"):
-        sim_ik._resolve_qp_solver(None)
-
-
-def test_resolve_qp_solver_missing_qpsolvers_gives_install_hint(monkeypatch):
-    """If qpsolvers itself is absent, the error carries the actionable hint."""
-    monkeypatch.setitem(sys.modules, "qpsolvers", None)
-    with pytest.raises(ImportError) as ei:
-        sim_ik._resolve_qp_solver(None)
-    assert "sim-mujoco" in str(ei.value)
-
-
-def test_delta_to_matrix_dispatches_rot6d_and_rejects_bad_dim():
-    """delta_to_matrix routes rotation_dim 6 -> rot6d and rejects other dims."""
-    rot6d = np.array([1, 0, 0, 0, 1, 0], dtype=np.float64)
-    assert np.allclose(sim_ik.delta_to_matrix(rot6d, 6), np.eye(3), atol=1e-6)
-    with pytest.raises(ValueError, match="unsupported rotation_dim"):
-        sim_ik.delta_to_matrix(np.zeros(4), 4)
-
-
-def test_decode_rejects_non_2d_chunk_and_short_pose_block(bridge):
-    """The decoder validates chunk shape and pose-dim sufficiency up front."""
-    with pytest.raises(ValueError, match=r"\[T, D\]"):
-        sim_ik.decode_vera_delta_chunk_to_targets(np.zeros((2, 3, 7)), bridge, np.zeros(bridge.model.nq))
-    # rotation_dim=6 needs >= 9 pose dims; a 4-wide chunk (3 pose + gripper) is short.
-    with pytest.raises(ValueError, match="pose dims"):
-        sim_ik.decode_vera_delta_chunk_to_targets(
-            np.zeros((2, 4), dtype=np.float64),
-            bridge,
-            np.zeros(bridge.model.nq),
-            rotation_dim=6,
-            has_gripper=True,
-        )


### PR DESCRIPTION
## Problem

The VERA eef-delta -> MuJoCo IK bridge (`strands_robots/policies/vera/sim_ik.py`) sat at **55% coverage**. Its only test module, `tests/policies/vera/test_vera_sim_ik_solver.py`, gated the *entire file* behind module-level `pytest.importorskip("mink")` / `importorskip("qpsolvers")`. On a clean install without the `sim-mujoco` extra (the default CI image), that skips every test in the file — including the **dependency-free** contracts that need no sim stack at all:

- `_resolve_qp_solver` QP-backend auto-selection + its error paths (requested-but-missing, none-installed, qpsolvers-absent);
- `_install_hint` actionable install message;
- `MinkIKBridge` construction failing with the install hint when `mink` is absent;
- `delta_to_matrix` rot6d / axis-angle dispatch and unsupported-dim rejection;
- `decode_vera_delta_chunk_to_targets` input validation (chunk rank, pose-dim sufficiency).

Those are exactly the paths a clean-install user hits first, and they were unguarded in default CI.

## Change

Mirror the `cosmos3/sim_ik` test layout (already at 100% for the same reason): split the dependency-free surface into two **ungated** modules driven by a stub `qpsolvers` module and a fake `mink` module, so the full `MinkIKBridge` construction, forward kinematics, and differential-IK solve loop (both the early-break and full-iteration-budget branches), plus solver resolution and decode validation, execute in plain CI.

- `tests/policies/vera/test_sim_ik_solver_selection.py` (new) — solver selection, install hint, import guard, `delta_to_matrix`, decode validation.
- `tests/policies/vera/test_sim_ik_bridge_solve_loop.py` (new) — bridge construction, `ee_pose`, `solve` loop via a fake one-step-exact `mink`.
- `tests/policies/vera/test_vera_sim_ik_solver.py` — trimmed to the real-solver accuracy regression it uniquely provides (still `importorskip`-gated on the sim extra); the dependency-free tests it previously held (and which never ran in clean CI) move to the ungated modules.

No production code change.

## Result

`strands_robots/policies/vera/sim_ik.py` coverage **55% -> 100%** (122 statements, 0 missing). `+18` new tests; full `tests/policies/vera/` green (115 passed, 1 skipped). `ruff check`, `ruff format --check`, and `mypy strands_robots tests tests_integ` clean.