### PR TITLE
feat(training): dynamic RewardModelConfig parity with lerobot (1/4 -> 4/4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Feature: full RewardModelConfig parity with lerobot (dynamic reward-type discovery)
+
+`LerobotTrainer` reward-model training (`TrainSpec.extra["reward_model"]`) now
+reaches EVERY reward model lerobot registers on its `RewardModelConfig` choice
+registry, not just SARM. The valid type set and each type's configurable fields
+are read live from `RewardModelConfig.get_known_choices()` and the resolved
+config dataclass (the same zero-maintenance discovery Robot / Teleop / Camera /
+Policy already use), so `robometer`, `topreward`, and `reward_classifier` - plus
+any future or plugin-registered reward type - validate and build with no strands
+change:
+
+- The previously hardcoded reward-type list and SARM-biased friendly-key set are
+  gone. Friendly `extra["reward_model"]` keys are now the chosen type's OWN
+  config fields, so each type is configurable with its own knobs (e.g.
+  robometer's `default_task` / `success_threshold`, the classifier's
+  `num_classes`). Cross-type fields (e.g. SARM's `annotation_mode` on
+  `robometer`) are rejected with the list of that type's configurable fields.
+- A static fallback (SARM keys, the four known types) keeps `validate()`
+  informative when `lerobot.rewards` is absent (lerobot < 0.5.2), where
+  reward-model training cannot run anyway.
+- Added a source-AST parity guard that scans the installed lerobot's reward
+  sources for `register_subclass` sites and asserts strands' discovery matches
+  exactly; it self-skips when `lerobot.rewards` is unavailable.
+
+
 ### Feature: Newton backend scene-discovery and per-joint state parity
 
 The Newton GPU backend gained the discovery and state-introspection methods the

--- a/docs/training/overview.md
+++ b/docs/training/overview.md
@@ -101,7 +101,7 @@ supports and **ignores the rest** (the same tolerance rule as
 | `extra["sft_toml"]` / `extra["cosmos_root"]` | recipe + checkout | Cosmos |
 | `extra["relative_actions"]` | train pi0-family with delta actions | lerobot `--policy.use_relative_actions=true` (pi0/pi05/pi0_fast) |
 | `extra["sample_weighting"]` | RA-BC per-sample loss weighting dict | lerobot `cfg.sample_weighting` (`--sample_weighting.*`) |
-| `extra["reward_model"]` | train a reward model (SARM) instead of a policy | lerobot `cfg.reward_model` (`--reward_model.*`); requires lerobot >= 0.5.2 |
+| `extra["reward_model"]` | train a reward model (`sarm` / `robometer` / `topreward` / `reward_classifier`) instead of a policy | lerobot `cfg.reward_model` (`--reward_model.*`); requires lerobot >= 0.5.2 |
 
 ## From an agent (natural language)
 
@@ -210,10 +210,18 @@ trainer.train(TrainSpec(
 ))
 ```
 
-`extra["reward_model"]` accepts `type` (default `sarm`), `annotation_mode`
-(`single_stage` / `dense_only` / `dual`), `image_key`, and `state_key`. The
-policy-only knobs (`sample_weighting`, `relative_actions`, non-`full` `method`)
-are rejected on a reward-model run rather than silently ignored.
+`extra["reward_model"]` works for every reward model lerobot registers on its
+`RewardModelConfig` choice registry - `sarm` (default), `robometer`, `topreward`,
+and `reward_classifier` today, plus any new type a future lerobot or a plugin
+adds, with no strands change needed. Besides `type`, the dict accepts that
+type's OWN config fields: e.g. SARM's `annotation_mode`
+(`single_stage` / `dense_only` / `dual`), `image_key`, `state_key`; robometer /
+topreward's `default_task`, `success_threshold`, `max_frames`; the classifier's
+`num_classes`, `hidden_dim`. Fields that do not belong to the chosen type (e.g.
+SARM's `annotation_mode` on `robometer`) are rejected with the list of that
+type's configurable fields. The policy-only knobs (`sample_weighting`,
+`relative_actions`, non-`full` `method`) are rejected on a reward-model run
+rather than silently ignored.
 
 A trained SARM can also be queried for a dense task-progress score in `[0, 1]`
 (e.g. as an eval-time signal):

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -46,6 +46,7 @@ Grounded against lerobot 0.5.x ``TrainPipelineConfig`` / ``DatasetConfig`` /
 from __future__ import annotations
 
 import contextlib
+import dataclasses
 import json
 import logging
 import os
@@ -102,14 +103,81 @@ _SAMPLE_WEIGHTING_TYPES = {"rabc", "uniform"}
 # policy, but populates ``cfg.reward_model`` instead of ``cfg.policy``
 # (``TrainPipelineConfig.is_reward_model_training``). Requires lerobot >= 0.5.2
 # (the ``lerobot.rewards`` package).
-_LEROBOT_REWARD_MODEL_TYPES = {"sarm", "reward_classifier", "robometer", "topreward"}
+#
+# Parity with lerobot is DYNAMIC, not a hardcoded list: both the set of reward
+# types and each type's configurable fields are read live from lerobot's
+# ``RewardModelConfig`` draccus ChoiceRegistry (see :func:`_reward_registry`) -
+# the same zero-maintenance discovery Robot / Teleop / Camera / Policy already
+# use. Any reward model lerobot ships (sarm, robometer, topreward,
+# reward_classifier, ...) or a third-party plugin registers is reachable with no
+# change here. The static fallbacks below are used ONLY when ``lerobot.rewards``
+# is absent (lerobot < 0.5.2), where reward-model training cannot run anyway but
+# ``validate()`` should still produce a useful message offline.
+_REWARD_MODEL_TYPES_FALLBACK = frozenset({"sarm", "reward_classifier", "robometer", "topreward"})
+
+# Friendly ``extra['reward_model']`` field names to fall back on when the live
+# registry is unavailable. These are SARM's (the offline default type)
+# configurable keys; ``type`` is the registry selector, handled separately.
+_REWARD_MODEL_FIELDS_FALLBACK = frozenset({"annotation_mode", "image_key", "state_key"})
 
 # SARM annotation modes (configuration_sarm.SARMConfig.annotation_mode):
 # ``single_stage`` needs NO annotations (linear progress over the episode).
 _SARM_ANNOTATION_MODES = {"single_stage", "dense_only", "dual"}
 
-# Friendly keys accepted in ``extra['reward_model']``.
-_REWARD_MODEL_KEYS = {"type", "annotation_mode", "image_key", "state_key"}
+
+def _reward_registry() -> dict[str, type] | None:
+    """Live ``RewardModelConfig`` ChoiceRegistry, or ``None`` when unavailable.
+
+    Importing ``lerobot.rewards`` runs each config module's
+    ``@RewardModelConfig.register_subclass`` decorator, which is what populates
+    the draccus ChoiceRegistry - querying it before that import yields an empty
+    mapping, so the import is the load-bearing step. Returns ``None`` when the
+    installed lerobot has no ``lerobot.rewards`` (lerobot < 0.5.2).
+    """
+    try:
+        import lerobot.rewards  # noqa: F401  (import for register_subclass side effect)
+        from lerobot.configs.rewards import RewardModelConfig
+    except ImportError:
+        return None
+    return dict(RewardModelConfig.get_known_choices())
+
+
+def _reward_model_types() -> set[str]:
+    """LeRobot-native reward-model type names (live registry, else fallback)."""
+    reg = _reward_registry()
+    if reg is None:
+        return set(_REWARD_MODEL_TYPES_FALLBACK)
+    return set(reg)
+
+
+def _reward_friendly_fields(rtype: str) -> set[str]:
+    """Configurable ``extra['reward_model']`` keys for a reward type.
+
+    Dynamic when ``lerobot.rewards`` is importable: the resolved config
+    dataclass's OWN (subclass-declared) constructor fields - the per-type
+    training knobs. The shared ``RewardModelConfig`` base fields are excluded:
+    ``device`` is auto-selected, ``push_to_hub`` is forced off, and
+    ``pretrained_path`` is set from ``TrainSpec.base_model``, while the rest
+    (Hub metadata, feature specs) are plumbing lerobot derives - none belong in
+    the friendly surface. This gives every reward type - not just SARM - full
+    knob reach with zero per-type maintenance. Falls back to SARM's documented
+    friendly keys when the registry is unavailable (offline / lerobot < 0.5.2),
+    where reward-model training cannot run anyway.
+
+    ``type`` (the registry selector) is never a config field and is handled by
+    the caller, so it is not part of the returned set.
+    """
+    reg = _reward_registry()
+    if reg is None or rtype not in reg:
+        return set(_REWARD_MODEL_FIELDS_FALLBACK)
+    from lerobot.configs.rewards import RewardModelConfig
+
+    # Only constructor (init=True) fields are valid make_reward_model_config
+    # kwargs; subtracting the base class's fields leaves the per-type knobs.
+    base = {f.name for f in dataclasses.fields(RewardModelConfig)}
+    own = {f.name for f in dataclasses.fields(reg[rtype]) if f.init}
+    return own - base
+
 
 # Hugging Face Hub dataset id: ``org/name`` (each segment alnum plus ._-). Used
 # to gate the agent-supplied ``dataset_repo_id`` before it becomes lerobot's
@@ -415,16 +483,21 @@ class LerobotTrainer(Trainer):
         """
         problems: list[str] = []
         rtype = self._reward_model_type(rm)
-        if rtype not in _LEROBOT_REWARD_MODEL_TYPES:
+        valid_types = _reward_model_types()
+        if rtype not in valid_types:
             problems.append(
-                f"reward_model type '{rtype}' is not LeRobot-native "
-                f"(expected one of {sorted(_LEROBOT_REWARD_MODEL_TYPES)})"
+                f"reward_model type '{rtype}' is not LeRobot-native (expected one of {sorted(valid_types)})"
             )
-        unknown = sorted(k for k in rm if k not in _REWARD_MODEL_KEYS)
+        # Validate friendly keys against the resolved config's OWN fields (live
+        # registry), so each reward type is configurable with its own knobs and
+        # cross-type fields (e.g. SARM's annotation_mode on robometer) are
+        # rejected with a clear message. Falls back to SARM's keys offline.
+        friendly = _reward_friendly_fields(rtype)
+        unknown = sorted(k for k in rm if k != "type" and k not in friendly)
         if unknown:
             problems.append(
-                f"extra['reward_model'] does not support field(s) {unknown}; "
-                f"accepted keys are {sorted(_REWARD_MODEL_KEYS)}."
+                f"reward_model type '{rtype}' does not support field(s) {unknown}; "
+                f"its configurable fields are {sorted(friendly)}."
             )
         if rtype == "sarm":
             am = rm.get("annotation_mode")
@@ -528,10 +601,11 @@ class LerobotTrainer(Trainer):
     def _reward_model_command_flags(self, rm: dict[str, Any]) -> list[str]:
         """argv-parity flags for a reward-model run (``--reward_model.*``)."""
         rtype = self._reward_model_type(rm)
+        friendly = _reward_friendly_fields(rtype)
         flags = [f"--reward_model.type={rtype}", f"--reward_model.device={self.device}"]
-        for key in ("annotation_mode", "image_key", "state_key"):
-            if key in rm:
-                flags.append(f"--reward_model.{key}={rm[key]}")
+        for key, value in rm.items():
+            if key != "type" and key in friendly:
+                flags.append(f"--reward_model.{key}={value}")
         return flags
 
     def build_config(self, spec: TrainSpec) -> TrainPipelineConfig:
@@ -603,10 +677,15 @@ class LerobotTrainer(Trainer):
         from lerobot.rewards import make_reward_model_config
 
         rtype = self._reward_model_type(rm)
+        # Forward every friendly key that is a real field of the resolved config
+        # dataclass (read supported fields, ignore the rest) - the dynamic
+        # passthrough that reaches all reward types, not just SARM. ``device``
+        # and the other managed base fields are set by the trainer below.
+        friendly = _reward_friendly_fields(rtype)
         reward_kwargs: dict[str, Any] = {"device": self.device}
-        for key in ("annotation_mode", "image_key", "state_key"):
-            if key in rm:
-                reward_kwargs[key] = rm[key]
+        for key, value in rm.items():
+            if key != "type" and key in friendly:
+                reward_kwargs[key] = value
         try:
             reward_cfg = make_reward_model_config(rtype, **reward_kwargs)
         except TypeError as e:

--- a/tests/training/test_reward_model_parity.py
+++ b/tests/training/test_reward_model_parity.py
@@ -1,0 +1,172 @@
+"""RewardModelConfig parity guard: every lerobot reward model reaches strands.
+
+LeRobot registers its reward models on a single draccus ChoiceRegistry,
+``RewardModelConfig`` (``@RewardModelConfig.register_subclass("<name>")`` in each
+``lerobot/rewards/<type>/configuration_<type>.py``). The strands
+:class:`~strands_robots.training.lerobot.LerobotTrainer` reward-model path must
+stay in lock-step with that registry with ZERO hardcoding, the same way Robot /
+Teleop / Camera / Policy discovery already does - any reward model lerobot ships
+(or a plugin registers) must be reachable through ``extra['reward_model']``
+without editing strands.
+
+This is a source-level guard: it AST-scans the INSTALLED lerobot's reward
+sources for the ``register_subclass`` decorators (the ground truth, independent
+of import side effects) and asserts strands' dynamic discovery sees exactly the
+same set and can validate + build a config for each. It ``importorskip``s
+``lerobot.rewards`` so it self-skips on a lerobot too old to ship it
+(< 0.5.2 / PyPI), where reward-model training cannot run anyway.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+from strands_robots.training.base import TrainSpec
+from strands_robots.training.lerobot import (
+    LerobotTrainer,
+    _reward_friendly_fields,
+    _reward_model_types,
+)
+
+
+def _registered_reward_types_from_source() -> set[str]:
+    """Ground-truth reward type names from the installed lerobot's source.
+
+    Walks ``lerobot/rewards`` for ``configuration_*.py`` files and AST-parses
+    each for an ``@RewardModelConfig.register_subclass(<name>)`` decorator,
+    returning the registered names. Source parsing (not the runtime registry)
+    is deliberate: it catches a type that lerobot ships but that strands' own
+    discovery fails to import/register.
+    """
+    import lerobot.rewards
+
+    rewards_root = Path(lerobot.rewards.__file__).parent
+    names: set[str] = set()
+    for cfg_path in rewards_root.rglob("configuration_*.py"):
+        tree = ast.parse(cfg_path.read_text(encoding="utf-8"), filename=str(cfg_path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ClassDef):
+                continue
+            for deco in node.decorator_list:
+                name = _register_subclass_name(deco)
+                if name is not None:
+                    names.add(name)
+    return names
+
+
+def _register_subclass_name(deco: ast.expr) -> str | None:
+    """Extract the name from a ``RewardModelConfig.register_subclass(...)`` call.
+
+    Handles both the positional (``register_subclass("sarm")``) and keyword
+    (``register_subclass(name="reward_classifier")``) forms lerobot uses.
+    Returns ``None`` for any other decorator.
+    """
+    if not isinstance(deco, ast.Call):
+        return None
+    func = deco.func
+    if not (isinstance(func, ast.Attribute) and func.attr == "register_subclass"):
+        return None
+    for arg in deco.args:
+        if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+            return arg.value
+    for kw in deco.keywords:
+        if kw.arg == "name" and isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+            return kw.value.value
+    return None
+
+
+@pytest.fixture
+def dataset_root(tmp_path):
+    meta = tmp_path / "meta"
+    meta.mkdir()
+    (meta / "info.json").write_text(json.dumps({"total_episodes": 10}))
+    return str(tmp_path)
+
+
+class TestRewardModelConfigParity:
+    """LerobotTrainer reaches every lerobot RewardModelConfig subclass."""
+
+    def test_strands_discovery_matches_lerobot_source(self):
+        """strands' dynamic reward-type discovery == lerobot's registered set.
+
+        Equality (not just superset) in both directions: strands must not miss a
+        type lerobot ships, and must not advertise a type lerobot does not.
+        """
+        pytest.importorskip("lerobot.rewards")
+        source_types = _registered_reward_types_from_source()
+        # Sanity: the audit baseline - lerobot ships at least these four.
+        assert {"sarm", "robometer", "topreward", "reward_classifier"} <= source_types
+        assert _reward_model_types() == source_types
+
+    @pytest.mark.parametrize("rtype", ["sarm", "robometer", "topreward", "reward_classifier"])
+    def test_every_reward_type_validates_and_builds(self, rtype, dataset_root, tmp_path):
+        """Each reward type is reachable: validate() accepts it and build_config
+        targets ``cfg.reward_model`` (lerobot's is_reward_model_training path)."""
+        pytest.importorskip("lerobot.rewards")
+        spec = TrainSpec(
+            dataset_root=dataset_root,
+            base_model="",
+            output_dir=str(tmp_path / f"{rtype}_out"),
+            steps=100,
+            extra={"reward_model": {"type": rtype}},
+        )
+        trainer = LerobotTrainer(device="cpu")
+        assert trainer.validate(spec) == [], f"{rtype} failed validation"
+        cfg = trainer.build_config(spec)
+        assert cfg.is_reward_model_training is True
+        assert cfg.policy is None
+        assert cfg.reward_model.type == rtype
+
+    @pytest.mark.parametrize("rtype", ["sarm", "robometer", "topreward", "reward_classifier"])
+    def test_own_field_passthrough_per_type(self, rtype, dataset_root, tmp_path):
+        """A type's own config knob flows through to the built config.
+
+        Picks one subclass-declared field per type and asserts it both passes
+        validation (the friendly surface is per-type, not SARM-only) and lands on
+        the built ``cfg.reward_model`` - the dynamic-passthrough contract that
+        makes all four types configurable, not just SARM.
+        """
+        pytest.importorskip("lerobot.rewards")
+        # normalization_mapping is declared by every reward subclass; use a
+        # simpler per-type scalar knob to assert real value passthrough.
+        knob = {
+            "sarm": ("annotation_mode", "single_stage"),
+            "robometer": ("default_task", "pick up the cube"),
+            "topreward": ("default_task", "pick up the cube"),
+            "reward_classifier": ("num_classes", 3),
+        }[rtype]
+        field, value = knob
+        assert field in _reward_friendly_fields(rtype)
+        spec = TrainSpec(
+            dataset_root=dataset_root,
+            base_model="",
+            output_dir=str(tmp_path / f"{rtype}_out"),
+            steps=100,
+            extra={"reward_model": {"type": rtype, field: value}},
+        )
+        trainer = LerobotTrainer(device="cpu")
+        assert trainer.validate(spec) == [], f"{rtype}.{field} rejected"
+        cfg = trainer.build_config(spec)
+        assert getattr(cfg.reward_model, field) == value
+
+    def test_cross_type_field_is_rejected(self, dataset_root, tmp_path):
+        """SARM's annotation_mode is not a robometer field -> rejected.
+
+        Guards the per-type field validation: before this, the friendly key set
+        was a single SARM-biased list that wrongly accepted annotation_mode for
+        every type (then failed deep in make_reward_model_config).
+        """
+        pytest.importorskip("lerobot.rewards")
+        spec = TrainSpec(
+            dataset_root=dataset_root,
+            base_model="",
+            output_dir=str(tmp_path / "robometer_out"),
+            steps=100,
+            extra={"reward_model": {"type": "robometer", "annotation_mode": "single_stage"}},
+        )
+        problems = LerobotTrainer(device="cpu").validate(spec)
+        assert any("does not support field" in p and "annotation_mode" in p for p in problems)


### PR DESCRIPTION
## Summary

`LerobotTrainer` reward-model training (`TrainSpec.extra["reward_model"]`) only fully wired **SARM**. The reward-type list was a hardcoded set and the friendly-key allowlist (`annotation_mode`, `image_key`, `state_key`) was SARM-biased - `annotation_mode`/`state_key` are SARM-only fields - so the other reward models lerobot ships were reachable *by name* but could not be configured with their own fields, and a fifth reward type would silently fall outside the static set.

This resolves the valid reward types **and** each type's configurable fields LIVE from lerobot's `RewardModelConfig` draccus choice registry and the resolved config dataclass - the same zero-maintenance discovery `Robot` / `Teleop` / `Camera` / `Policy` already use - so every reward model lerobot ships (or a plugin registers) validates and builds with no per-type maintenance.

## Parity

| lerobot reward type | source | before | after |
|---|---|---|---|
| `sarm` | `rewards/sarm/configuration_sarm.py` | fully wired | fully wired |
| `robometer` | `rewards/robometer/configuration_robometer.py` | name only | fully wired |
| `topreward` | `rewards/topreward/configuration_topreward.py` | name only | fully wired |
| `reward_classifier` | `rewards/classifier/configuration_classifier.py` | name only | fully wired |

`RewardModelConfig.get_known_choices()` is now the source of truth, so a 5th type needs no code change here.

## Changes

- `_reward_model_types()` reads `RewardModelConfig.get_known_choices()` (importing `lerobot.rewards` to trigger the `register_subclass` decorators), falling back to the four known names only when `lerobot.rewards` is absent (lerobot < 0.5.2), where reward-model training cannot run anyway but `validate()` should still be informative.
- `_reward_friendly_fields(rtype)` returns the chosen config's OWN (subclass-declared) constructor fields, so each type is configurable with its own knobs (e.g. robometer's `default_task` / `success_threshold`, the classifier's `num_classes`). Cross-type fields (e.g. SARM's `annotation_mode` on `robometer`) are rejected with the list of that type's configurable fields. Trainer-managed base fields (`device` / `push_to_hub` / `pretrained_path`) stay out of the friendly surface.
- `validate()` / `build_config()` / `build_command()` all forward through the dynamic surface; the hardcoded `_LEROBOT_REWARD_MODEL_TYPES` / SARM-biased `_REWARD_MODEL_KEYS` constants are gone.

## Tests

New `tests/training/test_reward_model_parity.py` - a source-AST parity guard that scans the installed lerobot's reward sources for `register_subclass` sites (ground truth, independent of import side effects) and asserts:
- strands' dynamic discovery equals lerobot's registered set (both directions),
- every reward type validates and `build_config` targets `cfg.reward_model` (the `is_reward_model_training` path),
- a per-type OWN field passes validation and lands on the built config,
- a cross-type field (SARM's `annotation_mode` on `robometer`) is rejected.

It `importorskip`s `lerobot.rewards`, so it self-skips on a lerobot too old to ship it (matches the existing `pytest.importorskip` reward tests).

Validated locally against lerobot 0.5.2 (built from source): all 4 types validate + build; existing `TestRewardModelTraining` and `test_reward.py` still pass; `ruff check` / `ruff format --check` / `mypy` clean over `strands_robots tests tests_integ` (529 source files, no issues).

No runtime behavior change for policy/simulation paths - this is a training-config reachability + validation change.