### PR TITLE
fix(simulation): verify_dataset_episodes cross-checks meta/info.json against the parquet

### DIFF
--- a/docs/recording.md
+++ b/docs/recording.md
@@ -82,6 +82,35 @@ single `episode_index=0` (1200 steps in one episode). To DISCARD a partial
 rollout instead of flushing it on the next `reset()`, call
 `clear_episode_buffer()` first.
 
+## Verifying episode count
+
+An LLM agent narrating "20 episodes recorded" is not proof: a single
+`run_policy(n_episodes=1)` (or 20 looped tool calls into one open buffer)
+produces one merged `episode_index=0` mega-episode while the agent believes it
+recorded 20. Never trust agent narration for dataset structure - verify against
+the on-disk metadata. After `stop_recording`, call `verify_dataset_episodes`:
+
+```python
+sim.stop_recording()
+result = sim.verify_dataset_episodes(expected=20)
+assert result["status"] == "success"   # else MISMATCH, fail loud
+```
+
+It checks two independent sources of truth and requires them to AGREE:
+
+* the parquet under `meta/episodes/**/*.parquet` (the distinct `episode_index`
+  set - the ground truth), and
+* the `total_episodes` header in `meta/info.json`.
+
+`status` is `"error"` when the parquet count differs from `expected` OR when the
+parquet disagrees with `info.json` (an internally inconsistent dataset, e.g. an
+interrupted finalize - `sources_agree` is then `False`), so a dataset that
+happens to match `expected` on one source but not the other still fails. The
+`{"json": {...}}` block carries `expected`, `actual`, `info_total_episodes`,
+`sources_agree`, `episode_indices`, and `total_frames` for programmatic CI
+gating. The pure-pyarrow `read_dataset_episode_indices(root)` exposes the same
+facts without instantiating a `LeRobotDataset`.
+
 ## Recording paths
 
 | Method | Extra needed | Output |

--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -21,6 +21,7 @@ Usage:
 """
 
 import functools
+import json
 import logging
 import re
 import sys
@@ -938,6 +939,11 @@ def read_dataset_episode_indices(root: str | Path) -> dict[str, Any]:
           - ``total_frames``: sum of per-episode ``length`` (0 if unavailable).
           - ``frames_per_episode``: per-episode frame counts aligned to
             ``episode_indices`` (empty list if the ``length`` column is absent).
+          - ``info_total_episodes``: the ``total_episodes`` recorded in
+            ``meta/info.json`` (``None`` if that file is absent or unreadable).
+            Returned alongside the parquet truth so callers can cross-check the
+            two metadata sources for agreement - a healthy dataset has
+            ``info_total_episodes == total_episodes``.
 
     Raises:
         ImportError: If ``pyarrow`` is not installed.
@@ -979,9 +985,26 @@ def read_dataset_episode_indices(root: str | Path) -> dict[str, Any]:
     episode_indices = [p[0] for p in pairs]
     frames_per_episode = [p[1] for p in pairs]
     has_lengths = any(f > 0 for f in frames_per_episode)
+
+    # Read meta/info.json total_episodes as a second, independent metadata
+    # source. A healthy LeRobot dataset has info.json.total_episodes equal to
+    # the distinct episode count in the parquet; a mismatch means the dataset
+    # is internally inconsistent (e.g. an interrupted finalize), which
+    # verify_dataset_episodes surfaces. Absent/corrupt info.json -> None (the
+    # parquet remains the ground truth and is still reported).
+    info_total_episodes: int | None = None
+    info_path = root_path / "meta" / "info.json"
+    if info_path.is_file():
+        try:
+            with info_path.open() as f:
+                info_total_episodes = int(json.load(f)["total_episodes"])
+        except (OSError, ValueError, KeyError, TypeError):
+            info_total_episodes = None
+
     return {
         "episode_indices": episode_indices,
         "total_episodes": len(episode_indices),
         "total_frames": sum(frames_per_episode) if has_lengths else 0,
         "frames_per_episode": frames_per_episode if has_lengths else [],
+        "info_total_episodes": info_total_episodes,
     }

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -880,7 +880,11 @@ class SimEngine(ABC):
         """Verify the recorded dataset holds exactly ``expected`` episodes.
 
         Reads the LeRobot dataset parquet (the ground truth) for the active or
-        most-recently-recorded session and reports the actual episode count.
+        most-recently-recorded session AND cross-checks it against the
+        ``meta/info.json`` ``total_episodes`` header. Both must agree with
+        ``expected``; a parquet that matches ``expected`` but disagrees with
+        info.json (an internally inconsistent dataset) still fails. Reports the
+        actual episode count.
         Call this AFTER :meth:`stop_recording` for a definitive check that a
         collection run produced N distinct episodes rather than one merged
         ``episode_index=0`` mega-episode.
