### PR TITLE
fix(sim): raycast/multi_raycast refresh geom poses and lock before mj_ray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -339,6 +339,24 @@ primitives (sphere/capsule/cylinder/ellipsoid/box) so a grown geom collides
 correctly, matching a fresh compile at the new size. Mesh/plane/height-field
 geoms take their extent from asset data, so a `size` write stays inert for them.
 
+### Fixed: `raycast`/`multi_raycast` intersected stale geom poses (no forward, no lock)
+
+`mj_ray` intersects a ray against `data.geom_xpos`/`geom_xmat` -- the world-frame
+geom poses, which are derived state populated by kinematics and NOT recomputed on
+a bare `qpos` write. Both `raycast` and `multi_raycast` called `mj_ray` directly
+without refreshing those poses and without holding the sim lock, unlike every
+other physics query (`get_jacobian`, `get_mass_matrix`, `get_body_state`,
+`inverse_dynamics`, `get_sensor_data`), which lock and forward before reading.
+As a result a cast issued after a direct pose change (a planning/IK loop that
+writes `qpos`) silently reported a hit against a geom's *previous* location while
+returning `status=success`, and a cast issued while a per-robot policy thread was
+stepping could tear the read mid-`mj_step`. Both methods now refresh geom world
+poses with `mj_kinematics` (the minimal forward for `mj_ray`, cheaper than a full
+`mj_forward`) and serialize the cast under the sim lock; `multi_raycast` refreshes
+once and holds the lock for the whole batch so all rays sample one consistent
+snapshot.
+
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -390,7 +390,10 @@ class PhysicsMixin:
     ) -> dict[str, Any]:
         """Cast a ray and find the first geom intersection.
 
-        Uses mj_ray for precise distance sensing / obstacle detection.
+        Uses mj_ray for precise distance sensing / obstacle detection. Geom
+        world poses are refreshed (``mj_kinematics``) under the sim lock before
+        the cast, so the result reflects the current ``qpos`` and cannot be torn
+        by a concurrent policy thread's ``mj_step``.
 
         Args:
             origin: [x, y, z] ray start point in world frame.
@@ -434,21 +437,30 @@ class PhysicsMixin:
         vec = vec / norm
 
         geomid = np.array([-1], dtype=np.int32)
-        dist = mj.mj_ray(
-            model,
-            data,
-            pnt,
-            vec,
-            None,  # geom group filter (None = all)
-            1 if include_static else 0,
-            exclude_body,
-            geomid,
-        )
-
-        hit = dist >= 0
-        geom_name = None
-        if hit and geomid[0] >= 0:
-            geom_name = mj.mj_id2name(model, mj.mjtObj.mjOBJ_GEOM, geomid[0])
+        # mj_ray intersects the ray against ``data.geom_xpos``/``geom_xmat``
+        # (world-frame geom poses -- derived state populated by kinematics, not
+        # recomputed on a bare ``qpos`` write). Refresh them under the lock so
+        # the cast reflects the current pose (e.g. after a direct ``qpos`` write
+        # from a planning/IK loop) and cannot be torn by a policy thread's
+        # ``mj_step``. ``mj_kinematics`` is the minimal forward that populates
+        # geom world poses -- cheaper than a full ``mj_forward`` and matching
+        # the defensive refresh the other query methods perform.
+        with self._lock:
+            mj.mj_kinematics(model, data)
+            dist = mj.mj_ray(
+                model,
+                data,
+                pnt,
+                vec,
+                None,  # geom group filter (None = all)
+                1 if include_static else 0,
+                exclude_body,
+                geomid,
+            )
+            hit = dist >= 0
+            geom_name = None
+            if hit and geomid[0] >= 0:
+                geom_name = mj.mj_id2name(model, mj.mjtObj.mjOBJ_GEOM, geomid[0])
 
         result = {
             "hit": hit,
@@ -1196,7 +1208,10 @@ class PhysicsMixin:
     ) -> dict[str, Any]:
         """Cast multiple rays from a single origin (e.g., for LIDAR simulation).
 
-        Efficiently casts N rays using individual mj_ray calls.
+        Efficiently casts N rays using individual mj_ray calls. Geom world poses
+        are refreshed once (``mj_kinematics``) and the whole batch is cast under
+        the sim lock, so every ray samples one consistent, current snapshot of
+        the scene (see ``raycast``).
         Returns array of distances and hit geoms.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
@@ -1218,36 +1233,45 @@ class PhysicsMixin:
         pnt = np.array(origin, dtype=np.float64)
         results: list[dict[str, Any]] = []
 
