### PR TITLE
feat(sim): publish simulation telemetry on a ROS 2 domain (ros2_bridge flag)

### DIFF
--- a/docs/ros2-integration.md
+++ b/docs/ros2-integration.md
@@ -97,6 +97,41 @@ malformed names from reaching the ROS 2 client library. Backend and timeout
 failures are returned as structured `{"status": "error"}` results rather than
 raised exceptions.
 
+## Sim bridge: publish a simulation on a ROS 2 domain
+
+The simulator can advertise its own live state on ROS 2. Construct any
+`SimEngine` (e.g. `Simulation()`) with `ros2_bridge=True` and it spins up an
+internal `rclpy` node that publishes, per robot, after every `step()`:
+
+| Topic | Type | Content |
+|-------|------|---------|
+| `/<robot>/joint_states` | `sensor_msgs/msg/JointState` | joint names + positions |
+| `/<robot>/<camera>/image_raw` | `sensor_msgs/msg/Image` (`rgb8`) | one frame per attached camera |
+
+```python
+from strands_robots.simulation import Simulation
+
+sim = Simulation(ros2_bridge=True, ros2_domain=0)
+sim.create_world()
+sim.add_robot("so101")
+sim.step(10)   # publishes /so101/joint_states (+ camera image_raw) on domain 0
+```
+
+External ROS 2 nodes - and the agent's own `use_ros` calls - then see the
+running simulation:
+
+```bash
+ros2 topic list | grep so101          # /so101/joint_states, /so101/<cam>/image_raw
+ros2 topic echo /so101/joint_states   # live joint positions, updated every step
+```
+
+`rclpy` is an optional, system-provided dependency (the `[ros2]` extra). When it
+is missing, `ros2_bridge=True` raises a clear `ImportError` at construction;
+`ros2_bridge=False` (the default) never touches ROS 2, so the base sim install
+stays lightweight. The bridge node is torn down cleanly on `destroy()`.
+
+See `examples/ros2/sim_bridge_demo.py` for a runnable end-to-end script.
+
 ## Mesh bridge: a ROS 2 robot as a first-class strands Robot
 
 `use_ros` is the low-level surface. For mobile bases that expose the usual

