### PR TITLE
feat(registry): zero-config robot discovery from robot_descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Feature: zero-config robot discovery from `robot_descriptions` (`registry`)
+
+`Robot("iiwa14", mode="sim")` (and every other MJCF robot shipped by
+`robot_descriptions`) now resolves without a hand-written `robots.json` entry.
+Previously a standard Menagerie robot had to be re-declared in the curated
+registry before the MuJoCo backend could load it, even though `robot_descriptions`
+already resolves its assets canonically - so the long tail (`iiwa14`, `gen3`,
+`viper`, `widow`, `so_arm101`, ...) was unreachable without a registry edit.
+
+- New `strands_robots.registry.discovery` module. `discover_robot(name)`
+  synthesizes a registry-shaped entry for any MJCF-capable `robot_descriptions`
+  robot by reading the module's `MJCF_PATH` / `PACKAGE_PATH`, so the existing
+  asset-download + resolution pipeline handles it unchanged. `descriptions_module`,
+  `is_discoverable`, and `list_discoverable` are cheap lookups (no import, no
+  network) for probing the long tail; `discover_robot` is consulted only by the
+  download-capable asset resolver.
+- The curated `robots.json` always wins: discovery fills the gap only for names
+  unknown to the curated registry, so existing robots, joint maps, hardware
+  ports, and aliases are unaffected. `robots.json` stays the place for any robot
+  that needs project-specific metadata.
+- `is_discoverable` / `list_discoverable` are re-exported from the top-level
+  `strands_robots` package and from `strands_robots.registry`. The `Robot()`
+  factory accepts a discoverable name instead of raising "Unknown robot".
+
 ### Feature: SARM reward-model training + the RA-BC production loop (`training`)
 
 Closes the *producing* half of Reward-Aligned Behavior Cloning: `strands-robots`

