### PR TITLE
feat(sim): add_object material/texture/reflectance for MuJoCo scenes

### DIFF
--- a/docs/simulation/world-building.md
+++ b/docs/simulation/world-building.md
@@ -40,6 +40,47 @@ for i in range(5):
     )
 ```
 
+## Materials and textures
+
+By default an object renders with a flat `color` (rgba) - a glossy, obviously
+synthetic primitive. Pass `material=` to `add_object` to attach a real MuJoCo
+material so the surface can be matte or carry a texture. This narrows the
+sim-to-real visual gap for VLM/VLA policies trained on real footage. The
+`color` (rgba) still applies and tints a textured or solid material.
+
+```python
+# Matte (non-plastic) surface: kill specular highlight + shininess.
+sim.add_object("apple", shape="sphere", size=[0.04, 0, 0], color=[0.8, 0.1, 0.1, 1],
+               material={"specular": 0, "shininess": 0, "reflectance": 0})
+
+# Image texture from disk (absolute path), tiled 2x2 across the surface.
+sim.add_object("table", shape="box", size=[0.5, 0.5, 0.02], is_static=True,
+               material={"texture": "/abs/path/wood.png", "texrepeat": [2, 2],
+                         "specular": 0, "shininess": 0})
+
+# Procedural builtin texture (no image file needed).
+sim.add_object("floor_tile", shape="box", size=[0.3, 0.3, 0.01], is_static=True,
+               material={"builtin": "checker", "rgb1": [0.2, 0.3, 0.4],
+                         "rgb2": [0.1, 0.2, 0.3], "texdim": 512})
+```
+
+`material` is a dict; all keys are optional:
+
+| Key | Type | Meaning |
+|-----|------|---------|
+| `reflectance` / `specular` / `shininess` | float 0..1 | Surface response. `specular=0, shininess=0` = matte; the defaults read as glossy plastic. |
+| `texrepeat` | `[u, v]` | Texture tiling across the surface. |
+| `texture` | str | Absolute path to an image file (PNG/etc.) used as the RGB texture. |
+| `builtin` | `"checker" \| "gradient" \| "flat"` | Procedural texture, coloured by `rgb1` / `rgb2` and sized `texdim` (default 512) per side. |
+
+Specify **either** `texture` **or** `builtin`, not both. An invalid texture
+path, an unknown `builtin` name, or specifying both fails loudly with a
+`ValueError` (returned as a `status=error` dict through the agent tool) - there
+is no silent fallback to the flat-plastic default. For natural surfaces prefer
+an **image texture**; the `checker` builtin reads as a literal checkerboard.
+Materials are currently supported by the MuJoCo backend; the Newton backend
+rejects a non-`None` `material` rather than silently ignoring it.
+
 ## Cameras
 
 Free cameras look from `position` toward `target` (`fov=60.0`, `width=640`, `height=480`). Robot-URDF cameras (wrist, etc.) are auto-discovered on `add_robot` - no `add_camera` needed.

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -333,6 +333,7 @@ class SimEngine(ABC):
         mass: float = 0.1,
         is_static: bool = False,
         mesh_path: str | None = None,
+        material: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         """Add a primitive or mesh object to the scene.
@@ -343,6 +344,12 @@ class SimEngine(ABC):
         half-extents / radii directly. See the concrete backend's
         ``add_object`` docstring for the exact per-shape semantics and an
         example. Returns an agent-tool status dict.
+
+        ``material`` (optional): backend-specific visual material/texture
+        spec. ``None`` keeps the flat ``color`` rgba (unchanged); a backend
+        that supports it (MuJoCo) attaches a real material so surfaces can be
+        matte or textured. Backends that do not support it should reject a
+        non-``None`` ``material`` loudly rather than silently ignore it.
         """
         ...
 
@@ -1819,8 +1826,12 @@ class SimEngine(ABC):
                 ),
                 "add_object": (
                     "(name: str, shape='box', position=None, orientation=None, "
-                    "size=None, color=None, mass=0.1, is_static=None, mesh_path=None) "
-                    "-> dict  # add a manipulable object (cube/sphere/.../mesh) to the scene"
+                    "size=None, color=None, mass=0.1, is_static=None, mesh_path=None, "
+                    "material=None) -> dict  # add a manipulable object "
+                    "(cube/sphere/.../mesh) to the scene. material is an optional "
+                    "dict for matte/textured surfaces: keys reflectance|specular|"
+                    "shininess (0..1), texture (abs image path) OR builtin "
+                    "(checker|gradient|flat) + rgb1/rgb2/texdim, texrepeat [u,v]"
                 ),
                 "remove_object": "(name: str) -> dict  # remove a previously added object",
                 "run_policy": "(robot_name: str, policy_provider='mock', n_episodes=1, reset_between=True, ...) -> dict",

--- a/strands_robots/simulation/models.py
+++ b/strands_robots/simulation/models.py
@@ -79,6 +79,14 @@ class SimObject:
     color: list[float] = field(default_factory=lambda: [0.5, 0.5, 0.5, 1.0])  # RGBA
     mass: float = 0.1
     mesh_path: str | None = None
+    # Optional visual material/texture spec (post-material PR). When ``None``
+    # the geom renders with the flat ``color`` rgba (byte-for-byte the old
+    # behaviour). When set, the MuJoCo spec builder attaches a real
+    # ``mjMaterial`` (reflectance/specular/shininess) and, optionally, a
+    # texture (image file or procedural builtin). Backend-independent dict so
+    # this module stays free of any MuJoCo import; see
+    # ``SpecBuilder._build_material`` for the schema and validation.
+    material: dict[str, Any] | None = None
     body_id: int = -1
     is_static: bool = False
     _original_position: list[float] = field(default_factory=list)

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1386,6 +1386,7 @@ class MuJoCoSimEngine(
         mass: float = 0.1,
         is_static: bool | None = None,
         mesh_path: str | None = None,
+        material: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         """Add a primitive or mesh object to the live MuJoCo scene.
@@ -1440,6 +1441,16 @@ class MuJoCoSimEngine(
         Example:
             >>> sim.add_object("cube", shape="box", size=[0.05, 0.05, 0.05])  # 5 cm cube
             >>> # on a table whose top is at z=0.75, the cube rests at z=0.775
+
+        ``material`` (optional): a visual material/texture spec. When ``None``
+        the object renders with the flat ``color`` rgba (unchanged behaviour).
+        When set, a real MuJoCo material/texture is attached so the surface can
+        be matte (``{"specular": 0, "shininess": 0}``) or carry an image
+        texture (``{"texture": "/abs/path.png", "texrepeat": [2, 2]}``) or a
+        procedural builtin (``{"builtin": "checker", "rgb1": [...], "rgb2":
+        [...]}``). See :meth:`SpecBuilder._build_material` for the full schema;
+        an invalid texture path or unknown builtin fails loudly (no silent
+        fallback to flat plastic).
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
@@ -1480,6 +1491,7 @@ class MuJoCoSimEngine(
             color=color or [0.5, 0.5, 0.5, 1.0],
             mass=mass,
             mesh_path=mesh_path,
+            material=material,
             is_static=is_static,
         )
         self._world.objects[name] = obj

--- a/strands_robots/simulation/mujoco/spec_builder.py
+++ b/strands_robots/simulation/mujoco/spec_builder.py
@@ -20,6 +20,7 @@ transformation goes through MuJoCo's own AST.
 from __future__ import annotations
 
 import logging
+import os
 from typing import Any
 
 import numpy as np
@@ -356,6 +357,13 @@ class SpecBuilder:
           registered (usually by :meth:`build`); this method does NOT
           register mesh assets.
         """
+        # Build the visual material/texture FIRST (gated on ``obj.material is
+        # not None`` so the rgba-only path is byte-for-byte unchanged). Doing
+        # it before ``add_body`` means an invalid material raises ValueError
+        # before any body/geom is added to the spec, so a rejected add never
+        # leaves an orphan body behind.
+        material_name = SpecBuilder._build_material(spec, obj) if obj.material is not None else None
+
         body = spec.worldbody.add_body(
             name=obj.name,
             pos=list(obj.position),
@@ -384,7 +392,113 @@ class SpecBuilder:
         if obj.shape == "box":
             geom_kwargs["friction"] = [1.0, 0.5, 0.001]
 
+        if material_name is not None:
+            geom_kwargs["material"] = material_name
+
         body.add_geom(**geom_kwargs)
+
+    # material build
+    @staticmethod
+    def _build_material(spec: Any, obj: SimObject) -> str:
+        """Create a ``mjMaterial`` (+ optional texture) for ``obj.material``.
+
+        Returns the material name to assign to the geom's ``material`` field.
+        Called only when ``obj.material is not None``.
+
+        Schema of the ``obj.material`` dict (all keys optional):
+
+        * ``reflectance`` / ``specular`` / ``shininess`` (float 0..1): surface
+          response. ``specular=0, shininess=0`` gives a matte (non-plastic)
+          look; the MuJoCo defaults read as glossy plastic.
+        * ``texrepeat`` (``[u, v]``): texture tiling across the surface.
+        * exactly one texture source, OR neither (matte solid colour):
+            - ``texture`` (str): absolute path to an image file (PNG/etc.),
+              applied as an ``mjTEXTURE_2D`` RGB texture.
+            - ``builtin`` (``"checker" | "gradient" | "flat"``): procedural
+              texture, coloured by ``rgb1`` / ``rgb2`` (each ``[r, g, b]``)
+              and sized ``texdim`` (default 512) per side.
+
+        Fails loudly (``ValueError``) on a missing texture file, an unknown
+        ``builtin`` name, or both ``texture`` and ``builtin`` set -- there is
+        no silent fallback to the flat-plastic default. The geom keeps its
+        ``rgba`` (which tints an image/solid material), so callers can still
+        colour a procedural/solid surface via ``color=``.
+        """
+        mujoco = _ensure_mujoco()
+        mat_spec = obj.material or {}
+        mat_name = f"{obj.name}_mat"
+        tex_name = f"{obj.name}_tex"
+
+        # 1) Validate the whole spec BEFORE mutating ``spec`` so an invalid
+        #    material never leaves a half-built (orphan) asset behind.
+        texture = mat_spec.get("texture")
+        builtin = mat_spec.get("builtin")
+        if texture is not None and builtin is not None:
+            raise ValueError(
+                f"add_object material for {obj.name!r}: specify either 'texture' "
+                "(image file) or 'builtin' (procedural), not both."
+            )
+        builtin_enum = None
+        if texture is not None:
+            path = str(texture)
+            if not os.path.isfile(path):
+                raise ValueError(f"add_object material for {obj.name!r}: texture file not found: {path!r}")
+        elif builtin is not None:
+            builtin_map = {
+                "checker": mujoco.mjtBuiltin.mjBUILTIN_CHECKER,
+                "gradient": mujoco.mjtBuiltin.mjBUILTIN_GRADIENT,
+                "flat": mujoco.mjtBuiltin.mjBUILTIN_FLAT,
+            }
+            key = str(builtin).lower()
+            if key not in builtin_map:
+                raise ValueError(
+                    f"add_object material for {obj.name!r}: unknown builtin "
+                    f"{builtin!r}; supported: {', '.join(sorted(builtin_map))}."
+                )
+            builtin_enum = builtin_map[key]
+
+        # 2) Defensive cleanup: a prior add under this object name (then a
+        #    remove_object that deletes only the body) can leave a stale
+        #    material/texture asset behind. Re-adding would collide at compile
+        #    ("repeated name"), so drop any existing asset under our names.
+        for existing in list(getattr(spec, "materials", []) or []):
+            if existing.name == mat_name:
+                spec.delete(existing)
+        for existing in list(getattr(spec, "textures", []) or []):
+            if existing.name == tex_name:
+                spec.delete(existing)
+
+        # 3) Build the texture (if any), then the material, then bind them.
+        tex = None
+        if texture is not None:
+            tex = spec.add_texture(name=tex_name, type=mujoco.mjtTexture.mjTEXTURE_2D, file=str(texture))
+        elif builtin_enum is not None:
+            texdim = int(mat_spec.get("texdim", 512))
+            tex_kwargs: dict[str, Any] = {
+                "name": tex_name,
+                "type": mujoco.mjtTexture.mjTEXTURE_2D,
+                "builtin": builtin_enum,
+                "width": texdim,
+                "height": texdim,
+            }
+            if mat_spec.get("rgb1") is not None:
+                tex_kwargs["rgb1"] = [float(c) for c in mat_spec["rgb1"]]
+            if mat_spec.get("rgb2") is not None:
+                tex_kwargs["rgb2"] = [float(c) for c in mat_spec["rgb2"]]
+            tex = spec.add_texture(**tex_kwargs)
+
+        mat_kwargs: dict[str, Any] = {}
+        for mat_key in ("reflectance", "specular", "shininess"):
+            if mat_spec.get(mat_key) is not None:
+                mat_kwargs[mat_key] = float(mat_spec[mat_key])
+        if mat_spec.get("texrepeat") is not None:
+            tr = mat_spec["texrepeat"]
+            mat_kwargs["texrepeat"] = [float(tr[0]), float(tr[1])]
+
+        mat = spec.add_material(name=mat_name, **mat_kwargs)
+        if tex is not None:
+            mat.textures[mujoco.mjtTextureRole.mjTEXROLE_RGB] = tex.name
+        return mat_name
 
     # camera add
     @staticmethod

--- a/strands_robots/simulation/mujoco/tool_spec.json
+++ b/strands_robots/simulation/mujoco/tool_spec.json
@@ -147,6 +147,21 @@
     "mesh_path": {
       "type": "string"
     },
+    "material": {
+      "type": "object",
+      "description": "Optional visual material/texture for add_object (MuJoCo backend). Keys: reflectance|specular|shininess (float 0..1; specular=0,shininess=0 = matte), texture (absolute image path) OR builtin (checker|gradient|flat) with rgb1/rgb2 ([r,g,b]) + texdim (int, default 512), texrepeat ([u,v]). Omit for a flat color-only surface. Invalid texture path or unknown builtin fails loudly.",
+      "properties": {
+        "reflectance": { "type": "number" },
+        "specular": { "type": "number" },
+        "shininess": { "type": "number" },
+        "texture": { "type": "string" },
+        "builtin": { "type": "string", "enum": ["checker", "gradient", "flat"] },
+        "rgb1": { "type": "array", "items": { "type": "number" } },
+        "rgb2": { "type": "array", "items": { "type": "number" } },
+        "texdim": { "type": "integer" },
+        "texrepeat": { "type": "array", "items": { "type": "number" } }
+      }
+    },
     "target": {
       "type": "array",
       "items": {

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -426,6 +426,7 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         mass: float = 0.1,
         is_static: bool = False,
         mesh_path: str | None = None,
+        material: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         """Add a primitive or mesh object to the scene.
@@ -447,6 +448,10 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
                 ``.usd`` -- anything ``trimesh.load`` accepts). Required and
                 only used when ``shape="mesh"``; the mesh is loaded via
                 ``trimesh`` and converted to a Newton collision/visual shape.
+            material: Visual material/texture spec. NOT supported by the
+                Newton backend yet; a non-``None`` value is rejected loudly
+                rather than silently dropped (use the MuJoCo backend for
+                matte/textured surfaces).
             **kwargs: Ignored.
 
         Returns:
@@ -454,6 +459,18 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         """
         if self._world is None:
             return {"status": "error", "content": [{"text": "No world. Call create_world first."}]}
+        if material is not None:
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            "add_object: material= is not supported by the Newton "
+                            "backend. Use the MuJoCo backend for matte/textured surfaces."
+                        )
+                    }
+                ],
+            }
         if name in self._world.objects:
             return {"status": "error", "content": [{"text": f"Object '{name}' already exists."}]}
         if shape not in ("box", "sphere", "capsule", "cylinder", "mesh"):

--- a/tests/simulation/mujoco/test_object_materials.py
+++ b/tests/simulation/mujoco/test_object_materials.py
@@ -1,0 +1,191 @@
+"""Regression tests for ``add_object(..., material=...)`` -- matte/textured surfaces.
+
+Before the material plumbing landed, ``add_object`` exposed only ``rgba`` so
+every object compiled with ``geom_matid == -1`` (flat, plastic-shiny primitive).
+These tests pin the new behaviour:
+
+* A ``material`` dict produces a real ``mjMaterial`` (and, when requested, a
+  ``mjTexture``) and the geom's ``matid`` points at it.
+* ``material=None`` is byte-for-byte the old behaviour (``matid == -1``).
+* Invalid material specs fail loudly (``ValueError``) -- no silent fallback to
+  the flat-plastic default.
+
+They exercise the full path ``Simulation.add_object`` -> ``SimObject`` ->
+``SpecBuilder._build_material`` -> compiled ``MjModel`` so the assertions are on
+the compiled model (real behaviour), not internal bookkeeping.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+import mujoco  # noqa: E402
+
+from strands_robots.simulation.models import SimObject, SimWorld  # noqa: E402
+from strands_robots.simulation.mujoco.spec_builder import SpecBuilder  # noqa: E402
+
+
+def _compile(*objects: SimObject) -> mujoco.MjModel:
+    """Build a fresh spec from a world holding ``objects`` and compile it."""
+    world = SimWorld()
+    for obj in objects:
+        world.objects[obj.name] = obj
+    return SpecBuilder.build(world).compile()
+
+
+def _matid(model: mujoco.MjModel, geom_name: str) -> int:
+    gid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_GEOM, geom_name)
+    assert gid >= 0, f"geom {geom_name!r} not found in compiled model"
+    return int(model.geom_matid[gid])
+
+
+@pytest.fixture
+def texture_png(tmp_path):
+    """A tiny on-disk RGB PNG to use as an image texture."""
+    from PIL import Image
+
+    path = tmp_path / "surface.png"
+    Image.new("RGB", (16, 16), (140, 90, 40)).save(path)
+    return str(path)
+
+
+def test_material_none_is_unchanged_flat_behaviour():
+    """material=None must compile with no material assigned (matid == -1)."""
+    model = _compile(SimObject(name="plain", shape="box"))
+    assert _matid(model, "plain_geom") == -1
+
+
+def test_matte_material_attaches_real_material():
+    """A reflectance/specular/shininess dict yields a real material, no texture."""
+    obj = SimObject(
+        name="apple",
+        shape="sphere",
+        material={"specular": 0.0, "shininess": 0.0, "reflectance": 0.0},
+    )
+    model = _compile(obj)
+
+    matid = _matid(model, "apple_geom")
+    assert matid >= 0
+    mat_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_MATERIAL, "apple_mat")
+    assert mat_id == matid
+    # Matte values round-tripped into the compiled material.
+    assert float(model.mat_specular[matid]) == pytest.approx(0.0)
+    assert float(model.mat_shininess[matid]) == pytest.approx(0.0)
+    assert float(model.mat_reflectance[matid]) == pytest.approx(0.0)
+    # No image/procedural texture was requested -> the only texture in the
+    # model is the ground grid's (the matte material carries none of its own).
+    assert int(model.mat_texid[matid][mujoco.mjtTextureRole.mjTEXROLE_RGB]) == -1
+
+
+def test_image_texture_material_attaches_texture(texture_png):
+    """A ``texture`` path yields a material whose RGB texture role is populated."""
+    obj = SimObject(
+        name="table",
+        shape="box",
+        material={"texture": texture_png, "texrepeat": [2, 2], "specular": 0.0},
+    )
+    model = _compile(obj)
+
+    matid = _matid(model, "table_geom")
+    assert matid >= 0
+    tex_role = int(model.mat_texid[matid][mujoco.mjtTextureRole.mjTEXROLE_RGB])
+    assert tex_role >= 0, "image texture not bound to the material RGB role"
+    tex_name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_TEXTURE, tex_role)
+    assert tex_name == "table_tex"
+
+
+def test_builtin_texture_material_creates_procedural_texture():
+    """A ``builtin`` checker yields a procedural texture bound to the material."""
+    obj = SimObject(
+        name="floor2",
+        shape="box",
+        material={"builtin": "checker", "rgb1": [1.0, 0.0, 0.0], "rgb2": [0.0, 1.0, 0.0]},
+    )
+    model = _compile(obj)
+
+    matid = _matid(model, "floor2_geom")
+    assert matid >= 0
+    assert int(model.mat_texid[matid][mujoco.mjtTextureRole.mjTEXROLE_RGB]) >= 0
+
+
+def test_missing_texture_file_fails_loudly(tmp_path):
+    """A texture path that does not exist must raise, not silently fall back."""
+    obj = SimObject(name="x", shape="box", material={"texture": str(tmp_path / "nope.png")})
+    with pytest.raises(ValueError, match="texture file not found"):
+        _compile(obj)
+
+
+def test_unknown_builtin_fails_loudly():
+    """An unknown builtin name must raise, not silently fall back."""
+    obj = SimObject(name="x", shape="box", material={"builtin": "marble"})
+    with pytest.raises(ValueError, match="unknown builtin"):
+        _compile(obj)
+
+
+def test_texture_and_builtin_conflict_fails_loudly(texture_png):
+    """Specifying both texture and builtin is ambiguous and must raise."""
+    obj = SimObject(name="x", shape="box", material={"texture": texture_png, "builtin": "checker"})
+    with pytest.raises(ValueError, match="not both"):
+        _compile(obj)
+
+
+def test_simulation_add_object_material_end_to_end(texture_png):
+    """The live Simulation.add_object path plumbs material through to the model."""
+    import strands_robots as sr
+
+    sim = sr.Simulation()
+    try:
+        assert sim.create_world(ground_plane=True)["status"] == "success"
+        matte = sim.add_object(
+            "ball",
+            shape="sphere",
+            position=[0.3, 0.0, 0.1],
+            material={"specular": 0.0, "shininess": 0.0},
+        )
+        assert matte["status"] == "success", matte
+        textured = sim.add_object(
+            "tabletop",
+            shape="box",
+            position=[0.3, 0.0, 0.0],
+            is_static=True,
+            material={"texture": texture_png, "texrepeat": [2, 2]},
+        )
+        assert textured["status"] == "success", textured
+
+        model = sim._world._model
+        assert _matid(model, "ball_geom") >= 0
+        table_matid = _matid(model, "tabletop_geom")
+        assert table_matid >= 0
+        assert int(model.mat_texid[table_matid][mujoco.mjtTextureRole.mjTEXROLE_RGB]) >= 0
+    finally:
+        sim.destroy()
+
+
+def test_simulation_add_object_bad_material_reports_error(tmp_path):
+    """Bad material via the live path is rejected (status=error, no crash).
+
+    The material is built before the body is added to the spec, so a rejected
+    add leaves no orphan body behind: re-adding the same name with a valid
+    material must succeed.
+    """
+    import strands_robots as sr
+
+    sim = sr.Simulation()
+    try:
+        sim.create_world(ground_plane=True)
+        result = sim.add_object(
+            "ball",
+            shape="sphere",
+            material={"texture": str(tmp_path / "missing.png")},
+        )
+        assert result["status"] == "error", result
+        # Failed add must not leave the object registered.
+        assert "ball" not in sim._world.objects
+        # No orphan body in the spec: the same name re-adds cleanly.
+        retry = sim.add_object("ball", shape="sphere", material={"specular": 0.0})
+        assert retry["status"] == "success", retry
+        assert _matid(sim._world._model, "ball_geom") >= 0
+    finally:
+        sim.destroy()

--- a/tests/simulation/test_foundation.py
+++ b/tests/simulation/test_foundation.py
@@ -84,6 +84,7 @@ def _make_dummy_engine_class() -> type[SimEngine]:
             mass: float = 0.1,
             is_static: bool = False,
             mesh_path: str | None = None,
+            material: dict[str, Any] | None = None,
             **kwargs: Any,
         ) -> dict[str, Any]:
             return {}

--- a/tests/simulation/test_sim_engine_describe_discovery.py
+++ b/tests/simulation/test_sim_engine_describe_discovery.py
@@ -79,6 +79,7 @@ def _make_minimal_engine():
             mass: float = 1.0,
             is_static: bool = False,
             mesh_path: str | None = None,
+            material: dict[str, Any] | None = None,
             **kwargs: Any,
         ) -> dict[str, Any]:
             return {}


### PR DESCRIPTION
## Problem

`Simulation.add_object()` exposed only `rgba`, so every object compiled with no material assigned (`geom.matid == -1`) and rendered as a flat, glossy-plastic primitive. There was no way to set matte materials, reflectance, or textures even though MuJoCo supports all of it (the spec builder already uses `spec.add_texture` / `spec.add_material` for the ground grid). A flat-plastic scene is an obviously-synthetic input for a VLM/VLA policy trained on real-camera footage, so this widens the sim-to-real visual gap.

## Change

Add an optional `material` spec to `add_object` that attaches a real MuJoCo material (and, optionally, a texture). Additive and backward-compatible: gated on `material is not None`, so the rgba-only path is byte-for-byte unchanged.

- `SimObject.material: dict | None` (backend-independent; no MuJoCo import in `models.py`).
- MuJoCo `add_object(..., material=...)` -> new `SpecBuilder._build_material` builds an `mjMaterial` (`reflectance` / `specular` / `shininess` / `texrepeat`) and, optionally, a texture: an image file (`mjTEXTURE_2D`, `file=`) or a procedural builtin (`checker` / `gradient` / `flat` with `rgb1` / `rgb2` / `texdim`), bound via `mjTEXROLE_RGB`. The geom keeps its `rgba`, which tints a textured/solid material.
- The material is built **before** the body is added to the spec, so an invalid material (missing texture file, unknown builtin, or both `texture` and `builtin` set) raises `ValueError` before any spec mutation: no silent fallback to flat plastic, and no orphan body left behind on a rejected add (re-adding the same name then succeeds).
- Newton backend rejects a non-`None` `material` loudly rather than silently dropping it.
- `describe()`, the agent tool schema (`tool_spec.json`), and the world-building docs document the material schema.

## Material schema

```python
material = {
  "reflectance": 0..1, "specular": 0..1, "shininess": 0..1,   # matte vs glossy
  "texture": "/abs/path.png",                                  # image texture
  "builtin": "checker|gradient|flat", "rgb1": [...], "rgb2": [...], "texdim": 512,  # procedural
  "texrepeat": [u, v],
}
```

```python
sim.add_object("apple", shape="sphere", material={"specular": 0, "shininess": 0, "reflectance": 0})
sim.add_object("table", shape="box", is_static=True,
               material={"texture": "/tmp/wood.png", "texrepeat": [2, 2], "specular": 0, "shininess": 0})
