### PR TITLE
fix(sim): honour configured gravity in the Newton backend; add set_gravity/set_timestep

### DIFF
--- a/docs/simulation/newton.md
+++ b/docs/simulation/newton.md
@@ -83,7 +83,16 @@ no-op until then.
   without modification.
 - `run_policy` / `eval_policy` / `replay_episode` are inherited from the
   `SimEngine` ABC - no backend-specific re-implementation.
-- `describe()` reports the active solver, available solvers, and device.
+- `describe()` reports the active solver, available solvers, device, and
+  the current gravity vector and timestep.
+- Gravity configured via `create_world(gravity=[x, y, z])` or `set_gravity`
+  drives the dynamics. Newton's solvers snapshot gravity at construction and
+  its builder only expresses gravity as a scalar along the up-axis, so the
+  full vector is written onto the finalised model before the solver is built;
+  off-axis components are honoured rather than dropped. `set_gravity` accepts
+  either a scalar (the z-component) or a 3-element `[x, y, z]` list and rebuilds
+  the model, which re-initialises the world to its rest pose. `set_timestep`
+  takes effect on the next `step()` without a rebuild.
 
 ## Limitations
 

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -452,6 +452,85 @@ class NewtonSimEngine(SimEngine):
             return None
         return float(self._world.timestep)
 
+    def set_gravity(self, gravity: list[float] | float | int) -> dict[str, Any]:
+        """Set the world gravity vector and rebuild so the solver applies it.
+
+        Mirrors the MuJoCo backend: a scalar is interpreted as the z-component
+        ``[0, 0, g]``; a 3-element list sets the full ``[x, y, z]`` vector in
+        m/s^2. Newton's solver snapshots gravity at construction time, so the
+        model is rebuilt; this re-initialises the world to its rest pose, so
+        prefer setting gravity before stepping. Live joint targets are
+        preserved across the rebuild.
+
+        Args:
+            gravity: Scalar z-gravity, or a 3-element ``[x, y, z]`` vector.
+
+        Returns:
+            Status dict echoing the applied gravity, or an error dict when no
+            world exists or the argument is not a finite 3-vector / scalar.
+        """
+        if self._world is None or self._model is None:
+            return {"status": "error", "content": [{"text": "No world. Call create_world first."}]}
+        if isinstance(gravity, (int, float)):
+            gravity = [0.0, 0.0, float(gravity)]
+        try:
+            if len(gravity) != 3:
+                return {
+                    "status": "error",
+                    "content": [
+                        {"text": f"set_gravity: 'gravity' must be a 3-element list [x,y,z], got {len(gravity)}"}
+                    ],
+                }
+            gravity = [float(g) for g in gravity]
+        except (TypeError, ValueError) as exc:
+            return {
+                "status": "error",
+                "content": [{"text": f"set_gravity: 'gravity' must be a 3-element list of numbers ({exc})"}],
+            }
+        if not all(math.isfinite(g) for g in gravity):
+            return {
+                "status": "error",
+                "content": [{"text": f"set_gravity: all components must be finite, got {gravity}"}],
+            }
+        with self._lock:
+            self._world.gravity = gravity
+            self._rebuild()
+        return {"status": "success", "content": [{"text": f"Gravity: {gravity}"}]}
+
+    def set_timestep(self, timestep: float) -> dict[str, Any]:
+        """Set the physics integration timestep in seconds.
+
+        Mirrors the MuJoCo backend. Newton reads the timestep live on each
+        :meth:`step` (``dt = timestep / substeps``), so no model rebuild is
+        required and the change takes effect on the next step.
+
+        Args:
+            timestep: Positive integration timestep in seconds.
+
+        Returns:
+            Status dict reporting the timestep and equivalent control rate, or
+            an error dict when no world exists or the value is not finite and
+            positive.
+        """
+        if self._world is None or self._model is None:
+            return {"status": "error", "content": [{"text": "No world. Call create_world first."}]}
+        try:
+            timestep = float(timestep)
+        except (TypeError, ValueError):
+            return {
+                "status": "error",
+                "content": [{"text": f"set_timestep: must be a positive number, got {timestep!r}"}],
+            }
+        if not math.isfinite(timestep) or timestep <= 0:
+            return {
+                "status": "error",
+                "content": [{"text": f"set_timestep: must be a finite positive number, got {timestep}"}],
+            }
+        warn = " Warning: unusually large timestep (>0.1s); physics may be unstable" if timestep > 0.1 else ""
+        with self._lock:
+            self._world.timestep = timestep
+        return {"status": "success", "content": [{"text": f"Timestep: {timestep}s ({1 / timestep:.0f}Hz){warn}"}]}
+
     # Rendering
 
     def render(
@@ -558,6 +637,7 @@ class NewtonSimEngine(SimEngine):
             "robots": self.list_robots(),
             "objects": list(self._world.objects) if self._world else [],
             "timestep": self._world.timestep if self._world else self.default_timestep,
+            "gravity": list(self._world.gravity) if self._world else [0.0, 0.0, -9.81],
         }
 
     def cleanup(self, policy_stop_timeout: float | None = None) -> None:
