### PR TITLE
feat(datasets): strands-robots verify-dataset CLI for episode-count integrity

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,26 @@ for frame in reader:
 `start_recording`/`stop_recording`. For full training, the upstream trainer uses
 the same engine — `python -m lerobot.scripts.train dataset.repo_id=... dataset.streaming=true`.
 
+**Verify episode integrity.** A recording's ground truth is the parquet under
+`meta/episodes/`, not the count a model narrates while collecting. Collect
+episodes with a deterministic Python loop (one `run_policy(..., n_episodes=1)`
+plus `save_episode()` per episode) rather than trusting a model to count its own
+tool calls, then confirm the dataset holds the episodes you intended - in-process
+or from the shell:
+
+```python
+sim.verify_dataset_episodes(expected=20)   # reads parquet; status="error" on a mega-episode
+```
+
+```bash
+# exit 0 = pass, 1 = fail, so it drops straight into CI as a dataset gate
+strands-robots verify-dataset /tmp/demo --expected 20
+```
+
+This catches the "mega-episode" corruption class - a run that buffered every
+frame into one `episode_index=0` episode while reporting `20/20` - plus
+`meta/info.json` vs parquet drift and zero-length episodes.
+
 **Dump to a Storage Bucket** during collection (mutable, Xet-deduplicated — the
 Phase 1/2 collection target that avoids git-LFS history bloat) with one kwarg:
 

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -111,6 +111,23 @@ happens to match `expected` on one source but not the other still fails. The
 gating. The pure-pyarrow `read_dataset_episode_indices(root)` exposes the same
 facts without instantiating a `LeRobotDataset`.
 
+The same check runs from the shell against any LeRobot dataset on disk, with an
+exit code suitable for CI:
+
+```bash
+strands-robots verify-dataset /path/to/dataset --expected 20   # exit 0 pass, 1 fail
+strands-robots verify-dataset /path/to/dataset --json          # machine-readable report
+```
+
+`verify-dataset` reuses the same pure-pyarrow `read_dataset_episode_indices`
+helper (no `lerobot` import) and flags three failure modes: the mega-episode
+(fewer distinct episodes than `--expected`), `meta/info.json` `total_episodes` /
+`total_frames` drifting from the parquet ground truth (caught even without
+`--expected`), and any episode below `--min-frames` (default 1). The
+programmatic form is
+`strands_robots.verify_dataset.verify_dataset(root, expected=None, min_frames=1)`,
+which returns the same report dict.
+
 ## Recording paths
 
 | Method | Extra needed | Output |

--- a/strands_robots/__main__.py
+++ b/strands_robots/__main__.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import sys
 
+_COMMANDS = ("doctor", "verify-dataset")
+
 
 def main() -> None:
     if len(sys.argv) < 2:
         print("Usage: python -m strands_robots <command>")
-        print("Commands: doctor")
+        print(f"Commands: {', '.join(_COMMANDS)}")
         sys.exit(1)
 
     cmd = sys.argv[1]
@@ -19,9 +21,13 @@ def main() -> None:
         from strands_robots.doctor import main as doctor_main
 
         doctor_main()
+    elif cmd == "verify-dataset":
+        from strands_robots.verify_dataset import main as verify_main
+
+        sys.exit(verify_main())
     else:
         print(f"Unknown command: {cmd}")
-        print("Available commands: doctor")
+        print(f"Available commands: {', '.join(_COMMANDS)}")
         sys.exit(1)
 
 

