### PR TITLE
fix(policies): catch ValueError when resolving unknown LeRobot policy types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: unknown LeRobot policy types raise a clean ImportError instead of leaking lerobot's internal ValueError
+
+`resolve_policy_class_by_name()` documents that it raises `ImportError` (naming
+the type and the strategies it tried) when no policy class can be resolved. Its
+legacy-factory rung (`lerobot.policies.factory.get_policy_class`) caught
+`ImportError`, `AttributeError`, `RuntimeError`, and `TypeError` so a strategy
+that is merely unavailable falls through to the clean `ImportError` -- but it
+did NOT catch `ValueError`. Current lerobot ends `get_policy_class` with
+`raise ValueError(f"Policy type '{name}' is not available.")` for every name it
+does not recognise, so resolving an unknown type -- or one of lerobot's internal
+building-block modules that live under `lerobot.policies` but are not registered
+policies (e.g. `pi_gemma`, the PaliGemma layers used by pi0/pi05) -- leaked that
+bare `ValueError` to the caller and broke the documented contract. `ValueError`
+is now included in the rung's caught set, so resolution falls through to the
+actionable `ImportError` as documented.
+
+
 ### Fixed: lerobot-availability probes no longer cache a transient failure
 
 `has_lerobot_dataset()` (dataset recording) and `has_streaming_dataset()`

--- a/strands_robots/policies/lerobot_local/resolution.py
+++ b/strands_robots/policies/lerobot_local/resolution.py
@@ -402,7 +402,7 @@ def resolve_policy_class_by_name(policy_type: str) -> type[Any]:
         from lerobot.policies.factory import get_policy_class
 
         return get_policy_class(policy_type)
-    except (ImportError, AttributeError, RuntimeError, TypeError):
+    except (ImportError, AttributeError, RuntimeError, TypeError, ValueError):
         # ``lerobot.policies.factory`` eagerly imports every optional policy
         # config module (groot, ...).  A config that is malformed under the
         # installed transformers - e.g. GR00TN15Config declares a
@@ -410,9 +410,17 @@ def resolve_policy_class_by_name(policy_type: str) -> type[Any]:
         # (where PretrainedConfig is itself a dataclass) rejects with
         # "non-default argument 'backbone_cfg' follows default argument
         # 'problem_type'" - raises TypeError at import time, not ImportError.
-        # That is still just "this resolution strategy is unavailable", so
-        # fall through to the remaining strategies and the clean ImportError
-        # below rather than leaking an unrelated TypeError to the caller.
+        #
+        # ``ValueError`` is the factory's signal for an unknown/unregistered
+        # name: ``get_policy_class`` ends in ``raise ValueError(f"Policy type
+        # '{name}' is not available.")``. That fires both for genuinely unknown
+        # types AND for lerobot internal modules that live under
+        # ``lerobot.policies`` but are not registered policies (e.g.
+        # ``pi_gemma`` is a PaliGemma building-block module for pi0/pi05, not a
+        # ``PreTrainedPolicy``). All of these are "this resolution strategy is
+        # unavailable", so fall through to the remaining strategies and the
+        # clean, actionable ImportError below rather than leaking lerobot's
+        # internal ValueError to the caller.
         pass
 
     # Strategy 4: PreTrainedPolicy - only if it's NOT abstract

--- a/tests/policies/lerobot_local/test_resolution.py
+++ b/tests/policies/lerobot_local/test_resolution.py
@@ -251,6 +251,23 @@ class TestPolicyConfigDiscovery:
         assert cls.__name__ == "MolmoAct2Policy"
         assert cls.__module__.endswith("molmoact2.modeling_molmoact2")
 
