### PR TITLE
fix(sim): add_object rejects unknown kwargs instead of silently dropping them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: `add_object` rejects unknown keyword arguments instead of silently dropping them
+
+`Simulation.add_object` declared `**kwargs` on both the MuJoCo and Newton
+backends, documented as "reserved for backend-specific extensions; currently
+ignored". In practice the two signatures are identical and carry no
+backend-specific parameters, so the `**kwargs` only served to swallow caller
+mistakes. Passing MuJoCo's native `add_object(rgba=[1, 0, 0, 1])`, or a typo
+such as `colour=`/`radius=`, silently discarded the argument and returned
+`{"status": "success"}` while creating a default-grey object -- the
+"success contract, wrong physical effect" failure mode the project forbids
+elsewhere ("never warn-and-continue; no silent defaults"). The agent-dispatch
+router (`sim(action="add_object", ...)`) reproduced the same silent drop because
+it skips its "Unknown parameter" guard for `**kwargs` methods.
+
+`add_object` now takes only its declared parameters. The agent-dispatch path
+reports a structured error naming the offending parameter and listing the valid
+ones (`rgba` -> use `color`); a direct Python call raises `TypeError`. The
+constructor's and `create_world`'s `**kwargs` are unchanged -- those carry
+genuine cross-backend forward-compat parameters (`num_envs`/`device`) that a
+parallel backend consumes and MuJoCo ignores.
+
+
 ### Security: Hardened MuJoCo `render(output_path=...)` against path traversal, symlink, oversize, and partial-write corruption
 
 `render(output_path=...)` is an LLM-callable tool, so its destination path is

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -352,7 +352,6 @@ class SimEngine(ABC):
         is_static: bool = False,
         mesh_path: str | None = None,
         material: dict[str, Any] | None = None,
-        **kwargs: Any,
     ) -> dict[str, Any]:
         """Add a primitive or mesh object to the scene.
 

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1416,7 +1416,6 @@ class MuJoCoSimEngine(
         is_static: bool | None = None,
         mesh_path: str | None = None,
         material: dict[str, Any] | None = None,
-        **kwargs: Any,
     ) -> dict[str, Any]:
         """Add a primitive or mesh object to the live MuJoCo scene.
 
