### PR TITLE
fix(policies): detect image features by FeatureType.VISUAL, not name substring

### DIFF
--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -244,6 +244,13 @@ The declared order follows the model config's `image_keys` list when present
 the robot supplies fewer cameras than the policy requires, a `ValueError` is
 raised instead of feeding the model a missing or wrong view.
 
+Image input slots are identified by their declared `FeatureType.VISUAL`, not
+by a substring match on the feature name. A policy may declare image keys that
+do not follow the `observation.images.*` convention (for example MolmoAct2's
+bare `base`/`wrist` keys); such cameras are still routed to their VISUAL slots
+rather than dropped, so the preprocessor never fails with a misleading
+"image_keys missing from observation".
+
 ```python
 policy = create_policy(
     "lerobot_local",

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -27,6 +27,35 @@ from .resolution import resolve_policy_class_by_name, resolve_policy_class_from_
 
 logger = logging.getLogger(__name__)
 
+
+def _declared_feature_is_image(name: str, feature: Any = None) -> bool:
+    """Return True if a declared input feature is a camera/image (VISUAL) feature.
+
+    Prefers the authoritative ``FeatureType.VISUAL`` carried by the declared
+    ``PolicyFeature`` (a real enum whose ``name`` is a string); falls back to
+    the ``observation.image*`` key-name convention only when no usable type
+    metadata is available. A plain ``"image" in name`` substring test silently
+    misclassifies VISUAL features whose key does not contain the literal
+    ``"image"`` (e.g. MolmoAct2 declares image feature keys such as
+    ``base``/``wrist``), which drops their camera frames from the remapped
+    observation and surfaces later as a confusing "image_keys missing from
+    observation" failure inside the preprocessor.
+
+    Args:
+        name: The declared feature key (e.g. ``observation.images.top``).
+        feature: The declared ``PolicyFeature`` (or any object exposing a
+            ``type`` whose ``name`` is ``"VISUAL"``). ``None`` forces the
+            name-based fallback.
+
+    Returns:
+        True when the feature is an image/visual input feature.
+    """
+    type_name = getattr(getattr(feature, "type", None), "name", None)
+    if isinstance(type_name, str):
+        return type_name == "VISUAL"
+    return "image" in name
+
+
 # Fallback control rate used ONLY when RTC runs without the runtime having
 # called set_control_frequency(). Used to keep a standalone (no-runner) RTC
 # call functional; the runner always plumbs the real rate. A loud one-time
@@ -1541,7 +1570,7 @@ class LerobotLocalPolicy(Policy):
 
         out: dict[str, Any] = {}
 
-        declared_img_feats = [f for f in self._input_features if "image" in f]
+        declared_img_feats = [f for f, feat in self._input_features.items() if _declared_feature_is_image(f, feat)]
 
         # 1) Map images. Prefer exact short-name match against declared features.
         image_items = [(k, v) for k, v in observation_dict.items() if isinstance(v, np.ndarray) and v.ndim >= 2]
@@ -1785,7 +1814,7 @@ class LerobotLocalPolicy(Policy):
         declared = getattr(cfg, "image_keys", None) if cfg is not None else None
         if isinstance(declared, (list, tuple)) and declared:
             return [str(k) for k in declared]
-        return [feat for feat in self._input_features if "image" in feat]
+        return [feat for feat, feature in self._input_features.items() if _declared_feature_is_image(feat, feature)]
 
     def _resolve_camera_targets(self, cam_names: list[str]) -> dict[str, str]:
         """Map robot/sim camera names to the policy's declared image feature keys.

--- a/tests/policies/lerobot_local/test_visual_feature_routing.py
+++ b/tests/policies/lerobot_local/test_visual_feature_routing.py
@@ -1,0 +1,89 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""Image-feature detection must use the declared FeatureType, not a name substring.
+
+A camera observation is routed to a model image slot only if the slot is
+recognized as an image feature. Detecting that by the ``"image" in key``
+substring silently misclassifies a declared ``FeatureType.VISUAL`` feature
+whose key does not contain the literal ``"image"`` - e.g. MolmoAct2 declares
+image feature keys such as ``base``/``wrist``. The frames were then dropped
+from the remapped observation and surfaced later as a confusing
+``image_keys missing from observation`` failure inside the preprocessor.
+
+These tests pin that image features are detected by their authoritative
+``PolicyFeature.type`` (``VISUAL``), with the name convention only as a
+no-type-metadata fallback.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+
+from strands_robots.policies.lerobot_local.policy import (
+    LerobotLocalPolicy,
+    _declared_feature_is_image,
+)
+
+
+def _visual(shape=(3, 224, 224)):
+    return SimpleNamespace(type=SimpleNamespace(name="VISUAL"), shape=shape)
+
+
+def _state(dim=6):
+    return SimpleNamespace(type=SimpleNamespace(name="STATE"), shape=(dim,))
+
+
+def _policy(input_features):
+    with patch.object(LerobotLocalPolicy, "_load_model"):
+        policy = LerobotLocalPolicy(pretrained_name_or_path=None, policy_type="molmoact2")
+    policy._input_features = input_features
+    policy.robot_state_keys = [f"j{i}" for i in range(6)]
+    return policy
+
+
+def _obs():
+    obs = {"base": np.zeros((224, 224, 3), np.uint8), "wrist": np.zeros((224, 224, 3), np.uint8)}
+    obs.update({f"j{i}": 0.0 for i in range(6)})
+    return obs
+
+
+def _routed_images(out):
+    return sorted(k for k, v in out.items() if isinstance(v, np.ndarray) and v.ndim >= 2)
+
+
+class TestDeclaredFeatureIsImage:
+    def test_prefers_visual_type_over_name(self):
+        # Bare key with VISUAL type IS an image; STATE never is.
+        assert _declared_feature_is_image("base", _visual()) is True
+        assert _declared_feature_is_image("observation.state", _state()) is False
+        # A non-image key whose name contains "image" is still not visual.
+        assert _declared_feature_is_image("observation.image_token_mask", _state()) is False
+
+    def test_name_fallback_without_type_metadata(self):
+        assert _declared_feature_is_image("observation.images.top", None) is True
+        assert _declared_feature_is_image("observation.state", None) is False
+
+
+class TestVisualFeatureRouting:
+    def test_bare_visual_keys_route_camera_frames(self):
+        # Regression: bare-named VISUAL slots (MolmoAct2 base/wrist) must receive
+        # the camera frames, not be dropped because the key lacks "image".
+        policy = _policy({"base": _visual(), "wrist": _visual(), "observation.state": _state()})
+        out = policy._to_lerobot_observation(_obs())
+        assert _routed_images(out) == ["base", "wrist"]
+
+    def test_qualified_image_keys_still_route(self):
+        # No regression for the conventional observation.images.* naming.
+        policy = _policy(
+            {
+                "observation.images.base": _visual(),
+                "observation.images.wrist": _visual(),
+                "observation.state": _state(),
+            }
+        )
+        out = policy._to_lerobot_observation(_obs())
+        assert _routed_images(out) == ["observation.images.base", "observation.images.wrist"]
+
+    def test_policy_image_keys_includes_bare_visual_slots(self):
+        policy = _policy({"base": _visual(), "wrist": _visual(), "observation.state": _state()})
+        assert sorted(policy._policy_image_keys()) == ["base", "wrist"]


### PR DESCRIPTION
## Problem

`LerobotLocalPolicy._to_lerobot_observation` (and `_policy_image_keys`) identified a policy's image input slots with a `"image" in key` substring test:

```python
declared_img_feats = [f for f in self._input_features if "image" in f]
```

That silently misclassifies a declared `FeatureType.VISUAL` feature whose key does **not** contain the literal `"image"`. MolmoAct2, for instance, declares its image input features under bare keys such as `base`/`wrist` (its `image_keys` are not forced to the `observation.images.*` namespace). For such a policy `declared_img_feats` comes back empty, every camera frame is dropped from the remapped observation, and the failure only surfaces later as a confusing error deep inside the preprocessor:

```
ValueError: MolmoAct2 image_keys missing from observation: ['base', 'wrist'].
```

The images were present in the raw observation the whole time; they were discarded by the name-substring filter before reaching the preprocessor.

## Change

Detect image features by their authoritative `PolicyFeature.type` (`VISUAL`) instead of a substring on the key name. A new module helper `_declared_feature_is_image(name, feature)` prefers `feature.type.name == "VISUAL"` and falls back to the `observation.image*` name convention only when no usable type metadata is available (so MagicMock-based tests and typeless features still resolve). Both `_to_lerobot_observation` and `_policy_image_keys` now use it.

Features that follow the conventional `observation.images.*` naming are unaffected; the only behavior change is that VISUAL slots with unconventional keys are now routed instead of dropped.

## Tests

`tests/policies/lerobot_local/test_visual_feature_routing.py` pins the contract. The key regression asserts that bare-named VISUAL slots receive their camera frames:

- Pre-fix: `_to_lerobot_observation` returns only `observation.state` (images dropped) -> test fails.
- Post-fix: both `base` and `wrist` frames are routed -> test passes.

It also covers type-vs-name precedence, the no-type-metadata name fallback, the conventional `observation.images.*` path (no regression), and `_policy_image_keys` including bare VISUAL slots. Full `tests/policies/lerobot_local` suite stays green (151 passed); `ruff check`, `ruff format --check`, and `mypy` over `strands_robots tests tests_integ` are clean.

## Visual proof

MolmoAct2 (`allenai/MolmoAct2-SO100_101`) rolling out "pick up the cube" on a simulated SO-101 in MuJoCo (headless EGL), recorded to a LeRobotDataset. Left: base camera; right: wrist camera (both 378x378, the processor's native size). This exact configuration previously aborted on the dropped-image error; it now binds and runs end to end (1/1 episode, 60 frames recorded).

![MolmoAct2 SO-101 rollout](https://github.com/cagataycali/robots/releases/download/viz-visual-feature-detection/molmoact2_so101_rollout.gif)
