### PR TITLE
fix(policies): add execution_horizon contract so RTC actually re-queries mid-chunk

### DIFF
--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -237,6 +237,20 @@ overlap execution**: the controller fires the next inference while the current
 chunk is still being executed, so the model's latency is hidden behind motion
 rather than appearing as a stall at the seam.
 
+### Re-query interval: `execution_horizon`
+
+The SIM consumes `policy.execution_horizon` actions from each chunk before
+re-querying - the single source of truth for the re-query rate. For an RTC
+policy this is `rtc_execution_horizon` (default 10), **not** the trained chunk
+length (`actions_per_step`, auto-detected from the model, e.g. 50). Re-querying
+mid-chunk is what lets the policy receive its previous chunk's unexecuted tail
+(`prev_chunk_left_over`) and blend the seam; draining the full trained chunk
+first leaves that tail empty and silently degrades RTC to open-loop replay. The
+policy decides this interval - a caller-supplied `action_horizon` is ignored for
+RTC policies (it cannot stretch the interval and break blending). For non-RTC
+policies `execution_horizon == actions_per_step` and the consumer still takes
+`max(action_horizon, actions_per_step)` so the trained chunk is never truncated.
+
 ### Synchronous vs async chunk execution in sim
 
 `run_policy` / `PolicyRunner.run` accept an `async_rtc` flag controlling which
@@ -244,7 +258,7 @@ of those two RTC benefits the sim reproduces:
 
 | `async_rtc` | Behaviour | Use when |
 | --- | --- | --- |
