### PR TITLE
docs(policies): document intentional divergence from LeRobot rollout subsystem

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,37 @@ hatch run format            # ruff check --fix, ruff format
   Enforced by `tests/test_registry_integrity.py`.
 
 
+## LeRobot rollout subsystem - intentional divergence
+
+LeRobot ships a `rollout/` deployment engine (`src/lerobot/rollout/`):
+`RolloutStrategyConfig` session managers (`base`, `sentry`, `highlight`,
+`dagger`, `episodic`) and `InferenceEngineConfig` action backends (`sync`,
+`rtc`). strands-robots does NOT mirror this engine wholesale. The boundary is
+deliberate; do not bridge LeRobot's rollout inference engine into the strands
+inference path. Pinned by `tests/policies/test_lerobot_rollout_divergence.py`.
+
+| LeRobot type | strands status | strands equivalent |
+|---|---|---|
+| strategy `dagger` | adopted | `lerobot_teleoperate` tool `action="dagger"` drives `lerobot-rollout --strategy.type=dagger` as a subprocess (HITL correction on hardware) |
+| strategy `base` | not adopted | autonomous no-record rollout = `run_policy()` without a recorder |
+| strategy `episodic` | not adopted | episode-oriented record = `run_policy(n_episodes=N)` + `DatasetRecorder` (or teleop tool driving `lerobot-record`) |
+| strategy `sentry` | not adopted | 24/7 size-rotated autonomous recording; an interactive hardware deployment-engine feature with no sim/agent home |
+| strategy `highlight` | not adopted | ring-buffer on-demand keypress save; interactive hardware-only |
+| engine `sync` | covered | synchronous `PolicyRunner` path (`async_rtc=False`): one policy call per control tick |
+| engine `rtc` | divergent loop driver | strands adopts LeRobot's RTC *algorithm* at the policy layer (`LerobotLocalPolicy` consumes LeRobot's `RTCConfig` + `predict_action_chunk`) but drives the re-query loop itself by integer step count |
+
+**Why the RTC loop driver diverges.** LeRobot's `RTCInferenceEngine` runs
+inference in a background thread and swaps chunks off a wall-clock
+`queue_threshold`, deriving the seam offset from measured latency - non-
+deterministic w.r.t. control-step count. strands re-queries at exactly
+`policy.execution_horizon` (`resolve_chunk_length`, the single re-query rule) and
+feeds the seam offset as a counted integer via `set_rtc_observed_delay` (0 in the
+paused-world sync loop; the still-pending step count in the async overlap). This
+keeps seeded eval reproducible (seed + step count -> identical trajectory). See
+`docs/policies/lerobot-local.md` -> "Relationship to LeRobot's rollout subsystem".
+
+
+
 ## Review Learnings (PR #85 - MuJoCo Backend)
 
 Corrections from code review that apply to all future contributions:

--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -312,6 +312,41 @@ real hardware where the arm genuinely keeps moving during inference), leave the
 override unset (`None`) and the policy falls back to the wall-clock p95 estimate,
 which is the right proxy there.
 
