### PR TITLE
fix(recording): default to OpenCV-decodable H.264; route vcodec onto LeRobot 0.5.2 encoder config

### DIFF
--- a/docs/recording.md
+++ b/docs/recording.md
@@ -241,6 +241,32 @@ which returns the same report dict.
 | `save_episode` | `[lerobot]` | Close current rollout as one episode (call once per `run_policy` for N episodes) |
 | `start_cameras_recording` / `stop_cameras_recording` | `[sim-mujoco]` alone | Plain MP4, no parquet |
 
+## Video codec (H.264 default, AV1 opt-in)
+
+`start_recording` (and `DatasetRecorder.create`/`resume`) default to
+`vcodec="h264"`. H.264 is universally decodable - including by OpenCV's
+`cv2.VideoCapture`, which is what many downstream VLM video readers use to
+*watch* a recorded episode. The recorded per-camera MP4s therefore reopen and
+decode everywhere without a transcode step:
+
+```python
+import cv2
+cap = cv2.VideoCapture(".../videos/observation.images.base/chunk-000/file-000.mp4")
+ok, frame = cap.read()   # H.264: ok is True, frame is a real (H, W, 3) array
+```
+
+Pass `vcodec="libsvtav1"` to opt into AV1 for smaller files in
+storage-constrained training pipelines. AV1 reads back fine through LeRobot's
+own loader (`torchcodec`/`pyav`), but OpenCV wheels commonly lack an AV1 decoder
+and silently yield **0 frames** (`VideoCapture.read()` returns `False`
+immediately even though the stream has frames) - so avoid AV1 if anything in
+your pipeline reads the videos through OpenCV.
+
+The flat `vcodec` value accepts either codec names (`h264`, `hevc`,
+`libsvtav1`) or ffmpeg encoder names (`libx264`, `libx265`); it is normalized
+to whatever the installed LeRobot version's encoder config expects. An
+unsupported codec fails loudly rather than silently reverting to the default.
+
 ## DatasetRecorder direct API
 
 ```python
@@ -260,7 +286,7 @@ recorder = DatasetRecorder.create(
     joint_names=["joint_1", "joint_2", "joint_3", "joint_4", "joint_5", "joint_6"],
     task="pick up the red cube",
     # root=None → ~/.strands_robots/datasets/
-    # vcodec="libsvtav1", streaming_encoding=True, image_writer_threads=4
+    # vcodec="h264", streaming_encoding=True, image_writer_threads=4
 )
 
 for step in control_loop:

--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -31,6 +31,74 @@ import numpy as np
 
 logger = logging.getLogger(__name__)
 
+
+# Codec-name vocabularies differ across LeRobot surfaces. The legacy flat
+# ``vcodec`` kwarg (0.5.0/0.5.1) was passed straight to ffmpeg, so it wants
+# ffmpeg encoder names ("libx264", "libsvtav1"). The 0.5.2+ encoder configs
+# (RGBEncoderConfig / VideoEncoderConfig) validate against a fixed allowlist
+# that uses codec names ("h264", "hevc", "libsvtav1") and reject "libx264".
+# We accept either spelling from callers and translate to the target surface.
+_FFMPEG_CODEC_NAMES = {"h264": "libx264", "hevc": "libx265"}
+_ENCODER_CODEC_NAMES = {"libx264": "h264", "libx265": "hevc"}
+
+
+def _codec_create_kwargs(sig_params: Any, vcodec: str, *, context: str = "create") -> dict[str, Any]:
+    """Map a flat ``vcodec`` onto whatever codec surface this LeRobot exposes.
+
+    LeRobot's video-codec plumbing drifted across releases, and the codec is
+    both named and routed differently on each. Passing the wrong kwarg (or none)
+    silently leaves the encoder on its built-in default, so the caller's
+    ``vcodec`` is dropped without error - which is how an AV1 default sneaks back
+    in even when the caller asked for H.264:
+
+      * 0.5.0 / 0.5.1: ``create/resume(..., vcodec="libx264")`` - a flat ffmpeg
+        encoder name.
+      * an interim build briefly exposed
+        ``camera_encoder=VideoEncoderConfig(vcodec="h264")``.
+      * 0.5.2+: ``rgb_encoder=RGBEncoderConfig(vcodec="h264")`` (the flat kwarg
+        and ``camera_encoder`` were both removed; the codec now lives inside the
+        per-modality encoder config and is validated against an allowlist that
+        uses codec names like "h264", NOT ffmpeg names like "libx264").
+
+    The caller may pass either spelling ("h264" or "libx264"); this normalizes
+    to whatever the detected surface expects. An unknown codec raises loudly
+    (LeRobot's own ValueError) rather than silently falling back to the default.
+
+    Args:
+        sig_params: ``inspect.Signature.parameters`` of ``create``/``resume``.
+        vcodec: Requested codec, as a codec name ("h264", "hevc", "libsvtav1")
+            or an ffmpeg encoder name ("libx264", "libx265").
+        context: Label for warning messages ("create" or "resume").
+
+    Returns:
+        Mapping with exactly one of ``vcodec`` / ``rgb_encoder`` /
+        ``camera_encoder``, or an empty dict if no known codec surface is
+        present (recorder falls back to the LeRobot default codec).
+
+    Raises:
+        ValueError: When the encoder-config surface rejects the requested codec
+            (propagated from LeRobot so an unsupported codec fails loudly
+            instead of silently reverting to the default).
+    """
+    if "vcodec" in sig_params:
+        return {"vcodec": _FFMPEG_CODEC_NAMES.get(vcodec, vcodec)}
+    if "rgb_encoder" in sig_params:
+        try:
+            from lerobot.configs.video import RGBEncoderConfig
+        except ImportError as exc:
+            logger.warning("RGBEncoderConfig import failed on %s (%s); using default codec", context, exc)
+            return {}
+        return {"rgb_encoder": RGBEncoderConfig(vcodec=_ENCODER_CODEC_NAMES.get(vcodec, vcodec))}
+    if "camera_encoder" in sig_params:
+        try:
+            from lerobot.configs.video import VideoEncoderConfig
+        except ImportError as exc:
+            logger.warning("VideoEncoderConfig import failed on %s (%s); using default codec", context, exc)
+            return {}
+        return {"camera_encoder": VideoEncoderConfig(vcodec=_ENCODER_CODEC_NAMES.get(vcodec, vcodec))}
+    return {}
+
+
 # Allowlist patterns for HF Storage Bucket sync targets. Both `bucket` and
 # `run_id` reach the `hf` CLI argv and the `hf://buckets/...` URI; they are
 # agent-reachable via stop_recording(bucket=, run_id=) dispatched through the
