### PR TITLE
test(sim): pin move_object static-reposition failure contract

### DIFF
--- a/tests/simulation/mujoco/test_move_object_static_reposition.py
+++ b/tests/simulation/mujoco/test_move_object_static_reposition.py
@@ -107,3 +107,55 @@ def test_move_unknown_object_errors(sim):
     result = sim.move_object("ghost", position=[0.0, 0.0, 0.0])
     assert result["status"] == "error", result
     assert "ghost" in result["content"][0]["text"]
+
+
+# The corrected static-object path routes through
+# ``reposition_body_in_scene`` (edit spec pose + recompile). That helper is
+# documented to return ``True`` on success and ``False`` when the spec/body is
+# missing or the recompile fails, so the ``move_object`` facade can surface a
+# loud error instead of the old silent no-op. The tests below pin that
+# failure contract - both the helper's bool return and the facade's
+# error-surfacing that depends on it.
+
+from strands_robots.simulation.mujoco import simulation as _sim_mod  # noqa: E402
+from strands_robots.simulation.mujoco.scene_ops import reposition_body_in_scene  # noqa: E402
+
+
+def test_reposition_missing_body_returns_false(sim):
+    """Repositioning a body absent from the spec is a clean False, not a crash.
+
+    A tracked object could desync from the compiled spec; the helper must
+    report the miss so the caller surfaces an error rather than silently
+    "succeeding" on a body that does not exist.
+    """
+    sim.add_object("wall", shape="box", size=[0.2, 0.02, 0.1], position=[0.3, 0.0, 0.1], is_static=True)
+    assert reposition_body_in_scene(sim._world, "no_such_body", position=[0.1, 0.2, 0.3]) is False
+
+
+def test_reposition_without_compiled_model_returns_false(sim):
+    """No compiled model -> the helper cannot recompile, so it returns False."""
+    sim.add_object("wall", shape="box", size=[0.2, 0.02, 0.1], position=[0.3, 0.0, 0.1], is_static=True)
+    saved_model = sim._world._model
+    sim._world._model = None
+    try:
+        assert reposition_body_in_scene(sim._world, "wall", position=[0.1, 0.2, 0.3]) is False
+    finally:
+        sim._world._model = saved_model
+
+
+def test_move_static_object_surfaces_error_when_reposition_fails(sim, monkeypatch):
+    """A failed static reposition must yield status=error, never silent success.
+
+    This locks the anti-silent-no-op contract at the facade boundary: when the
+    underlying spec-recompile cannot relocate the body, ``move_object`` reports
+    an error and leaves the stored ``SimObject`` pose untouched.
+    """
+    sim.add_object("wall", shape="box", size=[0.2, 0.02, 0.1], position=[0.3, 0.0, 0.1], is_static=True)
+    monkeypatch.setattr(_sim_mod, "reposition_body_in_scene", lambda *a, **k: False)
+
+    result = sim.move_object("wall", position=[0.5, 0.1, 0.2])
+
+    assert result["status"] == "error", result
+    assert "wall" in result["content"][0]["text"]
+    # The stored pose must NOT advance to the requested position on failure.
+    assert list(sim._world.objects["wall"].position) == pytest.approx([0.3, 0.0, 0.1])


### PR DESCRIPTION
## Problem

`Simulation.move_object` routes static objects (welded, no freejoint, so no `data.qpos` slice) through `reposition_body_in_scene`, which edits the body's spec pose and recompiles. The success paths of this are well covered, but the *failure* paths are not:

- `reposition_body_in_scene` is documented to return `False` when the spec/body is missing or the recompile fails (so the caller can surface a clean error instead of a silent no-op), yet the missing-body and no-compiled-model branches were untested.
- `move_object`'s error-surfacing branch (return `status=error` when the reposition fails) was likewise uncovered.

This is exactly the class of guard the project forbids to regress: a "success contract with no physical effect" silent no-op.

## Change

Test-only. Adds three focused regression tests to `tests/simulation/mujoco/test_move_object_static_reposition.py`:

1. `test_reposition_missing_body_returns_false` - repositioning a body absent from the live spec returns `False` (clean miss, not a crash or phantom success).
2. `test_reposition_without_compiled_model_returns_false` - a world with no compiled model returns `False` (cannot recompile).
3. `test_move_static_object_surfaces_error_when_reposition_fails` - when the underlying reposition fails, `move_object` returns `status=error` and leaves the stored `SimObject` pose untouched, never reporting a silent success.

These lock the documented bool contract of `reposition_body_in_scene` and the facade's anti-silent-no-op error surfacing at both layers.

## Coverage

Closes the previously-uncovered failure branches:
- `strands_robots/simulation/mujoco/scene_ops.py`: `reposition_body_in_scene` no-spec/model and body-not-found returns.
- `strands_robots/simulation/mujoco/simulation.py`: `move_object` static-reposition-failure error branch.

## Verification

- `ruff check strands_robots tests tests_integ` clean; `ruff format --check` clean.
- `mypy strands_robots tests tests_integ` clean (635 source files).
- `MUJOCO_GL=egl pytest tests/simulation/mujoco/test_move_object_static_reposition.py` - 8 passed; related suites (`test_error_paths.py`, `test_simulation.py`) - 197 passed.