### PR TITLE
fix(sim): validate add_camera fov/width/height eagerly

### DIFF
--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1464,6 +1464,12 @@ class MuJoCoSimEngine(
         ``list_bodies`` (optionally with ``robot_name``) to discover valid
         mount points before placing a camera; robot bodies are namespaced
         ``<robot>/<body>`` (e.g. ``so101/gripper`` is the SO101 wrist mount).
+
+        Validation: ``fov`` must be a finite angle in ``(0, 180)`` degrees and
+        ``width``/``height`` must be positive ints within the offscreen
+        framebuffer cap (same bounds ``render`` enforces). Invalid values are
+        rejected here at config time with an actionable error rather than
+        deferring a cryptic spec-recompile or GL failure to the first render.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
@@ -1492,6 +1498,31 @@ class MuJoCoSimEngine(
                     }
                 ],
             }
+
+        # Validate the field of view up front. MuJoCo's ``fovy`` must be a
+        # finite angle in the open interval (0, 180) degrees; otherwise the
+        # spec recompile aborts deep inside ``inject_camera_into_scene`` with a
+        # cryptic "spec recompile refused", or - for fov <= 0 - silently
+        # registers a degenerate camera that renders nothing useful. Reject it
+        # here with an actionable message, mirroring the position/target checks.
+        if not isinstance(fov, (int, float)) or isinstance(fov, bool) or not math.isfinite(fov):
+            return {
+                "status": "error",
+                "content": [{"text": f"add_camera: 'fov' must be a finite number in degrees, got {fov!r}."}],
+            }
+        if not (0.0 < float(fov) < 180.0):
+            return {
+                "status": "error",
+                "content": [{"text": f"add_camera: 'fov' must be in the open interval (0, 180) degrees, got {fov}."}],
+            }
+
+        # Validate the render resolution baked into this camera the same way
+        # ``render`` validates its dims, so a bad size fails at config time with
+        # a clear message instead of deferring a cryptic GL/Renderer error (or a
+        # silent non-positive dimension) to the first rollout that renders it.
+        if dim_err := self._validate_render_dims(width, height):
+            text = dim_err["content"][0]["text"].replace("render:", "add_camera:", 1)
+            return {"status": "error", "content": [{"text": text}]}
 
         # reject duplicate camera names.  Previously a second
         # add_camera(name=existing) silently overwrote the registry entry but

--- a/tests/simulation/mujoco/test_input_validation.py
+++ b/tests/simulation/mujoco/test_input_validation.py
@@ -558,3 +558,78 @@ class TestAddCameraTargetOrients:
             )
         finally:
             sim.destroy()
+
+
+class TestAddCameraParamValidation:
+    """add_camera validates fov / width / height eagerly.
+
+    Previously add_camera validated position, target, duplicate names and the
+    parent_body mount, but accepted any fov and any render resolution. A
+    non-positive or out-of-range fov silently registered a degenerate camera
+    (fov <= 0) or aborted with a cryptic "spec recompile refused" (fov >= 180),
+    and a non-positive / oversized width or height was accepted at config time
+    only to fail with an opaque GL/Renderer error on the first render. These
+    guard the config-time rejection with an actionable message.
+    """
+
+    def test_fov_zero_errors(self, sim_with_world):
+        res = sim_with_world.add_camera(name="c", position=[0.5, 0, 0.3], target=[0.2, 0, 0.05], fov=0.0)
+        assert res["status"] == "error"
+        assert "fov" in res["content"][0]["text"]
+        assert "c" not in sim_with_world._world.cameras
+
+    def test_fov_negative_errors(self, sim_with_world):
+        res = sim_with_world.add_camera(name="c", position=[0.5, 0, 0.3], target=[0.2, 0, 0.05], fov=-10.0)
+        assert res["status"] == "error"
+        assert "(0, 180)" in res["content"][0]["text"]
+
+    def test_fov_at_180_errors(self, sim_with_world):
+        res = sim_with_world.add_camera(name="c", position=[0.5, 0, 0.3], target=[0.2, 0, 0.05], fov=180.0)
+        assert res["status"] == "error"
+        assert "fov" in res["content"][0]["text"]
+
+    def test_fov_above_180_errors(self, sim_with_world):
+        res = sim_with_world.add_camera(name="c", position=[0.5, 0, 0.3], target=[0.2, 0, 0.05], fov=250.0)
+        assert res["status"] == "error"
+        # must fail cleanly, NOT with the opaque spec-recompile message
+        assert "spec recompile refused" not in res["content"][0]["text"]
+
+    def test_fov_nan_errors(self, sim_with_world):
+        res = sim_with_world.add_camera(name="c", position=[0.5, 0, 0.3], target=[0.2, 0, 0.05], fov=float("nan"))
+        assert res["status"] == "error"
+        assert "finite" in res["content"][0]["text"]
+
+    def test_fov_inf_errors(self, sim_with_world):
+        res = sim_with_world.add_camera(name="c", position=[0.5, 0, 0.3], target=[0.2, 0, 0.05], fov=float("inf"))
+        assert res["status"] == "error"
+        assert "finite" in res["content"][0]["text"]
+
+    def test_fov_bool_rejected(self, sim_with_world):
+        # bool is an int subclass; True (== 1 deg) is almost certainly a caller bug.
+        res = sim_with_world.add_camera(name="c", position=[0.5, 0, 0.3], target=[0.2, 0, 0.05], fov=True)
+        assert res["status"] == "error"
+        assert "finite number" in res["content"][0]["text"]
+
+    def test_width_zero_errors(self, sim_with_world):
+        res = sim_with_world.add_camera(name="c", position=[0.5, 0, 0.3], target=[0.2, 0, 0.05], width=0)
+        assert res["status"] == "error"
+        assert "> 0" in res["content"][0]["text"]
+        assert "c" not in sim_with_world._world.cameras
+
+    def test_height_negative_errors(self, sim_with_world):
+        res = sim_with_world.add_camera(name="c", position=[0.5, 0, 0.3], target=[0.2, 0, 0.05], height=-5)
+        assert res["status"] == "error"
+        assert "> 0" in res["content"][0]["text"]
+
+    def test_width_above_abs_max_errors(self, sim_with_world):
+        res = sim_with_world.add_camera(name="c", position=[0.5, 0, 0.3], target=[0.2, 0, 0.05], width=100000)
+        assert res["status"] == "error"
+        assert "add_camera" in res["content"][0]["text"]
+        assert "render:" not in res["content"][0]["text"]
+
+    def test_valid_camera_still_added(self, sim_with_world):
+        res = sim_with_world.add_camera(
+            name="good", position=[0.5, 0, 0.3], target=[0.2, 0, 0.05], fov=58.0, width=256, height=256
+        )
+        assert res["status"] == "success"
+        assert "good" in sim_with_world._world.cameras


