### PR TITLE
feat(datasets): verify per-episode video files in verify_dataset

### DIFF
--- a/docs/recording.md
+++ b/docs/recording.md
@@ -144,15 +144,23 @@ exit code suitable for CI:
 ```bash
 strands-robots verify-dataset /path/to/dataset --expected 20   # exit 0 pass, 1 fail
 strands-robots verify-dataset /path/to/dataset --json          # machine-readable report
+strands-robots verify-dataset /path/to/dataset --no-check-videos  # skip the per-episode MP4 checks
 ```
 
 `verify-dataset` reuses the same pure-pyarrow `read_dataset_episode_indices`
-helper (no `lerobot` import) and flags three failure modes: the mega-episode
+helper (no `lerobot` import) and flags four failure modes: the mega-episode
 (fewer distinct episodes than `--expected`), `meta/info.json` `total_episodes` /
 `total_frames` drifting from the parquet ground truth (caught even without
-`--expected`), and any episode below `--min-frames` (default 1). The
-programmatic form is
-`strands_robots.verify_dataset.verify_dataset(root, expected=None, min_frames=1)`,
+`--expected`), any episode below `--min-frames` (default 1), and - unless
+`--no-check-videos` is passed - any per-episode video file that is missing or
+empty on disk. The last check is the video-modality sibling of the
+mega-episode class: a dataset can carry the right episode count yet have no
+pixels because the recorder's video encoder failed or the MP4 streams were
+never written. It resolves each camera's MP4 from `meta/info.json`'s
+`video_path` template and the episode parquet's `videos/<key>/chunk_index` /
+`file_index` columns, and reports the count it checked in
+`video_files_checked`. The programmatic form is
+`strands_robots.verify_dataset.verify_dataset(root, expected=None, min_frames=1, check_videos=True)`,
 which returns the same report dict.
 
 ## Recording paths

--- a/strands_robots/verify_dataset.py
+++ b/strands_robots/verify_dataset.py
@@ -15,6 +15,13 @@ Checks performed against a dataset root (the dir containing ``meta/``):
      agree with the parquet ground truth - flags metadata/parquet drift;
   4. when ``--expected N`` is given, the parquet holds exactly N episodes -
      flags the "wanted N, got M" mismatch.
+  5. every per-episode video file referenced by the dataset (one MP4 per
+     camera per episode, resolved from ``meta/info.json``'s ``video_path``
+     template and the episode parquet's ``videos/<key>/chunk_index`` /
+     ``file_index`` columns) exists on disk and is non-empty - flags the
+     video-modality sibling of mega-episode corruption, where the episode
+     count is correct but the pixels are missing/unwritten (disable with
+     ``--no-check-videos``).
 
 Usage:
     strands-robots verify-dataset /path/to/dataset
@@ -41,6 +48,7 @@ def verify_dataset(
     root: str | Path,
     expected: int | None = None,
     min_frames: int = 1,
+    check_videos: bool = True,
 ) -> dict[str, Any]:
     """Verify the episode integrity of a LeRobot dataset on disk.
 
@@ -53,6 +61,8 @@ def verify_dataset(
         root: Dataset root directory (the dir that contains ``meta/``).
         expected: If given, require exactly this many distinct episodes.
         min_frames: Minimum frames every episode must contain (default 1).
+        check_videos: When True (default), verify that every per-episode
+            video file referenced by the dataset exists and is non-empty.
 
     Returns:
         A report dict with:
@@ -65,6 +75,9 @@ def verify_dataset(
           - ``expected``: the requested count (or ``None``).
           - ``info_total_episodes`` / ``info_total_frames``: values declared in
             ``meta/info.json`` (``None`` when the file is absent or lacks them).
+          - ``video_files_checked``: number of distinct per-episode video
+            files resolved and checked (``0`` when ``check_videos`` is False
+            or the dataset declares no video features).
           - ``problems``: list of human-readable failure strings (empty on pass).
     """
     from strands_robots.dataset_recorder import read_dataset_episode_indices
@@ -81,6 +94,7 @@ def verify_dataset(
         "expected": expected,
         "info_total_episodes": None,
         "info_total_frames": None,
+        "video_files_checked": 0,
         "problems": [],
     }
     problems: list[str] = report["problems"]
