### PR TITLE
feat(sim): add list_cameras() to the MuJoCo backend (camera discovery at backend parity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,25 @@ pixel jitter on rendered frames. Values must be finite and non-negative
 default (never-configured) path is an exact no-op, so unconfigured observations
 and renders are byte-for-byte unchanged. `describe()` now advertises the method.
 
+### Added: `list_cameras()` on the MuJoCo backend -- camera discovery at backend parity
+
+The Newton backend exposed a public `list_cameras()` and advertised it in
+`describe()`, but the default MuJoCo backend had no such method: `sim.list_cameras()`
+raised `AttributeError`, and `describe()["cameras"]` was built from a raw
+`model.ncam` loop whose contents depended on whether the loaded MJCF happened to
+bake a camera literally named `"default"`. The two backends therefore reported
+different camera sets for the same query, and the built-in `"default"` free view
+that `render()` (its default argument) always accepts could be absent from
+discovery.
+
+`MuJoCoSimEngine.list_cameras()` now returns every renderable camera name --
+`"default"` first, then all model-defined and `add_camera` cameras, deduplicated
+-- mirroring Newton. `describe()["cameras"]` delegates to it (so the two are
+always equal and `"default"` is always advertised), `describe()["methods"]`
+documents it, and `list_cameras` is a dispatchable agent action alongside
+`list_robots` / `list_objects` / `list_bodies`, completing the scene discovery
+surface on the default backend.
+
 
 ## [0.4.1] - 2026-07-01
 

--- a/docs/simulation/overview.md
+++ b/docs/simulation/overview.md
@@ -55,14 +55,21 @@ For walkthroughs see [Simulation overview](../simulation/overview.md).
 |--------|-----------|
 | `add_camera` | `name`, `position`, `target`, `fov=60.0`, `width=640`, `height=480` - no `attach_to`/`fovy`/`lookat` |
 | `remove_camera` | `name` |
+| `list_cameras` | - renderable camera names, `"default"` first, incl. model + user cameras |
 
 Robot-URDF cameras are auto-discovered on `add_robot`.
 
+`sim.list_cameras()` returns every name `render` / `start_recording` accepts -
+the built-in `"default"` free view first, then all model-defined and
+`add_camera` cameras. It equals `sim.describe()["cameras"]` and matches the
+Newton backend, so a rollout rig can be enumerated instead of guessed.
+
 !!! tip "Discover the scene-construction surface"
-    `add_robot`, `add_object`, `remove_object`, `add_camera`, and
-    `remove_camera` are all listed in `sim.describe()["methods"]`, so an agent
-    can learn how to build a scene (robot, manipulanda, camera rig) before a
-    rollout from one `describe()` call instead of guessing method names.
+    `add_robot`, `add_object`, `remove_object`, `add_camera`,
+    `remove_camera`, and `list_cameras` are all listed in
+    `sim.describe()["methods"]`, so an agent can learn how to build a scene
+    (robot, manipulanda, camera rig) before a rollout from one `describe()`
+    call instead of guessing method names.
 
 ## Rendering
 

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -996,6 +996,24 @@ class RenderingMixin:
                 names.append(k)
         return names
 
+    def list_cameras(self) -> list[str]:
+        """Return every renderable camera name on this backend.
+
+        The list always starts with the built-in ``"default"`` free view
+        (what ``render()`` / ``render(camera_name="default")`` targets) and is
+        followed by every model-defined and user-added (``add_camera``) camera,
+        deduplicated. This mirrors the Newton backend's :meth:`list_cameras`, so
+        ``describe()["cameras"]`` and this discovery surface are identical across
+        backends and independent of whether the loaded MJCF happens to bake a
+        camera literally named ``"default"`` (which ``render`` shadows with the
+        free view regardless).
+
+        Returns:
+            Camera names accepted by :meth:`render`, with ``"default"`` first.
+        """
+        named = self._list_camera_names()
+        return ["default", *[n for n in named if n != "default"]]
+
     def get_contacts(self) -> dict[str, Any]:
         """Return the list of active geom-geom contacts at the current step.
 

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1239,15 +1239,11 @@ class MuJoCoSimEngine(
         """
         base = super().describe()
 
-        cameras: list[str] = []
-        if self._world is not None and self._world._model is not None:
-            mj = self._mj
-            model = self._world._model
-            for i in range(model.ncam):
-                cam_name = mj.mj_id2name(model, mj.mjtObj.mjOBJ_CAMERA, i)
-                if cam_name:
-                    cameras.append(cam_name)
-        base["cameras"] = cameras
+        # Renderable camera names, incl. the built-in "default" free view.
+        # Delegates to list_cameras() so the discovery surface is identical to
+        # the Newton backend and always advertises "default" (which render()
+        # accepts) regardless of the loaded MJCF's own camera names.
+        base["cameras"] = self.list_cameras()
 
         bodies: list[str] = []
         if self._world is not None and self._world._model is not None:
@@ -1268,6 +1264,7 @@ class MuJoCoSimEngine(
             "scene; parent_body mounts it on a moving link (e.g. a wrist cam)"
         )
         base["methods"]["remove_camera"] = "(name: str) -> dict  # remove a camera added via add_camera"
+        base["methods"]["list_cameras"] = "() -> list[str]  # renderable camera names incl. the built-in 'default' view"
         # Rendering siblings of "render" (advertised in tool_spec.json + the
         # action dispatcher) that the base discovery surface omits. Listing
         # them here lets an agent enumerate the full render surface from
@@ -1655,6 +1652,20 @@ class MuJoCoSimEngine(
         lines = ["Objects:\n"]
         for name, obj in self._world.objects.items():
             lines.append(f"  - {name}: {obj.shape} at {obj.position}, {'static' if obj.is_static else f'{obj.mass}kg'}")
+        return {"status": "success", "content": [{"text": "\n".join(lines)}]}
+
+    def list_cameras_info(self) -> dict[str, Any]:
+        """Agent-facing camera listing (tool-result form of :meth:`list_cameras`).
+
+        Completes the discovery surface alongside ``list_robots`` /
+        ``list_objects`` / ``list_bodies`` so an agent can enumerate the
+        renderable cameras (what ``render`` / ``start_recording`` can target)
+        instead of guessing names or triggering a "camera not found" error.
+        """
+        if self._world is None or self._world._model is None:
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
+        cams = self.list_cameras()
+        lines = ["Cameras (renderable):\n"] + [f"  - {c}" for c in cams]
         return {"status": "success", "content": [{"text": "\n".join(lines)}]}
 
     # Camera Management
@@ -2389,11 +2400,11 @@ class MuJoCoSimEngine(
                 "(direct path or auto-resolve from data_config name), add objects, run VLA policies, "
                 "render cameras, record trajectories, domain randomize. "
                 "Same Policy ABC as real robot control - sim and real with zero code changes. "
-                "Actions (65 total): "
+                "Actions (66 total): "
                 "[World] create_world, load_scene, reset, get_state, destroy, export_xml; "
                 "[Robots] add_robot, remove_robot, list_robots, get_robot_state, list_bodies; "
                 "[Objects] add_object, remove_object, move_object, list_objects; "
-                "[Cameras] add_camera, remove_camera; "
+                "[Cameras] add_camera, remove_camera, list_cameras; "
                 "[Policy] run_policy, start_policy, stop_policy, eval_policy, replay_episode, list_policies_running; "
                 "[Rendering] render, render_depth, render_all, open_viewer, close_viewer; "
                 "[Physics] step, set_gravity, set_timestep, set_joint_positions, set_joint_velocities, "
@@ -2984,6 +2995,7 @@ class MuJoCoSimEngine(
     # Action name aliases (tool-action -> method-name)
     _ACTION_ALIASES = {
         "list_robots": "list_robots_info",
+        "list_cameras": "list_cameras_info",
     }
 
     # Input field name -> method parameter name (syntactic sugar for the LLM)

--- a/strands_robots/simulation/mujoco/tool_spec.json
+++ b/strands_robots/simulation/mujoco/tool_spec.json
@@ -23,6 +23,7 @@
         "list_objects",
         "add_camera",
         "remove_camera",
+        "list_cameras",
         "run_policy",
         "start_policy",
         "stop_policy",

--- a/tests/simulation/mujoco/test_list_cameras_discovery.py
+++ b/tests/simulation/mujoco/test_list_cameras_discovery.py
@@ -1,0 +1,109 @@
+"""``list_cameras`` is a first-class camera discovery surface on the MuJoCo backend.
+
+The Newton backend exposes a public ``list_cameras()`` and advertises it in
+``describe()`` (and always lists the built-in ``"default"`` free view), but the
+default MuJoCo backend had no such method: ``sim.list_cameras()`` raised
+``AttributeError``, and ``describe()["cameras"]`` was built from a raw
+``model.ncam`` loop whose contents depended on whether the loaded MJCF happened
+to bake a camera literally named ``"default"`` -- so the two backends reported
+different camera sets for the same query, and ``render("default")`` (the default
+argument!) targeted a view that discovery could omit.
+
+These tests pin the parity contract: ``list_cameras()`` exists, always begins
+with ``"default"`` (deduplicated), includes model + user cameras, equals
+``describe()["cameras"]``, and is reachable as an agent action alongside
+``list_robots`` / ``list_objects`` / ``list_bodies``. They are GL-free (no
+rendering), so they run in CI without an OpenGL context.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+from strands_robots import create_simulation
+
+
+def _sim_with_robot():
+    sim = create_simulation(backend="mujoco")
+    sim.create_world(ground_plane=True)
+    sim.add_robot("so101")
+    return sim
+
+
+def test_list_cameras_is_public_and_lists_default():
+    """The default backend exposes list_cameras() starting with 'default'."""
+    sim = _sim_with_robot()
+    assert hasattr(sim, "list_cameras"), "MuJoCo backend must expose list_cameras()"
+    cams = sim.list_cameras()
+    assert isinstance(cams, list)
+    assert cams[0] == "default"
+    # 'default' is the free-view token render() accepts; it must be listed once
+    assert cams.count("default") == 1
+
+
+def test_list_cameras_includes_user_camera_deduped():
+    """A camera added via add_camera appears exactly once; 'default' stays unique."""
+    sim = _sim_with_robot()
+    sim.add_camera(
+        "wristcam",
+        position=[0.05, 0.0, 0.15],
+        target=[0.3, 0.0, 0.05],
+        width=256,
+        height=256,
+        parent_body="so101/gripper",
+    )
+    cams = sim.list_cameras()
+    assert "wristcam" in cams
+    assert cams.count("default") == 1
+    assert cams.count("wristcam") == 1
+
+
+def test_describe_cameras_equals_list_cameras():
+    """describe()['cameras'] is the single source of truth: it equals list_cameras()."""
+    sim = _sim_with_robot()
+    sim.add_camera(
+        "topcam",
+        position=[0.2, 0.0, 0.7],
+        target=[0.2, 0.0, 0.0],
+        width=128,
+        height=128,
+    )
+    d = sim.describe()
+    assert d["cameras"] == sim.list_cameras()
+    assert "default" in d["cameras"]
+    assert "topcam" in d["cameras"]
+    assert "list_cameras" in d["methods"]
+
+
+def test_list_cameras_no_world_matches_newton():
+    """With no world the default view is still advertised (Newton-consistent)."""
+    sim = create_simulation(backend="mujoco")
+    assert sim.list_cameras() == ["default"]
+    assert sim.describe()["cameras"] == ["default"]
+
+
+def test_list_cameras_agent_action_dispatches():
+    """The agent action list_cameras returns a tool-result dict (not AttributeError)."""
+    sim = _sim_with_robot()
+    res = sim._dispatch_action("list_cameras", {"action": "list_cameras"})
+    assert res["status"] == "success", res
+    text = res["content"][0]["text"]
+    assert "default" in text
+
+
+def test_list_cameras_in_tool_spec_enum():
+    """The LLM-facing tool schema advertises list_cameras alongside the other lists."""
+    # Load the actual shipped tool_spec.json from the package.
+    import strands_robots.simulation.mujoco as mjpkg
+
+    ts = Path(mjpkg.__file__).parent / "tool_spec.json"
+    enum = json.load(open(ts))["properties"]["action"]["enum"]
+    assert "list_cameras" in enum
+    # parity with the sibling discovery actions
+    for sibling in ("list_robots", "list_objects", "list_bodies"):
+        assert sibling in enum


### PR DESCRIPTION
## Problem

The Newton backend exposes a public `list_cameras()` and advertises it in `describe()`, but the **default** MuJoCo backend has no such method:

- `sim.list_cameras()` raises `AttributeError` on the default backend.
- `describe()["cameras"]` is built from a raw `model.ncam` loop, so its contents depend on whether the loaded MJCF happens to bake a camera literally named `default`. The two backends therefore report **different camera sets for the same query**, and the built-in `"default"` free view that `render()` (its default argument!) always accepts can be **missing from discovery**.
- The agent action enum already has `list_robots` / `list_objects` / `list_bodies`, but `list_cameras` was the glaring omission — an agent can add/remove/render cameras on the default backend but cannot *list* them.

## Change

`MuJoCoSimEngine.list_cameras()` now returns every renderable camera name — `"default"` first, then all model-defined and `add_camera` cameras, deduplicated — mirroring Newton's contract. Then:

- `describe()["cameras"]` delegates to `list_cameras()`, so the two are always equal and `"default"` is always advertised, independent of the loaded MJCF.
- `describe()["methods"]` documents `list_cameras`.
- `list_cameras` is a dispatchable agent action (aliased to a tool-result `list_cameras_info`), added to the `tool_spec.json` enum + description, completing the scene discovery surface alongside `list_robots` / `list_objects` / `list_bodies`.

No rendering/behavior change — this is a pure discovery-surface addition (GL-free).

## Tests

`tests/simulation/mujoco/test_list_cameras_discovery.py` (6 tests, GL-free so they run in CI): `list_cameras()` exists and starts with `default`; a user camera appears once (default deduped); `describe()["cameras"] == list_cameras()` and advertises the method; the no-world case matches Newton (`["default"]`); the agent action dispatches to a success tool-result; and the tool_spec enum advertises it. All 6 **fail before** the change (`AttributeError` / `Unknown action` / not in enum) and pass after. Full `tests/simulation/mujoco` touched subset: 426 passed, 1 skipped; ruff + mypy clean on changed files.

## Visual proof

Every name `list_cameras()` returns is renderable — enumerated on a real SO-101 scene (built-in `default`, a `front` camera, and a `wrist` camera mounted on `so101/gripper`) and each rendered headlessly (`MUJOCO_GL=egl`):

![list_cameras montage](https://github.com/cagataycali/robots/releases/download/artifact-list-cameras-1783020985/list_cameras_montage.png)

## Changelog

**Round 2** (`272a4a4`): Close the `tool_spec.json` file handle in the enum test. The `json.load(open(ts))` idiom leaked the handle (CodeQL: "File is not always closed"); wrapped the read in a `with open(...)` context manager. Test-only, no behavior change. CI green; CodeQL alert auto-cleared.