### PR TITLE
fix(registry): hot-reload honors the user-overlay file's mtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: registry hot-reload ignored the user-overlay file's mtime
+
+The `robots` registry the read API serves (`get_robot` / `list_robots` /
+`resolve_name`) is the package `robots.json` merged with the user-local overlay
+`$STRANDS_BASE_DIR/user_robots.json` (`loader._merge_user_robots`). The loader's
+mtime hot-reload -- documented to "re-read when the source changes" -- keyed its
+cache on the *package* file's mtime only. `register_robot` / `unregister_robot`
+invalidate the cache explicitly, so the in-process path was fine, but any other
+writer (a second process, a manual edit, or a tool that writes the overlay
+directly) was silently ignored: the merged result stayed stale until the package
+mtime happened to change or `invalidate_cache()` was called by hand.
+
+The cache-validity signature now tracks the mtimes of *both* files for the
+`robots` registry, so external create / modify / delete of `user_robots.json` is
+picked up on the next read -- honoring the hot-reload contract for the overlay
+just as for the package file, while still avoiding a re-read (only two `stat()`
+calls) when nothing changed. A public `registry.user_registry_mtime()` helper
+keeps the overlay path a single source of truth.
+
 
 ### Fixed: `move_object` silently no-op'd on static objects
 

--- a/strands_robots/registry/__init__.py
+++ b/strands_robots/registry/__init__.py
@@ -58,6 +58,7 @@ from .user_registry import (
     list_user_robots,
     register_robot,
     unregister_robot,
+    user_registry_mtime,
 )
 
 __all__ = [
@@ -86,6 +87,7 @@ __all__ = [
     "register_robot",
     "unregister_robot",
     "list_user_robots",
+    "user_registry_mtime",
     # Utilities
     "reload",
     "invalidate_cache",

--- a/strands_robots/registry/loader.py
+++ b/strands_robots/registry/loader.py
@@ -1,8 +1,17 @@
 """JSON registry loader with mtime-based hot-reload and validation.
 
 Loads robots.json and policies.json from the registry directory,
-re-reading only when the file's mtime changes.  Validates uniqueness of
+re-reading only when the on-disk source changes.  Validates uniqueness of
 aliases, shorthands, and URL patterns on every reload.
+
+The ``robots`` registry is not a single file: its effective contents are the
+package ``robots.json`` merged with the user-local overlay
+(``$STRANDS_BASE_DIR/user_robots.json`` - see :func:`_merge_user_robots`).  The
+hot-reload signature therefore tracks the mtimes of *both* files, so an edit to
+the user overlay made outside this process (a second process, a manual edit, or
+any writer that does not call :func:`invalidate_cache`) is picked up on the next
+read - honoring the "re-read when the source changes" contract for the overlay
+just as for the package file.
 """
 
 import json
@@ -13,11 +22,40 @@ logger = logging.getLogger(__name__)
 
 _REGISTRY_DIR = Path(__file__).parent
 _cache: dict[str, dict] = {}
-_mtimes: dict[str, float] = {}
+# Cache-validity signature per registry (a tuple of mtimes).  For ``robots``
+# the signature is (package_mtime, user_overlay_mtime_or_None); for every other
+# registry it is (package_mtime,).
+_mtimes: dict[str, tuple] = {}
+
+
+def _user_registry_mtime() -> float | None:
+    """Modification time of the user-local robot overlay, or None if absent.
+
+    Kept in :mod:`user_registry` so the overlay path has a single source of
+    truth; imported lazily to avoid an import cycle (``user_registry`` imports
+    :func:`invalidate_cache` from this module).
+    """
+    try:
+        from .user_registry import user_registry_mtime
+    except ImportError:
+        return None
+    return user_registry_mtime()
+
+
+def _registry_signature(name: str, pkg_mtime: float) -> tuple:
+    """Cache-validity signature for a registry.
+
+    The ``robots`` registry merges the user overlay on top of the package JSON,
+    so its signature includes the overlay's mtime - otherwise an external edit
+    to ``user_robots.json`` would never invalidate the cached merge.
+    """
+    if name != "robots":
+        return (pkg_mtime,)
+    return (pkg_mtime, _user_registry_mtime())
 
 
 def _load(name: str) -> dict:
-    """Load a JSON registry file, re-reading only when mtime changes.
+    """Load a JSON registry file, re-reading only when its source changes.
 
     Args:
         name: Base name without extension (e.g. "robots", "policies").
@@ -27,12 +65,13 @@ def _load(name: str) -> dict:
     """
     path = _REGISTRY_DIR / f"{name}.json"
     try:
-        mtime = path.stat().st_mtime
+        pkg_mtime = path.stat().st_mtime
     except FileNotFoundError:
         logger.error("Registry file not found: %s", path)
         return {}
 
-    if name not in _cache or _mtimes.get(name) != mtime:
+    signature = _registry_signature(name, pkg_mtime)
+    if name not in _cache or _mtimes.get(name) != signature:
         with open(path, encoding="utf-8") as f:
             data = json.load(f)
 
@@ -42,7 +81,7 @@ def _load(name: str) -> dict:
 
         _validate(name, data)
         _cache[name] = data
-        _mtimes[name] = mtime
+        _mtimes[name] = signature
         logger.debug("Loaded registry: %s (%d bytes)", path, path.stat().st_size)
 
     return _cache[name]

--- a/strands_robots/registry/user_registry.py
+++ b/strands_robots/registry/user_registry.py
@@ -57,6 +57,21 @@ def _get_user_registry_path() -> Path:
     return get_base_dir() / "user_robots.json"
 
 
+def user_registry_mtime() -> float | None:
+    """Modification time of the user-local robot registry file.
+
+    Returns:
+        The file's ``st_mtime``, or ``None`` when the overlay file does not
+        exist yet. Used by the loader's mtime hot-reload so an external edit to
+        ``user_robots.json`` (a second process or a manual edit) invalidates the
+        merged ``robots`` cache without requiring a manual ``invalidate_cache``.
+    """
+    try:
+        return _get_user_registry_path().stat().st_mtime
+    except (FileNotFoundError, OSError):
+        return None
+
+
 def _load_user_registry() -> dict[str, Any]:
     """Load the user-local robot registry file.
 

--- a/tests/registry/test_user_overlay_hot_reload.py
+++ b/tests/registry/test_user_overlay_hot_reload.py
@@ -1,0 +1,86 @@
+"""The mtime hot-reload must honor the user overlay, not just the package JSON.
+
+The ``robots`` registry the read API serves is the package ``robots.json``
+merged with the user-local overlay ``$STRANDS_BASE_DIR/user_robots.json``
+(:func:`loader._merge_user_robots`).  ``register_robot`` / ``unregister_robot``
+invalidate the cache explicitly, but any *other* writer - a second process, a
+manual edit, or a tool that writes the file directly - relies on the loader's
+documented "re-read when the source changes" behavior.  These tests pin that
+the cache signature tracks the overlay file's mtime, so create / modify / delete
+of ``user_robots.json`` are all observed without a manual ``invalidate_cache``.
+
+Each test warms the cache first, then mutates the overlay file *directly*
+(never via ``register_robot``, which would invalidate the cache and mask the
+bug).  The autouse fixture in ``conftest`` isolates ``STRANDS_BASE_DIR`` per
+test and clears the cache on entry/exit.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+from strands_robots.registry import get_robot, list_robots
+from strands_robots.utils import get_base_dir
+
+
+def _overlay_path():
+    return get_base_dir() / "user_robots.json"
+
+
+def _write_overlay(robots: dict) -> None:
+    """Write user_robots.json directly, bypassing register_robot()."""
+    path = _overlay_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"robots": robots}))
+
+
+def _entry(description: str) -> dict:
+    return {
+        "description": description,
+        "category": "arm",
+        "joints": 6,
+        "asset": {"dir": "x", "model_xml": "x.xml", "scene_xml": "x.xml"},
+    }
+
+
+def test_external_overlay_creation_is_picked_up():
+    """A user robot written to the overlay by an external writer becomes visible
+    on the next read, without a manual cache invalidation."""
+    # Warm the cache while the overlay file does not exist yet.
+    assert get_robot("ext_created") is None
+
+    _write_overlay({"ext_created": _entry("added out of process")})
+
+    got = get_robot("ext_created")
+    assert got is not None, "external overlay creation was not picked up (stale cache)"
+    assert got["description"] == "added out of process"
+
+
+def test_external_overlay_modification_is_picked_up():
+    """Rewriting an existing overlay entry is observed on the next read."""
+    _write_overlay({"ext_mod": _entry("first")})
+    assert get_robot("ext_mod")["description"] == "first"  # warm cache
+
+    _write_overlay({"ext_mod": _entry("second")})
+    # Force a strictly-newer mtime so the change is unambiguous regardless of
+    # filesystem timestamp granularity.
+    path = _overlay_path()
+    now = path.stat().st_mtime
+    os.utime(path, (now + 10, now + 10))
+
+    assert get_robot("ext_mod")["description"] == "second", (
+        "external overlay modification was not picked up (stale cache)"
+    )
+
+
+def test_external_overlay_deletion_is_picked_up():
+    """Deleting the overlay file drops its robots on the next read."""
+    _write_overlay({"ext_deleted": _entry("temporary")})
+    assert get_robot("ext_deleted") is not None  # warm cache
+
+    _overlay_path().unlink()
+
+    assert get_robot("ext_deleted") is None, "external overlay deletion was not picked up (stale cache)"
+    # Package robots are unaffected by the overlay churn.
+    assert any(r["name"] == "so101" for r in list_robots())


### PR DESCRIPTION
## Problem

The `robots` registry served by `get_robot` / `list_robots` / `resolve_name` is not a single file: its effective contents are the package `robots.json` merged with the user-local overlay `$STRANDS_BASE_DIR/user_robots.json` (`loader._merge_user_robots`). The loader documents mtime-based hot-reload -- "re-reading only when the file's mtime changes" -- but keyed its cache-validity check on the **package** file's mtime only.

`register_robot` / `unregister_robot` call `invalidate_cache("robots")`, so the in-process registration path is fine. But any *other* writer of the overlay -- a second process, a manual edit, or a tool that writes `user_robots.json` directly -- is silently ignored: the merged result stays stale until the package mtime happens to change or `invalidate_cache()` is called by hand. This contradicts the module's own hot-reload contract for the overlay.

Reproduced against the real registry (no mocks), isolated `STRANDS_BASE_DIR`:

```
initial   get_robot('ext_bot'): False
external edit to user_robots.json (no invalidate_cache)
after     get_robot('ext_bot'): False   <-- stale; expected True
after invalidate_cache('robots'):  True <-- confirms the cache is the culprit
```

## Fix

The cache-validity signature is now a tuple of mtimes. For the `robots` registry it is `(package_mtime, user_overlay_mtime_or_None)`; for every other registry it stays `(package_mtime,)`. So an external create / modify / delete of `user_robots.json` invalidates the merged cache on the next read, honoring the hot-reload contract for the overlay just as for the package file -- while still avoiding a re-read (only two `stat()` calls) when nothing changed.

A public `registry.user_registry_mtime()` helper keeps the overlay path a single source of truth (the loader imports it lazily to avoid the import cycle with `user_registry`, which imports `invalidate_cache`). No re-read on every call, no path duplication.

## Tests

`tests/registry/test_user_overlay_hot_reload.py` mutates `user_robots.json` **directly** (never via `register_robot`, which would invalidate the cache and mask the bug) after warming the cache, and asserts each transition is observed:

- external **creation** of an overlay robot becomes visible;
- external **modification** of an existing entry is picked up (forced strictly-newer mtime via `os.utime`, robust to filesystem timestamp granularity);
- external **deletion** of the overlay drops its robots (package robots unaffected).

All three **fail before** the fix (`assert None is not None`, `'first' == 'second'`, stale entry still present) and **pass after**.

## Local gate

- `ruff check` + `ruff format --check` clean; `mypy` clean on the changed modules.
- `tests/registry/` (incl. `test_public_api`, `test_user_registry`, overlay isolation) -- 506 passed; `tests/test_user_registry.py` -- passed. No regressions.

## Changed files

- `strands_robots/registry/loader.py` -- two-file mtime signature (`_registry_signature`, `_user_registry_mtime`)
- `strands_robots/registry/user_registry.py` -- public `user_registry_mtime()`
- `strands_robots/registry/__init__.py` -- export `user_registry_mtime`
- `tests/registry/test_user_overlay_hot_reload.py` -- regression test
- `CHANGELOG.md`