### PR TITLE
fix(lerobot_local): warn when a normalization pipeline is present but inert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,30 @@ it. This extends the entry-point guards that already reject other
 fabricated-success-rate configs (non-positive `n_episodes`/`max_steps`, empty
 goal payloads).
 
+### Fixed: warn when a checkpoint's normalization pipeline is present but inert
+
+`lerobot_local` warned when a checkpoint shipped *no* `policy_postprocessor.json`
+(actions emitted in raw space). It stayed silent for a subtler, equally broken
+case: a pipeline that IS present and active but whose normalizer stats do not
+cover the declared `action` / `observation.state` keys. LeRobot's
+`NormalizerProcessorStep` returns a tensor unchanged when its lookup key is
+absent from the loaded stats, so such a pipeline normalizes NOTHING -
+`observation.state` reaches the model raw and predicted actions reach the robot
+without unnormalization - while `has_postprocessor` stays `True`, so the
+existing guard never fired.
+
+Pretraining *base* checkpoints hit this: `lerobot/smolvla_base` ships stats
+keyed by the training dataset (`so100.buffer.action`) with no
+`observation.state` stats and no bare `action` key, so both state normalization
+and action unnormalization silently pass through. The result looks like an
+out-of-distribution / proprioception-ignoring policy with no diagnostic.
+
+`ProcessorBridge.inert_normalization_features()` now reports declared,
+non-IDENTITY normalization features that will be skipped, and the load path
+warns (pointing at fine-tuning or `processor_overrides` stats) - matching the
+no-silent-passthrough intent of the missing-postprocessor warning. Diagnostic
+only; no change to action values.
+
 ### Fixed: `dataset_cameras` scoping crashed on the Newton backend
 
 `run_policy(dataset_cameras=[...])` scopes a recorded dataset to a chosen

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -833,17 +833,48 @@ class LerobotLocalPolicy(Policy):
         # normalized actions (~[-1, 1] or z-scored) straight to the robot. Fed
         # to a radian-joint sim those are micro-motions and the arm barely
         # moves. Warn once at load so this isn't debugged as a frozen policy.
-        if self.use_processor and (self._processor_bridge is None or not self._processor_bridge.has_postprocessor):
-            logger.warning(
-                "lerobot_local: %s loaded WITHOUT an action postprocessor "
-                "(no policy_postprocessor.json). Actions are emitted in the "
-                "model's RAW/normalized space and are NOT unnormalized to robot "
-                "units -- if the arm barely moves, this is why. Provide the "
-                "checkpoint's postprocessor, or drive it through a provider with "
-                "explicit unit handling (e.g. the 'transformers' provider's "
-                "state_units/action_units/stats knobs).",
-                self.pretrained_name_or_path or "<model>",
-            )
+        if self.use_processor:
+            bridge = self._processor_bridge
+            if bridge is None or not bridge.has_postprocessor:
+                logger.warning(
+                    "lerobot_local: %s loaded WITHOUT an action postprocessor "
+                    "(no policy_postprocessor.json). Actions are emitted in the "
+                    "model's RAW/normalized space and are NOT unnormalized to robot "
+                    "units -- if the arm barely moves, this is why. Provide the "
+                    "checkpoint's postprocessor, or drive it through a provider with "
+                    "explicit unit handling (e.g. the 'transformers' provider's "
+                    "state_units/action_units/stats knobs).",
+                    self.pretrained_name_or_path or "<model>",
+                )
+            else:
+                # Subtler failure than a missing postprocessor: the pipeline IS
+                # present and active, but its normalizer stats do not cover the
+                # declared action/state keys, so LeRobot's normalizer silently
+                # passes those tensors through (normalize_processor.py returns the
+                # tensor unchanged when the key is absent from its stats).
+                # Pretraining base checkpoints (e.g. lerobot/smolvla_base) ship
+                # stats keyed by the training dataset ('so100.buffer.action') with
+                # no 'observation.state' stats and no bare 'action' key -- so state
+                # reaches the model raw and actions reach the robot un-unnormalized
+                # while has_postprocessor stays True. Detect and warn, matching the
+                # no-silent-passthrough intent of the missing-postprocessor case.
+                inert = bridge.inert_normalization_features()
+                if inert:
+                    logger.warning(
+                        "lerobot_local: %s has an ACTIVE normalization pipeline "
+                        "but its stats do not cover %s -- those features are passed "
+                        "through UN-normalized (observation.state reaches the model "
+                        "raw; predicted actions reach the robot without "
+                        "unnormalization). Pretraining base checkpoints often ship "
+                        "dataset-prefixed stats (e.g. 'so100.buffer.action') instead "
+                        "of the canonical 'action'/'observation.state' keys. "
+                        "Fine-tune the checkpoint (which writes proper stats) or pass "
+                        "processor_overrides={'normalizer_processor': {'stats': "
+                        "<dataset stats>}} -- if the arm reaches an out-of-distribution "
+                        "pose or ignores proprioception, this is why.",
+                        self.pretrained_name_or_path or "<model>",
+                        inert,
+                    )
 
         # Initialize RTC if supported by this policy
         self._init_rtc()

