### PR TITLE
fix(sim): inverse_dynamics solves for zero desired acceleration (gravity/bias compensation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -215,6 +215,20 @@ documents it, and `list_cameras` is a dispatchable agent action alongside
 surface on the default backend.
 
 
+### Fixed: `inverse_dynamics` reported ~0 torques regardless of pose (stale `qacc`)
+
+`inverse_dynamics()` runs `mj_inverse`, which reads `data.qacc` as the
+*desired* acceleration. The method used whatever value was left in `qacc` by
+the previous forward pass -- the unforced free-fall acceleration -- and so
+asked `mj_inverse` to reproduce free-fall, which needs ~0 generalized force.
+It therefore returned near-zero torques at every pose instead of the
+gravity-/velocity-bias-compensation torques the query exists to provide (the
+standard "hold this configuration" inverse-dynamics result). It now runs
+`mj_forward` first (so the position/velocity kinematics match the current
+`qpos`/`qvel`, matching the defensive forward in `get_mass_matrix`), zeroes
+`qacc` for the solve, and restores the buffer afterwards, so the result is
+correct and independent of any leftover acceleration.
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/docs/simulation/overview.md
+++ b/docs/simulation/overview.md
@@ -99,7 +99,7 @@ Newton backend, so a rollout rig can be enumerated instead of guessed.
 | `apply_force` | `body_name`, `force`, `torque`, `point` |
 | `get_jacobian` | `body_name` *or* `site_name` *or* `geom_name` |
 | `get_mass_matrix` | - |
-| `inverse_dynamics` | - |
+| `inverse_dynamics` | - (compensation torques to hold the current `qpos`/`qvel`) |
 | `forward_kinematics` | `body_name` (optional) |
 | `save_state` / `load_state` | snapshot/restore full physics |
 | `get_energy` | - |

--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -516,10 +516,22 @@ class PhysicsMixin:
     # Inverse Dynamics
 
     def inverse_dynamics(self) -> dict[str, Any]:
-        """Compute inverse dynamics: given qacc, what forces are needed?
+        """Compute the generalized forces required to hold the current state.
 
-        Runs mj_inverse to compute qfrc_inverse - the generalized forces
-        that would produce the current accelerations.
+        Runs ``mj_inverse`` for a target acceleration of zero, so the result
+        is the gravity- and velocity-bias (Coriolis/centrifugal) compensation
+        torques that keep the robot at its current ``qpos``/``qvel`` with zero
+        acceleration - the standard inverse-dynamics query for a manipulator
+        (at rest, pure gravity compensation).
+
+        ``mj_inverse`` reads ``data.qacc`` as the *desired* acceleration, so
+        this method runs ``mj_forward`` first (so the position/velocity
+        kinematics match the current ``qpos``/``qvel``, matching the defensive
+        forward in ``get_mass_matrix``) and zeroes ``qacc`` for the solve,
+        restoring the buffer afterwards. Without this it would use whatever
+        stale forward-dynamics acceleration was left in ``data.qacc`` and ask
+        ``mj_inverse`` to reproduce free-fall - returning ~0 forces regardless
+        of pose, never the compensation torques the query is for.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
@@ -528,14 +540,22 @@ class PhysicsMixin:
         model, data = self._world._model, self._world._data
 
         with self._lock:
-            mj.mj_inverse(model, data)
-            # Build named force mapping
-            forces = {}
-            for i in range(model.njnt):
-                name = mj.mj_id2name(model, mj.mjtObj.mjOBJ_JOINT, i)
-                if name:
-                    dof_adr = model.jnt_dofadr[i]
-                    forces[name] = float(data.qfrc_inverse[dof_adr])
+            # Establish consistent position/velocity kinematics for the current
+            # state, then solve inverse dynamics for zero desired acceleration.
+            mj.mj_forward(model, data)
+            saved_qacc = data.qacc.copy()
+            data.qacc[:] = 0.0
+            try:
+                mj.mj_inverse(model, data)
+                # Build named force mapping
+                forces = {}
+                for i in range(model.njnt):
+                    name = mj.mj_id2name(model, mj.mjtObj.mjOBJ_JOINT, i)
+                    if name:
+                        dof_adr = model.jnt_dofadr[i]
+                        forces[name] = float(data.qfrc_inverse[dof_adr])
+            finally:
+                data.qacc[:] = saved_qacc
 
         return {
             "status": "success",

--- a/tests/simulation/mujoco/test_physics.py
+++ b/tests/simulation/mujoco/test_physics.py
@@ -312,12 +312,67 @@ class TestStateCheckpointing:
 
 
 class TestInverseDynamics:
+    @staticmethod
+    def _gravity_compensation(model, data):
+        """Ground-truth compensation torques: mj_inverse for zero desired qacc."""
+        mj.mj_forward(model, data)
+        data.qacc[:] = 0.0
+        mj.mj_inverse(model, data)
+        return {
+            mj.mj_id2name(model, mj.mjtObj.mjOBJ_JOINT, i): float(data.qfrc_inverse[model.jnt_dofadr[i]])
+            for i in range(model.njnt)
+            if mj.mj_id2name(model, mj.mjtObj.mjOBJ_JOINT, i)
+        }
+
     def test_inverse_dynamics(self, sim):
-        mj.mj_forward(sim._world._model, sim._world._data)
         result = sim.inverse_dynamics()
         assert result["status"] == "success"
         forces = _extract_json_block(result, 1)["qfrc_inverse"]
         assert "shoulder" in forces or "elbow" in forces
+
+    def test_inverse_dynamics_returns_gravity_compensation(self, sim):
+        """inverse_dynamics reports the torques that HOLD the current pose.
+
+        Regression: previously it read the stale forward-dynamics ``qacc``
+        (the unforced/free-fall acceleration) as the desired acceleration and
+        asked ``mj_inverse`` to reproduce free-fall - which needs ~0 force. It
+        therefore reported near-zero torques regardless of pose instead of the
+        gravity-/bias-compensation torques the query is for.
+        """
+        model, data = sim._world._model, sim._world._data
+        # A gravity-loaded pose (arm tilted away from the vertical).
+        sim.set_joint_positions({"shoulder": 0.8, "elbow": -0.5})
+
+        forces = _extract_json_block(sim.inverse_dynamics(), 1)["qfrc_inverse"]
+
+        # Ground truth computed independently AFTER the call (the fixed method
+        # forwards + restores qacc, so state is unchanged for this compare).
+        expected = self._gravity_compensation(model, data)
+        for jn in ("shoulder", "elbow"):
+            assert forces[jn] == pytest.approx(expected[jn], abs=1e-9)
+
+        # The shoulder carries a real gravity load in this pose; the buggy
+        # free-fall path returned ~0 here, so this discriminates the fix.
+        assert abs(forces["shoulder"]) > 1e-2
+
+    def test_inverse_dynamics_ignores_stale_qacc(self, sim):
+        """The result must not depend on leftover free-fall qacc.
+
+        Stepping (or a prior forward) leaves ``data.qacc`` holding the
+        forward-dynamics acceleration. inverse_dynamics must zero it for the
+        solve, so back-to-back calls are identical and independent of that
+        buffer.
+        """
+        sim.set_joint_positions({"shoulder": 0.6, "elbow": 0.4})
+        first = _extract_json_block(sim.inverse_dynamics(), 1)["qfrc_inverse"]
+
+        # Perturb the leftover qacc buffer directly; the answer must not move.
+        sim._world._data.qacc[:] = 123.4
+        second = _extract_json_block(sim.inverse_dynamics(), 1)["qfrc_inverse"]
+
+        for jn in ("shoulder", "elbow"):
+            assert first[jn] == pytest.approx(second[jn], abs=1e-9)
+        assert abs(first["shoulder"]) > 1e-2
 
 
 class TestBodyState:


### PR DESCRIPTION
## Problem

`Simulation.inverse_dynamics()` runs `mj_inverse`, which reads `data.qacc` as the **desired** acceleration. The method used whatever value the previous forward pass left in `qacc` — the *unforced/free-fall* acceleration — and never established a consistent state first. It therefore asked `mj_inverse` to reproduce free-fall, which requires ~0 generalized force, and so returned **near-zero torques at every pose** instead of the gravity/velocity-bias compensation torques the query exists to provide.

On an so101 held at a gravity-loaded pose the method reported `so101/2: 0.0` where the true compensation torque is `-0.805 N·m`; at rest it reported all zeros. Sibling dynamics queries (`get_mass_matrix`, `load_state`) already run a defensive `mj_forward`; this one did not.

## Fix

Run `mj_forward` first (so the position/velocity kinematics match the current `qpos`/`qvel`), zero `qacc` for the solve, and restore the buffer afterwards. The result is now the correct compensation torques (gravity + Coriolis/centrifugal at the current velocity; pure gravity compensation at rest) and is independent of any leftover acceleration. No signature or return-shape change.

## Verification

The returned torques feed a gravity-compensation controller: applied as feed-forward, the corrected torques hold the arm exactly, while the old ~0 torques let it collapse under gravity.

| feed-forward torques from `inverse_dynamics` | shoulder drift over 140 steps |
|---|---|
| old (~0) | **+0.837 rad** (arm collapses) |
| fixed | **+0.000 rad** (holds) |

![inverse_dynamics gravity compensation: left collapses, right holds](https://github.com/cagataycali/robots/releases/download/artifact-idyn-gravcomp-1783031242/idyn_demo.gif)

_Left (red): old ~0 torques. Right (green): fixed compensation torques. MuJoCo, headless render._

## Tests

`tests/simulation/mujoco/test_physics.py::TestInverseDynamics` (GL-free, runs in CI):
- `test_inverse_dynamics_returns_gravity_compensation` — reported torques equal an independent `mj_inverse(qacc=0)` solve and are non-zero on a gravity-loaded joint.
- `test_inverse_dynamics_ignores_stale_qacc` — perturbing the leftover `qacc` buffer does not change the result.

Both fail on the pre-fix code (reported `0.0` vs true `-0.179`; the injected `qacc` leaks a `2.7e14 N·m` garbage torque) and pass after. Full `test_physics.py` (65 tests) green; ruff + mypy clean on the changed files.