### PR TITLE
fix(wbc): accept canonical GR00T-WholeBodyControl ONNX filenames without a rename

### DIFF
--- a/docs/policies/wbc.md
+++ b/docs/policies/wbc.md
@@ -37,13 +37,22 @@ git-LFS tree at `decoupled_wbc/sim2mujoco/resources/robots/g1/policy/`:
 git clone https://github.com/NVlabs/GR00T-WholeBodyControl.git   # 4.6G LFS
 mkdir -p /path/to/grootwbc-g1
 cp GR00T-WholeBodyControl/decoupled_wbc/sim2mujoco/resources/robots/g1/policy/\
-GR00T-WholeBodyControl-Balance.onnx /path/to/grootwbc-g1/policy.onnx
-cp GR00T-WholeBodyControl/decoupled_wbc/sim2mujoco/resources/robots/g1/policy/\
-GR00T-WholeBodyControl-Walk.onnx /path/to/grootwbc-g1/walk_policy.onnx
+GR00T-WholeBodyControl-{Balance,Walk}.onnx /path/to/grootwbc-g1/
 ```
 
-The result is a directory containing `policy.onnx` (the Balance policy) plus an
-optional `walk_policy.onnx` and `config.json`. Note: the HuggingFace repo
+The canonical `GR00T-WholeBodyControl-Balance.onnx` / `-Walk.onnx` filenames are
+accepted verbatim - no rename is needed. The conventional `policy.onnx` /
+`walk_policy.onnx` names also work and take precedence when both are present, so
+either layout is valid:
+
+```text
+/path/to/grootwbc-g1/
+    GR00T-WholeBodyControl-Balance.onnx   # main (Balance) policy
+    GR00T-WholeBodyControl-Walk.onnx      # optional walk policy
+    config.json                           # optional
+```
+
+Note: the HuggingFace repo
 [`nvidia/GEAR-SONIC`](https://huggingface.co/nvidia/GEAR-SONIC) is the SONIC VLA
 inference stack (encoder/decoder/planner ONNX), **not** this decoupled-WBC
 Balance/Walk family; passing it as a checkpoint raises a clear error.

--- a/strands_robots/policies/wbc/policy.py
+++ b/strands_robots/policies/wbc/policy.py
@@ -141,6 +141,14 @@ _MAIN_POLICY_FILENAME = "policy.onnx"
 _WALK_POLICY_FILENAME = "walk_policy.onnx"
 _CONFIG_FILENAME = "config.json"
 
+# The canonical artifact names the decoupled-WBC weights ship under in the
+# NVlabs/GR00T-WholeBodyControl git-LFS tree (and its HuggingFace mirrors):
+# GR00T-WholeBodyControl-Balance.onnx (main) / -Walk.onnx (walk). The loader
+# accepts these verbatim so a user need not rename the official download to
+# policy.onnx / walk_policy.onnx before pointing the checkpoint at it.
+_MAIN_POLICY_CANONICAL = "GR00T-WholeBodyControl-Balance.onnx"
+_WALK_POLICY_CANONICAL = "GR00T-WholeBodyControl-Walk.onnx"
+
 # Raw-velocity-norm threshold for walk-vs-main policy selection, matching the
 # upstream reference (run_mujoco_gear_wbc.py: norm(loco_cmd) <= 0.05 -> main
 # "standing" policy; above -> walk_policy).
@@ -769,9 +777,40 @@ class WBCPolicy(Policy):
             return _MAIN_POLICY_FILENAME, _WALK_POLICY_FILENAME
         p = Path(checkpoint).expanduser()
         if p.is_dir():
-            return str(p / _MAIN_POLICY_FILENAME), str(p / _WALK_POLICY_FILENAME)
-        # checkpoint points directly at the main .onnx file.
-        return str(p), str(p.parent / _WALK_POLICY_FILENAME)
+            main = WBCPolicy._pick_onnx_in_dir(p, _MAIN_POLICY_FILENAME, _MAIN_POLICY_CANONICAL)
+            walk = WBCPolicy._pick_onnx_in_dir(p, _WALK_POLICY_FILENAME, _WALK_POLICY_CANONICAL)
+            return main, walk
+        # checkpoint points directly at the main .onnx file. Pair the walk policy
+        # beside it under the matching naming scheme: when the main file is the
+        # canonical upstream Balance artifact, the walk sibling is the canonical
+        # Walk artifact (not the conventional walk_policy.onnx).
+        walk_name = _WALK_POLICY_CANONICAL if p.name == _MAIN_POLICY_CANONICAL else _WALK_POLICY_FILENAME
+        return str(p), str(p.parent / walk_name)
+
+    @staticmethod
+    def _pick_onnx_in_dir(directory: Path, preferred: str, canonical: str) -> str:
+        """Resolve an ONNX filename inside ``directory``, accepting canonical names.
+
+        The conventional name (``policy.onnx`` / ``walk_policy.onnx``) wins when
+        it exists. Otherwise the canonical NVlabs/GR00T-WholeBodyControl artifact
+        name (``GR00T-WholeBodyControl-Balance.onnx`` / ``-Walk.onnx``) is
+        accepted verbatim, so users need not rename the official download. When
+        neither file exists the preferred name is returned unchanged, so the
+        downstream not-found error keeps naming the conventional file.
+
+        Args:
+            directory: Checkpoint directory to look in.
+            preferred: Conventional filename to prefer (e.g. ``policy.onnx``).
+            canonical: Canonical upstream artifact name to fall back to.
+
+        Returns:
+            Absolute path string to the chosen file.
+        """
+        if (directory / preferred).is_file():
+            return str(directory / preferred)
+        if (directory / canonical).is_file():
+            return str(directory / canonical)
+        return str(directory / preferred)
 
     def _load_sessions(self, checkpoint: str | None) -> None:
         """Load the ONNX sessions, raising loudly on any missing dependency/file.
@@ -862,11 +901,13 @@ class WBCPolicy(Policy):
         source_hint = (
             "No weights are bundled. Obtain GR00T-WholeBodyControl-Balance.onnx and "
             "GR00T-WholeBodyControl-Walk.onnx from the NVlabs/GR00T-WholeBodyControl "
-            "git-LFS tree (decoupled_wbc/sim2mujoco/resources/robots/g1/policy/), place "
-            "them in a directory as policy.onnx + walk_policy.onnx, and pass "
-            "checkpoint='/path/to/that/dir'. Note: the HuggingFace repo nvidia/GEAR-SONIC "
-            "is the SONIC VLA inference stack (encoder/decoder/planner), not this "
-            "decoupled-WBC Balance/Walk family."
+            "git-LFS tree (decoupled_wbc/sim2mujoco/resources/robots/g1/policy/), put "
+            "them in a directory, and pass checkpoint='/path/to/that/dir'. The "
+            "canonical GR00T-WholeBodyControl-Balance.onnx / -Walk.onnx filenames are "
+            "accepted verbatim (no rename needed); policy.onnx / walk_policy.onnx also "
+            "work if present. Note: the HuggingFace repo nvidia/GEAR-SONIC is the SONIC "
+            "VLA inference stack (encoder/decoder/planner), not this decoupled-WBC "
+            "Balance/Walk family."
         )
         if checkpoint is None:
             return f"WBCPolicy requires a checkpoint but none was provided. {source_hint}"

--- a/tests/policies/wbc/test_policy.py
+++ b/tests/policies/wbc/test_policy.py
@@ -38,7 +38,12 @@ from strands_robots.policies.wbc.control import (
     quat_rotate_inverse,
 )
 from strands_robots.policies.wbc.observation import ObservationHistory, build_single_frame
-from strands_robots.policies.wbc.policy import _MAIN_POLICY_FILENAME, _WALK_POLICY_FILENAME
+from strands_robots.policies.wbc.policy import (
+    _MAIN_POLICY_CANONICAL,
+    _MAIN_POLICY_FILENAME,
+    _WALK_POLICY_CANONICAL,
+    _WALK_POLICY_FILENAME,
+)
 
 # ---------------------------------------------------------------------------
 # Stub ONNX session
@@ -661,6 +666,56 @@ class TestCheckpointResolution:
         main, walk = WBCPolicy._default_onnx_paths(str(ckpt_file))
         assert main == str(ckpt_file)
         assert walk == str(ckpt_file.parent / _WALK_POLICY_FILENAME)
+
+    def test_default_onnx_paths_accepts_canonical_upstream_filenames(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        # Regression: a checkpoint directory holding the official upstream
+        # artifact names (GR00T-WholeBodyControl-Balance.onnx / -Walk.onnx) must
+        # resolve to those files verbatim, without forcing a rename to
+        # policy.onnx / walk_policy.onnx. Pre-fix this returned the conventional
+        # names, so the loader raised "policy.onnx not found".
+        d = tmp_path / "ckpt"
+        d.mkdir()
+        (d / _MAIN_POLICY_CANONICAL).touch()
+        (d / _WALK_POLICY_CANONICAL).touch()
+        main, walk = WBCPolicy._default_onnx_paths(str(d))
+        assert main == str(d / _MAIN_POLICY_CANONICAL)
+        assert walk == str(d / _WALK_POLICY_CANONICAL)
+
+    def test_default_onnx_paths_conventional_names_win_over_canonical(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        # When both the conventional and canonical names are present, the
+        # conventional policy.onnx / walk_policy.onnx take precedence.
+        d = tmp_path / "ckpt"
+        d.mkdir()
+        for name in (_MAIN_POLICY_FILENAME, _WALK_POLICY_FILENAME, _MAIN_POLICY_CANONICAL, _WALK_POLICY_CANONICAL):
+            (d / name).touch()
+        main, walk = WBCPolicy._default_onnx_paths(str(d))
+        assert main == str(d / _MAIN_POLICY_FILENAME)
+        assert walk == str(d / _WALK_POLICY_FILENAME)
+
+    def test_default_onnx_paths_empty_dir_keeps_conventional_names(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        # With neither name present the conventional filenames are returned
+        # unchanged, so the downstream not-found error names policy.onnx.
+        d = tmp_path / "ckpt"
+        d.mkdir()
+        main, walk = WBCPolicy._default_onnx_paths(str(d))
+        assert main == str(d / _MAIN_POLICY_FILENAME)
+        assert walk == str(d / _WALK_POLICY_FILENAME)
+
+    def test_default_onnx_paths_canonical_main_file_pairs_canonical_walk(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        # Checkpoint pointing directly at the canonical Balance .onnx: the walk
+        # sibling is expected under the matching canonical Walk name.
+        ckpt_file = tmp_path / "g1" / _MAIN_POLICY_CANONICAL
+        ckpt_file.parent.mkdir()
+        ckpt_file.touch()
+        main, walk = WBCPolicy._default_onnx_paths(str(ckpt_file))
+        assert main == str(ckpt_file)
+        assert walk == str(ckpt_file.parent / _WALK_POLICY_CANONICAL)
+
+    def test_checkpoint_not_found_message_states_no_rename_needed(self) -> None:
+        # The actionable error must advertise that the canonical filenames are
+        # accepted verbatim, rather than instructing a manual rename.
+        msg = WBCPolicy._checkpoint_not_found_message(None, None)
+        assert "no rename needed" in msg
 
     def test_hf_id_download_success_returns_local_snapshot_dir(self, monkeypatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
         # A bare org/repo id with huggingface_hub present downloads (cached) and


### PR DESCRIPTION
## Problem

`WBCPolicy` only resolved checkpoints under the conventional `policy.onnx` / `walk_policy.onnx` filenames. A checkpoint directory holding the **official upstream artifacts** - `GR00T-WholeBodyControl-Balance.onnx` / `GR00T-WholeBodyControl-Walk.onnx`, exactly what the `NVlabs/GR00T-WholeBodyControl` git-LFS tree (`decoupled_wbc/sim2mujoco/resources/robots/g1/policy/`) and its HF mirrors ship - resolved to the nonexistent `policy.onnx` and raised:

```
WBCPolicy main ONNX checkpoint not found (resolved: '.../policy.onnx').
```

The not-found error itself then instructed the user to manually `cp ...Balance.onnx .../policy.onnx`. So the loader knew the canonical names (they are documented at the module top and named in the error) yet refused to load them - a pure rename-tax on every user who points a checkpoint at the files they just downloaded.

## Change

`_default_onnx_paths` now prefers the conventional names but falls back to the canonical upstream artifact names when only those exist in the checkpoint directory (new `_pick_onnx_in_dir` helper). A checkpoint pointing directly at the canonical `-Balance.onnx` file pairs the canonical `-Walk.onnx` sibling. Behavior preserved:

- Conventional `policy.onnx` / `walk_policy.onnx` still win when both layouts are present.
- An empty/absent directory still yields the conventional names, so the not-found error keeps naming `policy.onnx`.
- No alias or second API name is introduced - the loader simply accepts the files the user actually downloaded. The not-found hint is updated to state the canonical names are accepted (no rename needed).

## Tests

New regression tests in `tests/policies/wbc/test_policy.py` (fail pre-fix, pass after):
- canonical-only directory resolves to the `-Balance.onnx` / `-Walk.onnx` files
- conventional names take precedence when both are present
- empty directory keeps the conventional names
- direct canonical `-Balance.onnx` file pairs the canonical `-Walk.onnx`
- not-found message advertises "no rename needed"

Full `tests/policies/wbc/` suite: **142 passed**. `ruff` + `mypy` clean. Docs `docs/policies/wbc.md` updated to drop the rename step.

## Visual artifact

End-to-end verification - `Robot('unitree_g1', mode='sim').run_policy(policy_provider='sonic', policy_config={'checkpoint': <dir with only the canonical filenames>, 'walk': True, 'target_velocity': [0.4, 0.0, 0.0]}, video=...)`. Pre-fix this raised the not-found error; post-fix it loads and rolls out (90 frames, 640x480). Rollout in MuJoCo (headless EGL):

![G1 WBC walk rollout](https://github.com/cagataycali/robots/releases/download/wbc-canonical-onnx-demo/wbc_g1_canonical.gif)

[MP4](https://github.com/cagataycali/robots/releases/download/wbc-canonical-onnx-demo/wbc_g1_canonical.mp4)