### PR TITLE
Enforce Strands tool-result contract: move top-level extras into content json

### DIFF
--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -1,0 +1,80 @@
+# Tool result contract
+
+Every tool-shaped return in `strands_robots` (any `@tool` function, any method
+the simulation/hardware routers dispatch to an agent) follows one shape. Keeping
+to it is what lets an agent chain tools, reason about telemetry, and lets
+downstream consumers (mesh, dashboards, evals) parse results with a fixed schema.
+
+## The shape
+
+A tool result is a dict with exactly two author-controlled top-level keys:
+
+- `status`: one of `"success"`, `"error"`, `"degraded"`.
+- `content`: a non-empty list of content blocks. Each block carries exactly one
+  of `"text"` (human-readable summary), `"json"` (structured payload), or
+  `"image"`.
+
+The Strands runtime may additionally inject a `toolUseId`; authors never set any
+other top-level key.
+
+```python
+return {
+    "status": "success",
+    "content": [
+        {"text": "Rollout completed: 2 episodes, 1.0 success rate."},
+        {"json": {"episodes": episodes, "success_rate": 1.0, "steps": 320}},
+    ],
+}
+```
+
+The canonical reference implementation is
+[`strands_robots/tools/run_policy.py`](https://github.com/strands-labs/robots/blob/main/strands_robots/tools/run_policy.py),
+which returns `content: [{"text": summary_line}, {"json": payload}]` so latency
+masking is provable from the payload, not the logs.
+
+## Why extra top-level keys are a bug
+
+It is tempting to return numeric telemetry as extra top-level keys:
+
+```python
+# WRONG - frames/errors/hz_actual are dropped by the runtime
+return {
+    "status": "success",
+    "content": [{"text": "Teleoperation completed: 512 frames, 0 errors."}],
+    "frames": 512,
+    "errors": 0,
+    "hz_actual": 49.7,
+}
+```
+
+The agent runtime serializes only `status` and `content` into the LLM turn.
+Anything outside `content` never reaches `agent.messages`, so the agent cannot
+reason about it (for example, deciding whether a teleop session is healthy), and
+structured consumers never see it. Put telemetry in a `{"json": {...}}` block:
+
+```python
+# RIGHT - telemetry rides in a json content block
+telemetry = {"frames": 512, "errors": 0, "hz_actual": 49.7}
+return {
+    "status": "success",
+    "content": [
+        {"text": "Teleoperation completed: 512 frames, 0 errors, 49.7Hz."},
+        {"json": telemetry},
+    ],
+}
+```
+
+## Choosing `status`
+
+- `"success"`: the operation completed as intended.
+- `"error"`: the operation failed (no useful result produced).
+- `"degraded"`: the operation ran but with partial failures worth surfacing (for
+  example, a teleop loop that produced frames but logged some per-frame errors).
+
+## Enforcement
+
+`tests/test_tool_result_contract.py` statically scans every tool-result-shaped
+dict literal in the package and fails if any carries an extra top-level key, so
+the contract cannot regress silently. The `assert_strands_tool_result` helper in
+`tests/tool_result_contract.py` validates a live result and can be applied in any
+test that exercises a tool method.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,6 +59,7 @@ nav:
 - Architecture: architecture.md
 - API Reference: api-reference.md
 - Security: security.md
+- Tool Result Contract: contracts.md
 - Contributing: contributing.md
 - Troubleshooting: troubleshooting.md
 theme:

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -1706,8 +1706,6 @@ class Robot(TeleopMixin, AgentTool):
 
         return {
             "status": "success",
-            "publishers": publishers,
-            "receivers": receivers,
             "content": [
                 {
                     "text": f"Teleop status:\n"
@@ -1721,6 +1719,7 @@ class Robot(TeleopMixin, AgentTool):
                         f"  [rcv] {k}: {s.get('frames_received', 0)} frames @ {s.get('hz_actual', 0):.1f}Hz\n"
                         for k, s in receivers.items()
                     )
-                }
+                },
+                {"json": {"publishers": publishers, "receivers": receivers}},
             ],
         }

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -2954,7 +2954,10 @@ class MuJoCoSimEngine(
             f"{step_count} synchronized steps"
             f"{' (recorded)' if recording else ''}"
         )
-        return {"status": "success", "content": [{"text": text}], "steps": step_count}
+        return {
+            "status": "success",
+            "content": [{"text": text}, {"json": {"steps": step_count}}],
+        }
 
     # Action name aliases (tool-action -> method-name)
     _ACTION_ALIASES = {

--- a/strands_robots/teleop_mixin.py
+++ b/strands_robots/teleop_mixin.py
@@ -235,8 +235,10 @@ class TeleopMixin:
         body = "\n".join(rows) if rows else "  (none)"
         return {
             "status": "success",
-            "content": [{"text": f"Attached teleoperators ({len(self._teleops)}):\n{body}"}],
-            "teleops": list(self._teleops),
+            "content": [
+                {"text": f"Attached teleoperators ({len(self._teleops)}):\n{body}"},
+                {"json": {"teleops": list(self._teleops)}},
+            ],
         }
 
     # --- drive ------------------------------------------------------------
@@ -390,10 +392,9 @@ class TeleopMixin:
                     "text": f"Teleoperation started: driving {selected} @ {hz:.0f}Hz "
                     f"-> {self.tool_name_label(robot_name)}{pub_note}.\n"
                     f"Call stop_teleoperate() to stop."
-                }
+                },
+                {"json": {"devices": selected, "publish": publish}},
             ],
-            "devices": selected,
-            "publish": publish,
         }
 
     def stop_teleoperate(self) -> dict[str, Any]:
@@ -428,17 +429,21 @@ class TeleopMixin:
         hz = self._teleop_frames / elapsed if elapsed > 0 else 0
         return {
             "status": "success",
-            "running": self._teleop_running,
-            "frames": self._teleop_frames,
-            "errors": self._teleop_errors,
-            "hz_actual": hz,
-            "devices": list(self._teleops),
             "content": [
                 {
                     "text": f"Local teleop: running={self._teleop_running}, "
                     f"frames={self._teleop_frames}, errors={self._teleop_errors}, "
                     f"hz={hz:.1f}, devices={list(self._teleops)}"
-                }
+                },
+                {
+                    "json": {
+                        "running": self._teleop_running,
+                        "frames": self._teleop_frames,
+                        "errors": self._teleop_errors,
+                        "hz_actual": hz,
+                        "devices": list(self._teleops),
+                    }
+                },
             ],
         }
 
@@ -534,18 +539,25 @@ class TeleopMixin:
             status = "error"  # every attempt failed, either mode
         else:
             status = "degraded"  # some ok, some failed
+        telemetry = {
+            "frames": frames,
+            "errors": errors,
+            "hz_actual": hz,
+            "elapsed_s": elapsed,
+            "status": status,
+            "blocking": blocking,
+            "publish_count": len(publish_results) if publish_results else 0,
+        }
         return {
             "status": status,
             "content": [
                 {
                     "text": f"Teleoperation {'completed' if blocking else 'stopped'}: "
-                    f"{self._teleop_frames} frames, {self._teleop_errors} errors, "
+                    f"{frames} frames, {errors} errors, "
                     f"{hz:.1f}Hz over {elapsed:.1f}s.{note}"
-                }
+                },
+                {"json": telemetry},
             ],
-            "frames": self._teleop_frames,
-            "errors": self._teleop_errors,
-            "hz_actual": hz,
         }
 
 

