### PR TITLE
fix(simulation): record per-step observation across action chunks

### DIFF
--- a/strands_robots/simulation/mujoco/recording.py
+++ b/strands_robots/simulation/mujoco/recording.py
@@ -62,6 +62,15 @@ class RecordingMixin(DatasetRecordingMixin):
         use :meth:`start_cameras_recording` - it runs under the
         ``[sim-mujoco]`` extra alone (imageio-ffmpeg backend).
 
+        Frame/action alignment: while this session is open, :meth:`run_policy`
+        records one ``(observation, action)`` frame per control step with the
+        observation re-sampled at that step, so each recorded image + state
+        pairs with the action actually taken from it. This holds even for
+        chunk-emitting policies (ACT, diffusion, pi0/pi0.5, SmolVLA, MolmoAct2),
+        whose open-loop action chunk drains across many steps from a single
+        ``get_actions`` call - the recorded frames advance with the robot
+        rather than freezing on the chunk-start observation.
+
         Args:
             cameras: Camera names to record into the dataset. When ``None``
                 (default) every scene camera is recorded - which includes the

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -731,6 +731,23 @@ class PolicyRunner:
         stopped_early = False
         # T26: skip camera rendering when the policy does not need images.
         _skip_images = not getattr(policy, "requires_images", True)
+        # Open-loop chunk replay consumes H actions from ONE observation. That
+        # observation is the correct PRE-action state for the FIRST action only;
+        # the sim advances as the chunk drains. When a dataset recording is
+        # active the on_frame hook writes (observation, action) per step, so
+        # re-using the chunk-start observation for every action records H
+        # identical (frozen image + frozen proprioceptive state) frames paired
+        # with H DIFFERENT actions - a temporally-misaligned behavioural-cloning
+        # dataset (the recorded image never matches the action taken from it).
+        # Detect an active recording via the engine's own contract and, when
+        # set, refresh the observation handed to on_frame per step so each
+        # recorded frame pairs the action with the state it actually acts on.
+        # Inference still consumes the chunk-start observation (correct
+        # open-loop replay); only the RECORDED frame is refreshed. The default
+        # (no recording / duck-typed sim without the hook) keeps the historical
+        # single-fetch-per-chunk behaviour, so eval/inference are unaffected.
+        _is_rec = getattr(self.sim, "_is_recording", None)
+        _record_per_step_obs = bool(_is_rec()) if callable(_is_rec) else False
         # Normalise the per-call goal payload once. Forwarded verbatim to every
         # get_actions() call; an empty dict is the historical (no-kwargs) path.
         _policy_kwargs = policy_kwargs or {}
@@ -980,7 +997,18 @@ class PolicyRunner:
                             observed_delay = max(0, len(cur_chunk) - prefetch_trigger)
                             prefetch = executor.submit(_query_chunk, prefetch_obs, observed_delay)
 
-                        _apply(cur_obs, cur_chunk[idx])
+                        # When recording, the chunk observation (the initial
+                        # query obs, or a horizon-shifted prefetch obs after a
+                        # swap) is stale for the step being applied; refresh it
+                        # so the recorded frame is time-aligned (see the
+                        # _record_per_step_obs note above). Inference is
+                        # unaffected - it already consumed cur_obs to produce
+                        # this chunk.
+                        if _record_per_step_obs:
+                            step_obs = self.sim.get_observation(robot_name=robot_name, skip_images=_skip_images)
+                        else:
+                            step_obs = cur_obs
+                        _apply(step_obs, cur_chunk[idx])
                         idx += 1
                 finally:
                     # Wait for any in-flight inference so no background thread
@@ -991,10 +1019,21 @@ class PolicyRunner:
                 while step_count < total_steps:
                     observation = self.sim.get_observation(robot_name=robot_name, skip_images=_skip_images)
                     chunk = _query_chunk(observation)
-                    for action_dict in chunk:
+                    for chunk_idx, action_dict in enumerate(chunk):
                         if step_count >= total_steps:
                             break
-                        _apply(observation, action_dict)
+                        # The chunk-start observation is the correct pre-action
+                        # state for the first action only. When recording,
+                        # refresh it before each SUBSEQUENT action so the
+                        # recorded frame is time-aligned (see the
+                        # _record_per_step_obs note above). chunk_idx == 0 reuses
+                        # the freshly-queried observation (no re-render, sim has
+                        # not stepped yet). Inference is unaffected.
+                        if _record_per_step_obs and chunk_idx > 0:
+                            step_obs = self.sim.get_observation(robot_name=robot_name, skip_images=_skip_images)
+                        else:
+                            step_obs = observation
+                        _apply(step_obs, action_dict)
 
         except CooperativeStop:
             stopped_early = True