+    def test_unregistered_internal_module_raises_importerror_not_valueerror(self):
+        """``lerobot.policies`` ships building-block modules that are NOT
+        registered policies -- e.g. ``pi_gemma`` is a PaliGemma layer module
+        used by pi0/pi05, with no ``PreTrainedPolicy`` subclass. Resolving such
+        a name (or any unknown type) against the real installed lerobot must
+        raise the documented ``ImportError`` from ``resolve_policy_class_by_name``,
+        NOT lerobot's internal ``ValueError("Policy type '<name>' is not
+        available.")`` (which the legacy-factory rung now raises for every
+        unknown name). This locks the cross-package contract end to end."""
+        from strands_robots.policies.lerobot_local.resolution import (
+            resolve_policy_class_by_name,
+        )
+
+        for name in ("pi_gemma", "strands_no_such_policy_xyz"):
+            with pytest.raises(ImportError, match=name):
+                resolve_policy_class_by_name(name)
+
     def test_walk_continues_after_subpackage_decorator_failure(self, tmp_path, monkeypatch, caplog):
         """A subpackage whose ``configuration_*`` raises a non-ImportError
         (e.g. ``RuntimeError`` from a re-registration collision, or
@@ -1039,6 +1056,49 @@ class TestResolvePolicyClassByNameFallbackLadder:
         monkeypatch.setitem(sys.modules, "lerobot.policies.factory", factory_mod)
 
         assert resolution.resolve_policy_class_by_name("tdmpc") is LegacyTDMPCPolicy
+
+    def test_strategy3_factory_value_error_falls_through_to_importerror(self, _isolate_resolution, monkeypatch):
+        """lerobot's ``get_policy_class`` raises ``ValueError("Policy type
+        '<name>' is not available.")`` for any name it does not recognise (its
+        ``else`` branch wraps the failed dynamic import in a ``ValueError``).
+
+        Strategy 3 must treat that as "this resolution strategy is unavailable"
+        and fall through to the clean, actionable ``ImportError`` that names the
+        type and the strategies tried -- NOT leak lerobot's internal
+        ``ValueError`` to the caller. Pre-fix the except tuple omitted
+        ``ValueError``, so the factory's error escaped ``resolve_policy_class_by_name``
+        and broke its documented "raises ImportError if no class found" contract.
+        """
+        import abc
+        import sys
+        import types
+
+        resolution = _isolate_resolution
+
+        def fake_import(name):
+            raise ImportError(name)  # Strategy 1 + 2 both miss
+
+        monkeypatch.setattr(resolution.importlib, "import_module", fake_import)
+
+        def raising_get_policy_class(policy_type):
+            raise ValueError(f"Policy type '{policy_type}' is not available.")
+
+        factory_mod = types.ModuleType("lerobot.policies.factory")
+        factory_mod.get_policy_class = raising_get_policy_class
+        monkeypatch.setitem(sys.modules, "lerobot.policies.factory", factory_mod)
+
+        # Abstract PreTrainedPolicy so Strategy 4 rejects it and the ladder is
+        # genuinely exhausted -> the only acceptable outcome is ImportError.
+        class AbstractPreTrainedPolicy(abc.ABC):
+            @abc.abstractmethod
+            def forward(self): ...
+
+        pretrained_mod = types.ModuleType("lerobot.policies.pretrained")
+        pretrained_mod.PreTrainedPolicy = AbstractPreTrainedPolicy
+        monkeypatch.setitem(sys.modules, "lerobot.policies.pretrained", pretrained_mod)
+
+        with pytest.raises(ImportError, match="pi_gemma"):
+            resolution.resolve_policy_class_by_name("pi_gemma")
 
     def test_strategy4_concrete_pretrained_policy_is_last_resort(self, _isolate_resolution, monkeypatch):
         """When every type-specific path misses and the legacy factory is gone,


### PR DESCRIPTION
## Problem

`resolve_policy_class_by_name()` (in `strands_robots/policies/lerobot_local/resolution.py`) documents that it raises `ImportError` -- naming the type and the strategies it tried -- when no policy class can be resolved. Its legacy-factory rung delegates to `lerobot.policies.factory.get_policy_class` and deliberately swallows "this strategy is unavailable" errors so resolution falls through to that clean `ImportError`:

```python
try:
    from lerobot.policies.factory import get_policy_class
    return get_policy_class(policy_type)
except (ImportError, AttributeError, RuntimeError, TypeError):
    pass
```

The caught set omitted `ValueError`. Current lerobot ends `get_policy_class` with:

```python
else:
    try:
        return _get_policy_cls_from_policy_name(name=name)
    except Exception as e:
        raise ValueError(f"Policy type '{name}' is not available.") from e
```

so for **any** name it does not recognise it raises `ValueError`. That includes both genuinely unknown types and lerobot's internal building-block modules that live under `lerobot.policies` but are not registered policies -- e.g. `pi_gemma`, the PaliGemma layer module used by pi0/pi05, which is a plain `.py` module with no `PreTrainedPolicy` subclass. In all those cases the bare `ValueError` leaked straight to the caller, breaking the documented contract.

Reproduce against current lerobot:

```python
from strands_robots.policies.lerobot_local.resolution import resolve_policy_class_by_name
resolve_policy_class_by_name("pi_gemma")
# ValueError: Policy type 'pi_gemma' is not available.   <-- expected ImportError
resolve_policy_class_by_name("totally_bogus_xyz")
# ValueError: Policy type 'totally_bogus_xyz' is not available.
```

## Change

Add `ValueError` to the legacy-factory rung's caught set (and expand the comment to explain lerobot's unknown-name signal). Resolution now falls through to the actionable `ImportError` that lists what was tried, exactly as documented. Valid types (`act`, `smolvla`, `molmoact2`, ...) are unaffected -- they resolve at Strategy 1/2 before reaching the factory rung.

## Tests

- `test_strategy3_factory_value_error_falls_through_to_importerror` -- layout-independent unit regression: a mocked factory raising lerobot's exact `ValueError` plus an abstract `PreTrainedPolicy` (so Strategy 4 rejects) must yield `ImportError`.
- `test_unregistered_internal_module_raises_importerror_not_valueerror` -- real-lerobot guard: `pi_gemma` and an unknown name resolve to `ImportError`, locking the cross-package contract end to end.

Both **fail pre-fix** (leaking `ValueError: Policy type 'pi_gemma' is not available.`) and pass after. Full file: 31 passed; `tests/policies/lerobot_local/` (410 tests) green under `MUJOCO_GL=egl`.

## Gate

`ruff check` + `ruff format --check` clean; `mypy strands_robots tests tests_integ` -> no issues found in 562 source files.

Error-path-only fix (no policy/sim/rendering/recording/asset behavior change), so no rollout artifact applies; the regression test captures the before/after.