### PR TITLE
fix(rtc): use the real control frequency for inference-delay estimation

### DIFF
--- a/strands_robots/policies/base.py
+++ b/strands_robots/policies/base.py
@@ -49,6 +49,37 @@ class Policy(ABC):
     ``MockPolicy`` for the canonical reference.
     """
 
+    #: Control rate (Hz) at which the consumer loop executes the actions this
+    #: policy returns. Set by the runtime (e.g. ``PolicyRunner``) via
+    #: :meth:`set_control_frequency` BEFORE the rollout loop starts, so
+    #: latency-sensitive providers can convert wall-clock inference latency into
+    #: a count of action steps consumed during inference (Real-Time Chunking).
+    #: ``None`` means the runtime has not told the policy its clock yet -
+    #: providers that need it MUST warn loudly and fall back rather than
+    #: silently assuming a rate (a wrong assumed rate corrupts RTC blending at
+    #: every control frequency except the assumed one).
+    control_frequency: float | None = None
+
+    def set_control_frequency(self, hz: float) -> None:
+        """Tell the policy the control rate (Hz) of the executing loop.
+
+        The runtime that drives the policy (``PolicyRunner.run`` / ``evaluate``)
+        calls this once before the rollout loop so providers that estimate an
+        inference delay in *action steps* (Real-Time Chunking) can convert their
+        measured wall-clock latency into the correct number of steps. Without
+        it, such providers fall back to a hardcoded rate and silently mis-blend
+        chunks at any other control frequency.
+
+        Args:
+            hz: Positive control frequency in Hz.
+
+        Raises:
+            ValueError: If ``hz`` is not strictly positive.
+        """
+        if hz <= 0:
+            raise ValueError(f"control_frequency must be positive, got {hz}")
+        self.control_frequency = float(hz)
+
     @abstractmethod
     async def get_actions(
         self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -26,6 +26,12 @@ from .resolution import resolve_policy_class_by_name, resolve_policy_class_from_
 
 logger = logging.getLogger(__name__)
 
+# Fallback control rate used ONLY when RTC runs without the runtime having
+# called set_control_frequency(). Used to keep a standalone (no-runner) RTC
+# call functional; the runner always plumbs the real rate. A loud one-time
+# warning fires whenever this fallback is used.
+_RTC_FALLBACK_FPS: float = 30.0
+
 
 # Process-level cache of loaded underlying models, keyed by the load-determining
 # inputs. Loading a VLA checkpoint (e.g. MolmoAct2 SO-100/101 = 1295 weight
@@ -199,6 +205,10 @@ class LerobotLocalPolicy(Policy):
         self._rtc_latency_history: deque = deque(maxlen=100)
         self._rtc_last_inference_time: float = 0.0
         self._rtc_last_log_time: float = 0.0
+        # Warn at most once per policy when RTC runs without a known
+        # control_frequency (set_control_frequency never called) so the
+        # 30Hz fallback is loud, not silent.
+        self._rtc_freq_warned: bool = False
 
         if pretrained_name_or_path:
             self._load_model()
@@ -850,14 +860,18 @@ class LerobotLocalPolicy(Policy):
             self._rtc_max_guidance_weight,
         )
 
-    def _estimate_inference_delay(self, fps: float = 30.0) -> int:
+    def _estimate_inference_delay(self, fps: float) -> int:
         """Estimate the number of action steps consumed during inference.
 
         Uses the p95 latency from recent inference calls to estimate how many
-        action steps the robot executed while waiting for the new chunk.
+        action steps the robot executed while waiting for the new chunk. The
+        result is ``p95_latency * fps``, so ``fps`` MUST be the real control
+        rate of the executing loop - a wrong rate scales the delay wrong and
+        corrupts the RTC chunk-seam blend. The caller resolves ``fps`` from
+        :attr:`Policy.control_frequency` (set by the runtime).
 
         Args:
