### PR TITLE
test(rl): pin FastSAC truncation-bootstrap contract (time-out vs terminal)

### DIFF
--- a/tests/training/test_rl_sim_env.py
+++ b/tests/training/test_rl_sim_env.py
@@ -136,3 +136,67 @@ def test_close_is_noop() -> None:
     env = SimEnv(_engine(_OneJointEngine()), actor_obs_keys=["J"], reward_terms=[lambda e: 1.0], action_dim=1)
     # close() owns no resources (engine lifecycle is the caller's); it must not raise.
     env.close()
+
+
+# --- termination vs truncation classification (the SAC/PPO bootstrap contract) ---
+#
+# ``step`` MUST report a time-out (episode-length limit) and a genuine success
+# terminal as DISTINCT events: a time-out is a truncation whose successor value
+# is still bootstrapped, while a success is a terminal that stops the value
+# backup. Collapsing the two -- surfacing a time-out as ``terminated`` -- silently
+# breaks the off-policy target (the FastTD3 truncation-bootstrap bug, fixed
+# upstream Jun 2025). These pin that the flags never collapse.
+
+
+def test_step_timeout_is_truncation_not_terminal() -> None:
+    """A time-out sets done=1 but reports time_out (bootstrappable), NOT terminated."""
+    # max_episode_steps=1 -> the first step is a time-out; no success_fn -> never a terminal.
+    env = SimEnv(
+        _engine(_OneJointEngine()),
+        actor_obs_keys=["J"],
+        reward_terms=[lambda e: 1.0],
+        action_dim=1,
+        max_episode_steps=1,
+    )
+    env.reset()
+    _, _, done, info = env.step(torch.zeros(1, 1))
+    assert float(done.reshape(-1)[0]) == 1.0  # episode ends (the caller resets)
+    assert info["time_out"] is True  # ...but as a truncation -> bootstrap the value
+    assert info["terminated"] is False  # a time-out is NOT a terminal state
+
+
+def test_step_success_is_terminal_not_truncation() -> None:
+    """A success_fn hit sets terminated (no bootstrap), NOT time_out; disproves always-False."""
+    # success on the first step, with head-room before the time-out limit so the
+    # two conditions are unambiguously separable.
+    env = SimEnv(
+        _engine(_OneJointEngine()),
+        actor_obs_keys=["J"],
+        reward_terms=[lambda e: 1.0],
+        action_dim=1,
+        max_episode_steps=99,
+        success_fn=lambda e: True,
+    )
+    env.reset()
+    _, _, done, info = env.step(torch.zeros(1, 1))
+    assert float(done.reshape(-1)[0]) == 1.0
+    assert info["terminated"] is True  # genuine terminal -> stop the value backup
+    assert info["time_out"] is False  # not a truncation
+
+
+def test_step_truncation_boundary_is_exact() -> None:
+    """time_out fires exactly at step == max_episode_steps, not the step before."""
+    env = SimEnv(
+        _engine(_OneJointEngine()),
+        actor_obs_keys=["J"],
+        reward_terms=[lambda e: 1.0],
+        action_dim=1,
+        max_episode_steps=2,
+    )
+    env.reset()
+    _, _, done1, info1 = env.step(torch.zeros(1, 1))
+    assert float(done1.reshape(-1)[0]) == 0.0  # step 1 of 2 -> not yet a time-out
+    assert info1["time_out"] is False
+    _, _, done2, info2 = env.step(torch.zeros(1, 1))
+    assert float(done2.reshape(-1)[0]) == 1.0  # step 2 == limit -> time-out
+    assert info2["time_out"] is True

