### PR TITLE
fix(rtc): make inference-delay deterministic via caller-supplied step count

### DIFF
--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -283,6 +283,31 @@ behind, so the benefit is largest at real-time pacing (`fast_mode=False`) with
 multi-step chunks; with `fast_mode=True` and near-instant physics there is
 little execution window to overlap.
 
+### Deterministic inference delay
+
+RTC has to know how many control steps the robot executed *while inference was
+running* - that offset is where it slices the next chunk so the seam lines up.
+Estimating it from wall-clock latency is non-reproducible: the measured latency
+warms up over the first few inferences of an episode and jitters run-to-run, so
+two fixed-seed episodes drift apart at the seam (the "seeds fixed but trajectory
+varies" symptom in multi-episode evals).
+
+`PolicyRunner` instead tells the policy the **exact** step count via
+`policy.set_rtc_observed_delay(steps)` immediately before each query:
+
+- Synchronous loop (`async_rtc=False`): the world is paused during inference, so
+  exactly `0` steps elapse.
+- Async pipeline (`async_rtc=True`): the prefetched chunk first applies after the
+  remaining steps of the chunk currently executing drain - a known integer,
+  independent of how long inference actually takes (a slow inference just stalls
+  the loop; the arm does not advance past the chunk end while it waits).
+
+So an eval driven by the runner is bit-reproducible across episodes regardless of
+machine load. When a policy is driven directly without a runner (e.g. on async
+real hardware where the arm genuinely keeps moving during inference), leave the
+override unset (`None`) and the policy falls back to the wall-clock p95 estimate,
+which is the right proxy there.
+
 ## See also
 
 - [MolmoAct2 (SO-100/101)](molmoact2.md) - action contract, units, and motion diagnostics

--- a/strands_robots/policies/base.py
+++ b/strands_robots/policies/base.py
@@ -80,6 +80,43 @@ class Policy(ABC):
             raise ValueError(f"control_frequency must be positive, got {hz}")
         self.control_frequency = float(hz)
 
+    #: Number of control steps the executing loop runs between issuing an
+    #: inference request and applying the FIRST action it returns. The runtime
+    #: (e.g. ``PolicyRunner``) sets this via :meth:`set_rtc_observed_delay`
+    #: immediately before each ``get_actions`` call so latency-sensitive
+    #: providers (Real-Time Chunking) can slice the leftover chunk by the EXACT
+    #: number of steps that elapsed rather than estimating it from wall-clock
+    #: latency. The estimate is non-reproducible (it warms up within an episode
+    #: and varies run-to-run), which silently perturbs otherwise-identical
+    #: seeded episodes; a counted integer is deterministic. ``None`` means the
+    #: runtime did not supply a count, so providers fall back to their
+    #: wall-clock estimate (appropriate for true-async hardware driven without a
+    #: runner, where the robot really does move during inference).
+    rtc_observed_delay_steps: int | None = None
+
+    def set_rtc_observed_delay(self, steps: int | None) -> None:
+        """Tell the policy how many control steps elapse during inference.
+
+        The runtime that drives the policy calls this before each
+        ``get_actions`` so Real-Time Chunking providers can compute the
+        chunk-seam offset deterministically instead of deriving it from
+        wall-clock latency. In a synchronous eval loop the world is paused
+        during inference, so exactly ``0`` steps elapse; in the async overlap
+        pipeline the count is the number of still-pending steps of the chunk
+        being executed. Either way it is a known integer, not a measurement.
+
+        Args:
+            steps: Non-negative control-step count, or ``None`` to clear the
+                override and let the provider fall back to its wall-clock
+                estimate.
+
+        Raises:
+            ValueError: If ``steps`` is negative.
+        """
+        if steps is not None and steps < 0:
+            raise ValueError(f"rtc_observed_delay_steps must be >= 0, got {steps}")
+        self.rtc_observed_delay_steps = None if steps is None else int(steps)
+
     @abstractmethod
     async def get_actions(
         self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -292,6 +292,7 @@ class LerobotLocalPolicy(Policy):
         self._rtc_latency_history.clear()
         self._rtc_last_inference_time = 0.0
         self._rtc_last_log_time = 0.0
+        self.rtc_observed_delay_steps = None
         # Re-arm action diagnostics for the next episode.
         self._zero_action_monitor.reset()
         self._action_dim_warned = False
@@ -970,25 +971,39 @@ class LerobotLocalPolicy(Policy):
         if action_chunk.dim() == 3 and action_chunk.shape[0] == 1:
             action_chunk = action_chunk.squeeze(0)
 
-        # Estimate inference delay - how many steps were consumed while
-        # computing. The delay is (p95 latency * control_frequency), so it
-        # MUST use the loop's real control rate; assuming a fixed rate makes
-        # the chunk-seam blend wrong at every other frequency. The runtime
-        # (PolicyRunner) calls set_control_frequency() before the loop.
-        fps = self.control_frequency
-        if fps is None:
-            if not self._rtc_freq_warned:
-                logger.warning(
-                    "RTC: control_frequency unknown for '%s', falling back to "
-                    "%.0fHz - inference-delay estimation will be off at any other "
-                    "control rate. Call set_control_frequency(hz) before running "
-                    "(PolicyRunner does this automatically).",
-                    type(self._policy).__name__,
-                    _RTC_FALLBACK_FPS,
-                )
-                self._rtc_freq_warned = True
-            fps = _RTC_FALLBACK_FPS
-        inference_delay = self._estimate_inference_delay(fps=fps)
+        # Resolve how many control steps the executor ran while this inference
+        # was in flight - the offset that the chunk-seam blend slices by. Prefer
+        # the DETERMINISTIC count the runtime supplied (set_rtc_observed_delay):
+        # in a synchronous eval loop the world is paused during inference so
+        # exactly 0 steps elapse, and in the async overlap pipeline the count is
+        # a known integer. Deriving it from wall-clock p95 latency instead is
+        # non-reproducible - it warms up within an episode and varies run-to-run,
+        # so two otherwise-identical seeded episodes drift apart at the seam.
+        # Fall back to the wall-clock estimate only when no count was supplied
+        # (true-async hardware driven without a runner, where the arm really
+        # does keep moving during inference).
+        observed = self.rtc_observed_delay_steps
+        if observed is not None:
+            inference_delay = max(0, int(observed))
+        else:
+            # The delay is (p95 latency * control_frequency), so it MUST use the
+            # loop's real control rate; assuming a fixed rate makes the
+            # chunk-seam blend wrong at every other frequency. The runtime
+            # (PolicyRunner) calls set_control_frequency() before the loop.
+            fps = self.control_frequency
+            if fps is None:
+                if not self._rtc_freq_warned:
+                    logger.warning(
+                        "RTC: control_frequency unknown for '%s', falling back to "
+                        "%.0fHz - inference-delay estimation will be off at any other "
+                        "control rate. Call set_control_frequency(hz) before running "
+                        "(PolicyRunner does this automatically).",
+                        type(self._policy).__name__,
+                        _RTC_FALLBACK_FPS,
+                    )
+                    self._rtc_freq_warned = True
+                fps = _RTC_FALLBACK_FPS
+            inference_delay = self._estimate_inference_delay(fps=fps)
 
         # Store leftover for next RTC call (unconsumed portion of this chunk).
         # The consumer executes ``execution_horizon`` actions before re-querying

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -616,7 +616,7 @@ class PolicyRunner:
                 if not fast_mode:
                     time.sleep(action_sleep)
 
-            def _query_chunk(observation: dict[str, Any]) -> list[dict[str, Any]]:
+            def _query_chunk(observation: dict[str, Any], observed_delay: int = 0) -> list[dict[str, Any]]:
                 # Resolve ONE action chunk from the policy. Never truncate below
                 # the policy's own intended chunk size: a model trained for
                 # N-step open-loop replay (policy.actions_per_step == N) must
@@ -624,6 +624,18 @@ class PolicyRunner:
                 # action_horizon drops the tail of every chunk and forces an
                 # out-of-distribution re-query (see LerobotLocalPolicy
                 # auto-detect of config.n_action_steps).
+                #
+                # Tell the policy how many control steps elapse between this
+                # observation and the first application of the returned chunk so
+                # latency-sensitive providers (RTC) slice the chunk-seam by an
+                # EXACT integer instead of a non-reproducible wall-clock
+                # estimate. The synchronous loop pauses the world during
+                # inference (delay 0); the async pipeline supplies the count of
+                # still-pending steps of the chunk currently executing. The set
+                # and the get_actions call happen on the SAME thread (the worker
+                # for a prefetch, the main thread otherwise), and at most one
+                # inference is ever in flight, so this never races.
+                policy.set_rtc_observed_delay(observed_delay)
                 coro_or_result = policy.get_actions(observation, instruction, **_policy_kwargs)
                 actions = _resolve_coroutine(coro_or_result)
                 _chunk = resolve_chunk_length(policy, action_horizon)
@@ -685,7 +697,14 @@ class PolicyRunner:
                         # current chunk, on a fresh mid-chunk observation.
                         if prefetch is None and idx >= prefetch_trigger:
                             prefetch_obs = self.sim.get_observation(robot_name=robot_name, skip_images=_skip_images)
-                            prefetch = executor.submit(_query_chunk, prefetch_obs)
+                            # The prefetched chunk first applies after the
+                            # remaining steps of the current chunk drain - a
+                            # known integer, independent of how long inference
+                            # actually takes in wall-clock time (a slow inference
+                            # just stalls the loop; the robot does not advance
+                            # past the chunk end while waiting).
+                            observed_delay = max(0, len(cur_chunk) - prefetch_trigger)
+                            prefetch = executor.submit(_query_chunk, prefetch_obs, observed_delay)
 
                         _apply(cur_obs, cur_chunk[idx])
                         idx += 1

--- a/tests/policies/lerobot_local/test_policy.py
+++ b/tests/policies/lerobot_local/test_policy.py
@@ -1393,6 +1393,104 @@ class TestRTCDelayEstimation:
         assert delay < 5
 
 
+class TestRTCDeterministicDelay:
+    """RTC inference delay is the caller-supplied step count, not a wall-clock guess.
+
+    Regression for the fixed-seed trajectory drift reported in multi-episode
+    evals: when the inference delay was derived from wall-clock p95 latency it
+    warmed up within an episode and varied run-to-run, so two otherwise-identical
+    seeded episodes sliced the chunk seam differently. The runtime now supplies
+    the exact number of control steps that elapse during inference
+    (``set_rtc_observed_delay``); the policy must use that integer verbatim and
+    ignore the latency history entirely.
+    """
+
+    @staticmethod
+    def _chunk_policy():
+        policy = _make_policy()
+        policy._rtc_enabled = True
+        policy._rtc_execution_horizon = 10
+        policy._rtc_prev_chunk = None
+        policy.actions_per_step = 1
+        mock_policy = MagicMock()
+        policy._policy = mock_policy
+        return policy, mock_policy
+
+    def test_observed_delay_overrides_wallclock_estimate(self):
+        """A supplied step count wins even when latency history implies a big delay."""
+        policy, mock_policy = self._chunk_policy()
+        # Deterministic chunk so we can assert exactly which row is returned.
+        chunk = torch.arange(20 * 6, dtype=torch.float32).reshape(1, 20, 6)
+        mock_policy.predict_action_chunk.return_value = chunk
+        # Poison the wall-clock path: 5s latency * 50Hz -> ~250 steps (clamps to 19).
+        policy.set_control_frequency(50.0)
+        policy._rtc_latency_history.extend([5.0] * 10)
+        # Runtime says exactly 2 control steps elapsed during inference.
+        policy.set_rtc_observed_delay(2)
+
+        result = policy._predict_with_rtc({})
+
+        squeezed = chunk.squeeze(0)
+        # usable_start == observed delay (2), NOT the wall-clock-implied 19.
+        assert torch.equal(result[0], squeezed[2])
+
+    def test_observed_delay_zero_executes_chunk_from_start(self):
+        """Synchronous loop (delay 0): the chunk is used from row 0, no skip."""
+        policy, mock_policy = self._chunk_policy()
+        chunk = torch.arange(20 * 6, dtype=torch.float32).reshape(1, 20, 6)
+        mock_policy.predict_action_chunk.return_value = chunk
+        policy.set_control_frequency(50.0)
+        policy._rtc_latency_history.extend([5.0] * 10)  # would imply a huge skip
+        policy.set_rtc_observed_delay(0)
+
+        result = policy._predict_with_rtc({})
+
+        assert torch.equal(result[0], chunk.squeeze(0)[0])
+
+    def test_reproducible_across_episodes_with_same_observed_delay(self):
+        """Same observed delay -> identical first action despite differing latency.
+
+        This is the fixed-seed drift the issue describes: only the latency
+        history differs between the two episodes (warm-up bleed), yet with the
+        deterministic delay the returned action is bit-identical.
+        """
+        chunk = torch.arange(20 * 6, dtype=torch.float32).reshape(1, 20, 6)
+
+        def run_episode(latencies):
+            policy, mock_policy = self._chunk_policy()
+            mock_policy.predict_action_chunk.return_value = chunk.clone()
+            policy.set_control_frequency(50.0)
+            policy._rtc_latency_history.extend(latencies)
+            policy.set_rtc_observed_delay(3)
+            return policy._predict_with_rtc({})
+
+        ep1 = run_episode([0.01] * 2)  # cold: short, sparse history
+        ep2 = run_episode([0.4] * 100)  # warm: long, saturated history
+        assert torch.equal(ep1[0], ep2[0])
+
+    def test_falls_back_to_wallclock_when_no_observed_delay(self):
+        """None observed delay preserves the wall-clock estimate (async hardware)."""
+        policy, mock_policy = self._chunk_policy()
+        chunk = torch.arange(20 * 6, dtype=torch.float32).reshape(1, 20, 6)
+        mock_policy.predict_action_chunk.return_value = chunk
+        policy.set_control_frequency(50.0)
+        policy._rtc_latency_history.extend([0.04] * 10)  # 0.04 * 50 = 2 steps
+        assert policy.rtc_observed_delay_steps is None
+
+        result = policy._predict_with_rtc({})
+
+        # Wall-clock estimate: p95(0.04) * 50 = 2 -> usable_start 2.
+        assert torch.equal(result[0], chunk.squeeze(0)[2])
+
+    def test_reset_clears_observed_delay(self):
+        policy = _make_policy()
+        policy._policy = MagicMock()
+        policy._processor_bridge = None
+        policy.set_rtc_observed_delay(4)
+        policy.reset()
+        assert policy.rtc_observed_delay_steps is None
+
+
 class TestRTCReset:
     """Tests for RTC state clearing on reset."""
 

--- a/tests/policies/test_base.py
+++ b/tests/policies/test_base.py
@@ -226,3 +226,50 @@ class TestControlFrequency:
         a.set_control_frequency(120.0)
         assert a.control_frequency == 120.0
         assert b.control_frequency is None
+
+
+class TestRTCObservedDelay:
+    """``Policy.set_rtc_observed_delay`` / ``rtc_observed_delay_steps`` contract.
+
+    The runtime supplies the EXACT number of control steps that elapse during
+    inference so latency-sensitive providers slice the chunk seam by a known
+    integer rather than a non-reproducible wall-clock estimate.
+    """
+
+    def test_default_observed_delay_is_none(self):
+        assert _IdentityPolicy().rtc_observed_delay_steps is None
+
+    def test_set_observed_delay_sets_attribute(self):
+        p = _IdentityPolicy()
+        p.set_rtc_observed_delay(3)
+        assert p.rtc_observed_delay_steps == 3
+
+    def test_set_observed_delay_zero_is_honoured_not_treated_as_none(self):
+        # 0 (synchronous loop: world paused during inference) is a real value,
+        # distinct from None (no count supplied -> wall-clock fallback).
+        p = _IdentityPolicy()
+        p.set_rtc_observed_delay(0)
+        assert p.rtc_observed_delay_steps == 0
+
+    def test_set_observed_delay_none_clears_override(self):
+        p = _IdentityPolicy()
+        p.set_rtc_observed_delay(5)
+        p.set_rtc_observed_delay(None)
+        assert p.rtc_observed_delay_steps is None
+
+    def test_set_observed_delay_coerces_to_int(self):
+        p = _IdentityPolicy()
+        p.set_rtc_observed_delay(True)  # bool is an int subclass
+        assert p.rtc_observed_delay_steps == 1
+        assert isinstance(p.rtc_observed_delay_steps, int)
+
+    def test_set_observed_delay_rejects_negative(self):
+        p = _IdentityPolicy()
+        with pytest.raises(ValueError, match="rtc_observed_delay_steps"):
+            p.set_rtc_observed_delay(-1)
+
+    def test_observed_delay_is_per_instance(self):
+        a, b = _IdentityPolicy(), _IdentityPolicy()
+        a.set_rtc_observed_delay(7)
+        assert a.rtc_observed_delay_steps == 7
+        assert b.rtc_observed_delay_steps is None

--- a/tests/simulation/test_policy_runner_async_rtc.py
+++ b/tests/simulation/test_policy_runner_async_rtc.py
@@ -111,6 +111,7 @@ class _ChunkPolicy(Policy):
         self._infer_sleep = infer_sleep
         self.robot_state_keys: list[str] = []
         self.infer_starts: list[int] = []
+        self.observed_delays: list[int | None] = []
         self._lock = threading.Lock()
 
     @property
@@ -129,6 +130,9 @@ class _ChunkPolicy(Policy):
     ) -> list[dict[str, Any]]:
         with self._lock:
             self.infer_starts.append(self._sim.send_count)
+            # The runtime sets the deterministic inference-delay step count just
+            # before each call (see PolicyRunner._query_chunk).
+            self.observed_delays.append(self.rtc_observed_delay_steps)
         if self._infer_sleep:
             time.sleep(self._infer_sleep)
         keys = self.robot_state_keys or ["j0", "j1", "j2"]
@@ -209,3 +213,26 @@ def test_async_rtc_defaults_to_false() -> None:
     """Back-compat: async_rtc is opt-in on both PolicyRunner.run and run_policy."""
     assert inspect.signature(PolicyRunner.run).parameters["async_rtc"].default is False
     assert inspect.signature(SimEngine.run_policy).parameters["async_rtc"].default is False
+
+
+def test_sync_loop_supplies_zero_observed_delay() -> None:
+    """Synchronous loop: the world is paused during inference, so the runtime
+    tells the policy exactly 0 control steps elapsed (not a wall-clock guess)."""
+    _, policy, _ = _run(async_rtc=False)
+    assert policy.observed_delays, "policy was never queried"
+    assert all(d == 0 for d in policy.observed_delays), policy.observed_delays
+
+
+def test_async_rtc_supplies_deterministic_observed_delay() -> None:
+    """Async pipeline: prefetched chunks carry the EXACT count of still-pending
+    steps (len(chunk) - prefetch_trigger), a known integer independent of how
+    long inference actually took. The cold-start and short-chunk re-queries are
+    synchronous (delay 0)."""
+    _, policy, _ = _run(async_rtc=True)
+    assert policy.observed_delays, "policy was never queried"
+    # prefetch_trigger = max(1, _CHUNK // 2); pending = _CHUNK - prefetch_trigger.
+    expected_prefetch_delay = _CHUNK - max(1, _CHUNK // 2)
+    assert all(d in (0, expected_prefetch_delay) for d in policy.observed_delays), policy.observed_delays
+    # At least one prefetched (overlapped) query must carry the non-zero count -
+    # otherwise the async path silently degraded to synchronous re-queries.
+    assert any(d == expected_prefetch_delay for d in policy.observed_delays), policy.observed_delays


### PR DESCRIPTION
## Problem

Real-Time Chunking slices each new action chunk by the number of control steps the robot executed *while inference was running* - that offset is where the next chunk is taken so the seam lines up (`usable_start`, `prev_chunk_left_over`). In `LerobotLocalPolicy` that offset was derived from wall-clock p95 latency (`_estimate_inference_delay`).

Wall-clock latency is non-reproducible:

- it **warms up** over the first few inferences of an episode (the latency `deque` starts empty after `reset()`), and
- it **jitters** run-to-run with machine load.

So two fixed-seed episodes slice the chunk seam at different offsets and the trajectories drift apart - the "seeds fixed but trajectory varies" symptom seen in multi-episode evals and dataset recording. It manifests as "flakey but mostly works".

## Change

The executing loop already knows the exact step count, so it should supply it instead of the policy guessing:

- **Synchronous eval loop**: the world is paused during inference, so exactly `0` control steps elapse.
- **Async overlap pipeline** (`async_rtc=True`): the prefetched chunk first applies after the still-pending steps of the chunk currently draining - `len(chunk) - prefetch_trigger`, a known integer independent of how long inference actually takes (a slow inference just stalls the loop; the arm does not advance past the chunk end while it waits).

New contract:

- `Policy.set_rtc_observed_delay(steps)` / `rtc_observed_delay_steps` on the base `Policy` (parallel to `set_control_frequency`). Validates non-negative; `None` clears the override.
- `PolicyRunner._query_chunk` sets it before each `get_actions` call (set + query happen on the same thread, at most one inference in flight, so no race).
- `LerobotLocalPolicy._predict_with_rtc` uses the supplied count verbatim when present; falls back to the existing wall-clock p95 estimate only when it is `None` (a policy driven directly without a runner, e.g. async real hardware where the arm genuinely keeps moving during inference - there wall-clock is the right proxy).
- `reset()` clears the override so a stale value never leaks across episodes.

This also removes the residual fps-scaling sensitivity for runner-driven rollouts: when the count is supplied there is no `latency * fps` multiply at all.

## Visual proof

RTC chunk-seam offset across three fixed-seed episodes on a 50 Hz loop. Before, the offset jumps as the latency history warms up and the threshold is crossed at slightly different inferences per run; after, every episode is a flat, identical 0.

![RTC inference-delay determinism](https://github.com/cagataycali/robots/releases/download/rtc-determinism-artifact/rtc_determinism.png)

Measured cross-episode offset spread over 40 inferences x 3 seeds: wall-clock = up to 1 step of drift; deterministic = 0 (bit-identical).

## Tests

All fail on pre-fix code (contract absent), pass after:

- `tests/policies/test_base.py::TestRTCObservedDelay` - setter/validation/clear/per-instance contract.
- `tests/policies/lerobot_local/test_policy.py::TestRTCDeterministicDelay` - the supplied count wins over a poisoned latency history; delay 0 executes from chunk row 0; two episodes with differing latency histories return a bit-identical first action; `None` preserves the wall-clock fallback; `reset()` clears the override.
- `tests/simulation/test_policy_runner_async_rtc.py` - the runner supplies `0` in the synchronous loop and the deterministic `len(chunk) - prefetch_trigger` count for prefetched async queries.

Green locally: `ruff check`/`ruff format --check`/`mypy strands_robots tests tests_integ` clean; affected pytest suites pass (185 in the policy+runner RTC scope; rollout in MuJoCo headless for the artifact).

Docs: `docs/policies/lerobot-local.md` gains a "Deterministic inference delay" subsection.