### PR TITLE
fix(sim): wire per-episode recorder.save_episode in policy_runner (#708)

### DIFF
--- a/strands_robots/simulation/mujoco/recording.py
+++ b/strands_robots/simulation/mujoco/recording.py
@@ -385,6 +385,39 @@ class RecordingMixin:
         # — streaming/training downstream needs it (App. F.2).
         recorder.finalize()
 
+        # #708 - parquet-truth gate. The recorder's ``episode_count`` is the
+        # author-side bookkeeping (incremented by every ``save_episode`` call).
+        # The dataset's own ``meta.total_episodes`` / parquet rowcount is what
+        # downstream consumers (HF hub, training loaders, audit tools) trust.
+        # If they disagree, the on-disk dataset is the source of truth (Law-7
+        # in AGENTS.md: parquet num_rows > meta/info.json > markdown). Surface
+        # the mismatch in the returned payload so the caller — and any CI that
+        # parses the status dict — can fail loudly instead of shipping a
+        # silent-collapse dataset.
+        parquet_episode_count: int | None = None
+        episode_count_mismatch: bool = False
+        episode_count_mismatch_orig: int = episode_count
+        try:
+            ds_meta = getattr(getattr(recorder, "dataset", None), "meta", None)
+            if ds_meta is not None:
+                parquet_episode_count = int(getattr(ds_meta, "total_episodes", 0))
+                if parquet_episode_count != episode_count:
+                    episode_count_mismatch = True
+                    logger.warning(
+                        "stop_recording: recorder.episode_count=%d but "
+                        "dataset.meta.total_episodes=%d. Trust the parquet. "
+                        "(#708 silent-collapse gate)",
+                        episode_count,
+                        parquet_episode_count,
+                    )
+                    # The parquet is the ground truth - report it as the
+                    # canonical episode_count downstream. Stash the original
+                    # recorder.episode_count so the text payload can name both.
+                    episode_count_mismatch_orig = episode_count
+                    episode_count = parquet_episode_count
+        except Exception as e:  # noqa: BLE001 - never fail finalize on a probe
+            logger.debug("episode_count gate probe failed: %s", e)
+
         extra = ""
         # Bucket sync (Phase 1/2): mutable, Xet-deduped collection dump.
         if bucket:
@@ -404,13 +437,40 @@ class RecordingMixin:
         self._world._backend_state["dataset_recorder"] = None
         self._world._backend_state["trajectory"] = []
 
+        # #708 - if recorder.episode_count and parquet disagree, surface
+        # it in the human-readable text too so an operator scanning the
+        # status log sees the gate firing.
+        if episode_count_mismatch:
+            text_episode_note = (
+                f"\n[#708 gate] recorder reported {episode_count_mismatch_orig} "
+                f"episodes but parquet has {episode_count}. Trusting parquet."
+            )
+        else:
+            text_episode_note = ""
+
         text = (
             f"Episode saved to LeRobotDataset\n"
-            f"{repo_id} -- {frame_count} frames, {episode_count} episode(s)\n"
+            f"{repo_id} -- {frame_count} frames, {episode_count} episode(s)"
+            f"{text_episode_note}\n"
             f"Local: {root}{extra}"
         )
 
-        return {"status": "success", "content": [{"text": text}]}
+        return {
+            "status": "success",
+            "content": [
+                {"text": text},
+                {
+                    "json": {
+                        "repo_id": repo_id,
+                        "frame_count": frame_count,
+                        "episode_count": episode_count,
+                        "parquet_episode_count": parquet_episode_count,
+                        "episode_count_mismatch": episode_count_mismatch,
+                        "root": root,
+                    }
+                },
+            ],
+        }
 
     def save_episode(self) -> dict[str, Any]:
         """Close the current episode and start a fresh one in the same session.

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -302,7 +302,10 @@ class PolicyRunner:
         actions and ``add_frame`` was never called).
         """
         try:
-            recorder = self.sim._world._backend_state.get("dataset_recorder")
+            world = getattr(self.sim, "_world", None)
+            if world is None:
+                return
+            recorder = world._backend_state.get("dataset_recorder")
         except AttributeError:
             return
         if recorder is None:

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -274,6 +274,55 @@ class PolicyRunner:
             return max(1, round((1.0 / control_frequency) / dt))
         return 1
 
+    # ------------------------------------------------------------------
+    # Recorder per-episode boundary (issue #708)
+    # ------------------------------------------------------------------
+    #
+    # The dataset_recorder attached to ``_world._backend_state`` keeps a single
+    # open LeRobot episode buffer. ``add_frame`` appends to that buffer; only
+    # ``save_episode`` rolls over to a new episode and bumps
+    # ``episode_count``. ``stop_recording`` flushes the last open episode but
+    # has no idea how many episodes the caller intended.
+    #
+    # Without this helper, every ``for ep in range(n_episodes):`` loop in
+    # ``evaluate`` / ``_evaluate_with_spec`` records ONE giant episode of
+    # ``n_episodes * max_steps`` frames into the dataset. The agent sees
+    # ``total_episodes=1`` in the parquet meta but a status=OK summary
+    # because the recorder did receive frames. (#708 — silent collapse.)
+    #
+    # Calling this at the end of each policy-runner episode forces a per-
+    # episode boundary in the recorded dataset. Skipped silently when no
+    # recorder is attached (eval without recording is the common case).
+    def _finalize_recorder_episode(self) -> None:
+        """Roll the attached dataset_recorder over to a new episode.
+
+        Called at end of each rollout iteration in ``evaluate`` and
+        ``_evaluate_with_spec``. No-op when no recorder is attached or when
+        the episode buffer is empty (e.g. degenerate policy returned no
+        actions and ``add_frame`` was never called).
+        """
+        try:
+            recorder = self.sim._world._backend_state.get("dataset_recorder")
+        except AttributeError:
+            return
+        if recorder is None:
+            return
+        # Don't flush an empty buffer - LeRobot raises on save_episode with
+        # zero frames, and a degenerate rollout still counts as "no data" for
+        # this episode rather than an error.
+        pending = getattr(recorder, "episode_frame_count", 0)
+        if pending <= 0:
+            return
+        try:
+            result = recorder.save_episode()
+            if isinstance(result, dict) and result.get("status") != "success":
+                logger.warning(
+                    "Per-episode save_episode returned non-success: %s",
+                    result.get("message", result),
+                )
+        except Exception as e:  # noqa: BLE001 - recorder errors must not abort eval
+            logger.warning("Per-episode save_episode raised: %s", e)
+
     # run(): blocking policy execution
     def run(
         self,
@@ -970,6 +1019,10 @@ class PolicyRunner:
                     break
 
             results.append({"episode": ep, "steps": steps, "success": success})
+            # #708 - roll the attached recorder over to a new episode so the
+            # dataset records per-episode boundaries rather than collapsing
+            # every rollout into one mega-episode.
+            self._finalize_recorder_episode()
 
         n_success = sum(1 for r in results if r["success"])
         success_rate = n_success / max(n_episodes, 1)
@@ -1285,6 +1338,8 @@ class PolicyRunner:
                     "info": last_info,
                 }
             )
