### PR TITLE
feat(policies): persistent worker - PersistentPolicy, cache controls, RSS telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Added: `PersistentPolicy` + cache controls, `policy_resident_rss_mb` telemetry [major-perf]
+
+A synchronous persistent worker that eliminates per-episode model-reload
+overhead for multi-rollout loops. Loading a VLA / LeRobot checkpoint (a
+MolmoAct2 SO-100/101 build reads ~1300 weight files into GPU memory) costs a
+minute or two; a loop that rebuilds the policy per episode pays it every time
+and its resident memory oscillates as the model is loaded and dropped.
+
+- `strands_robots.policies.PersistentPolicy(provider, **config)` - a thin,
+  thread-safe wrapper that builds the underlying policy ONCE and is passed to
+  every `run_policy`/`eval_policy` via `policy_object=` for zero-reload reuse.
+  It delegates the full `Policy` contract (chunk-shape introspection, RTC /
+  control-frequency hooks, `reset`, load telemetry) so the runtime drives it
+  exactly as the bare policy. Concurrent inference on one shared handle is
+  serialised behind a per-call lock.
+- `policies.preload(provider, **config)` warms the process-level model cache and
+  reports `load_time_s`, `load_cache_hit`, `resident_rss_mb`, `rss_delta_mb`,
+  plus the ready `PersistentPolicy`. `policies.list_cached()` introspects what is
+  resident; `policies.evict(pretrained_name_or_path=None)` frees one checkpoint
+  (or all) - `clear_model_cache` now accepts an optional checkpoint filter.
+- `run_policy`/`eval_policy` JSON now also carries `policy_resident_rss_mb`
+  (process RSS in MB at result time; `None` when unmeasurable). A flat value
+  across episodes confirms the model stays resident rather than oscillating - the
+  per-episode-reload smell, complementing the existing `policy_load_cache_hit`.
+
+Memory note: the cache shares the SAME live `nn.Module` across instances of one
+`(checkpoint, device)` key. Sequential reuse is safe (`Policy.reset()` clears
+per-episode state between episodes); `PersistentPolicy`'s lock makes concurrent
+reuse safe too. Opt out with `create_policy(..., cache_model=False)` for an
+independent live copy.
+
 ### Fixed: RTC inference now forwards `inference_delay` to lerobot's denoiser
 
 `LerobotLocalPolicy._predict_with_rtc` passed only `prev_chunk_left_over` and

