### PR TITLE
fix(lerobot_local): remap cuda-pinned device_processor on CPU/MPS so normalization is not silently dropped

### DIFF
--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -284,6 +284,20 @@ action_unnorm = (clip(action, -1, 1) + 1) * (q99 - q01) / 2 + q01
 When a stats file declares multiple embodiment tags, pass `norm_tag=` to select
 one; a single-tag file is auto-detected.
 
+### Device-pinned preprocessors on a CPU/MPS host
+
+A checkpoint trained on GPU saves its preprocessor's `device_processor` step
+pinned to `cuda`. Reconstructing that step on a host without a matching CUDA
+build (a Jetson whose driver predates the checkpoint's CUDA, a Mac, x86 CI)
+raises while loading the pipeline. The bridge detects this and retries the load
+once with the pin remapped to the resolved inference `device`, so input
+normalization is preserved automatically - you do not need to pass
+`processor_overrides`. A `WARNING` is logged when the remap happens. An explicit
+`processor_overrides={"device_processor": {"device": ...}}` is always honored and
+suppresses the auto-remap. Without this, the preprocessor would be dropped and
+the model would silently receive raw, un-normalized observations (out of its
+training distribution), producing off-policy actions.
+
 ## Camera routing
 
 Robot/sim observations use bare camera names (`top`, `wrist`, `side`); the policy

--- a/strands_robots/policies/lerobot_local/processor.py
+++ b/strands_robots/policies/lerobot_local/processor.py
@@ -200,12 +200,21 @@ class ProcessorBridge:
         preprocessor = None
         postprocessor = None
 
-        # Load preprocessor
+        # Load preprocessor. A checkpoint trained on GPU pins its
+        # ``device_processor`` step to ``cuda``; reconstructing that step on a
+        # CPU/MPS host raises (``get_safe_torch_device`` asserts the device is
+        # available). Without intervention the WHOLE preprocessor is then
+        # dropped and the bridge runs with no input normalization -- actions
+        # stay in raw space and the arm barely moves. ``_load_preprocessor``
+        # remaps the pin to the resolved inference device and retries so
+        # normalization is preserved automatically (no manual override needed).
         try:
-            preprocessor = DataProcessorPipeline.from_pretrained(
+            preprocessor = cls._load_preprocessor(
+                DataProcessorPipeline,
                 pretrained_name_or_path,
-                config_filename=preprocessor_config,
-                overrides=overrides or {},
+                preprocessor_config,
+                overrides or {},
+                device,
             )
             logger.info("Loaded preprocessor from %s: %d steps", pretrained_name_or_path, len(preprocessor))
         except _missing_config_errors() as exc:
@@ -237,6 +246,79 @@ class ProcessorBridge:
             postprocessor=postprocessor,
             device=device,
         )
+
+    @staticmethod
+    def _load_preprocessor(
+        pipeline_cls: Any,
+        pretrained_name_or_path: str,
+        config_filename: str,
+        overrides: dict[str, Any],
+        device: str | None,
+    ) -> Any:
+        """Load the preprocessor pipeline, remapping a stale device pin if needed.
+
+        A checkpoint trained on GPU saves its ``device_processor`` step pinned
+        to ``cuda``. Reconstructing that step on a CPU/MPS host raises inside
+        ``from_pretrained`` because ``get_safe_torch_device`` asserts the device
+        is available. The caller's ``except`` then treats the present-but-broken
+        config as "no preprocessor" and the bridge runs with NO input
+        normalization -- the single biggest cause of an arm that barely moves.
+
+        When a target ``device`` is known and the caller did not already supply a
+        ``device_processor`` override, this retries the load once with the pin
+        remapped to the inference device, so normalization is preserved without
+        the caller having to pass ``processor_overrides`` manually.
+
+        Args:
+            pipeline_cls: The resolved ``DataProcessorPipeline`` class.
+            pretrained_name_or_path: HF model ID or local checkpoint path.
+            config_filename: Preprocessor config filename.
+            overrides: User-supplied step overrides (never mutated).
+            device: Resolved inference device, or None when unknown.
+
+        Returns:
+            The loaded preprocessor pipeline.
+
+        Raises:
+            The original missing-config error when no preprocessor can be built
+            (genuinely absent config, or a failure unrelated to the device pin).
+        """
+        try:
+            return pipeline_cls.from_pretrained(
+                pretrained_name_or_path,
+                config_filename=config_filename,
+                overrides=overrides,
+            )
+        except _missing_config_errors() as exc:
+            # Only a stale device pin is recoverable here, and only when we know
+            # which device to remap to and the caller has not already pinned it.
+            if device is None or "device_processor" in overrides:
+                raise
+            retry_overrides = {**overrides, "device_processor": {"device": device}}
+            # lerobot raises KeyError when an override targets a step the
+            # pipeline lacks; bundle it with the missing-config errors so the
+            # retry is non-fatal and the ORIGINAL error wins.
+            retryable: tuple[type[BaseException], ...] = (*_missing_config_errors(), KeyError)
+            try:
+                preprocessor = pipeline_cls.from_pretrained(
+                    pretrained_name_or_path,
+                    config_filename=config_filename,
+                    overrides=retry_overrides,
+                )
+            except retryable:
+                # No device_processor step to remap (KeyError) or genuinely no
+                # config: surface the ORIGINAL error so the caller logs the
+                # normal "no preprocessor" path.
+                raise exc from None
+            logger.warning(
+                "Preprocessor for %s pinned device_processor to an unavailable "
+                "device; remapped to '%s' so input normalization is preserved. "
+                "Pass processor_overrides={'device_processor': {'device': ...}} "
+                "to override.",
+                pretrained_name_or_path,
+                device,
+            )
+            return preprocessor
 
     @staticmethod
     def _load_norm_stats_fallback(

--- a/tests/policies/lerobot_local/test_device_pin_remap.py
+++ b/tests/policies/lerobot_local/test_device_pin_remap.py
@@ -1,0 +1,123 @@
+"""Regression: a GPU-pinned ``device_processor`` must not silently disable normalization.
+
+A LeRobot checkpoint trained on GPU saves its preprocessor's ``device_processor``
+step pinned to ``cuda``. On a CPU/MPS host (a Jetson whose driver predates the
+checkpoint's CUDA build, a Mac, x86 CI) reconstructing that step raises because
+``get_safe_torch_device`` asserts the device is available. Before the fix the
+whole preprocessor was dropped and the bridge ran with NO input normalization --
+observations stayed in raw space, so an ACT policy emitted near-constant actions
+and the arm barely moved, while the cpu-pinned postprocessor loaded fine and made
+the failure look like a model problem rather than a dropped device pin.
+
+``ProcessorBridge`` now remaps the stale pin to the resolved inference device and
+retries, so normalization is preserved without a manual ``processor_overrides``.
+
+``torch.cuda.is_available`` is forced False so the cuda pin fails deterministically
+on every host (including a real GPU runner), exercising the exact recovery path.
+"""
+
+import json
+
+import pytest
+
+pytest.importorskip("lerobot")
+
+import torch
+
+from strands_robots.policies.lerobot_local.processor import ProcessorBridge
+
+
+def _build_cuda_pinned_single_cam_checkpoint(dest, state_mean=0.0, state_std=1.0):
+    """Write a single-camera ACT preprocessor whose device_processor pins ``cuda``."""
+    from lerobot.configs.types import FeatureType, PolicyFeature
+    from lerobot.policies.act.configuration_act import ACTConfig
+    from lerobot.policies.act.processor_act import make_act_pre_post_processors
+
+    cfg = ACTConfig(
+        n_action_steps=100,
+        chunk_size=100,
+        input_features={
+            "observation.state": PolicyFeature(type=FeatureType.STATE, shape=(6,)),
+            "observation.images.front": PolicyFeature(type=FeatureType.VISUAL, shape=(3, 480, 640)),
+        },
+        output_features={"action": PolicyFeature(type=FeatureType.ACTION, shape=(6,))},
+    )
+    stats = {
+        "observation.state": {"mean": torch.full((6,), state_mean), "std": torch.full((6,), state_std)},
+        "observation.images.front": {"mean": torch.zeros(3, 1, 1), "std": torch.ones(3, 1, 1)},
+        "action": {"mean": torch.zeros(6), "std": torch.ones(6)},
+    }
+    pre, post = make_act_pre_post_processors(cfg, dataset_stats=stats)
+    pre.save_pretrained(str(dest))
+    post.save_pretrained(str(dest))
+
+    # Simulate a GPU-trained checkpoint: pin the device_processor step to cuda.
+    cfg_path = dest / "policy_preprocessor.json"
+    data = json.loads(cfg_path.read_text())
+    pinned = False
+    for step in data["steps"]:
+        if step.get("registry_name") == "device_processor":
+            step["config"]["device"] = "cuda"
+            pinned = True
+    assert pinned, "expected a device_processor step in the ACT preprocessor"
+    cfg_path.write_text(json.dumps(data))
+
+
+@pytest.fixture
+def cuda_pinned_checkpoint(tmp_path, monkeypatch):
+    """A single-camera ACT checkpoint with a cuda-pinned device_processor + no GPU."""
+    _build_cuda_pinned_single_cam_checkpoint(tmp_path)
+    # Force the cuda pin to be unavailable so the failure is reproduced on any host.
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    return tmp_path
+
+
+def test_cuda_pinned_device_processor_is_remapped_so_normalization_survives(cuda_pinned_checkpoint):
+    """The preprocessor must load on CPU even though it is pinned to cuda.
+
+    Fails before the fix: the cuda pin raises, the bridge swallows it, and
+    ``has_preprocessor`` is False (normalization silently dropped).
+    """
+    bridge = ProcessorBridge.from_pretrained(str(cuda_pinned_checkpoint), device="cpu", policy_type="act")
+    assert bridge.has_preprocessor, "device pin should be remapped, not silently dropped"
+    assert bridge.has_postprocessor
+
+
+def test_remapped_preprocessor_actually_normalizes_observation_state(tmp_path, monkeypatch):
+    """A remapped preprocessor must apply MEAN_STD normalization, not pass through.
+
+    Built with state mean=2, std=4: a raw state of 10 must come back z-scored to
+    (10 - 2) / 4 = 2.0. Before the fix the preprocessor is dropped, so the state
+    would be returned in raw space (10.0) -- this asserts the numeric difference.
+    """
+    _build_cuda_pinned_single_cam_checkpoint(tmp_path, state_mean=2.0, state_std=4.0)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+
+    bridge = ProcessorBridge.from_pretrained(str(tmp_path), device="cpu", policy_type="act")
+    assert bridge.has_preprocessor
+    obs = {
+        "observation.state": torch.full((6,), 10.0),
+        "observation.images.front": torch.zeros(3, 480, 640),
+    }
+    out = bridge.preprocess(obs)
+    state = out["observation.state"].squeeze()
+    assert torch.allclose(state, torch.full((6,), 2.0), atol=1e-5), (
+        f"state must be normalized (expected 2.0), got {state.tolist()}"
+    )
+
+
+def test_no_device_means_no_remap_and_preprocessor_stays_absent(cuda_pinned_checkpoint):
+    """Without a target device there is nothing to remap to, so no false recovery."""
+    bridge = ProcessorBridge.from_pretrained(str(cuda_pinned_checkpoint), device=None, policy_type="act")
+    assert not bridge.has_preprocessor
+
+
+def test_explicit_device_processor_override_is_respected(cuda_pinned_checkpoint):
+    """A caller-supplied device_processor override is honored without auto-remap."""
+    bridge = ProcessorBridge.from_pretrained(
+        str(cuda_pinned_checkpoint),
+        device="cpu",
+        policy_type="act",
+        overrides={"device_processor": {"device": "cpu"}},
+    )
+    assert bridge.has_preprocessor


### PR DESCRIPTION
Addresses the F2 root cause in #880 (cuda-pinned `device_processor` drops normalization on CPU).

## Problem
A LeRobot checkpoint trained on GPU saves its preprocessor's `device_processor` step pinned to `cuda`. On a host without a matching CUDA build (a Jetson whose driver predates the checkpoint's CUDA, a Mac, x86 CI), reconstructing that step raises inside `DataProcessorPipeline.from_pretrained` because `get_safe_torch_device("cuda")` asserts `torch.cuda.is_available()`.

`ProcessorBridge.from_pretrained` caught that as a missing-config error (`logger.debug("No preprocessor found: ...")`) and continued with `has_preprocessor=False`. The model then received raw, un-normalized observations -- a leading cause of off-policy, near-frozen arm motion -- while the cpu-pinned postprocessor loaded fine and masked the cause. The only workaround was to pass `processor_overrides={"device_processor": {"device": "cpu"}}` by hand.

## Change
`ProcessorBridge` now retries the preprocessor load once with the `device_processor` pin remapped to the resolved inference `device`, when both:
- a target `device` is known, and
- the caller did not already supply a `device_processor` override.

Normalization is preserved automatically and a `WARNING` is logged on remap. An explicit `processor_overrides` is always honored and suppresses the auto-remap. If the retry cannot help (no `device_processor` step, or genuinely absent config), the original missing-config path is preserved unchanged (`KeyError` from an unused override is bundled with the missing-config errors so the original error wins).

## Tests
`tests/policies/lerobot_local/test_device_pin_remap.py` builds a single-camera ACT preprocessor with a cuda-pinned `device_processor` and forces `torch.cuda.is_available()` False, so the failure reproduces deterministically on any host (including a GPU runner):
- the preprocessor loads (was silently dropped before) and `observation.state` is MEAN_STD normalized (raw `10.0` -> `2.0` with mean=2/std=4);
- `device=None` -> no remap target -> preprocessor stays absent (no false recovery);
- an explicit `device_processor` override is honored without auto-remap.

The first two assertions fail on pre-fix code. Full `lerobot_local` suite: 422 passed; lint + mypy clean.

## Behavior
For a single-camera ACT MEAN_STD checkpoint on CPU and a real arm pose `[20, -45, 120, 30, 25, 55]` deg, the `observation.state` the model actually receives:
- without the fix (preprocessor dropped): raw degrees `[20, -45, 120, 30, 25, 55]` -- far outside the trained distribution;
- with the fix: `[0.44, 1.0, 0.67, 0.67, 0.56, 0.83]` -- z-scored into the trained `~[-1, 1]` range.

![device-pin normalization](https://github.com/cagataycali/robots/releases/download/harness-artifacts-device-pin/f2_device_pin_normalization.png)

Note: #880 also reports F1 (no single-camera SO embodiment) and F3 (declarative path single-camera obs handling); those are separate and not addressed here.