+            # #708 - same per-episode recorder boundary as evaluate().
+            self._finalize_recorder_episode()
 
         n_success = sum(1 for r in results if r["success"])
         n_failure = sum(1 for r in results if r["failure"])

--- a/tests/simulation/test_policy_runner_recorder_episode_boundary.py
+++ b/tests/simulation/test_policy_runner_recorder_episode_boundary.py
@@ -89,6 +89,7 @@ def _attach_recorder(sim: Simulation, frames_per_episode: int = 5) -> _StubRecor
     a non-empty buffer when it fires.
     """
     rec = _StubRecorder()
+    assert sim._world is not None
     sim._world._backend_state["dataset_recorder"] = rec
     return rec
 

--- a/tests/simulation/test_policy_runner_recorder_episode_boundary.py
+++ b/tests/simulation/test_policy_runner_recorder_episode_boundary.py
@@ -1,0 +1,200 @@
+"""Regression tests for issue #708 — silent episode collapse.
+
+Background
+==========
+``PolicyRunner.evaluate`` and ``PolicyRunner._evaluate_with_spec`` run a
+``for ep in range(n_episodes):`` loop. Before this fix, neither loop called
+``recorder.save_episode()`` between iterations. The recorder kept one open
+LeRobot episode buffer, ``add_frame`` (invoked from the sim step hook)
+appended to it, and ``stop_recording`` flushed the single buffer at the end.
+
+Net effect: a 20-episode × 60-step rollout produced one parquet episode of
+1140 frames, but the eval status text reported ``Episodes: 20`` because the
+runner's own bookkeeping counted iterations. A run was marked status=OK and
+shipped to HuggingFace with ``total_episodes=1`` — silent data-integrity
+loss across 47/47 historical molmoact-e2e runs.
+
+The fix wires ``self._finalize_recorder_episode()`` at the end of each
+``for ep ...`` body. The recorder is opaque-injected via
+``world._backend_state["dataset_recorder"]`` so we don't need a real
+``LeRobotDataset`` — a stub that counts ``save_episode`` calls is enough to
+pin the contract.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+from strands_robots.policies.mock import MockPolicy
+from strands_robots.simulation.mujoco.simulation import Simulation
+from strands_robots.simulation.policy_runner import PolicyRunner
+
+
+class _StubRecorder:
+    """Minimal stand-in for ``DatasetRecorder``.
+
+    Mimics the surface ``_finalize_recorder_episode`` touches:
+    * ``episode_frame_count``  — incremented by the test "step hook" so
+      :meth:`PolicyRunner._finalize_recorder_episode` doesn't skip the call
+      due to an empty buffer.
+    * ``save_episode``         — bumps ``episode_count``, resets
+      ``episode_frame_count``, and records the call for assertion.
+
+    We deliberately do NOT subclass the real recorder — keeping the contract
+    explicit and minimal documents what the fix actually depends on.
+    """
+
+    def __init__(self) -> None:
+        self.episode_count = 0
+        self.episode_frame_count = 0
+        self.frame_count = 0
+        self.save_calls: list[dict[str, int]] = []
+
+    def add_frame(self, *_a, **_kw) -> None:  # not used here but mimics surface
+        self.episode_frame_count += 1
+        self.frame_count += 1
+
+    def save_episode(self) -> dict[str, Any]:
+        ep_frames = self.episode_frame_count
+        self.episode_count += 1
+        self.episode_frame_count = 0
+        self.save_calls.append({"ep": self.episode_count, "frames": ep_frames})
+        return {
+            "status": "success",
+            "episode": self.episode_count,
+            "episode_frames": ep_frames,
+            "total_frames": self.frame_count,
+        }
+
+
+@pytest.fixture
+def sim_with_robot():
+    s = Simulation(tool_name="pr708", mesh=False)
+    s.create_world()
+    s.add_robot(name="alice", data_config="so100")
+    yield s
+    s.cleanup()
+
+
+def _attach_recorder(sim: Simulation, frames_per_episode: int = 5) -> _StubRecorder:
+    """Attach a stub recorder + simulate per-step ``add_frame`` calls.
+
+    The real recorder gets fed by ``Simulation`` send_action callbacks. For
+    this test we don't need to wire that — we manually pump ``add_frame``
+    inside an ``on_frame`` hook so :meth:`_finalize_recorder_episode` sees
+    a non-empty buffer when it fires.
+    """
+    rec = _StubRecorder()
+    sim._world._backend_state["dataset_recorder"] = rec
+    return rec
+
+
+class TestRecorderEpisodeBoundary:
+    """#708: evaluate() must call save_episode between rollouts."""
+
+    def test_evaluate_calls_save_episode_per_iteration(self, sim_with_robot):
+        rec = _attach_recorder(sim_with_robot)
+
+        policy = MockPolicy()
+        policy.set_robot_state_keys(sim_with_robot.robot_joint_names("alice"))
+        runner = PolicyRunner(sim_with_robot)
+
+        # Use on_frame to pump add_frame so the recorder buffer is non-empty
+        # when finalize is called. evaluate() does not call on_frame in the
+        # base loop, so feed via a stub helper instead: pretend each step
+        # added a frame.
+        def fake_step_recorder() -> None:
+            rec.add_frame()
+
+        # Wrap policy.get_actions so each policy step bumps the recorder.
+        orig_get = policy.get_actions
+
+        def wrapped(*a, **kw):
+            fake_step_recorder()
+            return orig_get(*a, **kw)
+
+        policy.get_actions = wrapped  # type: ignore[method-assign]
+
+        result = runner.evaluate(
+            "alice",
+            policy,
+            n_episodes=3,
+            max_steps=4,
+            control_frequency=50,
+        )
+
+        assert result["status"] == "success"
+
+        # The fix: save_episode must fire exactly once per evaluate iteration.
+        assert rec.episode_count == 3, (
+            f"Expected 3 episode boundaries, got {rec.episode_count}. "
+            f"Save calls: {rec.save_calls}"
+        )
+        assert len(rec.save_calls) == 3
+        # Each boundary must have flushed some frames (not the empty-buffer
+        # short-circuit path).
+        for call in rec.save_calls:
+            assert call["frames"] >= 1, f"empty-buffer save: {call}"
+
+    def test_finalize_helper_no_op_without_recorder(self, sim_with_robot):
+        """No recorder attached → helper must silently no-op (eval-only path)."""
+        # No recorder injected.
+        assert sim_with_robot._world._backend_state.get("dataset_recorder") is None
+
+        runner = PolicyRunner(sim_with_robot)
+        # Should not raise.
+        runner._finalize_recorder_episode()
+
+    def test_finalize_helper_skips_empty_buffer(self, sim_with_robot):
+        """Empty recorder buffer → helper must NOT call save_episode.
+
+        LeRobot raises on save_episode with zero frames. The helper guards
+        with ``episode_frame_count <= 0`` so degenerate rollouts that wrote
+        nothing don't trip an error.
+        """
+        rec = _attach_recorder(sim_with_robot)
+        # episode_frame_count starts at 0 — never wrote a frame this ep.
+        assert rec.episode_frame_count == 0
+
+        runner = PolicyRunner(sim_with_robot)
+        runner._finalize_recorder_episode()
+
+        assert rec.episode_count == 0, "save_episode fired on empty buffer"
+        assert rec.save_calls == []
+
+    def test_finalize_helper_calls_save_when_buffer_nonempty(self, sim_with_robot):
+        rec = _attach_recorder(sim_with_robot)
+        rec.add_frame()
+        rec.add_frame()
+        rec.add_frame()
+        assert rec.episode_frame_count == 3
+
+        runner = PolicyRunner(sim_with_robot)
+        runner._finalize_recorder_episode()
+
+        assert rec.episode_count == 1
+        assert rec.save_calls == [{"ep": 1, "frames": 3}]
+        # After save, buffer is reset.
+        assert rec.episode_frame_count == 0
+
+    def test_finalize_helper_tolerates_save_exception(self, sim_with_robot):
+        """Recorder.save_episode raising must not abort the eval.
+
+        Eval is the dominant use case; recording is opportunistic. Log and
+        continue — matches the existing on_frame failure handling pattern.
+        """
+        rec = _attach_recorder(sim_with_robot)
+        rec.episode_frame_count = 5  # non-empty buffer
+
+        def boom() -> dict:
+            raise RuntimeError("simulated lerobot crash")
+
+        rec.save_episode = boom  # type: ignore[method-assign]
+
+        runner = PolicyRunner(sim_with_robot)
+        # Must not raise.
+        runner._finalize_recorder_episode()

