### PR TITLE
fix(hardware): honour the RTC contract in the real-robot control loop (sim/real parity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,31 @@ background `get_actions` for the trailing chunk. Tests that assert the exact
 synchronous re-query count should pass `async_rtc=False`.
 
 
+### Fixed: hardware control loop honours the RTC contract (sim/real parity)
+
+`HardwareRobot._execute_task_async` (the real-robot rollout loop) drove the arm
+with a raw `robot_actions[:action_horizon]` slice and never told the policy its
+control clock, so RTC-capable providers (pi0, pi0.5, SmolVLA, MolmoAct2) fell
+back to a hardcoded assumed rate and mis-blended every chunk seam at any control
+frequency except the assumed one - a policy validated in sim behaved differently
+on the physical arm. The loop now mirrors the synchronous sim runner contract:
+
+- `policy.set_control_frequency(control_frequency)` is called once before the
+  rollout so latency-sensitive providers convert inference latency into the
+  correct count of action steps.
+- `policy.set_rtc_observed_delay(0)` is set before each inference. The hardware
+  loop is synchronous (observe -> infer -> apply) and issues no servo motion
+  during inference, so exactly 0 control steps elapse - a counted, deterministic
+  seam offset, not a wall-clock estimate. Drivers that coast servos during
+  inference would supply a non-zero counted delay here instead.
+- Chunk consumption now goes through `resolve_chunk_length(policy,
+  action_horizon)` instead of the raw slice: RTC policies are re-queried at
+  exactly their `execution_horizon` (so cross-chunk blending engages) while
+  single-step and open-loop chunked providers keep their prior
+  `max(action_horizon, execution_horizon)` behaviour (a no-op for them).
+
+Sim and hardware now share one RTC contract.
+
 ### Correctness: `run_policy` episode-count contract + `verify_dataset_episodes`
 
 `run_policy` could silently record a single merged `episode_index=0`

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -901,6 +901,10 @@ class Robot(TeleopMixin, AgentTool):
         duration: float = 30.0,
     ) -> None:
         """Execute robot task in background thread (internal method)."""
+        # resolve_chunk_length lives in the light policies.base module (no torch);
+        # imported lazily to match this file's policy-import convention.
+        from .policies.base import resolve_chunk_length
+
         try:
             # Update task state
             self._task_state.status = TaskStatus.CONNECTING
@@ -928,6 +932,15 @@ class Robot(TeleopMixin, AgentTool):
             logger.info(f"Starting task: '{instruction}' on {self.tool_name_str}")
             logger.info(f"Using policy: {policy_provider} on {policy_host}:{policy_port}")
 
+            # Real-Time Chunking contract (mirror PolicyRunner._run_policy_rollout
+            # in strands_robots/simulation/policy_runner.py): tell the policy the
+            # control rate ONCE before the rollout so RTC-capable providers
+            # (pi0/pi0.5/SmolVLA/MolmoAct2) convert their inference latency into a
+            # correct count of action steps and blend chunk seams identically to
+            # sim. Without it a wrong assumed rate corrupts RTC blending at every
+            # frequency except the assumed one. No-op for non-RTC policies.
+            policy_instance.set_control_frequency(self.control_frequency)
+
             self._task_state.status = TaskStatus.RUNNING
             start_time = time.time()
 
@@ -943,12 +956,29 @@ class Robot(TeleopMixin, AgentTool):
                 # is enabled). Best-effort: never blocks or breaks the loop.
                 self._publish_ros_telemetry(observation)
 
+                # Synchronous control loop: observe -> infer -> apply. The arm
+                # holds its last commanded position during inference (we issue no
+                # servo motion mid-inference), so exactly 0 control steps elapse
+                # between issuing the query and applying its first action. A
+                # counted 0 (not a wall-clock estimate) is the deterministic RTC
+                # seam offset for this loop, matching the synchronous sim runner.
+                # No-op for non-RTC policies. Drivers that coast servos during
+                # inference would need a non-zero counted delay here instead.
+                policy_instance.set_rtc_observed_delay(0)
+
                 # Get actions from policy
                 robot_actions = await policy_instance.get_actions(observation, instruction)
 
-                # Execute actions from chunk with proper timing control
-                # Wait between actions for smooth execution
-                for action_dict in robot_actions[: self.action_horizon]:
+                # Consume the chunk by the policy's own re-query interval rather
+                # than a raw action_horizon slice. resolve_chunk_length ignores
+                # action_horizon for RTC policies (they own execution_horizon;
+                # stretching/shrinking it silently degrades cross-chunk blending
+                # to open-loop replay) and returns max(action_horizon,
+                # execution_horizon) for non-RTC policies, so the prior
+                # robot_actions[:self.action_horizon] behaviour is preserved for
+                # single-step and open-loop chunked providers.
+                chunk_len = resolve_chunk_length(policy_instance, self.action_horizon)
+                for action_dict in robot_actions[:chunk_len]:
                     if self._task_state.status != TaskStatus.RUNNING:
                         break
                     await asyncio.to_thread(self.robot.send_action, action_dict)

