### PR TITLE
feat(robot): route Robot(backend=...) through create_simulation for unified backend selection

### DIFF
--- a/strands_robots/robot.py
+++ b/strands_robots/robot.py
@@ -25,10 +25,11 @@ Examples::
     # With custom URDF/MJCF path
     sim = Robot("my_arm", urdf_path="/path/to/robot.xml")
 
-Future (not yet implemented)::
+GPU backends (resolved through ``create_simulation``; require the backend's
+optional dependency or the ``strands-robots-sim`` plugin to be installed)::
 
     sim = Robot("unitree_go2", backend="isaac", num_envs=4096)
-    sim = Robot("so100", backend="newton", num_envs=4096)
+    sim = Robot("so100", backend="newton", num_envs=4096, device="cuda:0")
 """
 
 from __future__ import annotations
@@ -36,7 +37,7 @@ from __future__ import annotations
 import contextlib
 import logging
 import os
-from typing import TYPE_CHECKING, Any, Literal, overload
+from typing import TYPE_CHECKING, Any, Literal, cast, overload
 
 from strands_robots.registry import (
     get_hardware_type,
@@ -204,9 +205,17 @@ def Robot(  # noqa: N802 - uppercase by design (factory mimicking a class constr
         mode: "sim" (default - safe), "real" (explicit hardware), or
               "auto" (probes USB for servo controllers, falls back to sim).
               Case-insensitive; surrounding whitespace ignored.
-        backend: Simulation backend - currently only "mujoco" (CPU).
-                 Future: "isaac" (GPU), "newton" (GPU).
-                 Only applies to ``mode="sim"``; ignored for ``mode="real"``.
+        backend: Simulation backend name or alias, resolved through
+                 ``strands_robots.simulation.create_simulation`` - the same
+                 registry that powers ``create_simulation()`` directly. Built-in:
+                 ``"mujoco"`` (CPU, default; aliases ``"mj"``/``"mjc"``/``"mjx"``)
+                 and ``"newton"`` (GPU, warp-lang based; alias ``"nt"``). Heavy
+                 out-of-tree backends (``"isaac"``) ship in the ``strands-robots-sim``
+                 plugin package and resolve once installed. An unavailable backend
+                 surfaces the factory's actionable install hint. Backend-specific
+                 kwargs (e.g. ``num_envs``, ``device``) are forwarded to the
+                 backend constructor. Only applies to ``mode="sim"``; ignored for
+                 ``mode="real"``.
         urdf_path: Explicit path to URDF/MJCF file. If not provided,
                    resolved via ``strands_robots.simulation.model_registry``
                    (asset manager or ``STRANDS_ASSETS_DIR`` search paths).
@@ -236,9 +245,13 @@ def Robot(  # noqa: N802 - uppercase by design (factory mimicking a class constr
 
     Raises:
         ValueError: If ``mode`` is not 'sim'/'real'/'auto', if ``cameras=``
-                    is passed in sim mode, or if the robot name is empty
-                    or not in the registry (and no ``urdf_path=`` given).
-        NotImplementedError: If an unimplemented sim backend is requested.
+                    is passed in sim mode, if the robot name is empty
+                    or not in the registry (and no ``urdf_path=`` given), or if
+                    ``backend`` is not a known backend (the message lists the
+                    available backends and any install hint).
+        ImportError: If a known backend's optional dependency is missing
+                     (e.g. ``newton`` without ``warp``); the message names the
+                     pip extra to install.
         RuntimeError: If the sim world or robot fails to initialize.
 
     Examples::
@@ -282,13 +295,6 @@ def Robot(  # noqa: N802 - uppercase by design (factory mimicking a class constr
 
     # --- Simulation ---
     if mode == "sim":
-        if backend != "mujoco":
-            raise NotImplementedError(
-                f"Backend {backend!r} is not yet implemented. "
-                f"Currently supported: 'mujoco'. "
-                f"Isaac and Newton backends are on the roadmap."
-            )
-
         if cameras is not None:
             raise ValueError(
                 "cameras= is only supported in mode='real'. "
@@ -296,29 +302,34 @@ def Robot(  # noqa: N802 - uppercase by design (factory mimicking a class constr
                 "'add_camera' action after creation."
             )
 
-        from strands_robots.simulation import Simulation
+        from strands_robots.simulation import create_simulation
 
-        sim = Simulation(
-            tool_name=f"{name}_sim",
-            **kwargs,
-        )
+        # Resolve the backend through create_simulation - the single source of
+        # truth for backend selection (built-in registry + entry-point plugins +
+        # runtime registrations). The MuJoCo path is unchanged (returns the same
+        # MuJoCoSimEngine); ``newton`` and plugin backends (``isaac``) construct
+        # with the forwarded kwargs (``num_envs``, ``device``, ...), and an
+        # unavailable backend surfaces the factory's actionable install hint
+        # (e.g. ``pip install strands-robots[sim-newton]``) instead of a blanket
+        # NotImplementedError. World/robot population goes through the backend-
+        # agnostic SimEngine ABC methods, so it works for every backend.
+        # The sim-mode overloads contract a ``Simulation`` return; create_simulation
+        # is typed to the SimEngine ABC, so cast to keep that public contract.
+        sim = cast("Simulation", create_simulation(backend, tool_name=f"{name}_sim", **kwargs))
 
         try:
-            result = sim._dispatch_action("create_world", {})
+            result = sim.create_world()
             if result.get("status") == "error":
                 content = result.get("content", [])
                 msg = content[0].get("text", str(result)) if content else str(result)
                 raise RuntimeError(f"Failed to create sim world for {canonical!r}: {msg}")
 
-            add_robot_params: dict[str, Any] = {
-                "robot_name": name,
-                "data_config": data_config or canonical,
-                "position": position or [0.0, 0.0, 0.0],
-            }
-            if urdf_path:
-                add_robot_params["urdf_path"] = urdf_path
-
-            result = sim._dispatch_action("add_robot", add_robot_params)
+            result = sim.add_robot(
+                name=name,
+                urdf_path=urdf_path,
+                data_config=data_config or canonical,
+                position=position or [0.0, 0.0, 0.0],
+            )
             if result.get("status") == "error":
                 content = result.get("content", [])
                 msg = content[0].get("text", str(result)) if content else str(result)

--- a/strands_robots/simulation/factory.py
+++ b/strands_robots/simulation/factory.py
@@ -76,7 +76,12 @@ DEFAULT_BACKEND = "mujoco"
 _PLUGIN_INSTALL_HINTS: dict[str, str] = {
     "isaac": "pip install 'strands-robots-sim[isaac]'",
     "newton": "pip install 'strands-robots-sim[newton]'",
+    # The warp-lang based GPU-parallel MuJoCo path is the built-in ``newton``
+    # backend; ``warp`` and ``mjwarp`` are common names users reach for, so map
+    # both to the same actionable install hint instead of a bare "unknown
+    # backend" dead end.
     "warp": "pip install 'strands-robots-sim[newton]'",
+    "mjwarp": "pip install 'strands-robots-sim[newton]'",
 }
 
 # Plugin backends discovered via importlib.metadata entry points. Populated

--- a/tests/simulation/test_factory.py
+++ b/tests/simulation/test_factory.py
@@ -291,6 +291,17 @@ class TestEntryPointDiscovery:
             create_simulation("isaac")
         assert "pip install" in str(exc_info.value)
 
+    def test_mjwarp_and_warp_names_suggest_newton_plugin(self, monkeypatch):
+        """The GPU-parallel warp/MuJoCo path is the built-in ``newton`` backend.
+        ``warp`` and ``mjwarp`` are common names users reach for; both must
+        surface the ``strands-robots-sim[newton]`` install hint instead of a
+        bare unknown-backend dead end."""
+        _patch_entry_points(monkeypatch, [])
+        for name in ("warp", "mjwarp"):
+            with pytest.raises(ValueError, match="strands-robots-sim") as exc_info:
+                create_simulation(name)
+            assert "newton" in str(exc_info.value)
+
 
 class TestEntryPointLazyImport:
     def test_no_eager_plugin_scan_on_import(self):

--- a/tests/test_robot_factory.py
+++ b/tests/test_robot_factory.py
@@ -134,13 +134,44 @@ class TestRobotFactory:
         sig = inspect.signature(Robot)
         assert sig.parameters["mode"].default == "sim"
 
-    def test_unknown_backend_raises(self):
-        with pytest.raises(NotImplementedError, match="not yet implemented"):
+    def test_isaac_backend_routes_to_factory_install_hint(self):
+        """A non-mujoco backend resolves through ``create_simulation`` rather
+        than a blanket ``NotImplementedError``. ``isaac`` ships in the
+        out-of-tree ``strands-robots-sim`` plugin, so when it is absent the
+        factory's actionable install hint surfaces (a ``ValueError`` listing
+        available backends + a ``pip install`` pointer), not a dead-end
+        "on the roadmap" message."""
+        with pytest.raises(ValueError, match="strands-robots-sim") as exc_info:
             Robot("so100", mode="sim", backend="isaac")
+        msg = str(exc_info.value)
+        assert "pip install" in msg
+        # The misleading legacy framing must be gone.
+        assert "not yet implemented" not in msg
+        assert "roadmap" not in msg
 
-    def test_newton_not_implemented(self):
-        with pytest.raises(NotImplementedError, match="not yet implemented"):
+    def test_newton_backend_surfaces_dependency_install_hint(self):
+        """``newton`` is a built-in (warp-lang GPU) backend. With ``warp``
+        absent, ``Robot(backend="newton")`` now surfaces the backend's own
+        ``ImportError`` naming the ``sim-newton`` pip extra - the same error
+        ``create_simulation("newton")`` raises - instead of masking it behind
+        a generic NotImplementedError."""
+        with pytest.raises(ImportError, match="sim-newton"):
             Robot("so100", mode="sim", backend="newton")
+
+    def test_unknown_backend_lists_available(self):
+        """A genuinely unknown backend name yields the factory's ``ValueError``
+        that lists the available backends so the caller can self-correct."""
+        with pytest.raises(ValueError, match="Unknown simulation backend"):
+            Robot("so100", mode="sim", backend="totally_not_a_backend")
+
+    def test_mjwarp_backend_gives_plugin_install_hint(self):
+        """The GPU-parallel warp/MuJoCo path is the built-in ``newton`` backend;
+        ``mjwarp`` is a name users reach for. ``Robot(backend="mjwarp")`` must
+        point them at the warp/newton plugin rather than dead-ending on an
+        unhelpful unknown-backend error with no remedy."""
+        with pytest.raises(ValueError, match="strands-robots-sim") as exc_info:
+            Robot("so100", mode="sim", backend="mjwarp", num_envs=128)
+        assert "pip install" in str(exc_info.value)
 
     def test_invalid_mode_raises(self):
         with pytest.raises(ValueError, match="Invalid mode"):
@@ -344,9 +375,11 @@ class TestUnknownNameRejected:
 
 
 class TestCleanupOnDispatchRaise:
-    """If sim._dispatch_action itself raises (vs returns status=error), the
-    Simulation must still be destroyed. Pins the cleanup path that the original
-    review caught only for the status=error variant."""
+    """If a backend world/robot-population call itself raises (vs returns
+    status=error), the Simulation must still be destroyed. ``Robot()`` populates
+    the world through the backend-agnostic ``SimEngine`` ABC methods
+    (``create_world`` / ``add_robot``), so the cleanup path is pinned against
+    those."""
 
     def test_destroy_called_when_create_world_raises(self):
         """OSError (or any exception) from create_world must trigger destroy()."""
@@ -362,15 +395,11 @@ class TestCleanupOnDispatchRaise:
             destroyed.append(self)
             return real_destroy(self)
 
-        original_dispatch = SimImpl._dispatch_action
-
-        def raising_dispatch(self, action, params):
-            if action == "create_world":
-                raise OSError("simulated disk full")
-            return original_dispatch(self, action, params)
+        def raising_create_world(self, *args, **kwargs):
+            raise OSError("simulated disk full")
 
         with (
-            patch.object(SimImpl, "_dispatch_action", raising_dispatch),
+            patch.object(SimImpl, "create_world", raising_create_world),
             patch.object(SimImpl, "destroy", track),
         ):
             with pytest.raises(OSError, match="simulated disk full"):
@@ -392,15 +421,11 @@ class TestCleanupOnDispatchRaise:
             destroyed.append(self)
             return real_destroy(self)
 
-        original_dispatch = SimImpl._dispatch_action
-
-        def raising_dispatch(self, action, params):
-            if action == "add_robot":
-                raise RuntimeError("simulated MJCF compile error")
-            return original_dispatch(self, action, params)
+        def raising_add_robot(self, *args, **kwargs):
+            raise RuntimeError("simulated MJCF compile error")
 
         with (
-            patch.object(SimImpl, "_dispatch_action", raising_dispatch),
+            patch.object(SimImpl, "add_robot", raising_add_robot),
             patch.object(SimImpl, "destroy", track),
         ):
             with pytest.raises(RuntimeError, match="simulated MJCF compile error"):
@@ -1442,14 +1467,10 @@ class TestRobotFactoryErrorBranches:
 
         from strands_robots.simulation.mujoco.simulation import Simulation as SimImpl
 
-        original = SimImpl._dispatch_action
+        def fake_create_world(self, *args, **kwargs):
+            return {"status": "error", "content": [{"text": "mjcf compile failed"}]}
 
-        def fake_dispatch(self, action, params):
-            if action == "create_world":
-                return {"status": "error", "content": [{"text": "mjcf compile failed"}]}
-            return original(self, action, params)
-
-        with patch.object(SimImpl, "_dispatch_action", fake_dispatch):
+        with patch.object(SimImpl, "create_world", fake_create_world):
             with pytest.raises(RuntimeError, match="Failed to create sim world.*mjcf compile failed"):
                 Robot("so100")
 
@@ -1461,14 +1482,10 @@ class TestRobotFactoryErrorBranches:
 
         from strands_robots.simulation.mujoco.simulation import Simulation as SimImpl
 
-        original = SimImpl._dispatch_action
+        def fake_create_world(self, *args, **kwargs):
+            return {"status": "error", "content": []}
 
-        def fake_dispatch(self, action, params):
-            if action == "create_world":
-                return {"status": "error", "content": []}
-            return original(self, action, params)
-
-        with patch.object(SimImpl, "_dispatch_action", fake_dispatch):
+        with patch.object(SimImpl, "create_world", fake_create_world):
             with pytest.raises(RuntimeError, match="Failed to create sim world"):
                 Robot("so100")
 


### PR DESCRIPTION
## Problem

`Robot()` advertises GPU backends in its docstring and `@overload` signatures:

```python
sim = Robot("unitree_go2", backend="isaac", num_envs=4096)
sim = Robot("so100", backend="newton", num_envs=4096, device="cuda:0")
```

but the sim branch hardcoded the MuJoCo engine and raised a blanket `NotImplementedError` for anything else:

```python
if backend != "mujoco":
    raise NotImplementedError(
        f"Backend {backend!r} is not yet implemented. "
        f"Currently supported: 'mujoco'. Isaac and Newton backends are on the roadmap."
    )
```

This bypassed the entire `create_simulation()` factory that already exists one layer down — the built-in `newton` backend, entry-point plugins (`strands_robots.backends`, e.g. `strands-robots-sim[isaac]`), and runtime `register_backend()` registrations. Three concrete consequences:

1. `Robot("so100", backend="newton")` raised `NotImplementedError("on the roadmap")` even though `newton` is a registered built-in backend whose own error already names the `sim-newton` pip extra.
2. `num_envs` / `device` (and any other backend kwarg) were silently dropped — never forwarded to the backend constructor.
3. The error was a dead end: no available-backend list, no install hint, contradicting the factory's own actionable `ValueError`/`ImportError` messages.

## Change

Route the sim branch through `create_simulation` — the single source of truth for backend selection — and populate the world via the backend-agnostic `SimEngine` ABC methods (`create_world` / `add_robot`) instead of the MuJoCo-specific `_dispatch_action`:

```python
sim = cast("Simulation", create_simulation(backend, tool_name=f"{name}_sim", **kwargs))
result = sim.create_world()
result = sim.add_robot(name=name, urdf_path=urdf_path, data_config=data_config or canonical, position=position or [0, 0, 0])
```

The MuJoCo path is byte-identical: `create_simulation("mujoco")` returns the same `MuJoCoSimEngine`, and the ABC `create_world()`/`add_robot()` return the same `{"status": ...}` dicts the dispatch path produced. Non-mujoco backends now construct with the forwarded kwargs, and an unavailable backend surfaces the factory's actionable hint.

Also mapped the `warp` / `mjwarp` names to the `strands-robots-sim[newton]` install hint in the factory: the warp-lang GPU-parallel MuJoCo path **is** the built-in `newton` backend, so those names should point at the right plugin instead of a bare `Unknown simulation backend` dead end.

### Behavior before -> after

| Call | Before | After |
|---|---|---|
| `Robot("so100", backend="mujoco")` | `MuJoCoSimEngine` | `MuJoCoSimEngine` (unchanged) |
| `Robot("so100", backend="newton")` | `NotImplementedError: on the roadmap` | `ImportError` naming `sim-newton` extra (or constructs if `warp` installed) |
| `Robot("g1", backend="isaac")` | `NotImplementedError: on the roadmap` | `ValueError` + `pip install 'strands-robots-sim[isaac]'` |
| `Robot("g1", backend="mjwarp", num_envs=128)` | `NotImplementedError` | `ValueError` + `strands-robots-sim[newton]` hint |
| `Robot("g1", backend="nonsense")` | `NotImplementedError` | `ValueError` listing available backends |
| `num_envs` / `device` kwargs | dropped | forwarded to backend constructor |

## Tests

- Replaced the two `NotImplementedError` assertions (`test_unknown_backend_raises`, `test_newton_not_implemented`) with the new actionable-error contract: `isaac` -> `ValueError` + install hint (and asserts the old `roadmap`/`not yet implemented` framing is gone), `newton` -> `ImportError` naming `sim-newton`, unknown name -> lists backends, `mjwarp` -> plugin hint.
- Updated the cleanup-on-failure and `status=error` branch tests to patch the `SimEngine` ABC methods (`create_world`/`add_robot`) that `Robot()` now calls directly, preserving the destroy-on-partial-init and error-surfacing assertions.
- Added `test_mjwarp_and_warp_names_suggest_newton_plugin` in the factory suite.
- Full gate green: `ruff check` + `ruff format --check` clean, `mypy strands_robots tests tests_integ` -> no issues in 593 files, `pytest tests/simulation tests/test_robot_factory.py` -> 1587 passed (2 unrelated pre-existing `libtorchcodec` env failures in video-decode recording tests).

## Rollout evidence (MuJoCo, headless EGL)

Confirms the MuJoCo path is unchanged end to end through the new routing:

```
sim type: MuJoCoSimEngine
robots: ['so100']
run_policy status: success
MockPolicy | wave the arm | 120 steps | sim_t=4.080s
Video: 120 frames, 30fps, 640x480 | 323 KB
```

https://github.com/cagataycali/robots/releases/download/robot-backend-routing-artifact/so100_mujoco_rollout.mp4

## Scope note

This is the unified-backend-selection slice: it makes `Robot(...)` honor the existing factory/plugin architecture rather than vendoring heavy GPU backends into core. Implementing the actual GPU backends remains the domain of the `strands-robots-sim` plugin package (`strands_robots.backends` entry points); this change ensures `Robot(...)` resolves them consistently with `create_simulation(...)` once installed.