### PR TITLE
fix(lerobot_local): resolve_policy_class_by_name survives a broken policy-factory import

### DIFF
--- a/strands_robots/policies/lerobot_local/resolution.py
+++ b/strands_robots/policies/lerobot_local/resolution.py
@@ -385,7 +385,17 @@ def resolve_policy_class_by_name(policy_type: str) -> type[Any]:
         from lerobot.policies.factory import get_policy_class
 
         return get_policy_class(policy_type)
-    except (ImportError, AttributeError, RuntimeError):
+    except (ImportError, AttributeError, RuntimeError, TypeError):
+        # ``lerobot.policies.factory`` eagerly imports every optional policy
+        # config module (groot, ...).  A config that is malformed under the
+        # installed transformers - e.g. GR00TN15Config declares a
+        # ``field(init=False)`` without a default, which transformers 5.x
+        # (where PretrainedConfig is itself a dataclass) rejects with
+        # "non-default argument 'backbone_cfg' follows default argument
+        # 'problem_type'" - raises TypeError at import time, not ImportError.
+        # That is still just "this resolution strategy is unavailable", so
+        # fall through to the remaining strategies and the clean ImportError
+        # below rather than leaking an unrelated TypeError to the caller.
         pass
 
     # Strategy 4: PreTrainedPolicy - only if it's NOT abstract

--- a/tests/policies/lerobot_local/test_policy.py
+++ b/tests/policies/lerobot_local/test_policy.py
@@ -1010,6 +1010,36 @@ class TestPolicyResolution:
         with pytest.raises((ImportError, ValueError)):
             resolve_policy_class_by_name("nonexistent_policy_type_xyz")
 
+    def test_resolve_policy_class_by_name_degrades_when_factory_import_raises_typeerror(self, monkeypatch):
+        """A broken optional lerobot policy config must not leak a TypeError.
+
+        ``lerobot.policies.factory`` eagerly imports every optional policy
+        config module. Under transformers 5.x (where ``PretrainedConfig`` is a
+        dataclass) a config such as ``GR00TN15Config`` - which declares a
+        ``field(init=False)`` without a default - fails to build at import
+        time with ``TypeError: non-default argument 'backbone_cfg' follows
+        default argument 'problem_type'``. ``resolve_policy_class_by_name``
+        must treat that strategy as unavailable and surface a clean
+        ``ImportError``, never the raw ``TypeError``.
+        """
+        import sys
+
+        lerobot_stub = types.ModuleType("lerobot")
+        lerobot_stub.__path__ = []  # type: ignore[attr-defined]
+        policies_stub = types.ModuleType("lerobot.policies")
+        policies_stub.__path__ = []  # type: ignore[attr-defined]
+
+        class _BrokenFactory(types.ModuleType):
+            def __getattr__(self, name):
+                raise TypeError("non-default argument 'backbone_cfg' follows default argument 'problem_type'")
+
+        monkeypatch.setitem(sys.modules, "lerobot", lerobot_stub)
+        monkeypatch.setitem(sys.modules, "lerobot.policies", policies_stub)
+        monkeypatch.setitem(sys.modules, "lerobot.policies.factory", _BrokenFactory("lerobot.policies.factory"))
+
+        with pytest.raises(ImportError):
+            resolve_policy_class_by_name("nonexistent_policy_type_xyz")
+
     def test_resolve_from_hub_raises_without_type(self):
 
         with pytest.raises((ValueError, ImportError, Exception)):


### PR DESCRIPTION
## Problem

`resolve_policy_class_by_name` (Strategy 3) imports `lerobot.policies.factory` to use the legacy `get_policy_class`. That module eagerly imports every optional policy config module (groot, ...). Under transformers 5.x - where `PretrainedConfig` is itself a dataclass - `GR00TN15Config` (which declares a `field(init=False)` without a default) fails to build at import time and raises:

```
TypeError: non-default argument 'backbone_cfg' follows default argument 'problem_type'
```

The resolver only caught `(ImportError, AttributeError, RuntimeError)`, so this `TypeError` escaped Strategy 3 and crashed resolution of *any* policy type with an unrelated exception, instead of degrading to the documented clean `ImportError`. The function is explicitly designed to tolerate a broken/heavy groot import chain (see `_ensure_lerobot_policies_importable`) - the except tuple was simply missing the exception class that a malformed config dataclass raises.

## Change

Broaden the Strategy 3 except clause to include `TypeError` and fall through to the remaining strategies, ending in the clean `ImportError` the docstring promises. One-line behavior change plus an explanatory comment.

## Tests

Added `test_resolve_policy_class_by_name_degrades_when_factory_import_raises_typeerror`: it stubs a broken `lerobot.policies.factory` whose attribute access raises the same `TypeError`, and asserts the resolver surfaces `ImportError`, never the raw `TypeError`. The test is deterministic (no real lerobot/transformers needed) - it **fails on pre-fix code and passes after**. The pre-existing `test_resolve_policy_class_by_name_raises_for_unknown` also goes from failing to passing in environments running transformers 5.x.

Full suite green locally: 7481 passed, 88 skipped (`MUJOCO_GL=egl`), ruff + mypy clean.