### PR TITLE
test(simulation): cover mujoco noise-filter stderr-resilience paths

### DIFF
--- a/tests/simulation/mujoco/test_backend.py
+++ b/tests/simulation/mujoco/test_backend.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import builtins
 import importlib.util
+import io
 import os
 import subprocess
 import sys
@@ -347,3 +348,61 @@ class TestMujocoNoiseFilter:
         os.close(r_fd)
         assert "Attach conflict" not in output
         assert "FATAL: actuator index out of range" in output
+
+    def test_passthrough_when_stderr_has_no_dupable_fileno(self, monkeypatch):
+        """Replaced stderr without a real fd degrades to a transparent passthrough.
+
+        Under pytest capsys, Jupyter, or any wrapper that swaps ``sys.stderr``
+        for an object without a dup-able file descriptor, the fd-2 capture
+        cannot run. The filter must still yield and never raise; with no fd
+        capture there is nothing to scrub, so every line reaches the
+        replacement stream unfiltered.
+        """
+        monkeypatch.delenv("STRANDS_ROBOTS_VERBOSE_MUJOCO", raising=False)
+        buf = io.StringIO()  # .fileno() raises io.UnsupportedOperation
+        monkeypatch.setattr(sys, "stderr", buf)
+
+        with backend_mod.filter_mujoco_attach_noise():
+            print("Attach conflict when attaching scene", file=sys.stderr)
+            print("FATAL: real error", file=sys.stderr)
+
+        out = buf.getvalue()
+        assert "Attach conflict" in out
+        assert "FATAL: real error" in out
+
+    def test_detached_stderr_on_teardown_does_not_mask_body(self, monkeypatch):
+        """A stderr whose flush/write fail during teardown is swallowed.
+
+        The fd-2 capture path runs (the stream exposes a real fileno), but by
+        the time the captured output is replayed the stream is detached, so its
+        ``flush`` and ``write`` raise. The filter must absorb those failures
+        rather than let a dead stderr propagate out of and mask the protected
+        body.
+        """
+        monkeypatch.delenv("STRANDS_ROBOTS_VERBOSE_MUJOCO", raising=False)
+        r_fd, w_fd = os.pipe()
+
+        class _DetachedStderr:
+            """Real fileno (capture runs) but flush/write fail (detached)."""
+
+            def fileno(self):
+                return w_fd
+
+            def flush(self):
+                raise ValueError("stderr detached")
+
+            def write(self, _s):
+                raise ValueError("stderr detached")
+
+        saved_stderr = sys.stderr
+        monkeypatch.setattr(sys, "stderr", _DetachedStderr())
+        try:
+            # Must not raise even though every flush/write on stderr fails.
+            with backend_mod.filter_mujoco_attach_noise():
+                # Emit a real (kept) line on fd 2 so the replay path attempts a
+                # write to the detached stderr.
+                os.write(w_fd, b"FATAL: actuator index out of range\n")
+        finally:
+            monkeypatch.setattr(sys, "stderr", saved_stderr)
+            os.close(r_fd)
+            os.close(w_fd)


### PR DESCRIPTION
## Problem

`filter_mujoco_attach_noise` in `strands_robots.simulation.mujoco.backend` suppresses MuJoCo's benign attach/compile chatter by capturing fd 2. It has two robustness contracts that were unexercised by tests, leaving the defensive teardown branches uncovered (backend.py was at 90%):

1. **No dup-able stderr fd.** When `sys.stderr` is a replaced stream without a real file descriptor (pytest `capsys`, Jupyter, or any wrapper), the fd-2 capture cannot run. The manager must degrade to a transparent passthrough: still yield, never raise, and let output through unscrubbed.
2. **Detached stderr during teardown.** If stderr is detached by the time captured output is replayed, its `flush`/`write` raise. The manager must absorb those failures so a dead stderr never masks the protected body.

Neither path had a regression test, so a refactor could silently turn a captured/detached stderr into a crash that swallows the real work inside the `with` block.

## Change

Add two behavior tests to `TestMujocoNoiseFilter`:

- `test_passthrough_when_stderr_has_no_dupable_fileno` swaps `sys.stderr` for an `io.StringIO` (whose `.fileno()` raises) and asserts the manager yields and passes every line through unfiltered.
- `test_detached_stderr_on_teardown_does_not_mask_body` uses a stream that exposes a real `fileno()` (so the capture path runs) but whose `flush`/`write` raise, and asserts the `with` block completes without propagating the failure.

Both assert observable behavior (output / no-raise), not internal state.

## Tests

`MUJOCO_GL=egl pytest tests/simulation/mujoco/test_backend.py` -> 32 passed. Coverage of `simulation/mujoco/backend.py` rises **90% -> 97%** (covers the no-fileno fallback and the teardown flush/replay-write except paths). Full `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` clean.

Test-only change; no production behavior is modified.