@@ -150,9 +164,110 @@ def verify_dataset(
             "- the recording did not produce the intended number of distinct episodes"
         )
 
+    # Check 5: per-episode video files exist on disk and are non-empty. A
+    # dataset can pass every count check yet carry missing/empty MP4 streams
+    # (the recorder's video encoder failed, the files were partially synced, or
+    # frames were never captured) - correct episode counts, no pixels. This is
+    # the video-modality sibling of the mega-episode class above.
+    if check_videos:
+        checked, video_problems = _verify_video_files(root_path)
+        report["video_files_checked"] = checked
+        problems.extend(video_problems)
+
     report["ok"] = not problems
     report["status"] = "success" if report["ok"] else "error"
     return report
+
+
+def _verify_video_files(root_path: Path) -> tuple[int, list[str]]:
+    """Resolve and integrity-check every per-episode video file in a dataset.
+
+    For each video feature declared in ``meta/info.json`` (``dtype == "video"``)
+    and each episode, the on-disk MP4 path is resolved from the ``video_path``
+    template and the episode parquet's ``videos/<key>/chunk_index`` /
+    ``file_index`` columns, then checked for existence and non-zero size. This
+    catches datasets whose episode counts are correct but whose pixels are
+    missing or were never written.
+
+    Args:
+        root_path: Dataset root directory (the dir that contains ``meta/``).
+
+    Returns:
+        A ``(checked, problems)`` tuple where ``checked`` is the number of
+        distinct video files resolved and ``problems`` lists missing/empty
+        files (empty when the dataset declares no video features or all files
+        are present and non-empty).
+    """
+    info_path = root_path / "meta" / "info.json"
+    if not info_path.is_file():
+        return 0, []
+    try:
+        info = json.loads(info_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        # An unreadable info.json is already surfaced by the info.json drift
+        # check; do not double-report it here.
+        return 0, []
+
+    features = info.get("features")
+    if not isinstance(features, dict):
+        return 0, []
+    video_keys = [key for key, feat in features.items() if isinstance(feat, dict) and feat.get("dtype") == "video"]
+    if not video_keys:
+        return 0, []
+
+    template = info.get("video_path")
+    if not isinstance(template, str) or not template:
+        return 0, [
+            f"meta/info.json declares {len(video_keys)} video feature(s) but no 'video_path' "
+            "template - cannot locate the per-episode MP4 files"
+        ]
+
+    try:
+        import pyarrow.parquet as pq
+    except ImportError:  # pragma: no cover - pyarrow ships with the lerobot extra
+        return 0, []
+
+    parquet_files = sorted((root_path / "meta" / "episodes").glob("**/*.parquet"))
+    # (video_key, chunk_index, file_index) -> set of referencing episode_index.
+    referenced: dict[tuple[str, int, int], int] = {}
+    keys_with_refs: set[str] = set()
+    for pf in parquet_files:
+        table = pq.read_table(pf)
+        cols = set(table.column_names)
+        data = table.to_pydict()
+        episodes = data.get("episode_index", [])
+        for vk in video_keys:
+            ci_col = f"videos/{vk}/chunk_index"
+            fi_col = f"videos/{vk}/file_index"
+            if ci_col not in cols or fi_col not in cols:
+                continue
+            keys_with_refs.add(vk)
+            chunk_idx = data[ci_col]
+            file_idx = data[fi_col]
+            for i in range(len(chunk_idx)):
+                ci, fi = chunk_idx[i], file_idx[i]
+                if ci is None or fi is None:
+                    continue
+                ep = int(episodes[i]) if i < len(episodes) and episodes[i] is not None else -1
+                referenced.setdefault((vk, int(ci), int(fi)), ep)
+
+    problems: list[str] = []
+    for vk in video_keys:
+        if vk not in keys_with_refs:
+            problems.append(
+                f"video feature '{vk}' is declared but no episode references a video file for it "
+                "(missing videos/<key>/chunk_index|file_index columns)"
+            )
+
+    for (vk, ci, fi), ep in sorted(referenced.items()):
+        rel = template.format(video_key=vk, chunk_index=ci, file_index=fi)
+        path = root_path / rel
+        if not path.is_file():
+            problems.append(f"missing video file for '{vk}' (episode {ep}): {rel}")
+        elif path.stat().st_size == 0:
+            problems.append(f"empty video file for '{vk}' (episode {ep}): {rel}")
+
+    return len(referenced), problems
 
 
 def _format_report(report: dict[str, Any]) -> str:
@@ -161,6 +276,8 @@ def _format_report(report: dict[str, Any]) -> str:
     verdict = "PASS" if report["ok"] else "FAIL"
     lines.append(f"[{verdict}] {report['root']}")
     lines.append(f"  episodes (parquet): {report['total_episodes']}")
+    if report.get("video_files_checked"):
+        lines.append(f"  video files checked: {report['video_files_checked']}")
     if report["total_frames"]:
         lines.append(f"  frames   (parquet): {report['total_frames']}")
     if report["expected"] is not None:
@@ -197,9 +314,17 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Emit the report as JSON instead of the human-readable summary.",
     )
