### PR TITLE
fix(sim): flag eval_policy success_rate as unmeasured when no success criterion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,25 @@ base, 9 actuators). LeKiwi auto-downloads and compiles on first sim use, steps
 stably, and renders from its `front`/`wrist` cameras. The existing hardware mapping
 is unchanged.
 
+### Fixed: `eval_policy` no longer reports a silently-meaningless `success_rate`
+
+`eval_policy` / `PolicyRunner.evaluate` default `success_fn=None`. With no
+success criterion (and no benchmark spec) an episode can never be marked
+successful, so the loop reported a hard `success_rate: 0.0` for every episode
+regardless of what the policy did - a value indistinguishable from a policy
+that genuinely failed every episode, emitted with no warning. Callers
+comparing checkpoints saw `0.0` for all of them and (correctly) concluded
+nothing, while the number read like a real measurement.
+
+The no-criterion path now logs a warning, annotates the human-readable text
+(`... [no success criterion - not measured]`), and adds a `success_measured`
+boolean to the returned json (`False` on the legacy path with no `success_fn`,
+`True` on the `success_fn`/benchmark-spec paths). `success_rate` stays numeric
+(`0.0`) for backward compatibility; check `success_measured` before trusting
+it. This extends the entry-point guards that already reject other
+fabricated-success-rate configs (non-positive `n_episodes`/`max_steps`, empty
+goal payloads).
+
 ### Added: routing-degradation telemetry so a silently-degraded LeRobot rollout is machine-detectable
 
 `LerobotLocalPolicy`'s heuristic (non-declarative) remap path keeps a rollout alive even when it cannot bind the observation to the model's inputs by name: a camera whose name matches no declared image feature is routed to a free slot positionally, and `observation.state` is composed from the observation's own scalar keys when none of `robot_state_keys` match (the generic `joint_0..N` fallback). Either makes the robot move on meaningless inputs while `run_policy` / `eval_policy` still report `status="success"` with `success_rate ~ 0`, and the only trace was a log line (the positional fallback on the preprocessor path did not even warn). Both fallbacks now flip a flag on the policy (`positional_fallback_used` / `generic_state_keys_used`) and emit a WARNING, and `run_policy` / `eval_policy` surface both flags in their JSON result block alongside the existing `action_errors` / load telemetry. A `True` flag on an otherwise-successful run is the signature of a misconfigured camera/state binding. No behaviour change for correctly-named observations (both flags stay `False`); the remap itself is unchanged.

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -1493,6 +1493,14 @@ class SimEngine(ABC):
         locomotion policies; ``target_pose`` / ``target_joints`` / ``world_update``
         for cuRobo / MoveIt2 - the issue #300 contract). Without it the eval ran
         such a policy with an empty goal and reported a meaningless success rate.
