### PR TITLE
feat(sim): return a viewable depth PNG from render_depth

### DIFF
--- a/docs/simulation/overview.md
+++ b/docs/simulation/overview.md
@@ -63,7 +63,7 @@ Robot-URDF cameras are auto-discovered on `add_robot`.
 | Action | Notes |
 |--------|-------|
 | `render(camera_name="default", width=None, height=None)` | PNG in `content[...]["image"]["source"]["bytes"]`; no `frame` key |
-| `render_depth(camera_name="default", width=None, height=None)` | Depth float32 in content; no `depth` key |
+| `render_depth(camera_name="default", width=None, height=None)` | Viewable grayscale depth PNG `image` block (near=bright, far=dark) + metric `depth_min`/`depth_max` (meters) in the `json` block |
 | `render_all(cameras=None, width=None, height=None)` | One `image` block per camera (multi-view snapshot) |
 | `open_viewer` / `close_viewer` | Interactive MuJoCo passive viewer |
 

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -671,7 +671,20 @@ class RenderingMixin:
     def render_depth(
         self, camera_name: str = "default", width: int | None = None, height: int | None = None
     ) -> dict[str, Any]:
-        """Render depth map from a camera."""
+        """Render a metric depth map from a camera.
+
+        Returns an agent-tool dict with ``status`` and a ``content`` list. On
+        success the content mirrors :meth:`render`: a ``text`` summary, an
+        ``image`` block carrying a viewable 8-bit grayscale PNG of the depth map
+        (``{"image": {"format": "png", "source": {"bytes": ...}}}``; nearer
+        surfaces are brighter, the far plane is darkest), and a ``json`` block
+        with the exact metric bounds ``depth_min``/``depth_max`` in meters.
+
+        The PNG makes the depth actually consumable - visualized, saved, or fed
+        to a depth-aware downstream - whereas the scalar bounds alone discard the
+        per-pixel structure. Use the ``json`` bounds when exact metric values
+        matter; the grayscale image is normalized for display only.
+        """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
 
@@ -777,14 +790,38 @@ class RenderingMixin:
             # Clamp: pixels at far plane (depth==1) -> zfar
             depth_m = _np.clip(depth_m, znear, zfar)
 
-            text = f"Depth {w}x{h} from '{label}'\nMin: {float(depth_m.min()):.4f}m, Max: {float(depth_m.max()):.4f}m"
+            dmin = float(depth_m.min())
+            dmax = float(depth_m.max())
+            text = f"Depth {w}x{h} from '{label}'\nMin: {dmin:.4f}m, Max: {dmax:.4f}m"
             if clip_warn:
                 text += f"\n{clip_warn}"
