### PR TITLE
examples: add use_lerobot discovery example (script + notebook)

### DIFF
--- a/docs/examples/overview.md
+++ b/docs/examples/overview.md
@@ -15,6 +15,7 @@ hardware, no GPU, no Hugging Face credentials.
 | [`01_getting_started.ipynb`](https://github.com/strands-labs/robots/blob/main/examples/notebooks/01_getting_started.ipynb) | `Robot("so100")`, run a policy, read joint state, `create_policy()`. |
 | [`02_record_and_stream.ipynb`](https://github.com/strands-labs/robots/blob/main/examples/notebooks/02_record_and_stream.ipynb) | Record a LeRobotDataset, then stream it back with `stream_dataset()`. |
 | [`03_record_train_deploy.ipynb`](https://github.com/strands-labs/robots/blob/main/examples/notebooks/03_record_train_deploy.ipynb) | The full loop: record, train an ACT policy on CPU, export, and load it back. |
+| [`04_discover_lerobot.ipynb`](https://github.com/strands-labs/robots/blob/main/examples/notebooks/04_discover_lerobot.ipynb) | Discover the LeRobot API with `use_lerobot`: list robots, policies, teleoperators, cameras, and inspect any class. |
 
 ```bash
 uv pip install "strands-robots[sim-mujoco,lerobot]" jupyterlab

--- a/examples/08_discover_lerobot.py
+++ b/examples/08_discover_lerobot.py
@@ -1,0 +1,63 @@
+"""Discover the LeRobot API from a Strands agent with the use_lerobot tool.
+
+Goal: show how `use_lerobot` lets an agent (or you) explore everything LeRobot
+exposes - registered robots, policies, teleoperators, cameras - and inspect any
+class without hardcoding a thing. It reads from LeRobot's own draccus registries,
+so the answers track whatever version of LeRobot you have installed.
+
+Runs anywhere: no hardware, no GPU, no Hugging Face credentials. The calls below
+invoke the tool's function directly so the example is self-contained; in an agent,
+the same tool is selected by natural language ("which policies can I use?").
+
+    uv pip install "strands-robots[sim-mujoco,lerobot]"
+    python examples/08_discover_lerobot.py
+"""
+
+from strands_robots.tools import use_lerobot
+
+# use_lerobot is a Strands @tool; call its underlying function directly here.
+call = use_lerobot.func if hasattr(use_lerobot, "func") else use_lerobot
+
+
+def text(result: dict) -> str:
+    """Pull the text content out of a tool result."""
+    if isinstance(result, dict):
+        return "".join(c.get("text", "") for c in result.get("content", []) if isinstance(c, dict))
+    return str(result)
+
+
+# 1. Discover everything at once: packages, modules, and every registered config.
+print("=" * 70)
+print("1. Discovery: what does this LeRobot install expose?")
+print("=" * 70)
+print(text(call(module="__discovery__", method="list_modules"))[:900])
+
+# 2. List a single registry. The choices come from LeRobot, not from Strands,
+#    so they reflect the installed version (here: the policy types you can train
+#    or run).
+print("\n" + "=" * 70)
+print("2. Registry: which policy types are available?")
+print("=" * 70)
+print(text(call(module="__registry__", method="policies")))
+
+# 3. The same call works for robots, teleoperators, and cameras.
+for kind in ("robots", "teleoperators", "cameras"):
+    print(f"\n--- registry: {kind} ---")
+    print(text(call(module="__registry__", method=kind))[:300])
+
+# 4. Inspect a class without instantiating it. __describe__ returns its methods
+#    and signature, useful for finding the right call before you make it.
+print("\n" + "=" * 70)
+print("3. Describe a class: LeRobotDataset")
+print("=" * 70)
+print(text(call(module="datasets.lerobot_dataset.LeRobotDataset", method="__describe__"))[:600])
+
+# 5. Resolve a concrete object from a registry name. Here, the policy class
+#    behind "act" - the same lookup create_policy() does under the hood.
+print("\n" + "=" * 70)
+print("4. Resolve the policy class registered as 'act'")
+print("=" * 70)
+print(text(call(module="policies.factory", method="get_policy_class", parameters={"name": "act"}))[:400])
+
+print("\nDone. In an agent, ask in natural language: "
+      "\"List the LeRobot policies I can use, then describe the ACT policy.\"")

--- a/examples/08_discover_lerobot.py
+++ b/examples/08_discover_lerobot.py
@@ -15,8 +15,10 @@ the same tool is selected by natural language ("which policies can I use?").
 
 from strands_robots.tools import use_lerobot
 
-# use_lerobot is a Strands @tool; call its underlying function directly here.
-call = use_lerobot.func if hasattr(use_lerobot, "func") else use_lerobot
+# use_lerobot is a Strands @tool. ``__wrapped__`` is the original undecorated
+# function (preserved by functools.wraps), which we call directly so the example
+# is self-contained. In an agent, the same tool is selected by natural language.
+call = use_lerobot.__wrapped__
 
 
 def text(result: dict) -> str:

--- a/examples/README.md
+++ b/examples/README.md
@@ -26,6 +26,7 @@ record→train→deploy loop) as Jupyter notebooks - all CPU-only, no hardware o
 | 05 | [`05_agent_natural_language.py`](05_agent_natural_language.py) | `Agent` + `Robot` tool | No | No (needs LLM API) |
 | 06 | [`06_agent_collect_and_stream.py`](06_agent_collect_and_stream.py) | `Agent` record + `stream_dataset` | No | No (needs LLM API) |
 | 07 | [`07_post_tune_any_policy.py`](07_post_tune_any_policy.py) | `create_trainer` + `TrainSpec` (record→train→load) | No | No |
+| 08 | [`08_discover_lerobot.py`](08_discover_lerobot.py) | `use_lerobot` tool: discover LeRobot robots, policies, teleoperators, cameras | No | No |
 | -- | [`vla_g1_workflow.py`](vla_g1_workflow.py) | VLA-on-G1: record -> GR00T fine-tune -> WBC deploy | No | Optional (tune) |
 | — | [`vera_mimicgen_panda/`](vera_mimicgen_panda/) | VERA MimicGen → Panda (eef-delta + IK bridge) | No | **Yes** (server) |
 | -- | [`lerobot_hardware_catalog.py`](lerobot_hardware_catalog.py) | `Robot()` covers the whole LeRobot hardware catalog (name -> lerobot_type) | No | No |

--- a/examples/notebooks/04_discover_lerobot.ipynb
+++ b/examples/notebooks/04_discover_lerobot.ipynb
@@ -1,0 +1,167 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "8956d13e",
+   "metadata": {},
+   "source": [
+    "# 4 - Discover the LeRobot API with `use_lerobot`\n",
+    "\n",
+    "`use_lerobot` lets an agent (or you) explore everything LeRobot exposes - registered robots, policies, teleoperators, cameras - and inspect any class, without hardcoding anything. It reads from LeRobot's own registries, so the answers track the version you have installed.\n",
+    "\n",
+    "Runs anywhere: no hardware, no GPU, no Hugging Face credentials. Part of the [examples/notebooks](./README.md) series.\n",
+    "\n",
+    "**Install:** `uv pip install \"strands-robots[sim-mujoco,lerobot]\"`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bbccb301",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from strands_robots.tools import use_lerobot\n",
+    "\n",
+    "# use_lerobot is a Strands @tool; call its underlying function directly in a notebook.\n",
+    "call = use_lerobot.func if hasattr(use_lerobot, \"func\") else use_lerobot\n",
+    "\n",
+    "def text(result):\n",
+    "    \"\"\"Pull the text content out of a tool result.\"\"\"\n",
+    "    if isinstance(result, dict):\n",
+    "        return \"\".join(c.get(\"text\", \"\") for c in result.get(\"content\", []) if isinstance(c, dict))\n",
+    "    return str(result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "471be09e",
+   "metadata": {},
+   "source": [
+    "## Discover everything at once\n",
+    "\n",
+    "`module=\"__discovery__\"` returns the packages, modules, and every registered config in one view - the fastest way to see what you can work with."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2082b60b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(text(call(module=\"__discovery__\", method=\"list_modules\"))[:900])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c2086fb3",
+   "metadata": {},
+   "source": [
+    "## List a single registry\n",
+    "\n",
+    "The choices come from LeRobot, not from Strands, so they reflect the installed version. Here are the policy types you can train or run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "125b667c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(text(call(module=\"__registry__\", method=\"policies\")))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26664836",
+   "metadata": {},
+   "source": [
+    "The same call works for `robots`, `teleoperators`, and `cameras`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9f8f7118",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for kind in (\"robots\", \"teleoperators\", \"cameras\"):\n",
+    "    print(f\"--- {kind} ---\")\n",
+    "    print(text(call(module=\"__registry__\", method=kind))[:300])\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "601bcd45",
+   "metadata": {},
+   "source": [
+    "## Inspect a class without instantiating it\n",
+    "\n",
+    "`__describe__` returns a class's methods and signature - useful for finding the right call before you make it. No object is constructed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5002f368",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(text(call(module=\"datasets.lerobot_dataset.LeRobotDataset\",\n",
+    "                method=\"__describe__\"))[:600])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b1cec953",
+   "metadata": {},
+   "source": [
+    "## Resolve a concrete object from a registry name\n",
+    "\n",
+    "This is the same lookup `create_policy()` does under the hood: the registry name `act` resolves to its policy class."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dd729087",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(text(call(module=\"policies.factory\", method=\"get_policy_class\",\n",
+    "                parameters={\"name\": \"act\"}))[:400])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "577b04dc",
+   "metadata": {},
+   "source": [
+    "## In an agent\n",
+    "\n",
+    "When `use_lerobot` is handed to a Strands `Agent`, the model selects it from natural language - for example, *\"List the LeRobot policies I can use, then describe the ACT policy.\"* The agent makes the same calls shown above and reads back the results.\n",
+    "\n",
+    "## Next\n",
+    "\n",
+    "- **[1 - Getting started](./01_getting_started.ipynb)** - `Robot()` and policies.\n",
+    "- **[3 - Record, train, deploy](./03_record_train_deploy.ipynb)** - the full loop."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/notebooks/04_discover_lerobot.ipynb
+++ b/examples/notebooks/04_discover_lerobot.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "8956d13e",
+   "id": "43b3892e",
    "metadata": {},
    "source": [
     "# 4 - Discover the LeRobot API with `use_lerobot`\n",
@@ -17,14 +17,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bbccb301",
+   "id": "71f83af2",
    "metadata": {},
    "outputs": [],
    "source": [
     "from strands_robots.tools import use_lerobot\n",
     "\n",
-    "# use_lerobot is a Strands @tool; call its underlying function directly in a notebook.\n",
-    "call = use_lerobot.func if hasattr(use_lerobot, \"func\") else use_lerobot\n",
+    "# use_lerobot is a Strands @tool. __wrapped__ is the original undecorated\n",
+    "# function (preserved by functools.wraps), which we call directly in a notebook.\n",
+    "call = use_lerobot.__wrapped__\n",
     "\n",
     "def text(result):\n",
     "    \"\"\"Pull the text content out of a tool result.\"\"\"\n",
@@ -35,7 +36,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "471be09e",
+   "id": "ac7eef59",
    "metadata": {},
    "source": [
     "## Discover everything at once\n",
@@ -46,7 +47,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2082b60b",
+   "id": "8ca826d0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -55,7 +56,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c2086fb3",
+   "id": "b82d87b5",
    "metadata": {},
    "source": [
     "## List a single registry\n",
@@ -66,7 +67,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "125b667c",
+   "id": "04b85970",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -75,7 +76,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26664836",
+   "id": "d9197ac4",
    "metadata": {},
    "source": [
     "The same call works for `robots`, `teleoperators`, and `cameras`."
@@ -84,7 +85,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9f8f7118",
+   "id": "30b878c2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -96,7 +97,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "601bcd45",
+   "id": "7368e487",
    "metadata": {},
    "source": [
     "## Inspect a class without instantiating it\n",
@@ -107,7 +108,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5002f368",
+   "id": "3c0cf8ae",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -117,7 +118,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b1cec953",
+   "id": "f857466e",
    "metadata": {},
    "source": [
     "## Resolve a concrete object from a registry name\n",
@@ -128,7 +129,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dd729087",
+   "id": "71686beb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -138,7 +139,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "577b04dc",
+   "id": "47046908",
    "metadata": {},
    "source": [
     "## In an agent\n",

--- a/examples/notebooks/README.md
+++ b/examples/notebooks/README.md
@@ -22,6 +22,7 @@ Linux they fall back to the environment's default (set `MUJOCO_GL=egl` if needed
 | 1 | [`01_getting_started.ipynb`](01_getting_started.ipynb) | `Robot("so100")`, run a policy, read joint state, `create_policy()` |
 | 2 | [`02_record_and_stream.ipynb`](02_record_and_stream.ipynb) | Record a LeRobotDataset, then stream it back with `stream_dataset()` |
 | 3 | [`03_record_train_deploy.ipynb`](03_record_train_deploy.ipynb) | The full loop: record, train an ACT policy on CPU, export, and load it back |
+| 4 | [`04_discover_lerobot.ipynb`](04_discover_lerobot.ipynb) | Discover the LeRobot API with `use_lerobot`: list robots, policies, teleoperators, cameras, and inspect any class |
 
 Read them in order; each builds on the previous one. Notebook 3 trains a real
 policy on CPU with a tiny dataset and two steps - raise the step count and run on


### PR DESCRIPTION
## What

Adds an example for the `use_lerobot` tool (added in #624), which currently ships
without one. The tool lets an agent or user explore everything LeRobot exposes -
registered robots, policies, teleoperators, cameras - and inspect any class, all
read from LeRobot's own draccus registries (nothing hardcoded), so the output
tracks whatever LeRobot version is installed.

- `examples/08_discover_lerobot.py` - script form
- `examples/notebooks/04_discover_lerobot.ipynb` - notebook companion (joins the getting-started series from #843)

It walks the documented calls: `__discovery__` (everything at once), `__registry__`
listings (robots / policies / teleoperators / cameras), `__describe__` on a class,
and resolving a class from a registry name (`get_policy_class`).

## Why

A new user's first question is "what robots / policies / cameras can I actually
use?" `use_lerobot` answers that directly, and it had no example. It's also a
discovery tool, so it returns text/structured data - nothing to render, no
hardware behavior to depend on.

## Testing

Runs anywhere: no hardware, no GPU, no Hugging Face credentials.

- The script was run end-to-end (exit 0); it lists 14 robots, 15 policy types,
  17 teleoperators, and 4 cameras from the installed LeRobot.
- The notebook was executed with `jupyter nbconvert --to notebook --execute` in a
  clean Python 3.12 venv (`strands-robots[sim-mujoco,lerobot]`, lerobot from
  source): exit 0, zero error outputs. Committed without cell outputs.

## Notes

- No package code changed - example + docs index rows only (`examples/README.md`,
  `examples/notebooks/README.md`, `docs/examples/overview.md`).
