### PR TITLE
test(mesh): pin robot_mesh tell policy_port forwarding and broadcast summary truncation

### DIFF
--- a/tests/mesh/test_robot_mesh_tool.py
+++ b/tests/mesh/test_robot_mesh_tool.py
@@ -468,3 +468,40 @@ def test_emergency_stop_dispatch_error_returns_error_dict_and_audits(fake_local_
     assert calls and calls[-1][0] == "emergency_stop"
     assert calls[-1][1] == "*"
     assert calls[-1][2] is False
+
+
+def test_tell_forwards_nonzero_policy_port_and_omits_default(fake_local_mesh):
+    """``policy_port`` reaches ``mesh.tell`` only when non-zero.
+
+    ``tell`` lets a caller pin the port the remote peer serves its policy on.
+    The default (``0``) means "let the mesh pick", so it must NOT be forwarded
+    as an explicit kwarg (which would override the peer's own default), while a
+    non-zero value must be passed through verbatim.
+    """
+    fake_local_mesh.tell.return_value = {"executed": "go"}
+
+    _strands_call(action="tell", target="peer-b", instruction="go")
+    assert "policy_port" not in fake_local_mesh.tell.call_args.kwargs
+
+    fake_local_mesh.tell.reset_mock()
+    out = _strands_call(action="tell", target="peer-b", instruction="go", policy_port=5556)
+    assert out["status"] == "success"
+    assert fake_local_mesh.tell.call_args.kwargs["policy_port"] == 5556
+
+
+def test_broadcast_summary_truncates_to_ten_responses(fake_local_mesh):
+    """A large fan-out is summarised with at most ten itemised responses.
+
+    ``broadcast`` can return one response per peer; itemising all of them would
+    bury the caller. The summary lists the first ten and reports the remainder
+    as ``... and N more`` while still stating the true total.
+    """
+    fake_local_mesh.broadcast.return_value = [{"i": n} for n in range(13)]
+
+    out = _strands_call(action="broadcast", command='{"action": "status"}')
+
+    assert out["status"] == "success"
+    text = out["content"][0]["text"]
+    assert "13 responses" in text
+    assert "... and 3 more" in text
+    assert text.count("  - ") == 10


### PR DESCRIPTION
## Summary

Test-only PR (+37/-0) adding two focused regression tests to `tests/mesh/test_robot_mesh_tool.py` that pin two previously-unexercised observable behaviors of the Zenoh mesh-path handlers in `strands_robots/tools/robot_mesh.py`:

- **`tell` policy_port forwarding**: a non-zero `policy_port` is passed through to `mesh.tell(...)` as an explicit kwarg, but the default (`0`) is omitted so it does not override the remote peer's own default port. Existing `tell` tests only exercised the default, leaving the forwarding branch (and its default-omit counterpart) uncovered.
- **`broadcast` summary truncation**: the broadcast summary itemises at most ten responses and reports the remainder as `... and N more`, while still stating the true total, so a large fan-out stays readable. The existing broadcast happy-path test returned only two responses, so the truncation branch was never hit.

## Behavior pinned

Both tests assert on observable outputs (the kwargs `mesh.tell` receives; the rendered broadcast summary text), not internal state, per the "test behavior, not implementation" guidance. They drive the tool through its `@tool` wrapper with the existing `fake_local_mesh` fixture and a stub ToolContext, so they are hardware- and transport-free.

## Coverage

`strands_robots/tools/robot_mesh.py`: 96% -> 97% (20 -> 18 uncovered lines). The two tests close the `policy_port` forwarding branch (pre-interrupt pass + mesh-path handler) and the broadcast display-truncation branch.

No library behavior changes, no new public API / wire format / persisted schema, no host paths, no non-ASCII characters. `ruff check`, `ruff format --check`, and `mypy` are clean; the full `tests/mesh/test_robot_mesh_tool.py` suite passes (40 tests).