### PR TITLE
chore: replace Unicode dashes with ASCII hyphen in strands_robots sources

### DIFF
--- a/strands_robots/__init__.py
+++ b/strands_robots/__init__.py
@@ -168,7 +168,7 @@ if _importlib_util.find_spec("mujoco") is not None:
 
 
 # Auto-configure the macOS dyld search path so torchcodec can find Homebrew's
-# ffmpeg with zero user setup — making ``sim.stream_dataset(...)`` video decode
+# ffmpeg with zero user setup - making ``sim.stream_dataset(...)`` video decode
 # work out of the box. No-op off macOS, without torchcodec, or when already set.
 # May re-exec the interpreter ONCE on a plain script run (guarded; never in
 # Jupyter/REPL/pytest). Opt out with STRANDS_ROBOTS_NO_DYLD_SHIM=1. See _dyld.py.

--- a/strands_robots/_dyld.py
+++ b/strands_robots/_dyld.py
@@ -26,12 +26,12 @@ The fix (zero-touch, idempotent)
 2. Set ``DYLD_FALLBACK_LIBRARY_PATH`` to include the ffmpeg lib dir. This makes
    child processes (DataLoader workers with ``num_workers>0``, subprocess
    training) inherit a correct environment immediately.
-3. For the CURRENT process, dyld already snapshotted its env — so if (and only
+3. For the CURRENT process, dyld already snapshotted its env - so if (and only
    if) the env var was not already correct, re-exec the interpreter ONCE with
    the augmented environment. A guard env var prevents an exec loop.
 
 Re-exec is gated tightly: it only fires when torchcodec is importable, ffmpeg is
-present, and the var was missing — i.e. exactly the case where video streaming
+present, and the var was missing - i.e. exactly the case where video streaming
 would otherwise crash. Headless/Linux/Jetson and torchcodec-less installs never
 re-exec. Opt out entirely with ``STRANDS_ROBOTS_NO_DYLD_SHIM=1``.
 """
@@ -80,7 +80,7 @@ def _torchcodec_installed() -> bool:
 def _is_safe_to_reexec() -> bool:
     """True only for plain ``python script.py`` / ``python -m`` execution.
 
-    Re-exec'ing replaces the process image — fine for a script, catastrophic
+    Re-exec'ing replaces the process image - fine for a script, catastrophic
     inside a Jupyter kernel, an IPython REPL, a pytest run, or an embedding
     host. Detect those and refuse to re-exec there (we still export the env var
     for child processes and warn the user how to fix the current one).
@@ -91,7 +91,7 @@ def _is_safe_to_reexec() -> bool:
     # Jupyter / IPython kernels.
     if "ipykernel" in sys.modules or "IPython" in sys.modules:
         return False
-    # Test runners — re-exec would detach from the collector.
+    # Test runners - re-exec would detach from the collector.
     if "pytest" in sys.modules or "PYTEST_CURRENT_TEST" in os.environ:
         return False
     # ``python -c '...'`` sets argv[0] to '-c'; nothing safe to re-run.
@@ -136,7 +136,7 @@ def ensure_ffmpeg_on_dyld_path() -> bool:
         return True
 
     # The CURRENT process needs the var set at launch (dyld snapshot). Re-exec
-    # once — but ONLY when it's safe (plain script run, not Jupyter/REPL/pytest).
+    # once - but ONLY when it's safe (plain script run, not Jupyter/REPL/pytest).
     if _is_safe_to_reexec():
         os.environ[_GUARD_ENV] = "1"
         try:

--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -764,7 +764,7 @@ class DatasetRecorder:
     ) -> dict[str, Any]:
         """Sync the on-disk LeRobotDataset into an HF Storage Bucket (Phase 1/2).
 
-        Mutable, Xet-deduplicated dump target for COLLECTION — avoids git-LFS
+        Mutable, Xet-deduplicated dump target for COLLECTION - avoids git-LFS
         history bloat of push_to_hub during recording. Daily re-sync uploads
         only changed chunks (content-defined chunking). Requires the ``hf`` CLI
         (huggingface_hub>=1.x) and ``hf auth login``.

--- a/strands_robots/mesh/iot/bootstrap.py
+++ b/strands_robots/mesh/iot/bootstrap.py
@@ -907,7 +907,7 @@ def _ensure_provisioning_role(account: BootstrappedAccount) -> str:
         RoleName=name,
         PolicyArn="arn:aws:iam::aws:policy/service-role/AWSIoTThingsRegistration",
     )
-    # IAM role propagation is eventually-consistent (typically 5–10s, but can
+    # IAM role propagation is eventually-consistent (typically 5-10s, but can
     # take up to 15s under load). The provisioning template creation hits IoT
     # which then tries to AssumeRole - without the propagation wait we get
     # InvalidRequestException("provisioning role cannot be assumed").

--- a/strands_robots/mesh/iot/camera_offload.py
+++ b/strands_robots/mesh/iot/camera_offload.py
@@ -3,8 +3,8 @@
 Why it exists
 -------------
 Raw camera frames are too large for AWS IoT MQTT (128 KB hard cap, plus the
-cost model is brutal at 5–10 Hz × N robots). Even a 640×480 JPEG @ quality 80
-is 30–60 KB; base64-wrapping it inside JSON inflates that 33%. Multiple
+cost model is brutal at 5-10 Hz × N robots). Even a 640×480 JPEG @ quality 80
+is 30-60 KB; base64-wrapping it inside JSON inflates that 33%. Multiple
 cameras per robot at typical operational rates clears 100+ KB/s/robot
 trivially.
 

--- a/strands_robots/mesh/iot/provision.py
+++ b/strands_robots/mesh/iot/provision.py
@@ -708,7 +708,7 @@ def _cleanup_stale_certs(iot: Any, thing_name: str) -> int:
     Re-running :func:`provision_robot` on the same Thing has historically
     caused certs to accumulate (each run issues a fresh cert because
     AWS doesn't expose previously-generated private keys). That left
-    Things with 5–10 ACTIVE certs after a few dev iterations, which is
+    Things with 5-10 ACTIVE certs after a few dev iterations, which is
     a footgun: every old cert is a credential that *could* be used to
     impersonate the robot.
 

--- a/strands_robots/policies/curobo/__init__.py
+++ b/strands_robots/policies/curobo/__init__.py
@@ -3,13 +3,13 @@
 The :class:`CuroboPolicy` is a thin wrapper around
 `NVIDIA cuRobo <https://curobo.org/>`_'s ``MotionGen`` planner. Unlike
 :class:`~strands_robots.policies.moveit2.MoveIt2Policy` (which talks to a
-ROS 2 sidecar over ZMQ), cuRobo runs **in process** as a CUDA library —
+ROS 2 sidecar over ZMQ), cuRobo runs **in process** as a CUDA library -
 there is no network round-trip, but a CUDA-capable GPU + the
 ``[curobo]`` extra (``nvidia-curobo``) are required.
 
 The shape of the policy is identical to the rest of the non-VLA family:
 
-* ``requires_images = False`` — planners ignore camera frames.
+* ``requires_images = False`` - planners ignore camera frames.
 * ``get_actions`` reads the goal from the well-known ``**kwargs`` keys
   (``target_pose`` / ``target_joints`` / ``world_update``).
 * The full collision-free trajectory is cached on the first call;

--- a/strands_robots/policies/curobo/policy.py
+++ b/strands_robots/policies/curobo/policy.py
@@ -276,7 +276,7 @@ class CuroboPolicy(Policy):
         """cuRobo plans from joint state + collision world, never images.
 
         Returning ``False`` lets the simulation skip camera rendering for
-        this provider — same throughput optimisation
+        this provider - same throughput optimisation
         :class:`~strands_robots.policies.moveit2.MoveIt2Policy` and
         :class:`~strands_robots.policies.mock.MockPolicy` expose.
         """
@@ -417,7 +417,7 @@ class CuroboPolicy(Policy):
         if target_joints is not None:
             self._validate_target_joints(target_joints)
 
-        # 3. Cache check — if the previous trajectory still has unyielded
+        # 3. Cache check - if the previous trajectory still has unyielded
         # rows AND no new goal forces a replan, just stream the next
         # chunk. Otherwise re-plan from the current state.
         if not self._cache_has_waypoints() or replan:
@@ -908,7 +908,7 @@ class CuroboPolicy(Policy):
         from such a payload so the LLM-agent demo path works without
         forcing the agent to learn a new kwargs API.
 
-        Returns ``(None, None)`` when no goal is found — the caller will
+        Returns ``(None, None)`` when no goal is found - the caller will
         then raise :class:`ValueError`.
         """
         if not instruction or not isinstance(instruction, str):

