### PR TITLE
feat(sim_managers): whole-body-tracking (WBT) terms + MotionClip

### DIFF
--- a/docs/training/managers.md
+++ b/docs/training/managers.md
@@ -165,6 +165,64 @@ kernel; penalties return a squared magnitude (apply a negative weight).
 resamples every `resampling_time` seconds; seed with `reset(rng=...)` for
 reproducibility).
 
+## Whole-body tracking (WBT)
+
+Whole-body tracking trains a policy to imitate a reference motion. The terms
+build on the same primitives as locomotion - they read the per-step target from
+the `EnvState`, so the identical recipe runs on any backend.
+
+A `MotionClip` is an immutable reference trajectory (joint positions, optional
+velocities) sampled at a fixed `fps`, interpolated by *phase* in `[0, 1)`:
+
+```python
+from strands_robots.sim_managers import MotionClip
+clip = MotionClip.from_arrays(frames_pos, frames_vel, fps=30.0)  # (num_frames, num_joints)
+target_pos, target_vel, phase = clip.sample(t=0.5, loop=True)
+```
+
+The `motion_clip` **command** term replays a clip: each control step the
+`CommandManager` advances its clock by `state.dt` and publishes the interpolated
+target pose, target velocity, and phase into `state.extras` under the
+`motion_target_pos` / `motion_target_vel` / `motion_phase` keys (see
+`strands_robots.sim_managers.motion`). The WBT observation / reward / termination
+terms read those keys, so a `motion_clip` command term must run **before** them
+each step (the standard "commands first" ordering). A WBT term that runs without
+one raises a clear error naming the missing command.
+
+**Observation** (`motion_phase` - cyclic `[sin, cos]` of the phase;
+`motion_target_joint_pos`; `motion_target_joint_vel`; `joint_pos_error` -
+`joint_pos - target`).
+
+**Reward** (`track_joint_pos_exp`, `track_joint_vel_exp` - bounded `(0, 1]`
+Gaussian kernels of the per-joint pose / velocity error, same `track_*_exp`
+convention as locomotion). For smoothness penalties reuse the shared
+`action_rate_l2` / `dof_acc_l2` terms.
+
+**Termination** (`motion_divergence` - failure when the L2 joint-position error
+exceeds `threshold`, the standard "lost the motion" early stop).
+
+```yaml
+command_manager:
+  terms:
+    - {name: motion, func: motion_clip, params: {frames_pos: [[...]], fps: 30.0}}
+observation_manager:
+  terms:
+    - {func: motion_phase}
+    - {func: joint_pos_error}
+reward_manager:
+  terms:
+    - {name: track_pos, func: track_joint_pos_exp, weight: 1.0, params: {std: 0.4}}
+    - {name: track_vel, func: track_joint_vel_exp, weight: 0.2, params: {std: 2.0}}
+termination_manager:
+  terms:
+    - {func: time_out}
+    - {func: motion_divergence, params: {threshold: 1.5}}
+```
+
+Locomotion and WBT share the same managers, registry, and config DSL - they
+differ only in which terms a recipe selects, so a multi-task policy reuses the
+common terms with no code duplication.
+
 ## Worked example
 
 `examples/sim_managers_locomotion.py` loads `sim_managers_locomotion.yaml`,
