### PR TITLE
fix(sim): render_depth honors a camera's configured resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,22 @@ those views, names may be given in raw or schema-safe (`/` -> `__`) form, and
 an unknown name fails loudly listing the available cameras. `dataset_cameras`
 now behaves identically on both engines.
 
+### Fixed: `render_depth` ignored a camera's configured resolution
+
+`render()` and `render_all()` honor a named camera's configured resolution
+(from `add_camera(width=, height=)`) when the caller omits `width`/`height`, so
+the rendered frame matches the camera - and the recorded dataset - it belongs
+to. `render_depth()` was left out of that contract: it always fell back to the
+engine default (640x480) for a named camera, so `render_depth("cam")` came back
+at a different size than `render("cam")` for the same camera. Any depth-aware
+consumer pairing the RGB frame with the depth map per pixel got mismatched
+dimensions.
+
+`render_depth()` now resolves resolution exactly like `render()`: omitted dims
+-> the named camera's configured resolution; explicit dims -> override; the
+free/model-only cameras -> engine default. RGB and depth for the same camera
+are now pixel-aligned.
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -800,14 +800,26 @@ class RenderingMixin:
         to a depth-aware downstream - whereas the scalar bounds alone discard the
         per-pixel structure. Use the ``json`` bounds when exact metric values
         matter; the grayscale image is normalized for display only.
+
+        Resolution: when ``width``/``height`` are omitted, the named camera's
+        configured resolution (from ``add_camera``) is used - so the depth map
+        is pixel-aligned with :meth:`render` for the same camera. The free
+        camera and model-only cameras fall back to the engine default. Explicit
+        ``width``/``height`` override the camera config.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
 
         mj = _ensure_mujoco()
-        # see note in render() re: None vs 0/negative.
-        w = self.default_width if width is None else width
-        h = self.default_height if height is None else height
+        # see note in render() re: None vs 0/negative. Honor the named camera's
+        # CONFIGURED resolution (add_camera(width=, height=)) when the caller
+        # omits a dimension, so the depth map is pixel-aligned with the RGB
+        # frame render() produces for the same camera (and with get_observation).
+        # The free camera and model-only cameras with no SimCamera entry fall
+        # back to the engine default.
+        cam_cfg = self._world.cameras.get(camera_name) if camera_name not in (None, "", "default", "free") else None
+        w = (cam_cfg.width if cam_cfg is not None else self.default_width) if width is None else width
+        h = (cam_cfg.height if cam_cfg is not None else self.default_height) if height is None else height
         if err := self._validate_render_dims(w, h):
             return err
 

--- a/tests/simulation/mujoco/test_render_camera_resolution.py
+++ b/tests/simulation/mujoco/test_render_camera_resolution.py
@@ -97,3 +97,71 @@ def test_render_matches_get_observation_resolution() -> None:
     arr = np.asarray(obs["cam_obs"])
     obs_h, obs_w = arr.shape[0], arr.shape[1]
     assert (rendered_w, rendered_h) == (obs_w, obs_h) == (200, 160)