+    parser.add_argument(
+        "--no-check-videos",
+        dest="check_videos",
+        action="store_false",
+        help="Skip per-episode video-file existence/non-empty checks.",
+    )
     args = parser.parse_args(argv)
 
-    report = verify_dataset(args.root, expected=args.expected, min_frames=args.min_frames)
+    report = verify_dataset(
+        args.root, expected=args.expected, min_frames=args.min_frames, check_videos=args.check_videos
+    )
     if args.json:
         print(json.dumps(report, indent=2))
     else:

--- a/tests/test_verify_dataset.py
+++ b/tests/test_verify_dataset.py
@@ -146,3 +146,169 @@ class TestCLI:
         payload = json.loads(capsys.readouterr().out)
         assert payload["total_episodes"] == 3
         assert payload["ok"] is True
+
+
+def _write_video_dataset(
+    root: Path,
+    episode_indices: list[int],
+    video_keys: list[str],
+    *,
+    frames_per_episode: list[int] | None = None,
+    write_files: set[str] | None = None,
+    empty_files: set[str] | None = None,
+    video_path: str | None = "videos/{video_key}/chunk-{chunk_index:03d}/file-{file_index:03d}.mp4",
+    include_index_columns: bool = True,
+) -> Path:
+    """Write a synthetic LeRobot v3 dataset that declares video features.
+
+    Each episode references one MP4 per camera (chunk 0, file = episode index)
+    via the ``videos/<key>/chunk_index`` / ``file_index`` columns, mirroring the
+    real recorder layout. The actual MP4 files are written only for the
+    ``(video_key, episode)`` pairs in ``write_files`` (default: all), so a test
+    can simulate a missing or empty video stream.
+
+    Args:
+        root: Dataset root (the dir that will contain ``meta/``).
+        episode_indices: Distinct ``episode_index`` values to write.
+        video_keys: Video feature keys (e.g. ``observation.images.cam``).
+        frames_per_episode: Per-episode ``length`` column (omitted if None).
+        write_files: ``{"<video_key>:<episode>"}`` pairs whose MP4 is written
+            (default: every pair).
+        empty_files: Subset of ``write_files`` written as 0-byte files.
+        video_path: ``meta/info.json`` ``video_path`` template (None to omit).
+        include_index_columns: Whether to emit the per-key chunk/file columns.
+
+    Returns:
+        The dataset root path.
+    """
+    ep_dir = root / "meta" / "episodes" / "chunk-000"
+    ep_dir.mkdir(parents=True, exist_ok=True)
+    columns: dict[str, list] = {"episode_index": episode_indices}
+    if frames_per_episode is not None:
+        columns["length"] = frames_per_episode
+    if include_index_columns:
+        for vk in video_keys:
+            columns[f"videos/{vk}/chunk_index"] = [0 for _ in episode_indices]
+            columns[f"videos/{vk}/file_index"] = list(episode_indices)
+    pq.write_table(pa.table(columns), ep_dir / "episodes_000.parquet")
+
+    features = {
+        vk: {"dtype": "video", "shape": [3, 64, 64], "names": ["channels", "height", "width"]} for vk in video_keys
+    }
+    info: dict = {
+        "total_episodes": len(episode_indices),
+        "total_frames": sum(frames_per_episode) if frames_per_episode else 0,
+        "features": features,
+    }
+    if video_path is not None:
+        info["video_path"] = video_path
+    (root / "meta" / "info.json").write_text(json.dumps(info), encoding="utf-8")
+
+    if write_files is None:
+        write_files = {f"{vk}:{ep}" for vk in video_keys for ep in episode_indices}
+    empty_files = empty_files or set()
+    for pair in write_files:
+        vk, ep = pair.rsplit(":", 1)
+        rel = video_path.format(video_key=vk, chunk_index=0, file_index=int(ep)) if video_path else None
+        if rel is None:
+            continue
+        fpath = root / rel
+        fpath.parent.mkdir(parents=True, exist_ok=True)
+        fpath.write_bytes(b"" if pair in empty_files else b"\x00\x00\x00\x18ftypmp42")
+    return root
+
+
+class TestVideoFileIntegrity:
+    """Check 5: per-episode video files must exist on disk and be non-empty.
+
+    A dataset can pass every episode-count check yet carry missing or empty MP4
+    streams - correct episode counts, no pixels. These pin that the verifier
+    catches that video-modality corruption, and that ``check_videos=False``
+    opts out (the pre-Check-5 behaviour).
+    """
+
+    def test_all_videos_present_passes(self, tmp_path: Path) -> None:
+        _write_video_dataset(
+            tmp_path,
+            episode_indices=[0, 1],
+            video_keys=["observation.images.cam1", "observation.images.cam2"],
+            frames_per_episode=[3, 3],
+        )
+        report = verify_dataset(tmp_path)
+        assert report["status"] == "success", report["problems"]
+        # 2 cameras x 2 episodes = 4 distinct video files resolved and checked.
+        assert report["video_files_checked"] == 4
+
+    def test_missing_video_file_fails(self, tmp_path: Path) -> None:
+        # Episode 1's cam2 MP4 is never written; episode counts are still valid.
+        keys = ["observation.images.cam1", "observation.images.cam2"]
+        all_pairs = {f"{k}:{e}" for k in keys for e in (0, 1)}
+        _write_video_dataset(
+            tmp_path,
+            episode_indices=[0, 1],
+            video_keys=keys,
+            frames_per_episode=[3, 3],
+            write_files=all_pairs - {"observation.images.cam2:1"},
+        )
+        report = verify_dataset(tmp_path)
+        assert report["status"] == "error"
+        assert report["total_episodes"] == 2  # count check still passes
+        assert any("missing video file" in p and "cam2" in p for p in report["problems"])
+
+    def test_empty_video_file_fails(self, tmp_path: Path) -> None:
+        _write_video_dataset(
+            tmp_path,
+            episode_indices=[0],
+            video_keys=["observation.images.cam1"],
+            frames_per_episode=[3],
+            empty_files={"observation.images.cam1:0"},
+        )
+        report = verify_dataset(tmp_path)
+        assert report["status"] == "error"
+        assert any("empty video file" in p for p in report["problems"])
+
+    def test_check_videos_false_skips_the_check(self, tmp_path: Path) -> None:
+        # The exact pre-Check-5 behaviour: a missing MP4 is invisible when the
+        # video check is disabled, so the count-only verdict is success.
+        keys = ["observation.images.cam1"]
+        _write_video_dataset(
+            tmp_path,
+            episode_indices=[0],
+            video_keys=keys,
+            frames_per_episode=[3],
+            write_files=set(),  # write no MP4 files at all
+        )
+        report = verify_dataset(tmp_path, check_videos=False)
+        assert report["status"] == "success"
+        assert report["video_files_checked"] == 0
+
+    def test_no_video_features_checks_nothing(self, tmp_path: Path) -> None:
+        # A state-only dataset (no video features) has nothing to check.
+        _write_dataset(tmp_path, episode_indices=[0, 1], frames_per_episode=[4, 4])
+        report = verify_dataset(tmp_path)
+        assert report["status"] == "success"
+        assert report["video_files_checked"] == 0
+
+    def test_video_feature_without_path_template_fails(self, tmp_path: Path) -> None:
+        _write_video_dataset(
+            tmp_path,
+            episode_indices=[0],
+            video_keys=["observation.images.cam1"],
+            frames_per_episode=[3],
+            video_path=None,
+        )
+        report = verify_dataset(tmp_path)
+        assert report["status"] == "error"
+        assert any("no 'video_path' template" in p for p in report["problems"])
+
+    def test_cli_no_check_videos_flag_skips(self, tmp_path: Path, capsys) -> None:
+        _write_video_dataset(
+            tmp_path,
+            episode_indices=[0],
+            video_keys=["observation.images.cam1"],
+            frames_per_episode=[3],
+            write_files=set(),
+        )
+        assert verify_main([str(tmp_path)]) == 1  # missing MP4 fails by default
+        capsys.readouterr()
+        assert verify_main([str(tmp_path), "--no-check-videos"]) == 0  # opt out passes


