### PR TITLE
feat(teleoperate): add DAgger correction-collection action via lerobot-rollout

### DIFF
--- a/docs/hardware/tools.md
+++ b/docs/hardware/tools.md
@@ -20,7 +20,7 @@ from strands_robots.tools import (
 |------|-------------|------|
 | `lerobot_calibrate` | `"list"`, `"info"`, `"search"`, `"compare"`, `"backup"` | Manage existing calibration JSONs under `~/.cache/huggingface/lerobot/calibration/` (this tool inspects/organizes - actual calibration is run via the LeRobot CLI) |
 | `lerobot_camera` | `"list"`, `"test"`, `"stream"` | Enumerate, test, stream connected cameras |
-| `lerobot_teleoperate` | `"start"`, `"stop"`, `"status"` | Leader-follower teleop session |
+| `lerobot_teleoperate` | `"start"`, `"stop"`, `"status"`, `"replay"`, `"dagger"` | Leader-follower teleop session, episode replay, and DAgger correction collection |
 | `lerobot_train` | `"start"`, `"status"`, `"stop"`, `"list"` | Fine-tune a policy on a local dataset via `lerobot-train` |
 | `pose_tool` | `"fk"`, `"ik"`, `"set_gripper"` | Forward/inverse kinematics, gripper control |
 | `serial_tool` | `"list"`, `"send"` | Enumerate serial ports, send raw commands |
@@ -39,6 +39,19 @@ print(result["content"][0]["text"])
 result = lerobot_calibrate(action="list", device_type="robots")
 result = lerobot_camera(action="list", camera_type="opencv")
 result = pose_tool(action="fk", robot_id="so101_follower", port="/dev/ttyACM0")
+
+# DAgger / teleop takeover: a policy drives the follower while the leader can
+# pre-empt to record corrections (appended to the dataset as new episodes).
+# Drives lerobot-rollout with --strategy.type=dagger.
+result = lerobot_teleoperate(
+    action="dagger",
+    robot_type="so101_follower", robot_port="/dev/ttyACM0",
+    teleop_type="so101_leader", teleop_port="/dev/ttyACM1",
+    policy_path="user/act_fold",            # policy to roll out
+    dataset_repo_id="user/fold_corrections",
+    dataset_single_task="fold the towel",
+    dagger_num_episodes=10,                  # cap collected corrections
+)
 ```
 
 ## Use with an agent

--- a/strands_robots/tools/lerobot_teleoperate.py
+++ b/strands_robots/tools/lerobot_teleoperate.py
@@ -203,9 +203,14 @@ def build_lerobot_command(
     fps: int = 60,
     teleop_time_s: float | None = None,
     play_sounds: bool = True,
+    # DAgger / teleop-takeover (lerobot-rollout --strategy.type=dagger)
+    policy_path: str | None = None,
+    dagger_record_autonomous: bool = False,
+    dagger_input_device: str = "keyboard",
+    dagger_num_episodes: int | None = None,
     **kwargs,
 ) -> list[str]:
-    """Build the lerobot CLI argv for a teleoperate/record/replay action.
+    """Build the lerobot CLI argv for a teleoperate/record/replay/dagger action.
 
     Emits the lerobot 0.5 draccus-nested schema (``--robot.* / --teleop.* /
     --dataset.*``). The pre-0.5 flat flags (``--robot-path``, ``--repo-id``,
@@ -279,6 +284,49 @@ def build_lerobot_command(
             cmd.extend(["--display_data", "true"])
         return cmd
 
+    if action == "dagger":
+        # Human-in-the-loop correction (DAgger): a policy drives the follower
+        # while the leader can pre-empt to record corrections, appended to the
+        # dataset as new episodes. lerobot 0.5 implements this natively in
+        # lerobot-rollout with --strategy.type=dagger (RolloutConfig +
+        # DAggerStrategyConfig); the pre-0.5 "record with a policy" path was
+        # removed from lerobot_record, which now refuses a policy and points
+        # callers here.
+        if not policy_path:
+            raise ValueError("policy_path is required for dagger action (the policy to roll out)")
+        if not dataset_repo_id:
+            raise ValueError("dataset_repo_id is required for dagger action (corrections are recorded)")
+        if dagger_input_device not in ("keyboard", "pedal"):
+            raise ValueError(f"dagger_input_device must be 'keyboard' or 'pedal', got '{dagger_input_device}'")
+
+        cmd = ["python", "-m", "lerobot.scripts.lerobot_rollout"]
+        cmd.extend(
+            _robot_args(robot_type, robot_port, robot_id, robot_left_arm_port, robot_right_arm_port, robot_cameras)
+        )
+        cmd.extend(_teleop_args(teleop_type, teleop_port, teleop_id, teleop_left_arm_port, teleop_right_arm_port))
+        cmd.extend(["--policy.path", policy_path])
+        cmd.extend(["--strategy.type", "dagger"])
+        cmd.extend(["--strategy.input_device", dagger_input_device])
+        if dagger_record_autonomous:
+            cmd.extend(["--strategy.record_autonomous", "true"])
+        if dagger_num_episodes is not None:
+            cmd.extend(["--strategy.num_episodes", str(dagger_num_episodes)])
+        cmd.extend(["--dataset.repo_id", dataset_repo_id])
+        if dataset_single_task:
+            cmd.extend(["--dataset.single_task", dataset_single_task])
+        cmd.extend(["--dataset.num_episodes", str(dataset_num_episodes)])
+        cmd.extend(["--dataset.fps", str(dataset_fps)])
+        if dataset_root:
+            cmd.extend(["--dataset.root", dataset_root])
+        # push_to_hub defaults to True in lerobot's DatasetRecordConfig; make it
+        # explicit so an unattended correction run never uploads by surprise.
+        cmd.extend(["--dataset.push_to_hub", "true" if dataset_push_to_hub else "false"])
+        cmd.extend(["--dataset.video", "true" if dataset_video else "false"])
+        cmd.extend(["--fps", str(fps)])
+        if display_data:
+            cmd.extend(["--display_data", "true"])
+        return cmd
+
     raise ValueError(f"Unknown action: {action}")
 
 
@@ -318,6 +366,11 @@ def lerobot_teleoperate(
     teleop_time_s: float | None = None,
     play_sounds: bool = True,
     auto_accept_calibration: bool = True,
+    # DAgger / teleop-takeover (action="dagger")
+    policy_path: str | None = None,
+    dagger_record_autonomous: bool = False,
+    dagger_input_device: str = "keyboard",
+    dagger_num_episodes: int | None = None,
 ) -> dict[str, Any]:
     """
     Advanced LeRobot teleoperation tool with recording capabilities for robot training data collection.
@@ -352,6 +405,15 @@ def lerobot_teleoperate(
 
         replay: Replay a recorded episode on the robot
             - Requires dataset_repo_id and replay_episode
+
+        dagger: Human-in-the-loop correction (DAgger / teleop takeover)
+            - A policy drives the follower; the leader can pre-empt to record
+              corrections, appended to the dataset as new episodes.
+            - Requires policy_path (policy to roll out) and dataset_repo_id.
+            - Drives lerobot-rollout with --strategy.type=dagger. Toggle the
+              correction window with the keyboard/pedal (dagger_input_device);
+              set dagger_record_autonomous=True to also record the autonomous
+              phase, dagger_num_episodes to cap collected corrections.
 
     Robot Types:
         - so101_follower: Single-arm SO-101 robot
@@ -492,7 +554,7 @@ def lerobot_teleoperate(
     session_manager = SessionManager()
 
     try:
-        if action == "start":
+        if action in ("start", "dagger"):
             # Generate session name if not provided
             if not session_name:
                 session_name = f"teleop_{int(time.time())}"
@@ -530,6 +592,10 @@ def lerobot_teleoperate(
                     fps=fps,
                     teleop_time_s=teleop_time_s,
                     play_sounds=play_sounds,
+                    policy_path=policy_path,
+                    dagger_record_autonomous=dagger_record_autonomous,
+                    dagger_input_device=dagger_input_device,
+                    dagger_num_episodes=dagger_num_episodes,
                 )
             except Exception as e:
                 return {"status": "error", "content": [{"text": f"Command build failed: {str(e)}"}]}

--- a/tests/tools/test_lerobot_teleoperate.py
+++ b/tests/tools/test_lerobot_teleoperate.py
@@ -607,3 +607,135 @@ def test_start_foreground_nonzero_return_code_is_error(monkeypatch: pytest.Monke
     assert result["status"] == "error"
     assert result["return_code"] == 2
     _assert_ascii(_texts(result))
+
+
+# ---------------------------------------------------------------------------
+# DAgger / teleop-takeover action (lerobot-rollout --strategy.type=dagger)
+# ---------------------------------------------------------------------------
+def _dagger_cmd(**overrides: Any) -> list[str]:
+    kwargs: dict[str, Any] = dict(
+        action="dagger",
+        robot_type="so101_follower",
+        robot_port="/dev/ttyACM0",
+        robot_id="follower",
+        teleop_type="so101_leader",
+        teleop_port="/dev/ttyACM1",
+        teleop_id="leader",
+        policy_path="user/act_fold",
+        dataset_repo_id="user/fold_corrections",
+        dataset_single_task="fold the towel",
+        dagger_num_episodes=10,
+        fps=30,
+    )
+    kwargs.update(overrides)
+    return build_lerobot_command(**kwargs)
+
+
+def test_build_dagger_command_uses_rollout_with_dagger_strategy() -> None:
+    cmd = _dagger_cmd()
+    assert cmd[:3] == ["python", "-m", "lerobot.scripts.lerobot_rollout"]
+    assert "--robot.type" in cmd and "so101_follower" in cmd
+    assert "--teleop.type" in cmd and "so101_leader" in cmd
+    assert "--policy.path" in cmd and "user/act_fold" in cmd
+    assert "--strategy.type" in cmd and "dagger" in cmd
+    assert "--dataset.repo_id" in cmd and "user/fold_corrections" in cmd
+    # No stale pre-0.5 flat flags.
+    assert "--robot-path" not in cmd
+    assert "--repo-id" not in cmd
+
+
+def test_build_dagger_command_requires_policy_path() -> None:
+    with pytest.raises(ValueError, match="policy_path is required"):
+        _dagger_cmd(policy_path=None)
+
+
+def test_build_dagger_command_requires_dataset_repo_id() -> None:
+    with pytest.raises(ValueError, match="dataset_repo_id is required"):
+        _dagger_cmd(dataset_repo_id=None)
+
+
+def test_build_dagger_command_rejects_bad_input_device() -> None:
+    with pytest.raises(ValueError, match="dagger_input_device"):
+        _dagger_cmd(dagger_input_device="joystick")
+
+
+def test_build_dagger_command_push_to_hub_is_explicit_and_defaults_false() -> None:
+    # lerobot's DatasetRecordConfig defaults push_to_hub=True; the builder must
+    # make it explicit so an unattended correction run never auto-uploads.
+    cmd = _dagger_cmd()
+    idx = cmd.index("--dataset.push_to_hub")
+    assert cmd[idx + 1] == "false"
+    cmd_hub = _dagger_cmd(dataset_push_to_hub=True)
+    assert cmd_hub[cmd_hub.index("--dataset.push_to_hub") + 1] == "true"
+
+
+def test_build_dagger_command_record_autonomous_and_num_episodes() -> None:
+    cmd = _dagger_cmd(dagger_record_autonomous=True, dagger_num_episodes=5)
+    assert "--strategy.record_autonomous" in cmd
+    idx = cmd.index("--strategy.num_episodes")
+    assert cmd[idx + 1] == "5"
+
+
+def test_build_dagger_argv_matches_lerobot_rollout_fields() -> None:
+    """Cross-check every emitted --strategy/dataset/robot/teleop/top-level flag
+    against the real lerobot RolloutConfig / DAggerStrategyConfig /
+    DatasetRecordConfig dataclasses, so field drift is caught.
+
+    Skipped when lerobot is not importable (it is in the [all] test env).
+    """
+    pytest.importorskip("lerobot.scripts.lerobot_rollout")
+    import dataclasses
+    import typing
+
+    from lerobot.rollout.configs import DAggerStrategyConfig
+    from lerobot.scripts.lerobot_rollout import RolloutConfig
+
+    # Resolve the dataset config from RolloutConfig's own annotations rather than
+    # hardcoding a module path (lerobot relocates these between releases).
+    rollout_hints = typing.get_type_hints(RolloutConfig)
+    dataset_type = rollout_hints["dataset"]
+    dataset_cls = typing.get_args(dataset_type)[0] if typing.get_args(dataset_type) else dataset_type
+
+    rollout_fields = {f.name for f in dataclasses.fields(RolloutConfig)}
+    dagger_fields = {f.name for f in dataclasses.fields(DAggerStrategyConfig)} | {"type"}
+    dataset_fields = {f.name for f in dataclasses.fields(dataset_cls)}
+    robot_fields = {"type", "port", "id", "cameras", "left_arm_port", "right_arm_port"}
+    teleop_fields = {"type", "port", "id", "left_arm_port", "right_arm_port"}
+
+    cmd = _dagger_cmd(
+        dagger_record_autonomous=True,
+        robot_cameras={"front": {"type": "opencv", "index_or_path": 0}},
+        display_data=True,
+    )
+    flags = [tok[2:].split("=", 1)[0] for tok in cmd if tok.startswith("--")]
+    for flag in flags:
+        if flag.startswith("strategy."):
+            assert flag.split(".", 1)[1] in dagger_fields, f"{flag} not a DAggerStrategyConfig field"
+        elif flag.startswith("dataset."):
+            assert flag.split(".", 1)[1] in dataset_fields, f"{flag} not a DatasetRecordConfig field"
+        elif flag.startswith("robot."):
+            assert flag.split(".", 1)[1] in robot_fields, f"{flag} not a robot config field"
+        elif flag.startswith("teleop."):
+            assert flag.split(".", 1)[1] in teleop_fields, f"{flag} not a teleop config field"
+        elif flag.startswith("policy."):
+            assert flag.split(".", 1)[1] == "path", f"{flag} not the policy path arg"
+        else:
+            assert flag in rollout_fields, f"{flag} not a RolloutConfig field"
+
+
+def test_dagger_dispatch_starts_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(tele_mod.subprocess, "Popen", lambda *a, **k: _FakeProc(pid=os.getpid()))
+    result = lerobot_teleoperate(
+        action="dagger",
+        session_name="dagger_test",
+        robot_type="so101_follower",
+        teleop_type="so101_leader",
+        policy_path="user/act_fold",
+        dataset_repo_id="user/fold_corrections",
+        dataset_single_task="fold the towel",
+        auto_accept_calibration=False,
+    )
+    assert result["status"] == "success"
+    _assert_ascii(_texts(result))
+    listed = lerobot_teleoperate(action="list")
+    assert "dagger_test" in listed["sessions"]


### PR DESCRIPTION
## Problem

`lerobot_teleoperate` could teleoperate OR roll out a policy, but had no **intervention / takeover** path: there was no way to run a policy on the follower, let the leader pre-empt mid-episode, and record the human correction as new dataset episodes (DAgger). This is the data-collection loop behind correction-driven fine-tuning of long-horizon manipulation policies.

The pre-0.5 approach (`lerobot_record` with a `--policy.path`) no longer exists: lerobot 0.5 split policy rollout out of `lerobot_record` (which now raises `"A teleoperator is required... For policy-based deployment, use lerobot-rollout instead."`) into `lerobot-rollout`, which gained a native DAgger strategy (`RolloutConfig` + `DAggerStrategyConfig`).

## Change

Add a `dagger` action to `lerobot_teleoperate` that builds the correct nested `lerobot-rollout` CLI and runs it through the existing session/background machinery:

```python
lerobot_teleoperate(
    action="dagger",
    robot_type="so101_follower", robot_port="/dev/ttyACM0",
    teleop_type="so101_leader", teleop_port="/dev/ttyACM1",
    policy_path="user/act_fold",            # policy to roll out
    dataset_repo_id="user/fold_corrections",
    dataset_single_task="fold the towel",
    dagger_num_episodes=10,                  # cap collected corrections
)
# -> lerobot-rollout --robot.type=so101_follower --teleop.type=so101_leader
#      --policy.path=user/act_fold --strategy.type=dagger
#      --strategy.input_device=keyboard --strategy.num_episodes=10
#      --dataset.repo_id=user/fold_corrections --dataset.single_task=... --fps=30 ...
```

- New params: `policy_path`, `dagger_record_autonomous`, `dagger_input_device` (keyboard|pedal), `dagger_num_episodes`.
- `--dataset.push_to_hub` is emitted **explicitly** (lerobot's `DatasetRecordConfig` defaults it to `True`) so an unattended correction run never auto-uploads.
- Guards: `policy_path` and `dataset_repo_id` required; `dagger_input_device` enum-checked.
- Cameras render to the nested `--robot.cameras={...}` 0.5 form.
- docs(hardware/tools): document the `dagger` action + example.

## Tests

New tests cover the nested-CLI wiring, required-arg guards, the explicit push-to-hub default, `record_autonomous`/`num_episodes`, and session dispatch. A field-drift parity test resolves `RolloutConfig` / `DAggerStrategyConfig` / `DatasetRecordConfig` from lerobot's own `typing.get_type_hints` and asserts every emitted `--strategy.* / --dataset.* / --robot.* / --teleop.* / top-level` flag is a real dataclass field - so a future lerobot rename fails the test instead of silently building a bad command. All 8 new tests **fail on pre-fix code** (`Unknown action: dagger`); full `tests/tools/test_lerobot_teleoperate.py` green (38 passed); `ruff` + scoped `mypy` clean.

No visual artifact: this PR builds and validates a CLI for lerobot's native DAgger rollout; it changes no policy/sim/render behavior in this package, and a meaningful DAgger demo requires a leader+follower pair, a trained policy, and live human takeover (not reproducible headless). The argv parity test against lerobot's real config dataclasses is the verification.