--- a/tests/test_hardware_robot_lifecycle.py
+++ b/tests/test_hardware_robot_lifecycle.py
@@ -26,6 +26,7 @@ import pytest
 
 from strands_robots.hardware_robot import Robot as HwRobot
 from strands_robots.hardware_robot import RobotTaskState, TaskStatus
+from strands_robots.policies.base import Policy
 
 
 class _FakeLeRobot:
@@ -62,13 +63,26 @@ class _FakeLeRobot:
 
 
 class _StubPolicy:
-    """Deterministic policy: returns a fixed action chunk each step."""
+    """Deterministic policy: returns a fixed action chunk each step.
+
+    Records the Real-Time Chunking contract calls (``set_control_frequency`` /
+    ``set_rtc_observed_delay``) the control loop now issues, mirroring the
+    no-op base ``Policy`` hooks real providers inherit.
+    """
 
     def __init__(self) -> None:
         self.state_keys: list[str] | None = None
+        self.control_frequency_calls: list[float] = []
+        self.observed_delays: list[int | None] = []
 
     def set_robot_state_keys(self, keys: list[str]) -> None:
         self.state_keys = keys
+
+    def set_control_frequency(self, hz: float) -> None:
+        self.control_frequency_calls.append(hz)
+
+    def set_rtc_observed_delay(self, steps: int | None) -> None:
+        self.observed_delays.append(steps)
 
     async def get_actions(self, observation: dict[str, Any], instruction: str) -> list[dict[str, Any]]:
         return [{"j0.pos": 0.1}, {"j1.pos": 0.2}]
@@ -355,6 +369,118 @@ class TestExecuteTaskAsync:
         asyncio.run(hw._execute_task_async("pick", policy_port=5555, duration=0.01))
         assert hw._task_state.status == TaskStatus.ERROR
         assert "Failed to initialize policy" in hw._task_state.error_message
+        hw.cleanup()
+
+
+class _RtcChunkPolicy(Policy):
+    """RTC-capable policy: emits a 5-action chunk but owns a 2-step re-query.
+
+    ``supports_rtc`` + ``execution_horizon == 2`` mean a correct consumer
+    (``resolve_chunk_length``) executes exactly 2 actions before re-querying,
+    regardless of the caller's ``action_horizon`` (the RTC policy owns the
+    interval). It records the control rate and observed-delay the control loop
+    supplies via the base ``Policy`` RTC hooks.
+    """
+
+    supports_rtc = True
+    actions_per_step = 5  # trained chunk length emitted by get_actions
+
+    def __init__(self) -> None:
+        self.state_keys: list[str] | None = None
+        self.control_frequency_calls: list[float] = []
+        self.observed_delays: list[int | None] = []
+
+    @property
+    def provider_name(self) -> str:
+        return "rtc-test"
+
+    @property
+    def requires_images(self) -> bool:
+        return False
+
+    @property
+    def execution_horizon(self) -> int:
+        # RTC re-query interval, deliberately shorter than the 5-action chunk.
+        return 2
+
+    def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
+        self.state_keys = robot_state_keys
+
+    def set_control_frequency(self, hz: float) -> None:
+        self.control_frequency_calls.append(hz)
+
+    def set_rtc_observed_delay(self, steps: int | None) -> None:
+        self.observed_delays.append(steps)
+
+    async def get_actions(self, observation_dict, instruction, **kwargs):
+        return [{f"j{i}.pos": 0.1 * i} for i in range(self.actions_per_step)]
+
+
+@pytest.mark.timeout(30)
+class TestExecuteTaskAsyncRtcContract:
+    """Hardware control loop honours the same RTC contract as the sim runner.
+
+    Mirrors ``tests/simulation/test_policy_runner_async_rtc.py`` for the real-
+    robot path: the loop must set the control frequency once before the rollout,
+    supply a counted (zero) observed-delay per inference, and size each chunk by
+    the policy's RTC ``execution_horizon`` rather than the raw ``action_horizon``
+    slice. Pre-fix this consumed the full 5-action chunk (``[:action_horizon]``
+    with ``action_horizon == 8``); the fix consumes exactly ``execution_horizon``
+    (2) per query.
+    """
+
+    def _run_one_iteration(self, monkeypatch, policy: Policy, *, control_frequency: float = 100.0):
+        fake = _FakeLeRobot(connected=False)
+        hw = _make_robot(fake, control_frequency=control_frequency)
+
+        clock = {"now": 0.0}
+        monkeypatch.setattr(
+            "strands_robots.hardware_robot.time.time",
+            lambda: clock["now"],
+        )
+
+        # Advance the clock past the duration once the chunk is fetched so the
+        # loop runs exactly one observe->infer->apply iteration.
+        orig_get_actions = policy.get_actions
+
+        async def _advancing_get_actions(observation_dict, instruction, **kwargs):
+            actions = await orig_get_actions(observation_dict, instruction, **kwargs)
+            clock["now"] += 100.0
+            return actions
+
+        policy.get_actions = _advancing_get_actions  # type: ignore[method-assign]
+
+        async def _fake_get_policy(*a, **k):
+            return policy
+
+        hw._get_policy = _fake_get_policy  # type: ignore[assignment]
+        asyncio.run(hw._execute_task_async("pick", policy_port=5555, duration=0.05))
+        return hw, fake
+
+    def test_sets_control_frequency_once_before_loop(self, monkeypatch):
+        policy = _RtcChunkPolicy()
+        hw, _ = self._run_one_iteration(monkeypatch, policy, control_frequency=100.0)
+        assert hw._task_state.status == TaskStatus.COMPLETED
+        # Set exactly once, before the rollout, with the loop's control rate.
+        assert policy.control_frequency_calls == [100.0]
+        hw.cleanup()
+
+    def test_supplies_zero_observed_delay_per_inference(self, monkeypatch):
+        policy = _RtcChunkPolicy()
+        hw, _ = self._run_one_iteration(monkeypatch, policy)
+        # Synchronous loop: exactly 0 control steps elapse during inference.
+        assert policy.observed_delays, "policy was never queried"
+        assert all(d == 0 for d in policy.observed_delays), policy.observed_delays
+        hw.cleanup()
+
+    def test_consumes_rtc_execution_horizon_not_action_horizon(self, monkeypatch):
+        policy = _RtcChunkPolicy()
+        hw, fake = self._run_one_iteration(monkeypatch, policy)
+        # action_horizon defaults to 8 and the chunk is 5 actions, so the old
+        # robot_actions[:self.action_horizon] slice would have applied all 5.
+        # The RTC contract caps consumption at execution_horizon (2).
+        assert len(fake.sent_actions) == 2
+        assert hw._task_state.step_count == 2
         hw.cleanup()
 
 