-            fps: Robot control frequency in Hz. Defaults to 30.
+            fps: Robot control frequency in Hz (the loop's real control rate).
 
         Returns:
             Estimated delay in action steps (minimum 0).
@@ -909,8 +923,25 @@ class LerobotLocalPolicy(Policy):
         if action_chunk.dim() == 3 and action_chunk.shape[0] == 1:
             action_chunk = action_chunk.squeeze(0)
 
-        # Estimate inference delay - how many steps were consumed while computing
-        inference_delay = self._estimate_inference_delay()
+        # Estimate inference delay - how many steps were consumed while
+        # computing. The delay is (p95 latency * control_frequency), so it
+        # MUST use the loop's real control rate; assuming a fixed rate makes
+        # the chunk-seam blend wrong at every other frequency. The runtime
+        # (PolicyRunner) calls set_control_frequency() before the loop.
+        fps = self.control_frequency
+        if fps is None:
+            if not self._rtc_freq_warned:
+                logger.warning(
+                    "RTC: control_frequency unknown for '%s', falling back to "
+                    "%.0fHz - inference-delay estimation will be off at any other "
+                    "control rate. Call set_control_frequency(hz) before running "
+                    "(PolicyRunner does this automatically).",
+                    type(self._policy).__name__,
+                    _RTC_FALLBACK_FPS,
+                )
+                self._rtc_freq_warned = True
+            fps = _RTC_FALLBACK_FPS
+        inference_delay = self._estimate_inference_delay(fps=fps)
 
         # Store leftover for next RTC call (unconsumed portion of this chunk)
         # The delay represents steps already consumed, so leftover starts after

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -456,6 +456,12 @@ class PolicyRunner:
         # Normalise the per-call goal payload once. Forwarded verbatim to every
         # get_actions() call; an empty dict is the historical (no-kwargs) path.
         _policy_kwargs = policy_kwargs or {}
+        # Tell the policy the loop's control rate BEFORE the rollout so
+        # latency-sensitive providers (RTC) convert wall-clock inference
+        # latency into the correct number of consumed action steps. Without
+        # this they fall back to a hardcoded rate and mis-blend the chunk
+        # seam at any other frequency.
+        policy.set_control_frequency(control_frequency)
         # Initialize BEFORE try so CooperativeStop never sees unbound names.
         start_time = time.time()
         step_count = 0
@@ -944,6 +950,7 @@ class PolicyRunner:
         # Step physics for the full control period per action, same derivation
         # as run(). The default n_substeps=1 made eval rollouts under-step.
         n_substeps = self._control_substeps(control_frequency, control_substeps)
+        policy.set_control_frequency(control_frequency)
         results: list[dict[str, Any]] = []
         for ep in range(n_episodes):
             self.sim.reset()
@@ -1043,6 +1050,7 @@ class PolicyRunner:
         _skip_images = not getattr(policy, "requires_images", True)
         # Full control-period substeps per action (see run() / evaluate()).
         n_substeps = self._control_substeps(control_frequency, control_substeps)
+        policy.set_control_frequency(control_frequency)
         # #168: seed Python / NumPy / torch / cuDNN once before
         # the episode loop so policy stochastic ops (e.g. attention
         # dropout, sampling temperature) are reproducible across re-runs

--- a/tests/policies/lerobot_local/test_policy.py
+++ b/tests/policies/lerobot_local/test_policy.py
@@ -1651,3 +1651,78 @@ class TestFixupPreprocessedBatch:
         val = torch.zeros((1, 2), dtype=torch.float32)
         out = policy._fixup_preprocessed_batch({"observation.state": val})
         assert out["observation.state"].shape == (1, 2)
+
+
+# (section)
+# Tests: RTC inference-delay uses the loop's control frequency
+# (section)
+
+
+def _make_rtc_policy(chunk_steps=50, action_dim=6):
+    """Loaded policy wired for the RTC path with a fixed-size action chunk."""
+    policy = _make_loaded_policy(action_dim=action_dim, include_images=False)
+    policy._rtc_enabled = True
+    policy._rtc_execution_horizon = 10
+    policy.actions_per_step = 1
+    chunk = torch.zeros((1, chunk_steps, action_dim))
+    policy._policy.predict_action_chunk = MagicMock(return_value=chunk)
+    return policy
+
+
+class TestRtcInferenceDelay:
+    """RTC delay estimation must scale with the real control frequency.
+
+    ``_estimate_inference_delay`` returns ``int(p95_latency * fps)``: the number
+    of action steps consumed while the policy was computing the next chunk. If
+    ``fps`` is not the loop's actual control rate, the chunk-seam slice is wrong
+    at every other frequency (delay under-counted at >30Hz, jerky / oscillating
+    output). The control rate is plumbed via ``Policy.set_control_frequency``.
+    """
+
+    def test_estimate_inference_delay_scales_linearly_with_fps(self):
+        policy = _make_loaded_policy(include_images=False)
+        policy._rtc_latency_history.extend([0.1] * 10)  # p95 == 0.1s
+        assert policy._estimate_inference_delay(fps=30.0) == 3
+        assert policy._estimate_inference_delay(fps=60.0) == 6
+        assert policy._estimate_inference_delay(fps=120.0) == 12
+
+    def test_estimate_inference_delay_empty_history_is_zero(self):
+        policy = _make_loaded_policy(include_images=False)
+        assert policy._estimate_inference_delay(fps=200.0) == 0
+
+    def test_predict_with_rtc_uses_set_control_frequency(self):
+        """Regression: at 90Hz the delay (and chunk slice) must reflect 90Hz,
+        not the hardcoded 30Hz default. Pre-fix this returned the 30Hz slice
+        regardless of control_frequency."""
+        policy = _make_rtc_policy(chunk_steps=50)
+        policy._rtc_latency_history.extend([0.1] * 20)  # p95 == 0.1s
+        policy.set_control_frequency(90.0)
+
+        usable = policy._predict_with_rtc({})
+
+        # delay = int(0.1 * 90) = 9 -> usable_start = 9 -> 50 - 9 = 41 steps.
+        # At the buggy 30Hz default delay would be 3 -> 47 steps.
+        assert usable.shape[0] == 50 - 9
+
+    def test_predict_with_rtc_30hz_matches_legacy_slice(self):
+        """At 30Hz the result is unchanged from the historical behaviour."""
+        policy = _make_rtc_policy(chunk_steps=50)
+        policy._rtc_latency_history.extend([0.1] * 20)
+        policy.set_control_frequency(30.0)
+        usable = policy._predict_with_rtc({})
+        assert usable.shape[0] == 50 - 3
+
+    def test_predict_with_rtc_warns_once_when_frequency_unset(self, caplog):
+        """RTC without a known control rate falls back to 30Hz but MUST warn
+        loudly (once), never silently assume the rate."""
+        policy = _make_rtc_policy(chunk_steps=50)
+        policy._rtc_latency_history.extend([0.1] * 20)
+        assert policy.control_frequency is None
+
+        with caplog.at_level("WARNING"):
+            policy._predict_with_rtc({})
+            policy._predict_with_rtc({})
+
+        warnings = [r for r in caplog.records if "control_frequency unknown" in r.message]
+        assert len(warnings) == 1, "fallback must warn exactly once per policy"
+        assert policy._rtc_freq_warned is True

--- a/tests/policies/test_base.py
+++ b/tests/policies/test_base.py
@@ -190,3 +190,39 @@ def test_mock_policy_action_values_are_json_native_floats():
             )
     # JSON round-trip is the canonical proof of native-value compliance.
     json.dumps(actions)
