### PR TITLE
fix(training): discover LeRobot policy types from lerobot's live registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -374,6 +374,22 @@ lifecycle (path validation, camera probe, fps-cadence frame capture) is now a
 single `_RolloutVideoWriter` helper shared by `run` and `evaluate` instead of two
 copies.
 
+### Fixed: LeRobot fine-tuning validation discovers policy types from lerobot's live registry
+
+`LerobotTrainer.validate` guarded `extra['policy_type']` against a hardcoded set
+of LeRobot-native types, and gated `relative_actions` against a hardcoded
+`{pi0, pi05, pi0_fast}` set. Both had drifted behind lerobot: the native-type set
+omitted policies lerobot already ships (e.g. `eo1`, `molmoact2`, `vla_jepa`,
+`wall_x`, and newer additions), so validation wrongly rejected them as "not
+LeRobot-native" even though `make_policy_config` builds them and the inference
+side resolves their classes; and `groot` now exposes `use_relative_actions`, so a
+valid `groot` + relative-actions run was wrongly rejected. Both gates now read
+lerobot's live `PreTrainedConfig` ChoiceRegistry (the relative-action check is
+probed off each config class), matching the zero-maintenance dynamic discovery
+the reward-model, robot, teleop, and camera surfaces already use. A static
+fallback is kept for the offline case (lerobot not importable). Genuinely unknown
+policy types are still rejected.
+
 
 ## [0.4.1] - 2026-07-01
 

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -63,20 +63,19 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 
 logger = logging.getLogger(__name__)
 
-# LeRobot-native policy types (draccus --policy.type values / make_policy_config
-# keys). Mirrors the verified vla-ft POLICY_MAP; values pass straight through.
-_LEROBOT_POLICY_TYPES = {
-    "act",
-    "diffusion",
-    "vqbet",
-    "tdmpc",
-    "smolvla",
-    "pi0",
-    "pi05",
-    "pi0_fast",
-    "groot",
-    "xvla",
-}
+# LeRobot-native policy types. Parity with lerobot is DYNAMIC, not a hardcoded
+# list: the live set is read from lerobot's ``PreTrainedConfig`` draccus
+# ChoiceRegistry (see :func:`_lerobot_policy_types`) - the same zero-maintenance
+# discovery reward models / robots / teleops / cameras already use. Any policy
+# lerobot ships (act, smolvla, the pi0 family, groot, xvla, and newer additions
+# such as eo1, evo1, lingbot_va, molmoact2, wall_x, ...) or a plugin registers is
+# reachable with no change here. The static set below is the FALLBACK used ONLY
+# when lerobot's registry is unavailable (lerobot not importable), where training
+# cannot run anyway but ``validate()`` should still produce a useful offline
+# message.
+_LEROBOT_POLICY_TYPES_FALLBACK = frozenset(
+    {"act", "diffusion", "vqbet", "tdmpc", "smolvla", "pi0", "pi05", "pi0_fast", "groot", "xvla"}
+)
 
 _SUPPORTED_METHODS = {"full", "lora", "expert_only"}
 
@@ -84,8 +83,10 @@ _SUPPORTED_METHODS = {"full", "lora", "expert_only"}
 # relative-action processor pair: a RelativeActionsProcessorStep on the input
 # side and the matching AbsoluteActionsProcessorStep on the output side, both
 # built from ``config.use_relative_actions`` and saved into the checkpoint's
-# pre/post processors). Other policy types have no such field.
-_RELATIVE_ACTION_POLICY_TYPES = {"pi0", "pi05", "pi0_fast"}
+# pre/post processors). Discovered live per policy type off the config class
+# (see :func:`_policy_supports_relative_actions`); the static set is the offline
+# FALLBACK. Currently the pi0 family and groot expose the field.
+_RELATIVE_ACTION_POLICY_TYPES_FALLBACK = frozenset({"pi0", "pi05", "pi0_fast", "groot"})
 
 # RA-BC (Reward-Aligned Behavior Cloning) is surfaced to the agent through the
 # ``extra['sample_weighting']`` dict. lerobot >= 0.5.2 configures sample
