### PR TITLE
feat(simulation): scope recorded cameras via start_recording(cameras=...)

### DIFF
--- a/docs/recording.md
+++ b/docs/recording.md
@@ -17,6 +17,33 @@ sim.stop_recording()
 
 `start_recording` requires `[lerobot]`. Without it, use `start_cameras_recording` for plain MP4.
 
+## Selecting which cameras to record
+
+By default every camera in the scene is recorded into the dataset - including
+the implicit `default` free camera that exists even before you call
+`add_camera`. A policy that declares a fixed set of image features (e.g. SmolVLA
+expects exactly `observation.images.camera1/camera2/camera3`) then trains
+against a dataset that carries a stray `observation.images.default` view it
+never asked for, and the extra MP4 stream bloats every episode.
+
+Pass `cameras=` to record exactly the views the policy expects:
+
+```python
+sim.add_camera(name="camera1", ...)
+sim.add_camera(name="camera2", ...)
+sim.add_camera(name="camera3", ...)
+sim.start_recording(
+    repo_id="user/my_dataset", task="pick up the cube", fps=30,
+    cameras=["camera1", "camera2", "camera3"],   # drops the implicit 'default'
+)
+```
+
+The dataset schema then declares only those three image features. Names may be
+given in raw MuJoCo form (`arm0/wrist_cam`) or schema-safe form
+(`arm0__wrist_cam`); an unknown name fails loudly and lists the available
+cameras rather than silently recording the wrong set. Omit `cameras=` to keep
+the legacy behavior of recording every camera.
+
 ## Multi-episode recording
 
 A recording session is one dataset. The simplest way to collect N episodes in

--- a/strands_robots/simulation/mujoco/recording.py
+++ b/strands_robots/simulation/mujoco/recording.py
@@ -53,6 +53,7 @@ class RecordingMixin(DatasetRecordingMixin):
         push_to_hub: bool = False,
         vcodec: str = "libsvtav1",
         overwrite: bool = False,
