### PR TITLE
test: extend no-emoji guard to tests/ and fix half-applied emoji sweep

### DIFF
--- a/tests/benchmarks/libero/test_libero_adapter.py
+++ b/tests/benchmarks/libero/test_libero_adapter.py
@@ -218,7 +218,7 @@ class FakeSim(SimEngine):
                 "content": [{"text": f"add_camera: camera '{name}' already exists. Remove it first."}],
             }
         self._world.cameras[name] = kwargs
-        return {"status": "success", "content": [{"text": f"📷 Camera '{name}' added"}]}
+        return {"status": "success", "content": [{"text": f"Camera '{name}' added"}]}
 
 
 # Construction

--- a/tests/policies/vera/test_vera_action_binding.py
+++ b/tests/policies/vera/test_vera_action_binding.py
@@ -61,7 +61,7 @@ def test_joint_position_binds_to_joints():
     d = out[0]
     assert set(d.keys()) == set(joints), f"keys not bound to joints: {d.keys()}"
     assert "action_0" not in d, "raw action_i leaked!"
-    print("✅ joint_position -> joint keys:", list(d.keys()))
+    print("joint_position -> joint keys:", list(d.keys()))
 
 
 # --- 2) gripper binarization preserved ---
@@ -80,7 +80,7 @@ def test_gripper_binarized():
     obs = {"image": np.zeros((8, 8, 3), np.uint8), "a": 0.0, "b": 0.0, "gripper": 0.0}
     out = run(p, obs)
     assert out[0]["gripper"] == 1.0, f"gripper not binarized: {out[0]}"
-    print("✅ gripper binarized:", out[0])
+    print("gripper binarized:", out[0])
 
 
 # --- 3) eef_delta with NO ik target -> warns + falls back (no crash) ---
@@ -99,7 +99,7 @@ def test_eef_delta_without_ik_falls_back():
     out = run(p, obs)
     # falls back to raw mapping (warned); should not crash, returns dicts
     assert out, "no actions on fallback"
-    print("✅ eef_delta w/o IK falls back (warned), keys:", list(out[0].keys()))
+    print("eef_delta w/o IK falls back (warned), keys:", list(out[0].keys()))
 
 
 # --- 4) action_mapping override still wins ---
@@ -120,4 +120,4 @@ def test_action_mapping_override():
     obs = {"image": np.zeros((8, 8, 3), np.uint8), "wrong1": 0.0, "wrong2": 0.0}
     out = run(p, obs)
     assert set(out[0].keys()) == {"x", "y"}, f"action_mapping ignored: {out[0]}"
-    print("✅ action_mapping override wins:", list(out[0].keys()))
+    print("action_mapping override wins:", list(out[0].keys()))

--- a/tests/policies/vera/test_vera_action_ik.py
+++ b/tests/policies/vera/test_vera_action_ik.py
@@ -13,7 +13,7 @@ def test_rot6d_orthonormal():
     R2 = sim_ik.rot6d_to_matrix([0.3, 1, 0.1, 0, 0.2, 1])
     assert np.allclose(R2.T @ R2, np.eye(3), atol=1e-5), "not orthonormal"
     assert abs(np.linalg.det(R2) - 1.0) < 1e-5, "det != 1"
-    print("✅ rot6d_to_matrix orthonormal + det=1")
+    print("rot6d_to_matrix orthonormal + det=1")
 
 
 def test_axis_angle():
@@ -23,7 +23,7 @@ def test_axis_angle():
     assert np.allclose(R, exp, atol=1e-6), R
     # zero rotation -> identity
     assert np.allclose(sim_ik.axis_angle_to_matrix([0, 0, 0]), np.eye(3))
-    print("✅ axis_angle_to_matrix correct")
+    print("axis_angle_to_matrix correct")
 
 
 class FakeBridge:
@@ -73,7 +73,7 @@ def test_delta_decode_accumulates_translation():
     xs = qpos[:, 0]
     assert np.allclose(xs, [0.005, 0.010, 0.015], atol=1e-6), xs
     assert out["gripper"].tolist() == [1.0, 0.0, 1.0]
-    print("✅ delta decode re-anchors translation:", xs.tolist(), "grip:", out["gripper"].tolist())
+    print("delta decode re-anchors translation:", xs.tolist(), "grip:", out["gripper"].tolist())
 
 
 def test_osc_scaling_full_action_is_5cm_translation():
