### PR TITLE
feat(policies): surface lerobot_local model-load telemetry end-to-end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,32 @@ background `get_actions` for the trailing chunk. Tests that assert the exact
 synchronous re-query count should pass `async_rtc=False`.
 
 
+### Observability: `lerobot_local` model-load telemetry
+
+The process-level model cache already skips the expensive `from_pretrained`
+weight read when the same checkpoint is re-instantiated, but the saving was
+invisible: a warm reuse and a cold reload produced identical result text, so a
+caller paying a per-episode reload had no machine-checkable signal.
+
+- `LerobotLocalPolicy` now records `load_cache_hit` (bool) and `load_time_s`
+  (float) after each load, on both the generic and MolmoAct2 load paths.
+- `Simulation.run_policy` and `Simulation.eval_policy` surface these as
+  `policy_load_cache_hit` and `policy_load_time_s` in their `{"json": {...}}`
+  result block. A `policy_load_cache_hit=False` on episode 2+ of a loop is a
+  smell that the caller rebuilt the policy per episode instead of reusing one
+  warm `policy_object=`. Policies without load telemetry (e.g. `MockPolicy`)
+  report the honest defaults `0.0` / `False`.
+- New `list_cached_models()` read-only introspection helper (exported from
+  `strands_robots.policies.lerobot_local`) reports the resident cache entries
+  (`namespace`, `pretrained_name_or_path`, `device`, `policy_class`) without
+  exposing the private cache dict, complementing `clear_model_cache()`.
+
+Memory note: the cache is unchanged; this is observability only. The cached
+model is still one live module shared across instances with the same load key,
+so concurrent (not sequential) reuse should still opt out with
+`cache_model=False`.
+
+
 ### Correctness: `run_policy` episode-count contract + `verify_dataset_episodes`
 
 `run_policy` could silently record a single merged `episode_index=0`

--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -82,6 +82,36 @@ For multi-episode evaluation, prefer a single `Simulation.eval_policy(...,
 n_episodes=N)` (or `run_policy(..., policy_object=loaded)`) call, which loads
 the policy once and reuses it across episodes regardless of this cache.
 
+### Load telemetry
+
+Every `LerobotLocalPolicy` records two attributes after construction so the
+saving from the cache is observable instead of guessed:
+
+- `load_cache_hit` (`bool`): `True` when the heavy `from_pretrained` weight
+  read was skipped because the process cache already held this checkpoint.
+- `load_time_s` (`float`): wall time the load took (near `0.0` on a cache hit).
+
+`Simulation.run_policy` and `Simulation.eval_policy` surface these in their
+`{"json": {...}}` result block as `policy_load_cache_hit` and
+`policy_load_time_s`. In a multi-episode loop, a `policy_load_cache_hit=False`
+on episode 2+ is a smell that the caller rebuilt the policy per episode instead
+of reusing one warm `policy_object=`; an agent can read that field and
+self-correct. Policies that expose no load telemetry (e.g. `MockPolicy`) report
+the honest defaults `0.0` / `False`.
+
+```python
+from strands_robots.policies.lerobot_local import list_cached_models
+
+# Inspect what is resident without touching private state.
+for entry in list_cached_models():
+    print(entry["namespace"], entry["pretrained_name_or_path"], entry["device"])
+```
+
+`list_cached_models()` returns one read-only dict per cached entry
+(`namespace`, `pretrained_name_or_path`, `device`, `policy_class`); pair it with
+`clear_model_cache()` to decide when to evict before loading a different
+checkpoint.
+
 ## Supported models
 
 | Model | Notes |

--- a/strands_robots/policies/lerobot_local/__init__.py
+++ b/strands_robots/policies/lerobot_local/__init__.py
@@ -1,5 +1,5 @@
 """LeRobot Local Policy - Direct HuggingFace model inference (no server needed)."""
 
-from .policy import LerobotLocalPolicy, clear_model_cache
+from .policy import LerobotLocalPolicy, clear_model_cache, list_cached_models
 