+## Relationship to LeRobot's rollout subsystem
+
+LeRobot ships a `rollout/` deployment engine (`src/lerobot/rollout/`) with two
+polymorphic config families: `RolloutStrategyConfig` session managers (`base`,
+`sentry`, `highlight`, `dagger`, `episodic`) and `InferenceEngineConfig` action
+backends (`sync`, `rtc`). strands does not consume that engine in its inference
+path - the boundary is intentional, and a guard test
+(`tests/policies/test_lerobot_rollout_divergence.py`) pins it.
+
+**Inference engines.** LeRobot's `sync` engine (one policy call per control tick)
+maps to the synchronous `PolicyRunner` path (`async_rtc=False`). For `rtc`,
+strands adopts LeRobot's RTC *algorithm* - `LerobotLocalPolicy` loads LeRobot's
+own `RTCConfig` and calls `predict_action_chunk(..., execution_horizon=...)` for
+the seam blending - but **drives the re-query loop itself**. LeRobot's
+`RTCInferenceEngine` runs inference in a background thread and swaps chunks off a
+wall-clock `queue_threshold`, deriving the seam offset from measured latency;
+that is non-deterministic with respect to control-step count. strands re-queries
+at exactly `policy.execution_horizon` (the single rule in `resolve_chunk_length`)
+and supplies the seam offset as a counted integer through
+`set_rtc_observed_delay` (see [Deterministic inference delay](#deterministic-inference-delay)),
+so a runner-driven eval is bit-reproducible across fixed-seed episodes.
+Bridging LeRobot's wall-clock engine into the sim/eval loop would regress that
+determinism guarantee, so it is deliberately not done.
+
+**Rollout strategies.** `dagger` is adopted for hardware HITL correction: the
+`lerobot_teleoperate` tool with `action="dagger"` invokes
+`lerobot-rollout --strategy.type=dagger` as a subprocess. The remaining
+strategies are interactive hardware deployment-session managers (keyboard/foot-
+pedal input, Rerun display, video-file-size episode rotation) whose recording
+surface strands already covers without the engine: `base` is `run_policy()`
+without a recorder; `episodic` is `run_policy(n_episodes=N)` plus
+[`DatasetRecorder`](../recording.md) (or the teleop tool driving
+`lerobot-record`); `sentry` and `highlight` are 24/7 / on-demand interactive
+hardware recording with no sim or agent home.
+
 ## See also
 
 - [MolmoAct2 (SO-100/101)](molmoact2.md) - action contract, units, and motion diagnostics

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -202,4 +202,5 @@ python -m lerobot.scripts.train policy=act \
 ## See also
 
 - [Training](training/overview.md) - what to do with the data.
+- [LeRobot rollout subsystem - intentional divergence](policies/lerobot-local.md#relationship-to-lerobots-rollout-subsystem) - why strands does not adopt LeRobot's `sentry`/`highlight`/`episodic` recording strategies wholesale.
 - [LeRobot dataset docs](https://huggingface.co/docs/lerobot) - upstream spec.

--- a/tests/policies/test_lerobot_rollout_divergence.py
+++ b/tests/policies/test_lerobot_rollout_divergence.py
@@ -1,0 +1,152 @@
+"""Guard tests pinning the intentional divergence from LeRobot's rollout subsystem.
+
+LeRobot ships a ``rollout/`` deployment engine: ``RolloutStrategyConfig`` (base,
+sentry, highlight, dagger, episodic) session managers and ``InferenceEngineConfig``
+(sync, rtc) action backends. strands-robots deliberately does NOT consume that
+engine in its inference path. Instead it owns the re-query loop and drives Real-Time
+Chunking by an integer *control-step count*, so seeded episodes are reproducible.
+
+The divergence is by design (see ``docs/policies/lerobot-local.md`` -> "Relationship
+to LeRobot's rollout subsystem" and ``AGENTS.md``):
+
+* strands adopts LeRobot's RTC *algorithm* at the policy layer (``LerobotLocalPolicy``
+  consumes LeRobot's ``RTCConfig`` + ``predict_action_chunk``).
+* strands diverges on the *loop driver*: LeRobot's ``RTCInferenceEngine`` swaps chunks
+  off a wall-clock ``queue_threshold`` (non-deterministic by step count), whereas
+  strands re-queries at exactly ``execution_horizon`` and feeds the seam offset as a
+  counted integer via ``set_rtc_observed_delay``.
+
+These tests fail if a future change bridges LeRobot's wall-clock rollout inference
+engine into the strands inference path without re-reading that rationale.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from strands_robots.policies.base import Policy, resolve_chunk_length
+
+# Modules that make up the strands inference path. None of them may *import* the
+# LeRobot rollout deployment engine (the teleop tool may still invoke
+# ``lerobot-rollout`` as a CLI subprocess - that is a string, not an import).
+_INFERENCE_PATH = (
+    Path(__file__).resolve().parents[2] / "strands_robots" / "policies",
+    Path(__file__).resolve().parents[2] / "strands_robots" / "simulation",
+)
+
+# Import targets that would signal a bridge of LeRobot's rollout engine.
+_FORBIDDEN_IMPORT_PREFIXES = ("lerobot.rollout",)
+_FORBIDDEN_IMPORT_NAMES = (
+    "RolloutStrategyConfig",
+    "InferenceEngineConfig",
+    "RTCInferenceEngine",
+    "SyncInferenceEngine",
+)
+
+
+def _imported_modules(tree: ast.AST) -> list[str]:
+    """Return every module path referenced by ``import`` / ``from ... import``."""
+    modules: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.append(node.module)
+            modules.extend(f"{node.module}.{alias.name}" for alias in node.names)
+    return modules
+
+
+def _python_files() -> list[Path]:
+    files: list[Path] = []
+    for root in _INFERENCE_PATH:
+        files.extend(p for p in root.rglob("*.py") if "__pycache__" not in p.parts)
+    return files
+
+
+def test_inference_path_does_not_import_lerobot_rollout_engine() -> None:
+    """No strands inference module imports LeRobot's rollout deployment engine.
+
+    Pins decision (c)+(b): strands implements RTC at the policy layer and drives
+    the loop itself; it never consumes LeRobot's ``InferenceEngineConfig`` /
+    ``RolloutStrategyConfig``. A subprocess CLI invocation of ``lerobot-rollout``
+    (a string, not an import) is allowed and is how ``dagger`` is adopted.
+    """
+    offenders: list[str] = []
+    for path in _python_files():
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for module in _imported_modules(tree):
+            if module.startswith(_FORBIDDEN_IMPORT_PREFIXES):
+                offenders.append(f"{path.name}: imports {module}")
+            elif module.rsplit(".", 1)[-1] in _FORBIDDEN_IMPORT_NAMES:
+                offenders.append(f"{path.name}: imports {module}")
+    assert not offenders, (
+        "strands inference path must not bridge LeRobot's rollout engine; see "
+        "docs/policies/lerobot-local.md 'Relationship to LeRobot's rollout subsystem'. "
+        f"Offending imports: {offenders}"
+    )
+
+
+class _FakeRtcPolicy(Policy):
+    """Weight-free RTC policy: declares an execution horizon shorter than its chunk."""
+
+    requires_images = False
+    supports_rtc = True
+
+    def __init__(self, execution_horizon: int = 10, actions_per_step: int = 50) -> None:
+        self._exec = execution_horizon
+        self.actions_per_step = actions_per_step
+
+    @property
+    def provider_name(self) -> str:
+        return "fake_rtc"
+
+    @property
+    def execution_horizon(self) -> int:
+        return self._exec
+
+    def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
+        pass
+
+    async def get_actions(
+        self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any
+    ) -> list[dict[str, Any]]:
+        return [{"j0": 0.0} for _ in range(self.actions_per_step)]
+
+
+def test_rtc_observed_delay_is_deterministic_step_count() -> None:
+    """The seam offset is a counted non-negative integer, not a wall-clock measure.
+
+    This is the determinism guarantee that LeRobot's wall-clock ``RTCInferenceEngine``
+    cannot provide: the paused-world sync loop reports exactly 0 steps elapsed, and
+    any async overlap reports an integer step count.
+    """
+    policy = _FakeRtcPolicy()
+
+    policy.set_rtc_observed_delay(0)  # paused-world sync eval loop
+    assert policy.rtc_observed_delay_steps == 0
+
+    policy.set_rtc_observed_delay(7)  # async overlap: still-pending steps
+    assert policy.rtc_observed_delay_steps == 7
+
+    policy.set_rtc_observed_delay(None)  # clear -> provider falls back to estimate
+    assert policy.rtc_observed_delay_steps is None
+
+    with pytest.raises(ValueError):
+        policy.set_rtc_observed_delay(-1)
+
+
+def test_rtc_requery_interval_is_owned_by_strands_not_caller() -> None:
+    """An RTC policy is re-queried at ``execution_horizon`` regardless of caller hint.
+
+    strands owns the re-query interval (the divergence from delegating it to an
+    inference engine). A caller-supplied ``action_horizon`` cannot stretch or shrink
+    an RTC policy's interval - that would leave the prev-chunk tail empty and degrade
+    RTC to open-loop replay.
+    """
+    rtc = _FakeRtcPolicy(execution_horizon=10, actions_per_step=50)
+    assert resolve_chunk_length(rtc, action_horizon=1) == 10
+    assert resolve_chunk_length(rtc, action_horizon=999) == 10


### PR DESCRIPTION
## Problem

LeRobot grew a `rollout/` deployment engine (`src/lerobot/rollout/`) with two polymorphic config families: `RolloutStrategyConfig` session managers (`base`, `sentry`, `highlight`, `dagger`, `episodic`) and `InferenceEngineConfig` action backends (`sync`, `rtc`). strands-robots does not mirror this engine wholesale, and the reasons were undocumented - leaving it ambiguous whether the gap is a defect or a deliberate architectural boundary. In particular strands reimplements inference-time chunking (RTC) independently, which looks like duplication unless the determinism rationale is written down.

## Decision

The divergence is intentional. This PR documents it and pins it with a guard test.

| LeRobot type | strands status | equivalent |
|---|---|---|
| strategy `dagger` | adopted | `lerobot_teleoperate` tool `action="dagger"` drives `lerobot-rollout --strategy.type=dagger` as a subprocess (HITL correction on hardware) |
| strategy `base` | not adopted | autonomous no-record rollout = `run_policy()` without a recorder |
| strategy `episodic` | not adopted | episode-oriented record = `run_policy(n_episodes=N)` + `DatasetRecorder` (or teleop tool driving `lerobot-record`) |
| strategy `sentry` | not adopted | 24/7 size-rotated autonomous recording; interactive hardware deployment-engine feature with no sim/agent home |
| strategy `highlight` | not adopted | ring-buffer on-demand keypress save; interactive hardware-only |
| engine `sync` | covered | synchronous `PolicyRunner` path (`async_rtc=False`): one policy call per control tick |
| engine `rtc` | divergent loop driver | strands adopts LeRobot's RTC *algorithm* at the policy layer but drives the re-query loop itself by integer step count |

### Why the RTC loop driver diverges

strands does not reimplement RTC's math: `LerobotLocalPolicy` loads LeRobot's own `RTCConfig` and calls `predict_action_chunk(..., execution_horizon=...)` for the seam blending. The divergence is purely in *who drives the re-query loop*. LeRobot's `RTCInferenceEngine` runs inference in a background thread and swaps chunks off a wall-clock `queue_threshold`, deriving the seam offset from measured latency - non-deterministic w.r.t. control-step count. strands re-queries at exactly `policy.execution_horizon` (the single rule in `resolve_chunk_length`) and feeds the seam offset as a counted integer via `set_rtc_observed_delay` (0 in the paused-world sync loop; the still-pending step count in the async overlap). This keeps runner-driven eval bit-reproducible across fixed-seed episodes. Bridging LeRobot's wall-clock engine into the sim/eval loop would regress that guarantee.

## Changes

- `AGENTS.md`: new "LeRobot rollout subsystem - intentional divergence" section with the 7-type mapping and the RTC determinism rationale.
- `docs/policies/lerobot-local.md`: "Relationship to LeRobot's rollout subsystem" subsection under RTC.
- `docs/recording.md`: pointer to the divergence note for the recording strategies.
- `tests/policies/test_lerobot_rollout_divergence.py`: guard test pinning the decision.

## Tests

`tests/policies/test_lerobot_rollout_divergence.py` (3 tests, all green) pins:

1. No module in the strands inference path (`policies/`, `simulation/`) *imports* LeRobot's rollout engine (`lerobot.rollout.*`, `InferenceEngineConfig`, `RTCInferenceEngine`, ...). A subprocess CLI invocation of `lerobot-rollout` (a string, not an import) stays allowed - that is how `dagger` is adopted. Fails if a future change bridges the engine into the inference path without re-reading the determinism rationale.
2. `set_rtc_observed_delay` is a deterministic non-negative integer step count (accepts 0/7, clears on `None`, rejects negatives) - the determinism contract LeRobot's wall-clock engine cannot provide.
3. `resolve_chunk_length` for an RTC policy returns `execution_horizon` regardless of caller `action_horizon` - strands owns the re-query interval.

```
$ python -m pytest tests/policies/test_lerobot_rollout_divergence.py tests/policies/test_chunked_policy_contract.py -q
21 passed in 0.24s
```

`hatch run lint` clean (Success: no issues found in 529 source files). Docs + test only, ASCII-only, no host paths, no behavior change.