### PR TITLE
fix(simulation): Newton get_observation renders cameras while recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: Newton recording captures camera frames when the policy skips images
+
+`PolicyRunner` sets `skip_images = not policy.requires_images` to avoid rendering
+when the policy does not consume pixels. The default `mock` policy (and any
+non-VLA, proprioceptive-only policy) reports `requires_images=False`, so during a
+rollout the runner asks the backend for a pixel-free observation. While a dataset
+recording is active that hint must be overridden, because the recording `on_frame`
+hook writes the observation's camera ndarrays into the dataset's declared video
+features -- a pixel-free observation yields a dataset with correct episode counts
+but no pixels (the video-modality sibling of the mega-episode corruption class).
+The MuJoCo backend guards this in `get_observation`; the Newton backend wired the
+recorder later (named cameras + `DatasetRecorder`) and honored `skip_images`
+literally, so recording on Newton with a non-image policy silently dropped every
+frame's images. `NewtonSimEngine.get_observation` now applies the same guard:
+when an active recording is attached it renders cameras regardless of the
+`skip_images` hint, restoring MuJoCo parity. Inference still skips rendering when
+nothing is recording.
+
+
 ### Fixed: policy resolution no longer shadows `lerobot.policies` with a partial stub
 
 Smart-string resolution (`create_policy("org/model")`, `grpc://`, `ws://`, ...)

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -591,6 +591,13 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
             return {}
         if robot_name not in self._world.robots:
             return {}
+        if skip_images and self._world._backend_state.get("recording"):
+            # T26: dataset recording needs every frame's image obs. Override
+            # the policy's skip hint when an active recorder is attached so a
+            # non-image policy (e.g. the default mock, requires_images=False)
+            # does not silently record pixel-less frames for declared camera
+            # features. Mirrors the MuJoCo backend's get_observation guard.
+            skip_images = False
         with self._lock:
             joint_q = self._state_0.joint_q.numpy()
             robot_joints = self._world.robots[robot_name].joint_names

