### PR TITLE
refactor(sim): source the MuJoCo no-world guard message from one shared constant

### DIFF
--- a/strands_robots/simulation/mujoco/backend.py
+++ b/strands_robots/simulation/mujoco/backend.py
@@ -14,6 +14,14 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+# Canonical "no live world" error message shared by every world-touching
+# MuJoCo facade/mixin method. Defined in this low-level module so the
+# Simulation facade and its mixins (physics, randomization, rendering,
+# recording) can all source the single string without a circular import -
+# an agent that learns the error from one action recognises it identically
+# from every other.
+_NO_WORLD_MSG = "No world. Call create_world (or load_scene) first."
+
 _mujoco = None
 _mujoco_viewer = None
 

--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from strands_robots.simulation.mujoco.backend import _ensure_mujoco
+from strands_robots.simulation.mujoco.backend import _NO_WORLD_MSG, _ensure_mujoco
 
 logger = logging.getLogger(__name__)
 
@@ -109,7 +109,7 @@ class PhysicsMixin:
         including ctrl and qfrc_applied buffers.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
-            return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
 
         mj = _ensure_mujoco()
         model, data = self._world._model, self._world._data
@@ -145,7 +145,7 @@ class PhysicsMixin:
     def load_state(self, name: str = "default") -> dict[str, Any]:
         """Restore physics state from a named checkpoint."""
         if self._world is None or self._world._model is None or self._world._data is None:
-            return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         # load_state during a running policy races worker thread
         if err := self._require_no_running_policy("load_state"):
             return err
@@ -202,7 +202,7 @@ class PhysicsMixin:
                    Defaults to body CoM if not specified.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
-            return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         # apply_force during a running policy races worker thread
         if err := self._require_no_running_policy("apply_force"):
             return err
@@ -318,7 +318,7 @@ class PhysicsMixin:
             include_static: Whether to include static geoms.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
-            return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
 
         # validate vector shapes and reject zero-direction (mj_ray aborts the process on len=0)
         try:
@@ -400,7 +400,7 @@ class PhysicsMixin:
         Returns both positional (3×nv) and rotational (3×nv) Jacobians.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
-            return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
 
         mj = _ensure_mujoco()
         model, data = self._world._model, self._world._data
@@ -443,7 +443,7 @@ class PhysicsMixin:
     def get_energy(self) -> dict[str, Any]:
         """Compute potential and kinetic energy of the system."""
         if self._world is None or self._world._model is None or self._world._data is None:
-            return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
 
         mj = _ensure_mujoco()
         model, data = self._world._model, self._world._data
@@ -472,7 +472,7 @@ class PhysicsMixin:
         Useful for dynamics analysis, impedance control, etc.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
-            return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
 
         mj = _ensure_mujoco()
         model, data = self._world._model, self._world._data
@@ -518,7 +518,7 @@ class PhysicsMixin:
         that would produce the current accelerations.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
-            return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
 
         mj = _ensure_mujoco()
         model, data = self._world._model, self._world._data
@@ -552,7 +552,7 @@ class PhysicsMixin:
         Returns Cartesian pose + 6D spatial velocity (linear + angular).
         """
         if self._world is None or self._world._model is None or self._world._data is None:
-            return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
 
         mj = _ensure_mujoco()
         model, data = self._world._model, self._world._data
@@ -618,7 +618,7 @@ class PhysicsMixin:
           world must contain exactly one robot, or the call errors).
         """
         if self._world is None or self._world._model is None or self._world._data is None:
-            return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         # mutating qpos under a running policy races mj_step
         if err := self._require_no_running_policy("set_joint_positions"):
             return err