@@ -184,7 +252,7 @@ class DatasetRecorder:
         task: str = "",
         root: str | None = None,
         use_videos: bool = True,
-        vcodec: str = "libsvtav1",
+        vcodec: str = "h264",
         streaming_encoding: bool = True,
         image_writer_threads: int = 4,
         video_backend: str = "auto",
@@ -206,7 +274,13 @@ class DatasetRecorder:
             task: Default task description
             root: Local directory for dataset storage
             use_videos: Encode camera frames as video (True) or keep as images
-            vcodec: Video codec (h264, hevc, libsvtav1)
+            vcodec: Video codec for the per-camera MP4 streams. Defaults to
+                "h264" (H.264), which is universally decodable - including
+                by OpenCV's VideoCapture / FFmpeg build, used by many
+                downstream VLM video readers. Use "libsvtav1" (AV1) for
+                smaller files in storage-constrained training pipelines;
+                LeRobot read-back (torchcodec/pyav) handles AV1, but OpenCV
+                wheels commonly cannot decode it and silently yield 0 frames.
             streaming_encoding: Stream-encode video during capture
             image_writer_threads: Threads for writing image frames
             video_backend: Video backend for encoding ("auto" for HW encoder auto-detect)
@@ -249,23 +323,12 @@ class DatasetRecorder:
         create_sig = inspect.signature(LeRobotDatasetCls.create)
         create_params = create_sig.parameters
 
-        # Video codec plumbing drifted across LeRobot versions:
-        #   * 0.5.0/0.5.1: create(..., vcodec="libsvtav1")
-        #   * 0.5.2+:      create(..., camera_encoder=VideoEncoderConfig(vcodec=...))
-        # The flat ``vcodec`` kwarg was removed in 0.5.2 (codec now lives inside
-        # VideoEncoderConfig). Detect which surface this LeRobot exposes and route
-        # accordingly so the recorder works on both old and new versions.
-        if "vcodec" in create_params:
-            create_kwargs["vcodec"] = vcodec
-        elif "camera_encoder" in create_params:
-            try:
-                from lerobot.configs.video import VideoEncoderConfig
-
-                create_kwargs["camera_encoder"] = VideoEncoderConfig(vcodec=vcodec)
-            except (ImportError, AttributeError, TypeError, ValueError) as exc:
-                # If VideoEncoderConfig can't be built (e.g. unknown codec on this
-                # platform), fall back to the codec default rather than crashing.
-                logger.warning("VideoEncoderConfig(vcodec=%r) unavailable (%s); using default encoder", vcodec, exc)
+        # Route the requested codec onto whichever surface this LeRobot version
+        # exposes (vcodec / rgb_encoder / camera_encoder). The flat ``vcodec``
+        # kwarg and ``camera_encoder`` were both removed in 0.5.2; the codec now
+        # lives inside ``rgb_encoder=RGBEncoderConfig(vcodec=...)``. Missing this
+        # surface silently leaves the encoder on its built-in default.
+        create_kwargs.update(_codec_create_kwargs(create_params, vcodec, context="create"))
 
         # streaming_encoding / video_backend only in newer LeRobot versions
         if "streaming_encoding" in create_params:
@@ -284,7 +347,7 @@ class DatasetRecorder:
         repo_id: str,
         root: str | None = None,
         task: str = "",
-        vcodec: str = "libsvtav1",
+        vcodec: str = "h264",
         streaming_encoding: bool = True,
         image_writer_threads: int = 4,
         video_backend: str = "auto",
@@ -310,7 +373,9 @@ class DatasetRecorder:
             repo_id: HuggingFace dataset ID (same as the original recording).
             root: Local dataset directory (same as the original recording).
             task: Default task description for appended frames.
-            vcodec: Video codec (routed into ``camera_encoder`` on 0.5.2+).
+            vcodec: Video codec for the per-camera MP4 streams (default
+                "libx264"; routed into the version-appropriate encoder
+                config). See create() for the H.264-vs-AV1 trade-off.
             streaming_encoding: Stream-encode video during capture.
             image_writer_threads: Threads for writing image frames.
             video_backend: Video backend for encoding.
@@ -337,15 +402,7 @@ class DatasetRecorder:
         resume_sig = inspect.signature(LeRobotDatasetCls.resume).parameters
         resume_kwargs: dict[str, Any] = dict(repo_id=repo_id, root=root)
         # Mirror create()'s version-tolerant codec routing.
