### PR TITLE
fix(lerobot_local): make state-key mismatch loud instead of a silent open-loop rollout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 `LerobotLocalPolicy`'s heuristic (non-declarative) remap path keeps a rollout alive even when it cannot bind the observation to the model's inputs by name: a camera whose name matches no declared image feature is routed to a free slot positionally, and `observation.state` is composed from the observation's own scalar keys when none of `robot_state_keys` match (the generic `joint_0..N` fallback). Either makes the robot move on meaningless inputs while `run_policy` / `eval_policy` still report `status="success"` with `success_rate ~ 0`, and the only trace was a log line (the positional fallback on the preprocessor path did not even warn). Both fallbacks now flip a flag on the policy (`positional_fallback_used` / `generic_state_keys_used`) and emit a WARNING, and `run_policy` / `eval_policy` surface both flags in their JSON result block alongside the existing `action_errors` / load telemetry. A `True` flag on an otherwise-successful run is the signature of a misconfigured camera/state binding. No behaviour change for correctly-named observations (both flags stay `False`); the remap itself is unchanged.
 
+### Fixed: LerobotLocalPolicy state-key mismatch is now loud instead of a silent zero/open-loop rollout
+
+When `LerobotLocalPolicy` auto-generated generic state keys (`joint_0..N`, from
+the model action dim) but the sim/robot reported named joints (`shoulder_pan`
+...), none of the configured `robot_state_keys` matched the observation. Both
+observation-to-batch paths handled this silently: the preprocessor/VLA path
+(`_to_lerobot_observation`) fell back to the observation's scalar keys with no
+warning, and the strands-native path (`_build_batch_from_strands_format`)
+dropped `observation.state` entirely. The model then ran conditioned on a
+zero/missing state - effectively open-loop - while reporting `action_errors=0`,
+`success_rate=0`, and no error log. The mismatch is now surfaced through the
+existing `strict_keys` knob: with `strict_keys=True` it raises a `ValueError`
+that names the actual observation keys and points at `embodiment=` /
+`set_robot_state_keys()`; with the default `strict_keys=False` it logs a single
+WARNING with the same guidance and then falls back to the observation's own
+scalar keys, so the state is populated rather than silently zeroed or dropped.
+
+
 ### Removed: the `strands_robots.planning` package - locomotion intent is `policy_kwargs`
 
 The `strands_robots.planning` package (a `Planner` ABC, `PlannerCommand`,

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -370,6 +370,11 @@ class LerobotLocalPolicy(Policy):
         # control_frequency (set_control_frequency never called) so the
         # 30Hz fallback is loud, not silent.
         self._rtc_freq_warned: bool = False
+        # Warn at most once per policy when the configured robot_state_keys
+        # do not match ANY key in the observation (the generic joint_0..N
+        # vs named-joint mismatch). Keeps the state-key fallback loud, not
+        # silent (see _resolve_state_order).
+        self._state_key_mismatch_warned: bool = False
 
         # Action diagnostics: surface a model<->embodiment action-dim mismatch
         # (zero-filled actuators) and a persistent near-zero action stream
@@ -1795,6 +1800,62 @@ class LerobotLocalPolicy(Policy):
 
         return fixed
 
+    def _resolve_state_order(self, observation_dict: dict[str, Any], scalar_keys: list[str]) -> list[str]:
+        """Resolve which observation keys hold this step's joint-state vector.
+
+        Honors ``robot_state_keys`` when at least one of them is present in the
+        observation. When ``robot_state_keys`` is non-empty but NONE of its
+        keys appear in the observation, the configured keys cannot describe
+        this robot/sim - the canonical case being auto-generated generic names
+        (``joint_0..joint_N``, derived from the model action dim) paired with a
+        sim/robot that reports named joints (``shoulder_pan`` ...). That
+        mismatch previously yielded a zero/empty ``observation.state`` silently,
+        so the policy ran open-loop while reporting no error. It is now LOUD:
+
+          * ``strict_keys=True``  -> raise :class:`ValueError` naming the actual
+            observation keys and pointing at ``embodiment=`` /
+            ``set_robot_state_keys()``.
+          * ``strict_keys=False`` -> warn once with the same guidance, then
+            fall back to the observation's own scalar keys so the state is
+            populated rather than silently dropped.
+
+        Args:
+            observation_dict: Raw strands/sim observation for this step.
+            scalar_keys: Non-image, non-``task`` scalar keys present in the
+                observation, used as the fallback ordering.
+
+        Returns:
+            The ordered keys to pull scalar joint values from.
+
+        Raises:
+            ValueError: When ``strict_keys`` is set and no configured key
+                matches the observation.
+        """
+        if not self.robot_state_keys:
+            return scalar_keys
+        if any(k in observation_dict for k in self.robot_state_keys):
+            return self.robot_state_keys
+        shown = self.robot_state_keys[:8]
+        ellipsis = "..." if len(self.robot_state_keys) > 8 else ""
+        msg = (
+            f"None of the configured robot_state_keys {shown}{ellipsis} are present "
+            f"in the observation. Observed joint/state keys: {scalar_keys}. This "
+            "usually means generic auto-generated keys (joint_0..joint_N) were "
+            "paired with a robot/sim that reports named joints. Pass "
+            "embodiment='<name>' (e.g. embodiment='so101') or call "
+            "set_robot_state_keys([...]) with the robot's actual joint names."
+        )
+        if self.strict_keys:
+            raise ValueError("strict_keys=True: " + msg)
+        # Surface the degraded binding as machine-detectable telemetry
+        # (run_policy / eval_policy read generic_state_keys_used) and warn at
+        # most once per policy so a long rollout is not spammed.
+        self.generic_state_keys_used = True
+        if not self._state_key_mismatch_warned:
+            logger.warning(msg)
+            self._state_key_mismatch_warned = True
+        return scalar_keys
+
     def _to_lerobot_observation(self, observation_dict: dict[str, Any]) -> dict[str, Any]:
         """Remap a strands-native observation to LeRobot feature keys.
 
@@ -1880,27 +1941,11 @@ class LerobotLocalPolicy(Policy):
         scalar_keys = [
             k for k, v in observation_dict.items() if k != "task" and not (isinstance(v, np.ndarray) and v.ndim >= 2)
         ]
-        # Prefer robot_state_keys ordering, but fall back to the actual scalar
-        # keys present in the observation. robot_state_keys is often auto-filled
-        # with generic names (joint_0..joint_N) from the model's action dim,
-        # which won't match a sim/robot using real joint names ('1'..'6',
-        # 'shoulder', ...). If none of robot_state_keys are present, use the
-        # observation's own scalar keys so we never silently drop the state.
-        order = self.robot_state_keys or scalar_keys
-        if self.robot_state_keys and not any(k in observation_dict for k in self.robot_state_keys):
-            self.generic_state_keys_used = True
-            logger.warning(
-                "None of robot_state_keys %s are present in the observation "
-                "(scalar keys: %s); composing observation.state from the "
-                "observation's own scalar keys instead. This usually means the "
-                "policy fell back to generic joint_0..N names that do not match "
-                "the robot's real joint names - the state vector ordering may be "
-                "wrong. Set an embodiment or robot_state_keys that match the "
-                "runtime joints.",
-                list(self.robot_state_keys),
-                sorted(scalar_keys),
-            )
-            order = scalar_keys
+        # Resolve the joint-state ordering, raising/warning loudly when the
+        # configured robot_state_keys cannot describe this observation (the
+        # generic joint_0..N vs named-joint mismatch) instead of silently
+        # producing a zero/empty state (see _resolve_state_order).
+        order = self._resolve_state_order(observation_dict, scalar_keys)
         state_vals = []
         for k in order:
             if k in observation_dict:
@@ -2219,10 +2264,20 @@ class LerobotLocalPolicy(Policy):
                 "Call set_robot_state_keys() with the robot's motor names."
             )
 
-        # Collect state values in robot_state_keys order. Each key maps to a
-        # single float value representing one joint/motor position.
+        # Resolve the joint-state ordering. When the configured keys match
+        # nothing in the observation (generic joint_0..N vs named joints), this
+        # raises (strict_keys) or warns + falls back to the observation's own
+        # scalar keys, instead of silently dropping observation.state and
+        # running the policy open-loop (see _resolve_state_order).
+        scalar_keys = [
+            k for k, v in observation_dict.items() if k != "task" and not (isinstance(v, np.ndarray) and v.ndim >= 2)
+        ]
+        order = self._resolve_state_order(observation_dict, scalar_keys)
+
+        # Collect state values in resolved order. Each key maps to a single
+        # float value representing one joint/motor position.
         state_values = []
-        for key in self.robot_state_keys:
+        for key in order:
             if key in observation_dict:
                 value = observation_dict[key]
                 if isinstance(value, (int, float)):

--- a/tests/policies/lerobot_local/test_state_key_mismatch.py
+++ b/tests/policies/lerobot_local/test_state_key_mismatch.py
@@ -1,0 +1,124 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""State-key mismatch must be LOUD, never a silent zero/empty state vector.
+
+When ``robot_state_keys`` is auto-filled with generic names (``joint_0..N``,
+derived from the model action dim) but the sim/robot reports named joints
+(``shoulder_pan`` ...), none of the configured keys match the observation.
+Both observation-to-batch paths previously handled this silently:
+
+  * the preprocessor/VLA path (:meth:`_to_lerobot_observation`) fell back to
+    the observation's scalar keys with no warning, and
+  * the strands-native path (:meth:`_build_batch_from_strands_format`) dropped
+    ``observation.state`` entirely,
+
+so the policy ran open-loop (state conditioned on zeros / missing) with
+``action_errors=0`` and no error log. These tests pin that the mismatch is now
+loud: ``strict_keys=True`` raises an actionable error naming the actual
+observation keys, and ``strict_keys=False`` warns once and falls back so the
+state is populated rather than silently zeroed or dropped.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+import torch
+
+from strands_robots.policies.lerobot_local.policy import LerobotLocalPolicy
+
+NAMED_JOINTS = ["shoulder_pan", "shoulder_lift", "elbow_flex", "wrist_flex", "wrist_roll", "gripper"]
+
+
+def _visual(shape=(3, 224, 224)):
+    return SimpleNamespace(type=SimpleNamespace(name="VISUAL"), shape=shape)
+
+
+def _state(dim=6):
+    return SimpleNamespace(type=SimpleNamespace(name="STATE"), shape=(dim,))
+
+
+def _policy(policy_type="molmoact2", *, strict_keys=False):
+    with patch.object(LerobotLocalPolicy, "_load_model"):
+        policy = LerobotLocalPolicy(pretrained_name_or_path=None, policy_type=policy_type, strict_keys=strict_keys)
+    policy._input_features = {"observation.images.base": _visual(), "observation.state": _state(6)}
+    policy._device = torch.device("cpu")
+    # Generic auto-generated keys that match NO key in the named-joint obs.
+    policy.robot_state_keys = [f"joint_{i}" for i in range(6)]
+    return policy
+
+
+def _named_obs():
+    obs = {"base": np.zeros((224, 224, 3), np.uint8)}
+    obs.update({name: 0.5 for name in NAMED_JOINTS})
+    return obs
+
+
+class TestStrictKeysRaises:
+    """strict_keys=True turns a state-key mismatch into a clear, actionable error."""
+
+    def test_vla_path_raises_with_actionable_message(self):
+        policy = _policy("molmoact2", strict_keys=True)
+        with pytest.raises(ValueError) as exc:
+            policy._to_lerobot_observation(_named_obs())
+        msg = str(exc.value)
+        # Names the actual observation keys ...
+        assert "shoulder_pan" in msg
+        # ... and points at the two documented remedies.
+        assert "embodiment=" in msg
+        assert "set_robot_state_keys" in msg
+
+    def test_strands_native_path_raises_with_actionable_message(self):
+        policy = _policy("act", strict_keys=True)
+        with pytest.raises(ValueError) as exc:
+            policy._build_batch_from_strands_format(_named_obs(), {})
+        msg = str(exc.value)
+        assert "shoulder_pan" in msg
+        assert "embodiment=" in msg
+        assert "set_robot_state_keys" in msg
+
+
+class TestNonStrictWarnsAndFallsBack:
+    """strict_keys=False warns once and falls back so state is never silently lost."""
+
+    def test_vla_path_populates_state_from_named_joints(self, caplog):
+        policy = _policy("molmoact2", strict_keys=False)
+        with caplog.at_level("WARNING"):
+            out = policy._to_lerobot_observation(_named_obs())
+        assert "observation.state" in out
+        np.testing.assert_array_equal(out["observation.state"], np.full(6, 0.5, dtype=np.float32))
+        assert any("robot_state_keys" in r.message for r in caplog.records)
+        # The degraded binding is also surfaced as machine-detectable telemetry
+        # that run_policy / eval_policy report.
+        assert policy.generic_state_keys_used is True
+
+    def test_strands_native_path_no_longer_drops_state(self, caplog):
+        policy = _policy("act", strict_keys=False)
+        with caplog.at_level("WARNING"):
+            batch = policy._build_batch_from_strands_format(_named_obs(), {})
+        # Pre-fix this key was silently absent -> open-loop rollout.
+        assert "observation.state" in batch
+        assert batch["observation.state"].flatten().tolist() == [0.5] * 6
+        assert any("robot_state_keys" in r.message for r in caplog.records)
+        assert policy.generic_state_keys_used is True
+
+    def test_warns_at_most_once(self, caplog):
+        policy = _policy("act", strict_keys=False)
+        with caplog.at_level("WARNING"):
+            policy._build_batch_from_strands_format(_named_obs(), {})
+            policy._build_batch_from_strands_format(_named_obs(), {})
+        mismatch_warnings = [r for r in caplog.records if "robot_state_keys" in r.message]
+        assert len(mismatch_warnings) == 1
+
+
+class TestMatchingKeysUnaffected:
+    """When the configured keys match the observation, behavior is unchanged and silent."""
+
+    def test_matched_keys_populate_state_without_warning(self, caplog):
+        policy = _policy("act", strict_keys=False)
+        policy.robot_state_keys = NAMED_JOINTS
+        with caplog.at_level("WARNING"):
+            batch = policy._build_batch_from_strands_format(_named_obs(), {})
+        assert batch["observation.state"].flatten().tolist() == [0.5] * 6
+        assert not any("robot_state_keys" in r.message for r in caplog.records)
+        assert policy.generic_state_keys_used is False


### PR DESCRIPTION
## Problem

`LerobotLocalPolicy` auto-fills `robot_state_keys` with generic names (`joint_0..N`, derived from the model action dim) when no `embodiment=` and no `set_robot_state_keys()` are given. A sim/robot instead reports **named** joints (`shoulder_pan`, `shoulder_lift`, ...), so none of the configured keys match the observation. Both observation-to-batch paths handled that mismatch silently:

- `_to_lerobot_observation` (preprocessor/VLA path, e.g. MolmoAct2) fell back to the observation's scalar keys with **no warning**, and
- `_build_batch_from_strands_format` (strands-native ACT/diffusion path) **dropped `observation.state` entirely**.

The model then ran conditioned on a zero/missing state - effectively open-loop - while reporting `action_errors=0`, `success_rate=0`, and **no error log**. The robot moves but never accomplishes the task, with nothing pointing at the misconfiguration.

## Change

Both state-building paths now route through a shared `_resolve_state_order(observation_dict, scalar_keys)` that honors the existing `strict_keys` knob:

- **`strict_keys=True`** -> raise a `ValueError` that names the actual observation keys and points at the two remedies (`embodiment='<name>'` / `set_robot_state_keys([...])`).
- **`strict_keys=False`** (default) -> log a single `WARNING` with the same guidance, then fall back to the observation's own scalar keys, so the state is **populated** rather than silently zeroed or dropped.

This closes the remaining silent surface: the strands-native path used to drop `observation.state` with no fallback at all, and the VLA path's fallback was completely silent.

Example message (both paths):

```
None of the configured robot_state_keys ['joint_0', 'joint_1', ...] are present
in the observation. Observed joint/state keys: ['shoulder_pan', 'shoulder_lift',
'elbow_flex', 'wrist_flex', 'wrist_roll', 'gripper']. This usually means generic
auto-generated keys (joint_0..joint_N) were paired with a robot/sim that reports
named joints. Pass embodiment='<name>' (e.g. embodiment='so101') or call
set_robot_state_keys([...]) with the robot's actual joint names.
```

## Tests

New `tests/policies/lerobot_local/test_state_key_mismatch.py` pins both paths in both modes (the 5 mismatch cases fail on pre-fix code, verified by reverting `policy.py`):

- `strict_keys=True` raises on both paths with an actionable message (names `shoulder_pan`, suggests `embodiment=` and `set_robot_state_keys`).
- `strict_keys=False` warns once and populates `observation.state` from the named joints on both paths (the strands-native path no longer drops the key).
- Control: matched keys populate state with no warning (unchanged behavior).

Full `lerobot_local` suite: 434 passed, 11 skipped. `hatch run lint` clean (ruff + mypy).

This is an input-validation / error-surface fix; the normal matched-keys rollout path is byte-for-byte unchanged, so there is no rendered behavior delta to show - the populated-vs-dropped/zeroed state vector is asserted directly in the regression tests.

## Notes

The `strict_keys=True`-by-default flip (preflight) is intentionally out of scope here; this change keeps the zero-config default ergonomic (warn + fall back) while making the failure observable.