@@ -666,6 +746,23 @@ class NewtonSimEngine(SimEngine):
             self._world.sim_time += self._world.timestep
             self._world.step_count += 1
 
+    def _apply_gravity(self) -> None:
+        """Write the world's gravity vec3 onto the finalized model.
+
+        Must be called with ``self._lock`` held, after ``builder.finalize`` and
+        before the solver is constructed (Newton solvers snapshot gravity at
+        construction). Newton stores one gravity vec3 per parallel world; the
+        same world-gravity vector is broadcast to each of them. A no-op when no
+        model or gravity buffer exists yet.
+        """
+        assert self._world is not None and self._model is not None
+        grav = self._model.gravity
+        if grav is None:
+            return
+        n_worlds = grav.shape[0]
+        vec = np.tile(np.asarray(self._world.gravity, dtype=np.float32), (n_worlds, 1))
+        self._model.gravity = self._wp.array(vec, dtype=self._wp.vec3, device=self._model.device)
+
     def _write_targets(self) -> None:
         """Push pending position targets into the Newton control buffer.
 
@@ -721,6 +818,13 @@ class NewtonSimEngine(SimEngine):
             builder.add_ground_plane()
 
         self._model = builder.finalize(device=self.device)
+        # Newton solvers snapshot gravity at construction, and ModelBuilder only
+        # expresses gravity as a scalar magnitude along its up-axis (silently
+        # dropping any non-axis-aligned component). Write the world's full
+        # gravity vec3 onto the finalized model BEFORE building the solver so an
+        # arbitrary gravity vector configured via create_world / set_gravity is
+        # honoured instead of being ignored.
+        self._apply_gravity()
         # Rigid-body solvers (notably SolverMuJoCo) require at least one joint.
         # An empty world (ground plane only) has none, so defer solver creation
         # until a robot is added; stepping is a no-op until then.

--- a/tests/simulation/newton/test_gravity_timestep.py
+++ b/tests/simulation/newton/test_gravity_timestep.py
@@ -1,0 +1,167 @@
+"""Gravity honouring and physics-parameter setters for the Newton backend.
+
+The Newton backend previously built its model without writing the configured
+gravity vector onto the finalised model, so ``create_world(gravity=...)`` was
+silently ignored and every world fell under Newton's built-in default. These
+tests pin that a configured gravity vector actually drives the dynamics and
+that ``set_gravity`` / ``set_timestep`` mirror the MuJoCo backend's contract.
+
+Gated on Newton + a usable compute device: the dynamics assertions step the
+real solver, so they are skipped when Newton/Warp are unavailable.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+_HAS_NEWTON = importlib.util.find_spec("newton") is not None and importlib.util.find_spec("warp") is not None
+
+pytestmark = pytest.mark.skipif(not _HAS_NEWTON, reason="newton/warp not installed")
+
+
+def _make_engine():
+    from strands_robots.simulation.newton.simulation import NewtonSimEngine
+
+    return NewtonSimEngine(solver="mujoco")
+
+
+def _ball_z(engine) -> float:
+    """Return the current world-z of the single free body."""
+    return float(engine._state_0.body_q.numpy()[0][2])
+
+
+def _ball_x(engine) -> float:
+    return float(engine._state_0.body_q.numpy()[0][0])
+
+
+class TestGravityHonoured:
+    def test_zero_gravity_keeps_ball_static(self):
+        """Regression: zero gravity must leave a free body at rest.
+
+        Pre-fix the configured gravity was dropped, so the ball fell under the
+        engine default even when zero gravity was requested.
+        """
+        sim = _make_engine()
+        try:
+            sim.create_world(gravity=[0.0, 0.0, 0.0])
+            sim.add_object("ball", shape="sphere", position=[0.0, 0.0, 0.5], size=[0.05], mass=0.2)
+            z0 = _ball_z(sim)
+            sim.step(50)
+            assert _ball_z(sim) == pytest.approx(z0, abs=1e-3)
+        finally:
+            sim.destroy()
+
+    def test_negative_gravity_makes_ball_fall(self):
+        sim = _make_engine()
+        try:
+            sim.create_world(gravity=[0.0, 0.0, -9.81])
+            sim.add_object("ball", shape="sphere", position=[0.0, 0.0, 0.5], size=[0.05], mass=0.2)
+            z0 = _ball_z(sim)
+            sim.step(50)
+            assert _ball_z(sim) < z0 - 1e-2
+        finally:
+            sim.destroy()
+
+    def test_inverted_gravity_makes_ball_rise(self):
+        sim = _make_engine()
+        try:
+            sim.create_world(gravity=[0.0, 0.0, 5.0])
+            sim.add_object("ball", shape="sphere", position=[0.0, 0.0, 0.5], size=[0.05], mass=0.2)
+            z0 = _ball_z(sim)
+            sim.step(50)
+            assert _ball_z(sim) > z0 + 1e-3
+        finally:
+            sim.destroy()
+
+    def test_non_axis_aligned_gravity_drives_lateral_drift(self):
+        """A gravity vector with an x-component must move the body in x.
+
+        Newton's builder only expresses gravity as a scalar along its up-axis;
+        the full vec3 is written onto the finalised model so off-axis
+        components are not silently dropped.
+        """
+        sim = _make_engine()
+        try:
+            sim.create_world(gravity=[3.0, 0.0, -9.81])
+            sim.add_object("ball", shape="sphere", position=[0.0, 0.0, 0.5], size=[0.05], mass=0.2)
+            x0 = _ball_x(sim)
+            sim.step(50)
+            assert _ball_x(sim) > x0 + 1e-3
+        finally:
+            sim.destroy()
+
+
+class TestSetGravity:
+    def test_set_gravity_scalar_is_z_component(self):
+        sim = _make_engine()
+        try:
+            sim.create_world()
+            result = sim.set_gravity(0.0)
+            assert result["status"] == "success"
+            assert sim.describe()["gravity"] == [0.0, 0.0, 0.0]
+            sim.add_object("ball", shape="sphere", position=[0.0, 0.0, 0.5], size=[0.05], mass=0.2)
+            z0 = _ball_z(sim)
+            sim.step(50)
+            assert _ball_z(sim) == pytest.approx(z0, abs=1e-3)
+        finally:
+            sim.destroy()
+
+    def test_set_gravity_rejects_wrong_length(self):
+        sim = _make_engine()
+        try:
+            sim.create_world()
+            result = sim.set_gravity([1.0, 2.0])
+            assert result["status"] == "error"
+            assert "3-element" in result["content"][0]["text"]
+        finally:
+            sim.destroy()
+
+    def test_set_gravity_rejects_non_finite(self):
+        sim = _make_engine()
+        try:
+            sim.create_world()
+            result = sim.set_gravity([0.0, 0.0, float("inf")])
+            assert result["status"] == "error"
+            assert "finite" in result["content"][0]["text"]
+        finally:
+            sim.destroy()
+
+    def test_set_gravity_without_world_errors(self):
+        sim = _make_engine()
+        result = sim.set_gravity([0.0, 0.0, -9.81])
+        assert result["status"] == "error"
+        assert "create_world" in result["content"][0]["text"]
+
+
+class TestSetTimestep:
+    def test_set_timestep_updates_world(self):
+        sim = _make_engine()
+        try:
+            sim.create_world()
+            result = sim.set_timestep(0.002)
+            assert result["status"] == "success"
+            assert sim.physics_timestep() == pytest.approx(0.002)
+        finally:
+            sim.destroy()
+
+    def test_set_timestep_warns_on_large_value(self):
+        sim = _make_engine()
+        try:
+            sim.create_world()
+            result = sim.set_timestep(0.5)
+            assert result["status"] == "success"
+            assert "unusually large" in result["content"][0]["text"]
+        finally:
+            sim.destroy()
+
+    def test_set_timestep_rejects_non_positive(self):
+        sim = _make_engine()
+        try:
+            sim.create_world()
+            result = sim.set_timestep(0.0)
+            assert result["status"] == "error"
+            assert "positive" in result["content"][0]["text"]
+        finally:
+            sim.destroy()


