### PR TITLE
fix(sim): roll back the spec mutation when an object/camera injection recompile fails

### DIFF
--- a/strands_robots/simulation/mujoco/scene_ops.py
+++ b/strands_robots/simulation/mujoco/scene_ops.py
@@ -147,7 +147,16 @@ def inject_robot_into_scene(
 
 
 def inject_object_into_scene(world: SimWorld, obj: SimObject) -> bool:
-    """Add a ``SimObject`` to the scene and recompile in place."""
+    """Add a ``SimObject`` to the scene and recompile in place.
+
+    ``SpecBuilder.add_object`` mutates the spec (adds the body + geom) before
+    the recompile that validates it. If that recompile is refused - e.g. the
+    object references a mesh asset that was never registered - the orphan body
+    is deleted again before returning ``False`` so the spec stays compilable.
+    Without the rollback the orphan lingers and every later scene mutation,
+    including a corrected retry under the same name, keeps failing to recompile
+    (``repeated name`` collisions), bricking the whole scene after one bad add.
+    """
     spec = _get_spec(world)
     if spec is None or world._model is None:
         logger.error("inject_object: no spec or model in world")
@@ -159,11 +168,22 @@ def inject_object_into_scene(world: SimWorld, obj: SimObject) -> bool:
         logger.error("Object add failed for '%s': %s", obj.name, e)
         return False
 
-    return _recompile_preserving_state(world, spec)
+    if not _recompile_preserving_state(world, spec):
+        # Roll the just-added body back out so the spec returns to its last
+        # good, compilable state (a worldbody body delete is safe - the
+        # attach/delete segfault only affects spec.attach() child specs).
+        SpecBuilder.remove_body(spec, obj.name)
+        return False
+    return True
 
 
 def inject_camera_into_scene(world: SimWorld, cam: SimCamera) -> bool:
-    """Add a camera to the scene and recompile in place."""
+    """Add a camera to the scene and recompile in place.
+
+    Mirrors :func:`inject_object_into_scene`: ``SpecBuilder.add_camera`` mutates
+    the spec before the validating recompile, so a refused recompile rolls the
+    just-added camera back out to keep the spec compilable for later edits.
+    """
     spec = _get_spec(world)
     if spec is None or world._model is None:
         logger.error("inject_camera: no spec or model in world")
@@ -175,7 +195,10 @@ def inject_camera_into_scene(world: SimWorld, cam: SimCamera) -> bool:
         logger.error("Camera add failed for '%s': %s", cam.name, e)
         return False
 
-    return _recompile_preserving_state(world, spec)
+    if not _recompile_preserving_state(world, spec):
+        SpecBuilder.remove_camera(spec, cam.name)
+        return False
+    return True
 
 
 # Eject

--- a/tests/simulation/mujoco/test_inject_failure_cleanup.py
+++ b/tests/simulation/mujoco/test_inject_failure_cleanup.py
@@ -1,0 +1,93 @@
+"""Spec rollback when an object/camera scene injection recompile fails.
+
+``add_object`` / ``add_camera`` mutate the live ``MjSpec`` (insert the body or
+camera) *before* the recompile that validates the result. If that recompile is
+refused - e.g. an object references a mesh asset that was never registered -
+the just-inserted element must be rolled back out of the spec, not merely
+popped from the Python-side ``_world`` registry. Otherwise the orphan element
+lingers in the spec and every subsequent scene mutation keeps failing to
+recompile (``repeated name`` collisions), bricking the whole scene after a
+single bad add.
+
+The observable proof of correct rollback is that the *same name* can be added
+successfully right after a failed attempt: a leaked orphan would make the retry
+collide on the duplicate name at recompile time. These tests fail before the
+rollback fix (the retry errors with ``repeated name``) and pass after it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco import scene_ops  # noqa: E402
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="devx_inject_cleanup", mesh=False)
+    s.create_world()
+    s.add_robot("so100")  # a compiled world the injectors can recompile against
+    try:
+        yield s
+    finally:
+        s.cleanup(policy_stop_timeout=0.5)
+
+
+class TestAddObjectInjectionRollback:
+    def test_bad_mesh_rolls_back_and_same_name_is_reusable(self, sim):
+        # shape="mesh" with a non-existent file -> recompile refused.
+        result = sim.add_object(
+            name="widget",
+            shape="mesh",
+            mesh_path="/nonexistent/does-not-exist.stl",
+            position=[0.3, 0.0, 0.1],
+        )
+        assert result["status"] == "error"
+        assert "widget" not in sim._world.objects
+
+        # The spec was rolled back, so the same name is free: a valid object
+        # under that name now compiles. (Pre-fix this errored with a
+        # "repeated name 'widget' in body" recompile failure.)
+        retry = sim.add_object(name="widget", shape="box", position=[0.3, 0.0, 0.1])
+        assert retry["status"] == "success"
+        assert "widget" in sim._world.objects
+
+    def test_failed_add_does_not_brick_other_objects(self, sim):
+        bad = sim.add_object(name="bad", shape="mesh", mesh_path="/nope.stl", position=[0.3, 0.0, 0.1])
+        assert bad["status"] == "error"
+        # A completely different valid object still compiles - the scene is
+        # not bricked by the earlier failure.
+        ok = sim.add_object(name="cube", shape="box", position=[0.2, 0.1, 0.1])
+        assert ok["status"] == "success"
+        assert "cube" in sim._world.objects
+
+
+class TestAddCameraInjectionRollback:
+    def test_recompile_refusal_rolls_back_and_same_name_is_reusable(self, sim, monkeypatch):
+        # Camera-injection recompile failures are hard to trigger with valid
+        # inputs, so force the recompile to refuse once. The real add_camera
+        # spec mutation still runs, exercising the production rollback path
+        # (SpecBuilder.remove_camera) - the fix under test, not a stub.
+        real_recompile = scene_ops._recompile_preserving_state
+        calls = {"n": 0}
+
+        def flaky_recompile(world, spec):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return False  # simulate a refused recompile on the first inject
+            return real_recompile(world, spec)
+
+        monkeypatch.setattr(scene_ops, "_recompile_preserving_state", flaky_recompile)
+
+        result = sim.add_camera(name="wrist", position=[0.5, 0.0, 0.5], target=[0.0, 0.0, 0.1])
+        assert result["status"] == "error"
+        assert "wrist" not in sim._world.cameras
+
+        # Second inject uses the real recompile; it succeeds only if the first
+        # attempt's camera was rolled back out of the spec.
+        retry = sim.add_camera(name="wrist", position=[0.5, 0.0, 0.5], target=[0.0, 0.0, 0.1])
+        assert retry["status"] == "success"
+        assert "wrist" in sim._world.cameras


### PR DESCRIPTION
## Problem

`add_object` / `add_camera` insert the body or camera into the live `MjSpec` **before** the recompile that validates the result. When that recompile is refused - e.g. an object references a mesh asset that was never registered - the facade popped the Python-side `_world` registry entry but left the orphan element behind in the spec.

That orphan then poisons every subsequent recompile. The next scene mutation - including a *corrected retry under the same name* - fails with a `repeated name '<name>' in body` collision. In other words, **one bad `add_object` bricks the entire scene**: no further objects, cameras, or edits can ever be applied.

Reproduction (pre-fix):

```python
sim.add_object(name="widget", shape="mesh", mesh_path="/missing.stl")   # status=error (expected)
sim.add_object(name="widget", shape="box")                              # status=error: repeated name 'widget' in body (BUG)
sim.add_object(name="anything_else", shape="box")                       # also fails - scene is bricked
```

## Change

When the validating recompile fails, roll the just-inserted element back out of the spec (`SpecBuilder.remove_body` / `SpecBuilder.remove_camera`) before returning `False`, returning the spec to its last good, compilable state. A worldbody body/camera delete is safe here - the known MuJoCo attach/delete segfault only affects `spec.attach()` child specs, not plain worldbody elements.

Scope is deliberately limited to the object and camera injectors, which share the simple `worldbody.add_*` / `remove_*` inverse. The robot injector uses `spec.attach()` (a different primitive with the documented delete-segfault constraint, requiring a full spec rebuild) and is intentionally out of scope.

## Tests

New regression test `tests/simulation/mujoco/test_inject_failure_cleanup.py` asserts the observable contract: a same-name retry succeeds immediately after a failed object/camera injection. All three cases fail before this change (the retry errors with `repeated name`) and pass after it. Full `MUJOCO_GL=egl` mujoco suite stays green (the 2 unrelated failures are the torchcodec/CUDA video-decode env issue).

## Visual proof

Headless MuJoCo rollout (`MUJOCO_GL=egl`): a scene takes a refused object injection, then fully recovers - same-name retry, a second object, and a new camera all inject, and a 120-step policy rollout records cleanly from the freshly-added camera. Pre-fix the scene would be bricked at step 2.

![scene recovers after a refused injection](https://github.com/cagataycali/robots/releases/download/scene-rollback-artifact-1782594987/scene_recovered.gif)

[full MP4](https://github.com/cagataycali/robots/releases/download/scene-rollback-artifact-1782594987/scene_recovered.mp4)