```

## Rollout in MuJoCo sim (headless, `MUJOCO_GL=egl`)

Same scene (a static box "table" + a sphere) rendered three ways. Left to right: current flat `rgba`; matte material (`specular=0, shininess=0`); image texture + matte. The textured/matte variants drop the plastic sheen that marks the flat default as synthetic.

![material comparison](https://github.com/cagataycali/robots/releases/download/sim-material-demo-1782794625/material_compare.png)

## Tests

New `tests/simulation/mujoco/test_object_materials.py` asserts on the compiled `MjModel` (real behaviour, not internal state):
- matte / image-texture / builtin specs attach a real material and the geom's `matid >= 0` (texture role bound for textured variants);
- `material=None` keeps `matid == -1` (unchanged flat behaviour);
- a missing texture file, an unknown builtin, or both `texture` and `builtin` each raise `ValueError`;
- the live `Simulation.add_object` path plumbs material through, and a rejected bad-material add leaves no orphan body (the same name re-adds cleanly).

All 9 fail on pre-change code (8 hard-fail; the rgba-only baseline passes) and pass after. Green locally: `ruff check`/`ruff format` clean, `mypy strands_robots tests tests_integ` adds zero new errors, and the MuJoCo sim suite passes (pre-existing PyAV recording-codec failures are unrelated to this change).

## Scope

This is a render-fidelity improvement (a prerequisite for shrinking the sim-to-real visual gap), not on its own sufficient for zero-shot VLA grasping.