### PR TITLE
ci: enforce a minimum test-coverage threshold (--cov-fail-under=80)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -566,7 +566,7 @@ warn_return_any = false
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "-v --cov=strands_robots --cov-report=term-missing --strict-markers --timeout=120"
+addopts = "-v --cov=strands_robots --cov-report=term-missing --cov-fail-under=80 --strict-markers --timeout=120"
 markers = [
     "gpu: requires CUDA GPU and real model weights (run with: pytest -m gpu)",
     "slow: long-running test (deselect with: pytest -m 'not slow')",


### PR DESCRIPTION
## What

Adds a minimum test-coverage floor by appending `--cov-fail-under=80` to the pytest `addopts` in `pyproject.toml`. One-line change.

## Why

Coverage is already measured (`--cov=strands_robots --cov-report=term-missing`), but nothing defends it, so it can silently regress PR to PR. A floor turns the existing measurement into an enforced bar: a change that drops coverage below the threshold fails the test job.

## Choosing the number

A full local run reports roughly **85%** total coverage. The floor is set to **80** on purpose - a few points of headroom below the current level - so it protects existing coverage without red-lighting `main` on the first PR or forcing test-theater on hard-to-cover GPU/hardware paths. It can be ratcheted up over time as coverage climbs.

Please confirm the exact number against the CI `[all,dev]` environment before merge (the CI env covers optional-dependency paths that a minimal local env cannot, so its real number is at or above the local 85%); the threshold can be bumped to match.

## Testing

Ran the full suite locally to establish the baseline. No source or test code changed - only the pytest configuration.
