### PR TITLE
fix(sim): get_jacobian / get_body_state reflect the current qpos/qvel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -229,6 +229,23 @@ standard "hold this configuration" inverse-dynamics result). It now runs
 `qacc` for the solve, and restores the buffer afterwards, so the result is
 correct and independent of any leftover acceleration.
 
+### Fixed: `get_jacobian` / `get_body_state` returned values for a stale configuration
+
+Both physics-query methods read derived MuJoCo state without first running the
+forward pipeline. `get_jacobian` reads `data.xpos`/`site_xpos`/`geom_xpos`,
+`data.subtree_com` and `data.cdof`; `get_body_state` reads `data.xpos`/`xquat`/
+`xmat`/`xipos` and, via `mj_objectVelocity`, `data.cvel`. All of these are only
+recomputed by a forward pass, so after any state change that did not itself
+forward -- a direct `data.qpos` write, or `set_joint_velocities` (which writes
+`qvel` without forwarding) -- the methods silently returned the Jacobian /
+pose / 6D velocity of an *earlier* state while reporting `status="success"`.
+`get_body_state` even disagreed with its sibling `forward_kinematics` on the
+same body at the same `qpos`. `get_jacobian` now recomputes the position
+pipeline (`mj_kinematics` + `mj_comPos`, matching `forward_kinematics`) and
+`get_body_state` runs a full `mj_forward` (matching `get_mass_matrix` /
+`inverse_dynamics` / `get_sensor_data`), so both always reflect the current
+`qpos`/`qvel`.
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -401,7 +401,9 @@ class PhysicsMixin:
         The Jacobian maps joint velocities to Cartesian velocities:
             v = J @ dq
 
-        Returns both positional (3×nv) and rotational (3×nv) Jacobians.
+        Returns both positional (3×nv) and rotational (3×nv) Jacobians,
+        computed at the current ``qpos`` (the position pipeline is recomputed
+        first so the result is never a stale earlier configuration).
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
@@ -413,6 +415,14 @@ class PhysicsMixin:
         jacr = np.zeros((3, model.nv))
 
         with self._lock:
+            # Reflect the CURRENT configuration. mj_jac* read data.xpos/site_xpos/
+            # geom_xpos, data.subtree_com and data.cdof, all of which are stale if
+            # qpos changed since the last forward (e.g. a direct data.qpos write or
+            # set_joint_velocities). Recompute the position pipeline first so the
+            # Jacobian is not silently that of an earlier pose. Matches
+            # forward_kinematics; cheaper than a full mj_forward.
+            mj.mj_kinematics(model, data)
+            mj.mj_comPos(model, data)
             if body_name:
                 obj_id = self._resolve_mj_name(mj.mjtObj.mjOBJ_BODY, body_name)
                 if obj_id < 0:
@@ -573,7 +583,9 @@ class PhysicsMixin:
     ) -> dict[str, Any]:
         """Get the full state of a body: position, orientation, velocity, acceleration.
 
-        Returns Cartesian pose + 6D spatial velocity (linear + angular).
+        Returns Cartesian pose + 6D spatial velocity (linear + angular),
+        computed at the current ``qpos``/``qvel`` (the forward pipeline is run
+        first so pose and velocity are never a stale earlier state).
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
@@ -586,6 +598,14 @@ class PhysicsMixin:
             return {"status": "error", "content": [{"text": f"Body '{body_name}' not found."}]}
 
         with self._lock:
+            # Reflect the CURRENT qpos/qvel. This reads data.xpos/xquat/xmat/xipos
+            # (position pipeline) and data.cvel via mj_objectVelocity (velocity
+            # pipeline); both are stale if state changed since the last forward
+            # (e.g. set_joint_velocities writes qvel without forwarding, or a
+            # direct data.qpos write). Run the full pipeline so pose AND 6D
+            # velocity are consistent with the current state. Matches
+            # get_mass_matrix / inverse_dynamics / get_sensor_data.
+            mj.mj_forward(model, data)
             # Position and orientation
             pos = data.xpos[body_id].tolist()
             quat = data.xquat[body_id].tolist()

--- a/tests/simulation/mujoco/test_physics.py
+++ b/tests/simulation/mujoco/test_physics.py
@@ -144,6 +144,36 @@ class TestJacobians:
         result = sim.get_jacobian(body_name="nonexistent")
         assert result["status"] == "error"
 
+    def test_jacobian_reflects_current_configuration(self, sim):
+        """get_jacobian must be the Jacobian of the CURRENT qpos.
+
+        Regression: it read data.xpos/site_xpos/subtree_com/cdof left by an
+        earlier forward and never re-ran the position pipeline, so after a
+        qpos change that did not itself forward (here a direct data.qpos
+        write) it returned the OLD configuration's Jacobian while reporting
+        success.
+        """
+        model, data = sim._world._model, sim._world._data
+        j_rest = np.array(_extract_json_block(sim.get_jacobian(site_name="end_effector"), 1)["jacp"])
+
+        sh = model.jnt_qposadr[mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, "shoulder")]
+        el = model.jnt_qposadr[mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, "elbow")]
+        data.qpos[sh] = 0.9
+        data.qpos[el] = -0.7
+        j_after = np.array(_extract_json_block(sim.get_jacobian(site_name="end_effector"), 1)["jacp"])
+
+        # Independent ground truth for the new configuration.
+        mj.mj_kinematics(model, data)
+        mj.mj_comPos(model, data)
+        jacp = np.zeros((3, model.nv))
+        jacr = np.zeros((3, model.nv))
+        sid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_SITE, "end_effector")
+        mj.mj_jacSite(model, data, jacp, jacr, sid)
+
+        # fails-before: j_after equalled the stale j_rest, not the new-config truth.
+        assert np.linalg.norm(j_after - jacp) < 1e-9
+        assert np.linalg.norm(j_after - j_rest) > 1e-3
+
 
 class TestEnergy:
     def test_get_energy(self, sim):
@@ -392,6 +422,47 @@ class TestBodyState:
     def test_body_state_invalid(self, sim):
         result = sim.get_body_state(body_name="nonexistent")
         assert result["status"] == "error"
+
+    def test_body_state_pose_reflects_current_qpos(self, sim):
+        """get_body_state pose must reflect the current qpos and agree with
+        forward_kinematics.
+
+        Regression: it read stale data.xpos without forwarding, so after a
+        qpos change (here a direct data.qpos write) it reported the OLD pose
+        while its sibling forward_kinematics reported the new one.
+        """
+        model, data = sim._world._model, sim._world._data
+        sh = model.jnt_qposadr[mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, "shoulder")]
+        data.qpos[sh] = 1.0
+
+        pos_bs = _extract_json_block(sim.get_body_state(body_name="link2"), 1)["position"]
+        pos_fk = _extract_json_block(sim.forward_kinematics(body_name="link2"), 1)["position"]
+        # fails-before: get_body_state stale pose != forward_kinematics fresh pose.
+        assert pos_bs == pytest.approx(pos_fk, abs=1e-9)
+
+    def test_body_state_velocity_reflects_current_qvel(self, sim):
+        """get_body_state 6D velocity must reflect the current qvel.
+
+        Regression: it read data.cvel via mj_objectVelocity without
+        forwarding, so a velocity written by set_joint_velocities (which sets
+        qvel but does not forward) was reported as the stale ~zero velocity
+        while the call reported success.
+        """
+        sim.set_joint_velocities(velocities={"shoulder": 2.0, "elbow": -1.5})
+        state = _extract_json_block(sim.get_body_state(body_name="link2"), 1)
+        got = np.array(state["linear_velocity"] + state["angular_velocity"])
+
+        # Independent ground truth (order matches get_body_state: linear then angular).
+        model, data = sim._world._model, sim._world._data
+        mj.mj_forward(model, data)
+        vel = np.zeros(6)
+        bid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_BODY, "link2")
+        mj.mj_objectVelocity(model, data, mj.mjtObj.mjOBJ_BODY, bid, vel, 0)
+        truth = np.concatenate([vel[3:], vel[:3]])
+
+        assert np.linalg.norm(got - truth) < 1e-9
+        # fails-before: stale velocity was ~0 at the freshly-set qvel.
+        assert np.linalg.norm(got) > 1e-2
 
 
 class TestDirectJointControl:


### PR DESCRIPTION
## Problem

`get_jacobian` and `get_body_state` are read-only physics-query methods, but neither runs the MuJoCo forward pipeline before reading derived state:

- `get_jacobian` calls `mj_jacBody`/`mj_jacSite`/`mj_jacGeom`, which read `data.xpos`/`site_xpos`/`geom_xpos`, `data.subtree_com` and `data.cdof`.
- `get_body_state` reads `data.xpos`/`xquat`/`xmat`/`xipos` and, via `mj_objectVelocity`, `data.cvel`.

All of those are only recomputed by a forward pass. So after any state change that did not itself forward, both methods silently returned values for an **earlier** configuration while still reporting `status="success"`. Two such paths are ordinary public API:

- a direct `data.qpos` write (the documented advanced hook, exactly what a Jacobian-based IK loop does); and
- `set_joint_velocities(...)`, which writes `qvel` but does **not** forward (unlike `set_joint_positions`, which does).

Every sibling query method already forwards defensively — `forward_kinematics` (`mj_kinematics` + `mj_comPos`), `get_mass_matrix`, `inverse_dynamics` and `get_sensor_data` (`mj_forward`) — so `get_jacobian`/`get_body_state` were the outliers, and `get_body_state` would even disagree with `forward_kinematics` on the same body at the same `qpos`.

Reproduced on a real `so101` MuJoCo scene:

```
get_jacobian  : after a qpos change ||J_reported - J_rest|| = 0.0   (true delta 0.797) -> stale
get_body_state: after set_joint_velocities linvel = [0,0,0]         (true [0,-0.228,-0.167])
get_body_state: after a qpos change pos = [0.02,-0.28,0.27]         (forward_kinematics = [0.02,-0.12,0.005])
```

## Change

- `get_jacobian` recomputes the position pipeline (`mj_kinematics` + `mj_comPos`) before the `mj_jac*` call — matching `forward_kinematics`, cheaper than a full forward and exactly what the Jacobian needs.
- `get_body_state` runs a full `mj_forward` before reading (it needs both the position and velocity pipeline for the 6D velocity) — matching `get_mass_matrix`/`inverse_dynamics`/`get_sensor_data`.

Both are inside the existing lock; at rest the forward is idempotent so no existing behavior changes. Docstrings updated to state the reflect-current-state contract.

## Why it matters (visual)

Jacobian-based **resolved-rate velocity tracking** (`dq = J⁺·v`, no error feedback) is the canonical use of `get_jacobian` and is directly sensitive to Jacobian staleness. Tracing a 60 mm circle with the SO-101 gripper (headless MuJoCo, EGL):

![jacobian tracking](https://github.com/cagataycali/robots/releases/download/artifact-physics-query-forward-1783043072/jac_track.png)

- FRESH Jacobian (this fix): circle-tracking RMS **3.5 mm** (green, tight on the grey target).
- STALE Jacobian (pre-fix): RMS **11.6 mm**, ~3.3x worse — the path drifts off as the config moves away from where the Jacobian was last computed (red).

## Tests

`tests/simulation/mujoco/test_physics.py` (GL-free fixture, runs in CI):

- `test_jacobian_reflects_current_configuration` — reported Jacobian equals the new-config ground truth; fails pre-fix (equalled the stale rest Jacobian).
- `test_body_state_pose_reflects_current_qpos` — `get_body_state` pose agrees with `forward_kinematics`; fails pre-fix.
- `test_body_state_velocity_reflects_current_qvel` — 6D velocity matches ground truth after `set_joint_velocities`; fails pre-fix (reported ~0).

All three fail before the fix, pass after. Full `tests/simulation/mujoco/` suite: 1082 passed, 1 skipped. `ruff check`/`ruff format`/`mypy` clean on the changed files.