### PR TITLE
test(sim): cover MuJoCo interactive viewer open/close lifecycle

### DIFF
--- a/tests/simulation/mujoco/test_simulation.py
+++ b/tests/simulation/mujoco/test_simulation.py
@@ -19,6 +19,7 @@ import pytest
 
 mj = pytest.importorskip("mujoco")
 
+from strands_robots.simulation.mujoco import backend as backend_mod  # noqa: E402
 from strands_robots.simulation.mujoco.backend import _can_render  # noqa: E402
 
 requires_gl = pytest.mark.skipif(
@@ -850,7 +851,6 @@ class TestViewer:
     def test_open_viewer_reports_when_mujoco_viewer_unavailable(self, sim_with_world, monkeypatch):
         """With a world but no importable ``mujoco.viewer`` backend, open_viewer
         returns an actionable error instead of raising."""
-        import strands_robots.simulation.mujoco.backend as backend_mod
 
         monkeypatch.setattr(backend_mod, "_mujoco_viewer", None)
         result = sim_with_world.open_viewer()
@@ -860,7 +860,6 @@ class TestViewer:
     def test_open_viewer_launches_passive_and_close_releases_handle(self, sim_with_world, monkeypatch):
         """open_viewer launches a passive viewer on the live model/data and keeps
         the handle; close_viewer then closes that handle and clears it."""
-        import strands_robots.simulation.mujoco.backend as backend_mod
 
         launched: dict[str, object] = {}
 
@@ -898,7 +897,6 @@ class TestViewer:
     def test_open_viewer_does_not_relaunch_when_already_open(self, sim_with_world, monkeypatch):
         """A second open_viewer call reports the existing viewer rather than
         launching a second one (which would leak the first handle)."""
-        import strands_robots.simulation.mujoco.backend as backend_mod
 
         launches = {"n": 0}
 
@@ -919,7 +917,6 @@ class TestViewer:
     def test_open_viewer_surfaces_launch_failure_without_retaining_handle(self, sim_with_world, monkeypatch):
         """When launch_passive raises (e.g. no display), open_viewer returns a
         structured error and leaves no half-open handle behind."""
-        import strands_robots.simulation.mujoco.backend as backend_mod
 
         class _FakeViewer:
             @staticmethod
@@ -936,7 +933,6 @@ class TestViewer:
     def test_close_viewer_swallows_handle_close_error(self, sim_with_world, monkeypatch):
         """close_viewer must not propagate an exception raised by handle.close();
         the handle is cleared regardless so the sim is never wedged open."""
-        import strands_robots.simulation.mujoco.backend as backend_mod
 
         class _BadHandle:
             def close(self) -> None:

--- a/tests/simulation/mujoco/test_simulation.py
+++ b/tests/simulation/mujoco/test_simulation.py
@@ -847,6 +847,113 @@ class TestViewer:
         result = sim.close_viewer()
         assert result["status"] == "success"
 
+    def test_open_viewer_reports_when_mujoco_viewer_unavailable(self, sim_with_world, monkeypatch):
+        """With a world but no importable ``mujoco.viewer`` backend, open_viewer
+        returns an actionable error instead of raising."""
+        import strands_robots.simulation.mujoco.backend as backend_mod
+
+        monkeypatch.setattr(backend_mod, "_mujoco_viewer", None)
+        result = sim_with_world.open_viewer()
+        assert result["status"] == "error"
+        assert "viewer not available" in result["content"][0]["text"].lower()
+
+    def test_open_viewer_launches_passive_and_close_releases_handle(self, sim_with_world, monkeypatch):
+        """open_viewer launches a passive viewer on the live model/data and keeps
+        the handle; close_viewer then closes that handle and clears it."""
+        import strands_robots.simulation.mujoco.backend as backend_mod
+
+        launched: dict[str, object] = {}
+
+        class _FakeHandle:
+            def __init__(self) -> None:
+                self.closed = False
+
+            def close(self) -> None:
+                self.closed = True
+
+        class _FakeViewer:
+            @staticmethod
+            def launch_passive(model, data):
+                launched["model"] = model
+                launched["data"] = data
+                return _FakeHandle()
+
+        monkeypatch.setattr(backend_mod, "_mujoco_viewer", _FakeViewer)
+
+        result = sim_with_world.open_viewer()
+        assert result["status"] == "success"
+        assert "viewer opened" in result["content"][0]["text"].lower()
+        # Launched against the live world's model/data, not copies.
+        assert launched["model"] is sim_with_world._world._model
+        assert launched["data"] is sim_with_world._world._data
+
+        handle = sim_with_world._viewer_handle
+        assert handle is not None
+
+        close_result = sim_with_world.close_viewer()
+        assert close_result["status"] == "success"
+        assert handle.closed is True
+        assert sim_with_world._viewer_handle is None
+
+    def test_open_viewer_does_not_relaunch_when_already_open(self, sim_with_world, monkeypatch):
+        """A second open_viewer call reports the existing viewer rather than
+        launching a second one (which would leak the first handle)."""
+        import strands_robots.simulation.mujoco.backend as backend_mod
+
+        launches = {"n": 0}
+
+        class _FakeViewer:
+            @staticmethod
+            def launch_passive(model, data):
+                launches["n"] += 1
+                return object()
+
+        monkeypatch.setattr(backend_mod, "_mujoco_viewer", _FakeViewer)
+
+        assert sim_with_world.open_viewer()["status"] == "success"
+        second = sim_with_world.open_viewer()
+        assert second["status"] == "success"
+        assert "already open" in second["content"][0]["text"].lower()
+        assert launches["n"] == 1
+
+    def test_open_viewer_surfaces_launch_failure_without_retaining_handle(self, sim_with_world, monkeypatch):
+        """When launch_passive raises (e.g. no display), open_viewer returns a
+        structured error and leaves no half-open handle behind."""
+        import strands_robots.simulation.mujoco.backend as backend_mod
+
+        class _FakeViewer:
+            @staticmethod
+            def launch_passive(model, data):
+                raise RuntimeError("no display available")
+
+        monkeypatch.setattr(backend_mod, "_mujoco_viewer", _FakeViewer)
+
+        result = sim_with_world.open_viewer()
+        assert result["status"] == "error"
+        assert "viewer failed" in result["content"][0]["text"].lower()
+        assert sim_with_world._viewer_handle is None
+
+    def test_close_viewer_swallows_handle_close_error(self, sim_with_world, monkeypatch):
+        """close_viewer must not propagate an exception raised by handle.close();
+        the handle is cleared regardless so the sim is never wedged open."""
+        import strands_robots.simulation.mujoco.backend as backend_mod
+
+        class _BadHandle:
+            def close(self) -> None:
+                raise RuntimeError("boom")
+
+        class _FakeViewer:
+            @staticmethod
+            def launch_passive(model, data):
+                return _BadHandle()
+
+        monkeypatch.setattr(backend_mod, "_mujoco_viewer", _FakeViewer)
+
+        assert sim_with_world.open_viewer()["status"] == "success"
+        result = sim_with_world.close_viewer()
+        assert result["status"] == "success"
+        assert sim_with_world._viewer_handle is None
+
 
 # Error Paths
 


### PR DESCRIPTION
## Problem

`Simulation.open_viewer` / `close_viewer` (`strands_robots/simulation/mujoco/simulation.py`) were only exercised for the no-world and no-handle cases (`test_open_viewer_no_world`, `test_close_viewer_noop`). The branches that actually drive the interactive-viewer lifecycle were untested:

- the `mujoco.viewer`-unavailable guard,
- the `launch_passive` success path (handle tracking),
- the already-open short-circuit,
- the `launch_passive` failure path,
- `close_viewer` closing and clearing a live handle (including swallowing a `handle.close()` error).

A regression in any of these would silently break (or wedge) interactive viewing without any test catching it.

## Change

Adds behavior tests to `TestViewer` that inject a fake `mujoco.viewer` backend via `monkeypatch` and assert the user-visible contract:

- `open_viewer` returns a structured error when `mujoco.viewer` is unavailable.
- `open_viewer` launches a passive viewer against the live world `model`/`data` and retains the handle; `close_viewer` then closes that handle and clears it.
- A second `open_viewer` reports the existing viewer and does not relaunch (no leaked first handle).
- A `launch_passive` failure returns `status=error` with no half-open handle left behind.
- `close_viewer` does not propagate an exception from `handle.close()` and clears the handle regardless, so the sim is never wedged open.

Test-only; no production code changes. The new tests are deterministic and headless-safe (no real GL/display), exercising the previously-uncovered lines `1761-1789`.

## Verification

```
MUJOCO_GL=egl python -m pytest tests/simulation/mujoco/test_simulation.py -q
144 passed
```

`ruff check` and `ruff format --check` clean on the changed file. The viewer-lifecycle lines in `simulation.py` move from partially-covered (open/close branches missing) to fully covered.

---

## Round 2 changelog

Addressed CodeQL review feedback (dual-import findings 524-528): the test module imported `strands_robots.simulation.mujoco.backend` with both `from ... import _can_render` at module level and five in-function `import ... as backend_mod` statements, which CodeQL flagged as mixing `import` and `import from` for the same module.

Fix: hoisted a single module-level `from strands_robots.simulation.mujoco import backend as backend_mod` and removed the five local re-imports. All references now use from-style imports; the dual-import is resolved with zero behavioral change. `TestViewer` (7 tests) still passes and `ruff check` is clean.