### PR TITLE
feat(sim): implement set_obs_noise on the MuJoCo backend (sensor-noise parity with Newton)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,24 @@ dimensions.
 free/model-only cameras -> engine default. RGB and depth for the same camera
 are now pixel-aligned.
 
+### Added: `set_obs_noise` on the MuJoCo backend (sensor-noise parity with Newton)
+
+`set_obs_noise` is a declared `SimEngine` method for additive sensor
+measurement noise (a sim-to-real robustness lever), and the Newton backend
+implemented it, but the default MuJoCo backend inherited the base
+`NotImplementedError`. Robustness code that ran on Newton crashed on MuJoCo -
+the reference backend - and the two engines diverged on a shared contract.
+
+The MuJoCo backend now implements `set_obs_noise(joint_pos_std, joint_vel_std,
+camera_jitter_px, seed)` with the same semantics as Newton: joint-position and
+per-joint-velocity Gaussian noise applied on `get_observation` (positions, the
+`<joint>.vel` entries, and camera frames) and `get_robot_state`, plus integer
+pixel jitter on rendered frames. Values must be finite and non-negative
+(`status=error` otherwise). The noise stream is seedable/reproducible, and the
+default (never-configured) path is an exact no-op, so unconfigured observations
+and renders are byte-for-byte unchanged. `describe()` now advertises the method.
+
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/docs/simulation/domain-randomization.md
+++ b/docs/simulation/domain-randomization.md
@@ -44,11 +44,37 @@ for episode in range(N):
                              success_fn=my_fn)
 ```
 
+## Sensor noise
+
+`set_obs_noise` adds Gaussian measurement noise to observations so a policy is
+not trained (or evaluated) on noise-free sensing - a cheap sim-to-real
+robustness lever that is orthogonal to `randomize()` (which perturbs the world;
+this perturbs the *sensor*).
+
+```python
+sim.set_obs_noise(
+    joint_pos_std=0.01,      # rad, added to joint positions
+    joint_vel_std=0.05,      # rad/s, added to per-joint velocities
+    camera_jitter_px=2,      # max integer pixel shift per axis on rendered frames
+    seed=0,                  # reproducible noise stream
+)
+```
+
+Once configured, the noise is applied on every `get_observation`
+(joint positions, the `<joint>.vel` entries, and camera frames),
+`get_robot_state` (position + velocity), and `render` until reconfigured. Pass
+all-zero std to disable; leaving it unconfigured (the default) is an exact
+no-op, so existing observations and renders are unchanged. Floating-base
+`base_quat` / `base_ang_vel` signals are left untouched (a quaternion would need
+renormalization). Values must be finite and non-negative or the call returns
+`status=error`.
+
 ## Newton backend
 
-The Newton (GPU) backend mirrors this `randomize` contract for the axes it
-supports (colors, lighting, physics) and adds `set_obs_noise` for additive
-sensor noise. See [Newton backend](newton.md#domain-randomization-and-sensor-noise).
+The Newton (GPU) backend mirrors both the `randomize` contract for the axes it
+supports (colors, lighting, physics) and the `set_obs_noise` sensor-noise
+contract, so an identical call behaves the same on either backend. See
+[Newton backend](newton.md#domain-randomization-and-sensor-noise).
 
 ## See also
 

--- a/strands_robots/simulation/mujoco/randomization.py
+++ b/strands_robots/simulation/mujoco/randomization.py
@@ -31,6 +31,8 @@ class RandomizationMixin:
 
         _lock: "threading.RLock"
         _world: "SimWorld | None"
+        _obs_noise: "dict[str, float] | None"
+        _obs_noise_rng: "np.random.Generator | None"
 
         def _require_no_running_policy(
             self, action_name: str, robot_name: str | None = None
@@ -179,3 +181,151 @@ class RandomizationMixin:
             "status": "success",
             "content": [{"text": "Domain Randomization applied:\n" + "\n".join(changes)}],
         }
+
+    def set_obs_noise(
+        self,
+        joint_pos_std: float = 0.0,
+        joint_vel_std: float = 0.0,
+        camera_jitter_px: float = 0.0,
+        seed: int | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Configure additive Gaussian sensor noise on observations.
+
+        Models real-encoder / real-camera measurement noise so policies trained
+        on MuJoCo data do not assume noise-free sensing. Once set, the noise is
+        applied on every :meth:`get_observation` / :meth:`get_robot_state` and
+        every rendered camera frame (:meth:`render` and the camera frames in
+        ``get_observation``) until reconfigured. Pass all-zero std to disable -
+        with every std zero the noise path is an exact no-op, so leaving this
+        unconfigured (the default) leaves every observation and render
+        byte-for-byte unchanged. Mirrors :meth:`NewtonSimEngine.set_obs_noise`
+        so an identical call behaves the same on both backends.
+
+        Args:
+            joint_pos_std: Std (radians) of Gaussian noise added to joint
+                positions in ``get_observation`` and ``get_robot_state``.
+            joint_vel_std: Std (rad/s) of Gaussian noise added to per-joint
+                velocities - the ``<joint>.vel`` entries in ``get_observation``
+                and the ``velocity`` field in ``get_robot_state``.
+            camera_jitter_px: Max integer pixel shift applied to rendered
+                frames (uniform in ``[-px, px]`` per axis).
+            seed: Optional seed for a reproducible noise stream.
+            **kwargs: Accepted for ``SimEngine.set_obs_noise`` signature
+                compatibility; ignored by the MuJoCo backend.
+
+        Returns:
+            Status dict echoing the configured noise, or an error dict when any
+            value is negative or non-finite.
+        """
+        for label, value in (
+            ("joint_pos_std", joint_pos_std),
+            ("joint_vel_std", joint_vel_std),
+            ("camera_jitter_px", camera_jitter_px),
+        ):
+            try:
+                fvalue = float(value)
+            except (TypeError, ValueError):
+                return {
+                    "status": "error",
+                    "content": [{"text": f"set_obs_noise: {label} must be a number, got {value!r}"}],
+                }
+            if not np.isfinite(fvalue) or fvalue < 0:
+                return {
+                    "status": "error",
+                    "content": [
+                        {"text": f"set_obs_noise: {label} must be a finite non-negative number, got {value!r}"}
+                    ],
+                }
+
+        with self._lock:
+            self._obs_noise = {
+                "joint_pos_std": float(joint_pos_std),
+                "joint_vel_std": float(joint_vel_std),
+                "camera_jitter_px": float(camera_jitter_px),
+            }
+            self._obs_noise_rng = np.random.default_rng(seed)
+        return {
+            "status": "success",
+            "content": [
+                {
+                    "text": (
+                        f"Sensor noise: joint_pos_std={joint_pos_std}, "
+                        f"joint_vel_std={joint_vel_std}, camera_jitter_px={camera_jitter_px}"
+                    )
+                }
+            ],
+        }
+
+    def _apply_obs_noise(self, obs: dict[str, Any]) -> dict[str, Any]:
+        """Return ``obs`` with configured sensor noise applied.
+
+        ``get_observation`` returns a heterogeneous dict: scalar joint positions
+        keyed by joint name, scalar per-joint velocities keyed ``<joint>.vel``,
+        camera frames as ``(H, W, 3)`` uint8 arrays, and (for floating-base
+        robots) ``base_quat`` / ``base_ang_vel`` list values. Position noise
+        (``joint_pos_std``) applies to the position scalars, velocity noise
+        (``joint_vel_std``) to the ``.vel`` scalars, and camera jitter
+        (``camera_jitter_px``) to the image arrays. The floating-base list
+        signals are left untouched (a quaternion would need renormalization;
+        out of scope for additive scalar noise). A no-op returning the input
+        unchanged when no noise is configured.
+        """
+        cfg = self._obs_noise or {}
+        rng = self._obs_noise_rng
+        if rng is None or not cfg:
+            return obs
+        pos_std = cfg.get("joint_pos_std", 0.0)
+        vel_std = cfg.get("joint_vel_std", 0.0)
+        px = cfg.get("camera_jitter_px", 0.0)
+        if pos_std <= 0 and vel_std <= 0 and px <= 0:
+            return obs
+        out: dict[str, Any] = {}
+        for key, value in obs.items():
+            if isinstance(value, np.ndarray):
+                out[key] = self._maybe_jitter_frame(value) if px > 0 else value
+            elif isinstance(value, float):
+                if key.endswith(".vel"):
+                    out[key] = value + (float(rng.normal(0.0, vel_std)) if vel_std > 0 else 0.0)
+                else:
+                    out[key] = value + (float(rng.normal(0.0, pos_std)) if pos_std > 0 else 0.0)
+            else:
+                out[key] = value
+        return out
+
+    def _apply_state_noise(self, state: dict[str, dict[str, float]]) -> dict[str, dict[str, float]]:
+        """Return ``get_robot_state`` output with position + velocity noise.
+
+        Entries are ``{joint: {"position": p, "velocity": v}}``. Position noise
+        uses ``joint_pos_std`` and velocity noise uses ``joint_vel_std`` from
+        :meth:`set_obs_noise`. A no-op when neither std is positive.
+        """
+        cfg = self._obs_noise or {}
+        pos_std = cfg.get("joint_pos_std", 0.0)
+        vel_std = cfg.get("joint_vel_std", 0.0)
+        rng = self._obs_noise_rng
+        if rng is None or (pos_std <= 0 and vel_std <= 0) or not state:
+            return state
+        out: dict[str, dict[str, float]] = {}
+        for jname, vals in state.items():
+            pos = vals["position"] + (float(rng.normal(0.0, pos_std)) if pos_std > 0 else 0.0)
+            vel = vals["velocity"] + (float(rng.normal(0.0, vel_std)) if vel_std > 0 else 0.0)
+            out[jname] = {"position": pos, "velocity": vel}
+        return out
+
+    def _maybe_jitter_frame(self, frame: "np.ndarray") -> "np.ndarray":
+        """Return ``frame`` shifted by a random integer pixel offset.
+
+        Applies ``camera_jitter_px`` configured via :meth:`set_obs_noise` by
+        rolling the image along both axes. A no-op when jitter is disabled.
+        """
+        px = (self._obs_noise or {}).get("camera_jitter_px", 0.0)
+        rng = self._obs_noise_rng
+        if px <= 0 or rng is None or frame.ndim < 2:
+            return frame
+        max_shift = int(px)
+        if max_shift < 1:
+            return frame
+        dy = int(rng.integers(-max_shift, max_shift + 1))
+        dx = int(rng.integers(-max_shift, max_shift + 1))
+        return np.roll(frame, shift=(dy, dx), axis=(0, 1))

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -118,6 +118,10 @@ class RenderingMixin:
         default_height: int
         _lock: Any  # threading.RLock from Simulation
 
+        # Provided by RandomizationMixin (set_obs_noise); render() applies
+        # camera jitter through it. Stub so mypy accepts the cross-mixin call.
+        def _maybe_jitter_frame(self, frame: Any) -> Any: ...
+
     def _validate_render_dims(self, width: int, height: int) -> dict[str, Any] | None:
         """reject non-positive render dims; convert MuJoCo's framebuffer
         overflow to a plain-English message that tells the LLM the actual cap.
@@ -736,6 +740,8 @@ class RenderingMixin:
                 renderer.update_scene(self._world._data, scene_option=self._get_viz_option())
 
             img = renderer.render().copy()
+            # Additive camera jitter (set_obs_noise); no-op when disabled.
+            img = self._maybe_jitter_frame(img)
 
             from PIL import Image
 

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -210,6 +210,14 @@ class MuJoCoSimEngine(
         self.mesh: Any = mesh if mesh else None
         self.peer_id: str | None = peer_id
 
+        # Additive sensor-noise config + reproducible RNG (set_obs_noise).
+        # None until configured; the noise is then applied on every
+        # get_observation / get_robot_state and every rendered frame.
+        # Mirrors the Newton backend so a set_obs_noise(...) call behaves
+        # identically on both engines. Type-declared on RandomizationMixin.
+        self._obs_noise = None
+        self._obs_noise_rng = None
+
         self._world: SimWorld | None = None
         self._executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix=f"{tool_name}_sim")
         # Per-robot Future refs for *active* policies. Completed futures are
@@ -299,7 +307,10 @@ class MuJoCoSimEngine(
             # the policy's skip hint when an active recorder is attached.
             skip_images = False
         with self._lock:
-            return self._get_sim_observation(robot_name, skip_images=skip_images)
+            obs = self._get_sim_observation(robot_name, skip_images=skip_images)
+        # Additive sensor noise (set_obs_noise). Exact no-op / same dict when
+        # unconfigured, so the default path is byte-for-byte unchanged.
+        return self._apply_obs_noise(obs)
 
     def send_action(
         self,
@@ -1266,6 +1277,10 @@ class MuJoCoSimEngine(
             "(viewable grayscale depth PNG image block + metric depth_min/depth_max stats)"
         )
         base["methods"]["render_all"] = "(cameras=None, width=None, height=None) -> dict (one image block per camera)"
+        base["methods"]["set_obs_noise"] = (
+            "(joint_pos_std=0.0, joint_vel_std=0.0, camera_jitter_px=0.0, seed=None) -> dict "
+            "(additive Gaussian sensor noise on joint observations + rendered frames)"
+        )
         # Recording / dataset-collection surface (LeRobotDataset, [lerobot] extra).
         # Exposed here so agents discover the explicit episode-boundary workflow
         # (start_recording -> run_policy + save_episode per episode -> stop_recording)
@@ -1327,6 +1342,9 @@ class MuJoCoSimEngine(
                     "position": float(data.qpos[model.jnt_qposadr[jnt_id]]),
                     "velocity": float(data.qvel[model.jnt_dofadr[jnt_id]]),
                 }
+
+        # Additive sensor noise (set_obs_noise); no-op when unconfigured.
+        state = self._apply_state_noise(state)
 
         text = f"'{robot_name}' state (t={self._world.sim_time:.3f}s):\n"
         for jnt, vals in state.items():
@@ -1965,6 +1983,10 @@ class MuJoCoSimEngine(
         """
         if self._world is None:
             return {"status": "success", "content": [{"text": "No world to destroy."}]}
+        # Sensor-noise config is engine-level; clear it on destroy so a
+        # recreated world starts noise-free (parity with the Newton backend).
+        self._obs_noise = None
+        self._obs_noise_rng = None
         self.cleanup()
         return {"status": "success", "content": [{"text": "World destroyed."}]}
 

--- a/tests/simulation/mujoco/test_set_obs_noise.py
+++ b/tests/simulation/mujoco/test_set_obs_noise.py
@@ -1,0 +1,164 @@
+"""MuJoCo backend implements ``set_obs_noise`` (additive sensor-noise contract).
+
+``set_obs_noise`` is a declared ``SimEngine`` method - Newton implements it fully
+(joint-position/velocity noise on observations + camera-frame jitter), but the
+default MuJoCo backend historically inherited the base ``NotImplementedError``.
+That left sim-to-real robustness code that runs on Newton crashing on MuJoCo,
+the reference backend. These tests pin the MuJoCo implementation and its
+parity with Newton's contract:
+
+  * ``set_obs_noise(...)`` succeeds and is advertised in ``describe()``.
+  * joint-position and ``.vel`` noise perturb ``get_observation`` (pos + vel).
+  * position + velocity noise perturb ``get_robot_state``.
+  * a seed makes the noise stream reproducible.
+  * negative / non-finite / non-numeric values are rejected with ``status=error``.
+  * disabling (all-zero std) restores noise-free observations, and the default
+    (never-configured) path is an exact no-op.
+  * ``camera_jitter_px`` shifts rendered frames.
+
+Every test that calls ``set_obs_noise`` fails pre-fix with ``NotImplementedError``.
+"""
+
+from __future__ import annotations
+
+import io
+
+import numpy as np
+import pytest
+
+mj = pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.backend import _can_render  # noqa: E402
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+requires_gl = pytest.mark.skipif(
+    not _can_render(),
+    reason="No OpenGL context available (headless without EGL/OSMesa)",
+)
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="test_obs_noise", mesh=False)
+    assert s.create_world(gravity=[0, 0, -9.81])["status"] == "success"
+    assert s.add_robot("so101")["status"] == "success"
+    yield s
+    s.cleanup()
+
+
+def _pos_keys(obs: dict) -> list[str]:
+    return [k for k, v in obs.items() if isinstance(v, float) and not k.endswith(".vel")]
+
+
+def _vel_keys(obs: dict) -> list[str]:
+    return [k for k in obs if k.endswith(".vel")]
+
+
+def test_set_obs_noise_succeeds_and_is_discoverable(sim):
+    """The MuJoCo backend implements set_obs_noise (pre-fix: NotImplementedError)."""
+    result = sim.set_obs_noise(joint_pos_std=0.01)
+    assert result["status"] == "success", result
+    assert "set_obs_noise" in sim.describe()["methods"]
+
+
+def test_joint_position_and_velocity_noise_perturbs_observation(sim):
+    """joint_pos_std perturbs positions and joint_vel_std perturbs `.vel`."""
+    base = sim.get_observation(skip_images=True)
+    pos_keys, vel_keys = _pos_keys(base), _vel_keys(base)
+    assert pos_keys and vel_keys, "so101 should expose position + velocity keys"
+
+    assert sim.set_obs_noise(joint_pos_std=0.05, joint_vel_std=0.1, seed=0)["status"] == "success"
+    noisy = sim.get_observation(skip_images=True)
+
+    assert max(abs(noisy[k] - base[k]) for k in pos_keys) > 0, "position noise had no effect"
+    assert max(abs(noisy[k] - base[k]) for k in vel_keys) > 0, "velocity noise had no effect"
+
+
+def test_get_robot_state_is_noised(sim):
+    """set_obs_noise perturbs get_robot_state position + velocity fields."""
+    clean = sim.get_robot_state()["content"][1]["json"]["state"]
+    assert sim.set_obs_noise(joint_pos_std=0.05, joint_vel_std=0.1, seed=0)["status"] == "success"
+    noisy = sim.get_robot_state()["content"][1]["json"]["state"]
+
+    j = next(iter(clean))
+    assert abs(noisy[j]["position"] - clean[j]["position"]) > 0
+    assert abs(noisy[j]["velocity"] - clean[j]["velocity"]) > 0
+
+
+def test_seeded_noise_is_reproducible(sim):
+    """Re-seeding with the same seed reproduces the identical noise stream."""
+    keys = _pos_keys(sim.get_observation(skip_images=True))
+    sim.set_obs_noise(joint_pos_std=0.05, seed=42)
+    a = sim.get_observation(skip_images=True)
+    sim.set_obs_noise(joint_pos_std=0.05, seed=42)
+    b = sim.get_observation(skip_images=True)
+    assert all(abs(a[k] - b[k]) < 1e-12 for k in keys)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"joint_pos_std": -0.1},
+        {"joint_vel_std": -1.0},
+        {"camera_jitter_px": float("nan")},
+        {"joint_pos_std": float("inf")},
+        {"joint_pos_std": "fast"},
+    ],
+)
+def test_invalid_values_rejected(sim, kwargs):
+    """Negative / non-finite / non-numeric values return status=error."""
+    assert sim.set_obs_noise(**kwargs)["status"] == "error"
+
+
+def test_default_path_is_noise_free_and_disable_restores_it(sim):
+    """Unconfigured get_observation is an exact no-op; all-zero std disables noise."""
+    base = sim.get_observation(skip_images=True)
+    # never configured -> repeated observation is byte-identical
+    assert sim.get_observation(skip_images=True) == base
+
+    sim.set_obs_noise(joint_pos_std=0.05, seed=0)
+    assert sim.get_observation(skip_images=True) != base
+
+    sim.set_obs_noise(joint_pos_std=0.0, joint_vel_std=0.0, camera_jitter_px=0.0)
+    restored = sim.get_observation(skip_images=True)
+    pos_keys = _pos_keys(base)
+    assert max(abs(restored[k] - base[k]) for k in pos_keys) < 1e-9
+
+
+def test_maybe_jitter_frame_shifts_synthetic_frame(sim):
+    """The jitter helper rolls a non-uniform frame by an integer offset (no GL)."""
+    frame = np.arange(48 * 64 * 3, dtype=np.uint8).reshape(48, 64, 3)
+    # seed=0 draws a non-zero (dy, dx); (a zero draw is a legitimate but
+    # uninformative RNG outcome, so pin a seed that actually shifts).
+    sim.set_obs_noise(camera_jitter_px=8, seed=0)
+    jittered = sim._maybe_jitter_frame(frame)
+    assert jittered.shape == frame.shape
+    assert not np.array_equal(jittered, frame), "jitter helper did not shift the frame"
+
+    # disabled -> exact identity (same object returned)
+    sim.set_obs_noise(camera_jitter_px=0.0)
+    assert sim._maybe_jitter_frame(frame) is frame
+
+
+@requires_gl
+def test_camera_jitter_shifts_rendered_frame(sim):
+    """camera_jitter_px shifts the rendered frame vs the noise-free render."""
+    assert (
+        sim.add_camera(name="cam1", position=[0.5, 0.0, 0.3], target=[0.0, 0.0, 0.1], width=128, height=96)["status"]
+        == "success"
+    )
+
+    def _png(result: dict) -> np.ndarray:
+        assert result["status"] == "success", result
+        for block in result["content"]:
+            if "image" in block:
+                return np.array(Image.open(io.BytesIO(block["image"]["source"]["bytes"])))
+        raise AssertionError("no image block")
+
+    from PIL import Image
+
+    sim.set_obs_noise(camera_jitter_px=0.0)
+    clean = _png(sim.render(camera_name="cam1", width=128, height=96))
+    sim.set_obs_noise(camera_jitter_px=8, seed=0)
+    jittered = _png(sim.render(camera_name="cam1", width=128, height=96))
+    assert not np.array_equal(clean, jittered), "camera jitter had no effect on the render"


### PR DESCRIPTION
## Problem

`set_obs_noise` is a declared `SimEngine` method for additive sensor measurement noise (a sim-to-real robustness lever). The Newton backend implements it fully, but the default/reference **MuJoCo** backend inherited the base `NotImplementedError`:

```python
sim = Simulation()            # MuJoCo, the default backend
sim.create_world(); sim.add_robot("so101")
sim.set_obs_noise(joint_pos_std=0.01)
# -> NotImplementedError: set_obs_noise not implemented by this backend
```

The identical call works on Newton, so robustness code that ran on the GPU backend crashed on MuJoCo, and the two engines diverged on a shared contract.

## Change

Implement `set_obs_noise` in the MuJoCo `RandomizationMixin` with the same semantics and signature as the Newton backend:

- **`joint_pos_std`** (rad) - Gaussian noise on joint positions in `get_observation` and `get_robot_state`.
- **`joint_vel_std`** (rad/s) - Gaussian noise on per-joint velocities: the `<joint>.vel` entries in `get_observation` and the `velocity` field in `get_robot_state`.
- **`camera_jitter_px`** - max integer pixel shift (uniform per axis) applied to rendered frames in `render()` and to the camera frames in `get_observation`.
- **`seed`** - reproducible noise stream.

Validation rejects negative / non-finite / non-numeric values with `status=error`. Floating-base `base_quat` / `base_ang_vel` signals are left untouched (a quaternion would need renormalization; out of scope for additive scalar noise). `describe()` now advertises the method.

**Zero default-path impact:** with no `set_obs_noise` call (or all-zero std), the noise path returns the input unchanged, so unconfigured observations and renders are byte-for-byte identical to before. Verified against the full MuJoCo sim suite (1061 passed, 1 skipped).

## Camera jitter (rollout still, headless MuJoCo)

Left: `camera_jitter_px=0` (noise-free). Right: `camera_jitter_px=14, seed=3` - the frame is shifted (mean abs diff 18.3).

![camera jitter](https://github.com/cagataycali/robots/releases/download/artifact-obs-noise/obs_noise_camera_jitter.png)

## Tests

`tests/simulation/mujoco/test_set_obs_noise.py` (12 tests) - success + `describe()` surface, position+velocity noise on `get_observation`, `get_robot_state` noise, seeded reproducibility, validation, default-is-no-op + disable-restores, the jitter helper on a synthetic frame, and a GL-gated camera-jitter render. All 12 **fail pre-fix** with `NotImplementedError` and pass after.

Gate: `ruff check` + `ruff format` + `mypy` clean on all changed files; `MUJOCO_GL=egl` MuJoCo sim suite 1061 passed / 1 skipped.

## Docs

`docs/simulation/domain-randomization.md` gains a Sensor-noise section and the Newton paragraph is corrected to note both backends implement the contract identically. CHANGELOG updated.