### PR TITLE
fix(sim): forward policy_kwargs through eval_policy / evaluate_benchmark

### DIFF
--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -1415,6 +1415,7 @@ class SimEngine(ABC):
         async_rtc: bool = False,
         rtc_inference_timeout_s: float | None = None,
         on_frame: Callable[[int, dict[str, Any], dict[str, Any]], None] | None = None,
+        policy_kwargs: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Multi-episode policy evaluation via ``PolicyRunner.evaluate``.
 
@@ -1459,6 +1460,14 @@ class SimEngine(ABC):
         rejected with a structured error at the entry point (before
         ``create_policy``) rather than running a degenerate eval that
         reports a fabricated success rate over zero/negative episodes.
+
+        ``policy_kwargs`` is the per-call goal payload forwarded verbatim to
+        every ``policy.get_actions(obs, instruction, **policy_kwargs)`` call,
+        exactly as on :meth:`run_policy`. Goal-conditioned providers read their
+        target from these well-known keys (``target_velocity`` for WBC and other
+        locomotion policies; ``target_pose`` / ``target_joints`` / ``world_update``
+        for cuRobo / MoveIt2 - the issue #300 contract). Without it the eval ran
+        such a policy with an empty goal and reported a meaningless success rate.
         """
         if not robot_name:
             return {
@@ -1514,6 +1523,7 @@ class SimEngine(ABC):
             async_rtc=async_rtc,
             rtc_inference_timeout_s=rtc_inference_timeout_s,
             on_frame=on_frame,
+            policy_kwargs=policy_kwargs,
         )
 
     # Benchmark protocol facades
@@ -1529,6 +1539,7 @@ class SimEngine(ABC):
         seed: int | None = None,
         action_horizon: int = 8,
         on_frame: Callable[[int, dict[str, Any], dict[str, Any]], None] | None = None,
+        policy_kwargs: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Run a registered :class:`BenchmarkProtocol` against the current sim.
 
@@ -1578,6 +1589,13 @@ class SimEngine(ABC):
                 greenish GL clear-colour artifacts. Pair with
                 :meth:`~strands_robots.simulation.mujoco.simulation.Simulation.start_cameras_recording_synchronous`
                 for the recorder side. See #191.
+            policy_kwargs: Per-call goal payload forwarded verbatim to every
+                ``policy.get_actions(obs, instruction, **policy_kwargs)`` call
+                (same contract as :meth:`run_policy` / :meth:`eval_policy`).
+                Goal-conditioned providers read their target from these keys
+                (``target_velocity`` / ``target_pose`` / ``target_joints`` /
+                ``world_update``); a benchmark that drives such a policy must
+                pass them or the policy runs with an empty goal.
 
         Returns:
             Standard status dict. On success, carries per-episode cumulative
@@ -1651,6 +1669,7 @@ class SimEngine(ABC):
             seed=seed,
             action_horizon=action_horizon,
             on_frame=on_frame,
+            policy_kwargs=policy_kwargs,
         )
 
     def list_benchmarks(self) -> dict[str, Any]:

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -1301,6 +1301,7 @@ class PolicyRunner:
         control_substeps: int | None = None,
         async_rtc: bool = False,
         rtc_inference_timeout_s: float | None = None,
+        policy_kwargs: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Evaluate ``policy`` for ``n_episodes`` episodes.
 
@@ -1358,6 +1359,13 @@ class PolicyRunner:
                 async prefetch. When inference does not finish within the
                 timeout the eval fails with a structured error instead of
                 hanging the rollout. ``None`` waits indefinitely.
+            policy_kwargs: Per-call goal payload forwarded verbatim to every
+                ``policy.get_actions(obs, instruction, **policy_kwargs)`` call on
+                both eval paths (``success_fn`` and ``spec``). Empty/``None`` is
+                the historical no-kwargs behaviour. Goal-conditioned providers
+                (WBC ``target_velocity``; cuRobo/MoveIt2 ``target_pose`` /
+                ``target_joints`` / ``world_update`` - the issue #300 keys) need
+                this to be evaluated against a goal at all.
 
         Returns:
             Standard status dict. The JSON payload carries an RTC telemetry
@@ -1380,6 +1388,14 @@ class PolicyRunner:
                     }
                 ],
             }
+
+        # Per-call goal payload forwarded verbatim to every get_actions() call
+        # on both eval paths (success_fn + spec). An empty dict is the historical
+        # (no-kwargs) behaviour. Goal-conditioned providers (WBC target_velocity,
+        # cuRobo/MoveIt2 target_pose/target_joints, the issue #300 keys) need this
+        # to be evaluated against a goal at all; without it eval ran them with an
+        # empty goal and reported a meaningless success rate.
+        _policy_kwargs = policy_kwargs or {}
 
         if async_rtc and spec is not None:
             return {
@@ -1408,6 +1424,7 @@ class PolicyRunner:
                 on_frame=on_frame,
                 control_frequency=control_frequency,
                 control_substeps=control_substeps,
+                policy_kwargs=_policy_kwargs,
             )
 
         try:
@@ -1443,7 +1460,7 @@ class PolicyRunner:
             # count of still-pending steps of the chunk currently executing.
             policy.set_rtc_observed_delay(observed_delay)
             _t_infer = time.perf_counter()
-            actions = _resolve_coroutine(policy.get_actions(observation, instruction))
+            actions = _resolve_coroutine(policy.get_actions(observation, instruction, **_policy_kwargs))
             inference_ms.append((time.perf_counter() - _t_infer) * 1000.0)
             # resolve_chunk_length is the single source of truth for the
             # re-query interval (respects RTC + execution_horizon). Consuming the
@@ -1601,6 +1618,7 @@ class PolicyRunner:
         on_frame: OnFrame | None = None,
         control_frequency: float = 50.0,
         control_substeps: int | None = None,
+        policy_kwargs: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Drive a :class:`BenchmarkProtocol` for ``n_episodes`` episodes.
 
@@ -1764,7 +1782,7 @@ class PolicyRunner:
                         "status": "error",
                         "content": [{"text": f"augment_observation failed in {spec_name}: {e}"}],
                     }
-                coro_or_result = policy.get_actions(observation, effective_instruction)
+                coro_or_result = policy.get_actions(observation, effective_instruction, **(policy_kwargs or {}))
                 actions = _resolve_coroutine(coro_or_result)
 
                 # #168: consume up to ``action_horizon`` actions

--- a/tests/simulation/test_policy_kwargs_forwarding.py
+++ b/tests/simulation/test_policy_kwargs_forwarding.py
@@ -21,6 +21,7 @@ from typing import Any
 
 from strands_robots.policies.base import Policy
 from strands_robots.simulation.base import SimEngine
+from strands_robots.simulation.benchmark import BenchmarkProtocol
 from strands_robots.simulation.policy_runner import PolicyRunner
 
 
@@ -192,3 +193,169 @@ def test_run_policy_threads_policy_kwargs_through_base() -> None:
     assert result["status"] == "success"
     assert policy.kwargs_seen, "policy.get_actions was never called"
     assert all(seen == goal for seen in policy.kwargs_seen)
+
+
+# --- Eval-path forwarding ----------------------------------------------------
+#
+# ``run_policy`` forwarded ``policy_kwargs`` (tests above), but the evaluation
+# entry points historically did not: ``eval_policy`` / ``evaluate_benchmark``
+# had no ``policy_kwargs`` parameter and ``PolicyRunner.evaluate`` called
+# ``policy.get_actions(observation, instruction)`` positionally on BOTH eval
+# routes (the ``success_fn`` legacy path and the ``spec`` benchmark path). A
+# goal-conditioned policy (WBC ``target_velocity``; cuRobo/MoveIt2
+# ``target_pose`` - the #300 keys) was therefore evaluated with an EMPTY goal,
+# producing a meaningless success rate. These tests pin the forwarding through
+# every eval surface and the no-kwargs default.
+
+
+class _ConstSuccessSpec(BenchmarkProtocol):
+    """Minimal benchmark: accepts any robot, never terminates early.
+
+    Used only to drive the ``spec`` eval path so the goal-kwarg forwarding on
+    that route is exercised independently of the ``success_fn`` route.
+    """
+
+    max_steps = 3
+
+    @property
+    def supported_robots(self) -> list[str]:
+        return []  # empty == "any robot"
+
+    @property
+    def default_robot(self) -> str:
+        return "fake_robot"
+
+    def on_step(self, sim, obs, action):  # type: ignore[no-untyped-def]
+        from strands_robots.simulation.benchmark import StepInfo
+
+        return StepInfo(reward=0.0, done=False)
+
+    def is_success(self, sim) -> bool:  # type: ignore[no-untyped-def]
+        return False
+
+
+def test_eval_policy_threads_policy_kwargs_through_base() -> None:
+    """SimEngine.eval_policy(policy_kwargs=...) reaches the policy each tick."""
+    sim = FakeSim()
+    policy = _GoalRecordingPolicy()
+    goal = {"target_velocity": [0.5, 0.0, 0.0]}
+
+    result = sim.eval_policy(
+        robot_name="fake_robot",
+        policy_object=policy,
+        instruction="walk forward",
+        n_episodes=1,
+        max_steps=3,
+        control_frequency=50.0,
+        action_horizon=1,
+        policy_kwargs=goal,
+    )
+
+    assert result["status"] == "success"
+    assert policy.kwargs_seen, "policy.get_actions was never called"
+    for seen in policy.kwargs_seen:
+        assert seen == goal
+    # Forwarding must not alias the caller's dict.
+    assert all(seen is not goal for seen in policy.kwargs_seen)
+
+
+def test_eval_policy_none_policy_kwargs_reproduces_no_kwargs() -> None:
+    """Omitting policy_kwargs on the eval path forwards no extra kwargs."""
+    sim = FakeSim()
+    policy = _GoalRecordingPolicy()
+
+    result = sim.eval_policy(
+        robot_name="fake_robot",
+        policy_object=policy,
+        n_episodes=1,
+        max_steps=3,
+        control_frequency=50.0,
+        action_horizon=1,
+    )
+
+    assert result["status"] == "success"
+    assert policy.kwargs_seen, "policy.get_actions was never called"
+    assert all(seen == {} for seen in policy.kwargs_seen)
+
+
+def test_evaluate_legacy_success_fn_path_forwards_policy_kwargs() -> None:
+    """PolicyRunner.evaluate (success_fn route) forwards policy_kwargs."""
+    sim = FakeSim()
+    policy = _GoalRecordingPolicy()
+    policy.set_robot_state_keys(sim.robot_joint_names("fake_robot"))
+    goal = {"target_pose": [0.3, 0.0, 0.4, 1.0, 0.0, 0.0, 0.0]}
+
+    result = PolicyRunner(sim).evaluate(
+        "fake_robot",
+        policy,
+        n_episodes=1,
+        max_steps=3,
+        control_frequency=50.0,
+        action_horizon=1,
+        policy_kwargs=goal,
+    )
+
+    assert result["status"] == "success"
+    assert policy.kwargs_seen, "policy.get_actions was never called"
+    assert all(seen == goal for seen in policy.kwargs_seen)
+
+
+def test_evaluate_spec_path_forwards_policy_kwargs() -> None:
+    """PolicyRunner.evaluate (spec route) forwards policy_kwargs."""
+    sim = FakeSim()
+    policy = _GoalRecordingPolicy()
+    policy.set_robot_state_keys(sim.robot_joint_names("fake_robot"))
+    goal = {"target_velocity": [0.25, 0.0, 0.1]}
+
+    result = PolicyRunner(sim).evaluate(
+        "fake_robot",
+        policy,
+        spec=_ConstSuccessSpec(),
+        n_episodes=1,
+        control_frequency=50.0,
+        action_horizon=1,
+        policy_kwargs=goal,
+    )
+
+    assert result["status"] == "success"
+    assert policy.kwargs_seen, "policy.get_actions was never called"
+    assert all(seen == goal for seen in policy.kwargs_seen)
+
+
+def test_evaluate_benchmark_threads_policy_kwargs_through_base() -> None:
+    """SimEngine.evaluate_benchmark(policy_kwargs=...) reaches the policy.
+
+    Registers a goal-recording provider so the benchmark path (which builds the
+    policy from ``policy_provider`` via ``create_policy``) is genuinely shown to
+    forward the goal payload, not merely to accept the parameter.
+    """
+    from strands_robots.policies.factory import _runtime_registry, register_policy
+    from strands_robots.simulation.benchmark import register_benchmark, unregister_benchmark
+
+    sim = FakeSim()
+    goal = {"target_velocity": [0.5, 0.0, 0.0]}
+    seen: list[dict[str, Any]] = []
+
+    class _RecordingProvider(_GoalRecordingPolicy):
+        def __init__(self) -> None:
+            super().__init__()
+            self.kwargs_seen = seen  # share the module-local capture list
+
+    register_policy("_goal_recording_bench_test", lambda: _RecordingProvider)
+    register_benchmark("_const_success_kwargs_test", _ConstSuccessSpec())
+    try:
+        result = sim.evaluate_benchmark(
+            "_const_success_kwargs_test",
+            robot_name="fake_robot",
+            policy_provider="_goal_recording_bench_test",
+            n_episodes=1,
+            action_horizon=1,
+            policy_kwargs=goal,
+        )
+    finally:
+        unregister_benchmark("_const_success_kwargs_test")
+        _runtime_registry.pop("_goal_recording_bench_test", None)
+
+    assert result["status"] == "success"
+    assert seen, "policy.get_actions was never called"
+    assert all(s == goal for s in seen)


### PR DESCRIPTION
## Summary

`run_policy` forwards a per-call goal payload (`policy_kwargs`) to every `policy.get_actions()` call, but the evaluation entry points silently dropped it. `eval_policy` and `evaluate_benchmark` had **no `policy_kwargs` parameter**, and `PolicyRunner.evaluate` called `get_actions(observation, instruction)` positionally on **both** eval routes (the `success_fn` legacy path via `_query_chunk` and the `spec`/benchmark path via `_evaluate_with_spec`).

Consequence: a goal-conditioned policy is evaluated with an **empty goal**. WBC and other locomotion policies read `target_velocity`; cuRobo / MoveIt2 read `target_pose` / `target_joints` / `world_update` (the #300 goal-kwarg contract). Evaluating any of them today runs the policy with no goal, so `eval_policy` reports a meaningless success rate for exactly the policies whose behaviour depends on their goal. With the locomotion stack now in place (WBC, the kinematic planner, CompositePolicy), there was no way to measure "did the policy reach the commanded target".

## Change

Thread `policy_kwargs` from the public entry points (`SimEngine.eval_policy`, `SimEngine.evaluate_benchmark`) into `PolicyRunner.evaluate`, and forward it verbatim from **both** internal routes to `policy.get_actions(obs, instruction, **policy_kwargs)`:

- `eval_policy(..., policy_kwargs=None)` and `evaluate_benchmark(..., policy_kwargs=None)` -> `evaluate(policy_kwargs=...)`.
- success_fn path: `_query_chunk` now calls `get_actions(observation, instruction, **_policy_kwargs)`.
- spec path: `_evaluate_with_spec(policy_kwargs=...)` forwards into its `get_actions` call.

`None`/omitted reproduces the historical no-kwargs behaviour exactly (an empty dict). This is the same contract and signature shape already on `run_policy`, so the eval surfaces now match the run surface.

## Tests

Extends `tests/simulation/test_policy_kwargs_forwarding.py` with eval-path regression tests covering every surface:

- `eval_policy(policy_kwargs=...)` reaches the policy each tick (and does not alias the caller's dict).
- `eval_policy` with no `policy_kwargs` forwards no extra kwargs (baseline preserved).
- `PolicyRunner.evaluate` success_fn route forwards the goal.
- `PolicyRunner.evaluate` spec route (driven by a minimal `BenchmarkProtocol`) forwards the goal.
- `evaluate_benchmark(policy_kwargs=...)` reaches the policy, asserted through a registered goal-recording provider (genuine forwarding, not just signature acceptance).

The four new forwarding tests **fail on pre-fix code** with `TypeError: ... got an unexpected keyword argument 'policy_kwargs'`; the no-kwargs baseline test passes on both. Full local gate green: `ruff check` / `ruff format --check` clean, `mypy` clean (585 source files), and `tests/simulation/` eval + policy-runner suite passes (117 passed, 2 skipped).

### Real-physics check (MuJoCo headless, `MUJOCO_GL=egl`)

A real `eval_policy` rollout on the SO-101 in MuJoCo (2 episodes x 30 steps) confirms the goal is forwarded on the actual eval loop, not just in the stub-sim unit tests:

```
eval status: success
real-physics get_actions calls: 60
every call saw the goal verbatim: True
sample captured goal: {'target_velocity': [0.5, 0.0, 0.2], 'target_height': 0.74, 'locomotion_style': 'stealth'}
```

All 60 control-step `get_actions` calls received `{'target_velocity': [0.5, 0.0, 0.2], 'target_height': 0.74, 'locomotion_style': 'stealth'}` verbatim. On pre-fix code the same call raises `TypeError` at the `eval_policy` boundary.

## Docs

Docstrings on `eval_policy`, `evaluate_benchmark`, and `PolicyRunner.evaluate` document the new `policy_kwargs` and its relationship to the #300 goal-kwarg contract.