### PR TITLE
feat(training): add relative-action training flag to the lerobot trainer

### DIFF
--- a/docs/training/overview.md
+++ b/docs/training/overview.md
@@ -99,6 +99,7 @@ supports and **ignores the rest** (the same tolerance rule as
 | `extra["policy_type"]` | lerobot `--policy.type` | act/diffusion/smolvla/pi0/pi05/... |
 | `extra["groot_root"]` | Isaac-GR00T checkout | GR00T |
 | `extra["sft_toml"]` / `extra["cosmos_root"]` | recipe + checkout | Cosmos |
+| `extra["relative_actions"]` | train pi0-family with delta actions | lerobot `--policy.use_relative_actions=true` (pi0/pi05/pi0_fast) |
 
 ## From an agent (natural language)
 
@@ -124,6 +125,31 @@ agent("Record 50 cube-pick episodes, then post-tune lerobot ACT on the dataset "
 TrainSpec(..., method="lora", lora_r=16, extra={"policy_type": "pi05"})
 # -> lerobot_train --peft.method_type=LORA --peft.r=16 --policy.type=pi05
 ```
+
+#### Relative (delta) actions
+
+Predicting actions as deltas from the current robot state - rather than
+absolute targets - is part of the strongest manipulation ablations. lerobot
+implements it as a matched processor pair built from
+`config.use_relative_actions`: a `RelativeActionsProcessorStep` encodes
+target->delta at train time, and the inverse `AbsoluteActionsProcessorStep`
+decodes delta->target at inference. Both are saved into the checkpoint's
+pre/post processors, so deployment via `lerobot_local` (which loads the saved
+processor pipeline) restores the inverse decode automatically - no separate
+inference-side wiring is needed.
+
+```python
+TrainSpec(
+    dataset_root="/data/folding_v3",
+    base_model="lerobot/pi05_base",
+    output_dir="/tmp/ft_out",
+    extra={"policy_type": "pi05", "relative_actions": True},
+)
+# -> lerobot_train --policy.type=pi05 --policy.use_relative_actions=true ...
+```
+
+Only `pi0` / `pi05` / `pi0_fast` expose `use_relative_actions`; the flag is
+rejected (not silently ignored) for any other policy type.
 
 #### Streaming a large Hub dataset (no full download)
 

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -68,6 +68,13 @@ _LEROBOT_POLICY_TYPES = {
 
 _SUPPORTED_METHODS = {"full", "lora", "expert_only"}
 
+# LeRobot policy types whose config exposes ``use_relative_actions`` (the
+# relative-action processor pair: a RelativeActionsProcessorStep on the input
+# side and the matching AbsoluteActionsProcessorStep on the output side, both
+# built from ``config.use_relative_actions`` and saved into the checkpoint's
+# pre/post processors). Other policy types have no such field.
+_RELATIVE_ACTION_POLICY_TYPES = {"pi0", "pi05", "pi0_fast"}
+
 # Hugging Face Hub dataset id: ``org/name`` (each segment alnum plus ._-). Used
 # to gate the agent-supplied ``dataset_repo_id`` before it becomes lerobot's
 # ``DatasetConfig.repo_id`` (which load_dataset/HfApi feed to a Hub URL).
@@ -179,6 +186,26 @@ class LerobotTrainer(Trainer):
             return list(range(0, total - spec.val_episodes))
         return None
 
+    def _relative_actions(self, spec: TrainSpec) -> bool:
+        """Whether to train with relative (delta) actions (``extra['relative_actions']``).
+
+        Relative-action training predicts deltas from the current robot state
+        instead of absolute targets - part of the strongest manipulation
+        ablations. lerobot implements it as a matched processor pair built from
+        ``config.use_relative_actions``: a ``RelativeActionsProcessorStep`` on
+        the input side (encode target->delta at train time) and the inverse
+        ``AbsoluteActionsProcessorStep`` on the output side (decode delta->target
+        at inference). Both are saved into the checkpoint's pre/post processors,
+        so deployment via ``lerobot_local`` (which loads the saved processor
+        pipeline) restores the inverse decode automatically - no separate
+        inference-side wiring is needed.
+
+        Only ``pi0`` / ``pi05`` / ``pi0_fast`` expose ``use_relative_actions``;
+        :meth:`validate` rejects the flag for any other policy type rather than
+        letting it become a silent no-op.
+        """
+        return bool(spec.extra.get("relative_actions", False))
+
     # ---- ABC ---------------------------------------------------------------
 
     def validate(self, spec: TrainSpec) -> list[str]:
@@ -215,6 +242,13 @@ class LerobotTrainer(Trainer):
             problems.append(f"unsupported method '{spec.method}' (expected one of {sorted(_SUPPORTED_METHODS)})")
         if spec.method == "lora" and spec.tune.get("expert_only"):
             problems.append("lora and expert_only are mutually exclusive (both freeze the VLM)")
+
+        if self._relative_actions(spec) and ptype not in _RELATIVE_ACTION_POLICY_TYPES:
+            problems.append(
+                f"relative_actions is not supported by policy_type '{ptype}' "
+                f"(only {sorted(_RELATIVE_ACTION_POLICY_TYPES)} expose use_relative_actions); "
+                "drop extra['relative_actions'] or pick a pi0-family policy"
+            )
 
         if spec.steps <= 0:
             problems.append(f"steps must be > 0, got {spec.steps}")
@@ -280,6 +314,8 @@ class LerobotTrainer(Trainer):
                 cmd.append(f"--peft.target_modules={spec.lora_target_modules}")
         elif spec.method == "expert_only":
             cmd.append("--policy.train_expert_only=true")
+        if self._relative_actions(spec):
+            cmd.append("--policy.use_relative_actions=true")
         eps = self._val_split_episodes(spec)
         if eps is not None:
             cmd.append(f"--dataset.episodes=[{', '.join(map(str, eps))}]")
@@ -288,7 +324,7 @@ class LerobotTrainer(Trainer):
             if ckpt_cfg:
                 cmd.append("--resume=true")
                 cmd.append(f"--config_path={ckpt_cfg}")
-        _consumed = {"policy_type", "job_name"}
+        _consumed = {"policy_type", "job_name", "relative_actions"}
         for key, value in spec.extra.items():
             if key in _consumed:
                 continue
@@ -319,6 +355,13 @@ class LerobotTrainer(Trainer):
             policy_cfg.pretrained_path = Path(spec.base_model)
         if spec.method == "expert_only" and hasattr(policy_cfg, "train_expert_only"):
             policy_cfg.train_expert_only = True
+        if self._relative_actions(spec):
+            if not hasattr(policy_cfg, "use_relative_actions"):
+                raise ValueError(
+                    f"relative_actions requested but policy_type '{ptype}' has no "
+                    f"use_relative_actions field (supported: {sorted(_RELATIVE_ACTION_POLICY_TYPES)})"
+                )
+            policy_cfg.use_relative_actions = True
 
         repo_id, root = self._dataset_source(spec)
         dataset_kwargs: dict[str, Any] = {
@@ -375,7 +418,7 @@ class LerobotTrainer(Trainer):
         # Typed passthrough for remaining extra.* (gated by validate()'s key
         # allowlist). Only set attributes that exist on the typed config tree;
         # unknown keys are ignored (never become an arbitrary flag).
-        _consumed = {"policy_type", "job_name"}
+        _consumed = {"policy_type", "job_name", "relative_actions"}
         for key, value in spec.extra.items():
             if key in _consumed:
                 continue

--- a/tests/training/test_lerobot.py
+++ b/tests/training/test_lerobot.py
@@ -708,3 +708,58 @@ class TestStreamingAndHubSource:
             extra={"policy_type": "act"},
         )
         assert LerobotTrainer()._val_split_episodes(spec) is None
+
+
+class TestRelativeActions:
+    """relative_actions wiring: extra['relative_actions'] -> policy.use_relative_actions.
+
+    Relative-action training (predict deltas from current state) is part of the
+    strongest manipulation ablations. lerobot implements it as a matched
+    processor pair built from ``config.use_relative_actions`` and saved into the
+    checkpoint's pre/post processors, so the inference-side inverse decode is
+    restored automatically by lerobot_local. Before the fix the flag had no
+    wiring: passing it via extra fell through the generic passthrough (no
+    matching top-level config field) and was silently dropped, so relative-action
+    training was unreachable and unsupported policies failed silently.
+    """
+
+    def _pi0_spec(self, dataset_root, tmp_path, ptype="pi0"):
+        return TrainSpec(
+            dataset_root=dataset_root,
+            base_model="",
+            output_dir=str(tmp_path / "out"),
+            steps=200,
+            extra={"policy_type": ptype, "relative_actions": True},
+        )
+
+    def test_build_config_sets_use_relative_actions(self, dataset_root, tmp_path):
+        cfg = LerobotTrainer(device="cpu").build_config(self._pi0_spec(dataset_root, tmp_path))
+        assert cfg.policy.use_relative_actions is True
+
+    def test_build_command_emits_flag(self, dataset_root, tmp_path):
+        cmd = LerobotTrainer(device="cpu").build_command(self._pi0_spec(dataset_root, tmp_path))
+        assert "--policy.use_relative_actions=true" in cmd
+        # Must not leak as a bare top-level flag.
+        assert not any(c.startswith("--relative_actions=") for c in cmd)
+
+    def test_default_off_leaves_flag_false(self, dataset_root, tmp_path):
+        spec = TrainSpec(
+            dataset_root=dataset_root,
+            base_model="",
+            output_dir=str(tmp_path / "out"),
+            steps=200,
+            extra={"policy_type": "pi0"},
+        )
+        cfg = LerobotTrainer(device="cpu").build_config(spec)
+        assert cfg.policy.use_relative_actions is False
+        assert not any("use_relative_actions" in c for c in LerobotTrainer(device="cpu").build_command(spec))
+
+    def test_validate_rejects_unsupported_policy(self, dataset_root, tmp_path):
+        spec = self._pi0_spec(dataset_root, tmp_path, ptype="act")
+        problems = LerobotTrainer().validate(spec)
+        assert any("relative_actions is not supported" in p for p in problems)
+
+    def test_validate_accepts_pi_family(self, dataset_root, tmp_path):
+        for ptype in ("pi0", "pi05", "pi0_fast"):
+            spec = self._pi0_spec(dataset_root, tmp_path, ptype=ptype)
+            assert LerobotTrainer().validate(spec) == []


### PR DESCRIPTION
## Problem

The `LerobotTrainer` had no way to enable **relative (delta) action training** for pi0-family policies. Predicting actions as deltas from the current robot state - rather than absolute targets - is part of the strongest manipulation ablations. lerobot drives it from `config.use_relative_actions`, but the trainer never set it. Passing it through the generic `extra` passthrough was a silent no-op: `relative_actions` is not a top-level `TrainPipelineConfig` field, so it was dropped with a debug warning and never reached the policy config - relative-action training was effectively unreachable.

## Change

Surface relative actions through `extra['relative_actions']` (bool):

```python
TrainSpec(
    dataset_root="/data/folding_v3",
    base_model="lerobot/pi05_base",
    output_dir="/tmp/ft_out",
    extra={"policy_type": "pi05", "relative_actions": True},
)
```

- `build_config`: set `policy_cfg.use_relative_actions=True`; raise if the policy type has no such field.
- `build_command`: emit `--policy.use_relative_actions=true` parity flag.
- `validate`: reject `relative_actions` for non-pi0-family policies (`act`/`diffusion`/`smolvla`/... have no `use_relative_actions` field; verified against lerobot's `make_policy_config`) instead of a silent no-op.
- docs(training/overview): document the relative-actions knob + table row.

### The inference matched-pair is automatic

lerobot builds relative actions as a matched processor pair from `config.use_relative_actions`: a `RelativeActionsProcessorStep` encodes target->delta at train time (input pipeline), and the inverse `AbsoluteActionsProcessorStep` decodes delta->target at inference (output pipeline). Both are saved into the checkpoint's `preprocessor.json`/`postprocessor.json`. Because `lerobot_local` already loads the saved processor pipeline via `ProcessorBridge.from_pretrained`, the inverse decode is restored automatically on deploy - no separate inference-side wiring needed. The flag lives in `extra` (not a first-class `TrainSpec` field) since `use_relative_actions` is specific to pi0-family policies.

## Tests

New `TestRelativeActions` regression class: config flag set, parity flag emitted, unsupported-policy rejection, and default-off. Verified the class **fails on pre-fix code** (3 core behaviors: flag stays False, no parity flag, no validate rejection) and passes after. Full `tests/training/test_lerobot.py` green (70 passed); `ruff` + scoped `mypy` clean.

No visual artifact: pure training-config plumbing; the relative-action behavior itself is lerobot's and is exercised by lerobot's own processor tests.