--- a/strands_robots/tools/lerobot_calibrate.py
+++ b/strands_robots/tools/lerobot_calibrate.py
@@ -411,10 +411,9 @@ def lerobot_calibrate(
                     "content": [
                         {
                             "text": f"**No calibration files found.**\n\nCalibrations are stored in: `{manager.base_path}`"
-                        }
+                        },
+                        {"json": {"calibrations": structure, "count": 0}},
                     ],
-                    "calibrations": structure,
-                    "count": 0,
                 }
 
             # Format output
@@ -451,9 +450,10 @@ def lerobot_calibrate(
 
             return {
                 "status": "success",
-                "content": [{"text": "\n".join(content_lines)}],
-                "calibrations": structure,
-                "count": total_count,
+                "content": [
+                    {"text": "\n".join(content_lines)},
+                    {"json": {"calibrations": structure, "count": total_count}},
+                ],
             }
 
         elif action == "view":
@@ -496,7 +496,13 @@ def lerobot_calibrate(
                             ]
                         )
 
-            return {"status": "success", "content": [{"text": "\n".join(content_lines)}], "calibration_info": info}
+            return {
+                "status": "success",
+                "content": [
+                    {"text": "\n".join(content_lines)},
+                    {"json": {"calibration_info": info}},
+                ],
+            }
 
         elif action == "search":
             results = manager.search_calibrations(query or "", device_type, device_model)
@@ -505,9 +511,10 @@ def lerobot_calibrate(
                 search_desc = f"query '{query}'" if query else "specified criteria"
                 return {
                     "status": "success",
-                    "content": [{"text": f"**No calibrations found** matching {search_desc}"}],
-                    "results": [],
-                    "count": 0,
+                    "content": [
+                        {"text": f"**No calibrations found** matching {search_desc}"},
+                        {"json": {"results": [], "count": 0}},
+                    ],
                 }
 
             content_lines = [f"**Search Results** ({len(results)} found)", f"Query: `{query or 'all'}`", ""]
@@ -530,9 +537,10 @@ def lerobot_calibrate(
 
             return {
                 "status": "success",
-                "content": [{"text": "\n".join(content_lines)}],
-                "results": results,
-                "count": len(results),
+                "content": [
+                    {"text": "\n".join(content_lines)},
+                    {"json": {"results": results, "count": len(results)}},
+                ],
             }
 
         elif action == "backup":
@@ -558,9 +566,10 @@ def lerobot_calibrate(
 
                 return {
                     "status": "success",
-                    "content": [{"text": "\n".join(content_lines)}],
-                    "backup_path": message,
-                    "files_count": count,
+                    "content": [
+                        {"text": "\n".join(content_lines)},
+                        {"json": {"backup_path": message, "files_count": count}},
+                    ],
                 }
             else:
                 return {"status": "error", "content": [{"text": f"**Backup failed:** {message}"}]}
@@ -574,8 +583,10 @@ def lerobot_calibrate(
             if success:
                 return {
                     "status": "success",
-                    "content": [{"text": f"**{message}**\nFrom: `{backup_dir}`\nOverwrite mode: `{overwrite}`"}],
-                    "restored_count": count,
+                    "content": [
+                        {"text": f"**{message}**\nFrom: `{backup_dir}`\nOverwrite mode: `{overwrite}`"},
+                        {"json": {"restored_count": count}},
+                    ],
                 }
             else:
                 return {"status": "error", "content": [{"text": f"**Restore failed:** {message}"}]}
@@ -611,7 +622,13 @@ def lerobot_calibrate(
             structure = manager.get_calibration_structure()
 
             if not any(structure.values()):
-                return {"status": "success", "content": [{"text": "**No calibrations to analyze**"}], "analysis": {}}
+                return {
+                    "status": "success",
+                    "content": [
+                        {"text": "**No calibrations to analyze**"},
+                        {"json": {"analysis": {}}},
+                    ],
+                }
 
             total_calibrations = 0
             device_counts = {"teleoperators": 0, "robots": 0}
@@ -669,7 +686,13 @@ def lerobot_calibrate(
                 "base_path": str(manager.base_path),
             }
 
-            return {"status": "success", "content": [{"text": "\n".join(content_lines)}], "analysis": analysis}
+            return {
+                "status": "success",
+                "content": [
+                    {"text": "\n".join(content_lines)},
+                    {"json": {"analysis": analysis}},
+                ],
+            }
 
         elif action == "path":
             if device_type and device_model and device_id:
@@ -683,10 +706,9 @@ def lerobot_calibrate(
                         {
                             "text": f"**Calibration Path**\n`{calib_path}`\n\n"
                             f"{' File exists' if exists else ' File does not exist'}"
-                        }
+                        },
+                        {"json": {"path": str(calib_path), "exists": exists}},
                     ],
-                    "path": str(calib_path),
-                    "exists": exists,
                 }
             else:
                 # Show base paths
@@ -698,11 +720,15 @@ def lerobot_calibrate(
                             f"**Base:** `{manager.base_path}`\n"
                             f"**Teleoperators:** `{manager.teleop_path}`\n"
                             f"**Robots:** `{manager.robot_path}`"
-                        }
+                        },
+                        {
+                            "json": {
+                                "base_path": str(manager.base_path),
+                                "teleop_path": str(manager.teleop_path),
+                                "robot_path": str(manager.robot_path),
+                            }
+                        },
                     ],
-                    "base_path": str(manager.base_path),
-                    "teleop_path": str(manager.teleop_path),
-                    "robot_path": str(manager.robot_path),
                 }
 
         else:

--- a/strands_robots/tools/lerobot_teleoperate.py
+++ b/strands_robots/tools/lerobot_teleoperate.py
@@ -664,13 +664,17 @@ def lerobot_teleoperate(
                             f"Command: `{' '.join(cmd)}`\n"
                             f"Log file: `{log_file}`\n"
                             f"Running in background"
-                        }
+                        },
+                        {
+                            "json": {
+                                "session_name": session_name,
+                                "pid": proc.pid,
+                                "command": " ".join(cmd),
+                                "log_file": str(log_file),
+                                "background": True,
+                            }
+                        },
                     ],
-                    "session_name": session_name,
-                    "pid": proc.pid,
-                    "command": " ".join(cmd),
-                    "log_file": str(log_file),
-                    "background": True,
                 }
             else:
                 # Start in foreground
@@ -685,12 +689,16 @@ def lerobot_teleoperate(
                             f"Command: `{' '.join(cmd)}`\n\n"
                             f"**Output:**\n```\n{result.stdout}\n```\n\n"
                             f"**Errors:**\n```\n{result.stderr}\n```"
-                        }
+                        },
+                        {
+                            "json": {
+                                "command": " ".join(cmd),
+                                "return_code": result.returncode,
+                                "stdout": result.stdout,
+                                "stderr": result.stderr,
+                            }
+                        },
                     ],
-                    "command": " ".join(cmd),
-                    "return_code": result.returncode,
-                    "stdout": result.stdout,
-                    "stderr": result.stderr,
                 }
 
         elif action == "stop":
