### PR TITLE
fix(sim): warn when start_recording sweeps the implicit 'default' camera into a dataset

### DIFF
--- a/docs/recording.md
+++ b/docs/recording.md
@@ -42,7 +42,10 @@ The dataset schema then declares only those three image features. Names may be
 given in raw MuJoCo form (`arm0/wrist_cam`) or schema-safe form
 (`arm0__wrist_cam`); an unknown name fails loudly and lists the available
 cameras rather than silently recording the wrong set. Omit `cameras=` to keep
-the legacy behavior of recording every camera.
+the legacy behavior of recording every camera - in that case a one-time
+warning is logged when the implicit `default` overview camera is swept in
+alongside your real sensor cameras, so the stray view is never recorded
+silently.
 
 ### Where the dataset is written (`root` / `overwrite`)
 

--- a/strands_robots/simulation/mujoco/recording.py
+++ b/strands_robots/simulation/mujoco/recording.py
@@ -92,7 +92,10 @@ class RecordingMixin(DatasetRecordingMixin):
                 decode it and silently yield 0 frames.
             cameras: Camera names to record into the dataset. When ``None``
                 (default) every scene camera is recorded - which includes the
-                implicit ``default`` free camera. Pass an explicit subset to
+                implicit ``default`` overview camera (a one-time warning is
+                logged when it is swept in alongside real sensor cameras, since
+                no policy declares ``observation.images.default``). Pass an
+                explicit subset to
                 record exactly the views a policy declares (e.g.
                 ``cameras=["camera1", "camera2", "camera3"]`` for a 3-camera
                 SmolVLA dataset) and keep the stray ``default`` view out of the
@@ -217,7 +220,7 @@ class RecordingMixin(DatasetRecordingMixin):
                     camera_dims[safe_name] = (int(self.default_height), int(self.default_width))
 
             # Optional camera scoping. By default EVERY scene camera is recorded,
-            # which silently includes the implicit ``default`` free camera and any
+            # which sweeps in the implicit ``default`` overview camera and any
             # view the trained policy never declared - bloating the dataset and
             # producing image features that do not match the policy's
             # ``input_features``. When ``cameras`` is given, record exactly that
@@ -262,6 +265,28 @@ class RecordingMixin(DatasetRecordingMixin):
             # Stash the scoped RAW camera names so the run_policy frame hook drops
             # un-recorded camera arrays before add_frame (None -> record all).
             self._world._backend_state["recording_cameras"] = record_raw_cameras
+
+            # Doctrine: warn loudly, never silently surprise. On the record-all
+            # path (``cameras is None``) the implicit ``default`` overview camera
+            # that ``create_world`` auto-adds is swept into the dataset alongside
+            # the real, user-added sensor cameras. That produces an
+            # ``observation.images.default`` view no trained policy declares -
+            # bloating the dataset and breaking feature-matching against a
+            # policy's ``input_features``. Keep recording it (back-compat), but
+            # surface it instead of including it silently, and point at the
+            # ``cameras=`` escape hatch.
+            if cameras is None and "default" in camera_keys and len(camera_keys) > 1:
+                sensor_cams = [c for c in camera_keys if c != "default"]
+                logger.warning(
+                    "start_recording: recording the implicit 'default' overview "
+                    "camera into observation.images.default alongside %d sensor "
+                    "camera(s) %s. The 'default' view is not a sensor any policy "
+                    "declares; it bloats the dataset and will not match a policy's "
+                    "input_features. Pass cameras=%r to record only your sensors.",
+                    len(sensor_cams),
+                    sensor_cams,
+                    sensor_cams,
+                )
 
             assert _DatasetRecorder is not None  # checked above
             if resume_existing:

--- a/tests/simulation/mujoco/test_recording_camera_scoping.py
+++ b/tests/simulation/mujoco/test_recording_camera_scoping.py
@@ -147,3 +147,48 @@ def test_drop_unrecorded_cameras_helper():
     assert out["shoulder_pan"] == 0.1
     assert "cam_b" not in out
     assert "default" not in out
