### PR TITLE
test(sim): pin bounded renderer TLS cache eviction (max 4 resolutions/thread)

### DIFF
--- a/tests/simulation/mujoco/test_renderer_hygiene.py
+++ b/tests/simulation/mujoco/test_renderer_hygiene.py
@@ -58,3 +58,52 @@ class TestRendererTLSCache:
         sim.create_world()
         sim.render(width=160, height=120)
         assert (160, 120) in sim._renderer_tls.renderers
+
+
+@requires_gl
+class TestRendererCacheBounding:
+    """The per-thread renderer cache is bounded to a fixed number of distinct
+    resolutions and evicts the oldest entry (closing its GL context) once the
+    bound is exceeded. This prevents unbounded GL-context accumulation when a
+    caller renders at many different resolutions on one thread."""
+
+    MAX_RESOLUTIONS = 4
+
+    def _distinct_dims(self, count: int) -> list[tuple[int, int]]:
+        # Vary width only so each (w, h) is a distinct cache key; small sizes
+        # keep the GL allocations cheap.
+        return [(160 + i, 120) for i in range(count)]
+
+    def test_cache_bounded_and_evicts_oldest(self, sim):
+        sim.create_world()
+        dims = self._distinct_dims(self.MAX_RESOLUTIONS + 2)
+        for width, height in dims:
+            sim.render(width=width, height=height)
+
+        keys = list(sim._renderer_tls.renderers.keys())
+        assert len(keys) == self.MAX_RESOLUTIONS, "cache must stay capped at the max resolution count"
+        # The two oldest (first-inserted) keys are evicted; the most recent
+        # MAX_RESOLUTIONS keys remain, preserving insertion order.
+        assert keys == dims[-self.MAX_RESOLUTIONS :]
+        assert dims[0] not in keys
+        assert dims[1] not in keys
+
+    def test_eviction_closes_evicted_renderer(self, sim):
+        sim.create_world()
+        dims = self._distinct_dims(self.MAX_RESOLUTIONS + 1)
+
+        # Create the first (soon-to-be-evicted) renderer and wrap its close()
+        # so we can assert the eviction path frees its GL context.
+        first_w, first_h = dims[0]
+        sim.render(width=first_w, height=first_h)
+        evicted = sim._renderer_tls.renderers[(first_w, first_h)]
+        close_calls: list[int] = []
+        original_close = evicted.close
+        evicted.close = lambda *a, **k: (close_calls.append(1), original_close())[1]
+
+        # Fill past the cap so the first renderer is evicted.
+        for width, height in dims[1:]:
+            sim.render(width=width, height=height)
+
+        assert (first_w, first_h) not in sim._renderer_tls.renderers
+        assert close_calls == [1], "evicted renderer must have close() called exactly once"


### PR DESCRIPTION
## Problem

The per-thread MuJoCo renderer cache (`RenderingMixin._get_renderer`) bounds itself to 4 distinct resolutions and evicts the oldest entry, closing its GL context, once that bound is exceeded. This prevents unbounded GL-context accumulation when a caller renders at many different resolutions on a single thread (e.g. multi-resolution eval/benchmark loops, or a tool that renders thumbnails + full frames).

The existing `test_renderer_hygiene.py` covers cache reuse, destroy, and per-dimension creation, but the eviction path itself was untested. A regression that dropped the bound (leaking one GL context per new resolution) would pass CI silently.

## Change

Test-only. Adds `TestRendererCacheBounding` with two focused tests that assert the complete eviction behavior:

- `test_cache_bounded_and_evicts_oldest` — rendering at `max+2` distinct resolutions keeps the cache capped at 4 and evicts the oldest (first-inserted) keys, preserving insertion order.
- `test_eviction_closes_evicted_renderer` — wraps the soon-to-be-evicted renderer's `close()` and asserts it is called exactly once, confirming the GL context is freed rather than leaked.

## Verification

- Both tests pass on current `main`.
- Both tests fail when the bounding/eviction block is removed (verified locally), so they guard the memory-safety property rather than just restating it.
- Full gate green: `ruff check`, `ruff format --check`, `mypy strands_robots tests tests_integ` (no issues), and `MUJOCO_GL=egl pytest tests/simulation/mujoco/test_renderer_hygiene.py` (6 passed).

The new tests are GL-gated via the existing `@requires_gl` marker, so they skip cleanly on headless hosts without EGL/OSMesa.