### PR TITLE
test(policies): pin embodiment-pipeline tests to Hub offline mode

### DIFF
--- a/tests/policies/lerobot_local/test_embodiment_pipeline.py
+++ b/tests/policies/lerobot_local/test_embodiment_pipeline.py
@@ -4,6 +4,11 @@ Unlike the mock-heavy existing suite (which let B7/B12 slip past), these load an
 ACTUAL LeRobot processor pipeline and verify the embodiment map is injected and
 transforms raw strands-native observations correctly. Skips cleanly if the
 model config isn't cached / lerobot processor unavailable.
+
+Hub offline mode is forced for the whole module (see ``_force_hub_offline``):
+``ProcessorBridge.from_pretrained`` loads from the local cache or fails fast and
+skips, so a slow or unreachable Hub can never trigger an unbounded background
+download that hangs the suite past ``pytest-timeout``.
 """
 
 import numpy as np
@@ -15,6 +20,28 @@ from strands_robots.policies.lerobot_local.embodiment import EmbodimentMap
 from strands_robots.policies.lerobot_local.processor import ProcessorBridge
 
 SMOLVLA = "lerobot/smolvla_base"
+
+
+@pytest.fixture(autouse=True)
+def _force_hub_offline(monkeypatch):
+    """Pin huggingface_hub to offline mode for every test in this module.
+
+    ``ProcessorBridge.from_pretrained`` reads a real checkpoint from the Hub.
+    With a reachable cache that is fast; with a slow/unreachable Hub the xet
+    download neither completes nor raises promptly, so the ``try/except`` skip
+    guard in ``_load_bridge`` never fires and the whole session is killed by
+    ``pytest-timeout``. Forcing offline makes the load deterministic: a cache
+    hit runs the real pipeline, a cache miss raises ``LocalEntryNotFoundError``
+    immediately and the test skips.
+
+    ``huggingface_hub.constants.HF_HUB_OFFLINE`` is evaluated once at import,
+    so the environment variable alone is insufficient once the package is
+    imported; the module global must be patched directly. ``is_offline_mode()``
+    reads that global at call time, so the patch takes effect immediately.
+    """
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_OFFLINE", True)
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setenv("TRANSFORMERS_OFFLINE", "1")
 
 
 def _load_bridge():
@@ -32,6 +59,32 @@ def _load_bridge():
     if bridge is None or not bridge.has_preprocessor:
         pytest.skip("SmolVLA preprocessor not loaded")
     return bridge
+
+
+def test_load_bridge_runs_under_hub_offline_mode(monkeypatch):
+    """The bridge load must run with the Hub in offline mode.
+
+    Regression for a CI hang: ``from_pretrained`` triggered an unbounded xet
+    download that timed out the whole suite instead of skipping. The fix pins
+    the module to offline mode so the load is cache-only. This asserts the
+    invariant at the exact call site by spying on ``from_pretrained`` and
+    checking ``is_offline_mode()`` is active when it runs. Fails before the fix
+    (offline not forced -> ``is_offline_mode()`` is False).
+    """
+    import huggingface_hub.constants as hf_constants
+
+    seen = {}
+
+    def spy(*_args, **_kwargs):
+        seen["offline"] = hf_constants.is_offline_mode()
+        raise RuntimeError("forced: do not actually load weights")
+
+    monkeypatch.setattr(ProcessorBridge, "from_pretrained", spy)
+
+    with pytest.raises(pytest.skip.Exception):
+        _load_bridge()
+
+    assert seen.get("offline") is True, "from_pretrained must run under HF Hub offline mode"
 
 
 def test_apply_embodiment_injects_rename_and_pack():


### PR DESCRIPTION
## Problem

`tests/policies/lerobot_local/test_embodiment_pipeline.py` loads a real LeRobot processor pipeline via `ProcessorBridge.from_pretrained("lerobot/smolvla_base", ...)`. The `_load_bridge` helper wraps that call in `try/except` so the test can skip cleanly when the checkpoint is unavailable.

The problem: `from_pretrained` triggers a real Hub download. When the Hub (xet storage) is slow or unreachable, the download neither completes nor raises promptly, so the `except -> pytest.skip` guard never fires and the entire test session is killed by `pytest-timeout` (120s). This is a non-deterministic, network-dependent CI failure that can fail any PR, unrelated to the change under test.

Observed on a recent CI run, where `_load_bridge` hung inside `hf_hub_download -> xet_get` waiting on `lerobot/smolvla_base` and tripped the 120s timeout:

```
FAILED tests/policies/lerobot_local/test_embodiment_pipeline.py::test_apply_embodiment_injects_rename_and_pack - Failed: Timeout (>120.0s) from pytest-timeout.
...
strands_robots/policies/lerobot_local/processor.py:200: in from_pretrained
    preprocessor = DataProcessorPipeline.from_pretrained(...)
...
huggingface_hub/file_download.py:566: with session.new_file_download_group(...)
E   Failed: Timeout (>120.0s) from pytest-timeout.
```

## Change

Force huggingface_hub offline mode for the module via an autouse fixture so the bridge load is cache-only:

- a cache hit still runs the real pipeline (the test keeps its value where the checkpoint is present),
- a cache miss raises `LocalEntryNotFoundError` immediately and the test skips.

`huggingface_hub.constants.HF_HUB_OFFLINE` is evaluated once at import, so the environment variable alone is insufficient once the package is imported; the module global is patched directly. `is_offline_mode()` reads that global at call time, so the patch takes effect immediately. The env vars (`HF_HUB_OFFLINE`, `TRANSFORMERS_OFFLINE`) are set as well for any subprocess paths.

The sibling `test_processor_real_pipeline.py` constructs pipelines locally with no download and is unaffected; this is the only real-pipeline test that pulls a checkpoint, so the fix is scoped to the one offending file.

## Tests

Adds `test_load_bridge_runs_under_hub_offline_mode`: spies on `from_pretrained` and asserts `is_offline_mode()` is active at the call site. Fails before this change (offline not forced -> `is_offline_mode()` is `False`), passes after.

Local gate green: `ruff check` + `ruff format --check` + `mypy strands_robots tests tests_integ` all clean (533 source files, no issues); the 4 tests in the file pass (the 3 real-pipeline tests load from a warm local cache, confirming offline mode preserves real behavior).