### PR TITLE
test(sim): pin bidirectional name/robot_name router alias and None-vector passthrough

### DIFF
--- a/tests/simulation/mujoco/test_agenttool_contract.py
+++ b/tests/simulation/mujoco/test_agenttool_contract.py
@@ -138,6 +138,42 @@ class TestRouterValidatesVectorDims:
         assert result["status"] == "error"
         assert "'gravity'" in result["content"][0]["text"]
 
+    def test_none_vector_param_skips_validation(self, sim):
+        # An explicit ``None`` for an optional vector param means "use the
+        # default", so the router must skip dimension/dtype validation and let
+        # the value flow through rather than rejecting it as malformed.
+        result = sim._dispatch_action(
+            "add_object",
+            {"name": "box_none_orient", "shape": "box", "orientation": None},
+        )
+        assert result["status"] == "success"
+
+
+class TestRouterNameRobotNameAlias:
+    """The router aliases ``name`` and ``robot_name`` in both directions so an
+    agent can use either spelling regardless of which one the target method
+    declares. Without this, a caller guessing the wrong name gets a spurious
+    "requires parameter" error instead of reaching the method.
+    """
+
+    def test_robot_name_alias_feeds_a_name_param(self, sim):
+        # remove_object's signature uses ``name``; passing ``robot_name`` must
+        # resolve to it. Proof: we reach the method (which reports the object
+        # is missing) instead of failing validation with "requires parameter".
+        result = sim._dispatch_action("remove_object", {"robot_name": "ghost"})
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert "ghost" in text
+        assert "requires parameter" not in text
+
+    def test_name_alias_feeds_a_robot_name_param(self, sim):
+        # stop_policy's signature uses ``robot_name``; passing ``name`` must
+        # resolve to it. Proof: the method reports the named robot is unknown,
+        # rather than treating robot_name as empty (its default).
+        result = sim._dispatch_action("stop_policy", {"name": "ghost"})
+        assert result["status"] == "error"
+        assert "ghost" in result["content"][0]["text"]
+
 
 class TestRouterKwargsPassthrough:
     """Methods with **kwargs in signature accept unknown params without error."""


### PR DESCRIPTION
## Problem
The MuJoCo `Simulation` AgentTool router (`_dispatch_action` / `_validate_and_build_kwargs`) has two ergonomic contracts that were unexercised by the test suite:

1. **`name` <-> `robot_name` bidirectional aliasing.** A caller can use either spelling regardless of which one the target method declares (the router comment documents this). If a refactor dropped the alias, a valid call would start returning a spurious `requires parameter 'X'` error instead of reaching the method.
2. **`None` for an optional vector param.** An explicit `None` on a vector param (e.g. `orientation`, `color`) means use the default, so the router skips dimension/dtype validation and lets it flow through. If that skip regressed, a legitimate call would be rejected as malformed.

Both branches had zero coverage, so either could silently regress.

## Change
Adds three behavior-level tests (no production code change) that lock the contracts via the public dispatch path:

- `test_robot_name_alias_feeds_a_name_param`: dispatching `remove_object` with `robot_name=` reaches the method (object-not-found), not a `requires parameter` validation error.
- `test_name_alias_feeds_a_robot_name_param`: dispatching `stop_policy` with `name=` reaches the method (robot-not-found), not the empty-`robot_name` default path.
- `test_none_vector_param_skips_validation`: `add_object(orientation=None)` succeeds instead of being rejected.

Assertions check observable outputs (returned error/success messages), not internal state.

## Tests
All three added tests pass; the full `tests/simulation/mujoco/test_agenttool_contract.py` is green (66 passed). Verified the previously-uncovered router lines (the None-vector skip and both alias branches) are now covered. `ruff check` / `ruff format` clean.