### PR TITLE
feat(sim_managers): config-driven manager framework for RL sim environments

### DIFF
--- a/docs/training/managers.md
+++ b/docs/training/managers.md
@@ -1,0 +1,193 @@
+# Sim Managers: config-driven RL environments
+
+`strands_robots.sim_managers` is a backend-agnostic, config-driven composition
+layer for reinforcement-learning environments, modelled on the *manager* pattern
+used by Isaac Lab / RSL-RL. Instead of hand-wiring observation, reward,
+termination, and command logic inline for every task, you compose them from
+atomic, reusable **terms** described declaratively in a single config.
+
+```python
+from strands_robots.sim_managers import RewardManager, ObservationManager
+
+reward = RewardManager.from_config({
+    "terms": [
+        {"name": "track", "func": "track_lin_vel_xy_exp", "weight": 1.0,
+         "params": {"std": 0.25}},
+        {"name": "z_vel", "func": "lin_vel_z_l2", "weight": -2.0},
+    ]
+})
+r = reward.compute(state)        # scalar reward
+reward.term_values               # {"track": ..., "z_vel": ...}
+```
+
+## Why managers
+
+Without an abstraction, every example re-implements observation assembly, reward
+math, and termination checks. That blocks curriculum learning, multi-task
+training (locomotion and whole-body tracking share most terms), and reuse. The
+manager pattern makes the whole RL recipe a YAML file: change a weight, add a
+penalty, or swap a command source without touching Python.
+
+## Core concepts
+
+### EnvState - the backend-agnostic contract
+
+Every term reads from one object: `EnvState`. A simulator backend (or a rollout
+driver) populates it each control step; terms never touch the simulator, so the
+*same* recipe runs on MuJoCo, MJWarp, Isaac Gym, Isaac Sim, or Newton.
+
+```python
+from strands_robots.sim_managers import EnvState
+import numpy as np
+
+state = EnvState(
+    joint_pos=np.zeros(12), joint_vel=np.zeros(12),
+    action=np.zeros(12), last_action=np.zeros(12),
+    base_lin_vel=np.array([0.5, 0.0, 0.0]),     # base frame
+    base_ang_vel=np.array([0.0, 0.0, 0.1]),     # base frame
+    projected_gravity=np.array([0.0, 0.0, -1.0]),
+    base_height=0.78, dt=0.02, step_count=0, max_episode_length=1000,
+)
+```
+
+Velocities are expressed in the robot's **base frame**; `projected_gravity` is
+the gravity unit vector rotated into the base frame (`[0, 0, -1]` upright).
+Optional arrays (`joint_torque`, `joint_acc`, `default_joint_pos`) default to
+zeros sized to the joint count. See the `EnvState` docstring for the full field
+reference. A term that needs a field which was not populated raises a clear
+error rather than silently degrading.
+
+### Term - one atomic computation
+
+A `Term` subclass implements `__call__(state) -> value`. Terms are registered in
+a closed registry keyed by `(category, func_name)` via `@register_term`. Configs
+reference a term only by its `func` name; an unknown name is rejected (no
+`eval`), so configs are safe to parse from untrusted / LLM-authored YAML.
+
+```python
+from strands_robots.sim_managers import register_term, Term
+
+@register_term("reward", "my_penalty")
+class MyPenalty(Term):
+    def __init__(self, scale: float = 1.0, **params):
+        super().__init__(scale=scale, **params)
+        self.scale = scale
+    def __call__(self, state):
+        return self.scale * float((state.action ** 2).sum())
+```
+
+### Manager - combine terms into a result
+
+| Manager | `compute(state)` returns | Combination |
+|---|---|---|
+| `ObservationManager` | 1-D `float64` vector | scale -> clip -> concatenate (order preserved; `term_slices` maps label -> slice) |
+| `RewardManager` | scalar reward | `sum(weight * term(state) * dt)`; `term_values` holds the per-term breakdown |
+| `TerminationManager` | `TerminationResult` | classifies `time_out` (truncation) vs `terminated` (failure) |
+| `CommandManager` | `dict[str, vector]` | samples + resamples commands, writes them onto `state.commands` |
+
+The reward weight's **sign** distinguishes a reward (positive) from a penalty
+(negative), following the Isaac Lab convention. Reward contributions are scaled
+by `dt` by default so a recipe is invariant to control frequency
+(`scale_by_dt=False` to disable).
+
+## Config DSL
+
+A managers config is a mapping of manager keys to `{"terms": [...]}` blocks. Each
+term entry has:
+
+| Key | Applies to | Meaning |
+|---|---|---|
+| `func` | all | registered term name (required) |
+| `name` | all | instance label (defaults to `func`); must be unique per manager |
+| `params` | all | keyword arguments forwarded to the term constructor |
+| `weight` | reward | term weight (sign = reward vs penalty) |
+| `scale` | observation | multiplier applied before clipping |
+| `clip` | observation | `[low, high]` applied after scaling |
+
+```yaml
+command_manager:
+  terms:
+    - name: base_velocity
+      func: uniform_velocity
+      params: {lin_vel_x: [-1.0, 1.0], ang_vel_z: [-1.0, 1.0], resampling_time: 5.0}
+observation_manager:
+  terms:
+    - {func: base_lin_vel, scale: 2.0}
+    - {func: velocity_commands}
+    - {func: joint_pos}
+reward_manager:
+  terms:
+    - {name: track_lin, func: track_lin_vel_xy_exp, weight: 1.0, params: {std: 0.25}}
+    - {name: z_vel, func: lin_vel_z_l2, weight: -2.0}
+termination_manager:
+  terms:
+    - {func: time_out}
+    - {func: bad_orientation, params: {limit_angle: 1.0}}
+```
+
+Build the whole set at once:
+
+```python
+from strands_robots.sim_managers import build_managers, load_managers_config
+
+managers = build_managers(config_dict)            # from a dict
+managers = load_managers_config("recipe.yaml")    # from YAML or JSON
+
+managers.command.compute(state)        # publish commands first
+obs = managers.observation.compute(state)
+reward = managers.reward.compute(state)
+result = managers.termination.compute(state)
+```
+
+`build_managers` rejects unknown manager keys and unknown term `func` names with
+messages that list the valid options.
+
+## Term library
+
+Discover the registered terms at runtime with `list_terms()`. The first-class
+locomotion library ships:
+
+**Observation** (`base_lin_vel`, `base_ang_vel`, `projected_gravity`,
+`joint_pos` (relative to default), `joint_vel`, `last_action`,
+`velocity_commands`).
+
+**Reward** (`track_lin_vel_xy_exp`, `track_ang_vel_z_exp`, `lin_vel_z_l2`,
+`ang_vel_xy_l2`, `flat_orientation_l2`, `orientation_l2`, `dof_torques_l2`,
+`dof_acc_l2`, `dof_vel_l2`, `action_rate_l2`, `joint_pos_limits`,
+`joint_vel_limits`, `feet_air_time`, `feet_slide`, `alive`,
+`termination_penalty`). Tracking terms return a bounded `(0, 1]` Gaussian
+kernel; penalties return a squared magnitude (apply a negative weight).
+
+**Termination** (`time_out` (truncation), `bad_orientation`,
+`base_height_below_threshold`, `joint_pos_limit`).
+
+**Command** (`uniform_velocity` - samples `[vx, vy, wz]` from uniform ranges and
+resamples every `resampling_time` seconds; seed with `reset(rng=...)` for
+reproducibility).
+
+## Worked example
+
+`examples/sim_managers_locomotion.py` loads `sim_managers_locomotion.yaml`,
+builds the four managers, and steps a Unitree G1 in headless MuJoCo - feeding
+each step's physics state into the managers and printing the observation
+dimension, per-term reward breakdown, and termination classification. Its
+`_env_state_from_mujoco` helper shows exactly how a backend fills an `EnvState`
+from a floating-base model/data:
+
+```text
+robot=unitree_g1  control_dt=0.0200s  observation_dim=99
+episode ended at step 71: {'time_out': False, 'bad_orientation': True, ...}
+per-term reward contribution (summed):
+  dof_acc            -15.02715
+  ang_vel_xy          -0.86686
+  track_lin_vel       +0.30012
+  alive               +0.21600
+  ...
+```
+
+## Extending
+
+Register custom terms in any category with `@register_term(category, name)`;
+they immediately become available to the config DSL. Because terms read only the
+`EnvState` contract, a term written for MuJoCo runs unchanged on any other
+backend that can populate the same fields.

