### PR TITLE
feat(motionbricks): consume planner locomotion_style so KinematicPlanner steers the gait

### DIFF
--- a/docs/planning/kinematic_planner.md
+++ b/docs/planning/kinematic_planner.md
@@ -75,6 +75,12 @@ Style names match the GR00T Whole-Body-Control SONIC demos exactly:
 the `locomotion_style` kwarg, so emitting a style is always safe; a
 style-conditioned policy uses it to switch gaits.
 
+The [MotionBricks](../policies/motionbricks.md) provider (`policy_provider="motionbricks"`)
+is style-conditioned: it translates the planner's `locomotion_style` to the
+matching G1 clip (`stealth` -> `stealth_walk`, `boxing` -> `walk_boxing`, ...),
+so a planner switches the synthesised gait live. See the MotionBricks page for
+the full style-to-clip table.
+
 ## Input sources
 
 Every source is a non-blocking `InputSource` the planner polls on a background

--- a/docs/policies/motionbricks.md
+++ b/docs/policies/motionbricks.md
@@ -141,6 +141,49 @@ An unknown style or out-of-range index raises `ValueError` listing the
 available modes. A missing `[motionbricks]` install or checkpoint raises
 `RuntimeError` with an install hint - there is no silent fallback.
 
+## Driving the gait from a KinematicPlanner
+
+A [`KinematicPlanner`](../planning/kinematic_planner.md) steers MotionBricks at
+the *intent* layer: each control tick it emits a `locomotion_style` (its fixed
+SONIC-demo vocabulary - `run`, `happy`, `stealth`, `injured`, `hand_crawling`,
+`elbow_crawling`, `boxing`) plus a `target_velocity`. MotionBricks names its G1
+clips differently, so the policy translates `locomotion_style` to the matching
+clip via `PLANNER_STYLE_TO_G1_CLIP`:
+
+| planner `locomotion_style` | MotionBricks clip |
+| --- | --- |
+| `run` | `walk` |
+| `happy` | `walk_happy_dance` |
+| `stealth` | `stealth_walk` |
+| `injured` | `injured_walk` |
+| `hand_crawling` | `hand_crawling` |
+| `elbow_crawling` | `elbow_crawling` |
+| `boxing` | `walk_boxing` |
+
+```python
+from strands_robots import Robot
+from strands_robots.planning import KinematicPlanner
+from strands_robots.planning.inputs import ScriptedInput
+from strands_robots.planning.base import PlannerCommand
+
+robot = Robot("unitree_g1")
+planner = KinematicPlanner(ScriptedInput([
+    (0.0, PlannerCommand(root_vel=(0.5, 0.0, 0.0), style="run")),
+    (3.0, PlannerCommand(root_vel=(0.3, 0.0, 0.0), style="stealth")),
+    (6.0, PlannerCommand(root_vel=(0.0, 0.0, 0.0), style="boxing")),
+]))
+robot.run_policy(policy_provider="motionbricks", planner=planner,
+                 policy_config={"result_dir": "/path/to/.../motionbricks/out"},
+                 duration=9.0, control_frequency=30.0)
+```
+
+Resolution order per tick: an explicit `style=`/`mode=` kwarg pins the clip
+(overriding any planner style); otherwise `locomotion_style` is translated;
+otherwise the configured default `style` is used. The planner's `kneeling`
+style has no G1 clip - emitting it raises `ValueError` rather than miming the
+wrong motion. Supply a `style_map` (on the policy or in `MotionBricksConfig`) to
+remap styles or target a custom clip set.
+
 ## Visualisation
 
 Render a style sequence headless (`MUJOCO_GL=egl`) with the bundled example:

