### PR TITLE
fix(mesh): reject numpy booleans in teleop input frames

### DIFF
--- a/strands_robots/mesh/security.py
+++ b/strands_robots/mesh/security.py
@@ -1150,17 +1150,22 @@ def validate_input_frame(action: Any) -> dict[str, float]:
         if not _INPUT_KEY_RE.fullmatch(key):
             raise ValidationError(f"input frame key has illegal characters: {key!r}")
 
-        # Coerce to float with a finite check. bool is an int subclass;
-        # reject it explicitly so a stray True/False can't masquerade as
-        # a 1.0/0.0 actuator command.
-        if isinstance(value, bool):
-            raise ValidationError(f"input frame value for {key!r} must be numeric, not bool")
+        # Unwrap numpy scalars / 0-d arrays to a python scalar BEFORE the
+        # bool check. A numpy boolean (``np.bool_``) is NOT a python ``bool``,
+        # so an early ``isinstance(value, bool)`` would not catch it; ``.item()``
+        # then yields a python ``bool`` that sails through the numeric check
+        # below (``bool`` is an ``int`` subclass) and masquerades as a 1.0/0.0
+        # actuator command. Coercing first lets the single bool gate reject
+        # both python and numpy booleans.
         if hasattr(value, "item"):
-            # numpy scalar / 0-d array -> python scalar
             try:
                 value = value.item()
             except Exception as exc:  # pragma: no cover - defensive
                 raise ValidationError(f"input frame value for {key!r} is not a scalar") from exc
+        # bool is an int subclass; reject it explicitly so a stray True/False
+        # (python- or numpy-derived) can't masquerade as a 1.0/0.0 command.
+        if isinstance(value, bool):
+            raise ValidationError(f"input frame value for {key!r} must be numeric, not bool")
         if not isinstance(value, (int, float)):
             raise ValidationError(f"input frame value for {key!r} must be numeric (got {type(value).__name__})")
         fval = float(value)

--- a/tests/mesh/test_input_validation.py
+++ b/tests/mesh/test_input_validation.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import math
 import time
 
+import numpy as np
 import pytest
 
 from strands_robots.mesh import security
@@ -61,6 +62,50 @@ def test_bool_value_rejected():
 def test_non_numeric_value_rejected():
     with pytest.raises(security.ValidationError):
         security.validate_input_frame({"j0": "0.5"})
+
+
+@pytest.mark.parametrize("np_bool", [np.bool_(True), np.bool_(False)])
+def test_numpy_bool_value_rejected(np_bool):
+    """A numpy boolean must be rejected just like a python bool.
+
+    ``np.bool_`` is not a python ``bool``, so a bool gate placed before the
+    ``.item()`` numpy-scalar coercion lets it through; once coerced it becomes
+    a python ``bool`` that passes the ``isinstance(value, (int, float))`` check
+    (``bool`` subclasses ``int``) and silently maps to a 1.0 / 0.0 actuator
+    command. A LAN-adjacent peer streaming numpy-typed frames could otherwise
+    drive a joint with ``np.True_`` despite the explicit bool defense.
+    """
+    with pytest.raises(security.ValidationError):
+        security.validate_input_frame({"j0": np_bool})
+
+
+def test_numpy_scalar_value_accepted_and_coerced():
+    """Legitimate numpy scalars (the common case for arm reads) coerce to
+    plain python floats and pass the validator."""
+    out = security.validate_input_frame({"j0": np.float32(0.5), "j1": np.int64(3)})
+    assert out == {"j0": 0.5, "j1": 3.0}
+    assert all(type(v) is float for v in out.values())
+
+
+def test_numpy_non_finite_value_rejected():
+    """A numpy non-finite scalar is unwrapped then caught by the finite check."""
+    with pytest.raises(security.ValidationError):
+        security.validate_input_frame({"j0": np.float64("nan")})
+
+
+def test_non_string_key_rejected():
+    with pytest.raises(security.ValidationError):
+        security.validate_input_frame({123: 0.5})
+
+
+def test_empty_key_rejected():
+    with pytest.raises(security.ValidationError):
+        security.validate_input_frame({"": 0.5})
+
+
+def test_overlong_key_rejected():
+    with pytest.raises(security.ValidationError):
+        security.validate_input_frame({"x" * (security.MAX_INPUT_KEY_LEN + 1): 0.5})
 
 
 # --- InputReceiver wiring tests ------------------------------------------


### PR DESCRIPTION
## Problem

`security.validate_input_frame` is the validator that guards the teleop input path: `InputReceiver._on_input` runs every streamed `{motor_name: float}` frame through it before calling `robot.send_action()`, so a LAN-adjacent peer cannot drive a follower's joints with malformed or out-of-bounds values.

The value check ran its bool gate *before* the numpy scalar coercion:

```python
if isinstance(value, bool):              # rejects python bool
    raise ValidationError(...)
if hasattr(value, "item"):               # numpy scalar -> python scalar
    value = value.item()
if not isinstance(value, (int, float)):  # bool passes (bool subclasses int)
    raise ValidationError(...)
```

A numpy boolean (`np.bool_`) is **not** a python `bool`, so it slips past the first gate. `.item()` then turns it into a python `bool`, which passes `isinstance(value, (int, float))` because `bool` subclasses `int`, and `float(True)` -> `1.0`. The validator's own comment states the intent ("reject it explicitly so a stray True/False can't masquerade as a 1.0/0.0 actuator command"), but that intent is defeated for numpy booleans:

```
>>> validate_input_frame({"j0": numpy.bool_(True)})
{'j0': 1.0}        # accepted; masquerades as an actuator command
>>> validate_input_frame({"j0": True})
ValidationError    # python bool correctly rejected
```

A publisher that reads arm state into numpy arrays (the common case) can emit `np.bool_`-typed entries, so this is reachable from the wire.

## Change

`strands_robots/mesh/security.py`: unwrap numpy scalars via `.item()` **first**, then run a single bool gate. Python `bool`/`int`/`float` have no `.item()`, so they fall straight through to the gate unchanged; numpy booleans are coerced to a python `bool` and then rejected. Both python and numpy booleans now raise `ValidationError`; legitimate numpy `float`/`int` scalars still coerce to plain python floats. No behaviour change for non-numpy inputs.

## Tests

`tests/mesh/test_input_validation.py`:
- `test_numpy_bool_value_rejected` (parametrized `np.bool_(True)`/`np.bool_(False)`) - the regression test; **fails on pre-fix code** (`DID NOT RAISE ValidationError`) and passes after.
- `test_numpy_scalar_value_accepted_and_coerced` / `test_numpy_non_finite_value_rejected` - pin the numpy `.item()` accept path and the finite check after coercion.
- `test_non_string_key_rejected` / `test_empty_key_rejected` / `test_overlong_key_rejected` - cover the previously-untested key-validation rejection branches.

```
python -m pytest tests/mesh/test_input_validation.py    # 30 passed
python -m pytest tests/mesh/                            # 1833 passed, 2 skipped
```

Verified the regression test fails on the unfixed validator and passes after. `ruff check`, `ruff format --check`, and `mypy` are clean on the changed files. Coverage of `validate_input_frame` is now complete (the bool/numpy and key-rejection branches were the remaining gaps).