--- a/examples/sim_managers_locomotion.py
+++ b/examples/sim_managers_locomotion.py
@@ -1,0 +1,165 @@
+"""Drive a MuJoCo humanoid through the config-driven sim_managers framework.
+
+Builds a full locomotion env recipe (command + observation + reward +
+termination) from a single YAML file, then steps a Unitree G1 in headless
+MuJoCo and feeds each step's physics state into the managers. It prints the
+running observation dimension, the per-term reward breakdown, and the
+termination classification - demonstrating that the same declarative recipe
+that a trainer would consume runs end to end on real simulator data.
+
+The ``_env_state_from_mujoco`` helper shows how a backend populates the
+backend-agnostic :class:`~strands_robots.sim_managers.EnvState`: terms never
+touch MuJoCo, so the identical recipe runs on any simulator that can fill an
+EnvState.
+
+Run (headless):
+
+    MUJOCO_GL=egl python examples/sim_managers_locomotion.py
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import mujoco
+import numpy as np
+
+from strands_robots import create_simulation
+from strands_robots.sim_managers import EnvState, load_managers_config
+
+CONFIG_PATH = Path(__file__).with_suffix(".yaml")
+ROBOT = "unitree_g1"
+N_STEPS = 200
+SUBSTEPS = 10  # physics steps per control step
+
+
+def _env_state_from_mujoco(
+    model: mujoco.MjModel,
+    data: mujoco.MjData,
+    *,
+    last_action: np.ndarray,
+    dt: float,
+    step_count: int,
+    max_episode_length: int,
+) -> EnvState:
+    """Populate an EnvState from a floating-base MuJoCo model/data.
+
+    Assumes a free joint at the root: ``qpos[:3]`` base position, ``qpos[3:7]``
+    base quaternion ``[w, x, y, z]``, ``qvel[:3]`` world linear velocity,
+    ``qvel[3:6]`` world angular velocity, with the actuated DOFs following.
+    """
+    quat = np.array(data.qpos[3:7], dtype=np.float64)
+    inv_quat = np.zeros(4)
+    mujoco.mju_negQuat(inv_quat, quat)
+
+    base_lin_vel = np.zeros(3)
+    base_ang_vel = np.zeros(3)
+    projected_gravity = np.zeros(3)
+    mujoco.mju_rotVecQuat(base_lin_vel, np.array(data.qvel[:3]), inv_quat)
+    mujoco.mju_rotVecQuat(base_ang_vel, np.array(data.qvel[3:6]), inv_quat)
+    mujoco.mju_rotVecQuat(projected_gravity, np.array([0.0, 0.0, -1.0]), inv_quat)
+
+    joint_pos = np.array(data.qpos[7:], dtype=np.float64)
+    joint_vel = np.array(data.qvel[6:], dtype=np.float64)
+    joint_torque = np.array(data.qfrc_actuator[6:], dtype=np.float64)
+    joint_acc = np.array(data.qacc[6:], dtype=np.float64)
+
+    return EnvState(
+        joint_pos=joint_pos,
+        joint_vel=joint_vel,
+        action=last_action,
+        last_action=last_action,
+        base_lin_vel=base_lin_vel,
+        base_ang_vel=base_ang_vel,
+        projected_gravity=projected_gravity,
+        base_height=float(data.qpos[2]),
+        base_quat=quat,
+        joint_torque=joint_torque,
+        joint_acc=joint_acc,
+        dt=dt,
+        step_count=step_count,
+        max_episode_length=max_episode_length,
+    )
+
+
+def _extract_png_bytes(render: object) -> bytes | None:
+    """Pull the PNG bytes out of a ``render()`` agent-tool content payload."""
+    if not isinstance(render, dict):
+        return None
+    for block in render.get("content", []) or []:
+        image = block.get("image") if isinstance(block, dict) else None
+        if isinstance(image, dict):
+            source = image.get("source", {})
+            data = source.get("bytes") if isinstance(source, dict) else None
+            if isinstance(data, bytes):
+                return data
+    return None
+
+
+def main() -> None:
+    os.environ.setdefault("MUJOCO_GL", "egl")
+    managers = load_managers_config(CONFIG_PATH)
+    assert managers.command and managers.observation and managers.reward and managers.termination
+
+    sim = create_simulation(backend="mujoco")
+    sim.create_world()
+    if sim.add_robot(ROBOT).get("status") != "success":
+        raise RuntimeError(f"failed to add robot {ROBOT!r}")
+    sim.reset()
+
+    model = sim._world._model
+    data = sim._world._data
+    dt = float(model.opt.timestep) * SUBSTEPS
+
+    rng = np.random.default_rng(0)
+    managers.command.reset(rng=rng)
+    managers.reward.reset()
+
+    n_act = int(model.nu)
+    last_action = np.zeros(n_act)
+    reward_totals: dict[str, float] = {}
+    total_reward = 0.0
+    obs_dim = 0
+
+    for step in range(N_STEPS):
+        sim.step(SUBSTEPS)
+        state = _env_state_from_mujoco(
+            model,
+            data,
+            last_action=last_action,
+            dt=dt,
+            step_count=step,
+            max_episode_length=N_STEPS,
+        )
+        managers.command.compute(state)
+        obs = managers.observation.compute(state)
+        obs_dim = obs.shape[0]
+        reward = managers.reward.compute(state)
+        result = managers.termination.compute(state)
+        total_reward += reward
+        for label, value in managers.reward.term_values.items():
+            reward_totals[label] = reward_totals.get(label, 0.0) + value
+        if result.done:
+            print(f"episode ended at step {step}: {result.terms}")
+            break
+
+    out_png = "/tmp/sim_managers_g1.png"
+    render = sim.render(width=640, height=480)
+    png_bytes = _extract_png_bytes(render)
+    if png_bytes is not None:
+        Path(out_png).write_bytes(png_bytes)
+        print(f"saved render still -> {out_png}")
+
+    print(f"\nrobot={ROBOT}  control_dt={dt:.4f}s  observation_dim={obs_dim}")
+    print(f"command sample (vx, vy, wz) = {np.round(state.command('base_velocity'), 3)}")
+    print(f"\ntotal reward over rollout: {total_reward:.4f}")
+    print("per-term reward contribution (summed):")
+    for label, value in sorted(reward_totals.items(), key=lambda kv: -abs(kv[1])):
+        print(f"  {label:<18} {value:+.5f}")
+
+    sim.destroy()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/sim_managers_locomotion.yaml
+++ b/examples/sim_managers_locomotion.yaml
@@ -1,0 +1,40 @@
+# Declarative locomotion env recipe consumed by sim_managers.
+# Build with: strands_robots.sim_managers.load_managers_config(<this file>)
+command_manager:
+  terms:
+    - name: base_velocity
+      func: uniform_velocity
+      params:
+        lin_vel_x: [-1.0, 1.0]
+        lin_vel_y: [-0.5, 0.5]
+        ang_vel_z: [-1.0, 1.0]
+        resampling_time: 5.0
+
+observation_manager:
+  terms:
+    - {func: base_lin_vel, scale: 2.0}
+    - {func: base_ang_vel, scale: 0.25}
+    - {func: projected_gravity}
+    - {func: velocity_commands}
+    - {func: joint_pos}
+    - {func: joint_vel, scale: 0.05}
+    - {func: last_action}
+
+reward_manager:
+  scale_by_dt: true
+  terms:
+    - {name: track_lin_vel, func: track_lin_vel_xy_exp, weight: 1.0, params: {std: 0.25}}
+    - {name: track_ang_vel, func: track_ang_vel_z_exp, weight: 0.5, params: {std: 0.25}}
+    - {name: lin_vel_z, func: lin_vel_z_l2, weight: -2.0}
+    - {name: ang_vel_xy, func: ang_vel_xy_l2, weight: -0.05}
+    - {name: flat_orientation, func: flat_orientation_l2, weight: -1.0}
+    - {name: dof_torques, func: dof_torques_l2, weight: -2.0e-5}
+    - {name: dof_acc, func: dof_acc_l2, weight: -2.5e-7}
+    - {name: action_rate, func: action_rate_l2, weight: -0.01}
+    - {name: alive, func: alive, weight: 0.15}
+
+termination_manager:
+  terms:
+    - {func: time_out}
+    - {func: bad_orientation, params: {limit_angle: 1.0}}
+    - {func: base_height_below_threshold, params: {min_height: 0.5}}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ nav:
 - Training:
   - Overview: training/overview.md
   - VLA-on-G1 Workflow: training/vla_workflow.md
+  - Sim Managers (RL recipes): training/managers.md
 - Recording & Datasets: recording.md
 - Locomotion Planning: planning/kinematic_planner.md
 - Examples:

--- a/strands_robots/sim_managers/__init__.py
+++ b/strands_robots/sim_managers/__init__.py
@@ -1,0 +1,56 @@
+"""Backend-agnostic, config-driven manager framework for sim environments.
+
+Compose observation / reward / termination / command recipes declaratively from
+atomic, reusable *terms* - the manager pattern used by Isaac Lab / RSL-RL. Every
+term reads only a backend-agnostic :class:`EnvState`, so the same recipe runs on
+MuJoCo, MJWarp, Isaac Gym, Isaac Sim, or Newton.
+
+Example::
+
+    from strands_robots.sim_managers import RewardManager, ObservationManager
+
+    reward = RewardManager.from_config({
+        "terms": [
+            {"name": "track", "func": "track_lin_vel_xy_exp", "weight": 1.0,
+             "params": {"std": 0.25}},
+            {"name": "z_vel", "func": "lin_vel_z_l2", "weight": -2.0},
+        ]
+    })
+    r = reward.compute(state)            # scalar reward
+    breakdown = reward.term_values       # per-term contributions
+
+Or build the whole set from one YAML file via :func:`load_managers_config`.
+"""
+
+from strands_robots.sim_managers.base import (
+    EnvState,
+    Manager,
+    Term,
+    TermSpec,
+    get_term_class,
+    list_terms,
+    register_term,
+)
+from strands_robots.sim_managers.command import CommandManager
+from strands_robots.sim_managers.config import ManagerSet, build_managers, load_managers_config
+from strands_robots.sim_managers.observation import ObservationManager
+from strands_robots.sim_managers.reward import RewardManager
+from strands_robots.sim_managers.termination import TerminationManager, TerminationResult
+
+__all__ = [
+    "EnvState",
+    "Term",
+    "TermSpec",
+    "Manager",
+    "register_term",
+    "get_term_class",
+    "list_terms",
+    "ObservationManager",
+    "RewardManager",
+    "TerminationManager",
+    "TerminationResult",
+    "CommandManager",
+    "ManagerSet",
+    "build_managers",
+    "load_managers_config",
+]

--- a/strands_robots/sim_managers/base.py
+++ b/strands_robots/sim_managers/base.py
@@ -1,0 +1,360 @@
+"""Backend-agnostic manager framework for declarative sim environments.
+
+This module is the foundation of :mod:`strands_robots.sim_managers`, a
+config-driven composition layer for reinforcement-learning environments modelled
+on the *manager* pattern used by Isaac Lab / RSL-RL (and Holosoma). It defines
+three primitives:
+
+- :class:`EnvState` - the **backend-agnostic contract**. Every term reads the
+  physics quantities it needs from an ``EnvState`` and nothing else, so the same
+  term works whether the underlying simulator is MuJoCo, MJWarp, Isaac Gym,
+  Isaac Sim, or Newton. A backend (or the caller driving a rollout) is
+  responsible for populating an ``EnvState`` each control step.
+- :class:`Term` - an atomic, composable unit of computation (one observation
+  group, one reward component, one termination check, one command source).
+- :class:`Manager` - an ordered collection of terms that the manager combines
+  into a single result (concatenated observation vector, summed reward, ...).
+
+Terms are registered in a closed :data:`TERM_REGISTRY` keyed by
+``(category, func_name)``. Managers are built from a declarative config that
+references terms by ``func`` name; an unknown name is rejected rather than
+``eval``-ed, so configs are safe to parse from untrusted / LLM-authored YAML
+(same safety posture as :mod:`strands_robots.simulation.predicates`).
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass, field
+from typing import Any, TypeVar
+
+import numpy as np
+import numpy.typing as npt
+
+FloatArray = npt.NDArray[np.float64]
+
+# Closed registry of term classes: TERM_REGISTRY[category][func_name] -> Term subclass.
+TERM_REGISTRY: dict[str, dict[str, type[Term]]] = {}
+
+_T = TypeVar("_T", bound="type[Term]")
+
+
+def register_term(category: str, name: str) -> Callable[[_T], _T]:
+    """Register a :class:`Term` subclass under ``(category, name)``.
+
+    Args:
+        category: Manager category, e.g. ``"observation"``, ``"reward"``,
+            ``"termination"``, ``"command"``.
+        name: The ``func`` name configs reference this term by. Must be unique
+            within the category.
+
+    Returns:
+        Class decorator that records the term in :data:`TERM_REGISTRY`.
+
+    Raises:
+        ValueError: If ``name`` is already registered in ``category``.
+    """
+
+    def _decorator(cls: _T) -> _T:
+        bucket = TERM_REGISTRY.setdefault(category, {})
+        if name in bucket:
+            raise ValueError(f"term {name!r} already registered in category {category!r}")
+        cls.func_name = name
+        cls.category = category
+        bucket[name] = cls
+        return cls
+
+    return _decorator
+
+
+def get_term_class(category: str, name: str) -> type[Term]:
+    """Look up a registered term class, raising a helpful error if absent.
+
+    Args:
+        category: Manager category the term lives in.
+        name: The registered ``func`` name.
+
+    Returns:
+        The :class:`Term` subclass.
+
+    Raises:
+        ValueError: If ``category`` or ``name`` is unknown. The message lists
+            the available names so a caller (or agent) can self-correct without
+            reading the source.
+    """
+    bucket = TERM_REGISTRY.get(category)
+    if bucket is None:
+        raise ValueError(f"unknown term category {category!r}; available: {sorted(TERM_REGISTRY)}")
+    cls = bucket.get(name)
+    if cls is None:
+        raise ValueError(f"unknown {category} term {name!r}; available: {sorted(bucket)}")
+    return cls
+
+
+def list_terms(category: str | None = None) -> dict[str, list[str]]:
+    """Return registered term names, optionally filtered to one ``category``.
+
+    Args:
+        category: If given, return only that category's terms; otherwise all.
+
+    Returns:
+        Mapping of category -> sorted list of registered ``func`` names.
+    """
+    if category is not None:
+        return {category: sorted(TERM_REGISTRY.get(category, {}))}
+    return {cat: sorted(bucket) for cat, bucket in TERM_REGISTRY.items()}
+
+
+def _as_float_array(value: Any, name: str) -> FloatArray:
+    """Coerce ``value`` to a 1-D float64 array, raising on ragged / bad input."""
+    arr = np.asarray(value, dtype=np.float64)
+    if arr.ndim == 0:
+        arr = arr.reshape(1)
+    if arr.ndim != 1:
+        raise ValueError(f"EnvState.{name} must be 1-D, got shape {arr.shape}")
+    return arr
+
+
+@dataclass
+class EnvState:
+    """Backend-agnostic snapshot of one robot at one control step.
+
+    This is the contract every :class:`Term` reads from. A simulator backend (or
+    a rollout driver) populates the fields it can; terms that need a field that
+    was not populated raise a clear error rather than silently degrading.
+
+    All array fields are 1-D ``float64`` (coerced on construction). Angular and
+    linear base velocities are expressed in the robot's **base frame**;
+    ``projected_gravity`` is the gravity unit vector rotated into the base frame
+    (``[0, 0, -1]`` when perfectly upright).
+
+    Args:
+        joint_pos: Per-joint positions, shape ``(n_joints,)``.
+        joint_vel: Per-joint velocities, shape ``(n_joints,)``.
+        action: Current control action, shape ``(n_actions,)``.
+        last_action: Previous control action, shape ``(n_actions,)``.
+        base_lin_vel: Base-frame linear velocity ``[vx, vy, vz]``.
+        base_ang_vel: Base-frame angular velocity ``[wx, wy, wz]``.
+        projected_gravity: Gravity unit vector in the base frame.
+        base_height: Height of the base above the ground plane (metres).
+        base_quat: Base orientation quaternion ``[w, x, y, z]`` (optional).
+        joint_torque: Per-joint applied torque (defaults to zeros).
+        joint_acc: Per-joint acceleration (defaults to zeros).
+        default_joint_pos: Nominal joint pose used for relative observations and
+            soft-limit penalties (defaults to zeros).
+        joint_pos_limits: Per-joint ``(lower, upper)`` hard limits, shape
+            ``(n_joints, 2)`` (optional).
+        joint_vel_limits: Per-joint velocity magnitude limits (optional).
+        joint_torque_limits: Per-joint torque magnitude limits (optional).
+        soft_joint_pos_limit_factor: Fraction of the hard position range treated
+            as the soft limit for penalties (Isaac Lab default ``0.9``).
+        feet_contact: Boolean per-foot contact flags (optional).
+        feet_air_time: Per-foot time since last contact, seconds (optional).
+        commands: Named command vectors, populated by a ``CommandManager``.
+        dt: Control timestep in seconds.
+        step_count: Number of control steps elapsed this episode.
+        max_episode_length: Episode length in control steps (for ``time_out``).
+        terminated: ``True`` when the episode ended for a non-timeout reason
+            (used by the ``termination_penalty`` reward term).
+        extras: Free-form backend-specific data terms may opt into (e.g.
+            ``feet_lin_vel`` for the ``feet_slide`` reward).
+    """
+
+    joint_pos: FloatArray
+    joint_vel: FloatArray
+    action: FloatArray
+    last_action: FloatArray
+    base_lin_vel: FloatArray = field(default_factory=lambda: np.zeros(3))
+    base_ang_vel: FloatArray = field(default_factory=lambda: np.zeros(3))
+    projected_gravity: FloatArray = field(default_factory=lambda: np.array([0.0, 0.0, -1.0]))
+    base_height: float = 0.0
+    base_quat: FloatArray | None = None
+    joint_torque: FloatArray | None = None
+    joint_acc: FloatArray | None = None
+    default_joint_pos: FloatArray | None = None
+    joint_pos_limits: FloatArray | None = None
+    joint_vel_limits: FloatArray | None = None
+    joint_torque_limits: FloatArray | None = None
+    soft_joint_pos_limit_factor: float = 0.9
+    feet_contact: npt.NDArray[np.bool_] | None = None
+    feet_air_time: FloatArray | None = None
+    commands: dict[str, FloatArray] = field(default_factory=dict)
+    dt: float = 0.02
+    step_count: int = 0
+    max_episode_length: int = 1000
+    terminated: bool = False
+    extras: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.joint_pos = _as_float_array(self.joint_pos, "joint_pos")
+        self.joint_vel = _as_float_array(self.joint_vel, "joint_vel")
+        self.action = _as_float_array(self.action, "action")
+        self.last_action = _as_float_array(self.last_action, "last_action")
+        self.base_lin_vel = _as_float_array(self.base_lin_vel, "base_lin_vel")
+        self.base_ang_vel = _as_float_array(self.base_ang_vel, "base_ang_vel")
+        self.projected_gravity = _as_float_array(self.projected_gravity, "projected_gravity")
+        n = self.joint_pos.shape[0]
+        if self.joint_vel.shape[0] != n:
+            raise ValueError(f"joint_vel length {self.joint_vel.shape[0]} != joint_pos length {n}")
+        if self.joint_torque is None:
+            self.joint_torque = np.zeros(n)
+        if self.joint_acc is None:
+            self.joint_acc = np.zeros(n)
+        if self.default_joint_pos is None:
+            self.default_joint_pos = np.zeros(n)
+
+    @property
+    def num_joints(self) -> int:
+        """Number of joints described by this state."""
+        return int(self.joint_pos.shape[0])
+
+    def command(self, name: str) -> FloatArray:
+        """Return a named command vector, raising a clear error if absent.
+
+        Args:
+            name: Command key, e.g. ``"base_velocity"``.
+
+        Returns:
+            The command vector.
+
+        Raises:
+            KeyError: If no command named ``name`` has been set. The message
+                lists the available command names.
+        """
+        try:
+            return self.commands[name]
+        except KeyError:
+            raise KeyError(
+                f"command {name!r} not set on EnvState; available: {sorted(self.commands)}. "
+                "A CommandManager populates commands before reward/observation terms read them."
+            ) from None
+
+
+class Term(ABC):
+    """Atomic, composable unit evaluated against an :class:`EnvState`.
+
+    Subclasses implement :meth:`__call__`. Constructor keyword arguments are the
+    term's declarative ``params`` and are stored on ``self.params`` (and as
+    attributes) so a config can configure a term without bespoke wiring.
+
+    Class attributes ``func_name`` and ``category`` are set by
+    :func:`register_term`.
+    """
+
+    func_name: str = ""
+    category: str = ""
+
+    def __init__(self, **params: Any) -> None:
+        self.params: dict[str, Any] = dict(params)
+
+    @abstractmethod
+    def __call__(self, state: EnvState) -> Any:
+        """Compute this term's value from ``state``."""
+        raise NotImplementedError
+
+    def reset(self, state: EnvState | None = None, *, rng: np.random.Generator | None = None) -> None:
+        """Reset any internal term state at episode start. No-op by default."""
+        return None
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}({self.func_name!r}, params={self.params})"
+
+
+@dataclass
+class TermSpec:
+    """Declarative description of one term inside a manager config.
+
+    Args:
+        name: Instance label (unique within a manager; used as the breakdown /
+            observation-slice key). Defaults to ``func`` when omitted.
+        func: Registered term ``func`` name to instantiate.
+        weight: Reward weight (reward manager only). Sign encodes reward vs
+            penalty; ignored by other managers.
+        scale: Observation scale applied before clipping (observation manager).
+        clip: Optional ``(low, high)`` clip applied after scaling (observation).
+        params: Keyword arguments forwarded to the term constructor.
+    """
+
+    func: str
+    name: str = ""
+    weight: float = 1.0
+    scale: float = 1.0
+    clip: tuple[float, float] | None = None
+    params: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            self.name = self.func
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TermSpec:
+        """Build a :class:`TermSpec` from a config dict, validating keys.
+
+        Args:
+            data: A single term entry from a manager config.
+
+        Returns:
+            The parsed spec.
+
+        Raises:
+            ValueError: If ``func`` is missing or an unknown key is present.
+        """
+        allowed = {"name", "func", "weight", "scale", "clip", "params"}
+        unknown = set(data) - allowed
+        if unknown:
+            raise ValueError(f"unknown term config keys {sorted(unknown)}; allowed: {sorted(allowed)}")
+        if "func" not in data:
+            raise ValueError(f"term config missing required 'func' key: {data}")
+        clip = data.get("clip")
+        clip_tuple = (float(clip[0]), float(clip[1])) if clip is not None else None
+        return cls(
+            func=str(data["func"]),
+            name=str(data.get("name", "")),
+            weight=float(data.get("weight", 1.0)),
+            scale=float(data.get("scale", 1.0)),
+            clip=clip_tuple,
+            params=dict(data.get("params", {})),
+        )
+
+
+class Manager(ABC):
+    """Ordered collection of terms combined into one result.
+
+    Args:
+        terms: ``(label, term)`` pairs in evaluation order. Labels must be
+            unique within the manager.
+
+    Raises:
+        ValueError: On duplicate labels.
+    """
+
+    category: str = ""
+
+    def __init__(self, terms: list[tuple[str, Term]]) -> None:
+        labels = [label for label, _ in terms]
+        dupes = {label for label in labels if labels.count(label) > 1}
+        if dupes:
+            raise ValueError(f"duplicate term labels in {type(self).__name__}: {sorted(dupes)}")
+        self._terms = terms
+
+    @property
+    def term_names(self) -> list[str]:
+        """Ordered list of term labels."""
+        return [label for label, _ in self._terms]
+
+    def __len__(self) -> int:
+        return len(self._terms)
+
+    def __iter__(self) -> Iterator[tuple[str, Term]]:
+        return iter(self._terms)
+
+    @abstractmethod
+    def compute(self, state: EnvState) -> Any:
+        """Combine all terms against ``state`` into the manager's result."""
+        raise NotImplementedError
+
+    def reset(self, state: EnvState | None = None, *, rng: np.random.Generator | None = None) -> None:
+        """Reset every term at episode start."""
+        for _, term in self._terms:
+            term.reset(state, rng=rng)