--- a/strands_robots/policies/lerobot_local/processor.py
+++ b/strands_robots/policies/lerobot_local/processor.py
@@ -468,6 +468,71 @@ class ProcessorBridge:
         """Whether any processing pipeline is active."""
         return self.has_preprocessor or self.has_postprocessor
 
+    def inert_normalization_features(self) -> list[str]:
+        """Declared normalization features that will silently pass through.
+
+        A LeRobot ``NormalizerProcessorStep`` / ``UnnormalizerProcessorStep``
+        declares a ``norm_map`` (e.g. ``STATE`` / ``ACTION`` -> ``MEAN_STD``) but
+        applies it only when the looked-up stats key is present; otherwise it
+        returns the tensor unchanged (``normalize_processor.py``:
+        ``if norm_mode == IDENTITY or key not in self._tensor_stats: return
+        tensor``). Pretraining *base* checkpoints - notably
+        ``lerobot/smolvla_base`` - ship stats keyed by the training dataset
+        (e.g. ``so100.buffer.action``) with no ``observation.state`` stats and
+        no bare ``action`` key, so a present, active pipeline normalizes
+        NOTHING: ``observation.state`` reaches the model raw and the predicted
+        ``action`` reaches the robot without unnormalization. This is the same
+        silent-passthrough hazard :mod:`.norm_stats` guards for the MolmoAct2
+        ``norm_stats.json`` path, but it slips past the standard-pipeline path
+        because the pipeline *is* present.
+
+        Returns a list of ``"<key> (<type>/<mode>)"`` descriptors for every
+        feature whose declared, non-IDENTITY normalization will be skipped.
+        Empty when every declared normalization is backed by matching stats -
+        the normal case for a fine-tuned checkpoint whose stats use the
+        canonical ``action`` / ``observation.state`` keys.
+        """
+        try:
+            from lerobot.configs.types import FeatureType, NormalizationMode
+            from lerobot.utils.constants import ACTION
+        except ImportError:
+            return []
+
+        inert: list[str] = []
+        for pipeline in (self._preprocessor, self._postprocessor):
+            if pipeline is None:
+                continue
+            for step in getattr(pipeline, "steps", []):
+                class_name = type(step).__name__
+                if class_name not in ("NormalizerProcessorStep", "UnnormalizerProcessorStep"):
+                    continue
+                features = getattr(step, "features", None) or {}
+                norm_map = getattr(step, "norm_map", None) or {}
+                stat_keys = set((getattr(step, "stats", None) or {}).keys())
+                stat_keys |= set(getattr(step, "_tensor_stats", {}).keys())
+                is_unnormalizer = class_name == "UnnormalizerProcessorStep"
+                for key, feature in features.items():
+                    ftype = getattr(feature, "type", None)
+                    if ftype is None:
+                        continue
+                    mode = norm_map.get(ftype)
+                    if mode is None or mode == NormalizationMode.IDENTITY:
+                        continue
+                    # A NormalizerProcessorStep applies only observation features
+                    # (it skips ACTION); an UnnormalizerProcessorStep applies only
+                    # the ACTION. Mirror that so a feature the step never touches
+                    # is not falsely flagged.
+                    if is_unnormalizer and ftype != FeatureType.ACTION:
+                        continue
+                    if not is_unnormalizer and ftype == FeatureType.ACTION:
+                        continue
+                    lookup = ACTION if ftype == FeatureType.ACTION else key
+                    if lookup not in stat_keys:
+                        descriptor = f"{key} ({ftype.value}/{mode.value})"
+                        if descriptor not in inert:
+                            inert.append(descriptor)
+        return inert
+
     def preprocess(self, observation: dict[str, Any], instruction: str | None = None) -> dict[str, Any]:
         """Preprocess a raw observation dict through the pipeline.
 

--- a/tests/policies/lerobot_local/test_inert_normalization_detection.py
+++ b/tests/policies/lerobot_local/test_inert_normalization_detection.py
@@ -1,0 +1,81 @@
+"""Detection of a present-but-inert normalization pipeline.
+
+A LeRobot ``NormalizerProcessorStep`` silently returns a tensor unchanged when
+the looked-up stats key is absent (``normalize_processor.py``:
+``if norm_mode == IDENTITY or key not in self._tensor_stats: return tensor``).
+Pretraining *base* checkpoints such as ``lerobot/smolvla_base`` ship stats keyed
+by the training dataset (``so100.buffer.action``) with no ``observation.state``
+stats and no bare ``action`` key, so a present, active pipeline normalizes
+NOTHING while ``has_postprocessor`` stays ``True`` -- the load-time
+missing-postprocessor guard never fires and the passthrough is silent.
+
+These tests pin :meth:`ProcessorBridge.inert_normalization_features` against
+REAL LeRobot processor steps (no network, no model download): the dataset-keyed
+shape is flagged, the canonical ``action`` / ``observation.state`` shape is not.
+"""
+
+import pytest
+
+pytest.importorskip("lerobot.processor.pipeline")
+
+from lerobot.configs.types import FeatureType, NormalizationMode, PolicyFeature  # noqa: E402
+from lerobot.processor.normalize_processor import (  # noqa: E402
+    NormalizerProcessorStep,
+    UnnormalizerProcessorStep,
+)
+from lerobot.processor.pipeline import DataProcessorPipeline  # noqa: E402
+
+from strands_robots.policies.lerobot_local.processor import ProcessorBridge  # noqa: E402
+
+_FEATS = {
+    "observation.state": PolicyFeature(type=FeatureType.STATE, shape=(6,)),
+    "observation.image": PolicyFeature(type=FeatureType.VISUAL, shape=(3, 256, 256)),
+    "action": PolicyFeature(type=FeatureType.ACTION, shape=(6,)),
+}
+_NORM_MAP = {
+    FeatureType.VISUAL: NormalizationMode.IDENTITY,
+    FeatureType.STATE: NormalizationMode.MEAN_STD,
+    FeatureType.ACTION: NormalizationMode.MEAN_STD,
+}
+_MS = {"mean": [0.0] * 6, "std": [1.0] * 6}
+
+
+def _bridge(pre_stats: dict, post_stats: dict) -> ProcessorBridge:
+    """Build a real (network-free) bridge with the given normalizer stats."""
+    norm = NormalizerProcessorStep(features=dict(_FEATS), norm_map=dict(_NORM_MAP), stats=pre_stats)
+    unnorm = UnnormalizerProcessorStep(
+        features={"action": PolicyFeature(type=FeatureType.ACTION, shape=(6,))},
+        norm_map=dict(_NORM_MAP),
+        stats=post_stats,
+    )
+    return ProcessorBridge(
+        preprocessor=DataProcessorPipeline(steps=[norm]),
+        postprocessor=DataProcessorPipeline(steps=[unnorm]),
+        device="cpu",
+    )
+
+
+def test_dataset_prefixed_stats_are_flagged_inert():
+    """smolvla_base shape: stats keyed 'so100.buffer.action' -> state+action inert."""
+    dataset_keyed = {"so100.buffer.action": dict(_MS)}
+    bridge = _bridge(dataset_keyed, dataset_keyed)
+    inert = bridge.inert_normalization_features()
+    # observation.state (declared MEAN_STD, no matching stats) is passed through.
+    assert any(item.startswith("observation.state") for item in inert), inert
+    # action unnormalization (declared MEAN_STD, no bare 'action' stats) too.
+    assert any(item.startswith("action") for item in inert), inert
+    # The IDENTITY visual feature is never flagged.
+    assert not any(item.startswith("observation.image") for item in inert), inert
+
+
+def test_canonical_stats_are_not_flagged():
+    """A properly-keyed (fine-tuned) checkpoint normalizes everything -> no warning."""
+    canonical_pre = {"observation.state": dict(_MS), "action": dict(_MS)}
+    canonical_post = {"action": dict(_MS)}
+    bridge = _bridge(canonical_pre, canonical_post)
+    assert bridge.inert_normalization_features() == []
+
+
+def test_no_pipelines_returns_empty():
+    """A bridge with no pipelines has nothing to flag."""
+    assert ProcessorBridge().inert_normalization_features() == []


### PR DESCRIPTION
## Problem

`lerobot_local` already warns when a checkpoint ships **no** `policy_postprocessor.json` (actions emitted in raw space). It stays **silent** for a subtler, equally broken case: a normalization pipeline that *is* present and active but whose stats do not cover the declared `action` / `observation.state` keys.

LeRobot's `NormalizerProcessorStep` returns a tensor **unchanged** when its lookup key is absent from the loaded stats:

```python
# lerobot/processor/normalize_processor.py  (_apply_transform)
norm_mode = self.norm_map.get(feature_type, NormalizationMode.IDENTITY)
if norm_mode == NormalizationMode.IDENTITY or key not in self._tensor_stats:
    return tensor   # <-- silent passthrough
```

So a pipeline whose stats keys don't match the feature keys normalizes **nothing**: `observation.state` reaches the model raw and predicted actions reach the robot without unnormalization — while `has_postprocessor` stays `True`, so the existing guard in `policy.py` never fires.

### Canonical trigger: `lerobot/smolvla_base`

The pretraining base checkpoint ships its normalizer stats keyed by the training dataset, not by the canonical feature names:

```
policy_preprocessor_step_5_normalizer_processor.safetensors keys:
  so100.buffer.action.mean / .std
  so100-red.buffer.action.mean / .std
  so100-blue.buffer.action.mean / .std
  (no observation.state stats; no bare 'action' key)
```

Loaded via `lerobot_local` (`image_keys=[camera1,camera2,camera3]`, `strict_keys=True`), the bridge is active and `has_postprocessor=True`, yet direct calls confirm **both** transforms are passthrough:

```
STATE  norm passthrough? True   (observation.state absent from stats)
ACTION unnorm passthrough? True  (bare 'action' absent from stats)
```

The policy then receives un-normalized proprioception and its output is applied un-normalized. In a headless MuJoCo SO-101 rollout (seed=42, 110 steps @30Hz, cube at a reachable pose), the arm reaches a fixed pose and never engages the cube — **body-delta ground truth: cube `dxy=0.00000`, `dz=-0.016` (settle only), min gripper–cube ≈ 9 cm, no grasp** — with no diagnostic that normalization was inert.

![smolvla_base inert-normalization rollout](https://github.com/cagataycali/robots/releases/download/artifact-inert-normalizer-1782999880/smolvla_inert_rollout.gif)

## Fix

- Add `ProcessorBridge.inert_normalization_features()` — inspects the pre/post normalizer steps and returns `"<key> (<type>/<mode>)"` for every declared, non-IDENTITY feature whose lookup key is absent from the loaded stats (so it will passthrough). A `NormalizerProcessorStep` is checked for observation features; an `UnnormalizerProcessorStep` for the action — mirroring what each step actually applies, so a feature the step never touches is not falsely flagged. IDENTITY (visual) features are never flagged.
- Extend the load-time guard in `LerobotLocalPolicy`: when a postprocessor **is** present but `inert_normalization_features()` is non-empty, warn — matching the no-silent-passthrough intent of the existing missing-postprocessor warning, and pointing the user at fine-tuning (which writes proper stats) or `processor_overrides`.

**Diagnostic only — no change to action values.** A properly-keyed (fine-tuned) checkpoint whose stats use the canonical `action` / `observation.state` keys is not flagged.

Emitted warning for `smolvla_base`:

```
lerobot_local: lerobot/smolvla_base has an ACTIVE normalization pipeline but its
stats do not cover ['observation.state (STATE/MEAN_STD)', 'action (ACTION/MEAN_STD)']
-- those features are passed through UN-normalized ...
```

## Tests

`tests/policies/lerobot_local/test_inert_normalization_detection.py` builds real (network-free) LeRobot `NormalizerProcessorStep`/`UnnormalizerProcessorStep` pipelines:
- dataset-prefixed stats (`so100.buffer.action`) → state + action flagged inert (FAILS pre-fix: `AttributeError`, method absent);
- canonical `action`/`observation.state` stats → nothing flagged;
- no pipelines → empty.

Local gate: `ruff` + `ruff format` clean; `mypy` clean on both changed modules; `tests/policies/lerobot_local/` (`test_processor_real_pipeline`, `test_norm_stats_fallback`, `test_action_diagnostics`, `test_policy`, `test_configure_embodiment`, new test) — 245 passed.

## Changed files

- `strands_robots/policies/lerobot_local/processor.py` — `inert_normalization_features()`
- `strands_robots/policies/lerobot_local/policy.py` — extend load-time guard
- `tests/policies/lerobot_local/test_inert_normalization_detection.py` — regression test
- `CHANGELOG.md`