### PR TITLE
fix(sim): bind replay/send_action action vector to actuators, not joints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -773,6 +773,30 @@ locomotion (closes #466). Clean-room against the upstream reference
   `simulate_rollout` at `examples/wbc_g1_torque_deploy.py` (the real weights
   produce a stable forward G1 walk).
 
+### Fixed: `replay_episode` / `send_action` vector bound to joints, not actuators
+
+`PolicyRunner.replay` (`Simulation.replay_episode`) mapped a recorded
+`LeRobotDataset` action vector positionally onto `robot_joint_names`, and
+`SimEngine._coerce_action` bound a raw numeric action vector passed to
+`send_action` the same way. But the dataset recorder writes the `action`
+column in the robot's *actuator* order (`robot_action_keys`), and `send_action`
+resolves actuator keys -- these diverge from the joint names whenever a robot
+has passive/mimic joints with no driving actuator or a tendon-driven gripper
+(e.g. `aloha`: 14 actuators vs 16 joints; `xarm7`; dexterous hands).
+
+The result was a silent record->replay round-trip corruption: replaying a
+dataset recorded by `start_recording` shifted the action vector across the
+wrong DOFs and dropped the grippers (their names have no matching joint), while
+`replay_episode` still returned `status="success"`. This is the "success
+contract, no physical effect" failure mode the project forbids, and mirrors the
+policy-keying fix already applied to `run_policy`/`eval_policy`.
+
+Positional action-vector binding now uses `robot_action_keys` in both paths, so
+a self-recorded episode round-trips onto the actuators it was recorded from. For
+robots whose actuators mirror their joints (e.g. `so101`) behaviour is
+unchanged. Pass `action_key_map=` to `replay_episode` to override the ordering
+for third-party datasets.
+
 ## [0.4.0] - 2026-06-16
 
 First tagged release since v0.3.8. Collapses the full v0.3.9 (mesh security hardening) and v0.4.0 (docs, policies, motion planners, hardware compatibility, plus the coverage and API-ergonomics hardening pass) work that had accumulated under topic-scoped `Unreleased` sections. No code changed in this release-prep step; the version is derived from the git tag via `hatch-vcs`.

--- a/docs/simulation/overview.md
+++ b/docs/simulation/overview.md
@@ -105,9 +105,9 @@ Robot-URDF cameras are auto-discovered on `add_robot`.
 | Form | Binding |
 |------|---------|
 | `{joint_or_actuator_name: value}` mapping | applied by name; unresolved keys are reported in an `unresolved_keys` JSON block so a caller can self-correct (no silent drop) |
-| ordered numeric vector (`list` / `tuple` / 1-D `numpy` array) | bound positionally to `robot_joint_names(robot_name)` in declaration order - the same convention `replay_episode` uses |
+| ordered numeric vector (`list` / `tuple` / 1-D `numpy` array) | bound positionally to `robot_action_keys(robot_name)` (the robot's actuator keys) in declaration order - the same convention `replay_episode` uses |
 
-A vector lets a policy's raw action chunk drive the arm directly without first zipping it into a dict. The vector length must match the robot's joint count exactly; a mismatch (or a non-numeric / scalar / string `action`) returns a structured `status="error"` dict naming the joint count and order, rather than crashing or silently truncating commands. Use a mapping to target a subset of joints.
+A vector lets a policy's raw action chunk drive the arm directly without first zipping it into a dict. It binds to `robot_action_keys` (not `robot_joint_names`) because those are the keys `send_action` resolves and the ordering the `LeRobotDataset` recorder writes the `action` column in; the two coincide unless a robot has passive/mimic joints or a tendon gripper. The vector length must match the robot's actuator count exactly; a mismatch (or a non-numeric / scalar / string `action`) returns a structured `status="error"` dict naming the actuator count and order, rather than crashing or silently truncating commands. Use a mapping to target a subset of actuators.
 
 ## Policy
 

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -249,9 +249,11 @@ class SimEngine(ABC):
     def robot_joint_names(self, robot_name: str) -> list[str]:
         """Return ordered joint names for ``robot_name``.
 
-        Used by ``Policy.set_robot_state_keys`` and by
-        ``PolicyRunner.replay`` to map dataset action-vector indices to
-        named joints. Order must match the backend's action ordering.
+        Used by ``Policy.set_robot_state_keys`` to name the
+        ``observation.state`` vector. Action-vector binding (``send_action``
+        with a numeric vector, ``PolicyRunner.replay``) uses
+        :meth:`robot_action_keys` instead - a robot's actuators are not always
+        its joints. Order must match the backend's joint ordering.
         """
         ...
 
@@ -420,17 +422,22 @@ class SimEngine(ABC):
         Policies and the ``Robot`` ABC commonly emit an ordered action *vector*
         (a ``list`` / ``tuple`` / 1-D ``numpy`` array) rather than a name->value
         mapping. To keep :meth:`send_action` usable directly with such a vector -
-        and consistent with :meth:`replay_episode`, which already binds a recorded
-        action vector positionally to ``robot_joint_names`` - a sequence is zipped
-        against ``robot_joint_names(robot_name)`` in declaration order. A mapping
-        is returned unchanged. The vector length must match the robot's joint
+        and consistent with :meth:`replay_episode`, which binds a recorded action
+        vector positionally to :meth:`robot_action_keys` - a sequence is zipped
+        against ``robot_action_keys(robot_name)`` in declaration order. Those are
+        the robot's *actuator* keys (what ``send_action`` resolves and what the
+        LeRobotDataset recorder writes the ``action`` column in); they diverge
+        from ``robot_joint_names`` whenever a robot has passive/mimic joints with
+        no driving actuator or a tendon-driven gripper, so binding a raw action
+        vector to joint names there mis-maps or drops commanded DOFs. A mapping
+        is returned unchanged. The vector length must match the robot's actuator
         count exactly; a mismatch is reported as a caller error rather than
         silently truncated (which would drop commands - e.g. a gripper axis).
 
         Args:
             action: A ``{name: value}`` mapping, or an ordered numeric vector
-                whose entries correspond to ``robot_joint_names(robot_name)``.
-            robot_name: Resolved robot whose joint order defines the binding.
+                whose entries correspond to ``robot_action_keys(robot_name)``.
+            robot_name: Resolved robot whose actuator order defines the binding.
 
         Returns:
             An ``(action_dict, error)`` tuple. When ``error`` is non-None it is a
@@ -465,22 +472,22 @@ class SimEngine(ABC):
                 "content": [{"text": f"send_action: action vector has a non-numeric entry: {exc}."}],
             }
 