--- a/strands_robots/sim_managers/command/__init__.py
+++ b/strands_robots/sim_managers/command/__init__.py
@@ -1,0 +1,6 @@
+"""Command manager package."""
+
+from strands_robots.sim_managers.command import terms  # noqa: F401  (registers terms)
+from strands_robots.sim_managers.command.manager import CommandManager
+
+__all__ = ["CommandManager"]

--- a/strands_robots/sim_managers/command/manager.py
+++ b/strands_robots/sim_managers/command/manager.py
@@ -1,0 +1,64 @@
+"""Command manager - generates and refreshes command vectors on the EnvState."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from strands_robots.sim_managers.base import EnvState, FloatArray, Manager, Term, TermSpec, get_term_class
+
+
+class CommandManager(Manager):
+    """Generate named command vectors and write them onto the :class:`EnvState`.
+
+    Calling :meth:`compute` advances each command term's resample timer by
+    ``state.dt`` (when the term supports it) and writes the resulting vector into
+    ``state.commands[label]``, so downstream reward / observation terms can read
+    it via ``state.command(label)``.
+
+    Args:
+        terms: ``(label, term)`` pairs.
+
+    Raises:
+        ValueError: On duplicate labels.
+    """
+
+    category = "command"
+
+    def compute(self, state: EnvState) -> dict[str, FloatArray]:
+        """Refresh and publish all commands onto ``state.commands``.
+
+        Args:
+            state: The environment state to populate.
+
+        Returns:
+            The mapping of command label -> vector that was written.
+        """
+        out: dict[str, FloatArray] = {}
+        for label, term in self._terms:
+            update = getattr(term, "update", None)
+            if callable(update):
+                update(state.dt)
+            value = term(state)
+            state.commands[label] = value
+            out[label] = value
+        return out
+
+    @classmethod
+    def from_specs(cls, specs: Sequence[TermSpec]) -> CommandManager:
+        """Build a :class:`CommandManager` from term specs.
+
+        Raises:
+            ValueError: If a spec references an unknown command term.
+        """
+        terms: list[tuple[str, Term]] = []
+        for spec in specs:
+            term_cls = get_term_class("command", spec.func)
+            terms.append((spec.name, term_cls(**spec.params)))
+        return cls(terms)
+
+    @classmethod
+    def from_config(cls, config: dict[str, Any]) -> CommandManager:
+        """Build from a ``{"terms": [...]}`` config dict."""
+        specs = [TermSpec.from_dict(entry) for entry in config.get("terms", [])]
+        return cls.from_specs(specs)

--- a/strands_robots/sim_managers/command/terms/__init__.py
+++ b/strands_robots/sim_managers/command/terms/__init__.py
@@ -1,0 +1,5 @@
+"""Command term library. Importing registers terms in the global registry."""
+
+from strands_robots.sim_managers.command.terms import velocity
+
+__all__ = ["velocity"]

--- a/strands_robots/sim_managers/command/terms/velocity.py
+++ b/strands_robots/sim_managers/command/terms/velocity.py
@@ -1,0 +1,75 @@
+"""Velocity command terms for locomotion."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from strands_robots.sim_managers.base import EnvState, FloatArray, Term, register_term
+
+
+@register_term("command", "uniform_velocity")
+class UniformVelocityCommand(Term):
+    """Sample a planar base-velocity command ``[vx, vy, wz]`` from uniform ranges.
+
+    The command is resampled every ``resampling_time`` seconds and on
+    :meth:`reset`. Reading the term (``term(state)``) returns the current
+    command without advancing the timer; the :class:`CommandManager` advances
+    the timer via :meth:`update` once per control step.
+
+    Args:
+        lin_vel_x: ``(low, high)`` range for forward velocity (m/s).
+        lin_vel_y: ``(low, high)`` range for lateral velocity (m/s).
+        ang_vel_z: ``(low, high)`` range for yaw rate (rad/s).
+        resampling_time: Seconds between resamples.
+    """
+
+    def __init__(
+        self,
+        lin_vel_x: tuple[float, float] = (-1.0, 1.0),
+        lin_vel_y: tuple[float, float] = (-1.0, 1.0),
+        ang_vel_z: tuple[float, float] = (-1.0, 1.0),
+        resampling_time: float = 10.0,
+        **params: Any,
+    ) -> None:
+        super().__init__(
+            lin_vel_x=lin_vel_x,
+            lin_vel_y=lin_vel_y,
+            ang_vel_z=ang_vel_z,
+            resampling_time=resampling_time,
+            **params,
+        )
+        self.lin_vel_x = (float(lin_vel_x[0]), float(lin_vel_x[1]))
+        self.lin_vel_y = (float(lin_vel_y[0]), float(lin_vel_y[1]))
+        self.ang_vel_z = (float(ang_vel_z[0]), float(ang_vel_z[1]))
+        self.resampling_time = float(resampling_time)
+        self._rng = np.random.default_rng()
+        self._command: FloatArray = np.zeros(3)
+        self._time_since_resample = 0.0
+        self._resample()
+
+    def _resample(self) -> None:
+        self._command = np.array(
+            [
+                self._rng.uniform(*self.lin_vel_x),
+                self._rng.uniform(*self.lin_vel_y),
+                self._rng.uniform(*self.ang_vel_z),
+            ]
+        )
+        self._time_since_resample = 0.0
+
+    def reset(self, state: EnvState | None = None, *, rng: np.random.Generator | None = None) -> None:
+        """Reset the timer and draw a fresh command, optionally with a seeded rng."""
+        if rng is not None:
+            self._rng = rng
+        self._resample()
+
+    def update(self, dt: float) -> None:
+        """Advance the resample timer by ``dt`` seconds, resampling if due."""
+        self._time_since_resample += dt
+        if self._time_since_resample >= self.resampling_time:
+            self._resample()
+
+    def __call__(self, state: EnvState) -> FloatArray:
+        return self._command

