### PR TITLE
fix(recording): accept an existing empty root dir in start_recording

### DIFF
--- a/docs/recording.md
+++ b/docs/recording.md
@@ -44,6 +44,24 @@ given in raw MuJoCo form (`arm0/wrist_cam`) or schema-safe form
 cameras rather than silently recording the wrong set. Omit `cameras=` to keep
 the legacy behavior of recording every camera.
 
+### Where the dataset is written (`root` / `overwrite`)
+
+`root` is the on-disk directory for the dataset (defaults to the LeRobot cache
+under `repo_id` when omitted). Passing an existing **empty** directory - for
+example one returned by `tempfile.mkdtemp()` - is accepted and recorded into:
+
+```python
+import tempfile
+root = tempfile.mkdtemp()                       # existing empty dir
+sim.start_recording(repo_id="user/my_dataset", root=root, fps=30)   # records here
+```
+
+When `root` already contains a LeRobotDataset (a `meta/` directory),
+`start_recording` **resumes** it and appends new episodes unless
+`overwrite=True`, which wipes and recreates it. A `root` that exists, is not a
+LeRobotDataset, and is **not empty** is left untouched and reported as an error
+rather than clobbered - pass `overwrite=True` or choose a new/empty `root`.
+
 ## Multi-episode recording
 
 A recording session is one dataset. The simplest way to collect N episodes in

--- a/strands_robots/simulation/mujoco/recording.py
+++ b/strands_robots/simulation/mujoco/recording.py
@@ -9,7 +9,6 @@ resume-schema guard.
 """
 
 import logging
-import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -72,6 +71,14 @@ class RecordingMixin(DatasetRecordingMixin):
         rather than freezing on the chunk-start observation.
 
         Args:
+            root: On-disk dataset directory (defaults to the LeRobot cache under
+                ``repo_id``). An existing EMPTY directory (e.g. from
+                ``tempfile.mkdtemp()``) is accepted and recorded into; an
+                existing dataset is resumed/appended (see ``overwrite``).
+            overwrite: When True, wipe any existing dataset at ``root`` and
+                record from scratch. When False (default) an existing dataset is
+                appended to; a non-empty, non-dataset ``root`` is reported as an
+                error rather than clobbered.
             cameras: Camera names to record into the dataset. When ``None``
                 (default) every scene camera is recorded - which includes the
                 implicit ``default`` free camera. Pass an explicit subset to
@@ -133,18 +140,14 @@ class RecordingMixin(DatasetRecordingMixin):
 
         # Multi-episode append: when NOT overwriting and a dataset already
         # exists on disk, resume it (append new episodes) instead of calling
-        # create() - which hard-fails with FileExistsError (B12). resume() is
-        # the only correct append path in LeRobot 0.5.2+ (the plain constructor
-        # is read-only). When overwrite=True, wipe and recreate from scratch.
-        resume_existing = (
-            not overwrite and dataset_dir.exists() and dataset_dir.is_dir() and (dataset_dir / "meta").exists()
-        )
-
+        # create() - which hard-fails with FileExistsError. resume() is the
+        # only correct append path in LeRobot 0.5.2+ (the plain constructor is
+        # read-only). A pre-existing EMPTY root (e.g. tempfile.mkdtemp()) is
+        # cleared so create() does not dead-end on its own existence guard;
+        # overwrite=True wipes and recreates from scratch. See
+        # DatasetRecordingMixin._prepare_dataset_target.
         try:
-            if overwrite:
-                if dataset_dir.exists() and dataset_dir.is_dir():
-                    shutil.rmtree(dataset_dir)
-                    logger.info("Removed existing dataset dir: %s", dataset_dir)
+            resume_existing = self._prepare_dataset_target(dataset_dir, overwrite)
 
             # Collect joint names from every robot. When the scene contains
             # more than one robot (e.g. multi-agent dual-task recording), prefix

--- a/strands_robots/simulation/newton/recording.py
+++ b/strands_robots/simulation/newton/recording.py
@@ -24,7 +24,6 @@ per-camera MP4).
 from __future__ import annotations
 
 import logging
-import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -136,14 +135,12 @@ class NewtonRecordingMixin(DatasetRecordingMixin):
             dataset_dir = Path.home() / ".cache" / "huggingface" / "lerobot" / repo_id
         world._backend_state["last_dataset_root"] = str(dataset_dir)
 
-        resume_existing = (
-            not overwrite and dataset_dir.exists() and dataset_dir.is_dir() and (dataset_dir / "meta").exists()
-        )
-
         try:
-            if overwrite and dataset_dir.exists() and dataset_dir.is_dir():
-                shutil.rmtree(dataset_dir)
-                logger.info("Removed existing dataset dir: %s", dataset_dir)
+            # Resolve create-vs-resume and make the target safe for create():
+            # resume an existing dataset, clear a pre-existing EMPTY root (e.g.
+            # tempfile.mkdtemp()) so create() does not dead-end on FileExistsError,
+            # and wipe on overwrite. See DatasetRecordingMixin._prepare_dataset_target.
+            resume_existing = self._prepare_dataset_target(dataset_dir, overwrite)
 
             joint_names, camera_keys, camera_dims, robot_type, recording_cameras = self._collect_recording_schema()
             world._backend_state["recording_cameras"] = recording_cameras

--- a/strands_robots/simulation/recording.py
+++ b/strands_robots/simulation/recording.py
@@ -22,6 +22,8 @@ enforceable protocol.
 """
 
 import logging