--- a/README.md
+++ b/README.md
@@ -405,6 +405,40 @@ first use. List them at runtime with `from strands_robots import list_robots; li
 `so101`, `koch`, `omx`, `hope_jr`, `aloha`, `bi_openarm`, `reachy2`,
 `unitree_g1`, `lekiwi`, `earthrover`. All are simulatable.
 
+### Adding a robot
+
+There are two paths, depending on whether the robot needs project-specific
+metadata:
+
+1. **Standard `robot_descriptions` robot (zero config).** Any MJCF robot shipped
+   by [robot_descriptions](https://github.com/robot-descriptions/robot_descriptions.py)
+   resolves automatically without a `robots.json` entry - the asset is
+   discovered and downloaded on first use:
+
+   ```python
+   from strands_robots import Robot, list_discoverable
+
+   sim = Robot("iiwa14")          # discovered, not in robots.json
+   print(list_discoverable())     # the MJCF long tail you can load directly
+   ```
+
+   A curated `robots.json` entry always wins over discovery, so overriding a
+   discovered robot later is non-breaking.
+
+2. **Custom or metadata-rich robot.** If the robot needs a non-default joint
+   count, hardware port, aliases, scene tweaks, or local mesh overrides, add a
+   curated entry. For a robot that belongs in the shipped catalog, add it to
+   [`registry/robots.json`](strands_robots/registry/robots.json) and open a PR.
+   For a machine-local robot, register it at runtime instead of editing the
+   package:
+
+   ```python
+   from strands_robots.registry import register_robot
+
+   register_robot(name="my_arm", model_xml="my_arm.xml",
+                  asset_dir="~/robots/my_arm", joints=7, category="arm")
+   ```
+
 ## Tools reference
 
 Import any of these and pass to `Agent(tools=[...])`. Each is a Strands

--- a/strands_robots/__init__.py
+++ b/strands_robots/__init__.py
@@ -38,7 +38,12 @@ if TYPE_CHECKING:
         init_device_connect_sync,
     )
     from strands_robots.policies.groot import Gr00tPolicy
-    from strands_robots.registry import get_robot, list_robots
+    from strands_robots.registry import (
+        get_robot,
+        is_discoverable,
+        list_discoverable,
+        list_robots,
+    )
     from strands_robots.robot import Robot
     from strands_robots.simulation import (
         SimCamera,
@@ -76,6 +81,8 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "Teleoperator": ("strands_robots.teleoperator", "Teleoperator"),
     "list_robots": ("strands_robots.registry", "list_robots"),
     "get_robot": ("strands_robots.registry", "get_robot"),
+    "list_discoverable": ("strands_robots.registry", "list_discoverable"),
+    "is_discoverable": ("strands_robots.registry", "is_discoverable"),
     # Policies
     "Gr00tPolicy": ("strands_robots.policies.groot", "Gr00tPolicy"),
     # Simulation (MuJoCo)
@@ -122,6 +129,8 @@ __all__ = [
     "SimCamera",
     "list_robots",
     "get_robot",
+    "list_discoverable",
+    "is_discoverable",
     "create_simulation",
     "list_backends",
     "register_backend",

--- a/strands_robots/assets/manager.py
+++ b/strands_robots/assets/manager.py
@@ -32,6 +32,25 @@ except ImportError:
     _auto_download_robot_impl = None  # type: ignore[assignment]
 
 
+def _lookup(name: str) -> dict | None:
+    """Resolve a registry entry for *name*, with ``robot_descriptions`` fallback.
+
+    A curated ``robots.json`` entry always wins. When a name is unknown to the
+    curated registry, fall back to :func:`strands_robots.registry.discovery`,
+    which synthesizes an entry for any MJCF-capable ``robot_descriptions`` robot
+    (the long tail: ``go2``, ``spot``, ``h1``, ...). Discovery imports the
+    description module, which can trigger an asset download on first use, so
+    this helper is used only by download-capable resolvers - never by the
+    side-effect-free presence check.
+    """
+    info = get_robot(name)
+    if info is not None:
+        return info
+    from strands_robots.registry.discovery import discover_robot
+
+    return discover_robot(name)
+
+
 #
 # Model path resolution (delegates to registry)
 #
@@ -179,7 +198,7 @@ def resolve_model_path(
         resolve_model_path("so100", prefer_scene=True)  # → .../trs_so_arm100/scene.xml
         resolve_model_path("franka")            # → .../franka_emika_panda/panda.xml
     """
-    info = get_robot(name)
+    info = _lookup(name)
     if not info or "asset" not in info:
         # DEBUG, not WARNING: resolve_model() probes several candidate names
         # (incl. suffix-stripped variants) and handles a None return cleanly,
@@ -258,7 +277,7 @@ def resolve_model_dir(name: str) -> Path | None:
     Returns:
         Path to the robot's asset directory, or None if not found.
     """
-    info = get_robot(name)
+    info = _lookup(name)
     if not info or "asset" not in info:
         return None
 
@@ -283,7 +302,7 @@ def get_robot_info(name: str) -> dict | None:
     Returns:
         Dict with description, category, joints, asset info, etc.
     """
-    info = get_robot(name)
+    info = _lookup(name)
     if info is None:
         return None
     result = dict(info)

--- a/strands_robots/registry/__init__.py
+++ b/strands_robots/registry/__init__.py
@@ -29,6 +29,12 @@ Architecture:
         policies.json    ← policy providers (shorthands/urls inside each entry)
 """
 
+from .discovery import (
+    descriptions_module,
+    discover_robot,
+    is_discoverable,
+    list_discoverable,
+)
 from .loader import invalidate_cache, reload
 from .policies import (
     build_policy_kwargs,
@@ -65,6 +71,11 @@ __all__ = [
     "list_robots_by_category",
     "list_aliases",
     "format_robot_table",
+    # robot_descriptions auto-discovery (long tail)
+    "descriptions_module",
+    "is_discoverable",
+    "list_discoverable",
+    "discover_robot",
     # Policy registry
     "get_policy_provider",
     "list_policy_providers",

--- a/strands_robots/registry/discovery.py
+++ b/strands_robots/registry/discovery.py
@@ -1,0 +1,195 @@
+"""Auto-discovery of robots from the optional ``robot_descriptions`` package.
+
+The curated registry (``robots.json``) deliberately carries only robots that
+need project-specific metadata: hardware ports, custom joint counts, scene
+tweaks, aliases, or local mesh overrides. The much larger long tail of standard
+robots shipped by ``robot_descriptions`` (MuJoCo Menagerie and friends) does not
+need a hand-written entry - this module resolves those on demand so
+``Robot("go2", mode="sim")`` works without touching ``robots.json``.
+
+Resolution rules:
+    - A curated ``robots.json`` entry always wins. Discovery is consulted only
+      for names unknown to the curated registry (see
+      :func:`strands_robots.registry.get_robot`).
+    - Only MJCF-capable descriptions are discoverable: the MuJoCo backend needs
+      an ``.xml`` model, so URDF-only descriptions are skipped.
+    - :func:`descriptions_module`, :func:`is_discoverable`, and
+      :func:`list_discoverable` are cheap - a static dict lookup with no module
+      import and no network. :func:`discover_robot` is heavy: importing a
+      description module makes ``robot_descriptions`` clone the upstream asset
+      repository on first use, so it is called only from asset-resolution paths
+      that are already allowed to download.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import re
+from functools import lru_cache
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Robot names are interpolated into ``importlib`` module paths, so restrict them
+# to a conservative allowlist before any lookup - no dots, slashes, or
+# whitespace can reach the import machinery.
+_NAME_RE = re.compile(r"^[a-z0-9_]+$")
+
+# ``robot_descriptions`` names every MuJoCo (MJCF) description module with this
+# suffix, e.g. ``go2_mj_description`` -> canonical robot name ``go2``.
+_MJCF_SUFFIX = "_mj_description"
+
+# Candidate scene files (ground plane + lights) a Menagerie description may ship
+# alongside the bare robot model, in preference order.
+_SCENE_CANDIDATES = ("scene.xml", "scene_mjx.xml")
+
+# Cache of synthesized entries (and negative results) keyed by normalized name.
+_DISCOVER_CACHE: dict[str, dict[str, Any] | None] = {}
+
+
+def _normalize(name: str) -> str:
+    """Lowercase, strip, and underscore-normalize a robot name."""
+    return name.lower().strip().replace("-", "_")
+
+
+@lru_cache(maxsize=1)
+def _mjcf_modules() -> dict[str, str]:
+    """Map canonical robot name -> MJCF description module name.
+
+    Reads ``robot_descriptions``' static description table, which is a plain
+    dict - no module import and no network. Returns an empty mapping when
+    ``robot_descriptions`` is not installed.
+    """
+    try:
+        from robot_descriptions._descriptions import (  # type: ignore[import-not-found]
+            DESCRIPTIONS,
+            Format,
+        )
+    except ImportError:
+        return {}
+
+    mapping: dict[str, str] = {}
+    for module_name, desc in DESCRIPTIONS.items():
+        if Format.MJCF not in desc.formats:
+            continue
+        if not module_name.endswith(_MJCF_SUFFIX):
+            continue
+        short = module_name[: -len(_MJCF_SUFFIX)]
+        mapping[short] = module_name
+    return mapping
+
+
+def descriptions_module(name: str) -> str | None:
+    """Return the MJCF ``robot_descriptions`` module for *name*, or ``None``.
+
+    Cheap: a dict lookup against the static description table, with no module
+    import and no network. Returns ``None`` when the robot is not an
+    MJCF-capable ``robot_descriptions`` robot or when the package is missing.
+
+    Examples::
+
+        descriptions_module("go2")   # -> "go2_mj_description"
+        descriptions_module("so100") # -> None (curated, not a description)
+    """
+    norm = _normalize(name)
+    if not _NAME_RE.match(norm):
+        return None
+    return _mjcf_modules().get(norm)
+
+
+def is_discoverable(name: str) -> bool:
+    """Return ``True`` if *name* resolves from ``robot_descriptions`` (cheap)."""
+    return descriptions_module(name) is not None
+
+
+def list_discoverable() -> list[str]:
+    """Return sorted canonical names resolvable from ``robot_descriptions``.
+
+    This is the MJCF long tail - the standard robots that work in the MuJoCo
+    backend without a curated ``robots.json`` entry (e.g. ``go2``, ``spot``,
+    ``h1``, ``anymal_c``, ``cassie``). Cheap: no import, no network.
+    """
+    return sorted(_mjcf_modules())
+
+
+def discover_robot(name: str) -> dict[str, Any] | None:
+    """Synthesize a registry entry for *name* from ``robot_descriptions``.
+
+    Heavy: imports the description module, which makes ``robot_descriptions``
+    clone the upstream asset repository on first use. Call only from
+    asset-resolution paths that are allowed to download. Results (including
+    misses) are cached.
+
+    Args:
+        name: Robot name or alias (e.g. ``"go2"``).
+
+    Returns:
+        A registry-style entry with the same shape as a ``robots.json`` value -
+        an ``asset`` block wired to the resolved ``robot_descriptions`` module -
+        or ``None`` if the robot is not an MJCF-capable ``robot_descriptions``
+        robot.
+    """
+    norm = _normalize(name)
+    if norm in _DISCOVER_CACHE:
+        return _DISCOVER_CACHE[norm]
+
+    module_name = descriptions_module(norm)
+    if module_name is None:
+        _DISCOVER_CACHE[norm] = None
+        return None
+
+    try:
+        mod = importlib.import_module(f"robot_descriptions.{module_name}")
+    except ImportError as exc:
+        logger.debug("Discovery import failed for %r (%s): %s", norm, module_name, exc)
+        _DISCOVER_CACHE[norm] = None
+        return None
+
+    mjcf_path = getattr(mod, "MJCF_PATH", None)
+    package_path = getattr(mod, "PACKAGE_PATH", None)
+    if not mjcf_path or not package_path:
+        logger.warning(
+            "robot_descriptions module %r lacks MJCF_PATH/PACKAGE_PATH; cannot discover %r",
+            module_name,
+            norm,
+        )
+        _DISCOVER_CACHE[norm] = None
+        return None
+
+    package_dir = str(package_path)
+    asset_dir = os.path.basename(os.path.normpath(package_dir))
+    model_xml = os.path.basename(str(mjcf_path))
+
+    # Prefer a scene file (ground + lights) when the description ships one;
+    # otherwise fall back to the bare model so rendering still has something.
+    scene_xml = model_xml
+    for candidate in _SCENE_CANDIDATES:
+        if os.path.exists(os.path.join(package_dir, candidate)):
+            scene_xml = candidate
+            break
+
+    entry: dict[str, Any] = {
+        "description": f"{norm} (discovered via robot_descriptions:{module_name})",
+        "category": "discovered",
+        "discovered": True,
+        "asset": {
+            "dir": asset_dir,
+            "model_xml": model_xml,
+            "scene_xml": scene_xml,
+            "robot_descriptions_module": module_name,
+        },
+    }
+    _DISCOVER_CACHE[norm] = entry
+    return entry
+
+
+def invalidate_cache() -> None:
+    """Clear the discovery caches (synthesized entries + module table)."""
+    _DISCOVER_CACHE.clear()
+    # ``_mjcf_modules`` is normally an ``lru_cache``; guard ``cache_clear`` so a
+    # test (or future refactor) that swaps in a plain callable cannot break this.
+    clear = getattr(_mjcf_modules, "cache_clear", None)
+    if clear is not None:
+        clear()

--- a/strands_robots/robot.py
+++ b/strands_robots/robot.py
@@ -43,6 +43,7 @@ from strands_robots.registry import (
     get_robot,
     has_hardware,
     has_sim,
+    is_discoverable,
     resolve_name,
 )
 
@@ -124,10 +125,16 @@ def _validate_known_robot(canonical: str, original: str, urdf_path: str | None) 
         raise ValueError(
             f"Invalid robot name {original!r}. Pass a registered name (see ``list_robots()``) or supply ``urdf_path=``."
         )
-    if get_robot(canonical) is None and not (has_sim(canonical) or has_hardware(canonical)):
+    if (
+        get_robot(canonical) is None
+        and not (has_sim(canonical) or has_hardware(canonical))
+        and not is_discoverable(canonical)
+    ):
         raise ValueError(
             f"Unknown robot {original!r} (resolved to {canonical!r}). "
-            "Pass a registered name (see ``list_robots()``) or supply ``urdf_path=``."
+            "Pass a registered name (see ``list_robots()``), one of the "
+            "``robot_descriptions`` robots (see ``list_discoverable()``), "
+            "or supply ``urdf_path=``."
         )
 
 

--- a/tests/registry/test_discovery.py
+++ b/tests/registry/test_discovery.py
@@ -1,0 +1,244 @@
+"""Tests for ``robot_descriptions`` auto-discovery of the standard robot long tail.
+
+The curated ``robots.json`` carries only robots that need project-specific
+metadata. Standard MJCF robots shipped by ``robot_descriptions`` (MuJoCo
+Menagerie) are resolved on demand by ``strands_robots.registry.discovery`` so
+``Robot("iiwa14", mode="sim")`` works without a hand-written registry entry.
+
+These tests exercise observable behavior:
+    - the cheap name -> module lookup (``descriptions_module`` / ``is_discoverable``
+      / ``list_discoverable``) against the real description table,
+    - the heavy entry synthesis (``discover_robot``) with a stubbed import so the
+      synthesis logic is verified without any network clone,
+    - that a curated entry always wins over discovery in the asset resolver,
+    - that the ``Robot`` factory accepts a discoverable name.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import strands_robots.assets.manager as manager
+from strands_robots.registry import discovery
+from strands_robots.registry.user_registry import register_robot
+
+_MINIMAL_MJCF = '<mujoco><worldbody><body><geom size="0.1"/></body></worldbody></mujoco>'
+
+
+@pytest.fixture(autouse=True)
+def _clear_discovery_cache():
+    """Reset discovery caches around every test so synthesized entries don't leak."""
+    discovery.invalidate_cache()
+    yield
+    discovery.invalidate_cache()
+
+
+# Cheap lookup surface (real description table)
+
+
+def test_descriptions_module_resolves_long_tail_robot() -> None:
+    pytest.importorskip("robot_descriptions")
+    # iiwa14 is an MJCF Menagerie robot that is NOT in the curated robots.json.
+    assert discovery.descriptions_module("iiwa14") == "iiwa14_mj_description"
+
+
+def test_descriptions_module_normalizes_dashes_and_case() -> None:
+    pytest.importorskip("robot_descriptions")
+    assert discovery.descriptions_module("IIWA14") == "iiwa14_mj_description"
+
+
+def test_descriptions_module_rejects_traversal_names() -> None:
+    # Names with path/dot/slash chars must never reach importlib.
+    assert discovery.descriptions_module("../evil") is None
+    assert discovery.descriptions_module("robot_descriptions.os") is None
+
+
+def test_descriptions_module_unknown_returns_none() -> None:
+    assert discovery.descriptions_module("definitely_not_a_robot_xyz") is None
+
+
+def test_is_discoverable_true_for_menagerie_robot() -> None:
+    pytest.importorskip("robot_descriptions")
+    assert discovery.is_discoverable("iiwa14") is True
+
+
+def test_is_discoverable_false_for_unknown() -> None:
+    assert discovery.is_discoverable("definitely_not_a_robot_xyz") is False
+
+
+def test_list_discoverable_is_sorted_and_contains_known_robots() -> None:
+    pytest.importorskip("robot_descriptions")
+    names = discovery.list_discoverable()
+    assert names == sorted(names)
+    # A representative sample of MJCF Menagerie robots.
+    for expected in ("iiwa14", "go2", "h1", "cassie"):
+        assert expected in names
+
+
+# Entry synthesis (stubbed import - no network)
+
+
+def _install_stub_description(monkeypatch, tmp_path, *, with_scene: bool) -> Path:
+    """Wire discovery to a fake MJCF description rooted at *tmp_path*.
+
+    Returns the package directory containing the synthesized model files.
+    """
+    pkg_dir = tmp_path / "fakebot_pkg"
+    pkg_dir.mkdir()
+    (pkg_dir / "fakebot.xml").write_text(_MINIMAL_MJCF)
+    if with_scene:
+        (pkg_dir / "scene.xml").write_text(_MINIMAL_MJCF)
+
+    monkeypatch.setattr(
+        discovery,
+        "_mjcf_modules",
+        lambda: {"fakebot": "fakebot_mj_description"},
+    )
+
+    stub = SimpleNamespace(
+        MJCF_PATH=str(pkg_dir / "fakebot.xml"),
+        PACKAGE_PATH=str(pkg_dir),
+    )
+
+    def _fake_import(modpath: str):
+        if modpath == "robot_descriptions.fakebot_mj_description":
+            return stub
+        raise ImportError(modpath)
+
+    monkeypatch.setattr(discovery.importlib, "import_module", _fake_import)
+    return pkg_dir
+
+
+def test_discover_robot_synthesizes_entry_with_scene(monkeypatch, tmp_path) -> None:
+    _install_stub_description(monkeypatch, tmp_path, with_scene=True)
+    entry = discovery.discover_robot("fakebot")
+    assert entry is not None
+    assert entry["discovered"] is True
+    assert entry["category"] == "discovered"
+    asset = entry["asset"]
+    assert asset["dir"] == "fakebot_pkg"
+    assert asset["model_xml"] == "fakebot.xml"
+    assert asset["scene_xml"] == "scene.xml"
+    assert asset["robot_descriptions_module"] == "fakebot_mj_description"
+
+
+def test_discover_robot_falls_back_to_model_xml_without_scene(monkeypatch, tmp_path) -> None:
+    _install_stub_description(monkeypatch, tmp_path, with_scene=False)
+    entry = discovery.discover_robot("fakebot")
+    assert entry is not None
+    # No scene.xml shipped -> scene_xml falls back to the bare model.
+    assert entry["asset"]["scene_xml"] == "fakebot.xml"
+
+
+def test_discover_robot_returns_none_for_non_description(monkeypatch) -> None:
+    monkeypatch.setattr(discovery, "_mjcf_modules", dict)
+
+    def _explode(modpath: str):
+        raise AssertionError(f"import_module must not be called for {modpath!r}")
+
+    monkeypatch.setattr(discovery.importlib, "import_module", _explode)
+    assert discovery.discover_robot("definitely_not_a_robot_xyz") is None
+
+
+def test_discover_robot_handles_module_without_paths(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(discovery, "_mjcf_modules", lambda: {"fakebot": "fakebot_mj_description"})
+    monkeypatch.setattr(
+        discovery.importlib,
+        "import_module",
+        lambda modpath: SimpleNamespace(),  # no MJCF_PATH / PACKAGE_PATH
+    )
+    assert discovery.discover_robot("fakebot") is None
+
+
+# Resolver integration: curated wins, discovery fills the gap
+
+
+def test_curated_entry_wins_over_discovery(monkeypatch, tmp_path) -> None:
+    """A robots.json / user-registered entry must take precedence over discovery."""
+    assets_dir = tmp_path / "assets"
+    robot_dir = assets_dir / "curated_dir"
+    robot_dir.mkdir(parents=True)
+    (robot_dir / "curated.xml").write_text(_MINIMAL_MJCF)
+    monkeypatch.setenv("STRANDS_BASE_DIR", str(tmp_path))
+    monkeypatch.setenv("STRANDS_ASSETS_DIR", str(assets_dir))
+
+    register_robot(
+        name="dualbot",
+        model_xml="curated.xml",
+        description="curated dualbot",
+        category="arm",
+        joints=6,
+        asset_dir="curated_dir",
+        overwrite=True,
+    )
+
+    def _discovery_must_not_run(name: str):
+        raise AssertionError("discover_robot must not be consulted when curated entry exists")
+
+    monkeypatch.setattr("strands_robots.registry.discovery.discover_robot", _discovery_must_not_run)
+
+    resolved = manager.resolve_model_path("dualbot")
+    assert resolved is not None
+    assert resolved.name == "curated.xml"
+
+
+def test_resolve_model_path_uses_discovery_for_uncurated_robot(monkeypatch, tmp_path) -> None:
+    """When a name is unknown to the curated registry, the discovered asset resolves."""
+    assets_dir = tmp_path / "assets"
+    disc_dir = assets_dir / "discbot_pkg"
+    disc_dir.mkdir(parents=True)
+    (disc_dir / "discbot.xml").write_text(_MINIMAL_MJCF)
+    monkeypatch.setenv("STRANDS_BASE_DIR", str(tmp_path))
+    monkeypatch.setenv("STRANDS_ASSETS_DIR", str(assets_dir))
+    manager._MESH_CACHE.clear()
+
+    synth = {
+        "description": "discbot (discovered)",
+        "category": "discovered",
+        "discovered": True,
+        "asset": {
+            "dir": "discbot_pkg",
+            "model_xml": "discbot.xml",
+            "scene_xml": "discbot.xml",
+            "robot_descriptions_module": "discbot_mj_description",
+        },
+    }
+    monkeypatch.setattr(
+        "strands_robots.registry.discovery.discover_robot",
+        lambda name: synth if name == "discbot" else None,
+    )
+
+    resolved = manager.resolve_model_path("discbot")
+    assert resolved is not None
+    assert resolved.name == "discbot.xml"
+
+
+# Robot factory validation
+
+
+def test_robot_factory_accepts_discoverable_name(monkeypatch) -> None:
+    """``_validate_known_robot`` must not reject a robot_descriptions robot."""
+    from strands_robots.robot import _validate_known_robot
+
+    monkeypatch.setattr("strands_robots.robot.get_robot", lambda name: None)
+    monkeypatch.setattr("strands_robots.robot.has_sim", lambda name: False)
+    monkeypatch.setattr("strands_robots.robot.has_hardware", lambda name: False)
+    monkeypatch.setattr("strands_robots.robot.is_discoverable", lambda name: True)
+
+    # Should not raise.
+    _validate_known_robot("iiwa14", "iiwa14", None)
+
+
+def test_robot_factory_rejects_truly_unknown_name(monkeypatch) -> None:
+    from strands_robots.robot import _validate_known_robot
+
+    monkeypatch.setattr("strands_robots.robot.get_robot", lambda name: None)
+    monkeypatch.setattr("strands_robots.robot.has_sim", lambda name: False)
+    monkeypatch.setattr("strands_robots.robot.has_hardware", lambda name: False)
+    monkeypatch.setattr("strands_robots.robot.is_discoverable", lambda name: False)
+
+    with pytest.raises(ValueError, match="Unknown robot"):
+        _validate_known_robot("bogus", "bogus", None)


### PR DESCRIPTION
## Problem

A standard MJCF robot shipped by [`robot_descriptions`](https://github.com/robot-descriptions/robot_descriptions.py) cannot be loaded in the MuJoCo backend unless it is also re-declared in the curated `registry/robots.json`, even though `robot_descriptions` already resolves its assets canonically. So the long tail (`iiwa14`, `gen3`, `viper`, `widow`, `so_arm101`, `mujoco_humanoid`, ...) is unreachable without a registry edit, and `Robot("iiwa14")` raises `Unknown robot`.

## Change

Add a discovery layer that resolves any MJCF-capable `robot_descriptions` robot on demand, with **no `robots.json` entry required**. The curated registry stays the single place for robots that need project-specific metadata (joint maps, hardware ports, aliases, scene/mesh overrides); discovery only fills the gap for names the curated registry does not know.

New `strands_robots/registry/discovery.py`:
- `descriptions_module(name)`, `is_discoverable(name)`, `list_discoverable()` - cheap lookups against the static `robot_descriptions` description table (no module import, no network).
- `discover_robot(name)` - synthesizes a registry-shaped entry from a description module's `MJCF_PATH` / `PACKAGE_PATH` (dir, model_xml, scene_xml, robot_descriptions_module), so the existing asset-download + resolution pipeline handles it unchanged. This is the only heavy call (it imports the module, which can trigger the upstream asset clone), so it is consulted only by the download-capable asset resolver.

Wiring:
- `assets/manager.py` `resolve_model_path` / `resolve_model_dir` / `get_robot_info` fall back to discovery on a curated miss (a curated entry always wins).
- `robot.py` `_validate_known_robot` accepts a discoverable name instead of raising `Unknown robot`.
- `is_discoverable` / `list_discoverable` re-exported from `strands_robots` and `strands_robots.registry`.

```python
from strands_robots import Robot, list_discoverable

