### PR TITLE
test(sim): cover Simulation.step() non-int coercion and per-call ceiling

### DIFF
--- a/tests/simulation/mujoco/test_input_validation.py
+++ b/tests/simulation/mujoco/test_input_validation.py
@@ -66,6 +66,31 @@ class TestStepValidation:
         assert res["status"] == "success"
         assert sim_with_world._world.step_count == 3
 
+    def test_step_float_is_coerced_to_int(self, sim_with_world):
+        """A non-int but coercible n_steps (e.g. 3.0) is accepted as int(3)."""
+        res = sim_with_world.step(n_steps=3.0)
+        assert res["status"] == "success"
+        assert sim_with_world._world.step_count == 3
+
+    def test_step_non_coercible_type_errors(self, sim_with_world):
+        """A non-int n_steps that cannot be coerced errors and names the type."""
+        initial = sim_with_world._world.step_count
+        res = sim_with_world.step(n_steps="not-a-number")
+        assert res["status"] == "error"
+        msg = res["content"][0]["text"]
+        assert "n_steps must be an integer" in msg
+        assert "str" in msg
+        assert sim_with_world._world.step_count == initial, "step_count must not change on rejected call"
+
+    def test_step_exceeds_max_per_call_errors(self, sim_with_world):
+        """n_steps above the per-call ceiling is rejected without stepping."""
+        initial = sim_with_world._world.step_count
+        over = sim_with_world._MAX_STEPS_PER_CALL + 1
+        res = sim_with_world.step(n_steps=over)
+        assert res["status"] == "error"
+        assert "exceeds max" in res["content"][0]["text"]
+        assert sim_with_world._world.step_count == initial, "step_count must not change on rejected call"
+
 
 # Raycast zero-direction guard
 


### PR DESCRIPTION
## What
`Simulation.step()` already had tests for the negative-rejection and zero-no-op paths, but two real branches of its input-validation contract were untested:

- the `int()` coercion path for a non-int `n_steps` (both the success case and the non-coercible failure case), and
- the `_MAX_STEPS_PER_CALL` ceiling that bounds how long the engine lock is held in a single call.

## Change
Adds three focused cases to `TestStepValidation` in `tests/simulation/mujoco/test_input_validation.py`, asserting the public contract:

- `n_steps=3.0` is coerced to `int(3)` and advances `step_count` by 3.
- a non-coercible `n_steps` (e.g. a non-numeric string) returns `status=error`, names the offending type in the message, and leaves `step_count` unchanged.
- `n_steps` above `_MAX_STEPS_PER_CALL` is rejected without stepping (`step_count` unchanged).

Test-only; no production code changes. The cases lock observable behavior (returned status, message text, and `step_count`), not internals.

## Coverage
Closes the previously-missing branches in `strands_robots/simulation/mujoco/simulation.py` for the coercion-failure and over-ceiling returns.

## Verification
- `ruff check` / `ruff format --check` clean on `strands_robots tests tests_integ`.
- `mypy strands_robots tests tests_integ`: no issues found.
- `MUJOCO_GL=egl pytest tests/simulation/mujoco/test_input_validation.py` -> 6 passed (full `TestStepValidation`); run alongside the episode-contract suite -> 73 passed.