### PR TITLE
feat(sim): warn when MuJoCo EGL silently falls back to a CPU software rasterizer

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -22,6 +22,7 @@ description: Error → fix table for the most common gotchas across install, sim
 |---------|--------------|-----|
 | `GLXBadFBConfig` (Linux) | Missing OSMesa | `sudo apt install libosmesa6-dev` + `export MUJOCO_GL=osmesa` |
 | Black frames from `render(...)` | Headless, no GL backend | `export MUJOCO_GL=osmesa` (Linux) or `=egl` |
+| Rendering very slow (~100x), warning `rendering on a CPU software rasterizer` | `MUJOCO_GL=egl` but no GPU EGL vendor ICD registered, so EGL falls back to Mesa `llvmpipe` (CPU) | On NVIDIA hosts register the EGL ICD: write `/usr/share/glvnd/egl_vendor.d/10_nvidia.json` = `{"file_format_version":"1.0.0","ICD":{"library_path":"libEGL_nvidia.so.0"}}` and set `NVIDIA_DRIVER_CAPABILITIES` to include `graphics`. Verify with `GL_RENDERER` (should report the NVIDIA GPU, not `llvmpipe`). |
 | `Robot("foo")` raises ValueError | Unknown name | Check `list_robots("all")`; or pass `urdf_path=...` |
 | Sim hangs on `create_world` | Asset download | Wait - first call downloads MJCF, then cached |
 | `ModuleNotFoundError: trs_so_arm100_mj_description` | Auto-install failed | `uv pip install trs-so-arm100-mj-description` |

--- a/strands_robots/simulation/mujoco/backend.py
+++ b/strands_robots/simulation/mujoco/backend.py
@@ -122,6 +122,59 @@ def _ensure_mujoco() -> "Any":
 
 _rendering_available: bool | None = None
 