### PR DESCRIPTION
## Problem

`HardwareRobot._execute_task_async` (the real-robot rollout loop in `strands_robots/hardware_robot.py`) drives the arm with a raw `robot_actions[:self.action_horizon]` slice and never tells the policy its control clock. The synchronous sim runner (`strands_robots/simulation/policy_runner.py`) does both: `policy.set_control_frequency(...)` once before the rollout and `policy.set_rtc_observed_delay(...)` before each inference.

Consequence: RTC-capable providers (pi0, pi0.5, SmolVLA, MolmoAct2) fall back to a hardcoded assumed rate on hardware and mis-blend the chunk seam at every control frequency except the assumed one - exactly the failure mode `Policy.set_control_frequency`'s docstring warns about ("a wrong assumed rate corrupts RTC blending at every control frequency except the assumed one"). A policy validated in sim with correct seam blending behaves differently on the physical arm.

## Change

Mirror the synchronous sim-runner RTC contract in `_execute_task_async`:

- Call `policy.set_control_frequency(self.control_frequency)` **once** before the rollout loop, so latency-sensitive providers convert inference latency into the correct count of action steps.
- Set `policy.set_rtc_observed_delay(0)` **before each inference**. The hardware loop is synchronous (observe -> infer -> apply) and issues no servo motion during inference, so exactly 0 control steps elapse - a counted, deterministic seam offset, not a wall-clock estimate. (Drivers that coast servos during inference would supply a non-zero counted delay here instead; called out in an inline comment.)
- Replace the raw `robot_actions[:self.action_horizon]` slice with `resolve_chunk_length(policy, self.action_horizon)`. RTC policies are re-queried at exactly their `execution_horizon` so cross-chunk blending engages; single-step and open-loop chunked providers keep their prior `max(action_horizon, execution_horizon)` behaviour (a no-op for them).

Single-step and non-RTC chunked policies are unaffected: `set_control_frequency` / `set_rtc_observed_delay` are no-ops on the base `Policy`, and `resolve_chunk_length` reproduces the previous slice for them. Action-dict keys are untouched - this is purely a control-loop fix.

## Tests

New `TestExecuteTaskAsyncRtcContract` in `tests/test_hardware_robot_lifecycle.py` (mirrors `tests/simulation/test_policy_runner_async_rtc.py`) with an RTC-capable `Policy` subclass (`supports_rtc=True`, `execution_horizon=2`, emits a 5-action chunk, `action_horizon=8`):

- `set_control_frequency` is called exactly once before the loop with the loop's control rate.
- `set_rtc_observed_delay(0)` is supplied per inference.
- Exactly `execution_horizon` (2) actions are consumed per query, not the full 5-action chunk the old `[:action_horizon]` slice applied.

All three fail on pre-fix code (`assert 5 == 2`, `control_frequency_calls == []`, `observed_delays == []`) and pass after. Full suite green locally: `tests/test_hardware_robot_lifecycle.py` (49 passed), sim RTC + policies (`tests/simulation/test_policy_runner_async_rtc.py tests/policies`: 1161 passed, 2 skipped), and `ruff check` / `ruff format --check` / `mypy` clean over `strands_robots tests tests_integ`.

## Out of scope

- The async overlap pipeline on hardware (the sim runner's `async_rtc` prefetch). The synchronous loop already honours the RTC seam contract correctly; overlapping inference with execution to mask latency is a separate performance change.
- E-STOP latency, real-time scheduling guarantees, the ROS 2 telemetry path - all unchanged.

CHANGELOG entry added under `[Unreleased]` -> Fixed.