+        cameras: list[str] | None = None,
     ) -> dict[str, Any]:
         """Start recording to LeRobotDataset format (parquet + per-camera MP4).
 
@@ -60,6 +61,16 @@ class RecordingMixin(DatasetRecordingMixin):
         need plain MP4 video (no dataset schema, no policy-training metadata),
         use :meth:`start_cameras_recording` - it runs under the
         ``[sim-mujoco]`` extra alone (imageio-ffmpeg backend).
+
+        Args:
+            cameras: Camera names to record into the dataset. When ``None``
+                (default) every scene camera is recorded - which includes the
+                implicit ``default`` free camera. Pass an explicit subset to
+                record exactly the views a policy declares (e.g.
+                ``cameras=["camera1", "camera2", "camera3"]`` for a 3-camera
+                SmolVLA dataset) and keep the stray ``default`` view out of the
+                schema. Names may be raw (``arm0/wrist_cam``) or schema-safe
+                (``arm0__wrist_cam``); an unknown name fails loudly.
 
         Raises:
             Friendly error when ``lerobot`` is not installed, directing the
@@ -152,6 +163,10 @@ class RecordingMixin(DatasetRecordingMixin):
             # recording, abort the whole episode. We map each safe camera name
             # to its real (height, width) so _build_features sizes it correctly.
             camera_dims: dict[str, tuple[int, int]] = {}
+            # Raw MuJoCo camera name -> schema-safe name. Kept so the run_policy
+            # frame hook can map a caller-requested ``cameras`` subset (which may
+            # use either form) back to the RAW observation key it must keep.
+            raw_to_safe: dict[str, str] = {}
             for i in range(self._world._model.ncam):
                 cam_name = mj.mj_id2name(self._world._model, mj.mjtObj.mjOBJ_CAMERA, i)
                 if not cam_name:
@@ -161,12 +176,60 @@ class RecordingMixin(DatasetRecordingMixin):
                 # namespaced camera (e.g. ``arm0/wrist_cam``), collapse
                 # the separator to ``__`` for the dataset schema.
                 safe_name = cam_name.replace("/", "__")
+                raw_to_safe[cam_name] = safe_name
                 camera_keys.append(safe_name)
                 cam_info = self._world.cameras.get(cam_name) or self._world.cameras.get(safe_name)
                 if cam_info is not None:
                     camera_dims[safe_name] = (int(cam_info.height), int(cam_info.width))
                 else:
                     camera_dims[safe_name] = (int(self.default_height), int(self.default_width))
+
+            # Optional camera scoping. By default EVERY scene camera is recorded,
+            # which silently includes the implicit ``default`` free camera and any
+            # view the trained policy never declared - bloating the dataset and
+            # producing image features that do not match the policy's
+            # ``input_features``. When ``cameras`` is given, record exactly that
+            # subset. Names may be given in either the raw MuJoCo form
+            # (``arm0/wrist_cam``) or the schema-safe form (``arm0__wrist_cam``);
+            # an unknown name fails loudly (no silent drop) listing what exists.
+            record_raw_cameras: set[str] | None = None
+            if cameras is not None:
+                safe_to_raw = {safe: raw for raw, safe in raw_to_safe.items()}
+                selected_safe: list[str] = []
+                record_raw_cameras = set()
+                unknown: list[str] = []
+                for requested in cameras:
+                    if requested in raw_to_safe:  # raw name
+                        raw, safe = requested, raw_to_safe[requested]
+                    elif requested in safe_to_raw:  # already schema-safe
+                        raw, safe = safe_to_raw[requested], requested
+                    else:
+                        unknown.append(requested)
+                        continue
+                    if safe not in selected_safe:
+                        selected_safe.append(safe)
+                        record_raw_cameras.add(raw)
+                if unknown:
+                    self._world._backend_state["recording"] = False
+                    available = sorted(raw_to_safe)
+                    return {
+                        "status": "error",
+                        "content": [
+                            {
+                                "text": (
+                                    f"start_recording: unknown camera(s) {unknown} in cameras=. "
+                                    f"Available scene cameras: {available}. Add them with "
+                                    "add_camera(...) before recording, or omit cameras= to "
+                                    "record all of them."
+                                )
+                            }
+                        ],
+                    }
+                camera_keys = selected_safe
+                camera_dims = {safe: camera_dims[safe] for safe in selected_safe}
+            # Stash the scoped RAW camera names so the run_policy frame hook drops
+            # un-recorded camera arrays before add_frame (None -> record all).
+            self._world._backend_state["recording_cameras"] = record_raw_cameras
 
             assert _DatasetRecorder is not None  # checked above
             if resume_existing:

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -100,6 +100,33 @@ logger = logging.getLogger(__name__)
 # learns the string from one action recognises it from all of them.
 _NO_WORLD_MSG = "No world. Call create_world (or load_scene) first."
 
+
+def _drop_unrecorded_cameras(observation: dict[str, Any], recorded: set[str] | None) -> dict[str, Any]:
+    """Filter an observation down to the cameras the caller chose to record.
+
+    Drops image arrays (ndarray with ``ndim >= 2``) whose key is not in
+    ``recorded`` so the recorded frame matches a schema scoped via
+    ``start_recording(cameras=...)``. Scalar state values (joint positions /
+    velocities) and 1-D arrays are always kept.
+
+    Args:
+        observation: Raw observation dict (camera_name -> image, joint -> float).
+        recorded: Set of camera keys to keep, or ``None`` to record every
+            camera (the legacy default - the dict is returned unchanged).
+
+    Returns:
+        The observation unchanged when ``recorded`` is ``None``; otherwise a new
+        dict without the excluded camera arrays.
+    """
+    if recorded is None:
+        return observation
+    import numpy as np
+
+    return {
+        k: v for k, v in observation.items() if not (isinstance(v, np.ndarray) and v.ndim >= 2 and k not in recorded)
+    }
+
+
 _TOOL_SPEC_PATH = Path(__file__).parent / "tool_spec.json"
 
 # Tool schema is 357 lines of JSON. `tool_spec` property is on the LLM hot path
@@ -2255,6 +2282,12 @@ class MuJoCoSimEngine(
                     )
                     rec = world._backend_state.get("dataset_recorder")
                     if rec is not None:
+                        # Honor the start_recording(cameras=...) scope: drop image
+                        # arrays for cameras the caller chose not to record so the
+                        # frame matches the (already scoped) dataset schema. None
+                        # means record every camera (legacy default).
+                        rec_cams = world._backend_state.get("recording_cameras")
+                        observation = _drop_unrecorded_cameras(observation, rec_cams)
                         # In multi-robot scenes start_recording() declares
                         # the dataset schema with per-robot-prefixed joint ids
                         # (``alice__shoulder_pan``) so each agent has unique state/
@@ -2612,8 +2645,10 @@ class MuJoCoSimEngine(
                             merged_obs.update(per_robot_obs[rname])
                             merged_act.update(per_robot_action[rname])
                     # Cameras are scene-global (already namespaced if injected
-                    # per-robot); keep ndarray keys as-is.
-                    merged_obs.update(camera_imgs)
+                    # per-robot); keep ndarray keys as-is, minus any the caller
+                    # excluded via start_recording(cameras=...).
+                    rec_cams = self._world._backend_state.get("recording_cameras")
+                    merged_obs.update(_drop_unrecorded_cameras(camera_imgs, rec_cams))
                     task = instr_map[next(iter(policies))]
                     # add_frame writes to LeRobot's image-writer queue and parquet
                     # buffer; it does not touch MuJoCo model/data. The consistent

--- a/tests/simulation/mujoco/test_recording_camera_scoping.py
+++ b/tests/simulation/mujoco/test_recording_camera_scoping.py
@@ -1,0 +1,149 @@
+"""Regression tests for ``start_recording(cameras=...)`` camera scoping.
+
+By default every scene camera is recorded into the LeRobotDataset, which
+silently includes the implicit ``default`` free camera and any view the trained
+policy never declared. ``cameras=`` lets a caller record exactly the views the
+policy expects (e.g. the three SmolVLA cameras) so the dataset schema matches
+the policy's ``input_features`` and is not bloated by stray cameras.
+
+Covers:
+* default (``cameras=None``) records every camera including ``default``;
+* ``cameras=[subset]`` declares exactly that subset in the dataset schema;
+* an unknown camera name fails loudly (no silent drop);
+* the ``_drop_unrecorded_cameras`` frame filter keeps state, drops excluded
+  cameras, and is a no-op when nothing is scoped.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+import numpy as np
+import pytest
+
+pytest.importorskip("mujoco")
+pytest.importorskip("lerobot")
+
+os.environ.setdefault("MUJOCO_GL", "egl")
+
+_ROBOT_XML = """
+<mujoco model="test_arm">
+  <compiler angle="radian" autolimits="true"/>
+  <option timestep="0.002"/>
+  <worldbody>
+    <light name="main" pos="0 0 3" dir="0 0 -1"/>
+    <geom name="ground" type="plane" size="5 5 0.01" rgba="0.9 0.9 0.9 1"/>
+    <body name="base" pos="0 0 0.1">
+      <geom type="cylinder" size="0.05 0.05" rgba="0.3 0.3 0.8 1"/>
+      <joint name="shoulder_pan" type="hinge" axis="0 0 1" range="-3.14 3.14"/>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="shoulder_pan_act" joint="shoulder_pan" kp="50"/>
+  </actuator>
+</mujoco>
+"""
+
+
+@pytest.fixture
+def sim_with_cameras():
+    from strands_robots.simulation import Simulation
+
+    tmpdir = tempfile.mkdtemp()
+    path = os.path.join(tmpdir, "test_arm.xml")
+    with open(path, "w") as f:
+        f.write(_ROBOT_XML)
+
+    s = Simulation()
+    s.create_world()
+    s.add_robot("arm", urdf_path=path)
+    s.add_camera(name="cam_a", position=[0.5, 0.0, 0.3], target=[0.0, 0.0, 0.1], width=64, height=64)
+    s.add_camera(name="cam_b", position=[0.0, 0.0, 0.7], target=[0.0, 0.0, 0.0], width=64, height=64)
+    yield s
+    s.destroy()
+
+
+def _recorder_image_features(sim) -> set[str]:
+    rec = sim._world._backend_state["dataset_recorder"]
+    feats = rec.dataset.features
+    return {k for k in feats if k.startswith("observation.images.")}
+
+
+def test_default_records_every_camera_including_default(sim_with_cameras, tmp_path):
+    sim = sim_with_cameras
+    res = sim.start_recording(repo_id="local/scope_all", root=str(tmp_path / "all"), overwrite=True)
+    assert res["status"] == "success"
+    img = _recorder_image_features(sim)
+    assert img == {
+        "observation.images.default",
+        "observation.images.cam_a",
+        "observation.images.cam_b",
+    }
+    assert sim._world._backend_state["recording_cameras"] is None
+
+
+def test_cameras_subset_scopes_dataset_schema(sim_with_cameras, tmp_path):
+    sim = sim_with_cameras
+    res = sim.start_recording(
+        repo_id="local/scope_subset",
+        root=str(tmp_path / "subset"),
+        cameras=["cam_a", "cam_b"],
+        overwrite=True,
+    )
+    assert res["status"] == "success"
+    # The stray implicit ``default`` camera must NOT be in the schema.
+    assert _recorder_image_features(sim) == {
+        "observation.images.cam_a",
+        "observation.images.cam_b",
+    }
+    assert sim._world._backend_state["recording_cameras"] == {"cam_a", "cam_b"}
+
+
+def test_cameras_single_camera(sim_with_cameras, tmp_path):
+    sim = sim_with_cameras
+    res = sim.start_recording(
+        repo_id="local/scope_one",
+        root=str(tmp_path / "one"),
+        cameras=["cam_a"],
+        overwrite=True,
+    )
+    assert res["status"] == "success"
+    assert _recorder_image_features(sim) == {"observation.images.cam_a"}
+
+
+def test_unknown_camera_fails_loudly(sim_with_cameras, tmp_path):
+    sim = sim_with_cameras
+    res = sim.start_recording(
+        repo_id="local/scope_bad",
+        root=str(tmp_path / "bad"),
+        cameras=["cam_a", "nope"],
+        overwrite=True,
+    )
+    assert res["status"] == "error"
+    text = res["content"][0]["text"]
+    assert "nope" in text
+    assert "cam_a" in text  # available cameras are listed
+    # A failed start must not leave the engine half-armed.
+    assert sim._world._backend_state.get("recording") is False
+
+
+def test_drop_unrecorded_cameras_helper():
+    from strands_robots.simulation.mujoco.simulation import _drop_unrecorded_cameras
+
+    obs = {
+        "shoulder_pan": 0.1,
+        "shoulder_pan.vel": 0.0,
+        "cam_a": np.zeros((8, 8, 3), dtype=np.uint8),
+        "cam_b": np.zeros((8, 8, 3), dtype=np.uint8),
+        "default": np.zeros((8, 8, 3), dtype=np.uint8),
+    }
+    # None -> unchanged (legacy default: record all).
+    assert _drop_unrecorded_cameras(obs, None) is obs
+
+    out = _drop_unrecorded_cameras(obs, {"cam_a"})
+    assert set(out) == {"shoulder_pan", "shoulder_pan.vel", "cam_a"}
+    # Scalars preserved, excluded cameras dropped.
+    assert out["shoulder_pan"] == 0.1
+    assert "cam_b" not in out
+    assert "default" not in out