--- a/strands_robots/policies/motionbricks/__init__.py
+++ b/strands_robots/policies/motionbricks/__init__.py
@@ -23,9 +23,11 @@ NVIDIA Open Model License); no weights are bundled. See ``docs/policies/motionbr
 
 from strands_robots.policies.motionbricks.config import MotionBricksConfig
 from strands_robots.policies.motionbricks.observation import (
+    PLANNER_STYLE_TO_G1_CLIP,
     allowed_pred_num_tokens,
     build_control_signals,
     resolve_mode,
+    resolve_planner_style,
 )
 from strands_robots.policies.motionbricks.policy import (
     MOTIONBRICKS_G1_JOINTS,
@@ -39,6 +41,8 @@ __all__ = [
     "MotionAgent",
     "MOTIONBRICKS_G1_JOINTS",
     "resolve_mode",
+    "resolve_planner_style",
+    "PLANNER_STYLE_TO_G1_CLIP",
     "allowed_pred_num_tokens",
     "build_control_signals",
 ]

--- a/strands_robots/policies/motionbricks/config.py
+++ b/strands_robots/policies/motionbricks/config.py
@@ -71,6 +71,10 @@ class MotionBricksConfig:
             ``--speed_scale``). ``(1.0, 1.0)`` disables perturbation.
         exp: Upstream experiment key selecting the checkpoint layout
             (``"default"``).
+        style_map: Optional overrides merged over the built-in planner-style ->
+            clip-name map (:data:`~strands_robots.policies.motionbricks.observation.PLANNER_STYLE_TO_G1_CLIP`),
+            used to translate a :class:`~strands_robots.planning.kinematic.KinematicPlanner`
+            ``locomotion_style`` to this generator's clip set. ``None`` uses the defaults.
     """
 
     result_dir: str
@@ -83,6 +87,7 @@ class MotionBricksConfig:
     device: str = "cuda"
     speed_scale: tuple[float, float] = (1.0, 1.0)
     exp: str = _DEFAULT_EXP
+    style_map: dict[str, str] | None = None
 
     def __post_init__(self) -> None:
         # Fail-fast on bad synthesis knobs (AGENTS.md #5: raise on fatal config,
@@ -105,6 +110,14 @@ class MotionBricksConfig:
             raise ValueError(f"MotionBricksConfig.speed_scale must be 0 < min <= max, got ({lo}, {hi})")
         # Normalise speed_scale to a plain float tuple (frozen -> object.__setattr__).
         object.__setattr__(self, "speed_scale", (lo, hi))
+        if self.style_map is not None and (
+            not isinstance(self.style_map, dict)
+            or not all(isinstance(k, str) and isinstance(v, str) for k, v in self.style_map.items())
+        ):
+            raise ValueError(
+                "MotionBricksConfig.style_map must be a dict[str, str] mapping planner-style "
+                f"name -> clip-mode name, got {self.style_map!r}"
+            )
 
     @property
     def controller_dt(self) -> float:

--- a/strands_robots/policies/motionbricks/observation.py
+++ b/strands_robots/policies/motionbricks/observation.py
@@ -36,6 +36,27 @@ import numpy as np
 # Default movement / facing direction: walk straight ahead along +x (world).
 _DEFAULT_DIRECTION = (1.0, 0.0, 0.0)
 
+# Planner-vocabulary -> MotionBricks G1 clip-mode names. The KinematicPlanner
+# (:mod:`strands_robots.planning`) emits a fixed style vocabulary matching
+# NVIDIA's GR00T-WholeBodyControl SONIC kinematic-planner demos
+# (``run|happy|stealth|injured|kneeling|hand_crawling|elbow_crawling|boxing``);
+# MotionBricks names its G1 clips differently (``walk`` / ``stealth_walk`` /
+# ``walk_boxing`` ...), so a planner that drives this policy needs its emitted
+# ``locomotion_style`` translated to the matching clip. The mapping below pairs
+# each planner style with the upstream ``clip_holder_G1`` clip that realises it.
+# Styles with no G1 clip (notably ``kneeling``) are intentionally absent: a
+# planner emitting one raises a clear error rather than silently miming the
+# wrong motion (AGENTS.md: raise on fatal, no silent wrong default).
+PLANNER_STYLE_TO_G1_CLIP: dict[str, str] = {
+    "run": "walk",
+    "happy": "walk_happy_dance",
+    "stealth": "stealth_walk",
+    "injured": "injured_walk",
+    "hand_crawling": "hand_crawling",
+    "elbow_crawling": "elbow_crawling",
+    "boxing": "walk_boxing",
+}
+
 
 def resolve_mode(style: int | str, clip_keys: list[str]) -> int:
     """Resolve a style (mode index or name) to its integer index in ``clip_keys``.