### PR DESCRIPTION
## Problem

The Newton simulation backend ignored the gravity passed to `create_world(gravity=...)`. A free body fell under Newton's built-in default regardless of the requested vector, so zero-gravity and inverted-gravity worlds were impossible and any configured gravity was silently dropped.

```python
sim = create_simulation("newton", solver="mujoco")
sim.create_world(gravity=[0, 0, 0])          # requested: no gravity
sim.add_object("ball", shape="sphere", position=[0, 0, 0.5], mass=0.2)
z0 = ball_z(sim); sim.step(50)
# before: ball still falls (0.50 -> 0.466) -- gravity ignored
```

## Root cause

`_rebuild()` never wrote the world's gravity onto the finalised model. Two Newton specifics made the default leak through:

- Newton's solvers (notably `SolverMuJoCo`) **snapshot gravity at construction time**, so writing `model.gravity` after the solver is built has no effect.
- `ModelBuilder` only expresses gravity as a **scalar magnitude along its up-axis**, which additionally drops any non-axis-aligned component.

## Fix

Write the world's full gravity `vec3` onto the finalised model immediately after `builder.finalize()` and **before** the solver is constructed, broadcasting to each parallel world. This honours an arbitrary gravity vector (including off-axis components) instead of silently dropping it.

Adds, mirroring the MuJoCo backend's validation and return contract:

- `set_gravity(gravity)` -- scalar (z-component) or `[x, y, z]`; validates length / finiteness, rebuilds so the solver re-snapshots gravity.
- `set_timestep(timestep)` -- positive/finite validation, warns on `> 0.1s`; takes effect on the next `step()` without a rebuild (Newton reads `dt` live).
- `describe()` now reports the current `gravity` vector alongside `timestep`.

## Behaviour (so101 / sphere drop, 50 steps)

| gravity | before (z0 -> z1) | after (z0 -> z1) |
|---|---|---|
| `[0, 0, -9.81]` | 0.500 -> 0.466 (falls) | 0.500 -> 0.466 (falls) |
| `[0, 0, 0]` | 0.500 -> 0.466 (still falls -- bug) | 0.500 -> 0.500 (floats) |
| `[0, 0, 5]` | 0.500 -> 0.466 (still falls -- bug) | 0.500 -> 0.517 (rises) |
| `[3, 0, -9.81]` | x 0.000 -> 0.000 (no drift -- bug) | x 0.000 -> 0.010 (drifts) |

### Visual proof (MuJoCo-Warp solver, headless EGL)

Left `g = [0, 0, -9.81]` (falls) vs right `g = [0, 0, 0]` (floats):

![newton gravity demo](https://github.com/cagataycali/robots/releases/download/newton-gravity-demo-1782608005/newton_gravity.gif)

## Tests

New `tests/simulation/newton/test_gravity_timestep.py` (gated on Newton + Warp). The zero-gravity, inverted-gravity and off-axis-drift cases **fail on the pre-fix engine** (ball falls / no lateral drift) and pass after; plus `set_gravity` / `set_timestep` happy- and error-path coverage. Full `tests/simulation/newton/` green locally: 64 passed, 1 skipped (missing-dep path). Lint + format + mypy clean.