### PR TITLE
fix(registry): conform hardware entries to the full LeRobot catalog

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -24,6 +24,7 @@ MUJOCO_GL=egl python examples/01_sim_hello_world.py
 | 07 | [`07_post_tune_any_policy.py`](07_post_tune_any_policy.py) | `create_trainer` + `TrainSpec` (record→train→load) | No | No |
 | -- | [`vla_g1_workflow.py`](vla_g1_workflow.py) | VLA-on-G1: record -> GR00T fine-tune -> WBC deploy | No | Optional (tune) |
 | — | [`vera_mimicgen_panda/`](vera_mimicgen_panda/) | VERA MimicGen → Panda (eef-delta + IK bridge) | No | **Yes** (server) |
+| -- | [`lerobot_hardware_catalog.py`](lerobot_hardware_catalog.py) | `Robot()` covers the whole LeRobot hardware catalog (name -> lerobot_type) | No | No |
 
 ## What each example shows vs raw lerobot
 

--- a/examples/lerobot_hardware_catalog.py
+++ b/examples/lerobot_hardware_catalog.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""End-to-end: every LeRobot robot is reachable through ``strands_robots.Robot``.
+
+``strands_robots`` is a thin natural-language + policy layer over LeRobot's
+hardware drivers. This example walks the strands registry and shows that every
+robot with hardware support resolves a canonical name and a LeRobot
+``robot_type`` - the mapping ``Robot(name, mode="real")`` uses to construct the
+underlying LeRobot driver. It then builds a real Unitree G1 in simulation (no
+hardware, no GPU) to prove the same factory drives the catalog's most complex
+robot.
+
+Everything here goes through the ``strands_robots`` public API - the registry
+read helpers and the ``Robot()`` factory - never ``import lerobot`` directly.
+That is the whole point: users program against ``Robot("g1")``, not the driver.
+
+Run:
+    python examples/lerobot_hardware_catalog.py        # hardware catalog
+    python examples/lerobot_hardware_catalog.py --g1   # focus: Unitree G1 in sim
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+os.environ.setdefault("MUJOCO_GL", "cgl")
+
+
+def show_catalog() -> int:
+    """List every strands robot with hardware support + its LeRobot type."""
+    from strands_robots.registry import format_robot_table, get_hardware_type, list_robots, resolve_name
+
+    hw_robots = list_robots(mode="real")
+    print(f"strands_robots exposes {len(hw_robots)} robot(s) with LeRobot hardware support.")
+    print("Each maps a friendly name -> canonical name -> LeRobot robot_type:\n")
+
+    header = f"{'name':<16} {'canonical':<16} {'lerobot_type':<24} category"
+    print(header)
+    print("-" * len(header))
+    for entry in hw_robots:
+        name = entry["name"]
+        canonical = resolve_name(name)
+        lerobot_type = get_hardware_type(canonical) or "?"
+        print(f"{name:<16} {canonical:<16} {lerobot_type:<24} {entry.get('category', '')}")
+
+    print("\nDrive any of them for real with, e.g.:")
+    print("    from strands_robots import Robot")
+    print("    arm = Robot('so100', mode='real', port='/dev/ttyACM0')")
+    print("    arm('pick up the red cube', policy_port=8080)")
+    print("\nFull registry (sim + real):\n")
+    print(format_robot_table())
+    return 0
+
+
+def show_g1() -> int:
+    """Build a Unitree G1 in simulation through the same ``Robot()`` factory.
+
+    The G1 is the catalog's most complex robot - a 29-DOF humanoid. In
+    ``mode='real'`` a background ONNX locomotion controller owns the legs+waist
+    while the agent commands the arms; here we use the default ``mode='sim'`` so
+    it runs in MuJoCo with no hardware and no GPU.
+    """
+    from strands_robots import Robot
+    from strands_robots.registry import get_hardware_type, get_robot, resolve_name
+
+    print("=== Unitree G1 (29-DOF humanoid) ===\n")
+    canonical = resolve_name("g1")  # alias -> canonical
+    info = get_robot(canonical)
+    print(f"  alias 'g1' resolves to:  {canonical}")
+    print(f"  description:             {info['description']}")
+    print(f"  category:                {info['category']}")
+    print(f"  lerobot hardware type:   {get_hardware_type(canonical)}")
+    print(f"  sim asset (MuJoCo):      {info.get('asset', {}).get('model_xml')}")
+
+    print("\n  Building it in simulation via Robot('g1') ...")
+    sim = Robot("g1", mesh=False)
+    try:
+        print(f"  -> {type(sim).__name__} ready (MuJoCo backend, no hardware).")
+    finally:
+        sim.destroy()
+
+    print("\n  Drive it for real (locomotion + agent-controlled arms):")
+    print("    g1 = Robot('g1', mode='real',")
+    print("               robot_ip='192.168.123.164',")
+    print("               controller='GrootLocomotionController')")
+    print("    # Background thread owns legs+waist; send_action() publishes arm targets.")
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--g1", action="store_true", help="Focus on the Unitree G1 humanoid (builds it in sim).")
+    args = p.parse_args()
+
+    try:
+        return show_g1() if args.g1 else show_catalog()
+    except ImportError as e:
+        print(
+            f"This example needs the simulation extra: pip install 'strands-robots[sim-mujoco]'\n  {e}",
+            file=sys.stderr,
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/strands_robots/registry/robots.json
+++ b/strands_robots/registry/robots.json
@@ -978,31 +978,6 @@
         "hope_junior_hand"
       ]
     },
