### PR TITLE
fix(lerobot_local): mid-center the SO-arm degrees conversion like motors_bus

### DIFF
--- a/docs/policies/molmoact2.md
+++ b/docs/policies/molmoact2.md
@@ -59,6 +59,48 @@ So a model action of `[30, 30, 30, 30, 30, 50]` (degrees / 0..100) maps to
 Without this conversion, `30.0` is interpreted as 30 radians, which saturates the
 joint's `[-pi, pi]`-scale limit and the arm appears frozen.
 
+### Calibration mid-point (`joint_mids`)
+
+LeRobot's `MotorNormMode.DEGREES` is **mid-point-centered**: the value a
+checkpoint trains on is the angular displacement from each motor's calibration
+mid-point, not the absolute joint angle. Ground truth
+(`lerobot/motors/motors_bus.py`, `_normalize` / `_unnormalize`):
+
+```python
+mid = (range_min + range_max) / 2          # calibration mid, encoder ticks
+degrees = (raw - mid) * 360 / max_res      # reported state/action
+```
+
+On real hardware this is correct automatically because the driver owns the
+conversion and knows each servo's calibration mid. In sim, `qpos = 0` (the MJCF
+home pose) is generally **not** the calibration mid, so the absolute
+`deg = rad * 180/pi` conversion is offset per joint from the training
+distribution. After LeRobot's `MIN_MAX` state normalization that offset can push
+`observation.state` outside the dataset range, degrading the policy in sim while
+the same checkpoint works on the arm.
+
+Supply the per-joint mid-points (in degrees, aligned to `state_keys` /
+`action_keys`) via `joint_mids` so the conversion mid-centers like
+`motors_bus`. The gripper column (`gripper_index`) is exempt (RANGE_0_100 has no
+mid). Empty (the default) treats every mid as `0` -- i.e. sim `qpos = 0` is
+assumed to coincide with the calibration mid, preserving the prior
+absolute-degrees behavior:
+
+```json
+"so101": {
+  "state_units": "degrees",
+  "action_units": "degrees",
+  "gripper_index": 5,
+  "gripper_joint_range": [-0.175, 1.745],
+  "joint_mids": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+}
+```
+
+Populate `joint_mids` from the calibration the checkpoint was trained against
+(`mid = (range_min + range_max) / 2` per motor, expressed as a sim-frame joint
+angle in degrees). Leave it empty only when the sim home pose already coincides
+with the calibration mid.
+
 Pass `embodiment="so101"` to the policy (or `"so100"`, `"so_real"` for hardware):
 
 ```python

--- a/examples/06_agent_collect_and_stream.py
+++ b/examples/06_agent_collect_and_stream.py
@@ -48,13 +48,13 @@ reader = sim.stream_dataset(
     shuffle=False,
 )
 
-print(f"\nStreaming {reader.num_episodes} episode(s), "
-      f"{reader.num_frames} frames @ {reader.fps} fps")
+print(f"\nStreaming {reader.num_episodes} episode(s), {reader.num_frames} frames @ {reader.fps} fps")
 print(f"cameras: {reader.meta.video_keys}")
 for i, frame in enumerate(reader):
     cams = {k: tuple(frame[k].shape) for k in frame if k.startswith("observation.images.")}
-    print(f"  frame {i}: state{tuple(frame['observation.state'].shape)} "
-          f"action{tuple(frame['action'].shape)} cams={cams}")
+    print(
+        f"  frame {i}: state{tuple(frame['observation.state'].shape)} action{tuple(frame['action'].shape)} cams={cams}"
+    )
     if i >= 2:
         break
 

--- a/examples/07_post_tune_any_policy.py
+++ b/examples/07_post_tune_any_policy.py
@@ -23,7 +23,7 @@ os.environ.setdefault("MUJOCO_GL", "cgl")  # macOS offscreen GL
 from strands_robots import MockPolicy, Robot, create_policy
 from strands_robots.training import TrainSpec, create_trainer
 
-PROVIDER = "lerobot_local"      # swap -> "groot" / "cosmos3" (only this changes)
+PROVIDER = "lerobot_local"  # swap -> "groot" / "cosmos3" (only this changes)
 DATASET_ROOT = "/tmp/strands_post_tune_ds"
 OUTPUT_DIR = "/tmp/strands_post_tune_ft"
 
@@ -31,12 +31,17 @@ OUTPUT_DIR = "/tmp/strands_post_tune_ft"
 sim = Robot("so100", mesh=False)
 sim.add_camera(name="front", position=[0.5, 0.0, 0.4], target=[0.2, 0, 0.05])
 sim.start_recording(
-    repo_id="local/post_tune_demo", root=DATASET_ROOT,
-    fps=30, task="pick up the red cube", overwrite=True,
+    repo_id="local/post_tune_demo",
+    root=DATASET_ROOT,
+    fps=30,
+    task="pick up the red cube",
+    overwrite=True,
 )
 sim.run_policy(
-    robot_name="so100", policy_object=MockPolicy(),
-    instruction="pick up the red cube", n_steps=60,
+    robot_name="so100",
+    policy_object=MockPolicy(),
+    instruction="pick up the red cube",
+    n_steps=60,
 )
 sim.stop_recording()
 print(f"Recorded LeRobotDataset -> {DATASET_ROOT}")
@@ -46,13 +51,15 @@ print(f"Recorded LeRobotDataset -> {DATASET_ROOT}")
 trainer = create_trainer(PROVIDER, device="cpu")
 spec = TrainSpec(
     dataset_root=DATASET_ROOT,
-    base_model="",                       # ACT from scratch (smallest CPU path)
+    base_model="",  # ACT from scratch (smallest CPU path)
     output_dir=OUTPUT_DIR,
-    steps=2, save_freq=2, global_batch_size=2,
+    steps=2,
+    save_freq=2,
+    global_batch_size=2,
     extra={"policy_type": "act", "num_workers": 0},
 )
 
-problems = trainer.validate(spec)        # pure preflight - launch nothing if bad
+problems = trainer.validate(spec)  # pure preflight - launch nothing if bad
 if problems:
     raise SystemExit("Spec invalid:\n  - " + "\n  - ".join(problems))
 
@@ -70,5 +77,4 @@ print(f"exported artifact: {exported}")
 os.environ.setdefault("STRANDS_TRUST_REMOTE_CODE", "1")
 policy = create_policy(exported, device="cpu")
 print(f"loaded trained policy: {type(policy).__name__} (provider={policy.provider_name})")
-print("\nLoop closed: record -> train -> export -> load. "
-      "Swap PROVIDER to 'groot'/'cosmos3' to retarget the same flow.")
+print("\nLoop closed: record -> train -> export -> load. Swap PROVIDER to 'groot'/'cosmos3' to retarget the same flow.")

--- a/examples/lerobot/hub_to_hardware.ipynb
+++ b/examples/lerobot/hub_to_hardware.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "7fb27b941602401d91542211134fc71a",
    "metadata": {},
    "source": [
     "# From Hugging Face Hub to robot hardware\n",
@@ -22,6 +23,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "acae54e37e7d407bbb7b55eff062a284",
    "metadata": {},
    "source": [
     "## Prerequisites\n",
@@ -44,6 +46,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "9a63283cbaf04dbcab1f6479b197f3a8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,6 +75,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8dd0d8092fe74a7c96281538738b07e2",
    "metadata": {},
    "source": [
     "## Step 1: Build the agent\n",
@@ -84,11 +88,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "72eea5119410473aa328ad9291626812",
    "metadata": {},
    "outputs": [],
    "source": [
     "from strands import Agent\n",
     "from strands.models import BedrockModel\n",
+    "\n",
     "from strands_robots import Robot, robot_mesh\n",
     "\n",
     "model = BedrockModel(model_id=MODEL_ID, region_name=AWS_REGION) if AWS_REGION else BedrockModel(model_id=MODEL_ID)\n",
@@ -102,6 +108,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8edb47106e1a46a883d545849b8ab81b",
    "metadata": {},
    "source": [
     "## Step 2: Record a demonstration\n",
@@ -114,15 +121,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "10185d26023b46108eb7d9f57d49d2b3",
    "metadata": {},
    "outputs": [],
    "source": [
     "NUM_STEPS = 1000  # ≈ 33s of data at 30fps\n",
     "\n",
     "push_clause = (\n",
-    "    f\"Push the result to {REPO_ID} when done.\"\n",
-    "    if PUSH_TO_HUB\n",
-    "    else \"Keep the dataset local; do not push to the Hub.\"\n",
+    "    f\"Push the result to {REPO_ID} when done.\" if PUSH_TO_HUB else \"Keep the dataset local; do not push to the Hub.\"\n",
     ")\n",
     "\n",
     "prompt = (\n",
@@ -145,6 +151,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8763a12b2bbd4a93a75aff182afb95dc",
    "metadata": {},
    "source": [
     "### Verify the recording\n",
@@ -155,6 +162,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "7623eae2785240b9bd12b16a66d81610",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -173,6 +181,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7cdc8c89c7104fffa095e18ddfef8986",
    "metadata": {},
    "source": [
     "Inside the cache directory you'll find:\n",
@@ -186,6 +195,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b118ea5561624da68c537baed56e602f",
    "metadata": {},
    "source": [
     "## Step 3: Run a policy on the robot\n",
@@ -198,17 +208,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "938c804e27f84196a10c8828c723f798",
    "metadata": {},
    "outputs": [],
    "source": [
-    "agent(\n",
-    "    f\"Run the Mock policy on the robot for 200 steps with the instruction \"\n",
-    "    f\"'{TASK}'. Render the final frame.\"\n",
-    ")"
+    "agent(f\"Run the Mock policy on the robot for 200 steps with the instruction '{TASK}'. Render the final frame.\")"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "504fb2a444614c0babb325280ed9130a",
    "metadata": {},
    "source": [
     "## Step 4: Deploy to physical hardware (reference)\n",
@@ -235,6 +244,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "59bbdb311c014d738909a11f9e486628",
    "metadata": {},
    "source": [
     "## Step 5: Mesh broadcast\n",
@@ -247,6 +257,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "b43b363d81ae4b689946ece5c682cd59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -258,6 +269,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8a65eabff63a45729fe45fb5ade58bdc",
    "metadata": {},
    "source": [
     "## Cleanup\n",

--- a/examples/lerobot/hub_to_hardware.py
+++ b/examples/lerobot/hub_to_hardware.py
@@ -101,6 +101,7 @@ DEFAULT_MODEL_ID = "global.anthropic.claude-opus-4-8"  # ← verify in AWS conso
 # Agent construction
 # ---------------------------------------------------------------------------
 
+
 def _build_bedrock_model(model_id: str, region: str | None) -> Any | None:
     """Construct a Strands BedrockModel client.
 
@@ -136,7 +137,9 @@ def _build_bedrock_model(model_id: str, region: str | None) -> Any | None:
             "BedrockModel(%s, region=%s) init failed: %s. Falling back to "
             "Strands' default. Common causes: model not enabled in this AWS "
             "account, wrong region, or stale model ID - check the Bedrock console.",
-            model_id, region or "<unset>", exc,
+            model_id,
+            region or "<unset>",
+            exc,
         )
         return None
 
@@ -152,6 +155,7 @@ def build_agent(
 ) -> Any:
     """Build the Strands agent with the right tool set for the run."""
     from strands import Agent
+
     from strands_robots import (
         Robot,
         robot_mesh,
@@ -160,10 +164,7 @@ def build_agent(
     robot_kwargs: dict[str, Any] = {"data_config": "so100_dualcam"}
     if mode == "real":
         if not port:
-            raise SystemExit(
-                "--mode real requires --port (e.g. /dev/ttyACM0). "
-                "Hardware paths can't be guessed safely."
-            )
+            raise SystemExit("--mode real requires --port (e.g. /dev/ttyACM0). Hardware paths can't be guessed safely.")
         robot_kwargs.update(
             port=port,
             cameras={
@@ -185,18 +186,11 @@ def build_agent(
 
     if policy == "groot":
         from strands_robots import gr00t_inference
+
         tools.append(gr00t_inference)
 
-    resolved_model_id = (
-        model_id
-        or os.environ.get("STRANDS_BEDROCK_MODEL_ID")
-        or DEFAULT_MODEL_ID
-    )
-    resolved_region = (
-        aws_region
-        or os.environ.get("AWS_REGION")
-        or os.environ.get("AWS_DEFAULT_REGION")
-    )
+    resolved_model_id = model_id or os.environ.get("STRANDS_BEDROCK_MODEL_ID") or DEFAULT_MODEL_ID
+    resolved_region = aws_region or os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION")
     model = _build_bedrock_model(resolved_model_id, resolved_region)
 
     agent = Agent(model=model, tools=tools) if model else Agent(tools=tools)
@@ -212,6 +206,7 @@ def build_agent(
 # ---------------------------------------------------------------------------
 # Step 2: Record a demonstration
 # ---------------------------------------------------------------------------
+
 
 def record_demonstration(
     agent: Any,
@@ -254,9 +249,7 @@ def record_demonstration(
     else:
         leader_port = getattr(agent, "_leader_port", None)
         if not leader_port:
-            raise SystemExit(
-                "Hardware recording requires --leader-port (e.g. /dev/ttyACM1)"
-            )
+            raise SystemExit("Hardware recording requires --leader-port (e.g. /dev/ttyACM1)")
         prompt = (
             f"Record one demonstration of '{task}' on the SO-101, "
             f"with the leader on {leader_port}. Write the dataset "
@@ -269,6 +262,7 @@ def record_demonstration(
 # ---------------------------------------------------------------------------
 # Step 3: Run a policy on the robot
 # ---------------------------------------------------------------------------
+
 
 def run_policy(
     agent: Any,
@@ -286,10 +280,7 @@ def run_policy(
 
     elif policy == "groot":
         if not checkpoint:
-            raise SystemExit(
-                "--policy groot requires --checkpoint <hf_repo>, "
-                "e.g. nvidia/GR00T-N1.7-LIBERO"
-            )
+            raise SystemExit("--policy groot requires --checkpoint <hf_repo>, e.g. nvidia/GR00T-N1.7-LIBERO")
         prompt = (
             f"Use gr00t_inference lifecycle='full' to bring up the GR00T "
             f"container on port 5555 with checkpoint {checkpoint}. Then "
@@ -300,8 +291,7 @@ def run_policy(
     elif policy == "lerobot_local":
         if not checkpoint:
             raise SystemExit(
-                "--policy lerobot_local requires --checkpoint <hf_repo>, "
-                "e.g. lerobot/act_aloha_sim_transfer_cube_human"
+                "--policy lerobot_local requires --checkpoint <hf_repo>, e.g. lerobot/act_aloha_sim_transfer_cube_human"
             )
         if os.environ.get("STRANDS_TRUST_REMOTE_CODE") != "1":
             raise SystemExit(
@@ -328,6 +318,7 @@ def run_policy(
 # Step 5: Mesh broadcast
 # ---------------------------------------------------------------------------
 
+
 def broadcast_to_mesh(agent: Any, instruction: str = "go to home pose") -> Any:
     """Discover mesh peers and broadcast a command to all of them."""
     prompt = (
@@ -341,6 +332,7 @@ def broadcast_to_mesh(agent: Any, instruction: str = "go to home pose") -> Any:
 # ---------------------------------------------------------------------------
 # Cleanup
 # ---------------------------------------------------------------------------
+
 
 def cleanup(agent: Any, *, policy: str) -> None:
     """Tear down any long-running resources the workflow started."""
@@ -367,6 +359,7 @@ def cleanup(agent: Any, *, policy: str) -> None:
 # Entry point
 # ---------------------------------------------------------------------------
 
+
 def parse_args(argv: list[str]) -> argparse.Namespace:
     p = argparse.ArgumentParser(
         prog="hub_to_hardware",
@@ -389,8 +382,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     p.add_argument(
         "--checkpoint",
         default=None,
-        help="HF repo for the policy checkpoint "
-             "(required for --policy groot or lerobot_local).",
+        help="HF repo for the policy checkpoint (required for --policy groot or lerobot_local).",
     )
 
     # LLM knobs
@@ -398,56 +390,65 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "--model-id",
         default=None,
         help=f"Bedrock model ID to drive the agent. Default: {DEFAULT_MODEL_ID}. "
-             f"Override here or via STRANDS_BEDROCK_MODEL_ID. Verify the exact "
-             f"ID against your AWS Bedrock console.",
+        f"Override here or via STRANDS_BEDROCK_MODEL_ID. Verify the exact "
+        f"ID against your AWS Bedrock console.",
     )
     p.add_argument(
         "--aws-region",
         default=None,
         help="AWS region for Bedrock. If unset, resolves from AWS_REGION / "
-             "AWS_DEFAULT_REGION env vars or ~/.aws/config (boto3's standard chain).",
+        "AWS_DEFAULT_REGION env vars or ~/.aws/config (boto3's standard chain).",
     )
 
     # Hardware knobs
     p.add_argument(
-        "--port", default=None,
+        "--port",
+        default=None,
         help="USB device of the SO-101 follower (--mode real only).",
     )
     p.add_argument(
-        "--leader-port", default=None,
+        "--leader-port",
+        default=None,
         help="USB device of the SO-101 leader arm (--mode real only).",
     )
 
     # Recording knobs
     p.add_argument(
-        "--hf-user", default=None,
+        "--hf-user",
+        default=None,
         help="HF username for the dataset repo. If unset, the dataset stays local.",
     )
     p.add_argument(
-        "--dataset-name", default="strands-cube-pick",
+        "--dataset-name",
+        default="strands-cube-pick",
         help="Dataset name under <hf-user>. Default: strands-cube-pick.",
     )
     p.add_argument(
-        "--num-steps", type=int, default=1000,
-        help="Number of policy steps to record in the demonstration "
-             "(default: 1000, ≈ 33s of data at 30fps).",
+        "--num-steps",
+        type=int,
+        default=1000,
+        help="Number of policy steps to record in the demonstration (default: 1000, ≈ 33s of data at 30fps).",
     )
     p.add_argument(
-        "--instruction", default="pick up the red cube",
+        "--instruction",
+        default="pick up the red cube",
         help="Natural-language task instruction.",
     )
     p.add_argument(
-        "--clean-cache", action="store_true",
+        "--clean-cache",
+        action="store_true",
         help="Delete the local LeRobotDataset cache for this repo before recording.",
     )
 
     # Skip flags
     p.add_argument(
-        "--skip-record", action="store_true",
+        "--skip-record",
+        action="store_true",
         help="Skip the recording step (Step 2).",
     )
     p.add_argument(
-        "--skip-mesh", action="store_true",
+        "--skip-mesh",
+        action="store_true",
         help="Skip the mesh broadcast step (Step 5).",
     )
 
@@ -471,14 +472,11 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     push_to_hub = bool(args.hf_user)
-    repo_id = (
-        f"{args.hf_user}/{args.dataset_name}"
-        if push_to_hub
-        else f"local/{args.dataset_name}"
-    )
+    repo_id = f"{args.hf_user}/{args.dataset_name}" if push_to_hub else f"local/{args.dataset_name}"
 
     if args.clean_cache:
         import shutil
+
         cache_dir = Path.home() / ".cache" / "huggingface" / "lerobot" / repo_id
         if cache_dir.exists():
             logger.info("Removing cache at %s", cache_dir)
@@ -486,7 +484,11 @@ def main(argv: list[str] | None = None) -> int:
 
     logger.info(
         "Starting workflow (mode=%s, policy=%s, push_to_hub=%s, repo=%s, num_steps=%d)",
-        args.mode, args.policy, push_to_hub, repo_id, args.num_steps,
+        args.mode,
+        args.policy,
+        push_to_hub,
+        repo_id,
+        args.num_steps,
     )
 
     banner("Step 1: Build the agent")

--- a/examples/vera_mimicgen_panda/critique_with_cosmos3.py
+++ b/examples/vera_mimicgen_panda/critique_with_cosmos3.py
@@ -7,6 +7,7 @@ Requires a Cosmos3-Nano reasoner serving on :8000 (see strands-cosmos
 `c3-serve-reason`). Videos must live under an allowed workspace
 (/tmp/vera-critique or COSMOS_VIDEO_WORKSPACE, or set COSMOS_WORKSPACE).
 """
+
 import os
 import shutil
 import sys

--- a/examples/vera_mimicgen_panda/rollout.py
+++ b/examples/vera_mimicgen_panda/rollout.py
@@ -70,12 +70,20 @@ def _build_scene(robot: str = "panda", mesh: bool = False):
     sim = Robot(robot, mesh=mesh)
     # MimicGen 2-block stacking props.
     sim.add_object(
-        name="red_block", shape="box", position=[0.45, -0.05, 0.025],
-        size=[0.025, 0.025, 0.025], color=[0.9, 0.2, 0.2, 1], mass=0.05,
+        name="red_block",
+        shape="box",
+        position=[0.45, -0.05, 0.025],
+        size=[0.025, 0.025, 0.025],
+        color=[0.9, 0.2, 0.2, 1],
+        mass=0.05,
     )
     sim.add_object(
-        name="green_block", shape="box", position=[0.45, 0.10, 0.025],
-        size=[0.03, 0.03, 0.02], color=[0.2, 0.8, 0.2, 1], mass=0.08,
+        name="green_block",
+        shape="box",
+        position=[0.45, 0.10, 0.025],
+        size=[0.03, 0.03, 0.02],
+        color=[0.2, 0.8, 0.2, 1],
+        mass=0.08,
     )
     # Seed a natural Panda "ready" pose. The default all-zeros config is a
     # near-singular straight-up pose that sits half out of frame — a Cosmos3
@@ -83,8 +91,13 @@ def _build_scene(robot: str = "panda", mesh: bool = False):
     # because the (large) motion happened off-camera. A tabletop-ready pose
     # keeps the arm in view so the rollout reads as purposeful manipulation.
     ready = {
-        "joint1": 0.0, "joint2": -0.4, "joint3": 0.0, "joint4": -2.0,
-        "joint5": 0.0, "joint6": 1.6, "joint7": 0.8,
+        "joint1": 0.0,
+        "joint2": -0.4,
+        "joint3": 0.0,
+        "joint4": -2.0,
+        "joint5": 0.0,
+        "joint6": 1.6,
+        "joint7": 0.8,
     }
     try:
         sim.send_action(ready, robot_name=robot, n_substeps=200)
@@ -98,9 +111,7 @@ def _build_scene(robot: str = "panda", mesh: bool = False):
 
 
 def main() -> int:
-    p = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
-    )
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     p.add_argument("--host", default="127.0.0.1", help="VERA server host.")
     p.add_argument("--port", type=int, default=8800, help="VERA MimicGen ws port.")
     p.add_argument("--instruction", default="stack the red block on the green block")
@@ -116,9 +127,10 @@ def main() -> int:
         help="Record the rollout to this MP4 (set '' to disable).",
     )
     p.add_argument(
-        "--server-mode", choices=["subprocess", "docker", "attach"], default="attach",
-        help="attach (default): connect to a running server; docker/subprocess: "
-        "let the provider manage it.",
+        "--server-mode",
+        choices=["subprocess", "docker", "attach"],
+        default="attach",
+        help="attach (default): connect to a running server; docker/subprocess: let the provider manage it.",
     )
     p.add_argument("--ckpt-root", default=None, help="VERA checkpoint root (docker/subprocess modes).")
     p.add_argument("--mesh", action="store_true", help="Higher-fidelity mesh rendering.")
@@ -157,8 +169,7 @@ def main() -> int:
         video = {"path": str(out), "fps": 20, "camera": "agentview_image", "width": 512, "height": 512}
         print(f"Recording rollout -> {out}")
 
-    print(f"Rolling out VERA MimicGen -> {args.robot} for {args.n_steps} steps "
-          f"(server={args.server_mode}) ...")
+    print(f"Rolling out VERA MimicGen -> {args.robot} for {args.n_steps} steps (server={args.server_mode}) ...")
     result = sim.run_policy(
         robot_name=args.robot,
         policy_provider="vera",

--- a/strands_robots/policies/lerobot_local/embodiment.py
+++ b/strands_robots/policies/lerobot_local/embodiment.py
@@ -83,6 +83,7 @@ def _convert_joint_vector(
     to_model: bool,
     gripper_index: int = -1,
     gripper_joint_range: list[float] | None = None,
+    joint_mids: list[float] | None = None,
 ) -> list[float]:
     """Convert an ordered joint vector between sim units (radians + gripper joint
     range) and the LeRobot SO-arm training units (arm degrees, gripper 0..100).
@@ -99,12 +100,31 @@ def _convert_joint_vector(
     because the SO-arm gripper uses ``MotorNormMode.RANGE_0_100`` (0..100), not
     degrees - see ``lerobot/robots/so_follower/so_follower.py``.
 
+    LeRobot's ``MotorNormMode.DEGREES`` is **mid-point-centered**: the value a
+    checkpoint trains on is the angular displacement from each motor's
+    calibration mid-point, not the absolute joint angle (ground truth:
+    ``lerobot/motors/motors_bus.py`` ``_normalize`` / ``_unnormalize`` ->
+    ``mid = (range_min + range_max) / 2``; reported degrees = ``(val - mid) *
+    360 / max_res``). When ``joint_mids`` is supplied (per-joint mid offsets in
+    degrees, aligned to ``values``), the arm conversion subtracts the mid going
+    to the model and adds it back coming from the model, so the packed
+    ``observation.state`` matches the distribution the checkpoint was trained on
+    rather than being offset by each joint's mid. When ``joint_mids`` is empty
+    (the default), the mid is treated as zero -- i.e. the sim ``qpos = 0`` is
+    assumed to coincide with the calibration mid (absolute ``deg = rad *
+    180/pi``), preserving the prior behavior.
+
     Args:
         values: Ordered joint values.
         to_model: Conversion direction (see above).
         gripper_index: Index of the gripper column, or -1 for none.
         gripper_joint_range: ``[min, max]`` radians of the sim gripper joint;
             empty/None treats the gripper like an arm joint (deg<->rad).
+        joint_mids: Per-joint calibration mid-points in DEGREES, aligned to
+            ``values``. Subtracted from arm columns when ``to_model`` and added
+            back otherwise, matching ``motors_bus`` DEGREES mid-centering. The
+            gripper column (``gripper_index``) is exempt (RANGE_0_100 has no
+            mid). Empty/None / out-of-range indices use a mid of ``0.0``.
 
     Returns:
         A new list of converted values (input is not mutated).
@@ -112,6 +132,7 @@ def _convert_joint_vector(
     out = list(values)
     rad_per_deg = float(np.pi) / 180.0
     grange = gripper_joint_range or []
+    mids = joint_mids or []
     for i, v in enumerate(out):
         if i == gripper_index and len(grange) == 2:
             lo, hi = float(grange[0]), float(grange[1])
@@ -122,10 +143,12 @@ def _convert_joint_vector(
                 out[i] = (float(v) - lo) / span * 100.0  # joint rad -> 0..100
             else:
                 out[i] = lo + (float(v) / 100.0) * span  # 0..100 -> joint rad
-        elif to_model:
-            out[i] = float(v) / rad_per_deg  # radians -> degrees
         else:
-            out[i] = float(v) * rad_per_deg  # degrees -> radians
+            mid = float(mids[i]) if i < len(mids) else 0.0
+            if to_model:
+                out[i] = float(v) / rad_per_deg - mid  # radians -> mid-centered degrees
+            else:
+                out[i] = (float(v) + mid) * rad_per_deg  # mid-centered degrees -> radians
     return out
 
 
@@ -288,6 +311,10 @@ def register_pack_state_step() -> type | None:
         state_units: str = "native"
         gripper_index: int = -1
         gripper_joint_range: list[float] = field(default_factory=list)
+        # Per-joint calibration mid-points in DEGREES (aligned to state_keys);
+        # subtracted from arm columns so observation.state is mid-centered like
+        # lerobot motors_bus DEGREES mode. Empty = mid 0 (prior behavior).
+        joint_mids: list[float] = field(default_factory=list)
 
         def observation(self, observation: dict[str, Any]) -> dict[str, Any]:
             if "observation.state" in observation:
@@ -322,6 +349,7 @@ def register_pack_state_step() -> type | None:
                     to_model=True,
                     gripper_index=self.gripper_index,
                     gripper_joint_range=self.gripper_joint_range,
+                    joint_mids=self.joint_mids,
                 )
 
             target = self.expected_dim or len(vals)
@@ -389,6 +417,18 @@ class EmbodimentMap:
     # 0..100 gripper command onto the joint range (and back). Empty = treat the
     # gripper like an arm joint (deg<->rad). SO arms: [-0.175, 1.745].
     gripper_joint_range: list[float] = field(default_factory=list)
+    # Per-joint calibration mid-points in DEGREES, aligned to state_keys /
+    # action_keys. LeRobot's MotorNormMode.DEGREES is mid-point-centered: a
+    # checkpoint conditions on (joint_angle - calibration_mid), not the absolute
+    # angle (ground truth: lerobot/motors/motors_bus.py mid = (min + max) / 2).
+    # The sim expresses absolute angles, so without the mid the packed
+    # observation.state is offset per joint from the training distribution and
+    # can fall outside the dataset MIN_MAX range after normalization -> OOD.
+    # When set, the "degrees" conversion subtracts the mid (sim -> model) and
+    # adds it back (model -> sim). The gripper column (gripper_index) is exempt
+    # (RANGE_0_100). Empty (default) = mid 0, i.e. sim qpos=0 is assumed to be
+    # the calibration mid (the prior absolute-degrees behavior).
+    joint_mids: list[float] = field(default_factory=list)
 
     def validate(self, input_features: dict[str, Any], output_features: dict[str, Any]) -> None:
         """Fail-fast validation against the model's declared features.
@@ -458,6 +498,7 @@ class EmbodimentMap:
             to_model=to_model,
             gripper_index=self.gripper_index,
             gripper_joint_range=self.gripper_joint_range,
+            joint_mids=self.joint_mids,
         )
 
     def sim_state_to_model(self, values: list[float]) -> list[float]:

--- a/strands_robots/policies/lerobot_local/processor.py
+++ b/strands_robots/policies/lerobot_local/processor.py
@@ -348,6 +348,7 @@ class ProcessorBridge:
                     state_units=embodiment.state_units,
                     gripper_index=embodiment.gripper_index,
                     gripper_joint_range=list(embodiment.gripper_joint_range),
+                    joint_mids=list(embodiment.joint_mids),
                 ),
             )
 

--- a/tests/policies/lerobot_local/test_so_arm_units.py
+++ b/tests/policies/lerobot_local/test_so_arm_units.py
@@ -97,3 +97,97 @@ def test_convert_helper_does_not_mutate_input():
     src = [10.0, 20.0, 30.0]
     _convert_joint_vector(src, to_model=False)
     assert src == [10.0, 20.0, 30.0]
+
+
+# Mid-point centering (BUG-3): LeRobot MotorNormMode.DEGREES is mid-centered.
+# Ground truth lerobot/motors/motors_bus.py: reported degrees =
+# (raw - mid) * 360 / max_res with mid = (range_min + range_max) / 2.
+# The sim expresses absolute joint angles, so without the per-joint mid the
+# packed observation.state is offset from the training distribution. These pin
+# the joint_mids mechanism that carries the calibration mid into the conversion.
+
+MIDS = [10.0, -20.0, 30.0, -5.0, 15.0, 0.0]  # per-joint mid offsets (degrees)
+
+
+def _so_arm_map_with_mids() -> EmbodimentMap:
+    return EmbodimentMap(
+        name="test_so_mids",
+        state_keys=["1", "2", "3", "4", "5", "6"],
+        action_keys=["1", "2", "3", "4", "5", "6"],
+        state_units="degrees",
+        action_units="degrees",
+        gripper_index=5,
+        gripper_joint_range=GRIPPER_RANGE,
+        joint_mids=MIDS,
+    )
+
+
+def test_joint_mids_subtracts_calibration_midpoint():
+    """sim -> model must subtract the per-joint mid (mid-centered degrees),
+    matching motors_bus, rather than emitting the absolute joint angle."""
+    emb = _so_arm_map_with_mids()
+    # 90 deg arm joints (pi/2 rad). Model state = 90 - mid per joint.
+    sim_state = [math.pi / 2] * 5 + [0.5]  # gripper handled separately
+    out = emb.sim_state_to_model(sim_state)
+    for i in range(5):
+        assert math.isclose(out[i], 90.0 - MIDS[i], abs_tol=1e-6), (i, out)
+
+
+def test_joint_mids_round_trip():
+    """sim -> model -> sim recovers the original sim state with mids applied."""
+    emb = _so_arm_map_with_mids()
+    sim_state = [0.5, -1.0, 1.2, -0.3, 2.0, 0.4]
+    back = emb.model_action_to_sim(emb.sim_state_to_model(sim_state))
+    assert np.allclose(back, sim_state, atol=1e-6), (back, sim_state)
+
+
+def test_joint_mids_gripper_column_exempt():
+    """The gripper column uses RANGE_0_100 and must ignore its mid entry even
+    when joint_mids supplies a (non-zero) value at that index."""
+    mids = [0.0, 0.0, 0.0, 0.0, 0.0, 999.0]  # bogus gripper mid -> must be ignored
+    emb = EmbodimentMap(
+        name="t",
+        state_keys=["1", "2", "3", "4", "5", "6"],
+        action_keys=["1", "2", "3", "4", "5", "6"],
+        state_units="degrees",
+        action_units="degrees",
+        gripper_index=5,
+        gripper_joint_range=GRIPPER_RANGE,
+        joint_mids=mids,
+    )
+    lo, hi = GRIPPER_RANGE
+    # 50 -> midpoint regardless of the bogus gripper mid entry.
+    assert math.isclose(emb.model_action_to_sim([0, 0, 0, 0, 0, 50])[5], (lo + hi) / 2, abs_tol=1e-6)
+
+
+def test_joint_mids_matches_motors_bus_degrees_formula():
+    """Parity with lerobot motors_bus DEGREES mode for a 1:1-geared servo
+    (encoder full turn = 360 deg). For a physical angle and calibration mid,
+    motors_bus reports (raw - mid) * 360 / max_res == angle_deg - mid_deg, which
+    is exactly what the mid-centered conversion must produce."""
+    emb = _so_arm_map_with_mids()
+    max_res = 4095  # STS3215 12-bit resolution - 1
+    for joint, angle_deg in enumerate([12.0, -47.0, 88.0, -3.0, 61.0]):
+        mid_deg = MIDS[joint]
+        raw = angle_deg * max_res / 360.0
+        mid_ticks = mid_deg * max_res / 360.0
+        motors_bus_degrees = (raw - mid_ticks) * 360.0 / max_res
+        sim_rad = math.radians(angle_deg)
+        ours = emb.sim_state_to_model([sim_rad] * 6)[joint]
+        assert math.isclose(ours, motors_bus_degrees, abs_tol=1e-6), (joint, ours, motors_bus_degrees)
+
+
+def test_empty_joint_mids_preserves_prior_behavior():
+    """Default (no joint_mids) must be the prior absolute-degrees behavior:
+    deg = rad * 180/pi with no offset."""
+    emb = _so_arm_map()  # no joint_mids
+    assert emb.joint_mids == []
+    out = emb.sim_state_to_model([math.pi / 2] * 5 + [0.5])
+    for i in range(5):
+        assert math.isclose(out[i], 90.0, abs_tol=1e-6), out
+
+
+def test_convert_helper_joint_mids_does_not_mutate_input():
+    src = [10.0, 20.0, 30.0]
+    _convert_joint_vector(src, to_model=True, joint_mids=[1.0, 2.0, 3.0])
+    assert src == [10.0, 20.0, 30.0]


### PR DESCRIPTION
## Problem

LeRobot's `MotorNormMode.DEGREES` is **mid-point-centered**: a checkpoint conditions on the angular displacement from each motor's calibration mid-point, not the absolute joint angle. Ground truth in `lerobot/motors/motors_bus.py` (`_normalize` / `_unnormalize`):

```python
mid = (range_min + range_max) / 2          # calibration mid, encoder ticks
degrees = (raw - mid) * 360 / max_res      # reported state / action
```

The sim degrees conversion in `EmbodimentMap` / `PackStateProcessorStep` (`policies/lerobot_local/embodiment.py`) did a plain `rad * 180/pi` with **no mid term**. When the sim `qpos = 0` does not coincide with the calibration mid (the usual case -- the MJCF home pose is not the servo mid), the packed `observation.state` is offset per joint from the training distribution. After LeRobot's `MIN_MAX` state normalization that offset can push the state outside the dataset range -> OOD -> degraded / no-op actions in sim, while the *same* checkpoint works on hardware (there the driver owns the mid-centered conversion via `motors_bus`, so the hardware path -- a pure passthrough -- is already correct).

This is the structural reason a SO-arm checkpoint can look fine on the real arm but degrade in MuJoCo: the conversion was *incapable* of mid-centering, hard-coding `mid = 0`.

## Change

Carry per-joint calibration mid-points (in degrees, aligned to `state_keys` / `action_keys`) into `EmbodimentMap` and `PackStateProcessorStep` via a new `joint_mids` field, threaded through the processor wiring. When set, the degrees conversion subtracts the mid going to the model and adds it back coming from the model, matching `motors_bus` exactly. The gripper column (`gripper_index`) is exempt -- it uses `RANGE_0_100`, which has no mid.

`joint_mids` is **empty by default**, which treats every mid as `0` (sim `qpos = 0` assumed to coincide with the calibration mid). This preserves the prior absolute-degrees behavior, so the change is fully backward compatible -- existing embodiments behave identically until a mid is supplied. The mid values are per-calibration data (like the existing `gripper_joint_range`), populated from the calibration the checkpoint was trained against.

## Parity with `motors_bus`

For a 1:1-geared servo (encoder full turn = 360 deg), the mid-centered conversion reproduces `motors_bus` `DEGREES` mode exactly. Sim pose of 20 deg on every arm joint, with example per-joint calibration mids:

| joint | sim_deg | mid_deg | old (absolute) | new (mid-centered) | motors_bus |
|---|---|---|---|---|---|
| 0 | 20.0 | -8.0 | 20.000 | 28.000 | 28.000 |
| 1 | 20.0 | 12.0 | 20.000 | 8.000 | 8.000 |
| 2 | 20.0 | -30.0 | 20.000 | 50.000 | 50.000 |
| 3 | 20.0 | 5.0 | 20.000 | 15.000 | 15.000 |
| 4 | 20.0 | 18.0 | 20.000 | 2.000 | 2.000 |

The `new` column matches `motors_bus` to 1e-6; `old` is offset by each joint's mid.

## Tests

Added regression tests in `tests/policies/lerobot_local/test_so_arm_units.py` (all fail on pre-fix source -- `EmbodimentMap`/`_convert_joint_vector` have no `joint_mids`):
- mid subtraction (sim -> model emits mid-centered degrees, not absolute);
- sim -> model -> sim round-trip with mids;
- gripper column exempt from its mid entry;
- numeric parity with the `motors_bus` `DEGREES` formula;
- empty `joint_mids` preserves prior absolute-degrees behavior;
- helper does not mutate its input.

`tests/policies/` (1133 passed, 2 skipped) and the lint gate (`ruff check`, `ruff format --check`, `mypy` over `strands_robots tests tests_integ`) are clean.

Docs: added a "Calibration mid-point (`joint_mids`)" section to `docs/policies/molmoact2.md`.

No visual artifact: this is an off-by-default observation/action-space numerical conversion; it produces no rendered behavior change in the default config (empty `joint_mids` is a no-op).