### PR TITLE
examples(notebooks): CPU-only getting-started notebook series

### DIFF
--- a/docs/examples/overview.md
+++ b/docs/examples/overview.md
@@ -4,6 +4,25 @@ description: Runnable example scripts - links to the repo's examples/ directory.
 
 # Examples
 
+## Getting-started notebooks
+
+New to Strands Robots? The [`examples/notebooks/`](https://github.com/strands-labs/robots/tree/main/examples/notebooks)
+folder is a click-and-run series that runs end-to-end in simulation - no
+hardware, no GPU, no Hugging Face credentials.
+
+| Notebook | What it shows |
+|----------|---------------|
+| [`01_getting_started.ipynb`](https://github.com/strands-labs/robots/blob/main/examples/notebooks/01_getting_started.ipynb) | `Robot("so100")`, run a policy, read joint state, `create_policy()`. |
+| [`02_record_and_stream.ipynb`](https://github.com/strands-labs/robots/blob/main/examples/notebooks/02_record_and_stream.ipynb) | Record a LeRobotDataset, then stream it back with `stream_dataset()`. |
+| [`03_record_train_deploy.ipynb`](https://github.com/strands-labs/robots/blob/main/examples/notebooks/03_record_train_deploy.ipynb) | The full loop: record, train an ACT policy on CPU, export, and load it back. |
+
+```bash
+uv pip install "strands-robots[sim-mujoco,lerobot]" jupyterlab
+jupyter lab   # open examples/notebooks/
+```
+
+## Scripts
+
 Browse [`examples/`](https://github.com/strands-labs/robots/tree/main/examples):
 
 | File | What it does |

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,6 +13,10 @@ MUJOCO_GL=egl python examples/01_sim_hello_world.py
 
 ## Index
 
+Prefer a click-and-run walkthrough? The [`notebooks/`](notebooks/) folder has the
+getting-started series (`Robot()` basics, record + stream, and the full
+record→train→deploy loop) as Jupyter notebooks - all CPU-only, no hardware or GPU.
+
 | # | File | Primitive | Hardware | GPU |
 |---|------|-----------|----------|-----|
 | 01 | [`01_sim_hello_world.py`](01_sim_hello_world.py) | `Robot()` + `Simulation` | No | No |

--- a/examples/notebooks/01_getting_started.ipynb
+++ b/examples/notebooks/01_getting_started.ipynb
@@ -1,0 +1,190 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "6e223bb8",
+   "metadata": {},
+   "source": [
+    "# 1 - Getting started with Strands Robots\n",
+    "\n",
+    "The shortest path into the SDK: build a simulated robot, run a policy on it, and read its state back. No hardware, no GPU, no Hugging Face credentials.\n",
+    "\n",
+    "**Install:** `uv pip install \"strands-robots[sim-mujoco,lerobot]\"`\n",
+    "\n",
+    "Part of the [examples/notebooks](./README.md) getting-started series."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "264b463c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-29T14:28:00.611589Z",
+     "iopub.status.busy": "2026-06-29T14:28:00.611463Z",
+     "iopub.status.idle": "2026-06-29T14:28:00.618031Z",
+     "shell.execute_reply": "2026-06-29T14:28:00.617516Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "# macOS uses the 'cgl' offscreen GL backend; Linux headless uses 'egl'.\n",
+    "os.environ.setdefault(\"MUJOCO_GL\", \"cgl\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d984b1fd",
+   "metadata": {},
+   "source": [
+    "## Build a robot\n",
+    "\n",
+    "`Robot(\"so100\")` returns a [MuJoCo](https://mujoco.org)-backed simulation by default (`mode=\"sim\"`), so nothing touches real hardware. The same call with `mode=\"real\"` returns a hardware-backed robot driven by LeRobot - the agent code is identical across both."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3207293e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-29T14:28:00.619860Z",
+     "iopub.status.busy": "2026-06-29T14:28:00.619733Z",
+     "iopub.status.idle": "2026-06-29T14:28:02.293270Z",
+     "shell.execute_reply": "2026-06-29T14:28:02.292417Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from strands_robots import Robot, MockPolicy, create_policy\n",
+    "\n",
+    "sim = Robot(\"so100\", mesh=False)\n",
+    "print(\"sim ready:\", sim.tool_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0055d4e4",
+   "metadata": {},
+   "source": [
+    "## Run a policy\n",
+    "\n",
+    "A policy turns observations into actions. `MockPolicy` is a sinusoidal stand-in that runs anywhere, so you can exercise the full loop before attaching a trained checkpoint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d8b32c19",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-29T14:28:02.295436Z",
+     "iopub.status.busy": "2026-06-29T14:28:02.295258Z",
+     "iopub.status.idle": "2026-06-29T14:28:03.009758Z",
+     "shell.execute_reply": "2026-06-29T14:28:03.009277Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "result = sim.run_policy(\n",
+    "    robot_name=\"so100\",\n",
+    "    policy_object=MockPolicy(),\n",
+    "    instruction=\"wave the arm\",\n",
+    "    n_steps=30,\n",
+    ")\n",
+    "print(\"run_policy status:\", result.get(\"status\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2c33eb7",
+   "metadata": {},
+   "source": [
+    "## One entry point for every policy\n",
+    "\n",
+    "`create_policy()` is the universal constructor. The same call resolves a mock, a Hugging Face checkpoint (`create_policy(\"lerobot/act_aloha_sim\")`), a GR00T server (`create_policy(\"zmq://...\")`), or a local path - the provider is inferred from the argument."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3a5e66f2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-29T14:28:03.011347Z",
+     "iopub.status.busy": "2026-06-29T14:28:03.011244Z",
+     "iopub.status.idle": "2026-06-29T14:28:03.015595Z",
+     "shell.execute_reply": "2026-06-29T14:28:03.015203Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "policy = create_policy(\"mock\")\n",
+    "print(\"created policy:\", type(policy).__name__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "864e498b",
+   "metadata": {},
+   "source": [
+    "## Read the robot's state\n",
+    "\n",
+    "`get_observation()` returns the current joint state (and camera frames, if any cameras are attached)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "87fd742a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-29T14:28:03.016841Z",
+     "iopub.status.busy": "2026-06-29T14:28:03.016771Z",
+     "iopub.status.idle": "2026-06-29T14:28:03.522033Z",
+     "shell.execute_reply": "2026-06-29T14:28:03.521602Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "obs = sim.get_observation(robot_name=\"so100\")\n",
+    "print(\"observation keys (first 5):\", sorted(obs.keys())[:5])\n",
+    "sim.destroy()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a99431d7",
+   "metadata": {},
+   "source": [
+    "## Next\n",
+    "\n",
+    "- **[2 - Record and stream](./02_record_and_stream.ipynb)** - capture a LeRobotDataset and read it back.\n",
+    "- **[3 - Record, train, deploy](./03_record_train_deploy.ipynb)** - the full data loop, training included.\n",
+    "- The numbered scripts in [`examples/`](../) cover the mesh, agents, and natural-language control."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/notebooks/02_record_and_stream.ipynb
+++ b/examples/notebooks/02_record_and_stream.ipynb
@@ -1,0 +1,516 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d892408c",
+   "metadata": {},
+   "source": [
+    "# 2 - Record a dataset and stream it back\n",
+    "\n",
+    "Capture a robot demonstration as a [LeRobotDataset](https://github.com/huggingface/lerobot), then read it back frame by frame with `stream_dataset()` - the in-process counterpart to recording. Camera video decodes on the fly; nothing is re-materialized to disk.\n",
+    "\n",
+    "No hardware, no GPU, no Hugging Face credentials. Part of the [examples/notebooks](./README.md) series; see [notebook 1](./01_getting_started.ipynb) first."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4d8be70a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-29T14:28:06.809884Z",
+     "iopub.status.busy": "2026-06-29T14:28:06.809801Z",
+     "iopub.status.idle": "2026-06-29T14:28:06.813260Z",
+     "shell.execute_reply": "2026-06-29T14:28:06.812803Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "# macOS uses the 'cgl' offscreen GL backend; Linux headless uses 'egl'.\n",
+    "os.environ.setdefault(\"MUJOCO_GL\", \"cgl\")\n",
+    "\n",
+    "ROOT, REPO = \"/tmp/nb2_dataset\", \"local/nb2_demo\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b5d053c9",
+   "metadata": {},
+   "source": [
+    "## Record\n",
+    "\n",
+    "`start_recording()` opens a `LeRobotDataset`, the policy loop fills it frame by frame, and `stop_recording()` finalizes it (encoding per-camera MP4 and writing the `meta/` folder of stats and schema). A camera is added first so the recorded dataset has an image stream."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "68b1eca9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-29T14:28:06.814599Z",
+     "iopub.status.busy": "2026-06-29T14:28:06.814530Z",
+     "iopub.status.idle": "2026-06-29T14:28:15.941996Z",
+     "shell.execute_reply": "2026-06-29T14:28:15.941566Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from strands_robots import Robot, MockPolicy\n",
+    "\n",
+    "sim = Robot(\"so100\", mesh=False)\n",
+    "sim.add_camera(name=\"front\", position=[0.5, 0.0, 0.4], target=[0.2, 0.0, 0.05])\n",
+    "\n",
+    "sim.start_recording(repo_id=REPO, root=ROOT, fps=30,\n",
+    "                    task=\"pick up the red cube\", overwrite=True)\n",
+    "sim.run_policy(robot_name=\"so100\", policy_object=MockPolicy(),\n",
+    "               instruction=\"pick up the red cube\", n_steps=60)\n",
+    "sim.stop_recording()\n",
+    "print(\"recorded ->\", ROOT)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "89f25da9",
+   "metadata": {},
+   "source": [
+    "## Stream it back\n",
+    "\n",
+    "`stream_dataset()` reads the dataset you just wrote. Iterating yields one frame at a time: the joint state and action come from the Parquet shards, and camera frames decode from the MP4 shards as you go. Only the small `meta/` folder is read up front."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dc4e5a4f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-29T14:28:15.943456Z",
+     "iopub.status.busy": "2026-06-29T14:28:15.943290Z",
+     "iopub.status.idle": "2026-06-29T14:28:16.504988Z",
+     "shell.execute_reply": "2026-06-29T14:28:16.504582Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "reader = sim.stream_dataset(REPO, root=ROOT, shuffle=False)\n",
+    "print(\"episodes:\", reader.num_episodes, \"| frames:\", reader.num_frames, \"| fps:\", reader.fps)\n",
+    "\n",
+    "for n, frame in enumerate(reader):\n",
+    "    if n == 0:\n",
+    "        cams = [k for k in frame if k.startswith(\"observation.images.\")]\n",
+    "        print(\"state:\", tuple(frame[\"observation.state\"].shape),\n",
+    "              \"| action:\", tuple(frame[\"action\"].shape),\n",
+    "              \"| cameras:\", cams)\n",
+    "    if n >= 4:\n",
+    "        break\n",
+    "print(\"streamed frames OK - nothing re-downloaded\")\n",
+    "sim.destroy()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "39636a98",
+   "metadata": {},
+   "source": [
+    "## Why this matters\n",
+    "\n",
+    "The same `Robot()` that wrote the dataset reads it back, so collecting data and consuming it are two methods on one object in one format. For training at scale, hand the reader a `DataLoader` (`reader.dataloader(batch_size=64)`); for storing collection runs, `stop_recording(bucket=\"org/name\")` syncs to a Hugging Face Storage Bucket.\n",
+    "\n",
+    "## Next\n",
+    "\n",
+    "**[3 - Record, train, deploy](./03_record_train_deploy.ipynb)** trains a policy on a dataset like this one."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {
+     "0c8087d335804739a53b5d5b2c45d57f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_f1b16f3e2ae34978bb5db7bff19cb031",
+       "placeholder": "​",
+       "style": "IPY_MODEL_11dd2fb41ab549a3a89d58b454d9bcce",
+       "tabbable": null,
+       "tooltip": null,
+       "value": "Map: 100%"
+      }
+     },
+     "11dd2fb41ab549a3a89d58b454d9bcce": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "174f1aefeab54502ba7b70b89ac5bca3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "FloatProgressModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "ProgressView",
+       "bar_style": "success",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_3bb990ecfcc94fca9b8e474615c81592",
+       "max": 60.0,
+       "min": 0.0,
+       "orientation": "horizontal",
+       "style": "IPY_MODEL_6a83e2eeef88496a80b8ba91a0a5a969",
+       "tabbable": null,
+       "tooltip": null,
+       "value": 60.0
+      }
+     },
+     "359038edc86e408e85cd42166619cb30": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HBoxModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HBoxView",
+       "box_style": "",
+       "children": [
+        "IPY_MODEL_0c8087d335804739a53b5d5b2c45d57f",
+        "IPY_MODEL_174f1aefeab54502ba7b70b89ac5bca3",
+        "IPY_MODEL_a014bb0bfe1847dea7a7eff66e7e8966"
+       ],
+       "layout": "IPY_MODEL_8823f2c757d64c52864a0805f11a2b87",
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "3bb990ecfcc94fca9b8e474615c81592": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "6a83e2eeef88496a80b8ba91a0a5a969": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "ProgressStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "bar_color": null,
+       "description_width": ""
+      }
+     },
+     "8823f2c757d64c52864a0805f11a2b87": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "a014bb0bfe1847dea7a7eff66e7e8966": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_f966457bf5934c31a44c7c7f193c512e",
+       "placeholder": "​",
+       "style": "IPY_MODEL_fcb820f0030947e8aaae371dc73b01f6",
+       "tabbable": null,
+       "tooltip": null,
+       "value": " 60/60 [00:00&lt;00:00, 3162.25 examples/s]"
+      }
+     },
+     "f1b16f3e2ae34978bb5db7bff19cb031": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "f966457bf5934c31a44c7c7f193c512e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "fcb820f0030947e8aaae371dc73b01f6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     }
+    },
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/notebooks/03_record_train_deploy.ipynb
+++ b/examples/notebooks/03_record_train_deploy.ipynb
@@ -1,0 +1,554 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a79f1dae",
+   "metadata": {},
+   "source": [
+    "# 3 - Record, train, and deploy in one loop\n",
+    "\n",
+    "The full data loop in one notebook: **record** a LeRobotDataset, **train** an [ACT](https://tonyzhaozh.github.io/aloha/) policy on it, **export** the checkpoint, and **load** it back as a runnable policy. It runs on CPU - small dataset, two training steps - so you can see the whole loop close on a laptop with no GPU.\n",
+    "\n",
+    "For a real policy you would raise the step count and run on a GPU, but the code path is identical. Part of the [examples/notebooks](./README.md) series."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "65844717",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-29T14:28:42.601260Z",
+     "iopub.status.busy": "2026-06-29T14:28:42.601148Z",
+     "iopub.status.idle": "2026-06-29T14:28:42.636012Z",
+     "shell.execute_reply": "2026-06-29T14:28:42.635371Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "# macOS uses the 'cgl' offscreen GL backend; Linux headless uses 'egl'.\n",
+    "os.environ.setdefault(\"MUJOCO_GL\", \"cgl\")\n",
+    "os.environ.setdefault(\"STRANDS_TRUST_REMOTE_CODE\", \"1\")  # ACT loads through LeRobot\n",
+    "import shutil\n",
+    "ROOT, OUT = \"/tmp/nb3_dataset\", \"/tmp/nb3_ft\"\n",
+    "# LeRobot's trainer refuses to write into an existing output_dir, so clear it\n",
+    "# first to keep this notebook re-runnable.\n",
+    "shutil.rmtree(OUT, ignore_errors=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6777c453",
+   "metadata": {},
+   "source": [
+    "## 1. Record a small dataset\n",
+    "\n",
+    "Same recording flow as [notebook 2](./02_record_and_stream.ipynb), kept short for a fast CPU run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e8c87459",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-29T14:28:42.638007Z",
+     "iopub.status.busy": "2026-06-29T14:28:42.637894Z",
+     "iopub.status.idle": "2026-06-29T14:28:51.869477Z",
+     "shell.execute_reply": "2026-06-29T14:28:51.869072Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from strands_robots import Robot, MockPolicy, create_policy\n",
+    "from strands_robots.training import TrainSpec, create_trainer\n",
+    "\n",
+    "sim = Robot(\"so100\", mesh=False)\n",
+    "sim.add_camera(name=\"front\", position=[0.5, 0.0, 0.4], target=[0.2, 0.0, 0.05])\n",
+    "sim.start_recording(repo_id=\"local/nb3_demo\", root=ROOT, fps=30,\n",
+    "                    task=\"pick up the red cube\", overwrite=True)\n",
+    "sim.run_policy(robot_name=\"so100\", policy_object=MockPolicy(),\n",
+    "               instruction=\"pick up the red cube\", n_steps=60)\n",
+    "sim.stop_recording()\n",
+    "sim.destroy()\n",
+    "print(\"recorded ->\", ROOT)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f261c07e",
+   "metadata": {},
+   "source": [
+    "## 2. Train\n",
+    "\n",
+    "`create_trainer(provider)` returns a `Trainer` - the peer of `create_policy()`. The trainer is selected by the **same provider name** as the inference policy, so the same string that runs a policy also trains one. `TrainSpec` describes the run; `validate()` is a pure preflight that launches nothing if the spec is wrong. Here ACT trains from scratch for two steps on CPU.\n",
+    "\n",
+    "> Swap the provider to `\"groot\"` or `\"cosmos3\"` and only the provider string changes - the LeRobot, GR00T, and Cosmos training pipelines all sit behind the same `TrainSpec` + `Trainer` lifecycle."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "234c5fcb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-29T14:28:51.871123Z",
+     "iopub.status.busy": "2026-06-29T14:28:51.870958Z",
+     "iopub.status.idle": "2026-06-29T14:28:56.078829Z",
+     "shell.execute_reply": "2026-06-29T14:28:56.078287Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "trainer = create_trainer(\"lerobot_local\", device=\"cpu\")\n",
+    "spec = TrainSpec(\n",
+    "    dataset_root=ROOT,\n",
+    "    base_model=\"\",            # ACT from scratch (smallest CPU path)\n",
+    "    output_dir=OUT,\n",
+    "    steps=2,\n",
+    "    save_freq=2,\n",
+    "    global_batch_size=2,\n",
+    "    extra={\"policy_type\": \"act\", \"num_workers\": 0},\n",
+    ")\n",
+    "\n",
+    "problems = trainer.validate(spec)\n",
+    "assert not problems, problems\n",
+    "\n",
+    "result = trainer.train(spec)\n",
+    "print(\"train status:\", result.status)\n",
+    "print(\"checkpoint:\", result.checkpoint_dir)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bb9487c6",
+   "metadata": {},
+   "source": [
+    "## 3. Load the trained checkpoint back\n",
+    "\n",
+    "The exported checkpoint loads through the same `create_policy()` entry point from [notebook 1](./01_getting_started.ipynb) - the loop closes: the thing you trained is a policy you can run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "910ff14c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-29T14:28:56.080351Z",
+     "iopub.status.busy": "2026-06-29T14:28:56.080266Z",
+     "iopub.status.idle": "2026-06-29T14:28:56.595008Z",
+     "shell.execute_reply": "2026-06-29T14:28:56.594530Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "policy = create_policy(result.checkpoint_dir)\n",
+    "print(\"loaded:\", type(policy).__name__)\n",
+    "print(\"record -> train -> export -> load closed on CPU\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d946b26b",
+   "metadata": {},
+   "source": [
+    "## Where to go from here\n",
+    "\n",
+    "- Raise `steps`, point `base_model` at a pretrained checkpoint, and run on a GPU for a real policy.\n",
+    "- `stop_recording(bucket=...)` plus `stream_dataset()` let you train straight from a Hugging Face Storage Bucket without a full download.\n",
+    "- The [`07_post_tune_any_policy.py`](../07_post_tune_any_policy.py) script is the same loop in one file."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {
+     "07f210a62e8d45149b3c8042c037a685": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "3cfc996f83844d62af349ce92c632043": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "44c03ac9d6a140f7909e31c6f5f095da": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "990f486a45ce4ca7875a17d6de88cbea": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_3cfc996f83844d62af349ce92c632043",
+       "placeholder": "​",
+       "style": "IPY_MODEL_a7c51642b1394393bc369bab5ad41984",
+       "tabbable": null,
+       "tooltip": null,
+       "value": " 60/60 [00:00&lt;00:00, 2581.19 examples/s]"
+      }
+     },
+     "a07e93b294a346f290630b3de8c0a929": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "a7c51642b1394393bc369bab5ad41984": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "d1a1a80378df4cb288c9e82889fd0764": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "e8f42cbe8afa4fbe8e77065a7d11d540": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_44c03ac9d6a140f7909e31c6f5f095da",
+       "placeholder": "​",
+       "style": "IPY_MODEL_d1a1a80378df4cb288c9e82889fd0764",
+       "tabbable": null,
+       "tooltip": null,
+       "value": "Map: 100%"
+      }
+     },
+     "f169e0a2128d48f58d8f7790a8723c16": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "ProgressStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "bar_color": null,
+       "description_width": ""
+      }
+     },
+     "f4cc24ebe2e34c7a998887a913845fdb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HBoxModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HBoxView",
+       "box_style": "",
+       "children": [
+        "IPY_MODEL_e8f42cbe8afa4fbe8e77065a7d11d540",
+        "IPY_MODEL_f7c696c177c44757ad683554c52f8500",
+        "IPY_MODEL_990f486a45ce4ca7875a17d6de88cbea"
+       ],
+       "layout": "IPY_MODEL_a07e93b294a346f290630b3de8c0a929",
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "f7c696c177c44757ad683554c52f8500": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "FloatProgressModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "ProgressView",
+       "bar_style": "success",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_07f210a62e8d45149b3c8042c037a685",
+       "max": 60.0,
+       "min": 0.0,
+       "orientation": "horizontal",
+       "style": "IPY_MODEL_f169e0a2128d48f58d8f7790a8723c16",
+       "tabbable": null,
+       "tooltip": null,
+       "value": 60.0
+      }
+     }
+    },
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/notebooks/README.md
+++ b/examples/notebooks/README.md
@@ -1,0 +1,37 @@
+# Notebooks
+
+Click-and-run getting-started notebooks for Strands Robots. Each one runs
+end-to-end on a laptop in simulation - **no hardware, no GPU, no Hugging Face
+credentials**. They are the notebook companions to the numbered scripts in
+[`../`](../).
+
+## Install and launch
+
+```bash
+uv pip install "strands-robots[sim-mujoco,lerobot]" jupyterlab
+jupyter lab
+```
+
+On macOS the notebooks set `MUJOCO_GL=cgl` for offscreen rendering; on headless
+Linux they fall back to the environment's default (set `MUJOCO_GL=egl` if needed).
+
+## The series
+
+| # | Notebook | What it shows |
+|---|----------|---------------|
+| 1 | [`01_getting_started.ipynb`](01_getting_started.ipynb) | `Robot("so100")`, run a policy, read joint state, `create_policy()` |
+| 2 | [`02_record_and_stream.ipynb`](02_record_and_stream.ipynb) | Record a LeRobotDataset, then stream it back with `stream_dataset()` |
+| 3 | [`03_record_train_deploy.ipynb`](03_record_train_deploy.ipynb) | The full loop: record, train an ACT policy on CPU, export, and load it back |
+
+Read them in order; each builds on the previous one. Notebook 3 trains a real
+policy on CPU with a tiny dataset and two steps - raise the step count and run on
+a GPU for a production checkpoint; the code path is identical.
+
+## Notebook 3 and GPUs
+
+Notebook 3 trains [ACT](https://tonyzhaozh.github.io/aloha/) from scratch for two
+steps so the record -> train -> export -> load loop closes on a CPU laptop. For a
+real policy, point `TrainSpec.base_model` at a pretrained checkpoint, raise
+`steps`, and run on a GPU. Swapping `create_trainer("lerobot_local")` to
+`"groot"` or `"cosmos3"` retargets the same lifecycle to those providers (which do
+require a GPU).


### PR DESCRIPTION
## What

Adds a `examples/notebooks/` folder with three click-and-run getting-started
notebooks — the notebook companions to the numbered example scripts. They give a
new user a guided, runnable on-ramp instead of running scripts blind.

| # | Notebook | Primitives shown | Hardware | GPU |
|---|----------|------------------|----------|-----|
| 1 | `01_getting_started.ipynb` | `Robot("so100")`, `run_policy`, `create_policy`, `get_observation` | No | No |
| 2 | `02_record_and_stream.ipynb` | `start/stop_recording`, `stream_dataset` (record a LeRobotDataset, stream it back) | No | No |
| 3 | `03_record_train_deploy.ipynb` | `create_trainer` + `TrainSpec`: the full record → train (ACT) → export → load loop | No | No |

All three run end-to-end in simulation on a laptop — **no hardware, no GPU, no
Hugging Face credentials**. Notebook 3 trains a real ACT policy from scratch for
two steps on CPU so the whole loop closes locally; raise `steps` and point
`base_model` at a checkpoint to train for real on a GPU (same code path).

## Why here, and why notebooks

- The repo had exactly one notebook (`lerobot/hub_to_hardware.ipynb`); everything
  else is a script. New users asking "how do I get started and use the features"
  benefit most from a click-and-run series.
- Placed in a **new `examples/notebooks/` folder** so it's additive — it touches
  no existing example paths, so docs links, tests, and the published blog stay
  intact. The flat `01–07` scripts remain the script tour; `notebooks/` is the
  click-and-run tour.

## Testing

Every notebook was executed end-to-end with
`jupyter nbconvert --to notebook --execute` in a clean Python 3.12 venv
(`strands-robots[sim-mujoco,lerobot]`, `MUJOCO_GL=cgl` on macOS):

- All three: **exit 0, zero error outputs.**
- Notebook 3 verified **re-runnable** — it clears its `output_dir` first, so
  LeRobot's no-resume guard doesn't fail a second run (caught and fixed during
  testing).
- Committed **without cell outputs** (clean source; users execute fresh).

## Notes

- No changes to package code — examples + one README pointer row only.
- GPU/hardware/agent-LLM paths (GR00T, Cosmos3, MolmoAct2, mesh, the
  Agent-driven examples) are intentionally **not** added here, since they can't be
  CPU-validated; this series is strictly the runs-everywhere on-ramp.
