### PR TITLE
fix(lerobot_local): honor camera_key_map on the preprocessor remap path

### DIFF
--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -1585,11 +1585,30 @@ class LerobotLocalPolicy(Policy):
 
         declared_img_feats = [f for f, feat in self._input_features.items() if _declared_feature_is_image(f, feat)]
 
-        # 1) Map images. Prefer exact short-name match against declared features.
+        # 1) Map images. An explicit camera_key_map wins (mirroring the routing
+        #    precedence in _resolve_camera_targets), then an exact short-name
+        #    match against declared features, then positional fill. Honoring the
+        #    map here - not only on the batch path - means a camera-name mismatch
+        #    bound via camera_key_map is resolved on this preprocessor/VLA path
+        #    (MolmoAct2 etc.) too, so the strict_keys remedy advertised below
+        #    ("Provide an explicit mapping (camera_key_map)") actually fixes the
+        #    failure it points at instead of being silently ignored.
         image_items = [(k, v) for k, v in observation_dict.items() if isinstance(v, np.ndarray) and v.ndim >= 2]
         used_feats: set[str] = set()
         unmatched_imgs = []
         for k, v in image_items:
+            mapped = self.camera_key_map.get(k) if self.camera_key_map else None
+            if mapped is not None:
+                if mapped not in declared_img_feats:
+                    raise ValueError(
+                        f"camera_key_map routes camera '{k}' to image key '{mapped}', "
+                        "but the policy does not declare it. Declared image keys: "
+                        f"{sorted(declared_img_feats)}."
+                    )
+                if mapped not in used_feats:
+                    out[mapped] = v
+                    used_feats.add(mapped)
+                continue
             target = f"observation.images.{k}"
             if target in self._input_features and target not in used_feats:
                 out[target] = v

--- a/tests/policies/lerobot_local/test_policy.py
+++ b/tests/policies/lerobot_local/test_policy.py
@@ -1953,6 +1953,83 @@ class TestToLerobotObservation:
 
 
 # (section)
+# Tests: _to_lerobot_observation camera_key_map / strict_keys on the remap path
+# (section)
+
+
+class TestToLerobotObservationCameraKeyMap:
+    """camera_key_map and strict_keys on the preprocessor remap path.
+
+    ``_to_lerobot_observation`` is the bridge a preprocessor-backed VLA (e.g.
+    MolmoAct2) uses inside ``get_actions``. It must honor an explicit
+    ``camera_key_map`` with the same precedence as the batch path
+    (``_resolve_camera_targets``): explicit map first, then exact name match,
+    then positional fill. Otherwise a camera-name mismatch fixed via
+    ``camera_key_map`` is silently ignored here, and the strict_keys remedy
+    message ("Provide an explicit mapping (camera_key_map)") points at a fix
+    that does not work on this path.
+    """
+
+    @staticmethod
+    def _policy(slots, *, strict=False, camera_key_map=None):
+        policy = _make_loaded_policy(state_dim=2, include_images=False)
+        for slot in slots:
+            policy._input_features[f"observation.images.{slot}"] = MagicMock(shape=(3, 480, 640))
+        policy.strict_keys = strict
+        policy.camera_key_map = camera_key_map
+        return policy
+
+    def test_camera_key_map_routes_mismatched_name_to_declared_slot(self):
+        """A bare cam whose name does not match is routed by camera_key_map."""
+        policy = self._policy(["top"], camera_key_map={"front": "observation.images.top"})
+        img = np.ones((480, 640, 3), dtype=np.uint8)
+        out = policy._to_lerobot_observation({"front": img})
+        assert out["observation.images.top"] is img
+
+    def test_strict_keys_with_camera_key_map_does_not_raise(self):
+        """Under strict_keys, a name mismatch covered by camera_key_map resolves.
+
+        Pre-fix this raised the "cannot resolve camera keys" ValueError even
+        though camera_key_map fully bound the camera - the strict remedy
+        message advertised a fix that the remap path ignored.
+        """
+        policy = self._policy(["top"], strict=True, camera_key_map={"front": "observation.images.top"})
+        img = np.ones((480, 640, 3), dtype=np.uint8)
+        out = policy._to_lerobot_observation({"front": img})
+        assert out["observation.images.top"] is img
+
+    def test_camera_key_map_prevents_positional_misrouting(self):
+        """With two cameras the map binds each to its intended slot, not by order.
+
+        Positional fill would route cameras by declaration order; an explicit
+        map must override that so 'a' lands in wrist and 'b' in base.
+        """
+        policy = self._policy(
+            ["base", "wrist"],
+            camera_key_map={"a": "observation.images.wrist", "b": "observation.images.base"},
+        )
+        img_a = np.full((480, 640, 3), 10, dtype=np.uint8)
+        img_b = np.full((480, 640, 3), 20, dtype=np.uint8)
+        out = policy._to_lerobot_observation({"a": img_a, "b": img_b})
+        assert out["observation.images.wrist"] is img_a
+        assert out["observation.images.base"] is img_b
+
+    def test_camera_key_map_to_undeclared_image_key_raises(self):
+        """A map target the policy does not declare fails loudly (not silently)."""
+        policy = self._policy(["base"], camera_key_map={"a": "observation.images.nope"})
+        img = np.zeros((480, 640, 3), dtype=np.uint8)
+        with pytest.raises(ValueError, match="does not declare it"):
+            policy._to_lerobot_observation({"a": img})
+
+    def test_no_camera_key_map_keeps_positional_fallback(self):
+        """Without a map, a mismatched name still fills a free slot positionally."""
+        policy = self._policy(["top"])
+        img = np.full((480, 640, 3), 5, dtype=np.uint8)
+        out = policy._to_lerobot_observation({"front": img})
+        assert out["observation.images.top"] is img
+
+
+# (section)
 # Tests: _fixup_preprocessed_batch (raw arrays/tensors -> batched device tensors)
 # (section)
 


