### PR TITLE
perf(sim): auto-enable async-RTC for chunk-emitting policies + harden the seam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Feature: async-RTC latency masking is the default for chunk-emitting policies
+
+`run_policy` / `PolicyRunner.run` previously defaulted to `async_rtc=False`, so
+every chunk-emitting VLA (pi0, pi0.5, pi0-FAST, SmolVLA, MolmoAct2) paid the full
+inference latency at every chunk seam in sim even though the overlap pipeline
+already existed - it was invisible to callers who did not know to pass the flag.
+
+- `async_rtc` now defaults to `None` (auto-resolve). `None` reads the new
+  `Policy.is_chunk_emitting()` to enable the inference/execution overlap for
+  chunk-emitting policies and keep single-step policies (MockPolicy, classical
+  planners) on the synchronous loop. An explicit `async_rtc=True`/`False` still
+  wins. `Policy.is_chunk_emitting()` defaults to `execution_horizon > 1`;
+  `LerobotLocalPolicy` also reports `True` for an RTC model or a checkpoint that
+  must be driven via `predict_action_chunk` (MolmoAct2).
+- The run-result `{"json": {...}}` block now carries six async-RTC telemetry
+  fields - `rtc_async_enabled`, `rtc_chunks_acquired`, `rtc_prefetch_hits`,
+  `rtc_prefetch_blocks`, `rtc_avg_inference_ms`, `rtc_max_inference_ms` - so
+  latency masking is provable from the payload instead of from logs.
+- Seam hardening: an empty prefetched chunk degrades to one synchronous
+  re-query before erroring (a transient hiccup no longer kills the rollout); a
+  blocking prefetch logs a starvation warning; and the new
+  `rtc_inference_timeout_s` argument bounds a stuck inference, returning a
+  structured `status="error"` result (with telemetry) instead of waiting for
+  every remaining chunk.
+
+Behaviour change: a chunk-emitting policy run through `run_policy` without an
+explicit `async_rtc` now uses the overlap pipeline, which fires one extra
+background `get_actions` for the trailing chunk. Tests that assert the exact
+synchronous re-query count should pass `async_rtc=False`.
+
+
 ### Refactor: unify the rclpy + RTPS hardware ROS 2 bridges under `RosTelemetryBase`
 
 The two hardware ROS 2 transports now share a single source of truth for the

--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -258,20 +258,24 @@ of those two RTC benefits the sim reproduces:
 
 | `async_rtc` | Behaviour | Use when |
 | --- | --- | --- |
-| `False` (default) | Query the policy, drain `execution_horizon` actions (the full chunk for non-RTC; `rtc_execution_horizon` for RTC), then re-query. Seam blending works because the RTC policy is re-queried mid-chunk, but inference and execution do **not** overlap. | Single-step policies, deterministic regression runs, or any policy whose `get_actions` reads live sim state. |
+| `None` (default) | Auto-resolve from `policy.is_chunk_emitting()`: chunk-emitting policies get the async overlap, single-step policies stay synchronous. An explicit `True`/`False` always wins. | The common case - let the policy decide. |
+| `False` | Query the policy, drain `execution_horizon` actions (the full chunk for non-RTC; `rtc_execution_horizon` for RTC), then re-query. Seam blending works because the RTC policy is re-queried mid-chunk, but inference and execution do **not** overlap. | Single-step policies, deterministic regression runs, or any policy whose `get_actions` reads live sim state. |
 | `True` | While the current chunk drains, fire the next `get_actions` on a single background worker once the chunk is ~50% consumed (using a fresh mid-execution observation), then atomically swap it in. A policy whose inference latency is at most the chunk's execution window pays (almost) zero visible stall at the seam. | Chunk-emitting VLA / flow-matching policies (pi0, pi0.5, pi0-FAST, SmolVLA, MolmoAct2) where you want sim per-step timing to track real-hardware behaviour, or to benchmark a streaming controller. |
 
