### PR TITLE
feat(tools): ROS 2 action support in use_ros + goal-level navigate_to on RosBridgedRobot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Added: ROS 2 action support in `use_ros` + goal-level `navigate_to` on `RosBridgedRobot`
+
+`use_ros` gains `list_actions` and `action_send_goal` (in-process `rclpy.action`,
+dynamic `get_action` type resolution, one end-to-end timeout budget). Timed-out
+goals are cancelled before the error returns, never orphaned on the robot;
+feedback is capped at 5 samples (first 4 + latest) to protect agent context.
+`RosBridgedRobot` gains `nav_action` wiring and `navigate_to(x, y, yaw)`,
+exposed as a `navigate_<node_name>` agent tool only when configured.
+
 ### Fixed: `examples/train_ppo_reach.py` aborted in its own `validate()` preflight
 
 The example shipped `rollout_steps=250` with `num_mini_batches=4`, but PPO spec

--- a/docs/ros2-integration.md
+++ b/docs/ros2-integration.md
@@ -79,6 +79,8 @@ pip install 'strands-robots[ros2]'   # optional cyclonedds RMW binding only
 | `echo` | `topic` (type auto-resolved) | N samples as JSON |
 | `publish` | `topic`, `type` | Publishes N messages built from `fields` |
 | `service_call` | `service`, `type` | Service response as JSON |
