### PR TITLE
fix(sim): episode-count contract for run_policy + verify_dataset_episodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Correctness: `run_policy` episode-count contract + `verify_dataset_episodes`
+
+`run_policy` could silently record a single merged `episode_index=0`
+mega-episode while a caller believed it had collected N distinct episodes. The
+single-episode fast path returned none of the episode-count bookkeeping the
+multi-episode path did, and a `status="success"` rollout was no proof of
+episode-count correctness - frames buffer into the current episode and only
+flush to parquet at `save_episode`/`stop_recording`. An agent that calls
+`run_policy(n_episodes=1)` (the default) once but narrates "20 episodes" got a
+1-episode dataset and no signal that anything was wrong.
+
+- Both `run_policy` paths (single-episode fast path and the multi-episode
+  driver) now return the episode-count truth fields in their `{"json": {...}}`
+  block: `n_episodes_requested`, `n_episodes_completed`, `episodes_saved`, and
+  `dataset_episode_indices` (the episode indices the active recorder reports so
+  far). The fast path additionally sets `episode_flush_deferred=True` while
+  recording, making explicit that its rollout buffers into one episode that is
+  flushed at `stop_recording` rather than saved as a distinct boundary.
+- The fast path logs a single `INFO` line at run start when a recording is
+  active (`n_episodes=1, will produce 1 dataset episode ...`) so an agent driving
+  the tool sees the truth in its output and self-corrects on the next call.
+- New `SimEngine.verify_dataset_episodes(expected)` reads the on-disk LeRobot
+  parquet (the ground truth) after `stop_recording` and returns `status="error"`
+  when the recorded episode count differs from `expected`, with
+  `{expected, actual, episode_indices, total_frames, total_frames_per_ep, root}`
+  in the json block. Backed by the new pure-`pyarrow`
+  `strands_robots.dataset_recorder.read_dataset_episode_indices(root)` helper,
+  which parses `meta/episodes/**/*.parquet` without importing `lerobot`.
+- The `run_policy` `n_episodes` docstring and the MuJoCo `describe()` recording
+  surface now spell out the contract: pass `n_episodes=N` for N distinct
+  episodes, do not loop the call, and confirm with `verify_dataset_episodes`.
+
+No change to recorded trajectory content, video output, or the
+single-rollout payload shape (the per-episode `episodes` aggregate list is still
+absent on the fast path); only additive `{"json": {...}}` fields and a new
+verification method.
+
+
 ### Refactor: unify the rclpy + RTPS hardware ROS 2 bridges under `RosTelemetryBase`
 
 The two hardware ROS 2 transports now share a single source of truth for the

--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -24,6 +24,7 @@ import functools
 import logging
 import re
 import sys
