### PR TITLE
fix(sim): replay steps a full control period per recorded frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,6 +246,23 @@ pipeline (`mj_kinematics` + `mj_comPos`, matching `forward_kinematics`) and
 `inverse_dynamics` / `get_sensor_data`), so both always reflect the current
 `qpos`/`qvel`.
 
+### Fixed: `replay_episode` under-integrated physics (single dt/frame instead of a full control period)
+
+`PolicyRunner.replay` advanced physics by only a single `send_action` default
+`n_substeps=1` (~2 ms) per recorded frame, while each recorded frame represents
+one control step taken at the dataset's fps and the recording itself integrated
+a full `1/fps` control period per action (the substep convention `run()` and
+`evaluate()` already derive via `_control_substeps`). On a position-servo robot
+this meant replay got ~1/17 of the integration time per target at 30 Hz control
+(2 ms physics dt), so the servo could not track the recorded targets: replay
+produced a heavily under-integrated, attenuated trajectory (an SO-101 self-record
+diverged ~0.95 rad from its recording and its joint sweeps were attenuated up to
+11x) that did not reproduce the recording, while still reporting `Frames: N/N`
+and `status="success"` -- a silent record -> replay fidelity gap. Replay now
+derives its physics substeps from the dataset fps and steps a full control
+period per frame, so a recorded episode replays back to the pose it was recorded
+at. `speed` continues to scale only the wall-clock playback rate.
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -1421,7 +1421,10 @@ class SimEngine(ABC):
         ``speed`` is a playback-rate multiplier (1.0 = real time) and must be a
         positive number; a non-positive or non-numeric value is rejected with a
         structured error rather than raising or silently playing back at full
