### PR TITLE
refactor(hardware): unify the rclpy + RTPS hardware ROS 2 bridges under a shared RosTelemetryBase (+ HardwareRtpsBridge naming)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Refactor: unify the rclpy + RTPS hardware ROS 2 bridges under `RosTelemetryBase`
+
+The two hardware ROS 2 transports now share a single source of truth for the
+wire contract. Previously `HardwareRosBridge` (rclpy) subclassed
+`RosTelemetryBridge` while the pure-RTPS bridge was a parallel implementation
+that re-derived the topic names, name sanitization, and inbound `joint_command`
+parsing independently - so the "byte-identical topics" guarantee depended on two
+codepaths staying in sync by hand.
+
+- New `strands_robots.ros_telemetry.RosTelemetryBase` owns the transport-agnostic
+  contract: topic names (`joint_states_topic` / `image_topic` /
+  `joint_command_topic`), the `_safe` segment sanitizer, robot-name resolution,
+  and `joint_command` -> `send_action` dispatch. `RosTelemetryBridge` (and its
+  `SimRosBridge` / `HardwareRosBridge` subclasses) and the RTPS bridge now all
+  derive from it, so the rclpy and cyclonedds transports are identical on the
+  ROS 2 graph by construction rather than by convention.
+- The pure-RTPS bridge class is renamed `RtpsHardwareBridge` -> `HardwareRtpsBridge`
+  to match its rclpy sibling `HardwareRosBridge` (both `Hardware*Bridge`). The
+  module path (`strands_robots.hardware_rtps_bridge`) and the public
+  top-level export are unchanged except for the class name; `Robot(...,
+  ros2_transport="rtps")` selection is unaffected.
+
+No wire behavior changes: published topics, message layouts, and the
+`joint_command` contract are identical before and after.
+
+
 ### Feature: zero-config robot discovery from `robot_descriptions` (`registry`)
 
 `Robot("iiwa14", mode="sim")` (and every other MJCF robot shipped by

--- a/docs/ros2-integration.md
+++ b/docs/ros2-integration.md
@@ -179,9 +179,11 @@ it with `ros2_bridge=True` and it owns a
 `strands_robots.hardware_ros_bridge.HardwareRosBridge` that advertises the real
 arm's live observation on a ROS 2 domain. The sim bridge
 (`SimRosBridge`) and the hardware bridge (`HardwareRosBridge`) are thin
-subclasses of the same `RosTelemetryBridge`, so a physical arm and its digital
-twin publish **identical topics** - a simulated robot and the real one it
-mirrors are indistinguishable on the ROS 2 graph:
+subclasses of the same `RosTelemetryBridge`, and the pure-RTPS transport
+(`HardwareRtpsBridge`) shares the same wire contract through their common
+`RosTelemetryBase`, so a physical arm and its digital twin publish **identical
+topics** - a simulated robot and the real one it mirrors are indistinguishable on
+the ROS 2 graph:
 
 | Topic | Direction | Type | Content |
 |-------|-----------|------|---------|

--- a/docs/rtps-integration.md
+++ b/docs/rtps-integration.md
@@ -137,9 +137,12 @@ ros2 topic pub --once /so101/joint_command sensor_msgs/msg/JointState \
 
 The trade-off is the same as `use_rtps`: type coverage is bounded by the IDL
 bundle (joint_states + image_raw are in; anything else needs the rclpy backend).
-The bridge is implemented by `strands_robots.hardware_rtps_bridge.RtpsHardwareBridge`,
-the rclpy-free sibling of `HardwareRosBridge`; both present the identical
-`publish_joint_states` / `publish_image` / inbound-`joint_command` surface.
+The bridge is implemented by `strands_robots.hardware_rtps_bridge.HardwareRtpsBridge`,
+the rclpy-free sibling of `HardwareRosBridge`. Both derive from
+`strands_robots.ros_telemetry.RosTelemetryBase`, which owns the topic names and the
+inbound `joint_command` parsing, so the two transports are byte-identical on the wire
+by construction; they present the identical `publish_joint_states` / `publish_image` /
+inbound-`joint_command` surface.
 
 ## Safety
 

--- a/strands_robots/__init__.py
+++ b/strands_robots/__init__.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
         init_device_connect_sync,
     )
     from strands_robots.hardware_ros_bridge import HardwareRosBridge
