### PR TITLE
test(sim): cover verify_dataset_episodes missing-parquet error path

### DIFF
--- a/tests/simulation/test_run_policy_episode_contract.py
+++ b/tests/simulation/test_run_policy_episode_contract.py
@@ -162,6 +162,40 @@ class TestVerifyDatasetEpisodes:
         result = sim.verify_dataset_episodes(expected=-1)
         assert result["status"] == "error"
 
+    def test_verify_missing_episode_parquet_returns_full_contract(self, sim, tmp_path):
+        """A finalized dataset whose episode parquet later goes missing must
+        fail loudly with the full json contract, not crash.
+
+        An interrupted finalize or a partially-deleted dataset leaves the
+        recorded root in place but with no ``meta/episodes/**/*.parquet``. The
+        parquet read then raises FileNotFoundError; verify must convert that
+        into a structured ``status="error"`` carrying the complete machine-
+        checkable block (actual 0, no info header, sources disagree) so CI can
+        fail programmatically instead of hitting an unhandled exception.
+        """
+        root = str(tmp_path / "vmissing")
+        _record(sim, root, n_episodes=2, n_steps=3)
+        # Confirm it verifies before we corrupt it (guards against a no-op test).
+        assert sim.verify_dataset_episodes(expected=2)["status"] == "success"
+
+        removed = list((tmp_path / "vmissing" / "meta" / "episodes").glob("**/*.parquet"))
+        assert removed, "expected at least one episode parquet to remove"
+        for pf in removed:
+            pf.unlink()
+
+        result = sim.verify_dataset_episodes(expected=2)
+        assert result["status"] == "error"
+        assert "never finalized" in result["content"][0]["text"]
+        vj = _json_block(result)
+        assert vj["expected"] == 2
+        assert vj["actual"] == 0
+        assert vj["info_total_episodes"] is None
+        assert vj["sources_agree"] is False
+        assert vj["episode_indices"] == []
+        assert vj["total_frames"] == 0
+        assert vj["total_frames_per_ep"] == []
+        assert vj["root"] == root
+
 
 class TestInfoParquetCrossCheck:
     """verify_dataset_episodes requires meta/info.json AND parquet to agree.


### PR DESCRIPTION
## Problem

`SimEngine.verify_dataset_episodes` is the definitive post-`stop_recording` check that a collection run produced N distinct episodes. When the parquet read raises `FileNotFoundError` (no `meta/episodes/**/*.parquet` under the active root), it converts that into a structured `status="error"` carrying the full machine-checkable json block so CI can fail programmatically instead of hitting an unhandled exception.

That error branch had no test coverage. It is a real, reachable scenario: an interrupted finalize or a partially-deleted dataset leaves the recorded root in place but with no episode parquet, and an agent (or CI) calling `verify_dataset_episodes` then depends on the structured verdict rather than a traceback.

## Change

Add one focused regression test to `TestVerifyDatasetEpisodes` in `tests/simulation/test_run_policy_episode_contract.py`:

- Record two episodes end to end (`start_recording` -> `run_policy` -> `stop_recording`) into a tmp root, headless MuJoCo.
- Assert it verifies green first (guards against a no-op test).
- Remove the `meta/episodes/**/*.parquet` files to simulate an interrupted finalize / partially-deleted dataset.
- Assert `verify_dataset_episodes(expected=2)` now returns `status="error"`, the `never finalized` explanation, and every documented json field: `expected=2`, `actual=0`, `info_total_episodes=None`, `sources_agree=False`, `episode_indices=[]`, `total_frames=0`, `total_frames_per_ep=[]`, `root`.

This pins the FileNotFoundError branch's exact contract shape, which a future refactor could silently drop.

## Coverage

`strands_robots/simulation/base.py` `verify_dataset_episodes` FileNotFoundError branch: previously uncovered (the structured-error return body), now covered. The only remaining uncovered line in that method is the `except ImportError` sub-branch, which is unreachable when pyarrow is installed (it ships with the lerobot extra).

## Verification

Test-only change, no production behavior touched. Validated headless on `MUJOCO_GL=egl`: the full `tests/simulation/test_run_policy_episode_contract.py` suite passes (16 passed). Local gate green: `ruff check` / `ruff format --check` clean, `mypy strands_robots tests tests_integ` reports no issues (562 source files).