--- a/tests/simulation/test_policy_runner_recorder_episode_boundary.py
+++ b/tests/simulation/test_policy_runner_recorder_episode_boundary.py
@@ -131,8 +131,7 @@ class TestRecorderEpisodeBoundary:
 
         # The fix: save_episode must fire exactly once per evaluate iteration.
         assert rec.episode_count == 3, (
-            f"Expected 3 episode boundaries, got {rec.episode_count}. "
-            f"Save calls: {rec.save_calls}"
+            f"Expected 3 episode boundaries, got {rec.episode_count}. Save calls: {rec.save_calls}"
         )
         assert len(rec.save_calls) == 3
         # Each boundary must have flushed some frames (not the empty-buffer


### PR DESCRIPTION
Closes #708 — silent episode collapse in policy_runner.evaluate / _evaluate_with_spec.

## Root cause

`PolicyRunner.evaluate()` (line 797) and `PolicyRunner._evaluate_with_spec()` (line 939) both iterate `for ep in range(n_episodes):` but **neither called `recorder.save_episode()` between iterations**. The recorder kept a single open LeRobot episode buffer; `add_frame` (driven by the sim step hook) appended to it; `stop_recording` finalised one giant episode at the end.

**Effect**: a 20-episode × 60-step rollout produced a parquet dataset with `total_episodes=1` and 1140 frames, but the eval status text reported *"Episodes: 20"* because the runner's own bookkeeping counted iterations. Runs were marked status=OK and shipped to HuggingFace with collapsed data. **47/47 historical molmoact-e2e-2026-06-25 runs are affected; 16 were falsely marked OK** ([forensic audit](https://github.com/strands-labs/robots/issues/708)).

