### PR TITLE
fix(sim): mj_forward after mj_resetData so reset() leaves render-ready state

### DIFF
--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -204,7 +204,18 @@ class SimEngine(ABC):
 
     @abstractmethod
     def reset(self) -> dict[str, Any]:
-        """Reset simulation to initial state."""
+        """Reset simulation to its initial state.
+
+        Contract: on return the world must be left in a fully consistent,
+        observation-ready state - derived kinematics (Cartesian body/site/geom
+        poses and camera transforms) must reflect the reset pose WITHOUT
+        requiring a subsequent ``step()``. ``eval_policy`` calls
+        ``get_observation()`` immediately after ``reset()`` and before the
+        first action, so a backend that leaves derived state stale would feed
+        the policy's first inference of every episode a degenerate observation.
+        The MuJoCo backend enforces this by running ``mj_forward`` after
+        ``mj_resetData`` (which alone zeroes all derived quantities).
+        """
         ...
 
     @abstractmethod

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1879,6 +1879,18 @@ class MuJoCoSimEngine(
         mj = self._mj
         with self._lock:
             mj.mj_resetData(self._world._model, self._world._data)
+            # mj_resetData restores qpos/qvel/ctrl but zeroes ALL derived
+            # kinematics (xpos, site_xpos, geom_xpos, cam_xpos, ...) until the
+            # next mj_step/mj_forward. A consumer that reads state or RENDERS
+            # before the next step - e.g. eval_policy's per-episode loop, which
+            # calls get_observation() immediately after reset() and before the
+            # first send_action - would otherwise see every body collapsed at
+            # the origin: a degenerate camera frame and zeroed Cartesian state
+            # feeding the policy's FIRST inference of every episode. Forward
+            # here so reset() leaves a fully consistent, render-ready state,
+            # matching the mj_resetData -> mj_forward idiom used by
+            # _compile_world and load_scene.
+            mj.mj_forward(self._world._model, self._world._data)
             self._world.sim_time = 0.0
             self._world.step_count = 0
             # Flip policy_running flag inside the lock so a racing worker

--- a/tests/simulation/mujoco/test_reset_forwards_derived_state.py
+++ b/tests/simulation/mujoco/test_reset_forwards_derived_state.py
@@ -1,0 +1,130 @@
+"""reset() must leave forwarded (render-ready) derived kinematics.
+
+``mujoco.mj_resetData`` restores ``qpos``/``qvel``/``ctrl`` but zeroes every
+derived Cartesian quantity (``xpos``, ``site_xpos``, ``geom_xpos``,
+``cam_xpos``, ...) until the next ``mj_step``/``mj_forward``. The eval loop
+(:meth:`Simulation.eval_policy`) calls ``get_observation()`` immediately after
+``reset()`` and before the first ``send_action``, so without a forward the
+policy's first inference of every episode would receive a degenerate camera
+frame with all geometry collapsed at the origin and a zeroed Cartesian state.
+
+These tests pin that ``reset()`` forwards, so:
+  * derived body positions are valid immediately after ``reset()`` (no manual
+    ``mj_forward`` required), and
+  * a camera observation captured right after ``reset()`` is identical to one
+    captured after an explicit ``mj_forward`` (i.e. it is not degenerate).
+"""
+
+import numpy as np
+import pytest
+
+mj = pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.backend import _can_render  # noqa: E402
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+requires_gl = pytest.mark.skipif(
+    not _can_render(),
+    reason="No OpenGL context available (headless without EGL/OSMesa)",
+)
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="test_reset_forward", mesh=False)
+    yield s
+    s.cleanup()
+
+
+def _body_xpos(sim: Simulation, name: str) -> np.ndarray:
+    model, data = sim._world._model, sim._world._data
+    bid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_BODY, name)
+    assert bid >= 0, f"body {name!r} not found"
+    return np.asarray(data.xpos[bid]).copy()
+
+
+def test_reset_forwards_derived_body_positions(sim):
+    """After reset(), body Cartesian positions are populated WITHOUT a manual
+    forward. Pre-fix (mj_resetData only) they read [0, 0, 0]."""
+    assert sim.create_world(gravity=[0, 0, -9.81])["status"] == "success"
+    assert sim.add_robot("so101")["status"] == "success"
+    # A free object spawned well away from the origin is an unambiguous probe:
+    # if reset() forwards, its body xpos lands at the declared spawn; if not,
+    # it collapses to the origin.
+    assert (
+        sim.add_object(
+            name="cube",
+            shape="box",
+            position=[0.3, 0.0, 0.15],
+            size=[0.05, 0.05, 0.05],
+            color=[1, 0, 0, 1],
+            mass=0.05,
+        )["status"]
+        == "success"
+    )
+
+    sim.step(n_steps=50)
+    assert sim.reset()["status"] == "success"
+
+    # Read directly from mj_data with NO intervening mj_forward/mj_step.
+    cube_xpos = _body_xpos(sim, "cube")
+    assert np.linalg.norm(cube_xpos) > 0.05, (
+        f"cube body collapsed to origin after reset(): {cube_xpos} - reset() did not forward derived kinematics"
+    )
+    # x/y are exactly the declared spawn (a free body's rest z settles later,
+    # but the reset pose is the un-simulated spawn pose).
+    np.testing.assert_allclose(cube_xpos[:2], [0.3, 0.0], atol=1e-6)
+
+    # Sanity: values match an explicit forward (reset() did the same work).
+    mj.mj_forward(sim._world._model, sim._world._data)
+    np.testing.assert_allclose(_body_xpos(sim, "cube"), cube_xpos, atol=1e-9)
+
+
+@requires_gl
+def test_reset_leaves_render_ready_observation(sim):
+    """A camera observation captured right after reset() is identical to one
+    captured after an explicit mj_forward - i.e. not a collapsed-geometry
+    frame. Pre-fix the two differ substantially (geometry at the origin)."""
+    assert sim.create_world(gravity=[0, 0, -9.81])["status"] == "success"
+    assert sim.add_robot("so101")["status"] == "success"
+    assert (
+        sim.add_object(
+            name="cube",
+            shape="box",
+            position=[0.3, 0.0, 0.05],
+            size=[0.05, 0.05, 0.05],
+            color=[1, 0, 0, 1],
+            mass=0.05,
+        )["status"]
+        == "success"
+    )
+    assert (
+        sim.add_camera(
+            name="camera1",
+            position=[0.55, 0.0, 0.35],
+            target=[0.2, 0.0, 0.05],
+            fov=58.0,
+            width=128,
+            height=128,
+        )["status"]
+        == "success"
+    )
+
+    sim.step(n_steps=50)
+    assert sim.reset()["status"] == "success"
+
+    # First observation the policy would see - captured with NO manual forward.
+    obs_after_reset = sim.get_observation(robot_name="so101")["camera1"].copy()
+    # Now force a forward and re-capture: this is the "correct" frame.
+    mj.mj_forward(sim._world._model, sim._world._data)
+    obs_after_forward = sim.get_observation(robot_name="so101")["camera1"].copy()
+
+    assert obs_after_reset.shape == obs_after_forward.shape
+    np.testing.assert_array_equal(
+        obs_after_reset,
+        obs_after_forward,
+        err_msg="post-reset observation differs from forwarded frame - "
+        "reset() left a degenerate (collapsed-geometry) render",
+    )
+    # And the frame is not a single flat colour (real geometry is visible).
+    assert len(np.unique(obs_after_reset.reshape(-1, 3), axis=0)) > 50