### PR DESCRIPTION
## Problem

`Simulation.start_recording` records **every** camera in the scene into the LeRobotDataset, including the implicit `default` free camera that exists before any `add_camera` call. The recording loop builds the dataset schema by iterating all model cameras and the `run_policy` frame hook feeds `add_frame` with the full observation (no camera scoping).

The practical consequence: a policy that declares a fixed image-feature set trains against a dataset that carries views it never declared. For example SmolVLA expects exactly `observation.images.camera1/camera2/camera3`, but a sim built with those three cameras records a 4th `observation.images.default` view at the sim's default resolution. That mismatches the policy's `input_features` and bloats every episode with an extra MP4 stream. The caller has no way to control which cameras land in the dataset.

## Change

Add an optional `cameras=` argument to `start_recording` to scope the recorded views to a subset:

```python
sim.add_camera(name="camera1", ...)
sim.add_camera(name="camera2", ...)
sim.add_camera(name="camera3", ...)
sim.start_recording(repo_id="user/ds", fps=30,
                    cameras=["camera1", "camera2", "camera3"])  # drops 'default'
```

- The dataset schema declares only the requested image features.
- Names may be raw (`arm0/wrist_cam`) or schema-safe (`arm0__wrist_cam`).
- An unknown name fails loudly and lists the available cameras (no silent drop).
- Omitting `cameras=` preserves the record-all default (fully backward compatible).
- Both `run_policy` frame hooks (single-robot and multi-robot merged) drop un-recorded camera arrays via a shared `_drop_unrecorded_cameras` helper so written frames match the scoped schema.

