### PR TITLE
test(training): pin LerobotTrainer builder-side escape-hatch validation

### DIFF
--- a/tests/training/test_lerobot.py
+++ b/tests/training/test_lerobot.py
@@ -963,3 +963,57 @@ class TestRewardModelTraining:
         spec = self._sarm_spec(dataset_root, tmp_path, image_key="-x")
         problems = LerobotTrainer().validate(spec)
         assert any("must not start with '-'" in p for p in problems)
+
+
+class TestBuilderEscapeHatchValidation:
+    """The builders re-validate ``extra`` escape-hatch types independently of validate().
+
+    ``build_config`` / ``build_command`` are public entry points a caller can
+    reach without first running :meth:`LerobotTrainer.validate` (for example a
+    programmatic caller that already trusts its inputs). Each escape hatch that
+    ``validate()`` guards - ``extra['reward_model']``, ``extra['sample_weighting']``,
+    and ``extra['relative_actions']`` - is therefore re-checked at build time so
+    a malformed value fails fast with an actionable ValueError instead of being
+    silently coerced into a stray flag or a config missing the intended wiring.
+    """
+
+    def test_build_config_rejects_non_dict_reward_model(self, dataset_root, tmp_path):
+        # build_config resolves the reward-model escape hatch itself (before any
+        # lerobot config is built), so a non-dict value must raise here too.
+        spec = TrainSpec(
+            dataset_root=dataset_root,
+            base_model="",
+            output_dir=str(tmp_path / "out"),
+            steps=200,
+            extra={"reward_model": "sarm"},  # str, not a dict of fields
+        )
+        with pytest.raises(ValueError, match="must be a dict"):
+            LerobotTrainer(device="cpu").build_config(spec)
+
+    def test_build_command_rejects_non_dict_sample_weighting(self, dataset_root, tmp_path):
+        # A non-dict sample_weighting must raise, never be flattened into stray
+        # --sample_weighting.* flags.
+        spec = TrainSpec(
+            dataset_root=dataset_root,
+            base_model="",
+            output_dir=str(tmp_path / "out"),
+            steps=200,
+            extra={"policy_type": "act", "sample_weighting": "rabc"},
+        )
+        with pytest.raises(ValueError, match="must be a dict"):
+            LerobotTrainer(device="cpu").build_command(spec)
+
+    def test_build_config_rejects_relative_actions_for_unsupported_policy(self, dataset_root, tmp_path):
+        # Only the pi0 family exposes use_relative_actions; build_config must
+        # fail fast for any other policy rather than drop the flag silently
+        # (which would train an ordinary absolute-action policy unnoticed).
+        pytest.importorskip("lerobot")
+        spec = TrainSpec(
+            dataset_root=dataset_root,
+            base_model="",
+            output_dir=str(tmp_path / "out"),
+            steps=200,
+            extra={"policy_type": "act", "relative_actions": True},
+        )
+        with pytest.raises(ValueError, match="use_relative_actions"):
+            LerobotTrainer(device="cpu").build_config(spec)


### PR DESCRIPTION
## What

`LerobotTrainer.build_config` and `build_command` are public entry points a caller can reach without first running `validate()` (e.g. a programmatic caller that already trusts its inputs). Each `extra[...]` escape hatch that `validate()` guards is therefore re-checked at build time, so a malformed value fails fast with an actionable `ValueError` rather than being silently coerced into a stray flag or a config missing the intended wiring.

Those builder-side guards had no direct test coverage: only `validate()` and the valid-build paths were exercised. This adds a focused `TestBuilderEscapeHatchValidation` class that drives the builders directly with malformed `extra`:

- `build_config` rejects a non-dict `reward_model` (resolved before any lerobot config is built).
- `build_command` rejects a non-dict `sample_weighting` (never flattened into stray `--sample_weighting.*` flags).
- `build_config` rejects `relative_actions` for a non-pi0 policy (only the pi0 family exposes `use_relative_actions`; any other policy must fail fast instead of dropping the flag and training an ordinary absolute-action policy unnoticed).

## Why

These are the library's "raise on fatal, no silent no-op" contracts. `validate()` catches the same cases and is well tested, but the builders enforce them independently and that second layer was untested, so a regression there (silent coercion) would slip through.

## Coverage

`strands_robots/training/lerobot.py`: 25 -> 22 uncovered statements (the three builder-side raises at the `_reward_model_dict`, `_sample_weighting_dict`, and `_build_policy_config` relative-actions guards).

## Testing

Test-only change; no behavior change, no visual artifact needed.

- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ`: clean (no issues in 636 source files).
- Full suite: `MUJOCO_GL=egl pytest tests/` -> 8984 passed (was 8981; the 3 new tests pass), 167 skipped. The 3 new tests also pass in isolation.