### PR TITLE
feat(simulation): load robot_descriptions URDF robots on the Newton backend

### DIFF
--- a/docs/simulation/newton.md
+++ b/docs/simulation/newton.md
@@ -75,9 +75,11 @@ no-op until then.
 ## Capabilities and parity
 
 - `add_robot` ingests the same MJCF assets as the MuJoCo backend (resolved via
-  `strands_robots.assets`). Joint names use the short trailing segment
-  (`Rotation`, `Pitch`, ...), matching the MuJoCo backend exactly so policies
-  and observation mappings transfer unchanged.
+  `strands_robots.assets`) and, because Newton parses URDF natively, also loads
+  URDF models directly (see "URDF robots via robot_descriptions" below). Joint
+  names use the short trailing segment (`Rotation`, `Pitch`, ...), matching the
+  MuJoCo backend exactly so policies and observation mappings transfer
+  unchanged.
 - `render()` returns the same agent-tool image block (`{"image": {"format":
   "png", ...}}`) as MuJoCo, so the shared `PolicyRunner` video pipeline works
   without modification.
@@ -100,6 +102,47 @@ no-op until then.
   either a scalar (the z-component) or a 3-element `[x, y, z]` list and rebuilds
   the model, which re-initialises the world to its rest pose. `set_timestep`
   takes effect on the next `step()` without a rebuild.
