### PR TITLE
test(simulation): pin send_action non-numeric action-vector rejection

### DIFF
--- a/tests/simulation/mujoco/test_input_validation.py
+++ b/tests/simulation/mujoco/test_input_validation.py
@@ -697,3 +697,29 @@ class TestAddCameraParamValidation:
         )
         assert res["status"] == "success"
         assert "good" in sim_with_world._world.cameras
+
+
+# send_action ordered-vector normalization
+
+
+class TestSendActionVectorValidation:
+    """Pin send_action's ordered-vector contract.
+
+    send_action accepts either a ``{name: value}`` mapping or an ordered numeric
+    vector aligned with ``robot_action_keys``. A vector with a non-numeric entry
+    (e.g. a stray string) must fail with a structured error naming the offending
+    conversion, not raise past the tool boundary or coerce garbage downstream.
+    """
+
+    def test_non_numeric_entry_returns_structured_error(self, sim_with_robot):
+        keys = sim_with_robot.robot_action_keys("panda")
+        assert len(keys) >= 2, keys
+        bad_vector = [0.0, "not_a_number", *([0.0] * (len(keys) - 2))]
+        res = sim_with_robot.send_action(bad_vector)
+        assert res["status"] == "error", res
+        assert "non-numeric entry" in res["content"][0]["text"]
+
+    def test_numeric_vector_still_applies(self, sim_with_robot):
+        keys = sim_with_robot.robot_action_keys("panda")
+        res = sim_with_robot.send_action([0.0] * len(keys))
+        assert res["status"] == "success", res["content"][0]["text"]


### PR DESCRIPTION
## What

`send_action` accepts either a `{name: value}` mapping or an ordered numeric vector aligned with `robot_action_keys(robot_name)`. `SimEngine._normalize_action_vector` already has pinned tests for the wrong-length vector and the bad top-level type (str/bytes/scalar) branches, but the **non-numeric-entry** branch was unpinned:

```python
try:
    values = [float(v) for v in action]
except (TypeError, ValueError) as exc:
    return None, {"status": "error", "content": [{"text": f"send_action: action vector has a non-numeric entry: {exc}."}]}
```

A stray non-numeric element inside an otherwise numeric vector (e.g. `[0.0, "x", 0.0, ...]`) must return a structured `{"status": "error"}` naming the failed conversion, not raise past the tool boundary or coerce garbage actuator targets downstream.

## Change

Test-only. Adds `TestSendActionVectorValidation` to `tests/simulation/mujoco/test_input_validation.py` with a happy-path + error-path pair on the MuJoCo backend (`panda`):

- `test_numeric_vector_still_applies` - a full-length numeric vector applies and returns success.
- `test_non_numeric_entry_returns_structured_error` - a vector with a string entry returns `status == error` with `"non-numeric entry"` in the message.

This closes the coverage gap on the non-numeric branch of `_normalize_action_vector` in `strands_robots/simulation/base.py` (line no longer appears in `--cov-report=term-missing` after the error-path test runs).

## Validation

- `ruff check strands_robots tests tests_integ` - clean
- `ruff format --check strands_robots tests tests_integ` - clean
- `mypy strands_robots tests tests_integ` - Success, no issues found in 662 source files
- `MUJOCO_GL=egl pytest tests/simulation/mujoco/test_input_validation.py` - 80 passed (2 new)

No production code changed; no behavior change.