--- a/strands_robots/sim_managers/config.py
+++ b/strands_robots/sim_managers/config.py
@@ -1,0 +1,123 @@
+"""Declarative config DSL: build a full manager set from a dict or YAML file.
+
+A managers config is a mapping of manager keys to ``{"terms": [...]}`` blocks::
+
+    command_manager:
+      terms:
+        - name: base_velocity
+          func: uniform_velocity
+          params: {lin_vel_x: [-1.0, 1.0], ang_vel_z: [-1.0, 1.0]}
+    observation_manager:
+      terms:
+        - {func: base_lin_vel, scale: 2.0}
+        - {func: velocity_commands}
+    reward_manager:
+      terms:
+        - {name: track_lin_vel, func: track_lin_vel_xy_exp, weight: 1.0, params: {std: 0.25}}
+        - {name: lin_vel_z, func: lin_vel_z_l2, weight: -2.0}
+    termination_manager:
+      terms:
+        - {func: time_out}
+        - {func: bad_orientation, params: {limit_angle: 1.0}}
+
+Term ``func`` names are validated against the closed term registry; an unknown
+name raises rather than executing arbitrary code, so a config is safe to parse
+from untrusted / LLM-authored YAML.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from strands_robots.sim_managers.command import CommandManager
+from strands_robots.sim_managers.observation import ObservationManager
+from strands_robots.sim_managers.reward import RewardManager
+from strands_robots.sim_managers.termination import TerminationManager
+from strands_robots.utils import require_optional
+
+_MANAGER_KEYS = {
+    "command_manager",
+    "observation_manager",
+    "reward_manager",
+    "termination_manager",
+}
+
+
+@dataclass
+class ManagerSet:
+    """A bundle of managers built from one config.
+
+    Managers are ``None`` when their config block is absent. The
+    :class:`CommandManager` should be computed first each step so reward /
+    observation terms can read the commands it publishes.
+
+    Args:
+        command: Command manager, if configured.
+        observation: Observation manager, if configured.
+        reward: Reward manager, if configured.
+        termination: Termination manager, if configured.
+    """
+
+    command: CommandManager | None = None
+    observation: ObservationManager | None = None
+    reward: RewardManager | None = None
+    termination: TerminationManager | None = None
+
+
+def build_managers(config: dict[str, Any]) -> ManagerSet:
+    """Build a :class:`ManagerSet` from a config mapping.
+
+    Args:
+        config: Mapping with any of ``command_manager``, ``observation_manager``,
+            ``reward_manager``, ``termination_manager``.
+
+    Returns:
+        A :class:`ManagerSet` with the configured managers.
+
+    Raises:
+        ValueError: On an unknown top-level key or an unknown term ``func``.
+    """
+    unknown = set(config) - _MANAGER_KEYS
+    if unknown:
+        raise ValueError(f"unknown manager config keys {sorted(unknown)}; allowed: {sorted(_MANAGER_KEYS)}")
+    return ManagerSet(
+        command=CommandManager.from_config(config["command_manager"]) if "command_manager" in config else None,
+        observation=(
+            ObservationManager.from_config(config["observation_manager"]) if "observation_manager" in config else None
+        ),
+        reward=RewardManager.from_config(config["reward_manager"]) if "reward_manager" in config else None,
+        termination=(
+            TerminationManager.from_config(config["termination_manager"]) if "termination_manager" in config else None
+        ),
+    )
+
+
+def load_managers_config(path: str | Path) -> ManagerSet:
+    """Load a managers config from a YAML or JSON file and build the managers.
+
+    Args:
+        path: Path to a ``.yaml`` / ``.yml`` / ``.json`` config file.
+
+    Returns:
+        The built :class:`ManagerSet`.
+
+    Raises:
+        ImportError: If a YAML file is given but PyYAML is not installed
+            (raised by ``require_optional`` with an install hint).
+        ValueError: If the file does not parse to a mapping, or on an unknown
+            manager key / term ``func``.
+    """
+    text = Path(path).read_text(encoding="utf-8")
+    suffix = Path(path).suffix.lower()
+    if suffix in (".yaml", ".yml"):
+        yaml = require_optional("yaml", pip_install="pyyaml", purpose="YAML manager config loading")
+        data = yaml.safe_load(text)  # type: ignore[attr-defined]
+    else:
+        import json
+
+        data = json.loads(text)
+    if not isinstance(data, dict):
+        raise ValueError(f"managers config must be a mapping, got {type(data).__name__}")
+    return build_managers(data)

--- a/strands_robots/sim_managers/observation/__init__.py
+++ b/strands_robots/sim_managers/observation/__init__.py
@@ -1,0 +1,6 @@
+"""Observation manager package."""
+
+from strands_robots.sim_managers.observation import terms  # noqa: F401  (registers terms)
+from strands_robots.sim_managers.observation.manager import ObservationManager
+
+__all__ = ["ObservationManager"]

--- a/strands_robots/sim_managers/observation/manager.py
+++ b/strands_robots/sim_managers/observation/manager.py
@@ -1,0 +1,96 @@
+"""Observation manager - composes observation terms into one policy vector."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+import numpy as np
+
+from strands_robots.sim_managers.base import EnvState, FloatArray, Manager, Term, TermSpec, get_term_class
+
+
+class ObservationManager(Manager):
+    """Concatenate observation terms into a single 1-D observation vector.
+
+    Each term is scaled then optionally clipped (per :class:`TermSpec`) before
+    concatenation, in declaration order. The resulting vector layout is stable
+    and introspectable via :attr:`term_slices`.
+
+    Args:
+        terms: ``(label, term, scale, clip)`` tuples in observation order.
+
+    Raises:
+        ValueError: On duplicate labels.
+    """
+
+    category = "observation"
+
+    def __init__(self, terms: list[tuple[str, Term, float, tuple[float, float] | None]]) -> None:
+        super().__init__([(label, term) for label, term, _, _ in terms])
+        self._scales: dict[str, float] = {label: scale for label, _, scale, _ in terms}
+        self._clips: dict[str, tuple[float, float] | None] = {label: clip for label, _, _, clip in terms}
+        self._slices: dict[str, slice] = {}
+
+    @property
+    def term_slices(self) -> dict[str, slice]:
+        """Map term label -> slice into the observation vector (after first compute)."""
+        return dict(self._slices)
+
+    def compute(self, state: EnvState) -> FloatArray:
+        """Return the concatenated, scaled, clipped observation vector.
+
+        Args:
+            state: The environment state to observe.
+
+        Returns:
+            A 1-D ``float64`` observation vector. Empty (shape ``(0,)``) when the
+            manager has no terms.
+        """
+        chunks: list[FloatArray] = []
+        offset = 0
+        self._slices = {}
+        for label, term in self._terms:
+            value = np.atleast_1d(np.asarray(term(state), dtype=np.float64))
+            value = value * self._scales[label]
+            clip = self._clips[label]
+            if clip is not None:
+                value = np.clip(value, clip[0], clip[1])
+            self._slices[label] = slice(offset, offset + value.shape[0])
+            offset += value.shape[0]
+            chunks.append(value)
+        if not chunks:
+            return np.zeros(0)
+        return np.concatenate(chunks)
+
+    @classmethod
+    def from_specs(cls, specs: Sequence[TermSpec]) -> ObservationManager:
+        """Build an :class:`ObservationManager` from term specs.
+
+        Args:
+            specs: Ordered observation term specs.
+
+        Returns:
+            The constructed manager.
+
+        Raises:
+            ValueError: If a spec references an unknown observation term.
+        """
+        terms: list[tuple[str, Term, float, tuple[float, float] | None]] = []
+        for spec in specs:
+            term_cls = get_term_class("observation", spec.func)
+            terms.append((spec.name, term_cls(**spec.params), spec.scale, spec.clip))
+        return cls(terms)
+
+    @classmethod
+    def from_config(cls, config: dict[str, Any]) -> ObservationManager:
+        """Build from a ``{"terms": [...]}`` config dict.
+
+        Args:
+            config: Manager config with a ``terms`` list.
+
+        Returns:
+            The constructed manager.
+        """
+        specs = [TermSpec.from_dict(entry) for entry in config.get("terms", [])]
+        return cls.from_specs(specs)

--- a/strands_robots/sim_managers/observation/terms/__init__.py
+++ b/strands_robots/sim_managers/observation/terms/__init__.py
@@ -1,0 +1,5 @@
+"""Observation term library. Importing registers terms in the global registry."""
+
+from strands_robots.sim_managers.observation.terms import locomotion
+
+__all__ = ["locomotion"]

