### PR TITLE
feat(sim): list eval_policy and replay_episode in describe() discovery surface

### DIFF
--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -1494,6 +1494,16 @@ class SimEngine(ABC):
                 "send_action": "(action: dict, robot_name: str | None = None, n_substeps: int = 1) -> dict",
                 "run_policy": "(robot_name: str, policy_provider='mock', n_episodes=1, reset_between=True, ...) -> dict",
                 "start_policy": "(robot_name: str, policy_provider='mock', ...) -> dict",
+                "eval_policy": (
+                    "(robot_name: str, policy_provider='mock', n_episodes=1, "
+                    "max_steps=300, success_fn=None, ...) -> dict  # multi-episode "
+                    "success-rate evaluation (the rollout sibling of run_policy)"
+                ),
+                "replay_episode": (
+                    "(repo_id: str, robot_name=None, episode=0, root=None, "
+                    "speed=1.0, action_key_map=None) -> dict  # replay a recorded "
+                    "LeRobotDataset episode through the sim"
+                ),
                 "list_robots": "() -> list[str]",
                 "render": "(camera_name='default', width=None, height=None) -> dict",
                 "reset": "() -> dict  # during recording, flushes the buffered rollout as one episode before resetting",

--- a/tests/simulation/test_sim_engine_describe_discovery.py
+++ b/tests/simulation/test_sim_engine_describe_discovery.py
@@ -158,6 +158,26 @@ class TestDescribeABC:
         }
         assert expected_methods.issubset(set(desc["methods"].keys()))
 
+    def test_describe_lists_rollout_family_siblings(self):
+        """describe() advertises the whole rollout family, not just run_policy.
+
+        ``run_policy`` and ``start_policy`` were discoverable, but their
+        siblings ``eval_policy`` (multi-episode success-rate evaluation) and
+        ``replay_episode`` (replay a recorded LeRobotDataset episode) were not
+        - so a caller enumerating ``describe()["methods"]`` could not learn the
+        evaluation or replay entry points without guessing the names. They are
+        concrete backend-agnostic facades on the base engine and belong on the
+        discovery surface alongside ``run_policy``.
+        """
+        engine = _make_minimal_engine()
+        methods = engine.describe()["methods"]
+        for name in ("run_policy", "start_policy", "eval_policy", "replay_episode"):
+            assert name in methods, f"describe() omits rollout-family method {name!r}"
+        # Advertised signatures name the real first parameters so a caller can
+        # invoke them without reading the source.
+        assert "n_episodes" in methods["eval_policy"]
+        assert "repo_id" in methods["replay_episode"]
+
 
 @pytest.mark.skipif(
     not pytest.importorskip("mujoco", reason="MuJoCo not installed"),
@@ -183,6 +203,8 @@ class TestDescribeMuJoCo:
             assert desc["world_created"] is True
             assert isinstance(desc["cameras"], list)
             assert "get_robot_state" in desc["methods"]
+            for name in ("eval_policy", "replay_episode"):
+                assert name in desc["methods"], f"describe() omits {name!r}"
         finally:
             sim.destroy()
 


### PR DESCRIPTION
## Problem

`SimEngine.describe()` is the single-call discovery surface agents use to learn an engine's contract without guessing method names. It advertised the rollout entry points `run_policy` and `start_policy`, but omitted their two siblings:

- `eval_policy` - multi-episode success-rate evaluation
- `replay_episode` - replay a recorded `LeRobotDataset` episode through the sim

Both are concrete, backend-agnostic facades on `SimEngine` (defined in `simulation/base.py` right next to `run_policy`/`start_policy`). A caller enumerating `describe()["methods"]` could therefore not learn the evaluation or replay entry points without reading the source or guessing the names - exactly the probe-and-fail loop `describe()` exists to prevent. This mirrors the gap closed for the render family in #812.

## Change

List `eval_policy` and `replay_episode` on the base discovery surface, directly after `run_policy`/`start_policy`, with signatures that name the real first parameters so a caller can invoke them without reading the source. Because they are added to the base `describe()`, every backend (MuJoCo and any future engine) advertises them automatically.

## Discovery surface (after)

```
describe()['methods'] keys:
  get_robot_state, get_observation, send_action,
  run_policy, start_policy,
  eval_policy,        <- now listed
  replay_episode,     <- now listed
  list_robots, render, reset, step,
  list_bodies, render_depth, render_all,
  start_recording, save_episode, stop_recording,
  get_recording_status, verify_dataset_episodes
```

## Tests

Extended `tests/simulation/test_sim_engine_describe_discovery.py`:
- `TestDescribeABC::test_describe_lists_rollout_family_siblings` - asserts the base engine advertises the full rollout family (`run_policy`, `start_policy`, `eval_policy`, `replay_episode`) and that the advertised signatures name the real first parameters (`n_episodes`, `repo_id`).
- `TestDescribeMuJoCo::test_describe_with_world_and_robot` - extended to assert the siblings appear on the live MuJoCo engine.

Both new assertions fail on the pre-fix code (`2 failed, 10 passed`) and pass after (`12 passed`).

## Gate

- `ruff check` / `ruff format --check` clean on `strands_robots tests tests_integ`
- `mypy strands_robots tests tests_integ` - Success, no issues in 556 source files
- `MUJOCO_GL=egl pytest` of the discovery + tool-spec + agenttool-contract suites: 86 passed