### PR TITLE
feat(policies): re-export list_policy_types as a discovery peer of list_providers

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -20,6 +20,7 @@ import strands_robots
 | `create_policy(provider, **kw)` | Policy factory | [Policies](policies/overview.md) |
 | `register_policy(name, loader, aliases=None)` | Runtime registration | [Custom policies](policies/custom-policies.md) |
 | `list_providers()` | Known policy providers | [Policies](policies/overview.md) |
+| `list_policy_types()` (lazy) | Resolvable `lerobot_local` `policy_type` strings | [LeRobot local](policies/lerobot-local.md) |
 | `Simulation` (lazy) | MuJoCo-backed AgentTool | [Simulation overview](simulation/overview.md) |
 | `Gr00tPolicy` (lazy) | NVIDIA GR00T client | [GR00T](policies/groot.md) |
 
@@ -120,6 +121,7 @@ from strands_robots.policies.cosmos3 import Cosmos3Policy
 | `create_policy(provider, **kw)` | Resolve + construct. Accepts `zmq://`, `cosmos3://`, HF `org/model`. |
 | `register_policy(name, loader, aliases)` | Runtime registration. |
 | `list_providers()` | `['cosmos3', 'groot', 'lerobot_local', 'mock', + aliases]`. |
+| `list_policy_types()` | `policy_type` strings the installed lerobot resolves; `[]` without lerobot. Discovery peer of `list_providers`. |
 | `UntrustedRemoteCodeError` | Raised when `STRANDS_TRUST_REMOTE_CODE` is required but unset. |
 | `Gr00tPolicy` | GR00T N1.5/N1.6/N1.7 via ZMQ (service) or in-process. |
 | `LerobotLocalPolicy` | HF LeRobot inference (ACT, Pi0, Pi0.5, SmolVLA, …). Needs `STRANDS_TRUST_REMOTE_CODE=1`. |

