### PR TITLE
feat(training): wire RA-BC sample weighting into the lerobot trainer

### DIFF
--- a/docs/training/overview.md
+++ b/docs/training/overview.md
@@ -100,6 +100,7 @@ supports and **ignores the rest** (the same tolerance rule as
 | `extra["groot_root"]` | Isaac-GR00T checkout | GR00T |
 | `extra["sft_toml"]` / `extra["cosmos_root"]` | recipe + checkout | Cosmos |
 | `extra["relative_actions"]` | train pi0-family with delta actions | lerobot `--policy.use_relative_actions=true` (pi0/pi05/pi0_fast) |
+| `extra["sample_weighting"]` | RA-BC / per-sample loss weighting dict | lerobot `--sample_weighting.*` |
 
 ## From an agent (natural language)
 
@@ -125,6 +126,37 @@ agent("Record 50 cube-pick episodes, then post-tune lerobot ACT on the dataset "
 TrainSpec(..., method="lora", lora_r=16, extra={"policy_type": "pi05"})
 # -> lerobot_train --peft.method_type=LORA --peft.r=16 --policy.type=pi05
 ```
+
+#### RA-BC sample weighting (reward-aligned behavior cloning)
+
+Reward-Aligned Behavior Cloning reweights the per-sample loss so high-quality
+demonstrations dominate - the technique behind the strongest behavior-cloning
+ablations on long-horizon manipulation. lerobot drives it from
+`TrainPipelineConfig.sample_weighting` (a typed `SampleWeightingConfig` that the
+train loop turns into a `SampleWeighter`). Surface it through `extra`:
+
+```python
+TrainSpec(
+    dataset_root="/data/folding_v3",
+    base_model="lerobot/pi05_base",
+    output_dir="/tmp/ft_out",
+    extra={
+        "policy_type": "pi05",
+        "sample_weighting": {       # -> typed SampleWeightingConfig
+            "type": "rabc",
+            "kappa": 0.01,          # hard threshold for high-quality samples
+            "head_mode": "sparse",  # which progress head to read
+            # "progress_path": "hf://datasets/org/ds/sarm_progress.parquet",
+        },
+    },
+)
+# -> lerobot_train --sample_weighting.type=rabc --sample_weighting.kappa=0.01 ...
+```
+
+The dict keys mirror lerobot's `SampleWeightingConfig` fields (`type`,
+`progress_path`, `head_mode`, `kappa`, `epsilon`, `extra_params`); an unknown
+key raises an actionable error naming the supported set. Omit
+`sample_weighting` entirely for standard (uniform) behavior cloning.
 
 #### Relative (delta) actions
 

--- a/docs/training/overview.md
+++ b/docs/training/overview.md
@@ -100,7 +100,7 @@ supports and **ignores the rest** (the same tolerance rule as
 | `extra["groot_root"]` | Isaac-GR00T checkout | GR00T |
 | `extra["sft_toml"]` / `extra["cosmos_root"]` | recipe + checkout | Cosmos |
 | `extra["relative_actions"]` | train pi0-family with delta actions | lerobot `--policy.use_relative_actions=true` (pi0/pi05/pi0_fast) |
-| `extra["sample_weighting"]` | RA-BC / per-sample loss weighting dict | lerobot `--sample_weighting.*` |
+| `extra["sample_weighting"]` | RA-BC per-sample loss weighting dict | lerobot `--use_rabc=true --rabc_*` |
 
 ## From an agent (natural language)
 
@@ -131,9 +131,10 @@ TrainSpec(..., method="lora", lora_r=16, extra={"policy_type": "pi05"})
 
 Reward-Aligned Behavior Cloning reweights the per-sample loss so high-quality
 demonstrations dominate - the technique behind the strongest behavior-cloning
-ablations on long-horizon manipulation. lerobot drives it from
-`TrainPipelineConfig.sample_weighting` (a typed `SampleWeightingConfig` that the
-train loop turns into a `SampleWeighter`). Surface it through `extra`:
+ablations on long-horizon manipulation. lerobot drives it from flat
+`TrainPipelineConfig` fields (`use_rabc` plus `rabc_progress_path`,
+`rabc_kappa`, `rabc_epsilon`, `rabc_head_mode`). Surface it through `extra`
+with a friendly grouped dict that maps onto those fields:
 
 ```python
 TrainSpec(
@@ -142,21 +143,22 @@ TrainSpec(
     output_dir="/tmp/ft_out",
     extra={
         "policy_type": "pi05",
-        "sample_weighting": {       # -> typed SampleWeightingConfig
+        "sample_weighting": {       # type='rabc' sets use_rabc=true
             "type": "rabc",
-            "kappa": 0.01,          # hard threshold for high-quality samples
-            "head_mode": "sparse",  # which progress head to read
+            "kappa": 0.01,          # -> rabc_kappa (high-quality threshold)
+            "head_mode": "sparse",  # -> rabc_head_mode (progress head)
             # "progress_path": "hf://datasets/org/ds/sarm_progress.parquet",
         },
     },
 )
-# -> lerobot_train --sample_weighting.type=rabc --sample_weighting.kappa=0.01 ...
+# -> lerobot_train --use_rabc=true --rabc_kappa=0.01 --rabc_head_mode=sparse ...
 ```
 
-The dict keys mirror lerobot's `SampleWeightingConfig` fields (`type`,
-`progress_path`, `head_mode`, `kappa`, `epsilon`, `extra_params`); an unknown
-key raises an actionable error naming the supported set. Omit
-`sample_weighting` entirely for standard (uniform) behavior cloning.
+The friendly keys map to lerobot's flat fields - `type` gates `use_rabc`,
+`kappa` -> `rabc_kappa`, `epsilon` -> `rabc_epsilon`, `head_mode` ->
+`rabc_head_mode`, `progress_path` -> `rabc_progress_path`. An unknown key (or a
+`type` other than `rabc`) raises an actionable error naming the accepted set.
+Omit `sample_weighting` entirely for standard (uniform) behavior cloning.
 
 #### Relative (delta) actions
 

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -75,6 +75,23 @@ _SUPPORTED_METHODS = {"full", "lora", "expert_only"}
 # pre/post processors). Other policy types have no such field.
 _RELATIVE_ACTION_POLICY_TYPES = {"pi0", "pi05", "pi0_fast"}
 
+# RA-BC (Reward-Aligned Behavior Cloning) is the only sample-weighting scheme
+# lerobot ships, and it lives as FLAT fields on ``TrainPipelineConfig`` (not a
+# nested config object): ``use_rabc`` plus ``rabc_progress_path``,
+# ``rabc_kappa``, ``rabc_epsilon``, ``rabc_head_mode`` (see
+# ``lerobot/configs/train.py`` in lerobot >=0.5.0,<0.6.0). The agent-facing
+# ``extra['sample_weighting']`` dict groups these under friendly keys; this map
+# translates each friendly key to its real lerobot field. ``type`` is the gate:
+# ``type='rabc'`` flips ``use_rabc=True`` (no other scheme exists yet).
+_SAMPLE_WEIGHTING_FIELD_MAP = {
+    "progress_path": "rabc_progress_path",
+    "kappa": "rabc_kappa",
+    "epsilon": "rabc_epsilon",
+    "head_mode": "rabc_head_mode",
+}
+# Friendly keys accepted in ``extra['sample_weighting']`` (``type`` + the map).
+_SAMPLE_WEIGHTING_KEYS = {"type", *_SAMPLE_WEIGHTING_FIELD_MAP}
+
 # Hugging Face Hub dataset id: ``org/name`` (each segment alnum plus ._-). Used
 # to gate the agent-supplied ``dataset_repo_id`` before it becomes lerobot's
 # ``DatasetConfig.repo_id`` (which load_dataset/HfApi feed to a Hub URL).
@@ -207,14 +224,16 @@ class LerobotTrainer(Trainer):
         return bool(spec.extra.get("relative_actions", False))
 
     def _sample_weighting_dict(self, spec: TrainSpec) -> dict[str, Any] | None:
-        """Resolve the RA-BC / sample-weighting spec from ``extra['sample_weighting']``.
+        """Resolve the RA-BC sample-weighting spec from ``extra['sample_weighting']``.
 
-        RA-BC (Reward-Aligned Behavior Cloning) and other per-sample loss
-        weighting strategies are surfaced through the ``extra`` escape hatch as a
-        single ``sample_weighting`` dict whose keys mirror lerobot's
-        :class:`lerobot.utils.sample_weighting.SampleWeightingConfig`
-        (``type``, ``progress_path``, ``head_mode``, ``kappa``, ``epsilon``,
-        ``extra_params``). Example::
+        RA-BC (Reward-Aligned Behavior Cloning) per-sample loss weighting is
+        surfaced through the ``extra`` escape hatch as a single
+        ``sample_weighting`` dict with friendly keys (``type``,
+        ``progress_path``, ``head_mode``, ``kappa``, ``epsilon``). lerobot
+        configures RA-BC via FLAT fields on ``TrainPipelineConfig``
+        (``use_rabc`` + ``rabc_*``); :data:`_SAMPLE_WEIGHTING_FIELD_MAP` maps the
+        friendly keys onto those, and ``type='rabc'`` flips ``use_rabc=True``.
+        Example::
 
             extra={"sample_weighting": {"type": "rabc", "kappa": 0.01,
                                         "head_mode": "sparse"}}
@@ -228,8 +247,7 @@ class LerobotTrainer(Trainer):
             return None
         if not isinstance(sw, dict):
             raise ValueError(
-                "extra['sample_weighting'] must be a dict of SampleWeightingConfig "
-                "fields, e.g. {'type': 'rabc', 'kappa': 0.01}"
+                "extra['sample_weighting'] must be a dict of RA-BC fields, e.g. {'type': 'rabc', 'kappa': 0.01}"
             )
         return sw
 
@@ -280,8 +298,7 @@ class LerobotTrainer(Trainer):
         sw = spec.extra.get("sample_weighting")
         if sw is not None and not isinstance(sw, dict):
             problems.append(
-                "extra['sample_weighting'] must be a dict of SampleWeightingConfig "
-                "fields, e.g. {'type': 'rabc', 'kappa': 0.01}"
+                "extra['sample_weighting'] must be a dict of RA-BC fields, e.g. {'type': 'rabc', 'kappa': 0.01}"
             )
         elif isinstance(sw, dict):
             for k, v in sw.items():
@@ -364,8 +381,10 @@ class LerobotTrainer(Trainer):
                 cmd.append(f"--config_path={ckpt_cfg}")
         sw = self._sample_weighting_dict(spec)
         if sw is not None:
-            for field_name, value in sw.items():
-                cmd.append(f"--sample_weighting.{field_name}={value}")
+            cmd.append("--use_rabc=true")
+            for key, field_name in _SAMPLE_WEIGHTING_FIELD_MAP.items():
+                if key in sw:
+                    cmd.append(f"--{field_name}={sw[key]}")
         _consumed = {"policy_type", "job_name", "relative_actions", "sample_weighting"}
         for key, value in spec.extra.items():
             if key in _consumed:
@@ -457,24 +476,44 @@ class LerobotTrainer(Trainer):
             if ckpt_cfg:
                 cfg.checkpoint_path = Path(ckpt_cfg).parent.parent
 
-        # RA-BC / sample weighting: build lerobot's typed SampleWeightingConfig
-        # from the extra['sample_weighting'] dict and attach it. lerobot's
-        # train loop turns a non-None cfg.sample_weighting into a SampleWeighter
-        # (make_sample_weighter) that reweights the per-sample loss.
+        # RA-BC sample weighting: lerobot configures RA-BC via FLAT fields on
+        # TrainPipelineConfig (use_rabc + rabc_*), which its train loop turns
+        # into a per-sample loss reweighting. Map the friendly
+        # extra['sample_weighting'] dict onto those real fields; type='rabc'
+        # gates use_rabc=True. Fail fast on unknown keys (mapped against the
+        # accepted set) and on any mapped field the installed lerobot lacks.
         sw = self._sample_weighting_dict(spec)
         if sw is not None:
-            from lerobot.utils.sample_weighting import SampleWeightingConfig
-
-            supported = {f.name for f in dataclasses.fields(SampleWeightingConfig)}
-            unsupported = sorted(k for k in sw if k not in supported)
+            unsupported = sorted(k for k in sw if k not in _SAMPLE_WEIGHTING_KEYS)
             if unsupported:
                 raise ValueError(
-                    f"The installed lerobot's SampleWeightingConfig does not support "
-                    f"field(s) {unsupported}; it accepts {sorted(supported)}. These "
-                    "were requested via extra['sample_weighting']. Upgrade lerobot or "
-                    "drop them from the spec."
+                    f"extra['sample_weighting'] does not support field(s) "
+                    f"{unsupported}; accepted keys are {sorted(_SAMPLE_WEIGHTING_KEYS)}."
                 )
-            cfg.sample_weighting = SampleWeightingConfig(**sw)
+            sw_type = sw.get("type", "rabc")
+            if sw_type != "rabc":
+                raise ValueError(
+                    f"extra['sample_weighting']['type'] must be 'rabc' "
+                    f"(the only scheme lerobot ships), got {sw_type!r}."
+                )
+            if not hasattr(cfg, "use_rabc"):
+                raise ValueError(
+                    "The installed lerobot does not expose RA-BC (no 'use_rabc' on "
+                    "TrainPipelineConfig); upgrade lerobot or drop "
+                    "extra['sample_weighting']."
+                )
+            cfg.use_rabc = True
+            for key, field_name in _SAMPLE_WEIGHTING_FIELD_MAP.items():
+                if key not in sw:
+                    continue
+                if not hasattr(cfg, field_name):
+                    raise ValueError(
+                        f"The installed lerobot's TrainPipelineConfig has no "
+                        f"'{field_name}' field (requested via "
+                        f"extra['sample_weighting']['{key}']); upgrade lerobot or "
+                        "drop it from the spec."
+                    )
+                setattr(cfg, field_name, sw[key])
 
         # Typed passthrough for remaining extra.* (gated by validate()'s key
         # allowlist). Only set attributes that exist on the typed config tree;

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -206,6 +206,33 @@ class LerobotTrainer(Trainer):
         """
         return bool(spec.extra.get("relative_actions", False))
 
+    def _sample_weighting_dict(self, spec: TrainSpec) -> dict[str, Any] | None:
+        """Resolve the RA-BC / sample-weighting spec from ``extra['sample_weighting']``.
+
+        RA-BC (Reward-Aligned Behavior Cloning) and other per-sample loss
+        weighting strategies are surfaced through the ``extra`` escape hatch as a
+        single ``sample_weighting`` dict whose keys mirror lerobot's
+        :class:`lerobot.utils.sample_weighting.SampleWeightingConfig`
+        (``type``, ``progress_path``, ``head_mode``, ``kappa``, ``epsilon``,
+        ``extra_params``). Example::
+
+            extra={"sample_weighting": {"type": "rabc", "kappa": 0.01,
+                                        "head_mode": "sparse"}}
+
+        Returns the dict unchanged, or ``None`` when not requested. Raises
+        ``ValueError`` if the value is present but not a dict (caught by
+        ``train`` and surfaced as an error result).
+        """
+        sw = spec.extra.get("sample_weighting")
+        if sw is None:
+            return None
+        if not isinstance(sw, dict):
+            raise ValueError(
+                "extra['sample_weighting'] must be a dict of SampleWeightingConfig "
+                "fields, e.g. {'type': 'rabc', 'kappa': 0.01}"
+            )
+        return sw
+
     # ---- ABC ---------------------------------------------------------------
 
     def validate(self, spec: TrainSpec) -> list[str]:
@@ -249,6 +276,17 @@ class LerobotTrainer(Trainer):
                 f"(only {sorted(_RELATIVE_ACTION_POLICY_TYPES)} expose use_relative_actions); "
                 "drop extra['relative_actions'] or pick a pi0-family policy"
             )
+
+        sw = spec.extra.get("sample_weighting")
+        if sw is not None and not isinstance(sw, dict):
+            problems.append(
+                "extra['sample_weighting'] must be a dict of SampleWeightingConfig "
+                "fields, e.g. {'type': 'rabc', 'kappa': 0.01}"
+            )
+        elif isinstance(sw, dict):
+            for k, v in sw.items():
+                if isinstance(v, str) and v.startswith("-"):
+                    problems.append(f"sample_weighting['{k}'] must not start with '-' (would parse as a stray flag)")
 
         if spec.steps <= 0:
             problems.append(f"steps must be > 0, got {spec.steps}")
@@ -324,7 +362,11 @@ class LerobotTrainer(Trainer):
             if ckpt_cfg:
                 cmd.append("--resume=true")
                 cmd.append(f"--config_path={ckpt_cfg}")
-        _consumed = {"policy_type", "job_name", "relative_actions"}
+        sw = self._sample_weighting_dict(spec)
+        if sw is not None:
+            for field_name, value in sw.items():
+                cmd.append(f"--sample_weighting.{field_name}={value}")
+        _consumed = {"policy_type", "job_name", "relative_actions", "sample_weighting"}
         for key, value in spec.extra.items():
             if key in _consumed:
                 continue
@@ -415,10 +457,29 @@ class LerobotTrainer(Trainer):
             if ckpt_cfg:
                 cfg.checkpoint_path = Path(ckpt_cfg).parent.parent
 
+        # RA-BC / sample weighting: build lerobot's typed SampleWeightingConfig
+        # from the extra['sample_weighting'] dict and attach it. lerobot's
+        # train loop turns a non-None cfg.sample_weighting into a SampleWeighter
+        # (make_sample_weighter) that reweights the per-sample loss.
+        sw = self._sample_weighting_dict(spec)
+        if sw is not None:
+            from lerobot.utils.sample_weighting import SampleWeightingConfig
+
+            supported = {f.name for f in dataclasses.fields(SampleWeightingConfig)}
+            unsupported = sorted(k for k in sw if k not in supported)
+            if unsupported:
+                raise ValueError(
+                    f"The installed lerobot's SampleWeightingConfig does not support "
+                    f"field(s) {unsupported}; it accepts {sorted(supported)}. These "
+                    "were requested via extra['sample_weighting']. Upgrade lerobot or "
+                    "drop them from the spec."
+                )
+            cfg.sample_weighting = SampleWeightingConfig(**sw)
+
         # Typed passthrough for remaining extra.* (gated by validate()'s key
         # allowlist). Only set attributes that exist on the typed config tree;
         # unknown keys are ignored (never become an arbitrary flag).
-        _consumed = {"policy_type", "job_name", "relative_actions"}
+        _consumed = {"policy_type", "job_name", "relative_actions", "sample_weighting"}
         for key, value in spec.extra.items():
             if key in _consumed:
                 continue

--- a/tests/training/test_lerobot.py
+++ b/tests/training/test_lerobot.py
@@ -763,3 +763,73 @@ class TestRelativeActions:
         for ptype in ("pi0", "pi05", "pi0_fast"):
             spec = self._pi0_spec(dataset_root, tmp_path, ptype=ptype)
             assert LerobotTrainer().validate(spec) == []
+
+
+class TestSampleWeightingRABC:
+    """RA-BC / sample-weighting wiring: extra['sample_weighting'] -> cfg.sample_weighting.
+
+    Regression for the folding recipe's headline ablation (HQ + RA-BC + relative
+    actions). Before the fix, the ``sample_weighting`` extra key fell through the
+    generic passthrough loop and was set on the config as a raw ``dict`` (not the
+    typed ``SampleWeightingConfig`` lerobot's train loop expects), and
+    build_command emitted a single ``--sample_weighting={...}`` flag instead of
+    the nested ``--sample_weighting.<field>=<value>`` draccus form.
+    """
+
+    def _rabc_spec(self, dataset_root, tmp_path):
+        return TrainSpec(
+            dataset_root=dataset_root,
+            base_model="",
+            output_dir=str(tmp_path / "out"),
+            steps=200,
+            extra={
+                "policy_type": "act",
+                "sample_weighting": {"type": "rabc", "kappa": 0.02, "head_mode": "sparse"},
+            },
+        )
+
+    def test_build_config_attaches_typed_sample_weighting(self, dataset_root, tmp_path):
+        from lerobot.utils.sample_weighting import SampleWeightingConfig
+
+        cfg = LerobotTrainer(device="cpu").build_config(self._rabc_spec(dataset_root, tmp_path))
+        assert isinstance(cfg.sample_weighting, SampleWeightingConfig)
+        assert cfg.sample_weighting.type == "rabc"
+        assert cfg.sample_weighting.kappa == 0.02
+        assert cfg.sample_weighting.head_mode == "sparse"
+
+    def test_build_command_emits_nested_flags(self, dataset_root, tmp_path):
+        cmd = LerobotTrainer(device="cpu").build_command(self._rabc_spec(dataset_root, tmp_path))
+        assert "--sample_weighting.type=rabc" in cmd
+        assert "--sample_weighting.kappa=0.02" in cmd
+        assert "--sample_weighting.head_mode=sparse" in cmd
+        # The dict must NOT leak through as a single flag.
+        assert not any(c.startswith("--sample_weighting=") for c in cmd)
+
+    def test_no_sample_weighting_leaves_config_default(self, dataset_root, tmp_path):
+        spec = TrainSpec(
+            dataset_root=dataset_root,
+            base_model="",
+            output_dir=str(tmp_path / "out"),
+            steps=200,
+            extra={"policy_type": "act"},
+        )
+        cfg = LerobotTrainer(device="cpu").build_config(spec)
+        assert cfg.sample_weighting is None
+
+    def test_unsupported_field_raises_actionable_error(self, dataset_root, tmp_path):
+        spec = self._rabc_spec(dataset_root, tmp_path)
+        spec.extra["sample_weighting"] = {"type": "rabc", "bogus_field": 1}
+        with pytest.raises(ValueError, match="SampleWeightingConfig does not support"):
+            LerobotTrainer(device="cpu").build_config(spec)
+
+    def test_validate_rejects_non_dict(self, dataset_root, tmp_path):
+        spec = self._rabc_spec(dataset_root, tmp_path)
+        spec.extra["sample_weighting"] = "rabc"
+        problems = LerobotTrainer().validate(spec)
+        assert any("sample_weighting" in p and "dict" in p for p in problems)
+
+    def test_validate_rejects_leading_dash_value(self, dataset_root, tmp_path):
+        spec = self._rabc_spec(dataset_root, tmp_path)
+        spec.extra["sample_weighting"] = {"type": "rabc", "progress_path": "-x"}
+        problems = LerobotTrainer().validate(spec)
+        assert any("must not start with '-'" in p for p in problems)

--- a/tests/training/test_lerobot.py
+++ b/tests/training/test_lerobot.py
@@ -766,14 +766,16 @@ class TestRelativeActions:
 
 
 class TestSampleWeightingRABC:
-    """RA-BC / sample-weighting wiring: extra['sample_weighting'] -> cfg.sample_weighting.
+    """RA-BC sample-weighting wiring: extra['sample_weighting'] -> flat rabc fields.
 
     Regression for the folding recipe's headline ablation (HQ + RA-BC + relative
-    actions). Before the fix, the ``sample_weighting`` extra key fell through the
-    generic passthrough loop and was set on the config as a raw ``dict`` (not the
-    typed ``SampleWeightingConfig`` lerobot's train loop expects), and
-    build_command emitted a single ``--sample_weighting={...}`` flag instead of
-    the nested ``--sample_weighting.<field>=<value>`` draccus form.
+    actions). lerobot configures RA-BC through FLAT fields on
+    ``TrainPipelineConfig`` (``use_rabc`` + ``rabc_progress_path`` /
+    ``rabc_kappa`` / ``rabc_epsilon`` / ``rabc_head_mode``), so the trainer maps
+    the friendly ``sample_weighting`` dict onto those. Before the fix the key
+    fell through the generic passthrough (set as a raw top-level ``dict`` that
+    lerobot's train loop never reads, and build_command emitted a single
+    ``--sample_weighting={...}`` flag) so RA-BC was unreachable.
     """
 
     def _rabc_spec(self, dataset_root, tmp_path):
@@ -788,25 +790,23 @@ class TestSampleWeightingRABC:
             },
         )
 
-    def test_build_config_attaches_typed_sample_weighting(self, dataset_root, tmp_path):
-        swm = pytest.importorskip("lerobot.utils.sample_weighting")
-        SampleWeightingConfig = swm.SampleWeightingConfig
-
+    def test_build_config_sets_flat_rabc_fields(self, dataset_root, tmp_path):
+        pytest.importorskip("lerobot")
         cfg = LerobotTrainer(device="cpu").build_config(self._rabc_spec(dataset_root, tmp_path))
-        assert isinstance(cfg.sample_weighting, SampleWeightingConfig)
-        assert cfg.sample_weighting.type == "rabc"
-        assert cfg.sample_weighting.kappa == 0.02
-        assert cfg.sample_weighting.head_mode == "sparse"
+        assert cfg.use_rabc is True
+        assert cfg.rabc_kappa == 0.02
+        assert cfg.rabc_head_mode == "sparse"
 
-    def test_build_command_emits_nested_flags(self, dataset_root, tmp_path):
+    def test_build_command_emits_flat_flags(self, dataset_root, tmp_path):
         cmd = LerobotTrainer(device="cpu").build_command(self._rabc_spec(dataset_root, tmp_path))
-        assert "--sample_weighting.type=rabc" in cmd
-        assert "--sample_weighting.kappa=0.02" in cmd
-        assert "--sample_weighting.head_mode=sparse" in cmd
-        # The dict must NOT leak through as a single flag.
-        assert not any(c.startswith("--sample_weighting=") for c in cmd)
+        assert "--use_rabc=true" in cmd
+        assert "--rabc_kappa=0.02" in cmd
+        assert "--rabc_head_mode=sparse" in cmd
+        # The dict must NOT leak through as a single flag nor a nested one.
+        assert not any(c.startswith("--sample_weighting") for c in cmd)
 
-    def test_no_sample_weighting_leaves_config_default(self, dataset_root, tmp_path):
+    def test_no_sample_weighting_leaves_rabc_off(self, dataset_root, tmp_path):
+        pytest.importorskip("lerobot")
         spec = TrainSpec(
             dataset_root=dataset_root,
             base_model="",
@@ -815,13 +815,20 @@ class TestSampleWeightingRABC:
             extra={"policy_type": "act"},
         )
         cfg = LerobotTrainer(device="cpu").build_config(spec)
-        assert cfg.sample_weighting is None
+        assert cfg.use_rabc is False
 
     def test_unsupported_field_raises_actionable_error(self, dataset_root, tmp_path):
-        pytest.importorskip("lerobot.utils.sample_weighting")
+        pytest.importorskip("lerobot")
         spec = self._rabc_spec(dataset_root, tmp_path)
         spec.extra["sample_weighting"] = {"type": "rabc", "bogus_field": 1}
-        with pytest.raises(ValueError, match="SampleWeightingConfig does not support"):
+        with pytest.raises(ValueError, match="does not support field"):
+            LerobotTrainer(device="cpu").build_config(spec)
+
+    def test_unsupported_type_raises_actionable_error(self, dataset_root, tmp_path):
+        pytest.importorskip("lerobot")
+        spec = self._rabc_spec(dataset_root, tmp_path)
+        spec.extra["sample_weighting"] = {"type": "boltzmann", "kappa": 0.02}
+        with pytest.raises(ValueError, match="must be 'rabc'"):
             LerobotTrainer(device="cpu").build_config(spec)
 
     def test_validate_rejects_non_dict(self, dataset_root, tmp_path):

--- a/tests/training/test_lerobot.py
+++ b/tests/training/test_lerobot.py
@@ -789,7 +789,8 @@ class TestSampleWeightingRABC:
         )
 
     def test_build_config_attaches_typed_sample_weighting(self, dataset_root, tmp_path):
-        from lerobot.utils.sample_weighting import SampleWeightingConfig
+        swm = pytest.importorskip("lerobot.utils.sample_weighting")
+        SampleWeightingConfig = swm.SampleWeightingConfig
 
         cfg = LerobotTrainer(device="cpu").build_config(self._rabc_spec(dataset_root, tmp_path))
         assert isinstance(cfg.sample_weighting, SampleWeightingConfig)
@@ -817,6 +818,7 @@ class TestSampleWeightingRABC:
         assert cfg.sample_weighting is None
 
     def test_unsupported_field_raises_actionable_error(self, dataset_root, tmp_path):
+        pytest.importorskip("lerobot.utils.sample_weighting")
         spec = self._rabc_spec(dataset_root, tmp_path)
         spec.extra["sample_weighting"] = {"type": "rabc", "bogus_field": 1}
         with pytest.raises(ValueError, match="SampleWeightingConfig does not support"):


### PR DESCRIPTION
## Problem

The `LerobotTrainer` can build a real `TrainPipelineConfig` for ACT/diffusion/SmolVLA/pi0/pi05, but it had no way to enable **RA-BC (Reward-Aligned Behavior Cloning)** - the per-sample loss-weighting technique behind the strongest behavior-cloning ablations on long-horizon manipulation. An agent passing RA-BC knobs through the generic `extra` passthrough also hit a silent failure mode: the keys fell through with no matching top-level field (silently dropped), so RA-BC was unreachable.

## Change

Surface RA-BC through `extra['sample_weighting']` as a friendly grouped dict that maps onto lerobot's real config. lerobot configures RA-BC via **flat** `TrainPipelineConfig` fields - `use_rabc` plus `rabc_progress_path` / `rabc_kappa` / `rabc_epsilon` / `rabc_head_mode` (see `lerobot/configs/train.py` in the pinned `lerobot>=0.5.0,<0.6.0`, which resolves 0.5.1) - not a nested config object.

```python
TrainSpec(
    dataset_root="/data/folding_v3",
    base_model="lerobot/pi05_base",
    output_dir="/tmp/ft_out",
    extra={
        "policy_type": "pi05",
        "sample_weighting": {"type": "rabc", "kappa": 0.01, "head_mode": "sparse"},
    },
)
# -> lerobot_train --use_rabc=true --rabc_kappa=0.01 --rabc_head_mode=sparse ...
```

- `build_config`: `type='rabc'` gates `use_rabc=True`; `kappa`/`epsilon`/`head_mode`/`progress_path` map to the `rabc_*` fields via `_SAMPLE_WEIGHTING_FIELD_MAP`. Fails fast on an unknown key, a non-`rabc` type, or a mapped field the installed lerobot lacks (`hasattr` guard, no silent drop).
- `build_command`: emit flat `--use_rabc=true --rabc_<field>=<value>` parity flags (no nested `--sample_weighting.*` or dict-leak flag).
- `validate`: reject a non-dict value and flag-unsafe (leading-dash) string values.
- docs(training/overview): document the friendly-key -> `rabc_*` mapping + the `extra` table row.

The knob lives in `extra` (not a first-class `TrainSpec` field) because RA-BC is lerobot-specific; per the `TrainSpec` contract, backend-specific knobs stay in `extra` until >=2 backends share them.

## Tests

`TestSampleWeightingRABC` regression class: flat-field attach (`use_rabc`/`rabc_kappa`/`rabc_head_mode`), flat parity flags, unknown-field error, non-`rabc` type error, and both validate guards. `build_config` tests are gated with `pytest.importorskip("lerobot")` to match every other `build_config` test and the import-path-parity house rule. `ruff` + scoped `mypy` clean.

No visual artifact: this is a pure training-config plumbing change (no policy/sim/render/recording behavior in this repo's runtime; the weighting behavior itself is lerobot's).

---

## §13 Review Rounds

| Round | Concern | Fix Commit | Pin Test |
|-------|---------|------------|----------|
| R1 | CI red: the binding targeted a nested `lerobot.utils.sample_weighting.SampleWeightingConfig` API that does not exist in any released lerobot (`ModuleNotFoundError` on 0.5.1). RA-BC IS released in 0.5.1, but as flat `use_rabc`/`rabc_*` fields. Rebound `build_config`/`build_command` to those real fields and rewrote the tests to assert them (running on the released wheel, not skipping). Supersedes the earlier skip-based band-aid (`be9bb83`). | `6cd5b77` | `TestSampleWeightingRABC` asserts `cfg.use_rabc`/`rabc_*` + `--use_rabc=true --rabc_*` flags; gated by `importorskip("lerobot")` |