### PR TITLE
docs(changelog): collapse [Unreleased] into a dated 0.4.1 heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+
 ### Fixed: `move_object` silently no-op'd on static objects
 
 `Simulation.move_object(name, position=...)` moves an object by writing its
@@ -20,6 +21,67 @@ new `scene_ops.reposition_body_in_scene` helper -- mirroring how `add_object` /
 `remove_object` mutate the scene. Dynamic objects keep the cheap `data.qpos`
 path. A static-body recompile failure now reports `status="error"` rather than a
 misleading success.
+
+### Fixed: `replay_episode` / `send_action` vector bound to joints, not actuators
+
+`PolicyRunner.replay` (`Simulation.replay_episode`) mapped a recorded
+`LeRobotDataset` action vector positionally onto `robot_joint_names`, and
+`SimEngine._coerce_action` bound a raw numeric action vector passed to
+`send_action` the same way. But the dataset recorder writes the `action`
+column in the robot's *actuator* order (`robot_action_keys`), and `send_action`
+resolves actuator keys -- these diverge from the joint names whenever a robot
+has passive/mimic joints with no driving actuator or a tendon-driven gripper
+(e.g. `aloha`: 14 actuators vs 16 joints; `xarm7`; dexterous hands).
+
+The result was a silent record->replay round-trip corruption: replaying a
+dataset recorded by `start_recording` shifted the action vector across the
+wrong DOFs and dropped the grippers (their names have no matching joint), while
+`replay_episode` still returned `status="success"`. This is the "success
+contract, no physical effect" failure mode the project forbids, and mirrors the
+policy-keying fix already applied to `run_policy`/`eval_policy`.
+
+Positional action-vector binding now uses `robot_action_keys` in both paths, so
+a self-recorded episode round-trips onto the actuators it was recorded from. For
+robots whose actuators mirror their joints (e.g. `so101`) behaviour is
+unchanged. Pass `action_key_map=` to `replay_episode` to override the ordering
+for third-party datasets.
+
+### Fixed: `eval_policy` no longer reports a silently-meaningless `success_rate`
+
+`eval_policy` / `PolicyRunner.evaluate` default `success_fn=None`. With no
+success criterion (and no benchmark spec) an episode can never be marked
+successful, so the loop reported a hard `success_rate: 0.0` for every episode
+regardless of what the policy did - a value indistinguishable from a policy
+that genuinely failed every episode, emitted with no warning. Callers
+comparing checkpoints saw `0.0` for all of them and (correctly) concluded
+nothing, while the number read like a real measurement.
+
+The no-criterion path now logs a warning, annotates the human-readable text
+(`... [no success criterion - not measured]`), and adds a `success_measured`
+boolean to the returned json (`False` on the legacy path with no `success_fn`,
+`True` on the `success_fn`/benchmark-spec paths). `success_rate` stays numeric
+(`0.0`) for backward compatibility; check `success_measured` before trusting
+it. This extends the entry-point guards that already reject other
+fabricated-success-rate configs (non-positive `n_episodes`/`max_steps`, empty
+goal payloads).
+
+### Fixed: `dataset_cameras` scoping crashed on the Newton backend
+
+`run_policy(dataset_cameras=[...])` scopes a recorded dataset to a chosen
+subset of cameras by forwarding `start_recording(cameras=...)`. Only the
+MuJoCo backend accepted that keyword; the Newton backend's `start_recording`
+had no `cameras` parameter, so a scoped rollout on a Newton-backed simulation
+raised an uncaught `TypeError: start_recording() got an unexpected keyword
+argument 'cameras'` out of the otherwise backend-agnostic `run_policy` tool.
+
+`NewtonSimEngine.start_recording` now accepts `cameras=` with the same
+semantics as the MuJoCo backend: `None` records every named scene camera,
+a subset scopes the dataset schema (and the per-step capture hook) to exactly
+those views, names may be given in raw or schema-safe (`/` -> `__`) form, and
+an unknown name fails loudly listing the available cameras. `dataset_cameras`
+now behaves identically on both engines.
+
+## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)
 
@@ -278,44 +340,9 @@ base, 9 actuators). LeKiwi auto-downloads and compiles on first sim use, steps
 stably, and renders from its `front`/`wrist` cameras. The existing hardware mapping
 is unchanged.
 
