### PR TITLE
feat(simulation): Newton backend scene-discovery and per-joint state parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Feature: Newton backend scene-discovery and per-joint state parity
+
+The Newton GPU backend gained the discovery and state-introspection methods the
+MuJoCo backend already exposes, so agents can introspect a Newton world without
+guessing method names and `Robot(..., backend="newton")` reaches parity for
+scene queries:
+
+- `get_robot_state(robot_name=None)` returns per-joint `position` (from
+  `joint_q`) and `velocity` (from `joint_qd`). A dedicated DOF index is now
+  tracked alongside the coordinate index so velocities stay correct even when a
+  free-floating object adds a quaternion coordinate (coord count != DOF count).
+- `list_robots_info()`, `list_objects()`, `list_bodies(robot_name=None)` (with
+  best-guess `gripper_body` resolution), and `get_features(robot_name=None)`
+  return the same agent-tool dict shapes as the MuJoCo backend.
+- `move_object(name, position=None, orientation=None)` repositions an object and
+  rebuilds the model, preserving live joint targets.
+- `list_urdfs()` / `register_urdf(data_config, urdf_path)` read/write the shared
+  model registry (with path validation on register).
+- `describe()` now advertises these methods plus the body labels and the single
+  `default` camera so one call surfaces the full contract.
+
+
 ### Feature: async-RTC latency masking is the default for chunk-emitting policies
 
 `run_policy` / `PolicyRunner.run` previously defaulted to `async_rtc=False`, so

--- a/docs/simulation/newton.md
+++ b/docs/simulation/newton.md
@@ -94,6 +94,43 @@ no-op until then.
   the model, which re-initialises the world to its rest pose. `set_timestep`
   takes effect on the next `step()` without a rebuild.
 
+## Scene discovery and state queries
+
+The backend exposes the same discovery and per-joint state surface as the
+MuJoCo backend, so agents can introspect a Newton world without guessing
+method names:
+
+- `get_robot_state(robot_name=None)` returns each joint's `position` and
+  `velocity` (read from `joint_q` / `joint_qd` respectively) in a `json`
+  block, plus a human-readable summary.
+- `list_robots_info()` and `list_objects()` return pretty-printed listings of
+  the robots and primitive objects in the world.
+- `list_bodies(robot_name=None)` lists Newton body labels and, when scoped to
+  a robot, resolves a best-guess `gripper_body` mount (a body whose trailing
+  path segment contains `gripper`, `hand`, `jaw`, `ee`, or `tool`).
+- `move_object(name, position=None, orientation=None)` repositions an existing
+  object and rebuilds the model, preserving live joint targets.
+- `get_features(robot_name=None)` reports the model's joint / body / DOF counts,
+  timestep, solver, and per-robot joint listings (matching the MuJoCo
+  `features` schema).
+- `list_urdfs()` / `register_urdf(data_config, urdf_path)` read from and write
+  to the shared model registry, so assets registered for one backend resolve
+  for the other.
+
+`describe()` also advertises these methods (and the available cameras / bodies)
+so a single call surfaces the full contract.
+
+```python
+sim.add_robot("so100")
+sim.send_action({"Rotation": 0.6, "Elbow": -0.4}, robot_name="so100", n_substeps=10)
+
+state = sim.get_robot_state("so100")["content"][1]["json"]["state"]
+# {"Rotation": {"position": 0.03, "velocity": 3.72}, ...}
+
+mount = sim.list_bodies("so100")["content"][1]["json"]["gripper_body"]
+# "so_arm100/.../Fixed_Jaw"
+```
+
 ## Limitations
 
 - Only a single default camera view is provided by `render()`; named per-robot

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -28,12 +28,20 @@ from __future__ import annotations
 import logging
 import math
 import threading
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
 from strands_robots.assets import resolve_model_path, resolve_robot_name
 from strands_robots.simulation.base import SimEngine