-        if "vcodec" in resume_sig:
-            resume_kwargs["vcodec"] = vcodec
-        elif "camera_encoder" in resume_sig:
-            try:
-                from lerobot.configs.video import VideoEncoderConfig
-
-                resume_kwargs["camera_encoder"] = VideoEncoderConfig(vcodec=vcodec)
-            except (ImportError, AttributeError, TypeError, ValueError) as exc:
-                logger.warning("VideoEncoderConfig(vcodec=%r) unavailable on resume (%s)", vcodec, exc)
+        resume_kwargs.update(_codec_create_kwargs(resume_sig, vcodec, context="resume"))
         if "streaming_encoding" in resume_sig:
             resume_kwargs["streaming_encoding"] = streaming_encoding
         if "image_writer_threads" in resume_sig:

--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -32,37 +32,38 @@ import numpy as np
 logger = logging.getLogger(__name__)
 
 
-# Codec-name vocabularies differ across LeRobot surfaces. The legacy flat
-# ``vcodec`` kwarg (0.5.0/0.5.1) was passed straight to ffmpeg, so it wants
-# ffmpeg encoder names ("libx264", "libsvtav1"). The 0.5.2+ encoder configs
-# (RGBEncoderConfig / VideoEncoderConfig) validate against a fixed allowlist
-# that uses codec names ("h264", "hevc", "libsvtav1") and reject "libx264".
-# We accept either spelling from callers and translate to the target surface.
-_FFMPEG_CODEC_NAMES = {"h264": "libx264", "hevc": "libx265"}
+# Every LeRobot surface in the supported ``>=0.5.0,<0.6.0`` range validates the
+# codec against the same codec-name allowlist - ``video_utils.VALID_VIDEO_CODECS
+# = {"h264", "hevc", "libsvtav1", "auto"} | HW_ENCODERS`` - and *rejects* the
+# ffmpeg library names ("libx264"/"libx265"). This holds for the flat ``vcodec``
+# kwarg (0.5.0/0.5.1) just as much as for the ``RGBEncoderConfig`` /
+# ``VideoEncoderConfig`` surfaces a later minor may expose. So there is exactly
+# one correct normalization direction: ffmpeg name -> codec name, applied to
+# whichever surface is present. Callers may pass either spelling.
 _ENCODER_CODEC_NAMES = {"libx264": "h264", "libx265": "hevc"}
 
 
 def _codec_create_kwargs(sig_params: Any, vcodec: str, *, context: str = "create") -> dict[str, Any]:
     """Map a flat ``vcodec`` onto whatever codec surface this LeRobot exposes.
 
-    LeRobot's video-codec plumbing drifted across releases, and the codec is
-    both named and routed differently on each. Passing the wrong kwarg (or none)
-    silently leaves the encoder on its built-in default, so the caller's
-    ``vcodec`` is dropped without error - which is how an AV1 default sneaks back
-    in even when the caller asked for H.264:
+    LeRobot routes the codec differently across releases. Passing the wrong
+    kwarg (or none) silently leaves the encoder on its built-in default, so the
+    caller's ``vcodec`` is dropped without error - which is how an AV1 default
+    sneaks back in even when the caller asked for H.264:
 
-      * 0.5.0 / 0.5.1: ``create/resume(..., vcodec="libx264")`` - a flat ffmpeg
-        encoder name.
+      * 0.5.0 / 0.5.1: a flat ``create/resume(..., vcodec=...)`` kwarg.
       * an interim build briefly exposed
-        ``camera_encoder=VideoEncoderConfig(vcodec="h264")``.
-      * 0.5.2+: ``rgb_encoder=RGBEncoderConfig(vcodec="h264")`` (the flat kwarg
-        and ``camera_encoder`` were both removed; the codec now lives inside the
-        per-modality encoder config and is validated against an allowlist that
-        uses codec names like "h264", NOT ffmpeg names like "libx264").
+        ``camera_encoder=VideoEncoderConfig(vcodec=...)``.
+      * a later minor may move the codec into
+        ``rgb_encoder=RGBEncoderConfig(vcodec=...)``.
 
-    The caller may pass either spelling ("h264" or "libx264"); this normalizes
-    to whatever the detected surface expects. An unknown codec raises loudly
-    (LeRobot's own ValueError) rather than silently falling back to the default.
+    Every one of these surfaces validates against LeRobot's codec-name allowlist
+    (``{"h264", "hevc", "libsvtav1", "auto"} | HW_ENCODERS``) and rejects the
+    ffmpeg library names ("libx264"/"libx265"). So the codec is normalized to its
+    codec-name spelling once and routed onto whichever surface is present. The
+    caller may pass either spelling ("h264" or "libx264"). An unknown codec
+    raises loudly (LeRobot's own ValueError) rather than silently falling back
+    to the default.
 
     Args:
         sig_params: ``inspect.Signature.parameters`` of ``create``/``resume``.
@@ -76,26 +77,28 @@ def _codec_create_kwargs(sig_params: Any, vcodec: str, *, context: str = "create
         present (recorder falls back to the LeRobot default codec).
 
     Raises:
-        ValueError: When the encoder-config surface rejects the requested codec
+        ValueError: When the codec surface rejects the requested codec
             (propagated from LeRobot so an unsupported codec fails loudly
             instead of silently reverting to the default).
     """
+    # ffmpeg library name -> codec name; codec names (and HW encoders) pass through.
+    codec = _ENCODER_CODEC_NAMES.get(vcodec, vcodec)
     if "vcodec" in sig_params:
-        return {"vcodec": _FFMPEG_CODEC_NAMES.get(vcodec, vcodec)}
+        return {"vcodec": codec}
     if "rgb_encoder" in sig_params:
         try:
             from lerobot.configs.video import RGBEncoderConfig
         except ImportError as exc:
             logger.warning("RGBEncoderConfig import failed on %s (%s); using default codec", context, exc)
             return {}
-        return {"rgb_encoder": RGBEncoderConfig(vcodec=_ENCODER_CODEC_NAMES.get(vcodec, vcodec))}
+        return {"rgb_encoder": RGBEncoderConfig(vcodec=codec)}
     if "camera_encoder" in sig_params:
         try:
             from lerobot.configs.video import VideoEncoderConfig
         except ImportError as exc:
             logger.warning("VideoEncoderConfig import failed on %s (%s); using default codec", context, exc)
             return {}
-        return {"camera_encoder": VideoEncoderConfig(vcodec=_ENCODER_CODEC_NAMES.get(vcodec, vcodec))}
+        return {"camera_encoder": VideoEncoderConfig(vcodec=codec)}
     return {}
 
 
@@ -374,7 +377,7 @@ class DatasetRecorder:
             root: Local dataset directory (same as the original recording).
             task: Default task description for appended frames.
             vcodec: Video codec for the per-camera MP4 streams (default
-                "libx264"; routed into the version-appropriate encoder
+                "h264"; routed into the version-appropriate encoder
                 config). See create() for the H.264-vs-AV1 trade-off.
             streaming_encoding: Stream-encode video during capture.
             image_writer_threads: Threads for writing image frames.

--- a/strands_robots/simulation/mujoco/recording.py
+++ b/strands_robots/simulation/mujoco/recording.py
@@ -50,7 +50,7 @@ class RecordingMixin(DatasetRecordingMixin):
         fps: int = 30,
         root: str | None = None,
         push_to_hub: bool = False,
-        vcodec: str = "libsvtav1",
+        vcodec: str = "h264",
         overwrite: bool = False,
         cameras: list[str] | None = None,
     ) -> dict[str, Any]:
@@ -79,6 +79,14 @@ class RecordingMixin(DatasetRecordingMixin):
                 record from scratch. When False (default) an existing dataset is
                 appended to; a non-empty, non-dataset ``root`` is reported as an
                 error rather than clobbered.