+import shutil
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 logger = logging.getLogger(__name__)
@@ -44,6 +46,64 @@ class DatasetRecordingMixin:
         _world: "SimWorld | None"
         default_width: int
         default_height: int
+
+    @staticmethod
+    def _prepare_dataset_target(dataset_dir: Path, overwrite: bool) -> bool:
+        """Resolve create-vs-resume and make ``dataset_dir`` safe for create().
+
+        ``LeRobotDataset.create()`` raises ``FileExistsError`` when its target
+        directory already exists - even when that directory is empty. Callers
+        very commonly pass an existing empty directory as ``root`` (for example
+        one returned by ``tempfile.mkdtemp()``), which would otherwise dead-end
+        recording with a cryptic ``[Errno 17] File exists``. This resolves the
+        situation up front:
+
+        * ``overwrite``: remove any existing target, then create() fresh.
+        * existing dataset (has a ``meta/`` dir): resume (append episodes).
+        * existing EMPTY dir: remove it so create() can recreate it cleanly.
+        * existing NON-empty, non-dataset dir: raise ``ValueError`` with an
+          actionable message instead of clobbering unrelated files.
+
+        Args:
+            dataset_dir: Resolved on-disk dataset root.
+            overwrite: When True, replace any existing target.
+
+        Returns:
+            True if an existing dataset should be resumed (append), False if a
+            fresh ``create()`` should run.
+
+        Raises:
+            ValueError: When the target exists, is not a LeRobotDataset, is not
+                empty, and ``overwrite`` is False - so create() would fail with
+                a cryptic ``FileExistsError``.
+        """
+        if not dataset_dir.exists():
+            return False
+        if overwrite:
+            if dataset_dir.is_dir():
+                shutil.rmtree(dataset_dir)
+            else:
+                dataset_dir.unlink()
+            logger.info("Removed existing dataset target: %s", dataset_dir)
+            return False
+        if not dataset_dir.is_dir():
+            raise ValueError(
+                f"Recording target {dataset_dir} exists and is not a directory. "
+                "Pass a directory path as root=, or overwrite=True to replace it."
+            )
+        if (dataset_dir / "meta").exists():
+            return True  # real dataset on disk -> resume/append
+        if not any(dataset_dir.iterdir()):
+            # Empty dir (e.g. from tempfile.mkdtemp()): clear it so create()
+            # does not trip over its own pre-existing-directory guard.
+            shutil.rmtree(dataset_dir)
+            logger.info("Cleared empty recording target for fresh dataset: %s", dataset_dir)
+            return False
+        raise ValueError(
+            f"Recording target {dataset_dir} already exists, is not a LeRobotDataset "
+            "(no meta/ directory), and is not empty. Refusing to overwrite unrelated "
+            "files. Pass overwrite=True to replace it, or choose a new/empty root=."
+        )
 
     def _is_recording(self) -> bool:
         """True when a dataset-recording session is active.

--- a/tests/simulation/mujoco/test_recording_paths.py
+++ b/tests/simulation/mujoco/test_recording_paths.py
@@ -834,3 +834,42 @@ def test_reset_empty_buffer_during_recording_does_not_create_episode(sim_with_on
     ds = LeRobotDataset(repo_id="local/reset_empty", root=root)
     assert ds.meta.total_episodes == 1, f"expected 1 episode, got {ds.meta.total_episodes}"
     assert ds.meta.total_frames == 5
+
+
+def test_start_recording_existing_empty_root_records(sim_with_two_robots, tmp_path):
+    """An EXISTING empty ``root`` (e.g. from tempfile.mkdtemp()) must record.
+
+    Pre-fix, start_recording(overwrite=False) on an existing empty directory
+    dead-ended with ``Dataset init failed: [Errno 17] File exists`` because it
+    called LeRobotDataset.create() (mkdir exist_ok=False) on a dir that already
+    existed. The natural caller pattern is to mkdtemp() a root and pass it in;
+    that must produce a valid dataset, not a cryptic errno.
+    """
+    from strands_robots.dataset_recorder import has_lerobot_dataset
+
+    if not has_lerobot_dataset():
+        pytest.skip("lerobot not installed")
+
+    sim = sim_with_two_robots
+    # tmp_path is an EXISTING empty directory - the repro condition.
+    root = str(tmp_path)
+    assert os.path.isdir(root) and not os.listdir(root)
+
+    r = sim.start_recording(repo_id="local/empty_root_probe", fps=20, root=root, overwrite=False)
+    assert r["status"] == "success", f"empty-root start_recording failed: {r}"
+    sim.run_policy(
+        robot_name="alpha",
+        policy_provider="mock",
+        instruction="ep0",
+        duration=0.3,
+        control_frequency=20.0,
+        fast_mode=True,
+    )
+    r = sim.stop_recording()
+    assert r["status"] == "success", r
+
+    from lerobot.datasets.lerobot_dataset import LeRobotDataset
+
+    ds = LeRobotDataset(repo_id="local/empty_root_probe", root=root)
+    assert ds.meta.total_episodes == 1, f"expected 1 episode, got {ds.meta.total_episodes}"
+    assert ds.meta.total_frames > 0

--- a/tests/simulation/test_recording_target_resolution.py
+++ b/tests/simulation/test_recording_target_resolution.py
@@ -1,0 +1,78 @@
+"""Behavior tests for recording-target resolution (create-vs-resume + dir prep).
+
+``DatasetRecordingMixin._prepare_dataset_target`` decides whether a recording
+session should resume an existing dataset or create a fresh one, and makes the
+target directory safe for ``LeRobotDataset.create()`` - which raises
+``FileExistsError`` if its target directory already exists, even when empty.
+These tests pin that contract with real temp directories (no lerobot/mujoco
+needed): a pre-existing empty ``root`` (e.g. from ``tempfile.mkdtemp()``) must
+be accepted, a real dataset must resume, and a non-empty non-dataset dir must
+fail loudly rather than be clobbered.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from strands_robots.simulation.recording import DatasetRecordingMixin
+
+_prepare = DatasetRecordingMixin._prepare_dataset_target
+
+
+def test_nonexistent_target_is_fresh_create(tmp_path):
+    target = tmp_path / "new_dataset"
+    assert _prepare(target, overwrite=False) is False
+    # Nothing was created; create() will make it.
+    assert not target.exists()
+
+
+def test_existing_empty_dir_is_cleared_for_fresh_create(tmp_path):
+    # The canonical caller pattern: tempfile.mkdtemp() returns an EXISTING
+    # empty dir. Pre-fix this dead-ended LeRobotDataset.create() with
+    # [Errno 17] File exists; the empty dir must be cleared so create() runs.
+    target = tmp_path / "empty"
+    target.mkdir()
+    assert target.exists()
+    assert _prepare(target, overwrite=False) is False
+    assert not target.exists(), "empty target should be cleared for create()"
+
+
+def test_existing_dataset_dir_resumes(tmp_path):
+    target = tmp_path / "dataset"
+    (target / "meta").mkdir(parents=True)
+    (target / "meta" / "info.json").write_text("{}")
+    assert _prepare(target, overwrite=False) is True
+    # Resume must NOT delete the existing dataset.
+    assert (target / "meta" / "info.json").exists()
+
+
+def test_existing_nonempty_nondataset_dir_raises(tmp_path):
+    target = tmp_path / "busy"
+    target.mkdir()
+    (target / "unrelated.txt").write_text("keep me")
+    with pytest.raises(ValueError, match="not a LeRobotDataset"):
+        _prepare(target, overwrite=False)
+    # The unrelated file must be preserved (no clobber).
+    assert (target / "unrelated.txt").exists()
+
+
+def test_overwrite_removes_existing_dataset_dir(tmp_path):
+    target = tmp_path / "dataset"
+    (target / "meta").mkdir(parents=True)
+    (target / "meta" / "info.json").write_text("{}")
+    assert _prepare(target, overwrite=True) is False
+    assert not target.exists(), "overwrite must wipe the existing target"
+
+
+def test_overwrite_removes_existing_file_target(tmp_path):
+    target = tmp_path / "afile"
+    target.write_text("stale")
+    assert _prepare(target, overwrite=True) is False
+    assert not target.exists()
+
+
+def test_existing_file_target_without_overwrite_raises(tmp_path):
+    target = tmp_path / "afile"
+    target.write_text("stale")
+    with pytest.raises(ValueError, match="not a directory"):
+        _prepare(target, overwrite=False)


