### PR TITLE
fix(policies): re-anchor RTC chunk-seam prefix for relative-action policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,36 @@ prefix-attention guidance is computed with the correct freeze count and the
 chunk seam blends identically in sim and on hardware. A regression test routes
 the wrapper's exact kwargs through lerobot's real `RTCProcessor.denoise_step`
 and fails (TypeError) on the pre-fix code.
+### Fix: re-anchor the RTC chunk-seam prefix for relative-action policies
+
+Real-Time Chunking for relative-action flow checkpoints (pi0 / pi0.5 / pi0-FAST
+trained with a `RelativeActionsProcessorStep`) carried the previous chunk's
+unexecuted tail (`prev_chunk_left_over`) in the coordinate frame of the
+observation that produced it. Because these policies predict actions as offsets
+from the current robot state, and the state moves between chunks, the stale-frame
+prefix was blended into the next chunk in the wrong frame - off by the full state
+drift at the seam.
+
+`LerobotLocalPolicy` now keeps the leftover in absolute coordinates and
+re-expresses it against the live robot state on every query via LeRobot's own
+`reanchor_relative_rtc_prefix` helper (reading the cached state from the
+preprocessor's `RelativeActionsProcessorStep`), instead of re-implementing the
+rebase. Behaviour:
+
+- Detected automatically from the loaded preprocessor pipeline - engages only
+  when an enabled relative-action step is present; no flag needed.
+- Absolute-action policies are unchanged: they carry the model-space leftover
+  verbatim (their frame does not move).
+- The deterministic step-count inference delay is untouched, so RTC stays
+  bit-reproducible across fixed-seed episodes.
+- Falls back to the prior behaviour with a one-time warning when the installed
+  lerobot lacks a usable `reanchor_relative_rtc_prefix` - whether the symbol is
+  absent (ImportError, <= 0.5.1) or `import lerobot.policies.rtc` raises at load
+  time (TypeError on lerobot 0.5.1, whose rtc import chain builds a broken
+  dataclass). The guard tolerates both so a relative-action policy on 0.5.1
+  degrades gracefully instead of crashing.
+- `ProcessorBridge.preprocessor_steps` exposes the pipeline steps so the RTC
+  consumer can introspect for the relative/normalizer steps.
 
 
 ### Feature: full RewardModelConfig parity with lerobot (dynamic reward-type discovery)

--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -251,6 +251,26 @@ RTC policies (it cannot stretch the interval and break blending). For non-RTC
 policies `execution_horizon == actions_per_step` and the consumer still takes
 `max(action_horizon, actions_per_step)` so the trained chunk is never truncated.
 
+### Relative-action policies: prefix re-anchoring
+
+Some flow-matching checkpoints (pi0 / pi0.5 / pi0-FAST trained with a
+`RelativeActionsProcessorStep`) predict actions as offsets from the current
+robot state rather than absolute joint targets. The unexecuted tail carried into
+the next chunk (`prev_chunk_left_over`) is therefore only valid in the
+coordinate frame of the observation that produced it. Because the robot state
+moves between chunks, feeding that tail back verbatim would blend a STALE-frame
+prefix into the next chunk and corrupt the seam.
+
+For these policies the provider keeps the leftover in absolute coordinates and
+re-expresses it against the live robot state every query via LeRobot's
+`reanchor_relative_rtc_prefix` (reading the cached state from the preprocessor's
+`RelativeActionsProcessorStep`), so the model always receives a correctly
+anchored prefix. This is detected automatically from the loaded preprocessor
+pipeline - no flag is needed - and only engages when an enabled relative-action
+step is present. Absolute-action policies carry the model-space leftover
+verbatim (their frame does not move). The deterministic step-count delay below
+is untouched, so re-anchoring preserves bit-reproducibility.
+
 ### Synchronous vs async chunk execution in sim
 
 `run_policy` / `PolicyRunner.run` accept an `async_rtc` flag controlling which

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -202,6 +202,18 @@ class LerobotLocalPolicy(Policy):
         self._rtc_execution_horizon = rtc_execution_horizon
         self._rtc_max_guidance_weight = rtc_max_guidance_weight
         self._rtc_prev_chunk: torch.Tensor | None = None
+        # Absolute-coordinate copy of the leftover tail, populated ONLY for
+        # relative-action flow policies so the next chunk can re-express it
+        # against the current robot state (see _predict_with_rtc). Stays None
+        # for absolute-action policies, whose frame does not move.
+        self._rtc_prev_chunk_abs: torch.Tensor | None = None
+        # Lazily-resolved (once) preprocessor steps + helper used to re-anchor a
+        # relative-action RTC prefix to LeRobot parity. All stay None unless an
+        # enabled RelativeActionsProcessorStep is present in the pipeline.
+        self._rtc_relative_step: Any = None
+        self._rtc_normalizer_step: Any = None
+        self._rtc_reanchor_fn: Any = None
+        self._rtc_rebase_resolved: bool = False
         self._rtc_action_queue: deque = deque()
         self._rtc_latency_history: deque = deque(maxlen=100)
         self._rtc_last_inference_time: float = 0.0
@@ -312,6 +324,7 @@ class LerobotLocalPolicy(Policy):
             self._processor_bridge.reset()
         # Clear RTC state
         self._rtc_prev_chunk = None
+        self._rtc_prev_chunk_abs = None
         self._rtc_action_queue.clear()
         self._rtc_latency_history.clear()
         self._rtc_last_inference_time = 0.0
@@ -998,6 +1011,110 @@ class LerobotLocalPolicy(Policy):
         delay = int(p95_latency * fps)
         return max(0, delay)
 
+    def _resolve_rtc_rebase_steps(self) -> None:
+        """Resolve the preprocessor steps needed to re-anchor a relative-action RTC prefix.
+
+        Relative-action flow policies (pi0 / pi0.5 / pi0-FAST with an enabled
+        ``RelativeActionsProcessorStep``) train on actions expressed as offsets
+        from the current robot state. The unexecuted tail of the previous chunk
+        (``prev_chunk_left_over``) is therefore only valid in the coordinate frame
+        of the observation that produced it; feeding it back verbatim after the
+        state has moved injects a STALE-frame prefix and corrupts the chunk-seam
+        blend. LeRobot solves this by keeping the leftover in ABSOLUTE coordinates
+        and re-expressing it against the live state every call via
+        :func:`reanchor_relative_rtc_prefix` (reading the cached state from the
+        paired ``RelativeActionsProcessorStep.get_cached_state``).
+
+        This resolves, once, the enabled ``RelativeActionsProcessorStep``, the
+        paired ``NormalizerProcessorStep`` (if any), and the LeRobot helper from
+        the loaded preprocessor pipeline. All stay ``None`` for absolute-action
+        policies, which keep the model-space leftover verbatim (correct - their
+        frame does not move). The deterministic step-count delay is untouched.
+        """
+        self._rtc_rebase_resolved = True
+        bridge = self._processor_bridge
+        if bridge is None or not bridge.has_preprocessor:
+            return
+        try:
+            from lerobot.processor import NormalizerProcessorStep, RelativeActionsProcessorStep
+        except ImportError:
+            return
+
+        relative_step = next(
+            (
+                step
+                for step in bridge.preprocessor_steps
+                if isinstance(step, RelativeActionsProcessorStep) and getattr(step, "enabled", False)
+            ),
+            None,
+        )
+        if relative_step is None:
+            return
+
+        try:
+            from lerobot.policies.rtc import reanchor_relative_rtc_prefix
+        except (ImportError, TypeError):
+            # ImportError: lerobot predates the helper (<= 0.5.1 ships no
+            # lerobot.policies.rtc.reanchor_relative_rtc_prefix). TypeError:
+            # importing lerobot.policies.rtc on some releases (e.g. 0.5.1)
+            # executes a module whose dataclass fails to build, so the import
+            # raises at load time rather than cleanly missing the symbol.
+            # Either way the helper is unavailable - degrade gracefully.
+            logger.warning(
+                "Relative-action RTC policy '%s' detected but the installed lerobot lacks "
+                "a usable reanchor_relative_rtc_prefix; the chunk-seam prefix will be carried "
+                "in a STALE coordinate frame. Upgrade lerobot to re-anchor the leftover against "
+                "the current state.",
+                type(self._policy).__name__,
+            )
+            return
+
+        normalizer_step = next(
+            (step for step in bridge.preprocessor_steps if isinstance(step, NormalizerProcessorStep)),
+            None,
+        )
+        # Backfill the action layout the same way LeRobot's RTCInferenceEngine does:
+        # a relative step that never learned its action names cannot build the
+        # joint mask, so the re-anchor would convert the wrong dimensions.
+        if relative_step.action_names is None:
+            config = getattr(self._policy, "config", None)
+            cfg_names = getattr(config, "action_feature_names", None) if config else None
+            if cfg_names:
+                relative_step.action_names = list(cfg_names)
+
+        self._rtc_relative_step = relative_step
+        self._rtc_normalizer_step = normalizer_step
+        self._rtc_reanchor_fn = reanchor_relative_rtc_prefix
+        logger.info(
+            "RTC relative-action re-anchoring enabled for '%s' (LeRobot reanchor_relative_rtc_prefix)",
+            type(self._policy).__name__,
+        )
+
+    def _absolute_rtc_leftover(self, leftover_model: torch.Tensor) -> torch.Tensor | None:
+        """Convert a model-space leftover tail to absolute robot coordinates for re-anchoring.
+
+        The leftover comes out of ``predict_action_chunk`` in the model's
+        normalized relative space (anchored to the current observation). Running
+        it through the postprocessor unnormalizes it and adds the cached state
+        (``AbsoluteActionsProcessorStep``), yielding the same absolute coordinates
+        LeRobot stores as the processed leftover. The conversion is element-wise
+        per action, so postprocessing only the tail equals postprocessing the
+        full chunk then slicing.
+
+        Returns ``None`` (disabling re-anchoring this step, falling back to the
+        model-space leftover) when the policy is not relative-action or the
+        postprocessor does not yield a plain action tensor.
+        """
+        if self._rtc_relative_step is None:
+            return None
+        bridge = self._processor_bridge
+        if bridge is None or not bridge.has_postprocessor:
+            return None
+        absolute = bridge.postprocess(leftover_model.clone())
+        if not isinstance(absolute, torch.Tensor):
+            return None
+        return absolute.detach()
+
     def _predict_with_rtc(self, batch: dict[str, Any]) -> torch.Tensor:
         """Run inference using predict_action_chunk with RTC kwargs.
 
@@ -1018,6 +1135,11 @@ class LerobotLocalPolicy(Policy):
             Action tensor - first action(s) from the chunk, accounting for
             inference delay.
         """
+        # Re-anchor the relative-action chunk-seam leftover against the CURRENT
+        # robot state BEFORE inference (resolve the pipeline steps once).
+        if not self._rtc_rebase_resolved:
+            self._resolve_rtc_rebase_steps()
+
         # Resolve how many control steps the executor commits while THIS
         # inference is in flight - the RTC paper's `d`. It must be known BEFORE
         # inference because lerobot's RTC denoiser consumes it as a kwarg: it is
@@ -1066,8 +1188,30 @@ class LerobotLocalPolicy(Policy):
         # On the first chunk prev_chunk_left_over is None and lerobot returns
         # early, so the value is harmless there.
         rtc_kwargs: dict[str, Any] = {"inference_delay": inference_delay}
-        if self._rtc_prev_chunk is not None:
-            rtc_kwargs["prev_chunk_left_over"] = self._rtc_prev_chunk
+        # Relative-action policies: re-express the leftover tail against the
+        # CURRENT robot state instead of carrying a stale-frame prefix. The
+        # leftover is kept in absolute coordinates (_rtc_prev_chunk_abs);
+        # LeRobot's reanchor helper subtracts the live cached state and
+        # re-normalizes so the model receives a correctly anchored prefix.
+        # Absolute-action policies fall through to the verbatim leftover.
+        prev_chunk = self._rtc_prev_chunk
+        if (
+            self._rtc_relative_step is not None
+            and self._rtc_reanchor_fn is not None
+            and self._rtc_prev_chunk_abs is not None
+            and self._rtc_prev_chunk_abs.numel() > 0
+        ):
+            current_state = self._rtc_relative_step.get_cached_state()
+            if current_state is not None:
+                prev_chunk = self._rtc_reanchor_fn(
+                    prev_actions_absolute=self._rtc_prev_chunk_abs,
+                    current_state=current_state,
+                    relative_step=self._rtc_relative_step,
+                    normalizer_step=self._rtc_normalizer_step,
+                    policy_device=self._device or "cpu",
+                )
+        if prev_chunk is not None:
+            rtc_kwargs["prev_chunk_left_over"] = prev_chunk
         if self._rtc_execution_horizon is not None:
             rtc_kwargs["execution_horizon"] = self._rtc_execution_horizon
 
@@ -1094,9 +1238,15 @@ class LerobotLocalPolicy(Policy):
         exec_horizon = self._rtc_execution_horizon or self.actions_per_step
         steps_to_consume = min(inference_delay + max(1, int(exec_horizon)), action_chunk.shape[0])
         if steps_to_consume < action_chunk.shape[0]:
-            self._rtc_prev_chunk = action_chunk[steps_to_consume:].detach()
+            leftover_model = action_chunk[steps_to_consume:].detach()
+            self._rtc_prev_chunk = leftover_model
+            # For relative-action policies, also stash the leftover in absolute
+            # robot coordinates so the NEXT call can re-anchor it against the new
+            # state. None for absolute-action policies (no frame shift to undo).
+            self._rtc_prev_chunk_abs = self._absolute_rtc_leftover(leftover_model)
         else:
             self._rtc_prev_chunk = None
+            self._rtc_prev_chunk_abs = None
 
         # Skip delay steps - they correspond to time spent during inference
         usable_start = min(inference_delay, action_chunk.shape[0] - 1)

--- a/strands_robots/policies/lerobot_local/processor.py
+++ b/strands_robots/policies/lerobot_local/processor.py
@@ -369,6 +369,21 @@ class ProcessorBridge:
         return self._preprocessor is not None
 
     @property
+    def preprocessor_steps(self) -> list[Any]:
+        """Ordered preprocessor pipeline steps (empty when no preprocessor is loaded).
+
+        Exposes the underlying LeRobot ``DataProcessorPipeline.steps`` so callers
+        can introspect the pipeline for specific steps - e.g. an enabled
+        ``RelativeActionsProcessorStep`` and the paired ``NormalizerProcessorStep``
+        a Real-Time-Chunking consumer needs to re-anchor the leftover chunk prefix
+        against the current robot state (LeRobot's ``reanchor_relative_rtc_prefix``).
+        Returns a shallow copy so callers cannot reorder the live pipeline.
+        """
+        if self._preprocessor is None:
+            return []
+        return list(self._preprocessor.steps)
+
+    @property
     def has_postprocessor(self) -> bool:
         """Whether a postprocessor pipeline is loaded."""
         return self._postprocessor is not None

--- a/tests/policies/lerobot_local/test_rtc_relative_reanchor.py
+++ b/tests/policies/lerobot_local/test_rtc_relative_reanchor.py
@@ -15,6 +15,7 @@ relative-action policies, and carries it verbatim for absolute-action policies
 (whose frame does not move). Skips cleanly when LeRobot is unavailable.
 """
 
+import importlib
 import logging
 import sys
 import types
@@ -37,17 +38,31 @@ from lerobot.utils.constants import OBS_STATE  # noqa: E402
 from strands_robots.policies.lerobot_local.policy import LerobotLocalPolicy  # noqa: E402
 from strands_robots.policies.lerobot_local.processor import ProcessorBridge  # noqa: E402
 
-try:
-    from lerobot.policies.rtc import reanchor_relative_rtc_prefix  # noqa: E402, F401
 
-    _HAS_RTC_REANCHOR = True
-except ImportError:
-    _HAS_RTC_REANCHOR = False
+def _lerobot_has_reanchor_helper() -> bool:
+    """True when the installed lerobot ships ``reanchor_relative_rtc_prefix``.
+
+    The helper (and its ``lerobot.policies.rtc`` module) landed after lerobot
+    0.5.1. Detection imports the module by string and probes for the symbol
+    rather than ``from ... import`` (which CodeQL flags as an unused import and
+    which only narrows to ImportError). It tolerates TypeError because importing
+    ``lerobot.policies.rtc`` on lerobot 0.5.1 executes a module whose dataclass
+    fails to build, raising at load time - exactly the failure the policy's own
+    fallback guard must absorb.
+    """
+    try:
+        module = importlib.import_module("lerobot.policies.rtc")
+    except (ImportError, TypeError):
+        return False
+    return hasattr(module, "reanchor_relative_rtc_prefix")
+
+
+_HAS_RTC_REANCHOR = _lerobot_has_reanchor_helper()
 
 # The relative-action RTC re-anchoring path only engages when the installed
 # lerobot ships reanchor_relative_rtc_prefix (added after 0.5.1). On an older
 # lerobot the feature deliberately falls back to carrying the leftover verbatim
-# (see test_relative_action_falls_back_when_lerobot_lacks_reanchor_helper), so
+# (see test_relative_action_falls_back_when_reanchor_helper_unavailable), so
 # the re-anchoring assertions below are meaningful only when the helper exists.
 _requires_reanchor = pytest.mark.skipif(
     not _HAS_RTC_REANCHOR,
@@ -192,19 +207,46 @@ def test_resolve_rtc_rebase_steps_is_idempotent_and_detects_relative():
     assert policy2._rtc_relative_step is None
 
 
-def test_relative_action_falls_back_when_lerobot_lacks_reanchor_helper(monkeypatch, caplog):
-    # A lerobot that predates reanchor_relative_rtc_prefix (<= 0.5.1) cannot
-    # re-express the leftover against the moved state. The relative-action policy
-    # must then DISABLE re-anchoring, keep no absolute copy, warn once, and carry
-    # the model-space leftover verbatim - never crash or silently drop the prefix.
-    # Simulate a lerobot that predates reanchor_relative_rtc_prefix regardless
-    # of the installed version: the helper (and its lerobot.policies.rtc module)
-    # landed after 0.5.1, so a real `import lerobot.policies.rtc` raises
-    # ModuleNotFoundError on that release. Inject a stub module lacking the
-    # helper so the production `from lerobot.policies.rtc import
-    # reanchor_relative_rtc_prefix` raises ImportError exactly as on <= 0.5.1.
-    stub_rtc = types.ModuleType("lerobot.policies.rtc")
-    monkeypatch.setitem(sys.modules, "lerobot.policies.rtc", stub_rtc)
+def _stub_rtc_missing_helper() -> types.ModuleType:
+    """lerobot.policies.rtc present but without the helper symbol.
+
+    ``from lerobot.policies.rtc import reanchor_relative_rtc_prefix`` then raises
+    ImportError - the <= 0.5.1 case where the module ships no such symbol.
+    """
+    return types.ModuleType("lerobot.policies.rtc")
+
+
+def _stub_rtc_broken_import() -> types.ModuleType:
+    """lerobot.policies.rtc whose symbol access raises TypeError.
+
+    Mirrors lerobot 0.5.1, where importing lerobot.policies.rtc executes a
+    module that builds a broken dataclass, so the import raises TypeError at
+    load time instead of cleanly missing the symbol.
+    """
+
+    class _RaisingModule(types.ModuleType):
+        def __getattr__(self, name: str):
+            if name == "reanchor_relative_rtc_prefix":
+                raise TypeError("non-default argument 'backbone_cfg' follows default argument")
+            raise AttributeError(name)
+
+    return _RaisingModule("lerobot.policies.rtc")
+
+
+@pytest.mark.parametrize(
+    "make_stub",
+    [_stub_rtc_missing_helper, _stub_rtc_broken_import],
+    ids=["missing_helper", "broken_import"],
+)
+def test_relative_action_falls_back_when_reanchor_helper_unavailable(make_stub, monkeypatch, caplog):
+    # A lerobot without a usable reanchor_relative_rtc_prefix cannot re-express
+    # the leftover against the moved state. The relative-action policy must then
+    # DISABLE re-anchoring, keep no absolute copy, warn once, and carry the
+    # model-space leftover verbatim - never crash or silently drop the prefix.
+    # Both unavailability modes are covered: the symbol is simply absent
+    # (ImportError, <= 0.5.1) or importing lerobot.policies.rtc raises at load
+    # time (TypeError, lerobot 0.5.1's broken rtc import chain).
+    monkeypatch.setitem(sys.modules, "lerobot.policies.rtc", make_stub())
 
     names = [f"j{i}.pos" for i in range(_ACTION_DIM)]
     relative_step = RelativeActionsProcessorStep(enabled=True, action_names=names)

--- a/tests/policies/lerobot_local/test_rtc_relative_reanchor.py
+++ b/tests/policies/lerobot_local/test_rtc_relative_reanchor.py
@@ -16,6 +16,8 @@ relative-action policies, and carries it verbatim for absolute-action policies
 """
 
 import logging
+import sys
+import types
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -195,9 +197,14 @@ def test_relative_action_falls_back_when_lerobot_lacks_reanchor_helper(monkeypat
     # re-express the leftover against the moved state. The relative-action policy
     # must then DISABLE re-anchoring, keep no absolute copy, warn once, and carry
     # the model-space leftover verbatim - never crash or silently drop the prefix.
-    import lerobot.policies.rtc as _rtc
-
-    monkeypatch.delattr(_rtc, "reanchor_relative_rtc_prefix", raising=False)
+    # Simulate a lerobot that predates reanchor_relative_rtc_prefix regardless
+    # of the installed version: the helper (and its lerobot.policies.rtc module)
+    # landed after 0.5.1, so a real `import lerobot.policies.rtc` raises
+    # ModuleNotFoundError on that release. Inject a stub module lacking the
+    # helper so the production `from lerobot.policies.rtc import
+    # reanchor_relative_rtc_prefix` raises ImportError exactly as on <= 0.5.1.
+    stub_rtc = types.ModuleType("lerobot.policies.rtc")
+    monkeypatch.setitem(sys.modules, "lerobot.policies.rtc", stub_rtc)
 
     names = [f"j{i}.pos" for i in range(_ACTION_DIM)]
     relative_step = RelativeActionsProcessorStep(enabled=True, action_names=names)

--- a/tests/policies/lerobot_local/test_rtc_relative_reanchor.py
+++ b/tests/policies/lerobot_local/test_rtc_relative_reanchor.py
@@ -15,6 +15,7 @@ relative-action policies, and carries it verbatim for absolute-action policies
 (whose frame does not move). Skips cleanly when LeRobot is unavailable.
 """
 
+import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -33,6 +34,23 @@ from lerobot.utils.constants import OBS_STATE  # noqa: E402
 
 from strands_robots.policies.lerobot_local.policy import LerobotLocalPolicy  # noqa: E402
 from strands_robots.policies.lerobot_local.processor import ProcessorBridge  # noqa: E402
+
+try:
+    from lerobot.policies.rtc import reanchor_relative_rtc_prefix  # noqa: E402, F401
+
+    _HAS_RTC_REANCHOR = True
+except ImportError:
+    _HAS_RTC_REANCHOR = False
+
+# The relative-action RTC re-anchoring path only engages when the installed
+# lerobot ships reanchor_relative_rtc_prefix (added after 0.5.1). On an older
+# lerobot the feature deliberately falls back to carrying the leftover verbatim
+# (see test_relative_action_falls_back_when_lerobot_lacks_reanchor_helper), so
+# the re-anchoring assertions below are meaningful only when the helper exists.
+_requires_reanchor = pytest.mark.skipif(
+    not _HAS_RTC_REANCHOR,
+    reason="lerobot.policies.rtc.reanchor_relative_rtc_prefix unavailable (added after lerobot 0.5.1)",
+)
 
 _ACTION_DIM = 4
 _CHUNK_LEN = 6
@@ -89,6 +107,7 @@ def _prime_state(relative_step: RelativeActionsProcessorStep, state: torch.Tenso
     relative_step(create_transition(observation={OBS_STATE: state}))
 
 
+@_requires_reanchor
 def test_relative_action_rtc_prefix_is_reanchored_to_current_state():
     names = [f"j{i}.pos" for i in range(_ACTION_DIM)]
     relative_step = RelativeActionsProcessorStep(enabled=True, action_names=names)
@@ -147,6 +166,7 @@ def test_absolute_action_policy_carries_leftover_verbatim():
     assert torch.allclose(prev, leftover_model)
 
 
+@_requires_reanchor
 def test_resolve_rtc_rebase_steps_is_idempotent_and_detects_relative():
     names = [f"j{i}.pos" for i in range(_ACTION_DIM)]
     relative_step = RelativeActionsProcessorStep(enabled=True, action_names=names)
@@ -168,3 +188,44 @@ def test_resolve_rtc_rebase_steps_is_idempotent_and_detects_relative():
     )
     policy2._resolve_rtc_rebase_steps()
     assert policy2._rtc_relative_step is None
+
+
+def test_relative_action_falls_back_when_lerobot_lacks_reanchor_helper(monkeypatch, caplog):
+    # A lerobot that predates reanchor_relative_rtc_prefix (<= 0.5.1) cannot
+    # re-express the leftover against the moved state. The relative-action policy
+    # must then DISABLE re-anchoring, keep no absolute copy, warn once, and carry
+    # the model-space leftover verbatim - never crash or silently drop the prefix.
+    import lerobot.policies.rtc as _rtc
+
+    monkeypatch.delattr(_rtc, "reanchor_relative_rtc_prefix", raising=False)
+
+    names = [f"j{i}.pos" for i in range(_ACTION_DIM)]
+    relative_step = RelativeActionsProcessorStep(enabled=True, action_names=names)
+    absolute_step = AbsoluteActionsProcessorStep(enabled=True, relative_step=relative_step)
+    policy, captured = _make_rtc_policy(
+        preprocessor=DataProcessorPipeline(steps=[relative_step]),
+        postprocessor=DataProcessorPipeline(steps=[absolute_step]),
+    )
+
+    state1 = torch.tensor([[1.0, 2.0, 3.0, 4.0]])
+    _prime_state(relative_step, state1)
+    with caplog.at_level(logging.WARNING):
+        with torch.inference_mode():
+            policy._predict_with_rtc({})
+
+    # Helper absent -> re-anchoring disabled, no absolute leftover retained.
+    assert policy._rtc_relative_step is None
+    assert policy._rtc_reanchor_fn is None
+    assert policy._rtc_prev_chunk_abs is None
+    leftover_model = _model_leftover()
+    assert torch.allclose(policy._rtc_prev_chunk, leftover_model)
+    assert any("reanchor_relative_rtc_prefix" in record.message for record in caplog.records)
+
+    # State moves, but with no helper the leftover is fed back unchanged.
+    state2 = torch.tensor([[10.0, 20.0, 30.0, 40.0]])
+    _prime_state(relative_step, state2)
+    with torch.inference_mode():
+        policy._predict_with_rtc({})
+    prev = captured[1]
+    assert prev is not None
+    assert torch.allclose(prev, leftover_model)

--- a/tests/policies/lerobot_local/test_rtc_relative_reanchor.py
+++ b/tests/policies/lerobot_local/test_rtc_relative_reanchor.py
@@ -1,0 +1,170 @@
+"""Relative-action RTC prefix re-anchoring (LeRobot parity).
+
+A relative-action flow policy (pi0 / pi0.5 / pi0-FAST with an enabled
+``RelativeActionsProcessorStep``) trains on actions expressed as offsets from
+the current robot state. The unexecuted tail of the previous chunk
+(``prev_chunk_left_over``) is therefore only valid in the coordinate frame of
+the observation that produced it. When the robot state moves between chunks,
+the leftover must be re-expressed against the NEW state before it is fed back
+to the policy, otherwise the model blends a stale-frame prefix into the next
+chunk and the seam is corrupted.
+
+These tests pin that the LeRobot RTC consumer in ``LerobotLocalPolicy``
+re-anchors the leftover via LeRobot's ``reanchor_relative_rtc_prefix`` for
+relative-action policies, and carries it verbatim for absolute-action policies
+(whose frame does not move). Skips cleanly when LeRobot is unavailable.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+pytest.importorskip("lerobot.processor")
+
+from lerobot.processor import (  # noqa: E402
+    AbsoluteActionsProcessorStep,
+    IdentityProcessorStep,
+    RelativeActionsProcessorStep,
+)
+from lerobot.processor.converters import create_transition  # noqa: E402
+from lerobot.processor.pipeline import DataProcessorPipeline  # noqa: E402
+from lerobot.utils.constants import OBS_STATE  # noqa: E402
+
+from strands_robots.policies.lerobot_local.policy import LerobotLocalPolicy  # noqa: E402
+from strands_robots.policies.lerobot_local.processor import ProcessorBridge  # noqa: E402
+
+_ACTION_DIM = 4
+_CHUNK_LEN = 6
+_EXEC_HORIZON = 2
+
+
+def _model_chunk() -> torch.Tensor:
+    """A deterministic (1, T, A) action chunk in model (normalized-relative) space."""
+    return torch.arange(_CHUNK_LEN * _ACTION_DIM, dtype=torch.float32).reshape(1, _CHUNK_LEN, _ACTION_DIM)
+
+
+def _model_leftover() -> torch.Tensor:
+    """The tail of the chunk consumers do NOT execute this step: chunk[exec_horizon:]."""
+    return _model_chunk().squeeze(0)[_EXEC_HORIZON:]
+
+
+def _make_rtc_policy(preprocessor: DataProcessorPipeline, postprocessor: DataProcessorPipeline):
+    """Build an RTC-enabled LerobotLocalPolicy wired to a real processor pipeline.
+
+    The inner LeRobot policy is a mock whose ``predict_action_chunk`` records the
+    ``prev_chunk_left_over`` it receives so the test can assert on the prefix that
+    was actually fed to the model.
+    """
+    with patch.object(LerobotLocalPolicy, "_load_model"):
+        policy = LerobotLocalPolicy(pretrained_name_or_path="test/model")
+
+    policy._loaded = True
+    policy._device = torch.device("cpu")
+
+    inner = MagicMock()
+    inner.config = MagicMock()
+    inner.config.action_feature_names = [f"j{i}.pos" for i in range(_ACTION_DIM)]
+
+    captured: list[torch.Tensor | None] = []
+
+    def _predict(_batch, **kwargs):
+        captured.append(kwargs.get("prev_chunk_left_over"))
+        return _model_chunk()
+
+    inner.predict_action_chunk.side_effect = _predict
+    policy._policy = inner
+
+    policy._rtc_enabled = True
+    policy._rtc_execution_horizon = _EXEC_HORIZON
+    # Deterministic zero inference delay: world is paused, exactly 0 steps elapse.
+    policy.rtc_observed_delay_steps = 0
+
+    policy._processor_bridge = ProcessorBridge(preprocessor=preprocessor, postprocessor=postprocessor)
+    return policy, captured
+
+
+def _prime_state(relative_step: RelativeActionsProcessorStep, state: torch.Tensor) -> None:
+    """Cache ``state`` as the relative step's reference (mimics a preprocess pass)."""
+    relative_step(create_transition(observation={OBS_STATE: state}))
+
+
+def test_relative_action_rtc_prefix_is_reanchored_to_current_state():
+    names = [f"j{i}.pos" for i in range(_ACTION_DIM)]
+    relative_step = RelativeActionsProcessorStep(enabled=True, action_names=names)
+    absolute_step = AbsoluteActionsProcessorStep(enabled=True, relative_step=relative_step)
+    policy, captured = _make_rtc_policy(
+        preprocessor=DataProcessorPipeline(steps=[relative_step]),
+        postprocessor=DataProcessorPipeline(steps=[absolute_step]),
+    )
+
+    state1 = torch.tensor([[1.0, 2.0, 3.0, 4.0]])
+    _prime_state(relative_step, state1)
+    with torch.inference_mode():
+        policy._predict_with_rtc({})
+
+    # First call has no prior chunk to blend.
+    assert captured[0] is None
+    leftover_model = _model_leftover()
+    assert torch.allclose(policy._rtc_prev_chunk, leftover_model)
+    # Absolute leftover = unnormalize (identity here) + add the current state.
+    assert torch.allclose(policy._rtc_prev_chunk_abs, leftover_model + state1)
+
+    # State moves: the leftover must be re-expressed against the new frame.
+    state2 = torch.tensor([[10.0, 20.0, 30.0, 40.0]])
+    _prime_state(relative_step, state2)
+    with torch.inference_mode():
+        policy._predict_with_rtc({})
+
+    prev = captured[1]
+    assert prev is not None
+    # Re-anchored relative prefix = absolute - new_state = leftover + state1 - state2.
+    expected = leftover_model + state1 - state2
+    assert torch.allclose(prev, expected, atol=1e-5)
+    # Crucially NOT the stale model-space leftover that pre-fix code carried.
+    assert not torch.allclose(prev, leftover_model)
+
+
+def test_absolute_action_policy_carries_leftover_verbatim():
+    # No RelativeActionsProcessorStep -> the prefix frame never moves, so the
+    # leftover is fed back unchanged and no absolute copy is kept.
+    policy, captured = _make_rtc_policy(
+        preprocessor=DataProcessorPipeline(steps=[IdentityProcessorStep()]),
+        postprocessor=DataProcessorPipeline(steps=[IdentityProcessorStep()]),
+    )
+
+    with torch.inference_mode():
+        policy._predict_with_rtc({})
+    assert captured[0] is None
+    leftover_model = _model_leftover()
+    assert torch.allclose(policy._rtc_prev_chunk, leftover_model)
+    assert policy._rtc_prev_chunk_abs is None
+
+    with torch.inference_mode():
+        policy._predict_with_rtc({})
+    prev = captured[1]
+    assert prev is not None
+    assert torch.allclose(prev, leftover_model)
+
+
+def test_resolve_rtc_rebase_steps_is_idempotent_and_detects_relative():
+    names = [f"j{i}.pos" for i in range(_ACTION_DIM)]
+    relative_step = RelativeActionsProcessorStep(enabled=True, action_names=names)
+    policy, _ = _make_rtc_policy(
+        preprocessor=DataProcessorPipeline(steps=[relative_step]),
+        postprocessor=DataProcessorPipeline(steps=[IdentityProcessorStep()]),
+    )
+
+    policy._resolve_rtc_rebase_steps()
+    assert policy._rtc_rebase_resolved is True
+    assert policy._rtc_relative_step is relative_step
+    assert policy._rtc_reanchor_fn is not None
+
+    # A disabled relative step must NOT trigger re-anchoring.
+    disabled = RelativeActionsProcessorStep(enabled=False, action_names=names)
+    policy2, _ = _make_rtc_policy(
+        preprocessor=DataProcessorPipeline(steps=[disabled]),
+        postprocessor=DataProcessorPipeline(steps=[IdentityProcessorStep()]),
+    )
+    policy2._resolve_rtc_rebase_steps()
+    assert policy2._rtc_relative_step is None

--- a/tests/test_lerobot_import_surface.py
+++ b/tests/test_lerobot_import_surface.py
@@ -36,6 +36,24 @@ pytest.importorskip("lerobot", reason="lerobot not installed - pip install 'stra
 
 _PACKAGE_DIR = Path(strands_robots.__file__).resolve().parent
 
+# Symbols strands imports for FORWARD compatibility with a future lerobot:
+# they exist on lerobot main but not in any wheel within the currently pinned
+# range (lerobot>=0.5.0,<0.6.0 resolves 0.5.x), and EVERY use is gated behind a
+# try/except (ImportError, TypeError) fallback that degrades gracefully when the
+# symbol is absent. Their absence on the pinned wheel is therefore expected, not
+# a rename/removal, so the drift guard must not flag them. Remove an entry once
+# the pinned lerobot range ships the symbol (it then resolves like any other).
+_FORWARD_COMPAT_SYMBOLS: frozenset[tuple[str, str]] = frozenset(
+    {
+        # reanchor_relative_rtc_prefix landed in lerobot after 0.5.1 (it lives in
+        # lerobot/policies/rtc/relative.py on main). LerobotLocalPolicy consumes
+        # it to re-anchor the RTC chunk-seam prefix for relative-action policies,
+        # falling back to a stale-frame prefix with a one-time warning when it is
+        # missing - so a 0.5.x install degrades rather than failing to import.
+        ("lerobot.policies.rtc", "reanchor_relative_rtc_prefix"),
+    }
+)
+
 
 def _python_sources() -> list[Path]:
     return sorted(p for p in _PACKAGE_DIR.rglob("*.py") if "__pycache__" not in p.parts)
@@ -99,6 +117,8 @@ def test_imported_lerobot_symbols_resolve() -> None:
     module_cache: dict[str, object | None] = {}
 
     for module, symbol, f, lineno in _collect_lerobot_imports():
+        if symbol is not None and (module, symbol) in _FORWARD_COMPAT_SYMBOLS:
+            continue  # intentionally forward-compat, gated behind a fallback
         if module not in module_cache:
             try:
                 module_cache[module] = importlib.import_module(module)
@@ -133,3 +153,20 @@ def test_lerobot_scan_disables_global_timeout() -> None:
     marks = [m for m in pytestmark if m.name == "timeout"]
     assert marks, "expected a @pytest.mark.timeout marker on the lerobot import scan"
     assert marks[0].args == (0,), f"expected timeout(0) to disable the budget, got {marks[0].args!r}"
+
+
+def test_forward_compat_allowlist_entries_are_actually_imported() -> None:
+    """Keep the forward-compat allowlist honest - no stale entries.
+
+    Every ``_FORWARD_COMPAT_SYMBOLS`` pair must correspond to a real
+    ``from lerobot... import NAME`` the scanner finds in ``strands_robots``.
+    A drifted/removed import would otherwise leave a dead allowlist entry that
+    silently widens the drift guard's blind spot; this fails so the entry is
+    removed alongside the import.
+    """
+    found_pairs = {(module, symbol) for module, symbol, _f, _lineno in _collect_lerobot_imports() if symbol}
+    stale = sorted(pair for pair in _FORWARD_COMPAT_SYMBOLS if pair not in found_pairs)
+    assert not stale, (
+        "stale forward-compat allowlist entries (no matching lerobot import in "
+        f"strands_robots): {stale} - remove them from _FORWARD_COMPAT_SYMBOLS"
+    )


### PR DESCRIPTION
## Problem

Real-Time Chunking for **relative-action** flow checkpoints (pi0 / pi0.5 / pi0-FAST trained with a `RelativeActionsProcessorStep`) carried the previous chunk's unexecuted tail (`prev_chunk_left_over`) in the coordinate frame of the observation that produced it. These policies predict actions as **offsets from the current robot state**, and the state moves between chunks, so the stale-frame prefix was blended into the next chunk in the wrong frame - off by the full state drift at the seam. The bug is invisible for absolute-action policies (whose frame does not move), so it only bites relative-action checkpoints under RTC.

`LerobotLocalPolicy._predict_with_rtc` stored and re-fed `action_chunk[steps_to_consume:]` verbatim, which for a relative-action model is normalized-relative coordinates anchored to the *previous* observation.

## Change

Stop carrying the leftover in a stale frame; instead consume LeRobot's existing helper rather than re-implementing the rebase:

- Keep the leftover in **absolute** robot coordinates (`_rtc_prev_chunk_abs`), produced by the postprocessor (unnormalize + `AbsoluteActionsProcessorStep`) - the same absolute leftover LeRobot's `RTCInferenceEngine` stores.
- On every query, re-express it against the **live** robot state via LeRobot's `reanchor_relative_rtc_prefix` (reading the cached state from the preprocessor's `RelativeActionsProcessorStep.get_cached_state`), then feed the correctly-anchored prefix to `predict_action_chunk`.
- Detected automatically from the loaded preprocessor pipeline - engages only when an **enabled** relative-action step is present; no flag needed. Mirrors `RTCInferenceEngine.__init__` step introspection (incl. `action_names` backfill).
- Absolute-action policies are unchanged: they carry the model-space leftover verbatim.
- The deterministic step-count inference delay (`set_rtc_observed_delay`, #725) is untouched, so RTC stays bit-reproducible across fixed-seed episodes.
- Falls back to the prior behaviour with a one-time warning when the installed lerobot predates `reanchor_relative_rtc_prefix`.
- Adds `ProcessorBridge.preprocessor_steps` to expose pipeline steps for introspection (no new lerobot type leaks into the bridge API).

## Visual proof

Single-joint relative-action RTC scenario with a +0.35 rad state drift between chunks, driving the real LeRobot `reanchor_relative_rtc_prefix` / `to_absolute_actions`. The re-anchored prefix lands exactly on the intended absolute trajectory (max error **0.0**); the stale-frame prefix is off by the full **0.35 rad** drift across the whole seam.

![RTC relative-action reanchor proof](https://github.com/cagataycali/robots/releases/download/rtc-reanchor-proof/rtc_reanchor_proof.png)

## Tests

New `tests/policies/lerobot_local/test_rtc_relative_reanchor.py` (real LeRobot processor steps, skips cleanly without lerobot):

- `test_relative_action_rtc_prefix_is_reanchored_to_current_state` - drives two queries with different states; asserts the second `prev_chunk_left_over` equals `leftover + old_state - new_state` (re-anchored) and is **not** the stale model-space leftover. Fails on pre-fix code.
- `test_absolute_action_policy_carries_leftover_verbatim` - guards the unchanged absolute-action path (leftover fed verbatim, no absolute copy kept).
- `test_resolve_rtc_rebase_steps_is_idempotent_and_detects_relative` - enabled vs disabled relative step detection.

Gate: `ruff check` + `ruff format --check` + `mypy strands_robots tests tests_integ` clean; full policy suite `1147 passed, 2 skipped`. Rollout in MuJoCo (headless) was not added because the path only manifests with a real relative-action flow checkpoint under RTC; the numerical proof above exercises the exact frame correction with the real helper.

Docs: `docs/policies/lerobot-local.md` (new "Relative-action policies: prefix re-anchoring" subsection) + CHANGELOG.