### PR TITLE
feat(newton): domain randomization + sensor-noise hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,30 @@ Memory note: the cache shares the SAME live `nn.Module` across instances of one
 per-episode state between episodes); `PersistentPolicy`'s lock makes concurrent
 reuse safe too. Opt out with `create_policy(..., cache_model=False)` for an
 independent live copy.
+### Added: Newton backend domain randomization + sensor-noise hooks
+
+The Newton (GPU) backend gained `randomize()` and `set_obs_noise()`, the
+sim2real pieces it was missing so datasets collected on it do not overfit to
+the default physics constants. `randomize()` mirrors the MuJoCo backend's
+contract (same keyword names and `randomize_physics=False` default) for the
+axes Newton supports: per-shape colors (`shape_color`), directional-light
+orientation, and physics - per-body mass + inertia (`body_mass` /
+`body_inertia`, scaled together so Newton recomputes the inverse mass/inertia
+at finalisation) and per-shape friction (`shape_material_mu`). Multipliers are
+applied to the `ModelBuilder` before the immutable model is finalised and the
+model is rebuilt. A fixed `seed` yields an identical multiplier sequence for a
+given scene (the builder visits bodies/shapes deterministically); the applied
+`mass_scales` / `friction_scales` / `light_direction` are returned in the
+`json` block so callers can log or assert per-episode physics.
+`randomize_positions` is not supported yet and returns an explicit error rather
+than a silent no-op.
+
+`set_obs_noise(joint_pos_std=, joint_vel_std=, camera_jitter_px=, seed=)` adds
+reproducible additive Gaussian noise to `get_observation` joint positions,
+`get_robot_state` positions/velocities, and rendered camera frames (integer
+pixel jitter). `SimEngine` gained a `set_obs_noise` optional override (default
+`NotImplementedError`) alongside `randomize`, and the Newton `describe()`
+advertises both methods.
 
 ### Fixed: RTC inference now forwards `inference_delay` to lerobot's denoiser
 

