### PR TITLE
test(sim): pin patch_scene_mjcf rollback-restore-failure contract

### DIFF
--- a/tests/simulation/mujoco/test_scene_patch_rollback_restore_failure.py
+++ b/tests/simulation/mujoco/test_scene_patch_rollback_restore_failure.py
@@ -1,0 +1,92 @@
+"""Contract tests for ``patch_scene_mjcf`` rollback when the restore itself fails.
+
+``patch_scene_mjcf`` applies a batch of structured ops to the live ``MjSpec``
+atomically: if any op raises, the mutated spec is discarded and the world is
+rolled back to a pre-patch XML snapshot. The happy rollback (snapshot restores
+cleanly) is covered elsewhere; this module pins the *degraded* branch where the
+rollback's own ``SpecBuilder.from_mjcf_string(backup_xml)`` restore raises.
+
+The contract in that branch is twofold:
+
+1. The ORIGINAL op failure is surfaced to the caller - a restore failure must
+   not mask why the patch was rejected in the first place.
+2. The live compiled model/data are left intact (the batch never recompiled),
+   so the world remains steppable even though the cached spec could not be
+   swapped back to the clean snapshot.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+
+from strands_robots.simulation.mujoco import scene_ops  # noqa: E402
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="devx_patch_rollback", mesh=False)
+    try:
+        yield s
+    finally:
+        s.cleanup(policy_stop_timeout=0.5)
+
+
+class TestPatchRollbackRestoreFailure:
+    def test_restore_failure_surfaces_original_op_error(self, sim: Simulation, monkeypatch) -> None:
+        """A failing rollback-restore must not hide the original op error."""
+        sim.create_world()
+        assert sim._world is not None
+
+        def _boom(_xml: str):
+            raise RuntimeError("snapshot round-trip unavailable")
+
+        # Only the rollback path calls from_mjcf_string during a patch; the
+        # backup snapshot itself is taken via spec.to_xml(), not this function.
+        monkeypatch.setattr(scene_ops.SpecBuilder, "from_mjcf_string", staticmethod(_boom))
+
+        result = sim.patch_scene_mjcf(
+            [
+                {"op": "add_body", "name": "doomed", "pos": [0, 0, 1]},
+                {"op": "totally_made_up", "name": "whatever"},
+            ]
+        )
+
+        assert result["status"] == "error"
+        message = result["content"][0]["text"].lower()
+        # The caller sees which op failed and why - not the restore failure.
+        assert "patch op #2" in message
+        assert "snapshot round-trip unavailable" not in message
+
+    def test_restore_failure_leaves_live_model_steppable(self, sim: Simulation, monkeypatch) -> None:
+        """Even when restore fails, the pre-patch model is never recompiled away."""
+        sim.create_world()
+        assert sim._world is not None
+        mj = sim._mj
+        nbody_before = sim._world._model.nbody
+
+        monkeypatch.setattr(
+            scene_ops.SpecBuilder,
+            "from_mjcf_string",
+            staticmethod(lambda _xml: (_ for _ in ()).throw(RuntimeError("no restore"))),
+        )
+
+        result = sim.patch_scene_mjcf(
+            [
+                {"op": "add_body", "name": "doomed", "pos": [0, 0, 1]},
+                {"op": "totally_made_up", "name": "whatever"},
+            ]
+        )
+        assert result["status"] == "error"
+
+        # The half-applied batch never recompiled, so the live model is unchanged
+        # and the doomed body from op #1 is absent.
+        assert sim._world is not None
+        assert sim._world._model.nbody == nbody_before
+        assert mj.mj_name2id(sim._world._model, mj.mjtObj.mjOBJ_BODY, "doomed") == -1
+
+        # And the world still steps without raising.
+        sim.step(1)


### PR DESCRIPTION
## Problem

`patch_scene_mjcf` applies a batch of structured MJCF ops to the live `MjSpec` atomically: if any op raises, the mutated spec is discarded and the world is rolled back to a pre-patch XML snapshot via `SpecBuilder.from_mjcf_string(backup_xml)`. The happy rollback (snapshot restores cleanly) is covered by `test_failed_op_rolls_back_whole_batch`, but the *degraded* branch - where the rollback's own restore raises - was unpinned (`scene_ops.py` lines 726-730, the inner `except Exception: pass`).

That branch encodes a subtle correctness contract that was not asserted anywhere: a failing restore must not swallow or mask the original op error, and the live compiled model must not be left corrupted.

## Change

Adds `tests/simulation/mujoco/test_scene_patch_rollback_restore_failure.py` with two focused tests that pin the contract for the restore-failure branch:

1. **Original error surfaces** - with `SpecBuilder.from_mjcf_string` monkeypatched to raise during rollback, the caller still sees `patch op #2 failed: ...` (the real reason the batch was rejected), never the restore exception.
2. **Live model stays intact / steppable** - because the batch never reaches the single end-of-batch `recompile`, the pre-patch model is unchanged (the half-applied `doomed` body is absent) and `sim.step(1)` still runs.

Test-only; no production code changes.

## Verification

```
MUJOCO_GL=egl pytest tests/simulation/mujoco/test_patch_scene_mjcf.py \
  tests/simulation/mujoco/test_scene_patch_rollback_restore_failure.py \
  tests/simulation/mujoco/test_scene_ops_guardrails.py
# 46 passed
```

Coverage on `strands_robots/simulation/mujoco/scene_ops.py`: lines 726-730 move from uncovered to covered (the pre-existing happy-rollback test already covers 724-725/731). `ruff check` + `ruff format --check` clean.