@@ -722,7 +722,7 @@ class PhysicsMixin:
         (see set_joint_positions for list semantics).
         """
         if self._world is None or self._world._model is None or self._world._data is None:
-            return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         if err := self._require_no_running_policy("set_joint_velocities"):
             return err
 
@@ -819,7 +819,7 @@ class PhysicsMixin:
             sensor_name: Specific sensor name, or None for all sensors.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
-            return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
 
         mj = _ensure_mujoco()
         model, data = self._world._model, self._world._data
@@ -885,7 +885,7 @@ class PhysicsMixin:
         Changes take effect on the next mj_step.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
-            return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         if err := self._require_no_running_policy("set_body_properties"):
             return err
 
@@ -935,7 +935,7 @@ class PhysicsMixin:
         Changes take effect immediately for rendering (color) or next step (friction, size).
         """
         if self._world is None or self._world._model is None or self._world._data is None:
-            return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         if err := self._require_no_running_policy("set_geom_properties"):
             return err
 
@@ -984,7 +984,7 @@ class PhysicsMixin:
         Returns normal and friction forces.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
-            return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
 
         mj = _ensure_mujoco()
         model, data = self._world._model, self._world._data
@@ -1040,7 +1040,7 @@ class PhysicsMixin:
         Returns array of distances and hit geoms.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
-            return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
 
         mj = _ensure_mujoco()
         model, data = self._world._model, self._world._data
@@ -1111,7 +1111,7 @@ class PhysicsMixin:
         Otherwise returns every body as before.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
-            return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
 
         mj = _ensure_mujoco()
         model, data = self._world._model, self._world._data
@@ -1158,7 +1158,7 @@ class PhysicsMixin:
     def get_total_mass(self) -> dict[str, Any]:
         """Get total mass and per-body mass breakdown."""
         if self._world is None or self._world._model is None or self._world._data is None:
-            return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
 
         mj = _ensure_mujoco()
         model = self._world._model
@@ -1191,7 +1191,7 @@ class PhysicsMixin:
         mutation, so no extra caching or round-tripping is needed.
         """
         if self._world is None or self._world._model is None:
-            return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
 
         spec = self._world._backend_state.get("spec") if self._world._backend_state else None
         if spec is None:

--- a/strands_robots/simulation/mujoco/randomization.py
+++ b/strands_robots/simulation/mujoco/randomization.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from strands_robots.simulation.mujoco.backend import _ensure_mujoco
+from strands_robots.simulation.mujoco.backend import _NO_WORLD_MSG, _ensure_mujoco
 
 logger = logging.getLogger(__name__)
 
@@ -74,7 +74,7 @@ class RandomizationMixin:
             seed:                 Optional np.random seed for reproducibility.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
-            return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         # domain randomization mutates model arrays; a running policy racing with it is UB
         if err := self._require_no_running_policy("randomize"):
             return err

--- a/strands_robots/simulation/mujoco/recording.py
+++ b/strands_robots/simulation/mujoco/recording.py
@@ -12,7 +12,7 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from strands_robots.simulation.mujoco.backend import _ensure_mujoco
+from strands_robots.simulation.mujoco.backend import _NO_WORLD_MSG, _ensure_mujoco
 from strands_robots.simulation.recording import DatasetRecordingMixin
 
 logger = logging.getLogger(__name__)
@@ -94,7 +94,7 @@ class RecordingMixin(DatasetRecordingMixin):
             optional extra.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
-            return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
 
         _DatasetRecorder: Any = None
         _has_lerobot = False

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -4,7 +4,7 @@ import io
 import logging
 from typing import TYPE_CHECKING, Any
 
-from strands_robots.simulation.mujoco.backend import _can_render, _ensure_mujoco
+from strands_robots.simulation.mujoco.backend import _NO_WORLD_MSG, _can_render, _ensure_mujoco
 
 logger = logging.getLogger(__name__)
 
@@ -581,7 +581,7 @@ class RenderingMixin:
         ``width``/``height`` override the camera config.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
-            return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
 
         mj = _ensure_mujoco()
         # treat `None` as "use default", but `0` / negative values must
@@ -686,7 +686,7 @@ class RenderingMixin:
         matter; the grayscale image is normalized for display only.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
-            return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
 
         mj = _ensure_mujoco()
         # see note in render() re: None vs 0/negative.
@@ -853,7 +853,7 @@ class RenderingMixin:
         memory can appear as phantom penetrations at t=0).
         """
         if self._world is None or self._world._model is None or self._world._data is None:
