### PR TITLE
test(sim): cover NVIDIA EGL vendor-ICD scan resilience and staging fallbacks

### DIFF
--- a/tests/simulation/mujoco/test_nvidia_egl_icd.py
+++ b/tests/simulation/mujoco/test_nvidia_egl_icd.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import sys
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -154,3 +155,100 @@ class TestConfigureGLBackendWiring:
                 assert called == [True]
             finally:
                 backend.os.environ.pop("MUJOCO_GL", None)
+
+
+class TestNvidiaIcdScanResilience:
+    """Host-detection scans are best-effort: an unreadable glvnd dir or vendor
+    JSON must be skipped, never abort the scan, so a later real match is still
+    found. Staging failures leave glvnd's default routing untouched rather than
+    crashing MuJoCo import.
+    """
+
+    def test_library_scan_skips_unreadable_dir_and_finds_later_match(self, monkeypatch, tmp_path):
+        """A permission error globbing one lib dir does not hide an NVIDIA library
+        installed in a subsequent dir."""
+        denied = tmp_path / "denied"
+        lib_dir = tmp_path / "lib"
+        lib_dir.mkdir()
+        (lib_dir / "libEGL_nvidia.so.580.1").write_text("")
+        real_glob = Path.glob
+
+        def flaky_glob(self, pattern, *args, **kwargs):
+            if str(self) == str(denied):
+                raise PermissionError("EACCES")
+            return real_glob(self, pattern, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "glob", flaky_glob)
+        monkeypatch.setattr(backend, "_NVIDIA_EGL_LIB_DIRS", (str(denied), str(lib_dir)))
+
+        assert backend._nvidia_egl_library_present() is True
+
+    def test_icd_scan_skips_unreadable_dir_and_unreadable_json(self, monkeypatch, tmp_path):
+        """An unreadable vendor dir and an unreadable JSON entry are both skipped;
+        a readable NVIDIA vendor JSON still registers as present."""
+        denied_dir = tmp_path / "denied_dir"
+        vendor_dir = tmp_path / "vendor"
+        vendor_dir.mkdir()
+        # sorted() visits 00_broken.json (unreadable) before 10_nvidia.json.
+        (vendor_dir / "00_broken.json").write_text("unreadable")
+        (vendor_dir / "10_nvidia.json").write_text(backend._NVIDIA_EGL_ICD_JSON)
+        real_glob = Path.glob
+        real_read = Path.read_text
+
+        def flaky_glob(self, pattern, *args, **kwargs):
+            if str(self) == str(denied_dir):
+                raise PermissionError("EACCES")
+            return real_glob(self, pattern, *args, **kwargs)
+
+        def flaky_read(self, *args, **kwargs):
+            if self.name == "00_broken.json":
+                raise PermissionError("EACCES")
+            return real_read(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "glob", flaky_glob)
+        monkeypatch.setattr(Path, "read_text", flaky_read)
+        monkeypatch.setattr(backend, "_GLVND_EGL_VENDOR_DIRS", (str(denied_dir), str(vendor_dir)))
+
+        assert backend._nvidia_egl_icd_registered() is True
+
+    def test_staging_write_failure_is_nonfatal(self, isolate):
+        """When the user base dir is not writable, staging fails soft: glvnd's
+        default routing is left in place (no __EGL_VENDOR_LIBRARY_FILENAMES)."""
+        isolate.setattr(backend, "_nvidia_egl_icd_registered", lambda: False)
+        isolate.setattr(backend, "_nvidia_egl_library_present", lambda: True)
+
+        def boom(self, *args, **kwargs):
+            raise OSError("read-only file system")
+
+        isolate.setattr(Path, "write_text", boom)
+
+        backend._ensure_nvidia_egl_vendor_icd()
+
+        assert _FILENAMES not in backend.os.environ
+
+    def test_staged_filenames_list_nvidia_first_then_system_fallbacks(self, isolate, tmp_path):
+        """The staged vendor list puts the NVIDIA ICD first (wins glvnd resolution)
+        and appends readable system vendor ICDs as fallback, skipping any vendor
+        dir that cannot be listed."""
+        isolate.setattr(backend, "_nvidia_egl_icd_registered", lambda: False)
+        isolate.setattr(backend, "_nvidia_egl_library_present", lambda: True)
+        system_vendor = tmp_path / "system_glvnd"
+        system_vendor.mkdir()
+        (system_vendor / "50_mesa.json").write_text("{}")
+        denied_vendor = tmp_path / "denied_glvnd"
+        real_glob = Path.glob
+
+        def flaky_glob(self, pattern, *args, **kwargs):
+            if str(self) == str(denied_vendor):
+                raise PermissionError("EACCES")
+            return real_glob(self, pattern, *args, **kwargs)
+
+        isolate.setattr(Path, "glob", flaky_glob)
+        isolate.setattr(backend, "_GLVND_EGL_VENDOR_DIRS", (str(denied_vendor), str(system_vendor)))
+
+        backend._ensure_nvidia_egl_vendor_icd()
+
+        filenames = backend.os.environ[_FILENAMES].split(":")
+        staged = tmp_path / "egl_vendor.d" / "10_nvidia.json"
+        assert filenames[0] == str(staged)
+        assert filenames[-1] == str(system_vendor / "50_mesa.json")


### PR DESCRIPTION
## Problem

When `MUJOCO_GL=egl` on an NVIDIA host whose glvnd vendor directory is missing `10_nvidia.json` (common in CUDA base images without the `graphics` capability), libglvnd silently routes offscreen rendering to Mesa `llvmpipe` (CPU, ~100x slower). The MuJoCo backend defends against this by staging a user-writable NVIDIA vendor ICD and pointing glvnd at it via `__EGL_VENDOR_LIBRARY_FILENAMES`.

The host-detection scans (`_nvidia_egl_library_present`, `_nvidia_egl_icd_registered`) and the staging routine (`_ensure_nvidia_egl_vendor_icd`) are deliberately best-effort, but their error-handling branches were uncovered by tests. A regression that let a single unreadable dir/file abort the whole scan, or a staging write failure crash `import mujoco`, would slip through silently.

## Change

Adds four deterministic, dependency-free tests (no GPU / EGL / mujoco required; they mock host detection and patch `pathlib.Path`) that lock in the best-effort contract:

- `_nvidia_egl_library_present` skips a lib dir whose `glob` raises `OSError` and still detects an NVIDIA library in a later dir.
- `_nvidia_egl_icd_registered` skips an unreadable vendor dir and an unreadable vendor JSON, still detecting a readable NVIDIA ICD.
- `_ensure_nvidia_egl_vendor_icd` fails soft on a staging write error, leaving glvnd's default routing in place (no `__EGL_VENDOR_LIBRARY_FILENAMES`).
- The staged vendor list orders the NVIDIA ICD first (wins glvnd resolution) and appends readable system vendor ICDs as fallback, skipping any vendor dir that cannot be listed.

Test-only; no runtime behavior changes.

## Coverage

`strands_robots/simulation/mujoco/backend.py`: the previously-uncovered branches (`72-73`, `82-83`, `88-89`, `135-137`, `144-145`) are now exercised, raising the module from 90% toward ~96%.

## Tests

`MUJOCO_GL=egl pytest tests/simulation/mujoco/test_nvidia_egl_icd.py` -> 16 passed. Lint (ruff check + format) and mypy clean on the changed file.