-    from strands_robots.hardware_rtps_bridge import RtpsHardwareBridge
+    from strands_robots.hardware_rtps_bridge import HardwareRtpsBridge
     from strands_robots.policies.groot import Gr00tPolicy
     from strands_robots.registry import (
         get_robot,
@@ -81,7 +81,7 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     # Hardware robot
     "Robot": ("strands_robots.robot", "Robot"),
     "HardwareRosBridge": ("strands_robots.hardware_ros_bridge", "HardwareRosBridge"),
-    "RtpsHardwareBridge": ("strands_robots.hardware_rtps_bridge", "RtpsHardwareBridge"),
+    "HardwareRtpsBridge": ("strands_robots.hardware_rtps_bridge", "HardwareRtpsBridge"),
     "Teleoperator": ("strands_robots.teleoperator", "Teleoperator"),
     "list_robots": ("strands_robots.registry", "list_robots"),
     "get_robot": ("strands_robots.registry", "get_robot"),
@@ -125,7 +125,7 @@ __all__ = [
     # Lazy-loaded
     "Robot",
     "HardwareRosBridge",
-    "RtpsHardwareBridge",
+    "HardwareRtpsBridge",
     "Teleoperator",
     "Gr00tPolicy",
     "Simulation",

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -386,7 +386,7 @@ class Robot(TeleopMixin, AgentTool):
 
         * ``"rclpy"`` (default) - :class:`~strands_robots.hardware_ros_bridge.HardwareRosBridge`,
           full ``sensor_msgs`` fidelity, needs a sourced ROS 2 distro.
-        * ``"rtps"`` - :class:`~strands_robots.hardware_rtps_bridge.RtpsHardwareBridge`,
+        * ``"rtps"`` - :class:`~strands_robots.hardware_rtps_bridge.HardwareRtpsBridge`,
           pure cyclonedds (a pip wheel, no rclpy / no sourced distro), type
           coverage bounded by the local IDL bundle.
 
@@ -415,9 +415,9 @@ class Robot(TeleopMixin, AgentTool):
         # joint_states under (lerobot device .name, falling back to the tool
         # name) so a controller can echo our names straight back.
         if ros2_transport == "rtps":
-            from strands_robots.hardware_rtps_bridge import RtpsHardwareBridge
+            from strands_robots.hardware_rtps_bridge import HardwareRtpsBridge
 
-            self._ros_bridge = RtpsHardwareBridge(
+            self._ros_bridge = HardwareRtpsBridge(
                 self,
                 domain_id=self._ros2_domain,
                 enable_commands=bool(ros2_commands),

--- a/strands_robots/hardware_ros_bridge.py
+++ b/strands_robots/hardware_ros_bridge.py
@@ -110,52 +110,25 @@ class HardwareRosBridge(RosTelemetryBridge):
             self._command_robot_name = self._safe(name)
             self._command_sub = self._node.create_subscription(
                 self._JointState,
-                f"/{self._command_robot_name}/joint_command",
+                self.joint_command_topic(name),
                 self._on_command,
                 self._qos_depth,
             )
             self._start_spin()
-
-    @staticmethod
-    def _resolve_robot_name(robot: Any) -> str:
-        """Namespace inbound commands under the same name we publish under.
-
-        Mirrors ``Robot._publish_ros_telemetry``: the lerobot device ``.name``
-        (e.g. ``so101``) is preferred, falling back to the strands tool name, so
-        ``joint_command`` and ``joint_states`` share one namespace.
-        """
-        inner = getattr(robot, "robot", None)
-        return getattr(inner, "name", None) or getattr(robot, "tool_name_str", None) or "robot"
 
     # -- inbound: drive the arm from /<robot>/joint_command ----------------
 
     def _on_command(self, msg: Any) -> None:
         """Forward an inbound ``joint_command`` JointState to ``send_action``.
 
-        The message's ``name``/``position`` arrays are zipped into the flat
-        ``{motor.pos: float}`` action dict the hardware ``Robot`` accepts - the
-        exact shape this bridge publishes in ``joint_states``. A mismatched- or
-        zero-length message is rejected with a warning rather than partially
-        applied, so a malformed command never drives the arm to a surprising
-        pose.
+        Delegates to :meth:`RosTelemetryBase._drive_from_command` (shared with
+        the RTPS bridge): the message's ``name``/``position`` arrays are zipped
+        into the flat ``{motor.pos: float}`` action dict the hardware ``Robot``
+        accepts - the exact shape this bridge publishes in ``joint_states`` - and
+        a mismatched/empty message is rejected rather than partially applied, so
+        a malformed command never drives the arm to a surprising pose.
         """
-        names = list(getattr(msg, "name", []) or [])
-        positions = list(getattr(msg, "position", []) or [])
-        if not names or len(names) != len(positions):
-            logger.warning(
-                "HardwareRosBridge: ignoring joint_command with name/position length mismatch (%d vs %d)",
-                len(names),
-                len(positions),
-            )
-            return
-        action = {name: float(pos) for name, pos in zip(names, positions)}
-        try:
-            result = self._robot.send_action(action)  # type: ignore[union-attr]
-        except Exception:
-            logger.warning("HardwareRosBridge: send_action raised on joint_command; arm not moved", exc_info=True)
-            return
-        if isinstance(result, dict) and result.get("status") == "error":
-            logger.warning("HardwareRosBridge: send_action rejected joint_command: %s", result)
+        self._drive_from_command(self._robot, msg)
 
     # -- command spin thread ----------------------------------------------
 

--- a/strands_robots/hardware_rtps_bridge.py
+++ b/strands_robots/hardware_rtps_bridge.py
@@ -1,12 +1,14 @@
 """Pure-RTPS (cyclonedds) hardware bridge - a real robot on ROS 2, no rclpy.
 
 This is the rclpy-free sibling of
-:class:`strands_robots.hardware_ros_bridge.HardwareRosBridge`. It exposes the
-exact same ROS 2 topics for a physical
-:class:`strands_robots.hardware_robot.Robot` - byte-compatible on the wire with
-the rclpy bridge and with real ROS 2 nodes - but speaks DDS/RTPS directly
-through the pip-installable ``cyclonedds`` binding instead of a sourced ROS 2
-distro:
+:class:`strands_robots.hardware_ros_bridge.HardwareRosBridge`. Both derive from
+:class:`strands_robots.ros_telemetry.RosTelemetryBase` - the single source of
+truth for the ROS 2 topic names and the inbound ``joint_command`` contract - so
+they are byte-compatible on the wire by construction. ``HardwareRtpsBridge``
+exposes the exact same ROS 2 topics for a physical
+:class:`strands_robots.hardware_robot.Robot` - and to real ROS 2 nodes - but
+speaks DDS/RTPS directly through the pip-installable ``cyclonedds`` binding
+instead of a sourced ROS 2 distro:
 
 * **publish** (outbound) - ``/<robot>/joint_states``
   (``sensor_msgs/msg/JointState``) and, per camera,
@@ -15,7 +17,7 @@ distro:
   (``sensor_msgs/msg/JointState``) forwarded into
   ``robot.send_action({motor.pos: float})`` over a background poll thread, so an
   external ROS 2 stack can drive the physical arm. Full duplex, same contract as
-  the rclpy bridge.
+  the rclpy bridge (shared via :class:`~strands_robots.ros_telemetry.RosTelemetryBase`).
 
 Why this exists alongside ``HardwareRosBridge``: ``rclpy`` needs a *sourced ROS 2
 distro* (apt / RoboStack / docker), which is heavy and version-pinned (Humble vs
@@ -41,6 +43,7 @@ import threading
 import time
 from typing import TYPE_CHECKING, Any
 
+from strands_robots.ros_telemetry import RosTelemetryBase
 from strands_robots.utils import require_optional
 
 if TYPE_CHECKING:
@@ -56,13 +59,15 @@ _JOINT_STATE_TYPE = "sensor_msgs/msg/JointState"
 _IMAGE_TYPE = "sensor_msgs/msg/Image"
 
 
-class RtpsHardwareBridge:
+class HardwareRtpsBridge(RosTelemetryBase):
     """Full-duplex hardware ROS 2 bridge over pure RTPS (cyclonedds, no rclpy).
 
-    Wire-compatible with :class:`~strands_robots.hardware_ros_bridge.HardwareRosBridge`:
-    same topics, same ``sensor_msgs`` types, same ``joint_command`` -> ``send_action``
-    contract. Differs only in the transport (cyclonedds RTPS vs rclpy) and in
-    type coverage (bounded by the local IDL bundle).
+    The rclpy-free sibling of
+    :class:`~strands_robots.hardware_ros_bridge.HardwareRosBridge`. Both derive
+    from :class:`~strands_robots.ros_telemetry.RosTelemetryBase`, so they share
+    the topic names and the ``joint_command`` -> ``send_action`` contract and are
+    wire-compatible by construction; they differ only in transport (cyclonedds
+    RTPS vs rclpy) and in type coverage (bounded by the local IDL bundle).
 
     Args:
         robot: The hardware ``Robot`` to drive on inbound commands. When
@@ -125,20 +130,10 @@ class RtpsHardwareBridge:
         if self._enable_commands:
             name = command_robot_name or self._resolve_robot_name(robot)
             self._command_robot_name = self._safe(name)
-            self._command_reader = self._make_reader(f"/{self._command_robot_name}/joint_command", self._JointState)
+            self._command_reader = self._make_reader(self.joint_command_topic(name), self._JointState)
             self._start_poll()
 
     # -- helpers ----------------------------------------------------------
-
-    @staticmethod
-    def _safe(name: str) -> str:
-        """Map a robot/camera name to a valid ROS 2 topic segment."""
-        return "".join(c if (c.isalnum() or c == "_") else "_" for c in name).strip("_") or "robot"
-
-    @staticmethod
-    def _resolve_robot_name(robot: Any) -> str:
-        inner = getattr(robot, "robot", None)
-        return getattr(inner, "name", None) or getattr(robot, "tool_name_str", None) or "robot"
 
     def _make_writer(self, ros_topic: str, idl_cls: Any) -> Any:
         from cyclonedds.pub import DataWriter
@@ -163,7 +158,7 @@ class RtpsHardwareBridge:
         hardware ``Robot`` telemetry path is transport-agnostic.
         """
         if self._joint_writer is None:
-            self._joint_writer = self._make_writer(f"/{self._safe(robot)}/joint_states", self._JointState)
+            self._joint_writer = self._make_writer(self.joint_states_topic(robot), self._JointState)
         msg = self._JointState(
             header=self._header(self._safe(robot)),
             name=list(names),
@@ -180,8 +175,7 @@ class RtpsHardwareBridge:
         key = f"{robot}/{camera}"
         writer = self._image_writers.get(key)
         if writer is None:
-            topic = f"/{self._safe(robot)}/{self._safe(camera)}/image_raw"
-            writer = self._make_writer(topic, self._Image)
+            writer = self._make_writer(self.image_topic(robot, camera), self._Image)
             self._image_writers[key] = writer
         height, width = int(image.shape[0]), int(image.shape[1])
         msg = self._Image(
@@ -209,33 +203,15 @@ class RtpsHardwareBridge:
     def _on_command(self, msg: Any) -> None:
         """Forward an inbound ``joint_command`` JointState to ``send_action``.
 
-        Identical contract to the rclpy bridge: zip ``name``/``position`` into a
-        flat ``{motor.pos: float}`` action; reject mismatched/empty messages
-        rather than partially applying; surface (never raise) ``send_action``
-        errors.
+        Delegates to :meth:`RosTelemetryBase._drive_from_command` (shared with
+        the rclpy bridge): zip ``name``/``position`` into a flat
+        ``{motor.pos: float}`` action; reject mismatched messages rather than
+        partially applying; surface (never raise) ``send_action`` errors.
+        ``skip_empty=True`` because cyclonedds ``take()`` may surface a wholly
+        empty sample (DDS dispose / keep-alive) that is not a real actuation
+        request, so it is dropped quietly rather than warned on.
         """
-        names = list(getattr(msg, "name", []) or [])
-        positions = list(getattr(msg, "position", []) or [])
-        # cyclonedds take() may surface invalid/empty samples (DDS dispose or
-        # keep-alive); a wholly empty command is not a real actuation request,
-        # so skip it quietly rather than warning on a non-event.
-        if not names and not positions:
-            return
-        if not names or len(names) != len(positions):
-            logger.warning(
-                "RtpsHardwareBridge: ignoring joint_command with name/position length mismatch (%d vs %d)",
-                len(names),
-                len(positions),
-            )
-            return
-        action = {name: float(pos) for name, pos in zip(names, positions)}
-        try:
-            result = self._robot.send_action(action)  # type: ignore[union-attr]
-        except Exception:
-            logger.warning("RtpsHardwareBridge: send_action raised on joint_command; arm not moved", exc_info=True)
-            return
-        if isinstance(result, dict) and result.get("status") == "error":
-            logger.warning("RtpsHardwareBridge: send_action rejected joint_command: %s", result)
+        self._drive_from_command(self._robot, msg, skip_empty=True)
 
     def _poll_loop(self) -> None:
         """Poll the command reader and dispatch new samples to ``_on_command``.
@@ -248,7 +224,7 @@ class RtpsHardwareBridge:
                 for sample in self._command_reader.take(N=10):
                     self._on_command(sample)
             except Exception:
-                logger.debug("RtpsHardwareBridge: command poll raised", exc_info=True)
+                logger.debug("HardwareRtpsBridge: command poll raised", exc_info=True)
             self._stop.wait(self._poll_period)
 
     def _start_poll(self) -> None:
@@ -262,7 +238,7 @@ class RtpsHardwareBridge:
         )
         self._poll_thread.start()
         logger.info(
-            "RtpsHardwareBridge: driving %r from /%s/joint_command (cyclonedds, no rclpy)",
+            "HardwareRtpsBridge: driving %r from /%s/joint_command (cyclonedds, no rclpy)",
             self._command_robot_name,
             self._command_robot_name,
         )
@@ -285,6 +261,6 @@ class RtpsHardwareBridge:
 
     def __repr__(self) -> str:
         return (
-            f"RtpsHardwareBridge(robot={self._robot_name!r}, domain_id={self._domain_id}, "
+            f"HardwareRtpsBridge(robot={self._robot_name!r}, domain_id={self._domain_id}, "
             f"enable_commands={self._enable_commands})"
         )

--- a/strands_robots/ros_telemetry.py
+++ b/strands_robots/ros_telemetry.py
@@ -10,17 +10,24 @@ identical on the ROS 2 graph:
 * ``/<robot>/<camera>/image_raw`` (``sensor_msgs/msg/Image``, ``rgb8``) - one
   message per camera frame.
 
-This module holds the rclpy machinery once - node ownership, topic mangling,
-per-robot publisher caching, and message construction - so the sim and hardware
-bridges are thin, symmetric subclasses that differ only in their default node
-name. ``rclpy`` and the ROS 2 message packages are optional, system-provided
-dependencies (they are not on PyPI); they are imported lazily through
+The ROS 2 *wire contract* - topic names, name sanitization, and inbound
+``joint_command`` parsing - lives in the transport-agnostic
+:class:`RosTelemetryBase`, so the rclpy and pure-RTPS
+(:class:`strands_robots.hardware_rtps_bridge.HardwareRtpsBridge`) transports
+are byte-identical on the graph by construction, not by two independent
+codepaths happening to agree. :class:`RosTelemetryBridge` adds the rclpy
+machinery on top - node ownership, per-robot publisher caching, and message
+construction - so the sim and hardware bridges are thin, symmetric subclasses
+that differ only in their default node name. ``rclpy`` and the ROS 2 message
+packages are optional, system-provided dependencies (they are not on PyPI);
+they are imported lazily through
 :func:`strands_robots.utils.require_optional`, so importing this module - and
 running with the bridge disabled - never requires ROS 2.
 """
 
 from __future__ import annotations
 
+import logging
 import os
 from typing import TYPE_CHECKING, Any
 
@@ -29,13 +36,111 @@ from strands_robots.utils import require_optional
 if TYPE_CHECKING:
     import numpy as np
 
+logger = logging.getLogger(__name__)
 
-class RosTelemetryBridge:
+
+class RosTelemetryBase:
+    """Transport-agnostic ROS 2 wire contract shared by every telemetry bridge.
+
+    The rclpy bridges (:class:`RosTelemetryBridge` and its
+    :class:`~strands_robots.hardware_ros_bridge.HardwareRosBridge` /
+    :class:`~strands_robots.simulation.ros_bridge.SimRosBridge` subclasses) and
+    the pure-RTPS bridge
+    (:class:`~strands_robots.hardware_rtps_bridge.HardwareRtpsBridge`) all derive
+    from this base, so the ROS 2 topic names and the inbound ``joint_command``
+    parsing live in exactly one place. That makes the two transports
+    byte-identical on the ROS 2 graph by construction rather than relying on two
+    independent codepaths staying in sync as the contract evolves.
+
+    This base pulls in no transport library; each subclass owns its own
+    rclpy / cyclonedds machinery and message construction.
+    """
+
+    @staticmethod
+    def _safe(name: str) -> str:
+        """Map a robot/camera name to a valid ROS 2 topic segment."""
+        return "".join(c if (c.isalnum() or c == "_") else "_" for c in name).strip("_") or "robot"
+
+    @staticmethod
+    def _resolve_robot_name(robot: Any) -> str:
+        """Namespace topics under the bound robot's name.
+
+        Prefers the lerobot device ``.name`` (e.g. ``so101``), falling back to
+        the strands tool name, so ``joint_command`` and ``joint_states`` share
+        one namespace - a controller can echo our published joint names straight
+        back to drive the arm.
+        """
+        inner = getattr(robot, "robot", None)
+        return getattr(inner, "name", None) or getattr(robot, "tool_name_str", None) or "robot"
+
+    @classmethod
+    def joint_states_topic(cls, robot: str) -> str:
+        """ROS 2 topic a robot's ``JointState`` telemetry is published on."""
+        return f"/{cls._safe(robot)}/joint_states"
+
+    @classmethod
+    def image_topic(cls, robot: str, camera: str) -> str:
+        """ROS 2 topic a robot camera's ``Image`` frames are published on."""
+        return f"/{cls._safe(robot)}/{cls._safe(camera)}/image_raw"
+
+    @classmethod
+    def joint_command_topic(cls, robot: str) -> str:
+        """ROS 2 topic inbound ``joint_command`` messages are read from."""
+        return f"/{cls._safe(robot)}/joint_command"
+
+    def _command_action(self, msg: Any, *, skip_empty: bool = False) -> dict[str, float] | None:
+        """Parse an inbound ``joint_command`` ``JointState`` into an action dict.
+
+        Returns ``{motor: pos}`` ready for ``Robot.send_action``, or ``None``
+        when the message must be ignored. With ``skip_empty=True`` a wholly
+        empty sample (a DDS dispose / keep-alive, which is not a real actuation
+        request) is dropped silently; an empty or length-mismatched message is
+        otherwise rejected with a warning rather than partially applied, so a
+        malformed command never drives the arm to a surprising pose.
+        """
+        names = list(getattr(msg, "name", []) or [])
+        positions = list(getattr(msg, "position", []) or [])
+        if skip_empty and not names and not positions:
+            return None
+        if not names or len(names) != len(positions):
+            logger.warning(
+                "%s: ignoring joint_command with name/position length mismatch (%d vs %d)",
+                type(self).__name__,
+                len(names),
+                len(positions),
+            )
+            return None
+        return {name: float(pos) for name, pos in zip(names, positions)}
+
+    def _drive_from_command(self, robot: Any, msg: Any, *, skip_empty: bool = False) -> None:
+        """Forward an inbound ``joint_command`` to ``robot.send_action``.
+
+        Shared by both hardware bridges: parse via :meth:`_command_action`, then
+        dispatch the flat ``{motor.pos: float}`` action, surfacing (never
+        raising) a ``send_action`` failure so a bad command cannot kill the
+        command loop.
+        """
+        action = self._command_action(msg, skip_empty=skip_empty)
+        if action is None:
+            return
+        try:
+            result = robot.send_action(action)
+        except Exception:
+            logger.warning("%s: send_action raised on joint_command; arm not moved", type(self).__name__, exc_info=True)
+            return
+        if isinstance(result, dict) and result.get("status") == "error":
+            logger.warning("%s: send_action rejected joint_command: %s", type(self).__name__, result)
+
+
+class RosTelemetryBridge(RosTelemetryBase):
     """A thin rclpy publisher for per-robot joint state and camera frames.
 
     Subclassed by :class:`SimRosBridge` and :class:`HardwareRosBridge`, which
     set a distinguishing default ``node_name`` but share every publish path so
     a simulated robot and a real one are byte-for-byte identical on the wire.
+    Topic naming and the inbound command contract come from
+    :class:`RosTelemetryBase`, which the pure-RTPS bridge also derives from, so
+    the rclpy and cyclonedds transports advertise the same topics.
 
     Args:
         domain_id: ROS 2 domain (``ROS_DOMAIN_ID``) the bridge publishes on.
@@ -74,19 +179,13 @@ class RosTelemetryBridge:
         self._joint_pubs: dict[str, Any] = {}
         self._image_pubs: dict[str, Any] = {}
 
-    @staticmethod
-    def _safe(name: str) -> str:
-        """Map a robot/camera name to a valid ROS 2 topic segment."""
-        return "".join(c if (c.isalnum() or c == "_") else "_" for c in name).strip("_") or "robot"
-
     def _now(self) -> Any:
         return self._node.get_clock().now().to_msg()
 
     def _joint_publisher(self, robot: str) -> Any:
         pub = self._joint_pubs.get(robot)
         if pub is None:
-            topic = f"/{self._safe(robot)}/joint_states"
-            pub = self._node.create_publisher(self._JointState, topic, self._qos_depth)
+            pub = self._node.create_publisher(self._JointState, self.joint_states_topic(robot), self._qos_depth)
             self._joint_pubs[robot] = pub
         return pub
 
@@ -94,8 +193,7 @@ class RosTelemetryBridge:
         key = f"{robot}/{camera}"
         pub = self._image_pubs.get(key)
         if pub is None:
-            topic = f"/{self._safe(robot)}/{self._safe(camera)}/image_raw"
-            pub = self._node.create_publisher(self._Image, topic, self._qos_depth)
+            pub = self._node.create_publisher(self._Image, self.image_topic(robot, camera), self._qos_depth)
             self._image_pubs[key] = pub
         return pub
 

--- a/tests/test_hardware_rtps_bridge.py
+++ b/tests/test_hardware_rtps_bridge.py
@@ -1,4 +1,4 @@
-"""Behavior tests for the pure-RTPS hardware bridge (``RtpsHardwareBridge``).
+"""Behavior tests for the pure-RTPS hardware bridge (``HardwareRtpsBridge``).
 
 ``cyclonedds`` is an optional pip dependency, so these tests inject a fake
 ``cyclonedds`` (domain/pub/sub/topic) into ``sys.modules`` to exercise the
@@ -167,9 +167,9 @@ class _FakeRobot:
 
 
 def _bridge(robot=None, **kw):
-    from strands_robots.hardware_rtps_bridge import RtpsHardwareBridge
+    from strands_robots.hardware_rtps_bridge import HardwareRtpsBridge
 
-    return RtpsHardwareBridge(robot, **kw)  # type: ignore[arg-type]
+    return HardwareRtpsBridge(robot, **kw)  # type: ignore[arg-type]
 
 
 def test_publish_joint_states_uses_mangled_topic_and_fields(fake_cyclonedds: dict[str, Any]) -> None:
@@ -241,7 +241,7 @@ def test_shutdown_is_idempotent(fake_cyclonedds: dict[str, Any]) -> None:
 def test_missing_cyclonedds_raises_importerror(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(utils_mod, "_lazy_modules", {}, raising=False)
     monkeypatch.setitem(sys.modules, "cyclonedds", None)
-    from strands_robots.hardware_rtps_bridge import RtpsHardwareBridge
+    from strands_robots.hardware_rtps_bridge import HardwareRtpsBridge
 
     with pytest.raises(ImportError):
-        RtpsHardwareBridge(_FakeRobot())  # type: ignore[arg-type]
+        HardwareRtpsBridge(_FakeRobot())  # type: ignore[arg-type]

--- a/tests/test_ros_telemetry_topic_parity.py
+++ b/tests/test_ros_telemetry_topic_parity.py
@@ -1,0 +1,91 @@
+"""The rclpy and RTPS hardware bridges are one symmetric pair on the ROS 2 graph.
+
+A real arm exposed over rclpy (``HardwareRosBridge``) and the same arm exposed
+over pure RTPS/cyclonedds (``HardwareRtpsBridge``) must advertise byte-identical
+topics so an external ROS 2 node cannot tell the transports apart. These tests
+pin the *structural* guarantee behind that promise: both transports - and the
+sim bridge - derive from :class:`RosTelemetryBase`, the single source of truth
+for topic names and the inbound ``joint_command`` contract, so the two
+codepaths cannot drift as the contract evolves.
+
+These tests need neither rclpy nor cyclonedds: they exercise the
+transport-agnostic base directly.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from strands_robots.hardware_ros_bridge import HardwareRosBridge
+from strands_robots.hardware_rtps_bridge import HardwareRtpsBridge
+from strands_robots.ros_telemetry import RosTelemetryBase, RosTelemetryBridge
+from strands_robots.simulation.ros_bridge import SimRosBridge
+
+
+def test_every_telemetry_bridge_derives_from_the_shared_base() -> None:
+    # The structural guarantee: one base owns the wire contract for both
+    # transports (and the sim bridge), so they cannot diverge.
+    for cls in (RosTelemetryBridge, HardwareRosBridge, SimRosBridge, HardwareRtpsBridge):
+        assert issubclass(cls, RosTelemetryBase), f"{cls.__name__} must derive from RosTelemetryBase"
+
+
+@pytest.mark.parametrize(
+    "robot,camera",
+    [
+        ("so101", "wrist"),
+        ("arm 1", "cam/2"),  # characters needing sanitization
+        ("--lead--", "front cam"),
+        ("", ""),  # degenerate -> both fall back identically
+    ],
+)
+def test_topic_names_identical_across_transports(robot: str, camera: str) -> None:
+    # rclpy and RTPS resolve the same wire names for every input, because both
+    # inherit the same classmethods from the base.
+    assert RosTelemetryBridge.joint_states_topic(robot) == HardwareRtpsBridge.joint_states_topic(robot)
+    assert RosTelemetryBridge.image_topic(robot, camera) == HardwareRtpsBridge.image_topic(robot, camera)
+    assert RosTelemetryBridge.joint_command_topic(robot) == HardwareRtpsBridge.joint_command_topic(robot)
+
+
+def test_topic_name_format_is_the_documented_contract() -> None:
+    assert RosTelemetryBase.joint_states_topic("so101") == "/so101/joint_states"
+    assert RosTelemetryBase.image_topic("so101", "wrist") == "/so101/wrist/image_raw"
+    assert RosTelemetryBase.joint_command_topic("so101") == "/so101/joint_command"
+    # Unsafe segments are sanitized to alnum/underscore and never leak.
+    assert RosTelemetryBase.joint_states_topic("a/b 1") == "/a_b_1/joint_states"
+
+
+class _Msg:
+    def __init__(self, name: list[str], position: list[float]) -> None:
+        self.name = name
+        self.position = position
+
+
+def test_command_action_shared_contract() -> None:
+    base = RosTelemetryBase()
+    assert base._command_action(_Msg(["a", "b"], [0.1, 0.2])) == {"a": 0.1, "b": 0.2}
+    # Length mismatch is rejected (returns None) rather than partially applied.
+    assert base._command_action(_Msg(["a", "b"], [0.1])) is None
+    # An empty message is rejected; with skip_empty it is dropped silently.
+    assert base._command_action(_Msg([], [])) is None
+    assert base._command_action(_Msg([], []), skip_empty=True) is None
+
+
+def test_drive_from_command_dispatches_and_surfaces_errors() -> None:
+    base = RosTelemetryBase()
+
+    sent: list[dict[str, float]] = []
+
+    class _OkRobot:
+        def send_action(self, action: dict[str, float]) -> dict[str, str]:
+            sent.append(action)
+            return {"status": "success"}
+
+    base._drive_from_command(_OkRobot(), _Msg(["a"], [0.5]))
+    assert sent == [{"a": 0.5}]
+
+    # A raising send_action is surfaced (logged), never propagated.
+    class _BoomRobot:
+        def send_action(self, action: dict[str, float]) -> dict[str, str]:
+            raise RuntimeError("bus fault")
+
+    base._drive_from_command(_BoomRobot(), _Msg(["a"], [0.5]))  # must not raise


### PR DESCRIPTION
## Problem

A real arm exposed over rclpy (`HardwareRosBridge`) and the same arm exposed over pure RTPS/cyclonedds advertise the same ROS 2 topics, so an external ROS 2 node cannot tell the transports apart. That "byte-identical topics" guarantee was, however, maintained by **two independent codepaths**:

```
HardwareRosBridge.__mro__:  [HardwareRosBridge, RosTelemetryBridge, object]   # shares the contract
RtpsHardwareBridge.__mro__: [RtpsHardwareBridge, object]                       # parallel impl
```

The RTPS bridge re-derived the topic names, the `_safe` segment sanitizer, robot-name resolution, and the inbound `joint_command` -> `send_action` parsing on its own. Any future change to `RosTelemetryBridge` (a QoS/naming policy tweak, a `joint_command` validation change) would silently diverge between the rclpy and cyclonedds transports. Separately, the RTPS class name `RtpsHardwareBridge` flipped word order versus its sibling `HardwareRosBridge`, which trips grep/completion.

## Change

Extract a transport-agnostic `RosTelemetryBase` (in `strands_robots.ros_telemetry`) that owns the entire wire contract in one place:

- topic builders `joint_states_topic` / `image_topic` / `joint_command_topic`,
- the `_safe` topic-segment sanitizer,
- `_resolve_robot_name` (lerobot `.name` -> tool name fallback),
- `_command_action` (parse/validate a `joint_command` JointState) and `_drive_from_command` (dispatch to `send_action`, surface-not-raise on failure).

Every telemetry bridge now derives from it: `RosTelemetryBridge` (and its `SimRosBridge` / `HardwareRosBridge` subclasses) **and** the RTPS bridge. The two transports are therefore identical on the ROS 2 graph **by construction**, not by two hand-synced codepaths. The duplicated `_safe` / `_resolve_robot_name` / `_on_command` bodies are removed; `_on_command` in each hardware bridge is now a one-line delegation (`HardwareRosBridge` calls `_drive_from_command`; `HardwareRtpsBridge` calls it with `skip_empty=True` for the DDS dispose/keep-alive case).

Rename the RTPS bridge class `RtpsHardwareBridge` -> `HardwareRtpsBridge` so it matches its rclpy sibling `HardwareRosBridge` (both `Hardware*Bridge`). The module path (`strands_robots.hardware_rtps_bridge`), the top-level lazy export, and `Robot(..., ros2_transport="rtps")` selection are unchanged - only the class name. All call sites are updated (no alias/shim).

**No wire behavior change**: published topics, message layouts, and the `joint_command` contract are byte-identical before and after.

## Tests

New `tests/test_ros_telemetry_topic_parity.py` pins the structural guarantee (rclpy- and cyclonedds-free; it exercises the base directly):

- every bridge (`RosTelemetryBridge`, `HardwareRosBridge`, `SimRosBridge`, `HardwareRtpsBridge`) derives from `RosTelemetryBase`;
- both transports resolve identical `joint_states` / `image_raw` / `joint_command` topic names across a battery of inputs (incl. names needing sanitization and the degenerate empty fallback);
- the shared `_command_action` / `_drive_from_command` contract: zip to `{motor: pos}`, reject length-mismatch and empty, dispatch, and surface (never raise) a failing `send_action`.

This test fails on `main` (neither `RosTelemetryBase` nor `HardwareRtpsBridge` exist there) and passes after the refactor.

Gate: `ruff check` + `ruff format --check` clean; `mypy strands_robots tests tests_integ` clean (525 files); `202 passed, 1 skipped` across the hardware/ros/rtps/sim-bridge/factory/use_ros/mesh-ros suites including the new parity tests.

Docs (`docs/ros2-integration.md`, `docs/rtps-integration.md`) and `CHANGELOG.md` updated in this PR.

The live DDS/rclpy roundtrip is unchanged by this refactor (pure structural dedup + rename); the existing fake-rclpy / fake-cyclonedds suites continue to cover both transports' wiring.