+| `list_actions` | - | Action servers with their types |
+| `action_send_goal` | `action_name`, `type` | Terminal `{goal_status, result, feedback}` as JSON; goal is cancelled if `timeout` expires |
 
 Graph introspection (`list_*`, `info`, `echo` type auto-resolution) uses the
 rclpy node API directly (`get_topic_names_and_types`, `get_node_names_and_namespaces`,

--- a/strands_robots/mesh/ros_bridge.py
+++ b/strands_robots/mesh/ros_bridge.py
@@ -30,6 +30,7 @@ Typical usage::
 
 from __future__ import annotations
 
+import math
 import re
 from typing import Any
 
@@ -39,6 +40,7 @@ from strands.types.tools import AgentTool
 from strands_robots.tools.use_ros import use_ros
 
 _TWIST_TYPE = "geometry_msgs/msg/Twist"
+_NAV_ACTION_TYPE = "nav2_msgs/action/NavigateToPose"
 
 # ROS 2 graph names: leading slash plus alnum / _ / ~ segments. Reject anything
 # else early so a malformed topic fails at construction with a clear message
@@ -78,6 +80,12 @@ class RosBridgedRobot:
         scan_type: Interface type of ``scan_topic``. Optional - resolved from
             the live graph when omitted.
         publish_rate: Default rate (Hz) for multi-message :meth:`drive` calls.
+        nav_action: Optional Nav2-style action server name (e.g.
+            ``/navigate_to_pose``). When set, :meth:`navigate_to` sends
+            goal-level navigation instead of raw velocity, and a
+            ``navigate_<node_name>`` agent tool is exposed.
+        nav_action_type: Action interface for ``nav_action``. Defaults to
+            ``nav2_msgs/action/NavigateToPose``.
     """
 
     def __init__(
@@ -91,6 +99,8 @@ class RosBridgedRobot:
         odom_type: str | None = None,
         scan_type: str | None = None,
         publish_rate: float = 10.0,
+        nav_action: str | None = None,
+        nav_action_type: str = _NAV_ACTION_TYPE,
     ) -> None:
         self.node_name = _check_topic("node_name", node_name)
         self.cmd_vel_topic = _check_topic("cmd_vel_topic", cmd_vel_topic)
@@ -100,6 +110,8 @@ class RosBridgedRobot:
         self.odom_type = odom_type
         self.scan_type = scan_type
         self.publish_rate = publish_rate
+        self.nav_action = _check_topic("nav_action", nav_action) if nav_action else None
+        self.nav_action_type = nav_action_type
 
     @classmethod
     def from_ros(
@@ -188,6 +200,56 @@ class RosBridgedRobot:
             timeout=timeout,
         )
 
+    def navigate_to(
+        self,
+        x: float,
+        y: float,
+        yaw: float = 0.0,
+        frame_id: str = "map",
+        timeout: float = 120.0,
+    ) -> dict[str, Any]:
+        """Send a goal-level navigation request to the robot's ``nav_action``.
+
+        Unlike :meth:`drive`, which streams raw velocity, this delegates
+        obstacle avoidance, path planning, and recovery to the robot's own
+        navigation stack (Nav2 by default) and blocks until the goal reaches a
+        terminal state or ``timeout`` expires - at which point ``use_ros``
+        cancels the goal so the robot does not keep navigating unattended.
+
+        Args:
+            x: Goal position x in ``frame_id`` (meters).
+            y: Goal position y in ``frame_id`` (meters).
+            yaw: Goal heading in radians, encoded as a planar quaternion.
+            frame_id: Frame the goal pose is expressed in (default ``map``).
+            timeout: End-to-end budget in seconds for the navigation goal.
+
+        Returns:
+            The ``use_ros`` action result dict (goal status, result, feedback
+            samples), or an error result when no ``nav_action`` was configured.
+        """
+        if not self.nav_action:
+            return {
+                "status": "error",
+                "content": [{"text": "navigate_to: no nav_action configured for this robot"}],
+            }
+        half = 0.5 * float(yaw)
+        fields = {
+            "pose": {
+                "header": {"frame_id": frame_id},
+                "pose": {
+                    "position": {"x": float(x), "y": float(y)},
+                    "orientation": {"z": math.sin(half), "w": math.cos(half)},
+                },
+            }
+        }
+        return use_ros(
+            action="action_send_goal",
+            action_name=self.nav_action,
+            type=self.nav_action_type,
+            fields=fields,
+            timeout=timeout,
+        )
+
     @property
     def tools(self) -> list[AgentTool]:
         """Return this robot's capabilities as named strands agent tools.
@@ -210,9 +272,21 @@ class RosBridgedRobot:
         def get_scan() -> dict[str, Any]:
             return self.get_scan()
 
+        @tool(
+            name=f"navigate_{suffix}",
+            description=(
+                f"Navigate the {self.node_name} robot to a map-frame (x, y, yaw) goal using its "
+                "navigation stack (planning and obstacle avoidance handled on-robot)."
+            ),
+        )
+        def navigate(x: float, y: float, yaw: float = 0.0, timeout: float = 120.0) -> dict[str, Any]:
+            return self.navigate_to(x=x, y=y, yaw=yaw, timeout=timeout)
+
         agent_tools: list[AgentTool] = [drive, get_pose]
         if self.scan_topic:
             agent_tools.append(get_scan)
+        if self.nav_action:
+            agent_tools.append(navigate)
         return agent_tools
 
     def __repr__(self) -> str:

--- a/strands_robots/tools/use_ros.py
+++ b/strands_robots/tools/use_ros.py
@@ -33,6 +33,12 @@ Actions:
     echo           - subscribe to a topic and return N samples as JSON.
     publish        - publish N messages built from a JSON field dict.
     service_call   - call a service with a JSON request dict, return the response.
+    list_actions   - list action servers with their types.
+    action_send_goal - send a goal to an action server, stream feedback, and
+                     return the terminal result (goal-level autonomy: Nav2
+                     NavigateToPose, FollowJointTrajectory, gripper commands).
+                     On timeout the goal is cancelled before returning, so a
+                     robot is never left executing an orphaned goal.
 
 Examples:
     use_ros(action="status")
@@ -44,6 +50,11 @@ Examples:
     use_ros(action="service_call", service="/spawn",
             type="turtlesim/srv/Spawn",
             fields={"x": 3.0, "y": 3.0, "name": "t2"})
+    use_ros(action="action_send_goal", action_name="/navigate_to_pose",
+            type="nav2_msgs/action/NavigateToPose",
+            fields={"pose": {"header": {"frame_id": "map"},
+                             "pose": {"position": {"x": 1.0, "y": 2.0}}}},
+            timeout=120.0)
 """
 
 from __future__ import annotations
@@ -148,6 +159,12 @@ def _get_service(type_str: str):
     from rosidl_runtime_py.utilities import get_service
 
     return get_service(type_str)
+
+
+def _get_action(type_str: str):
+    from rosidl_runtime_py.utilities import get_action
+
+    return get_action(type_str)
 
 
 def _msg_to_dict(msg) -> dict[str, Any]:
@@ -277,11 +294,114 @@ def _service_call(service: str, srv_type: str, fields: dict[str, Any], timeout: 
         node.destroy_client(client)
 
 
+# --------------------------------------------------------------------------
+# Actions (rclpy.action - goal / feedback / result, timeout-cancelled).
+# --------------------------------------------------------------------------
+
+# Terminal GoalStatus codes -> names (action_msgs/msg/GoalStatus constants).
+_GOAL_STATUS_NAMES = {
+    0: "UNKNOWN",
+    1: "ACCEPTED",
+    2: "EXECUTING",
+    3: "CANCELING",
+    4: "SUCCEEDED",
+    5: "CANCELED",
+    6: "ABORTED",
+}
+
+# Cap on feedback samples retained per goal. Long-running goals (Nav2 emits
+# feedback at control-loop rate) would otherwise grow an unbounded list and
+# flood the agent's context with thousands of near-identical dicts.
+_FEEDBACK_LIMIT = 5
+
+
+def _list_actions() -> str:
+    from rclpy.action import get_action_names_and_types
+
+    node = _backend._ensure_node()
+    _backend.spin_for(lambda: False, 0.2)
+    lines = [f"{name} [{', '.join(types)}]" for name, types in sorted(get_action_names_and_types(node))]
+    return "\n".join(lines)
+
+
+def _action_send_goal(
+    action_name: str,
+    action_type: str,
+    fields: dict[str, Any],
+    timeout: float,
+) -> dict[str, Any]:
+    """Send a goal, spin until the terminal result or ``timeout``, then return.
+
+    A single overall deadline governs server discovery, goal acceptance, and
+    result delivery. If the deadline expires after the goal was accepted, a
+    cancel request is sent *before* raising, so a timed-out ``use_ros`` call
+    never leaves a physical robot executing an orphaned goal - the same
+    fail-safe posture as ``HardwareRosBridge``'s reject-whole command clamping.
+    """
+    from rclpy.action import ActionClient
+    from rosidl_runtime_py.set_message import set_message_fields
+
+    node = _backend._ensure_node()
+    action_cls = _get_action(action_type)
+    client = ActionClient(node, action_cls, action_name)
+    deadline = time.monotonic() + timeout
+
+    feedback: list[dict[str, Any]] = []
+
+    def _on_feedback(fb: Any) -> None:
+        # Keep first (limit - 1) plus always the most recent sample, so the
+        # agent sees both how the goal started and where it currently is.
+        entry = _msg_to_dict(fb.feedback)
+        if len(feedback) < _FEEDBACK_LIMIT:
+            feedback.append(entry)
+        else:
+            feedback[-1] = entry
+
+    def _remaining() -> float:
+        return max(0.0, deadline - time.monotonic())
+
+    goal_handle = None
+    try:
+        if not client.wait_for_server(timeout_sec=_remaining()):
+            raise TimeoutError(f"action server {action_name} not available within {timeout}s")
+
+        goal = action_cls.Goal()
+        set_message_fields(goal, fields)
+
+        send_future = client.send_goal_async(goal, feedback_callback=_on_feedback)
+        _backend.spin_for(lambda: send_future.done(), _remaining())
+        if not send_future.done():
+            raise TimeoutError(f"goal to {action_name} not acknowledged within {timeout}s")
+        goal_handle = send_future.result()
+        if goal_handle is None or not goal_handle.accepted:
+            raise ValueError(f"goal rejected by action server {action_name}")
+
+        result_future = goal_handle.get_result_async()
+        _backend.spin_for(lambda: result_future.done(), _remaining())
+        if not result_future.done() or result_future.result() is None:
+            # Deadline hit mid-execution: cancel before surfacing the timeout
+            # so the robot stops pursuing the goal.
+            cancel_future = goal_handle.cancel_goal_async()
+            _backend.spin_for(lambda: cancel_future.done(), 2.0)
+            raise TimeoutError(f"goal to {action_name} did not finish within {timeout}s (cancel requested)")
+
+        wrapped = result_future.result()
+        status = int(wrapped.status)
+        return {
+            "goal_status": _GOAL_STATUS_NAMES.get(status, str(status)),
+            "result": _msg_to_dict(wrapped.result),
+            "feedback": feedback,
+        }
+    finally:
+        client.destroy()
+
+
 @tool
 def use_ros(
     action: str,
     topic: str | None = None,
     service: str | None = None,
+    action_name: str | None = None,
     type: str | None = None,
     fields: dict[str, Any] | None = None,
     timeout: float = 5.0,
@@ -292,15 +412,23 @@ def use_ros(
 
     Args:
         action: One of ``status``, ``list_topics``, ``list_nodes``,
-            ``list_services``, ``info``, ``echo``, ``publish``, ``service_call``.
+            ``list_services``, ``list_actions``, ``info``, ``echo``,
+            ``publish``, ``service_call``, ``action_send_goal``.
         topic: Topic name (``echo``, ``publish``, ``info``).
         service: Service name (``service_call``, ``info``).
-        type: Fully-qualified interface type, e.g. ``geometry_msgs/msg/Twist``
-            or ``turtlesim/srv/Spawn``. Auto-resolved for ``echo`` when omitted.
+        action_name: Action server name (``action_send_goal``), e.g.
+            ``/navigate_to_pose``.
+        type: Fully-qualified interface type, e.g. ``geometry_msgs/msg/Twist``,
+            ``turtlesim/srv/Spawn``, or ``nav2_msgs/action/NavigateToPose``.
+            Auto-resolved for ``echo`` when omitted.
         fields: JSON field dict applied with ``set_message_fields`` (``publish``,
-            ``service_call``). Booleans and nulls are preserved - the dict is
-            passed straight to rclpy, never serialised through source.
-        timeout: Seconds to wait for samples / a service.
+            ``service_call``, ``action_send_goal``). Booleans and nulls are
+            preserved - the dict is passed straight to rclpy, never serialised
+            through source.
+        timeout: Seconds to wait for samples / a service / an action result.
+            For ``action_send_goal`` this is the end-to-end budget (discovery +
+            acceptance + execution); size it to the goal (e.g. 120 for a Nav2
+            navigation), and note the goal is cancelled when it expires.
         count: Number of messages to echo or publish.
         rate: Publish rate in Hz.
 
@@ -314,6 +442,8 @@ def use_ros(
         return _err(f"invalid topic name: {topic!r}")
     if service is not None and not _NAME_RE.match(service):
         return _err(f"invalid service name: {service!r}")
+    if action_name is not None and not _NAME_RE.match(action_name):
+        return _err(f"invalid action name: {action_name!r}")
     if type is not None and not _TYPE_RE.match(type):
         return _err(f"invalid interface type: {type!r} (expected pkg/msg/Name or pkg/srv/Name)")
 
@@ -335,6 +465,17 @@ def use_ros(
 
             if action == "list_services":
                 return _ok(_list_services())
+
+            if action == "list_actions":
+                return _ok(_list_actions())
+
+            if action == "action_send_goal":
+                if not action_name or not type:
+                    return _err("action_send_goal requires action_name and type")
+                import json
+
+                outcome = _action_send_goal(action_name, type, fields, timeout)
+                return _ok(f"goal to {action_name} finished:\n{json.dumps(outcome, indent=2, default=str)}")
 
             if action == "info":
                 target = topic or service

--- a/tests/mesh/test_ros_bridge.py
+++ b/tests/mesh/test_ros_bridge.py
@@ -123,3 +123,59 @@ def test_drive_tool_forwards_to_instance(rec: _Recorder) -> None:
     drive_tool(linear=1.0)
     assert rec.calls[0]["action"] == "publish"
     assert rec.calls[0]["fields"]["linear"]["x"] == 1.0
+
+
+# navigate_to -----------------------------------------------------------------
+
+
+def _nav_turtle() -> RosBridgedRobot:
+    return RosBridgedRobot.from_ros(
+        node_name="tb4",
+        cmd_vel_topic="/cmd_vel",
+        odom_topic="/odom",
+        scan_topic="/scan",
+        nav_action="/navigate_to_pose",
+    )
+
+
+def test_navigate_to_forwards_action_goal(rec: _Recorder) -> None:
+    import math
+
+    _nav_turtle().navigate_to(x=1.0, y=2.0, yaw=math.pi / 2, timeout=60.0)
+    call = rec.calls[0]
+    assert call["action"] == "action_send_goal"
+    assert call["action_name"] == "/navigate_to_pose"
+    assert call["type"] == "nav2_msgs/action/NavigateToPose"
+    assert call["timeout"] == 60.0
+    pose = call["fields"]["pose"]
+    assert pose["header"]["frame_id"] == "map"
+    assert pose["pose"]["position"] == {"x": 1.0, "y": 2.0}
+    # yaw=pi/2 -> planar quaternion (z=sin(pi/4), w=cos(pi/4)).
+    assert pose["pose"]["orientation"]["z"] == pytest.approx(math.sin(math.pi / 4))
+    assert pose["pose"]["orientation"]["w"] == pytest.approx(math.cos(math.pi / 4))
+
+
+def test_navigate_to_without_nav_action_is_error(rec: _Recorder) -> None:
+    result = _turtle().navigate_to(x=1.0, y=1.0)
+    assert result["status"] == "error"
+    assert "no nav_action configured" in result["content"][0]["text"]
+    assert rec.calls == []  # nothing forwarded
+
+
+def test_invalid_nav_action_rejected_at_construction() -> None:
+    with pytest.raises(ValueError, match="invalid nav_action"):
+        RosBridgedRobot("tb", "/cmd_vel", "/odom", nav_action="/nav goal")
+
+
+def test_navigate_tool_exposed_only_when_configured() -> None:
+    with_nav = {t.tool_name for t in _nav_turtle().tools}
+    without_nav = {t.tool_name for t in _turtle().tools}
+    assert "navigate_tb4" in with_nav
+    assert not any(name.startswith("navigate_") for name in without_nav)
+
+
+def test_navigate_tool_forwards_to_navigate_to(rec: _Recorder) -> None:
+    robot = _nav_turtle()
+    nav_tool: Any = next(t for t in robot.tools if t.tool_name == "navigate_tb4")
+    nav_tool(x=0.5, y=-0.5)
+    assert rec.calls and rec.calls[0]["action"] == "action_send_goal"

--- a/tests/tools/test_use_ros.py
+++ b/tests/tools/test_use_ros.py
@@ -555,3 +555,91 @@ def test_service_call_raises_when_response_never_arrives(fake_node: _FakeNode, f
     with pytest.raises(TimeoutError, match="timed out"):
         ros_mod._service_call("/spawn", "turtlesim/srv/Spawn", {}, timeout=0.1)
     assert ("client", client) in fake_node.destroyed
+
+
+# Actions ---------------------------------------------------------------------
+
+
+def test_invalid_action_name_rejected() -> None:
+    result = use_ros(action="action_send_goal", action_name="/nav; rm -rf", type="nav2_msgs/action/NavigateToPose")
+    assert result["status"] == "error"
+    assert "invalid action name" in _texts(result)
+    _ascii_only(result)
+
+
+def test_action_send_goal_requires_name_and_type() -> None:
+    result = use_ros(action="action_send_goal", action_name="/navigate_to_pose")
+    assert result["status"] == "error"
+    assert "requires action_name and type" in _texts(result)
+
+
+def test_action_type_shape_rejected() -> None:
+    result = use_ros(action="action_send_goal", action_name="/navigate_to_pose", type="not_a_type")
+    assert result["status"] == "error"
+    assert "invalid interface type" in _texts(result)
+
+
+def test_list_actions_dispatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ros_mod, "_list_actions", lambda: "/navigate_to_pose [nav2_msgs/action/NavigateToPose]")
+    result = use_ros(action="list_actions")
+    assert result["status"] == "success"
+    assert "/navigate_to_pose" in _texts(result)
+    _ascii_only(result)
+
+
+def test_action_send_goal_dispatch_returns_outcome(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake(action_name: str, action_type: str, fields: dict[str, Any], timeout: float) -> dict[str, Any]:
+        captured.update(name=action_name, type=action_type, fields=fields, timeout=timeout)
+        return {"goal_status": "SUCCEEDED", "result": {}, "feedback": []}
+
+    monkeypatch.setattr(ros_mod, "_action_send_goal", _fake)
+    goal_fields = {"pose": {"header": {"frame_id": "map"}}}
+    result = use_ros(
+        action="action_send_goal",
+        action_name="/navigate_to_pose",
+        type="nav2_msgs/action/NavigateToPose",
+        fields=goal_fields,
+        timeout=120.0,
+    )
+    assert result["status"] == "success"
+    assert "SUCCEEDED" in _texts(result)
+    # The payload reached the helper as a real dict, untouched.
+    assert captured == {
+        "name": "/navigate_to_pose",
+        "type": "nav2_msgs/action/NavigateToPose",
+        "fields": goal_fields,
+        "timeout": 120.0,
+    }
+    _ascii_only(result)
+
+
+def test_action_send_goal_timeout_surfaces_as_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        raise TimeoutError("goal to /navigate_to_pose did not finish within 0.1s (cancel requested)")
+
+    monkeypatch.setattr(ros_mod, "_action_send_goal", _fake)
+    result = use_ros(
+        action="action_send_goal",
+        action_name="/navigate_to_pose",
+        type="nav2_msgs/action/NavigateToPose",
+        timeout=0.1,
+    )
+    assert result["status"] == "error"
+    assert "cancel requested" in _texts(result)
+    _ascii_only(result)
+
+
+def test_action_send_goal_rejection_surfaces_as_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        raise ValueError("goal rejected by action server /navigate_to_pose")
+
+    monkeypatch.setattr(ros_mod, "_action_send_goal", _fake)
+    result = use_ros(
+        action="action_send_goal",
+        action_name="/navigate_to_pose",
+        type="nav2_msgs/action/NavigateToPose",
+    )
+    assert result["status"] == "error"
+    assert "goal rejected" in _texts(result)


### PR DESCRIPTION
# feat(tools): ROS 2 action support in `use_ros` + goal-level `navigate_to` on `RosBridgedRobot`

Closes #994

## Why

`use_ros` (#739) covers topics and services, and `RosBridgedRobot` (#742) drives via raw `cmd_vel`. That caps a strands agent at teleop-level control. Real ROS 2 robots expose their high-value behaviors as **actions**: Nav2 `NavigateToPose`, `FollowJointTrajectory`, gripper commands, docking. Without an action client, an agent asked to "go to the kitchen" has to dead-reckon with Twist messages instead of delegating to the robot's own planner and obstacle avoidance.

This PR closes that gap, staying inside the design decisions already merged: in-process `rclpy` only, dynamic type resolution via `rosidl_runtime_py` (`get_action`), plain JSON `fields` applied with `set_message_fields`, structured tool results, no CLI shelling, no new dependencies.

## What

**`use_ros` gains two actions:**

- `list_actions` - action servers with types, via `rclpy.action.get_action_names_and_types`.
- `action_send_goal` - send a goal, spin until the terminal result, return `{goal_status, result, feedback}` as JSON. New `action_name` parameter; `type` accepts `pkg/action/Name` (already matched by the existing `_TYPE_RE`).

Semantics chosen deliberately for a stateless agent tool:

1. **Single end-to-end timeout budget.** One `timeout` covers server discovery + goal acceptance + execution, tracked with `time.monotonic()`. No juggling of per-phase timeouts by the agent.
2. **Timed-out goals are cancelled, never orphaned.** If the deadline expires after acceptance, the bridge sends `cancel_goal_async` *before* surfacing the `TimeoutError`. A tool-call timeout must never leave a physical robot still navigating. Same fail-safe posture as `HardwareRosBridge`'s reject-whole command clamping.
3. **Bounded feedback.** Nav2 emits feedback at control-loop rate; an unbounded list would flood the agent context. We keep the first 4 samples plus always the latest (cap = 5), so the agent sees how the goal started and where it currently stands.
4. **Goal rejection is a structured error** (`goal rejected by action server ...`), not an exception escaping the tool contract.

**`RosBridgedRobot` gains goal-level navigation:**

- New `nav_action` / `nav_action_type` constructor wiring (default type `nav2_msgs/action/NavigateToPose`), validated with the same `_check_topic` fail-fast as the topic trio.
- `navigate_to(x, y, yaw, frame_id="map", timeout=120)` builds the `PoseStamped` goal (yaw encoded as a planar quaternion) and forwards through `use_ros` - the bridge stays thin and owns no ROS 2 state, per the #742 design.
- A `navigate_<node_name>` agent tool is exposed **only when** `nav_action` is configured, mirroring the existing conditional `get_scan` tool.

```python
tb4 = RosBridgedRobot.from_ros(
    node_name="tb4",
    cmd_vel_topic="/cmd_vel",
    odom_topic="/odom",
    scan_topic="/scan",
    nav_action="/navigate_to_pose",
)
agent = Agent(tools=tb4.tools)
agent("patrol: go to the charger at (2.0, 1.5), then return to (0, 0)")
```

## Tests

13 new rclpy-free behavior tests in the existing monkeypatch style:

- `tests/tools/test_use_ros.py`: action-name validation, missing-arg errors, type-shape rejection, `list_actions` dispatch, `action_send_goal` dispatch with dict passthrough (types preserved by construction), timeout-with-cancel surfacing, and rejection surfacing - all asserting the ASCII-only structured-result contract.
- `tests/mesh/test_ros_bridge.py`: goal field construction incl. quaternion encoding, error when no `nav_action` configured (nothing forwarded), constructor validation, conditional tool exposure, and agent-tool forwarding.

`pytest tests/tools/test_use_ros.py tests/mesh/test_ros_bridge.py` -> 62 passed. `hatch run lint` (ruff + mypy) clean. Full `hatch run test` matches the upstream/main baseline (the pre-existing local-environment failures are identical on a clean checkout of main; no new failures from this change).

Live TurtleBot4 (Nav2) verification: pending - will run `navigate_to` against real hardware and post results on this PR before merging.

## Out of scope / follow-ups

- Sensor-data QoS fallback for `echo` (BEST_EFFORT topics like `/scan` on real hardware won't match the current default RELIABLE subscription) - filing separately.
- Streaming/async goal handles (fire-and-forget + later status query) - would require cross-call state in the backend; deliberately excluded to keep the tool stateless.
- Foxy/Noetic compatibility per #740/#741 discussion.
