### PR TITLE
fix(sim): honor policy chunk length in synchronized multi-robot loop via shared ChunkedPolicy contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Internal Refactor: unified chunk-length rule across all policy runners (`ChunkedPolicy`)
+
+A chunk-emitting policy (ACT, diffusion, pi0, SmolVLA, MolmoAct2) returns N
+actions per `get_actions` call and expects all N consumed open-loop before a
+re-query. Three consumers sized that chunk independently and had drifted: the
+single-policy `PolicyRunner.run` and the multi-episode eval loop consumed
+`max(action_horizon, policy.actions_per_step)`, but the synchronized
+`run_multi_policy` loop truncated to `action_horizon` alone. A chunk-emitting
+policy driven through `run_multi_policy` therefore had its chunk tail dropped
+and was re-queried out-of-distribution (e.g. an `actions_per_step=30` policy run
+with the default `action_horizon=8` re-queried every 8 steps instead of 30),
+diverging from `run_policy` for the same policy.
+
+- New `ChunkedPolicy` runtime-checkable `Protocol` in
+  `strands_robots.policies.base` declares the chunk introspection contract
+  (`actions_per_step: int`, `supports_rtc: bool`). Consumers can branch on
+  `isinstance(policy, ChunkedPolicy)` and a type checker rejects a non-chunked
+  policy where a chunked one is required.
+- New `resolve_chunk_length(policy, action_horizon)` helper centralizes the one
+  chunk-sizing rule (`max(action_horizon, actions_per_step)`, single-action
+  policies default to 1). `PolicyRunner.run`, the multi-episode eval loop, and
+  `run_multi_policy` now all route through it, so the rule can no longer drift
+  per consumer.
+- `run_multi_policy` now honours a policy's `actions_per_step`, matching
+  `run_policy`. A chunk-emitting policy keeps its full trained chunk in the
+  synchronized multi-robot loop.
+- `LerobotLocalPolicy` exposes `supports_rtc` publicly (over its internal RTC
+  state) so it satisfies the `ChunkedPolicy` contract; `actions_per_step` was
+  already public.
+- Behaviour is unchanged for single-action policies (`mock` and friends) and
+  for `run_policy`, whose chunk sizing was already correct. `ChunkedPolicy` and
+  `resolve_chunk_length` are exported from `strands_robots.policies`.
+
+
 ### Added: `async_rtc` chunk pipeline for `run_policy` (overlap inference with execution)
 
 `run_policy` / `PolicyRunner.run` drove policies through a synchronous

