### PR TITLE
docs(sim): action_horizon is a lower bound (clamped up to execution_horizon), not a maximum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -263,6 +263,20 @@ derives its physics substeps from the dataset fps and steps a full control
 period per frame, so a recorded episode replays back to the pose it was recorded
 at. `speed` continues to scale only the wall-clock playback rate.
 
+### Docs: `action_horizon` is a lower bound, not a maximum
+
+The public `run_policy`/`eval_policy` (and `run_policy` tool) docstrings
+described `action_horizon` as the *maximum* actions consumed from each policy
+chunk before re-querying. The effective interval is actually
+`max(action_horizon, policy.execution_horizon)` (`resolve_chunk_length`): it is
+a *lower* bound, and RTC policies ignore it entirely. So for a chunk-emitting
+policy (e.g. a VLA with `execution_horizon=50`) any smaller `action_horizon`
+has no effect -- the full trained chunk is always consumed. In particular
+`eval_policy`'s "set to `1` for closed-loop control" advice holds only for
+single-action policies. The docstrings now state the clamp semantics so a
+caller does not silently get open-loop chunk execution when expecting a tighter
+re-query interval.
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -741,9 +741,16 @@ class SimEngine(ABC):
             control_frequency: Target Hz for policy queries. Must be a
                 positive number; a non-positive, non-numeric, or bool value
                 is reported as a structured caller error.
-            action_horizon: Max actions consumed from each policy chunk
-                before re-querying. Must be a positive integer (>= 1); a
-                non-positive or non-int value is reported as a caller error.
+            action_horizon: Lower bound on actions consumed from each
+                policy chunk before re-querying. The effective interval is
+                ``max(action_horizon, policy.execution_horizon)`` (see
+                ``strands_robots.policies.resolve_chunk_length``): a
+                chunk-emitting policy always keeps its full trained chunk, so
+                a value below that chunk length (e.g. a VLA whose
+                ``execution_horizon`` is 50) has no effect. RTC policies own
+                their own interval and ignore this entirely. Must be a
+                positive integer (>= 1); a non-positive or non-int value is
+                reported as a caller error.
             fast_mode: Skip real-time sleep between steps.
             video: Optional video-recording config dict. Accepted keys:
                 ``path`` (str, output MP4 - required to enable recording),
@@ -1622,7 +1629,11 @@ class SimEngine(ABC):
                 before re-observing, which is what GR00T-N1.7-LIBERO
                 checkpoints were trained against. Set to ``1`` for
                 closed-loop receding-horizon control (re-observe every
-                step; matches OpenVLA-style eval). Values < 1 are
+                step; matches OpenVLA-style eval) ONLY for single-action
+                policies: the interval is clamped up to the policy's
+                ``execution_horizon`` (``resolve_chunk_length``), so a
+                chunk-emitting policy (e.g. a VLA) still consumes its full
+                chunk open-loop regardless of this value. Values < 1 are
                 rejected with a structured error. ``on_step`` and
                 success/failure checks run after EACH applied action,
                 so per-step rewards and early termination work

--- a/strands_robots/tools/run_policy.py
+++ b/strands_robots/tools/run_policy.py
@@ -160,8 +160,11 @@ def run_policy(
         n_steps: Hard cap on control steps per episode. Forwarded to
             ``run_policy`` as ``n_steps``.
         control_frequency: Target Hz for policy queries.
-        action_horizon: Actions consumed per policy call before
-            re-querying.
+        action_horizon: Lower bound on actions consumed per policy call
+            before re-querying; the effective interval is
+            ``max(action_horizon, policy.execution_horizon)``, so a
+            chunk-emitting policy always consumes its full chunk and a
+            smaller value has no effect (see ``resolve_chunk_length``).
         fast_mode: Skip real-time sleep between steps (default True for
             rollouts - wall-clock pacing slows headless eval).
         dataset_root: When set, the tool drives the full recording


### PR DESCRIPTION
## Problem

The public `run_policy`/`eval_policy` docstrings (and the `run_policy` tool) describe `action_horizon` as the **maximum** number of actions consumed from each policy chunk before re-querying:

```
action_horizon: Max actions consumed from each policy chunk before re-querying.
```

The actual contract, implemented and tested in `resolve_chunk_length`, is the opposite. The effective re-query interval is:

```
max(action_horizon, policy.execution_horizon)   # non-RTC
policy.execution_horizon                          # RTC (action_horizon ignored)
```

So `action_horizon` is a **lower bound**, not a maximum. For a chunk-emitting policy (any VLA — e.g. `execution_horizon = 50`) a value below the chunk length is silently inert: the full trained chunk is always consumed. This is exactly what the well-documented `resolve_chunk_length` docstring and `start_policy` already state — the `run_policy`/`eval_policy` public entry points had simply drifted from it.

The most consequential drift is in `eval_policy`:

```
Set to 1 for closed-loop receding-horizon control (re-observe every step; matches OpenVLA-style eval).
```

That advice only holds for **single-action** policies (`execution_horizon == 1`). For a chunk-emitting VLA, `action_horizon=1` is clamped up to the full chunk — so a caller running a VLA eval and setting `action_horizon=1` expecting closed-loop control silently gets open-loop chunk execution, which changes how the eval should be interpreted.

### Confirming the behavior

On `lerobot/smolvla_base` (`execution_horizon = actions_per_step = 50`, `supports_rtc = False`), a 110-step rollout at 30 Hz queries the policy at control-steps `[0, 25, 75]` (3 vision queries), and `action_horizon ∈ {2, 8, 16, 32}` all produce byte-identical trajectories — the value is inert below the chunk length, as `resolve_chunk_length` dictates.

## Change

Docs only — no behavior change. Corrects the `action_horizon` docstrings on the public rollout entry points (`run_policy`, `eval_policy`, `run_policy` tool) to state the `max(action_horizon, execution_horizon)` clamp and that RTC policies ignore it, and qualifies the `eval_policy` "set to 1 for closed-loop" note to single-action policies. `start_policy` and `resolve_chunk_length` already documented this accurately and are unchanged. The clamp semantics themselves remain covered by `tests/policies/test_chunked_policy_contract.py` (unchanged, 26 passed).

## Test

`ruff`/`mypy` clean; `tests/policies/test_chunked_policy_contract.py` 26 passed. No functional change (docstring/CHANGELOG only).