+
+## URDF robots via robot_descriptions
+
+Newton loads URDF natively, so `add_robot` can pull robots straight from the
+[`robot_descriptions`](https://github.com/robot-descriptions/robot_descriptions.py)
+package - including the large URDF-only long tail (humanoids, quadrupeds, hands,
+dual-arm rigs) that has no MJCF model and is therefore unavailable to the MuJoCo
+backend.
+
+The `source` selector on `add_robot` controls resolution:
+
+| `source` | Resolution |
+|----------|------------|
+| `None` (default) | Curated registry / MJCF asset manager first, then a `robot_descriptions` URDF fallback. |
+| `"registry"` | Curated registry / MJCF asset manager only (no URDF fallback). |
+| `"robot_descriptions"` | URDF directly via `robot_descriptions.<name>_description.URDF_PATH`. |
+
+```python
+sim = create_simulation("newton", solver="mujoco")
+sim.create_world()
+
+# Load the Franka Panda from its robot_descriptions URDF (no curated entry needed).
+sim.add_robot("panda", source="robot_descriptions")
+print(sim.robot_joint_names("panda"))
+# ['panda_joint1', ..., 'panda_joint7', 'panda_finger_joint1', 'panda_finger_joint2']
+
+sim.step(10)   # real GPU model build + step
+```
+
+The asset format is detected from the resolved path: `.urdf` files load through
+Newton's URDF importer, everything else through the MJCF importer. An explicit
+`urdf_path=` argument always wins and bypasses `source`.
+
+`list_urdfs()` returns the union of the registry listing and the
+`robot_descriptions` URDF long tail; its `json` block exposes
+`robot_descriptions_urdf` (the sorted list of URDF-discoverable names) for
+programmatic use. The cheap name lookups behind this
+(`urdf_descriptions_module`, `is_urdf_discoverable`, `list_urdf_discoverable`)
+live in `strands_robots.registry.discovery` and read a static table with no
+import and no network; resolving an actual URDF path clones the upstream asset
+repository on first use.
 
 ## Scene discovery and state queries
 

--- a/strands_robots/registry/discovery.py
+++ b/strands_robots/registry/discovery.py
@@ -11,8 +11,13 @@ Resolution rules:
     - A curated ``robots.json`` entry always wins. Discovery is consulted only
       for names unknown to the curated registry (see
       :func:`strands_robots.registry.get_robot`).
-    - Only MJCF-capable descriptions are discoverable: the MuJoCo backend needs
-      an ``.xml`` model, so URDF-only descriptions are skipped.
+    - Curated-registry / MJCF discovery (``descriptions_module``,
+      ``list_discoverable``, ``discover_robot``) is MJCF-only: the MuJoCo backend
+      and the curated registry need an ``.xml`` model.
+    - URDF discovery (``urdf_descriptions_module``, ``list_urdf_discoverable``,
+      ``discover_urdf_path``) is a parallel surface for URDF-native backends
+      (Newton via ``ModelBuilder.add_urdf``). It covers the large URDF-only long
+      tail that MJCF discovery cannot (humanoids, quadrupeds, hands).
     - :func:`descriptions_module`, :func:`is_discoverable`, and
       :func:`list_discoverable` are cheap - a static dict lookup with no module
       import and no network. :func:`discover_robot` is heavy: importing a
@@ -40,6 +45,13 @@ _NAME_RE = re.compile(r"^[a-z0-9_]+$")
 # ``robot_descriptions`` names every MuJoCo (MJCF) description module with this
 # suffix, e.g. ``go2_mj_description`` -> canonical robot name ``go2``.
 _MJCF_SUFFIX = "_mj_description"
+
+# URDF description modules use the bare ``_description`` suffix (e.g.
+# ``panda_description``). MJCF modules use ``_mj_description``; the URDF table
+# below excludes those. URDF descriptions are consumable only by URDF-native
+# backends (Newton via ``ModelBuilder.add_urdf``); the MuJoCo backend ignores
+# them because it needs an MJCF ``.xml`` model.
+_URDF_SUFFIX = "_description"
 
 # Candidate scene files (ground plane + lights) a Menagerie description may ship
 # alongside the bare robot model, in preference order.
@@ -185,11 +197,121 @@ def discover_robot(name: str) -> dict[str, Any] | None:
     return entry
 
 
+@lru_cache(maxsize=1)
+def _urdf_modules() -> dict[str, str]:
+    """Map canonical robot name -> URDF ``robot_descriptions`` module name.
+
+    The complement of :func:`_mjcf_modules`: every description that ships a URDF
+    model (and is not the MJCF ``_mj_description`` variant). URDF-native backends
+    such as Newton can ingest these directly via ``ModelBuilder.add_urdf`` even
+    when no MJCF model exists, which unlocks the large URDF-only long tail
+    (humanoids, quadrupeds, hands) absent from MJCF discovery. Reads
+    ``robot_descriptions``' static description table - no module import and no
+    network. Returns an empty mapping when ``robot_descriptions`` is not
+    installed.
+    """
+    try:
+        from robot_descriptions._descriptions import (  # type: ignore[import-not-found]
+            DESCRIPTIONS,
+            Format,
+        )
+    except ImportError:
+        return {}
+
+    mapping: dict[str, str] = {}
+    for module_name, desc in DESCRIPTIONS.items():
+        if Format.URDF not in desc.formats:
+            continue
+        if not module_name.endswith(_URDF_SUFFIX):
+            continue
+        # ``_mj_description`` also ends with ``_description`` but is the MJCF
+        # variant; it is handled by :func:`_mjcf_modules`, not here.
+        if module_name.endswith(_MJCF_SUFFIX):
+            continue
+        short = module_name[: -len(_URDF_SUFFIX)]
+        mapping[short] = module_name
+    return mapping
+
+
+def urdf_descriptions_module(name: str) -> str | None:
+    """Return the URDF ``robot_descriptions`` module for *name*, or ``None``.
+
+    Cheap: a dict lookup against the static description table, with no module
+    import and no network. Returns ``None`` when *name* is not a URDF-capable
+    ``robot_descriptions`` robot or when the package is missing.
+
+    Examples::
+
+        urdf_descriptions_module("panda")    # -> "panda_description"
+        urdf_descriptions_module("atlas_v4") # -> "atlas_v4_description"
+        urdf_descriptions_module("so100")    # -> None (curated, not a description)
+    """
+    norm = _normalize(name)
+    if not _NAME_RE.match(norm):
+        return None
+    return _urdf_modules().get(norm)
+
+
+def is_urdf_discoverable(name: str) -> bool:
+    """Return ``True`` if *name* resolves to a URDF ``robot_descriptions`` model."""
+    return urdf_descriptions_module(name) is not None
+
+
+def list_urdf_discoverable() -> list[str]:
+    """Return sorted canonical names resolvable to a URDF from ``robot_descriptions``.
+
+    This is the URDF long tail consumable by URDF-native backends (Newton). It
+    includes robots with no MJCF model at all (e.g. ``atlas_v4``, ``baxter``,
+    ``b1``), which is why it is disjoint from :func:`list_discoverable` for those
+    entries. Cheap: no import, no network.
+    """
+    return sorted(_urdf_modules())
+
+
+def discover_urdf_path(name: str) -> str | None:
+    """Resolve the on-disk URDF path for *name* via ``robot_descriptions``.
+
+    Heavy: imports the description module, which makes ``robot_descriptions``
+    clone the upstream asset repository on first use. Call only from
+    asset-resolution paths that are allowed to download.
+
+    Args:
+        name: Robot name or alias (e.g. ``"panda"``).
+
+    Returns:
+        Absolute path to the URDF file, or ``None`` when *name* is not a
+        URDF-capable ``robot_descriptions`` robot, the module cannot be
+        imported, or it exposes no readable ``URDF_PATH``.
+    """
+    norm = _normalize(name)
+    module_name = urdf_descriptions_module(norm)
+    if module_name is None:
+        return None
+
+    try:
+        mod = importlib.import_module(f"robot_descriptions.{module_name}")
+    except ImportError as exc:
+        logger.debug("URDF discovery import failed for %r (%s): %s", norm, module_name, exc)
+        return None
+
+    urdf_path = getattr(mod, "URDF_PATH", None)
+    if not urdf_path or not os.path.exists(str(urdf_path)):
+        logger.warning(
+            "robot_descriptions module %r lacks a readable URDF_PATH; cannot discover %r",
+            module_name,
+            norm,
+        )
+        return None
+    return str(urdf_path)
+
+
 def invalidate_cache() -> None:
     """Clear the discovery caches (synthesized entries + module table)."""
     _DISCOVER_CACHE.clear()
-    # ``_mjcf_modules`` is normally an ``lru_cache``; guard ``cache_clear`` so a
-    # test (or future refactor) that swaps in a plain callable cannot break this.
-    clear = getattr(_mjcf_modules, "cache_clear", None)
-    if clear is not None:
-        clear()
+    # ``_mjcf_modules`` / ``_urdf_modules`` are normally ``lru_cache``-wrapped;
+    # guard ``cache_clear`` so a test (or future refactor) that swaps in a plain
+    # callable cannot break this.
+    for cached in (_mjcf_modules, _urdf_modules):
+        clear = getattr(cached, "cache_clear", None)
+        if clear is not None:
+            clear()

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -34,6 +34,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from strands_robots.assets import resolve_model_path, resolve_robot_name
+from strands_robots.registry.discovery import discover_urdf_path, list_urdf_discoverable
 from strands_robots.simulation.base import SimEngine
 from strands_robots.simulation.model_registry import (
     list_available_models,
@@ -55,6 +56,15 @@ logger = logging.getLogger(__name__)
 # hundred substeps; 60 Hz frames with 10 substeps each matches the Newton
 # example cadence and keeps position-servo arms tracking their targets.
 _DEFAULT_TIMESTEP = 1.0 / 600.0
+
+# Valid ``add_robot(source=...)`` selectors. ``None``/``"registry"`` resolve
+# the curated registry + MJCF asset manager (the same path the MuJoCo backend
+# uses); ``"robot_descriptions"`` resolves a URDF directly from the
+# ``robot_descriptions`` package and loads it through Newton's native URDF
+# importer. ``None`` additionally falls back to ``robot_descriptions`` when the
+# registry has no asset, so the URDF-only long tail resolves without an
+# explicit selector.
+_ROBOT_SOURCES = (None, "registry", "robot_descriptions")
 
 
 def _short_joint_name(label: str) -> str:
@@ -226,6 +236,52 @@ class NewtonSimEngine(NewtonRecordingMixin, SimEngine):
 
     # Robot management
 
+    def _resolve_asset(self, name: str, source: str | None) -> tuple[str | None, str | None]:
+        """Resolve a robot name to an MJCF/URDF model path for the given source.
+
+        Args:
+            name: Robot name or alias to resolve.
+            source: One of :data:`_ROBOT_SOURCES`. ``"robot_descriptions"``
+                resolves a URDF directly; ``"registry"`` restricts to the
+                curated registry / MJCF asset manager; ``None`` tries the
+                registry first then falls back to a ``robot_descriptions`` URDF.
+
+        Returns:
+            ``(model_path, None)`` on success, or ``(None, error_text)`` with a
+            human-readable reason on failure.
+        """
+        if source == "robot_descriptions":
+            urdf = discover_urdf_path(name)
+            if urdf:
+                return urdf, None
+            return None, (
+                f"Could not resolve a URDF for '{name}' via robot_descriptions. "
+                "See list_urdfs() for URDF-discoverable robots."
+            )
+
+        # source is None or "registry": curated registry / MJCF asset manager.
+        try:
+            resolved = resolve_robot_name(name)
+            asset_path = resolve_model_path(resolved)
+        except (ValueError, FileNotFoundError, KeyError) as exc:
+            asset_path = None
+            resolve_error: Exception | None = exc
+        else:
+            resolve_error = None
+        if asset_path:
+            return str(asset_path), None
+
+        # Default selector: fall back to a robot_descriptions URDF before failing
+        # so the URDF-only long tail resolves without an explicit source.
+        if source is None:
+            urdf = discover_urdf_path(name)
+            if urdf:
+                return urdf, None
+
+        detail = f": {resolve_error}" if resolve_error else ""
+        hint = "See list_robots() / list_urdfs()." if source is None else "See list_robots()."
+        return None, f"Could not resolve a sim asset for robot '{name}'{detail}. {hint}"
+
     def add_robot(
         self,
         name: str,
@@ -233,18 +289,31 @@ class NewtonSimEngine(NewtonRecordingMixin, SimEngine):
         data_config: str | None = None,
         position: list[float] | None = None,
         orientation: list[float] | None = None,
+        source: str | None = None,
     ) -> dict[str, Any]:
-        """Add a robot to the world from a registered name or an MJCF path.
+        """Add a robot to the world from a registered name, MJCF, or URDF.
+
+        Newton ingests both MJCF and URDF models natively, so a robot can be
+        resolved three ways (see ``source``). The asset format is detected from
+        the resolved path's extension - ``.urdf`` files load through Newton's
+        URDF importer, everything else through the MJCF importer.
 
         Args:
-            name: Robot name in the registry, or an arbitrary instance name
-                when ``urdf_path`` points at an explicit MJCF/URDF.
-            urdf_path: Optional explicit MJCF/URDF path. When omitted, the
-                asset is resolved from the registry by ``name``.
+            name: Robot name in the registry / ``robot_descriptions``, or an
+                arbitrary instance name when ``urdf_path`` points at an explicit
+                MJCF/URDF file.
+            urdf_path: Optional explicit MJCF/URDF path. When given it wins
+                outright and ``source`` is ignored.
             data_config: Accepted for ABC parity; unused by Newton.
             position: World position ``[x, y, z]`` (default origin).
             orientation: World orientation as a wxyz quaternion
                 (default identity).
+            source: Asset-resolution selector. ``None`` (default) tries the
+                curated registry / MJCF asset manager first and falls back to a
+                ``robot_descriptions`` URDF lookup; ``"registry"`` restricts to
+                the registry; ``"robot_descriptions"`` resolves the URDF directly
+                via ``robot_descriptions.<name>_description.URDF_PATH``. See
+                :func:`~strands_robots.registry.discovery.list_urdf_discoverable`.
 
         Returns:
             Status dict including the resolved joint names.
@@ -253,27 +322,26 @@ class NewtonSimEngine(NewtonRecordingMixin, SimEngine):
             return {"status": "error", "content": [{"text": "No world. Call create_world first."}]}
         if name in self._world.robots:
             return {"status": "error", "content": [{"text": f"Robot '{name}' already exists."}]}
+        if source not in _ROBOT_SOURCES:
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            f"Unknown source {source!r}. "
+                            f"Valid: {[s for s in _ROBOT_SOURCES if s is not None]} or None (default)."
+                        )
+                    }
+                ],
+            }
 