-### Fixed: `eval_policy` no longer reports a silently-meaningless `success_rate`
-
-`eval_policy` / `PolicyRunner.evaluate` default `success_fn=None`. With no
-success criterion (and no benchmark spec) an episode can never be marked
-successful, so the loop reported a hard `success_rate: 0.0` for every episode
-regardless of what the policy did - a value indistinguishable from a policy
-that genuinely failed every episode, emitted with no warning. Callers
-comparing checkpoints saw `0.0` for all of them and (correctly) concluded
-nothing, while the number read like a real measurement.
-
-The no-criterion path now logs a warning, annotates the human-readable text
-(`... [no success criterion - not measured]`), and adds a `success_measured`
-boolean to the returned json (`False` on the legacy path with no `success_fn`,
-`True` on the `success_fn`/benchmark-spec paths). `success_rate` stays numeric
-(`0.0`) for backward compatibility; check `success_measured` before trusting
-it. This extends the entry-point guards that already reject other
-fabricated-success-rate configs (non-positive `n_episodes`/`max_steps`, empty
-goal payloads).
-
 ### Added: routing-degradation telemetry so a silently-degraded LeRobot rollout is machine-detectable
 
 `LerobotLocalPolicy`'s heuristic (non-declarative) remap path keeps a rollout alive even when it cannot bind the observation to the model's inputs by name: a camera whose name matches no declared image feature is routed to a free slot positionally, and `observation.state` is composed from the observation's own scalar keys when none of `robot_state_keys` match (the generic `joint_0..N` fallback). Either makes the robot move on meaningless inputs while `run_policy` / `eval_policy` still report `status="success"` with `success_rate ~ 0`, and the only trace was a log line (the positional fallback on the preprocessor path did not even warn). Both fallbacks now flip a flag on the policy (`positional_fallback_used` / `generic_state_keys_used`) and emit a WARNING, and `run_policy` / `eval_policy` surface both flags in their JSON result block alongside the existing `action_errors` / load telemetry. A `True` flag on an otherwise-successful run is the signature of a misconfigured camera/state binding. No behaviour change for correctly-named observations (both flags stay `False`); the remap itself is unchanged.
-
-### Fixed: `dataset_cameras` scoping crashed on the Newton backend
-
-`run_policy(dataset_cameras=[...])` scopes a recorded dataset to a chosen
-subset of cameras by forwarding `start_recording(cameras=...)`. Only the
-MuJoCo backend accepted that keyword; the Newton backend's `start_recording`
-had no `cameras` parameter, so a scoped rollout on a Newton-backed simulation
-raised an uncaught `TypeError: start_recording() got an unexpected keyword
-argument 'cameras'` out of the otherwise backend-agnostic `run_policy` tool.
-
-`NewtonSimEngine.start_recording` now accepts `cameras=` with the same
-semantics as the MuJoCo backend: `None` records every named scene camera,
-a subset scopes the dataset schema (and the per-step capture hook) to exactly
-those views, names may be given in raw or schema-safe (`/` -> `__`) form, and
-an unknown name fails loudly listing the available cameras. `dataset_cameras`
-now behaves identically on both engines.
 
 ### Fixed: LerobotLocalPolicy state-key mismatch is now loud instead of a silent zero/open-loop rollout
 
