### PR TITLE
docs(sim): correct MuJoCoSimEngine __init__ **kwargs docstring to match runtime behavior

### DIFF
--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -185,8 +185,15 @@ class MuJoCoSimEngine(
             peer_id: Stable identifier the mesh transport uses to
                 address this Simulation. Opaque to MuJoCo itself; only
                 consulted when ``mesh`` is truthy.
-            **kwargs: Forwarded to ``AgentTool.__init__`` for subclass
-                compatibility.
+            **kwargs: Accepted and ignored, for cross-backend forward
+                compatibility. The shared ``create_simulation`` / ``Robot``
+                factory forwards one superset of keyword arguments to whichever
+                backend is selected; MuJoCo tolerates and drops backend-specific
+                kwargs it does not use (e.g. ``num_envs`` / ``device`` meant for
+                GPU backends) so an identical call resolves across backends.
+                Mirrors ``NewtonSimEngine``'s forward-compatible contract. Note
+                they are NOT passed to ``super().__init__()`` (``AgentTool``
+                takes no constructor arguments).
         """
         super().__init__()
         self._init_ros_bridge(ros2_bridge=ros2_bridge, ros2_domain=ros2_domain)

--- a/tests/simulation/mujoco/test_simulation.py
+++ b/tests/simulation/mujoco/test_simulation.py
@@ -190,6 +190,37 @@ def sim_with_robot(sim_with_world, robot_xml_path):
 # World Management
 
 
+class TestConstructorForwardCompatKwargs:
+    """The engine constructor accepts and ignores backend-specific kwargs.
+
+    The shared ``create_simulation`` / ``Robot`` factory forwards one superset
+    of keyword arguments to whichever backend is selected. MuJoCo tolerates and
+    drops kwargs it does not use (e.g. ``num_envs`` / ``device`` meant for GPU
+    backends), mirroring ``NewtonSimEngine``, so an identical factory call
+    resolves across backends. This pins that documented forward-compatible
+    contract: unknown kwargs must neither raise nor disturb recognized params.
+    """
+
+    def test_unknown_kwargs_are_ignored_not_raised(self):
+        sim = Simulation(num_envs=4, device="cuda", some_future_backend_kwarg=True)
+        assert sim._world is None  # construction only; no world yet
+        sim.cleanup()
+
+    def test_recognized_params_survive_alongside_unknown_kwargs(self):
+        sim = Simulation(
+            tool_name="factory_sim",
+            default_width=320,
+            default_height=240,
+            num_envs=8,  # forwarded-but-ignored backend kwarg
+        )
+        assert sim.tool_name_str == "factory_sim"
+        assert sim.default_width == 320
+        assert sim.default_height == 240
+        # The ignored kwarg leaves no stray attribute behind.
+        assert not hasattr(sim, "num_envs")
+        sim.cleanup()
+
+
 class TestWorldLifecycle:
     """Test create_world → get_state → reset → destroy lifecycle."""
 


### PR DESCRIPTION
## Problem

`MuJoCoSimEngine.__init__` documents its `**kwargs` as:

> **kwargs: Forwarded to `AgentTool.__init__` for subclass compatibility.

That is not what the code does. `__init__` calls `super().__init__()` with **no arguments**, and `AgentTool.__init__(self)` takes none, so `**kwargs` is captured and silently dropped -- nothing is forwarded anywhere. A reader trusting the docstring would expect a mistyped or misplaced kwarg to reach `AgentTool`; instead it vanishes, and a downstream call (`run_policy` -> `No world`) is the first sign anything was off.

## Change

Correct the docstring to describe the actual, intentional behavior: `**kwargs` is **accepted and ignored** for cross-backend forward compatibility. The shared `create_simulation` / `Robot` factory forwards one superset of keyword arguments to whichever backend is selected, and MuJoCo tolerates-and-drops backend-specific kwargs it does not use (e.g. `num_envs` / `device` meant for GPU backends). This mirrors `NewtonSimEngine`, whose `**kwargs` is already documented honestly as "Ignored; accepted for forward compatibility" -- so the two backends now describe the same contract consistently.

No behavior change: the constructor already ignored these kwargs. This aligns the documentation with the code (code is the source of truth).

## Tests

Adds `TestConstructorForwardCompatKwargs` pinning the contract so it cannot silently drift:
- `test_unknown_kwargs_are_ignored_not_raised`: `Simulation(num_envs=4, device="cuda", some_future_backend_kwarg=True)` constructs cleanly (no `TypeError`).
- `test_recognized_params_survive_alongside_unknown_kwargs`: recognized params (`tool_name`, `default_width`, `default_height`) still take effect alongside an ignored backend kwarg, and the ignored kwarg leaves no stray attribute.

If a future change made the constructor reject unknown kwargs (breaking cross-backend factory forwarding), the first test fails.

## Verification

- `ruff check` / `ruff format --check` clean; `mypy strands_robots tests tests_integ` -> no issues.
- `MUJOCO_GL=egl pytest tests/simulation/mujoco/test_simulation.py` -> 146 passed (incl. the 2 new).