### PR TITLE
feat(sim): RTC inference telemetry + opt-in async-RTC overlap in eval_policy

### DIFF
--- a/docs/simulation/overview.md
+++ b/docs/simulation/overview.md
@@ -95,7 +95,7 @@ Robot-URDF cameras are auto-discovered on `add_robot`.
 | `stop_policy` | `robot_name` (optional, defaults to `""`) |
 | `list_policies_running` | - |
 | `run_multi_policy` | `policies={robot: Policy}`, `instructions`, `duration`, `n_steps` |
-| `eval_policy` | `robot_name` (required), `n_episodes=1`, `max_steps=300`, `success_fn=None` |
+| `eval_policy` | `robot_name` (required), `n_episodes=1`, `max_steps=300`, `success_fn=None`, `async_rtc=False`, `rtc_inference_timeout_s=None` |
 
 The step horizon is given either as `duration` (seconds) or as `n_steps` (`duration = n_steps / control_frequency`; `n_steps` wins when both are set, and the legacy `max_steps` is an alias for `n_steps`). A non-positive `n_steps` or `control_frequency` is rejected up front with a structured `status="error"` dict naming the bad parameter - `start_policy` validates synchronously before the background rollout starts, so a malformed horizon never returns a false "started" success.
 
@@ -135,6 +135,8 @@ chunk N+1 exec               |####|
 | `rtc_max_inference_ms` | Slowest `get_actions` wall time |
 
 A healthy masked rollout shows `rtc_prefetch_hits` near the chunk count and `rtc_prefetch_blocks == 0`; persistent blocks mean inference is slower than chunk execution and the seam cannot be fully hidden.
+
+**Async-RTC in `eval_policy` (opt-in).** The success-rate eval path (`eval_policy` / `evaluate(success_fn=...)`) accepts the same `async_rtc` and `rtc_inference_timeout_s`, but defaults to `async_rtc=False`. The synchronous eval pauses the world during inference, so the success-rate is bit-stable and reproducible (the policy always sees the seam observation). Setting `async_rtc=True` evaluates a chunk-emitting policy under the realistic control latency it faces in deployment: the prefetch feeds the policy a slightly staler (mid-chunk) observation at the seam, so the measured success-rate can shift - that is the point, it measures robustness to inference latency. Either way the eval `{"json": {...}}` payload now carries the same six `rtc_*` fields (inference timing is reported even on the synchronous path). `async_rtc=True` is rejected on the benchmark/spec path (`evaluate_benchmark` / `evaluate(spec=...)`), which stays synchronous for bit-stable reproducibility; use `run_policy(async_rtc=...)` for benchmark-style wall-clock latency masking.
 
 `run_policy` returns a `{"json": {...}}` content block alongside the human-readable `text`, mirroring `eval_policy`. The json block carries the rollout facts as typed fields - `robot_name`, `policy`, `instruction`, `n_steps`, `elapsed_s`, `stopped_early`, `action_errors`, `video_path` (`None` when no MP4 was written), `video_frames`, `sim_time_s` (when the backend reports it) and the six `rtc_*` async-RTC telemetry fields above - so an agent can read the outcome programmatically (did it move? how many steps? was inference masked?) without regex-parsing the prose.
 | `replay_episode` | `repo_id`, `robot_name=None`, `episode=0` |

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -1102,6 +1102,8 @@ class SimEngine(ABC):
         control_substeps: int | None = None,
         action_horizon: int = 8,
         seed: int | None = None,
