### PR TITLE
test: guard that lerobot import surface resolves symbol-by-symbol

### DIFF
--- a/strands_robots/policies/lerobot_local/molmoact2.py
+++ b/strands_robots/policies/lerobot_local/molmoact2.py
@@ -309,7 +309,7 @@ def build_policy(
     import torch
 
     try:
-        from lerobot.configs import FeatureType, PolicyFeature
+        from lerobot.configs.types import FeatureType, PolicyFeature
     except ImportError as exc:
         raise _factory_import_error(exc) from exc
 

--- a/tests/policies/lerobot_local/test_molmoact2.py
+++ b/tests/policies/lerobot_local/test_molmoact2.py
@@ -416,7 +416,9 @@ class TestBuildPolicy:
         real_import = builtins.__import__
 
         def blocked_import(name, *args, **kwargs):
-            if name == "lerobot.configs":
+            # Block the configs subtree: the actual import target is
+            # lerobot.configs.types since the 0.5.2 migration.
+            if name == "lerobot.configs" or name.startswith("lerobot.configs."):
                 raise ModuleNotFoundError("No module named 'einops'", name="einops")
             return real_import(name, *args, **kwargs)
 
@@ -456,7 +458,9 @@ class TestBuildPolicy:
         def blocked_import(name, *args, **kwargs):
             if name == "lerobot.policies.factory":
                 raise ModuleNotFoundError("No module named 'qwen_vl_utils'", name="qwen_vl_utils")
-            if name == "lerobot.configs":
+            # Stub the configs subtree so the first guard passes and we
+            # isolate the factory guard.
+            if name == "lerobot.configs" or name.startswith("lerobot.configs."):
                 return types.SimpleNamespace(FeatureType=object, PolicyFeature=object)
             return real_import(name, *args, **kwargs)
 

--- a/tests/policies/lerobot_local/test_molmoact2.py
+++ b/tests/policies/lerobot_local/test_molmoact2.py
@@ -378,7 +378,12 @@ class TestBuildPolicy:
         real_import = builtins.__import__
 
         def blocked_import(name, *args, **kwargs):
-            if name == "lerobot.configs":
+            # The first import guard pulls FeatureType/PolicyFeature from the
+            # lerobot.configs package; the concrete submodule moved to
+            # lerobot.configs.types in 0.5.2+. Block the whole configs subtree
+            # so this guard stays pinned to the import target wherever inside
+            # lerobot.configs it lives.
+            if name == "lerobot.configs" or name.startswith("lerobot.configs."):
                 raise ImportError("no configs")
             return real_import(name, *args, **kwargs)
 

--- a/tests/test_lerobot_import_surface.py
+++ b/tests/test_lerobot_import_surface.py
@@ -1,0 +1,109 @@
+"""Regression: every ``lerobot`` symbol ``strands_robots`` imports must resolve.
+
+``strands_robots`` integrates LeRobot through 45 deferred imports (policy
+inference, dataset recording, teleoperation, motor buses). Every one of them is
+lazy: it lives inside a function body, a ``try`` block, or a method, never at
+module top level (so optional-dep absence does not break ``import
+strands_robots``). The flip side is that a plain ``import strands_robots`` -- or
+any test that only imports the package -- exercises NONE of these import
+statements. A LeRobot release that renames or moves a symbol therefore stays
+invisible until the exact code path runs, which for several paths only happens
+on GPU or attached hardware.
+
+This guard closes that gap statically. It parses every module under the
+``strands_robots`` package, collects each ``from lerobot... import NAME`` and
+``import lerobot...`` statement, imports the referenced LeRobot module, and
+asserts the named symbol exists. A renamed/removed LeRobot attribute fails here,
+in the fast unit suite, instead of at runtime in a deferred branch.
+
+The scan is conservative: a LeRobot submodule that cannot be imported in the
+current environment (an optional extra is absent) is skipped rather than failed,
+so the guard never turns an optional-dependency gap into a red test. It only
+asserts on symbols belonging to modules that successfully import.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+from pathlib import Path
+
+import pytest
+
+import strands_robots
+
+pytest.importorskip("lerobot", reason="lerobot not installed - pip install 'strands-robots[lerobot]'")
+
+_PACKAGE_DIR = Path(strands_robots.__file__).resolve().parent
+
+
+def _python_sources() -> list[Path]:
+    return sorted(p for p in _PACKAGE_DIR.rglob("*.py") if "__pycache__" not in p.parts)
+
+
+def _collect_lerobot_imports() -> list[tuple[str, str | None, Path, int]]:
+    """Return ``(module, symbol, file, lineno)`` for every lerobot import.
+
+    ``symbol`` is ``None`` for plain ``import lerobot.foo`` statements (only the
+    module needs to resolve). Star imports are skipped (no single symbol to
+    check).
+    """
+    found: list[tuple[str, str | None, Path, int]] = []
+    for f in _python_sources():
+        try:
+            tree = ast.parse(f.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                if not node.module or not node.module.startswith("lerobot"):
+                    continue
+                for alias in node.names:
+                    if alias.name == "*":
+                        continue
+                    found.append((node.module, alias.name, f, node.lineno))
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name == "lerobot" or alias.name.startswith("lerobot."):
+                        found.append((alias.name, None, f, node.lineno))
+    return found
+
+
+def test_scan_found_lerobot_imports() -> None:
+    """Meta-guard: the scan must actually find lerobot imports.
+
+    If a refactor moves the imports or the AST walk regresses, this catches the
+    guard silently becoming a no-op.
+    """
+    imports = _collect_lerobot_imports()
+    assert len(imports) > 20, f"expected many lerobot imports, found {len(imports)}"
+
+
+def test_imported_lerobot_symbols_resolve() -> None:
+    """Every imported lerobot symbol must exist in the installed lerobot.
+
+    Modules that cannot be imported in this environment (missing optional
+    extra) are skipped; only symbols from importable modules are asserted.
+    """
+    drift: list[str] = []
+    module_cache: dict[str, object | None] = {}
+
+    for module, symbol, f, lineno in _collect_lerobot_imports():
+        if module not in module_cache:
+            try:
+                module_cache[module] = importlib.import_module(module)
+            except Exception:  # noqa: BLE001 - optional extra absent: skip, do not fail
+                module_cache[module] = None
+        mod = module_cache[module]
+        if mod is None:
+            continue
+        if symbol is None:
+            continue  # plain `import lerobot.x` already validated by import_module
+        if not hasattr(mod, symbol):
+            rel = f.relative_to(_PACKAGE_DIR.parent)
+            drift.append(f"  {rel}:{lineno}: `from {module} import {symbol}` - symbol not found")
+
+    assert not drift, (
+        "lerobot API drift: strands_robots imports symbols that no longer exist in the "
+        f"installed lerobot ({len(drift)} broken):\n" + "\n".join(drift)
+    )


### PR DESCRIPTION
## Problem

`strands_robots` integrates LeRobot through 45 `from lerobot... import ...` statements, every one of them lazy - inside a function body, a `try` block, or a method, never at module top level (a deliberate design so a missing optional extra never breaks `import strands_robots`).

The side effect: a plain `import strands_robots`, or any test that only imports the package, exercises none of these import statements. So when a LeRobot release renames or moves a symbol, the break is invisible to the unit suite and only surfaces when the exact deferred branch runs at runtime - which for several paths (policy inference, motor buses, dataset recording) only happens on GPU or with hardware attached.

## Change

Add `tests/test_lerobot_import_surface.py`, a static drift guard that:

- parses every module under the `strands_robots` package,
- collects each `from lerobot... import NAME` and `import lerobot...` statement,
- imports the referenced LeRobot module, and
- asserts the named symbol exists (`hasattr`).

A renamed/removed LeRobot attribute now fails in the fast unit suite with the offending `file:line` and import statement, instead of crashing at runtime in a deferred branch.

The scan is conservative by design:
- A LeRobot submodule that cannot be imported in the current environment (optional extra absent) is skipped, not failed - the guard never turns an optional-dependency gap into a red test. Only symbols from modules that successfully import are asserted.
- A meta-test (`test_scan_found_lerobot_imports`) asserts the scan still finds imports, so a future refactor cannot silently turn the guard into a no-op.

## Drift this guard already caught

The guard immediately flagged a real, latent break: `strands_robots/policies/lerobot_local/molmoact2.py` imported `FeatureType` and `PolicyFeature` from `lerobot.configs`. Those names are only re-exported from the `lerobot.configs` package `__init__` in lerobot 0.5.2+; on the pinned `lerobot>=0.5.0,<0.6.0` floor (0.5.1) they live solely in `lerobot.configs.types`, so the deferred import raised `ImportError` the moment a MolmoAct2 policy was constructed.

Fix included in this PR: import from `lerobot.configs.types`, the module that actually defines both symbols (`FeatureType.__module__ == PolicyFeature.__module__ == 'lerobot.configs.types'`) and has done so across 0.5.1, 0.5.2, and main. The guard turns red on the old import line against lerobot 0.5.1 and green after the fix.

## Validation

- `test_imported_lerobot_symbols_resolve` and `test_scan_found_lerobot_imports` pass.
- Teeth confirmed: the guard fails with a precise `file:line - symbol not found` message on the pre-fix `molmoact2.py` import against lerobot 0.5.1, and passes after the fix.
- Gate clean: `ruff check`, `ruff format --check`, and `mypy strands_robots tests tests_integ` all pass (no issues in 493 source files).

## §13 — Review Round Table

| Round | Concern | Fix commit | Pin test |
|-------|---------|------------|----------|
| R2 | `test_missing_lerobot_configs_raises_install_hint` blocked wrong module name after import move | `04328ae` | `tests/policies/lerobot_local/test_molmoact2.py::TestBuildPolicy::test_missing_lerobot_configs_raises_install_hint` |
| R3 | `test_transitive_dep_failure_*` stubs blocked `lerobot.configs` but actual import is now `lerobot.configs.types` — CI FAILURE | `4a8d5b8` | `tests/policies/lerobot_local/test_molmoact2.py::TestBuildPolicy::test_transitive_dep_failure_names_real_dep_not_lerobot` |

## Changelog

### Round 2 - fix CI regression from the molmoact2 import move

The `lerobot.configs.types` import move (the drift fix above) broke a pinned regression test: `tests/policies/lerobot_local/test_molmoact2.py::TestBuildPolicy::test_missing_lerobot_configs_raises_install_hint`. That test blocks the `lerobot.configs` import to assert `build_policy` raises the `MolmoAct2 requires lerobot` install hint from its first import guard. It matched the import name with an exact-string check `name == "lerobot.configs"`, so once the guard imported `lerobot.configs.types` the block no longer fired - execution fell through to `make_policy_config`, which raised `ValueError: Policy type 'molmoact2' is not available` instead of the expected `ImportError`.

Fix: block the whole `lerobot.configs` subtree (`name == "lerobot.configs" or name.startswith("lerobot.configs.")`) so the test stays pinned to the first import guard's target wherever inside the configs package the line lives, and does not over-block unrelated lerobot modules.

### Round 3 - align remaining transitive-dep tests with the configs.types migration

The Round 2 fix addressed `test_missing_lerobot_configs_raises_install_hint` but missed two sibling tests (`test_transitive_dep_failure_names_real_dep_not_lerobot` and `test_transitive_dep_failure_in_factory_import_names_real_dep`) that had the same stale `name == "lerobot.configs"` block. These failed identically: the stub did not match the new `lerobot.configs.types` import, so `build_policy` passed through the configs guard and hit a later `ValueError` instead of the expected `ImportError`.

Fix: apply the same `name.startswith("lerobot.configs.")` predicate to both remaining tests, consistent with the Round 2 pattern.