### PR TITLE
fix(lerobot_local): bind bare declared image keys by name on the VLA observation path

### DIFF
--- a/docs/policies/camera-naming.md
+++ b/docs/policies/camera-naming.md
@@ -82,6 +82,24 @@ policy declaring only `observation.images.front`) driven via an embodiment
 is handled the same as the legacy (no-embodiment) path. You do not need to
 name your camera with an `image` substring for this to work.
 
+## Bare declared image keys bind by exact name
+
+Most ACT/diffusion checkpoints declare image features in the prefixed form
+(`observation.images.<cam>`). Some VLAs - notably MolmoAct2 - instead declare
+BARE image keys (`base`, `wrist`) in their `input_features`. When you route sim
+cameras onto such a policy by name (via `image_keys` or simply by naming the
+sim cameras to match), a camera whose name equals a bare declared key binds to
+it BY NAME, exactly like the prefixed form does. Positional fallback (with its
+`Camera '<name>' does not match any declared policy image key` warning) only
+kicks in for cameras whose names match neither a prefixed nor a bare declared
+key.
+
+This matters when the scene carries an extra camera the policy does not
+consume (for example the MuJoCo `default` free camera): the named views still
+bind to their own slots and the extra camera is dropped, instead of the extra
+camera positionally displacing a real view. Set `strict_keys=True` to turn an
+unresolved camera name into a hard error rather than a positional guess.
+
 ## See also
 
 - [LeRobot Local](lerobot-local.md) - camera routing, the pre-flight check, `obs_rename_override`.

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -1807,9 +1807,10 @@ class LerobotLocalPolicy(Policy):
         Mapping rules:
           * Keys already starting with ``observation.`` (and ``task``) pass through.
           * ndarray values with ndim>=2 (images) are matched to the model's
-            declared ``observation.images.*`` features. An exact short-name match
-            (``image`` → ``observation.images.image``) is preferred; otherwise
-            images fill declared image slots in order.
+            declared image features by exact name first - either the prefixed
+            form (``image`` → ``observation.images.image``) or a BARE declared
+            key (``base`` → ``base``, as VLAs like MolmoAct2 declare them);
+            otherwise images fill remaining declared image slots in order.
           * Remaining scalar joint values are collected (in ``robot_state_keys``
             order when available, else insertion order) into ``observation.state``.
 
@@ -1847,10 +1848,22 @@ class LerobotLocalPolicy(Policy):
                     out[mapped] = v
                     used_feats.add(mapped)
                 continue
-            target = f"observation.images.{k}"
-            if target in self._input_features and target not in used_feats:
-                out[target] = v
-                used_feats.add(target)
+            prefixed = f"observation.images.{k}"
+            if prefixed in self._input_features and prefixed not in used_feats:
+                out[prefixed] = v
+                used_feats.add(prefixed)
+            elif k in declared_img_feats and k not in used_feats:
+                # VLAs such as MolmoAct2 declare bare image keys (``base`` /
+                # ``wrist``) rather than the ``observation.images.<cam>`` form.
+                # Mirror the exact-name precedence already in
+                # ``_resolve_camera_targets`` so a camera whose name equals a
+                # bare declared key binds BY NAME, not positionally - otherwise
+                # every camera falls through to positional fill, which shuffles
+                # views (and drops a real one when an extra free camera such as
+                # the sim ``default`` is present) and emits a misleading
+                # "does not match" warning even on an exact-name hit.
+                out[k] = v
+                used_feats.add(k)
             else:
                 unmatched_imgs.append((k, v))
         # Fill any remaining declared image slots, in declaration order.

