### PR TITLE
feat(sim): async_rtc chunk pipeline overlaps inference with execution in run_policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Added: `async_rtc` chunk pipeline for `run_policy` (overlap inference with execution)
+
+`run_policy` / `PolicyRunner.run` drove policies through a synchronous
+chunk-then-drain loop: query the policy, fully execute the returned action
+chunk, then re-query. Inference and execution never overlapped, so a
+chunk-emitting VLA (pi0, SmolVLA, MolmoAct2) showed a per-seam stall in sim that
+it would NOT show on real hardware, where an async controller hides inference
+latency behind chunk execution. RTC's seam blending worked, but its second
+benefit - latency masking - was invisible in sim, making sim timing diverge from
+real-hardware timing and RTC-tuned policies look worse than they are.
+
+- `run_policy` and `PolicyRunner.run` accept `async_rtc: bool = False`. When
+  `True`, the next `get_actions` is fired on a single background worker once the
+  current chunk is ~50% drained (using a fresh mid-execution observation) and
+  atomically swapped in when the chunk runs out. A policy whose inference
+  latency is at most the chunk's execution window then pays (almost) zero
+  visible stall at the seam.
+- Provider-agnostic: the runner only schedules the inference/execution overlap;
+  it never touches the policy's RTC machinery, so RTC-capable policies still
+  blend the seam internally via their own prev-chunk state.
+- Thread-safe by construction: the policy is invoked from at most one thread at
+  a time (a new prefetch is only submitted after the previous one is consumed),
+  the sim is only ever touched from the calling thread, and the runner blocks on
+  any in-flight inference before returning so no background thread touches the
+  policy or sim after `run_policy` exits.
+- Backward compatible: `async_rtc=False` (default) keeps the exact synchronous
+  loop. Most useful at real-time pacing (`fast_mode=False`) with multi-step
+  chunks, where there is an execution window to hide inference behind.
+
 ### Fixed: `reset()` during recording flushes the buffered rollout as an episode
 
 A `run_policy` + `reset` data-collection loop silently merged every rollout into

