### PR TITLE
test(lerobot_local): cover policy-type resolution fallback paths

### DIFF
--- a/tests/policies/lerobot_local/test_list_policy_types.py
+++ b/tests/policies/lerobot_local/test_list_policy_types.py
@@ -90,3 +90,26 @@ def test_list_policy_types_empty_when_lerobot_config_unimportable(monkeypatch) -
     """
     monkeypatch.setitem(sys.modules, "lerobot.configs.policies", None)
     assert list_policy_types() == []
+
+
+def test_list_policy_types_falls_back_to_choice_registry_on_old_draccus(monkeypatch) -> None:
+    """Older draccus lacks the public ``get_known_choices()`` accessor.
+
+    The discovery surface must degrade to the private ``_choice_registry`` dict
+    that accessor wraps so enumeration still works on those installs, instead of
+    raising ``AttributeError``. A fake ``PreTrainedConfig`` (no
+    ``get_known_choices``, only ``_choice_registry``) is injected so the
+    fallback runs without depending on the installed draccus version.
+    """
+    import types
+
+    from strands_robots.policies.lerobot_local import resolution
+
+    class _OldDraccusConfig:
+        _choice_registry = {"diffusion": object, "act": object}
+
+    fake_module = types.ModuleType("lerobot.configs.policies")
+    setattr(fake_module, "PreTrainedConfig", _OldDraccusConfig)
+    monkeypatch.setitem(sys.modules, "lerobot.configs.policies", fake_module)
+
+    assert resolution.list_policy_types() == ["act", "diffusion"]

--- a/tests/policies/lerobot_local/test_resolution.py
+++ b/tests/policies/lerobot_local/test_resolution.py
@@ -965,6 +965,59 @@ class TestReadPolicyTypeFromConfig:
             pytest.skip("HF Hub unreachable; cannot exercise live repo")
         assert result == "molmoact2"
 
+    def test_hub_download_success_resolves_type(self, tmp_path, monkeypatch):
+        """When the path is not a local dir, the reader downloads ``config.json``
+        from the Hub and resolves its type.
+
+        This is the production path for a bare HF repo id (the common case);
+        the only other coverage of it is a network-gated live-repo test that is
+        skipped offline. Mock just the ``hf_hub_download`` boundary so the Hub
+        branch runs deterministically, and assert the revision is forwarded."""
+        import json
+
+        from strands_robots.policies.lerobot_local import resolution
+
+        downloaded = tmp_path / "config.json"
+        downloaded.write_text(json.dumps({"type": "smolvla"}))
+        captured: dict[str, object] = {}
+
+        def _fake_download(repo_id, filename, revision=None, **_kwargs):
+            captured["repo_id"] = repo_id
+            captured["filename"] = filename
+            captured["revision"] = revision
+            return str(downloaded)
+
+        monkeypatch.setattr("huggingface_hub.hf_hub_download", _fake_download)
+
+        result = resolution._read_policy_type_from_config("acme/remote-policy", revision="v2")
+
+        assert result == "smolvla"
+        assert captured == {"repo_id": "acme/remote-policy", "filename": "config.json", "revision": "v2"}
+
+    def test_auto_map_skips_non_string_values(self, tmp_path):
+        """``auto_map`` values that are not strings are skipped without crashing.
+
+        Some transformers configs use list-valued ``auto_map`` entries
+        (``{"AutoModel": ["modeling_x.Cfg", "modeling_x.Model"]}``). The reader
+        must step over those rather than calling ``str`` methods on a list, and
+        still resolve a later recognized string entry."""
+        import json
+
+        from strands_robots.policies.lerobot_local import resolution
+
+        (tmp_path / "config.json").write_text(
+            json.dumps(
+                {
+                    "auto_map": {
+                        "AutoModel": ["modeling_molmoact2.A", "modeling_molmoact2.B"],
+                        "AutoModelForImageTextToText": "modeling_molmoact2.MolmoAct2ForConditionalGeneration",
+                    }
+                }
+            )
+        )
+
+        assert resolution._read_policy_type_from_config(str(tmp_path)) == "molmoact2"
+
 
 class TestResolvePolicyClassByNameFallbackLadder:
     """Behavioral tests for the resolution ladder in


### PR DESCRIPTION
## Problem
The `lerobot_local` policy-type resolver has three behavioral branches that real third-party checkpoints (e.g. MolmoAct2) exercise in production, but that were untested or only covered by a network-gated test skipped in CI:

1. **`_read_policy_type_from_config` Hub-download success** — resolving a bare HF repo id (`acme/policy`) downloads `config.json` and reads its type. The only existing coverage was `@pytest.mark.slow test_real_molmoact2_repo_resolves_model_type`, which is deselected offline, so the common production path ran uncovered in CI.
2. **`_policy_type_from_config` non-string `auto_map` values** — some transformers configs use list-valued `auto_map` entries (`{"AutoModel": ["modeling_x.Cfg", "modeling_x.Model"]}`); the `if not isinstance(value, str): continue` guard that steps over them was never exercised.
3. **`list_policy_types` older-draccus fallback** — when `PreTrainedConfig.get_known_choices()` is absent, the discovery surface degrades to the private `_choice_registry` it wraps instead of raising `AttributeError`. This version-compat path was uncovered.

## Change
Adds three focused, deterministic behavioral tests (assert outputs; mock only the `hf_hub_download` network boundary, no real network/hardware):

- `test_hub_download_success_resolves_type` — mocks `hf_hub_download` to return a local `config.json`, asserts the type resolves and the `revision` is forwarded.
- `test_auto_map_skips_non_string_values` — a list-valued `auto_map` entry is skipped without crashing and a later recognized string entry still resolves.
- `test_list_policy_types_falls_back_to_choice_registry_on_old_draccus` — injects a fake `PreTrainedConfig` with only `_choice_registry` and asserts enumeration still works.

## Coverage
`strands_robots/policies/lerobot_local/resolution.py`: **90% -> 94%** (17 -> 11 uncovered lines). Lines 507-510, 556, 596-598 now covered.

## Tests
`MUJOCO_GL=egl hatch run test tests/policies/lerobot_local/` — 446 passed, 11 skipped. ruff check + format clean; mypy clean on both changed files. Test-only change; no library behavior modified.