### PR TITLE
fix(policies): forward inference_delay to lerobot RTC denoiser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: RTC inference now forwards `inference_delay` to lerobot's denoiser
+
+`LerobotLocalPolicy._predict_with_rtc` passed only `prev_chunk_left_over` and
+`execution_horizon` to lerobot's `predict_action_chunk`, omitting the
+`inference_delay` kwarg that the RTC denoiser (pi0, pi0.5, SmolVLA) requires. It
+is the `start` argument of `RTCProcessor.get_prefix_weights(start, end, total)`,
+which freezes the first `d` committed actions of the new chunk to the previous
+chunk's prefix and linearly blends `d..execution_horizon`. With it omitted the
+denoiser received `inference_delay=None`, and `min(None, end)` raised
+`TypeError: '<' not supported between instances of 'int' and 'NoneType'` the
+moment a previous-chunk prefix existed (the 2nd inference onward) - so a real
+flow-matching RTC policy crashed on its second chunk. The existing unit tests
+missed it because they mock `predict_action_chunk` with a static tensor that
+ignores its kwargs.
+
+The wrapper now resolves the delay (the deterministic count from
+`set_rtc_observed_delay`, else a wall-clock p95 estimate over PRIOR calls)
+BEFORE inference and forwards it as `inference_delay` on every call, so the
+prefix-attention guidance is computed with the correct freeze count and the
+chunk seam blends identically in sim and on hardware. A regression test routes
+the wrapper's exact kwargs through lerobot's real `RTCProcessor.denoise_step`
+and fails (TypeError) on the pre-fix code.
+
+
 ### Feature: full RewardModelConfig parity with lerobot (dynamic reward-type discovery)
 
 `LerobotTrainer` reward-model training (`TrainSpec.extra["reward_model"]`) now

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -1002,9 +1002,14 @@ class LerobotLocalPolicy(Policy):
         """Run inference using predict_action_chunk with RTC kwargs.
 
         This replaces select_action() for RTC-enabled policies. It:
-        1. Calls predict_action_chunk with prev_chunk_left_over and execution_horizon
-        2. Tracks inference latency for delay estimation
-        3. Stores the new chunk's leftover for the next call
+        1. Resolves the inference delay (RTC ``d``) BEFORE inference so it can be
+           forwarded to the denoiser, not just used to slice the result.
+        2. Calls predict_action_chunk with inference_delay + prev_chunk_left_over
+           + execution_horizon (lerobot's RTC denoiser requires inference_delay
+           as the get_prefix_weights ``start`` arg; omitting it sends None and
+           raises TypeError once a previous-chunk prefix exists).
+        3. Tracks inference latency for the wall-clock delay-estimate fallback.
+        4. Stores the new chunk's leftover for the next call.
 
         Args:
             batch: Observation batch tensors ready for the policy.
@@ -1013,37 +1018,23 @@ class LerobotLocalPolicy(Policy):
             Action tensor - first action(s) from the chunk, accounting for
             inference delay.
         """