## Fix

### 1. `policy_runner.py` — `_finalize_recorder_episode()` helper

Reads the recorder out of `self.sim._world._backend_state`, no-ops when absent or when the buffer is empty (degenerate-policy path), and tolerates `save_episode` exceptions (eval is the dominant use case; recording is opportunistic). Wired into both eval loops at the end of the per-episode body, after `results.append(...)`.

### 2. `recording.py::stop_recording` — parquet-truth gate

Post-finalize, compare `recorder.episode_count` against `dataset.meta.total_episodes`. If they disagree:
- log a warning
- trust the parquet (per Law-7 in `AGENTS.md`: parquet num_rows > meta/info.json > markdown)
- surface both values in the returned text + JSON payload (`episode_count_mismatch: bool`, `parquet_episode_count: int`) so CI / audit tools can detect silent regressions

## Tests

New regression file: `tests/simulation/test_policy_runner_recorder_episode_boundary.py` (5 tests, all green):
- **Integration**: 3-episode `evaluate()` with a stub recorder records exactly 3 `save_episode` calls, not 1.
- **Unit**: helper no-ops without a recorder, skips empty buffer (LeRobot raises on `save_episode` with zero frames), fires on non-empty buffer, tolerates `save_episode` raising.

```
tests/simulation/test_policy_runner_behaviour.py
tests/simulation/test_policy_runner_paths.py
tests/simulation/test_policy_runner_recorder_episode_boundary.py
tests/simulation/mujoco/test_stop_recording_finalize.py
```
**65/65 green.**

