### PR TITLE
feat(verify-dataset): flag dead (all-zero) action/state columns

### DIFF
--- a/strands_robots/verify_dataset.py
+++ b/strands_robots/verify_dataset.py
@@ -22,6 +22,11 @@ Checks performed against a dataset root (the dir containing ``meta/``):
      video-modality sibling of mega-episode corruption, where the episode
      count is correct but the pixels are missing/unwritten (disable with
      ``--no-check-videos``).
+  6. no ``action`` / ``observation.state`` column is identically zero across
+     a multi-frame episode - the dead-control-column corruption (correct
+     counts and pixels, but the proprioceptive/action signal was written as
+     all zeros), read from the per-episode stats (disable with
+     ``--no-check-stats``).
 
 Usage:
     strands-robots verify-dataset /path/to/dataset
@@ -49,6 +54,7 @@ def verify_dataset(
     expected: int | None = None,
     min_frames: int = 1,
     check_videos: bool = True,
+    check_stats: bool = True,
 ) -> dict[str, Any]:
     """Verify the episode integrity of a LeRobot dataset on disk.
 
@@ -63,6 +69,9 @@ def verify_dataset(
         min_frames: Minimum frames every episode must contain (default 1).
         check_videos: When True (default), verify that every per-episode
             video file referenced by the dataset exists and is non-empty.
+        check_stats: When True (default), flag any episode whose ``action``
+            or ``observation.state`` column is identically zero across the
+            whole episode (a dead control column).
 
     Returns:
         A report dict with:
@@ -78,6 +87,9 @@ def verify_dataset(
           - ``video_files_checked``: number of distinct per-episode video
             files resolved and checked (``0`` when ``check_videos`` is False
             or the dataset declares no video features).
+          - ``stats_vectors_checked``: number of per-episode control-feature
+            stat vectors inspected for the dead-column check (``0`` when
+            ``check_stats`` is False or the dataset carries no stats).
           - ``problems``: list of human-readable failure strings (empty on pass).
     """
     from strands_robots.dataset_recorder import read_dataset_episode_indices
@@ -95,6 +107,7 @@ def verify_dataset(
         "info_total_episodes": None,
         "info_total_frames": None,
         "video_files_checked": 0,
+        "stats_vectors_checked": 0,
         "problems": [],
     }
     problems: list[str] = report["problems"]
