### PR TITLE
docs(sim): surface [Benchmark] actions in tool_spec description + pin enum/description parity

### DIFF
--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -193,7 +193,7 @@ class MuJoCoSimEngine(
         # mj_step can produce torn/stale values). The lock is acquired:
         #
         #   * In ``_dispatch_action`` - so every agent-dispatched action
-        #     (all 37 handlers) is automatically serialized.
+        #     is automatically serialized.
         #   * In ``send_action`` / ``get_observation`` - so the
         #     PolicyRunner worker thread is also serialized against the
         #     agent's dispatch thread.
@@ -2082,7 +2082,7 @@ class MuJoCoSimEngine(
                 "(direct path or auto-resolve from data_config name), add objects, run VLA policies, "
                 "render cameras, record trajectories, domain randomize. "
                 "Same Policy ABC as real robot control - sim and real with zero code changes. "
-                "Actions (62 total): "
+                "Actions (65 total): "
                 "[World] create_world, load_scene, reset, get_state, destroy, export_xml; "
                 "[Robots] add_robot, remove_robot, list_robots, get_robot_state, list_bodies; "
                 "[Objects] add_object, remove_object, move_object, list_objects; "
@@ -2097,6 +2097,7 @@ class MuJoCoSimEngine(
                 "[Recording] start_recording, save_episode, stop_recording, get_recording_status, "
                 "start_cameras_recording, stop_cameras_recording, get_cameras_recording_status; "
                 "[Randomize] randomize; "
+                "[Benchmark] list_benchmarks, register_benchmark_from_file, evaluate_benchmark; "
                 "[Registry] list_urdfs, register_urdf, get_features. "
                 "Call destroy() at session end to release resources."
             ),

--- a/tests/simulation/mujoco/test_tool_spec.py
+++ b/tests/simulation/mujoco/test_tool_spec.py
@@ -292,8 +292,7 @@ def test_tool_spec_description_mentions_every_enum_action(sim: Simulation) -> No
     # scan. We assert exact whole-token presence via word boundaries.
     missing = [a for a in enum if not re.search(rf"\b{re.escape(a)}\b", description)]
     assert not missing, (
-        "tool_spec description must name every dispatchable enum action; "
-        f"undocumented: {sorted(missing)}"
+        f"tool_spec description must name every dispatchable enum action; undocumented: {sorted(missing)}"
     )
 
 

--- a/tests/simulation/mujoco/test_tool_spec.py
+++ b/tests/simulation/mujoco/test_tool_spec.py
@@ -264,3 +264,48 @@ def test_tool_spec_schema_has_expected_shape() -> None:
     assert "type" in _TOOL_SPEC_SCHEMA
     assert "properties" in _TOOL_SPEC_SCHEMA
     assert "required" in _TOOL_SPEC_SCHEMA
+
+
+# Description vs. enum drift contract
+#
+# The ``tool_spec`` description string is on the LLM hot path: an agent
+# discovers the available actions from this text, so an action that is in the
+# enum (and therefore dispatchable) but absent from the description is
+# effectively invisible. This is exactly how the three [Benchmark] actions went
+# undiscoverable while the "Actions (N total)" count drifted. These two checks
+# pin the description to the enum so the next added action fails CI until it is
+# documented.
+
+
+def test_tool_spec_description_mentions_every_enum_action(sim: Simulation) -> None:
+    """Every action in the enum must appear by name in the tool_spec description.
+
+    Catches the drift where a dispatchable action (e.g. the [Benchmark] trio) is
+    added to tool_spec.json + a handler but never surfaced in the human/LLM
+    description, leaving it undiscoverable.
+    """
+    description = sim.tool_spec["description"]
+    enum = sim.tool_spec["inputSchema"]["json"]["properties"]["action"]["enum"]
+
+    # Longest-name-first so a substring action (e.g. "render") does not mask a
+    # genuinely-missing longer action (e.g. "render_all") during the membership
+    # scan. We assert exact whole-token presence via word boundaries.
+    missing = [a for a in enum if not re.search(rf"\b{re.escape(a)}\b", description)]
+    assert not missing, (
+        "tool_spec description must name every dispatchable enum action; "
+        f"undocumented: {sorted(missing)}"
+    )
+
+
+def test_tool_spec_description_action_count_matches_enum(sim: Simulation) -> None:
+    """The "Actions (N total)" count in the description must equal len(enum)."""
+    description = sim.tool_spec["description"]
+    enum = sim.tool_spec["inputSchema"]["json"]["properties"]["action"]["enum"]
+
+    m = re.search(r"Actions \((\d+) total\)", description)
+    assert m is not None, "tool_spec description must state 'Actions (N total)'"
+    stated = int(m.group(1))
+    assert stated == len(enum), (
+        f"tool_spec description says {stated} actions but the enum has {len(enum)}; "
+        "update the count when adding/removing an action."
+    )


### PR DESCRIPTION
## Summary

The `Simulation.tool_spec` **description** is on the LLM hot path: an agent discovers the available actions from this string. Three dispatchable enum actions were absent from it, so an agent could not discover them, and the stated action count had drifted.

Ground truth (verified against `HEAD`):
- `list_benchmarks`, `register_benchmark_from_file`, `evaluate_benchmark` are real `SimEngine` methods (`strands_robots/simulation/base.py`), are in `tool_spec.json`'s `action` enum, and are exercised by `tests/simulation/mujoco/test_benchmark_dispatch.py` (asserts both enum membership and live dispatch). They were simply never mentioned in the description text.
- The description said `Actions (62 total)` while the enum has **65** entries.
- A dispatch-lock comment carried a stale `(all 37 handlers)` magic number.

This is a documentation-accuracy fix only. No behaviour changes, no enum changes, no handler changes.

## Changes

1. **`simulation.py` (tool_spec description)** - add a `[Benchmark]` category listing the three actions; correct `62 total` -> `65 total` to match the enum.
2. **`simulation.py` (`__init__` comment)** - drop the stale `(all 37 handlers)` count and reword so the comment cannot re-drift when an action is added.
3. **`tests/simulation/mujoco/test_tool_spec.py`** - two regression tests pinning the contract:
   - every enum action appears by name in the description (catches the undiscoverable-action drift);
   - the `Actions (N total)` count equals `len(enum)`.

## Verification

The pin was checked both directions against the live enum:
- **pre-fix** description: `missing=['list_benchmarks','register_benchmark_from_file','evaluate_benchmark']`, count `62 != 65` -> tests FAIL.
- **post-fix** description: `missing=[]`, count `65 == 65` -> tests PASS.

Locally: `python -m py_compile` clean; ASCII-only additions; lines within the 120-char limit. The `test_tool_spec.py` module is `importorskip("mujoco")`-gated, so the new tests execute on the `[sim-mujoco]` CI lane.

## Scope / non-goals

- `save_episode` is intentionally described but not in the enum (reachable via the dispatcher; `run_policy(n_episodes=N)` is the recommended agent path). The parity test asserts only the enum->description direction, so this remains valid and is not touched.
- No change to `tool_spec.json`, handlers, or dispatch logic.

## §13 Round-N changelog

- **Round 1 (initial):** description `[Benchmark]` category + count fix; stale comment reword; two parity regression tests.