--- a/docs/policies/overview.md
+++ b/docs/policies/overview.md
@@ -78,6 +78,7 @@ sim.run_policy(robot_name="so100", instruction="pick up the cube",
 
 - [GR00T](groot.md) - ZMQ server, 27 embodiments, container lifecycle.
 - [LeRobot Local](lerobot-local.md) - in-process HF models, RTC.
+- [Persistent worker](persistent-worker.md) - load once, reuse across rollouts; cache controls + telemetry.
 - [Cosmos 3](cosmos3.md) - NVIDIA Cosmos 3 omnimodal VLA.
 - [cuRobo](curobo.md) - in-process collision-aware motion planning (non-VLA, GPU).
 - [MoveIt2](moveit2.md) - ROS 2 sidecar collision-aware planning (non-VLA, no in-venv ROS 2).

--- a/docs/policies/persistent-worker.md
+++ b/docs/policies/persistent-worker.md
@@ -1,0 +1,98 @@
+# Persistent worker - load once, reuse everywhere
+
+Loading a VLA / LeRobot checkpoint is the dominant cost in a multi-episode
+rollout: a MolmoAct2 SO-100/101 build reads ~1300 weight files into GPU memory,
+on the order of a minute or two. A loop that rebuilds the policy per episode -
+the natural shape of an LLM tool loop that re-calls `run_policy` with
+`policy_provider=...` - pays that full cost every episode and its resident
+memory oscillates as the model is loaded and dropped.
+
+`strands_robots.policies` provides a synchronous persistent worker so the model
+is loaded **once** and reused with zero reload across every subsequent rollout.
+
+## The pattern
+
+```python
+from strands_robots.policies import PersistentPolicy
+
+# Build the policy once (loads weights, warms the process-level model cache).
+policy = PersistentPolicy("lerobot_local", pretrained_name_or_path="allenai/MolmoAct2-SO100_101")
+
+for _ in range(20):
+    sim.run_policy(robot_name="so101_follower", policy_object=policy)  # zero reload
+    sim.save_episode()
+    sim.reset()
+```
+
+`PersistentPolicy` is a thin, thread-safe wrapper around any provider. It builds
+the underlying policy in its constructor and delegates the full `Policy`
+contract transparently - chunk-shape introspection (`execution_horizon`,
+`is_chunk_emitting`, `actions_per_step`, `supports_rtc`), the RTC delay /
+control-frequency hooks, `reset(seed=...)`, and the load telemetry
+(`load_time_s`, `load_cache_hit`) all forward to the wrapped policy, so the
+runtime drives it exactly as it would the bare policy. `eval_policy` already
+builds the policy once outside its episode loop; `PersistentPolicy` extends the
+same guarantee to *separately issued* `run_policy` calls (LLM tool loops,
+sequential benchmarks).
+
+## Cache controls
+
+The model cache is process-wide, so even without `PersistentPolicy` two
+instances of the same `(checkpoint, device)` share resident weights. The
+agent-facing controls make that explicit:
+
+```python
+from strands_robots.policies import preload, list_cached, evict
+
+# Warm the cache ahead of a run; reports the load cost and resident memory.
+info = preload("lerobot_local", pretrained_name_or_path="allenai/MolmoAct2-SO100_101")
+# {'policy': <PersistentPolicy>, 'load_time_s': 84.2, 'load_cache_hit': False,
+#  'resident_rss_mb': 14803.1, 'rss_delta_mb': 12911.4}
+
+list_cached()
+# [{'namespace': 'molmoact2', 'pretrained_name_or_path': 'allenai/MolmoAct2-SO100_101',
+#   'device': 'cuda', 'policy_class': '...'}]
+
+evict("allenai/MolmoAct2-SO100_101")  # free one checkpoint before loading another
+evict()                                # free everything
+```
+
+`preload(...)["policy"]` is a ready `PersistentPolicy` - pass it straight to
+`run_policy(policy_object=...)`.
+
+## Telemetry
+
+`run_policy` and `eval_policy` carry three load-telemetry fields in their JSON
+result block so the saving is observable end to end:
+
+| field | meaning |
+| --- | --- |
+| `policy_load_time_s` | wall seconds the weight load took (`0.0` on a cache hit) |
+| `policy_load_cache_hit` | whether the heavy `from_pretrained` read was skipped |
+| `policy_resident_rss_mb` | process RSS in MB at result time (`None` if unmeasurable) |
+
+A `policy_load_cache_hit == False` on episode 2+ of a loop is the smell that the
+caller rebuilt the policy instead of reusing `policy_object=` - an agent can
+self-correct on it. `policy_resident_rss_mb` staying flat across episodes
+confirms the model is resident and not oscillating.
+
+## Memory-safety caveats
+
+The cached object is the SAME live `nn.Module` shared across every wrapper that
+requests the same `(checkpoint, device)` key. LeRobot policies hold per-episode
+mutable state (action queue, temporal-ensemble buffers) which `Policy.reset()`
+clears between episodes, so **sequential** reuse is safe. Two wrappers driving
+the same checkpoint **concurrently** would share that state; `PersistentPolicy`
+serialises inference behind a per-call lock so two threads reusing one handle
+never interleave. If you genuinely need two independent live copies of the same
+checkpoint, opt out of sharing with `create_policy(..., cache_model=False)`.
+
+This is an in-process worker: the model and cache live in one Python process.
+There is no background daemon or cross-process IPC - inference is GIL- and
+GPU-serialised, so the per-call lock gives correct reuse without a separate
+worker process. Cross-process sharing is a separate concern.
+
+## See also
+
+- [LeRobot Local](lerobot-local.md) - the in-process HF model provider.
+- [Overview](overview.md) - the `Policy` ABC and factory.

--- a/strands_robots/policies/__init__.py
+++ b/strands_robots/policies/__init__.py
@@ -47,6 +47,12 @@ from strands_robots.policies.factory import (
     register_policy,
 )
 from strands_robots.policies.mock import MockPolicy
+from strands_robots.policies.persistent import (
+    PersistentPolicy,
+    evict,
+    list_cached,
+    preload,
+)
 
 __all__ = [
     "Policy",
@@ -58,4 +64,8 @@ __all__ = [
     "register_policy",
     "list_providers",
     "UntrustedRemoteCodeError",
+    "PersistentPolicy",
+    "preload",
+    "list_cached",
+    "evict",
 ]

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -53,16 +53,29 @@ _MODEL_CACHE: dict[tuple[Any, ...], Any] = {}
 _MODEL_CACHE_LOCK = threading.Lock()
 
 
-def clear_model_cache() -> int:
-    """Evict all cached lerobot_local models, freeing their held memory.
+def clear_model_cache(pretrained_name_or_path: str | None = None) -> int:
+    """Evict cached lerobot_local models, freeing their held memory.
+
+    Args:
+        pretrained_name_or_path: When ``None`` (default), evict every entry.
+            When set, evict only the entries loaded from that checkpoint
+            (matched against the second field of each cache key) - lets a caller
+            free one model before loading a different one without dropping other
+            resident checkpoints.
 
     Returns:
         Number of cache entries evicted. Best-effort releases the CUDA caching
         allocator afterwards so freed GPU memory is returned to the driver.
     """
     with _MODEL_CACHE_LOCK:
-        n = len(_MODEL_CACHE)
-        _MODEL_CACHE.clear()
+        if pretrained_name_or_path is None:
+            n = len(_MODEL_CACHE)
+            _MODEL_CACHE.clear()
+        else:
+            doomed = [k for k in _MODEL_CACHE if len(k) > 1 and k[1] == pretrained_name_or_path]
+            for k in doomed:
+                del _MODEL_CACHE[k]
+            n = len(doomed)
     try:
         if torch.cuda.is_available():
             torch.cuda.empty_cache()

--- a/strands_robots/policies/persistent.py
+++ b/strands_robots/policies/persistent.py
@@ -1,0 +1,236 @@
+"""Persistent, reusable policy handles - load the model once, reuse everywhere.
+
+Loading a VLA / LeRobot checkpoint (a MolmoAct2 SO-100/101 build reads ~1300
+weight files into GPU memory) costs on the order of a minute or two. A naive
+multi-episode loop that calls :func:`create_policy` per rollout pays that cost
+every episode; the dominant fix already exists - a process-level model cache in
+:mod:`strands_robots.policies.lerobot_local.policy` shares the resident weights
+across instances - but two ergonomic gaps remained:
+
+1. The win was implicit. There was no first-class "load this once and hand me a
+   handle I reuse" object, so an LLM harness driving the API blind had no
+   obvious way to express the intent and would re-call ``create_policy``.
+2. There was no provider-agnostic way to *warm* the cache ahead of a run, *see*
+   what is resident, or *free* a checkpoint between runs of different policies.
+
+This module closes both. :class:`PersistentPolicy` is a thin, thread-safe
+wrapper that builds the underlying policy ONCE at construction and is meant to
+be passed to every ``run_policy``/``eval_policy`` call via ``policy_object=``::
+
+    from strands_robots.policies import PersistentPolicy
+
+    policy = PersistentPolicy("lerobot_local", pretrained_name_or_path="...")
+    for _ in range(20):
+        sim.run_policy(robot_name="arm", policy_object=policy)  # zero reload
+        sim.save_episode()
+        sim.reset()
+
+The :func:`preload`, :func:`list_cached`, and :func:`evict` helpers are the
+agent-facing cache controls: warm before a run, introspect what is hot, free
+memory before switching checkpoints.
+
+This is a SYNCHRONOUS persistent worker: the model lives in-process and is
+shared via the module-level cache. It deliberately does not spawn a background
+daemon or expose cross-process IPC - inference is GIL- and GPU-serialised, so a
+per-call lock gives correct concurrent reuse without the complexity (and races)
+of a separate worker process. Cross-process sharing is a separable concern.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import Any
+
+from strands_robots.policies.base import Policy
+from strands_robots.policies.factory import create_policy
+from strands_robots.utils import process_rss_mb
+
+__all__ = ["PersistentPolicy", "preload", "list_cached", "evict"]
+
+
+class PersistentPolicy(Policy):
+    """A persistent, reusable handle around an underlying policy.
+
+    Builds the wrapped policy ONCE (warming the process-level model cache) and
+    delegates every :class:`Policy` operation to it, so the same object can be
+    passed to many ``run_policy``/``eval_policy`` calls without ever reloading
+    weights. Inference calls are serialised by a per-call lock, so two threads
+    sharing one handle never corrupt the wrapped model's per-episode state.
+
+    The wrapper is transparent: chunk-shape introspection (``execution_horizon``,
+    ``is_chunk_emitting``, ``actions_per_step``, ``supports_rtc``), RTC delay /
+    control-frequency hooks, ``reset``, and load telemetry (``load_time_s``,
+    ``load_cache_hit``) all forward to the wrapped policy, so the runtime drives
+    it exactly as it would the bare policy.
+
+    Args:
+        provider: Provider name or smart string forwarded to
+            :func:`create_policy` (e.g. ``"lerobot_local"``, ``"mock"``).
+        policy_object: An already-constructed policy to wrap instead of building
+            a new one. When given, ``provider`` is recorded for identification
+            only and ``**config`` is ignored.
+        **config: Provider-specific keyword arguments forwarded to
+            :func:`create_policy`.
+    """
+
+    def __init__(
+        self,
+        provider: str,
+        *,
+        policy_object: Policy | None = None,
+        **config: Any,
+    ) -> None:
+        self._provider_arg = provider
+        self._config = dict(config)
+        # Serialise inference across threads (sync path) and coroutines (async
+        # path). The wrapped model holds per-episode state, so concurrent
+        # get_actions on one shared handle must not interleave.
+        self._call_lock = threading.Lock()
+        self._async_lock = asyncio.Lock()
+        if policy_object is not None:
+            self._inner: Policy = policy_object
+        else:
+            self._inner = create_policy(provider, **config)
+        # Snapshot the wrapped policy's load telemetry so it surfaces on the
+        # wrapper too (the runtime reads these off whatever object it is given).
+        self.load_time_s: float = float(getattr(self._inner, "load_time_s", 0.0))
+        self.load_cache_hit: bool = bool(getattr(self._inner, "load_cache_hit", False))
+
+    @property
+    def inner(self) -> Policy:
+        """The wrapped policy instance."""
+        return self._inner
+
+    async def get_actions(
+        self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any
+    ) -> list[dict[str, Any]]:
+        async with self._async_lock:
+            return await self._inner.get_actions(observation_dict, instruction, **kwargs)
+
+    def get_actions_sync(
+        self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any
+    ) -> list[dict[str, Any]]:
+        with self._call_lock:
+            return self._inner.get_actions_sync(observation_dict, instruction, **kwargs)
+
+    def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
+        self._inner.set_robot_state_keys(robot_state_keys)
+
+    def reset(self, seed: int | None = None) -> None:
+        self._inner.reset(seed)
+
+    def set_control_frequency(self, hz: float) -> None:
+        self._inner.set_control_frequency(hz)
+
+    def set_rtc_observed_delay(self, steps: int | None) -> None:
+        self._inner.set_rtc_observed_delay(steps)
+
+    @property
+    def requires_images(self) -> bool:
+        return self._inner.requires_images
+
+    @property
+    def execution_horizon(self) -> int:
+        return self._inner.execution_horizon
+
+    def is_chunk_emitting(self) -> bool:
+        return self._inner.is_chunk_emitting()
+
+    @property
+    def provider_name(self) -> str:
+        return self._inner.provider_name
+
+    def __getattr__(self, name: str) -> Any:
+        # Forward any attribute not defined on the wrapper (e.g.
+        # ``actions_per_step``, ``supports_rtc``, ``control_frequency``) to the
+        # wrapped policy. Only invoked when normal lookup fails, so it never
+        # shadows the explicit delegations above. ``object.__getattribute__``
+        # avoids re-entering __getattr__ while fetching ``_inner`` itself.
+        inner = object.__getattribute__(self, "_inner")
+        return getattr(inner, name)
+
+
+def preload(provider: str, **config: Any) -> dict[str, Any]:
+    """Warm the model cache for a provider and report the load cost.
+
+    Builds a :class:`PersistentPolicy` (which loads the model once into the
+    process-level cache) and measures the wall time and resident-memory delta.
+    Call this before a multi-episode run so every subsequent ``run_policy`` with
+    the returned ``policy`` is a zero-reload cache hit.
+
+    Args:
+        provider: Provider name or smart string (see :func:`create_policy`).
+        **config: Provider-specific keyword arguments.
+
+    Returns:
+        A dict with:
+            ``policy``: the ready :class:`PersistentPolicy` to pass as
+                ``policy_object=`` to ``run_policy``/``eval_policy``.
+            ``load_time_s``: wall-clock seconds spent constructing the policy.
+            ``load_cache_hit``: whether the heavy weight load was served from
+                the process-level cache (a warm preload).
+            ``resident_rss_mb``: process RSS in MB after the load (``None`` if
+                unmeasurable on this platform).
+            ``rss_delta_mb``: change in process RSS across the load (``None`` if
+                unmeasurable); ~0 on a cache hit, large on a cold load.
+    """
+    import time
+
+    rss_before = process_rss_mb()
+    t0 = time.perf_counter()
+    policy = PersistentPolicy(provider, **config)
+    elapsed = time.perf_counter() - t0
+    rss_after = process_rss_mb()
+    # Prefer the wrapped policy's own measured load time (it isolates the weight
+    # read from wrapper overhead); fall back to the wall clock around construction.
+    load_time_s = float(getattr(policy, "load_time_s", 0.0)) or round(elapsed, 3)
+    rss_delta = None
+    if rss_before is not None and rss_after is not None:
+        rss_delta = round(rss_after - rss_before, 1)
+    return {
+        "policy": policy,
+        "load_time_s": round(load_time_s, 3),
+        "load_cache_hit": bool(getattr(policy, "load_cache_hit", False)),
+        "resident_rss_mb": None if rss_after is None else round(rss_after, 1),
+        "rss_delta_mb": rss_delta,
+    }
+
+
+def list_cached() -> list[dict[str, Any]]:
+    """List the heavy models currently resident in the process-level cache.
+
+    Provider-agnostic introspection for deciding whether to evict before
+    loading a different checkpoint. Currently the ``lerobot_local`` provider is
+    the only one with a process-level weight cache; the list is empty when its
+    optional dependencies are not installed.
+
+    Returns:
+        One dict per cached entry (see
+        :func:`strands_robots.policies.lerobot_local.list_cached_models`), or an
+        empty list when no cache is available.
+    """
+    try:
+        from strands_robots.policies.lerobot_local import list_cached_models
+    except ImportError:
+        return []
+    return list_cached_models()
+
+
+def evict(pretrained_name_or_path: str | None = None) -> int:
+    """Free cached models, returning held GPU/CPU memory.
+
+    Args:
+        pretrained_name_or_path: When ``None`` (default), evict every cached
+            model. When set, evict only the entries loaded from that checkpoint
+            - free one policy before switching to another without dropping the
+            rest.
+
+    Returns:
+        Number of cache entries evicted (``0`` when no cache is available).
+    """
+    try:
+        from strands_robots.policies.lerobot_local import clear_model_cache
+    except ImportError:
+        return 0
+    return clear_model_cache(pretrained_name_or_path)

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -43,7 +43,7 @@ import numpy as np
 
 from strands_robots._async_utils import _resolve_coroutine
 from strands_robots.policies.base import resolve_chunk_length
-from strands_robots.utils import require_optional
+from strands_robots.utils import process_rss_mb, require_optional
 
 if TYPE_CHECKING:
     from strands_robots.policies.base import Policy
@@ -904,6 +904,10 @@ class PolicyRunner:
             # no load telemetry (e.g. MockPolicy).
             "policy_load_time_s": round(float(getattr(policy, "load_time_s", 0.0)), 3),
             "policy_load_cache_hit": bool(getattr(policy, "load_cache_hit", False)),
+            # Process RSS (MB) at result time: confirms a heavy model is resident
+            # and, across a loop, that it stays resident instead of oscillating
+            # as it would on a per-episode reload. None when unmeasurable.
+            "policy_resident_rss_mb": process_rss_mb(),
         }
         if sim_time is not None:
             payload["sim_time_s"] = round(sim_time, 3)
@@ -1230,6 +1234,7 @@ class PolicyRunner:
                         "max_steps": max_steps,
                         "policy_load_time_s": round(float(getattr(policy, "load_time_s", 0.0)), 3),
                         "policy_load_cache_hit": bool(getattr(policy, "load_cache_hit", False)),
+                        "policy_resident_rss_mb": process_rss_mb(),
                         "episodes": results,
                     }
                 },