+
+
+def test_recording_default_camera_alongside_sensors_warns(sim_with_cameras, tmp_path, caplog):
+    """Record-all (``cameras=None``) must not silently sweep in ``default``.
+
+    The implicit ``default`` overview camera that ``create_world`` adds is not a
+    sensor any policy declares; recording it bloats the dataset with an
+    ``observation.images.default`` view. Recording still happens (back-compat),
+    but a one-time warning must surface it instead of including it silently.
+    """
+    sim = sim_with_cameras
+    with caplog.at_level("WARNING"):
+        res = sim.start_recording(
+            repo_id="local/scope_warn",
+            root=str(tmp_path / "warn"),
+            overwrite=True,
+        )
+    assert res["status"] == "success"
+    # Behavior unchanged: default is still recorded alongside the sensors.
+    assert _recorder_image_features(sim) == {
+        "observation.images.default",
+        "observation.images.cam_a",
+        "observation.images.cam_b",
+    }
+    warnings = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+    assert any("default" in m and "observation.images.default" in m and "cameras=" in m for m in warnings), (
+        f"expected a stray-default-camera warning, got: {warnings}"
+    )
+
+
+def test_recording_scoped_cameras_does_not_warn(sim_with_cameras, tmp_path, caplog):
+    """Scoping with ``cameras=`` drops ``default`` and must emit no stray warning."""
+    sim = sim_with_cameras
+    with caplog.at_level("WARNING"):
+        res = sim.start_recording(
+            repo_id="local/scope_quiet",
+            root=str(tmp_path / "quiet"),
+            cameras=["cam_a", "cam_b"],
+            overwrite=True,
+        )
+    assert res["status"] == "success"
+    warnings = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+    assert not any("observation.images.default" in m for m in warnings), (
+        f"scoped recording must not warn about default, got: {warnings}"
+    )


### PR DESCRIPTION
## Problem

`Simulation.start_recording(...)` with the default `cameras=None` records **every** scene camera into the LeRobotDataset. That includes the implicit `default` overview camera that `create_world` auto-adds (a non-sensor viewport at a fixed corner angle, `camera_id=-1`). The result is a silent `observation.images.default` (640x480) video stream that **no trained policy declares**, which:

- bloats every episode with an extra MP4 stream nobody asked for, and
- produces an image-feature key that does not match a policy's `input_features` (e.g. a SmolVLA dataset that should carry exactly `observation.images.camera1/camera2/camera3`).

The code path even comments that it "silently includes the implicit `default` free camera", and the docs call it the "stray `observation.images.default` view" — but nothing surfaced it at runtime. This contradicts the repo's established "warn loudly, never silently surprise" convention (cf. the EGL software-fallback warning, the verify-dataset dead-column flag, the actuator-keying all-zero-column guard).

## Reproduction (real MuJoCo sim, headless EGL)

Build a SO-101 scene with three sensor cameras and record without `cameras=`:

```python
sim.create_world(ground_plane=True); sim.add_robot("so101")
for n in ("camera1","camera2","camera3"): sim.add_camera(name=n, ...)
sim.start_recording(repo_id="local/demo", task="...", fps=30)
sim.run_policy(robot_name="so101", policy_provider="lerobot_local",
    policy_config={"pretrained_name_or_path":"lerobot/smolvla_base", "policy_type":"smolvla",
                   "image_keys":["camera1","camera2","camera3"], "strict_keys":True}, n_steps=30)
sim.stop_recording()
```

Reopening the produced dataset shows the stray view:

```
observation.images.default  video (3, 480, 640)   <- not declared by any policy
observation.images.camera1  video (3, 256, 256)
observation.images.camera2  video (3, 256, 256)
observation.images.camera3  video (3, 256, 256)
```

## Change

Keep the recording behavior unchanged (full back-compat — `default` is still recorded so existing datasets/appends are byte-identical), but on the record-all path emit a one-time warning when `default` is swept in alongside real sensor cameras, naming them and pointing at the `cameras=` scoping escape hatch:

```
WARNING strands_robots.simulation.mujoco.recording: start_recording: recording the
implicit 'default' overview camera into observation.images.default alongside 3 sensor
camera(s) ['camera1', 'camera2', 'camera3']. The 'default' view is not a sensor any
policy declares; it bloats the dataset and will not match a policy's input_features.
Pass cameras=['camera1', 'camera2', 'camera3'] to record only your sensors.
```

The warning is suppressed when the caller scopes with `cameras=`, and when the scene has only the `default` camera (nothing to disambiguate).

## Tests

Adds two regression tests to `tests/simulation/mujoco/test_recording_camera_scoping.py` (real `Simulation` + `start_recording`, no mocks):

- `test_recording_default_camera_alongside_sensors_warns` — asserts the warning fires on the record-all path and that `default` is **still** recorded (behavior unchanged). Fails before this change (`got: []`), passes after.
- `test_recording_scoped_cameras_does_not_warn` — asserts no stray-default warning when `cameras=` is supplied.

## Verification

- `ruff check` / `ruff format --check`: clean.
- `mypy strands_robots tests tests_integ`: `Success: no issues found in 610 source files`.
- `MUJOCO_GL=egl pytest tests/simulation/mujoco/test_recording_*.py tests/simulation/test_recording_lifecycle_accessors.py`: 64 passed.
- Round-trip evidence above produced from a real SmolVLA rollout in MuJoCo (headless EGL): start -> write -> stop -> reopen, 1 episode / 30 frames, all declared cameras non-empty, real non-zero actions recorded.

## Docs

`docs/recording.md` and the `start_recording` docstring updated to note the one-time warning on the legacy record-all path.