@@ -184,6 +242,12 @@ per-term reward contribution (summed):
   alive               +0.21600
   ...
 ```
+
+`examples/sim_managers_wbt.py` is the WBT counterpart: it builds a `motion_clip`
+recipe and drives a position-controlled SO-101 arm in headless MuJoCo to imitate
+the reference, recording the rollout to an MP4 while scoring it through the
+tracking reward (the arm completes the clip with no divergence and a
+pose-tracking-dominated reward).
 
 ## Extending
 

--- a/examples/sim_managers_wbt.py
+++ b/examples/sim_managers_wbt.py
@@ -1,0 +1,174 @@
+"""Whole-body tracking (WBT) through the config-driven sim_managers framework.
+
+Builds a WBT env recipe - a reference *motion clip* command plus tracking
+observation / reward / termination terms - and drives a position-controlled
+SO-101 arm in headless MuJoCo to imitate the clip. Each control step feeds the
+simulator's joint state into the managers: the ``motion_clip`` command publishes
+the per-step target pose, the observation manager assembles the policy input,
+the reward manager scores how well the arm matches the reference, and the
+termination manager watches for divergence.
+
+The observation / reward / termination half of the recipe is loaded from
+``sim_managers_wbt.yaml``; the command block (the clip frames) is generated here
+because the frames are large arrays. The same declarative terms a WBT trainer
+consumes therefore run end to end on real simulator data, and the arm visibly
+performs the reference motion (saved to an MP4 + still).
+
+Run (headless):
+
+    MUJOCO_GL=egl python examples/sim_managers_wbt.py
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import numpy as np
+
+from strands_robots import create_simulation
+from strands_robots.sim_managers import EnvState, build_managers, load_managers_config
+from strands_robots.sim_managers.motion import MOTION_TARGET_POS
+
+CONFIG_PATH = Path(__file__).with_suffix(".yaml")
+ROBOT = "so101"
+N_STEPS = 240
+SUBSTEPS = 5
+VIDEO_PATH = "/tmp/sim_managers_wbt.mp4"
+STILL_PATH = "/tmp/sim_managers_wbt.png"
+
+
+def _make_motion_clip(n_joints: int, *, num_frames: int = 60, fps: float = 30.0) -> dict[str, object]:
+    """Build a smooth sinusoidal reference clip as a command_manager config block.
+
+    Each joint follows a 0.6 rad sine wave phase-offset from its neighbours, with
+    the analytic derivative supplied as the velocity target.
+    """
+    t = np.linspace(0.0, 2 * np.pi, num_frames, endpoint=False)
+    amp = 0.6
+    frames_pos = np.stack([amp * np.sin(t + 0.6 * j) for j in range(n_joints)], axis=1)
+    frames_vel = np.stack(
+        [amp * np.cos(t + 0.6 * j) * (2 * np.pi / (num_frames / fps)) for j in range(n_joints)], axis=1
+    )
+    return {
+        "terms": [
+            {
+                "name": "motion",
+                "func": "motion_clip",
+                "params": {"frames_pos": frames_pos.tolist(), "frames_vel": frames_vel.tolist(), "fps": fps},
+            }
+        ]
+    }
+
+
+def _extract_image(render: object) -> np.ndarray | None:
+    """Decode the RGB image out of a ``render()`` agent-tool content payload."""
+    if not isinstance(render, dict):
+        return None
+    import imageio.v3 as iio
+
+    for block in render.get("content", []) or []:
+        image = block.get("image") if isinstance(block, dict) else None
+        if isinstance(image, dict):
+            source = image.get("source", {})
+            data = source.get("bytes") if isinstance(source, dict) else None
+            if isinstance(data, bytes):
+                return np.asarray(iio.imread(data))
+    return None
+
+
+def main() -> None:
+    os.environ.setdefault("MUJOCO_GL", "egl")
+
+    sim = create_simulation(backend="mujoco")
+    sim.create_world()
+    if sim.add_robot(ROBOT).get("status") != "success":
+        raise RuntimeError(f"failed to add robot {ROBOT!r}")
+    sim.reset()
+
+    joint_names = sim.robot_joint_names(ROBOT)
+    n_joints = len(joint_names)
+
+    config = load_managers_config(CONFIG_PATH)  # validates the YAML half
+    assert config.observation and config.reward and config.termination
+    # Merge the generated command block with the YAML recipe and rebuild.
+    import yaml
+
+    recipe = yaml.safe_load(CONFIG_PATH.read_text())
+    recipe["command_manager"] = _make_motion_clip(n_joints)
+    managers = build_managers(recipe)
+    assert managers.command and managers.observation and managers.reward and managers.termination
+
+    model = sim._world._model
+    dt = float(model.opt.timestep) * SUBSTEPS
+
+    managers.command.reset()
+    managers.reward.reset()
+
+    last_action = np.zeros(n_joints)
+    frames: list[np.ndarray] = []
+    reward_totals: dict[str, float] = {}
+    total_reward = 0.0
+    obs_dim = 0
+    ended_at = None
+
+    for step in range(N_STEPS):
+        obs = sim.get_observation(ROBOT, skip_images=True)
+        joint_pos = np.array([float(obs[name]) for name in joint_names])
+        joint_vel = np.array([float(obs[f"{name}.vel"]) for name in joint_names])
+
+        state = EnvState(
+            joint_pos=joint_pos,
+            joint_vel=joint_vel,
+            action=last_action,
+            last_action=last_action,
+            dt=dt,
+            step_count=step,
+            max_episode_length=N_STEPS,
+        )
+        managers.command.compute(state)
+        target = np.asarray(state.extras[MOTION_TARGET_POS], dtype=np.float64)
+        state.action = target
+
+        obs_vec = managers.observation.compute(state)
+        obs_dim = obs_vec.shape[0]
+        total_reward += managers.reward.compute(state)
+        for label, value in managers.reward.term_values.items():
+            reward_totals[label] = reward_totals.get(label, 0.0) + value
+        result = managers.termination.compute(state)
+
+        sim.send_action(target.tolist(), ROBOT)
+        sim.step(SUBSTEPS)
+        last_action = target
+
+        image = _extract_image(sim.render(width=640, height=480))
+        if image is not None:
+            frames.append(image)
+
+        if result.done:
+            ended_at = (step, result.terms)
+            break
+
+    if frames:
+        import imageio.v3 as iio
+
+        iio.imwrite(VIDEO_PATH, np.stack(frames), fps=int(round(1.0 / dt)), codec="libx264")
+        iio.imwrite(STILL_PATH, frames[-1])
+        print(f"saved rollout video -> {VIDEO_PATH} ({len(frames)} frames)")
+        print(f"saved final still  -> {STILL_PATH}")
+
+    print(f"\nrobot={ROBOT}  control_dt={dt:.4f}s  observation_dim={obs_dim}  joints={n_joints}")
+    if ended_at is not None:
+        print(f"episode ended early at step {ended_at[0]}: {ended_at[1]}")
+    else:
+        print(f"completed full {N_STEPS}-step rollout with no divergence")
+    print(f"\ntotal reward over rollout: {total_reward:.4f}")
+    print("per-term reward contribution (summed):")
+    for label, value in sorted(reward_totals.items(), key=lambda kv: -abs(kv[1])):
+        print(f"  {label:<14} {value:+.5f}")
+
+    sim.destroy()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/sim_managers_wbt.yaml
+++ b/examples/sim_managers_wbt.yaml
@@ -1,0 +1,24 @@
+# Declarative whole-body-tracking (WBT) recipe consumed by sim_managers.
+# The command_manager block (the reference motion clip) is generated in
+# sim_managers_wbt.py because its frames are large arrays; the observation /
+# reward / termination blocks below are the declarative half of the recipe.
+observation_manager:
+  terms:
+    - {func: motion_phase}
+    - {func: joint_pos}
+    - {func: joint_vel, scale: 0.05}
+    - {func: motion_target_joint_pos}
+    - {func: joint_pos_error}
+    - {func: last_action}
+
+reward_manager:
+  scale_by_dt: true
+  terms:
+    - {name: track_pos, func: track_joint_pos_exp, weight: 1.0, params: {std: 0.4}}
+    - {name: track_vel, func: track_joint_vel_exp, weight: 0.2, params: {std: 2.0}}
+    - {name: action_rate, func: action_rate_l2, weight: -0.01}
+
+termination_manager:
+  terms:
+    - {func: time_out}
+    - {func: motion_divergence, params: {threshold: 1.5}}

--- a/strands_robots/sim_managers/__init__.py
+++ b/strands_robots/sim_managers/__init__.py
@@ -33,6 +33,7 @@ from strands_robots.sim_managers.base import (
 )
 from strands_robots.sim_managers.command import CommandManager
 from strands_robots.sim_managers.config import ManagerSet, build_managers, load_managers_config
+from strands_robots.sim_managers.motion import MotionClip
 from strands_robots.sim_managers.observation import ObservationManager
 from strands_robots.sim_managers.reward import RewardManager
 from strands_robots.sim_managers.termination import TerminationManager, TerminationResult
@@ -50,6 +51,7 @@ __all__ = [
     "TerminationManager",
     "TerminationResult",
     "CommandManager",
+    "MotionClip",
     "ManagerSet",
     "build_managers",
     "load_managers_config",

--- a/strands_robots/sim_managers/command/terms/__init__.py
+++ b/strands_robots/sim_managers/command/terms/__init__.py
@@ -1,5 +1,5 @@
 """Command term library. Importing registers terms in the global registry."""
 
-from strands_robots.sim_managers.command.terms import velocity
+from strands_robots.sim_managers.command.terms import motion, velocity
 
-__all__ = ["velocity"]
+__all__ = ["motion", "velocity"]

--- a/strands_robots/sim_managers/command/terms/motion.py
+++ b/strands_robots/sim_managers/command/terms/motion.py
@@ -1,0 +1,65 @@
+"""Reference-motion command term for whole-body tracking (WBT)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from strands_robots.sim_managers.base import EnvState, FloatArray, Term, register_term
+from strands_robots.sim_managers.motion import (
+    MOTION_PHASE,
+    MOTION_TARGET_POS,
+    MOTION_TARGET_VEL,
+    MotionClip,
+)
+
+
+@register_term("command", "motion_clip")
+class MotionClipCommand(Term):
+    """Replay a reference motion clip and publish its per-step targets.
+
+    On each control step the :class:`~strands_robots.sim_managers.CommandManager`
+    advances this term's clock by ``state.dt`` (via :meth:`update`) and then
+    calls it. The term samples the clip at the current elapsed time and writes
+    the interpolated target pose, target velocity, and phase into
+    ``state.extras`` under the :mod:`~strands_robots.sim_managers.motion` keys, so
+    the WBT observation / reward / termination terms can read them. The returned
+    value (also published as the command vector under this term's label) is the
+    target joint pose.
+
+    Args:
+        frames_pos: Reference joint positions, shape ``(num_frames, num_joints)``.
+        frames_vel: Optional matching joint velocities; defaults to zeros.
+        fps: Native frame rate of the clip in frames per second.
+        loop: When ``True`` the clip repeats; when ``False`` it holds the final
+            frame after one pass.
+    """
+
+    def __init__(
+        self,
+        frames_pos: Any,
+        frames_vel: Any | None = None,
+        fps: float = 30.0,
+        loop: bool = True,
+        **params: Any,
+    ) -> None:
+        super().__init__(frames_pos=frames_pos, frames_vel=frames_vel, fps=fps, loop=loop, **params)
+        self.clip = MotionClip.from_arrays(frames_pos, frames_vel, fps=fps)
+        self.loop = bool(loop)
+        self._t = 0.0
+
+    def reset(self, state: EnvState | None = None, *, rng: np.random.Generator | None = None) -> None:
+        """Rewind the clip to its start."""
+        self._t = 0.0
+
+    def update(self, dt: float) -> None:
+        """Advance the clip clock by ``dt`` seconds."""
+        self._t += dt
+
+    def __call__(self, state: EnvState) -> FloatArray:
+        target_pos, target_vel, phase = self.clip.sample(self._t, loop=self.loop)
+        state.extras[MOTION_TARGET_POS] = target_pos
+        state.extras[MOTION_TARGET_VEL] = target_vel
+        state.extras[MOTION_PHASE] = phase
+        return target_pos

--- a/strands_robots/sim_managers/motion.py
+++ b/strands_robots/sim_managers/motion.py
@@ -1,0 +1,166 @@
+"""Reference-motion support for whole-body-tracking (WBT) terms.
+
+Whole-body tracking trains a policy to imitate a reference motion: at each
+control step the robot is rewarded for matching a per-joint target pose (and
+velocity) sampled from a *motion clip*. This module provides the
+backend-agnostic plumbing shared by the WBT command / observation / reward /
+termination terms:
+
+- :class:`MotionClip` - an immutable reference trajectory (joint positions, and
+  optionally velocities) sampled at a fixed ``fps``, with phase-based
+  interpolation. It carries no simulator state, so the same clip drives a
+  MuJoCo, Isaac, or Newton rollout.
+- The :data:`MOTION_TARGET_POS` / :data:`MOTION_TARGET_VEL` / :data:`MOTION_PHASE`
+  keys, written into :attr:`EnvState.extras` by the ``motion_clip`` command term
+  and read by the WBT observation / reward / termination terms. Centralising the
+  keys keeps the producer and consumers in agreement (one source of truth) and
+  lets a consumer raise a clear, actionable error when no command term populated
+  them.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from strands_robots.sim_managers.base import EnvState, FloatArray
+
+# Keys the ``motion_clip`` command term writes into ``EnvState.extras`` and the
+# WBT observation / reward / termination terms read back.
+MOTION_TARGET_POS = "motion_target_pos"
+MOTION_TARGET_VEL = "motion_target_vel"
+MOTION_PHASE = "motion_phase"
+
+
+def read_motion_target(state: EnvState, key: str) -> Any:
+    """Read a motion-tracking quantity from ``state.extras``.
+
+    Args:
+        state: The environment state, expected to have been populated by a
+            ``motion_clip`` command term earlier in the same control step.
+        key: One of :data:`MOTION_TARGET_POS`, :data:`MOTION_TARGET_VEL`,
+            :data:`MOTION_PHASE`.
+
+    Returns:
+        The stored value (a float for the phase, a 1-D array for the targets).
+
+    Raises:
+        KeyError: If the key is absent, with a message pointing at the missing
+            ``motion_clip`` command term rather than degrading silently.
+    """
+    try:
+        return state.extras[key]
+    except KeyError:
+        raise KeyError(
+            f"motion target {key!r} not found in EnvState.extras; available: "
+            f"{sorted(state.extras)}. A 'motion_clip' command term must run "
+            "(CommandManager.compute) before WBT observation/reward/termination "
+            "terms can read its targets."
+        ) from None
+
+
+@dataclass
+class MotionClip:
+    """A reference joint trajectory sampled at a fixed frame rate.
+
+    The clip is interpolated by *phase* - the fractional position along the
+    trajectory in ``[0, 1)``. :meth:`sample` maps an elapsed time to a phase and
+    linearly interpolates the bracketing frames, so a clip can be replayed at any
+    control rate independent of its native ``fps``.
+
+    Args:
+        frames_pos: Per-frame joint positions, shape ``(num_frames, num_joints)``.
+        frames_vel: Per-frame joint velocities, same shape as ``frames_pos``.
+        fps: Native sampling rate of the clip in frames per second.
+    """
+
+    frames_pos: FloatArray
+    frames_vel: FloatArray
+    fps: float
+
+    @classmethod
+    def from_arrays(
+        cls,
+        frames_pos: Any,
+        frames_vel: Any | None = None,
+        fps: float = 30.0,
+    ) -> MotionClip:
+        """Build and validate a :class:`MotionClip` from array-likes.
+
+        Args:
+            frames_pos: ``(num_frames, num_joints)`` joint positions.
+            frames_vel: Optional matching joint velocities; defaults to zeros.
+            fps: Native frame rate (must be positive).
+
+        Returns:
+            The validated clip.
+
+        Raises:
+            ValueError: If ``frames_pos`` is not a non-empty 2-D array, if
+                ``frames_vel`` does not match its shape, or if ``fps <= 0``.
+        """
+        pos = np.asarray(frames_pos, dtype=np.float64)
+        if pos.ndim != 2 or pos.shape[0] == 0 or pos.shape[1] == 0:
+            raise ValueError(
+                f"frames_pos must be a non-empty 2-D (num_frames, num_joints) array, got shape {pos.shape}"
+            )
+        if frames_vel is None:
+            vel = np.zeros_like(pos)
+        else:
+            vel = np.asarray(frames_vel, dtype=np.float64)
+            if vel.shape != pos.shape:
+                raise ValueError(f"frames_vel shape {vel.shape} must match frames_pos shape {pos.shape}")
+        if fps <= 0.0:
+            raise ValueError(f"fps must be positive, got {fps}")
+        return cls(frames_pos=pos, frames_vel=vel, fps=float(fps))
+
+    @property
+    def num_frames(self) -> int:
+        """Number of frames in the clip."""
+        return int(self.frames_pos.shape[0])
+
+    @property
+    def num_joints(self) -> int:
+        """Number of joints each frame describes."""
+        return int(self.frames_pos.shape[1])
+
+    @property
+    def duration(self) -> float:
+        """Clip duration in seconds (``num_frames / fps``)."""
+        return self.num_frames / self.fps
+
+    def sample(self, t: float, *, loop: bool = True) -> tuple[FloatArray, FloatArray, float]:
+        """Sample the interpolated target pose, velocity, and phase at time ``t``.
+
+        Args:
+            t: Elapsed time in seconds since the clip started.
+            loop: When ``True`` the clip wraps (cyclic interpolation across the
+                last->first frame); when ``False`` ``t`` is clamped to the final
+                frame.
+
+        Returns:
+            ``(target_pos, target_vel, phase)`` where the targets are 1-D arrays
+            of length ``num_joints`` and ``phase`` is in ``[0, 1)``.
+        """
+        n = self.num_frames
+        if n == 1:
+            return self.frames_pos[0].copy(), self.frames_vel[0].copy(), 0.0
+
+        if loop:
+            phase = (t / self.duration) % 1.0
+            frame = phase * n
+            lo = int(np.floor(frame)) % n
+            hi = (lo + 1) % n
+            frac = frame - np.floor(frame)
+        else:
+            phase = float(np.clip(t / self.duration, 0.0, 1.0))
+            frame = min(phase * n, n - 1.0)
+            lo = int(np.floor(frame))
+            hi = min(lo + 1, n - 1)
+            frac = frame - lo
+
+        pos = (1.0 - frac) * self.frames_pos[lo] + frac * self.frames_pos[hi]
+        vel = (1.0 - frac) * self.frames_vel[lo] + frac * self.frames_vel[hi]
+        return pos, vel, float(phase)

--- a/strands_robots/sim_managers/observation/terms/__init__.py
+++ b/strands_robots/sim_managers/observation/terms/__init__.py
@@ -1,5 +1,5 @@
 """Observation term library. Importing registers terms in the global registry."""
 
-from strands_robots.sim_managers.observation.terms import locomotion
+from strands_robots.sim_managers.observation.terms import locomotion, tracking
 
-__all__ = ["locomotion"]
+__all__ = ["locomotion", "tracking"]

--- a/strands_robots/sim_managers/observation/terms/tracking.py
+++ b/strands_robots/sim_managers/observation/terms/tracking.py
@@ -1,0 +1,69 @@
+"""Whole-body-tracking (WBT) observation terms.
+
+These expose the reference-motion targets published by the ``motion_clip``
+command term so a tracking policy observes what it is being asked to imitate.
+Each reads ``state.extras`` via :func:`~strands_robots.sim_managers.motion.read_motion_target`,
+which raises a clear error if no ``motion_clip`` command term ran this step.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from strands_robots.sim_managers.base import EnvState, FloatArray, Term, register_term
+from strands_robots.sim_managers.motion import (
+    MOTION_PHASE,
+    MOTION_TARGET_POS,
+    MOTION_TARGET_VEL,
+    read_motion_target,
+)
+
+
+@register_term("observation", "motion_phase")
+class MotionPhase(Term):
+    """Cyclic clip phase encoded as ``[sin(2*pi*phase), cos(2*pi*phase)]``.
+
+    The sin/cos encoding is continuous across the loop boundary (phase 1 -> 0),
+    unlike the raw scalar, which is the standard phase observation for periodic
+    motion tracking.
+    """
+
+    def __call__(self, state: EnvState) -> FloatArray:
+        phase = float(read_motion_target(state, MOTION_PHASE))
+        angle = 2.0 * np.pi * phase
+        return np.array([np.sin(angle), np.cos(angle)])
+
+
+@register_term("observation", "motion_target_joint_pos")
+class MotionTargetJointPos(Term):
+    """Target joint positions for the current clip frame (shape ``(n_joints,)``)."""
+
+    def __call__(self, state: EnvState) -> FloatArray:
+        return np.asarray(read_motion_target(state, MOTION_TARGET_POS), dtype=np.float64)
+
+
+@register_term("observation", "motion_target_joint_vel")
+class MotionTargetJointVel(Term):
+    """Target joint velocities for the current clip frame (shape ``(n_joints,)``)."""
+
+    def __call__(self, state: EnvState) -> FloatArray:
+        return np.asarray(read_motion_target(state, MOTION_TARGET_VEL), dtype=np.float64)
+
+
+@register_term("observation", "joint_pos_error")
+class JointPosError(Term):
+    """Per-joint tracking error ``joint_pos - target`` (shape ``(n_joints,)``).
+
+    Raises:
+        ValueError: If the target length does not match the robot's joint count
+            (a misconfigured clip), rather than broadcasting silently.
+    """
+
+    def __call__(self, state: EnvState) -> FloatArray:
+        target = np.asarray(read_motion_target(state, MOTION_TARGET_POS), dtype=np.float64)
+        if target.shape != state.joint_pos.shape:
+            raise ValueError(
+                f"motion target length {target.shape[0]} != joint count {state.num_joints}; "
+                "the motion_clip frames must have one column per joint."
+            )
+        return state.joint_pos - target

--- a/strands_robots/sim_managers/reward/terms/__init__.py
+++ b/strands_robots/sim_managers/reward/terms/__init__.py
@@ -1,5 +1,5 @@
 """Reward term library. Importing registers terms in the global registry."""
 
-from strands_robots.sim_managers.reward.terms import locomotion
+from strands_robots.sim_managers.reward.terms import locomotion, tracking
 
-__all__ = ["locomotion"]
+__all__ = ["locomotion", "tracking"]

--- a/strands_robots/sim_managers/reward/terms/tracking.py
+++ b/strands_robots/sim_managers/reward/terms/tracking.py
@@ -1,0 +1,68 @@
+"""Whole-body-tracking (WBT) reward terms.
+
+Tracking terms return a bounded ``(0, 1]`` Gaussian kernel of the per-joint
+imitation error, matching the ``track_*_exp`` convention of the locomotion
+terms: the :class:`~strands_robots.sim_managers.RewardManager` applies the
+configured ``weight``. They read the reference targets published by the
+``motion_clip`` command term.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from strands_robots.sim_managers.base import EnvState, Term, register_term
+from strands_robots.sim_managers.motion import (
+    MOTION_TARGET_POS,
+    MOTION_TARGET_VEL,
+    read_motion_target,
+)
+
+
+def _tracking_error(value: np.ndarray, target: np.ndarray, quantity: str) -> float:
+    """Sum of squared per-joint error, validating matching shapes."""
+    target = np.asarray(target, dtype=np.float64)
+    if target.shape != value.shape:
+        raise ValueError(
+            f"motion {quantity} target length {target.shape[0]} != joint count {value.shape[0]}; "
+            "the motion_clip frames must have one column per joint."
+        )
+    return float(np.sum((value - target) ** 2))
+
+
+@register_term("reward", "track_joint_pos_exp")
+class TrackJointPosExp(Term):
+    """Reward matching the reference joint pose (Gaussian kernel).
+
+    Args:
+        std: Tracking tolerance; smaller is stricter.
+    """
+
+    def __init__(self, std: float = 0.5, **params: Any) -> None:
+        super().__init__(std=std, **params)
+        self.std = float(std)
+
+    def __call__(self, state: EnvState) -> float:
+        target = read_motion_target(state, MOTION_TARGET_POS)
+        err = _tracking_error(state.joint_pos, target, "position")
+        return float(np.exp(-err / self.std**2))
+
+
+@register_term("reward", "track_joint_vel_exp")
+class TrackJointVelExp(Term):
+    """Reward matching the reference joint velocity (Gaussian kernel).
+
+    Args:
+        std: Tracking tolerance; smaller is stricter.
+    """
+
+    def __init__(self, std: float = 1.0, **params: Any) -> None:
+        super().__init__(std=std, **params)
+        self.std = float(std)
+
+    def __call__(self, state: EnvState) -> float:
+        target = read_motion_target(state, MOTION_TARGET_VEL)
+        err = _tracking_error(state.joint_vel, target, "velocity")
+        return float(np.exp(-err / self.std**2))

--- a/strands_robots/sim_managers/termination/terms/__init__.py
+++ b/strands_robots/sim_managers/termination/terms/__init__.py
@@ -1,5 +1,5 @@
 """Termination term library. Importing registers terms in the global registry."""
 
-from strands_robots.sim_managers.termination.terms import locomotion
+from strands_robots.sim_managers.termination.terms import locomotion, tracking
 
-__all__ = ["locomotion"]
+__all__ = ["locomotion", "tracking"]

--- a/strands_robots/sim_managers/termination/terms/tracking.py
+++ b/strands_robots/sim_managers/termination/terms/tracking.py
@@ -1,0 +1,36 @@
+"""Whole-body-tracking (WBT) termination terms."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from strands_robots.sim_managers.base import EnvState, Term, register_term
+from strands_robots.sim_managers.motion import MOTION_TARGET_POS, read_motion_target
+
+
+@register_term("termination", "motion_divergence")
+class MotionDivergence(Term):
+    """Terminate (failure) when the pose strays too far from the reference.
+
+    Fires when the L2 norm of the per-joint position error exceeds
+    ``threshold`` - the standard "lost the motion" early-termination used in
+    imitation / tracking training. This is a failure, not a timeout.
+
+    Args:
+        threshold: Maximum allowed L2 joint-position error (radians).
+    """
+
+    def __init__(self, threshold: float = 1.5, **params: Any) -> None:
+        super().__init__(threshold=threshold, **params)
+        self.threshold = float(threshold)
+
+    def __call__(self, state: EnvState) -> bool:
+        target = np.asarray(read_motion_target(state, MOTION_TARGET_POS), dtype=np.float64)
+        if target.shape != state.joint_pos.shape:
+            raise ValueError(
+                f"motion target length {target.shape[0]} != joint count {state.num_joints}; "
+                "the motion_clip frames must have one column per joint."
+            )
+        return float(np.linalg.norm(state.joint_pos - target)) > self.threshold

--- a/tests/sim_managers/test_motion_clip.py
+++ b/tests/sim_managers/test_motion_clip.py
@@ -1,0 +1,89 @@
+"""MotionClip: construction validation and phase-based interpolation."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from strands_robots.sim_managers.motion import MotionClip
+
+
+def _ramp_clip(num_frames: int = 4, num_joints: int = 2, fps: float = 10.0) -> MotionClip:
+    pos = np.linspace(0.0, 1.0, num_frames)[:, None] * np.ones((1, num_joints))
+    return MotionClip.from_arrays(pos, fps=fps)
+
+
+def test_metadata():
+    clip = _ramp_clip(num_frames=5, num_joints=3, fps=25.0)
+    assert clip.num_frames == 5
+    assert clip.num_joints == 3
+    assert clip.duration == pytest.approx(5 / 25.0)
+
+
+def test_defaults_velocity_to_zeros():
+    clip = _ramp_clip()
+    _, vel, _ = clip.sample(0.0)
+    np.testing.assert_array_equal(vel, np.zeros(clip.num_joints))
+
+
+def test_sample_first_frame_exact():
+    clip = _ramp_clip(num_frames=4, num_joints=2, fps=10.0)
+    pos, _, phase = clip.sample(0.0, loop=True)
+    np.testing.assert_allclose(pos, clip.frames_pos[0])
+    assert phase == pytest.approx(0.0)
+
+
+def test_sample_interpolates_between_frames():
+    # 2 frames [0,0] -> [1,1] over 0.2s (fps=10 -> 2 frames). Halfway phase=0.5.
+    pos = np.array([[0.0, 0.0], [1.0, 1.0]])
+    clip = MotionClip.from_arrays(pos, fps=10.0)
+    # duration = 2/10 = 0.2; t=0.05 -> phase 0.25 -> frame 0.5 -> halfway between f0 and f1
+    p, _, phase = clip.sample(0.05, loop=True)
+    assert phase == pytest.approx(0.25)
+    np.testing.assert_allclose(p, [0.5, 0.5])
+
+
+def test_loop_wraps_around():
+    pos = np.array([[0.0], [1.0]])
+    clip = MotionClip.from_arrays(pos, fps=10.0)
+    # duration 0.2; t equal to one full period returns to start
+    p0, _, ph0 = clip.sample(0.0, loop=True)
+    p1, _, ph1 = clip.sample(clip.duration, loop=True)
+    np.testing.assert_allclose(p0, p1)
+    assert ph1 == pytest.approx(0.0)
+
+
+def test_no_loop_clamps_to_final_frame():
+    pos = np.array([[0.0], [1.0]])
+    clip = MotionClip.from_arrays(pos, fps=10.0)
+    p, _, phase = clip.sample(t=10.0, loop=False)  # far past the end
+    np.testing.assert_allclose(p, [1.0])
+    assert phase == pytest.approx(1.0)
+
+
+def test_single_frame_clip_is_constant():
+    clip = MotionClip.from_arrays([[0.3, -0.2]], fps=30.0)
+    p, v, phase = clip.sample(5.0, loop=True)
+    np.testing.assert_allclose(p, [0.3, -0.2])
+    np.testing.assert_allclose(v, [0.0, 0.0])
+    assert phase == 0.0
+
+
+def test_rejects_non_2d_frames():
+    with pytest.raises(ValueError, match="non-empty 2-D"):
+        MotionClip.from_arrays([0.0, 1.0, 2.0])
+
+
+def test_rejects_empty_frames():
+    with pytest.raises(ValueError, match="non-empty 2-D"):
+        MotionClip.from_arrays(np.zeros((0, 3)))
+
+
+def test_rejects_mismatched_velocity_shape():
+    with pytest.raises(ValueError, match="frames_vel shape"):
+        MotionClip.from_arrays(np.zeros((4, 2)), frames_vel=np.zeros((4, 3)))
+
+
+def test_rejects_non_positive_fps():
+    with pytest.raises(ValueError, match="fps must be positive"):
+        MotionClip.from_arrays(np.zeros((4, 2)), fps=0.0)

--- a/tests/sim_managers/test_wbt_integral.py
+++ b/tests/sim_managers/test_wbt_integral.py
@@ -1,0 +1,114 @@
+"""WBT integral rollout: a tracking agent outscores a stationary one.
+
+Drives a 6-joint clip through the full manager stack (command + observation +
+reward + termination) for a synthetic agent that perfectly follows the
+reference, and a stationary agent that never moves. The tracking agent must
+accumulate a strictly higher pose-tracking reward and never trigger the
+divergence termination, while the stationary agent diverges - the end-to-end
+contract a WBT trainer relies on.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from strands_robots.sim_managers import (
+    CommandManager,
+    EnvState,
+    ObservationManager,
+    RewardManager,
+    TerminationManager,
+)
+from strands_robots.sim_managers.motion import MOTION_TARGET_POS, MOTION_TARGET_VEL
+
+# A smooth 16-frame sinusoidal clip on 6 joints.
+_N_FRAMES = 16
+_N_JOINTS = 6
+_t = np.linspace(0.0, 2 * np.pi, _N_FRAMES, endpoint=False)
+FRAMES_POS = np.stack([0.5 * np.sin(_t + j) for j in range(_N_JOINTS)], axis=1)
+FRAMES_VEL = np.stack([0.5 * np.cos(_t + j) for j in range(_N_JOINTS)], axis=1)
+FPS = 20.0
+DT = 0.05
+
+
+def _managers():
+    command = CommandManager.from_config(
+        {
+            "terms": [
+                {
+                    "name": "motion",
+                    "func": "motion_clip",
+                    "params": {"frames_pos": FRAMES_POS.tolist(), "frames_vel": FRAMES_VEL.tolist(), "fps": FPS},
+                }
+            ]
+        }
+    )
+    observation = ObservationManager.from_config(
+        {
+            "terms": [
+                {"func": "motion_phase"},
+                {"func": "joint_pos"},
+                {"func": "joint_pos_error"},
+            ]
+        }
+    )
+    reward = RewardManager.from_config(
+        {
+            "terms": [
+                {"name": "track_pos", "func": "track_joint_pos_exp", "weight": 1.0, "params": {"std": 0.4}},
+                {"name": "track_vel", "func": "track_joint_vel_exp", "weight": 0.5, "params": {"std": 2.0}},
+            ]
+        }
+    )
+    termination = TerminationManager.from_config(
+        {"terms": [{"func": "time_out"}, {"func": "motion_divergence", "params": {"threshold": 0.7}}]}
+    )
+    return command, observation, reward, termination
+
+
+def _rollout(*, track: bool, n_steps: int = 40):
+    command, observation, reward, termination = _managers()
+    command.reset()
+    reward.reset()
+    total = 0.0
+    diverged = False
+    obs_dim = 0
+    for step in range(n_steps):
+        state = EnvState(
+            joint_pos=np.zeros(_N_JOINTS),
+            joint_vel=np.zeros(_N_JOINTS),
+            action=np.zeros(_N_JOINTS),
+            last_action=np.zeros(_N_JOINTS),
+            dt=DT,
+            step_count=step,
+            max_episode_length=n_steps,
+        )
+        command.compute(state)
+        if track:
+            # perfect follower: actual joints equal the published targets
+            state.joint_pos = np.asarray(state.extras[MOTION_TARGET_POS], dtype=float)
+            state.joint_vel = np.asarray(state.extras[MOTION_TARGET_VEL], dtype=float)
+        obs = observation.compute(state)
+        obs_dim = obs.shape[0]
+        total += reward.compute(state)
+        result = termination.compute(state)
+        if result.terminated:
+            diverged = True
+            break
+    return total, diverged, obs_dim
+
+
+def test_tracking_agent_outscores_stationary():
+    track_reward, track_diverged, obs_dim = _rollout(track=True)
+    still_reward, _, _ = _rollout(track=False)
+    assert track_reward > still_reward
+    assert not track_diverged  # perfect follower never diverges
+    # obs = phase(2) + joint_pos(6) + joint_pos_error(6) = 14
+    assert obs_dim == 14
+
+
+def test_stationary_agent_diverges_from_motion():
+    # With a clip amplitude of 0.5 across 6 joints, the stationary agent's
+    # error norm (~0.85) crosses the 0.7 threshold within the rollout.
+    _, diverged, _ = _rollout(track=False)
+    assert diverged

--- a/tests/sim_managers/test_wbt_terms.py
+++ b/tests/sim_managers/test_wbt_terms.py
@@ -1,0 +1,131 @@
+"""WBT terms: command publication, observations, rewards, termination, errors."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from strands_robots.sim_managers import (
+    CommandManager,
+    EnvState,
+    ObservationManager,
+    get_term_class,
+)
+from strands_robots.sim_managers.motion import (
+    MOTION_PHASE,
+    MOTION_TARGET_POS,
+    MOTION_TARGET_VEL,
+)
+
+# A 2-frame clip on 2 joints: [0,0] -> [1,-1], fps=10 (duration 0.2s).
+FRAMES_POS = [[0.0, 0.0], [1.0, -1.0]]
+FRAMES_VEL = [[0.0, 0.0], [2.0, -2.0]]
+
+
+def _state(joint_pos, joint_vel=None, dt=0.02):
+    jp = np.asarray(joint_pos, dtype=float)
+    jv = np.zeros_like(jp) if joint_vel is None else np.asarray(joint_vel, dtype=float)
+    return EnvState(joint_pos=jp, joint_vel=jv, action=np.zeros_like(jp), last_action=np.zeros_like(jp), dt=dt)
+
+
+def _command_manager():
+    return CommandManager.from_config(
+        {
+            "terms": [
+                {
+                    "name": "motion",
+                    "func": "motion_clip",
+                    "params": {"frames_pos": FRAMES_POS, "frames_vel": FRAMES_VEL, "fps": 10.0},
+                }
+            ]
+        }
+    )
+
+
+def test_command_publishes_targets_to_extras():
+    mgr = _command_manager()
+    state = _state([0.0, 0.0])
+    out = mgr.compute(state)  # t=0 after one update of dt -> still near frame 0
+    assert MOTION_TARGET_POS in state.extras
+    assert MOTION_TARGET_VEL in state.extras
+    assert MOTION_PHASE in state.extras
+    # returned command vector equals the published target pose
+    np.testing.assert_allclose(out["motion"], state.extras[MOTION_TARGET_POS])
+
+
+def test_command_phase_advances_over_steps():
+    mgr = _command_manager()
+    state = _state([0.0, 0.0], dt=0.05)  # quarter of the 0.2s clip per step
+    phases = []
+    for _ in range(4):
+        mgr.compute(state)
+        phases.append(state.extras[MOTION_PHASE])
+    # phase strictly increases through the first cycle then wraps
+    assert phases[0] < phases[1] < phases[2]
+
+
+def test_observation_terms_dims_and_values():
+    mgr = _command_manager()
+    obs_mgr = ObservationManager.from_config(
+        {
+            "terms": [
+                {"func": "motion_phase"},
+                {"func": "motion_target_joint_pos"},
+                {"func": "motion_target_joint_vel"},
+                {"func": "joint_pos_error"},
+            ]
+        }
+    )
+    state = _state([0.25, 0.25])
+    mgr.compute(state)
+    obs = obs_mgr.compute(state)
+    # phase(2) + target_pos(2) + target_vel(2) + error(2) = 8
+    assert obs.shape == (8,)
+    # joint_pos_error slice == joint_pos - target
+    sl = obs_mgr.term_slices["joint_pos_error"]
+    np.testing.assert_allclose(obs[sl], state.joint_pos - state.extras[MOTION_TARGET_POS])
+
+
+def test_track_joint_pos_exp_peaks_when_matched():
+    term = get_term_class("reward", "track_joint_pos_exp")(std=0.5)
+    state = _state([0.0, 0.0])
+    state.extras[MOTION_TARGET_POS] = np.array([0.0, 0.0])
+    matched = term(state)
+    state2 = _state([0.0, 0.0])
+    state2.extras[MOTION_TARGET_POS] = np.array([1.0, -1.0])
+    mismatched = term(state2)
+    assert matched == pytest.approx(1.0)
+    assert mismatched < matched
+
+
+def test_track_joint_vel_exp_peaks_when_matched():
+    term = get_term_class("reward", "track_joint_vel_exp")(std=1.0)
+    state = _state([0.0, 0.0], joint_vel=[0.5, -0.5])
+    state.extras[MOTION_TARGET_VEL] = np.array([0.5, -0.5])
+    assert term(state) == pytest.approx(1.0)
+
+
+def test_motion_divergence_terminates_when_far():
+    term = get_term_class("termination", "motion_divergence")(threshold=0.5)
+    state = _state([1.0, -1.0])
+    state.extras[MOTION_TARGET_POS] = np.array([0.0, 0.0])  # error norm ~1.41 > 0.5
+    assert term(state) is True
+    assert getattr(term, "is_time_out", False) is False
+    near = _state([0.1, 0.0])
+    near.extras[MOTION_TARGET_POS] = np.array([0.0, 0.0])
+    assert term(near) is False
+
+
+def test_missing_motion_target_raises_actionable_error():
+    term = get_term_class("reward", "track_joint_pos_exp")()
+    state = _state([0.0, 0.0])  # no command term ran -> extras empty
+    with pytest.raises(KeyError, match="motion_clip"):
+        term(state)
+
+
+def test_target_dimension_mismatch_raises():
+    term = get_term_class("observation", "joint_pos_error")()
+    state = _state([0.0, 0.0, 0.0])  # 3 joints
+    state.extras[MOTION_TARGET_POS] = np.array([0.0, 0.0])  # 2-joint clip
+    with pytest.raises(ValueError, match="one column per joint"):
+        term(state)


### PR DESCRIPTION
## Problem

The `sim_managers` framework ships first-class locomotion terms but no support for *whole-body tracking* (WBT) - training a policy to imitate a reference motion. Tracking is the other half of the manager pattern: locomotion and WBT share most terms (the same observation assembly, the same `track_*_exp` reward convention, the same timeout/failure termination split) and differ only in a few motion-specific terms. Without those terms a WBT recipe still has to be hand-wired in Python, which is exactly what the framework exists to avoid.

## Change

Add reference-motion tracking on top of the existing managers - no new manager kind, no change to the `EnvState` contract. A WBT recipe is now just a different selection of registered terms in the same config DSL.

**Motion primitive (`sim_managers/motion.py`)**
- `MotionClip` - an immutable reference trajectory (joint positions, optional velocities) sampled at a fixed `fps` and interpolated by *phase* in `[0, 1)`, so a clip replays at any control rate independent of its native frame rate. Validates shape/`fps` on construction.
- A documented extras-key convention (`motion_target_pos` / `motion_target_vel` / `motion_phase`) plus `read_motion_target`, which raises an actionable error naming the missing `motion_clip` command term rather than degrading silently. One source of truth shared by the producer and the consuming terms.

**Command term** - `motion_clip` replays a clip: the `CommandManager` advances its clock by `state.dt` each step, and it publishes the interpolated target pose, target velocity, and phase into `state.extras` for the tracking terms to read (the standard commands-first ordering).

**Observation terms** - `motion_phase` (cyclic `[sin, cos]`, continuous across the loop boundary), `motion_target_joint_pos`, `motion_target_joint_vel`, `joint_pos_error` (`joint_pos - target`).

**Reward terms** - `track_joint_pos_exp`, `track_joint_vel_exp`: bounded `(0, 1]` Gaussian kernels of the per-joint pose / velocity error, matching the locomotion `track_*_exp` convention. Smoothness penalties reuse the existing `action_rate_l2` / `dof_acc_l2` terms.

**Termination term** - `motion_divergence`: a failure (not a timeout) when the L2 joint-position error exceeds `threshold` - the standard "lost the motion" early stop.

`MotionClip` is exported from the package; the terms register on import, so they are immediately available to `build_managers` / `load_managers_config`. Locomotion and WBT now share the same managers, registry, and DSL, so a multi-task recipe reuses the common terms with no duplication.

```yaml
command_manager:
  terms: [{name: motion, func: motion_clip, params: {frames_pos: [[...]], fps: 30.0}}]
