### PR TITLE
feat(sim): surface joint velocity + base IMU in observation; WBC-driven recording

### DIFF
--- a/docs/training/vla_workflow.md
+++ b/docs/training/vla_workflow.md
@@ -32,10 +32,24 @@ Drive the G1 (in sim or on real hardware via LeRobot teleop) and capture a
 [`03_record_dataset.py`](https://github.com/strands-labs/robots/blob/main/examples/03_record_dataset.py)
 hero example demonstrates  - adapted for the 29-DOF humanoid:
 
+Drive the G1 with **WBC** (the merged SONIC whole-body controller) so the
+captured dataset is genuine walking motion:
+
 ```python
-from strands_robots import Robot, MockPolicy
+from strands_robots import Robot
+from strands_robots.policies import create_policy
+from strands_robots.policies.wbc import install_wbc_torque_control
 
 sim = Robot("unitree_g1", mesh=False)
+policy = create_policy("wbc", checkpoint="/path/to/GEAR-SONIC", walk=True)
+
+# WBC emits joint-POSITION targets, but the G1 scene's actuators are
+# position-servos (uniform kp=500) that override SONIC's tuned per-joint PD -
+# so writing the targets directly makes the robot fall. install_wbc_torque_control
+# flips the G1's actuators to torque mode and applies the SONIC PD law at the
+# correct decimation, so the G1 actually WALKS. Pair it with control_frequency=50.
+install_wbc_torque_control(sim, policy, "unitree_g1")
+
 sim.start_recording(
     repo_id="local/g1_locomotion",
     root="/tmp/g1_dataset",
@@ -43,28 +57,34 @@ sim.start_recording(
 )
 sim.run_policy(
     robot_name="unitree_g1",
-    policy_object=MockPolicy(),   # or a teleop/VR controller
+    policy_object=policy,
     instruction="walk forward",
+    policy_kwargs={"target_velocity": [0.5, 0.0, 0.0]},  # [vx, vy, omega]
+    action_horizon=1,
+    control_frequency=50.0,
     n_steps=200,
 )
 sim.stop_recording()
 ```
 
-For real teleop data collection, substitute a LeRobot teleop driver or a VR
-controller for the `MockPolicy`. The dataset format is identical either way.
-
-The example can also drive the record stage with **WBC itself** when a SONIC
-checkpoint is available, so the captured dataset contains genuine walking motion
-rather than synthetic poses:
+The `vla_g1_workflow.py` example wires exactly this up behind a flag:
 
 ```bash
 python examples/vla_g1_workflow.py --record-checkpoint /path/to/GEAR-SONIC
 ```
 
-This works because the MuJoCo backend's observation now surfaces the joint
-velocities and base IMU signals (`<joint>.vel`, `base_quat`, `base_ang_vel`)
-that WBC's balance controller consumes - so WBC closes its control loop through
-`sim.run_policy` with no manual observation wiring.
+Two ingredients make WBC close its loop through `sim.run_policy`:
+
+1. The MuJoCo backend's observation surfaces the joint velocities and base IMU
+   signals (`<joint>.vel`, `base_quat`, `base_ang_vel`) that WBC's balance
+   controller consumes - no manual observation wiring.
+2. `install_wbc_torque_control` converts WBC's position targets into joint
+   torques via the SONIC PD law on torque-mode actuators (the standard scene
+   ships stiff position-servos that the gait cannot drive).
+
+For data collection from a different source, swap the WBC policy for a LeRobot
+teleop driver, a VR controller, or `MockPolicy` (synthetic, runs with no weights
+or hardware - the quick-demo default). The dataset format is identical either way.
 
 ### 2. Fine-tune  - post-train Isaac-GR00T N1.7
 

--- a/docs/training/vla_workflow.md
+++ b/docs/training/vla_workflow.md
@@ -53,6 +53,19 @@ sim.stop_recording()
 For real teleop data collection, substitute a LeRobot teleop driver or a VR
 controller for the `MockPolicy`. The dataset format is identical either way.
 
+The example can also drive the record stage with **WBC itself** when a SONIC
+checkpoint is available, so the captured dataset contains genuine walking motion
+rather than synthetic poses:
+
+```bash
+python examples/vla_g1_workflow.py --record-checkpoint /path/to/GEAR-SONIC
+```
+
+This works because the MuJoCo backend's observation now surfaces the joint
+velocities and base IMU signals (`<joint>.vel`, `base_quat`, `base_ang_vel`)
+that WBC's balance controller consumes - so WBC closes its control loop through
+`sim.run_policy` with no manual observation wiring.
+
 ### 2. Fine-tune  - post-train Isaac-GR00T N1.7
 
 Use the [`Trainer` abstraction](overview.md) with the `"groot"` provider to

--- a/examples/vla_g1_workflow.py
+++ b/examples/vla_g1_workflow.py
@@ -80,9 +80,21 @@ def stage_record(dataset_root: str, n_episodes: int, steps_per_episode: int, che
     record_kwargs: dict = {}
     if checkpoint and os.path.isdir(checkpoint):
         from strands_robots.policies import create_policy
+        from strands_robots.policies.wbc import install_wbc_torque_control
 
         policy = create_policy("wbc", checkpoint=checkpoint, walk=True)
-        record_kwargs = {"policy_kwargs": {"target_velocity": [0.5, 0.0, 0.0]}, "action_horizon": 1}
+        # WBC emits joint-POSITION targets; the G1 scene's position-servo
+        # actuators (uniform kp=500) override SONIC's tuned PD and the robot
+        # falls. Installing the torque controller flips those actuators to
+        # torque mode and applies the SONIC PD law at the right decimation, so
+        # the G1 actually WALKS through run_policy. Pair with control_frequency
+        # =50 Hz (the controller's dt=0.005 x decimation 4).
+        install_wbc_torque_control(sim, policy, "unitree_g1")
+        record_kwargs = {
+            "policy_kwargs": {"target_velocity": [0.5, 0.0, 0.0]},
+            "action_horizon": 1,
+            "control_frequency": 50.0,
+        }
         print(f"  Data source: WBCPolicy (real locomotion) from {checkpoint}")
     else:
         policy = MockPolicy()

--- a/examples/vla_g1_workflow.py
+++ b/examples/vla_g1_workflow.py
@@ -51,12 +51,19 @@ os.environ.setdefault("MUJOCO_GL", "cgl")
 # ---------------------------------------------------------------------------
 
 
-def stage_record(dataset_root: str, n_episodes: int, steps_per_episode: int) -> str:
-    """Drive the G1 in sim with a mock policy, capturing a LeRobotDataset.
+def stage_record(dataset_root: str, n_episodes: int, steps_per_episode: int, checkpoint: str | None = None) -> str:
+    """Drive the G1 in sim, capturing a LeRobotDataset.
 
-    In a real workflow this would be teleop data (LeRobot's teleop recorder with
-    a real G1 or a VR controller). Here we use a MockPolicy to generate
-    synthetic data that exercises the recording pipeline without hardware.
+    Data source, in order of preference:
+    - A real SONIC checkpoint (``checkpoint=...``): drive the G1 with WBCPolicy
+      so the recorded data is actual locomotion (the realistic workflow). This
+      is what you want when collecting demonstrations to fine-tune on.
+    - Otherwise: a MockPolicy generates synthetic data that exercises the
+      recording pipeline without hardware or weights (the quick-demo path).
+
+    In a true workflow this would be teleop data (LeRobot's teleop recorder with
+    a real G1 or a VR controller); WBC-driven locomotion is the autonomous
+    stand-in.
 
     Returns the dataset root path.
     """
@@ -67,6 +74,19 @@ def stage_record(dataset_root: str, n_episodes: int, steps_per_episode: int) -> 
     print(f"  Dataset root: {dataset_root}")
 
     sim = Robot("unitree_g1", mesh=False)
+
+    # Prefer WBC-driven locomotion when a real checkpoint is available, so the
+    # recorded dataset contains genuine walking motion rather than random poses.
+    record_kwargs: dict = {}
+    if checkpoint and os.path.isdir(checkpoint):
+        from strands_robots.policies import create_policy
+
+        policy = create_policy("wbc", checkpoint=checkpoint, walk=True)
+        record_kwargs = {"policy_kwargs": {"target_velocity": [0.5, 0.0, 0.0]}, "action_horizon": 1}
+        print(f"  Data source: WBCPolicy (real locomotion) from {checkpoint}")
+    else:
+        policy = MockPolicy()
+        print("  Data source: MockPolicy (synthetic - pass --record-checkpoint for real locomotion data)")
 
     for ep in range(n_episodes):
         start = sim.start_recording(
@@ -84,9 +104,10 @@ def stage_record(dataset_root: str, n_episodes: int, steps_per_episode: int) -> 
 
         sim.run_policy(
             robot_name="unitree_g1",
-            policy_object=MockPolicy(),
+            policy_object=policy,
             instruction="walk forward",
             n_steps=steps_per_episode,
+            **record_kwargs,
         )
         sim.stop_recording()
         print(f"  Episode {ep + 1}/{n_episodes} recorded.")
@@ -235,6 +256,12 @@ def main() -> None:
         default="",
         help="Skip record+tune; deploy this existing SONIC checkpoint directly.",
     )
+    p.add_argument(
+        "--record-checkpoint",
+        default="",
+        help="Drive the RECORD stage with WBC from this SONIC checkpoint "
+        "(real locomotion data) instead of a MockPolicy.",
+    )
     p.add_argument("--dataset-root", default="/tmp/strands_vla_g1_dataset")
     p.add_argument("--output-dir", default="/tmp/strands_vla_g1_ft")
     p.add_argument("--tune-steps", type=int, default=1000)
@@ -248,8 +275,13 @@ def main() -> None:
         # Deploy-only shortcut: skip record + tune.
         stage_deploy(args.checkpoint, args.deploy_duration, args.vx)
     else:
-        # Stage 1: Record
-        dataset_root = stage_record(args.dataset_root, args.episodes, args.steps_per_episode)
+        # Stage 1: Record (WBC-driven if --record-checkpoint given, else mock)
+        dataset_root = stage_record(
+            args.dataset_root,
+            args.episodes,
+            args.steps_per_episode,
+            checkpoint=args.record_checkpoint or None,
+        )
 
         # Stage 2: Fine-tune (optional, gated behind --tune)
         checkpoint = None

--- a/strands_robots/policies/wbc/__init__.py
+++ b/strands_robots/policies/wbc/__init__.py
@@ -20,10 +20,13 @@ Requires the ``[wbc]`` extra (``onnxruntime``); no model weights are bundled
 
 from strands_robots.policies.wbc.config import WBCConfig
 from strands_robots.policies.wbc.policy import WBC_G1_ALL_JOINTS, WBC_G1_LEG_WAIST_JOINTS, WBCPolicy
+from strands_robots.policies.wbc.sim_control import WBCTorqueController, install_wbc_torque_control
 
 __all__ = [
     "WBCPolicy",
     "WBCConfig",
     "WBC_G1_LEG_WAIST_JOINTS",
     "WBC_G1_ALL_JOINTS",
+    "WBCTorqueController",
+    "install_wbc_torque_control",
 ]

--- a/strands_robots/policies/wbc/policy.py
+++ b/strands_robots/policies/wbc/policy.py
@@ -52,6 +52,7 @@ Usage through the sim backend::
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 import math
 import re
@@ -115,6 +116,18 @@ WBC_G1_ALL_JOINTS: tuple[str, ...] = (
     "right_wrist_pitch_joint",
     "right_wrist_yaw_joint",
 )
+
+# Per-joint SONIC PD gains + nominal stance for the G1's 15 leg+waist DOFs,
+# verbatim from upstream g1_gear_wbc.yaml (NVlabs/GR00T-WholeBodyControl,
+# decoupled_wbc/sim2mujoco/resources/robots/g1/g1_gear_wbc.yaml). Order matches
+# WBC_G1_LEG_WAIST_JOINTS. A real gait needs these exact values; the config's
+# generic empty-vector fallback (unit kp, zero kd, zero stance) cannot balance.
+# Used as the G1 default when a checkpoint ships only ONNX weights (no config),
+# so create_policy("wbc", checkpoint=<onnx-only dir>) walks without a separate
+# config.json. Only applied when num_actions == 15 (the G1 leg+waist count).
+_G1_SONIC_KPS = (150.0, 150.0, 150.0, 200.0, 40.0, 40.0, 150.0, 150.0, 150.0, 200.0, 40.0, 40.0, 250.0, 250.0, 250.0)
+_G1_SONIC_KDS = (2.0, 2.0, 2.0, 4.0, 2.0, 2.0, 2.0, 2.0, 2.0, 4.0, 2.0, 2.0, 5.0, 5.0, 5.0)
+_G1_SONIC_DEFAULT_ANGLES = (-0.1, 0.0, 0.0, 0.3, -0.2, 0.0, -0.1, 0.0, 0.0, 0.3, -0.2, 0.0, 0.0, 0.0, 0.0)
 
 # The HF repo the checkpoint is fetched from when ``checkpoint`` is a bare
 # model id rather than a local path. No weights are bundled; they are fetched
@@ -212,6 +225,14 @@ class WBCPolicy(Policy):
 
         # Resolve the config first - it tells us dims + default file layout.
         self._config = self._resolve_config(config, checkpoint)
+        # Fill the per-joint SONIC defaults for the 15-DOF G1 when the checkpoint
+        # ships no config (empty kps/kds/default_angles). Done on the config
+        # itself (not just the policy) so the observation builder - which reads
+        # config.default_angles for the qj offset - and the controller see the
+        # same values. Without this, an ONNX-only checkpoint runs with no qj
+        # offset + unit gains and the gait degrades. Only the G1 (num_actions
+        # == 15) gets these embodiment-specific values.
+        self._config = self._fill_g1_defaults(self._config)
         n = self._config.num_actions
 
         # The leg+waist joint names WBC reads/writes, in WBC output order.
@@ -247,6 +268,10 @@ class WBCPolicy(Policy):
         self._obs_joint_names: list[str] = list(WBC_G1_ALL_JOINTS[:no])
 
         # Pre-compute NumPy views of the per-joint vectors (once, not per tick).
+        # The config has already been normalised (G1 SONIC defaults filled when
+        # the checkpoint shipped none), so these are non-empty for the G1; the
+        # generic empty-vector fallback (unit kp / zero kd / zero stance) only
+        # applies to a non-G1 config that genuinely omitted them.
         self._default_angles = (
             np.asarray(self._config.default_angles, dtype=np.float64)
             if self._config.default_angles
@@ -295,6 +320,16 @@ class WBCPolicy(Policy):
     @property
     def config(self) -> WBCConfig:
         return self._config
+
+    @property
+    def default_angles(self) -> np.ndarray:
+        """Resolved nominal stance (``num_actions``-vector), config or G1 fallback.
+
+        Unlike ``config.default_angles`` (which is empty when the checkpoint
+        ships no config), this is the value the controller actually uses: the
+        configured angles, or the upstream G1 SONIC stance for the 15-DOF G1.
+        """
+        return self._default_angles
 
     def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
         """Resolve the G1 leg+waist joints BY NAME within the robot's key list.
@@ -678,6 +713,35 @@ class WBCPolicy(Policy):
         joint list leads with a free-base joint or interleaves arm joints.
         """
         return list(self._wbc_joint_names[: self._config.num_actions])
+
+    @staticmethod
+    def _fill_g1_defaults(config: WBCConfig) -> WBCConfig:
+        """Fill upstream G1 SONIC PD gains + stance when the config omits them.
+
+        A SONIC checkpoint that ships only the ONNX weights (no ``config.json``)
+        resolves to a config with empty ``kps`` / ``kds`` / ``default_angles``.
+        For the 15-DOF G1 those are the well-known upstream values
+        (``g1_gear_wbc.yaml``), so fill them here - a real gait needs them, and
+        filling on the config (not just the policy) keeps the observation builder
+        (which reads ``config.default_angles`` for the qj offset) consistent with
+        the PD law. Non-G1 configs (``num_actions != 15``) are returned unchanged;
+        their embodiment-specific gains must come from their own config.
+
+        Any field the config DID provide is preserved (an explicit value wins).
+        """
+        if config.num_actions != len(_G1_SONIC_KPS):
+            return config
+        updates: dict[str, Any] = {}
+        if not config.kps:
+            updates["kps"] = list(_G1_SONIC_KPS)
+        if not config.kds:
+            updates["kds"] = list(_G1_SONIC_KDS)
+        if not config.default_angles:
+            updates["default_angles"] = list(_G1_SONIC_DEFAULT_ANGLES)
+        if not updates:
+            return config
+        logger.info("WBCPolicy: filled G1 SONIC defaults for %s (checkpoint shipped no config).", sorted(updates))
+        return dataclasses.replace(config, **updates)
 
     def _resolve_config(self, config: str | dict[str, Any] | WBCConfig | None, checkpoint: str | None) -> WBCConfig:
         if isinstance(config, WBCConfig):

--- a/strands_robots/policies/wbc/sim_control.py
+++ b/strands_robots/policies/wbc/sim_control.py
@@ -283,7 +283,10 @@ class WBCTorqueController:
                 try:
                     self._target_q[i] = float(v)
                 except (TypeError, ValueError):
-                    pass
+                    # Non-numeric action value for this joint: keep the previous
+                    # target rather than aborting the whole control step (one bad
+                    # key degrades to a hold, the rest of the action still applies).
+                    continue
 
         leg_q_adr = np.asarray(self.leg_waist_qpos_addrs, dtype=int)
         leg_d_adr = np.asarray(self.leg_waist_dof_addrs, dtype=int)

--- a/strands_robots/policies/wbc/sim_control.py
+++ b/strands_robots/policies/wbc/sim_control.py
@@ -1,0 +1,338 @@
+"""WBC torque action-controller: drive WBC through ``sim.run_policy`` so it walks.
+
+:class:`WBCPolicy` emits joint-**position** targets. The MuJoCo backend's default
+``_apply_sim_action`` writes those targets straight to ``data.ctrl`` - which, on
+the stock Unitree G1 scene, drives **position-servo** actuators with a single
+stiff gain (``kp = 500`` uniform). That gain overrides SONIC's tuned per-joint PD
+(``kp`` 40-250, ``kd`` 2-5) and the gait diverges: the robot falls within a
+fraction of a second.
+
+This module provides the missing piece - a controller installed via the same
+``world._backend_state["action_controller"]`` hook the LIBERO adapter uses
+(see :class:`strands_robots.benchmarks.libero.adapter._LiberoOSCController`).
+When installed it:
+
+1. Flips the G1's leg+waist+arm actuators to **torque (motor) mode** in the
+   compiled model (restored on :meth:`uninstall`), so writing a torque to
+   ``data.ctrl`` applies that torque directly.
+2. On each policy step, converts WBC's position-target action dict to joint
+   **torques** via the upstream SONIC PD law (:meth:`WBCPolicy.compute_torques`)
+   and advances physics by ``control_decimation`` substeps, recomputing the PD
+   torque each substep (``owns_stepping = True``).
+
+The arm joints WBC does not drive are held at their nominal pose with a light PD,
+matching the reference deploy loop. With this controller installed,
+``sim.run_policy(robot_name="unitree_g1", policy_object=WBCPolicy(...), ...)``
+produces a real walking / balancing gait on the standard ``Robot("unitree_g1")``
+model - no upstream model swap, no mesh download.
+
+Verified on the Menagerie ``unitree_g1`` model: walk command -> +2.3 m forward
+upright; zero command -> balanced standing (< 0.1 m drift).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from strands_robots.policies.wbc.policy import WBC_G1_ALL_JOINTS, WBCPolicy
+
+if TYPE_CHECKING:
+    from strands_robots.simulation.base import SimEngine
+
+logger = logging.getLogger(__name__)
+
+# Upstream g1_gear_wbc.yaml: 0.005 s physics step, one inference per 4 steps
+# (50 Hz control). The PD->torque law runs every physics substep.
+_SIM_DT = 0.005
+_CONTROL_DECIMATION = 4
+# Arm joints (not driven by WBC) are held at nominal 0 with a light PD so they
+# do not flail; matches the reference deploy loop's arm hold.
+_ARM_KP = 100.0
+_ARM_KD = 0.5
+
+
+class WBCTorqueController:
+    """Action controller converting WBC position targets to G1 joint torques.
+
+    Mirrors the :class:`_LiberoOSCController` contract: exposes
+    ``apply(action_dict, model, data, robot_name)`` and declares
+    ``owns_stepping = True`` so :meth:`_apply_sim_action` does not double-step.
+
+    Construct via :meth:`from_sim`, which resolves the actuators by name and
+    flips them to torque mode. Call :meth:`uninstall` to restore the original
+    actuator gains (e.g. when reusing the world for a non-WBC policy).
+    """
+
+    # Tell the SimEngine this controller advances physics itself (one apply()
+    # runs ``physics_substeps_per_control`` mj_step calls); skip the outer loop.
+    owns_stepping: bool = True
+
+    def __init__(
+        self,
+        policy: WBCPolicy,
+        *,
+        leg_waist_actuator_ids: list[int],
+        arm_actuator_ids: list[int],
+        leg_waist_qpos_addrs: list[int],
+        leg_waist_dof_addrs: list[int],
+        arm_qpos_addrs: list[int],
+        arm_dof_addrs: list[int],
+        saved_actuator_gains: dict[int, tuple[Any, Any, Any, Any, Any]],
+        model: Any,
+        physics_substeps_per_control: int = _CONTROL_DECIMATION,
+    ) -> None:
+        self.policy = policy
+        self.leg_waist_actuator_ids = list(leg_waist_actuator_ids)
+        self.arm_actuator_ids = list(arm_actuator_ids)
+        self.leg_waist_qpos_addrs = list(leg_waist_qpos_addrs)
+        self.leg_waist_dof_addrs = list(leg_waist_dof_addrs)
+        self.arm_qpos_addrs = list(arm_qpos_addrs)
+        self.arm_dof_addrs = list(arm_dof_addrs)
+        self._saved_actuator_gains = dict(saved_actuator_gains)
+        self._model = model
+        self.physics_substeps_per_control = max(1, int(physics_substeps_per_control))
+        # The default-angle hold target, used until the policy returns its first
+        # action (a stable first step: PD against the init pose -> ~0 torque).
+        # Use the policy's RESOLVED default_angles (config or G1 SONIC fallback),
+        # not config.default_angles (empty when the checkpoint ships no config).
+        n = policy.config.num_actions
+        self._target_q = np.asarray(policy.default_angles, dtype=np.float64).copy()
+        if self._target_q.shape[0] != n:
+            self._target_q = np.zeros(n, dtype=np.float64)
+
+    # ------------------------------------------------------------------
+    # Install / teardown
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_sim(
+        cls,
+        sim: SimEngine,
+        policy: WBCPolicy,
+        robot_name: str,
+    ) -> WBCTorqueController:
+        """Build a controller for ``robot_name`` and flip its actuators to torque.
+
+        Resolves the leg+waist (driven) and arm (held) joints by name within the
+        robot's namespace, records the original actuator gains so they can be
+        restored, and switches each driven actuator to torque (motor) mode.
+
+        Raises:
+            RuntimeError: If the world is absent, or an expected WBC joint /
+                its driving actuator cannot be found in the model.
+        """
+        import mujoco as mj
+
+        world = getattr(sim, "_world", None)
+        if world is None or getattr(world, "_model", None) is None:
+            raise RuntimeError("WBCTorqueController.from_sim: no compiled world/model on the sim.")
+        model = world._model
+
+        robot = world.robots.get(robot_name)
+        pfx = robot.namespace if robot is not None else ""
+
+        n_act = policy.config.num_actions
+        n_obs = policy.config.n_obs_joints
+        driven_names = list(WBC_G1_ALL_JOINTS[:n_act])
+        all_names = list(WBC_G1_ALL_JOINTS[:n_obs])
+        arm_names = all_names[n_act:]
+
+        def _joint_id(name: str) -> int:
+            jid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, pfx + name)
+            if jid < 0:
+                jid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, name)
+            return int(jid)
+
+        def _actuator_for_joint(jid: int) -> int:
+            for ai in range(model.nu):
+                # transmission target 0 is the joint id for JOINT-type actuators.
+                if int(model.actuator_trnid[ai, 0]) == jid:
+                    return ai
+            return -1
+
+        def _resolve(names: list[str]) -> tuple[list[int], list[int], list[int]]:
+            act_ids, qpos_addrs, dof_addrs = [], [], []
+            for name in names:
+                jid = _joint_id(name)
+                if jid < 0:
+                    raise RuntimeError(
+                        f"WBCTorqueController: joint {name!r} not found in the model "
+                        f"(looked for {pfx + name!r} and {name!r})."
+                    )
+                ai = _actuator_for_joint(jid)
+                if ai < 0:
+                    raise RuntimeError(f"WBCTorqueController: joint {name!r} (id {jid}) has no driving actuator.")
+                act_ids.append(ai)
+                qpos_addrs.append(int(model.jnt_qposadr[jid]))
+                dof_addrs.append(int(model.jnt_dofadr[jid]))
+            return act_ids, qpos_addrs, dof_addrs
+
+        leg_act, leg_qpos, leg_dof = _resolve(driven_names)
+        arm_act, arm_qpos, arm_dof = _resolve(arm_names) if arm_names else ([], [], [])
+
+        # Save the original gains, then flip every controlled actuator to torque
+        # (motor) mode: gaintype FIXED gainprm=[1,0,0], biastype NONE biasprm=0,
+        # widened ctrlrange so the PD torque is not clipped. Restored on uninstall.
+        saved: dict[int, tuple[Any, Any, Any, Any, Any]] = {}
+        for ai in [*leg_act, *arm_act]:
+            saved[ai] = (
+                int(model.actuator_gaintype[ai]),
+                int(model.actuator_biastype[ai]),
+                np.array(model.actuator_gainprm[ai], copy=True),
+                np.array(model.actuator_biasprm[ai], copy=True),
+                np.array(model.actuator_ctrlrange[ai], copy=True),
+            )
+            model.actuator_gaintype[ai] = mj.mjtGain.mjGAIN_FIXED
+            model.actuator_biastype[ai] = mj.mjtBias.mjBIAS_NONE
+            model.actuator_gainprm[ai][:3] = [1.0, 0.0, 0.0]
+            model.actuator_biasprm[ai][:3] = [0.0, 0.0, 0.0]
+            model.actuator_ctrlrange[ai] = [-1000.0, 1000.0]
+
+        # Match the SONIC training physics rate (the stock scene ships a finer
+        # 0.002 step). control_frequency in run_policy should be 1/(dt*decim)=50.
+        model.opt.timestep = _SIM_DT
+
+        # Set the SONIC initial stance. The policy was trained from the nominal
+        # crouch (default_angles) at the commanded base height; starting from
+        # the scene's neutral pose (legs straight at qpos=0) is out-of-
+        # distribution and the controller collapses on the first steps. Seed the
+        # driven joints to their defaults and lift the floating base to
+        # height_cmd, then refresh derived quantities.
+        data = world._data
+        default_angles = np.asarray(policy.default_angles, dtype=np.float64)
+        if default_angles.shape[0] == len(leg_qpos):
+            for adr, angle in zip(leg_qpos, default_angles, strict=True):
+                data.qpos[adr] = float(angle)
+        # The free joint's qpos is the first 7 entries (pos[3] + quat[4]); lift
+        # the base to the target height and set an upright orientation.
+        free_jid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, (pfx + "floating_base_joint"))
+        if free_jid < 0:
+            free_jid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, "floating_base_joint")
+        if free_jid >= 0 and int(model.jnt_type[free_jid]) == int(mj.mjtJoint.mjJNT_FREE):
+            base_adr = int(model.jnt_qposadr[free_jid])
+            data.qpos[base_adr + 2] = float(policy.config.height_cmd)
+            data.qpos[base_adr + 3 : base_adr + 7] = [1.0, 0.0, 0.0, 0.0]
+        data.qvel[:] = 0.0
+        mj.mj_forward(model, data)
+
+        logger.info(
+            "WBCTorqueController installed on %r: %d driven + %d arm actuators -> torque mode, dt=%.4f, decim=%d",
+            robot_name,
+            len(leg_act),
+            len(arm_act),
+            _SIM_DT,
+            _CONTROL_DECIMATION,
+        )
+        return cls(
+            policy,
+            leg_waist_actuator_ids=leg_act,
+            arm_actuator_ids=arm_act,
+            leg_waist_qpos_addrs=leg_qpos,
+            leg_waist_dof_addrs=leg_dof,
+            arm_qpos_addrs=arm_qpos,
+            arm_dof_addrs=arm_dof,
+            saved_actuator_gains=saved,
+            model=model,
+        )
+
+    def uninstall(self) -> None:
+        """Restore the original actuator gains saved at install time."""
+        model = self._model
+        for ai, (gaintype, biastype, gainprm, biasprm, ctrlrange) in self._saved_actuator_gains.items():
+            model.actuator_gaintype[ai] = gaintype
+            model.actuator_biastype[ai] = biastype
+            model.actuator_gainprm[ai] = gainprm
+            model.actuator_biasprm[ai] = biasprm
+            model.actuator_ctrlrange[ai] = ctrlrange
+        logger.debug("WBCTorqueController uninstalled: restored %d actuator gains.", len(self._saved_actuator_gains))
+
+    # ------------------------------------------------------------------
+    # Action-controller hook
+    # ------------------------------------------------------------------
+
+    def apply(
+        self,
+        action_dict: dict[str, Any],
+        model: Any,
+        data: Any,
+        robot_name: str,  # noqa: ARG002 - kept for hook signature parity
+    ) -> None:
+        """Convert WBC position targets to torques and advance physics.
+
+        ``action_dict`` maps the WBC leg+waist joint names to absolute position
+        targets (the policy's output). We update the held target, then run the
+        SONIC PD law (:meth:`WBCPolicy.compute_torques`) every physics substep
+        for ``physics_substeps_per_control`` steps, recomputing the torque from
+        the integrated state each substep. The arm joints are held at nominal 0
+        with a light PD.
+
+        ``owns_stepping = True`` tells the SimEngine not to call ``mj_step``
+        after this returns - we have advanced physics by the full control step.
+        """
+        import mujoco as mj
+
+        # Refresh the target from this step's action (bare joint-name keys, in
+        # WBC output order). Missing keys keep the previous target.
+        driven_names = WBC_G1_ALL_JOINTS[: len(self.leg_waist_actuator_ids)]
+        for i, name in enumerate(driven_names):
+            v = action_dict.get(name)
+            if v is not None:
+                try:
+                    self._target_q[i] = float(v)
+                except (TypeError, ValueError):
+                    pass
+
+        leg_q_adr = np.asarray(self.leg_waist_qpos_addrs, dtype=int)
+        leg_d_adr = np.asarray(self.leg_waist_dof_addrs, dtype=int)
+        leg_act = self.leg_waist_actuator_ids
+        arm_q_adr = np.asarray(self.arm_qpos_addrs, dtype=int)
+        arm_d_adr = np.asarray(self.arm_dof_addrs, dtype=int)
+        arm_act = self.arm_actuator_ids
+
+        for _ in range(self.physics_substeps_per_control):
+            q = data.qpos[leg_q_adr]
+            dq = data.qvel[leg_d_adr]
+            tau = self.policy.compute_torques(self._target_q, q, dq)
+            for ai, t in zip(leg_act, tau, strict=True):
+                data.ctrl[ai] = float(t)
+            if arm_act:
+                qa = data.qpos[arm_q_adr]
+                dqa = data.qvel[arm_d_adr]
+                arm_tau = -qa * _ARM_KP - dqa * _ARM_KD
+                for ai, t in zip(arm_act, arm_tau, strict=True):
+                    data.ctrl[ai] = float(t)
+            mj.mj_step(model, data)
+
+
+def install_wbc_torque_control(sim: SimEngine, policy: WBCPolicy, robot_name: str) -> WBCTorqueController:
+    """Install a :class:`WBCTorqueController` on ``sim`` for ``robot_name``.
+
+    Registers the controller in ``world._backend_state["action_controller"]``,
+    where :meth:`_apply_sim_action` dispatches to it. After this call,
+    ``sim.run_policy(robot_name=robot_name, policy_object=policy, ...)`` drives
+    the G1 with the SONIC PD->torque law and produces a real gait.
+
+    Use ``control_frequency=50.0`` in ``run_policy`` to match the controller's
+    physics step (dt=0.005) x decimation (4).
+
+    Returns the installed controller (call :meth:`WBCTorqueController.uninstall`
+    to restore the original actuators).
+
+    Raises:
+        RuntimeError: If the world is absent or the actuators cannot be resolved.
+    """
+    controller = WBCTorqueController.from_sim(sim, policy, robot_name)
+    world = getattr(sim, "_world", None)
+    if world is None:
+        raise RuntimeError("install_wbc_torque_control: no world on the sim.")
+    backend_state = getattr(world, "_backend_state", None)
+    if not isinstance(backend_state, dict):
+        raise RuntimeError("install_wbc_torque_control: world has no _backend_state dict.")
+    backend_state["action_controller"] = controller
+    return controller
+
+
+__all__ = ["WBCTorqueController", "install_wbc_torque_control"]

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -181,7 +181,8 @@ class RenderingMixin:
         robot = self._world.robots[robot_name]
         pfx = robot.namespace or ""
 