@@ -173,6 +186,19 @@ def verify_dataset(
         checked, video_problems = _verify_video_files(root_path)
         report["video_files_checked"] = checked
         problems.extend(video_problems)
+
+    # Check 6: dead control columns. A dataset can pass every count/length
+    # and video check yet carry an ``action`` (or ``observation.state``)
+    # column that is identically zero across an entire multi-frame episode -
+    # the proprioceptive sibling of the mega-episode and missing-video
+    # classes. This happens when a writer's action keys never resolve to the
+    # declared columns, so every frame's action is written as zeros while the
+    # episode and frame counts stay correct. The per-episode feature stats
+    # LeRobot v3 writes inline make this a cheap, decoder-independent check.
+    if check_stats:
+        stats_checked, stats_problems = _verify_feature_stats(root_path)
+        report["stats_vectors_checked"] = stats_checked
+        problems.extend(stats_problems)
 
     report["ok"] = not problems
     report["status"] = "success" if report["ok"] else "error"
@@ -270,6 +296,101 @@ def _verify_video_files(root_path: Path) -> tuple[int, list[str]]:
     return len(referenced), problems
 
 
+def _verify_feature_stats(root_path: Path) -> tuple[int, list[str]]:
+    """Flag dead (identically-zero) control columns via per-episode stats.
+
+    LeRobot v3 writes per-episode feature statistics inline in
+    ``meta/episodes/**/*.parquet`` (``stats/<feature>/min`` / ``.../max`` /
+    ``.../count`` ...). A recording whose ``action`` (or ``observation.state``)
+    column is identically zero across an entire multi-frame episode passes every
+    count, length and video check yet carries no usable control signal -- the
+    proprioceptive sibling of the mega-episode and missing-video corruption
+    classes. This happens when a writer's action keys never resolve to the
+    declared columns (so every frame's action is written as zeros) while the
+    episode and frame counts stay correct.
+
+    For each control feature (``action`` and any ``observation.state*``) that
+    carries per-episode ``min``/``max`` stats, flag every episode with at least
+    two frames whose feature vector is identically zero (every component
+    ``min == max == 0``). Single-frame episodes are skipped: a lone frame has
+    ``min == max`` trivially, so all-zero there is not yet evidence of a dead
+    column. Reading only the lightweight stats columns keeps this
+    decoder-independent (no video decode, no ``data/`` scan).
+
+    Args:
+        root_path: Dataset root directory (the dir that contains ``meta/``).
+
+    Returns:
+        A ``(checked, problems)`` tuple where ``checked`` is the number of
+        per-episode control-feature stat vectors inspected and ``problems``
+        lists the dead-column episodes (empty when the dataset carries no stats
+        or every control column varies).
+    """
+    try:
+        import pyarrow.parquet as pq
+    except ImportError:  # pragma: no cover - pyarrow ships with the lerobot extra
+        return 0, []
+
+    parquet_files = sorted((root_path / "meta" / "episodes").glob("**/*.parquet"))
+    if not parquet_files:
+        return 0, []
+
+    def _is_control_feature(name: str) -> bool:
+        return name == "action" or name == "observation.state" or name.startswith("observation.state.")
+
+    def _episode_count(value: Any) -> int | None:
+        # The stats ``count`` column is stored as a length-1 list per episode.
+        if value is None:
+            return None
+        if isinstance(value, (list, tuple)):
+            return int(value[0]) if value else None
+        return int(value)
+
+    checked = 0
+    problems: list[str] = []
+    for pf in parquet_files:
+        table = pq.read_table(pf)
+        cols = set(table.column_names)
+        if "episode_index" not in cols:
+            continue
+        data = table.to_pydict()
+        episodes = data["episode_index"]
+        features = sorted(
+            {
+                c[len("stats/") : -len("/min")]
+                for c in cols
+                if c.startswith("stats/")
+                and c.endswith("/min")
+                and _is_control_feature(c[len("stats/") : -len("/min")])
+            }
+        )
+        for feat in features:
+            min_col = f"stats/{feat}/min"
+            max_col = f"stats/{feat}/max"
+            if max_col not in cols:
+                continue
+            mins = data[min_col]
+            maxs = data[max_col]
+            counts = data.get(f"stats/{feat}/count")
+            for i in range(len(mins)):
+                row_min = mins[i]
+                row_max = maxs[i]
+                if row_min is None or row_max is None:
+                    continue
+                checked += 1
+                n = _episode_count(counts[i]) if counts is not None and i < len(counts) else None
+                if n is not None and n < 2:
+                    continue  # single frame: identically-zero is not yet corruption evidence
+                ep = int(episodes[i]) if i < len(episodes) and episodes[i] is not None else -1
+                if all(v == 0 for v in row_min) and all(v == 0 for v in row_max):
+                    frames = f"{n} frame(s)" if n is not None else "all frames"
+                    problems.append(
+                        f"feature '{feat}' is identically zero across episode {ep} ({frames}) - "
+                        "dead control column (the recorded values never change and are all zero)"
+                    )
+    return checked, problems
+
+
 def _format_report(report: dict[str, Any]) -> str:
     """Render a report dict as a human-readable multi-line summary."""
     lines: list[str] = []
@@ -278,6 +399,8 @@ def _format_report(report: dict[str, Any]) -> str:
     lines.append(f"  episodes (parquet): {report['total_episodes']}")
     if report.get("video_files_checked"):
         lines.append(f"  video files checked: {report['video_files_checked']}")
+    if report.get("stats_vectors_checked"):
+        lines.append(f"  stat vectors checked: {report['stats_vectors_checked']}")
     if report["total_frames"]:
         lines.append(f"  frames   (parquet): {report['total_frames']}")
     if report["expected"] is not None:
@@ -320,10 +443,20 @@ def main(argv: list[str] | None = None) -> int:
         action="store_false",
         help="Skip per-episode video-file existence/non-empty checks.",
     )
+    parser.add_argument(
+        "--no-check-stats",
+        dest="check_stats",
+        action="store_false",
+        help="Skip the dead-control-column (all-zero action/state) check.",
+    )
     args = parser.parse_args(argv)
 
     report = verify_dataset(
-        args.root, expected=args.expected, min_frames=args.min_frames, check_videos=args.check_videos
+        args.root,
+        expected=args.expected,
+        min_frames=args.min_frames,
+        check_videos=args.check_videos,
+        check_stats=args.check_stats,
     )
     if args.json:
         print(json.dumps(report, indent=2))

--- a/tests/test_verify_dataset.py
+++ b/tests/test_verify_dataset.py
@@ -439,3 +439,155 @@ class TestVideoIndexColumnEdgeCases:
         # No file resolved (the only row is null) and no missing-file problem.
         assert report["video_files_checked"] == 0
         assert not any("video file" in p for p in report["problems"])