-    "rebot_b601": {
-      "description": "Seeed Studio reBot B601-DM (6-DOF arm + gripper, Damiao CAN)",
-      "category": "arm",
-      "joints": 7,
-      "hardware": {
-        "lerobot_type": "rebot_b601_follower"
-      },
-      "aliases": [
-        "rebot_b601_follower",
-        "seeed_rebot_b601",
-        "b601"
-      ]
-    },
-    "bi_rebot_b601": {
-      "description": "Bimanual Seeed reBot B601-DM (dual 6-DOF arms, Damiao CAN)",
-      "category": "bimanual",
-      "joints": 14,
-      "hardware": {
-        "lerobot_type": "bi_rebot_b601_follower"
-      },
-      "aliases": [
-        "bi_rebot_b601_follower",
-        "dual_rebot_b601"
-      ]
-    },
     "lekiwi_client": {
       "description": "LeKiwi networked client (drives a remote LeKiwi host over ZMQ)",
       "category": "mobile_manip",

--- a/strands_robots/registry/robots.json
+++ b/strands_robots/registry/robots.json
@@ -77,10 +77,10 @@
       ]
     },
     "hope_jr": {
-      "description": "Hope Junior arm",
+      "description": "HopeJR Arm (high-DOF anthropomorphic arm, Feetech)",
       "category": "arm",
       "hardware": {
-        "lerobot_type": "hope_jr"
+        "lerobot_type": "hope_jr_arm"
       }
     },
     "kinova_gen3": {
@@ -131,7 +131,7 @@
       "description": "OMX Robot Arm (ROBOTIS, CAN bus motors)",
       "category": "arm",
       "hardware": {
-        "lerobot_type": "omx"
+        "lerobot_type": "omx_follower"
       },
       "aliases": [
         "omx_follower",
@@ -153,7 +153,10 @@
         "enactic_openarm",
         "open_arm",
         "openarm_v10"
-      ]
+      ],
+      "hardware": {
+        "lerobot_type": "openarm_follower"
+      }
     },
     "panda": {
       "description": "Franka Emika Panda (7-DOF + gripper)",
@@ -370,7 +373,7 @@
       "description": "Bi-manual OpenArm (dual-arm coordination)",
       "category": "bimanual",
       "hardware": {
-        "lerobot_type": "bi_openarm"
+        "lerobot_type": "bi_openarm_follower"
       },
       "aliases": [
         "bi_openarm_follower",
@@ -821,7 +824,7 @@
       "description": "EarthRover Mini Plus (mobile outdoor navigation)",
       "category": "mobile",
       "hardware": {
-        "lerobot_type": "earthrover"
+        "lerobot_type": "earthrover_mini_plus"
       },
       "aliases": [
         "earth_rover",
@@ -962,6 +965,53 @@
       },
       "aliases": [
         "oxe_google"
+      ]
+    },
+    "hope_jr_hand": {
+      "description": "HopeJR Hand (dexterous anthropomorphic hand, Feetech)",
+      "category": "hand",
+      "hardware": {
+        "lerobot_type": "hope_jr_hand"
+      },
+      "aliases": [
+        "hopejr_hand",
+        "hope_junior_hand"
+      ]
+    },
+    "rebot_b601": {
+      "description": "Seeed Studio reBot B601-DM (6-DOF arm + gripper, Damiao CAN)",
+      "category": "arm",
+      "joints": 7,
+      "hardware": {
+        "lerobot_type": "rebot_b601_follower"
+      },
+      "aliases": [
+        "rebot_b601_follower",
+        "seeed_rebot_b601",
+        "b601"
+      ]
+    },
+    "bi_rebot_b601": {
+      "description": "Bimanual Seeed reBot B601-DM (dual 6-DOF arms, Damiao CAN)",
+      "category": "bimanual",
+      "joints": 14,
+      "hardware": {
+        "lerobot_type": "bi_rebot_b601_follower"
+      },
+      "aliases": [
+        "bi_rebot_b601_follower",
+        "dual_rebot_b601"
+      ]
+    },
+    "lekiwi_client": {
+      "description": "LeKiwi networked client (drives a remote LeKiwi host over ZMQ)",
+      "category": "mobile_manip",
+      "hardware": {
+        "lerobot_type": "lekiwi_client"
+      },
+      "aliases": [
+        "lekiwi_remote",
+        "lekiwi_net"
       ]
     }
   }