### PR DESCRIPTION
## Problem

`verify_dataset` is the dataset-integrity gate that catches the "mega-episode" corruption class (a run that intended N episodes but buffered everything into one) and `meta/info.json`-vs-parquet drift. But it only inspects episode *metadata*: episode counts, per-episode frame lengths, and the info.json/parquet agreement.

It never checks that the per-episode **video files** the dataset references actually exist and are non-empty on disk. A dataset can therefore pass every existing check while carrying missing or zero-byte MP4 streams — correct episode counts, no pixels — because the recorder's video encoder failed, the files were only partially synced, or frames were never captured. The verifier reported `PASS` and the dataset blew up only later, at train time. This is the video-modality sibling of the mega-episode class the verifier already guards against.

## Change

Add Check 5 to `verify_dataset`: for every video feature declared in `meta/info.json` (`dtype == "video"`), resolve each per-episode MP4 from the `video_path` template plus the episode parquet's `videos/<key>/chunk_index` / `file_index` columns, then flag any file that is missing or zero-bytes. It also flags a declared video feature that no episode references, and a video feature with no `video_path` template to resolve.

- New `check_videos: bool = True` parameter and a `--no-check-videos` CLI flag to opt out (count-only, the prior behavior).
- New `video_files_checked` field in the report dict and a line in the human-readable summary.
- Pure-pyarrow file read — no `lerobot` import, consistent with the rest of the module.