--- a/strands_robots/policies/moveit2/__init__.py
+++ b/strands_robots/policies/moveit2/__init__.py
@@ -2,7 +2,7 @@
 
 The :class:`MoveIt2Policy` is a thin ZMQ + msgpack client that talks to a
 sidecar ROS 2 node running ``moveit_py``. ROS 2 lives entirely out of
-process, so users without ROS 2 sourced are unaffected — the only
+process, so users without ROS 2 sourced are unaffected - the only
 client-side dependencies are ``pyzmq`` and ``msgpack`` (extra ``[moveit2]``).
 
 Wire protocol (mirrors :class:`~strands_robots.policies.groot.client.Gr00tInferenceClient`)::
@@ -21,7 +21,7 @@ Wire protocol (mirrors :class:`~strands_robots.policies.groot.client.Gr00tInfere
     }
 
 The reference sidecar implementation lives under
-:mod:`strands_robots.policies.moveit2.server` (import-only Python source —
+:mod:`strands_robots.policies.moveit2.server` (import-only Python source -
 the ROS 2 deps stay out of ``pyproject.toml``).
 
 Subtask 3 of issue #299. The :class:`Policy` ABC contract for non-VLA

--- a/strands_robots/policies/moveit2/client.py
+++ b/strands_robots/policies/moveit2/client.py
@@ -4,7 +4,7 @@ Mirrors the shape of :class:`~strands_robots.policies.groot.client.Gr00tInferenc
 so users familiar with the GR00T service-mode pattern can use the same mental
 model. The only wire types are JSON-equivalent values plus 1-D / 2-D float
 arrays (joint state and trajectory rows), so we keep msgpack handling
-deliberately minimal — no custom ``__class__`` markers, no numpy probing on
+deliberately minimal - no custom ``__class__`` markers, no numpy probing on
 the hot path.
 """
 
@@ -66,13 +66,13 @@ class MoveIt2InferenceClient:
     """ZMQ REQ client for the MoveIt2 sidecar.
 
     Args:
-        host: Server hostname or IP. Default ``"127.0.0.1"`` — bind to
+        host: Server hostname or IP. Default ``"127.0.0.1"`` - bind to
             loopback by default; users opt into network exposure.
         port: Server port.
         timeout_ms: Socket send/recv timeout in milliseconds.
         api_token: Optional token included in every request for
             authentication. When unset, no auth is sent. Sent in
-            plaintext over TCP — use a TLS tunnel or SSH port-forward
+            plaintext over TCP - use a TLS tunnel or SSH port-forward
             for non-localhost deployments (same caveat as
             :class:`~strands_robots.policies.groot.client.Gr00tInferenceClient`).
     """
@@ -197,7 +197,7 @@ class MoveIt2InferenceClient:
     def _teardown(self) -> None:
         """Best-effort ZMQ socket + context teardown.
 
-        Extracted from ``__del__`` so the destructor stays one line — CodeQL
+        Extracted from ``__del__`` so the destructor stays one line - CodeQL
         flags non-trivial logic in ``__del__`` because exceptions raised
         during interpreter shutdown are swallowed silently and can mask
         resource leaks.

--- a/strands_robots/policies/moveit2/policy.py
+++ b/strands_robots/policies/moveit2/policy.py
@@ -26,7 +26,7 @@ service mode:
         target_pose=[0.3, 0.0, 0.4, 1.0, 0.0, 0.0, 0.0],
     )
 
-The ROS 2 / ``moveit_py`` deps stay out of ``pyproject.toml`` — only the
+The ROS 2 / ``moveit_py`` deps stay out of ``pyproject.toml`` - only the
 client side (``pyzmq``, ``msgpack``) is installed via the ``[moveit2]`` extra.
 See :mod:`strands_robots.policies.moveit2.server` for the sidecar reference
 implementation and :mod:`strands_robots.policies.moveit2.server.docker-compose.yml`
@@ -57,12 +57,12 @@ _JOINT_NAME_PATTERN = r"^[A-Za-z][A-Za-z0-9_-]*$"
 class MoveIt2Policy(Policy):
     """ZMQ + msgpack client for the MoveIt2 sidecar.
 
-    The policy is intentionally thin — all motion-planning state lives in
+    The policy is intentionally thin - all motion-planning state lives in
     the sidecar. This keeps the Python process free of ROS 2 deps and lets
     a single sidecar serve multiple agent processes.
 
     Args:
-        host: Sidecar hostname. Default ``"127.0.0.1"`` (loopback only —
+        host: Sidecar hostname. Default ``"127.0.0.1"`` (loopback only -
             users opt into network exposure).
         port: Sidecar port.
         planning_group: Default MoveIt2 planning-group name. Per-call
@@ -142,7 +142,7 @@ class MoveIt2Policy(Policy):
         """MoveIt2 plans from joint state + collision world, never images.
 
         Returning ``False`` lets the simulation skip camera rendering for
-        this provider — same throughput optimisation
+        this provider - same throughput optimisation
         :class:`~strands_robots.policies.mock.MockPolicy` exposes.
         """
         return False
@@ -166,7 +166,7 @@ class MoveIt2Policy(Policy):
         randomised samplers (RRT-Connect, KPIECE) that the sidecar may
         expose.
 
-        Best-effort — any failure (server doesn't expose ``reset``,
+        Best-effort - any failure (server doesn't expose ``reset``,
         endpoint raises, network timeout) is logged and swallowed. Eval
         correctness is preserved even when reset is a no-op (the next
         ``plan`` call re-derives state from ``joint_state``).
@@ -197,7 +197,7 @@ class MoveIt2Policy(Policy):
         or ``target_joints`` must be provided; if both are set,
         ``target_joints`` wins (matches the MoveIt2 ``setJointValueTarget``
         precedence). If neither is provided, raises ``ValueError`` rather
-        than returning a no-op trajectory — the issue #300 contract says
+        than returning a no-op trajectory - the issue #300 contract says
         unknown kwargs are silently ignored, but a missing goal is a
         caller bug, not an unknown extension.
 
@@ -224,7 +224,7 @@ class MoveIt2Policy(Policy):
 
         Returns:
             List of action dicts; one entry per trajectory waypoint (the
-            time column from the sidecar is dropped — :class:`Robot`
+            time column from the sidecar is dropped - :class:`Robot`
             consumes per-step joint targets, the runner schedules the
             timing).
 
@@ -313,7 +313,7 @@ class MoveIt2Policy(Policy):
     def _unpack_trajectory(self, trajectory: list[list[float]]) -> list[dict[str, Any]]:
         """Convert ``[[t, q0, q1, ...], ...]`` rows into per-step action dicts.
 
-        The leading time column is dropped — the runner schedules the
+        The leading time column is dropped - the runner schedules the
         timing. If ``set_robot_state_keys`` was called, joint names come
         from there; otherwise we emit ``"joint_<i>"`` keys derived from
         the row width.
@@ -391,7 +391,7 @@ class MoveIt2Policy(Policy):
 
         if not isinstance(planning_group, str):
             raise ValueError(f"planning_group must be a str, got {type(planning_group).__name__}")
