### PR TITLE
test(lerobot_local): keep FeatureNormalizer tests off the lerobot pipeline gate

### DIFF
--- a/tests/policies/lerobot_local/test_norm_stats_fallback.py
+++ b/tests/policies/lerobot_local/test_norm_stats_fallback.py
@@ -26,6 +26,31 @@ import pytest
 
 from strands_robots.policies.lerobot_local import norm_stats as ns
 
+
+def _lerobot_pipeline_importable() -> bool:
+    """Return True if LeRobot's real processor pipeline can be imported.
+
+    Used to gate only the tests that build real LeRobot ``ProcessorStep`` /
+    ``DataProcessorPipeline`` objects. The pure-numpy ``FeatureNormalizer``
+    tests below must NOT depend on this: the normalizer math is the single
+    most safety-critical path (un-normalized actions reach the motors), so it
+    has to stay covered even on installs without the optional processor
+    framework. The import can fail with ImportError (framework absent) or, on
+    some torch/coverage ABI combinations, AttributeError while resolving the
+    lazy ``torch`` surface -- both mean "pipeline unavailable here".
+    """
+    try:
+        import lerobot.processor.pipeline  # noqa: F401
+    except (ImportError, AttributeError):
+        return False
+    return True
+
+
+_requires_lerobot_pipeline = pytest.mark.skipif(
+    not _lerobot_pipeline_importable(),
+    reason="requires LeRobot's processor pipeline (real ProcessorStep framework)",
+)
+
 FIXTURE = Path(__file__).parent / "fixtures" / "molmoact2_norm_stats.json"
 
 
@@ -169,10 +194,7 @@ class TestLoadNormStats:
         assert ns.load_norm_stats("") is None
 
 
-# Tests below need LeRobot's processor framework (real pipeline steps).
-pytest.importorskip("lerobot.processor.pipeline")
-
-
+@_requires_lerobot_pipeline
 class TestBuildProcessors:
     """build_norm_stats_processors against the real LeRobot pipeline."""
 
@@ -212,6 +234,7 @@ class TestBuildProcessors:
         assert ns.build_norm_stats_processors(payload) == (None, None)
 
 
+@_requires_lerobot_pipeline
 class TestProcessorBridgeFallback:
     """ProcessorBridge.from_pretrained wires the norm_stats fallback.
 
@@ -259,6 +282,7 @@ class TestProcessorBridgeFallback:
         assert migration_error in _missing_config_errors()
 
 
+@_requires_lerobot_pipeline
 class TestUpstreamLerobotParity:
     """Bit-equality audit vs the real upstream lerobot normalizer.
 
@@ -520,6 +544,7 @@ class TestSelectTagMalformedMetadata:
         assert ns.select_norm_tag({}) is None
 
 
+@_requires_lerobot_pipeline
 class TestProcessorStepEdgeCases:
     """Pre/post ProcessorStep helpers: identity transform_features + None action."""
 


### PR DESCRIPTION
## Problem

`tests/policies/lerobot_local/test_norm_stats_fallback.py` gated every class after a module-level `pytest.importorskip("lerobot.processor.pipeline")`. Four of those classes test only the pure-numpy `FeatureNormalizer` and never touch LeRobot's processor framework:

- `TestContainerTypePreservation` - torch-tensor in/out container + dtype/device preservation (incl. bfloat16/float16 coercion)
- `TestNoneMode` - explicit `none` identity transform
- `TestMaskAndZeroMask` - per-feature mask + degenerate `min==max` handling
- `TestMinMaxUnnormalize` - exact normalize/unnormalize inverse

Because the gate is at module scope, an install **without** the optional processor framework fails to import the module entirely, so the whole file fails to collect and the normalizer math loses all test coverage. That math is the most safety-critical path in this module: an un-normalized observation or an un-unnormalized action reaches the motors directly (the documented "single biggest cause of off-policy arm motion").

## Change

Replace the blanket module-level `importorskip` with a class-level `pytest.mark.skipif` applied only to the classes that build real `ProcessorStep` / `DataProcessorPipeline` objects:

- `TestBuildProcessors`
- `TestProcessorBridgeFallback`
- `TestUpstreamLerobotParity`
- `TestProcessorStepEdgeCases`

The gating helper catches both `ImportError` (framework absent) and the `AttributeError` that some torch/coverage ABI combinations raise while resolving the lazy `torch` surface during the pipeline import - both mean "pipeline unavailable here".

## Verification

Simulating the processor framework being unimportable (a meta-path finder that blocks `lerobot.processor.pipeline`):

- **Before:** `1 error during collection` - the entire module is uncollectable, every test (including all FeatureNormalizer math) is lost.
- **After:** `40 passed, 13 skipped` - all pure-numpy normalizer tests run; only the genuinely pipeline-dependent tests skip cleanly.

With the framework available (normal install), behaviour is unchanged: `53 passed`. Full `tests/policies/lerobot_local/` suite: `357 passed`. `ruff check`, `ruff format --check`, and `mypy strands_robots tests tests_integ` all clean.

Test-only change; no library behaviour is modified.