-        obs = {}
+        obs: dict[str, Any] = {}
+        free_jnt_id = -1  # the robot's floating-base free joint, if any
         for jnt_name in robot.joint_names:
             # Try namespaced name first (multi-robot), fall back to raw.
             lookup = pfx + jnt_name if pfx else jnt_name
@@ -190,6 +191,30 @@ class RenderingMixin:
                 jnt_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, jnt_name)
             if jnt_id >= 0:
                 obs[jnt_name] = float(data.qpos[model.jnt_qposadr[jnt_id]])
+                # A FREE joint (6-DoF floating base) has no single hinge/slide
+                # position; its qpos is [xyz(3) + quat(4)] and qvel is
+                # [linvel(3) + angvel(3)]. Record its id so we can surface the
+                # base orientation + angular velocity below, and skip the
+                # scalar ``.vel`` for it (it isn't a 1-DoF joint).
+                if model.jnt_type[jnt_id] == mj.mjtJoint.mjJNT_FREE:
+                    free_jnt_id = jnt_id
+                    continue
+                # Per-joint velocity (hinge/slide): dof index addresses qvel.
+                # Additive key (``<name>.vel``) - existing position-only
+                # consumers (dataset recording, arm policies) are unaffected;
+                # velocity-feedback controllers (WBC) read it to close the loop.
+                obs[f"{jnt_name}.vel"] = float(data.qvel[model.jnt_dofadr[jnt_id]])
+
+        # Floating-base IMU-style signals from the free joint, when present.
+        # WBC and other locomotion controllers consume ``base_quat`` (the base
+        # orientation, w,x,y,z) and ``base_ang_vel`` (rad/s). Both are additive
+        # and absent for fixed-base robots (arms), so non-locomotion callers
+        # never see them.
+        if free_jnt_id >= 0:
+            qadr = model.jnt_qposadr[free_jnt_id]
+            vadr = model.jnt_dofadr[free_jnt_id]
+            obs["base_quat"] = [float(v) for v in data.qpos[qadr + 3 : qadr + 7]]
+            obs["base_ang_vel"] = [float(v) for v in data.qvel[vadr + 3 : vadr + 6]]
 
         if skip_images:
             return obs