+            vcodec: Video codec for the per-camera MP4 streams. Defaults to
+                "h264" (H.264), which decodes everywhere - including OpenCV's
+                VideoCapture, used by many downstream VLM video readers - so a
+                recorded episode can be replayed/reasoned about without
+                transcoding. Use "libsvtav1" (AV1) for smaller files in
+                storage-constrained training pipelines; LeRobot read-back
+                (torchcodec/pyav) handles AV1, but OpenCV wheels commonly cannot
+                decode it and silently yield 0 frames.
             cameras: Camera names to record into the dataset. When ``None``
                 (default) every scene camera is recorded - which includes the
                 implicit ``default`` free camera. Pass an explicit subset to

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1241,7 +1241,7 @@ class MuJoCoSimEngine(
         # instead of guessing method names.
         base["methods"]["start_recording"] = (
             "(repo_id='local/sim_recording', task='', fps=30, root=None, "
-            "push_to_hub=False, vcodec='libsvtav1', overwrite=False) -> dict"
+            "push_to_hub=False, vcodec='h264', overwrite=False) -> dict"
         )
         base["methods"]["save_episode"] = (
             "() -> dict  (flush current rollout as one episode; call once per "

--- a/strands_robots/simulation/newton/recording.py
+++ b/strands_robots/simulation/newton/recording.py
@@ -60,7 +60,7 @@ class NewtonRecordingMixin(DatasetRecordingMixin):
         fps: int = 30,
         root: str | None = None,
         push_to_hub: bool = False,
-        vcodec: str = "libsvtav1",
+        vcodec: str = "h264",
         overwrite: bool = False,
     ) -> dict[str, Any]:
         """Start recording the Newton scene to LeRobotDataset format.
@@ -85,7 +85,12 @@ class NewtonRecordingMixin(DatasetRecordingMixin):
             root: Explicit on-disk dataset directory (overrides the repo_id
                 cache-path resolution).
             push_to_hub: Publish to the Hub at ``stop_recording``.
-            vcodec: Video codec for camera MP4 encoding.
+            vcodec: Video codec for the per-camera MP4 streams. Defaults to
+                "h264" (H.264), universally decodable including by OpenCV's
+                VideoCapture (used by many downstream VLM video readers). Use
+                "libsvtav1" (AV1) for smaller files in storage-constrained
+                training pipelines; LeRobot read-back handles AV1 but OpenCV
+                wheels commonly cannot decode it and silently yield 0 frames.
             overwrite: Wipe and recreate an existing dataset dir instead of
                 appending to it.
 

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -1548,7 +1548,7 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
                 "step": "(n_steps: int = 1) -> dict",
                 "start_recording": (
                     "(repo_id='local/sim_recording', task='', fps=30, root=None, "
-                    "push_to_hub=False, vcodec='libsvtav1', overwrite=False) -> dict  "
+                    "push_to_hub=False, vcodec='h264', overwrite=False) -> dict  "
                     "(record joint state + action + named cameras to a LeRobotDataset)"
                 ),
                 "save_episode": (

--- a/tests/simulation/mujoco/test_recording_codec_opencv.py
+++ b/tests/simulation/mujoco/test_recording_codec_opencv.py
@@ -1,0 +1,146 @@
+"""Regression tests: recorded LeRobotDataset videos must be OpenCV-decodable.
+
+``start_recording`` defaults to an H.264 codec because the per-camera MP4s in a
+LeRobotDataset are frequently re-opened by OpenCV-backed readers (``cv2.Video
+Capture``), which is what many downstream VLM video readers use to *watch* a
+recorded episode. The previous default (AV1 / ``libsvtav1``) is commonly
+undecodable by the FFmpeg build bundled in OpenCV wheels: ``VideoCapture`` opens
+the file, reports a non-zero frame count, yet ``read()`` yields zero frames.
+
+A second, subtler defect this guards: LeRobot's codec plumbing drifted to
+``rgb_encoder=RGBEncoderConfig(vcodec="h264")`` and validates ``vcodec`` against
+an allowlist that uses codec names ("h264") and rejects ffmpeg encoder names
+("libx264"). A recorder that routed the flat ``vcodec`` only onto the old
+surfaces silently dropped it and fell back to the AV1 default - so the H.264
+request never took effect.
+
+Covers:
+* the default codec produces an MP4 that OpenCV decodes to exactly the recorded
+  frame count (the acceptance criterion);
+* an explicit ffmpeg alias ("libx264") is normalized and still OpenCV-decodable;
+* opt-in AV1 ("libsvtav1") is honored (the stream really is AV1), confirming the
+  storage-oriented codec remains available for callers who want it.
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+
+import pytest
+
+pytest.importorskip("mujoco")
+pytest.importorskip("lerobot")
+cv2 = pytest.importorskip("cv2")
+
+os.environ.setdefault("MUJOCO_GL", "egl")
+
+_ROBOT_XML = """
+<mujoco model="test_arm">
+  <compiler angle="radian" autolimits="true"/>
+  <option timestep="0.002"/>
+  <worldbody>
+    <light name="main" pos="0 0 3" dir="0 0 -1"/>
+    <geom name="ground" type="plane" size="5 5 0.01" rgba="0.9 0.9 0.9 1"/>
+    <body name="base" pos="0 0 0.1">
+      <geom type="cylinder" size="0.05 0.05" rgba="0.3 0.3 0.8 1"/>
+      <joint name="shoulder_pan" type="hinge" axis="0 0 1" range="-3.14 3.14"/>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="shoulder_pan_act" joint="shoulder_pan" kp="50"/>
+  </actuator>
+</mujoco>
+"""
+
+_N_STEPS = 12
+
+
+@pytest.fixture
+def sim_with_camera(tmp_path):
+    from strands_robots.simulation import Simulation
+
+    path = tmp_path / "test_arm.xml"
+    path.write_text(_ROBOT_XML)
+
+    s = Simulation()
+    s.create_world()
+    s.add_robot("arm", urdf_path=str(path))
+    s.add_camera(name="base", position=[0.5, 0.0, 0.35], target=[0.2, 0.0, 0.05], width=64, height=64)
+    s.step(3)
+    yield s
+    s.destroy()
+
+
+def _record_episode(sim, dataset_dir, vcodec=None):
+    from strands_robots import MockPolicy
+
+    kwargs = dict(
+        repo_id="local/codec_demo",
+        root=str(dataset_dir),
+        fps=30,
+        task="codec round-trip",
+        overwrite=True,
+        cameras=["base"],
+    )
+    if vcodec is not None:
+        kwargs["vcodec"] = vcodec
+    assert sim.start_recording(**kwargs)["status"] == "success"
+    sim.run_policy(robot_name="arm", policy_object=MockPolicy(), n_steps=_N_STEPS)
+    sim.stop_recording()
+    mp4s = glob.glob(os.path.join(str(dataset_dir), "videos", "**", "*.mp4"), recursive=True)
+    assert mp4s, "no per-camera MP4 was written"
+    return mp4s
+
+
+def _opencv_frame_count(path):
+    cap = cv2.VideoCapture(path)
+    try:
+        assert cap.isOpened(), f"OpenCV could not open {path}"
+        decoded = 0
+        while True:
+            ok, _ = cap.read()
+            if not ok:
+                break
+            decoded += 1
+        return decoded
+    finally:
+        cap.release()
+
+
+def _fourcc(path):
+    """Return the lowercased 4-char FOURCC codec tag OpenCV reports for ``path``.
+
+    Read from container metadata, so it works even when the active OpenCV build
+    cannot decode the stream (e.g. AV1 -> "av01" with zero decodable frames).
+    """
+    cap = cv2.VideoCapture(path)
+    try:
+        code = int(cap.get(cv2.CAP_PROP_FOURCC))
+    finally:
+        cap.release()
+    return "".join(chr((code >> 8 * i) & 0xFF) for i in range(4)).lower()
+
+
+def test_default_codec_is_opencv_decodable(sim_with_camera, tmp_path):
+    """The default-codec dataset video opens in OpenCV and yields every frame."""
+    mp4s = _record_episode(sim_with_camera, tmp_path / "ds_default")
+    for mp4 in mp4s:
+        decoded = _opencv_frame_count(mp4)
+        assert decoded == _N_STEPS, f"{mp4}: OpenCV decoded {decoded} frames, expected {_N_STEPS}"
+        assert _fourcc(mp4) == "h264"
+
+
+def test_libx264_alias_is_normalized_and_decodable(sim_with_camera, tmp_path):
+    """An ffmpeg-style ``libx264`` request is normalized to H.264, not dropped."""
+    mp4s = _record_episode(sim_with_camera, tmp_path / "ds_libx264", vcodec="libx264")
+    for mp4 in mp4s:
+        assert _opencv_frame_count(mp4) == _N_STEPS
+        assert _fourcc(mp4) == "h264"
+
+
+def test_libsvtav1_optin_is_honored(sim_with_camera, tmp_path):
+    """Opt-in AV1 still works: the stream really is AV1 (storage-oriented codec)."""
+    mp4s = _record_episode(sim_with_camera, tmp_path / "ds_av1", vcodec="libsvtav1")
+    for mp4 in mp4s:
+        assert _fourcc(mp4) == "av01"

--- a/tests/simulation/mujoco/test_recording_codec_opencv.py
+++ b/tests/simulation/mujoco/test_recording_codec_opencv.py
@@ -7,12 +7,12 @@ recorded episode. The previous default (AV1 / ``libsvtav1``) is commonly
 undecodable by the FFmpeg build bundled in OpenCV wheels: ``VideoCapture`` opens
 the file, reports a non-zero frame count, yet ``read()`` yields zero frames.
 
-A second, subtler defect this guards: LeRobot's codec plumbing drifted to
-``rgb_encoder=RGBEncoderConfig(vcodec="h264")`` and validates ``vcodec`` against
-an allowlist that uses codec names ("h264") and rejects ffmpeg encoder names
-("libx264"). A recorder that routed the flat ``vcodec`` only onto the old
-surfaces silently dropped it and fell back to the AV1 default - so the H.264
-request never took effect.
+A second, subtler defect this guards: every LeRobot in the supported
+``>=0.5.0,<0.6.0`` range validates ``vcodec`` against a codec-name allowlist
+(``{"h264", "hevc", "libsvtav1", "auto"} | HW_ENCODERS``) and rejects the ffmpeg
+encoder names ("libx264"/"libx265"). A recorder that forwarded the ffmpeg name
+onto the flat ``vcodec`` surface had its H.264 request rejected outright - so
+the codec never took effect.
 
 Covers:
 * the default codec produces an MP4 that OpenCV decodes to exactly the recorded

--- a/tests/test_dataset_recorder.py
+++ b/tests/test_dataset_recorder.py
@@ -871,7 +871,9 @@ def test_resume_passes_vcodec_directly_when_supported(monkeypatch):
     recorder = dr.DatasetRecorder.resume("user/data", root="/tmp/ds", vcodec="libx264", task="pick")
 
     sent = _FakeDatasetVcodecResume.last_resume_kwargs
-    assert sent["vcodec"] == "libx264"
+    # The flat ``vcodec`` surface validates against the codec-name allowlist
+    # (it rejects "libx264"), so the ffmpeg name is normalized to "h264".
+    assert sent["vcodec"] == "h264"
     assert sent["repo_id"] == "user/data"
     assert sent["root"] == "/tmp/ds"
     assert sent["streaming_encoding"] is True
@@ -1046,7 +1048,9 @@ def test_create_passes_vcodec_directly_when_supported(monkeypatch):
     )
 
     sent = _FakeDatasetVcodecCreate.last_create_kwargs
