### PR TITLE
feat(run_policy): forward dataset_cameras to scope recorded dataset cameras

### DIFF
--- a/docs/recording.md
+++ b/docs/recording.md
@@ -80,8 +80,10 @@ run_policy(
 )
 ```
 
-`dataset_cameras` is forwarded verbatim to `start_recording(cameras=...)`;
-omit it (the default `None`) to record every scene camera.
+When set, `dataset_cameras` is forwarded as `start_recording(cameras=...)`
+(the camera subset is a MuJoCo-backend feature). Omit it (the default `None`)
+to record every scene camera - the default path forwards no `cameras` kwarg at
+all, so it stays backend-agnostic across the MuJoCo and Newton engines.
 
 ## Multi-episode recording
 

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -62,6 +62,27 @@ When `root` already contains a LeRobotDataset (a `meta/` directory),
 LeRobotDataset, and is **not empty** is left untouched and reported as an error
 rather than clobbered - pass `overwrite=True` or choose a new/empty `root`.
 
+When you drive recording through the `run_policy` tool (which owns the
+`start_recording` -> rollout -> `stop_recording` cycle), forward the same
+subset with `dataset_cameras=`:
+
+```python
+from strands_robots.tools.run_policy import run_policy
+
+run_policy(
+    simulation=sim,
+    robot_name="so101",
+    policy_provider="lerobot_local",
+    instruction="pick up the cube",
+    n_episodes=1,
+    dataset_root="/tmp/my_dataset",
+    dataset_cameras=["camera1", "camera2", "camera3"],  # drops the implicit 'default'
+)
+```
+
+`dataset_cameras` is forwarded verbatim to `start_recording(cameras=...)`;
+omit it (the default `None`) to record every scene camera.
+
 ## Multi-episode recording
 
 A recording session is one dataset. The simplest way to collect N episodes in

--- a/strands_robots/tools/run_policy.py
+++ b/strands_robots/tools/run_policy.py
@@ -119,6 +119,7 @@ def run_policy(
     dataset_repo_id: str = "local/run_policy_rollout",
     dataset_task: str = "",
     dataset_fps: int = 30,
+    dataset_cameras: list[str] | None = None,
     seed: int | None = None,
     policy_kwargs: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
@@ -169,6 +170,15 @@ def run_policy(
         dataset_repo_id: Forwarded to ``start_recording``.
         dataset_task: Task label forwarded to ``start_recording``.
         dataset_fps: Dataset FPS forwarded to ``start_recording``.
+        dataset_cameras: Camera names to record into the dataset,
+            forwarded to ``start_recording(cameras=...)``. When
+            ``None`` (default) every scene camera is recorded -
+            including the implicit ``default`` free camera the
+            MuJoCo backend ships. Pass an explicit subset (e.g.
+            ``["camera1", "camera2", "camera3"]``) to scope a
+            policy-specific dataset to exactly the views the policy
+            declares and keep the stray ``default`` view out of
+            ``observation.images.*``.
         seed: Master RNG seed. Each episode derives a deterministic
             offset so rollouts are reproducible within a process.
         policy_kwargs: Optional per-call goal payload forwarded to
@@ -230,6 +240,7 @@ def run_policy(
             fps=dataset_fps,
             root=dataset_root,
             overwrite=True,
+            cameras=dataset_cameras,
         )
         if start_result.get("status") != "success":
             # Surface the engine's own error verbatim - it already explains

--- a/strands_robots/tools/run_policy.py
+++ b/strands_robots/tools/run_policy.py
@@ -170,15 +170,16 @@ def run_policy(
         dataset_repo_id: Forwarded to ``start_recording``.
         dataset_task: Task label forwarded to ``start_recording``.
         dataset_fps: Dataset FPS forwarded to ``start_recording``.
-        dataset_cameras: Camera names to record into the dataset,
-            forwarded to ``start_recording(cameras=...)``. When
-            ``None`` (default) every scene camera is recorded -
-            including the implicit ``default`` free camera the
-            MuJoCo backend ships. Pass an explicit subset (e.g.
-            ``["camera1", "camera2", "camera3"]``) to scope a
-            policy-specific dataset to exactly the views the policy
-            declares and keep the stray ``default`` view out of
-            ``observation.images.*``.
+        dataset_cameras: Camera names to record into the dataset.
+            When set, forwarded as ``start_recording(cameras=...)``
+            (a MuJoCo-backend feature) to scope a policy-specific
+            dataset to exactly the views the policy declares (e.g.
+            ``["camera1", "camera2", "camera3"]``) and keep the
+            implicit ``default`` free camera out of
+            ``observation.images.*``. When ``None`` (default) no
+            ``cameras`` kwarg is forwarded at all, so every scene
+            camera is recorded and the call stays backend-agnostic
+            across the MuJoCo and Newton engines.
         seed: Master RNG seed. Each episode derives a deterministic
             offset so rollouts are reproducible within a process.
         policy_kwargs: Optional per-call goal payload forwarded to
@@ -234,14 +235,24 @@ def run_policy(
                 "expose .start_recording(). Install the [lerobot] extra or pass "
                 "dataset_root=None for a recording-less rollout."
             )
-        start_result = simulation.start_recording(
+        # Only forward ``cameras`` when the caller asked for a subset. The
+        # kwarg is MuJoCo-only (``simulation/mujoco/recording.py``); the Newton
+        # backend's ``start_recording`` takes no ``cameras`` and no ``**kwargs``
+        # catch-all, so an unconditional ``cameras=`` would raise an uncaught
+        # ``TypeError`` out of this backend-agnostic tool - a regression even
+        # when ``dataset_cameras`` is omitted (it would still forward
+        # ``cameras=None``). Gating on ``is not None`` keeps the default path
+        # byte-for-byte identical to pre-feature behaviour on every backend.
+        start_kwargs: dict[str, Any] = dict(
             repo_id=dataset_repo_id,
             task=dataset_task,
             fps=dataset_fps,
             root=dataset_root,
             overwrite=True,
-            cameras=dataset_cameras,
         )
+        if dataset_cameras is not None:
+            start_kwargs["cameras"] = dataset_cameras
+        start_result = simulation.start_recording(**start_kwargs)
         if start_result.get("status") != "success":
             # Surface the engine's own error verbatim - it already explains
             # missing extras, world not loaded, etc.

--- a/tests/tools/test_run_policy.py
+++ b/tests/tools/test_run_policy.py
@@ -496,3 +496,43 @@ class TestCorruptParquetTruth:
         assert any("info.json missing" in w for w in payload["warnings"])
         # Cannot confirm the count -> status must not be a false OK.
         assert result["status"] == "error"
+
+
+class TestDatasetCameraScoping:
+    """Pins that ``run_policy`` can scope which cameras land in the dataset.
+
+    The MuJoCo backend's ``start_recording`` accepts a ``cameras`` subset so a
+    policy-specific dataset only carries the views the policy declares (e.g.
+    SmolVLA's ``camera1/2/3``) and excludes the implicit ``default`` free
+    camera every scene ships. Before this contract, ``run_policy`` - the
+    recording entry point that owns the ``start_recording`` -> ``stop_recording``
+    cycle - had no way to forward that subset, so every recorded dataset was
+    forced to include the stray ``default`` view in ``observation.images.*``.
+    """
+
+    def test_forwards_dataset_cameras_to_start_recording(self, tmp_path: Path) -> None:
+        sim = _FakeSim()
+        ds = tmp_path / "ds"
+        _write_info_json(ds, total_episodes=1, total_frames=12)
+        result = run_policy(
+            sim,
+            policy_provider="mock",
+            n_episodes=1,
+            n_steps=12,
+            dataset_root=str(ds),
+            dataset_cameras=["camera1", "camera2", "camera3"],
+        )
+        assert result["status"] == "success"
+        assert len(sim.start_recording_calls) == 1
+        assert sim.start_recording_calls[0]["cameras"] == ["camera1", "camera2", "camera3"]
+
+    def test_dataset_cameras_defaults_to_none(self, tmp_path: Path) -> None:
+        """Default (no scoping) forwards ``cameras=None`` so the backend keeps
+        its record-every-camera behaviour - the opt-in subset never changes
+        the default."""
+        sim = _FakeSim()
+        ds = tmp_path / "ds"
+        _write_info_json(ds, total_episodes=1, total_frames=6)
+        run_policy(sim, n_episodes=1, n_steps=6, dataset_root=str(ds))
+        assert len(sim.start_recording_calls) == 1
+        assert sim.start_recording_calls[0]["cameras"] is None

--- a/tests/tools/test_run_policy.py
+++ b/tests/tools/test_run_policy.py
@@ -83,6 +83,41 @@ class _FakeSim:
         return _ok_rollout("recording stopped")
 
 
+class _CameraslessSim:
+    """Simulation stand-in whose ``start_recording`` has NO ``cameras``
+    parameter and NO ``**kwargs`` catch-all - mirroring the Newton backend
+    (``strands_robots/simulation/newton/recording.py``). Forwarding an
+    unexpected ``cameras=`` kwarg here raises ``TypeError``, which is exactly
+    the crash this fake exists to pin against.
+    """
+
+    def __init__(self) -> None:
+        self.run_policy_calls: list[dict[str, Any]] = []
+        self.start_recording_calls: int = 0
+        self.stop_recording_calls: int = 0
+
+    def run_policy(self, **kwargs: Any) -> dict[str, Any]:
+        self.run_policy_calls.append(kwargs)
+        return _ok_rollout(f"rollout {len(self.run_policy_calls)}")
+
+    def start_recording(
+        self,
+        repo_id: str = "local/sim_recording",
+        task: str = "",
+        fps: int = 30,
+        root: str | None = None,
+        push_to_hub: bool = False,
+        vcodec: str = "libsvtav1",
+        overwrite: bool = False,
+    ) -> dict[str, Any]:
+        self.start_recording_calls += 1
+        return _ok_rollout("recording started")
+
+    def stop_recording(self, **kwargs: Any) -> dict[str, Any]:
+        self.stop_recording_calls += 1
+        return _ok_rollout("recording stopped")
+
+
 class _NoRecordingSim:
     """Simulation stand-in WITHOUT recording surface - exercises the
     ``hasattr`` guard in run_policy."""
@@ -526,13 +561,31 @@ class TestDatasetCameraScoping:
         assert len(sim.start_recording_calls) == 1
         assert sim.start_recording_calls[0]["cameras"] == ["camera1", "camera2", "camera3"]
 
-    def test_dataset_cameras_defaults_to_none(self, tmp_path: Path) -> None:
-        """Default (no scoping) forwards ``cameras=None`` so the backend keeps
-        its record-every-camera behaviour - the opt-in subset never changes
-        the default."""
+    def test_dataset_cameras_omitted_forwards_no_cameras_kwarg(self, tmp_path: Path) -> None:
+        """Default (no scoping) forwards NO ``cameras`` kwarg at all so the
+        backend keeps its record-every-camera behaviour - the opt-in subset
+        never touches the default path. Forwarding ``cameras=None`` would crash
+        any backend (e.g. Newton) whose ``start_recording`` has no ``cameras``
+        parameter, so the kwarg must be entirely absent when unset."""
         sim = _FakeSim()
         ds = tmp_path / "ds"
         _write_info_json(ds, total_episodes=1, total_frames=6)
         run_policy(sim, n_episodes=1, n_steps=6, dataset_root=str(ds))
         assert len(sim.start_recording_calls) == 1
-        assert sim.start_recording_calls[0]["cameras"] is None
+        assert "cameras" not in sim.start_recording_calls[0]
+
+    def test_omitted_dataset_cameras_does_not_crash_camerasless_backend(self, tmp_path: Path) -> None:
+        """Regression: a backend whose ``start_recording`` has no ``cameras``
+        parameter and no ``**kwargs`` catch-all (mirroring the Newton backend,
+        ``simulation/newton/recording.py``) must record cleanly when
+        ``dataset_cameras`` is omitted. The pre-fix code forwarded
+        ``cameras=None`` unconditionally - before the ``try:`` block - so the
+        resulting ``TypeError`` propagated uncaught out of this backend-agnostic
+        tool, violating the 'return error dicts, never raise' handler contract.
+        """
+        sim = _CameraslessSim()
+        ds = tmp_path / "ds"
+        _write_info_json(ds, total_episodes=1, total_frames=6)
+        result = run_policy(sim, n_episodes=1, n_steps=6, dataset_root=str(ds))
+        assert result["status"] == "success"
+        assert sim.start_recording_calls == 1


### PR DESCRIPTION
## Problem

`Simulation.start_recording` already accepts a `cameras=[...]` subset so a policy-specific dataset records exactly the views the policy declares. But the `run_policy` tool — which owns the `start_recording -> rollout -> stop_recording` cycle so callers (and agents) never improvise the recording lifecycle — had no way to forward that subset. As a result every dataset recorded through the tool was forced to include the implicit `default` free camera the MuJoCo backend ships, even when the caller added a policy-specific rig.

Concretely, recording a SmolVLA rollout (which declares exactly `observation.images.camera1/camera2/camera3`) through `run_policy` produced a dataset with a fourth, unrequested `observation.images.default` image feature and its own MP4 stream — bloating every episode and feeding training a feature the policy never declared.

## Change

Add a `dataset_cameras: list[str] | None = None` parameter to the `run_policy` tool. The `cameras` subset is a MuJoCo-backend feature, so the kwarg is forwarded to `start_recording(cameras=...)` **only when `dataset_cameras is not None`**. When omitted (the default), no `cameras` kwarg is forwarded at all — keeping the call byte-for-byte identical to pre-feature behaviour on every backend (MuJoCo and Newton). This is purely additive and backend-agnostic on the default path.

```python
run_policy(
    simulation=sim, robot_name="so101", policy_provider="lerobot_local",
    instruction="pick up the cube", n_episodes=1, dataset_root="/tmp/ds",
    dataset_cameras=["camera1", "camera2", "camera3"],  # drops the implicit 'default'
)
```

## Tests

`TestDatasetCameraScoping` in `tests/tools/test_run_policy.py` (unit-level, no MuJoCo/LeRobot):
- `test_forwards_dataset_cameras_to_start_recording` — asserts the subset reaches `start_recording(cameras=...)`.
- `test_dataset_cameras_omitted_forwards_no_cameras_kwarg` — pins that the default forwards **no** `cameras` kwarg (record-every-camera, backend-agnostic).
- `test_omitted_dataset_cameras_does_not_crash_camerasless_backend` — drives `run_policy` against `_CameraslessSim`, a strict-signature fake mirroring the Newton `start_recording` (no `cameras`, no `**kwargs`), and asserts a clean `success` payload.

The two default-path assertions fail against the pre-gate commit with `TypeError: ... unexpected keyword argument 'cameras'` and pass after the gate. Full `tests/tools/test_run_policy.py` (28 tests) green. `ruff check`, `ruff format --check`, and `mypy` clean on the touched files.

## Verification (rollout in MuJoCo sim, headless EGL)

Real SmolVLA (`lerobot/smolvla_base`) rollout on a simulated SO-101 with the 3-camera rig, recorded through `run_policy`:

- Without `dataset_cameras`: dataset image features = `[default, camera1, camera2, camera3]`, 4 per-camera MP4s.
- With `dataset_cameras=["camera1","camera2","camera3"]`: dataset image features = `[camera1, camera2, camera3]`, 3 per-camera MP4s — the stray `default` view is gone. Dataset reopens via `LeRobotDataset` with 16 non-empty frames, `observation.state`/`action` dim 6, and one non-empty MP4 per camera.

Front-3/4 (`camera1`) + top-down (`camera2`) views of the scoped rollout:

![SmolVLA SO-101 rollout](https://github.com/cagataycali/robots/releases/download/artifact-run-policy-cameras/smolvla_rollout.gif)

## Docs

`docs/recording.md` ("Selecting which cameras to record") documents the tool-level `dataset_cameras` passthrough, noting the subset is MuJoCo-only and that the default path stays backend-agnostic.

---

## Round 2 changelog

- **Gate `cameras` forwarding (review feedback).** The first commit forwarded `cameras=dataset_cameras` unconditionally — before the `try:` block — to `start_recording()`. Since the kwarg only exists on the MuJoCo backend (the Newton `start_recording` has no `cameras` and no `**kwargs`), this raised an uncaught `TypeError` out of the backend-agnostic tool, violating the handler contract (return error dicts, never raise). It was also a regression with `dataset_cameras` omitted, since the tool still forwarded `cameras=None`. Now `start_kwargs` is built without `cameras` and the key is added only when `dataset_cameras is not None`.
- **Regression coverage.** Added `_CameraslessSim` (strict Newton-style `start_recording` signature) and `test_omitted_dataset_cameras_does_not_crash_camerasless_backend`; renamed the default test to `test_dataset_cameras_omitted_forwards_no_cameras_kwarg`, now asserting the kwarg is **absent** rather than `None`. Both fail pre-gate with the exact `TypeError` and pass after.
- **Docs/docstring** updated to state the subset is MuJoCo-only and the default stays backend-agnostic across MuJoCo and Newton.

---

## Round 3 changelog

- **Rebased onto main (no functional change).** A sibling docs change landed on main that added a "Where the dataset is written (`root` / `overwrite`)" section to `docs/recording.md` in the same region this PR appends its `dataset_cameras` section, producing a docs-only merge conflict. Resolved by keeping both sections in logical order (write-location first, then the tool-level `dataset_cameras` passthrough). No code or test changes — `run_policy.py` and `test_run_policy.py` rebased without conflict; full `tests/tools/test_run_policy.py` (28 tests) re-run green post-rebase.