### PR TITLE
fix(sim): register mesh assets on runtime add_object(shape="mesh") injection

### DIFF
--- a/docs/simulation/world-building.md
+++ b/docs/simulation/world-building.md
@@ -40,6 +40,23 @@ for i in range(5):
     )
 ```
 
+## Mesh objects
+
+Beyond primitives, `add_object` can inject a triangle-mesh asset (STL/OBJ) into
+the live scene at runtime. Pass `shape="mesh"` with a `mesh_path` to the asset
+file; the extent is defined by the mesh's own units, so `size` is ignored.
+
+```python
+sim.add_object(name="bracket", shape="mesh", mesh_path="/abs/path/bracket.stl",
+               position=[0.3, 0.0, 0.1])
+```
+
+`mesh_path` is required for `shape="mesh"` - a mesh without a path is rejected
+with an actionable error rather than an opaque recompile failure. If the mesh
+file cannot be loaded the add is rejected and the scene is rolled back to its
+previous compilable state (including the mesh asset), so the object name stays
+reusable and one bad add never bricks later scene edits.
+
 ## Materials and textures
 
 By default an object renders with a flat `color` (rgba) - a glossy, obviously

--- a/strands_robots/simulation/mujoco/scene_ops.py
+++ b/strands_robots/simulation/mujoco/scene_ops.py
@@ -150,10 +150,18 @@ def inject_robot_into_scene(
 def inject_object_into_scene(world: SimWorld, obj: SimObject) -> bool:
     """Add a ``SimObject`` to the scene and recompile in place.
 
+    A ``shape="mesh"`` object references a mesh asset that must be registered
+    on the spec before the geom that names it can compile. The full-scene
+    ``SpecBuilder.build`` registers those assets in its own pass, but the
+    incremental path (``SpecBuilder.add_object``) does not, so this function
+    registers the mesh (``spec.add_mesh(name=f"mesh_{obj.name}", ...)``) itself
+    before adding the body. Without this, ``add_object(shape="mesh")`` at
+    runtime always failed to recompile even for a valid mesh file.
+
     ``SpecBuilder.add_object`` mutates the spec (adds the body + geom) before
     the recompile that validates it. If that recompile is refused - e.g. the
-    object references a mesh asset that was never registered - the orphan body
-    is deleted again before returning ``False`` so the spec stays compilable.
+    mesh file cannot be loaded - the just-added body AND its mesh asset are
+    deleted again before returning ``False`` so the spec stays compilable.
     Without the rollback the orphan lingers and every later scene mutation,
     including a corrected retry under the same name, keeps failing to recompile
     (``repeated name`` collisions), bricking the whole scene after one bad add.
@@ -164,16 +172,24 @@ def inject_object_into_scene(world: SimWorld, obj: SimObject) -> bool:
         return False
 
     try:
+        # Meshes need their asset registered before the geom references it.
+        # build() registers meshes in a separate pass, so add_object does not;
+        # the incremental path must register it here.
+        if obj.shape == "mesh" and obj.mesh_path:
+            spec.add_mesh(name=f"mesh_{obj.name}", file=obj.mesh_path)
         SpecBuilder.add_object(spec, obj)
     except (ValueError, RuntimeError) as e:
         logger.error("Object add failed for '%s': %s", obj.name, e)
+        SpecBuilder.remove_mesh(spec, f"mesh_{obj.name}")
         return False
 
     if not _recompile_preserving_state(world, spec):
-        # Roll the just-added body back out so the spec returns to its last
-        # good, compilable state (a worldbody body delete is safe - the
-        # attach/delete segfault only affects spec.attach() child specs).
+        # Roll the just-added body (and any mesh asset) back out so the spec
+        # returns to its last good, compilable state (a worldbody body delete
+        # is safe - the attach/delete segfault only affects spec.attach()
+        # child specs).
         SpecBuilder.remove_body(spec, obj.name)
+        SpecBuilder.remove_mesh(spec, f"mesh_{obj.name}")
         return False
     return True
 
@@ -217,6 +233,11 @@ def eject_body_from_scene(world: SimWorld, body_name: str) -> bool:
         # Matching legacy behaviour: return True so scene state stays consistent
         # (caller has already popped the Python-side dict entry).
         return True
+
+    # Objects added at runtime register a mesh asset named f"mesh_{name}".
+    # Delete it too so the name is fully reusable and unused assets do not
+    # accumulate across remove/re-add cycles (safe no-op for primitives).
+    SpecBuilder.remove_mesh(spec, f"mesh_{body_name}")
 
     return _recompile_preserving_state(world, spec)
 

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1480,8 +1480,8 @@ class MuJoCoSimEngine(
         Returns:
             Agent-tool status dict. ``{"status": "success", ...}`` on success;
             ``{"status": "error", ...}`` when no world exists, a policy is
-            running, the name is taken, ``size`` has a non-positive extent, or
-            the recompile fails.
+            running, the name is taken, ``size`` has a non-positive extent,
+            ``shape="mesh"`` is missing ``mesh_path``, or the recompile fails.
 
         Example:
             >>> sim.add_object("cube", shape="box", size=[0.05, 0.05, 0.05])  # 5 cm cube
@@ -1520,6 +1520,15 @@ class MuJoCoSimEngine(
             is_static = True
         elif is_static is None:
             is_static = False
+
+        # A mesh geom names an asset that must be loaded from a file; without a
+        # path there is nothing to register, so fail fast with an actionable
+        # message rather than letting the recompile refuse the unresolved geom.
+        if shape == "mesh" and not mesh_path:
+            return {
+                "status": "error",
+                "content": [{"text": "add_object: shape='mesh' requires mesh_path (path to an STL/OBJ asset)."}],
+            }
 
         # 'size' is the full extent in meters per the docstring; reject a
         # non-positive (degenerate) extent before mutating scene state so the

--- a/strands_robots/simulation/mujoco/spec_builder.py
+++ b/strands_robots/simulation/mujoco/spec_builder.py
@@ -610,6 +610,28 @@ class SpecBuilder:
                 return True
         return False
 
+    # mesh remove
+    @staticmethod
+    def remove_mesh(spec: Any, name: str) -> bool:
+        """Remove a mesh asset by name from the spec.
+
+        Objects added at runtime through ``inject_object_into_scene`` register
+        a mesh asset named ``f"mesh_{obj.name}"``. Removing the body alone
+        leaves that asset orphaned in the spec, so a later add under the same
+        name would collide on a duplicate mesh at recompile. This deletes the
+        asset so the name stays fully reusable. Returns ``True`` if the mesh
+        existed and was removed, ``False`` otherwise (safe no-op for
+        primitive-shape objects that never registered a mesh).
+        """
+        try:
+            mesh = spec.mesh(name)
+        except (KeyError, ValueError):
+            return False
+        if mesh is None:
+            return False
+        spec.delete(mesh)
+        return True
+
     # -attach
     @staticmethod
     def attach_robot(

--- a/tests/simulation/mujoco/test_runtime_mesh_injection.py
+++ b/tests/simulation/mujoco/test_runtime_mesh_injection.py
@@ -1,0 +1,122 @@
+"""Runtime injection of ``shape="mesh"`` objects into a live MuJoCo scene.
+
+A mesh geom names a mesh asset that must be registered on the ``MjSpec`` before
+the geom can compile. The full-scene ``SpecBuilder.build`` registers those
+assets in a dedicated pass, but the incremental scene-edit path
+(``inject_object_into_scene`` -> ``SpecBuilder.add_object``) historically did
+not, so ``Simulation.add_object(shape="mesh", mesh_path=...)`` at runtime always
+failed to recompile - even for a valid mesh file - and reported the opaque
+"spec recompile refused". These tests pin the behaviour that the incremental
+path now registers the mesh, that a missing ``mesh_path`` fails fast with an
+actionable message, and that a failed add rolls the mesh asset back out so the
+name stays reusable and the scene is not bricked.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+# A minimal but valid triangle mesh (tetrahedron) MuJoCo can load.
+_TETRA_OBJ = """v 0.0 0.0 0.0
+v 0.05 0.0 0.0
+v 0.0 0.05 0.0
+v 0.0 0.0 0.05
+f 1 3 2
+f 1 2 4
+f 1 4 3
+f 2 3 4
+"""
+
+
+@pytest.fixture
+def mesh_file(tmp_path: Path) -> str:
+    p = tmp_path / "tetra.obj"
+    p.write_text(_TETRA_OBJ)
+    return str(p)
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="devx_runtime_mesh", mesh=False)
+    s.create_world()
+    s.add_robot("so100")  # a compiled world the injector can recompile against
+    try:
+        yield s
+    finally:
+        s.cleanup(policy_stop_timeout=0.5)
+
+
+class TestRuntimeMeshInjection:
+    def test_valid_mesh_object_is_added(self, sim, mesh_file):
+        """add_object(shape='mesh', mesh_path=<valid>) succeeds and registers the asset.
+
+        Pre-fix this returned an error ("spec recompile refused") because the
+        incremental path never called spec.add_mesh.
+        """
+        result = sim.add_object(name="widget", shape="mesh", mesh_path=mesh_file, position=[0.3, 0.0, 0.1])
+        assert result["status"] == "success"
+        assert "widget" in sim._world.objects
+
+        import mujoco as mj
+
+        model = sim._world._model
+        assert mj.mj_name2id(model, mj.mjtObj.mjOBJ_BODY, "widget") >= 0
+        # The mesh asset the geom references is registered on the live spec.
+        spec = sim._world._backend_state["spec"]
+        assert "mesh_widget" in [m.name for m in spec.meshes]
+
+    def test_mesh_without_path_fails_fast(self, sim):
+        """A mesh with no mesh_path is rejected up front with an actionable error."""
+        result = sim.add_object(name="nopath", shape="mesh")
+        assert result["status"] == "error"
+        text = result["content"][0]["text"].lower()
+        assert "mesh_path" in text
+        # Fail-fast means the scene was never mutated.
+        assert "nopath" not in sim._world.objects
+
+    def test_bad_mesh_rolls_back_asset_and_name_is_reusable(self, sim, mesh_file):
+        """A mesh file that fails to compile rolls the asset back; the name is reusable.
+
+        A leaked mesh asset would collide on a duplicate mesh name when the same
+        object name is retried with a valid file, so a successful mesh retry
+        proves the rollback removed the orphan asset.
+        """
+        bad = sim.add_object(name="widget", shape="mesh", mesh_path="/nonexistent/does-not-exist.stl")
+        assert bad["status"] == "error"
+        assert "widget" not in sim._world.objects
+
+        spec = sim._world._backend_state["spec"]
+        assert "mesh_widget" not in [m.name for m in spec.meshes]
+
+        retry = sim.add_object(name="widget", shape="mesh", mesh_path=mesh_file, position=[0.3, 0.0, 0.1])
+        assert retry["status"] == "success"
+        assert "widget" in sim._world.objects
+
+    def test_remove_then_readd_mesh_under_same_name(self, sim, mesh_file):
+        """Removing a mesh object frees its asset so the same name can be re-added.
+
+        remove_object must delete the f"mesh_{name}" asset, otherwise a re-add
+        collides on the duplicate mesh name at recompile.
+        """
+        assert sim.add_object(name="widget", shape="mesh", mesh_path=mesh_file)["status"] == "success"
+        assert sim.remove_object("widget")["status"] == "success"
+
+        spec = sim._world._backend_state["spec"]
+        assert "mesh_widget" not in [m.name for m in spec.meshes]
+
+        readd = sim.add_object(name="widget", shape="mesh", mesh_path=mesh_file, position=[0.2, 0.1, 0.1])
+        assert readd["status"] == "success"
+
+    def test_primitive_add_after_bad_mesh_still_works(self, sim):
+        """A failed mesh add must not brick later primitive adds (scene stays compilable)."""
+        bad = sim.add_object(name="bad", shape="mesh", mesh_path="/nope.stl")
+        assert bad["status"] == "error"
+        ok = sim.add_object(name="cube", shape="box", position=[0.2, 0.1, 0.1])
+        assert ok["status"] == "success"
+        assert "cube" in sim._world.objects


### PR DESCRIPTION
## Problem

`Simulation.add_object(shape="mesh", mesh_path=...)` always failed at runtime, even with a valid mesh file, reporting the opaque error `Failed to inject '<name>': spec recompile refused`.

A mesh geom names a mesh asset (`mesh_<name>`) that must be registered on the `MjSpec` before the geom can compile. `SpecBuilder.build` (full-scene build) registers those assets in a dedicated pass, but the incremental scene-edit path (`inject_object_into_scene` -> `SpecBuilder.add_object`) never did. So the geom referenced an asset that did not exist and every recompile was refused. Runtime mesh injection was effectively dead despite `mesh_path` being a documented, supported `add_object` parameter.

## Change

- `inject_object_into_scene` now registers the mesh asset (`spec.add_mesh(name=f"mesh_{obj.name}", file=...)`) before adding the body. `build()` is left untouched so the two paths do not double-register the same mesh name.
- On a refused recompile (e.g. an unloadable mesh file), the body **and** its mesh asset are rolled back, so the scene returns to its last compilable state and the object name stays reusable. A leaked asset would otherwise collide on a duplicate mesh name at the next recompile and brick further edits.
- `eject_body_from_scene` deletes the `mesh_<name>` asset too, so remove/re-add cycles under the same name work.
- The facade `add_object` now rejects `shape="mesh"` without a `mesh_path` up front with an actionable message (`add_object: shape='mesh' requires mesh_path ...`) instead of letting the recompile fail opaquely.
- New `SpecBuilder.remove_mesh` helper.

No change to any success-path signature, return shape, wire format, or persisted schema.

## Tests

`tests/simulation/mujoco/test_runtime_mesh_injection.py` (5 tests): valid mesh add succeeds and registers the asset; missing `mesh_path` fails fast; an unloadable mesh rolls back and the name is reusable; remove-then-re-add under the same name works; a failed mesh add does not brick later primitive adds. 4 of the 5 fail on pre-fix code (the 5th is a guardrail that legitimately stayed green). Full local gate is clean: `ruff check`, `ruff format --check`, `mypy strands_robots tests tests_integ` (no issues in 646 files), and the affected sim suites (183 tests) pass under `MUJOCO_GL=egl`.

## Visual

Three mesh objects (plus a primitive box) injected into a live scene at runtime with an SO-100 arm, rendered headless in MuJoCo (`MUJOCO_GL=egl`). This scene could not be constructed before the fix.

![runtime mesh injection](https://github.com/cagataycali/robots/releases/download/artifact-runtime-mesh-injection-1783034426/mesh_injection.png)

## Docs

`docs/simulation/world-building.md` gains a "Mesh objects" section documenting runtime mesh injection, the `mesh_path` requirement, and the rollback guarantee; the `add_object` docstring error list is updated.