### PR TITLE
test(composite): cover CompositePolicy child accessors + RTC-delay forwarding

### DIFF
--- a/tests/policies/test_composite.py
+++ b/tests/policies/test_composite.py
@@ -229,3 +229,44 @@ class TestWithRealMockPolicy:
         out = _run(c, obs={"observation.state": [0.0] * 3})
         assert len(out) == 8  # both mocks emit an 8-step chunk
         assert set(out[0]) == set(LEG_JOINTS + ARM_JOINTS)
+
+
+class TestChildAccessAndRtcForwarding:
+    """Public child accessors and RTC observed-delay forwarding."""
+
+    def test_lower_and_upper_expose_the_child_policies(self):
+        # The composite exposes its children so a caller can introspect or
+        # re-scope them (e.g. re-running set_robot_state_keys per child).
+        lower, upper = StubPolicy([{"hip": 0.0}]), StubPolicy([{"shoulder": 0.0}])
+        c = CompositePolicy(lower, upper)
+        assert c.lower is lower
+        assert c.upper is upper
+
+    def test_set_rtc_observed_delay_forwarded_to_composite_and_both_children(self):
+        # A latency-sensitive child slices its leftover chunk by this counted
+        # step delay; it must reach BOTH children and the composite itself.
+        lower, upper = StubPolicy([{"hip": 0.0}]), StubPolicy([{"shoulder": 0.0}])
+        c = CompositePolicy(lower, upper)
+        c.set_rtc_observed_delay(3)
+        assert c.rtc_observed_delay_steps == 3
+        assert lower.rtc_observed_delay_steps == 3
+        assert upper.rtc_observed_delay_steps == 3
+
+    def test_set_rtc_observed_delay_none_clears_on_all(self):
+        lower, upper = StubPolicy([{"hip": 0.0}]), StubPolicy([{"shoulder": 0.0}])
+        c = CompositePolicy(lower, upper)
+        c.set_rtc_observed_delay(5)
+        c.set_rtc_observed_delay(None)
+        assert c.rtc_observed_delay_steps is None
+        assert lower.rtc_observed_delay_steps is None
+        assert upper.rtc_observed_delay_steps is None
+
+    def test_set_rtc_observed_delay_rejects_negative_before_forwarding(self):
+        # The base contract rejects a negative count; the composite surfaces it
+        # without leaving children in a half-updated state.
+        lower, upper = StubPolicy([{"hip": 0.0}]), StubPolicy([{"shoulder": 0.0}])
+        c = CompositePolicy(lower, upper)
+        with pytest.raises(ValueError, match="rtc_observed_delay_steps must be >= 0"):
+            c.set_rtc_observed_delay(-1)
+        assert lower.rtc_observed_delay_steps is None
+        assert upper.rtc_observed_delay_steps is None


### PR DESCRIPTION
## What

Brings `strands_robots/policies/composite.py` from **94% to 100%** line coverage by pinning two public behaviors that previously had no test.

## Why

`CompositePolicy` stacks a lower-body and upper-body policy on one robot. Two parts of its public surface were exercised only indirectly (or not at all):

- **`lower` / `upper` accessors** expose the wrapped child policies so a caller can introspect or re-scope a child (e.g. re-running `set_robot_state_keys` per child after composing, as the existing end-to-end MockPolicy test already needs to do).
- **`set_rtc_observed_delay`** must forward the counted observed-delay to *both* children and the composite itself so latency-sensitive (Real-Time-Chunking) children slice their leftover chunk by the exact step count rather than a wall-clock estimate. This forwarding had no direct test.

## Tests added (`tests/policies/test_composite.py`)

- `lower` / `upper` return the exact child instances.
- `set_rtc_observed_delay(n)` propagates to both children and the composite.
- `set_rtc_observed_delay(None)` clears it everywhere.
- a negative count raises `ValueError` from the base contract before forwarding, leaving children unmodified.

All use the existing `StubPolicy` children, no model weights. Local gate: `ruff check` / `ruff format --check` clean; `pytest tests/policies/test_composite.py` 24 passed, composite.py at 100%.