-    assert sent["vcodec"] == "libx264"
+    # The flat ``vcodec`` surface validates against the codec-name allowlist
+    # (it rejects "libx264"), so the ffmpeg name is normalized to "h264".
+    assert sent["vcodec"] == "h264"
     assert sent["repo_id"] == "user/data"
     assert sent["fps"] == 50
     assert sent["streaming_encoding"] is True
@@ -1121,9 +1125,9 @@ def test_create_forwards_optional_kwargs_only_when_supported(monkeypatch):
     recorder = DatasetRecorder.create("user/data", joint_names=["j1"])
 
     sent = _FakeDatasetMinimalCreate.last_create_kwargs
-    # The default codec is the codec name "h264"; on the legacy flat ``vcodec``
-    # surface it is normalized to the ffmpeg encoder name "libx264".
-    assert sent == {"repo_id": "user/data", "vcodec": "libx264"}
+    # The default codec "h264" is already an allowlist-valid codec name and is
+    # forwarded unchanged onto the flat ``vcodec`` surface.
+    assert sent == {"repo_id": "user/data", "vcodec": "h264"}
     assert recorder.dataset.repo_id == "user/data"
 
 
@@ -1285,23 +1289,28 @@ def test_load_lerobot_episode_rejects_negative_index():
 class TestCodecRouting:
     """Cover ``_codec_create_kwargs`` version-tolerant codec routing.
 
-    LeRobot's codec plumbing drifted across releases - flat ``vcodec`` (ffmpeg
-    encoder names) on 0.5.0/0.5.1, then ``rgb_encoder=RGBEncoderConfig(...)`` on
-    0.5.2+ (codec-name allowlist). Routing the codec onto the wrong (or no)
+    LeRobot routes the codec onto different surfaces across releases (flat
+    ``vcodec`` on 0.5.0/0.5.1; an encoder-config object on later minors), but
+    every one validates against the same codec-name allowlist and rejects the
+    ffmpeg names "libx264"/"libx265". Routing the codec onto the wrong (or no)
     surface silently drops the caller's request and falls back to the AV1
     default. These tests assert the requested codec actually reaches the
     surface this LeRobot exposes, with name spellings normalized per surface.
     """
 
-    def test_legacy_flat_vcodec_uses_ffmpeg_name(self):
+    def test_flat_vcodec_uses_codec_name(self):
         from strands_robots.dataset_recorder import _codec_create_kwargs
 
