### PR TITLE
fix(training): honor TrainSpec.learning_rate in lerobot_local (None now means the backend default)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,21 @@ split would silently drop samples), so the reference PPO entry point exited
 with `spec invalid` before training ever started. The example now uses
 `num_mini_batches=5` (`250 % 5 == 0`, 50 samples/mini-batch).
 
+### Fixed: `TrainSpec.learning_rate` was silently ignored by the `lerobot_local` trainer
+
+Every other backend honors `TrainSpec.learning_rate` (PPO / FastSAC bind it to
+their optimizers, GR00T and Cosmos forward it), and the `train_policy` tool
+exposes it as a first-class parameter -- but the lerobot trainer never wired it
+into the config it builds, so the policy's training-preset LR (1e-5 for ACT)
+was always used and a user-set value was silently ignored (confirmed on a real
+base + post-tune ACT run: the logs show `lr:1.0e-05` regardless of the spec).
+An explicit `learning_rate` now reaches `policy.optimizer_lr` on both the
+typed-config and argv-parity paths, and fails loudly for a policy type without
+that field. Compat: the field's default changed from `1e-4` to `None` ("use
+the backend's default") -- behavior with an unset `learning_rate` is unchanged
+in every backend (RL / GR00T / Cosmos fall back to the previous `1e-4`
+default; lerobot keeps the policy preset).
+
 ### Fixed: registry hot-reload ignored the user-overlay file's mtime
 
 The `robots` registry the read API serves (`get_robot` / `list_robots` /

--- a/strands_robots/tools/train_policy.py
+++ b/strands_robots/tools/train_policy.py
@@ -56,7 +56,7 @@ def train_policy(
     embodiment: str | None = None,
     steps: int = 10000,
     batch_size: int = 32,
-    learning_rate: float = 1e-4,
+    learning_rate: float | None = None,
     save_freq: int = 1000,
     num_gpus: int = 1,
     num_nodes: int = 1,
@@ -107,7 +107,8 @@ def train_policy(
         embodiment: Embodiment tag (REQUIRED for GR00T; inferred by lerobot).
         steps: Total optimizer steps.
         batch_size: Global batch size (summed across GPUs).
-        learning_rate: Initial LR.
+        learning_rate: Initial LR (``None`` keeps each backend's own
+            default; see ``TrainSpec.learning_rate``).
         save_freq: Checkpoint cadence in steps.
         num_gpus: GPUs on this node (``>1`` -> accelerate/torchrun multi-GPU).
         num_nodes: Nodes (Cosmos HSDP / torchrun ``--nnodes``).

--- a/strands_robots/training/base.py
+++ b/strands_robots/training/base.py
@@ -39,6 +39,11 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any
 
+#: LR the RL (PPO / FastSAC), GR00T, and Cosmos backends apply when
+#: ``TrainSpec.learning_rate`` is None - the field's previous default.
+#: The lerobot backend instead keeps the policy's training-preset LR.
+DEFAULT_LEARNING_RATE: float = 1e-4
+
 
 @dataclass
 class TrainSpec:
@@ -79,7 +84,11 @@ class TrainSpec:
         steps: Total optimizer steps (maps to lerobot ``--steps`` /
             GR00T ``max_steps`` / Cosmos ``trainer.max_iter``).
         global_batch_size: Batch summed across GPUs before grad accumulation.
-        learning_rate: Initial LR.
+        learning_rate: Initial LR. ``None`` (the default) means "the
+            backend's own default": PPO / FastSAC / GR00T / Cosmos fall back
+            to :data:`DEFAULT_LEARNING_RATE` (``1e-4``, this field's previous
+            default) and lerobot keeps the policy's training-preset LR. An
+            explicit value is honored by every backend.
         save_freq: Checkpoint cadence in steps.
         num_gpus: GPUs on this node. ``>1`` runs the backend under torch's
             in-process ``elastic_launch`` (the engine behind ``torchrun``).
@@ -118,7 +127,7 @@ class TrainSpec:
     embodiment: str | None = None
     steps: int = 10_000
     global_batch_size: int = 32
-    learning_rate: float = 1e-4
+    learning_rate: float | None = None
     save_freq: int = 1_000
     num_gpus: int = 1
     num_nodes: int = 1

--- a/strands_robots/training/cosmos3.py
+++ b/strands_robots/training/cosmos3.py
@@ -38,7 +38,7 @@ import time
 from typing import Any
 
 from strands_robots.training._inproc import call_callable, elastic_launch_callable
-from strands_robots.training.base import Trainer, TrainResult, TrainSpec
+from strands_robots.training.base import DEFAULT_LEARNING_RATE, Trainer, TrainResult, TrainSpec
 
 logger = logging.getLogger(__name__)
 
@@ -221,10 +221,11 @@ class Cosmos3Trainer(Trainer):
         after the TOML so they win. Caller ``extra.*`` keys are gated by
         ``validate()``'s allowlist so a stray entry can't inject tokens.
         """
+        lr = spec.learning_rate if spec.learning_rate is not None else DEFAULT_LEARNING_RATE
         overrides = [
             f"trainer.max_iter={spec.steps}",
             f"checkpoint.save_iter={spec.save_freq}",
-            f"optimizer.lr={spec.learning_rate}",
+            f"optimizer.lr={lr}",
             f"checkpoint.load_path={self._dcp_path(spec)}",
             f"dataloader_train.max_samples_per_batch={spec.global_batch_size}",
         ]

--- a/strands_robots/training/groot.py
+++ b/strands_robots/training/groot.py
@@ -46,7 +46,7 @@ import time
 from typing import Any
 
 from strands_robots.training._inproc import call_callable, elastic_launch_callable
-from strands_robots.training.base import Trainer, TrainResult, TrainSpec
+from strands_robots.training.base import DEFAULT_LEARNING_RATE, Trainer, TrainResult, TrainSpec
 
 logger = logging.getLogger(__name__)
 
@@ -189,6 +189,7 @@ class Gr00tTrainer(Trainer):
         else:
             launcher = ["python", script]
 
+        lr = spec.learning_rate if spec.learning_rate is not None else DEFAULT_LEARNING_RATE
         cmd = [
             *launcher,
             f"--base_model_path={spec.base_model}",
@@ -197,7 +198,7 @@ class Gr00tTrainer(Trainer):
             f"--output_dir={spec.output_dir}",
             f"--max_steps={spec.steps}",
             f"--global_batch_size={spec.global_batch_size}",
-            f"--learning_rate={spec.learning_rate}",
+            f"--learning_rate={lr}",
             f"--save_steps={spec.save_freq}",
             f"--num_gpus={spec.num_gpus}",
         ]
@@ -243,6 +244,7 @@ class Gr00tTrainer(Trainer):
         import dataclasses
 
         tune = self._resolve_tune(spec)
+        lr = spec.learning_rate if spec.learning_rate is not None else DEFAULT_LEARNING_RATE
         kwargs: dict[str, Any] = {
             "base_model_path": spec.base_model,
             "dataset_path": spec.dataset_root,
@@ -250,7 +252,7 @@ class Gr00tTrainer(Trainer):
             "output_dir": spec.output_dir,
             "max_steps": spec.steps,
             "global_batch_size": spec.global_batch_size,
-            "learning_rate": spec.learning_rate,
+            "learning_rate": lr,
             "save_steps": spec.save_freq,
             "num_gpus": spec.num_gpus,
             "tune_llm": tune["llm"],

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -551,6 +551,8 @@ class LerobotTrainer(Trainer):
             cmd.append(f"--policy.type={ptype}")
             cmd.append(f"--policy.device={self.device}")
             cmd.append("--policy.push_to_hub=false")
+            if spec.learning_rate is not None:
+                cmd.append(f"--policy.optimizer_lr={spec.learning_rate}")
         cmd.extend(
             [
                 f"--output_dir={spec.output_dir}",
@@ -737,6 +739,15 @@ class LerobotTrainer(Trainer):
                     f"use_relative_actions field (supported: {sorted(_RELATIVE_ACTION_POLICY_TYPES)})"
                 )
             policy_cfg.use_relative_actions = True
+
+        if spec.learning_rate is not None:
+            if not hasattr(policy_cfg, "optimizer_lr"):
+                raise ValueError(
+                    f"TrainSpec.learning_rate is set but policy_type '{ptype}' exposes no "
+                    "optimizer_lr field; drop learning_rate or set the policy's own LR "
+                    "field via extra={'policy.<field>': ...}."
+                )
+            policy_cfg.optimizer_lr = spec.learning_rate
 
         peft_cfg = None
         if spec.method == "lora":

--- a/strands_robots/training/rl/fast_sac.py
+++ b/strands_robots/training/rl/fast_sac.py
@@ -29,7 +29,7 @@ import json
 import os
 from typing import TYPE_CHECKING, Any
 
-from strands_robots.training.base import TrainResult, TrainSpec
+from strands_robots.training.base import DEFAULT_LEARNING_RATE, TrainResult, TrainSpec
 from strands_robots.training.rl.base_algo import BaseRLAlgo, RLTrainSpec
 from strands_robots.utils import require_optional
 
@@ -183,8 +183,9 @@ class FastSacTrainer(BaseRLAlgo):
 
         actor_params = list(self.actor_critic.actor.parameters())
         critic_params = list(self.actor_critic.q1.parameters()) + list(self.actor_critic.q2.parameters())
-        self.actor_optimizer = torch.optim.Adam(actor_params, lr=spec.learning_rate)
-        self.critic_optimizer = torch.optim.Adam(critic_params, lr=spec.learning_rate)
+        lr = spec.learning_rate if spec.learning_rate is not None else DEFAULT_LEARNING_RATE
+        self.actor_optimizer = torch.optim.Adam(actor_params, lr=lr)
+        self.critic_optimizer = torch.optim.Adam(critic_params, lr=lr)
 
         # Automatic entropy temperature (alpha): optimize log_alpha against the
         # target entropy (default -num_actions, the SAC heuristic).

--- a/strands_robots/training/rl/ppo.py
+++ b/strands_robots/training/rl/ppo.py
@@ -18,7 +18,7 @@ import json
 import os
 from typing import TYPE_CHECKING, Any
 
-from strands_robots.training.base import TrainSpec
+from strands_robots.training.base import DEFAULT_LEARNING_RATE, TrainSpec
 from strands_robots.training.rl.base_algo import BaseRLAlgo, RLTrainSpec
 from strands_robots.utils import require_optional
 
@@ -196,7 +196,8 @@ class PpoTrainer(BaseRLAlgo):
         self.actor_critic = _build_actor_critic(
             self.env.num_actor_obs, self.env.num_critic_obs, self.env.num_actions, spec
         ).to(self.device)
-        self.optimizer = torch.optim.Adam(self.actor_critic.parameters(), lr=spec.learning_rate)
+        lr = spec.learning_rate if spec.learning_rate is not None else DEFAULT_LEARNING_RATE
+        self.optimizer = torch.optim.Adam(self.actor_critic.parameters(), lr=lr)
 
         self.actor_norm = EmpiricalNormalization(self.env.num_actor_obs, self.device) if spec.normalize_obs else None
         self.critic_norm = EmpiricalNormalization(self.env.num_critic_obs, self.device) if spec.normalize_obs else None

--- a/tests/training/test_lerobot.py
+++ b/tests/training/test_lerobot.py
@@ -312,6 +312,28 @@ class TestBuildCommandResume:
         assert "--resume=true" not in cmd
 
 
+class TestLearningRateWiring:
+    """TrainSpec.learning_rate must reach lerobot; None must keep the preset LR."""
+
+    def test_explicit_learning_rate_reaches_policy_config_and_argv(self, spec):
+        pytest.importorskip("lerobot")
+        spec.learning_rate = 5e-5
+        cfg = LerobotTrainer(device="cpu").build_config(spec)
+        assert cfg.policy.optimizer_lr == 5e-5
+        cmd = LerobotTrainer(device="cpu").build_command(spec)
+        assert "--policy.optimizer_lr=5e-05" in cmd
+
+    def test_default_none_keeps_policy_preset_lr(self, spec):
+        pytest.importorskip("lerobot")
+        from lerobot.policies.factory import make_policy_config
+
+        assert spec.learning_rate is None  # the TrainSpec default
+        cfg = LerobotTrainer(device="cpu").build_config(spec)
+        assert cfg.policy.optimizer_lr == make_policy_config("act").optimizer_lr
+        cmd = LerobotTrainer(device="cpu").build_command(spec)
+        assert not any(t.startswith("--policy.optimizer_lr=") for t in cmd)
+
+
 class TestBuildConfigAdditionalBranches:
     def test_expert_only_sets_flag(self, spec):
         pytest.importorskip("lerobot")


### PR DESCRIPTION
Fixes #1020.

`TrainSpec.learning_rate` was honored by four of the five backends (PPO / FastSAC bind it to their optimizers, GR00T / Cosmos forward it) and exposed as a first-class `train_policy` tool parameter — but the lerobot trainer never mapped it (the only universal spec field `training/lerobot.py` doesn't read), so the policy's training-preset LR always won and a user-set value was silently ignored. Confirmed on a real base + post-tune ACT run (A100): both phases logged `lr:1.0e-05` regardless of the spec.

The fix follows the spec's own `seed` pattern:

- `TrainSpec.learning_rate: float | None = None` — `None` means "the backend's own default". Unset behavior is unchanged in **every** backend: PPO / FastSAC / GR00T / Cosmos fall back to `DEFAULT_LEARNING_RATE = 1e-4` (the previous field default), lerobot keeps the policy preset.
- An explicit value now reaches lerobot on both build paths: `build_config()` sets `cfg.policy.optimizer_lr` (which `get_optimizer_preset()` reads) and `build_command()` emits `--policy.optimizer_lr=...` — and a policy type without an `optimizer_lr` field raises a clear `ValueError` instead of ignoring the request. (The spec's tolerance rule protects fields a backend *doesn't use*; an explicitly requested value it *can't honor* shouldn't vanish.)
- The `train_policy` tool signature follows (`learning_rate: float | None = None`; the parameter name is unchanged, so the agent action contract is intact).

Tests: 2 new in `tests/training/test_lerobot.py` (an explicit LR reaches `policy.optimizer_lr` and the argv mirror; the default `None` keeps the ACT preset and emits no flag). Existing GR00T / Cosmos / RL tests pass unchanged — the `1e-4` fallback preserves their previous rendering exactly.

Compat note (also in the CHANGELOG): the field default changed `1e-4` → `None`. No runtime behavior changes for unset specs; the griffe breaking-change report will flag the default change — that's this change, by design. If you'd rather keep `float = 1e-4` and only warn from `validate()` that lerobot ignores the field, happy to switch — the trade-off is that an explicit 1e-4 then can't be expressed for lerobot.

Found tuning a two-phase (base → post-tune) ACT training for an SO-101 dataset on Colab; the silent preset LR is why both phases trained at 1e-5.