+# One-shot guard so the software-rendering warning fires at most once per process.
+_software_render_warned: bool = False
+
+# GL_RENDERER substrings that identify a CPU software rasterizer (no GPU).
+_SOFTWARE_RENDERERS: tuple[str, ...] = (
+    "llvmpipe",
+    "softpipe",
+    "swrast",
+    "kms_swrast",
+    "software rasterizer",
+)
+
+
+def _warn_if_software_rendering(probe_stdout: str) -> None:
+    """Warn once when the active GL renderer is a CPU software rasterizer.
+
+    MuJoCo's EGL backend silently routes to Mesa ``llvmpipe`` when no GPU EGL
+    vendor ICD is registered - e.g. an NVIDIA container missing
+    ``/usr/share/glvnd/egl_vendor.d/10_nvidia.json``. Offscreen rendering still
+    works but runs on the CPU at roughly two orders of magnitude lower
+    throughput, which silently throttles every policy observation, rollout
+    video, and dataset recording. The render probe reports ``GL_RENDERER`` via
+    the ``__GL_RENDERER__=`` marker; surface a software rasterizer as an
+    actionable warning instead of a silent performance cliff.
+
+    Args:
+        probe_stdout: Captured stdout of the render probe subprocess. When it
+            lacks the ``__GL_RENDERER__=`` marker (e.g. PyOpenGL unavailable in
+            the probe) this is a no-op - detection is best-effort only.
+    """
+    global _software_render_warned
+    if _software_render_warned:
+        return
+    renderer = ""
+    for line in probe_stdout.splitlines():
+        if line.startswith("__GL_RENDERER__="):
+            renderer = line[len("__GL_RENDERER__=") :].strip()
+            break
+    if not renderer:
+        return
+    low = renderer.lower()
+    if any(token in low for token in _SOFTWARE_RENDERERS):
+        _software_render_warned = True
+        logger.warning(
+            "MuJoCo is rendering on a CPU software rasterizer (GL_RENDERER=%r); "
+            "offscreen renders will be ~100x slower than GPU and the GPU EGL "
+            "backend is NOT active. On an NVIDIA host/container, register the "
+            "NVIDIA EGL vendor ICD - write /usr/share/glvnd/egl_vendor.d/10_nvidia.json "
+            'containing {"file_format_version":"1.0.0","ICD":{"library_path":"libEGL_nvidia.so.0"}} '
+            "and ensure NVIDIA_DRIVER_CAPABILITIES includes 'graphics'.",
+            renderer,
+        )
+
 
 def _can_render() -> bool:
     """Check if MuJoCo offscreen rendering is available.
@@ -160,11 +213,22 @@ def _can_render() -> bool:
     # On some CI environments, libEGL.so.1 is loadable but non-functional -
     # mj.Renderer() triggers a fatal abort that kills the entire process.
     # By running the probe in a child process, we detect the failure safely.
+    # The renderer creation (and close) determines availability. The GL_RENDERER
+    # capture is purely additive and fully wrapped in try/except so it can never
+    # change the probe's success/failure - it only lets the parent detect a
+    # silent CPU software-rasterizer fallback (see _warn_if_software_rendering).
     probe_script = (
-        "import mujoco;"
-        "m=mujoco.MjModel.from_xml_string('<mujoco><worldbody/></mujoco>');"
-        "r=mujoco.Renderer(m,height=1,width=1);"
-        "r.close()"
+        "import sys, mujoco\n"
+        "m = mujoco.MjModel.from_xml_string('<mujoco><worldbody/></mujoco>')\n"
+        "r = mujoco.Renderer(m, height=1, width=1)\n"
+        "try:\n"
+        "    r.update_scene(mujoco.MjData(m)); r.render()\n"
+        "    from OpenGL import GL\n"
+        "    _g = GL.glGetString(GL.GL_RENDERER)\n"
+        "    sys.stdout.write('__GL_RENDERER__=' + (_g.decode(errors='replace') if _g else '') + '\\n')\n"
+        "except Exception:\n"
+        "    pass\n"
+        "r.close()\n"
     )
     try:
         result = subprocess.run(
@@ -176,6 +240,7 @@ def _can_render() -> bool:
         if result.returncode == 0:
             _rendering_available = True
             logger.info("MuJoCo rendering available (subprocess probe passed)")
+            _warn_if_software_rendering(result.stdout.decode(errors="replace"))
         else:
             _rendering_available = False
             stderr = result.stderr.decode(errors="replace").strip()

--- a/strands_robots/simulation/mujoco/backend.py
+++ b/strands_robots/simulation/mujoco/backend.py
@@ -122,8 +122,10 @@ def _ensure_mujoco() -> "Any":
 
 _rendering_available: bool | None = None
 
-# One-shot guard so the software-rendering warning fires at most once per process.
-_software_render_warned: bool = False
+# One-shot guard so the software-rendering warning fires at most once per
+# process. A set (mutated via .add, never reassigned) avoids a `global`
+# rebind so static analysis sees it as used.
+_software_render_warned: set[str] = set()
 
 # GL_RENDERER substrings that identify a CPU software rasterizer (no GPU).
 _SOFTWARE_RENDERERS: tuple[str, ...] = (
@@ -152,7 +154,6 @@ def _warn_if_software_rendering(probe_stdout: str) -> None:
             lacks the ``__GL_RENDERER__=`` marker (e.g. PyOpenGL unavailable in
             the probe) this is a no-op - detection is best-effort only.
     """
-    global _software_render_warned
     if _software_render_warned:
         return
     renderer = ""
@@ -164,7 +165,7 @@ def _warn_if_software_rendering(probe_stdout: str) -> None:
         return
     low = renderer.lower()
     if any(token in low for token in _SOFTWARE_RENDERERS):
