### PR TITLE
feat(training): VecSimEnv - N independent SimEnv as one (N, D)-batched env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,24 @@ PPO and FastSAC share one implementation with no per-subclass override.
 env's `success_fn`), not a time-out. Purely additive - no existing behaviour
 changes.
 
+### Added: `VecSimEnv` - N independent `SimEnv` presented as one `(N, D)`-batched env
+
+The single-env `SimEnv` emits `(1, D)` tensors by design ("only the env count
+changes"); `VecSimEnv` is the realisation of that promise for the CPU/MuJoCo
+backend. It owns `num_envs` independent `SimEnv` (each its own engine), steps
+them through one reused thread pool (MuJoCo releases the GIL during `mj_step`,
+so threads give real parallelism on the physics call), and stacks the results
+to `(N, D)` so the from-scratch PPO / FastSAC trainers can collect N
+trajectories per step. Autoreset matches the gymnasium vector API: on a done
+env the pre-reset terminal observation is captured into
+`infos[i]["terminal_obs"]` before reset (load-bearing for value bootstrapping a
+truncation), and the returned `obs[i]` is the fresh post-reset observation. A
+construction-time homogeneity guard rejects sub-envs that disagree on
+obs/action dims, and `num_envs=1` skips the thread pool entirely. Exported from
+`strands_robots.training.rl`. A future GPU-batched backend can implement this
+same interface as one engine driving N worlds, so trainer code written against
+`VecSimEnv` does not change when the backend does.
+
 ### Added: LeKiwi is now simulatable (`Robot("lekiwi", mode="sim")`)
 
 The `lekiwi` registry entry was hardware-only - it carried a `hardware.lerobot_type`

--- a/strands_robots/training/rl/__init__.py
+++ b/strands_robots/training/rl/__init__.py
@@ -13,6 +13,7 @@ Public surface:
     - :class:`FastSacTrainer` - Soft Actor-Critic (off-policy, replay buffer).
     - :class:`SimpleReplayBuffer` - off-policy transition store.
     - :class:`SimEnv` - ``SimEngine`` -> RL env adapter.
+    - :class:`VecSimEnv` - N independent ``SimEnv`` presented as one ``(N, D)`` env.
     - :class:`EmpiricalNormalization` - running observation normalizer.
 
 Importing this package imports ``torch`` (via the env / algo modules), so it is
@@ -26,6 +27,7 @@ from strands_robots.training.rl.fast_sac import FastSacTrainer
 from strands_robots.training.rl.normalization import EmpiricalNormalization
 from strands_robots.training.rl.ppo import PpoTrainer
 from strands_robots.training.rl.replay_buffer import SimpleReplayBuffer
+from strands_robots.training.rl.vec_env import VecSimEnv
 
 __all__ = [
     "BaseRLAlgo",
@@ -34,5 +36,6 @@ __all__ = [
     "FastSacTrainer",
     "SimpleReplayBuffer",
     "SimEnv",
+    "VecSimEnv",
     "EmpiricalNormalization",
 ]

--- a/strands_robots/training/rl/vec_env.py
+++ b/strands_robots/training/rl/vec_env.py
@@ -1,0 +1,180 @@
+"""Vectorized multi-environment wrapper over N independent :class:`SimEnv`.
+
+The single-env :class:`~strands_robots.training.rl.env.SimEnv` emits ``(1, D)``
+tensors by design ("only the env count changes"). ``VecSimEnv`` is the realisation
+of that promise for the CPU/MuJoCo backend: it owns N independent ``SimEnv``
+(each its own engine), steps them through ONE reused thread pool, and stacks the
+results to ``(N, D)`` so the from-scratch PPO / FastSAC trainers can collect N
+trajectories per step instead of one.
+
+Autoreset semantics (matching gymnasium's vector API and what on-policy GAE
+needs): when env ``i`` reports ``done`` on a step, the TERMINAL observation is
+captured into ``infos[i]["terminal_obs"]`` BEFORE the env is reset, and the
+returned ``obs[i]`` is the FRESH post-reset observation. The trainer bootstraps
+the value of a truncation from ``terminal_obs`` (a time-out is value-bootstrapped,
+a real terminal is not), so this capture is load-bearing for correctness, not a
+convenience.
+
+A future GPU-batched backend (Newton warp ``replicate`` + a batched
+``get_observations``) can implement this SAME interface as a single engine driving
+N worlds, so the trainer code written against ``VecSimEnv`` does not change when
+the backend does.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from strands_robots.training.rl.env import SimEnv
+
+
+class VecSimEnv:
+    """N independent :class:`SimEnv` presented as one ``(N, D)``-batched env.
+
+    Args:
+        env_factory: Zero-arg callable returning a fresh :class:`SimEnv`. Called
+            ``num_envs`` times. (Same contract the trainers already use for the
+            single-env path, so existing factories work unchanged.)
+        num_envs: Number of parallel environments. Must be >= 1.
+        device: Torch device for the stacked tensors. ``None`` inherits the
+            first sub-env's device.
+        max_workers: Thread-pool size for stepping sub-envs. ``None`` uses
+            ``min(num_envs, 8)`` - MuJoCo releases the GIL during ``mj_step`` so
+            threads give real parallelism on the physics call. One executor is
+            created and reused for the env's lifetime (never per-step).
+
+    Raises:
+        ValueError: ``num_envs < 1`` or the sub-envs disagree on obs/action dims.
+    """
+
+    def __init__(
+        self,
+        env_factory: Callable[[], SimEnv],
+        num_envs: int,
+        *,
+        device: torch.device | str | None = None,
+        max_workers: int | None = None,
+    ) -> None:
+        if num_envs < 1:
+            raise ValueError(f"num_envs must be >= 1, got {num_envs}")
+        self.num_envs = int(num_envs)
+        self.envs: list[SimEnv] = [env_factory() for _ in range(self.num_envs)]
+
+        first = self.envs[0]
+        self.num_actor_obs = first.num_actor_obs
+        self.num_critic_obs = first.num_critic_obs
+        self.num_actions = first.num_actions
+        # Fail loudly if sub-envs are not homogeneous - a heterogeneous batch
+        # would silently misalign the stacked tensors.
+        for i, e in enumerate(self.envs[1:], start=1):
+            if (e.num_actor_obs, e.num_critic_obs, e.num_actions) != (
+                self.num_actor_obs,
+                self.num_critic_obs,
+                self.num_actions,
+            ):
+                raise ValueError(
+                    f"VecSimEnv sub-env {i} dims "
+                    f"({e.num_actor_obs}, {e.num_critic_obs}, {e.num_actions}) "
+                    f"differ from env 0 ({self.num_actor_obs}, {self.num_critic_obs}, {self.num_actions})"
+                )
+
+        self.device = torch.device(device) if device is not None else first.device
+        # Reconcile every sub-env onto the batch device so the per-env (1, D)
+        # tensors stack without a device mismatch.
+        for e in self.envs:
+            e.device = self.device
+
+        self._max_workers = max_workers if max_workers is not None else min(self.num_envs, 8)
+        # ONE executor for the whole lifetime (AGENTS.md: never create executors
+        # in the hot loop). Only spin up a pool when there is real concurrency.
+        self._executor: ThreadPoolExecutor | None = (
+            ThreadPoolExecutor(max_workers=self._max_workers) if self.num_envs > 1 else None
+        )
+
+    # --- metadata proxies (delegate to sub-env 0) ----------------------------
+    # The trainer's save_checkpoint reads these off ``self.env``; they are
+    # identical across homogeneous sub-envs, so env 0 is authoritative. This
+    # lets a VecSimEnv stand in anywhere a SimEnv is expected for metadata.
+
+    @property
+    def actor_obs_keys(self) -> list[str]:
+        return self.envs[0].actor_obs_keys
+
+    @property
+    def critic_obs_keys(self) -> list[str]:
+        return self.envs[0].critic_obs_keys
+
+    @property
+    def engine(self) -> Any:
+        return self.envs[0].engine
+
+    @property
+    def robot_name(self) -> str | None:
+        return self.envs[0].robot_name
+
+    # --- helpers -------------------------------------------------------------
+
+    def _stack(self, per_env: list[dict[str, torch.Tensor]]) -> dict[str, torch.Tensor]:
+        """Stack a list of per-env ``{actor_obs:(1,Da), critic_obs:(1,Dc)}`` to ``(N, D)``."""
+        actor = torch.cat([d["actor_obs"] for d in per_env], dim=0)
+        critic = torch.cat([d["critic_obs"] for d in per_env], dim=0)
+        return {"actor_obs": actor, "critic_obs": critic}
+
+    def _map(self, fn: Callable[[int], Any]) -> list[Any]:
+        """Run ``fn(i)`` for every env, in parallel when a pool exists, order-preserving."""
+        if self._executor is None:
+            return [fn(i) for i in range(self.num_envs)]
+        return list(self._executor.map(fn, range(self.num_envs)))
+
+    # --- API -----------------------------------------------------------------
+
+    def reset(self) -> dict[str, torch.Tensor]:
+        """Reset ALL sub-envs; return stacked ``{actor_obs:(N,Da), critic_obs:(N,Dc)}``."""
+        per_env = self._map(lambda i: self.envs[i].reset())
+        return self._stack(per_env)
+
+    def step(
+        self, actions: torch.Tensor
+    ) -> tuple[dict[str, torch.Tensor], torch.Tensor, torch.Tensor, list[dict[str, Any]]]:
+        """Step all envs with ``actions`` shape ``(N, A)``; autoreset on done.
+
+        Returns:
+            ``(obs, rewards, dones, infos)`` where ``obs`` is the stacked
+            ``(N, D)`` post-step (post-autoreset) observation, ``rewards`` and
+            ``dones`` are ``(N,)``, and ``infos`` is a length-N list. On a done
+            env, ``infos[i]["terminal_obs"]`` holds the pre-reset terminal
+            ``{actor_obs, critic_obs}`` (each ``(1, D)``) for value bootstrapping,
+            and ``infos[i]`` carries ``time_out`` / ``terminated``.
+        """
+        if actions.shape[0] != self.num_envs:
+            raise ValueError(f"actions batch {actions.shape[0]} != num_envs {self.num_envs}")
+
+        def _one(i: int) -> tuple[dict[str, torch.Tensor], torch.Tensor, torch.Tensor, dict[str, Any]]:
+            obs_i, reward_i, done_i, info_i = self.envs[i].step(actions[i : i + 1])
+            if bool(done_i.item()):
+                # Capture the TRUE terminal obs before autoreset clobbers it.
+                info_i = dict(info_i)
+                info_i["terminal_obs"] = obs_i
+                obs_i = self.envs[i].reset()
+            return obs_i, reward_i, done_i, info_i
+
+        results = self._map(_one)
+        obs = self._stack([r[0] for r in results])
+        rewards = torch.cat([r[1] for r in results], dim=0)  # each (1,) -> (N,)
+        dones = torch.cat([r[2] for r in results], dim=0)
+        infos = [r[3] for r in results]
+        return obs, rewards, dones, infos
+
+    def close(self) -> None:
+        """Shut down the thread pool. Engine teardown is the caller's concern."""
+        if self._executor is not None:
+            self._executor.shutdown(wait=True)
+            self._executor = None
+
+
+__all__ = ["VecSimEnv"]

--- a/tests/training/test_rl_vec_env.py
+++ b/tests/training/test_rl_vec_env.py
@@ -1,0 +1,170 @@
+"""Unit tests for ``VecSimEnv`` - the N-env vectorized wrapper over ``SimEnv``.
+
+CPU-only, fake engine. Pins: batch shapes (N, D), per-env independent reset,
+autoreset + terminal_obs capture (load-bearing for GAE bootstrap), homogeneity
+guard, num_envs=1 degenerate path, and executor lifecycle.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from strands_robots.training.rl import SimEnv, VecSimEnv  # noqa: E402 - after torch importorskip
+
+
+class _CountdownEngine:
+    """Fake engine whose joint ``J`` counts steps; lets us script per-env dones.
+
+    ``J`` starts at 0 and increments by 1 each step. With max_episode_steps=K
+    the SimEnv times out after K steps -> done. Each engine instance is
+    independent, so different envs advance independently.
+    """
+
+    def __init__(self) -> None:
+        self._j = 0.0
+
+    def list_robots(self) -> list[str]:
+        return ["fake"]
+
+    def robot_joint_names(self, robot_name: str) -> list[str]:
+        return ["J"]
+
+    def reset(self) -> dict:
+        self._j = 0.0
+        return {"status": "success"}
+
+    def get_observation(self, robot_name=None, *, skip_images: bool = False) -> dict:
+        return {"J": self._j, "J.vel": 1.0}
+
+    def send_action(self, action, robot_name=None, n_substeps: int = 1) -> dict:
+        self._j += 1.0
+        return {"status": "success"}
+
+
+def _factory(max_steps=3):  # type: ignore[no-untyped-def]
+    def make():  # type: ignore[no-untyped-def]
+        return SimEnv(
+            _CountdownEngine(),
+            actor_obs_keys=["J", "J.vel"],
+            reward_terms=[lambda e: 1.0],
+            action_dim=1,
+            max_episode_steps=max_steps,
+        )
+
+    return make
+
+
+def test_vec_reset_shapes() -> None:
+    vec = VecSimEnv(_factory(), num_envs=4)
+    assert vec.num_envs == 4
+    assert vec.num_actor_obs == 2
+    assert vec.num_actions == 1
+    obs = vec.reset()
+    assert obs["actor_obs"].shape == (4, 2)
+    assert obs["critic_obs"].shape == (4, 2)
+    vec.close()
+
+
+def test_vec_step_shapes() -> None:
+    vec = VecSimEnv(_factory(), num_envs=4)
+    vec.reset()
+    actions = torch.zeros(4, 1)
+    obs, rewards, dones, infos = vec.step(actions)
+    assert obs["actor_obs"].shape == (4, 2)
+    assert rewards.shape == (4,)
+    assert dones.shape == (4,)
+    assert len(infos) == 4
+    vec.close()
+
+
+def test_autoreset_and_terminal_obs_capture() -> None:
+    """On done, terminal_obs is captured and obs is the fresh post-reset obs."""
+    vec = VecSimEnv(_factory(max_steps=2), num_envs=2)
+    vec.reset()  # J=0 in both
+    a = torch.zeros(2, 1)
+    # Step 1: J -> 1, not done (max_steps=2).
+    _o, _r, dones, infos = vec.step(a)
+    assert not bool(dones.any())
+    assert all("terminal_obs" not in inf for inf in infos)
+    # Step 2: J -> 2, time-out done for BOTH envs.
+    obs, _r, dones, infos = vec.step(a)
+    assert bool(dones.all()), "both envs should time out at step 2"
+    for inf in infos:
+        assert "terminal_obs" in inf, "terminal obs must be captured on done"
+        assert inf["time_out"] is True
+        assert inf["terminated"] is False
+        # terminal obs J should be 2 (pre-reset), fresh obs should be 0.
+        assert float(inf["terminal_obs"]["actor_obs"][0, 0].item()) == pytest.approx(2.0)
+    # Returned obs is the fresh (post-reset) observation: J back to 0.
+    assert float(obs["actor_obs"][0, 0].item()) == pytest.approx(0.0)
+    vec.close()
+
+
+def test_per_env_independent_dones() -> None:
+    """Envs with different max_steps must finish independently (no cross-contamination)."""
+    # Build envs with staggered horizons by alternating factories.
+    envs_specs = [2, 5]
+    idx = {"i": 0}
+
+    def make():  # type: ignore[no-untyped-def]
+        ms = envs_specs[idx["i"] % len(envs_specs)]
+        idx["i"] += 1
+        return SimEnv(
+            _CountdownEngine(),
+            actor_obs_keys=["J", "J.vel"],
+            reward_terms=[lambda e: 1.0],
+            action_dim=1,
+            max_episode_steps=ms,
+        )
+
+    vec = VecSimEnv(make, num_envs=2)
+    vec.reset()
+    a = torch.zeros(2, 1)
+    vec.step(a)  # J=1
+    _o, _r, dones, _infos = vec.step(a)  # J=2: env0 (ms=2) done, env1 (ms=5) not
+    assert bool(dones[0].item()) is True
+    assert bool(dones[1].item()) is False
+    vec.close()
+
+
+def test_num_envs_one_uses_no_executor() -> None:
+    vec = VecSimEnv(_factory(), num_envs=1)
+    assert vec._executor is None  # degenerate path: no thread pool
+    obs = vec.reset()
+    assert obs["actor_obs"].shape == (1, 2)
+    vec.close()
+
+
+def test_rejects_bad_num_envs() -> None:
+    with pytest.raises(ValueError, match="num_envs must be >= 1"):
+        VecSimEnv(_factory(), num_envs=0)
+
+
+def test_rejects_heterogeneous_envs() -> None:
+    """Sub-envs with mismatched dims must be rejected at construction."""
+    flip = {"n": 0}
+
+    def make():  # type: ignore[no-untyped-def]
+        # First env has 2 actor obs, second has 1 -> mismatch.
+        keys = ["J", "J.vel"] if flip["n"] == 0 else ["J"]
+        flip["n"] += 1
+        return SimEnv(
+            _CountdownEngine(),
+            actor_obs_keys=keys,
+            reward_terms=[lambda e: 1.0],
+            action_dim=1,
+            max_episode_steps=3,
+        )
+
+    with pytest.raises(ValueError, match="differ from env 0"):
+        VecSimEnv(make, num_envs=2)
+
+
+def test_step_rejects_wrong_action_batch() -> None:
+    vec = VecSimEnv(_factory(), num_envs=3)
+    vec.reset()
+    with pytest.raises(ValueError, match="!= num_envs"):
+        vec.step(torch.zeros(2, 1))  # batch 2 != 3
+    vec.close()


### PR DESCRIPTION
## Summary

Adds `VecSimEnv` to `strands_robots.training.rl`: the N-env vectorized realization of the single-env `SimEnv`'s `(1, D)` promise for the CPU/MuJoCo backend. It owns `num_envs` independent `SimEnv` (each its own engine), steps them through **one reused thread pool** (MuJoCo releases the GIL during `mj_step`, so threads give real parallelism on the physics call), and stacks results to `(N, D)` so the from-scratch PPO / FastSAC trainers can collect N trajectories per step instead of one.

This is the foundational vectorized-env layer the RL training stack needs. It relates to #863 (the broader GymVecEnv adapter epic under #858); this PR delivers the CPU/MuJoCo threaded path and the autoreset/terminal-obs contract that the trainers consume. Newton GPU batching, the TensorDict `get_observations` surface, and the `simulation/vecenv.py` location described in #863 remain follow-up scope.

## What it does

- **Batched API:** `reset() -> {actor_obs:(N,Da), critic_obs:(N,Dc)}`; `step(actions:(N,A)) -> (obs, rewards:(N,), dones:(N,), infos:list[N])`.
- **Autoreset (gymnasium vector semantics):** on a done env the pre-reset terminal observation is captured into `infos[i]["terminal_obs"]` **before** reset, and the returned `obs[i]` is the fresh post-reset observation. This capture is load-bearing for value-bootstrapping a truncation (a time-out is bootstrapped, a real terminal is not).
- **Homogeneity guard:** sub-envs that disagree on obs/action dims are rejected at construction (a heterogeneous batch would silently misalign the stacked tensors).
- **Lifecycle:** one `ThreadPoolExecutor` for the env's whole lifetime (never per-step, per AGENTS.md); `num_envs=1` skips the pool entirely; `close()` shuts it down.
- **Backend-agnostic interface:** a future GPU-batched backend (Newton `replicate` + batched `get_observations`) can implement this same interface as one engine driving N worlds, so trainer code written against `VecSimEnv` does not change when the backend does.

## Tests

`tests/training/test_rl_vec_env.py` - CPU-only, fake countdown engine, deterministic. Pins:
- batch shapes `(N, D)` on reset and step;
- autoreset + `terminal_obs` capture (terminal J pre-reset, fresh J post-reset, `time_out`/`terminated` flags);
- per-env independent dones (staggered horizons, no cross-contamination);
- `num_envs=1` uses no executor;
- homogeneity guard and action-batch-size validation.

8 tests, run in CI (need `torch` only). Verified locally: lint (`ruff check`), format (`ruff format --check`), and `mypy` all clean; tests pass deterministically.

## Merge ordering

This PR and #920 (`evaluate()`) each insert a new section at the top of the CHANGELOG `[Unreleased]` block, so they touch the same hunk and the second to land will hit a CHANGELOG-only merge conflict (the source files are disjoint - `vec_env.py` here, `base_algo.py` there - no code overlap). Suggested order: land #920 (already approved) first; this branch will then rebase its one-line CHANGELOG section cleanly. The conflict is mechanical and CHANGELOG-only either way.

## §13 Changelog

**Round 1 (initial):** New `VecSimEnv` module + exports + tests + CHANGELOG `[Unreleased]` entry. Single coherent unit; no changes to existing source. Surgical diff (4 files, +371).

**Round 2 (no code push):** Documented the CHANGELOG-only merge-ordering relationship with #920 (see Merge ordering above). No source change.