--- a/strands_robots/sim_managers/observation/terms/locomotion.py
+++ b/strands_robots/sim_managers/observation/terms/locomotion.py
@@ -1,0 +1,81 @@
+"""First-class locomotion observation terms.
+
+Each term returns a 1-D ``float64`` vector that the :class:`ObservationManager`
+concatenates (after optional per-term scale + clip) into the policy observation.
+These mirror the canonical Isaac Lab / RSL-RL locomotion observation group.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from strands_robots.sim_managers.base import EnvState, FloatArray, Term, register_term
+
+
+@register_term("observation", "base_lin_vel")
+class BaseLinVel(Term):
+    """Base-frame linear velocity ``[vx, vy, vz]`` (shape ``(3,)``)."""
+
+    def __call__(self, state: EnvState) -> FloatArray:
+        return state.base_lin_vel
+
+
+@register_term("observation", "base_ang_vel")
+class BaseAngVel(Term):
+    """Base-frame angular velocity ``[wx, wy, wz]`` (shape ``(3,)``)."""
+
+    def __call__(self, state: EnvState) -> FloatArray:
+        return state.base_ang_vel
+
+
+@register_term("observation", "projected_gravity")
+class ProjectedGravity(Term):
+    """Gravity unit vector projected into the base frame (shape ``(3,)``)."""
+
+    def __call__(self, state: EnvState) -> FloatArray:
+        return state.projected_gravity
+
+
+@register_term("observation", "joint_pos")
+class JointPos(Term):
+    """Joint positions relative to the default pose (``joint_pos - default``).
+
+    Relative encoding is the locomotion convention: it centres the observation
+    on the nominal stance so the policy sees deviations, not absolute angles.
+    """
+
+    def __call__(self, state: EnvState) -> FloatArray:
+        assert state.default_joint_pos is not None  # set in EnvState.__post_init__
+        return state.joint_pos - state.default_joint_pos
+
+
+@register_term("observation", "joint_vel")
+class JointVel(Term):
+    """Joint velocities (shape ``(n_joints,)``)."""
+
+    def __call__(self, state: EnvState) -> FloatArray:
+        return state.joint_vel
+
+
+@register_term("observation", "last_action")
+class LastAction(Term):
+    """Previous control action (shape ``(n_actions,)``)."""
+
+    def __call__(self, state: EnvState) -> FloatArray:
+        return state.last_action
+
+
+@register_term("observation", "velocity_commands")
+class VelocityCommands(Term):
+    """The active base-velocity command vector the policy should track.
+
+    Args:
+        command_name: Key of the command in :attr:`EnvState.commands`.
+    """
+
+    def __init__(self, command_name: str = "base_velocity", **params: Any) -> None:
+        super().__init__(command_name=command_name, **params)
+        self.command_name = command_name
+
+    def __call__(self, state: EnvState) -> FloatArray:
+        return state.command(self.command_name)

--- a/strands_robots/sim_managers/reward/__init__.py
+++ b/strands_robots/sim_managers/reward/__init__.py
@@ -1,0 +1,6 @@
+"""Reward manager package."""
+
+from strands_robots.sim_managers.reward import terms  # noqa: F401  (registers terms)
+from strands_robots.sim_managers.reward.manager import RewardManager
+
+__all__ = ["RewardManager"]

--- a/strands_robots/sim_managers/reward/manager.py
+++ b/strands_robots/sim_managers/reward/manager.py
@@ -1,0 +1,87 @@
+"""Reward manager - composes weighted reward terms into a scalar reward."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from strands_robots.sim_managers.base import EnvState, Manager, Term, TermSpec, get_term_class
+
+
+class RewardManager(Manager):
+    """Sum weighted reward terms into a scalar reward per control step.
+
+    Each term contributes ``weight * term(state) * dt`` (Isaac Lab convention:
+    rewards are time-integrated so a recipe is invariant to control frequency).
+    The most recent per-term contribution is kept in :attr:`term_values` for
+    logging / curriculum.
+
+    Args:
+        terms: ``(label, term, weight)`` tuples.
+        scale_by_dt: When ``True`` (default), multiply each contribution by
+            ``state.dt`` so total reward is consistent across control rates.
+
+    Raises:
+        ValueError: On duplicate labels.
+    """
+
+    category = "reward"
+
+    def __init__(self, terms: list[tuple[str, Term, float]], *, scale_by_dt: bool = True) -> None:
+        super().__init__([(label, term) for label, term, _ in terms])
+        self._weights: dict[str, float] = {label: weight for label, _, weight in terms}
+        self._scale_by_dt = scale_by_dt
+        self._term_values: dict[str, float] = {}
+
+    @property
+    def term_values(self) -> dict[str, float]:
+        """Most recent weighted per-term contributions (after :meth:`compute`)."""
+        return dict(self._term_values)
+
+    @property
+    def weights(self) -> dict[str, float]:
+        """Configured per-term weights."""
+        return dict(self._weights)
+
+    def compute(self, state: EnvState) -> float:
+        """Return the total weighted reward and refresh :attr:`term_values`.
+
+        Args:
+            state: The environment state to score.
+
+        Returns:
+            The scalar reward for this step.
+        """
+        dt = state.dt if self._scale_by_dt else 1.0
+        self._term_values = {}
+        for label, term in self._terms:
+            self._term_values[label] = self._weights[label] * float(term(state)) * dt
+        # Return the sum of the recorded breakdown so the contract
+        # ``compute(state) == sum(term_values.values())`` holds exactly.
+        return float(sum(self._term_values.values()))
+
+    @classmethod
+    def from_specs(cls, specs: Sequence[TermSpec], *, scale_by_dt: bool = True) -> RewardManager:
+        """Build a :class:`RewardManager` from term specs.
+
+        Args:
+            specs: Ordered reward term specs (``weight`` is honoured).
+            scale_by_dt: See the constructor.
+
+        Returns:
+            The constructed manager.
+
+        Raises:
+            ValueError: If a spec references an unknown reward term.
+        """
+        terms: list[tuple[str, Term, float]] = []
+        for spec in specs:
+            term_cls = get_term_class("reward", spec.func)
+            terms.append((spec.name, term_cls(**spec.params), spec.weight))
+        return cls(terms, scale_by_dt=scale_by_dt)
+
+    @classmethod
+    def from_config(cls, config: dict[str, Any]) -> RewardManager:
+        """Build from a ``{"terms": [...], "scale_by_dt": bool}`` config dict."""
+        specs = [TermSpec.from_dict(entry) for entry in config.get("terms", [])]
+        return cls.from_specs(specs, scale_by_dt=bool(config.get("scale_by_dt", True)))

--- a/strands_robots/sim_managers/reward/terms/__init__.py
+++ b/strands_robots/sim_managers/reward/terms/__init__.py
@@ -1,0 +1,5 @@
+"""Reward term library. Importing registers terms in the global registry."""
+
+from strands_robots.sim_managers.reward.terms import locomotion
+
+__all__ = ["locomotion"]

--- a/strands_robots/sim_managers/reward/terms/locomotion.py
+++ b/strands_robots/sim_managers/reward/terms/locomotion.py
@@ -1,0 +1,238 @@
+"""First-class locomotion reward terms.
+
+Each term returns a non-negative scalar *magnitude*; the :class:`RewardManager`
+applies the configured ``weight`` (whose sign distinguishes a reward from a
+penalty, following the Isaac Lab / RSL-RL convention). Tracking terms return a
+bounded ``(0, 1]`` Gaussian kernel; penalties return a squared magnitude.
+
+The base-velocity command is read from ``state.command(command_name)`` and is
+expected to be ``[vx, vy, wz]`` (planar linear + yaw rate).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from strands_robots.sim_managers.base import EnvState, Term, register_term
+
+
+@register_term("reward", "track_lin_vel_xy_exp")
+class TrackLinVelXYExp(Term):
+    """Reward tracking of the commanded planar linear velocity (Gaussian kernel).
+
+    Args:
+        std: Tracking tolerance; smaller is stricter.
+        command_name: Command key holding ``[vx, vy, wz]``.
+    """
+
+    def __init__(self, std: float = 0.25, command_name: str = "base_velocity", **params: Any) -> None:
+        super().__init__(std=std, command_name=command_name, **params)
+        self.std = float(std)
+        self.command_name = command_name
+
+    def __call__(self, state: EnvState) -> float:
+        cmd = state.command(self.command_name)
+        err = np.sum((cmd[:2] - state.base_lin_vel[:2]) ** 2)
+        return float(np.exp(-err / self.std**2))
+
+
+@register_term("reward", "track_ang_vel_z_exp")
+class TrackAngVelZExp(Term):
+    """Reward tracking of the commanded yaw rate (Gaussian kernel).
+
+    Args:
+        std: Tracking tolerance; smaller is stricter.
+        command_name: Command key holding ``[vx, vy, wz]``.
+    """
+
+    def __init__(self, std: float = 0.25, command_name: str = "base_velocity", **params: Any) -> None:
+        super().__init__(std=std, command_name=command_name, **params)
+        self.std = float(std)
+        self.command_name = command_name
+
+    def __call__(self, state: EnvState) -> float:
+        cmd = state.command(self.command_name)
+        err = (cmd[2] - state.base_ang_vel[2]) ** 2
+        return float(np.exp(-err / self.std**2))
+
+
+@register_term("reward", "lin_vel_z_l2")
+class LinVelZL2(Term):
+    """Penalise vertical base velocity (squared)."""
+
+    def __call__(self, state: EnvState) -> float:
+        return float(state.base_lin_vel[2] ** 2)
+
+
+@register_term("reward", "ang_vel_xy_l2")
+class AngVelXYL2(Term):
+    """Penalise roll/pitch angular velocity (sum of squares)."""
+
+    def __call__(self, state: EnvState) -> float:
+        return float(np.sum(state.base_ang_vel[:2] ** 2))
+
+
+@register_term("reward", "flat_orientation_l2")
+class FlatOrientationL2(Term):
+    """Penalise non-flat base orientation via projected-gravity xy (sum of squares)."""
+
+    def __call__(self, state: EnvState) -> float:
+        return float(np.sum(state.projected_gravity[:2] ** 2))
+
+
+@register_term("reward", "orientation_l2")
+class OrientationL2(Term):
+    """Penalise deviation of projected gravity z from the upright value (-1)."""
+
+    def __call__(self, state: EnvState) -> float:
+        return float((state.projected_gravity[2] + 1.0) ** 2)
+
+
+@register_term("reward", "dof_torques_l2")
+class DofTorquesL2(Term):
+    """Penalise applied joint torques (sum of squares)."""
+
+    def __call__(self, state: EnvState) -> float:
+        assert state.joint_torque is not None
+        return float(np.sum(state.joint_torque**2))
+
+
+@register_term("reward", "dof_acc_l2")
+class DofAccL2(Term):
+    """Penalise joint accelerations (sum of squares)."""
+
+    def __call__(self, state: EnvState) -> float:
+        assert state.joint_acc is not None
+        return float(np.sum(state.joint_acc**2))
+
+
+@register_term("reward", "dof_vel_l2")
+class DofVelL2(Term):
+    """Penalise joint velocities (sum of squares)."""
+
+    def __call__(self, state: EnvState) -> float:
+        return float(np.sum(state.joint_vel**2))
+
+
+@register_term("reward", "action_rate_l2")
+class ActionRateL2(Term):
+    """Penalise the change in action between steps (sum of squares)."""
+
+    def __call__(self, state: EnvState) -> float:
+        return float(np.sum((state.action - state.last_action) ** 2))
+
+
+@register_term("reward", "joint_pos_limits")
+class JointPosLimits(Term):
+    """Penalise joint positions outside their soft limits (sum of violations).
+
+    Uses ``joint_pos_limits`` shrunk to ``soft_joint_pos_limit_factor`` of the
+    hard range about its midpoint. Zero when limits are unavailable.
+    """
+
+    def __call__(self, state: EnvState) -> float:
+        if state.joint_pos_limits is None:
+            return 0.0
+        lower = state.joint_pos_limits[:, 0]
+        upper = state.joint_pos_limits[:, 1]
+        mid = 0.5 * (lower + upper)
+        half = 0.5 * (upper - lower) * state.soft_joint_pos_limit_factor
+        soft_lower = mid - half
+        soft_upper = mid + half
+        below = np.clip(soft_lower - state.joint_pos, a_min=0.0, a_max=None)
+        above = np.clip(state.joint_pos - soft_upper, a_min=0.0, a_max=None)
+        return float(np.sum(below + above))
+
+
+@register_term("reward", "joint_vel_limits")
+class JointVelLimits(Term):
+    """Penalise joint velocities exceeding a fraction of their limit.
+
+    Args:
+        soft_ratio: Fraction of the velocity limit treated as the threshold.
+    """
+
+    def __init__(self, soft_ratio: float = 1.0, **params: Any) -> None:
+        super().__init__(soft_ratio=soft_ratio, **params)
+        self.soft_ratio = float(soft_ratio)
+
+    def __call__(self, state: EnvState) -> float:
+        if state.joint_vel_limits is None:
+            return 0.0
+        threshold = state.joint_vel_limits * self.soft_ratio
+        excess = np.clip(np.abs(state.joint_vel) - threshold, a_min=0.0, a_max=None)
+        return float(np.sum(excess))
+
+
+@register_term("reward", "feet_air_time")
+class FeetAirTime(Term):
+    """Reward foot air time at touchdown to encourage stepping, not shuffling.
+
+    Rewards ``(air_time - threshold)`` on the step a foot makes first contact,
+    gated to only apply while a non-trivial velocity command is active. Needs
+    ``feet_air_time`` and ``feet_contact``; returns 0 if either is absent.
+
+    Args:
+        threshold: Target air time per step, seconds.
+        command_name: Command key gating the reward (norm > 0.1).
+    """
+
+    def __init__(self, threshold: float = 0.4, command_name: str = "base_velocity", **params: Any) -> None:
+        super().__init__(threshold=threshold, command_name=command_name, **params)
+        self.threshold = float(threshold)
+        self.command_name = command_name
+        self._prev_contact: np.ndarray | None = None
+
+    def reset(self, state: EnvState | None = None, *, rng: np.random.Generator | None = None) -> None:
+        self._prev_contact = None
+
+    def __call__(self, state: EnvState) -> float:
+        if state.feet_air_time is None or state.feet_contact is None:
+            return 0.0
+        contact = state.feet_contact
+        if self._prev_contact is None:
+            self._prev_contact = np.zeros_like(contact)
+        first_contact = np.logical_and(contact, np.logical_not(self._prev_contact))
+        reward = float(np.sum((state.feet_air_time - self.threshold) * first_contact))
+        self._prev_contact = contact.copy()
+        cmd = state.commands.get(self.command_name)
+        if cmd is not None and float(np.linalg.norm(cmd[:2])) <= 0.1:
+            return 0.0
+        return reward
+
+
+@register_term("reward", "feet_slide")
+class FeetSlide(Term):
+    """Penalise foot sliding: foot speed while in contact (sum of squares).
+
+    Reads per-foot planar speed from ``state.extras['feet_lin_vel']`` (shape
+    ``(n_feet,)`` or ``(n_feet, 2/3)``). Returns 0 if unavailable.
+    """
+
+    def __call__(self, state: EnvState) -> float:
+        if state.feet_contact is None:
+            return 0.0
+        feet_vel = state.extras.get("feet_lin_vel")
+        if feet_vel is None:
+            return 0.0
+        vel = np.asarray(feet_vel, dtype=np.float64)
+        speed_sq = vel**2 if vel.ndim == 1 else np.sum(vel**2, axis=-1)
+        return float(np.sum(speed_sq * state.feet_contact))
+
+
+@register_term("reward", "alive")
+class Alive(Term):
+    """Constant per-step survival reward (1.0)."""
+
+    def __call__(self, state: EnvState) -> float:
+        return 1.0
+
+
+@register_term("reward", "termination_penalty")
+class TerminationPenalty(Term):
+    """Penalise non-timeout episode termination (1.0 when terminated)."""
+
+    def __call__(self, state: EnvState) -> float:
+        return 1.0 if state.terminated else 0.0

--- a/strands_robots/sim_managers/termination/__init__.py
+++ b/strands_robots/sim_managers/termination/__init__.py
@@ -1,0 +1,6 @@
+"""Termination manager package."""
+
+from strands_robots.sim_managers.termination import terms  # noqa: F401  (registers terms)
+from strands_robots.sim_managers.termination.manager import TerminationManager, TerminationResult
+
+__all__ = ["TerminationManager", "TerminationResult"]

--- a/strands_robots/sim_managers/termination/manager.py
+++ b/strands_robots/sim_managers/termination/manager.py
@@ -1,0 +1,88 @@
+"""Termination manager - evaluates termination + timeout terms."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from strands_robots.sim_managers.base import EnvState, Manager, Term, TermSpec, get_term_class
+
+
+@dataclass
+class TerminationResult:
+    """Outcome of a :class:`TerminationManager` evaluation.
+
+    Args:
+        done: ``True`` if any term (failure or timeout) fired.
+        time_out: ``True`` if a timeout term fired (episode truncated, not
+            failed). Trainers bootstrap value across a timeout but not a failure.
+        terminated: ``True`` if a non-timeout (failure) term fired.
+        terms: Per-term boolean breakdown.
+    """
+
+    done: bool
+    time_out: bool
+    terminated: bool
+    terms: dict[str, bool]
+
+
+class TerminationManager(Manager):
+    """Evaluate termination terms, separating failures from timeouts.
+
+    Args:
+        terms: ``(label, term)`` pairs. A term is treated as a timeout when its
+            class sets ``is_time_out = True``.
+
+    Raises:
+        ValueError: On duplicate labels.
+    """
+
+    category = "termination"
+
+    def compute(self, state: EnvState) -> TerminationResult:
+        """Evaluate all terms and classify the episode outcome.
+
+        Args:
+            state: The environment state to check.
+
+        Returns:
+            A :class:`TerminationResult`.
+        """
+        breakdown: dict[str, bool] = {}
+        time_out = False
+        terminated = False
+        for label, term in self._terms:
+            fired = bool(term(state))
+            breakdown[label] = fired
+            if not fired:
+                continue
+            if getattr(term, "is_time_out", False):
+                time_out = True
+            else:
+                terminated = True
+        return TerminationResult(
+            done=time_out or terminated,
+            time_out=time_out,
+            terminated=terminated,
+            terms=breakdown,
+        )
+
+    @classmethod
+    def from_specs(cls, specs: Sequence[TermSpec]) -> TerminationManager:
+        """Build a :class:`TerminationManager` from term specs.
+
+        Raises:
+            ValueError: If a spec references an unknown termination term.
+        """
+        terms: list[tuple[str, Term]] = []
+        for spec in specs:
+            term_cls = get_term_class("termination", spec.func)
+            terms.append((spec.name, term_cls(**spec.params)))
+        return cls(terms)
+
+    @classmethod
+    def from_config(cls, config: dict[str, Any]) -> TerminationManager:
+        """Build from a ``{"terms": [...]}`` config dict."""
+        specs = [TermSpec.from_dict(entry) for entry in config.get("terms", [])]
+        return cls.from_specs(specs)