-        if urdf_path is None:
-            try:
-                resolved = resolve_robot_name(name)
-                asset_path = resolve_model_path(resolved)
-            except (ValueError, FileNotFoundError, KeyError) as exc:
-                asset_path = None
-                _resolve_error: Exception | None = exc
-            else:
-                _resolve_error = None
-            if not asset_path:
-                detail = f": {_resolve_error}" if _resolve_error else ""
-                return {
-                    "status": "error",
-                    "content": [
-                        {"text": f"Could not resolve a sim asset for robot '{name}'{detail}. See list_robots()."}
-                    ],
-                }
-            model_path = str(asset_path)
-        else:
+        if urdf_path is not None:
             model_path = urdf_path
+        else:
+            resolved_path, error = self._resolve_asset(name, source)
+            if resolved_path is None:
+                return {"status": "error", "content": [{"text": error}]}
+            model_path = resolved_path
 
         with self._lock:
             robot = SimRobot(
@@ -1105,13 +1173,33 @@ class NewtonSimEngine(NewtonRecordingMixin, SimEngine):
         return {"status": "success", "content": [{"text": "\n".join(lines)}, {"json": {"features": features}}]}
 
     def list_urdfs(self) -> dict[str, Any]:
-        """List registry-resolvable robot assets (shared registry).
+        """List robot assets resolvable by this backend.
+
+        Returns the union of the curated registry / MJCF asset manager listing
+        and the URDF long tail discoverable through ``robot_descriptions``.
+        Because Newton loads URDF natively, the URDF-only descriptions (which the
+        MuJoCo backend cannot use) are first-class here.
 
         Returns:
             Agent-tool dict whose ``text`` block is the formatted registry
-            listing from :func:`list_available_models`.
+            listing plus the ``robot_descriptions`` URDF names, and whose
+            ``json`` block exposes ``robot_descriptions_urdf`` (the sorted URDF
+            long tail) for programmatic use.
         """
-        return {"status": "success", "content": [{"text": list_available_models()}]}
+        urdf_robots = list_urdf_discoverable()
+        text = list_available_models()
+        if urdf_robots:
+            text += (
+                "\n\nURDF-native via robot_descriptions "
+                f"(Newton loads through add_urdf, {len(urdf_robots)} robots):\n  " + ", ".join(urdf_robots)
+            )
+        return {
+            "status": "success",
+            "content": [
+                {"text": text},
+                {"json": {"robot_descriptions_urdf": urdf_robots}},
+            ],
+        }
 
     def register_urdf(self, data_config: str, urdf_path: str) -> dict[str, Any]:
         """Register an MJCF/URDF asset under ``data_config`` in the registry.
@@ -1171,6 +1259,12 @@ class NewtonSimEngine(NewtonRecordingMixin, SimEngine):
             "gravity": list(self._world.gravity) if self._world else [0.0, 0.0, -9.81],
             "world_created": self._world is not None and self._model is not None,
             "methods": {
+                "add_robot": (
+                    "(name: str, urdf_path=None, position=None, orientation=None, source=None) -> dict  "
+                    "(source: None=registry then robot_descriptions URDF fallback, "
+                    "'registry'=registry only, 'robot_descriptions'=URDF via "
+                    "robot_descriptions.<name>_description.URDF_PATH; see list_urdfs)"
+                ),
                 "get_robot_state": "(robot_name: str | None = None) -> dict (per-joint position + velocity)",
                 "get_observation": "(robot_name: str | None = None, *, skip_images: bool = False) -> dict",
                 "send_action": "(action: dict, robot_name: str | None = None, n_substeps: int = 1) -> dict",
@@ -1180,7 +1274,7 @@ class NewtonSimEngine(NewtonRecordingMixin, SimEngine):
                 "list_objects": "() -> dict",
                 "move_object": "(name: str, position=None, orientation=None) -> dict",
                 "get_features": "(robot_name: str | None = None) -> dict (joints/bodies/robots schema)",
-                "list_urdfs": "() -> dict",
+                "list_urdfs": "() -> dict (registry + robot_descriptions URDF long tail; json.robot_descriptions_urdf)",
                 "register_urdf": "(data_config: str, urdf_path: str) -> dict",
                 "set_gravity": "(gravity: list[float] | float) -> dict",
                 "set_timestep": "(dt: float) -> dict",
@@ -1384,7 +1478,13 @@ class NewtonSimEngine(NewtonRecordingMixin, SimEngine):
                 wp.vec3(*robot.position),
                 self._wxyz_to_wp_quat(robot.orientation),
             )
-            builder.add_mjcf(str(robot.urdf_path), xform=xform, collapse_fixed_joints=True)
+            model_path = str(robot.urdf_path)
+            if model_path.lower().endswith(".urdf"):
+                # Newton ingests URDF natively; floating=None leaves the root
+                # fixed to the world (correct for table-mounted arms like panda).
+                builder.add_urdf(model_path, xform=xform, collapse_fixed_joints=True)
+            else:
+                builder.add_mjcf(model_path, xform=xform, collapse_fixed_joints=True)
             new_labels = builder.joint_label[label_before:]
             short_names: list[str] = []
             for offset, label in enumerate(new_labels):

--- a/tests/registry/test_robot_descriptions_urdf.py
+++ b/tests/registry/test_robot_descriptions_urdf.py
@@ -1,0 +1,159 @@
+"""URDF auto-discovery of the ``robot_descriptions`` long tail.
+
+The curated ``robots.json`` and the MJCF discovery surface only expose robots
+that ship an MJCF model, because the MuJoCo backend needs an ``.xml``. URDF-only
+descriptions (humanoids, quadrupeds, hands, dual-arm rigs) were therefore
+invisible even though URDF-native backends such as Newton can load them
+directly.
+
+These tests exercise observable behavior of the parallel URDF surface in
+``strands_robots.registry.discovery``:
+    - the cheap name -> module lookup (``urdf_descriptions_module`` /
+      ``is_urdf_discoverable`` / ``list_urdf_discoverable``) against the real
+      description table,
+    - the heavy path resolution (``discover_urdf_path``) with a stubbed import so
+      the logic is verified without any network clone,
+    - that the URDF surface covers the URDF-only long tail that MJCF discovery
+      cannot.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from strands_robots.registry import discovery
+
+
+@pytest.fixture(autouse=True)
+def _clear_discovery_cache():
+    """Reset discovery caches around every test so stubbed tables do not leak."""
+    discovery.invalidate_cache()
+    yield
+    discovery.invalidate_cache()
+
+
+# Cheap lookup surface (real description table)
+
+
+def test_urdf_module_resolves_urdf_only_robot() -> None:
+    pytest.importorskip("robot_descriptions")
+    # atlas_v4 ships a URDF but no MJCF Menagerie model -> URDF discovery only.
+    assert discovery.urdf_descriptions_module("atlas_v4") == "atlas_v4_description"
+
+
+def test_urdf_module_resolves_panda() -> None:
+    pytest.importorskip("robot_descriptions")
+    assert discovery.urdf_descriptions_module("panda") == "panda_description"
+
+
+def test_urdf_module_normalizes_dashes_and_case() -> None:
+    pytest.importorskip("robot_descriptions")
+    assert discovery.urdf_descriptions_module("Atlas-V4") == "atlas_v4_description"
+
+
+def test_urdf_module_rejects_traversal_names() -> None:
+    # Names with path/dot/slash chars must never reach importlib.
+    assert discovery.urdf_descriptions_module("../evil") is None
+    assert discovery.urdf_descriptions_module("robot_descriptions.os") is None
+
+
+def test_urdf_module_unknown_returns_none() -> None:
+    assert discovery.urdf_descriptions_module("definitely_not_a_robot_xyz") is None
+
+
+def test_is_urdf_discoverable() -> None:
+    pytest.importorskip("robot_descriptions")
+    assert discovery.is_urdf_discoverable("panda") is True
+    assert discovery.is_urdf_discoverable("definitely_not_a_robot_xyz") is False
+
+
+def test_list_urdf_discoverable_is_sorted_and_nonempty() -> None:
+    pytest.importorskip("robot_descriptions")
+    names = discovery.list_urdf_discoverable()
+    assert names == sorted(names)
+    assert "panda" in names
+    # MJCF modules (``_mj_description``) must not leak into the URDF table.
+    assert all(not n.endswith("_mj") for n in names)
+
+
+def test_urdf_surface_covers_mjcf_only_long_tail() -> None:
+    pytest.importorskip("robot_descriptions")
+    urdf = set(discovery.list_urdf_discoverable())
+    mjcf = set(discovery.list_discoverable())
+    # The URDF long tail must include robots with no MJCF model at all -
+    # that is the whole point of URDF-native discovery.
+    urdf_only = urdf - mjcf
+    assert len(urdf_only) >= 5
+    assert "atlas_v4" in urdf_only
+
+
+# Heavy path resolution (stubbed import - no network)
+
+
+def test_discover_urdf_path_resolves_existing_file(monkeypatch, tmp_path) -> None:
+    urdf_file = tmp_path / "panda.urdf"
+    urdf_file.write_text("<robot name='panda'></robot>")
+    monkeypatch.setattr(discovery, "_urdf_modules", lambda: {"panda": "panda_description"})
+    monkeypatch.setattr(
+        discovery.importlib,
+        "import_module",
+        lambda modpath: SimpleNamespace(URDF_PATH=str(urdf_file)),
+    )
+    assert discovery.discover_urdf_path("panda") == str(urdf_file)
+
+
+def test_discover_urdf_path_returns_none_for_non_description(monkeypatch) -> None:
+    monkeypatch.setattr(discovery, "_urdf_modules", dict)
+
+    def _explode(modpath: str):
+        raise AssertionError(f"import_module must not be called for {modpath!r}")
+
+    monkeypatch.setattr(discovery.importlib, "import_module", _explode)
+    assert discovery.discover_urdf_path("definitely_not_a_robot_xyz") is None
+
+
+def test_discover_urdf_path_none_when_module_lacks_urdf_path(monkeypatch) -> None:
+    monkeypatch.setattr(discovery, "_urdf_modules", lambda: {"fakebot": "fakebot_description"})
+    monkeypatch.setattr(
+        discovery.importlib,
+        "import_module",
+        lambda modpath: SimpleNamespace(),  # no URDF_PATH attribute
+    )
+    assert discovery.discover_urdf_path("fakebot") is None
+
+
+def test_discover_urdf_path_none_when_file_missing(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(discovery, "_urdf_modules", lambda: {"fakebot": "fakebot_description"})
+    monkeypatch.setattr(
+        discovery.importlib,
+        "import_module",
+        lambda modpath: SimpleNamespace(URDF_PATH=str(tmp_path / "nope.urdf")),
+    )
+    assert discovery.discover_urdf_path("fakebot") is None
+
+
+def test_discover_urdf_path_handles_import_error(monkeypatch) -> None:
+    monkeypatch.setattr(discovery, "_urdf_modules", lambda: {"fakebot": "fakebot_description"})
+
+    def _raise(modpath: str):
+        raise ImportError(modpath)
+
+    monkeypatch.setattr(discovery.importlib, "import_module", _raise)
+    assert discovery.discover_urdf_path("fakebot") is None
+
+
+def test_invalidate_cache_clears_urdf_modules(monkeypatch) -> None:
+    pytest.importorskip("robot_descriptions")
+    # Prime the cache, then confirm invalidate_cache resets it.
+    first = discovery.list_urdf_discoverable()
+    assert first  # non-empty real table
+    discovery.invalidate_cache()
+    # After invalidation a fresh stub takes effect (proves the lru_cache cleared).
+    monkeypatch.setattr(
+        discovery,
+        "_urdf_modules",
+        lambda: {"onlybot": "onlybot_description"},
+    )
+    assert discovery.list_urdf_discoverable() == ["onlybot"]

--- a/tests/simulation/newton/test_robot_descriptions.py
+++ b/tests/simulation/newton/test_robot_descriptions.py
@@ -1,0 +1,157 @@
+"""Newton ``add_robot`` resolution of the ``robot_descriptions`` URDF long tail.
+
+Newton ingests URDF natively, so robots that ship only a URDF (no MJCF) can be
+loaded straight from ``robot_descriptions`` - a capability the MuJoCo backend
+lacks. These tests exercise the resolution + import wiring end to end on a real
+Newton model build, using a self-contained minimal URDF (no network clone) so
+they are deterministic in CI:
+
+    - ``source="robot_descriptions"`` routes through the URDF importer and
+      discovers the robot's joints,
+    - ``source=None`` falls back to a URDF when the registry has no asset,
+    - ``source="registry"`` does NOT fall back,
+    - an explicit ``urdf_path`` wins over ``source``,
+    - bad / unknown selectors produce clear error dicts,
+    - ``list_urdfs`` returns the registry + ``robot_descriptions`` URDF union.
+
+The real ``robot_descriptions.panda_description`` flow (URDF clone + 9-joint
+build) is the design target; it is validated out-of-band to keep the suite
+network-free. The cheap name->module mapping it relies on is covered by
+``tests/registry/test_robot_descriptions_urdf.py``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+_HAS_NEWTON = importlib.util.find_spec("newton") is not None and importlib.util.find_spec("warp") is not None
+
+pytestmark = pytest.mark.skipif(not _HAS_NEWTON, reason="newton/warp not installed")
+
+_MINI_URDF = """<?xml version="1.0"?>
+<robot name="mini_arm">
+  <link name="base_link">
+    <inertial><mass value="1.0"/><inertia ixx="0.01" ixy="0" ixz="0" iyy="0.01" iyz="0" izz="0.01"/></inertial>
+    <collision><geometry><box size="0.1 0.1 0.1"/></geometry></collision>
+  </link>
+  <link name="link1">
+    <inertial><mass value="0.5"/><inertia ixx="0.01" ixy="0" ixz="0" iyy="0.01" iyz="0" izz="0.01"/></inertial>
+    <collision><geometry><box size="0.05 0.05 0.2"/></geometry></collision>
+  </link>
+  <link name="link2">
+    <inertial><mass value="0.3"/><inertia ixx="0.01" ixy="0" ixz="0" iyy="0.01" iyz="0" izz="0.01"/></inertial>
+    <collision><geometry><box size="0.05 0.05 0.2"/></geometry></collision>
+  </link>
+  <joint name="shoulder" type="revolute">
+    <parent link="base_link"/><child link="link1"/>
+    <origin xyz="0 0 0.1"/><axis xyz="0 0 1"/>
+    <limit lower="-1.57" upper="1.57" effort="10" velocity="2"/>
+  </joint>
+  <joint name="elbow" type="revolute">
+    <parent link="link1"/><child link="link2"/>
+    <origin xyz="0 0 0.2"/><axis xyz="0 1 0"/>
+    <limit lower="-1.57" upper="1.57" effort="10" velocity="2"/>
+  </joint>
+</robot>
+"""
+
+
+@pytest.fixture
+def urdf_file(tmp_path):
+    path = tmp_path / "mini_arm.urdf"
+    path.write_text(_MINI_URDF)
+    return str(path)
+
+
+@pytest.fixture
+def engine():
+    from strands_robots.simulation.newton.simulation import NewtonSimEngine
+
+    sim = NewtonSimEngine(solver="mujoco")
+    sim.create_world()
+    yield sim
+    sim.destroy()
+
+
+def _stub_discovery(monkeypatch, *, urdf_path):
+    """Make ``discover_urdf_path`` resolve any name to *urdf_path* (or None)."""
+    from strands_robots.simulation.newton import simulation as sim_mod
+
+    monkeypatch.setattr(sim_mod, "discover_urdf_path", lambda name: urdf_path)
+
+
+class TestRobotDescriptionsSource:
+    def test_loads_urdf_and_discovers_joints(self, engine, urdf_file, monkeypatch):
+        _stub_discovery(monkeypatch, urdf_path=urdf_file)
+        result = engine.add_robot("mini_arm", source="robot_descriptions")
+        assert result["status"] == "success"
+        # Joints are discovered from the URDF and exposed under short names.
+        assert engine.robot_joint_names("mini_arm") == ["shoulder", "elbow"]
+        # The world is a real Newton model that steps.
+        assert engine.step(3)["status"] == "success"
+
+    def test_unknown_robot_errors_with_hint(self, engine, monkeypatch):
+        _stub_discovery(monkeypatch, urdf_path=None)
+        result = engine.add_robot("not_a_robot", source="robot_descriptions")
+        assert result["status"] == "error"
+        assert "list_urdfs" in result["content"][0]["text"]
+
+
+class TestSourceSelector:
+    def test_unknown_source_rejected(self, engine):
+        result = engine.add_robot("anything", source="bogus")
+        assert result["status"] == "error"
+        assert "Unknown source" in result["content"][0]["text"]
+
+    def test_default_source_falls_back_to_urdf(self, engine, urdf_file, monkeypatch):
+        # 'mini_arm' is not in the curated registry, so default resolution must
+        # fall back to the robot_descriptions URDF rather than failing.
+        _stub_discovery(monkeypatch, urdf_path=urdf_file)
+        result = engine.add_robot("mini_arm", source=None)
+        assert result["status"] == "success"
+        assert engine.robot_joint_names("mini_arm") == ["shoulder", "elbow"]
+
+    def test_registry_source_does_not_fall_back(self, engine, urdf_file, monkeypatch):
+        # A URDF is available, but source='registry' must not consult it.
+        _stub_discovery(monkeypatch, urdf_path=urdf_file)
+        result = engine.add_robot("mini_arm", source="registry")
+        assert result["status"] == "error"
+        assert "mini_arm" not in engine.list_robots()
+
+    def test_explicit_urdf_path_wins_over_source(self, engine, urdf_file):
+        result = engine.add_robot("mini_arm", urdf_path=urdf_file, source="registry")
+        assert result["status"] == "success"
+        assert engine.robot_joint_names("mini_arm") == ["shoulder", "elbow"]
+
+
+class TestResolveAsset:
+    def test_default_returns_urdf_for_discoverable(self, engine, urdf_file, monkeypatch):
+        _stub_discovery(monkeypatch, urdf_path=urdf_file)
+        path, error = engine._resolve_asset("mini_arm", None)
+        assert error is None
+        assert path == urdf_file
+
+    def test_registry_only_no_urdf_fallback(self, engine, urdf_file, monkeypatch):
+        _stub_discovery(monkeypatch, urdf_path=urdf_file)
+        path, error = engine._resolve_asset("mini_arm", "registry")
+        assert path is None
+        assert error and "mini_arm" in error
+
+    def test_known_registry_robot_resolves_mjcf(self, engine):
+        path, error = engine._resolve_asset("so100", None)
+        assert error is None
+        assert path is not None and path.endswith(".xml")
+
+
+class TestListUrdfsUnion:
+    def test_includes_robot_descriptions_urdf_long_tail(self, engine):
+        result = engine.list_urdfs()
+        assert result["status"] == "success"
+        urdf_robots = result["content"][1]["json"]["robot_descriptions_urdf"]
+        # Real static table (no network): the URDF long tail is non-empty and
+        # surfaced for programmatic use alongside the human-readable listing.
+        assert isinstance(urdf_robots, list) and len(urdf_robots) > 0
+        if urdf_robots:
+            assert "robot_descriptions" in result["content"][0]["text"]


### PR DESCRIPTION
## Problem

The Newton backend's `add_robot` resolved only MJCF assets (via `strands_robots.assets`), the same path the MuJoCo backend uses. But Newton parses URDF natively, and `robot_descriptions` ships a large **URDF-only** long tail (humanoids, quadrupeds, hands, dual-arm rigs) with no MJCF model. Those robots were unreachable on Newton even though the MuJoCo-only limitation does not apply to it. 84 of the 120 URDF-capable `robot_descriptions` robots have no MJCF model at all.

## Change

**Parallel URDF discovery surface** in `strands_robots.registry.discovery`, mirroring the existing MJCF surface and reading the same static description table (no import, no network for the cheap lookups):
- `urdf_descriptions_module(name)` -> e.g. `panda` -> `panda_description`
- `is_urdf_discoverable(name)`, `list_urdf_discoverable()`
- `discover_urdf_path(name)` -> resolves `robot_descriptions.<name>_description.URDF_PATH` (heavy; clones the asset repo on first use)

**Newton backend wiring** (`simulation/newton/simulation.py`):
- `add_robot` gains a `source` selector:
  - `None` (default): curated registry / MJCF asset manager first, then a `robot_descriptions` URDF fallback (so the URDF-only tail resolves without an explicit selector)
  - `"registry"`: registry only, no URDF fallback
  - `"robot_descriptions"`: URDF directly via the accessor above
- `_rebuild` dispatches `builder.add_urdf` vs `builder.add_mjcf` by file extension (`.urdf` -> URDF importer; URDF root stays fixed to the world, correct for table-mounted arms)
- `list_urdfs` returns the registry + URDF long-tail union and exposes `robot_descriptions_urdf` in its `json` block
- Joint names reuse the existing short-name helper for MuJoCo parity

An explicit `urdf_path=` still wins and bypasses `source`. Bad selectors and unresolvable names return clear error dicts pointing at `list_urdfs()`.

## Visual proof

Franka Panda loaded from its `robot_descriptions` URDF and stepped in Newton (MuJoCo-Warp solver, headless EGL), 9 joints discovered (`panda_joint1..7`, `panda_finger_joint1/2`):

![panda loaded from URDF in Newton](https://github.com/cagataycali/robots/releases/download/artifact-newton-urdf-panda/panda_newton_urdf.png)

```python
sim = create_simulation("newton", solver="mujoco")
sim.create_world()
sim.add_robot("panda", source="robot_descriptions")
print(sim.robot_joint_names("panda"))
# ['panda_joint1', ..., 'panda_joint7', 'panda_finger_joint1', 'panda_finger_joint2']
sim.step(10)
```

## Tests

- `tests/registry/test_robot_descriptions_urdf.py` (14 tests, no Newton/network): cheap name->module lookup against the real table, traversal/case normalization, the URDF long tail covering the MJCF-only gap, and `discover_urdf_path` path resolution with stubbed imports (success, missing file, no `URDF_PATH`, import error, cache invalidation).
- `tests/simulation/newton/test_robot_descriptions.py` (10 tests, gated on Newton, network-free via a self-contained minimal URDF): `source` routing through the URDF importer with joint discovery + a real model step, default URDF fallback, `"registry"` refusing to fall back, explicit `urdf_path` precedence, error paths, and the `list_urdfs` union.

All new tests fail on pre-change code (missing API) and pass after. Full local gate green: `ruff check` / `ruff format --check` clean, `mypy strands_robots tests tests_integ` success, and the Newton + registry suites pass (built and stepped on a real Newton/MuJoCo-Warp GPU model). Existing tests unaffected.

## Docs

New "URDF robots via robot_descriptions" section in `docs/simulation/newton.md` with the `source` resolution table and a runnable panda example; the capabilities bullet now notes native URDF loading.