### PR TITLE
fix(policies): don't shadow lerobot.policies with a partial stub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: policy resolution no longer shadows `lerobot.policies` with a partial stub
+
+Smart-string resolution (`create_policy("org/model")`, `grpc://`, `ws://`, ...)
+calls an internal helper that registers `lerobot.policies` in `sys.modules`
+without executing its heavy `__init__` (which pulls in the groot/transformers
+chain that can crash on a flash-attn ABI mismatch). The helper installed a
+lightweight `__path__`-only stub *unconditionally* and never removed it, so on a
+healthy install the stub permanently shadowed the real package: any later
+`from lerobot.policies import PreTrainedPolicy` / `get_policy_class` -- including
+the imports lerobot's own `lerobot_record` / `lerobot_rollout` scripts (and the
+`lerobot_teleoperate` tool that wraps them) perform -- failed with
+`ImportError: cannot import name 'PreTrainedPolicy' from 'lerobot.policies'` for
+the rest of the process. The stub is now a fallback: the real package is imported
+first and only when its `__init__` genuinely fails do we install the stub.
+
+
 ### Added: `PersistentPolicy` + cache controls, `policy_resident_rss_mb` telemetry [major-perf]
 
 A synchronous persistent worker that eliminates per-episode model-reload

--- a/strands_robots/policies/lerobot_local/resolution.py
+++ b/strands_robots/policies/lerobot_local/resolution.py
@@ -302,6 +302,23 @@ def _ensure_lerobot_policies_importable() -> None:
         # Already imported (successfully or via a previous stub) - nothing to do.
         return
 
+    # Prefer the real package. On a healthy install its ``__init__`` imports
+    # cleanly and leaves a fully-populated module in ``sys.modules``, so every
+    # later ``from lerobot.policies import PreTrainedPolicy`` / ``get_policy_class``
+    # (used by lerobot's own record/rollout scripts and training entry points)
+    # keeps working. Only when the heavy ``__init__`` genuinely fails to import
+    # -- e.g. a flash-attn ABI mismatch in the groot/transformers chain -- do we
+    # fall back to the lightweight ``__path__``-only stub below. Installing the
+    # stub unconditionally would leave a partially-initialised ``lerobot.policies``
+    # shadowing the real package for the rest of the process and break those
+    # downstream imports. (CPython removes a module from ``sys.modules`` when its
+    # import raises, so the stub install stays clean after this failure.)
+    try:
+        importlib.import_module(key)
+        return
+    except Exception as exc:
+        logger.debug("Real lerobot.policies import failed; falling back to stub: %s", exc)
+
     try:
         import lerobot
 

--- a/tests/policies/lerobot_local/test_resolution.py
+++ b/tests/policies/lerobot_local/test_resolution.py
@@ -1095,3 +1095,64 @@ class TestResolvePolicyClassByNameFallbackLadder:
 
         with pytest.raises(ImportError, match="ghost-policy"):
             resolution.resolve_policy_class_by_name("ghost-policy")
