### PR TITLE
fix(sim): move_object repositions static objects instead of silently no-op'ing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: `move_object` silently no-op'd on static objects
+
+`Simulation.move_object(name, position=...)` moves an object by writing its
+freejoint `data.qpos`. Static objects (`is_static=True`) are welded to the
+worldbody and have no freejoint, so the write was skipped -- but the method
+still returned `{"status": "success", "text": "'<name>' moved to ..."}` while
+the body never moved and its stored `SimObject.position` stayed stale. This is
+the "success contract, no physical effect" failure mode the project forbids.
+
+`move_object` now repositions static objects by editing the body pose in the
+live `MjSpec` and recompiling the scene (preserving other joints' state), via a
+new `scene_ops.reposition_body_in_scene` helper -- mirroring how `add_object` /
+`remove_object` mutate the scene. Dynamic objects keep the cheap `data.qpos`
+path. A static-body recompile failure now reports `status="error"` rather than a
+misleading success.
+
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)
 
 The `vera-sim` extra pinned `mimicgen==1.0.0`, but NVlabs MimicGen has never

--- a/strands_robots/simulation/mujoco/scene_ops.py
+++ b/strands_robots/simulation/mujoco/scene_ops.py
@@ -16,6 +16,7 @@ Public API:
 * :func:`inject_object_into_scene` - ``SpecBuilder.add_object(spec, obj)`` + recompile.
 * :func:`inject_camera_into_scene` - ``SpecBuilder.add_camera(spec, cam)`` + recompile.
 * :func:`eject_body_from_scene` - ``SpecBuilder.remove_body(spec, name)`` + recompile.
+* :func:`reposition_body_in_scene` - edit a body's spec ``pos``/``quat`` + recompile.
 * :func:`eject_robot_from_scene` - walk the spec, delete everything namespaced
   under ``{robot_name}/``, then recompile.
 
@@ -216,6 +217,47 @@ def eject_body_from_scene(world: SimWorld, body_name: str) -> bool:
         # Matching legacy behaviour: return True so scene state stays consistent
         # (caller has already popped the Python-side dict entry).
         return True
+
+    return _recompile_preserving_state(world, spec)
+
+
+def reposition_body_in_scene(
+    world: SimWorld,
+    body_name: str,
+    position: list[float] | None = None,
+    orientation: list[float] | None = None,
+) -> bool:
+    """Reposition a body (by short name) by editing its spec pose and recompiling.
+
+    Used for STATIC objects, which have no freejoint and therefore cannot be
+    moved through ``data.qpos`` at runtime - MuJoCo welds a static body to the
+    worldbody with no DOF. Editing the spec body ``pos``/``quat`` and
+    recompiling (preserving other joints' state) is the only way to move a
+    welded fixture, mirroring :func:`inject_object_into_scene` /
+    :func:`eject_body_from_scene`.
+
+    ``position`` / ``orientation`` are applied only when provided (a ``None``
+    leaves that component untouched). Returns ``True`` on success, ``False`` if
+    the spec/body is missing or the recompile fails (both logged), so the
+    caller can surface a clean error instead of a silent no-op.
+    """
+    spec = _get_spec(world)
+    if spec is None or world._model is None:
+        logger.error("reposition_body: no spec or model in world")
+        return False
+
+    try:
+        body = spec.body(body_name)
+    except (KeyError, ValueError):
+        body = None
+    if body is None:
+        logger.warning("Body '%s' not found in spec - nothing repositioned", body_name)
+        return False
+
+    if position is not None:
+        body.pos = list(position)
+    if orientation is not None:
+        body.quat = list(orientation)
 
     return _recompile_preserving_state(world, spec)
 

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -85,6 +85,7 @@ from strands_robots.simulation.mujoco.scene_ops import (
     inject_robot_into_scene,
     patch_scene_mjcf,
     replace_scene_mjcf,
+    reposition_body_in_scene,
 )
 from strands_robots.simulation.mujoco.spec_builder import SpecBuilder, _validate_size
 from strands_robots.simulation.policy_runner import CooperativeStop
