### PR TITLE
docs(lerobot_local): correct stale lerobot reference paths in norm_stats docstring

### DIFF
--- a/strands_robots/policies/lerobot_local/norm_stats.py
+++ b/strands_robots/policies/lerobot_local/norm_stats.py
@@ -21,8 +21,9 @@ objects:
 * :class:`NormStatsPostprocessorStep` unnormalizes ``action``.
 
 The numeric transform is a bit-for-bit port of the reference normalizer in
-``lerobot.policies.molmoact2.hf_model.modeling_molmoact2._FeatureNormalizer``
-(see ``configuration_molmoact2.py::apply_norm_tag_metadata``). For ``q01_q99``::
+``lerobot.policies.molmoact2.molmoact2_hf_model.modeling_molmoact2._FeatureNormalizer``
+(see the ``_RobotStats.normalize_state`` / ``.unnormalize_action`` norm-tag
+dispatch in the same module). For ``q01_q99``::
 
     x_norm   = clip(2 * (x - q01) / max(q99 - q01, eps) - 1, -1, 1)
     x_unnorm = (clip(x_norm, -1, 1) + 1) * (q99 - q01) / 2 + q01


### PR DESCRIPTION
## Problem

The `norm_stats` module docstring documents where the reference normalizer lives so a maintainer can verify the port stays *bit-for-bit faithful* to lerobot as lerobot evolves. Both reference paths it cites have gone stale after lerobot's `molmoact2` package reorg, so following them now leads nowhere:

* `lerobot.policies.molmoact2.hf_model.modeling_molmoact2._FeatureNormalizer` — the submodule is `molmoact2_hf_model`, not `hf_model`. Importing the cited path raises `ModuleNotFoundError`.
* `configuration_molmoact2.py::apply_norm_tag_metadata` — this function no longer exists. The per-tag normalization is now dispatched by `_RobotStats.normalize_state` / `.unnormalize_action` in `modeling_molmoact2`.

The module's numeric core is a deliberate port of that reference (and `TestUpstreamLerobotParity` pins it bit-equal to lerobot's public `NormalizerProcessorStep`), so an accurate pointer to the reference of record matters: a wrong path silently defeats anyone trying to re-verify faithfulness against a newer lerobot.

## Change

Correct both references in the module docstring to the current, resolvable locations. Docstring only — no code or behavior change.

## Verification

* Both corrected paths resolve against the installed lerobot (`_FeatureNormalizer` imports from `...molmoact2_hf_model.modeling_molmoact2`; `_RobotStats.normalize_state`/`unnormalize_action` present); the old paths raise `ModuleNotFoundError` / are absent.
* `ruff check` + `ruff format --check` + `mypy` clean on the file; the full `test_norm_stats_fallback.py` suite (55 tests) passes.