### PR TITLE
fix(sim): reject non-positive action_horizon in run_policy/eval_policy/start_policy

### DIFF
--- a/docs/hardware/robot-control.md
+++ b/docs/hardware/robot-control.md
@@ -36,7 +36,7 @@ robot.cleanup()
 | `tool_name` | Tool identifier for the agent. |
 | `robot` | LeRobot `Robot` instance, `RobotConfig`, or string (e.g. `"so100"`). |
 | `cameras` | `{name: config_dict}`. Config keys: `type`, `index_or_path`, `fps`, `width`, `height`, `serial`. |
-| `action_horizon` | Actions per inference step (default 8). |
+| `action_horizon` | Actions per inference step (default 8; must be a positive integer). |
 | `data_config` | GR00T data_config name. |
 | `control_frequency` | Control loop Hz (default 50). |
 | `**kwargs` | Forwarded to LeRobot backend (`port`, `robot_ip`, `kp`, `kd`, …). Unknown kwargs raise `ValueError`. |

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -546,6 +546,32 @@ class SimEngine(ABC):
             duration = float(n_steps) / float(control_frequency)
         return duration, n_steps, None
 
+    @staticmethod
+    def _validate_action_horizon(action_horizon: Any, method: str) -> dict[str, Any] | None:
+        """Reject a non-positive-integer ``action_horizon`` at the public API.
+
+        ``action_horizon`` is how many actions are consumed from each policy
+        chunk before re-querying. A value below 1 (or a non-int) is meaningless
+        and would otherwise be silently clamped to 1 by
+        :func:`~strands_robots.policies.base.resolve_chunk_length`, hiding the
+        caller's mistake behind a rollout that does not run the requested
+        horizon. Returns a structured ``{"status": "error", ...}`` dict to
+        surface, or ``None`` when the value is valid.
+
+        Args:
+            action_horizon: The caller-supplied value to validate.
+            method: Public method name, used to prefix the error message.
+
+        Returns:
+            An error dict naming the offending parameter, or ``None``.
+        """
+        if not isinstance(action_horizon, int) or action_horizon < 1:
+            return {
+                "status": "error",
+                "content": [{"text": f"{method}: action_horizon must be a positive integer, got {action_horizon!r}."}],
+            }
+        return None
+
     def run_policy(
         self,
         robot_name: str | None = None,
@@ -589,7 +615,9 @@ class SimEngine(ABC):
             instruction: Natural-language instruction for the policy.
             duration: Wall-clock seconds to run.
             control_frequency: Target Hz for policy queries.
-            action_horizon: Max actions per policy call.
+            action_horizon: Max actions consumed from each policy chunk
+                before re-querying. Must be a positive integer (>= 1); a
+                non-positive or non-int value is reported as a caller error.
             fast_mode: Skip real-time sleep between steps.
             video: Optional video-recording config dict. Accepted keys:
                 ``path`` (str, output MP4 - required to enable recording),
@@ -684,6 +712,9 @@ class SimEngine(ABC):
                 "status": "error",
                 "content": [{"text": f"run_policy: n_episodes must be a positive integer, got {n_episodes!r}."}],
             }
+
+        if err := self._validate_action_horizon(action_horizon, "run_policy"):
+            return err
 
         if robot_name not in self.list_robots():
             return {
@@ -1314,6 +1345,9 @@ class SimEngine(ABC):
             }
         resolved_robot = robot_name
 
+        if err := self._validate_action_horizon(action_horizon, "eval_policy"):
+            return err
+
         if policy_object is None:
             from strands_robots.policies import create_policy
 
@@ -1414,13 +1448,8 @@ class SimEngine(ABC):
         from strands_robots.policies import create_policy
         from strands_robots.simulation.benchmark import get_benchmark
 
