### PR TITLE
feat(lerobot_local): surface routing-degradation telemetry in run_policy/eval_policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Added: routing-degradation telemetry so a silently-degraded LeRobot rollout is machine-detectable
+
+`LerobotLocalPolicy`'s heuristic (non-declarative) remap path keeps a rollout alive even when it cannot bind the observation to the model's inputs by name: a camera whose name matches no declared image feature is routed to a free slot positionally, and `observation.state` is composed from the observation's own scalar keys when none of `robot_state_keys` match (the generic `joint_0..N` fallback). Either makes the robot move on meaningless inputs while `run_policy` / `eval_policy` still report `status="success"` with `success_rate ~ 0`, and the only trace was a log line (the positional fallback on the preprocessor path did not even warn). Both fallbacks now flip a flag on the policy (`positional_fallback_used` / `generic_state_keys_used`) and emit a WARNING, and `run_policy` / `eval_policy` surface both flags in their JSON result block alongside the existing `action_errors` / load telemetry. A `True` flag on an otherwise-successful run is the signature of a misconfigured camera/state binding. No behaviour change for correctly-named observations (both flags stay `False`); the remap itself is unchanged.
+
 ### Removed: the `strands_robots.planning` package - locomotion intent is `policy_kwargs`
 
 The `strands_robots.planning` package (a `Planner` ABC, `PlannerCommand`,

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -266,6 +266,18 @@ class LerobotLocalPolicy(Policy):
         # camera_key_map covers them). Defaults to False (positional fallback
         # with a warning), preserving zero-config ergonomics.
         self.strict_keys = strict_keys
+        # Routing-degradation telemetry. The heuristic (non-declarative)
+        # remap path can keep a run alive while silently producing
+        # meaningless inputs - a camera routed to an arbitrary model image
+        # slot positionally, or a state vector ordered by the observation's
+        # own keys because none of robot_state_keys matched. Both make the
+        # robot wiggle with success_rate ~ 0 while the run reports success.
+        # These flags are flipped True the first time each fallback fires so
+        # run_policy / eval_policy can surface a machine-checkable signal
+        # (positional_fallback_used / generic_state_keys_used) instead of the
+        # degradation only living in a log line nobody reads.
+        self.positional_fallback_used = False
+        self.generic_state_keys_used = False
         # When True (default), the loaded underlying model is cached at
         # process level and shared by later instances with the same load
         # key (see _MODEL_CACHE). Set False to force a private load (e.g.
@@ -1782,6 +1794,15 @@ class LerobotLocalPolicy(Policy):
                 "or set strict_keys=False to allow positional fallback."
             )
         for (k, v), feat in zip(unmatched_imgs, free_feats):
+            self.positional_fallback_used = True
+            logger.warning(
+                "Camera '%s' does not match any declared policy image key by name; "
+                "routing positionally to '%s'. The frame may feed the wrong model "
+                "input - pass camera_key_map to bind cameras explicitly (or "
+                "strict_keys=True to make this an error).",
+                k,
+                feat,
+            )
             out[feat] = v
             used_feats.add(feat)
 
@@ -1797,6 +1818,18 @@ class LerobotLocalPolicy(Policy):
         # observation's own scalar keys so we never silently drop the state.
         order = self.robot_state_keys or scalar_keys
         if self.robot_state_keys and not any(k in observation_dict for k in self.robot_state_keys):
+            self.generic_state_keys_used = True
+            logger.warning(
+                "None of robot_state_keys %s are present in the observation "
+                "(scalar keys: %s); composing observation.state from the "
+                "observation's own scalar keys instead. This usually means the "
+                "policy fell back to generic joint_0..N names that do not match "
+                "the robot's real joint names - the state vector ordering may be "
+                "wrong. Set an embodiment or robot_state_keys that match the "
+                "runtime joints.",
+                list(self.robot_state_keys),
+                sorted(scalar_keys),
+            )
             order = scalar_keys
         state_vals = []
         for k in order:
@@ -2068,6 +2101,7 @@ class LerobotLocalPolicy(Policy):
                 "or set strict_keys=False to allow positional fallback."
             )
         for cam, feat in zip(unmatched, free):