-            return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
 
         mj = _ensure_mujoco()
         model, data = self._world._model, self._world._data
@@ -983,7 +983,7 @@ class RenderingMixin:
                                      {"text": "cam2"}, {"image": {...}}, ...]}``
         """
         if self._world is None or self._world._model is None or self._world._data is None:
-            return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         names, unresolved = self._active_camera_list(cameras)
         if cameras is not None and unresolved:
             return {
@@ -1066,7 +1066,7 @@ class RenderingMixin:
         import uuid as _uuid
 
         if self._world is None or self._world._model is None or self._world._data is None:
-            return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
 
         if getattr(self, "_cams_rec_state", None) and self._cams_rec_state.get("running"):
             cur = self._cams_rec_state["name"]
@@ -1437,7 +1437,7 @@ class RenderingMixin:
         import uuid as _uuid
 
         if self._world is None or self._world._model is None or self._world._data is None:
-            return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
 
         if getattr(self, "_cams_rec_state", None) and self._cams_rec_state.get("running"):
             cur = self._cams_rec_state["name"]

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -69,6 +69,7 @@ from strands_robots.simulation.model_registry import (
 )
 from strands_robots.simulation.models import SimCamera, SimObject, SimRobot, SimStatus, SimWorld
 from strands_robots.simulation.mujoco.backend import (
+    _NO_WORLD_MSG,
     _ensure_mujoco,
     filter_mujoco_attach_noise,
 )
@@ -93,12 +94,6 @@ if TYPE_CHECKING:
     from strands_robots.policies import Policy
 
 logger = logging.getLogger(__name__)
-
-# Single source of truth for the "no live world" guard message. Every
-# world-touching facade method checks the same condition (world + compiled
-# model + data all present) and returns this exact text, so an agent that
-# learns the string from one action recognises it from all of them.
-_NO_WORLD_MSG = "No world. Call create_world (or load_scene) first."
 
 
 def _drop_unrecorded_cameras(observation: dict[str, Any], recorded: set[str] | None) -> dict[str, Any]:

--- a/tests/simulation/mujoco/test_no_world_guard_contract.py
+++ b/tests/simulation/mujoco/test_no_world_guard_contract.py
@@ -1,11 +1,16 @@
 """Unified "no world" guard contract for the MuJoCo Simulation facade.
 
-Every world-touching facade method must, when called before ``create_world``
-(or after a failed ``load_scene`` that leaves a partial world), return the same
-structured error - never raise and never drift the wording. The canonical text
-lives in ``strands_robots.simulation.mujoco.simulation._NO_WORLD_MSG``; this
-module pins that single string across every guarded method so an agent that
-learns the error from one action recognises it from all of them.
+Every world-touching facade/mixin method must, when called before
+``create_world`` (or after a failed ``load_scene`` that leaves a partial
+world), return the same structured error - never raise and never drift the
+wording. The canonical text lives in a single shared constant,
+``strands_robots.simulation.mujoco.backend._NO_WORLD_MSG`` (re-exported from
+``...mujoco.simulation`` for the facade); this module pins that single string
+across every guarded method - the high-level facade methods AND the dynamics,
+randomization, rendering, and recording mixin methods - so an agent that learns
+the error from one action recognises it from all of them. Because every method
+sources the one constant, editing the message in one place can never silently
+leave a hand-rolled copy behind in a mixin.
 
 Two states are exercised:
 
