### PR TITLE
security: remove unregistered mimicgen dep (dependency confusion RCE, CVE-pending)

### DIFF
--- a/docs/policies/vera.md
+++ b/docs/policies/vera.md
@@ -199,5 +199,16 @@ pip install 'strands-robots[vera]'        # provider + the VERA git dep (subproc
 pip install 'strands-robots[vera-sim]'    # + MimicGen sim deps for the example (also pulls the experimental PushT env)
 ```
 
+> **Note on MimicGen.** The `vera-sim` extra does **not** install NVlabs
+> MimicGen: that project has no PyPI release, and the `mimicgen` name on
+> PyPI is an unaffiliated package (a dependency-confusion risk), so it is
+> intentionally not pinned here. The `mimicgen` VERA *embodiment* is just a
+> config string and needs no such package. If you genuinely need NVlabs
+> MimicGen for data generation, install it from source:
+>
+> ```bash
+> pip install "mimicgen @ git+https://github.com/NVlabs/mimicgen.git"
+> ```
+
 For the **docker** path the host needs only `websockets` + `msgpack` (the client
 transport) — no `vera`, no torch.

--- a/examples/vera_mimicgen_panda/README.md
+++ b/examples/vera_mimicgen_panda/README.md
@@ -48,6 +48,16 @@ so the provider:
    arm joints are read back by qpos address (robust to free-body DOFs).
 4. The gripper column is binarized and routed to the Panda's finger joints.
 
+> **Note.** This demo uses VERA's `mimicgen` *embodiment* (a config string),
+> not the NVlabs MimicGen package -- which has no PyPI release. The
+> `mimicgen` name on PyPI is unaffiliated (a dependency-confusion risk) and
+> is intentionally not a dependency. If you need NVlabs MimicGen for data
+> generation, install it from source:
+>
+> ```bash
+> pip install "mimicgen @ git+https://github.com/NVlabs/mimicgen.git"
+> ```
+
 ## See also
 
 - Provider docs: [`docs/policies/vera.md`](../../docs/policies/vera.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -293,7 +293,13 @@ vera-sim = [
     "gym-pusht==0.1.5",
     "robomimic==0.5.0",
     "robosuite==1.4.1",
-    "mimicgen==1.0.0",
+    # MimicGen (NVlabs) is NOT published to PyPI -- the `mimicgen` name on PyPI
+    # is an unaffiliated third-party package, so pinning it here is a
+    # dependency-confusion risk and it is not imported anywhere in the source.
+    # The `mimicgen` VERA *embodiment* is just a config string and does not need
+    # the package. If you genuinely need NVlabs MimicGen for data generation,
+    # install it from source:
+    #     pip install "mimicgen @ git+https://github.com/NVlabs/mimicgen.git"
     "mujoco>=3.5.0",
     "imageio",
 ]

--- a/scripts/audit_deps.py
+++ b/scripts/audit_deps.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Supply-chain audit for the project's declared dependencies.
+
+Guards against two classes of packaging defect:
+
+1. Dependency confusion / name hijacking -- a dependency whose distribution
+   name is known to be unaffiliated with the upstream it claims to be (for
+   example, the ``mimicgen`` name on PyPI is not NVlabs MimicGen, which has
+   never published a release there). Such names are listed in ``DENYLIST`` and
+   must never appear as a PyPI-sourced dependency in ``pyproject.toml``.
+
+2. Nonexistent / typosquat names -- a PyPI-sourced dependency whose name does
+   not resolve on PyPI at all. Catching these early stops a typo from becoming
+   a future confusion target. This check hits the network and is only run when
+   ``--check-pypi`` is passed.
+
+Git-sourced dependencies (``pkg @ git+https://...``) and self-references
+(``strands-robots[...]``) are intentionally excluded: they never resolve from
+PyPI, so neither check applies to them.
+
+Exit code is 0 when the audit passes and 1 when any finding is reported, so the
+script can gate CI directly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import tomllib
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+# Distribution names that must never be pinned as a PyPI dependency because the
+# PyPI name is not controlled by the upstream project it appears to reference.
+# Map name -> reason (surfaced in the failure message).
+DENYLIST: dict[str, str] = {
+    "mimicgen": (
+        "NVlabs MimicGen has no PyPI release; the 'mimicgen' name on PyPI is an "
+        "unaffiliated package (dependency-confusion risk). Install from source: "
+        'pip install "mimicgen @ git+https://github.com/NVlabs/mimicgen.git"'
+    ),
+}
+
+# Leading distribution name in a PEP 508 requirement string.
+_NAME_RE = re.compile(r"^\s*([A-Za-z0-9][A-Za-z0-9._-]*)")
+
+
+def _canonical(name: str) -> str:
+    """Return the PEP 503 canonical (lowercased, dash-normalized) name."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def collect_pypi_dependencies(pyproject_path: Path) -> dict[str, str]:
+    """Return {canonical_name: original_requirement} for PyPI-sourced deps.
+
+    Git/URL-sourced requirements (``name @ <url>``) and self-references to
+    ``strands-robots[...]`` extras are excluded because they never resolve from
+    PyPI.
+    """
+    data = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    project = data.get("project", {})
+    own_name = _canonical(project.get("name", ""))
+    requirements: list[str] = list(project.get("dependencies", []))
+    for deps in project.get("optional-dependencies", {}).values():
+        requirements.extend(deps)
+
+    found: dict[str, str] = {}
+    for req in requirements:
+        stripped = req.strip()
+        name_match = _NAME_RE.match(stripped)
+        if name_match and own_name and _canonical(name_match.group(1)) == own_name:
+            continue  # self-reference to another extra (e.g. pkg[all])
+        if "@" in stripped:
+            continue  # direct URL / git reference, not from PyPI
+        match = _NAME_RE.match(stripped)
+        if not match:
+            continue
+        found.setdefault(_canonical(match.group(1)), stripped)
+    return found
+
+
+def check_denylist(deps: dict[str, str]) -> list[str]:
+    """Return a list of failure messages for any denylisted dependency."""
+    findings = []
+    for name, reason in DENYLIST.items():
+        canonical = _canonical(name)
+        if canonical in deps:
+            findings.append(f"DENYLISTED '{deps[canonical]}': {reason}")
+    return findings
+
+
+def _exists_on_pypi(canonical_name: str, retries: int = 3) -> bool:
+    """Return True if the name resolves on PyPI (404 -> False).
+
+    Transient network / server errors are retried and, if still failing, treated
+    as inconclusive (True) so the audit never fails the build on flakiness -- a
+    definitive 404 is the only signal that fails it.
+    """
+    url = f"https://pypi.org/pypi/{canonical_name}/json"
+    for attempt in range(retries):
+        try:
+            req = urllib.request.Request(url, method="HEAD")
+            with urllib.request.urlopen(req, timeout=15) as resp:
+                return bool(resp.status == 200)
+        except urllib.error.HTTPError as exc:
+            if exc.code == 404:
+                return False
+            # 5xx / rate limit: retry, then treat as inconclusive.
+        except (urllib.error.URLError, TimeoutError, OSError):
+            pass  # network hiccup: retry, then inconclusive
+    return True
+
+
+def check_pypi_existence(deps: dict[str, str]) -> list[str]:
+    """Return failure messages for PyPI-sourced deps that 404 on PyPI."""
+    findings = []
+    for name, req in sorted(deps.items()):
+        if not _exists_on_pypi(name):
+            findings.append(f"NOT ON PYPI '{req}': name '{name}' returns 404 (typo or unregistered?)")
+    return findings
+
+
+def audit(pyproject_path: Path, check_pypi: bool = False) -> list[str]:
+    """Run all enabled checks and return the combined findings list."""
+    deps = collect_pypi_dependencies(pyproject_path)
+    findings = check_denylist(deps)
+    if check_pypi:
+        findings.extend(check_pypi_existence(deps))
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--pyproject",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent / "pyproject.toml",
+        help="Path to pyproject.toml (default: repo root).",
+    )
+    parser.add_argument(
+        "--check-pypi",
+        action="store_true",
+        help="Also verify each PyPI-sourced dependency name resolves on PyPI (network).",
+    )
+    args = parser.parse_args(argv)
+
+    findings = audit(args.pyproject, check_pypi=args.check_pypi)
+    if findings:
+        print("Dependency audit FAILED:", file=sys.stderr)
+        for finding in findings:
+            print(f"  - {finding}", file=sys.stderr)
+        return 1
+    print("Dependency audit passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_dependency_audit.py
+++ b/tests/test_dependency_audit.py
@@ -1,0 +1,91 @@
+"""Supply-chain audit regression tests for declared dependencies.
+
+Pins the guard added after a dependency-confusion finding: the ``mimicgen``
+distribution name on PyPI is not NVlabs MimicGen (which has never published to
+PyPI), so it must never appear as a PyPI-sourced dependency. These tests verify
+both the live ``pyproject.toml`` and that the reusable audit in
+``scripts/audit_deps.py`` actually catches a re-introduction.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_PYPROJECT = _REPO_ROOT / "pyproject.toml"
+_AUDIT_PATH = _REPO_ROOT / "scripts" / "audit_deps.py"
+
+
+def _load_audit_module():
+    spec = importlib.util.spec_from_file_location("audit_deps", _AUDIT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules["audit_deps"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+audit_deps = _load_audit_module()
+
+
+def test_pyproject_has_no_denylisted_pypi_dependency():
+    """The live pyproject must not pin any denylisted name from PyPI."""
+    findings = audit_deps.audit(_PYPROJECT, check_pypi=False)
+    assert findings == [], f"dependency audit reported: {findings}"
+
+
+def test_mimicgen_is_not_a_pypi_dependency():
+    """mimicgen must not be a PyPI-sourced dependency (confusion vector)."""
+    deps = audit_deps.collect_pypi_dependencies(_PYPROJECT)
+    assert "mimicgen" not in deps
+
+
+def test_mimicgen_stays_denylisted():
+    """The guard's denylist must retain mimicgen so re-adds are blocked."""
+    assert "mimicgen" in audit_deps.DENYLIST
+
+
+def test_audit_flags_reintroduced_mimicgen(tmp_path):
+    """Re-adding mimicgen==1.0.0 must make the denylist audit fail."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        "[project]\n"
+        'name = "x"\n'
+        'version = "0"\n'
+        'dependencies = ["numpy>=1.24"]\n'
+        "[project.optional-dependencies]\n"
+        'vera-sim = ["mimicgen==1.0.0", "mujoco>=3.5.0"]\n',
+        encoding="utf-8",
+    )
+    findings = audit_deps.audit(pyproject, check_pypi=False)
+    assert any("mimicgen" in f.lower() for f in findings)
+
+
+def test_git_and_self_reference_deps_are_excluded(tmp_path):
+    """Git-sourced and self-referencing extras are not treated as PyPI deps."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        "[project]\n"
+        'name = "x"\n'
+        'version = "0"\n'
+        'dependencies = ["numpy>=1.24"]\n'
+        "[project.optional-dependencies]\n"
+        'vera = ["vera @ git+https://github.com/sizhe-li/VERA.git"]\n'
+        'all = ["x[vera]"]\n',
+        encoding="utf-8",
+    )
+    deps = audit_deps.collect_pypi_dependencies(pyproject)
+    assert deps == {"numpy": "numpy>=1.24"}
+
+
+def test_denylist_names_are_canonicalized(tmp_path):
+    """A denylisted name is caught regardless of case / dash-underscore form."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        '[project]\nname = "x"\nversion = "0"\ndependencies = ["MimicGen==1.0.0"]\n',
+        encoding="utf-8",
+    )
+    findings = audit_deps.audit(pyproject, check_pypi=False)
+    assert findings, "canonicalized denylist match should fire"


### PR DESCRIPTION
## Summary

The `vera-sim` extra pinned `mimicgen==1.0.0`, but **NVlabs MimicGen has never been published to PyPI**. The `mimicgen` name on PyPI is an unaffiliated third-party package, making this a dependency-confusion vector: `pip install`/resolution would fetch and execute an attacker-controllable distribution at install time, before any project code runs.

The dependency is dead weight from the source's perspective: `grep -rn "import mimicgen\|from mimicgen" src/` returns nothing. The `mimicgen` VERA *embodiment* is only a config string and needs no such package.

## Evidence

The `mimicgen` project on PyPI:
- single release `1.0.0`, uploaded `2026-06-27T12:34:44Z`
- author email `Ai-model@example.com`, summary "A professional-grade AI utility for automated data synchronization and backend management" — unrelated to NVlabs MimicGen (robot data generation)
- real MimicGen lives at `github.com/NVlabs/mimicgen` and has no PyPI release

## Changes

- **Remove `mimicgen==1.0.0`** from the `vera-sim` extra. Replaced with a comment explaining that NVlabs MimicGen is git-only, including the exact source-install command.
- **Docs**: add a MimicGen note to `docs/policies/vera.md` (Install) and `examples/vera_mimicgen_panda/README.md` — the `vera-sim` extra does not install NVlabs MimicGen, and if you need it: `pip install "mimicgen @ git+https://github.com/NVlabs/mimicgen.git"`.
- **`scripts/audit_deps.py`** (stdlib only): a supply-chain checker that fails on (a) any denylisted dependency-confusion name and (b) with `--check-pypi`, any PyPI-sourced dependency name that returns 404 on PyPI (typosquat / unregistered). Git-sourced (`pkg @ git+...`) and self-referencing (`pkg[extra]`) requirements are excluded, and transient PyPI errors are treated as inconclusive so the check never flakes the build — only a definitive 404 fails it.
- **`tests/test_dependency_audit.py`**: regression guard that runs in the existing test suite (CI). It fails on the pre-fix `pyproject.toml` and blocks any `mimicgen` re-introduction (case/dash-insensitive).

## Repo-wide audit for other unregistered pinned deps

Every PyPI-sourced dependency name across `[project.dependencies]` and all extras was checked against PyPI. Findings:
- **`mimicgen`** — the only dependency-confusion case; removed here.
- `robomimic==0.5.0`, `robosuite==1.4.1` (also in `vera-sim`) are legitimate ARISE-Initiative packages — kept.
- `vera @ git+https://github.com/sizhe-li/VERA.git` is git-sourced (not from PyPI) — not affected.
- All other pinned names (`newton`, `libero`, `mujoco-warp`, `device-connect-edge`, `device-connect-agent-tools`, `adam-atan2-pytorch`, `vector-quantize-pytorch`, etc.) resolve on PyPI. `python scripts/audit_deps.py --check-pypi` passes on the fixed tree.

