### PR TITLE
fix(api): re-export list_providers and register_policy at package root

### DIFF
--- a/strands_robots/__init__.py
+++ b/strands_robots/__init__.py
@@ -77,7 +77,13 @@ if TYPE_CHECKING:
 # ------------------------------------------------------------------
 # Light-weight imports - no torch / lerobot / mujoco dependency
 # ------------------------------------------------------------------
-from strands_robots.policies import MockPolicy, Policy, create_policy  # noqa: F401
+from strands_robots.policies import (  # noqa: F401
+    MockPolicy,
+    Policy,
+    create_policy,
+    list_providers,
+    register_policy,
+)
 
 # ------------------------------------------------------------------
 # Lazy-loaded heavy symbols
@@ -134,6 +140,8 @@ __all__ = [
     "Policy",
     "MockPolicy",
     "create_policy",
+    "list_providers",
+    "register_policy",
     # Lazy-loaded
     "Robot",
     "HardwareRosBridge",

--- a/tests/test_package_lazy_imports.py
+++ b/tests/test_package_lazy_imports.py
@@ -174,3 +174,39 @@ class TestToolsReexportedAtTopLevel:
         for name in tools_pkg.__all__:
             submodule = importlib.import_module(f"strands_robots.tools.{name}")
             assert getattr(strands_robots, name) is getattr(submodule, name), name
+
+
+class TestPolicyFactorySymbolsReexported:
+    """The policy factory's constructor *and* its discovery/registration peers
+    are all re-exported at the package root.
+
+    ``create_policy`` is the eager top-level entry point, but an agent that
+    reaches it also needs the two calls that make it usable blind:
+    ``list_providers()`` (what can I pass to ``create_policy``?) and
+    ``register_policy()`` (add my own). All three live in the light-weight
+    ``strands_robots.policies.factory`` module (no torch/lerobot), so they
+    import eagerly alongside ``create_policy`` rather than lazily. This pins
+    that the discovery counterparts sit next to the constructor instead of
+    forcing a reach into the ``strands_robots.policies`` subpackage.
+    """
+
+    def test_discovery_symbols_in_top_level_all(self):
+        for name in ("create_policy", "list_providers", "register_policy"):
+            assert name in strands_robots.__all__
+
+    def test_discovery_symbols_are_eager_not_lazy(self):
+        # Same provenance as create_policy: light imports, never lazy entries.
+        for name in ("list_providers", "register_policy"):
+            assert name not in strands_robots._LAZY_IMPORTS
+
+    def test_discovery_symbols_resolve_to_policies_objects(self):
+        import strands_robots.policies as policies_pkg
+
+        for name in ("create_policy", "list_providers", "register_policy"):
+            assert getattr(strands_robots, name) is getattr(policies_pkg, name), name
+
+    def test_list_providers_callable_from_top_level(self):
+        # The whole point: call it straight off the package root.
+        providers = strands_robots.list_providers()
+        assert isinstance(providers, (list, tuple, set))
+        assert "mock" in providers


### PR DESCRIPTION
## Problem

`create_policy` is exported at the package root, but its discovery and registration counterparts from the same light-weight `strands_robots.policies.factory` module are not:

```python
import strands_robots as sr
sr.create_policy("cosmos3")   # works (top-level)
sr.list_providers()            # AttributeError: module 'strands_robots' has no attribute 'list_providers'
sr.register_policy(...)        # AttributeError: ... 'register_policy'
sr.list_robots()               # works (top-level)
```

An agent (or any caller) that reaches `create_policy` off the package root cannot find the one call that tells it what providers to pass (`list_providers`) nor the call to add its own (`register_policy`) without dropping into the `strands_robots.policies` subpackage. This is the discovery counterpart of an exported constructor not sitting next to it (same theme as #781 re-exporting tools at the root).

The API reference already documents both as top-level `strands_robots` symbols (`docs/api-reference.md`, the `strands_robots` table lists `register_policy(...)` and `list_providers()`), so the code contradicted its own documented contract.

## Change

Add `list_providers` and `register_policy` to the eager light-weight import line and `__all__` alongside `create_policy`. All three come from `strands_robots.policies.factory`, which pulls in no torch/lerobot/mujoco, so they stay eager rather than lazy — `import strands_robots` cost is unchanged.

## Tests

New regression class in `tests/test_package_lazy_imports.py` pins that the policy-factory constructor and its discovery/registration peers are all re-exported at the root, resolve to the same `strands_robots.policies` objects, and remain eager (not lazy entries). It fails on exactly `list_providers`/`register_policy` pre-fix (3 failed, 1 passed) and passes after. Full CI-scope gate clean: `ruff check`/`ruff format --check` pass, `mypy strands_robots tests tests_integ` reports no issues, and `tests/test_package_lazy_imports.py tests/tools/test_tools_lazy_import.py tests/policies/ tests/test_docs_policy_nav_coverage.py` => 1190 passed, 2 skipped.

No docs change needed: `docs/api-reference.md` already lists both under `strands_robots`; this PR makes the code match.