@@ -45,6 +50,38 @@ GUARDED_CALLS: list[tuple[str, tuple, dict]] = [
     ("start_policy", (), {}),
     ("run_policy", (), {}),
     ("run_multi_policy", ({},), {}),
+    # PhysicsMixin dynamics/state methods - same unified guard.
+    ("save_state", (), {}),
+    ("load_state", (), {}),
+    ("apply_force", ("base",), {}),
+    ("raycast", ([0.0, 0.0, 1.0], [0.0, 0.0, -1.0]), {}),
+    ("get_jacobian", (), {}),
+    ("get_energy", (), {}),
+    ("get_mass_matrix", (), {}),
+    ("inverse_dynamics", (), {}),
+    ("get_body_state", ("base",), {}),
+    ("set_joint_positions", (), {}),
+    ("set_joint_velocities", (), {}),
+    ("get_sensor_data", (), {}),
+    ("set_body_properties", ("base",), {}),
+    ("set_geom_properties", (), {}),
+    ("get_contact_forces", (), {}),
+    ("multi_raycast", ([0.0, 0.0, 1.0], [[0.0, 0.0, -1.0]]), {}),
+    ("forward_kinematics", (), {}),
+    ("get_total_mass", (), {}),
+    ("export_xml", (), {}),
+    # RandomizationMixin.
+    ("randomize", (), {}),
+    # RenderingMixin - render + contact-query + camera-recording entry points.
+    ("render", (), {}),
+    ("render_depth", (), {}),
+    ("get_contacts", (), {}),
+    ("render_all", (), {}),
+    ("start_cameras_recording", (), {}),
+    ("start_cameras_recording_synchronous", (), {}),
+    # RecordingMixin - LeRobotDataset recording (guard fires before the
+    # lerobot extra is touched).
+    ("start_recording", (), {}),
 ]
 
 


### PR DESCRIPTION
## Problem

The canonical "no live world" guard text lives as `_NO_WORLD_MSG` in `simulation.py`. Every world-touching facade method already references it, and `_require_world()`'s docstring states the contract explicitly: *"every guard - inline or via this helper - returns the single `_NO_WORLD_MSG` string so the contract reads identically across the facade."*

But the dynamics, randomization, rendering, and recording mixins did **not** honour that single source. Each of their guards hand-rolled an identical copy of the literal string:

```python
if self._world is None or self._world._model is None or self._world._data is None:
    return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
```

That is 27 duplicated copies across `physics.py` (19), `rendering.py` (6), `recording.py` (1), and `randomization.py` (1). Editing `_NO_WORLD_MSG` would silently leave all 27 behind, drifting the agent-facing error - the exact failure mode `test_no_world_guard_contract.py` exists to prevent, except those mixin methods were never in its parametrize list.

## Change

- Move `_NO_WORLD_MSG` to the low-level `mujoco/backend.py` module, which the facade and every mixin already import from (`_ensure_mujoco`). This gives a single definition reachable without a circular import. `simulation.py` re-exports it, so `from ...simulation import _NO_WORLD_MSG` keeps working.
- Replace all 27 hand-rolled literals with a reference to the shared constant. The guard *conditions* are unchanged (kept inline for mypy narrowing); only the message source changes.
- Extend `test_no_world_guard_contract.py` to cover the 27 mixin methods under both the **no-world** and **partial-world** states (46 guarded methods x 2 states + 2 helper tests = 94 cases).

**No behavior change**: the emitted error dict is byte-identical for every method. The legitimately different `"No world to destroy."` message (idempotent `destroy()`, returns `status: success`) is left untouched.

## Verification

The extended contract test is a genuine drift regression. Demonstrated against pre-change source: editing `_NO_WORLD_MSG` to a new value makes the 27 mixin methods drift and the contract test reports **54 failures** (27 methods x 2 states) while the facade methods stay green. After this change, the same edit keeps all 94 cases in sync.

Local gate (as CI runs it):

```
ruff check strands_robots tests tests_integ        # All checks passed
ruff format --check strands_robots tests tests_integ
mypy strands_robots tests tests_integ              # Success: no issues found in 571 source files
MUJOCO_GL=egl pytest tests/simulation/mujoco/test_no_world_guard_contract.py   # 94 passed
MUJOCO_GL=egl pytest tests/simulation/mujoco/   # 860 passed (2 unrelated torchcodec env failures in video-decode)
```

No public API, env var, or wire-format change; the centralized symbol is private and not in `__all__`.