-        joint_names = self.robot_joint_names(robot_name)
-        if len(values) != len(joint_names):
+        action_keys = self.robot_action_keys(robot_name)
+        if len(values) != len(action_keys):
             return None, {
                 "status": "error",
                 "content": [
                     {
                         "text": (
                             f"send_action: action vector length {len(values)} does not "
-                            f"match robot '{robot_name}' joint count {len(joint_names)}. "
-                            f"Joints (in order): {joint_names}. Pass a {{name: value}} "
-                            "mapping to target a subset of joints."
+                            f"match robot '{robot_name}' action-key count {len(action_keys)}. "
+                            f"Action keys (in order): {action_keys}. Pass a {{name: value}} "
+                            "mapping to target a subset of actuators."
                         )
                     }
                 ],
             }
-        return {name: value for name, value in zip(joint_names, values)}, None
+        return {name: value for name, value in zip(action_keys, values)}, None
 
     @abstractmethod
     def send_action(

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -303,11 +303,13 @@ class MuJoCoSimEngine(
 
         ``action`` is normally a ``{joint/actuator name: value}`` mapping, but an
         ordered numeric vector (``list`` / ``tuple`` / 1-D ``numpy`` array) is
-        also accepted and bound positionally to ``robot_joint_names(robot_name)``
+        also accepted and bound positionally to ``robot_action_keys(robot_name)``
         - the same positional convention :meth:`replay_episode` uses - so a
-        policy's raw action vector can be applied directly. A vector whose length
-        does not match the robot's joint count is rejected with an actionable
-        error rather than silently truncated.
+        policy's raw action vector can be applied directly. Those are the robot's
+        *actuator* keys, which diverge from its joint names when it has
+        passive/mimic joints or a tendon gripper. A vector whose length does not
+        match the robot's actuator count is rejected with an actionable error
+        rather than silently truncated.
 
         Thread-safety: acquires self._lock around ctrl writes + mj_step,
         as documented in base.py's SimEngine contract. Concurrent calls

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -1310,10 +1310,13 @@ class PolicyRunner:
             speed: Playback speed multiplier (1.0 = real time). Must be a
                 positive number; a non-positive or non-numeric value is
                 rejected with a structured error.
-            action_key_map: Optional list of joint names, one per action
-                vector index. Required when dataset joint ordering differs
-                from ``robot_joint_names(robot_name)``. If ``None``, positional
-                mapping to ``robot_joint_names`` is used.
+            action_key_map: Optional list of action keys, one per action
+                vector index. Required when dataset action ordering differs
+                from ``robot_action_keys(robot_name)``. If ``None``, positional
+                mapping to ``robot_action_keys`` is used - the robot's
+                *actuator* keys, which is the ordering the LeRobotDataset
+                recorder writes the ``action`` column in (a robot's actuators
+                are not always its joints; see :meth:`SimEngine.robot_action_keys`).
 
         Returns:
             Standard status dict with per-frame stats.
@@ -1359,8 +1362,16 @@ class PolicyRunner:
         except Exception as e:  # noqa: BLE001 - library errors are opaque
             return {"status": "error", "content": [{"text": f"{e}"}]}
 
-        # Resolve joint name ordering for action vector index → action dict.
-        joint_names = list(action_key_map) if action_key_map else self.sim.robot_joint_names(resolved_robot)
+        # Resolve the action-key ordering for action-vector index -> action
+        # dict. The recorded ``action`` column is written in the robot's
+        # *actuator* order (SimEngine.robot_action_keys), which diverges from
+        # robot_joint_names whenever a robot has passive/mimic joints with no
+        # driving actuator or a tendon-driven gripper. Mapping the recorded
+        # vector back onto joint names there shifts/drops the recorded values
+        # (send_action cannot resolve passive-joint names) while replay still
+        # reports success - a silent round-trip corruption. Bind to the same
+        # actuator keys the recorder used so record -> replay round-trips.
+        action_keys = list(action_key_map) if action_key_map else self.sim.robot_action_keys(resolved_robot)
 
         dataset_fps = getattr(ds, "fps", 30)
         frame_interval = 1.0 / (dataset_fps * speed)
@@ -1404,9 +1415,9 @@ class PolicyRunner:
 
                 action_dict: dict[str, Any] = {}
                 for i, val in enumerate(action_vals):
-                    if i >= len(joint_names):
+                    if i >= len(action_keys):
                         break
-                    action_dict[joint_names[i]] = float(val)
+                    action_dict[action_keys[i]] = float(val)
 
                 self.sim.send_action(action_dict, robot_name=resolved_robot)
                 frames_applied += 1

--- a/tests/simulation/mujoco/test_replay_action_actuator_mapping.py
+++ b/tests/simulation/mujoco/test_replay_action_actuator_mapping.py
@@ -81,7 +81,7 @@ class TestReplayRoundTrip:
     """A self-recorded dataset replays onto the actuators it was recorded from."""
 
     def test_replay_maps_recorded_actions_to_actuators(self, aloha_sim):
-        lerobot = pytest.importorskip("lerobot")  # noqa: F841
+        pytest.importorskip("lerobot")
         from strands_robots.dataset_recorder import load_lerobot_episode
 
         root = tempfile.mkdtemp(prefix="aloha_replay_rt_")

--- a/tests/simulation/mujoco/test_replay_action_actuator_mapping.py
+++ b/tests/simulation/mujoco/test_replay_action_actuator_mapping.py
@@ -1,0 +1,127 @@
+"""Regression: positional action-vector binding uses actuators, not joints.
+
+A ``LeRobotDataset``'s ``action`` column is written in the robot's *actuator*
+order (``SimEngine.robot_action_keys``); see the recorder in
+``strands_robots/simulation/mujoco/recording.py``, which deliberately keys the
+action schema by actuators because keying by joint names "records all-zero
+action columns" for robots whose actuators differ from their joints.
+
+On replay the recorded vector must be mapped back onto the SAME actuator keys.
+Mapping it onto ``robot_joint_names`` instead (the pre-fix behaviour) mis-maps
+and silently drops commanded DOFs on any robot whose actuator set differs from
+its joint set - passive/mimic finger joints or a tendon-driven gripper - while
+``replay_episode`` still reports ``status="success"``: a silent record->replay
+round-trip corruption. The same convention governs ``send_action`` when given a
+raw numeric action vector (``SimEngine._coerce_action``).
+
+``aloha`` is the decisive case: 14 actuators (per-arm 6 joints + 1 gripper
+tendon) vs 16 joints (each arm adds 2 passive finger joints with no driving
+actuator). A 14-long action vector recorded in actuator order was previously
+mapped onto the 16-joint list, shifting the entire right arm by one index and
+dropping both grippers.
+"""
+
+from __future__ import annotations
+
+import tempfile
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+from strands_robots.simulation.policy_runner import PolicyRunner  # noqa: E402
+
+
+@pytest.fixture
+def aloha_sim():
+    s = Simulation()
+    s.create_world(ground_plane=True)
+    s.add_robot("aloha")
+    yield s
+    s.cleanup()
+
+
+def test_aloha_actuators_differ_from_joints(aloha_sim):
+    """Precondition: aloha has passive finger joints -> actuators != joints.
+
+    If this ever stops holding the round-trip test below is vacuous, so pin it.
+    """
+    joints = aloha_sim.robot_joint_names("aloha")
+    actuators = aloha_sim.robot_action_keys("aloha")
+    assert joints != actuators
+    assert len(actuators) == 14
+    assert len(joints) == 16
+    # The grippers are tendon actuators with no matching joint name; the finger
+    # joints are passive (no driving actuator).
+    assert "left/gripper" in actuators and "right/gripper" in actuators
+    assert "left/gripper" not in joints and "right/gripper" not in joints
+
+
+class TestSendActionVectorBindsToActuators:
+    """``send_action`` numeric vector binds to actuator order, not joint order."""
+
+    def test_actuator_length_vector_applies(self, aloha_sim):
+        """A vector of length == actuator count applies to every actuator."""
+        n = len(aloha_sim.robot_action_keys("aloha"))  # 14
+        result = aloha_sim.send_action([0.0] * n, robot_name="aloha", n_substeps=1)
+        assert result["status"] == "success", result
+        # No key was left unresolved (no silent drops).
+        assert not any(isinstance(b, dict) and b.get("json", {}).get("unresolved_keys") for b in result["content"])
+
+    def test_joint_length_vector_is_rejected(self, aloha_sim):
+        """A vector of length == joint count no longer matches the actuator count."""
+        n_joints = len(aloha_sim.robot_joint_names("aloha"))  # 16
+        result = aloha_sim.send_action([0.0] * n_joints, robot_name="aloha")
+        assert result["status"] == "error"
+        assert "action-key count 14" in result["content"][0]["text"]
+
+
+class TestReplayRoundTrip:
+    """A self-recorded dataset replays onto the actuators it was recorded from."""
+
+    def test_replay_maps_recorded_actions_to_actuators(self, aloha_sim):
+        lerobot = pytest.importorskip("lerobot")  # noqa: F841
+        from strands_robots.dataset_recorder import load_lerobot_episode
+
+        root = tempfile.mkdtemp(prefix="aloha_replay_rt_")
+        repo = "local/aloha_replay_rt"
+
+        # Record a short episode through the real recorder (no cameras -> fast,
+        # action-only). The recorder writes the action column in actuator order.
+        assert aloha_sim.start_recording(repo_id=repo, task="rt", fps=30, root=root, cameras=[])["status"] == "success"
+        assert (
+            aloha_sim.run_policy(
+                robot_name="aloha", policy_provider="mock", n_steps=6, control_frequency=30, fast_mode=True
+            )["status"]
+            == "success"
+        )
+        assert aloha_sim.stop_recording()["status"] == "success"
+
+        ds, _start, ep_len = load_lerobot_episode(repo, 0, root)
+        action_column_names = list(ds.meta.features["action"]["names"])
+        assert action_column_names == aloha_sim.robot_action_keys("aloha")
+
+        # Capture the action dicts replay emits to send_action.
+        emitted: list[list[str]] = []
+        original = aloha_sim.send_action
+
+        def spy(action, robot_name=None, n_substeps=1):
+            if isinstance(action, dict):
+                emitted.append(list(action.keys()))
+            return original(action, robot_name=robot_name, n_substeps=n_substeps)
+
+        aloha_sim.send_action = spy  # type: ignore[method-assign]
+        try:
+            rep = PolicyRunner(aloha_sim).replay(repo, robot_name="aloha", root=root, speed=1000.0)
+        finally:
+            aloha_sim.send_action = original  # type: ignore[method-assign]
+
+        assert rep["status"] == "success"
+        assert len(emitted) == ep_len
+        # Every replayed frame must map the recorded vector back onto the exact
+        # actuator keys the recorder wrote (positional round-trip). Pre-fix this
+        # bound to robot_joint_names, shifting the right arm and dropping the
+        # grippers (which have no matching joint name).
+        for keys in emitted:
+            assert keys == action_column_names

--- a/tests/simulation/mujoco/test_send_action_vector.py
+++ b/tests/simulation/mujoco/test_send_action_vector.py
@@ -4,11 +4,13 @@ A policy's ``get_actions`` naturally emits an ordered action *vector* (a list /
 tuple / 1-D numpy array), not a ``{joint: value}`` mapping. Before the fix,
 passing such a vector to ``send_action`` crashed deep in the actuator/joint
 name-lookup loop with ``AttributeError: 'list' object has no attribute 'items'``
-- a cryptic failure far from the call site. ``replay_episode`` already binds a
-recorded action vector positionally to ``robot_joint_names``, so ``send_action``
-is made consistent: a vector is zipped against the robot's joint order, a mapping
-is applied unchanged, and an ill-typed / wrong-length action returns an
-actionable error instead of crashing or being silently dropped.
+- a cryptic failure far from the call site. ``replay_episode`` binds a recorded
+action vector positionally to ``robot_action_keys`` (the robot's actuator keys,
+the ordering the dataset recorder writes the action column in), so ``send_action``
+is made consistent: a vector is zipped against the robot's actuator order, a
+mapping is applied unchanged, and an ill-typed / wrong-length action returns an
+actionable error instead of crashing or being silently dropped. For a robot whose
+actuators mirror its joints (e.g. so101) the two orderings coincide.
 """
 
 import numpy as np
@@ -64,8 +66,8 @@ class TestSendActionVector:
         assert result["status"] == "error"
         text = result["content"][0]["text"]
         assert "length 3" in text
-        assert "joint count 6" in text
-        # The valid joint order is surfaced so the caller can self-correct.
+        assert "action-key count 6" in text
+        # The valid actuator order is surfaced so the caller can self-correct.
         assert "1" in text and "6" in text
 
     def test_scalar_action_is_actionable_error(self, sim):


### PR DESCRIPTION
## Problem

`Simulation.replay_episode` (via `PolicyRunner.replay`) mapped a recorded `LeRobotDataset` action vector positionally onto **`robot_joint_names`**. But the dataset recorder writes the `action` column in the robot's **actuator** order (`robot_action_keys`) — see `simulation/mujoco/recording.py`, which keys the action schema by actuators precisely because keying by joint names "records all-zero action columns" — and `send_action` resolves actuator keys. These two orderings diverge whenever a robot has passive/mimic joints with no driving actuator, or a tendon-driven gripper (an actuator with no matching joint name).

The consequence is a silent record→replay round-trip corruption: replaying a dataset produced by `start_recording` maps the recorded vector across the **wrong DOFs** and drops the grippers entirely, while `replay_episode` still returns `status="success"`. This is the "success contract, no physical effect" failure mode the project forbids, and it is the mirror of the policy-keying fix already applied to `run_policy`/`eval_policy` (key by actuators, not joints).

`SimEngine._coerce_action` shares the defect: a raw numeric action vector passed to `send_action` was zipped against `robot_joint_names`, so a valid actuator-length policy vector (e.g. 14 for `aloha`) was rejected as a length mismatch against the 16 joints.

### Ground truth (aloha: 14 actuators vs 16 joints)

Recording then replaying a short episode through the real pipeline, the emitted keys diverge from the recorded action column from index 6 on:

```
dataset action column : [..., left/wrist_rotate, left/gripper,       right/waist, ..., right/gripper]   (robot_action_keys)
replay emitted (before): [..., left/wrist_rotate, left/left_finger,   left/right_finger, right/waist, ...] (robot_joint_names)
                                                  ^ left/gripper -> passive finger (dropped)   ^ entire right arm shifted by one; right/gripper never commanded
```

## Change

Bind positional action-vector binding to **`robot_action_keys`** in both paths:
- `PolicyRunner.replay` maps the recorded vector onto `robot_action_keys` (the ordering the recorder wrote).
- `SimEngine._coerce_action` zips a numeric `send_action` vector against `robot_action_keys`.

For robots whose actuators mirror their joints (e.g. `so101`) the two orderings coincide, so behaviour is unchanged; the Newton backend inherits the `robot_action_keys` fallback (== joints) and is likewise unaffected. `action_key_map=` on `replay_episode` still overrides the ordering for third-party datasets. Docstrings, the simulation overview doc, and CHANGELOG are updated.

## Tests

`tests/simulation/mujoco/test_replay_action_actuator_mapping.py` (new) records a real `aloha` episode via `start_recording` + `run_policy` and asserts the replayed action dicts map back onto the exact actuator keys the recorder wrote, plus that a 14-long (actuator-count) vector applies and a 16-long (joint-count) vector is rejected. All three behavioural assertions **fail on the pre-fix code** (right-arm shift + dropped grippers; vector length rejected against the joint count) and pass after. `test_send_action_vector.py` is updated for the actuator-order wording. Full `tests/simulation/` suite: 1824 passed, 21 skipped (both backends). `ruff` + `mypy` clean on the changed files.

## Rollout in MuJoCo (headless)

Replaying the same self-recorded `aloha` episode, before vs after — the two runs diverge in 30,466/172,800 pixels (17.6%) while both report `status="success"`. Only the after-fix run faithfully round-trips the recorded actuators (both grippers actuate; right arm tracks its recorded joints):

![before/after](https://github.com/cagataycali/robots/releases/download/artifact-replay-actuator-1782946027/replay_before_after.png)

Post-fix replay (overhead camera):

![replay](https://github.com/cagataycali/robots/releases/download/artifact-replay-actuator-1782946027/replay_postfix.gif)

---

## Review changelog

**Round 1** (`fcbe5cb`) — code-scanning follow-up:
- Dropped the unused `lerobot` local binding in the replay round-trip test (`pytest.importorskip("lerobot")` is called for its skip side effect only). Code scanning flagged the bound-but-unused local independently of the ruff `F841` suppression; removing the binding clears the finding and the now-redundant `# noqa` in one line, with no behavioural change to the test.
- Re-triggered CI on the fork-safe breaking-change-check (merged separately to `main`).