### PR TITLE
fix(sim): fire on_frame on the success_fn eval path and expose it on eval_policy

### DIFF
--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -1259,6 +1259,7 @@ class SimEngine(ABC):
         seed: int | None = None,
         async_rtc: bool = False,
         rtc_inference_timeout_s: float | None = None,
+        on_frame: Callable[[int, dict[str, Any], dict[str, Any]], None] | None = None,
     ) -> dict[str, Any]:
         """Multi-episode policy evaluation via ``PolicyRunner.evaluate``.
 
@@ -1287,6 +1288,16 @@ class SimEngine(ABC):
         bounds each async inference (structured error instead of a hung
         rollout). For benchmark-style latency masking use
         :meth:`run_policy` (``async_rtc=...``).
+
+        ``on_frame`` is an optional ``(step, observation, action) -> None``
+        hook fired per applied control step on the eval thread, immediately
+        after ``sim.send_action`` - the success-rate analogue of the
+        :meth:`run_policy` / :meth:`evaluate_benchmark` hook. ``step`` is a
+        monotonic index that continues across episode boundaries. Use it to
+        record frames or stream telemetry synchronously on the eval thread
+        (e.g. paired with ``start_cameras_recording_synchronous``) so a
+        daemon-thread recorder does not race ``mjData`` mutations. A hook
+        exception is logged at WARN and never aborts the eval.
         """
         if not robot_name:
             return {
@@ -1332,6 +1343,7 @@ class SimEngine(ABC):
             seed=seed,
             async_rtc=async_rtc,
             rtc_inference_timeout_s=rtc_inference_timeout_s,
+            on_frame=on_frame,
         )
 
     # Benchmark protocol facades

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -1303,11 +1303,12 @@ class PolicyRunner:
                 when ``spec`` is provided.
             on_frame: Optional ``(step, observation, action) -> None`` hook
                 fired per applied control step on the eval thread, after
