### PR TITLE
fix(lerobot_local): surface silent zero-fill / near-zero actions that freeze the arm

### DIFF
--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -231,6 +231,7 @@ policy = create_policy("lerobot_local", pretrained_name_or_path="lerobot/pi0_so1
 
 ## See also
 
+- [MolmoAct2 (SO-100/101)](molmoact2.md) - action contract, units, and motion diagnostics
 - [Policy providers](../policies/overview.md)
 - [Training](../training/overview.md)
 - [GR00T](groot.md)

--- a/docs/policies/molmoact2.md
+++ b/docs/policies/molmoact2.md
@@ -1,0 +1,117 @@
+---
+description: MolmoAct2 SO-100/101 in MuJoCo - concrete action_dim, range, units, the SO-arm embodiment mapping, and the "runs but does not move" diagnostics.
+---
+
+# MolmoAct2 (SO-100 / SO-101)
+
+MolmoAct2 runs through the [LeRobot Local](lerobot-local.md) provider
+(`create_policy("lerobot_local", ...)`). This page documents the concrete
+action/observation contract for the SO-100/101 checkpoints and how to debug the
+common "the policy runs but the arm does not move in MuJoCo" report.
+
+For install (lerobot from source + the `[molmoact2]` extra), caching, the
+processor/`norm_stats.json` bridge and camera routing, see the
+[LeRobot Local](lerobot-local.md) page.
+
+## Action / observation contract (SO-100/101)
+
+`allenai/MolmoAct2-SO100_101` is a 6-DoF SO-arm checkpoint:
+
+| Quantity | Value |
+| --- | --- |
+| `action_dim` | 6 (5 arm joints + 1 gripper) |
+| `observation.state` dim | 6 |
+| Arm joint units | DEGREES (LeRobot `MotorNormMode.DEGREES`) |
+| Gripper units | RANGE_0_100 (LeRobot `MotorNormMode.RANGE_0_100`), **not** degrees |
+| Joint order | shoulder_pan, shoulder_lift, elbow_flex, wrist_flex, wrist_roll, gripper |
+| Cameras | `observation.images.image` (front), `observation.images.wrist_image` |
+
+The MuJoCo `so101` sim, by contrast, expresses revolute joints in **RADIANS**
+with bare numeric joint names `1..6` (the gripper is joint `6`, range
+`[-0.175, 1.745]` rad). The mismatch in both units and naming is what the
+embodiment map reconciles.
+
+## SO-arm embodiment mapping
+
+The `so101` (and `so100`) entry in
+`strands_robots/policies/lerobot_local/embodiments.json` declares the mapping
+that bridges the model's training units to the sim:
+
+```json
+"so101": {
+  "obs_rename": {"front": "observation.images.image", "wrist": "observation.images.wrist_image"},
+  "state_keys":  ["1", "2", "3", "4", "5", "6"],
+  "action_keys": ["1", "2", "3", "4", "5", "6"],
+  "state_units": "degrees",
+  "action_units": "degrees",
+  "gripper_index": 5,
+  "gripper_joint_range": [-0.175, 1.745]
+}
+```
+
+At inference the policy converts in both directions:
+
+* **state (sim -> model)**: arm radians -> degrees; gripper joint radians -> 0..100.
+* **action (model -> sim)**: arm degrees -> radians; gripper 0..100 -> joint radians.
+
+So a model action of `[30, 30, 30, 30, 30, 50]` (degrees / 0..100) maps to
+`[0.524, 0.524, 0.524, 0.524, 0.524, 0.785]` radians before it reaches the sim.
+Without this conversion, `30.0` is interpreted as 30 radians, which saturates the
+joint's `[-pi, pi]`-scale limit and the arm appears frozen.
+
+Pass `embodiment="so101"` to the policy (or `"so100"`, `"so_real"` for hardware):
+
+```python
+policy = create_policy(
+    "lerobot_local",
+    pretrained_name_or_path="allenai/MolmoAct2-SO100_101",
+    embodiment="so101",
+    inference_action_mode="continuous",
+)
+```
+
+## Debugging "runs but does not move"
+
+The provider surfaces two previously-silent failure modes as `WARNING` logs from
+the `lerobot_local` logger:
+
+1. **Action-dim mismatch.** Actions are mapped onto actuators by index. If the
+   model emits fewer values than the embodiment declares actuators, the
+   unmatched actuators are zero-filled (frozen). The policy now logs once, e.g.:
+
+   ```
+   lerobot_local: Policy action dim 4 < embodiment 'so101' actuator count 6:
+   the 2 unmatched actuator(s) are zero-filled and will not move. ...
+   ```
+
+2. **Persistent near-zero actions.** If `max(abs(action)) < 1e-3` for 10
+   consecutive steps (a starved obs/rename pipeline, an all-zero
+   `observation.state`), the policy logs once:
+
+   ```
+   lerobot_local: Policy emitted near-zero actions (max abs < 0.001) for 10
+   consecutive steps: the robot will not move. ...
+   ```
+
+These do not raise (a near-zero action can be legitimate mid-trajectory); they
+point you at the embodiment / rename config. The warnings re-arm on
+`policy.reset()` so each episode is evaluated independently.
+
+### Repro / debug script
+
+`examples/molmoact2_so101_debug.py` pushes a known degree-space action through
+the `so101` mapping into MuJoCo and logs per-step joint deltas - no model
+weights needed - then contrasts it with feeding raw degrees (which saturates):
+
+```bash
+MUJOCO_GL=egl python examples/molmoact2_so101_debug.py
+# ... add --checkpoint allenai/MolmoAct2-SO100_101 to roll out the real policy
+```
+
+Expected: >5 deg cumulative motion on at least one joint within 20 steps.
+
+## See also
+
+- [LeRobot Local](lerobot-local.md) - install, caching, processor bridge, RTC
+- [Policy providers](overview.md)
+- [LeRobot project](https://github.com/huggingface/lerobot)

--- a/examples/molmoact2_so101_debug.py
+++ b/examples/molmoact2_so101_debug.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Debug why a MolmoAct2 (or any lerobot_local) policy "runs but does not move".
+
+A common report: the SO-101 arm produces predictions every control tick but does
+not visibly move in MuJoCo. The usual root causes are silent until you look:
+
+  1. ACTION-DIM mismatch - the model emits fewer values than the embodiment
+     declares actuators, so unmatched joints are zero-filled (frozen).
+  2. UNITS - SO-arm checkpoints (MolmoAct2 etc.) emit arm joints in DEGREES and
+     the gripper in RANGE_0_100, but the MuJoCo sim joints are RADIANS. Feeding
+     raw degrees saturates the radian joint limits and the arm freezes.
+  3. A starved obs/rename pipeline -> the model keeps emitting near-zero actions.
+
+This script makes those visible. By default it needs NO model weights: it pushes
+a known degree-space action through the ``so101`` embodiment mapping into the
+MuJoCo sim and logs per-step joint deltas, proving the mapping yields real
+motion. Pass ``--checkpoint <hf_repo_or_dir>`` to instead roll out the real
+policy via ``sim.run_policy`` (the lerobot_local diagnostics then warn on the
+console if the action stream is degenerate).
+
+Dependencies: pip install "strands-robots[sim-mujoco]"   (+[molmoact2] for --checkpoint)
+Run:
+    MUJOCO_GL=egl python examples/molmoact2_so101_debug.py
+    MUJOCO_GL=egl python examples/molmoact2_so101_debug.py --checkpoint allenai/MolmoAct2-SO100_101
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+
+import numpy as np
+
+from strands_robots import create_simulation
+from strands_robots.policies.lerobot_local.embodiment import load_embodiment
+
+ROBOT = "so101"
+
+
+def _read_joints(sim, joints):
+    obs = sim.get_observation(ROBOT, skip_images=True)
+    return {k: float(np.ravel(obs[k])[0]) for k in joints}
+
+
+def demo_mapping(sim, joints, emb) -> None:
+    """Push a degree-space action through the embodiment mapping and log motion."""
+    print(
+        f"embodiment '{emb.name}': action_keys={emb.action_keys} "
+        f"action_units={emb.action_units} gripper_index={emb.gripper_index} "
+        f"gripper_joint_range={emb.gripper_joint_range}"
+    )
+
+    # SO-arm checkpoint convention: arm joints DEGREES, gripper 0..100.
+    deg_action = [30.0, 30.0, 30.0, 30.0, 30.0, 50.0]
+    rad_action = emb.model_action_to_sim(deg_action)
+    print(f"model action (deg/0..100): {deg_action}")
+    print(f"mapped to sim (rad):       {[round(v, 3) for v in rad_action]}")
+
+    action = {k: rad_action[i] for i, k in enumerate(joints)}
+    before = _read_joints(sim, joints)
+    for step in range(20):
+        sim.send_action(action, robot_name=ROBOT, n_substeps=10)
+        if step % 5 == 0:
+            now = _read_joints(sim, joints)
+            delta = {k: round((now[k] - before[k]) * 180.0 / math.pi, 2) for k in joints}
+            print(f"step={step:2d} joint_delta_deg={delta}")
+
+    after = _read_joints(sim, joints)
+    max_delta_deg = max(abs(after[k] - before[k]) for k in joints) * 180.0 / math.pi
+    print(
+        f"max cumulative joint motion: {max_delta_deg:.2f} deg "
+        f"({'OK - arm moves' if max_delta_deg > 5.0 else 'FROZEN - check mapping/units'})"
+    )
+
+    # Contrast: raw degrees fed straight in saturate the radian joint limits.
+    raw = {k: deg_action[i] for i, k in enumerate(joints)}
+    b2 = _read_joints(sim, joints)
+    for _ in range(20):
+        sim.send_action(raw, robot_name=ROBOT, n_substeps=10)
+    a2 = _read_joints(sim, joints)
+    print(
+        "raw-degrees (no mapping) joint positions saturate at limits: "
+        f"{[round(a2[k], 2) for k in joints]} (started {[round(b2[k], 2) for k in joints]})"
+    )
+
+
+def rollout_real(sim, checkpoint: str, instruction: str) -> None:
+    """Roll out the real policy; lerobot_local logs warnings if actions degenerate."""
+    print(f"running real policy {checkpoint!r} - watch for 'lerobot_local:' warnings")
+    result = sim.run_policy(
+        robot_name=ROBOT,
+        policy_provider="lerobot_local",
+        policy_config={
+            "pretrained_name_or_path": checkpoint,
+            "embodiment": ROBOT,
+            "inference_action_mode": "continuous",
+        },
+        instruction=instruction,
+        n_steps=30,
+        action_horizon=30,
+    )
+    print(f"run_policy result: {result}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--checkpoint", default=None, help="HF repo id or local dir of a real policy")
+    parser.add_argument("--instruction", default="pick up the cube")
+    args = parser.parse_args()
+
+    sim = create_simulation("mujoco")
+    try:
+        sim.create_world()
+        sim.add_robot(ROBOT)
+        emb = load_embodiment(ROBOT)
+        joints = emb.action_keys
+        if args.checkpoint:
+            rollout_real(sim, args.checkpoint, args.instruction)
+        else:
+            demo_mapping(sim, joints, emb)
+    finally:
+        sim.cleanup()
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ nav:
   - MoveIt2: policies/moveit2.md
   - WBC (Whole-Body-Control): policies/wbc.md
   - LeRobot Local: policies/lerobot-local.md
+  - MolmoAct2 (SO-100/101): policies/molmoact2.md
   - Custom Policies: policies/custom-policies.md
 - Real Hardware:
   - Robot Control: hardware/robot-control.md

--- a/strands_robots/policies/lerobot_local/embodiment.py
+++ b/strands_robots/policies/lerobot_local/embodiment.py
@@ -129,6 +129,110 @@ def _convert_joint_vector(
     return out
 
 
+# Action diagnostics
+
+
+def diagnose_action_dim(n_action_values: int, n_action_keys: int, *, name: str = "") -> str | None:
+    """Return a warning message when a model action vector mis-matches the
+    embodiment's declared actuator count, else ``None``.
+
+    The local policy maps a model's action tensor onto robot actuators by index
+    (``LerobotLocalPolicy._tensor_to_action_dicts``). When the model emits FEWER
+    values than the embodiment declares actuator keys, the unmatched actuators
+    are zero-filled -- which silently freezes those joints and looks exactly like
+    "the policy runs but the robot does not move". When it emits MORE, the extra
+    trailing values are dropped. Either case is almost always an
+    embodiment/checkpoint mismatch the operator wants surfaced, not swallowed.
+
+    Args:
+        n_action_values: Length of the model's per-step action vector.
+        n_action_keys: Number of declared actuator keys (``robot_state_keys``).
+        name: Embodiment name for the message (optional).
+
+    Returns:
+        A human-readable warning string, or ``None`` when the dims match.
+    """
+    if n_action_values == n_action_keys:
+        return None
+    label = f" '{name}'" if name else ""
+    if n_action_values < n_action_keys:
+        missing = n_action_keys - n_action_values
+        return (
+            f"Policy action dim {n_action_values} < embodiment{label} actuator count "
+            f"{n_action_keys}: the {missing} unmatched actuator(s) are zero-filled and will "
+            f"not move. Check the embodiment's action_keys order/count against the "
+            f"checkpoint's action dimension."
+        )
+    extra = n_action_values - n_action_keys
+    return (
+        f"Policy action dim {n_action_values} > embodiment{label} actuator count "
+        f"{n_action_keys}: {extra} trailing action value(s) are dropped. Check the "
+        f"embodiment's action_keys against the checkpoint's action dimension."
+    )
+
+
+class ZeroActionMonitor:
+    """Detect a policy that keeps emitting near-zero actions (no robot motion).
+
+    Even with correct action dims and units, a misconfigured obs/rename pipeline
+    (a dropped camera key, an all-zero ``observation.state``) makes a VLA emit
+    effectively-zero actions every step: the robot "runs the policy" but never
+    moves. This monitor watches the per-step action magnitude and emits ONE
+    warning when it stays below ``threshold`` for ``patience`` consecutive steps,
+    pointing the operator at the embodiment / rename config.
+
+    Stateful but dependency-free (no torch/lerobot) so it is unit-testable in
+    isolation. Call :meth:`update` once per inference step and :meth:`reset` on
+    episode reset.
+
+    Attributes:
+        threshold: Max-abs action magnitude below which a step counts as
+            near-zero.
+        patience: Consecutive near-zero steps required before warning.
+    """
+
+    def __init__(self, threshold: float = 1e-3, patience: int = 10) -> None:
+        if threshold < 0:
+            raise ValueError(f"threshold must be >= 0, got {threshold}")
+        if patience < 1:
+            raise ValueError(f"patience must be >= 1, got {patience}")
+        self.threshold = threshold
+        self.patience = patience
+        self._streak = 0
+        self._warned = False
+
+    def update(self, max_abs_action: float) -> str | None:
+        """Record one step's max-abs action magnitude.
+
+        Args:
+            max_abs_action: ``max(abs(action))`` for this inference step.
+
+        Returns:
+            A warning string exactly once -- on the step where the near-zero
+            streak first reaches ``patience`` -- and ``None`` otherwise. A single
+            above-threshold step clears the streak and re-arms the warning.
+        """
+        if max_abs_action >= self.threshold:
+            self._streak = 0
+            self._warned = False
+            return None
+        self._streak += 1
+        if self._streak >= self.patience and not self._warned:
+            self._warned = True
+            return (
+                f"Policy emitted near-zero actions (max abs < {self.threshold:g}) for "
+                f"{self._streak} consecutive steps: the robot will not move. This usually "
+                f"means the observation never reached the model -- check the embodiment's "
+                f"obs_rename / camera keys and that observation.state is populated."
+            )
+        return None
+
+    def reset(self) -> None:
+        """Reset streak + warned state (call on episode reset)."""
+        self._streak = 0
+        self._warned = False
+
+
 # Registered pipeline step: pack scalar joint obs -> observation.state
 
 
@@ -461,6 +565,8 @@ def load_embodiment(embodiment: str | EmbodimentMap | dict) -> EmbodimentMap:
 __all__ = [
     "EmbodimentMap",
     "EMBODIMENT_MAP",
+    "ZeroActionMonitor",
+    "diagnose_action_dim",
     "load_embodiment",
     "reconcile_dim",
     "register_pack_state_step",

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -21,6 +21,7 @@ import numpy as np
 import torch
 
 from .. import Policy
+from .embodiment import ZeroActionMonitor, diagnose_action_dim
 from .processor import ProcessorBridge
 from .resolution import resolve_policy_class_by_name, resolve_policy_class_from_hub
 
@@ -200,6 +201,12 @@ class LerobotLocalPolicy(Policy):
         self._rtc_last_inference_time: float = 0.0
         self._rtc_last_log_time: float = 0.0
 
+        # Action diagnostics: surface a model<->embodiment action-dim mismatch
+        # (zero-filled actuators) and a persistent near-zero action stream
+        # (robot "runs the policy" but never moves) instead of swallowing them.
+        self._zero_action_monitor = ZeroActionMonitor()
+        self._action_dim_warned = False
+
         if pretrained_name_or_path:
             self._load_model()
 
@@ -238,6 +245,9 @@ class LerobotLocalPolicy(Policy):
         self._rtc_latency_history.clear()
         self._rtc_last_inference_time = 0.0
         self._rtc_last_log_time = 0.0
+        # Re-arm action diagnostics for the next episode.
+        self._zero_action_monitor.reset()
+        self._action_dim_warned = False
 
     def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
         """Set robot state keys for observation→tensor mapping.
@@ -1618,6 +1628,24 @@ class LerobotLocalPolicy(Policy):
                 "Cannot convert action tensor to dicts: robot_state_keys is empty. "
                 "Call set_robot_state_keys() before inference."
             )
+
+        # Diagnostics (issue: MolmoAct2 "runs but does not move in MuJoCo").
+        # Surface two silent failure modes instead of swallowing them:
+        #   1. action-dim mismatch -> unmatched actuators get zero-filled below
+        #      (the for-loop's `else 0.0`), freezing those joints.
+        #   2. a persistent near-zero action stream -> the robot never moves even
+        #      though the policy "runs" every step.
+        emb_name = self._embodiment.name if self._embodiment is not None else ""
+        n_values = len(actions_list[0]) if actions_list else 0
+        if not self._action_dim_warned:
+            dim_msg = diagnose_action_dim(n_values, len(self.robot_state_keys), name=emb_name)
+            if dim_msg:
+                logger.warning("lerobot_local: %s", dim_msg)
+                self._action_dim_warned = True
+        max_abs = float(np.abs(action_array).max()) if action_array.size else 0.0
+        zero_msg = self._zero_action_monitor.update(max_abs)
+        if zero_msg:
+            logger.warning("lerobot_local: %s", zero_msg)
 
         # Convert the model's action units to sim units when the embodiment
         # declares them. SO-arm checkpoints (so100/so101, MolmoAct2) emit joint

--- a/tests/policies/lerobot_local/test_action_diagnostics.py
+++ b/tests/policies/lerobot_local/test_action_diagnostics.py
@@ -1,0 +1,178 @@
+"""Diagnostics for the "policy runs but the robot does not move" failure mode.
+
+A VLA (e.g. MolmoAct2 on SO-101) can step every control tick yet leave the arm
+motionless when its action vector mis-matches the embodiment's actuator count
+(unmatched actuators are zero-filled) or when it keeps emitting near-zero
+actions (a broken obs/rename pipeline starves the model). These were silent.
+This pins the surfaced diagnostics: a one-shot action-dim warning, a
+consecutive near-zero-action warning, and an end-to-end MuJoCo check that a
+correctly-mapped action actually moves the joints.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+
+import numpy as np
+import pytest
+import torch  # real or conftest mock - both work
+
+from strands_robots.policies.lerobot_local.embodiment import (
+    ZeroActionMonitor,
+    diagnose_action_dim,
+    load_embodiment,
+)
+from strands_robots.policies.lerobot_local.policy import LerobotLocalPolicy
+
+# diagnose_action_dim (pure)
+
+
+def test_diagnose_action_dim_match_is_silent():
+    assert diagnose_action_dim(6, 6) is None
+    assert diagnose_action_dim(6, 6, name="so101") is None
+
+
+def test_diagnose_action_dim_fewer_values_flags_zero_fill():
+    msg = diagnose_action_dim(4, 6, name="so101")
+    assert msg is not None
+    assert "zero-filled" in msg
+    assert "so101" in msg
+    # names the count of frozen actuators
+    assert "2" in msg
+
+
+def test_diagnose_action_dim_more_values_flags_dropped():
+    msg = diagnose_action_dim(8, 6)
+    assert msg is not None
+    assert "dropped" in msg
+
+
+# ZeroActionMonitor (pure)
+
+
+def test_zero_action_monitor_fires_once_after_patience():
+    mon = ZeroActionMonitor(threshold=1e-3, patience=5)
+    fired = [mon.update(0.0) for _ in range(8)]
+    hits = [m for m in fired if m]
+    assert len(hits) == 1  # exactly one warning, not per-step spam
+    assert "near-zero" in hits[0]
+    # warning lands on the patience-th near-zero step (index 4), not before
+    assert all(m is None for m in fired[:4])
+    assert fired[4] is not None
+
+
+def test_zero_action_monitor_above_threshold_rearms():
+    mon = ZeroActionMonitor(threshold=1e-3, patience=3)
+    assert all(mon.update(0.0) is None for _ in range(2))
+    assert mon.update(1.0) is None  # a real action clears the streak
+    assert all(mon.update(0.0) is None for _ in range(2))
+    assert mon.update(0.0) is not None  # streak rebuilt -> warns again
+
+
+def test_zero_action_monitor_reset_clears_state():
+    mon = ZeroActionMonitor(threshold=1e-3, patience=2)
+    assert mon.update(0.0) is None
+    assert mon.update(0.0) is not None
+    mon.reset()
+    assert mon.update(0.0) is None  # streak restarted from zero
+
+
+@pytest.mark.parametrize("bad", [{"threshold": -1.0}, {"patience": 0}])
+def test_zero_action_monitor_rejects_bad_config(bad):
+    with pytest.raises(ValueError):
+        ZeroActionMonitor(**bad)
+
+
+# Wiring into LerobotLocalPolicy._tensor_to_action_dicts
+
+
+def test_tensor_to_action_dicts_warns_on_dim_mismatch(caplog):
+    policy = LerobotLocalPolicy()
+    policy.set_robot_state_keys(["1", "2", "3", "4", "5", "6"])
+    with caplog.at_level(logging.WARNING):
+        result = policy._tensor_to_action_dicts(torch.zeros(4))
+    # unmatched actuators are still returned (zero-filled), but now flagged
+    assert set(result[0].keys()) == {"1", "2", "3", "4", "5", "6"}
+    assert result[0]["5"] == 0.0 and result[0]["6"] == 0.0
+    assert any("action dim 4" in r.message and "zero-filled" in r.message for r in caplog.records)
+
+
+def test_tensor_to_action_dicts_dim_warning_is_one_shot(caplog):
+    policy = LerobotLocalPolicy()
+    policy.set_robot_state_keys(["1", "2", "3", "4", "5", "6"])
+    with caplog.at_level(logging.WARNING):
+        for _ in range(5):
+            policy._tensor_to_action_dicts(torch.zeros(4))
+    dim_warnings = [r for r in caplog.records if "actuator count" in r.message]
+    assert len(dim_warnings) == 1
+
+
+def test_tensor_to_action_dicts_warns_on_persistent_near_zero(caplog):
+    policy = LerobotLocalPolicy()
+    policy.set_robot_state_keys(["1", "2", "3", "4", "5", "6"])
+    with caplog.at_level(logging.WARNING):
+        for _ in range(policy._zero_action_monitor.patience + 2):
+            policy._tensor_to_action_dicts(torch.zeros(6))
+    near_zero = [r for r in caplog.records if "near-zero actions" in r.message]
+    assert len(near_zero) == 1
+
+
+def test_reset_rearms_near_zero_warning(caplog):
+    policy = LerobotLocalPolicy()
+    policy.set_robot_state_keys(["1", "2", "3", "4", "5", "6"])
+    with caplog.at_level(logging.WARNING):
+        for _ in range(policy._zero_action_monitor.patience):
+            policy._tensor_to_action_dicts(torch.zeros(6))
+        policy.reset()
+        caplog.clear()
+        for _ in range(policy._zero_action_monitor.patience):
+            policy._tensor_to_action_dicts(torch.zeros(6))
+    assert any("near-zero actions" in r.message for r in caplog.records)
+
+
+def test_nonzero_actions_never_warn(caplog):
+    policy = LerobotLocalPolicy()
+    policy.set_robot_state_keys(["1", "2", "3"])
+    with caplog.at_level(logging.WARNING):
+        for _ in range(20):
+            policy._tensor_to_action_dicts(torch.tensor([0.3, -0.5, 0.9]))
+    assert not [r for r in caplog.records if "near-zero" in r.message]
+
+
+# End-to-end: a correctly-mapped action moves SO-101 joints in MuJoCo
+
+
+def test_so101_mapped_action_produces_visible_motion():
+    """A degree-space action mapped through the so101 embodiment must move the
+    arm >5 deg on at least one joint within 20 steps (acceptance for the
+    "not moving" report). Pins that the deg->rad / gripper RANGE_0_100 mapping
+    yields real motion, not a saturated freeze.
+    """
+    pytest.importorskip("mujoco")
+    from strands_robots import create_simulation
+
+    sim = create_simulation("mujoco")
+    try:
+        sim.create_world()
+        sim.add_robot("so101")
+        emb = load_embodiment("so101")
+        joints = emb.action_keys
+
+        def read():
+            obs = sim.get_observation("so101", skip_images=True)
+            return {k: float(np.ravel(obs[k])[0]) for k in joints}
+
+        before = read()
+        # SO-arm checkpoint convention: arm joints in DEGREES, gripper 0..100.
+        deg_action = [30.0, 30.0, 30.0, 30.0, 30.0, 50.0]
+        rad_action = emb.model_action_to_sim(deg_action)
+        action = {k: rad_action[i] for i, k in enumerate(joints)}
+        for _ in range(20):
+            sim.send_action(action, robot_name="so101", n_substeps=10)
+        after = read()
+
+        max_delta_deg = max(abs(after[k] - before[k]) for k in joints) * 180.0 / math.pi
+        assert max_delta_deg > 5.0, f"arm barely moved ({max_delta_deg:.2f} deg)"
+    finally:
+        sim.cleanup()


### PR DESCRIPTION
## Problem

A `lerobot_local` policy (e.g. MolmoAct2 on SO-101) can step every control tick yet leave the arm motionless in MuJoCo, with no signal as to why. Two failure modes were swallowed inside `LerobotLocalPolicy._tensor_to_action_dicts`:

1. **Action-dim mismatch.** Actions are mapped onto actuators by index. When the model emits *fewer* values than the embodiment declares actuators, the unmatched actuators are filled with `0.0` (frozen) silently. When it emits more, the trailing values are dropped.
2. **Persistent near-zero actions.** A starved obs/rename pipeline (a dropped camera key, an all-zero `observation.state`) makes the model emit effectively-zero actions every step: the policy "runs" but never commands motion.

Both were invisible, so a units/embodiment misconfiguration presented as a mysterious "policy runs but robot doesn't move".

## Change

Two dependency-free diagnostics in `policies/lerobot_local/embodiment.py`, wired into the policy:

- `diagnose_action_dim(n_values, n_keys, name=)` — returns a one-shot WARNING string naming the model/embodiment dim mismatch and the count of zero-filled (frozen) actuators.
- `ZeroActionMonitor(threshold=1e-3, patience=10)` — emits a WARNING **once** after N consecutive near-zero action steps, pointing at the embodiment / rename config. It re-arms on `Policy.reset()` so each episode is judged independently, and a single above-threshold step clears the streak.

Neither **raises**: a near-zero action can be legitimate mid-trajectory. They make the degenerate cases loud instead of silent. The action-dim warning is one-shot per policy instance to avoid 50 Hz log spam.

The SO-arm degrees->radians + gripper RANGE_0_100 mapping itself is unchanged (already correct); this PR is purely about surfacing the silent failure paths around it.

## Tests (fail pre-fix)

`tests/policies/lerobot_local/test_action_diagnostics.py`:
- pure unit tests for `diagnose_action_dim` (match / fewer / more) and `ZeroActionMonitor` (one-shot fire, re-arm, reset, config validation);
- wiring tests asserting the warnings fire through `_tensor_to_action_dicts`, are one-shot, and that `reset()` re-arms;
- a `nonzero_actions_never_warn` negative test;
- an end-to-end MuJoCo check: a degree-space action mapped through the `so101` embodiment moves the arm **>5 deg** on at least one joint within 20 steps (acceptance for the "not moving" report).

Full local gate green: `hatch run lint` (ruff + mypy, 480 files, no issues) and the lerobot_local suite (345 passed).

## Docs & example

- `docs/policies/molmoact2.md` (new, in nav): the concrete SO-100/101 action contract — `action_dim=6`, arm units DEGREES, gripper RANGE_0_100, joint order, cameras — plus the embodiment mapping and the diagnostics.
- `examples/molmoact2_so101_debug.py`: reproduces and explains the mapping with **no model weights** required (pushes a degree-space action through the `so101` mapping into MuJoCo, logs per-step joint deltas, and contrasts with raw degrees which saturate). `--checkpoint` rolls out the real policy.

## Visual artifact

SO-101 executing a rollout in MuJoCo (headless EGL) — joints move once actions are correctly mapped:

![SO-101 rollout in MuJoCo](https://github.com/cagataycali/robots/releases/download/so101-motion-demo/so101_rollout.gif)

MP4: https://github.com/cagataycali/robots/releases/download/so101-motion-demo/so101_rollout.mp4

Debug-script output (no weights):
```
embodiment 'so101': action_keys=['1','2','3','4','5','6'] action_units=degrees gripper_index=5 gripper_joint_range=[-0.175, 1.745]
model action (deg/0..100): [30, 30, 30, 30, 30, 50]
mapped to sim (rad):       [0.524, 0.524, 0.524, 0.524, 0.524, 0.785]
max cumulative joint motion: 44.13 deg (OK - arm moves)
raw-degrees (no mapping) joint positions saturate at limits
```