### PR TITLE
feat(sim): list render_depth and render_all in describe() discovery surface

### DIFF
--- a/docs/simulation/overview.md
+++ b/docs/simulation/overview.md
@@ -64,10 +64,16 @@ Robot-URDF cameras are auto-discovered on `add_robot`.
 |--------|-------|
 | `render(camera_name="default", width=None, height=None)` | PNG in `content[...]["image"]["source"]["bytes"]`; no `frame` key |
 | `render_depth(camera_name="default", width=None, height=None)` | Depth float32 in content; no `depth` key |
+| `render_all(cameras=None, width=None, height=None)` | One `image` block per camera (multi-view snapshot) |
 | `open_viewer` / `close_viewer` | Interactive MuJoCo passive viewer |
 
 !!! note "Get a numpy frame"
     `sim.get_observation(robot_name)[camera_name]` → `np.uint8 (H, W, 3)`
+
+!!! tip "Discover the render surface"
+    `render`, `render_depth`, and `render_all` are all listed in
+    `sim.describe()["methods"]`, so an agent can enumerate the full rendering
+    surface in one call instead of guessing method names.
 
 ## Physics
 

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1156,6 +1156,14 @@ class MuJoCoSimEngine(
                     bodies.append(body_name)
         base["bodies"] = bodies
         base["methods"]["list_bodies"] = "(robot_name: str | None = None) -> dict (camera mount points)"
+        # Rendering siblings of "render" (advertised in tool_spec.json + the
+        # action dispatcher) that the base discovery surface omits. Listing
+        # them here lets an agent enumerate the full render surface from
+        # describe() rather than discovering depth / multi-view by guessing.
+        base["methods"]["render_depth"] = (
+            "(camera_name='default', width=None, height=None) -> dict (metric depth map stats)"
+        )
+        base["methods"]["render_all"] = "(cameras=None, width=None, height=None) -> dict (one image block per camera)"
         # Recording / dataset-collection surface (LeRobotDataset, [lerobot] extra).
         # Exposed here so agents discover the explicit episode-boundary workflow
         # (start_recording -> run_policy + save_episode per episode -> stop_recording)

--- a/tests/simulation/test_sim_engine_describe_discovery.py
+++ b/tests/simulation/test_sim_engine_describe_discovery.py
@@ -197,6 +197,33 @@ class TestDescribeMuJoCo:
         assert desc["robots"] == []
         assert desc["world_created"] is False
 
+    def test_describe_lists_render_siblings(self):
+        """describe() must advertise the full render surface, not just render().
+
+        ``render_depth`` and ``render_all`` are public MuJoCo methods that the
+        tool spec and action dispatcher already expose, but the programmatic
+        discovery surface previously listed only ``render`` - so a caller
+        enumerating ``describe()["methods"]`` could not learn that depth and
+        multi-view rendering exist without guessing the names. They belong
+        alongside ``render`` so one describe() call reveals the whole surface.
+        """
+        import os
+
+        os.environ.setdefault("MUJOCO_GL", "egl")
+        from strands_robots.simulation import Simulation
+
+        sim = Simulation()
+        try:
+            methods = sim.describe()["methods"]
+            for name in ("render", "render_depth", "render_all"):
+                assert name in methods, f"describe() omits public render method {name!r}"
+            # The advertised signatures name the real first parameters so a
+            # caller can invoke them without reading the source.
+            assert "camera_name" in methods["render_depth"]
+            assert "cameras" in methods["render_all"]
+        finally:
+            sim.destroy()
+
 
 class TestNoAlias:
     """Code is the single source of truth: no duplicate-name aliases.


### PR DESCRIPTION
## Problem

`MuJoCoSimEngine.describe()["methods"]` is the single-call discovery surface an agent is meant to consult first to learn an engine's contract instead of guessing method names. It advertised only `render()` from the rendering surface, even though `render_depth()` and `render_all()` are equally public:

- both are listed in `simulation/mujoco/tool_spec.json`,
- both route through the action dispatcher (`sim(action="render_depth")` / `sim(action="render_all")`),
- both are named in the dispatcher's `[Rendering]` help string.

So a caller enumerating `describe()["methods"]` could not discover depth or multi-view rendering without reading the source or guessing the names — exactly the probe-and-fail that `describe()` exists to prevent.

Before:
```python
>>> sorted(Simulation().describe()["methods"])
[... 'render', 'reset', 'run_policy', ...]   # render_depth / render_all absent
```

## Change

List `render_depth` and `render_all` alongside `render` in the MuJoCo `describe()` override, with their real signatures. This is a pure discovery-metadata addition — rendering behavior is unchanged, no public API is renamed, and no alias is introduced.

After:
```python
>>> m = Simulation().describe()["methods"]
>>> m["render_depth"]
"(camera_name='default', width=None, height=None) -> dict (metric depth map stats)"
>>> m["render_all"]
"(cameras=None, width=None, height=None) -> dict (one image block per camera)"
```

## Tests

Adds `TestDescribeMuJoCo::test_describe_lists_render_siblings`, which asserts all three render methods appear in `describe()["methods"]` with their key parameter names. It fails on pre-change code (`AssertionError: describe() omits public render method 'render_depth'`) and passes after.

```
tests/simulation/test_sim_engine_describe_discovery.py ... 11 passed
```

Local gate green: `ruff check` + `ruff format --check` + `mypy strands_robots tests tests_integ` all clean; full `test_sim_engine_describe_discovery.py` passes under `MUJOCO_GL=egl`.

## Docs

`docs/simulation/overview.md` rendering table gains a `render_all` row plus a discovery tip noting the three render methods are enumerable via `describe()["methods"]`.

## Proof the advertised methods deliver

Headless MuJoCo (`MUJOCO_GL=egl`) SO-101 + cube; `describe()` now lists `['render', 'render_depth', 'render_all']`, `render_depth` returns metric depth (min 0.010 m, max 1.524 m), `render_all` returns one image block per camera, and `render` produces this frame:

![render surface demo](https://raw.githubusercontent.com/cagataycali/robots/pr-media-describe-render/render_surface_demo.png)