### PR TITLE
security(sim): sandbox + harden LLM-supplied video output paths (run_policy video=, start_cameras_recording)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,26 @@ so a crash mid-write cannot corrupt an existing file; created files are `0o644`
 and freshly created directories `0o755`.
 
 
+### Security: Extended output-path hardening to `run_policy(video=...)` and `start_cameras_recording`
+
+`render(output_path=...)` was hardened in isolation, but the sibling video sinks
+that also persist an LLM-supplied filesystem path were still unguarded:
+`run_policy(video={"path": ...})` and `start_cameras_recording(output_dir=...,
+name=...)` did `os.path.abspath` + `os.makedirs` on the raw path (and
+interpolated the raw `name` tag into the per-camera filename), so a `..`
+traversal, a symlinked target, shell metacharacters, or a `name` carrying path
+separators could escape the intended location. The guards are now centralized in
+`strands_robots.simulation.safe_output` and shared by all three sinks: `..`
+traversal segments, backslash separators, shell metacharacters, and symlinked
+targets are rejected with `status=error` before any file is opened, and the
+recording `name` is validated as a single path component. Unlike `render`, whose
+sandbox is on by default, the video sinks preserve their historic
+absolute-path contract: confinement is opt-in via `STRANDS_ROBOTS_VIDEO_ROOT`
+(with `STRANDS_ROBOTS_VIDEO_ALLOW_ABS=1` to re-permit absolute paths inside that
+mode). The `render` implementation now delegates to the shared helpers; its
+behavior and env vars (`STRANDS_ROBOTS_RENDER_*`) are unchanged.
+
+
 ### Added: `BaseRLAlgo.evaluate()` - deterministic eval peer of `train()`
 
 The from-scratch RL trainers (`PpoTrainer`, `FastSacTrainer`) could `train()` a

--- a/README.md
+++ b/README.md
@@ -986,6 +986,8 @@ touches ROS 2.
 | `STRANDS_ROBOTS_RENDER_ROOT` | Sandbox directory that `Simulation.render(output_path=...)` may write into | `~/.strands_robots/renders/` |
 | `STRANDS_ROBOTS_RENDER_ALLOW_ABS` | Set `1` to allow `render(output_path=...)` to write absolute paths outside the render sandbox | unset |
 | `STRANDS_ROBOTS_RENDER_MAX_BYTES` | Max PNG size `render(output_path=...)` will persist | `52428800` (50 MB) |