@@ -153,7 +153,7 @@ def test_provider_ik_path_emits_joint_keys():
     assert "gripper" in d, f"no gripper: {d}"
     # joint keys present (subset of robot joints)
     assert any(k.startswith("joint_") for k in d), d
-    print("✅ provider eef_delta IK path -> joint keys:", list(d.keys()))
+    print("provider eef_delta IK path -> joint keys:", list(d.keys()))
 
 
 def test_ik_smoothing_ema_damps_targets():
@@ -237,4 +237,4 @@ def test_ik_smoothing_ema_damps_targets():
     raw_var = np.var(raw)
     smoothed_var = np.var(smoothed)
     assert smoothed_var < raw_var, f"EMA should reduce variance: raw={raw_var} smoothed={smoothed_var}"
-    print(f"✅ ik_smoothing damps jitter: raw_var={raw_var:.3f} -> smoothed_var={smoothed_var:.3f}")
+    print(f"ik_smoothing damps jitter: raw_var={raw_var:.3f} -> smoothed_var={smoothed_var:.3f}")

--- a/tests/policies/vera/test_vera_autoconfig_ik.py
+++ b/tests/policies/vera/test_vera_autoconfig_ik.py
@@ -63,7 +63,7 @@ def test_discover_prefers_attachment_site():
     model = _install_fake_mujoco(bodies, sites, {1: 0, 2: 1, 3: 2})
     found = ee_frame.discover_ee_frame(model, "panda/")
     assert found == ("panda/attachment_site", "site"), found
-    print("✅ discovers attachment_site:", found)
+    print("discovers attachment_site:", found)
 
 
 def test_discover_falls_back_to_hand_body():
@@ -77,7 +77,7 @@ def test_discover_falls_back_to_hand_body():
     model = _install_fake_mujoco(bodies, sites, {1: 0, 2: 1})
     found = ee_frame.discover_ee_frame(model, "panda/")
     assert found == ("panda/hand", "body"), found
-    print("✅ falls back to hand body:", found)
+    print("falls back to hand body:", found)
 
 
 def test_discover_leaf_body_when_no_hints():
@@ -92,7 +92,7 @@ def test_discover_leaf_body_when_no_hints():
     model = _install_fake_mujoco(bodies, sites, {1: 0, 2: 1, 3: 2})
     found = ee_frame.discover_ee_frame(model, "arm/")
     assert found == ("arm/link2", "body"), found
-    print("✅ leaf body fallback:", found)
+    print("leaf body fallback:", found)
 
 
 def test_set_sim_context_autoconfigures_for_eef_delta():
@@ -131,7 +131,7 @@ def test_set_sim_context_autoconfigures_for_eef_delta():
     p.set_sim_context(model, "panda/")
     assert p._ee_frame_name == "panda/attachment_site", p._ee_frame_name
     assert p._ee_frame_type == "site"
-    print("✅ set_sim_context auto-configured IK:", p._ee_frame_name, p._ee_frame_type)
+    print("set_sim_context auto-configured IK:", p._ee_frame_name, p._ee_frame_type)
 
 
 def test_no_autoconfig_for_joint_position():
@@ -167,7 +167,7 @@ def test_no_autoconfig_for_joint_position():
     p._ensure_started()
     p.set_sim_context(model, "allegro/")
     assert p._ee_frame_name is None, "should NOT auto-config IK for joint_position"
-    print("✅ joint_position: no IK auto-config (correct)")
+    print("joint_position: no IK auto-config (correct)")
 
 
 def test_discover_without_namespace_scopes_whole_model():

--- a/tests/simulation/test_policy_runner.py
+++ b/tests/simulation/test_policy_runner.py
@@ -310,8 +310,8 @@ def test_run_policy_video_writes_mp4(tmp_path: Path) -> None:
 
     text_blocks = [c.get("text", "") for c in result.get("content", []) if isinstance(c, dict)]
     summary = "\n".join(text_blocks)
-    assert "🎬 Video:" in summary, f"no video summary in output: {summary}"
-    assert "📹" in summary and "frames" in summary, f"frame count missing: {summary}"
+    assert "Video:" in summary, f"no video summary in output: {summary}"
+    assert "frames" in summary, f"frame count missing: {summary}"
 
 
 def test_extract_frame_ndarray_handles_render_shape() -> None:

--- a/tests/simulation/test_video_camera_validation.py
+++ b/tests/simulation/test_video_camera_validation.py
@@ -93,7 +93,7 @@ class TestVideoCameraPreValidation:
         )
         assert r["status"] == "success", r
         text = r["content"][0]["text"]