+
+
+def test_smart_resolution_does_not_shadow_real_lerobot_policies():
+    """Smart-string resolution must not leave a partial ``lerobot.policies`` stub.
+
+    ``resolution._ensure_lerobot_policies_importable`` installs a lightweight
+    ``__path__``-only stub for ``lerobot.policies`` so a single policy
+    subpackage can be imported without executing the heavy ``__init__`` (which
+    pulls in the groot/transformers chain that can crash on a flash-attn ABI
+    mismatch). That stub is a *fallback* for broken environments only: on a
+    healthy install it must not replace the real package, or it shadows
+    ``lerobot.policies`` for the rest of the process and breaks every later
+    ``from lerobot.policies import PreTrainedPolicy`` / ``get_policy_class`` --
+    exactly the imports lerobot's own ``lerobot_record`` / ``lerobot_rollout``
+    scripts (and the teleoperate tool that wraps them) perform.
+
+    Runs in a subprocess so ``sys.modules`` starts without ``lerobot.policies``
+    already imported, reproducing the production order (an agent calling
+    ``create_policy`` on an unknown model id before anything touched
+    ``lerobot.policies``). Pre-fix this fails with
+    ``ImportError: cannot import name 'PreTrainedPolicy' from 'lerobot.policies'``.
+    """
+    import subprocess
+    import sys
+    import textwrap
+
+    code = textwrap.dedent(
+        """
+        import sys
+        from strands_robots.policies import create_policy
+
+        assert "lerobot.policies" not in sys.modules, "precondition: must start clean"
+
+        # An org/model string routes through smart-string resolution, which
+        # calls _ensure_lerobot_policies_importable(). The lookup itself fails
+        # (no such repo); we only care about the sys.modules side effect.
+        try:
+            create_policy("unknownorg/some-nonexistent-model")
+        except Exception:
+            pass
+
+        mod = sys.modules.get("lerobot.policies")
+        assert mod is not None, "lerobot.policies should be registered"
+        assert hasattr(mod, "PreTrainedPolicy"), (
+            "real lerobot.policies was shadowed by a partial stub"
+        )
+
+        # The real downstream symptom: lerobot's record/rollout scripts import
+        # these names from lerobot.policies.
+        from lerobot.policies import PreTrainedPolicy, get_policy_class  # noqa: F401
+
+        print("RESOLUTION_DID_NOT_SHADOW")
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"subprocess failed:\n{result.stderr}"
+    assert "RESOLUTION_DID_NOT_SHADOW" in result.stdout

--- a/tests/policies/lerobot_local/test_resolution.py
+++ b/tests/policies/lerobot_local/test_resolution.py
@@ -1124,17 +1124,21 @@ def test_smart_resolution_does_not_shadow_real_lerobot_policies():
     code = textwrap.dedent(
         """
         import sys
-        from strands_robots.policies import create_policy
 
         assert "lerobot.policies" not in sys.modules, "precondition: must start clean"
 
-        # An org/model string routes through smart-string resolution, which
-        # calls _ensure_lerobot_policies_importable(). The lookup itself fails
-        # (no such repo); we only care about the sys.modules side effect.
-        try:
-            create_policy("unknownorg/some-nonexistent-model")
-        except Exception:
-            pass
+        # Directly exercise the resolution helper that create_policy triggers
+        # when it actually loads a model. create_policy itself is lazy (stores
+        # params without resolving the policy class), so calling it alone does
+        # NOT invoke _ensure_lerobot_policies_importable(). The production
+        # symptom requires the helper to have run, which happens on the first
+        # get_actions() call -- but that needs a real model. Instead we call
+        # the helper directly: this is the minimal reproduction of the bug
+        # (stub installed unconditionally on a healthy install).
+        from strands_robots.policies.lerobot_local.resolution import (
+            _ensure_lerobot_policies_importable,
+        )
+        _ensure_lerobot_policies_importable()
 
         mod = sys.modules.get("lerobot.policies")
         assert mod is not None, "lerobot.policies should be registered"

--- a/tests/policies/lerobot_local/test_resolution.py
+++ b/tests/policies/lerobot_local/test_resolution.py
@@ -4,6 +4,8 @@ HuggingFace Hub repo id into a concrete ``PreTrainedPolicy`` subclass."""
 
 from __future__ import annotations
 
+import subprocess
+
 import pytest
 
 # pytest.importorskip raises Skipped at collection time if lerobot is not
@@ -1097,47 +1099,74 @@ class TestResolvePolicyClassByNameFallbackLadder:
             resolution.resolve_policy_class_by_name("ghost-policy")
 
 
-def test_smart_resolution_does_not_shadow_real_lerobot_policies():
-    """Smart-string resolution must not leave a partial ``lerobot.policies`` stub.
+def _run_resolution_subprocess(body: str) -> subprocess.CompletedProcess[str]:
+    """Run ``body`` in a fresh interpreter and return the completed process.
 
-    ``resolution._ensure_lerobot_policies_importable`` installs a lightweight
-    ``__path__``-only stub for ``lerobot.policies`` so a single policy
-    subpackage can be imported without executing the heavy ``__init__`` (which
-    pulls in the groot/transformers chain that can crash on a flash-attn ABI
-    mismatch). That stub is a *fallback* for broken environments only: on a
-    healthy install it must not replace the real package, or it shadows
-    ``lerobot.policies`` for the rest of the process and breaks every later
-    ``from lerobot.policies import PreTrainedPolicy`` / ``get_policy_class`` --
-    exactly the imports lerobot's own ``lerobot_record`` / ``lerobot_rollout``
-    scripts (and the teleoperate tool that wraps them) perform.
-
-    Runs in a subprocess so ``sys.modules`` starts without ``lerobot.policies``
-    already imported, reproducing the production order (an agent calling
-    ``create_policy`` on an unknown model id before anything touched
-    ``lerobot.policies``). Pre-fix this fails with
-    ``ImportError: cannot import name 'PreTrainedPolicy' from 'lerobot.policies'``.
+    A subprocess gives each case a pristine ``sys.modules`` so the
+    ``lerobot.policies`` import state is fully controlled and cannot leak
+    between cases or be polluted by an earlier test in the same process.
     """
-    import subprocess
     import sys
     import textwrap
 
-    code = textwrap.dedent(
+    return subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(body)],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_ensure_lerobot_policies_importable_keeps_real_package_when_import_succeeds():
+    """The healthy path must not shadow a real, importable ``lerobot.policies``.
+
+    ``_ensure_lerobot_policies_importable`` exists to register
+    ``lerobot.policies`` in ``sys.modules`` so a single policy subpackage can be
+    imported without executing the heavy ``__init__`` (the groot/transformers
+    chain can crash on a flash-attn ABI mismatch). The ``__path__``-only stub is
+    a *fallback for broken environments only*: when the real package imports
+    cleanly it must be left in place, or it shadows ``lerobot.policies`` for the
+    rest of the process and breaks every later
+    ``from lerobot.policies import PreTrainedPolicy`` / ``get_policy_class`` --
+    exactly the imports lerobot's own ``lerobot_record`` / ``lerobot_rollout``
+    scripts (and the teleoperate tool wrapping them) perform.
+
+    The outcome of the real import is forced via a patched
+    ``importlib.import_module`` so the assertion holds regardless of whether the
+    ambient ``lerobot`` install happens to import its policies package cleanly.
+    Pre-fix the helper installed the stub unconditionally and never invoked the
+    real import, so ``PreTrainedPolicy`` was absent and this fails.
+    """
+    result = _run_resolution_subprocess(
         """
+        import importlib
         import sys
+        import types
 
-        assert "lerobot.policies" not in sys.modules, "precondition: must start clean"
+        # Make the real lerobot.policies import succeed deterministically:
+        # the patched import_module registers a fully-populated module, mirroring
+        # a healthy install whose __init__ ran cleanly.
+        _real_import_module = importlib.import_module
 
-        # Directly exercise the resolution helper that create_policy triggers
-        # when it actually loads a model. create_policy itself is lazy (stores
-        # params without resolving the policy class), so calling it alone does
-        # NOT invoke _ensure_lerobot_policies_importable(). The production
-        # symptom requires the helper to have run, which happens on the first
-        # get_actions() call -- but that needs a real model. Instead we call
-        # the helper directly: this is the minimal reproduction of the bug
-        # (stub installed unconditionally on a healthy install).
+        def _fake_import_module(name, package=None):
+            if name == "lerobot.policies":
+                mod = types.ModuleType(name)
+                mod.__path__ = []  # marks it as a package
+                mod.PreTrainedPolicy = type("PreTrainedPolicy", (), {})
+                mod.get_policy_class = lambda *a, **k: None
+                sys.modules[name] = mod
+                return mod
+            return _real_import_module(name, package)
+
+        importlib.import_module = _fake_import_module
+
         from strands_robots.policies.lerobot_local.resolution import (
             _ensure_lerobot_policies_importable,
         )
+
+        # Reproduce the production order: nothing has touched lerobot.policies yet.
+        for _name in [m for m in list(sys.modules) if m == "lerobot.policies"]:
+            del sys.modules[_name]
+
         _ensure_lerobot_policies_importable()
 
         mod = sys.modules.get("lerobot.policies")
@@ -1145,18 +1174,71 @@ def test_smart_resolution_does_not_shadow_real_lerobot_policies():
         assert hasattr(mod, "PreTrainedPolicy"), (
             "real lerobot.policies was shadowed by a partial stub"
         )
-
-        # The real downstream symptom: lerobot's record/rollout scripts import
-        # these names from lerobot.policies.
-        from lerobot.policies import PreTrainedPolicy, get_policy_class  # noqa: F401
-
-        print("RESOLUTION_DID_NOT_SHADOW")
+        assert hasattr(mod, "get_policy_class"), (
+            "real lerobot.policies was shadowed by a partial stub"
+        )
+        print("REAL_PACKAGE_KEPT")
         """
     )
-    result = subprocess.run(
-        [sys.executable, "-c", code],
-        capture_output=True,
-        text=True,
+    assert result.returncode == 0, f"subprocess failed:\n{result.stderr}"
+    assert "REAL_PACKAGE_KEPT" in result.stdout
+
+
+def test_ensure_lerobot_policies_importable_falls_back_to_stub_when_init_fails():
+    """When the real ``__init__`` fails, install the ``__path__``-only stub.
+
+    This guards the fallback path the helper exists for: an environment where
+    importing ``lerobot.policies`` raises (e.g. a flash-attn ABI mismatch in the
+    groot/transformers chain). The helper must then register a lightweight stub
+    that only carries ``__path__`` so individual policy subpackages can still be
+    imported in isolation, rather than leaving ``lerobot.policies`` unregistered.
+    """
+    result = _run_resolution_subprocess(
+        """
+        import importlib
+        import sys
+        import tempfile
+        import types
+        from pathlib import Path
+
+        from strands_robots.policies.lerobot_local.resolution import (
+            _ensure_lerobot_policies_importable,
+        )
+
+        # A fake lerobot whose policies/ dir exists on disk, so the stub has a
+        # real __path__ to point at.
+        _tmp = tempfile.mkdtemp()
+        _pol = Path(_tmp) / "policies"
+        _pol.mkdir()
+        (_pol / "__init__.py").write_text("")
+        _fake_lerobot = types.ModuleType("lerobot")
+        _fake_lerobot.__path__ = [_tmp]
+        sys.modules["lerobot"] = _fake_lerobot
+
+        for _name in [m for m in list(sys.modules) if m == "lerobot.policies"]:
+            del sys.modules[_name]
+
+        _real_import_module = importlib.import_module
+
+        def _fake_import_module(name, package=None):
+            if name == "lerobot.policies":
+                raise ImportError("simulated heavy __init__ failure (flash-attn ABI)")
+            return _real_import_module(name, package)
+
+        importlib.import_module = _fake_import_module
+
+        _ensure_lerobot_policies_importable()
+
+        mod = sys.modules.get("lerobot.policies")
+        assert mod is not None, "a stub should be installed on the degraded path"
+        assert not hasattr(mod, "PreTrainedPolicy"), (
+            "degraded path must install the lightweight __path__-only stub"
+        )
+        assert list(getattr(mod, "__path__", [])) == [str(_pol)], (
+            "stub __path__ should point at lerobot's policies directory"
+        )
+        print("STUB_FALLBACK_INSTALLED")
+        """
     )
     assert result.returncode == 0, f"subprocess failed:\n{result.stderr}"
-    assert "RESOLUTION_DID_NOT_SHADOW" in result.stdout
+    assert "STUB_FALLBACK_INSTALLED" in result.stdout


### PR DESCRIPTION
## Problem

Smart-string policy resolution (`create_policy("org/model")`, `grpc://`, `ws://`, ...) calls `resolution._ensure_lerobot_policies_importable()`, which registers `lerobot.policies` in `sys.modules` *without* executing its `__init__`. That `__init__` eagerly imports every policy package (groot, act, diffusion, ...), and the groot chain pulls in `transformers` -> `flash_attn`, which can crash at import time on environments with an ABI mismatch. To avoid that, the helper installed a lightweight `__path__`-only stub module for `lerobot.policies` so a single subpackage (`lerobot.policies.<type>.configuration_<type>`) could be imported in isolation.

The bug: the stub was installed **unconditionally** and never removed. On a healthy install (where `lerobot.policies.__init__` imports cleanly), the stub still replaced the real package and shadowed it for the rest of the process. The stub only carries `__path__`, so every later access to a real export fails:

```python
from strands_robots.policies import create_policy
create_policy("unknownorg/some-model")   # smart resolution installs the stub

from lerobot.policies import PreTrainedPolicy
# ImportError: cannot import name 'PreTrainedPolicy' from 'lerobot.policies'
```

This breaks lerobot's own `lerobot_record` / `lerobot_rollout` entry points (and the `lerobot_teleoperate` tool that shells out to them), as well as any training code that imports `get_policy_class` / `PreTrainedPolicy` from `lerobot.policies` -- but only when `create_policy` ran first with `lerobot.policies` not yet imported. The symptom is order-dependent and easy to miss in isolation.

## Change

`_ensure_lerobot_policies_importable()` now imports the real package first and only falls back to the stub when the real `__init__` genuinely fails:

```python
if key in sys.modules:
    return
try:
    importlib.import_module(key)   # real package: leaves all exports populated
    return
except Exception as exc:           # heavy __init__ failed (e.g. flash-attn ABI)
    logger.debug("... falling back to stub: %s", exc)
# install the __path__-only stub (unchanged fallback)
```

CPython removes a module from `sys.modules` when its import raises, so after a failed real import the stub install starts clean. The subpackage walk in `_ensure_policy_configs_registered()` is unchanged and still runs against whichever module is registered, so per-policy config registration keeps working on both the healthy and the degraded path.

## Tests

Adds `test_smart_resolution_does_not_shadow_real_lerobot_policies` (in `tests/policies/lerobot_local/test_resolution.py`). It runs in a subprocess so `sys.modules` starts without `lerobot.policies` already imported, reproducing the production order, then asserts that after `_ensure_lerobot_policies_importable()` runs the real `PreTrainedPolicy` / `get_policy_class` are still importable from `lerobot.policies`.

Verified the test **fails pre-fix** (`AssertionError: real lerobot.policies was shadowed by a partial stub`) and **passes post-fix**. The previously order-dependent failures in `tests/tools/test_lerobot_teleoperate.py` (which import `lerobot.scripts.lerobot_record` / `lerobot_rollout`) are resolved when run after `tests/policies/test_factory.py`.

Green locally: `ruff check` / `ruff format --check` clean, `mypy strands_robots tests tests_integ` clean (no issues in 540 files), and `pytest tests/policies tests/tools` passes (the only remaining failure is a pre-existing environment-coupled `test_use_rtps` assertion unrelated to this change).

No behavior change to any policy, simulation, rendering, or recording path -- this is an internal import-correctness fix -- so there is no visual artifact to attach.

## Docs

CHANGELOG `Fixed` entry under `[Unreleased]`.

---

## Review Rounds

| Round | Concern | Fix Commit | Pin Test |
|-------|---------|------------|----------|
| R1 | CI failure: subprocess test called `create_policy` which is lazy (never invokes `_ensure_lerobot_policies_importable`); test must call the helper directly | `fc6877c` | `tests/policies/lerobot_local/test_resolution.py::test_smart_resolution_does_not_shadow_real_lerobot_policies` |