### PR TITLE
test(mesh/bridge): pin idempotent-teardown fail-soft contracts

### DIFF
--- a/tests/mesh/test_bridge_transport.py
+++ b/tests/mesh/test_bridge_transport.py
@@ -416,3 +416,59 @@ class TestDefaultBridgeSuffixesPinned:
                 f"{suffix!r} is documented as not bridged by default but is in "
                 f"DEFAULT_BRIDGE_SUFFIXES; remove it or update the documentation."
             )
+
+
+class TestSubHandleTeardownFailSoft:
+    """``_BridgeSubHandle.undeclare`` must swallow the documented transport-
+    teardown failure surface (already-closed handle / socket race) so idempotent
+    cleanup never propagates, while still tearing down the other side and
+    letting unexpected exceptions escape."""
+
+    @pytest.mark.parametrize("exc", [RuntimeError, AttributeError, OSError])
+    def test_undeclare_swallows_documented_transport_errors(self, exc):
+        raising, healthy = MagicMock(), MagicMock()
+        raising.undeclare.side_effect = exc("teardown race")
+        h = _BridgeSubHandle(raising, healthy)
+
+        h.undeclare()  # must not raise despite the zenoh side failing
+
+        raising.undeclare.assert_called_once()
+        # A failure on the first side must not abort teardown of the second.
+        healthy.undeclare.assert_called_once()
+
+    def test_undeclare_propagates_unexpected_error(self):
+        raising = MagicMock()
+        raising.undeclare.side_effect = ValueError("not a teardown error")
+        h = _BridgeSubHandle(raising, MagicMock())
+
+        with pytest.raises(ValueError):
+            h.undeclare()
+
+
+class TestBridgeCloseFailSoft:
+    """``BridgeTransport.close`` must swallow the documented transport-close
+    failure surface on either backend, still attempt to close both, and let
+    unexpected exceptions propagate."""
+
+    @pytest.mark.parametrize("exc", [RuntimeError, ConnectionError, OSError])
+    def test_close_swallows_documented_transport_errors(self, fake_transports, exc):
+        z, i = fake_transports
+        z.close.side_effect = exc("zenoh close race")
+        i.close.side_effect = exc("iot close race")
+        b = BridgeTransport(zenoh=z, iot=i)
+        b.connect()
+
+        b.close()  # must not raise despite both backends failing to close
+
+        # A failure closing zenoh must not skip closing iot.
+        z.close.assert_called_once()
+        i.close.assert_called_once()
+
+    def test_close_propagates_unexpected_error(self, fake_transports):
+        z, i = fake_transports
+        z.close.side_effect = ValueError("not a close error")
+        b = BridgeTransport(zenoh=z, iot=i)
+        b.connect()
+
+        with pytest.raises(ValueError):
+            b.close()


### PR DESCRIPTION
## Problem

`BridgeTransport.close()` and `_BridgeSubHandle.undeclare()` in `strands_robots/mesh/transport/bridge_transport.py` document a deliberately narrow fail-soft teardown contract: idempotent cleanup swallows the documented transport-close failure surface (already-closed handle, connection drop racing with close, socket teardown race) so it never propagates, while still tearing down the *other* backend and letting *unexpected* exceptions escape.

Those exception branches were unpinned. A future refactor could narrow the caught set (breaking idempotent teardown → a crash on `close()`) or broaden it to `except Exception` (hiding real bugs) with no test catching either regression.

## Change

Test-only. Adds four hermetic tests (both transports mocked, no network) to `tests/mesh/test_bridge_transport.py`:

- `undeclare` swallows `RuntimeError`/`AttributeError`/`OSError` raised by one side and still undeclares the other side.
- `undeclare` propagates an unexpected error (narrowness guard).
- `close` swallows `RuntimeError`/`ConnectionError`/`OSError` from both backends and still attempts to close both.
- `close` propagates an unexpected error (narrowness guard).

The tests assert observable behavior (no propagation for documented errors, propagation for undocumented ones, both sides always attempted) rather than internal state.

## Coverage

`bridge_transport.py`: the previously-uncovered `undeclare` error-swallow loop and both `close` exception handlers are now exercised, taking the module from 90% to ~94% (12 previously-uncovered statements pinned).

## Verification

`pytest tests/mesh/test_bridge_transport.py` — 60 passed. `ruff check` / `ruff format --check` / `mypy` clean. No production code touched.