### PR TITLE
feat(ros2): DDS Security gate + joint-limit bounds on the hardware bridges

### DIFF
--- a/README.md
+++ b/README.md
@@ -989,6 +989,7 @@ touches ROS 2.
 | `GROOT_API_TOKEN` | API token for the GR00T inference service | unset |
 | `STRANDS_MESH` | Set `false` to disable Zenoh mesh globally | `true` |
 | `STRANDS_MESH_LOCAL_DEV` | Set `1` for a one-var localhost preset (auth `none`, no second factor needed) | unset |
+| `STRANDS_ROS2_BRIDGE_I_KNOW_THIS_IS_INSECURE` | Second factor to expose a `Robot(ros2_transport="rtps")` inbound `joint_command` surface with no `dds_security_config` (DDS Security). Truthy: `1`/`true`/`yes` | unset |
 <details>
 <summary><b>Mesh / IoT / GR00T-container env vars (advanced)</b></summary>
 

--- a/docs/ros2-integration.md
+++ b/docs/ros2-integration.md
@@ -246,6 +246,20 @@ inbound command path is on by default (`ros2_commands=True`); set
 be driven. A daemon thread spins the node so inbound commands are serviced
 concurrently with publishing, and it is torn down cleanly on `cleanup()`/`stop()`.
 
