### PR TITLE
fix(lerobot_local): batch declarative obs when the pipeline has no AddBatchDimension step

### DIFF
--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -280,6 +280,14 @@ through un-normalized: state reaches the policy in raw degrees and predicted
 actions reach the motors still in the model's normalized space, producing
 off-policy / micro-motion trajectories.
 
+The `norm_stats.json` fallback builds a minimal pipeline (the normalizer
+step only) - it has no `AddBatchDimension` or device step, unlike a standard
+`policy_preprocessor.json`. The runtime batches and device-moves the
+preprocessed observation itself, so a stats-only checkpoint runs on the
+declarative `embodiment=` path with the same batched-tensor contract as a
+standard pipeline; the model never sees an unbatched `observation.state`
+alongside a batched image.
+
 The fallback supports the `q01_q99`, `q10_q90`, `min_max` and `mean_std`
 normalization modes declared by `norm_mode`. For `q01_q99`:
 

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -1594,18 +1594,30 @@ class LerobotLocalPolicy(Policy):
         # numpy, state tensors missing a batch dimension).
         if self._processor_bridge and self._processor_bridge.has_preprocessor:
             if self._embodiment is not None:
-                # SOLUTION.md bulletproof path: the embodiment map was injected
+                # SOLUTION.md declarative path: the embodiment map was injected
                 # into the pipeline at load time (rename_map + strands_pack_state
                 # step), so the pipeline itself renames cameras and composes
                 # observation.state. Feed RAW obs straight in - ZERO per-step
-                # strands-side remapping, no _fixup needed (AddBatchDimension +
-                # Device steps in the pipeline handle shape/device).
+                # strands-side remapping.
                 observation = self._canonicalize_obs_images(
                     observation, image_source_keys=self._embodiment_image_source_keys()
                 )
                 batch = self._processor_bridge.preprocess(observation, instruction=instruction)
                 if not isinstance(batch, dict):
                     batch = {"observation.state": batch}
+                # A standard lerobot preprocessor pipeline ends in
+                # AddBatchDimension + Device steps that batch every tensor and
+                # move it to the policy device, so _fixup is a no-op there. But a
+                # MINIMAL pipeline does not: the norm_stats.json fallback builds
+                # ``DataProcessorPipeline(steps=[normalizer])`` only (no batch /
+                # device step), so without this the model receives an unbatched
+                # ``observation.state`` (D,) alongside a (1, C, H, W) image -> a
+                # torch.stack rank mismatch inside select_action. _fixup is
+                # idempotent (it leaves already-batched, already-CHW, already-on-
+                # device tensors untouched), so run it on BOTH paths to make the
+                # batched-tensor contract independent of which steps the
+                # checkpoint's pipeline happens to ship.
+                batch = self._fixup_preprocessed_batch(batch)
             else:
                 # Legacy heuristic path (no embodiment declared). B12: remap
                 # strands-native obs (bare camera names + per-joint scalars) to

--- a/tests/policies/lerobot_local/test_declarative_single_camera.py
+++ b/tests/policies/lerobot_local/test_declarative_single_camera.py
@@ -191,3 +191,63 @@ class TestDeclarativeSingleCameraEndToEnd:
         state = batch["observation.state"]
         assert tuple(state.shape) == (1, 6)
         assert state.dtype.is_floating_point