-        # Same charset as joint names — matches the MoveIt2 group naming
+        # Same charset as joint names - matches the MoveIt2 group naming
         # conventions documented at https://moveit.picknik.ai/.
         if not re.match(r"^[A-Za-z][A-Za-z0-9_-]{0,63}$", planning_group):
             raise ValueError(

--- a/strands_robots/policies/moveit2/server/__init__.py
+++ b/strands_robots/policies/moveit2/server/__init__.py
@@ -1,18 +1,18 @@
 """Reference ROS 2 / ``moveit_py`` sidecar for :class:`MoveIt2Policy`.
 
 This package is **import-only** Python source. The ROS 2 / ``moveit_py``
-deps stay out of ``pyproject.toml`` — the sidecar is meant to run inside a
+deps stay out of ``pyproject.toml`` - the sidecar is meant to run inside a
 ROS 2 environment (``source /opt/ros/jazzy/setup.bash`` + ``moveit_py``
 installed) and the strands-robots client side talks to it via ZMQ +
 msgpack from a plain Python venv.
 
 Two recommended ways to run the sidecar:
 
-1. **Docker compose** — see ``docker-compose.yml`` next to this module.
+1. **Docker compose** - see ``docker-compose.yml`` next to this module.
    ``docker compose up`` brings up a ``moveit_py`` container exposing
    port 5556 and connects the client transparently.
 
-2. **Native ROS 2** — source your ROS 2 distro and ``moveit_py``, then::
+2. **Native ROS 2** - source your ROS 2 distro and ``moveit_py``, then::
 
        python -m strands_robots.policies.moveit2.server.zmq_node \\
            --port 5556 --planning-group arm

--- a/strands_robots/policies/moveit2/server/zmq_node.py
+++ b/strands_robots/policies/moveit2/server/zmq_node.py
@@ -2,7 +2,7 @@
 
 This is a **reference implementation** matching the wire protocol the
 client (:class:`strands_robots.policies.moveit2.MoveIt2Policy`) expects.
-It is intentionally minimal — production deployments should fork this
+It is intentionally minimal - production deployments should fork this
 file and harden it for their own collision world / planner pipeline /
 auth posture.
 
@@ -13,7 +13,7 @@ Run it with::
     python -m strands_robots.policies.moveit2.server.zmq_node \\
         --port 5556 --planning-group arm
 
-The sidecar is single-threaded REQ/REP — one in-flight plan request at a
+The sidecar is single-threaded REQ/REP - one in-flight plan request at a
 time. That matches the ``MoveItPy.plan()`` API which is itself
 single-threaded.
 
@@ -29,7 +29,7 @@ Wire protocol::
                 "success": bool,
                 "status": str}
 
-The trajectory rows are ``[time_from_start_seconds, q0, q1, ..., qN]`` —
+The trajectory rows are ``[time_from_start_seconds, q0, q1, ..., qN]`` -
 the time column lets the client / runner schedule waypoints precisely.
 
 Notes for forks:
@@ -38,7 +38,7 @@ Notes for forks:
   production sidecar should validate it against a known schema (e.g.
   expect ``{"depth_topic": str, "stamp": int, "frame_id": str}``) before
   pushing to the planning scene.
-* ``api_token`` validation is left as an exercise — the reference
+* ``api_token`` validation is left as an exercise - the reference
   implementation accepts any client. Enable it by checking
   ``request.get("api_token")`` against an env-var / file secret.
 """
@@ -73,7 +73,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--port",
         type=int,
         default=5556,
-        help="Bind port. Default 5556 — matches MoveIt2Policy's default.",
+        help="Bind port. Default 5556 - matches MoveIt2Policy's default.",
     )
     parser.add_argument(
         "--planning-group",

--- a/strands_robots/policies/vera/__init__.py
+++ b/strands_robots/policies/vera/__init__.py
@@ -1,6 +1,6 @@
-"""VERA policy provider — video-to-action (two-stage planner + Jacobian IDM).
+"""VERA policy provider - video-to-action (two-stage planner + Jacobian IDM).
 
-VERA (Video-to-Embodied Robot Action, MIT/CSAIL — https://github.com/sizhe-li/VERA)
+VERA (Video-to-Embodied Robot Action, MIT/CSAIL - https://github.com/sizhe-li/VERA)
 is a two-stage closed-loop video-to-action policy: an embodiment-agnostic video
 planner (DFoT / WAN) dreams future frames, and an embodiment-specific Jacobian
 IDM translates the dream into robot actions. *One video planner, many IDMs.*

--- a/strands_robots/policies/vera/_msgpack_numpy.py
+++ b/strands_robots/policies/vera/_msgpack_numpy.py
@@ -1,10 +1,10 @@
-"""Vendored msgpack codec with NumPy support — wire-compatible with VERA's server.
+"""Vendored msgpack codec with NumPy support - wire-compatible with VERA's server.
 
 Mirrors ``vera/server/protocol/_msgpack_numpy.py`` (itself a port of
 DreamZero / openpi_client's ``msgpack_numpy``): ndarrays and numpy scalars are
 encoded as tagged maps so dicts-of-arrays pack/unpack directly over the
 websocket. Vendored (not imported from ``vera``) so the client has **zero**
-dependency on the heavy ``vera`` package — only ``msgpack`` + ``numpy`` — and
+dependency on the heavy ``vera`` package - only ``msgpack`` + ``numpy`` - and
 composes with any numpy version (matching the ``cosmos3`` client rationale).
 """
 

--- a/strands_robots/policies/vera/client.py
+++ b/strands_robots/policies/vera/client.py
@@ -1,7 +1,7 @@
 """Self-contained WebSocket client for the VERA policy server.
 
 Speaks VERA's websocket wire protocol (``vera/server/protocol/``) directly using
-only ``websockets`` + ``msgpack`` + a vendored NumPy packer — **no dependency on
+only ``websockets`` + ``msgpack`` + a vendored NumPy packer - **no dependency on
 the ``vera`` package** at client time. This mirrors the ``cosmos3`` client: the
 heavy model stack lives in the server subprocess; the client is import-light and
 composes with any numpy version.
@@ -9,13 +9,13 @@ composes with any numpy version.
 Wire contract (verified against ``vera.server.protocol.websocket_policy_client``
 and ``vera.controller.run_mimicgen_eval.RemotePolicy``):
 
-* On connect the server sends one msgpack metadata blob — the
+* On connect the server sends one msgpack metadata blob - the
   ``VeraServerConfig`` (``view_keys``, ``context_frames``, ``action_space``,
   ``action_dim``, ``action_horizon``, ``control_dt``, ``gripper_dim_index`` …).
 * ``infer`` request = ``{"context_rgb": (T,H,W,3) uint8, "view_keys": [...],
   "view_widths": [...], "session_id": str, "prompt"?: str, "endpoint": "infer"}``.
 * ``infer`` response = ``{"action": np.ndarray[H, D], ...}``.
-* A *string* response is the error sentinel — raise.
+* A *string* response is the error sentinel - raise.
 """
 
 from __future__ import annotations
@@ -96,14 +96,14 @@ class VeraWebsocketClient:
         """Send one inference request; return the server response dict.
 
         Args:
-            observation: Wire dict — must carry ``context_rgb`` (the rolling
+            observation: Wire dict - must carry ``context_rgb`` (the rolling
                 context window), ``view_keys``, ``view_widths`` and
                 ``session_id``; ``prompt`` is optional (only when the server
                 was launched with text conditioning).
 
         Returns:
-            Response dict containing at least ``"action"`` — an ``[H, D]``
-            NumPy array — the chunk the controller plays before refilling.
+            Response dict containing at least ``"action"`` - an ``[H, D]``
+            NumPy array - the chunk the controller plays before refilling.
         """
         ws = self._ensure()
         msg = {**observation, "endpoint": "infer"}
@@ -118,7 +118,7 @@ class VeraWebsocketClient:
         try:
             ws = self._ensure()
         except ConnectionError:
-            # Reset is best-effort — never a correctness requirement (mirrors
+            # Reset is best-effort - never a correctness requirement (mirrors
             # Cosmos3WebsocketClient.reset / Gr00tPolicy.reset).
             return
         msg = {**(reset_info or {}), "endpoint": "reset"}

--- a/strands_robots/policies/vera/config.py
+++ b/strands_robots/policies/vera/config.py
@@ -26,7 +26,7 @@ Embodiment = Literal["pusht", "mimicgen", "allegro", "droid"]
 # provider -> server -> action plumbing rather than producing a solving
 # rollout. "allegro"/"droid" are code-present but checkpoint-absent (Wave 2).
 
-# Per-embodiment default ports (policy, viz) — match the VERA examples
+# Per-embodiment default ports (policy, viz) - match the VERA examples
 # (PushT uses 8820/8821; everything else uses 8800/8801).
 # Per-embodiment per-view render width the VERA WAN/DFoT planner expects. The
 # server does NOT advertise this (image_resolution is None); it is the client's
@@ -86,7 +86,7 @@ class VeraConfig:
     the environment win for deploy-time knobs (ports, checkpoint roots).
 
     Args:
-        embodiment: VERA embodiment — selects the WAN/DFoT planner + Jacobian
+        embodiment: VERA embodiment - selects the WAN/DFoT planner + Jacobian
             IDM pair and the client-side action adapter.
         host: Policy-server hostname.
         server_port: Policy-server websocket port (per-embodiment default).
@@ -191,7 +191,7 @@ class VeraConfig:
         if self.docker_container_name is None:
             self.docker_container_name = _env("VERA_DOCKER_CONTAINER") or f"vera-server-{self.embodiment}"
 
-        # Coerce string paths to Path (defensive — callers may pass str).
+        # Coerce string paths to Path (defensive - callers may pass str).
         if self.algo_config is not None and not isinstance(self.algo_config, Path):
             self.algo_config = Path(self.algo_config)
         if self.ckpt_root is not None and not isinstance(self.ckpt_root, Path):

--- a/strands_robots/policies/vera/docker/sitecustomize_vera.py
+++ b/strands_robots/policies/vera/docker/sitecustomize_vera.py
@@ -11,7 +11,7 @@ torchmetrics (the version the NGC base ships):
 Rather than pin torchmetrics back to 0.11.x (which collides with lightning 2.6),
 we keep the modern torchmetrics and re-expose the names VERA expects. These are
 **eval-only metrics** not used on the inference rollout path, so the shim only
-needs to satisfy the import — exactness of the metric is irrelevant for serving.
+needs to satisfy the import - exactness of the metric is irrelevant for serving.
 """
 
 from __future__ import annotations
@@ -29,7 +29,7 @@ def _apply() -> None:
         if priv is not None:
             _lpip.NoTrainLpips = priv
 
-    # _valid_img: removed from the public module in modern torchmetrics — provide
+    # _valid_img: removed from the public module in modern torchmetrics - provide
     # a faithful reimplementation (range/shape check used by the LPIPS metric).
     if not hasattr(_lpip, "_valid_img"):
 

--- a/strands_robots/policies/vera/docker/wandb_offline_resolve.py
+++ b/strands_robots/policies/vera/docker/wandb_offline_resolve.py
@@ -5,7 +5,7 @@ Why this exists
 VERA loads its Jacobian IDM by **wandb run id**: ``load_checkpoint`` builds a
 ``run_path = "{entity}/{project}/{run_id}"`` and calls
 ``vera.utils.ckpt_utils.download_checkpoint``, which does
-``wandb.Api().run(run_path)`` **unconditionally** — before it checks whether the
+``wandb.Api().run(run_path)`` **unconditionally** - before it checks whether the
 checkpoint already exists on disk. In an offline container (no wandb network /
 no API key) that call raises, so the server never comes up.
 
@@ -21,7 +21,7 @@ already imported into ``vera.policy.motion_policy_loading``) with a version that
 
 1. Scans ``$VERA_CKPT_ROOT`` for ``*/provenance.json`` whose ``wandb_run`` matches
    the requested ``run_path`` (full ``entity/project/run_id`` OR just the trailing
-   ``run_id`` — tolerant of the entity/project drift between code defaults and the
+   ``run_id`` - tolerant of the entity/project drift between code defaults and the
    released artifacts).
 2. If found, returns that dir's ``model.ckpt`` (+ the ``config.yaml`` sidecar as
    the run config when ``return_config=True``), exactly like the real function.

--- a/strands_robots/policies/vera/ee_frame.py
+++ b/strands_robots/policies/vera/ee_frame.py
@@ -4,17 +4,17 @@ VERA's ``eef_delta`` (mimicgen) and ``cartesian_delta`` (droid) embodiments emit
 end-effector pose *deltas*; driving a MuJoCo arm needs an IK target frame (the
 body/site the Cartesian task tracks). The robot registry does **not** record an
 ee-frame, so we discover it from the compiled ``mujoco.MjModel`` with a robust,
-namespace-aware heuristic — making eef-delta embodiments **zero-config**.
+namespace-aware heuristic - making eef-delta embodiments **zero-config**.
 
 Heuristic (first match wins), scoped to the robot's ``namespace`` (``<robot>/``):
   1. A **site** whose name hints at the tool point:
      ``attachment_site`` | ``grasp`` | ``ee`` | ``tcp`` | ``pinch`` | ``flange``
-     — these are the conventional MuJoCo IK targets (e.g. menagerie Panda ships
+     - these are the conventional MuJoCo IK targets (e.g. menagerie Panda ships
      ``attachment_site``). Sites are preferred: they are the intended TCP.
   2. A **body** whose name hints at the hand/tool:
      ``hand`` | ``gripper`` | ``tool`` | ``ee`` | ``tcp`` | ``wrist`` | ``flange``.
   3. The **leaf body** of the robot's kinematic chain (the descendant of the
-     robot's joints that has no child body) — the last link, where a tool mounts.
+     robot's joints that has no child body) - the last link, where a tool mounts.
 
 Returns ``(frame_name, frame_type)`` ready for ``mink.FrameTask`` /
 ``MinkIKBridge`` (frame_type ∈ {``"site"``, ``"body"``}); names keep the robot

--- a/strands_robots/policies/vera/provider.py
+++ b/strands_robots/policies/vera/provider.py
@@ -1,4 +1,4 @@
-"""VERA policy provider — :class:`Policy` implementation for strands-robots.
+"""VERA policy provider - :class:`Policy` implementation for strands-robots.
 
 VERA (Video-to-Embodied Robot Action, MIT/CSAIL) is a two-stage closed-loop
 video-to-action policy: an embodiment-agnostic **video planner** (DFoT / WAN)
@@ -19,7 +19,7 @@ VERA is *video-first*: it consumes the camera frame(s) only (proprio is read
 server-side from its own sim/IDM where needed). The provider keeps a rolling
 **context window** of the last ``context_frames`` camera frames (width-concat
 across views, matching the server's ``view_keys`` order) and calls the server's
-chunked ``infer`` when its local action queue drains — exactly the
+chunked ``infer`` when its local action queue drains - exactly the
 ``RemotePolicy`` contract from VERA's own eval harness.
 
 Action flow
@@ -28,7 +28,7 @@ The server returns ``{"action": np.ndarray[H, D]}``. Actions are queued and
 popped one per :meth:`get_actions` chunk request; each ``D``-vector is mapped to
 robot actuator names via ``action_mapping`` (or the embodiment's default action
 column names). Values are coerced to python ``float`` / ``list[float]`` per the
-:class:`Policy` contract — never raw ``np.ndarray``.
+:class:`Policy` contract - never raw ``np.ndarray``.
 """
 
 from __future__ import annotations
@@ -122,7 +122,7 @@ class VeraPolicy(Policy):
         config: Pre-built :class:`VeraConfig` (overrides the kwargs above).
 
     Notes:
-        * Needs camera frames — ``requires_images`` is ``True``.
+        * Needs camera frames - ``requires_images`` is ``True``.
         * Latency is chunked (a diffusion video planner), not 500 Hz servo;
           one infer returns ``action_horizon`` steps.
     """
@@ -261,7 +261,7 @@ class VeraPolicy(Policy):
         already configured unless ``force``. Picks the rotation encoding from the
         server's ``action_space`` once the metadata handshake has happened
         (``cartesian_delta`` => axis-angle dim 3; ``eef_delta`` => axis-angle dim 3
-        by default — override via ``set_ik_target(rotation_dim=...)``).
+        by default - override via ``set_ik_target(rotation_dim=...)``).
 
         Returns:
             True when an ee-frame was resolved + configured, else False.
@@ -290,7 +290,7 @@ class VeraPolicy(Policy):
         world model + this robot's namespace. Triggers IK auto-config for
         eef/cartesian-delta embodiments; a no-op for joint_position / pos.
 
-        Safe to call before the server handshake — auto-config is also retried
+        Safe to call before the server handshake - auto-config is also retried
         lazily on first eef-delta infer if the action_space turns out to need it.
         """
         self._mj_model = mj_model
@@ -423,13 +423,13 @@ class VeraPolicy(Policy):
         """Convert a raw ``[H, D]`` VERA chunk into a list of robot-actuator dicts.
 
         Routes on the server's ``action_space`` so each provider output maps onto
-        the robot's REAL joint/actuator names (what ``send_action`` resolves) —
+        the robot's REAL joint/actuator names (what ``send_action`` resolves) -
         never bare ``action_i`` keys (which the sim drops as unresolved):
 
         * ``joint_position`` (allegro): columns map directly onto
           ``robot_state_keys`` (positional joint targets).
         * ``eef_delta`` / ``cartesian_delta`` (mimicgen / droid): the chunk is a
-          6-DoF end-effector delta — IK the whole chunk to joint targets keyed by
+          6-DoF end-effector delta - IK the whole chunk to joint targets keyed by
           ``robot_state_keys`` (needs ``set_ik_target`` / a ``mj_model`` kwarg).
         * ``pos`` / unknown: keep server column names (or ``action_mapping``).
         """
@@ -460,7 +460,7 @@ class VeraPolicy(Policy):
 
         Priority: explicit ``action_mapping`` > robot joint names
         (``robot_state_keys``, the names ``send_action`` resolves) > server
-        default ``action_{i}`` (last-resort; warned once — the sim would drop it).
+        default ``action_{i}`` (last-resort; warned once - the sim would drop it).
         """
         # 1) explicit caller-provided rename.
         if self.action_mapping:
@@ -570,7 +570,7 @@ class VeraPolicy(Policy):
         addr: dict[str, int] = {}
         # Real MjModel: map robot_state_keys -> qpos addresses by (namespaced)
         # joint name. Falls back to a positional identity map when the model
-        # lacks MuJoCo joint introspection (e.g. a test stub) — state_key i -> i.
+        # lacks MuJoCo joint introspection (e.g. a test stub) - state_key i -> i.
         try:
             import mujoco
 

--- a/strands_robots/policies/vera/server_runner.py
+++ b/strands_robots/policies/vera/server_runner.py
@@ -1,12 +1,12 @@
 """Managed VERA policy-server subprocess.
 
 Launches ``python -m vera.server.start_vera_server`` with **list args** (never a
-shell string — see PR #621 feedback), health-checks the websocket before
+shell string - see PR #621 feedback), health-checks the websocket before
 returning, streams the server's stdout/stderr to the logger, and shuts the
 process down cleanly on :meth:`stop`.
 
 The server holds the GPU and the two-stage model; this provider talks to it over
-the websocket (see :mod:`client`). Auto-launch is optional — point the provider
+the websocket (see :mod:`client`). Auto-launch is optional - point the provider
 at an already-running server by setting ``auto_launch_server=False``.
 """
 
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 
 def _port_open(host: str, port: int, timeout: float = 1.0) -> bool:
     """True if a TCP connection to ``host:port`` succeeds (server is listening)."""
-    # 0.0.0.0 is a bind address, not connectable — probe loopback instead.
+    # 0.0.0.0 is a bind address, not connectable - probe loopback instead.
     probe_host = "127.0.0.1" if host in ("0.0.0.0", "") else host
     try:
         with socket.create_connection((probe_host, port), timeout=timeout):
@@ -93,7 +93,7 @@ class VeraServerRunner:
         """Launch the server (idempotent) and block until its websocket is up."""
         cfg = self.config
 
-        # Already serving (ours or someone else's) — reuse it.
+        # Already serving (ours or someone else's) - reuse it.
         if _port_open(cfg.host, int(cfg.server_port or 0)):
             logger.info("VERA server already listening on %s:%s; reusing", cfg.host, cfg.server_port)
             return
@@ -146,7 +146,7 @@ class VeraServerRunner:
         self.stop()
         raise TimeoutError(
             f"VERA server did not become ready on {cfg.host}:{cfg.server_port} "
-            f"within {cfg.server_ready_timeout:.0f}s (WAN model load can be slow — "
+            f"within {cfg.server_ready_timeout:.0f}s (WAN model load can be slow - "
             f"raise server_ready_timeout / VERA_SERVER_READY_TIMEOUT if needed)."
         )
 
@@ -240,7 +240,7 @@ class DockerServerRunner:
             cmd += ["-p", f"{cfg.vis_port}:{cfg.vis_port}"]
         if cfg.ckpt_root is not None:
             cmd += ["-v", f"{cfg.ckpt_root}:/ckpts:ro"]
-        # WAN base (frozen Wan2.1-T2V-1.3B) — REQUIRED for mimicgen/omni, unused for
+        # WAN base (frozen Wan2.1-T2V-1.3B) - REQUIRED for mimicgen/omni, unused for
         # pusht. Mounted read-only at /wan; the container's algo_config reads it via
         # ${oc.env:VERA_WAN_CKPT_ROOT}. Falls back to the ckpt root (harmless no-op
         # bind) so pusht works without the separate download.
@@ -313,7 +313,7 @@ class DockerServerRunner:
         self.stop()
         raise TimeoutError(
             f"VERA container did not become ready on {cfg.host}:{cfg.server_port} "
-            f"within {cfg.server_ready_timeout:.0f}s (WAN model load can be slow — "
+            f"within {cfg.server_ready_timeout:.0f}s (WAN model load can be slow - "
             f"raise server_ready_timeout / VERA_SERVER_READY_TIMEOUT)."
         )
 

--- a/strands_robots/policies/vera/sim_ik.py
+++ b/strands_robots/policies/vera/sim_ik.py
@@ -10,7 +10,7 @@ This module is **copied** from (and intentionally independent of) the cosmos3
 ``sim_ik.py``: the cosmos3 version decodes an *absolute* EE pose trajectory
 (translation + rot6d) for its in-process diffusers backend, whereas VERA emits
 *relative* deltas. Copying (rather than sharing) keeps the two providers'
-kinematics decoupled — a change to one model's action semantics can never
+kinematics decoupled - a change to one model's action semantics can never
 silently break the other. The shared piece is only the generic ``mink`` solver
 wrapper (:class:`MinkIKBridge`); the VERA-specific decode lives in
 :func:`decode_vera_delta_chunk_to_targets`.
@@ -41,7 +41,7 @@ def _install_hint() -> str:
         "  uv pip install 'strands-robots[sim-mujoco]' mink\n"
         "This turns VERA's end-effector delta chunk (mimicgen/droid) into joint "
         "targets the MuJoCo arm can track. For joint_position embodiments "
-        "(allegro) no IK is needed — the action maps directly to joints."
+        "(allegro) no IK is needed - the action maps directly to joints."
     )
 
 
@@ -214,14 +214,14 @@ def decode_vera_delta_chunk_to_targets(
 
     VERA emits, per step, ``[translation(3), rotation(rotation_dim), gripper?]``
     as a delta on the *current* end-effector pose. We re-anchor each delta on the
-    arm's **achieved** EE pose (closed loop — the FK of the previous IK solve),
+    arm's **achieved** EE pose (closed loop - the FK of the previous IK solve),
     mirroring how robot deploy servers anchor on the observed pose so per-step
     tracking error stays bounded instead of compounding down the chunk.
 
     Args:
         action_chunk: ``[T, D]`` VERA action chunk (per-step EE delta + gripper).
         ik_bridge: A :class:`MinkIKBridge` over the target arm's MuJoCo model.
-        q_init: Seed joint config (length ``model.nq``) — the robot's current pose.
+        q_init: Seed joint config (length ``model.nq``) - the robot's current pose.
         rotation_dim: 3 (axis-angle) or 6 (rot6d) rotation delta encoding.
         has_gripper: Whether the chunk carries a trailing gripper column.
         gripper_dim_index: Index of the gripper column (``-1`` => last when

--- a/strands_robots/simulation/mujoco/recording.py
+++ b/strands_robots/simulation/mujoco/recording.py
@@ -306,7 +306,7 @@ class RecordingMixin:
                 artifact). Overrides the ``push_to_hub`` set at start_recording.
             bucket: If set (e.g. ``"my-org/robot-fave"``), sync the dataset into
                 a mutable HF Storage Bucket instead of/in addition to the dataset
-                repo — the Phase 1/2 collection target (Xet-deduped, overwrite in
+                repo - the Phase 1/2 collection target (Xet-deduped, overwrite in
                 place). See reports/STREAMING_DATA_LOOP_DEEP_DIVE.md §2.4 / App. A.
             run_id: Optional subpath inside the bucket (defaults to dataset name).
         """
@@ -382,7 +382,7 @@ class RecordingMixin:
         root = recorder.root
 
         # Finalize FIRST so meta/ (stats/info) is written before any bucket sync
-        # — streaming/training downstream needs it (App. F.2).
+        # - streaming/training downstream needs it (App. F.2).
         recorder.finalize()
 
         # #708 - parquet-truth gate. The recorder's ``episode_count`` is the
@@ -391,8 +391,8 @@ class RecordingMixin:
         # downstream consumers (HF hub, training loaders, audit tools) trust.
         # If they disagree, the on-disk dataset is the source of truth (Law-7
         # in AGENTS.md: parquet num_rows > meta/info.json > markdown). Surface
-        # the mismatch in the returned payload so the caller — and any CI that
-        # parses the status dict — can fail loudly instead of shipping a
+        # the mismatch in the returned payload so the caller - and any CI that
+        # parses the status dict - can fail loudly instead of shipping a
         # silent-collapse dataset.
         parquet_episode_count: int | None = None
         episode_count_mismatch: bool = False
@@ -573,7 +573,7 @@ class RecordingMixin:
         }
 
     def stream_dataset(self, repo_id: str, **kwargs):
-        """Open a streaming reader for a LeRobotDataset — read frames straight
+        """Open a streaming reader for a LeRobotDataset - read frames straight
         from the Hub (or a local root) with no full materialization.
 
         This is the in-process counterpart to ``start_recording`` /
@@ -587,7 +587,7 @@ class RecordingMixin:
             repo_id: HF dataset id (e.g. ``"lerobot/svla_so100_pickplace"``) or
                 a local repo_id paired with ``root=``.
             **kwargs: Forwarded to
-                :meth:`StreamingDatasetReader.open` — e.g. ``root``,
+                :meth:`StreamingDatasetReader.open` - e.g. ``root``,
                 ``delta_timestamps``, ``episodes``, ``shuffle``, ``buffer_size``,
                 ``max_num_shards``, ``drop_videos`` (proprio-only, torchcodec-free).
 

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -288,7 +288,7 @@ class PolicyRunner:
     # ``evaluate`` / ``_evaluate_with_spec`` records ONE giant episode of
     # ``n_episodes * max_steps`` frames into the dataset. The agent sees
     # ``total_episodes=1`` in the parquet meta but a status=OK summary
-    # because the recorder did receive frames. (#708 — silent collapse.)
+    # because the recorder did receive frames. (#708 - silent collapse.)
     #
     # Calling this at the end of each policy-runner episode forces a per-
     # episode boundary in the recorded dataset. Skipped silently when no

--- a/strands_robots/streaming_dataset.py
+++ b/strands_robots/streaming_dataset.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-"""Streaming read-back for LeRobotDataset — read frames directly from the Hub.
+"""Streaming read-back for LeRobotDataset - read frames directly from the Hub.
 
 Primary use: in-process eval / replay / notebooks / agent loops (NOT a
-precondition for streamed *training* — ``python -m lerobot.scripts.train
+precondition for streamed *training* - ``python -m lerobot.scripts.train
 dataset.streaming=true`` already uses StreamingLeRobotDataset via
 ``lerobot.datasets.factory.make_dataset``; see
 reports/STREAMING_DATA_LOOP_DEEP_DIVE.md Appendix D).
@@ -12,7 +12,7 @@ Design mirrors ``dataset_recorder.py``:
     Jetson; see dataset_recorder.py header).
   * Constructor kwargs are forwarded via ``inspect.signature`` introspection so
     a lerobot version bump can't break us (lerobot's dataset API drifted across
-    0.5.0->0.5.2; streaming is newer and still changing — upstream has a
+    0.5.0->0.5.2; streaming is newer and still changing - upstream has a
     multi-thread prefetch TODO).
 """
 
@@ -55,7 +55,7 @@ def _get_streaming_cls() -> Any:
             f"StreamingLeRobotDataset unavailable ({exc}). "
             "Install with: pip install 'strands-robots[lerobot]' "
             "(needs torchcodec for video keys; on aarch64/Jetson that means "
-            "torch>=2.11 + torchcodec>=0.11 — see deep-dive Appendix C). "
+            "torch>=2.11 + torchcodec>=0.11 - see deep-dive Appendix C). "
             "For proprio-only streaming without torchcodec, use drop_videos=True."
         ) from exc
 
@@ -103,7 +103,7 @@ class StreamingDatasetReader:
         accepts_var_kw = any(p.kind is inspect.Parameter.VAR_KEYWORD for p in init_sig.values())
 
         # Proprio-only: strip video keys from delta_timestamps so video decode
-        # (torchcodec) is never invoked — lets constrained edge devices stream
+        # (torchcodec) is never invoked - lets constrained edge devices stream
         # state/action without a torchcodec wheel (App. C.2).
         if drop_videos and delta_timestamps:
             delta_timestamps = {
@@ -140,7 +140,7 @@ class StreamingDatasetReader:
         )
         ds = StreamingCls(**kwargs)
 
-        # Tolerance grid-check — the streaming path skips check_delta_timestamps
+        # Tolerance grid-check - the streaming path skips check_delta_timestamps
         # (App. A.2); replicate it for parity with the materialized dataset.
         if delta_timestamps and validate_deltas:
             try:
@@ -158,9 +158,9 @@ class StreamingDatasetReader:
         WARNING (verified upstream): StreamingLeRobotDataset is an
         IterableDataset that shuffles INTERNALLY (reservoir buffer). Do NOT pass
         shuffle=True here. With num_workers>0, video decode parallelizes across
-        worker processes — the documented mitigation for the single-thread
+        worker processes - the documented mitigation for the single-thread
         bottleneck (streaming_dataset.py ~L312 TODO). Never decode video in the
-        main process while workers>0 (segfault — _query_videos docstring).
+        main process while workers>0 (segfault - _query_videos docstring).
 
         Note: lerobot's make_dataset couples max_num_shards = num_workers
         (factory.py). If you need that coupling, pass the same N to

--- a/strands_robots/training/cosmos3.py
+++ b/strands_robots/training/cosmos3.py
@@ -1,19 +1,19 @@
-"""Cosmos3 trainer — wrapper over cosmos_framework's SFT pipeline.
+"""Cosmos3 trainer - wrapper over cosmos_framework's SFT pipeline.
 
 Cosmos3 has the most distinct pipeline of the three backends, and is the reason
 the :class:`Trainer` ABC has optional ``prepare``/``export`` hooks:
 
-* **prepare()** — the base HF checkpoint MUST be converted to PyTorch DCP
+* **prepare()** - the base HF checkpoint MUST be converted to PyTorch DCP
   (``cosmos_framework.scripts.convert_model_to_dcp``) before training.
   LeRobot/GR00T need no such step.
-* **train()** — builds the cosmos ``Config`` via
+* **train()** - builds the cosmos ``Config`` via
   ``cosmos_framework.configs.toml_config.sft_config.load_experiment_from_toml``
   (TOML recipe + a Hydra ``key.path=value`` override LIST) and calls
   ``cosmos_framework.scripts.train.launch(config, args)`` DIRECTLY. (train.py
-  has no reusable ``main()`` — only ``launch`` — verified against upstream.)
+  has no reusable ``main()`` - only ``launch`` - verified against upstream.)
   Multi-GPU uses torch's programmatic ``elastic_launch`` (the engine behind
-  ``torchrun``); each worker calls ``launch`` — no shell, no torchrun binary.
-* **export()** — the trained DCP is converted back to HF safetensors via
+  ``torchrun``); each worker calls ``launch`` - no shell, no torchrun binary.
+* **export()** - the trained DCP is converted back to HF safetensors via
   ``cosmos_framework.scripts.export_model`` so ``create_policy`` can consume
   it.
 
@@ -25,7 +25,7 @@ The cosmos_framework checkout is resolved from ``COSMOS_ROOT`` env var or
 ``extra['cosmos_root']``; the SFT recipe TOML from ``extra['sft_toml']``.
 
 Install cosmos-framework from source (per its README) and ensure
-``cosmos_framework`` is importable in the active Python — this trainer drives
+``cosmos_framework`` is importable in the active Python - this trainer drives
 it as a Python library, NOT as a subprocess invoking another interpreter.
 """
 
@@ -48,7 +48,7 @@ _INSTALL_HINT = (
     "cosmos-framework is not importable from this interpreter. "
     "Install it from source (see https://github.com/nvidia-cosmos/cosmos-framework "
     "or the path passed via cosmos_root / COSMOS_ROOT) into the *same* Python "
-    "that imports strands_robots — e.g. `pip install -e $COSMOS_ROOT`."
+    "that imports strands_robots - e.g. `pip install -e $COSMOS_ROOT`."
 )
 
 
@@ -57,7 +57,7 @@ def _import_cosmos_module(qualname: str) -> Any:
 
     ``qualname`` is e.g. ``scripts.convert_model_to_dcp`` /
     ``scripts.train`` / ``scripts.export_model``. We resolve as a Python
-    library so the trainer runs in-process — no nested ``python`` invocation.
+    library so the trainer runs in-process - no nested ``python`` invocation.
     """
     full = f"cosmos_framework.{qualname}"
     try:
@@ -75,7 +75,7 @@ class Cosmos3Trainer(Trainer):
             Falls back to the ``COSMOS_ROOT`` env var, then
             ``TrainSpec.extra['cosmos_root']``. The package itself is loaded
             as a Python library via :func:`importlib.import_module` from the
-            active interpreter — install from source per cosmos-framework's
+            active interpreter - install from source per cosmos-framework's
             README; ``COSMOS_ROOT`` is for runtime config resolution, not the
             interpreter path.
     """
@@ -168,7 +168,7 @@ class Cosmos3Trainer(Trainer):
 
         Skips if the DCP target already exists (idempotent). Calls
         ``cosmos_framework.scripts.convert_model_to_dcp.convert_model_to_dcp``
-        DIRECTLY with a typed ``Args`` object — no subprocess, no argv.
+        DIRECTLY with a typed ``Args`` object - no subprocess, no argv.
         Verified against github.com/NVIDIA/cosmos-framework:
         ``convert_model_to_dcp(Args(checkpoint=CheckpointOverrides(
         checkpoint_path=<hf>), output_path=<dcp>))``.
@@ -193,7 +193,7 @@ class Cosmos3Trainer(Trainer):
         call_callable(convert_mod.convert_model_to_dcp, args)
 
     def build_command(self, spec: TrainSpec) -> list[str]:
-        """PURE argv-parity helper — the torchrun CLI the library call maps to.
+        """PURE argv-parity helper - the torchrun CLI the library call maps to.
 
         NOT used to launch training (``train()`` builds the cosmos ``Config`` via
         ``load_experiment_from_toml`` and calls ``train.launch(config, args)``
@@ -312,7 +312,7 @@ class Cosmos3Trainer(Trainer):
         try:
             if nproc > 1 or spec.num_nodes > 1:
                 # Multi-GPU/-node: torch elastic agent spawns workers; each builds
-                # the cosmos Config and calls train.launch() — Python objects, no
+                # the cosmos Config and calls train.launch() - Python objects, no
                 # argv, no torchrun binary.
                 rdzv = str(spec.extra.get("rdzv_endpoint", "")) if spec.num_nodes > 1 else ""
                 elastic_launch_callable(
@@ -353,7 +353,7 @@ def _run_cosmos_launch(sft_toml: str, overrides: list[str], *, log_path: str | N
     and calls ``launch(config, args)``. We construct the same argparse-shaped
     ``args`` namespace with the non-deterministic, non-debug defaults the script
     uses for a real run, so calling ``launch`` is behaviourally identical to the
-    CLI — minus the process spawn and argv parse.
+    CLI - minus the process spawn and argv parse.
     """
     import argparse
 

--- a/strands_robots/training/groot.py
+++ b/strands_robots/training/groot.py
@@ -1,13 +1,13 @@
-"""GR00T trainer — wrapper over Isaac-GR00T's ``launch_finetune``.
+"""GR00T trainer - wrapper over Isaac-GR00T's ``launch_finetune``.
 
 GR00T N1.7 ships its own post-training pipeline (NOT lerobot): a
 ``FinetuneConfig`` dataclass. ``launch_finetune.py`` is only a thin
 ``__main__`` shim (build ``FinetuneConfig`` via tyro → lower to a ``Config``
 → call ``experiment.run(config)``); it has NO reusable function. So we
 reproduce that translation here and call ``gr00t.experiment.experiment.run``
-DIRECTLY as a library — same interpreter, no argv, no nested ``python``.
+DIRECTLY as a library - same interpreter, no argv, no nested ``python``.
 Multi-GPU uses torch's programmatic ``elastic_launch`` (the engine behind
-``torchrun``); each worker builds the ``Config`` and calls ``run`` — no
+``torchrun``); each worker builds the ``Config`` and calls ``run`` - no
 ``torchrun`` binary, no shell.
 
 This adapter translates a provider-agnostic
