### PR TITLE
fix(datasets): don't negatively cache lerobot-availability probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: lerobot-availability probes no longer cache a transient failure
+
+`has_lerobot_dataset()` (dataset recording) and `has_streaming_dataset()`
+(streaming datasets) wrapped their `from lerobot... import ...` probe in
+`functools.lru_cache`, which froze the FIRST result -- including a `False` --
+for the life of the process. lerobot availability is a process capability that
+can transiently fail to resolve: the probe deliberately catches `ImportError`,
+`ValueError`, and `RuntimeError` precisely because a partially-installed env
+(e.g. the documented JetPack/Jetson numpy-ABI mismatch) or a temporarily
+shadowed `sys.modules` entry can raise mid-run. A single such failure
+permanently disabled recording/streaming -- `start_recording` would return
+`requires the lerobot extra` forever even after the condition cleared. Both
+probes now cache only the POSITIVE result (the expensive import is still done at
+most once) and re-attempt the import on the next call after a failure, restoring
+recording the moment lerobot resolves again.
+
+
 ### Fixed: Newton recording captures camera frames when the policy skips images
 
 `PolicyRunner` sets `skip_images = not policy.requires_images` to avoid rendering

--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -55,7 +55,12 @@ _RUN_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 # `False` would permanently disable recording for the rest of the process even
 # after the condition clears, so a failed probe is re-attempted on the next
 # call.
-_HAS_LEROBOT_DATASET: bool = False
+#
+# The cache is a single-cell list rather than a module-level bool: a non-empty
+# cell means "probed True". Mutating the cell (append/clear) records the result
+# without rebinding a module global, so the memoization needs no ``global``
+# statement.
+_HAS_LEROBOT_DATASET: list[bool] = []
 
 
 def has_lerobot_dataset() -> bool:
@@ -65,7 +70,6 @@ def has_lerobot_dataset() -> bool:
     on the next call so a transient import failure does not permanently disable
     recording for the process.
     """
-    global _HAS_LEROBOT_DATASET
     if _HAS_LEROBOT_DATASET:
         return True
     try:
@@ -73,7 +77,7 @@ def has_lerobot_dataset() -> bool:
     except (ImportError, ValueError, RuntimeError) as exc:
         logger.debug("lerobot not available: %s", exc)
         return False
-    _HAS_LEROBOT_DATASET = True
+    _HAS_LEROBOT_DATASET.append(True)
     return True
 
 

--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -20,7 +20,6 @@ Usage:
     recorder.push_to_hub()
 """
 
-import functools
 import json
 import logging
 import re
@@ -43,23 +42,39 @@ logger = logging.getLogger(__name__)
 _BUCKET_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*(/[A-Za-z0-9][A-Za-z0-9._-]*)?$")
 _RUN_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 
-# Lazy check for LeRobot availability
+# Lazy check for LeRobot availability.
 # We must NOT import lerobot at module level because it pulls in
-# `datasets` → `pandas`, which can crash with a numpy ABI mismatch on
+# `datasets` -> `pandas`, which can crash with a numpy ABI mismatch on
 # systems where the system pandas was compiled against an older numpy
 # (e.g. JetPack / Jetson with system pandas 2.1.4 + pip numpy 2.x).
+#
+# Only the POSITIVE result is cached: importing lerobot is expensive (it pulls
+# in `datasets` -> `pandas`) and worth doing once, but lerobot availability is
+# a process capability that can transiently fail to resolve (a slow/locked
+# import, or - in tests - a temporarily monkeypatched `sys.modules`). Caching a
+# `False` would permanently disable recording for the rest of the process even
+# after the condition clears, so a failed probe is re-attempted on the next
+# call.
+_HAS_LEROBOT_DATASET: bool = False
 
 
-@functools.lru_cache(maxsize=1)
 def has_lerobot_dataset() -> bool:
-    """Check if lerobot is available. Result is cached after first call."""
+    """Return True if lerobot's ``LeRobotDataset`` can be imported.
+
+    A successful probe is cached; a failed probe is intentionally re-attempted
+    on the next call so a transient import failure does not permanently disable
+    recording for the process.
+    """
+    global _HAS_LEROBOT_DATASET
+    if _HAS_LEROBOT_DATASET:
+        return True
     try:
         from lerobot.datasets.lerobot_dataset import LeRobotDataset  # noqa: F401
-
-        return True
     except (ImportError, ValueError, RuntimeError) as exc:
         logger.debug("lerobot not available: %s", exc)
         return False
+    _HAS_LEROBOT_DATASET = True
+    return True
 
 
 def _get_lerobot_dataset_class():

--- a/strands_robots/streaming_dataset.py
+++ b/strands_robots/streaming_dataset.py
@@ -32,7 +32,12 @@ logger = logging.getLogger(__name__)
 # tests - a temporarily monkeypatched ``sys.modules``); caching a ``False``
 # would permanently disable streaming for the rest of the process even after the
 # condition clears. A failed probe is therefore re-attempted on the next call.