### PR DESCRIPTION
## Problem

`start_recording(root=<dir>)` dead-ends with a cryptic error whenever `root` is an existing **empty** directory:

```
Dataset init failed: [Errno 17] File exists: '/tmp/...'
```

This is the canonical caller pattern - `root = tempfile.mkdtemp()` then pass the directory in. `LeRobotDataset.create()` refuses a pre-existing target directory (its `mkdir` uses `exist_ok=False`), and the create-vs-resume gate only resumed when a `meta/` directory was present. An existing **empty** root has no `meta/`, so it fell through to `create()` and crashed. The existing recording tests masked this by always passing `overwrite=True` with `tmp_path`.

Both the MuJoCo and Newton backends carried the same inline gate, so both were affected.

## Change

Add `DatasetRecordingMixin._prepare_dataset_target(dataset_dir, overwrite)` (backend-agnostic) to resolve the target up front:

- existing dataset (`meta/` present) -> **resume** (append episodes);
- existing **empty** dir -> clear it so `create()` can recreate it cleanly;
- `overwrite=True` -> wipe any existing target;
- existing **non-empty, non-dataset** dir -> raise a clear, actionable `ValueError` instead of clobbering unrelated files.

Both backends now call this helper, dropping their duplicated inline resume/overwrite logic. No public signature changes.