+from strands_robots.simulation.model_registry import (
+    list_available_models,
+    resolve_model,
+)
+from strands_robots.simulation.model_registry import (
+    register_urdf as _register_urdf,
+)
 from strands_robots.simulation.models import SimObject, SimRobot, SimWorld
 from strands_robots.simulation.newton.backend import ensure_newton, resolve_solver_class, solver_registry
 
@@ -135,6 +143,12 @@ class NewtonSimEngine(SimEngine):
         self._joint_coord_index: dict[tuple[str, str], int] = {}
         # Short joint names per robot (rebuilt with the model).
         self._robot_joint_map: dict[str, list[str]] = {}
+        # Coordinate-to-DOF index of each (robot, joint) in joint_qd (velocity).
+        # Distinct from _joint_coord_index because free joints have more
+        # coordinates (quaternion) than DOFs; arm joints are 1:1.
+        self._joint_dof_index: dict[tuple[str, str], int] = {}
+        # Ordered full body labels per robot (rebuilt with the model).
+        self._robot_body_map: dict[str, list[str]] = {}
 
         logger.info("Newton simulation engine initialised (solver=%s)", self._solver_name)
 
@@ -364,6 +378,57 @@ class NewtonSimEngine(SimEngine):
             del self._world.objects[name]
             self._rebuild()
         return {"status": "success", "content": [{"text": f"Removed object '{name}'."}]}
+
+    def move_object(
+        self, name: str, position: list[float] | None = None, orientation: list[float] | None = None
+    ) -> dict[str, Any]:
+        """Move an existing object to a new pose and rebuild the world.
+
+        Mirrors the MuJoCo backend contract. Newton finalises an immutable
+        model from a builder, so the object's stored pose is updated on its
+        :class:`SimObject` and the model is rebuilt; live joint targets are
+        preserved across the rebuild (see :meth:`_rebuild`).
+
+        Args:
+            name: Name of an object previously added via :meth:`add_object`.
+            position: New world position ``[x, y, z]``. ``None`` keeps the
+                current position.
+            orientation: New wxyz quaternion. ``None`` keeps the current
+                orientation.
+
+        Returns:
+            Status dict echoing the new position, or an error dict when no
+            world exists or the object is unknown.
+        """
+        if self._world is None or self._model is None:
+            return {"status": "error", "content": [{"text": "No world. Call create_world first."}]}
+        if name not in self._world.objects:
+            return {"status": "error", "content": [{"text": f"Object '{name}' not found."}]}
+        with self._lock:
+            obj = self._world.objects[name]
+            if position is not None:
+                obj.position = position
+            if orientation is not None:
+                obj.orientation = orientation
+            self._rebuild()
+        return {"status": "success", "content": [{"text": f"'{name}' moved to {position or 'same'}"}]}
+
+    def list_objects(self) -> dict[str, Any]:
+        """List objects in the world with their shape, pose, and mass.
+
+        Returns:
+            Agent-tool dict whose ``text`` block mirrors the MuJoCo backend's
+            human-readable object listing.
+        """
+        if self._world is None or self._model is None:
+            return {"status": "error", "content": [{"text": "No world. Call create_world first."}]}
+        if not self._world.objects:
+            return {"status": "success", "content": [{"text": "No objects."}]}
+        lines = ["Objects:\n"]
+        for name, obj in self._world.objects.items():
+            mass = "static" if obj.is_static or obj.mass <= 0 else f"{obj.mass}kg"
+            lines.append(f"  - {name}: {obj.shape} at {obj.position}, {mass}")
+        return {"status": "success", "content": [{"text": "\n".join(lines)}]}
 
     # Observation / action
 
@@ -619,6 +684,230 @@ class NewtonSimEngine(SimEngine):
         frame = rgba[0, 0] if rgba.ndim == 5 else rgba[0]
         return np.ascontiguousarray(frame[..., :3])
 