+| `STRANDS_ROBOTS_VIDEO_ROOT` | Opt-in sandbox for video/recording output paths (`run_policy(video=...)`, `start_cameras_recording`). Unset = absolute paths allowed (historic contract); set to confine writes | unset |
+| `STRANDS_ROBOTS_VIDEO_ALLOW_ABS` | Set `1` to re-permit absolute paths when `STRANDS_ROBOTS_VIDEO_ROOT` is set | unset |
 | `STRANDS_TRUST_REMOTE_CODE` | Set `1` to allow HF `trust_remote_code` for `lerobot_local` | unset |
 | `STRANDS_ROBOTS_NO_DYLD_SHIM` | Set `1` to disable the macOS auto-fix that puts Homebrew ffmpeg on the dyld path for torchcodec video streaming (see [Recording & streaming datasets](#recording--streaming-datasets)) | unset |
 | `MUJOCO_GL` | MuJoCo GL backend (`egl`, `osmesa`, `glfw`) | auto |

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -1,10 +1,8 @@
 """Rendering mixin - render, render_depth, get_contacts, observation helpers."""
 
-import contextlib
 import io
 import logging
 import os
-import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -14,14 +12,23 @@ from strands_robots.simulation.mujoco.backend import (
     _ensure_mujoco,
     capture_stderr_fd,
 )
+from strands_robots.simulation.safe_output import (
+    atomic_write_bytes,
+    env_flag,
+    resolve_sandbox_root,
+    sanitize_name_component,
+    validate_output_path,
+    video_sandbox_args,
+)
 
 logger = logging.getLogger(__name__)
 
 # render(output_path=...) is an LLM-callable tool: the path is attacker-influenced.
 # Confine writes to a sandbox root, reject shell metacharacters / traversal /
 # symlinked targets, cap the payload size, and write atomically so a crash mid-write
-# cannot corrupt an existing file. See docs and the STRANDS_ROBOTS_RENDER_* env vars.
-_RENDER_PATH_BAD_CHARS = frozenset({";", "|", "$", "`", ">", "<", "\n", "\r", "\x00"})
+# cannot corrupt an existing file. The generic guards live in
+# strands_robots.simulation.safe_output; the render-specific sandbox + size cap
+# (STRANDS_ROBOTS_RENDER_* env vars) are bound here.
 _DEFAULT_MAX_RENDER_BYTES = 50 * 1024 * 1024  # 50 MB
 
 
@@ -31,8 +38,7 @@ def _render_sandbox_root() -> Path:
     Defaults to ``~/.strands_robots/renders``; override with the
     ``STRANDS_ROBOTS_RENDER_ROOT`` env var.
     """
-    raw = os.getenv("STRANDS_ROBOTS_RENDER_ROOT") or str(Path.home() / ".strands_robots" / "renders")
-    return Path(raw).expanduser().resolve(strict=False)
+    return resolve_sandbox_root("STRANDS_ROBOTS_RENDER_ROOT", "renders")
 
 
 def _max_render_bytes() -> int:
@@ -50,77 +56,21 @@ def _max_render_bytes() -> int:
 
 
 def _validate_render_output_path(output_path: str) -> Path:
-    """Validate and resolve an LLM-supplied render output path.
+    """Validate an LLM-supplied render path, confined to the render sandbox.
 
-    Rejects shell metacharacters, backslash (Windows-style) separators, paths
-    that resolve outside the render sandbox root, and symlinked targets. Returns
-    the fully-resolved destination ``Path``.
-
-    Args:
-        output_path: Caller-supplied destination path.
-
-    Returns:
-        The resolved, sandbox-confined destination path.
+    Thin render-specific binding over
+    :func:`strands_robots.simulation.safe_output.validate_output_path`: absolute
+    paths outside the sandbox are rejected unless ``STRANDS_ROBOTS_RENDER_ALLOW_ABS``
+    opts in.
 
     Raises:
         ValueError: If the path is unsafe (the caller maps this to a tool error).
     """
-    if any(b in output_path for b in _RENDER_PATH_BAD_CHARS):
-        raise ValueError("unsafe output_path: shell metacharacters")
-    # Backslash is not a POSIX separator, so "..\..\etc" would survive a
-    # "/"-only traversal check. Reject it outright rather than guess intent.
-    if "\\" in output_path:
-        raise ValueError("unsafe output_path: backslash separators not allowed")
-    if not output_path.strip():
-        raise ValueError("unsafe output_path: empty")
-
-    raw = Path(output_path).expanduser()
-    # Refuse to follow a symlink planted at the target (arbitrary-write vector).
-    if raw.is_symlink():
-        raise ValueError(f"output_path {output_path!r} is a symlink - refusing to follow")
-
-    # resolve() normalizes "..", expands the chain, and follows any intermediate
-    # symlinks, so the sandbox check below sees the true on-disk destination.
-    resolved = raw.resolve(strict=False)
-
-    allow_abs = (os.getenv("STRANDS_ROBOTS_RENDER_ALLOW_ABS") or "").strip().lower() in ("1", "true", "yes")
-    if not allow_abs:
-        root = _render_sandbox_root()
-        try:
-            resolved.relative_to(root)
-        except ValueError as e:
-            raise ValueError(
-                f"output_path {resolved} is outside the render sandbox {root} "
-                "(set STRANDS_ROBOTS_RENDER_ALLOW_ABS=1 to allow absolute paths)"
-            ) from e
-    return resolved
-
-
-def _atomic_write_png(path: Path, data: bytes) -> None:
-    """Write ``data`` to ``path`` atomically with restrictive permissions.
-
-    Writes to a temp file in the destination directory then ``os.replace``s it
-    into place, so a crash mid-write cannot truncate or corrupt an existing file
-    at ``path``. Created directories are ``0o700`` and the final file is ``0o600``
-    (owner-only; the render sandbox is private to the running user).
-    """
-    parent = path.parent
-    parent_existed = parent.exists()
-    parent.mkdir(parents=True, exist_ok=True)
-    if not parent_existed:
-        with contextlib.suppress(OSError):
-            os.chmod(parent, 0o700)
-
-    fd, tmp = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp", dir=parent)
-    try:
-        with os.fdopen(fd, "wb") as f:
-            f.write(data)
-        os.replace(tmp, path)
-    except BaseException:
-        with contextlib.suppress(OSError):
-            os.unlink(tmp)
-        raise
-    os.chmod(path, 0o600)
+    return validate_output_path(
+        output_path,
+        sandbox_root=_render_sandbox_root(),
+        allow_abs=env_flag("STRANDS_ROBOTS_RENDER_ALLOW_ABS"),
+    )
 
 
 def _save_render_png(output_path: str, png_bytes: bytes) -> str:
@@ -135,7 +85,7 @@ def _save_render_png(output_path: str, png_bytes: bytes) -> str:
     max_bytes = _max_render_bytes()
     if len(png_bytes) > max_bytes:
         raise ValueError(f"png is {len(png_bytes)} bytes, exceeds limit {max_bytes}")
-    _atomic_write_png(safe, png_bytes)
+    atomic_write_bytes(safe, png_bytes)
     return str(safe)
 
 
@@ -1237,10 +1187,13 @@ class RenderingMixin:
 
         Args:
             cameras: list of camera names; None = every camera.
-            output_dir: where to write ``{tag}__{cam}.mp4``.
+            output_dir: where to write ``{tag}__{cam}.mp4``. Validated against
+                ``..`` traversal / backslash / shell metacharacters / symlink;
+                set ``STRANDS_ROBOTS_VIDEO_ROOT`` to confine it to a sandbox.
             fps: capture rate.
             width/height: per-frame size.
-            name: filename tag (auto if None).
+            name: filename tag (auto if None). Validated as a single path
+                component - separators / traversal / metacharacters rejected.
             max_frames_per_camera: safety cap on in-memory buffers.
         """
         import os as _os
@@ -1272,7 +1225,22 @@ class RenderingMixin:
         if not names:
             return {"status": "error", "content": [{"text": "No cameras to record."}]}
 
-        out_dir = _os.path.abspath(output_dir or _os.path.join(_tempfile.gettempdir(), "strands_robots", "recordings"))
+        # output_dir and name are LLM-supplied: reject traversal / symlink /
+        # metacharacters (and a name carrying path separators) before we
+        # makedirs and interpolate name into the per-camera filename.
+        # Confinement to a video sandbox is opt-in via STRANDS_ROBOTS_VIDEO_ROOT.
+        try:
+            if name is not None:
+                sanitize_name_component(name, label="name")
+            if output_dir is not None:
+                _sb_root, _allow_abs = video_sandbox_args()
+                out_dir = str(
+                    validate_output_path(output_dir, sandbox_root=_sb_root, allow_abs=_allow_abs, label="output_dir")
+                )
+            else:
+                out_dir = _os.path.join(_tempfile.gettempdir(), "strands_robots", "recordings")
+        except ValueError as _e:
+            return {"status": "error", "content": [{"text": f"cameras_recording: {_e}"}]}
         _os.makedirs(out_dir, exist_ok=True)
         tag = name or f"rec_{_uuid.uuid4().hex[:8]}"
 
@@ -1594,12 +1562,16 @@ class RenderingMixin:
         Args:
             cameras: list of camera names; ``None`` = every camera.
             output_dir: where to write ``{tag}__{cam}.mp4``. Defaults to
-                ``$TMPDIR/strands_robots/recordings``.
+                ``$TMPDIR/strands_robots/recordings``. Validated against ``..``
+                traversal / backslash / shell metacharacters / symlink; set
+                ``STRANDS_ROBOTS_VIDEO_ROOT`` to confine it to a sandbox.
             fps: encoded MP4 frame rate (and target capture rate when
                 ``on_frame`` fires more often than ``fps``).
             width, height: per-frame size; defaults to the renderer's
                 native resolution.
             name: filename tag (auto-generated UUID prefix when ``None``).
+                Validated as a single path component - separators / traversal
+                / metacharacters rejected.
             max_frames_per_camera: safety cap on in-memory buffers.
                 Frames beyond the cap are silently dropped (status
                 visible via :meth:`get_cameras_recording_status`).
@@ -1639,7 +1611,22 @@ class RenderingMixin:
         if not names:
             return {"status": "error", "content": [{"text": "No cameras to record."}]}
 
-        out_dir = _os.path.abspath(output_dir or _os.path.join(_tempfile.gettempdir(), "strands_robots", "recordings"))
+        # output_dir and name are LLM-supplied: reject traversal / symlink /
+        # metacharacters (and a name carrying path separators) before we
+        # makedirs and interpolate name into the per-camera filename.
+        # Confinement to a video sandbox is opt-in via STRANDS_ROBOTS_VIDEO_ROOT.
+        try:
+            if name is not None:
+                sanitize_name_component(name, label="name")
+            if output_dir is not None:
+                _sb_root, _allow_abs = video_sandbox_args()
+                out_dir = str(
+                    validate_output_path(output_dir, sandbox_root=_sb_root, allow_abs=_allow_abs, label="output_dir")
+                )
+            else:
+                out_dir = _os.path.join(_tempfile.gettempdir(), "strands_robots", "recordings")
+        except ValueError as _e:
+            return {"status": "error", "content": [{"text": f"cameras_recording: {_e}"}]}
         _os.makedirs(out_dir, exist_ok=True)
         tag = name or f"rec_{_uuid.uuid4().hex[:8]}"
 

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -51,6 +51,7 @@ if TYPE_CHECKING:
     from strands_robots.simulation.benchmark import BenchmarkProtocol
 
 from strands_robots.simulation.models import TrajectoryStep
+from strands_robots.simulation.safe_output import validate_output_path, video_sandbox_args
 
 logger = logging.getLogger(__name__)
 
@@ -186,6 +187,10 @@ class VideoConfig:
 
     Attributes:
         path: Output MP4 path. ``None``/empty string → recording disabled.
+            LLM-supplied, so it is validated (no ``..`` traversal, backslash
+            separators, shell metacharacters, or symlinked target) before a
+            writer is opened; set ``STRANDS_ROBOTS_VIDEO_ROOT`` to confine it
+            to a sandbox.
         fps: Frames per second to write.
         camera: Camera name to render from. ``None`` → backend default.
         width: Render width in pixels.
@@ -724,7 +729,17 @@ class PolicyRunner:
         if video is not None and video.enabled:
             # video.enabled guarantees video.path is a non-empty str; narrow for mypy.
             assert video.path is not None
-            video_path = video.path
+            # video.path is LLM-supplied: reject shell metacharacters, backslash
+            # separators, ".." traversal, and a symlinked target before we
+            # makedirs + open a writer on it. Absolute paths stay allowed (the
+            # historic contract); set STRANDS_ROBOTS_VIDEO_ROOT to sandbox them.
+            _sb_root, _allow_abs = video_sandbox_args()
+            try:
+                video_path = str(
+                    validate_output_path(video.path, sandbox_root=_sb_root, allow_abs=_allow_abs, label="video path")
+                )
+            except ValueError as _e:
+                return {"status": "error", "content": [{"text": f"video recording: {_e}"}]}
 
             # Pre-validate the camera name ONCE before the step loop. This
             # surfaces "camera not found" as a clean up-front error rather

--- a/strands_robots/simulation/safe_output.py
+++ b/strands_robots/simulation/safe_output.py
@@ -1,0 +1,189 @@
+"""Sandboxed validation for LLM-supplied simulation output paths.
+
+Several simulation entry points persist an artifact to a caller-chosen
+filesystem path that originates from an untrusted (LLM tool-call) source:
+
+* ``render(output_path=...)`` - a PNG still,
+* ``run_policy(video={"path": ...})`` - a rollout MP4,
+* ``start_cameras_recording(output_dir=..., name=...)`` - per-camera MP4s.
+
+Left unchecked, such a path is an arbitrary-write vector: ``..`` traversal,
+a symlinked target, shell metacharacters interpolated into a later command, or
+a ``name`` tag carrying path separators can all escape the intended location.
+This module centralizes the guards so every sink shares one implementation
+instead of each re-deriving a partial blacklist.
+
+Two confinement policies are supported, selected per sink:
+
+* **Sandbox (default-on)** - the resolved path must live under a sandbox root
+  (used by ``render``, whose ``output_path`` is a newer, sandboxed-by-design
+  feature). Pass a non-``None`` ``sandbox_root`` with ``allow_abs=False``.
+* **Guards-only (opt-in sandbox)** - absolute paths are permitted (the historic
+  video/recording contract) but the metacharacter, backslash, symlink, and
+  name-traversal guards still apply. Pass ``sandbox_root=None`` (or
+  ``allow_abs=True``); callers opt in to confinement by supplying a root.
+"""
+
+import contextlib
+import os
+import tempfile
+from pathlib import Path
+
+# Shell metacharacters / control bytes that must never appear in an LLM-supplied
+# path: they enable command injection if the path is later interpolated into a
+# shell and serve no purpose in a legitimate filesystem path.
+PATH_BAD_CHARS = frozenset({";", "|", "$", "`", ">", "<", "\n", "\r", "\x00"})
+
+
+def env_flag(name: str) -> bool:
+    """Return True when env var ``name`` is a truthy opt-in (``1``/``true``/``yes``)."""
+    return (os.getenv(name) or "").strip().lower() in ("1", "true", "yes")
+
+
+def resolve_sandbox_root(env_var: str, default_subdir: str) -> Path:
+    """Resolve a sandbox root from ``env_var`` (read at call time).
+
+    Falls back to ``~/.strands_robots/<default_subdir>`` when ``env_var`` is
+    unset. The result is fully resolved (``..`` normalized, symlinks expanded)
+    so confinement checks compare true on-disk locations.
+    """
+    raw = os.getenv(env_var) or str(Path.home() / ".strands_robots" / default_subdir)
+    return Path(raw).expanduser().resolve(strict=False)
+
+
+def _reject_unsafe_chars(value: str, *, label: str) -> None:
+    """Reject empty strings, shell metacharacters, and backslash separators."""
+    if not value or not value.strip():
+        raise ValueError(f"unsafe {label}: empty")
+    if any(b in value for b in PATH_BAD_CHARS):
+        raise ValueError(f"unsafe {label}: shell metacharacters")
+    # Backslash is not a POSIX separator, so "..\\..\\etc" would survive a
+    # "/"-only traversal check. Reject it outright rather than guess intent.
+    if "\\" in value:
+        raise ValueError(f"unsafe {label}: backslash separators not allowed")
+
+
+def validate_output_path(
+    output_path: str,
+    *,
+    sandbox_root: Path | None,
+    allow_abs: bool,
+    label: str = "output_path",
+) -> Path:
+    """Validate and resolve an LLM-supplied output path (file or directory).
+
+    Always rejects shell metacharacters, backslash separators, and a symlinked
+    target. Normalizes ``..`` via ``resolve()``. When ``sandbox_root`` is given
+    and ``allow_abs`` is False, the resolved path must live under it.
+
+    Args:
+        output_path: Caller-supplied destination path.
+        sandbox_root: Directory the path must resolve under, or ``None`` to skip
+            confinement (guards-only mode).
+        allow_abs: When True, skip the sandbox confinement check even if
+            ``sandbox_root`` is provided (explicit absolute-path opt-in).
+        label: Noun used in error messages (e.g. ``"output_path"``/``"output_dir"``).
+
+    Returns:
+        The fully-resolved destination ``Path``.
+
+    Raises:
+        ValueError: If the path is unsafe (callers map this to a tool error).
+    """
+    _reject_unsafe_chars(output_path, label=label)
+
+    raw = Path(output_path).expanduser()
+    # Reject ".." traversal segments outright (defense-in-depth): even in
+    # guards-only mode (no sandbox root) this blocks escaping the intended
+    # directory, while plain absolute paths without ".." remain permitted.
+    if ".." in raw.parts:
+        raise ValueError(f"unsafe {label}: path traversal")
+    # Refuse to follow a symlink planted at the target (arbitrary-write vector).
+    if raw.is_symlink():
+        raise ValueError(f"{label} {output_path!r} is a symlink - refusing to follow")
+
+    # resolve() normalizes "..", expands the chain, and follows any intermediate
+    # symlinks, so the confinement check below sees the true on-disk destination.
+    resolved = raw.resolve(strict=False)
+
+    if sandbox_root is not None and not allow_abs:
+        try:
+            resolved.relative_to(sandbox_root)
+        except ValueError as e:
+            raise ValueError(
+                f"{label} {resolved} is outside the sandbox {sandbox_root} "
+                "(set the corresponding *_ALLOW_ABS env var to permit absolute paths)"
+            ) from e
+    return resolved
+
+
+def video_sandbox_args() -> tuple[Path | None, bool]:
+    """Return ``(sandbox_root, allow_abs)`` for video / recording output paths.
+
+    Unlike ``render``, the video and camera-recording sinks have historically
+    accepted arbitrary absolute paths, so confinement is OPT-IN: when
+    ``STRANDS_ROBOTS_VIDEO_ROOT`` is set, writes are confined to it (and
+    ``STRANDS_ROBOTS_VIDEO_ALLOW_ABS`` re-permits absolute paths inside that
+    mode); otherwise absolute paths are allowed. The metacharacter, backslash,
+    symlink, and traversal guards in :func:`validate_output_path` apply in
+    either mode.
+    """
+    if os.getenv("STRANDS_ROBOTS_VIDEO_ROOT"):
+        return (
+            resolve_sandbox_root("STRANDS_ROBOTS_VIDEO_ROOT", "videos"),
+            env_flag("STRANDS_ROBOTS_VIDEO_ALLOW_ABS"),
+        )
+    return None, True
+
+
+def sanitize_name_component(name: str, *, label: str = "name") -> str:
+    """Validate a filename tag that will be interpolated into an output path.
+
+    A ``name`` that carries path separators or ``..`` can escape the directory
+    it is joined into (e.g. ``name="../../etc/x"`` -> a write outside
+    ``output_dir``). Reject separators, traversal, metacharacters, and leading
+    dots rather than silently sanitizing, so the caller sees the rejection.
+
+    Args:
+        name: Caller-supplied filename tag.
+        label: Noun used in error messages.
+
+    Returns:
+        The validated ``name`` unchanged.
+
+    Raises:
+        ValueError: If ``name`` is unsafe as a single path component.
+    """
+    _reject_unsafe_chars(name, label=label)
+    if "/" in name or "\\" in name:
+        raise ValueError(f"unsafe {label}: path separators not allowed")
+    if name in (".", "..") or name.startswith(".."):
+        raise ValueError(f"unsafe {label}: path traversal")
+    return name
+
+
+def atomic_write_bytes(path: Path, data: bytes) -> None:
+    """Write ``data`` to ``path`` atomically with owner-only permissions.
+
+    Writes to a temp file in the destination directory then ``os.replace``s it
+    into place, so a crash mid-write cannot truncate or corrupt an existing file
+    at ``path``. A newly created parent directory is ``0o700`` and the final
+    file is ``0o600`` (the sim output roots are private to the running user).
+    """
+    parent = path.parent
+    parent_existed = parent.exists()
+    parent.mkdir(parents=True, exist_ok=True)
+    if not parent_existed:
+        with contextlib.suppress(OSError):
+            os.chmod(parent, 0o700)
+
+    fd, tmp = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp", dir=parent)
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(data)
+        os.replace(tmp, path)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp)
+        raise
+    os.chmod(path, 0o600)

--- a/tests/simulation/mujoco/test_render_output_path.py
+++ b/tests/simulation/mujoco/test_render_output_path.py
@@ -1,7 +1,7 @@
 """Security regression tests for render(output_path=...) path hardening.
 
 Exercises the pure helpers behind ``MuJoCoSimEngine.render(output_path=...)``
-(:func:`_validate_render_output_path`, :func:`_atomic_write_png`,
+(:func:`_validate_render_output_path`, :func:`~strands_robots.simulation.safe_output.atomic_write_bytes`,
 :func:`_save_render_png`). These are GL-free so they run in CI without an
 OpenGL context and on both Linux and macOS.
 """
@@ -13,10 +13,10 @@ import pytest
 
 from strands_robots.simulation.mujoco import rendering
 from strands_robots.simulation.mujoco.rendering import (
-    _atomic_write_png,
     _save_render_png,
     _validate_render_output_path,
 )
+from strands_robots.simulation.safe_output import atomic_write_bytes
 
 PNG = b"\x89PNG\r\n\x1a\n" + b"x" * 64
 
@@ -118,7 +118,7 @@ def test_atomic_write_preserves_existing_on_failure(sandbox, monkeypatch):
 
     monkeypatch.setattr(rendering.os, "replace", boom)
     with pytest.raises(OSError, match="simulated replace failure"):
-        _atomic_write_png(target, b"NEW-DATA-THAT-SHOULD-NOT-LAND")
+        atomic_write_bytes(target, b"NEW-DATA-THAT-SHOULD-NOT-LAND")
 
     # Original content preserved; no stray temp files left behind.
     assert target.read_bytes() == b"ORIGINAL"

--- a/tests/simulation/test_output_path_sandbox.py
+++ b/tests/simulation/test_output_path_sandbox.py
@@ -1,0 +1,185 @@
+"""Security tests for LLM-supplied simulation output-path guards.
+
+Exercises the pure helpers in :mod:`strands_robots.simulation.safe_output` that
+back ``run_policy(video={"path": ...})`` and
+``start_cameras_recording(output_dir=..., name=...)``: metacharacter / backslash
+/ symlink / traversal rejection, opt-in sandbox confinement, atomic writes, and
+filename-component sanitization. GL-free so they run in CI without an OpenGL
+context and on both Linux and macOS.
+"""
+
+import os
+import sys
+
+import pytest
+
+from strands_robots.simulation.safe_output import (
+    atomic_write_bytes,
+    env_flag,
+    sanitize_name_component,
+    validate_output_path,
+    video_sandbox_args,
+)
+
+# --- guards that apply unconditionally (guards-only mode: sandbox_root=None) ---
+
+
+@pytest.mark.parametrize("meta", [";", "|", "$", "`", ">", "<", "\n", "\r", "\x00"])
+def test_rejects_shell_metacharacters(meta):
+    """A path containing any shell metacharacter is rejected."""
+    with pytest.raises(ValueError, match="metacharacters"):
+        validate_output_path(f"clip{meta}.mp4", sandbox_root=None, allow_abs=True)
+
+
+def test_rejects_backslash_separator():
+    """Backslash separators (Windows-style traversal) are rejected outright."""
+    with pytest.raises(ValueError, match="backslash"):
+        validate_output_path("..\\..\\etc\\passwd", sandbox_root=None, allow_abs=True)
+
+
+def test_rejects_empty():
+    """An empty / whitespace-only path is rejected."""
+    with pytest.raises(ValueError, match="empty"):
+        validate_output_path("   ", sandbox_root=None, allow_abs=True)
+
+
+def test_rejects_symlink_target(tmp_path):
+    """A symlink planted at the target is refused (arbitrary-write vector)."""
+    victim = tmp_path / "victim.mp4"
+    victim.write_bytes(b"important")
+    link = tmp_path / "clip.mp4"
+    link.symlink_to(victim)
+    with pytest.raises(ValueError, match="symlink"):
+        validate_output_path(str(link), sandbox_root=None, allow_abs=True)
+
+
+@pytest.mark.parametrize("bad", ["../escape.mp4", "../../etc/x.mp4", "sub/../../etc/x.mp4"])
+def test_rejects_traversal_even_without_sandbox(bad):
+    """`..` segments are rejected outright, even in guards-only mode."""
+    with pytest.raises(ValueError, match="traversal"):
+        validate_output_path(bad, sandbox_root=None, allow_abs=True)
+
+
+def test_allows_plain_absolute_path_without_sandbox(tmp_path):
+    """A plain absolute path (no `..`) is permitted in guards-only mode."""
+    target = tmp_path / "sub" / "clip.mp4"
+    resolved = validate_output_path(str(target), sandbox_root=None, allow_abs=True)
+    assert resolved == target.resolve()
+
+
+# --- opt-in sandbox confinement ------------------------------------------------
+
+
+def test_sandbox_rejects_path_outside_root(tmp_path):
+    """With a sandbox root and allow_abs=False, a path outside it is rejected."""
+    root = tmp_path / "videos"
+    root.mkdir()
+    with pytest.raises(ValueError, match="outside the sandbox"):
+        validate_output_path("/etc/cron.d/evil", sandbox_root=root.resolve(), allow_abs=False)
+
+
+def test_sandbox_rejects_traversal_escape(tmp_path):
+    """`..` that would escape the sandbox root is rejected as traversal."""
+    root = tmp_path / "videos"
+    root.mkdir()
+    escape = root / ".." / "outside.mp4"
+    with pytest.raises(ValueError, match="traversal"):
+        validate_output_path(str(escape), sandbox_root=root.resolve(), allow_abs=False)
+
+
+def test_sandbox_accepts_path_inside_root(tmp_path):
+    """A path inside the sandbox root resolves cleanly."""
+    root = tmp_path / "videos"
+    root.mkdir()
+    target = root / "sub" / "clip.mp4"
+    resolved = validate_output_path(str(target), sandbox_root=root.resolve(), allow_abs=False)
+    assert resolved == target.resolve()
+
+
+def test_allow_abs_bypasses_sandbox(tmp_path):
+    """allow_abs=True permits an absolute path outside the sandbox root."""
+    root = tmp_path / "videos"
+    root.mkdir()
+    resolved = validate_output_path(str(tmp_path / "elsewhere.mp4"), sandbox_root=root.resolve(), allow_abs=True)
+    assert resolved == (tmp_path / "elsewhere.mp4").resolve()
+
+
+# --- video_sandbox_args env policy --------------------------------------------
+
+
+def test_video_sandbox_args_default_allows_abs(monkeypatch):
+    """Without STRANDS_ROBOTS_VIDEO_ROOT, video paths are unconfined (historic contract)."""
+    monkeypatch.delenv("STRANDS_ROBOTS_VIDEO_ROOT", raising=False)
+    root, allow_abs = video_sandbox_args()
+    assert root is None
+    assert allow_abs is True
+
+
+def test_video_sandbox_args_confines_when_root_set(monkeypatch, tmp_path):
+    """Setting STRANDS_ROBOTS_VIDEO_ROOT switches to sandbox-confined mode."""
+    monkeypatch.setenv("STRANDS_ROBOTS_VIDEO_ROOT", str(tmp_path / "vids"))
+    monkeypatch.delenv("STRANDS_ROBOTS_VIDEO_ALLOW_ABS", raising=False)
+    root, allow_abs = video_sandbox_args()
+    assert root == (tmp_path / "vids").resolve()
+    assert allow_abs is False
+
+
+def test_video_sandbox_args_allow_abs_override(monkeypatch, tmp_path):
+    """STRANDS_ROBOTS_VIDEO_ALLOW_ABS re-permits absolute paths inside sandbox mode."""
+    monkeypatch.setenv("STRANDS_ROBOTS_VIDEO_ROOT", str(tmp_path / "vids"))
+    monkeypatch.setenv("STRANDS_ROBOTS_VIDEO_ALLOW_ABS", "1")
+    _, allow_abs = video_sandbox_args()
+    assert allow_abs is True
+
+
+@pytest.mark.parametrize("val,expected", [("1", True), ("true", True), ("YES", True), ("0", False), ("", False)])
+def test_env_flag(monkeypatch, val, expected):
+    """env_flag treats 1/true/yes (case-insensitive) as opt-in."""
+    monkeypatch.setenv("SOME_FLAG", val)
+    assert env_flag("SOME_FLAG") is expected
+
+
+# --- name-component sanitization (interpolated into per-camera filenames) ------
+
+
+@pytest.mark.parametrize("bad", ["../escape", "a/b", "a\\b", "..", ".", "rec;rm", "..leading"])
+def test_sanitize_name_rejects_unsafe(bad):
+    """A recording `name` carrying separators / traversal / metachars is rejected."""
+    with pytest.raises(ValueError):
+        sanitize_name_component(bad)
+
+
+@pytest.mark.parametrize("ok", ["rec_01", "grasp-cube", "episode.0", "T1"])
+def test_sanitize_name_accepts_safe(ok):
+    """A plain filename tag passes through unchanged."""
+    assert sanitize_name_component(ok) == ok
+
+
+# --- atomic write --------------------------------------------------------------
+
+
+def test_atomic_write_creates_file_with_owner_perms(tmp_path):
+    """atomic_write_bytes writes the payload and sets 0o600 / 0o700 perms."""
+    target = tmp_path / "deep" / "clip.bin"
+    atomic_write_bytes(target, b"payload")
+    assert target.read_bytes() == b"payload"
+    if sys.platform != "win32":
+        assert oct(target.stat().st_mode & 0o777) == "0o600"
+        assert oct((tmp_path / "deep").stat().st_mode & 0o777) == "0o700"
+
+
+def test_atomic_write_preserves_existing_on_failure(tmp_path, monkeypatch):
+    """If os.replace fails mid-write, the existing target and dir are untouched."""
+    target = tmp_path / "keep.bin"
+    target.write_bytes(b"ORIGINAL")
+
+    def boom(_src, _dst):
+        raise OSError("simulated replace failure")
+
+    monkeypatch.setattr(os, "replace", boom)
+    with pytest.raises(OSError, match="simulated replace failure"):
+        atomic_write_bytes(target, b"NEW-DATA-THAT-SHOULD-NOT-LAND")
+
+    assert target.read_bytes() == b"ORIGINAL"
+    leftovers = [p for p in target.parent.iterdir() if p.name.endswith(".tmp")]
+    assert leftovers == []


### PR DESCRIPTION
## Problem

PR #929 hardened `render(output_path=...)` against path traversal, symlink, oversize, and partial-write corruption. But `render` was only one of several simulation entry points that persist an **LLM-supplied filesystem path** to disk. Two sibling video sinks were left with the old, weaker pattern:

- `run_policy(video={"path": ...})` (`policy_runner.py`) did `os.makedirs(os.path.dirname(os.path.abspath(video_path)))` and opened an imageio writer on the raw path with **no validation at all**.
- `start_cameras_recording(output_dir=..., name=...)` and `start_cameras_recording_synchronous(...)` (`rendering.py`) did `os.path.abspath(output_dir)` + `os.makedirs(...)` with no validation, and interpolated the raw `name` tag directly into the per-camera filename `{tag}__{cam}.mp4` — so `name="../../x"` escapes `output_dir`.

Because these paths come from an LLM tool call, a `..` traversal, a symlinked target, shell metacharacters, or a `name` carrying path separators could write outside the intended location.

## Change

Centralize the guards in a new module `strands_robots/simulation/safe_output.py` and share them across all three sinks (single source of truth — `render` now delegates to it instead of keeping its own copy):

- `validate_output_path(...)` — rejects `..` traversal segments, backslash separators, shell metacharacters (`;|$` `` ` `` `><` NUL, CR/LF), empty paths, and a symlinked target; normalizes and (optionally) confines to a sandbox root.
- `sanitize_name_component(...)` — validates the recording `name` as a single path component (no separators / traversal / metacharacters).
- `atomic_write_bytes(...)` — the atomic temp-file + `os.replace` writer with `0o600`/`0o700` perms (moved out of `rendering.py`).
- `video_sandbox_args()` — the video sinks' sandbox policy.

All three sinks now reject an unsafe path with `status=error` **before any file is opened or ffmpeg process spawns**.

### Backward compatibility

Unlike `render` (sandbox on by default), the video/recording sinks have historically accepted arbitrary **absolute** paths (`/tmp/foo.mp4`, `str(tmp_path)`), and that contract is preserved: absolute paths without `..` are still allowed. Sandbox confinement is **opt-in** via `STRANDS_ROBOTS_VIDEO_ROOT` (`STRANDS_ROBOTS_VIDEO_ALLOW_ABS=1` to re-permit absolute paths inside that mode). The always-on guards (traversal, backslash, metacharacters, symlink, name-injection) close the sharpest edges without breaking existing callers. `render`'s behavior and `STRANDS_ROBOTS_RENDER_*` env vars are unchanged.

## Tests

`tests/simulation/test_output_path_sandbox.py` (38 cases): metacharacter / backslash / empty / symlink / traversal rejection, opt-in sandbox confinement + allow-abs override, `env_flag` parsing, `name`-component sanitization, and atomic-write perms + mid-write-failure preservation. The existing render regression test is updated to import the moved `atomic_write_bytes`.

Green locally: `mypy strands_robots tests tests_integ` clean (624 files), `ruff check`/`format` clean, and the sim recording + policy-runner suites pass (`MUJOCO_GL=egl`).

## Rollout in MuJoCo sim (headless)

Mock-policy rollout on `so100`, recorded through the hardened `run_policy(video=...)` path (60 frames, 30 fps, 640x480, 166 KB MP4):

![so100 rollout](https://github.com/cagataycali/robots/releases/download/artifact-sim-video-hardening-1782867886/so100_rollout.gif)

Guard behavior on the same path (rejected before ffmpeg spawns):

```
video={"path": "/tmp/artifacts/so100_rollout.mp4"}  -> success | 60 frames, 30fps, 640x480 | 166 KB
video={"path": "../../etc/cron.d/evil.mp4"}         -> error: video recording: unsafe video path: path traversal
video={"path": "/tmp/x;rm -rf ~.mp4"}              -> error: video recording: unsafe video path: shell metacharacters
video={"path": "..\\..\\etc\\passwd.mp4"}           -> error: video recording: unsafe video path: backslash separators not allowed
```

MP4: https://github.com/cagataycali/robots/releases/download/artifact-sim-video-hardening-1782867886/so100_rollout.mp4

Follow-up to #929.