### PR TITLE
test(mesh): pin seq-flock graceful-degradation contract

### DIFF
--- a/tests/mesh/test_audit_seq_flock_degradation.py
+++ b/tests/mesh/test_audit_seq_flock_degradation.py
@@ -1,0 +1,112 @@
+"""Graceful-degradation contract for the cross-process seq flock.
+
+``strands_robots.mesh.audit._seq_flock`` serialises per-peer sequence-number
+allocation across processes with an ``flock``'d lockfile. Its documented
+contract splits failure modes in two:
+
+* An attacker pre-creating the lockfile as a symlink (``O_NOFOLLOW`` ->
+  ``ELOOP``) is a HARD failure -- it raises ``SeqLockSymlinkError`` so the
+  safety path records a poison record instead of silently downgrading the
+  cross-process guarantee. That path is pinned elsewhere
+  (``TestSeqFlockSymlinkRejection``).
+* Ordinary operational failures -- the lockfile directory cannot be created,
+  the lockfile cannot be opened for a non-symlink reason (``EACCES`` /
+  ``ENOSPC``), or the best-effort unlock / close in the ``finally`` block
+  fail -- must DEGRADE to yield-without-lock, never crash the caller. An
+  audit-lock failure must not propagate into the safety code path.
+
+These tests pin the degradation half of that contract.
+"""
+
+from __future__ import annotations
+
+import errno
+import pathlib
+
+import pytest
+
+from strands_robots.mesh import audit as mesh_audit
+
+pytestmark = pytest.mark.skipif(
+    not mesh_audit._HAS_FCNTL,
+    reason="cross-process seq flock requires POSIX fcntl (not available here)",
+)
+
+
+@pytest.fixture
+def audit_dir(tmp_path, monkeypatch):
+    """Redirect the audit directory (and thus the seq lockfile) to tmp_path."""
+    monkeypatch.setenv("STRANDS_MESH_AUDIT_DIR", str(tmp_path))
+    return tmp_path
+
+
+def test_lockfile_dir_mkdir_failure_degrades_to_no_lock(audit_dir, monkeypatch):
+    """An OSError creating the lockfile's parent dir yields without locking."""
+
+    def boom(self, *args, **kwargs):
+        raise OSError(errno.EACCES, "cannot create dir")
+
+    monkeypatch.setattr(pathlib.Path, "mkdir", boom)
+
+    entered = False
+    with mesh_audit._seq_flock():
+        entered = True
+    # The block ran despite the mkdir failure -- degraded, did not raise.
+    assert entered
+
+
+def test_non_symlink_open_failure_degrades_to_no_lock(audit_dir, monkeypatch):
+    """A non-ELOOP OSError opening the lockfile (e.g. EACCES) degrades, not raises."""
+    real_open = mesh_audit.os.open
+
+    def fake_open(path, flags, mode=0o777):
+        if str(path).endswith("mesh_audit.seq.lock"):
+            raise OSError(errno.EACCES, "permission denied")
+        return real_open(path, flags, mode)
+
+    monkeypatch.setattr(mesh_audit.os, "open", fake_open)
+
+    entered = False
+    with mesh_audit._seq_flock():
+        entered = True
+    assert entered
+
+
+def test_finally_swallows_unlock_and_close_errors(audit_dir, monkeypatch):
+    """Best-effort unlock + close failures in ``finally`` never surface to the caller."""
+    ops: list[int] = []
+
+    monkeypatch.setattr(mesh_audit.os, "open", lambda *a, **k: 4242)
+
+    def fake_flock(fd, op):
+        ops.append(op)
+        if op == mesh_audit.fcntl.LOCK_UN:
+            raise OSError(errno.EIO, "unlock failed")
+
+    def fake_close(fd):
+        raise OSError(errno.EIO, "close failed")
+
+    monkeypatch.setattr(mesh_audit.fcntl, "flock", fake_flock)
+    monkeypatch.setattr(mesh_audit.os, "close", fake_close)
+
+    entered = False
+    with mesh_audit._seq_flock():
+        entered = True
+
+    assert entered
+    # Exclusive lock was taken on entry and unlock attempted on exit.
+    assert mesh_audit.fcntl.LOCK_EX in ops
+    assert mesh_audit.fcntl.LOCK_UN in ops
+
+
+def test_symlink_open_still_hard_fails(audit_dir, monkeypatch):
+    """Contract boundary: an ELOOP (symlink) open is NOT degraded -- it raises."""
+
+    def fake_open(path, flags, mode=0o777):
+        raise OSError(errno.ELOOP, "symlink refused")
+
+    monkeypatch.setattr(mesh_audit.os, "open", fake_open)
+
+    with pytest.raises(mesh_audit.SeqLockSymlinkError):
+        with mesh_audit._seq_flock():
+            pass