+
+
+class TestDeclarativeBatchesWithoutAddBatchDimensionStep:
+    """F3: the declarative path must batch even when the pipeline omits AddBatchDimension.
+
+    The end-to-end test above runs a pipeline that ends in
+    ``AddBatchDimensionProcessorStep``, which batches every tensor. But not every
+    checkpoint ships such a pipeline: when a checkpoint has no standard
+    ``policy_preprocessor.json`` the bridge falls back to a ``norm_stats.json``
+    pipeline built as ``DataProcessorPipeline(steps=[normalizer])`` only - no
+    batch step and no device step. On that pipeline the declarative branch
+    previously fed the model an unbatched ``observation.state`` ``(D,)`` next to a
+    batched ``(1, C, H, W)`` image, a ``torch.stack`` rank mismatch inside
+    ``select_action``. The branch now runs the idempotent
+    ``_fixup_preprocessed_batch`` so the batched-tensor contract holds regardless
+    of which steps the pipeline ships.
+    """
+
+    def test_get_actions_batches_state_and_image_without_add_batch_step(self):
+        pytest.importorskip("lerobot.processor.pipeline")
+        import torch
+        from lerobot.processor import RenameObservationsProcessorStep
+        from lerobot.processor.pipeline import DataProcessorPipeline
+
+        from strands_robots.policies.lerobot_local.processor import ProcessorBridge
+
+        policy = _single_camera_policy("observation.images.front")
+        policy._device = "cpu"
+        policy._rtc_enabled = False
+        policy.actions_per_step = 1
+        policy.inference_kwargs = {}
+
+        # Minimal pipeline: rename only, NO AddBatchDimension / Device step -
+        # the shape the norm_stats.json fallback produces.
+        pipe = DataProcessorPipeline(steps=[RenameObservationsProcessorStep(rename_map={})])
+        policy._processor_bridge = ProcessorBridge(preprocessor=pipe, device="cpu")
+        policy.set_robot_state_keys([f"j{i}" for i in range(6)])
+        policy._configure_embodiment()
+        assert policy._embodiment is not None  # declarative branch is taken
+
+        captured: dict[str, object] = {}
+
+        class _Inner:
+            def eval(self):
+                return None
+
+            def select_action(self, batch, **kw):
+                captured["batch"] = {k: getattr(v, "shape", None) for k, v in batch.items()}
+                return torch.zeros(6)
+
+        policy._policy = _Inner()
+        policy._requires_action_chunk = lambda: False
+
+        obs = {f"j{i}": float(i) for i in range(6)}
+        obs["front"] = np.ones((48, 64, 3), dtype=np.uint8) * 255
+        policy.get_actions_sync(obs, "pick up the cube")
+
+        # State and image both reach the model batched (no rank mismatch).
+        assert tuple(captured["batch"]["observation.state"]) == (1, 6)
+        assert tuple(captured["batch"]["observation.images.front"]) == (1, 3, 48, 64)


### PR DESCRIPTION
## Problem

The declarative `embodiment=` path in `LerobotLocalPolicy.get_actions` feeds the preprocessed observation straight to the model on the assumption that the preprocessor pipeline always ends in `AddBatchDimension` + `Device` steps that batch every tensor and move it to the policy device:

```python
# no _fixup needed (AddBatchDimension + Device steps in the pipeline handle shape/device)
batch = self._processor_bridge.preprocess(observation, instruction=instruction)
```

That assumption holds for a standard `policy_preprocessor.json`, but **not** for the `norm_stats.json` fallback. When a checkpoint ships no standard pipeline config, the bridge builds a minimal pipeline (`norm_stats.py`):

```python
preprocessor = pipeline_cls(steps=[pre_step_cls(state_norm)])  # normalizer only
```

This pipeline has no batch step and no device step. On the declarative path the model therefore receives an unbatched `observation.state` `(D,)` alongside a batched `(1, C, H, W)` image, producing a `torch.stack` rank mismatch inside `select_action`. The legacy (no-embodiment) branch already guards against this by running `_fixup_preprocessed_batch`; the declarative branch did not.

## Fix

Run the idempotent `_fixup_preprocessed_batch` on the declarative path too. It leaves already-batched, already-CHW, and already-on-device tensors untouched, so it is a **no-op** for standard pipelines (which `AddBatchDimension` already batched) and restores the batched-tensor contract for minimal ones. The batched-tensor contract is now independent of which steps a checkpoint's pipeline happens to ship.

## Reproduction (real lerobot pipeline, network-free)

Driving `get_actions` on the declarative path with a pipeline that lacks `AddBatchDimension` (the exact shape the `norm_stats.json` fallback builds):

```
before: observation.images.front (3, 48, 64),  observation.state (6,)    # rank mismatch
after:  observation.images.front (1, 3, 48, 64), observation.state (1, 6) # batched
```

## Tests

Adds `TestDeclarativeBatchesWithoutAddBatchDimensionStep` in `tests/policies/lerobot_local/test_declarative_single_camera.py`. It builds a real (no-download) `DataProcessorPipeline(steps=[RenameObservationsProcessorStep(...)])` with no batch step, drives the full `get_actions_sync` declarative path, and asserts the model receives `observation.state (1, 6)` and `observation.images.front (1, 3, 48, 64)`. The test fails on pre-fix code (`(6,) != (1, 6)`) and passes after.

## Verification

- `ruff check` / `ruff format --check` clean; `mypy strands_robots tests tests_integ` clean.
- `pytest tests/policies/lerobot_local/` — 459 passed (458 prior + 1 new).
- Docs: added a note to the processor-bridge section of `docs/policies/lerobot-local.md` describing the minimal-fallback pipeline being batched at runtime.

Scope: one branch + one idempotent call; no behavior change on the standard pipeline path.