### PR TITLE
fix(lerobot_local): surface non-ImportError module failures as a clean ImportError in resolve_policy_class_by_name

### DIFF
--- a/strands_robots/policies/lerobot_local/resolution.py
+++ b/strands_robots/policies/lerobot_local/resolution.py
@@ -381,8 +381,16 @@ def resolve_policy_class_by_name(policy_type: str) -> type[Any]:
                     and hasattr(obj, "from_pretrained")
                 ):
                     return obj
-        except ImportError:
-            pass
+        except (ImportError, TypeError, AttributeError, RuntimeError, ValueError) as exc:
+            # A candidate ``modeling_*`` submodule can fail at import/execution
+            # time for reasons other than ImportError: when an optional VLA dep
+            # (e.g. transformers) is absent, a building-block module sets its
+            # base class to ``None`` and ``class Foo(None)`` raises TypeError at
+            # import. Any such failure means "this strategy cannot resolve the
+            # class here", so fall through to the remaining strategies and the
+            # clean, actionable ImportError below instead of leaking lerobot's
+            # internal exception type to the caller.
+            logger.debug("modeling_ import for '%s' failed (%s); trying next strategy", policy_type, exc)
 
     # Strategy 2: Direct package-level import
     try:
@@ -396,8 +404,16 @@ def resolve_policy_class_by_name(policy_type: str) -> type[Any]:
                 and hasattr(obj, "from_pretrained")
             ):
                 return obj
-    except ImportError:
-        pass
+    except (ImportError, TypeError, AttributeError, RuntimeError, ValueError) as exc:
+        # Importing ``lerobot.policies.<type>`` executes that module's body,
+        # which can raise a non-ImportError when an optional VLA dependency is
+        # missing -- e.g. ``lerobot.policies.pi_gemma`` (a PaliGemma
+        # building-block module for pi0/pi05, not a registered policy) does
+        # ``class PiGemmaModel(GemmaModel)`` where ``GemmaModel`` is ``None``
+        # when transformers is absent, raising ``TypeError`` at import. Treat
+        # every such failure as "this strategy is unavailable" and fall through
+        # to the clean ImportError below rather than leaking the internal type.
+        logger.debug("package-level import for '%s' failed (%s); trying next strategy", policy_type, exc)
 
     # Strategy 3: Legacy get_policy_class (LeRobot <0.4)
     try:

--- a/tests/policies/lerobot_local/test_resolution.py
+++ b/tests/policies/lerobot_local/test_resolution.py
@@ -268,6 +268,35 @@ class TestPolicyConfigDiscovery:
             with pytest.raises(ImportError, match=name):
                 resolve_policy_class_by_name(name)
 
+    def test_package_import_typeerror_is_surfaced_as_importerror(self, monkeypatch):
+        """Importing a candidate ``lerobot.policies.<type>`` module executes its
+        body, which can raise a *non*-ImportError when an optional VLA dep is
+        absent: e.g. ``lerobot.policies.pi_gemma`` does ``class
+        PiGemmaModel(GemmaModel)`` where ``GemmaModel`` is ``None`` without
+        transformers, raising ``TypeError`` at import. ``resolve_policy_class_by_name``
+        must still honour its documented contract and raise a clean ``ImportError``
+        naming the unresolvable type -- never leak lerobot's internal exception.
+
+        Env-independent: the failing package import is simulated so the contract
+        holds whether or not transformers/the VLA extras are installed."""
+        from strands_robots.policies.lerobot_local import resolution
+
+        real_import = resolution.importlib.import_module
+
+        def fake_import(name, *args, **kwargs):
+            # The bare package import (Strategy 2) blows up like ``class Foo(None)``.
+            if name == "lerobot.policies.faketype":
+                raise TypeError("NoneType takes no arguments")
+            # The ``modeling_*`` submodules (Strategy 1) simply do not exist.
+            if name.startswith("lerobot.policies.faketype."):
+                raise ImportError(f"No module named {name!r}")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(resolution.importlib, "import_module", fake_import)
+
+        with pytest.raises(ImportError, match="faketype"):
+            resolution.resolve_policy_class_by_name("faketype")
+
     def test_walk_continues_after_subpackage_decorator_failure(self, tmp_path, monkeypatch, caplog):
         """A subpackage whose ``configuration_*`` raises a non-ImportError
         (e.g. ``RuntimeError`` from a re-registration collision, or


### PR DESCRIPTION
## Problem

`resolve_policy_class_by_name` resolves a LeRobot policy class from a type string by importing candidate `lerobot.policies.*` modules and scanning for the concrete `*Policy` class. Its docstring promises `ImportError` when no class can be found, and downstream callers rely on that contract to distinguish "unresolvable policy type" from a genuine programming error.

Strategies 1 (`modeling_*` submodule) and 2 (package-level import) only caught `ImportError`. But importing a candidate module *executes its module body*, which can raise a non-`ImportError` when an optional VLA dependency is absent. Concretely, `lerobot.policies.pi_gemma` (a PaliGemma building-block module used by pi0/pi05, not a registered policy) does:

```python
class PiGemmaModel(GemmaModel):  # GemmaModel is None when transformers is absent
```

With transformers not installed, `GemmaModel` is `None`, so `class PiGemmaModel(None)` raises `TypeError: NoneType takes no arguments` at import time. That `TypeError` leaked straight out of `resolve_policy_class_by_name`, violating the documented `ImportError` contract whenever a candidate building-block module depends on an absent optional dep.

Strategy 3 (legacy `get_policy_class`) already documents and handles this exact broader exception set; Strategy 2 just hadn't been brought in line.

## Change

Broaden the `except` in Strategies 1 and 2 to the same set Strategy 3 already catches: `(ImportError, TypeError, AttributeError, RuntimeError, ValueError)`. A failed candidate import is debug-logged with its cause and treated as "this strategy cannot resolve the class here", so resolution falls through to the clean, actionable `ImportError` that enumerates the policy types this install can resolve. No exception is silently dropped: the underlying cause is logged at debug level, and the terminal `ImportError` remains the single, well-defined failure surfaced to callers.

## Tests

Adds `test_package_import_typeerror_is_surfaced_as_importerror`, an environment-independent regression test that monkeypatches the package import to raise `TypeError` (mimicking `class Foo(None)`) and asserts `resolve_policy_class_by_name` raises a clean `ImportError` naming the unresolvable type. It fails on the pre-fix code (the `TypeError` leaks) and passes after.

Full `tests/policies/lerobot_local/test_resolution.py` passes; `ruff check`, `ruff format --check`, and `mypy strands_robots` are clean.