@@ -1069,30 +1096,6 @@ locomotion (closes #466). Clean-room against the upstream reference
   `docs/policies/wbc.md`; torque-control deploy harness +
   `simulate_rollout` at `examples/wbc_g1_torque_deploy.py` (the real weights
   produce a stable forward G1 walk).
-
-### Fixed: `replay_episode` / `send_action` vector bound to joints, not actuators
-
-`PolicyRunner.replay` (`Simulation.replay_episode`) mapped a recorded
-`LeRobotDataset` action vector positionally onto `robot_joint_names`, and
-`SimEngine._coerce_action` bound a raw numeric action vector passed to
-`send_action` the same way. But the dataset recorder writes the `action`
-column in the robot's *actuator* order (`robot_action_keys`), and `send_action`
-resolves actuator keys -- these diverge from the joint names whenever a robot
-has passive/mimic joints with no driving actuator or a tendon-driven gripper
-(e.g. `aloha`: 14 actuators vs 16 joints; `xarm7`; dexterous hands).
-
-The result was a silent record->replay round-trip corruption: replaying a
-dataset recorded by `start_recording` shifted the action vector across the
-wrong DOFs and dropped the grippers (their names have no matching joint), while
-`replay_episode` still returned `status="success"`. This is the "success
-contract, no physical effect" failure mode the project forbids, and mirrors the
-policy-keying fix already applied to `run_policy`/`eval_policy`.
-
-Positional action-vector binding now uses `robot_action_keys` in both paths, so
-a self-recorded episode round-trips onto the actuators it was recorded from. For
-robots whose actuators mirror their joints (e.g. `so101`) behaviour is
-unchanged. Pass `action_key_map=` to `replay_episode` to override the ordering
-for third-party datasets.
 
 ## [0.4.0] - 2026-06-16
 

--- a/tests/test_changelog_format.py
+++ b/tests/test_changelog_format.py
@@ -1,0 +1,80 @@
+"""CHANGELOG integrity guard (Keep a Changelog conventions).
+
+`CHANGELOG.md` is the human-facing record of behavioural changes and the source
+material for release notes. When a tag is cut, the accumulated `## [Unreleased]`
+section must be collapsed into a dated `## [x.y.z] - YYYY-MM-DD` heading and a
+fresh empty `[Unreleased]` opened for the next wave. Skipping that collapse
+leaves shipped content mislabelled as unreleased -- the published tag then has
+no dated section in the log.
+
+These checks pin the structural contract so the collapse is not forgotten:
+
+- exactly one `## [Unreleased]` heading, and it comes first;
+- every other version heading is `## [MAJOR.MINOR.PATCH] - YYYY-MM-DD` with a
+  real ISO date;
+- version sections appear in strictly descending semantic-version order with no
+  duplicates;
+- every published release (``PUBLISHED_RELEASES``) has its own dated section --
+  i.e. its content is not still sitting under `[Unreleased]`.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import re
+from pathlib import Path
+
+# Every git tag that has been published MUST have a dated CHANGELOG section.
+# Append the version here whenever a new tag is cut (and collapse `[Unreleased]`
+# into the matching dated heading in the same change).
+PUBLISHED_RELEASES = frozenset({"0.4.0", "0.4.1"})
+
+_CHANGELOG = Path(__file__).resolve().parents[1] / "CHANGELOG.md"
+_VERSION_HEADING = re.compile(r"^## \[(?P<ver>\d+\.\d+\.\d+)\] - (?P<date>\d{4}-\d{2}-\d{2})\s*$")
+_UNRELEASED_HEADING = re.compile(r"^## \[Unreleased\]\s*$")
+_ANY_H2 = re.compile(r"^## ")
+
+
+def _h2_lines() -> list[str]:
+    text = _CHANGELOG.read_text(encoding="utf-8")
+    return [ln for ln in text.splitlines() if _ANY_H2.match(ln)]
+
+
+def test_changelog_exists() -> None:
+    assert _CHANGELOG.is_file(), f"CHANGELOG.md not found at {_CHANGELOG}"
+
+
+def test_single_unreleased_heading_first() -> None:
+    h2 = _h2_lines()
+    unreleased = [ln for ln in h2 if _UNRELEASED_HEADING.match(ln)]
+    assert len(unreleased) == 1, f"expected exactly one '## [Unreleased]', found {len(unreleased)}"
+    assert _UNRELEASED_HEADING.match(h2[0]), f"first level-2 heading must be '## [Unreleased]', got {h2[0]!r}"
+
+
+def test_version_headings_well_formed_and_descending() -> None:
+    versions: list[tuple[int, int, int]] = []
+    for ln in _h2_lines():
+        if _UNRELEASED_HEADING.match(ln):
+            continue
+        m = _VERSION_HEADING.match(ln)
+        assert m, f"malformed version heading (want '## [x.y.z] - YYYY-MM-DD'): {ln!r}"
+        # date must be a real calendar date
+        _dt.date.fromisoformat(m.group("date"))
+        versions.append(tuple(int(p) for p in m.group("ver").split(".")))  # type: ignore[arg-type]
+
+    assert versions, "no dated version sections found"
+    assert len(versions) == len(set(versions)), f"duplicate version heading(s): {versions}"
+    assert versions == sorted(versions, reverse=True), f"version sections must be in descending order, got {versions}"
+
+
+def test_published_releases_have_dated_sections() -> None:
+    """Each published tag must be collapsed into its own dated section.
+
+    Fails while a shipped release's content is still under `[Unreleased]`.
+    """
+    documented = {m.group("ver") for ln in _h2_lines() if (m := _VERSION_HEADING.match(ln))}
+    missing = PUBLISHED_RELEASES - documented
+    assert not missing, (
+        f"published release(s) {sorted(missing)} have no dated CHANGELOG section - "
+        "collapse '[Unreleased]' into the matching '## [x.y.z] - YYYY-MM-DD' heading"
+    )


### PR DESCRIPTION
## Problem

The `v0.4.1` tag was published on 2026-07-01, but the CHANGELOG `[Unreleased]` section was never collapsed into a dated heading when the tag was cut. As a result:

- the shipped `v0.4.1` release has **no dated section** in the log, and
- the post-tag wave of changes is **interleaved** with released content under `[Unreleased]`, so there is no clean boundary for the next patch tag.

## Change

Split `[Unreleased]` at the `v0.4.1` tag boundary, recovered *verbatim* from the tagged file (`git show v0.4.1:CHANGELOG.md`) rather than by guesswork:

- The **49 entries that shipped in the tag** move under a new `## [0.4.1] - 2026-07-01` heading (byte-for-byte the section that was under `[Unreleased]` at the tag commit).
- The **4 post-tag sim-fix entries** stay under a fresh `## [Unreleased]` for the next patch tag:
  - `move_object` static-object reposition
  - `replay_episode` / `send_action` actuator-vector binding
  - `eval_policy` unmeasured `success_rate` flag
  - Newton `dataset_cameras` parity

No entry text is changed. The sorted set of all `###`/`####` entry headings is identical before and after (verified), so this is a pure re-partition. Version is still derived from the git tag via `hatch-vcs`, so no version-file bump is needed (same as the `0.4.0` release-prep step).

## Test

Adds `tests/test_changelog_format.py`, a Keep a Changelog integrity guard:

- exactly one leading `## [Unreleased]`;
- every dated version heading is `## [x.y.z] - YYYY-MM-DD` with a real ISO date;
- version sections are strictly descending with no duplicates;
- every published release in `PUBLISHED_RELEASES` has its own dated section (i.e. its content is not still sitting under `[Unreleased]`).

The last check **fails on the pre-collapse CHANGELOG** (`0.4.1` had no dated section) and **passes after**, so a future tag cannot ship without its collapse. `ruff` + `mypy` clean; the four checks pass.