@@ -1556,6 +1561,7 @@ class PolicyRunner:
                         "benchmark_class": spec_name,
                         "policy_load_time_s": round(float(getattr(policy, "load_time_s", 0.0)), 3),
                         "policy_load_cache_hit": bool(getattr(policy, "load_cache_hit", False)),
+                        "policy_resident_rss_mb": process_rss_mb(),
                         "episodes": results,
                     }
                 },

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -233,3 +233,41 @@ def get_search_paths() -> list[Path]:
     if cwd_assets not in paths:
         paths.append(cwd_assets)
     return paths
+
+
+def process_rss_mb() -> float | None:
+    """Current resident set size (RSS) of this process, in megabytes.
+
+    Used to surface ``policy_resident_rss_mb`` telemetry so a caller can see
+    whether a heavy model (e.g. a multi-GB VLA checkpoint) is actually resident
+    after a load - and, across a multi-episode loop, that it stays resident
+    rather than oscillating as it would if the policy were rebuilt per episode.
+
+    Prefers :mod:`psutil` (true *current* RSS, the meaningful "is it resident
+    now" number). Falls back to :func:`resource.getrusage`, which reports peak
+    RSS for the process (``ru_maxrss``) - an over-estimate of current usage, but
+    still a useful floor when psutil is absent. ``ru_maxrss`` is in kilobytes on
+    Linux and bytes on macOS; both are normalised to MB.
+
+    Returns:
+        Resident memory in MB as a float, or ``None`` when neither source is
+        available (e.g. a platform without ``resource``), so callers can omit
+        the field rather than report a misleading zero.
+    """
+    try:
+        import psutil
+
+        return float(psutil.Process().memory_info().rss) / (1024.0 * 1024.0)
+    except (ImportError, OSError):
+        # psutil missing or the /proc read failed; fall back to stdlib resource.
+        pass
+    try:
+        import resource
+        import sys
+
+        maxrss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        # ru_maxrss units differ by platform: bytes on macOS, kilobytes on Linux.
+        divisor = 1024.0 * 1024.0 if sys.platform == "darwin" else 1024.0
+        return float(maxrss) / divisor
+    except (ImportError, ValueError, OSError):
+        return None

