### PR TITLE
fix(sim): randomize() recolors unnamed + material-backed geoms and reports the true count

### DIFF
--- a/strands_robots/simulation/mujoco/randomization.py
+++ b/strands_robots/simulation/mujoco/randomization.py
@@ -63,7 +63,9 @@ class RandomizationMixin:
         arrays and to ``data.qpos``); recompile the scene to undo.
 
         Args:
-            randomize_colors:     Re-sample geom RGB values.
+            randomize_colors:     Re-sample every non-ground geom's RGB (and
+                                  its material colour, which overrides geom RGB
+                                  in the renderer).
             randomize_lighting:   Jitter light positions + diffuse colour.
             randomize_physics:    Scale geom friction and body mass.
             randomize_positions:  Add uniform noise to dynamic-object xyz.
@@ -87,11 +89,27 @@ class RandomizationMixin:
 
         with self._lock:
             if randomize_colors:
+                # Recolor every geom except the ground plane. Two correctness
+                # points, both previously silent:
+                #   1. Robot mesh geoms are typically UNNAMED, so a truthiness
+                #      check on the name skipped them entirely - the robot kept
+                #      its original colors while the call reported success.
+                #   2. A geom that references a material draws its colour from
+                #      that material in the renderer, NOT from geom_rgba, so the
+                #      recolor is visually inert unless the material is updated
+                #      too. Geoms sharing one material converge to the last
+                #      colour written - acceptable for domain randomization.
+                n_recolored = 0
                 for i in range(model.ngeom):
-                    geom_name = mj.mj_id2name(model, mj.mjtObj.mjOBJ_GEOM, i)
-                    if geom_name and geom_name != "ground":
-                        model.geom_rgba[i, :3] = rng.uniform(color_range[0], color_range[1], size=3)
-                changes.append(f"Colors: {model.ngeom} geoms randomized")
+                    if mj.mj_id2name(model, mj.mjtObj.mjOBJ_GEOM, i) == "ground":
+                        continue
+                    color = rng.uniform(color_range[0], color_range[1], size=3)
+                    model.geom_rgba[i, :3] = color
+                    matid = int(model.geom_matid[i])
+                    if matid >= 0:
+                        model.mat_rgba[matid, :3] = color
+                    n_recolored += 1
+                changes.append(f"Colors: {n_recolored} geoms randomized")
 
             if randomize_lighting:
                 for i in range(model.nlight):

--- a/tests/simulation/mujoco/test_simulation.py
+++ b/tests/simulation/mujoco/test_simulation.py
@@ -15,6 +15,7 @@ import os
 import shutil
 import tempfile
 
+import numpy as np
 import pytest
 
 mj = pytest.importorskip("mujoco")
@@ -87,6 +88,29 @@ FREE_BASE_XML = """
 """
 
 
+# Scene with a material-backed, UNNAMED geom - mirrors a real robot whose mesh
+# geoms are unnamed and draw their colour from a referenced material (so the
+# renderer ignores geom_rgba for them).
+MATERIAL_SCENE_XML = """
+<mujoco model="mat_scene">
+  <compiler angle="radian" autolimits="true"/>
+  <asset>
+    <material name="body_mat" rgba="0.2 0.2 0.2 1"/>
+  </asset>
+  <worldbody>
+    <light name="main" pos="0 0 3" dir="0 0 -1"/>
+    <body name="base" pos="0 0 0.1">
+      <joint name="j" type="hinge" axis="0 0 1"/>
+      <geom type="box" size="0.05 0.05 0.05" material="body_mat"/>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="j_act" joint="j" kp="10"/>
+  </actuator>
+</mujoco>
+"""
+
+
 @pytest.fixture
 def sim():
     """Create a fresh Simulation instance."""
@@ -140,6 +164,17 @@ def robot_xml_path():
     path = os.path.join(tmpdir, "test_arm.xml")
     with open(path, "w") as f:
         f.write(ROBOT_XML)
+    yield path
+    shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+@pytest.fixture
+def material_scene_path():
+    """Write the material-backed scene XML to a temp file."""
+    tmpdir = tempfile.mkdtemp()
+    path = os.path.join(tmpdir, "mat_scene.xml")
+    with open(path, "w") as f:
+        f.write(MATERIAL_SCENE_XML)
     yield path
     shutil.rmtree(tmpdir, ignore_errors=True)
 
@@ -739,6 +774,50 @@ class TestRandomization:
         sim_with_world.add_object("cube", shape="box", position=[0, 0, 0.1])
         result = sim_with_world.randomize(randomize_positions=True, seed=42)
         assert result["status"] == "success"