@@ -123,6 +124,47 @@ _REWARD_MODEL_FIELDS_FALLBACK = frozenset({"annotation_mode", "image_key", "stat
 # SARM annotation modes (configuration_sarm.SARMConfig.annotation_mode):
 # ``single_stage`` needs NO annotations (linear progress over the episode).
 _SARM_ANNOTATION_MODES = {"single_stage", "dense_only", "dual"}
+
+
+def _policy_registry() -> dict[str, type] | None:
+    """Live ``PreTrainedConfig`` ChoiceRegistry (policy_type -> config class), or
+    ``None`` when lerobot is unavailable.
+
+    Importing ``lerobot.policies`` runs each config module's
+    ``@PreTrainedConfig.register_subclass`` decorator, which is what populates
+    the draccus ChoiceRegistry - querying it before that import yields an empty
+    mapping, so the import is the load-bearing step (mirrors
+    :func:`_reward_registry`). Returns ``None`` when lerobot is not importable.
+    """
+    try:
+        import lerobot.policies  # noqa: F401  (import for register_subclass side effect)
+        from lerobot.configs.policies import PreTrainedConfig
+    except ImportError:
+        return None
+    return dict(PreTrainedConfig.get_known_choices())
+
+
+def _lerobot_policy_types() -> set[str]:
+    """LeRobot-native ``policy.type`` names (live registry, else static fallback)."""
+    reg = _policy_registry()
+    if reg is None:
+        return set(_LEROBOT_POLICY_TYPES_FALLBACK)
+    return set(reg)
+
+
+def _policy_supports_relative_actions(ptype: str) -> bool:
+    """Whether ``ptype``'s lerobot config exposes ``use_relative_actions``.
+
+    Probed live off the registry's config *class* (a dataclass field lookup, no
+    instantiation - so no device warnings or construction cost), so any policy
+    lerobot adds with relative-action support is recognized with zero per-type
+    maintenance. Falls back to the documented static set when lerobot's registry
+    is unavailable offline.
+    """
+    reg = _policy_registry()
+    if reg is not None and ptype in reg:
+        return any(f.name == "use_relative_actions" for f in dataclasses.fields(reg[ptype]))
+    return ptype in _RELATIVE_ACTION_POLICY_TYPES_FALLBACK
 
 
 def _reward_registry() -> dict[str, type] | None:
@@ -339,9 +381,11 @@ class LerobotTrainer(Trainer):
         pipeline) restores the inverse decode automatically - no separate
         inference-side wiring is needed.
 
-        Only ``pi0`` / ``pi05`` / ``pi0_fast`` expose ``use_relative_actions``;
-        :meth:`validate` rejects the flag for any other policy type rather than
-        letting it become a silent no-op.
+        Only some policy configs expose ``use_relative_actions`` (currently the
+        ``pi0`` family and ``groot``); the supported set is discovered live from
+        lerobot's registry (:func:`_policy_supports_relative_actions`), and
+        :meth:`validate` rejects the flag for any policy type whose config lacks
+        the field rather than letting it become a silent no-op.
         """
         return bool(spec.extra.get("relative_actions", False))
 
@@ -443,9 +487,9 @@ class LerobotTrainer(Trainer):
         """Policy-training preflight (the default, ``cfg.policy`` path)."""
         problems: list[str] = []
         ptype = self._resolve_policy_type(spec)
-        if ptype not in _LEROBOT_POLICY_TYPES:
+        if ptype not in _lerobot_policy_types():
             problems.append(
-                f"policy_type '{ptype}' is not LeRobot-native (expected one of {sorted(_LEROBOT_POLICY_TYPES)})"
+                f"policy_type '{ptype}' is not LeRobot-native (expected one of {sorted(_lerobot_policy_types())})"
             )
 
         if spec.method not in _SUPPORTED_METHODS:
@@ -453,11 +497,12 @@ class LerobotTrainer(Trainer):
         if spec.method == "lora" and spec.tune.get("expert_only"):
             problems.append("lora and expert_only are mutually exclusive (both freeze the VLM)")
 
-        if self._relative_actions(spec) and ptype not in _RELATIVE_ACTION_POLICY_TYPES:
+        if self._relative_actions(spec) and not _policy_supports_relative_actions(ptype):
+            supported = sorted(t for t in _lerobot_policy_types() if _policy_supports_relative_actions(t))
             problems.append(
                 f"relative_actions is not supported by policy_type '{ptype}' "
-                f"(only {sorted(_RELATIVE_ACTION_POLICY_TYPES)} expose use_relative_actions); "
-                "drop extra['relative_actions'] or pick a pi0-family policy"
+                f"(only {supported} expose use_relative_actions); "
+                "drop extra['relative_actions'] or pick a supporting policy"
             )
 
         sw = spec.extra.get("sample_weighting")
@@ -743,9 +788,10 @@ class LerobotTrainer(Trainer):
             policy_cfg.optimizer_lr = spec.learning_rate
         if self._relative_actions(spec):
             if not hasattr(policy_cfg, "use_relative_actions"):
+                rel_supported = sorted(t for t in _lerobot_policy_types() if _policy_supports_relative_actions(t))
                 raise ValueError(
                     f"relative_actions requested but policy_type '{ptype}' has no "
-                    f"use_relative_actions field (supported: {sorted(_RELATIVE_ACTION_POLICY_TYPES)})"
+                    f"use_relative_actions field (supported: {rel_supported})"
                 )
             policy_cfg.use_relative_actions = True
 

--- a/tests/training/test_lerobot.py
+++ b/tests/training/test_lerobot.py
@@ -1004,9 +1004,10 @@ class TestBuilderEscapeHatchValidation:
             LerobotTrainer(device="cpu").build_command(spec)
 
     def test_build_config_rejects_relative_actions_for_unsupported_policy(self, dataset_root, tmp_path):
-        # Only the pi0 family exposes use_relative_actions; build_config must
-        # fail fast for any other policy rather than drop the flag silently
-        # (which would train an ordinary absolute-action policy unnoticed).
+        # act does not expose use_relative_actions (only the pi0 family and
+        # groot do); build_config must fail fast for such a policy rather than
+        # drop the flag silently (which would train an ordinary absolute-action
+        # policy unnoticed).
         pytest.importorskip("lerobot")
         spec = TrainSpec(
             dataset_root=dataset_root,

--- a/tests/training/test_lerobot_policy_type_discovery.py
+++ b/tests/training/test_lerobot_policy_type_discovery.py
@@ -1,0 +1,134 @@
+"""LeRobot policy-type validation is discovered from lerobot's live registry.
+
+``LerobotTrainer.validate`` guards ``extra['policy_type']`` two ways: it rejects
+types that are not LeRobot-native, and it rejects ``relative_actions`` for types
+whose config lacks ``use_relative_actions``. Both gates used to consult
+hardcoded sets that drifted behind lerobot: the native-type set listed only a
+subset of the policies lerobot actually ships (so newer types such as ``eo1`` /
+``molmoact2`` / ``vla_jepa`` / ``wall_x`` were wrongly reported "not
+LeRobot-native"), and the relative-action set omitted ``groot`` (which exposes
+``use_relative_actions``), so a valid ``groot`` + relative-actions run was
+wrongly rejected. Both are now discovered live from lerobot's
+``PreTrainedConfig`` ChoiceRegistry - the same zero-maintenance discovery the
+reward-model, robot, teleop, and camera surfaces already use.
+
+These tests pin the invariant against whatever lerobot is installed (they read
+its live registry rather than hardcoding type names), so they hold across
+lerobot versions and fail on the pre-fix hardcoded gates whenever the registry
+contains a type outside the stale sets.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+
+import pytest
+
+from strands_robots.training import TrainSpec
+from strands_robots.training.lerobot import (
+    _LEROBOT_POLICY_TYPES_FALLBACK,
+    _RELATIVE_ACTION_POLICY_TYPES_FALLBACK,
+    LerobotTrainer,
+    _lerobot_policy_types,
+    _policy_registry,
+    _policy_supports_relative_actions,
+)
+
+
+@pytest.fixture
+def dataset_root(tmp_path):
+    meta = tmp_path / "meta"
+    meta.mkdir()
+    (meta / "info.json").write_text(json.dumps({"total_episodes": 10}))
+    return str(tmp_path)
+
+
+def _spec(dataset_root, tmp_path, **extra) -> TrainSpec:
+    return TrainSpec(
+        dataset_root=dataset_root,
+        base_model="",
+        output_dir=str(tmp_path / "out"),
+        steps=10,
+        extra=extra,
+    )
+
+
+class TestNativePolicyTypeDiscovery:
+    def test_every_registry_type_is_accepted_as_native(self, dataset_root, tmp_path):
+        """No policy type lerobot registers may be flagged "not LeRobot-native".
+
+        Pre-fix the check consulted a hardcoded 10-name set; any registered type
+        beyond it (eo1, molmoact2, vla_jepa, wall_x, ... - present even before
+        the latest additions) was wrongly rejected. This iterates lerobot's live
+        registry, so it is version-agnostic and fails on the stale set.
+        """
+        reg = _policy_registry()
+        if reg is None:
+            pytest.skip("lerobot not installed; registry-driven check not applicable")
+        assert reg, "lerobot registry unexpectedly empty"
+        trainer = LerobotTrainer(device="cpu")
+        for ptype in reg:
+            problems = trainer.validate(_spec(dataset_root, tmp_path, policy_type=ptype))
+            not_native = [p for p in problems if "not LeRobot-native" in p]
+            assert not not_native, f"registry type {ptype!r} wrongly rejected: {not_native}"
+
+    def test_lerobot_policy_types_matches_registry(self):
+        reg = _policy_registry()
+        if reg is None:
+            pytest.skip("lerobot not installed")
+        assert _lerobot_policy_types() == set(reg)
+
+    def test_unknown_type_still_rejected(self, dataset_root, tmp_path):
+        # A genuinely non-native name must still be caught (no over-permissiveness).
+        problems = LerobotTrainer(device="cpu").validate(
+            _spec(dataset_root, tmp_path, policy_type="definitely_not_a_policy")
+        )
+        assert any("not LeRobot-native" in p for p in problems)
+
+
+class TestRelativeActionDiscovery:
+    def test_gate_tracks_config_field_for_every_registry_type(self, dataset_root, tmp_path):
+        """`relative_actions` is rejected iff the config class lacks the field.
+
+        Pre-fix the gate used a hardcoded {pi0, pi05, pi0_fast} set; groot also
+        exposes ``use_relative_actions`` on current lerobot, so a groot +
+        relative-actions run was wrongly rejected. This derives the expectation
+        from the actual dataclass field, so it fails whenever the hardcoded set
+        diverges from lerobot's configs.
+        """
+        reg = _policy_registry()
+        if reg is None:
+            pytest.skip("lerobot not installed")
+        trainer = LerobotTrainer(device="cpu")
+        for ptype, cfg_cls in reg.items():
+            has_field = any(f.name == "use_relative_actions" for f in dataclasses.fields(cfg_cls))
+            problems = trainer.validate(_spec(dataset_root, tmp_path, policy_type=ptype, relative_actions=True))
+            rejected = any("relative_actions is not supported" in p for p in problems)
+            assert rejected == (not has_field), (
+                f"{ptype!r}: config has use_relative_actions={has_field} but "
+                f"validate {'rejected' if rejected else 'accepted'} relative_actions"
+            )
+
+    def test_helper_agrees_with_config_field(self):
+        reg = _policy_registry()
+        if reg is None:
+            pytest.skip("lerobot not installed")
+        for ptype, cfg_cls in reg.items():
+            has_field = any(f.name == "use_relative_actions" for f in dataclasses.fields(cfg_cls))
+            assert _policy_supports_relative_actions(ptype) == has_field
+
+
+class TestOfflineFallback:
+    """When lerobot's registry is unavailable, the static fallbacks drive the gate."""
+
+    def test_native_types_fall_back_to_static_set(self, monkeypatch):
+        monkeypatch.setattr("strands_robots.training.lerobot._policy_registry", lambda: None)
+        assert _lerobot_policy_types() == set(_LEROBOT_POLICY_TYPES_FALLBACK)
+
+    def test_relative_actions_fall_back_to_static_set(self, monkeypatch):
+        monkeypatch.setattr("strands_robots.training.lerobot._policy_registry", lambda: None)
+        for ptype in _RELATIVE_ACTION_POLICY_TYPES_FALLBACK:
+            assert _policy_supports_relative_actions(ptype) is True
+        assert _policy_supports_relative_actions("act") is False
+        assert _policy_supports_relative_actions("definitely_not_a_policy") is False


### PR DESCRIPTION
## Problem

`LerobotTrainer.validate` (the preflight for `lerobot-train` fine-tuning) guarded `extra['policy_type']` two ways, both against **hardcoded sets that have drifted behind lerobot**:

1. **Native-type allowlist** `{act, diffusion, vqbet, tdmpc, smolvla, pi0, pi05, pi0_fast, groot, xvla}`. lerobot ships more policy types than this (`eo1`, `molmoact2`, `vla_jepa`, `wall_x`, plus newer additions such as `evo1` / `lingbot_va` / `gaussian_actor` / `multi_task_dit` / `fastwam`). Requesting any of them was rejected with `policy_type '<x>' is not LeRobot-native` even though `lerobot.policies.factory.make_policy_config('<x>')` builds the config and the inference side already resolves the class. Fine-tuning those policies was unreachable.

2. **Relative-action allowlist** `{pi0, pi05, pi0_fast}`. `groot`'s config now exposes `use_relative_actions`, so a valid `groot` + `relative_actions` run was wrongly rejected as unsupported (and the build-time error message listed a stale set).

The reward-model surface right below these sets already documents *why* this is wrong and uses live discovery ("Parity with lerobot is DYNAMIC, not a hardcoded list ... the same zero-maintenance discovery Robot / Teleop / Camera / Policy already use"). The two policy-type gates were the last hardcoded holdouts.

## Change

Both gates now read lerobot's live `PreTrainedConfig` ChoiceRegistry (populated by importing `lerobot.policies`), mirroring `_reward_registry`:

- `_lerobot_policy_types()` returns the live registered `policy.type` names.
- `_policy_supports_relative_actions(ptype)` probes the field off the registry's config **class** (a `dataclasses.fields` lookup, no instantiation, no device warnings).

Static fallbacks (`_LEROBOT_POLICY_TYPES_FALLBACK`, `_RELATIVE_ACTION_POLICY_TYPES_FALLBACK`) are retained for the offline case (lerobot not importable), where training cannot run anyway but `validate()` should still emit a useful message. Genuinely unknown types (`openvla`, typos) are still rejected. `build_config`'s relative-actions error message is derived from the same live set.

Against current lerobot the native check now accepts all 19 registered types; the relative-action set resolves to `{pi0, pi05, pi0_fast, groot}`.

## Tests

New `tests/training/test_lerobot_policy_type_discovery.py` pins the invariant **against whatever lerobot is installed** (reads the live registry rather than hardcoding type names, so it holds across lerobot versions):

- every registry type passes the native check (fails pre-fix: e.g. `eo1 wrongly rejected`),
- the relative-action gate is rejected iff the config class lacks `use_relative_actions` (fails pre-fix: `groot rejected relative_actions`),
- a genuinely non-native name is still rejected,
- the offline fallbacks drive the gate when the registry is unavailable (monkeypatched).

Verified fails-before by reverting only the two check-sites to the old hardcoded logic (2 behavioral tests fail: `eo1` rejected, `groot` relative-actions rejected), passes after. Full `tests/training/` suite: 339 passed, 4 skipped. `ruff check` / `ruff format` / `mypy` clean on the changed files.

No public API or signature change; validation is strictly more correct (accepts real lerobot policies, still rejects unknown ones).