### PR TITLE
ci: detect breaking changes to the AgentTool action contract

### DIFF
--- a/.github/scripts/agent_api_snapshot.py
+++ b/.github/scripts/agent_api_snapshot.py
@@ -87,15 +87,20 @@ def render_markdown(breaking: list[str], info: list[str]) -> str:
     if not breaking and not info:
         return (
             "## No AgentTool API Changes Detected\n\n"
-            "No changes to the dispatched action contract in this PR."
+            + "No changes to the dispatched action contract in this PR."
         )
     lines: list[str] = []
     if breaking:
+        # Built as a single explicit expression (not two adjacent literals in a
+        # list) so it does not read as a missing-comma bug.
+        summary_line = (
+            f"Found **{len(breaking)}** potential breaking change(s) in the "
+            + "dispatched action contract (the actions and parameters agents call):"
+        )
         lines += [
             "## AgentTool Breaking Change Warning",
             "",
-            f"Found **{len(breaking)}** potential breaking change(s) in the "
-            "dispatched action contract (the actions and parameters agents call):",
+            summary_line,
             "",
         ]
         lines += [f"- {b}" for b in breaking]
@@ -105,13 +110,12 @@ def render_markdown(breaking: list[str], info: list[str]) -> str:
         lines += ["", "<details><summary>Backward-compatible additions</summary>", ""]
         lines += [f"- {i}" for i in info]
         lines += ["", "</details>"]
-    lines += [
-        "",
-        "---",
+    footer = (
         "> Automated static check of the AgentTool action contract. Removed or "
-        "renamed actions/parameters break agent code that calls them. If a change "
-        "is intentional, add a `CHANGELOG.md` entry or a deprecation notice.",
-    ]
+        + "renamed actions/parameters break agent code that calls them. If a change "
+        + "is intentional, add a `CHANGELOG.md` entry or a deprecation notice."
+    )
+    lines += ["", "---", footer]
     return "\n".join(lines)
 
 

