### PR TITLE
fix(lerobot_local): reconcile a device-pinned processor step onto the host device

### DIFF
--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -284,6 +284,24 @@ action_unnorm = (clip(action, -1, 1) + 1) * (q99 - q01) / 2 + q01
 When a stats file declares multiple embodiment tags, pass `norm_tag=` to select
 one; a single-tag file is auto-detected.
 
+### Device-pinned checkpoints
+
+A checkpoint trained on GPU bakes `device_processor.device = "cuda"` into its
+`policy_preprocessor.json` / `policy_postprocessor.json`. Loaded on a host
+without that device (CPU-only edge box, or a CUDA build on a machine whose
+driver predates the wheel's CUDA version), LeRobot asserts the device is
+available and the `device_processor` step fails to instantiate -- which surfaces
+as an error indistinguishable from "no pipeline config present".
+
+The bridge already moves every tensor onto the `device` you pass to
+`create_policy` (auto-detected when `None`), so it reconciles the pinned step
+onto that resolved device and retries the load once, rather than dropping the
+pipeline. Without this, normalization would be silently disabled: state reaches
+the policy in raw units and actions reach the motors in normalized space,
+producing off-policy / micro-motion trajectories. An explicit
+`processor_overrides={"device_processor": {"device": ...}}` is still honored
+as-is and takes precedence over the automatic reconciliation.
+
 ## Camera routing
 
 Robot/sim observations use bare camera names (`top`, `wrist`, `side`); the policy

--- a/strands_robots/policies/lerobot_local/processor.py
+++ b/strands_robots/policies/lerobot_local/processor.py
@@ -197,32 +197,22 @@ class ProcessorBridge:
         # leaving model_inputs empty at inference time. See B10.
         _register_policy_processor_steps(policy_type)
 
-        preprocessor = None
-        postprocessor = None
-
-        # Load preprocessor
-        try:
-            preprocessor = DataProcessorPipeline.from_pretrained(
-                pretrained_name_or_path,
-                config_filename=preprocessor_config,
-                overrides=overrides or {},
-            )
-            logger.info("Loaded preprocessor from %s: %d steps", pretrained_name_or_path, len(preprocessor))
-        except _missing_config_errors() as exc:
-            # No config file found - model doesn't ship a preprocessor. This is normal.
-            logger.debug("No preprocessor found: %s", exc)
-
-        # Load postprocessor
-        try:
-            postprocessor = DataProcessorPipeline.from_pretrained(
-                pretrained_name_or_path,
-                config_filename=postprocessor_config,
-                overrides=overrides or {},
-            )
-            logger.info("Loaded postprocessor from %s: %d steps", pretrained_name_or_path, len(postprocessor))
-        except _missing_config_errors() as exc:
-            # No config file found - model doesn't ship a postprocessor. This is normal.
-            logger.debug("No postprocessor found: %s", exc)
+        preprocessor = cls._load_pipeline(
+            DataProcessorPipeline,
+            pretrained_name_or_path,
+            preprocessor_config,
+            overrides or {},
+            device,
+            kind="preprocessor",
+        )
+        postprocessor = cls._load_pipeline(
+            DataProcessorPipeline,
+            pretrained_name_or_path,
+            postprocessor_config,
+            overrides or {},
+            device,
+            kind="postprocessor",
+        )
 
         # Fallback: a checkpoint may ship NEITHER standard pipeline config but a
         # recognized norm_stats.json (e.g. MolmoAct2 SO-100/101). Without this,
@@ -237,6 +227,85 @@ class ProcessorBridge:
             postprocessor=postprocessor,
             device=device,
         )