### PR DESCRIPTION
## Problem

`LerobotLocalPolicy._to_lerobot_observation` is the observation bridge a preprocessor-backed VLA uses inside `get_actions` when no embodiment map is declared (the "legacy heuristic path"). This is the active path for SmolVLA and MolmoAct2 (both load with `has_preprocessor=True` and `_embodiment=None`).

That method resolved cameras only by (a) exact short-name match and (b) positional fill into remaining slots. It **never consulted `self.camera_key_map`**, even though the batch path (`_resolve_camera_targets`) does. Two consequences:

1. A camera-name mismatch the caller fixed via `camera_key_map` was **silently ignored** on this path. Under `strict_keys=True` the call raised `strict_keys=True: cannot resolve camera keys by exact name ...`, whose own remedy text says *"Provide an explicit mapping (camera_key_map) ..."* - advice that did not work here. The error pointed at a fix the path ignored.
2. With multiple cameras, positional fill could route a frame to the **wrong** model slot (e.g. the wrist view into the base slot) instead of the binding the caller requested - a silent correctness bug that surfaces as degraded policy behavior, not an error.

## Change

Apply the same routing precedence already used by the batch path on the remap path: explicit `camera_key_map` first (raising the same `does not declare it` error for an undeclared target), then exact name match, then positional fill. `strict_keys` and the no-map positional-fallback behavior are unchanged. This also makes the constructor docstring's claim - that `strict_keys` is a no-op "when `camera_key_map` ... already resolve[s] every camera" - true on this path, where it previously was not.

## Tests

New `TestToLerobotObservationCameraKeyMap` (5 cases). Against the pre-fix source, 3 fail and 2 pass:

- `test_strict_keys_with_camera_key_map_does_not_raise` - **failed pre-fix** (raised the misleading `cannot resolve camera keys` error despite a covering map).
- `test_camera_key_map_prevents_positional_misrouting` - **failed pre-fix** (frames routed positionally, swapping the two slots).
- `test_camera_key_map_to_undeclared_image_key_raises` - **failed pre-fix** (`DID NOT RAISE`; target silently dropped).
- `test_camera_key_map_routes_mismatched_name_to_declared_slot`, `test_no_camera_key_map_keeps_positional_fallback` - pass on both, guarding the unchanged paths.

Full `tests/policies/lerobot_local/` suite: 156 passed. Local gate clean: `ruff check`, `ruff format --check`, `mypy strands_robots tests tests_integ` (Success: no issues found in 556 files).

## End-to-end validation

SmolVLA (`lerobot/smolvla_base`) rollout on the SO-101 in MuJoCo (headless EGL), with sim cameras deliberately named `frontcam`/`topcam`/`wristcam` (not the policy's declared `camera1/2/3`) and rebound via `camera_key_map` under `strict_keys=True`. Pre-fix this rollout aborts inside `_to_lerobot_observation`; post-fix it runs 45 steps with 0 action errors.

![camera_key_map rollout](https://github.com/cagataycali/robots/releases/download/demo-camera-key-map-1782687769/camera_key_map_rollout.gif)

[MP4](https://github.com/cagataycali/robots/releases/download/demo-camera-key-map-1782687769/camera_key_map_rollout.mp4)