### PR TITLE
test(mesh): pin resume FAIL-CLOSED on undecodable/unparseable payloads

### DIFF
--- a/tests/mesh/test_resume_malformed_envelope_rejected.py
+++ b/tests/mesh/test_resume_malformed_envelope_rejected.py
@@ -130,3 +130,41 @@ def test_missing_peer_id_rejected(engaged_mesh: Mesh, caplog: pytest.LogCaptureF
     assert any("missing/invalid ``peer_id``" in r.getMessage() for r in caplog.records), (
         f"expected a missing-peer_id warning; got {[r.getMessage() for r in caplog.records]}"
     )
+
+
+def _raw_sample(raw: object) -> MagicMock:
+    """Fake Zenoh sample whose payload bytes are supplied verbatim (or None).
+
+    Unlike ``_sample`` this bypasses JSON encoding so a test can hand the
+    handler payloads that fail *before* ``json.loads`` -- a payload that is not
+    bytes-like, or bytes that are not valid UTF-8 / JSON. ``raw=None`` models a
+    sample whose ``payload`` attribute is absent entirely.
+    """
+    s = MagicMock()
+    if raw is None:
+        s.payload = None
+    else:
+        s.payload.to_bytes.return_value = raw
+    return s
+
+
+@pytest.mark.parametrize(
+    ("raw", "label"),
+    [
+        (None, "payload attribute is None (AttributeError)"),
+        (b"\xff\xfe\x00garbage", "payload bytes are not valid UTF-8 (UnicodeDecodeError)"),
+        (b"{not: valid json,", "payload decodes but is not valid JSON (JSONDecodeError)"),
+    ],
+)
+def test_undecodable_payload_leaves_lockout_engaged(engaged_mesh: Mesh, raw: object, label: str) -> None:
+    """A payload that cannot be decoded to a JSON object never clears the lockout.
+
+    The four JSON-shape refuse-paths above all assume ``json.loads`` succeeded.
+    This pins the earlier guard: an envelope whose payload is not bytes-like,
+    not valid UTF-8, or not valid JSON must be dropped before touching the
+    lockout -- garbage on the wire can never resume a stopped fleet, and it must
+    not pollute the replay cache either.
+    """
+    engaged_mesh._on_safety_resume(_raw_sample(raw))
+    assert engaged_mesh._estop_lockout.is_set(), f"undecodable payload must not clear the lockout: {label}"
+    assert len(engaged_mesh._resume_replay_cache) == 0, f"no cache entry for an undecodable envelope: {label}"


### PR DESCRIPTION
## Problem

`Mesh._on_safety_resume` clears a fleet-wide emergency-stop lockout, so it must reject anything that is not a well-formed, fully-attributed resume envelope. The handler's first guard is a decode step:

```python
try:
    raw = sample.payload.to_bytes().decode()
    data = json.loads(raw)
except (AttributeError, UnicodeDecodeError, json.JSONDecodeError):
    return
```

The four existing refuse-path tests in `test_resume_malformed_envelope_rejected.py` all feed the handler payloads that parse cleanly as JSON (a list, a body with an unbacked `source_zid`, a missing-proof envelope, a missing-`peer_id` envelope), so they only exercise the JSON-*shape* guards that run after `json.loads` has already succeeded. The earlier decode guard itself had no runtime coverage: it was only asserted to exist as source text by a separate static test (`test_wire_handler_narrow_except.py`), which greps the source for the except tuple but never drives the branch.

Result: the FAIL-CLOSED behavior for genuinely un-decodable wire bytes (payload not bytes-like, non-UTF-8 bytes, non-JSON bytes) was unpinned.

## Change

Add a single parametrized test covering the three decode-failure modes the except tuple is meant to swallow:

- payload attribute is `None` -> `AttributeError` (payload not bytes-like)
- payload bytes are not valid UTF-8 -> `UnicodeDecodeError`
- payload decodes but is not valid JSON -> `json.JSONDecodeError`

Each case asserts the e-stop lockout stays engaged **and** the replay cache stays empty, pinning the contract that garbage on the wire can never resume a stopped fleet nor pollute the replay cache. Reuses the existing `engaged_mesh` fixture and adds a small `_raw_sample` helper that bypasses JSON encoding so a test can supply payloads that fail before `json.loads`.

Test-only; no production code changes.

## Verification

- `test_resume_malformed_envelope_rejected.py`: 7 passed (4 existing + 3 new).
- Full `tests/mesh/` suite: 1902 passed, 2 skipped.
- ruff check + ruff format --check + mypy clean on the changed file.
- Guard check: narrowing the handler's except tuple to drop `AttributeError`/`UnicodeDecodeError` makes exactly the corresponding two new cases fail (the undecodable payloads then escape the handler), confirming the test exercises real behavior rather than restating it.

Coverage of `strands_robots/mesh/core.py`: the resume-handler decode branch (previously in the term-missing report) is now covered.