### PR TITLE
fix(eval): legacy success_fn path drops action chunk + checks success on stale obs

### DIFF
--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -1029,22 +1029,50 @@ class PolicyRunner:
             success = False
             steps = 0
 
-            for _ in range(max_steps):
+            while steps < max_steps:
                 observation = self.sim.get_observation(robot_name=robot_name, skip_images=_skip_images)
                 coro_or_result = policy.get_actions(observation, instruction)
                 actions = _resolve_coroutine(coro_or_result)
 
-                if actions:
-                    self.sim.send_action(actions[0], robot_name=robot_name, n_substeps=n_substeps)
-                else:
+                if not actions:
                     # Policy returned nothing - still advance one physics step
                     # so episodes don't hang on degenerate policies.
                     self.sim.step(n_steps=1)
+                    steps += 1
+                    # Check success on the live post-action sim state, same as
+                    # the spec path (see below).
+                    fresh_obs = self.sim.get_observation(robot_name=robot_name, skip_images=_skip_images)
+                    if resolved_check is not None and resolved_check(fresh_obs):
+                        success = True
+                        break
+                    continue
 
-                steps += 1
-
-                if resolved_check is not None and resolved_check(observation):
-                    success = True
+                # Consume the full action chunk before re-querying, identical to
+                # run() and the spec eval path. ``resolve_chunk_length`` applies
+                # the single re-query rule (``execution_horizon`` vs
+                # ``action_horizon``, RTC-aware). The earlier code applied only
+                # ``actions[0]`` and re-queried every step: that silently ignored
+                # ``action_horizon`` and forced an out-of-distribution control
+                # regime for chunk-predicting VLA policies (SmolVLA, GR00T, ...),
+                # diverging from both ``run()`` and ``evaluate_benchmark``.
+                _chunk = resolve_chunk_length(policy, action_horizon)
+                stop_episode = False
+                for action_dict in actions[:_chunk]:
+                    if steps >= max_steps:
+                        break
+                    self.sim.send_action(action_dict, robot_name=robot_name, n_substeps=n_substeps)
+                    steps += 1
+                    # Check success against the FRESH post-action observation,
+                    # matching the spec path (``spec.is_success`` runs against
+                    # the live post-action sim state). Checking the stale
+                    # pre-action observation detected success one step late and
+                    # missed success that lands on the final step entirely.
+                    fresh_obs = self.sim.get_observation(robot_name=robot_name, skip_images=_skip_images)
+                    if resolved_check is not None and resolved_check(fresh_obs):
+                        success = True
+                        stop_episode = True
+                        break
+                if stop_episode:
                     break
 
             results.append({"episode": ep, "steps": steps, "success": success})

