### PR TITLE
fix(sim): mj_forward after randomize() so light-position jitter is not a silent render no-op

### DIFF
--- a/docs/simulation/domain-randomization.md
+++ b/docs/simulation/domain-randomization.md
@@ -20,6 +20,8 @@ sim.randomize(
 
 **Destructive** - writes into MuJoCo model arrays. To restore: `load_scene(...)` or recreate the sim.
 
+`randomize()` leaves the sim in a forwarded, render-ready state: the next `render()` / `get_observation()` reflects the perturbation immediately, with no manual `step()` in between. This matters for lighting in particular - the renderer reads light positions from the derived `data.light_xpos`, not `model.light_pos`, so a light-position jitter only reaches a render after a forward.
+
 ## Categories
 
 | Flag | What changes | Range param |

--- a/strands_robots/simulation/mujoco/randomization.py
+++ b/strands_robots/simulation/mujoco/randomization.py
@@ -160,8 +160,20 @@ class RandomizationMixin:
                             qpos_addr = model.jnt_qposadr[jnt_id]
                             noise = rng.uniform(-position_noise, position_noise, size=3)
                             data.qpos[qpos_addr : qpos_addr + 3] += noise
-                mj.mj_forward(model, data)
                 changes.append(f"Positions: ±{position_noise}m noise on dynamic objects")
+
+            # Recompute derived state so the sim is left render-ready. Several
+            # randomization axes mutate model arrays whose rendered/simulated
+            # effect flows through data: light_pos -> data.light_xpos (the
+            # array the renderer reads, NOT model.light_pos), and object qpos ->
+            # body xpos. Without a forward the next render()/get_observation()
+            # keeps stale derived values, so a light-position jitter is a silent
+            # visual no-op until some later mj_step. Mirror the mutate-then-
+            # forward contract already used by reset(), load_scene() and
+            # move_object(). Guarded on ``changes`` so a no-flag call stays a
+            # true no-op.
+            if changes:
+                mj.mj_forward(model, data)
 
         return {
             "status": "success",

--- a/tests/simulation/mujoco/test_randomize_forwards_derived_state.py
+++ b/tests/simulation/mujoco/test_randomize_forwards_derived_state.py
@@ -1,0 +1,137 @@
+"""randomize() must leave forwarded (render-ready) derived state.
+
+Domain randomization mutates ``model`` arrays whose rendered/simulated effect
+flows through ``data``:
+
+  * ``randomize_lighting`` writes ``model.light_pos``, but the renderer reads
+    light positions from ``data.light_xpos`` (populated by ``mj_forward`` from
+    ``model.light_pos`` and the parent body kinematics). Jittering
+    ``light_pos`` without a forward leaves ``light_xpos`` stale, so the light
+    move is a silent visual no-op until some later ``mj_step`` - even though
+    ``randomize()`` reports success ("Lighting: N lights randomized").
+  * ``randomize_positions`` writes object ``qpos``; the resulting body
+    ``xpos`` is only valid after a forward.
+
+These tests pin that ``randomize()`` forwards after mutating, matching the
+mutate-then-forward contract already used by ``reset()``, ``load_scene()`` and
+``move_object()``.
+"""
+
+import numpy as np
+import pytest
+
+mj = pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.backend import _can_render  # noqa: E402
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+requires_gl = pytest.mark.skipif(
+    not _can_render(),
+    reason="No OpenGL context available (headless without EGL/OSMesa)",
+)
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="test_randomize_forward", mesh=False)
+    assert s.create_world(gravity=[0, 0, -9.81])["status"] == "success"
+    assert s.add_robot("so101")["status"] == "success"
+    yield s
+    s.cleanup()
+
+
+def test_randomize_lighting_forwards_light_xpos(sim):
+    """After randomize(randomize_lighting=True), data.light_xpos (what the
+    renderer consumes) tracks the jittered model.light_pos WITHOUT a manual
+    forward. Pre-fix the two diverge - the light move never reaches the render.
+    """
+    assert sim._world is not None
+    model, data = sim._world._model, sim._world._data
+    if model.nlight == 0:
+        pytest.skip("scene has no lights")
+
+    pos_before = np.asarray(model.light_pos).copy()
+    result = sim.randomize(randomize_colors=False, randomize_lighting=True, seed=7)
+    assert result["status"] == "success"
+
+    # The jitter actually moved the lights in the model...
+    assert not np.allclose(model.light_pos, pos_before), "lighting jitter did not move any light"
+    # ...and the derived (rendered) light position was recomputed to match.
+    assert np.allclose(model.light_pos, data.light_xpos), (
+        "data.light_xpos is stale after randomize(); the light-position jitter "
+        "is a silent visual no-op until the next mj_step"
+    )
+
+
+def test_randomize_positions_forwards_body_xpos(sim):
+    """Consolidating the forward must not regress randomize_positions: a moved
+    dynamic object's body xpos reflects the qpos noise immediately."""
+    assert sim._world is not None
+    assert (
+        sim.add_object(
+            name="cube",
+            shape="box",
+            position=[0.3, 0.0, 0.15],
+            size=[0.05, 0.05, 0.05],
+        )["status"]
+        == "success"
+    )
+    # add_object recompiles the model; re-fetch model/data (the pre-add handles
+    # are now stale and would not contain the new body).
+    model, data = sim._world._model, sim._world._data
+    bid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_BODY, "cube")
+    assert bid >= 0
+    xpos_before = np.asarray(data.xpos[bid]).copy()
+
+    result = sim.randomize(
+        randomize_colors=False,
+        randomize_lighting=False,
+        randomize_positions=True,
+        position_noise=0.05,
+        seed=3,
+    )
+    assert result["status"] == "success"
+    # Body Cartesian position reflects the qpos perturbation (forward ran).
+    assert not np.allclose(data.xpos[bid], xpos_before)
+
+
+def test_randomize_no_flags_is_true_noop(sim):
+    """A no-flag call changes nothing and does not run a spurious forward."""
+    assert sim._world is not None
+    data = sim._world._data
+    light_xpos_before = np.asarray(data.light_xpos).copy()
+    result = sim.randomize(
+        randomize_colors=False,
+        randomize_lighting=False,
+        randomize_physics=False,
+        randomize_positions=False,
+    )
+    assert result["status"] == "success"
+    assert np.array_equal(data.light_xpos, light_xpos_before)
+
+
+@requires_gl
+def test_randomize_lighting_changes_render(sim):
+    """Positive end-to-end smoke: randomize_lighting visibly relights the scene.
+
+    This exercises the render path but is NOT the fail-before proof for the
+    stale-``light_xpos`` bug: ``randomize_lighting`` also resamples
+    ``light_diffuse``, which the renderer reads straight from ``model`` (no
+    forward needed), so the frame changes pre-fix from the diffuse component
+    alone. The clean regression is
+    ``test_randomize_lighting_forwards_light_xpos`` above, which isolates the
+    light-*position* component that only reaches the renderer after a forward.
+    """
+    before = sim.render(camera_name="default", width=256, height=256)
+    assert before["status"] == "success"
+    import imageio.v3 as iio
+
+    img_before = iio.imread(before["content"][1]["image"]["source"]["bytes"]).astype(np.int32)
+
+    assert sim.randomize(randomize_colors=False, randomize_lighting=True, seed=7)["status"] == "success"
+
+    after = sim.render(camera_name="default", width=256, height=256)
+    img_after = iio.imread(after["content"][1]["image"]["source"]["bytes"]).astype(np.int32)
+
+    changed = int((np.abs(img_before - img_after).max(axis=2) > 8).sum())
+    assert changed > 0, "randomize_lighting produced no rendered change (silent visual no-op)"


