### PR TITLE
feat(policies): pin HF Hub revision for lerobot_local checkpoints

### DIFF
--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -43,8 +43,32 @@ LerobotLocalPolicy(
     obs_rename_override=None,            # {runtime_obs_key: "observation.images.*"} merged over embodiment.obs_rename
     strict_keys=False,                   # raise instead of positional camera fallback
     cache_model=True,                    # reuse a process-cached model across instances
+    revision=None,                       # pin a HF Hub revision (branch/tag/commit SHA)
 )
 ```
+
+### Pinning a Hub revision
+
+Pass `revision=` to pin a checkpoint to a reproducible Hub version - a
+branch name, tag, or commit SHA. It is threaded to lerobot's
+`PreTrainedPolicy.from_pretrained(..., revision=...)` (and to the config
+resolution that auto-detects `policy_type`), so the exact weights are
+loaded regardless of later pushes to the repo's default branch:
+
+```python
+policy = create_policy(
+    "lerobot_local",
+    pretrained_name_or_path="lerobot/smolvla_base",
+    revision="v1.0",   # or a 40-char commit SHA
+)
+```
+
+Two revisions of the same repo are cached independently (the revision is
+part of the model-cache key), so pinning never collides with an unpinned
+load. Revision pinning is not supported for transformers-native MolmoAct2
+checkpoints, which load weights via `checkpoint_path` rather than
+`from_pretrained`; passing `revision=` with one raises `ValueError`. Pin
+those by downloading the revision locally and pointing at the directory.
 
 ## Model caching
 

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -222,9 +222,13 @@ class LerobotLocalPolicy(Policy):
         obs_rename_override: dict[str, str] | None = None,
         strict_keys: bool = False,
         cache_model: bool = True,
+        revision: str | None = None,
         **kwargs,
     ):
         self.pretrained_name_or_path = pretrained_name_or_path
+        # Optional Hub revision (branch, tag, or commit SHA) to pin the
+        # checkpoint to a reproducible version. None loads the default branch.
+        self.revision = revision
         self.policy_type = policy_type
         self.requested_device = device
         self.actions_per_step = actions_per_step
@@ -629,6 +633,14 @@ class LerobotLocalPolicy(Policy):
         from . import molmoact2 as _molmoact2
 
         if _molmoact2.is_molmoact2(self.pretrained_name_or_path, self.policy_type):
+            if self.revision:
+                raise ValueError(
+                    "revision pinning is not supported for transformers-native "
+                    "MolmoAct2 checkpoints (loaded via checkpoint_path, not "
+                    "PreTrainedPolicy.from_pretrained). Pin the version by passing "
+                    "a commit-SHA-qualified pretrained_name_or_path, or download the "
+                    "revision locally and point at the directory."
+                )
             self._load_molmoact2_model()
             return
 
@@ -654,7 +666,7 @@ class LerobotLocalPolicy(Policy):
         # (path, policy_type, device) - skips the expensive from_pretrained
         # weight read + GPU upload on repeat instantiation. The resolved
         # policy_type is cached alongside the module so a hit needs no hub call.
-        cache_key = self._model_cache_key("generic", self.policy_type)
+        cache_key = self._model_cache_key("generic", self.policy_type, self.revision)
         cached = self._cache_get(cache_key)
         self.load_cache_hit = cached is not None
         if cached is not None:
@@ -669,9 +681,15 @@ class LerobotLocalPolicy(Policy):
             if self.policy_type:
                 PolicyClass = resolve_policy_class_by_name(self.policy_type)
             else:
-                PolicyClass, self.policy_type = resolve_policy_class_from_hub(self.pretrained_name_or_path)
+                PolicyClass, self.policy_type = resolve_policy_class_from_hub(
+                    self.pretrained_name_or_path, revision=self.revision
+                )
 
-            self._policy = PolicyClass.from_pretrained(self.pretrained_name_or_path)
+            # Pass revision only when set so the call matches lerobot's
+            # default (revision=None) and stays compatible with policy
+            # classes whose from_pretrained does not accept the kwarg.
+            from_pretrained_kwargs = {"revision": self.revision} if self.revision else {}
+            self._policy = PolicyClass.from_pretrained(self.pretrained_name_or_path, **from_pretrained_kwargs)
             assert self._policy is not None
 
             self._policy.eval()

--- a/strands_robots/policies/lerobot_local/resolution.py
+++ b/strands_robots/policies/lerobot_local/resolution.py
@@ -209,7 +209,7 @@ def _ensure_policy_configs_registered() -> None:
                 continue
 
 
-def resolve_policy_class_from_hub(pretrained_name_or_path: str) -> tuple[type[Any], str]:
+def resolve_policy_class_from_hub(pretrained_name_or_path: str, revision: str | None = None) -> tuple[type[Any], str]:
     """Resolve the LeRobot policy class from a pretrained path or HF repo.
 
     Uses PreTrainedConfig.from_pretrained() which handles config resolution,
@@ -220,6 +220,8 @@ def resolve_policy_class_from_hub(pretrained_name_or_path: str) -> tuple[type[An
 
     Args:
         pretrained_name_or_path: HF model ID or local directory path.
+        revision: Optional Hub revision (branch, tag, or commit SHA) to pin the
+            resolved config to. ``None`` resolves the default branch.
 
     Returns:
         Tuple of (PolicyClass, policy_type_string).
@@ -238,7 +240,7 @@ def resolve_policy_class_from_hub(pretrained_name_or_path: str) -> tuple[type[An
         # ALL policies via their module-level @ChoiceRegistry decorators.
         _ensure_policy_configs_registered()
 
-        config = PreTrainedConfig.from_pretrained(pretrained_name_or_path)
+        config = PreTrainedConfig.from_pretrained(pretrained_name_or_path, revision=revision)
         policy_type = getattr(config, "type", type(config).__name__.replace("Config", "").lower())
         logger.info("Auto-resolved via PreTrainedConfig: '%s' -> type='%s'", pretrained_name_or_path, policy_type)
 
@@ -258,7 +260,7 @@ def resolve_policy_class_from_hub(pretrained_name_or_path: str) -> tuple[type[An
             raise
 
     # Strategy 2: Manual config.json reading (fallback for custom/third-party)
-    policy_type = _read_policy_type_from_config(pretrained_name_or_path)
+    policy_type = _read_policy_type_from_config(pretrained_name_or_path, revision=revision)
 
     if not policy_type:
         raise ValueError(
@@ -546,7 +548,7 @@ def _policy_type_from_config(config: dict[str, Any]) -> str | None:
     return None
 
 
-def _read_policy_type_from_config(pretrained_name_or_path: str) -> str | None:
+def _read_policy_type_from_config(pretrained_name_or_path: str, revision: str | None = None) -> str | None:
     """Read policy type from config.json (local or HF Hub).
 
     Tries the lerobot-native ``type`` field first, then falls back to the
@@ -557,6 +559,8 @@ def _read_policy_type_from_config(pretrained_name_or_path: str) -> str | None:
 
     Args:
         pretrained_name_or_path: Local path or HF model ID.
+        revision: Optional Hub revision (branch, tag, or commit SHA) to pin the
+            downloaded config.json to. ``None`` uses the default branch.
 
     Returns:
         Policy type string or None if not found.
@@ -572,7 +576,7 @@ def _read_policy_type_from_config(pretrained_name_or_path: str) -> str | None:
     try:
         from huggingface_hub import hf_hub_download
 
-        config_path = hf_hub_download(pretrained_name_or_path, "config.json")
+        config_path = hf_hub_download(pretrained_name_or_path, "config.json", revision=revision)
         with open(config_path) as config_file:
             config = json.load(config_file)
         return _policy_type_from_config(config)

--- a/tests/policies/lerobot_local/test_policy.py
+++ b/tests/policies/lerobot_local/test_policy.py
@@ -1800,6 +1800,7 @@ class TestLoadModelDeviceMove:
         policy.processor_overrides = {}
         policy.actions_per_step = 1
         policy.cache_model = False
+        policy.revision = None
 
         mock_policy = _load_model_with_mocks(policy, param_device="meta", bridge_active=False)
 
@@ -1819,6 +1820,7 @@ class TestLoadModelDeviceMove:
         policy.processor_overrides = {}
         policy.actions_per_step = 1
         policy.cache_model = False
+        policy.revision = None
 
         mock_policy = _load_model_with_mocks(policy, param_device="cpu", bridge_active=False)
 
@@ -1842,6 +1844,7 @@ class TestLoadModelPostprocessorWarning:
         policy.processor_overrides = {}
         policy.actions_per_step = 1
         policy.cache_model = False
+        policy.revision = None
         return policy
 
     def test_warns_without_postprocessor(self, caplog):

--- a/tests/policies/lerobot_local/test_resolution.py
+++ b/tests/policies/lerobot_local/test_resolution.py
@@ -713,7 +713,7 @@ class TestResolvePolicyClassFromHub:
         class _FakeACTPolicy:
             pass
 
-        def _from_pretrained(_path):
+        def _from_pretrained(_path, revision=None):
             return _FakeConfig()
 
         monkeypatch.setattr(
@@ -740,7 +740,7 @@ class TestResolvePolicyClassFromHub:
         class _FakeCustomPolicy:
             pass
 
-        def _boom(_path):
+        def _boom(_path, revision=None):
             raise ValueError("draccus cannot decode this third-party config")
 
         monkeypatch.setattr(
@@ -748,7 +748,7 @@ class TestResolvePolicyClassFromHub:
             staticmethod(_boom),
         )
         monkeypatch.setattr(resolution, "_ensure_policy_configs_registered", lambda: None)
-        monkeypatch.setattr(resolution, "_read_policy_type_from_config", lambda _p: "custom_type")
+        monkeypatch.setattr(resolution, "_read_policy_type_from_config", lambda _p, revision=None: "custom_type")
         monkeypatch.setattr(
             resolution,
             "resolve_policy_class_by_name",
@@ -765,7 +765,7 @@ class TestResolvePolicyClassFromHub:
         function raises ``ValueError`` telling the caller to pass it explicitly."""
         from strands_robots.policies.lerobot_local import resolution
 
-        def _boom(_path):
+        def _boom(_path, revision=None):
             raise ValueError("undecodable")
 
         monkeypatch.setattr(
@@ -773,7 +773,7 @@ class TestResolvePolicyClassFromHub:
             staticmethod(_boom),
         )
         monkeypatch.setattr(resolution, "_ensure_policy_configs_registered", lambda: None)
-        monkeypatch.setattr(resolution, "_read_policy_type_from_config", lambda _p: None)
+        monkeypatch.setattr(resolution, "_read_policy_type_from_config", lambda _p, revision=None: None)
 
         with pytest.raises(ValueError, match="Could not determine policy type"):
             resolution.resolve_policy_class_from_hub("mystery/repo")
@@ -805,7 +805,7 @@ class TestResolvePolicyClassFromHub:
         class _WeirdError(Exception):
             pass
 
-        def _boom(_path):
+        def _boom(_path, revision=None):
             raise _WeirdError("not a draccus error and not in the handled tuple")
 
         monkeypatch.setattr(

--- a/tests/policies/lerobot_local/test_revision_pinning.py
+++ b/tests/policies/lerobot_local/test_revision_pinning.py
@@ -1,0 +1,129 @@
+"""Hub revision pinning for the lerobot_local provider.
+
+lerobot's ``PreTrainedPolicy.from_pretrained`` accepts ``revision=`` to pin a
+checkpoint to a branch, tag, or commit SHA for reproducible loads. These tests
+pin that ``LerobotLocalPolicy`` threads a caller-supplied ``revision`` all the
+way to ``from_pretrained`` and the hub-side class resolution, that omitting it
+preserves the default (unpinned) call shape, and that asking for a revision on a
+transformers-native MolmoAct2 checkpoint fails loudly instead of silently
+ignoring the request.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from strands_robots.policies.lerobot_local.policy import (
+    LerobotLocalPolicy,
+    clear_model_cache,
+)
+
+
+def _generic_inner():
+    inner = MagicMock()
+    inner.config = MagicMock(
+        input_features={"observation.state": MagicMock(shape=(6,))},
+        output_features={"action": MagicMock(shape=(6,))},
+        device="cpu",
+    )
+    inner.eval.return_value = None
+    return inner
+
+
+def _build(policy_type="act", **kwargs):
+    """Construct a generic lerobot_local policy with the weight load stubbed.
+
+    Returns ``(policy, from_pretrained_mock)`` so a test can inspect exactly how
+    the underlying ``PreTrainedPolicy.from_pretrained`` was invoked.
+    """
+    mock_cls = MagicMock()
+    captured: dict = {}
+
+    def _fp(path, **kw):
+        captured["path"] = path
+        captured["kwargs"] = kw
+        return _generic_inner()
+
+    mock_cls.from_pretrained.side_effect = _fp
+    with (
+        patch(
+            "strands_robots.policies.lerobot_local.policy.resolve_policy_class_by_name",
+            return_value=mock_cls,
+        ),
+        patch(
+            "strands_robots.policies.lerobot_local.policy.ProcessorBridge.from_pretrained",
+            return_value=MagicMock(is_active=False),
+        ),
+    ):
+        policy = LerobotLocalPolicy(
+            pretrained_name_or_path="test/model",
+            policy_type=policy_type,
+            device="cpu",
+            cache_model=False,
+            **kwargs,
+        )
+    return policy, captured
+
+
+class TestRevisionPinning:
+    def setup_method(self):
+        clear_model_cache()
+
+    def teardown_method(self):
+        clear_model_cache()
+
+    def test_revision_threaded_to_from_pretrained(self):
+        _policy, captured = _build(revision="v1.2.3")
+        assert captured["kwargs"].get("revision") == "v1.2.3"
+
+    def test_no_revision_keeps_default_call_shape(self):
+        # Without a revision the wrapper must not inject revision=None, so it
+        # stays compatible with policy classes whose from_pretrained predates
+        # the kwarg.
+        _policy, captured = _build()
+        assert "revision" not in captured["kwargs"]
+
+    def test_revision_threaded_to_hub_class_resolution(self):
+        # When policy_type is not given, the wrapper resolves the class from the
+        # hub; the revision must pin that config read too.
+        seen: dict = {}
+
+        def _resolve(path, revision=None):
+            seen["revision"] = revision
+            mock_cls = MagicMock()
+            mock_cls.from_pretrained.side_effect = lambda _p, **_kw: _generic_inner()
+            return mock_cls, "act"
+
+        with (
+            patch(
+                "strands_robots.policies.lerobot_local.policy.resolve_policy_class_from_hub",
+                side_effect=_resolve,
+            ),
+            patch(
+                "strands_robots.policies.lerobot_local.policy.ProcessorBridge.from_pretrained",
+                return_value=MagicMock(is_active=False),
+            ),
+        ):
+            LerobotLocalPolicy(
+                pretrained_name_or_path="test/model",
+                policy_type=None,
+                device="cpu",
+                cache_model=False,
+                revision="abc1234",
+            )
+        assert seen["revision"] == "abc1234"
+
+    def test_revision_on_molmoact2_raises(self):
+        # MolmoAct2 SO-100/101 checkpoints load weights via checkpoint_path, not
+        # PreTrainedPolicy.from_pretrained, so revision cannot be honored. Asking
+        # for one must fail loudly rather than silently load the default branch.
+        with pytest.raises(ValueError, match="revision pinning is not supported"):
+            LerobotLocalPolicy(
+                pretrained_name_or_path="allenai/MolmoAct2-SO100_101",
+                policy_type="molmoact2",
+                device="cpu",
+                cache_model=False,
+                revision="v1.0",
+            )


### PR DESCRIPTION
## Problem

The `lerobot_local` provider always loaded checkpoints from the repo's default branch. `LerobotLocalPolicy` never threaded a `revision` into `PreTrainedPolicy.from_pretrained`, even though lerobot supports `from_pretrained(..., revision=...)` for reproducible, version-pinned loads. A caller passing `revision=` had it silently swallowed by `**kwargs`, so the resolved weights drifted with any later push to the repo — no way to pin an eval/deploy to an exact checkpoint version.

## Change

Add a first-class `revision: str | None = None` parameter to `LerobotLocalPolicy` that threads through the generic load path:

- Hub class resolution — `resolve_policy_class_from_hub(..., revision=)` pins both `PreTrainedConfig.from_pretrained` and the manual `config.json` fallback (`hf_hub_download(..., revision=)`).
- Weight load — `PreTrainedPolicy.from_pretrained(..., revision=)`.
- Process model cache — the revision is part of the cache key, so two pinned revisions of one repo are cached independently and never collide with an unpinned load.

`revision` is passed only when set, preserving the existing unpinned call shape for policy classes whose `from_pretrained` predates the kwarg.

Transformers-native MolmoAct2 checkpoints load weights via `checkpoint_path` rather than `from_pretrained`, so a revision cannot be honored there. Passing one now raises a clear `ValueError` (pin via a commit-SHA-qualified path or a local directory) instead of silently loading the default branch.

```python
policy = create_policy(
    "lerobot_local",
    pretrained_name_or_path="lerobot/smolvla_base",
    revision="v1.0",   # branch, tag, or 40-char commit SHA
)
```

## Tests

New `tests/policies/lerobot_local/test_revision_pinning.py`:
- `revision` is threaded to `from_pretrained` when set.
- `revision` is threaded to hub class resolution when `policy_type` is not given.
- Omitting `revision` keeps the default (unpinned) call shape — no `revision=None` injected.
- A `revision` on a MolmoAct2 checkpoint raises `ValueError`.

The four assertions fail on pre-change code (the threaded-revision and hub-resolution tests see no `revision`; the MolmoAct2 case silently proceeds to a real load instead of raising). Existing internal mocks in `test_resolution.py` / `test_policy.py` were updated to mirror the new signatures.

Green local gate: `ruff check`, `ruff format --check`, `mypy` clean on the changed modules; full `tests/policies/` suite passes (1236 passed, 2 skipped) under `MUJOCO_GL=egl`.

Docs: `docs/policies/lerobot-local.md` gains a "Pinning a Hub revision" section and the `revision=` parameter entry.

This is a loader/reproducibility addition with no rollout-visual surface, mirroring lerobot's own `revision` pinning support.