### PR TITLE
feat(sim): accept ordered action vectors in send_action

### DIFF
--- a/docs/simulation/overview.md
+++ b/docs/simulation/overview.md
@@ -98,6 +98,17 @@ Robot-URDF cameras are auto-discovered on `add_robot`.
 | `get_energy` | - |
 | `get_sensor_data` | `sensor_name` (optional) |
 
+## Actions
+
+`send_action(action, robot_name=None, n_substeps=1)` writes actuator/joint targets and advances physics. `action` accepts either form:
+
+| Form | Binding |
+|------|---------|
+| `{joint_or_actuator_name: value}` mapping | applied by name; unresolved keys are reported in an `unresolved_keys` JSON block so a caller can self-correct (no silent drop) |
+| ordered numeric vector (`list` / `tuple` / 1-D `numpy` array) | bound positionally to `robot_joint_names(robot_name)` in declaration order - the same convention `replay_episode` uses |
+
+A vector lets a policy's raw action chunk drive the arm directly without first zipping it into a dict. The vector length must match the robot's joint count exactly; a mismatch (or a non-numeric / scalar / string `action`) returns a structured `status="error"` dict naming the joint count and order, rather than crashing or silently truncating commands. Use a mapping to target a subset of joints.
+
 ## Policy
 
 | Action | Key params |

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import logging
 import os
 from abc import ABC, abstractmethod