--- a/tests/test_lerobot_hardware_conformance.py
+++ b/tests/test_lerobot_hardware_conformance.py
@@ -1,0 +1,113 @@
+"""LeRobot hardware conformance - every ``hardware.lerobot_type`` in the strands
+registry must name a robot type that LeRobot actually registers.
+
+This closes the gap left by ``test_registry_integrity.test_hardware_only_robots
+_declare_lerobot_type``, which only checks that ``lerobot_type`` is a non-empty
+string. That weaker check passed four entries (hope_jr, omx, bi_openarm,
+earthrover) whose ``lerobot_type`` did NOT match any LeRobot
+``@RobotConfig.register_subclass`` name, so ``Robot(name, mode="real")`` raised
+``ValueError: Unsupported robot type`` at runtime instead of at test time.
+
+Source-of-truth: the set of names passed to ``@RobotConfig.register_subclass``
+in the vendored LeRobot tree. We parse the decorators from source rather than
+importing each driver because several drivers only register when an optional
+hardware SDK is installed (e.g. the reBot B601 needs ``motorbridge``); the type
+is still a valid LeRobot choice, it just won't appear in a live
+``RobotConfig.get_known_choices()`` on a CI host without that SDK. Parsing source
+keeps the test dependency-free and deterministic.
+
+If the vendored LeRobot tree is not present (pip-installed lerobot, or a slim
+checkout), the test self-skips rather than failing.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+REGISTRY_PATH = Path(__file__).parent.parent / "strands_robots" / "registry" / "robots.json"
+
+# Candidate locations for the LeRobot robots package (vendored sibling checkout
+# first, then an installed distribution).
+_LEROBOT_ROOTS = [
+    Path(__file__).parent.parent.parent / "lerobot" / "src" / "lerobot" / "robots",
+    Path(__file__).parent.parent / "lerobot" / "src" / "lerobot" / "robots",
+]
+
+_REGISTER_RE = re.compile(r"""@RobotConfig\.register_subclass\(\s*["']([a-zA-Z0-9_]+)["']""")
+
+
+def _find_lerobot_robots_dir() -> Path | None:
+    for root in _LEROBOT_ROOTS:
+        if root.is_dir():
+            return root
+    # Fall back to an installed lerobot.
+    try:
+        import lerobot.robots as _lr  # type: ignore
+
+        return Path(next(iter(_lr.__path__)))
+    except Exception:
+        return None
+
+
+def _lerobot_registered_types(robots_dir: Path) -> set[str]:
+    types: set[str] = set()
+    for cfg in robots_dir.rglob("config*.py"):
+        types |= set(_REGISTER_RE.findall(cfg.read_text(encoding="utf-8", errors="ignore")))
+    for cfg in robots_dir.rglob("configuration*.py"):
+        types |= set(_REGISTER_RE.findall(cfg.read_text(encoding="utf-8", errors="ignore")))
+    return types
+
+
+@pytest.fixture(scope="module")
+def strands_hw_types() -> dict[str, str]:
+    """Map strands robot name -> declared lerobot_type (hardware entries only)."""
+    data = json.loads(REGISTRY_PATH.read_text())
+    robots = data.get("robots", data)
+    return {
+        name: info["hardware"]["lerobot_type"]
+        for name, info in robots.items()
+        if isinstance(info.get("hardware"), dict) and info["hardware"].get("lerobot_type")
+    }
+
+
+@pytest.fixture(scope="module")
+def lerobot_types() -> set[str]:
+    robots_dir = _find_lerobot_robots_dir()
+    if robots_dir is None:
+        pytest.skip("LeRobot robots package not found (sim-only / no [lerobot] extra)")
+    types = _lerobot_registered_types(robots_dir)
+    if not types:
+        pytest.skip(f"No @RobotConfig.register_subclass found under {robots_dir}")
+    return types
+
+
+def test_every_strands_lerobot_type_is_real(strands_hw_types: dict[str, str], lerobot_types: set[str]) -> None:
+    """Each strands ``hardware.lerobot_type`` must be a registered LeRobot choice.
+
+    Regression guard for hope_jr/omx/bi_openarm/earthrover, whose lerobot_type
+    was a made-up shorthand that broke ``Robot(name, mode="real")``.
+    """
+    offenders = {name: lt for name, lt in strands_hw_types.items() if lt not in lerobot_types}
+    assert not offenders, (
+        "Robots whose hardware.lerobot_type is not a real LeRobot register_subclass "
+        f"name (Robot(name, mode='real') would raise): {offenders}. "
+        f"Valid LeRobot types: {sorted(lerobot_types)}"
+    )
+
+
+def test_full_lerobot_hardware_coverage(strands_hw_types: dict[str, str], lerobot_types: set[str]) -> None:
+    """Every LeRobot robot type is reachable through at least one strands entry.
+
+    This is the 'conform to all the toys' invariant: if LeRobot ships a robot,
+    a user can drive it with ``Robot(name, mode='real')`` via some strands name.
+    """
+    reachable = set(strands_hw_types.values())
+    missing = lerobot_types - reachable
+    assert not missing, (
+        "LeRobot robot types not reachable from any strands registry entry "
+        f"(add a hardware entry with this lerobot_type): {sorted(missing)}"
+    )


### PR DESCRIPTION
## Summary

Makes the strands robot registry conform to the **entire LeRobot hardware catalog** and fixes four entries that broke `Robot(name, mode="real")` at runtime.

## The bugs

Four hardware entries declared a `hardware.lerobot_type` that is **not a real LeRobot `@RobotConfig.register_subclass` name**, so `Robot(name, mode="real")` raised `ValueError: Unsupported robot type` the moment a user tried to drive real hardware:

| strands name | was (broken) | now (real LeRobot type) |
|---|---|---|
| `hope_jr` | `hope_jr` | `hope_jr_arm` |
| `omx` | `omx` | `omx_follower` |
| `bi_openarm` | `bi_openarm` | `bi_openarm_follower` |
| `earthrover` | `earthrover` | `earthrover_mini_plus` |

The existing `test_registry_integrity.test_hardware_only_robots_declare_lerobot_type` check only asserted `lerobot_type` was a **non-empty string** — so these typos sailed through CI but broke real-hardware use.

## Full-catalog coverage

Nine LeRobot robot types were unreachable from any strands entry. Wired them all so every robot LeRobot ships is drivable via `Robot(name, mode="real")`:

- `openarm`: added `hardware: openarm_follower` to the existing sim-only entry
- new hardware entries: `hope_jr_hand`, ~~`rebot_b601`~~, ~~`bi_rebot_b601`~~, `lekiwi_client`

All **14 runtime-importable** LeRobot types now resolve to a config class (verified live). ~~The two reBot B601 types are declared in LeRobot source but need the optional `motorbridge` SDK to register at runtime — the strands wiring is correct regardless.~~

**Update (R1):** The `rebot_b601` / `bi_rebot_b601` entries were dropped — their `lerobot_type` values (`rebot_b601_follower` / `bi_rebot_b601_follower`) are not registered in lerobot 0.5.1 (the version the pinned `lerobot>=0.5.0,<0.6.0` resolves on PyPI). Keeping them would make the conformance test fail in CI. They will be re-added when a lerobot release that registers them lands on PyPI.

## New regression test

`tests/test_lerobot_hardware_conformance.py` closes the gap the old check left:
- Parses `@RobotConfig.register_subclass` names from LeRobot **source** (dependency-free, deterministic — doesn't need each driver's hardware SDK installed).
- Asserts (1) every strands `lerobot_type` is a real LeRobot type, and (2) every LeRobot type is reachable from some strands entry.
- Self-skips cleanly when the LeRobot tree is absent (sim-only / no `[lerobot]` extra).

## End-to-end example

`examples/lerobot_hardware_catalog.py`:
- Walks the registry showing `name -> canonical -> lerobot_type` for all hardware robots.
- Builds a Unitree G1 (29-DOF humanoid, the catalog's most complex robot) in **simulation** through the same `Robot()` factory as a 6-DOF SO-100 — proving the seam holds across the catalog.
- Uses **only the strands public API** (no direct `import lerobot`, per AGENTS.md #14).

## Testing

```
92 passed — test_lerobot_hardware_conformance + test_registry_integrity +
test_registry + test_examples_no_lerobot_imports + test_source_strings_no_emoji +
test_no_host_paths
```
lint clean, `ruff format` applied. The 4 previously-broken robots now resolve name → lerobot_type → config class end-to-end.

## Notes

- No new aliases collide (verified against canonical names + existing aliases).
- JSON entry order preserved; diff is +56/-6 (net after R1 removal: +31/-6).

---

## §13 Review Rounds

| Round | Concern | Fix commit | Pin test |
|---|---|---|---|
| R1 | `rebot_b601_follower` / `bi_rebot_b601_follower` not in pinned lerobot 0.5.1 wheel — conformance test fails in CI | `9641ac7` | `tests/test_lerobot_hardware_conformance.py::test_every_strands_lerobot_type_is_real` |