-        for idx, d in enumerate(directions):
-            try:
-                if len(d) != 3:
+        # Refresh geom world poses once, then serialize every mj_ray against a
+        # policy thread's mj_step (see ``raycast``). Held for the whole batch so
+        # all rays sample one consistent snapshot of the scene.
+        with self._lock:
+            mj.mj_kinematics(model, data)
+            for idx, d in enumerate(directions):
+                try:
+                    if len(d) != 3:
+                        results.append(
+                            {
+                                "distance": None,
+                                "geom_id": None,
+                                "error": f"ray[{idx}]: direction must have 3 elements, got {len(d)}",
+                            }
+                        )
+                        continue
+                except TypeError:
                     results.append(
                         {
                             "distance": None,
                             "geom_id": None,
-                            "error": f"ray[{idx}]: direction must have 3 elements, got {len(d)}",
+                            "error": f"ray[{idx}]: direction must be a list of 3 numbers",
                         }
                     )
                     continue
-            except TypeError:
+                vec = np.array(d, dtype=np.float64)
+                norm = np.linalg.norm(vec)
+                if norm < 1e-10:
+                    results.append({"distance": None, "geom_id": None, "error": f"ray[{idx}]: zero-length direction"})
+                    continue
+                vec /= norm
+                geomid = np.array([-1], dtype=np.int32)
+                dist = mj.mj_ray(model, data, pnt, vec, None, 1, exclude_body, geomid)
                 results.append(
-                    {"distance": None, "geom_id": None, "error": f"ray[{idx}]: direction must be a list of 3 numbers"}
+                    {
+                        "distance": float(dist) if dist >= 0 else None,
+                        "geom_id": int(geomid[0]) if dist >= 0 else None,
+                    }
                 )
-                continue
-            vec = np.array(d, dtype=np.float64)
-            norm = np.linalg.norm(vec)
-            if norm < 1e-10:
-                results.append({"distance": None, "geom_id": None, "error": f"ray[{idx}]: zero-length direction"})
-                continue
-            vec /= norm
-            geomid = np.array([-1], dtype=np.int32)
-            dist = mj.mj_ray(model, data, pnt, vec, None, 1, exclude_body, geomid)
-            results.append(
-                {
-                    "distance": float(dist) if dist >= 0 else None,
-                    "geom_id": int(geomid[0]) if dist >= 0 else None,
-                }
-            )
 
         hit_count = sum(1 for r in results if r["distance"] is not None)
         return {

--- a/tests/simulation/mujoco/test_concurrency_lock_audit.py
+++ b/tests/simulation/mujoco/test_concurrency_lock_audit.py
@@ -46,6 +46,18 @@ class TestRacePreventionLocks:
         assert "with self._lock" in src
         assert "contact_snapshot" in src
 
+    def test_raycast_holds_lock(self):
+        # mj_ray reads data.geom_xpos/geom_xmat (derived); the refresh + cast
+        # must be serialized against a policy thread's mj_step.
+        src = inspect.getsource(PhysicsMixin.raycast)
+        assert "with self._lock" in src, "raycast must acquire self._lock"
+        assert "mj_kinematics" in src, "raycast must refresh geom poses before mj_ray"
+
+    def test_multi_raycast_holds_lock(self):
+        src = inspect.getsource(PhysicsMixin.multi_raycast)
+        assert "with self._lock" in src, "multi_raycast must acquire self._lock"
+        assert "mj_kinematics" in src, "multi_raycast must refresh geom poses before mj_ray"
+
 
 class TestFunctionalCorrectnessUnderLock:
     """The lock addition must NOT change observable behaviour."""

--- a/tests/simulation/mujoco/test_physics.py
+++ b/tests/simulation/mujoco/test_physics.py
@@ -910,3 +910,50 @@ class TestMultiRaycast:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+class TestRaycastReflectsCurrentPose:
+    """raycast / multi_raycast must intersect the CURRENT geom poses.
+
+    ``mj_ray`` reads ``data.geom_xpos``/``geom_xmat`` (world-frame geom poses,
+    derived state). MuJoCo does not recompute those on a bare ``qpos`` write --
+    a planning/IK loop that pokes ``qpos`` (or a policy thread mid-``mj_step``)
+    leaves them stale. The query must refresh kinematics first, exactly like
+    ``get_jacobian``/``get_body_state`` do, or it silently reports a hit against
+    a geom's previous location while returning ``status=success``.
+    """
+
+    @staticmethod
+    def _move_box_far(sim):
+        """Translate the free box off the +z axis via a direct qpos write, no forward."""
+        model, data = sim._world._model, sim._world._data
+        jid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, "box_free")
+        adr = int(model.jnt_qposadr[jid])
+        data.qpos[adr : adr + 3] = [3.0, 0.0, 0.5]  # move box out of the downward ray at x=0
+        data.qpos[adr + 3 : adr + 7] = [1.0, 0.0, 0.0, 0.0]
+        # deliberately NO mj_forward / mj_kinematics here
+
+    def test_raycast_reflects_pose_change_without_forward(self, sim):
+        # Baseline: the downward ray hits the box (nearest) at its top face.
+        base = _extract_json_block(sim.raycast(origin=[0, 0, 2], direction=[0, 0, -1]), 1)
+        assert base["geom_name"] == "box_geom"
+        assert base["distance"] == pytest.approx(1.4, abs=1e-3)
+
+        self._move_box_far(sim)
+
+        # After moving the box (no forward), the downward ray at x=0 must miss
+        # the box and hit the ground plane at z=0 -> distance 2.0. Pre-fix this
+        # reads the stale geom_xpos and still reports box_geom at 1.4.
+        after = _extract_json_block(sim.raycast(origin=[0, 0, 2], direction=[0, 0, -1]), 1)
+        assert after["geom_name"] == "ground"
+        assert after["distance"] == pytest.approx(2.0, abs=1e-3)
+
+    def test_multi_raycast_reflects_pose_change_without_forward(self, sim):
+        dirs = [[0, 0, -1]]
+        base = _extract_json_block(sim.multi_raycast(origin=[0, 0, 2], directions=dirs), 1)["rays"]
+        assert base[0]["distance"] == pytest.approx(1.4, abs=1e-3)  # hits box top
+
+        self._move_box_far(sim)
+
+        after = _extract_json_block(sim.multi_raycast(origin=[0, 0, 2], directions=dirs), 1)["rays"]
+        assert after[0]["distance"] == pytest.approx(2.0, abs=1e-3)  # now hits ground