+Because the inbound `joint_command` topic drives the physical arm, two guards
+harden it (both threaded through `Robot()`):
+
+- `joint_limits={motor: (min, max)}` range-checks every inbound command; if any
+  commanded joint is outside its declared range the **entire** command is
+  rejected (no partial application). Joints without a declared bound are
+  unconstrained. Available on both transports.
+- For the pure-RTPS transport (`ros2_transport="rtps"`), a `dds_security_config`
+  (or the explicit `STRANDS_ROS2_BRIDGE_I_KNOW_THIS_IS_INSECURE=1` opt-out) is
+  **required** to expose the command surface - see the
+  [RTPS integration guide](rtps-integration.md#securing-the-inbound-command-surface).
+  rclpy DDS Security is configured at the RMW layer (`ROS_SECURITY_*` / `sros2`),
+  not by a config dict.
+
 See `examples/ros2/hardware_bridge_demo.py` for a runnable end-to-end script.
 
 ![Hardware ROS 2 bridge: an SO-101 camera frame published by HardwareRosBridge and received by an independent ros2 subscriber over DDS, byte-identical](assets/hardware_ros_bridge_proof.png)

--- a/docs/rtps-integration.md
+++ b/docs/rtps-integration.md
@@ -144,6 +144,74 @@ inbound `joint_command` parsing, so the two transports are byte-identical on the
 by construction; they present the identical `publish_joint_states` / `publish_image` /
 inbound-`joint_command` surface.
 
+## Securing the inbound command surface
+
+The inbound `/<robot>/joint_command` subscription lets **any participant on the
+DDS domain drive the physical arm**. Two layers harden it, both threaded through
+the `Robot()` constructor.
+
+### DDS Security gate (RTPS only)
+
+When the command surface is enabled (`ros2_bridge=True`, `ros2_commands=True`,
+`ros2_transport="rtps"`), `HardwareRtpsBridge` **refuses to start** unless one of
+the following is true:
+
+- a `dds_security_config` dict is supplied, or
+- the operator sets `STRANDS_ROS2_BRIDGE_I_KNOW_THIS_IS_INSECURE=1` (truthy:
+  `1` / `true` / `yes`) to explicitly accept an unsecured graph.
+
+A telemetry-only bridge (`ros2_commands=False`) is publish-only and is **not**
+gated. `dds_security_config` requires the following keys (each a path or a
+`file:` / `data:` URI per the OMG DDS-Security spec); `permissions_ca` is
+optional:
+
+```python
+from strands_robots import Robot
+
+arm = Robot(
+    "so101",
+    mode="real",
+    ros2_bridge=True,
+    ros2_transport="rtps",
+    dds_security_config={
+        "identity_ca":  "file:/etc/dds/identity_ca.pem",   # identity CA
+        "certificate":  "file:/etc/dds/participant.pem",   # participant cert
+        "private_key":  "file:/etc/dds/participant_key.pem",
+        "governance":   "file:/etc/dds/governance.p7s",    # signed governance
+        "permissions":  "file:/etc/dds/permissions.p7s",   # signed permissions
+        # "permissions_ca": "file:/etc/dds/permissions_ca.pem",  # optional
+    },
+)
+```
+
+The credentials are wired into the cyclonedds `DomainParticipant` QoS together
+with the builtin DDS-Security plugins, so **both** the outbound telemetry and the
+inbound command surface ride an authenticated, access-controlled graph. A
+half-filled config is rejected at construction.
+
+`dds_security_config` is RTPS-specific: passing it with `ros2_transport="rclpy"`
+raises, because the rclpy backend gets its DDS Security from the ROS 2 RMW
+keystore/env (`ROS_SECURITY_*` / `sros2`), not from a config dict.
+
+### Joint position bounds
+
+`joint_limits={motor: (min, max)}` (threaded into either transport) range-checks
+every inbound command. If **any** commanded joint falls outside its declared
+range, the **entire** command is rejected - never partially applied - so one
+out-of-range joint can never drive part of the arm while the rest holds. Joints
+without a declared bound are unconstrained.
+
+```python
+arm = Robot(
+    "so101",
+    mode="real",
+    ros2_bridge=True,
+    ros2_transport="rtps",
+    dds_security_config={...},
+    joint_limits={"shoulder_pan.pos": (-3.14, 3.14), "elbow.pos": (-1.57, 1.57)},
+)
+```
+
 ## Safety
 
 Agent-supplied topic and type names are validated against an allowlist before

--- a/docs/security.md
+++ b/docs/security.md
@@ -130,6 +130,14 @@ Reference: `strands_robots.tools.gr00t_inference`.
 - **Calibration files** under `~/.cache/huggingface/lerobot/calibration/` define how joint commands map to the physical device. Protect them as integrity-sensitive configuration - corrupted or swapped calibration can produce unexpected motion.
 - **The `serial_tool` is broad.** It can enumerate and write to any serial port the process can see, not just the intended robot. Scope it out of agents that do not need raw device access (see [Tool scoping](#prompt-injection)).
 
+## ROS 2 / DDS bridge command surface
+
+`Robot(ros2_bridge=True)` can expose an inbound `/<robot>/joint_command` topic that drives the physical arm. Because **any participant on the DDS domain can publish to it**, the command surface is hardened:
+
+- **DDS Security gate (pure-RTPS transport).** When `ros2_transport="rtps"` and commands are enabled, the bridge **refuses to start** unless given a `dds_security_config` (identity CA, participant certificate + private key, signed governance + permissions) or the explicit `STRANDS_ROS2_BRIDGE_I_KNOW_THIS_IS_INSECURE=1` opt-out. The credentials are wired into the cyclonedds participant QoS so the whole graph is authenticated and access-controlled. The rclpy transport gets its DDS Security from the ROS 2 RMW keystore/env (`ROS_SECURITY_*` / `sros2`) instead. See the [RTPS integration guide](rtps-integration.md#securing-the-inbound-command-surface).
+- **Joint position bounds.** Pass `joint_limits={motor: (min, max)}` to reject any inbound command whose any joint falls outside its declared range - the whole command is dropped, never partially applied, so one out-of-range value cannot drive part of the arm.
+- **Telemetry-only is ungated.** `ros2_commands=False` is publish-only (no inbound surface) and needs no security config.
+
 ## Credentials and secrets
 
 The product touches several classes of secret. Handle each per least-privilege:

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -226,6 +226,8 @@ class Robot(TeleopMixin, AgentTool):
         ros2_domain: int = 0,
         ros2_commands: bool = True,
         ros2_transport: str = "rclpy",
+        joint_limits: dict[str, tuple[float, float]] | None = None,
+        dds_security_config: dict[str, str] | None = None,
         **kwargs: Any,
     ) -> None:
         """Initialize Robot with async capabilities.
@@ -259,6 +261,21 @@ class Robot(TeleopMixin, AgentTool):
                 pip wheel, no rclpy / no sourced distro), type coverage bounded
                 by the local IDL bundle (joint_states + image_raw). Both emit
                 byte-identical topics. Ignored unless ``ros2_bridge=True``.
+            joint_limits: Optional ``{motor: (min, max)}`` clamp ranges threaded
+                into the ROS 2 bridge. When set, an inbound ``joint_command``
+                whose ANY joint is outside its declared range is rejected whole
+                (no partial application). Requires ``ros2_bridge=True``.
+            dds_security_config: Optional DDS Security credentials
+                (``identity_ca``, ``certificate``, ``private_key``,
+                ``governance``, ``permissions``; ``permissions_ca`` optional)
+                for the pure-RTPS bridge. When ``ros2_commands=True`` on the
+                ``"rtps"`` transport this (or the
+                ``STRANDS_ROS2_BRIDGE_I_KNOW_THIS_IS_INSECURE=1`` opt-out) is
+                REQUIRED - the bridge refuses to drive the arm over an unsecured
+                DDS graph. Only the ``"rtps"`` transport consumes it (rclpy DDS
+                Security is configured via the ROS 2 RMW keystore/env); passing
+                it with ``ros2_transport="rclpy"`` raises. Requires
+                ``ros2_bridge=True``.
             **kwargs: Robot-specific parameters (port, etc.)
         """
         super().__init__()
@@ -327,6 +344,8 @@ class Robot(TeleopMixin, AgentTool):
             ros2_domain=ros2_domain,
             ros2_commands=ros2_commands,
             ros2_transport=ros2_transport,
+            joint_limits=joint_limits,
+            dds_security_config=dds_security_config,
         )
 
     # ------------------------------------------------------------------
@@ -370,6 +389,8 @@ class Robot(TeleopMixin, AgentTool):
         ros2_domain: int = 0,
         ros2_commands: bool = True,
         ros2_transport: str = "rclpy",
+        joint_limits: dict[str, tuple[float, float]] | None = None,
+        dds_security_config: dict[str, str] | None = None,
     ) -> None:
         """Initialize the optional ROS 2 telemetry bridge state.
 
@@ -396,19 +417,45 @@ class Robot(TeleopMixin, AgentTool):
             ros2_commands: When True (default), also subscribe to
                 ``joint_command`` and drive the arm; False for read-only.
             ros2_transport: ``"rclpy"`` or ``"rtps"`` (see above).
+            joint_limits: Optional ``{motor: (min, max)}`` clamp ranges threaded
+                into whichever bridge is built (both enforce them on inbound
+                commands via the shared base).
+            dds_security_config: Optional DDS Security credentials, consumed
+                only by the ``"rtps"`` bridge. Passing it with the ``"rclpy"``
+                transport raises (rclpy DDS Security is configured at the RMW
+                layer, not by a config dict).
 
         Raises:
-            ValueError: If ``ros2_transport`` is not ``"rclpy"`` or ``"rtps"``.
+            ValueError: If ``ros2_transport`` is not ``"rclpy"`` or ``"rtps"``;
+                if ``joint_limits`` / ``dds_security_config`` are supplied with
+                ``ros2_bridge=False``; or if ``dds_security_config`` is supplied
+                with ``ros2_transport="rclpy"``.
         """
         self._ros2_bridge_enabled = bool(ros2_bridge)
         self._ros2_domain = int(ros2_domain)
         self._ros2_transport = ros2_transport
         self._ros_bridge: Any = None
         if not self._ros2_bridge_enabled:
+            # No silent no-op: a security/safety config that never reaches a
+            # bridge is almost certainly an operator mistake.
+            if joint_limits is not None or dds_security_config is not None:
+                raise ValueError(
+                    "joint_limits / dds_security_config require ros2_bridge=True "
+                    "(they configure the ROS 2 bridge, which is disabled here)."
+                )
             return
 
         if ros2_transport not in ("rclpy", "rtps"):
             raise ValueError(f"ros2_transport must be 'rclpy' or 'rtps', got {ros2_transport!r}")
+
+        # DDS Security credentials are an RTPS (cyclonedds) concept; the rclpy
+        # transport gets its DDS Security from the ROS 2 RMW keystore/env, not a
+        # config dict. Reject rather than silently ignore.
+        if dds_security_config is not None and ros2_transport != "rtps":
+            raise ValueError(
+                "dds_security_config is only supported with ros2_transport='rtps'; "
+                "rclpy DDS Security is configured via the ROS 2 RMW keystore/env."
+            )
 
         # Bind self so the bridge can drive the arm on inbound commands.
         # command_robot_name is pinned to the same namespace we publish
@@ -421,6 +468,8 @@ class Robot(TeleopMixin, AgentTool):
                 self,
                 domain_id=self._ros2_domain,
                 enable_commands=bool(ros2_commands),
+                joint_limits=joint_limits,
+                dds_security_config=dds_security_config,
             )
         else:
             from strands_robots.hardware_ros_bridge import HardwareRosBridge