+
+
+class TestControlFrequency:
+    """``Policy.set_control_frequency`` / ``control_frequency`` contract.
+
+    The control rate is how a latency-sensitive provider converts wall-clock
+    inference latency into a count of consumed action steps (RTC). The runtime
+    sets it before the loop; until then it is ``None`` so providers can detect
+    "not told yet" rather than silently assuming a rate.
+    """
+
+    def test_default_control_frequency_is_none(self):
+        assert _IdentityPolicy().control_frequency is None
+
+    def test_set_control_frequency_sets_attribute(self):
+        p = _IdentityPolicy()
+        p.set_control_frequency(90.0)
+        assert p.control_frequency == 90.0
+
+    def test_set_control_frequency_coerces_to_float(self):
+        p = _IdentityPolicy()
+        p.set_control_frequency(50)
+        assert isinstance(p.control_frequency, float)
+        assert p.control_frequency == 50.0
+
+    @pytest.mark.parametrize("bad", [0, -1, -30.0])
+    def test_set_control_frequency_rejects_non_positive(self, bad):
+        p = _IdentityPolicy()
+        with pytest.raises(ValueError, match="must be positive"):
+            p.set_control_frequency(bad)
+
+    def test_control_frequency_is_per_instance(self):
+        a, b = _IdentityPolicy(), _IdentityPolicy()
+        a.set_control_frequency(120.0)
+        assert a.control_frequency == 120.0
+        assert b.control_frequency is None

