### PR TITLE
feat(sim): make LeKiwi simulatable via GitHub asset source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Added: LeKiwi is now simulatable (`Robot("lekiwi", mode="sim")`)
+
+The `lekiwi` registry entry was hardware-only - it carried a `hardware.lerobot_type`
+mapping but no `asset` block, and `robot_descriptions` ships no lekiwi module, so
+`Robot("lekiwi", mode="sim")` failed with `No model found for 'lekiwi'`. The entry
+now points at the Apache-2.0 [Ekumen-OS/lekiwi](https://github.com/Ekumen-OS/lekiwi)
+MuJoCo description via a GitHub asset `source` (6-DOF SO-ARM arm on a 3-omniwheel
+base, 9 actuators). LeKiwi auto-downloads and compiles on first sim use, steps
+stably, and renders from its `front`/`wrist` cameras. The existing hardware mapping
+is unchanged.
+
 ### Added: routing-degradation telemetry so a silently-degraded LeRobot rollout is machine-detectable
 
 `LerobotLocalPolicy`'s heuristic (non-declarative) remap path keeps a rollout alive even when it cannot bind the observation to the model's inputs by name: a camera whose name matches no declared image feature is routed to a free slot positionally, and `observation.state` is composed from the observation's own scalar keys when none of `robot_state_keys` match (the generic `joint_0..N` fallback). Either makes the robot move on meaningless inputs while `run_policy` / `eval_policy` still report `status="success"` with `success_rate ~ 0`, and the only trace was a log line (the positional fallback on the preprocessor path did not even warn). Both fallbacks now flip a flag on the policy (`positional_fallback_used` / `generic_state_keys_used`) and emit a WARNING, and `run_policy` / `eval_policy` surface both flags in their JSON result block alongside the existing `action_errors` / load telemetry. A `True` flag on an otherwise-successful run is the signature of a misconfigured camera/state binding. No behaviour change for correctly-named observations (both flags stay `False`); the remap itself is unchanged.

--- a/docs/robots/mobile.md
+++ b/docs/robots/mobile.md
@@ -25,7 +25,7 @@ sim = Robot("crazyflie")        # Bitcraze Crazyflie 2 quadcopter
 | `earthrover` | EarthRover Mini Plus (mobile outdoor navigation) _(hardware-only, no sim asset)_ | ? | `earth_rover`, `earthrover_mini_plus`, `frodobots` |
 | `go1` | Unitree Go1 Quadruped (12-DOF) | 13 | `unitree_go1` |
 | `google_robot` | Google Robot (mobile base + arm, RT-X) | 10 | `oxe_google` |
-| `lekiwi` | LeKiwi mobile robot _(hardware-only, no sim asset)_ | ? | - |
+| `lekiwi` | LeKiwi mobile manipulator (6-DOF arm on 3-omniwheel base, 9 actuators) | 9 | - |
 | `robot_soccer_kit` | Robot Soccer Kit (multi-robot soccer, 65-DOF total) | 65 | `rsk` |
 | `skydio_x2` | Skydio X2 Autonomous Drone | 1 | - |
 | `spot` | Boston Dynamics Spot (with arm) | 20 | `boston_dynamics_spot` |

--- a/strands_robots/registry/robots.json
+++ b/strands_robots/registry/robots.json
@@ -873,8 +873,19 @@
       ]
     },
     "lekiwi": {
-      "description": "LeKiwi mobile robot",
+      "description": "LeKiwi mobile manipulator (6-DOF arm on 3-omniwheel base, 9 actuators)",
       "category": "mobile",
+      "joints": 9,
+      "asset": {
+        "dir": "lekiwi",
+        "model_xml": "lekiwi/lekiwi.xml",
+        "scene_xml": "scene.xml",
+        "source": {
+          "type": "github",
+          "repo": "Ekumen-OS/lekiwi",
+          "subdir": "packages/lekiwi_sim/lekiwi_sim/assets"
+        }
+      },
       "hardware": {
         "lerobot_type": "lekiwi"
       }

--- a/tests/registry/test_lekiwi_simulatable.py
+++ b/tests/registry/test_lekiwi_simulatable.py
@@ -1,0 +1,48 @@
+"""Regression: LeKiwi must be simulatable, not hardware-only.
+
+``Robot("lekiwi", mode="sim")`` previously failed with ``No model found for
+'lekiwi'`` because the registry entry carried only a ``hardware`` block and no
+``asset`` block, while ``robot_descriptions`` ships no lekiwi module. The fix
+points the entry at the Apache-2.0 Ekumen-OS/lekiwi MuJoCo description (SO-ARM
+arm on a 3-omniwheel base, 9 actuators) via a GitHub asset source.
+
+These checks are network-free: they validate the registry metadata that makes
+LeKiwi resolvable. End-to-end download + load + render is covered in
+``tests_integ/simulation/test_lekiwi_sim.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+_REGISTRY_PATH = Path(__file__).resolve().parents[2] / "strands_robots" / "registry" / "robots.json"
+
+
+def _lekiwi() -> dict:
+    with open(_REGISTRY_PATH) as f:
+        robots = json.load(f)["robots"]
+    return robots["lekiwi"]
+
+
+def test_lekiwi_has_sim_asset_block() -> None:
+    """LeKiwi exposes a sim asset (regression: was hardware-only)."""
+    asset = _lekiwi().get("asset")
+    assert asset is not None, "lekiwi must have an 'asset' block to be simulatable"
+    assert asset["dir"] == "lekiwi"
+    assert asset["model_xml"].endswith(".xml")
+    assert asset["scene_xml"].endswith(".xml")
+
+
+def test_lekiwi_declares_github_download_source() -> None:
+    """The asset is auto-downloadable from a GitHub source (no robot_descriptions module exists)."""
+    asset = _lekiwi()["asset"]
+    source = asset.get("source")
+    assert isinstance(source, dict) and source.get("type") == "github"
+    assert source["repo"] == "Ekumen-OS/lekiwi"
+    assert source.get("subdir"), "github source needs a subdir to locate the MJCF tree"
+
+
+def test_lekiwi_retains_hardware_block() -> None:
+    """Adding sim support must not drop the existing hardware mapping."""
+    assert _lekiwi().get("hardware", {}).get("lerobot_type") == "lekiwi"

--- a/tests/registry/test_public_api.py
+++ b/tests/registry/test_public_api.py
@@ -345,7 +345,7 @@ class TestRobotRegistry:
         assert has_sim("panda") is True
 
     def test_has_sim_false_for_real_only(self):
-        assert has_sim("lekiwi") is False
+        assert has_sim("reachy2") is False
 
     def test_has_hardware(self):
         assert has_hardware("so100") is True
@@ -376,7 +376,7 @@ class TestRobotRegistry:
         robots = list_robots("sim")
         for r in robots:
             assert r["has_sim"] is True
-        assert "lekiwi" not in [r["name"] for r in robots]
+        assert "reachy2" not in [r["name"] for r in robots]
 
     def test_list_robots_real_only(self):
         robots = list_robots("real")
@@ -391,7 +391,8 @@ class TestRobotRegistry:
             assert r["has_real"] is True
         names = [r["name"] for r in robots]
         assert "so100" in names
-        assert "lekiwi" not in names
+        assert "lekiwi" in names  # sim + real
+        assert "reachy2" not in names
         assert "ur5e" not in names
 
     def test_list_robots_by_category(self):

--- a/tests/registry/test_resolves.py
+++ b/tests/registry/test_resolves.py
@@ -37,7 +37,7 @@ def _load_registry() -> dict:
 _ROBOTS = _load_registry()
 
 # Robots that have simulation assets (asset.dir + asset.model_xml).
-# Hardware-only robots (e.g. lekiwi, reachy2) have no 'asset' key.
+# Hardware-only robots (e.g. reachy2) have no 'asset' key.
 _SIM_ROBOTS = {name: info for name, info in _ROBOTS.items() if "asset" in info}
 _SIM_ROBOT_NAMES = list(_SIM_ROBOTS.keys())
 

--- a/tests/test_device_connect_all_robots.py
+++ b/tests/test_device_connect_all_robots.py
@@ -386,7 +386,7 @@ class TestSimDriverAllRobots:
 
 
 class TestRealOnlyRobots:
-    """Tests for real-only robots (no sim asset): lekiwi, reachy2, hope_jr, earthrover, omx, bi_openarm."""
+    """Tests for real-only robots (no sim asset): reachy2, hope_jr, earthrover, omx, bi_openarm."""
 
     @pytest.mark.parametrize("robot_name,robot_info", REAL_ONLY_ROBOTS, ids=[r[0] for r in REAL_ONLY_ROBOTS])
     def test_driver_creation(self, robot_name, robot_info):

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -345,7 +345,7 @@ class TestRobotRegistry:
         assert has_sim("panda") is True
 
     def test_has_sim_false_for_real_only(self):
-        assert has_sim("lekiwi") is False
+        assert has_sim("reachy2") is False
 
     def test_has_hardware(self):
         assert has_hardware("so100") is True
@@ -376,7 +376,7 @@ class TestRobotRegistry:
         robots = list_robots("sim")
         for r in robots:
             assert r["has_sim"] is True
-        assert "lekiwi" not in [r["name"] for r in robots]
+        assert "reachy2" not in [r["name"] for r in robots]
 
     def test_list_robots_real_only(self):
         robots = list_robots("real")
@@ -391,7 +391,8 @@ class TestRobotRegistry:
             assert r["has_real"] is True
         names = [r["name"] for r in robots]
         assert "so100" in names
-        assert "lekiwi" not in names
+        assert "lekiwi" in names  # sim + real
+        assert "reachy2" not in names
         assert "ur5e" not in names
 
     def test_list_robots_by_category(self):

--- a/tests_integ/simulation/test_lekiwi_sim.py
+++ b/tests_integ/simulation/test_lekiwi_sim.py
@@ -1,0 +1,63 @@
+"""End-to-end: LeKiwi resolves from its GitHub asset source and simulates.
+
+Network + MuJoCo integration. Exercises the full path that was broken when
+``lekiwi`` was a hardware-only registry entry: registry lookup -> GitHub asset
+auto-download (Ekumen-OS/lekiwi) -> MuJoCo compile -> step -> mock policy
+rollout driving all 9 actuators -> render.
+"""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+import pytest
+
+os.environ.setdefault("MUJOCO_GL", "egl")
+
+# 6-DOF SO-ARM arm + 3 omniwheels.
+_EXPECTED_ACTUATORS = 9
+
+
+@pytest.fixture
+def lekiwi_sim(tmp_path, monkeypatch):
+    """Resolve + build LeKiwi in sim, downloading assets into an isolated cache."""
+    monkeypatch.setenv("STRANDS_ASSETS_DIR", str(tmp_path))
+    import strands_robots as sr
+    from strands_robots.registry import reload
+
+    reload()
+    sim = sr.Robot("lekiwi", mode="sim")
+    yield sim
+    sim.destroy()
+
+
+def test_lekiwi_builds_and_steps(lekiwi_sim) -> None:
+    """LeKiwi compiles with 9 actuators and steps stably (no NaN)."""
+    name = lekiwi_sim.list_robots()[0]
+    assert name == "lekiwi"
+
+    joints = lekiwi_sim.robot_joint_names(name)
+    assert len(joints) == _EXPECTED_ACTUATORS, joints
+    assert {"base_left_wheel_joint", "base_right_wheel_joint", "base_back_wheel_joint"} <= set(joints)
+
+    lekiwi_sim.step(n_steps=300)
+    state = lekiwi_sim.get_observation(robot_name=name, skip_images=True)
+    assert all(np.isfinite(v) for v in state.values())
+
+
+def test_lekiwi_mock_policy_rollout_and_render(lekiwi_sim) -> None:
+    """A mock policy drives all 9 joints and the namespaced camera renders."""
+    name = lekiwi_sim.list_robots()[0]
+
+    result = lekiwi_sim.run_policy(
+        robot_name=name,
+        policy_provider="mock",
+        instruction="drive forward and move the arm",
+        duration=2.0,
+        control_frequency=30.0,
+    )
+    assert result["status"] == "success", result
+
+    render = lekiwi_sim.render(camera_name="lekiwi/front", width=320, height=240)
+    assert render["status"] == "success", render


### PR DESCRIPTION
## Problem

`Robot("lekiwi", mode="sim")` fails:

```
RuntimeError: Failed to create sim robot 'lekiwi': No model found for 'lekiwi'.
```

The `lekiwi` registry entry is hardware-only: it carries `hardware.lerobot_type` but no `asset` block, and `robot_descriptions` ships no lekiwi module. So LeKiwi cannot be simulated at all, even though every other mobile robot in the catalog can.

## Change

Add an `asset` block to the `lekiwi` entry pointing at the Apache-2.0 [`Ekumen-OS/lekiwi`](https://github.com/Ekumen-OS/lekiwi) MuJoCo description via the existing GitHub asset `source` mechanism (same path `reachy_mini`, `asimov_v0`, and `open_duck_mini` already use):

```json
"asset": {
  "dir": "lekiwi",
  "model_xml": "lekiwi/lekiwi.xml",
  "scene_xml": "scene.xml",
  "source": { "type": "github", "repo": "Ekumen-OS/lekiwi", "subdir": "packages/lekiwi_sim/lekiwi_sim/assets" }
}
```

The model is an authentic LeKiwi: a 6-DOF SO-ARM arm mounted on a 3-omniwheel base (9 actuators total: `base_left/right/back_wheel_joint` + `Rotation/Pitch/Elbow/Wrist_Pitch/Wrist_Roll/Jaw`). It auto-downloads on first sim use, compiles, steps stably (no NaN over 300 steps), and ships `front`/`wrist` cameras. The existing `hardware` mapping is untouched, so `mode="real"` is unaffected.

## Verification (MuJoCo, headless, MUJOCO_GL=egl)

Mock-policy rollout driving all 9 joints, rendered from the `lekiwi/front` camera:

![LeKiwi mock-policy rollout](https://github.com/cagataycali/robots/releases/download/lekiwi-sim-assets/lekiwi_rollout.gif)

Still frame:

![LeKiwi front camera](https://github.com/cagataycali/robots/releases/download/lekiwi-sim-assets/lekiwi_still.png)

```
>>> sim = Robot("lekiwi", mode="sim")
>>> sim.robot_joint_names("lekiwi")
['base_back_wheel_joint', 'base_right_wheel_joint', 'base_left_wheel_joint',
 'Rotation', 'Pitch', 'Elbow', 'Wrist_Pitch', 'Wrist_Roll', 'Jaw']
>>> sim.run_policy(robot_name="lekiwi", policy_provider="mock", duration=4.0,
...                control_frequency=30.0, video={"path": ".../rollout.mp4",
...                "camera": "lekiwi/front", "width": 640, "height": 480})
{'status': 'success', ...}  # 120 frames, 30fps, 640x480
```

## Tests

- `tests/registry/test_lekiwi_simulatable.py` - network-free regression on the asset/source metadata. Fails on the pre-fix hardware-only entry (`KeyError: 'asset'`), passes after.
- `tests_integ/simulation/test_lekiwi_sim.py` - e2e download + compile + 300-step stability + mock-policy rollout + render.
- Registry tests that used `lekiwi` as the real-only example now use `reachy2` (a genuinely hardware-only robot); `lekiwi` is additionally asserted present in `list_robots("both")`.
- Catalog/docs updated (`docs/robots/mobile.md`, CHANGELOG).

Local gate green: `ruff check`/`ruff format --check`/`mypy` clean on `strands_robots tests tests_integ`; relevant pytest suites pass.

Note on fidelity: the Ekumen-OS model uses SO-ARM100 arm geometry; real LeKiwi ships an SO-101 follower. The two are near-identical 6-DOF arms and this is consistent with how the existing `so100`/`so101` MuJoCo entries are handled - good for sim policy bring-up and scene composition.