### PR TITLE
fix(build): remove git-only vera extra that breaks PyPI upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,7 +553,7 @@ create_policy("lerobot/act_aloha_sim_transfer_cube")   # local HF inference
 | `mock` | none | Sinusoidal trajectories; `requires_images=False` (~10x faster) |
 | `groot` | NVIDIA GR00T N1.5/N1.6/N1.7 | Service mode (ZMQ to a Docker container) or local in-process (`model_path=`) |
 | `lerobot_local` | HuggingFace | Direct ACT / Pi0 / SmolVLA / Diffusion inference, no server |
-| `vera` | MIT VERA (DFoT/WAN planner + Jacobian IDM) | Two-stage video-to-action over a WebSocket GPU server (Docker); PushT + MimicGen, IK for eef-delta arms |
+| `vera` | MIT VERA (DFoT/WAN planner + Jacobian IDM) | Two-stage video-to-action over a WebSocket GPU server (Docker); PushT + MimicGen, IK for eef-delta arms. **Git-only** (not on PyPI, no extra): `pip install 'vera @ git+https://github.com/sizhe-li/VERA.git'` plus `websockets msgpack numpy` |
 
 ```mermaid
 classDiagram

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -282,12 +282,14 @@ device-connect = [
 ros2 = [
     "cyclonedds>=0.10.2,<1.0.0",
 ]
-vera = [
-    "vera @ git+https://github.com/sizhe-li/VERA.git",
-    "websockets>=14",
-    "msgpack>=1",
-    "numpy>=1.24",
-]
+# NOTE: There is intentionally no `vera` extra. VERA is only distributed as a
+# git repository (https://github.com/sizhe-li/VERA) and PyPI rejects any package
+# whose metadata contains a direct URL/VCS reference (HTTP 400 on upload). The
+# VERA provider launches the git-installed `vera` package as a subprocess
+# (`python -m vera.server...`), so install it directly alongside strands-robots:
+#     pip install "strands-robots[vera-sim]" websockets msgpack "numpy>=1.24"
+#     pip install "vera @ git+https://github.com/sizhe-li/VERA.git"
+# See README (VERA row) and strands_robots/policies/vera/__init__.py.
 vera-sim = [
     "gymnasium==0.29.1",
     "gym-pusht==0.1.5",
@@ -332,9 +334,6 @@ Documentation = "https://github.com/strands-labs/robots#readme"
 Repository = "https://github.com/strands-labs/robots.git"
 Issues = "https://github.com/strands-labs/robots/issues"
 Changelog = "https://github.com/strands-labs/robots/releases"
-
-[tool.hatch.metadata]
-allow-direct-references = true  # VERA is a git-only dependency (see the 'vera' extra)
 
 [tool.hatch.version]
 source = "vcs"

--- a/scripts/audit_deps.py
+++ b/scripts/audit_deps.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Supply-chain audit for the project's declared dependencies.
 
-Guards against two classes of packaging defect:
+Guards against three classes of packaging defect:
 
 1. Dependency confusion / name hijacking -- a dependency whose distribution
    name is known to be unaffiliated with the upstream it claims to be (for
@@ -13,6 +13,13 @@ Guards against two classes of packaging defect:
    not resolve on PyPI at all. Catching these early stops a typo from becoming
    a future confusion target. This check hits the network and is only run when
    ``--check-pypi`` is passed.
+
+3. Direct references -- a PEP 508 ``name @ <url>`` requirement (git/URL/file).
+   Such a dependency lets the wheel build locally and pass ``twine check``, but
+   the PyPI upload endpoint hard-rejects any distribution whose metadata carries
+   a direct reference, so it silently breaks the release at the final upload
+   step. A git-only dependency must be documented as a manual install, never
+   declared as a dependency or extra of a distribution that ships to PyPI.
 
 Git-sourced dependencies (``pkg @ git+https://...``) and self-references
 (``strands-robots[...]``) are intentionally excluded: they never resolve from
@@ -122,10 +129,44 @@ def check_pypi_existence(deps: dict[str, str]) -> list[str]:
     return findings
 
 
+def collect_all_requirements(pyproject_path: Path) -> list[str]:
+    """Return every declared requirement string (core deps + all extras)."""
+    data = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    project = data.get("project", {})
+    requirements: list[str] = list(project.get("dependencies", []))
+    for deps in project.get("optional-dependencies", {}).values():
+        requirements.extend(deps)
+    return requirements
+
+
+def check_direct_references(pyproject_path: Path) -> list[str]:
+    """Return failure messages for any direct-reference (URL/VCS/file) dependency.
+
+    A PEP 508 direct reference (``name @ <url>``, e.g. ``pkg @ git+https://...``)
+    is the only place ``@`` may appear in a requirement string -- version
+    specifiers never use it -- so its presence unambiguously marks a direct
+    reference. PyPI rejects any uploaded distribution whose metadata carries one,
+    which is why declaring such a dependency (even behind ``allow-direct-references``)
+    breaks the publish at the upload step while passing ``twine check``.
+    """
+    findings = []
+    for req in collect_all_requirements(pyproject_path):
+        stripped = req.strip()
+        if "@" in stripped:
+            findings.append(
+                f"DIRECT REFERENCE '{stripped}': PyPI rejects distributions whose "
+                "metadata carries a VCS/URL reference, so this breaks the publish "
+                "at the upload step. Document a manual git install instead of "
+                "declaring it as a dependency or extra."
+            )
+    return findings
+
+
 def audit(pyproject_path: Path, check_pypi: bool = False) -> list[str]:
     """Run all enabled checks and return the combined findings list."""
     deps = collect_pypi_dependencies(pyproject_path)
     findings = check_denylist(deps)
+    findings.extend(check_direct_references(pyproject_path))
     if check_pypi:
         findings.extend(check_pypi_existence(deps))
     return findings

--- a/strands_robots/policies/vera/__init__.py
+++ b/strands_robots/policies/vera/__init__.py
@@ -17,7 +17,9 @@ Quickstart::
     #    export VERA_CKPT_ROOT=$PWD/vera-ckpts
     #
     # 2. Install VERA + extras (Python 3.11, torch 2.6 / CUDA 12.4):
-    #    pip install 'strands-robots[vera]'   # or: pip install -e 'VERA[idm,video]'
+    #    pip install 'vera @ git+https://github.com/sizhe-li/VERA.git'
+    #    pip install websockets msgpack 'numpy>=1.24'   # VERA websocket client deps
+    #    (VERA is git-only - not a strands-robots extra; PyPI rejects VCS refs)
 
     from strands_robots.policies import create_policy
 

--- a/strands_robots/policies/vera/server_runner.py
+++ b/strands_robots/policies/vera/server_runner.py
@@ -21,6 +21,38 @@ import threading
 import time
 from typing import TYPE_CHECKING
 
+
+def _require_vera_installed(python_executable: str) -> None:
+    """Verify the git-only ``vera`` package is importable, else raise clearly.
+
+    VERA (https://github.com/sizhe-li/VERA) is distributed only as a git
+    repository and cannot ship as a ``strands-robots`` extra, because PyPI
+    rejects any distribution whose metadata carries a direct VCS/URL reference.
+    The server is launched as ``python -m vera.server...`` in *python_executable*,
+    so that is the interpreter we probe.
+
+    Raises:
+        ImportError: with a git install instruction if ``vera`` is absent.
+    """
+    import subprocess
+
+    probe = subprocess.run(  # noqa: S603 - list args, no shell
+        [python_executable, "-c", "import vera"],
+        capture_output=True,
+        text=True,
+    )
+    if probe.returncode != 0:
+        raise ImportError(
+            "The 'vera' package is required to run the VERA policy server but is "
+            f"not importable in {python_executable}.\n"
+            "VERA is git-only (not on PyPI, and cannot be a strands-robots extra "
+            "because PyPI rejects direct VCS references). Install it directly:\n"
+            "  pip install 'vera @ git+https://github.com/sizhe-li/VERA.git'\n"
+            "  # plus the client deps: pip install websockets msgpack 'numpy>=1.24'\n"
+            "See strands_robots/policies/vera/__init__.py for the full quickstart."
+        )
+
+
 if TYPE_CHECKING:
     from .config import VeraConfig
 
@@ -97,6 +129,14 @@ class VeraServerRunner:
         if _port_open(cfg.host, int(cfg.server_port or 0)):
             logger.info("VERA server already listening on %s:%s; reusing", cfg.host, cfg.server_port)
             return
+
+        # Pre-flight: the git-only `vera` package must be importable in the
+        # target interpreter before we spawn `python -m vera.server...`. Without
+        # this check a missing install surfaces only as an opaque "server exited
+        # early (code 1)" RuntimeError several seconds later. VERA is NOT on PyPI
+        # (and cannot be a strands-robots extra: PyPI rejects direct VCS refs), so
+        # it must be installed directly from git.
+        _require_vera_installed(cfg.python_executable or sys.executable)
 
         cmd = self._build_command()
         env = {**os.environ, **cfg.server_env()}

--- a/tests/policies/vera/test_vera_server_lifecycle.py
+++ b/tests/policies/vera/test_vera_server_lifecycle.py
@@ -104,6 +104,41 @@ class _FakeCompleted:
 
 
 # --------------------------------------------------------------------------- #
+# _require_vera_installed — git-only install gate (PR #950 regression)
+# --------------------------------------------------------------------------- #
+class TestRequireVeraInstalled:
+    """VERA is git-only (not a PyPI extra); the runner must gate on it clearly.
+
+    Pins the fix for the v0.4.1 PyPI-upload failure: the `vera` extra carried a
+    `git+https` direct reference that PyPI rejects. With the extra removed, a
+    missing `vera` must raise an actionable ImportError *before* we spawn the
+    server (previously it surfaced as an opaque "exited early (code 1)").
+    """
+
+    def test_raises_importerror_with_git_hint_when_vera_absent(self, monkeypatch):
+        # Probe subprocess reports non-zero -> `import vera` failed.
+        monkeypatch.setattr(sr.subprocess, "run", lambda *a, **k: _FakeCompleted(returncode=1))
+        with pytest.raises(ImportError, match="git\\+https://github.com/sizhe-li/VERA"):
+            sr._require_vera_installed("python3")
+
+    def test_passes_silently_when_vera_importable(self, monkeypatch):
+        # Probe subprocess reports success -> `import vera` worked.
+        monkeypatch.setattr(sr.subprocess, "run", lambda *a, **k: _FakeCompleted(returncode=0))
+        sr._require_vera_installed("python3")  # must not raise
+
+    def test_probes_the_target_interpreter(self, monkeypatch):
+        seen: dict[str, object] = {}
+
+        def _capture(cmd, **kwargs):
+            seen["cmd"] = cmd
+            return _FakeCompleted(returncode=0)
+
+        monkeypatch.setattr(sr.subprocess, "run", _capture)
+        sr._require_vera_installed("/custom/python")
+        assert seen["cmd"] == ["/custom/python", "-c", "import vera"]
+
+
+# --------------------------------------------------------------------------- #
 # VeraServerRunner lifecycle
 # --------------------------------------------------------------------------- #
 class TestVeraServerRunnerStart:
@@ -120,6 +155,8 @@ class TestVeraServerRunnerStart:
         assert runner.is_running() is False
 
     def test_launches_and_returns_once_ready(self, monkeypatch):
+        # Bypass the git-only vera install gate; this test covers supervision.
+        monkeypatch.setattr(sr, "_require_vera_installed", lambda *a, **k: None)
         # First probe (reuse check) -> down; second probe (ready poll) -> up.
         probes = iter([False, True])
         monkeypatch.setattr(sr, "_port_open", lambda *a, **k: next(probes))
@@ -137,6 +174,7 @@ class TestVeraServerRunnerStart:
         assert "vera.server.start_vera_server" in captured["cmd"]
 
     def test_raises_when_server_exits_before_ready(self, monkeypatch):
+        monkeypatch.setattr(sr, "_require_vera_installed", lambda *a, **k: None)
         monkeypatch.setattr(sr, "_port_open", lambda *a, **k: False)
         # poll() reports an exit code -> process died during startup.
         monkeypatch.setattr(sr.subprocess, "Popen", lambda *a, **k: _FakeProc(poll_values=[1], stdout=None))
@@ -145,6 +183,7 @@ class TestVeraServerRunnerStart:
             runner.start()
 
     def test_times_out_when_never_ready(self, monkeypatch):
+        monkeypatch.setattr(sr, "_require_vera_installed", lambda *a, **k: None)
         monkeypatch.setattr(sr, "_port_open", lambda *a, **k: False)
         proc = _FakeProc(poll_values=[None], stdout=None)
         monkeypatch.setattr(sr.subprocess, "Popen", lambda *a, **k: proc)

--- a/tests/test_dependency_audit.py
+++ b/tests/test_dependency_audit.py
@@ -89,3 +89,47 @@ def test_denylist_names_are_canonicalized(tmp_path):
     )
     findings = audit_deps.audit(pyproject, check_pypi=False)
     assert findings, "canonicalized denylist match should fire"
+
+
+def test_pyproject_has_no_direct_reference_dependency():
+    """The live pyproject must declare no PEP 508 direct-reference dependency.
+
+    A ``name @ <url>`` requirement (git/URL/file) makes the PyPI upload endpoint
+    reject the distribution even though the wheel builds and passes ``twine
+    check`` -- this is what failed the v0.4.1 publish. Git-only dependencies must
+    be documented as a manual install, never declared as a dependency or extra.
+    """
+    findings = audit_deps.check_direct_references(_PYPROJECT)
+    assert findings == [], f"direct-reference dependency found: {findings}"
+
+
+def test_audit_flags_direct_reference_dependency(tmp_path):
+    """A re-introduced ``git+`` dependency must make the audit fail."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        "[project]\n"
+        'name = "x"\n'
+        'version = "0"\n'
+        'dependencies = ["numpy>=1.24"]\n'
+        "[project.optional-dependencies]\n"
+        'vera = ["vera @ git+https://github.com/sizhe-li/VERA.git"]\n',
+        encoding="utf-8",
+    )
+    findings = audit_deps.audit(pyproject, check_pypi=False)
+    assert any("DIRECT REFERENCE" in f and "vera" in f for f in findings), findings
+
+
+def test_direct_reference_check_ignores_extras_specifiers_and_markers(tmp_path):
+    """Self-referencing extras, version specifiers and markers are not flagged."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        "[project]\n"
+        'name = "x"\n'
+        'version = "0"\n'
+        'dependencies = ["numpy>=1.24", "torch>=2.0; platform_machine == \'aarch64\'"]\n'
+        "[project.optional-dependencies]\n"
+        'all = ["x[dev]"]\n'
+        'dev = ["pytest>=8"]\n',
+        encoding="utf-8",
+    )
+    assert audit_deps.check_direct_references(pyproject) == []


### PR DESCRIPTION
## Problem

The **v0.4.1 release failed** at the PyPI upload step with a bare `400 Bad Request` ([run](https://github.com/strands-labs/robots/actions/runs/28531170555/job/84583467143)). Build, twine check, and sigstore attestations all passed — only the final POST to `upload.pypi.org` was rejected.

**Root cause:** PyPI hard-rejects any distribution whose metadata contains a direct VCS/URL reference. The `vera` extra pinned:

```toml
vera = [
    "vera @ git+https://github.com/sizhe-li/VERA.git",
    ...
]
```

and `[tool.hatch.metadata] allow-direct-references = true` let the wheel **build locally and pass `twine check`** — but the PyPI upload endpoint refuses it. This is why v0.4.0 (no `vera` extra) published fine and v0.4.1 did not.

## Fix

- **pyproject.toml**: remove the `vera` extra and `allow-direct-references` (vera was the *only* direct ref in the file). Replace with a `NOTE` comment explaining the PyPI constraint.
- **server_runner.py**: add `_require_vera_installed()` pre-flight that probes `python -c 'import vera'` in the target interpreter before spawning `python -m vera.server...`, raising a clear `ImportError` with the git-install command. Previously a missing `vera` install surfaced only as an opaque `server exited early (code 1)` `RuntimeError` seconds later.
- **README.md** + **vera/__init__.py**: document the git install (`pip install 'vera @ git+https://github.com/sizhe-li/VERA.git'`) instead of the removed `[vera]` extra.

## Verification

- Wheel + sdist build cleanly (`HATCH_VCS_PRETEND_VERSION=0.4.1`)
- `twine check` **PASSED** on both
- **Zero** direct-ref `Requires-Dist` lines in the wheel METADATA
- `vera-sim` extra unaffected; `vera` was never in `[all]`
- `ruff check` + `ruff format --check` clean

## Release path after merge

The `v0.4.1` git tag exists but PyPI has nothing under 0.4.1 (upload never succeeded), so the version slot is still free. After merge, re-cut the tag on the new `main` (move `v0.4.1` or bump to `v0.4.2`) to re-trigger the publish workflow.

Fixes the failed publish for #180 release track.