### PR TITLE
fix(wbc): drop wrong-family default checkpoint; actionable error + SONIC-stack detection

### DIFF
--- a/docs/policies/wbc.md
+++ b/docs/policies/wbc.md
@@ -27,11 +27,26 @@ pip install "strands-robots[wbc]"            # onnxruntime only - light, no torc
 pip install "strands-robots[wbc,sim-mujoco]" # + MuJoCo to drive the G1 in sim
 ```
 
-No model weights are bundled. Download a GR00T-WBC (SONIC) checkpoint under the
-NVIDIA Open Model License (e.g.
-[`nvidia/GEAR-SONIC`](https://huggingface.co/nvidia/GEAR-SONIC)) into a
-directory containing `policy.onnx` (plus an optional `walk_policy.onnx` and
-`config.json`).
+No model weights are bundled and there is no default download: a bare
+`create_policy("wbc")` raises an actionable error instead of fetching the wrong
+model family. The decoupled-WBC G1 policies live in the
+[`NVlabs/GR00T-WholeBodyControl`](https://github.com/NVlabs/GR00T-WholeBodyControl)
+git-LFS tree at `decoupled_wbc/sim2mujoco/resources/robots/g1/policy/`:
+
+```bash
+git clone https://github.com/NVlabs/GR00T-WholeBodyControl.git   # 4.6G LFS
+mkdir -p /path/to/grootwbc-g1
+cp GR00T-WholeBodyControl/decoupled_wbc/sim2mujoco/resources/robots/g1/policy/\
+GR00T-WholeBodyControl-Balance.onnx /path/to/grootwbc-g1/policy.onnx
+cp GR00T-WholeBodyControl/decoupled_wbc/sim2mujoco/resources/robots/g1/policy/\
+GR00T-WholeBodyControl-Walk.onnx /path/to/grootwbc-g1/walk_policy.onnx
+```
+
+The result is a directory containing `policy.onnx` (the Balance policy) plus an
+optional `walk_policy.onnx` and `config.json`. Note: the HuggingFace repo
+[`nvidia/GEAR-SONIC`](https://huggingface.co/nvidia/GEAR-SONIC) is the SONIC VLA
+inference stack (encoder/decoder/planner ONNX), **not** this decoupled-WBC
+Balance/Walk family; passing it as a checkpoint raises a clear error.
 
 ## Quickstart
 
@@ -40,7 +55,7 @@ from strands_robots.policies import create_policy
 
 policy = create_policy(
     "wbc",                                  # shorthand: "sonic"
-    checkpoint="/path/to/GEAR-SONIC",       # dir with policy.onnx (+ walk_policy.onnx)
+    checkpoint="/path/to/grootwbc-g1",       # dir with policy.onnx (+ walk_policy.onnx)
     walk=True,
 )
 
@@ -57,7 +72,7 @@ actions = policy.get_actions_sync(
 
 ```python
 WBCPolicy(
-    checkpoint="/path/to/GEAR-SONIC",  # dir with policy.onnx, a direct .onnx path, or an HF id
+    checkpoint="/path/to/grootwbc-g1",  # dir with policy.onnx, a direct .onnx path, or an HF id
     config=None,                       # WBCConfig | path | dict | None (None -> config.json in checkpoint)
     walk=True,                         # load + prefer walk_policy.onnx for locomotion
     target_velocity=None,              # constructor-time default [vx, vy, omega] (per-call kwarg overrides)
@@ -131,7 +146,7 @@ sim.run_policy(
     robot_name="unitree_g1",
     instruction="walk forward",       # ignored by the controller
     policy_provider="wbc",
-    policy_config={"checkpoint": "/path/to/GEAR-SONIC", "walk": True},
+    policy_config={"checkpoint": "/path/to/grootwbc-g1", "walk": True},
     policy_kwargs={"target_velocity": [0.5, 0.0, 0.0]},   # per-call locomotion goal
     duration=10.0,
     control_frequency=50.0,
@@ -166,7 +181,7 @@ reproduces that loop - torque motors, `policy.compute_torques(...)` at
 IMU - and is the right way to see the G1 actually locomote:
 
 ```bash
-python examples/wbc_g1_torque_deploy.py --checkpoint /path/to/GEAR-SONIC \
+python examples/wbc_g1_torque_deploy.py --checkpoint /path/to/grootwbc-g1 \
     --duration 5 --vx 0.5 --mp4 /tmp/g1_walk.mp4
 ```
 

--- a/docs/training/vla_workflow.md
+++ b/docs/training/vla_workflow.md
@@ -20,7 +20,7 @@ python examples/vla_g1_workflow.py
 python examples/vla_g1_workflow.py --tune --base-model nvidia/GR00T-N1.7-3B
 
 # Deploy-only with downloaded SONIC weights:
-python examples/vla_g1_workflow.py --checkpoint /path/to/GEAR-SONIC
+python examples/vla_g1_workflow.py --checkpoint /path/to/grootwbc-g1
 ```
 
 ## Pipeline stages
@@ -41,7 +41,7 @@ from strands_robots.policies import create_policy
 from strands_robots.policies.wbc import install_wbc_torque_control
 
 sim = Robot("unitree_g1", mesh=False)
-policy = create_policy("wbc", checkpoint="/path/to/GEAR-SONIC", walk=True)
+policy = create_policy("wbc", checkpoint="/path/to/grootwbc-g1", walk=True)
 
 # WBC emits joint-POSITION targets, but the G1 scene's actuators are
 # position-servos (uniform kp=500) that override SONIC's tuned per-joint PD -
@@ -70,7 +70,7 @@ sim.stop_recording()
 The `vla_g1_workflow.py` example wires exactly this up behind a flag:
 
 ```bash
-python examples/vla_g1_workflow.py --record-checkpoint /path/to/GEAR-SONIC
+python examples/vla_g1_workflow.py --record-checkpoint /path/to/grootwbc-g1
 ```
 
 Two ingredients make WBC close its loop through `sim.run_policy`:

--- a/examples/vla_g1_workflow.py
+++ b/examples/vla_g1_workflow.py
@@ -13,7 +13,7 @@ Each stage is self-contained and gated:
   checkpoint). This completes in ~10 seconds on CPU with no external services.
 - Pass ``--tune`` to enable stage 2 (requires Docker + a GPU for Isaac-GR00T
   fine-tuning; takes ~hours). The deploy stage then uses the fine-tuned output.
-- Pass ``--checkpoint /path/to/GEAR-SONIC`` to skip recording + fine-tuning and
+- Pass ``--checkpoint /path/to/grootwbc-g1`` to skip recording + fine-tuning and
   jump straight to deploy with an existing SONIC checkpoint.
 
 This example proves the three pieces compose - dataset_recorder, GR00T Trainer,
@@ -34,7 +34,7 @@ Usage:
     python examples/vla_g1_workflow.py --tune --base-model nvidia/GR00T-N1.7-3B
 
     # Deploy-only with an existing SONIC checkpoint:
-    python examples/vla_g1_workflow.py --checkpoint /path/to/GEAR-SONIC
+    python examples/vla_g1_workflow.py --checkpoint /path/to/grootwbc-g1
 """
 
 from __future__ import annotations

--- a/examples/wbc_g1_torque_deploy.py
+++ b/examples/wbc_g1_torque_deploy.py
@@ -32,7 +32,7 @@ Usage::
     # Point at a checkpoint dir with policy.onnx (+ optional walk_policy.onnx,
     # config.json). The real weights live in the upstream GR00T-WBC repo under
     # decoupled_wbc/sim2mujoco/resources/robots/g1/policy/.
-    python examples/wbc_g1_torque_deploy.py --checkpoint /path/to/GEAR-SONIC \
+    python examples/wbc_g1_torque_deploy.py --checkpoint /path/to/grootwbc-g1 \
         --duration 5 --vx 0.5 [--mp4 /tmp/g1_walk.mp4]
 
 It prints per-second base x/z and a final verdict (advanced / fell / stayed put),

--- a/strands_robots/policies/wbc/policy.py
+++ b/strands_robots/policies/wbc/policy.py
@@ -44,7 +44,7 @@ Usage through the sim backend::
 
     sim.run_policy(
         robot_name="unitree_g1", policy_provider="wbc",
-        policy_config={"checkpoint": ".../GEAR-SONIC", "walk": True},
+        policy_config={"checkpoint": "/path/to/grootwbc-g1", "walk": True},
         policy_kwargs={"target_velocity": [0.5, 0.0, 0.0]},
         duration=10.0, control_frequency=50.0,
     )
@@ -129,10 +129,11 @@ _G1_SONIC_KPS = (150.0, 150.0, 150.0, 200.0, 40.0, 40.0, 150.0, 150.0, 150.0, 20
 _G1_SONIC_KDS = (2.0, 2.0, 2.0, 4.0, 2.0, 2.0, 2.0, 2.0, 2.0, 4.0, 2.0, 2.0, 5.0, 5.0, 5.0)
 _G1_SONIC_DEFAULT_ANGLES = (-0.1, 0.0, 0.0, 0.3, -0.2, 0.0, -0.1, 0.0, 0.0, 0.3, -0.2, 0.0, 0.0, 0.0, 0.0)
 
-# The HF repo the checkpoint is fetched from when ``checkpoint`` is a bare
-# model id rather than a local path. No weights are bundled; they are fetched
-# at runtime under the NVIDIA Open Model License.
-_DEFAULT_HF_REPO = "nvidia/GEAR-SONIC"
+# Filenames the SONIC VLA inference stack ships in its HuggingFace repo
+# (nvidia/GEAR-SONIC). These are NOT the decoupled-WBC Balance/Walk policies
+# this provider runs - detecting them lets us reject that checkpoint up front
+# with an actionable error instead of a confusing "policy.onnx not found".
+_SONIC_INFERENCE_STACK_FILES = frozenset({"model_encoder.onnx", "model_decoder.onnx", "planner_sonic.onnx"})
 
 # Default per-session ONNX filenames inside a checkpoint directory.
 _MAIN_POLICY_FILENAME = "policy.onnx"
@@ -215,13 +216,13 @@ class WBCPolicy(Policy):
         self._warned_no_velocity = False
         self._default_command = self._validate_velocity(target_velocity) if target_velocity is not None else None
 
-        # Default to the canonical SONIC checkpoint when none is given, so
-        # ``create_policy("wbc")`` resolves to a downloadable repo rather than
-        # failing with a bare "checkpoint not found". No weights are bundled;
-        # the HF download happens lazily in _load_sessions under the model
-        # license. An explicit local path / id always wins.
-        if checkpoint is None:
-            checkpoint = _DEFAULT_HF_REPO
+        # No weights are bundled and there is no default download. The
+        # decoupled-WBC Balance/Walk ONNX policies this provider runs live only
+        # in the NVlabs/GR00T-WholeBodyControl git-LFS tree (not as a standalone
+        # HuggingFace repo), so a bare ``create_policy("wbc")`` cannot guess a
+        # working checkpoint. A missing checkpoint surfaces an actionable error
+        # in _load_sessions (before any network call) rather than silently
+        # downloading the wrong model family. An explicit local path / id wins.
 
         # Resolve the config first - it tells us dims + default file layout.
         self._config = self._resolve_config(config, checkpoint)
@@ -800,14 +801,13 @@ class WBCPolicy(Policy):
         # under the model's license and cache under the HF cache.
         checkpoint = self._maybe_download_checkpoint(checkpoint)
 
+        # Reject the SONIC VLA inference stack early: it ships encoder/decoder/
+        # planner ONNX, not the decoupled-WBC policy.onnx this provider loads.
+        self._reject_sonic_inference_stack(checkpoint)
+
         main_path = self._resolve_onnx_path(self._config.policy_path, checkpoint, _MAIN_POLICY_FILENAME)
         if main_path is None or not Path(main_path).is_file():
-            raise RuntimeError(
-                f"WBCPolicy main ONNX checkpoint not found (resolved: {main_path!r}). "
-                "Pass checkpoint='/path/to/GEAR-SONIC' (a dir with policy.onnx) or a "
-                "direct .onnx path. No weights are bundled - download them under the "
-                "NVIDIA Open Model License (e.g. nvidia/GEAR-SONIC)."
-            )
+            raise RuntimeError(self._checkpoint_not_found_message(checkpoint, main_path))
         self.policy_session = ort.InferenceSession(main_path)  # type: ignore[attr-defined]
 
         if self._walk:
@@ -822,12 +822,65 @@ class WBCPolicy(Policy):
                 )
 
     @staticmethod
+    def _reject_sonic_inference_stack(checkpoint: str | None) -> None:
+        """Raise if ``checkpoint`` is the SONIC inference stack, not decoupled-WBC.
+
+        The HuggingFace repo ``nvidia/GEAR-SONIC`` ships the SONIC VLA inference
+        stack (``model_encoder.onnx`` / ``model_decoder.onnx`` /
+        ``planner_sonic.onnx``), NOT the decoupled-WBC Balance/Walk policies this
+        provider runs. Loading it would fail later with a confusing
+        ``policy.onnx not found``; detect it up front and point at the correct
+        source. A directory holding both a SONIC marker and ``policy.onnx`` is
+        left alone (the caller knowingly colocated files).
+
+        Raises:
+            RuntimeError: If the checkpoint directory holds SONIC inference-stack
+                ONNX files but no ``policy.onnx``.
+        """
+        if not checkpoint:
+            return
+        d = Path(checkpoint).expanduser()
+        if not d.is_dir():
+            return
+        onnx_names = {f.name for f in d.glob("*.onnx")}
+        sonic_found = onnx_names & _SONIC_INFERENCE_STACK_FILES
+        if sonic_found and _MAIN_POLICY_FILENAME not in onnx_names:
+            raise RuntimeError(
+                f"WBCPolicy checkpoint {str(d)!r} looks like the SONIC VLA inference stack "
+                f"(found {sorted(sonic_found)}), not the decoupled-WBC policy family. "
+                "WBCPolicy loads GR00T-WholeBodyControl-Balance.onnx (as policy.onnx) and "
+                "GR00T-WholeBodyControl-Walk.onnx (as walk_policy.onnx) from the "
+                "NVlabs/GR00T-WholeBodyControl git-LFS tree "
+                "(decoupled_wbc/sim2mujoco/resources/robots/g1/policy/). The SONIC "
+                "encoder/decoder/planner ONNX are a different runtime and are not loaded here."
+            )
+
+    @staticmethod
+    def _checkpoint_not_found_message(checkpoint: str | None, main_path: str | None) -> str:
+        """Build an actionable not-found error for a missing main ONNX policy."""
+        source_hint = (
+            "No weights are bundled. Obtain GR00T-WholeBodyControl-Balance.onnx and "
+            "GR00T-WholeBodyControl-Walk.onnx from the NVlabs/GR00T-WholeBodyControl "
+            "git-LFS tree (decoupled_wbc/sim2mujoco/resources/robots/g1/policy/), place "
+            "them in a directory as policy.onnx + walk_policy.onnx, and pass "
+            "checkpoint='/path/to/that/dir'. Note: the HuggingFace repo nvidia/GEAR-SONIC "
+            "is the SONIC VLA inference stack (encoder/decoder/planner), not this "
+            "decoupled-WBC Balance/Walk family."
+        )
+        if checkpoint is None:
+            return f"WBCPolicy requires a checkpoint but none was provided. {source_hint}"
+        return (
+            f"WBCPolicy main ONNX checkpoint not found (resolved: {main_path!r}). "
+            f"Pass checkpoint='/path/to/dir' containing policy.onnx or a direct .onnx path. {source_hint}"
+        )
+
+    @staticmethod
     def _maybe_download_checkpoint(checkpoint: str | None) -> str | None:
         """Resolve a HuggingFace model id to a local snapshot directory.
 
         Checkpoint resolution order (issue #466): local path | HF download | cache.
         A value that already exists on disk (file or dir) is returned unchanged.
-        A bare ``org/repo`` id (e.g. the default ``nvidia/GEAR-SONIC``) is
+        A bare ``org/repo`` id (e.g. an explicit ``org/repo`` checkpoint) is
         fetched via ``huggingface_hub.snapshot_download`` - which is itself a
         cache (repeat calls are offline-fast) - and the local dir is returned.
 
@@ -862,8 +915,8 @@ class WBCPolicy(Policy):
                 f"path, pass an existing directory or .onnx file.\n{e}"
             ) from e
         # Log BEFORE the network call so an unexpected download (e.g. a bare
-        # create_policy("wbc") defaulting to nvidia/GEAR-SONIC, or a mistyped
-        # local path that happens to be org/repo-shaped) is visible, not silent.
+        # an explicit org/repo checkpoint, or a mistyped local path that happens
+        # to be org/repo-shaped) is visible, not silent.
         logger.info(
             "WBCPolicy resolving checkpoint %r as a HuggingFace model id; downloading (cached after first use)...",
             checkpoint,

--- a/tests/policies/wbc/test_policy.py
+++ b/tests/policies/wbc/test_policy.py
@@ -584,10 +584,10 @@ class TestCheckpointResolution:
 
         monkeypatch.setattr(wbc_policy, "require_optional", _boom)
         with pytest.raises(RuntimeError, match="HuggingFace model id"):
-            WBCPolicy._maybe_download_checkpoint("nvidia/GEAR-SONIC")
+            WBCPolicy._maybe_download_checkpoint("acme/wbc-g1")
 
     def test_hf_id_heuristic_accepts_org_repo(self) -> None:
-        assert wbc_policy._looks_like_hf_repo_id("nvidia/GEAR-SONIC")
+        assert wbc_policy._looks_like_hf_repo_id("acme/wbc-g1")
         assert wbc_policy._looks_like_hf_repo_id("org-name/repo.name_1")
 
     def test_hf_id_heuristic_rejects_path_like(self) -> None:
@@ -680,9 +680,9 @@ class TestCheckpointResolution:
 
         fake = _FakeHub()
         monkeypatch.setattr(wbc_policy, "require_optional", lambda *a, **k: fake)
-        result = WBCPolicy._maybe_download_checkpoint("nvidia/GEAR-SONIC")
+        result = WBCPolicy._maybe_download_checkpoint("acme/wbc-g1")
         assert result == str(snapshot)
-        assert fake.calls == ["nvidia/GEAR-SONIC"]
+        assert fake.calls == ["acme/wbc-g1"]
 
     def test_hf_id_download_failure_raises_actionable_runtime_error(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
         # A hub download failure must surface as a RuntimeError with an
@@ -693,7 +693,84 @@ class TestCheckpointResolution:
 
         monkeypatch.setattr(wbc_policy, "require_optional", lambda *a, **k: _BoomHub())
         with pytest.raises(RuntimeError, match="failed to download checkpoint"):
-            WBCPolicy._maybe_download_checkpoint("nvidia/GEAR-SONIC")
+            WBCPolicy._maybe_download_checkpoint("acme/wbc-g1")
+
+
+# ---------------------------------------------------------------------------
+# GAP-1: no default HF repo; a bare create_policy("wbc") must fail with an
+# actionable error BEFORE any network call (the old default nvidia/GEAR-SONIC
+# is the SONIC inference stack, not the decoupled-WBC Balance/Walk family).
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultCheckpoint:
+    def test_no_default_hf_repo_constant(self) -> None:
+        # The wrong-family default constant must be gone entirely.
+        assert not hasattr(wbc_policy, "_DEFAULT_HF_REPO")
+
+    def test_create_policy_wbc_without_checkpoint_raises_actionable_error(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        # A bare create_policy("wbc") must raise an actionable error and must
+        # NOT trigger a real HuggingFace download (no silent wrong-family fetch).
+        # snapshot_download is wired to blow up if ever reached; checkpoint=None
+        # short-circuits long before it, so the error is the no-checkpoint one.
+        class _ExplodingHub:
+            def snapshot_download(self, *a, **k):  # type: ignore[no-untyped-def]
+                raise AssertionError("create_policy('wbc') must not download a checkpoint")
+
+        monkeypatch.setattr(wbc_policy, "require_optional", lambda *a, **k: _ExplodingHub())
+        with pytest.raises(RuntimeError, match="requires a checkpoint but none was provided"):
+            create_policy("wbc")
+
+    def test_no_checkpoint_message_points_at_nvlabs_lfs(self) -> None:
+        msg = WBCPolicy._checkpoint_not_found_message(None, None)
+        assert "NVlabs/GR00T-WholeBodyControl" in msg
+        assert "decoupled_wbc/sim2mujoco/resources/robots/g1/policy/" in msg
+        # Names GEAR-SONIC only to warn it is the wrong family.
+        assert "GEAR-SONIC" in msg
+
+    def test_sonic_inference_stack_dir_rejected(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        # A directory holding the SONIC encoder/decoder/planner ONNX (and no
+        # policy.onnx) must be rejected up front with a clear error.
+        d = tmp_path / "GEAR-SONIC"
+        d.mkdir()
+        for name in ("model_encoder.onnx", "model_decoder.onnx", "planner_sonic.onnx"):
+            (d / name).touch()
+        with pytest.raises(RuntimeError, match="SONIC VLA inference stack"):
+            WBCPolicy._reject_sonic_inference_stack(str(d))
+
+    def test_sonic_marker_with_policy_onnx_is_allowed(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        # If policy.onnx is colocated with a SONIC marker, the caller knowingly
+        # placed it - do not reject.
+        d = tmp_path / "mixed"
+        d.mkdir()
+        (d / "model_encoder.onnx").touch()
+        (d / "policy.onnx").touch()
+        WBCPolicy._reject_sonic_inference_stack(str(d))  # no raise
+
+    def test_reject_sonic_noops_on_none_and_files(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        WBCPolicy._reject_sonic_inference_stack(None)  # no raise
+        f = tmp_path / "policy.onnx"
+        f.touch()
+        WBCPolicy._reject_sonic_inference_stack(str(f))  # a file, not a dir: no raise
+
+    def test_explicit_checkpoint_dir_still_works(self, tmp_path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        # An explicit local checkpoint dir with a real policy.onnx must load
+        # (sanity that removing the default did not break the happy path). The
+        # ONNX session is stubbed so no real model file is needed.
+        d = tmp_path / "ckpt"
+        d.mkdir()
+        (d / "policy.onnx").touch()
+
+        class _FakeSession:
+            def __init__(self, path):  # type: ignore[no-untyped-def]
+                self.path = path
+
+        class _FakeOrt:
+            InferenceSession = _FakeSession
+
+        monkeypatch.setattr(wbc_policy, "require_optional", lambda *a, **k: _FakeOrt())
+        pol = WBCPolicy(checkpoint=str(d), walk=False)
+        assert pol.policy_session is not None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`create_policy("wbc")` with no `checkpoint` defaulted to the HuggingFace repo `nvidia/GEAR-SONIC`. That repo ships the **SONIC VLA inference stack** (`model_encoder.onnx`, `model_decoder.onnx`, `planner_sonic.onnx`, `low_latency/*`) — **not** the decoupled-WBC Balance/Walk ONNX policies `WBCPolicy` actually loads (`policy.onnx` / `walk_policy.onnx`).

The decoupled-WBC G1 weights live only in the `NVlabs/GR00T-WholeBodyControl` git-LFS tree at `decoupled_wbc/sim2mujoco/resources/robots/g1/policy/` (`GR00T-WholeBodyControl-Balance.onnx` + `GR00T-WholeBodyControl-Walk.onnx`), not as a standalone HF repo.

So a bare `create_policy("wbc")` silently downloaded ~MB of the **wrong model family**, then failed with a confusing `WBCPolicy main ONNX checkpoint not found` — whose own hint pointed back at `nvidia/GEAR-SONIC`, sending the user in a circle.

## Change

- **Remove the `_DEFAULT_HF_REPO = "nvidia/GEAR-SONIC"` default.** No weights are bundled and there is no working default repo to guess, so a missing checkpoint now raises an actionable error **before any network call**, pointing at the correct NVlabs git-LFS source.
- **Add `_reject_sonic_inference_stack()`**: if a checkpoint directory holds the SONIC encoder/decoder/planner ONNX but no `policy.onnx`, raise a clear error up front explaining it is the wrong family and where to obtain the Balance/Walk weights (covers the case where a user explicitly passes the SONIC checkpoint). A dir that colocates both a SONIC marker and `policy.onnx` is left alone.
- **Centralize the not-found message** in `_checkpoint_not_found_message()` with distinct text for the no-checkpoint vs. resolved-but-missing cases.
- **Docs**: `docs/policies/wbc.md` now explains there is no default download and gives the exact `git clone` + copy steps from the NVlabs LFS tree; clarifies that `nvidia/GEAR-SONIC` is the SONIC inference stack, not this family. Updated `docs/training/vla_workflow.md` + example placeholder paths to a neutral `grootwbc-g1` dir name.

## Behavior after fix

```
>>> create_policy("wbc")
RuntimeError: WBCPolicy requires a checkpoint but none was provided. No weights are
bundled. Obtain GR00T-WholeBodyControl-Balance.onnx and GR00T-WholeBodyControl-Walk.onnx
from the NVlabs/GR00T-WholeBodyControl git-LFS tree
(decoupled_wbc/sim2mujoco/resources/robots/g1/policy/), place them in a directory as
policy.onnx + walk_policy.onnx, and pass checkpoint='/path/to/that/dir'. Note: the
HuggingFace repo nvidia/GEAR-SONIC is the SONIC VLA inference stack
(encoder/decoder/planner), not this decoupled-WBC Balance/Walk family.
```

No network call is made for the no-checkpoint path (verified by the regression test, which wires `snapshot_download` to assert-raise if reached).

## Tests

New `TestDefaultCheckpoint` class in `tests/policies/wbc/test_policy.py`:
- `test_no_default_hf_repo_constant` — the wrong-family default constant is gone.
- `test_create_policy_wbc_without_checkpoint_raises_actionable_error` — bare `create_policy("wbc")` raises the actionable error and attempts **no** download.
- `test_no_checkpoint_message_points_at_nvlabs_lfs` — message names the LFS path + warns GEAR-SONIC is the wrong family.
- `test_sonic_inference_stack_dir_rejected` / `test_sonic_marker_with_policy_onnx_is_allowed` / `test_reject_sonic_noops_on_none_and_files` — SONIC-stack detection.
- `test_explicit_checkpoint_dir_still_works` — explicit local checkpoint dir happy path unchanged.

These fail on pre-fix code (reproducing the `nvidia/GEAR-SONIC` download) and pass after.

## Gate

- `ruff check strands_robots tests tests_integ`: clean
- `ruff format --check`: clean
- `mypy strands_robots tests tests_integ`: Success, no issues in 564 source files
- `MUJOCO_GL=egl pytest tests/policies/wbc/`: 109 passed (7 new)

No behavior change to a loaded gait — this is a loading-path correctness + UX fix, so a rollout video is not applicable; the before/after error reproduction above is the relevant proof.