--- a/tests/training/test_rl_truncation_bootstrap.py
+++ b/tests/training/test_rl_truncation_bootstrap.py
@@ -1,0 +1,101 @@
+"""Truncation-bootstrap contract for the off-policy RL trainer (FastSAC).
+
+``SimpleReplayBuffer`` bootstraps the SAC target through a stored transition as
+``target = r + gamma * (1 - done) * q_next``. A time-out (the episode-length
+limit) is NOT a terminal state, so its successor value must still be
+bootstrapped: the buffer's ``done`` slot must carry ``info["terminated"]`` (the
+genuine terminal), never the env's ``done`` (which is ``terminated OR
+time_out``). Storing ``done`` would zero the bootstrap on every time-out -- the
+FastTD3 truncation-bootstrap bug fixed upstream in Jun 2025 -- and silently
+degrade training while every shape / smoke-train test stays green.
+
+These pin that ``FastSacTrainer.collect_rollout`` stores the terminal flag. They
+are ``torch``-only (no MuJoCo, no model downloads): a scripted fake env drives
+the done/terminated bookkeeping directly, so the contract runs in the fast CI
+lane rather than the GPU / physics lane where the smoke train lives.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+
+class _FakeTermEnv:
+    """Minimal ``SimEnv``-shaped fake whose ``step`` emits a scripted terminated/done.
+
+    Exposes only what ``FastSacTrainer.setup`` / ``collect_rollout`` touch:
+    device, obs/action dims, ``reset`` and ``step``. ``step`` returns the
+    ``SimEnv`` 4-tuple ``(obs, reward, done, info)`` with ``info["terminated"]``
+    and ``info["time_out"]`` controlled by ``terminated_flag`` so a test can
+    drive a time-out (done=1, terminated=0) or a genuine terminal
+    (done=1, terminated=1).
+    """
+
+    def __init__(self, terminated_flag: bool, device: str = "cpu") -> None:
+        self.device = torch.device(device)
+        self.num_actor_obs = 2
+        self.num_critic_obs = 2
+        self.num_actions = 1
+        self._terminated = terminated_flag
+        self.resets = 0
+
+    def _obs(self) -> dict:
+        return {
+            "actor_obs": torch.zeros(1, self.num_actor_obs, device=self.device),
+            "critic_obs": torch.zeros(1, self.num_critic_obs, device=self.device),
+        }
+
+    def reset(self) -> dict:
+        self.resets += 1
+        return self._obs()
+
+    def step(self, action):  # type: ignore[no-untyped-def]
+        # Every step ends the episode (done=1). Whether that end is a genuine
+        # terminal or a truncation is exactly what the trainer must record.
+        done = torch.tensor([1.0], dtype=torch.float32, device=self.device)
+        reward = torch.tensor([0.0], dtype=torch.float32, device=self.device)
+        info = {"time_out": (not self._terminated), "terminated": self._terminated}
+        return self._obs(), reward, done, info
+
+
+def _sac_trainer_on_fake(terminated_flag: bool):  # type: ignore[no-untyped-def]
+    """Build a ``FastSacTrainer`` set up on a scripted fake env, warmup branch only."""
+    from strands_robots.training.rl import RLTrainSpec
+    from strands_robots.training.rl.fast_sac import FastSacTrainer
+
+    trainer = FastSacTrainer()
+    spec = RLTrainSpec(
+        env_factory=lambda: _FakeTermEnv(terminated_flag),
+        output_dir="/tmp/sac_truncation_contract",
+        device="cpu",
+        rollout_steps=1,
+        batch_size=16,
+        # Keep the buffer below learning_starts so collect_rollout takes the
+        # random-action warmup branch and never calls actor_critic.sample -- the
+        # test isolates the done/terminated bookkeeping, not the policy output.
+        learning_starts=1_000,
+        normalize_obs=False,
+        seed=0,
+    )
+    trainer.setup(spec)
+    return trainer
+
+
+def test_collect_rollout_stores_terminal_not_done_on_timeout() -> None:
+    """A time-out (done=1, terminated=0) must be stored as done=0 (bootstrappable)."""
+    trainer = _sac_trainer_on_fake(terminated_flag=False)
+    trainer.collect_rollout()
+    assert trainer.buffer.size == 1
+    # The env reported done=1 but terminated=0; the buffer must record the
+    # terminal (0.0) so the SAC target still bootstraps through the truncation.
+    assert float(trainer.buffer._dones[0].item()) == 0.0
+
+
+def test_collect_rollout_stores_terminal_on_genuine_terminal() -> None:
+    """A genuine terminal (done=1, terminated=1) must be stored as done=1 (no bootstrap)."""
+    trainer = _sac_trainer_on_fake(terminated_flag=True)
+    trainer.collect_rollout()
+    assert trainer.buffer.size == 1
+    assert float(trainer.buffer._dones[0].item()) == 1.0

--- a/tests/training/test_rl_truncation_bootstrap.py
+++ b/tests/training/test_rl_truncation_bootstrap.py
@@ -17,9 +17,14 @@ lane rather than the GPU / physics lane where the smoke train lives.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, cast
+
 import pytest
 
 torch = pytest.importorskip("torch")
+
+if TYPE_CHECKING:
+    from strands_robots.training.rl import SimEnv
 
 
 class _FakeTermEnv:
@@ -67,7 +72,7 @@ def _sac_trainer_on_fake(terminated_flag: bool):  # type: ignore[no-untyped-def]
 
     trainer = FastSacTrainer()
     spec = RLTrainSpec(
-        env_factory=lambda: _FakeTermEnv(terminated_flag),
+        env_factory=lambda: cast("SimEnv", _FakeTermEnv(terminated_flag)),
         output_dir="/tmp/sac_truncation_contract",
         device="cpu",
         rollout_steps=1,


### PR DESCRIPTION
## What

Pins the truncation-bootstrap contract for the off-policy RL trainer (FastSAC), an explicit acceptance item of #861 ("Bootstrap-mask test: truncation -> bootstrap, true done -> no bootstrap") that had no regression test. Test-only; no production change.

## Why

The SAC target bootstraps through a stored transition as `target = r + gamma * (1 - done) * q_next`. A time-out (the episode-length limit) is **not** a terminal state, so its successor value must still be bootstrapped -- it is a truncation, not a terminal. Two surfaces own this contract and neither was pinned:

- **`SimEnv.step`** must classify a time-out as `info["time_out"]=True` / `info["terminated"]=False` (while `done` is still `1`), and a `success_fn` hit as `info["terminated"]=True` / `info["time_out"]=False`. The two flags must never collapse into a single `done`.
- **`FastSacTrainer.collect_rollout`** must store `info["terminated"]` (not the env `done`, which is `terminated OR time_out`) into the replay buffer's `done` slot, so a time-out is stored as `done=0` and the value backup bootstraps through it.

Collapsing either surface is the FastTD3 truncation-bootstrap bug fixed upstream in Jun 2025. It degrades training **silently**: every shape test, the circular-buffer test, and the smoke-train checkpoint test all stay green while the policy quietly learns worse.

## Changes

- `tests/training/test_rl_sim_env.py` (+3): pin `SimEnv.step` termination-vs-truncation classification, including the exact off-by-one boundary (`time_out` fires at `step == max_episode_steps`, not before).
- `tests/training/test_rl_truncation_bootstrap.py` (new): pin that `collect_rollout` stores the terminal flag, via a scripted fake env. Scenario A (time-out -> stored `done=0`) is the discriminating pin; Scenario B (genuine terminal -> stored `done=1`) disproves an always-zero implementation.

## Test lane

The trainer pin lives in a **new torch-only module** (no MuJoCo, no model downloads), so it runs in the fast CI lane rather than the physics lane where the FastSAC smoke train (`test_rl_fast_sac.py`, gated on a module-level `importorskip("mujoco")`) lives. Placing it there would have skipped it in the torch-only lane entirely.

## Regression proof

Both pins were verified to fail on the collapsed (pre-fix) form and pass on current code:

- Trainer: injecting `terminal = info["terminated"] or info["time_out"]` -> `test_collect_rollout_stores_terminal_not_done_on_timeout` fails (`1.0 == 0.0`).
- Env: injecting `"terminated": done` -> `test_step_timeout_is_truncation_not_terminal` fails (`True is False`).

All 13 tests across the two files pass with both source files intact; ruff check + format clean; ASCII-only.

Part of #858.

## §13 Changelog

- Round 1: initial submission.