+        async_rtc: bool = False,
+        rtc_inference_timeout_s: float | None = None,
     ) -> dict[str, Any]:
         """Multi-episode policy evaluation via ``PolicyRunner.evaluate``.
 
@@ -1121,6 +1123,15 @@ class SimEngine(ABC):
         full control period per action (same servo-tracking semantics as
         :meth:`run_policy`). Without these the arm under-steps and the policy
         looks like a no-op (the arm under-steps each control period).
+
+        ``async_rtc`` (default ``False``) opts into overlapping policy
+        inference with action-chunk execution, evaluating a chunk-emitting
+        policy under the realistic control latency it faces in deployment.
+        It is forwarded to :meth:`PolicyRunner.evaluate`; the default keeps
+        the success-rate synchronous and bit-stable. ``rtc_inference_timeout_s``
+        bounds each async inference (structured error instead of a hung
+        rollout). For benchmark-style latency masking use
+        :meth:`run_policy` (``async_rtc=...``).
         """
         if not robot_name:
             return {
@@ -1160,6 +1171,8 @@ class SimEngine(ABC):
             control_substeps=control_substeps,
             action_horizon=action_horizon,
             seed=seed,
+            async_rtc=async_rtc,
+            rtc_inference_timeout_s=rtc_inference_timeout_s,
         )
 
     # Benchmark protocol facades

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -35,7 +35,7 @@ import logging
 import os
 import random
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -236,6 +236,166 @@ class CooperativeStop(BaseException):
     by ``PolicyRunner.run`` and caught at the top of the loop to return
     a normal stopped-early success result.
     """
+
+
+class _ChunkPipeline:
+    """Yield ``(observation, action)`` pairs for a policy rollout.
+
+    Two acquisition strategies behind one iterator:
+
+    * **synchronous** (``async_rtc=False``): query the policy, fully drain the
+      returned chunk, then re-query - inference never overlaps execution.
+    * **async-RTC** (``async_rtc=True``): while the current chunk drains, fire
+      the next ``get_actions`` on a single background worker once the chunk is
+      ~50% consumed, then atomically swap it in at the seam. A chunk-emitting
+      policy whose inference latency is <= the chunk's execution time pays
+      (almost) zero visible stall - exactly how an async real-time controller
+      hides inference latency on real hardware.
+
+    Backend-agnostic and free of sim data races: the worker only ever calls the
+    supplied ``query_chunk`` (pure policy inference). The sim observation for a
+    prefetch is captured on the CONSUMING thread via ``observation_fn`` before
+    the worker is submitted, and the sim is only ever stepped by the consumer,
+    so no MuJoCo/Warp array is touched from two threads at once.
+
+    The pipeline is an unbounded iterator - the consumer controls termination
+    (success / failure / max-steps) by breaking out of the loop. Use it as a
+    context manager so the inference worker is always joined on exit, even when
+    the consumer breaks mid-chunk::
+
+        with _ChunkPipeline(query_chunk, obs_fn, async_rtc=True,
+                            rtc_inference_timeout_s=None) as chunks:
+            for observation, action in chunks:
+                sim.send_action(action, ...)
+                if done:
+                    break
+
+    ``chunks_acquired`` / ``prefetch_hits`` / ``prefetch_blocks`` and the
+    inference timings collected by ``query_chunk`` make latency masking provable
+    from the result payload without grepping logs.
+    """
+
+    def __init__(
+        self,
+        query_chunk: Callable[[dict[str, Any], int], list[dict[str, Any]]],
+        observation_fn: Callable[[], dict[str, Any]],
+        *,
+        async_rtc: bool,
+        rtc_inference_timeout_s: float | None,
+    ) -> None:
+        self._query_chunk = query_chunk
+        self._observation_fn = observation_fn
+        self._async_rtc = async_rtc
+        self._timeout = rtc_inference_timeout_s
+        self.chunks_acquired = 0
+        self.prefetch_hits = 0
+        self.prefetch_blocks = 0
+        self._executor: Any = None
+
+    def __enter__(self) -> Iterator[tuple[dict[str, Any], dict[str, Any]]]:
+        return self._iter_async() if self._async_rtc else self._iter_sync()
+
+    def __exit__(self, *exc: object) -> None:
+        # Join any in-flight inference so no background thread touches the
+        # policy/sim after the rollout returns (the caller may immediately
+        # reset() or destroy() the world). Returns None so an exception raised
+        # inside the ``with`` block (e.g. a prefetch timeout) propagates.
+        if self._executor is not None:
+            self._executor.shutdown(wait=True)
+
+    def _iter_sync(self) -> Iterator[tuple[dict[str, Any], dict[str, Any]]]:
+        while True:
+            observation = self._observation_fn()
+            # The world is paused during inference on the synchronous path, so
+            # the policy observed exactly 0 control steps of delay.
+            chunk = self._query_chunk(observation, 0)
+            self.chunks_acquired += 1
+            if not chunk:
+                raise RuntimeError("policy returned an empty action chunk; cannot run rollout")
+            for action in chunk:
+                yield observation, action
+
+    def _iter_async(self) -> Iterator[tuple[dict[str, Any], dict[str, Any]]]:
+        from concurrent.futures import Future, ThreadPoolExecutor
+        from concurrent.futures import TimeoutError as FuturesTimeout
+
+        def _swap_in(fut: Future[list[dict[str, Any]]]) -> list[dict[str, Any]]:
+            # A prefetch HIT means inference already finished (the seam is
+            # invisible); a BLOCK means inference ran slower than the chunk's
+            # execution - the actionable "shorten the chunk / earlier trigger"
+            # signal, so log it. A hard timeout turns a stuck model into a
+            # structured error instead of an unbounded sim hang.
+            if fut.done():
+                self.prefetch_hits += 1
+            else:
+                self.prefetch_blocks += 1
+                logger.warning(
+                    "async-RTC seam starvation: prefetched chunk was not ready at the swap "
+                    "point (inference slower than chunk execution). Blocking on it; consider a "
+                    "shorter chunk or an earlier prefetch trigger."
+                )
+            try:
+                return fut.result(timeout=self._timeout)
+            except FuturesTimeout as e:
+                raise RuntimeError(
+                    f"async-RTC prefetch exceeded rtc_inference_timeout_s={self._timeout}s; "
+                    f"policy inference is stuck. Raise the timeout or check the policy/server."
+                ) from e
+
+        self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="rtc-prefetch-eval")
+        cur_obs = self._observation_fn()
+        cur_chunk = self._query_chunk(cur_obs, 0)
+        self.chunks_acquired += 1
+        if not cur_chunk:
+            raise RuntimeError("policy returned an empty action chunk; cannot run rollout")
+        idx = 0
+        prefetch_trigger = max(1, len(cur_chunk) // 2)
+        prefetch: Future[list[dict[str, Any]]] | None = None
+        prefetch_obs: dict[str, Any] | None = None
+
+        while True:
+            if idx >= len(cur_chunk):
+                if prefetch is not None:
+                    cur_chunk = _swap_in(prefetch)
+                    if prefetch_obs is not None:
+                        cur_obs = prefetch_obs
+                    prefetch = None
+                    prefetch_obs = None
+                    self.chunks_acquired += 1
+                else:
+                    # Chunk too short to have triggered a prefetch -> one
+                    # synchronous re-query.
+                    cur_obs = self._observation_fn()
+                    cur_chunk = self._query_chunk(cur_obs, 0)
+                    self.chunks_acquired += 1
+                if not cur_chunk:
+                    # Drop-and-requery: a prefetched chunk arriving empty (a
+                    # transient policy hiccup) degrades to ONE synchronous
+                    # re-query before erroring, rather than killing an
+                    # otherwise-healthy rollout on a single empty result.
+                    logger.warning("async-RTC chunk arrived empty; falling back to one synchronous re-query.")
+                    cur_obs = self._observation_fn()
+                    cur_chunk = self._query_chunk(cur_obs, 0)
+                    self.chunks_acquired += 1
+                    if not cur_chunk:
+                        raise RuntimeError(
+                            "policy returned an empty action chunk twice (prefetch + synchronous "
+                            "re-query); cannot continue rollout"
+                        )
+                idx = 0
+                prefetch_trigger = max(1, len(cur_chunk) // 2)
+                continue
+
+            if prefetch is None and idx >= prefetch_trigger:
+                prefetch_obs = self._observation_fn()
+                # The prefetched chunk first applies after the remaining steps of
+                # the current chunk drain - a known integer independent of how
+                # long inference actually takes in wall-clock time.
+                observed_delay = max(0, len(cur_chunk) - prefetch_trigger)
+                prefetch = self._executor.submit(self._query_chunk, prefetch_obs, observed_delay)
+
+            yield cur_obs, cur_chunk[idx]
+            idx += 1
 
 
 class PolicyRunner:
@@ -1066,6 +1226,8 @@ class PolicyRunner:
         on_frame: OnFrame | None = None,
         control_frequency: float = 50.0,
         control_substeps: int | None = None,
+        async_rtc: bool = False,
+        rtc_inference_timeout_s: float | None = None,
     ) -> dict[str, Any]:
         """Evaluate ``policy`` for ``n_episodes`` episodes.
 