-        if not isinstance(action_horizon, int) or action_horizon < 1:
-            return {
-                "status": "error",
-                "content": [
-                    {"text": (f"evaluate_benchmark: action_horizon must be a positive integer, got {action_horizon!r}")}
-                ],
-            }
+        if err := self._validate_action_horizon(action_horizon, "evaluate_benchmark"):
+            return err
 
         spec = get_benchmark(benchmark_name)
         if spec is None:

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -2271,6 +2271,8 @@ class MuJoCoSimEngine(
         _, _, horizon_error = self._resolve_horizon(n_steps, max_steps, control_frequency, duration)
         if horizon_error is not None:
             return horizon_error
+        if err := self._validate_action_horizon(action_horizon, "start_policy"):
+            return err
 
         # Concurrent multi-robot policies run on disjoint ctrl slices (physics
         # serialized by _lock). For SYNCHRONIZED multi-robot *recording* (both

--- a/tests/simulation/test_run_policy_horizon_validation.py
+++ b/tests/simulation/test_run_policy_horizon_validation.py
@@ -123,3 +123,51 @@ class TestEvalPolicyResolution:
     def test_empty_world_reports_no_robots(self, empty_sim):
         text = _err_text(empty_sim.eval_policy(robot_name="arm1"))
         assert "No robots" in text
+
+
+class TestActionHorizonGuards:
+    """run_policy / start_policy / eval_policy must reject a non-positive
+    ``action_horizon`` rather than silently clamping it.
+
+    ``action_horizon`` is the number of actions consumed from each policy
+    chunk before re-querying. ``resolve_chunk_length`` clamps it to ``>= 1``,
+    so a typo like ``action_horizon=0`` or ``-3`` used to be silently coerced
+    to 1 and the rollout ran a horizon the caller never asked for. The public
+    entry points now surface this as a structured caller error - matching the
+    guard ``evaluate_benchmark`` already enforced.
+    """
+
+    @pytest.mark.parametrize("bad", [0, -1, -8])
+    def test_run_policy_rejects_non_positive_action_horizon(self, sim, bad):
+        text = _err_text(sim.run_policy("arm1", n_steps=4, action_horizon=bad))
+        assert "action_horizon must be a positive integer" in text
+        assert str(bad) in text
+
+    def test_run_policy_rejects_non_int_action_horizon(self, sim):
+        text = _err_text(sim.run_policy("arm1", n_steps=4, action_horizon=2.5))
+        assert "action_horizon must be a positive integer" in text
+
+    def test_run_policy_accepts_positive_action_horizon(self, sim):
+        result = sim.run_policy("arm1", n_steps=2, control_frequency=50.0, fast_mode=True, action_horizon=1)
+        assert result["status"] == "success", result
+
+    def test_eval_policy_rejects_non_positive_action_horizon(self, sim):
+        text = _err_text(sim.eval_policy(robot_name="arm1", max_steps=4, action_horizon=0))
+        assert "action_horizon must be a positive integer" in text
+
+    def test_start_policy_rejects_action_horizon_synchronously(self, sim):
+        # The rollout runs on a background thread, so a bad action_horizon must
+        # be caught before submission - otherwise the caller gets a false
+        # "started" success and the robot is left marked as running.
+        result = sim.start_policy("arm1", n_steps=4, action_horizon=-1)
+        assert result["status"] == "error"
+        assert "action_horizon must be a positive integer" in result["content"][0]["text"]
+        assert "arm1" not in sim._policy_threads
+        # A well-formed start on the same robot still succeeds afterwards.
+        ok = sim.start_policy("arm1", n_steps=2, control_frequency=50.0, fast_mode=True)
+        assert ok["status"] == "success", ok
+        sim.stop_policy("arm1")
+
+    def test_action_horizon_error_is_ascii(self, sim):
+        text = _err_text(sim.run_policy("arm1", n_steps=4, action_horizon=0))
+        text.encode("ascii")  # raises UnicodeEncodeError if any non-ASCII leaks


### PR DESCRIPTION
## Problem

`run_policy`, `eval_policy`, and `start_policy` accepted any `action_horizon` and forwarded it to `resolve_chunk_length`, which clamps the value to `max(action_horizon, 1, execution_horizon)`. So a typo like `action_horizon=0`, `-3`, or a non-int was **silently coerced** to a valid horizon and the rollout ran a chunk length the caller never requested, hiding the mistake instead of surfacing it. This is the same silent-default class the recent `n_steps` / `n_episodes` / `add_camera` guards already close.

`evaluate_benchmark` was the only entry point that already rejected a non-positive `action_horizon` (inline), so the validation was inconsistent across the public surface.

## Change

- Factor the existing `evaluate_benchmark` check into a shared `SimEngine._validate_action_horizon(action_horizon, method)` helper (mirrors the `_resolve_horizon` "return error dict or None" pattern) and apply it at `run_policy`, `eval_policy`, and `evaluate_benchmark`.
- Add a **synchronous** guard in the MuJoCo `start_policy` override (right after the existing `_resolve_horizon` check), before the rollout is submitted to the executor. Otherwise a bad value would only fail inside the background future, giving the caller a false "started" success and leaving the robot marked as running.
- Error message is consistent and ASCII: `"<method>: action_horizon must be a positive integer, got <value>."`
- Behavior for valid `action_horizon` is unchanged (verified by an "accepts positive horizon" test plus the full sim/benchmark suites passing).

## Tests

Added `TestActionHorizonGuards` to `tests/simulation/test_run_policy_horizon_validation.py` covering `run_policy` / `eval_policy` / `start_policy`: non-positive (`0`, `-1`, `-8`), non-int (`2.5`), the ASCII-message contract, that a valid horizon still runs, and that a rejected `start_policy` does not leave a thread registered (and a well-formed start on the same robot still succeeds afterwards). These fail on pre-fix code (7/8 new cases) and pass after.

## Verification

- `ruff check` / `ruff format --check` clean; `mypy strands_robots tests tests_integ` clean (562 files).
- `MUJOCO_GL=egl pytest tests/simulation/test_run_policy_horizon_validation.py tests/simulation/test_policy_runner_benchmark.py tests/simulation/test_run_policy_multi_episode.py tests/simulation/mujoco/test_input_validation.py` -> 161 passed.
- Manual MuJoCo (so101) check: `run_policy`/`eval_policy`/`start_policy` now return `status=error` for `0`/`-3`/`2.5`; `action_horizon=1` still completes a rollout; a rejected `start_policy` leaves `arm1` out of `_policy_threads`.