+
+    def test_randomize_colors_recolors_unnamed_geoms_and_reports_true_count(self, sim_with_robot):
+        """Recoloring must touch every non-ground geom - including the UNNAMED
+        mesh geoms a real robot body is built from - and the success message
+        must report the count it actually changed, not the total geom count.
+
+        Pre-fix the loop skipped any geom with a falsy (unnamed) name, so a
+        robot kept its colours while the call reported every geom randomized.
+        """
+        m = sim_with_robot._world._model
+        before = m.geom_rgba.copy()
+
+        result = sim_with_robot.randomize(randomize_colors=True, randomize_lighting=False, seed=42)
+        assert result["status"] == "success"
+        after = m.geom_rgba.copy()
+
+        changed = [i for i in range(m.ngeom) if not np.allclose(before[i, :3], after[i, :3])]
+        ground = mj.mj_name2id(m, mj.mjtObj.mjOBJ_GEOM, "ground")
+        # the robot's geoms are unnamed; every non-ground geom must recolor
+        assert ground not in changed
+        assert len(changed) == m.ngeom - 1
+        # the reported count is the true number changed, not ngeom
+        assert f"Colors: {len(changed)} geoms" in result["content"][0]["text"]
+
+    def test_randomize_colors_propagates_to_materials(self, sim, material_scene_path):
+        """A material-backed geom draws its colour from the material, which
+        overrides geom_rgba in the renderer, so randomization must recolor the
+        material too or the change is visually inert.
+
+        The scene's geom is both unnamed and material-backed, so pre-fix it was
+        skipped entirely and no material colour ever changed.
+        """
+        sim.create_world(ground_plane=False)
+        assert sim.add_robot("m", urdf_path=material_scene_path)["status"] == "success"
+        m = sim._world._model
+        assert m.nmat >= 1
+
+        mat_before = m.mat_rgba.copy()
+        result = sim.randomize(randomize_colors=True, randomize_lighting=False, seed=1)
+        assert result["status"] == "success"
+        mat_after = m.mat_rgba.copy()
+
+        changed_mats = [i for i in range(m.nmat) if not np.allclose(mat_before[i, :3], mat_after[i, :3])]
+        assert changed_mats, "material colours must be randomized so the recolor is visible"
 
     def test_randomize_no_world(self, sim):
         result = sim.randomize()


### PR DESCRIPTION
## Problem

`Simulation.randomize(randomize_colors=True)` (an opt-in default) reports success while leaving most of a real scene visually unchanged. Three issues compound:

1. **Unnamed geoms are skipped.** The recolor loop guarded on `if geom_name and geom_name != "ground"`. A robot's mesh geoms are typically *unnamed* (`mj_id2name` returns `None`), so the truthiness check skipped the entire robot — it kept its original colours.
2. **Material-backed geoms ignore `geom_rgba`.** A geom that references a material draws its colour from that material in the renderer, not from `geom_rgba`. On a real scene almost every geom has a material (e.g. 31/32 on an SO-101 + cube scene), so writing `geom_rgba` was visually inert for them.
3. **The success message lied about the count.** It reported `model.ngeom` geoms randomized regardless of how many were actually touched — e.g. `"Colors: 32 geoms randomized"` when exactly **1** (the bare cube) changed.

Net effect: vision-facing domain randomization silently does almost nothing on any scene containing a robot, while the call returns `status: success` with a count that overstates the work.

## Change

In the `randomize_colors` branch of `simulation/mujoco/randomization.py`:

- Recolor **every** non-ground geom (skip only the geom literally named `ground`), so unnamed mesh geoms are no longer dropped.
- When a geom references a material (`geom_matid >= 0`), propagate the sampled colour to `model.mat_rgba[matid]` too, so the recolor is actually visible in the renderer. Geoms sharing one material converge to the last colour written — acceptable for domain randomization.
- Report the count actually recolored instead of `model.ngeom`.

## Tests

Adds two regression tests in `tests/simulation/mujoco/test_simulation.py` using network-free inline scenes (no asset download):

- `test_randomize_colors_recolors_unnamed_geoms_and_reports_true_count` — asserts every non-ground geom (all unnamed in the fixture) recolors, ground is untouched, and the reported count equals the real number changed.
- `test_randomize_colors_propagates_to_materials` — a geom that is both unnamed and material-backed; asserts at least one material colour changes.

Both **fail on the pre-fix loop** (`0 == 3` recolored; no material changed) and pass after. Full `tests/simulation/mujoco/test_simulation.py` is green (143 passed, rendering deselected); ruff + mypy clean on the changed files.

## Visual proof

SO-101 + cube scene rendered headless (MuJoCo, EGL) before vs after `randomize(randomize_colors=True)` through the shipped code path. Pre-fix the robot stayed grey and the message claimed 32 geoms; now it reports `Colors: 31 geoms randomized` and the robot body actually recolors.

![randomize before/after](https://raw.githubusercontent.com/cagataycali/robots/assets/randomize-color-demo/randomize_before_after.png)

Left: before. Right: after randomization.