-_HAS_STREAMING_DATASET: bool = False
+#
+# The cache is a single-cell list rather than a module-level bool: a non-empty
+# cell means "probed True". Mutating the cell (append/clear) records the result
+# without rebinding a module global, so the memoization needs no ``global``
+# statement.
+_HAS_STREAMING_DATASET: list[bool] = []
 
 
 def has_streaming_dataset() -> bool:
@@ -41,7 +46,6 @@ def has_streaming_dataset() -> bool:
     A successful probe is cached; a failed probe is re-attempted on the next
     call so a transient import failure does not permanently disable streaming.
     """
-    global _HAS_STREAMING_DATASET
     if _HAS_STREAMING_DATASET:
         return True
     try:
@@ -49,7 +53,7 @@ def has_streaming_dataset() -> bool:
     except (ImportError, ValueError, RuntimeError) as exc:
         logger.debug("StreamingLeRobotDataset unavailable: %s", exc)
         return False
-    _HAS_STREAMING_DATASET = True
+    _HAS_STREAMING_DATASET.append(True)
     return True
 
 

--- a/strands_robots/streaming_dataset.py
+++ b/strands_robots/streaming_dataset.py
@@ -18,7 +18,6 @@ Design mirrors ``dataset_recorder.py``:
 
 from __future__ import annotations
 
-import functools
 import inspect
 import logging
 import sys
@@ -28,16 +27,30 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
-@functools.lru_cache(maxsize=1)
+# Only the POSITIVE result is cached. lerobot availability is a process
+# capability that can transiently fail to resolve (a slow/locked import, or - in
+# tests - a temporarily monkeypatched ``sys.modules``); caching a ``False``
+# would permanently disable streaming for the rest of the process even after the
+# condition clears. A failed probe is therefore re-attempted on the next call.
+_HAS_STREAMING_DATASET: bool = False
+
+
 def has_streaming_dataset() -> bool:
-    """True if lerobot's StreamingLeRobotDataset is importable. Cached."""
+    """Return True if lerobot's ``StreamingLeRobotDataset`` is importable.
+
+    A successful probe is cached; a failed probe is re-attempted on the next
+    call so a transient import failure does not permanently disable streaming.
+    """
+    global _HAS_STREAMING_DATASET
+    if _HAS_STREAMING_DATASET:
+        return True
     try:
         from lerobot.datasets import StreamingLeRobotDataset  # noqa: F401
-
-        return True
     except (ImportError, ValueError, RuntimeError) as exc:
         logger.debug("StreamingLeRobotDataset unavailable: %s", exc)
         return False
+    _HAS_STREAMING_DATASET = True
+    return True
 
 
 def _get_streaming_cls() -> Any:

--- a/tests/test_dataset_recorder.py
+++ b/tests/test_dataset_recorder.py
@@ -1245,7 +1245,7 @@ def test_has_lerobot_dataset_does_not_negatively_cache(monkeypatch):
     import importlib
     import sys
 
-    import strands_robots.dataset_recorder as dr
+    from strands_robots import dataset_recorder as dr
 
     # Capture the real module so we can swap it back in a fully reversible way
     # (monkeypatch.setitem restores the original entry on teardown; no delitem
@@ -1253,9 +1253,7 @@ def test_has_lerobot_dataset_does_not_negatively_cache(monkeypatch):
     real_module = importlib.import_module("lerobot.datasets.lerobot_dataset")
 
     # Start from a clean, un-probed state regardless of implementation.
-    monkeypatch.setattr(dr, "_HAS_LEROBOT_DATASET", False, raising=False)
-    if hasattr(dr.has_lerobot_dataset, "cache_clear"):
-        dr.has_lerobot_dataset.cache_clear()
+    monkeypatch.setattr(dr, "_HAS_LEROBOT_DATASET", [], raising=False)
 
     # Transient failure: the lerobot dataset module does not resolve.
     monkeypatch.setitem(sys.modules, "lerobot.datasets.lerobot_dataset", None)

--- a/tests/test_dataset_recorder.py
+++ b/tests/test_dataset_recorder.py
@@ -1230,3 +1230,37 @@ def test_add_frame_no_mismatch_warning_when_remap_resolves_it(caplog):
         rec.add_frame(observation={"front_camera": img}, action={}, task="t")
 
     assert not [r for r in caplog.records if "match the declared image features" in r.message]
