### PR TITLE
test(tools): make use_ros/use_rtps availability probes hermetic

### DIFF
--- a/tests/tools/test_use_ros.py
+++ b/tests/tools/test_use_ros.py
@@ -388,7 +388,14 @@ def test_backend_available_true_when_rclpy_importable(monkeypatch: pytest.Monkey
 
 
 def test_backend_available_false_when_rclpy_absent(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delitem(sys.modules, "rclpy", raising=False)
+    # Simulate rclpy being absent regardless of whether a ROS 2 distro is
+    # sourced in the test environment. Deleting the cached module is not enough
+    # -- `import rclpy` would just re-resolve an installed distribution, so the
+    # assertion only held on a ROS-free machine. Binding the name to None in
+    # sys.modules makes the import statement raise ImportError deterministically
+    # (CPython's documented "module set to None" contract), exercising the real
+    # dependency-absent fallback on every machine.
+    monkeypatch.setitem(sys.modules, "rclpy", None)
     backend = ros_mod._RosBackend()
     assert backend.available() is False
 

--- a/tests/tools/test_use_rtps.py
+++ b/tests/tools/test_use_rtps.py
@@ -1,10 +1,11 @@
 """Behavior tests for the ``use_rtps`` tool.
 
-``use_rtps`` is a pure-RTPS ROS 2 participant on cyclonedds. These tests run
-with NO cyclonedds and NO ROS 2 present: the backend's ``available`` probe and
-its writer/reader factories are monkeypatched, so every action-dispatch branch,
-the agent-input validation, the no-backend error path, and the structured
-error-return contract are exercised middleware-free.
+``use_rtps`` is a pure-RTPS ROS 2 participant on cyclonedds. These tests are
+hermetic: they neither require nor reject an installed cyclonedds / ROS 2 -- the
+backend's ``available`` probe and its writer/reader factories are monkeypatched,
+so every action-dispatch branch, the agent-input validation, the no-backend
+error path, and the structured error-return contract are exercised middleware-
+free on any machine.
 """
 
 from __future__ import annotations
@@ -296,12 +297,28 @@ def test_resolve_field_types_falls_back_when_hints_unresolvable(monkeypatch: pyt
     assert set(resolved) == {"x", "y", "z"}
 
 
-# Real backend availability probe (no monkeypatch on available) -------------
+# Backend availability probe (have_cyclonedds gated) ------------------------
 
 
-def test_backend_available_false_without_cyclonedds() -> None:
-    # cyclonedds is not installed in this environment; the real probe returns
-    # False rather than raising, so the tool degrades to a clear status message.
+def test_backend_available_true_when_cyclonedds_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    # available() delegates to strands_robots.rtps.idl.have_cyclonedds(). Drive
+    # the present-dependency branch deterministically rather than depending on
+    # whether cyclonedds happens to be installed in the test environment.
+    import strands_robots.rtps.idl as idl_mod
+
+    monkeypatch.setattr(idl_mod, "have_cyclonedds", lambda: True)
+    assert rtps_mod._RtpsBackend().available() is True
+
+
+def test_backend_available_false_without_cyclonedds(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Simulate cyclonedds being absent regardless of the test environment.
+    # available() imports have_cyclonedds() from strands_robots.rtps.idl on each
+    # call, so forcing that probe to report False exercises the documented
+    # dependency-absent fallback (the tool degrades to a clear status message)
+    # on a machine where cyclonedds IS installed too.
+    import strands_robots.rtps.idl as idl_mod
+
+    monkeypatch.setattr(idl_mod, "have_cyclonedds", lambda: False)
     assert rtps_mod._RtpsBackend().available() is False
 
 
@@ -324,7 +341,7 @@ def test_backend_available_import_error_returns_false(monkeypatch: pytest.Monkey
 # The action-dispatch tests above stub ``_backend.writer`` / ``_backend.reader``
 # so they never reach the real get-or-create factories. These tests drive the
 # real ``_RtpsBackend`` methods with fake ``cyclonedds`` submodules injected
-# into ``sys.modules`` (cyclonedds is not installed), exercising the documented
+# into ``sys.modules`` (overriding any real install), exercising the documented
 # contract: one shared DomainParticipant, and writers/readers cached per
 # (topic, type) so repeated calls reuse the same DDS entity.
 


### PR DESCRIPTION
## Problem

The backend-availability tests for `use_ros` and `use_rtps` assert the dependency-absent fallback (`available()` is `False`) but never actually simulate absence -- they pass only by accident of the test environment lacking ROS 2 / cyclonedds:

- `tests/tools/test_use_ros.py::test_backend_available_false_when_rclpy_absent` does `monkeypatch.delitem(sys.modules, "rclpy", raising=False)`. Deleting the cached module does not prevent re-import: `_RosBackend.available()` runs `import rclpy`, which re-resolves an installed distribution, so the assertion only holds on a ROS-free machine.
- `tests/tools/test_use_rtps.py::test_backend_available_false_without_cyclonedds` had no monkeypatch at all -- it relied entirely on cyclonedds being absent from the interpreter.

On any machine with ROS 2 / cyclonedds installed -- i.e. exactly this project's audience -- both tests fail with a confusing `assert True is False`, turning a green suite red for no real defect:

```
FAILED tests/tools/test_use_ros.py::test_backend_available_false_when_rclpy_absent - assert True is False
FAILED tests/tools/test_use_rtps.py::test_backend_available_false_without_cyclonedds - assert True is False
```

The product code (`_RosBackend.available()` / `_RtpsBackend.available()`) is correct -- it returns `True`/`False` by probing the import. The defect is purely in the tests: a green result that depends on ambient environment is a false negative waiting to surface on a contributor's box.

## Change

Make the probes hermetic so they exercise the real fallback regardless of what is installed:

- **rclpy-absent**: bind `sys.modules["rclpy"] = None` so the `import rclpy` statement raises `ImportError` deterministically (CPython's documented "module set to `None`" contract), instead of dropping a cache entry that gets re-resolved.
- **cyclonedds-absent**: `available()` re-imports `have_cyclonedds()` from `strands_robots.rtps.idl` on each call, so monkeypatch that probe to return `False` to drive the dependency-absent branch.

Also adds `test_backend_available_true_when_cyclonedds_present` -- the missing present-dependency companion (probe patched to `True`) so both branches of `_RtpsBackend.available()` are pinned -- and corrects now-stale module/section comments that asserted the environment lacked the deps.

Pure test hardening: no product-code or behavioural change (no CHANGELOG entry; the file follows the convention for the coverage/test-hardening sweep).

## Verification

Reproduced on a machine with ROS 2 jazzy + cyclonedds present. Before this change the two tests fail (`assert True is False`); after, all pass -- and because the absent/present states are now simulated rather than ambient, they also pass on a ROS-free machine by construction.

```
tests/tools/test_use_ros.py::test_backend_available_false_when_rclpy_absent PASSED
tests/tools/test_use_ros.py::test_backend_available_true_when_rclpy_importable PASSED
tests/tools/test_use_rtps.py::test_backend_available_false_without_cyclonedds PASSED
tests/tools/test_use_rtps.py::test_backend_available_true_when_cyclonedds_present PASSED
tests/tools/test_use_rtps.py::test_backend_available_import_error_returns_false PASSED
```

Full files: `tests/tools/test_use_ros.py` + `tests/tools/test_use_rtps.py` -> 65 passed. Gate: `ruff check` + `ruff format --check` clean; `mypy` -> no issues found.