+            self.positional_fallback_used = True
             logger.warning(
                 "Camera '%s' does not match any declared policy image key by name; "
                 "routing positionally to '%s'. Pass camera_key_map to bind cameras "

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -779,8 +779,16 @@ class SimEngine(ABC):
             content block alongside the human-readable ``text``. The json block
             carries the rollout facts as typed fields (``n_steps``,
             ``elapsed_s``, ``stopped_early``, ``action_errors``, ``video_path``,
-            ``video_frames``, ...) so callers can self-correct programmatically
-            without parsing the text. Mirrors :meth:`eval_policy`.
+            ``video_frames``, ``positional_fallback_used``,
+            ``generic_state_keys_used``, ...) so callers can self-correct
+            programmatically without parsing the text. The two routing-
+            degradation flags are True when the driving policy could not bind
+            the observation to the model's inputs by name and silently fell
+            back (a camera routed to a model image slot positionally, or
+            ``observation.state`` composed from the observation's own scalar
+            keys because none of ``robot_state_keys`` matched). A True flag on
+            an otherwise ``success`` run is the signature of the robot moving
+            on meaningless inputs. Mirrors :meth:`eval_policy`.
         """
         from strands_robots.policies import create_policy
 

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -1104,6 +1104,16 @@ class PolicyRunner:
             # no load telemetry (e.g. MockPolicy).
             "policy_load_time_s": round(float(getattr(policy, "load_time_s", 0.0)), 3),
             "policy_load_cache_hit": bool(getattr(policy, "load_cache_hit", False)),
+            # Routing-degradation telemetry from the driving policy. True means
+            # the heuristic remap silently degraded the run: a camera routed to
+            # a model image slot positionally (no name/camera_key_map match), or
+            # observation.state composed from the observation's own scalar keys
+            # because none of robot_state_keys matched (generic joint_0..N). The
+            # robot then moves on meaningless inputs while status stays "success",
+            # so the signal must be machine-readable, not only a log line.
+            # Defaults False for policies without the attribute (e.g. MockPolicy).
+            "positional_fallback_used": bool(getattr(policy, "positional_fallback_used", False)),
+            "generic_state_keys_used": bool(getattr(policy, "generic_state_keys_used", False)),
             # Process RSS (MB) at result time: confirms a heavy model is resident
             # and, across a loop, that it stays resident instead of oscillating
             # as it would on a per-episode reload. None when unmeasurable.
@@ -1599,6 +1609,8 @@ class PolicyRunner:
                         "max_steps": max_steps,
                         "policy_load_time_s": round(float(getattr(policy, "load_time_s", 0.0)), 3),
                         "policy_load_cache_hit": bool(getattr(policy, "load_cache_hit", False)),
+                        "positional_fallback_used": bool(getattr(policy, "positional_fallback_used", False)),
+                        "generic_state_keys_used": bool(getattr(policy, "generic_state_keys_used", False)),
                         **rtc_telemetry,
                         "policy_resident_rss_mb": process_rss_mb(),
                         "episodes": results,
@@ -1928,6 +1940,8 @@ class PolicyRunner:
                         "benchmark_class": spec_name,
                         "policy_load_time_s": round(float(getattr(policy, "load_time_s", 0.0)), 3),
                         "policy_load_cache_hit": bool(getattr(policy, "load_cache_hit", False)),
+                        "positional_fallback_used": bool(getattr(policy, "positional_fallback_used", False)),
+                        "generic_state_keys_used": bool(getattr(policy, "generic_state_keys_used", False)),
                         "policy_resident_rss_mb": process_rss_mb(),
                         "episodes": results,
                     }

--- a/tests/policies/lerobot_local/test_routing_degradation_telemetry.py
+++ b/tests/policies/lerobot_local/test_routing_degradation_telemetry.py
@@ -1,0 +1,111 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""Heuristic remap fallbacks must be observable, not silent.
+
+The non-declarative ``_to_lerobot_observation`` / ``_resolve_camera_targets``
+remap path keeps a run alive even when it cannot bind the observation to the
+model's inputs by name: a camera whose name matches no declared image feature
+is routed to a free slot positionally, and ``observation.state`` is composed
+from the observation's own scalar keys when none of ``robot_state_keys`` match
+(the generic ``joint_0..N`` fallback). Either makes the robot move on
+meaningless inputs while the rollout still reports ``status="success"`` and
+``success_rate ~ 0``.
+
+These tests pin that each fallback (a) flips a machine-readable flag on the
+policy (``positional_fallback_used`` / ``generic_state_keys_used``) that
+``run_policy`` / ``eval_policy`` surface in their JSON, and (b) emits a WARNING,
+while a correctly-named observation leaves both flags False and stays quiet.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+
+from strands_robots.policies.lerobot_local.policy import LerobotLocalPolicy
+
+
+def _visual(shape=(3, 224, 224)):
+    return SimpleNamespace(type=SimpleNamespace(name="VISUAL"), shape=shape)
+
+
+def _state(dim=6):
+    return SimpleNamespace(type=SimpleNamespace(name="STATE"), shape=(dim,))
+
+
+def _policy(input_features, robot_state_keys):
+    with patch.object(LerobotLocalPolicy, "_load_model"):
+        policy = LerobotLocalPolicy(pretrained_name_or_path=None, policy_type="molmoact2")
+    policy._input_features = input_features
+    policy.robot_state_keys = list(robot_state_keys)
+    return policy
+
+
+def test_flags_default_false_on_fresh_policy():
+    policy = _policy({"observation.state": _state()}, ["shoulder_pan"])
+    assert policy.positional_fallback_used is False
+    assert policy.generic_state_keys_used is False
+
+
+class TestPositionalCameraFallback:
+    FEATURES = {
+        "observation.images.top": _visual(),
+        "observation.images.wrist": _visual(),
+        "observation.state": _state(),
+    }
+    STATE_KEYS = [f"j{i}" for i in range(6)]
+
+    def _obs(self, cam_names):
+        obs = {name: np.zeros((224, 224, 3), np.uint8) for name in cam_names}
+        obs.update({f"j{i}": 0.0 for i in range(6)})
+        return obs
+
+    def test_unmatched_camera_names_flip_flag_and_warn(self, caplog):
+        # Cameras "cam0"/"cam1" match no declared image feature by name -> the
+        # frames are routed positionally into the two free slots.
+        policy = _policy(self.FEATURES, self.STATE_KEYS)
+        with caplog.at_level(logging.WARNING):
+            out = policy._to_lerobot_observation(self._obs(["cam0", "cam1"]))
+        assert policy.positional_fallback_used is True
+        # Frames still land in the declared image slots (run is not aborted).
+        routed = sorted(k for k, v in out.items() if isinstance(v, np.ndarray) and v.ndim >= 2)
+        assert routed == ["observation.images.top", "observation.images.wrist"]
+        assert any("routing positionally" in r.message for r in caplog.records)
+
+    def test_matching_camera_names_leave_flag_false_and_quiet(self, caplog):
+        policy = _policy(self.FEATURES, self.STATE_KEYS)
+        with caplog.at_level(logging.WARNING):
+            out = policy._to_lerobot_observation(self._obs(["top", "wrist"]))
+        assert policy.positional_fallback_used is False
+        routed = sorted(k for k, v in out.items() if isinstance(v, np.ndarray) and v.ndim >= 2)
+        assert routed == ["observation.images.top", "observation.images.wrist"]
+        assert not any("routing positionally" in r.message for r in caplog.records)
+
+
+class TestGenericStateKeysFallback:
+    FEATURES = {"observation.state": _state(dim=6)}
+
+    def _obs(self, scalar_keys):
+        return {k: float(i) for i, k in enumerate(scalar_keys)}
+
+    def test_mismatched_state_keys_flip_flag_and_warn(self, caplog):
+        # robot_state_keys are real joint names, but the observation is keyed
+        # "1".."6" (the SO arm's bus ids) -> none match -> state composed from
+        # the observation's own scalar keys, which the caller cannot see.
+        policy = _policy(self.FEATURES, ["shoulder_pan", "shoulder_lift", "elbow", "wrist", "wrist_roll", "gripper"])
+        with caplog.at_level(logging.WARNING):
+            out = policy._to_lerobot_observation(self._obs([str(i) for i in range(1, 7)]))
+        assert policy.generic_state_keys_used is True
+        # State is still composed (not silently dropped) so the run continues.
+        assert out["observation.state"].shape == (6,)
+        assert any("robot_state_keys" in r.message for r in caplog.records)
+
+    def test_matching_state_keys_leave_flag_false_and_quiet(self, caplog):
+        keys = ["shoulder_pan", "shoulder_lift", "elbow", "wrist", "wrist_roll", "gripper"]
+        policy = _policy(self.FEATURES, keys)
+        with caplog.at_level(logging.WARNING):
+            policy._to_lerobot_observation(self._obs(keys))
+        assert policy.generic_state_keys_used is False
+        assert not any("robot_state_keys" in r.message for r in caplog.records)

--- a/tests/simulation/test_run_policy_routing_telemetry.py
+++ b/tests/simulation/test_run_policy_routing_telemetry.py
@@ -1,0 +1,64 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""run_policy / eval_policy surface the driving policy's routing-degradation flags.
+
+A run that silently degraded (camera routed positionally, or observation.state
+composed from generic joint_0..N keys) reports ``status="success"`` exactly
+like a healthy run -- the only machine-checkable difference is the
+``positional_fallback_used`` / ``generic_state_keys_used`` flags the policy
+raises. These tests pin that both keys are always present in the JSON block and
+default honestly to False for a policy that exposes no such attribute
+(MockPolicy), so an agent can self-correct without parsing the text or scraping
+logs.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import Simulation
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="routing_telemetry", mesh=False)
+    s.create_world()
+    s.add_robot(name="so100", data_config="so100")
+    yield s
+    s.cleanup()
+
+
+def _json_block(result: dict) -> dict:
+    for blk in result.get("content", []):
+        if isinstance(blk, dict) and isinstance(blk.get("json"), dict):
+            return blk["json"]
+    raise AssertionError(f"no json content block in {result}")
+
+
+def test_run_policy_payload_has_routing_flags(sim):
+    run = sim.run_policy(
+        robot_name="so100",
+        policy_provider="mock",
+        n_steps=4,
+        control_frequency=50,
+        fast_mode=True,
+    )
+    assert run["status"] == "success", run
+    payload = _json_block(run)
+    assert payload["positional_fallback_used"] is False
+    assert payload["generic_state_keys_used"] is False
+
+
+def test_eval_policy_payload_has_routing_flags(sim):
+    ev = sim.eval_policy(
+        robot_name="so100",
+        policy_provider="mock",
+        n_episodes=1,
+        max_steps=4,
+        control_frequency=50,
+    )
+    assert ev["status"] == "success", ev
+    payload = _json_block(ev)
+    assert payload["positional_fallback_used"] is False
+    assert payload["generic_state_keys_used"] is False


### PR DESCRIPTION
## Problem

`LerobotLocalPolicy`'s heuristic (non-declarative) remap path keeps a rollout alive even when it cannot bind the observation to the model's inputs by name:

1. A camera whose name matches no declared image feature (and no `camera_key_map` covers it) is routed to a free model image slot **positionally**. On the preprocessor path (`_to_lerobot_observation`) this happened with no log at all.
2. `observation.state` is composed from the observation's own scalar keys when **none** of `robot_state_keys` match the observation (the generic `joint_0..N` fallback against real joint names like `shoulder_pan`/`shoulder_lift` or bus ids `1..6`).

Either path makes the robot move on meaningless inputs while `run_policy` / `eval_policy` still return `status="success"` with `success_rate ~ 0`. The only trace was a log line (and the positional preprocessor fallback did not even emit one), so a misconfigured camera/state binding is indistinguishable from a healthy run programmatically.

## Change

Make the silent degradation **machine-detectable** without changing rollout behaviour:

- `LerobotLocalPolicy` gains two flags, initialized `False`: `positional_fallback_used` and `generic_state_keys_used`. Each is flipped `True` the first time its fallback fires, on both the preprocessor path (`_to_lerobot_observation`) and the batch path (`_resolve_camera_targets`).
- Both fallbacks now emit a `WARNING` (the preprocessor positional fallback previously had none; the generic-state reorder was silent).
- `run_policy`, `eval_policy`, and the benchmark result all carry the two flags in their `{"json": {...}}` block, alongside the existing `action_errors` and load telemetry. They read via `getattr(policy, ..., False)` so any policy without the attribute (e.g. `MockPolicy`) reports honest `False` defaults.

No behaviour change for correctly-named observations: both flags stay `False`, the remap output is byte-for-byte unchanged, and no new warning fires. The flags are sticky for the duration of a `run_policy`/`eval_policy` call (across multi-episode rollouts) so a fallback in any episode is reported; `create_policy` builds a fresh policy per call so they start `False`.

## Tests

- `tests/policies/lerobot_local/test_routing_degradation_telemetry.py` (no model download; patches `_load_model`): unmatched camera names flip `positional_fallback_used` + warn; matching names leave it `False` and quiet; mismatched `robot_state_keys` flip `generic_state_keys_used` + warn; matching keys leave it `False` and quiet; fresh policy defaults both `False`.
- `tests/simulation/test_run_policy_routing_telemetry.py`: `run_policy` and `eval_policy` JSON blocks always contain both keys, defaulting `False` for `MockPolicy`.

Both new tests fail on pre-change code (`AttributeError: ... has no attribute 'positional_fallback_used'`) and pass after. Full `tests/policies/lerobot_local/` (433) and the run_policy/eval_policy contract suites (110) pass; ruff + mypy clean on the changed files.

## Proof

Healthy sim rollout (MuJoCo headless, mock policy) result JSON now carries the flags:

```json
{
  "status": "success", "n_steps": 5, "action_errors": 0,
  "positional_fallback_used": false,
  "generic_state_keys_used": false
}
```

A deliberately misconfigured observation (cameras `cam0`/`cam1` against declared `observation.images.top`/`wrist`, state keyed `1..6` against `shoulder_pan..gripper`) flips both flags and warns:

```
positional_fallback_used = True
generic_state_keys_used  = True
```

## Notes

This is the non-breaking precursor to a stricter default: the same safety goal (no silent degradation) is achieved by making the condition observable, leaving the zero-config positional fallback intact for callers that rely on it. Flipping `strict_keys` to raise can follow as a separate, clearly backward-incompatible change if desired.

CHANGELOG updated under Unreleased.