### PR TITLE
test(robot_mesh): cover the broadcast/send/tell command-validation contract

### DIFF
--- a/tests/mesh/test_robot_mesh_command_validation.py
+++ b/tests/mesh/test_robot_mesh_command_validation.py
@@ -1,0 +1,90 @@
+"""Input-validation contract for the ``robot_mesh`` dispatcher.
+
+``robot_mesh`` validates the ``broadcast`` / ``send`` / ``tell`` command
+bodies *before* any mesh dispatch or human-in-the-loop approval gate, and
+always returns a structured ``{"status": "error", ...}`` dict (it never
+raises out of the dispatcher). These tests pin that fail-closed contract so
+a malformed agent tool call is rejected with an actionable message instead
+of reaching the transport.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from strands_robots.tools.robot_mesh import _reset_rate_limits, robot_mesh
+
+
+def _call(**kwargs):
+    """Invoke the underlying tool fn (Strands ``@tool`` wraps it as ``.original``)."""
+    fn = getattr(robot_mesh, "original", robot_mesh)
+    return fn(**kwargs)
+
+
+def _text(out) -> str:
+    return out["content"][0]["text"]
+
+
+@pytest.fixture(autouse=True)
+def _isolate_rate_limits():
+    """Each validation case consumes a per-action rate-limit slot; reset so
+    the cases stay independent of collection order."""
+    _reset_rate_limits()
+    yield
+    _reset_rate_limits()
+
+
+def test_broadcast_without_command_is_rejected():
+    out = _call(action="broadcast", command="", tool_context=MagicMock())
+    assert out["status"] == "error"
+    assert "broadcast requires command" in _text(out)
+
+
+def test_broadcast_with_malformed_json_is_rejected():
+    out = _call(action="broadcast", command="{not valid", tool_context=MagicMock())
+    assert out["status"] == "error"
+    assert "not valid JSON" in _text(out)
+
+
+def test_broadcast_with_non_object_json_is_rejected():
+    # A JSON array parses but is not a command object -> reject.
+    out = _call(action="broadcast", command="[1, 2, 3]", tool_context=MagicMock())
+    assert out["status"] == "error"
+    assert "JSON object" in _text(out)
+
+
+def test_broadcast_with_disallowed_action_is_rejected():
+    out = _call(action="broadcast", command='{"action": "rm_rf"}', tool_context=MagicMock())
+    assert out["status"] == "error"
+    assert "broadcast rejected" in _text(out)
+
+
+def test_send_without_target_is_rejected():
+    out = _call(action="send", target="", command='{"action": "stop"}', tool_context=MagicMock())
+    assert out["status"] == "error"
+    assert "send requires target" in _text(out)
+
+
+def test_tell_with_overlong_instruction_is_rejected():
+    # policy_port is forwarded into the synthesised execute command; pass one
+    # so the rejection path covers the port-forwarding branch too. The
+    # instruction-length check still fires first, so the command is rejected.
+    out = _call(
+        action="tell",
+        target="peer-b",
+        instruction="x" * 5000,
+        policy_port=5555,
+        tool_context=MagicMock(),
+    )
+    assert out["status"] == "error"
+    assert "tell rejected" in _text(out)
+
+
+def test_interrupt_gated_action_without_tool_context_fails_closed():
+    # emergency_stop is HITL-gated by default; with no tool_context the
+    # dispatcher must refuse rather than fire a fleet-wide stop unattended.
+    out = _call(action="emergency_stop", tool_context=None)
+    assert out["status"] == "error"
+    assert "human-in-the-loop interrupt" in _text(out)


### PR DESCRIPTION
## What
`robot_mesh` validates the `broadcast` / `send` / `tell` command bodies *before* any mesh dispatch or human-in-the-loop approval gate, and always returns a structured `{"status": "error", ...}` dict (it never raises out of the dispatcher). Several of those fail-closed branches had no test coverage. This adds a focused `tests/mesh/test_robot_mesh_command_validation.py` that pins the contract.

## Branches now covered
- `broadcast` with no command, malformed JSON, and non-object JSON (e.g. a JSON array)
- `broadcast` rejected by the command security validator (disallowed action)
- `send` invoked without a target
- `tell` rejected by the validator (over-long instruction), exercising the `policy_port` forwarding branch
- an interrupt-gated action (`emergency_stop`) invoked without a `tool_context` -> fails closed instead of dispatching a fleet-wide stop unattended

## Why
These are the dispatcher's input-validation guarantees an agent relies on: a malformed tool call must be rejected with an actionable message at the boundary, never reach the transport, and never raise. Pinning them protects the contract against regressions.

## Coverage
`strands_robots/tools/robot_mesh.py`: +11 previously-uncovered lines (861-862, 865-867, 869-870, 878-879, 902, 917-918). Scoped to the dispatcher's tests the module goes 79% -> 81%.

## Tests
Additive test-only change; no source modified. `tests/mesh` + `tests/tools` suites pass (2486 passed, 3 skipped) and `ruff` + `mypy` are clean (no issues in 513 source files).