+    # Robot / scene discovery
+
+    def get_robot_state(self, robot_name: str | None = None) -> dict[str, Any]:
+        """Return per-joint position and velocity for a robot.
+
+        Mirrors the MuJoCo backend: the ``json`` block carries a ``state``
+        mapping of short joint name to ``{"position", "velocity"}`` (radians
+        and radians/second for revolute joints). Positions are read from
+        ``joint_q`` via the per-joint coordinate index and velocities from
+        ``joint_qd`` via the per-joint DOF index (the two indices differ once
+        a free-floating object adds a quaternion coordinate).
+
+        Args:
+            robot_name: Robot to query. ``None`` resolves to the sole robot
+                when exactly one exists.
+
+        Returns:
+            Agent-tool dict with a human-readable ``text`` block and a
+            ``json`` block ``{"state": {joint: {"position", "velocity"}}}``.
+        """
+        if self._world is None or self._model is None:
+            return {"status": "error", "content": [{"text": "No world. Call create_world first."}]}
+        try:
+            robot_name = self._resolve_single_robot(robot_name)
+        except ValueError as exc:
+            return {"status": "error", "content": [{"text": str(exc)}]}
+        if robot_name not in self._world.robots:
+            return {"status": "error", "content": [{"text": f"Robot '{robot_name}' not found."}]}
+
+        with self._lock:
+            joint_q = self._state_0.joint_q.numpy()
+            joint_qd = self._state_0.joint_qd.numpy()
+            state: dict[str, dict[str, float]] = {}
+            for jname in self._world.robots[robot_name].joint_names:
+                q_idx = self._joint_coord_index.get((robot_name, jname))
+                d_idx = self._joint_dof_index.get((robot_name, jname))
+                pos = float(joint_q[q_idx]) if q_idx is not None and q_idx < len(joint_q) else 0.0
+                vel = float(joint_qd[d_idx]) if d_idx is not None and d_idx < len(joint_qd) else 0.0
+                state[jname] = {"position": pos, "velocity": vel}
+
+        text = f"'{robot_name}' state (t={self._world.sim_time:.3f}s):\n"
+        for jnt, vals in state.items():
+            text += f"{jnt}: pos={vals['position']:.4f}, vel={vals['velocity']:.4f}\n"
+        return {"status": "success", "content": [{"text": text}, {"json": {"state": state}}]}
+
+    def list_robots_info(self) -> dict[str, Any]:
+        """Pretty-printed robot listing (dict-shaped, for agent display).
+
+        Distinct from :meth:`list_robots` (which returns ``list[str]`` for the
+        SimEngine ABC). Mirrors the MuJoCo backend's per-robot summary.
+
+        Returns:
+            Agent-tool dict whose ``text`` block lists each robot's asset,
+            world position, joint count, and config.
+        """
+        if self._world is None or self._model is None:
+            return {"status": "error", "content": [{"text": "No world. Call create_world first."}]}
+        if not self._world.robots:
+            return {"status": "success", "content": [{"text": "No robots. Use add_robot."}]}
+        lines = ["Robots in simulation:\n"]
+        for name, robot in self._world.robots.items():
+            lines.append(
+                f"  - {name} ({Path(robot.urdf_path).name})\n"
+                f"    Position: {robot.position}, Joints: {len(robot.joint_names)}, "
+                f"Config: {robot.data_config or 'direct'}"
+            )
+        return {"status": "success", "content": [{"text": "\n".join(lines)}]}
+
+    def list_bodies(self, robot_name: str | None = None) -> dict[str, Any]:
+        """List Newton body labels, optionally scoped to one robot.
+
+        This is the discovery surface for resolving a robot's end-effector /
+        mount body without guessing. Newton labels bodies by their full MJCF
+        path (``so_arm100/.../Moving_Jaw``); the ``json`` block returns the
+        full labels and, when ``robot_name`` is given, a best-guess
+        ``gripper_body`` whose trailing path segment contains ``gripper``,
+        ``hand``, ``jaw``, ``ee``, or ``tool``.
+
+        Args:
+            robot_name: When set, return only that robot's bodies. When
+                omitted, return every body label in the world.
+
+        Returns:
+            Agent-tool dict with a ``text`` block and a ``json`` block
+            ``{"bodies": [...]}`` (plus ``"gripper_body"`` when scoped).
+        """
+        if self._world is None or self._model is None:
+            return {"status": "error", "content": [{"text": "No world. Call create_world first."}]}
+
+        if robot_name is not None:
+            if robot_name not in self._world.robots:
+                return {
+                    "status": "error",
+                    "content": [
+                        {
+                            "text": (
+                                f"list_bodies: robot '{robot_name}' not found. "
+                                f"Known robots: {list(self._world.robots.keys())}"
+                            )
+                        }
+                    ],
+                }
+            bodies = list(self._robot_body_map.get(robot_name, []))
+        else:
+            bodies = list(self._model.body_label)
+
+        json_payload: dict[str, Any] = {"bodies": bodies}
+        if robot_name is not None:
+            gripper_body: str | None = None
+            for name in bodies:
+                short = _short_joint_name(name).lower()
+                if any(tok in short for tok in ("gripper", "hand", "jaw", "ee", "tool")):
+                    gripper_body = name
+                    break
+            json_payload["gripper_body"] = gripper_body
+
+        text = "Bodies:\n" + "\n".join(f"  - {b}" for b in bodies) if bodies else "No bodies."
+        return {"status": "success", "content": [{"text": text}, {"json": json_payload}]}
+
+    def get_features(self, robot_name: str | None = None) -> dict[str, Any]:
+        """Describe the model's joints / bodies / robots for the agent.
+
+        Mirrors the MuJoCo backend's ``features`` json schema with values
+        sourced from the finalized Newton model. Newton drives joints through
+        position targets rather than named MuJoCo actuators, so
+        ``actuator_names`` echoes the robot's joint names and ``camera_names``
+        is the single headless ``"default"`` view.
+
+        Args:
+            robot_name: When set, scope joint / robot listings to that robot.
+
+        Returns:
+            Agent-tool dict with a ``text`` summary and a ``json`` block
+            ``{"features": {...}}``.
+        """
+        if self._world is None or self._model is None:
+            return {"status": "error", "content": [{"text": "No world. Call create_world first."}]}
+
+        m = self._model
+        if robot_name is not None:
+            if robot_name not in self._world.robots:
+                return {"status": "error", "content": [{"text": f"Robot '{robot_name}' not found."}]}
+            joint_names = list(self._world.robots[robot_name].joint_names)
+            scoped = {robot_name: self._world.robots[robot_name]}
+        else:
+            joint_names = list(self._joint_order)
+            scoped = dict(self._world.robots)
+
+        robots_info = {
+            rname: {
+                "joint_names": list(robot.joint_names),
+                "n_joints": len(robot.joint_names),
+                "data_config": robot.data_config,
+                "source": Path(robot.urdf_path).name,
+            }
+            for rname, robot in scoped.items()
+        }
+        actuator_names = list(joint_names)
+        camera_names = ["default"]
+        features = {
+            "n_bodies": int(m.body_count),
+            "n_joints": int(m.joint_count),
+            "n_dofs": int(m.joint_dof_count),
+            "timestep": float(self._world.timestep),
+            "solver": self._solver_name,
+            "joint_names": joint_names,
+            "actuator_names": actuator_names,
+            "camera_names": camera_names,
+            "robots": robots_info,
+        }
+        lines = [
+            "Simulation Features (Newton)",
+            f"Joints ({m.joint_count}): {', '.join(joint_names[:12])}{'...' if len(joint_names) > 12 else ''}",
+            f"DOFs: {m.joint_dof_count} | Bodies: {m.body_count}",
+            f"Solver: {self._solver_name} | Cameras: default",
+            f"Timestep: {self._world.timestep}s ({1 / self._world.timestep:.0f}Hz)",
+        ]
+        for rname, rinfo in robots_info.items():
+            lines.append(f"{rname}: {rinfo['n_joints']} joints ({rinfo['source']})")
+        return {"status": "success", "content": [{"text": "\n".join(lines)}, {"json": {"features": features}}]}
+
+    def list_urdfs(self) -> dict[str, Any]:
+        """List registry-resolvable robot assets (shared registry).
+
+        Returns:
+            Agent-tool dict whose ``text`` block is the formatted registry
+            listing from :func:`list_available_models`.
+        """
+        return {"status": "success", "content": [{"text": list_available_models()}]}
+
+    def register_urdf(self, data_config: str, urdf_path: str) -> dict[str, Any]:
+        """Register an MJCF/URDF asset under ``data_config`` in the registry.
+
+        Validates ``urdf_path`` before handing it to the shared registry so a
+        missing or unreadable file surfaces a clear error here rather than
+        deep inside the Newton MJCF importer.
+
+        Args:
+            data_config: Registry name to bind the asset to.
+            urdf_path: Filesystem path to the MJCF/URDF asset.
+
+        Returns:
+            Status dict reporting the resolved path, or an error dict when the
+            file is missing / unreadable.
+        """
+        if not urdf_path:
+            return {"status": "error", "content": [{"text": "register_urdf: 'urdf_path' must be a non-empty string."}]}
+        path = Path(urdf_path)
+        if not path.exists():
+            return {"status": "error", "content": [{"text": f"register_urdf: file not found: {urdf_path}"}]}
+        if not path.is_file():
+            return {"status": "error", "content": [{"text": f"register_urdf: not a file: {urdf_path}"}]}
+        try:
+            with path.open("rb"):
+                pass
+        except OSError as exc:
+            return {"status": "error", "content": [{"text": f"register_urdf: cannot read {urdf_path}: {exc}"}]}
+        _register_urdf(data_config, urdf_path)
+        resolved = resolve_model(data_config)
+        return {
+            "status": "success",
+            "content": [{"text": f"Registered '{data_config}' -> {urdf_path}\nResolved: {resolved or 'NOT FOUND'}"}],
+        }
+
     # Introspection
 
     def describe(self) -> dict[str, Any]:
