### PR TITLE
fix(mesh): reject non-finite STRANDS_MESH_CAMERA_HZ (inf busy-spins the camera loop)

### DIFF
--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -12,6 +12,7 @@ import hashlib
 import hmac
 import json
 import logging
+import math
 import os
 import re
 import socket
@@ -1045,6 +1046,12 @@ class Mesh(SensorLoopsMixin):
                 hz = float(env)
             except ValueError:
                 logger.warning("STRANDS_MESH_CAMERA_HZ=%r invalid; camera loop disabled", env)
+                return 0.0
+            if not math.isfinite(hz):
+                # float() accepts "inf"/"nan"/"1e999"; a non-finite rate would
+                # make _camera_loop compute period = 1.0/hz = 0.0 and busy-spin
+                # (or silently disable on nan). Treat it as invalid.
+                logger.warning("STRANDS_MESH_CAMERA_HZ=%r is not finite; camera loop disabled", env)
                 return 0.0
         return hz if hz > 0 else 0.0
 

--- a/tests/mesh/test_camera_schema.py
+++ b/tests/mesh/test_camera_schema.py
@@ -82,6 +82,22 @@ def test_resolve_camera_hz_invalid_disables(fake_robot_with_camera, monkeypatch)
     assert m._resolve_camera_hz() == 0.0
 
 
+@pytest.mark.parametrize("value", ["inf", "-inf", "nan", "1e999"])
+def test_resolve_camera_hz_non_finite_disables(fake_robot_with_camera, monkeypatch, value):
+    """Non-finite env values disable the loop instead of producing a 0s period.
+
+    float() accepts "inf"/"nan" and overflows "1e999" to inf, so these slip
+    past the ValueError guard. A non-finite rate would make _camera_loop
+    compute period = 1.0/hz = 0.0 and busy-spin the render/publish loop with no
+    throttle. They must resolve to 0.0 (disabled) like any other bad value.
+    """
+    from strands_robots.mesh import Mesh
+
+    monkeypatch.setenv("STRANDS_MESH_CAMERA_HZ", value)
+    m = Mesh(fake_robot_with_camera, peer_id="test-cam-nonfinite")
+    assert m._resolve_camera_hz() == 0.0
+
+
 def test_publish_cameras_once_calls_put(fake_robot_with_camera):
     """One frame is read per camera and forwarded via mesh_session.put.
 


### PR DESCRIPTION
## Problem

`Mesh._resolve_camera_hz()` parses `STRANDS_MESH_CAMERA_HZ` with `float(env)` inside a `try/except ValueError`. But `float()` does **not** raise on non-finite strings: `float("inf")`, `float("nan")`, and the overflow case `float("1e999")` (which becomes `inf`) all parse successfully and slip past the guard.

The resolved rate feeds the camera loop:

```python
def _camera_loop(self, hz: float) -> None:
    period = 1.0 / hz          # 1.0 / inf == 0.0
    while self._running:
        ...
        if self._stop_event.wait(period):   # wait(0.0) returns immediately
            break
```

With `hz = inf`, `period` is `0.0`, so `_stop_event.wait(0.0)` returns instantly and the loop renders + JPEG-encodes + publishes camera frames as fast as the CPU allows, with no throttle — a busy-spin that saturates CPU and floods the mesh. `nan` takes the other path (`nan > 0` is `False`) and silently disables the loop **without** the warning that every other bad value emits.

## Change

After a successful `float()` parse, reject non-finite values with `math.isfinite`: log the same actionable warning used for unparseable input and return `0.0` (loop disabled). This extends the existing bad-value contract to cover `inf`/`-inf`/`nan`/overflow, so a misconfigured rate degrades to camera-stream-off instead of a busy-spin.

## Tests

Adds a parametrized regression in `tests/mesh/test_camera_schema.py` over `inf`, `-inf`, `nan`, `1e999`, asserting `_resolve_camera_hz() == 0.0`. It fails pre-fix on `inf`/`1e999` (`assert inf == 0.0`) and passes after. Full `tests/mesh` suite green (1921 passed, 2 skipped); ruff + mypy clean.

No visual artifact: this is env-var parsing/validation only — it changes when the camera loop is enabled, not what it renders or publishes.