### PR TITLE
fix(api): re-export all tools at package root

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -130,8 +130,11 @@ from strands_robots.policies.cosmos3 import Cosmos3Policy
 ```python
 from strands_robots.tools import (
     download_assets, gr00t_inference, lerobot_calibrate, lerobot_camera,
-    lerobot_teleoperate, lerobot_train, pose_tool, serial_tool, robot_mesh,
+    lerobot_teleoperate, lerobot_train, pose_tool, robot_mesh, run_policy,
+    serial_tool, train_policy, use_lerobot, use_ros, use_rtps,
 )
+# Every tool is also re-exported at the package root, e.g.
+#   from strands_robots import use_lerobot, run_policy
 # All return {"status": "...", "content": [{"text": "..."}]}
 ```
 

--- a/strands_robots/__init__.py
+++ b/strands_robots/__init__.py
@@ -59,6 +59,7 @@ if TYPE_CHECKING:
     )
     from strands_robots.streaming_dataset import StreamingDatasetReader
     from strands_robots.teleoperator import Teleoperator
+    from strands_robots.tools.download_assets import download_assets
     from strands_robots.tools.gr00t_inference import gr00t_inference
     from strands_robots.tools.lerobot_calibrate import lerobot_calibrate
     from strands_robots.tools.lerobot_camera import lerobot_camera
@@ -66,7 +67,12 @@ if TYPE_CHECKING:
     from strands_robots.tools.lerobot_train import lerobot_train
     from strands_robots.tools.pose_tool import pose_tool
     from strands_robots.tools.robot_mesh import robot_mesh
+    from strands_robots.tools.run_policy import run_policy
     from strands_robots.tools.serial_tool import serial_tool
+    from strands_robots.tools.train_policy import train_policy
+    from strands_robots.tools.use_lerobot import use_lerobot
+    from strands_robots.tools.use_ros import use_ros
+    from strands_robots.tools.use_rtps import use_rtps
 
 # ------------------------------------------------------------------
 # Light-weight imports - no torch / lerobot / mujoco dependency
@@ -99,13 +105,19 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "SimObject": ("strands_robots.simulation", "SimObject"),
     "SimCamera": ("strands_robots.simulation", "SimCamera"),
     # Tools
+    "download_assets": ("strands_robots.tools.download_assets", "download_assets"),
     "gr00t_inference": ("strands_robots.tools.gr00t_inference", "gr00t_inference"),
     "lerobot_calibrate": ("strands_robots.tools.lerobot_calibrate", "lerobot_calibrate"),
     "lerobot_camera": ("strands_robots.tools.lerobot_camera", "lerobot_camera"),
     "lerobot_teleoperate": ("strands_robots.tools.lerobot_teleoperate", "lerobot_teleoperate"),
     "lerobot_train": ("strands_robots.tools.lerobot_train", "lerobot_train"),
     "pose_tool": ("strands_robots.tools.pose_tool", "pose_tool"),
+    "run_policy": ("strands_robots.tools.run_policy", "run_policy"),
     "serial_tool": ("strands_robots.tools.serial_tool", "serial_tool"),
+    "train_policy": ("strands_robots.tools.train_policy", "train_policy"),
+    "use_lerobot": ("strands_robots.tools.use_lerobot", "use_lerobot"),
+    "use_ros": ("strands_robots.tools.use_ros", "use_ros"),
+    "use_rtps": ("strands_robots.tools.use_rtps", "use_rtps"),
     # Robot mesh coordination tool (Device Connect dispatch + mesh fallback)
     "robot_mesh": ("strands_robots.tools.robot_mesh", "robot_mesh"),
     # Device Connect integration - wraps robots as Device Connect devices