@@ -629,6 +918,7 @@ class NewtonSimEngine(SimEngine):
             device, and current robot / object counts.
         """
         device = str(self._wp.get_device(self.device)) if self.device else str(self._wp.get_device())
+        bodies = list(self._model.body_label) if self._model is not None else []
         return {
             "backend": "newton",
             "solver": self._solver_name,
@@ -636,8 +926,34 @@ class NewtonSimEngine(SimEngine):
             "device": device,
             "robots": self.list_robots(),
             "objects": list(self._world.objects) if self._world else [],
+            "bodies": bodies,
+            "cameras": ["default"],
             "timestep": self._world.timestep if self._world else self.default_timestep,
             "gravity": list(self._world.gravity) if self._world else [0.0, 0.0, -9.81],
+            "world_created": self._world is not None and self._model is not None,
+            "methods": {
+                "get_robot_state": "(robot_name: str | None = None) -> dict (per-joint position + velocity)",
+                "get_observation": "(robot_name: str | None = None, *, skip_images: bool = False) -> dict",
+                "send_action": "(action: dict, robot_name: str | None = None, n_substeps: int = 1) -> dict",
+                "run_policy": "(robot_name: str, policy_provider='mock', n_episodes=1, ...) -> dict",
+                "list_robots_info": "() -> dict (pretty robot listing)",
+                "list_bodies": "(robot_name: str | None = None) -> dict (body labels + gripper_body)",
+                "list_objects": "() -> dict",
+                "move_object": "(name: str, position=None, orientation=None) -> dict",
+                "get_features": "(robot_name: str | None = None) -> dict (joints/bodies/robots schema)",
+                "list_urdfs": "() -> dict",
+                "register_urdf": "(data_config: str, urdf_path: str) -> dict",
+                "set_gravity": "(gravity: list[float] | float) -> dict",
+                "set_timestep": "(dt: float) -> dict",
+                "render": "(camera_name='default', width=None, height=None) -> dict",
+                "reset": "() -> dict (restore baseline joint configuration)",
+                "step": "(n_steps: int = 1) -> dict",
+            },
+            "note": (
+                "robot_name defaults to the sole robot when only one exists for "
+                "get_observation, send_action, get_robot_state, get_features, run_policy. "
+                "With multiple robots, pass robot_name explicitly (from 'robots')."
+            ),
         }
 
     def cleanup(self, policy_stop_timeout: float | None = None) -> None:
@@ -793,11 +1109,15 @@ class NewtonSimEngine(SimEngine):
 
         # Track coordinate index of each robot's joints in the global joint_q.
         self._joint_coord_index = {}
+        self._joint_dof_index = {}
         self._robot_joint_map = {}
+        self._robot_body_map = {}
 
         for robot_name, robot in self._world.robots.items():
             coord_before = builder.joint_coord_count
+            dof_before = builder.joint_dof_count
             label_before = len(builder.joint_label)
+            body_before = builder.body_count
             xform = wp.transform(
                 wp.vec3(*robot.position),
                 self._wxyz_to_wp_quat(robot.orientation),
@@ -809,7 +1129,9 @@ class NewtonSimEngine(SimEngine):
                 short = _short_joint_name(label)
                 short_names.append(short)
                 self._joint_coord_index[(robot_name, short)] = coord_before + offset
+                self._joint_dof_index[(robot_name, short)] = dof_before + offset
             self._robot_joint_map[robot_name] = short_names
+            self._robot_body_map[robot_name] = list(builder.body_label[body_before:])
 
         for obj in self._world.objects.values():
             self._add_object_to_builder(builder, obj)

--- a/tests/simulation/newton/test_discovery_and_state.py
+++ b/tests/simulation/newton/test_discovery_and_state.py
@@ -1,0 +1,148 @@
+"""Discovery and state-introspection parity for the Newton backend.
+
+Exercises the methods that bring NewtonSimEngine to MuJoCo parity for scene
+discovery and per-joint state queries: get_robot_state, list_robots_info,
+list_bodies, list_objects, move_object, get_features, list_urdfs,
+register_urdf, plus the discovery surface in describe(). Gated on Newton +
+Warp being importable (real GPU model build).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+_HAS_NEWTON = importlib.util.find_spec("newton") is not None and importlib.util.find_spec("warp") is not None
+
+pytestmark = pytest.mark.skipif(not _HAS_NEWTON, reason="newton/warp not installed")
+
+
+@pytest.fixture
+def engine():
+    from strands_robots.simulation.newton.simulation import NewtonSimEngine
+
+    sim = NewtonSimEngine(solver="mujoco")
+    sim.create_world()
+    yield sim
+    sim.destroy()
+
+
+@pytest.fixture
+def engine_so100(engine):
+    engine.add_robot("so100")
+    return engine
+
+
+class TestGetRobotState:
+    def test_returns_position_and_velocity_per_joint(self, engine_so100):
+        result = engine_so100.get_robot_state()
+        assert result["status"] == "success"
+        state = result["content"][1]["json"]["state"]
+        # All six arm joints present with the position/velocity contract.
+        assert set(state) == set(engine_so100.robot_joint_names("so100"))
+        for vals in state.values():
+            assert set(vals) == {"position", "velocity"}
+            assert isinstance(vals["position"], float)
+            assert isinstance(vals["velocity"], float)
+
+    def test_velocity_is_nonzero_after_actuation(self, engine_so100):
+        # Drive a joint hard, then confirm a non-zero velocity is reported -
+        # i.e. velocities are read from joint_qd, not left at zero.
+        engine_so100.send_action({"Rotation": 0.8}, robot_name="so100", n_substeps=5)
+        state = engine_so100.get_robot_state()["content"][1]["json"]["state"]
+        assert abs(state["Rotation"]["velocity"]) > 1e-3
+
+    def test_no_world_errors(self):
+        from strands_robots.simulation.newton.simulation import NewtonSimEngine
+
+        sim = NewtonSimEngine(solver="mujoco")
+        assert sim.get_robot_state()["status"] == "error"
+
+    def test_unknown_robot_errors(self, engine_so100):
+        assert engine_so100.get_robot_state("ghost")["status"] == "error"
+
+
+class TestListBodies:
+    def test_scoped_lists_only_robot_bodies_with_gripper(self, engine_so100):
+        result = engine_so100.list_bodies("so100")
+        assert result["status"] == "success"
+        payload = result["content"][1]["json"]
+        assert payload["bodies"]
+        assert all(b.startswith("so_arm100") for b in payload["bodies"])
+        # Gripper auto-detection resolves a jaw/gripper mount body.
+        assert payload["gripper_body"] is not None
+        assert "jaw" in payload["gripper_body"].lower()
+
+    def test_global_includes_object_bodies(self, engine_so100):
+        engine_so100.add_object("cube", shape="box", position=[0.3, 0.0, 0.05], mass=0.2)
+        scoped = engine_so100.list_bodies("so100")["content"][1]["json"]["bodies"]
+        every = engine_so100.list_bodies()["content"][1]["json"]["bodies"]
+        # The free-floating cube body is in the global list but not the robot scope.
+        assert len(every) > len(scoped)
+
+    def test_unknown_robot_errors(self, engine_so100):
+        assert engine_so100.list_bodies("ghost")["status"] == "error"
+
+
+class TestObjectsListingAndMove:
+    def test_list_objects_reports_shape_and_pose(self, engine_so100):
+        engine_so100.add_object("cube", shape="box", position=[0.3, 0.0, 0.05], mass=0.2)
+        text = engine_so100.list_objects()["content"][0]["text"]
+        assert "cube" in text and "box" in text
+
+    def test_list_objects_empty(self, engine_so100):
+        assert "No objects" in engine_so100.list_objects()["content"][0]["text"]
+
+    def test_move_object_updates_pose_and_rebuilds(self, engine_so100):
+        engine_so100.add_object("cube", shape="box", position=[0.3, 0.0, 0.05], mass=0.2)
+        result = engine_so100.move_object("cube", position=[0.1, 0.1, 0.05])
+        assert result["status"] == "success"
+        assert engine_so100._world.objects["cube"].position == [0.1, 0.1, 0.05]
+        # Model still steppable after the rebuild triggered by the move.
+        assert engine_so100.step(1)["status"] == "success"
+
+    def test_move_unknown_object_errors(self, engine_so100):
+        assert engine_so100.move_object("ghost", position=[0, 0, 0])["status"] == "error"
+
+
+class TestRobotsInfoAndFeatures:
+    def test_list_robots_info_names_asset(self, engine_so100):
+        text = engine_so100.list_robots_info()["content"][0]["text"]
+        assert "so100" in text and "so_arm100.xml" in text
+
+    def test_list_robots_info_empty(self, engine):
+        assert "No robots" in engine.list_robots_info()["content"][0]["text"]
+
+    def test_get_features_schema(self, engine_so100):
+        features = engine_so100.get_features("so100")["content"][1]["json"]["features"]
+        for key in ("n_bodies", "n_joints", "n_dofs", "timestep", "joint_names", "robots"):
+            assert key in features
+        assert features["robots"]["so100"]["n_joints"] == 6
+        assert "so100" in features["robots"]
+
+    def test_get_features_unknown_robot_errors(self, engine_so100):
+        assert engine_so100.get_features("ghost")["status"] == "error"
+
+
+class TestRegistryPassthrough:
+    def test_list_urdfs_returns_registry_table(self, engine):
+        text = engine.list_urdfs()["content"][0]["text"]
+        assert "Category" in text
+
+    def test_register_urdf_missing_file_errors(self, engine):
+        assert engine.register_urdf("xx", "/no/such/path.xml")["status"] == "error"
+
+    def test_register_urdf_empty_path_errors(self, engine):
+        assert engine.register_urdf("xx", "")["status"] == "error"
+
+
+class TestDescribeSurface:
+    def test_describe_exposes_new_methods(self, engine_so100):
+        described = engine_so100.describe()
+        methods = described["methods"]
+        for name in ("get_robot_state", "list_bodies", "move_object", "get_features", "list_urdfs"):
+            assert name in methods
+        assert described["cameras"] == ["default"]
+        assert described["bodies"]
+        assert described["world_created"] is True


