### PR TITLE
test(hardware): pin _execute_task_sync re-entrant event-loop offload

### DIFF
--- a/tests/test_hardware_robot_lifecycle.py
+++ b/tests/test_hardware_robot_lifecycle.py
@@ -872,6 +872,42 @@ class TestExecuteTaskSync:
         assert "boom" in result["content"][0]["text"]
         hw.cleanup()
 
+    def test_sync_runner_within_running_loop_offloads_to_thread(self):
+        """When called from inside a live event loop, _execute_task_sync must
+        offload to a worker thread instead of calling asyncio.run() on the
+        running loop (which raises "cannot be called from a running event
+        loop"). An async tool context drives this path, so it must complete
+        and report success rather than crash."""
+        fake = _FakeLeRobot(connected=True)
+        hw = _make_robot(fake)
+
+        loop_ids: list[int] = []
+
+        async def _ok_async(*a, **k):
+            # Records the loop the task actually ran on so we can assert it is
+            # a fresh worker-thread loop, not the caller's running loop.
+            loop_ids.append(id(asyncio.get_running_loop()))
+            hw._task_state.status = TaskStatus.COMPLETED
+            hw._task_state.duration = 0.5
+            hw._task_state.step_count = 3
+
+        hw._execute_task_async = _ok_async  # type: ignore[assignment]
+
+        async def _driver() -> dict:
+            caller_loop_id = id(asyncio.get_running_loop())
+            # Blocking call from within a running loop; exercises the
+            # ThreadPoolExecutor branch. Must not raise.
+            result = hw._execute_task_sync("pick", policy_port=5555, policy_provider="mock")
+            return {"result": result, "caller_loop_id": caller_loop_id}
+
+        out = asyncio.run(_driver())
+        assert out["result"]["status"] == "success"
+        assert "completed" in out["result"]["content"][0]["text"]
+        # The task ran on a distinct loop created in the worker thread, proving
+        # the running loop was not reused by asyncio.run().
+        assert loop_ids and loop_ids[0] != out["caller_loop_id"]
+        hw.cleanup()
+
 
 class TestStreamExecuteHappyPath:
     def test_execute_action_runs_task_and_returns_result(self):


### PR DESCRIPTION
## Problem

`Robot._execute_task_sync` (in `strands_robots.hardware_robot`) branches on whether an asyncio event loop is already running:

- **No running loop** -> `asyncio.run(task_runner())` on a fresh loop.
- **Running loop** (the method is invoked from inside a live event loop, e.g. an async tool/agent context) -> it must offload the coroutine to a `ThreadPoolExecutor` worker thread and `asyncio.run()` there, because calling `asyncio.run()` on the already-running loop raises `RuntimeError: asyncio.run() cannot be called from a running event loop`.

The existing suite covered only the no-loop branch (`test_sync_runner_no_running_loop_completes`) and the error-status path (`test_sync_runner_reports_error_status`). The re-entrant `ThreadPoolExecutor` branch was unpinned, so a regression that reused the running loop (or dropped the thread offload) would go unnoticed until it deadlocked/raised in production.

## Change

Add `test_sync_runner_within_running_loop_offloads_to_thread`: it drives `_execute_task_sync` from within `asyncio.run(...)` and asserts

1. the call completes and reports `status == success` (no `RuntimeError` from re-entrant `asyncio.run`), and
2. the task coroutine actually ran on a **distinct** event loop from the caller's (recorded via `id(asyncio.get_running_loop())`), proving the running loop was not reused.

Test-only; no production code changes. Uses the existing `_FakeLeRobot` + `__new__` wiring helper so no serial/USB hardware is touched.

## Tests

```
pytest tests/test_hardware_robot_lifecycle.py -q   # 57 passed
```

Coverage: the previously-missing `_execute_task_sync` running-loop branch (`hardware_robot.py` lines ~1120-1129) is now exercised. Lint (`ruff check` / `ruff format --check`) clean on the changed file.