### PR TITLE
test(lerobot_local): pin inert-normalization detector across pipeline variety and import drift

### DIFF
--- a/tests/policies/lerobot_local/test_inert_normalization_detection.py
+++ b/tests/policies/lerobot_local/test_inert_normalization_detection.py
@@ -11,8 +11,14 @@ missing-postprocessor guard never fires and the passthrough is silent.
 
 These tests pin :meth:`ProcessorBridge.inert_normalization_features` against
 REAL LeRobot processor steps (no network, no model download): the dataset-keyed
-shape is flagged, the canonical ``action`` / ``observation.state`` shape is not.
+shape is flagged, the canonical ``action`` / ``observation.state`` shape is not,
+and the detector stays robust to realistic pipeline variety -- non-normalizer
+steps, an unnormalizer's non-action features, features whose type is
+unresolved, and lerobot import drift.
 """
+
+import sys
+import types
 
 import pytest
 
@@ -79,3 +85,86 @@ def test_canonical_stats_are_not_flagged():
 def test_no_pipelines_returns_empty():
     """A bridge with no pipelines has nothing to flag."""
     assert ProcessorBridge().inert_normalization_features() == []
+
+
+def test_non_normalizer_steps_are_ignored():
+    """A realistic pipeline mixes normalizer and non-normalizer steps.
+
+    Only Normalizer/Unnormalizer steps carry normalization stats; every other
+    step kind (rename, tokenizer, device transfer, ...) has no ``norm_map`` to
+    honour and must be skipped without affecting the verdict. Here a rename step
+    precedes a normalizer whose ``observation.state`` stats are absent: the
+    detector must still flag exactly that one inert feature and ignore the
+    rename step entirely.
+    """
+    from lerobot.processor.rename_processor import RenameObservationsProcessorStep
+
+    norm = NormalizerProcessorStep(
+        features={"observation.state": PolicyFeature(type=FeatureType.STATE, shape=(6,))},
+        norm_map={FeatureType.STATE: NormalizationMode.MEAN_STD},
+        stats={},  # no matching stats -> observation.state is inert
+    )
+    bridge = ProcessorBridge(
+        preprocessor=DataProcessorPipeline(steps=[RenameObservationsProcessorStep(rename_map={}), norm])
+    )
+    inert = bridge.inert_normalization_features()
+    assert inert == ["observation.state (STATE/MEAN_STD)"], inert
+
+
+def test_unnormalizer_ignores_non_action_features():
+    """An UnnormalizerProcessorStep applies only to ACTION features.
+
+    Upstream ``UnnormalizerProcessorStep`` unnormalizes the ACTION output and
+    leaves observation features untouched. So even if it *declares* a STATE
+    feature with a non-IDENTITY mode and no backing stats, that STATE feature is
+    never applied and must NOT be reported as inert -- reporting it would raise
+    a false alarm about a passthrough that cannot happen.
+    """
+    unnorm = UnnormalizerProcessorStep(
+        features={
+            "observation.state": PolicyFeature(type=FeatureType.STATE, shape=(6,)),
+            "action": PolicyFeature(type=FeatureType.ACTION, shape=(6,)),
+        },
+        norm_map={FeatureType.STATE: NormalizationMode.MEAN_STD, FeatureType.ACTION: NormalizationMode.MEAN_STD},
+        stats={"action": dict(_MS)},  # action is backed; state is not, but state is never applied
+    )
+    bridge = ProcessorBridge(postprocessor=DataProcessorPipeline(steps=[unnorm]))
+    assert bridge.inert_normalization_features() == []
+
+
+def test_feature_without_resolved_type_is_skipped():
+    """A step exposing a feature whose ``type`` is unresolved must not crash.
+
+    ``inert_normalization_features`` reads ``feature.type`` to look up the
+    normalization mode. A step that surfaces a feature with ``type is None``
+    (e.g. a partially-populated custom step) has no mode to honour and must be
+    skipped defensively rather than raising or being falsely flagged.
+    """
+    fake_norm_cls = type("NormalizerProcessorStep", (), {})
+    step = fake_norm_cls()
+    step.features = {"weird": types.SimpleNamespace(type=None, shape=(6,))}
+    step.norm_map = {FeatureType.STATE: NormalizationMode.MEAN_STD}
+    step.stats = {}
+    bridge = ProcessorBridge(preprocessor=types.SimpleNamespace(steps=[step]))
+    assert bridge.inert_normalization_features() == []
+
+
+def test_import_drift_degrades_to_empty(monkeypatch):
+    """If the lerobot type imports are unavailable, degrade to an empty verdict.
+
+    Older / drifted lerobot layouts may not expose ``lerobot.configs.types`` or
+    ``lerobot.utils.constants``. The detector guards those imports and returns
+    an empty list instead of raising, so a present pipeline never turns an
+    optional diagnostic into a hard failure.
+    """
+    norm = NormalizerProcessorStep(
+        features={"observation.state": PolicyFeature(type=FeatureType.STATE, shape=(6,))},
+        norm_map={FeatureType.STATE: NormalizationMode.MEAN_STD},
+        stats={},
+    )
+    bridge = ProcessorBridge(preprocessor=DataProcessorPipeline(steps=[norm]))
+    # Sanity: with imports intact the feature IS flagged.
+    assert bridge.inert_normalization_features() == ["observation.state (STATE/MEAN_STD)"]
+    # Force the in-method import to raise ImportError.
+    monkeypatch.setitem(sys.modules, "lerobot.configs.types", None)
+    assert bridge.inert_normalization_features() == []


### PR DESCRIPTION
## What

Extends the `ProcessorBridge.inert_normalization_features` regression suite so the present-but-inert normalization detector is pinned against realistic pipeline shapes and lerobot import drift, not just the two canonical stat-keying cases.

## Why

`inert_normalization_features` is a safety diagnostic: it flags a present, active normalization pipeline that silently passes tensors through because the looked-up stats key is absent (the `lerobot/smolvla_base` dataset-keyed-stats hazard). The detector walks arbitrary pipeline steps, so it must stay correct across the pipeline variety real checkpoints produce and degrade cleanly if lerobot's type modules move. Those guard branches were previously unexercised, so a regression in any of them would silently weaken the diagnostic (either missing a real passthrough or raising a false alarm).

## Tests added

All run network-free against real LeRobot processor steps (`NormalizerProcessorStep` / `UnnormalizerProcessorStep` / `RenameObservationsProcessorStep`):

- `test_non_normalizer_steps_are_ignored` - a mixed pipeline (rename step + normalizer) still flags exactly the one unbacked normalizer feature and ignores the non-normalizer step.
- `test_unnormalizer_ignores_non_action_features` - an `UnnormalizerProcessorStep` reports only ACTION features; a declared non-action feature it never applies is not falsely flagged.
- `test_feature_without_resolved_type_is_skipped` - a step surfacing a feature whose `type` is unresolved is skipped defensively instead of raising.
- `test_import_drift_degrades_to_empty` - when `lerobot.configs.types` is unavailable the detector returns an empty verdict rather than turning an optional diagnostic into a hard failure.

## Verification

- `ruff check` / `ruff format --check`: clean.
- `mypy strands_robots tests tests_integ`: no issues found.
- `pytest tests/policies/lerobot_local/`: 479 passed (7 in this file).
- Confirmed the four guard branches in `inert_normalization_features` move from uncovered to covered (`--cov=strands_robots` term-missing).

Test-only change; no source or behavior changes.