### PR TITLE
fix(sim): eval_policy resolves robot_name like run_policy (auto-select sole robot)

### DIFF
--- a/docs/simulation/overview.md
+++ b/docs/simulation/overview.md
@@ -118,7 +118,7 @@ A vector lets a policy's raw action chunk drive the arm directly without first z
 | `stop_policy` | `robot_name` (optional, defaults to `""`) |
 | `list_policies_running` | - |
 | `run_multi_policy` | `policies={robot: Policy}`, `instructions`, `duration`, `n_steps` |
-| `eval_policy` | `robot_name` (required), `n_episodes=1`, `max_steps=300`, `success_fn=None`, `async_rtc=False`, `rtc_inference_timeout_s=None` |
+| `eval_policy` | `robot_name` (optional; auto-resolves the sole robot like `run_policy`), `n_episodes=1`, `max_steps=300`, `success_fn=None`, `async_rtc=False`, `rtc_inference_timeout_s=None` |
 
 The step horizon is given either as `duration` (seconds) or as `n_steps` (`duration = n_steps / control_frequency`; `n_steps` wins when both are set, and the legacy `max_steps` is an alias for `n_steps`). A non-positive `n_steps` or `control_frequency` is rejected up front with a structured `status="error"` dict naming the bad parameter - `start_policy` validates synchronously before the background rollout starts, so a malformed horizon never returns a false "started" success. `eval_policy` likewise rejects a non-positive `n_episodes`, `max_steps`, or `control_frequency` at the entry point (before `create_policy`), so a typo cannot produce a "successful" evaluation over zero or negative episodes.
 

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -1422,8 +1422,12 @@ class SimEngine(ABC):
     ) -> dict[str, Any]:
         """Multi-episode policy evaluation via ``PolicyRunner.evaluate``.
 
-        ``robot_name`` is required - eval_policy used to silently pick
-        the first robot, which is surprising in multi-robot scenes.
+        ``robot_name`` resolves like :meth:`run_policy`: ``None`` (the
+        default) auto-selects the sole robot in a single-robot scene and
+        errors with the candidate list only when the choice is ambiguous
+        (multiple robots) or impossible (empty scene). This keeps the two
+        sibling entry points consistent - a policy you just ran with
+        ``run_policy()`` evals the same way with ``eval_policy()``.
         ``n_episodes`` default lowered from 10 to 1 (callers opt in to
         longer evals explicitly).
 
@@ -1472,20 +1476,18 @@ class SimEngine(ABC):
         for cuRobo / MoveIt2 - the issue #300 contract). Without it the eval ran
         such a policy with an empty goal and reported a meaningless success rate.
         """
-        if not robot_name:
-            return {
-                "status": "error",
-                "content": [{"text": "eval_policy requires 'robot_name'."}],
-            }
         robots = self.list_robots()
         if not robots:
             return {"status": "error", "content": [{"text": "No robots in sim. Add one first."}]}
-        if robot_name not in robots:
+        try:
+            resolved_robot = self._resolve_single_robot(robot_name)
+        except ValueError as exc:
+            return {"status": "error", "content": [{"text": str(exc)}]}
+        if resolved_robot not in robots:
             return {
                 "status": "error",
-                "content": [{"text": f"Robot '{robot_name}' not found."}],
+                "content": [{"text": f"Robot '{resolved_robot}' not found."}],
             }
-        resolved_robot = robot_name
 
         if err := self._validate_action_horizon(action_horizon, "eval_policy"):
             return err

--- a/tests/simulation/mujoco/test_agenttool_contract.py
+++ b/tests/simulation/mujoco/test_agenttool_contract.py
@@ -522,12 +522,15 @@ class TestSetGeomPropertiesAlias:
 
 
 class TestEvalPolicyDefaults:
-    """T34: eval_policy requires robot_name; n_episodes default is 1."""
+    """T34: eval_policy resolves robot_name like run_policy; n_episodes default
+    is 1."""
 
-    def test_eval_policy_missing_robot_name_errors(self, sim):
+    def test_eval_policy_empty_world_errors(self, sim):
+        # The fixture sim has a world but no robots; eval_policy reports the
+        # empty scene rather than a "requires robot_name" guard.
         r = sim._dispatch_action("eval_policy", {})
         assert r["status"] == "error"
-        assert "robot_name" in r["content"][0]["text"]
+        assert "No robots" in r["content"][0]["text"]
 
     def test_eval_policy_unknown_robot_errors(self, sim):
         r = sim._dispatch_action("eval_policy", {"robot_name": "ghost"})

--- a/tests/simulation/test_run_policy_horizon_validation.py
+++ b/tests/simulation/test_run_policy_horizon_validation.py
@@ -110,11 +110,19 @@ class TestStartPolicyHorizonGuards:
 
 
 class TestEvalPolicyResolution:
-    """eval_policy requires an explicit, existing robot (no silent first-pick)."""
+    """eval_policy resolves robot_name like run_policy: None auto-selects the
+    sole robot, and only errors when the choice is ambiguous or impossible."""
 
