### PR TITLE
fix(sim): accept cameras= scope in Newton start_recording (dataset_cameras parity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,22 @@ is unchanged.
 
 `LerobotLocalPolicy`'s heuristic (non-declarative) remap path keeps a rollout alive even when it cannot bind the observation to the model's inputs by name: a camera whose name matches no declared image feature is routed to a free slot positionally, and `observation.state` is composed from the observation's own scalar keys when none of `robot_state_keys` match (the generic `joint_0..N` fallback). Either makes the robot move on meaningless inputs while `run_policy` / `eval_policy` still report `status="success"` with `success_rate ~ 0`, and the only trace was a log line (the positional fallback on the preprocessor path did not even warn). Both fallbacks now flip a flag on the policy (`positional_fallback_used` / `generic_state_keys_used`) and emit a WARNING, and `run_policy` / `eval_policy` surface both flags in their JSON result block alongside the existing `action_errors` / load telemetry. A `True` flag on an otherwise-successful run is the signature of a misconfigured camera/state binding. No behaviour change for correctly-named observations (both flags stay `False`); the remap itself is unchanged.
 
+### Fixed: `dataset_cameras` scoping crashed on the Newton backend
+
+`run_policy(dataset_cameras=[...])` scopes a recorded dataset to a chosen
+subset of cameras by forwarding `start_recording(cameras=...)`. Only the
+MuJoCo backend accepted that keyword; the Newton backend's `start_recording`
+had no `cameras` parameter, so a scoped rollout on a Newton-backed simulation
+raised an uncaught `TypeError: start_recording() got an unexpected keyword
+argument 'cameras'` out of the otherwise backend-agnostic `run_policy` tool.
+
+`NewtonSimEngine.start_recording` now accepts `cameras=` with the same
+semantics as the MuJoCo backend: `None` records every named scene camera,
+a subset scopes the dataset schema (and the per-step capture hook) to exactly
+those views, names may be given in raw or schema-safe (`/` -> `__`) form, and
+an unknown name fails loudly listing the available cameras. `dataset_cameras`
+now behaves identically on both engines.
+
 ### Fixed: LerobotLocalPolicy state-key mismatch is now loud instead of a silent zero/open-loop rollout
 
 When `LerobotLocalPolicy` auto-generated generic state keys (`joint_0..N`, from

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -80,10 +80,10 @@ run_policy(
 )
 ```
 
-When set, `dataset_cameras` is forwarded as `start_recording(cameras=...)`
-(the camera subset is a MuJoCo-backend feature). Omit it (the default `None`)
-to record every scene camera - the default path forwards no `cameras` kwarg at
-all, so it stays backend-agnostic across the MuJoCo and Newton engines.
+When set, `dataset_cameras` is forwarded as `start_recording(cameras=...)`,
+which both the MuJoCo and Newton backends support, so the subset is applied
+identically on either engine. Omit it (the default `None`) to record every
+scene camera - the default path forwards no `cameras` kwarg at all.
 
 To also capture a rollout MP4 (the visual artifact for review or VLM
 defect-checking), pass the same `video={...}` config the

--- a/strands_robots/simulation/newton/recording.py
+++ b/strands_robots/simulation/newton/recording.py
@@ -62,6 +62,7 @@ class NewtonRecordingMixin(DatasetRecordingMixin):
         push_to_hub: bool = False,
         vcodec: str = "h264",
         overwrite: bool = False,
+        cameras: list[str] | None = None,
     ) -> dict[str, Any]:
         """Start recording the Newton scene to LeRobotDataset format.
 
@@ -93,6 +94,14 @@ class NewtonRecordingMixin(DatasetRecordingMixin):
                 wheels commonly cannot decode it and silently yield 0 frames.
             overwrite: Wipe and recreate an existing dataset dir instead of
                 appending to it.
+            cameras: Camera names to record into the dataset. When ``None``
+                (default) every named scene camera is recorded. Pass a subset
+                (e.g. ``cameras=["camera1", "camera2"]``) to scope the dataset
+                to exactly those views - matching the MuJoCo backend so
+                ``run_policy(dataset_cameras=...)`` behaves identically on both
+                engines. Names may be given in either the raw camera name or the
+                schema-safe form (``/`` collapsed to ``__``); an unknown name
+                fails loudly, listing the available cameras.
 
         Returns:
             Standard status dict. ``status="error"`` when no world exists, the
@@ -148,6 +157,51 @@ class NewtonRecordingMixin(DatasetRecordingMixin):
             resume_existing = self._prepare_dataset_target(dataset_dir, overwrite)
 
             joint_names, camera_keys, camera_dims, robot_type, recording_cameras = self._collect_recording_schema()
+
+            # Optional camera scoping (parity with the MuJoCo backend). By
+            # default every named scene camera is recorded; when ``cameras`` is
+            # given, record exactly that subset. Names may be the raw camera
+            # name (``arm0/wrist_cam``) or the schema-safe form
+            # (``arm0__wrist_cam``); an unknown name fails loudly (no silent
+            # drop), listing what exists. Scoping filters the ``recording_cameras``
+            # tuples so the on_frame hook renders only the selected views.
+            if cameras is not None:
+                raw_to_safe = {src: safe for src, safe, _w, _h in recording_cameras}
+                safe_to_raw = {safe: src for src, safe in raw_to_safe.items()}
+                selected_safe: list[str] = []
+                selected_raw: set[str] = set()
+                unknown: list[str] = []
+                for requested in cameras:
+                    if requested in raw_to_safe:  # raw camera name
+                        raw, safe = requested, raw_to_safe[requested]
+                    elif requested in safe_to_raw:  # already schema-safe
+                        raw, safe = safe_to_raw[requested], requested
+                    else:
+                        unknown.append(requested)
+                        continue
+                    if safe not in selected_safe:
+                        selected_safe.append(safe)
+                        selected_raw.add(raw)
+                if unknown:
+                    world._backend_state["recording"] = False
+                    available = sorted(raw_to_safe)
+                    return {
+                        "status": "error",
+                        "content": [
+                            {
+                                "text": (
+                                    f"start_recording: unknown camera(s) {unknown} in cameras=. "
+                                    f"Available scene cameras: {available}. Add them with "
+                                    "add_camera(...) before recording, or omit cameras= to "
+                                    "record all of them."
+                                )
+                            }
+                        ],
+                    }
+                camera_keys = selected_safe
+                camera_dims = {safe: camera_dims[safe] for safe in selected_safe}
+                recording_cameras = [tpl for tpl in recording_cameras if tpl[0] in selected_raw]
+
             world._backend_state["recording_cameras"] = recording_cameras
 
             if resume_existing:

--- a/strands_robots/tools/run_policy.py
+++ b/strands_robots/tools/run_policy.py
@@ -174,10 +174,10 @@ def run_policy(
         dataset_fps: Dataset FPS forwarded to ``start_recording``.
         dataset_cameras: Camera names to record into the dataset.
             When set, forwarded as ``start_recording(cameras=...)``
-            (a MuJoCo-backend feature) to scope a policy-specific
-            dataset to exactly the views the policy declares (e.g.
-            ``["camera1", "camera2", "camera3"]``) and keep the
-            implicit ``default`` free camera out of
+            (supported by both the MuJoCo and Newton backends) to
+            scope a policy-specific dataset to exactly the views the
+            policy declares (e.g. ``["camera1", "camera2", "camera3"]``)
+            and keep the implicit ``default`` free camera out of
             ``observation.images.*``. When ``None`` (default) no
             ``cameras`` kwarg is forwarded at all, so every scene
             camera is recorded and the call stays backend-agnostic
@@ -252,14 +252,12 @@ def run_policy(
                 "expose .start_recording(). Install the [lerobot] extra or pass "
                 "dataset_root=None for a recording-less rollout."
             )
-        # Only forward ``cameras`` when the caller asked for a subset. The
-        # kwarg is MuJoCo-only (``simulation/mujoco/recording.py``); the Newton
-        # backend's ``start_recording`` takes no ``cameras`` and no ``**kwargs``
-        # catch-all, so an unconditional ``cameras=`` would raise an uncaught
-        # ``TypeError`` out of this backend-agnostic tool - a regression even
-        # when ``dataset_cameras`` is omitted (it would still forward
-        # ``cameras=None``). Gating on ``is not None`` keeps the default path
-        # byte-for-byte identical to pre-feature behaviour on every backend.
+        # Only forward ``cameras`` when the caller asked for a subset. Both
+        # the MuJoCo and Newton backends' ``start_recording`` accept a
+        # ``cameras=`` scope, so this tool stays backend-agnostic. Gating on
+        # ``is not None`` keeps the default record-all path byte-for-byte
+        # identical to pre-feature behaviour on every backend (no redundant
+        # ``cameras=None`` forwarded).
         start_kwargs: dict[str, Any] = dict(
             repo_id=dataset_repo_id,
             task=dataset_task,

--- a/tests/simulation/newton/test_dataset_recording.py
+++ b/tests/simulation/newton/test_dataset_recording.py
@@ -211,3 +211,65 @@ def _encode_png(img: np.ndarray) -> bytes:
     buf = io.BytesIO()
     Image.fromarray(img).save(buf, format="PNG")
     return buf.getvalue()
+
+
+def test_start_recording_scopes_cameras_to_subset(tmp_path):
+    """``cameras=`` records only the requested subset (parity with MuJoCo).
+
+    Regression: ``run_policy(dataset_cameras=...)`` is a backend-agnostic tool
+    that forwards ``start_recording(cameras=...)``. The Newton backend must
+    accept the same scope the MuJoCo backend does; before it did not accept a
+    ``cameras`` kwarg at all, so a scoped Newton rollout raised
+    ``TypeError: start_recording() got an unexpected keyword argument 'cameras'``.
+    """
+    root = str(tmp_path / "newton_scope")
+    world = _world_with_robot()
+    world.cameras["front"] = SimCamera(name="front", width=64, height=48)
+    world.cameras["top"] = SimCamera(name="top", width=64, height=48)
+    engine = _make_engine(world)
+
+    started = engine.start_recording(repo_id="local/newton_scope", root=root, fps=30, overwrite=True, cameras=["front"])
+    assert started["status"] == "success", started
+
+    recorder = world._backend_state["dataset_recorder"]
+    image_feats = {k for k in recorder.dataset.features if k.startswith("observation.images")}
+    assert image_feats == {"observation.images.front"}, image_feats
+
+    # The on_frame hook renders only the scoped camera.
+    scoped = [tpl[0] for tpl in world._backend_state["recording_cameras"]]
+    assert scoped == ["front"], scoped
+
+
+def test_start_recording_accepts_schema_safe_camera_name(tmp_path):
+    """A namespaced camera can be scoped by its schema-safe ``__`` form."""
+    root = str(tmp_path / "newton_safe")
+    world = _world_with_robot()
+    world.cameras["arm0/wrist"] = SimCamera(name="arm0/wrist", width=64, height=48)
+    world.cameras["overview"] = SimCamera(name="overview", width=64, height=48)
+    engine = _make_engine(world)
+
+    started = engine.start_recording(
+        repo_id="local/newton_safe", root=root, fps=30, overwrite=True, cameras=["arm0__wrist"]
+    )
+    assert started["status"] == "success", started
+
+    recorder = world._backend_state["dataset_recorder"]
+    image_feats = {k for k in recorder.dataset.features if k.startswith("observation.images")}
+    assert image_feats == {"observation.images.arm0__wrist"}, image_feats
+
+
+def test_start_recording_unknown_camera_errors(tmp_path):
+    """An unknown ``cameras=`` name fails loudly and lists what exists."""
+    root = str(tmp_path / "newton_unknown")
+    world = _world_with_robot()
+    world.cameras["front"] = SimCamera(name="front", width=64, height=48)
+    engine = _make_engine(world)
+
+    result = engine.start_recording(repo_id="local/newton_unknown", root=root, fps=30, overwrite=True, cameras=["nope"])
+    assert result["status"] == "error", result
+    text = result["content"][0]["text"]
+    assert "unknown camera(s)" in text
+    assert "nope" in text
+    assert "front" in text  # the available list is surfaced
+    # A failed scope must not leave the session flagged as recording.
+    assert world._backend_state.get("recording") is False


### PR DESCRIPTION
## Problem

`run_policy(dataset_cameras=[...])` is a backend-agnostic tool that scopes a recorded dataset to a chosen subset of cameras by forwarding `start_recording(cameras=...)`. Only the MuJoCo backend accepted that keyword. `NewtonRecordingMixin.start_recording` had no `cameras` parameter, so a scoped rollout on a Newton-backed simulation raised an uncaught error straight out of the otherwise backend-agnostic tool:

```
TypeError: NewtonRecordingMixin.start_recording() got an unexpected keyword argument 'cameras'
```

Reproduced on a real Newton (`newton` 1.3.0) simulation: `sim.start_recording(repo_id=..., cameras=['camera1'])` and `run_policy(..., dataset_cameras=['camera1'])` both crashed. The `run_policy` tool already gated the forward on `dataset_cameras is not None` to keep the *default* path safe, but any explicit `dataset_cameras=[...]` on Newton still hit the crash. The tool docstring and `docs/recording.md` both described the scope as "a MuJoCo-backend feature" while exposing it on a backend-agnostic entry point.

## Change

`NewtonSimEngine.start_recording` now accepts `cameras: list[str] | None = None` with the **same semantics as the MuJoCo backend**:

- `None` (default) records every named scene camera - byte-for-byte unchanged behaviour.
- A subset scopes the dataset schema **and** the per-step capture hook (via the `recording_cameras` state the hook already iterates) to exactly those views.
- Names may be given in raw (`arm0/wrist_cam`) or schema-safe (`arm0__wrist_cam`) form.
- An unknown name fails loudly with `status="error"` listing the available cameras, and does not leave the session flagged as recording (no silent wrong-set drop).

`dataset_cameras` now behaves identically on both engines. The stale "MuJoCo-backend feature" wording in the `run_policy` tool and `docs/recording.md` is corrected.

## Tests (fail before, pass after)

Added three CI-runnable regression tests to `tests/simulation/newton/test_dataset_recording.py` (real `SimWorld` + real `NewtonSimEngine` recording lifecycle, no Warp needed):

- `test_start_recording_scopes_cameras_to_subset` - two cameras, `cameras=["front"]` -> schema has exactly `observation.images.front`, capture hook scoped to `front`.
- `test_start_recording_accepts_schema_safe_camera_name` - a namespaced camera scoped by its `__` form.
- `test_start_recording_unknown_camera_errors` - unknown name -> `status="error"`, message lists what exists, session not left recording.

All three fail on pre-fix code with the exact `TypeError` and pass after. `tests/simulation/newton/test_dataset_recording.py` (10) and `tests/tools/test_run_policy.py` (34) are green; `ruff` and `mypy` are clean on the changed files.

## End-to-end verification on a real Newton simulation

Real `run_policy(dataset_cameras=['camera1'])` rollout on Newton with a second `camera2` in the scene, recording to a real LeRobot v3 dataset, then reopened from disk:

- `status: success` (pre-fix: `TypeError`)
- reopened `meta/info.json` image features: `['observation.images.camera1']` only (`camera2` scoped out)
- `total_episodes: 1`, `total_frames: 5`

Scoped rollout (camera1 view, MuJoCo-parity `cameras=` on the Newton backend, headless render):

![newton scoped rollout](https://github.com/cagataycali/robots/releases/download/artifact-newton-cam-scope-1782970110/newton_scoped_rollout.gif)