@@ -140,12 +152,18 @@ __all__ = [
     "create_simulation",
     "list_backends",
     "register_backend",
+    "download_assets",
     "gr00t_inference",
     "lerobot_camera",
     "lerobot_teleoperate",
     "lerobot_train",
     "lerobot_calibrate",
+    "run_policy",
     "serial_tool",
+    "train_policy",
+    "use_lerobot",
+    "use_ros",
+    "use_rtps",
     "pose_tool",
     "robot_mesh",
     "init_device_connect",

--- a/tests/test_package_lazy_imports.py
+++ b/tests/test_package_lazy_imports.py
@@ -145,3 +145,32 @@ class TestStaticExportContract:
             "Lazy symbols missing a TYPE_CHECKING import (CodeQL py/undefined-export "
             f"will flag these as exported-but-undefined): {missing}"
         )
+
+
+class TestToolsReexportedAtTopLevel:
+    """Every ``@tool`` in ``strands_robots.tools`` is re-exported at the package root.
+
+    Agents and tool loaders address tools as ``strands_robots:<tool>`` (the
+    top-level package), so a tool present in ``strands_robots.tools.__all__``
+    but absent from the package root fails to load with
+    ``module 'strands_robots' has no attribute '<tool>'``. This pins parity so
+    a newly added tool cannot drift out of the top-level surface.
+    """
+
+    def test_every_tool_is_in_top_level_all(self):
+        import strands_robots.tools as tools_pkg
+
+        missing = sorted(name for name in tools_pkg.__all__ if name not in strands_robots.__all__)
+        assert not missing, f"tools missing from top-level strands_robots.__all__: {missing}"
+
+    def test_every_tool_resolves_from_top_level(self):
+        import importlib
+
+        import strands_robots.tools as tools_pkg
+
+        # Each tool lives in a submodule named after it, defining an attribute
+        # of the same name. The top-level lazy export must resolve to that same
+        # object (not, for example, the submodule).
+        for name in tools_pkg.__all__:
+            submodule = importlib.import_module(f"strands_robots.tools.{name}")
+            assert getattr(strands_robots, name) is getattr(submodule, name), name


### PR DESCRIPTION
## Problem

Six `@tool` functions live in `strands_robots.tools` and are listed in `strands_robots.tools.__all__`, but were missing from the top-level `strands_robots` package surface:

`download_assets`, `run_policy`, `train_policy`, `use_lerobot`, `use_ros`, `use_rtps`

Tool loaders address tools as `strands_robots:<tool>` (the package root), so loading any of these failed:

```
module 'strands_robots' has no attribute 'use_lerobot'
module 'strands_robots' has no attribute 'run_policy'
module 'strands_robots' has no attribute 'download_assets'
...
```

The other eight tools (`gr00t_inference`, `lerobot_camera`, `lerobot_train`, ...) loaded fine because they were already in the root `_LAZY_IMPORTS`. The two surfaces had drifted apart.

## Change

Add the six missing names to the package-root `_LAZY_IMPORTS`, `__all__`, and the `TYPE_CHECKING` import block in `strands_robots/__init__.py`. The `TYPE_CHECKING` import keeps CodeQL `py/undefined-export` and type-checkers satisfied (matching the existing convention for every other lazy symbol). The package root and `strands_robots.tools.__all__` are now in parity: all 14 tools resolve from both surfaces.

## Test

New `TestToolsReexportedAtTopLevel` in `tests/test_package_lazy_imports.py` pins the invariant:
- every name in `strands_robots.tools.__all__` is in `strands_robots.__all__`
- each resolves from the package root to the same object as its submodule attribute

The test fails pre-fix on exactly the six missing names and passes after. Existing lazy-import contract tests (eager light symbols, lazy caching, missing-dep warn-and-raise, `TYPE_CHECKING` parity) remain green.

Gate: `ruff check`/`ruff format` clean on changed files; `mypy strands_robots/__init__.py tests/test_package_lazy_imports.py` clean; `pytest tests/test_package_lazy_imports.py` 10 passed.

Docs: `docs/api-reference.md` tools list updated to all 14 tools with a note that each is re-exported at the package root.