### PR TITLE
feat(hardware): run_policy(policy_object=...) on the hardware Robot (sim parity for pre-built policies)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Added: `run_policy(policy_object=...)` on the hardware `Robot` -- sim parity for pre-built policies
+
+The simulation side has a one-call rollout for a policy constructed in-process
+(`Simulation.run_policy(policy_object=..., n_steps=...)`), but the hardware
+path's only control loop (`start_task`) builds its own server-backed policy
+from `policy_provider` + `policy_port` and accepts no policy object -- so
+deploying a local checkpoint on an edge device (in-process policy, no server
+on a port) meant hand-writing the connect -> observe -> get_actions ->
+send_action loop the library already contains. The hardware `Robot` now has
+`run_policy(policy_object=..., instruction=..., duration=..., n_steps=None)`
+(blocking): it drives the caller's object through the exact `start_task` loop
+(connect with half-open-port rollback, state-key initialization, the RTC
+control-frequency / observed-delay contract, `resolve_chunk_length` chunk
+consumption), stops at `duration` or after `n_steps` applied actions (the sim
+parameter), and returns a text + `{"json": ...}` result per the tool-result
+contract. `start_task` and the provider+port path are unchanged.
+
 ### Fixed: `TrainSpec.learning_rate` was silently ignored by the `lerobot_local` trainer
 
 `learning_rate` was the one universal `TrainSpec` field with zero references in

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -971,8 +971,16 @@ class Robot(TeleopMixin, AgentTool):
         policy_host: str = "localhost",
         policy_provider: str = "groot",
         duration: float = 30.0,
+        policy_object: Policy | None = None,
+        n_steps: int | None = None,
     ) -> None:
-        """Execute robot task in background thread (internal method)."""
+        """Execute robot task in background thread (internal method).
+
+        ``policy_object`` (when given) is driven as-is and the provider/port
+        arguments are ignored - the ``run_policy`` path. ``n_steps`` caps the
+        number of applied actions; the loop stops at whichever of
+        ``duration`` / ``n_steps`` comes first.
+        """
         # resolve_chunk_length lives in the light policies.base module (no torch);
         # imported lazily to match this file's policy-import convention.
         from .policies.base import resolve_chunk_length
@@ -992,8 +1000,12 @@ class Robot(TeleopMixin, AgentTool):
                 self._task_state.error_message = connect_error or f"Failed to connect to {self.tool_name_str}"
                 return
 
-            # Get policy instance
-            policy_instance = await self._get_policy(policy_port, policy_host, policy_provider)
+            # Get policy instance: a caller-supplied pre-built object wins;
+            # otherwise build the server-backed one from provider + port.
+            if policy_object is not None:
+                policy_instance = policy_object
+            else:
+                policy_instance = await self._get_policy(policy_port, policy_host, policy_provider)
 
             # Initialize policy with robot state keys
             if not await self._initialize_policy(policy_instance):
@@ -1002,7 +1014,10 @@ class Robot(TeleopMixin, AgentTool):
                 return
 
             logger.info(f"Starting task: '{instruction}' on {self.tool_name_str}")
-            logger.info(f"Using policy: {policy_provider} on {policy_host}:{policy_port}")
+            if policy_object is not None:
+                logger.info(f"Using pre-built policy object: {type(policy_instance).__name__}")
+            else:
+                logger.info(f"Using policy: {policy_provider} on {policy_host}:{policy_port}")
 
             # Real-Time Chunking contract (mirror PolicyRunner._run_policy_rollout
             # in strands_robots/simulation/policy_runner.py): tell the policy the
@@ -1018,6 +1033,7 @@ class Robot(TeleopMixin, AgentTool):
 
             while (
                 time.time() - start_time < duration
+                and (n_steps is None or self._task_state.step_count < n_steps)
                 and self._task_state.status == TaskStatus.RUNNING
                 and not self._shutdown_event.is_set()
             ):
@@ -1053,6 +1069,8 @@ class Robot(TeleopMixin, AgentTool):
                 for action_dict in robot_actions[:chunk_len]:
                     if self._task_state.status != TaskStatus.RUNNING:
                         break
+                    if n_steps is not None and self._task_state.step_count >= n_steps:
+                        break
                     await asyncio.to_thread(self.robot.send_action, action_dict)
                     self._task_state.step_count += 1
                     # Wait for action to complete before sending next action
