### PR TITLE
test(conformance): match from-source lerobot types in coverage invariant

### DIFF
--- a/tests/test_lerobot_hardware_conformance.py
+++ b/tests/test_lerobot_hardware_conformance.py
@@ -82,6 +82,27 @@ def strands_hw_types() -> dict[str, str]:
 
 
 @pytest.fixture(scope="module")
+def strands_hw_types_all() -> dict[str, str]:
+    """Map strands robot name -> declared lerobot_type for ALL hardware entries.
+
+    Unlike ``strands_hw_types`` this keeps entries flagged
+    ``requires_lerobot_from_source``. Those entries deliberately reference
+    LeRobot types that only exist in a lerobot-from-source install (not in a
+    PyPI release within the pinned range). When the test runs against such a
+    source tree, ``lerobot_types`` includes those types, so the strands entries
+    that cover them must count as reachable - otherwise the coverage direction
+    reports a false ``missing`` for a robot that is, in fact, drivable.
+    """
+    data = json.loads(REGISTRY_PATH.read_text())
+    robots = data.get("robots", data)
+    return {
+        name: info["hardware"]["lerobot_type"]
+        for name, info in robots.items()
+        if isinstance(info.get("hardware"), dict) and info["hardware"].get("lerobot_type")
+    }
+
+
+@pytest.fixture(scope="module")
 def lerobot_types() -> set[str]:
     robots_dir = _find_lerobot_robots_dir()
     if robots_dir is None:
@@ -106,13 +127,18 @@ def test_every_strands_lerobot_type_is_real(strands_hw_types: dict[str, str], le
     )
 
 
-def test_full_lerobot_hardware_coverage(strands_hw_types: dict[str, str], lerobot_types: set[str]) -> None:
+def test_full_lerobot_hardware_coverage(strands_hw_types_all: dict[str, str], lerobot_types: set[str]) -> None:
     """Every LeRobot robot type is reachable through at least one strands entry.
 
     This is the 'conform to all the toys' invariant: if LeRobot ships a robot,
     a user can drive it with ``Robot(name, mode='real')`` via some strands name.
+
+    Uses ``strands_hw_types_all`` (not the reality-check subset) so that
+    from-source-only LeRobot types - which appear in ``lerobot_types`` when the
+    test runs against a source checkout - are matched by the strands entries
+    that carry ``requires_lerobot_from_source``.
     """
-    reachable = set(strands_hw_types.values())
+    reachable = set(strands_hw_types_all.values())
     missing = lerobot_types - reachable
     assert not missing, (
         "LeRobot robot types not reachable from any strands registry entry "


### PR DESCRIPTION
## Problem

`test_full_lerobot_hardware_coverage` in `tests/test_lerobot_hardware_conformance.py` enforces the "conform to all the toys" invariant: every LeRobot `@RobotConfig.register_subclass(...)` name must be reachable from a strands registry hardware entry, so `Robot(name, mode='real')` can drive any robot LeRobot ships.

It computed the reachable set from the `strands_hw_types` fixture, which intentionally **drops** entries flagged `requires_lerobot_from_source`. That exclusion is correct for the *reality* check (`test_every_strands_lerobot_type_is_real`): on a PyPI lerobot install those types are absent from `lerobot_types`, so a from-source-gated entry would otherwise look like a bogus offender.

But it is wrong for the **coverage direction**. When lerobot is installed from source, the parser walks the source tree and `lerobot_types` *does* include from-source-only types. The strands entries that cover them (`rebot_b601` -> `rebot_b601_follower`, `bi_rebot_b601` -> `bi_rebot_b601_follower`) carry `requires_lerobot_from_source: true` and were therefore excluded from `reachable`, so the test reported:

```
LeRobot robot types not reachable from any strands registry entry
(add a hardware entry with this lerobot_type): ['bi_rebot_b601_follower', 'rebot_b601_follower']
```

The registry already covers both types; the failure is a false negative produced by the fixture asymmetry. It surfaces whenever the suite runs against a lerobot source checkout.

## Change

Add a `strands_hw_types_all` fixture that keeps every hardware entry (including `requires_lerobot_from_source` ones) and use it for the coverage assertion. `test_every_strands_lerobot_type_is_real` keeps using the filtered `strands_hw_types`. The invariant still flags a genuinely uncovered LeRobot type (it would be in `lerobot_types` but absent from the full reachable set). No production code change.

## Verification

```
# pre-fix: 1 failed, 2 passed  (false 'missing' on a from-source lerobot tree)
# post-fix:
tests/test_lerobot_hardware_conformance.py ...  3 passed
```

Full local gate clean: `ruff check`, `ruff format --check`, `mypy strands_robots tests tests_integ` (no issues, 553 files), and `tests/test_lerobot_hardware_conformance.py tests/registry/ tests/test_registry_integrity.py` -> 506 passed.