## Lint

`ruff check` + `ruff format --check` + `mypy` passes for all changed files.

## Diff stat

```
strands_robots/simulation/mujoco/recording.py      |  64 ++++++-
strands_robots/simulation/policy_runner.py         |  55 ++++++
tests/.../test_policy_runner_recorder_episode...py | 200 +++++++++++++++++++++
3 files changed, 317 insertions(+), 2 deletions(-)
```

## Backward compatibility

- Public API unchanged.
- `stop_recording` still returns `{"status": "success", "content": [...]}`; the `content` list now has a 2nd `json` block carrying the gate result. Existing callers that read only `content[0].text` are unaffected; the text now includes a `[#708 gate]` annotation only when a mismatch is detected.
- Eval calls without an attached recorder (the common path) are unchanged — the helper no-ops.

## Follow-ups (separate PRs)

Outside this PR's scope but documented in #708:
- Add a `@tool run_policy_rollout(n_episodes, steps_per_episode, ...)` so the agent stops improvising rollout loops in English (root of the silent-collapse blast radius).
- Add a `strict=True` mode that raises `EpisodeCountMismatchError` from `stop_recording` instead of just logging.

---

## §13 Review rounds

| Round | Concern | Commit | Pin test |
|-------|---------|--------|----------|
| R1 | mypy attr-defined: `_world` access without None guard | `27fae3cd5ac8` | tests/simulation/test_policy_runner_recorder_episode_boundary.py |