-        assert "🎬 Video" in text or "Video:" in text, text
+        assert "Video:" in text, text
         assert video_path.exists() and video_path.stat().st_size > 0
 
 

--- a/tests/test_source_strings_no_emoji.py
+++ b/tests/test_source_strings_no_emoji.py
@@ -1,4 +1,4 @@
-"""Regression: no ``strands_robots`` module may embed emoji in source strings.
+"""Regression: no ``strands_robots`` module or test module may embed emoji.
 
 AGENTS.md forbids emoji in code, logs, and error messages: agents read these
 strings programmatically, emoji are tokenizer noise, and they render
@@ -68,3 +68,37 @@ def test_no_emoji_in_package_sources() -> None:
                     f"{path.relative_to(_PACKAGE_DIR.parent)}:{lineno}: U+{ord(cp[0]):04X} {line.strip()[:80]!r}"
                 )
     assert not offenders, "emoji found in strands_robots sources:\n" + "\n".join(offenders)
+
+
+# The test tree itself is held to the same bar. A half-applied emoji sweep is
+# easy to spot in production code but slips through in test files: prod stops
+# emitting a glyph, yet an assertion (or a debug ``print``) still pins it. The
+# package-only scan above cannot catch that, so scan ``tests/`` too. This guard
+# would have failed when ``test_policy_runner.py`` still asserted ``"X Video:"``
+# against output the engine is forbidden to emit.
+_TESTS_DIR = Path(__file__).resolve().parent
+
+
+def _test_sources() -> list[Path]:
+    return sorted(p for p in _TESTS_DIR.rglob("*.py") if "__pycache__" not in p.parts)
+
+
+def test_test_sources_discovered() -> None:
+    """Guard: the scan walked the whole test tree, not just the top level."""
+    sources = _test_sources()
+    assert len(sources) > 50
+    rel_dirs = {p.relative_to(_TESTS_DIR).parts[0] for p in sources if p.parent != _TESTS_DIR}
+    assert {"simulation", "policies", "benchmarks"} <= rel_dirs
+
+
+def test_no_emoji_in_test_sources() -> None:
+    """No test module may embed emoji in assertions, fixtures, or debug prints."""
+    offenders: list[str] = []
+    for path in _test_sources():
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            for match in _EMOJI.finditer(line):
+                cp = match.group()
+                offenders.append(
+                    f"{path.relative_to(_TESTS_DIR.parent)}:{lineno}: U+{ord(cp[0]):04X} {line.strip()[:80]!r}"
+                )
+    assert not offenders, "emoji found in test sources:\n" + "\n".join(offenders)


### PR DESCRIPTION
## Problem

`PolicyRunner.run()` correctly emits ASCII video summaries (`Video: <path>` / `N frames, ...`), per the project rule against emoji in user-facing strings. But the emoji sweep was half-applied: two assertions in `tests/simulation/test_policy_runner.py` still pinned the old emoji output, so they fail against the string the engine is now forbidden to emit:

```python
assert "\U0001f3ac Video:" in summary   # line 313
assert "\U0001f4f9" in summary and "frames" in summary  # line 314
```

The existing guard `test_no_emoji_in_package_sources` only scans `strands_robots/`, so it cannot catch stray emoji left behind in the test tree. That is exactly how this slipped through: prod stopped emitting the glyph, the assertion guarding it did not.

## Change

- `test_policy_runner.py`: assert on ASCII output (`Video:`, `frames`).
- `test_video_camera_validation.py`: drop the emoji branch, assert `Video:`.
- `test_libero_adapter.py` and `policies/vera/*`: strip stray emoji from a mock return string and debug `print`s.
- `test_source_strings_no_emoji.py`: add `test_no_emoji_in_test_sources`, scanning the whole `tests/` tree with the same emoji regex as the package guard. It rejects any emoji codepoint or variation selector in an assertion, fixture, or print.

## Validation

- The new guard **fails pre-fix** (flags `test_policy_runner.py:313 U+1F3AC`) and **passes after** the cleanup.
- `tests/test_source_strings_no_emoji.py`, `tests/simulation/test_policy_runner.py`, `tests/simulation/test_video_camera_validation.py`, `tests/policies/vera/`, `tests/benchmarks/libero/test_libero_adapter.py`: all green (`325 passed, 29 skipped` for the touched set; the previously-red video summary test now passes).
- `ruff check` / `ruff format --check` / `mypy` clean on `strands_robots tests tests_integ`.

No production code changed; this is test + CI-guard hygiene only.