### PR TITLE
feat(sim): auto-install WBC torque control on the run_policy default path

### DIFF
--- a/docs/policies/wbc.md
+++ b/docs/policies/wbc.md
@@ -139,6 +139,23 @@ sim.run_policy(
 )
 ```
 
+`run_policy` writes a policy's joint-position **targets** straight to the sim's
+actuators, but the stock Menagerie G1 ships *position-servo* actuators with a
+uniform `kp=500` gain that overrides SONIC's tuned per-joint PD - so driving
+those servos directly diverges and the robot falls. To make this quickstart
+just work, `run_policy` auto-detects a `WBCPolicy` on a position-servo scene and
+installs the torque shim (the `WBCTorqueController` PD->torque loop) for the
+duration of the call, then restores the actuators afterwards. With the real
+`GR00T-WholeBodyControl-{Balance,Walk}.onnx` weights and `target_velocity =
+[0.5, 0, 0]` the base advances ~1.9 m over 5 s while holding pelvis height
+~0.75 m and staying upright. Pass `wbc_install_torque_control=False` to opt out
+(e.g. to drive a torque-actuated scene directly or manage the controller
+yourself):
+
+```python
+sim.run_policy(..., policy_provider="wbc", wbc_install_torque_control=False)
+```
+
 The per-call command rides through `run_policy`'s `policy_kwargs` to
 `policy.get_actions(..., target_velocity=[...])`. A *static* walk can also be
 set once at construction via `policy_config={"checkpoint": ..., "target_velocity":
@@ -154,14 +171,15 @@ command reaches the policy over the mesh `tell()` path.
 
 ## Watching it walk (torque-control deploy)
 
-`sim.run_policy` writes the policy's joint-position **targets** to the sim's
-actuators. The default MuJoCo Menagerie G1 has *position-servo* actuators with
-their own gains, so a stable gait is not expected through that path. The real
-deploy loop (and the upstream reference) converts the targets to **torque** via
-the PD law on a *torque-actuated* model.
+The `sim.run_policy` path above already produces a stable gait: it auto-installs
+the torque shim that converts the policy's joint-position **targets** to
+**torque** via SONIC's per-joint PD law (the stock position-servo actuators
+alone diverge - see the note in [In simulation](#in-simulation)).
 
+For a self-contained, low-level reference - building the torque-actuated G1,
+running `policy.compute_torques(...)` at `control_decimation=4`, and rendering -
 [`examples/wbc_g1_torque_deploy.py`](https://github.com/strands-labs/robots/blob/main/examples/wbc_g1_torque_deploy.py)
-reproduces that loop - torque motors, `policy.compute_torques(...)` at
+reproduces the upstream deploy loop directly - torque motors, `policy.compute_torques(...)` at
 `control_decimation=4`, whole-body observation with real joint velocities + base
 IMU - and is the right way to see the G1 actually locomote:
 

--- a/strands_robots/policies/wbc/__init__.py
+++ b/strands_robots/policies/wbc/__init__.py
@@ -20,7 +20,11 @@ Requires the ``[wbc]`` extra (``onnxruntime``); no model weights are bundled
 
 from strands_robots.policies.wbc.config import WBCConfig
 from strands_robots.policies.wbc.policy import WBC_G1_ALL_JOINTS, WBC_G1_LEG_WAIST_JOINTS, WBCPolicy
-from strands_robots.policies.wbc.sim_control import WBCTorqueController, install_wbc_torque_control
+from strands_robots.policies.wbc.sim_control import (
+    WBCTorqueController,
+    install_wbc_torque_control,
+    wbc_uses_position_servo,
+)
 
 __all__ = [
     "WBCPolicy",
@@ -29,4 +33,5 @@ __all__ = [
     "WBC_G1_ALL_JOINTS",
     "WBCTorqueController",
     "install_wbc_torque_control",
+    "wbc_uses_position_servo",
 ]

--- a/strands_robots/policies/wbc/sim_control.py
+++ b/strands_robots/policies/wbc/sim_control.py
@@ -310,6 +310,47 @@ class WBCTorqueController:
             mj.mj_step(model, data)
 
 
+def wbc_uses_position_servo(sim: SimEngine, policy: WBCPolicy, robot_name: str) -> bool:
+    """Return True if the WBC-driven actuators on ``robot_name`` are position-servo.
+
+    :class:`WBCPolicy` emits joint-**position** targets. On a position-servo
+    scene (the stock Menagerie Unitree G1 ships a uniform ``kp=500`` servo) those
+    targets fight the servo gain and override SONIC's tuned per-joint PD, so the
+    gait diverges and the robot falls. This predicate lets ``run_policy`` decide
+    whether the torque shim (:func:`install_wbc_torque_control`) is needed.
+
+    A MuJoCo *position* actuator has ``biastype == mjBIAS_AFFINE`` (the ``-kp``
+    bias term); a *motor* (pure torque) actuator has ``biastype == mjBIAS_NONE``.
+    Returns ``True`` as soon as one driven actuator is position-servo, ``False``
+    when they are already torque actuators or cannot be resolved (no world,
+    unknown joints) - the conservative answer that leaves an already-correct or
+    unrecognised scene untouched.
+    """
+    import mujoco as mj
+
+    world = getattr(sim, "_world", None)
+    if world is None or getattr(world, "_model", None) is None:
+        return False
+    model = world._model
+    robot = world.robots.get(robot_name) if getattr(world, "robots", None) else None
+    pfx = robot.namespace if robot is not None else ""
+
+    n_act = policy.config.num_actions
+    driven_names = list(WBC_G1_ALL_JOINTS[:n_act])
+    for name in driven_names:
+        jid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, (pfx or "") + name)
+        if jid < 0:
+            jid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, name)
+        if jid < 0:
+            continue
+        for ai in range(model.nu):
+            if int(model.actuator_trnid[ai, 0]) == jid:
+                if int(model.actuator_biastype[ai]) == int(mj.mjtBias.mjBIAS_AFFINE):
+                    return True
+                break
+    return False
+
+
 def install_wbc_torque_control(sim: SimEngine, policy: WBCPolicy, robot_name: str) -> WBCTorqueController:
     """Install a :class:`WBCTorqueController` on ``sim`` for ``robot_name``.
 
@@ -338,4 +379,4 @@ def install_wbc_torque_control(sim: SimEngine, policy: WBCPolicy, robot_name: st
     return controller
 
 
-__all__ = ["WBCTorqueController", "install_wbc_torque_control"]
+__all__ = ["WBCTorqueController", "install_wbc_torque_control", "wbc_uses_position_servo"]

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -266,6 +266,21 @@ class SimEngine(ABC):
         """
         return None
 
+    def _maybe_install_wbc_torque_control(self, policy: Any, robot_name: str) -> Callable[[], None] | None:
+        """Hook: auto-install an action controller a policy needs to run correctly.
+
+        Default no-op (returns ``None``). The MuJoCo engine overrides this so a
+        :class:`~strands_robots.policies.wbc.WBCPolicy` driven through
+        :meth:`run_policy` on a position-servo scene gets the torque shim
+        (:func:`~strands_robots.policies.wbc.install_wbc_torque_control`) wired
+        up automatically - otherwise WBC's position targets fight the stiff
+        servo gain and the documented quickstart silently falls over.
+
+        Returns an optional zero-arg cleanup callable that :meth:`run_policy`
+        invokes in a ``finally`` block to restore the scene after the rollout.
+        """
+        return None
+
     def _preflight_policy_config(
         self,
         robot_name: str,
@@ -641,6 +656,7 @@ class SimEngine(ABC):
         reset_between: bool = True,
         async_rtc: bool | None = None,
         rtc_inference_timeout_s: float | None = None,
+        wbc_install_torque_control: bool = True,
     ) -> dict[str, Any]:
         """Run a policy loop in the simulation (blocking).
 
@@ -734,6 +750,16 @@ class SimEngine(ABC):
                 telemetry) instead of hanging the sim. ``None`` (default) waits
                 without a deadline. Forwarded verbatim to
                 :meth:`PolicyRunner.run`; ignored on the synchronous path.
+            wbc_install_torque_control: When ``True`` (default), a
+                :class:`~strands_robots.policies.wbc.WBCPolicy` run on a
+                position-servo scene (the stock ``Robot("unitree_g1")``) gets the
+                torque shim auto-installed for the duration of this call, then
+                uninstalled. WBC emits joint-position targets; the stock G1's
+                uniform ``kp=500`` servo would override SONIC's tuned per-joint
+                PD and the gait diverges, so the documented quickstart silently
+                falls over without it. Set ``False`` to manage the controller
+                yourself or to drive a torque-actuated scene directly. No-op for
+                non-WBC policies and on backends without the hook.
 
         Returns:
             Standard status dict with an agent-consumable ``{"json": {...}}``
@@ -782,23 +808,62 @@ class SimEngine(ABC):
         policy.set_robot_state_keys(self.robot_joint_names(robot_name))
         self.bind_policy_sim_context(policy, robot_name)
 
-        runner = PolicyRunner(self)
+        # Auto-install any action controller this policy needs to run correctly
+        # on this scene (e.g. the WBC torque shim on a position-servo G1). The
+        # cleanup callable restores the scene in the finally below. Opt out with
+        # wbc_install_torque_control=False (e.g. when you manage the controller
+        # yourself or drive a torque-actuated scene directly).
+        controller_cleanup = (
+            self._maybe_install_wbc_torque_control(policy, robot_name) if wbc_install_torque_control else None
+        )
 
-        # Single-episode fast path: byte-for-byte the historical behaviour
-        # (no reset, no episode-boundary flush). n_episodes defaults to 1 so
-        # existing callers are completely unaffected.
-        if n_episodes == 1:
-            recording = self._is_recording()
-            if recording:
-                logger.info(
-                    "run_policy: n_episodes=1, will produce 1 dataset episode of ~%d frames "
-                    "(frames buffer into the current episode and flush at save_episode/"
-                    "stop_recording). To record N DISTINCT dataset episodes pass n_episodes=N "
-                    "- do NOT loop the tool call.",
-                    int(duration * control_frequency),
+        try:
+            runner = PolicyRunner(self)
+
+            # Single-episode fast path: byte-for-byte the historical behaviour
+            # (no reset, no episode-boundary flush). n_episodes defaults to 1 so
+            # existing callers are completely unaffected.
+            if n_episodes == 1:
+                recording = self._is_recording()
+                if recording:
+                    logger.info(
+                        "run_policy: n_episodes=1, will produce 1 dataset episode of ~%d frames "
+                        "(frames buffer into the current episode and flush at save_episode/"
+                        "stop_recording). To record N DISTINCT dataset episodes pass n_episodes=N "
+                        "- do NOT loop the tool call.",
+                        int(duration * control_frequency),
+                    )
+                on_frame = self._make_run_policy_hook(robot_name, instruction)
+                result = runner.run(
+                    robot_name,
+                    policy,
+                    instruction=instruction,
+                    duration=duration,
+                    control_frequency=control_frequency,
+                    action_horizon=action_horizon,
+                    fast_mode=fast_mode,
+                    video=VideoConfig.from_dict(video),
+                    on_frame=on_frame,
+                    max_onframe_failures=max_onframe_failures,
+                    control_substeps=control_substeps,
+                    policy_kwargs=policy_kwargs,
+                    seed=seed,
+                    async_rtc=async_rtc,
+                    rtc_inference_timeout_s=rtc_inference_timeout_s,
                 )
-            on_frame = self._make_run_policy_hook(robot_name, instruction)
-            result = runner.run(
+                completed = 1 if result.get("status") == "success" else 0
+                contract = self._episode_contract_fields(
+                    requested=1, completed=completed, saved=0, flush_deferred=recording
+                )
+                self._merge_json_fields(result, contract)
+                return result
+
+            # Multi-episode path: one rollout per episode, flushing a dataset
+            # episode boundary (save_episode) when recording and resetting between
+            # episodes. Replaces the brittle manual
+            # ``for _ in range(n): run_policy(); save_episode(); reset()`` loop.
+            return self._run_episodes(
+                runner,
                 robot_name,
                 policy,
                 instruction=instruction,
@@ -806,45 +871,19 @@ class SimEngine(ABC):
                 control_frequency=control_frequency,
                 action_horizon=action_horizon,
                 fast_mode=fast_mode,
-                video=VideoConfig.from_dict(video),
-                on_frame=on_frame,
+                video=video,
                 max_onframe_failures=max_onframe_failures,
                 control_substeps=control_substeps,
                 policy_kwargs=policy_kwargs,
                 seed=seed,
+                n_episodes=n_episodes,
+                reset_between=reset_between,
                 async_rtc=async_rtc,
                 rtc_inference_timeout_s=rtc_inference_timeout_s,
             )
-            completed = 1 if result.get("status") == "success" else 0
-            contract = self._episode_contract_fields(
-                requested=1, completed=completed, saved=0, flush_deferred=recording
-            )
-            self._merge_json_fields(result, contract)
-            return result
-
-        # Multi-episode path: one rollout per episode, flushing a dataset
-        # episode boundary (save_episode) when recording and resetting between
-        # episodes. Replaces the brittle manual
-        # ``for _ in range(n): run_policy(); save_episode(); reset()`` loop.
-        return self._run_episodes(
-            runner,
-            robot_name,
-            policy,
-            instruction=instruction,
-            duration=duration,
-            control_frequency=control_frequency,
-            action_horizon=action_horizon,
-            fast_mode=fast_mode,
-            video=video,
-            max_onframe_failures=max_onframe_failures,
-            control_substeps=control_substeps,
-            policy_kwargs=policy_kwargs,
-            seed=seed,
-            n_episodes=n_episodes,
-            reset_between=reset_between,
-            async_rtc=async_rtc,
-            rtc_inference_timeout_s=rtc_inference_timeout_s,
-        )
+        finally:
+            if controller_cleanup is not None:
+                controller_cleanup()
 
     def _run_episodes(
         self,

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -49,7 +49,7 @@ import os
 import re
 import threading
 import time
-from collections.abc import AsyncGenerator, Sequence
+from collections.abc import AsyncGenerator, Callable, Sequence
 from concurrent.futures import Future, ThreadPoolExecutor
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -1121,6 +1121,54 @@ class MuJoCoSimEngine(
             ctx(self._world._model, namespace)
         except Exception as exc:  # noqa: BLE001 - non-fatal (mirrors set_robot_state_keys)
             logger.debug("bind_policy_sim_context(%s) failed: %s", robot_name, exc)
+
+    def _maybe_install_wbc_torque_control(self, policy: Any, robot_name: str) -> Callable[[], None] | None:
+        """Auto-install the WBC torque shim when a WBCPolicy drives a servo scene.
+
+        Overrides :meth:`SimEngine._maybe_install_wbc_torque_control`. WBC emits
+        joint-position targets; on the stock position-servo Unitree G1 those
+        targets fight the uniform ``kp=500`` servo gain and override SONIC's
+        tuned per-joint PD, so ``sim.run_policy(policy_provider="wbc")`` would
+        otherwise fall over within a fraction of a second. When the driven
+        actuators are position-servo (see
+        :func:`~strands_robots.policies.wbc.wbc_uses_position_servo`) and no
+        action controller is already installed, this wires up
+        :func:`~strands_robots.policies.wbc.install_wbc_torque_control` and
+        returns its :meth:`uninstall` so the scene is restored after the run.
+
+        Returns ``None`` (no-op) when ``[wbc]`` is not installed, ``policy`` is
+        not a ``WBCPolicy``, the actuators are already torque mode, or a
+        controller is already registered (a manual install always wins).
+        """
+        try:
+            from strands_robots.policies.wbc import (
+                WBCPolicy,
+                install_wbc_torque_control,
+                wbc_uses_position_servo,
+            )
+        except ImportError:
+            return None
+
+        if not isinstance(policy, WBCPolicy):
+            return None
+        world = self._world
+        if world is None or world._model is None:
+            return None
+        backend_state = getattr(world, "_backend_state", None)
+        if isinstance(backend_state, dict) and backend_state.get("action_controller") is not None:
+            return None  # a manually-installed controller wins
+        if not wbc_uses_position_servo(self, policy, robot_name):
+            return None
+
+        controller = install_wbc_torque_control(self, policy, robot_name)
+        logger.info(
+            "run_policy: auto-installed WBC torque control on %r (position-servo "
+            "actuators detected). WBC emits joint-position targets the stock servo "
+            "gain would override; the torque shim applies SONIC's per-joint PD law "
+            "so the gait is stable. Pass wbc_install_torque_control=False to opt out.",
+            robot_name,
+        )
+        return controller.uninstall
 
     def list_robots_info(self) -> dict[str, Any]:
         """Agent-tool action: pretty-printed robot listing.
@@ -2400,6 +2448,7 @@ class MuJoCoSimEngine(
         reset_between: bool = True,
         async_rtc: bool | None = None,
         rtc_inference_timeout_s: float | None = None,
+        wbc_install_torque_control: bool = True,
     ) -> dict[str, Any]:
         """MuJoCo ``run_policy`` override: pre-flight world check + graceful stop.
 
@@ -2447,6 +2496,7 @@ class MuJoCoSimEngine(
                 reset_between=reset_between,
                 async_rtc=async_rtc,
                 rtc_inference_timeout_s=rtc_inference_timeout_s,
+                wbc_install_torque_control=wbc_install_torque_control,
             )
         finally:
             if self._world is not None and robot_name in self._world.robots:

--- a/tests/policies/wbc/test_run_policy_auto_torque.py
+++ b/tests/policies/wbc/test_run_policy_auto_torque.py
@@ -1,0 +1,161 @@
+"""Regression tests for the WBC auto-torque-control path on ``run_policy``.
+
+:class:`WBCPolicy` emits joint-**position** targets. The stock
+``Robot("unitree_g1")`` ships position-servo actuators with a uniform
+``kp=500`` gain that overrides SONIC's tuned per-joint PD, so a bare
+``sim.run_policy(policy_provider="wbc", robot_name="unitree_g1")`` drove the
+servos directly and the gait diverged within a fraction of a second - the
+documented quickstart silently fell over.
+
+The fix gives the MuJoCo engine a ``_maybe_install_wbc_torque_control`` hook
+that ``run_policy`` invokes after binding the policy: when a WBCPolicy meets a
+position-servo scene it auto-installs the torque shim for the duration of the
+call and restores the actuators afterwards. The opt-out is the
+``wbc_install_torque_control=False`` kwarg.
+
+These run WITHOUT real SONIC weights (stub ONNX session, real config + joint
+mapping) on the real torque/position-servo G1 model. The end-to-end "does it
+actually WALK" validation needs real weights and lives in the gated
+integration suite.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import cast
+
+import numpy as np
+import pytest
+
+from strands_robots.policies import MockPolicy
+from strands_robots.policies.wbc import WBCConfig, WBCPolicy, wbc_uses_position_servo
+from strands_robots.simulation.base import SimEngine
+
+mujoco = pytest.importorskip("mujoco", reason="mujoco not installed")
+
+
+class _StubSession:
+    class _In:
+        name = "obs"
+
+    def get_inputs(self):  # type: ignore[no-untyped-def]
+        return [self._In()]
+
+    def run(self, output_names, feed):  # type: ignore[no-untyped-def]
+        return [np.zeros((1, 15), dtype=np.float32)]
+
+
+def _g1_policy() -> WBCPolicy:
+    cfg = WBCConfig(policy_path="x.onnx")
+    p = WBCPolicy(config=cfg, walk=False, allow_missing_models=True)
+    p.policy_session = _StubSession()
+    return p
+
+
+def _build_g1_model():  # type: ignore[no-untyped-def]
+    from strands_robots.simulation.model_registry import resolve_model
+
+    xml = resolve_model("unitree_g1")
+    if not xml:
+        pytest.skip("unitree_g1 model assets not available")
+    model = mujoco.MjModel.from_xml_path(xml)
+    data = mujoco.MjData(model)
+    return model, data
+
+
+class _FakeRobot:
+    def __init__(self, namespace: str) -> None:
+        self.namespace = namespace
+
+
+class _FakeWorld:
+    def __init__(self, model, data, namespace) -> None:  # type: ignore[no-untyped-def]
+        self._model = model
+        self._data = data
+        self.robots = {"unitree_g1": _FakeRobot(namespace)}
+        self._backend_state: dict = {}
+
+
+def _namespace_for(model) -> str:  # type: ignore[no-untyped-def]
+    name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, 1) or ""
+    return "unitree_g1/" if name.startswith("unitree_g1/") else ""
+
+
+def _mujoco_sim_with_world(model, data):  # type: ignore[no-untyped-def]
+    """A real MuJoCo Simulation engine whose world holds the given G1 model."""
+    from strands_robots.simulation.mujoco.simulation import Simulation
+
+    sim = Simulation()
+    sim._world = _FakeWorld(model, data, _namespace_for(model))  # type: ignore[assignment]
+    return sim
+
+
+# ---------------------------------------------------------------------------
+# wbc_uses_position_servo predicate
+# ---------------------------------------------------------------------------
+
+
+class TestPositionServoDetection:
+    def test_stock_g1_is_position_servo(self) -> None:
+        model, data = _build_g1_model()
+        sim = _FakeWorld(model, data, _namespace_for(model))
+        wrapper = type("S", (), {"_world": sim})()
+        policy = _g1_policy()
+        assert wbc_uses_position_servo(cast(SimEngine, wrapper), policy, "unitree_g1") is True
+
+    def test_false_after_actuators_flipped_to_torque(self) -> None:
+        from strands_robots.policies.wbc import install_wbc_torque_control
+
+        model, data = _build_g1_model()
+        world = _FakeWorld(model, data, _namespace_for(model))
+        wrapper = type("S", (), {"_world": world})()
+        policy = _g1_policy()
+        # Flip to torque mode; the predicate must now report "no servo".
+        install_wbc_torque_control(cast(SimEngine, wrapper), policy, "unitree_g1")
+        assert wbc_uses_position_servo(cast(SimEngine, wrapper), policy, "unitree_g1") is False
+
+    def test_false_without_world(self) -> None:
+        wrapper = type("S", (), {"_world": None})()
+        assert wbc_uses_position_servo(cast(SimEngine, wrapper), _g1_policy(), "unitree_g1") is False
+
+
+# ---------------------------------------------------------------------------
+# MuJoCo engine auto-install hook
+# ---------------------------------------------------------------------------
+
+
+class TestAutoInstallHook:
+    def test_installs_torque_shim_and_cleanup_restores(self, caplog) -> None:  # type: ignore[no-untyped-def]
+        model, data = _build_g1_model()
+        sim = _mujoco_sim_with_world(model, data)
+        policy = _g1_policy()
+
+        driven_before = [int(model.actuator_biastype[ai]) for ai in range(model.nu)]
+        assert int(mujoco.mjtBias.mjBIAS_AFFINE) in driven_before  # stock = servo
+
+        with caplog.at_level(logging.INFO):
+            cleanup = sim._maybe_install_wbc_torque_control(policy, "unitree_g1")
+
+        assert callable(cleanup), "expected a cleanup callable when shim is installed"
+        assert "auto-installed WBC torque control" in caplog.text
+        controller = sim._world._backend_state["action_controller"]
+        # The driven actuators are now torque motors (biastype NONE).
+        for ai in controller.leg_waist_actuator_ids:
+            assert int(model.actuator_biastype[ai]) == int(mujoco.mjtBias.mjBIAS_NONE)
+
+        # Cleanup restores the original position-servo gains.
+        cleanup()
+        first = controller.leg_waist_actuator_ids[0]
+        assert int(model.actuator_biastype[first]) == int(mujoco.mjtBias.mjBIAS_AFFINE)
+
+    def test_skips_when_controller_already_installed(self) -> None:
+        model, data = _build_g1_model()
+        sim = _mujoco_sim_with_world(model, data)
+        sim._world._backend_state["action_controller"] = object()  # manual install wins
+        assert sim._maybe_install_wbc_torque_control(_g1_policy(), "unitree_g1") is None
+
+    def test_skips_for_non_wbc_policy(self) -> None:
+        model, data = _build_g1_model()
+        sim = _mujoco_sim_with_world(model, data)
+        assert sim._maybe_install_wbc_torque_control(MockPolicy(), "unitree_g1") is None
+        assert "action_controller" not in sim._world._backend_state


### PR DESCRIPTION
## Problem

`WBCPolicy` emits joint-**position** targets. The stock `Robot("unitree_g1")`
ships *position-servo* actuators with a uniform `kp=500` gain that overrides
SONIC's tuned per-joint PD, so the documented quickstart

```python
sim = Robot("unitree_g1")
sim.run_policy(robot_name="unitree_g1", policy_provider="wbc", ...)
```

drove those servos directly and the gait diverged within a fraction of a second
- the robot fell. The only way to get a real walk was the manual
`install_wbc_torque_control(sim, policy, robot_name)` path, and `docs/policies/wbc.md`
had to warn readers that "a stable gait is not expected through that path". A UX
cliff: the docs say one thing, the sim does another.

## Change

Add a `SimEngine._maybe_install_wbc_torque_control(policy, robot_name)` hook
(default no-op, returning an optional cleanup callable) that `run_policy` invokes
after the policy is bound, wrapping the rollout in `try/finally`. The MuJoCo
engine overrides it to:

- detect a `WBCPolicy` on a position-servo scene via the new
  `wbc_uses_position_servo(sim, policy, robot_name)` predicate (a MuJoCo
  *position* actuator has `biastype == mjBIAS_AFFINE`; a *motor* has
  `mjBIAS_NONE`), and
- auto-install the existing `WBCTorqueController` PD->torque shim for the
  duration of the call, restoring the original actuators afterwards.

It is a no-op for non-WBC policies, when an `action_controller` is already
installed (a manual install always wins), and on torque-actuated scenes. Opt out
with the new `wbc_install_torque_control: bool = True` kwarg (e.g. to drive a
torque-actuated scene directly or manage the controller yourself).

This keeps `SimEngine` backend-agnostic (the hook is generic; all WBC/MuJoCo
specifics live in the override and the WBC module) and adds no back-compat shim.

## Verification (MuJoCo, headless EGL)

With the real `GR00T-WholeBodyControl-{Balance,Walk}.onnx` weights and
`target_velocity = [0.5, 0, 0]`, `sim.run_policy(policy_provider="wbc", ...)` now
walks straight out of the box - identical to the manual-install result, with no
extra wiring:

```
run_policy: auto-installed WBC torque control on 'unitree_g1' (position-servo
  actuators detected). ...
RESULT status=success  base x: +0.000 -> +1.888 m  (forward +1.888 m)  z=0.747 m (upright)
```

![G1 walking via sim.run_policy WBC auto-torque path](https://github.com/cagataycali/robots/releases/download/wbc-autotorque-demo/wbc_autoinstall_walk.gif)

G1 under `WBCPolicy` (GR00T-WBC SONIC, `walk_policy.onnx`) commanded at
`vx = 0.5 m/s`, driven entirely through `sim.run_policy(policy_provider="wbc")`
with the torque shim auto-installed - base advances ~1.9 m over 5 s while holding
pelvis height ~0.75 m, upright.
([MP4](https://github.com/cagataycali/robots/releases/download/wbc-autotorque-demo/wbc_autoinstall_walk.mp4))

## Tests

`tests/policies/wbc/test_run_policy_auto_torque.py` (new, 6 tests) covers:
- `wbc_uses_position_servo` True on the stock G1, False once actuators are torque, False with no world;
- the MuJoCo hook installs the shim and the returned cleanup restores the position-servo gains;
- the hook skips when a controller is already installed and for a non-WBC policy.

These fail on pre-fix code (the predicate and hook do not exist). Full gate green
locally: `ruff check`/`ruff format --check` clean, `mypy strands_robots tests
tests_integ` clean (565 files), `MUJOCO_GL=egl pytest tests/policies/wbc/` 108
passed plus the run_policy/e2e sim suites.

Docs: `docs/policies/wbc.md` updated - the quickstart now walks, with the
position-servo note and the `wbc_install_torque_control=False` opt-out.