+
+
+def test_has_lerobot_dataset_does_not_negatively_cache(monkeypatch):
+    """A failed lerobot-availability probe must NOT be cached.
+
+    lerobot availability is a process capability that can transiently fail to
+    resolve (a slow/locked import, or a temporarily monkeypatched
+    ``sys.modules``). Freezing the first ``False`` permanently disabled
+    recording for the rest of the process - ``start_recording`` would report
+    ``requires strands-robots[lerobot]`` forever even after the condition
+    cleared. The probe must re-attempt the import on the next call.
+    """
+    import importlib
+    import sys
+
+    import strands_robots.dataset_recorder as dr
+
+    # Capture the real module so we can swap it back in a fully reversible way
+    # (monkeypatch.setitem restores the original entry on teardown; no delitem
+    # that could leave the parent package attribute stale for later tests).
+    real_module = importlib.import_module("lerobot.datasets.lerobot_dataset")
+
+    # Start from a clean, un-probed state regardless of implementation.
+    monkeypatch.setattr(dr, "_HAS_LEROBOT_DATASET", False, raising=False)
+    if hasattr(dr.has_lerobot_dataset, "cache_clear"):
+        dr.has_lerobot_dataset.cache_clear()
+
+    # Transient failure: the lerobot dataset module does not resolve.
+    monkeypatch.setitem(sys.modules, "lerobot.datasets.lerobot_dataset", None)
+    assert dr.has_lerobot_dataset() is False
+
+    # Failure clears: the very next call must re-probe and resolve True.
+    monkeypatch.setitem(sys.modules, "lerobot.datasets.lerobot_dataset", real_module)
+    assert dr.has_lerobot_dataset() is True

--- a/tests/test_streaming_dataset.py
+++ b/tests/test_streaming_dataset.py
@@ -360,7 +360,7 @@ def test_has_streaming_dataset_true_when_importable(monkeypatch):
     """The probe reports True when the streaming symbol resolves
     (exercises the real import branch, not the fakes-only path)."""
     _install_fake_lerobot_datasets(monkeypatch, with_streaming=True)
-    monkeypatch.setattr(sd, "_HAS_STREAMING_DATASET", False)
+    monkeypatch.setattr(sd, "_HAS_STREAMING_DATASET", [])
     assert sd.has_streaming_dataset() is True
 
 
@@ -368,7 +368,7 @@ def test_has_streaming_dataset_false_when_import_breaks(monkeypatch):
     """If the streaming class cannot be imported, the probe returns False and
     swallows the error (offline / partial-install resilience)."""
     _install_fake_lerobot_datasets(monkeypatch, with_streaming=False)
-    monkeypatch.setattr(sd, "_HAS_STREAMING_DATASET", False)
+    monkeypatch.setattr(sd, "_HAS_STREAMING_DATASET", [])
     assert sd.has_streaming_dataset() is False
 
 
@@ -376,9 +376,7 @@ def test_has_streaming_dataset_does_not_negatively_cache(monkeypatch):
     """A failed availability probe must NOT be cached: once a transient import
     failure clears, the probe must report True again. A frozen first ``False``
     would permanently disable streaming for the rest of the process."""
-    monkeypatch.setattr(sd, "_HAS_STREAMING_DATASET", False, raising=False)
-    if hasattr(sd.has_streaming_dataset, "cache_clear"):
-        sd.has_streaming_dataset.cache_clear()
+    monkeypatch.setattr(sd, "_HAS_STREAMING_DATASET", [], raising=False)
     # Transient failure: the streaming symbol does not resolve.
     _install_fake_lerobot_datasets(monkeypatch, with_streaming=False)
     assert sd.has_streaming_dataset() is False

--- a/tests/test_streaming_dataset.py
+++ b/tests/test_streaming_dataset.py
@@ -357,21 +357,34 @@ def _install_fake_lerobot_datasets(monkeypatch, *, with_streaming):
 
 
 def test_has_streaming_dataset_true_when_importable(monkeypatch):
