### PR TITLE
fix(sim): recompute geom_rbound/geom_aabb when set_geom_properties resizes a geom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -307,6 +307,21 @@ compound-pendulum check, a mass-only change wrongly shrank the swing period ~2x
 (0.87 s vs 1.76 s); with the fix the period stays mass-invariant as physics
 requires. Massless frames (mass 0) are guarded against division by zero.
 
+### Fixed: `set_geom_properties(size=...)` left stale collision bounds so grown geoms were passed through
+
+Resizing a primitive geom at runtime wrote the new `geom_size` but never
+refreshed `geom_rbound` (the broadphase bounding-sphere radius) or `geom_aabb`
+(the mid-phase AABB), both of which are derived from `geom_size` at compile time
+and are not recomputed by `mj_forward`/`mj_step`. A geom grown past its original
+bounds was therefore silently culled from the broadphase, so other bodies passed
+straight through it while the call still reported `status="success"`. In a
+repro, a ball dropped onto a small platform grown into a wide table fell through
+to the floor (rest z 0.03) instead of landing on it (rest z 0.55). The bounds
+are now recomputed from `geom_type` + `geom_size` for the size-defined
+primitives (sphere/capsule/cylinder/ellipsoid/box) so a grown geom collides
+correctly, matching a fresh compile at the new size. Mesh/plane/height-field
+geoms take their extent from asset data, so a `size` write stays inert for them.
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -75,6 +75,58 @@ def _full_mass_matrix(mj: Any, model: Any, data: Any) -> np.ndarray:
     return dst
 
 
+def _recompute_primitive_geom_bounds(mj: Any, model: Any, gid: int) -> bool:
+    """Recompute a geom's collision bounding volumes after a runtime size change.
+
+    ``geom_rbound`` (the broadphase bounding-sphere radius) and ``geom_aabb``
+    (the mid-phase axis-aligned bounding box) are derived from ``geom_size`` at
+    compile time and are NOT recomputed by ``mj_forward``/``mj_step``. Writing a
+    larger ``geom_size`` at runtime without refreshing them leaves the broadphase
+    culling against the old, smaller radius, so contacts with the grown surface
+    are silently dropped and other bodies pass straight through it.
+
+    Recompute both from ``geom_type`` + ``geom_size`` for the primitive types
+    whose extent is defined by ``geom_size`` (sphere, capsule, cylinder,
+    ellipsoid, box). Mesh/plane/height-field/SDF geoms derive their extent from
+    asset data, not ``geom_size``, so a size write is inert for them and their
+    bounds are left untouched.
+
+    Args:
+        mj: The imported ``mujoco`` module.
+        model: The live ``MjModel`` to update in place.
+        gid: The geom id whose ``geom_size`` was just changed.
+
+    Returns:
+        ``True`` if the bounds were recomputed (a size-defined primitive),
+        ``False`` for a type whose extent is not defined by ``geom_size``.
+    """
+    g = mj.mjtGeom
+    gtype = int(model.geom_type[gid])
+    s = [float(v) for v in model.geom_size[gid]]
+
+    # Per-type extent: (bounding-sphere radius, aabb half-extents). geom_size
+    # semantics differ by type, so both the rbound and the aabb are type-
+    # specific (they match a fresh compile at the new size).
+    if gtype == g.mjGEOM_SPHERE:
+        rbound, half = s[0], [s[0], s[0], s[0]]
+    elif gtype == g.mjGEOM_CAPSULE:
+        rbound, half = s[0] + s[1], [s[0], s[0], s[0] + s[1]]
+    elif gtype == g.mjGEOM_CYLINDER:
+        rbound, half = float(np.hypot(s[0], s[1])), [s[0], s[0], s[1]]
+    elif gtype == g.mjGEOM_ELLIPSOID:
+        rbound, half = max(s[0], s[1], s[2]), [s[0], s[1], s[2]]
+    elif gtype == g.mjGEOM_BOX:
+        rbound, half = float(np.linalg.norm(s[:3])), [s[0], s[1], s[2]]
+    else:
+        # mesh / plane / hfield / sdf: extent is not defined by geom_size.
+        return False
+
+    model.geom_rbound[gid] = float(rbound)
+    # geom_aabb layout is [center(3), half-extent(3)]; primitives are centered.
+    model.geom_aabb[gid, 3:6] = half
+    return True
+
+
 class PhysicsMixin:
     """Advanced MuJoCo physics capabilities mixed into ``Simulation``.
 
@@ -1003,7 +1055,13 @@ class PhysicsMixin:
     ) -> dict[str, Any]:
         """Modify geom properties at runtime (no recompile needed).
 