--- a/strands_robots/sim_managers/termination/terms/__init__.py
+++ b/strands_robots/sim_managers/termination/terms/__init__.py
@@ -1,0 +1,5 @@
+"""Termination term library. Importing registers terms in the global registry."""
+
+from strands_robots.sim_managers.termination.terms import locomotion
+
+__all__ = ["locomotion"]

--- a/strands_robots/sim_managers/termination/terms/locomotion.py
+++ b/strands_robots/sim_managers/termination/terms/locomotion.py
@@ -1,0 +1,80 @@
+"""First-class locomotion termination terms.
+
+A termination term returns ``bool`` (terminate this step or not). Terms whose
+``is_time_out`` class attribute is ``True`` signal episode truncation (a
+horizon timeout), which an RL trainer treats differently from a genuine failure
+(it bootstraps the value function across a timeout but not a failure).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from strands_robots.sim_managers.base import EnvState, Term, register_term
+
+
+@register_term("termination", "time_out")
+class TimeOut(Term):
+    """Truncate when the episode reaches its horizon (``step_count >= max``)."""
+
+    is_time_out = True
+
+    def __call__(self, state: EnvState) -> bool:
+        return state.step_count >= state.max_episode_length
+
+
+@register_term("termination", "bad_orientation")
+class BadOrientation(Term):
+    """Terminate when the base tilts past ``limit_angle`` from upright.
+
+    Args:
+        limit_angle: Maximum tilt of the gravity vector from straight-down,
+            radians.
+    """
+
+    def __init__(self, limit_angle: float = 1.0, **params: Any) -> None:
+        super().__init__(limit_angle=limit_angle, **params)
+        self.limit_angle = float(limit_angle)
+
+    def __call__(self, state: EnvState) -> bool:
+        gravity = state.projected_gravity
+        norm = float(np.linalg.norm(gravity))
+        if norm == 0.0:
+            return False
+        # Tilt of -gravity from world up == angle of gravity_z below the horizon.
+        cos_tilt = -gravity[2] / norm
+        cos_tilt = float(np.clip(cos_tilt, -1.0, 1.0))
+        return float(np.arccos(cos_tilt)) > self.limit_angle
+
+
+@register_term("termination", "base_height_below_threshold")
+class BaseHeightBelowThreshold(Term):
+    """Terminate when the base falls below ``min_height``.
+
+    Args:
+        min_height: Minimum allowed base height, metres.
+    """
+
+    def __init__(self, min_height: float = 0.3, **params: Any) -> None:
+        super().__init__(min_height=min_height, **params)
+        self.min_height = float(min_height)
+
+    def __call__(self, state: EnvState) -> bool:
+        return state.base_height < self.min_height
+
+
+@register_term("termination", "joint_pos_limit")
+class JointPosLimit(Term):
+    """Terminate when any joint position exceeds its hard limits.
+
+    Returns ``False`` when ``joint_pos_limits`` is unavailable.
+    """
+
+    def __call__(self, state: EnvState) -> bool:
+        if state.joint_pos_limits is None:
+            return False
+        lower = state.joint_pos_limits[:, 0]
+        upper = state.joint_pos_limits[:, 1]
+        return bool(np.any(state.joint_pos < lower) or np.any(state.joint_pos > upper))

--- a/tests/sim_managers/conftest.py
+++ b/tests/sim_managers/conftest.py
@@ -1,0 +1,29 @@
+"""Shared fixtures for sim_managers tests."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from strands_robots.sim_managers import EnvState
+
+
+@pytest.fixture
+def state() -> EnvState:
+    """A representative 6-joint locomotion state with an active command."""
+    return EnvState(
+        joint_pos=np.array([0.1, -0.2, 0.3, 0.0, 0.5, -0.5]),
+        joint_vel=np.array([0.0, 1.0, -1.0, 0.0, 2.0, 0.0]),
+        action=np.array([0.1, 0.2, 0.3, 0.0, 0.0, 0.0]),
+        last_action=np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+        base_lin_vel=np.array([0.5, 0.0, 0.1]),
+        base_ang_vel=np.array([0.0, 0.0, 0.3]),
+        projected_gravity=np.array([0.0, 0.0, -1.0]),
+        base_height=0.7,
+        joint_torque=np.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+        joint_acc=np.array([0.0, 2.0, 0.0, 0.0, 0.0, 0.0]),
+        commands={"base_velocity": np.array([0.5, 0.0, 0.3])},
+        dt=0.02,
+        step_count=5,
+        max_episode_length=100,
+    )

--- a/tests/sim_managers/test_command_manager.py
+++ b/tests/sim_managers/test_command_manager.py
@@ -1,0 +1,53 @@
+"""Command terms + manager: sampling, resampling, seeding, publication."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from strands_robots.sim_managers import CommandManager, EnvState, get_term_class
+
+
+def _state(dt=0.02):
+    return EnvState(joint_pos=np.zeros(2), joint_vel=np.zeros(2), action=np.zeros(2), last_action=np.zeros(2), dt=dt)
+
+
+def test_command_within_ranges():
+    term = get_term_class("command", "uniform_velocity")(
+        lin_vel_x=(0.5, 0.5), lin_vel_y=(-0.1, 0.1), ang_vel_z=(1.0, 1.0)
+    )
+    cmd = term(_state())
+    assert cmd[0] == 0.5
+    assert -0.1 <= cmd[1] <= 0.1
+    assert cmd[2] == 1.0
+
+
+def test_seeded_reset_is_reproducible():
+    term = get_term_class("command", "uniform_velocity")(lin_vel_x=(-1.0, 1.0))
+    term.reset(rng=np.random.default_rng(0))
+    a = term(_state()).copy()
+    term.reset(rng=np.random.default_rng(0))
+    b = term(_state()).copy()
+    np.testing.assert_allclose(a, b)
+
+
+def test_resamples_after_interval():
+    term = get_term_class("command", "uniform_velocity")(lin_vel_x=(-1.0, 1.0), resampling_time=0.05)
+    term.reset(rng=np.random.default_rng(1))
+    first = term(_state()).copy()
+    # advance 2 steps of dt=0.02 (0.04s) -> no resample yet
+    term.update(0.02)
+    term.update(0.02)
+    np.testing.assert_allclose(term(_state()), first)
+    term.update(0.02)  # now 0.06s >= 0.05 -> resample
+    assert not np.allclose(term(_state()), first)
+
+
+def test_manager_publishes_command_onto_state():
+    mgr = CommandManager.from_config(
+        {"terms": [{"name": "base_velocity", "func": "uniform_velocity", "params": {"lin_vel_x": [0.3, 0.3]}}]}
+    )
+    state = _state()
+    out = mgr.compute(state)
+    assert "base_velocity" in state.commands
+    np.testing.assert_allclose(state.command("base_velocity"), out["base_velocity"])
+    assert state.command("base_velocity")[0] == 0.3

--- a/tests/sim_managers/test_config_dsl.py
+++ b/tests/sim_managers/test_config_dsl.py
@@ -1,0 +1,74 @@
+"""Config DSL: build_managers, YAML/JSON loading, validation."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from strands_robots.sim_managers import build_managers, load_managers_config
+
+_CONFIG = {
+    "command_manager": {"terms": [{"name": "base_velocity", "func": "uniform_velocity"}]},
+    "observation_manager": {"terms": [{"func": "base_lin_vel"}, {"func": "velocity_commands"}]},
+    "reward_manager": {"terms": [{"name": "track", "func": "track_lin_vel_xy_exp", "weight": 1.0}]},
+    "termination_manager": {"terms": [{"func": "time_out"}]},
+}
+
+
+def test_build_all_managers():
+    ms = build_managers(_CONFIG)
+    assert ms.command is not None
+    assert ms.observation is not None and ms.observation.term_names == ["base_lin_vel", "velocity_commands"]
+    assert ms.reward is not None and ms.reward.weights == {"track": 1.0}
+    assert ms.termination is not None
+
+
+def test_missing_blocks_are_none():
+    ms = build_managers({"reward_manager": {"terms": [{"func": "alive", "weight": 1.0}]}})
+    assert ms.reward is not None
+    assert ms.observation is None and ms.command is None and ms.termination is None
+
+
+def test_unknown_manager_key_rejected():
+    with pytest.raises(ValueError, match="unknown manager config keys"):
+        build_managers({"bogus_manager": {"terms": []}})
+
+
+def test_unknown_term_func_rejected():
+    with pytest.raises(ValueError, match="unknown reward term"):
+        build_managers({"reward_manager": {"terms": [{"func": "no_such_term"}]}})
+
+
+def test_unknown_term_key_rejected():
+    with pytest.raises(ValueError, match="unknown term config keys"):
+        build_managers({"reward_manager": {"terms": [{"func": "alive", "wieght": 1.0}]}})
+
+
+def test_missing_func_key_rejected():
+    with pytest.raises(ValueError, match="missing required 'func'"):
+        build_managers({"reward_manager": {"terms": [{"weight": 1.0}]}})
+
+
+def test_load_json_file(tmp_path):
+    path = tmp_path / "cfg.json"
+    path.write_text(json.dumps(_CONFIG), encoding="utf-8")
+    ms = load_managers_config(path)
+    assert ms.reward is not None
+
+
+def test_load_yaml_file(tmp_path):
+    pytest.importorskip("yaml")
+    import yaml  # type: ignore[import-untyped]
+
+    path = tmp_path / "cfg.yaml"
+    path.write_text(yaml.safe_dump(_CONFIG), encoding="utf-8")
+    ms = load_managers_config(path)
+    assert ms.observation is not None
+
+
+def test_load_non_mapping_rejected(tmp_path):
+    path = tmp_path / "bad.json"
+    path.write_text("[1, 2, 3]", encoding="utf-8")
+    with pytest.raises(ValueError, match="must be a mapping"):
+        load_managers_config(path)

