### PR TITLE
test(training): cover Gr00tTrainer.validate core-field branches

### DIFF
--- a/tests/training/test_groot.py
+++ b/tests/training/test_groot.py
@@ -86,6 +86,30 @@ class TestValidate:
         problems = Gr00tTrainer().validate(spec)
         assert any("modality_config_path does not exist" in p for p in problems)
 
+    @pytest.mark.parametrize(
+        ("mutate", "expected"),
+        [
+            (lambda s: setattr(s, "dataset_root", ""), "dataset_root is required"),
+            (lambda s: setattr(s, "base_model", ""), "base_model is required"),
+            (lambda s: setattr(s, "output_dir", ""), "output_dir is required"),
+            (lambda s: setattr(s, "method", "bogus"), "unsupported method 'bogus'"),
+            (lambda s: setattr(s, "steps", 0), "steps must be > 0"),
+        ],
+    )
+    def test_required_field_branch(self, spec, mutate, expected):
+        """Each missing/invalid core field surfaces its own problem string."""
+        mutate(spec)
+        problems = Gr00tTrainer().validate(spec)
+        assert any(expected in p for p in problems), problems
+
+    def test_dataset_root_without_info_json_rejected(self, spec, tmp_path):
+        """A dataset_root dir lacking meta/info.json is not a v3 root."""
+        empty = tmp_path / "not_a_dataset"
+        empty.mkdir()
+        spec.dataset_root = str(empty)
+        problems = Gr00tTrainer().validate(spec)
+        assert any("is not a LeRobotDataset v3 root" in p for p in problems), problems
+
 
 class TestBuildCommand:
     def test_single_gpu_core_flags(self, spec):


### PR DESCRIPTION
## Problem
`Gr00tTrainer.validate()` flags six core-field problems that had no direct test coverage. The existing `TestValidate` cases only flipped `embodiment` / `num_nodes` / `groot_root` / `modality_config_path`, so these branches were never exercised:

- empty `dataset_root` -> `dataset_root is required`
- a `dataset_root` dir lacking `meta/info.json` -> `is not a LeRobotDataset v3 root`
- missing `base_model` -> `base_model is required`
- missing `output_dir` -> `output_dir is required`
- unsupported `method` -> `unsupported method '...'`
- non-positive `steps` -> `steps must be > 0`

## Change
Adds a parametrized test asserting each missing/invalid core field surfaces its own problem string, plus a focused test for the non-v3 `dataset_root` path (real dir without `meta/info.json`). Assertions are behavior-only (on `validate()` output), not implementation details.

## Coverage
`strands_robots/training/groot.py`: the six validate branch lines (124, 126, 132, 134, 139, 145) are now covered (module 91% -> ~94%). No production code changed.

## Test
```
MUJOCO_GL=egl python -m pytest tests/training/test_groot.py -q
# 40 passed
```
Lint/format/mypy clean (ruff check, ruff format --check, mypy).