### PR TITLE
test(sim): validate apply_force vector elements are finite numbers

### DIFF
--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -16,6 +16,7 @@ Exposes the deep MuJoCo C API through clean Python methods:
 """
 
 import logging
+import math
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -234,6 +235,30 @@ class PhysicsMixin:
                         "status": "error",
                         "content": [{"text": f"apply_force: '{_name}' must be a list/tuple of 3 numbers"}],
                     }
+                # Every element must be a finite real number. Without this,
+                # non-numeric elements (e.g. ["a", "b", "c"]) raise ValueError
+                # inside np.array(dtype=float64) - escaping the structured-error
+                # contract - and nan/inf or nested lists slip silently into
+                # mj_applyFT, injecting bad state into the physics buffer.
+                # bool is intentionally accepted (subclass of int -> finite);
+                # rejecting it is out of scope for numeric-element validation.
+                for _elem in _vec:
+                    try:
+                        _f = float(_elem)
+                    except (TypeError, ValueError):
+                        return {
+                            "status": "error",
+                            "content": [{"text": f"apply_force: '{_name}' elements must be numbers, got {_vec!r}"}],
+                        }
+                    if not math.isfinite(_f):
+                        return {
+                            "status": "error",
+                            "content": [
+                                {
+                                    "text": f"apply_force: '{_name}' must contain finite numbers (no nan/inf), got {_vec!r}"
+                                }
+                            ],
+                        }
 
         mj = _ensure_mujoco()
         model, data = self._world._model, self._world._data

--- a/tests/simulation/mujoco/test_input_validation.py
+++ b/tests/simulation/mujoco/test_input_validation.py
@@ -151,6 +151,45 @@ class TestApplyForceValidation:
         assert res["status"] == "error"
         assert "3-element" in res["content"][0]["text"]
 
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            # non-numeric elements: pre-fix these raise ValueError inside
+            # np.array(dtype=float64), escaping the structured-error contract.
+            {"force": ["a", "b", "c"]},
+            {"torque": ["x", "y", "z"]},
+            {"force": [0.0, 0.0, 0.0], "point": ["p", "q", "r"]},
+            # nested lists are length-3 but not scalar numbers.
+            {"force": [[1], [2], [3]]},
+            # None element is neither a number nor iterable of length mismatch.
+            {"force": [1, None, 3]},
+        ],
+    )
+    def test_non_numeric_elements_error(self, sim_with_robot, kwargs):
+        """Regression: 3-element vectors with non-numeric entries must return a
+        structured error, not raise or silently coerce into the physics buffer."""
+        res = sim_with_robot.apply_force(body_name="link1", **kwargs)
+        assert res["status"] == "error"
+        assert "must be numbers" in res["content"][0]["text"]
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            # nan/inf pass the length check and, pre-fix, are silently applied to
+            # qfrc_applied - poisoning every subsequent mj_step.
+            {"force": [float("nan"), 0.0, 0.0]},
+            {"force": [float("inf"), 0.0, 0.0]},
+            {"torque": [0.0, float("-inf"), 0.0]},
+            {"force": [0.0, 0.0, 0.0], "point": [0.0, 0.0, float("nan")]},
+        ],
+    )
+    def test_non_finite_elements_error(self, sim_with_robot, kwargs):
+        """Regression: nan/inf in a force/torque/point vector must return a
+        structured error instead of injecting non-finite state into physics."""
+        res = sim_with_robot.apply_force(body_name="link1", **kwargs)
+        assert res["status"] == "error"
+        assert "finite numbers" in res["content"][0]["text"]
+
 
 # negative/invalid mass, timestep
 


### PR DESCRIPTION
## Summary

`PhysicsMixin.apply_force` validated the *length* of the `force` / `torque` / `point` vectors (must be 3 elements) but never the element *type*. Two silent-failure classes slipped through:

1. **Non-numeric elements escape the structured-error contract.** A length-3 vector of non-numbers (e.g. `force=["a", "b", "c"]` — a realistic shape for LLM-sourced JSON args) passed the length guard and reached `np.array(..., dtype=np.float64)`, which raises `ValueError`. That exception bypasses the `{"status": "error", ...}` dict every dispatch handler is supposed to return (AGENTS.md: *"Return error dicts, never raise"*).
2. **nan/inf and nested lists poison the physics buffer silently.** `force=[float("nan"), 0, 0]` and `force=[[1],[2],[3]]` are length-3, pass every existing check, and flow straight into `mj_applyFT`, latching non-finite / wrong-shape state into `qfrc_applied` that then corrupts every subsequent `mj_step`.

## Change

Extend the existing per-vector validation loop with a single per-element pass: each element must convert via `float()` and be `math.isfinite`. On failure the method returns the same structured-error shape as the neighbouring length check — no new error channel, no signature change.

`bool` is intentionally accepted (it is a subclass of `int` and always finite); rejecting it is intent-inference, out of scope for numeric-element validation. A code comment records that decision.

## Tests (pinned regressions)

Added to `TestApplyForceValidation`, parametrized across `force` / `torque` / `point`:
- `test_non_numeric_elements_error` — strings, nested lists, `None` element
- `test_non_finite_elements_error` — `nan`, `inf`, `-inf`

Each case fails on pre-fix code (verified: 9 failures with the source change stashed — non-finite and nested/None cases silently returned `success`; string cases raised). All 12 pass post-fix; full `test_input_validation.py` + `test_physics.py` (144 passed, 4 GL-skipped) confirm no regression. `ruff check` + `ruff format --check` clean.

Hardens the same setter-input surface as #1024 / #1027 / #1030.