### PR TITLE
fix(simulation): render() honors per-camera configured resolution

### DIFF
--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -366,9 +366,13 @@ class SimEngine(ABC):
     ) -> dict[str, Any]:
         """Render a camera view.
 
-        Returns dict with ``"image"`` key (numpy array, RGB uint8) and
-        optional ``"depth"`` key (float32 depth map). Resolution comes
-        from camera config unless ``width``/``height`` are given.
+        Returns an agent-tool dict with ``status`` and a ``content`` list. On
+        success the content holds an ``image`` block carrying PNG bytes
+        (``{"image": {"format": "png", "source": {"bytes": ...}}}``); the raw
+        RGB ``numpy`` arrays are available per-camera via :meth:`get_observation`.
+        Resolution comes from the named camera's configuration (set via
+        ``add_camera``) unless ``width``/``height`` are given; the free camera
+        and model-only cameras fall back to the engine default.
         """
         ...
 

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -568,15 +568,32 @@ class RenderingMixin:
     def render(
         self, camera_name: str = "default", width: int | None = None, height: int | None = None
     ) -> dict[str, Any]:
-        """Render a camera view as base64 PNG image."""
+        """Render a camera view to a PNG image.
+
+        Returns an agent-tool dict with ``status`` and a ``content`` list; on
+        success the content holds an ``image`` block carrying PNG bytes
+        (``{"image": {"format": "png", "source": {"bytes": ...}}}``) plus a
+        ``json`` block with ``pixel_variance``/``pixel_mean``/``camera``.
+
+        Resolution: when ``width``/``height`` are omitted, the named camera's
+        configured resolution (from ``add_camera``) is used; the free camera and
+        model-only cameras fall back to the engine default. Explicit
+        ``width``/``height`` override the camera config.
+        """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
 
         mj = _ensure_mujoco()
         # treat `None` as "use default", but `0` / negative values must
         # still hit the validator (bool coercion would swallow them silently).
-        w = self.default_width if width is None else width
-        h = self.default_height if height is None else height
+        # When the caller omits a dimension, honor the named camera's CONFIGURED
+        # resolution (set via add_camera(width=, height=)) so render() agrees
+        # with get_observation, which already keys off the per-camera config.
+        # The free camera ("default"/"free") and model-only cameras that have no
+        # SimCamera entry fall back to the engine default.
+        cam_cfg = self._world.cameras.get(camera_name) if camera_name not in (None, "", "default", "free") else None
+        w = (cam_cfg.width if cam_cfg is not None else self.default_width) if width is None else width
+        h = (cam_cfg.height if cam_cfg is not None else self.default_height) if height is None else height
         if err := self._validate_render_dims(w, h):
             return err
 

