### PR TITLE
fix(lerobot_local): empty instruction crashes language-VLA preprocessor with cryptic KeyError

### DIFF
--- a/strands_robots/policies/lerobot_local/processor.py
+++ b/strands_robots/policies/lerobot_local/processor.py
@@ -501,13 +501,20 @@ class ProcessorBridge:
             from lerobot.processor import TransitionKey
             from lerobot.processor.converters import create_transition
 
-            complementary: dict[str, Any] = {}
-            if instruction:
-                complementary["task"] = instruction
-
+            # Always include the "task" key so language-conditioned VLA
+            # pipelines (LeRobot's TokenizerProcessorStep) can find it. An
+            # empty or None instruction is a valid EMPTY task string (""),
+            # which LeRobot tokenizes without complaint. Omitting the key
+            # entirely (the old `if instruction:` guard) makes the tokenizer
+            # step raise a cryptic `KeyError: 'task'` -- the exact failure
+            # this transition-based path exists to avoid, per this method's
+            # docstring. run_policy's own default is `instruction=""`, so the
+            # guard broke the documented default for every language VLA.
+            # Non-language pipelines (ACT, diffusion) have no task-consuming
+            # step and simply ignore the extra complementary key.
             transition = create_transition(
                 observation=observation,
-                complementary_data=complementary if complementary else None,
+                complementary_data={"task": instruction or ""},
             )
             processed = self._preprocessor._forward(transition)
 

--- a/tests/policies/lerobot_local/test_empty_instruction_task_key.py
+++ b/tests/policies/lerobot_local/test_empty_instruction_task_key.py
@@ -18,7 +18,7 @@ import pytest
 
 pytest.importorskip("lerobot.processor.pipeline")
 
-from lerobot.configs import PipelineFeatureType, PolicyFeature  # noqa: E402
+from lerobot.configs.types import PipelineFeatureType, PolicyFeature  # noqa: E402
 from lerobot.processor.pipeline import (  # noqa: E402
     ComplementaryDataProcessorStep,
     DataProcessorPipeline,

--- a/tests/policies/lerobot_local/test_empty_instruction_task_key.py
+++ b/tests/policies/lerobot_local/test_empty_instruction_task_key.py
@@ -1,0 +1,79 @@
+"""Empty instruction must not crash a language-VLA preprocessor.
+
+``run_policy`` documents its instruction default as ``instruction=""``. A
+language-conditioned VLA (SmolVLA, pi0, ...) routes that instruction through
+LeRobot's ``TokenizerProcessorStep``, which reads ``complementary_data["task"]``.
+If :class:`ProcessorBridge` omits the ``task`` key when the instruction is
+empty, that indexing raises a cryptic ``KeyError: 'task'`` -- the exact failure
+the bridge's transition-based path exists to avoid (see ``preprocess`` docstring).
+
+These tests build a real (network-free) LeRobot ``DataProcessorPipeline`` whose
+single step mimics the tokenizer's ``["task"]`` access, so the regression is
+verified against real LeRobot pipeline internals, not a mock of the bridge.
+"""
+
+from typing import Any
+
+import pytest
+
+pytest.importorskip("lerobot.processor.pipeline")
+
+from lerobot.configs import PipelineFeatureType, PolicyFeature  # noqa: E402
+from lerobot.processor.pipeline import (  # noqa: E402
+    ComplementaryDataProcessorStep,
+    DataProcessorPipeline,
+)
+
+from strands_robots.policies.lerobot_local.processor import ProcessorBridge  # noqa: E402
+
+
+class _RequiresTaskStep(ComplementaryDataProcessorStep):
+    """Minimal stand-in for LeRobot's TokenizerProcessorStep.
+
+    Indexes ``complementary_data["task"]`` exactly like the real tokenizer's
+    ``get_task``, so a missing key reproduces the production ``KeyError: 'task'``.
+    Records the task it saw so tests can assert the empty-instruction value.
+    """
+
+    def __init__(self) -> None:
+        self.seen_task: Any = "<unset>"
+
+    def complementary_data(self, complementary_data: dict[str, Any]) -> dict[str, Any]:
+        self.seen_task = complementary_data["task"]  # KeyError: 'task' if absent
+        return complementary_data
+
+    def transform_features(
+        self, features: dict[PipelineFeatureType, dict[str, PolicyFeature]]
+    ) -> dict[PipelineFeatureType, dict[str, PolicyFeature]]:
+        return features
+
+
+def _bridge_with_task_step() -> tuple[ProcessorBridge, _RequiresTaskStep]:
+    step = _RequiresTaskStep()
+    pipe = DataProcessorPipeline(steps=[step])
+    return ProcessorBridge(preprocessor=pipe, device="cpu"), step
+
+
+_OBS = {"observation.state": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]}
+
+
+def test_empty_instruction_does_not_raise_key_error():
+    """The documented ``instruction=""`` default must reach the tokenizer step."""
+    bridge, step = _bridge_with_task_step()
+    # Pre-fix this raised RuntimeError("Preprocessor pipeline failed: 'task'").
+    bridge.preprocess(dict(_OBS), instruction="")
+    assert step.seen_task == ""
+
+
+def test_none_instruction_does_not_raise_key_error():
+    """A ``None`` instruction is also a valid empty task, not a crash."""
+    bridge, step = _bridge_with_task_step()
+    bridge.preprocess(dict(_OBS), instruction=None)
+    assert step.seen_task == ""
+
+
+def test_non_empty_instruction_still_forwarded_verbatim():
+    """A real instruction must still reach the tokenizer unchanged."""
+    bridge, step = _bridge_with_task_step()
+    bridge.preprocess(dict(_OBS), instruction="pick up the red cube")
+    assert step.seen_task == "pick up the red cube"