+
+    @staticmethod
+    def _load_pipeline(
+        pipeline_cls: Any,
+        pretrained_name_or_path: str,
+        config_filename: str,
+        overrides: dict[str, Any],
+        device: str | None,
+        kind: str,
+    ) -> Any | None:
+        """Load one processor pipeline, reconciling a device-pinned step.
+
+        A checkpoint trained on GPU bakes ``device_processor.device = "cuda"``
+        into its ``policy_preprocessor.json`` / ``policy_postprocessor.json``.
+        On a host without that device, LeRobot's ``get_safe_torch_device``
+        asserts the device is available and the ``device_processor`` step fails
+        to instantiate, which ``DataProcessorPipeline.from_pretrained`` surfaces
+        as a ``ValueError`` indistinguishable from "no config file present".
+        Swallowing it drops normalization silently: observations reach the model
+        un-normalized and predicted actions reach the motors un-unnormalized
+        (the arm barely moves). Since the bridge already knows its resolved
+        target ``device`` and moves every tensor there itself, reconcile the
+        pinned step onto that device and retry once before giving up.
+
+        Args:
+            pipeline_cls: LeRobot ``DataProcessorPipeline`` class.
+            pretrained_name_or_path: HF model ID or local checkpoint path.
+            config_filename: Pipeline config filename to load.
+            overrides: User-provided step overrides (never mutated here).
+            device: Resolved target device, or None when unknown.
+            kind: ``"preprocessor"`` or ``"postprocessor"`` (for log messages).
+
+        Returns:
+            The loaded pipeline, or ``None`` when the checkpoint genuinely ships
+            no such config.
+        """
+        try:
+            pipeline = pipeline_cls.from_pretrained(
+                pretrained_name_or_path,
+                config_filename=config_filename,
+                overrides=overrides,
+            )
+            logger.info("Loaded %s from %s: %d steps", kind, pretrained_name_or_path, len(pipeline))
+            return pipeline
+        except _missing_config_errors() as exc:
+            # Distinguish a device-pinned step that failed to instantiate from a
+            # genuinely absent config. The former is a ValueError whose message
+            # names the device_processor step (LeRobot wraps the underlying
+            # device assertion via _instantiate_step); the latter is a
+            # FileNotFoundError / ProcessorMigrationError. Only retry the former,
+            # and only when we know our device and the user has not already
+            # pinned device_processor themselves.
+            if (
+                device
+                and "device_processor" not in overrides
+                and isinstance(exc, ValueError)
+                and "device_processor" in str(exc)
+            ):
+                retry_overrides = {**overrides, "device_processor": {"device": device}}
+                try:
+                    pipeline = pipeline_cls.from_pretrained(
+                        pretrained_name_or_path,
+                        config_filename=config_filename,
+                        overrides=retry_overrides,
+                    )
+                    logger.warning(
+                        "%s ships a device-pinned 'device_processor' step that is "
+                        "unavailable on this host; reconciled it onto '%s' so "
+                        "normalization is applied. Original error: %s",
+                        kind,
+                        device,
+                        exc,
+                    )
+                    return pipeline
+                except _missing_config_errors() as retry_exc:
+                    logger.debug("%s device_processor retry on '%s' failed: %s", kind, device, retry_exc)
+            # No config file found - model doesn't ship this pipeline. Normal.
+            logger.debug("No %s found: %s", kind, exc)
+            return None
 
     @staticmethod
     def _load_norm_stats_fallback(

--- a/tests/policies/lerobot_local/test_device_pinned_processor_reconcile.py
+++ b/tests/policies/lerobot_local/test_device_pinned_processor_reconcile.py
@@ -1,0 +1,117 @@
+"""Regression tests: reconcile a device-pinned processor step onto the host.
+
+A LeRobot checkpoint trained on GPU bakes ``device_processor.device = "cuda"``
+into its ``policy_preprocessor.json`` / ``policy_postprocessor.json``. Loaded on
+a host without that device, LeRobot's ``get_safe_torch_device`` asserts the
+device is available, so the ``device_processor`` step fails to instantiate and
+``DataProcessorPipeline.from_pretrained`` raises a ``ValueError`` that is
+indistinguishable from "no config file present".
+
+Pre-fix, :meth:`ProcessorBridge.from_pretrained` swallowed that ValueError as a
+missing config and returned a passthrough bridge -- normalization was silently
+dropped, so observations reached the model un-normalized and predicted actions
+reached the motors un-unnormalized (the arm barely moves). These tests pin the
+behavior: the bridge knows its resolved target device and reconciles the pinned
+step onto it instead of dropping the pipeline.
+
+The tests build real (network-free) pipeline configs on disk and load them
+through the real LeRobot pipeline, so they verify behavior against actual
+LeRobot internals rather than mocks.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("lerobot.processor.pipeline")
+
+from strands_robots.policies.lerobot_local.processor import ProcessorBridge  # noqa: E402
+
+
+def _unavailable_device() -> str:
+    """Return a real accelerator device string that is NOT available here.
+
+    Reproducing the bug needs a ``device_processor`` pinned to a device whose
+    ``get_safe_torch_device`` assertion fails on this host. ``"cuda"`` covers
+    CPU-only CI and CPU-only edge hosts; ``"mps"`` covers CUDA GPU hosts. Skip
+    only on the rare host where both are available.
+    """
+    import torch
+
+    if not torch.cuda.is_available():
+        return "cuda"
+    if not torch.backends.mps.is_available():
+        return "mps"
+    pytest.skip("host has both CUDA and MPS; cannot pin an unavailable device")
+
+
+def _write_pipeline_config(directory: Path, filename: str, device: str) -> None:
+    """Write a minimal one-step (device_processor) pipeline config to disk."""
+    config = {
+        "name": filename.removesuffix(".json"),
+        "steps": [{"registry_name": "device_processor", "config": {"device": device, "float_dtype": None}}],
+    }
+    (directory / filename).write_text(json.dumps(config))
+
+
+def test_device_pinned_preprocessor_reconciled_to_target_device(tmp_path: Path) -> None:
+    """A device-pinned preprocessor loads (not dropped) by reconciling the device.
+
+    Fails pre-fix: the unavailable-device assertion is swallowed as "no config"
+    and the bridge is an inert passthrough (``has_preprocessor`` False).
+    """
+    pinned = _unavailable_device()
+    _write_pipeline_config(tmp_path, "policy_preprocessor.json", pinned)
+
+    bridge = ProcessorBridge.from_pretrained(str(tmp_path), device="cpu")
+
+    assert bridge.has_preprocessor is True
+    assert bridge.is_active is True
+
+
+def test_device_pinned_postprocessor_reconciled_to_target_device(tmp_path: Path) -> None:
+    """The same reconciliation covers the postprocessor (un-normalization) path."""
+    pinned = _unavailable_device()
+    _write_pipeline_config(tmp_path, "policy_postprocessor.json", pinned)
+
+    bridge = ProcessorBridge.from_pretrained(str(tmp_path), device="cpu")
+
+    assert bridge.has_postprocessor is True
+    assert bridge.is_active is True
+
+
+def test_user_device_processor_override_is_not_clobbered(tmp_path: Path) -> None:
+    """An explicit user device_processor override is honored as-is (no retry)."""
+    pinned = _unavailable_device()
+    _write_pipeline_config(tmp_path, "policy_preprocessor.json", pinned)
+
+    bridge = ProcessorBridge.from_pretrained(
+        str(tmp_path), device="cpu", overrides={"device_processor": {"device": "cpu"}}
+    )
+
+    assert bridge.has_preprocessor is True
+
+
+def test_genuinely_missing_config_stays_passthrough(tmp_path: Path) -> None:
+    """No config on disk -> passthrough bridge, no spurious device retry."""
+    bridge = ProcessorBridge.from_pretrained(str(tmp_path), device="cpu")
+
+    assert bridge.has_preprocessor is False
+    assert bridge.has_postprocessor is False
+    assert bridge.is_active is False
+
+
+def test_unknown_device_cannot_reconcile_and_stays_passthrough(tmp_path: Path) -> None:
+    """With no resolved target device the bridge cannot reconcile and stays inert.
+
+    Documents the boundary: reconciliation requires knowing the host device.
+    """
+    pinned = _unavailable_device()
+    _write_pipeline_config(tmp_path, "policy_preprocessor.json", pinned)
+
+    bridge = ProcessorBridge.from_pretrained(str(tmp_path), device=None)
+
+    assert bridge.has_preprocessor is False

--- a/tests/policies/lerobot_local/test_device_pinned_processor_reconcile.py
+++ b/tests/policies/lerobot_local/test_device_pinned_processor_reconcile.py
@@ -45,7 +45,10 @@ def _unavailable_device() -> str:
         return "cuda"
     if not torch.backends.mps.is_available():
         return "mps"
-    pytest.skip("host has both CUDA and MPS; cannot pin an unavailable device")
+    # Both accelerators present: no unavailable device to pin. Return the
+    # skip (typed NoReturn) so every exit path is an explicit return and the
+    # function has no implicit fall-through.
+    return pytest.skip("host has both CUDA and MPS; cannot pin an unavailable device")
 
 
 def _write_pipeline_config(directory: Path, filename: str, device: str) -> None:


### PR DESCRIPTION
## Problem

A LeRobot checkpoint trained on GPU bakes `device_processor.device = "cuda"` into its `policy_preprocessor.json` / `policy_postprocessor.json`. Loaded on a host without that device (a CPU-only edge box, or a CUDA build on a machine whose driver predates the wheel's CUDA version), LeRobot's `get_safe_torch_device` asserts the device is available:

```python
# lerobot/utils/device_utils.py
if try_device.startswith("cuda"):
    assert torch.cuda.is_available()
```

so the `device_processor` step fails to instantiate, and `DataProcessorPipeline.from_pretrained` wraps it (via `_instantiate_step`) as a `ValueError` that is indistinguishable from "no pipeline config present".

`ProcessorBridge.from_pretrained` caught that `ValueError` in its missing-config handler and returned a passthrough bridge. The effect is a **silent loss of normalization**: observations reach the model un-normalized and predicted actions reach the motors un-unnormalized, so the arm barely moves. The misleading part is that both config files exist and are valid; only the device pin is unsatisfiable on the host.

## Change

The bridge already knows its resolved target `device` and moves every tensor there itself, so the GPU-pinned `device_processor` is redundant on the host anyway. `from_pretrained` now reconciles the pinned step onto the resolved device and retries the load once before giving up:

- The retry is **narrowly gated**: only when a target `device` is known, the user has not already pinned `device_processor`, and the failure is a `ValueError` naming the `device_processor` step. A genuinely absent config (`FileNotFoundError` / `ProcessorMigrationError`) is untouched and still yields a passthrough.
- An explicit `processor_overrides={"device_processor": {"device": ...}}` is honored as-is and takes precedence over the automatic reconciliation.
- Pre- and post-processor loads share one helper, so both the input-normalization and the action-unnormalization paths are covered.

## Verification (real LeRobot pipeline, CPU host)

Reproduced with an on-disk `device_processor`-pinned config loaded through the real pipeline (no mocks, no network):

```
PRE-FIX  device=cpu   has_preprocessor: False  is_active: False   # normalization silently dropped
POST-FIX device=cpu   has_preprocessor: True   is_active: True    # reconciled onto cpu, normalization applied
RAW load raises: ValueError | Failed to instantiate processor step 'device_processor' ...
```

## Tests

Adds `tests/policies/lerobot_local/test_device_pinned_processor_reconcile.py` (real, network-free pipeline configs on disk, loaded through the installed LeRobot pipeline):

- `test_device_pinned_preprocessor_reconciled_to_target_device` - **fails pre-fix** (passthrough), passes post-fix.
- `test_device_pinned_postprocessor_reconciled_to_target_device` - **fails pre-fix**, passes post-fix.
- `test_user_device_processor_override_is_not_clobbered` - explicit override honored.
- `test_genuinely_missing_config_stays_passthrough` - no spurious retry on a truly missing config.
- `test_unknown_device_cannot_reconcile_and_stays_passthrough` - documents the boundary.

The pinned device is chosen as a real accelerator unavailable on the host (`cuda` on CPU/CPU-only hosts, `mps` on CUDA hosts), so the assertion-failure path reproduces deterministically across CI and GPU machines.

## Gate

`ruff check` + `ruff format --check` clean; `mypy strands_robots tests tests_integ` -> `Success: no issues found in 624 source files`; full `tests/policies/lerobot_local/` suite (223 tests) green.

## Docs

Adds a "Device-pinned checkpoints" subsection to `docs/policies/lerobot-local.md`.