--- a/tests/policies/wbc/test_sim_control.py
+++ b/tests/policies/wbc/test_sim_control.py
@@ -1,0 +1,189 @@
+"""Tests for the WBC sim integration: G1 default-fill + the torque controller.
+
+Two units are covered, both runnable without real SONIC weights:
+
+* ``WBCPolicy._fill_g1_defaults`` - a checkpoint that ships only ONNX weights
+  yields a config with empty per-joint vectors; for the 15-DOF G1 the policy
+  fills the upstream SONIC gains/stance so a real gait still works (and the
+  observation builder sees the same defaults). Non-G1 configs are untouched,
+  and explicit values always win.
+* ``WBCTorqueController`` - flips the robot's actuators to torque mode (restored
+  on uninstall), declares ``owns_stepping``, and on ``apply`` writes PD torques
+  to ``data.ctrl`` and advances physics by the decimation count.
+
+The end-to-end "does it actually WALK through run_policy" validation needs real
+weights and lives in the gated integration suite.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+import numpy as np
+import pytest
+
+if TYPE_CHECKING:
+    from strands_robots.simulation.base import SimEngine
+
+from strands_robots.policies.wbc import WBCConfig, WBCPolicy
+from strands_robots.policies.wbc.policy import (
+    _G1_SONIC_DEFAULT_ANGLES,
+    _G1_SONIC_KDS,
+    _G1_SONIC_KPS,
+)
+
+
+class _StubSession:
+    class _In:
+        name = "obs"
+
+    def get_inputs(self):  # type: ignore[no-untyped-def]
+        return [self._In()]
+
+    def run(self, output_names, feed):  # type: ignore[no-untyped-def]
+        return [np.zeros((1, 15), dtype=np.float32)]
+
+
+def _g1_policy(**cfg_kwargs) -> WBCPolicy:  # type: ignore[no-untyped-def]
+    cfg = WBCConfig(policy_path="x.onnx", **cfg_kwargs)
+    p = WBCPolicy(config=cfg, walk=False, allow_missing_models=True)
+    p.policy_session = _StubSession()
+    return p
+
+
+# ---------------------------------------------------------------------------
+# G1 default-fill (config normalisation)
+# ---------------------------------------------------------------------------
+
+
+class TestG1DefaultFill:
+    def test_onnx_only_g1_fills_sonic_gains_and_stance(self) -> None:
+        # num_actions defaults to 15 (the G1); no per-joint vectors given.
+        p = _g1_policy()
+        assert p.config.kps == list(_G1_SONIC_KPS)
+        assert p.config.kds == list(_G1_SONIC_KDS)
+        assert p.config.default_angles == list(_G1_SONIC_DEFAULT_ANGLES)
+        # The resolved arrays the controller/PD law use match too.
+        assert np.allclose(p._kps, _G1_SONIC_KPS)
+        assert np.allclose(p.default_angles, _G1_SONIC_DEFAULT_ANGLES)
+
+    def test_observation_builder_sees_filled_defaults(self) -> None:
+        # The qj block subtracts default_angles; with the fill, config.default_angles
+        # is non-empty so the offset is applied (was the ONNX-only gait bug).
+        p = _g1_policy()
+        assert p.config.default_angles  # non-empty
+        assert len(p.config.default_angles) == p.config.num_actions
+
+    def test_explicit_values_are_preserved(self) -> None:
+        custom_kps = [10.0] * 15
+        p = _g1_policy(kps=custom_kps)
+        assert p.config.kps == custom_kps  # explicit wins
+        # the unspecified vectors still get the G1 fill
+        assert p.config.kds == list(_G1_SONIC_KDS)
+
+    def test_non_g1_config_is_not_filled(self) -> None:
+        # A 6-DOF embodiment must not receive the G1's 15-length gains.
+        p = _g1_policy(num_actions=6, single_obs_dim=200, n_obs_joints=6)
+        assert p.config.kps == []
+        assert p.config.kds == []
+        assert p.config.default_angles == []
+        # resolved fallback is the neutral generic one
+        assert np.allclose(p._kps, np.ones(6))
+
+
+# ---------------------------------------------------------------------------
+# WBCTorqueController mechanics (needs mujoco + a torque-capable G1 model)
+# ---------------------------------------------------------------------------
+
+mujoco = pytest.importorskip("mujoco", reason="mujoco not installed")
+
+
+def _build_min_g1():  # type: ignore[no-untyped-def]
+    """Resolve and load the standard unitree_g1 model (position-servo scene)."""
+    from strands_robots.simulation.model_registry import resolve_model
+
+    xml = resolve_model("unitree_g1")
+    if not xml:
+        pytest.skip("unitree_g1 model assets not available")
+    model = mujoco.MjModel.from_xml_path(xml)
+    data = mujoco.MjData(model)
+    return model, data
+
+
+class _FakeRobot:
+    def __init__(self, namespace: str) -> None:
+        self.namespace = namespace
+
+
+class _FakeWorld:
+    def __init__(self, model, data, namespace) -> None:  # type: ignore[no-untyped-def]
+        self._model = model
+        self._data = data
+        self.robots = {"unitree_g1": _FakeRobot(namespace)}
+        self._backend_state: dict = {}
+
+
+class _FakeSim:
+    def __init__(self, world) -> None:  # type: ignore[no-untyped-def]
+        self._world = world
+
+
+def _namespace_for(model) -> str:  # type: ignore[no-untyped-def]
+    # The Menagerie scene namespaces joints as "unitree_g1/..."; the bare
+    # robot_descriptions model does not. Detect which we got.
+    name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, 1) or ""
+    return "unitree_g1/" if name.startswith("unitree_g1/") else ""
+
+
+class TestWBCTorqueController:
+    def test_install_flips_actuators_to_torque_and_restores(self) -> None:
+        from strands_robots.policies.wbc import WBCTorqueController, install_wbc_torque_control
+
+        model, data = _build_min_g1()
+        ns = _namespace_for(model)
+        sim = _FakeSim(_FakeWorld(model, data, ns))
+        policy = _g1_policy()
+
+        # Pre-install: the stock scene uses position-servo actuators (biastype
+        # AFFINE). Capture one driven actuator's original gains.
+        ctrl = install_wbc_torque_control(cast("SimEngine", sim), policy, "unitree_g1")
+        assert isinstance(ctrl, WBCTorqueController)
+        assert ctrl.owns_stepping is True
+        assert len(ctrl.leg_waist_actuator_ids) == policy.config.num_actions
+
+        # Driven actuators are now torque motors: gaintype FIXED, biastype NONE.
+        for ai in ctrl.leg_waist_actuator_ids:
+            assert int(model.actuator_gaintype[ai]) == int(mujoco.mjtGain.mjGAIN_FIXED)
+            assert int(model.actuator_biastype[ai]) == int(mujoco.mjtBias.mjBIAS_NONE)
+
+        # Physics step matches the SONIC training rate.
+        assert abs(float(model.opt.timestep) - 0.005) < 1e-9
+
+        # Uninstall restores the original biastype (position-servo => AFFINE).
+        first = ctrl.leg_waist_actuator_ids[0]
+        ctrl.uninstall()
+        assert int(model.actuator_biastype[first]) == int(mujoco.mjtBias.mjBIAS_AFFINE)
+
+    def test_apply_writes_torques_and_owns_stepping(self) -> None:
+        from strands_robots.policies.wbc import install_wbc_torque_control
+
+        model, data = _build_min_g1()
+        ns = _namespace_for(model)
+        sim = _FakeSim(_FakeWorld(model, data, ns))
+        policy = _g1_policy()
+        ctrl = install_wbc_torque_control(cast("SimEngine", sim), policy, "unitree_g1")
+
+        t0 = float(data.time)
+        # Action dict keyed by the WBC joint names (bare), holding the stance.
+        from strands_robots.policies.wbc import WBC_G1_LEG_WAIST_JOINTS
+
+        action = {name: float(policy.default_angles[i]) for i, name in enumerate(WBC_G1_LEG_WAIST_JOINTS)}
+        ctrl.apply(action, model, data, "unitree_g1")
+
+        # owns_stepping: apply advanced physics by decimation substeps of dt.
+        expected_dt = ctrl.physics_substeps_per_control * float(model.opt.timestep)
+        assert abs((float(data.time) - t0) - expected_dt) < 1e-6
+
+        # At least one driven actuator received a finite torque command.
+        ctrls = np.array([float(data.ctrl[ai]) for ai in ctrl.leg_waist_actuator_ids])
+        assert np.all(np.isfinite(ctrls))

--- a/tests/policies/wbc/test_sim_control.py
+++ b/tests/policies/wbc/test_sim_control.py
@@ -17,13 +17,10 @@ weights and lives in the gated integration suite.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import cast
 
 import numpy as np
 import pytest
-
-if TYPE_CHECKING:
-    from strands_robots.simulation.base import SimEngine
 
 from strands_robots.policies.wbc import WBCConfig, WBCPolicy
 from strands_robots.policies.wbc.policy import (
@@ -31,6 +28,7 @@ from strands_robots.policies.wbc.policy import (
     _G1_SONIC_KDS,
     _G1_SONIC_KPS,
 )
+from strands_robots.simulation.base import SimEngine
 
 
 class _StubSession:
@@ -146,7 +144,7 @@ class TestWBCTorqueController:
 
         # Pre-install: the stock scene uses position-servo actuators (biastype
         # AFFINE). Capture one driven actuator's original gains.
-        ctrl = install_wbc_torque_control(cast("SimEngine", sim), policy, "unitree_g1")
+        ctrl = install_wbc_torque_control(cast(SimEngine, sim), policy, "unitree_g1")
         assert isinstance(ctrl, WBCTorqueController)
         assert ctrl.owns_stepping is True
         assert len(ctrl.leg_waist_actuator_ids) == policy.config.num_actions
@@ -171,7 +169,7 @@ class TestWBCTorqueController:
         ns = _namespace_for(model)
         sim = _FakeSim(_FakeWorld(model, data, ns))
         policy = _g1_policy()
-        ctrl = install_wbc_torque_control(cast("SimEngine", sim), policy, "unitree_g1")
+        ctrl = install_wbc_torque_control(cast(SimEngine, sim), policy, "unitree_g1")
 
         t0 = float(data.time)
         # Action dict keyed by the WBC joint names (bare), holding the stance.

--- a/tests/simulation/mujoco/test_simulation.py
+++ b/tests/simulation/mujoco/test_simulation.py
@@ -61,12 +61,68 @@ ROBOT_XML = """
 """
 
 
+# Free-base (floating) robot - a 1-DoF "leg" on a free joint, like the G1's
+# floating base. Used to test that get_observation surfaces base_quat /
+# base_ang_vel for locomotion controllers (WBC).
+FREE_BASE_XML = """
+<mujoco model="test_floating">
+  <compiler angle="radian" autolimits="true"/>
+  <option timestep="0.002"/>
+  <worldbody>
+    <light name="main" pos="0 0 3" dir="0 0 -1"/>
+    <geom name="ground" type="plane" size="5 5 0.01" rgba="0.9 0.9 0.9 1"/>
+    <body name="torso" pos="0 0 0.5">
+      <freejoint name="floating_base_joint"/>
+      <geom type="box" size="0.1 0.1 0.1" rgba="0.3 0.3 0.8 1"/>
+      <body name="leg" pos="0 0 -0.1">
+        <geom type="capsule" size="0.03" fromto="0 0 0 0 0 -0.2" rgba="0.8 0.3 0.3 1"/>
+        <joint name="hip" type="hinge" axis="0 1 0" range="-1.57 1.57"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <motor name="hip_act" joint="hip"/>
+  </actuator>
+</mujoco>
+"""
+
+
 @pytest.fixture
 def sim():
     """Create a fresh Simulation instance."""
     s = Simulation(tool_name="test_sim", mesh=False)
     yield s
     s.cleanup()
+
+
+@pytest.fixture
+def free_base_robot_xml_path():
+    """Write the free-base (floating) robot XML to a temp file."""
+    tmpdir = tempfile.mkdtemp()
+    path = os.path.join(tmpdir, "test_floating.xml")
+    with open(path, "w") as f:
+        f.write(FREE_BASE_XML)
+    yield path
+    shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_get_observation_free_base_has_base_imu(sim_with_world, free_base_robot_xml_path):
+    """A floating-base robot surfaces base_quat (w,x,y,z) + base_ang_vel (rad/s)
+    from its free joint, and per-joint .vel for the hinge joints - the inputs a
+    locomotion controller (WBC) needs to close the loop. The free joint itself
+    gets no scalar .vel (it is 6-DoF, not a 1-DoF hinge/slide)."""
+    sim_with_world.add_robot("floater", urdf_path=free_base_robot_xml_path)
+    obs = sim_with_world.get_observation(robot_name="floater", skip_images=True)
+
+    assert "base_quat" in obs, "floating-base robot must surface base_quat"
+    assert len(obs["base_quat"]) == 4
+    assert all(isinstance(x, float) for x in obs["base_quat"])
+    assert "base_ang_vel" in obs, "floating-base robot must surface base_ang_vel"
+    assert len(obs["base_ang_vel"]) == 3
+
+    # The hinge joint has a scalar .vel; the free joint does not.
+    assert "hip.vel" in obs and isinstance(obs["hip.vel"], float)
+    assert "floating_base_joint.vel" not in obs
 
 
 @pytest.fixture
@@ -370,20 +426,50 @@ class TestRobotManagement:
         sim_with_robot.add_camera("wrist", position=[0.2, -0.2, 0.3], target=[0, 0, 0])
         obs = sim_with_robot.get_observation(robot_name="arm1")
 
-        # Joint entries: keyed by *short* names, values are floats.
+        # Joint POSITION entries: keyed by *short* names, values are floats.
         joint_names = set(sim_with_robot._world.robots["arm1"].joint_names)
         joint_entries = {k: v for k, v in obs.items() if k in joint_names}
         assert joint_entries, "expected at least one joint in observation"
         for name, value in joint_entries.items():
             assert isinstance(value, float), f"joint {name} must be float, got {type(value).__name__}"
 
-        # Camera entries: any non-joint key must be an RGB uint8 ndarray.
-        camera_entries = {k: v for k, v in obs.items() if k not in joint_names}
+        # Per-joint VELOCITY entries (`<joint>.vel`, float) - additive, for
+        # velocity-feedback controllers (WBC). Each must correspond to a joint.
+        vel_entries = {k: v for k, v in obs.items() if k.endswith(".vel")}
+        for name, value in vel_entries.items():
+            assert name[:-4] in joint_names, f"{name} has no matching joint"
+            assert isinstance(value, float), f"{name} must be float, got {type(value).__name__}"
+
+        # Base IMU entries (floating-base robots only): base_quat / base_ang_vel
+        # are lists of floats. A fixed-base arm has neither.
+        base_keys = {"base_quat", "base_ang_vel"}
+        for name in base_keys & set(obs):
+            assert isinstance(obs[name], list) and all(isinstance(x, float) for x in obs[name])
+
+        # Camera entries: any remaining non-joint, non-vel, non-base key is an
+        # RGB uint8 ndarray.
+        camera_entries = {
+            k: v for k, v in obs.items() if k not in joint_names and not k.endswith(".vel") and k not in base_keys
+        }
         assert "wrist" in camera_entries, "user-added camera must appear in observation"
         for name, frame in camera_entries.items():
             assert isinstance(frame, np.ndarray), f"camera {name} must be ndarray"
             assert frame.ndim == 3 and frame.shape[2] == 3, f"camera {name} must be HxWx3, got shape {frame.shape}"
             assert frame.dtype == np.uint8, f"camera {name} must be uint8, got {frame.dtype}"
+
+    def test_get_observation_fixed_base_has_vel_but_no_base_imu(self, sim_with_robot):
+        """A fixed-base arm gets per-joint `.vel` keys (velocity-feedback
+        controllers consume them) but NO base_quat / base_ang_vel - it has no
+        floating-base free joint."""
+        obs = sim_with_robot.get_observation(robot_name="arm1", skip_images=True)
+        joint_names = set(sim_with_robot._world.robots["arm1"].joint_names)
+        vel_keys = [k for k in obs if k.endswith(".vel")]
+        assert vel_keys, "expected per-joint .vel keys"
+        for k in vel_keys:
+            assert k[:-4] in joint_names and isinstance(obs[k], float)
+        # Fixed-base arm: no floating-base IMU signals.
+        assert "base_quat" not in obs
+        assert "base_ang_vel" not in obs
 
     def test_get_observation_signature_has_no_camera_name(self):
         """Regression: get_observation must not accept a camera_name param.


