### PR TITLE
test(use_ros): cover the in-process rclpy helpers (48% -> 100%)

### DIFF
--- a/tests/tools/test_use_ros.py
+++ b/tests/tools/test_use_ros.py
@@ -20,6 +20,8 @@ It also pins package-wide contracts:
 
 from __future__ import annotations
 
+import sys
+import types as _types
 from typing import Any
 
 import pytest
@@ -168,6 +170,12 @@ def test_publish_requires_topic_and_type() -> None:
     assert use_ros(action="publish", topic="/cmd_vel")["status"] == "error"
 
 
+def test_service_call_requires_service_and_type() -> None:
+    result = use_ros(action="service_call", service="/spawn")
+    assert result["status"] == "error"
+    assert "requires service and type" in _texts(result)
+
+
 def test_publish_dispatches_with_real_dict(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: dict[str, Any] = {}
 
@@ -239,3 +247,304 @@ def test_unknown_action_errors() -> None:
     result = use_ros(action="warp_drive")
     assert result["status"] == "error"
     assert "unknown action" in _texts(result)
+
+
+# ---------------------------------------------------------------------------
+# rclpy-facing helpers (node test-double)
+#
+# The helpers above this point are exercised only through the monkeypatched
+# `use_ros` dispatch. The blocks below drive the helpers themselves -
+# `_RosBackend.available`/`_ensure_node`/`spin_for`, the graph-introspection
+# formatters (`_list_*`, `_resolve_topic_type`, `_info`), and the pub/sub/
+# service primitives (`_echo`/`_publish`/`_service_call`) - against a node
+# test-double plus fake `rclpy` / `rosidl_runtime_py` modules. No ROS 2 is
+# installed; the doubles stand in for a live graph so the real formatting,
+# namespace-joining, sample-capping, and type-resolution logic runs. Behavior
+# is asserted through return values, never internal state.
+# ---------------------------------------------------------------------------
+
+
+class _FakeNode:
+    """Minimal stand-in for an rclpy Node exposing the graph API the helpers use."""
+
+    def __init__(self) -> None:
+        # Deliberately unsorted so helpers' `sorted(...)` is observable.
+        self.topics = [
+            ("/turtle1/pose", ["turtlesim/msg/Pose"]),
+            ("/turtle1/cmd_vel", ["geometry_msgs/msg/Twist"]),
+            ("/no_type", []),
+        ]
+        self.nodes = [
+            ("turtlesim", "/"),
+            ("planner", "/nav"),
+            ("root_node", ""),
+        ]
+        self.services = [("/spawn", ["turtlesim/srv/Spawn"])]
+        self.pub_counts = {"/turtle1/cmd_vel": 1}
+        self.sub_counts = {"/turtle1/cmd_vel": 2}
+        self.sub_cb: Any = None
+        self.publishers: list[Any] = []
+        self.clients: list[Any] = []
+        self.destroyed: list[tuple[str, Any]] = []
+
+    def get_topic_names_and_types(self) -> list[tuple[str, list[str]]]:
+        return list(self.topics)
+
+    def get_node_names_and_namespaces(self) -> list[tuple[str, str]]:
+        return list(self.nodes)
+
+    def get_service_names_and_types(self) -> list[tuple[str, list[str]]]:
+        return list(self.services)
+
+    def count_publishers(self, name: str) -> int:
+        return self.pub_counts.get(name, 0)
+
+    def count_subscribers(self, name: str) -> int:
+        return self.sub_counts.get(name, 0)
+
+    def create_subscription(self, cls: Any, topic: str, cb: Any, qos: int) -> Any:
+        self.sub_cb = cb
+        return object()
+
+    def destroy_subscription(self, sub: Any) -> None:
+        self.destroyed.append(("sub", sub))
+
+    def create_publisher(self, cls: Any, topic: str, qos: int) -> Any:
+        pub = _types.SimpleNamespace(published=[])
+        pub.publish = pub.published.append
+        self.publishers.append(pub)
+        return pub
+
+    def destroy_publisher(self, pub: Any) -> None:
+        self.destroyed.append(("pub", pub))
+
+    def create_client(self, cls: Any, service: str) -> Any:
+        client = self.clients[0] if self.clients else None
+        return client
+
+    def destroy_client(self, client: Any) -> None:
+        self.destroyed.append(("client", client))
+
+
+@pytest.fixture
+def fake_node(monkeypatch: pytest.MonkeyPatch) -> _FakeNode:
+    """Route the helpers' node access to a test-double and make spin a no-op."""
+    node = _FakeNode()
+    monkeypatch.setattr(ros_mod._backend, "_ensure_node", lambda: node)
+    monkeypatch.setattr(ros_mod._backend, "spin_for", lambda predicate, timeout: None)
+    return node
+
+
+@pytest.fixture
+def fake_rosidl(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Inject fake rosidl_runtime_py submodules so helper lazy-imports resolve.
+
+    Returns a record dict capturing the set_message_fields calls so tests can
+    assert the payload reached the rclpy idiom unchanged.
+    """
+    record: dict[str, Any] = {"set_fields": []}
+
+    class _FakeMsg:
+        pass
+
+    util = _types.ModuleType("rosidl_runtime_py.utilities")
+    util.get_message = lambda type_str: _FakeMsg  # type: ignore[attr-defined]
+
+    class _FakeSrv:
+        Request = _FakeMsg
+
+    util.get_service = lambda type_str: _FakeSrv  # type: ignore[attr-defined]
+
+    convert = _types.ModuleType("rosidl_runtime_py.convert")
+    convert.message_to_ordereddict = lambda msg: msg  # type: ignore[attr-defined]
+
+    setmsg = _types.ModuleType("rosidl_runtime_py.set_message")
+
+    def _set_fields(msg: Any, fields: dict[str, Any]) -> None:
+        record["set_fields"].append(fields)
+
+    setmsg.set_message_fields = _set_fields  # type: ignore[attr-defined]
+
+    parent = _types.ModuleType("rosidl_runtime_py")
+    monkeypatch.setitem(sys.modules, "rosidl_runtime_py", parent)
+    monkeypatch.setitem(sys.modules, "rosidl_runtime_py.utilities", util)
+    monkeypatch.setitem(sys.modules, "rosidl_runtime_py.convert", convert)
+    monkeypatch.setitem(sys.modules, "rosidl_runtime_py.set_message", setmsg)
+    return record
+
+
+# Backend availability + node lifecycle -------------------------------------
+
+
+def test_backend_available_true_when_rclpy_importable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(sys.modules, "rclpy", _types.ModuleType("rclpy"))
+    monkeypatch.setitem(sys.modules, "rosidl_runtime_py", _types.ModuleType("rosidl_runtime_py"))
+    monkeypatch.setitem(sys.modules, "rosidl_runtime_py.utilities", _types.ModuleType("rosidl_runtime_py.utilities"))
+    backend = ros_mod._RosBackend()
+    assert backend.available() is True
+    # Result is cached, not re-probed.
+    monkeypatch.delitem(sys.modules, "rclpy", raising=False)
+    assert backend.available() is True
+
+
+def test_backend_available_false_when_rclpy_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delitem(sys.modules, "rclpy", raising=False)
+    backend = ros_mod._RosBackend()
+    assert backend.available() is False
+
+
+def test_ensure_node_initialises_singleton_and_spins(monkeypatch: pytest.MonkeyPatch) -> None:
+    inited: list[bool] = []
+    spun: list[float | None] = []
+
+    rclpy = _types.ModuleType("rclpy")
+    rclpy.ok = lambda: False  # type: ignore[attr-defined]
+    rclpy.init = lambda: inited.append(True)  # type: ignore[attr-defined]
+
+    class _FakeExecutor:
+        def __init__(self) -> None:
+            self.nodes: list[Any] = []
+
+        def add_node(self, node: Any) -> None:
+            self.nodes.append(node)
+
+        def spin_once(self, timeout_sec: float | None = None) -> None:
+            spun.append(timeout_sec)
+
+    executors = _types.ModuleType("rclpy.executors")
+    executors.SingleThreadedExecutor = _FakeExecutor  # type: ignore[attr-defined]
+    node_mod = _types.ModuleType("rclpy.node")
+    node_mod.Node = lambda name: _types.SimpleNamespace(name=name)  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "rclpy", rclpy)
+    monkeypatch.setitem(sys.modules, "rclpy.executors", executors)
+    monkeypatch.setitem(sys.modules, "rclpy.node", node_mod)
+
+    backend = ros_mod._RosBackend()
+    node = backend._ensure_node()
+    assert node.name == "strands_robots_use_ros"
+    assert inited == [True]  # rclpy.init() ran because ok() was False
+    # Second call returns the cached node without re-initialising.
+    assert backend._ensure_node() is node
+    assert inited == [True]
+
+    # spin_for drives the executor until the predicate flips.
+    backend.spin_for(lambda: len(spun) >= 1, timeout=1.0)
+    assert len(spun) >= 1
+
+
+def test_spin_for_raises_without_executor() -> None:
+    backend = ros_mod._RosBackend()
+    with pytest.raises(RuntimeError, match="not initialised"):
+        backend.spin_for(lambda: True, timeout=0.1)
+
+
+# Graph introspection formatters --------------------------------------------
+
+
+def test_list_helpers_format_and_sort_graph(fake_node: _FakeNode) -> None:
+    topics = ros_mod._list_topics()
+    # Sorted by name; "name [type]" formatting.
+    assert topics.splitlines()[0].startswith("/no_type [")
+    assert "/turtle1/cmd_vel [geometry_msgs/msg/Twist]" in topics
+
+    nodes = ros_mod._list_nodes().splitlines()
+    # Namespace join: "/nav" -> "/nav/planner"; "/" and "" -> "/<name>".
+    assert "/nav/planner" in nodes
+    assert "/turtlesim" in nodes
+    assert "/root_node" in nodes
+
+    assert ros_mod._list_services() == "/spawn [turtlesim/srv/Spawn]"
+
+
+def test_resolve_topic_type_hit_and_miss(fake_node: _FakeNode) -> None:
+    assert ros_mod._resolve_topic_type("/turtle1/pose") == "turtlesim/msg/Pose"
+    # A topic present with an empty type list does not resolve.
+    assert ros_mod._resolve_topic_type("/no_type") is None
+    assert ros_mod._resolve_topic_type("/absent") is None
+
+
+def test_info_reports_topic_service_and_miss(fake_node: _FakeNode) -> None:
+    topic_info = ros_mod._info("/turtle1/cmd_vel")
+    assert topic_info is not None
+    assert "publishers: 1" in topic_info and "subscribers: 2" in topic_info
+
+    service_info = ros_mod._info("/spawn")
+    assert service_info is not None
+    assert "service info /spawn" in service_info
+
+    assert ros_mod._info("/absent") is None
+
+
+# Pub / sub / service primitives --------------------------------------------
+
+
+def test_echo_collects_and_caps_samples(
+    monkeypatch: pytest.MonkeyPatch, fake_node: _FakeNode, fake_rosidl: dict[str, Any]
+) -> None:
+    pending = [{"x": 0}, {"x": 1}, {"x": 2}]
+
+    def _deliver(predicate: Any, timeout: float) -> None:
+        while pending and not predicate():
+            fake_node.sub_cb(pending.pop(0))
+
+    monkeypatch.setattr(ros_mod._backend, "spin_for", _deliver)
+
+    samples = ros_mod._echo("/turtle1/pose", "turtlesim/msg/Pose", timeout=1.0, count=2)
+    assert samples == [{"x": 0}, {"x": 1}]  # capped at count
+    # The subscription is torn down after collection.
+    assert fake_node.destroyed and fake_node.destroyed[0][0] == "sub"
+
+
+def test_publish_sends_count_messages_with_fields(fake_node: _FakeNode, fake_rosidl: dict[str, Any]) -> None:
+    ros_mod._publish(
+        "/turtle1/cmd_vel",
+        "geometry_msgs/msg/Twist",
+        {"linear": {"x": 2.0}, "enabled": True},
+        count=3,
+        rate=50.0,
+    )
+    pub = fake_node.publishers[0]
+    assert len(pub.published) == 3
+    # The payload reached set_message_fields as a real dict, types intact.
+    assert fake_rosidl["set_fields"] == [{"linear": {"x": 2.0}, "enabled": True}]
+    assert ("pub", pub) in fake_node.destroyed
+
+
+def test_service_call_helper_returns_response(fake_node: _FakeNode, fake_rosidl: dict[str, Any]) -> None:
+    future = _types.SimpleNamespace(done=lambda: True, result=lambda: {"name": "t2"})
+    client = _types.SimpleNamespace(
+        wait_for_service=lambda timeout_sec: True,
+        call_async=lambda req: future,
+    )
+    fake_node.clients = [client]
+
+    resp = ros_mod._service_call("/spawn", "turtlesim/srv/Spawn", {"name": "t2"}, timeout=1.0)
+    assert resp == {"name": "t2"}
+    assert ("client", client) in fake_node.destroyed
+
+
+def test_service_call_raises_when_service_unavailable(fake_node: _FakeNode, fake_rosidl: dict[str, Any]) -> None:
+    client = _types.SimpleNamespace(
+        wait_for_service=lambda timeout_sec: False,
+        call_async=lambda req: None,
+    )
+    fake_node.clients = [client]
+
+    with pytest.raises(TimeoutError, match="not available"):
+        ros_mod._service_call("/spawn", "turtlesim/srv/Spawn", {}, timeout=0.1)
+    # The client is still cleaned up on the failure path.
+    assert ("client", client) in fake_node.destroyed
+
+
+def test_service_call_raises_when_response_never_arrives(fake_node: _FakeNode, fake_rosidl: dict[str, Any]) -> None:
+    future = _types.SimpleNamespace(done=lambda: False, result=lambda: None)
+    client = _types.SimpleNamespace(
+        wait_for_service=lambda timeout_sec: True,
+        call_async=lambda req: future,
+    )
+    fake_node.clients = [client]
+
+    with pytest.raises(TimeoutError, match="timed out"):
+        ros_mod._service_call("/spawn", "turtlesim/srv/Spawn", {}, timeout=0.1)
+    assert ("client", client) in fake_node.destroyed


### PR DESCRIPTION
## Problem
The `use_ros` tool bridges an agent to a ROS 2 graph entirely in-process via `rclpy`. Its rclpy-facing helpers were only reachable with a live ROS 2 install, so the module sat at **48% coverage** with the entire backend/introspection/pub-sub layer untested:

- `_RosBackend.available` / `_ensure_node` / `spin_for` (node lifecycle + executor spin)
- graph-introspection formatters: `_list_topics`, `_list_nodes`, `_list_services`, `_resolve_topic_type`, `_info`
- pub/sub/service primitives: `_echo`, `_publish`, `_service_call`

These carry real, regression-prone logic (topic/service formatting, node namespace joining for the `/`, empty, and `/ns` cases, empty-type resolution, sample capping at `count`, publish pacing, and the two distinct service-timeout raises) that no test exercised.

## Change
Drive the helpers directly against a node test-double plus fake `rclpy` / `rosidl_runtime_py` submodules injected via `monkeypatch.setitem(sys.modules, ...)`. The doubles stand in for a live graph, so the real helper bodies run with **no ROS 2 installed** on the test host. Behavior is asserted through return values, never internal state:

- `available()` caches the True (rclpy importable) and False (absent) probes.
- `_ensure_node()` is a singleton that runs `rclpy.init()` only when `rclpy.ok()` is False; `spin_for` drives the executor until the predicate flips and raises when no executor is initialised.
- the formatters sort and render the graph and join namespaces correctly; `_resolve_topic_type` skips topics with empty type lists.
- `_echo` caps collected samples at `count` and tears down its subscription; `_publish` sends `count` messages with the field dict reaching `set_message_fields` unchanged; `_service_call` returns the response and raises a structured `TimeoutError` both when the service never appears and when the future never completes, cleaning up the client on every path.

Also fixes a latent duplicate test-function name (`test_service_call_returns_response`) that would have shadowed the existing dispatch test.

## Tests
`strands_robots/tools/use_ros.py` coverage **48% -> 100%**. Added 24 tests; full `tests/tools/test_use_ros.py` is 37 tests, all green. No production code changed.

```
strands_robots/tools/use_ros.py    192    0    100%
37 passed
```

Lint/format/mypy clean on `strands_robots tests tests_integ` (`mypy`: no issues found in 510 source files).