### PR TITLE
fix(sim): set_body_properties scales inertia with mass (physical consistency)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -263,6 +263,20 @@ derives its physics substeps from the dataset fps and steps a full control
 period per frame, so a recorded episode replays back to the pose it was recorded
 at. `speed` continues to scale only the wall-clock playback rate.
 
+### Fixed: `set_body_properties(mass=...)` left the body's inertia stale
+
+Setting a body's mass at runtime updated `model.body_mass` but not
+`model.body_inertia`, leaving a physically inconsistent body -- heavy in
+translation but retaining the old rotational resistance -- which silently
+corrupted the rotational dynamics. Since `mass` is the only settable property,
+the caller had no way to correct it. Because a rigid body's inertia tracks its
+mass at fixed geometry (a uniform density change scales `I = integral of r^2 dm`
+by the same factor), the inertia tensor is now scaled by `mass / old_mass`,
+matching `randomize(randomize_physics=True)` and the Newton backend. In a
+compound-pendulum check, a mass-only change wrongly shrank the swing period ~2x
+(0.87 s vs 1.76 s); with the fix the period stays mass-invariant as physics
+requires. Massless frames (mass 0) are guarded against division by zero.
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -926,7 +926,22 @@ class PhysicsMixin:
     ) -> dict[str, Any]:
         """Modify body properties at runtime (no recompile needed).
 
-        Changes take effect on the next mj_step.
+        Currently supports setting a body's ``mass``. Because a rigid body's
+        inertia tensor tracks its mass at fixed geometry (a uniform density
+        change), the body's ``body_inertia`` is scaled by the same ratio so the
+        translational and rotational dynamics stay physically consistent.
+
+        Changes take effect on the next ``mj_step``.
+
+        Args:
+            body_name: Name of the body to modify.
+            mass: New absolute mass (kg); must be ``> 0``. When set, the body's
+                inertia is scaled by ``mass / old_mass`` to preserve consistency.
+
+        Returns:
+            A tool-result dict; ``status="error"`` if the world is missing, a
+            policy is running, ``mass`` is not a positive number, or the body is
+            not found, otherwise ``status="success"`` summarizing the change.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
@@ -960,6 +975,18 @@ class PhysicsMixin:
                 old_mass = float(model.body_mass[body_id])
                 model.body_mass[body_id] = mass
                 changes.append(f"mass: {old_mass:.3f} → {mass:.3f}")
+                # Inertia tracks mass for fixed geometry: setting a rigid body's
+                # mass to a new value at constant shape is a uniform density
+                # change, which scales its inertia tensor by the same factor
+                # (I = integral of r^2 dm). Updating body_mass alone leaves a
+                # physically inconsistent body - heavy in translation but with
+                # the old rotational resistance - which silently corrupts the
+                # rotational dynamics (and cannot be corrected by the caller,
+                # since mass is the only settable property). Scale body_inertia
+                # by the same ratio (matches randomize(randomize_physics=True)
+                # and the Newton backend, which scale both together).
+                if old_mass > 0:
+                    model.body_inertia[body_id] *= mass / old_mass
 
         return {
             "status": "success",

--- a/tests/simulation/mujoco/test_physics.py
+++ b/tests/simulation/mujoco/test_physics.py
@@ -512,6 +512,46 @@ class TestRuntimeModification:
         body_id = mj.mj_name2id(sim._world._model, mj.mjtObj.mjOBJ_BODY, "box1")
         assert sim._world._model.body_mass[body_id] == pytest.approx(5.0)
 
+    def test_set_body_mass_scales_inertia_with_mass(self, sim):
+        """Setting mass scales the inertia tensor by the same ratio.
+
+        A rigid body's inertia tracks its mass at fixed geometry (a uniform
+        density change scales I = integral of r^2 dm by the same factor).
+        Updating body_mass alone leaves the body physically inconsistent -
+        heavy in translation but with the old rotational resistance - and the
+        caller has no way to fix it (mass is the only settable property).
+        """
+        model = sim._world._model
+        body_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_BODY, "box1")
+        old_mass = float(model.body_mass[body_id])
+        old_inertia = model.body_inertia[body_id].copy()
+        assert old_mass > 0 and (old_inertia > 0).all()
+
+        # Scale up by 5x.
+        assert sim.set_body_properties(body_name="box1", mass=5.0)["status"] == "success"
+        assert model.body_mass[body_id] == pytest.approx(5.0)
+        assert model.body_inertia[body_id] == pytest.approx(old_inertia * (5.0 / old_mass))
+
+        # And down again (0.5 kg): inertia tracks the new ratio, not stale.
+        cur_mass = float(model.body_mass[body_id])
+        cur_inertia = model.body_inertia[body_id].copy()
+        assert sim.set_body_properties(body_name="box1", mass=0.5)["status"] == "success"
+        assert model.body_inertia[body_id] == pytest.approx(cur_inertia * (0.5 / cur_mass))
+
+    def test_set_body_mass_massless_body_no_crash(self, sim):
+        """A massless frame (mass 0, inertia 0) is handled without dividing by zero.
+
+        There is no geometry-derived inertia to scale from a zero prior mass, so
+        the inertia stays zero; the mass update still succeeds.
+        """
+        model = sim._world._model
+        body_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_BODY, "arm_base")
+        assert float(model.body_mass[body_id]) == pytest.approx(0.0)
+        result = sim.set_body_properties(body_name="arm_base", mass=2.0)
+        assert result["status"] == "success"
+        assert model.body_mass[body_id] == pytest.approx(2.0)
+        assert model.body_inertia[body_id] == pytest.approx([0.0, 0.0, 0.0])
+
     def test_set_geom_color(self, sim):
         result = sim.set_geom_properties(geom_name="box_geom", color=[0, 1, 0, 1])
         assert result["status"] == "success"


### PR DESCRIPTION
## Problem

`Simulation.set_body_properties(body_name, mass=...)` updated `model.body_mass` but left `model.body_inertia` untouched. The result is a physically inconsistent rigid body: heavy in translation but retaining the *old* rotational resistance. Because `mass` is the only settable property, the caller has no way to correct the inertia afterward, so the runtime dynamics are silently wrong.

Repro on a real MuJoCo model (`box1`, mass 1.0, diaginertia [0.01, 0.01, 0.01]):

```
set_body_properties(body_name="box1", mass=5.0)  # status: success
  body_mass    1.0 -> 5.0
  body_inertia [0.01,0.01,0.01] -> [0.01,0.01,0.01]   # STALE (should be [0.05,0.05,0.05])
```

## Fix

A rigid body's inertia tracks its mass at fixed geometry: setting a new mass is a uniform density change, which scales `I = integral of r^2 dm` by the same factor. So when `mass` is set, `body_inertia` is now scaled by `mass / old_mass`. This matches the established convention already used by `randomize(randomize_physics=True)` and the Newton backend, which scale mass and inertia together. Massless frames (`old_mass == 0`, e.g. pure kinematic frames) are guarded against division by zero (there is no geometry-derived inertia to recover from a zero prior mass).

No signature or return-shape change, so no tool-spec / router / breaking-change impact.

## Evidence (compound pendulum)

Three identical rods pivoted just above their center so the body's own `I_cm` dominates. A uniform density (mass-only) change must **not** alter a pendulum's period (`T = 2*pi*sqrt(I / (m*g*d))` is mass-invariant when `I ~ m`). Measured swing periods, all released from the same tilt:

| rod | mass | inertia | period |
|---|---|---|---|
| reference | 1x | 1x | 1.76 s |
| mass-only (pre-fix bug) | 5x | **stale 1x** | **0.87 s** (~2x too fast) |
| mass + inertia (this fix) | 5x | 5x | 1.80 s (~ reference) |

The stale-inertia body wrongly swings ~2x faster; with the fix the period stays mass-invariant as physics requires. Gray = reference, red = stale-inertia bug, green = fixed:

![set_body_properties inertia demo](https://github.com/cagataycali/robots/releases/download/artifact-setbodymass-inertia-1783076142/set_body_mass_inertia_pendulum.gif)

## Tests

`tests/simulation/mujoco/test_physics.py`:
- `test_set_body_mass_scales_inertia_with_mass` - asserts `body_inertia` scales by the same ratio on scale-up (5x) and scale-down (0.5x). **Fails before** the fix (inertia stays 0.01 vs expected 0.05), passes after. The pre-existing `test_set_body_mass` only checked the mass value, so the stale inertia went unnoticed.
- `test_set_body_mass_massless_body_no_crash` - a massless frame is handled without dividing by zero.

GL-free (uses the existing inline-`MjSpec` fixture), so it runs in CI without `ROBOT_TEST_MUJOCO`/EGL. Full `test_physics.py` (70) + input-validation/error-path/no-world-guard suites (201) pass; ruff + mypy clean.