--- a/tests/policies/lerobot_local/test_model_cache.py
+++ b/tests/policies/lerobot_local/test_model_cache.py
@@ -19,6 +19,7 @@ from strands_robots.policies.lerobot_local import molmoact2
 from strands_robots.policies.lerobot_local.policy import (
     LerobotLocalPolicy,
     clear_model_cache,
+    list_cached_models,
 )
 
 
@@ -184,3 +185,40 @@ class TestMolmoAct2ModelCache:
         # cleared between them.
         assert calls[0] is None
         assert calls[1] is None
+
+
+class TestSelectiveEviction:
+    """clear_model_cache(path) evicts one checkpoint, leaving others resident.
+
+    The agent-facing ``policies.evict(path)`` control frees a single model
+    before switching to a different one without dropping every other resident
+    checkpoint - the filter matches the checkpoint field of each cache key.
+    """
+
+    def setup_method(self):
+        clear_model_cache()
+
+    def teardown_method(self):
+        clear_model_cache()
+
+    def test_evict_by_path_removes_only_matching_entry(self):
+        from strands_robots.policies.lerobot_local import policy as policy_mod
+
+        sentinel_a = object()
+        sentinel_b = object()
+        with policy_mod._MODEL_CACHE_LOCK:
+            policy_mod._MODEL_CACHE[("generic", "owner/model-a", "cpu")] = sentinel_a
+            policy_mod._MODEL_CACHE[("generic", "owner/model-b", "cpu")] = sentinel_b
+
+        evicted = clear_model_cache("owner/model-a")
+        assert evicted == 1
+        remaining = {entry["pretrained_name_or_path"] for entry in list_cached_models()}
+        assert remaining == {"owner/model-b"}
+
+    def test_evict_unknown_path_is_a_noop(self):
+        from strands_robots.policies.lerobot_local import policy as policy_mod
+
+        with policy_mod._MODEL_CACHE_LOCK:
+            policy_mod._MODEL_CACHE[("generic", "owner/model-a", "cpu")] = object()
+        assert clear_model_cache("owner/not-loaded") == 0
+        assert len(list_cached_models()) == 1

