### PR TITLE
test(lerobot_local): cover state-vector dim adaptation in _build_batch_from_strands_format

### DIFF
--- a/tests/policies/lerobot_local/test_policy.py
+++ b/tests/policies/lerobot_local/test_policy.py
@@ -770,6 +770,32 @@ class TestBuildBatchFromStrandsFormat:
         np.testing.assert_allclose(state[:2], [1.0, 2.0], atol=1e-5)
         np.testing.assert_allclose(state[2:], [0.0, 0.0], atol=1e-5)
 
+    def test_state_truncated_to_expected_dim(self):
+        """A robot exposing MORE joints than the model was trained on truncates
+        the leading values to the model's expected state dim (not raise).
+
+        Mirrors the documented aloha-16-joints / ACT-expects-14 case: the policy
+        adapts the observation rather than crashing the rollout.
+        """
+        policy = _make_loaded_policy(state_dim=2, include_images=False)
+        policy.set_robot_state_keys(["a", "b", "c", "d"])
+        observation = {"a": 1.0, "b": 2.0, "c": 3.0, "d": 4.0}
+        batch = policy._build_batch_from_strands_format(observation, {})
+        state = batch["observation.state"][0].numpy()
+        assert len(state) == 2
+        np.testing.assert_allclose(state, [1.0, 2.0], atol=1e-5)
+
+    def test_zero_dim_ndarray_state_value(self):
+        """A joint value supplied as a 0-d numpy array is coerced to a scalar
+        float and packed into the state tensor (not silently dropped)."""
+        policy = _make_loaded_policy(state_dim=2, include_images=False)
+        policy.set_robot_state_keys(["a", "b"])
+        observation = {"a": np.array(1.5), "b": np.array(2.5)}
+        batch = policy._build_batch_from_strands_format(observation, {})
+        state = batch["observation.state"][0].numpy()
+        assert len(state) == 2
+        np.testing.assert_allclose(state, [1.5, 2.5], atol=1e-5)
+
     def test_empty_state_keys_raises(self):
         """Empty robot_state_keys should raise ValueError."""
         policy = _make_loaded_policy()


### PR DESCRIPTION
## What

Adds two focused tests pinning previously-uncovered branches of `LerobotLocalPolicy._build_batch_from_strands_format`, the path that packs a strands-robots native observation (individual joint keys) into LeRobot's `observation.state` tensor.

## Why

The method auto-adapts the assembled state vector to the model's declared input dim so a robot whose joint count differs from the policy's training embodiment still rolls out instead of crashing. Two branches of that contract were unpinned:

- **Truncation (over-supplied joints).** When the robot exposes more joints than the model was trained on (the documented aloha-16-joints vs ACT-expects-14 case), the leading values are truncated to `expected_dim`. Only the pad-when-fewer and exact-match cases had tests; the truncation branch had none, so a regression turning truncation into a raise or an unclipped tensor would have passed CI.
- **0-d numpy array joint value.** A joint value supplied as `np.array(1.5)` (ndim == 0) is coerced to a scalar float and packed; without coverage a regression dropping it would silently shrink the state vector.

## Tests

`tests/policies/lerobot_local/test_policy.py::TestBuildBatchFromStrandsFormat`:

- `test_state_truncated_to_expected_dim` - 4 joint keys, model state dim 2 -> state truncated to the first 2 values.
- `test_zero_dim_ndarray_state_value` - 0-d ndarray joint values packed as scalars.

Both are GL-free and deterministic (mocked model features via the existing `_make_loaded_policy` helper). The truncation branch and the 0-d ndarray coercion go from uncovered to covered; the full file (130 tests) passes. `ruff check` / `ruff format --check` clean; `mypy strands_robots tests tests_integ` reports no issues.

Test-only change; no library behavior is modified.