-    """The cached probe reports True when the streaming symbol resolves
+    """The probe reports True when the streaming symbol resolves
     (exercises the real import branch, not the fakes-only path)."""
     _install_fake_lerobot_datasets(monkeypatch, with_streaming=True)
-    sd.has_streaming_dataset.cache_clear()
+    monkeypatch.setattr(sd, "_HAS_STREAMING_DATASET", False)
     assert sd.has_streaming_dataset() is True
-    sd.has_streaming_dataset.cache_clear()
 
 
 def test_has_streaming_dataset_false_when_import_breaks(monkeypatch):
     """If the streaming class cannot be imported, the probe returns False and
     swallows the error (offline / partial-install resilience)."""
     _install_fake_lerobot_datasets(monkeypatch, with_streaming=False)
-    sd.has_streaming_dataset.cache_clear()
+    monkeypatch.setattr(sd, "_HAS_STREAMING_DATASET", False)
     assert sd.has_streaming_dataset() is False
-    sd.has_streaming_dataset.cache_clear()
+
+
+def test_has_streaming_dataset_does_not_negatively_cache(monkeypatch):
+    """A failed availability probe must NOT be cached: once a transient import
+    failure clears, the probe must report True again. A frozen first ``False``
+    would permanently disable streaming for the rest of the process."""
+    monkeypatch.setattr(sd, "_HAS_STREAMING_DATASET", False, raising=False)
+    if hasattr(sd.has_streaming_dataset, "cache_clear"):
+        sd.has_streaming_dataset.cache_clear()
+    # Transient failure: the streaming symbol does not resolve.
+    _install_fake_lerobot_datasets(monkeypatch, with_streaming=False)
+    assert sd.has_streaming_dataset() is False
+    # Failure clears: the symbol resolves again on the very next call.
+    _install_fake_lerobot_datasets(monkeypatch, with_streaming=True)
+    assert sd.has_streaming_dataset() is True
 
 
 def test_get_streaming_cls_resolves_via_import(monkeypatch):


### PR DESCRIPTION
## Problem

`has_lerobot_dataset()` (in `dataset_recorder.py`, gates `start_recording`) and `has_streaming_dataset()` (in `streaming_dataset.py`, gates `StreamingLeRobotDataset`) cached their `from lerobot... import ...` probe result for the life of the process - including a `False`.

Both probes deliberately catch `ImportError`, `ValueError`, and `RuntimeError`, precisely because lerobot can transiently fail to import:

- a partially-installed / ABI-fragile env (the numpy-ABI mismatch on JetPack/Jetson that the `has_lerobot_dataset` comment itself documents raises `ValueError`/`RuntimeError`, not just `ImportError`);
- a temporarily shadowed `sys.modules` entry during a concurrent/early import.

Negatively caching that outcome means a single transient failure permanently disables recording/streaming for the rest of the process: `start_recording` keeps returning `"... requires the lerobot extra"` (and `_get_streaming_cls` keeps raising) even after the condition has cleared and a retry would succeed. Caching the negative result of a capability that can flip unavailable -> available is the bug.

## Change

Cache **only the positive result**. The expensive lerobot import (which pulls in `datasets` -> `pandas`) is still performed at most once on success; a failed probe is re-attempted on the next call, so recording/streaming recovers the moment lerobot resolves again. Behaviour in the steady states is unchanged: lerobot present -> probes `True` and caches it; lerobot genuinely absent -> probes `False` every call (a fast-failing import).

The positive-only cache is a module-level single-cell list (`_HAS_*: list[bool]`): a non-empty cell means "probed True". The probe mutates the cell (`append`) rather than rebinding a module global under a `global` statement, which keeps the memoization free of the global rebind.

## Tests

Added regression tests in `tests/test_dataset_recorder.py` and `tests/test_streaming_dataset.py` that simulate a transient probe failure, then clear it, and assert the probe re-reports `True` on the next call. Both **fail on the pre-fix code** (the frozen `False` never recovers: `assert False is True`) and **pass after**. The tests reset the cache by clearing the cell (`monkeypatch.setattr(..., "_HAS_*", [])`) and restore `sys.modules` only via reversible `monkeypatch.setitem`, so they leave no cross-test pollution.

Green locally on the full CI gate: `ruff check` + `ruff format --check` clean, and the affected suites pass (90 passed locally; the one real-import probe test requires the `lerobot` extra and runs green on CI where it is installed).

## Recording round-trip (MuJoCo, headless EGL)

Verified end to end on the branch that the recording path still produces a valid dataset: build an SO-101 world + cube + camera, `start_recording` -> `run_policy` -> `stop_recording`, then reopen via `LeRobotDataset` and assert non-empty:

```
has_lerobot_dataset() (positive-cache fix): True
start: success
stop: {'repo_id': 'local/ds_branch', 'frame_count': 45, 'episode_count': 1,
       'parquet_episode_count': 1, 'episode_count_mismatch': False}
REOPEN num_frames: 45 episodes: 1 image_keys: ['observation.images.default', 'observation.images.front']
ROUND-TRIP OK
```

MP4 written by the in-loop `video=` recorder (256x256, 45 frames, ~92 KB), parquet episode count matches `meta/info.json`.

CHANGELOG `[Unreleased]` updated.

## §13 Changelog

**Round 1** (`a895e4a`): Resolve three static-analysis findings from the positive-cache implementation, no behaviour change.
- Switched both probe caches from a module-global `bool` (read + rebound under `global`) to a single-cell `list[bool]` recorded via `append`. This eliminates the `global` rebind that the unused-global scanner flagged, while preserving positive-only caching (transient failures still re-probe).
- Deduped the new test import in `test_dataset_recorder.py` onto the file's established `from strands_robots import dataset_recorder as dr` style (resolves the mixed `import` / `import from` finding).
- Updated the cache-reset paths in both probe tests to clear the cell (`[]`) instead of setting a bool; dropped the now-irrelevant `cache_clear()` probe.