-        inference_start = time.time()
-
-        # Build RTC kwargs for flow-matching denoiser
-        rtc_kwargs: dict[str, Any] = {}
-        if self._rtc_prev_chunk is not None:
-            rtc_kwargs["prev_chunk_left_over"] = self._rtc_prev_chunk
-        if self._rtc_execution_horizon is not None:
-            rtc_kwargs["execution_horizon"] = self._rtc_execution_horizon
-
-        # predict_action_chunk returns (batch, chunk_size, action_dim)
-        assert self._policy is not None, "Policy not loaded"
-        action_chunk = self._policy.predict_action_chunk(batch, **rtc_kwargs)
-
-        inference_elapsed = time.time() - inference_start
-        self._rtc_latency_history.append(inference_elapsed)
-
-        # Remove batch dim if present: (1, T, A) → (T, A)
-        if action_chunk.dim() == 3 and action_chunk.shape[0] == 1:
-            action_chunk = action_chunk.squeeze(0)
-
-        # Resolve how many control steps the executor ran while this inference
-        # was in flight - the offset that the chunk-seam blend slices by. Prefer
-        # the DETERMINISTIC count the runtime supplied (set_rtc_observed_delay):
-        # in a synchronous eval loop the world is paused during inference so
-        # exactly 0 steps elapse, and in the async overlap pipeline the count is
-        # a known integer. Deriving it from wall-clock p95 latency instead is
-        # non-reproducible - it warms up within an episode and varies run-to-run,
-        # so two otherwise-identical seeded episodes drift apart at the seam.
-        # Fall back to the wall-clock estimate only when no count was supplied
-        # (true-async hardware driven without a runner, where the arm really
-        # does keep moving during inference).
+        # Resolve how many control steps the executor commits while THIS
+        # inference is in flight - the RTC paper's `d`. It must be known BEFORE
+        # inference because lerobot's RTC denoiser consumes it as a kwarg: it is
+        # the `start` argument of RTCProcessor.get_prefix_weights, which freezes
+        # the first `d` actions of the new chunk to the already-committed prefix
+        # and linearly blends steps d..execution_horizon. It is ALSO the offset
+        # the chunk-seam slice below skips. Prefer the DETERMINISTIC count the
+        # runtime supplied (set_rtc_observed_delay): in a synchronous eval loop
+        # the world is paused during inference so exactly 0 steps elapse, and in
+        # the async overlap pipeline the count is a known integer. Deriving it
+        # from wall-clock p95 latency instead is non-reproducible - it warms up
+        # within an episode and varies run-to-run, so two otherwise-identical
+        # seeded episodes drift apart at the seam. Fall back to the wall-clock
+        # estimate (over PRIOR calls; this inference's own latency is not yet
+        # known) only when no count was supplied (true-async hardware driven
+        # without a runner, where the arm really does keep moving during
+        # inference).
         observed = self.rtc_observed_delay_steps
         if observed is not None:
             inference_delay = max(0, int(observed))
@@ -1066,6 +1057,31 @@ class LerobotLocalPolicy(Policy):
                     self._rtc_freq_warned = True
                 fps = _RTC_FALLBACK_FPS
             inference_delay = self._estimate_inference_delay(fps=fps)
+
+        # Build RTC kwargs for the flow-matching denoiser. inference_delay is
+        # passed on EVERY call: lerobot's RTCProcessor.denoise_step computes
+        # get_prefix_weights(inference_delay, execution_horizon, T), and
+        # `min(inference_delay, execution_horizon)` raises TypeError the moment a
+        # prev_chunk_left_over prefix exists (2nd chunk onward) if it is None.
+        # On the first chunk prev_chunk_left_over is None and lerobot returns
+        # early, so the value is harmless there.
+        rtc_kwargs: dict[str, Any] = {"inference_delay": inference_delay}
+        if self._rtc_prev_chunk is not None:
+            rtc_kwargs["prev_chunk_left_over"] = self._rtc_prev_chunk
+        if self._rtc_execution_horizon is not None:
+            rtc_kwargs["execution_horizon"] = self._rtc_execution_horizon
+
+        # predict_action_chunk returns (batch, chunk_size, action_dim)
+        assert self._policy is not None, "Policy not loaded"
+        inference_start = time.time()
+        action_chunk = self._policy.predict_action_chunk(batch, **rtc_kwargs)
+
+        inference_elapsed = time.time() - inference_start
+        self._rtc_latency_history.append(inference_elapsed)
+
+        # Remove batch dim if present: (1, T, A) → (T, A)
+        if action_chunk.dim() == 3 and action_chunk.shape[0] == 1:
+            action_chunk = action_chunk.squeeze(0)
 
         # Store leftover for next RTC call (unconsumed portion of this chunk).
         # The consumer executes ``execution_horizon`` actions before re-querying