@@ -1459,7 +1458,6 @@ class MuJoCoSimEngine(
                 True; other shapes default to dynamic.
             mesh_path: Mesh asset path; required and only used when
                 ``shape="mesh"``.
-            **kwargs: Reserved for backend-specific extensions; currently ignored.
 
         Returns:
             Agent-tool status dict. ``{"status": "success", ...}`` on success;

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -427,7 +427,6 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         is_static: bool = False,
         mesh_path: str | None = None,
         material: dict[str, Any] | None = None,
-        **kwargs: Any,
     ) -> dict[str, Any]:
         """Add a primitive or mesh object to the scene.
 
@@ -452,7 +451,6 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
                 Newton backend yet; a non-``None`` value is rejected loudly
                 rather than silently dropped (use the MuJoCo backend for
                 matte/textured surfaces).
-            **kwargs: Ignored.
 
         Returns:
             Status dict.

--- a/tests/simulation/mujoco/test_add_object_rejects_unknown_kwargs.py
+++ b/tests/simulation/mujoco/test_add_object_rejects_unknown_kwargs.py
@@ -1,0 +1,81 @@
+"""Regression tests: ``add_object`` must not silently swallow unknown kwargs.
+
+The MuJoCo/Newton ``add_object`` signatures are identical and carry no
+backend-specific parameters, yet both previously declared ``**kwargs`` that
+were documented as "currently ignored". A caller reaching for MuJoCo's native
+``rgba=`` (or making a typo such as ``colour=`` / ``radius=``) had the argument
+silently dropped while the call still returned ``{"status": "success"}`` - the
+object was created with the default grey ``color`` and no signal was given.
+This is the "success contract, wrong physical effect" failure mode the project
+explicitly forbids ("never warn-and-continue; no silent defaults").
+
+These pin the corrected contract:
+
+* the agent-dispatch path (``sim(action="add_object", ...)``) reports a
+  structured error that names the offending parameter and lists the valid
+  ones (so ``rgba`` -> use ``color``);
+* a direct Python call with an unknown keyword fails loudly (``TypeError``)
+  instead of returning a misleading success;
+* the supported ``color=`` parameter actually reaches ``geom_rgba``.
+"""
+
+import pytest
+
+mj = pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="test_unknown_kwargs_sim", mesh=False)
+    s.create_world(gravity=[0, 0, -9.81])
+    yield s
+    s.cleanup()
+
+
+def _geom_rgba(world, geom_name):
+    model = world._model
+    gid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_GEOM, geom_name)
+    assert gid >= 0, f"geom {geom_name!r} not found in compiled model"
+    return list(model.geom_rgba[gid])
+
+
+def test_router_rejects_rgba_and_lists_color(sim):
+    """The agent-dispatch path names the bad kwarg and points at ``color``."""
+    result = sim(
+        action="add_object",
+        name="cube",
+        shape="box",
+        size=[0.05, 0.05, 0.05],
+        position=[0.2, 0.0, 0.05],
+        rgba=[1, 0, 0, 1],
+    )
+    assert result["status"] == "error", result
+    text = result["content"][0]["text"]
+    assert "rgba" in text
+    assert "color" in text  # the valid parameter to use instead
+    # the rejected call must not have created a (grey) object
+    assert "cube" not in sim._world.objects
+
+
+def test_router_rejects_typo_kwarg(sim):
+    """A plain typo (``colour``) is rejected, not silently swallowed."""
+    result = sim(action="add_object", name="c2", shape="box", colour=[0, 0, 1, 1])
+    assert result["status"] == "error", result
+    assert "colour" in result["content"][0]["text"]
+    assert "c2" not in sim._world.objects
+
+
+def test_direct_call_raises_typeerror_on_unknown_kwarg(sim):
+    """A direct library call fails loudly instead of returning success."""
+    with pytest.raises(TypeError):
+        sim.add_object("cube", shape="box", size=[0.05, 0.05, 0.05], rgba=[1, 0, 0, 1])
+
+
+def test_color_parameter_applies_to_geom_rgba(sim):
+    """The supported ``color=`` argument actually colours the geom."""
+    result = sim.add_object("red", shape="box", size=[0.05, 0.05, 0.05], color=[1, 0, 0, 1])
+    assert result["status"] == "success", result
+    rgba = _geom_rgba(sim._world, "red_geom")
+    assert rgba == pytest.approx([1.0, 0.0, 0.0, 1.0])

--- a/tests/simulation/mujoco/test_agenttool_contract.py
+++ b/tests/simulation/mujoco/test_agenttool_contract.py
@@ -153,12 +153,10 @@ class TestRouterKwargsPassthrough:
         import inspect
 
         def fake(self, name, **kwargs):  # noqa: ANN001, ANN002, ANN202
-            ...
+            """Signature-only stub; never called, its body is irrelevant."""
 
         sig = inspect.signature(fake)
-        kwargs, err = sim._validate_and_build_kwargs(
-            "fake", "fake", sig, {"name": "x", "future_flag": True}
-        )
+        kwargs, err = sim._validate_and_build_kwargs("fake", "fake", sig, {"name": "x", "future_flag": True})
         assert err is None
         # only declared params are forwarded; the extra key is dropped silently
         assert kwargs == {"name": "x"}

--- a/tests/simulation/mujoco/test_agenttool_contract.py
+++ b/tests/simulation/mujoco/test_agenttool_contract.py
@@ -142,16 +142,26 @@ class TestRouterValidatesVectorDims:
 class TestRouterKwargsPassthrough:
     """Methods with **kwargs in signature accept unknown params without error."""
 
-    def test_add_object_accepts_extra_kwargs(self, sim):
-        # add_object has **kwargs so extra params are allowed (backwards compat).
-        result = sim._dispatch_action(
-            "add_object",
-            {"name": "box1", "shape": "box", "future_flag": True},
+    def test_router_skips_unknown_check_for_var_keyword_methods(self, sim):
+        # The router's unknown-parameter guard is skipped only for methods that
+        # genuinely declare **kwargs; extra keys are dropped (not rejected).
+        # Verified directly against the validator, because no dispatchable
+        # action currently relies on this branch: add_object used to, but its
+        # signature is identical across backends and now rejects unknown params
+        # instead of silently dropping them (see
+        # test_add_object_rejects_unknown_kwargs.py).
+        import inspect
+
+        def fake(self, name, **kwargs):  # noqa: ANN001, ANN002, ANN202
+            ...
+
+        sig = inspect.signature(fake)
+        kwargs, err = sim._validate_and_build_kwargs(
+            "fake", "fake", sig, {"name": "x", "future_flag": True}
         )
-        # Either success (extra key ignored) or a proper runtime error; must NOT
-        # be an "unknown parameter" router rejection.
-        if result["status"] == "error":
-            assert "Unknown parameter" not in result["content"][0]["text"]
+        assert err is None
+        # only declared params are forwarded; the extra key is dropped silently
+        assert kwargs == {"name": "x"}
 
 
 class TestToolSpecMethodParity:

--- a/tests_integ/simulation/test_mujoco_journeys.py
+++ b/tests_integ/simulation/test_mujoco_journeys.py
@@ -108,8 +108,8 @@ def test_j1_scene_build_multi_robot_multi_camera():
         ("blue_ball", "sphere", [0.03, 0.03, 0.03], [0.0, 0.25, 0.05], [0, 0, 1, 1]),
         ("green_rod", "cylinder", [0.02, 0.02, 0.08], [0.2, 0.25, 0.08], [0, 1, 0, 1]),
     ]
-    for name, shape, size, pos, rgba in shapes:
-        r = sim.add_object(name=name, shape=shape, size=size, position=pos, rgba=rgba)
+    for name, shape, size, pos, color in shapes:
+        r = sim.add_object(name=name, shape=shape, size=size, position=pos, color=color)
         assert r["status"] == "success", r
 
     # 4 user-defined cameras

--- a/tests_integ/simulation/test_multi_robot_tasks.py
+++ b/tests_integ/simulation/test_multi_robot_tasks.py
@@ -35,8 +35,8 @@ def dual_robot_world():
     sim.create_world(timestep=0.002, gravity=[0, 0, -9.81])
     sim.add_robot("alice", data_config="so101", position=[-0.25, 0.0, 0.0])
     sim.add_robot("bob", data_config="so101", position=[0.25, 0.0, 0.0])
-    sim.add_object("red_cube", shape="box", size=[0.025, 0.025, 0.025], position=[-0.15, 0.2, 0.05], rgba=[1, 0, 0, 1])
-    sim.add_object("blue_ball", shape="sphere", size=[0.03, 0.03, 0.03], position=[0.15, 0.2, 0.05], rgba=[0, 0, 1, 1])
+    sim.add_object("red_cube", shape="box", size=[0.025, 0.025, 0.025], position=[-0.15, 0.2, 0.05], color=[1, 0, 0, 1])
+    sim.add_object("blue_ball", shape="sphere", size=[0.03, 0.03, 0.03], position=[0.15, 0.2, 0.05], color=[0, 0, 1, 1])
     sim.add_camera("top", position=[0, 0, 0.9], target=[0, 0.2, 0.05])
     # Per-robot wrist cameras: the "/" namespace separator is normalised to
     # "__" in recorded LeRobot feature names (observation.images.alice__wrist_cam).


### PR DESCRIPTION
## Problem

`Simulation.add_object` declared `**kwargs` on **both** the MuJoCo and Newton backends, documented as "reserved for backend-specific extensions; currently ignored". But the two `add_object` signatures are identical and carry **no** backend-specific parameters, so the `**kwargs` only ever swallowed caller mistakes.

Passing MuJoCo's native color name, or a typo, silently discarded the argument while the call still reported success and created a default-grey object:

```python
sim.add_object("cube", shape="box", rgba=[1, 0, 0, 1])
# -> {"status": "success", ...}   but the cube is default grey; `rgba` was dropped
sim.add_object("c2", shape="box", colour=[0, 0, 1, 1], radius=0.1)
# -> {"status": "success", ...}   `colour` and `radius` silently swallowed
```

This is the "success contract, wrong physical effect" failure mode the project forbids elsewhere (`AGENTS.md`: *never warn-and-continue; no silent defaults*). The agent-dispatch router (`sim(action="add_object", ...)`) reproduces the same silent drop, because `_validate_and_build_kwargs` deliberately **skips** its "Unknown parameter" guard for methods that declare `**kwargs` — and then forwards only the declared params, dropping the rest. `add_object` was the sole dispatchable action relying on that skip, and it slipped past the `test_no_method_has_silently_unused_param` anti-drift ward for exactly that reason.

The repo's own integration tests were victims: `test_multi_robot_tasks.py` and `test_mujoco_journeys.py` pass `rgba=` intending red/blue/green objects and silently created grey ones (they never assert color, so they passed).

## Change

Remove the vestigial `**kwargs` from `add_object` on the base ABC and both backends. `add_object` now takes only its declared parameters:

- **agent-dispatch path** — the router's existing machinery now fires: `Unknown parameter 'rgba' for action 'add_object'. Valid: ['color', 'is_static', 'mass', 'material', 'mesh_path', 'name', 'orientation', 'position', 'shape', 'size']` (so `rgba` -> use `color`).
- **direct Python call** — raises a clear `TypeError` instead of returning a misleading success.

The constructor's and `create_world`'s `**kwargs` are **left untouched** — those carry genuine cross-backend forward-compat params (`num_envs`/`device`) that a parallel backend consumes and MuJoCo ignores. The router's `**kwargs`-skip branch keeps its coverage via a direct `_validate_and_build_kwargs` test.

The two integration tests that were silently creating grey objects are corrected to `color=`.

## Tests

New `tests/simulation/mujoco/test_add_object_rejects_unknown_kwargs.py` (fails before, passes after):
- router path returns `status=error` naming `rgba` and listing `color`;
- a plain typo (`colour`) is rejected, not swallowed;
- a direct call raises `TypeError`;
- the supported `color=` argument actually reaches `geom_rgba`.

Local gate: `ruff check` clean, `ruff format --check` clean, `mypy` clean on the changed sources; the mujoco + newton simulation suites pass (`1152 passed` with the one pre-existing contract test updated to reflect the new behavior).

## Rollout in MuJoCo sim (headless, EGL)

Left: what `add_object(rgba=...)` silently produced pre-fix (default grey, sampled px `[62, 62, 62]`). Right: `add_object(color=[0.85, 0.12, 0.12, 1])` (px `[106, 15, 15]`).

![add_object color before/after](https://github.com/cagataycali/robots/releases/download/artifact-add-object-color-fix/add_object_color_fix.png)

---

## Changelog

### Round 1

Green-CI fixes on the var-keyword passthrough test (`tests/simulation/mujoco/test_agenttool_contract.py`), no behavior change:

- **`call-test-lint` failure**: `ruff format --check` wanted the `_validate_and_build_kwargs(...)` call in `test_router_skips_unknown_check_for_var_keyword_methods` collapsed onto one line. Applied `ruff format`.
- **CodeQL "Statement has no effect" (code-scanning/595)**: the `fake` signature-only stub had a bare `...` body, which is never executed (the stub exists solely for `inspect.signature`). Replaced with a one-line docstring — idiomatic no-op that isn't flagged as a dead expression.

The test still pins the router's `**kwargs`-skip branch (extra keys dropped, `err is None`) exactly as before.