### PR DESCRIPTION
## Problem

`randomize(randomize_lighting=True)` writes `model.light_pos`, but the MuJoCo renderer reads light positions from the *derived* `data.light_xpos` (populated by `mj_forward` from `model.light_pos` plus the parent body kinematics), not from `model.light_pos` directly. `randomize()` only ran `mj_forward` inside the `randomize_positions` branch, so a lighting-only (or the default colors+lighting) call left `light_xpos` stale.

Result: the light-position jitter never reached the next `render()` / `get_observation()` until some later `mj_step`, yet the call still reported success (`Lighting: N lights randomized`). A domain-randomization axis that is documented and reports success was a silent visual no-op for its position component.

Repro on an `so101` scene (two worldbody lights):

```python
sim.randomize(randomize_colors=False, randomize_lighting=True, seed=7)
# model.light_pos jittered to e.g. [0.125, 0.397, 3.78]
# data.light_xpos still [0, 0, 3.5]  <- renderer keeps the old position
```

Moving a light's position and rendering without a forward produces **0** changed pixels; after a forward, the same move produces a clearly relit frame.

## Fix

Consolidate a single `mj_forward` at the end of the randomization block, guarded on whether anything was applied, so `randomize()` leaves the sim in a forwarded, render-ready state. This matches the mutate-then-forward contract already used by `reset()`, `load_scene()` and `move_object()`, and removes the now-redundant per-branch forward in `randomize_positions`. A no-flag call stays a true no-op (no spurious forward).

## Visual proof (MuJoCo headless render)

Left: baseline. Middle: light moved **without** a forward (pre-fix behavior) - byte-identical, 0 px changed. Right: light moved **with** the forward (this fix) - 1194 px changed, scene visibly relit.

![randomize light fix](https://github.com/cagataycali/robots/releases/download/artifact-randomize-light-1782913973/randomize_light_fix.png)

## Tests

New `tests/simulation/mujoco/test_randomize_forwards_derived_state.py`:
- `test_randomize_lighting_forwards_light_xpos` - asserts `data.light_xpos` tracks the jittered `model.light_pos` after `randomize()`. **Fails pre-fix** (stale `[0,0,3.5]` vs jittered position), passes after.
- `test_randomize_positions_forwards_body_xpos` - guards that consolidating the forward did not regress `randomize_positions` (moved-object body `xpos` reflects the qpos noise immediately).
- `test_randomize_no_flags_is_true_noop` - a no-flag call changes nothing and runs no forward.
- `test_randomize_lighting_changes_render` (GL-gated) - positive end-to-end smoke; docstring notes it is not the fail-before proof (the `light_diffuse` component renders without a forward), pointing at the deterministic test above.

Local gate: `ruff check`, `ruff format --check`, `mypy` clean on changed files; `tests/simulation/mujoco/{test_randomize_forwards_derived_state,test_reset_forwards_derived_state,test_simulation}.py` = 157 passed (`MUJOCO_GL=egl`).

Docs: `docs/simulation/domain-randomization.md` notes the render-ready contract and the `light_xpos` vs `light_pos` subtlety.