### PR TITLE
fix(examples): platform-aware MUJOCO_GL default (cgl is macOS-only; examples crash on Linux)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: examples defaulted `MUJOCO_GL` to the macOS-only `cgl` on every platform
+
+`07_post_tune_any_policy.py`, `06_agent_collect_and_stream.py`,
+`lerobot_hardware_catalog.py` and `vla_g1_workflow.py` ran
+`os.environ.setdefault("MUJOCO_GL", "cgl")`, a value only valid on macOS -- on a
+bare Linux box the first offscreen render died with `RuntimeError: invalid value
+for environment variable MUJOCO_GL: cgl`. The default is now platform-aware
+(`cgl` on macOS, headless-safe `egl` elsewhere, matching what
+`04_mesh_peer_discovery.py` and the cosmos3 examples already do); a
+user-exported `MUJOCO_GL` is still never overridden.
+
 ### Fixed: `move_object` silently no-op'd on static objects
 
 `Simulation.move_object(name, position=...)` moves an object by writing its

--- a/examples/06_agent_collect_and_stream.py
+++ b/examples/06_agent_collect_and_stream.py
@@ -7,7 +7,7 @@ back with ``sim.stream_dataset(...)`` — no torchcodec/av plumbing in user code
 (it's a declared dependency of the ``[lerobot]`` extra).
 
 Run:
-    MUJOCO_GL=cgl python examples/06_agent_collect_and_stream.py
+    python examples/06_agent_collect_and_stream.py
 
 Dependencies:
     pip install "strands-robots[sim-mujoco,lerobot]" strands-agents
@@ -15,8 +15,9 @@ Dependencies:
 """
 
 import os
+import sys
 
-os.environ.setdefault("MUJOCO_GL", "cgl")  # macOS offscreen GL
+os.environ.setdefault("MUJOCO_GL", "cgl" if sys.platform == "darwin" else "egl")  # offscreen GL
 
 from strands import Agent
 

--- a/examples/07_post_tune_any_policy.py
+++ b/examples/07_post_tune_any_policy.py
@@ -17,8 +17,9 @@ Runtime: ~30s on CPU (2 training steps - just enough to prove the loop).
 """
 
 import os
+import sys
 
-os.environ.setdefault("MUJOCO_GL", "cgl")  # macOS offscreen GL
+os.environ.setdefault("MUJOCO_GL", "cgl" if sys.platform == "darwin" else "egl")  # offscreen GL
 
 from strands_robots import MockPolicy, Robot, create_policy
 from strands_robots.training import TrainSpec, create_trainer

--- a/examples/lerobot_hardware_catalog.py
+++ b/examples/lerobot_hardware_catalog.py
@@ -24,7 +24,7 @@ import argparse
 import os
 import sys
 
-os.environ.setdefault("MUJOCO_GL", "cgl")
+os.environ.setdefault("MUJOCO_GL", "cgl" if sys.platform == "darwin" else "egl")
 
 
 def show_catalog() -> int:

--- a/examples/vla_g1_workflow.py
+++ b/examples/vla_g1_workflow.py
@@ -43,7 +43,7 @@ import argparse
 import os
 import sys
 
-os.environ.setdefault("MUJOCO_GL", "cgl")
+os.environ.setdefault("MUJOCO_GL", "cgl" if sys.platform == "darwin" else "egl")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #972.

Four shipped examples default `MUJOCO_GL` to the macOS-only `"cgl"` via
`os.environ.setdefault`: `07_post_tune_any_policy.py`, `06_agent_collect_and_stream.py`,
`lerobot_hardware_catalog.py`, and `vla_g1_workflow.py`. On Linux the first offscreen
render dies:

    $ MUJOCO_GL=cgl python -c "import mujoco; mujoco.GLContext(64,64)"
    RuntimeError: invalid value for environment variable MUJOCO_GL: cgl

On a bare Linux box (no MUJOCO_GL exported) that's a first-run crash: 07 records camera
video; 06 does the same once its agent step runs; and `vla_g1_workflow.py`'s record stage
calls `start_recording` without `cameras=`, which by contract records every scene camera
including the implicit `default` overview camera — so it renders (and dies) too.
Meanwhile `04_mesh_peer_discovery.py` and the cosmos3 examples already default to
`"egl"` — the examples are inconsistent with each other.

Fix (same one line in all four):
`os.environ.setdefault("MUJOCO_GL", "cgl" if sys.platform == "darwin" else "egl")`
— keeps the macOS behavior, picks the headless-safe `egl` on Linux, and never overrides a
user-exported value. (`07`/`06` also gain the `import sys`; the other two already import it.
`06`'s docstring run line drops its `MUJOCO_GL=cgl` prefix since the default now does the
right thing per platform.)
Verified on Linux (Jetson, headless): `egl` GLContext creates fine; `cgl` raises as above.

Related: the three notebooks under `examples/notebooks/` set the same unconditional
`"cgl"` default in their first cell, and `examples/notebooks/README.md` says they "fall
back to the environment's default" on headless Linux — which `setdefault` doesn't do.
Happy to fold the same platform-aware line into the notebooks here or in a follow-up,
whichever you prefer.

Found while validating the shipped examples on an SO-101 / Jetson harness.