--- a/tests/simulation/test_policy_runner_chunk_obs_alignment.py
+++ b/tests/simulation/test_policy_runner_chunk_obs_alignment.py
@@ -1,0 +1,134 @@
+"""Regression: dataset frames must stay time-aligned across an action chunk.
+
+A chunk-emitting policy returns H actions from ONE ``get_actions`` call and the
+runner replays them open-loop (re-querying only every H steps). The recording
+``on_frame`` hook writes one ``(observation, action)`` frame per step. The bug:
+the runner handed the SAME chunk-start observation to ``on_frame`` for every one
+of the H actions, so a recorded episode contained H identical frames (frozen
+image + frozen proprioceptive state) paired with H DIFFERENT actions while the
+robot visibly moved. That is temporally-misaligned behavioural-cloning data: the
+recorded observation does not match the action taken from it.
+
+This bites every chunk-emitting policy (ACT, diffusion, pi0/pi0.5, SmolVLA,
+MolmoAct2) and is worst for long chunks (SmolVLA ``n_action_steps=50`` froze an
+entire short rollout). It is independent of the chunk-acquisition strategy, so
+it manifests on BOTH the synchronous loop and the async-RTC loop.
+
+The fix refreshes the observation handed to ``on_frame`` per step while a
+recording is active (inference still consumes the chunk-start observation, so
+open-loop replay is unchanged). These tests pin that the recorded per-step
+proprioceptive state actually advances within a single chunk.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+pytest.importorskip("mujoco")
+
+from strands_robots.policies.mock import MockPolicy
+from strands_robots.simulation.mujoco.simulation import Simulation
+
+
+class _CapturingRecorder:
+    """Stub recorder that records the observation handed to each ``add_frame``.
+
+    Mirrors only the surface the MuJoCo ``on_frame`` recording hook touches:
+    ``add_frame(observation=, action=, task=)``. The hook forwards the raw sim
+    observation (per-joint scalar keys such as ``Rotation`` / ``Pitch`` plus
+    their ``.vel`` companions - the real ``DatasetRecorder`` packs these into
+    ``observation.state``). We snapshot the scalar proprioceptive vector per
+    frame so the test can assert the recorded trajectory advances instead of
+    being frozen across the chunk.
+    """
+
+    def __init__(self) -> None:
+        self.states: list[np.ndarray] = []
+        self.actions: list[dict[str, Any]] = []
+        self.episode_frame_count = 0
+        self.frame_count = 0
+
+    @staticmethod
+    def _scalar_state(observation: dict[str, Any]) -> np.ndarray:
+        # Pack every scalar (non-image) observation value into a stable vector.
+        items = sorted(
+            (k, float(v)) for k, v in observation.items() if isinstance(v, (int, float)) and not isinstance(v, bool)
+        )
+        return np.array([v for _, v in items], dtype=float)
+
+    def add_frame(self, observation: dict[str, Any], action: dict[str, Any], task: str = "") -> None:
+        self.states.append(self._scalar_state(observation))
+        self.actions.append(dict(action))
+        self.episode_frame_count += 1
+        self.frame_count += 1
+
+    def save_episode(self) -> dict[str, Any]:  # not exercised for n_episodes=1
+        self.episode_frame_count = 0
+        return {"status": "success"}
+
+
+def _make_recording_sim() -> tuple[Simulation, _CapturingRecorder]:
+    sim = Simulation(tool_name="chunk_obs_align", mesh=False)
+    sim.create_world()
+    sim.add_robot(name="arm", data_config="so100")
+    assert sim._world is not None
+    rec = _CapturingRecorder()
+    # Open a recording session WITHOUT a real LeRobotDataset: the on_frame hook
+    # only needs ``recording`` truthy and a recorder with ``add_frame``. This is
+    # the same opaque-injection seam used by the episode-boundary regression.
+    sim._world._backend_state["recording"] = True
+    sim._world._backend_state["trajectory"] = []
+    sim._world._backend_state["dataset_recorder"] = rec
+    return sim, rec
+
+
+@pytest.mark.parametrize("async_rtc", [False, True], ids=["sync", "async_rtc"])
+def test_recorded_state_advances_within_a_single_chunk(async_rtc: bool) -> None:
+    """Every recorded frame in one chunk must reflect the live (moving) state.
+
+    The rollout is capped BELOW the chunk length so the whole episode is served
+    from a single ``get_actions`` call (one chunk, no re-query). Pre-fix all
+    frames carry the frozen chunk-start state; post-fix they advance step by
+    step. MockPolicy emits smooth sinusoidal targets that move the arm, so a
+    correctly time-aligned recording has a strictly non-zero step-to-step delta.
+    """
+    sim, rec = _make_recording_sim()
+    try:
+        policy = MockPolicy()
+        # MockPolicy emits an 8-action chunk; stay strictly inside it so the
+        # only motion in the recording would come from per-step obs refresh,
+        # never from a chunk boundary re-query.
+        n_steps = 6
+        result = sim.run_policy(
+            robot_name="arm",
+            policy_provider="mock",
+            policy_object=policy,
+            instruction="move",
+            n_steps=n_steps,
+            action_horizon=8,
+            control_frequency=50.0,
+            fast_mode=True,
+            async_rtc=async_rtc,
+        )
+        assert result["status"] == "success", result
+
+        assert len(rec.states) == n_steps, f"expected {n_steps} recorded frames, got {len(rec.states)}"
+        states = np.stack(rec.states)
+        # The recorded actions DO differ per step (this was never the bug).
+        # The defect was the OBSERVATION being frozen against those actions.
+        step_deltas = np.linalg.norm(np.diff(states, axis=0), axis=1)
+        assert step_deltas.max() > 1e-6, (
+            "recorded observation.state is frozen across the chunk - the dataset "
+            f"would pair {n_steps} identical observations with {n_steps} distinct "
+            f"actions (per-step deltas={step_deltas})"
+        )
+        # Stronger: most consecutive frames advance (a moving rollout), not just
+        # a single non-frozen frame.
+        assert (step_deltas > 1e-6).sum() >= n_steps - 2, (
+            f"recorded state barely advances across the chunk: deltas={step_deltas}"
+        )
+    finally:
+        sim.cleanup()


### PR DESCRIPTION
## Problem

`PolicyRunner` replays a chunk-emitting policy's actions open-loop, re-querying the policy only every `H` steps (`H = resolve_chunk_length`). The dataset-recording `on_frame` hook writes one `(observation, action)` frame per control step, but the runner handed the **same chunk-start observation** to the hook for every action in the chunk.

The sim advances and the actions differ at each step, so a recorded episode ended up with `H` identical frames (frozen image + frozen proprioceptive `observation.state`) paired with `H` distinct actions. That is temporally-misaligned behavioural-cloning data: the recorded observation never matches the action taken from it. A model trained on it sees one image mapped to many different actions.

The severity scales with chunk length. SmolVLA (`n_action_steps=50`) froze an entire short rollout, while the in-loop render video (which re-renders fresh per step) showed the arm moving. A moving video next to a frozen dataset is the smoking gun. The bug is present on both the synchronous loop and the async-RTC loop.

## Before / after

Recorded dataset wrist camera (`observation.images.camera3`) from a SmolVLA pick rollout in MuJoCo (headless), same scene, 20 control steps. Left = before (every recorded frame frozen on the chunk-start observation); right = after (frames advance with the robot):

![before/after recorded dataset camera](https://raw.githubusercontent.com/cagataycali/robots/pr-assets/recording-obs-alignment/recording_obs_alignment.gif)

Per-camera mean inter-frame pixel delta over the recorded MP4s for that rollout:

| camera | before (frozen) | after |
|---|---|---|
| `camera1` (front) | 0.000 | 2.17 |
| `camera2` (top) | 0.000 | 2.41 |
| `camera3` (wrist) | 0.000 | 5.11 |

## Fix

While a recording session is active, refresh the observation handed to `on_frame` per step so each recorded frame pairs the action with the state it actually acts on:

- Sync loop: reuse the freshly-queried observation for the first action of each chunk (sim has not stepped yet, no extra render) and re-sample for subsequent actions.
- Async-RTC loop: re-sample every step, since its chunk observation is horizon-shifted and never the clean pre-action state for a given step.

Inference still consumes the chunk-start observation, so open-loop chunk replay is byte-for-byte unchanged - only the **recorded** frame is refreshed. Recording is detected through the engine's own `_is_recording()` contract, so eval/inference paths (no recorder attached) keep the historical single-fetch-per-chunk behaviour with zero extra renders.

## Tests

`tests/simulation/test_policy_runner_chunk_obs_alignment.py` drives a recording rollout capped below the chunk length (one chunk, no re-query) and asserts the recorded per-step proprioceptive state advances. Parametrized over the sync and async-RTC loops. Fails pre-fix (step deltas all `0.0`), passes post-fix.

Full simulation recording/eval suite (`test_policy_runner*`, `test_run_policy_*`, `test_recording_backends`, `test_stop_recording_finalize`, episode-boundary) stays green: 140 passed, 3 skipped. `ruff check`, `ruff format --check`, and `mypy` clean.