### PR TITLE
fix(sim): get_energy recomputes the forward pipeline for the current pose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: `get_energy` reported the energy of a stale pose after a direct `qpos`/`qvel` write
+
+`get_energy` called `mj_energyPos` / `mj_energyVel` on whatever derived state
+happened to be in `data`, without first recomputing the forward pipeline.
+Potential energy is a function of `data.xipos` (inertial body positions in the
+world frame) and kinetic energy of the config-dependent inertia `data.qM`, all
+of which are position-stage derived state that a bare `qpos`/`qvel` write does
+not refresh -- so after a direct `data.qpos` write (a planning/IK loop) or
+`set_joint_velocities`, `get_energy` silently returned the energy of the
+*previous* configuration. It now runs `mj_forward` under the sim lock before
+reading, matching the defensive forward already in `get_mass_matrix` and
+`inverse_dynamics`. The explicit `mj_energyPos`/`mj_energyVel` calls are kept
+because `mj_forward` only recomputes `data.energy` when `mjENBL_ENERGY` is
+enabled (it is not by default), whereas the explicit calls populate it
+unconditionally.
+
 ### Added: `run_policy(policy_object=...)` on the hardware `Robot` -- sim parity for pre-built policies
 
 The simulation side has a one-call rollout for a policy constructed in-process

--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -544,7 +544,22 @@ class PhysicsMixin:
     # Energy
 
     def get_energy(self) -> dict[str, Any]:
-        """Compute potential and kinetic energy of the system."""
+        """Compute potential and kinetic energy of the system.
+
+        Reflects the CURRENT configuration. ``mj_energyPos`` reads the
+        position-stage derived state (``data.xipos`` for the gravitational
+        term, spring/tendon lengths) and ``mj_energyVel`` reads the
+        config-dependent inertia (``data.qM``, itself position-stage derived)
+        against ``data.qvel``. All of that is stale after a bare ``qpos``/
+        ``qvel`` write (e.g. a direct ``data.qpos`` write from a planning/IK
+        loop, or ``set_joint_velocities``), so the position pipeline is
+        recomputed first - otherwise the reported energy is silently that of
+        an earlier pose. Matches the defensive forward in ``get_mass_matrix``
+        / ``inverse_dynamics``. The explicit ``mj_energyPos``/``mj_energyVel``
+        calls are kept because ``mj_forward`` only recomputes ``data.energy``
+        when ``mjENBL_ENERGY`` is enabled (it is not, by default), whereas the
+        explicit calls populate ``data.energy`` unconditionally.
+        """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
 
@@ -552,6 +567,7 @@ class PhysicsMixin:
         model, data = self._world._model, self._world._data
 
         with self._lock:
+            mj.mj_forward(model, data)
             mj.mj_energyPos(model, data)
             mj.mj_energyVel(model, data)
             potential = float(data.energy[0])

--- a/tests/simulation/mujoco/test_physics.py
+++ b/tests/simulation/mujoco/test_physics.py
@@ -195,6 +195,38 @@ class TestEnergy:
         # Kinetic energy should change (box falls)
         assert e1["kinetic"] != e2["kinetic"] or e1["potential"] != e2["potential"]
 
+    def test_energy_reflects_direct_qpos_write(self, sim):
+        """get_energy must recompute derived state for the CURRENT qpos.
+
+        mj_energyPos reads position-stage derived state (data.xipos for the
+        gravity term). A direct data.qpos write - e.g. a planning/IK loop -
+        does not refresh it, so without the defensive forward get_energy
+        reports the potential energy of the STALE pose. Regression pin for the
+        missing forward: fails-before because e_after equalled e_rest.
+        """
+        model, data = sim._world._model, sim._world._data
+        # box1 has a freejoint: qpos = [x, y, z, qw, qx, qy, qz]; index 2 is z.
+        z_adr = model.jnt_qposadr[mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, "box_free")] + 2
+
+        e_rest = _extract_json_block(sim.get_energy(), 1)
+
+        # Directly raise the box (no forward) - stale path.
+        new_z = float(data.qpos[z_adr]) + 1.5
+        data.qpos[z_adr] = new_z
+        e_after = _extract_json_block(sim.get_energy(), 1)
+
+        # Independent ground truth on a fresh MjData at the new configuration.
+        gt = mj.MjData(model)
+        gt.qpos[:] = data.qpos
+        gt.qvel[:] = data.qvel
+        mj.mj_forward(model, gt)
+        mj.mj_energyPos(model, gt)
+        truth_potential = float(gt.energy[0])
+
+        # fails-before: e_after["potential"] equalled the stale e_rest value.
+        assert abs(e_after["potential"] - truth_potential) < 1e-6
+        assert abs(e_after["potential"] - e_rest["potential"]) > 1e-3
+
 
 class TestExternalForces:
     def test_apply_force(self, sim):


### PR DESCRIPTION
## What

`Simulation.get_energy()` reported the potential/kinetic energy of a **stale pose** after a direct `qpos`/`qvel` write.

`get_energy` called `mj_energyPos` / `mj_energyVel` on whatever derived state happened to be left in `data`, without recomputing the forward pipeline first:

- Potential energy is a function of `data.xipos` (inertial body positions in the world frame, plus spring/tendon lengths).
- Kinetic energy is `0.5 * qvel^T M qvel`, reading the config-dependent inertia `data.qM`.

Both `xipos` and `qM` are **position-stage derived state** that a bare `qpos`/`qvel` write does not refresh. So after a direct `data.qpos` write (a planning/IK loop) or `set_joint_velocities`, `get_energy` silently returned the energy of the *previous* configuration.

This is the same class of stale-derived-state bug already fixed for the sibling query methods: `get_jacobian` / `forward_kinematics` (#1006), `raycast` (#1038), `set_geom_properties` broadphase bounds (#1032), `inverse_dynamics` (#1002).

## Fix

Run `mj_forward` under the existing sim lock before reading, matching the defensive forward already in `get_mass_matrix` and `inverse_dynamics`.

The explicit `mj_energyPos` / `mj_energyVel` calls are **kept**: `mj_forward` only recomputes `data.energy` when `mjENBL_ENERGY` is enabled (it is not, by default), whereas the explicit calls populate `data.energy` unconditionally. The forward refreshes `xipos`/`qM`; the explicit calls then compute energy from that fresh state.

## Test

Pinned regression `test_energy_reflects_direct_qpos_write`: writes `data.qpos[z]` directly (no forward), then asserts the reported potential energy matches an independent `mj_forward` at the new configuration, and differs from the rest value.

**Fails-before:** on pre-fix code the test reports `5.56 J` (stale) vs the `20.27 J` ground truth (a 14.7 J error). Verified by reverting the source hunk and re-running.

```
76 passed  (tests/simulation/mujoco/test_physics.py)
ruff check: All checks passed
ruff format --check: 2 files already formatted
```

## Scope

Three files, one logical change: the `mj_forward` line + docstring in `physics.py`, the regression test, and a CHANGELOG `[Unreleased]` entry. No behavioural change to any other method.