--- a/.github/scripts/agent_api_snapshot.py
+++ b/.github/scripts/agent_api_snapshot.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Snapshot and diff the AgentTool action contract for breaking-change detection.
+
+The public API most users of this SDK build against is not only the Python
+surface (that is covered by the griffe breaking-change check) - it is the set of
+AgentTool ACTIONS an agent dispatches and the parameters each action accepts.
+That contract lives in each simulation backend's dispatcher: an action string is
+resolved to a method (via the backend's ``_ACTION_ALIASES``) and its arguments
+are validated against that method's signature. A silent rename of an action or of
+an action parameter (for example ``add_camera(name=...)`` becoming
+``add_camera(camera_name=...)``) breaks agent code without touching any Python
+signature griffe would flag.
+
+This script builds a snapshot of ``{action: [sorted params]}`` for a backend by:
+  1. reading the declared action enum from the backend's ``tool_spec.json``,
+  2. resolving each action to its method (honoring ``_ACTION_ALIASES``),
+  3. recording the method's parameter names (minus ``self``).
+
+Modes:
+  snapshot <out.json>        write the current contract to a file
+  diff <old.json> <new.json> compare two snapshots, print markdown, exit non-zero
+                             if a breaking change (removed action or removed/
+                             renamed parameter) is found
+
+Backward-compatible additions (new actions, new parameters) are NOT breaking and
+are reported separately as informational.
+"""
+from __future__ import annotations
+
+import inspect
+import json
+import sys
+from pathlib import Path
+
+# The backend whose dispatch contract we snapshot. MuJoCo is the default,
+# CPU-only backend shipped in strands-robots; it is the surface agents call in
+# every getting-started path.
+TOOL_SPEC = Path("strands_robots/simulation/mujoco/tool_spec.json")
+
+
+def build_snapshot() -> dict[str, list[str]]:
+    """Return {action: [sorted param names]} for the declared action enum."""
+    from strands_robots.simulation.mujoco.simulation import MuJoCoSimulation as Sim
+
+    spec = json.loads(TOOL_SPEC.read_text())
+    actions = spec["properties"]["action"]["enum"]
+    aliases = getattr(Sim, "_ACTION_ALIASES", {}) or {}
+
+    snapshot: dict[str, list[str]] = {}
+    for action in actions:
+        method = getattr(Sim, aliases.get(action, action), None)
+        if method is None:
+            # Declared in the enum but not resolvable - record explicitly so a
+            # diff surfaces it rather than silently skipping.
+            snapshot[action] = ["<unresolved>"]
+            continue
+        try:
+            params = [p for p in inspect.signature(method).parameters if p != "self"]
+            snapshot[action] = sorted(params)
+        except (ValueError, TypeError):
+            snapshot[action] = ["<no-signature>"]
+    return snapshot
+
+
+def diff(old: dict[str, list[str]], new: dict[str, list[str]]) -> tuple[list[str], list[str]]:
+    """Return (breaking, informational) change lists."""
+    breaking: list[str] = []
+    info: list[str] = []
+
+    for action in sorted(old):
+        if action not in new:
+            breaking.append(f"Removed action: `{action}`")
+            continue
+        old_params, new_params = set(old[action]), set(new[action])
+        for p in sorted(old_params - new_params):
+            breaking.append(f"`{action}`: removed or renamed parameter `{p}`")
+        for p in sorted(new_params - old_params):
+            info.append(f"`{action}`: added parameter `{p}`")
+
+    for action in sorted(set(new) - set(old)):
+        info.append(f"Added action: `{action}`")
+
+    return breaking, info
+
+
+def render_markdown(breaking: list[str], info: list[str]) -> str:
+    if not breaking and not info:
+        return (
+            "## No AgentTool API Changes Detected\n\n"
+            "No changes to the dispatched action contract in this PR."
+        )
+    lines: list[str] = []
+    if breaking:
+        lines += [
+            "## AgentTool Breaking Change Warning",
+            "",
+            f"Found **{len(breaking)}** potential breaking change(s) in the "
+            "dispatched action contract (the actions and parameters agents call):",
+            "",
+        ]
+        lines += [f"- {b}" for b in breaking]
+    else:
+        lines += ["## AgentTool API Changes (non-breaking)", ""]
+    if info:
+        lines += ["", "<details><summary>Backward-compatible additions</summary>", ""]
+        lines += [f"- {i}" for i in info]
+        lines += ["", "</details>"]
+    lines += [
+        "",
+        "---",
+        "> Automated static check of the AgentTool action contract. Removed or "
+        "renamed actions/parameters break agent code that calls them. If a change "
+        "is intentional, add a `CHANGELOG.md` entry or a deprecation notice.",
+    ]
+    return "\n".join(lines)
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) >= 2 and argv[0] == "snapshot":
+        Path(argv[1]).write_text(json.dumps(build_snapshot(), indent=2, sort_keys=True))
+        print(f"wrote snapshot -> {argv[1]}")
+        return 0
+
+    if len(argv) >= 3 and argv[0] == "diff":
+        old = json.loads(Path(argv[1]).read_text())
+        new = json.loads(Path(argv[2]).read_text())
+        breaking, info = diff(old, new)
+        md = render_markdown(breaking, info)
+        Path("/tmp/agent-api-changes.md").write_text(md)
+        print(md)
+        return 1 if breaking else 0
+
+    print(__doc__)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.github/workflows/agent-api-check.yml
+++ b/.github/workflows/agent-api-check.yml
@@ -1,0 +1,150 @@
+# .github/workflows/agent-api-check.yml
+#
+# Detects breaking changes to the AgentTool ACTION contract - the actions an
+# agent dispatches and the parameters each action accepts - and posts a comment
+# on the PR. This is the surface most users of the SDK build against, and it is
+# NOT the Python signature surface the griffe breaking-change check covers: a
+# rename like add_camera(name=) -> add_camera(camera_name=) breaks agent code
+# without changing any public Python signature griffe would flag.
+#
+# The check builds a {action: [params]} snapshot from the simulation backend's
+# dispatcher (see .github/scripts/agent_api_snapshot.py), for both the base
+# branch and the PR, and diffs them. Because it reads _ACTION_ALIASES and method
+# signatures, it must IMPORT the backend, so it installs the sim-mujoco extra
+# (CPU-only) and renders headless with osmesa.
+#
+# INFORMATIONAL ONLY. It never blocks a merge - the signal is the PR comment.
+#
+# Actions are pinned to full commit SHAs per the AGENTS.md Action Pinning
+# convention (a mutable tag can be repointed to malicious code).
+
+name: Agent API Check
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'strands_robots/simulation/**'
+      - '.github/scripts/agent_api_snapshot.py'
+      - '.github/workflows/agent-api-check.yml'
+
+permissions:
+  contents: read       # checkout
+  pull-requests: write # post/update PR comment
+
+jobs:
+  check-agent-api:
+    name: Detect AgentTool API Breaking Changes
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install system dependencies (OpenGL for MuJoCo)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libosmesa6-dev
+
+      # Importing the sim backend needs the sim-mujoco extra. CPU-only backend,
+      # headless osmesa rendering - no GPU required.
+      - name: Install strands-robots (sim-mujoco)
+        env:
+          UV_TORCH_BACKEND: cpu
+        run: pip install --no-cache-dir -e ".[sim-mujoco]"
+
+      # Snapshot the PR's action contract.
+      - name: Snapshot PR contract
+        env:
+          MUJOCO_GL: osmesa
+        run: python .github/scripts/agent_api_snapshot.py snapshot /tmp/api_pr.json
+
+      # Snapshot the base branch's contract. Check out the base worktree, install
+      # it, and run the SAME script from the PR (the base branch may not carry the
+      # script yet, so copy the PR's copy in). If the base cannot be snapshotted
+      # (e.g. the script is new), emit a neutral note instead of failing.
+      - name: Snapshot base contract
+        id: base
+        env:
+          MUJOCO_GL: osmesa
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set +e
+          git worktree add /tmp/base "origin/${BASE_REF}" 2>/tmp/wt.err
+          if [ $? -ne 0 ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::could not create base worktree: $(cat /tmp/wt.err)"
+            exit 0
+          fi
+          # Use the PR's script + PR's install (contract is read from the checked-out
+          # base source tree, so run the script with /tmp/base as CWD).
+          cp .github/scripts/agent_api_snapshot.py /tmp/base/.github/scripts/agent_api_snapshot.py 2>/dev/null || true
+          ( cd /tmp/base && python "${GITHUB_WORKSPACE}/.github/scripts/agent_api_snapshot.py" snapshot /tmp/api_base.json )
+          if [ ! -f /tmp/api_base.json ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::base snapshot not produced; skipping diff"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Diff contracts
+        id: diff
+        if: steps.base.outputs.skip != 'true'
+        run: |
+          set +e
+          python .github/scripts/agent_api_snapshot.py diff /tmp/api_base.json /tmp/api_pr.json
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+
+      - name: Neutral note when base skipped
+        if: steps.base.outputs.skip == 'true'
+        run: |
+          printf '%s\n' \
+            "## AgentTool API Check Skipped" "" \
+            "The base branch contract could not be snapshotted (usually because this check is new on the base). It will run normally once merged." \
+            > /tmp/agent-api-changes.md
+
+      - name: Post or update PR comment
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7.1.0
+        env:
+          DIFF_EXIT: ${{ steps.diff.outputs.exit_code }}
+        with:
+          script: |
+            const fs = require('fs');
+            let body = '';
+            try {
+              body = fs.readFileSync('/tmp/agent-api-changes.md', 'utf8');
+            } catch (e) {
+              body = '## AgentTool API Check\n\nNo report produced.';
+            }
+            const marker = '<!-- agent-api-check -->';
+            const fullBody = `${marker}\n${body}`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                comment_id: existing.id, body: fullBody,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number, body: fullBody,
+              });
+            }
+            if (process.env.DIFF_EXIT === '1') {
+              core.warning('AgentTool breaking changes detected - see PR comment.');
+            }

--- a/.github/workflows/agent-api-check.yml
+++ b/.github/workflows/agent-api-check.yml
@@ -112,7 +112,27 @@ jobs:
             "The base branch contract could not be snapshotted (usually because this check is new on the base). It will run normally once merged." \
             > /tmp/agent-api-changes.md
 
-      - name: Post or update PR comment
+      # Always write the report to the job summary. This needs no token
+      # permissions and works on fork PRs (where GITHUB_TOKEN is read-only), so
+      # the signal is never lost even if the PR comment cannot be posted.
+      - name: Write job summary
+        if: always()
+        run: |
+          if [ -f /tmp/agent-api-changes.md ]; then
+            cat /tmp/agent-api-changes.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            printf '%s\n' "## AgentTool API Check" "" "No report produced." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      # Posting a PR comment needs issues:write, which GitHub forces to
+      # read-only for pull_request events from forks. This step is therefore
+      # best-effort: a 403 is logged as a notice and does not fail the job. The
+      # authoritative report is the job summary above. We do NOT switch to
+      # pull_request_target, which would run untrusted PR code (this workflow
+      # installs and imports the branch) with a write token.
+      - name: Post or update PR comment (best-effort)
+        if: always()
+        continue-on-error: true
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7.1.0
         env:
           DIFF_EXIT: ${{ steps.diff.outputs.exit_code }}
@@ -128,23 +148,29 @@ jobs:
             const marker = '<!-- agent-api-check -->';
             const fullBody = `${marker}\n${body}`;
 
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-            });
-            const existing = comments.find(c => c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner, repo: context.repo.repo,
-                comment_id: existing.id, body: fullBody,
+            try {
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
               });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner, repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number, body: fullBody,
-              });
+              const existing = comments.find(c => c.body.includes(marker));
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  comment_id: existing.id, body: fullBody,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  issue_number: context.payload.pull_request.number, body: fullBody,
+                });
+              }
+            } catch (e) {
+              // Expected on fork PRs: GITHUB_TOKEN is read-only, so commenting
+              // returns 403. The job summary carries the report; do not fail.
+              core.notice(`Could not post PR comment (${e.status || 'error'}); see the job summary for the AgentTool API report.`);
             }
             if (process.env.DIFF_EXIT === '1') {
-              core.warning('AgentTool breaking changes detected - see PR comment.');
+              core.warning('AgentTool breaking changes detected - see the job summary / PR comment.');
             }


### PR DESCRIPTION
## What

Adds an informational PR check for the **AgentTool action contract** - the actions an agent dispatches and the parameters each action accepts. It complements the griffe Python-API breaking-change check by covering a different, agent-facing surface.

- `.github/scripts/agent_api_snapshot.py` - builds a `{action: [params]}` snapshot from the MuJoCo backend's dispatcher and diffs two snapshots
- `.github/workflows/agent-api-check.yml` - snapshots the base branch and the PR, diffs them, posts a single persistent PR comment

## Why this is separate from the griffe check

The surface most users build against is not only the Python signature surface. It is the dispatched actions: `add_camera`, `run_policy`, `start_recording`, and their parameters. A rename like `add_camera(name=...)` becoming `add_camera(camera_name=...)` breaks agent code that calls the tool, but changes no public Python signature - so a static Python-API diff does not see it. The dispatcher validates action parameters against each method's signature (resolved through the action enum in `tool_spec.json` and `_ACTION_ALIASES`), so this check snapshots exactly that contract.

## Behavior

- **Informational only - never blocks a merge.** The signal is the PR comment.
- Removed actions and removed/renamed parameters are flagged as breaking; new actions and new parameters are reported separately as backward-compatible.
- Reading `_ACTION_ALIASES` and method signatures requires importing the backend, so the job installs the `sim-mujoco` extra (CPU-only, headless `osmesa`). If the base branch cannot be snapshotted (for example, this check is new on the base), it posts a neutral "skipped" note rather than failing.
- Actions are pinned to full commit SHAs per the AGENTS.md Action Pinning convention.

## Testing

Validated locally: the snapshot captures all 65 declared actions; a clean diff reports no changes (exit 0); and a simulated `add_camera` `name` -> `camera_name` rename plus an action removal are both flagged as breaking (exit 1), while added parameters are correctly bucketed as non-breaking. No package code changed - one script and one workflow.