@@ -431,6 +480,7 @@ class Robot(TeleopMixin, AgentTool):
                 domain_id=self._ros2_domain,
                 node_name=node,
                 enable_commands=bool(ros2_commands),
+                joint_limits=joint_limits,
             )
 
     def _publish_ros_telemetry(self, observation: dict[str, Any], *, skip_images: bool = False) -> None:

--- a/strands_robots/hardware_ros_bridge.py
+++ b/strands_robots/hardware_ros_bridge.py
@@ -79,6 +79,14 @@ class HardwareRosBridge(RosTelemetryBridge):
             bridge *publishes* ``joint_states`` under), so a controller can echo
             our own joint names straight back to drive the arm.
         spin_period: Seconds between ``spin_once`` calls on the command thread.
+        joint_limits: Optional ``{motor: (min, max)}`` clamp ranges. When set,
+            an inbound ``joint_command`` whose ANY commanded joint is outside
+            its declared range is rejected whole (no partial application), so a
+            single out-of-range joint can never drive part of the arm.
+
+    Raises:
+        ValueError: If ``joint_limits`` is not a ``{motor: (min, max)}`` mapping
+            of numeric pairs with ``min <= max``.
     """
 
     default_node_name = "strands_hardware"
@@ -93,10 +101,14 @@ class HardwareRosBridge(RosTelemetryBridge):
         enable_commands: bool = True,
         command_robot_name: str | None = None,
         spin_period: float = 0.02,
+        joint_limits: dict[str, tuple[float, float]] | None = None,
     ) -> None:
         super().__init__(domain_id=domain_id, node_name=node_name, qos_depth=qos_depth)
 
         self._robot = robot
+        # Optional {motor: (min, max)} clamp ranges enforced on inbound commands
+        # by RosTelemetryBase._command_action (validated up front, fail fast).
+        self._joint_limits = self._validate_joint_limits(joint_limits)
         # Commands require a robot to drive; a pure-publisher bridge (robot
         # None) is telemetry-only and stays symmetric with the sim sibling.
         self._enable_commands = bool(enable_commands) and robot is not None

--- a/strands_robots/hardware_rtps_bridge.py
+++ b/strands_robots/hardware_rtps_bridge.py
@@ -59,6 +59,36 @@ _JOINT_STATE_TYPE = "sensor_msgs/msg/JointState"
 _IMAGE_TYPE = "sensor_msgs/msg/Image"
 
 
+# Map the operator-facing dds_security_config keys to the DDS Security
+# participant property names cyclonedds reads (OMG DDS-Security v1.1, table 8.20
+# "dds.sec.*"). Values are passed through verbatim so the operator controls the
+# scheme (``file:/path`` or ``data:`` per the spec). ``permissions_ca`` is
+# optional; the rest are required (validated by RosTelemetryBase).
+_DDS_SECURITY_PROPERTY = {
+    "identity_ca": "dds.sec.auth.identity_ca",
+    "certificate": "dds.sec.auth.identity_certificate",
+    "private_key": "dds.sec.auth.private_key",
+    "permissions_ca": "dds.sec.access.permissions_ca",
+    "governance": "dds.sec.access.governance",
+    "permissions": "dds.sec.access.permissions",
+}
+
+# The OMG DDS-Security builtin plugins cyclonedds ships. Set unconditionally
+# alongside the credentials so an operator only supplies cert/CA/governance/
+# permissions, not the plugin wiring.
+_DDS_SECURITY_PLUGINS = {
+    "dds.sec.auth.library.path": "dds_security_auth",
+    "dds.sec.auth.library.init": "init_authentication",
+    "dds.sec.auth.library.finalize": "finalize_authentication",
+    "dds.sec.crypto.library.path": "dds_security_crypto",
+    "dds.sec.crypto.library.init": "init_crypto",
+    "dds.sec.crypto.library.finalize": "finalize_crypto",
+    "dds.sec.access.library.path": "dds_security_ac",
+    "dds.sec.access.library.init": "init_access_control",
+    "dds.sec.access.library.finalize": "finalize_access_control",
+}
+
+
 class HardwareRtpsBridge(RosTelemetryBase):
     """Full-duplex hardware ROS 2 bridge over pure RTPS (cyclonedds, no rclpy).
 
@@ -80,9 +110,24 @@ class HardwareRtpsBridge(RosTelemetryBase):
             the bound robot's name (the namespace we publish ``joint_states``
             under).
         poll_period: Seconds between inbound command reads on the poll thread.
+        joint_limits: Optional ``{motor: (min, max)}`` clamp ranges. When set,
+            an inbound ``joint_command`` whose ANY commanded joint falls outside
+            its declared range is rejected whole (no partial application), so a
+            single out-of-range joint can never drive part of the arm.
+        dds_security_config: Optional DDS Security credentials. Required keys
+            (``identity_ca``, ``certificate``, ``private_key``, ``governance``,
+            ``permissions``; ``permissions_ca`` optional) wire the participant's
+            DDS Security plugins so the whole graph is authenticated and
+            access-controlled. When ``enable_commands`` is in effect this (or
+            the ``STRANDS_ROS2_BRIDGE_I_KNOW_THIS_IS_INSECURE=1`` opt-out) is
+            REQUIRED - the bridge refuses to expose an arm-driving command
+            surface on an unsecured DDS graph.
 
     Raises:
         ImportError: If ``cyclonedds`` (the ``[ros2]`` extra) is not installed.