@@ -1564,6 +1565,25 @@ class MuJoCoSimEngine(
     def move_object(
         self, name: str, position: list[float] | None = None, orientation: list[float] | None = None
     ) -> dict[str, Any]:
+        """Move an existing object to a new pose.
+
+        ``position`` is ``[x, y, z]`` in meters; ``orientation`` is a
+        ``[w, x, y, z]`` quaternion. Either may be omitted to leave that
+        component unchanged.
+
+        Two paths, transparent to the caller:
+
+        * **Dynamic objects** (``is_static=False``, created with a freejoint)
+          are moved cheaply by writing ``data.qpos`` + a forward pass.
+        * **Static objects** (``is_static=True``, welded to the worldbody with
+          no DOF) cannot be moved through ``data.qpos``; they are repositioned
+          by editing the spec body pose and recompiling the scene (preserving
+          other joints' state), just like ``add_object`` / ``remove_object``.
+
+        Returns ``status="error"`` if the object is unknown or the static-body
+        recompile fails - it never reports success without actually moving the
+        object.
+        """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         if name not in self._world.objects:
@@ -1577,6 +1597,8 @@ class MuJoCoSimEngine(
 
         jnt_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, f"{name}_joint")
         if jnt_id >= 0:
+            # Dynamic object: a freejoint carries its pose, so move it cheaply
+            # through data.qpos + a forward pass (no recompile).
             qpos_addr = model.jnt_qposadr[jnt_id]
             if position:
                 data.qpos[qpos_addr : qpos_addr + 3] = position
@@ -1585,6 +1607,22 @@ class MuJoCoSimEngine(
                 data.qpos[qpos_addr + 3 : qpos_addr + 7] = orientation
                 self._world.objects[name].orientation = orientation
             mj.mj_forward(model, data)
+        elif position is not None or orientation is not None:
+            # Static object: welded to the worldbody with no freejoint, so it
+            # has no data.qpos slice to write - the old code fell through here
+            # and returned success while moving nothing (a silent no-op).
+            # Reposition it by editing the spec body pose and recompiling
+            # (preserving other joints' state), mirroring add_object /
+            # remove_object.
+            if not reposition_body_in_scene(self._world, name, position=position, orientation=orientation):
+                return {
+                    "status": "error",
+                    "content": [{"text": f"Failed to reposition '{name}' in the live scene."}],
+                }
+            if position is not None:
+                self._world.objects[name].position = position
+            if orientation is not None:
+                self._world.objects[name].orientation = orientation
 
         return {"status": "success", "content": [{"text": f"'{name}' moved to {position or 'same'}"}]}
 

--- a/tests/simulation/mujoco/test_move_object_static_reposition.py
+++ b/tests/simulation/mujoco/test_move_object_static_reposition.py
@@ -1,0 +1,109 @@
+"""Regression tests: ``move_object`` must actually move STATIC objects.
+
+A static object (``is_static=True``) is welded to the worldbody with no
+freejoint, so it has no ``data.qpos`` slice. The old ``move_object`` only wrote
+``data.qpos`` when a ``<name>_joint`` freejoint existed and otherwise fell
+through to ``return {"status": "success", ...}`` - reporting a successful move
+while the body never budged and its stored ``SimObject.position`` stayed stale.
+That is the "success contract, no physical effect" failure mode the project
+forbids ("never warn-and-continue; no silent defaults").
+
+These pin the corrected contract:
+
+* moving a static object repositions the compiled body AND updates the stored
+  ``SimObject`` pose (the previously-silent no-op);
+* orientation-only moves of a static object are applied;
+* the state of other (dynamic) objects survives the static-body recompile;
+* dynamic objects still move through the cheap ``data.qpos`` path;
+* an unknown object name is a loud error.
+"""
+
+import pytest
+
+mj = pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="test_move_static_sim", mesh=False)
+    s.create_world(gravity=[0, 0, -9.81])
+    yield s
+    s.cleanup()
+
+
+def _body_xpos(world, name):
+    bid = mj.mj_name2id(world._model, mj.mjtObj.mjOBJ_BODY, name)
+    assert bid >= 0, f"body {name!r} not found in compiled model"
+    return [float(x) for x in world._data.xpos[bid]]
+
+
+def _body_xquat(world, name):
+    bid = mj.mj_name2id(world._model, mj.mjtObj.mjOBJ_BODY, name)
+    assert bid >= 0, f"body {name!r} not found in compiled model"
+    return [float(x) for x in world._data.xquat[bid]]
+
+
+def test_move_static_object_repositions_body(sim):
+    """Moving a static fixture actually relocates the compiled body."""
+    sim.add_object("wall", shape="box", size=[0.2, 0.02, 0.1], position=[0.3, 0.0, 0.1], is_static=True)
+    assert _body_xpos(sim._world, "wall") == pytest.approx([0.3, 0.0, 0.1])
+
+    result = sim.move_object("wall", position=[0.5, 0.1, 0.2])
+    assert result["status"] == "success", result
+
+    # The previously-silent no-op: the body must have actually moved...
+    assert _body_xpos(sim._world, "wall") == pytest.approx([0.5, 0.1, 0.2])
+    # ...and the stored SimObject pose must reflect the new position.
+    assert list(sim._world.objects["wall"].position) == pytest.approx([0.5, 0.1, 0.2])
+
+
+def test_move_static_object_orientation_only(sim):
+    """An orientation-only move of a static object is applied."""
+    sim.add_object("wall", shape="box", size=[0.2, 0.02, 0.1], position=[0.3, 0.0, 0.1], is_static=True)
+    quat = [0.9238795, 0.0, 0.0, 0.3826834]  # 45 deg about +z
+
+    result = sim.move_object("wall", orientation=quat)
+    assert result["status"] == "success", result
+
+    assert _body_xquat(sim._world, "wall") == pytest.approx(quat, abs=1e-4)
+    # position untouched when only orientation is supplied
+    assert _body_xpos(sim._world, "wall") == pytest.approx([0.3, 0.0, 0.1])
+    assert list(sim._world.objects["wall"].orientation) == pytest.approx(quat)
+
+
+def test_static_move_preserves_dynamic_object_state(sim):
+    """Repositioning a static body must not reset other objects' state.
+
+    The static path recompiles the scene; a dynamic object mid-trajectory must
+    keep its qpos (not snap back to its spawn pose).
+    """
+    sim.add_object("wall", shape="box", size=[0.2, 0.02, 0.1], position=[0.3, 0.0, 0.1], is_static=True)
+    sim.add_object("cube", shape="box", size=[0.03, 0.03, 0.03], position=[0.0, 0.0, 0.30], is_static=False)
+    sim.step(60)  # cube falls away from its spawn height
+    cube_before = _body_xpos(sim._world, "cube")
+    assert cube_before[2] < 0.27  # it has actually left the spawn height
+
+    result = sim.move_object("wall", position=[0.5, 0.1, 0.2])
+    assert result["status"] == "success", result
+
+    cube_after = _body_xpos(sim._world, "cube")
+    # cube state preserved across the recompile (not reset to spawn 0.30)
+    assert cube_after == pytest.approx(cube_before, abs=5e-3)
+
+
+def test_move_dynamic_object_uses_qpos_path(sim):
+    """Dynamic objects still move (via the cheap data.qpos path)."""
+    sim.add_object("cube", shape="box", size=[0.03, 0.03, 0.03], position=[0.0, 0.0, 0.05], is_static=False)
+    result = sim.move_object("cube", position=[0.2, 0.2, 0.05])
+    assert result["status"] == "success", result
+    assert _body_xpos(sim._world, "cube") == pytest.approx([0.2, 0.2, 0.05])
+    assert list(sim._world.objects["cube"].position) == pytest.approx([0.2, 0.2, 0.05])
+
+
+def test_move_unknown_object_errors(sim):
+    """An unknown object name is a loud error, not a false success."""
+    result = sim.move_object("ghost", position=[0.0, 0.0, 0.0])
+    assert result["status"] == "error", result
+    assert "ghost" in result["content"][0]["text"]


### PR DESCRIPTION
## What

`Simulation.move_object(name, position=..., orientation=...)` moved objects by writing their freejoint `data.qpos`. Static objects (`is_static=True`) are welded to the worldbody and have **no freejoint**, so the write was skipped -- but the method still returned:

```
{"status": "success", "content": [{"text": "'wall' moved to [0.5, 0.1, 0.2]"}]}
```

...while the body never moved and its stored `SimObject.position` stayed stale. A "success contract, no physical effect" no-op.

Reproduction (before this change):

```python
sim.add_object("wall", shape="box", size=[0.2,0.02,0.1], position=[0.3,0,0.1], is_static=True)
sim.move_object("wall", position=[0.5, 0.1, 0.2])   # -> status="success"
# wall body xpos still [0.3, 0.0, 0.1]; sim._world.objects["wall"].position still [0.3, 0.0, 0.1]
```

## Change

`move_object` now repositions static objects by editing the body pose in the live `MjSpec` and recompiling the scene (preserving other joints' state), via a new `scene_ops.reposition_body_in_scene` helper -- the same spec-edit-then-recompile pattern used by `add_object` / `remove_object`. Dynamic objects keep the cheap `data.qpos` path (no recompile). A static-body recompile failure now returns `status="error"` instead of a misleading success.

Because the recompile preserves existing joint state, other dynamic objects mid-trajectory are not reset when a static fixture is repositioned (covered by a test).

## Visual proof (MuJoCo sim, headless EGL)

A red static fixture is repositioned and rotated 45deg via `move_object`; the compiled body actually relocates (green dynamic cube shown for context):

![move_object static before/after](https://github.com/cagataycali/robots/releases/download/artifact-move-static-1782934471/move_static_before_after.png)

## Tests

New `tests/simulation/mujoco/test_move_object_static_reposition.py` (5 tests). The two static-move assertions FAIL on the pre-fix code (body unmoved / stored pose stale) and pass after:

- static position move relocates the compiled body AND updates the stored pose
- static orientation-only move is applied (position untouched)
- a dynamic object's state survives the static-body recompile (not reset to spawn)
- dynamic objects still move via the `data.qpos` path
- an unknown object name is a loud `status="error"`

Local gate: `ruff` + `ruff format` clean, `mypy` clean on both changed source files, and the MuJoCo simulation suite passes (`1042 passed, 18 skipped`).

## Docs

- `move_object` gains a docstring documenting the dynamic vs static paths and the error contract.
- `scene_ops` module docstring lists the new `reposition_body_in_scene` helper.
- CHANGELOG `[Unreleased]` entry added.