--- a/tests/mesh/test_audit_seq_flock_degradation.py
+++ b/tests/mesh/test_audit_seq_flock_degradation.py
@@ -59,7 +59,7 @@ def test_non_symlink_open_failure_degrades_to_no_lock(audit_dir, monkeypatch):
     """A non-ELOOP OSError opening the lockfile (e.g. EACCES) degrades, not raises."""
     real_open = mesh_audit.os.open
 
-    def fake_open(path, flags, mode=0o777):
+    def fake_open(path, flags, mode=0o600):
         if str(path).endswith("mesh_audit.seq.lock"):
             raise OSError(errno.EACCES, "permission denied")
         return real_open(path, flags, mode)
@@ -102,7 +102,7 @@ def test_finally_swallows_unlock_and_close_errors(audit_dir, monkeypatch):
 def test_symlink_open_still_hard_fails(audit_dir, monkeypatch):
     """Contract boundary: an ELOOP (symlink) open is NOT degraded -- it raises."""
 
-    def fake_open(path, flags, mode=0o777):
+    def fake_open(path, flags, mode=0o600):
         raise OSError(errno.ELOOP, "symlink refused")
 
     monkeypatch.setattr(mesh_audit.os, "open", fake_open)


### PR DESCRIPTION
## Problem

The cross-process seq lock in `strands_robots.mesh.audit._seq_flock` serialises per-peer sequence-number allocation with an `flock`'d lockfile. Its docstring and inline comments define a deliberate two-way split of failure modes:

- An attacker pre-creating the lockfile as a symlink (`O_NOFOLLOW` -> `ELOOP`) is a **hard** failure: it raises `SeqLockSymlinkError` so the safety path records a `SEQ_LOCK_DEGRADED` poison record instead of silently downgrading the guarantee.
- Ordinary **operational** failures (lockfile dir cannot be created; lockfile open fails for a non-symlink reason such as `EACCES`/`ENOSPC`; best-effort unlock/close in the `finally` block fail) must **degrade to yield-without-lock** and never propagate into the safety code path that called the audit logger.

The hard-fail (ELOOP) branch was pinned, but the degradation half of the contract had no coverage: the `mkdir` failure, non-ELOOP open failure, and the `finally` best-effort unlock/close swallow paths were untested. A refactor could turn any of these into an exception that crashes the safety path with no test catching it.

## Change

Adds `tests/mesh/test_audit_seq_flock_degradation.py` pinning the degradation contract:

- `mkdir` `OSError` on the lockfile dir -> context manager still yields (no lock, no raise).
- Non-ELOOP open `OSError` (`EACCES`) -> yields without lock, does not raise.
- `finally` unlock (`fcntl.flock(LOCK_UN)`) and `os.close` raising `OSError` are swallowed; the caller sees a clean exit and the exclusive lock was still taken on entry.
- Boundary check: an `ELOOP` open still hard-fails with `SeqLockSymlinkError` (asserts the two branches stay distinct).

Tests skip cleanly on platforms without POSIX `fcntl`.

## Coverage

`strands_robots/mesh/audit.py`: previously-uncovered lines 390-393, 430-432, 439-441, 444-446 are now exercised. Tests-only; no source change.

## Testing

- `pytest tests/mesh/test_audit_seq_flock_degradation.py` -> 4 passed.
- Full `pytest tests/mesh/` -> 1955 passed, 2 skipped (no regressions).
- `ruff check` / `ruff format --check` / `mypy` clean.

## Changelog

### Round 1 (review feedback)

- Static analysis flagged the `fake_open` test doubles for an overly-permissive default `mode=0o777`. In `test_non_symlink_open_failure` that mode is forwarded to the real `os.open` for non-lockfile paths, so it could create a world-writable file. Tightened both fake_open defaults to `0o600` (owner-only), the correct mask for a private lockfile. No change to the pinned degradation contract or assertions.