## Tests (fail before, pass after)

- `tests/simulation/test_recording_target_resolution.py` - unit coverage of every resolver branch (empty-dir cleared, dataset resumed, overwrite wipes, non-empty non-dataset raises, file targets).
- `tests/simulation/mujoco/test_recording_paths.py::test_start_recording_existing_empty_root_records` - records into an existing empty `root` (default `overwrite=False`), then reopens the dataset and asserts 1 episode / non-empty frames.

Both fail on pre-fix code with the `[Errno 17] File exists` crash and pass after. Full local gate green: `ruff check`/`ruff format` clean, `mypy strands_robots tests tests_integ` reports no issues, and the MuJoCo + Newton recording suites pass (62 passed, 1 skipped).

## Artifact

90-step rollout recorded into a `tempfile.mkdtemp()` root (the repro condition), reopened round-trip = 1 episode, 90 frames, `observation.images.cam_top` + `observation.images.cam_side`, 2 per-camera MP4s written. Rollout (MuJoCo, headless EGL):

![empty-root rollout](https://github.com/cagataycali/robots/releases/download/artifact-recording-empty-root/empty_root_rollout.gif)

## Docs

`docs/recording.md` gains a "Where the dataset is written (`root` / `overwrite`)" section, and the MuJoCo `start_recording` docstring documents the `root`/`overwrite` semantics.