### PR TITLE
fix(simulation): validate replay_episode robot_name and reject negative episode index

### DIFF
--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -891,8 +891,12 @@ def load_lerobot_episode(repo_id: str, episode: int = 0, root: str | None = None
 
     Raises:
         ImportError: If lerobot is not installed.
-        ValueError: If the episode is out of range or has no frames.
+        ValueError: If the episode index is negative, out of range, or the
+            resolved episode has no frames.
     """
+    if episode < 0:
+        raise ValueError(f"Episode index must be non-negative, got {episode}")
+
     from lerobot.datasets.lerobot_dataset import LeRobotDataset
 
     ds = LeRobotDataset(repo_id=repo_id, root=root)

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -1145,8 +1145,11 @@ class PolicyRunner:
 
         Args:
             repo_id: HuggingFace dataset id (e.g. ``lerobot/pusht``).
-            robot_name: Target robot. Defaults to first robot in the sim.
-            episode: Episode index in the dataset.
+            robot_name: Target robot. Defaults to the first robot in the sim
+                when omitted; an explicit name not present in the sim is
+                rejected with a structured error (no silent replay onto a
+                non-existent robot).
+            episode: Episode index in the dataset (non-negative).
             root: Optional local dataset root override.
             speed: Playback speed multiplier (1.0 = real time).
             action_key_map: Optional list of joint names, one per action
@@ -1166,6 +1169,17 @@ class PolicyRunner:
             resolved_robot = robot_name or self._require_default_robot()
         except ValueError as e:
             return {"status": "error", "content": [{"text": f"{e}"}]}
+
+        # Validate the target robot is actually in the sim before applying any
+        # actions. Without this an explicit ``robot_name`` that does not exist
+        # silently "replays" onto a phantom robot (send_action no-ops), mirroring
+        # neither run_policy nor eval_policy, both of which reject unknown robots.
+        robots = self.sim.list_robots()
+        if resolved_robot not in robots:
+            return {
+                "status": "error",
+                "content": [{"text": f"Robot '{resolved_robot}' not found in sim. Available robots: {robots}"}],
+            }
 
         try:
             ds, episode_start, episode_length = load_lerobot_episode(repo_id, episode, root)

--- a/tests/simulation/test_policy_runner_paths.py
+++ b/tests/simulation/test_policy_runner_paths.py
@@ -57,6 +57,31 @@ def test_replay_no_robots_errors_cleanly():
     assert "No robots" in r["content"][0]["text"]
 
 
+def test_replay_unknown_robot_name_errors_before_loading(monkeypatch):
+    """An explicit ``robot_name`` that is not in the sim must fail fast.
+
+    Previously replay() used ``robot_name`` verbatim without checking
+    membership, so an unknown name silently "replayed" onto a phantom robot
+    (send_action no-ops) and reported success - unlike run_policy/eval_policy,
+    which reject unknown robots. The check must run BEFORE the dataset loader,
+    so a typo does not trigger a wasted dataset download; the loader is
+    monkeypatched to fail loudly if it is ever reached.
+    """
+    sim = _MinimalSim(robots=["r0"])
+
+    import strands_robots.dataset_recorder as dr
+
+    def _must_not_load(*args, **kwargs):
+        raise AssertionError("load_lerobot_episode reached despite unknown robot")
+
+    monkeypatch.setattr(dr, "load_lerobot_episode", _must_not_load, raising=False)
+
+    r = PolicyRunner(sim).replay(repo_id="some/dataset", robot_name="ghost")
+    assert r["status"] == "error"
+    assert "ghost" in r["content"][0]["text"]
+    assert "not found" in r["content"][0]["text"]
+
+
 def test_replay_dataset_loader_raises_is_handled(monkeypatch):
     sim = _MinimalSim(robots=["r0"])
 

--- a/tests/test_dataset_recorder.py
+++ b/tests/test_dataset_recorder.py
@@ -1262,3 +1262,19 @@ def test_has_lerobot_dataset_does_not_negatively_cache(monkeypatch):
     # Failure clears: the very next call must re-probe and resolve True.
     monkeypatch.setitem(sys.modules, "lerobot.datasets.lerobot_dataset", real_module)
     assert dr.has_lerobot_dataset() is True
+
+
+def test_load_lerobot_episode_rejects_negative_index():
+    """A negative episode index is a programming error, not episode N-1.
+
+    ``load_lerobot_episode`` previously only guarded the upper bound
+    (``episode >= num_episodes``); a negative index fell through to Python's
+    negative list indexing, silently resolving (and replaying) the LAST
+    episode while reporting the negative number. Reject it up front, before
+    any dataset construction, so the contract holds even without lerobot
+    installed and without a network round-trip.
+    """
+    from strands_robots.dataset_recorder import load_lerobot_episode
+
+    with pytest.raises(ValueError, match="non-negative"):
+        load_lerobot_episode("any/repo", episode=-1)


### PR DESCRIPTION
## Problem

`Simulation.replay_episode` / `PolicyRunner.replay` accepted two invalid inputs **silently**, contradicting the fail-fast contract that `run_policy` and `eval_policy` already enforce.

**1. Unknown `robot_name` silently "succeeds".** An explicit `robot_name` was used verbatim with no membership check. Replaying onto a robot that does not exist reports success while `send_action` no-ops onto a phantom robot:

```
>>> sim.replay_episode(repo_id=ds, robot_name="ghost", root=root)
{'status': 'success', 'content': [{'text': "Replayed episode 0 from ... on 'ghost'\nFrames: 30/30 ..."}]}   # no robot named 'ghost' exists
```

`run_policy` and `eval_policy` both reject unknown robots (`Robot '...' not found`); `replay_episode` did not.

**2. Negative `episode` index silently replays the wrong episode.** The range guard only checked the upper bound (`episode >= num_episodes`). A negative index slipped through and fell into Python negative list-indexing, resolving (and replaying) the **last** episode while reporting the negative number:

```
>>> sim.replay_episode(repo_id=ds, robot_name="so101", episode=-1, root=root)
{'status': 'success', 'content': [{'text': 'Replayed episode -1 ... Frames: 30/30 ...'}]}   # silently replayed the last episode
```

## Change

- `PolicyRunner.replay`: validate `resolved_robot in self.sim.list_robots()` **before** loading the dataset, so a typo fails fast (and avoids a wasted dataset download) with `Robot '<name>' not found in sim. Available robots: [...]`.
- `load_lerobot_episode`: reject `episode < 0` up front, before any `LeRobotDataset` construction, so the contract holds even without lerobot installed and without a network round-trip (`ValueError: Episode index must be non-negative, got -1`).

After the fix both inputs return a structured error; a valid replay is unchanged.

## Tests

Two regression tests that fail on pre-fix code and pass after:
- `tests/simulation/test_policy_runner_paths.py::test_replay_unknown_robot_name_errors_before_loading` - monkeypatches the dataset loader to raise if reached, proving validation precedes loading. Pre-fix: the loader is reached (`AssertionError`).
- `tests/test_dataset_recorder.py::test_load_lerobot_episode_rejects_negative_index` - asserts a clean `ValueError`. Pre-fix: a negative index proceeds to dataset construction (`RepositoryNotFoundError`/negative-index) instead.

## Verification

Validated end-to-end against a real recorded LeRobotDataset (SO-101 in MuJoCo, headless `MUJOCO_GL=egl`, 30 frames, per-camera video streams): record -> reopen -> `replay_episode` round-trips 30/30 frames for valid inputs, while `episode=-1` and `robot_name="ghost"` now fail fast. Local gate green: `ruff check` / `ruff format --check` clean, `mypy strands_robots tests tests_integ` reports no issues, and the policy-runner + dataset-recorder suites pass (207 passed, 2 skipped).