--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -229,6 +229,46 @@ policy = create_policy("lerobot_local", pretrained_name_or_path="lerobot/pi0_so1
                         rtc_enabled=True, rtc_execution_horizon=16, rtc_max_guidance_weight=1.0)
 ```
 
+Real-Time Chunking does two things. First, **seam blending**: each new action
+chunk is denoised conditioned on the still-unexecuted tail of the previous
+chunk (`rtc_execution_horizon`), so the trajectory has no discontinuity where
+one chunk hands off to the next. Second, on real hardware, it lets **inference
+overlap execution**: the controller fires the next inference while the current
+chunk is still being executed, so the model's latency is hidden behind motion
+rather than appearing as a stall at the seam.
+
+### Synchronous vs async chunk execution in sim
+
+`run_policy` / `PolicyRunner.run` accept an `async_rtc` flag controlling which
+of those two RTC benefits the sim reproduces:
+
+| `async_rtc` | Behaviour | Use when |
+| --- | --- | --- |
+| `False` (default) | Query the policy, fully drain the returned chunk, then re-query. Seam blending still works, but inference and execution do **not** overlap. | Single-step policies, deterministic regression runs, or any policy whose `get_actions` reads live sim state. |
+| `True` | While the current chunk drains, fire the next `get_actions` on a single background worker once the chunk is ~50% consumed (using a fresh mid-execution observation), then atomically swap it in. A policy whose inference latency is at most the chunk's execution window pays (almost) zero visible stall at the seam. | Chunk-emitting VLA / flow-matching policies (pi0, pi0.5, pi0-FAST, SmolVLA, MolmoAct2) where you want sim per-step timing to track real-hardware behaviour, or to benchmark a streaming controller. |
+
+```python
+# Default sync loop - inference shows up as a per-seam stall in sim.
+sim.run_policy(robot_name="so101", policy_provider="lerobot_local",
+               policy_config={"pretrained_name_or_path": "lerobot/pi0_so100", "rtc_enabled": True},
+               action_horizon=8)
+
+# Async pipeline - the next chunk is computed in the background while the
+# current one executes, so inference latency is masked (same as real hardware).
+sim.run_policy(robot_name="so101", policy_provider="lerobot_local",
+               policy_config={"pretrained_name_or_path": "lerobot/pi0_so100", "rtc_enabled": True},
+               action_horizon=8, async_rtc=True)
+```
+
+`async_rtc` is provider-agnostic: it only schedules the inference/execution
+overlap and never touches the policy's RTC machinery, so RTC-capable policies
+still blend the seam internally. The runner invokes the policy from at most one
+thread at a time and blocks on any in-flight inference before returning, so it
+introduces no data race. Masking only helps when there is execution to hide
+behind, so the benefit is largest at real-time pacing (`fast_mode=False`) with
+multi-step chunks; with `fast_mode=True` and near-instant physics there is
+little execution window to overlap.
+
 ## See also
 
 - [Policy providers](../policies/overview.md)

--- a/docs/simulation/overview.md
+++ b/docs/simulation/overview.md
@@ -90,7 +90,7 @@ Robot-URDF cameras are auto-discovered on `add_robot`.
 
 | Action | Key params |
 |--------|-----------|
-| `run_policy` | `robot_name` (required), `policy_provider="mock"`, `policy_config={}`, `policy_object=None`, `instruction=""`, `duration=10.0`, `control_frequency=50.0`, `action_horizon=8`, `n_steps=None`, `seed=None` |
+| `run_policy` | `robot_name` (required), `policy_provider="mock"`, `policy_config={}`, `policy_object=None`, `instruction=""`, `duration=10.0`, `control_frequency=50.0`, `action_horizon=8`, `n_steps=None`, `seed=None`, `async_rtc=False` |
 | `start_policy` | same args, async/non-blocking |
 | `stop_policy` | `robot_name` (optional, defaults to `""`) |
 | `list_policies_running` | - |
@@ -100,6 +100,8 @@ Robot-URDF cameras are auto-discovered on `add_robot`.
 The step horizon is given either as `duration` (seconds) or as `n_steps` (`duration = n_steps / control_frequency`; `n_steps` wins when both are set, and the legacy `max_steps` is an alias for `n_steps`). A non-positive `n_steps` or `control_frequency` is rejected up front with a structured `status="error"` dict naming the bad parameter - `start_policy` validates synchronously before the background rollout starts, so a malformed horizon never returns a false "started" success.
 
 Pass `seed=` to `run_policy` / `start_policy` for a reproducible single rollout: it reseeds Python / NumPy / torch / cuDNN and forwards `policy.reset(seed=...)`, so a stochastic policy (VLA action-chunk sampling, diffusion noise) produces the same trajectory on re-run of the same scene. Without a seed the rollout draws from the process-global RNG and can differ run to run. `eval_policy` already seeds per episode via the same mechanism.
+
+Pass `async_rtc=True` to `run_policy` to overlap policy inference with action execution: while the current action chunk drains, the next `get_actions` is computed on a background worker and atomically swapped in when the chunk runs out (latency masking). The default `False` keeps the synchronous chunk-then-drain loop. This is most useful for chunk-emitting VLA / flow-matching policies (pi0, SmolVLA, MolmoAct2) where it makes sim per-step timing track real-hardware behaviour; see [LeRobot Local -> RTC](../policies/lerobot-local.md#synchronous-vs-async-chunk-execution-in-sim).
 
 `run_policy` returns a `{"json": {...}}` content block alongside the human-readable `text`, mirroring `eval_policy`. The json block carries the rollout facts as typed fields - `robot_name`, `policy`, `instruction`, `n_steps`, `elapsed_s`, `stopped_early`, `action_errors`, `video_path` (`None` when no MP4 was written), `video_frames` and `sim_time_s` (when the backend reports it) - so an agent can read the outcome programmatically (did it move? how many steps? where is the video?) without regex-parsing the prose.
 | `replay_episode` | `repo_id`, `robot_name=None`, `episode=0` |

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -380,6 +380,7 @@ class SimEngine(ABC):
         seed: int | None = None,
         n_episodes: int = 1,
         reset_between: bool = True,
+        async_rtc: bool = False,
     ) -> dict[str, Any]:
         """Run a policy loop in the simulation (blocking).
 
@@ -446,6 +447,16 @@ class SimEngine(ABC):
                 initial state between episodes (default ``True``). The reset
                 never fires after the final episode. Set ``False`` to chain
                 episodes from the end state of the previous one.
+            async_rtc: When ``True``, overlap policy inference with action
+                execution so the next action chunk is computed in the
+                background while the current chunk is still draining (latency
+                masking). ``False`` (default) keeps the synchronous
+                chunk-then-drain loop. Forwarded verbatim to
+                :meth:`PolicyRunner.run`; see its docstring for the full
+                contract (provider-agnostic, RTC-policy seam blending, thread
+                safety). Most useful for chunk-emitting VLA/flow-matching
+                policies (pi0, pi0.5, SmolVLA, MolmoAct2) where it makes sim
+                per-step timing track real-hardware behaviour.
 
         Returns:
             Standard status dict with an agent-consumable ``{"json": {...}}``
@@ -509,6 +520,7 @@ class SimEngine(ABC):
                 control_substeps=control_substeps,
                 policy_kwargs=policy_kwargs,
                 seed=seed,
+                async_rtc=async_rtc,
             )
 
         # Multi-episode path: one rollout per episode, flushing a dataset
@@ -531,6 +543,7 @@ class SimEngine(ABC):
             seed=seed,
             n_episodes=n_episodes,
             reset_between=reset_between,
+            async_rtc=async_rtc,
         )
 
     def _run_episodes(
@@ -551,6 +564,7 @@ class SimEngine(ABC):
         seed: int | None,
         n_episodes: int,
         reset_between: bool,
+        async_rtc: bool = False,
     ) -> dict[str, Any]:
         """Run ``n_episodes`` sequential rollouts; shared multi-episode driver.
 
@@ -584,6 +598,7 @@ class SimEngine(ABC):
                 control_substeps=control_substeps,
                 policy_kwargs=policy_kwargs,
                 seed=ep_seed,
+                async_rtc=async_rtc,
             )
             ep_json = self._extract_json_payload(result)
             ep_record: dict[str, Any] = {"episode": ep, **ep_json}

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -2287,6 +2287,7 @@ class MuJoCoSimEngine(
         seed: int | None = None,
         n_episodes: int = 1,
         reset_between: bool = True,
+        async_rtc: bool = False,
     ) -> dict[str, Any]:
         """MuJoCo ``run_policy`` override: pre-flight world check + graceful stop.
 
@@ -2332,6 +2333,7 @@ class MuJoCoSimEngine(
                 seed=seed,
                 n_episodes=n_episodes,
                 reset_between=reset_between,
+                async_rtc=async_rtc,
             )
         finally:
             if self._world is not None and robot_name in self._world.robots:

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -290,6 +290,7 @@ class PolicyRunner:
         control_substeps: int | None = None,
         policy_kwargs: dict[str, Any] | None = None,
         seed: int | None = None,
+        async_rtc: bool = False,
     ) -> dict[str, Any]:
         """Run ``policy`` on ``robot_name`` for ``duration`` seconds.
 
@@ -342,6 +343,26 @@ class PolicyRunner:
                 on the next. ``None`` (default) leaves RNG state untouched,
                 preserving historical behaviour. Multi-episode reproducibility
                 already flows through :meth:`evaluate`'s per-episode reseed.
+            async_rtc: When ``True``, overlap policy inference with action
+                execution via a single background worker (latency masking).
+                While the current action chunk drains, the next
+                ``get_actions()`` is fired once the chunk is ~50% consumed,
+                using a fresh mid-execution observation, and atomically swapped
+                in when the current chunk runs out. A policy whose inference
+                latency is at most the chunk's execution time then pays
+                (almost) zero visible stall at the chunk seam - the same way an
+                async real-time controller hides inference latency on real
+                hardware. RTC-capable policies (pi0, pi0.5, SmolVLA, MolmoAct2)
+                blend the seam internally through their own prev-chunk state
+                (``rtc_config.execution_horizon``); this flag only schedules the
+                overlap and never touches the policy's RTC machinery, so it is
+                provider-agnostic. ``False`` (default) keeps the historical
+                synchronous chunk-then-drain loop, which is correct for
+                single-step policies and any policy whose ``get_actions`` reads
+                live sim state. The policy object is only ever invoked from the
+                single background worker (never concurrently), and the runner
+                blocks on any in-flight inference before returning so no thread
+                touches the policy or sim after :meth:`run` exits.
 
         Returns:
             ``{"status": "success"|"error", "content": [{"text": ...},
@@ -473,78 +494,155 @@ class PolicyRunner:
                 max_onframe_failures if max_onframe_failures is not None else _MAX_CONSECUTIVE_ONFRAME_FAILURES
             )
             consecutive_onframe_failures = 0
-            while step_count < total_steps:
-                observation = self.sim.get_observation(robot_name=robot_name, skip_images=_skip_images)
 
+            # Per-action execution body shared by BOTH the synchronous loop and
+            # the async-RTC pipeline so they send, record, count and pace
+            # identically - only the chunk-ACQUISITION strategy differs between
+            # the two paths.
+            def _apply(observation: dict[str, Any], action_dict: dict[str, Any]) -> None:
+                nonlocal step_count, _action_errors, consecutive_onframe_failures
+                nonlocal frame_count, next_frame_step
+
+                _send_result = self.sim.send_action(action_dict, robot_name=robot_name, n_substeps=n_substeps)
+                if isinstance(_send_result, dict) and _send_result.get("status") == "error":
+                    _action_errors += 1
+
+                if on_frame is not None:
+                    try:
+                        on_frame(step_count, observation, action_dict)
+                        consecutive_onframe_failures = 0
+                    except CooperativeStop:
+                        # Backend (e.g. MuJoCo) signalled a graceful stop.
+                        raise
+                    except Exception as e:
+                        # on_frame is user-provided telemetry - never fatal
+                        # *per call*. But if it fails on every step, a 500-
+                        # step episode completes "successfully" with zero
+                        # frames recorded and the dataset is silently empty.
+                        # Count consecutive failures and fail the episode
+                        # after ``onframe_failure_limit`` in a row. See GH #117.
+                        consecutive_onframe_failures += 1
+                        logger.warning(
+                            "on_frame hook failed (%d/%d consecutive): %s",
+                            consecutive_onframe_failures,
+                            onframe_failure_limit,
+                            e,
+                        )
+                        if consecutive_onframe_failures >= onframe_failure_limit:
+                            raise RuntimeError(
+                                f"on_frame hook failed {onframe_failure_limit} times in a row; "
+                                f"aborting episode to avoid silent dataset corruption. "
+                                f"Last error: {e!r}"
+                            ) from e
+
+                step_count += 1
+
+                if writer is not None and step_count >= next_frame_step:
+                    assert video is not None  # for mypy: writer only set when video.enabled
+                    frame = self.sim.render(
+                        camera_name=video.camera or "default",
+                        width=video.width,
+                        height=video.height,
+                    )
+                    # sim.render() returns {status, content:[{text},{image:{source:{bytes}}}]}
+                    # Decode the PNG bytes from the content block and hand an ndarray
+                    # to imageio. Silently skips when the PNG decode fails rather than
+                    # aborting the whole rollout (renderer errors shouldn't kill training).
+                    img_arr = _extract_frame_ndarray(frame)
+                    if img_arr is not None:
+                        writer.append_data(img_arr)
+                        frame_count += 1
+                    next_frame_step += frame_interval
+
+                if not fast_mode:
+                    time.sleep(action_sleep)
+
+            def _query_chunk(observation: dict[str, Any]) -> list[dict[str, Any]]:
+                # Resolve ONE action chunk from the policy. Never truncate below
+                # the policy's own intended chunk size: a model trained for
+                # N-step open-loop replay (policy.actions_per_step == N) must
+                # have its full chunk consumed; clamping to a smaller
+                # action_horizon drops the tail of every chunk and forces an
+                # out-of-distribution re-query (see LerobotLocalPolicy
+                # auto-detect of config.n_action_steps).
                 coro_or_result = policy.get_actions(observation, instruction, **_policy_kwargs)
                 actions = _resolve_coroutine(coro_or_result)
-
-                # Never truncate below the policy's own intended chunk size.
-                # A model trained for N-step open-loop replay
-                # (policy.actions_per_step == N) must have its full chunk
-                # consumed; clamping to a smaller action_horizon drops the
-                # tail of every chunk and forces an out-of-distribution
-                # re-query (see LerobotLocalPolicy auto-detect of
-                # config.n_action_steps).
                 _chunk = max(action_horizon, getattr(policy, "actions_per_step", 1))
-                for action_dict in actions[:_chunk]:
-                    if step_count >= total_steps:
-                        break
+                return list(actions[:_chunk])
 
-                    _send_result = self.sim.send_action(action_dict, robot_name=robot_name, n_substeps=n_substeps)
-                    if isinstance(_send_result, dict) and _send_result.get("status") == "error":
-                        _action_errors += 1
+            if async_rtc:
+                # Async chunk pipeline: overlap inference for chunk N+1 with the
+                # EXECUTION of chunk N. While the current chunk drains we fire
+                # the next get_actions() on a single background worker using a
+                # mid-execution ("horizon-shifted") observation, then atomically
+                # swap it in when the current chunk runs out. A policy whose
+                # inference latency is <= the chunk's execution time pays
+                # (almost) zero visible stall at the seam - exactly how an async
+                # real-time controller hides latency on real hardware. RTC
+                # policies blend the seam internally via their own prev-chunk
+                # state, so the runner only schedules the overlap (it never
+                # touches the policy's RTC machinery). The policy is invoked from
+                # AT MOST one thread at a time (a new prefetch is only submitted
+                # after the previous one has been consumed), and the sim is only
+                # ever touched from THIS thread, so there is no MuJoCo data race.
+                from concurrent.futures import Future, ThreadPoolExecutor
 
-                    if on_frame is not None:
-                        try:
-                            on_frame(step_count, observation, action_dict)
-                            consecutive_onframe_failures = 0
-                        except CooperativeStop:
-                            # Backend (e.g. MuJoCo) signalled a graceful stop.
-                            # Break both loops and return a normal success result.
-                            raise
-                        except Exception as e:
-                            # on_frame is user-provided telemetry - never fatal
-                            # *per call*. But if it fails on every step, a 500-
-                            # step episode completes "successfully" with zero
-                            # frames recorded and the dataset is silently empty.
-                            # Count consecutive failures and fail the episode
-                            # after ``onframe_failure_limit`` in a row. See GH #117.
-                            consecutive_onframe_failures += 1
-                            logger.warning(
-                                "on_frame hook failed (%d/%d consecutive): %s",
-                                consecutive_onframe_failures,
-                                onframe_failure_limit,
-                                e,
-                            )
-                            if consecutive_onframe_failures >= onframe_failure_limit:
-                                raise RuntimeError(
-                                    f"on_frame hook failed {onframe_failure_limit} times in a row; "
-                                    f"aborting episode to avoid silent dataset corruption. "
-                                    f"Last error: {e!r}"
-                                ) from e
+                executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="rtc-prefetch")
+                try:
+                    cur_obs = self.sim.get_observation(robot_name=robot_name, skip_images=_skip_images)
+                    cur_chunk = _query_chunk(cur_obs)
+                    if not cur_chunk:
+                        raise RuntimeError("policy returned an empty action chunk; cannot run rollout")
+                    idx = 0
+                    prefetch_trigger = max(1, len(cur_chunk) // 2)
+                    prefetch: Future[list[dict[str, Any]]] | None = None
+                    prefetch_obs: dict[str, Any] | None = None
 
-                    step_count += 1
+                    while step_count < total_steps:
+                        if idx >= len(cur_chunk):
+                            # Current chunk drained -> swap in the next chunk.
+                            if prefetch is not None:
+                                # Atomic swap. Blocks ONLY if inference is still
+                                # in flight (it ran slower than chunk execution);
+                                # otherwise the result is already waiting and the
+                                # seam is invisible.
+                                cur_chunk = prefetch.result()
+                                if prefetch_obs is not None:
+                                    cur_obs = prefetch_obs
+                                prefetch = None
+                                prefetch_obs = None
+                            else:
+                                # Chunk was too short to trigger a prefetch;
+                                # fall back to a synchronous re-query.
+                                cur_obs = self.sim.get_observation(robot_name=robot_name, skip_images=_skip_images)
+                                cur_chunk = _query_chunk(cur_obs)
+                            if not cur_chunk:
+                                raise RuntimeError("policy returned an empty action chunk; cannot continue rollout")
+                            idx = 0
+                            prefetch_trigger = max(1, len(cur_chunk) // 2)
+                            continue
 
-                    if writer is not None and step_count >= next_frame_step:
-                        assert video is not None  # for mypy: writer only set when video.enabled
-                        frame = self.sim.render(
-                            camera_name=video.camera or "default",
-                            width=video.width,
-                            height=video.height,
-                        )
-                        # sim.render() returns {status, content:[{text},{image:{source:{bytes}}}]}
-                        # Decode the PNG bytes from the content block and hand an ndarray
-                        # to imageio. Silently skips when the PNG decode fails rather than
-                        # aborting the whole rollout (renderer errors shouldn't kill training).
-                        img_arr = _extract_frame_ndarray(frame)
-                        if img_arr is not None:
-                            writer.append_data(img_arr)
-                            frame_count += 1
-                        next_frame_step += frame_interval
+                        # Fire the next inference once we are ~50% through the
+                        # current chunk, on a fresh mid-chunk observation.
+                        if prefetch is None and idx >= prefetch_trigger:
+                            prefetch_obs = self.sim.get_observation(robot_name=robot_name, skip_images=_skip_images)
+                            prefetch = executor.submit(_query_chunk, prefetch_obs)
 
-                    if not fast_mode:
-                        time.sleep(action_sleep)
+                        _apply(cur_obs, cur_chunk[idx])
+                        idx += 1
+                finally:
+                    # Wait for any in-flight inference so no background thread
+                    # touches the policy/sim after run() returns (the caller may
+                    # immediately reset() or destroy() the world).
+                    executor.shutdown(wait=True)
+            else:
+                while step_count < total_steps:
+                    observation = self.sim.get_observation(robot_name=robot_name, skip_images=_skip_images)
+                    chunk = _query_chunk(observation)
+                    for action_dict in chunk:
+                        if step_count >= total_steps:
+                            break
+                        _apply(observation, action_dict)
 
         except CooperativeStop:
             stopped_early = True

--- a/tests/simulation/test_policy_runner_async_rtc.py
+++ b/tests/simulation/test_policy_runner_async_rtc.py
@@ -1,0 +1,211 @@
+"""Async-RTC chunk pipeline in :class:`PolicyRunner.run`.
+
+The synchronous loop queries the policy, fully drains the returned chunk, then
+re-queries - so inference never overlaps execution and a chunk-emitting VLA
+shows a per-seam stall in sim that it would NOT show on real hardware (where an
+async controller hides inference latency behind chunk execution).
+
+``run(..., async_rtc=True)`` overlaps the two: while the current chunk drains,
+the next ``get_actions`` is fired on a single background worker once the chunk
+is ~50% consumed, then atomically swapped in. These tests pin:
+
+* overlap: the next inference STARTS mid-chunk (before the current chunk drains)
+* synchronous baseline: inference only starts after the chunk fully drains
+* latency masking: async wall-time is materially lower than synchronous
+* correctness/back-compat: identical step accounting; default is synchronous
+"""
+
+from __future__ import annotations
+
+import inspect
+import threading
+import time
+from typing import Any
+
+import numpy as np
+
+from strands_robots.policies.base import Policy
+from strands_robots.simulation.base import SimEngine
+from strands_robots.simulation.policy_runner import PolicyRunner
+
+_CHUNK = 4
+_INFER_SLEEP = 0.05
+_EXEC_SLEEP = 0.02  # per send_action; chunk exec (~0.08s) > infer (0.05s) -> hidden
+
+
+class _CountingSim(SimEngine):
+    """Minimal ``SimEngine`` that counts ``send_action`` calls and can pace them.
+
+    ``send_count`` is incremented BEFORE the optional per-action sleep so a
+    concurrently-running policy that reads it observes the step index reached so
+    far, which is what the overlap assertions key off.
+    """
+
+    def __init__(self, exec_sleep: float = 0.0) -> None:
+        self._joint_names = ["j0", "j1", "j2"]
+        self._robots = {"arm": self._joint_names}
+        self._exec_sleep = exec_sleep
+        self._lock = threading.Lock()
+        self.send_count = 0
+
+    def create_world(self, timestep=None, gravity=None, ground_plane=True):
+        return {"status": "success"}
+
+    def destroy(self):
+        return {"status": "success"}
+
+    def reset(self):
+        return {"status": "success"}
+
+    def step(self, n_steps: int = 1):
+        return {"status": "success"}
+
+    def get_state(self):
+        return {"sim_time": 0.0, "step_count": self.send_count}
+
+    def add_robot(self, name, **kw):
+        return {"status": "success"}
+
+    def remove_robot(self, name):
+        return {"status": "success"}
+
+    def list_robots(self) -> list[str]:
+        return list(self._robots.keys())
+
+    def robot_joint_names(self, robot_name: str) -> list[str]:
+        return list(self._robots.get(robot_name, []))
+
+    def add_object(self, name, **kw):
+        return {"status": "success"}
+
+    def remove_object(self, name):
+        return {"status": "success"}
+
+    def get_observation(self, robot_name=None, *, skip_images=False):
+        return {n: 0.0 for n in self._joint_names}
+
+    def send_action(self, action, robot_name=None, n_substeps=1):
+        with self._lock:
+            self.send_count += 1
+        if self._exec_sleep:
+            time.sleep(self._exec_sleep)
+
+    def render(self, camera_name="default", width=None, height=None):
+        return {"image": np.zeros((height or 48, width or 64, 3), dtype=np.uint8)}
+
+
+class _ChunkPolicy(Policy):
+    """Emits fixed-size chunks; records the sim step index at each inference start.
+
+    ``infer_starts[k]`` is the value of ``sim.send_count`` captured at the very
+    first line of the k-th ``get_actions`` call (before the inference sleep). In
+    the synchronous loop these are exact multiples of the chunk size (the chunk
+    is always fully drained before the next query); the async pipeline fires the
+    query mid-chunk, so at least one value is NOT a chunk multiple.
+    """
+
+    def __init__(self, sim: _CountingSim, chunk: int = _CHUNK, infer_sleep: float = _INFER_SLEEP) -> None:
+        self._sim = sim
+        self.actions_per_step = chunk
+        self._chunk = chunk
+        self._infer_sleep = infer_sleep
+        self.robot_state_keys: list[str] = []
+        self.infer_starts: list[int] = []
+        self._lock = threading.Lock()
+
+    @property
+    def provider_name(self) -> str:
+        return "chunk-test"
+
+    @property
+    def requires_images(self) -> bool:
+        return False
+
+    def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
+        self.robot_state_keys = robot_state_keys
+
+    async def get_actions(
+        self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any
+    ) -> list[dict[str, Any]]:
+        with self._lock:
+            self.infer_starts.append(self._sim.send_count)
+        if self._infer_sleep:
+            time.sleep(self._infer_sleep)
+        keys = self.robot_state_keys or ["j0", "j1", "j2"]
+        return [{k: 0.0 for k in keys} for _ in range(self._chunk)]
+
+
+def _run(
+    async_rtc: bool, *, exec_sleep: float = _EXEC_SLEEP, n_steps: int = 16
+) -> tuple[dict, _ChunkPolicy, _CountingSim]:
+    sim = _CountingSim(exec_sleep=exec_sleep)
+    policy = _ChunkPolicy(sim)
+    policy.set_robot_state_keys(sim.robot_joint_names("arm"))
+    duration = n_steps / 50.0
+    result = PolicyRunner(sim).run(
+        "arm",
+        policy,
+        duration=duration,
+        control_frequency=50.0,
+        action_horizon=_CHUNK,
+        fast_mode=True,
+        async_rtc=async_rtc,
+    )
+    return result, policy, sim
+
+
+def test_async_rtc_starts_next_inference_mid_chunk() -> None:
+    """The prefetched chunk-N+1 inference fires while chunk N is still draining."""
+    result, policy, sim = _run(async_rtc=True)
+    assert result["status"] == "success"
+    # More than one chunk was consumed, so prefetch had to fire.
+    assert len(policy.infer_starts) >= 2
+    # At least one inference began at a non-chunk-boundary step index -> the
+    # query overlapped execution rather than waiting for a full drain.
+    assert any(c % _CHUNK != 0 for c in policy.infer_starts), policy.infer_starts
+    # Specifically the first prefetch starts strictly before chunk 1 drains.
+    assert policy.infer_starts[1] < _CHUNK, policy.infer_starts
+
+
+def test_sync_only_queries_after_chunk_drains() -> None:
+    """The synchronous baseline never overlaps: every query is on a boundary."""
+    result, policy, sim = _run(async_rtc=False)
+    assert result["status"] == "success"
+    assert len(policy.infer_starts) >= 2
+    assert all(c % _CHUNK == 0 for c in policy.infer_starts), policy.infer_starts
+
+
+def test_async_rtc_masks_inference_latency() -> None:
+    """Async wall-time is materially lower because inference hides behind exec."""
+    t0 = time.perf_counter()
+    sync_result, _, _ = _run(async_rtc=False)
+    sync_elapsed = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    async_result, _, _ = _run(async_rtc=True)
+    async_elapsed = time.perf_counter() - t0
+
+    assert sync_result["status"] == "success"
+    assert async_result["status"] == "success"
+    # 16 steps / chunk 4 => 4 chunks. Sync pays infer_sleep per chunk serially;
+    # async hides all but (at most) the first. Saving >= 2 inference periods is
+    # a conservative, non-flaky margin.
+    assert sync_elapsed - async_elapsed > 2 * _INFER_SLEEP, (sync_elapsed, async_elapsed)
+
+
+def test_async_rtc_matches_sync_step_accounting() -> None:
+    """Both paths run the same number of steps and send the same action count."""
+    sync_result, _, sync_sim = _run(async_rtc=False, exec_sleep=0.0)
+    async_result, _, async_sim = _run(async_rtc=True, exec_sleep=0.0)
+
+    sync_json = sync_result["content"][1]["json"]
+    async_json = async_result["content"][1]["json"]
+    assert sync_json["n_steps"] == async_json["n_steps"] == 16
+    assert sync_sim.send_count == async_sim.send_count == 16
+    assert async_json["action_errors"] == 0
+
+
+def test_async_rtc_defaults_to_false() -> None:
+    """Back-compat: async_rtc is opt-in on both PolicyRunner.run and run_policy."""
+    assert inspect.signature(PolicyRunner.run).parameters["async_rtc"].default is False
+    assert inspect.signature(SimEngine.run_policy).parameters["async_rtc"].default is False


### PR DESCRIPTION
## Problem

The sim policy runners drive every policy through a **synchronous** chunk-then-drain loop: query the policy, fully execute the returned action chunk, then re-query. Inference and execution never overlap.

`LerobotLocalPolicy` already has full Real-Time Chunking (RTC) support, so the **seam blending** half of RTC works in sim (each new chunk is denoised conditioned on the unexecuted tail of the previous one). But RTC's *second* benefit, **latency masking** (firing the next inference while the current chunk is still executing so model latency hides behind motion), was invisible in sim because the runner waited for a chunk to fully drain before re-querying.

Consequences:
- A chunk-emitting VLA (pi0, pi0.5, SmolVLA, MolmoAct2) shows a per-seam stall in sim that it would NOT show on real hardware.
- Sim per-step timing diverges from real-hardware timing, so RTC-tuned policies look worse in sim than they actually are and baseline benchmarks are unfair.

## Change

Add `async_rtc: bool = False` to `PolicyRunner.run` and `SimEngine.run_policy` (threaded through the MuJoCo `run_policy` override and the multi-episode driver). When `True`:

1. While the current chunk drains, the next `get_actions` is fired on a single background worker once the chunk is ~50% consumed, using a fresh mid-execution ("horizon-shifted") observation.
2. The result is atomically swapped in when the current chunk runs out; the swap blocks only if inference is still in flight (i.e. it ran slower than the chunk's execution window).

A policy whose inference latency is at most the chunk's execution window then pays (almost) zero visible stall at the seam, exactly how an async real-time controller hides latency on real hardware.

Design properties:
- **Provider-agnostic**: the runner only schedules the inference/execution overlap; it never touches the policy's RTC machinery, so RTC-capable policies still blend the seam internally via their own prev-chunk state (`rtc_config.execution_horizon`).
- **Thread-safe by construction**: the policy is invoked from at most one thread at a time (a new prefetch is submitted only after the previous one is consumed), the sim is only ever touched from the calling thread, and the runner blocks on any in-flight inference before returning so no background thread touches the policy or sim after `run_policy` exits.
- **Backward compatible**: `async_rtc=False` (default) keeps the exact synchronous loop. The synchronous and async paths share one per-action execution body, so recording, `on_frame`, step accounting and real-time pacing are identical between them.

## Tests

New `tests/simulation/test_policy_runner_async_rtc.py` (fails on pre-change code, passes after) pins:
- **overlap**: the prefetched chunk-N+1 inference starts mid-chunk (before chunk N drains) using a mock policy with injected `time.sleep` latency;
- **synchronous baseline**: inference only starts on chunk boundaries when `async_rtc=False`;
- **latency masking**: async wall-time is materially lower than synchronous;
- **parity**: both paths run the same step count and send the same action count;
- **opt-in default**: `async_rtc` defaults to `False` on both `PolicyRunner.run` and `SimEngine.run_policy`.

Full `tests/simulation/` suite passes (the only failures on my machine are pre-existing `libtorchcodec`/`libc10_cuda.so` load errors in `test_recording_paths.py`, unrelated to this change and present on a clean checkout).

## Visual artifact

MuJoCo rollout (headless, `MUJOCO_GL=egl`) of `run_policy(..., async_rtc=True)` on an SO-101 arm, 120 steps at 30 Hz, 120/120 frames captured:

![async_rtc rollout](https://github.com/cagataycali/robots/releases/download/async-rtc-demo/async_rtc_demo.gif)

Latency-masking microbenchmark in the same sim (real-time pacing, 8-action chunks at 30 Hz, ~100 ms injected inference latency, 80 steps):

| mode | total | per-step |
| --- | --- | --- |
| `async_rtc=False` | 3.78 s | 47.3 ms/step |
| `async_rtc=True` | 2.86 s | 35.7 ms/step |

~25% lower per-step wall time once inference overlaps execution. The gap widens as inference latency approaches the chunk execution window (the regime RTC targets).

## Docs

- `docs/policies/lerobot-local.md`: new "Synchronous vs async chunk execution in sim" section (sync vs async table + when to use each).
- `docs/simulation/overview.md`: `async_rtc` added to the `run_policy` parameter row + a usage note.
- `CHANGELOG.md`: Unreleased entry.