## Demo

Verifier run against a real recorded dataset (a 3-camera SO-101 rollout in MuJoCo, headless), then with one camera's MP4 removed (episode counts stay valid), then the same corrupt dataset with `--no-check-videos`:

```
### healthy dataset (3 cameras)
[PASS] /path/to/ds
  episodes (parquet): 1
  video files checked: 3
  frames   (parquet): 48
  info.json episodes: 1

### after a camera MP4 goes missing (episode counts still correct)
[FAIL] /path/to/ds
  episodes (parquet): 1
  video files checked: 3
  frames   (parquet): 48
  info.json episodes: 1
  - missing video file for 'observation.images.camera2' (episode 0): videos/observation.images.camera2/chunk-000/file-000.mp4
exit=1

### same corrupt dataset with --no-check-videos (count-only)
[PASS] /path/to/ds
exit=0
```

The recorded per-camera video streams the verifier validates (front / top-down / wrist), as written to the LeRobot v3 dataset:

![3-camera rollout the verifier validates](https://github.com/cagataycali/robots/releases/download/verify-dataset-video-demo/verify_dataset_video_demo.gif)

## Tests

`tests/test_verify_dataset.py::TestVideoFileIntegrity` builds synthetic v3 datasets with pyarrow (no lerobot/mujoco) and covers: all-present passes, missing file fails, empty file fails, no-video-features is a no-op, missing `video_path` template fails, `check_videos=False` opts out, and the `--no-check-videos` CLI flag. All seven fail on pre-change code (the missing/empty-MP4 datasets return `success` without the check) and pass after.

## Docs

`docs/recording.md` updated: the fourth failure mode, the `--no-check-videos` flag, `video_files_checked`, and the `check_videos` parameter in the programmatic signature.

Gate: `ruff check` + `ruff format --check` clean; `mypy strands_robots tests tests_integ` reports no issues; full `tests/test_verify_dataset.py` (17) + `tests/test_main_cli.py` pass.