### PR TITLE
fix(sim): scale body_inertia with body_mass in MuJoCo randomize_physics

### DIFF
--- a/strands_robots/simulation/mujoco/randomization.py
+++ b/strands_robots/simulation/mujoco/randomization.py
@@ -13,8 +13,9 @@ logger = logging.getLogger(__name__)
 class RandomizationMixin:
     """Domain randomization mixed into ``Simulation``.
 
-    Recolors geoms, perturbs lighting, and scales body mass / geom friction
-    by a random factor inside a user-supplied range.
+    Recolors geoms, perturbs lighting, and scales body mass (with a matching
+    inertia scale, so randomized bodies stay physically consistent) and geom
+    friction by a random factor inside a user-supplied range.
 
     **Coupling** (see simulation.py top-level docstring): mixin reaches
     into ``self._world``, ``self._lock``, and the host's
@@ -67,7 +68,10 @@ class RandomizationMixin:
                                   its material colour, which overrides geom RGB
                                   in the renderer).
             randomize_lighting:   Jitter light positions + diffuse colour.
-            randomize_physics:    Scale geom friction and body mass.
+            randomize_physics:    Scale geom friction and body mass (body
+                                  inertia is scaled by the same factor as the
+                                  mass so each randomized body stays physically
+                                  consistent).
             randomize_positions:  Add uniform noise to dynamic-object xyz.
             position_noise:       Max ± xyz offset in meters when randomising positions.
             color_range:          (lo, hi) for uniform RGB sampling.
@@ -130,6 +134,16 @@ class RandomizationMixin:
                         bn = mj.mj_id2name(model, mj.mjtObj.mjOBJ_BODY, i) or f"body_{i}"
                         s = float(rng.uniform(*mass_range))
                         model.body_mass[i] *= s
+                        # Inertia tracks mass for fixed geometry: scaling a
+                        # rigid body's mass by ``s`` at constant shape (a uniform
+                        # density change) scales its inertia tensor by the same
+                        # ``s`` (I = integral of r^2 dm). Scaling mass alone
+                        # leaves a physically inconsistent body - heavy in
+                        # translation but with the light body's rotational
+                        # resistance - which silently corrupts the dynamics the
+                        # randomization is meant to perturb. Match the Newton
+                        # backend, which scales both.
+                        model.body_inertia[i] *= s
                         mass_scales[bn] = s
                 changes.append(
                     f"Physics: {len(friction_scales)} geoms friction-scaled, {len(mass_scales)} bodies mass-scaled"

--- a/tests/simulation/mujoco/test_simulation.py
+++ b/tests/simulation/mujoco/test_simulation.py
@@ -770,6 +770,46 @@ class TestRandomization:
         assert result["status"] == "success"
         assert "Physics" in result["content"][0]["text"]
 
+    def test_randomize_physics_scales_inertia_with_mass(self, sim_with_robot):
+        """Scaling a body's mass must scale its inertia by the same factor.
+
+        For a rigid body at fixed geometry a mass scale ``s`` (a uniform
+        density change) scales the inertia tensor by the same ``s`` (I is the
+        integral of r^2 dm). Pre-fix ``randomize_physics`` scaled ``body_mass``
+        but left ``body_inertia`` untouched, producing physically inconsistent
+        bodies - heavy in translation but with the light body's rotational
+        resistance - which silently corrupts the dynamics the randomization is
+        meant to perturb (and diverges from the Newton backend, which scales
+        both).
+        """
+        m = sim_with_robot._world._model
+        mass_before = m.body_mass.copy()
+        inertia_before = m.body_inertia.copy()
+
+        result = sim_with_robot.randomize(
+            randomize_colors=False, randomize_lighting=False, randomize_physics=True, seed=42
+        )
+        assert result["status"] == "success"
+
+        mass_after = m.body_mass.copy()
+        inertia_after = m.body_inertia.copy()
+
+        scaled_bodies = [
+            i for i in range(m.nbody) if mass_before[i] > 0 and not np.isclose(mass_before[i], mass_after[i])
+        ]
+        assert scaled_bodies, "the robot must have bodies whose mass was scaled"
+
+        # inertia must actually move (pre-fix it stayed stale) ...
+        assert not np.allclose(inertia_before[scaled_bodies], inertia_after[scaled_bodies])
+        # ... and by exactly the per-body mass factor, keeping each body consistent.
+        for i in scaled_bodies:
+            s = mass_after[i] / mass_before[i]
+            assert np.allclose(inertia_after[i], inertia_before[i] * s, rtol=1e-6), (
+                f"body {i}: inertia scaled by "
+                f"{inertia_after[i] / np.where(inertia_before[i] != 0, inertia_before[i], 1)} "
+                f"but mass scaled by {s}"
+            )
+
     def test_randomize_positions(self, sim_with_world):
         sim_with_world.add_object("cube", shape="box", position=[0, 0, 0.1])
         result = sim_with_world.randomize(randomize_positions=True, seed=42)


### PR DESCRIPTION
## What
`Simulation.randomize(randomize_physics=True)` on the MuJoCo backend scaled every body's `body_mass` by a random factor but left `body_inertia` untouched. This patch scales `body_inertia[i]` by the same factor as `body_mass[i]`, so each randomized body stays physically consistent.

## Why
For a rigid body at fixed geometry, scaling mass by `s` (a uniform density change) scales the inertia tensor by the same `s` (`I = integral of r^2 dm`). Scaling mass alone leaves a body that is heavy in translation but keeps the light body's rotational resistance -- a non-physical body that silently corrupts exactly the dynamics domain randomization is meant to perturb (any contact/torque interaction, and any DR-trained policy, learns on impossible bodies).

The Newton backend already documents and does the right thing: *"Physics randomization scales the builder's `body_mass` and `body_inertia` (inertia tracks mass for fixed geometry ...)"*. The MuJoCo backend diverged from that contract; this brings it back in line.

## Reproduction (pre-fix)
A MuJoCo scene (`so101` + a cube), `randomize_physics=True`:
```
bodies with mass changed:    8/9
inertia entries changed:     0/27   <- every randomized body is now inconsistent
```

## Physical demonstration
A compound pendulum (long rod pivoted 3 cm above its center, so the body's own `I_cm` dominates the parallel-axis term). Its period is `T = 2*pi*sqrt(I_pivot / (m*g*d))` and, because `I` is proportional to `m` for fixed geometry, **must be invariant to a mass-only randomization** -- the textbook fact that a pendulum's period does not depend on its mass. Same start angle, same `randomize_physics` call (mass x3):

| | swing period | drift vs baseline |
|---|---|---|
| baseline (un-randomized) | 2.073 s | - |
| **pre-fix** (stale inertia) | 1.231 s | **-40.6%** (matches theory `1/sqrt(3)-1 = -42.3%`) -- wrong |
| **post-fix** (inertia scaled) | 2.073 s | +0.0% -- correct |

Left = pre-fix bug (swings visibly faster), right = post-fix (period preserved). Rollout rendered in MuJoCo (headless EGL):

![randomize_physics inertia fix](https://github.com/cagataycali/robots/releases/download/artifact-randomize-inertia-1782871742/pendulum_inertia_fix.gif)

## Tests
Adds `test_randomize_physics_scales_inertia_with_mass` (in `tests/simulation/mujoco/`): randomizes a robot's physics and asserts that for every body whose mass changed, `body_inertia` changed by exactly the same per-body factor. It **fails on pre-fix code** (inertia stays stale) and passes after.

`MUJOCO_GL=egl pytest tests/simulation/mujoco/test_simulation.py tests/simulation/newton/test_domain_randomization.py` -> 181 passed. Lint clean (`ruff check`, `ruff format --check`, `mypy strands_robots tests` -> no issues).