--- a/tests/simulation/newton/test_recording_image_obs.py
+++ b/tests/simulation/newton/test_recording_image_obs.py
@@ -1,0 +1,67 @@
+"""Recording must capture camera frames even when the policy skips images.
+
+``PolicyRunner`` sets ``skip_images = not policy.requires_images`` to avoid
+rendering when the policy does not consume pixels. The default ``mock`` policy
+(and any non-VLA, proprioceptive-only policy) reports ``requires_images=False``,
+so the runner asks the backend for a pixel-free observation.
+
+While a dataset recording is active, that hint must be overridden: the recorder
+writes the observation's camera ndarrays into the dataset's declared video
+features, so a pixel-free observation produces frames with correct episode
+counts but no pixels - a silently corrupt behavioural-cloning dataset. The
+MuJoCo backend guards this in ``get_observation``; the Newton backend wired the
+recorder later and honored ``skip_images`` literally, dropping every recorded
+frame's images. These tests pin the parity contract on the real Newton engine.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import numpy as np
+import pytest
+
+_HAS_NEWTON = importlib.util.find_spec("newton") is not None and importlib.util.find_spec("warp") is not None
+
+pytestmark = pytest.mark.skipif(not _HAS_NEWTON, reason="newton/warp not installed")
+
+
+@pytest.fixture
+def engine_with_camera():
+    from strands_robots.simulation.newton.simulation import NewtonSimEngine
+
+    sim = NewtonSimEngine(solver="mujoco")
+    sim.create_world()
+    sim.add_robot("so101")
+    sim.add_camera("front", position=[0.0, -0.6, 0.4], target=[0.0, 0.0, 0.1])
+    yield sim
+    sim.destroy()
+
+
+def test_skip_images_drops_cameras_without_recording(engine_with_camera):
+    """The render-skip optimization still applies when nothing is recording."""
+    obs = engine_with_camera.get_observation(skip_images=True)
+    assert "front" not in obs, "skip_images should drop camera frames when not recording"
+
+
+def test_full_observation_includes_camera(engine_with_camera):
+    """skip_images=False renders the camera into the observation (sanity)."""
+    obs = engine_with_camera.get_observation(skip_images=False)
+    assert isinstance(obs.get("front"), np.ndarray)
+    assert obs["front"].ndim == 3 and obs["front"].shape[2] == 3
+
+
+def test_recording_overrides_skip_images(engine_with_camera):
+    """skip_images=True must still render cameras while a recording is active.
+
+    Pre-fix the Newton backend honored ``skip_images`` literally and returned a
+    camera-free observation here, so the recorder wrote frames with no pixels.
+    """
+    sim = engine_with_camera
+    assert sim._world is not None
+    sim._world._backend_state["recording"] = True
+    obs = sim.get_observation(skip_images=True)
+    assert isinstance(obs.get("front"), np.ndarray), (
+        "active recording must override the skip-images hint so declared camera features receive real pixels"
+    )
+    assert obs["front"].ndim == 3 and obs["front"].shape[2] == 3


### PR DESCRIPTION
## Problem

`PolicyRunner` sets `skip_images = not policy.requires_images` so it does not pay the render cost when the policy does not consume pixels. The default `mock` policy -- and any non-VLA, proprioceptive-only policy -- reports `requires_images=False`, so during a rollout the runner asks the backend for a pixel-free observation.

While a dataset recording is active that hint must be overridden, because the recording `on_frame` hook writes the observation's camera ndarrays straight into the dataset's declared video features. A pixel-free observation therefore produces a dataset with correct episode counts but **no pixels** -- the video-modality sibling of the mega-episode corruption class, where the dataset passes every count check yet blows up at train time.

The MuJoCo backend guards this directly in `get_observation`:

```python
if skip_images and self._world is not None and self._world._backend_state.get("recording"):
    # dataset recording needs every frame's image obs
    skip_images = False
```

The Newton backend wired the recorder later (named cameras + `DatasetRecorder`) and honored `skip_images` literally, so recording on Newton with a non-image policy silently dropped every frame's images. Because the default `run_policy(policy_provider="mock")` reports `requires_images=False`, the most common `start_recording(...) -> run_policy() -> stop_recording()` path on Newton recorded pixel-less datasets, even though the live render video (which re-renders per step independently) showed the arm moving -- the moving video vs. empty dataset divergence is the smoking gun.

## Change

`NewtonSimEngine.get_observation` now applies the same guard the MuJoCo backend has: when an active recording is attached it renders cameras regardless of the `skip_images` hint, restoring backend parity. Inference still skips rendering when nothing is recording, so the non-recording optimization is unchanged.

## Tests

New `tests/simulation/newton/test_recording_image_obs.py` pins the contract on the **real** Newton engine (skipped when newton/warp are absent), covering all three paths:

- `skip_images=True` without recording drops camera frames (optimization intact),
- `skip_images=False` renders the camera (sanity),
- `skip_images=True` **with** an active recording renders the camera (the fix).

The third test fails on pre-change code (`observation.images.front` is absent, so the recorder would write pixel-less frames) and passes after.

End-to-end check on the Newton MuJoCo solver: `start_recording -> run_policy(policy_provider="mock", video=...) -> stop_recording`, then reopen the dataset via `LeRobotDataset`. Post-fix the recorded `observation.images.front` feature carries real pixels (`max=1.0`, `nonzero_frac=1.0`) across all 30 frames; pre-fix it was empty.

Gate: `ruff check` + `ruff format --check` clean; `mypy strands_robots tests tests_integ` reports no issues; the Newton recording + multi-camera + new regression suites pass (26 tests).

## Demo

Frames read back from the reopened dataset's `observation.images.front` feature -- the camera stream that recorded pixel-less before this fix:

![Newton recorded camera frames](https://github.com/cagataycali/robots/releases/download/newton-recording-image-obs-demo/newton_recording_image_obs.gif)

## Docs

CHANGELOG `[Unreleased]` gains a `Fixed:` entry describing the parity gap and the guard.