### PR TITLE
test(verify-dataset): cover _verify_feature_stats defensive branches

### DIFF
--- a/tests/test_verify_dataset.py
+++ b/tests/test_verify_dataset.py
@@ -24,8 +24,8 @@ pytest.importorskip("pyarrow")
 import pyarrow as pa
 import pyarrow.parquet as pq
 
+from strands_robots.verify_dataset import _verify_feature_stats, verify_dataset
 from strands_robots.verify_dataset import main as verify_main
-from strands_robots.verify_dataset import verify_dataset
 
 
 def _write_dataset(
@@ -591,3 +591,102 @@ class TestDeadControlColumn:
         )
         assert verify_main([str(tmp_path), "--no-check-videos"]) == 1
         assert verify_main([str(tmp_path), "--no-check-videos", "--no-check-stats"]) == 0
+
+
+def _write_stats_parquet(root: Path, columns: dict[str, list]) -> Path:
+    """Write a raw episodes-stats parquet from explicit columns.
+
+    Unlike ``_write_dataset_with_stats`` this performs no schema normalisation,
+    so malformed-but-valid layouts (missing ``episode_index``, a ``min`` without
+    a matching ``max``, scalar or null ``count`` cells, null min/max rows) can be
+    written to exercise the defensive branches of ``_verify_feature_stats``.
+    """
+    ep_dir = root / "meta" / "episodes" / "chunk-000"
+    ep_dir.mkdir(parents=True, exist_ok=True)
+    pq.write_table(pa.table(columns), ep_dir / "episodes_000.parquet")
+    return root
+
+
+class TestFeatureStatsEdgeCases:
+    """Defensive branches of ``_verify_feature_stats`` over irregular parquet.
+
+    Each case returns ``(checked, problems)`` so the behaviour is asserted on
+    outputs alone: a malformed or stat-free parquet must never raise and must
+    never invent a problem it cannot prove.
+    """
+
+    def test_no_parquet_files_returns_empty(self, tmp_path: Path) -> None:
+        # No meta/episodes dir at all: nothing to inspect, no problems.
+        assert _verify_feature_stats(tmp_path) == (0, [])
+
+    def test_parquet_without_episode_index_is_skipped(self, tmp_path: Path) -> None:
+        # A stats parquet lacking the episode_index key column is unusable for
+        # per-episode attribution and is skipped without checking anything.
+        _write_stats_parquet(
+            tmp_path,
+            {
+                "stats/action/min": [[0.0, 0.0]],
+                "stats/action/max": [[0.0, 0.0]],
+                "stats/action/count": [[10]],
+            },
+        )
+        assert _verify_feature_stats(tmp_path) == (0, [])
+
+    def test_min_without_matching_max_is_skipped(self, tmp_path: Path) -> None:
+        # A ``min`` column with no paired ``max`` cannot be range-checked.
+        _write_stats_parquet(
+            tmp_path,
+            {
+                "episode_index": [0],
+                "stats/action/min": [[0.0, 0.0]],
+                "stats/action/count": [[10]],
+            },
+        )
+        assert _verify_feature_stats(tmp_path) == (0, [])
+
+    def test_null_minmax_row_is_skipped(self, tmp_path: Path) -> None:
+        # A null min/max row (a stat that failed to compute) is not evidence of
+        # a dead column, so it is skipped and never counted.
+        _write_stats_parquet(
+            tmp_path,
+            {
+                "episode_index": [0],
+                "stats/action/min": [None],
+                "stats/action/max": [None],
+                "stats/action/count": [[10]],
+            },
+        )
+        assert _verify_feature_stats(tmp_path) == (0, [])
+
+    def test_scalar_count_cell_is_accepted(self, tmp_path: Path) -> None:
+        # LeRobot normally stores count as a length-1 list; a scalar cell must
+        # still resolve to the frame count (>= 2 here), so a varying column is
+        # checked and passes clean.
+        _write_stats_parquet(
+            tmp_path,
+            {
+                "episode_index": [0],
+                "stats/action/min": [[-0.5, -0.2]],
+                "stats/action/max": [[0.5, 0.2]],
+                "stats/action/count": [5],
+            },
+        )
+        checked, problems = _verify_feature_stats(tmp_path)
+        assert checked == 1
+        assert problems == []
+
+    def test_null_count_cell_flags_dead_column_as_all_frames(self, tmp_path: Path) -> None:
+        # A null count cannot prove single-frame, so an all-zero column is still
+        # flagged - and reported against "all frames" rather than a frame total.
+        _write_stats_parquet(
+            tmp_path,
+            {
+                "episode_index": [0],
+                "stats/action/min": [[0.0, 0.0]],
+                "stats/action/max": [[0.0, 0.0]],
+                "stats/action/count": [None],
+            },
+        )
+        checked, problems = _verify_feature_stats(tmp_path)
+        assert checked == 1
+        assert any("identically zero" in p and "all frames" in p for p in problems)


### PR DESCRIPTION
## Problem

`verify_dataset._verify_feature_stats` (the dead-control-column detector) has several defensive branches over irregular per-episode stats parquet that were never exercised, leaving the module at 96% coverage with the gaps concentrated in exactly the error-handling paths a malformed recording would hit:

- no episodes parquet present at all;
- a stats parquet missing the `episode_index` key column;
- a `min` column with no paired `max`;
- a null min/max stat row;
- a `count` cell stored as a scalar rather than the usual length-1 list;
- a null `count` cell.

Those are the inputs most likely to come from a half-written or non-standard dataset, so they are the branches that most need a regression net.

## Change

Add `TestFeatureStatsEdgeCases` plus a `_write_stats_parquet` helper that writes raw, un-normalised stats parquet so each layout above can be constructed directly. Every test asserts on the `(checked, problems)` return value (behaviour, not internals):

- malformed/stat-free inputs return `(0, [])` and never raise;
- a scalar `count` still resolves to the frame count and a varying column passes clean;
- a null `count` cannot prove single-frame, so an all-zero column is still flagged and reported against "all frames".

Test-only; no library behaviour changes.

## Coverage

`strands_robots/verify_dataset.py`: 96% -> 99% (only the `__main__` guard line remains uncovered). All six previously-uncovered reachable branches in `_verify_feature_stats` are now exercised.

## Verification

- `tests/test_verify_dataset.py`: 38 passed.
- `ruff check` / `ruff format --check`: clean.
- `hatch run lint` (ruff + mypy, scoped config): `Success: no issues found in 607 source files`.