--- a/tests/simulation/test_eval_legacy_chunk_and_success_timing.py
+++ b/tests/simulation/test_eval_legacy_chunk_and_success_timing.py
@@ -1,0 +1,187 @@
+"""Legacy ``PolicyRunner.evaluate(success_fn=...)`` chunk + success-timing.
+
+Regression for the eval-success-rate corruption on the legacy ``success_fn``
+path of :meth:`PolicyRunner.evaluate`:
+
+* **Chunk consumption** - the legacy path used to apply only ``actions[0]``
+  and re-query the policy every step, silently ignoring ``action_horizon``.
+  A chunk-predicting policy must instead have its full chunk consumed
+  (``resolve_chunk_length`` actions) before the next ``get_actions`` call,
+  identical to ``run()`` and the ``spec=`` benchmark path.
+* **Post-action success check** - the legacy path used to evaluate the
+  success predicate against the STALE pre-action observation, so success was
+  detected one step late and success that lands on the final step was missed
+  entirely (under-reporting ``success_rate``). The predicate must run against
+  the live post-action observation, matching ``spec.is_success``.
+* **Path parity** - the legacy ``success_fn`` path and the ``spec=`` benchmark
+  path must agree on ``success_rate`` for a deterministic policy + predicate.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("MUJOCO_GL", "glfw")
+
+from strands_robots.policies.mock import MockPolicy
+from strands_robots.simulation.benchmark import BenchmarkProtocol, StepInfo
+from strands_robots.simulation.policy_runner import PolicyRunner
+from tests.simulation.test_policy_runner import FakeSim
+
+
+class _CountingSim(FakeSim):
+    """FakeSim whose integer ``pos`` advances by one per applied action.
+
+    ``get_observation`` exposes ``pos`` so a legacy ``success_fn`` and a
+    benchmark ``is_success`` can key off the exact same monotone state.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.pos = 0
+
+    def reset(self):
+        self.pos = 0
+        return super().reset()
+
+    def send_action(self, action, robot_name=None, n_substeps=1):
+        super().send_action(action, robot_name=robot_name, n_substeps=n_substeps)
+        self.pos += 1
+
+    def step(self, n_steps: int = 1):
+        # Degenerate-policy path advances physics; keep pos in lockstep.
+        self.pos += n_steps
+        return super().step(n_steps=n_steps)
+
+    def get_observation(self, robot_name=None, *, skip_images=False):
+        obs = super().get_observation(robot_name=robot_name, skip_images=skip_images)
+        obs["pos"] = self.pos
+        return obs
+
+
+class _ChunkPolicy(MockPolicy):
+    """Returns ``chunk_size`` actions per call; records ``get_actions`` count."""
+
+    def __init__(self, joint_names, chunk_size: int) -> None:
+        super().__init__()
+        self.set_robot_state_keys(list(joint_names))
+        self.actions_per_step = chunk_size
+        self._chunk_size = chunk_size
+        self.get_actions_calls = 0
+        self._joint_names = list(joint_names)
+
+    def get_actions_sync(self, observation_dict, instruction, **kwargs):
+        self.get_actions_calls += 1
+        return [{n: 0.0 for n in self._joint_names} for _ in range(self._chunk_size)]
+
+    async def get_actions(self, observation_dict, instruction, **kwargs):
+        return self.get_actions_sync(observation_dict, instruction, **kwargs)
+
+
+class _PosThresholdBenchmark(BenchmarkProtocol):
+    """Sparse-success spec: succeeds once ``sim.pos`` reaches ``threshold``."""
+
+    def __init__(self, threshold: int, max_steps: int) -> None:
+        self.threshold = threshold
+        self.max_steps = max_steps
+
+    @property
+    def supported_robots(self) -> list[str]:
+        return []  # any robot
+
+    @property
+    def default_robot(self) -> str:
+        return "fake_robot"
+
+    def on_step(self, sim, obs, action) -> StepInfo:
+        return StepInfo(reward=0.0, done=False)
+
+    def is_success(self, sim) -> bool:
+        return getattr(sim, "pos", 0) >= self.threshold
+
+
+def test_legacy_eval_consumes_full_chunk_before_requery():
+    """action_horizon=8, chunk=8, max_steps=24 -> 3 queries, 24 actions.
+
+    Pre-fix this was 24 queries / 24 actions (``actions[0]`` only, re-query
+    every step), so ``action_horizon`` had zero effect.
+    """
+    sim = _CountingSim()
+    policy = _ChunkPolicy(sim.robot_joint_names("fake_robot"), chunk_size=8)
+
+    result = PolicyRunner(sim).evaluate(
+        "fake_robot",
+        policy,
+        n_episodes=1,
+        max_steps=24,
+        action_horizon=8,
+        success_fn=lambda obs: False,  # never succeeds: full horizon runs
+    )
+
+    assert result["status"] == "success"
+    send_actions = [c for c in sim.calls if c[0] == "send_action"]
+    assert len(send_actions) == 24, f"expected 24 actions applied, got {len(send_actions)}"
+    assert policy.get_actions_calls == 3, (
+        f"expected 3 chunk queries (24/8), got {policy.get_actions_calls} - "
+        "the legacy path is re-querying instead of consuming the chunk"
+    )
+
+
+def test_legacy_eval_success_on_final_step_is_recorded():
+    """Predicate true exactly when the last action lands -> success=True.
+
+    Threshold == max_steps: success only becomes true on the post-action
+    observation of the final applied action. Pre-fix the loop exited without
+    re-reading the observation, so this was reported as failure.
+    """
+    sim = _CountingSim()
+    policy = _ChunkPolicy(sim.robot_joint_names("fake_robot"), chunk_size=8)
+
+    result = PolicyRunner(sim).evaluate(
+        "fake_robot",
+        policy,
+        n_episodes=1,
+        max_steps=8,
+        action_horizon=8,
+        success_fn=lambda obs: obs["pos"] >= 8,
+    )
+
+    payload = result["content"][1]["json"]
+    assert payload["success_rate"] == 1.0, "success on the final step was not recorded"
+    # avg_steps must be exactly 8, not 9 (no stale one-step-late detection).
+    assert payload["avg_steps"] == 8.0, f"expected avg_steps=8, got {payload['avg_steps']}"
+
+
+def test_legacy_success_fn_and_spec_paths_agree_on_success_rate():
+    """Same deterministic policy + predicate -> identical success_rate.
+
+    The threshold lands on the final applied action so the stale-observation
+    bug is observable: pre-fix the legacy path missed the final-step success
+    (rate 0.0) while the spec path recorded it (rate 1.0). Post-fix both agree.
+    """
+    threshold, max_steps, chunk = 24, 24, 8
+
+    legacy_sim = _CountingSim()
+    legacy = PolicyRunner(legacy_sim).evaluate(
+        "fake_robot",
+        _ChunkPolicy(legacy_sim.robot_joint_names("fake_robot"), chunk_size=chunk),
+        n_episodes=3,
+        max_steps=max_steps,
+        action_horizon=chunk,
+        success_fn=lambda obs: obs["pos"] >= threshold,
+    )
+
+    spec_sim = _CountingSim()
+    spec = PolicyRunner(spec_sim).evaluate(
+        "fake_robot",
+        _ChunkPolicy(spec_sim.robot_joint_names("fake_robot"), chunk_size=chunk),
+        n_episodes=3,
+        action_horizon=chunk,
+        spec=_PosThresholdBenchmark(threshold=threshold, max_steps=max_steps),
+    )
+
+    legacy_rate = legacy["content"][1]["json"]["success_rate"]
+    spec_rate = spec["content"][1]["json"]["success_rate"]
+    assert legacy_rate == spec_rate == 1.0, (
+        f"legacy success_fn and spec paths disagree: legacy={legacy_rate} spec={spec_rate}"
+    )