-        speed.
+        speed. ``speed`` scales only the wall-clock playback rate: each recorded
+        frame always advances physics for a full control period (derived from
+        the dataset fps), so a position-servo robot reproduces the recorded
+        trajectory instead of under-integrating it.
 
         Override per backend for optimised replay (e.g. direct ctrl
         writes) only when measured necessary.

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -1314,6 +1314,14 @@ class PolicyRunner:
     ) -> dict[str, Any]:
         """Replay a recorded LeRobotDataset episode through ``send_action``.
 
+        Each recorded frame is one control step taken at the dataset's fps, so
+        replay advances physics for a full control period per frame (derived
+        from the dataset fps and physics timestep, the same integration the
+        recording used) rather than a single physics dt. This lets a
+        position-servo robot track the recorded targets and reproduce the
+        recorded trajectory; ``speed`` scales only the wall-clock playback
+        rate, not the physics per frame.
+
         Args:
             repo_id: HuggingFace dataset id (e.g. ``lerobot/pusht``).
             robot_name: Target robot. Defaults to the first robot in the sim
@@ -1390,6 +1398,20 @@ class PolicyRunner:
 
         dataset_fps = getattr(ds, "fps", 30)
         frame_interval = 1.0 / (dataset_fps * speed)
+        # Step a FULL control period per recorded frame, not a single physics
+        # dt. The recorded control frequency IS the dataset fps, so derive the
+        # physics substeps from it (same convention as run() and evaluate()).
+        # Without this, replay fell through to ``send_action``'s default
+        # ``n_substeps=1`` - a single ~2 ms physics step per recorded frame -
+        # while the recording integrated a full ~1/fps control period per
+        # frame. A position-servo robot could not track the recorded targets in
+        # ~2 ms, so replay produced a heavily under-integrated, attenuated
+        # trajectory that did NOT reproduce the recording (the arm barely moved)
+        # while still reporting ``Frames: N/N`` and ``status="success"`` - a
+        # silent record -> replay fidelity gap. ``speed`` scales only the
+        # wall-clock playback rate (frame_interval), never the physics per
+        # frame, so it is deliberately excluded here.
+        n_substeps = self._control_substeps(dataset_fps)
         frames_applied = 0
         start_time = time.time()
 
@@ -1419,8 +1441,9 @@ class PolicyRunner:
 
             action_vals = frame.get("action") if isinstance(frame, dict) else None
             if action_vals is None:
-                # No action at this index - just advance physics one step.
-                self.sim.step(n_steps=1)
+                # No action at this index - advance physics one full control
+                # period so the frame still occupies its recorded time slice.
+                self.sim.step(n_steps=n_substeps)
                 frames_applied += 1
             else:
                 if hasattr(action_vals, "numpy"):
@@ -1434,7 +1457,7 @@ class PolicyRunner:
                         break
                     action_dict[action_keys[i]] = float(val)
 
-                self.sim.send_action(action_dict, robot_name=resolved_robot)
+                self.sim.send_action(action_dict, robot_name=resolved_robot, n_substeps=n_substeps)
                 frames_applied += 1
 
             sleep_time = frame_interval - (time.time() - step_start)

--- a/tests/simulation/mujoco/test_replay_control_period_fidelity.py
+++ b/tests/simulation/mujoco/test_replay_control_period_fidelity.py
@@ -1,0 +1,137 @@
+"""Regression: replay steps a FULL control period per recorded frame.
+
+A recorded ``LeRobotDataset`` frame corresponds to one control step taken at the
+dataset's fps. During recording (``run_policy`` / ``eval_policy``) the engine
+advances physics for the full control period per action - derived from the
+control frequency and physics timestep (``PolicyRunner._control_substeps``) -
+so a position-servo robot actually tracks each commanded target.
+
+``PolicyRunner.replay`` previously fell through to ``send_action``'s default
+``n_substeps=1``: a single ~2 ms physics step per recorded frame regardless of
+the recording's control period. On an SO-101 (position servos, ~2 ms physics
+dt, 30 Hz control -> 17 substeps/frame) the arm got ~1/17 of the integration
+time per target, so it could not track the recorded trajectory: replay produced
+a heavily under-integrated, attenuated motion that did not reproduce the
+recording, while still reporting ``Frames: N/N`` and ``status="success"`` - a
+silent record -> replay fidelity gap.
+
+These tests pin (1) the mechanism - every replayed frame steps the full control
+period - and (2) the behaviour - a self-recorded episode replays back to the
+same final pose it was recorded at.
+"""
+
+from __future__ import annotations
+
+import tempfile
+
+import numpy as np
+import pytest
+
+pytest.importorskip("mujoco")
+
+import mujoco  # noqa: E402
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+from strands_robots.simulation.policy_runner import PolicyRunner  # noqa: E402
+
+
+@pytest.fixture
+def so101_sim():
+    s = Simulation()
+    s.create_world(ground_plane=True)
+    s.add_robot("so101")
+    yield s
+    s.cleanup()
+
+
+def _arm_qpos(sim: Simulation) -> np.ndarray:
+    """Current SO-101 arm joint positions (so101/1..6) straight from mjData."""
+    m = sim.mj_model
+    d = sim.mj_data
+    assert m is not None and d is not None
+    adrs = [
+        int(m.jnt_qposadr[mujoco.mj_name2id(m, mujoco.mjtObj.mjOBJ_JOINT, f"so101/{j}")]) for j in range(1, 7)
+    ]
+    return d.qpos[adrs].copy()
+
+
+def _record_episode(sim: Simulation, repo: str, root: str, fps: int = 30) -> None:
+    """Record a short mock (sinusoidal) rollout, action-only (no cameras)."""
+    assert sim.start_recording(repo_id=repo, task="rt", fps=fps, root=root, cameras=[])["status"] == "success"
+    assert (
+        sim.run_policy(
+            robot_name="so101",
+            policy_provider="mock",
+            n_steps=90,
+            control_frequency=fps,
+            action_horizon=8,
+            fast_mode=True,
+        )["status"]
+        == "success"
+    )
+    assert sim.stop_recording()["status"] == "success"
+
+
+def test_replay_steps_full_control_period(so101_sim):
+    """Every replayed frame steps a full control period, not a single dt.
+
+    Pre-fix each ``send_action`` call used the default ``n_substeps=1``; post-fix
+    it uses ``_control_substeps(fps)`` (17 for 30 Hz control at a 2 ms physics
+    dt), the same integration the recording used.
+    """
+    pytest.importorskip("lerobot")
+    root = tempfile.mkdtemp(prefix="so101_replay_period_")
+    repo = "local/so101_replay_period"
+    _record_episode(so101_sim, repo, root, fps=30)
+
+    expected = PolicyRunner(so101_sim)._control_substeps(30)
+    assert expected > 1, "precondition: a 30 Hz control period must span >1 physics dt"
+
+    used: list[int] = []
+    original = so101_sim.send_action
+
+    def spy(action, robot_name=None, n_substeps=1):
+        used.append(n_substeps)
+        return original(action, robot_name=robot_name, n_substeps=n_substeps)
+
+    so101_sim.send_action = spy  # type: ignore[method-assign]
+    try:
+        rep = PolicyRunner(so101_sim).replay(repo, robot_name="so101", root=root, speed=1000.0)
+    finally:
+        so101_sim.send_action = original  # type: ignore[method-assign]
+
+    assert rep["status"] == "success"
+    assert used, "replay applied no actions"
+    # Pre-fix: every element is 1. Post-fix: every element is the full period.
+    assert set(used) == {expected}
+
+
+def test_replay_reproduces_recorded_trajectory(so101_sim):
+    """A self-recorded episode replays back to the pose it was recorded at.
+
+    Physics is deterministic, so replaying the exact recorded action sequence
+    from the same reset state must reproduce the recorded final pose - but only
+    if replay integrates the same full control period per frame. Pre-fix the
+    under-integrated replay diverged by ~0.95 rad; post-fix it matches to
+    float32 round-trip precision.
+    """
+    pytest.importorskip("lerobot")
+    root = tempfile.mkdtemp(prefix="so101_replay_traj_")
+    repo = "local/so101_replay_traj"
+
+    _record_episode(so101_sim, repo, root, fps=30)
+    recorded_final = _arm_qpos(so101_sim)  # arm pose at the end of the recording
+
+    so101_sim.reset()
+    after_reset = _arm_qpos(so101_sim)
+    assert np.linalg.norm(after_reset) < 1e-6, "so101 should reset to the zero rest pose"
+
+    rep = PolicyRunner(so101_sim).replay(repo, robot_name="so101", root=root, speed=1000.0)
+    assert rep["status"] == "success"
+    replay_final = _arm_qpos(so101_sim)
+
+    gap = float(np.linalg.norm(recorded_final - replay_final))
+    # The recorded motion sweeps ~1 rad on several joints; the under-stepped
+    # (pre-fix) replay diverged by ~0.95 rad. A faithful full-control-period
+    # replay reproduces it to float32 round-trip precision (<1e-3).
+    assert gap < 1e-2, f"replay did not reproduce the recording: {gap:.4f} rad gap"

--- a/tests/simulation/mujoco/test_replay_control_period_fidelity.py
+++ b/tests/simulation/mujoco/test_replay_control_period_fidelity.py
@@ -49,9 +49,7 @@ def _arm_qpos(sim: Simulation) -> np.ndarray:
     m = sim.mj_model
     d = sim.mj_data
     assert m is not None and d is not None
-    adrs = [
-        int(m.jnt_qposadr[mujoco.mj_name2id(m, mujoco.mjtObj.mjOBJ_JOINT, f"so101/{j}")]) for j in range(1, 7)
-    ]
+    adrs = [int(m.jnt_qposadr[mujoco.mj_name2id(m, mujoco.mjtObj.mjOBJ_JOINT, f"so101/{j}")]) for j in range(1, 7)]
     return d.qpos[adrs].copy()
 
 


### PR DESCRIPTION
## Problem

`PolicyRunner.replay` (`Simulation.replay_episode`) advanced physics by only `send_action`'s default `n_substeps=1` (a single ~2 ms physics dt) per recorded frame. But each recorded `LeRobotDataset` frame is one control step taken at the dataset's fps, and the recording itself integrated a full `1/fps` control period per action — the substep convention `run()` and `evaluate()` already derive via `_control_substeps` (`evaluate` even carries the comment *"The default n_substeps=1 made eval rollouts under-step"*). Replay was the one playback path left on the single-dt default.

On a position-servo robot this is a silent fidelity gap. At 30 Hz control with a 2 ms physics dt, a control period is **17 substeps**; replay gave the servo ~1/17 of the integration time per target, so it could not track the recorded targets. Replay produced a heavily under-integrated, attenuated trajectory that did **not** reproduce the recording — while still reporting `Frames: N/N` and `status="success"`.

### Reproduction (SO-101, MuJoCo, 30 Hz)

Record a rollout, then `replay_episode` the dataset and compare the arm's actual trajectory to the recording:

| | recorded | replay (before) |
|---|---|---|
| final arm pose gap | — | **0.948 rad** |
| per-joint sweep vs recording | 1.0 rad | attenuated up to **11.5x** |
| `send_action` substeps/frame | 17 | 1 |

The recorded trajectory sweeps ~1 rad on several joints; the under-stepped replay barely moves. Left = the recording (identical to replay **after** the fix); right = replay **before** the fix:

![replay fidelity](https://github.com/cagataycali/robots/releases/download/replay-fidelity-artifact/replay_fidelity.gif)

## Fix

Derive replay's physics substeps from the dataset fps (`_control_substeps(dataset_fps)`) and step a full control period per frame, in both the action and no-action branches — mirroring `run()`/`evaluate()`. `speed` continues to scale only the wall-clock playback rate, never the physics per frame. After the fix, replaying a self-recorded episode reproduces the recorded final pose to float32 round-trip precision (**0.000 rad** gap, substeps = 17).

## Tests

`tests/simulation/mujoco/test_replay_control_period_fidelity.py` (GL-free, action-only recording):
- `test_replay_steps_full_control_period` — every replayed frame steps the full control period. Fails pre-fix: `assert {1} == {17}`.
- `test_replay_reproduces_recorded_trajectory` — a self-recorded episode replays back to the pose it was recorded at. Fails pre-fix: `0.9480 rad gap`.

Both pass post-fix; the surrounding replay/recording suite (47 tests) is green; ruff + mypy clean on the changed modules.

## Changelog

- **67e8d92** style(sim): `ruff format` the new test file so `ruff format --check` in CI passes (the only failing gate was a one-line list-comprehension reflow; no logic change).