### PR TITLE
fix(examples): molmoact2 sim example uses hardware embodiment "so_real"

### DIFF
--- a/docs/policies/molmoact2.md
+++ b/docs/policies/molmoact2.md
@@ -112,6 +112,26 @@ policy = create_policy(
 )
 ```
 
+### Sim vs hardware embodiment
+
+The embodiment string is **not** interchangeable between MuJoCo and a physical
+arm - they declare different `state_keys`/`action_keys`, so the wrong one yields
+an empty `observation.state` and the policy fails with
+`MolmoAct2 requires observation.state for discrete state prompting`:
+
+| Context | Robot | Embodiment | `state_keys` |
+| --- | --- | --- | --- |
+| MuJoCo sim | `Robot("so101")` (`mode="sim"`, default) | `"so101"` | `["1", "2", "3", "4", "5", "6"]` (bare-numeric MJCF joints) |
+| MuJoCo sim | `Robot("so100")` | `"so100"` | `["Rotation", "Pitch", "Elbow", "Wrist_Pitch", "Wrist_Roll", "Jaw"]` |
+| Hardware | `Robot("so101", mode="real", ...)` | `"so_real"` | `["shoulder_pan.pos", ..., "gripper.pos"]` (SOFollower driver) |
+
+The `so101`/`so100` keys match the MuJoCo model's joint names; `so_real` (and
+its `so101_real`/`so100_follower` aliases) match the lerobot SOFollower driver's
+`<motor>.pos` keys reported over the serial bus. Pick the embodiment for the
+robot you actually instantiate: `embodiment="so101"` for the sim examples,
+`embodiment="so_real"` for the hardware example
+(`examples/molmoact2_so101_pickplace.py`).
+
 ## Debugging "runs but does not move"
 
 The provider surfaces two previously-silent failure modes as `WARNING` logs from

--- a/examples/molmoact2_sim_pickplace.py
+++ b/examples/molmoact2_sim_pickplace.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
 """SO101 pick-and-place in MuJoCo simulation - same policy, sim robot.
 
-Identical to ``molmoact2_so101_pickplace.py`` but swaps the robot to sim mode.
-This demonstrates that the abstraction works: one line changes from real to sim,
-everything else (policy, inference loop, observation keys) stays the same.
+Mirrors ``molmoact2_so101_pickplace.py`` but swaps the robot to sim mode. Two
+things change versus the hardware example: ``mode="sim"`` (the default) and the
+policy ``embodiment``. Sim uses ``embodiment="so101"`` (bare-numeric MuJoCo
+joint keys "1".."6"); the hardware example uses ``embodiment="so_real"`` (the
+SOFollower driver's ".pos" joint keys). The policy, inference loop, and action
+plumbing are otherwise identical.
 
 Usage:
   export STRANDS_TRUST_REMOTE_CODE=1
@@ -54,8 +57,13 @@ def main():
         },
     )
 
-    # Same create_policy call - the abstraction is identical.
-    policy = create_policy(REPO, embodiment="so_real", device=args.device)
+    # For MuJoCo sim use embodiment="so101". The "so_real" variant is for
+    # physical SO-100/101 hardware ONLY: it declares ".pos" joint keys
+    # (shoulder_pan.pos, ...) that match the lerobot SOFollower driver, whereas
+    # the MuJoCo SO-101 model exposes bare-numeric joint names "1".."6". Using
+    # "so_real" here leaves observation.state empty and MolmoAct2 raises
+    # "requires observation.state". See docs/policies/molmoact2.md.
+    policy = create_policy(REPO, embodiment="so101", device=args.device)
     policy.reset()
 
     # Retrieve initial sim state to verify observation keys.

--- a/tests/test_examples_sim_embodiment.py
+++ b/tests/test_examples_sim_embodiment.py
@@ -1,0 +1,127 @@
+"""Sim examples must not pass a hardware-only embodiment to ``create_policy``.
+
+A recurring documentation defect: a MuJoCo sim example is copied from a hardware
+example and keeps ``embodiment="so_real"``. The ``*_real`` embodiments declare
+the lerobot driver's ``<motor>.pos`` joint keys (e.g. ``shoulder_pan.pos``),
+which never match the bare-numeric MuJoCo joint names (``"1".."6"``). The
+``PackStateProcessorStep`` then finds zero state keys, never composes
+``observation.state``, and a state-conditioned policy (MolmoAct2) fails deep
+inside the lerobot processor pipeline with ``requires observation.state``.
+
+This statically scans top-level example scripts: any example that constructs a
+SIM robot (``Robot(...)`` without ``mode="real"``, or ``create_simulation(...)``)
+and passes a hardware (``*_real``) embodiment to ``create_policy`` is a defect.
+Pure-hardware examples (``Robot(..., mode="real")``) are exempt - ``so_real`` is
+correct there.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_EXAMPLES_DIR = _REPO_ROOT / "examples"
+_EMBODIMENTS_JSON = _REPO_ROOT / "strands_robots" / "policies" / "lerobot_local" / "embodiments.json"
+
+
+def _hardware_embodiments() -> set[str]:
+    """Names (configs + aliases) that resolve to a hardware (``*_real``) config.
+
+    Derived from ``embodiments.json`` so the rule tracks the registry rather than
+    a hand-maintained list. A config is hardware iff its name ends in ``_real``;
+    an alias is hardware iff its target config is.
+    """
+    raw = json.loads(_EMBODIMENTS_JSON.read_text(encoding="utf-8"))
+    configs = raw.get("configs", {})
+    aliases = raw.get("aliases", {})
+    hardware = {name for name in configs if name.endswith("_real")}
+    hardware |= {alias for alias, target in aliases.items() if target in hardware}
+    return hardware
+
+
+def _string_value(node: ast.AST) -> str | None:
+    """Return the literal string value of ``node``, else ``None``."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _is_sim_robot_example(tree: ast.AST) -> bool:
+    """True if the script constructs a sim robot.
+
+    Sim = a ``Robot(...)`` call WITHOUT ``mode="real"`` (sim is the default), or a
+    ``create_simulation(...)`` call. A script that only ever builds
+    ``Robot(..., mode="real")`` robots is treated as hardware-only.
+    """
+    has_sim = False
+    has_real_only_robot = False
+    saw_robot = False
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", None)
+        if name == "create_simulation":
+            return True
+        if name == "Robot":
+            saw_robot = True
+            mode = None
+            for kw in node.keywords:
+                if kw.arg == "mode":
+                    mode = _string_value(kw.value)
+            if mode == "real":
+                has_real_only_robot = True
+            else:
+                has_sim = True
+    if has_sim:
+        return True
+    # Only real robots constructed -> not a sim example.
+    if saw_robot and has_real_only_robot:
+        return False
+    return False
+
+
+def _create_policy_embodiments(tree: ast.AST) -> list[str]:
+    """Collect literal ``embodiment=`` string kwargs passed to ``create_policy``."""
+    found: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", None)
+        if name != "create_policy":
+            continue
+        for kw in node.keywords:
+            if kw.arg == "embodiment":
+                val = _string_value(kw.value)
+                if val is not None:
+                    found.append(val)
+    return found
+
+
+def _example_scripts() -> list[Path]:
+    if not _EXAMPLES_DIR.is_dir():
+        return []
+    return sorted(_EXAMPLES_DIR.glob("*.py"))
+
+
+@pytest.mark.parametrize("script", _example_scripts(), ids=[p.name for p in _example_scripts()])
+def test_sim_example_uses_sim_embodiment(script: Path) -> None:
+    """Sim examples must not pass a hardware (``*_real``) embodiment."""
+    tree = ast.parse(script.read_text(encoding="utf-8"))
+    if not _is_sim_robot_example(tree):
+        pytest.skip(f"{script.name} is not a sim example")
+    hardware = _hardware_embodiments()
+    used = _create_policy_embodiments(tree)
+    offending = [e for e in used if e in hardware]
+    assert not offending, (
+        f"{script.name} builds a sim robot but passes hardware embodiment(s) "
+        f"{offending} to create_policy. Hardware ('*_real') embodiments declare "
+        f"'<motor>.pos' joint keys that never match the MuJoCo bare-numeric joint "
+        f"names; observation.state ends up empty. Use the sim embodiment (e.g. "
+        f'"so101"/"so100") for MuJoCo.'
+    )


### PR DESCRIPTION
## Problem

`examples/molmoact2_sim_pickplace.py` builds a MuJoCo sim robot (`Robot("so101")`, `mode="sim"`) but passes `embodiment="so_real"` to `create_policy`. `so_real` is the **hardware** embodiment: its `state_keys` are the SOFollower driver's `<motor>.pos` names (`shoulder_pan.pos`, ..., `gripper.pos`). The MuJoCo SO-101 model exposes bare-numeric joint names `"1".."6"`, so `PackStateProcessorStep` finds **zero** matching keys, never composes `observation.state`, and MolmoAct2 raises:

```
ValueError: MolmoAct2 requires observation.state for discrete state prompting.
```

The sim example was broken end to end: `run_policy` returns `status=error`, no frames are written. The hardware example (`molmoact2_so101_pickplace.py`, `mode="real"`) correctly uses `so_real`; only the sim example cargo-culted that line.

Deterministic proof against the live sim observation (`PackStateProcessorStep`):

| embodiment | matched sim keys | `observation.state` |
| --- | --- | --- |
| `so_real` | `[]` (0 of 6) | `None` -> MolmoAct2 raises |
| `so101` | `["1".."6"]` (6 of 6) | dim 6 -> OK |

## Change

- `examples/molmoact2_sim_pickplace.py`: `embodiment="so_real"` -> `embodiment="so101"`; add a header comment explaining the sim/hardware split; correct the docstring (the embodiment is the second thing that changes from the hardware example, not "everything else stays the same").
- Audited the other examples: `molmoact2_so101_debug.py` already uses `so101` (sim); `molmoact2_so101_pickplace.py` correctly uses `so_real` (hardware). No other sim example was affected.
- `docs/policies/molmoact2.md`: add a "Sim vs hardware embodiment" subsection with the `state_keys` table.
- `tests/test_examples_sim_embodiment.py`: static AST regression test that flags any example building a sim robot while passing a hardware (`*_real`) embodiment to `create_policy`. The hardware set is derived from `embodiments.json` (configs ending `_real` + aliases resolving to them) so it tracks the registry. Fails on the pre-fix code (`['so_real']`), passes after; runs in CI without a GPU or model download and guards the whole `examples/` tree against this class of copy-paste defect.

## Tests

```
python -m pytest tests/test_examples_sim_embodiment.py tests/test_examples_no_lerobot_imports.py
# 26 passed, 4 skipped
```

Verified the regression test fails on the unfixed example (`AssertionError: ... passes hardware embodiment(s) ['so_real']`) and passes after the flip. `ruff check`, `ruff format --check`, and `mypy` are clean on the changed files.

## Visual artifact

Rollout of the `so101` robot in MuJoCo sim (headless EGL), 60 steps, front-facing camera, 640x480 @ 30fps - confirming the sim render path the example drives:

![so101 sim rollout](https://github.com/cagataycali/robots/releases/download/sim-embodiment-artifact-144/so101_sim_rollout.gif)

MP4: https://github.com/cagataycali/robots/releases/download/sim-embodiment-artifact-144/so101_sim_rollout.mp4