--- a/strands_robots/policies/__init__.py
+++ b/strands_robots/policies/__init__.py
@@ -34,7 +34,7 @@ Usage::
     register_policy("my_provider", lambda: MyPolicy, aliases=["my"])
 """
 
-from strands_robots.policies.base import Policy
+from strands_robots.policies.base import ChunkedPolicy, Policy, resolve_chunk_length
 
 # Cosmos3Policy is import-safe: it depends only on numpy. The WebSocket
 # client uses a self-contained msgpack+websockets transport (no
@@ -50,6 +50,8 @@ from strands_robots.policies.mock import MockPolicy
 
 __all__ = [
     "Policy",
+    "ChunkedPolicy",
+    "resolve_chunk_length",
     "MockPolicy",
     "Cosmos3Policy",
     "create_policy",

--- a/strands_robots/policies/base.py
+++ b/strands_robots/policies/base.py
@@ -24,7 +24,7 @@ non-VLA reference implementation.
 import asyncio
 import concurrent.futures
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, Protocol, runtime_checkable
 
 
 class Policy(ABC):
@@ -172,3 +172,78 @@ class Policy(ABC):
     def provider_name(self) -> str:
         """Get provider name for identification."""
         pass
+
+
+@runtime_checkable
+class ChunkedPolicy(Protocol):
+    """Introspection contract for policies that emit ACTION CHUNKS.
+
+    A *chunked* policy returns more than one action per
+    :meth:`Policy.get_actions` call: a model trained for N-step open-loop replay
+    (ACT, diffusion, pi0, SmolVLA, MolmoAct2) emits a length-N chunk that a
+    consumer executes before re-querying. The chunk PRODUCER is the existing
+    async :meth:`Policy.get_actions` - this protocol deliberately does NOT add a
+    second chunk-producing method (that would split one contract across two
+    code paths); it only surfaces the metadata a consumer needs to drive an
+    already-produced chunk correctly.
+
+    Every consumer of a chunk (the single-policy runner, the multi-episode eval
+    loop, and the synchronized multi-robot loop) must size the chunk the same
+    way - see :func:`resolve_chunk_length`. Routing all of them through one
+    helper that reads this contract keeps a chunk-emitting policy from being
+    truncated differently depending on which loop happens to drive it.
+
+    The protocol is ``runtime_checkable`` so a consumer can branch on
+    ``isinstance(policy, ChunkedPolicy)`` and a type checker rejects a
+    non-chunked policy where a chunked one is required.
+
+    Attributes:
+        actions_per_step: Number of actions the policy intends a consumer to
+            execute open-loop from one ``get_actions`` chunk before re-querying
+            (the policy's trained chunk length). Truncating below this drops the
+            chunk tail and forces an out-of-distribution re-query.
+        supports_rtc: Whether the policy blends chunk seams internally via
+            Real-Time Chunking - it carries prev-chunk state across re-queries
+            so consecutive chunks join smoothly. Introspection only; a consumer
+            never has to drive RTC, the policy does it inside ``get_actions``.
+    """
+
+    actions_per_step: int
+    supports_rtc: bool
+
+
+def resolve_chunk_length(policy: "Policy", action_horizon: int) -> int:
+    """Effective number of actions to consume from one ``get_actions`` chunk.
+
+    Centralizes the single chunk-length rule every consumer must apply
+    identically: consume ``max(action_horizon, policy.actions_per_step)``
+    actions before re-querying. A policy trained for N-step open-loop replay
+    (``actions_per_step == N``) must have its FULL chunk consumed; clamping to a
+    smaller ``action_horizon`` drops the chunk tail and forces an
+    out-of-distribution re-query. Policies that do not declare
+    ``actions_per_step`` (single-action providers such as ``MockPolicy``) behave
+    as a 1-action chunk, so the result is just ``max(action_horizon, 1)``.
+
+    Before this helper existed each consumer inlined the same
+    ``max(action_horizon, getattr(policy, "actions_per_step", 1))`` expression,
+    and they drifted: the synchronized multi-robot loop truncated to
+    ``action_horizon`` alone, silently dropping a chunk-emitting policy's tail
+    while the single-policy runner consumed the full chunk.
+
+    Args:
+        policy: Any policy. Its chunk length is read from the optional
+            :class:`ChunkedPolicy` ``actions_per_step`` attribute; a policy that
+            does not declare it is treated as single-action.
+        action_horizon: Consumer-requested actions per chunk (clamped to >= 1).
+
+    Returns:
+        The number of leading chunk actions to execute before re-querying.
+    """
+    intended = getattr(policy, "actions_per_step", 1)
+    try:
+        intended_int = int(intended)
+    except (TypeError, ValueError):
+        intended_int = 1
+    if intended_int < 1:
+        intended_int = 1
+    return max(int(action_horizon), 1, intended_int)

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -207,6 +207,21 @@ class LerobotLocalPolicy(Policy):
     def provider_name(self) -> str:
         return "lerobot_local"
 
+    @property
+    def supports_rtc(self) -> bool:
+        """Whether Real-Time Chunking is active for the loaded policy.
+
+        Surfaces the internal RTC state as the public ``ChunkedPolicy`` contract
+        attribute (see ``strands_robots.policies.base.ChunkedPolicy``). ``True``
+        only after a flow-matching policy with an enabled ``rtc_config`` has been
+        loaded - it carries prev-chunk state across re-queries to blend chunk
+        seams internally, so a consumer never has to drive RTC itself. Returns
+        ``False`` before a model is loaded or for non-flow-matching policies
+        (ACT, diffusion), which still emit chunks (``actions_per_step``) but do
+        not blend seams.
+        """
+        return self._rtc_enabled
+
     def reset(self, seed: int | None = None) -> None:
         """Reset policy state between episodes.
 

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -2381,7 +2381,13 @@ class MuJoCoSimEngine(
                 returned chunk before re-querying it (open-loop chunk
                 execution, mirrors ``run_policy``). Either a single int applied
                 to all robots, or a ``{robot_name: horizon}`` mapping for
-                per-robot control. A robot's policy is only re-queried when its
+                per-robot control. The effective per-robot chunk length is
+                ``max(action_horizon, policy.actions_per_step)`` (see
+                ``strands_robots.policies.resolve_chunk_length``): a
+                chunk-emitting policy keeps its full trained chunk even when
+                ``action_horizon`` is smaller, identical to ``run_policy``, so a
+                model is never re-queried out-of-distribution in one driver but
+                not the other. A robot's policy is only re-queried when its
                 action queue drains - so an expensive VLA emitting a 30-action
                 chunk with ``action_horizon=30`` runs inference ~once per 30
                 steps instead of every step. Physics still advances ONE step per
@@ -2396,6 +2402,7 @@ class MuJoCoSimEngine(
         import numpy as np
 
         from strands_robots._async_utils import _resolve_coroutine
+        from strands_robots.policies.base import resolve_chunk_length
 
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
@@ -2538,8 +2545,15 @@ class MuJoCoSimEngine(
                         pol_obs.update(camera_imgs)
                         coro = pol.get_actions(pol_obs, instr_map[rname])
                         acts = _resolve_coroutine(coro)
-                        # Buffer up to this robot's horizon; re-query when drained.
-                        for a in acts[: horizon_map[rname]]:
+                        # Buffer the policy's chunk; re-query only when drained.
+                        # Size the chunk via the shared ChunkedPolicy rule so a
+                        # chunk-emitting policy (actions_per_step == N) keeps its
+                        # full trained chunk here exactly as the single-policy
+                        # runner does - clamping to action_horizon alone would
+                        # drop the chunk tail and force an out-of-distribution
+                        # re-query for one driver but not the other.
+                        _chunk = resolve_chunk_length(pol, horizon_map[rname])
+                        for a in acts[:_chunk]:
                             action_queues[rname].append(a)
                     if not action_queues[rname]:
                         # A policy yielded no actions (empty chunk) -- emitting an

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -42,6 +42,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from strands_robots._async_utils import _resolve_coroutine
+from strands_robots.policies.base import resolve_chunk_length
 from strands_robots.utils import require_optional
 
 if TYPE_CHECKING:
@@ -567,7 +568,7 @@ class PolicyRunner:
                 # auto-detect of config.n_action_steps).
                 coro_or_result = policy.get_actions(observation, instruction, **_policy_kwargs)
                 actions = _resolve_coroutine(coro_or_result)
-                _chunk = max(action_horizon, getattr(policy, "actions_per_step", 1))
+                _chunk = resolve_chunk_length(policy, action_horizon)
                 return list(actions[:_chunk])
 
             if async_rtc:
@@ -1194,7 +1195,7 @@ class PolicyRunner:
                     # Degenerate policy - advance physics so loop terminates.
                     self.sim.step(n_steps=1)
                 else:
-                    _chunk = max(action_horizon, getattr(policy, "actions_per_step", 1))
+                    _chunk = resolve_chunk_length(policy, action_horizon)
                     for action_in_chunk in actions[:_chunk]:
                         if steps >= max_steps:
                             break

--- a/tests/policies/test_chunked_policy_contract.py
+++ b/tests/policies/test_chunked_policy_contract.py
@@ -1,0 +1,135 @@
+"""Contract tests for the ``ChunkedPolicy`` introspection protocol and the
+shared ``resolve_chunk_length`` chunk-sizing rule.
+
+A chunk-emitting policy (ACT, diffusion, pi0, SmolVLA, MolmoAct2) returns N
+actions per ``get_actions`` call and expects all N consumed open-loop before a
+re-query. Every consumer - the single-policy runner, the multi-episode eval
+loop, and the synchronized multi-robot loop - must size that chunk identically.
+These tests pin the typed contract and the one helper they all route through,
+independent of any real model weights, so the chunk-sizing rule cannot drift
+back to per-consumer copies.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from strands_robots.policies import ChunkedPolicy, MockPolicy, resolve_chunk_length
+from strands_robots.policies.base import Policy
+
+
+class MockChunkedPolicy(Policy):
+    """Weight-free chunk-emitting policy for driver/contract tests.
+
+    Returns a fixed-length chunk of zero actions and declares the
+    ``ChunkedPolicy`` contract attributes, so tests can assert chunk-consumption
+    behaviour without loading a real VLA checkpoint.
+    """
+
+    requires_images = False
+
+    def __init__(self, actions_per_step: int = 10, supports_rtc: bool = False) -> None:
+        self.actions_per_step = actions_per_step
+        self.supports_rtc = supports_rtc
+        self.calls = 0
+        self._keys: list[str] = []
+
+    @property
+    def provider_name(self) -> str:
+        return "mock_chunked"
+
+    def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
+        self._keys = list(robot_state_keys)
+
+    async def get_actions(
+        self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any
+    ) -> list[dict[str, Any]]:
+        self.calls += 1
+        keys = self._keys or ["j0", "j1", "j2"]
+        return [{k: 0.0 for k in keys} for _ in range(self.actions_per_step)]
+
+
+def test_mock_chunked_policy_satisfies_protocol() -> None:
+    """A policy declaring the contract attrs is recognised at runtime."""
+    assert isinstance(MockChunkedPolicy(), ChunkedPolicy)
+
+
+def test_single_action_policy_is_not_chunked() -> None:
+    """A single-action provider does not satisfy the chunked contract."""
+    assert not isinstance(MockPolicy(), ChunkedPolicy)
+
+
+def test_protocol_requires_both_attributes() -> None:
+    """Declaring only one of the two contract attrs is not enough."""
+
+    class OnlyChunk:
+        actions_per_step = 8
+
+    class OnlyRtc:
+        supports_rtc = True
+
+    assert not isinstance(OnlyChunk(), ChunkedPolicy)
+    assert not isinstance(OnlyRtc(), ChunkedPolicy)
+
+
+def test_resolve_chunk_length_honors_actions_per_step() -> None:
+    """A chunk longer than the horizon is kept whole (no tail dropped)."""
+    pol = MockChunkedPolicy(actions_per_step=30)
+    assert resolve_chunk_length(pol, action_horizon=8) == 30
+
+
+def test_resolve_chunk_length_uses_horizon_when_larger() -> None:
+    """A horizon larger than the policy's chunk wins."""
+    pol = MockChunkedPolicy(actions_per_step=4)
+    assert resolve_chunk_length(pol, action_horizon=16) == 16
+
+
+def test_resolve_chunk_length_defaults_single_action_policy() -> None:
+    """A policy without ``actions_per_step`` is treated as a 1-action chunk."""
+    assert resolve_chunk_length(MockPolicy(), action_horizon=8) == 8
+    assert resolve_chunk_length(MockPolicy(), action_horizon=1) == 1
+
+
+def test_resolve_chunk_length_clamps_nonpositive_inputs() -> None:
+    """Degenerate horizon / chunk values clamp to at least one action."""
+    assert resolve_chunk_length(MockChunkedPolicy(actions_per_step=0), action_horizon=0) == 1
+    assert resolve_chunk_length(MockChunkedPolicy(actions_per_step=-5), action_horizon=0) == 1
+
+
+def test_resolve_chunk_length_ignores_non_integer_attr() -> None:
+    """A non-integer ``actions_per_step`` falls back to single-action.
+
+    Guards the defensive coercion branch: a malformed attribute (here a str)
+    must not blow up the control loop, it degrades to a 1-action chunk. The
+    ``type: ignore`` is intentional - we deliberately feed a duck type that
+    violates the ``Policy`` signature to exercise that runtime defence.
+    """
+
+    class Bad:
+        actions_per_step = "lots"
+
+    assert resolve_chunk_length(Bad(), action_horizon=5) == 5  # type: ignore[arg-type]
+
+
+def test_chunked_policy_accepts_property_backed_attrs() -> None:
+    """The contract is satisfied by property-backed attributes too.
+
+    ``LerobotLocalPolicy`` exposes ``supports_rtc`` as a property over its
+    internal RTC state; the protocol must recognise that shape.
+    """
+
+    class PropBacked:
+        actions_per_step = 16
+
+        @property
+        def supports_rtc(self) -> bool:
+            return True
+
+    assert isinstance(PropBacked(), ChunkedPolicy)
+
+
+@pytest.mark.parametrize("horizon,chunk,expected", [(8, 50, 50), (8, 1, 8), (1, 1, 1), (30, 30, 30)])
+def test_resolve_chunk_length_matrix(horizon: int, chunk: int, expected: int) -> None:
+    assert resolve_chunk_length(MockChunkedPolicy(actions_per_step=chunk), horizon) == expected

--- a/tests/simulation/mujoco/test_run_multi_policy_no_recording.py
+++ b/tests/simulation/mujoco/test_run_multi_policy_no_recording.py
@@ -276,3 +276,56 @@ def test_run_multi_policy_cooperative_stop_ends_early(sim_two_robots):
     # Running flags are cleared on the way out regardless of early stop.
     for name in ("alpha", "beta"):
         assert sim._world.robots[name].policy_running is False
+
+
+class _ChunkedCounter(Policy):
+    """Chunk-emitting policy that declares the ``ChunkedPolicy`` contract.
+
+    Unlike ``_ChunkCounter`` it exposes ``actions_per_step`` (its trained chunk
+    length) and ``supports_rtc``, so the synchronized loop must consume the full
+    chunk before re-querying - exactly as the single-policy runner does.
+    """
+
+    requires_images = False
+
+    def __init__(self, actions_per_step: int = 10):
+        self.actions_per_step = actions_per_step
+        self.supports_rtc = False
+        self.calls = 0
+        self._keys: list[str] | None = None
+
+    def set_robot_state_keys(self, keys):
+        self._keys = list(keys)
+
+    @property
+    def provider_name(self) -> str:
+        return "chunked_counter"
+
+    async def get_actions(self, obs, instruction=""):
+        self.calls += 1
+        keys = self._keys or ["shoulder_pan", "shoulder_lift", "elbow"]
+        return [{k: 0.02 * (j + 1) for k in keys} for j in range(self.actions_per_step)]
+
+
+def test_run_multi_policy_honors_policy_chunk_length_over_smaller_horizon(sim_two_robots):
+    """A chunk-emitting policy keeps its full trained chunk in the synchronized loop.
+
+    With ``actions_per_step=10`` and a smaller ``action_horizon=2`` over 20
+    steps, each policy must run inference exactly twice (ceil(20/10)) - the loop
+    consumes ``max(action_horizon, actions_per_step) == 10`` actions per chunk,
+    matching ``run_policy``. Before the shared chunk-length rule, the loop
+    truncated to ``action_horizon`` alone (re-query every 2 steps -> 10 calls),
+    dropping the chunk tail and forcing out-of-distribution re-queries that the
+    single-policy runner never makes.
+    """
+    sim = sim_two_robots
+    pa, pb = _ChunkedCounter(actions_per_step=10), _ChunkedCounter(actions_per_step=10)
+    r = sim.run_multi_policy(
+        policies={"alpha": pa, "beta": pb},
+        n_steps=20,
+        control_frequency=50.0,
+        action_horizon=2,
+    )
+    assert r["status"] == "success", r
+    assert pa.calls == 2
+    assert pb.calls == 2


### PR DESCRIPTION
## Problem

A chunk-emitting policy (ACT, diffusion, pi0, SmolVLA, MolmoAct2) returns N actions per `get_actions` call and expects all N consumed open-loop before a re-query. Three consumers sized that chunk independently and had drifted:

- `PolicyRunner.run` (single-policy) and the multi-episode eval loop both consume `max(action_horizon, policy.actions_per_step)`.
- The synchronized `run_multi_policy` loop truncated to `action_horizon` alone (`acts[: horizon_map[rname]]`).

So the same chunk-emitting policy behaves differently depending on which loop drives it. Through `run_multi_policy`, an `actions_per_step=30` policy run with the default `action_horizon=8` is re-queried every 8 steps instead of 30 - its chunk tail is dropped and it is queried from a mid-chunk observation it never saw in training (out-of-distribution), exactly the failure mode the single-policy runner already guards against.

## Change

Introduce one typed chunk contract and route every consumer through it.

- **`ChunkedPolicy`** - a `runtime_checkable` `Protocol` in `strands_robots.policies.base` declaring the chunk introspection contract (`actions_per_step: int`, `supports_rtc: bool`). Consumers branch on `isinstance(policy, ChunkedPolicy)` and a type checker rejects a non-chunked policy where a chunked one is required. The chunk PRODUCER stays the existing async `get_actions` - the protocol deliberately does not add a second chunk-producing method.
- **`resolve_chunk_length(policy, action_horizon)`** - centralizes the one chunk-sizing rule (`max(action_horizon, actions_per_step)`; single-action policies default to 1). `PolicyRunner.run`, the multi-episode eval loop, and `run_multi_policy` all call it, so the rule can no longer drift per consumer.
- **`run_multi_policy`** now honors `actions_per_step`, matching `run_policy`.
- **`LerobotLocalPolicy`** exposes `supports_rtc` publicly (over its internal RTC state) so it satisfies the contract; `actions_per_step` was already public.

Behaviour is unchanged for single-action policies (`mock`) and for `run_policy`, whose chunk sizing was already correct.

## Tests

- `tests/simulation/mujoco/test_run_multi_policy_no_recording.py::test_run_multi_policy_honors_policy_chunk_length_over_smaller_horizon` - regression test. With `actions_per_step=10` and `action_horizon=2` over 20 steps each policy must run inference exactly twice. **Fails pre-fix** (`assert 10 == 2`: re-queried every 2 steps), passes after.
- `tests/policies/test_chunked_policy_contract.py` - 13 contract tests: protocol `isinstance` recognition (instance- and property-backed attrs), single-action policies are not chunked, and the `resolve_chunk_length` matrix incl. degenerate-input clamping.

Full local gate green: `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` clean; affected sim + policy suites pass under `MUJOCO_GL=egl`.

## Visual artifact

Chunk-emitting policy (`actions_per_step=30`) rollout in MuJoCo (headless EGL), driven with `action_horizon=8`. The full 30-action chunk is consumed before re-query, so a 180-step rollout runs inference exactly 6 times (180 / 30) and the open-loop trajectory is smooth across seams.

![chunked rollout](https://github.com/cagataycali/robots/releases/download/artifact-chunked-policy-1782503512/chunked_rollout.gif)

MP4: https://github.com/cagataycali/robots/releases/download/artifact-chunked-policy-1782503512/chunked_rollout.mp4

CHANGELOG updated under Unreleased / Internal Refactor.