--- a/tests/policies/lerobot_local/test_policy.py
+++ b/tests/policies/lerobot_local/test_policy.py
@@ -1396,6 +1396,89 @@ class TestRTCInference:
         assert "prev_chunk_left_over" in call_kwargs
         assert call_kwargs["prev_chunk_left_over"].shape == (15, 6)
 
+    def test_predict_with_rtc_forwards_inference_delay(self):
+        """RTC inference must forward inference_delay to predict_action_chunk.
+
+        Regression: lerobot's RTC denoiser (pi0/pi0.5/SmolVLA) reads
+        ``inference_delay`` from the predict_action_chunk kwargs and uses it as
+        the ``start`` argument of ``get_prefix_weights`` to freeze the committed
+        action prefix. The wrapper previously passed only prev_chunk_left_over +
+        execution_horizon, so the denoiser received ``inference_delay=None`` and
+        ``min(None, end)`` raised TypeError once a prefix existed. The kwarg must
+        be present on the first call (delay==0 in the synchronous loop) too.
+        """
+        policy = _make_policy()
+        policy._rtc_enabled = True
+        policy._rtc_execution_horizon = 10
+        policy._rtc_prev_chunk = None
+        policy.actions_per_step = 1
+        # Synchronous loop: world paused during inference -> deterministic 0.
+        policy.set_rtc_observed_delay(0)
+
+        mock_policy = MagicMock()
+        mock_policy.predict_action_chunk.return_value = torch.randn(1, 20, 6)
+        policy._policy = mock_policy
+
+        policy._predict_with_rtc({})
+        call_kwargs = mock_policy.predict_action_chunk.call_args[1]
+        assert "inference_delay" in call_kwargs
+        assert call_kwargs["inference_delay"] == 0
+        # Forward the counted delay verbatim on subsequent (prefixed) calls.
+        policy._rtc_prev_chunk = torch.randn(15, 6)
+        policy.set_rtc_observed_delay(3)
+        policy._predict_with_rtc({})
+        call_kwargs = mock_policy.predict_action_chunk.call_args[1]
+        assert call_kwargs["inference_delay"] == 3
+        assert "prev_chunk_left_over" in call_kwargs
+
+    def test_predict_with_rtc_kwargs_satisfy_lerobot_rtc_denoiser(self):
+        """The exact kwargs the wrapper sends must not crash lerobot's RTC.
+
+        Faithful end-to-end guard against drift: route the wrapper's
+        predict_action_chunk kwargs through lerobot's REAL
+        ``RTCProcessor.denoise_step`` (the path pi0/pi0.5/SmolVLA take). Before
+        the fix this raised ``TypeError: '<' not supported between instances of
+        'int' and 'NoneType'`` from ``get_prefix_weights`` the moment a
+        prev_chunk_left_over prefix was present. Self-skips when lerobot is
+        absent so the file's no-lerobot invariant holds.
+        """
+        rtc_mod = pytest.importorskip("lerobot.policies.rtc.modeling_rtc")
+        rtc_cfg_mod = pytest.importorskip("lerobot.policies.rtc.configuration_rtc")
+        processor = rtc_mod.RTCProcessor(rtc_cfg_mod.RTCConfig())
+
+        captured = {}
+
+        def fake_predict_action_chunk(_batch, **kwargs):
+            # Mirror lerobot pi0/SmolVLA sample_actions: when a prefix exists the
+            # denoiser runs with the supplied inference_delay. None -> TypeError.
+            captured.update(kwargs)
+            prev = kwargs.get("prev_chunk_left_over")
+            if prev is not None:
+                processor.denoise_step(
+                    x_t=torch.zeros(20, 6),
+                    prev_chunk_left_over=prev,
+                    inference_delay=kwargs.get("inference_delay"),
+                    time=0.5,
+                    original_denoise_step_partial=lambda xt: torch.zeros_like(xt),
+                    execution_horizon=kwargs.get("execution_horizon"),
+                )
+            return torch.randn(1, 20, 6)
+
+        policy = _make_policy()
+        policy._rtc_enabled = True
+        policy._rtc_execution_horizon = 10
+        policy._rtc_prev_chunk = torch.randn(15, 6)  # prefix present -> guidance runs
+        policy.actions_per_step = 1
+        policy.set_rtc_observed_delay(0)
+
+        mock_policy = MagicMock()
+        mock_policy.predict_action_chunk.side_effect = fake_predict_action_chunk
+        policy._policy = mock_policy
+
+        # Must not raise: inference_delay is now an int, not None.
+        policy._predict_with_rtc({})
+        assert captured["inference_delay"] == 0
+
     def test_predict_with_rtc_stores_leftover(self):
         """After RTC inference, leftover should be stored for next call."""
         policy = _make_policy()