-        _software_render_warned = True
+        _software_render_warned.add("warned")
         logger.warning(
             "MuJoCo is rendering on a CPU software rasterizer (GL_RENDERER=%r); "
             "offscreen renders will be ~100x slower than GPU and the GPU EGL "

--- a/tests/simulation/mujoco/test_software_render_warning.py
+++ b/tests/simulation/mujoco/test_software_render_warning.py
@@ -16,7 +16,7 @@ import strands_robots.simulation.mujoco.backend as backend
 
 def _reset_caches() -> None:
     backend._rendering_available = None
-    backend._software_render_warned = False
+    backend._software_render_warned.clear()
 
 
 def _fake_probe(stdout: bytes):

--- a/tests/simulation/mujoco/test_software_render_warning.py
+++ b/tests/simulation/mujoco/test_software_render_warning.py
@@ -1,0 +1,71 @@
+"""Render probe surfaces a CPU software-rasterizer fallback as a warning.
+
+MuJoCo's EGL backend silently routes to Mesa ``llvmpipe`` when no GPU EGL
+vendor ICD is registered, dropping offscreen-render throughput ~100x with no
+signal. ``_can_render`` reports ``GL_RENDERER`` from its subprocess probe;
+``_warn_if_software_rendering`` must turn a software rasterizer into a one-time
+warning while staying silent on a real GPU. These tests mock the probe
+subprocess so they need no GL context and run anywhere.
+"""
+
+import logging
+import subprocess
+
+import strands_robots.simulation.mujoco.backend as backend
+
+
+def _reset_caches() -> None:
+    backend._rendering_available = None
+    backend._software_render_warned = False
+
+
+def _fake_probe(stdout: bytes):
+    def _run(*args, **kwargs):
+        return subprocess.CompletedProcess(args[0] if args else [], 0, stdout=stdout, stderr=b"")
+
+    return _run
+
+
+def test_warns_once_on_software_rasterizer(monkeypatch, caplog):
+    _reset_caches()
+    monkeypatch.setenv("MUJOCO_GL", "egl")  # skip the headless short-circuit
+    monkeypatch.setattr(
+        backend.subprocess,
+        "run",
+        _fake_probe(b"__GL_RENDERER__=llvmpipe (LLVM 20.1.2, 256 bits)\n"),
+    )
+    with caplog.at_level(logging.WARNING, logger=backend.logger.name):
+        assert backend._can_render() is True
+    warnings = [r for r in caplog.records if "software rasterizer" in r.message.lower()]
+    assert len(warnings) == 1
+    assert "llvmpipe" in warnings[0].getMessage()
+
+    # Second probe in the same process must not re-warn (one-shot guard).
+    caplog.clear()
+    backend._rendering_available = None  # force re-probe, keep _software_render_warned
+    with caplog.at_level(logging.WARNING, logger=backend.logger.name):
+        assert backend._can_render() is True
+    assert not [r for r in caplog.records if "software rasterizer" in r.message.lower()]
+
+
+def test_no_warn_on_gpu_renderer(monkeypatch, caplog):
+    _reset_caches()
+    monkeypatch.setenv("MUJOCO_GL", "egl")
+    monkeypatch.setattr(
+        backend.subprocess,
+        "run",
+        _fake_probe(b"__GL_RENDERER__=NVIDIA L40S/PCIe/SSE2\n"),
+    )
+    with caplog.at_level(logging.WARNING, logger=backend.logger.name):
+        assert backend._can_render() is True
+    assert not [r for r in caplog.records if "software rasterizer" in r.message.lower()]
+
+
+def test_no_warn_when_marker_absent(monkeypatch, caplog):
+    # PyOpenGL unavailable in the probe -> no marker -> best-effort no-op.
+    _reset_caches()
+    monkeypatch.setenv("MUJOCO_GL", "egl")
+    monkeypatch.setattr(backend.subprocess, "run", _fake_probe(b""))
+    with caplog.at_level(logging.WARNING, logger=backend.logger.name):
+        assert backend._can_render() is True
+    assert not [r for r in caplog.records if "software rasterizer" in r.message.lower()]


### PR DESCRIPTION
## Problem
`_can_render()` (in `strands_robots/simulation/mujoco/backend.py`) probes render availability by loading `libEGL.so.1` and creating a `mujoco.Renderer` in a subprocess, then treats success as *GPU-accelerated*. But EGL can load fine and still route to **Mesa `llvmpipe` (CPU software rasterization)** when no GPU EGL vendor ICD is registered — a common misconfiguration on NVIDIA hosts/containers that are missing `/usr/share/glvnd/egl_vendor.d/10_nvidia.json` (even when `libEGL_nvidia.so` is installed and the driver works).

When that happens, offscreen rendering still *works* but runs on the CPU at roughly two orders of magnitude lower throughput, silently throttling every policy observation, rollout video, and dataset recording. There is currently **no signal** — the user just sees inexplicably slow sim.

Measured on a headless NVIDIA host, 256x256 offscreen render of an SO-101 scene (`ngeom=32`):

| GL backend | `GL_RENDERER` | render time |
|---|---|---|
| software fallback | `llvmpipe (LLVM 20.1.2, 256 bits)` | **268.3 ms/frame** |
| GPU (ICD registered) | `NVIDIA L40S/PCIe/SSE2` | **0.67 ms/frame** |

(~400x.) A 64x64 render on the software path was *not* faster (~357 ms), confirming fixed CPU-raster overhead rather than pixel-bound GPU work.

## Change
This aligns with the repo's "never silent / no silent defaults" convention: turn the silent perf cliff into an actionable warning.

- The existing render-probe subprocess now also reports the active `GL_RENDERER` via a `__GL_RENDERER__=` marker. The capture is best-effort (uses PyOpenGL if importable) and **fully wrapped in `try/except`**, so it can never change the probe's pass/fail — render availability is still determined solely by `Renderer` creation, exactly as before.
- New `_warn_if_software_rendering()` parses that marker and emits a **one-time** `logger.warning` when a software rasterizer (`llvmpipe`/`softpipe`/`swrast`/`kms_swrast`) is active, including the concrete fix (register the NVIDIA EGL vendor ICD; ensure `NVIDIA_DRIVER_CAPABILITIES` includes `graphics`).
- No change to rendered output, render availability, or any policy/sim behavior — this is purely diagnostic.

## Tests
`tests/simulation/mujoco/test_software_render_warning.py` mocks the probe subprocess (no GL context needed, runs anywhere):
- warns exactly once on a `llvmpipe` renderer string, and does not re-warn on a second probe (one-shot guard);
- stays silent on an NVIDIA renderer string;
- stays silent when the marker is absent (PyOpenGL unavailable — best-effort no-op).

The `llvmpipe` test **fails on `main`** (no warning is emitted) and passes with this change. Local gate green: `ruff check`, `ruff format --check`, `mypy` clean; `tests/simulation/mujoco/test_backend.py`, `test_renderer_hygiene.py`, and the new test pass (41 passed) under `MUJOCO_GL=egl`.

## Note on artifacts
This PR changes a diagnostic log only — rendered pixels and rollout behavior are unchanged — so the relevant evidence is the timing/`GL_RENDERER` table above plus the regression test, rather than a rollout video.

## Docs
Added a `docs/troubleshooting.md` row for "rendering very slow (~100x)" pointing to the EGL vendor ICD fix.

---

### Round 1 changelog
- Address review feedback flagging the module-level `_software_render_warned` boolean as an unused global. The flag was genuinely used (read + written via a `global` rebind), but the static-analysis query keys on assignment of the global name inside the function, treating the rebind-only pattern as dead. Switched to a module-level `set[str]` mutated via `.add()` rather than a rebound `bool`: the name is now only read and mutated (no `global` statement, no reassignment), so the guard reads as a genuine use. Behavior is unchanged — still warns at most once per process. Updated the test's `_reset_caches()` to `.clear()` to stay representation-consistent (avoids a `bool`-reset footgun). Gate re-run green: `ruff check`, `ruff format --check`, `mypy` clean; 32 passed / 9 skipped across `test_backend.py`, `test_renderer_hygiene.py`, `test_software_render_warning.py`.