-                ``sim.send_action``. Currently only forwarded on the
-                ``spec=`` path (the legacy ``success_fn`` path doesn't
-                expose telemetry hooks). Use this for synchronous
-                recording when the eval runs on a thread distinct from
-                the script main (e.g. Strands ``Agent`` tool dispatch
+                ``sim.send_action``. Forwarded on BOTH the ``spec=`` and the
+                legacy ``success_fn`` paths; ``step`` is a monotonic index
+                that continues across episode boundaries. A hook exception is
+                logged at WARN and never aborts the eval. Use this for
+                synchronous recording when the eval runs on a thread distinct
+                from the script main (e.g. Strands ``Agent`` tool dispatch
                 under asyncio) - see #191 and
                 :meth:`~strands_robots.simulation.mujoco.simulation.Simulation.start_cameras_recording_synchronous`.
             async_rtc: Opt-in overlap of policy inference with action-chunk
@@ -1422,6 +1423,24 @@ class PolicyRunner:
             return list(actions[: resolve_chunk_length(policy, action_horizon)])
 
         results: list[dict[str, Any]] = []
+        # #191 - monotonic global step index handed to ``on_frame`` so a
+        # synchronous recorder/telemetry hook sees a continuous count across
+        # episode boundaries, exactly like the spec eval path and ``run()``.
+        global_step = 0
+
+        def _fire_on_frame(obs: dict[str, Any], action: dict[str, Any]) -> None:
+            # Fire AFTER ``send_action`` (post-action obs unavailable yet, so
+            # pass the pre-action obs the chunk was queried with - matches
+            # ``_evaluate_with_spec``). The hook is best-effort telemetry: a
+            # failure is logged at WARN and never aborts the eval.
+            nonlocal global_step
+            if on_frame is not None:
+                try:
+                    on_frame(global_step, obs, action)
+                except Exception as e:  # noqa: BLE001 - hook is best-effort telemetry
+                    logger.warning("on_frame hook failed at global_step=%d: %s", global_step, e)
+            global_step += 1
+
         for ep in range(n_episodes):
             self.sim.reset()
             success = False
@@ -1446,6 +1465,7 @@ class PolicyRunner:
                         if steps >= max_steps:
                             break
                         self.sim.send_action(action_dict, robot_name=robot_name, n_substeps=n_substeps)
+                        _fire_on_frame(_observation, action_dict)
                         steps += 1
                         # Check success against the LIVE post-action observation
                         # (mirrors the synchronous path / _evaluate_with_spec).
@@ -1477,6 +1497,7 @@ class PolicyRunner:
                         if steps >= max_steps:
                             break
                         self.sim.send_action(action_dict, robot_name=robot_name, n_substeps=n_substeps)
+                        _fire_on_frame(observation, action_dict)
                         steps += 1
                         # Check success against the LIVE post-action observation,
                         # not the stale pre-action obs. Checking the pre-action

--- a/tests/simulation/test_policy_runner_behaviour.py
+++ b/tests/simulation/test_policy_runner_behaviour.py
@@ -676,3 +676,85 @@ class TestRunPolicyStructuredResult:
         # Recording was requested but produced no frames -> path None.
         assert payload["video_path"] is None
         assert payload["video_frames"] == 0
+
+
+class TestEvaluateOnFrameSuccessFnPath:
+    """The ``on_frame`` hook must fire on the legacy ``success_fn`` eval path.
+
+    Regression for the hook being accepted by ``PolicyRunner.evaluate`` (and
+    surfaced via ``Simulation.eval_policy``) yet silently dropped on the
+    non-benchmark path - the path ``eval_policy`` actually drives by default.
+    """
+
+    def test_success_fn_path_fires_on_frame_once_per_applied_step(self, sim_with_robot):
+        policy = MockPolicy()
+        policy.set_robot_state_keys(sim_with_robot.robot_joint_names("alice"))
+        runner = PolicyRunner(sim_with_robot)
+
+        steps_seen: list[int] = []
+
+        def on_frame(step: int, obs: dict, action: dict) -> None:
+            steps_seen.append(step)
+
+        result = runner.evaluate(
+            "alice",
+            policy,
+            n_episodes=2,
+            max_steps=3,
+            control_frequency=50,
+            on_frame=on_frame,
+        )
+        assert result["status"] == "success"
+
+        # Hook fired at least once and crossed the episode boundary (proves the
+        # global counter is continuous, not reset per episode).
+        assert steps_seen, "on_frame never fired on the success_fn eval path"
+        assert steps_seen == sorted(steps_seen)
+        assert steps_seen == list(range(len(steps_seen)))
+        assert len(steps_seen) > 3, "hook did not continue into the second episode"
+
+        # Exactly one hook call per applied control step (MockPolicy always
+        # emits a non-empty chunk, so applied steps == sum of per-episode steps).
+        json_block = next(b["json"] for b in result["content"] if "json" in b)
+        applied = sum(ep["steps"] for ep in json_block["episodes"])
+        assert len(steps_seen) == applied
+
+    def test_default_on_frame_none_is_noop(self, sim_with_robot):
+        policy = MockPolicy()
+        policy.set_robot_state_keys(sim_with_robot.robot_joint_names("alice"))
+        runner = PolicyRunner(sim_with_robot)
+        result = runner.evaluate("alice", policy, n_episodes=1, max_steps=2, control_frequency=50)
+        assert result["status"] == "success"
+
+    def test_on_frame_exception_is_logged_not_fatal(self, sim_with_robot):
+        policy = MockPolicy()
+        policy.set_robot_state_keys(sim_with_robot.robot_joint_names("alice"))
+        runner = PolicyRunner(sim_with_robot)
+
+        def boom(step: int, obs: dict, action: dict) -> None:
+            raise ValueError("hook blew up")
+
+        # A best-effort telemetry hook must never abort the eval.
+        result = runner.evaluate("alice", policy, n_episodes=1, max_steps=2, control_frequency=50, on_frame=boom)
+        assert result["status"] == "success"
+
+    def test_eval_policy_public_surface_forwards_on_frame(self, sim_with_robot):
+        policy = MockPolicy()
+        policy.set_robot_state_keys(sim_with_robot.robot_joint_names("alice"))
+
+        seen: list[int] = []
+
+        def on_frame(step: int, obs: dict, action: dict) -> None:
+            seen.append(step)
+
+        result = sim_with_robot.eval_policy(
+            robot_name="alice",
+            policy_object=policy,
+            n_episodes=1,
+            max_steps=2,
+            control_frequency=50,
+            on_frame=on_frame,
+        )
+        assert result["status"] == "success"
+        assert seen, "eval_policy did not forward on_frame to the success_fn path"
+        assert seen == sorted(seen)

--- a/tests/simulation/test_policy_runner_recorder_episode_boundary.py
+++ b/tests/simulation/test_policy_runner_recorder_episode_boundary.py
@@ -104,10 +104,10 @@ class TestRecorderEpisodeBoundary:
         policy.set_robot_state_keys(sim_with_robot.robot_joint_names("alice"))
         runner = PolicyRunner(sim_with_robot)
 
-        # Use on_frame to pump add_frame so the recorder buffer is non-empty
-        # when finalize is called. evaluate() does not call on_frame in the
-        # base loop, so feed via a stub helper instead: pretend each step
-        # added a frame.
+        # Pump add_frame per policy step so the recorder buffer is non-empty
+        # when finalize is called. This test wraps ``policy.get_actions``
+        # (rather than ``on_frame``) to keep the recorder feed independent of
+        # the hook under test elsewhere.
         def fake_step_recorder() -> None:
             rec.add_frame()
 


### PR DESCRIPTION
## Problem

`PolicyRunner.evaluate` accepts an `on_frame` hook but only invokes it on the `spec=`/benchmark path. The legacy `success_fn` path - the one `Simulation.eval_policy` actually drives by default - silently dropped it. So a caller passing `on_frame` to record frames or stream telemetry *during a success-rate eval* got a no-op hook, with no error. Worse, `Simulation.eval_policy` did not expose `on_frame` at all, even though its siblings `run_policy` and `evaluate_benchmark` do, so there was no public way to capture a rollout while measuring success rate (you had to run the policy twice over diverging episodes).

The gap was even documented in a test comment: `evaluate() does not call on_frame in the base loop`.

## Change

- Fire `on_frame(global_step, observation, action)` after every `send_action` on **both** the synchronous and `async_rtc` `success_fn` branches of `PolicyRunner.evaluate`, mirroring the `spec` path exactly:
  - a monotonic `global_step` index that stays continuous across episode boundaries,
  - post-action timing with the pre-action observation the chunk was queried with,
  - best-effort contract: a hook exception is logged at WARN and never aborts the eval.
- Expose `on_frame` on `Simulation.eval_policy` and forward it through, so the capability is reachable from the public surface and consistent with `run_policy` / `evaluate_benchmark`.
- Update the `evaluate` docstring (hook now fires on both paths) and correct the stale test comment.

This closes the obvious use case: capture a per-step rollout video synchronously on the eval thread (avoiding the daemon-thread recorder racing `mjData`) while `eval_policy` measures success rate, in a single pass.

## Tests

Added `TestEvaluateOnFrameSuccessFnPath` (MuJoCo + `MockPolicy`, CPU-only):
- hook fires exactly once per applied control step, indices monotonic and continuous across two episodes (`steps_seen == range(...)`, `len == sum(per-episode steps)`);
- `on_frame=None` default is a no-op;
- a raising hook is tolerated (eval still succeeds);
- `eval_policy(on_frame=...)` public surface forwards the hook end-to-end.

Two of these fail on pre-fix code (`on_frame never fired` and `eval_policy() got an unexpected keyword argument 'on_frame'`); all pass after. Full related suite green (139 passed across the policy_runner / eval test files), `ruff check`/`ruff format`/`mypy` clean on `strands_robots tests tests_integ`.

## Visual proof

A SmolVLA rollout in MuJoCo (headless EGL), recorded **through the new `on_frame` hook during `eval_policy`** - 40 live per-step frames captured on the eval thread (zero frozen frames, pixel std 48.7):

![eval_policy on_frame rollout](https://github.com/cagataycali/robots/releases/download/eval-onframe-demo/eval_onframe_demo.gif)

[MP4 version](https://github.com/cagataycali/robots/releases/download/eval-onframe-demo/eval_onframe_demo.mp4)