### PR TITLE
fix(lerobot_local): honor ACT temporal ensembling instead of silently dropping it

### DIFF
--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -643,33 +643,71 @@ class LerobotLocalPolicy(Policy):
         self._init_rtc()
 
     def _auto_detect_actions_per_step(self) -> None:
-        """Adopt the model's intended open-loop chunk size when left at default.
+        """Select the inference regime the loaded checkpoint was trained for.
 
-        Many LeRobot policies declare ``config.n_action_steps`` - the number of
-        actions the model emits per inference call that it was trained to replay
-        open-loop before requerying observation (e.g. MolmoAct2 SO-100/101 = 30,
-        ACT = 100, Diffusion = 32). The default ``actions_per_step=1`` is a
-        closed-loop receding-horizon convention: it returns one action per call
-        and re-queries vision every step. For a model trained on N-step chunk
-        replay, that puts inference out of the training distribution - the policy
-        sees state where its training had it after 1 step, not N - and the
-        distribution shift compounds every chunk.
+        Two mutually exclusive regimes exist, and the wrong one degrades motion:
 
-        When ``actions_per_step`` is still at the default ``1`` and the loaded
-        model exposes ``config.n_action_steps > 1``, adopt that value so the
-        chunk is consumed as trained. An explicit ``actions_per_step > 1`` from
-        the caller is always respected. Logged at INFO so the change is visible.
+        Temporal ensembling (``config.temporal_ensemble_coeff is not None``):
+            LeRobot applies the ensembler inside ``select_action()`` on a fresh
+            chunk every step (a receding-horizon, per-step operation - see
+            ``ACTPolicy.select_action``). ``predict_action_chunk()`` returns the
+            RAW chunk and BYPASSES the ensembler entirely. So an ensembling
+            checkpoint MUST be driven one step at a time via ``select_action()``;
+            replaying its chunk open-loop silently discards the smoothing the
+            checkpoint was trained to produce (jerky motion). We therefore keep
+            ``actions_per_step=1`` for these checkpoints, and if a caller pinned
+            ``actions_per_step > 1`` we override it with a loud warning rather
+            than quietly throwing the ensembling away.
+
+        Open-loop chunk replay (``temporal_ensemble_coeff is None``):
+            Many policies declare ``config.n_action_steps`` - the number of
+            actions emitted per inference that the model was trained to replay
+            open-loop before requerying observation (e.g. MolmoAct2 SO-100/101 =
+            30, ACT = 100, Diffusion = 32). The default ``actions_per_step=1`` is
+            a closed-loop convention that re-queries every step; for a chunk-
+            trained model that is out of distribution and the shift compounds
+            every chunk. When left at the default ``1`` we adopt
+            ``n_action_steps`` so the chunk is consumed as trained. An explicit
+            ``actions_per_step > 1`` from the caller is respected here.
+
+        Logged at INFO so the active regime is always visible.
         """
+        config = getattr(self._policy, "config", None)
+        ensemble_coeff = getattr(config, "temporal_ensemble_coeff", None)
+        if ensemble_coeff is not None:
+            # Ensembling regime: must run per-step through select_action().
+            if self.actions_per_step != 1:
+                logger.warning(
+                    "lerobot_local: %s checkpoint enables temporal ensembling "
+                    "(temporal_ensemble_coeff=%s) but actions_per_step=%d was "
+                    "set explicitly. Open-loop chunk replay and temporal "
+                    "ensembling are mutually exclusive - chunk replay bypasses "
+                    "the ensembler and discards the motion smoothing the "
+                    "checkpoint was trained for. Overriding to actions_per_step="
+                    "1 so ensembling is honored via select_action().",
+                    type(self._policy).__name__,
+                    ensemble_coeff,
+                    self.actions_per_step,
+                )
+                self.actions_per_step = 1
+            logger.info(
+                "lerobot_local: %s temporal ensembling ON "
+                "(temporal_ensemble_coeff=%s) - driving per-step via "
+                "select_action().",
+                type(self._policy).__name__,
+                ensemble_coeff,
+            )
+            return
         if self.actions_per_step != 1:
             return  # caller pinned an explicit horizon - never override it
-        config = getattr(self._policy, "config", None)
         n_action_steps = getattr(config, "n_action_steps", None)
         if isinstance(n_action_steps, int) and n_action_steps > 1:
             self.actions_per_step = n_action_steps
             logger.info(
-                "lerobot_local: auto-set actions_per_step=%d from "
-                "%s.config.n_action_steps (model's trained open-loop chunk "
-                "size). Pass actions_per_step explicitly to override.",
+                "lerobot_local: open-loop chunk replay - auto-set "
+                "actions_per_step=%d from %s.config.n_action_steps (model's "
+                "trained open-loop chunk size). Pass actions_per_step "
+                "explicitly to override.",
                 n_action_steps,
                 type(self._policy).__name__,
             )

--- a/tests/policies/lerobot_local/test_policy.py
+++ b/tests/policies/lerobot_local/test_policy.py
@@ -150,6 +150,58 @@ class TestAutoDetectActionsPerStep:
         policy._auto_detect_actions_per_step()
         assert policy.actions_per_step == 1
 
+    def _policy_with_ensemble(self, coeff, n_action_steps=100, actions_per_step=1):
+        """A checkpoint that enables temporal ensembling (e.g. ACT folding).
+
+        Mirrors LeRobot's ACTConfig: ``temporal_ensemble_coeff`` is set and
+        ``n_action_steps`` is the full chunk (100). LeRobot forces
+        ``n_action_steps == 1`` internally when ensembling, but the config still
+        advertises the chunk size, so the detector must route on the coeff.
+        """
+        policy = _make_policy(actions_per_step=actions_per_step)
+        mock_lerobot_policy = MagicMock()
+        mock_lerobot_policy.config = types.SimpleNamespace(n_action_steps=n_action_steps, temporal_ensemble_coeff=coeff)
+        policy._policy = mock_lerobot_policy
+        return policy
+
+    def test_ensembling_checkpoint_keeps_per_step_path(self):
+        """temporal_ensemble_coeff set -> stay at actions_per_step=1.
+
+        Regression: previously the detector bumped actions_per_step to
+        config.n_action_steps (100 for ACT) for EVERY checkpoint, which routes
+        get_actions() through predict_action_chunk() and silently bypasses the
+        temporal ensembler. An ensembling checkpoint must stay per-step so
+        select_action() runs the ensembler.
+        """
+        policy = self._policy_with_ensemble(0.01)
+        assert policy.actions_per_step == 1
+        policy._auto_detect_actions_per_step()
+        assert policy.actions_per_step == 1  # NOT auto-bumped to 100
+
+    def test_ensembling_overrides_explicit_chunk_with_warning(self, caplog):
+        """Explicit actions_per_step > 1 on an ensembling checkpoint is
+
+        overridden to 1 with a loud warning - chunk replay and ensembling are
+        mutually exclusive, and silently dropping the smoothing is the bug.
+        """
+        import logging
+
+        policy = self._policy_with_ensemble(0.01, actions_per_step=8)
+        with caplog.at_level(logging.WARNING):
+            policy._auto_detect_actions_per_step()
+        assert policy.actions_per_step == 1
+        assert any(
+            "temporal ensembling" in r.message and "actions_per_step" in r.message
+            for r in caplog.records
+            if r.levelno == logging.WARNING
+        )
+
+    def test_non_ensembling_act_still_chunk_replays(self):
+        """temporal_ensemble_coeff=None -> open-loop chunk replay (unchanged)."""
+        policy = self._policy_with_ensemble(None, n_action_steps=100)
+        policy._auto_detect_actions_per_step()
+        assert policy.actions_per_step == 100
+
 
 # (section)
 # Tests: set_robot_state_keys
@@ -570,6 +622,31 @@ class TestGetActions:
         policy._policy.name = "act"
 
         actions = policy.get_actions_sync({}, "test")
+
+        policy._policy.select_action.assert_called_once()
+        policy._policy.predict_action_chunk.assert_not_called()
+        assert len(actions) == 1
+
+    def test_ensembling_act_routes_to_select_action_end_to_end(self):
+        """ACT ensembling checkpoint: detection -> get_actions runs select_action.
+
+        Regression for the silent ensembling-disable bug. The checkpoint
+        advertises n_action_steps=100 and temporal_ensemble_coeff=0.01. Before
+        the fix, auto-detect bumped actions_per_step to 100 and get_actions()
+        called predict_action_chunk() (bypassing the ensembler). After the fix,
+        actions_per_step stays 1 and get_actions() calls select_action() so the
+        temporal ensembler runs.
+        """
+        policy = _make_loaded_policy(action_dim=3, include_images=False)
+        policy.set_robot_state_keys(["a", "b", "c"])
+        policy._policy.name = "act"
+        policy._policy.config = types.SimpleNamespace(n_action_steps=100, temporal_ensemble_coeff=0.01)
+
+        # Simulate the load-time regime selection.
+        policy._auto_detect_actions_per_step()
+        assert policy.actions_per_step == 1
+
+        actions = policy.get_actions_sync({}, "fold the shirt")
 
         policy._policy.select_action.assert_called_once()
         policy._policy.predict_action_chunk.assert_not_called()


### PR DESCRIPTION
## Problem

LeRobot ACT checkpoints can enable temporal ensembling via `config.temporal_ensemble_coeff` (the original ACT work defaults it to `0.01`). LeRobot applies that ensembler **inside `ACTPolicy.select_action()`**, on a fresh action chunk every step (a receding-horizon, per-step operation). `predict_action_chunk()` returns the **raw** chunk and bypasses the ensembler entirely.

`LerobotLocalPolicy._auto_detect_actions_per_step()` bumped `actions_per_step` to `config.n_action_steps` (100 for ACT) for **every** checkpoint that advertised a chunk size. `get_actions()` then routes on `actions_per_step > 1` straight to `predict_action_chunk()`:

```python
elif self.actions_per_step > 1 or self._requires_action_chunk():
    action_tensor = self._policy.predict_action_chunk(batch, **self.inference_kwargs)  # raw chunk, no ensembler
else:
    action_tensor = self._policy.select_action(batch, **self.inference_kwargs)         # would run the ensembler
```

So for an ensembling ACT checkpoint the ensembler was **never invoked** and the motion smoothing the checkpoint was trained to produce was silently discarded (jerky motion). Nothing warned.

## Change

`_auto_detect_actions_per_step()` now inspects `config.temporal_ensemble_coeff`:

- **`temporal_ensemble_coeff is not None`** (ensembling): keep the per-step `select_action()` path (`actions_per_step` stays `1`) so the ensembler runs. Open-loop chunk replay and temporal ensembling are mutually exclusive, so if a caller explicitly pinned `actions_per_step > 1` it is overridden to `1` with a **loud warning** rather than quietly dropping the smoothing.
- **`temporal_ensemble_coeff is None`** (open-loop chunk replay): unchanged — still adopts `n_action_steps` when left at the default.
- The active regime is logged at INFO on load.

## Tests

Adds regression tests (in `tests/policies/lerobot_local/test_policy.py`) that **fail on the pre-fix routing**:

- `test_ensembling_checkpoint_keeps_per_step_path` — `temporal_ensemble_coeff=0.01` keeps `actions_per_step=1` (was auto-bumped to 100).
- `test_ensembling_overrides_explicit_chunk_with_warning` — explicit `actions_per_step=8` on an ensembling checkpoint is overridden to `1` with a warning.
- `test_non_ensembling_act_still_chunk_replays` — `temporal_ensemble_coeff=None` still adopts the 100-step chunk.
- `test_ensembling_act_routes_to_select_action_end_to_end` — full load→route: `get_actions()` calls `select_action()`, not `predict_action_chunk()`.

Full `lerobot_local` suite: 139 passed. Lint/format/mypy clean over `strands_robots tests tests_integ`.

## Smoothing delta (quantitative)

Feeding overlapping per-step ACT chunk predictions (shared smooth multi-joint target + iid per-prediction noise) through the two regimes, using LeRobot's real `ACTTemporalEnsembler` (`coeff=0.01`, `chunk_size=100`) for the post-fix path:

| regime | joint-velocity variance | RMSE vs target |
|---|---|---|
| chunk replay (pre-fix) | 0.00617 | 0.0489 |
| temporal ensembling (post-fix) | 0.00149 | 0.0091 |

**4.1x lower joint-velocity variance, 5.4x lower tracking error.** The pre-fix stream also shows a discontinuity at every open-loop chunk boundary (re-prediction jump); the ensembled stream does not.

![ACT temporal ensembling smoothing](https://github.com/cagataycali/robots/releases/download/act-ensembling-artifact/act_ensembling_smoothing.png)