### PR TITLE
test(sim): pin register_urdf directory + unreadable-file validation branches

### DIFF
--- a/tests/simulation/mujoco/test_agenttool_contract.py
+++ b/tests/simulation/mujoco/test_agenttool_contract.py
@@ -4,6 +4,7 @@ vector dims validated, tool_spec matches method signatures."""
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -513,6 +514,39 @@ class TestRegisterUrdfValidation:
         # Router handles empty string as missing? No - it's a truthy string
         # in the presence test. So we hit our explicit empty guard.
         assert "non-empty" in r["content"][0]["text"] or "requires parameter" in r["content"][0]["text"]
+
+    def test_register_urdf_directory_path_errors(self, sim, tmp_path):
+        # A path that exists but is a directory must be rejected with a
+        # distinct "not a file" message, not the generic "file not found"
+        # (the latter would mislead an agent into thinking the path is wrong
+        # when it is actually pointing at the wrong kind of node).
+        r = sim._dispatch_action(
+            "register_urdf",
+            {"data_config": "my_bot", "urdf_path": str(tmp_path)},
+        )
+        assert r["status"] == "error"
+        assert "not a file" in r["content"][0]["text"].lower()
+
+    def test_register_urdf_unreadable_file_errors(self, sim, tmp_path):
+        # An existing regular file that cannot be opened (permission denied)
+        # is caught up front with an actionable "cannot read" message rather
+        # than deferring to a cryptic MuJoCo load error later.
+        if hasattr(os, "geteuid") and os.geteuid() == 0:
+            pytest.skip("root bypasses filesystem permission checks")
+        urdf = tmp_path / "locked.urdf"
+        urdf.write_text("<mujoco/>")
+        urdf.chmod(0o000)
+        if os.access(urdf, os.R_OK):
+            pytest.skip("filesystem does not enforce read permissions here")
+        try:
+            r = sim._dispatch_action(
+                "register_urdf",
+                {"data_config": "my_bot", "urdf_path": str(urdf)},
+            )
+        finally:
+            urdf.chmod(0o644)
+        assert r["status"] == "error"
+        assert "cannot read" in r["content"][0]["text"].lower()
 
 
 class TestDuplicateCameraName:


### PR DESCRIPTION
## Problem

`Simulation.register_urdf(data_config, urdf_path)` validates `urdf_path` before handing it to the registry and returns a distinct, actionable error for each failure mode. Two of those guard branches were unpinned by tests:

- a path that **exists but is a directory** -> `not a file` (kept distinct from `file not found` so a caller can tell the path points at the wrong kind of node, not a wrong path);
- an existing but **unreadable file** -> the up-front `cannot read` OSError catch (surfaced eagerly instead of deferring to a cryptic MuJoCo load error later).

Both are agent-facing error contracts, but neither branch was exercised, so a regression that collapsed them into the generic `file not found` (or dropped the readability smoke-check) would have gone unnoticed.

## Change

Add two behavior tests to `TestRegisterUrdfValidation` that drive the branches through the public `_dispatch_action("register_urdf", ...)` path:

- `test_register_urdf_directory_path_errors` - passes a directory (`tmp_path`) and asserts the `not a file` message.
- `test_register_urdf_unreadable_file_errors` - writes a file, `chmod(0o000)`, and asserts the `cannot read` message. Skips when the process can bypass permission checks (root / non-enforcing filesystem) and restores the mode in a `finally`.

Test-only; no production code changes.

## Coverage

`register_urdf` input-validation branches go from 2 uncovered lines (the `not a file` guard and the `cannot read` OSError catch) to fully covered. `strands_robots/simulation/mujoco/simulation.py` no longer reports those lines as missing.

## Verification

- `MUJOCO_GL=egl pytest tests/simulation/mujoco/test_agenttool_contract.py` -> 68 passed.
- `ruff check` + `ruff format --check` clean on the touched file.