### PR TITLE
test(dataset_recorder): cover rgb_encoder codec-surface ImportError fallback

### DIFF
--- a/tests/test_dataset_recorder.py
+++ b/tests/test_dataset_recorder.py
@@ -1385,3 +1385,32 @@ class TestCodecRouting:
         # silently reverting to the default codec.
         with pytest.raises(ValueError):
             _codec_create_kwargs({"rgb_encoder": None}, "not_a_codec")
+
+    def test_rgb_encoder_falls_back_when_config_class_missing(self, monkeypatch, caplog):
+        """A LeRobot exposing ``rgb_encoder=`` but whose ``RGBEncoderConfig`` is
+        unimportable must warn and route no codec surface (falling back to the
+        default) rather than crash dataset setup.
+
+        This mirrors the ``camera_encoder`` fallback contract: the two encoder-
+        config surfaces are equivalent version-drift shims, so a build that
+        renamed/moved ``RGBEncoderConfig`` should degrade identically to one that
+        dropped ``VideoEncoderConfig`` - a warning, an empty routing dict, and no
+        exception.
+        """
+        import sys
+
+        from strands_robots.dataset_recorder import _codec_create_kwargs
+
+        # Setting the import target to None makes
+        # ``from lerobot.configs.video import RGBEncoderConfig`` raise
+        # ImportError, exercising the fallback branch without needing a LeRobot
+        # build that actually lacks the class.
+        monkeypatch.setitem(sys.modules, "lerobot.configs.video", None)
+
+        with caplog.at_level("WARNING"):
+            out = _codec_create_kwargs({"rgb_encoder": None}, "libsvtav1", context="create")
+
+        # No codec surface routed -> recorder uses the LeRobot default codec.
+        assert out == {}
+        # The warning names the missing config class so the cause is actionable.
+        assert any("RGBEncoderConfig" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Problem

`_codec_create_kwargs` in `strands_robots/dataset_recorder.py` routes the requested video codec onto whichever LeRobot codec surface a given release exposes (flat `vcodec=`, `rgb_encoder=RGBEncoderConfig(...)`, or `camera_encoder=VideoEncoderConfig(...)`). When the config class for the exposed surface can't be imported (a LeRobot build that renamed or moved it), the helper is designed to warn and route no codec surface so recording setup falls back to the default codec instead of crashing.

That fallback contract was pinned for the `camera_encoder` surface (`test_create_warns_when_video_encoder_config_missing`, `test_resume_warns_when_video_encoder_config_missing`) but the equivalent `rgb_encoder` fallback branch was untested. The two encoder-config surfaces are equivalent version-drift shims, so the asymmetry left a real resilience path (a build exposing `rgb_encoder=` but with an unimportable `RGBEncoderConfig`) unverified.

## Change

Adds `TestCodecRouting::test_rgb_encoder_falls_back_when_config_class_missing`, mirroring the existing `camera_encoder` fallback tests: it forces `from lerobot.configs.video import RGBEncoderConfig` to raise `ImportError` (via `monkeypatch.setitem(sys.modules, "lerobot.configs.video", None)`), then asserts the helper returns an empty routing dict and emits an actionable warning naming `RGBEncoderConfig` - never raising.

The test avoids constructing `RGBEncoderConfig`, so it stays robust regardless of the installed LeRobot's transformers lazy-import state.

## Coverage

Closes the previously-uncovered fallback branch in `_codec_create_kwargs` (the `rgb_encoder` ImportError path, `dataset_recorder.py:91-93`). Behavior-only assertions (return value + warning), no production code changed.

## Testing

`ruff check` + `ruff format --check` + `mypy` clean over `strands_robots tests tests_integ` (632 files, no issues). `tests/test_dataset_recorder.py` green (64 passed).