### PR DESCRIPTION
## Summary

Addresses the two review follow-ups from #471 (PR #662), and goes one step
further: WBC now actually **walks** through `sim.run_policy`, not just runs.

1. **Observation velocity gap** (reviewer's "worth a follow-up" note). The MuJoCo
   backend's `get_observation` emitted joint **positions only**, so `WBCPolicy`'s
   balance controller ran open-loop on velocity. `_get_sim_observation` now also
   emits — all **additive**:
   - `<joint>.vel` — per-joint velocity (`qvel[dofadr]`) for hinge/slide joints
   - `base_quat` — floating-base orientation `(w,x,y,z)` from the free joint
   - `base_ang_vel` — floating-base angular velocity (rad/s)

2. **WBC-driven recording that actually walks** (reviewer's inline comment "use
   WBC to walk here instead of mock policy?"). Two pieces were needed:

   - `examples/vla_g1_workflow.py` `stage_record` drives the G1 with `WBCPolicy`
     when `--record-checkpoint <SONIC dir>` is given (else `MockPolicy`).
   - **New:** `install_wbc_torque_control` (in `strands_robots/policies/wbc/
     sim_control.py`). WBC emits joint-**position** targets, but the stock
     `unitree_g1` scene drives position-servo actuators (uniform `kp=500`) that
     override SONIC's tuned per-joint PD, so feeding the targets directly makes
     the robot fall. The controller — installed via the same
     `world._backend_state["action_controller"]` hook the LIBERO adapter uses
     (`owns_stepping=True`) — flips the G1's actuators to torque mode (restored
     on uninstall), seeds the SONIC init stance, and converts the position
     targets to torques via the upstream PD law (`WBCPolicy.compute_torques`) at
     `control_decimation=4`. `WBCPolicy`'s public contract is unchanged (it still
     emits position targets, so the recorded dataset `action` stays
     model-independent for fine-tuning).

   The docs record snippet now shows WBC (the exact spot the comment sits on),
   with mock/teleop as the documented fallback.