+Because MolmoAct2, pi0, pi0.5, pi0-FAST and SmolVLA all self-report as chunk-emitting, the default `async_rtc=None` enables latency masking for them automatically - no flag needed. Each `run_policy` result carries `rtc_*` telemetry (`rtc_async_enabled`, `rtc_prefetch_hits`, `rtc_prefetch_blocks`, `rtc_avg_inference_ms`, ...) so you can confirm the masking worked; see [Simulation -> Async-RTC chunk pipeline](../simulation/overview.md#async-rtc-chunk-pipeline-latency-masking). Pass `rtc_inference_timeout_s=` to abort cleanly on a stuck inference instead of stalling the whole rollout.
+
 ```python
-# Default sync loop - inference shows up as a per-seam stall in sim.
+# Default (async_rtc=None): pi0 self-reports as chunk-emitting, so the async
+# overlap is enabled automatically - inference latency is masked.
 sim.run_policy(robot_name="so101", policy_provider="lerobot_local",
                policy_config={"pretrained_name_or_path": "lerobot/pi0_so100", "rtc_enabled": True},
                action_horizon=8)
 
-# Async pipeline - the next chunk is computed in the background while the
-# current one executes, so inference latency is masked (same as real hardware).
+# Force the synchronous chunk-then-drain loop (inference shows up as a per-seam
+# stall in sim) - e.g. for a deterministic regression run.
 sim.run_policy(robot_name="so101", policy_provider="lerobot_local",
                policy_config={"pretrained_name_or_path": "lerobot/pi0_so100", "rtc_enabled": True},
-               action_horizon=8, async_rtc=True)
+               action_horizon=8, async_rtc=False)
 ```
 
 `async_rtc` is provider-agnostic: it only schedules the inference/execution

--- a/docs/simulation/overview.md
+++ b/docs/simulation/overview.md
@@ -90,7 +90,7 @@ Robot-URDF cameras are auto-discovered on `add_robot`.
 
 | Action | Key params |
 |--------|-----------|
-| `run_policy` | `robot_name` (required), `policy_provider="mock"`, `policy_config={}`, `policy_object=None`, `instruction=""`, `duration=10.0`, `control_frequency=50.0`, `action_horizon=8`, `n_steps=None`, `seed=None`, `async_rtc=False` |
+| `run_policy` | `robot_name` (required), `policy_provider="mock"`, `policy_config={}`, `policy_object=None`, `instruction=""`, `duration=10.0`, `control_frequency=50.0`, `action_horizon=8`, `n_steps=None`, `seed=None`, `async_rtc=None`, `rtc_inference_timeout_s=None` |
 | `start_policy` | same args, async/non-blocking |
 | `stop_policy` | `robot_name` (optional, defaults to `""`) |
 | `list_policies_running` | - |
@@ -101,9 +101,42 @@ The step horizon is given either as `duration` (seconds) or as `n_steps` (`durat
 
 Pass `seed=` to `run_policy` / `start_policy` for a reproducible single rollout: it reseeds Python / NumPy / torch / cuDNN and forwards `policy.reset(seed=...)`, so a stochastic policy (VLA action-chunk sampling, diffusion noise) produces the same trajectory on re-run of the same scene. Without a seed the rollout draws from the process-global RNG and can differ run to run. `eval_policy` already seeds per episode via the same mechanism.
 
-Pass `async_rtc=True` to `run_policy` to overlap policy inference with action execution: while the current action chunk drains, the next `get_actions` is computed on a background worker and atomically swapped in when the chunk runs out (latency masking). The default `False` keeps the synchronous chunk-then-drain loop. This is most useful for chunk-emitting VLA / flow-matching policies (pi0, SmolVLA, MolmoAct2) where it makes sim per-step timing track real-hardware behaviour; see [LeRobot Local -> RTC](../policies/lerobot-local.md#synchronous-vs-async-chunk-execution-in-sim).
+### Async-RTC chunk pipeline (latency masking)
 
-`run_policy` returns a `{"json": {...}}` content block alongside the human-readable `text`, mirroring `eval_policy`. The json block carries the rollout facts as typed fields - `robot_name`, `policy`, `instruction`, `n_steps`, `elapsed_s`, `stopped_early`, `action_errors`, `video_path` (`None` when no MP4 was written), `video_frames` and `sim_time_s` (when the backend reports it) - so an agent can read the outcome programmatically (did it move? how many steps? where is the video?) without regex-parsing the prose.
+`async_rtc` overlaps policy inference with action execution: while the current action chunk drains, the *next* `get_actions` runs on a single background worker (using a fresh mid-chunk observation) and is atomically swapped in when the current chunk runs out. A policy whose inference latency is at most one chunk's execution time then pays (almost) zero visible stall at the chunk seam - the same way an async real-time controller hides inference latency on real hardware.
+
+```
+async_rtc=True (inference <= chunk execution):
+
+chunk N exec   |####============|
+prefetch N+1            |~~~~~~~|              <- fires at ~50% of chunk N
+chunk N+1 exec                  |####========|   <- ready at the seam: HIT, no stall
+
+async_rtc=False (synchronous chunk-then-drain):
+
+chunk N exec   |####|
+infer N+1            |~~~~~~~|                 <- the loop stalls here every seam
+chunk N+1 exec               |####|
+```
+
+**Auto-enable rule.** `async_rtc=None` (the default) resolves the flag from `policy.is_chunk_emitting()`: chunk-emitting VLA / flow-matching policies (pi0, pi0.5, pi0-FAST, SmolVLA, MolmoAct2) get the overlap automatically, while single-step policies (MockPolicy, classical planners) stay on the synchronous loop, where overlap would gain nothing. An explicit `async_rtc=True` / `async_rtc=False` always wins over the auto-resolution. `Policy.is_chunk_emitting()` defaults to `execution_horizon > 1`; `LerobotLocalPolicy` additionally reports `True` for an RTC model or a checkpoint that must be driven via `predict_action_chunk` (MolmoAct2). See [LeRobot Local -> RTC](../policies/lerobot-local.md#synchronous-vs-async-chunk-execution-in-sim).
+
+**Hardening.** If a prefetched chunk arrives empty, the runner degrades to one synchronous re-query before erroring (a transient hiccup does not kill an otherwise-healthy rollout). When a prefetch blocks at the seam (inference slower than chunk execution) the runner logs a starvation warning so you can shorten the chunk or fire the prefetch earlier. Set `rtc_inference_timeout_s` to bound a stuck inference: the swap then returns a structured `status="error"` result (carrying the telemetry below) instead of waiting for every remaining chunk - bounded by the single in-flight inference the executor joins on shutdown (Python cannot forcibly kill a running worker thread).
+
+**Telemetry.** Every `run_policy` result `{"json": {...}}` block carries six RTC fields so latency masking is provable from the payload, not the logs:
+
+| Field | Meaning |
+|-------|---------|
+| `rtc_async_enabled` | Whether the overlap pipeline ran (the resolved `async_rtc`) |
+| `rtc_chunks_acquired` | Chunks the rollout acquired (cold start + swaps + re-queries) |
+| `rtc_prefetch_hits` | Seams where the next chunk was already computed (stall hidden) |
+| `rtc_prefetch_blocks` | Seams where the runner had to wait for inference (seam starved) |
+| `rtc_avg_inference_ms` | Mean `get_actions` wall time across the rollout |
+| `rtc_max_inference_ms` | Slowest `get_actions` wall time |
+
+A healthy masked rollout shows `rtc_prefetch_hits` near the chunk count and `rtc_prefetch_blocks == 0`; persistent blocks mean inference is slower than chunk execution and the seam cannot be fully hidden.
+
+`run_policy` returns a `{"json": {...}}` content block alongside the human-readable `text`, mirroring `eval_policy`. The json block carries the rollout facts as typed fields - `robot_name`, `policy`, `instruction`, `n_steps`, `elapsed_s`, `stopped_early`, `action_errors`, `video_path` (`None` when no MP4 was written), `video_frames`, `sim_time_s` (when the backend reports it) and the six `rtc_*` async-RTC telemetry fields above - so an agent can read the outcome programmatically (did it move? how many steps? was inference masked?) without regex-parsing the prose.
 | `replay_episode` | `repo_id`, `robot_name=None`, `episode=0` |
 
 ## Recording

--- a/strands_robots/policies/base.py
+++ b/strands_robots/policies/base.py
@@ -269,6 +269,33 @@ class Policy(ABC):
             intended_int = 1
         return max(1, intended_int)
 
+    def is_chunk_emitting(self) -> bool:
+        """Whether this policy returns multi-action chunks per ``get_actions``.
+
+        A chunk-emitting policy (ACT, diffusion, pi0, pi0.5, pi0-FAST, SmolVLA,
+        MolmoAct2) returns more than one action per inference, so its inference
+        latency can be hidden behind the EXECUTION of the current chunk while the
+        next chunk is computed in the background. The async-RTC pipeline in
+        :meth:`PolicyRunner.run` uses this signal to auto-enable latency masking
+        for exactly the policies that benefit (``run_policy(async_rtc=None)``);
+        single-step policies (``MockPolicy``, classical planners) gain nothing
+        from overlap and stay on the synchronous loop.
+
+        The default derives the answer from the re-query interval the consumer
+        actually drives - :attr:`execution_horizon` - so ANY policy that emits a
+        chunk longer than one action is detected without enumerating provider
+        names: a model under RTC reports its RTC horizon (> 1), a chunked
+        open-loop model reports its trained chunk length (> 1), and a single-step
+        policy reports ``1``. Providers whose chunk shape is not visible through
+        ``execution_horizon`` (e.g. a model that must be driven via
+        ``predict_action_chunk``) override this.
+
+        Returns:
+            ``True`` when the policy emits multi-action chunks; ``False`` for
+            single-step policies.
+        """
+        return self.execution_horizon > 1
+
     @property
     @abstractmethod
     def provider_name(self) -> str:

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -261,6 +261,30 @@ class LerobotLocalPolicy(Policy):
             return max(1, int(self._rtc_execution_horizon))
         return max(1, int(self.actions_per_step))
 
+    def is_chunk_emitting(self) -> bool:
+        """Whether this LeRobot policy returns multi-action chunks per inference.
+
+        Extends :meth:`Policy.is_chunk_emitting` so the async-RTC pipeline
+        auto-enables latency masking for every chunk-emitting LeRobot model, not
+        only those whose chunk shape is visible through ``execution_horizon``:
+
+        * ``execution_horizon > 1`` covers ACT, diffusion, pi0, pi0.5, pi0-FAST
+          and SmolVLA, whose trained chunk (or RTC horizon) is more than one
+          action (the base-class check).
+        * :attr:`supports_rtc` covers a flow-matching model that blends chunk
+          seams internally - it is chunk-emitting by construction.
+        * :meth:`_requires_action_chunk` covers MolmoAct2, which MUST be driven
+          via ``predict_action_chunk`` (its ``select_action`` raises under an
+          enabled ``rtc_config``); its trained chunk is not always reflected in
+          ``actions_per_step``, so detect it through the same path that already
+          routes it to chunked inference.
+
+        Returns:
+            ``True`` when the loaded policy emits multi-action chunks; ``False``
+            for single-step checkpoints or before a model is loaded.
+        """
+        return super().is_chunk_emitting() or self.supports_rtc or self._requires_action_chunk()
+
     def reset(self, seed: int | None = None) -> None:
         """Reset policy state between episodes.
 

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -449,7 +449,8 @@ class SimEngine(ABC):
         seed: int | None = None,
         n_episodes: int = 1,
         reset_between: bool = True,
-        async_rtc: bool = False,
+        async_rtc: bool | None = None,
+        rtc_inference_timeout_s: float | None = None,
     ) -> dict[str, Any]:
         """Run a policy loop in the simulation (blocking).
 
@@ -519,13 +520,21 @@ class SimEngine(ABC):
             async_rtc: When ``True``, overlap policy inference with action
                 execution so the next action chunk is computed in the
                 background while the current chunk is still draining (latency
-                masking). ``False`` (default) keeps the synchronous
-                chunk-then-drain loop. Forwarded verbatim to
+                masking). ``False`` keeps the synchronous chunk-then-drain loop.
+                ``None`` (default) auto-resolves from ``policy.is_chunk_emitting()``
+                so chunk-emitting VLA/flow-matching policies (pi0, pi0.5,
+                pi0-FAST, SmolVLA, MolmoAct2) get latency masking automatically
+                while single-step policies stay synchronous; an explicit
+                ``True``/``False`` always wins. Forwarded verbatim to
                 :meth:`PolicyRunner.run`; see its docstring for the full
                 contract (provider-agnostic, RTC-policy seam blending, thread
-                safety). Most useful for chunk-emitting VLA/flow-matching
-                policies (pi0, pi0.5, SmolVLA, MolmoAct2) where it makes sim
-                per-step timing track real-hardware behaviour.
+                safety).
+            rtc_inference_timeout_s: Optional hard per-chunk timeout (seconds)
+                for the async-RTC prefetch. When set, a stuck inference surfaces
+                as a structured ``status=error`` result (carrying the RTC
+                telemetry) instead of hanging the sim. ``None`` (default) waits
+                without a deadline. Forwarded verbatim to
+                :meth:`PolicyRunner.run`; ignored on the synchronous path.
 
         Returns:
             Standard status dict with an agent-consumable ``{"json": {...}}``
@@ -590,6 +599,7 @@ class SimEngine(ABC):
                 policy_kwargs=policy_kwargs,
                 seed=seed,
                 async_rtc=async_rtc,
+                rtc_inference_timeout_s=rtc_inference_timeout_s,
             )
 
         # Multi-episode path: one rollout per episode, flushing a dataset
@@ -613,6 +623,7 @@ class SimEngine(ABC):
             n_episodes=n_episodes,
             reset_between=reset_between,
             async_rtc=async_rtc,
+            rtc_inference_timeout_s=rtc_inference_timeout_s,
         )
 
     def _run_episodes(
@@ -633,7 +644,8 @@ class SimEngine(ABC):
         seed: int | None,
         n_episodes: int,
         reset_between: bool,
-        async_rtc: bool = False,
+        async_rtc: bool | None = None,
+        rtc_inference_timeout_s: float | None = None,
     ) -> dict[str, Any]:
         """Run ``n_episodes`` sequential rollouts; shared multi-episode driver.
 
@@ -668,6 +680,7 @@ class SimEngine(ABC):
                 policy_kwargs=policy_kwargs,
                 seed=ep_seed,
                 async_rtc=async_rtc,
+                rtc_inference_timeout_s=rtc_inference_timeout_s,
             )
             ep_json = self._extract_json_payload(result)
             ep_record: dict[str, Any] = {"episode": ep, **ep_json}

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -2291,7 +2291,8 @@ class MuJoCoSimEngine(
         seed: int | None = None,
         n_episodes: int = 1,
         reset_between: bool = True,
-        async_rtc: bool = False,
+        async_rtc: bool | None = None,
+        rtc_inference_timeout_s: float | None = None,
     ) -> dict[str, Any]:
         """MuJoCo ``run_policy`` override: pre-flight world check + graceful stop.
 
@@ -2338,6 +2339,7 @@ class MuJoCoSimEngine(
                 n_episodes=n_episodes,
                 reset_between=reset_between,
                 async_rtc=async_rtc,
+                rtc_inference_timeout_s=rtc_inference_timeout_s,
             )
         finally:
             if self._world is not None and robot_name in self._world.robots:

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -343,7 +343,8 @@ class PolicyRunner:
         control_substeps: int | None = None,
         policy_kwargs: dict[str, Any] | None = None,
         seed: int | None = None,
-        async_rtc: bool = False,
+        async_rtc: bool | None = None,
+        rtc_inference_timeout_s: float | None = None,
     ) -> dict[str, Any]:
         """Run ``policy`` on ``robot_name`` for ``duration`` seconds.
 
@@ -409,13 +410,30 @@ class PolicyRunner:
                 blend the seam internally through their own prev-chunk state
                 (``rtc_config.execution_horizon``); this flag only schedules the
                 overlap and never touches the policy's RTC machinery, so it is
-                provider-agnostic. ``False`` (default) keeps the historical
+                provider-agnostic. ``False`` keeps the historical
                 synchronous chunk-then-drain loop, which is correct for
                 single-step policies and any policy whose ``get_actions`` reads
-                live sim state. The policy object is only ever invoked from the
+                live sim state. ``None`` (default) auto-resolves the flag from
+                ``policy.is_chunk_emitting()``: chunk-emitting VLAs (pi0, pi0.5,
+                pi0-FAST, SmolVLA, MolmoAct2) enable the overlap and single-step
+                policies stay synchronous, so the latency-masking default is
+                correct without the caller having to know the policy's shape. An
+                explicit ``True``/``False`` always wins over the auto-resolution.
+                The policy object is only ever invoked from the
                 single background worker (never concurrently), and the runner
                 blocks on any in-flight inference before returning so no thread
                 touches the policy or sim after :meth:`run` exits.
+            rtc_inference_timeout_s: Hard per-chunk timeout (seconds) for the
+                async-RTC prefetch. When set and a prefetched inference has not
+                returned by the time its chunk must be swapped in, the swap
+                raises and :meth:`run` returns a structured ``status=error``
+                result (with the RTC telemetry block) rather than waiting for
+                every remaining chunk of a slow model. The runner still joins the
+                single in-flight worker on shutdown (Python cannot forcibly kill a
+                running thread, and a leaked worker would touch the policy after
+                :meth:`run` returns), so the abort is bounded by ONE inference,
+                not the whole rollout. ``None`` (default) waits without a deadline
+                (historical behaviour). Ignored on the synchronous path.
 
         Returns:
             ``{"status": "success"|"error", "content": [{"text": ...},
@@ -425,7 +443,11 @@ class PolicyRunner:
             ``stopped_early``, ``action_errors``, ``video_path`` (``None`` when
             no MP4 was written), ``video_frames`` and ``sim_time_s`` (when the
             backend reports sim time) - so callers can self-correct without
-            regex-parsing the human-readable ``text``.
+            regex-parsing the human-readable ``text``. The block also carries the
+            async-RTC telemetry (``rtc_async_enabled``, ``rtc_chunks_acquired``,
+            ``rtc_prefetch_hits``, ``rtc_prefetch_blocks``, ``rtc_avg_inference_ms``,
+            ``rtc_max_inference_ms``) so latency masking is provable from the
+            payload instead of from logs.
         """
         # A single rollout draws the policy's stochastic ops (VLA action-
         # chunk sampling, diffusion noise) from the unmanaged global RNG, so the
@@ -443,6 +465,49 @@ class PolicyRunner:
                     seed,
                     e,
                 )
+
+        # Auto-resolve the async-RTC overlap from the policy's own shape when the
+        # caller did not pin it. Chunk-emitting VLAs (pi0/pi0.5/pi0-FAST/SmolVLA/
+        # MolmoAct2) benefit from hiding inference behind chunk execution, while a
+        # single-step policy gains nothing - so the latency-masking default is
+        # correct without the caller knowing the policy's internals. An explicit
+        # True/False always wins. Use getattr so a duck-typed policy_object that
+        # predates is_chunk_emitting() simply stays on the synchronous path.
+        if async_rtc is None:
+            _emit = getattr(policy, "is_chunk_emitting", None)
+            async_rtc = bool(_emit()) if callable(_emit) else False
+            logger.info(
+                "async_rtc auto-resolved to %s from %s.is_chunk_emitting()",
+                async_rtc,
+                type(policy).__name__,
+            )
+
+        # RTC telemetry, reported in the result json so latency masking is
+        # provable without grepping logs. inference_ms collects every
+        # get_actions wall-time (both paths); the prefetch hit/block counters and
+        # chunks_acquired are async-only (0 on the synchronous path). list.append
+        # is atomic under the GIL, so the worker thread appending an inference
+        # time never races the main thread reading the list after shutdown(wait).
+        inference_ms: list[float] = []
+        rtc_chunks_acquired = 0
+        rtc_prefetch_hits = 0
+        rtc_prefetch_blocks = 0
+
+        def _rtc_telemetry() -> dict[str, Any]:
+            # The async-RTC telemetry block, merged into every result json
+            # (success and error) so latency masking is provable from the
+            # structured payload without grepping logs. On the synchronous path
+            # the prefetch counters stay 0 and only the inference timings carry
+            # information.
+            _n = len(inference_ms)
+            return {
+                "rtc_async_enabled": bool(async_rtc),
+                "rtc_chunks_acquired": rtc_chunks_acquired,
+                "rtc_prefetch_hits": rtc_prefetch_hits,
+                "rtc_prefetch_blocks": rtc_prefetch_blocks,
+                "rtc_avg_inference_ms": round(sum(inference_ms) / _n, 3) if _n else 0.0,
+                "rtc_max_inference_ms": round(max(inference_ms), 3) if _n else 0.0,
+            }
 
         # Lazy optional import - only imageio is optional.
         writer = None
@@ -636,8 +701,14 @@ class PolicyRunner:
                 # for a prefetch, the main thread otherwise), and at most one
                 # inference is ever in flight, so this never races.
                 policy.set_rtc_observed_delay(observed_delay)
+                _t_infer = time.perf_counter()
                 coro_or_result = policy.get_actions(observation, instruction, **_policy_kwargs)
                 actions = _resolve_coroutine(coro_or_result)
+                # Record inference wall-time (ms) for both the sync and async
+                # paths. Under async this runs on the prefetch worker; list
+                # append is atomic under the GIL so the read after
+                # shutdown(wait=True) sees every entry.
+                inference_ms.append((time.perf_counter() - _t_infer) * 1000.0)
                 _chunk = resolve_chunk_length(policy, action_horizon)
                 return list(actions[:_chunk])
 
@@ -657,11 +728,41 @@ class PolicyRunner:
                 # after the previous one has been consumed), and the sim is only
                 # ever touched from THIS thread, so there is no MuJoCo data race.
                 from concurrent.futures import Future, ThreadPoolExecutor
+                from concurrent.futures import TimeoutError as FuturesTimeout
+
+                def _swap_in(fut: Future[list[dict[str, Any]]]) -> list[dict[str, Any]]:
+                    # Block on the prefetched chunk at the seam. A prefetch HIT
+                    # means inference already finished (the seam is invisible); a
+                    # BLOCK means we still have to wait because inference ran
+                    # slower than the chunk's execution - the seam was starved,
+                    # which is the actionable "tune prefetch_trigger / shorten
+                    # the chunk" signal, so log it. A hard timeout turns a stuck
+                    # model into a structured error instead of an unbounded sim
+                    # hang.
+                    nonlocal rtc_prefetch_hits, rtc_prefetch_blocks
+                    if fut.done():
+                        rtc_prefetch_hits += 1
+                    else:
+                        rtc_prefetch_blocks += 1
+                        logger.warning(
+                            "async-RTC seam starvation: prefetched chunk was not ready at the "
+                            "swap point (inference slower than chunk execution). Blocking on it; "
+                            "consider a shorter chunk or an earlier prefetch_trigger."
+                        )
+                    try:
+                        return fut.result(timeout=rtc_inference_timeout_s)
+                    except FuturesTimeout as e:
+                        raise RuntimeError(
+                            f"async-RTC prefetch exceeded rtc_inference_timeout_s="
+                            f"{rtc_inference_timeout_s}s; policy inference is stuck. Raise the "
+                            f"timeout or check the policy/server."
+                        ) from e
 
                 executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="rtc-prefetch")
                 try:
                     cur_obs = self.sim.get_observation(robot_name=robot_name, skip_images=_skip_images)
                     cur_chunk = _query_chunk(cur_obs)
+                    rtc_chunks_acquired += 1
                     if not cur_chunk:
                         raise RuntimeError("policy returned an empty action chunk; cannot run rollout")
                     idx = 0
@@ -673,11 +774,7 @@ class PolicyRunner:
                         if idx >= len(cur_chunk):
                             # Current chunk drained -> swap in the next chunk.
                             if prefetch is not None:
-                                # Atomic swap. Blocks ONLY if inference is still
-                                # in flight (it ran slower than chunk execution);
-                                # otherwise the result is already waiting and the
-                                # seam is invisible.
-                                cur_chunk = prefetch.result()
+                                cur_chunk = _swap_in(prefetch)
                                 if prefetch_obs is not None:
                                     cur_obs = prefetch_obs
                                 prefetch = None
@@ -687,8 +784,25 @@ class PolicyRunner:
                                 # fall back to a synchronous re-query.
                                 cur_obs = self.sim.get_observation(robot_name=robot_name, skip_images=_skip_images)
                                 cur_chunk = _query_chunk(cur_obs)
+                            rtc_chunks_acquired += 1
                             if not cur_chunk:
-                                raise RuntimeError("policy returned an empty action chunk; cannot continue rollout")
+                                # Drop-and-requery: a prefetched chunk arriving
+                                # empty (a transient policy hiccup) degrades to
+                                # ONE synchronous re-query before we give up,
+                                # rather than killing an otherwise-healthy
+                                # rollout on a single empty result.
+                                logger.warning(
+                                    "async-RTC chunk arrived empty; falling back to one "
+                                    "synchronous re-query before erroring."
+                                )
+                                cur_obs = self.sim.get_observation(robot_name=robot_name, skip_images=_skip_images)
+                                cur_chunk = _query_chunk(cur_obs)
+                                rtc_chunks_acquired += 1
+                                if not cur_chunk:
+                                    raise RuntimeError(
+                                        "policy returned an empty action chunk twice (prefetch + "
+                                        "synchronous re-query); cannot continue rollout"
+                                    )
                             idx = 0
                             prefetch_trigger = max(1, len(cur_chunk) // 2)
                             continue
@@ -728,7 +842,10 @@ class PolicyRunner:
             if writer is not None:
                 writer.close()
             logger.exception("PolicyRunner.run failed")
-            return {"status": "error", "content": [{"text": f"Policy failed: {e}"}]}
+            return {
+                "status": "error",
+                "content": [{"text": f"Policy failed: {e}"}, {"json": _rtc_telemetry()}],
+            }
 
         # Either finished all steps or was cooperatively stopped
         elapsed = time.time() - start_time
@@ -786,6 +903,7 @@ class PolicyRunner:
             wrote_video = frame_count > 0 and os.path.exists(video_path)
             payload["video_path"] = video_path if wrote_video else None
             payload["video_frames"] = frame_count
+        payload.update(_rtc_telemetry())
 
         # If every send_action call failed (all keys unresolved), the robot
         # never moved -- report this as an error rather than a false success.

--- a/tests/simulation/test_policy_runner.py
+++ b/tests/simulation/test_policy_runner.py
@@ -695,6 +695,12 @@ class TestChunkNotTruncatedBelowActionsPerStep:
             control_frequency=50.0,  # -> 30 total steps
             action_horizon=8,
             fast_mode=True,
+            # Pin the synchronous path: this regression is about the sync loop
+            # consuming the FULL trained chunk before re-querying. async_rtc now
+            # defaults to None (auto-enabled for chunk policies); its mid-chunk
+            # prefetch would fire a second background query, which is exercised
+            # in test_policy_runner_async_rtc.py rather than here.
+            async_rtc=False,
         )
 
         assert result["status"] == "success"

--- a/tests/simulation/test_policy_runner_async_rtc.py
+++ b/tests/simulation/test_policy_runner_async_rtc.py
@@ -209,10 +209,14 @@ def test_async_rtc_matches_sync_step_accounting() -> None:
     assert async_json["action_errors"] == 0
 
 
-def test_async_rtc_defaults_to_false() -> None:
-    """Back-compat: async_rtc is opt-in on both PolicyRunner.run and run_policy."""
-    assert inspect.signature(PolicyRunner.run).parameters["async_rtc"].default is False
-    assert inspect.signature(SimEngine.run_policy).parameters["async_rtc"].default is False
+def test_async_rtc_defaults_to_none_and_auto_resolves() -> None:
+    """The default is ``None`` (auto-resolve), not a hardcoded ``False``.
+
+    ``None`` means "let the policy decide" - chunk-emitting VLAs opt into
+    latency masking automatically while single-step policies stay synchronous.
+    """
+    assert inspect.signature(PolicyRunner.run).parameters["async_rtc"].default is None
+    assert inspect.signature(SimEngine.run_policy).parameters["async_rtc"].default is None
 
 
 def test_sync_loop_supplies_zero_observed_delay() -> None:
@@ -236,3 +240,246 @@ def test_async_rtc_supplies_deterministic_observed_delay() -> None:
     # At least one prefetched (overlapped) query must carry the non-zero count -
     # otherwise the async path silently degraded to synchronous re-queries.
     assert any(d == expected_prefetch_delay for d in policy.observed_delays), policy.observed_delays
+
+
+# --- is_chunk_emitting + auto-enable contract -----------------------------
+
+
+class _SingleStepPolicy(Policy):
+    """One action per ``get_actions`` (``MockPolicy`` shape) -> not chunk-emitting."""
+
+    def __init__(self) -> None:
+        self.actions_per_step = 1
+        self.robot_state_keys: list[str] = []
+
+    @property
+    def provider_name(self) -> str:
+        return "single-step-test"
+
+    @property
+    def requires_images(self) -> bool:
+        return False
+
+    def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
+        self.robot_state_keys = robot_state_keys
+
+    async def get_actions(
+        self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any
+    ) -> list[dict[str, Any]]:
+        keys = self.robot_state_keys or ["j0", "j1", "j2"]
+        return [{k: 0.0 for k in keys}]
+
+
+def test_is_chunk_emitting_true_for_multistep_policy() -> None:
+    """A policy whose execution horizon is > 1 reports itself chunk-emitting."""
+    sim = _CountingSim()
+    assert _ChunkPolicy(sim, chunk=4).is_chunk_emitting() is True
+
+
+def test_is_chunk_emitting_false_for_single_step_policy() -> None:
+    """A single-action policy is NOT chunk-emitting (overlap would not help)."""
+    assert _SingleStepPolicy().is_chunk_emitting() is False
+
+
+def test_async_rtc_auto_enabled_for_chunk_policy() -> None:
+    """``async_rtc=None`` (default) auto-enables overlap for a chunk policy."""
+    sim = _CountingSim(exec_sleep=_EXEC_SLEEP)
+    policy = _ChunkPolicy(sim)
+    policy.set_robot_state_keys(sim.robot_joint_names("arm"))
+    # No async_rtc kwarg at all -> uses the None default -> resolves via the
+    # policy. A chunk-emitting policy must enable the overlap.
+    result = PolicyRunner(sim).run(
+        "arm", policy, duration=16 / 50.0, control_frequency=50.0, action_horizon=_CHUNK, fast_mode=True
+    )
+    assert result["status"] == "success"
+    telem = result["content"][1]["json"]
+    assert telem["rtc_async_enabled"] is True
+    # Prefetch fired mid-chunk (the overlap actually ran).
+    assert any(c % _CHUNK != 0 for c in policy.infer_starts), policy.infer_starts
+
+
+def test_async_rtc_auto_disabled_for_single_step_policy() -> None:
+    """``async_rtc=None`` keeps a single-step policy on the synchronous loop."""
+    sim = _CountingSim()
+    policy = _SingleStepPolicy()
+    policy.set_robot_state_keys(sim.robot_joint_names("arm"))
+    result = PolicyRunner(sim).run("arm", policy, duration=8 / 50.0, control_frequency=50.0, fast_mode=True)
+    assert result["status"] == "success"
+    assert result["content"][1]["json"]["rtc_async_enabled"] is False
+
+
+# --- telemetry block ------------------------------------------------------
+
+_RTC_KEYS = {
+    "rtc_async_enabled",
+    "rtc_chunks_acquired",
+    "rtc_prefetch_hits",
+    "rtc_prefetch_blocks",
+    "rtc_avg_inference_ms",
+    "rtc_max_inference_ms",
+}
+
+
+def test_telemetry_fields_present_on_both_paths() -> None:
+    """All six RTC telemetry fields appear in the json on sync AND async runs."""
+    for async_rtc in (False, True):
+        result, _, _ = _run(async_rtc=async_rtc, exec_sleep=0.0)
+        telem = result["content"][1]["json"]
+        assert _RTC_KEYS <= set(telem), (async_rtc, telem)
+        assert telem["rtc_async_enabled"] is async_rtc
+
+
+def test_async_rtc_prefetch_blocks_when_inference_slow() -> None:
+    """Fake-slow policy: inference > chunk exec -> prefetch blocks at every seam,
+    and total wall time tracks inference x n_chunks (not x 2 - no double pay)."""
+    # chunk exec ~0.04s (4 x 0.01) << infer 0.10s -> inference cannot be hidden,
+    # so every swap blocks. Keep exec tiny so wall time is dominated by inference.
+    n_steps = 16
+    n_chunks = n_steps // _CHUNK
+    infer = 0.10
+    sim = _CountingSim(exec_sleep=0.01)
+    policy = _ChunkPolicy(sim, infer_sleep=infer)
+    policy.set_robot_state_keys(sim.robot_joint_names("arm"))
+    t0 = time.perf_counter()
+    result = PolicyRunner(sim).run(
+        "arm",
+        policy,
+        duration=n_steps / 50.0,
+        control_frequency=50.0,
+        action_horizon=_CHUNK,
+        fast_mode=True,
+        async_rtc=True,
+    )
+    elapsed = time.perf_counter() - t0
+    assert result["status"] == "success"
+    telem = result["content"][1]["json"]
+    assert telem["rtc_prefetch_blocks"] > 0, telem
+    # Each chunk's inference is paid ONCE (serialized behind the next), never
+    # twice: wall time stays under the 2x-per-chunk ceiling the issue calls out.
+    assert elapsed < 2 * infer * n_chunks, (elapsed, infer, n_chunks)
+
+
+def test_async_rtc_prefetch_hits_when_inference_fast() -> None:
+    """Fake-fast policy: inference << chunk exec -> every seam is a hit, no blocks."""
+    n_steps = 16
+    n_chunks = n_steps // _CHUNK
+    # infer 0.005s << exec 0.08s/chunk -> the prefetch is always ready at swap.
+    sim = _CountingSim(exec_sleep=0.02)
+    policy = _ChunkPolicy(sim, infer_sleep=0.005)
+    policy.set_robot_state_keys(sim.robot_joint_names("arm"))
+    result = PolicyRunner(sim).run(
+        "arm",
+        policy,
+        duration=n_steps / 50.0,
+        control_frequency=50.0,
+        action_horizon=_CHUNK,
+        fast_mode=True,
+        async_rtc=True,
+    )
+    assert result["status"] == "success"
+    telem = result["content"][1]["json"]
+    assert telem["rtc_prefetch_blocks"] == 0, telem
+    assert telem["rtc_prefetch_hits"] == n_chunks - 1, telem
+
+
+# --- empty-chunk drop-and-requery fallback --------------------------------
+
+
+class _EmptyOnCallsPolicy(_ChunkPolicy):
+    """Emits an EMPTY chunk on the configured (1-indexed) inference calls.
+
+    Lets a test force a prefetched chunk to arrive empty and assert the runner
+    degrades to one synchronous re-query rather than killing the rollout.
+    """
+
+    def __init__(self, sim: _CountingSim, empty_calls: set[int], **kw: Any) -> None:
+        super().__init__(sim, **kw)
+        self._empty_calls = empty_calls
+        self._calls = 0
+
+    async def get_actions(
+        self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any
+    ) -> list[dict[str, Any]]:
+        with self._lock:
+            self._calls += 1
+            call_no = self._calls
+            self.infer_starts.append(self._sim.send_count)
+            self.observed_delays.append(self.rtc_observed_delay_steps)
+        if self._infer_sleep:
+            time.sleep(self._infer_sleep)
+        if call_no in self._empty_calls:
+            return []
+        keys = self.robot_state_keys or ["j0", "j1", "j2"]
+        return [{k: 0.0 for k in keys} for _ in range(self._chunk)]
+
+
+def test_async_rtc_empty_prefetch_degrades_to_resync() -> None:
+    """An empty prefetched chunk triggers ONE synchronous re-query, not an error."""
+    sim = _CountingSim(exec_sleep=0.0)
+    # Call 1 = cold start (non-empty), call 2 = first prefetch (empty -> resync).
+    policy = _EmptyOnCallsPolicy(sim, empty_calls={2}, infer_sleep=0.005)
+    policy.set_robot_state_keys(sim.robot_joint_names("arm"))
+    result = PolicyRunner(sim).run(
+        "arm",
+        policy,
+        duration=16 / 50.0,
+        control_frequency=50.0,
+        action_horizon=_CHUNK,
+        fast_mode=True,
+        async_rtc=True,
+    )
+    assert result["status"] == "success", result
+    assert result["content"][1]["json"]["n_steps"] == 16
+
+
+def test_async_rtc_empty_twice_errors() -> None:
+    """Empty prefetch AND empty re-query is fatal (structured error, no hang)."""
+    sim = _CountingSim(exec_sleep=0.0)
+    # Every inference after the cold start returns empty -> resync also empty.
+    policy = _EmptyOnCallsPolicy(sim, empty_calls={2, 3, 4, 5, 6}, infer_sleep=0.005)
+    policy.set_robot_state_keys(sim.robot_joint_names("arm"))
+    result = PolicyRunner(sim).run(
+        "arm",
+        policy,
+        duration=16 / 50.0,
+        control_frequency=50.0,
+        action_horizon=_CHUNK,
+        fast_mode=True,
+        async_rtc=True,
+    )
+    assert result["status"] == "error", result
+    assert "empty action chunk" in result["content"][0]["text"]
+    # The error result still carries the telemetry block.
+    assert _RTC_KEYS <= set(result["content"][1]["json"])
+
+
+# --- hard inference timeout -----------------------------------------------
+
+
+def test_async_rtc_prefetch_timeout_errors_cleanly() -> None:
+    """A stuck prefetch hits the hard timeout and returns a structured error
+    instead of hanging the sim indefinitely."""
+    infer = 0.15
+    n_steps = 64  # many chunks remain; the timeout must NOT wait for all of them
+    sim = _CountingSim(exec_sleep=0.0)
+    policy = _ChunkPolicy(sim, infer_sleep=infer)
+    policy.set_robot_state_keys(sim.robot_joint_names("arm"))
+    t0 = time.perf_counter()
+    result = PolicyRunner(sim).run(
+        "arm",
+        policy,
+        duration=n_steps / 50.0,
+        control_frequency=50.0,
+        action_horizon=_CHUNK,
+        fast_mode=True,
+        async_rtc=True,
+        rtc_inference_timeout_s=0.02,
+    )
+    elapsed = time.perf_counter() - t0
+    assert result["status"] == "error", result
+    assert "rtc_inference_timeout_s" in result["content"][0]["text"]
+    # The rollout aborts after the cold-start query plus the single in-flight
+    # inference the executor joins on shutdown - bounded by ~2 inferences, NOT
+    # the full 16-chunk rollout it would otherwise run.
+    assert elapsed < 4 * infer, elapsed
+    assert _RTC_KEYS <= set(result["content"][1]["json"])

--- a/tests/simulation/test_rtc_requery_interval.py
+++ b/tests/simulation/test_rtc_requery_interval.py
@@ -126,6 +126,12 @@ def _run(policy: _RtcChunkPolicy, *, n_steps: int, action_horizon: int) -> dict:
         control_frequency=50.0,
         action_horizon=action_horizon,
         fast_mode=True,
+        # Pin the SYNCHRONOUS path: these tests assert the re-query interval of
+        # the chunk-then-drain loop. async_rtc defaults to None (auto-enabled
+        # for chunk-emitting/RTC policies), whose mid-chunk prefetch fires an
+        # extra background query and is covered separately in
+        # test_policy_runner_async_rtc.py.
+        async_rtc=False,
     )
 
 

--- a/tests_integ/lerobot_local/test_lerobot_local_integration.py
+++ b/tests_integ/lerobot_local/test_lerobot_local_integration.py
@@ -325,3 +325,92 @@ class TestErrorHandling:
 
         # Restore
         act_policy._policy.select_action = original_select_action
+
+
+class TestAsyncRtcLatencyMasking:
+    """End-to-end async-RTC latency masking with a real chunk-emitting VLA.
+
+    ``run_policy(async_rtc=None)`` (the default) auto-enables the overlap
+    pipeline for a chunk-emitting policy, hiding inference for chunk N+1 behind
+    the execution of chunk N. For MolmoAct2 - whose per-chunk inference is the
+    dominant per-step cost - this should materially cut the rollout wall time
+    versus the synchronous chunk-then-drain loop, and the saving must be visible
+    in the run-result telemetry rather than only in the logs.
+
+    Gated behind ``STRANDS_TEST_MOLMOACT2`` because it downloads a multi-GB
+    checkpoint and needs a GPU; it is skipped in the default integ run.
+    """
+
+    MOLMOACT2_MODEL = os.getenv("LEROBOT_MOLMOACT2_MODEL", "allenai/MolmoAct2-SO100_101")
+    # Steps per rollout. Several chunk seams are needed for the overlap to pay
+    # off; keep it modest so the test stays within the integ timeout on a GPU.
+    N_STEPS = int(os.getenv("MOLMOACT2_RTC_STEPS", "60"))
+    CONTROL_HZ = float(os.getenv("MOLMOACT2_RTC_HZ", "30"))
+
+    @pytest.mark.skipif(
+        not os.getenv("STRANDS_TEST_MOLMOACT2"),
+        reason="Set STRANDS_TEST_MOLMOACT2=1 (GPU + multi-GB MolmoAct2 download) to run.",
+    )
+    def test_molmoact2_async_rtc_cuts_wall_time(self):
+        """async_rtc=True is >=30% faster wall-clock than async_rtc=False."""
+        os.environ.setdefault("STRANDS_TRUST_REMOTE_CODE", "1")
+        from strands_robots.policies.lerobot_local.policy import LerobotLocalPolicy
+        from strands_robots.simulation import Simulation
+
+        logger.info("Loading MolmoAct2 model: %s", self.MOLMOACT2_MODEL)
+        policy = LerobotLocalPolicy(
+            pretrained_name_or_path=self.MOLMOACT2_MODEL,
+            trust_remote_code=True,
+        )
+        assert policy._loaded is True
+        # The auto-enable signal: MolmoAct2 must self-report as chunk-emitting so
+        # run_policy(async_rtc=None) turns the overlap on without an explicit flag.
+        assert policy.is_chunk_emitting() is True
+
+        sim = Simulation()
+        try:
+            sim.create_world(timestep=0.002, gravity=[0, 0, -9.81])
+            sim.add_robot("arm", data_config="so100", position=[0.0, 0.0, 0.0])
+            sim.step(n_steps=10)  # settle
+
+            def _rollout(async_rtc: bool) -> dict:
+                sim.reset()
+                policy.reset()
+                return sim.run_policy(
+                    robot_name="arm",
+                    policy_object=policy,
+                    instruction="pick up the cube",
+                    n_steps=self.N_STEPS,
+                    control_frequency=self.CONTROL_HZ,
+                    fast_mode=True,
+                    async_rtc=async_rtc,
+                )
+
+            sync = _rollout(async_rtc=False)
+            asyncr = _rollout(async_rtc=True)
+            assert sync["status"] == "success", sync
+            assert asyncr["status"] == "success", asyncr
+
+            sync_json = sync["content"][1]["json"]
+            async_json = asyncr["content"][1]["json"]
+            assert sync_json["rtc_async_enabled"] is False
+            assert async_json["rtc_async_enabled"] is True
+            # The overlap actually fired and at least one seam was hidden.
+            assert async_json["rtc_prefetch_hits"] > 0, async_json
+
+            sync_t = float(sync_json["elapsed_s"])
+            async_t = float(async_json["elapsed_s"])
+            reduction = (sync_t - async_t) / sync_t
+            logger.info(
+                "MolmoAct2 wall time: sync=%.2fs async=%.2fs reduction=%.1f%% (telemetry=%s)",
+                sync_t,
+                async_t,
+                reduction * 100.0,
+                async_json,
+            )
+            assert reduction > 0.30, (
+                f"async-RTC reduced wall time by only {reduction * 100:.1f}% "
+                f"(sync={sync_t:.2f}s async={async_t:.2f}s); expected >30%."
+            )
+        finally:
+            sim.destroy()


### PR DESCRIPTION
## Problem

`PolicyRunner.run` / `SimEngine.run_policy` ship an async-RTC pipeline that overlaps inference for chunk N+1 with the execution of chunk N (single background worker, atomic seam swap), but it defaulted to `async_rtc=False`. So every chunk-emitting VLA (pi0, pi0.5, pi0-FAST, SmolVLA, MolmoAct2) ran the synchronous chunk-then-drain loop and paid the full inference latency at every chunk seam in sim, even though the overlap machinery was already there. The latency mask was invisible to anyone who did not know to pass the flag, and there was no way to prove it engaged without grepping logs.

## Change

**Auto-enable.** `async_rtc` now defaults to `None` (auto-resolve). `None` reads a new `Policy.is_chunk_emitting()` and turns the overlap on for chunk-emitting policies while keeping single-step policies (MockPolicy, classical planners) on the synchronous loop, where overlap gains nothing. An explicit `async_rtc=True`/`False` always wins.

- `Policy.is_chunk_emitting()` defaults to `execution_horizon > 1` - provider-agnostic, no name enumeration.
- `LerobotLocalPolicy` overrides it to also report `True` for an RTC model (`supports_rtc`) or a checkpoint that must be driven via `predict_action_chunk` (MolmoAct2, detected through the existing `_requires_action_chunk()` path).

**Telemetry.** Every `run_policy` result `{"json": {...}}` block (success and error) now carries six fields so latency masking is provable from the payload:
`rtc_async_enabled`, `rtc_chunks_acquired`, `rtc_prefetch_hits`, `rtc_prefetch_blocks`, `rtc_avg_inference_ms`, `rtc_max_inference_ms`.

**Seam hardening.**
- Empty prefetched chunk degrades to **one synchronous re-query** before erroring (a transient hiccup no longer kills an otherwise-healthy rollout; two empties in a row is still fatal).
- A blocking prefetch (inference slower than chunk execution) logs a starvation warning so you can shorten the chunk or fire the prefetch earlier.
- New `rtc_inference_timeout_s` bounds a stuck inference: the swap returns a structured `status=error` result (with telemetry) instead of waiting for every remaining chunk. The runner still joins the single in-flight worker on shutdown (Python cannot forcibly kill a running thread, and a leaked worker would touch the policy after `run()` returns), so the abort is bounded by one inference, not the whole rollout.

## Proof (headless MuJoCo sim)

Same chunk-emitting policy (chunk=10) run through `run_policy` twice on an so101 arm at a real-time 20 Hz control rate, with an injected per-chunk inference latency standing in for a heavy VLA (no GPU checkpoint needed to exercise the runner/seam/telemetry paths):

![latency masking](https://github.com/cagataycali/robots/releases/download/rtc-async-demo/rtc_latency_masking.png)

- `async_rtc=False`: **5.71 s**
- `async_rtc=True` (the new auto-enabled default): **4.30 s** -> **24.7% faster**
- async telemetry: `rtc_async_enabled=true`, `rtc_prefetch_hits=7`, `rtc_prefetch_blocks=0`, `rtc_chunks_acquired=8` (every seam hidden).

Rollout (async, identical trajectory, MP4 -> GIF):

![async rollout](https://github.com/cagataycali/robots/releases/download/rtc-async-demo/rtc_async_rollout.gif)

## Tests

`tests/simulation/test_policy_runner_async_rtc.py` adds the latency-masking contract: auto-enable on a chunk policy / auto-disable on a single-step policy, `is_chunk_emitting` true/false, all six telemetry fields present on sync+async paths, slow inference -> `prefetch_blocks > 0` under the 2x-per-chunk ceiling, fast inference -> `prefetch_hits == n_chunks-1` with zero blocks, empty-prefetch drop-and-requery (and the twice-empty fatal case), and the hard timeout returning a clean error. `tests_integ/lerobot_local/` gains a MolmoAct2 wall-time test asserting `>30%` reduction end-to-end (gated behind an env flag + GPU). Tests that assert the exact **synchronous** re-query count now pin `async_rtc=False`, since chunk policies auto-enable the overlap (which fires one trailing background query).

Local gate green: `ruff check` / `ruff format --check` clean, `mypy strands_robots tests tests_integ` clean (526 files), full `MUJOCO_GL=egl pytest tests/` passes except 3 pre-existing torchcodec/CUDA env failures unrelated to this change.

## Behaviour change

A chunk-emitting policy run through `run_policy` without an explicit `async_rtc` now uses the overlap pipeline. CHANGELOG updated under `[Unreleased]`; docs updated in `docs/simulation/overview.md` (prefetch timeline + auto-enable rule + telemetry table) and `docs/policies/lerobot-local.md`.