-    def test_missing_robot_name_errors(self, sim):
+    def test_omitted_robot_name_resolves_sole_robot(self, sim):
+        # Single-robot scene + no name -> resolves to that robot and runs,
+        # exactly like run_policy() (no spurious "requires robot_name" error).
+        result = sim.eval_policy(n_episodes=1, max_steps=2, control_frequency=10.0)
+        assert result["status"] == "success", result
+
+    def test_ambiguous_multi_robot_lists_candidates(self, sim):
+        sim.add_robot("arm2", data_config="so100", position=[0.5, 0, 0])
         text = _err_text(sim.eval_policy())
-        assert "robot_name" in text
+        assert "arm1" in text and "arm2" in text
 
     def test_unknown_robot_name_errors(self, sim):
         text = _err_text(sim.eval_policy(robot_name="ghost"))

--- a/tests/simulation/test_simengine_facade_guardrails.py
+++ b/tests/simulation/test_simengine_facade_guardrails.py
@@ -77,11 +77,29 @@ class FakeSim(SimEngine):
 # eval_policy
 
 
-def test_eval_policy_requires_robot_name():
-    """Empty robot_name is rejected with a structured error, never a guess."""
-    result = FakeSim().eval_policy(robot_name="")
+def test_eval_policy_resolves_sole_robot_when_name_omitted():
+    """None robot_name auto-selects the only robot, mirroring run_policy.
+
+    eval_policy and run_policy are siblings; a single-robot scene must
+    resolve identically for both so a policy run with run_policy() can be
+    evaluated the same way with eval_policy() (no spurious hard error).
+    """
+    result = FakeSim().eval_policy(policy_object=MockPolicy(), n_episodes=1, max_steps=2, control_frequency=10.0)
+    assert result["status"] == "success", result
+
+
+def test_eval_policy_ambiguous_multi_robot_lists_candidates():
+    """None robot_name in a multi-robot scene errors with the candidate list."""
+    result = FakeSim(robots=("arm_a", "arm_b")).eval_policy(policy_object=MockPolicy())
     assert result["status"] == "error"
-    assert "robot_name" in result["content"][0]["text"]
+    text = result["content"][0]["text"]
+    assert "arm_a" in text and "arm_b" in text
+
+
+def test_eval_policy_empty_world_reports_no_robots():
+    result = FakeSim(robots=()).eval_policy(policy_object=MockPolicy())
+    assert result["status"] == "error"
+    assert "No robots" in result["content"][0]["text"]
 
 
 def test_eval_policy_unknown_robot_reports_not_found():


### PR DESCRIPTION
## Problem
`eval_policy` and `run_policy` are sibling Simulation entry points, but they handled an omitted `robot_name` differently:

- `run_policy(policy_provider="mock")` with one robot -> works (auto-resolves the sole robot).
- `eval_policy(policy_provider="mock")` with one robot -> hard error: `eval_policy requires 'robot_name'.`

A caller who just ran a policy with `run_policy()` and tries to evaluate it the same way with `eval_policy()` hits a confusing error even though the robot is unambiguous.

## Root cause
`SimEngine.eval_policy` opened with a hard guard:
```python
if not robot_name:
    return {"status": "error", "content": [{"text": "eval_policy requires 'robot_name'."}]}
```
whereas `run_policy` uses the shared `_resolve_single_robot(robot_name)` helper, which resolves `None` to the sole robot and only errors (with the candidate list) when the choice is ambiguous.

## Change
Replace the hard guard with the shared resolver so both methods behave identically:
```python
robots = self.list_robots()
if not robots:
    return {"status": "error", "content": [{"text": "No robots in sim. Add one first."}]}
try:
    resolved_robot = self._resolve_single_robot(robot_name)
except ValueError as exc:
    return {"status": "error", "content": [{"text": str(exc)}]}
if resolved_robot not in robots:
    return {"status": "error", "content": [{"text": f"Robot '{resolved_robot}' not found."}]}
```

Resulting contract (now matching `run_policy`):
- single robot + no name -> resolves to that robot and runs
- multiple robots + no name -> error listing the candidates
- empty scene -> `No robots in sim`
- explicit unknown name -> `Robot '<name>' not found`

## Tests
Updated the three tests that encoded the old required-`robot_name` contract:
- `tests/simulation/test_simengine_facade_guardrails.py` (pure-Python fake engine) now covers sole-robot resolve, multi-robot ambiguity (candidate list), and empty-world reporting.
- `tests/simulation/test_run_policy_horizon_validation.py::TestEvalPolicyResolution` asserts omitted-name resolution and ambiguity.
- `tests/simulation/mujoco/test_agenttool_contract.py::TestEvalPolicyDefaults` now exercises the empty-world path.

The new resolution tests fail on pre-fix code (the old guard returned `eval_policy requires 'robot_name'`) and pass after. Full local gate green: `ruff check` + `ruff format --check` + `mypy` clean; the affected simulation suites (121 tests) pass under `MUJOCO_GL=egl`.

## Rollout proof (MuJoCo sim, headless)
`eval_policy()` with no `robot_name` resolves the sole robot and runs the eval; the resolved name is reported in the result text (`Evaluation: MockPolicy on 'so101'`). Rollout of the resolved robot under the mock policy:

![eval_policy resolve demo](https://github.com/cagataycali/robots/releases/download/eval-policy-resolve-demo/eval_resolve_demo.gif)

Docs (`docs/simulation/overview.md`) updated: `eval_policy` `robot_name` is now documented as optional (auto-resolves the sole robot like `run_policy`).