### PR TITLE
fix(ci): make breaking-change-check fork-safe

### DIFF
--- a/.github/workflows/breaking-change-check.yml
+++ b/.github/workflows/breaking-change-check.yml
@@ -25,7 +25,7 @@ on:
 
 permissions:
   contents: read       # checkout
-  pull-requests: write # post/update PR comment
+  pull-requests: write # post/update PR comment (read-only on fork PRs)
 
 jobs:
   check-breaking-changes:
@@ -154,49 +154,82 @@ jobs:
           sys.exit(0)
           PYEOF
 
+      # Always write the report to the job summary. This needs no token
+      # permissions and works on fork PRs (where GITHUB_TOKEN is read-only), so
+      # the signal is never lost even if the PR comment cannot be posted.
+      - name: Write job summary
+        if: always()
+        run: |
+          if [ -f /tmp/breaking-changes.md ]; then
+            cat /tmp/breaking-changes.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            printf '%s\n' "## Breaking Change Check" "" "No report produced." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       # Post or update a single persistent comment on the PR.
       # Uses a hidden HTML marker so subsequent pushes update the same comment
       # rather than creating a new one per commit.
-      - name: Post or update PR comment
+      #
+      # Best-effort: on pull_request events from a fork, GitHub forces
+      # GITHUB_TOKEN to read-only regardless of the permissions block above, so
+      # issues.createComment returns 403 "Resource not accessible by
+      # integration". We swallow that (continue-on-error + try/catch -> notice)
+      # because the authoritative report is the job summary written above. We do
+      # NOT switch to pull_request_target, which would run untrusted PR code with
+      # a write token.
+      - name: Post or update PR comment (best-effort)
+        if: always()
+        continue-on-error: true
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7.1.0
         env:
           GRIFFE_EXIT_CODE: ${{ steps.griffe.outputs.exit_code }}
         with:
           script: |
             const fs = require('fs');
-            const body = fs.readFileSync('/tmp/breaking-changes.md', 'utf8');
+            let body = '';
+            try {
+              body = fs.readFileSync('/tmp/breaking-changes.md', 'utf8');
+            } catch (e) {
+              body = '## Breaking Change Check\n\nNo report produced.';
+            }
 
             // Marker that identifies the comment as ours for future updates.
             const marker = '<!-- breaking-change-check -->';
             const fullBody = `${marker}\n${body}`;
 
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-            });
-
-            const existing = comments.find(c => c.body.includes(marker));
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body: fullBody,
-              });
-              console.log(`Updated existing breaking change comment (id: ${existing.id})`);
-            } else {
-              await github.rest.issues.createComment({
+            try {
+              const { data: comments } = await github.rest.issues.listComments({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.payload.pull_request.number,
-                body: fullBody,
               });
-              console.log('Created new breaking change comment');
+
+              const existing = comments.find(c => c.body.includes(marker));
+
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body: fullBody,
+                });
+                console.log(`Updated existing breaking change comment (id: ${existing.id})`);
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.payload.pull_request.number,
+                  body: fullBody,
+                });
+                console.log('Created new breaking change comment');
+              }
+            } catch (e) {
+              // Expected on fork PRs: GITHUB_TOKEN is read-only, so commenting
+              // returns 403. The job summary carries the report; do not fail.
+              core.notice(`Could not post PR comment (${e.status || 'error'}); see the job summary for the breaking change report.`);
             }
 
             const exitCode = process.env.GRIFFE_EXIT_CODE;
             if (exitCode === '1') {
-              core.warning('Breaking changes detected - see PR comment for details.');
+              core.warning('Breaking changes detected - see PR comment / job summary for details.');
             }


### PR DESCRIPTION
## Problem

The **Breaking Change Check** workflow crashes on PRs opened from a fork (e.g. #962):

```
RequestError [HttpError]: Resource not accessible by integration
  status: 403
  POST https://api.github.com/repos/strands-labs/robots/issues/962/comments
  x-accepted-github-permissions: 'issues=write; pull_requests=write'
```

### Root cause

On `pull_request` events **from a fork**, GitHub forces `GITHUB_TOKEN` to **read-only** regardless of the `permissions:` block in the workflow. So `github.rest.issues.createComment(...)` returns **403 "Resource not accessible by integration"**, and because the `actions/github-script` step was called bare (no error handling), the step — and the job — fail.

## Fix

Mirror the pattern already proven in the sibling `agent-api-check.yml` workflow:

1. **Add an always-run `Write job summary` step** that dumps the griffe report to `$GITHUB_STEP_SUMMARY`. This needs no token permissions and works on fork PRs, so the breaking-change signal is **never lost** even when the comment can't be posted.
2. **Make the comment step best-effort**: `continue-on-error: true` + wrap the Octokit calls in `try/catch`, downgrading the expected fork 403 to a `core.notice(...)` instead of crashing.

### Deliberately NOT done

- **No switch to `pull_request_target`.** That would run untrusted PR code with a write token — a well-known security footgun. The workflow remains informational-only and never blocks a merge; the job summary carries the authoritative report.

## Testing

- YAML validated with `yaml.safe_load` ✅
- Behavior matches `agent-api-check.yml`, which already handles fork PRs correctly.

FYI @strands-labs — this unblocks the CI on fork PR #962.