### PR TITLE
test(sim): pin staged_reward input-validation contract (predicates 99->100%)

### DIFF
--- a/tests/simulation/test_staged_reward.py
+++ b/tests/simulation/test_staged_reward.py
@@ -185,3 +185,45 @@ def test_rejects_non_numeric_bonus() -> None:
     ]
     with pytest.raises(ValueError, match="bonus must be a number"):
         make_predicate("staged_reward", stages=bad)
+
+
+def test_rejects_non_dict_stage() -> None:
+    # A stage that is not a mapping cannot declare reward/advance_when, so the
+    # factory must reject it up front rather than raising a cryptic AttributeError
+    # deeper in compilation.
+    with pytest.raises(ValueError, match=r"stage\[0\] must be a dict, got str"):
+        make_predicate("staged_reward", stages=["reach then grasp"])
+
+
+def test_rejects_stage_with_missing_reward() -> None:
+    # ``reward`` is mandatory and must be a predicate-call dict. A stage that
+    # omits it (or supplies a non-dict) is malformed.
+    with pytest.raises(ValueError, match=r"stage\[0\]\.reward must be a predicate-call dict"):
+        make_predicate("staged_reward", stages=[{"advance_when": {"predicate": "contact_any"}}])
+
+
+def test_rejects_non_dict_reward_call() -> None:
+    with pytest.raises(ValueError, match=r"stage\[0\]\.reward must be a predicate-call dict"):
+        make_predicate("staged_reward", stages=[{"reward": "distance_neg"}])
+
+
+def test_rejects_non_dict_advance_when() -> None:
+    # When ``advance_when`` is present it must itself be a predicate-call dict;
+    # a bare string is not a valid gate.
+    bad = [
+        {"reward": {"predicate": "constant", "value": 1.0}, "advance_when": "contact_any"},
+        {"reward": {"predicate": "constant", "value": 1.0}},
+    ]
+    with pytest.raises(ValueError, match=r"stage\[0\]\.advance_when must be a predicate-call dict"):
+        make_predicate("staged_reward", stages=bad)
+
+
+def test_empty_compiled_stages_reward_is_zero() -> None:
+    # The factory rejects empty stages, but the compiled term itself must stay
+    # safe if ever handed an empty stage list directly: it scores 0.0 rather
+    # than indexing out of range.
+    from strands_robots.simulation.predicates import _StagedReward
+
+    term = _StagedReward([])
+    assert term(_ScriptedEngine()) == 0.0
+    assert term.phase == 0


### PR DESCRIPTION
## What

Adds five focused tests that pin the input-validation contract of the `staged_reward` phase-machine primitive in `strands_robots/simulation/predicates.py`, closing the last uncovered branches in that module (99% -> 100%).

`staged_reward` compiles a user-authored list of stage dicts into a stateful reward term entirely through the closed predicate registry (no `eval`). Its factory validates the stage schema up front so a malformed spec fails with a clear message instead of a cryptic error deeper in compilation. Those rejection branches were previously unexercised.

## Branches now pinned

- Non-dict stage entry -> `stage[i] must be a dict, got <type>`.
- Stage missing `reward` / `reward` not a predicate-call dict -> `stage[i].reward must be a predicate-call dict`.
- `advance_when` present but not a predicate-call dict -> `stage[i].advance_when must be a predicate-call dict`.
- Runtime safety guard: a `_StagedReward` compiled with an empty stage list scores `0.0` and stays at phase 0 rather than indexing out of range (the factory rejects empty stages, but the term must not crash if ever handed one directly).

These complement the existing rejection tests (empty stages, non-final stage without `advance_when`, unknown sub-predicate, unknown stage key, non-numeric bonus), which already covered their branches.

## Coverage

`strands_robots/simulation/predicates.py`: 331 stmts, **4 missing -> 0 missing (99% -> 100%)**. Missing lines closed: the non-dict-stage, malformed-reward, malformed-advance_when, and empty-compiled-stages guards.

## Testing

```
MUJOCO_GL=egl pytest tests/simulation/test_staged_reward.py  # 16 passed
```

No behavior change (test-only). `ruff check`, `ruff format --check`, and `mypy` clean on the changed file.