+        ValueError: If ``joint_limits`` / ``dds_security_config`` is malformed,
+            or commands are enabled with neither a security config nor the
+            explicit insecure opt-out.
     """
 
     def __init__(
@@ -93,6 +138,8 @@ class HardwareRtpsBridge(RosTelemetryBase):
         enable_commands: bool = True,
         command_robot_name: str | None = None,
         poll_period: float = 0.02,
+        joint_limits: dict[str, tuple[float, float]] | None = None,
+        dds_security_config: dict[str, str] | None = None,
     ) -> None:
         # cyclonedds is the only dependency - no rclpy, no sourced ROS 2 distro.
         require_optional(
@@ -110,7 +157,36 @@ class HardwareRtpsBridge(RosTelemetryBase):
 
         self._robot = robot
         self._domain_id = int(domain_id)
-        self._participant: Any = DomainParticipant(self._domain_id)
+
+        # Whether this bridge exposes an inbound (arm-driving) command surface.
+        # Resolved BEFORE the participant is built so the DDS Security gate and
+        # the participant's security QoS are decided together.
+        self._enable_commands = bool(enable_commands) and robot is not None
+
+        # Validate the optional clamp ranges up front (fail fast at construction).
+        self._joint_limits = self._validate_joint_limits(joint_limits)
+
+        # DDS Security gate: an enabled inbound command surface lets any DDS
+        # participant drive the physical arm, so refuse to start one on an
+        # unsecured graph unless given a dds_security_config or an explicit
+        # operator opt-out (STRANDS_ROS2_BRIDGE_I_KNOW_THIS_IS_INSECURE=1).
+        if dds_security_config is not None:
+            dds_security_config = self._validate_dds_security_config(dds_security_config)
+        self._require_secure_command_surface(
+            enable_commands=self._enable_commands,
+            dds_security_config=dds_security_config,
+        )
+        self._dds_security_config = dds_security_config
+
+        # Build the participant with DDS Security QoS when a config is supplied,
+        # so BOTH the outbound telemetry and the inbound command surface ride a
+        # secured (authenticated + access-controlled) DDS graph.
+        if dds_security_config is not None:
+            self._participant: Any = DomainParticipant(
+                self._domain_id, qos=self._build_security_qos(dds_security_config)
+            )
+        else:
+            self._participant = DomainParticipant(self._domain_id)
 
         self._robot_name = self._safe(self._resolve_robot_name(robot) if robot is not None else "robot")
         self._joint_writer: Any = None
@@ -121,7 +197,6 @@ class HardwareRtpsBridge(RosTelemetryBase):
         self._JointState = get_type(_JOINT_STATE_TYPE)
         self._Image = get_type(_IMAGE_TYPE)
 
-        self._enable_commands = bool(enable_commands) and robot is not None
         self._poll_period = float(poll_period)
         self._command_reader: Any = None
         self._stop = threading.Event()
@@ -132,6 +207,23 @@ class HardwareRtpsBridge(RosTelemetryBase):
             self._command_robot_name = self._safe(name)
             self._command_reader = self._make_reader(self.joint_command_topic(name), self._JointState)
             self._start_poll()
+
+    def _build_security_qos(self, config: dict[str, str]) -> Any:
+        """Build a cyclonedds ``Qos`` carrying the DDS Security participant properties.
+
+        Combines the builtin DDS-Security plugin wiring (:data:`_DDS_SECURITY_PLUGINS`)
+        with the operator-supplied credentials, mapped to their ``dds.sec.*``
+        property names (:data:`_DDS_SECURITY_PROPERTY`). Optional keys absent
+        from ``config`` (e.g. ``permissions_ca``) are simply not set.
+        """
+        from cyclonedds.qos import Policy, Qos
+
+        properties = dict(_DDS_SECURITY_PLUGINS)
+        for key, prop in _DDS_SECURITY_PROPERTY.items():
+            value = config.get(key)
+            if value:
+                properties[prop] = str(value)
+        return Qos(*[Policy.Property(name, value) for name, value in properties.items()])
 
     # -- helpers ----------------------------------------------------------
 

--- a/strands_robots/ros_telemetry.py
+++ b/strands_robots/ros_telemetry.py
@@ -39,6 +39,27 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+#: Env var an operator sets to explicitly run an INBOUND ``joint_command``
+#: surface on an unsecured DDS graph (no ``dds_security_config``). Truthy values
+#: mirror the mesh insecure opt-out (``STRANDS_MESH_I_KNOW_THIS_IS_INSECURE``):
+#: ``1``, ``true``, ``yes`` (case-insensitive). This is a deliberate second
+#: factor so a forgotten config cannot silently expose a drivable arm.
+ROS2_INSECURE_ENV = "STRANDS_ROS2_BRIDGE_I_KNOW_THIS_IS_INSECURE"
+
+#: Keys a ``dds_security_config`` dict must supply (non-empty). Each names a
+#: credential the RTPS bridge wires into its DDS Security participant: the
+#: identity CA, the participant's own certificate and private key (identity is
+#: unprovable without the key), and the signed governance + permissions
+#: documents. ``permissions_ca`` is optional and applied when present.
+_DDS_SECURITY_REQUIRED_KEYS = (
+    "identity_ca",
+    "certificate",
+    "private_key",
+    "governance",
+    "permissions",
+)
+
+
 class RosTelemetryBase:
     """Transport-agnostic ROS 2 wire contract shared by every telemetry bridge.
 
@@ -88,7 +109,121 @@ class RosTelemetryBase:
         """ROS 2 topic inbound ``joint_command`` messages are read from."""
         return f"/{cls._safe(robot)}/joint_command"
 