-        # Canonical "h264" maps to the ffmpeg encoder name on the flat surface.
-        assert _codec_create_kwargs({"vcodec": None}, "h264") == {"vcodec": "libx264"}
-        # An ffmpeg name passes through unchanged.
-        assert _codec_create_kwargs({"vcodec": None}, "libx264") == {"vcodec": "libx264"}
-        # AV1 is spelled the same on both surfaces.
+        # The flat ``vcodec`` surface validates against the codec-name allowlist
+        # in every supported LeRobot (>=0.5.0,<0.6.0), so the codec name is
+        # forwarded as-is - NOT mapped to the ffmpeg name "libx264".
+        assert _codec_create_kwargs({"vcodec": None}, "h264") == {"vcodec": "h264"}
+        # An ffmpeg name is normalized to its allowlist codec name.
+        assert _codec_create_kwargs({"vcodec": None}, "libx264") == {"vcodec": "h264"}
+        assert _codec_create_kwargs({"vcodec": None}, "libx265") == {"vcodec": "hevc"}
+        # AV1 and HW encoders are already codec names and pass through.
         assert _codec_create_kwargs({"vcodec": None}, "libsvtav1") == {"vcodec": "libsvtav1"}
+        assert _codec_create_kwargs({"vcodec": None}, "h264_nvenc") == {"vcodec": "h264_nvenc"}
 
     def test_no_known_codec_surface_returns_empty(self):
         from strands_robots.dataset_recorder import _codec_create_kwargs

--- a/tests/test_dataset_recorder.py
+++ b/tests/test_dataset_recorder.py
@@ -1121,7 +1121,9 @@ def test_create_forwards_optional_kwargs_only_when_supported(monkeypatch):
     recorder = DatasetRecorder.create("user/data", joint_names=["j1"])
 
     sent = _FakeDatasetMinimalCreate.last_create_kwargs
-    assert sent == {"repo_id": "user/data", "vcodec": "libsvtav1"}
+    # The default codec is the codec name "h264"; on the legacy flat ``vcodec``
+    # surface it is normalized to the ffmpeg encoder name "libx264".
+    assert sent == {"repo_id": "user/data", "vcodec": "libx264"}
     assert recorder.dataset.repo_id == "user/data"
 
 
@@ -1278,3 +1280,63 @@ def test_load_lerobot_episode_rejects_negative_index():
 
     with pytest.raises(ValueError, match="non-negative"):
         load_lerobot_episode("any/repo", episode=-1)
+
+
+class TestCodecRouting:
+    """Cover ``_codec_create_kwargs`` version-tolerant codec routing.
+
+    LeRobot's codec plumbing drifted across releases - flat ``vcodec`` (ffmpeg
+    encoder names) on 0.5.0/0.5.1, then ``rgb_encoder=RGBEncoderConfig(...)`` on
+    0.5.2+ (codec-name allowlist). Routing the codec onto the wrong (or no)
+    surface silently drops the caller's request and falls back to the AV1
+    default. These tests assert the requested codec actually reaches the
+    surface this LeRobot exposes, with name spellings normalized per surface.
+    """
+
+    def test_legacy_flat_vcodec_uses_ffmpeg_name(self):
+        from strands_robots.dataset_recorder import _codec_create_kwargs
+
+        # Canonical "h264" maps to the ffmpeg encoder name on the flat surface.
+        assert _codec_create_kwargs({"vcodec": None}, "h264") == {"vcodec": "libx264"}
+        # An ffmpeg name passes through unchanged.
+        assert _codec_create_kwargs({"vcodec": None}, "libx264") == {"vcodec": "libx264"}
+        # AV1 is spelled the same on both surfaces.
+        assert _codec_create_kwargs({"vcodec": None}, "libsvtav1") == {"vcodec": "libsvtav1"}
+
+    def test_no_known_codec_surface_returns_empty(self):
+        from strands_robots.dataset_recorder import _codec_create_kwargs
+
+        # A signature exposing none of the known codec kwargs -> no routing
+        # (recorder falls back to the LeRobot default codec).
+        assert _codec_create_kwargs({"repo_id": None, "fps": None}, "h264") == {}
+
+    def test_rgb_encoder_normalizes_ffmpeg_name_to_allowlist(self):
+        pytest.importorskip("lerobot")
+        rgb = pytest.importorskip("lerobot.configs.video")
+        if not hasattr(rgb, "RGBEncoderConfig"):
+            pytest.skip("this LeRobot has no RGBEncoderConfig surface")
+        from strands_robots.dataset_recorder import _codec_create_kwargs
+
+        # ffmpeg "libx264" must be normalized to the allowlist name "h264",
+        # otherwise RGBEncoderConfig rejects it and the codec is dropped.
+        out = _codec_create_kwargs({"rgb_encoder": None}, "libx264")
+        assert set(out) == {"rgb_encoder"}
+        assert out["rgb_encoder"].vcodec == "h264"
+        # Canonical "h264" is already allowlist-valid and passes through.
+        out2 = _codec_create_kwargs({"rgb_encoder": None}, "h264")
+        assert out2["rgb_encoder"].vcodec == "h264"
+        # AV1 opt-in survives onto the encoder config.
+        out3 = _codec_create_kwargs({"rgb_encoder": None}, "libsvtav1")
+        assert out3["rgb_encoder"].vcodec == "libsvtav1"
+
+    def test_rgb_encoder_rejects_unknown_codec_loudly(self):
+        pytest.importorskip("lerobot")
+        rgb = pytest.importorskip("lerobot.configs.video")
+        if not hasattr(rgb, "RGBEncoderConfig"):
+            pytest.skip("this LeRobot has no RGBEncoderConfig surface")
+        from strands_robots.dataset_recorder import _codec_create_kwargs
+
+        # An unsupported codec must surface LeRobot's ValueError rather than
+        # silently reverting to the default codec.
+        with pytest.raises(ValueError):
+            _codec_create_kwargs({"rgb_encoder": None}, "not_a_codec")