observation_manager:
  terms: [{func: motion_phase}, {func: joint_pos_error}]
reward_manager:
  terms:
    - {name: track_pos, func: track_joint_pos_exp, weight: 1.0, params: {std: 0.4}}
    - {name: track_vel, func: track_joint_vel_exp, weight: 0.2, params: {std: 2.0}}
termination_manager:
  terms: [{func: time_out}, {func: motion_divergence, params: {threshold: 1.5}}]
```

## Tests

21 new tests (`tests/sim_managers/`): `MotionClip` interpolation (first/mid/wrap/clamp/single-frame) and construction validation; the `motion_clip` command publishing targets and advancing phase; each observation/reward/termination term's numeric behaviour; the missing-target and dimension-mismatch error paths; and an integral rollout asserting a perfect follower outscores a stationary agent on pose tracking and never diverges, while the stationary agent crosses the divergence threshold. The new modules do not exist on `main`, so these tests fail to import on pre-change code and guard the contract going forward.

Green locally (CI scope `strands_robots tests tests_integ`): `ruff check` + `ruff format --check` clean, `mypy` clean (no issues in 632 source files), full `sim_managers` suite 74 passed.

## Integration evidence

`examples/sim_managers_wbt.py` builds a `motion_clip` recipe (observation/reward/termination from `sim_managers_wbt.yaml`, clip frames generated in Python) and drives a position-controlled SO-101 arm in headless MuJoCo (`MUJOCO_GL=egl`) to imitate the reference. The same terms a trainer would consume run end to end on real simulator data:

```text
robot=so101  control_dt=0.0100s  observation_dim=32  joints=6
completed full 240-step rollout with no divergence

total reward over rollout: 1.7049
per-term reward contribution (summed):
  track_pos      +1.42909
  track_vel      +0.27594
  action_rate    -0.00012
```

The arm completes the clip with no divergence and a pose-tracking-dominated reward. Rollout in MuJoCo sim (headless):

![WBT rollout: SO-101 arm imitating a reference motion clip](https://github.com/cagataycali/robots/releases/download/sim-managers-wbt-demo/sim_managers_wbt.gif)

<video src="https://github.com/cagataycali/robots/releases/download/sim-managers-wbt-demo/sim_managers_wbt.mp4" controls></video>

## Docs

`docs/training/managers.md` gains a Whole-body tracking section (the `MotionClip` primitive, the extras convention and ordering requirement, the full term list, and a recipe), plus a pointer to the WBT example.