-from collections.abc import Callable
+from collections.abc import Callable, Mapping, Sequence
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -326,8 +326,83 @@ class SimEngine(ABC):
         """
         ...
 
+    def _coerce_action(
+        self, action: dict[str, Any] | Sequence[float], robot_name: str
+    ) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+        """Normalize an action into a ``{joint/actuator name: value}`` mapping.
+
+        Policies and the ``Robot`` ABC commonly emit an ordered action *vector*
+        (a ``list`` / ``tuple`` / 1-D ``numpy`` array) rather than a name->value
+        mapping. To keep :meth:`send_action` usable directly with such a vector -
+        and consistent with :meth:`replay_episode`, which already binds a recorded
+        action vector positionally to ``robot_joint_names`` - a sequence is zipped
+        against ``robot_joint_names(robot_name)`` in declaration order. A mapping
+        is returned unchanged. The vector length must match the robot's joint
+        count exactly; a mismatch is reported as a caller error rather than
+        silently truncated (which would drop commands - e.g. a gripper axis).
+
+        Args:
+            action: A ``{name: value}`` mapping, or an ordered numeric vector
+                whose entries correspond to ``robot_joint_names(robot_name)``.
+            robot_name: Resolved robot whose joint order defines the binding.
+
+        Returns:
+            An ``(action_dict, error)`` tuple. When ``error`` is non-None it is a
+            structured ``{"status": "error", ...}`` dict and ``action_dict`` must
+            be ignored. Otherwise ``action_dict`` is the normalized mapping.
+        """
+        if isinstance(action, Mapping):
+            return dict(action), None
+
+        # ``str``/``bytes`` are iterable but never a valid multi-joint action;
+        # a scalar has no length. Reject both with an actionable message instead
+        # of producing garbage character/positional keys downstream.
+        if isinstance(action, (str, bytes)) or not hasattr(action, "__len__"):
+            return None, {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            "send_action: 'action' must be a mapping of "
+                            "{joint/actuator name: value} or an ordered numeric "
+                            f"vector, got {type(action).__name__}."
+                        )
+                    }
+                ],
+            }
+
+        try:
+            values = [float(v) for v in action]
+        except (TypeError, ValueError) as exc:
+            return None, {
+                "status": "error",
+                "content": [{"text": f"send_action: action vector has a non-numeric entry: {exc}."}],
+            }
+
+        joint_names = self.robot_joint_names(robot_name)
+        if len(values) != len(joint_names):
+            return None, {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            f"send_action: action vector length {len(values)} does not "
+                            f"match robot '{robot_name}' joint count {len(joint_names)}. "
+                            f"Joints (in order): {joint_names}. Pass a {{name: value}} "
+                            "mapping to target a subset of joints."
+                        )
+                    }
+                ],
+            }
+        return {name: value for name, value in zip(joint_names, values)}, None
+
     @abstractmethod
-    def send_action(self, action: dict[str, Any], robot_name: str | None = None, n_substeps: int = 1) -> dict[str, Any]:
+    def send_action(
+        self,
+        action: dict[str, Any] | Sequence[float],
+        robot_name: str | None = None,
+        n_substeps: int = 1,
+    ) -> dict[str, Any]:
         """Apply action and advance physics by n_substeps.
 
         Contract: each call writes actuator/ctrl values and then runs

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -49,7 +49,7 @@ import os
 import re
 import threading
 import time
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Sequence
 from concurrent.futures import Future, ThreadPoolExecutor
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -298,8 +298,21 @@ class MuJoCoSimEngine(
         with self._lock:
             return self._get_sim_observation(robot_name, skip_images=skip_images)
 
-    def send_action(self, action: dict[str, Any], robot_name: str | None = None, n_substeps: int = 1) -> dict[str, Any]:
+    def send_action(
+        self,
+        action: dict[str, Any] | Sequence[float],
+        robot_name: str | None = None,
+        n_substeps: int = 1,
+    ) -> dict[str, Any]:
         """Apply action to simulation (Robot ABC compatible).
+
+        ``action`` is normally a ``{joint/actuator name: value}`` mapping, but an
+        ordered numeric vector (``list`` / ``tuple`` / 1-D ``numpy`` array) is
+        also accepted and bound positionally to ``robot_joint_names(robot_name)``
+        - the same positional convention :meth:`replay_episode` uses - so a
+        policy's raw action vector can be applied directly. A vector whose length
+        does not match the robot's joint count is rejected with an actionable
+        error rather than silently truncated.
 
         Thread-safety: acquires self._lock around ctrl writes + mj_step,
         as documented in base.py's SimEngine contract. Concurrent calls
@@ -321,11 +334,15 @@ class MuJoCoSimEngine(
             robot_name = next(iter(self._world.robots))
         if robot_name not in self._world.robots:
             return {"status": "error", "content": [{"text": f"Robot '{robot_name}' not found."}]}
+        action_map, coerce_error = self._coerce_action(action, robot_name)
+        if coerce_error is not None:
+            return coerce_error
+        assert action_map is not None  # narrow for mypy: no error implies a mapping
         with self._lock:
             self._unresolved_action_keys: list[str] = []
-            self._apply_sim_action(robot_name, action, n_substeps=n_substeps)
+            self._apply_sim_action(robot_name, action_map, n_substeps=n_substeps)
             unresolved = self._unresolved_action_keys
-        applied = [k for k in action if k not in unresolved]
+        applied = [k for k in action_map if k not in unresolved]
         if unresolved:
             # Surface the actual valid actuator names so the user can
             # self-correct without inspecting the MJCF by hand.

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -620,8 +620,19 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
                     obs_out[cam_name] = img
         return obs_out
 
-    def send_action(self, action: dict[str, Any], robot_name: str | None = None, n_substeps: int = 1) -> dict[str, Any]:
+    def send_action(
+        self,
+        action: dict[str, Any] | Sequence[float],
+        robot_name: str | None = None,
+        n_substeps: int = 1,
+    ) -> dict[str, Any]:
         """Apply position targets and advance physics by ``n_substeps``.
+
+        ``action`` may be a ``{joint name: target}`` mapping or an ordered
+        numeric vector (``list`` / ``tuple`` / 1-D ``numpy`` array) bound
+        positionally to ``robot_joint_names(robot_name)`` - the same positional
+        convention :meth:`replay_episode` uses. A vector whose length does not
+        match the robot's joint count is rejected with an actionable error.
 
         Args:
             action: Mapping of short joint name to target position (radians).
@@ -644,12 +655,17 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         if robot_name not in self._world.robots:
             return {"status": "error", "content": [{"text": f"Robot '{robot_name}' not found."}]}
 
+        action_map, coerce_error = self._coerce_action(action, robot_name)
+        if coerce_error is not None:
+            return coerce_error
+        assert action_map is not None  # narrow for mypy: no error implies a mapping
+
         valid = set(self._world.robots[robot_name].joint_names)
-        unresolved = [k for k in action if k not in valid]
-        applied = [k for k in action if k in valid]
+        unresolved = [k for k in action_map if k not in valid]
+        applied = [k for k in action_map if k in valid]
         with self._lock:
             for jname in applied:
-                self._targets[(robot_name, jname)] = float(action[jname])
+                self._targets[(robot_name, jname)] = float(action_map[jname])
             self._write_targets()
             self._advance(n_substeps)
 

--- a/tests/simulation/mujoco/test_send_action_vector.py
+++ b/tests/simulation/mujoco/test_send_action_vector.py
@@ -1,0 +1,81 @@
+"""Regression tests: send_action accepts an ordered action vector.
+
+A policy's ``get_actions`` naturally emits an ordered action *vector* (a list /
+tuple / 1-D numpy array), not a ``{joint: value}`` mapping. Before the fix,
+passing such a vector to ``send_action`` crashed deep in the actuator/joint
+name-lookup loop with ``AttributeError: 'list' object has no attribute 'items'``
+- a cryptic failure far from the call site. ``replay_episode`` already binds a
+recorded action vector positionally to ``robot_joint_names``, so ``send_action``
+is made consistent: a vector is zipped against the robot's joint order, a mapping
+is applied unchanged, and an ill-typed / wrong-length action returns an
+actionable error instead of crashing or being silently dropped.
+"""
+
+import numpy as np
+import pytest
+
+from strands_robots.simulation.mujoco.simulation import Simulation
+
+
+@pytest.fixture
+def sim():
+    s = Simulation()
+    s.create_world()
+    s.add_robot("so101")
+    yield s
+    s.cleanup()
+
+
+class TestSendActionVector:
+    def test_list_vector_applies_positionally(self, sim):
+        """A list action vector binds positionally to robot_joint_names."""
+        joints = sim.robot_joint_names("so101")
+        vector = [0.3, 0.2, 0.1, 0.0, 0.0, 0.0]
+        assert len(vector) == len(joints)
+
+        result = sim.send_action(vector, robot_name="so101", n_substeps=10)
+
+        assert result["status"] == "success", result
+        # All joints resolved -> no unresolved-keys json block.
+        assert not any(isinstance(b, dict) and b.get("json", {}).get("unresolved_keys") for b in result["content"])
+
+    def test_numpy_vector_applies(self, sim):
+        """A 1-D numpy array is accepted just like a list."""
+        result = sim.send_action(np.array([0.1, 0.2, 0.0, 0.0, 0.0, 0.0]), robot_name="so101", n_substeps=5)
+        assert result["status"] == "success", result
+
+    def test_vector_actually_moves_the_arm(self, sim):
+        """A non-trivial vector target drives the joints away from rest."""
+        before = sim.get_observation(robot_name="so101", skip_images=True)
+        sim.send_action([0.6, 0.5, 0.4, 0.0, 0.0, 0.0], robot_name="so101", n_substeps=60)
+        after = sim.get_observation(robot_name="so101", skip_images=True)
+        joints = sim.robot_joint_names("so101")
+        moved = sum(abs(float(after[j]) - float(before[j])) for j in joints if j in before and j in after)
+        assert moved > 1e-3, f"arm did not move under a vector action (delta={moved})"
+
+    def test_dict_action_still_works(self, sim):
+        """The original mapping contract is unchanged (backward compatible)."""
+        result = sim.send_action({"1": 0.0, "2": 0.0}, robot_name="so101", n_substeps=2)
+        assert result["status"] == "success", result
+
+    def test_wrong_length_vector_is_actionable_error(self, sim):
+        """A length mismatch reports the joint count + names, not a crash."""
+        result = sim.send_action([0.1, 0.2, 0.3], robot_name="so101")
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert "length 3" in text
+        assert "joint count 6" in text
+        # The valid joint order is surfaced so the caller can self-correct.
+        assert "1" in text and "6" in text
+
+    def test_scalar_action_is_actionable_error(self, sim):
+        """A scalar (no length) is rejected with a clear message, not a crash."""
+        result = sim.send_action(5.0, robot_name="so101")
+        assert result["status"] == "error"
+        assert "mapping" in result["content"][0]["text"]
+
+    def test_string_action_is_rejected(self, sim):
+        """A str is iterable but never a valid action; reject it explicitly."""
+        result = sim.send_action("oops", robot_name="so101")
+        assert result["status"] == "error"
+        assert "mapping" in result["content"][0]["text"]

--- a/tests/simulation/test_foundation.py
+++ b/tests/simulation/test_foundation.py
@@ -4,6 +4,7 @@ These tests verify the lightweight simulation abstractions without
 requiring MuJoCo or any heavy dependencies.
 """
 
+from collections.abc import Sequence
 from typing import Any
 
 import pytest
@@ -94,7 +95,7 @@ def _make_dummy_engine_class() -> type[SimEngine]:
             return {}
 
         def send_action(
-            self, action: dict[str, Any], robot_name: str | None = None, n_substeps: int = 1
+            self, action: dict[str, Any] | Sequence[float], robot_name: str | None = None, n_substeps: int = 1
         ) -> dict[str, Any]:
             return {"status": "success", "content": [{"text": "ok"}]}
 

--- a/tests/simulation/test_sim_engine_describe_discovery.py
+++ b/tests/simulation/test_sim_engine_describe_discovery.py
@@ -10,6 +10,7 @@ Also pins the no-alias rule: the registry must NOT export a duplicate
 it from the discovery surface rather than the API carrying a second name.
 """
 
+from collections.abc import Sequence
 from typing import Any
 
 import pytest
@@ -90,7 +91,7 @@ def _make_minimal_engine():
 
         def send_action(
             self,
-            action: dict[str, Any],
+            action: dict[str, Any] | Sequence[float],
             robot_name: str | None = None,
             n_substeps: int = 1,
         ) -> dict[str, Any]:


### PR DESCRIPTION
## Problem

`send_action(action, robot_name=None, n_substeps=1)` was typed and implemented for a `{joint/actuator name: value}` mapping only. But a policy's `get_actions` naturally emits an ordered action *vector* (a `list` / `tuple` / 1-D `numpy` array), and that is what a caller reaches for first. Passing one today:

- **MuJoCo** crashes deep in the actuator/joint name-lookup loop with `AttributeError: 'list' object has no attribute 'items'` - a cryptic failure far from the call site.
- **Newton** silently drops the whole vector: it iterates the list, treats each float *value* as an unknown joint *key*, and reports `unresolved_keys` full of numbers while applying nothing.

`replay_episode` already binds a recorded action vector positionally to `robot_joint_names`, so the two entry points disagree on what an action vector means.

## Change

Add `SimEngine._coerce_action(action, robot_name)` (concrete helper on the ABC, alongside `_resolve_horizon`) that normalizes an action into a `{joint: value}` mapping:

- a `Mapping` is returned unchanged (the original contract, fully backward compatible);
- an ordered numeric vector (`list` / `tuple` / 1-D `numpy` array) is zipped against `robot_joint_names(robot_name)` in declaration order - the **same** positional convention `replay_episode` uses;
- a length mismatch, or an ill-typed action (scalar / `str` / `bytes` / non-numeric entry), returns a structured `status="error"` dict that names the joint count and order, instead of crashing or silently truncating commands (e.g. dropping a gripper axis).

Both the MuJoCo and Newton `send_action` paths route through the helper, and the type annotation is widened to `dict[str, Any] | Sequence[float]` on the ABC and both backends.

## Tests

`tests/simulation/mujoco/test_send_action_vector.py` - list / numpy vectors apply and actually move the arm, a dict still works (backward compat), and wrong-length / scalar / string actions return actionable errors. The vector cases **fail pre-fix** with the exact `AttributeError: 'list' object has no attribute 'items'` and pass after.

Green locally: `ruff check` + `ruff format --check` clean, `mypy strands_robots tests tests_integ` clean (no issues in 560 files), and `MUJOCO_GL=egl pytest` on the new test plus the touched/adjacent sim suites - 194 passed.

## Demo

SO-101 in MuJoCo (headless EGL) driven directly by positional action vectors (lists and numpy arrays) through `send_action`:

![send_action vector rollout](https://github.com/cagataycali/robots/releases/download/artifact-send-action-vector/send_action_vector.gif)

MP4: https://github.com/cagataycali/robots/releases/download/artifact-send-action-vector/send_action_vector.mp4

Docs: a new **Actions** section in `docs/simulation/overview.md` documents both accepted action forms.