-        Changes take effect immediately for rendering (color) or next step (friction, size).
+        Changes take effect immediately for rendering (``color``) or on the next
+        step (``friction``, ``size``). When ``size`` is changed on a size-defined
+        primitive (sphere/capsule/cylinder/ellipsoid/box), the geom's collision
+        bounding volumes (``geom_rbound`` for broadphase, ``geom_aabb`` for
+        mid-phase) are recomputed so a grown geom collides correctly instead of
+        letting other bodies pass through it. Mesh/plane/height-field geoms take
+        their extent from asset data, so a ``size`` write is inert for them.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
@@ -1039,6 +1097,12 @@ class PhysicsMixin:
             if size is not None:
                 n = min(len(size), 3)
                 model.geom_size[gid, :n] = size[:n]
+                # geom_rbound (broadphase) and geom_aabb (mid-phase) are derived
+                # from geom_size at compile time and are not refreshed by the
+                # solver; without recomputing them a grown geom keeps its old,
+                # smaller collision bounds and other bodies silently pass through
+                # it. Recompute both for size-defined primitives.
+                _recompute_primitive_geom_bounds(mj, model, gid)
                 changes.append(f"size → {model.geom_size[gid].tolist()}")
 
         return {

--- a/tests/simulation/mujoco/test_physics.py
+++ b/tests/simulation/mujoco/test_physics.py
@@ -592,6 +592,85 @@ class TestRuntimeModification:
         assert float(new_size[2]) == pytest.approx(original_tail)
 
 
+    def test_set_geom_size_grow_recomputes_rbound_and_aabb(self, sim):
+        """Growing a size-defined primitive refreshes its collision bounds.
+
+        ``geom_rbound`` (broadphase) and ``geom_aabb`` (mid-phase) are derived
+        from ``geom_size`` at compile time and are not refreshed by the solver.
+        A grown geom whose bounds are left stale is silently culled from
+        broadphase, so other bodies pass through it. The recompute must bring
+        both to the values a fresh compile at the new size would produce.
+        """
+        model = sim._world._model
+        gid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_GEOM, "box_geom")
+        # box_geom compiles at half-extents 0.1 (rbound ~= 0.1732).
+        assert float(model.geom_rbound[gid]) == pytest.approx(np.linalg.norm([0.1, 0.1, 0.1]))
+
+        result = sim.set_geom_properties(geom_name="box_geom", size=[0.25, 0.25, 0.02])
+        assert result["status"] == "success"
+
+        expected_half = [0.25, 0.25, 0.02]
+        assert float(model.geom_rbound[gid]) == pytest.approx(np.linalg.norm(expected_half))
+        assert model.geom_aabb[gid][3:6].tolist() == pytest.approx(expected_half)
+
+    def test_set_geom_size_capsule_recomputes_rbound(self, sim):
+        """The recompute uses the correct per-type formula (capsule = r + halflen)."""
+        model = sim._world._model
+        gid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_GEOM, "link1_geom")
+        result = sim.set_geom_properties(geom_name="link1_geom", size=[0.05, 0.2])
+        assert result["status"] == "success"
+        # capsule rbound = radius + half-length; aabb half = [r, r, r + halflen].
+        assert float(model.geom_rbound[gid]) == pytest.approx(0.25)
+        assert model.geom_aabb[gid][3:6].tolist() == pytest.approx([0.05, 0.05, 0.25])
+
+    def test_set_geom_size_grow_lets_object_rest_on_it(self, sim):
+        """Behavioral: a body rests on a grown static geom instead of falling through.
+
+        A small static platform is grown into a wide table via the public API,
+        then a ball offset well beyond the platform's original bounding radius
+        is dropped. With stale collision bounds the broadphase culls the pair
+        and the ball falls to the floor; after the recompute it lands on the
+        grown table.
+        """
+        from strands_robots.simulation.models import SimStatus, SimWorld
+
+        scene = """
+        <mujoco>
+          <option timestep="0.002" gravity="0 0 -9.81"/>
+          <worldbody>
+            <geom name="floor" type="plane" size="5 5 0.1"/>
+            <body name="plat" pos="0 0 0.5">
+              <geom name="platg" type="box" size="0.02 0.02 0.02"/>
+            </body>
+            <body name="ball" pos="0.15 0 0.6">
+              <freejoint/>
+              <geom name="ballg" type="sphere" size="0.03"/>
+            </body>
+          </worldbody>
+        </mujoco>
+        """
+        s = Simulation(tool_name="test_grow", mesh=False)
+        try:
+            s._world = SimWorld()
+            spec = mj.MjSpec.from_string(scene)
+            s._world._backend_state["spec"] = spec
+            s._world._model = spec.compile()
+            s._world._data = mj.MjData(s._world._model)
+            s._world.status = SimStatus.IDLE
+            mj.mj_forward(s._world._model, s._world._data)
+
+            result = s.set_geom_properties(geom_name="platg", size=[0.25, 0.25, 0.02])
+            assert result["status"] == "success"
+
+            model, data = s._world._model, s._world._data
+            for _ in range(2000):
+                mj.mj_step(model, data)
+            ball_z = float(data.body("ball").xpos[2])
+            # Table top is at z = 0.5 + 0.02 = 0.52; ball (r=0.03) rests ~0.55.
+            assert ball_z > 0.5, f"ball fell through the grown table (rest z={ball_z:.4f})"
+        finally:
+            s.cleanup()
+
 class TestContactForces:
     def test_get_contact_forces_after_settling(self, sim):
         # Let box fall and settle