--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -165,16 +165,23 @@ static list (see [Discovering supported policy types](#discovering-supported-pol
 ### Discovering supported policy types
 
 Enumerate the resolvable `policy_type` strings programmatically instead of
-guessing:
+guessing. `list_policy_types` is the discovery peer of `list_providers` (the
+follow-up to "which provider?" is "which `policy_type` does it take?"), so it
+is re-exported at the package root and on `strands_robots.policies` alongside
+`list_providers` -- no reach into the `lerobot_local` submodule required:
 
 ```python
-from strands_robots.policies.lerobot_local import list_policy_types
+from strands_robots import list_policy_types  # or: from strands_robots.policies import list_policy_types
 
 list_policy_types()
 # ['act', 'diffusion', 'eo1', 'gaussian_actor', 'groot', 'molmoact2',
 #  'multi_task_dit', 'pi0', 'pi05', 'pi0_fast', 'smolvla', 'tdmpc',
 #  'vla_jepa', 'vqbet', 'wall_x', 'xvla']
 ```
+
+The submodule path `from strands_robots.policies.lerobot_local import
+list_policy_types` keeps working; the top-level re-export is lazy, so reaching
+it does not make a bare `import strands_robots` pull in torch.
 
 The list reflects the *installed* lerobot (sourced from its policy registry),
 so a newer lerobot reports more entries and a slimmer one fewer; it returns

--- a/docs/policies/overview.md
+++ b/docs/policies/overview.md
@@ -5,9 +5,10 @@ description: The Policy ABC and the providers that ship - MockPolicy, Gr00tPolic
 # Policy providers
 
 ```python
-from strands_robots.policies import create_policy, list_providers
+from strands_robots.policies import create_policy, list_policy_types, list_providers
 
 print(list_providers())   # ['cosmos3', 'groot', 'lerobot_local', 'mock', 'vera', ...]
+print(list_policy_types())  # lerobot_local policy_type strings: ['act', 'diffusion', 'smolvla', ...]
 
 policy = create_policy("mock")                                                     # always works, no model
 policy = create_policy("groot", port=5555, data_config="so100_dualcam")

--- a/strands_robots/__init__.py
+++ b/strands_robots/__init__.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
     from strands_robots.hardware_ros_bridge import HardwareRosBridge
     from strands_robots.hardware_rtps_bridge import HardwareRtpsBridge
     from strands_robots.policies.groot import Gr00tPolicy
+    from strands_robots.policies.lerobot_local.resolution import list_policy_types
     from strands_robots.registry import (
         get_robot,
         is_discoverable,
@@ -101,6 +102,11 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "is_discoverable": ("strands_robots.registry", "is_discoverable"),
     # Policies
     "Gr00tPolicy": ("strands_robots.policies.groot", "Gr00tPolicy"),
+    # lerobot_local policy-type discovery surface. Lazy (unlike list_providers,
+    # whose factory is torch-free) because the lerobot_local package import
+    # chain pulls in torch; resolving on first access keeps "import
+    # strands_robots" torch-free while still exposing the discovery peer.
+    "list_policy_types": ("strands_robots.policies.lerobot_local.resolution", "list_policy_types"),
     # Simulation (MuJoCo)
     "Simulation": ("strands_robots.simulation", "Simulation"),
     "create_simulation": ("strands_robots.simulation.factory", "create_simulation"),
@@ -148,6 +154,7 @@ __all__ = [
     "HardwareRtpsBridge",
     "Teleoperator",
     "Gr00tPolicy",
+    "list_policy_types",
     "Simulation",
     "SimWorld",
     "SimRobot",

--- a/strands_robots/policies/__init__.py
+++ b/strands_robots/policies/__init__.py
@@ -34,6 +34,8 @@ Usage::
     register_policy("my_provider", lambda: MyPolicy, aliases=["my"])
 """
 
+from typing import TYPE_CHECKING
+
 from strands_robots.policies.base import ChunkedPolicy, Policy, resolve_chunk_length
 
 # Cosmos3Policy is import-safe: it depends only on numpy. The WebSocket
@@ -67,9 +69,37 @@ __all__ = [
     "preflight_policy",
     "register_policy",
     "list_providers",
+    "list_policy_types",
     "UntrustedRemoteCodeError",
     "PersistentPolicy",
     "preload",
     "list_cached",
     "evict",
 ]
+
+
+if TYPE_CHECKING:
+    # Static-analysis import so ``list_policy_types`` (resolved lazily below)
+    # is a defined export for type-checkers / CodeQL py/undefined-export.
+    from strands_robots.policies.lerobot_local.resolution import list_policy_types
+
+
+def __getattr__(name: str) -> object:
+    """Lazily expose the ``lerobot_local`` policy-type discovery surface.
+
+    ``list_policy_types()`` answers "which ``policy_type`` strings can I pass to
+    ``create_policy('lerobot_local', policy_type=...)``?" -- the natural follow-up
+    to ``list_providers()``. It lives in the ``lerobot_local`` package, whose
+    eager import chain pulls in torch, so it is resolved on first access (PEP
+    562) rather than at ``import strands_robots.policies`` time. This keeps the
+    package import torch-free while still exposing the discovery peer next to
+    ``list_providers``.
+    """
+    if name == "list_policy_types":
+        from strands_robots.policies.lerobot_local.resolution import (
+            list_policy_types as _list_policy_types,
+        )
+
+        globals()["list_policy_types"] = _list_policy_types
+        return _list_policy_types
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/test_package_lazy_imports.py
+++ b/tests/test_package_lazy_imports.py
@@ -210,3 +210,60 @@ class TestPolicyFactorySymbolsReexported:
         providers = strands_robots.list_providers()
         assert isinstance(providers, (list, tuple, set))
         assert "mock" in providers
+
+
+class TestPolicyTypeDiscoveryReexported:
+    """``list_policy_types`` is re-exported as a peer of ``list_providers``.
+
+    ``list_providers()`` answers "which providers can I pass to
+    ``create_policy``?" and resolves ``lerobot_local``. The blind follow-up is
+    "which ``policy_type`` strings does ``lerobot_local`` accept?", answered by
+    ``list_policy_types()``. Pre-fix that discovery surface was reachable only
+    via the buried ``strands_robots.policies.lerobot_local`` submodule, so an
+    agent that found the provider had no peer-level way to enumerate its types.
+    These pin the surface at both the package root and ``strands_robots.policies``.
+
+    It is exported *lazily* (in ``_LAZY_IMPORTS``, not eagerly like
+    ``list_providers``) because the ``lerobot_local`` package import chain pulls
+    in torch -- resolving on first access keeps the package imports torch-free.
+    """
+
+    def test_in_top_level_all_and_is_lazy(self):
+        assert "list_policy_types" in strands_robots.__all__
+        # Unlike list_providers (torch-free factory), this peer is lazy.
+        assert "list_policy_types" in strands_robots._LAZY_IMPORTS
+
+    def test_in_policies_subpackage_all(self):
+        import strands_robots.policies as policies_pkg
+
+        assert "list_policy_types" in policies_pkg.__all__
+
+    def test_resolves_to_canonical_object_at_both_levels(self):
+        import strands_robots.policies as policies_pkg
+        from strands_robots.policies.lerobot_local.resolution import (
+            list_policy_types as canonical,
+        )
+
+        assert strands_robots.list_policy_types is canonical
+        assert policies_pkg.list_policy_types is canonical
+
+    def test_callable_returns_list_from_top_level(self):
+        # Discovery surface: callable straight off the package root, and it
+        # degrades to an empty list (never raises) when lerobot is absent.
+        result = strands_robots.list_policy_types()
+        assert isinstance(result, list)
+
+    def test_policies_import_stays_torch_free(self):
+        # The new lazy export must not regress the torch-free import contract:
+        # a clean interpreter importing strands_robots.policies must not pull
+        # torch, yet must still advertise list_policy_types in __all__.
+        import subprocess
+        import sys
+
+        code = (
+            "import sys, strands_robots.policies as p; "
+            "assert 'torch' not in sys.modules, 'torch eagerly imported'; "
+            "assert 'list_policy_types' in p.__all__"
+        )
+        proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+        assert proc.returncode == 0, proc.stderr


### PR DESCRIPTION
## Problem

`list_providers()` answers the first discovery question an agent (or human) asks before calling `create_policy`: *which provider can I pass?* It resolves `lerobot_local`. The immediate blind follow-up is *which `policy_type` does `lerobot_local` accept?* — answered by `list_policy_types()`.

But `list_policy_types` was reachable only via the buried `strands_robots.policies.lerobot_local` submodule, while its natural peer `list_providers` sits at both `strands_robots` (package root) and `strands_robots.policies`. So a caller that discovered the provider via `list_providers()` had no peer-level way to enumerate the `policy_type` strings that provider takes — they had to already know to reach into the `lerobot_local` package.

## Change

Re-export `list_policy_types` next to `list_providers` at both `strands_robots` and `strands_robots.policies`.

The export is **lazy** (PEP 562 `__getattr__` / `_LAZY_IMPORTS`), unlike the eager `list_providers`: the `lerobot_local` package import chain pulls in torch, so resolving on first access keeps `import strands_robots` and `import strands_robots.policies` torch-free. `list_providers` stays eager because its factory is torch-free. Both top-level names resolve to the same canonical `lerobot_local.resolution.list_policy_types` object; the existing submodule path keeps working.

```python
from strands_robots import list_providers, list_policy_types

list_providers()       # ['cosmos3', 'groot', 'lerobot_local', 'mock', ...]
list_policy_types()    # ['act', 'diffusion', 'smolvla', 'pi0', ...]  (reflects installed lerobot; [] without lerobot)
```

## Tests

New `TestPolicyTypeDiscoveryReexported` in `tests/test_package_lazy_imports.py` (mirrors the existing `TestPolicyFactorySymbolsReexported`):
- presence in `__all__` at both sites + membership in `_LAZY_IMPORTS` (lazy contract);
- canonical-object identity at the package root and `strands_robots.policies`;
- callable straight off the root, returning a list;
- torch-free import contract for `strands_robots.policies` verified in a clean subprocess.

All 5 fail on pre-fix code (AttributeError / missing `__all__` entries) and pass after. The pre-existing `test_every_lazy_name_is_exported` and `test_every_lazy_name_has_a_type_checking_import` contracts continue to pass with the new lazy entry (a matching `TYPE_CHECKING` import is added at both sites).

Local gate: `ruff check` / `ruff format --check` clean; `mypy strands_robots tests tests_integ` → "Success: no issues found in 624 source files"; `MUJOCO_GL=egl pytest tests/test_package_lazy_imports.py tests/policies/ ...` → 1366 passed, 2 skipped.

## Docs

`docs/policies/lerobot-local.md` (discovery section now shows the package-level import), `docs/policies/overview.md`, and `docs/api-reference.md` updated.