### PR DESCRIPTION
## Problem

`PolicyRunner.evaluate()` has three rollout paths. The legacy `success_fn` path (taken whenever `spec is None`, i.e. any `eval_policy(..., success_fn=...)` call) diverged from both `run()` and the `spec=`/benchmark path (`_evaluate_with_spec`) in two ways that corrupt evaluation success rates and force out-of-distribution control for chunk-predicting policies.

### Bug 1 - action chunk thrown away; `action_horizon` silently ignored
`run()` and `_evaluate_with_spec` consume `resolve_chunk_length(policy, action_horizon)` actions before re-querying. The legacy path applied only `actions[0]` and re-queried `policy.get_actions` every single step. Consequences: the caller's `action_horizon` had **zero effect**; a chunk-predicting VLA (SmolVLA, GR00T, ...) was re-queried ~chunk-times too often and driven in a control regime it was never trained for (re-sampling diffusion noise every step -> jerky/incoherent trajectories). A prime cause of "policy looks like a no-op / low success in eval but fine in `run()`".

### Bug 2 - success checked on the stale pre-action observation
The legacy path evaluated the predicate against the observation captured **before** the action was applied. So success was detected one step late, and success that lands on the **final** step was never recorded -> systematically under-reports `success_rate` and inflates `avg_steps` by ~1. `_evaluate_with_spec` does this correctly (`spec.is_success` runs against the live post-action sim state), so the two paths disagreed on the same rollout.

## Deterministic reproduction (pre-fix)
Mock-sim + 8-action-chunk policy through the legacy `success_fn` path, `action_horizon=8`, `max_steps=24`:

```
queries (get_actions calls): 24   <- expected 3 (24/8)
actions applied:             24
```
`action_horizon=8` had no effect; only `actions[0]` was used. A predicate that becomes true exactly when the final action lands was reported as failure (`success_rate` under-counted).

## Fix
Make the legacy path consume the full chunk and check success on the fresh post-action observation, identical to `run()` and `_evaluate_with_spec`:
- consume `resolve_chunk_length(policy, action_horizon)` actions per query (single source of truth for the re-query rule, RTC-aware);
- re-read the observation after `send_action` and check the predicate against that.

Post-fix the same scenario yields 3 queries / 24 actions, and final-step success is recorded (`avg_steps` no longer inflated).

## Tests
`tests/simulation/test_eval_legacy_chunk_and_success_timing.py` (3 tests, all FAIL pre-fix, PASS post-fix):
1. legacy `evaluate()` consumes the full chunk before re-querying (`get_actions` called `max_steps/action_horizon` times, not `max_steps`);
2. success that lands on the final step is recorded (`success_rate=1.0`, `avg_steps` exact, not +1);
3. legacy `success_fn` and `spec=` paths agree on `success_rate` for a deterministic policy + predicate (threshold landing on the final step, where the stale-obs bug diverges the two paths).

Full `tests/simulation/` suite passes (2 unrelated pre-existing failures are `libtorchcodec`/CUDA shared-lib load errors in `test_recording_paths.py`). Lint/format/mypy clean on the changed files.

## Artifact
Headless MuJoCo rollout (so100, `MUJOCO_GL=egl`) exercising the eval path:

![eval rollout](https://github.com/cagataycali/robots/releases/download/eval-chunk-stale-obs-artifact/eval_chunk_rollout.gif)

MP4: https://github.com/cagataycali/robots/releases/download/eval-chunk-stale-obs-artifact/eval_chunk_rollout.mp4