--- a/tests/simulation/test_policy_runner_benchmark.py
+++ b/tests/simulation/test_policy_runner_benchmark.py
@@ -345,6 +345,13 @@ class TestAugmentObservationHook:
             def set_robot_state_keys(self, keys):
                 self.robot_state_keys = list(keys)
 
+            def set_control_frequency(self, hz):
+                # PolicyRunner now announces the loop's control rate to every
+                # policy before the rollout (RTC latency->step conversion). This
+                # double only verifies the observation-augmentation hook, so it
+                # records the rate to honor the contract without acting on it.
+                self.control_frequency = hz
+
             def get_actions(self, obs, instruction):
                 captured.append(dict(obs))
                 return [{"j0": 0.0, "j1": 0.0}]

--- a/tests/simulation/test_policy_runner_control_frequency.py
+++ b/tests/simulation/test_policy_runner_control_frequency.py
@@ -1,0 +1,55 @@
+"""``PolicyRunner`` tells the policy the loop's control rate before running.
+
+Latency-sensitive providers (Real-Time Chunking) convert measured wall-clock
+inference latency into a count of consumed action steps using the control rate.
+The runner is the only component that knows that rate, so it MUST call
+``policy.set_control_frequency`` before the rollout loop - otherwise the policy
+falls back to a hardcoded rate and mis-blends the chunk seam at every other
+frequency. These tests pin that the rate is propagated on every rollout entry
+point (``run`` / ``evaluate``).
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("MUJOCO_GL", "glfw")
+
+from strands_robots.policies.mock import MockPolicy
+from strands_robots.simulation.policy_runner import PolicyRunner
+from tests.simulation.test_policy_runner import FakeSim
+
+
+def test_run_sets_control_frequency_on_policy():
+    sim = FakeSim()
+    policy = MockPolicy()
+    assert policy.control_frequency is None
+    PolicyRunner(sim).run(
+        "fake_robot",
+        policy,
+        duration=0.04,
+        control_frequency=120.0,
+        fast_mode=True,
+    )
+    assert policy.control_frequency == 120.0
+
+
+def test_run_default_control_frequency_propagated():
+    sim = FakeSim()
+    policy = MockPolicy()
+    PolicyRunner(sim).run("fake_robot", policy, duration=0.04, fast_mode=True)
+    # PolicyRunner.run default control_frequency is 50.0.
+    assert policy.control_frequency == 50.0
+
+
+def test_evaluate_sets_control_frequency_on_policy():
+    sim = FakeSim()
+    policy = MockPolicy()
+    PolicyRunner(sim).evaluate(
+        "fake_robot",
+        policy,
+        n_episodes=1,
+        max_steps=3,
+        control_frequency=200.0,
+    )
+    assert policy.control_frequency == 200.0


### PR DESCRIPTION
## Problem

`LerobotLocalPolicy._estimate_inference_delay` computes the RTC inference delay as `int(p95_latency * fps)` — the number of action steps consumed while the next chunk is being computed. But the only call site (`_predict_with_rtc`) invoked it with no argument, so `fps` always fell back to its `30.0` default. The policy had no channel to learn the control rate of the loop actually executing its actions.

`PolicyRunner` defaults `control_frequency=50.0`, and sims commonly run at 30/50/100/200 Hz. Because the delay drives how `prev_chunk_left_over` is sliced for cross-chunk RTC blending, a wrong rate corrupts the chunk seam at every frequency except 30 Hz:

- 50 Hz: delay under-counted ~40% -> leftover sliced wrong -> stale steps blended
- 100 Hz: under-counted ~67% -> the same chunk gets re-applied on top of itself
- 30 Hz: correct only by coincidence

It passes unit tests (which run at 30 Hz) and degrades silently everywhere else.

## Change

Add a generic control-rate channel on the `Policy` base class and plumb it from the runner:

- `Policy.control_frequency` (default `None`) + `Policy.set_control_frequency(hz)` — any provider can read the executing loop's rate; `None` means "not told yet" so providers can detect it rather than silently assume.
- `PolicyRunner.run` / `evaluate` / `_evaluate_with_spec` call `set_control_frequency(control_frequency)` before the rollout loop.
- `_predict_with_rtc` resolves `fps` from `self.control_frequency` and passes it to `_estimate_inference_delay`. If unset, it falls back to 30 Hz with a loud **one-time** warning instead of silently assuming the rate.
- `_estimate_inference_delay(fps)` now takes `fps` as a required argument (no silent default) and documents that it must be the loop's real rate.

## Tests

All added tests fail on the pre-fix code and pass after:

- `Policy.set_control_frequency`: sets / validates positivity / coerces to float / per-instance / default `None`.
- `lerobot_local`: `_estimate_inference_delay` scales linearly with fps; `_predict_with_rtc` honours `set_control_frequency` (90 Hz slice != 30 Hz slice — the core regression); warn-once fallback when the rate is unset.
- `policy_runner`: `run` / `evaluate` propagate `control_frequency` onto the policy.

Full suite (`tests/policies`, `tests/simulation` policy-runner files): 1172 passed, 4 skipped. Lint + mypy clean.

## Visual proof

Estimated RTC inference delay vs control frequency at a fixed p95 latency of 100 ms. Before: stuck at 3 steps regardless of rate. After: scales linearly (3, 5, 6, 10, 15, 20 at 30/50/60/100/150/200 Hz).

![rtc delay scaling](https://github.com/cagataycali/robots/releases/download/rtc-cfreq-artifacts-1782506064/rtc_delay_scaling.png)

Headless MuJoCo rollout (so100, mock policy) at `control_frequency=100.0`, 400 control steps / 4.0s sim — confirms the runner sets the rate and the rollout path is healthy at a non-30Hz rate:

https://github.com/cagataycali/robots/releases/download/rtc-cfreq-artifacts-1782506064/rtc_rollout_100hz.mp4

---

## §13 Changelog

**Round 2** — CI fix (`call-test-lint`)

The new unconditional `policy.set_control_frequency(control_frequency)` call in `PolicyRunner.evaluate` surfaced an `AttributeError` on a pre-existing test: `TestAugmentObservationHook::test_hook_output_reaches_policy`. Its `_CapturePolicy` is a bare duck-typed double (does not subclass `Policy`) so it lacked the new contract method.

Fix: added a no-op `set_control_frequency(self, hz)` to `_CapturePolicy` that records the rate to honor the `Policy.set_control_frequency` contract without acting on it (the double exists only to assert the augment-observation hook output reaches `get_actions`). No production-code change. Verified locally: the previously-failing test plus `test_policy_runner_benchmark.py`, `test_policy_runner_control_frequency.py`, `test_base.py` — 73 passed; format + ruff clean.