### PR DESCRIPTION
## Problem
`Simulation.run_policy` documents its instruction default as `instruction=""`. A language-conditioned VLA (SmolVLA, pi0, ...) routes that instruction through LeRobot's `TokenizerProcessorStep`, which reads `complementary_data["task"]`. `ProcessorBridge.preprocess` only set that key `if instruction:`, so an empty (or `None`) instruction produced `complementary_data=None`; LeRobot then indexes an empty dict and the bridge re-raises it as:

```
RuntimeError: Preprocessor pipeline failed: 'task'
```

Calling `run_policy` with a SmolVLA policy and no explicit instruction — i.e. the documented default — therefore crashes with an unactionable message. This is the exact failure `preprocess`'s own docstring says the transition-based path exists to avoid.

Minimal repro:
```python
sim.run_policy(
    robot_name="so101", policy_provider="lerobot_local",
    policy_config={"pretrained_name_or_path": "lerobot/smolvla_base",
                   "policy_type": "smolvla",
                   "image_keys": ["camera1", "camera2", "camera3"]},
    instruction="",   # -> RuntimeError: Preprocessor pipeline failed: 'task'
)
```

## Fix
Always include the `task` key, using the instruction as an empty task string (`""`) when it is empty/`None`. LeRobot tokenizes an empty task without complaint (`get_task("") -> [""]`, and the newline step turns it into `"\n"`). Non-language pipelines (ACT, diffusion) have no task-consuming step and simply ignore the extra complementary key.

## Tests
`tests/policies/lerobot_local/test_empty_instruction_task_key.py` builds a real, network-free LeRobot `DataProcessorPipeline` whose single step mimics the tokenizer's `["task"]` access, so the regression is verified against real LeRobot internals rather than a bridge mock. The empty- and `None`-instruction cases **fail pre-fix** with the production `Preprocessor pipeline failed: 'task'` and pass after; a non-empty control passes both ways.

- `ruff check` / `ruff format`: clean
- `mypy` on changed files: clean
- `pytest tests/policies/lerobot_local/`: 463 passed

## Rollout (MuJoCo, headless)
SmolVLA on an SO-101 with `instruction=""` — previously a hard crash, now runs the full 90-step rollout (arm settles the cube; zero-shot does not grasp, which is expected and orthogonal to this fix):

![empty-instruction rollout](https://github.com/cagataycali/robots/releases/download/artifact-empty-instr-1782878040/empty_instr.gif)