--- a/tests/sim_managers/test_env_state_contract.py
+++ b/tests/sim_managers/test_env_state_contract.py
@@ -1,0 +1,39 @@
+"""EnvState contract: coercion, defaults, and command lookup behaviour."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from strands_robots.sim_managers import EnvState
+
+
+def test_array_fields_coerced_to_1d_float64():
+    state = EnvState(joint_pos=[1, 2, 3], joint_vel=[0, 0, 0], action=[0.0], last_action=[0.0])
+    assert state.joint_pos.dtype == np.float64
+    assert state.joint_pos.shape == (3,)
+    assert state.num_joints == 3
+
+
+def test_optional_arrays_default_to_zeros_sized_to_joints():
+    state = EnvState(joint_pos=np.zeros(4), joint_vel=np.zeros(4), action=np.zeros(2), last_action=np.zeros(2))
+    assert state.joint_torque is not None and state.joint_torque.shape == (4,)
+    assert state.joint_acc is not None and state.joint_acc.shape == (4,)
+    assert state.default_joint_pos is not None and state.default_joint_pos.shape == (4,)
+
+
+def test_joint_vel_length_mismatch_raises():
+    with pytest.raises(ValueError, match="joint_vel length"):
+        EnvState(joint_pos=np.zeros(3), joint_vel=np.zeros(2), action=np.zeros(1), last_action=np.zeros(1))
+
+
+def test_2d_field_rejected():
+    with pytest.raises(ValueError, match="must be 1-D"):
+        EnvState(joint_pos=np.zeros((2, 2)), joint_vel=np.zeros(4), action=np.zeros(1), last_action=np.zeros(1))
+
+
+def test_command_lookup_missing_raises_with_available_names():
+    state = EnvState(joint_pos=np.zeros(2), joint_vel=np.zeros(2), action=np.zeros(2), last_action=np.zeros(2))
+    state.commands["base_velocity"] = np.zeros(3)
+    with pytest.raises(KeyError, match="base_velocity"):
+        state.command("missing")

--- a/tests/sim_managers/test_manager_reset.py
+++ b/tests/sim_managers/test_manager_reset.py
@@ -1,0 +1,17 @@
+"""Manager.reset propagates to stateful terms (e.g. feet_air_time, command)."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from strands_robots.sim_managers import RewardManager
+
+
+def test_reset_clears_feet_air_time_history():
+    mgr = RewardManager.from_config({"terms": [{"func": "feet_air_time", "weight": 1.0}]})
+    label, term = next(iter(mgr))
+    assert label == "feet_air_time"
+    # set internal history then reset it
+    term._prev_contact = np.array([True, True])
+    mgr.reset()
+    assert term._prev_contact is None

--- a/tests/sim_managers/test_observation_manager.py
+++ b/tests/sim_managers/test_observation_manager.py
@@ -1,0 +1,51 @@
+"""Observation terms + ObservationManager concatenation / scale / clip / slices."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from strands_robots.sim_managers import EnvState, ObservationManager, get_term_class
+
+
+def test_joint_pos_is_relative_to_default():
+    state = EnvState(
+        joint_pos=np.array([1.0, 2.0]),
+        joint_vel=np.zeros(2),
+        action=np.zeros(2),
+        last_action=np.zeros(2),
+        default_joint_pos=np.array([0.5, 0.5]),
+    )
+    term = get_term_class("observation", "joint_pos")()
+    np.testing.assert_allclose(term(state), [0.5, 1.5])
+
+
+def test_manager_concatenates_in_order_and_records_slices(state):
+    mgr = ObservationManager.from_config(
+        {"terms": [{"func": "base_lin_vel"}, {"func": "joint_vel"}, {"func": "velocity_commands"}]}
+    )
+    obs = mgr.compute(state)
+    assert obs.shape == (3 + 6 + 3,)
+    assert mgr.term_slices["base_lin_vel"] == slice(0, 3)
+    assert mgr.term_slices["joint_vel"] == slice(3, 9)
+    assert mgr.term_slices["velocity_commands"] == slice(9, 12)
+    np.testing.assert_allclose(obs[mgr.term_slices["base_lin_vel"]], state.base_lin_vel)
+
+
+def test_scale_and_clip_applied(state):
+    mgr = ObservationManager.from_config({"terms": [{"func": "base_lin_vel", "scale": 10.0, "clip": [-2.0, 2.0]}]})
+    obs = mgr.compute(state)
+    # base_lin_vel = [0.5, 0, 0.1] * 10 = [5, 0, 1] clipped to [-2, 2] -> [2, 0, 1].
+    np.testing.assert_allclose(obs, [2.0, 0.0, 1.0])
+
+
+def test_empty_manager_returns_empty_vector(state):
+    mgr = ObservationManager.from_config({"terms": []})
+    assert mgr.compute(state).shape == (0,)
+
+
+def test_duplicate_labels_rejected():
+    with pytest.raises(ValueError, match="duplicate term labels"):
+        ObservationManager.from_config(
+            {"terms": [{"name": "x", "func": "base_lin_vel"}, {"name": "x", "func": "joint_vel"}]}
+        )

--- a/tests/sim_managers/test_registry.py
+++ b/tests/sim_managers/test_registry.py
@@ -1,0 +1,35 @@
+"""Term registry: lookup, listing, and duplicate / unknown handling."""
+
+from __future__ import annotations
+
+import pytest
+
+from strands_robots.sim_managers import get_term_class, list_terms, register_term
+from strands_robots.sim_managers.base import Term
+
+
+def test_locomotion_terms_registered():
+    terms = list_terms()
+    assert "track_lin_vel_xy_exp" in terms["reward"]
+    assert "base_lin_vel" in terms["observation"]
+    assert "time_out" in terms["termination"]
+    assert "uniform_velocity" in terms["command"]
+
+
+def test_unknown_term_lists_available():
+    with pytest.raises(ValueError, match="available"):
+        get_term_class("reward", "does_not_exist")
+
+
+def test_unknown_category_raises():
+    with pytest.raises(ValueError, match="unknown term category"):
+        get_term_class("nope", "x")
+
+
+def test_duplicate_registration_raises():
+    with pytest.raises(ValueError, match="already registered"):
+
+        @register_term("reward", "track_lin_vel_xy_exp")
+        class _Dup(Term):
+            def __call__(self, state):  # pragma: no cover - registration fails first
+                return 0.0

--- a/tests/sim_managers/test_reward_manager_integral.py
+++ b/tests/sim_managers/test_reward_manager_integral.py
@@ -1,0 +1,104 @@
+"""Integral test: a full manager-driven rollout loop with a closed-loop reward.
+
+Exercises the four managers together over a synthetic episode and asserts the
+emergent behaviour reviewers care about: a perfectly tracking agent accrues
+more reward than a stationary one, the per-term breakdown sums to the total,
+and dt-scaling makes total reward invariant to control frequency.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from strands_robots.sim_managers import EnvState, build_managers
+
+_CONFIG = {
+    "command_manager": {
+        "terms": [
+            {
+                "name": "base_velocity",
+                "func": "uniform_velocity",
+                "params": {"lin_vel_x": [0.5, 0.5], "lin_vel_y": [0.0, 0.0], "ang_vel_z": [0.0, 0.0]},
+            }
+        ]
+    },
+    "observation_manager": {
+        "terms": [
+            {"func": "base_lin_vel"},
+            {"func": "base_ang_vel"},
+            {"func": "projected_gravity"},
+            {"func": "joint_pos"},
+            {"func": "joint_vel"},
+            {"func": "last_action"},
+            {"func": "velocity_commands"},
+        ]
+    },
+    "reward_manager": {
+        "terms": [
+            {"name": "track_lin", "func": "track_lin_vel_xy_exp", "weight": 1.0, "params": {"std": 0.25}},
+            {"name": "track_ang", "func": "track_ang_vel_z_exp", "weight": 0.5, "params": {"std": 0.25}},
+            {"name": "lin_vel_z", "func": "lin_vel_z_l2", "weight": -2.0},
+            {"name": "action_rate", "func": "action_rate_l2", "weight": -0.01},
+            {"name": "alive", "func": "alive", "weight": 0.25},
+        ]
+    },
+    "termination_manager": {
+        "terms": [
+            {"func": "time_out"},
+            {"func": "bad_orientation", "params": {"limit_angle": 1.0}},
+        ]
+    },
+}
+
+
+def _rollout(track_command: bool, n_steps: int = 50, dt: float = 0.02) -> float:
+    ms = build_managers(_CONFIG)
+    assert ms.command and ms.observation and ms.reward and ms.termination
+    ms.reward.reset()
+    ms.command.reset(rng=np.random.default_rng(0))
+    total = 0.0
+    last_action = np.zeros(6)
+    for step in range(n_steps):
+        state = EnvState(
+            joint_pos=np.zeros(6),
+            joint_vel=np.zeros(6),
+            action=last_action,
+            last_action=last_action,
+            base_lin_vel=np.array([0.5, 0.0, 0.0]) if track_command else np.zeros(3),
+            base_ang_vel=np.zeros(3),
+            dt=dt,
+            step_count=step,
+            max_episode_length=n_steps,
+        )
+        ms.command.compute(state)
+        obs = ms.observation.compute(state)
+        assert obs.shape == (3 + 3 + 3 + 6 + 6 + 6 + 3,)
+        reward = ms.reward.compute(state)
+        # breakdown sums to total (within float tolerance)
+        assert sum(ms.reward.term_values.values()) == reward
+        term = ms.termination.compute(state)
+        total += reward
+        if term.done:
+            break
+    return total
+
+
+def test_tracking_agent_outscores_stationary_agent():
+    assert _rollout(track_command=True) > _rollout(track_command=False)
+
+
+def test_breakdown_keys_match_configured_terms():
+    ms = build_managers(_CONFIG)
+    assert ms.command and ms.reward
+    state = EnvState(joint_pos=np.zeros(6), joint_vel=np.zeros(6), action=np.zeros(6), last_action=np.zeros(6))
+    ms.command.compute(state)
+    ms.reward.compute(state)
+    assert set(ms.reward.term_values) == {"track_lin", "track_ang", "lin_vel_z", "action_rate", "alive"}
+
+
+def test_reward_is_dt_invariant_over_fixed_horizon():
+    # Same physical episode duration, half the dt -> twice the steps -> equal total.
+    coarse = _rollout(track_command=True, n_steps=50, dt=0.02)
+    fine = _rollout(track_command=True, n_steps=100, dt=0.01)
+    assert coarse == pytest.approx(fine)