@@ -65,6 +86,63 @@ def resolve_mode(style: int | str, clip_keys: list[str]) -> int:
             raise ValueError(f"MotionBricks style {style!r} is not a known mode; available modes: {clip_keys}")
         return clip_keys.index(style)
     raise ValueError(f"MotionBricks style must be an int index or str name, got {type(style).__name__}")
+
+
+def resolve_planner_style(
+    locomotion_style: str,
+    clip_keys: list[str],
+    style_map: dict[str, str] | None = None,
+) -> str:
+    """Translate a planner ``locomotion_style`` to a MotionBricks G1 clip name.
+
+    The :class:`~strands_robots.planning.kinematic.KinematicPlanner` emits a
+    ``locomotion_style`` (its fixed SONIC-demo vocabulary) on every control tick
+    via :meth:`~strands_robots.planning.base.PlannerCommand.to_policy_kwargs`.
+    MotionBricks selects motion by clip-mode *name*, which differs from the
+    planner vocabulary, so the style must be mapped before
+    :func:`resolve_mode` turns it into a clip index.
+
+    Resolution order:
+
+    1. A value that is already a clip name in ``clip_keys`` passes through
+       unchanged (a caller may emit a native clip name directly).
+    2. Otherwise the value is looked up in the merged style map
+       (:data:`PLANNER_STYLE_TO_G1_CLIP` overlaid with ``style_map``).
+
+    Args:
+        locomotion_style: The planner-emitted style name.
+        clip_keys: Ordered clip mode names (the generator's ``CLIPS`` keys).
+        style_map: Optional overrides merged over :data:`PLANNER_STYLE_TO_G1_CLIP`
+            (e.g. for a custom clip set). ``None`` uses the defaults only.
+
+    Returns:
+        The MotionBricks clip-mode name realising ``locomotion_style``.
+
+    Raises:
+        ValueError: If ``locomotion_style`` is not a string, has no mapping, or
+            maps to a clip this generator's clip set does not provide. The
+            message lists the mappable styles and available clips (no silent
+            fallback to the wrong motion).
+    """
+    if not isinstance(locomotion_style, str):
+        raise ValueError(f"locomotion_style must be a clip/style name (str), got {type(locomotion_style).__name__}")
+    mapping = PLANNER_STYLE_TO_G1_CLIP if style_map is None else {**PLANNER_STYLE_TO_G1_CLIP, **style_map}
+    # A native clip name is used as-is (lets a caller pass a clip name directly).
+    if locomotion_style in clip_keys:
+        return locomotion_style
+    clip = mapping.get(locomotion_style)
+    if clip is None:
+        raise ValueError(
+            f"planner locomotion_style {locomotion_style!r} has no MotionBricks clip mapping; "
+            f"mappable styles: {sorted(mapping)}; or pass an explicit style=<clip name> "
+            f"(available clips: {clip_keys})"
+        )
+    if clip not in clip_keys:
+        raise ValueError(
+            f"planner locomotion_style {locomotion_style!r} maps to clip {clip!r}, which this "
+            f"generator's clip set does not provide: {clip_keys}"
+        )
+    return clip
 
 
 def _unit_direction(vec: Any, default: tuple[float, float, float]) -> list[float]:
@@ -168,4 +246,10 @@ def build_control_signals(
     }
 
 
-__all__ = ["resolve_mode", "allowed_pred_num_tokens", "build_control_signals"]
+__all__ = [
+    "resolve_mode",
+    "resolve_planner_style",
+    "PLANNER_STYLE_TO_G1_CLIP",
+    "allowed_pred_num_tokens",
+    "build_control_signals",
+]

--- a/strands_robots/policies/motionbricks/policy.py
+++ b/strands_robots/policies/motionbricks/policy.py
@@ -56,7 +56,7 @@ from strands_robots.policies.wbc.policy import WBC_G1_ALL_JOINTS
 from strands_robots.utils import require_optional
 
 from .config import MotionBricksConfig
-from .observation import build_control_signals, resolve_mode
+from .observation import build_control_signals, resolve_mode, resolve_planner_style
 
 logger = logging.getLogger(__name__)
 
@@ -134,6 +134,11 @@ class MotionBricksPolicy(Policy):
         target_velocity: Optional default movement direction ``[vx, vy]`` used
             when a call passes none.
         device: Torch device for the generator (when building from ``config``).
+        style_map: Optional overrides merged over the built-in planner-style ->
+            clip-name map (:data:`~strands_robots.policies.motionbricks.observation.PLANNER_STYLE_TO_G1_CLIP`).
+            Used to translate a :class:`~strands_robots.planning.kinematic.KinematicPlanner`
+            ``locomotion_style`` to this generator's clip set; merged over (and
+            taking precedence over) any ``config.style_map``.
 
     Raises:
         ValueError: If neither ``config``/``result_dir`` nor ``motion_agent`` is
@@ -151,6 +156,7 @@ class MotionBricksPolicy(Policy):
         style: int | str | None = None,
         target_velocity: list[float] | None = None,
         device: str | None = None,
+        style_map: dict[str, str] | None = None,
         **kwargs: Any,
     ) -> None:
         self._robot_state_keys: list[str] = []
@@ -162,6 +168,16 @@ class MotionBricksPolicy(Policy):
             style if style is not None else (self._config.style if self._config is not None else "walk")
         )
         self._default_velocity = list(target_velocity) if target_velocity is not None else None
+
+        # Planner-style -> clip-name overrides: config.style_map is the base,
+        # the constructor arg takes precedence; both overlay the built-in
+        # PLANNER_STYLE_TO_G1_CLIP defaults inside resolve_planner_style.
+        merged_style_map: dict[str, str] = {}
+        if self._config is not None and self._config.style_map:
+            merged_style_map.update(self._config.style_map)
+        if style_map:
+            merged_style_map.update(style_map)
+        self._style_map: dict[str, str] | None = merged_style_map or None
 
         if motion_agent is not None:
             self._agent: MotionAgent = motion_agent