--- a/tests/policies/test_persistent_worker.py
+++ b/tests/policies/test_persistent_worker.py
@@ -1,0 +1,171 @@
+"""PersistentPolicy and the preload/list_cached/evict cache controls.
+
+Loading a VLA checkpoint is the dominant cost in a multi-episode rollout. The
+process-level model cache (tested in
+``tests/policies/lerobot_local/test_model_cache.py``) already shares resident
+weights across instances; these tests pin the ergonomic layer on top of it:
+
+* :class:`PersistentPolicy` builds the wrapped policy ONCE and reuses it across
+  many calls, delegating the full Policy contract transparently.
+* Concurrent inference on one shared handle is serialised (no interleaving of
+  the wrapped model's per-episode state).
+* :func:`preload` warms the cache and reports honest load/RSS telemetry.
+* :func:`list_cached` / :func:`evict` introspect and free the cache.
+
+The tests use the dependency-free ``mock`` provider so they run without torch /
+lerobot, exercising the wrapper contract rather than any specific backend.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from strands_robots.policies import (
+    PersistentPolicy,
+    evict,
+    list_cached,
+    preload,
+)
+from strands_robots.policies.base import Policy
+from strands_robots.policies.mock import MockPolicy
+
+
+class _CountingPolicy(MockPolicy):
+    """MockPolicy that counts constructions to prove single-load reuse."""
+
+    build_count = 0
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        type(self).build_count += 1
+        self.load_time_s = 0.0
+        self.load_cache_hit = False
+
+
+def _obs():
+    return {"observation.state": [0.0] * 6}
+
+
+class TestPersistentPolicyWrapper:
+    def test_builds_once_and_reuses_inner(self):
+        _CountingPolicy.build_count = 0
+        inner = _CountingPolicy()
+        assert _CountingPolicy.build_count == 1
+        wrapper = PersistentPolicy("mock", policy_object=inner)
+        # Wrapping an existing object never rebuilds it.
+        assert _CountingPolicy.build_count == 1
+        assert wrapper.inner is inner
+
+    def test_is_a_policy(self):
+        wrapper = PersistentPolicy("mock", policy_object=MockPolicy())
+        assert isinstance(wrapper, Policy)
+
+    def test_delegates_inference(self):
+        inner = MockPolicy()
+        inner.set_robot_state_keys(["j1", "j2", "j3", "j4", "j5", "j6"])
+        wrapper = PersistentPolicy("mock", policy_object=inner)
+        wrapper.set_robot_state_keys(["j1", "j2", "j3", "j4", "j5", "j6"])
+        actions = wrapper.get_actions_sync(_obs(), "")
+        assert isinstance(actions, list) and len(actions) >= 1
+        assert all(isinstance(a, dict) for a in actions)
+
+    def test_forwards_introspection_and_telemetry(self):
+        inner = MockPolicy()
+        inner.load_time_s = 12.5
+        inner.load_cache_hit = True
+        wrapper = PersistentPolicy("mock", policy_object=inner)
+        # Provider identity, chunk-shape introspection, and image need all
+        # reflect the wrapped policy so the runtime drives it identically.
+        assert wrapper.provider_name == inner.provider_name
+        assert wrapper.requires_images == inner.requires_images
+        assert wrapper.execution_horizon == inner.execution_horizon
+        assert wrapper.is_chunk_emitting() == inner.is_chunk_emitting()
+        # Snapshotted load telemetry surfaces on the wrapper.
+        assert wrapper.load_time_s == 12.5
+        assert wrapper.load_cache_hit is True
+
+    def test_reset_and_control_hooks_delegate(self):
+        inner = MockPolicy()
+        wrapper = PersistentPolicy("mock", policy_object=inner)
+        wrapper.set_control_frequency(50.0)
+        wrapper.set_rtc_observed_delay(3)
+        wrapper.reset(seed=7)
+        # Hooks land on the wrapped object (the one the runtime's get_actions
+        # ultimately reads), not on the wrapper's inherited class defaults.
+        assert inner.control_frequency == 50.0
+        assert inner.rtc_observed_delay_steps == 3
+
+    def test_concurrent_inference_is_serialised(self):
+        # Two threads share one handle; the per-call lock must serialise them so
+        # no two inferences run on the wrapped model's mutable state at once.
+        inner = MockPolicy()
+        inner.set_robot_state_keys(["j1", "j2", "j3", "j4", "j5", "j6"])
+        wrapper = PersistentPolicy("mock", policy_object=inner)
+
+        overlap = {"max": 0}
+        active = {"n": 0}
+        guard = threading.Lock()
+        orig = inner.get_actions_sync
+
+        def instrumented(*a, **k):
+            with guard:
+                active["n"] += 1
+                overlap["max"] = max(overlap["max"], active["n"])
+            try:
+                return orig(*a, **k)
+            finally:
+                with guard:
+                    active["n"] -= 1
+
+        inner.get_actions_sync = instrumented  # type: ignore[method-assign]
+
+        results: list[int] = []
+        rlock = threading.Lock()
+
+        def worker():
+            for _ in range(20):
+                acts = wrapper.get_actions_sync(_obs(), "")
+                with rlock:
+                    results.append(len(acts))
+
+        threads = [threading.Thread(target=worker) for _ in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(results) == 40
+        # The wrapper's lock guarantees at most one inference in flight.
+        assert overlap["max"] == 1
+
+
+class TestPreload:
+    def test_returns_policy_and_telemetry(self):
+        out = preload("mock")
+        assert isinstance(out["policy"], PersistentPolicy)
+        assert isinstance(out["load_time_s"], float)
+        assert out["load_cache_hit"] in (True, False)
+        # RSS is a positive float when measurable, else None on a bare platform.
+        rss = out["resident_rss_mb"]
+        assert rss is None or (isinstance(rss, float) and rss > 0.0)
+        assert "rss_delta_mb" in out
+
+    def test_preloaded_policy_is_reusable(self):
+        policy = preload("mock")["policy"]
+        policy.set_robot_state_keys(["j1", "j2", "j3", "j4", "j5", "j6"])
+        first = policy.get_actions_sync(_obs(), "")
+        second = policy.get_actions_sync(_obs(), "")
+        assert len(first) >= 1 and len(second) >= 1
+
+
+class TestCacheControls:
+    def test_list_cached_returns_list(self):
+        # No model loaded through the cache here; the call must still be safe and
+        # return a list (empty when the lerobot cache is unavailable/empty).
+        assert isinstance(list_cached(), list)
+
+    def test_evict_returns_int(self):
+        # Evicting a checkpoint that is not resident frees nothing but reports a
+        # count rather than raising - safe to call defensively before a run.
+        assert evict("definitely/not-loaded") == 0
+        assert isinstance(evict(), int)

--- a/tests/simulation/test_run_policy_load_telemetry.py
+++ b/tests/simulation/test_run_policy_load_telemetry.py
@@ -51,6 +51,13 @@ def test_run_policy_payload_has_telemetry_keys(sim):
     # MockPolicy exposes no load telemetry -> honest defaults.
     assert payload["policy_load_time_s"] == 0.0
     assert payload["policy_load_cache_hit"] is False
+    # Resident RSS is reported so an agent can confirm the model is loaded and,
+    # across a loop, that it is not oscillating (per-episode reload smell). It
+    # is a positive float when measurable; None only on a platform with neither
+    # psutil nor resource.getrusage.
+    assert "policy_resident_rss_mb" in payload
+    rss = payload["policy_resident_rss_mb"]
+    assert rss is None or (isinstance(rss, float) and rss > 0.0)
 
 
 def test_run_policy_echoes_policy_object_telemetry(sim):
@@ -82,3 +89,4 @@ def test_eval_policy_payload_has_telemetry_keys(sim):
     payload = _json_block(ev)
     assert "policy_load_time_s" in payload
     assert "policy_load_cache_hit" in payload
+    assert "policy_resident_rss_mb" in payload


### PR DESCRIPTION
## Problem

Loading a VLA / LeRobot checkpoint is the dominant cost in a multi-episode rollout: a MolmoAct2 SO-100/101 build reads ~1300 weight files into GPU memory, on the order of a minute or two. `eval_policy` already builds the policy once outside its episode loop, but a loop that issues *separate* `run_policy` calls with `policy_provider=...` (the natural shape of an LLM tool loop, or a sequential benchmark) rebuilds the policy every episode and pays that full load each time. Resident memory oscillates as the model is loaded and dropped.

The process-level model cache (`_MODEL_CACHE` in `policies/lerobot_local/policy.py`) already shares resident weights across instances of the same `(checkpoint, device)`, so the dominant cost is *already* eliminated for shared-instance paths. What was missing: a first-class, discoverable way to express "load once, reuse", provider-agnostic cache controls, and a resident-memory signal so the saving is observable.

## Change

**`PersistentPolicy(provider, **config)`** - a thin, thread-safe wrapper that builds the underlying policy ONCE and is passed to every `run_policy`/`eval_policy` via `policy_object=` for zero-reload reuse:

```python
from strands_robots.policies import PersistentPolicy
policy = PersistentPolicy("lerobot_local", pretrained_name_or_path="allenai/MolmoAct2-SO100_101")
for _ in range(20):
    sim.run_policy(robot_name="so101_follower", policy_object=policy)  # zero reload
    sim.save_episode(); sim.reset()
```

It delegates the full `Policy` contract transparently - chunk-shape introspection (`execution_horizon`, `is_chunk_emitting`, `actions_per_step`, `supports_rtc`), the RTC delay / control-frequency hooks, `reset(seed=...)`, and load telemetry - so the runtime drives it exactly as the bare policy. Concurrent inference on one shared handle is serialised behind a per-call lock.

**Cache controls** (`policies.preload/list_cached/evict`):
- `preload(provider, **config)` warms the cache and returns `load_time_s`, `load_cache_hit`, `resident_rss_mb`, `rss_delta_mb`, plus the ready `PersistentPolicy`.
- `list_cached()` introspects what is resident.
- `evict(pretrained_name_or_path=None)` frees one checkpoint (or all); `clear_model_cache` now accepts an optional checkpoint filter.

**`policy_resident_rss_mb` telemetry** - `run_policy`/`eval_policy` JSON now also carries process RSS in MB at result time (`None` when unmeasurable; prefers psutil, falls back to `resource.getrusage`). A flat value across episodes confirms the model stays resident rather than oscillating - the per-episode-reload smell, complementing the existing `policy_load_cache_hit`.

This is a synchronous in-process worker: no background daemon or cross-process IPC. Inference is GIL- and GPU-serialised, so the per-call lock gives correct reuse without a separate worker process; cross-process sharing is a separable concern.

## Rollout artifact (MuJoCo, headless EGL)

One `PersistentPolicy` handle reused across 3 `run_policy` rollouts on `so100`. Resident RSS stays flat (311.4 MB) across all episodes - no per-episode oscillation - and the rollout renders cleanly:

![persistent worker rollout](https://github.com/cagataycali/robots/releases/download/artifact-persistent-worker/persistent_rollout.gif)

```
preload telemetry: {'load_time_s': 0.0, 'load_cache_hit': False, 'resident_rss_mb': 75.0, 'rss_delta_mb': 0.0}
episode 0: load_time_s=0.0 cache_hit=False resident_rss_mb=311.4 video_frames=60
episode 1: load_time_s=0.0 cache_hit=False resident_rss_mb=311.4
episode 2: load_time_s=0.0 cache_hit=False resident_rss_mb=311.4
```

(MP4: https://github.com/cagataycali/robots/releases/download/artifact-persistent-worker/persistent_rollout.mp4)

## Tests

- `tests/policies/test_persistent_worker.py`: wrapper builds-once/reuses-inner, delegates the full contract + telemetry, reset/control hooks land on the wrapped policy, **concurrent inference on one handle is serialised** (instrumented overlap counter asserts max-in-flight == 1), `preload` returns honest telemetry, `list_cached`/`evict` are safe and return list/int.
- `tests/policies/lerobot_local/test_model_cache.py`: selective eviction by checkpoint - `clear_model_cache(path)` removes only the matching entry, unknown path is a no-op (fails pre-change: the filter arg did not exist).
- `tests/simulation/test_run_policy_load_telemetry.py`: `run_policy`/`eval_policy` payloads carry `policy_resident_rss_mb` (positive float when measurable).

Local gate green: `ruff check` + `ruff format --check` + `mypy strands_robots tests tests_integ` all clean; 2400+ relevant policies/simulation tests pass (the only failures are a pre-existing torchcodec `.so` load issue in recording tests, identical on a clean tree). Docs (`docs/policies/persistent-worker.md` + overview link) and CHANGELOG included.