sim = Robot("iiwa14")          # discovered, not in robots.json
print(list_discoverable())     # the MJCF long tail you can load directly
```

### Why not shrink `robots.json`?

The curated entries carry metadata `robot_descriptions` does not provide - `joints`, `category`, `aliases`, `hardware` (LeRobot type/port), `scene_xml`, descriptions - which `list_robots()`, `format_robot_table()`, hardware resolution, and teleop all depend on. Removing them would lose information and break those surfaces. This PR keeps the curated catalog intact and makes the *long tail* zero-config instead, which is the part that actually carried maintenance drag. For reference, of the 57 MJCF-capable descriptions, 49 are already curated; the remaining 8 (`gen3`, `iiwa14`, `mujoco_humanoid`, `n1`, `openarm_v1`, `so_arm101`, `viper`, `widow`) plus any future additions now resolve with no edit.

## Tests

New `tests/registry/test_discovery.py` (fails pre-fix - the module did not exist and the factory rejected discoverable names):
- cheap-lookup surface (`descriptions_module` / `is_discoverable` / `list_discoverable`), including name-allowlist rejection of traversal-ish inputs;
- hermetic entry synthesis with a stubbed import (no network), incl. scene fallback and missing-path handling;
- curated entry wins over discovery in `resolve_model_path`;
- resolver fallback resolves an uncurated robot;
- `Robot()` factory accepts a discoverable name, still rejects truly unknown names.

Gate: `ruff check` + `ruff format --check` + `mypy` clean on `strands_robots tests tests_integ`; `tests/registry/`, `test_asset_manager`, `test_asset_download`, `test_robot_factory`, `test_registry*`, `test_model_registry` all pass (726+).

## Visual proof (MuJoCo, headless EGL)

`iiwa14` - a robot **not** in `robots.json` - loaded purely via discovery, rendered + stepped through a mock-policy rollout (90 steps):

![iiwa14 discovered render](https://github.com/cagataycali/robots/releases/download/discovery-artifacts/iiwa14_discovered.png)

![iiwa14 rollout](https://github.com/cagataycali/robots/releases/download/discovery-artifacts/iiwa14_rollout.gif)

MP4: https://github.com/cagataycali/robots/releases/download/discovery-artifacts/iiwa14_rollout.mp4

## Docs

README gains an "Adding a robot" section (zero-config discovery vs. curated/registered) and a CHANGELOG entry under Unreleased.