### PR TITLE
feat(sim): list scene-construction methods in describe() discovery surface

### DIFF
--- a/docs/simulation/overview.md
+++ b/docs/simulation/overview.md
@@ -58,6 +58,12 @@ For walkthroughs see [Simulation overview](../simulation/overview.md).
 
 Robot-URDF cameras are auto-discovered on `add_robot`.
 
+!!! tip "Discover the scene-construction surface"
+    `add_robot`, `add_object`, `remove_object`, `add_camera`, and
+    `remove_camera` are all listed in `sim.describe()["methods"]`, so an agent
+    can learn how to build a scene (robot, manipulanda, camera rig) before a
+    rollout from one `describe()` call instead of guessing method names.
+
 ## Rendering
 
 | Action | Notes |

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -1492,6 +1492,17 @@ class SimEngine(ABC):
                 "get_robot_state": "(robot_name: str) -> dict",
                 "get_observation": "(robot_name: str | None = None, *, skip_images: bool = False) -> dict",
                 "send_action": "(action: dict, robot_name: str | None = None, n_substeps: int = 1) -> dict",
+                "add_robot": (
+                    "(name: str, urdf_path=None, data_config=None, position=None, "
+                    "orientation=None) -> dict  # add a robot to the scene by "
+                    "registry name (or urdf_path); the first scene-construction step"
+                ),
+                "add_object": (
+                    "(name: str, shape='box', position=None, orientation=None, "
+                    "size=None, color=None, mass=0.1, is_static=None, mesh_path=None) "
+                    "-> dict  # add a manipulable object (cube/sphere/.../mesh) to the scene"
+                ),
+                "remove_object": "(name: str) -> dict  # remove a previously added object",
                 "run_policy": "(robot_name: str, policy_provider='mock', n_episodes=1, reset_between=True, ...) -> dict",
                 "start_policy": "(robot_name: str, policy_provider='mock', ...) -> dict",
                 "eval_policy": (

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1156,6 +1156,15 @@ class MuJoCoSimEngine(
                     bodies.append(body_name)
         base["bodies"] = bodies
         base["methods"]["list_bodies"] = "(robot_name: str | None = None) -> dict (camera mount points)"
+        # Scene-construction cameras: the SO-101 rollout rig is built with
+        # add_camera before run_policy, so the discovery surface must name it
+        # (and its inverse) rather than leave a caller to guess.
+        base["methods"]["add_camera"] = (
+            "(name: str, position=None, target=None, fov=60.0, width=640, "
+            "height=480, parent_body=None) -> dict  # attach a camera to the "
+            "scene; parent_body mounts it on a moving link (e.g. a wrist cam)"
+        )
+        base["methods"]["remove_camera"] = "(name: str) -> dict  # remove a camera added via add_camera"
         # Rendering siblings of "render" (advertised in tool_spec.json + the
         # action dispatcher) that the base discovery surface omits. Listing
         # them here lets an agent enumerate the full render surface from

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -1486,6 +1486,12 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
                     "'registry'=registry only, 'robot_descriptions'=URDF via "
                     "robot_descriptions.<name>_description.URDF_PATH; see list_urdfs)"
                 ),
+                "add_object": (
+                    "(name: str, shape='box', position=None, orientation=None, size=None, "
+                    "color=None, mass=0.1, is_static=False, mesh_path=None) -> dict  "
+                    "(add a manipulable object -- box/sphere/.../mesh -- to the scene)"
+                ),
+                "remove_object": "(name: str) -> dict  (remove a previously added object)",
                 "get_robot_state": "(robot_name: str | None = None) -> dict (per-joint position + velocity)",
                 "get_observation": "(robot_name: str | None = None, *, skip_images: bool = False) -> dict",
                 "send_action": "(action: dict, robot_name: str | None = None, n_substeps: int = 1) -> dict",

--- a/tests/simulation/newton/test_discovery_and_state.py
+++ b/tests/simulation/newton/test_discovery_and_state.py
@@ -141,8 +141,19 @@ class TestDescribeSurface:
     def test_describe_exposes_new_methods(self, engine_so100):
         described = engine_so100.describe()
         methods = described["methods"]
-        for name in ("get_robot_state", "list_bodies", "move_object", "get_features", "list_urdfs"):
+        for name in (
+            "get_robot_state",
+            "list_bodies",
+            "move_object",
+            "get_features",
+            "list_urdfs",
+            "add_object",
+            "remove_object",
+        ):
             assert name in methods
+        # add_object advertises its real distinguishing parameter so a
+        # caller can place a manipulable object without reading source.
+        assert "shape" in methods["add_object"]
         assert described["cameras"] == ["default"]
         assert described["bodies"]
         assert described["world_created"] is True

--- a/tests/simulation/test_sim_engine_describe_discovery.py
+++ b/tests/simulation/test_sim_engine_describe_discovery.py
@@ -178,6 +178,26 @@ class TestDescribeABC:
         assert "n_episodes" in methods["eval_policy"]
         assert "repo_id" in methods["replay_episode"]
 
+    def test_describe_lists_scene_construction_methods(self):
+        """describe() advertises how to build a scene, not just run one.
+
+        Every rollout begins by constructing a scene -- add_robot, then
+        add_object for manipulanda. These are concrete/abstract methods on the
+        base contract, but describe() previously listed only the runtime
+        (observe/act/rollout) surface, so a caller enumerating
+        ``describe()["methods"]`` could not learn how to populate the world
+        without guessing the names. They belong on the discovery surface as the
+        first step a caller takes.
+        """
+        engine = _make_minimal_engine()
+        methods = engine.describe()["methods"]
+        for name in ("add_robot", "add_object", "remove_object"):
+            assert name in methods, f"describe() omits scene-construction method {name!r}"
+        # Advertised signatures name real parameters so a caller can invoke
+        # them without reading the source.
+        assert "urdf_path" in methods["add_robot"]
+        assert "shape" in methods["add_object"]
+
 
 @pytest.mark.skipif(
     not pytest.importorskip("mujoco", reason="MuJoCo not installed"),
@@ -243,6 +263,54 @@ class TestDescribeMuJoCo:
             # caller can invoke them without reading the source.
             assert "camera_name" in methods["render_depth"]
             assert "cameras" in methods["render_all"]
+        finally:
+            sim.destroy()
+
+    def test_describe_lists_scene_construction_methods(self):
+        """describe() advertises the full scene-construction surface on MuJoCo.
+
+        The documented rollout workflow is create_world -> add_robot ->
+        add_object -> add_camera -> run_policy. add_camera/remove_camera are
+        MuJoCo methods the tool spec already exposes, but the programmatic
+        discovery surface omitted them (and add_object/remove_object), so a
+        caller could not learn how to build the camera rig or place a cube from
+        one describe() call.
+        """
+        import os
+
+        os.environ.setdefault("MUJOCO_GL", "egl")
+        from strands_robots.simulation import Simulation
+
+        sim = Simulation()
+        try:
+            methods = sim.describe()["methods"]
+            for name in ("add_robot", "add_object", "remove_object", "add_camera", "remove_camera"):
+                assert name in methods, f"describe() omits scene-construction method {name!r}"
+            # Advertised signatures name the real distinguishing parameters.
+            assert "parent_body" in methods["add_camera"]
+            assert "shape" in methods["add_object"]
+        finally:
+            sim.destroy()
+
+    def test_describe_methods_resolve_to_real_attributes(self):
+        """Every method MuJoCo describe() advertises must be a real callable.
+
+        Pins the discovery-surface-is-a-contract invariant on the live engine:
+        an advertised name that is not callable would dead-end a caller in an
+        AttributeError instead of a working call.
+        """
+        import os
+
+        os.environ.setdefault("MUJOCO_GL", "egl")
+        from strands_robots.simulation import Simulation
+
+        sim = Simulation()
+        try:
+            methods = sim.describe()["methods"]
+            for name in methods:
+                assert callable(getattr(sim, name, None)), (
+                    f"describe() advertises {name!r} but it is not a callable on the engine"
+                )
         finally:
             sim.destroy()
 


### PR DESCRIPTION
## Problem

`SimEngine.describe()` is the single-call discovery surface an agent reads to learn an engine's contract instead of guessing method names. It already advertises the runtime family (`get_observation`, `send_action`, `run_policy`, `eval_policy`, `replay_episode`) and the render family (`render`, `render_depth`, `render_all`), but it omitted **scene construction** entirely:

- base: `add_robot`, `add_object`, `remove_object`
- MuJoCo: `add_camera`, `remove_camera`
- Newton: `add_object`, `remove_object` (it already listed `add_robot`, `add_camera`, `remove_camera`)

Yet every rollout begins with exactly those calls — the documented workflow is `create_world -> add_robot -> add_object -> add_camera -> run_policy`. A caller enumerating `describe()["methods"]` could learn how to *run* a policy and *render* a frame, but not how to *populate the world* or *build a camera rig* without guessing names and signatures — the probe-and-fail loop `describe()` exists to prevent.

## Change

Add the scene-construction methods to the discovery surface, mirroring how the render and rollout families are already listed:

- `SimEngine.describe()` (base): `add_robot`, `add_object`, `remove_object` — inherited by every backend that calls `super().describe()`.
- `MuJoCoSimEngine.describe()`: `add_camera`, `remove_camera`.
- `NewtonSimEngine.describe()`: `add_object`, `remove_object` (close the same gap in its independently-built methods dict).

Each advertised signature names the real distinguishing parameters (`urdf_path`/`data_config`, `shape`, `parent_body`, ...) so a caller can invoke without reading the source. No runtime behavior changes — this is purely additive metadata.

## Proof

`sim.describe()["methods"]` on a live MuJoCo engine now resolves the full scene-construction surface:

```
add_robot:     (name: str, urdf_path=None, data_config=None, position=None, orientation=None) -> dict  # ...first scene-construction step
add_object:    (name: str, shape='box', position=None, ..., mass=0.1, is_static=None, mesh_path=None) -> dict  # add a manipulable object (cube/sphere/.../mesh)
remove_object: (name: str) -> dict  # remove a previously added object
add_camera:    (name: str, position=None, target=None, fov=60.0, width=640, height=480, parent_body=None) -> dict  # ...parent_body mounts it on a moving link (wrist cam)
remove_camera: (name: str) -> dict  # remove a camera added via add_camera
```

## Tests

`tests/simulation/test_sim_engine_describe_discovery.py` and `tests/simulation/newton/test_discovery_and_state.py`:

- `test_describe_lists_scene_construction_methods` on the ABC (minimal engine) and the live MuJoCo engine — asserts the methods are advertised and their signatures name the real distinguishing parameters.
- Newton `test_describe_exposes_new_methods` extended to cover `add_object`/`remove_object`.
- `test_describe_methods_resolve_to_real_attributes` on the live MuJoCo engine — an invariant that *every* name `describe()` advertises resolves to a real callable, so a future edit cannot list a phantom method that dead-ends a caller in an `AttributeError`.

The new scene-construction assertions fail on pre-fix code (3 failures across ABC/MuJoCo/Newton) and pass after; the full discovery suite is green (34 passed, MuJoCo headless EGL). `ruff check`/`ruff format` clean; `mypy` clean on the changed modules and test files.

## Docs

`docs/simulation/overview.md` gains a "Discover the scene-construction surface" tip mirroring the existing render-surface tip.