### PR TITLE
fix(sim): complete control_frequency validation across all entry points and paths

### DIFF
--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -534,15 +534,10 @@ class SimEngine(ABC):
                         "content": [{"text": f"run_policy: n_steps must be > 0, got {n_steps}."}],
                     },
                 )
-            if control_frequency <= 0:
-                return (
-                    duration,
-                    n_steps,
-                    {
-                        "status": "error",
-                        "content": [{"text": "run_policy: control_frequency must be > 0 when n_steps is used."}],
-                    },
-                )
+            # control_frequency is validated as a positive number at the public
+            # entry points (run_policy / start_policy / eval_policy) via
+            # _validate_positive_frequency before this helper runs, so the
+            # division below is safe.
             duration = float(n_steps) / float(control_frequency)
         return duration, n_steps, None
 
@@ -602,17 +597,33 @@ class SimEngine(ABC):
         return None
 
     @staticmethod
-    def _validate_positive_frequency(control_frequency: float, method: str) -> dict[str, Any] | None:
-        """Reject a non-positive ``control_frequency`` at the public API.
+    def _validate_positive_frequency(control_frequency: Any, method: str) -> dict[str, Any] | None:
+        """Reject a non-positive or non-numeric ``control_frequency`` at the public API.
 
-        ``control_frequency`` sets the control-loop rate the rollout steps
-        physics at; a value ``<= 0`` is meaningless and otherwise reaches the
-        per-period substep computation (``round(1 / control_frequency / ...)``)
-        deep inside :class:`PolicyRunner`, where it raises a bare ``ValueError``
-        rather than the structured tool-error dict the public API contracts.
-        Returns a structured error dict to surface, or ``None`` when valid.
+        ``control_frequency`` (Hz) sets the control-loop rate the rollout steps
+        physics at. It is used as a divisor (the per-action period is
+        ``1 / control_frequency`` and ``duration = n_steps / control_frequency``)
+        and is handed to :meth:`PolicyRunner`'s per-period substep computation
+        (``round(1 / control_frequency / ...)``); a value ``<= 0`` or a
+        non-number otherwise reaches that arithmetic deep inside the runner and
+        raises a bare ``ValueError``/``TypeError``/``ZeroDivisionError`` rather
+        than the structured tool-error dict the public API contracts. ``bool`` is
+        rejected explicitly: it is an ``int`` subclass, so ``True`` would slip
+        through the numeric check and act as a silent 1 Hz. Returns a structured
+        error dict to surface, or ``None`` when valid.
+
+        Args:
+            control_frequency: The caller-supplied value to validate.
+            method: Public method name, used to prefix the error message.
+
+        Returns:
+            An error dict naming the offending parameter, or ``None``.
         """
-        if not isinstance(control_frequency, (int, float)) or control_frequency <= 0:
+        if (
+            isinstance(control_frequency, bool)
+            or not isinstance(control_frequency, (int, float))
+            or control_frequency <= 0
+        ):
             return {
                 "status": "error",
                 "content": [{"text": f"{method}: control_frequency must be > 0, got {control_frequency!r}."}],
@@ -661,7 +672,9 @@ class SimEngine(ABC):
                 ...). Forwarded verbatim to ``create_policy``.
             instruction: Natural-language instruction for the policy.
             duration: Wall-clock seconds to run.
-            control_frequency: Target Hz for policy queries.
+            control_frequency: Target Hz for policy queries. Must be a
+                positive number; a non-positive, non-numeric, or bool value
+                is reported as a structured caller error.
             action_horizon: Max actions consumed from each policy chunk
                 before re-querying. Must be a positive integer (>= 1); a
                 non-positive or non-int value is reported as a caller error.
@@ -746,6 +759,9 @@ class SimEngine(ABC):
         from strands_robots.policies import create_policy
 
         robot_name = self._resolve_single_robot(robot_name)
+
+        if err := self._validate_positive_frequency(control_frequency, "run_policy"):
+            return err
 
         # accept n_steps (or legacy max_steps) as an alternate horizon
         # specification. duration = n_steps / control_frequency. If both

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -2267,7 +2267,11 @@ class MuJoCoSimEngine(
         # executor. run_policy runs on a background thread, so a malformed
         # horizon (n_steps <= 0, control_frequency <= 0) would otherwise be
         # reported only inside the future - the caller would receive a false
-        # "started" success and the robot would be left marked as running.
+        # "started" success and the robot would be left marked as running. The
+        # control_frequency guard covers the duration path too (n_steps omitted),
+        # which _resolve_horizon only checks when n_steps is given.
+        if err := self._validate_positive_frequency(control_frequency, "start_policy"):
+            return err
         _, _, horizon_error = self._resolve_horizon(n_steps, max_steps, control_frequency, duration)
         if horizon_error is not None:
             return horizon_error

--- a/tests/simulation/test_run_policy_horizon_validation.py
+++ b/tests/simulation/test_run_policy_horizon_validation.py
@@ -54,9 +54,10 @@ class TestRunPolicyHorizonGuards:
 
     @pytest.mark.parametrize("bad_freq", [0, -10.0])
     def test_non_positive_control_frequency_errors(self, sim, bad_freq):
-        # control_frequency is only validated on the n_steps path (it divides
-        # n_steps to produce a duration); a bad frequency there would otherwise
-        # raise ZeroDivisionError or yield a negative duration.
+        # control_frequency is validated at the run_policy entry point (it is a
+        # divisor: 1 / control_frequency action period and n_steps /
+        # control_frequency duration); a bad frequency would otherwise raise
+        # ZeroDivisionError or yield a negative duration deep in the runner.
         text = _err_text(sim.run_policy("arm1", n_steps=5, control_frequency=bad_freq))
         assert "control_frequency must be > 0" in text
 
@@ -170,6 +171,71 @@ class TestActionHorizonGuards:
 
     def test_action_horizon_error_is_ascii(self, sim):
         text = _err_text(sim.run_policy("arm1", n_steps=4, action_horizon=0))
+        text.encode("ascii")  # raises UnicodeEncodeError if any non-ASCII leaks
+
+
+class TestControlFrequencyGuards:
+    """control_frequency is validated at EVERY public entry point, on every path.
+
+    ``control_frequency`` (Hz) is a divisor (``1 / control_frequency`` action
+    period, ``n_steps / control_frequency`` duration) and is handed to the
+    runner's per-period substep arithmetic, which raises a bare
+    ``ValueError``/``TypeError``/``ZeroDivisionError`` on a bad value. The
+    n_steps path and ``eval_policy`` were already guarded, but three paths still
+    leaked a raw traceback instead of the structured tool-error dict:
+
+    - ``run_policy`` duration path (``n_steps`` omitted): never validated.
+    - ``start_policy`` duration path: the synchronous guard only covered the
+      n_steps path, so a bad rate passed, raised inside the background future,
+      and left the robot falsely marked running.
+    - a ``bool`` (``True``): an ``int`` subclass, it slipped through the numeric
+      check on every path and silently acted as a 1 Hz rate.
+    """
+
+    @pytest.mark.parametrize("bad_freq", [0, 0.0, -10.0])
+    def test_run_policy_duration_path_rejects_non_positive(self, sim, bad_freq):
+        # n_steps omitted -> duration path; pre-fix this reached the runner and
+        # raised ValueError instead of returning a structured error.
+        text = _err_text(sim.run_policy("arm1", duration=1.0, control_frequency=bad_freq, fast_mode=True))
+        assert "control_frequency must be > 0" in text
+        assert str(bad_freq) in text
+
+    @pytest.mark.parametrize("bad_freq", ["fast", None])
+    def test_run_policy_rejects_non_numeric(self, sim, bad_freq):
+        # Pre-fix the n_steps inline check did `bad <= 0`, raising TypeError for
+        # a str/None rather than returning a structured error.
+        text = _err_text(sim.run_policy("arm1", n_steps=4, control_frequency=bad_freq))
+        assert "control_frequency must be > 0" in text
+
+    def test_run_policy_rejects_bool_control_frequency(self, sim):
+        # bool is an int subclass; True would sneak through an isinstance(int)
+        # check and act as a silent 1 Hz, so it is rejected explicitly.
+        text = _err_text(sim.run_policy("arm1", n_steps=4, control_frequency=True))
+        assert "control_frequency must be > 0" in text
+
+    def test_eval_policy_rejects_bool_control_frequency(self, sim):
+        text = _err_text(sim.eval_policy(robot_name="arm1", max_steps=4, control_frequency=True))
+        assert "control_frequency must be > 0" in text
+
+    def test_start_policy_duration_path_rejects_synchronously(self, sim):
+        # Duration path on the background-threaded start_policy: pre-fix the
+        # n_steps-only horizon guard let this through, it raised in the future,
+        # and the robot was left marked running.
+        result = sim.start_policy("arm1", duration=1.0, control_frequency=0)
+        assert result["status"] == "error"
+        assert "control_frequency must be > 0" in result["content"][0]["text"]
+        assert "arm1" not in sim._policy_threads
+        # A well-formed start on the same robot still succeeds afterwards.
+        ok = sim.start_policy("arm1", n_steps=2, control_frequency=50.0, fast_mode=True)
+        assert ok["status"] == "success", ok
+        sim.stop_policy("arm1")
+
+    def test_run_policy_accepts_positive_control_frequency(self, sim):
+        result = sim.run_policy("arm1", n_steps=2, control_frequency=30.0, fast_mode=True)
+        assert result["status"] == "success", result
+
+    def test_control_frequency_error_is_ascii(self, sim):
+        text = _err_text(sim.run_policy("arm1", duration=1.0, control_frequency=-1.0, fast_mode=True))
         text.encode("ascii")  # raises UnicodeEncodeError if any non-ASCII leaks
 
 


### PR DESCRIPTION
## Problem

The `_validate_positive_frequency` guard validates `control_frequency` for `eval_policy`, but three paths still let a malformed value escape the simulation facade as a **raw traceback** instead of the structured `{"status": "error"}` dict every other parameter check returns:

- **`run_policy` duration path** (`n_steps` omitted): `control_frequency` was never validated at the entry point, so it reached `PolicyRunner`'s per-period substep arithmetic and raised `ValueError: control_frequency must be positive`.
- **`run_policy` n_steps path, non-numeric value**: the inline `_resolve_horizon` check did `control_frequency <= 0`, which raises `TypeError` for a `str`/`None` (`'<=' not supported between instances of 'str' and 'int'`).
- **`start_policy` (MuJoCo, background thread)**: the synchronous guard only covered the n_steps path, so a bad duration-path rate passed the check, raised inside the future, and left the robot **falsely marked running** (the failure class the action_horizon guard already prevents).
- **a `bool` (`True`)**: an `int` subclass, it slipped through the numeric check on every path and silently acted as a **1 Hz** rate.

## Change

- Strengthen `_validate_positive_frequency` to also reject `bool`, and apply it at the `run_policy` and MuJoCo `start_policy` entry points (`eval_policy` already used it).
- Remove the now-redundant inline `control_frequency` branch in `_resolve_horizon` (the entry-point guard runs first), which also **unifies the error message** across paths instead of the n_steps-only `"... when n_steps is used"` variant.
- Document the positive-number contract on `run_policy`.

No new helper is introduced: the existing `_validate_positive_frequency` (one name, one place) is the single source of truth, now wired at every entry point.

## Tests

New `TestControlFrequencyGuards` covers the `run_policy` duration path, non-numeric and bool inputs, the synchronous `start_policy` duration-path guard (asserting the robot is not left marked running), `eval_policy` bool rejection, the happy path, and ASCII-only messages. **9 of these fail on pre-fix code** (raw `ValueError`/`TypeError`, or a silent `status=success`) and pass after.

Local gate (CI scope): `ruff check`, `ruff format --check`, `mypy strands_robots tests tests_integ` all clean; `MUJOCO_GL=egl pytest tests/simulation/test_run_policy_horizon_validation.py tests/simulation/mujoco/test_input_validation.py tests/simulation/mujoco/test_run_multi_policy_no_recording.py` -> 124 passed.

Pure error-path validation guard (no policy/rendering/recording behavior change), so no rollout artifact applies.