@@ -29,7 +29,7 @@ argv. Mapping highlights:
 
 GR00T checkpoints are HF-native, so :meth:`export` is the default passthrough.
 The Isaac-GR00T checkout is resolved from the ``GR00T_ROOT`` env var or
-``extra['groot_root']`` — needed so we can ``chdir`` there for relative configs.
+``extra['groot_root']`` - needed so we can ``chdir`` there for relative configs.
 Install Isaac-GR00T from source (per its README) and ensure ``gr00t`` is
 importable from the active interpreter; this trainer drives it as a Python
 library, NOT by invoking another interpreter.
@@ -50,7 +50,7 @@ from strands_robots.training.base import Trainer, TrainResult, TrainSpec
 
 logger = logging.getLogger(__name__)
 
-# GR00T's tune flags — the model-tuning surface lerobot does NOT have.
+# GR00T's tune flags - the model-tuning surface lerobot does NOT have.
 # Sensible default mirrors FinetuneConfig defaults (projector + diffusion on).
 _DEFAULT_TUNE = {"llm": False, "visual": False, "projector": True, "diffusion": True}
 
@@ -60,7 +60,7 @@ _INSTALL_HINT = (
     "Isaac-GR00T is not importable from this interpreter. Install it from source "
     "(see https://github.com/NVIDIA/Isaac-GR00T or the path passed via "
     "groot_root / GR00T_ROOT) into the *same* Python that imports strands_robots "
-    "— e.g. `pip install -e $GR00T_ROOT`."
+    "- e.g. `pip install -e $GR00T_ROOT`."
 )
 
 
