### PR TITLE
test(mesh): cover bridge backend + release-close resilience in transport factory

### DIFF
--- a/tests/mesh/test_transport_factory.py
+++ b/tests/mesh/test_transport_factory.py
@@ -172,3 +172,60 @@ class TestThreadSafety:
                 assert len(results) == 8
                 assert all(r is results[0] for r in results)
                 assert factory._TRANSPORT_REFS == 8
+
+
+class TestBridgeBackendSelection:
+    """When STRANDS_MESH_BACKEND=bridge, the factory builds a BridgeTransport.
+
+    ``bridge`` is the third documented backend (Zenoh + IoT together). Its
+    factory-level construction path was previously unexercised, so a regression
+    that dropped it from ``_construct`` (or from ``_select_backend``'s allow
+    list) would go unnoticed while the two other backends stayed green.
+    """
+
+    def test_bridge_backend_constructs_bridge_transport(self, monkeypatch):
+        from strands_robots.mesh.transport.bridge_transport import BridgeTransport
+
+        monkeypatch.setenv("STRANDS_MESH_BACKEND", "bridge")
+        with patch.object(BridgeTransport, "connect", return_value=True):
+            with patch.object(BridgeTransport, "is_alive", return_value=True):
+                t = factory.get_transport()
+                assert t is not None
+                assert isinstance(t, BridgeTransport)
+                assert factory.current_backend() == "bridge"
+
+    def test_bridge_connect_failure_returns_none(self, monkeypatch):
+        from strands_robots.mesh.transport.bridge_transport import BridgeTransport
+
+        monkeypatch.setenv("STRANDS_MESH_BACKEND", "bridge")
+        with patch.object(BridgeTransport, "connect", return_value=False):
+            assert factory.get_transport() is None
+            assert factory._TRANSPORT is None
+            assert factory._TRANSPORT_REFS == 0
+
+
+class TestReleaseIsResilientToRaisingClose:
+    """Releasing the final reference must reset the singleton even when the
+    transport's ``close()`` raises.
+
+    ``release_transport`` runs during host teardown; a transport whose
+    ``close()`` throws (e.g. a Zenoh session already torn down by a signal
+    handler) must NOT propagate that exception or leave a stale singleton
+    installed. The factory swallows the error and clears its state so the next
+    ``get_transport`` starts clean.
+    """
+
+    def test_raising_close_is_swallowed_and_singleton_cleared(self, monkeypatch):
+        monkeypatch.setenv("STRANDS_MESH_BACKEND", "zenoh")
+        with patch.object(ZenohTransport, "connect", return_value=True):
+            with patch.object(ZenohTransport, "is_alive", return_value=True):
+                with patch.object(ZenohTransport, "close", side_effect=RuntimeError("session already gone")):
+                    factory.get_transport()
+                    assert factory._TRANSPORT_REFS == 1
+
+                    # Must not raise despite close() throwing on the last release.
+                    factory.release_transport()
+
+                    assert factory._TRANSPORT is None
+                    assert factory._TRANSPORT_REFS == 0
+                    assert factory._TRANSPORT_BACKEND == ""


### PR DESCRIPTION
## Problem
The process-wide mesh transport factory (`strands_robots/mesh/transport/factory.py`) documents three backends selected by `STRANDS_MESH_BACKEND`: `zenoh`, `iot`, and `bridge`. The existing suite pins `zenoh` and `iot` end to end but never exercises the `bridge` construction path through `get_transport()`, and `release_transport()`'s guard against a raising `close()` was untested. A regression that dropped `bridge` from `_construct` (or from `_select_backend`'s allow list), or that let a throwing `close()` leave a stale singleton installed during host teardown, would go unnoticed.

Uncovered lines pre-change: `_construct` bridge branch (66-68) and the `release_transport` close-resilience guard (119-120).

## Change
Add two focused test classes to `tests/mesh/test_transport_factory.py`:

- `TestBridgeBackendSelection` - mirrors the existing IoT coverage: `STRANDS_MESH_BACKEND=bridge` constructs a `BridgeTransport` (backend reported as `bridge`) on connect-success, and returns `None` without installing a singleton on connect-failure.
- `TestReleaseIsResilientToRaisingClose` - releasing the final reference when the transport's `close()` raises must swallow the error and reset the singleton (`_TRANSPORT=None`, refcount 0, backend cleared), so the next `get_transport()` starts clean.

Both assert observable contracts (return value / singleton state), use `monkeypatch.setenv`, and mock only the transport connect/close boundary - no real Zenoh/AWS, no host paths.

## Verification
- `factory.py` coverage 93% -> 100% (both remaining uncovered branches closed).
- `tests/mesh/test_transport_factory.py`: 17 passed.
- `ruff check` + `ruff format --check` clean.

Test-only change; no runtime behavior modified.