--- a/tests/policies/lerobot_local/test_bare_image_key_binding.py
+++ b/tests/policies/lerobot_local/test_bare_image_key_binding.py
@@ -1,0 +1,107 @@
+"""Exact-name camera binding for policies that declare BARE image keys.
+
+Some VLAs (e.g. MolmoAct2) declare their visual ``input_features`` with bare
+camera names (``base`` / ``wrist``) rather than the ``observation.images.<cam>``
+form used by ACT/diffusion checkpoints. The strands-native observation path
+``_to_lerobot_observation`` used to test only the prefixed form
+(``observation.images.<cam>``) against ``_input_features``, so a camera whose
+name matched a bare declared key NEVER bound by name -- it fell through to
+positional fill. That:
+
+  * emitted a misleading "does not match any declared policy image key" warning
+    on an exact-name hit,
+  * shuffled views when the observation key order differed from the declared
+    order, and
+  * dropped a real view when an extra free camera (such as the sim ``default``
+    free camera) occupied a positional slot.
+
+These pin the fix: a bare-key camera binds by name (mirroring the precedence in
+``_resolve_camera_targets``), with no positional fallback and no extra view
+displacing a named one.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import numpy as np
+
+from strands_robots.policies.lerobot_local.policy import LerobotLocalPolicy
+
+
+class _VisualFeature:
+    """Minimal stand-in for a declared VISUAL ``PolicyFeature``."""
+
+    class _T:
+        name = "VISUAL"
+
+    type = _T()
+
+
+def _molmoact2_style_policy() -> LerobotLocalPolicy:
+    """A policy declaring BARE image keys (``base`` / ``wrist``), MolmoAct2-style."""
+    with patch.object(LerobotLocalPolicy, "_load_model"):
+        p = LerobotLocalPolicy(pretrained_name_or_path="test/model")
+    p._input_features = {
+        "base": _VisualFeature(),
+        "wrist": _VisualFeature(),
+        "observation.state": object(),
+    }
+    p.robot_state_keys = ["1", "2", "3", "4", "5", "6"]
+    return p
+
+
+def _state_scalars() -> dict[str, float]:
+    return {"1": 0.1, "2": 0.2, "3": 0.3, "4": 0.4, "5": 0.5, "6": 0.6}
+
+
+def test_bare_image_keys_bind_by_name_no_positional_fallback():
+    """Cameras whose names equal bare declared keys bind by name, not positionally."""
+    p = _molmoact2_style_policy()
+    base = np.ones((8, 8, 3), dtype=np.uint8) * 1
+    wrist = np.ones((8, 8, 3), dtype=np.uint8) * 2
+    out = p._to_lerobot_observation({"base": base, "wrist": wrist, **_state_scalars()})
+
+    assert p.positional_fallback_used is False
+    # Each frame reached its OWN declared slot (not swapped).
+    assert float(np.asarray(out["base"]).mean()) == 1.0
+    assert float(np.asarray(out["wrist"]).mean()) == 2.0
+
+
+def test_extra_free_camera_does_not_displace_a_named_view():
+    """A leaked free camera (sim ``default``) is dropped, not fed as a named view.
+
+    With the observation iterating ``default`` first, the pre-fix positional
+    fill bound ``default`` -> ``base`` and ``base`` -> ``wrist`` while DROPPING
+    the real ``wrist`` frame. After the fix, ``base``/``wrist`` bind by name and
+    the unmatched ``default`` is discarded.
+    """
+    p = _molmoact2_style_policy()
+    default = np.ones((8, 8, 3), dtype=np.uint8) * 9
+    base = np.ones((8, 8, 3), dtype=np.uint8) * 1
+    wrist = np.ones((8, 8, 3), dtype=np.uint8) * 2
+    out = p._to_lerobot_observation({"default": default, "base": base, "wrist": wrist, **_state_scalars()})
+
+    assert p.positional_fallback_used is False
+    assert float(np.asarray(out["base"]).mean()) == 1.0  # not 9.0 (the default cam)
+    assert float(np.asarray(out["wrist"]).mean()) == 2.0  # not dropped
+    assert "default" not in out  # the extra free camera is discarded
+
+
+def test_prefixed_image_keys_still_bind_by_name():
+    """ACT/diffusion-style ``observation.images.<cam>`` features keep binding by name."""
+    with patch.object(LerobotLocalPolicy, "_load_model"):
+        p = LerobotLocalPolicy(pretrained_name_or_path="test/model")
+    p._input_features = {
+        "observation.images.top": _VisualFeature(),
+        "observation.images.wrist": _VisualFeature(),
+        "observation.state": object(),
+    }
+    p.robot_state_keys = ["1", "2", "3", "4", "5", "6"]
+    top = np.ones((8, 8, 3), dtype=np.uint8) * 1
+    wrist = np.ones((8, 8, 3), dtype=np.uint8) * 2
+    out = p._to_lerobot_observation({"top": top, "wrist": wrist, **_state_scalars()})
+
+    assert p.positional_fallback_used is False
+    assert float(np.asarray(out["observation.images.top"]).mean()) == 1.0
+    assert float(np.asarray(out["observation.images.wrist"]).mean()) == 2.0


### PR DESCRIPTION
## Problem

VLAs such as MolmoAct2 declare their visual `input_features` with **bare** camera keys (`base`, `wrist`) rather than the `observation.images.<cam>` form used by ACT/diffusion checkpoints. On the strands-native observation path, `LerobotLocalPolicy._to_lerobot_observation` only tested the *prefixed* form against `_input_features`:

```python
target = f"observation.images.{k}"
if target in self._input_features and target not in used_feats:
    ...
else:
    unmatched_imgs.append((k, v))   # bare-key cameras always land here
```

So a camera whose name *equals a bare declared key* never bound by name — it fell through to positional fill. Consequences:

- A misleading `Camera '<name>' does not match any declared policy image key` warning is emitted on an **exact-name hit**.
- Views get **shuffled** when the observation key order differs from declaration order.
- A real view is **dropped** when an extra free camera (e.g. the MuJoCo `default` free camera) occupies a positional slot. Observed in a MolmoAct2 SO-101 rollout: with cameras iterating `default, base, wrist`, positional fill bound `default -> base` and `base -> wrist` while **dropping the real `wrist` frame** — the model was fed the orbit camera as its primary view.
- `strict_keys=True` would wrongly **raise** for a VLA whose camera names match its bare declared keys exactly.

The sibling routing helper `_resolve_camera_targets` already handles both the prefixed and bare forms; this path did not, so the two disagreed.

## Change

In `_to_lerobot_observation`, mirror the exact-name precedence already used by `_resolve_camera_targets`: try the prefixed form, then the **bare** declared key, before positional fallback. Bare-key cameras now bind by name; an unmatched extra camera (like `default`) is dropped instead of displacing a named view.

## Tests

`tests/policies/lerobot_local/test_bare_image_key_binding.py` (new):
- `test_bare_image_keys_bind_by_name_no_positional_fallback` — bare `base`/`wrist` bind by name, no positional fallback.
- `test_extra_free_camera_does_not_displace_a_named_view` — a leaked `default` camera (iterated first) is dropped; `base`/`wrist` keep their own frames.
- `test_prefixed_image_keys_still_bind_by_name` — control: `observation.images.<cam>` still binds by name.

The two bare-key tests **fail on pre-fix `main`** (`assert positional_fallback_used is False` -> `assert True is False`) and pass after. Full `tests/policies/lerobot_local/` suite: 447 passed. `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` all clean.

## Rollout (MuJoCo, headless EGL)

MolmoAct2 SO-101 rollout (`pick up the red cube`) after the fix — cameras `base`/`wrist` bind by name (no positional-fallback warnings), the dataset reopens with the expected `observation.images.base` / `observation.images.wrist` features and non-empty frames:

![MolmoAct2 SO-101 rollout](https://github.com/cagataycali/robots/releases/download/rollout-bare-key-binding/molmo_rollout_fixed.gif)

MP4: https://github.com/cagataycali/robots/releases/download/rollout-bare-key-binding/molmo_rollout_fixed.mp4

## Docs

`docs/policies/camera-naming.md` gains a *Bare declared image keys bind by exact name* section, and the `_to_lerobot_observation` docstring now documents both the prefixed and bare matching forms.