-__all__ = ["LerobotLocalPolicy", "clear_model_cache"]
+__all__ = ["LerobotLocalPolicy", "clear_model_cache", "list_cached_models"]

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -74,6 +74,45 @@ def clear_model_cache() -> int:
     return n
 
 
+def list_cached_models() -> list[dict[str, Any]]:
+    """Report the underlying models currently held in the process-level cache.
+
+    Complements :func:`clear_model_cache` with read-only introspection so a
+    caller (or an LLM harness deciding whether to evict before loading a
+    different checkpoint) can see what is resident without poking at the
+    private ``_MODEL_CACHE`` dict. The heavy model object itself is never
+    returned - only its identifying key fields and resolved class name.
+
+    Returns:
+        One dict per cached entry, each with:
+            ``namespace``: load path family (``"generic"`` or ``"molmoact2"``).
+            ``pretrained_name_or_path``: the checkpoint the entry was keyed on.
+            ``device``: the requested device string (or ``None`` if unset).
+            ``policy_class``: class name of the cached model (best-effort).
+        The list is ordered as the cache was populated.
+    """
+    with _MODEL_CACHE_LOCK:
+        items = list(_MODEL_CACHE.items())
+    out: list[dict[str, Any]] = []
+    for key, value in items:
+        # Keys are (namespace, pretrained_name_or_path, device, *extra). The
+        # generic path stores a (policy, policy_type) tuple; molmoact2 stores
+        # the bare policy. Resolve the underlying module for the class name.
+        model = value[0] if isinstance(value, tuple) else value
+        namespace = key[0] if len(key) > 0 else None
+        path = key[1] if len(key) > 1 else None
+        device = key[2] if len(key) > 2 else None
+        out.append(
+            {
+                "namespace": namespace,
+                "pretrained_name_or_path": path,
+                "device": device,
+                "policy_class": type(model).__name__,
+            }
+        )
+    return out
+
+
 class LerobotLocalPolicy(Policy):
     """Policy that loads and runs LeRobot models directly (no server).
 
@@ -191,6 +230,16 @@ class LerobotLocalPolicy(Policy):
         self._input_features: dict[str, Any] = {}
         self._output_features: dict[str, Any] = {}
         self._loaded = False
+        # Load telemetry, observable end-to-end (PolicyRunner surfaces these
+        # as ``policy_load_time_s`` / ``policy_load_cache_hit`` in its result
+        # JSON). ``load_cache_hit`` True means the heavy from_pretrained weight
+        # read was skipped because the process-level _MODEL_CACHE already held
+        # this checkpoint - an agent driving a multi-episode loop can read a
+        # False on episode 2+ as a smell that it rebuilt the policy instead of
+        # reusing policy_object=. ``load_time_s`` is the wall time the load
+        # actually took (near 0 on a cache hit).
+        self.load_time_s: float = 0.0
+        self.load_cache_hit: bool = False
         self._processor_bridge: ProcessorBridge | None = None
         self._tokenizer: Any = None
         self._tokenizer_max_length: int = tokenizer_max_length
@@ -543,6 +592,7 @@ class LerobotLocalPolicy(Policy):
         # policy_type is cached alongside the module so a hit needs no hub call.
         cache_key = self._model_cache_key("generic", self.policy_type)
         cached = self._cache_get(cache_key)
+        self.load_cache_hit = cached is not None
         if cached is not None:
             self._policy, self.policy_type = cached
             logger.info(
@@ -593,6 +643,7 @@ class LerobotLocalPolicy(Policy):
                 self._output_features = config.output_features
 
         elapsed = time.time() - start
+        self.load_time_s = elapsed
         logger.info(
             "Loaded %s (type='%s') in %.1fs on %s",
             type(self._policy).__name__,
@@ -778,6 +829,7 @@ class LerobotLocalPolicy(Policy):
             action_dim,
         )
         cached_model = self._cache_get(model_cache_key)
+        self.load_cache_hit = cached_model is not None
         policy, preprocessor, postprocessor, cfg = _molmoact2.build_policy(
             self.pretrained_name_or_path,
             device=self.requested_device,
@@ -801,6 +853,7 @@ class LerobotLocalPolicy(Policy):
         self.inference_kwargs.setdefault("inference_action_mode", self._molmoact2_inference_action_mode)
 
         elapsed = time.time() - start
+        self.load_time_s = elapsed
         logger.info(
             "Loaded MolmoAct2Policy (type='molmoact2') in %.1fs on %s",
             elapsed,

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -896,6 +896,14 @@ class PolicyRunner:
             "action_errors": _action_errors,
             "video_path": None,
             "video_frames": 0,
+            # Load telemetry of the policy that drove this rollout. For
+            # LerobotLocalPolicy these reflect the process-level model cache:
+            # policy_load_cache_hit=False on episode 2+ of a loop is a smell
+            # that the caller rebuilt the policy instead of reusing
+            # policy_object=. Defaults (0.0 / False) cover policies that expose
+            # no load telemetry (e.g. MockPolicy).
+            "policy_load_time_s": round(float(getattr(policy, "load_time_s", 0.0)), 3),
+            "policy_load_cache_hit": bool(getattr(policy, "load_cache_hit", False)),
         }
         if sim_time is not None:
             payload["sim_time_s"] = round(sim_time, 3)
@@ -1220,6 +1228,8 @@ class PolicyRunner:
                         "n_success": n_success,
                         "avg_steps": round(avg_steps, 1),
                         "max_steps": max_steps,
+                        "policy_load_time_s": round(float(getattr(policy, "load_time_s", 0.0)), 3),
+                        "policy_load_cache_hit": bool(getattr(policy, "load_cache_hit", False)),
                         "episodes": results,
                     }
                 },
@@ -1544,6 +1554,8 @@ class PolicyRunner:
                         "max_steps": max_steps,
                         "seed": seed,
                         "benchmark_class": spec_name,
+                        "policy_load_time_s": round(float(getattr(policy, "load_time_s", 0.0)), 3),
+                        "policy_load_cache_hit": bool(getattr(policy, "load_cache_hit", False)),
                         "episodes": results,
                     }
                 },

--- a/tests/policies/lerobot_local/test_load_telemetry.py
+++ b/tests/policies/lerobot_local/test_load_telemetry.py
@@ -1,0 +1,114 @@
+"""Load telemetry for LerobotLocalPolicy: cache-hit + load-time observability.
+
+The process-level model cache (see ``_MODEL_CACHE``) already skips the heavy
+``from_pretrained`` weight read on repeat instantiation of the same checkpoint.
+These tests pin that the saving is *observable*: every policy exposes
+``load_time_s`` and ``load_cache_hit`` so a caller (or an LLM harness) can tell
+a cold load apart from a cache hit and self-correct a per-episode reload, and
+``list_cached_models()`` reports what is resident without poking the private
+cache dict.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from strands_robots.policies.lerobot_local import (
+    clear_model_cache,
+    list_cached_models,
+)
+from strands_robots.policies.lerobot_local.policy import LerobotLocalPolicy
+
+
+def _generic_inner():
+    inner = MagicMock()
+    inner.config = MagicMock(
+        input_features={"observation.state": MagicMock(shape=(6,))},
+        output_features={"action": MagicMock(shape=(6,))},
+        device="cpu",
+    )
+    inner.eval.return_value = None
+    return inner
+
+
+def _load_generic(**kwargs):
+    """Instantiate a generic lerobot_local policy with the weight load stubbed."""
+    mock_cls = MagicMock()
+    mock_cls.from_pretrained.side_effect = lambda _path: _generic_inner()
+    with (
+        patch(
+            "strands_robots.policies.lerobot_local.policy.resolve_policy_class_by_name",
+            return_value=mock_cls,
+        ),
+        patch(
+            "strands_robots.policies.lerobot_local.policy.ProcessorBridge.from_pretrained",
+            return_value=MagicMock(is_active=False),
+        ),
+    ):
+        return LerobotLocalPolicy(
+            pretrained_name_or_path="test/model",
+            policy_type="act",
+            device="cpu",
+            **kwargs,
+        )
+
+
+class TestLoadTelemetry:
+    def setup_method(self):
+        clear_model_cache()
+
+    def teardown_method(self):
+        clear_model_cache()
+
+    def test_cold_load_reports_miss(self):
+        p = _load_generic()
+        # First load actually read weights -> not a cache hit, time recorded.
+        assert p.load_cache_hit is False
+        assert isinstance(p.load_time_s, float)
+        assert p.load_time_s >= 0.0
+
+    def test_second_instance_reports_cache_hit(self):
+        _load_generic()
+        p2 = _load_generic()
+        # Second instance of the same checkpoint skipped from_pretrained.
+        assert p2.load_cache_hit is True
+
+    def test_cache_model_false_never_reports_hit(self):
+        _load_generic()
+        p2 = _load_generic(cache_model=False)
+        # Opt-out instance always loads privately, so it is never a hit.
+        assert p2.load_cache_hit is False
+
+    def test_telemetry_defaults_before_load(self):
+        # A parameterless policy never loads on construction; telemetry stays
+        # at its honest defaults rather than raising AttributeError.
+        p = LerobotLocalPolicy()
+        assert p.load_cache_hit is False
+        assert p.load_time_s == 0.0
+
+
+class TestListCachedModels:
+    def setup_method(self):
+        clear_model_cache()
+
+    def teardown_method(self):
+        clear_model_cache()
+
+    def test_empty_cache_lists_nothing(self):
+        assert list_cached_models() == []
+
+    def test_reports_resident_entry_fields(self):
+        _load_generic()
+        cached = list_cached_models()
+        assert len(cached) == 1
+        entry = cached[0]
+        assert entry["namespace"] == "generic"
+        assert entry["pretrained_name_or_path"] == "test/model"
+        assert entry["device"] == "cpu"
+        assert "policy_class" in entry
+
+    def test_clear_empties_the_listing(self):
+        _load_generic()
+        assert list_cached_models()
+        clear_model_cache()
+        assert list_cached_models() == []

