### PR TITLE
test(lerobot_local): cover FeatureNormalizer torch-absent fallback + q10_q90 mode

### DIFF
--- a/tests/policies/lerobot_local/test_norm_stats_fallback.py
+++ b/tests/policies/lerobot_local/test_norm_stats_fallback.py
@@ -141,6 +141,37 @@ class TestFeatureNormalizer:
         assert fn.normalize(None) is None
         assert fn.unnormalize(None) is None
 
+    def test_q10_q90_mode_round_trip_matches_analytic_form(self):
+        # q10_q90 is a documented mode (see class docstring) that shares the
+        # quantile-scaling math of q01_q99 but keys off q10/q90 stats. Verify
+        # both the forward map and that a value inside [q10, q90] round-trips.
+        stats = {"q10": [0.0, -5.0], "q90": [10.0, 5.0]}
+        fn = ns.FeatureNormalizer.from_stats(stats, "q10_q90")
+        q10 = np.asarray(stats["q10"], dtype=np.float32)
+        q90 = np.asarray(stats["q90"], dtype=np.float32)
+
+        x = np.array([2.5, 0.0], dtype=np.float32)  # strictly inside [q10, q90]
+        want = 2.0 * (x - q10) / np.maximum(q90 - q10, 1e-6) - 1.0
+        got = fn.normalize(x)
+        assert np.allclose(got, want, atol=1e-6)
+        assert np.allclose(fn.unnormalize(got), x, atol=1e-4)
+
+    def test_normalizes_without_torch_installed(self, monkeypatch):
+        # torch is an optional dep: the normalizer must still work numpy-in /
+        # numpy-out when torch cannot be imported. Masking sys.modules["torch"]
+        # with None makes ``import torch`` raise ImportError, exercising the
+        # documented torch-absent fallback in _to_array and _restore_like.
+        import sys
+
+        monkeypatch.setitem(sys.modules, "torch", None)
+        stats = {"min": [0.0, 0.0], "max": [10.0, 10.0]}
+        fn = ns.FeatureNormalizer.from_stats(stats, "min_max")
+
+        got = fn.normalize(np.array([5.0, 0.0], dtype=np.float32))
+        assert isinstance(got, np.ndarray)
+        assert np.allclose(got, [0.0, -1.0])
+        assert np.allclose(fn.unnormalize(got), [5.0, 0.0])
+
 
 class TestSchemaDetection:
     """Payload schema detection and tag selection."""


### PR DESCRIPTION
## What
`FeatureNormalizer` (`strands_robots/policies/lerobot_local/norm_stats.py`) is the normalization port wired into the LeRobot processor steps that run on the `norm_stats.json` fallback path. It is safety-critical: a normalizer that silently drops or mis-applies normalization sends raw-space values to the motors. Two parts of its documented contract had no test.

### 1. Optional-torch fallback (untested branch)
`_to_array` and `_restore_like` each wrap `import torch` in `except ImportError`, and the class docstring promises numpy-in/numpy-out when torch is absent. No test exercised the torch-less branch, so that behavior was unverified. The new test masks `sys.modules["torch"]` with `None` (making `import torch` raise `ImportError`) and asserts `normalize`/`unnormalize` still produce correct `np.ndarray` output.

### 2. `q10_q90` mode numerics (unvalidated)
Only `q01_q99` was validated against an analytic reference. `q10_q90` shares the quantile-scaling branch but selects the `q10`/`q90` stat keys; nothing pinned that key selection or its transform, so a regression swapping the keys would pass silently. The new test checks the forward map against the analytic form and an in-range round-trip.

## Tests
Both added to `TestFeatureNormalizer` in `tests/policies/lerobot_local/test_norm_stats_fallback.py`. Behavior-only assertions (outputs, not internals).

Result on the file's own run: `norm_stats.py` coverage **95% -> 97%** (12 -> 8 uncovered lines; the torch-absent `_to_array`/`_restore_like` branches are now covered). Full file suite: **53 -> 55 passed**.

```
before: norm_stats.py  242  12  95%  71-73, 194, 222, 235-238, 371-372, 442, 446, 452-453
after:  norm_stats.py  242   8  97%  194, 222, 371-372, 442, 446, 452-453
```

Gate: `ruff check` + `ruff format --check` + `mypy strands_robots tests tests_integ` clean; `MUJOCO_GL=egl` pytest of the file green. Test-only change; no production code touched.