### PR TITLE
fix(lerobot_local): accept HWC/uint8 camera frames in get_actions (canonicalize image layout before preprocess)

### DIFF
--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -1116,6 +1116,7 @@ class LerobotLocalPolicy(Policy):
                 # observation.state. Feed RAW obs straight in - ZERO per-step
                 # strands-side remapping, no _fixup needed (AddBatchDimension +
                 # Device steps in the pipeline handle shape/device).
+                observation = self._canonicalize_obs_images(observation)
                 batch = self._processor_bridge.preprocess(observation, instruction=instruction)
                 if not isinstance(batch, dict):
                     batch = {"observation.state": batch}
@@ -1125,6 +1126,7 @@ class LerobotLocalPolicy(Policy):
                 # the model's LeRobot feature names BEFORE preprocess, then fix up
                 # any arrays/tensors the pipeline left unconverted.
                 lerobot_obs = self._to_lerobot_observation(observation)
+                lerobot_obs = self._canonicalize_obs_images(lerobot_obs)
                 batch = self._processor_bridge.preprocess(lerobot_obs, instruction=instruction)
                 if not isinstance(batch, dict):
                     batch = {"observation.state": batch}
@@ -1171,6 +1173,44 @@ class LerobotLocalPolicy(Policy):
         return self._tensor_to_action_dicts(action_tensor)
 
     # Observation batch building