--- a/tests/simulation/mujoco/test_physics.py
+++ b/tests/simulation/mujoco/test_physics.py
@@ -591,7 +591,6 @@ class TestRuntimeModification:
         assert new_size[0] == pytest.approx(0.2)
         assert float(new_size[2]) == pytest.approx(original_tail)
 
-
     def test_set_geom_size_grow_recomputes_rbound_and_aabb(self, sim):
         """Growing a size-defined primitive refreshes its collision bounds.
 
@@ -670,6 +669,7 @@ class TestRuntimeModification:
             assert ball_z > 0.5, f"ball fell through the grown table (rest z={ball_z:.4f})"
         finally:
             s.cleanup()
+
 
 class TestContactForces:
     def test_get_contact_forces_after_settling(self, sim):


### PR DESCRIPTION
## Problem

`Simulation.set_geom_properties(size=...)` resizes a geom at runtime by writing the new `geom_size`, but never refreshes the geom's **collision bounding volumes**:

- `geom_rbound` — the broadphase bounding-sphere radius
- `geom_aabb` — the mid-phase axis-aligned bounding box

Both are derived from `geom_size` at compile time and are **not** recomputed by `mj_forward`/`mj_step`. A geom grown past its original bounds is therefore silently culled from the broadphase collision pass, so other bodies pass straight through it — while the call still returns `status="success"` reporting the new size.

### Repro (grow a small platform into a wide table, drop a ball onto it)

```python
sim.set_geom_properties(geom_name="platg", size=[0.25, 0.25, 0.02])  # 2cm cube -> 50cm table
# ball offset 0.15m (well inside the new table, outside the old 0.035m rbound)
```

| | ball rest z | outcome |
|---|---|---|
| before | `0.0296` | falls **through** the grown table to the floor |
| after | `0.5496` | rests on the table (matches a fresh compile at the new size) |

![before/after](https://github.com/cagataycali/robots/releases/download/artifact-setgeom-size-1783106880/setgeom_size_collision.gif)

*Rollout in MuJoCo (headless EGL): left = stale bounds (fall-through), right = recomputed bounds (rests on table).*

## Fix

After mutating `geom_size`, recompute `geom_rbound` + `geom_aabb` from `geom_type` + `geom_size` for the size-defined primitives (sphere/capsule/cylinder/ellipsoid/box), using each type's exact extent (matches MuJoCo's compiler: capsule `r+halflen`, cylinder `hypot(r,halflen)`, ellipsoid `max`, box `norm`). Mesh/plane/height-field/SDF geoms take their extent from asset data, so a `size` write is inert for them and their bounds are left untouched.

No signature/return-shape change; color and friction paths are unaffected.

## Tests

New regression tests in `tests/simulation/mujoco/test_physics.py` (GL-free, run in CI):
- `test_set_geom_size_grow_recomputes_rbound_and_aabb` — box rbound/aabb match a fresh compile
- `test_set_geom_size_capsule_recomputes_rbound` — pins the per-type capsule formula (`r+halflen`)
- `test_set_geom_size_grow_lets_object_rest_on_it` — behavioral fall-through guard

All three fail before the fix (stale rbound `0.173` vs `0.354`; capsule `0.12` vs `0.25`; ball rest z `0.0296`). Green after. Local gate: ruff + ruff-format + mypy clean; full `test_physics.py` 73 passed; `test_object_shapes`/`test_error_paths`/`test_no_world_guard_contract`/`test_agenttool_contract` 206 passed.

---

## §13 Review Rounds

| Round | Concern | Fix Commit | Pin Test |
|-------|---------|------------|----------|
| R1 | CI lint failure: `ruff format --check` whitespace (extra blank line before method, missing blank between classes) | `a9a0b07` | `tests/simulation/mujoco/test_physics.py::TestRuntimeModification::test_set_geom_size_grow_recomputes_rbound_and_aabb` |