### PR TITLE
fix(teleoperate): port record/replay branches to lerobot 0.5 nested CLI

### DIFF
--- a/strands_robots/tools/lerobot_teleoperate.py
+++ b/strands_robots/tools/lerobot_teleoperate.py
@@ -98,6 +98,84 @@ class SessionManager:
         return self._load_sessions()
 
 
+def _build_camera_arg(robot_cameras: dict[str, Any]) -> str:
+    """Render a camera map as a lerobot 0.5 nested ``--robot.cameras`` value.
+
+    lerobot 0.5's draccus CLI parses ``--robot.cameras`` as a nested dict, e.g.
+    ``{front: {type: opencv, index_or_path: 0, width: 640, height: 480, fps: 30}}``.
+    The pre-0.5 ``--camera-config name=type:path:fps:WxH`` flat form no longer
+    exists. Each entry defaults to opencv/index 0/640x480/30fps when unset.
+
+    Args:
+        robot_cameras: Map of camera name to a config dict with optional keys
+            ``type``, ``index_or_path``, ``width``, ``height``, ``fps``.
+
+    Returns:
+        The nested dict string suitable for ``--robot.cameras=<value>``.
+    """
+    entries = []
+    for cam_name, cam_config in robot_cameras.items():
+        cam_type = cam_config.get("type", "opencv")
+        cam_path = cam_config.get("index_or_path", 0)
+        fps_val = cam_config.get("fps", 30)
+        width = cam_config.get("width", 640)
+        height = cam_config.get("height", 480)
+        entries.append(
+            f"{cam_name}: {{type: {cam_type}, index_or_path: {cam_path}, "
+            f"width: {width}, height: {height}, fps: {fps_val}}}"
+        )
+    return "{" + ", ".join(entries) + "}"
+
+
+def _robot_args(
+    robot_type: str,
+    robot_port: str | None,
+    robot_id: str | None,
+    robot_left_arm_port: str | None,
+    robot_right_arm_port: str | None,
+    robot_cameras: dict[str, Any] | None,
+) -> list[str]:
+    """Build the nested ``--robot.*`` argv for lerobot 0.5's draccus CLI.
+
+    Single-arm robots bind ``--robot.port``; bimanual robots have no single port
+    and instead pass ``--robot.left_arm_port`` / ``--robot.right_arm_port``.
+    """
+    args = ["--robot.type", robot_type]
+    if robot_port:
+        args.extend(["--robot.port", robot_port])
+    if robot_id:
+        args.extend(["--robot.id", robot_id])
+    if robot_left_arm_port:
+        args.extend(["--robot.left_arm_port", robot_left_arm_port])
+    if robot_right_arm_port:
+        args.extend(["--robot.right_arm_port", robot_right_arm_port])
+    if robot_cameras:
+        args.append(f"--robot.cameras={_build_camera_arg(robot_cameras)}")
+    return args
+
+
+def _teleop_args(
+    teleop_type: str | None,
+    teleop_port: str | None,
+    teleop_id: str | None,
+    teleop_left_arm_port: str | None,
+    teleop_right_arm_port: str | None,
+) -> list[str]:
+    """Build the nested ``--teleop.*`` argv for lerobot 0.5's draccus CLI."""
+    args: list[str] = []
+    if teleop_type:
+        args.extend(["--teleop.type", teleop_type])
+    if teleop_id:
+        args.extend(["--teleop.id", teleop_id])
+    if teleop_port:
+        args.extend(["--teleop.port", teleop_port])
+    if teleop_left_arm_port:
+        args.extend(["--teleop.left_arm_port", teleop_left_arm_port])
+    if teleop_right_arm_port:
+        args.extend(["--teleop.right_arm_port", teleop_right_arm_port])
+    return args
+
+
 def build_lerobot_command(
     action: str,
     robot_type: str,
@@ -127,116 +205,81 @@ def build_lerobot_command(
     play_sounds: bool = True,
     **kwargs,
 ) -> list[str]:
-    """Build the lerobot command based on action and parameters."""
+    """Build the lerobot CLI argv for a teleoperate/record/replay action.
 
+    Emits the lerobot 0.5 draccus-nested schema (``--robot.* / --teleop.* /
+    --dataset.*``). The pre-0.5 flat flags (``--robot-path``, ``--repo-id``,
+    ``--num-episodes``, ``--single-task``, ``--episode``, ``--no-video`` ...) were
+    removed upstream and are NOT emitted; passing them makes the lerobot scripts
+    exit with an unrecognized-argument error.
+
+    Args:
+        action: One of ``"start"`` (teleoperate or record) or ``"replay"``.
+            ``"start"`` records when ``dataset_repo_id`` is set, otherwise it
+            runs plain teleoperation.
+        robot_type: Follower robot type (e.g. ``"so101_follower"``).
+        dataset_repo_id: HuggingFace dataset id; presence enables record mode for
+            ``start`` and is required for ``replay``.
+        replay_episode: Episode index to replay (``--dataset.episode``).
+
+    Returns:
+        The argv list, beginning with ``["python", "-m", "lerobot.scripts...."]``.
+
+    Raises:
+        ValueError: If ``action`` is unknown, or ``replay`` is requested without
+            ``dataset_repo_id``.
+    """
     if action == "replay":
-        # Build replay command
         if not dataset_repo_id:
             raise ValueError("dataset_repo_id is required for replay action")
-        cmd = [
-            "python",
-            "-m",
-            "lerobot.scripts.lerobot_replay",
-            "--robot-path",
-            robot_type,
-            "--policy-path",
-            dataset_repo_id,
-            "--episode",
-            str(replay_episode),
-        ]
-
-        if robot_port:
-            cmd.extend(["--robot-port", robot_port])
-        if robot_left_arm_port:
-            cmd.extend(["--robot-left-arm-port", robot_left_arm_port])
-        if robot_right_arm_port:
-            cmd.extend(["--robot-right-arm-port", robot_right_arm_port])
-        if display_data:
-            cmd.append("--display-data")
-
+        cmd = ["python", "-m", "lerobot.scripts.lerobot_replay"]
+        cmd.extend(
+            _robot_args(robot_type, robot_port, robot_id, robot_left_arm_port, robot_right_arm_port, robot_cameras)
+        )
+        cmd.extend(["--dataset.repo_id", dataset_repo_id, "--dataset.episode", str(replay_episode)])
+        if dataset_root:
+            cmd.extend(["--dataset.root", dataset_root])
+        if dataset_fps:
+            cmd.extend(["--dataset.fps", str(dataset_fps)])
         return cmd
 
-    elif action == "start":
-        # Determine the base command based on whether we're recording
+    if action == "start":
         if dataset_repo_id:
-            # Recording mode
-            cmd = [
-                "python",
-                "-m",
-                "lerobot.scripts.lerobot_record",
-                "--robot-path",
-                robot_type,
-                "--robot-port",
-                robot_port or "/dev/ttyACM0",
-                "--fps",
-                str(fps),
-                "--repo-id",
-                dataset_repo_id,
-                "--num-episodes",
-                str(dataset_num_episodes),
-                "--episode-time-s",
-                str(dataset_episode_time_s),
-                "--reset-time-s",
-                str(dataset_reset_time_s),
-            ]
-
+            # Recording mode -> lerobot-record (pure data collection via teleop).
+            cmd = ["python", "-m", "lerobot.scripts.lerobot_record"]
+            cmd.extend(
+                _robot_args(robot_type, robot_port, robot_id, robot_left_arm_port, robot_right_arm_port, robot_cameras)
+            )
+            cmd.extend(_teleop_args(teleop_type, teleop_port, teleop_id, teleop_left_arm_port, teleop_right_arm_port))
+            cmd.extend(["--dataset.repo_id", dataset_repo_id])
+            cmd.extend(["--dataset.num_episodes", str(dataset_num_episodes)])
             if dataset_single_task:
-                cmd.extend(["--single-task", dataset_single_task])
+                cmd.extend(["--dataset.single_task", dataset_single_task])
+            cmd.extend(["--dataset.fps", str(dataset_fps)])
+            cmd.extend(["--dataset.episode_time_s", str(dataset_episode_time_s)])
+            cmd.extend(["--dataset.reset_time_s", str(dataset_reset_time_s)])
             if dataset_root:
-                cmd.extend(["--root", dataset_root])
-            if dataset_push_to_hub:
-                cmd.append("--push-to-hub")
-            if not dataset_video:
-                cmd.append("--no-video")
-        else:
-            # Simple teleoperation mode
-            cmd = ["python", "-m", "lerobot.scripts.lerobot_teleoperate", "--robot.type", robot_type, "--fps", str(fps)]
+                cmd.extend(["--dataset.root", dataset_root])
+            cmd.extend(["--dataset.push_to_hub", "true" if dataset_push_to_hub else "false"])
+            cmd.extend(["--dataset.video", "true" if dataset_video else "false"])
+            if display_data:
+                cmd.extend(["--display_data", "true"])
+            return cmd
 
-            if teleop_time_s:
-                cmd.extend(["--teleop_time_s", str(teleop_time_s)])
-
-        # Add robot configuration
-        if robot_port:
-            cmd.extend(["--robot.port", robot_port])
-        if robot_id:
-            cmd.extend(["--robot.id", robot_id])
-        if robot_left_arm_port:
-            cmd.extend(["--robot.left_arm_port", robot_left_arm_port])
-        if robot_right_arm_port:
-            cmd.extend(["--robot.right_arm_port", robot_right_arm_port])
-
-        # Add teleoperator configuration
-        if teleop_type:
-            cmd.extend(["--teleop.type", teleop_type])
-        if teleop_id:
-            cmd.extend(["--teleop.id", teleop_id])
-        if teleop_port:
-            cmd.extend(["--teleop.port", teleop_port])
-        if teleop_left_arm_port:
-            cmd.extend(["--teleop.left_arm_port", teleop_left_arm_port])
-        if teleop_right_arm_port:
-            cmd.extend(["--teleop.right_arm_port", teleop_right_arm_port])
-
-        # Add camera configuration
-        if robot_cameras:
-            for cam_name, cam_config in robot_cameras.items():
-                cam_type = cam_config.get("type", "opencv")
-                cam_path = str(cam_config.get("index_or_path", 0))
-                fps_val = cam_config.get("fps", 30)
-                width = cam_config.get("width", 640)
-                height = cam_config.get("height", 480)
-
-                cmd.extend(["--camera-config", f"{cam_name}={cam_type}:{cam_path}:{fps_val}:{width}x{height}"])
-
-        # Add common options
+        # Simple teleoperation mode -> lerobot-teleoperate.
+        cmd = ["python", "-m", "lerobot.scripts.lerobot_teleoperate"]
+        cmd.extend(
+            _robot_args(robot_type, robot_port, robot_id, robot_left_arm_port, robot_right_arm_port, robot_cameras)
+        )
+        cmd.extend(_teleop_args(teleop_type, teleop_port, teleop_id, teleop_left_arm_port, teleop_right_arm_port))
+        cmd.extend(["--fps", str(fps)])
+        if teleop_time_s:
+            cmd.extend(["--teleop_time_s", str(teleop_time_s)])
         if display_data:
             cmd.extend(["--display_data", "true"])
-        # Note: play_sounds option may not exist in lerobot_teleoperate
-
         return cmd
 
-    else:
-        raise ValueError(f"Unknown action: {action}")
+    raise ValueError(f"Unknown action: {action}")
 
 
 @tool

--- a/tests/tools/test_lerobot_teleoperate.py
+++ b/tests/tools/test_lerobot_teleoperate.py
@@ -68,7 +68,14 @@ class _FakeProc:
 # ---------------------------------------------------------------------------
 # build_lerobot_command - argv mapping for each action
 # ---------------------------------------------------------------------------
-def test_build_replay_command_includes_episode_and_paths() -> None:
+def test_build_replay_command_uses_nested_dataset_and_robot_args() -> None:
+    """Replay must use lerobot 0.5's nested ``--dataset.* / --robot.*`` schema.
+
+    Pre-0.5 emitted ``--policy-path`` / ``--episode`` / ``--robot-port``; lerobot
+    0.5's ``lerobot_replay`` reads ``--dataset.repo_id`` / ``--dataset.episode``
+    and the robot's port from ``--robot.port``. ``ReplayConfig`` has no
+    ``display_data`` field, so the viewer flag must not be emitted.
+    """
     cmd = build_lerobot_command(
         action="replay",
         robot_type="so101_follower",
@@ -78,10 +85,16 @@ def test_build_replay_command_includes_episode_and_paths() -> None:
         display_data=True,
     )
     assert cmd[:3] == ["python", "-m", "lerobot.scripts.lerobot_replay"]
-    assert "--episode" in cmd and cmd[cmd.index("--episode") + 1] == "5"
-    assert "--policy-path" in cmd and "user/cubes" in cmd
-    assert "--robot-port" in cmd
-    assert "--display-data" in cmd
+    assert cmd[cmd.index("--dataset.episode") + 1] == "5"
+    assert cmd[cmd.index("--dataset.repo_id") + 1] == "user/cubes"
+    assert cmd[cmd.index("--robot.type") + 1] == "so101_follower"
+    assert cmd[cmd.index("--robot.port") + 1] == "/dev/ttyACM0"
+    # The stale flat flags must be gone.
+    assert "--policy-path" not in cmd
+    assert "--robot-port" not in cmd
+    assert "--episode" not in cmd
+    # ReplayConfig has no display_data field -> never emit it.
+    assert "--display_data" not in cmd and "--display-data" not in cmd
 
 
 def test_build_replay_command_requires_dataset_repo_id() -> None:
@@ -92,10 +105,10 @@ def test_build_replay_command_requires_dataset_repo_id() -> None:
 def test_build_replay_command_routes_bimanual_arm_ports() -> None:
     """Replay on a bimanual (ALOHA-class) robot must forward both arm ports.
 
-    Single-arm SO-100/SO-101 robots use ``--robot-port``; bimanual robots have
-    no single port and instead pass ``--robot-left-arm-port`` /
-    ``--robot-right-arm-port``. The replay builder must emit the per-arm flags
-    (and may omit ``--robot-port`` entirely) so the lerobot CLI binds each arm.
+    Single-arm SO-100/SO-101 robots use ``--robot.port``; bimanual robots have
+    no single port and instead pass ``--robot.left_arm_port`` /
+    ``--robot.right_arm_port``. The replay builder must emit the per-arm flags
+    (and may omit ``--robot.port`` entirely) so the lerobot CLI binds each arm.
     """
     cmd = build_lerobot_command(
         action="replay",
@@ -106,20 +119,20 @@ def test_build_replay_command_routes_bimanual_arm_ports() -> None:
         robot_right_arm_port="/dev/ttyACM1",
     )
     assert cmd[:3] == ["python", "-m", "lerobot.scripts.lerobot_replay"]
-    assert cmd[cmd.index("--robot-left-arm-port") + 1] == "/dev/ttyACM0"
-    assert cmd[cmd.index("--robot-right-arm-port") + 1] == "/dev/ttyACM1"
+    assert cmd[cmd.index("--robot.left_arm_port") + 1] == "/dev/ttyACM0"
+    assert cmd[cmd.index("--robot.right_arm_port") + 1] == "/dev/ttyACM1"
     # No single robot_port was given, so the single-arm flag must be absent.
-    assert "--robot-port" not in cmd
+    assert "--robot.port" not in cmd
 
 
-def test_build_start_teleop_command_routes_bimanual_ports_ids_and_root() -> None:
-    """A bimanual teleop start must forward per-arm ports, ids, root + display.
+def test_build_start_record_command_routes_bimanual_ports_ids_and_root() -> None:
+    """A bimanual record start must forward per-arm ports, ids, root + display.
 
     Exercises the option branches a leader->follower ALOHA recording session
     needs: robot/teleop ``--*.id`` namespacing, the left/right arm ports for
-    both the follower (robot) and leader (teleop), a dataset ``--root`` for the
-    on-disk recording location, and the ``--display_data`` viewer flag. Each
-    must map to its lerobot CLI argument with the supplied value.
+    both the follower (robot) and leader (teleop), a dataset ``--dataset.root``
+    for the on-disk recording location, and the ``--display_data`` viewer flag.
+    Each must map to its lerobot 0.5 CLI argument with the supplied value.
     """
     cmd = build_lerobot_command(
         action="start",
@@ -137,7 +150,7 @@ def test_build_start_teleop_command_routes_bimanual_ports_ids_and_root() -> None
     )
     # Recording mode (dataset given) -> lerobot_record entrypoint.
     assert "lerobot.scripts.lerobot_record" in cmd
-    assert cmd[cmd.index("--root") + 1] == "/data/lerobot/bimanual_pick"
+    assert cmd[cmd.index("--dataset.root") + 1] == "/data/lerobot/bimanual_pick"
     # Robot (follower) per-arm config.
     assert cmd[cmd.index("--robot.id") + 1] == "follower_arm"
     assert cmd[cmd.index("--robot.left_arm_port") + 1] == "/dev/ttyACM0"
@@ -150,11 +163,21 @@ def test_build_start_teleop_command_routes_bimanual_ports_ids_and_root() -> None
     assert cmd[cmd.index("--display_data") + 1] == "true"
 
 
-def test_build_start_record_command_when_dataset_given() -> None:
+def test_build_start_record_command_uses_nested_dataset_schema() -> None:
+    """Record mode must emit lerobot 0.5's nested ``--dataset.*`` flags.
+
+    The pre-0.5 record CLI used flat ``--repo-id`` / ``--num-episodes`` /
+    ``--single-task`` / ``--push-to-hub`` / ``--no-video``. lerobot 0.5's
+    ``lerobot_record`` nests these under ``--dataset.*`` and reads booleans as
+    explicit ``true``/``false`` values (``--dataset.video false``). The stale
+    flat flags must be gone or the script exits on an unrecognized argument.
+    """
     cmd = build_lerobot_command(
         action="start",
         robot_type="so101_follower",
         robot_port="/dev/ttyACM0",
+        teleop_type="so101_leader",
+        teleop_port="/dev/ttyACM1",
         dataset_repo_id="user/cubes",
         dataset_single_task="pick the cube",
         dataset_num_episodes=10,
@@ -162,11 +185,67 @@ def test_build_start_record_command_when_dataset_given() -> None:
         dataset_video=False,
     )
     assert "lerobot.scripts.lerobot_record" in cmd
-    assert "--repo-id" in cmd and "user/cubes" in cmd
-    assert cmd[cmd.index("--num-episodes") + 1] == "10"
-    assert "--single-task" in cmd
-    assert "--push-to-hub" in cmd
-    assert "--no-video" in cmd
+    assert cmd[cmd.index("--robot.type") + 1] == "so101_follower"
+    assert cmd[cmd.index("--teleop.type") + 1] == "so101_leader"
+    assert cmd[cmd.index("--dataset.repo_id") + 1] == "user/cubes"
+    assert cmd[cmd.index("--dataset.num_episodes") + 1] == "10"
+    assert cmd[cmd.index("--dataset.single_task") + 1] == "pick the cube"
+    assert cmd[cmd.index("--dataset.push_to_hub") + 1] == "true"
+    assert cmd[cmd.index("--dataset.video") + 1] == "false"
+    # No pre-0.5 flat flags survive.
+    for stale in ("--repo-id", "--num-episodes", "--single-task", "--push-to-hub", "--no-video", "--robot-path"):
+        assert stale not in cmd
+
+
+def test_build_start_record_argv_matches_lerobot_record_fields() -> None:
+    """Cross-check every emitted ``--robot/teleop/dataset.<field>`` against the
+    real lerobot ``RecordConfig`` dataclasses, so field drift is caught.
+
+    Skipped when lerobot is not importable (it is in the ``[all]`` test env).
+    """
+    pytest.importorskip("lerobot.scripts.lerobot_record")
+    import dataclasses
+
+    from lerobot.configs.dataset import DatasetRecordConfig
+    from lerobot.robots import RobotConfig
+    from lerobot.scripts.lerobot_record import RecordConfig
+
+    dataset_fields = {f.name for f in dataclasses.fields(DatasetRecordConfig)}
+    record_fields = {f.name for f in dataclasses.fields(RecordConfig)}
+
+    cmd = build_lerobot_command(
+        action="start",
+        robot_type="so101_follower",
+        robot_port="/dev/ttyACM0",
+        robot_id="follower",
+        teleop_type="so101_leader",
+        teleop_port="/dev/ttyACM1",
+        teleop_id="leader",
+        dataset_repo_id="user/cubes",
+        dataset_single_task="pick the cube",
+        robot_cameras={"front": {"type": "opencv", "index_or_path": 0}},
+        display_data=True,
+    )
+    # Collect the flag stems (strip a trailing "=value" for cameras-style flags).
+    flags = [tok[2:].split("=", 1)[0] for tok in cmd if tok.startswith("--")]
+    robot_config_fields = {f.name for f in dataclasses.fields(RobotConfig)} | {
+        "type",
+        "port",
+        "cameras",
+        "left_arm_port",
+        "right_arm_port",
+    }
+    for flag in flags:
+        if flag.startswith("dataset."):
+            assert flag.split(".", 1)[1] in dataset_fields, f"{flag} not a DatasetRecordConfig field"
+        elif flag.startswith("robot."):
+            assert flag.split(".", 1)[1] in robot_config_fields, f"{flag} not a robot config field"
+        elif flag.startswith("teleop."):
+            # teleop mirrors robot's id/port/type namespacing.
+            assert flag.split(".", 1)[1] in {"type", "port", "id", "left_arm_port", "right_arm_port"}
+        else:
+            # Top-level RecordConfig flags (display_data, ...).
+            assert flag in record_fields, f"{flag} not a RecordConfig field"
 
 
 def test_build_start_teleop_command_without_dataset() -> None:
@@ -185,14 +264,21 @@ def test_build_start_teleop_command_without_dataset() -> None:
     assert "--teleop_time_s" in cmd
 
 
-def test_build_start_command_emits_camera_config() -> None:
+def test_build_start_command_emits_nested_camera_config() -> None:
+    """Cameras must be emitted as lerobot 0.5's nested ``--robot.cameras`` dict.
+
+    The pre-0.5 ``--camera-config name=type:path:fps:WxH`` flat form was removed
+    upstream; lerobot 0.5 parses a nested dict string instead.
+    """
     cmd = build_lerobot_command(
         action="start",
         robot_type="so101_follower",
         robot_cameras={"front": {"type": "opencv", "index_or_path": 2, "width": 1280, "height": 720, "fps": 60}},
     )
-    cam_args = [a for a in cmd if a.startswith("front=")]
-    assert cam_args == ["front=opencv:2:60:1280x720"]
+    cam_args = [a for a in cmd if a.startswith("--robot.cameras=")]
+    assert cam_args == ["--robot.cameras={front: {type: opencv, index_or_path: 2, width: 1280, height: 720, fps: 60}}"]
+    # The stale flat camera flag must not appear.
+    assert not any(a.startswith("--camera-config") for a in cmd)
 
 
 def test_build_command_rejects_unknown_action() -> None:

--- a/tests/tools/test_lerobot_teleoperate.py
+++ b/tests/tools/test_lerobot_teleoperate.py
@@ -205,10 +205,19 @@ def test_build_start_record_argv_matches_lerobot_record_fields() -> None:
     """
     pytest.importorskip("lerobot.scripts.lerobot_record")
     import dataclasses
+    import typing
 
-    from lerobot.configs.dataset import DatasetRecordConfig
-    from lerobot.robots import RobotConfig
     from lerobot.scripts.lerobot_record import RecordConfig
+
+    # Resolve the nested config classes from RecordConfig's own type hints rather
+    # than hardcoding their module paths. lerobot relocates these dataclasses
+    # between releases (DatasetRecordConfig and RobotConfig have lived under
+    # different modules across 0.5.x), so importing a fixed path breaks whenever
+    # the layout drifts. Following RecordConfig's resolved annotations keeps the
+    # field-drift cross-check pinned to whatever lerobot is installed.
+    record_hints = typing.get_type_hints(RecordConfig)
+    DatasetRecordConfig = record_hints["dataset"]
+    RobotConfig = record_hints["robot"]
 
     dataset_fields = {f.name for f in dataclasses.fields(DatasetRecordConfig)}
     record_fields = {f.name for f in dataclasses.fields(RecordConfig)}


### PR DESCRIPTION
## Problem

`lerobot_teleoperate`'s command builder shells out to `lerobot.scripts.lerobot_record` and `lerobot.scripts.lerobot_replay` using the **pre-0.5 flat CLI**:

```
--robot-path  --robot-port  --repo-id  --num-episodes  --single-task
--episode-time-s  --reset-time-s  --no-video  --push-to-hub        (record)
--robot-path  --policy-path  --episode  --robot-port               (replay)
--camera-config name=type:path:fps:WxH                             (cameras)
```

lerobot 0.5's `lerobot_record` / `lerobot_replay` are **draccus-nested** (`RecordConfig`/`ReplayConfig`, `DatasetRecordConfig`/`DatasetReplayConfig`). The flat flags no longer exist, so the scripts exit with `unrecognized arguments` (exit code 2) and **data collection never runs** through the tool. The teleop branch of the same builder already used the correct nested `--robot.type` / `--teleop.type` form; the record and replay branches were simply stale.

Verified against lerobot 0.5.2:

```
# OLD flat args -> rejected
$ python -m lerobot.scripts.lerobot_record --robot-path so101_follower --robot-port /dev/null \
    --repo-id u/d --num-episodes 1 --single-task x --no-video
lerobot_record.py: error: unrecognized arguments: --robot-path so101_follower --robot-port /dev/null \
    --repo-id u/d --num-episodes 1 --single-task x --no-video        # exit 2
```

## Change

Port the record and replay branches to lerobot 0.5's nested schema:

- `--robot.type / --robot.port / --robot.id / --robot.left_arm_port / --robot.right_arm_port`
- `--teleop.type / --teleop.port / --teleop.id / --teleop.{left,right}_arm_port`
- `--dataset.repo_id / --dataset.num_episodes / --dataset.single_task / --dataset.fps / --dataset.episode_time_s / --dataset.reset_time_s / --dataset.root / --dataset.push_to_hub / --dataset.video` (record)
- `--dataset.repo_id / --dataset.episode / --dataset.root` (replay)
- cameras as the nested `--robot.cameras={name: {type: opencv, index_or_path: 0, width: 640, height: 480, fps: 30}}` dict
- booleans as explicit `true`/`false` values
- drop `--display_data` for replay (`ReplayConfig` has no such field; emitting it would error)

The shared robot/teleop/camera argv is factored into small helpers so all three actions stay in lockstep. The public tool signature and its dict-shaped `robot_cameras` input are unchanged.

## Tests

- Updated the argv-mapping tests to assert the nested record/replay/teleop/camera schema.
- Added `test_build_start_record_argv_matches_lerobot_record_fields`: a cross-check that validates every emitted `--robot/teleop/dataset.<field>` against the real `RecordConfig` / `DatasetRecordConfig` dataclasses, so future lerobot field drift is caught (skips when lerobot is not importable).
- The new tests **fail on the pre-fix builder** (6 failures, including the schema cross-check catching `--robot-path`) and pass after.

```
45 passed   (tests/tools/test_lerobot_teleoperate.py + lazy-import)
ruff check / ruff format --check / mypy strands_robots tests tests_integ: clean
```

## End-to-end verification (lerobot 0.5.2)

The builder's nested argv is accepted by the real `lerobot_record` parser, which constructs a full `RecordConfig` and proceeds to robot init (here it stops at a bogus `/dev/null` port — no arg-parse error):

```
$ python -m lerobot.scripts.lerobot_record --robot.type so101_follower --robot.port /dev/null \
    --teleop.type so101_leader --teleop.port /dev/null --dataset.repo_id u/folding_smoke \
    --dataset.single_task "fold the cloth" --dataset.num_episodes 1 --dataset.fps 30 \
    --dataset.video false --dataset.push_to_hub false
INFO  t_record.py:355 {'dataset': {... 'repo_id': 'u/folding_smoke', 'num_episodes': 1,
                                   'fps': 30, 'push_to_hub': False, 'video': False ...}}
# parsed OK -> advances to robot connect (no 'unrecognized arguments')
```