+
+    def _canonicalize_obs_images(self, observation: dict[str, Any]) -> dict[str, Any]:
+        """Normalize image-array layout BEFORE the preprocessor runs.
+
+        LeRobot's normalizer step inside ``preprocess()`` expects images as
+        channel-first ``(C, H, W)`` (or batched ``(B, C, H, W)``) tensors so its
+        per-channel mean/std broadcast correctly. Direct ``get_actions`` callers
+        commonly pass camera frames as HWC numpy arrays (the natural format from
+        OpenCV / a renderer), and uint8 frames in [0, 255]. Feeding those raw
+        makes the normalizer either broadcast a 3-vector against the 480 height
+        (``size of tensor a (480) must match b (3)``) or overflow uint8.
+
+        This converts every ``observation.images.*`` entry to CHW ``float32`` in
+        [0, 1] up front, so HWC-uint8, HWC-float, CHW-float, and torch/np inputs
+        all work. Non-image entries pass through untouched. Runs before BOTH the
+        embodiment and legacy preprocess paths; ``_fixup_preprocessed_batch``
+        still adds the batch dimension afterwards.
+        """
+        out = dict(observation)
+        for key, val in observation.items():
+            if "image" not in key or val is None:
+                continue
+            if isinstance(val, np.ndarray):
+                img = torch.from_numpy(val)
+            elif isinstance(val, torch.Tensor):
+                img = val
+            else:
+                continue  # leave exotic types for the pipeline to handle
+            # uint8 [0,255] -> float32 [0,1]; other ints/floats just cast.
+            if img.dtype == torch.uint8:
+                img = img.float() / 255.0
+            else:
+                img = img.float()
+            # HWC -> CHW (a trailing channel dim of 1/3/4 is the giveaway).
+            if img.ndim == 3 and img.shape[-1] in (1, 3, 4) and img.shape[0] not in (1, 3, 4):
+                img = img.permute(2, 0, 1)
+            out[key] = img
+        return out
 
     def _fixup_preprocessed_batch(self, batch: dict[str, Any]) -> dict[str, Any]:
         """Fix up a preprocessor-produced batch so every value is a proper batched tensor.

--- a/tests/policies/lerobot_local/test_policy.py
+++ b/tests/policies/lerobot_local/test_policy.py
@@ -1998,3 +1998,54 @@ class TestRtcInferenceDelay:
         warnings = [r for r in caplog.records if "control_frequency unknown" in r.message]
         assert len(warnings) == 1, "fallback must warn exactly once per policy"
         assert policy._rtc_freq_warned is True
+
+
+class TestCanonicalizeObsImages:
+    """_canonicalize_obs_images normalizes camera frames to CHW float32 [0,1]
+    BEFORE the preprocessor's normalizer runs.
+
+    Regression: direct get_actions() callers pass HWC uint8 frames (the natural
+    OpenCV/renderer format). Feeding those raw made lerobot's normalizer broadcast
+    a 3-vector against the 480 height ("size of tensor a (480) must match b (3)")
+    or overflow uint8. The fix converts to CHW float32 up front; these pin every
+    input layout the helper must accept.
+    """
+
+    def _policy(self):
+        with patch.object(LerobotLocalPolicy, "_load_model"):
+            return LerobotLocalPolicy(pretrained_name_or_path="test/model")
+
+    def test_hwc_uint8_to_chw_float01(self):
+        p = self._policy()
+        img = np.ones((480, 640, 3), dtype=np.uint8) * 255
+        out = p._canonicalize_obs_images({"observation.images.top": img})["observation.images.top"]
+        assert tuple(out.shape) == (3, 480, 640)  # HWC -> CHW
+        assert out.dtype == torch.float32
+        assert float(out.max()) <= 1.0 and float(out.min()) >= 0.0  # uint8 [0,255] -> [0,1]
+
+    def test_hwc_float_to_chw(self):
+        p = self._policy()
+        img = np.random.rand(480, 640, 3).astype(np.float32)
+        out = p._canonicalize_obs_images({"observation.images.top": img})["observation.images.top"]
+        assert tuple(out.shape) == (3, 480, 640)
+        assert out.dtype == torch.float32
+
+    def test_chw_float_passthrough_layout(self):
+        p = self._policy()
+        img = np.random.rand(3, 480, 640).astype(np.float32)
+        out = p._canonicalize_obs_images({"observation.images.top": img})["observation.images.top"]
+        assert tuple(out.shape) == (3, 480, 640)  # already CHW -> unchanged layout
+
+    def test_chw_uint8_torch_normalized(self):
+        p = self._policy()
+        img = (torch.rand(3, 480, 640) * 255).to(torch.uint8)
+        out = p._canonicalize_obs_images({"observation.images.top": img})["observation.images.top"]
+        assert tuple(out.shape) == (3, 480, 640)
+        assert out.dtype == torch.float32 and float(out.max()) <= 1.0
+
+    def test_non_image_keys_pass_through(self):
+        p = self._policy()
+        obs = {"observation.state": [0.0] * 6, "task": "pick up the cube"}
+        out = p._canonicalize_obs_images(obs)
+        assert out["observation.state"] == [0.0] * 6
+        assert out["task"] == "pick up the cube"


### PR DESCRIPTION
## Problem

Calling `LerobotLocalPolicy.get_actions()` directly with camera frames in the **natural HWC format** (what OpenCV, a MuJoCo renderer, or a mesh camera stream produces) crashes inside lerobot's normalizer:

```python
policy = create_policy("/path/to/checkpoint")          # a post-tuned ACT/VLA policy
policy.set_robot_state_keys([f"joint_{i}" for i in range(12)])
obs = {"observation.state": [...],
       "observation.images.front": frame}                # HWC uint8 (480, 640, 3)
policy.get_actions_sync(obs, "pick up the cube")
# RuntimeError: Preprocessor pipeline failed: value cannot be converted to type uint8 without overflow
# (or, for HWC float)   The size of tensor a (480) must match the size of tensor b (3) at non-singleton dimension 0
```

The normalizer step inside `preprocess()` expects channel-first `(C, H, W)` so its per-channel mean/std broadcast correctly. With HWC it broadcasts a 3-channel stat against the 480-pixel height; with uint8 it overflows on normalization.

`_fixup_preprocessed_batch` already does an HWC->CHW conversion, but it runs **after** `preprocess()` - too late, because the normalizer inside `preprocess()` has already seen the raw HWC array. So direct callers had to pre-transpose and pre-normalize images themselves, which isn't obvious and isn't documented.

## Fix

Add `_canonicalize_obs_images()` and call it **before** `preprocess()` in both the embodiment and legacy paths. It converts every `observation.images.*` entry to **CHW `float32` in [0, 1]** up front:

- uint8 [0,255] -> float32 [0,1]; other dtypes just cast to float
- HWC -> CHW (detected by a trailing channel dim of 1/3/4)
- numpy and torch inputs both handled; non-image keys pass through untouched

The later `_fixup_preprocessed_batch` still adds the batch dimension, so existing rollout paths (sim/hardware via `run_policy`, which already feed CHW) are unaffected.

## Verification

Reproduced and verified end to end against **real lerobot 0.5.2**:

1. Post-tuned an ACT policy on a real SO-101 dataset (`trainer` -> `build_config` -> `lerobot_train`), producing a 52M-param checkpoint.
2. `create_policy(checkpoint)` -> `get_actions_sync(obs, ...)` with **HWC uint8** camera frames now returns a correct **100x12 action chunk** (chunk_size x DOF). It raised before this fix.
3. All four input layouts work: HWC-uint8, HWC-float, CHW-float, CHW-uint8(torch).

## Tests

`TestCanonicalizeObsImages` (5 cases) pins the transform - HWC-uint8 -> CHW float [0,1], HWC-float -> CHW, CHW-float layout preserved, CHW-uint8 torch normalized, and non-image keys passthrough. The HWC cases fail on pre-fix code. They run with no lerobot installed (pure tensor assertions), matching the rest of `test_policy.py`.

Full `lerobot_local` policy suite green (306 passed); `ruff` + `ruff format` + `mypy` clean.

## Why it matters

This is a real DX papercut for anyone wiring a freshly-trained policy to live cameras: frames arrive HWC uint8, and `get_actions()` should just accept them rather than failing with a cryptic broadcast/overflow error from deep inside lerobot. Surfaced while validating the SARM -> RA-BC -> ACT folding-recipe flow end to end (#749).