### PR TITLE
test(policies): pin the chunk re-query interval floor (>= 1) invariant

### DIFF
--- a/tests/policies/test_chunked_policy_contract.py
+++ b/tests/policies/test_chunked_policy_contract.py
@@ -212,3 +212,38 @@ def test_resolve_chunk_length_nonrtc_unaffected_by_execution_horizon() -> None:
     pol = MockChunkedPolicy(actions_per_step=50)
     assert resolve_chunk_length(pol, action_horizon=8) == 50
     assert resolve_chunk_length(pol, action_horizon=80) == 80
+
+
+# --- Floor invariant: the re-query interval is never < 1 -------------------
+# The chunk consumer executes ``resolve_chunk_length`` actions before it
+# re-queries the policy. If that count were ever 0 or negative the consumer
+# would execute an EMPTY slice every cycle - a silent no-op that scores
+# success_rate=0 with no error surfaced. Both the ``execution_horizon``
+# property and ``resolve_chunk_length`` floor the value at 1 so a misconfigured
+# or buggy policy degrades to single-step instead of stalling. These pin that
+# floor for the degenerate inputs the happy-path tests above never reach.
+
+
+@pytest.mark.parametrize("bad_chunk", [None, "auto", 0, -5, object()])
+def test_execution_horizon_floors_degenerate_chunk_to_single(bad_chunk: Any) -> None:
+    """A non-positive or non-integer ``actions_per_step`` yields a horizon of 1.
+
+    A policy that declares a bad trained-chunk length (a config typo leaving it
+    ``None``/a string, or a zero/negative value) must not propagate a horizon
+    the consumer cannot act on; it degrades to a single-step policy.
+    """
+    pol = MockChunkedPolicy(actions_per_step=bad_chunk)  # type: ignore[arg-type]
+    assert pol.execution_horizon == 1
+
+
+@pytest.mark.parametrize("bad_horizon", [0, -1, -7])
+def test_resolve_chunk_length_floors_subunit_execution_horizon(bad_horizon: int) -> None:
+    """A policy reporting a zero/negative ``execution_horizon`` is floored to 1.
+
+    ``resolve_chunk_length`` reads the interval straight off the policy, so a
+    custom (e.g. RTC) policy that miscomputes its re-query interval as <= 0 must
+    still drive at least one action per cycle rather than an empty chunk.
+    """
+    pol = MockRtcPolicy(actions_per_step=50, execution_horizon=bad_horizon)
+    assert pol.execution_horizon == bad_horizon  # property reports it verbatim
+    assert resolve_chunk_length(pol, action_horizon=8) == 1


### PR DESCRIPTION
## Problem
The chunk consumer executes `resolve_chunk_length(policy, action_horizon)` actions before re-querying the policy. If that count were ever `0` or negative, the consumer would execute an **empty action slice every cycle** - a silent no-op that scores `success_rate=0` with no error surfaced.

Both `Policy.execution_horizon` and `resolve_chunk_length` floor the value at `1` to prevent this (`max(1, intended_int)` and the `if horizon_int < 1` clamp). The happy paths are well covered, but the **degenerate inputs that actually exercise those guards were untested**:

- a non-integer / non-positive `actions_per_step` on a `Policy` subclass (the `execution_horizon` coercion fallback), and
- a policy reporting a zero/negative `execution_horizon` (the `resolve_chunk_length` clamp).

A future refactor could quietly drop either floor (e.g. simplifying `max(1, int(x))` to `int(x)`) and reintroduce the empty-chunk no-op with no failing test.

## Change
Test-only. Adds two parametrized tests to `tests/policies/test_chunked_policy_contract.py` pinning the `>= 1` floor on both paths:

- `test_execution_horizon_floors_degenerate_chunk_to_single` - `None`, a string, `0`, `-5`, and an arbitrary object all resolve to `execution_horizon == 1`.
- `test_resolve_chunk_length_floors_subunit_execution_horizon` - a policy reporting `execution_horizon` of `0`, `-1`, `-7` still yields `resolve_chunk_length(...) == 1`.

No production code changes; the existing guards are correct and these lock them in.

## Verification
- Regression check: temporarily removing either floor in `policies/base.py` makes the new tests fail (5 failures); they pass on the unmodified code.
- `tests/policies/` full suite: 1166 passed, 2 skipped.
- The two previously-uncovered defensive branches in `strands_robots/policies/base.py` (the `execution_horizon` coercion fallback and the `resolve_chunk_length` sub-unit clamp) are now exercised.
- `hatch run lint`: Success, no issues found.