@@ -69,7 +69,7 @@ def _import_groot_module(qualname: str) -> Any:
     full = f"gr00t.{qualname}"
     try:
         return importlib.import_module(full)
-    except ImportError as e:  # pragma: no cover — exercised in integration
+    except ImportError as e:  # pragma: no cover - exercised in integration
         raise ImportError(f"{_INSTALL_HINT} (failed to import {full})") from e
 
 
@@ -82,7 +82,7 @@ class Gr00tTrainer(Trainer):
             for ``launch_finetune.py``). Falls back to the ``GR00T_ROOT`` env
             var, then ``TrainSpec.extra['groot_root']``. The package itself
             is loaded via :func:`importlib.import_module` from the active
-            interpreter — install from source; ``GR00T_ROOT`` is for runtime
+            interpreter - install from source; ``GR00T_ROOT`` is for runtime
             config resolution, not the interpreter path.
     """
 
@@ -168,7 +168,7 @@ class Gr00tTrainer(Trainer):
         return problems
 
     def build_command(self, spec: TrainSpec) -> list[str]:
-        """PURE argv-parity helper — the launch_finetune CLI the config maps to.
+        """PURE argv-parity helper - the launch_finetune CLI the config maps to.
 
         NOT used to launch training (``train()`` builds a ``FinetuneConfig`` +
         ``Config`` and calls ``gr00t.experiment.experiment.run`` directly).
@@ -234,7 +234,7 @@ class Gr00tTrainer(Trainer):
         """Build GR00T's own ``FinetuneConfig`` object from a TrainSpec (pure).
 
         Returns an instance of ``gr00t.configs.finetune_config.FinetuneConfig``
