### PR TITLE
docs(sim): document add_object size as full extent + reject degenerate sizes

### DIFF
--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -335,7 +335,15 @@ class SimEngine(ABC):
         mesh_path: str | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
-        """Add an object to the scene."""
+        """Add a primitive or mesh object to the scene.
+
+        The ``size`` convention is backend-specific -- the default MuJoCo
+        backend treats ``size`` as the **full extent in meters** per axis
+        (halved internally to MuJoCo's half-extents), whereas Newton consumes
+        half-extents / radii directly. See the concrete backend's
+        ``add_object`` docstring for the exact per-shape semantics and an
+        example. Returns an agent-tool status dict.
+        """
         ...
 
     @abstractmethod

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -86,7 +86,7 @@ from strands_robots.simulation.mujoco.scene_ops import (
     patch_scene_mjcf,
     replace_scene_mjcf,
 )
-from strands_robots.simulation.mujoco.spec_builder import SpecBuilder
+from strands_robots.simulation.mujoco.spec_builder import SpecBuilder, _validate_size
 from strands_robots.simulation.policy_runner import CooperativeStop
 from strands_robots.teleop_mixin import TeleopMixin
 
@@ -1388,7 +1388,59 @@ class MuJoCoSimEngine(
         mesh_path: str | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
-        """Add an object to the simulation."""
+        """Add a primitive or mesh object to the live MuJoCo scene.
+
+        The ``size`` argument is the **full extent in meters** along each local
+        axis -- *not* MuJoCo's native half-extent. It is halved internally when
+        the geom is compiled, so a box created with ``size=[0.05, 0.05, 0.05]``
+        is a 5 cm cube (MuJoCo stores ``geom_size == [0.025, 0.025, 0.025]``).
+        Per-shape ``size`` semantics (all values are full extents / diameters in
+        meters):
+
+        * ``box`` / ``ellipsoid``: ``[x, y, z]`` full edge lengths per axis.
+        * ``sphere``: ``size[0]`` is the diameter (``size[1:]`` ignored).
+        * ``cylinder`` / ``capsule``: ``size[0]`` diameter, ``size[2]`` full
+          height (``size[1]`` ignored).
+        * ``plane``: ``size[0]`` / ``size[1]`` are visual half-widths; planes are
+          infinite for collision and are forced static.
+        * ``mesh``: ``size`` is ignored -- the asset's own units define the
+          extent (requires ``mesh_path``).
+
+        A free (non-static) body rests on a horizontal support at
+        ``rest_z = support_top + size_z / 2`` -- e.g. a 5 cm cube on a table
+        whose top is at ``z = 0.75`` settles with its body origin at
+        ``z = 0.775``. Assuming half-extent makes objects look like they "sink
+        into" a support when the rest height was simply mis-computed.
+
+        Args:
+            name: Unique object name. Its geom is injected as ``"<name>_geom"``.
+            shape: ``"box"``, ``"sphere"``, ``"cylinder"``, ``"capsule"``,
+                ``"ellipsoid"``, ``"plane"``, or ``"mesh"``.
+            position: World position ``[x, y, z]`` of the body origin (default
+                origin).
+            orientation: wxyz quaternion (default identity).
+            size: Full extents in meters per the per-shape table above. Defaults
+                to ``[0.05, 0.05, 0.05]`` (a 5 cm box). Every meaningful
+                component must be > 0; a non-positive extent is rejected.
+            color: RGBA in 0..1 (default mid-grey).
+            mass: Body mass in kg for dynamic objects (default 0.1); ignored when
+                ``is_static``.
+            is_static: Fix the body in the world. ``shape="plane"`` forces this
+                True; other shapes default to dynamic.
+            mesh_path: Mesh asset path; required and only used when
+                ``shape="mesh"``.
+            **kwargs: Reserved for backend-specific extensions; currently ignored.
+
+        Returns:
+            Agent-tool status dict. ``{"status": "success", ...}`` on success;
+            ``{"status": "error", ...}`` when no world exists, a policy is
+            running, the name is taken, ``size`` has a non-positive extent, or
+            the recompile fails.
+
+        Example:
+            >>> sim.add_object("cube", shape="box", size=[0.05, 0.05, 0.05])  # 5 cm cube
+            >>> # on a table whose top is at z=0.75, the cube rests at z=0.775
+        """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         if err := self._require_no_running_policy("add_object"):
@@ -1412,6 +1464,12 @@ class MuJoCoSimEngine(
             is_static = True
         elif is_static is None:
             is_static = False
+
+        # 'size' is the full extent in meters per the docstring; reject a
+        # non-positive (degenerate) extent before mutating scene state so the
+        # caller gets a clear error rather than a confusing recompile failure.
+        if size is not None and (size_err := _validate_size(shape, list(size))) is not None:
+            return {"status": "error", "content": [{"text": size_err}]}
 
         obj = SimObject(
             name=name,

--- a/strands_robots/simulation/mujoco/spec_builder.py
+++ b/strands_robots/simulation/mujoco/spec_builder.py
@@ -61,6 +61,41 @@ def _geom_type(shape: str) -> int:
         raise ValueError(f"Unsupported shape {shape!r}. Supported: {supported}.") from e
 
 
+def _validate_size(shape: str, size: list[float]) -> str | None:
+    """Return an error message if ``size`` has a non-positive meaningful extent.
+
+    ``size`` follows the full-extent convention used by
+    :meth:`~strands_robots.simulation.mujoco.simulation.MuJoCoSimEngine.add_object`
+    (meters along each axis, halved internally to MuJoCo's half-extents). Only
+    the components a given shape actually consumes are checked, so a cylinder
+    may legitimately pass ``size[1] == 0`` (it is ignored). ``mesh`` ignores
+    ``size`` entirely. Returns ``None`` when the size is acceptable.
+    """
+    if shape == "mesh":
+        return None
+    if shape in ("box", "ellipsoid"):
+        used: tuple[tuple[int, str], ...] = ((0, "x"), (1, "y"), (2, "z"))
+    elif shape == "sphere":
+        used = ((0, "diameter"),)
+    elif shape in ("cylinder", "capsule"):
+        used = ((0, "diameter"), (2, "height"))
+    elif shape == "plane":
+        used = ((0, "x"),) if len(size) < 2 else ((0, "x"), (1, "y"))
+    else:
+        # Unknown shapes are rejected by _geom_type; nothing to validate here.
+        return None
+    for idx, axis in used:
+        if idx >= len(size):
+            continue
+        if size[idx] <= 0:
+            return (
+                f"add_object: {shape} {axis} extent must be > 0, got "
+                f"{size[idx]} (size={list(size)}). 'size' is the full extent "
+                "in meters along each axis (not MuJoCo's half-extent)."
+            )
+    return None
+
+
 def _normalize_size(shape: str, size: list[float]) -> list[float]:
     """Convert SimObject ``size`` convention to MuJoCo's per-geom size vector.
 
@@ -77,8 +112,12 @@ def _normalize_size(shape: str, size: list[float]) -> list[float]:
     ``SimObject.size`` is always 3 floats. Box/ellipsoid use all 3 as full
     extents, sphere uses ``size[0]`` as diameter (MuJoCo halves it to radius),
     cylinder/capsule use ``size[0]`` as diameter and ``size[2]`` as full height
-    (both halved), plane uses ``size[0]``/``size[1]`` as full extents (halved).
+    (both halved). Plane is the one exception: ``size[0]``/``size[1]`` are
+    passed through unchanged as MuJoCo's visual half-widths (a plane is
+    infinite for collision, so only its rendered grid extent matters).
     """
+    if (msg := _validate_size(shape, size)) is not None:
+        raise ValueError(msg)
     if shape == "box":
         sx, sy, sz = size if len(size) >= 3 else (0.1, 0.1, 0.1)
         return [sx / 2, sy / 2, sz / 2]
@@ -572,5 +611,6 @@ __all__ = [
     "_is_z0_ground_plane",
     "_geom_type",
     "_normalize_size",
+    "_validate_size",
     "_target_quat",
 ]

--- a/tests/simulation/mujoco/test_add_object_size_full_extent.py
+++ b/tests/simulation/mujoco/test_add_object_size_full_extent.py
@@ -1,0 +1,77 @@
+"""Behavioral tests for ``add_object`` size semantics on the MuJoCo backend.
+
+These pin the documented contract: ``size`` is the **full extent in meters**
+along each axis, which MuJoCo stores internally as half-extents. They also
+cover the rejection of degenerate (non-positive) extents.
+"""
+
+import pytest
+
+mj = pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="test_size_sim", mesh=False)
+    s.create_world(gravity=[0, 0, -9.81])
+    yield s
+    s.cleanup()
+
+
+def _geom_size(world, geom_name):
+    model = world._model
+    gid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_GEOM, geom_name)
+    assert gid >= 0, f"geom {geom_name!r} not found in compiled model"
+    return list(model.geom_size[gid])
+
+
+def test_box_full_extent_compiles_to_half(sim):
+    """A 5 cm box (full extent) compiles to MuJoCo half-extents of 2.5 cm."""
+    full = [0.06, 0.04, 0.02]
+    result = sim.add_object("cube", shape="box", size=full)
+    assert result["status"] == "success"
+
+    half = _geom_size(sim._world, "cube_geom")
+    assert half[0] == pytest.approx(full[0] / 2)
+    assert half[1] == pytest.approx(full[1] / 2)
+    assert half[2] == pytest.approx(full[2] / 2)
+
+
+def test_sphere_size_is_diameter(sim):
+    """``size[0]`` is the sphere diameter; the compiled radius is half of it."""
+    result = sim.add_object("ball", shape="sphere", size=[0.1, 0.1, 0.1])
+    assert result["status"] == "success"
+    radius = _geom_size(sim._world, "ball_geom")[0]
+    assert radius == pytest.approx(0.05)
+
+
+def test_cylinder_diameter_and_full_height(sim):
+    """``size[0]`` is the diameter and ``size[2]`` is the full height; both halve."""
+    result = sim.add_object("can", shape="cylinder", size=[0.08, 0.0, 0.2])
+    assert result["status"] == "success"
+    out = _geom_size(sim._world, "can_geom")
+    assert out[0] == pytest.approx(0.04)  # radius = diameter / 2
+    assert out[1] == pytest.approx(0.1)  # half-height = full height / 2
+
+
+def test_degenerate_zero_extent_rejected(sim):
+    """A zero extent is rejected and the object is not added."""
+    result = sim.add_object("flat", shape="box", size=[0.05, 0.05, 0.0])
+    assert result["status"] == "error"
+    assert "extent must be > 0" in result["content"][0]["text"]
+    assert sim.list_objects()["content"][0]["text"] == "No objects."
+
+
+def test_degenerate_negative_extent_rejected(sim):
+    """A negative extent is rejected before any scene mutation."""
+    result = sim.add_object("bad", shape="box", size=[-0.05, 0.05, 0.05])
+    assert result["status"] == "error"
+    assert "extent must be > 0" in result["content"][0]["text"]
+
+
+def test_cylinder_ignores_unused_middle_component(sim):
+    """``size[1]`` is unused for a cylinder, so a zero there is accepted."""
+    result = sim.add_object("rod", shape="cylinder", size=[0.06, 0.0, 0.15])
+    assert result["status"] == "success"


### PR DESCRIPTION
## Problem
`Simulation.add_object(size=...)` takes the **full extent** of a geom, but MuJoCo's native geom `size` is the **half-extent**. The spec builder (`_normalize_size`) halves the value internally, so a caller passing `size=[0.028, 0.028, 0.028]` gets a **2.8 cm** cube, not 5.6 cm. This was undocumented and is an easy footgun: getting object size wrong cascades into wrong grasp heights, wrong rest-center math, and mis-tuned IK approach poses that all look like physics or control bugs but are just the size convention. A box resting on a support sits at `support_top + size_z/2`, so objects look like they "sink into the table" when in fact the size assumption was wrong.

## Change
- Document full-extent `size` semantics per shape on `MuJoCoSimEngine.add_object`, with a known-size cube example and the `rest_z = support_top + size_z/2` resting relation.
- Correct the `_normalize_size` plane docstring to match the code: a plane's `size[0]`/`size[1]` pass through unchanged as MuJoCo's visual half-widths (a plane is infinite for collision), they are not halved like box extents.
- Note the backend-specific `size` convention on the `SimEngine` ABC (MuJoCo = full extent; Newton consumes half-extents/radii directly) and point to the concrete backend docstring.
- Reject degenerate (non-positive) extents in `add_object` with a clear, shape-aware error instead of a confusing `spec recompile refused` failure. Validation only checks the components a given shape actually consumes (e.g. a cylinder may still pass `size[1]=0`); `mesh` is exempt.

## Tests
New behavioral tests in `tests/simulation/mujoco/test_add_object_size_full_extent.py`:
- Assert the compiled MuJoCo geom half-extent equals the requested full extent / 2 for box, sphere (diameter), and cylinder (diameter + full height).
- Assert non-positive extents are rejected with an actionable message and no scene mutation.
- Assert a cylinder's unused middle component is tolerated.

The rejection tests fail on the pre-change code (the degenerate size reached the compiler and produced `spec recompile refused` / `size 0 must be positive in geom`) and pass after. Full local gate green: `ruff check` / `ruff format --check` clean, `mypy strands_robots` clean for the changed files, `pytest tests/simulation/mujoco/test_add_object_size_full_extent.py tests/simulation/mujoco/test_spec_builder.py` -> 51 passed.

## Visual proof
Headless MuJoCo rollout (EGL): a 5 cm cube (`size=[0.05,0.05,0.05]`) dropped onto a static table whose top is at `z=0.30`. After settling, the cube body origin reads `z=0.3249`, matching the documented `rest_z = support_top + size_z/2 = 0.30 + 0.025 = 0.325`.

![add_object size demo](https://github.com/cagataycali/robots/releases/download/add-object-size-demo/add_object_size_demo.png)