--- a/docs/simulation/domain-randomization.md
+++ b/docs/simulation/domain-randomization.md
@@ -42,6 +42,12 @@ for episode in range(N):
                              success_fn=my_fn)
 ```
 
+## Newton backend
+
+The Newton (GPU) backend mirrors this `randomize` contract for the axes it
+supports (colors, lighting, physics) and adds `set_obs_noise` for additive
+sensor noise. See [Newton backend](newton.md#domain-randomization-and-sensor-noise).
+
 ## See also
 
 - [Simulation overview](overview.md)

--- a/docs/simulation/newton.md
+++ b/docs/simulation/newton.md
@@ -267,6 +267,73 @@ When no named cameras are registered the dataset records joint state and action
 only (a valid proprio-only dataset); camera columns are added automatically once
 cameras are registered on the world.
 
+
+## Domain randomization and sensor noise
+
+Sim2real workflows need per-episode variation so policies do not overfit to the
+default physics constants. The Newton backend mirrors the MuJoCo
+`randomize` contract (same keyword names and defaults for the axes it supports)
+and adds `set_obs_noise` for additive Gaussian sensor noise.
+
+```python
+sim = create_simulation("newton", solver="mujoco")
+sim.create_world()
+sim.add_robot("so100")
+
+# Per-episode domain randomization. Physics is opt-in (matches MuJoCo's
+# randomize_physics=False default); colors and lighting are on by default.
+for episode in range(10):
+    sim.reset()
+    result = sim.randomize(
+        randomize_colors=True,
+        randomize_lighting=True,
+        randomize_physics=True,
+        mass_range=(0.8, 1.2),       # multiplicative scale on per-body mass
+        friction_range=(0.5, 1.5),   # multiplicative scale on per-shape friction
+        seed=episode,                # deterministic per episode
+    )
+    scales = result["content"][1]["json"]
+    # scales["mass_scales"], scales["friction_scales"], scales["light_direction"]
+    sim.run_policy(robot_name="so100", policy_provider="mock", n_steps=60)
+```
+
+What each axis changes (applied to the Newton `ModelBuilder` before the
+immutable model is finalised, then rebuilt):
+
+| Axis | What changes | Range param |
+|------|--------------|-------------|
+| `randomize_colors` | Per-shape RGB (`builder.shape_color`) | `color_range` |
+| `randomize_lighting` | Directional-light orientation (re-steered each render) | - |
+| `randomize_physics` | Per-body mass + inertia (`body_mass` / `body_inertia`) and per-shape friction (`shape_material_mu`) | `mass_range`, `friction_range` |
+
+Physics randomization scales mass and inertia together (inertia tracks mass for
+fixed geometry); Newton recomputes the inverse mass/inertia at finalisation.
+**Reproducibility**: a fixed `seed` yields an identical multiplier sequence for a
+given scene, because the builder visits bodies and shapes in a deterministic
+order. The applied multipliers are returned in the `json` block so callers can
+log or assert the per-episode physics. Object-position randomization
+(`randomize_positions`) is not supported by the Newton backend yet; requesting
+it returns an explicit error rather than silently doing nothing.
+
+### Sensor noise
+
+`set_obs_noise` adds additive Gaussian noise so observations carry realistic
+measurement error. It applies to every `get_observation` / `get_robot_state`
+and every rendered camera frame until reconfigured (pass all-zero to disable):
+
+```python
+sim.set_obs_noise(
+    joint_pos_std=0.01,     # radians, added to joint positions
+    joint_vel_std=0.05,     # rad/s, added to joint velocities (get_robot_state)
+    camera_jitter_px=2,     # max integer pixel shift on rendered frames
+    seed=0,                 # reproducible noise stream
+)
+obs = sim.get_observation("so100")   # joint positions now carry +/- noise
+```
+
+`describe()` advertises both `randomize` and `set_obs_noise` so a single call
+surfaces their signatures.
+
 ## Mesh objects
 
 `add_object` accepts triangle-mesh assets in addition to primitives, at parity

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -1456,6 +1456,15 @@ class SimEngine(ABC):
         """
         raise NotImplementedError("randomize not implemented by this backend")
 
+    def set_obs_noise(self, **kwargs: Any) -> dict[str, Any]:
+        """Configure additive sensor noise on observations.
+
+        Models real-sensor measurement noise (joint encoders, camera frames)
+        so policies are not trained on noise-free observations. Concrete
+        backends define their own parameter signatures. Override per backend.
+        """
+        raise NotImplementedError("set_obs_noise not implemented by this backend")
+
     def get_contacts(self) -> dict[str, Any]:
         """Get contact information. Override per backend."""
         raise NotImplementedError("get_contacts not implemented by this backend")

--- a/strands_robots/simulation/newton/randomization.py
+++ b/strands_robots/simulation/newton/randomization.py
@@ -1,0 +1,393 @@
+"""Domain randomization and sensor-noise hooks for the Newton backend.
+
+Mixed into :class:`~strands_robots.simulation.newton.simulation.NewtonSimEngine`.
+Mirrors the MuJoCo backend's ``randomize`` contract (same keyword names and
+defaults for the axes Newton supports) and adds ``set_obs_noise`` for additive
+Gaussian sensor noise on joint encoders and camera frames -- the pieces a
+sim2real workflow needs so datasets collected on the GPU backend do not overfit
+to the default physics constants.
+
+Where MuJoCo mutates a live ``mjModel`` in place, Newton finalises an immutable
+``Model`` from a ``ModelBuilder``, so physics randomization (per-body mass and
+per-shape friction) is applied to the builder arrays *before* finalisation. The
+host's :meth:`NewtonSimEngine._rebuild` calls :meth:`_apply_domain_randomization`
+at exactly that point. Lighting is applied at render time by steering the
+directional light, and camera-frame jitter is a post-process on the rendered
+RGB buffer.
+
+**Coupling** (mirrors the MuJoCo mixin): this mixin reaches into the host's
+``_world``, ``_lock``, ``_wp``, ``_rebuild``, and the domain-randomization /
+sensor-noise state attributes initialised in ``NewtonSimEngine.__init__``. The
+``TYPE_CHECKING`` stubs below are a documentary contract so mypy accepts those
+lookups; they are not an enforceable protocol.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+class DomainRandomizationMixin:
+    """Domain randomization + sensor-noise hooks for ``NewtonSimEngine``."""
+
+    if TYPE_CHECKING:
+        from strands_robots.simulation.models import SimWorld
+
+        _lock: threading.RLock
+        _world: SimWorld | None
+        _wp: Any
+        # Domain-randomization state (initialised in NewtonSimEngine.__init__).
+        _dr: dict[str, Any] | None
+        _dr_applied: dict[str, Any] | None
+        _dr_light_dir: tuple[float, float, float] | None
+        # Sensor-noise state.
+        _obs_noise: dict[str, float] | None
+        _obs_noise_rng: np.random.Generator | None
+
+        def _rebuild(self) -> None: ...
+
+    # Domain randomization
+
+    def randomize(
+        self,
+        randomize_colors: bool = True,
+        randomize_lighting: bool = True,
+        randomize_physics: bool = False,
+        mass_range: tuple[float, float] = (0.5, 2.0),
+        friction_range: tuple[float, float] = (0.5, 1.5),
+        color_range: tuple[float, float] = (0.1, 1.0),
+        seed: int | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Apply domain randomization to the Newton scene.
+
+        Keyword names and defaults mirror the MuJoCo backend so randomization
+        code transfers across backends unchanged. Each axis is opt-in:
+
+          - ``randomize_colors=True``  - per-shape RGB resampled in ``color_range``.
+          - ``randomize_lighting=True`` - directional-light orientation jittered.
+          - ``randomize_physics=False`` - per-body mass (``mass_range``) and
+            per-shape friction (``friction_range``) scaled; left untouched unless
+            asked, matching MuJoCo's default.
+
+        Physics randomization scales the builder's ``body_mass`` and
+        ``body_inertia`` (inertia tracks mass for fixed geometry; Newton
+        recomputes the inverse mass/inertia at finalisation) and the per-shape
+        ``shape_material_mu`` friction coefficient, then rebuilds the model.
+        Colors and the sampled light direction take effect on the next
+        ``render`` call.
+
+        Reproducibility: a fixed ``seed`` yields an identical multiplier
+        sequence for a given scene, because the builder visits bodies and shapes
+        in a deterministic order. The applied multipliers are returned in the
+        ``json`` block (``mass_scales`` / ``friction_scales`` /
+        ``light_direction``) so callers can assert reproducibility or log the
+        per-episode physics.
+
+        Args:
+            randomize_colors: Resample per-shape RGB.
+            randomize_lighting: Jitter the directional-light orientation.
+            randomize_physics: Scale per-body mass and per-shape friction.
+            mass_range: ``(lo, hi)`` multiplicative scale on body mass.
+            friction_range: ``(lo, hi)`` multiplicative scale on shape friction.
+            color_range: ``(lo, hi)`` for uniform RGB sampling.
+            seed: Optional seed for reproducible randomization.
+            **kwargs: Tolerated for MuJoCo-signature parity. Passing a truthy
+                ``randomize_positions`` returns an error: Newton does not yet
+                support object-position randomization.
+
+        Returns:
+            Status dict. On success the ``json`` block carries the applied
+            multipliers; an error dict is returned when no world exists, a
+            range is invalid, or an unsupported axis is requested.
+        """
+        if self._world is None:
+            return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+        if kwargs.get("randomize_positions"):
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            "randomize_positions is not supported by the Newton backend yet. "
+                            "Supported axes: randomize_colors, randomize_lighting, randomize_physics. "
+                            "Use the MuJoCo backend for object-position randomization."
+                        )
+                    }
+                ],
+            }
+        for label, rng_range in (
+            ("mass_range", mass_range),
+            ("friction_range", friction_range),
+            ("color_range", color_range),
+        ):
+            err = _validate_range(label, rng_range)
+            if err is not None:
+                return {"status": "error", "content": [{"text": err}]}
+
+        with self._lock:
+            self._dr = {
+                "randomize_colors": bool(randomize_colors),
+                "randomize_lighting": bool(randomize_lighting),
+                "randomize_physics": bool(randomize_physics),
+                "mass_range": (float(mass_range[0]), float(mass_range[1])),
+                "friction_range": (float(friction_range[0]), float(friction_range[1])),
+                "color_range": (float(color_range[0]), float(color_range[1])),
+                "seed": seed,
+            }
+            # _rebuild invokes _apply_domain_randomization, which samples the
+            # multipliers and populates self._dr_applied / self._dr_light_dir.
+            self._rebuild()
+            applied = self._dr_applied or {}
+
+        n_mass = len(applied.get("mass_scales", []))
+        n_fric = len(applied.get("friction_scales", []))
+        changes = []
+        if randomize_colors:
+            changes.append(f"Colors: {applied.get('n_colors', 0)} shapes randomized")
+        if randomize_lighting:
+            changes.append(f"Lighting: light direction = {applied.get('light_direction')}")
+        if randomize_physics:
+            changes.append(f"Physics: {n_mass} bodies mass-scaled, {n_fric} shapes friction-scaled")
+        if not changes:
+            changes.append("No axes enabled; nothing randomized.")
+
+        return {
+            "status": "success",
+            "content": [
+                {"text": "Domain randomization applied:\n" + "\n".join(changes)},
+                {"json": applied},
+            ],
+        }
+
+    def _apply_domain_randomization(self, builder: Any) -> None:
+        """Apply the active randomization spec to a fresh ``ModelBuilder``.
+
+        Called by :meth:`NewtonSimEngine._rebuild` after robots, objects, and
+        the ground plane have been added but before ``builder.finalize``. A
+        no-op when no randomization spec is active. Must be called with
+        ``self._lock`` held. Samples deterministically from ``self._dr["seed"]``
+        and records the applied multipliers in ``self._dr_applied``.
+
+        Args:
+            builder: The Newton ``ModelBuilder`` being assembled this rebuild.
+        """
+        dr = self._dr
+        if not dr:
+            return
+        rng = np.random.default_rng(dr["seed"])
+        applied: dict[str, Any] = {}
+
+        if dr["randomize_colors"]:
+            lo, hi = dr["color_range"]
+            n = len(builder.shape_color)
+            for i in range(n):
+                builder.shape_color[i] = tuple(float(c) for c in rng.uniform(lo, hi, size=3))
+            applied["n_colors"] = n
+
+        if dr["randomize_physics"]:
+            wp = self._wp
+            mlo, mhi = dr["mass_range"]
+            mass_scales: list[float] = []
+            for i in range(len(builder.body_mass)):
+                if builder.body_mass[i] > 0:
+                    s = float(rng.uniform(mlo, mhi))
+                    builder.body_mass[i] *= s
+                    inertia = np.array(builder.body_inertia[i], dtype=np.float32).reshape(3, 3) * s
+                    builder.body_inertia[i] = wp.mat33f(inertia)
+                    mass_scales.append(s)
+            flo, fhi = dr["friction_range"]
+            friction_scales: list[float] = []
+            for i in range(len(builder.shape_material_mu)):
+                f = float(rng.uniform(flo, fhi))
+                builder.shape_material_mu[i] *= f
+                friction_scales.append(f)
+            applied["mass_scales"] = mass_scales
+            applied["friction_scales"] = friction_scales
+
+        if dr["randomize_lighting"]:
+            # Jitter the default directional light (normalized (-1, 1, -1)) and
+            # renormalize so the renderer receives a unit direction.
+            base = np.array([-1.0, 1.0, -1.0])
+            jitter = rng.uniform(-0.6, 0.6, size=3)
+            direction = base + jitter
+            norm = float(np.linalg.norm(direction))
+            if norm > 1e-6:
+                direction = direction / norm
+            light_dir = (float(direction[0]), float(direction[1]), float(direction[2]))
+            self._dr_light_dir = light_dir
+            applied["light_direction"] = light_dir
+        else:
+            self._dr_light_dir = None
+
+        self._dr_applied = applied
+
+    # Sensor noise
+
+    def set_obs_noise(
+        self,
+        joint_pos_std: float = 0.0,
+        joint_vel_std: float = 0.0,
+        camera_jitter_px: float = 0.0,
+        seed: int | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Configure additive Gaussian sensor noise on observations.
+
+        Models real-encoder / real-camera measurement noise so policies trained
+        on Newton data do not assume noise-free sensing. Once set, the noise is
+        applied on every :meth:`get_observation` / :meth:`get_robot_state` and
+        every rendered camera frame until reconfigured. Pass all-zero std to
+        disable.
+
+        Args:
+            joint_pos_std: Std (radians) of Gaussian noise added to joint
+                positions in ``get_observation`` and ``get_robot_state``.
+            joint_vel_std: Std (rad/s) of Gaussian noise added to joint
+                velocities in ``get_robot_state``.
+            camera_jitter_px: Max integer pixel shift applied to rendered
+                frames (uniform in ``[-px, px]`` per axis).
+            seed: Optional seed for a reproducible noise stream.
+            **kwargs: Accepted for ``SimEngine.set_obs_noise`` signature
+                compatibility; ignored by the Newton backend.
+
+        Returns:
+            Status dict echoing the configured noise, or an error dict when any
+            value is negative or non-finite.
+        """
+        for label, value in (
+            ("joint_pos_std", joint_pos_std),
+            ("joint_vel_std", joint_vel_std),
+            ("camera_jitter_px", camera_jitter_px),
+        ):
+            try:
+                fvalue = float(value)
+            except (TypeError, ValueError):
+                return {
+                    "status": "error",
+                    "content": [{"text": f"set_obs_noise: {label} must be a number, got {value!r}"}],
+                }
+            if not np.isfinite(fvalue) or fvalue < 0:
+                return {
+                    "status": "error",
+                    "content": [
+                        {"text": f"set_obs_noise: {label} must be a finite non-negative number, got {value!r}"}
+                    ],
+                }
+
+        with self._lock:
+            self._obs_noise = {
+                "joint_pos_std": float(joint_pos_std),
+                "joint_vel_std": float(joint_vel_std),
+                "camera_jitter_px": float(camera_jitter_px),
+            }
+            self._obs_noise_rng = np.random.default_rng(seed)
+        return {
+            "status": "success",
+            "content": [
+                {
+                    "text": (
+                        f"Sensor noise: joint_pos_std={joint_pos_std}, "
+                        f"joint_vel_std={joint_vel_std}, camera_jitter_px={camera_jitter_px}"
+                    )
+                }
+            ],
+        }
+
+    def _apply_joint_pos_noise(self, obs: dict[str, float]) -> dict[str, float]:
+        """Return ``obs`` with Gaussian noise added to each joint position.
+
+        A no-op (returns the input unchanged) when no positive-std joint
+        position noise is configured.
+
+        Args:
+            obs: Mapping of joint name to position (radians).
+
+        Returns:
+            New mapping with noise applied, or the original when disabled.
+        """
+        std = (self._obs_noise or {}).get("joint_pos_std", 0.0)
+        rng = self._obs_noise_rng
+        if std <= 0 or rng is None or not obs:
+            return obs
+        return {k: float(v) + float(rng.normal(0.0, std)) for k, v in obs.items()}
+
+    def _apply_state_noise(self, state: dict[str, dict[str, float]]) -> dict[str, dict[str, float]]:
+        """Return ``state`` with Gaussian noise added to positions and velocities.
+
+        Used by :meth:`NewtonSimEngine.get_robot_state`, whose entries are
+        ``{joint: {"position": p, "velocity": v}}``. Position noise uses
+        ``joint_pos_std`` and velocity noise uses ``joint_vel_std`` from
+        :meth:`set_obs_noise`. A no-op when neither std is positive.
+
+        Args:
+            state: Per-joint ``{"position", "velocity"}`` mapping.
+
+        Returns:
+            New mapping with noise applied, or the original when disabled.
+        """
+        cfg = self._obs_noise or {}
+        pos_std = cfg.get("joint_pos_std", 0.0)
+        vel_std = cfg.get("joint_vel_std", 0.0)
+        rng = self._obs_noise_rng
+        if rng is None or (pos_std <= 0 and vel_std <= 0) or not state:
+            return state
+        out: dict[str, dict[str, float]] = {}
+        for jname, vals in state.items():
+            pos = vals["position"] + (float(rng.normal(0.0, pos_std)) if pos_std > 0 else 0.0)
+            vel = vals["velocity"] + (float(rng.normal(0.0, vel_std)) if vel_std > 0 else 0.0)
+            out[jname] = {"position": pos, "velocity": vel}
+        return out
+
+    def _maybe_jitter_frame(self, frame: np.ndarray) -> np.ndarray:
+        """Return ``frame`` shifted by a random integer pixel offset.
+
+        Applies ``camera_jitter_px`` configured via :meth:`set_obs_noise` by
+        rolling the image along both axes. A no-op when jitter is disabled.
+
+        Args:
+            frame: ``(H, W, 3)`` uint8 RGB array.
+
+        Returns:
+            Jittered array (a rolled view/copy), or the original when disabled.
+        """
+        px = (self._obs_noise or {}).get("camera_jitter_px", 0.0)
+        rng = self._obs_noise_rng
+        if px <= 0 or rng is None or frame.ndim < 2:
+            return frame
+        max_shift = int(px)
+        if max_shift < 1:
+            return frame
+        dy = int(rng.integers(-max_shift, max_shift + 1))
+        dx = int(rng.integers(-max_shift, max_shift + 1))
+        return np.roll(frame, shift=(dy, dx), axis=(0, 1))
+
+
+def _validate_range(label: str, rng_range: Any) -> str | None:
+    """Validate a ``(lo, hi)`` randomization range.
+
+    Args:
+        label: Parameter name for the error message.
+        rng_range: The candidate ``(lo, hi)`` pair.
+
+    Returns:
+        ``None`` when valid, otherwise an error message string.
+    """
+    try:
+        lo, hi = rng_range
+        lo, hi = float(lo), float(hi)
+    except (TypeError, ValueError):
+        return f"{label} must be a (lo, hi) pair of numbers, got {rng_range!r}"
+    if not (np.isfinite(lo) and np.isfinite(hi)):
+        return f"{label} bounds must be finite, got {rng_range!r}"
+    if lo > hi:
+        return f"{label} lower bound {lo} exceeds upper bound {hi}"
+    if lo < 0:
+        return f"{label} bounds must be non-negative, got {rng_range!r}"
+    return None

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -47,6 +47,7 @@ from strands_robots.simulation.model_registry import (
 )
 from strands_robots.simulation.models import SimCamera, SimObject, SimRobot, SimWorld
 from strands_robots.simulation.newton.backend import ensure_newton, resolve_solver_class, solver_registry
+from strands_robots.simulation.newton.randomization import DomainRandomizationMixin
 from strands_robots.simulation.newton.recording import NewtonRecordingMixin
 from strands_robots.utils import require_optional
 
@@ -88,7 +89,7 @@ def _short_joint_name(label: str) -> str:
     return label.rsplit("/", 1)[-1]
 
 
-class NewtonSimEngine(NewtonRecordingMixin, SimEngine):
+class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine):
     """GPU-native simulation backend built on Newton (Warp / MuJoCo-Warp).
 
     One Newton model per instance. The world is rebuilt whenever robots or
@@ -172,6 +173,15 @@ class NewtonSimEngine(NewtonRecordingMixin, SimEngine):
         # Parsed mesh geometry keyed by resolved mesh_path, so rebuilds do not
         # re-read mesh assets off disk on every scene mutation.
         self._mesh_cache: dict[str, tuple[Any, Any]] = {}
+        # Domain-randomization spec + applied multipliers (see
+        # strands_robots.simulation.newton.randomization). None until
+        # randomize() is called; applied during _rebuild.
+        self._dr: dict[str, Any] | None = None
+        self._dr_applied: dict[str, Any] | None = None
+        self._dr_light_dir: tuple[float, float, float] | None = None
+        # Additive sensor-noise config + reproducible RNG (set_obs_noise).
+        self._obs_noise: dict[str, float] | None = None
+        self._obs_noise_rng: np.random.Generator | None = None
 
         logger.info("Newton simulation engine initialised (solver=%s)", self._solver_name)
 
@@ -213,6 +223,11 @@ class NewtonSimEngine(NewtonRecordingMixin, SimEngine):
             self._state_0 = self._state_1 = self._control = None
             self._joint_order = []
             self._targets = {}
+            self._dr = None
+            self._dr_applied = None
+            self._dr_light_dir = None
+            self._obs_noise = None
+            self._obs_noise_rng = None
         return {"status": "success", "content": [{"text": "Newton world destroyed."}]}
 
     def reset(self) -> dict[str, Any]:
@@ -584,6 +599,10 @@ class NewtonSimEngine(NewtonRecordingMixin, SimEngine):
                 idx = self._joint_coord_index.get((robot_name, jname))
                 if idx is not None and idx < len(joint_q):
                     obs[jname] = float(joint_q[idx])
+        # Joint-position sensor noise applies only to the float joint entries;
+        # camera frames are added afterwards (and carry their own jitter via the
+        # render path), so the result holds mixed float/ndarray values.
+        obs_out: dict[str, Any] = dict(self._apply_joint_pos_noise(obs))
         if not skip_images:
             from strands_robots.simulation.policy_runner import _extract_frame_ndarray
 
@@ -591,8 +610,8 @@ class NewtonSimEngine(NewtonRecordingMixin, SimEngine):
                 render_result = self.render(camera_name=cam_name)
                 img = _extract_frame_ndarray(render_result)
                 if img is not None:
-                    obs[cam_name] = img
-        return obs
+                    obs_out[cam_name] = img
+        return obs_out
 
     def send_action(self, action: dict[str, Any], robot_name: str | None = None, n_substeps: int = 1) -> dict[str, Any]:
         """Apply position targets and advance physics by ``n_substeps``.
@@ -1018,7 +1037,8 @@ class NewtonSimEngine(NewtonRecordingMixin, SimEngine):
         with self._lock:
             sensors = self._nt.sensors
             cam = sensors.SensorTiledCamera(model=self._model)
-            cam.utils.create_default_light(enable_shadows=False)
+            light_dir = self._wp.vec3f(*self._dr_light_dir) if self._dr_light_dir is not None else None
+            cam.utils.create_default_light(enable_shadows=False, direction=light_dir)
             rays = cam.utils.compute_pinhole_camera_rays(w, h, math.radians(fov_deg))
             color = cam.utils.create_color_image_output(w, h, 1)
             q = self._look_at_quat(tuple(eye), tuple(target))
@@ -1034,7 +1054,8 @@ class NewtonSimEngine(NewtonRecordingMixin, SimEngine):
             )
             rgba = cam.utils.to_rgba_from_color(color).numpy()
         frame = rgba[0, 0] if rgba.ndim == 5 else rgba[0]
-        return np.ascontiguousarray(frame[..., :3])
+        frame = np.ascontiguousarray(frame[..., :3])
+        return self._maybe_jitter_frame(frame)
 
     # Interactive viewer
 
@@ -1222,6 +1243,7 @@ class NewtonSimEngine(NewtonRecordingMixin, SimEngine):
                 pos = float(joint_q[q_idx]) if q_idx is not None and q_idx < len(joint_q) else 0.0
                 vel = float(joint_qd[d_idx]) if d_idx is not None and d_idx < len(joint_qd) else 0.0
                 state[jname] = {"position": pos, "velocity": vel}
+        state = self._apply_state_noise(state)
 
         text = f"'{robot_name}' state (t={self._world.sim_time:.3f}s):\n"
         for jnt, vals in state.items():
@@ -1484,6 +1506,15 @@ class NewtonSimEngine(NewtonRecordingMixin, SimEngine):
                     "streams a browser dashboard at localhost:port headless)"
                 ),
                 "close_viewer": "() -> dict  (close the interactive viewer)",
+                "randomize": (
+                    "(randomize_colors=True, randomize_lighting=True, randomize_physics=False, "
+                    "mass_range=(0.5, 2.0), friction_range=(0.5, 1.5), color_range=(0.1, 1.0), "
+                    "seed=None) -> dict (domain randomization; json block carries applied multipliers)"
+                ),
+                "set_obs_noise": (
+                    "(joint_pos_std=0.0, joint_vel_std=0.0, camera_jitter_px=0.0, seed=None) -> dict "
+                    "(additive Gaussian sensor noise on observations + rendered frames)"
+                ),
                 "reset": "() -> dict (restore baseline joint configuration)",
                 "step": "(n_steps: int = 1) -> dict",
                 "start_recording": (
@@ -1700,6 +1731,10 @@ class NewtonSimEngine(NewtonRecordingMixin, SimEngine):
 
         if self._world.ground_plane:
             builder.add_ground_plane()
+
+        # Apply active domain randomization (mass/friction/colors) to the
+        # builder arrays before the immutable model is finalized.
+        self._apply_domain_randomization(builder)
 
         self._model = builder.finalize(device=self.device)
         # Newton solvers snapshot gravity at construction, and ModelBuilder only

--- a/tests/simulation/newton/test_domain_randomization.py
+++ b/tests/simulation/newton/test_domain_randomization.py
@@ -1,0 +1,277 @@
+"""Domain randomization and sensor-noise hooks for the Newton backend.
+
+Two layers:
+
+- Pure-helper unit tests (no Newton/Warp required) cover the deterministic
+  sampling, range validation, and observation/frame noise application that the
+  feature is built on. These run everywhere, including CPU-only CI.
+- Integration tests (gated on Newton + Warp) drive the real engine: physics
+  randomization mutates the finalized model's mass/friction, the multiplier
+  sequence is reproducible for a fixed seed and varies across episodes, lighting
+  and colors flow through to rendered frames, and configured sensor noise shows
+  up with the requested standard deviation on observations.
+
+The integration tests use the ``featherstone`` solver so they do not require
+``mujoco_warp`` (the default ``mujoco`` solver's extra dependency).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import threading
+
+import numpy as np
+import pytest
+
+from strands_robots.simulation.newton.randomization import (
+    DomainRandomizationMixin,
+    _validate_range,
+)
+
+_HAS_NEWTON = importlib.util.find_spec("newton") is not None and importlib.util.find_spec("warp") is not None
+
+
+# --------------------------------------------------------------------------- #
+# Pure-helper unit tests (no Newton required)
+# --------------------------------------------------------------------------- #
+
+
+class _NoiseHost(DomainRandomizationMixin):
+    """Minimal host exposing only the state the noise/validation helpers touch."""
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._world = None
+        self._dr = None
+        self._dr_applied = None
+        self._dr_light_dir = None
+        self._obs_noise = None
+        self._obs_noise_rng = None
+
+
+class TestValidateRange:
+    def test_accepts_ordered_non_negative_pair(self):
+        assert _validate_range("mass_range", (0.5, 2.0)) is None
+
+    def test_rejects_inverted_bounds(self):
+        msg = _validate_range("mass_range", (2.0, 0.5))
+        assert msg is not None and "exceeds upper bound" in msg
+
+    def test_rejects_negative_bound(self):
+        msg = _validate_range("friction_range", (-0.1, 1.0))
+        assert msg is not None and "non-negative" in msg
+
+    def test_rejects_non_numeric(self):
+        assert _validate_range("color_range", "nope") is not None
+
+    def test_rejects_non_finite(self):
+        assert _validate_range("mass_range", (0.0, float("inf"))) is not None
+
+
+class TestSetObsNoiseValidation:
+    def test_negative_std_is_error(self):
+        host = _NoiseHost()
+        result = host.set_obs_noise(joint_pos_std=-0.1)
+        assert result["status"] == "error"
+        assert host._obs_noise is None
+
+    def test_non_finite_is_error(self):
+        host = _NoiseHost()
+        assert host.set_obs_noise(camera_jitter_px=float("nan"))["status"] == "error"
+
+    def test_valid_config_is_stored(self):
+        host = _NoiseHost()
+        result = host.set_obs_noise(joint_pos_std=0.02, joint_vel_std=0.1, camera_jitter_px=3, seed=0)
+        assert result["status"] == "success"
+        assert host._obs_noise == {"joint_pos_std": 0.02, "joint_vel_std": 0.1, "camera_jitter_px": 3.0}
+        assert host._obs_noise_rng is not None
+
+
+class TestJointPosNoise:
+    def test_disabled_returns_input_unchanged(self):
+        host = _NoiseHost()
+        obs = {"Rotation": 0.5, "Pitch": -0.2}
+        assert host._apply_joint_pos_noise(obs) is obs
+
+    def test_adds_noise_with_requested_std(self):
+        host = _NoiseHost()
+        host.set_obs_noise(joint_pos_std=0.05, seed=0)
+        samples = [host._apply_joint_pos_noise({"j": 1.0})["j"] for _ in range(20000)]
+        assert abs(float(np.std(samples)) - 0.05) < 0.005
+        assert abs(float(np.mean(samples)) - 1.0) < 0.005
+
+    def test_is_reproducible_for_same_seed(self):
+        a, b = _NoiseHost(), _NoiseHost()
+        a.set_obs_noise(joint_pos_std=0.1, seed=7)
+        b.set_obs_noise(joint_pos_std=0.1, seed=7)
+        seq_a = [a._apply_joint_pos_noise({"j": 0.0})["j"] for _ in range(50)]
+        seq_b = [b._apply_joint_pos_noise({"j": 0.0})["j"] for _ in range(50)]
+        assert seq_a == seq_b
+
+
+class TestStateNoise:
+    def test_velocity_noise_independent_of_position(self):
+        host = _NoiseHost()
+        host.set_obs_noise(joint_pos_std=0.0, joint_vel_std=0.2, seed=1)
+        states = [host._apply_state_noise({"j": {"position": 0.3, "velocity": 0.0}})["j"] for _ in range(20000)]
+        positions = [s["position"] for s in states]
+        velocities = [s["velocity"] for s in states]
+        assert positions == [0.3] * len(positions)  # pos std == 0 -> untouched
+        assert abs(float(np.std(velocities)) - 0.2) < 0.02
+
+    def test_disabled_returns_input_unchanged(self):
+        host = _NoiseHost()
+        state = {"j": {"position": 0.1, "velocity": 0.2}}
+        assert host._apply_state_noise(state) is state
+
+
+class TestFrameJitter:
+    def test_disabled_returns_input_unchanged(self):
+        host = _NoiseHost()
+        frame = np.zeros((8, 8, 3), dtype=np.uint8)
+        assert host._maybe_jitter_frame(frame) is frame
+
+    def test_jitter_shifts_pixels_without_changing_shape(self):
+        host = _NoiseHost()
+        host.set_obs_noise(camera_jitter_px=3, seed=2)
+        frame = np.arange(8 * 8 * 3, dtype=np.uint8).reshape(8, 8, 3)
+        out = host._maybe_jitter_frame(frame)
+        assert out.shape == frame.shape
+        assert not np.array_equal(out, frame)
+        # A roll is a permutation: the pixel multiset is preserved.
+        assert sorted(out.flatten().tolist()) == sorted(frame.flatten().tolist())
+
+
+class TestRandomizeGuards:
+    def test_no_world_is_error(self):
+        host = _NoiseHost()  # _world is None
+        assert host.randomize(randomize_physics=True)["status"] == "error"
+
+    def test_randomize_positions_rejected(self):
+        host = _NoiseHost()
+        host._world = object()  # non-None so the world guard passes
+        result = host.randomize(randomize_positions=True)
+        assert result["status"] == "error"
+        assert "randomize_positions is not supported" in result["content"][0]["text"]
+
+    def test_invalid_range_rejected(self):
+        host = _NoiseHost()
+        host._world = object()
+        assert host.randomize(mass_range=(2.0, 0.5))["status"] == "error"
+
+
+# --------------------------------------------------------------------------- #
+# Integration tests (real Newton engine)
+# --------------------------------------------------------------------------- #
+
+newton_only = pytest.mark.skipif(not _HAS_NEWTON, reason="newton/warp not installed")
+
+
+@pytest.fixture
+def engine():
+    from strands_robots.simulation.newton.simulation import NewtonSimEngine
+
+    sim = NewtonSimEngine(solver="featherstone")
+    sim.create_world()
+    sim.add_robot("so100")
+    yield sim
+    sim.destroy()
+
+
+def _model_mass(sim) -> np.ndarray:
+    return np.array(sim._model.body_mass.numpy())
+
+
+def _model_friction(sim) -> np.ndarray:
+    return np.array(sim._model.shape_material_mu.numpy())
+
+
+@newton_only
+class TestPhysicsRandomization:
+    def test_physics_scales_mass_and_friction(self, engine):
+        base_mass = _model_mass(engine)
+        base_friction = _model_friction(engine)
+        result = engine.randomize(randomize_physics=True, mass_range=(0.8, 1.2), friction_range=(0.5, 1.5), seed=42)
+        assert result["status"] == "success"
+        assert not np.allclose(base_mass, _model_mass(engine))
+        assert not np.allclose(base_friction, _model_friction(engine))
+
+    def test_mass_scales_stay_within_range(self, engine):
+        result = engine.randomize(randomize_physics=True, mass_range=(0.8, 1.2), seed=11)
+        scales = result["content"][1]["json"]["mass_scales"]
+        assert scales
+        assert all(0.8 <= s <= 1.2 for s in scales)
+
+    def test_colors_only_leaves_physics_untouched(self, engine):
+        base_mass = _model_mass(engine)
+        engine.randomize(randomize_colors=True, randomize_physics=False, seed=1)
+        assert np.allclose(base_mass, _model_mass(engine))
+
+
+@newton_only
+class TestReproducibility:
+    def test_same_seed_identical_scales(self, engine):
+        a = engine.randomize(randomize_physics=True, seed=42)["content"][1]["json"]
+        b = engine.randomize(randomize_physics=True, seed=42)["content"][1]["json"]
+        assert a["mass_scales"] == b["mass_scales"]
+        assert a["friction_scales"] == b["friction_scales"]
+        assert a["light_direction"] == b["light_direction"]
+
+    def test_different_seed_differs(self, engine):
+        a = engine.randomize(randomize_physics=True, seed=1)["content"][1]["json"]
+        b = engine.randomize(randomize_physics=True, seed=2)["content"][1]["json"]
+        assert a["mass_scales"] != b["mass_scales"]
+
+    def test_ten_episode_sequence_is_reproducible(self, engine):
+        def run() -> list[list[float]]:
+            seq = []
+            for episode in range(10):
+                engine.reset()
+                out = engine.randomize(randomize_physics=True, mass_range=(0.8, 1.2), seed=episode)
+                seq.append(out["content"][1]["json"]["mass_scales"])
+            return seq
+
+        first = run()
+        second = run()
+        assert first == second
+        # Acceptance: across episodes the physics actually varies.
+        assert first[0] != first[1]
+
+
+@newton_only
+class TestRenderingAxes:
+    def test_lighting_changes_rendered_frame(self, engine):
+        engine.randomize(randomize_lighting=True, randomize_colors=False, seed=1)
+        img_a = engine.render(width=120, height=90)
+        mean_a = img_a["content"][2]["json"]["pixel_mean"]
+        engine.randomize(randomize_lighting=True, randomize_colors=False, seed=99)
+        img_b = engine.render(width=120, height=90)
+        mean_b = img_b["content"][2]["json"]["pixel_mean"]
+        assert img_a["status"] == "success" and img_b["status"] == "success"
+        assert mean_a != mean_b
+
+    def test_colors_render_succeeds(self, engine):
+        engine.randomize(randomize_colors=True, randomize_lighting=False, seed=5)
+        assert engine.render(width=120, height=90)["status"] == "success"
+
+
+@newton_only
+class TestSensorNoiseOnEngine:
+    def test_observation_position_noise_has_requested_std(self, engine):
+        engine.send_action({"Rotation": 0.3}, robot_name="so100", n_substeps=20)
+        engine.set_obs_noise(joint_pos_std=0.03, seed=0)
+        samples = [engine.get_observation("so100")["Rotation"] for _ in range(3000)]
+        assert abs(float(np.std(samples)) - 0.03) < 0.004
+
+    def test_robot_state_velocity_noise(self, engine):
+        engine.set_obs_noise(joint_vel_std=0.05, seed=0)
+        vels = [
+            engine.get_robot_state("so100")["content"][1]["json"]["state"]["Rotation"]["velocity"] for _ in range(3000)
+        ]
+        assert float(np.std(vels)) > 0.0
+
+    def test_camera_jitter_changes_frame(self, engine):
+        baseline = engine.render(width=120, height=90)["content"][1]["image"]["source"]["bytes"]
+        engine.set_obs_noise(camera_jitter_px=6, seed=3)
+        jittered = engine.render(width=120, height=90)["content"][1]["image"]["source"]["bytes"]
+        assert baseline != jittered


### PR DESCRIPTION
## Problem

The Newton GPU backend has no domain randomization and no sensor-noise injection point, while the MuJoCo backend exposes `randomize()`. Without per-episode variation and additive sensor noise, datasets collected on Newton overfit to the default physics constants, so policies trained on them transfer poorly to real arms.

## Change

Add the two sim2real hooks to `NewtonSimEngine` via a new `DomainRandomizationMixin` (mirrors the MuJoCo backend's `randomization.py` module layout).

### `randomize(...)`

Mirrors the MuJoCo backend's contract exactly for the axes Newton supports - same keyword names and the same `randomize_physics=False` default - so randomization code transfers across backends unchanged:

| Axis | What changes | Range param |
|------|--------------|-------------|
| `randomize_colors` (default on) | per-shape RGB (`builder.shape_color`) | `color_range` |
| `randomize_lighting` (default on) | directional-light orientation, re-steered each render | - |
| `randomize_physics` (default off) | per-body mass + inertia (`body_mass`/`body_inertia`) and per-shape friction (`shape_material_mu`) | `mass_range`, `friction_range` |

Multipliers are applied to the `ModelBuilder` arrays before the immutable `Model` is finalised, then the model is rebuilt. Mass and inertia are scaled together; Newton recomputes the inverse mass/inertia at finalisation. A fixed `seed` yields an identical multiplier sequence for a given scene; the applied `mass_scales` / `friction_scales` / `light_direction` are returned in the `json` block. `randomize_positions` is not supported yet and returns an explicit error rather than a silent no-op.

### `set_obs_noise(joint_pos_std=, joint_vel_std=, camera_jitter_px=, seed=)`

Adds reproducible additive Gaussian noise to `get_observation` joint positions, `get_robot_state` positions/velocities, and rendered camera frames (integer pixel jitter), modelling real encoder/camera measurement error. `SimEngine` gains a `set_obs_noise` optional override (default `NotImplementedError`) alongside `randomize`, and the Newton `describe()` advertises both methods.

## Tests

`tests/simulation/newton/test_domain_randomization.py`:
- **Pure-helper unit tests** (no Newton/Warp required, run on CPU CI): range validation, `set_obs_noise` validation, deterministic joint/state noise, reproducible noise stream, and frame-jitter permutation invariants.
- **Newton-gated integration tests** (featherstone solver): physics randomization mutates the finalised model's `body_mass`/`shape_material_mu`; same-seed runs produce identical scales while different seeds diverge; a 10-episode `seed=episode` loop is byte-identical across two runs and varies across episodes; lighting/color changes flow through to rendered frames; configured sensor noise shows the requested std on observations; camera jitter changes the rendered frame.

## Visual artifact

Rollout in Newton sim (headless, `MUJOCO_GL=egl`), so100 arm.

Per-seed domain randomization (colors + lighting + physics), seeds 0-5:

![domain-randomization grid](https://github.com/cagataycali/robots/releases/download/newton-dr-artifacts-1782632870/newton_dr_grid.png)

Domain-randomized mock-policy rollout:

![domain-randomized rollout](https://github.com/cagataycali/robots/releases/download/newton-dr-artifacts-1782632870/newton_dr_rollout.gif)

MP4: https://github.com/cagataycali/robots/releases/download/newton-dr-artifacts-1782632870/newton_dr_rollout.mp4

## Docs

New "Domain randomization and sensor noise" section in `docs/simulation/newton.md`, a cross-reference from `docs/simulation/domain-randomization.md`, and a CHANGELOG entry.

---

## Changelog

**Rebased onto main** (resolves the merge conflict from sibling Newton PRs merging ahead - #785, #789, #782/#787/#790):
- `simulation.py` `get_observation`: joint-position sensor noise now applies to the joint floats before the named-camera frames (#789) are added; mypy clean.
- `simulation.py` render light path: kept the DR directional-light `direction=` override and #789's per-camera `fov_deg` rays.
- `simulation.py` `NewtonSimEngine` bases + `describe()`: composes `DomainRandomizationMixin` alongside `NewtonRecordingMixin`.
- `CHANGELOG.md` / `docs/simulation/newton.md`: DR/sensor-noise entries sit after the dataset-recording and named-camera sections.
- CodeQL alert 560 (`randomization.py:53`): dismissed as a false positive - a `TYPE_CHECKING`-only stub for the host method `NewtonSimEngine._rebuild` (concrete at `simulation.py:1123`). The `...` body is load-bearing for standalone mixin type-checking; structurally identical to the un-flagged `mujoco/randomization.py:37` stub.

### Rebase round 2 - onto main @ 7be35a5 (#797 cameras / #796 verify-dataset / #792 mesh objects)

The approved branch went CONFLICTING again when three sibling PRs merged ahead of it. Re-rebased and resolved:
- `simulation.py` `__init__`: kept #792's `_mesh_cache` attribute and this branch's DR / sensor-noise state (`_dr`, `_dr_applied`, `_dr_light_dir`, `_obs_noise`, `_obs_noise_rng`) - independent instance attributes, both retained.
- `simulation.py` `describe()` methods dict: kept #791's `open_viewer`/`close_viewer` entries alongside this branch's `randomize`/`set_obs_noise` entries.
- `docs/simulation/newton.md`: **removed the now-false `## Limitations` section.** Its sole bullet ("Mesh objects in `add_object` are not yet supported") was contradicted by #792, which landed mesh-object support on main. The `## Domain randomization and sensor noise` section now precedes the `## Mesh objects` section from #792 with no stale claim.

Verification: `git merge-tree` against main reports 0 conflicts; `py_compile` + `ruff check`/`ruff format` clean on the resolved Python file; CHANGELOG and docs carry no conflict markers and no stale "not yet supported" mesh claim.