### PR TITLE
fix(policies): fail fast on camera/obs_rename mismatch before model download

### DIFF
--- a/docs/policies/camera-naming.md
+++ b/docs/policies/camera-naming.md
@@ -1,0 +1,76 @@
+---
+description: Camera naming for VLA policies in sim - the model-card to embodiment obs_rename translation table, the pre-flight check, and the obs_rename_override escape hatch.
+---
+
+# Camera naming (model card vs embodiment)
+
+VLA checkpoints declare image input features (e.g.
+`observation.images.image`, `observation.images.wrist_image`). The
+[LeRobot Local](lerobot-local.md) provider routes a robot/sim camera onto each
+of those features using the embodiment's `obs_rename` map
+(`{runtime_camera_name: "observation.images.*"}`).
+
+The trap: a model's HuggingFace card often describes its cameras in
+human terms ("top + side", "third-person + wrist") that do NOT match the
+runtime source key the embodiment expects. If you name your sim cameras after
+the card ("realsense_top"), the rename step never produces the model's image
+features, and inference fails with a confusing
+`image_keys missing from observation`.
+
+`run_policy` / `eval_policy` catch this with a cheap pre-flight check BEFORE any
+model weights download, returning a `status=error` that names the expected
+source camera keys and how to fix it. See
+[the pre-flight check](lerobot-local.md#embodiment-obs_rename-and-the-pre-flight-check).
+
+## Translation table
+
+Use the **embodiment source key** column when naming sim cameras
+(`sim.add_camera(name=...)`). The model-feature column is what the checkpoint
+declares internally.
+
+| Model | Embodiment | Camera source key (`add_camera` name) | Model image feature |
+| --- | --- | --- | --- |
+| `allenai/MolmoAct2-SO100_101` | `so100` / `so101` | `front` | `observation.images.image` |
+| `allenai/MolmoAct2-SO100_101` | `so100` / `so101` | `wrist` | `observation.images.wrist_image` |
+| SmolVLA (single-cam SO arm) | `so100` / `so101` | `front` | `observation.images.image` |
+| pi0 / pi0-FAST (Aloha) | `aloha` | `cam_high` | `observation.images.cam_high` |
+| pi0 / pi0-FAST (Aloha) | `aloha` | `cam_left_wrist` | `observation.images.cam_left_wrist` |
+| pi0 / pi0-FAST (Aloha) | `aloha` | `cam_right_wrist` | `observation.images.cam_right_wrist` |
+
+The authoritative source for every embodiment is its entry in
+`strands_robots/policies/lerobot_local/embodiments.json` (`obs_rename`). When in
+doubt, read the `obs_rename` keys for your embodiment - those are exactly the
+camera names the runtime observation must contain.
+
+## Two ways to satisfy the check
+
+1. **Rename your cameras** to the expected source keys:
+
+   ```python
+   sim.add_camera(name="front", position=[0.22, 0.025, 0.6], target=[0.22, 0.025, 0])
+   sim.add_camera(name="wrist", parent_body="so101/gripper")
+   ```
+
+2. **Keep your names and override** - `obs_rename_override` merges OVER the
+   embodiment's `obs_rename`, so a custom camera name routes onto the model's
+   image feature without renaming:
+
+   ```python
+   sim.run_policy(
+       robot_name="so101",
+       policy_provider="lerobot_local",
+       policy_config={
+           "pretrained_name_or_path": "allenai/MolmoAct2-SO100_101",
+           "embodiment": "so101",
+           "obs_rename_override": {
+               "realsense_top": "observation.images.image",
+               "realsense_side": "observation.images.wrist_image",
+           },
+       },
+   )
+   ```
+
+## See also
+
+- [LeRobot Local](lerobot-local.md) - camera routing, the pre-flight check, `obs_rename_override`.
+- [MolmoAct2](molmoact2.md) - the SO-100/101 action/observation contract.

--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -40,6 +40,7 @@ LerobotLocalPolicy(
     image_keys=None,                     # MolmoAct2 camera key override
     inference_action_mode="continuous",  # "continuous" | "discrete"
     camera_key_map=None,                 # {robot_cam_name: policy_image_key}
+    obs_rename_override=None,            # {runtime_obs_key: "observation.images.*"} merged over embodiment.obs_rename
     strict_keys=False,                   # raise instead of positional camera fallback
     cache_model=True,                    # reuse a process-cached model across instances
 )
@@ -258,6 +259,61 @@ policy = create_policy(
     camera_key_map={"front": "observation.images.top", "hand": "observation.images.wrist"},
 )
 ```
+
+### Embodiment `obs_rename` and the pre-flight check
+
+When you pass an `embodiment` (e.g. `embodiment="so101"`), camera routing is
+configured declaratively from the embodiment's `obs_rename` map
+(`{runtime_camera_name: "observation.images.*"}`) instead of the heuristic
+above. The runtime observation MUST therefore contain the camera names the
+embodiment declares as rename sources. For `so101` those are `front` and
+`wrist`:
+
+```json
+"obs_rename": {"front": "observation.images.image", "wrist": "observation.images.wrist_image"}
+```
+
+A camera-name mismatch (e.g. you added `realsense_top` / `realsense_side`
+because a model card said "top + side") used to surface only deep in the
+preprocessor AFTER the multi-minute weight download, as a confusing
+`image_keys missing from observation` failure. `run_policy` / `eval_policy` now
+run a cheap pre-flight check (`Policy.preflight`) BEFORE `create_policy`
+downloads anything, and return a `status=error` naming the expected source
+keys:
+
+```
+Embodiment 'so101' cannot route cameras to the model's image feature(s)
+['observation.images.image', 'observation.images.wrist_image']: none of the
+expected source key(s) ['front', 'wrist'] are in the runtime observation, which
+provides [...]. Either: (a) rename your sim cameras to one of ['front', 'wrist']
+..., or (b) pass policy_config={'obs_rename_override': {...}} ...
+```
+
+Two ways to fix it:
+
+1. Rename your cameras to the expected source keys
+   (`sim.add_camera(name="front", ...)`, `sim.add_camera(name="wrist", ...)`).
+2. Keep your custom names and pass `obs_rename_override`, which merges OVER the
+   embodiment's `obs_rename` so your names route onto the model's image
+   features without renaming cameras:
+
+   ```python
+   sim.run_policy(
+       robot_name="so101",
+       policy_provider="lerobot_local",
+       policy_config={
+           "pretrained_name_or_path": "allenai/MolmoAct2-SO100_101",
+           "embodiment": "so101",
+           "obs_rename_override": {
+               "realsense_top": "observation.images.image",
+               "realsense_side": "observation.images.wrist_image",
+           },
+       },
+   )
+   ```
+
+See [camera naming](camera-naming.md) for the model-card -> embodiment
+translation table.
 
 ## RTC
 

--- a/docs/policies/molmoact2.md
+++ b/docs/policies/molmoact2.md
@@ -26,6 +26,10 @@ processor/`norm_stats.json` bridge and camera routing, see the
 | Joint order | shoulder_pan, shoulder_lift, elbow_flex, wrist_flex, wrist_roll, gripper |
 | Cameras | `observation.images.image` (front), `observation.images.wrist_image` |
 
+The sim camera names that feed these features are `front` and `wrist` (the
+`so101` `obs_rename` source keys) - NOT "top"/"side". `run_policy` fails fast
+before download if they do not match; see [Camera Naming](camera-naming.md).
+
 The MuJoCo `so101` sim, by contrast, expresses revolute joints in **RADIANS**
 with bare numeric joint names `1..6` (the gripper is joint `6`, range
 `[-0.175, 1.745]` rad). The mismatch in both units and naming is what the

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,7 @@ nav:
   - WBC (Whole-Body-Control): policies/wbc.md
   - LeRobot Local: policies/lerobot-local.md
   - MolmoAct2 (SO-100/101): policies/molmoact2.md
+  - Camera Naming: policies/camera-naming.md
   - Custom Policies: policies/custom-policies.md
 - Real Hardware:
   - Robot Control: hardware/robot-control.md

--- a/strands_robots/policies/__init__.py
+++ b/strands_robots/policies/__init__.py
@@ -44,6 +44,7 @@ from strands_robots.policies.factory import (
     UntrustedRemoteCodeError,
     create_policy,
     list_providers,
+    preflight_policy,
     register_policy,
 )
 from strands_robots.policies.mock import MockPolicy
@@ -61,6 +62,7 @@ __all__ = [
     "MockPolicy",
     "Cosmos3Policy",
     "create_policy",
+    "preflight_policy",
     "register_policy",
     "list_providers",
     "UntrustedRemoteCodeError",

--- a/strands_robots/policies/base.py
+++ b/strands_robots/policies/base.py
@@ -222,6 +222,38 @@ class Policy(ABC):
         # reset endpoint call, etc.).
         return None
 
+    @classmethod
+    def preflight(cls, observation_keys: set[str], **policy_config: Any) -> None:
+        """Cheap pre-construction validation hook (no download, no instantiation).
+
+        Called by the simulation's ``run_policy`` / ``eval_policy`` BEFORE
+        :func:`~strands_robots.policies.create_policy` builds the policy - and
+        therefore before any model weight download - with the set of
+        observation keys the runtime will feed the policy. Override this to
+        fail fast on a misconfiguration (e.g. sim camera names that cannot be
+        routed to the model's declared image inputs) instead of surfacing it as
+        a confusing failure deep inside inference after a multi-minute weight
+        download.
+
+        The default implementation is a no-op. Implementations MUST be cheap:
+        no network access, no model instantiation - only local metadata
+        (``policy_config`` plus packaged JSON such as the embodiment registry)
+        and the provided ``observation_keys``.
+
+        Args:
+            observation_keys: Keys present in the runtime observation dict the
+                policy will receive (joint state names + attached camera
+                names), as returned by ``SimEngine.get_observation``.
+            **policy_config: The same provider kwargs that will be forwarded to
+                the policy constructor by ``create_policy``.
+
+        Raises:
+            ValueError: When the configuration cannot consume the runtime
+                observation (e.g. a required camera source key is absent and no
+                override maps an available key onto the model's image feature).
+        """
+        return None
+
     @property
     def requires_images(self) -> bool:
         """Whether this policy needs camera frames in its observation.

--- a/strands_robots/policies/factory.py
+++ b/strands_robots/policies/factory.py
@@ -87,6 +87,57 @@ def _check_trust_remote_code(provider: str) -> None:
     )
 
 
+def _resolve_policy_class(provider: str, **kwargs) -> tuple[str, type[Policy], dict]:
+    """Resolve ``provider`` to its policy class WITHOUT instantiating it.
+
+    Imports the class and computes the effective constructor kwargs using the
+    same three-stage lookup as :func:`create_policy` (runtime registry, smart
+    string, then ``policies.json``), but never calls the constructor and never
+    enforces the trust-remote-code gate. This lets callers inspect or run a
+    class-level :meth:`Policy.preflight` check before paying the cost (and,
+    for remote-code providers, the risk) of construction.
+
+    Args:
+        provider: Provider name, HF model ID, or server URL.
+        **kwargs: Provider-specific parameters.
+
+    Returns:
+        ``(canonical_provider_name, PolicyClass, resolved_kwargs)``.
+
+    Raises:
+        ImportError / ValueError: Propagated from the underlying class import
+            or smart-string resolution when the provider cannot be resolved.
+    """
+    # 1. Runtime registry (user-registered providers).
+    resolved_name = _runtime_aliases.get(provider, provider)
+    if resolved_name in _runtime_registry:
+        return resolved_name, _runtime_registry[resolved_name](), dict(kwargs)
+
+    # 2. Smart string (HF ID, URL, etc.).
+    _needs_resolution = (
+        "/" in provider
+        or (":" in provider and not provider.replace("_", "").isalpha())
+        or provider.startswith("ws://")
+        or provider.startswith("grpc://")
+        or provider.startswith("zmq://")
+    )
+    if _needs_resolution:
+        try:
+            resolved_provider, resolved_kwargs = resolve_policy(provider, **kwargs)
+        except ImportError:
+            resolved_provider = None
+            resolved_kwargs = {}
+        except Exception as e:
+            logger.warning("Policy resolution failed for '%s': %s", provider, e)
+            resolved_provider = None
+            resolved_kwargs = {}
+        if resolved_provider:
+            return resolved_provider, import_policy_class(resolved_provider), dict(resolved_kwargs)
+
+    # 3. Standard lookup from policies.json.
+    return provider, import_policy_class(provider), dict(kwargs)
+
+
 def create_policy(provider: str, **kwargs) -> Policy:
     """Create a policy instance.
 
@@ -110,39 +161,49 @@ def create_policy(provider: str, **kwargs) -> Policy:
             ``trust_remote_code=True`` and ``STRANDS_TRUST_REMOTE_CODE``
             is not set.
     """
-    # 1. Check runtime registry first (user-registered providers)
-    resolved_name = _runtime_aliases.get(provider, provider)
-    if resolved_name in _runtime_registry:
-        _check_trust_remote_code(resolved_name)
-        PolicyClass = _runtime_registry[resolved_name]()
-        return PolicyClass(**kwargs)
+    canonical, PolicyClass, resolved_kwargs = _resolve_policy_class(provider, **kwargs)
+    _check_trust_remote_code(canonical)
+    return PolicyClass(**resolved_kwargs)
 
-    # 2. Check if this looks like a smart string (HF ID, URL, etc.)
-    _needs_resolution = (
-        "/" in provider
-        or (":" in provider and not provider.replace("_", "").isalpha())
-        or provider.startswith("ws://")
-        or provider.startswith("grpc://")
-        or provider.startswith("zmq://")
-    )
 
-    if _needs_resolution:
-        try:
-            resolved_provider, resolved_kwargs = resolve_policy(provider, **kwargs)
-        except ImportError:
-            resolved_provider = None
-            resolved_kwargs = {}
-        except Exception as e:
-            logger.warning("Policy resolution failed for '%s': %s", provider, e)
-            resolved_provider = None
-            resolved_kwargs = {}
+def preflight_policy(provider: str, observation_keys: set[str], **kwargs) -> None:
+    """Run a provider's class-level :meth:`Policy.preflight` check, if any.
 
-        if resolved_provider:
-            _check_trust_remote_code(resolved_provider)
-            PolicyClass = import_policy_class(resolved_provider)
-            return PolicyClass(**resolved_kwargs)
+    Resolves ``provider`` to its policy class WITHOUT instantiating it (so no
+    model weights are downloaded) and invokes the class's ``preflight`` hook
+    with the runtime ``observation_keys`` and the provider kwargs. Providers
+    that do not override :meth:`Policy.preflight` are a no-op.
 
-    # 3. Standard lookup from policies.json
-    _check_trust_remote_code(provider)
-    PolicyClass = import_policy_class(provider)
-    return PolicyClass(**kwargs)
+    This is the fail-fast seam used by ``SimEngine.run_policy`` /
+    ``eval_policy`` to catch a misconfiguration (e.g. sim camera names that
+    cannot be routed to the model's declared image inputs) BEFORE the
+    expensive ``create_policy`` download, instead of crashing deep inside the
+    first inference. Resolution failures are swallowed (the matching error is
+    surfaced authoritatively by the subsequent ``create_policy``); only the
+    provider's own ``preflight`` ``ValueError`` propagates.
+
+    Args:
+        provider: Provider name, HF model ID, or server URL (as passed to
+            ``create_policy``).
+        observation_keys: Keys the runtime observation will contain (joint
+            names + camera names).
+        **kwargs: Provider-specific parameters (the policy_config).
+
+    Raises:
+        ValueError: When the resolved provider's ``preflight`` rejects the
+            configuration.
+    """
+    try:
+        _canonical, PolicyClass, resolved_kwargs = _resolve_policy_class(provider, **kwargs)
+    except Exception as e:
+        # Resolution problems (unknown provider, missing optional dep) are not
+        # this hook's concern - create_policy raises the authoritative error.
+        logger.debug("preflight_policy: could not resolve '%s' (%s); skipping", provider, e)
+        return
+
+    hook = getattr(PolicyClass, "preflight", None)
+    base_hook = getattr(Policy.preflight, "__func__", Policy.preflight)
+    if hook is None or getattr(hook, "__func__", hook) is base_hook:
+        # Provider did not override the default no-op preflight.
+        return
+    PolicyClass.preflight(set(observation_keys), **resolved_kwargs)

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -219,6 +219,7 @@ class LerobotLocalPolicy(Policy):
         image_keys: list[str] | None = None,
         inference_action_mode: str = "continuous",
         camera_key_map: dict[str, str] | None = None,
+        obs_rename_override: dict[str, str] | None = None,
         strict_keys: bool = False,
         cache_model: bool = True,
         **kwargs,
@@ -248,6 +249,14 @@ class LerobotLocalPolicy(Policy):
         # When None, cameras are matched by exact short name and then by
         # declared order (see _resolve_camera_targets).
         self.camera_key_map = dict(camera_key_map) if camera_key_map else None
+        # Optional override merged OVER the embodiment's declared ``obs_rename``
+        # (``{runtime_obs_key: "observation.images.*"}``). Lets a caller keep
+        # custom sim camera names (e.g. ``realsense_top``) and still route them
+        # onto the model's declared image features without renaming cameras.
+        # Merged in :meth:`_configure_embodiment`; also consulted by the
+        # class-level :meth:`preflight` so the override is honoured before any
+        # model download.
+        self._obs_rename_override = dict(obs_rename_override) if obs_rename_override else None
         # When True, raise instead of routing cameras positionally if their
         # names cannot be matched to the policy's declared image keys (and no
         # camera_key_map covers them). Defaults to False (positional fallback
@@ -944,6 +953,82 @@ class LerobotLocalPolicy(Policy):
 
     # Embodiment configuration (declarative obs/action mapping)
 
+    @classmethod
+    def preflight(cls, observation_keys: set[str], **policy_config: Any) -> None:
+        """Validate camera routing against the embodiment BEFORE any download.
+
+        The crash this prevents: a VLA checkpoint (e.g. MolmoAct2 SO-100/101)
+        declares image input features that the embodiment's ``obs_rename`` feeds
+        from named runtime keys (e.g. ``front`` -> ``observation.images.image``).
+        If the sim's attached camera names do not match any source key for a
+        model image feature, the mismatch only surfaces deep in the preprocessor
+        after the multi-minute weight download, as a confusing "image_keys
+        missing from observation" failure. This hook catches it up front.
+
+        Resolution: the model needs every declared image feature populated, so
+        for each image rename TARGET (``observation.images.*``) at least one of
+        its source keys must be present in ``observation_keys``. A caller-
+        supplied ``obs_rename_override`` is merged over the embodiment's
+        ``obs_rename`` first, so an explicit override that maps a present camera
+        onto the feature satisfies the check.
+
+        No-op when no ``embodiment`` is configured (the policy then uses the
+        legacy heuristic camera routing, which this hook cannot reason about),
+        or when the embodiment name/spec cannot be resolved (``create_policy``
+        surfaces that error authoritatively).
+
+        Args:
+            observation_keys: Runtime observation keys (joint + camera names).
+            **policy_config: Provider kwargs (``embodiment``,
+                ``obs_rename_override``, ...).
+
+        Raises:
+            ValueError: When a model image feature has no satisfiable source
+                camera key in ``observation_keys``.
+        """
+        spec = policy_config.get("embodiment")
+        if spec is None:
+            return
+        from .embodiment import load_embodiment
+
+        try:
+            embodiment = load_embodiment(spec)
+        except Exception:  # noqa: BLE001 - unknown/odd spec; create_policy reports it
+            return
+
+        obs_rename = dict(embodiment.obs_rename)
+        override = policy_config.get("obs_rename_override") or {}
+        obs_rename.update(override)
+
+        # Group source keys by the image feature TARGET they feed. A target is
+        # satisfied when ANY of its sources is present in the observation, so an
+        # override that maps a present camera onto the feature counts even if
+        # the embodiment's default source key is absent.
+        targets: dict[str, list[str]] = {}
+        for src, dst in obs_rename.items():
+            if "image" in dst:
+                targets.setdefault(dst, []).append(src)
+        if not targets:
+            return
+
+        obs = set(observation_keys)
+        unsatisfied = {dst: srcs for dst, srcs in targets.items() if not any(s in obs for s in srcs)}
+        if not unsatisfied:
+            return
+
+        expected = sorted({s for srcs in unsatisfied.values() for s in srcs})
+        missing_features = sorted(unsatisfied)
+        raise ValueError(
+            f"Embodiment {embodiment.name!r} cannot route cameras to the model's image "
+            f"feature(s) {missing_features}: none of the expected source key(s) {expected} "
+            f"are in the runtime observation, which provides {sorted(obs)}. Either:\n"
+            f"  (a) rename your sim cameras to one of {expected} "
+            f"(e.g. sim.add_camera(name={expected[0]!r}, ...)), or\n"
+            f"  (b) pass policy_config={{'obs_rename_override': "
+            f"{{'<your_camera_name>': '{missing_features[0]}'}}}} to map an existing "
+            f"camera onto the model's image feature without renaming it."
+        )
+
     def _configure_embodiment(self) -> None:
         """Build, validate, and inject the declarative embodiment map (SOLUTION.md).
 
@@ -984,6 +1069,15 @@ class LerobotLocalPolicy(Policy):
             embodiment = load_embodiment(spec)
         except ValueError as exc:
             raise RuntimeError(f"Failed to load embodiment {spec!r}: {exc}") from exc
+
+        # Merge any caller-supplied obs_rename override OVER the embodiment's
+        # declared renames so custom sim camera names route onto the model's
+        # image features without renaming cameras. Override entries win.
+        if self._obs_rename_override:
+            from dataclasses import replace
+
+            merged = {**embodiment.obs_rename, **self._obs_rename_override}
+            embodiment = replace(embodiment, obs_rename=merged)
 
         # Fail-fast validation against the model's declared features.
         embodiment.validate(self._input_features, self._output_features)

--- a/strands_robots/policies/lerobot_local/processor.py
+++ b/strands_robots/policies/lerobot_local/processor.py
@@ -140,6 +140,11 @@ class ProcessorBridge:
         self._preprocessor = preprocessor
         self._postprocessor = postprocessor
         self._device = device
+        # The embodiment's obs_rename map ({runtime_key: model_feature}),
+        # latched by apply_embodiment. Used to enrich the 'image_keys
+        # missing' preprocessor failure with the expected camera source
+        # keys and what the runtime observation actually provided.
+        self._obs_rename: dict[str, str] = {}
 
     @classmethod
     def from_pretrained(
@@ -354,6 +359,7 @@ class ProcessorBridge:
 
         # Pipelines are mutable dataclasses; reassign the steps sequence.
         self._preprocessor.steps = steps
+        self._obs_rename = dict(embodiment.obs_rename)
         logger.info(
             "Embodiment '%s' applied: rename=%d keys, state_keys=%d, dim_policy=%s -> %d pipeline steps",
             embodiment.name,
@@ -454,7 +460,41 @@ class ProcessorBridge:
                 return merged
             return obs_out
         except Exception as exc:
-            raise RuntimeError(f"Preprocessor pipeline failed: {exc}") from exc
+            raise RuntimeError(f"Preprocessor pipeline failed: {exc}{self._camera_hint(exc, observation)}") from exc
+
+    def _camera_hint(self, exc: Exception, observation: dict[str, Any]) -> str:
+        """Actionable hint appended to an "image_keys missing" preprocessor error.
+
+        VLA preprocessors (e.g. MolmoAct2's ``pack_inputs``) raise when a
+        declared image feature is absent from the (already renamed) observation.
+        That happens when the runtime camera names do not match any source key
+        in the embodiment's ``obs_rename``, so the rename step never produces
+        the model's ``observation.images.*`` features. The raw error names only
+        the model feature keys, not the camera names to fix, so we append the
+        expected source camera key(s) and what the observation actually
+        provided. Returns an empty string for unrelated failures.
+
+        Args:
+            exc: The exception raised inside the pipeline.
+            observation: The raw observation fed to the pipeline.
+
+        Returns:
+            A "\nHint: ..." suffix, or "" when the failure is not an
+            image-keys mismatch or no obs_rename is known.
+        """
+        if "image_keys missing" not in str(exc) or not self._obs_rename:
+            return ""
+        expected = sorted(src for src, dst in self._obs_rename.items() if "image" in dst)
+        if not expected:
+            return ""
+        got = sorted(observation) if isinstance(observation, dict) else []
+        return (
+            f"\nHint: this usually means the runtime camera names do not match the "
+            f"embodiment's obs_rename. Expected camera source key(s): {expected}. "
+            f"Observation provided: {got}. Rename your cameras to the expected key(s), "
+            f"or pass policy_config={{'obs_rename_override': {{'<your_camera>': "
+            f"'observation.images.<feature>'}}}}."
+        )
 
     def postprocess(self, action: Any) -> Any:
         """Postprocess a policy action through the pipeline.

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -266,6 +266,44 @@ class SimEngine(ABC):
         """
         return None
 
+    def _preflight_policy_config(
+        self,
+        robot_name: str,
+        policy_provider: str,
+        policy_config: dict[str, Any] | None,
+    ) -> dict[str, Any] | None:
+        """Run a provider's pre-construction preflight before ``create_policy``.
+
+        Resolves the provider's policy class WITHOUT instantiating it and runs
+        its :meth:`~strands_robots.policies.base.Policy.preflight` hook (a
+        no-op for providers that do not override it) against the runtime
+        observation keys. This catches a misconfiguration - e.g. sim camera
+        names that cannot be routed to a VLA's declared image inputs - BEFORE
+        the expensive model-weight download, instead of crashing deep inside
+        the first inference.
+
+        Args:
+            robot_name: Robot whose observation keys define the runtime inputs.
+            policy_provider: Provider name / smart string passed to
+                ``create_policy``.
+            policy_config: Provider kwargs (the policy_config).
+
+        Returns:
+            A ``status=error`` dict (for the caller to return) when the
+            provider's preflight rejects the configuration; ``None`` when the
+            check passes, is a no-op, or the observation is not yet available.
+        """
+        from strands_robots.policies import preflight_policy
+
+        obs = self.get_observation(robot_name)
+        if not isinstance(obs, dict) or not obs:
+            return None
+        try:
+            preflight_policy(policy_provider, set(obs.keys()), **(policy_config or {}))
+        except ValueError as e:
+            return {"status": "error", "content": [{"text": str(e)}]}
+        return None
+
     # Object management
 
     @abstractmethod
@@ -578,13 +616,19 @@ class SimEngine(ABC):
                 "content": [{"text": f"Robot '{robot_name}' not found."}],
             }
 
-        if policy_object is not None:
+        if policy_object is None:
+            # Fail fast on a misconfiguration (e.g. camera names that cannot be
+            # routed to the policy's declared image inputs) BEFORE the expensive
+            # create_policy weight download.
+            preflight_error = self._preflight_policy_config(robot_name, policy_provider, policy_config)
+            if preflight_error is not None:
+                return preflight_error
+            policy = create_policy(policy_provider, **(policy_config or {}))
+        else:
             # Pre-built policy path - skip the expensive create_policy call.
             # Caller is responsible for policy.set_robot_state_keys(...) if needed,
             # but we set it here defensively so the semantics match the provider path.
             policy = policy_object
-        else:
-            policy = create_policy(policy_provider, **(policy_config or {}))
         policy.set_robot_state_keys(self.robot_joint_names(robot_name))
         self.bind_policy_sim_context(policy, robot_name)
 
@@ -1184,15 +1228,19 @@ class SimEngine(ABC):
             }
         resolved_robot = robot_name
 
-        if policy_object is not None:
+        if policy_object is None:
+            from strands_robots.policies import create_policy
+
+            # Fail fast on a misconfiguration BEFORE the create_policy download.
+            preflight_error = self._preflight_policy_config(resolved_robot, policy_provider, policy_config)
+            if preflight_error is not None:
+                return preflight_error
+            policy = create_policy(policy_provider, **(policy_config or {}))
+        else:
             # Pre-built policy path - mirror run_policy. Caller may have already
             # set robot_state_keys; we set defensively so semantics match the
             # provider path.
             policy = policy_object
-        else:
-            from strands_robots.policies import create_policy
-
-            policy = create_policy(policy_provider, **(policy_config or {}))
         policy.set_robot_state_keys(self.robot_joint_names(resolved_robot))
         self.bind_policy_sim_context(policy, resolved_robot)
 

--- a/tests/policies/lerobot_local/test_camera_obs_rename_preflight.py
+++ b/tests/policies/lerobot_local/test_camera_obs_rename_preflight.py
@@ -1,0 +1,292 @@
+"""Camera <-> embodiment ``obs_rename`` alignment is validated before download.
+
+A VLA checkpoint (e.g. MolmoAct2 SO-100/101) declares image input features that
+the embodiment's ``obs_rename`` feeds from named runtime keys
+(``front`` -> ``observation.images.image``). When the sim's attached camera
+names do not match any source key for a model image feature, the mismatch used
+to surface only deep inside the preprocessor AFTER a multi-minute weight
+download, as a confusing "image_keys missing from observation" failure.
+
+These tests pin the fail-fast behavior:
+
+* :meth:`LerobotLocalPolicy.preflight` raises a ``ValueError`` naming the
+  expected camera source keys when none are present, passes when they are, and
+  is satisfied by an ``obs_rename_override`` that maps a present camera onto the
+  model feature;
+* :func:`strands_robots.policies.preflight_policy` dispatches to the resolved
+  provider class without instantiating it (a no-op for providers that do not
+  override ``preflight``);
+* ``SimEngine.run_policy`` / ``eval_policy`` short-circuit with a
+  ``status=error`` result BEFORE ``create_policy`` is ever called;
+* ``ProcessorBridge`` enriches the deep "image_keys missing" failure with the
+  expected camera source keys and what the observation actually provided;
+* ``obs_rename_override`` merges over the embodiment's ``obs_rename`` when the
+  policy configures its embodiment.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from strands_robots.policies import preflight_policy
+from strands_robots.policies.base import Policy
+from strands_robots.policies.lerobot_local.embodiment import EmbodimentMap
+from strands_robots.policies.lerobot_local.policy import LerobotLocalPolicy
+from strands_robots.policies.lerobot_local.processor import ProcessorBridge
+from strands_robots.simulation.base import SimEngine
+
+SO101_CAMS = {"front", "wrist"}
+SO101_JOINTS = {"1", "2", "3", "4", "5", "6"}
+
+
+# ---------------------------------------------------------------------------
+# LerobotLocalPolicy.preflight (the embodiment-aware check)
+# ---------------------------------------------------------------------------
+def test_preflight_passes_when_camera_names_match_embodiment():
+    """No raise when the observation carries the embodiment's source keys."""
+    LerobotLocalPolicy.preflight(SO101_CAMS | SO101_JOINTS, embodiment="so101")
+
+
+def test_preflight_raises_naming_expected_cameras_on_mismatch():
+    """Mismatched camera names raise, naming both the model features and fix."""
+    with pytest.raises(ValueError) as ei:
+        LerobotLocalPolicy.preflight({"realsense_top", "realsense_side"} | SO101_JOINTS, embodiment="so101")
+    msg = str(ei.value)
+    # Expected camera source names the user must provide.
+    assert "front" in msg and "wrist" in msg
+    # Names the model image features it could not satisfy.
+    assert "observation.images.image" in msg
+    # Points at both escape hatches.
+    assert "obs_rename_override" in msg
+    # Shows what the runtime actually provided.
+    assert "realsense_top" in msg
+
+
+def test_preflight_satisfied_by_obs_rename_override():
+    """An override mapping a present camera onto the feature satisfies preflight."""
+    LerobotLocalPolicy.preflight(
+        {"realsense_top", "realsense_side"} | SO101_JOINTS,
+        embodiment="so101",
+        obs_rename_override={
+            "realsense_top": "observation.images.image",
+            "realsense_side": "observation.images.wrist_image",
+        },
+    )
+
+
+def test_preflight_partial_override_still_raises_for_unmapped_feature():
+    """Overriding only one feature still raises for the other unmapped one."""
+    with pytest.raises(ValueError) as ei:
+        LerobotLocalPolicy.preflight(
+            {"realsense_top"} | SO101_JOINTS,
+            embodiment="so101",
+            obs_rename_override={"realsense_top": "observation.images.image"},
+        )
+    # The wrist feature remains unsatisfied; its default source key is named.
+    assert "wrist" in str(ei.value)
+    assert "observation.images.wrist_image" in str(ei.value)
+
+
+def test_preflight_noop_without_embodiment():
+    """No embodiment -> the legacy heuristic path; preflight cannot reason, no-op."""
+    LerobotLocalPolicy.preflight({"whatever"})  # must not raise
+
+
+def test_preflight_noop_for_unknown_embodiment_name():
+    """Unknown embodiment names are left for create_policy to report."""
+    LerobotLocalPolicy.preflight({"front"}, embodiment="totally_unknown_embodiment")
+
+
+# ---------------------------------------------------------------------------
+# Factory dispatch: preflight_policy
+# ---------------------------------------------------------------------------
+def test_preflight_policy_noop_for_provider_without_override():
+    """A provider that does not override Policy.preflight is a no-op."""
+    preflight_policy("mock", {"anything", "at", "all"})  # must not raise
+
+
+def test_preflight_policy_dispatches_to_lerobot_local():
+    """preflight_policy routes the check to the resolved lerobot_local class."""
+    with pytest.raises(ValueError):
+        preflight_policy("lerobot_local", {"realsense_top"}, embodiment="so101")
+
+
+def test_preflight_policy_swallows_unresolvable_provider():
+    """Resolution failures are not this hook's concern (create_policy reports)."""
+    preflight_policy("definitely_not_a_provider", {"front"})  # must not raise
+
+
+def test_base_policy_preflight_is_a_noop():
+    """The ABC default is a no-op so most providers need no override."""
+    assert Policy.preflight(set(), foo="bar") is None
+
+
+# ---------------------------------------------------------------------------
+# SimEngine.run_policy / eval_policy fail fast BEFORE create_policy
+# ---------------------------------------------------------------------------
+class _CamSim(SimEngine):
+    """Minimal SimEngine stub whose observation carries named camera keys."""
+
+    def __init__(self, camera_keys: tuple[str, ...]) -> None:
+        self._joints = ["1", "2", "3", "4", "5", "6"]
+        self._cams = list(camera_keys)
+
+    def create_world(self, timestep=None, gravity=None, ground_plane=True):  # type: ignore[no-untyped-def]
+        return {"status": "success"}
+
+    def destroy(self):  # type: ignore[no-untyped-def]
+        return {"status": "success"}
+
+    def reset(self):  # type: ignore[no-untyped-def]
+        return {"status": "success"}
+
+    def step(self, n_steps: int = 1):  # type: ignore[no-untyped-def]
+        return {"status": "success"}
+
+    def get_state(self):  # type: ignore[no-untyped-def]
+        return {"sim_time": 0.0, "step_count": 0}
+
+    def add_robot(self, name, **kw):  # type: ignore[no-untyped-def]
+        return {"status": "success"}
+
+    def remove_robot(self, name):  # type: ignore[no-untyped-def]
+        return {"status": "success"}
+
+    def list_robots(self) -> list[str]:
+        return ["so101"]
+
+    def robot_joint_names(self, robot_name: str) -> list[str]:
+        return list(self._joints)
+
+    def add_object(self, name, **kw):  # type: ignore[no-untyped-def]
+        return {"status": "success"}
+
+    def remove_object(self, name):  # type: ignore[no-untyped-def]
+        return {"status": "success"}
+
+    def get_observation(self, robot_name=None, *, skip_images=False):  # type: ignore[no-untyped-def]
+        obs: dict[str, object] = {j: 0.0 for j in self._joints}
+        for c in self._cams:
+            obs[c] = object()  # stand-in for an RGB frame; only keys matter
+        return obs
+
+    def send_action(self, action, robot_name=None, n_substeps=1):  # type: ignore[no-untyped-def]
+        return {"status": "success"}
+
+    def render(self, camera_name="default", width=None, height=None):  # type: ignore[no-untyped-def]
+        return {"status": "success", "content": []}
+
+
+def _exploding_create_policy(*_a, **_k):
+    raise AssertionError("create_policy must not be called when preflight fails")
+
+
+def test_run_policy_fails_fast_before_create_policy_on_camera_mismatch():
+    """run_policy returns status=error from preflight, never reaching create_policy."""
+    sim = _CamSim(camera_keys=("realsense_top", "realsense_side"))
+    with patch("strands_robots.policies.create_policy", _exploding_create_policy):
+        result = sim.run_policy(
+            robot_name="so101",
+            policy_provider="lerobot_local",
+            policy_config={"embodiment": "so101", "pretrained_name_or_path": "x"},
+            n_steps=2,
+            control_frequency=10.0,
+        )
+    assert result["status"] == "error"
+    text = result["content"][0]["text"]
+    assert "front" in text and "wrist" in text
+
+
+def test_eval_policy_fails_fast_before_create_policy_on_camera_mismatch():
+    """eval_policy mirrors run_policy's fail-fast preflight."""
+    sim = _CamSim(camera_keys=("realsense_top", "realsense_side"))
+    with patch("strands_robots.policies.create_policy", _exploding_create_policy):
+        result = sim.eval_policy(
+            robot_name="so101",
+            policy_provider="lerobot_local",
+            policy_config={"embodiment": "so101", "pretrained_name_or_path": "x"},
+            n_episodes=1,
+            max_steps=2,
+        )
+    assert result["status"] == "error"
+    assert "front" in result["content"][0]["text"]
+
+
+def test_preflight_policy_config_returns_none_when_cameras_match():
+    """Correct camera names let the preflight helper pass through (returns None)."""
+    sim = _CamSim(camera_keys=("front", "wrist"))
+    assert sim._preflight_policy_config("so101", "lerobot_local", {"embodiment": "so101"}) is None
+
+
+# ---------------------------------------------------------------------------
+# ProcessorBridge crash-site error enrichment
+# ---------------------------------------------------------------------------
+def test_camera_hint_enriches_image_keys_missing_error():
+    """The deep 'image_keys missing' failure gains expected/actual camera names."""
+    bridge = ProcessorBridge()
+    bridge._obs_rename = {
+        "front": "observation.images.image",
+        "wrist": "observation.images.wrist_image",
+    }
+    hint = bridge._camera_hint(
+        RuntimeError("MolmoAct2 image_keys missing from observation: [...]"),
+        {"realsense_top": object(), "1": 0.0},
+    )
+    assert "front" in hint and "wrist" in hint
+    assert "realsense_top" in hint
+    assert "obs_rename_override" in hint
+
+
+def test_camera_hint_empty_for_unrelated_error():
+    """Unrelated pipeline failures get no camera hint."""
+    bridge = ProcessorBridge()
+    bridge._obs_rename = {"front": "observation.images.image"}
+    assert bridge._camera_hint(RuntimeError("CUDA out of memory"), {"front": object()}) == ""
+
+
+def test_camera_hint_empty_without_obs_rename():
+    """No latched obs_rename (legacy path) -> no hint even on image-keys error."""
+    bridge = ProcessorBridge()
+    assert bridge._camera_hint(RuntimeError("image_keys missing"), {}) == ""
+
+
+# ---------------------------------------------------------------------------
+# obs_rename_override merges into the configured embodiment
+# ---------------------------------------------------------------------------
+def _feature(dim: int) -> MagicMock:
+    feat = MagicMock()
+    feat.shape = (dim,)
+    return feat
+
+
+def test_obs_rename_override_merges_into_configured_embodiment():
+    """_configure_embodiment merges obs_rename_override over the embodiment map."""
+    with patch.object(LerobotLocalPolicy, "_load_model"):
+        policy = LerobotLocalPolicy(
+            embodiment=EmbodimentMap(
+                name="so101_test",
+                obs_rename={"front": "observation.images.image"},
+                state_keys=["1", "2", "3", "4", "5", "6"],
+                action_keys=["1", "2", "3", "4", "5", "6"],
+                dim_policy="pad",
+            ),
+            obs_rename_override={"realsense_side": "observation.images.wrist_image"},
+        )
+    policy._input_features = {
+        "observation.images.image": _feature(3),
+        "observation.images.wrist_image": _feature(3),
+        "observation.state": _feature(6),
+    }
+    policy._output_features = {"action": _feature(6)}
+    bridge = MagicMock(name="ProcessorBridge")
+    policy._processor_bridge = bridge
+
+    policy._configure_embodiment()
+
+    applied = bridge.apply_embodiment.call_args.args[0]
+    assert applied.obs_rename == {
+        "front": "observation.images.image",
+        "realsense_side": "observation.images.wrist_image",
+    }


### PR DESCRIPTION
## Problem

A `lerobot_local` VLA checkpoint (e.g. `allenai/MolmoAct2-SO100_101`) declares image input features that the embodiment's `obs_rename` feeds from named runtime keys (`front` -> `observation.images.image`, `wrist` -> `observation.images.wrist_image`). If the sim's attached camera names do not match any source key for a model image feature, the mismatch only surfaces deep inside the LeRobot preprocessor **after** a multi-minute weight download, as a confusing:

```
RuntimeError: Preprocessor pipeline failed: MolmoAct2 image_keys missing from observation: ['observation.images.image', 'observation.images.wrist_image'].
```

There was no upfront validation, so a wrongly-named camera rig (e.g. naming cameras `realsense_top`/`realsense_side` after a model card that says "top + side") wasted minutes per attempt and looked like the policy "runs but does not move" - the policy never executed a single inference.

## Change

Add a cheap pre-construction validation seam plus an explicit escape hatch.

- **`Policy.preflight(observation_keys, **policy_config)`** - optional classmethod hook on the policy ABC (default no-op). `run_policy` / `eval_policy` call it BEFORE `create_policy`, so a misconfiguration is caught before any model download.
- **`preflight_policy(provider, observation_keys, **kwargs)`** factory dispatch - resolves the provider class WITHOUT instantiating it (extracted a shared `_resolve_policy_class`; the trust-remote-code gate stays in `create_policy`) and runs its `preflight`. No-op for providers that do not override it (mock, groot, ...).
- **`LerobotLocalPolicy.preflight`** - for each declared model image feature, requires that at least one of its `obs_rename` source keys is present in the runtime observation. Raises a `ValueError` naming the expected camera source keys, what the observation actually provided, and both fixes.
- **`obs_rename_override` policy_config kwarg** - merges OVER the embodiment's `obs_rename` so custom camera names route onto the model's image features without renaming cameras. Honoured by both `preflight` and `_configure_embodiment`.
- **Crash-site hint** - `ProcessorBridge` enriches the deep "image_keys missing" failure with the expected source keys and the observation keys, for callers that bypass preflight (a pre-built `policy_object` or direct processor use).

`run_policy` / `eval_policy` now return a `status=error` from the preflight before `create_policy` is ever called. The trust-remote-code gate is unaffected (preflight reads only local metadata; the gate still fires at construction).

Resulting error on a mismatch (before any download):

```
Embodiment 'so101' cannot route cameras to the model's image feature(s)
['observation.images.image', 'observation.images.wrist_image']: none of the
expected source key(s) ['front', 'wrist'] are in the runtime observation, which
provides [...]. Either: (a) rename your sim cameras to one of ['front', 'wrist']
..., or (b) pass policy_config={'obs_rename_override': {...}} ...
```

## Tests

`tests/policies/lerobot_local/test_camera_obs_rename_preflight.py` (17 tests) pins: matching / mismatch / override / partial-override / no-embodiment / unknown-embodiment; factory dispatch (mock no-op, lerobot_local raise, unresolvable swallowed); `run_policy` and `eval_policy` fail-fast asserting `create_policy` is **never called** when preflight fails; the `obs_rename_override` merge into the configured embodiment; and the processor crash-site hint. The fail-fast tests fail on pre-change code (the mismatch reaches `create_policy`).

Green locally: `ruff check` + `ruff format --check` + `mypy strands_robots tests tests_integ` clean; `pytest tests/policies` = 1208 passed.

## Visual artifact

MuJoCo rollout (headless EGL) of `so101` viewed from the embodiment-correct `front` camera - the camera name the new pre-flight steers users toward (90 frames, 640x480 h264):

![so101 front-camera rollout](https://github.com/cagataycali/robots/releases/download/harness-artifact-camera-preflight/so101_front_rollout.gif)

## Docs

- New `docs/policies/camera-naming.md`: model-card -> embodiment `obs_rename` translation table for popular checkpoints.
- `docs/policies/lerobot-local.md`: `obs_rename_override` parameter + the pre-flight check section.
- `docs/policies/molmoact2.md`: cross-reference that the so101 cameras are `front`/`wrist`, not "top"/"side".