+
+
+def _write_dataset_with_stats(
+    root: Path,
+    episode_indices: list[int],
+    counts: list[int],
+    action_minmax: list[tuple[list[float], list[float]]] | None = None,
+    state_minmax: list[tuple[list[float], list[float]]] | None = None,
+    info: dict | None = None,
+) -> Path:
+    """Write an episodes parquet carrying the inline per-episode feature stats.
+
+    LeRobot v3 stores ``stats/<feature>/min`` / ``.../max`` / ``.../count`` as
+    list-typed columns (one row per episode). This builds exactly that schema so
+    the dead-control-column check can be exercised without lerobot or mujoco.
+
+    Args:
+        root: Dataset root (the dir that will contain ``meta/``).
+        episode_indices: Distinct ``episode_index`` values to write.
+        counts: Per-episode frame count (the ``count`` stat).
+        action_minmax: Per-episode ``(min_vec, max_vec)`` for ``action`` (omit
+            the column when None).
+        state_minmax: Per-episode ``(min_vec, max_vec)`` for
+            ``observation.state`` (omit the column when None).
+        info: Optional ``meta/info.json`` payload.
+
+    Returns:
+        The dataset root path.
+    """
+    ep_dir = root / "meta" / "episodes" / "chunk-000"
+    ep_dir.mkdir(parents=True, exist_ok=True)
+    columns: dict[str, list] = {
+        "episode_index": episode_indices,
+        "length": counts,
+    }
+    if action_minmax is not None:
+        columns["stats/action/min"] = [mn for mn, _ in action_minmax]
+        columns["stats/action/max"] = [mx for _, mx in action_minmax]
+        columns["stats/action/count"] = [[c] for c in counts]
+    if state_minmax is not None:
+        columns["stats/observation.state/min"] = [mn for mn, _ in state_minmax]
+        columns["stats/observation.state/max"] = [mx for _, mx in state_minmax]
+        columns["stats/observation.state/count"] = [[c] for c in counts]
+    pq.write_table(pa.table(columns), ep_dir / "episodes_000.parquet")
+    if info is not None:
+        (root / "meta" / "info.json").write_text(json.dumps(info), encoding="utf-8")
+    return root
+
+
+class TestDeadControlColumn:
+    """All-zero ``action`` / ``observation.state`` columns are flagged.
+
+    A recording can pass every count, length and video check yet carry a control
+    column written entirely as zeros (a writer whose action keys never resolved
+    to the declared columns). The per-episode stats expose this cheaply.
+    """
+
+    def test_all_zero_action_column_flagged(self, tmp_path: Path) -> None:
+        _write_dataset_with_stats(
+            tmp_path,
+            episode_indices=[0],
+            counts=[10],
+            action_minmax=[([0.0, 0.0, 0.0], [0.0, 0.0, 0.0])],
+        )
+        report = verify_dataset(tmp_path, check_videos=False)
+        assert report["ok"] is False
+        assert report["stats_vectors_checked"] == 1
+        assert any("identically zero" in p and "action" in p for p in report["problems"])
+
+    def test_varying_action_column_passes(self, tmp_path: Path) -> None:
+        _write_dataset_with_stats(
+            tmp_path,
+            episode_indices=[0, 1],
+            counts=[10, 12],
+            action_minmax=[
+                ([-0.5, -0.1, 0.0], [0.5, 0.2, 0.3]),
+                ([-0.4, 0.0, -0.2], [0.4, 0.1, 0.2]),
+            ],
+        )
+        report = verify_dataset(tmp_path, check_videos=False)
+        assert report["ok"] is True
+        assert report["stats_vectors_checked"] == 2
+        assert report["problems"] == []
+
+    def test_all_zero_observation_state_flagged(self, tmp_path: Path) -> None:
+        _write_dataset_with_stats(
+            tmp_path,
+            episode_indices=[0],
+            counts=[8],
+            state_minmax=[([0.0, 0.0], [0.0, 0.0])],
+        )
+        report = verify_dataset(tmp_path, check_videos=False)
+        assert report["ok"] is False
+        assert any("observation.state" in p and "identically zero" in p for p in report["problems"])
+
+    def test_single_frame_all_zero_not_flagged(self, tmp_path: Path) -> None:
+        # A single-frame episode has min == max trivially; all-zero there is not
+        # yet evidence of a dead column, so it must not be flagged.
+        _write_dataset_with_stats(
+            tmp_path,
+            episode_indices=[0],
+            counts=[1],
+            action_minmax=[([0.0, 0.0, 0.0], [0.0, 0.0, 0.0])],
+        )
+        report = verify_dataset(tmp_path, check_videos=False)
+        assert report["ok"] is True
+        assert report["problems"] == []
+
+    def test_no_check_stats_skips_dead_column(self, tmp_path: Path) -> None:
+        _write_dataset_with_stats(
+            tmp_path,
+            episode_indices=[0],
+            counts=[10],
+            action_minmax=[([0.0, 0.0, 0.0], [0.0, 0.0, 0.0])],
+        )
+        report = verify_dataset(tmp_path, check_videos=False, check_stats=False)
+        assert report["ok"] is True
+        assert report["stats_vectors_checked"] == 0
+
+    def test_dataset_without_stats_columns_passes(self, tmp_path: Path) -> None:
+        # Writers that omit inline stats must not be penalized.
+        _write_dataset(tmp_path, episode_indices=[0, 1], frames_per_episode=[5, 5])
+        report = verify_dataset(tmp_path, check_videos=False)
+        assert report["ok"] is True
+        assert report["stats_vectors_checked"] == 0
+
+    def test_one_dead_episode_among_healthy_flagged(self, tmp_path: Path) -> None:
+        _write_dataset_with_stats(
+            tmp_path,
+            episode_indices=[0, 1, 2],
+            counts=[10, 10, 10],
+            action_minmax=[
+                ([-0.5, -0.1], [0.5, 0.2]),
+                ([0.0, 0.0], [0.0, 0.0]),  # dead
+                ([-0.3, -0.2], [0.3, 0.2]),
+            ],
+        )
+        report = verify_dataset(tmp_path, check_videos=False)
+        assert report["ok"] is False
+        dead = [p for p in report["problems"] if "identically zero" in p]
+        assert len(dead) == 1
+        assert "episode 1" in dead[0]
+
+    def test_dead_action_cli_exit_code(self, tmp_path: Path) -> None:
+        _write_dataset_with_stats(
+            tmp_path,
+            episode_indices=[0],
+            counts=[10],
+            action_minmax=[([0.0, 0.0], [0.0, 0.0])],
+        )
+        assert verify_main([str(tmp_path), "--no-check-videos"]) == 1
+        assert verify_main([str(tmp_path), "--no-check-videos", "--no-check-stats"]) == 0


