### PR TITLE
fix(teleop): derive teleoperate() status from frame/error counters (dead teleop reported "success")

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,34 @@ was not affected; exposure was limited to `[vera-sim]`. Anyone who installed
 `[vera-sim]` since 2026-06-27 should `pip uninstall -y mimicgen` and reinstall
 into a clean environment.
 
+### Fixed: `teleoperate()` reported `status="success"` even for a dead follower
+
+Running teleop with the follower unpowered still ended the session with
+`status: "success"` -- a dead teleop was indistinguishable from a healthy one
+by `status`. Two layers, both fixed:
+
+- `_teleop_stats` hardcoded `"status": "success"`. It now derives the
+  session-end status from the counters it already returns: `success` when
+  `errors == 0`, `error` when every attempt failed (`frames == 0 or errors >=
+  frames`, covering both the soft mode where `send_action` returns an error
+  dict and the hard mode where the leader's `get_action()` raises), and
+  `degraded` for a mixed session. `degraded` is a new value -- strict
+  `status == "success"` callers now treat a partially-failing session as
+  unhealthy, which is the point.
+- Hardware validation exposed why honest counters alone were not enough:
+  lerobot's `MotorsBus.connect()` opens the serial port *before* the motor
+  handshake, so a failed handshake left `is_connected` True and fire-and-forget
+  writes to the dead bus kept "succeeding" (a fully unpowered session counted 1
+  error in 142 frames). A failed connect now rolls back by closing the
+  half-open port -- skipping the default torque write, which would raise on
+  the unreachable bus and leave the port open again -- on both the lazy teleop
+  connect in `send_action` (every tick retries and keeps surfacing the
+  failure) and the explicit `_connect_robot` path (which would otherwise
+  short-circuit its next attempt on "already connected" and report success
+  against a dead bus).
+
+The live-status query `get_teleoperate_status` is unchanged.
+
 ### Added: RL parity -- `staged_reward`, a gym adapter, and vectorized PPO
 
 The from-scratch RL lane reaches parity with the reference stacks: a

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -863,6 +863,24 @@ class Robot(TeleopMixin, AgentTool):
 
         return create_policy(policy_provider, **policy_config)
 
+    def _rollback_half_open_connect(self) -> None:
+        """Close the half-open port a failed connect can leave behind.
+
+        lerobot's ``MotorsBus.connect()`` opens the serial port *before* the
+        motor handshake, so a failed handshake (e.g. an unpowered bus) leaves
+        ``is_connected`` True while fire-and-forget writes to the dead bus
+        keep "succeeding". Closing the port makes the next attempt retry the
+        connect and keep surfacing the failure. ``disable_torque=False``: the
+        handshake already failed, so the default disconnect's torque write
+        would only raise again (before ``closePort``) and leave the port open.
+        """
+        bus = getattr(self.robot, "bus", None)
+        try:
+            if bus is not None and getattr(bus, "is_connected", False):
+                bus.disconnect(disable_torque=False)
+        except Exception:  # noqa: BLE001 - best-effort cleanup
+            logger.debug("%s post-connect-failure port close failed", self.tool_name_str)
+
     async def _connect_robot(self) -> tuple[bool, str]:
         """Connect to robot hardware with proper error handling.
 
@@ -919,6 +937,10 @@ class Robot(TeleopMixin, AgentTool):
         except Exception as e:
             error_msg = f"Robot connection failed: {e}. Ensure robot is calibrated and accessible on the specified port"
             logger.error(f"{error_msg}")
+            # Same rollback as the lazy teleop connect: without it a half-open
+            # port makes the NEXT _connect_robot short-circuit on
+            # "already connected" and report success against a dead bus.
+            self._rollback_half_open_connect()
             return False, error_msg
 
     async def _initialize_policy(self, policy: Policy) -> bool:
@@ -1470,7 +1492,11 @@ class Robot(TeleopMixin, AgentTool):
                 # Lazy connect on first action. calibrate=False: a teleop
                 # session assumes the follower is already calibrated (same
                 # contract as the policy-run path).
-                self.robot.connect(False)
+                try:
+                    self.robot.connect(False)
+                except Exception:
+                    self._rollback_half_open_connect()
+                    raise
             self.robot.send_action(action)
             return {"status": "success", "content": [{"text": "ok"}]}
         except Exception as e:  # noqa: BLE001 - surface as status, never kill the loop

--- a/strands_robots/teleop_mixin.py
+++ b/strands_robots/teleop_mixin.py
@@ -520,8 +520,22 @@ class TeleopMixin:
         note = ""
         if publish_results:
             note = f"\nMesh publishers started: {len(publish_results)}"
+        # Derive the session-end status from the counters instead of hardcoding
+        # "success", so a dead teleop is not reported as healthy. Two failure
+        # modes with distinct counter signatures (see _teleop_loop):
+        #   soft: send_action returns {"status": "error"} -> errors += 1 AND
+        #         frames += 1 (an unpowered follower gives errors == frames)
+        #   hard: get_action()/send raises -> errors += 1 only, no frame that
+        #         tick (a dead leader gives frames == 0)
+        frames, errors = self._teleop_frames, self._teleop_errors
+        if errors == 0:
+            status = "success"  # clean run (or idle: no actions attempted)
+        elif frames == 0 or errors >= frames:
+            status = "error"  # every attempt failed, either mode
+        else:
+            status = "degraded"  # some ok, some failed
         return {
-            "status": "success",
+            "status": status,
             "content": [
                 {
                     "text": f"Teleoperation {'completed' if blocking else 'stopped'}: "

--- a/tests/test_hardware_robot_lifecycle.py
+++ b/tests/test_hardware_robot_lifecycle.py
@@ -950,3 +950,67 @@ class TestEnsureLerobotRobotsRegistered:
         with caplog.at_level("WARNING"):
             hw._ensure_lerobot_robots_registered()
         assert any("third-party plugin registration failed" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# lazy-connect rollback: a failed connect must not leave the port half-open
+# ---------------------------------------------------------------------------
+
+
+class _HalfOpenConnectLeRobot(_FakeLeRobot):
+    """connect() opens the port, then fails the handshake (mirrors lerobot's
+    MotorsBus.connect: openPort -> _handshake raises), leaving is_connected
+    True. Exposes itself as ``bus`` like the SO follower robots do."""
+
+    def __init__(self) -> None:
+        super().__init__(connected=False)
+        self.connect_attempts = 0
+        self.bus = self
+        self.bus_disconnect_calls: list[bool] = []
+
+    def connect(self, calibrate: bool = False) -> None:  # noqa: ARG002 - lerobot signature
+        self.connect_attempts += 1
+        self._connected = True  # port opened...
+        raise ConnectionError("motor handshake failed")  # ...handshake failed
+
+    def disconnect(self, disable_torque: bool = True) -> None:
+        self.bus_disconnect_calls.append(disable_torque)
+        self._connected = False
+
+
+def test_send_action_rolls_back_half_open_lazy_connect() -> None:
+    """A failed lazy connect must not leave the port half-open: every
+    send_action retries the connect and reports error (an unpowered follower
+    would otherwise report success forever via fire-and-forget writes)."""
+    fake = _HalfOpenConnectLeRobot()
+    hw = _make_robot(fake)
+
+    r1 = hw.send_action({"j0.pos": 0.1})
+    r2 = hw.send_action({"j0.pos": 0.2})
+
+    assert r1["status"] == "error"
+    assert r2["status"] == "error"
+    # rollback closed the port, so the second call retried the connect
+    assert fake.connect_attempts == 2
+    # port closed WITHOUT a torque write (it would raise on a dead bus)
+    assert fake.bus_disconnect_calls == [False, False]
+    # nothing was ever written to the dead bus
+    assert fake.sent_actions == []
+    hw.cleanup()
+
+
+def test_connect_robot_rolls_back_half_open_connect() -> None:
+    """The explicit connect path must roll back too: without it, a failed
+    connect leaves is_connected True and the NEXT _connect_robot short-circuits
+    on "already connected" -- reporting success against a dead bus."""
+    fake = _HalfOpenConnectLeRobot()
+    hw = _make_robot(fake)
+
+    ok1, err1 = asyncio.run(hw._connect_robot())
+    ok2, err2 = asyncio.run(hw._connect_robot())
+
+    assert ok1 is False and "handshake" in err1
+    assert ok2 is False and "handshake" in err2  # retried, not "already connected"
+    assert fake.connect_attempts == 2
+    assert fake.bus_disconnect_calls == [False, False]
+    hw.cleanup()

--- a/tests/test_teleop.py
+++ b/tests/test_teleop.py
@@ -524,3 +524,70 @@ def test_bare_mixin_send_action_raises_not_implemented():
     mixin = TeleopMixin()
     with pytest.raises(NotImplementedError, match="send_action"):
         mixin.send_action({"a": 1.0})
+
+
+# ---------------------------------------------------------------------------
+# session-end status honesty: _teleop_stats derives status from the counters
+# (a dead teleop must not report "success"). Two failure modes with distinct
+# counter signatures: soft (send_action returns an error dict) advances errors
+# AND frames; hard (get_action() raises) advances errors only.
+# ---------------------------------------------------------------------------
+
+
+class FlakyHost(FakeHost):
+    """Host whose send_action alternates ok / structured error."""
+
+    def __init__(self, tool_name: str = "flaky_host"):
+        super().__init__(tool_name)
+        self._tick = 0
+
+    def send_action(self, action: dict, robot_name: str | None = None, n_substeps: int = 1):  # noqa: ARG002
+        with self._send_lock:
+            self.sent.append((dict(action), robot_name))
+        self._tick += 1
+        if self._tick % 2 == 0:
+            return {"status": "error", "content": [{"text": "dropped"}]}
+        return {"status": "success", "content": [{"text": "ok"}]}
+
+
+def test_stats_all_soft_errors_reports_error():
+    """Unpowered-follower mode: every send fails softly -> errors == frames -> error."""
+    host = ErrorHost()
+    host.attach_teleop(FakeTeleop({"a.pos": 1.0}), name="leader")
+    host.teleoperate(hz=200)
+    assert _spin_until(lambda: host._teleop_frames >= 3)
+    res = host.stop_teleoperate()
+    assert host._teleop_errors == host._teleop_frames  # soft-mode signature
+    assert res["status"] == "error"
+
+
+def test_stats_all_raises_reports_error():
+    """Dead-leader mode: get_action() raises every tick -> frames stays 0 -> error."""
+    host = FakeHost()
+    host.attach_teleop(RaisingTeleop({"a.pos": 1.0}), name="flaky")
+    host.teleoperate(hz=200)
+    assert _spin_until(lambda: host._teleop_errors >= 3)
+    res = host.stop_teleoperate()
+    assert host._teleop_frames == 0  # hard-mode signature: no frame ever produced
+    assert res["status"] == "error"
+
+
+def test_stats_mixed_reports_degraded():
+    """Some sends ok, some failing -> 0 < errors < frames -> degraded."""
+    host = FlakyHost()
+    host.attach_teleop(FakeTeleop({"a.pos": 1.0}), name="leader")
+    host.teleoperate(hz=200)
+    assert _spin_until(lambda: host._teleop_frames >= 4)
+    res = host.stop_teleoperate()
+    assert 0 < host._teleop_errors < host._teleop_frames  # genuinely mixed
+    assert res["status"] == "degraded"
+
+
+def test_stats_clean_run_reports_success():
+    """Regression: a healthy blocking session still reports success."""
+    host = FakeHost()
+    host.attach_teleop(FakeTeleop({"a.pos": 1.0}), name="leader")
+    res = host.teleoperate(hz=100, block=True, duration=0.2)
+    assert host._teleop_frames > 0
+    assert host._teleop_errors == 0
+    assert res["status"] == "success"


### PR DESCRIPTION
Fixes #978.

On real hardware, teleoperating with the follower unpowered still ends the session with
`status: "success"` — a dead teleop is indistinguishable from a healthy one by `status`,
a silent failure an agent/automation layer will happily trust. Measured on an SO-101
pair (12 V supply unplugged, USB in, 5 s): `{"status": "success", frames: 142, errors: 1}`.

Two layers, both fixed here:

1. **`_teleop_stats` hardcoded `"status": "success"`** (teleop_mixin.py). It now derives
   the session-end status from the counters it already returns, covering both failure
   modes: soft — `HardwareRobot.send_action` never raises by design, it returns
   `{"status":"error"}` → errors++ AND frames++; hard — the leader's `get_action()`
   raises → errors++ only. Result: `success` when `errors == 0`; `error` when
   `frames == 0 or errors >= frames` (every attempt failed, either mode); else
   `degraded`. All existing fields are kept; `get_teleoperate_status` is untouched.

2. **A failed connect left the port half-open, masking the counters themselves.**
   lerobot's `MotorsBus.connect()` opens the serial port *before* the motor handshake,
   and `is_connected` means "port open" — so a failed handshake leaves
   `is_connected == True`, the lazy-connect guard never fires again, and fire-and-forget
   writes to the dead bus keep "succeeding" (hence 1 error in 142 frames, which honest
   status derivation alone would have called `degraded`). A failed connect now rolls
   back by closing the half-open port, on both call sites: the lazy teleop connect in
   `send_action` (every tick retries and keeps surfacing the failure) and the explicit
   `_connect_robot` path (which would otherwise short-circuit its next attempt on
   "already connected" and report success against a dead bus). The rollback closes with
   `disable_torque=False`: the default disconnect issues a retried torque write before
   `closePort()`, which raises on the unreachable bus and would leave the port open
   again.

**Hardware validation** (real SO-101 leader/follower pair, Jetson Orin Nano, this exact
commit):

- Unpowered follower (the original bug session): `teleoperate()` now reports
  `status='error'` with `errors == frames` (17/17 over 5 s; the loop paces down to
  ~3 Hz in this dead mode because every tick retries the connect — acceptable for a
  dead path), and two consecutive explicit connects both report failure — the second no
  longer short-circuits on the half-open port's "already connected" state.
- Healthy session: explicit connect succeeds and `teleoperate()` reports `success`
  (148–150 frames, 0 errors, ~29.5 Hz — no measurable overhead on the healthy path).
- Red/green pairing on identical hardware in the same session: against the pre-fix
  base, the unpowered session reported `success` (142 frames / 1 error), and after a
  failed explicit connect the *second* connect returned True (the "already connected"
  short-circuit) with the subsequent dead teleop reporting a completely clean `success`
  (150 frames, 0 errors).
- Side benefit: if power returns mid-session, teleop now recovers via a clean reconnect.

Compat note: `degraded` is a new value — strict `status == "success"` callers will now
treat a partially-failing session as unhealthy, which is the point. If you'd prefer no
new value, the conservative variant is `error`/`success` only; happy to switch. One
honest edge: a session mixing successes with hard-raises (errors > frames > 0) is
conservatively labeled `error` — the two counters can't distinguish that mix.

Tests: 4 in `tests/test_teleop.py` (all-soft → error, all-raise → error, mixed →
degraded, clean → success) and 2 in `tests/test_hardware_robot_lifecycle.py` (lazy
path: a failed connect rolls back the half-open port and every send_action retries and
reports error; explicit path: a second `_connect_robot` retries instead of
short-circuiting on "already connected" against a dead bus). In the spirit of #897 and
#968 (make silent/unmeasured failure loud).
