### PR TITLE
test(utils): cover process_rss_mb resource fallback + None path

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from strands_robots.utils import require_optional, require_optionals
+from strands_robots.utils import process_rss_mb, require_optional, require_optionals
 
 
 class TestRequireOptional:
@@ -266,3 +266,55 @@ class TestPathResolution:
         # joined under the assets dir.
         assert result == tmp_path / "home" / "models" / "policy.pt"
         assert not str(result).startswith(str(tmp_path / "assets"))
+
+
+class TestProcessRssMb:
+    """Tests for process_rss_mb resident-memory telemetry helper.
+
+    Covers all three resolution paths: psutil (preferred), the
+    resource.getrusage fallback (with Linux/macOS unit normalisation), and the
+    None result when neither source is available.
+    """
+
+    def test_psutil_path_returns_positive_float(self):
+        """With psutil available, returns this process's current RSS in MB."""
+        rss = process_rss_mb()
+        assert isinstance(rss, float)
+        assert rss > 0.0
+
+    def test_resource_fallback_linux_normalises_kilobytes(self, monkeypatch):
+        """psutil absent + Linux: ru_maxrss is kilobytes, divided by 1024 -> MB."""
+        import sys
+        import types
+
+        monkeypatch.setitem(sys.modules, "psutil", None)
+        fake_resource = types.ModuleType("resource")
+        fake_resource.RUSAGE_SELF = 0
+        fake_resource.getrusage = lambda _who: types.SimpleNamespace(ru_maxrss=2048)
+        monkeypatch.setitem(sys.modules, "resource", fake_resource)
+        monkeypatch.setattr(sys, "platform", "linux")
+
+        assert process_rss_mb() == pytest.approx(2.0)
+
+    def test_resource_fallback_macos_normalises_bytes(self, monkeypatch):
+        """psutil absent + macOS: ru_maxrss is bytes, divided by 1024**2 -> MB."""
+        import sys
+        import types
+
+        monkeypatch.setitem(sys.modules, "psutil", None)
+        fake_resource = types.ModuleType("resource")
+        fake_resource.RUSAGE_SELF = 0
+        fake_resource.getrusage = lambda _who: types.SimpleNamespace(ru_maxrss=2 * 1024 * 1024)
+        monkeypatch.setitem(sys.modules, "resource", fake_resource)
+        monkeypatch.setattr(sys, "platform", "darwin")
+
+        assert process_rss_mb() == pytest.approx(2.0)
+
+    def test_returns_none_when_no_source_available(self, monkeypatch):
+        """Neither psutil nor resource importable: returns None, not a misleading 0."""
+        import sys
+
+        monkeypatch.setitem(sys.modules, "psutil", None)
+        monkeypatch.setitem(sys.modules, "resource", None)
+
+        assert process_rss_mb() is None


### PR DESCRIPTION
## Problem

`process_rss_mb()` in `strands_robots/utils.py` powers the `policy_resident_rss_mb` telemetry that callers use to confirm a heavy VLA checkpoint stays resident across a multi-episode loop. Only its preferred psutil branch was exercised; the `resource.getrusage` fallback (used when psutil is absent) and the `None` result (when neither source is available) had no test coverage. That left the platform-specific unit normalisation (Linux reports `ru_maxrss` in kilobytes, macOS in bytes) unverified - a silent wrong-by-1024x regression there would have shipped undetected.

## Change

Add `TestProcessRssMb` covering all three resolution paths, asserting observable outputs rather than internals:

- psutil path returns a positive float (this process's current RSS in MB).
- psutil absent + `sys.platform == 'linux'`: `ru_maxrss` kilobytes normalised by /1024 -> MB.
- psutil absent + `sys.platform == 'darwin'`: `ru_maxrss` bytes normalised by /1024**2 -> MB.
- Neither psutil nor `resource` importable: returns `None` (not a misleading `0`).

The import-failure paths are simulated with `monkeypatch.setitem(sys.modules, name, None)` (forces `ImportError` on the in-function `import`), and a fake `resource` module supplies a deterministic `ru_maxrss` so the unit-normalisation arithmetic is checked exactly.

## Tests

`strands_robots/utils.py` coverage 89% -> 100% (lines 261-273 previously uncovered). 4 new tests pass, full `tests/test_utils.py` green (34 passed). Lint/format/mypy clean on `strands_robots tests tests_integ`.