--- a/tests/simulation/mujoco/test_render_camera_resolution.py
+++ b/tests/simulation/mujoco/test_render_camera_resolution.py
@@ -1,0 +1,99 @@
+"""render() honors a named camera's configured resolution.
+
+A camera added via ``add_camera(width=, height=)`` declares its own resolution.
+``get_observation`` already keys off that per-camera config, but ``render()``
+historically ignored it and fell back to the engine default whenever the caller
+omitted ``width``/``height`` - contradicting its documented contract and
+silently producing a different frame size than the camera (and the recorded
+dataset) used. These tests pin the agreed contract: omitted dims -> the named
+camera's configured resolution; explicit dims -> override; free/unknown camera
+-> engine default.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+_requires_mujoco = pytest.mark.skipif(
+    os.environ.get("CI") == "true" and not os.environ.get("ROBOT_TEST_MUJOCO"),
+    reason="requires OpenGL; opt-in via ROBOT_TEST_MUJOCO=1",
+)
+
+
+def _rendered_size(result: dict) -> tuple[int, int]:
+    """Decode the PNG image block and return its ``(width, height)``."""
+    from PIL import Image
+
+    assert result["status"] == "success", result
+    for block in result["content"]:
+        if "image" in block:
+            png = block["image"]["source"]["bytes"]
+            return Image.open(io.BytesIO(png)).size
+    raise AssertionError(f"no image block in render result: {result}")
+
+
+@_requires_mujoco
+def test_render_uses_camera_configured_resolution() -> None:
+    """Omitted width/height -> the camera's own configured resolution."""
+    os.environ.setdefault("MUJOCO_GL", "glfw")
+    from strands_robots.simulation import Simulation
+
+    sim = Simulation()
+    sim.create_world()
+    # A non-default resolution distinct from the 640x480 engine default.
+    sim.add_camera("cam_hi", position=[0.5, 0.0, 0.4], target=[0.0, 0.0, 0.1], width=320, height=240)
+
+    result = sim.render(camera_name="cam_hi")  # no width/height
+    assert _rendered_size(result) == (320, 240)
+
+
+@_requires_mujoco
+def test_render_explicit_dims_override_camera_config() -> None:
+    """Explicit width/height still win over the camera's configured resolution."""
+    os.environ.setdefault("MUJOCO_GL", "glfw")
+    from strands_robots.simulation import Simulation
+
+    sim = Simulation()
+    sim.create_world()
+    sim.add_camera("cam_hi", position=[0.5, 0.0, 0.4], target=[0.0, 0.0, 0.1], width=320, height=240)
+
+    result = sim.render(camera_name="cam_hi", width=128, height=96)
+    assert _rendered_size(result) == (128, 96)
+
+
+@_requires_mujoco
+def test_render_free_camera_uses_engine_default() -> None:
+    """The free ('default') camera has no SimCamera config -> engine default."""
+    os.environ.setdefault("MUJOCO_GL", "glfw")
+    from strands_robots.simulation import Simulation
+
+    sim = Simulation()
+    sim.create_world()
+
+    result = sim.render(camera_name="default")  # free camera, no config
+    assert _rendered_size(result) == (sim.default_width, sim.default_height)
+
+
+@_requires_mujoco
+def test_render_matches_get_observation_resolution() -> None:
+    """render() and get_observation() agree on a configured camera's frame size."""
+    os.environ.setdefault("MUJOCO_GL", "glfw")
+    import numpy as np
+
+    from strands_robots.simulation import Simulation
+
+    sim = Simulation()
+    sim.create_world()
+    sim.add_robot("arm", data_config="so101", position=[0.0, 0.0, 0.0])
+    sim.add_camera("cam_obs", position=[0.5, 0.0, 0.4], target=[0.0, 0.0, 0.1], width=200, height=160)
+
+    rendered_w, rendered_h = _rendered_size(sim.render(camera_name="cam_obs"))
+    obs = sim.get_observation()
+    arr = np.asarray(obs["cam_obs"])
+    obs_h, obs_w = arr.shape[0], arr.shape[1]
+    assert (rendered_w, rendered_h) == (obs_w, obs_h) == (200, 160)


### PR DESCRIPTION
## Problem

MuJoCo `render()` fell back to the engine default (`640x480`) whenever the caller omitted `width`/`height`, ignoring the resolution declared on the named camera via `add_camera(width=, height=)`. This:

- contradicts `render()`'s documented contract ("Resolution comes from camera config unless width/height are given"), and
- silently diverges from `get_observation()`, which already keys off the per-camera `SimCamera` config.

So a snapshot of a `320x240` camera came back `640x480` -- a different frame size than the camera (and any dataset recorded from that camera) actually used. Reproduction:

```python
sim.add_camera("cam_hi", position=[0.55,0,0.4], target=[0.1,0,0.05], width=320, height=240)
sim.render(camera_name="cam_hi")   # -> 640x480 (wrong; expected 320x240)
sim.get_observation()["cam_hi"]    # -> (240, 320, 3)  (correct)
```

## Change

`render()` now resolves an omitted dimension from the named camera's `SimCamera` config, matching `get_observation()`. The free (`"default"`/`"free"`) camera and model-only cameras with no `SimCamera` entry fall back to the engine default; explicit `width`/`height` still override. The base `SimEngine.render()` and MuJoCo `render()` docstrings are corrected to describe the actual tool-dict return shape and the resolution contract.

## Tests

Adds `tests/simulation/mujoco/test_render_camera_resolution.py` pinning the contract: omitted dims -> camera config, explicit dims -> override, free camera -> engine default, and `render()`/`get_observation()` agreement. Two of the four fail on pre-fix code (`640x480 != configured`) and pass after. The existing render/recording suite (64 tests) stays green.

## Visual proof (headless MuJoCo, EGL)

Same `cam_hi` (configured `320x240`), rendered with no explicit dims -- before vs after:

![before/after render resolution](https://github.com/cagataycali/robots/releases/download/render-res-demo-1782666942/render_fix_compare.png)

The rendering pipeline end to end on a 3-camera SO-101 rollout (256x256 cameras, recorded to a LeRobotDataset + MP4): [smolvla_rollout.mp4](https://github.com/cagataycali/robots/releases/download/render-res-demo-1782666942/smolvla_rollout.mp4)