### PR TITLE
fix(lerobot_local): canonicalize bare camera frames on the declarative embodiment path

### DIFF
--- a/docs/policies/camera-naming.md
+++ b/docs/policies/camera-naming.md
@@ -70,6 +70,18 @@ camera names the runtime observation must contain.
    )
    ```
 
+## Bare camera keys are canonicalized on the declarative path
+
+On the declarative `embodiment` path the camera rename
+(`front` -> `observation.images.front`) happens INSIDE the preprocessor
+pipeline, so the observation still carries the bare source key when the
+frame is normalized to channel-first `float32`. Frames keyed by a bare
+name whose embodiment `obs_rename` target is an image feature are now
+recognized and canonicalized, so a single-camera checkpoint (e.g. an ACT
+policy declaring only `observation.images.front`) driven via an embodiment
+is handled the same as the legacy (no-embodiment) path. You do not need to
+name your camera with an `image` substring for this to work.
+
 ## See also
 
 - [LeRobot Local](lerobot-local.md) - camera routing, the pre-flight check, `obs_rename_override`.

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -1513,7 +1513,9 @@ class LerobotLocalPolicy(Policy):
                 # observation.state. Feed RAW obs straight in - ZERO per-step
                 # strands-side remapping, no _fixup needed (AddBatchDimension +
                 # Device steps in the pipeline handle shape/device).
-                observation = self._canonicalize_obs_images(observation)
+                observation = self._canonicalize_obs_images(
+                    observation, image_source_keys=self._embodiment_image_source_keys()
+                )
                 batch = self._processor_bridge.preprocess(observation, instruction=instruction)
                 if not isinstance(batch, dict):
                     batch = {"observation.state": batch}
@@ -1571,7 +1573,9 @@ class LerobotLocalPolicy(Policy):
 
     # Observation batch building
 
-    def _canonicalize_obs_images(self, observation: dict[str, Any]) -> dict[str, Any]:
+    def _canonicalize_obs_images(
+        self, observation: dict[str, Any], image_source_keys: set[str] | None = None
+    ) -> dict[str, Any]:
         """Normalize image-array layout BEFORE the preprocessor runs.
 
         LeRobot's normalizer step inside ``preprocess()`` expects images as
@@ -1587,10 +1591,29 @@ class LerobotLocalPolicy(Policy):
         all work. Non-image entries pass through untouched. Runs before BOTH the
         embodiment and legacy preprocess paths; ``_fixup_preprocessed_batch``
         still adds the batch dimension afterwards.
+
+        In the declarative embodiment path the camera rename
+        (``front`` -> ``observation.images.front``) happens INSIDE the pipeline,
+        so the observation handed here still carries the bare source key, which
+        lacks the ``"image"`` substring and would be skipped -- leaving the frame
+        as raw HWC uint8 for the normalizer to overflow on. ``image_source_keys``
+        (the embodiment ``obs_rename`` sources that target a declared image
+        feature; see :meth:`_embodiment_image_source_keys`) names those bare keys
+        so they are canonicalized too.
+
+        Args:
+            observation: Raw observation dict (bare or LeRobot-keyed).
+            image_source_keys: Extra non-``image`` keys to treat as camera
+                frames (the embodiment's image rename sources). ``None`` keeps
+                the legacy ``"image"``-substring-only behavior.
+
+        Returns:
+            A new dict with every recognized camera frame as CHW ``float32``.
         """
         out = dict(observation)
         for key, val in observation.items():
-            if "image" not in key or val is None:
+            is_image = "image" in key or (image_source_keys is not None and key in image_source_keys)
+            if not is_image or val is None:
                 continue
             if isinstance(val, np.ndarray):
                 img = torch.from_numpy(val)
@@ -1608,6 +1631,27 @@ class LerobotLocalPolicy(Policy):
                 img = img.permute(2, 0, 1)
             out[key] = img
         return out
+
+    def _embodiment_image_source_keys(self) -> set[str]:
+        """Bare observation keys the embodiment renames onto a declared image feature.
+
+        In the declarative path the camera rename runs INSIDE the preprocessor
+        pipeline, so the observation reaching :meth:`_canonicalize_obs_images`
+        still uses the robot-native source key (e.g. ``front``), not the model
+        feature name (``observation.images.front``). Returning those source
+        keys lets canonicalization recognize them as camera frames even though
+        they lack the ``"image"`` substring.
+
+        Returns:
+            The set of ``obs_rename`` sources whose target is a declared image
+            (VISUAL) input feature. Empty when no embodiment is configured.
+        """
+        emb = self._embodiment
+        if emb is None:
+            return set()
+        return {
+            src for src, dst in emb.obs_rename.items() if _declared_feature_is_image(dst, self._input_features.get(dst))
+        }
 
     def _fixup_preprocessed_batch(self, batch: dict[str, Any]) -> dict[str, Any]:
         """Fix up a preprocessor-produced batch so every value is a proper batched tensor.

--- a/tests/policies/lerobot_local/test_declarative_obs_image_canonicalization.py
+++ b/tests/policies/lerobot_local/test_declarative_obs_image_canonicalization.py
@@ -1,0 +1,139 @@
+"""Declarative-path canonicalization of bare camera frames.
+
+Regression for the declarative ``embodiment`` path of ``LerobotLocalPolicy``.
+There, the camera rename (``front`` -> ``observation.images.front``) runs
+INSIDE the preprocessor pipeline, so the observation handed to
+``_canonicalize_obs_images`` still carries the bare source key. The helper used
+to key purely off the ``"image"`` substring, so a bare ``front`` frame was
+skipped and reached the normalizer as raw HWC uint8 -- which overflows
+(``value cannot be converted to type uint8 without overflow``) or mismatches
+shapes. A single-camera SO-101 ACT checkpoint driven via the declarative path
+therefore could not run at all; only the legacy (no-embodiment) path worked.
+
+These pin the fix: ``_embodiment_image_source_keys`` surfaces the embodiment's
+image rename sources, and ``_canonicalize_obs_images`` canonicalizes those bare
+keys (while leaving the legacy substring-only behavior intact when no source
+keys are supplied).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import numpy as np
+import torch
+
+from strands_robots.policies.lerobot_local.embodiment import EmbodimentMap
+from strands_robots.policies.lerobot_local.policy import LerobotLocalPolicy
+
+
+class _VisualFeature:
+    """Minimal stand-in for a declared VISUAL ``PolicyFeature``."""
+
+    class _T:
+        name = "VISUAL"
+
+    type = _T()
+
+
+def _policy():
+    with patch.object(LerobotLocalPolicy, "_load_model"):
+        return LerobotLocalPolicy(pretrained_name_or_path="test/model")
+
+
+def test_embodiment_image_source_keys_lists_only_image_renames():
+    """Only obs_rename sources targeting a declared image feature are returned."""
+    p = _policy()
+    p._input_features = {
+        "observation.images.front": _VisualFeature(),
+        "observation.state": object(),
+    }
+    p._embodiment = EmbodimentMap(
+        name="so101_front_only",
+        obs_rename={"front": "observation.images.front"},
+        state_keys=["1", "2", "3", "4", "5", "6"],
+    )
+    assert p._embodiment_image_source_keys() == {"front"}
+
+
+def test_embodiment_image_source_keys_empty_without_embodiment():
+    """No embodiment configured -> no extra source keys (legacy behavior)."""
+    p = _policy()
+    assert p._embodiment_image_source_keys() == set()
+
+
+def test_bare_camera_key_canonicalized_with_source_keys():
+    """A bare ``front`` HWC uint8 frame is converted to CHW float32 [0,1]."""
+    p = _policy()
+    img = np.ones((480, 640, 3), dtype=np.uint8) * 255
+    out = p._canonicalize_obs_images({"front": img}, image_source_keys={"front"})["front"]
+    assert tuple(out.shape) == (3, 480, 640)  # HWC -> CHW
+    assert out.dtype == torch.float32
+    assert float(out.max()) <= 1.0 and float(out.min()) >= 0.0  # uint8 -> [0,1]
+
+
+def test_bare_camera_key_untouched_without_source_keys():
+    """Legacy path (no source keys): a bare camera key is left raw, unchanged."""
+    p = _policy()
+    img = np.ones((480, 640, 3), dtype=np.uint8) * 255
+    out = p._canonicalize_obs_images({"front": img})["front"]
+    # Still the original raw HWC uint8 array (substring-only gate, unchanged).
+    assert isinstance(out, np.ndarray)
+    assert out.dtype == np.uint8
+    assert out.shape == (480, 640, 3)
+
+
+def test_declarative_branch_uses_source_keys_for_bare_camera():
+    """End-to-end on get_actions' declarative branch: a bare camera key is
+    canonicalized to CHW float32 BEFORE preprocess, not left as raw HWC uint8."""
+    p = _policy()
+    p._loaded = True
+    p._device = "cpu"
+    p._rtc_enabled = False
+    p.actions_per_step = 1
+    p.inference_kwargs = {}
+    p._input_features = {
+        "observation.images.front": _VisualFeature(),
+        "observation.state": object(),
+    }
+    p._embodiment = EmbodimentMap(
+        name="so101_front_only",
+        obs_rename={"front": "observation.images.front"},
+        state_keys=["1", "2", "3", "4", "5", "6"],
+    )
+
+    captured: dict[str, object] = {}
+
+    class _Bridge:
+        has_preprocessor = True
+        has_postprocessor = False
+
+        def preprocess(self, observation, instruction=""):
+            captured["obs"] = observation
+            return {"observation.state": torch.zeros(1, 6)}
+
+    p._processor_bridge = _Bridge()
+
+    class _Inner:
+        def eval(self):
+            return None
+
+        def select_action(self, batch, **kw):
+            return torch.zeros(1, 6)
+
+    p._policy = _Inner()
+
+    def _no_chunk():
+        return False
+
+    p._requires_action_chunk = _no_chunk
+    p._tensor_to_action_dicts = lambda t: [{"ok": True}]
+
+    obs = {"front": np.ones((64, 64, 3), dtype=np.uint8) * 255}
+    p.get_actions_sync(obs, "pick up the cube")
+
+    frame = captured["obs"]["front"]
+    assert isinstance(frame, torch.Tensor)
+    assert frame.dtype == torch.float32
+    assert tuple(frame.shape) == (3, 64, 64)
+    assert float(frame.max()) <= 1.0


### PR DESCRIPTION
## Problem

Driving a **single-camera** lerobot checkpoint (e.g. an ACT policy declaring only `observation.images.front`) through the declarative `embodiment` path crashes, while the legacy (no-embodiment) path works.

On the declarative path the camera rename (`front` -> `observation.images.front`) happens **inside** the preprocessor pipeline, so the observation handed to `_canonicalize_obs_images` still carries the **bare** source key. That helper gated purely on the `"image"` substring, so a bare `front` frame was skipped and reached lerobot's normalizer as raw HWC uint8:

```
Preprocessor pipeline failed: value cannot be converted to type uint8 without overflow
```

(or a `torch.stack ... [3, H] and [H]` shape mismatch). `_canonicalize_obs_images`'s own docstring claims it "runs before BOTH the embodiment and legacy preprocess paths", but the substring gate made it a no-op for bare keys on the declarative branch.

## Change

- Add `_embodiment_image_source_keys()` — the embodiment `obs_rename` sources whose target is a declared image (VISUAL) input feature (resolved via the existing `_declared_feature_is_image`, so VISUAL keys without an `image` substring are honored too).
- `_canonicalize_obs_images(observation, image_source_keys=None)` now canonicalizes a bare key when it is one of those image sources. The declarative branch in `get_actions` passes the embodiment's source keys; the legacy `"image"`-substring-only behavior is unchanged when `image_source_keys` is `None`.

No public API change; the fix is confined to the lerobot_local observation-canonicalization path.

## Tests

New `tests/policies/lerobot_local/test_declarative_obs_image_canonicalization.py`. The behavioral case drives `get_actions` through the declarative branch with a bare `front` HWC uint8 frame and asserts it reaches `preprocess` as CHW `float32` in `[0,1]`. **Pre-fix: 4 of 5 fail** (bare frame reaches `preprocess` as raw HWC uint8); the 5th is a control pinning that the legacy substring-only path is unchanged. Post-fix all pass, and the existing `test_policy.py` / `test_camera_obs_rename_preflight.py` / `test_configure_embodiment.py` suites stay green (178 passed).

Gate: `ruff check` + `ruff format --check` + `mypy strands_robots tests tests_integ` clean; tests run with `MUJOCO_GL=egl`.

## Rollout in MuJoCo sim (headless)

SmolVLA on the SO-101 through the `lerobot_local` pipeline this change lives in — headless MuJoCo (`MUJOCO_GL=egl`), 60 steps, recorded to a LeRobotDataset (3 cameras, per-camera MP4s, 60 frames verified on reopen) with continuous motion (no frozen frames):

![smolvla so101 rollout](https://github.com/cagataycali/robots/releases/download/rollout-artifacts/smolvla_so101_declarative_pipeline_1782783672.gif)

Docs: `docs/policies/camera-naming.md` gains a short note that bare camera keys are canonicalized on the declarative path (no `image`-substring naming requirement).