-    def _command_action(self, msg: Any, *, skip_empty: bool = False) -> dict[str, float] | None:
+    # -- security / safety gate (shared by both hardware bridges) ---------
+
+    @staticmethod
+    def _validate_joint_limits(
+        joint_limits: dict[str, Any] | None,
+    ) -> dict[str, tuple[float, float]] | None:
+        """Validate and normalize a ``joint_limits`` mapping at construction.
+
+        Returns ``{motor: (min, max)}`` with floats and ``min <= max``, or
+        ``None`` when no limits are configured. Failing fast here (rather than
+        per-command) means a malformed bound surfaces at bridge construction,
+        not as a silent mid-run rejection of every command.
+
+        Raises:
+            ValueError: If ``joint_limits`` is not a mapping of name to a
+                ``(min, max)`` numeric pair with ``min <= max``.
+        """
+        if joint_limits is None:
+            return None
+        if not isinstance(joint_limits, dict):
+            raise ValueError(f"joint_limits must be a dict[str, (min, max)], got {type(joint_limits).__name__}")
+        normalized: dict[str, tuple[float, float]] = {}
+        for name, bounds in joint_limits.items():
+            try:
+                low, high = bounds
+                low, high = float(low), float(high)
+            except (TypeError, ValueError):
+                raise ValueError(f"joint_limits[{name!r}] must be a (min, max) numeric pair, got {bounds!r}") from None
+            if low > high:
+                raise ValueError(f"joint_limits[{name!r}] has min {low} > max {high}")
+            normalized[str(name)] = (low, high)
+        return normalized
+
+    @staticmethod
+    def _validate_dds_security_config(config: Any) -> dict[str, str]:
+        """Validate a ``dds_security_config`` dict supplies every required key.
+
+        Returns the config unchanged on success. The required keys
+        (:data:`_DDS_SECURITY_REQUIRED_KEYS`) are the credentials a DDS Security
+        participant cannot authenticate or be governed without; each must be a
+        non-empty string (a path, ``file:`` / ``data:`` URI per the DDS Security
+        spec). Validated at construction so a half-filled config refuses the
+        bridge rather than silently degrading wire security.
+
+        Raises:
+            ValueError: If ``config`` is not a dict or a required key is missing
+                or empty.
+        """
+        if not isinstance(config, dict):
+            raise ValueError(f"dds_security_config must be a dict, got {type(config).__name__}")
+        missing = [k for k in _DDS_SECURITY_REQUIRED_KEYS if not str(config.get(k, "")).strip()]
+        if missing:
+            raise ValueError(
+                f"dds_security_config is missing required keys: {missing}. "
+                f"All of {list(_DDS_SECURITY_REQUIRED_KEYS)} must be supplied "
+                "(identity CA, participant certificate + private key, governance, permissions)."
+            )
+        return config
+
+    @staticmethod
+    def _insecure_opt_out() -> bool:
+        """True when the operator explicitly accepted an unsecured command surface.
+
+        Mirrors the mesh insecure opt-out contract: ``1`` / ``true`` / ``yes``
+        (case-insensitive) on :data:`ROS2_INSECURE_ENV`.
+        """
+        return os.getenv(ROS2_INSECURE_ENV, "").strip().lower() in ("1", "true", "yes")
+
+    @classmethod
+    def _require_secure_command_surface(
+        cls,
+        *,
+        enable_commands: bool,
+        dds_security_config: Any,
+    ) -> None:
+        """Refuse to expose an inbound command surface on an unsecured DDS graph.
+
+        An inbound ``joint_command`` subscription lets any participant on the
+        DDS domain drive the physical arm. When ``enable_commands`` is in
+        effect, require either a ``dds_security_config`` (DDS Security: signed
+        governance + permissions, authenticated identities) OR an explicit
+        operator opt-out via :data:`ROS2_INSECURE_ENV` (``=1``). A telemetry-only
+        bridge (``enable_commands`` False) is publish-only and is not gated.
+
+        Raises:
+            ValueError: When commands are enabled with neither a security config
+                nor the explicit insecure opt-out.
+        """
+        if not enable_commands:
+            return
+        if dds_security_config:
+            return
+        if cls._insecure_opt_out():
+            logger.warning(
+                "%s: exposing an inbound joint_command surface on an UNSECURED DDS graph "
+                "(%s set). Any participant on the domain can drive the arm. Provide a "
+                "dds_security_config for production.",
+                cls.__name__,
+                ROS2_INSECURE_ENV,
+            )
+            return
+        raise ValueError(
+            "Refusing to start an inbound joint_command surface on an unsecured DDS graph. "
+            "An enabled command bridge lets any DDS participant drive the physical arm. "
+            "Pass a dds_security_config (identity CA, participant certificate + private key, "
+            f"governance, permissions) or set {ROS2_INSECURE_ENV}=1 to explicitly accept the risk."
+        )
+
+    def _command_action(
+        self,
+        msg: Any,
+        *,
+        skip_empty: bool = False,
+        joint_limits: dict[str, tuple[float, float]] | None = None,
+    ) -> dict[str, float] | None:
         """Parse an inbound ``joint_command`` ``JointState`` into an action dict.
 
         Returns ``{motor: pos}`` ready for ``Robot.send_action``, or ``None``
@@ -97,6 +232,19 @@ class RosTelemetryBase:
         request) is dropped silently; an empty or length-mismatched message is
         otherwise rejected with a warning rather than partially applied, so a
         malformed command never drives the arm to a surprising pose.
+
+        When ``joint_limits`` is supplied (``{motor: (min, max)}``), the command
+        is range-checked against the declared bounds: if ANY commanded joint
+        falls outside its range the ENTIRE command is rejected (returns
+        ``None``) - no partial application - so one out-of-range joint can never
+        drive part of the arm to a surprising pose while the rest holds. Joints
+        without a declared bound are not constrained.
+
+        Args:
+            msg: The inbound ``JointState``-like message (``name``/``position``).
+            skip_empty: Drop a wholly empty sample silently (DDS keep-alive).
+            joint_limits: Optional ``{motor: (min, max)}`` clamp ranges; a
+                command with any joint outside its range is rejected whole.
         """
         names = list(getattr(msg, "name", []) or [])
         positions = list(getattr(msg, "position", []) or [])