### PR DESCRIPTION
## Problem

`mj_ray` intersects a ray against `data.geom_xpos`/`geom_xmat` — the world-frame geom poses, which are **derived state** populated by kinematics and **not** recomputed on a bare `qpos` write. Both `raycast` and `multi_raycast` called `mj_ray` directly, without refreshing those poses and without holding the sim lock — unlike every other physics query in `PhysicsMixin` (`get_jacobian`, `get_mass_matrix`, `get_body_state`, `inverse_dynamics`, `get_sensor_data`), all of which lock and forward before reading derived state.

Two silent-wrong-result consequences:

1. **Stale geometry.** A cast issued after a direct pose change (e.g. a planning/IK loop that writes `qpos`) intersects the geom's *previous* location while still returning `status=success`. This is the same contract `get_jacobian`/`get_body_state` were fixed to honor.
2. **Torn read under concurrency.** These are read-only queries meant to be safe while a per-robot policy thread is running (they do not require a stopped policy), but without the lock a concurrent `mj_step` can mutate `geom_xpos` mid-cast.

## Fix

Both methods now refresh geom world poses with `mj_kinematics` — the minimal forward that populates `geom_xpos`/`geom_xmat` for `mj_ray`, cheaper than a full `mj_forward` — and serialize the cast under `self._lock`. `multi_raycast` refreshes once and holds the lock for the whole batch so every ray samples one consistent snapshot of the scene. No signature or return-shape change.

## Test

`TestRaycastReflectsCurrentPose` (in `test_physics.py`, GL-free) moves a free-jointed box via a direct `qpos` write (no forward) and asserts the downward ray now reports the ground behind it rather than the box's stale location. Both cases **fail before** the fix (`box_geom` @ 1.4 m) and **pass after** (`ground` @ 2.0 m). The concurrency lock is pinned by two source-inspection cases added to the existing `test_concurrency_lock_audit.py`. Full `test_physics.py` (75) + concurrency + lock-audit suites pass; ruff + mypy clean.

## Visual

Same downward cast, before/after a direct pose change — the result now follows the box's real position:

![raycast follows current geom pose](https://github.com/cagataycali/robots/releases/download/artifact-raycast-1783117586/raycast_fix.png)

Left: box under the ray → `box_geom @ 1.35 m`. Right: box moved to x=3 via `qpos` (no forward) → the cast correctly reaches `ground @ 2.0 m`.