+from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -782,7 +783,6 @@ class DatasetRecorder:
         """
         import shutil
         import subprocess
-        from pathlib import Path
 
         if shutil.which("hf") is None:
             return {
@@ -913,3 +913,75 @@ def load_lerobot_episode(repo_id: str, episode: int = 0, root: str | None = None
         raise ValueError(f"Episode {episode} has no frames")
 
     return ds, episode_start, episode_length
+
+
+def read_dataset_episode_indices(root: str | Path) -> dict[str, Any]:
+    """Read episode-level ground truth from a LeRobot v3 dataset on disk.
+
+    Parses every ``meta/episodes/**/*.parquet`` file under ``root`` and returns
+    the recorded episode index set plus per-episode frame counts. This is the
+    parquet source of truth used by :meth:`SimEngine.verify_dataset_episodes`
+    to confirm a recording session produced the number of distinct episodes the
+    caller intended (rather than one merged ``episode_index=0`` mega-episode).
+
+    Pure ``pyarrow`` read - it does NOT import ``lerobot`` or instantiate a
+    ``LeRobotDataset`` (which would re-validate/scan the whole dataset). Reads
+    only the lightweight episode metadata parquet.
+
+    Args:
+        root: Dataset root directory (the dir that contains ``meta/``).
+
+    Returns:
+        Dict with:
+          - ``episode_indices``: sorted list of distinct ``episode_index`` values.
+          - ``total_episodes``: number of distinct episodes (``len`` of above).
+          - ``total_frames``: sum of per-episode ``length`` (0 if unavailable).
+          - ``frames_per_episode``: per-episode frame counts aligned to
+            ``episode_indices`` (empty list if the ``length`` column is absent).
+
+    Raises:
+        ImportError: If ``pyarrow`` is not installed.
+        FileNotFoundError: If no ``meta/episodes`` parquet exists under ``root``
+            (no episode was ever flushed - the dataset is empty/unfinalized).
+    """
+    try:
+        import pyarrow.parquet as pq
+    except ImportError as e:  # pragma: no cover - pyarrow ships with lerobot
+        raise ImportError("read_dataset_episode_indices requires pyarrow (installed with the lerobot extra).") from e
+
+    root_path = Path(root)
+    parquet_files = sorted((root_path / "meta" / "episodes").glob("**/*.parquet"))
+    if not parquet_files:
+        raise FileNotFoundError(
+            f"No meta/episodes parquet under {root_path}. The dataset is empty or was "
+            "never finalized (episodes are flushed to parquet at stop_recording/finalize)."
+        )
+
+    pairs: list[tuple[int, int]] = []
+    seen: set[int] = set()
+    for pf in parquet_files:
+        table = pq.read_table(pf)
+        cols = table.column_names
+        if "episode_index" not in cols:
+            continue
+        data = table.to_pydict()
+        ep_indices = data["episode_index"]
+        lengths = data.get("length")
+        for i, ep in enumerate(ep_indices):
+            ep_int = int(ep)
+            if ep_int in seen:
+                continue
+            seen.add(ep_int)
+            length = int(lengths[i]) if lengths is not None and lengths[i] is not None else 0
+            pairs.append((ep_int, length))
+
+    pairs.sort(key=lambda p: p[0])
+    episode_indices = [p[0] for p in pairs]
+    frames_per_episode = [p[1] for p in pairs]
+    has_lengths = any(f > 0 for f in frames_per_episode)
+    return {
+        "episode_indices": episode_indices,
+        "total_episodes": len(episode_indices),
+        "total_frames": sum(frames_per_episode) if has_lengths else 0,
+        "frames_per_episode": frames_per_episode if has_lengths else [],
+    }

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -500,7 +500,14 @@ class SimEngine(ABC):
                 kwargs per the #300 contract, so forwarding is always safe.
             n_episodes: Number of sequential episode rollouts to run in this
                 single call (default ``1`` - the historical single-rollout
-                behaviour, unchanged). When ``> 1``, each episode runs one
+                behaviour, unchanged). IMPORTANT: calling with the default
+                ``n_episodes=1`` produces exactly ONE dataset episode, no matter
+                how many "episodes" you intend in natural language. To record N
+                DISTINCT dataset episodes pass ``n_episodes=N`` in a single call
+                - do NOT loop this call N times narrating "N episodes" (that
+                buffers all frames into one merged ``episode_index=0``
+                mega-episode). After ``stop_recording``, confirm the count with
+                :meth:`verify_dataset_episodes`. When ``> 1``, each episode runs one
                 rollout for the configured horizon, then a dataset episode
                 boundary is flushed via :meth:`save_episode` (only when a
                 recording is active) so the dataset ends up with N correctly
@@ -574,8 +581,17 @@ class SimEngine(ABC):
         # (no reset, no episode-boundary flush). n_episodes defaults to 1 so
         # existing callers are completely unaffected.
         if n_episodes == 1:
+            recording = self._is_recording()
+            if recording:
+                logger.info(
+                    "run_policy: n_episodes=1, will produce 1 dataset episode of ~%d frames "
+                    "(frames buffer into the current episode and flush at save_episode/"
+                    "stop_recording). To record N DISTINCT dataset episodes pass n_episodes=N "
+                    "- do NOT loop the tool call.",
+                    int(duration * control_frequency),
+                )
             on_frame = self._make_run_policy_hook(robot_name, instruction)
-            return runner.run(
+            result = runner.run(
                 robot_name,
                 policy,
                 instruction=instruction,
@@ -591,6 +607,12 @@ class SimEngine(ABC):
                 seed=seed,
                 async_rtc=async_rtc,
             )
+            completed = 1 if result.get("status") == "success" else 0
+            contract = self._episode_contract_fields(
+                requested=1, completed=completed, saved=0, flush_deferred=recording
+            )
+            self._merge_json_fields(result, contract)
+            return result
 
         # Multi-episode path: one rollout per episode, flushing a dataset
         # episode boundary (save_episode) when recording and resetting between
@@ -741,6 +763,20 @@ class SimEngine(ABC):
         return {}
 
     @staticmethod
+    def _merge_json_fields(result: dict[str, Any], fields: dict[str, Any]) -> None:
+        """Merge ``fields`` into the result's ``{"json": {...}}`` block in place.
+
+        Augments the first existing json content block, or appends a new one if
+        the result has none. Lets :meth:`run_policy` attach the episode-contract
+        fields onto a ``PolicyRunner.run`` result without rebuilding it.
+        """
+        for blk in result.get("content", []) or []:
+            if isinstance(blk, dict) and isinstance(blk.get("json"), dict):
+                blk["json"].update(fields)
+                return
+        result.setdefault("content", []).append({"json": dict(fields)})
+
+    @staticmethod
     def _episode_video_config(video: dict[str, Any] | None, episode: int) -> VideoConfig | None:
         """Per-episode :class:`VideoConfig` with ``_ep{i}`` in the filename.
 