### PR DESCRIPTION
## What

`NewtonSimEngine` implemented the core physics primitives (`create_world`, `add_robot`, `send_action`, `step`, `render`, ...) but lacked the scene-discovery and per-joint state surface the MuJoCo backend already exposes. Agents driving a Newton world had no way to read joint velocities, enumerate bodies/objects, resolve an end-effector mount, or list registry assets without guessing method names that did not exist (`AttributeError`).

This PR brings the Newton backend to parity with MuJoCo for scene discovery and state introspection, so `Robot(..., backend="newton")` is a first-class citizen for these queries. All methods return the same agent-tool dict shapes as the MuJoCo backend.

## Methods added

| Method | Contract |
|---|---|
| `get_robot_state(robot_name=None)` | per-joint `{position, velocity}` json block |
| `list_robots_info()` | pretty robot listing (asset, pose, joints) |
| `list_objects()` | object listing (shape, pose, mass) |
| `list_bodies(robot_name=None)` | body labels + best-guess `gripper_body` |
| `move_object(name, position=None, orientation=None)` | reposition + rebuild |
| `get_features(robot_name=None)` | joint/body/DOF/timestep/robots schema |
| `list_urdfs()` / `register_urdf(data_config, urdf_path)` | shared registry passthrough (path-validated) |