## Visual proof

The three scoped camera streams read back from the recorded dataset (headless MuJoCo rollout). The dataset contains exactly these three views, no stray `default`:

![scoped cameras](https://github.com/cagataycali/robots/releases/download/scoped-cameras-demo/scoped_cameras.gif)

End-to-end round-trip on a 3-camera SmolVLA-style rig (`run_policy` -> `stop_recording` -> reopen with `LeRobotDataset`):

```
frames: 45 episodes: 1
image features: ['observation.images.camera1', 'observation.images.camera2', 'observation.images.camera3']
ROUND-TRIP OK: exactly 3 cameras, no stray default
```

## Tests

`tests/simulation/mujoco/test_recording_camera_scoping.py` (all fail on pre-change code, pass after):
- default (`cameras=None`) records every camera including `default`;
- `cameras=[subset]` declares exactly that subset in the dataset schema;
- single-camera scoping;
- unknown camera name returns a loud error listing available cameras and does not leave the engine half-armed;
- `_drop_unrecorded_cameras` keeps state, drops excluded cameras, and is a no-op when nothing is scoped.

Green locally: `ruff check`/`ruff format` clean, `mypy strands_robots tests` clean, and the MuJoCo recording suite (`test_recording_paths`, `test_recording_backends`, `test_stop_recording_finalize`, `test_run_multi_policy_no_recording`, `test_run_policy_episode_contract`) passes (66 passed, 1 skipped) plus the new test (5 passed).