### PR TITLE
fix(sim): validate replay() speed is positive (no ZeroDivisionError / silent full-speed playback)

### DIFF
--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -1385,6 +1385,11 @@ class SimEngine(ABC):
     ) -> dict[str, Any]:
         """Replay a LeRobotDataset episode via ``PolicyRunner.replay``.
 
+        ``speed`` is a playback-rate multiplier (1.0 = real time) and must be a
+        positive number; a non-positive or non-numeric value is rejected with a
+        structured error rather than raising or silently playing back at full
+        speed.
+
         Override per backend for optimised replay (e.g. direct ctrl
         writes) only when measured necessary.
         """

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -1167,7 +1167,9 @@ class PolicyRunner:
                 non-existent robot).
             episode: Episode index in the dataset (non-negative).
             root: Optional local dataset root override.
-            speed: Playback speed multiplier (1.0 = real time).
+            speed: Playback speed multiplier (1.0 = real time). Must be a
+                positive number; a non-positive or non-numeric value is
+                rejected with a structured error.
             action_key_map: Optional list of joint names, one per action
                 vector index. Required when dataset joint ordering differs
                 from ``robot_joint_names(robot_name)``. If ``None``, positional
@@ -1176,6 +1178,21 @@ class PolicyRunner:
         Returns:
             Standard status dict with per-frame stats.
         """
+        # ``speed`` is a playback-rate multiplier used as the divisor in
+        # ``frame_interval = 1 / (dataset_fps * speed)``. A value of 0 raised a
+        # bare ZeroDivisionError (breaking the documented "returns a status
+        # dict" contract) and a negative value silently played the episode
+        # forward at full speed while reporting success with a meaningless
+        # "Speed: -1.0x". Reject a non-positive or non-numeric speed up front,
+        # before the (potentially multi-minute) dataset download. ``bool`` is
+        # an ``int`` subclass, so ``True`` is rejected explicitly rather than
+        # acting as a silent 1.0x.
+        if isinstance(speed, bool) or not isinstance(speed, (int, float)) or speed <= 0:
+            return {
+                "status": "error",
+                "content": [{"text": f"replay: speed must be a positive number (got {speed!r})."}],
+            }
+
         try:
             from strands_robots.dataset_recorder import load_lerobot_episode
         except ImportError:

--- a/tests/simulation/test_policy_runner_paths.py
+++ b/tests/simulation/test_policy_runner_paths.py
@@ -3,6 +3,8 @@
 Covers:
 * ``replay()`` when no robots exist (``_require_default_robot`` ValueError)
 * ``replay()`` when the dataset loader raises (opaque upstream error)
+* ``replay()`` rejects a non-positive / non-numeric ``speed`` before the
+  dataset loader (no ZeroDivisionError, no silent full-speed playback)
 * ``replay()`` when lerobot is not installed (ImportError → graceful)
 * ``replay()`` with actions that have ``.numpy()`` and ``.tolist()`` methods
   (tensor-backed dataset frames)
@@ -95,6 +97,64 @@ def test_replay_dataset_loader_raises_is_handled(monkeypatch):
     r = PolicyRunner(sim).replay(repo_id="bad/dataset")
     assert r["status"] == "error"
     assert "simulated HF download failure" in r["content"][0]["text"]
+
+
+def test_replay_speed_zero_rejected_before_loading(monkeypatch):
+    """``speed=0`` must fail fast with a structured error, not ZeroDivisionError.
+
+    ``frame_interval = 1 / (dataset_fps * speed)`` divided by zero, raising a
+    bare ``ZeroDivisionError`` that escaped replay()'s documented "returns a
+    status dict" contract. The guard must run BEFORE the dataset loader so an
+    invalid speed does not trigger a wasted dataset download; the loader is
+    monkeypatched to fail loudly if it is ever reached.
+    """
+    sim = _MinimalSim(robots=["r0"])
+
+    import strands_robots.dataset_recorder as dr
+
+    def _must_not_load(*args, **kwargs):
+        raise AssertionError("load_lerobot_episode reached despite invalid speed")
+
+    monkeypatch.setattr(dr, "load_lerobot_episode", _must_not_load, raising=False)
+
+    r = PolicyRunner(sim).replay(repo_id="some/dataset", robot_name="r0", speed=0.0)
+    assert r["status"] == "error"
+    assert "positive" in r["content"][0]["text"]
+
+
+def test_replay_negative_speed_rejected_before_loading(monkeypatch):
+    """A negative ``speed`` previously played the episode forward at full speed
+    and reported success with a meaningless "Speed: -1.0x". It must be rejected
+    with a structured error before the dataset loader runs.
+    """
+    sim = _MinimalSim(robots=["r0"])
+
+    import strands_robots.dataset_recorder as dr
+
+    def _must_not_load(*args, **kwargs):
+        raise AssertionError("load_lerobot_episode reached despite invalid speed")
+
+    monkeypatch.setattr(dr, "load_lerobot_episode", _must_not_load, raising=False)
+
+    r = PolicyRunner(sim).replay(repo_id="some/dataset", robot_name="r0", speed=-1.0)
+    assert r["status"] == "error"
+    assert "positive" in r["content"][0]["text"]
+
+
+def test_replay_bool_speed_rejected(monkeypatch):
+    """``bool`` is an ``int`` subclass; ``True`` must not slip through as 1.0x."""
+    sim = _MinimalSim(robots=["r0"])
+
+    import strands_robots.dataset_recorder as dr
+
+    def _must_not_load(*args, **kwargs):
+        raise AssertionError("load_lerobot_episode reached despite bool speed")
+
+    monkeypatch.setattr(dr, "load_lerobot_episode", _must_not_load, raising=False)
+
+    r = PolicyRunner(sim).replay(repo_id="some/dataset", robot_name="r0", speed=True)
+    assert r["status"] == "error"
+    assert "positive" in r["content"][0]["text"]
 
 
 def test_replay_with_tensor_like_actions(monkeypatch):


### PR DESCRIPTION
## Problem

`Simulation.replay_episode` / `PolicyRunner.replay` accept a `speed` playback-rate multiplier but never validate it. It is used directly as a divisor:

```python
frame_interval = 1.0 / (dataset_fps * speed)
```

Two bad inputs slip through:

- **`speed=0`** raises a bare `ZeroDivisionError: float division by zero`. This escapes `replay()`'s documented "Returns a status dict" contract — every other error path in `replay()` (no robots, unknown robot, loader failure, lerobot missing) returns a structured `{"status": "error", ...}`, but a zero speed crashes the caller.
- **negative `speed`** makes `frame_interval` negative, so `sleep_time` is always `<= 0` and the episode plays forward at full speed while the method reports `status="success"` with a meaningless `"Speed: -1.0x"`. A silent wrong-behavior, exactly the kind this codebase rejects elsewhere (`_validate_positive_frequency`, etc.).

Reproduction on a recorded LeRobotDataset:

```
--- replay speed=0 ---
RAISED: ZeroDivisionError float division by zero
--- replay speed=-1 (negative) ---
RETURNED: success wall=0.18s        # played through, reported success
```

## Change

Reject a non-positive or non-numeric `speed` at the top of `PolicyRunner.replay`, **before** the (potentially multi-minute) dataset download — mirroring the existing fail-fast `_validate_positive_frequency` / unknown-robot guards. `bool` is rejected explicitly since it is an `int` subclass (so `True` cannot act as a silent `1.0x`).

After the fix, both inputs return the structured error and never touch the dataset loader:

```
--- replay speed=0 ---
RETURNED: error ['replay: speed must be a positive number (got 0.0).']
--- replay speed=-1 (negative) ---
RETURNED: error wall=0.00s
```

Docstrings on `PolicyRunner.replay` and the `SimEngine.replay_episode` facade now state that `speed` must be positive.

## Tests

Added three regression tests to `tests/simulation/test_policy_runner_paths.py` (`speed=0`, negative, and `bool`). Each monkeypatches `load_lerobot_episode` to fail loudly if reached, proving the guard runs before the dataset load. They **fail on pre-fix code** (the loader is reached / `ZeroDivisionError`) and pass after.

```
# pre-fix
3 failed, 20 deselected
# post-fix
3 passed, 20 deselected
```

Full `tests/simulation/test_policy_runner_paths.py` + `test_policy_runner.py`: `54 passed, 2 skipped`. `ruff check`/`ruff format` clean; `mypy` clean on the changed source files.

## Scope

Input-validation hardening on an error path — no rendering, policy, recording, or asset behavior changes; valid replays (`speed > 0`) are untouched.