--- a/strands_robots/verify_dataset.py
+++ b/strands_robots/verify_dataset.py
@@ -1,0 +1,211 @@
+"""``strands-robots verify-dataset`` - validate a recorded LeRobot dataset.
+
+Detects the "mega-episode" corruption class: a collection run that intended to
+record N distinct episodes but instead buffered every frame into a single
+``episode_index=0`` episode (or whose ``meta/info.json`` count drifted from the
+on-disk parquet). The parquet under ``meta/episodes/**/*.parquet`` is the ground
+truth; this never trusts an agent's narration ("recorded 20/20") or in-memory
+recorder bookkeeping.
+
+Checks performed against a dataset root (the dir containing ``meta/``):
+  1. parquet exists and holds at least one distinct episode;
+  2. every episode has at least ``--min-frames`` frames (default 1) - flags any
+     zero-length episode;
+  3. ``meta/info.json`` ``total_episodes`` / ``total_frames`` (when present)
+     agree with the parquet ground truth - flags metadata/parquet drift;
+  4. when ``--expected N`` is given, the parquet holds exactly N episodes -
+     flags the "wanted N, got M" mismatch.
+
+Usage:
+    strands-robots verify-dataset /path/to/dataset
+    strands-robots verify-dataset /path/to/dataset --expected 20
+    python -m strands_robots verify-dataset ~/.cache/huggingface/lerobot/user/ds
+
+Exit code is 0 when every check passes, 1 otherwise - so it drops straight into
+CI as a dataset-integrity gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def verify_dataset(
+    root: str | Path,
+    expected: int | None = None,
+    min_frames: int = 1,
+) -> dict[str, Any]:
+    """Verify the episode integrity of a LeRobot dataset on disk.
+
+    Reads the canonical ``meta/episodes/**/*.parquet`` (via
+    :func:`strands_robots.dataset_recorder.read_dataset_episode_indices`) and,
+    when present, ``meta/info.json``, then runs the integrity checks described
+    in the module docstring.
+
+    Args:
+        root: Dataset root directory (the dir that contains ``meta/``).
+        expected: If given, require exactly this many distinct episodes.
+        min_frames: Minimum frames every episode must contain (default 1).
+
+    Returns:
+        A report dict with:
+          - ``status``: ``"success"`` if every check passed, else ``"error"``.
+          - ``ok``: bool mirror of ``status``.
+          - ``root``: the resolved dataset root as a string.
+          - ``total_episodes`` / ``total_frames`` / ``episode_indices`` /
+            ``frames_per_episode``: parquet ground truth (zeros/empties when the
+            dataset is empty or unreadable).
+          - ``expected``: the requested count (or ``None``).
+          - ``info_total_episodes`` / ``info_total_frames``: values declared in
+            ``meta/info.json`` (``None`` when the file is absent or lacks them).
+          - ``problems``: list of human-readable failure strings (empty on pass).
+    """
+    from strands_robots.dataset_recorder import read_dataset_episode_indices
+
+    root_path = Path(root)
+    report: dict[str, Any] = {
+        "status": "error",
+        "ok": False,
+        "root": str(root_path),
+        "total_episodes": 0,
+        "total_frames": 0,
+        "episode_indices": [],
+        "frames_per_episode": [],
+        "expected": expected,
+        "info_total_episodes": None,
+        "info_total_frames": None,
+        "problems": [],
+    }
+    problems: list[str] = report["problems"]
+
+    if expected is not None and (not isinstance(expected, int) or expected < 0):
+        problems.append(f"expected must be a non-negative int, got {expected!r}")
+        return report
+
+    # Parquet ground truth.
+    try:
+        info = read_dataset_episode_indices(root_path)
+    except FileNotFoundError as e:
+        problems.append(str(e))
+        return report
+    except ImportError as e:
+        problems.append(str(e))
+        return report
+
+    report["total_episodes"] = info["total_episodes"]
+    report["total_frames"] = info["total_frames"]
+    report["episode_indices"] = info["episode_indices"]
+    report["frames_per_episode"] = info["frames_per_episode"]
+
+    # Check 1: non-empty.
+    if info["total_episodes"] == 0:
+        problems.append("no episodes found in parquet (dataset is empty)")
+
+    # Check 2: every episode has >= min_frames frames. Only when per-episode
+    # lengths are available (the length column is optional in some writers).
+    if min_frames > 0 and info["frames_per_episode"]:
+        short = [
+            (ep, n)
+            for ep, n in zip(info["episode_indices"], info["frames_per_episode"], strict=False)
+            if n < min_frames
+        ]
+        if short:
+            detail = ", ".join(f"episode {ep}={n} frame(s)" for ep, n in short)
+            problems.append(f"{len(short)} episode(s) below min_frames={min_frames}: {detail}")
+
+    # Check 3: meta/info.json vs parquet ground truth (drift detection).
+    info_json_path = root_path / "meta" / "info.json"
+    if info_json_path.is_file():
+        try:
+            declared = json.loads(info_json_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as e:
+            problems.append(f"could not read meta/info.json: {e}")
+            declared = {}
+        decl_eps = declared.get("total_episodes")
+        decl_frames = declared.get("total_frames")
+        report["info_total_episodes"] = decl_eps
+        report["info_total_frames"] = decl_frames
+        if isinstance(decl_eps, int) and decl_eps != info["total_episodes"]:
+            problems.append(
+                f"meta/info.json total_episodes={decl_eps} disagrees with parquet "
+                f"({info['total_episodes']} distinct episode(s)) - metadata/parquet drift"
+            )
+        # Frame totals only meaningful when parquet carries per-episode lengths.
+        if isinstance(decl_frames, int) and info["total_frames"] and decl_frames != info["total_frames"]:
+            problems.append(
+                f"meta/info.json total_frames={decl_frames} disagrees with parquet ({info['total_frames']} frame(s))"
+            )
+
+    # Check 4: exact expected episode count.
+    if expected is not None and info["total_episodes"] != expected:
+        problems.append(
+            f"expected {expected} episode(s) but parquet holds {info['total_episodes']} "
+            "- the recording did not produce the intended number of distinct episodes"
+        )
+
+    report["ok"] = not problems
+    report["status"] = "success" if report["ok"] else "error"
+    return report
+
+
+def _format_report(report: dict[str, Any]) -> str:
+    """Render a report dict as a human-readable multi-line summary."""
+    lines: list[str] = []
+    verdict = "PASS" if report["ok"] else "FAIL"
+    lines.append(f"[{verdict}] {report['root']}")
+    lines.append(f"  episodes (parquet): {report['total_episodes']}")
+    if report["total_frames"]:
+        lines.append(f"  frames   (parquet): {report['total_frames']}")
+    if report["expected"] is not None:
+        lines.append(f"  expected episodes : {report['expected']}")
+    if report["info_total_episodes"] is not None:
+        lines.append(f"  info.json episodes: {report['info_total_episodes']}")
+    for problem in report["problems"]:
+        lines.append(f"  - {problem}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Returns 0 on success, 1 on any failed check."""
+    parser = argparse.ArgumentParser(
+        prog="strands-robots verify-dataset",
+        description="Validate the episode integrity of a recorded LeRobot dataset.",
+    )
+    parser.add_argument("root", help="Dataset root directory (the dir that contains meta/).")
+    parser.add_argument(
+        "-e",
+        "--expected",
+        type=int,
+        default=None,
+        help="Require exactly this many distinct episodes (the count you intended to record).",
+    )
+    parser.add_argument(
+        "--min-frames",
+        type=int,
+        default=1,
+        help="Minimum frames every episode must contain (default: 1).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the report as JSON instead of the human-readable summary.",
+    )
+    args = parser.parse_args(argv)
+
+    report = verify_dataset(args.root, expected=args.expected, min_frames=args.min_frames)
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print(_format_report(report))
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -73,3 +73,22 @@ class TestMainDispatch:
         main()
 
         assert seen_argv == [["strands_robots", "--verbose", "extra"]]