@@ -781,10 +817,17 @@ class SimEngine(ABC):
         )
         if extra:
             text += f"\n{extra}"
+        dataset_episode_indices: list[int] = []
+        if self._is_recording():
+            recorder = self._active_recorder()
+            meta = getattr(getattr(recorder, "dataset", None), "meta", None)
+            total_episodes = int(getattr(meta, "total_episodes", 0) or 0) if meta is not None else 0
+            dataset_episode_indices = list(range(total_episodes))
         payload: dict[str, Any] = {
             "n_episodes_requested": n_episodes,
             "n_episodes_completed": completed,
             "episodes_saved": episodes_saved,
+            "dataset_episode_indices": dataset_episode_indices,
             "total_steps": total_steps,
             "episodes": episodes,
             "video_paths": video_paths,
@@ -799,6 +842,156 @@ class SimEngine(ABC):
         flushes episode boundaries on backends that actually record.
         """
         return False
+
+    def _active_recorder(self) -> Any:
+        """Return the active dataset recorder object, or ``None``.
+
+        Backends that support LeRobot dataset recording override this to expose
+        the live recorder (see the MuJoCo ``RecordingMixin``). The base has no
+        recorder, so it returns ``None``. Used by :meth:`run_policy` to read the
+        in-memory episode count for the episode-contract fields.
+        """
+        return None
+
+    def _active_dataset_root(self) -> str | None:
+        """On-disk root of the active (or most recent) recording, or ``None``.
+
+        Backends that record override this so :meth:`verify_dataset_episodes`
+        can locate the dataset parquet AFTER ``stop_recording`` has finalized it
+        (the recorder object is gone by then). The base has no recorder, so it
+        returns ``None``.
+        """
+        return None
+
+    def verify_dataset_episodes(self, expected: int) -> dict[str, Any]:
+        """Verify the recorded dataset holds exactly ``expected`` episodes.
+
+        Reads the LeRobot dataset parquet (the ground truth) for the active or
+        most-recently-recorded session and reports the actual episode count.
+        Call this AFTER :meth:`stop_recording` for a definitive check that a
+        collection run produced N distinct episodes rather than one merged
+        ``episode_index=0`` mega-episode.
+
+        Episodes are flushed to ``meta/episodes/**/*.parquet`` only at
+        ``save_episode`` / ``stop_recording`` (``finalize``) time, so this reads
+        the canonical on-disk truth - it does not trust the recorder's in-memory
+        bookkeeping (which is what :meth:`run_policy` reports while a session is
+        still open).
+
+        Args:
+            expected: The episode count the caller intended to record.
+
+        Returns:
+            Standard status dict. ``status`` is ``"success"`` when the parquet
+            holds exactly ``expected`` episodes, else ``"error"``. The
+            ``{"json": {...}}`` block carries ``expected``, ``actual``,
+            ``episode_indices``, ``total_frames``, ``total_frames_per_ep`` and
+            ``root`` so a caller (or CI) can fail loudly programmatically.
+        """
+        if not isinstance(expected, int) or expected < 0:
+            return {
+                "status": "error",
+                "content": [
+                    {"text": f"verify_dataset_episodes: expected must be a non-negative int, got {expected!r}."}
+                ],
+            }
+
+        root = self._active_dataset_root()
+        if not root:
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            "verify_dataset_episodes: no active or recently-recorded dataset to verify. "
+                            "Record one first (start_recording -> run_policy -> stop_recording)."
+                        )
+                    }
+                ],
+            }
+
+        from strands_robots.dataset_recorder import read_dataset_episode_indices
+
+        try:
+            info = read_dataset_episode_indices(root)
+        except FileNotFoundError as e:
+            return {
+                "status": "error",
+                "content": [
+                    {"text": f"verify_dataset_episodes: {e}"},
+                    {
+                        "json": {
+                            "expected": expected,
+                            "actual": 0,
+                            "episode_indices": [],
+                            "total_frames": 0,
+                            "total_frames_per_ep": [],
+                            "root": str(root),
+                        }
+                    },
+                ],
+            }
+        except ImportError as e:
+            return {"status": "error", "content": [{"text": f"verify_dataset_episodes: {e}"}]}
+
+        actual = info["total_episodes"]
+        ok = actual == expected
+        status = "success" if ok else "error"
+        verdict = "matches" if ok else "MISMATCH"
+        text = (
+            f"verify_dataset_episodes: {verdict} - expected {expected}, "
+            f"found {actual} episode(s) in parquet "
+            f"({info['total_frames']} total frames). Root: {root}"
+        )
+        return {
+            "status": status,
+            "content": [
+                {"text": text},
+                {
+                    "json": {
+                        "expected": expected,
+                        "actual": actual,
+                        "episode_indices": info["episode_indices"],
+                        "total_frames": info["total_frames"],
+                        "total_frames_per_ep": info["frames_per_episode"],
+                        "root": str(root),
+                    }
+                },
+            ],
+        }
+
+    def _episode_contract_fields(
+        self, *, requested: int, completed: int, saved: int, flush_deferred: bool = False
+    ) -> dict[str, Any]:
+        """Build the episode-count truth fields for a ``run_policy`` json block.
+
+        Returns ``n_episodes_requested`` / ``n_episodes_completed`` /
+        ``episodes_saved`` plus ``dataset_episode_indices`` - the episode indices
+        the active recorder reports so far (derived from the recorder's in-memory
+        ``meta.total_episodes``; ``[]`` when not recording). Episodes are flushed
+        to parquet only at ``stop_recording``/``finalize``, so this reflects the
+        recorder bookkeeping; call :meth:`verify_dataset_episodes` after
+        ``stop_recording`` for the definitive on-disk parquet count.
+
+        ``flush_deferred`` marks the single-episode fast path while recording:
+        the rollout's frames are buffered into the CURRENT episode and become one
+        dataset episode at the next ``save_episode`` / ``stop_recording`` - they
+        are not yet a distinct flushed episode, so ``episodes_saved`` is ``0``.
+        """
+        fields: dict[str, Any] = {
+            "n_episodes_requested": requested,
+            "n_episodes_completed": completed,
+            "episodes_saved": saved,
+            "dataset_episode_indices": [],
+        }
+        if flush_deferred:
+            fields["episode_flush_deferred"] = True
+        if self._is_recording():
+            recorder = self._active_recorder()
+            total = getattr(getattr(recorder, "dataset", None), "meta", None)
+            total_episodes = int(getattr(total, "total_episodes", 0) or 0) if total is not None else 0
+            fields["dataset_episode_indices"] = list(range(total_episodes))
+        return fields
 
     def save_episode(self) -> dict[str, Any]:
         """Flush the current recording episode and begin a fresh one.

--- a/strands_robots/simulation/mujoco/recording.py
+++ b/strands_robots/simulation/mujoco/recording.py
@@ -41,6 +41,36 @@ class RecordingMixin:
         """
         return self._world is not None and bool(self._world._backend_state.get("recording", False))
 
+    def _active_recorder(self) -> Any:
+        """Live dataset recorder, or ``None`` when no session is open.
+
+        Overrides :meth:`SimEngine._active_recorder` so the base ``run_policy``
+        episode-contract fields can read the recorder's in-memory episode count.
+        """
+        if self._world is None:
+            return None
+        return self._world._backend_state.get("dataset_recorder")
+
+    def _active_dataset_root(self) -> str | None:
+        """On-disk root of the active or most-recently-recorded dataset.
+
+        Overrides :meth:`SimEngine._active_dataset_root` so
+        :meth:`verify_dataset_episodes` can locate the parquet AFTER
+        ``stop_recording`` has finalized it and dropped the recorder. Prefers
+        the live recorder's root; falls back to the ``last_dataset_root`` stashed
+        at ``start_recording``.
+        """
+        recorder = self._active_recorder()
+        if recorder is not None:
+            try:
+                return str(recorder.root)
+            except (AttributeError, TypeError):
+                pass
+        if self._world is None:
+            return None
+        last = self._world._backend_state.get("last_dataset_root")
+        return str(last) if last else None
+
     def start_recording(
         self,
         repo_id: str = "local/sim_recording",
@@ -104,6 +134,9 @@ class RecordingMixin:
             dataset_dir = Path(repo_id)
         else:
             dataset_dir = Path.home() / ".cache" / "huggingface" / "lerobot" / repo_id
+        # Stash the resolved root so verify_dataset_episodes can read the parquet
+        # after stop_recording has finalized the dataset and dropped the recorder.
+        self._world._backend_state["last_dataset_root"] = str(dataset_dir)
 
         # Multi-episode append: when NOT overwriting and a dataset already
         # exists on disk, resume it (append new episodes) instead of calling

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1145,6 +1145,11 @@ class MuJoCoSimEngine(
         )
         base["methods"]["stop_recording"] = "(push_to_hub=False, bucket=None, run_id=None) -> dict"
         base["methods"]["get_recording_status"] = "() -> dict"
+        base["methods"]["verify_dataset_episodes"] = (
+            "(expected: int) -> dict  (after stop_recording, read the parquet "
+            "and confirm the dataset holds exactly `expected` episodes; "
+            "status=error on mismatch)"
+        )
 
         if self._world is not None:
             base["sim_time"] = self._world.sim_time

--- a/tests/simulation/test_run_policy_episode_contract.py
+++ b/tests/simulation/test_run_policy_episode_contract.py
@@ -1,0 +1,162 @@
+"""Episode-count contract for ``run_policy`` + ``verify_dataset_episodes``.
+
+A recording driven by a single ``run_policy(n_episodes=1)`` buffers all frames
+into one merged ``episode_index=0`` mega-episode, while an agent narrating "20
+episodes" believes it recorded 20. ``status=OK`` from the rollout does not prove
+episode-count correctness. These tests pin the contract that closes that gap:
+
+* both the single-episode fast path and the multi-episode path of
+  ``SimEngine.run_policy`` return the episode-count truth fields
+  (``n_episodes_requested`` / ``n_episodes_completed`` / ``episodes_saved`` /
+  ``dataset_episode_indices``);
+* ``verify_dataset_episodes(expected)`` reads the on-disk parquet (the ground
+  truth) and returns ``status=error`` when the recorded episode count differs
+  from what the caller intended;
+* the pure-pyarrow ``read_dataset_episode_indices`` helper reports the actual
+  ``episode_index`` set and per-episode frame counts.
+
+The fast path's loud INFO log (#3 in the contract) is exercised implicitly by
+the recording path; the structured fields are the machine-checkable surface.
+"""
+
+from __future__ import annotations
+
+import shutil
+
+import pytest
+
+pytest.importorskip("mujoco")
+pytest.importorskip("lerobot")
+pytest.importorskip("pyarrow")
+
+from strands_robots.dataset_recorder import read_dataset_episode_indices
+from strands_robots.simulation.mujoco.simulation import Simulation
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="episode_contract", mesh=False)
+    s.create_world()
+    s.add_robot(name="so100", data_config="so100")
+    yield s
+    s.cleanup()
+
+
+def _record(sim: Simulation, root: str, *, n_episodes: int, n_steps: int = 4) -> dict:
+    """Drive a full start -> run_policy -> stop recording cycle; return run json."""
+    shutil.rmtree(root, ignore_errors=True)
+    start = sim.start_recording(repo_id="local/episode_contract", task="t", fps=30, root=root, overwrite=True)
+    assert start["status"] == "success", start
+    run = sim.run_policy(
+        robot_name="so100",
+        policy_provider="mock",
+        n_steps=n_steps,
+        n_episodes=n_episodes,
+        control_frequency=50,
+        fast_mode=True,
+    )
+    assert run["status"] == "success", run
+    stop = sim.stop_recording()
+    assert stop["status"] == "success", stop
+    return _json_block(run)
+
+
+def _json_block(result: dict) -> dict:
+    for blk in result.get("content", []):
+        if isinstance(blk, dict) and isinstance(blk.get("json"), dict):
+            return blk["json"]
+    raise AssertionError(f"no json content block in {result}")
+
+
+class TestRunPolicyContractFields:
+    """Both run_policy paths must return episode-count truth fields."""
+
+    def test_fast_path_returns_contract_fields(self, sim, tmp_path):
+        run_json = _record(sim, str(tmp_path / "fast"), n_episodes=1)
+        # Fast path: one rollout, frames buffered into the current episode and
+        # flushed at stop_recording, so episodes_saved is 0 (no boundary flushed
+        # WITHIN run_policy) and the flush is flagged as deferred.
+        assert run_json["n_episodes_requested"] == 1
+        assert run_json["n_episodes_completed"] == 1
+        assert run_json["episodes_saved"] == 0
+        assert run_json["episode_flush_deferred"] is True
+        assert "dataset_episode_indices" in run_json
+
+    def test_multi_path_returns_contract_fields(self, sim, tmp_path):
+        run_json = _record(sim, str(tmp_path / "multi"), n_episodes=3)
+        assert run_json["n_episodes_requested"] == 3
+        assert run_json["n_episodes_completed"] == 3
+        assert run_json["episodes_saved"] == 3
+        assert run_json["dataset_episode_indices"] == [0, 1, 2]
+
+    def test_fields_present_without_recording(self, sim):
+        """Contract fields exist even when not recording (dataset indices empty)."""
+        run = sim.run_policy(
+            robot_name="so100", policy_provider="mock", n_steps=4, control_frequency=50, fast_mode=True
+        )
+        run_json = _json_block(run)
+        assert run_json["n_episodes_requested"] == 1
+        assert run_json["dataset_episode_indices"] == []
+
+
+class TestParquetTruth:
+    """The on-disk parquet is the ground truth for episode count."""
+
+    def test_n_episodes_20_writes_20_parquet_rows(self, sim, tmp_path):
+        root = str(tmp_path / "twenty")
+        _record(sim, root, n_episodes=20, n_steps=3)
+        info = read_dataset_episode_indices(root)
+        assert info["total_episodes"] == 20
+        assert info["episode_indices"] == list(range(20))
+        assert info["frames_per_episode"] == [3] * 20
+        assert info["total_frames"] == 60
+
+    def test_n_episodes_1_writes_1_parquet_row(self, sim, tmp_path):
+        root = str(tmp_path / "one")
+        _record(sim, root, n_episodes=1, n_steps=12)
+        info = read_dataset_episode_indices(root)
+        assert info["total_episodes"] == 1
+        assert info["episode_indices"] == [0]
+        assert info["total_frames"] == 12
+
+    def test_read_helper_raises_on_empty_dataset(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            read_dataset_episode_indices(str(tmp_path / "does_not_exist"))
+
+
+class TestVerifyDatasetEpisodes:
+    """verify_dataset_episodes is the definitive post-stop_recording check."""
+
+    def test_verify_matches_after_20_episode_run(self, sim, tmp_path):
+        _record(sim, str(tmp_path / "v20"), n_episodes=20, n_steps=3)
+        result = sim.verify_dataset_episodes(expected=20)
+        assert result["status"] == "success"
+        vj = _json_block(result)
+        assert vj["expected"] == 20
+        assert vj["actual"] == 20
+        assert vj["episode_indices"] == list(range(20))
+
+    def test_verify_errors_after_1_episode_run_expecting_20(self, sim, tmp_path):
+        _record(sim, str(tmp_path / "v1"), n_episodes=1, n_steps=12)
+        result = sim.verify_dataset_episodes(expected=20)
+        assert result["status"] == "error"
+        vj = _json_block(result)
+        assert vj["expected"] == 20
+        assert vj["actual"] == 1
+
+    def test_verify_after_stop_recording_uses_last_root(self, sim, tmp_path):
+        """verify works after stop_recording drops the recorder (uses stashed root)."""
+        _record(sim, str(tmp_path / "vlast"), n_episodes=2, n_steps=3)
+        assert sim._world._backend_state.get("dataset_recorder") is None
+        result = sim.verify_dataset_episodes(expected=2)
+        assert result["status"] == "success"
+        assert _json_block(result)["actual"] == 2
+
+    def test_verify_no_dataset_returns_error(self, sim):
+        result = sim.verify_dataset_episodes(expected=5)
+        assert result["status"] == "error"
+
+    def test_verify_rejects_negative_expected(self, sim, tmp_path):
+        _record(sim, str(tmp_path / "vneg"), n_episodes=1, n_steps=3)
+        result = sim.verify_dataset_episodes(expected=-1)
+        assert result["status"] == "error"

--- a/tests/simulation/test_run_policy_multi_episode.py
+++ b/tests/simulation/test_run_policy_multi_episode.py
@@ -139,13 +139,20 @@ class TestMultiEpisodeRollout:
 
     def test_single_episode_keeps_historical_result_shape(self, sim):
         # Default n_episodes=1 must NOT wrap the result in the multi-episode
-        # aggregate; it stays the single-rollout payload existing callers parse.
+        # aggregate (the per-episode ``episodes`` list); it stays the
+        # single-rollout payload existing callers parse. It DOES, however, carry
+        # the episode-count contract fields so an agent can read the truth
+        # without parsing text (both run_policy paths expose them).
         result = sim.run_policy("arm1", n_steps=5)
         assert result["status"] == "success"
         payload = _json(result)
         assert payload["n_steps"] == 5
-        assert "n_episodes_requested" not in payload
-        assert "episodes" not in payload
+        assert "episodes" not in payload  # no multi-episode aggregate wrapper
+        # Episode-count contract fields present on the fast path too.
+        assert payload["n_episodes_requested"] == 1
+        assert payload["n_episodes_completed"] == 1
+        assert payload["episodes_saved"] == 0
+        assert payload["dataset_episode_indices"] == []
 
     def test_explicit_n_episodes_one_matches_single(self, sim):
         result = sim.run_policy("arm1", n_steps=4, n_episodes=1)


### PR DESCRIPTION
## Problem

`run_policy` can silently record a single merged `episode_index=0` mega-episode while a caller believes it collected N distinct episodes. Two gaps combine:

1. The single-episode fast path (`n_episodes=1`, the default) returns **none** of the episode-count bookkeeping the multi-episode path returns. A caller has no machine-readable way to learn how many dataset episodes its call actually produced.
2. A `status="success"` rollout is **no proof of episode-count correctness**. Frames buffer into the current episode and flush to parquet only at `save_episode`/`stop_recording`, so a caller that runs `run_policy(n_episodes=1)` once but treats it as "20 episodes" ends up with a 1-episode dataset and no signal that anything is wrong.

Verified failure shape: a 20x60-step rollout recorded as one `episode_index=0` row of 1140+ frames, while the caller reported 20/20.

## Change

**Both** `run_policy` paths (single-episode fast path and the multi-episode driver) now return the episode-count truth fields in their `{"json": {...}}` block:

- `n_episodes_requested`
- `n_episodes_completed`
- `episodes_saved` (save_episode boundaries flushed within this call)
- `dataset_episode_indices` (episode indices the active recorder reports so far)

The fast path additionally sets `episode_flush_deferred=True` while recording — making explicit that its rollout buffers into one episode that is flushed at `stop_recording`, rather than saved as a distinct boundary — and logs a single `INFO` line at run start (`run_policy: n_episodes=1, will produce 1 dataset episode ...`) so an agent driving the tool sees the truth in its output and self-corrects on the next call.

New **`SimEngine.verify_dataset_episodes(expected)`** reads the on-disk LeRobot parquet (the ground truth) after `stop_recording` and returns `status="error"` when the recorded episode count differs from `expected`:

```json
{"expected": 20, "actual": 1, "episode_indices": [0], "total_frames": 1140, "total_frames_per_ep": [1140], "root": "..."}
```

It is backed by a new pure-`pyarrow` helper `strands_robots.dataset_recorder.read_dataset_episode_indices(root)` that parses `meta/episodes/**/*.parquet` without importing `lerobot` (episodes are only flushed there at `save_episode`/`finalize`, so reading parquet is the definitive count). `RecordingMixin` stashes the dataset root at `start_recording` so verification works after `stop_recording` has dropped the recorder.

The `run_policy` `n_episodes` docstring and the MuJoCo `describe()` recording surface now spell out the contract: pass `n_episodes=N` for N distinct episodes, do not loop the call, and confirm with `verify_dataset_episodes`.

No change to recorded trajectory content, video output, or the single-rollout payload shape (the per-episode `episodes` aggregate list is still absent on the fast path) — only additive `{"json": {...}}` fields and a new verification method.

## Demo (MuJoCo sim, headless EGL)

3-episode recorded rollout. `run_policy(n_episodes=3)` returns the contract fields and `verify_dataset_episodes` confirms parquet truth:

```
run_policy json: {"n_episodes_requested": 3, "n_episodes_completed": 3,
                  "episodes_saved": 3, "dataset_episode_indices": [0, 1, 2],
                  "total_steps": 120}
verify_dataset_episodes(expected=3):  matches  - expected 3, found 3 (120 frames)
verify_dataset_episodes(expected=20): MISMATCH - expected 20, found 3  -> status=error
```

![episode contract demo](https://github.com/cagataycali/robots/releases/download/episode-contract-demo/episode_contract_demo.gif)

Full MP4: https://github.com/cagataycali/robots/releases/download/episode-contract-demo/episode_contract_demo_ep0.mp4

## Tests

New `tests/simulation/test_run_policy_episode_contract.py` (11 cases): fast-path and multi-path contract fields, the parquet-truth helper (20-episode and 1-episode datasets, empty-dataset raise), and `verify_dataset_episodes` match / mismatch / post-stop_recording / no-dataset / negative-expected. The new symbols make the file fail-to-import on pre-change code (genuine regression). Extended `test_run_policy_multi_episode.py` to assert the fast path now carries the contract fields while still omitting the multi-episode aggregate wrapper.

Local gate green: `ruff check` + `ruff format --check` + `mypy strands_robots tests tests_integ` clean; `MUJOCO_GL=egl pytest tests/simulation/` passing (2 unrelated failures are pre-existing `libtorchcodec` load errors on this host, reproduced on a clean checkout).