+
+
+@_requires_mujoco
+def test_render_depth_uses_camera_configured_resolution() -> None:
+    """render_depth() also honors the camera's configured resolution.
+
+    render_depth historically fell back to the engine default whenever the
+    caller omitted width/height, so the depth map came back at a different size
+    than render()'s RGB frame for the same camera - breaking pixel alignment
+    for any depth-aware downstream consumer. Omitted dims must resolve to the
+    camera's own configured resolution, matching render() / render_all().
+    """
+    os.environ.setdefault("MUJOCO_GL", "glfw")
+    from strands_robots.simulation import Simulation
+
+    sim = Simulation()
+    sim.create_world()
+    sim.add_camera("cam_hi", position=[0.5, 0.0, 0.4], target=[0.0, 0.0, 0.1], width=320, height=240)
+
+    result = sim.render_depth(camera_name="cam_hi")  # no width/height
+    assert _rendered_size(result) == (320, 240)
+
+
+@_requires_mujoco
+def test_render_depth_explicit_dims_override_camera_config() -> None:
+    """Explicit width/height still win over the camera's configured resolution."""
+    os.environ.setdefault("MUJOCO_GL", "glfw")
+    from strands_robots.simulation import Simulation
+
+    sim = Simulation()
+    sim.create_world()
+    sim.add_camera("cam_hi", position=[0.5, 0.0, 0.4], target=[0.0, 0.0, 0.1], width=320, height=240)
+
+    result = sim.render_depth(camera_name="cam_hi", width=128, height=96)
+    assert _rendered_size(result) == (128, 96)
+
+
+@_requires_mujoco
+def test_render_depth_free_camera_uses_engine_default() -> None:
+    """The free ('default') camera has no SimCamera config -> engine default."""
+    os.environ.setdefault("MUJOCO_GL", "glfw")
+    from strands_robots.simulation import Simulation
+
+    sim = Simulation()
+    sim.create_world()
+
+    result = sim.render_depth(camera_name="default")  # free camera, no config
+    assert _rendered_size(result) == (sim.default_width, sim.default_height)
+
+
+@_requires_mujoco
+def test_render_depth_matches_render_resolution() -> None:
+    """render() and render_depth() agree on a configured camera's frame size.
+
+    Depth-aware consumers pair the RGB frame with the depth map per pixel; the
+    two must be the same size for the same named camera.
+    """
+    os.environ.setdefault("MUJOCO_GL", "glfw")
+    from strands_robots.simulation import Simulation
+
+    sim = Simulation()
+    sim.create_world()
+    sim.add_robot("arm", data_config="so101", position=[0.0, 0.0, 0.0])
+    sim.add_camera("cam_obs", position=[0.5, 0.0, 0.4], target=[0.0, 0.0, 0.1], width=200, height=160)
+
+    rgb_size = _rendered_size(sim.render(camera_name="cam_obs"))
+    depth_size = _rendered_size(sim.render_depth(camera_name="cam_obs"))
+    assert rgb_size == depth_size == (200, 160)


### PR DESCRIPTION
## Problem

`render()` and `render_all()` resolve an omitted `width`/`height` to the named camera's configured resolution (set via `add_camera(width=, height=)`), so the rendered frame matches the camera - and the recorded dataset - it belongs to. `get_observation()` already keys off the same per-camera config.

`render_depth()` was left out of that contract. For a named camera it always fell back to the engine default (640x480) whenever the caller omitted `width`/`height`, so `render_depth("cam")` came back at a **different size** than `render("cam")` for the same camera. Any depth-aware consumer that pairs the RGB frame with the depth map per pixel (RGB-D fusion, masking, point-cloud back-projection) got mismatched dimensions with no error.

Reproduced on a camera configured at 128x96:

```
render('camera1')        -> 128x96   (honors camera config)
render_depth('camera1')  -> 640x480  (ignored it -> engine default)
```

## Change

`render_depth()` now resolves resolution exactly like `render()`:
- omitted dims -> the named camera's configured resolution
- explicit `width`/`height` -> override
- free / model-only cameras (no `SimCamera` entry) -> engine default

RGB and depth for the same named camera are now pixel-aligned. The fix is a two-line resolution lookup mirroring `render()`, plus the matching docstring note.

## Tests

Extends `tests/simulation/mujoco/test_render_camera_resolution.py` (which already pins the `render()` per-camera-resolution contract) with the `render_depth` counterparts: configured-resolution, explicit-override, free-camera-default, and a `render`/`render_depth` size-agreement check. The configured-resolution and size-agreement tests **fail before** this change (depth came back 640x480 for a 320x240 / 200x160 camera) and pass after.

## Verification (MuJoCo, headless EGL)

After the fix, `render('wrist_view')` and `render_depth('wrist_view')` on a camera configured at 256x192 both return 256x192 and are pixel-aligned:

![render vs render_depth at the camera's configured resolution](https://github.com/cagataycali/robots/releases/download/artifact-render-depth-res-1782989837/depth_resolution_parity.png)

Full `tests/simulation/mujoco/` render suite (`test_render_camera_resolution`, `test_rendering`, `test_render_all_multicamera`, `test_render_output_path`, `test_render_after_scene_edit`) passes; `ruff` + `mypy` clean on the changed module.