-        — the SAME typed object ``launch_finetune.py`` builds via tyro, but
+        - the SAME typed object ``launch_finetune.py`` builds via tyro, but
         constructed directly from Python values (no argv). Requires the gr00t
         package importable.
         """
@@ -273,7 +273,7 @@ class Gr00tTrainer(Trainer):
             kwargs["modality_config_path"] = spec.extra["modality_config_path"]
 
         # Passthrough: any other extra.* that is a REAL FinetuneConfig field
-        # (typed allowlist — an unknown key can never set an attribute).
+        # (typed allowlist - an unknown key can never set an attribute).
         valid_fields = {f.name for f in dataclasses.fields(FinetuneConfig)}
         _consumed = {"groot_root", "master_port", "modality_config_path"}
         for key, value in spec.extra.items():
@@ -290,7 +290,7 @@ class Gr00tTrainer(Trainer):
 
         Mirrors the body of ``launch_finetune.py``'s ``__main__`` exactly
         (verified against the Isaac-GR00T checkout), so calling ``run(config)``
-        is behaviourally identical to launching the script — minus the process
+        is behaviourally identical to launching the script - minus the process
         spawn and the tyro argv parse.
         """
         get_default_config = _import_groot_module("configs.base_config").get_default_config
@@ -410,7 +410,7 @@ class Gr00tTrainer(Trainer):
         try:
             if spec.num_gpus and spec.num_gpus > 1:
                 # Multi-GPU: torch elastic agent spawns workers; each builds the