`describe()` now advertises these methods plus the body labels and the single `default` camera, so one call surfaces the full contract.

Newton public method count: **19 -> 27**.

## Key correctness detail: position vs velocity indexing

Newton's `joint_coord_count` and `joint_dof_count` diverge once a free-floating object is in the world (a free body contributes 7 coordinates -- 3 position + 4 quaternion -- but only 6 DOFs). Reading velocity at the *coordinate* index would therefore read the wrong slot. The rebuild now tracks a per-joint **DOF index** (`_joint_dof_index`) alongside the existing coordinate index, so `get_robot_state` reads positions from `joint_q` via the coord index and velocities from `joint_qd` via the DOF index. Verified non-zero velocities under actuation in the regression suite.

## Tests

`tests/simulation/newton/test_discovery_and_state.py` -- 19 tests, gated on `newton`/`warp` availability, exercising the real GPU model build (no mocks). Each test fails on the pre-change code (`AttributeError` / missing `describe` keys) and passes after. Full backend suite green:

```
83 passed, 1 skipped in 166.52s   # tests/simulation/newton/
```

Lint/format/mypy clean (`ruff check`, `ruff format --check`, `mypy strands_robots tests tests_integ`).

## Visual proof

so100 + cube stepped in the Newton MuJoCo-Warp solver, rendered headless via the ray-traced tiled camera (640x480), then introspected through the new methods:

![Newton so100 scene](https://github.com/cagataycali/robots/releases/download/newton-discovery-demo/newton_so100_scene.png)

```
'so100' state (t=0.167s):
Rotation: pos=1.0078, vel=-1.6609
Pitch: pos=-1.0826, vel=6.2031
Elbow: pos=1.4697, vel=-9.8366
...
list_bodies('so100').gripper_body -> so_arm100/.../Fixed_Jaw
```

## Docs

`docs/simulation/newton.md` gains a "Scene discovery and state queries" section; `CHANGELOG.md` updated under Unreleased.