--- a/tests/sim_managers/test_reward_terms.py
+++ b/tests/sim_managers/test_reward_terms.py
@@ -1,0 +1,127 @@
+"""Numeric behaviour of individual locomotion reward terms."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from strands_robots.sim_managers import EnvState, get_term_class
+
+
+def _make(func, **params):
+    return get_term_class("reward", func)(**params)
+
+
+def test_track_lin_vel_exact_match_is_one(state):
+    # base_lin_vel xy == command xy -> perfect tracking -> exp(0) == 1.
+    term = _make("track_lin_vel_xy_exp", std=0.25)
+    assert term(state) == pytest.approx(1.0)
+
+
+def test_track_lin_vel_decreases_with_error(state):
+    term = _make("track_lin_vel_xy_exp", std=0.25)
+    state.base_lin_vel = np.array([0.0, 0.0, 0.0])  # command is [0.5, 0, 0.3]
+    assert 0.0 < term(state) < 1.0
+
+
+def test_track_ang_vel_exact_match_is_one(state):
+    term = _make("track_ang_vel_z_exp", std=0.25)
+    assert term(state) == pytest.approx(1.0)
+
+
+def test_lin_vel_z_l2_is_squared_vertical_velocity(state):
+    term = _make("lin_vel_z_l2")
+    assert term(state) == pytest.approx(0.1**2)
+
+
+def test_ang_vel_xy_l2_ignores_yaw(state):
+    term = _make("ang_vel_xy_l2")
+    assert term(state) == pytest.approx(0.0)  # only yaw is non-zero
+
+
+def test_flat_orientation_zero_when_upright(state):
+    assert _make("flat_orientation_l2")(state) == pytest.approx(0.0)
+
+
+def test_orientation_l2_zero_when_upright(state):
+    assert _make("orientation_l2")(state) == pytest.approx(0.0)
+
+
+def test_orientation_l2_penalises_tilt(state):
+    state.projected_gravity = np.array([0.0, 0.0, -0.5])
+    assert _make("orientation_l2")(state) == pytest.approx(0.25)
+
+
+def test_action_rate_is_squared_delta(state):
+    # action - last_action = [0.1, 0.2, 0.3, 0, 0, 0] -> 0.14
+    assert _make("action_rate_l2")(state) == pytest.approx(0.01 + 0.04 + 0.09)
+
+
+def test_dof_torques_and_acc_and_vel(state):
+    assert _make("dof_torques_l2")(state) == pytest.approx(1.0)
+    assert _make("dof_acc_l2")(state) == pytest.approx(4.0)
+    assert _make("dof_vel_l2")(state) == pytest.approx(1.0 + 1.0 + 4.0)
+
+
+def test_alive_is_constant(state):
+    assert _make("alive")(state) == 1.0
+
+
+def test_termination_penalty_tracks_flag(state):
+    assert _make("termination_penalty")(state) == 0.0
+    state.terminated = True
+    assert _make("termination_penalty")(state) == 1.0
+
+
+def test_joint_pos_limits_zero_when_within(state):
+    state.joint_pos_limits = np.array([[-2.0, 2.0]] * 6)
+    assert _make("joint_pos_limits")(state) == pytest.approx(0.0)
+
+
+def test_joint_pos_limits_penalises_violation():
+    state = EnvState(
+        joint_pos=np.array([1.0]),
+        joint_vel=np.array([0.0]),
+        action=np.array([0.0]),
+        last_action=np.array([0.0]),
+        joint_pos_limits=np.array([[-1.0, 1.0]]),
+        soft_joint_pos_limit_factor=0.5,
+    )
+    # soft upper = 0.5; pos 1.0 -> violation 0.5.
+    assert _make("joint_pos_limits")(state) == pytest.approx(0.5)
+
+
+def test_joint_pos_limits_zero_without_limits(state):
+    assert state.joint_pos_limits is None
+    assert _make("joint_pos_limits")(state) == 0.0
+
+
+def test_feet_air_time_rewards_first_contact():
+    state = EnvState(
+        joint_pos=np.zeros(2),
+        joint_vel=np.zeros(2),
+        action=np.zeros(2),
+        last_action=np.zeros(2),
+        feet_air_time=np.array([0.6, 0.0]),
+        feet_contact=np.array([True, False]),
+        commands={"base_velocity": np.array([0.5, 0.0, 0.0])},
+    )
+    term = _make("feet_air_time", threshold=0.4)
+    term.reset(state)
+    # foot 0 just made contact with 0.6s air time -> (0.6 - 0.4) == 0.2.
+    assert term(state) == pytest.approx(0.2)
+    # second step, still in contact -> no first-contact event.
+    assert term(state) == pytest.approx(0.0)
+
+
+def test_feet_slide_penalises_sliding_contact():
+    state = EnvState(
+        joint_pos=np.zeros(2),
+        joint_vel=np.zeros(2),
+        action=np.zeros(2),
+        last_action=np.zeros(2),
+        feet_contact=np.array([True, False]),
+        extras={"feet_lin_vel": np.array([[1.0, 0.0], [5.0, 0.0]])},
+    )
+    # only the in-contact foot (1 m/s) is penalised.
+    assert _make("feet_slide")(state) == pytest.approx(1.0)

--- a/tests/sim_managers/test_termination_manager.py
+++ b/tests/sim_managers/test_termination_manager.py
@@ -1,0 +1,52 @@
+"""Termination terms + manager failure/timeout classification."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from strands_robots.sim_managers import TerminationManager, get_term_class
+
+
+def test_time_out_fires_at_horizon(state):
+    state.step_count = 100
+    assert get_term_class("termination", "time_out")()(state) is True
+    state.step_count = 99
+    assert get_term_class("termination", "time_out")()(state) is False
+
+
+def test_bad_orientation_triggers_when_tilted(state):
+    term = get_term_class("termination", "bad_orientation")(limit_angle=0.5)
+    assert term(state) is False  # upright
+    state.projected_gravity = np.array([1.0, 0.0, 0.0])  # 90 deg tilt
+    assert term(state) is True
+
+
+def test_base_height_below_threshold(state):
+    term = get_term_class("termination", "base_height_below_threshold")(min_height=0.5)
+    assert term(state) is False  # height 0.7
+    state.base_height = 0.2
+    assert term(state) is True
+
+
+def test_manager_separates_timeout_from_failure(state):
+    mgr = TerminationManager.from_config(
+        {"terms": [{"func": "time_out"}, {"func": "base_height_below_threshold", "params": {"min_height": 0.5}}]}
+    )
+    # nothing fires
+    res = mgr.compute(state)
+    assert not res.done and not res.time_out and not res.terminated
+
+    # failure only
+    state.base_height = 0.1
+    res = mgr.compute(state)
+    assert res.done and res.terminated and not res.time_out
+
+    # timeout
+    state.base_height = 0.7
+    state.step_count = 100
+    res = mgr.compute(state)
+    assert res.done and res.time_out and not res.terminated
+
+
+def test_joint_pos_limit_safe_without_limits(state):
+    assert get_term_class("termination", "joint_pos_limit")()(state) is False


### PR DESCRIPTION
## Problem

`strands_robots` has no abstraction for composing reinforcement-learning environments. Every example wires observation assembly, reward math, termination checks, and command generation inline, in Python, per task. That blocks declarative reward composition, curriculum learning, and multi-task training (locomotion and whole-body tracking share most terms but differ in a few), and forces hand-rolled code for each new recipe.

The existing pieces are narrow and single-purpose: `policies/wbc/observation.py` (one ONNX observation builder), `simulation/predicates.py` (termination/success predicates), and `training/reward.py` (RA-BC weight helper only).

## Change

Add `strands_robots.sim_managers`, a backend-agnostic, config-driven composition layer modelled on the manager pattern used by Isaac Lab / RSL-RL. Observation, reward, termination, and command logic is composed from atomic, reusable **terms** described declaratively in a single config (dict / YAML / JSON) rather than hand-wired.

**Core primitives (`base.py`)**
- `EnvState` is the backend-agnostic contract every term reads from. A simulator backend (or a rollout driver) populates it each control step, so the identical recipe runs on MuJoCo, MJWarp, Isaac Gym, Isaac Sim, or Newton. Array fields are validated/coerced; a term that needs an unpopulated field raises a clear error instead of degrading silently.
- `Term` is an atomic computation registered in a closed registry keyed by `(category, func_name)`. Configs reference terms by `func` name only (never `eval`), so they are safe to parse from untrusted / LLM-authored YAML — the same safety posture as `simulation/predicates.py`.
- `Manager` is an ordered collection of terms combined into one result.

**Managers + first-class locomotion terms**
- `ObservationManager` — scale -> clip -> concatenate, with an introspectable `term_slices` map. Terms: `base_lin_vel`, `base_ang_vel`, `projected_gravity`, `joint_pos` (relative to default), `joint_vel`, `last_action`, `velocity_commands`.
- `RewardManager` — `sum(weight * term * dt)` with a per-term breakdown in `term_values`; `dt`-scaling makes a recipe invariant to control frequency. 16 terms: `track_lin_vel_xy_exp`, `track_ang_vel_z_exp`, `lin_vel_z_l2`, `ang_vel_xy_l2`, `flat_orientation_l2`, `orientation_l2`, `dof_torques_l2`, `dof_acc_l2`, `dof_vel_l2`, `action_rate_l2`, `joint_pos_limits`, `joint_vel_limits`, `feet_air_time`, `feet_slide`, `alive`, `termination_penalty`.
- `TerminationManager` — classifies `time_out` (truncation, for value bootstrapping) vs `terminated` (failure). Terms: `time_out`, `bad_orientation`, `base_height_below_threshold`, `joint_pos_limit`.
- `CommandManager` — generates and refreshes command vectors onto the `EnvState`. Term: `uniform_velocity` (seedable, resampling).

**Config DSL (`config.py`)** — `build_managers(dict)` and `load_managers_config(path)` assemble a `ManagerSet`. Unknown manager keys and unknown term `func` names are rejected with messages that list the valid options.

```python
from strands_robots.sim_managers import RewardManager, ObservationManager

reward = RewardManager.from_config({"terms": [
    {"name": "track", "func": "track_lin_vel_xy_exp", "weight": 1.0, "params": {"std": 0.25}},
    {"name": "z_vel", "func": "lin_vel_z_l2", "weight": -2.0},
]})
r = reward.compute(state)        # scalar reward
reward.term_values               # per-term breakdown
```

## Tests

53 new tests (`tests/sim_managers/`): `EnvState` coercion/validation, the term registry (lookup, listing, duplicate/unknown handling), every locomotion term's numeric behaviour, manager composition / scale / clip / slice tracking, timeout-vs-failure classification, command sampling / resampling / seeded reproducibility, the config DSL plus its validation rejections, and an integral rollout asserting a tracking agent outscores a stationary one with a `dt`-invariant total reward. On pre-change code the package does not exist, so every test fails to import — they guard the new contract going forward.

Green locally: `ruff check` + `ruff format --check` clean, `mypy` clean (strict, fully typed), all 53 tests pass.

## Integration evidence

`examples/sim_managers_locomotion.py` builds the four managers from `sim_managers_locomotion.yaml` and drives a Unitree G1 in headless MuJoCo (`MUJOCO_GL=egl`), feeding each step's physics state through the managers via a documented `_env_state_from_mujoco` helper. Running it on a passive (zero-action) G1:

```text
robot=unitree_g1  control_dt=0.0200s  observation_dim=99
episode ended at step 71: {'time_out': False, 'bad_orientation': True, 'base_height_below_threshold': False}

per-term reward contribution (summed):
  dof_acc            -15.02715
  ang_vel_xy          -0.86686
  dof_torques         -0.47676
  track_lin_vel       +0.30012
  alive               +0.21600
  flat_orientation    -0.21128
  lin_vel_z           -0.04973
```

The `TerminationManager` correctly classifies the fall as a `bad_orientation` failure (not a timeout), and the `RewardManager` breakdown reflects the wild accelerations of an untrained passive humanoid — confirming the framework runs end to end on real simulator data with terms that never touch MuJoCo.

## Docs

`docs/training/managers.md` (wired into the nav): full reference — core concepts, the config DSL, the complete term library, the worked example, and how to register custom terms.

## Scope

This lands the framework foundation plus the four state-driven managers (observation / reward / termination / command) with first-class locomotion terms — a complete, standalone, mergeable unit. The remaining manager kinds (curriculum, terrain, randomization, reset-events, action) and whole-body-tracking terms build naturally on these same primitives (`register_term` + the config DSL) and are left to focused follow-ups so this change stays reviewable.