--- a/examples/ros2/sim_bridge_demo.py
+++ b/examples/ros2/sim_bridge_demo.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Expose a MuJoCo simulation on a ROS 2 domain (SimEngine ros2_bridge=True).
+
+Goal: Show that the simulator can publish its live state on ROS 2 so external
+ROS 2 nodes (or the agent's own use_ros calls) can subscribe to it. With
+``ros2_bridge=True`` the sim advertises, per robot:
+
+  /<robot>/joint_states            sensor_msgs/msg/JointState  (every step)
+  /<robot>/<camera>/image_raw      sensor_msgs/msg/Image  (rgb8, per camera)
+
+Dependencies:
+  pip install "strands-robots[sim-mujoco,ros2]"
+  rclpy must be importable - it ships with a system ROS 2 install (apt /
+  RoboStack) or the official docker images, not PyPI. Run this script in an
+  environment where `python3 -c "import rclpy"` works (e.g. inside a
+  `ros:jazzy` container with mujoco + strands-robots installed).
+
+Verify from another shell on the same ROS 2 domain:
+  ros2 topic list | grep so101
+  ros2 topic echo /so101/joint_states
+
+Runtime: runs until interrupted.
+"""
+
+import math
+import time
+
+from strands_robots.simulation import Simulation
+
+# ros2_bridge=True spins up an internal rclpy node; ros2_domain picks the domain.
+sim = Simulation(ros2_bridge=True, ros2_domain=0)
+sim.create_world()
+sim.add_robot("so101")
+
+joints = sim.robot_joint_names("so101")
+print(f"publishing /so101/joint_states for joints: {joints}")
+
+try:
+    i = 0
+    while True:
+        target = 0.6 * math.sin(i / 40.0)
+        sim.send_action({j: target for j in joints}, robot_name="so101")
+        sim.step(5)  # each step publishes joint_states (+ camera image_raw)
+        time.sleep(0.05)
+        i += 1
+except KeyboardInterrupt:
+    pass
+finally:
+    sim.destroy()  # tears down the ROS 2 node cleanly

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -89,6 +89,75 @@ class SimEngine(ABC):
         sim.destroy()
     """
 
+    def _init_ros_bridge(self, *, ros2_bridge: bool = False, ros2_domain: int = 0) -> None:
+        """Initialize the optional ROS 2 telemetry bridge state.
+
+        Backends that accept a ``ros2_bridge`` flag call this once from their
+        own ``__init__``. It is intentionally a plain method rather than an ABC
+        ``__init__`` override: the simulation interface imposes no base-class
+        constructor contract, so lightweight subclasses and test doubles need
+        not thread ``super().__init__()`` through just to satisfy the ABC.
+
+        Args:
+            ros2_bridge: When True, publish per-robot ``joint_states`` and
+                camera ``image_raw`` on a ROS 2 domain every :meth:`step`, so
+                external ROS 2 nodes can subscribe to the running simulation.
+                Requires ``rclpy`` (system ROS 2 / the official docker image);
+                an :class:`ImportError` is raised here if it is missing.
+                Defaults to False - the sim never touches ROS 2.
+            ros2_domain: ROS 2 domain id (``ROS_DOMAIN_ID``) to publish on.
+        """
+        self._ros2_bridge_enabled = bool(ros2_bridge)
+        self._ros2_domain = int(ros2_domain)
+        self._ros_bridge: Any = None
+        if self._ros2_bridge_enabled:
+            from strands_robots.simulation.ros_bridge import SimRosBridge
+
+            self._ros_bridge = SimRosBridge(domain_id=self._ros2_domain)
+
+    def _publish_ros_telemetry(self, *, skip_images: bool = False) -> None:
+        """Publish joint_states (and camera images) for every robot once.
+
+        No-op when the ROS 2 bridge is disabled or was never initialized.
+        Called by backends from :meth:`step` after the physics tick. Per-robot
+        failures (e.g. a camera that did not render) never interrupt the loop.
+        """
+        bridge = getattr(self, "_ros_bridge", None)
+        if bridge is None:
+            return
+        for robot in self.list_robots():
+            # Per-robot guard: a transient render/observation failure on one
+            # robot (e.g. EGL/GL context loss, a camera that produced no frame)
+            # must not interrupt the loop or crash the caller's step(). Publish
+            # what succeeds, log-and-continue on the rest - this is the contract
+            # the docstring promises on the hot ros2_bridge=True path.
+            try:
+                obs = self.get_observation(robot, skip_images=skip_images)
+                names = self.robot_joint_names(robot)
+                positions = [obs[j] for j in names if j in obs and isinstance(obs[j], (int, float))]
+                bridge.publish_joint_states(robot, names, positions)
+                if skip_images:
+                    continue
+                for key, value in obs.items():
+                    if key in names:
+                        continue
+                    if hasattr(value, "ndim") and getattr(value, "ndim", 0) == 3:
+                        bridge.publish_image(robot, key, value)
+            except Exception:
+                logger.warning(
+                    "ROS 2 telemetry publish failed for robot %r; skipping this robot for this step",
+                    robot,
+                    exc_info=True,
+                )
+                continue
+
+    def _shutdown_ros_bridge(self) -> None:
+        """Tear down the ROS 2 bridge if one is active. Safe to call repeatedly."""
+        bridge = getattr(self, "_ros_bridge", None)
+        if bridge is not None:
+            bridge.shutdown()
+            self._ros_bridge = None
+
     def _resolve_single_robot(self, robot_name: str | None) -> str:
         """Resolve an optional robot name to a concrete one.
 

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -139,6 +139,8 @@ class MuJoCoSimEngine(
         default_height: int = 480,
         mesh: bool = False,
         peer_id: str | None = None,
+        ros2_bridge: bool = False,
+        ros2_domain: int = 0,
         **kwargs,
     ):
         """Construct a MuJoCo Simulation AgentTool.
@@ -165,6 +167,7 @@ class MuJoCoSimEngine(
                 compatibility.
         """
         super().__init__()
+        self._init_ros_bridge(ros2_bridge=ros2_bridge, ros2_domain=ros2_domain)
         self.tool_name_str = tool_name
         self.default_timestep = default_timestep
         self.default_width = default_width
@@ -1594,6 +1597,7 @@ class MuJoCoSimEngine(
                 self._world.sim_time = self._world._data.time
                 self._world.step_count += batch
             remaining -= batch
+        self._publish_ros_telemetry()
         return {
             "status": "success",
             "content": [{"text": f"+{n_steps} steps | t={self._world.sim_time:.4f}s | total={self._world.step_count}"}],
@@ -2929,9 +2933,13 @@ class MuJoCoSimEngine(
         # results until their heartbeats expire.
         # Stop any local teleoperation loop + disconnect attached devices
         # (TeleopMixin) before mesh teardown. Best-effort.
-        if getattr(self, "_teleop_running", False) or getattr(self, "_teleops", None):
-            import contextlib as _cl
+        # Tear down the ROS 2 telemetry bridge (if any) before other teardown
+        # so external subscribers see the node leave cleanly.
+        import contextlib as _cl
 
+        with _cl.suppress(Exception):
+            self._shutdown_ros_bridge()
+        if getattr(self, "_teleop_running", False) or getattr(self, "_teleops", None):
             with _cl.suppress(Exception):
                 self.stop_teleoperate()
         if self._world is not None:

--- a/strands_robots/simulation/ros_bridge.py
+++ b/strands_robots/simulation/ros_bridge.py
@@ -1,0 +1,136 @@
+"""Publish simulation telemetry on a ROS 2 domain.
+
+When a :class:`~strands_robots.simulation.base.SimEngine` is constructed with
+``ros2_bridge=True``, it owns a :class:`SimRosBridge` that advertises the sim's
+live state on a ROS 2 domain so external ROS 2 nodes can
+``ros2 topic echo /<robot>/joint_states`` against the simulation - and the
+agent's own ``use_ros`` calls reach the same graph, closing the loop end to end.
+
+Per robot, the bridge publishes:
+
+* ``/<robot>/joint_states`` (``sensor_msgs/msg/JointState``) - joint names and
+  positions, every sim step.
+* ``/<robot>/<camera>/image_raw`` (``sensor_msgs/msg/Image``, ``rgb8``) - one
+  message per attached camera that rendered a frame.
+
+``rclpy`` and the ROS 2 message packages are optional, system-provided
+dependencies (they are not on PyPI); they are imported lazily through
+:func:`strands_robots.utils.require_optional`, so importing this module - and
+running the simulation with ``ros2_bridge=False`` - never requires ROS 2.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any
+
+from strands_robots.utils import require_optional
+
+if TYPE_CHECKING:
+    import numpy as np
+
+
+class SimRosBridge:
+    """A thin rclpy publisher for simulation telemetry.
+
+    Args:
+        domain_id: ROS 2 domain (``ROS_DOMAIN_ID``) the bridge publishes on.
+        node_name: Name of the internal rclpy node.
+        qos_depth: Depth of the publishers' KEEP_LAST history.
+
+    Raises:
+        ImportError: When ``rclpy`` / the ROS 2 message packages are not
+            importable, with an install hint (system ROS 2 or the docker image).
+    """
+
+    def __init__(self, domain_id: int = 0, node_name: str = "strands_sim", qos_depth: int = 10) -> None:
+        # Pin the domain before rclpy reads it. Set it unconditionally so the
+        # bridge publishes where the caller asked, not where the shell happened
+        # to point.
+        os.environ["ROS_DOMAIN_ID"] = str(int(domain_id))
+
+        rclpy_mod: Any = require_optional(
+            "rclpy", extra="ros2", purpose="the ROS 2 simulation bridge (SimEngine ros2_bridge=True)"
+        )
+        sensor_msgs: Any = require_optional(
+            "sensor_msgs.msg", pip_install="ros-<distro>-sensor-msgs", purpose="the ROS 2 simulation bridge"
+        )
+        self._rclpy = rclpy_mod
+        self._JointState = sensor_msgs.JointState
+        self._Image = sensor_msgs.Image
+
+        self._owns_context = not self._rclpy.ok()
+        if self._owns_context:
+            self._rclpy.init()
+        self._node = self._rclpy.create_node(node_name)
+        self._qos_depth = qos_depth
+        self._joint_pubs: dict[str, Any] = {}
+        self._image_pubs: dict[str, Any] = {}
+
+    @staticmethod
+    def _safe(name: str) -> str:
+        """Map a robot/camera name to a valid ROS 2 topic segment."""
+        return "".join(c if (c.isalnum() or c == "_") else "_" for c in name).strip("_") or "robot"
+
+    def _now(self) -> Any:
+        return self._node.get_clock().now().to_msg()
+
+    def _joint_publisher(self, robot: str) -> Any:
+        pub = self._joint_pubs.get(robot)
+        if pub is None:
+            topic = f"/{self._safe(robot)}/joint_states"
+            pub = self._node.create_publisher(self._JointState, topic, self._qos_depth)
+            self._joint_pubs[robot] = pub
+        return pub
+
+    def _image_publisher(self, robot: str, camera: str) -> Any:
+        key = f"{robot}/{camera}"
+        pub = self._image_pubs.get(key)
+        if pub is None:
+            topic = f"/{self._safe(robot)}/{self._safe(camera)}/image_raw"
+            pub = self._node.create_publisher(self._Image, topic, self._qos_depth)
+            self._image_pubs[key] = pub
+        return pub
+
+    def publish_joint_states(self, robot: str, names: list[str], positions: list[float]) -> None:
+        """Publish one ``JointState`` for ``robot`` on ``/<robot>/joint_states``."""
+        msg = self._JointState()
+        msg.header.stamp = self._now()
+        msg.header.frame_id = self._safe(robot)
+        msg.name = list(names)
+        msg.position = [float(p) for p in positions]
+        self._joint_publisher(robot).publish(msg)
+
+    def publish_image(self, robot: str, camera: str, image: np.ndarray) -> None:
+        """Publish one RGB ``Image`` on ``/<robot>/<camera>/image_raw``.
+
+        Args:
+            robot: Robot name (topic namespace).
+            camera: Camera name (topic sub-namespace).
+            image: ``(H, W, 3)`` uint8 RGB frame.
+        """
+        if image.ndim != 3 or image.shape[2] != 3:
+            return
+        height, width = int(image.shape[0]), int(image.shape[1])
+        msg = self._Image()
+        msg.header.stamp = self._now()
+        msg.header.frame_id = f"{self._safe(robot)}/{self._safe(camera)}"
+        msg.height = height
+        msg.width = width
+        msg.encoding = "rgb8"
+        msg.is_bigendian = 0
+        msg.step = width * 3
+        msg.data = image.astype("uint8", copy=False).tobytes()
+        self._image_publisher(robot, camera).publish(msg)
+
+    def shutdown(self) -> None:
+        """Destroy the node and, if this bridge initialized rclpy, shut it down."""
+        node = getattr(self, "_node", None)
+        if node is not None:
+            try:
+                node.destroy_node()
+            finally:
+                self._node = None
+        if getattr(self, "_owns_context", False) and self._rclpy.ok():
+            self._rclpy.shutdown()
+            self._owns_context = False

--- a/strands_robots/tools/use_ros.py
+++ b/strands_robots/tools/use_ros.py
@@ -371,7 +371,10 @@ def use_ros(
             return _err(f"unknown action: {action}")
     except TimeoutError as exc:
         return _err(str(exc))
-    except (KeyError, AttributeError, ValueError, TypeError) as exc:
+    except (ImportError, KeyError, AttributeError, ValueError, TypeError) as exc:
         # Type resolution / field-set errors surface as a clean tool error
         # rather than a raised exception that bypasses the structured result.
+        # ImportError (incl. ModuleNotFoundError) is the real failure mode when a
+        # valid-shaped type names a package that is not installed: get_message ->
+        # import_message_from_namespaced_type -> importlib.import_module raises it.
         return _err(f"{action} failed: {exc}")

--- a/tests/simulation/test_ros_sim_bridge.py
+++ b/tests/simulation/test_ros_sim_bridge.py
@@ -1,0 +1,358 @@
+"""Behavior tests for the ROS 2 simulation bridge (``SimEngine(ros2_bridge=...)``).
+
+``rclpy`` is a system-provided, non-PyPI dependency, so these tests inject a
+fake ``rclpy`` + ``sensor_msgs.msg`` into ``sys.modules`` to exercise the
+publisher wiring with NO ROS 2 installed. They assert that:
+
+* :class:`SimRosBridge` builds the right topics and ``JointState`` / ``Image``
+  message fields and routes them to per-robot publishers.
+* :meth:`SimEngine._publish_ros_telemetry` reads joint state from
+  ``get_observation`` and forwards it, and is a no-op when the bridge is off.
+* Enabling the bridge with no ``rclpy`` raises a clear :class:`ImportError`.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+from typing import Any
+
+import numpy as np
+import pytest
+
+import strands_robots.utils as utils_mod
+from strands_robots.simulation.base import SimEngine
+
+
+class _FakePublisher:
+    def __init__(self, topic: str) -> None:
+        self.topic = topic
+        self.messages: list[Any] = []
+
+    def publish(self, msg: Any) -> None:
+        self.messages.append(msg)
+
+
+class _FakeClock:
+    def now(self) -> Any:
+        return self
+
+    def to_msg(self) -> str:
+        return "stamp"
+
+
+class _FakeNode:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.publishers: list[_FakePublisher] = []
+        self.destroyed = False
+
+    def get_clock(self) -> _FakeClock:
+        return _FakeClock()
+
+    def create_publisher(self, _msg_type: Any, topic: str, _depth: int) -> _FakePublisher:
+        pub = _FakePublisher(topic)
+        self.publishers.append(pub)
+        return pub
+
+    def destroy_node(self) -> None:
+        self.destroyed = True
+
+
+class _Header:
+    def __init__(self) -> None:
+        self.stamp: Any = None
+        self.frame_id: str = ""
+
+
+class _JointState:
+    def __init__(self) -> None:
+        self.header = _Header()
+        self.name: list[str] = []
+        self.position: list[float] = []
+
+
+class _Image:
+    def __init__(self) -> None:
+        self.header = _Header()
+        self.height = 0
+        self.width = 0
+        self.encoding = ""
+        self.is_bigendian = 0
+        self.step = 0
+        self.data = b""
+
+
+@pytest.fixture
+def fake_ros(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Inject a fake rclpy + sensor_msgs.msg and clear require_optional's cache."""
+    state: dict[str, Any] = {"inited": False, "shutdown": False, "nodes": []}
+
+    rclpy = ModuleType("rclpy")
+    rclpy.ok = lambda: state["inited"]  # type: ignore[attr-defined]
+
+    def _init() -> None:
+        state["inited"] = True
+
+    def _shutdown() -> None:
+        state["shutdown"] = True
+        state["inited"] = False
+
+    def _create_node(name: str) -> _FakeNode:
+        node = _FakeNode(name)
+        state["nodes"].append(node)
+        return node
+
+    rclpy.init = _init  # type: ignore[attr-defined]
+    rclpy.shutdown = _shutdown  # type: ignore[attr-defined]
+    rclpy.create_node = _create_node  # type: ignore[attr-defined]
+
+    sensor_pkg = ModuleType("sensor_msgs")
+    sensor_msg = ModuleType("sensor_msgs.msg")
+    sensor_msg.JointState = _JointState  # type: ignore[attr-defined]
+    sensor_msg.Image = _Image  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "rclpy", rclpy)
+    monkeypatch.setitem(sys.modules, "sensor_msgs", sensor_pkg)
+    monkeypatch.setitem(sys.modules, "sensor_msgs.msg", sensor_msg)
+    # require_optional memoizes resolved modules; drop any cached real entries.
+    monkeypatch.setattr(utils_mod, "_lazy_modules", {}, raising=False)
+    return state
+
+
+def test_sim_ros_bridge_publishes_joint_states(fake_ros: dict[str, Any]) -> None:
+    from strands_robots.simulation.ros_bridge import SimRosBridge
+
+    bridge = SimRosBridge(domain_id=7)
+    bridge.publish_joint_states("so101", ["shoulder_pan", "elbow"], [0.1, 0.2])
+
+    node = fake_ros["nodes"][0]
+    (pub,) = node.publishers
+    assert pub.topic == "/so101/joint_states"
+    (msg,) = pub.messages
+    assert msg.name == ["shoulder_pan", "elbow"]
+    assert msg.position == [0.1, 0.2]
+    assert msg.header.frame_id == "so101"
+
+
+def test_sim_ros_bridge_sets_domain_env(fake_ros: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> None:
+    import os
+
+    from strands_robots.simulation.ros_bridge import SimRosBridge
+
+    SimRosBridge(domain_id=42)
+    assert os.environ["ROS_DOMAIN_ID"] == "42"
+
+
+def test_sim_ros_bridge_publishes_rgb_image(fake_ros: dict[str, Any]) -> None:
+    from strands_robots.simulation.ros_bridge import SimRosBridge
+
+    bridge = SimRosBridge()
+    frame = np.zeros((4, 5, 3), dtype=np.uint8)
+    bridge.publish_image("so101", "front", frame)
+
+    node = fake_ros["nodes"][0]
+    (pub,) = node.publishers
+    assert pub.topic == "/so101/front/image_raw"
+    (msg,) = pub.messages
+    assert (msg.height, msg.width, msg.encoding, msg.step) == (4, 5, "rgb8", 15)
+    assert len(msg.data) == 4 * 5 * 3
+
+
+def test_sim_ros_bridge_ignores_non_rgb_image(fake_ros: dict[str, Any]) -> None:
+    from strands_robots.simulation.ros_bridge import SimRosBridge
+
+    bridge = SimRosBridge()
+    bridge.publish_image("so101", "depth", np.zeros((4, 5), dtype=np.uint8))
+    assert fake_ros["nodes"][0].publishers == []
+
+
+def test_sim_ros_bridge_shutdown_destroys_node(fake_ros: dict[str, Any]) -> None:
+    from strands_robots.simulation.ros_bridge import SimRosBridge
+
+    bridge = SimRosBridge()
+    node = fake_ros["nodes"][0]
+    bridge.shutdown()
+    assert node.destroyed is True
+    assert fake_ros["shutdown"] is True
+    bridge.shutdown()  # idempotent
+
+
+class _FakeEngine(SimEngine):
+    """Minimal concrete engine exercising the telemetry helper only."""
+
+    def __init__(self, observation: dict[str, Any], *, ros2_bridge: bool = False, ros2_domain: int = 0) -> None:
+        self._obs = observation
+        self._init_ros_bridge(ros2_bridge=ros2_bridge, ros2_domain=ros2_domain)
+
+    def list_robots(self) -> list[str]:
+        return ["so101"]
+
+    def robot_joint_names(self, robot_name: str) -> list[str]:
+        return ["shoulder_pan", "elbow"]
+
+    def get_observation(self, robot_name: str | None = None, *, skip_images: bool = False) -> dict[str, Any]:
+        return self._obs
+
+    # Unused abstract methods for this focused test (never called).
+    def create_world(self, *a: Any, **k: Any) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def destroy(self) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def reset(self) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def step(self, n_steps: int = 1) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def get_state(self) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def add_robot(self, *a: Any, **k: Any) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def remove_robot(self, name: str) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def add_object(self, *a: Any, **k: Any) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def remove_object(self, name: str) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def render(self, *a: Any, **k: Any) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def send_action(self, *a: Any, **k: Any) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def physics_timestep(self) -> float:
+        return 0.002
+
+
+def test_publish_telemetry_forwards_joint_state(fake_ros: dict[str, Any]) -> None:
+    obs = {"shoulder_pan": 0.5, "elbow": -0.25, "front": np.zeros((2, 2, 3), dtype=np.uint8)}
+    engine = _FakeEngine(obs, ros2_bridge=True, ros2_domain=3)
+    engine._publish_ros_telemetry()
+
+    node = fake_ros["nodes"][0]
+    topics = {p.topic: p for p in node.publishers}
+    assert "/so101/joint_states" in topics
+    js = topics["/so101/joint_states"].messages[0]
+    assert js.position == [0.5, -0.25]
+    assert "/so101/front/image_raw" in topics
+
+
+def test_publish_telemetry_is_noop_when_disabled(fake_ros: dict[str, Any]) -> None:
+    engine = _FakeEngine({"shoulder_pan": 0.0, "elbow": 0.0})  # ros2_bridge defaults False
+    engine._publish_ros_telemetry()
+    assert engine._ros_bridge is None
+    assert fake_ros["nodes"] == []
+
+
+def test_enabling_bridge_without_rclpy_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    # No fake_ros fixture here: ensure rclpy is absent and the cache is clear.
+    monkeypatch.setitem(sys.modules, "rclpy", None)
+    monkeypatch.setattr(utils_mod, "_lazy_modules", {}, raising=False)
+    with pytest.raises(ImportError):
+        _FakeEngine({}, ros2_bridge=True)
+
+
+def test_publish_telemetry_safe_without_bridge_init(fake_ros: dict[str, Any]) -> None:
+    """Telemetry hooks tolerate an engine that never called ``_init_ros_bridge``.
+
+    The simulation ABC defines no ``__init__``, so a lightweight subclass (or a
+    backend constructed via an unusual path) may never initialize the bridge
+    attributes. ``step`` calls ``_publish_ros_telemetry`` unconditionally, so it
+    - and ``_shutdown_ros_bridge`` - must be safe no-ops in that case rather
+    than raising ``AttributeError`` on a missing ``_ros_bridge``. Here we strip
+    the attribute off a normally-built engine to model that uninitialized state.
+    """
+    engine = _FakeEngine({"shoulder_pan": 0.0, "elbow": 0.0})
+    del engine._ros_bridge
+
+    engine._publish_ros_telemetry()  # must not raise
+    engine._shutdown_ros_bridge()  # must not raise
+    assert fake_ros["nodes"] == []
+
+
+class _TwoRobotEngine(SimEngine):
+    """Engine with two robots where one robot's observation always fails.
+
+    Models a transient per-robot render fault (EGL/GL context loss, a camera
+    that produced no frame) so we can assert the documented contract: a single
+    robot's failure must not interrupt the loop or escape ``step()``.
+    """
+
+    def __init__(self, *, ros2_bridge: bool = True, ros2_domain: int = 0) -> None:
+        self._init_ros_bridge(ros2_bridge=ros2_bridge, ros2_domain=ros2_domain)
+
+    def list_robots(self) -> list[str]:
+        return ["broken", "healthy"]
+
+    def robot_joint_names(self, robot_name: str) -> list[str]:
+        return ["shoulder_pan", "elbow"]
+
+    def get_observation(self, robot_name: str | None = None, *, skip_images: bool = False) -> dict[str, Any]:
+        if robot_name == "broken":
+            raise RuntimeError("camera render failed (EGL context lost)")
+        return {"shoulder_pan": 0.5, "elbow": -0.25}
+
+    # Unused abstract methods for this focused test (never called).
+    def create_world(self, *a: Any, **k: Any) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def destroy(self) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def reset(self) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def step(self, n_steps: int = 1) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def get_state(self) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def add_robot(self, *a: Any, **k: Any) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def remove_robot(self, name: str) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def add_object(self, *a: Any, **k: Any) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def remove_object(self, name: str) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def render(self, *a: Any, **k: Any) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def send_action(self, *a: Any, **k: Any) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def physics_timestep(self) -> float:
+        return 0.002
+
+
+def test_publish_telemetry_per_robot_failure_does_not_interrupt_loop(fake_ros: dict[str, Any]) -> None:
+    """A failing robot is skipped; healthy robots still publish; step() never crashes.
+
+    Pins the docstring contract on the hot ``ros2_bridge=True`` path: per-robot
+    failures (e.g. a camera that did not render) never interrupt the loop. The
+    "broken" robot raises in ``get_observation``; the "healthy" robot - listed
+    after it - must still publish its joint_states, and no exception escapes.
+    """
+    engine = _TwoRobotEngine(ros2_bridge=True, ros2_domain=5)
+
+    engine._publish_ros_telemetry()  # must not raise despite the broken robot
+
+    node = fake_ros["nodes"][0]
+    topics = {p.topic: p for p in node.publishers}
+    # Broken robot never published; healthy one published despite being second.
+    assert "/broken/joint_states" not in topics
+    assert "/healthy/joint_states" in topics
+    assert topics["/healthy/joint_states"].messages[0].position == [0.5, -0.25]

--- a/tests/tools/test_use_ros.py
+++ b/tests/tools/test_use_ros.py
@@ -222,11 +222,15 @@ def test_timeout_surfaces_as_structured_error(monkeypatch: pytest.MonkeyPatch) -
 
 
 def test_type_resolution_failure_is_structured(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A valid-shaped type naming a package that is not installed is an ordinary
+    # agent input (e.g. an LLM-hallucinated type). rosidl_runtime_py.get_message
+    # resolves it via importlib.import_module, which raises ModuleNotFoundError
+    # (a subclass of ImportError) - the real production failure mode, not KeyError.
     def boom(*a: Any, **k: Any) -> Any:
-        raise KeyError("geometry_msgs/msg/Nope")
+        raise ModuleNotFoundError("No module named 'nonexistent_pkg'")
 
     monkeypatch.setattr(ros_mod, "_publish", boom)
-    result = use_ros(action="publish", topic="/cmd", type="geometry_msgs/msg/Nope")
+    result = use_ros(action="publish", topic="/cmd", type="nonexistent_pkg/msg/Foo")
     assert result["status"] == "error"
     assert "publish failed" in _texts(result)
 


### PR DESCRIPTION
## What

Lets the simulator advertise its own live state on ROS 2. Construct any `SimEngine` (e.g. `Simulation()`) with `ros2_bridge=True` and it spins up an internal `rclpy` node that publishes, per robot, after every `step()`:

| Topic | Type | Content |
|-------|------|---------|
| `/<robot>/joint_states` | `sensor_msgs/msg/JointState` | joint names + positions |
| `/<robot>/<camera>/image_raw` | `sensor_msgs/msg/Image` (`rgb8`) | one frame per attached camera |

External ROS 2 nodes - and the agent's own `use_ros` calls - can then subscribe to a running simulation, closing the loop end to end.

```python
from strands_robots.simulation import Simulation

sim = Simulation(ros2_bridge=True, ros2_domain=0)
sim.create_world()
sim.add_robot("so101")
sim.step(10)   # publishes /so101/joint_states (+ camera image_raw) on domain 0
```

## Live cross-process proof (so101 in MuJoCo, headless EGL)

Verified end to end: a real MuJoCo physics sim (`Simulation(ros2_bridge=True)`, SO-101 arm, headless EGL) was run in one process, and a **separate `ros2` process** on the same DDS domain saw and read it live - the sim genuinely appears on the ROS 2 graph as a node:

```
$ ros2 node list
/strands_sim                       <- the simulation is a ROS 2 node

$ ros2 topic list | grep so101
/so101/joint_states
/so101/default/image_raw

$ ros2 topic info /so101/joint_states
Type: sensor_msgs/msg/JointState
Publisher count: 1

$ ros2 topic echo /so101/joint_states            # sample A
name:     ['1','2','3','4','5','6']
position: [4.53e-08, 0.032499, 0.027553, 0.0056316, 1.91e-06, -4.40e-05]

$ ros2 topic echo /so101/joint_states            # sample B, ~2.5s later
position: [4.39e-08, 0.032482, 0.027524, 0.0056459, 2.02e-06, -4.64e-05]
                     ^ values advanced - LIVE data off the running physics, not a fixture

$ ros2 topic echo /so101/default/image_raw       # header
height: 480   width: 640   encoding: rgb8
```

The joint positions changed between the two samples (joints settling under gravity as the sim steps), and the camera streams a real 640x480 rgb8 frame per step.

## Design

- `SimRosBridge` (`strands_robots/simulation/ros_bridge.py`) is a thin rclpy publisher. `rclpy` and `sensor_msgs` are imported lazily through `require_optional`, so importing the module - and running the sim with `ros2_bridge=False` (the default) - never touches ROS 2 and keeps the base install lightweight.
- The simulation interface stays constructor-free: backends opt into the bridge via `SimEngine._init_ros_bridge(ros2_bridge=..., ros2_domain=...)` rather than an ABC `__init__`, so lightweight subclasses and test doubles need not thread `super().__init__()` just to satisfy the base class. Backend-agnostic `_publish_ros_telemetry()` and `_shutdown_ros_bridge()` helpers are `getattr`-safe no-ops when a subclass never initialized the bridge.
- `MuJoCoSimEngine` forwards the flags, publishes after the physics tick in `step()`, and tears the node down in `cleanup()`.
- Per-robot publish is guarded: a transient single-camera render fault (EGL/GL context loss, empty frame) logs-and-continues instead of crashing `step()` - the documented fail-soft contract, regression-pinned.
- Enabling the bridge with no `rclpy` raises a clear `ImportError` at construction (no warn-and-continue).

## Tests

`tests/simulation/test_ros_sim_bridge.py` injects a fake `rclpy` + `sensor_msgs.msg` into `sys.modules`, so the publisher wiring is exercised with NO ROS 2 installed: topic naming, `JointState`/`Image` field mapping, the per-step telemetry forward, the disabled no-op, the missing-rclpy error path, the per-robot fail-soft guard, and the uninitialized-bridge path. `ruff` + `ruff format` + `mypy` clean; sim-bridge + use_ros suites green (34 passed).

## Notes on this branch

Rebased cleanly onto current `main`. The `use_ros` tool itself already landed on `main` via #742, so this branch carries **only** the sim bridge plus the small shared `use_ros` review fix (widen the dispatch except to catch `ModuleNotFoundError` when a valid-shaped type names a non-installed package). No conflicts.

This supersedes #743 (which was still based on the pre-merge `use_ros` branch and had replay conflicts against `main`).

Closes #741.