@@ -898,8 +902,13 @@ class SimEngine(ABC):
             Standard status dict. ``status`` is ``"success"`` when the parquet
             holds exactly ``expected`` episodes, else ``"error"``. The
             ``{"json": {...}}`` block carries ``expected``, ``actual``,
-            ``episode_indices``, ``total_frames``, ``total_frames_per_ep`` and
-            ``root`` so a caller (or CI) can fail loudly programmatically.
+            ``info_total_episodes``, ``sources_agree``, ``episode_indices``,
+            ``total_frames``, ``total_frames_per_ep`` and ``root`` so a caller
+            (or CI) can fail loudly programmatically. ``status`` is ``"error"``
+            both when the parquet count differs from ``expected`` AND when the
+            parquet disagrees with ``meta/info.json``'s ``total_episodes``
+            (``sources_agree`` is then ``False``) - the two metadata sources
+            must agree, never just one.
         """
         if not isinstance(expected, int) or expected < 0:
             return {
@@ -936,6 +945,8 @@ class SimEngine(ABC):
                         "json": {
                             "expected": expected,
                             "actual": 0,
+                            "info_total_episodes": None,
+                            "sources_agree": False,
                             "episode_indices": [],
                             "total_frames": 0,
                             "total_frames_per_ep": [],
@@ -948,14 +959,33 @@ class SimEngine(ABC):
             return {"status": "error", "content": [{"text": f"verify_dataset_episodes: {e}"}]}
 
         actual = info["total_episodes"]
-        ok = actual == expected
+        info_total = info.get("info_total_episodes")
+
+        # Two independent truths must agree: the parquet episode count AND the
+        # meta/info.json total_episodes header. A dataset can report the right
+        # parquet count yet carry a stale/inconsistent info.json (interrupted
+        # finalize), so a parquet-only check is not sufficient. sources_agree is
+        # True when info.json is absent (parquet is then the sole truth) or when
+        # the header matches the parquet.
+        sources_agree = info_total is None or info_total == actual
+        ok = actual == expected and sources_agree
         status = "success" if ok else "error"
-        verdict = "matches" if ok else "MISMATCH"
-        text = (
-            f"verify_dataset_episodes: {verdict} - expected {expected}, "
-            f"found {actual} episode(s) in parquet "
-            f"({info['total_frames']} total frames). Root: {root}"
-        )
+
+        if not sources_agree:
+            verdict = "MISMATCH"
+            text = (
+                f"verify_dataset_episodes: {verdict} - meta/info.json reports "
+                f"{info_total} episode(s) but the parquet holds {actual}; the "
+                f"dataset metadata is inconsistent (expected {expected}). "
+                f"Root: {root}"
+            )
+        else:
+            verdict = "matches" if ok else "MISMATCH"
+            text = (
+                f"verify_dataset_episodes: {verdict} - expected {expected}, "
+                f"found {actual} episode(s) in parquet "
+                f"({info['total_frames']} total frames). Root: {root}"
+            )
         return {
             "status": status,
             "content": [
@@ -964,6 +994,8 @@ class SimEngine(ABC):
                     "json": {
                         "expected": expected,
                         "actual": actual,
+                        "info_total_episodes": info_total,
+                        "sources_agree": sources_agree,
                         "episode_indices": info["episode_indices"],
                         "total_frames": info["total_frames"],
                         "total_frames_per_ep": info["frames_per_episode"],

--- a/tests/simulation/test_run_policy_episode_contract.py
+++ b/tests/simulation/test_run_policy_episode_contract.py
@@ -21,6 +21,7 @@ the recording path; the structured fields are the machine-checkable surface.
 
 from __future__ import annotations
 
+import json
 import shutil
 
 import pytest
@@ -160,3 +161,62 @@ class TestVerifyDatasetEpisodes:
         _record(sim, str(tmp_path / "vneg"), n_episodes=1, n_steps=3)
         result = sim.verify_dataset_episodes(expected=-1)
         assert result["status"] == "error"
+
+
+class TestInfoParquetCrossCheck:
+    """verify_dataset_episodes requires meta/info.json AND parquet to agree.
+
+    A dataset can carry the right parquet episode count yet a stale/inconsistent
+    ``meta/info.json`` header (e.g. an interrupted finalize). A parquet-only
+    check would pass it; the two independent metadata sources must agree.
+    """
+
+    def test_read_helper_reports_info_total_episodes(self, sim, tmp_path):
+        root = str(tmp_path / "info")
+        _record(sim, root, n_episodes=3, n_steps=3)
+        info = read_dataset_episode_indices(root)
+        # info.json header agrees with the parquet on a healthy dataset.
+        assert info["info_total_episodes"] == 3
+        assert info["total_episodes"] == 3
+
+    def test_verify_reports_agreement_on_healthy_dataset(self, sim, tmp_path):
+        _record(sim, str(tmp_path / "agree"), n_episodes=2, n_steps=3)
+        result = sim.verify_dataset_episodes(expected=2)
+        assert result["status"] == "success"
+        vj = _json_block(result)
+        assert vj["info_total_episodes"] == 2
+        assert vj["sources_agree"] is True
+
+    def test_verify_errors_when_info_json_disagrees_with_parquet(self, sim, tmp_path):
+        """info.json claims a different count than the parquet -> MISMATCH.
+
+        The parquet holds exactly ``expected`` episodes, so a parquet-only check
+        would (wrongly) pass. Cross-checking info.json catches the inconsistent
+        dataset and fails loudly.
+        """
+        root = tmp_path / "skew"
+        _record(sim, str(root), n_episodes=2, n_steps=3)
+
+        info_path = root / "meta" / "info.json"
+        meta = json.loads(info_path.read_text())
+        meta["total_episodes"] = 99  # corrupt: header disagrees with 2 parquet episodes
+        info_path.write_text(json.dumps(meta))
+
+        result = sim.verify_dataset_episodes(expected=2)
+        assert result["status"] == "error", "parquet matches expected but info.json disagrees"
+        vj = _json_block(result)
+        assert vj["actual"] == 2
+        assert vj["info_total_episodes"] == 99
+        assert vj["sources_agree"] is False
+
+    def test_verify_treats_parquet_as_sole_truth_when_info_json_absent(self, sim, tmp_path):
+        """Missing info.json -> parquet is the sole truth; verify still passes."""
+        root = tmp_path / "noinfo"
+        _record(sim, str(root), n_episodes=2, n_steps=3)
+        (root / "meta" / "info.json").unlink()
+
+        result = sim.verify_dataset_episodes(expected=2)
+        assert result["status"] == "success"
+        vj = _json_block(result)
+        assert vj["info_total_episodes"] is None
+        assert vj["sources_agree"] is True


### PR DESCRIPTION
## Problem

`SimEngine.verify_dataset_episodes(expected)` is the definitive, post-`stop_recording` check that a collection run produced N distinct episodes rather than one merged `episode_index=0` mega-episode. It read **only** the parquet episode count, however, so it trusted a single metadata source.

A LeRobot v3 dataset carries the episode count in two independent places that must agree:
- the distinct `episode_index` set in `meta/episodes/**/*.parquet` (the ground truth), and
- the `total_episodes` header in `meta/info.json`.

When these disagree — e.g. an interrupted `finalize` that flushed the parquet but left a stale `info.json`, or vice versa — the dataset is internally inconsistent, yet a parquet-only check passes it as long as the parquet happens to match `expected`. That is exactly the failure mode `verify_dataset_episodes` exists to catch loudly, so a one-source check is insufficient.

## Change

Cross-check both metadata sources and require them to agree:

- `read_dataset_episode_indices(root)` now also reads `meta/info.json` and returns `info_total_episodes` (`None` when the file is absent or unreadable — the parquet remains the ground truth and is still reported; pure-pyarrow, still no `LeRobotDataset` instantiation).
- `verify_dataset_episodes(expected)` adds `info_total_episodes` and `sources_agree` to its `{"json": {...}}` block. `status` is now `"error"` when the parquet count differs from `expected` **OR** when the parquet disagrees with `info.json` (`sources_agree=False`) — a dataset that matches `expected` on one source but not the other still fails. When `info.json` is absent, the parquet is treated as the sole truth and the check behaves as before.

No behavior change for healthy datasets: a normal `start_recording -> run_policy(n_episodes=N) -> stop_recording` writes a consistent `info.json`+parquet, so `sources_agree=True` and existing callers are unaffected.

## Tests

New `TestInfoParquetCrossCheck` in `tests/simulation/test_run_policy_episode_contract.py`:
- `read_dataset_episode_indices` reports `info_total_episodes` on a healthy dataset.
- healthy dataset -> `sources_agree=True`, `status=success`.
- **regression (fails pre-change):** record 2 episodes, corrupt `meta/info.json` `total_episodes` to 99, then `verify_dataset_episodes(expected=2)` — the parquet matches `expected` so a parquet-only check passes, but the cross-check now returns `status=error` / `sources_agree=False`.
- absent `info.json` -> parquet-only, `status=success`.

Confirmed the corrupt-info.json regression test fails on the pre-change code (`assert 'success' == 'error'`) and passes after. Full `tests/simulation/test_run_policy_episode_contract.py` (15) + recording/dataset suites (54 passed, 2 skipped) green; lint+mypy clean over `strands_robots tests tests_integ`.

## Docs

`docs/recording.md` gains a "Verifying episode count" section documenting the two-source contract: never trust agent narration for dataset structure — verify the parquet AND `info.json`, and they must agree.