--- a/tests/simulation/mujoco/test_reset_forwards_derived_state.py
+++ b/tests/simulation/mujoco/test_reset_forwards_derived_state.py
@@ -37,6 +37,7 @@ def sim():
 
 
 def _body_xpos(sim: Simulation, name: str) -> np.ndarray:
+    assert sim._world is not None, "world not created"
     model, data = sim._world._model, sim._world._data
     bid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_BODY, name)
     assert bid >= 0, f"body {name!r} not found"


### PR DESCRIPTION
## Problem

`MuJoCoSimEngine.reset()` calls `mujoco.mj_resetData` but never `mj_forward`. `mj_resetData` restores `qpos`/`qvel`/`ctrl` but **zeroes every derived Cartesian quantity** (`xpos`, `site_xpos`, `geom_xpos`, `cam_xpos`, ...) until the next `mj_step`/`mj_forward`.

`eval_policy`'s per-episode loop (`PolicyRunner._evaluate_with_spec` and the async-RTC pipeline) does:

```
self.sim.reset()
...
observation = self.sim.get_observation(...)   # <- no step/forward in between
actions = policy.get_actions(observation, ...) # policy's FIRST inference of the episode
```

The default `on_episode_start` does not forward, so the policy's **first inference of every episode** is conditioned on a degenerate observation: a camera frame with all geometry collapsed at the origin, plus a zeroed Cartesian state. Calling `render()` or `get_observation()` directly after `reset()` is broken the same way.

Measured on a headless SO-101 + cube scene (256x256 front camera): the first observation captured after `reset()` differs from the same frame after an explicit `mj_forward` by a mean absolute pixel difference of **49.1** (153 vs 850 unique colours -- collapsed vs real geometry), and the cube body `xpos` reads `[0, 0, 0]` instead of its spawn `[0.3, 0, 0.05]`.

The LIBERO benchmark path avoids this only because its `on_episode_start` runs `mj_forward` itself (the adapter is full of explicit `mj_forward` calls, including a documented 2-pass warmup for exactly the "render before forward -> gradient frame" problem). The general, non-LIBERO eval path had no such workaround.

## Fix

Run `mj_forward` inside the lock right after `mj_resetData`, matching the `mj_resetData -> mj_forward` idiom already used by `_compile_world` and `load_scene`. `reset()` now leaves a fully consistent, render-ready state. This is defense-in-depth for LIBERO (which already forwards) and fixes the general eval path, `render()`-after-reset, and `get_observation()`-after-reset.

## Tests

`tests/simulation/mujoco/test_reset_forwards_derived_state.py`:
- `test_reset_forwards_derived_body_positions` -- after `reset()` (no manual forward) the cube body `xpos` is its spawn pose, not the origin. **Fails pre-fix** (`[0,0,0]`), passes post-fix.
- `test_reset_leaves_render_ready_observation` (GL-gated) -- a camera observation captured right after `reset()` is byte-identical to one captured after an explicit `mj_forward`, and is not a flat frame. Fails pre-fix.

Local gate: `ruff check`/`format` + `mypy` clean; `test_reset_forwards_derived_state.py` 2 passed; regression sweep over `tests/simulation/mujoco/{test_simulation,test_recording_paths,test_concurrency}.py` = 205 passed, and all `eval`/`policy_runner`/`run_policy`/`reset` sim tests = 341 passed, 2 skipped.

## Visual

The exact frame the policy's first inference receives, before vs after the fix (headless MuJoCo, EGL). Before: geometry collapsed at the origin; after: the arm, gripper and red cube are correctly rendered.

![before/after](https://github.com/cagataycali/robots/releases/download/reset-forward-artifact-1782900043/reset_forward_before_after.png)