@@ -719,9 +727,10 @@ def lerobot_teleoperate(
 
                 return {
                     "status": "success",
-                    "content": [{"text": f"**Session Stopped**\nSession: `{session_name}`\nPID: {pid}"}],
-                    "session_name": session_name,
-                    "session_info": session_info,
+                    "content": [
+                        {"text": f"**Session Stopped**\nSession: `{session_name}`\nPID: {pid}"},
+                        {"json": {"session_name": session_name, "session_info": session_info}},
+                    ],
                 }
 
             except ProcessLookupError:
@@ -729,8 +738,10 @@ def lerobot_teleoperate(
                 session_manager.remove_session(session_name)
                 return {
                     "status": "success",
-                    "content": [{"text": f"Session '{session_name}' was already stopped"}],
-                    "session_name": session_name,
+                    "content": [
+                        {"text": f"Session '{session_name}' was already stopped"},
+                        {"json": {"session_name": session_name}},
+                    ],
                 }
             except Exception as e:
                 return {
@@ -767,9 +778,10 @@ def lerobot_teleoperate(
 
             return {
                 "status": "success",
-                "content": [{"text": "\n".join(content_lines)}],
-                "sessions": sessions,
-                "count": len(sessions),
+                "content": [
+                    {"text": "\n".join(content_lines)},
+                    {"json": {"sessions": sessions, "count": len(sessions)}},
+                ],
             }
 
         elif action == "status":
@@ -858,11 +870,17 @@ def lerobot_teleoperate(
 
             return {
                 "status": "success" if result.returncode == 0 else "error",
-                "content": [{"text": "\n".join(content_lines)}],
-                "command": " ".join(cmd),
-                "return_code": result.returncode,
-                "stdout": result.stdout,
-                "stderr": result.stderr,
+                "content": [
+                    {"text": "\n".join(content_lines)},
+                    {
+                        "json": {
+                            "command": " ".join(cmd),
+                            "return_code": result.returncode,
+                            "stdout": result.stdout,
+                            "stderr": result.stderr,
+                        }
+                    },
+                ],
             }
 
         else:

--- a/strands_robots/tools/lerobot_train.py
+++ b/strands_robots/tools/lerobot_train.py
@@ -462,13 +462,17 @@ def lerobot_train(
                         f"Command: `{' '.join(cmd)}`\n"
                         f"Log file: `{log_file}`\n"
                         f"Running in background"
-                    }
+                    },
+                    {
+                        "json": {
+                            "session_name": session_name,
+                            "pid": proc.pid,
+                            "command": " ".join(cmd),
+                            "log_file": str(log_file),
+                            "output_dir": resolved_output_dir,
+                        }
+                    },
                 ],
-                "session_name": session_name,
-                "pid": proc.pid,
-                "command": " ".join(cmd),
-                "log_file": str(log_file),
-                "output_dir": resolved_output_dir,
             }
 
         elif action == "stop":
@@ -490,16 +494,19 @@ def lerobot_train(
                 session_manager.remove_session(session_name)
                 return {
                     "status": "success",
-                    "content": [{"text": f"**Session Stopped**\nSession: `{session_name}`\nPID: {pid}"}],
-                    "session_name": session_name,
-                    "session_info": session_info,
+                    "content": [
+                        {"text": f"**Session Stopped**\nSession: `{session_name}`\nPID: {pid}"},
+                        {"json": {"session_name": session_name, "session_info": session_info}},
+                    ],
                 }
             except ProcessLookupError:
                 session_manager.remove_session(session_name)
                 return {
                     "status": "success",
-                    "content": [{"text": f"Session '{session_name}' was already stopped"}],
-                    "session_name": session_name,
+                    "content": [
+                        {"text": f"Session '{session_name}' was already stopped"},
+                        {"json": {"session_name": session_name}},
+                    ],
                 }
 
         elif action == "list":
@@ -526,9 +533,10 @@ def lerobot_train(
                 lines.append("No active sessions")
             return {
                 "status": "success",
-                "content": [{"text": "\n".join(lines)}],
-                "sessions": sessions,
-                "count": len(sessions),
+                "content": [
+                    {"text": "\n".join(lines)},
+                    {"json": {"sessions": sessions, "count": len(sessions)}},
+                ],
             }
 
         elif action == "status":

--- a/strands_robots/tools/pose_tool.py
+++ b/strands_robots/tools/pose_tool.py
@@ -376,8 +376,10 @@ def pose_tool(
             if not poses:
                 return {
                     "status": "success",
-                    "content": [{"text": f"No poses stored for robot {robot_id}"}],
-                    "poses": [],
+                    "content": [
+                        {"text": f"No poses stored for robot {robot_id}"},
+                        {"json": {"poses": []}},
+                    ],
                 }
 
             # Get detailed pose information
@@ -401,8 +403,10 @@ def pose_tool(
 
             return {
                 "status": "success",
-                "content": [{"text": f"Stored poses for {robot_id}:\n{pose_list}"}],
-                "poses": pose_details,
+                "content": [
+                    {"text": f"Stored poses for {robot_id}:\n{pose_list}"},
+                    {"json": {"poses": pose_details}},
+                ],
             }
 
         if action == "show_pose":
@@ -423,9 +427,9 @@ def pose_tool(
                         f"Description: {pose.description or 'None'}\n"
                         f"Created: {time.ctime(pose.timestamp)}\n"
                         f"Motor Positions:\n{motor_info}"
-                    }
+                    },
+                    {"json": {"pose": pose.to_dict()}},
                 ],
-                "pose": pose.to_dict(),
             }
 
         if action == "delete_pose":
@@ -465,8 +469,10 @@ def pose_tool(
                     unit = "%" if motor_name == "gripper" else " deg"
                     return {
                         "status": "success",
-                        "content": [{"text": f"{motor_name}: {position:.2f}{unit}"}],
-                        "position": position,
+                        "content": [
+                            {"text": f"{motor_name}: {position:.2f}{unit}"},
+                            {"json": {"position": position}},
+                        ],
                     }
                 else:
                     return {"status": "error", "content": [{"text": f"Failed to read {motor_name}"}]}
@@ -489,8 +495,10 @@ def pose_tool(
                     )
                     return {
                         "status": "success",
-                        "content": [{"text": f"Current robot positions:\n{pos_text}"}],
-                        "positions": positions,
+                        "content": [
+                            {"text": f"Current robot positions:\n{pos_text}"},
+                            {"json": {"positions": positions}},
+                        ],
                     }
                 else:
                     return {"status": "error", "content": [{"text": "Failed to read positions"}]}
@@ -521,8 +529,10 @@ def pose_tool(
 
                 return {
                     "status": "success",
-                    "content": [{"text": f"Stored pose '{pose_name}':\n{pos_text}"}],
-                    "pose": pose.to_dict(),
+                    "content": [
+                        {"text": f"Stored pose '{pose_name}':\n{pos_text}"},
+                        {"json": {"pose": pose.to_dict()}},
+                    ],
                 }
             finally:
                 controller.disconnect()
@@ -549,8 +559,10 @@ def pose_tool(
                 if success:
                     return {
                         "status": "success",
-                        "content": [{"text": f"Moved to pose '{pose_name}'"}],
-                        "target_positions": pose.positions,
+                        "content": [
+                            {"text": f"Moved to pose '{pose_name}'"},
+                            {"json": {"target_positions": pose.positions}},
+                        ],
                     }
                 else:
                     return {"status": "error", "content": [{"text": f"Failed to move to pose '{pose_name}'"}]}
@@ -637,8 +649,10 @@ def pose_tool(
                 if success:
                     return {
                         "status": "success",
-                        "content": [{"text": "Robot moved to home position"}],
-                        "home_positions": home_positions,
+                        "content": [
+                            {"text": "Robot moved to home position"},
+                            {"json": {"home_positions": home_positions}},
+                        ],
                     }
                 else:
                     return {"status": "error", "content": [{"text": "Failed to move to home position"}]}

--- a/strands_robots/tools/serial_tool.py
+++ b/strands_robots/tools/serial_tool.py
@@ -80,9 +80,9 @@ def serial_tool(
                     {
                         "text": f"Found {len(ports)} serial ports:\n"
                         + "\n".join([f"- {p['device']} - {p['description']}" for p in ports])
-                    }
+                    },
+                    {"json": {"ports": ports}},
                 ],
-                "ports": ports,
             }
 
         if not port:
@@ -117,9 +117,10 @@ def serial_tool(
 
             return {
                 "status": "success",
-                "content": [{"text": f"Read {len(read_data)} bytes:\nHex: {hex_str}\nASCII: {ascii_str}"}],
-                "raw_data": read_data.hex(),
-                "length": len(read_data),
+                "content": [
+                    {"text": f"Read {len(read_data)} bytes:\nHex: {hex_str}\nASCII: {ascii_str}"},
+                    {"json": {"raw_data": read_data.hex(), "length": len(read_data)}},
+                ],
             }
 
         elif action == "send_read":
@@ -221,8 +222,10 @@ def serial_tool(
 
             return {
                 "status": "success",
-                "content": [{"text": f"Monitored {len(monitor_data)} data chunks in 5 seconds"}],
-                "monitor_data": monitor_data,
+                "content": [
+                    {"text": f"Monitored {len(monitor_data)} data chunks in 5 seconds"},
+                    {"json": {"monitor_data": monitor_data}},
+                ],
             }
 
         else:

--- a/tests/simulation/mujoco/test_recording_paths.py
+++ b/tests/simulation/mujoco/test_recording_paths.py
@@ -22,6 +22,8 @@ pytest.importorskip("mujoco")
 
 os.environ.setdefault("MUJOCO_GL", "glfw")
 
+from tests.tool_result_contract import tool_json  # noqa: E402
+
 # Inline MJCF XML to avoid network-dependent so101 model downloads.
 _ROBOT_XML = """
 <mujoco model="test_arm">
@@ -248,7 +250,7 @@ def test_b4_synchronized_multi_robot_recording(sim_with_two_robots, tmp_path):
         policies=pols, instructions={"alpha": "a", "beta": "b"}, duration=0.5, control_frequency=20.0
     )
     assert r["status"] == "success", r
-    assert r["steps"] > 0
+    assert tool_json(r)["steps"] > 0
     sim.stop_recording()
 
     from lerobot.datasets.lerobot_dataset import LeRobotDataset
@@ -326,7 +328,7 @@ def test_multi_robot_recording_action_columns_keyed_by_actuators(sim_with_two_ro
         policies=pols, instructions={"alpha": "a", "beta": "b"}, duration=0.5, control_frequency=20.0
     )
     assert r["status"] == "success", r
-    assert r["steps"] > 0
+    assert tool_json(r)["steps"] > 0
     sim.stop_recording()
 
     # Read the action column directly from parquet (no video decode needed).

--- a/tests/simulation/mujoco/test_run_multi_policy_no_recording.py
+++ b/tests/simulation/mujoco/test_run_multi_policy_no_recording.py
@@ -27,6 +27,7 @@ os.environ.setdefault("MUJOCO_GL", "egl")
 from strands_robots.policies.base import Policy  # noqa: E402
 from strands_robots.policies.mock import MockPolicy  # noqa: E402
 from strands_robots.simulation import Simulation  # noqa: E402
+from tests.tool_result_contract import tool_json  # noqa: E402
 
 _ROBOT_XML = """
 <mujoco model="test_arm">
@@ -109,7 +110,7 @@ def test_run_multi_policy_runs_without_recorder(sim_two_robots):
         action_horizon=4,
     )
     assert r["status"] == "success", r
-    assert r["steps"] == 10
+    assert tool_json(r)["steps"] == 10
     assert "synchronized steps" in r["content"][0]["text"]
     # No "(recorded)" suffix when no recorder is attached.
     assert "recorded" not in r["content"][0]["text"]
@@ -165,7 +166,7 @@ def test_run_multi_policy_max_steps_aliases_n_steps(sim_two_robots):
         control_frequency=40.0,
     )
     assert r["status"] == "success", r
-    assert r["steps"] == 8
+    assert tool_json(r)["steps"] == 8
 
 
 def test_run_multi_policy_rejects_empty_policies(sim_two_robots):
@@ -274,7 +275,7 @@ def test_run_multi_policy_cooperative_stop_ends_early(sim_two_robots):
     )
     assert r["status"] == "success", r
     assert "stopped early" in r["content"][0]["text"]
-    assert r["steps"] < 50
+    assert tool_json(r)["steps"] < 50
     # Running flags are cleared on the way out regardless of early stop.
     for name in ("alpha", "beta"):
         assert sim._world.robots[name].policy_running is False

--- a/tests/test_hardware_robot_lifecycle.py
+++ b/tests/test_hardware_robot_lifecycle.py
@@ -27,6 +27,7 @@ import pytest
 from strands_robots.hardware_robot import Robot as HwRobot
 from strands_robots.hardware_robot import RobotTaskState, TaskStatus
 from strands_robots.policies.base import Policy
+from tests.tool_result_contract import tool_json
 
 
 class _FakeLeRobot:
@@ -711,8 +712,8 @@ class TestTeleopStopAndStatus:
         self._wire(hw)
         result = hw.get_teleop_status()
         assert result["status"] == "success"
-        assert len(result["publishers"]) == 1
-        assert len(result["receivers"]) == 1
+        assert len(tool_json(result)["publishers"]) == 1
+        assert len(tool_json(result)["receivers"]) == 1
         assert "Publishers: 1 active" in result["content"][0]["text"]
         assert "Receivers: 1 active" in result["content"][0]["text"]
         hw.cleanup()

--- a/tests/test_teleop.py
+++ b/tests/test_teleop.py
@@ -15,6 +15,7 @@ import time
 import pytest
 
 from strands_robots.teleop_mixin import AttachedTeleop, TeleopMixin
+from tests.tool_result_contract import tool_json
 
 # ---------------------------------------------------------------------------
 # Fakes
@@ -326,7 +327,7 @@ def test_list_teleops():
     host.attach_teleop(FakeTeleop({"a": 1.0}), name="leader")
     res = host.list_teleops()
     assert res["status"] == "success"
-    assert "leader" in res["teleops"]
+    assert "leader" in tool_json(res)["teleops"]
 
 
 def test_publish_delegates_to_host():
@@ -336,7 +337,7 @@ def test_publish_delegates_to_host():
     res = host.teleoperate(hz=100, publish=True)
     try:
         assert res["status"] == "success"
-        assert res["publish"] is True
+        assert tool_json(res)["publish"] is True
         assert len(host.publish_calls) == 1
         assert host.publish_calls[0]["device_name"] == "arm"
         assert host.publish_calls[0]["teleoperator"] is arm
@@ -360,8 +361,8 @@ def test_get_teleoperate_status():
     host = FakeHost()
     host.attach_teleop(FakeTeleop({"a": 1.0}), name="leader")
     st = host.get_teleoperate_status()
-    assert st["running"] is False
-    assert st["devices"] == ["leader"]
+    assert tool_json(st)["running"] is False
+    assert tool_json(st)["devices"] == ["leader"]
 
 
 def test_attached_teleop_dataclass():

--- a/tests/test_tool_result_contract.py
+++ b/tests/test_tool_result_contract.py
@@ -1,0 +1,146 @@
+"""Enforce the Strands tool-result contract across ``strands_robots``.
+
+Tool results must expose exactly ``{"status", "content"}`` at the top level
+(the runtime may add ``toolUseId``). Structured telemetry belongs inside
+``content`` as a ``{"json": {...}}`` block, never as extra top-level keys --
+extras are dropped by the agent runtime and never reach ``agent.messages``.
+
+The repo-wide ``test_no_extra_top_level_keys`` test is the standing guard: it
+statically scans every tool-result-shaped dict literal in the package and
+fails if any carries extra top-level keys. The remaining tests apply
+``assert_strands_tool_result`` to live results from representative call sites
+(teleop stats, simulation policy rollout, action dispatch).
+"""
+
+from __future__ import annotations
+
+import ast
+import threading
+from pathlib import Path
+
+import pytest
+
+import strands_robots
+from strands_robots.teleop_mixin import TeleopMixin
+from tests.tool_result_contract import (
+    VALID_TOP_LEVEL_KEYS,
+    assert_strands_tool_result,
+)
+
+_PKG_ROOT = Path(strands_robots.__file__).resolve().parent
+
+
+def _tool_result_violations() -> list[str]:
+    """Statically find tool-result dict literals with extra top-level keys.
+
+    A dict literal counts as tool-result-shaped when it has constant string
+    keys including both ``status`` and ``content``. Any key outside
+    ``{"status", "content", "toolUseId"}`` is a contract violation.
+    """
+    violations: list[str] = []
+    for path in _PKG_ROOT.rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Dict):
+                continue
+            keys = [k.value for k in node.keys if isinstance(k, ast.Constant) and isinstance(k.value, str)]
+            if len(keys) != len(node.keys):  # non-constant / **spread keys present
+                continue
+            ks = set(keys)
+            if {"status", "content"} <= ks:
+                extra = ks - set(VALID_TOP_LEVEL_KEYS)
+                if extra:
+                    rel = path.relative_to(_PKG_ROOT.parent)
+                    violations.append(f"{rel}:{node.lineno} extra_keys={sorted(extra)}")
+    return violations
+
+
+def test_no_extra_top_level_keys():
+    """No tool-result-shaped return in the package may carry extra top-level keys."""
+    violations = _tool_result_violations()
+    assert not violations, "Tool-result contract violations found:\n" + "\n".join(violations)
+
+
+# ---------------------------------------------------------------------------
+# Representative call site 1: TeleopMixin._teleop_stats (success/degraded/error)
+# ---------------------------------------------------------------------------
+
+
+class _FakeHost(TeleopMixin):
+    def __init__(self):
+        self.tool_name_str = "ct_host"
+        self.mesh = None
+        self.peer_id = None
+        self._send_lock = threading.Lock()
+
+    def send_action(self, action, robot_name=None, n_substeps=1):  # noqa: ARG002
+        return {"status": "success", "content": [{"text": "ok"}]}
+
+
+@pytest.mark.parametrize(
+    ("frames", "errors", "expected"),
+    [
+        (100, 0, "success"),  # clean run
+        (100, 5, "degraded"),  # some per-frame errors, mostly fine
+        (0, 0, "success"),  # no frames, no errors (idle stop)
+        (10, 10, "error"),  # every frame errored
+        (0, 3, "error"),  # no good frames at all
+    ],
+)
+def test_teleop_stats_contract_and_status(frames, errors, expected):
+    host = _FakeHost()
+    host._ensure_teleop_state()
+    host._teleop_frames = frames
+    host._teleop_errors = errors
+    host._teleop_start_time = 1.0  # non-zero so elapsed/hz compute
+
+    result = host._teleop_stats(blocking=True)
+    assert_strands_tool_result(result)
+    assert result["status"] == expected
+
+    # Telemetry must live in the json content block, not at the top level.
+    json_blocks = [b["json"] for b in result["content"] if "json" in b]
+    assert len(json_blocks) == 1
+    telemetry = json_blocks[0]
+    assert telemetry["frames"] == frames
+    assert telemetry["errors"] == errors
+    assert "hz_actual" in telemetry
+    assert telemetry["status"] == expected
+
+
+def test_teleop_status_and_list_contract():
+    host = _FakeHost()
+    host._ensure_teleop_state()
+    assert_strands_tool_result(host.get_teleoperate_status())
+    assert_strands_tool_result(host.list_teleops())
+
+
+# ---------------------------------------------------------------------------
+# Representative call sites 2 & 3: Simulation.run_policy + action dispatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sim():
+    pytest.importorskip("mujoco")
+    from strands_robots.simulation.mujoco.simulation import Simulation
+
+    s = Simulation(tool_name="contract_sim", mesh=False)
+    s.create_world()
+    yield s
+    s.cleanup()
+
+
+def test_run_policy_result_contract(sim):
+    result = sim.run_policy(policy_provider="mock", n_steps=2)
+    assert_strands_tool_result(result)
+
+
+def test_dispatch_action_results_contract(sim):
+    for action, params in [
+        ("list_robots", {}),
+        ("reset", {}),
+        ("step", {"n_steps": 1}),
+        ("get_gravity", {}),
+    ]:
+        assert_strands_tool_result(sim._dispatch_action(action, params))

--- a/tests/tool_result_contract.py
+++ b/tests/tool_result_contract.py
@@ -1,0 +1,87 @@
+"""Strands tool-result contract helper and enforcement primitives.
+
+A Strands tool result is a dict with exactly two author-controlled top-level
+keys, ``status`` and ``content`` (the runtime may additionally inject
+``toolUseId``). Structured telemetry belongs inside ``content`` as a
+``{"json": {...}}`` block alongside the human-readable ``{"text": ...}``
+block -- never as extra top-level keys. Extra top-level keys are silently
+dropped by the agent runtime and never surface in ``agent.messages``, so any
+data placed there is invisible to the agent and to downstream consumers
+(mesh, dashboards, evals).
+
+See ``docs/contracts.md`` for the canonical shape and rationale.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# ``toolUseId`` is injected by the Strands runtime when a method result is
+# wrapped into a ToolResultEvent; it is a legitimate top-level key.
+VALID_TOP_LEVEL_KEYS = frozenset({"status", "content", "toolUseId"})
+
+# Author-selectable statuses. ``degraded`` reports partial success (e.g. a
+# teleop loop that ran but logged some per-frame errors).
+VALID_STATUSES = frozenset({"success", "error", "degraded"})
+
+# The value-bearing content-block variants this contract recognises.
+VALID_CONTENT_KEYS = frozenset({"text", "json", "image"})
+
+
+def assert_strands_tool_result(result: Any) -> None:
+    """Assert ``result`` conforms to the Strands tool-result contract.
+
+    Enforces:
+      * ``result`` is a dict whose keys are a subset of
+        ``{"status", "content", "toolUseId"}`` (no other top-level extras).
+      * ``status`` is present and one of ``{"success", "error", "degraded"}``.
+      * ``content`` is a non-empty list of dicts, each carrying exactly one of
+        ``{"text", "json", "image"}``.
+
+    Args:
+        result: The value returned by a tool method / ``@tool`` function.
+
+    Raises:
+        AssertionError: If any part of the contract is violated, with a message
+            naming the offending keys so the fix is obvious.
+    """
+    assert isinstance(result, dict), f"tool result must be a dict, got {type(result).__name__}"
+
+    extra = set(result) - VALID_TOP_LEVEL_KEYS
+    assert not extra, (
+        f"tool result has extra top-level keys {sorted(extra)}; move telemetry "
+        f'into content as a {{"json": {{...}}}} block'
+    )
+
+    assert "status" in result, "tool result missing 'status'"
+    assert result["status"] in VALID_STATUSES, f"status {result['status']!r} not in {sorted(VALID_STATUSES)}"
+
+    assert "content" in result, "tool result missing 'content'"
+    content = result["content"]
+    assert isinstance(content, list) and content, "content must be a non-empty list"
+    for i, block in enumerate(content):
+        assert isinstance(block, dict), f"content[{i}] must be a dict, got {type(block).__name__}"
+        present = set(block) & VALID_CONTENT_KEYS
+        assert len(present) == 1, (
+            f"content[{i}] must carry exactly one of {sorted(VALID_CONTENT_KEYS)}, got keys {sorted(block)}"
+        )
+
+
+def tool_json(result: Any) -> dict[str, Any]:
+    """Merge every ``{"json": {...}}`` content block of a tool result into one dict.
+
+    Telemetry that used to live as extra top-level keys now lives inside
+    ``content`` json blocks. Tests read it back through this helper so they
+    assert on the agent-visible payload rather than on dropped top-level keys.
+
+    Args:
+        result: A Strands tool result dict.
+
+    Returns:
+        The union of all json content blocks (later blocks win on key clash).
+    """
+    merged: dict[str, Any] = {}
+    for block in result.get("content", []):
+        if isinstance(block, dict) and isinstance(block.get("json"), dict):
+            merged.update(block["json"])
+    return merged

--- a/tests/tools/test_lerobot_calibrate.py
+++ b/tests/tools/test_lerobot_calibrate.py
@@ -22,6 +22,7 @@ from strands_robots.tools.lerobot_calibrate import (
     LeRobotCalibrationManager,
     lerobot_calibrate,
 )
+from tests.tool_result_contract import tool_json
 
 
 def _motor(idx: int) -> dict[str, int]:
@@ -195,21 +196,21 @@ def test_list_empty_tree_reports_zero(tmp_path: Path) -> None:
     """``list`` on an empty tree succeeds with count 0."""
     result = lerobot_calibrate(action="list", base_path=str(tmp_path))
     assert result["status"] == "success"
-    assert result["count"] == 0
+    assert tool_json(result)["count"] == 0
 
 
 def test_list_populated_counts_all(populated: Path) -> None:
     """``list`` enumerates every calibration across both device types."""
     result = lerobot_calibrate(action="list", base_path=str(populated))
     assert result["status"] == "success"
-    assert result["count"] == 3
+    assert tool_json(result)["count"] == 3
     assert "so101_follower" in result["content"][0]["text"]
 
 
 def test_list_filtered_by_device_type(populated: Path) -> None:
     """``list`` with device_type='robots' counts only robot calibrations."""
     result = lerobot_calibrate(action="list", device_type="robots", base_path=str(populated))
-    assert result["count"] == 2
+    assert tool_json(result)["count"] == 2
 
 
 def test_view_returns_motor_details(populated: Path) -> None:
@@ -222,7 +223,7 @@ def test_view_returns_motor_details(populated: Path) -> None:
         base_path=str(populated),
     )
     assert result["status"] == "success"
-    assert result["calibration_info"]["motor_count"] == 6
+    assert tool_json(result)["calibration_info"]["motor_count"] == 6
     assert "shoulder" in result["content"][0]["text"]
 
 
@@ -249,31 +250,31 @@ def test_search_action_returns_matches(populated: Path) -> None:
     """``search`` returns the matching calibration records."""
     result = lerobot_calibrate(action="search", query="green", base_path=str(populated))
     assert result["status"] == "success"
-    assert result["count"] == 1
-    assert result["results"][0]["device_id"] == "green_arm"
+    assert tool_json(result)["count"] == 1
+    assert tool_json(result)["results"][0]["device_id"] == "green_arm"
 
 
 def test_search_no_match_reports_zero(populated: Path) -> None:
     """``search`` with no hits succeeds with an empty result set."""
     result = lerobot_calibrate(action="search", query="zzz", base_path=str(populated))
     assert result["status"] == "success"
-    assert result["count"] == 0
+    assert tool_json(result)["count"] == 0
 
 
 def test_backup_action_reports_file_count(populated: Path, tmp_path: Path) -> None:
     """``backup`` copies all calibrations and reports the count."""
     result = lerobot_calibrate(action="backup", output_dir=str(tmp_path / "out"), base_path=str(populated))
     assert result["status"] == "success"
-    assert result["files_count"] == 3
+    assert tool_json(result)["files_count"] == 3
 
 
 def test_restore_action_round_trips(populated: Path, tmp_path: Path) -> None:
     """``restore`` rebuilds calibrations from a prior ``backup``."""
     backup = lerobot_calibrate(action="backup", output_dir=str(tmp_path / "out"), base_path=str(populated))
     dest = tmp_path / "dest"
-    result = lerobot_calibrate(action="restore", backup_dir=backup["backup_path"], base_path=str(dest))
+    result = lerobot_calibrate(action="restore", backup_dir=tool_json(backup)["backup_path"], base_path=str(dest))
     assert result["status"] == "success"
-    assert result["restored_count"] == 3
+    assert tool_json(result)["restored_count"] == 3
 
 
 def test_restore_action_requires_backup_dir(tmp_path: Path) -> None:
@@ -318,7 +319,7 @@ def test_analyze_action_summarizes_statistics(populated: Path) -> None:
     """``analyze`` aggregates counts and per-model motor statistics."""
     result = lerobot_calibrate(action="analyze", base_path=str(populated))
     assert result["status"] == "success"
-    analysis: dict[str, Any] = result["analysis"]
+    analysis: dict[str, Any] = tool_json(result)["analysis"]
     assert analysis["total_calibrations"] == 3
     assert analysis["device_counts"] == {"teleoperators": 1, "robots": 2}
     assert analysis["motor_stats"]["robots/so101_follower"]["max"] == 6
@@ -328,7 +329,7 @@ def test_analyze_empty_tree(tmp_path: Path) -> None:
     """``analyze`` on an empty tree succeeds with an empty analysis."""
     result = lerobot_calibrate(action="analyze", base_path=str(tmp_path))
     assert result["status"] == "success"
-    assert result["analysis"] == {}
+    assert tool_json(result)["analysis"] == {}
 
 
 def test_path_action_specific_calibration(populated: Path) -> None:
@@ -341,16 +342,16 @@ def test_path_action_specific_calibration(populated: Path) -> None:
         base_path=str(populated),
     )
     assert result["status"] == "success"
-    assert result["exists"] is True
-    assert result["path"].endswith("orange_arm.json")
+    assert tool_json(result)["exists"] is True
+    assert tool_json(result)["path"].endswith("orange_arm.json")
 
 
 def test_path_action_base_paths(tmp_path: Path) -> None:
     """``path`` without an identifier reports the base/teleop/robot paths."""
     result = lerobot_calibrate(action="path", base_path=str(tmp_path))
     assert result["status"] == "success"
-    assert result["teleop_path"].endswith("teleoperators")
-    assert result["robot_path"].endswith("robots")
+    assert tool_json(result)["teleop_path"].endswith("teleoperators")
+    assert tool_json(result)["robot_path"].endswith("robots")
 
 
 def test_unknown_action_errors(tmp_path: Path) -> None:
@@ -508,7 +509,7 @@ def test_list_filters_out_nonmatching_model(populated: Path) -> None:
     # so101_follower has two calibrations; the teleoperator model must be hidden.
     assert "so101_follower" in text
     assert "so101_leader" not in text
-    assert result["count"] == 2
+    assert tool_json(result)["count"] == 2
 
 
 def test_list_marks_unreadable_calibration_without_failing(populated: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/tools/test_lerobot_teleoperate.py
+++ b/tests/tools/test_lerobot_teleoperate.py
@@ -20,6 +20,7 @@ from typing import Any
 import pytest
 
 import strands_robots.tools.lerobot_teleoperate as tele_mod
+from tests.tool_result_contract import tool_json
 
 # Bind the public names off the single module handle rather than a second
 # ``from ... import`` of the same module (CodeQL: import + import-from of one
@@ -336,11 +337,11 @@ def test_start_background_session_is_ascii_and_persisted(monkeypatch: pytest.Mon
         auto_accept_calibration=False,
     )
     assert result["status"] == "success"
-    assert result["pid"] == os.getpid()
+    assert tool_json(result)["pid"] == os.getpid()
     _assert_ascii(_texts(result))
     # Session was persisted and is discoverable.
     listed = lerobot_teleoperate(action="list")
-    assert "teleop_test" in listed["sessions"]
+    assert "teleop_test" in tool_json(listed)["sessions"]
 
 
 def test_start_rejects_duplicate_session(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -354,7 +355,7 @@ def test_start_rejects_duplicate_session(monkeypatch: pytest.MonkeyPatch) -> Non
 def test_list_empty_is_ascii() -> None:
     result = lerobot_teleoperate(action="list")
     assert result["status"] == "success"
-    assert result["count"] == 0
+    assert tool_json(result)["count"] == 0
     _assert_ascii(_texts(result))
 
 
@@ -402,7 +403,7 @@ def test_replay_runs_command_and_is_ascii(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setattr(tele_mod.subprocess, "run", lambda *a, **k: _FakeProc(returncode=0, stdout="done", stderr=""))
     result = lerobot_teleoperate(action="replay", dataset_repo_id="user/cubes", replay_episode=2)
     assert result["status"] == "success"
-    assert result["return_code"] == 0
+    assert tool_json(result)["return_code"] == 0
     _assert_ascii(_texts(result))
 
 
@@ -422,7 +423,7 @@ def test_start_foreground_runs_and_is_ascii(monkeypatch: pytest.MonkeyPatch) -> 
         background=False,
     )
     assert result["status"] == "success"
-    assert result["return_code"] == 0
+    assert tool_json(result)["return_code"] == 0
     _assert_ascii(_texts(result))
 
 
@@ -433,7 +434,7 @@ def test_list_with_active_session_is_ascii(monkeypatch: pytest.MonkeyPatch) -> N
     )
     result = lerobot_teleoperate(action="list")
     assert result["status"] == "success"
-    assert result["count"] == 1
+    assert tool_json(result)["count"] == 1
     body = _texts(result)
     assert "live" in body
     assert "Running" in body
@@ -491,7 +492,7 @@ def test_start_auto_accept_calibration_sends_enter_keys(monkeypatch: pytest.Monk
     )
 
     assert result["status"] == "success"
-    assert result["background"] is True
+    assert tool_json(result)["background"] is True
     # Two ENTER presses were sent and stdin was closed afterwards.
     assert stdin.writes == ["\n", "\n"]
     assert stdin.closed
@@ -591,7 +592,7 @@ def test_replay_nonzero_return_code_is_error(monkeypatch: pytest.MonkeyPatch) ->
     monkeypatch.setattr(tele_mod.subprocess, "run", lambda *a, **k: _FakeProc(returncode=1, stdout="", stderr="boom"))
     result = lerobot_teleoperate(action="replay", dataset_repo_id="user/cubes", replay_episode=0)
     assert result["status"] == "error"
-    assert result["return_code"] == 1
+    assert tool_json(result)["return_code"] == 1
     _assert_ascii(_texts(result))
 
 
@@ -605,7 +606,7 @@ def test_start_foreground_nonzero_return_code_is_error(monkeypatch: pytest.Monke
         background=False,
     )
     assert result["status"] == "error"
-    assert result["return_code"] == 2
+    assert tool_json(result)["return_code"] == 2
     _assert_ascii(_texts(result))
 
 
@@ -738,4 +739,4 @@ def test_dagger_dispatch_starts_session(monkeypatch: pytest.MonkeyPatch) -> None
     assert result["status"] == "success"
     _assert_ascii(_texts(result))
     listed = lerobot_teleoperate(action="list")
-    assert "dagger_test" in listed["sessions"]
+    assert "dagger_test" in tool_json(listed)["sessions"]

--- a/tests/tools/test_lerobot_train.py
+++ b/tests/tools/test_lerobot_train.py
@@ -29,6 +29,7 @@ from typing import Any
 import pytest
 
 import strands_robots.tools.lerobot_train as train_mod
+from tests.tool_result_contract import tool_json
 
 build_train_command = train_mod.build_train_command
 lerobot_train = train_mod.lerobot_train
@@ -287,13 +288,13 @@ def test_session_lifecycle_round_trips(tmp_path: Path, monkeypatch: pytest.Monke
         session_name="t1",
     )
     assert start["status"] == "success"
-    assert start["session_name"] == "t1"
-    assert start["pid"] == 9999
+    assert tool_json(start)["session_name"] == "t1"
+    assert tool_json(start)["pid"] == 9999
     _assert_ascii(_texts(start))
 
     listed = lerobot_train(action="list", dataset_root=str(root))
     assert listed["status"] == "success"
-    assert "t1" in listed["sessions"]
+    assert "t1" in tool_json(listed)["sessions"]
     _assert_ascii(_texts(listed))
 
     status = lerobot_train(action="status", dataset_root=str(root), session_name="t1")
@@ -500,7 +501,7 @@ def test_status_reports_log_tail(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 def test_list_reports_no_active_sessions_when_empty(tmp_path: Path) -> None:
     result = lerobot_train(action="list", dataset_root="/x")
     assert result["status"] == "success"
-    assert result["count"] == 0
+    assert tool_json(result)["count"] == 0
     assert "No active sessions" in _texts(result)
 
 
@@ -543,7 +544,7 @@ def test_start_autogenerates_session_name_and_clears_stale_empty_output(
     monkeypatch.setattr(train_mod.shutil, "rmtree", _spy_rmtree)
     result = lerobot_train(action="start", dataset_root=str(root), policy_type="act", output_dir=str(out))
     assert result["status"] == "success"
-    assert result["session_name"].startswith("train_")
+    assert tool_json(result)["session_name"].startswith("train_")
     assert str(out) in rmtree_calls
 
 

--- a/tests/tools/test_pose_tool.py
+++ b/tests/tools/test_pose_tool.py
@@ -31,6 +31,7 @@ from strands_robots.tools.pose_tool import (
     RobotPose,
     pose_tool,
 )
+from tests.tool_result_contract import tool_json
 
 
 def _texts(result: dict[str, Any]) -> str:
@@ -251,7 +252,7 @@ def test_read_motor_position_decodes_response(fake_serial) -> None:
 def test_pose_tool_list_empty_is_ascii(cwd_tmp) -> None:
     result = pose_tool(action="list_poses", robot_id="empty_arm")
     assert result["status"] == "success"
-    assert result["poses"] == []
+    assert tool_json(result)["poses"] == []
     _assert_ascii(result)
 
 
@@ -259,12 +260,12 @@ def test_pose_tool_show_and_list_after_store(cwd_tmp) -> None:
     PoseManager("disp_arm").store_pose("ready", {"gripper": 40.0, "wrist_flex": 5.0}, description="staged")
     listed = pose_tool(action="list_poses", robot_id="disp_arm")
     assert listed["status"] == "success"
-    assert any(p["name"] == "ready" for p in listed["poses"])
+    assert any(p["name"] == "ready" for p in tool_json(listed)["poses"])
     _assert_ascii(listed)
 
     shown = pose_tool(action="show_pose", robot_id="disp_arm", pose_name="ready")
     assert shown["status"] == "success"
-    assert shown["pose"]["description"] == "staged"
+    assert tool_json(shown)["pose"]["description"] == "staged"
     _assert_ascii(shown)
 
 
@@ -344,7 +345,7 @@ def test_pose_tool_reset_to_home_is_ascii(cwd_tmp, fake_serial) -> None:
     result = pose_tool(action="reset_to_home", robot_id="hw_arm", port="/dev/ttyTEST")
     assert result["status"] == "success"
     _assert_ascii(result)
-    assert "home_positions" in result
+    assert "home_positions" in tool_json(result)
 
 
 def test_module_source_is_ascii() -> None:
@@ -399,7 +400,7 @@ def test_pose_tool_read_position_decodes_and_returns_degrees(cwd_tmp, reading_se
     result = pose_tool(action="read_position", robot_id="hw_arm", port="/dev/ttyTEST", motor_name="shoulder_pan")
     assert result["status"] == "success"
     _assert_ascii(result)
-    assert result["position"] == pytest.approx(0.0, abs=1.0)
+    assert tool_json(result)["position"] == pytest.approx(0.0, abs=1.0)
 
 
 def test_pose_tool_read_position_reports_failure_without_response(cwd_tmp, fake_serial) -> None:
@@ -416,7 +417,7 @@ def test_pose_tool_read_all_formats_every_motor(cwd_tmp, reading_serial) -> None
     assert result["status"] == "success"
     _assert_ascii(result)
     # All six SO-101 motors should be present in the positions payload.
-    assert set(result["positions"]) == {
+    assert set(tool_json(result)["positions"]) == {
         "shoulder_pan",
         "shoulder_lift",
         "elbow_flex",
@@ -473,7 +474,7 @@ def test_pose_tool_load_pose_moves_to_stored_positions(cwd_tmp, fake_serial) -> 
     )
     assert result["status"] == "success"
     _assert_ascii(result)
-    assert result["target_positions"] == {"shoulder_pan": 10.0, "gripper": 50.0}
+    assert tool_json(result)["target_positions"] == {"shoulder_pan": 10.0, "gripper": 50.0}
     assert fake_serial[0].writes
 
 
@@ -747,7 +748,7 @@ def test_pose_tool_list_poses_skips_pose_removed_mid_listing(cwd_tmp, monkeypatc
     result = pose_tool(action="list_poses", robot_id="race_arm")
     assert result["status"] == "success"
     _assert_ascii(result)
-    names = [p["name"] for p in result.get("poses", [])]
+    names = [p["name"] for p in tool_json(result).get("poses", [])]
     assert "keep" in names
     assert "gone" not in names
 

--- a/tests/tools/test_serial_tool.py
+++ b/tests/tools/test_serial_tool.py
@@ -16,6 +16,7 @@ import pytest
 import serial
 
 from strands_robots.tools.serial_tool import serial_tool
+from tests.tool_result_contract import tool_json
 
 
 def _texts(result: dict[str, Any]) -> str:
@@ -85,7 +86,7 @@ def test_list_ports_formats_discovered_ports(monkeypatch):
     result = serial_tool(action="list_ports")
 
     assert result["status"] == "success"
-    assert result["ports"][0]["device"] == "/dev/ttyACM0"
+    assert tool_json(result)["ports"][0]["device"] == "/dev/ttyACM0"
     text = _texts(result)
     assert "Found 1 serial ports" in text
     assert "/dev/ttyACM0" in text
@@ -126,8 +127,8 @@ def test_read_formats_hex_and_ascii(fake_serial_factory):
     created = fake_serial_factory(reads=[b"AB\x01"])
     result = serial_tool(action="read", port="/dev/ttyACM0", read_bytes=8)
     assert result["status"] == "success"
-    assert result["length"] == 3
-    assert result["raw_data"] == b"AB\x01".hex()
+    assert tool_json(result)["length"] == 3
+    assert tool_json(result)["raw_data"] == b"AB\x01".hex()
     text = _texts(result)
     assert "41 42 01" in text
     assert "AB\\x01" in text
@@ -233,8 +234,8 @@ def test_monitor_collects_chunks(fake_serial_factory, monkeypatch):
     created = fake_serial_factory(reads=[b"hi"], in_waiting=2)
     result = serial_tool(action="monitor", port="/dev/ttyACM0")
     assert result["status"] == "success"
-    assert len(result["monitor_data"]) == 1
-    assert result["monitor_data"][0]["data"] == b"hi".hex()
+    assert len(tool_json(result)["monitor_data"]) == 1
+    assert tool_json(result)["monitor_data"][0]["data"] == b"hi".hex()
     assert _texts(result).isascii()
     assert created[0].closed
 


### PR DESCRIPTION
## Problem

Strands tool results must expose exactly `{"status", "content"}` at the top level (the runtime may additionally inject `toolUseId`). The agent runtime serializes only `status` and `content` into the LLM turn, so any other top-level key is silently dropped before it reaches `agent.messages`. Numeric telemetry placed there is invisible both to the agent (it can't reason about e.g. teleop health) and to structured consumers (mesh, dashboards, evals).

`teleop_mixin.py::_teleop_stats` returned `frames`/`errors`/`hz_actual` as top-level keys. A repo-wide sweep found the same drift in several other tool-result returns.

## Change

Move all structured telemetry into a `{"json": {...}}` content block alongside the human-readable `{"text": ...}` block, matching the canonical implementation in `strands_robots/tools/run_policy.py` (`content: [{"text": summary_line}, {"json": payload}]`).

Sites fixed (across 8 modules):
- `teleop_mixin.py` (`list_teleops`, `teleoperate`, `get_teleoperate_status`, `_teleop_stats`)
- `hardware_robot.py::get_teleop_status`
- `simulation/mujoco/simulation.py::run_multi_policy`
- `tools/pose_tool.py`, `tools/serial_tool.py`, `tools/lerobot_calibrate.py`, `tools/lerobot_train.py`, `tools/lerobot_teleoperate.py`

No production consumer read these extras (they were being dropped); only unit tests read them directly, and those now read them back through a `tool_json()` helper.

## Tests

- `tests/tool_result_contract.py`: `assert_strands_tool_result(result)` (subset-of-`{status, content, toolUseId}`, valid status, content blocks each carrying exactly one of `{text, json, image}`) plus a `tool_json()` reader helper.
- `tests/test_tool_result_contract.py`: a repo-wide static audit that walks every tool-result-shaped dict literal in the package and fails if any regains an extra top-level key (fails on pre-fix `main` naming the exact offending sites, passes after), plus live-result checks applied to `_teleop_stats` (all three statuses), `Simulation.run_policy`, and action dispatch.

Local gate green: `ruff check` / `ruff format --check` clean, `mypy strands_robots tests tests_integ` reports no issues, and the affected suites pass (`test_teleop`, tools, hardware lifecycle, `run_multi_policy`, docs nav, contract).

## Docs

New `docs/contracts.md` ("Tool result contract") documenting the canonical shape with the `run_policy` example and the right/wrong telemetry patterns; wired into the mkdocs nav.

Rebased on current `main`: the honest-status derivation for `_teleop_stats` (deriving `success`/`degraded`/`error` from frame/error counters) landed separately in #979, so this PR is now scoped to the tool-result-contract move only. Follow-up to #979.

---

### Round 2 changelog

- Rebased onto current `main` to clear the merge conflict in `teleop_mixin.py::_teleop_stats`. The conflict was the expected overlap with #979 (honest-status derivation), which merged after this branch was cut. Resolution keeps #979's counter-based `success`/`degraded`/`error` derivation (and its explanatory comment) and layers this PR's telemetry-into-`{"json": ...}` move on top; the two changes are orthogonal within that function.
- The post-rebase tree is byte-identical to the previously-approved diff (no content change beyond the mechanical rebase), so this is a re-approval rather than a re-review. The rebase force-push auto-dismissed the prior approval.
- Verified post-rebase: `ruff check` clean; `test_teleop` and `test_tool_result_contract` green (44 passed / 2 skipped locally); clean merge-tree against `main`.