-                # FinetuneConfig + Config and calls experiment.run() — Python
+                # FinetuneConfig + Config and calls experiment.run() - Python
                 # objects, no argv, no torchrun binary.
                 groot_root = self._resolve_groot_root(spec)
                 elastic_launch_callable(
@@ -427,7 +427,7 @@ class Gr00tTrainer(Trainer):
                 call_callable(run, run_config, log_path=log_path)
         except ImportError as e:
             return TrainResult(status="error", job_id=job_id, message=str(e))
-        except Exception as e:  # noqa: BLE001 — convert ANY failure to a result
+        except Exception as e:  # noqa: BLE001 - convert ANY failure to a result
             train_error = e
             logger.error("Gr00tTrainer in-process run failed: %s", e)
 
@@ -473,7 +473,7 @@ def _groot_worker(groot_root: str | None, spec: TrainSpec, log_path: str) -> Non
 
     Runs in a torch-spawned worker (one per GPU). torch sets RANK / LOCAL_RANK /
     WORLD_SIZE; GR00T's experiment.run() + HF Trainer read those to shard. We do
-    NOT pin CUDA_VISIBLE_DEVICES here — each worker sees all devices and selects
+    NOT pin CUDA_VISIBLE_DEVICES here - each worker sees all devices and selects
     by LOCAL_RANK. Only local rank 0 tees to the shared log file.
     """
     import os as _os

--- a/tests/test_source_strings_no_unicode_dashes.py
+++ b/tests/test_source_strings_no_unicode_dashes.py
@@ -1,0 +1,56 @@
+"""Regression: no ``strands_robots`` module may embed Unicode dash punctuation.
+
+AGENTS.md mandates plain ASCII in user-facing strings and warns specifically
+about orphan typographic glyphs left behind by automated authoring/sweeps. The
+em dash (``U+2014``), en dash (``U+2013``), figure dash (``U+2012``), and
+horizontal bar (``U+2015``) are an AI-authoring tell: they render
+inconsistently across terminals and log pipelines, are tokenizer noise for the
+agents that read these strings programmatically, and several appear inside
+``logger`` / error / tool-result strings the ASCII rule covers. An ASCII hyphen
+``-`` carries the same meaning everywhere.
+
+This scan walks every Python module under the ``strands_robots`` package and
+rejects any of those four dash codepoints. It is the dash analogue of
+``test_source_strings_no_emoji`` and would have failed when 118 lines across 24
+modules still carried ``U+2014``.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import strands_robots
+
+# Figure dash, en dash, em dash, horizontal bar. ASCII hyphen-minus (U+002D) is
+# the sanctioned replacement and is, of course, allowed.
+_UNICODE_DASH = re.compile("[\u2012-\u2015]")
+
+_PACKAGE_DIR = Path(strands_robots.__file__).resolve().parent
+
+
+def _python_sources() -> list[Path]:
+    return sorted(p for p in _PACKAGE_DIR.rglob("*.py") if "__pycache__" not in p.parts)
+
+
+def test_package_sources_discovered() -> None:
+    """Guard: the scan actually walked the whole package, not one subtree."""
+    sources = _python_sources()
+    assert len(sources) > 50
+    rel_dirs = {p.relative_to(_PACKAGE_DIR).parts[0] for p in sources if p.parent != _PACKAGE_DIR}
+    assert {"simulation", "tools", "registry", "benchmarks", "device_connect"} <= rel_dirs
+
+
+def test_no_unicode_dashes_in_package_sources() -> None:
+    """No ``strands_robots`` module may embed em/en/figure dashes or the horizontal bar."""
+    offenders: list[str] = []
+    for path in _python_sources():
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            for match in _UNICODE_DASH.finditer(line):
+                cp = match.group()
+                offenders.append(
+                    f"{path.relative_to(_PACKAGE_DIR.parent)}:{lineno}: U+{ord(cp[0]):04X} {line.strip()[:80]!r}"
+                )
+    assert not offenders, "Unicode dash punctuation found in strands_robots sources (use ASCII '-'):\n" + "\n".join(
+        offenders
+    )


### PR DESCRIPTION
## Problem

`AGENTS.md` mandates plain ASCII in code, logs, and error/tool-result strings and explicitly warns about orphan typographic glyphs left behind by automated authoring sweeps. 125 lines across 28 modules still carried Unicode dash punctuation:

- em dash `U+2014` (121 occurrences)
- en dash `U+2013` (4, all numeric ranges like `5-10s`)

These render inconsistently across terminals and log pipelines, are tokenizer noise for agents that read these strings programmatically, and several sit inside runtime `logger`/error/tool-result strings the ASCII rule covers. An ASCII hyphen carries identical meaning everywhere.

## Change

Swept `U+2012`-`U+2015` -> `-` across `strands_robots/**/*.py`. The vast majority are comments/docstrings; a handful are runtime strings, all now ASCII:

- `policies/vera/server_runner.py` readiness-timeout error (`WAN model load can be slow - `)
- `streaming_dataset.py` torchcodec install hint
- `training/cosmos3.py` editable-install hint
- `policies/moveit2/server/zmq_node.py` argparse `--port` help text

No behavior change: only punctuation in comments/docstrings/strings. Confirmed no test asserts on any swept runtime string.

## Regression guard

Adds `tests/test_source_strings_no_unicode_dashes.py`, the dash analogue of the existing `test_source_strings_no_emoji.py`. It walks every package module and rejects `U+2012`-`U+2015`. Verified it FAILS on pre-sweep sources (reports `U+2014` offenders) and PASSES after.

## Validation

- `ruff check` / `ruff format --check` on `strands_robots tests tests_integ`: clean
- `mypy strands_robots tests tests_integ`: `Success: no issues found in 492 source files`
- `pytest tests/test_source_strings_no_unicode_dashes.py tests/test_source_strings_no_emoji.py tests/simulation/test_policy_runner.py tests/policies/vera tests/policies/moveit2`: 223 passed, 3 skipped
- `grep -rnP '[\x{2012}-\x{2015}]' strands_robots/`: 0 matches