### PR DESCRIPTION
## Problem

`LerobotLocalPolicy._predict_with_rtc` builds the RTC kwargs for lerobot's `predict_action_chunk` with only `prev_chunk_left_over` and `execution_horizon`. It never passes `inference_delay`.

lerobot's RTC denoiser (pi0, pi0.5, SmolVLA) reads `inference_delay` from those kwargs and uses it as the `start` argument of `RTCProcessor.get_prefix_weights(start, end, total)`. That weight curve freezes the first `d` committed actions of the new chunk to the previous chunk's prefix (weight 1.0) and linearly blends `d..execution_horizon` to 0 — it is the core of the chunk-seam guidance.

With `inference_delay` omitted, the denoiser receives `None`, and `get_prefix_weights` does `start = min(None, end)`, raising:

```
TypeError: '<' not supported between instances of 'int' and 'NoneType'
```

This fires the moment a `prev_chunk_left_over` prefix exists — i.e. the **second** inference onward — so a real flow-matching RTC policy crashes on its second chunk. The first chunk survives only because `prev_chunk_left_over` is `None` there and lerobot returns early before computing weights.

The existing RTC unit tests missed this because they mock `predict_action_chunk` with a static return tensor that ignores its kwargs, so lerobot's real `get_prefix_weights` was never exercised, and no test asserted `inference_delay` was forwarded.

## Fix

Resolve the inference delay (the RTC paper's `d`) **before** inference so it can be forwarded to the denoiser instead of only used to slice the returned chunk:

- Prefer the deterministic count supplied by the runtime via `set_rtc_observed_delay` (a synchronous loop pauses the world during inference, so `d == 0`; the async overlap pipeline supplies a known integer).
- Fall back to the wall-clock p95 estimate over PRIOR calls (this inference's own latency is not yet known) only when no count was supplied.
- Pass `inference_delay` in the kwargs on every call. It is harmless on the first chunk (no prefix → lerobot returns early) and required on every subsequent chunk.

The same value continues to drive the chunk-seam slice and leftover bookkeeping, so sim and hardware now share one consistent delay contract.

## Tests

Added two regression tests in `tests/policies/lerobot_local/test_policy.py`:

- `test_predict_with_rtc_forwards_inference_delay` — asserts `inference_delay` is in the `predict_action_chunk` kwargs (0 in the synchronous loop, and the verbatim counted value on prefixed calls). Fails pre-fix with `AssertionError: 'inference_delay' in {'execution_horizon': 10}`.
- `test_predict_with_rtc_kwargs_satisfy_lerobot_rtc_denoiser` — routes the wrapper's exact kwargs through lerobot's **real** `RTCProcessor.denoise_step` (the path pi0/pi0.5/SmolVLA take). Fails pre-fix with the production `TypeError` at `rtc/modeling_rtc.py:252`; passes after. Self-skips when lerobot is absent.

Full RTC + policy + hardware suites pass (257 tests), lint/mypy clean.

## Behavioral proof

The prefix-attention weight curve that the denoiser now receives the correct `d` for (rendered from lerobot's real `get_prefix_weights`, LINEAR schedule, `execution_horizon=10`). Pre-fix `d=None` crashes before any curve can be computed.

![rtc prefix weights](https://github.com/cagataycali/robots/releases/download/rtc-inference-delay-proof/rtc_prefix_weights.png)