### PR TITLE
fix(sim): resolve vertical (top-down / straight-up) camera look-at orientation

### DIFF
--- a/strands_robots/simulation/mujoco/spec_builder.py
+++ b/strands_robots/simulation/mujoco/spec_builder.py
@@ -152,8 +152,13 @@ def _target_quat(position: list[float], target: list[float]) -> list[float] | No
     * Right   (cam local +X) = normalize(forward x up)
     * Image-up (cam local +Y) = normalize(right x forward)
 
-    Returns ``None`` for degenerate cases (target == position, or forward
-    parallel to up). Callers handle the degenerate case upstream.
+    The up vector is world +Z, except when the view direction is parallel to
+    +Z (a vertical / top-down camera), in which case world +Y is used as the
+    reference up so the look-at still resolves to a valid orientation.
+
+    Returns ``None`` only for the truly degenerate case where
+    ``target == position`` (zero-length view direction). Callers handle the
+    degenerate case upstream.
 
     Uses MuJoCo's ``mju_mat2Quat`` so no hand-rolled quaternion math.
     """
@@ -169,7 +174,16 @@ def _target_quat(position: list[float], target: list[float]) -> list[float] | No
     right = np.cross(fwd, up)
     rlen = float(np.linalg.norm(right))
     if rlen < 1e-9:
-        return None
+        # Forward is parallel to world +Z (a vertical camera, e.g. the
+        # top-down overhead view). The world-up reference is degenerate, so
+        # fall back to world +Y as the reference up. This still yields a
+        # well-defined orientation instead of silently dropping the quat and
+        # leaving the camera at its default (mis-oriented) pose.
+        up = np.array([0.0, 1.0, 0.0])
+        right = np.cross(fwd, up)
+        rlen = float(np.linalg.norm(right))
+        if rlen < 1e-9:
+            return None
     right /= rlen
     image_up = np.cross(right, fwd)
     image_up /= float(np.linalg.norm(image_up))

--- a/tests/simulation/mujoco/test_spec_builder.py
+++ b/tests/simulation/mujoco/test_spec_builder.py
@@ -101,9 +101,44 @@ class TestTargetQuat:
         norm = (quat[0] ** 2 + quat[1] ** 2 + quat[2] ** 2 + quat[3] ** 2) ** 0.5
         assert norm == pytest.approx(1.0, abs=1e-6)
 
-    def test_forward_parallel_to_up_returns_none(self):
-        # Straight-down camera - forward is (0,0,-1), colinear with world up.
-        assert _target_quat([0, 0, 1], [0, 0, 0]) is None
+    def test_top_down_camera_resolves_valid_quat(self):
+        # Top-down overhead camera: forward (0,0,-1) is parallel to world +Z.
+        # Previously this returned None (degenerate) and add_camera silently
+        # dropped the orientation, leaving the camera mis-pointed. It must now
+        # fall back to world +Y and produce a valid, normalised quaternion.
+        quat = _target_quat([0.2, 0, 0.5], [0.2, 0, 0])
+        assert quat is not None
+        assert len(quat) == 4
+        norm = sum(c * c for c in quat) ** 0.5
+        assert norm == pytest.approx(1.0, abs=1e-6)
+
+    def test_straight_up_camera_resolves_valid_quat(self):
+        # Looking straight up: forward (0,0,+1), also parallel to world +Z.
+        quat = _target_quat([0, 0, 0], [0, 0, 1])
+        assert quat is not None
+        norm = sum(c * c for c in quat) ** 0.5
+        assert norm == pytest.approx(1.0, abs=1e-6)
+
+    @pytest.mark.parametrize(
+        ("pos", "target"),
+        [
+            ([0.2, 0.0, 0.5], [0.2, 0.0, 0.0]),  # top-down looking down
+            ([0.0, 0.0, 0.0], [0.0, 0.0, 1.0]),  # straight up
+        ],
+    )
+    def test_vertical_camera_forward_points_at_target(self, pos, target):
+        """A vertical look-at must orient the camera's -Z toward the target."""
+        quat = _target_quat(pos, target)
+        assert quat is not None
+
+        spec = mujoco.MjSpec()
+        spec.worldbody.add_camera(name="c", pos=pos, quat=quat, fovy=60, mode=mujoco.mjtCamLight.mjCAMLIGHT_FIXED)
+        model = spec.compile()
+        rot = model.cam_mat0[0].reshape(3, 3)
+        cam_forward = -rot[:, 2]
+        expected = np.array(target, dtype=float) - np.array(pos, dtype=float)
+        expected /= np.linalg.norm(expected)
+        assert np.allclose(cam_forward, expected, atol=1e-3)
 
     def test_quat_rotates_camera_to_face_target(self):
         """Compile a spec with quat=, then check the resulting cam_mat0 actually


### PR DESCRIPTION
## Problem
`add_camera(position, target)` produced a mis-oriented camera whenever the view direction is **vertical** (straight down or straight up). The top-down overhead view is the most natural camera for inspecting object placement in a scene, and it was silently broken.

Root cause is in `strands_robots/simulation/mujoco/spec_builder.py::_target_quat`:

```python
up = np.array([0.0, 0.0, 1.0])
right = np.cross(fwd, up)
if np.linalg.norm(right) < 1e-9:
    return None          # degenerate when fwd is parallel to world +Z
```

When the view direction is parallel to world up (`fwd = [0,0,-1]` or `[0,0,+1]`), `cross(fwd, up)` is the zero vector, so the function returned `None`. `add_camera` then skipped setting the quaternion entirely, leaving the camera at its default orientation. MuJoCo's default fixed camera happens to look straight *down*, so a top-down look-at coincidentally still pointed roughly right, but a **straight-up** look-at kept pointing down and the target fell completely out of frame.

## Change
When `fwd` is parallel to world +Z, fall back to world +Y as the reference up. This yields a well-defined orientation instead of dropping the quaternion. `None` is now returned only for the truly degenerate `target == position` case (zero-length view direction).

## Tests
Updated `tests/simulation/mujoco/test_spec_builder.py`:
- `test_top_down_camera_resolves_valid_quat` / `test_straight_up_camera_resolves_valid_quat`: both vertical cases now return a valid, normalised quaternion (previously `None`).
- `test_vertical_camera_forward_points_at_target` (parametrized, top-down + straight-up): compiles a spec with the quat and asserts the camera's local -Z forward axis actually points at the target. This test **fails on pre-fix code** (quat is `None`).

Full local gate green: `ruff check` / `ruff format --check` clean, `mypy strands_robots tests tests_integ` clean, and the MuJoCo sim suite passes (`158 passed, 18 skipped` across camera/render/spec tests, `MUJOCO_GL=egl`).

## Visual proof (MuJoCo headless rollout, EGL)
A red cube placed **above** a camera, with a straight-up look-at (`position=[0,0,0.05]`, `target=[0,0,0.4]`), rendered at 400x400. Left = before fix (camera left looking down, 0 cube pixels in frame); right = after fix (camera correctly looks up at the cube, 1024 cube pixels). Images brightened 2x for visibility.

![before/after](https://github.com/cagataycali/robots/releases/download/sim-camera-artifacts/vertical_lookat_before_after.png)