--- a/tests/simulation/test_run_policy_load_telemetry.py
+++ b/tests/simulation/test_run_policy_load_telemetry.py
@@ -1,0 +1,84 @@
+"""run_policy / eval_policy surface the driving policy's load telemetry.
+
+A multi-episode harness that pays a model reload per episode looks identical in
+the result text to one that reuses a warm policy -- the only machine-checkable
+difference is whether the load was a cache hit. These tests pin that
+``run_policy`` and ``eval_policy`` carry ``policy_load_time_s`` and
+``policy_load_cache_hit`` in their JSON block, that the values default honestly
+for policies without load telemetry (MockPolicy), and that a policy_object
+carrying telemetry has it echoed through verbatim.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+from strands_robots.policies.mock import MockPolicy
+from strands_robots.simulation.mujoco.simulation import Simulation
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="load_telemetry", mesh=False)
+    s.create_world()
+    s.add_robot(name="so100", data_config="so100")
+    yield s
+    s.cleanup()
+
+
+def _json_block(result: dict) -> dict:
+    for blk in result.get("content", []):
+        if isinstance(blk, dict) and isinstance(blk.get("json"), dict):
+            return blk["json"]
+    raise AssertionError(f"no json content block in {result}")
+
+
+def test_run_policy_payload_has_telemetry_keys(sim):
+    run = sim.run_policy(
+        robot_name="so100",
+        policy_provider="mock",
+        n_steps=4,
+        control_frequency=50,
+        fast_mode=True,
+    )
+    assert run["status"] == "success", run
+    payload = _json_block(run)
+    # Keys always present so an agent never has to regex the text block.
+    assert "policy_load_time_s" in payload
+    assert "policy_load_cache_hit" in payload
+    # MockPolicy exposes no load telemetry -> honest defaults.
+    assert payload["policy_load_time_s"] == 0.0
+    assert payload["policy_load_cache_hit"] is False
+
+
+def test_run_policy_echoes_policy_object_telemetry(sim):
+    policy = MockPolicy()
+    # Simulate a warm, cache-hit load on the supplied policy object.
+    policy.load_time_s = 0.0
+    policy.load_cache_hit = True
+    run = sim.run_policy(
+        robot_name="so100",
+        policy_object=policy,
+        n_steps=4,
+        control_frequency=50,
+        fast_mode=True,
+    )
+    assert run["status"] == "success", run
+    payload = _json_block(run)
+    assert payload["policy_load_cache_hit"] is True
+
+
+def test_eval_policy_payload_has_telemetry_keys(sim):
+    ev = sim.eval_policy(
+        robot_name="so100",
+        policy_provider="mock",
+        n_episodes=2,
+        max_steps=4,
+        control_frequency=50,
+    )
+    assert ev["status"] == "success", ev
+    payload = _json_block(ev)
+    assert "policy_load_time_s" in payload
+    assert "policy_load_cache_hit" in payload


### PR DESCRIPTION
## Problem

The `lerobot_local` provider keeps a process-level model cache (`_MODEL_CACHE`) that skips the expensive `from_pretrained` weight read when the same checkpoint is re-instantiated. For a large VLA (MolmoAct2 SO-100/101 ships 1295 weight files) that load is on the order of a minute or more, so the cache is a big win for eval/rollout drivers that build a fresh policy per call.

The problem: the saving was **invisible**. A warm cache reuse and a cold reload produce identical result text, so a caller paying a per-episode reload (built a fresh policy each iteration instead of reusing one warm `policy_object=`) had no machine-checkable signal that anything was wrong. `status="success"` is no proof the model wasn't reloaded.

## Change

Make the cache observable end to end:

- `LerobotLocalPolicy` records two attributes after each load, on **both** the generic and MolmoAct2 load paths:
  - `load_cache_hit` (`bool`) — `True` when the heavy `from_pretrained` read was skipped because the cache already held this checkpoint.
  - `load_time_s` (`float`) — wall time the load took (near `0.0` on a hit).
- `Simulation.run_policy` and `Simulation.eval_policy` surface these in their `{"json": {...}}` result block as `policy_load_cache_hit` and `policy_load_time_s`. A `policy_load_cache_hit=False` on episode 2+ of a loop is a smell a caller can read and self-correct on. Policies that expose no load telemetry (e.g. `MockPolicy`) report the honest defaults `0.0` / `False` via `getattr`.
- New `list_cached_models()` read-only introspection helper (exported from `strands_robots.policies.lerobot_local`) reports the resident cache entries (`namespace`, `pretrained_name_or_path`, `device`, `policy_class`) without exposing the private `_MODEL_CACHE` dict, complementing the existing `clear_model_cache()`.

This is **observability only** — the cache behaviour is unchanged, so no simulation/policy/rendering/recording behaviour changes (no rollout artifact applicable). The cached model is still one live module shared across instances with the same load key; concurrent (not sequential) reuse should still opt out with `cache_model=False`.

## Tests

- `tests/policies/lerobot_local/test_load_telemetry.py` — unit coverage with the weight load stubbed: cold load reports a miss, a second instance of the same checkpoint reports a hit, `cache_model=False` never reports a hit, defaults hold before any load, and `list_cached_models()` reports/clears resident entries.
- `tests/simulation/test_run_policy_load_telemetry.py` — `run_policy`/`eval_policy` payloads carry the telemetry keys, default honestly for `MockPolicy`, and echo a `policy_object`'s telemetry through verbatim.

Both fail on pre-change code (missing keys / missing `list_cached_models` export) and pass after. Full local gate green: `ruff check`, `ruff format --check`, `mypy strands_robots tests tests_integ` (no issues, 529 files); the affected suites pass (`tests/policies/lerobot_local/` + the sim policy-runner suites, 428 passed). Two unrelated `test_recording_paths.py` failures are a local `libtorchcodec`/CUDA environment issue, identical on the base branch.

Docs: new "Load telemetry" subsection in `docs/policies/lerobot-local.md` and a CHANGELOG entry under Unreleased.