### PR DESCRIPTION
## Problem

`start_recording` (and `DatasetRecorder.create`/`resume`) defaulted to `vcodec="libsvtav1"` (AV1). The per-camera MP4s inside the resulting `LeRobotDataset` are frequently re-opened by OpenCV-backed readers (`cv2.VideoCapture`) - which many downstream VLM video readers use to *watch* a recorded episode. OpenCV's bundled FFmpeg commonly cannot decode AV1: `VideoCapture` opens the file and reports a non-zero frame count, yet `read()` returns zero frames. So recording a rollout and feeding it back to a video reader silently produces an empty `(0, H, W, 3)` array.

There is a second, load-bearing detail in LeRobot's codec plumbing. Across the supported `>=0.5.0,<0.6.0` range the codec is *routed* onto different surfaces depending on the release (a flat `vcodec` kwarg on 0.5.0/0.5.1; an encoder-config object on a later minor), but **every** surface validates the codec against the same allowlist - `video_utils.VALID_VIDEO_CODECS = {"h264", "hevc", "libsvtav1", "auto"} | HW_ENCODERS` - which uses **codec names** (`h264`) and **rejects the ffmpeg library names** (`libx264`/`libx265`). A recorder that hands the ffmpeg name to that surface has its request rejected outright, so an explicit `h264` never takes effect.

## Change

- Default `vcodec` is now `"h264"` (universally decodable H.264) across `start_recording` (MuJoCo + Newton), `DatasetRecorder.create`/`resume`, and the `describe()` discovery strings.
- Centralize routing in `_codec_create_kwargs`: normalize the requested codec toward its **codec-name** spelling once (`libx264`->`h264`, `libx265`->`hevc`; codec names and HW encoders pass through) and route that onto whichever surface this LeRobot exposes (`vcodec` / `rgb_encoder` / `camera_encoder`). An unsupported codec now raises loudly (LeRobot's own `ValueError`) instead of silently reverting to the default.
- `libsvtav1` (AV1) remains available opt-in for storage-constrained training pipelines; LeRobot read-back (`torchcodec`/`pyav`) handles it fine.
- Document the codec trade-off (size vs. universal decode) in `docs/recording.md` and the docstrings.

## Visual artifact

Rollout recorded in MuJoCo sim (headless EGL) with the new default codec, then reopened with OpenCV: FOURCC `h264`, 60/60 frames decoded, each `(320, 320, 3)`.

![h264 rollout, OpenCV-decodable](https://github.com/cagataycali/robots/releases/download/artifact-recording-h264/codec_demo_h264.gif)

MP4: https://github.com/cagataycali/robots/releases/download/artifact-recording-h264/codec_demo_h264.mp4

## Tests

- `tests/simulation/mujoco/test_recording_codec_opencv.py` (new): record a short sim episode, reopen each per-camera MP4 with OpenCV, and assert the decoded frame count equals the recorded count for the default and the `libx264` alias; assert `libsvtav1` still yields an AV1 stream. Fails pre-fix (0 frames decoded for the default).
- `tests/test_dataset_recorder.py`: unit-cover `_codec_create_kwargs` surface detection and codec-name normalization, including the loud-failure path for an unknown codec; the version-tolerant-forwarding test now asserts the new `h264` default forwards unchanged.

## Acceptance criteria

- [x] A recorded episode's per-camera MP4 opens in OpenCV and yields `n` non-empty frames where `n == recorded frame count`.
- [x] LeRobot read-back path (`torchcodec`/`pyav`) is unaffected (codec is standard H.264).
- [x] Regression test reopens each MP4 with OpenCV and asserts frame count > 0 and equals the recorded count.
- [x] README/docstring documents the codec trade-off.

## §13 Changelog

**round 1 (CI fix):** The approved revision routed the new `h264` default to the ffmpeg name `libx264` on the flat `vcodec` surface, on the incorrect premise that 0.5.0/0.5.1 wanted ffmpeg names there. The CI env resolves lerobot 0.5.1, whose flat `vcodec` kwarg is validated against the codec-name allowlist and **rejects** `libx264` - so the default-codec recording roundtrip (`test_concurrency.py::TestRecordingRoundtripCameraFrames`) failed with `Invalid vcodec 'libx264'`.
  - `_codec_create_kwargs` now normalizes toward codec names once (`libx264`->`h264`, `libx265`->`hevc`) and routes that onto every surface; deleted the wrong `_FFMPEG_CODEC_NAMES` forward map.
  - Corrected the comments/docstrings (module, `resume`, both test docstrings) that asserted the flat surface wanted ffmpeg names; fixed the `resume` default-codec docstring (`libx264` -> `h264`).
  - Updated the affected unit-test expectations to assert codec-name forwarding; added `libx265`->`hevc` and a HW-encoder pass-through case.
  - Verified against the installed lerobot 0.5.1 that `resolve_vcodec` accepts every routed value for `h264`/`libx264`/`libx265`/`hevc`/`libsvtav1`.