### PR TITLE
fix(lerobot_local): drive a single-camera SO-101 ACT on the declarative path

### DIFF
--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -40,7 +40,7 @@ LerobotLocalPolicy(
     image_keys=None,                     # MolmoAct2 camera key override
     inference_action_mode="continuous",  # "continuous" | "discrete"
     camera_key_map=None,                 # {robot_cam_name: policy_image_key}
-    obs_rename_override=None,            # {runtime_obs_key: "observation.images.*"} merged over embodiment.obs_rename
+    obs_rename_override=None,            # {runtime_obs_key: "observation.images.*"} merged over embodiment.obs_rename (value None/"" DROPS that key)
     strict_keys=False,                   # raise instead of positional camera fallback
     cache_model=True,                    # reuse a process-cached model across instances
     revision=None,                       # pin a HF Hub revision (branch/tag/commit SHA)
@@ -394,6 +394,49 @@ Two ways to fix it:
        },
    )
    ```
+
+3. Drop a camera the embodiment declares but your checkpoint does not. The
+   built-in SO embodiments declare both `front` and `wrist`; a single-camera
+   checkpoint declares only one image feature, so the unmatched `wrist` rename
+   targets a feature the model never declares and fails validation. Map the
+   stale source key to `None` (or `""`) in `obs_rename_override` to remove it,
+   and route your real camera onto the model's feature:
+
+   ```python
+   create_policy(
+       "lerobot_local",
+       pretrained_name_or_path="your-org/so101-single-cam-act",
+       embodiment="so_real",
+       obs_rename_override={
+           "front": "observation.images.front",  # route the one camera you have
+           "wrist": None,                         # drop the camera you do not
+       },
+   )
+   ```
+
+### Single camera with no embodiment
+
+You do not need an embodiment at all for a single-camera checkpoint. Declare the
+robot's joint names with `set_robot_state_keys([...])` and the policy synthesizes
+a state-only embodiment that routes each declared `observation.images.*` feature
+from its short name (`observation.images.front` <- `front`) and composes
+`observation.state` in your joint order. A bare camera key (`front`) is
+canonicalized to CHW float and renamed onto the model feature, and the state is
+batched alongside it, so a single-camera ACT checkpoint runs on the declarative
+path without manual key wiring:
+
+```python
+policy = create_policy("lerobot_local", pretrained_name_or_path="your-org/so101-single-cam-act")
+policy.set_robot_state_keys(
+    ["shoulder_pan.pos", "shoulder_lift.pos", "elbow_flex.pos",
+     "wrist_flex.pos", "wrist_roll.pos", "gripper.pos"]
+)
+# obs={"front": <HWC uint8 frame>, "shoulder_pan.pos": ..., ...}
+actions = policy.get_actions_sync(obs, "pick up the cube")
+```
+
+Pass `camera_key_map={"my_cam": "observation.images.front"}` if your runtime
+camera name differs from the feature's short name.
 
 See [camera naming](camera-naming.md) for the model-card -> embodiment
 translation table.

--- a/strands_robots/policies/lerobot_local/embodiment.py
+++ b/strands_robots/policies/lerobot_local/embodiment.py
@@ -268,6 +268,7 @@ def register_pack_state_step() -> type | None:
     unavailable. Idempotent: returns the already-registered class on re-call.
     """
     try:
+        import torch
         from lerobot.processor.pipeline import ObservationProcessorStep, ProcessorStepRegistry
     except ImportError:
         logger.debug("lerobot processor framework unavailable; PackStateProcessorStep not registered")
@@ -356,7 +357,15 @@ def register_pack_state_step() -> type | None:
             vals = reconcile_dim(vals, target, self.dim_policy, label="observation.state")
 
             out = {k: v for k, v in observation.items() if k not in self.state_keys}
-            out["observation.state"] = np.asarray(vals, dtype=np.float32)
+            # Emit a 1-D float32 torch Tensor (not a numpy array) so the
+            # pipeline's own AddBatchDimensionObservationStep batches it to
+            # (1, D) exactly as it batches image tensors. A numpy state is left
+            # unbatched by that step, which on the declarative path stranded
+            # observation.state at (D,) while images were (1, C, H, W) -> a
+            # torch.stack rank mismatch inside the model. A real LeRobot dataset
+            # feeds observation.state as a tensor too, so this matches the
+            # convention the downstream steps (normalizer, batcher) expect.
+            out["observation.state"] = torch.as_tensor(vals, dtype=torch.float32)
             return out
 
         def get_config(self) -> dict[str, Any]:

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -56,6 +56,34 @@ def _declared_feature_is_image(name: str, feature: Any = None) -> bool:
     return "image" in name
 
 
+def _merge_obs_rename(base: dict[str, str], override: dict[str, str | None] | None) -> dict[str, str]:
+    """Merge an ``obs_rename_override`` over an embodiment's ``obs_rename``.
+
+    An override entry whose value is falsy (``None`` or ``""``) DROPS the
+    matching source key from the merged map instead of adding a bogus rename.
+    This is how a caller adapts a multi-camera embodiment (e.g. ``so_real``
+    declares both ``front`` and ``wrist``) to a single-camera checkpoint that
+    does not declare ``observation.images.wrist_image``: pass
+    ``obs_rename_override={"wrist": None}`` to remove the stale rename whose
+    target the model never declares (the embodiment ``validate`` would
+    otherwise reject it). Non-empty values add or replace a rename as before.
+
+    Args:
+        base: The embodiment's declared ``obs_rename`` map.
+        override: Caller override; falsy values drop, truthy values set.
+
+    Returns:
+        The merged rename map with dropped keys removed.
+    """
+    merged = dict(base)
+    for src, dst in (override or {}).items():
+        if dst:
+            merged[src] = dst
+        else:
+            merged.pop(src, None)
+    return merged
+
+
 # Fallback control rate used ONLY when RTC runs without the runtime having
 # called set_control_frequency(). Used to keep a standalone (no-runner) RTC
 # call functional; the runner always plumbs the real rate. A loud one-time
@@ -219,7 +247,7 @@ class LerobotLocalPolicy(Policy):
         image_keys: list[str] | None = None,
         inference_action_mode: str = "continuous",
         camera_key_map: dict[str, str] | None = None,
-        obs_rename_override: dict[str, str] | None = None,
+        obs_rename_override: dict[str, str | None] | None = None,
         strict_keys: bool = False,
         cache_model: bool = True,
         revision: str | None = None,
@@ -256,10 +284,14 @@ class LerobotLocalPolicy(Policy):
         # Optional override merged OVER the embodiment's declared ``obs_rename``
         # (``{runtime_obs_key: "observation.images.*"}``). Lets a caller keep
         # custom sim camera names (e.g. ``realsense_top``) and still route them
-        # onto the model's declared image features without renaming cameras.
-        # Merged in :meth:`_configure_embodiment`; also consulted by the
-        # class-level :meth:`preflight` so the override is honoured before any
-        # model download.
+        # onto the model's declared image features without renaming cameras. A
+        # falsy value (``None`` or ``""``) DROPS that source key, so a
+        # multi-camera embodiment (e.g. ``so_real`` declares ``front`` +
+        # ``wrist``) can be adapted to a single-camera checkpoint that does not
+        # declare the second image feature. Merged in
+        # :meth:`_configure_embodiment` via :func:`_merge_obs_rename`; also
+        # consulted by the class-level :meth:`preflight` so the override is
+        # honoured before any model download.
         self._obs_rename_override = dict(obs_rename_override) if obs_rename_override else None
         # When True, raise instead of routing cameras positionally if their
         # names cannot be matched to the policy's declared image keys (and no
@@ -1014,9 +1046,7 @@ class LerobotLocalPolicy(Policy):
         except Exception:  # noqa: BLE001 - unknown/odd spec; create_policy reports it
             return
 
-        obs_rename = dict(embodiment.obs_rename)
-        override = policy_config.get("obs_rename_override") or {}
-        obs_rename.update(override)
+        obs_rename = _merge_obs_rename(embodiment.obs_rename, policy_config.get("obs_rename_override"))
 
         # Group source keys by the image feature TARGET they feed. A target is
         # satisfied when ANY of its sources is present in the observation, so an
@@ -1047,6 +1077,46 @@ class LerobotLocalPolicy(Policy):
             f"camera onto the model's image feature without renaming it."
         )
 
+    def _synthesized_camera_renames(self) -> dict[str, str]:
+        """Derive camera ``obs_rename`` entries for a state-only embodiment.
+
+        When a caller declares only joint names via :meth:`set_robot_state_keys`
+        (no explicit ``embodiment``), :meth:`_configure_embodiment` synthesizes a
+        state-only embodiment so the declarative pipeline composes
+        ``observation.state``. That synthesized map previously had an empty
+        ``obs_rename``, so the pipeline never renamed the robot's bare camera key
+        (e.g. ``front``) onto the model's declared image feature
+        (``observation.images.front``); the model then raised a ``KeyError`` for
+        its missing image input, and :meth:`_embodiment_image_source_keys`
+        returned nothing so the bare frame was never canonicalized either. This
+        routes each declared image feature from a runtime source key so a
+        single-camera (or multi-camera) checkpoint works on the declarative path
+        without an explicit embodiment.
+
+        Routing precedence per declared image feature:
+          1. An explicit ``camera_key_map`` entry (runtime cam -> feature) wins.
+          2. Otherwise the feature is fed from its short name
+             (``observation.images.front`` <- ``front``); a bare-named feature
+             (e.g. MolmoAct2 ``base``) maps from itself (a harmless no-op rename).
+
+        Returns:
+            A ``{runtime_source_key: model_image_feature}`` map (possibly empty
+            when the model declares no image features).
+        """
+        declared = {f for f, feat in self._input_features.items() if _declared_feature_is_image(f, feat)}
+        renames: dict[str, str] = {}
+        if self.camera_key_map:
+            for cam, feat in self.camera_key_map.items():
+                if feat in declared:
+                    renames[cam] = feat
+        mapped = set(renames.values())
+        for feat in declared:
+            if feat in mapped:
+                continue
+            short = feat.rsplit(".", 1)[-1] if "." in feat else feat
+            renames.setdefault(short, feat)
+        return renames
+
     def _configure_embodiment(self) -> None:
         """Build, validate, and inject the declarative embodiment map (SOLUTION.md).
 
@@ -1073,7 +1143,7 @@ class LerobotLocalPolicy(Policy):
             if self.robot_state_keys and not any(k.startswith("joint_") for k in self.robot_state_keys):
                 spec = EmbodimentMap(
                     name="<from robot_state_keys>",
-                    obs_rename={},
+                    obs_rename=self._synthesized_camera_renames(),
                     state_keys=list(self.robot_state_keys),
                     action_keys=list(self.robot_state_keys),
                     dim_policy="pad",
@@ -1094,7 +1164,7 @@ class LerobotLocalPolicy(Policy):
         if self._obs_rename_override:
             from dataclasses import replace
 
-            merged = {**embodiment.obs_rename, **self._obs_rename_override}
+            merged = _merge_obs_rename(embodiment.obs_rename, self._obs_rename_override)
             embodiment = replace(embodiment, obs_rename=merged)
 
         # Fail-fast validation against the model's declared features.

--- a/tests/policies/lerobot_local/test_declarative_single_camera.py
+++ b/tests/policies/lerobot_local/test_declarative_single_camera.py
@@ -1,0 +1,193 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""Declarative path must drive a single-camera SO-101 ACT checkpoint.
+
+Setting joint names via ``set_robot_state_keys`` (no explicit ``embodiment``)
+synthesizes a state-only embodiment so the declarative pipeline composes
+``observation.state``. That path previously could not process a single-camera
+observation:
+
+* The synthesized embodiment had an empty ``obs_rename``, so the pipeline never
+  renamed the robot's bare ``front`` key onto the model's declared
+  ``observation.images.front`` feature -> ``KeyError`` in the model.
+* ``_canonicalize_obs_images`` keyed off the ``"image"`` substring, so a bare
+  ``front`` frame was left as HWC ``uint8`` -> the normalizer overflowed.
+* ``PackStateProcessorStep`` emitted ``observation.state`` as a numpy array,
+  which the pipeline's ``AddBatchDimensionObservationStep`` does not batch (it
+  only batches 1-D tensors), so state stayed ``(D,)`` while images were
+  ``(1, C, H, W)`` -> a ``torch.stack`` rank mismatch inside the model.
+
+A multi-camera embodiment (e.g. ``so_real`` declares ``front`` + ``wrist``)
+also could not be adapted to a single-camera checkpoint: ``obs_rename_override``
+merged OVER the declared map but could not DROP the stale ``wrist`` rename whose
+target the model never declares, so ``validate`` rejected it.
+
+These tests pin both behaviors. The unit tests are deterministic (no network);
+the end-to-end test runs a real (network-free) LeRobot pipeline.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.lerobot_local.embodiment import load_embodiment
+from strands_robots.policies.lerobot_local.policy import LerobotLocalPolicy, _merge_obs_rename
+
+
+def _visual(shape=(3, 480, 640)):
+    return SimpleNamespace(type=SimpleNamespace(name="VISUAL"), shape=shape)
+
+
+def _state(dim=6):
+    return SimpleNamespace(type=SimpleNamespace(name="STATE"), shape=(dim,))
+
+
+def _action(dim=6):
+    return SimpleNamespace(type=SimpleNamespace(name="ACTION"), shape=(dim,))
+
+
+def _single_camera_policy(image_feature="observation.images.front", camera_key_map=None):
+    """A loaded policy declaring one camera + 6-dof state, no model download."""
+    with patch.object(LerobotLocalPolicy, "_load_model"):
+        policy = LerobotLocalPolicy(pretrained_name_or_path=None, policy_type="act", camera_key_map=camera_key_map)
+    policy._input_features = {"observation.state": _state(6), image_feature: _visual()}
+    policy._output_features = {"action": _action(6)}
+    policy._loaded = True
+    return policy
+
+
+class TestSynthesizedEmbodimentRoutesCamera:
+    """F3: state-only synthesized embodiment must route the single camera."""
+
+    def test_synthesized_obs_rename_maps_declared_image_feature(self):
+        policy = _single_camera_policy("observation.images.front")
+        policy.set_robot_state_keys([f"j{i}" for i in range(6)])
+        renames = policy._synthesized_camera_renames()
+        # Bare 'front' must route onto the model's declared image feature.
+        assert renames == {"front": "observation.images.front"}
+
+    def test_camera_key_map_wins_in_synthesis(self):
+        policy = _single_camera_policy(
+            "observation.images.front", camera_key_map={"realsense": "observation.images.front"}
+        )
+        policy.set_robot_state_keys([f"j{i}" for i in range(6)])
+        renames = policy._synthesized_camera_renames()
+        assert renames == {"realsense": "observation.images.front"}
+
+    def test_state_only_model_has_no_camera_renames(self):
+        with patch.object(LerobotLocalPolicy, "_load_model"):
+            policy = LerobotLocalPolicy(pretrained_name_or_path=None, policy_type="act")
+        policy._input_features = {"observation.state": _state(6)}
+        policy._output_features = {"action": _action(6)}
+        policy._loaded = True
+        policy.set_robot_state_keys([f"j{i}" for i in range(6)])
+        assert policy._synthesized_camera_renames() == {}
+
+
+class TestCanonicalizeBareCameraKey:
+    """F3: a bare (pre-rename) camera key must be canonicalized to CHW float."""
+
+    def test_bare_key_converted_when_listed_in_image_keys(self):
+        policy = _single_camera_policy()
+        obs = {"front": (np.ones((480, 640, 3), dtype=np.uint8) * 255)}
+        out = policy._canonicalize_obs_images(obs, image_source_keys={"front"})
+        front = out["front"]
+        assert front.dtype.is_floating_point  # was uint8
+        assert tuple(front.shape) == (3, 480, 640)  # was HWC
+        assert float(front.max()) <= 1.0  # normalized from [0,255]
+
+    def test_bare_key_untouched_without_image_keys(self):
+        # Default behavior preserved: a bare key not flagged stays raw.
+        policy = _single_camera_policy()
+        obs = {"front": np.ones((480, 640, 3), dtype=np.uint8)}
+        out = policy._canonicalize_obs_images(obs)
+        assert out["front"].dtype == np.uint8
+
+
+class TestDropStaleObsRename:
+    """F1: obs_rename_override must be able to DROP a stale source key."""
+
+    def test_falsy_override_drops_key(self):
+        base = {"front": "observation.images.image", "wrist": "observation.images.wrist_image"}
+        assert _merge_obs_rename(base, {"wrist": None}) == {"front": "observation.images.image"}
+        assert _merge_obs_rename(base, {"wrist": ""}) == {"front": "observation.images.image"}
+
+    def test_truthy_override_still_sets(self):
+        base = {"front": "observation.images.image"}
+        merged = _merge_obs_rename(base, {"front": "observation.images.front", "wrist": None})
+        assert merged == {"front": "observation.images.front"}
+
+    def test_multi_camera_embodiment_adapts_to_single_camera_model(self):
+        # so_real declares front + wrist; a single-camera checkpoint declares
+        # only observation.images.image. Dropping wrist lets validate pass.
+        embodiment = load_embodiment("so_real")
+        assert "wrist" in embodiment.obs_rename  # precondition
+        merged = _merge_obs_rename(embodiment.obs_rename, {"wrist": None})
+        single_cam = replace(embodiment, obs_rename=merged)
+        input_features = {"observation.state": _state(6), "observation.images.image": _visual()}
+        output_features = {"action": _action(6)}
+        # Pre-fix (wrist retained) this raised: target observation.images.wrist_image
+        # is not a declared model feature.
+        single_cam.validate(input_features, output_features)
+
+    def test_stale_key_retained_fails_validation(self):
+        # Documents the failure the drop fixes: keeping wrist rejects the model.
+        embodiment = load_embodiment("so_real")
+        input_features = {"observation.state": _state(6), "observation.images.image": _visual()}
+        output_features = {"action": _action(6)}
+        with pytest.raises(ValueError, match="wrist"):
+            embodiment.validate(input_features, output_features)
+
+
+class TestPreflightHonorsDrop:
+    """F1: the pre-flight check must also honor a dropped key."""
+
+    def test_preflight_passes_when_stale_camera_dropped(self):
+        # front present, wrist absent at runtime; dropping wrist must satisfy
+        # preflight for a model whose only image feature is fed by front.
+        LerobotLocalPolicy.preflight(
+            {"front", "shoulder_pan.pos"},
+            embodiment="so_real",
+            obs_rename_override={"wrist": None, "front": "observation.images.image"},
+        )
+
+
+class TestDeclarativeSingleCameraEndToEnd:
+    """F3 end-to-end against a real (network-free) LeRobot pipeline."""
+
+    def test_real_pipeline_renames_normalizes_and_batches(self):
+        pytest.importorskip("lerobot.processor.pipeline")
+        from lerobot.processor import AddBatchDimensionProcessorStep, RenameObservationsProcessorStep
+        from lerobot.processor.pipeline import DataProcessorPipeline
+
+        from strands_robots.policies.lerobot_local.processor import ProcessorBridge
+
+        policy = _single_camera_policy("observation.images.front")
+        pipe = DataProcessorPipeline(
+            steps=[RenameObservationsProcessorStep(rename_map={}), AddBatchDimensionProcessorStep()]
+        )
+        policy._processor_bridge = ProcessorBridge(preprocessor=pipe, device="cpu")
+        policy.set_robot_state_keys([f"j{i}" for i in range(6)])
+        policy._configure_embodiment()
+
+        obs = {f"j{i}": float(i) for i in range(6)}
+        obs["front"] = np.ones((48, 64, 3), dtype=np.uint8) * 255
+        obs = policy._canonicalize_obs_images(obs, image_source_keys=policy._embodiment_image_source_keys())
+        batch = policy._processor_bridge.preprocess(obs, instruction="pick up the cube")
+
+        # Camera renamed onto the model feature, normalized float, batched.
+        assert "observation.images.front" in batch
+        assert "front" not in batch
+        img = batch["observation.images.front"]
+        assert tuple(img.shape) == (1, 3, 48, 64)
+        assert img.dtype.is_floating_point
+        assert float(img.max()) <= 1.0
+
+        # State composed AND batched to (1, D) like the image (no rank mismatch).
+        state = batch["observation.state"]
+        assert tuple(state.shape) == (1, 6)
+        assert state.dtype.is_floating_point


### PR DESCRIPTION
A local single-camera ACT checkpoint (`observation.state[6]` + `observation.images.front`, no wrist) cannot run on the promoted declarative `embodiment` path. `Robot("so101", mode="real", cameras={"front": ...})` + a local ACT checkpoint + `policy.set_robot_state_keys([...6 SO-101 motors...])` synthesizes a state-only embodiment so the pipeline composes `observation.state`, but that path still fails for a single camera.

Builds on #892 (bare-frame canonicalization), which fixes the case where the embodiment's `obs_rename` already names the camera source. This addresses the remaining gaps for a SYNTHESIZED state-only embodiment and for adapting a multi-camera embodiment to one camera.

## Root cause and fix

1. The synthesized embodiment had an empty `obs_rename`, so the pipeline never renamed the bare `front` key onto `observation.images.front` (model `KeyError`), and `_embodiment_image_source_keys()` (added in #892) returned nothing, so the frame was never canonicalized either -- the substring-`"image"` guard skips a bare `front`. New `_synthesized_camera_renames` routes each declared image feature from its short name (`observation.images.front` <- `front`), honoring an explicit `camera_key_map` first, so both #892's canonicalization and the pipeline rename apply.

2. `PackStateProcessorStep` emitted `observation.state` as a numpy array. The pipeline's `AddBatchDimensionObservationStep` only batches 1-D **tensors**, so state stayed `(D,)` while images were `(1, C, H, W)` -> a `torch.stack` rank mismatch inside the model. It now emits a 1-D `float32` tensor (the convention a real LeRobot dataset feeds), so the pipeline batches state uniformly with images.

3. `obs_rename_override` can now DROP a stale source key (value `None` or `""`). A built-in SO embodiment (`so_real`) declares both `front` and `wrist`; a single-camera checkpoint does not declare `observation.images.wrist_image`, so `validate` rejected the unmatched `wrist` rename and the override (a merge) could not remove it. `_merge_obs_rename` drops falsy-valued keys, honored in both `_configure_embodiment` and the `preflight` check.

## Tests
`tests/policies/lerobot_local/test_declarative_single_camera.py` (11 tests): synthesized-rename routing (incl. `camera_key_map` precedence and the state-only-model no-op), bare-key canonicalization, the drop-key merge + a precondition test showing the retained `wrist` fails `validate`, preflight honoring the drop, and an end-to-end test that runs a real (network-free) LeRobot pipeline and asserts the camera ends up at `observation.images.front` as a normalized `(1, 3, H, W)` float tensor and the state at `(1, 6)`.

Full `lerobot_local` suite: 439 passed; ruff + mypy clean on the changed files. Docs updated (`docs/policies/lerobot-local.md`): the drop-key `obs_rename_override` and a no-embodiment single-camera recipe.

## Observation the model receives (declarative path)
![single-camera declarative](https://github.com/cagataycali/robots/releases/download/harness-artifacts-single-cam-declarative/single_camera_declarative.png)