### PR TITLE
test(policies): cover MoveIt2InferenceClient reconnect + teardown + ping-success

### DIFF
--- a/tests/policies/moveit2/test_policy.py
+++ b/tests/policies/moveit2/test_policy.py
@@ -135,6 +135,59 @@ class TestMoveIt2InferenceClient:
         client.socket.send = MagicMock(side_effect=Exception("timeout"))
         assert client.ping() is False
 
+    def test_ping_returns_true_when_server_responds(self):
+        """ping() reports True when the round-trip call_endpoint succeeds."""
+        client = MoveIt2InferenceClient(host="127.0.0.1", port=9999)
+        client.socket.send = MagicMock()
+        client.socket.recv = MagicMock(return_value=MsgSerializer.to_bytes({"status": "ok"}))
+        assert client.ping() is True
+
+    def test_reconnect_closes_old_socket_and_connects_a_fresh_one(self):
+        """reconnect() closes the current socket and builds a new connected one.
+
+        A stale/timed-out REQ socket cannot be reused for another request, so
+        the client must be able to swap in a fresh socket. The replacement must
+        be a distinct object and must be re-connected to the same endpoint.
+        """
+        client = MoveIt2InferenceClient(host="127.0.0.1", port=9999)
+        old_socket = client.socket
+        old_socket.close = MagicMock()
+
+        client.reconnect()
+
+        old_socket.close.assert_called_once()
+        assert client.socket is not old_socket
+        # New socket is usable for a round-trip (send/recv wired by _init_socket).
+        client.socket.send = MagicMock()
+        client.socket.recv = MagicMock(return_value=MsgSerializer.to_bytes({"status": "ok"}))
+        assert client.ping() is True
+
+    def test_reconnect_ignores_errors_closing_a_broken_socket(self):
+        """A close() that raises must not stop reconnect from rebuilding.
+
+        On a dead connection the old socket's close() can raise; reconnect must
+        swallow it and still hand back a fresh, connected socket.
+        """
+        client = MoveIt2InferenceClient(host="127.0.0.1", port=9999)
+        old_socket = client.socket
+        old_socket.close = MagicMock(side_effect=RuntimeError("already dead"))
+
+        client.reconnect()  # must not propagate
+
+        assert client.socket is not old_socket
+
+    def test_teardown_swallows_socket_close_errors(self):
+        """_teardown() is best-effort: a raising close()/term() never propagates.
+
+        It runs from __del__ during interpreter shutdown, where a raised
+        exception would be swallowed silently and could mask a resource leak,
+        so the method itself must never raise.
+        """
+        client = MoveIt2InferenceClient(host="127.0.0.1", port=9999)
+        client.socket.close = MagicMock(side_effect=RuntimeError("boom"))
+        client.context.term = MagicMock(side_effect=RuntimeError("boom"))
+        client._teardown()  # must not raise
+
     def test_plan_helper_omits_optional_fields_when_unset(self):
         """plan() should not send ``target_pose`` / ``world_update`` keys when
         those are None — keeps the wire payload minimal and lets the


### PR DESCRIPTION
## Problem

The MoveIt2 ZMQ REQ client (`strands_robots/policies/moveit2/client.py`) had no test coverage for its socket-recovery and shutdown paths (module was at 89%):

- `reconnect()` (lines 120-125) - never exercised. A stale/timed-out ZMQ REQ socket cannot be reused for another request, so the client must be able to close the old socket and swap in a fresh, connected one. On a broken connection `socket.close()` itself can raise, and that must be swallowed so the rebuild still happens.
- `_teardown()` (lines 210-211) - the error-swallowing branch was uncovered. It runs from `__del__` during interpreter shutdown, where a raised exception is silently dropped and can mask a resource leak, so it must never propagate.
- `ping()` success (line 131) - only the failure path (`return False`) was covered; the `return True` round-trip success was not.

## Change

Adds four focused behavior tests to `TestMoveIt2InferenceClient`, all running in-process against stubbed sockets (no live network, consistent with the existing client tests):

- `test_ping_returns_true_when_server_responds` - `ping()` reports `True` on a successful round-trip.
- `test_reconnect_closes_old_socket_and_connects_a_fresh_one` - `reconnect()` closes the current socket and hands back a distinct, usable one.
- `test_reconnect_ignores_errors_closing_a_broken_socket` - a raising `close()` does not stop `reconnect()` from rebuilding.
- `test_teardown_swallows_socket_close_errors` - a raising `close()`/`term()` never propagates out of `_teardown()`.

No production code changed - test-only hardening.

## Coverage

`strands_robots/policies/moveit2/client.py`: 89% -> 100% (verified via `coverage run --source=strands_robots.policies.moveit2.client`).

## Testing

`ruff check` / `ruff format --check` clean; `mypy` clean on the changed file. The full `tests/policies/moveit2/test_policy.py` suite passes headless.