-| `False` (default) | Query the policy, fully drain the returned chunk, then re-query. Seam blending still works, but inference and execution do **not** overlap. | Single-step policies, deterministic regression runs, or any policy whose `get_actions` reads live sim state. |
+| `False` (default) | Query the policy, drain `execution_horizon` actions (the full chunk for non-RTC; `rtc_execution_horizon` for RTC), then re-query. Seam blending works because the RTC policy is re-queried mid-chunk, but inference and execution do **not** overlap. | Single-step policies, deterministic regression runs, or any policy whose `get_actions` reads live sim state. |
 | `True` | While the current chunk drains, fire the next `get_actions` on a single background worker once the chunk is ~50% consumed (using a fresh mid-execution observation), then atomically swap it in. A policy whose inference latency is at most the chunk's execution window pays (almost) zero visible stall at the seam. | Chunk-emitting VLA / flow-matching policies (pi0, pi0.5, pi0-FAST, SmolVLA, MolmoAct2) where you want sim per-step timing to track real-hardware behaviour, or to benchmark a streaming controller. |
 
 ```python

--- a/strands_robots/policies/base.py
+++ b/strands_robots/policies/base.py
@@ -168,6 +168,40 @@ class Policy(ABC):
         return True
 
     @property
+    def execution_horizon(self) -> int:
+        """Number of actions the SIM consumes from one ``get_actions`` chunk before re-querying.
+
+        This is the SINGLE source of truth for the re-query interval; a chunk
+        consumer (the single-policy runner, the multi-episode eval loop, the
+        synchronized multi-robot loop) reads it via
+        :func:`resolve_chunk_length` and never inspects ``actions_per_step``
+        directly. Distinguishing the re-query interval from the trained chunk
+        length is what makes Real-Time Chunking (RTC) actually engage:
+
+        * **RTC policy** -> the RTC ``execution_horizon`` (typically << the
+          trained chunk). The policy is re-queried mid-chunk so it can blend
+          the unexecuted tail of the previous chunk (``prev_chunk_left_over``)
+          into the next one. Re-querying only after the full trained chunk
+          drains leaves that tail permanently empty and silently degrades RTC
+          to plain open-loop replay.
+        * **chunked open-loop** (ACT, diffusion, pi0/SmolVLA without RTC) ->
+          ``actions_per_step`` (the trained chunk; truncating drops its tail
+          and forces an out-of-distribution re-query).
+        * **single-step** (``MockPolicy``, classical planners) -> ``1``.
+
+        The default derives from ``actions_per_step`` (``1`` when undeclared),
+        so a single-step or chunked open-loop policy needs no override; only a
+        policy with an inference-time budget distinct from its trained chunk
+        (RTC) overrides this.
+        """
+        intended = getattr(self, "actions_per_step", 1)
+        try:
+            intended_int = int(intended)
+        except (TypeError, ValueError):
+            intended_int = 1
+        return max(1, intended_int)
+
+    @property
     @abstractmethod
     def provider_name(self) -> str:
         """Get provider name for identification."""
@@ -215,35 +249,56 @@ class ChunkedPolicy(Protocol):
 def resolve_chunk_length(policy: "Policy", action_horizon: int) -> int:
     """Effective number of actions to consume from one ``get_actions`` chunk.
 
-    Centralizes the single chunk-length rule every consumer must apply
-    identically: consume ``max(action_horizon, policy.actions_per_step)``
-    actions before re-querying. A policy trained for N-step open-loop replay
-    (``actions_per_step == N``) must have its FULL chunk consumed; clamping to a
-    smaller ``action_horizon`` drops the chunk tail and forces an
-    out-of-distribution re-query. Policies that do not declare
-    ``actions_per_step`` (single-action providers such as ``MockPolicy``) behave
-    as a 1-action chunk, so the result is just ``max(action_horizon, 1)``.
+    Centralizes the single re-query rule every consumer must apply identically.
+    The number of actions consumed before re-querying is the policy's
+    :attr:`Policy.execution_horizon` - the single source of truth - never
+    ``actions_per_step`` read directly. How ``action_horizon`` interacts with it
+    depends on whether the policy carries cross-chunk state (RTC):
+
+    * **RTC policy** (``supports_rtc`` is true): the policy hard-decides the
+      interval and is re-queried at exactly its ``execution_horizon`` so it can
+      blend the unexecuted tail of the previous chunk into the next one. A
+      caller-supplied ``action_horizon`` must NOT stretch (or shrink) this
+      interval - doing so leaves ``prev_chunk_left_over`` empty and silently
+      degrades RTC to plain open-loop replay. ``action_horizon`` is ignored.
+    * **non-RTC** (open-loop chunked or single-step): consume
+      ``max(action_horizon, execution_horizon)`` so a model trained for N-step
+      replay (``execution_horizon == actions_per_step == N``) keeps its FULL
+      chunk - clamping to a smaller ``action_horizon`` drops the chunk tail and
+      forces an out-of-distribution re-query. Single-action providers
+      (``MockPolicy``) have ``execution_horizon == 1`` so the result is just
+      ``max(action_horizon, 1)``.
 
     Before this helper existed each consumer inlined the same
-    ``max(action_horizon, getattr(policy, "actions_per_step", 1))`` expression,
-    and they drifted: the synchronized multi-robot loop truncated to
-    ``action_horizon`` alone, silently dropping a chunk-emitting policy's tail
-    while the single-policy runner consumed the full chunk.
+    ``max(action_horizon, getattr(policy, "actions_per_step", 1))`` expression
+    and they drifted; worse, all of them keyed off ``actions_per_step``, so an
+    RTC policy was re-queried only after its full trained chunk drained and its
+    cross-chunk blending never engaged.
 
     Args:
-        policy: Any policy. Its chunk length is read from the optional
-            :class:`ChunkedPolicy` ``actions_per_step`` attribute; a policy that
-            does not declare it is treated as single-action.
+        policy: Any policy. The re-query interval is read from
+            :attr:`Policy.execution_horizon` (falling back to a raw
+            ``actions_per_step`` attribute for duck-typed objects that are not
+            ``Policy`` subclasses); a policy that declares neither is treated as
+            single-action.
         action_horizon: Consumer-requested actions per chunk (clamped to >= 1).
+            Ignored for RTC policies, which decide their own interval.
 
     Returns:
         The number of leading chunk actions to execute before re-querying.
     """
-    intended = getattr(policy, "actions_per_step", 1)
+    horizon = getattr(policy, "execution_horizon", None)
+    if horizon is None:
+        # Duck-typed object that is not a ``Policy`` subclass (no
+        # execution_horizon property): fall back to its raw chunk length.
+        horizon = getattr(policy, "actions_per_step", 1)
     try:
-        intended_int = int(intended)
+        horizon_int = 1 if horizon is None else int(horizon)
     except (TypeError, ValueError):
-        intended_int = 1
-    if intended_int < 1:
-        intended_int = 1
-    return max(int(action_horizon), 1, intended_int)
+        horizon_int = 1
+    if horizon_int < 1:
+        horizon_int = 1
+    if getattr(policy, "supports_rtc", False):
+        # RTC owns the interval; action_horizon cannot override it.
+        return horizon_int
+    return max(int(action_horizon), 1, horizon_int)

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -229,6 +229,28 @@ class LerobotLocalPolicy(Policy):
         """
         return self._rtc_enabled
 
+    @property
+    def execution_horizon(self) -> int:
+        """Actions the SIM executes from one chunk before re-querying.
+
+        Overrides :attr:`Policy.execution_horizon` to separate the inference-time
+        re-query budget from the trained chunk length (``actions_per_step``):
+
+        * RTC active -> the RTC execution horizon (``rtc_execution_horizon``,
+          default 10). The policy is re-queried mid-chunk so it blends the
+          unexecuted tail of the previous chunk (``prev_chunk_left_over``) into
+          the next - the whole point of Real-Time Chunking. Re-querying only
+          after the full trained chunk drains keeps that tail empty and silently
+          collapses RTC to open-loop replay.
+        * otherwise -> ``actions_per_step`` (the trained chunk, consumed whole).
+
+        Falls back to ``actions_per_step`` when RTC is enabled but the horizon
+        was never resolved (defensive; ``_init_rtc`` always sets it).
+        """
+        if self._rtc_enabled and self._rtc_execution_horizon:
+            return max(1, int(self._rtc_execution_horizon))
+        return max(1, int(self.actions_per_step))
+
     def reset(self, seed: int | None = None) -> None:
         """Reset policy state between episodes.
 
@@ -937,13 +959,16 @@ class LerobotLocalPolicy(Policy):
         # Estimate inference delay - how many steps were consumed while computing
         inference_delay = self._estimate_inference_delay()
 
-        # Store leftover for next RTC call (unconsumed portion of this chunk)
-        # The delay represents steps already consumed, so leftover starts after
-        # the steps we'll actually return
-        steps_to_consume = min(
-            max(self.actions_per_step, inference_delay + self.actions_per_step),
-            action_chunk.shape[0],
-        )
+        # Store leftover for next RTC call (unconsumed portion of this chunk).
+        # The consumer executes ``execution_horizon`` actions before re-querying
+        # (see Policy.execution_horizon / resolve_chunk_length), so the tail past
+        # that point - shifted by the steps already burned during inference - is
+        # what carries into the next chunk as ``prev_chunk_left_over``. Keying
+        # this on the full trained chunk (actions_per_step) emptied the tail
+        # whenever the chunk was consumed whole, so cross-chunk blending never
+        # engaged.
+        exec_horizon = self._rtc_execution_horizon or self.actions_per_step
+        steps_to_consume = min(inference_delay + max(1, int(exec_horizon)), action_chunk.shape[0])
         if steps_to_consume < action_chunk.shape[0]:
             self._rtc_prev_chunk = action_chunk[steps_to_consume:].detach()
         else:
@@ -1620,21 +1645,28 @@ class LerobotLocalPolicy(Policy):
             action_tensor: Raw action tensor from policy.select_action().
 
         Returns:
-            List of action dicts, length capped by actions_per_step.
+            List of action dicts, length capped by execution_horizon
+            (== actions_per_step except under RTC, where it is the RTC
+            execution horizon - the consumer re-queries at that interval).
 
         Raises:
             RuntimeError: If robot_state_keys is empty.
         """
         action_array = action_tensor.cpu().numpy()
 
-        # Normalize tensor shape to a list of 1D action arrays
+        # Normalize tensor shape to a list of 1D action arrays. Cap the chunk
+        # at execution_horizon (the re-query interval the consumer drives, via
+        # resolve_chunk_length) rather than the raw trained chunk length: under
+        # RTC these differ (execution_horizon << actions_per_step) and emitting
+        # more than the consumer will execute is wasted work past the seam.
+        _cap = self.execution_horizon
         if action_array.ndim == 1:
             actions_list = [action_array]
         elif action_array.ndim == 2:
-            actions_list = [action_array[i] for i in range(min(len(action_array), self.actions_per_step))]
+            actions_list = [action_array[i] for i in range(min(len(action_array), _cap))]
         elif action_array.ndim == 3:
             # Batched: take first batch element, then slice horizon
-            actions_list = [action_array[0, i] for i in range(min(action_array.shape[1], self.actions_per_step))]
+            actions_list = [action_array[0, i] for i in range(min(action_array.shape[1], _cap))]
         else:
             actions_list = [action_array.flatten()]
 

--- a/tests/policies/lerobot_local/test_policy.py
+++ b/tests/policies/lerobot_local/test_policy.py
@@ -1280,6 +1280,47 @@ class TestRTCInference:
         assert policy._rtc_prev_chunk is not None
         assert policy._rtc_prev_chunk.dim() == 2
 
+    def test_predict_with_rtc_leftover_keyed_on_execution_horizon(self):
+        """Leftover is the chunk tail past execution_horizon, not actions_per_step.
+
+        Regression: when the consumer drained the FULL trained chunk
+        (actions_per_step == chunk length) the old bookkeeping set steps_to_consume
+        to the whole chunk, so ``_rtc_prev_chunk`` was always ``None`` and the
+        cross-chunk blend never received a previous-chunk tail. With the
+        execution-horizon contract the consumer re-queries every
+        execution_horizon steps, so the tail past that point must carry over.
+        """
+        policy = _make_policy()
+        policy._rtc_enabled = True
+        policy._rtc_execution_horizon = 10
+        policy._rtc_prev_chunk = None
+        policy.actions_per_step = 20  # full trained chunk == chunk length below
+
+        mock_policy = MagicMock()
+        mock_policy.predict_action_chunk.return_value = torch.randn(1, 20, 6)
+        policy._policy = mock_policy
+
+        policy._predict_with_rtc({})
+
+        # delay ~= 0 on the first call -> leftover starts at execution_horizon.
+        assert policy._rtc_prev_chunk is not None
+        assert policy._rtc_prev_chunk.shape == (10, 6)
+
+    def test_execution_horizon_prefers_rtc_over_actions_per_step(self):
+        """execution_horizon is the RTC horizon while RTC is active."""
+        policy = _make_policy()
+        policy.actions_per_step = 50
+        policy._rtc_enabled = True
+        policy._rtc_execution_horizon = 10
+        assert policy.execution_horizon == 10
+
+    def test_execution_horizon_falls_back_to_chunk_without_rtc(self):
+        """Without RTC, execution_horizon is the trained chunk length."""
+        policy = _make_policy()
+        policy.actions_per_step = 50
+        policy._rtc_enabled = False
+        assert policy.execution_horizon == 50
+
     def test_predict_with_rtc_tracks_latency(self):
         """RTC should track inference latency for delay estimation."""
         policy = _make_policy()

--- a/tests/policies/test_chunked_policy_contract.py
+++ b/tests/policies/test_chunked_policy_contract.py
@@ -133,3 +133,82 @@ def test_chunked_policy_accepts_property_backed_attrs() -> None:
 @pytest.mark.parametrize("horizon,chunk,expected", [(8, 50, 50), (8, 1, 8), (1, 1, 1), (30, 30, 30)])
 def test_resolve_chunk_length_matrix(horizon: int, chunk: int, expected: int) -> None:
     assert resolve_chunk_length(MockChunkedPolicy(actions_per_step=chunk), horizon) == expected
+
+
+class MockRtcPolicy(Policy):
+    """Weight-free RTC policy: trained chunk of ``actions_per_step`` but a
+    smaller ``execution_horizon`` re-query interval.
+
+    Mirrors a flow-matching policy (pi0/SmolVLA) that emits a long chunk yet
+    must be re-queried every ``execution_horizon`` steps so it can blend the
+    previous chunk's unexecuted tail into the next one.
+    """
+
+    requires_images = False
+
+    def __init__(self, actions_per_step: int = 50, execution_horizon: int = 10) -> None:
+        self.actions_per_step = actions_per_step
+        self.supports_rtc = True
+        self._execution_horizon = execution_horizon
+        self.calls = 0
+        self._keys: list[str] = []
+
+    @property
+    def provider_name(self) -> str:
+        return "mock_rtc"
+
+    @property
+    def execution_horizon(self) -> int:
+        return self._execution_horizon
+
+    def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
+        self._keys = list(robot_state_keys)
+
+    async def get_actions(
+        self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any
+    ) -> list[dict[str, Any]]:
+        self.calls += 1
+        keys = self._keys or ["j0", "j1", "j2"]
+        return [{k: 0.0 for k in keys} for _ in range(self.actions_per_step)]
+
+
+def test_execution_horizon_defaults_to_actions_per_step() -> None:
+    """A non-RTC chunked policy executes its full trained chunk per query."""
+    assert MockChunkedPolicy(actions_per_step=30).execution_horizon == 30
+
+
+def test_execution_horizon_single_action_default() -> None:
+    """A single-action policy has a one-action execution horizon."""
+    assert MockPolicy().execution_horizon == 1
+
+
+def test_resolve_chunk_length_rtc_uses_execution_horizon() -> None:
+    """RTC re-queries at execution_horizon, NOT the full trained chunk.
+
+    Regression for the silent ``max(action_horizon, actions_per_step)`` collide:
+    a policy trained for a 50-step chunk but with a 10-step RTC execution
+    horizon must be re-queried every 10 steps so its cross-chunk blending
+    engages. The old rule consumed all 50 and the blend never ran.
+    """
+    pol = MockRtcPolicy(actions_per_step=50, execution_horizon=10)
+    assert pol.execution_horizon == 10
+    assert pol.actions_per_step == 50
+    assert resolve_chunk_length(pol, action_horizon=8) == 10
+
+
+def test_resolve_chunk_length_rtc_ignores_user_horizon() -> None:
+    """The user cannot stretch an RTC policy's re-query interval.
+
+    Even a huge ``action_horizon`` must not push the interval past the policy's
+    execution horizon - otherwise ``prev_chunk_left_over`` stays empty and RTC
+    degrades to open-loop replay.
+    """
+    pol = MockRtcPolicy(actions_per_step=50, execution_horizon=10)
+    assert resolve_chunk_length(pol, action_horizon=999) == 10
+
+
+def test_resolve_chunk_length_nonrtc_unaffected_by_execution_horizon() -> None:
+    """Non-RTC chunked policies still consume the larger of horizon and chunk."""
+    pol = MockChunkedPolicy(actions_per_step=50)
+    assert resolve_chunk_length(pol, action_horizon=8) == 50
+    assert resolve_chunk_length(pol, action_horizon=80) == 80

--- a/tests/simulation/test_rtc_requery_interval.py
+++ b/tests/simulation/test_rtc_requery_interval.py
@@ -1,0 +1,146 @@
+"""The SIM re-queries an RTC policy at its ``execution_horizon``, not its chunk.
+
+Regression for the policy/sim contract collision: the runner used to consume
+``max(action_horizon, policy.actions_per_step)`` actions before re-querying. For
+a Real-Time-Chunking policy trained on a long chunk (e.g. 50) but with a short
+execution horizon (e.g. 10), that drained the entire chunk before re-querying,
+so the policy never received its previous chunk's unexecuted tail and its
+cross-chunk blending was dead code - identical output to plain open-loop replay.
+
+The fix routes every consumer through ``policy.execution_horizon`` (via
+``resolve_chunk_length``). These tests pin the consumer behaviour - the runner
+re-queries every ``execution_horizon`` steps and a user-supplied
+``action_horizon`` cannot stretch that interval - without a real VLA checkpoint,
+using an instrumented counting sim and a weight-free chunk policy.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+import numpy as np
+
+from strands_robots.policies.base import Policy
+from strands_robots.simulation.base import SimEngine
+from strands_robots.simulation.policy_runner import PolicyRunner
+
+
+class _CountingSim(SimEngine):
+    """Minimal ``SimEngine`` that counts ``send_action`` calls."""
+
+    def __init__(self) -> None:
+        self._joint_names = ["j0", "j1", "j2"]
+        self._robots = {"arm": self._joint_names}
+        self._lock = threading.Lock()
+        self.send_count = 0
+
+    def create_world(self, timestep=None, gravity=None, ground_plane=True):
+        return {"status": "success"}
+
+    def destroy(self):
+        return {"status": "success"}
+
+    def reset(self):
+        return {"status": "success"}
+
+    def step(self, n_steps: int = 1):
+        return {"status": "success"}
+
+    def get_state(self):
+        return {"sim_time": 0.0, "step_count": self.send_count}
+
+    def add_robot(self, name, **kw):
+        return {"status": "success"}
+
+    def remove_robot(self, name):
+        return {"status": "success"}
+
+    def list_robots(self) -> list[str]:
+        return list(self._robots.keys())
+
+    def robot_joint_names(self, robot_name: str) -> list[str]:
+        return list(self._robots.get(robot_name, []))
+
+    def add_object(self, name, **kw):
+        return {"status": "success"}
+
+    def remove_object(self, name):
+        return {"status": "success"}
+
+    def get_observation(self, robot_name=None, *, skip_images=False):
+        return {n: 0.0 for n in self._joint_names}
+
+    def send_action(self, action, robot_name=None, n_substeps=1):
+        with self._lock:
+            self.send_count += 1
+
+    def render(self, camera_name="default", width=None, height=None):
+        return {"image": np.zeros((height or 48, width or 64, 3), dtype=np.uint8)}
+
+
+class _RtcChunkPolicy(Policy):
+    """Weight-free RTC stand-in: long trained chunk, short execution horizon."""
+
+    requires_images = False
+
+    def __init__(self, actions_per_step: int = 50, execution_horizon: int = 10) -> None:
+        self.actions_per_step = actions_per_step
+        self.supports_rtc = True
+        self._execution_horizon = execution_horizon
+        self.robot_state_keys: list[str] = []
+        self.query_steps: list[int] = []
+        self._sim: _CountingSim | None = None
+
+    @property
+    def provider_name(self) -> str:
+        return "rtc-test"
+
+    @property
+    def execution_horizon(self) -> int:
+        return self._execution_horizon
+
+    def bind(self, sim: _CountingSim) -> None:
+        self._sim = sim
+
+    def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
+        self.robot_state_keys = robot_state_keys
+
+    async def get_actions(
+        self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any
+    ) -> list[dict[str, Any]]:
+        assert self._sim is not None
+        self.query_steps.append(self._sim.send_count)
+        keys = self.robot_state_keys or ["j0", "j1", "j2"]
+        return [{k: 0.0 for k in keys} for _ in range(self.actions_per_step)]
+
+
+def _run(policy: _RtcChunkPolicy, *, n_steps: int, action_horizon: int) -> dict:
+    sim = _CountingSim()
+    policy.bind(sim)
+    policy.set_robot_state_keys(sim.robot_joint_names("arm"))
+    return PolicyRunner(sim).run(
+        "arm",
+        policy,
+        duration=n_steps / 50.0,
+        control_frequency=50.0,
+        action_horizon=action_horizon,
+        fast_mode=True,
+    )
+
+
+def test_rtc_policy_requeried_every_execution_horizon() -> None:
+    """Re-query interval == execution_horizon (10), not the 50-step chunk."""
+    policy = _RtcChunkPolicy(actions_per_step=50, execution_horizon=10)
+    result = _run(policy, n_steps=30, action_horizon=8)
+    assert result["status"] == "success"
+    # Queries fired at sim steps 0, 10, 20 -> three inferences over 30 steps.
+    assert policy.query_steps == [0, 10, 20], policy.query_steps
+
+
+def test_user_action_horizon_cannot_stretch_rtc_interval() -> None:
+    """A huge action_horizon must not collapse RTC back to one big chunk."""
+    policy = _RtcChunkPolicy(actions_per_step=50, execution_horizon=10)
+    result = _run(policy, n_steps=30, action_horizon=999)
+    assert result["status"] == "success"
+    assert policy.query_steps == [0, 10, 20], policy.query_steps


### PR DESCRIPTION
## Problem

The sim consumer sizes every action chunk through `resolve_chunk_length`, which until now keyed the re-query interval off the policy's trained chunk length:

```python
return max(action_horizon, policy.actions_per_step)
```

For a Real-Time-Chunking (RTC) policy this is wrong. A flow-matching policy (pi0, SmolVLA) is trained on a long chunk (`actions_per_step`, auto-detected from `config.n_action_steps`, e.g. 50) but is meant to be re-queried every `rtc_execution_horizon` steps (e.g. 10) so each new chunk is denoised conditioned on the *unexecuted tail* of the previous one (`prev_chunk_left_over`). Draining the full 50-step chunk before re-querying means:

- the leftover tail handed to the next inference is always empty, so the cross-chunk blend is dead code;
- a caller-supplied `action_horizon` cannot influence the rate at all (the larger trained chunk always wins);
- RTC produces output identical to plain open-loop replay while *appearing* to be enabled.

The re-query interval and the trained chunk length are two different quantities that were collapsed into one.

## Change

Introduce `Policy.execution_horizon` as the single source of truth for how many actions the sim consumes from one `get_actions` chunk before re-querying:

- **RTC policy** -> `rtc_execution_horizon` (re-query mid-chunk so the seam blends)
- **chunked open-loop** (ACT, diffusion, pi0/SmolVLA without RTC) -> `actions_per_step` (consume the full trained chunk; truncating drops its tail)
- **single-step** (`MockPolicy`, classical planners) -> `1`

The default derives from `actions_per_step`, so only RTC policies need an override.

`resolve_chunk_length` now reads `execution_horizon`. For RTC policies it returns exactly that interval - a caller-supplied `action_horizon` can no longer stretch it and silently break blending. For non-RTC policies the behaviour is unchanged: `max(action_horizon, actions_per_step)`, so a trained chunk is never truncated.

`LerobotLocalPolicy` keys both its RTC leftover bookkeeping (`_predict_with_rtc`) and its action-dict cap (`_tensor_to_action_dicts`) on `execution_horizon`, so the unexecuted tail of each chunk actually carries into the next inference instead of being discarded whenever the trained chunk was consumed whole.

The `ChunkedPolicy` protocol and the non-RTC contract are untouched, so existing consumers and tests keep working.

## Tests (all fail on pre-fix code)

- `tests/policies/test_chunked_policy_contract.py`: `execution_horizon` defaults; `resolve_chunk_length` returns the RTC execution horizon and ignores an oversized `action_horizon`; non-RTC path unchanged.
- `tests/simulation/test_rtc_requery_interval.py`: drives the real `PolicyRunner` through an instrumented counting sim and asserts an RTC policy (chunk 50, horizon 10) is re-queried at sim steps `[0, 10, 20]` - and that `action_horizon=999` cannot stretch that.
- `tests/policies/lerobot_local/test_policy.py`: `_predict_with_rtc` now populates `_rtc_prev_chunk` even when the trained chunk is consumed whole; `execution_horizon` prefers the RTC horizon over `actions_per_step`.

Full suite green locally (lint + ruff format + mypy clean; `MUJOCO_GL=egl` pytest for `tests/policies` and `tests/simulation` passes, excluding two pre-existing `torchcodec`/CUDA environment failures unrelated to this change).

## Visual artifact

Re-query points over a 50-step rollout, captured from the real `PolicyRunner` driven by the instrumented sim (chunk=50, execution_horizon=10). Before: a single query at step 0 (the whole chunk drains, blend never runs). After: queries at 0/10/20/30/40 so each chunk receives the previous tail.

![re-query timeline](https://github.com/cagataycali/robots/releases/download/artifacts-execution-horizon-1782507199/execution_horizon_requery.png)

MuJoCo headless rollout (SO-101, mock provider) confirming the consumer path runs end-to-end after the change: https://github.com/cagataycali/robots/releases/download/artifacts-execution-horizon-1782507199/execution_horizon_demo.mp4