## Scope correction

The `[all]` extra does **not** reference `vera-sim` (it aggregates `groot-service`, `moveit2`, `lerobot`, `sim-mujoco`, `mesh`, `mesh-iot`, `device-connect`, `wbc`, `motionbricks`, `molmoact2` only), so `pip install 'strands-robots[all]'` was **not** affected. The exposure was limited to `pip install 'strands-robots[vera-sim]'` and `pip install -e '.[vera-sim]'`.

## Optional: network-based CI gate

The regression is already enforced by `tests/test_dependency_audit.py` in the existing test job. To additionally block *nonexistent* PyPI names (typosquats) at CI time, a maintainer can add this step to `.github/workflows/test-lint.yml` (kept out of this PR because the automated push credential lacks the `workflow` scope):

```yaml
      - name: Audit dependencies for supply-chain risks
        run: python scripts/audit_deps.py --check-pypi
```

## Verification

- `python scripts/audit_deps.py` (offline denylist) passes on this tree; fails on the pre-fix `pyproject.toml`.
- `python scripts/audit_deps.py --check-pypi` passes (all PyPI-sourced names resolve).
- `pytest tests/test_dependency_audit.py` — 6 passed.
- ruff check + ruff format --check + mypy clean on the new files.

## Migration note for existing installs

Anyone who ran `pip install 'strands-robots[vera-sim]'` or `pip install -e '.[vera-sim]'` since 2026-06-27 should uninstall the package and reinstall into a clean environment:

```bash
pip uninstall -y mimicgen
# then recreate the venv and reinstall strands-robots
```

A private GHSA security advisory draft should be prepared for this repo before any public disclosure; deferring the advisory publication to the maintainers.