### PR DESCRIPTION
## Problem

`MuJoCoSimEngine.add_camera` already validates `position`, `target`, duplicate names, and the `parent_body` mount up front, but it accepts **any** `fov` and **any** render resolution. That leaves three sharp edges for callers building a camera rig:

- `fov <= 0` (e.g. `0.0`, `-10.0`) is **silently accepted** and registers a degenerate camera that renders nothing useful.
- `fov >= 180` aborts deep inside `inject_camera_into_scene` and surfaces only as the opaque `Failed to inject camera 'c': spec recompile refused.` (the real MuJoCo cause, `fovy too large`, is printed to stderr).
- `width <= 0` / `height <= 0` / oversized dimensions are **accepted at config time** and then fail with a cryptic GL/`mujoco.Renderer` error on the first rollout that renders the camera.

Validation already exists for the render path (`_validate_render_dims`), but `add_camera` does not use it, so a bad rig is only discovered later (or never).

## Change

Validate camera parameters eagerly in `add_camera`, mirroring the existing position/target/parent_body checks:

- `fov` must be a finite number in the open interval `(0, 180)` degrees (rejects `NaN`/`inf` and the `bool` subclass-of-int footgun).
- `width`/`height` are validated by reusing the existing `_validate_render_dims` helper (positive ints, within the offscreen framebuffer cap) so `add_camera` and `render` enforce identical bounds, with the message prefix rewritten to `add_camera:`.

Invalid config now fails immediately with an actionable message instead of deferring a cryptic spec-recompile or GL error. Valid cameras are unaffected.

## Tests

Adds `TestAddCameraParamValidation` in `tests/simulation/mujoco/test_input_validation.py` covering `fov` (zero, negative, `==180`, `>180`, `NaN`, `inf`, `bool`), `width`/`height` (zero, negative, above absolute max), and a regression guard that a valid camera still adds. The new tests **fail on pre-fix code** (10 failed, 1 passed) and pass after (11 passed). Full `test_input_validation.py` + `test_rendering.py` + `test_render_camera_resolution.py` stay green (92 passed, 16 GL-skips). `ruff check`/`ruff format` clean; `mypy` clean on the changed module.

## Visual proof

The valid reference rig (three 256x256 SO-101 cameras: front 3/4, top-down, wrist) still renders correctly after the change (MuJoCo headless, EGL):

![valid camera rig render](https://github.com/cagataycali/robots/releases/download/cam-validation-artifact-1782697283/valid_rig.png)

Rejection messages for invalid input:

```
add_camera: 'fov' must be in the open interval (0, 180) degrees, got 0.0.
add_camera: 'fov' must be in the open interval (0, 180) degrees, got 250.0.
add_camera: width and height must be > 0, got 0x480.
add_camera: width and height must be > 0, got 640x-5.
```