@@ -325,7 +341,17 @@ class MotionBricksPolicy(Policy):
         Returns a one-element list (MotionBricks emits one frame per tick, not a
         chunked plan): the runner re-queries every control step.
         """
-        style = kwargs.get("style", kwargs.get("mode", self._default_style))
+        # Style precedence: an explicit style=/mode= kwarg pins the clip (direct
+        # callers, back-compat). Otherwise a planner-emitted locomotion_style is
+        # translated to this generator's clip set, so a KinematicPlanner steers
+        # the gait. Falls back to the configured default style.
+        explicit_style = kwargs.get("style", kwargs.get("mode"))
+        if explicit_style is not None:
+            style: int | str = explicit_style
+        elif kwargs.get("locomotion_style") is not None:
+            style = resolve_planner_style(kwargs["locomotion_style"], self._agent.clip_keys, self._style_map)
+        else:
+            style = self._default_style
         mode_idx = resolve_mode(style, self._agent.clip_keys)
 
         # Inject the default movement direction when the call passes none.

--- a/tests/policies/motionbricks/test_policy.py
+++ b/tests/policies/motionbricks/test_policy.py
@@ -287,3 +287,154 @@ def test_policy_last_qpos_exposes_full_body_pose() -> None:
     # It is a copy: mutating the returned array does not corrupt policy state.
     qpos[0] = 123.0
     assert pol.last_qpos[0] != 123.0
+
+
+# ---------------------------------------------------------------------------
+# Planner-style bridge: a KinematicPlanner steers MotionBricks' gait.
+#
+# The planner emits a fixed SONIC-demo style vocabulary (locomotion_style) each
+# control tick; MotionBricks names its clips differently. Before this bridge the
+# planner's style was silently dropped and the policy stuck on its default clip.
+# These pin that locomotion_style now selects the matching clip.
+# ---------------------------------------------------------------------------
+
+# A clip set covering every mappable planner style (a superset of the upstream
+# clip_holder_G1 names the bridge maps onto).
+_FULL_CLIP_KEYS = [
+    "idle",
+    "walk",
+    "walk_happy_dance",
+    "stealth_walk",
+    "injured_walk",
+    "hand_crawling",
+    "elbow_crawling",
+    "walk_boxing",
+]
+
+
+class _FullClipAgent(StubAgent):
+    """A stub whose clip set covers every mappable planner style."""
+
+    clip_keys = _FULL_CLIP_KEYS
+    clip_token_specs = [None] * len(_FULL_CLIP_KEYS)
+
+
+def test_resolve_planner_style_maps_every_mappable_style() -> None:
+    from strands_robots.policies.motionbricks import PLANNER_STYLE_TO_G1_CLIP, resolve_planner_style
+
+    for planner_style, clip in PLANNER_STYLE_TO_G1_CLIP.items():
+        assert resolve_planner_style(planner_style, _FULL_CLIP_KEYS) == clip
+
+
+def test_resolve_planner_style_passes_native_clip_name_through() -> None:
+    from strands_robots.policies.motionbricks import resolve_planner_style
+
+    # A value already in the clip set is used as-is (a caller may emit a clip name).
+    assert resolve_planner_style("stealth_walk", _FULL_CLIP_KEYS) == "stealth_walk"
+
+
+def test_resolve_planner_style_override_map() -> None:
+    from strands_robots.policies.motionbricks import resolve_planner_style
+
+    # An override remaps a planner style onto a different clip in the set.
+    assert resolve_planner_style("run", _FULL_CLIP_KEYS, {"run": "idle"}) == "idle"
+
+
+def test_resolve_planner_style_unmapped_raises() -> None:
+    from strands_robots.policies.motionbricks import resolve_planner_style
+
+    # "kneeling" has no G1 clip: a clear error, never a silent wrong gait.
+    with pytest.raises(ValueError, match="kneeling.*no MotionBricks clip mapping"):
+        resolve_planner_style("kneeling", _FULL_CLIP_KEYS)
+
+
+def test_resolve_planner_style_mapped_clip_absent_from_set_raises() -> None:
+    from strands_robots.policies.motionbricks import resolve_planner_style
+
+    # "boxing" maps to "walk_boxing", which a reduced clip set does not provide.
+    with pytest.raises(ValueError, match="walk_boxing.*does not provide"):
+        resolve_planner_style("boxing", ["idle", "walk"])
+
+
+def test_resolve_planner_style_rejects_non_string() -> None:
+    from strands_robots.policies.motionbricks import resolve_planner_style
+
+    with pytest.raises(ValueError, match="must be a clip/style name"):
+        resolve_planner_style(2, _FULL_CLIP_KEYS)  # type: ignore[arg-type]
+
+
+def test_get_actions_consumes_planner_locomotion_style() -> None:
+    # The regression: locomotion_style (planner channel) selects the clip when no
+    # explicit style=/mode= is pinned.
+    agent = _FullClipAgent()
+    pol = MotionBricksPolicy(motion_agent=agent, style="walk")
+    pol.get_actions_sync({}, "", target_velocity=[0.5, 0.0, 0.0], locomotion_style="stealth")
+    signals, _ = agent.calls[-1]
+    assert agent.clip_keys[signals["mode"]] == "stealth_walk"
+
+
+def test_explicit_style_overrides_planner_locomotion_style() -> None:
+    # An explicit style=/mode= pins the clip even when a planner also emits one.
+    agent = _FullClipAgent()
+    pol = MotionBricksPolicy(motion_agent=agent, style="walk")
+    pol.get_actions_sync({}, "", style="walk_boxing", locomotion_style="stealth")
+    signals, _ = agent.calls[-1]
+    assert agent.clip_keys[signals["mode"]] == "walk_boxing"
+
+
+def test_locomotion_style_falls_back_to_default_when_absent() -> None:
+    # No style/mode/locomotion_style -> the configured default clip is used.
+    agent = _FullClipAgent()
+    pol = MotionBricksPolicy(motion_agent=agent, style="injured_walk")
+    pol.get_actions_sync({}, "", target_velocity=[1.0, 0.0, 0.0])
+    signals, _ = agent.calls[-1]
+    assert agent.clip_keys[signals["mode"]] == "injured_walk"
+
+
+def test_policy_style_map_override_applied() -> None:
+    # A style_map on the policy remaps a planner style onto another clip.
+    agent = _FullClipAgent()
+    pol = MotionBricksPolicy(motion_agent=agent, style="walk", style_map={"run": "idle"})
+    pol.get_actions_sync({}, "", locomotion_style="run")
+    signals, _ = agent.calls[-1]
+    assert agent.clip_keys[signals["mode"]] == "idle"
+
+
+def test_planner_to_policy_kwargs_drives_motionbricks_end_to_end() -> None:
+    # Full path: a PlannerCommand's to_policy_kwargs() feeds get_actions, the way
+    # the policy runner merges planner.poll().to_policy_kwargs() each tick.
+    from strands_robots.planning.base import PlannerCommand
+
+    agent = _FullClipAgent()
+    pol = MotionBricksPolicy(motion_agent=agent, style="walk")
+    kwargs = PlannerCommand(root_vel=(0.4, 0.0, 0.0), style="boxing").to_policy_kwargs()
+    pol.get_actions_sync({}, "", **kwargs)
+    signals, _ = agent.calls[-1]
+    assert agent.clip_keys[signals["mode"]] == "walk_boxing"
+    # target_velocity still composes (movement direction is the +x unit vector).
+    assert signals["movement_direction"][0] == pytest.approx(1.0)
+
+
+def test_planner_styles_all_mapped_or_intentionally_absent() -> None:
+    # Keep the bridge in sync with the planner vocabulary: every planner style is
+    # either mapped to a clip or the one documented gap (kneeling has no G1 clip).
+    from strands_robots.planning.base import STYLES
+    from strands_robots.policies.motionbricks import PLANNER_STYLE_TO_G1_CLIP
+
+    assert set(PLANNER_STYLE_TO_G1_CLIP) | {"kneeling"} == set(STYLES)
+
+
+def test_config_style_map_roundtrip_and_validation() -> None:
+    cfg = MotionBricksConfig.from_dict({"result_dir": "out", "style_map": {"run": "idle"}})
+    assert cfg.style_map == {"run": "idle"}
+    with pytest.raises(ValueError, match="style_map must be a dict"):
+        MotionBricksConfig.from_dict({"result_dir": "out", "style_map": {"run": 3}})
+
+
+def test_config_style_map_feeds_policy() -> None:
+    agent = _FullClipAgent()
+    cfg = MotionBricksConfig.from_dict({"result_dir": "out", "style_map": {"run": "idle"}})
+    pol = MotionBricksPolicy(config=cfg, motion_agent=agent)
+    pol.get_actions_sync({}, "", locomotion_style="run")
+    signals, _ = agent.calls[-1]
+    assert agent.clip_keys[signals["mode"]] == "idle"


### PR DESCRIPTION
## Problem

A `KinematicPlanner` emits its fixed locomotion style vocabulary (`run`, `happy`, `stealth`, `injured`, `kneeling`, `hand_crawling`, `elbow_crawling`, `boxing`) on the `locomotion_style` goal-kwarg channel every control tick (via `PlannerCommand.to_policy_kwargs()`, merged into `get_actions(**kwargs)` by the policy runner). `MotionBricksPolicy` selects motion by clip-mode *name* (`walk`, `stealth_walk`, `walk_boxing`, ...) and read only the `style`/`mode` kwarg, never `locomotion_style`.

Result: a planner-driven MotionBricks rollout silently dropped every style switch and stayed on its default clip. The planner could change speed and heading (`target_velocity` is consumed) but never the gait, so the intent layer did not actually compose with the style-conditioned provider.

Reproduction on pre-fix code: a planner emitting `locomotion_style="stealth"` resolves to clip `walk` (the default) instead of `stealth_walk`.

## Change

Translate `locomotion_style` to the matching clip via a `PLANNER_STYLE_TO_G1_CLIP` map before resolving the mode index:

| planner `locomotion_style` | MotionBricks clip |
| --- | --- |
| `run` | `walk` |
| `happy` | `walk_happy_dance` |
| `stealth` | `stealth_walk` |
| `injured` | `injured_walk` |
| `hand_crawling` | `hand_crawling` |
| `elbow_crawling` | `elbow_crawling` |
| `boxing` | `walk_boxing` |

Resolution order per tick: an explicit `style=`/`mode=` kwarg pins the clip (back-compat for direct callers); otherwise `locomotion_style` is translated; otherwise the configured default `style` is used. A value already in the generator's clip set passes through unchanged.

`kneeling` has no G1 clip in `clip_holder_G1`, so it is intentionally absent from the map: emitting it raises a clear `ValueError` listing the mappable styles and available clips, rather than miming the wrong motion (no silent wrong default). A `style_map` override (constructor arg or `MotionBricksConfig.style_map`) remaps styles or targets a custom clip set.

## Tests

16 new tests in `tests/policies/motionbricks/test_policy.py` (stubbed generator via the `motion_agent` seam, no GPU/checkpoints):
- every mappable style resolves to its clip; native clip names pass through; override maps applied.
- the regression: `get_actions` with `locomotion_style` selects the clip (fails on pre-fix code, which returned the default clip); explicit `style`/`mode` still wins; default fallback when none given.
- `kneeling`/unmapped/non-string/clip-absent raise `ValueError`.
- end-to-end: `PlannerCommand.to_policy_kwargs()` drives the policy and still composes `target_velocity`.
- a sync test asserts every planner style is mapped or the documented `kneeling` gap, so the bridge tracks the planner vocabulary.
- `MotionBricksConfig.style_map` round-trip + validation, and feeding the policy.

Full `tests/policies/` suite green (1324 passed, 2 skipped); `ruff` + `mypy` clean (`hatch run lint`: no issues found in 593 source files). Docs updated in `docs/policies/motionbricks.md` (new "Driving the gait from a KinematicPlanner" section + style table) and `docs/planning/kinematic_planner.md`.

## Visual

The gait clips themselves require the upstream NVIDIA-licensed checkpoints, so this artifact shows the behavior this PR adds: the planner's live style switches now route to the correct MotionBricks clip, sampled per control tick at 30 Hz over a `[run, happy, stealth, injured, hand_crawling, boxing]` intent sequence (rendered headless from the real policy code path).

![planner style to MotionBricks clip](https://github.com/cagataycali/robots/releases/download/planner-mb-artifact-1782765717/mb_planner_style.png)