+
+            # Encode the metric depth map as a viewable 8-bit grayscale PNG so the
+            # depth is actually consumable (visualized, saved, or fed to a
+            # depth-aware downstream) - mirroring render()'s image block - instead
+            # of discarding the HxW array and returning only min/max scalars.
+            # Shading convention: nearer surfaces are brighter (255), the far
+            # plane is darkest (0); the exact metric bounds stay in the json block.
+            span = dmax - dmin
+            if span > 0:
+                gray = (255.0 * (1.0 - (depth_m - dmin) / span)).astype(_np.uint8)
+            else:
+                # Uniform depth (a single surface filling the view): flat mid-gray
+                # rather than a divide-by-zero or a misleading all-black frame.
+                gray = _np.full(depth_m.shape, 128, dtype=_np.uint8)
+
+            from PIL import Image
+
+            buffer = io.BytesIO()
+            Image.fromarray(gray, mode="L").save(buffer, format="PNG")
+            depth_png = buffer.getvalue()
+
             return {
                 "status": "success",
                 "content": [
                     {"text": text},
-                    {"json": {"depth_min": float(depth_m.min()), "depth_max": float(depth_m.max())}},
+                    {"image": {"format": "png", "source": {"bytes": depth_png}}},
+                    {"json": {"depth_min": dmin, "depth_max": dmax}},
                 ],
             }
         except Exception as e:

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1161,7 +1161,8 @@ class MuJoCoSimEngine(
         # them here lets an agent enumerate the full render surface from
         # describe() rather than discovering depth / multi-view by guessing.
         base["methods"]["render_depth"] = (
-            "(camera_name='default', width=None, height=None) -> dict (metric depth map stats)"
+            "(camera_name='default', width=None, height=None) -> dict "
+            "(viewable grayscale depth PNG image block + metric depth_min/depth_max stats)"
         )
         base["methods"]["render_all"] = "(cameras=None, width=None, height=None) -> dict (one image block per camera)"
         # Recording / dataset-collection surface (LeRobotDataset, [lerobot] extra).

--- a/tests/simulation/mujoco/test_rendering.py
+++ b/tests/simulation/mujoco/test_rendering.py
@@ -952,7 +952,7 @@ def test_render_depth_linearizes_normalized_buffer_to_meters(monkeypatch) -> Non
 
         r = sim.render_depth(camera_name="cam_a", width=2, height=2)
         assert r["status"] == "success", r
-        payload = r["content"][1]["json"]
+        payload = next(b["json"] for b in r["content"] if isinstance(b, dict) and "json" in b)
         assert payload["depth_min"] == pytest.approx(znear, rel=1e-4)
         assert payload["depth_max"] == pytest.approx(zfar, rel=1e-4)
         assert "Depth 2x2 from 'cam_a'" in r["content"][0]["text"]
@@ -1104,6 +1104,52 @@ def test_render_depth_output_is_ascii_only(monkeypatch) -> None:
         assert any("Depth" in t for t in texts)
         for text in texts:
             assert text.isascii(), f"non-ASCII in render_depth output: {text!r}"
+    finally:
+        sim.destroy()
+
+
+def test_render_depth_returns_viewable_grayscale_png_image_block(monkeypatch) -> None:
+    """render_depth() returns the depth map as a viewable PNG image block, not
+    just scalar min/max stats.
+
+    Regression for the depth map being discarded: the engine computed a full
+    HxW metric depth array but returned only depth_min/depth_max, so an agent
+    could never see or consume the depth. The response must now carry an
+    ``{"image": {"format": "png", ...}}`` block (mirroring render()) whose PNG
+    decodes to a single-channel image of the requested size, with the metric
+    bounds still present in the json block. Shading is near=bright, far=dark:
+    the near pixel must be brighter than the far pixel.
+    """
+    np = pytest.importorskip("numpy")
+    Image = pytest.importorskip("PIL.Image")
+    import io as _io
+
+    sim = _depth_world()
+    try:
+        # 0.0 -> near plane (brightest), 1.0 -> far plane (darkest), plus mids.
+        buf = np.array([[0.0, 1.0], [0.5, 0.5]], dtype=np.float32)
+        monkeypatch.setattr(sim, "_get_renderer", lambda w, h: _FakeDepthRenderer(buf))
+
+        r = sim.render_depth(camera_name="cam_a", width=2, height=2)
+        assert r["status"] == "success", r
+
+        image_blocks = [b for b in r["content"] if isinstance(b, dict) and "image" in b]
+        assert image_blocks, f"render_depth returned no image block: {r}"
+        img = image_blocks[0]["image"]
+        assert img["format"] == "png"
+        png_bytes = img["source"]["bytes"]
+        assert isinstance(png_bytes, bytes) and png_bytes[:8] == b"\x89PNG\r\n\x1a\n"
+
+        decoded = Image.open(_io.BytesIO(png_bytes))
+        assert decoded.mode == "L", f"depth PNG must be grayscale, got {decoded.mode}"
+        assert decoded.size == (2, 2)
+        arr = np.asarray(decoded)
+        # near pixel (0,0) brighter than far pixel (0,1).
+        assert int(arr[0, 0]) > int(arr[0, 1])
+
+        # metric bounds still available in the json block.
+        payload = next(b["json"] for b in r["content"] if isinstance(b, dict) and "json" in b)
+        assert "depth_min" in payload and "depth_max" in payload
     finally:
         sim.destroy()
 


### PR DESCRIPTION
## Problem

`render_depth` linearizes a full HxW metric depth buffer but then returns only `depth_min`/`depth_max` scalars in its `json` block - the per-pixel depth structure is discarded. A caller (visualizing a scene, a depth-conditioned pipeline, dataset annotation) cannot actually see or consume the depth map. This is asymmetric with `render`, which returns the frame as a PNG `image` block.

## Change

`render_depth` now normalizes the metric depth map to an 8-bit grayscale PNG and returns it as an `image` block, mirroring `render`'s `text -> image -> json` content shape. Nearer surfaces are brighter, the far plane is darkest; the exact metric bounds remain in the `json` block for precise use. A uniform-depth view (single surface filling the frame) falls back to flat mid-gray rather than a divide-by-zero or a misleading all-black frame.

## Tests

- New regression `test_render_depth_returns_viewable_grayscale_png_image_block`: asserts an `image` block is present, the PNG decodes to a single-channel image of the requested size, near pixel is brighter than far pixel, and the metric bounds remain in the `json` block. It fails on the pre-change code (no image block).
- The linearization test now locates the `json` block by scan (robust to the added image block) instead of a hard content index.
- Rendering + discovery suites green under `MUJOCO_GL=egl` (`tests/simulation/mujoco/test_rendering.py`, `test_sim_engine_describe_discovery.py`, plus the `render`/`depth` paths in `test_simulation.py`/`test_e2e.py`).

## Docs / discovery

- `render_depth` docstring documents the new contract.
- `describe()["methods"]["render_depth"]` and the `docs/simulation/overview.md` rendering table updated to describe the image block + metric bounds.

## Visual

RGB vs. depth, rendered in MuJoCo (headless EGL) - SO-101 + cube, front 3/4 camera at 384x384:

![render_depth RGB vs depth](https://raw.githubusercontent.com/cagataycali/robots/render-depth-demo-assets/media/render_depth_sidebyside.png)

For this frame the depth bounds were `depth_min=0.0100m`, `depth_max=2.1254m`; the grayscale image is normalized for display while the exact meters stay in the `json` block.