@@ -1105,11 +1267,32 @@ class PolicyRunner:
                 the script main (e.g. Strands ``Agent`` tool dispatch
                 under asyncio) - see #191 and
                 :meth:`~strands_robots.simulation.mujoco.simulation.Simulation.start_cameras_recording_synchronous`.
+            async_rtc: Opt-in overlap of policy inference with action-chunk
+                execution on the legacy ``success_fn`` path, mirroring
+                :meth:`run`. Defaults to ``False`` (synchronous): the world is
+                paused during inference, so the success-rate is bit-stable and
+                reproducible. Set ``True`` to evaluate a chunk-emitting policy
+                under the realistic control latency it faces in deployment - a
+                background worker computes chunk N+1 while chunk N drains, which
+                feeds the policy a slightly staler (mid-chunk) observation at
+                the seam and therefore can shift the measured success-rate (that
+                is the point: it measures robustness to inference latency).
+                ``True`` is rejected on the ``spec=`` benchmark path, which
+                stays synchronous for bit-stable reproducibility; use
+                :meth:`run` (``run_policy``) for benchmark-style latency masking.
+            rtc_inference_timeout_s: Hard per-chunk timeout (seconds) for the
+                async prefetch. When inference does not finish within the
+                timeout the eval fails with a structured error instead of
+                hanging the rollout. ``None`` waits indefinitely.
 
         Returns:
-            Standard status dict. When ``spec`` is used, the JSON payload
-            also contains ``cumulative_reward`` and ``avg_reward`` fields
-            per episode and aggregate.
+            Standard status dict. The JSON payload carries an RTC telemetry
+            block (``rtc_async_enabled``, ``rtc_chunks_acquired``,
+            ``rtc_prefetch_hits``, ``rtc_prefetch_blocks``,
+            ``rtc_avg_inference_ms``, ``rtc_max_inference_ms``) so inference
+            cost and latency masking are provable from the payload. When
+            ``spec`` is used, it also contains ``cumulative_reward`` and
+            ``avg_reward`` fields per episode and aggregate.
         """
         if spec is not None and success_fn is not None:
             return {
@@ -1119,6 +1302,21 @@ class PolicyRunner:
                         "text": (
                             "evaluate() accepts either 'spec' or 'success_fn', not both. "
                             "'spec' defines its own success predicate."
+                        )
+                    }
+                ],
+            }
+
+        if async_rtc and spec is not None:
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            "async_rtc is only supported on the success_fn eval path. "
+                            "The spec/benchmark path stays synchronous for bit-stable "
+                            "reproducibility; use run_policy(async_rtc=...) for "
+                            "benchmark-style latency masking."
                         )
                     }
                 ],
@@ -1149,56 +1347,105 @@ class PolicyRunner:
         # as run(). The default n_substeps=1 made eval rollouts under-step.
         n_substeps = self._control_substeps(control_frequency, control_substeps)
         policy.set_control_frequency(control_frequency)
+
+        # RTC telemetry, reported in the result json so inference cost (and,
+        # under async_rtc, latency masking) is provable without grepping logs.
+        # inference_ms collects every get_actions wall-time on both paths; the
+        # prefetch hit/block counters are async-only (0 on the synchronous path).
+        inference_ms: list[float] = []
+        rtc_chunks_acquired = 0
+        rtc_prefetch_hits = 0
+        rtc_prefetch_blocks = 0
+
+        def _observation_fn() -> dict[str, Any]:
+            return self.sim.get_observation(robot_name=robot_name, skip_images=_skip_images)
+
+        def _query_chunk(observation: dict[str, Any], observed_delay: int = 0) -> list[dict[str, Any]]:
+            # Tell latency-sensitive (RTC) policies how many control steps
+            # elapse between this observation and the first application of the
+            # returned chunk so they slice the chunk-seam by an EXACT integer
+            # instead of a wall-clock estimate. The synchronous path pauses the
+            # world during inference (delay 0); the async pipeline supplies the
+            # count of still-pending steps of the chunk currently executing.
+            policy.set_rtc_observed_delay(observed_delay)
+            _t_infer = time.perf_counter()
+            actions = _resolve_coroutine(policy.get_actions(observation, instruction))
+            inference_ms.append((time.perf_counter() - _t_infer) * 1000.0)
+            # resolve_chunk_length is the single source of truth for the
+            # re-query interval (respects RTC + execution_horizon). Consuming the
+            # FULL chunk before re-querying matches run() and _evaluate_with_spec
+            # (#168); truncating to a smaller horizon would force an
+            # out-of-distribution re-query of chunk-predicting VLAs.
+            return list(actions[: resolve_chunk_length(policy, action_horizon)])
+
         results: list[dict[str, Any]] = []
         for ep in range(n_episodes):
             self.sim.reset()
             success = False
             steps = 0
 
-            while steps < max_steps:
-                observation = self.sim.get_observation(robot_name=robot_name, skip_images=_skip_images)
-                coro_or_result = policy.get_actions(observation, instruction)
-                actions = _resolve_coroutine(coro_or_result)
-
-                if not actions:
-                    # Policy returned nothing - still advance one physics step
-                    # so episodes don't hang on degenerate policies, then check
-                    # the post-step observation (same post-action semantics as
-                    # the chunk branch below).
-                    self.sim.step(n_steps=1)
-                    steps += 1
-                    if resolved_check is not None:
-                        fresh_obs = self.sim.get_observation(robot_name=robot_name, skip_images=_skip_images)
-                        if resolved_check(fresh_obs):
+            if async_rtc:
+                # Opt-in async overlap: a single background worker computes the
+                # next chunk while the current one drains, so a chunk-emitting
+                # policy is evaluated under the realistic inference latency it
+                # faces in deployment. The pipeline only ever calls the policy
+                # off-thread; the sim is stepped solely here, so there is no
+                # data race. The context manager joins the worker on exit even
+                # when we break mid-chunk on success.
+                pipeline = _ChunkPipeline(
+                    _query_chunk,
+                    _observation_fn,
+                    async_rtc=True,
+                    rtc_inference_timeout_s=rtc_inference_timeout_s,
+                )
+                with pipeline as chunks:
+                    for _observation, action_dict in chunks:
+                        if steps >= max_steps:
+                            break
+                        self.sim.send_action(action_dict, robot_name=robot_name, n_substeps=n_substeps)
+                        steps += 1
+                        # Check success against the LIVE post-action observation
+                        # (mirrors the synchronous path / _evaluate_with_spec).
+                        if resolved_check is not None and resolved_check(_observation_fn()):
                             success = True
                             break
-                    continue
+                rtc_chunks_acquired += pipeline.chunks_acquired
+                rtc_prefetch_hits += pipeline.prefetch_hits
+                rtc_prefetch_blocks += pipeline.prefetch_blocks
+            else:
+                while steps < max_steps:
+                    observation = _observation_fn()
+                    chunk = _query_chunk(observation, 0)
+                    rtc_chunks_acquired += 1
 
-                # Consume the FULL action chunk before re-querying, identical to
-                # run() and _evaluate_with_spec (#168). Re-querying a chunk-
-                # predicting VLA every step and using only actions[0] forces an
-                # out-of-distribution control regime (re-sampled diffusion noise,
-                # ignored action_horizon) and made legacy eval disagree with the
-                # benchmark path. resolve_chunk_length is the single source of
-                # truth for the re-query interval (respects RTC + execution_horizon).
-                _chunk = resolve_chunk_length(policy, action_horizon)
-                for action_dict in actions[:_chunk]:
-                    if steps >= max_steps:
+                    if not chunk:
+                        # Policy returned nothing - still advance one physics
+                        # step so episodes don't hang on degenerate policies,
+                        # then check the post-step observation (same post-action
+                        # semantics as the chunk branch below).
+                        self.sim.step(n_steps=1)
+                        steps += 1
+                        if resolved_check is not None and resolved_check(_observation_fn()):
+                            success = True
+                            break
+                        continue
+
+                    for action_dict in chunk:
+                        if steps >= max_steps:
+                            break
+                        self.sim.send_action(action_dict, robot_name=robot_name, n_substeps=n_substeps)
+                        steps += 1
+                        # Check success against the LIVE post-action observation,
+                        # not the stale pre-action obs. Checking the pre-action
+                        # obs detects success one step late and never records a
+                        # task that completes on the final step -> under-reported
+                        # success_rate / inflated avg_steps. Mirrors
+                        # _evaluate_with_spec's post-send is_success.
+                        if resolved_check is not None and resolved_check(_observation_fn()):
+                            success = True
+                            break
+                    if success:
                         break
-                    self.sim.send_action(action_dict, robot_name=robot_name, n_substeps=n_substeps)
-                    steps += 1
-                    # Check success against the LIVE post-action observation, not
-                    # the stale pre-action obs. Checking the pre-action obs detects
-                    # success one step late and never records a task that completes
-                    # on the final step -> under-reported success_rate / inflated
-                    # avg_steps. Mirrors _evaluate_with_spec's post-send is_success.
-                    if resolved_check is not None:
-                        fresh_obs = self.sim.get_observation(robot_name=robot_name, skip_images=_skip_images)
-                        if resolved_check(fresh_obs):
-                            success = True
-                            break
-                if success:
-                    break
 
             results.append({"episode": ep, "steps": steps, "success": success})
             # #708 - roll the attached recorder over to a new episode so the
@@ -1209,6 +1456,15 @@ class PolicyRunner:
         n_success = sum(1 for r in results if r["success"])
         success_rate = n_success / max(n_episodes, 1)
         avg_steps = sum(r["steps"] for r in results) / max(n_episodes, 1)
+        _n_infer = len(inference_ms)
+        rtc_telemetry = {
+            "rtc_async_enabled": bool(async_rtc),
+            "rtc_chunks_acquired": rtc_chunks_acquired,
+            "rtc_prefetch_hits": rtc_prefetch_hits,
+            "rtc_prefetch_blocks": rtc_prefetch_blocks,
+            "rtc_avg_inference_ms": round(sum(inference_ms) / _n_infer, 3) if _n_infer else 0.0,
+            "rtc_max_inference_ms": round(max(inference_ms), 3) if _n_infer else 0.0,
+        }
 
         return {
             "status": "success",
@@ -1230,6 +1486,7 @@ class PolicyRunner:
                         "max_steps": max_steps,
                         "policy_load_time_s": round(float(getattr(policy, "load_time_s", 0.0)), 3),
                         "policy_load_cache_hit": bool(getattr(policy, "load_cache_hit", False)),
+                        **rtc_telemetry,
                         "episodes": results,
                     }
                 },

--- a/tests/simulation/test_eval_policy_async_rtc.py
+++ b/tests/simulation/test_eval_policy_async_rtc.py
@@ -1,0 +1,239 @@
+"""Async-RTC overlap in the ``success_fn`` path of :meth:`PolicyRunner.evaluate`.
+
+``run_policy`` overlaps chunk-N+1 inference with chunk-N execution
+(:mod:`tests.simulation.test_policy_runner_async_rtc`), but the success-rate
+eval path used to run policies fully synchronously with no way to ask for the
+overlap - so a chunk-emitting VLA could not be evaluated under the realistic
+inference latency it faces in deployment, and the eval payload exposed no
+inference-cost telemetry.
+
+``evaluate(..., async_rtc=True)`` (and the ``eval_policy`` facade) now opt into
+the same single-worker prefetch pipeline. These tests pin:
+
+* default eval stays synchronous (every inference starts on a chunk boundary)
+* opt-in async eval overlaps (an inference STARTS mid-chunk)
+* async wall-time is materially lower (latency is hidden behind execution)
+* both paths report RTC inference telemetry in the payload
+* identical step accounting for an observation-independent policy
+* the spec/benchmark path rejects ``async_rtc=True`` (reproducible by design)
+"""
+
+from __future__ import annotations
+
+import inspect
+import threading
+import time
+from typing import Any
+
+import numpy as np
+
+from strands_robots.policies.base import Policy
+from strands_robots.simulation.base import SimEngine
+from strands_robots.simulation.policy_runner import PolicyRunner
+
+_CHUNK = 4
+_INFER_SLEEP = 0.05
+_EXEC_SLEEP = 0.02  # per send_action; chunk exec (~0.08s) > infer (0.05s) -> hidden
+
+
+class _CountingSim(SimEngine):
+    """Minimal ``SimEngine`` that counts ``send_action`` calls and can pace them."""
+
+    def __init__(self, exec_sleep: float = 0.0) -> None:
+        self._joint_names = ["j0", "j1", "j2"]
+        self._robots = {"arm": self._joint_names}
+        self._exec_sleep = exec_sleep
+        self._lock = threading.Lock()
+        self.send_count = 0
+
+    def create_world(self, timestep=None, gravity=None, ground_plane=True):
+        return {"status": "success"}
+
+    def destroy(self):
+        return {"status": "success"}
+
+    def reset(self):
+        with self._lock:
+            self.send_count = 0
+        return {"status": "success"}
+
+    def step(self, n_steps: int = 1):
+        return {"status": "success"}
+
+    def get_state(self):
+        return {"sim_time": 0.0, "step_count": self.send_count}
+
+    def add_robot(self, name, **kw):
+        return {"status": "success"}
+
+    def remove_robot(self, name):
+        return {"status": "success"}
+
+    def list_robots(self) -> list[str]:
+        return list(self._robots.keys())
+
+    def robot_joint_names(self, robot_name: str) -> list[str]:
+        return list(self._robots.get(robot_name, []))
+
+    def add_object(self, name, **kw):
+        return {"status": "success"}
+
+    def remove_object(self, name):
+        return {"status": "success"}
+
+    def get_observation(self, robot_name=None, *, skip_images=False):
+        return {n: 0.0 for n in self._joint_names}
+
+    def send_action(self, action, robot_name=None, n_substeps=1):
+        with self._lock:
+            self.send_count += 1
+        if self._exec_sleep:
+            time.sleep(self._exec_sleep)
+
+    def render(self, camera_name="default", width=None, height=None):
+        return {"image": np.zeros((height or 48, width or 64, 3), dtype=np.uint8)}
+
+
+class _ChunkPolicy(Policy):
+    """Emits fixed-size chunks; records the sim step index at each inference start."""
+
+    def __init__(self, sim: _CountingSim, chunk: int = _CHUNK, infer_sleep: float = _INFER_SLEEP) -> None:
+        self._sim = sim
+        self.actions_per_step = chunk
+        self._chunk = chunk
+        self._infer_sleep = infer_sleep
+        self.robot_state_keys: list[str] = []
+        self.infer_starts: list[int] = []
+        self._lock = threading.Lock()
+
+    @property
+    def provider_name(self) -> str:
+        return "chunk-test"
+
+    @property
+    def requires_images(self) -> bool:
+        return False
+
+    def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
+        self.robot_state_keys = robot_state_keys
+
+    async def get_actions(
+        self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any
+    ) -> list[dict[str, Any]]:
+        with self._lock:
+            self.infer_starts.append(self._sim.send_count)
+        if self._infer_sleep:
+            time.sleep(self._infer_sleep)
+        keys = self.robot_state_keys or ["j0", "j1", "j2"]
+        return [{k: 0.0 for k in keys} for _ in range(self._chunk)]
+
+
+def _evaluate(
+    async_rtc: bool, *, exec_sleep: float = _EXEC_SLEEP, max_steps: int = 16
+) -> tuple[dict, _ChunkPolicy, _CountingSim]:
+    sim = _CountingSim(exec_sleep=exec_sleep)
+    policy = _ChunkPolicy(sim)
+    policy.set_robot_state_keys(sim.robot_joint_names("arm"))
+    result = PolicyRunner(sim).evaluate(
+        "arm",
+        policy,
+        n_episodes=1,
+        max_steps=max_steps,
+        action_horizon=_CHUNK,
+        control_frequency=50.0,
+        async_rtc=async_rtc,
+    )
+    return result, policy, sim
+
+
+def _payload(result: dict) -> dict[str, Any]:
+    return result["content"][1]["json"]
+
+
+def test_eval_async_rtc_overlaps_inference_mid_chunk() -> None:
+    """The prefetched chunk-N+1 inference fires while chunk N is still draining."""
+    result, policy, _ = _evaluate(async_rtc=True)
+    assert result["status"] == "success"
+    assert len(policy.infer_starts) >= 2
+    assert any(c % _CHUNK != 0 for c in policy.infer_starts), policy.infer_starts
+    # The first prefetch starts strictly before chunk 1 drains.
+    assert policy.infer_starts[1] < _CHUNK, policy.infer_starts
+
+
+def test_eval_default_is_synchronous() -> None:
+    """The default eval never overlaps: every inference is on a chunk boundary."""
+    result, policy, _ = _evaluate(async_rtc=False)
+    assert result["status"] == "success"
+    assert len(policy.infer_starts) >= 2
+    assert all(c % _CHUNK == 0 for c in policy.infer_starts), policy.infer_starts
+
+
+def test_eval_async_rtc_masks_inference_latency() -> None:
+    """Async wall-time is materially lower because inference hides behind exec."""
+    t0 = time.perf_counter()
+    sync_result, _, _ = _evaluate(async_rtc=False)
+    sync_elapsed = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    async_result, _, _ = _evaluate(async_rtc=True)
+    async_elapsed = time.perf_counter() - t0
+
+    assert sync_result["status"] == "success"
+    assert async_result["status"] == "success"
+    # 16 steps / chunk 4 => 4 chunks. Sync pays infer_sleep per chunk serially;
+    # async hides all but (at most) the first. Saving >= 2 inference periods is
+    # a conservative, non-flaky margin.
+    assert sync_elapsed - async_elapsed > 2 * _INFER_SLEEP, (sync_elapsed, async_elapsed)
+
+
+def test_eval_async_rtc_reports_telemetry() -> None:
+    """Async eval payload proves overlap: a prefetch HIT + inference timing.
+
+    With chunk execution (per-step ``exec_sleep``) longer than inference, the
+    prefetched chunk finishes before the seam, so the swap is a hit (inference
+    fully hidden) rather than a starvation-block.
+    """
+    result, _, _ = _evaluate(async_rtc=True, exec_sleep=0.05)
+    payload = _payload(result)
+    assert payload["rtc_async_enabled"] is True
+    assert payload["rtc_chunks_acquired"] >= 2
+    assert payload["rtc_prefetch_hits"] >= 1
+    assert payload["rtc_avg_inference_ms"] > 0.0
+
+
+def test_eval_sync_reports_inference_telemetry() -> None:
+    """Even synchronous eval reports inference cost (rtc_async_enabled=False)."""
+    result, _, _ = _evaluate(async_rtc=False)
+    payload = _payload(result)
+    assert payload["rtc_async_enabled"] is False
+    assert payload["rtc_prefetch_hits"] == 0
+    assert payload["rtc_prefetch_blocks"] == 0
+    assert payload["rtc_avg_inference_ms"] > 0.0
+
+
+def test_eval_async_matches_sync_step_accounting() -> None:
+    """Both paths run the same number of steps for an obs-independent policy."""
+    sync_result, _, _ = _evaluate(async_rtc=False, exec_sleep=0.0)
+    async_result, _, _ = _evaluate(async_rtc=True, exec_sleep=0.0)
+    sync_json = _payload(sync_result)
+    async_json = _payload(async_result)
+    assert sync_json["episodes"][0]["steps"] == async_json["episodes"][0]["steps"] == 16
+    assert sync_json["success_rate"] == async_json["success_rate"]
+
+
+def test_eval_async_rtc_rejected_on_spec_path() -> None:
+    """The spec/benchmark path stays synchronous: async_rtc=True is rejected."""
+    sim = _CountingSim()
+    policy = _ChunkPolicy(sim)
+    policy.set_robot_state_keys(sim.robot_joint_names("arm"))
+    # The guard fires before any spec method is touched, so any non-None spec
+    # exercises it.
+    result = PolicyRunner(sim).evaluate("arm", policy, spec=object(), async_rtc=True)  # type: ignore[arg-type]
+    assert result["status"] == "error"
+    assert "async_rtc" in result["content"][0]["text"]
+
+
+def test_eval_async_rtc_defaults_to_false() -> None:
+    """Eval defaults to synchronous (reproducible) - async is explicit opt-in."""
+    assert inspect.signature(PolicyRunner.evaluate).parameters["async_rtc"].default is False
+    assert inspect.signature(SimEngine.eval_policy).parameters["async_rtc"].default is False


### PR DESCRIPTION
## Problem

`run_policy` overlaps chunk-N+1 inference with chunk-N execution (async-RTC) and reports `rtc_*` telemetry in its result payload. The success-rate eval path (`eval_policy` / `PolicyRunner.evaluate`'s `success_fn` route) did **neither**:

- It ran chunk-emitting policies **fully synchronously** with no knob to ask for the overlap.
- Its `{"json": {...}}` payload reported `success_rate` / `avg_steps` but **no inference cost**, so you could not tell how expensive the policy's `get_actions` was from the rigorous eval path.
- There was no way to evaluate a chunk-emitting policy under the **inference-latency observation staleness** it actually faces in async deployment.

## Change

- Add a small reusable `_ChunkPipeline` that yields `(observation, action)` pairs with either the synchronous drain-then-requery strategy or a single-worker async prefetch that overlaps inference for chunk N+1 with execution of chunk N. It is backend-agnostic and race-free: the worker only runs policy inference, the sim is stepped solely on the consuming thread, and the prefetch observation is captured on that thread before submit. Empty-chunk fallback, seam-starvation warning, and `rtc_inference_timeout_s` mirror `run`.
- `eval_policy` / `PolicyRunner.evaluate` gain `async_rtc` (**default `False`**) and `rtc_inference_timeout_s`, forwarded to the `success_fn` path. The default keeps the success-rate **synchronous, bit-stable and reproducible** (the world is paused during inference, so the policy always sees the seam observation). `async_rtc=True` evaluates the policy under realistic mid-chunk-observation staleness.
- The eval payload now carries the six `rtc_*` fields on **both** paths (`rtc_async_enabled`, `rtc_chunks_acquired`, `rtc_prefetch_hits`, `rtc_prefetch_blocks`, `rtc_avg_inference_ms`, `rtc_max_inference_ms`), so inference cost is provable from the eval result even synchronously.
- The **spec/benchmark path** (`evaluate_benchmark` / `evaluate(spec=...)`) rejects `async_rtc=True` with a structured error and stays synchronous for bit-stable reproducibility. `run_policy(async_rtc=...)` remains the path for benchmark-style wall-clock latency masking.

## A note on sim wall-clock

In a non-paced sim eval, physics steps far faster than model inference, so the async prefetch has little execution to hide behind — the telemetry honestly reports this as `rtc_prefetch_blocks` rather than a fake speedup. The eval value here is the **inference-cost telemetry** and **deployment-fidelity** (staleness), not sim wall-clock. Wall-clock latency masking is a `run_policy`/hardware property.

## Tests

`tests/simulation/test_eval_policy_async_rtc.py` pins: overlap fires mid-chunk under `async_rtc=True`; the default eval stays synchronous (every inference on a chunk boundary); inference telemetry is reported on both paths; identical step accounting for an observation-independent policy; and the spec path rejects `async_rtc=True`. The new test fails on pre-change code (`evaluate` had no `async_rtc` parameter). Full local gate green: `ruff`/`ruff format`/`mypy` clean (537 files), and the simulation suite passes (`MUJOCO_GL=egl`, the only 2 failures are pre-existing torchcodec/CUDA env issues on `main`, unrelated).

## Eval telemetry (so100, MuJoCo headless, chunk=8, ~40 ms inference)

| field | sync (`async_rtc=False`) | async (`async_rtc=True`) |
|---|---|---|
| `rtc_async_enabled` | false | true |
| `rtc_chunks_acquired` | 20 | 22 |
| `rtc_prefetch_hits` | 0 | 0 |
| `rtc_prefetch_blocks` | 0 | 20 |
| `rtc_avg_inference_ms` | 40.4 | 40.4 |

Inference cost (40 ms/chunk) is now visible from the eval payload; the async blocks honestly reflect that a non-paced sim has nothing to hide the inference behind.

## Visual artifact

Chunk-emitting policy rollout on `so100`, rendered in MuJoCo headless (`MUJOCO_GL=egl`):

![rollout](https://github.com/cagataycali/robots/releases/download/eval-async-rtc-demo-1782634417/eval_async_rtc_rollout.gif)

<video src="https://github.com/cagataycali/robots/releases/download/eval-async-rtc-demo-1782634417/eval_async_rtc_rollout.mp4" controls></video>