### PR TITLE
docs(readme): correct simulation action count 64 -> 65

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ sim.step(100)   # publishes /so101/joint_states + camera image_raw on the ROS 2 
   plus classical motion planners, MPC, and scripted controllers behind one ABC.
 - **Mesh networking built in.** Every robot is a Zenoh peer. `tell()` another
   robot what to do; broadcast an E-STOP; bridge to AWS IoT Core for fleets.
-- **64-action simulation tool.** World building, physics, rendering, domain
+- **65-action simulation tool.** World building, physics, rendering, domain
   randomization, and LeRobotDataset recording - all agent-callable.
 - **ROS 2 interop.** Observe + command any ROS 2 graph (`use_ros`), act as a
   robot with no rclpy (`use_rtps`), or expose a running sim as a ROS node.
@@ -208,7 +208,7 @@ agent = Agent(tools=[robot])
 agent("Wave the arm using the mock policy for 200 steps, then render a top-down view")
 ```
 
-`Robot("so100")` returns a `Simulation` instance - the full 64-action
+`Robot("so100")` returns a `Simulation` instance - the full 65-action
 simulation AgentTool. Drive it in natural language through an `Agent`, call its
 methods directly (`robot.render(camera_name="topdown")`), or dispatch an action
 by calling it (`robot(action="render", camera_name="topdown")`). See
@@ -492,7 +492,7 @@ AgentTool returning `{"status", "content"}`.
 | `start` | `instruction`, `policy_port`, `duration` | Non-blocking async start |
 | `status` | - | Current task status |
 | `stop` | - | Interrupt running task (emergency stop) |
-In sim mode the same tool exposes the 64 Simulation actions - see Simulation (MuJoCo).
+In sim mode the same tool exposes the 65 Simulation actions - see Simulation (MuJoCo).
 </details>
 
 <details>
@@ -775,7 +775,7 @@ same `target_pose` / `target_joints` / `world_update` kwargs through.
 ## Simulation (MuJoCo)
 
 `Robot("so100")` (sim mode) returns a `Simulation` - a MuJoCo-backed AgentTool
-exposing **64 actions** for world composition, physics, rendering, policy
+exposing **65 actions** for world composition, physics, rendering, policy
 execution, and dataset recording. Build it directly when you want full control:
 
 ```python
@@ -1079,7 +1079,7 @@ strands_robots/
 │   ├── base.py            # SimEngine ABC
 │   ├── factory.py         # create_simulation() + backend registry
 │   ├── models.py          # SimWorld / SimRobot / SimObject / SimCamera
-│   └── mujoco/            # MuJoCo backend (64-action AgentTool)
+│   └── mujoco/            # MuJoCo backend (65-action AgentTool)
 ├── mesh/                  # Zenoh mesh: core, sensors, input, audit, transport, iot
 ├── benchmarks/libero/     # LIBERO suite + BDDL parser + adapter
 └── tools/                 # gr00t_inference, lerobot_*, pose, serial, robot_mesh


### PR DESCRIPTION
## What

The README describes the MuJoCo simulation AgentTool as a "64-action" tool in five places, but the tool_spec enum has had **65 actions** since `list_bodies` was added in #655. This updates the five references to 65.

## Verification

```
strands_robots/simulation/mujoco/tool_spec.json -> action enum length = 65
```

Confirmed via git history that the count was exactly 64 before #655 (`list_bodies`) and 65 after, so this is a clean off-by-one that the README missed.

Lines updated: features list, `Robot()` factory note, hardware-mode note, Simulation section intro, and the repo-tree comment.

## Not touched

The `STRANDS_MESH_CA_PINS` row ("comma-separated **64-char hex**") is unrelated to the action count and is intentionally left as-is.

Docs only, no code changes.