### PR TITLE
feat(packaging): add [ollama] extra so the local-LLM agent path installs out-of-the-box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ new `scene_ops.reposition_body_in_scene` helper -- mirroring how `add_object` /
 path. A static-body recompile failure now reports `status="error"` rather than a
 misleading success.
 
+### Added: `[ollama]` extra -- the local-LLM agent path installs out of the box
+
+`strands.models.ollama.OllamaModel` does a top-level `import ollama`, but no
+strands-robots extra pulled the client, so the no-cloud agent path (the natural
+choice on an edge device) failed with `ModuleNotFoundError: No module named
+'ollama'` on a fresh install. The new `[ollama]` extra delegates to
+strands-agents' own `[ollama]` extra (bounded pin, `ollama>=0.4.8,<1.0.0`) to
+keep a single source of truth for the client version, and is included in
+`[all]`. Opt-in; the base install is unchanged.
+
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)
 
 The `vera-sim` extra pinned `mimicgen==1.0.0`, but NVlabs MimicGen has never

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -305,6 +305,13 @@ vera-sim = [
     "mujoco>=3.5.0",
     "imageio",
 ]
+# Local-LLM agent path (no API key / no AWS -- the natural choice on an edge
+# device): strands.models.ollama.OllamaModel does a top-level `import ollama`.
+# Delegate to strands-agents' own [ollama] extra (bounded pin, ollama>=0.4.8,<1.0.0)
+# so the client version stays in sync with the code that imports it.
+ollama = [
+    "strands-agents[ollama]>=1.0.0,<2.0.0",
+]
 all = [
     "strands-robots[groot-service]",
     "strands-robots[moveit2]",
@@ -316,6 +323,7 @@ all = [
     "strands-robots[wbc]",
     "strands-robots[motionbricks]",
     "strands-robots[molmoact2]",
+    "strands-robots[ollama]",
 ]
 dev = [
     "pytest>=6.0,<10.0.0",


### PR DESCRIPTION
Fixes #974.

The natural-language agent path with a **local** model — no API key, no AWS; the natural
choice on an edge device like a Jetson — goes through `strands.models.ollama.OllamaModel`,
which does a top-level `import ollama` (strands/models/ollama.py). No strands-robots
extra pulls the client, so a fresh
`pip install "strands-robots[sim-mujoco,lerobot,mesh]"` + running the Ollama agent path
fails immediately:

    ModuleNotFoundError: No module named 'ollama'

Meanwhile the shipped agent examples (05/06) use the default Bedrock model (needs AWS
credentials), so the path an edge user actually needs isn't first-class installable.

Fix: add an `[ollama]` optional-dependency delegating to strands-agents' own `[ollama]`
extra (which carries a bounded pin, `ollama>=0.4.8,<1.0.0`) and include it in `[all]`
following the file's self-referential pattern. Single source of truth for the client
version, opt-in, no change to the base install. With strands-robots now published to
PyPI (v0.4.1), this fresh-install path is exactly what new users hit first.

Verified: with the client installed,
`Agent(model=OllamaModel(...), tools=[Robot("so100")])` orchestrated a scene-build +
policy-run + dataset-record end-to-end with a local llama3.2:3b on a Jetson Orin Nano
(CPU). The extra also composes cleanly today: a dev env synced with it resolves the
dependency and `import ollama` succeeds. Happy to also mention the extra in the 05/06
example docstrings.