@@ -1079,6 +1097,8 @@ class Robot(TeleopMixin, AgentTool):
         policy_host: str = "localhost",
         policy_provider: str = "groot",
         duration: float = 30.0,
+        policy_object: Policy | None = None,
+        n_steps: int | None = None,
     ) -> dict[str, Any]:
         """Execute task synchronously in thread - no new event loop."""
 
@@ -1087,7 +1107,15 @@ class Robot(TeleopMixin, AgentTool):
 
         # Run task without creating new event loop - let it run in thread
         async def task_runner() -> None:
-            await self._execute_task_async(instruction, policy_port, policy_host, policy_provider, duration)
+            await self._execute_task_async(
+                instruction,
+                policy_port,
+                policy_host,
+                policy_provider,
+                duration,
+                policy_object=policy_object,
+                n_steps=n_steps,
+            )
 
         # Use asyncio.run only if no loop is running, otherwise run in existing loop
         try:
@@ -1104,13 +1132,18 @@ class Robot(TeleopMixin, AgentTool):
             asyncio.run(task_runner())
 
         # Return final status
+        policy_desc = (
+            f"{type(policy_object).__name__} (pre-built object)"
+            if policy_object is not None
+            else f"{policy_provider} on {policy_host}:{policy_port}"
+        )
         return {
             "status": "success" if self._task_state.status == TaskStatus.COMPLETED else "error",
             "content": [
                 {
                     "text": f"Task: '{instruction}' - {self._task_state.status.value}\n"
                     f"Robot: {self.tool_name_str} ({self.robot})\n"
-                    f"Policy: {policy_provider} on {policy_host}:{policy_port}\n"
+                    f"Policy: {policy_desc}\n"
                     f"Duration: {self._task_state.duration:.1f}s\n"
                     f"Steps: {self._task_state.step_count}"
                     + (f"\nError: {self._task_state.error_message}" if self._task_state.error_message else "")
@@ -1150,6 +1183,81 @@ class Robot(TeleopMixin, AgentTool):
                     f"Use action='stop' to interrupt"
                 }
             ],
+        }
+
+    def run_policy(
+        self,
+        policy_object: Policy,
+        instruction: str = "",
+        duration: float = 30.0,
+        n_steps: int | None = None,
+    ) -> dict[str, Any]:
+        """Run a pre-built policy object on the real robot (blocking).
+
+        Hardware counterpart of ``Simulation.run_policy(policy_object=...)``:
+        drive a policy already constructed in-process (e.g. via
+        ``create_policy(...)`` around a local checkpoint) without standing up
+        a policy server on a port. Reuses the exact ``start_task`` control
+        loop - connect (with half-open rollback), state-key initialization,
+        the RTC control-frequency / observed-delay contract, and
+        ``resolve_chunk_length`` chunk consumption - so a pre-built object
+        and a server-backed provider behave identically on the wire.
+
+        Blocking: returns when ``duration`` elapses, after ``n_steps``
+        applied actions, or when ``stop_task()`` is called from another
+        thread. For the server-backed provider path (and for fire-and-forget
+        execution) use ``start_task``.
+
+        Args:
+            policy_object: A constructed ``Policy`` instance. The object's
+                own device / embodiment / chunking configuration is honored;
+                the loop only injects the robot state keys and the RTC
+                control rate, exactly as it does for server-backed policies.
+            instruction: Natural-language instruction passed to the policy on
+                every ``get_actions`` call.
+            duration: Wall-clock budget in seconds (same default as
+                ``start_task``).
+            n_steps: Optional cap on applied actions (mirrors the sim
+                ``run_policy`` parameter); the loop stops at whichever of
+                ``duration`` / ``n_steps`` comes first.
+
+        Returns:
+            Tool-shaped result: a text summary plus a ``{"json": ...}`` block
+            carrying ``status`` / ``steps`` / ``duration_s`` / ``instruction``
+            / ``policy`` (and ``error`` when one occurred).
+        """
+        if policy_object is None:
+            return {
+                "status": "error",
+                "content": [{"text": "policy_object is required (for the provider+port path use start_task)"}],
+            }
+        if self._task_state.status == TaskStatus.RUNNING:
+            return {
+                "status": "error",
+                "content": [{"text": f"Task already running: {self._task_state.instruction}"}],
+            }
+
+        self._execute_task_sync(instruction, duration=duration, policy_object=policy_object, n_steps=n_steps)
+
+        succeeded = self._task_state.status == TaskStatus.COMPLETED
+        summary = (
+            f"Policy rollout {self._task_state.status.value}: "
+            f"{self._task_state.step_count} steps in {self._task_state.duration:.1f}s "
+            f"({type(policy_object).__name__} on {self.tool_name_str})"
+        )
+        payload: dict[str, Any] = {
+            "status": self._task_state.status.value,
+            "steps": self._task_state.step_count,
+            "duration_s": round(self._task_state.duration, 3),
+            "instruction": instruction,
+            "policy": type(policy_object).__name__,
+        }
+        if self._task_state.error_message:
+            payload["error"] = self._task_state.error_message
+            summary += f"\nError: {self._task_state.error_message}"
+        return {
+            "status": "success" if succeeded else "error",
+            "content": [{"text": summary}, {"json": payload}],
         }
 
     def get_task_status(self) -> dict[str, Any]:

--- a/tests/test_hardware_robot_lifecycle.py
+++ b/tests/test_hardware_robot_lifecycle.py
@@ -373,6 +373,84 @@ class TestExecuteTaskAsync:
         hw.cleanup()
 
 
+@pytest.mark.timeout(30)
+class TestRunPolicyObject:
+    """``run_policy(policy_object=...)`` - sim-parity rollout for pre-built policies.
+
+    The hardware counterpart of ``Simulation.run_policy(policy_object=...)``:
+    the caller's own object must be initialized and driven through the same
+    control loop ``start_task`` uses, ``n_steps`` must bound the applied
+    actions deterministically (no wall-clock dependence), and the server-policy
+    construction path (``_get_policy``) must never run.
+    """
+
+    def test_drives_prebuilt_object_and_reports_json(self):
+        fake = _FakeLeRobot(connected=False)
+        hw = _make_robot(fake)
+        policy = _StubPolicy()
+
+        async def _boom(*a, **k):
+            raise AssertionError("_get_policy must not be called when policy_object is given")
+
+        hw._get_policy = _boom  # type: ignore[assignment]
+        result = hw.run_policy(policy_object=policy, instruction="pick", n_steps=4)
+
+        assert result["status"] == "success"
+        payload = tool_json(result)
+        assert payload["status"] == "completed"
+        assert payload["steps"] == 4
+        assert payload["policy"] == "_StubPolicy"
+        assert len(fake.sent_actions) == 4
+        # The caller's OWN object was initialized and driven (identity, not a
+        # rebuilt copy): state keys + the RTC control rate landed on it.
+        assert policy.state_keys == ["j0.pos", "j1.pos"]
+        assert policy.control_frequency_calls == [1000.0]
+        assert all(d == 0 for d in policy.observed_delays)
+        hw.cleanup()
+
+    def test_n_steps_stops_mid_chunk(self):
+        fake = _FakeLeRobot(connected=False)
+        hw = _make_robot(fake)
+
+        class _FiveChunk(_StubPolicy):
+            async def get_actions(self, observation, instruction):
+                return [{"j0.pos": 0.1 * i} for i in range(5)]
+
+        result = hw.run_policy(policy_object=_FiveChunk(), instruction="pick", n_steps=3)
+        assert result["status"] == "success"
+        assert tool_json(result)["steps"] == 3
+        assert len(fake.sent_actions) == 3  # stopped inside the 5-action chunk
+        hw.cleanup()
+
+    def test_requires_policy_object(self):
+        hw = _make_robot()
+        result = hw.run_policy(policy_object=None)  # type: ignore[arg-type]
+        assert result["status"] == "error"
+        assert "policy_object is required" in result["content"][0]["text"]
+        hw.cleanup()
+
+    def test_rejects_concurrent_task(self):
+        hw = _make_robot()
+        hw._task_state.status = TaskStatus.RUNNING
+        hw._task_state.instruction = "busy"
+        result = hw.run_policy(policy_object=_StubPolicy(), instruction="pick", n_steps=1)
+        assert result["status"] == "error"
+        assert "already running" in result["content"][0]["text"].lower()
+        hw._task_state.status = TaskStatus.IDLE
+        hw.cleanup()
+
+    def test_connect_failure_reports_error_payload(self):
+        fake = _FakeLeRobot(connected=False, calibrated=False)
+        hw = _make_robot(fake)
+        result = hw.run_policy(policy_object=_StubPolicy(), instruction="pick", n_steps=1)
+        assert result["status"] == "error"
+        payload = tool_json(result)
+        assert payload["status"] == "error"
+        assert "not calibrated" in payload["error"]
+        assert fake.sent_actions == []
+        hw.cleanup()
+
+
 class _RtcChunkPolicy(Policy):
     """RTC-capable policy: emits a 5-action chunk but owns a 2-step re-query.
 


### PR DESCRIPTION
Fixes #1025 (the rollout half; the recording half is tracked there).

## Problem

`Simulation.run_policy(policy_object=..., n_steps=...)` gives sim users a one-call rollout for a policy constructed in-process, but the hardware `Robot`'s only control loop (`start_task`) builds its own server-backed policy from `policy_provider` + `policy_port` and accepts no policy object. On an edge device the policy runs in-process (a local checkpoint via `create_policy(...)`, no server on a port) — exactly the combination the hardware loop can't wrap — so deploying a local ACT checkpoint on a real SO-101 from a CPU-only Jetson meant hand-writing the `connect → observe → get_actions → send_action` loop that `_execute_task_async` already implements.

## Change

- `_execute_task_async` / `_execute_task_sync` gain `policy_object: Policy | None = None` and `n_steps: int | None = None`. A caller-supplied object wins over the provider+port construction; `n_steps` caps applied actions (checked mid-chunk too), and the loop stops at whichever of `duration` / `n_steps` comes first. With both parameters at their defaults the code path is byte-for-byte the previous one — `start_task` and the server-backed path are unchanged.
- New public `run_policy(policy_object, instruction="", duration=30.0, n_steps=None)` on the hardware `Robot` (blocking, mirroring the sim method's semantics for these parameters). It reuses the exact `start_task` machinery: connect with the half-open-port rollback, `_initialize_policy` state-key injection, the RTC control-frequency / observed-delay contract, and `resolve_chunk_length` chunk consumption — so a pre-built object and a server-backed provider behave identically on the wire. `stop_task()` from another thread still interrupts it, and `get_task_status()` reports it while it runs.
- Returns follow the tool-result contract: a text summary plus a `{"json": {...}}` block with `status` / `steps` / `duration_s` / `instruction` / `policy` (+ `error` when one occurred).
- Deliberately **not** added to the agent `tool_spec`: a Python policy object can't cross the JSON tool boundary — this is the programmatic surface, the same way `policy_object` is on the sim side. No tool schema changes (agent action contract untouched).

## Tests

5 new tests in `tests/test_hardware_robot_lifecycle.py` (same fake-robot / stub-policy rig the existing loop tests use):

- a pre-built object is initialized and driven as-is (state keys + RTC control rate land on the caller's object; `_get_policy` is monkeypatched to raise, proving the server path never runs), and the json payload reports `steps` / `status`
- `n_steps` stops mid-chunk (5-action chunk, `n_steps=3` → exactly 3 actions applied) — deterministic, no wall-clock dependence
- missing `policy_object` → structured caller error pointing at `start_task` for the provider path
- a concurrent running task is rejected (same guard as `start_task`)
- a connect failure surfaces as `status="error"` with the message in the json payload and zero actions sent

`tests/test_hardware_robot_lifecycle.py` + the repo-wide tool-result contract audit + changelog format: 69 passed. Neighboring hardware suites (`test_robot_factory`, `test_customer_workflow_regressions`, `test_device_connect_hardening`): 149 passed, 1 skipped. Lint clean.

Live SO-101 verification (Jetson Orin Nano, CPU-only, in-process policy): on current `main` the harness script exits red (`Robot.run_policy` missing); on this branch the same script (a) drives a do-nothing hold-position policy for 100 steps (`status=completed, steps=100, duration_s=2.1`, arm visibly stationary — safe loop smoke) and (b) drives a self-trained local ACT checkpoint loaded via `create_policy(...)` for 150 and 600 steps (`steps=600, duration_s=19.0`), with task behaviour matching the previously hand-written loop run-for-run — `n_steps` visibly capping mid-task at 150. The lifecycle suite also passes on the ARM board (56 passed), and the neighbouring hardware suites match `main`'s results exactly there (no branch-attributable failures).

Found deploying a self-trained (base + post-tuned) ACT checkpoint on a real SO-101 from a CPU-only Jetson Orin Nano.