@@ -110,7 +258,25 @@ class RosTelemetryBase:
                 len(positions),
             )
             return None
-        return {name: float(pos) for name, pos in zip(names, positions)}
+        action = {name: float(pos) for name, pos in zip(names, positions)}
+        if joint_limits:
+            for name, pos in action.items():
+                bounds = joint_limits.get(name)
+                if bounds is None:
+                    continue
+                low, high = bounds
+                if not (low <= pos <= high):
+                    logger.warning(
+                        "%s: rejecting joint_command - %s=%.4f outside declared range "
+                        "[%.4f, %.4f] (whole command dropped, no partial application)",
+                        type(self).__name__,
+                        name,
+                        pos,
+                        low,
+                        high,
+                    )
+                    return None
+        return action
 
     def _drive_from_command(self, robot: Any, msg: Any, *, skip_empty: bool = False) -> None:
         """Forward an inbound ``joint_command`` to ``robot.send_action``.
@@ -120,7 +286,7 @@ class RosTelemetryBase:
         raising) a ``send_action`` failure so a bad command cannot kill the
         command loop.
         """
-        action = self._command_action(msg, skip_empty=skip_empty)
+        action = self._command_action(msg, skip_empty=skip_empty, joint_limits=getattr(self, "_joint_limits", None))
         if action is None:
             return
         try:

--- a/tests/test_hardware_ros_bridge.py
+++ b/tests/test_hardware_ros_bridge.py
@@ -420,6 +420,32 @@ def test_joint_command_drives_send_action(fake_ros: dict[str, Any]) -> None:
     bridge.shutdown()
 
 
+def test_joint_limits_reject_out_of_range_command_whole(fake_ros: dict[str, Any]) -> None:
+    # joint_limits threaded into the rclpy bridge are enforced by the shared
+    # base: any out-of-range joint rejects the WHOLE command (no partial apply).
+    robot = _FakeDrivableRobot()
+    bridge = HardwareRosBridge(robot, joint_limits={"shoulder_pan.pos": (-1.0, 1.0)})  # type: ignore[arg-type]
+    sub = next(s for s in fake_ros["nodes"][0].subscriptions if s.topic == "/so101/joint_command")
+
+    over = _JointState()
+    over.name = ["shoulder_pan.pos", "elbow.pos"]
+    over.position = [5.0, 0.0]  # shoulder_pan out of [-1, 1]
+    sub.callback(over)
+    assert robot.sent_actions == []
+
+    ok = _JointState()
+    ok.name = ["shoulder_pan.pos", "elbow.pos"]
+    ok.position = [0.5, 9.0]  # elbow has no declared bound -> unconstrained
+    sub.callback(ok)
+    assert robot.sent_actions == [{"shoulder_pan.pos": 0.5, "elbow.pos": 9.0}]
+    bridge.shutdown()
+
+
+def test_invalid_joint_limits_raise_at_construction(fake_ros: dict[str, Any]) -> None:
+    with pytest.raises(ValueError, match="min .* > max"):
+        HardwareRosBridge(_FakeDrivableRobot(), joint_limits={"j0.pos": (1.0, -1.0)})  # type: ignore[arg-type]
+
+
 def test_joint_command_length_mismatch_is_ignored(fake_ros: dict[str, Any]) -> None:
     robot = _FakeDrivableRobot()
     bridge = HardwareRosBridge(robot)  # type: ignore[arg-type]
