### PR TITLE
fix(examples): train_ppo_reach passes its own spec validation (num_mini_batches 4 -> 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: `examples/train_ppo_reach.py` aborted in its own `validate()` preflight
+
+The example shipped `rollout_steps=250` with `num_mini_batches=4`, but PPO spec
+validation requires `rollout_steps % num_mini_batches == 0` (a non-divisible
+split would silently drop samples), so the reference PPO entry point exited
+with `spec invalid` before training ever started. The example now uses
+`num_mini_batches=5` (`250 % 5 == 0`, 50 samples/mini-batch).
+
 ### Fixed: registry hot-reload ignored the user-overlay file's mtime
 
 The `robots` registry the read API serves (`get_robot` / `list_robots` /

--- a/examples/train_ppo_reach.py
+++ b/examples/train_ppo_reach.py
@@ -56,7 +56,7 @@ def main() -> None:
         output_dir=output_dir,
         total_timesteps=250 * 150,
         rollout_steps=250,
-        num_mini_batches=4,
+        num_mini_batches=5,
         num_learning_epochs=5,
         learning_rate=1e-3,
         init_noise_std=0.8,


### PR DESCRIPTION
Fixes #988.

`examples/train_ppo_reach.py` aborts before training on a clean checkout:

    $ MUJOCO_GL=egl python examples/train_ppo_reach.py
    SystemExit: spec invalid: ['rollout_steps (250) must be divisible by num_mini_batches (4)']

The example sets `rollout_steps=250` with `num_mini_batches=4`, but PPO spec validation
(`strands_robots/training/rl/ppo.py`) requires `rollout_steps % num_mini_batches == 0`,
and `250 % 4 == 2` — the shipped example contradicts the library's own rule and never
trains. The validation rule is sound (a non-divisible split would silently drop samples),
so this PR changes only the example.

Fix: `num_mini_batches=5` (`250 % 5 == 0`, 50 samples/mini-batch), keeping the round
`rollout_steps=250` — a one-line change. Verified on main @a5d9916: `trainer.validate(spec)`
returns `[]` and the example now trains end-to-end on CPU (150 iterations / 37,500
timesteps, `status=success`, policy exported). If you'd rather keep 4 mini-batches, the
equivalent is `rollout_steps=252` + `total_timesteps=252 * 150` (two lines); happy to switch.

Notes:
- `train_fastsac_reach.py` is unaffected (uses `batch_size`).
- `tests_integ/training/test_ppo_reach.py` uses the same 250/4 values without crashing —
  it drives `setup()` plus a manual rollout loop and never enters `validate()` (which runs
  on the `train()` path). The example is the path that validates; the integ test is left
  untouched.

Found exercising the RL trainer end-to-end on an SO-101 / Jetson test harness.