+
+    def test_verify_dataset_command_dispatches_and_propagates_exit_code(self, monkeypatch) -> None:
+        """``verify-dataset`` should call verify_dataset.main() and exit with its code."""
+        seen_argv: list[list[str]] = []
+
+        def fake_verify_main() -> int:
+            import sys
+
+            seen_argv.append(list(sys.argv))
+            return 1
+
+        monkeypatch.setattr("strands_robots.verify_dataset.main", fake_verify_main)
+        monkeypatch.setattr("sys.argv", ["strands_robots", "verify-dataset", "/data/ds", "--expected", "20"])
+
+        with pytest.raises(SystemExit) as exc:
+            main()
+
+        assert exc.value.code == 1
+        assert seen_argv == [["strands_robots", "/data/ds", "--expected", "20"]]

--- a/tests/test_verify_dataset.py
+++ b/tests/test_verify_dataset.py
@@ -1,0 +1,148 @@
+"""Episode-integrity verification for recorded LeRobot datasets.
+
+Pins the contract of ``strands_robots.verify_dataset`` - the dataset-integrity
+gate that detects the "mega-episode" corruption class (a run that intended N
+episodes but buffered everything into one ``episode_index=0`` episode) and
+``meta/info.json`` vs parquet drift.
+
+Fixtures are built with pyarrow directly so the tests need neither lerobot nor
+mujoco: they write the canonical ``meta/episodes/**/*.parquet`` (and optional
+``meta/info.json``) that :func:`read_dataset_episode_indices` reads as ground
+truth. Each test asserts observable behaviour - the report's ``status`` /
+``problems`` and the CLI exit code - not internal state.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pyarrow")
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from strands_robots.verify_dataset import main as verify_main
+from strands_robots.verify_dataset import verify_dataset
+
+
+def _write_dataset(
+    root: Path,
+    episode_indices: list[int],
+    frames_per_episode: list[int] | None = None,
+    info: dict | None = None,
+) -> Path:
+    """Write a minimal LeRobot v3 dataset (episodes parquet + optional info.json).
+
+    Args:
+        root: Dataset root (the dir that will contain ``meta/``).
+        episode_indices: Distinct ``episode_index`` values to write.
+        frames_per_episode: Per-episode ``length`` column (omitted if None).
+        info: Optional ``meta/info.json`` payload.
+
+    Returns:
+        The dataset root path.
+    """
+    ep_dir = root / "meta" / "episodes" / "chunk-000"
+    ep_dir.mkdir(parents=True, exist_ok=True)
+    columns: dict[str, list] = {"episode_index": episode_indices}
+    if frames_per_episode is not None:
+        columns["length"] = frames_per_episode
+    pq.write_table(pa.table(columns), ep_dir / "episodes_000.parquet")
+    if info is not None:
+        (root / "meta" / "info.json").write_text(json.dumps(info), encoding="utf-8")
+    return root
+
+
+class TestVerifyDatasetHealthy:
+    """A well-formed multi-episode dataset passes every check."""
+
+    def test_three_episodes_with_matching_info_passes(self, tmp_path: Path) -> None:
+        _write_dataset(
+            tmp_path,
+            episode_indices=[0, 1, 2],
+            frames_per_episode=[3, 3, 3],
+            info={"total_episodes": 3, "total_frames": 9},
+        )
+        report = verify_dataset(tmp_path)
+        assert report["status"] == "success"
+        assert report["ok"] is True
+        assert report["problems"] == []
+        assert report["total_episodes"] == 3
+        assert report["total_frames"] == 9
+
+    def test_expected_count_match_passes(self, tmp_path: Path) -> None:
+        _write_dataset(tmp_path, episode_indices=[0, 1, 2], frames_per_episode=[5, 5, 5])
+        report = verify_dataset(tmp_path, expected=3)
+        assert report["status"] == "success"
+
+
+class TestMegaEpisodeCorruption:
+    """The headline bug: one merged episode where N were intended."""
+
+    def test_single_episode_against_expected_20_fails(self, tmp_path: Path) -> None:
+        _write_dataset(tmp_path, episode_indices=[0], frames_per_episode=[60])
+        report = verify_dataset(tmp_path, expected=20)
+        assert report["status"] == "error"
+        assert report["total_episodes"] == 1
+        assert any("expected 20" in p and "holds 1" in p for p in report["problems"])
+
+    def test_info_json_claims_20_but_parquet_has_1_fails(self, tmp_path: Path) -> None:
+        # No --expected supplied: the metadata/parquet drift alone is the signal.
+        _write_dataset(
+            tmp_path,
+            episode_indices=[0],
+            frames_per_episode=[60],
+            info={"total_episodes": 20, "total_frames": 60},
+        )
+        report = verify_dataset(tmp_path)
+        assert report["status"] == "error"
+        assert any("info.json total_episodes=20" in p for p in report["problems"])
+
+
+class TestEdgeCases:
+    """Empty datasets, zero-length episodes, and bad arguments."""
+
+    def test_missing_dataset_reports_filenotfound(self, tmp_path: Path) -> None:
+        report = verify_dataset(tmp_path / "does_not_exist")
+        assert report["status"] == "error"
+        assert report["total_episodes"] == 0
+        assert report["problems"]
+
+    def test_zero_length_episode_flagged(self, tmp_path: Path) -> None:
+        _write_dataset(tmp_path, episode_indices=[0, 1], frames_per_episode=[5, 0])
+        report = verify_dataset(tmp_path, min_frames=1)
+        assert report["status"] == "error"
+        assert any("min_frames" in p for p in report["problems"])
+
+    def test_negative_expected_rejected(self, tmp_path: Path) -> None:
+        _write_dataset(tmp_path, episode_indices=[0], frames_per_episode=[3])
+        report = verify_dataset(tmp_path, expected=-1)
+        assert report["status"] == "error"
+        assert any("non-negative int" in p for p in report["problems"])
+
+
+class TestCLI:
+    """The ``verify-dataset`` CLI maps pass/fail to exit codes 0/1."""
+
+    def test_cli_exit_zero_on_healthy(self, tmp_path: Path, capsys) -> None:
+        _write_dataset(tmp_path, episode_indices=[0, 1], frames_per_episode=[4, 4])
+        rc = verify_main([str(tmp_path)])
+        assert rc == 0
+        assert "PASS" in capsys.readouterr().out
+
+    def test_cli_exit_one_on_mismatch(self, tmp_path: Path, capsys) -> None:
+        _write_dataset(tmp_path, episode_indices=[0], frames_per_episode=[60])
+        rc = verify_main([str(tmp_path), "--expected", "20"])
+        assert rc == 1
+        assert "FAIL" in capsys.readouterr().out
+
+    def test_cli_json_output_parses(self, tmp_path: Path, capsys) -> None:
+        _write_dataset(tmp_path, episode_indices=[0, 1, 2], frames_per_episode=[3, 3, 3])
+        rc = verify_main([str(tmp_path), "--json"])
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["total_episodes"] == 3
+        assert payload["ok"] is True


### PR DESCRIPTION
## Problem

The ground truth for how many episodes a recording session produced is the parquet under `meta/episodes/`, not the count a caller believes it recorded. A session that buffers every frame into a single `episode_index=0` episode while reporting "20/20" silently produces a corrupt single-mega-episode dataset. The library already exposes `SimEngine.verify_dataset_episodes(expected)` and the pure-pyarrow `read_dataset_episode_indices` helper for the in-process check, but there was no way to validate an arbitrary dataset on disk from the shell or wire that check into CI.

## Change

Add a `verify-dataset` CLI (and a `strands_robots.verify_dataset.verify_dataset(root, expected=None, min_frames=1)` function) that reads the parquet ground truth and returns a CI-friendly exit code (0 pass, 1 fail):

```bash
strands-robots verify-dataset /path/to/dataset --expected 20   # exit 1 on a mega-episode
strands-robots verify-dataset /path/to/dataset --json          # machine-readable report
```

It reuses the existing `read_dataset_episode_indices` helper (no `lerobot` import) and flags three failure modes:

1. **mega-episode** - fewer distinct episodes than `--expected`;
2. **metadata drift** - `meta/info.json` `total_episodes` / `total_frames` disagreeing with the parquet ground truth (caught even without `--expected`);
3. **zero-length episodes** - any episode below `--min-frames` (default 1).

Example output on a single-episode dataset whose `info.json` claims 20:

```
[FAIL] /tmp/ds
  episodes (parquet): 1
  frames   (parquet): 60
  expected episodes : 20
  info.json episodes: 20
  - meta/info.json total_episodes=20 disagrees with parquet (1 distinct episode(s)) - metadata/parquet drift
  - expected 20 episode(s) but parquet holds 1 - the recording did not produce the intended number of distinct episodes
```

## Surface

- `strands_robots/verify_dataset.py` - `verify_dataset()` + argparse CLI (`--expected`, `--min-frames`, `--json`).
- `strands_robots/__main__.py` - wire the `verify-dataset` subcommand; exit code propagated via `sys.exit`.
- `tests/test_verify_dataset.py` - healthy / mega-episode / info-drift / zero-length / empty / bad-arg cases plus CLI exit codes and JSON output. Fixtures are built with pyarrow directly, so the tests need neither `lerobot` nor `mujoco`.
- `tests/test_main_cli.py` - dispatch + exit-code-propagation test for the new subcommand.
- Docs: README "Recording & streaming datasets" and `docs/recording.md` gain a "Verify episode integrity" note pointing collectors at a deterministic per-episode loop and the verification CLI.

## Tests

`ruff check` / `ruff format --check` / `mypy` clean on `strands_robots tests tests_integ`. Targeted run green:

```
tests/test_verify_dataset.py tests/test_main_cli.py tests/test_dataset_recorder.py
tests/simulation/test_run_policy_episode_contract.py  ->  80 passed
```