+
+        ``success_fn`` defaults to ``None``. With no ``success_fn`` (and no
+        benchmark spec) there is no criterion by which an episode can be marked
+        successful, so ``success_rate`` reports a hard ``0.0`` for every episode
+        regardless of what the policy does - indistinguishable from a policy that
+        genuinely failed every episode. This case logs a warning and sets
+        ``success_measured=false`` in the returned json; pass
+        ``success_fn="contact"`` (or a callable) to measure real task success.
         """
         robots = self.list_robots()
         if not robots:

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -1532,6 +1532,13 @@ class PolicyRunner:
             cost and latency masking are provable from the payload. When
             ``spec`` is used, it also contains ``cumulative_reward`` and
             ``avg_reward`` fields per episode and aggregate.
+
+            Every payload carries ``success_measured`` (bool): ``True`` when a
+            success criterion was in force (a ``spec`` or a non-``None``
+            ``success_fn``), ``False`` when neither was given. When ``False`` the
+            reported ``success_rate`` is a hard ``0.0`` that measures nothing
+            (no episode can be marked successful without a criterion), and a
+            warning is logged - check this flag before trusting ``success_rate``.
         """
         if spec is not None and success_fn is not None:
             return {
@@ -1588,6 +1595,24 @@ class PolicyRunner:
             resolved_check = self._resolve_success_fn(success_fn)
         except ValueError as e:
             return {"status": "error", "content": [{"text": f"{e}"}]}
+
+        # A None check means no success criterion was supplied (the
+        # success_fn=None default with no spec). The loop then never sets
+        # success=True, so success_rate reports a hard 0.0 for every
+        # episode - indistinguishable from a policy that genuinely failed
+        # every episode. Warn loudly and flag the payload so 0.0 is not
+        # mistaken for a measurement (mirrors the entry-point guards that
+        # reject other degenerate/fabricated success-rate configs).
+        success_measured = resolved_check is not None
+        if not success_measured:
+            logger.warning(
+                "evaluate()/eval_policy called without a success criterion "
+                "(success_fn=None and no spec): success_rate will be 0.0 for "
+                "every episode regardless of what the policy does and does "
+                "NOT measure task success. Pass success_fn (e.g. 'contact' "
+                "or a callable) or a benchmark spec to measure success; the "
+                "returned json flags this as success_measured=false."
+            )
 
         # T26: skip camera rendering when the policy does not need images.
         _skip_images = not getattr(policy, "requires_images", True)
@@ -1741,13 +1766,16 @@ class PolicyRunner:
                     "text": (
                         f"Evaluation: {type(policy).__name__} on '{robot_name}'\n"
                         f"Episodes: {n_episodes} | Success: {n_success}/{n_episodes} "
-                        f"({success_rate:.1%})\n"
+                        f"({success_rate:.1%})"
+                        + ("" if success_measured else " [no success criterion - not measured]")
+                        + "\n"
                         f"Avg steps: {avg_steps:.0f}/{max_steps}"
                     )
                 },
                 {
                     "json": {
                         "success_rate": round(success_rate, 4),
+                        "success_measured": success_measured,
                         "n_episodes": n_episodes,
                         "n_success": n_success,
                         "avg_steps": round(avg_steps, 1),
@@ -2075,6 +2103,7 @@ class PolicyRunner:
                 {
                     "json": {
                         "success_rate": round(success_rate, 4),
+                        "success_measured": True,
                         "n_episodes": n_episodes,
                         "n_success": n_success,
                         "n_failure": n_failure,

--- a/tests/simulation/test_policy_runner_behaviour.py
+++ b/tests/simulation/test_policy_runner_behaviour.py
@@ -758,3 +758,54 @@ class TestEvaluateOnFrameSuccessFnPath:
         assert result["status"] == "success"
         assert seen, "eval_policy did not forward on_frame to the success_fn path"
         assert seen == sorted(seen)
+
+
+class TestEvaluateSuccessMeasured:
+    """Guard against a silently-meaningless success_rate.
+
+    With no success criterion (``success_fn=None`` and no benchmark spec) an
+    episode can never be marked successful, so ``success_rate`` is a hard
+    ``0.0`` regardless of policy behaviour - indistinguishable from a policy
+    that genuinely failed every episode. The payload must flag this
+    (``success_measured=False``), the text must say so, and a warning must be
+    logged, so callers do not mistake the fabricated 0.0 for a measurement.
+    """
+
+    def test_no_success_criterion_flags_unmeasured_and_warns(self, sim_with_robot, caplog):
+        policy = MockPolicy()
+        policy.set_robot_state_keys(sim_with_robot.robot_joint_names("alice"))
+        runner = PolicyRunner(sim_with_robot)
+
+        with caplog.at_level("WARNING", logger="strands_robots.simulation.policy_runner"):
+            result = runner.evaluate("alice", policy, n_episodes=1, max_steps=3, success_fn=None)
+
+        assert result["status"] == "success"
+        payload = result["content"][-1]["json"]
+        # success_rate stays numeric (0.0) for backward compatibility ...
+        assert payload["success_rate"] == 0.0
+        # ... but the payload must flag that nothing was measured.
+        assert payload["success_measured"] is False
+        # The human-readable text must not present 0.0% as a real result.
+        text = result["content"][0]["text"]
+        assert "not measured" in text
+        # And a warning must be logged so interactive callers are not misled.
+        assert any("without a success criterion" in r.message for r in caplog.records), (
+            "expected a warning when eval runs with no success criterion"
+        )
+
+    def test_success_fn_marks_measured(self, sim_with_robot):
+        policy = MockPolicy()
+        policy.set_robot_state_keys(sim_with_robot.robot_joint_names("alice"))
+        runner = PolicyRunner(sim_with_robot)
+
+        result = runner.evaluate(
+            "alice",
+            policy,
+            n_episodes=1,
+            max_steps=3,
+            success_fn=lambda obs: True,
+        )
+        payload = result["content"][-1]["json"]
+        assert payload["success_measured"] is True
+        assert payload["success_rate"] == 1.0
+        assert "not measured" not in result["content"][0]["text"]


### PR DESCRIPTION
## Problem

`Simulation.eval_policy` / `PolicyRunner.evaluate` default `success_fn=None`. On the legacy path with no success criterion (and no benchmark spec), `_resolve_success_fn(None)` returns `None`, the rollout loop never sets `success=True`, and the method returns a hard `success_rate: 0.0` for **every** episode regardless of what the policy actually does.

That `0.0` is indistinguishable from a policy that genuinely failed every episode, and it is emitted with no warning. A user evaluating a checkpoint (`sim.eval_policy(robot_name="so101", policy_provider="...")` with the default `success_fn`) sees `0.0%` and reasonably concludes the policy is broken, when in fact no success was ever being measured. Comparing two checkpoints both report `0.0` and the number reads like a real measurement.

This is the same fabricated-success-rate footgun the surrounding code already guards elsewhere: the entry point rejects non-positive `n_episodes`/`max_steps`/`control_frequency` "rather than running a degenerate eval that reports a fabricated success rate", and the docstring flags the empty-`policy_kwargs` goal case. The `success_fn=None` default — the most common invocation — was the one un-guarded, un-warned, undocumented case.

## Change

When no success criterion is in force, `evaluate()` now:
- logs a `WARNING` explaining that `success_rate` does not measure task success and how to fix it;
- annotates the human-readable text: `Success: 0/2 (0.0%) [no success criterion - not measured]`;
- adds a `success_measured` boolean to the returned json — `False` on the legacy path with no `success_fn`, `True` on both the `success_fn` and benchmark-`spec` paths.

`success_rate` stays numeric (`0.0`) for backward compatibility — existing callers and the `== 0.0` / `== 1.0` assertions are unaffected; callers that care can branch on `success_measured`. Docstrings for `eval_policy` (facade) and `evaluate` (Returns) document the behaviour and the new field.

## Behaviour (MuJoCo, `so101`, headless)

```
===== eval_policy WITHOUT success_fn (the default) =====
WARNING strands_robots.simulation.policy_runner: evaluate()/eval_policy called without a
  success criterion (success_fn=None and no spec): success_rate will be 0.0 for every episode
  regardless of what the policy does and does NOT measure task success. Pass success_fn ...
TEXT: Episodes: 2 | Success: 0/2 (0.0%) [no success criterion - not measured]
json.success_rate = 0.0 | json.success_measured = False

===== eval_policy WITH success_fn='contact' =====
TEXT: Episodes: 2 | Success: 0/2 (0.0%)
json.success_rate = 0.0 | json.success_measured = True
```

## Tests

`tests/simulation/test_policy_runner_behaviour.py::TestEvaluateSuccessMeasured` (real MuJoCo `Simulation` + `MockPolicy`):
- no criterion -> `success_measured is False`, text contains `not measured`, warning logged (both **fail before** this change with `KeyError: 'success_measured'`);
- `success_fn` given -> `success_measured is True`.

Local gate: `ruff check` + `ruff format --check` + `mypy` clean on the changed files; `tests/simulation/test_policy_runner*.py`, `test_simengine_facade_guardrails.py`, `test_eval_policy_async_rtc.py`, `tests/training/test_rl_evaluate.py`, `tests/simulation/mujoco/test_simulation.py` — 293 passed, 2 skipped — confirm no regression to the numeric `success_rate` contract.