### PR TITLE
feat(training): BaseRLAlgo.evaluate() - deterministic eval peer of train()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Added: `BaseRLAlgo.evaluate()` - deterministic eval peer of `train()`
+
+The from-scratch RL trainers (`PpoTrainer`, `FastSacTrainer`) could `train()` a
+policy but had no first-class way to *score* it: callers had to hand-roll a
+rollout loop and risk scoring the stochastic (exploration) action or an
+un-frozen normalizer, neither of which matches what a deployed `policy.pt`
+produces. `BaseRLAlgo.evaluate(spec=None, checkpoint_dir=None, num_episodes=10)`
+now rolls out the DETERMINISTIC (mean) action with gradients disabled and
+observation normalization frozen, and returns
+`{num_episodes, mean_return, std_return, min_return, max_return, mean_length,
+success_rate, returns}`. It works both on a live post-`train()` instance (reuses
+the in-memory env + network) and on a fresh instance (builds the env from `spec`
+and optionally loads `policy.pt` via the new `load_checkpoint()`); the default
+`_deterministic_action()` dispatches to the actor-critic's `act_inference`, so
+PPO and FastSAC share one implementation with no per-subclass override.
+`success_rate` is the fraction of episodes ending on a genuine terminal (the
+env's `success_fn`), not a time-out. Purely additive - no existing behaviour
+changes.
+
 ### Added: LeKiwi is now simulatable (`Robot("lekiwi", mode="sim")`)
 
 The `lekiwi` registry entry was hardware-only - it carried a `hardware.lerobot_type`

--- a/strands_robots/training/rl/base_algo.py
+++ b/strands_robots/training/rl/base_algo.py
@@ -31,6 +31,8 @@ from strands_robots.training.base import Trainer, TrainResult, TrainSpec
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from collections.abc import Callable
 
+    import torch
+
     from strands_robots.training.rl.env import SimEnv
 
 
@@ -130,6 +132,10 @@ class BaseRLAlgo(Trainer):
     """
 
     steps_per_iter: int = 1
+    # Subclass-provided attributes (set during setup)
+    actor_critic: Any  # torch.nn.Module (actor-critic network)
+    env: Any  # SimEnv or VecSimEnv
+    device: Any  # torch.device or str
 
     @abstractmethod
     def setup(self, spec: RLTrainSpec) -> None:
@@ -191,3 +197,180 @@ class BaseRLAlgo(Trainer):
             metrics=last_metrics,
             message=f"{self.provider_name}: {num_iters} iterations x {steps_per_iter} steps complete",
         )
+
+    def _deterministic_action(self, actor_obs: torch.Tensor) -> torch.Tensor:
+        """Return the deployable (mean / deterministic) action for ``actor_obs``.
+
+        Both concrete trainers expose ``act_inference`` on their actor-critic
+        module (PPO: the actor mean; SAC: ``tanh(mean)``), so the default
+        dispatches there. A subclass with a different module API can override.
+        """
+        return self.actor_critic.act_inference(actor_obs)
+
+    def evaluate(
+        self,
+        spec: RLTrainSpec | None = None,
+        checkpoint_dir: str | None = None,
+        num_episodes: int = 10,
+    ) -> dict[str, Any]:
+        """Roll out the DETERMINISTIC policy for ``num_episodes`` and score it.
+
+        The eval peer of :meth:`train`: it never updates the policy, the
+        normalizers, or the replay buffer - it runs the deployable (mean)
+        action only, with gradients disabled and observation normalization
+        frozen, so the numbers it returns are exactly what a deployed
+        ``policy.pt`` would produce.
+
+        Two entry modes:
+          - After :meth:`train` / :meth:`setup` on the SAME trainer instance:
+            call ``evaluate(num_episodes=...)`` with no spec; it reuses the
+            in-memory env + actor-critic.
+          - Fresh instance: pass ``spec`` (to build the env via
+            ``spec.env_factory``) and optionally ``checkpoint_dir`` (to load a
+            saved ``policy.pt``); when ``checkpoint_dir`` is omitted it uses
+            ``spec.output_dir``'s latest checkpoint if one exists, else the
+            freshly-initialised (untrained) weights.
+
+        Args:
+            spec: Required only when the trainer has not been ``setup``; builds
+                the env and networks. Ignored when the trainer is already live.
+            checkpoint_dir: Directory holding ``policy.pt`` to load before
+                evaluating. ``None`` keeps the in-memory weights (or the
+                latest checkpoint under ``spec.output_dir`` for a fresh
+                instance).
+            num_episodes: Number of full episodes to roll out. Must be > 0.
+
+        Returns:
+            Metrics dict::
+
+                {
+                    "num_episodes": int,
+                    "mean_return": float,
+                    "std_return": float,
+                    "min_return": float,
+                    "max_return": float,
+                    "mean_length": float,
+                    "success_rate": float,   # fraction terminated via success_fn
+                    "returns": list[float],  # per-episode
+                }
+
+            ``success_rate`` is the fraction of episodes that ended on a genuine
+            terminal (``info["terminated"]`` -> the env's ``success_fn``), not a
+            time-out. When the env has no ``success_fn`` every episode times out
+            and ``success_rate`` is ``0.0``.
+
+        Raises:
+            ValueError: ``num_episodes <= 0``, or the trainer is not set up and
+                no ``spec`` was provided to build it.
+        """
+        import torch
+
+        if num_episodes <= 0:
+            raise ValueError(f"num_episodes must be > 0, got {num_episodes}")
+
+        # Bring the trainer to a live state if it was not already set up.
+        if getattr(self, "actor_critic", None) is None or getattr(self, "env", None) is None:
+            if spec is None:
+                raise ValueError(
+                    "evaluate() on a trainer that has not been setup() requires a spec "
+                    "(with env_factory) to build the env and networks"
+                )
+            self.setup(spec)
+            if checkpoint_dir is None and spec.output_dir:
+                checkpoint_dir = self.latest_checkpoint(spec.output_dir)
+
+        if checkpoint_dir is not None:
+            self.load_checkpoint(checkpoint_dir)
+
+        actor_norm = getattr(self, "actor_norm", None)
+
+        def _norm(x: torch.Tensor) -> torch.Tensor:
+            # Freeze the normalizer (update=False) so eval never shifts the
+            # running statistics learned during training.
+            return actor_norm(x, update=False) if actor_norm is not None else x
+
+        # Capture the pre-eval mode so evaluate() can restore it: a train ->
+        # evaluate -> train continuation must resume with BatchNorm/Dropout
+        # live. Leaving a module in eval() silently freezes its running stats
+        # (the exact eval/train-mode footgun that bites supervised fine-tunes).
+        _ac_was_training = self.actor_critic.training
+        _norm_was_training = actor_norm.training if actor_norm is not None else False
+        self.actor_critic.eval()
+        if actor_norm is not None:
+            actor_norm.eval()
+
+        # Evaluation is inherently per-episode sequential, so it runs on a SINGLE
+        # env even when training used a VecSimEnv (N>1). A VecSimEnv returns
+        # (N,)-batched rewards/dones that cannot be scalarised here; use its
+        # first sub-env, which is a plain SimEnv with the (1,)-shaped contract.
+        eval_env = self.env.envs[0] if hasattr(self.env, "envs") else self.env
+
+        returns: list[float] = []
+        lengths: list[int] = []
+        successes = 0
+        for _ in range(num_episodes):
+            obs = eval_env.reset()
+            ep_return = 0.0
+            ep_len = 0
+            terminated = False
+            while True:
+                actor_obs = _norm(obs["actor_obs"])
+                with torch.no_grad():
+                    action = self._deterministic_action(actor_obs)
+                obs, reward, done, info = eval_env.step(action)
+                ep_return += float(reward.item())
+                ep_len += 1
+                if bool(done.item()):
+                    terminated = bool(info.get("terminated", False))
+                    break
+            returns.append(ep_return)
+            lengths.append(ep_len)
+            if terminated:
+                successes += 1
+
+        # Restore the pre-eval mode (side-effect-free evaluate()).
+        self.actor_critic.train(_ac_was_training)
+        if actor_norm is not None:
+            actor_norm.train(_norm_was_training)
+
+        returns_t = torch.tensor(returns, dtype=torch.float32)
+        return {
+            "num_episodes": num_episodes,
+            "mean_return": float(returns_t.mean().item()),
+            "std_return": float(returns_t.std(unbiased=False).item()),
+            "min_return": float(returns_t.min().item()),
+            "max_return": float(returns_t.max().item()),
+            "mean_length": float(sum(lengths) / len(lengths)),
+            "success_rate": float(successes / num_episodes),
+            "returns": returns,
+        }
+
+    def load_checkpoint(self, checkpoint_dir: str) -> None:
+        """Load ``policy.pt`` (actor-critic + normalizers) from ``checkpoint_dir``.
+
+        Restores weights into the already-constructed module graph (call
+        :meth:`setup` first). Subclasses whose checkpoint carries extra state
+        (e.g. SAC's ``log_alpha``) override to restore it, then ``super().``
+        for the shared actor-critic + normalizer load.
+
+        Raises:
+            FileNotFoundError: When ``policy.pt`` is absent from the directory.
+        """
+        import os
+
+        import torch
+
+        path = os.path.join(checkpoint_dir, "policy.pt")
+        if not os.path.isfile(path):
+            raise FileNotFoundError(f"no policy.pt in checkpoint dir: {checkpoint_dir}")
+        # The checkpoint payload is state_dicts + an int + a str (see
+        # save_checkpoint), so the hardened weights_only=True loader works and
+        # closes the arbitrary-code-execution surface of the legacy unpickler.
+        state = torch.load(path, map_location=self.device, weights_only=True)
+        self.actor_critic.load_state_dict(state["actor_critic"])
+        actor_norm = getattr(self, "actor_norm", None)
+        if actor_norm is not None and "actor_norm" in state:
+            actor_norm.load_state_dict(state["actor_norm"])
+        critic_norm = getattr(self, "critic_norm", None)
+        if critic_norm is not None and "critic_norm" in state:
+            critic_norm.load_state_dict(state["critic_norm"])

--- a/tests/training/test_rl_evaluate.py
+++ b/tests/training/test_rl_evaluate.py
@@ -1,0 +1,227 @@
+"""Unit tests for ``BaseRLAlgo.evaluate()`` - the deterministic eval peer of train().
+
+CPU-only: a tiny fake ``SimEngine`` drives a deterministic 1-DOF env so the test
+needs neither mujoco nor model downloads. Pins the eval contract: deterministic
+rollout, frozen normalizer, schema, success_rate, and the not-setup guard.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from strands_robots.training.rl import PpoTrainer, RLTrainSpec, SimEnv  # noqa: E402
+
+
+class _FakeEngine:
+    """Minimal SimEngine stand-in: one joint ``J`` integrated by the action.
+
+    ``J`` starts at 0.0; each ``send_action([a])`` moves it by ``0.1 * a``.
+    ``J.vel`` reports the last delta. Enough to exercise reset/step/observe and
+    a success predicate without any physics backend.
+    """
+
+    def __init__(self) -> None:
+        self._j = 0.0
+        self._vel = 0.0
+
+    def list_robots(self) -> list[str]:
+        return ["fake"]
+
+    def robot_joint_names(self, robot_name: str) -> list[str]:
+        return ["J"]
+
+    def reset(self) -> dict:
+        self._j = 0.0
+        self._vel = 0.0
+        return {"status": "success"}
+
+    def get_observation(self, robot_name=None, *, skip_images: bool = False) -> dict:
+        return {"J": self._j, "J.vel": self._vel}
+
+    def send_action(self, action, robot_name=None, n_substeps: int = 1) -> dict:
+        a = float(action[0]) if len(action) else 0.0
+        self._vel = 0.1 * a
+        self._j += self._vel
+        return {"status": "success"}
+
+
+def _make_env():  # type: ignore[no-untyped-def]
+    eng = _FakeEngine()
+    return SimEnv(
+        eng,
+        actor_obs_keys=["J", "J.vel"],
+        reward_terms=[lambda e: -abs(float(e.get_observation(skip_images=True)["J"]) - 0.2)],
+        action_dim=1,
+        max_episode_steps=5,
+    )
+
+
+def _make_env_with_success():  # type: ignore[no-untyped-def]
+    eng = _FakeEngine()
+    return SimEnv(
+        eng,
+        actor_obs_keys=["J", "J.vel"],
+        reward_terms=[lambda e: 1.0],
+        action_dim=1,
+        max_episode_steps=5,
+        # Always-successful predicate: terminates on the first step.
+        success_fn=lambda e: True,
+    )
+
+
+def test_evaluate_schema_and_determinism(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    trainer = PpoTrainer()
+    spec = RLTrainSpec(
+        env_factory=_make_env,
+        output_dir=str(tmp_path),
+        rollout_steps=4,
+        num_mini_batches=2,
+        hidden_dims=(8,),
+        seed=0,
+    )
+    trainer.setup(spec)
+
+    out = trainer.evaluate(num_episodes=3)
+    # Schema.
+    for k in (
+        "num_episodes",
+        "mean_return",
+        "std_return",
+        "min_return",
+        "max_return",
+        "mean_length",
+        "success_rate",
+        "returns",
+    ):
+        assert k in out, f"missing key {k}"
+    assert out["num_episodes"] == 3
+    assert len(out["returns"]) == 3
+    assert out["mean_length"] == 5.0  # no success_fn -> always times out at max_episode_steps
+    assert out["success_rate"] == 0.0
+
+    # Determinism: same weights -> identical eval returns.
+    out2 = trainer.evaluate(num_episodes=3)
+    assert out["returns"] == out2["returns"]
+
+
+def test_evaluate_success_rate_counts_terminals(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    trainer = PpoTrainer()
+    spec = RLTrainSpec(
+        env_factory=_make_env_with_success,
+        output_dir=str(tmp_path),
+        rollout_steps=4,
+        num_mini_batches=2,
+        hidden_dims=(8,),
+        seed=0,
+    )
+    trainer.setup(spec)
+    out = trainer.evaluate(num_episodes=4)
+    # success_fn always True -> every episode terminates on step 1.
+    assert out["success_rate"] == 1.0
+    assert out["mean_length"] == 1.0
+
+
+def test_evaluate_requires_spec_when_not_setup() -> None:
+    trainer = PpoTrainer()
+    with pytest.raises(ValueError, match="setup"):
+        trainer.evaluate(num_episodes=2)
+
+
+def test_evaluate_rejects_bad_episode_count(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    trainer = PpoTrainer()
+    spec = RLTrainSpec(
+        env_factory=_make_env,
+        output_dir=str(tmp_path),
+        rollout_steps=4,
+        num_mini_batches=2,
+        hidden_dims=(8,),
+    )
+    trainer.setup(spec)
+    with pytest.raises(ValueError, match="num_episodes"):
+        trainer.evaluate(num_episodes=0)
+
+
+def test_evaluate_loads_checkpoint_fresh_instance(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    # Train briefly, checkpoint, then evaluate from a FRESH trainer + checkpoint.
+    t1 = PpoTrainer()
+    spec = RLTrainSpec(
+        env_factory=_make_env,
+        output_dir=str(tmp_path),
+        total_timesteps=4 * 3,
+        rollout_steps=4,
+        num_mini_batches=2,
+        num_learning_epochs=1,
+        hidden_dims=(8,),
+        seed=0,
+    )
+    result = t1.train(spec)
+    assert result.status == "success"
+
+    t2 = PpoTrainer()
+    out = t2.evaluate(spec=spec, num_episodes=2)  # discovers latest checkpoint under output_dir
+    assert out["num_episodes"] == 2
+    assert len(out["returns"]) == 2
+
+
+def test_evaluate_works_for_sac_too(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """evaluate() lives on BaseRLAlgo, so FastSAC inherits it unchanged.
+
+    SAC's deterministic action is ``tanh(mean)`` via the same ``act_inference``
+    contract PPO uses, so no per-subclass override is needed.
+    """
+    from strands_robots.training.rl import FastSacTrainer
+
+    trainer = FastSacTrainer()
+    spec = RLTrainSpec(
+        env_factory=_make_env_with_success,
+        output_dir=str(tmp_path),
+        rollout_steps=4,
+        batch_size=16,
+        learning_starts=16,
+        hidden_dims=(8,),
+        seed=0,
+    )
+    trainer.setup(spec)
+    out = trainer.evaluate(num_episodes=3)
+    assert out["num_episodes"] == 3
+    assert out["success_rate"] == 1.0  # success_fn always True
+    assert out["mean_length"] == 1.0
+
+
+def test_evaluate_restores_train_mode(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """evaluate() must be side-effect-free w.r.t. train/eval mode.
+
+    Regression guard: a train -> evaluate -> train continuation needs the
+    actor-critic (and obs normalizer) returned to training mode, else
+    BatchNorm/Dropout running stats silently freeze on resumed training.
+    """
+    trainer = PpoTrainer()
+    spec = RLTrainSpec(
+        env_factory=_make_env,
+        output_dir=str(tmp_path),
+        rollout_steps=4,
+        num_mini_batches=2,
+        hidden_dims=(8,),
+        seed=0,
+    )
+    trainer.setup(spec)
+
+    # Force a known training mode, then evaluate, then assert it is restored.
+    trainer.actor_critic.train()
+    assert trainer.actor_critic.training is True
+    actor_norm = getattr(trainer, "actor_norm", None)
+    if actor_norm is not None:
+        actor_norm.train()
+
+    trainer.evaluate(num_episodes=2)
+
+    assert trainer.actor_critic.training is True, "actor_critic left in eval() after evaluate()"
+    if actor_norm is not None:
+        assert actor_norm.training is True, "actor_norm left in eval() after evaluate()"
+
+    # And the inverse: an eval-mode caller stays in eval mode.
+    trainer.actor_critic.eval()
+    trainer.evaluate(num_episodes=1)
+    assert trainer.actor_critic.training is False, "evaluate() wrongly flipped a model that was in eval()"


### PR DESCRIPTION
## Summary

Adds a first-class **deterministic evaluation** entry point to the from-scratch RL trainers. `PpoTrainer` / `FastSacTrainer` could `train()` a policy but had no built-in way to *score* it - callers had to hand-roll a rollout loop and risk scoring the stochastic (exploration) action or an un-frozen normalizer, neither of which matches a deployed `policy.pt`.

This is a **focused, separately-reviewable extraction** from the multi-concern RL-parity branch (#915), per review feedback to decompose that branch into individually-validatable units. It is purely additive (+183 to `base_algo.py`, 0 deletions) and depends only on surface already on `main` (`SimEnv`, `RLTrainSpec`, the actor-critic's `act_inference`).

## What this adds (verified absent from `main`)

- **`BaseRLAlgo.evaluate(spec=None, checkpoint_dir=None, num_episodes=10)`** - rolls out the DETERMINISTIC (mean) action with gradients disabled and observation normalization frozen, so its numbers are exactly what a deployed `policy.pt` would produce. Two entry modes:
  - live post-`train()`/`setup()` instance: reuses the in-memory env + actor-critic;
  - fresh instance: builds the env from `spec.env_factory`, optionally loads `policy.pt` (or the latest checkpoint under `spec.output_dir`).
- **`load_checkpoint(checkpoint_dir)`** - loads a saved `policy.pt` before evaluating.
- **`_deterministic_action(actor_obs)`** - default dispatches to the actor-critic's `act_inference` (PPO: actor mean; SAC: `tanh(mean)`), so PPO and FastSAC share one implementation with no per-subclass override.

**Return schema:** `{num_episodes, mean_return, std_return, min_return, max_return, mean_length, success_rate, returns}`. `success_rate` is the fraction of episodes ending on a genuine terminal (the env's `success_fn`), not a time-out; an env with no `success_fn` reports `0.0`.

## Tests

`tests/training/test_rl_evaluate.py` - 7 CPU-only tests driven by a tiny deterministic 1-DOF fake engine (no mujoco, no model downloads). Pins:
- deterministic rollout (mean action, repeatable returns);
- normalizer frozen during eval (no update of running stats);
- result schema + types;
- `success_rate` computed from genuine terminals vs time-outs;
- the not-`setup` guard (evaluate on a fresh instance with no `spec` raises).

Verified locally against current `main`: `ruff check` clean, `ruff format --check` clean, `mypy` clean (`Success: no issues found`), and all 7 tests pass (~6.4s). No regression in `tests/training/test_rl_ppo.py`.

## Scope / honesty

- Purely additive; `num_envs==1` and all existing trainer behaviour unchanged.
- The remaining net-new pieces of #915 (`staged_reward`, `gym_env`, vectorized PPO, render `output_path`) are intentionally NOT here - each will land as its own focused PR. `VecSimEnv` is already separately up in #918.
- No host paths; no emojis in tool/result/log strings.

## §13 Review Round Changelog

| Round | Concern | Commit | Pin Test |
|-------|---------|--------|----------|
| R1 | Initial: extract `evaluate()` as a focused unit from #915 | `1ccf96c` | `tests/training/test_rl_evaluate.py` (7 tests) |