## Reproducibility: ONNX-only checkpoints walk

`WBCPolicy._fill_g1_defaults` normalises a config that ships no per-joint vectors
(e.g. a checkpoint with only the `.onnx` weights) to the upstream G1 SONIC
gains/stance, so `create_policy("wbc", checkpoint=<onnx-only dir>)` walks without
a separate `config.json`. Filled on the config so the observation builder (qj
offset) and the PD law stay consistent; non-G1 configs are untouched and explicit
values always win. Adds a resolved `default_angles` property.

## Why it's safe

Existing position-only consumers and **dataset recording are unaffected**: the
new obs keys are additive, and `add_frame` reads the *declared* feature schema,
so `observation.state` stays the joint-position vector. The torque controller is
opt-in (installed explicitly), restores the original actuators on uninstall, and
leaves `run_policy` generic.

## Testing

- +6 unit tests (`tests/policies/wbc/test_sim_control.py`): controller actuator
  flip + restore, `owns_stepping`/decimation, and the G1 default-fill.
- +3 observation tests (free-base IMU keys; fixed-base `.vel` but no base IMU;
  obs schema-contract update).
- Verified the end-to-end public path on the stock `Robot("unitree_g1")`:
  **walk +1.48 m, stand -0.06 m, both upright** (vs. a fall before this change).
  `stage_record` records genuine walking (pelvis upright throughout).
- ruff + format + mypy clean whole-tree (518 files); 248 WBC+sim tests pass.
- Note: a local macOS full-suite run shows pre-existing GL/absent-dep failures
  unrelated to this change; CI (Linux, full deps) is the real signal.