@@ -500,3 +526,28 @@ def test_make_robot_command_bridges_do_not_leak_spin_threads(fake_ros: dict[str,
     while _live_command_threads() > before and time.monotonic() < deadline:
         time.sleep(0.01)
     assert _live_command_threads() == before
+
+
+# --- Robot() threading of joint_limits / dds_security_config ----------------
+
+
+def test_joint_limits_threaded_into_rclpy_bridge(fake_ros: dict[str, Any]) -> None:
+    hw = _make_robot({"j0.pos": 0.0})
+    hw._init_ros_bridge(ros2_bridge=True, ros2_transport="rclpy", joint_limits={"j0.pos": (-2.0, 2.0)})
+    assert hw._ros_bridge._joint_limits == {"j0.pos": (-2.0, 2.0)}
+
+
+def test_dds_security_config_rejected_for_rclpy_transport(fake_ros: dict[str, Any]) -> None:
+    hw = _make_robot({"j0.pos": 0.0})
+    with pytest.raises(ValueError, match="only supported with ros2_transport='rtps'"):
+        hw._init_ros_bridge(
+            ros2_bridge=True,
+            ros2_transport="rclpy",
+            dds_security_config={"identity_ca": "file:ca.pem"},
+        )
+
+
+def test_inert_safety_config_without_bridge_is_rejected(fake_ros: dict[str, Any]) -> None:
+    hw = _make_robot({"j0.pos": 0.0})
+    with pytest.raises(ValueError, match="require ros2_bridge=True"):
+        hw._init_ros_bridge(ros2_bridge=False, joint_limits={"j0.pos": (-1.0, 1.0)})

--- a/tests/test_hardware_rtps_bridge.py
+++ b/tests/test_hardware_rtps_bridge.py
@@ -59,8 +59,9 @@ class _FakeTopic:
 
 
 class _FakeParticipant:
-    def __init__(self, domain_id: int = 0) -> None:
+    def __init__(self, domain_id: int = 0, qos: Any = None) -> None:
         self.domain_id = domain_id
+        self.qos = qos
 
 
 # Minimal IDL stand-ins (the real layouts are validated against live ROS 2).
@@ -116,8 +117,8 @@ def fake_cyclonedds(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     sub_mod = ModuleType("cyclonedds.sub")
     topic_mod = ModuleType("cyclonedds.topic")
 
-    def _make_participant(domain_id: int = 0) -> _FakeParticipant:
-        p = _FakeParticipant(domain_id)
+    def _make_participant(domain_id: int = 0, qos: Any = None) -> _FakeParticipant:
+        p = _FakeParticipant(domain_id, qos=qos)
         state["participants"].append(p)
         return p
 
@@ -136,11 +137,28 @@ def fake_cyclonedds(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     sub_mod.DataReader = _make_reader  # type: ignore[attr-defined]
     topic_mod.Topic = _FakeTopic  # type: ignore[attr-defined]
 
+    # Fake cyclonedds.qos so _build_security_qos can assemble Property policies.
+    qos_mod = ModuleType("cyclonedds.qos")
+
+    class _FakeQos:
+        def __init__(self, *policies: Any) -> None:
+            self.policies = list(policies)
+
+    class _FakePolicy:
+        class Property:
+            def __init__(self, name: str, value: str) -> None:
+                self.name = name
+                self.value = value
+
+    qos_mod.Qos = _FakeQos  # type: ignore[attr-defined]
+    qos_mod.Policy = _FakePolicy  # type: ignore[attr-defined]
+
     monkeypatch.setitem(sys.modules, "cyclonedds", cyclonedds)
     monkeypatch.setitem(sys.modules, "cyclonedds.domain", domain_mod)
     monkeypatch.setitem(sys.modules, "cyclonedds.pub", pub_mod)
     monkeypatch.setitem(sys.modules, "cyclonedds.sub", sub_mod)
     monkeypatch.setitem(sys.modules, "cyclonedds.topic", topic_mod)
+    monkeypatch.setitem(sys.modules, "cyclonedds.qos", qos_mod)
     monkeypatch.setattr(utils_mod, "_lazy_modules", {"cyclonedds": cyclonedds}, raising=False)
 
     # Patch the IDL bundle resolver so it returns our trivial classes.
@@ -148,6 +166,12 @@ def fake_cyclonedds(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
 
     monkeypatch.setattr(idl_mod, "get_type", lambda t: _IDL[t], raising=True)
     monkeypatch.setattr(idl_mod, "have_cyclonedds", lambda: True, raising=True)
+
+    # The command-behavior tests below exercise the inbound surface, which is
+    # now gated on DDS Security. They are not security tests, so run them under
+    # the explicit insecure opt-out; the dedicated gate tests control this env
+    # and a dds_security_config themselves.
+    monkeypatch.setenv("STRANDS_ROS2_BRIDGE_I_KNOW_THIS_IS_INSECURE", "1")
     return state
 
 
@@ -245,3 +269,128 @@ def test_missing_cyclonedds_raises_importerror(monkeypatch: pytest.MonkeyPatch) 
 
     with pytest.raises(ImportError):
         HardwareRtpsBridge(_FakeRobot())  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# DDS Security gate on the inbound command surface
+# ---------------------------------------------------------------------------
+
+_VALID_SECURITY = {
+    "identity_ca": "file:/etc/dds/identity_ca.pem",
+    "certificate": "file:/etc/dds/participant_cert.pem",
+    "private_key": "file:/etc/dds/participant_key.pem",
+    "governance": "file:/etc/dds/governance.p7s",
+    "permissions": "file:/etc/dds/permissions.p7s",
+}
+
+
+def test_command_surface_refuses_without_security_or_optout(
+    fake_cyclonedds: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # An enabled inbound command surface drives the physical arm, so without a
+    # dds_security_config and without the explicit opt-out the bridge refuses.
+    monkeypatch.delenv("STRANDS_ROS2_BRIDGE_I_KNOW_THIS_IS_INSECURE", raising=False)
+    with pytest.raises(ValueError, match="unsecured DDS graph"):
+        _bridge(_FakeRobot())
+
+
+def test_command_surface_allowed_with_insecure_optout(
+    fake_cyclonedds: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("STRANDS_ROS2_BRIDGE_I_KNOW_THIS_IS_INSECURE", "yes")
+    b = _bridge(_FakeRobot())
+    assert b._enable_commands is True
+    b.shutdown()
+
+
+def test_command_surface_allowed_with_security_config_when_env_unset(
+    fake_cyclonedds: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("STRANDS_ROS2_BRIDGE_I_KNOW_THIS_IS_INSECURE", raising=False)
+    b = _bridge(_FakeRobot(), dds_security_config=dict(_VALID_SECURITY))
+    assert b._enable_commands is True
+    b.shutdown()
+
+
+def test_telemetry_only_bridge_is_not_gated(fake_cyclonedds: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> None:
+    # enable_commands=False is publish-only: no inbound surface, so no gate.
+    monkeypatch.delenv("STRANDS_ROS2_BRIDGE_I_KNOW_THIS_IS_INSECURE", raising=False)
+    b = _bridge(_FakeRobot(), enable_commands=False)
+    assert b._enable_commands is False
+    b.shutdown()
+
+
+def test_security_config_missing_required_key_raises(fake_cyclonedds: dict[str, Any]) -> None:
+    incomplete = dict(_VALID_SECURITY)
+    del incomplete["private_key"]
+    with pytest.raises(ValueError, match="missing required keys"):
+        _bridge(_FakeRobot(), dds_security_config=incomplete)
+
+
+def test_security_config_wires_plugins_and_credentials_into_participant_qos(
+    fake_cyclonedds: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("STRANDS_ROS2_BRIDGE_I_KNOW_THIS_IS_INSECURE", raising=False)
+    b = _bridge(_FakeRobot(), dds_security_config=dict(_VALID_SECURITY))
+    participant = fake_cyclonedds["participants"][-1]
+    assert participant.qos is not None
+    props = {p.name: p.value for p in participant.qos.policies}
+    # Builtin DDS-Security plugins are wired automatically.
+    assert props["dds.sec.auth.library.path"] == "dds_security_auth"
+    assert props["dds.sec.crypto.library.path"] == "dds_security_crypto"
+    assert props["dds.sec.access.library.path"] == "dds_security_ac"
+    # Operator credentials are mapped to their dds.sec.* property names.
+    assert props["dds.sec.auth.identity_ca"] == _VALID_SECURITY["identity_ca"]
+    assert props["dds.sec.auth.identity_certificate"] == _VALID_SECURITY["certificate"]
+    assert props["dds.sec.auth.private_key"] == _VALID_SECURITY["private_key"]
+    assert props["dds.sec.access.governance"] == _VALID_SECURITY["governance"]
+    assert props["dds.sec.access.permissions"] == _VALID_SECURITY["permissions"]
+    # Optional permissions_ca absent -> property not set.
+    assert "dds.sec.access.permissions_ca" not in props
+    b.shutdown()
+
+
+def test_telemetry_only_participant_has_no_security_qos(fake_cyclonedds: dict[str, Any]) -> None:
+    b = _bridge(enable_commands=False)  # no robot, no config
+    assert fake_cyclonedds["participants"][-1].qos is None
+    b.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Joint position bounds enforcement on the inbound command surface
+# ---------------------------------------------------------------------------
+
+
+def test_joint_limits_apply_in_range_command(fake_cyclonedds: dict[str, Any]) -> None:
+    robot = _FakeRobot()
+    b = _bridge(robot, joint_limits={"a": (-1.0, 1.0), "b": (-1.0, 1.0)})
+    b._on_command(_JointState(name=["a", "b"], position=[0.5, -0.5]))
+    assert robot.sent_actions == [{"a": 0.5, "b": -0.5}]
+    b.shutdown()
+
+
+def test_joint_limits_reject_whole_command_when_one_joint_out_of_range(
+    fake_cyclonedds: dict[str, Any],
+) -> None:
+    # One joint out of range -> the ENTIRE command is dropped (no partial apply).
+    robot = _FakeRobot()
+    b = _bridge(robot, joint_limits={"a": (-1.0, 1.0), "b": (-1.0, 1.0)})
+    b._on_command(_JointState(name=["a", "b"], position=[0.5, 9.0]))
+    assert robot.sent_actions == []
+    b.shutdown()
+
+
+def test_joint_limits_do_not_constrain_undeclared_joints(fake_cyclonedds: dict[str, Any]) -> None:
+    robot = _FakeRobot()
+    b = _bridge(robot, joint_limits={"a": (-1.0, 1.0)})
+    # "b" has no declared bound -> not constrained.
+    b._on_command(_JointState(name=["a", "b"], position=[0.5, 100.0]))
+    assert robot.sent_actions == [{"a": 0.5, "b": 100.0}]
+    b.shutdown()
+
+
+def test_invalid_joint_limits_raise_at_construction(fake_cyclonedds: dict[str, Any]) -> None:
+    with pytest.raises(ValueError, match="min .* > max|must be a"):
+        _bridge(_FakeRobot(), joint_limits={"a": (1.0, -1.0)})
+    with pytest.raises(ValueError, match="must be a"):
+        _bridge(_FakeRobot(), joint_limits={"a": 5.0})  # type: ignore[dict-item]


### PR DESCRIPTION
## Problem

The ROS 2 hardware bridges expose an inbound `/<robot>/joint_command` topic that forwards straight into `Robot.send_action` - the one path on the DDS graph that can drive a physical arm. Two gaps:

1. The pure-RTPS bridge (`HardwareRtpsBridge`, cyclonedds) creates its `DomainParticipant` with no DDS Security, so on a shared domain any participant can publish a `joint_command` and move the arm. There was no gate forcing an operator to either secure the graph or knowingly accept the risk.
2. There was no bound on commanded joint positions - a malformed or hostile command could drive joints anywhere within actuator range.

## Change

### DDS Security gate (`HardwareRtpsBridge`)
When an inbound command surface is enabled (`enable_commands=True` with a bound robot), the bridge now refuses to start unless one of:
- a `dds_security_config` dict is supplied (`identity_ca`, `certificate`, `private_key`, `governance`, `permissions`; `permissions_ca` optional), or
- the operator sets `STRANDS_ROS2_BRIDGE_I_KNOW_THIS_IS_INSECURE=1` (truthy `1`/`true`/`yes`).

The credentials are wired into the cyclonedds `DomainParticipant` QoS alongside the builtin DDS-Security plugins, so both the outbound telemetry and the inbound command surface ride an authenticated, access-controlled graph. Telemetry-only bridges (`enable_commands=False`) are publish-only and are not gated. The second-factor env mirrors the existing mesh `STRANDS_MESH_I_KNOW_THIS_IS_INSECURE` contract.

### Joint position bounds (`RosTelemetryBase._command_action`)
Optional `joint_limits={motor: (min, max)}` range-checks every inbound command. If any commanded joint falls outside its declared range the entire command is rejected - no partial application - so one out-of-range joint can never drive part of the arm while the rest holds. Joints without a declared bound are unconstrained. Enforcement lives in the shared base, so both the rclpy and RTPS transports inherit it.

### Threading through `Robot()`
`Robot()` / `hardware_robot.Robot.__init__` accept `joint_limits` (threaded into whichever bridge is built) and `dds_security_config` (consumed by the RTPS transport). DDS credentials with `ros2_transport="rclpy"` raise rather than silently no-op (rclpy DDS Security is configured at the ROS 2 RMW keystore/env layer); a safety/security config supplied with `ros2_bridge=False` is likewise rejected. All inputs are validated at construction (fail fast on malformed limits / incomplete config).

## Tests
Regression tests in `tests/test_hardware_rtps_bridge.py` and `tests/test_hardware_ros_bridge.py` cover: gate refuse-to-start, env opt-out, valid config, security-QoS wiring (plugin + `dds.sec.*` property names), telemetry-only ungated, missing-key rejection; whole-command rejection on an out-of-range joint, undeclared joints unconstrained, malformed-limits rejection; and the `Robot()` threading guards. The gate and bounds tests fail on pre-change code (no gate, `joint_limits` kwarg absent) and pass after.

Local gate green: `ruff check` + `ruff format --check` + `mypy strands_robots tests tests_integ` clean; the ROS/RTPS/hardware suites pass (`tests/test_hardware_rtps_bridge.py`, `tests/test_hardware_ros_bridge.py`, `tests/test_ros_telemetry_topic_parity.py`, mesh + sim ROS bridges, `use_ros`/`use_rtps` tools).

No visual artifact: this is a transport/security change with no simulation, policy, rendering, recording, or asset behavior.

## Docs
`docs/rtps-integration.md` (new "Securing the inbound command surface" section), `docs/ros2-integration.md`, `docs/security.md`, and the README environment-variable table.