### PR DESCRIPTION
## Problem

`strands-robots verify-dataset` already catches two dataset-corruption classes: the mega-episode class (N intended episodes buffered into one `episode_index=0`, or `meta/info.json` drift) and the missing-video class (correct episode counts, but the per-episode MP4s are missing/empty). It has no detector for the *proprioceptive* sibling.

A recording can pass every count, length and video check yet carry an `action` (or `observation.state`) column written **entirely as zeros** across a whole multi-frame episode. This happens when a writer's action keys never resolve to the declared columns, so every frame's action is stored as zeros while the episode and frame counts stay correct. The dataset looks healthy by every existing check but holds no usable control signal -- the arm never moved.

## Change

Add a sixth check to `verify_dataset`. It reads the per-episode feature statistics LeRobot v3 writes inline in `meta/episodes/**/*.parquet` (`stats/<feature>/min` / `.../max` / `.../count`) and flags any episode with at least two frames whose `action` or `observation.state` vector is identically zero (every component `min == max == 0`).

- **Cheap and decoder-independent**: reads only the lightweight stats columns -- no video decode, no `data/` scan -- the same source of truth the existing checks use.
- **Conservative (high precision)**: single-frame episodes are skipped (a lone frame has `min == max` trivially, so all-zero is not yet evidence of a dead column). Only an identically-zero control vector across a multi-frame episode is flagged.
- **Backward compatible**: gated behind `check_stats=True` with a `--no-check-stats` CLI flag, mirroring `--no-check-videos`. Datasets that omit inline stats are unaffected (`stats_vectors_checked == 0`, no problems). The report gains `stats_vectors_checked`.

## Verification

Real recorded SO-101 dataset (MuJoCo, headless `MUJOCO_GL=egl`, 15 frames, 1 episode, 2 cameras). Healthy run passes; the same dataset with the `action` column zeroed is flagged and the CLI exits non-zero:

```
$ strands-robots verify-dataset <healthy>
[PASS] ...
  episodes (parquet): 1
  video files checked: 2
  stat vectors checked: 2
  frames   (parquet): 15
  info.json episodes: 1   (exit 0)

$ strands-robots verify-dataset <action-zeroed>
[FAIL] ...
  stat vectors checked: 2
  - feature 'action' is identically zero across episode 0 (15 frame(s)) - dead control column (the recorded values never change and are all zero)   (exit 1)
```

Regression suite `tests/test_verify_dataset.py::TestDeadControlColumn` (8 tests; 7 fail on pre-fix code, all pass after): all-zero action flagged, all-zero `observation.state` flagged, a single dead episode among healthy ones, the single-frame guard, the `check_stats` opt-out, the no-stats-columns path, and the CLI exit code. Full `test_verify_dataset.py` + `test_dataset_recorder.py` + recording-lifecycle + main-CLI suites: 111 passed. `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` all clean.