### PR TITLE
feat(sim): evaluate_benchmark honors policy_object + control_frequency/control_substeps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -390,6 +390,22 @@ the reward-model, robot, teleop, and camera surfaces already use. A static
 fallback is kept for the offline case (lerobot not importable). Genuinely unknown
 policy types are still rejected.
 
+### Added
+
+- `evaluate_benchmark(policy_object=..., control_frequency=..., control_substeps=...)`
+  brings the benchmark evaluation entry point to parity with `run_policy` /
+  `eval_policy`. It could previously neither evaluate a pre-built `Policy` (it
+  always ran `create_policy`, forcing a redundant reload of a multi-GB VLA
+  checkpoint) nor set the control-loop rate (physics stepped at a hardcoded
+  50 Hz). A benchmark's `max_steps` maps to a wall-clock episode length that
+  depends on the control frequency, so a policy trained/evaluated at a
+  different rate was scored over a mismatched horizon; `control_frequency`
+  now lets the benchmark run at the policy's rate. The shared
+  `PolicyRunner.evaluate` plumbing already supported these; only the facade
+  exposes them now. A non-positive `control_frequency` is rejected with a
+  structured error, and the `control_frequency` tool parameter is forwarded on
+  the agent-dispatch path.
+
 
 ## [0.4.1] - 2026-07-01
 

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -1610,6 +1610,9 @@ class SimEngine(ABC):
         action_horizon: int = 8,
         on_frame: Callable[[int, dict[str, Any], dict[str, Any]], None] | None = None,
         policy_kwargs: dict[str, Any] | None = None,
+        control_frequency: float = 50.0,
+        control_substeps: int | None = None,
+        policy_object: Policy | None = None,
     ) -> dict[str, Any]:
         """Run a registered :class:`BenchmarkProtocol` against the current sim.
 
@@ -1670,6 +1673,27 @@ class SimEngine(ABC):
                 (``target_velocity`` / ``target_pose`` / ``target_joints`` /
                 ``world_update``); a benchmark that drives such a policy must
                 pass them or the policy runs with an empty goal.
+            control_frequency: Target Hz for ``policy.get_actions`` calls, used
+                to derive the physics substeps executed per action
+                (``round(1 / control_frequency / physics_timestep)``) so the
+                benchmark loop steps a full control period per action. Must be
+                ``> 0``; a non-positive value is rejected with a structured
+                error. Defaults to ``50.0`` (same default as :meth:`eval_policy`).
+                Set it to the rate the policy was trained/evaluated at - a
+                benchmark's ``max_steps`` maps to a wall-clock episode length
+                that depends on this rate, so a mismatched frequency changes the
+                effective episode horizon.
+            control_substeps: Explicit physics substeps per action, overriding
+                the ``control_frequency``-derived value (mirrors
+                :meth:`eval_policy`). ``None`` (default) derives it from
+                ``control_frequency``.
+            policy_object: An already-built :class:`Policy` to evaluate,
+                skipping the ``create_policy`` round-trip (mirrors
+                :meth:`run_policy` / :meth:`eval_policy`). Use it to benchmark a
+                checkpoint you have already loaded - e.g. a multi-GB VLA - once
+                per process instead of reloading it on every benchmark call.
+                When ``None`` the policy is built from ``policy_provider`` /
+                ``policy_config``.
 
         Returns:
             Standard status dict. On success, carries per-episode cumulative
@@ -1682,6 +1706,8 @@ class SimEngine(ABC):
         if err := self._validate_action_horizon(action_horizon, "evaluate_benchmark"):
             return err
         if err := self._validate_positive_int(n_episodes, "n_episodes", "evaluate_benchmark"):
+            return err
+        if err := self._validate_positive_frequency(control_frequency, "evaluate_benchmark"):
             return err
 
         spec = get_benchmark(benchmark_name)
@@ -1730,7 +1756,13 @@ class SimEngine(ABC):
                 "content": [{"text": f"Robot '{resolved_robot}' not found. Loaded: {robots}"}],
             }
 
-        policy = create_policy(policy_provider, **(policy_config or {}))
+        if policy_object is None:
+            policy = create_policy(policy_provider, **(policy_config or {}))
+        else:
+            # Pre-built policy path - mirror run_policy / eval_policy. Lets a
+            # caller benchmark an already-loaded checkpoint (e.g. a multi-GB
+            # VLA) without a create_policy round-trip / redundant reload.
+            policy = policy_object
         policy.set_robot_state_keys(self.robot_action_keys(resolved_robot))
         self.bind_policy_sim_context(policy, resolved_robot)
 
@@ -1742,6 +1774,8 @@ class SimEngine(ABC):
             spec=spec,
             seed=seed,
             action_horizon=action_horizon,
+            control_frequency=control_frequency,
+            control_substeps=control_substeps,
             on_frame=on_frame,
             policy_kwargs=policy_kwargs,
         )

--- a/tests/simulation/mujoco/test_evaluate_benchmark_control_and_policy_object.py
+++ b/tests/simulation/mujoco/test_evaluate_benchmark_control_and_policy_object.py
@@ -1,0 +1,194 @@
+"""``evaluate_benchmark`` parity with ``run_policy`` / ``eval_policy``.
+
+``evaluate_benchmark`` was the sole policy-evaluation entry point that could
+neither run a pre-built policy (``policy_object=``) nor set the control-loop
+rate (``control_frequency`` / ``control_substeps``); it always built a fresh
+policy via ``create_policy`` and stepped physics at a hardcoded 50 Hz. Both
+capabilities already exist on the shared ``PolicyRunner.evaluate`` /
+``_evaluate_with_spec`` plumbing - the facade just did not expose them.
+
+These tests drive a real MuJoCo physics benchmark (inline MJCF, dt=0.002,
+no rendering - the policy declares ``requires_images=False``) and assert:
+
+* ``policy_object=`` is accepted and the benchmark runs against it WITHOUT a
+  ``create_policy`` round-trip (a heavy checkpoint is not reloaded);
+* ``control_frequency`` flows through to the physics substeps stepped per
+  action (``round(1 / control_frequency / physics_timestep)``), so a benchmark
+  can run at the rate the policy was trained at;
+* a non-positive ``control_frequency`` is rejected with a structured error.
+
+Each assertion fails on the pre-fix facade (``TypeError: evaluate_benchmark()
+got an unexpected keyword argument ...``).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from typing import Any
+
+import pytest
+
+mj = pytest.importorskip("mujoco")
+
+from strands_robots.policies.mock import MockPolicy  # noqa: E402
+from strands_robots.simulation.benchmark import (  # noqa: E402
+    _BENCHMARK_REGISTRY,
+    BenchmarkProtocol,
+    StepInfo,
+    register_benchmark,
+)
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+ROBOT_XML = """
+<mujoco model="test_arm">
+  <compiler angle="radian" autolimits="true"/>
+  <option timestep="0.002"/>
+  <worldbody>
+    <light name="main" pos="0 0 3" dir="0 0 -1"/>
+    <geom name="ground" type="plane" size="5 5 0.01" rgba="0.9 0.9 0.9 1"/>
+    <body name="base" pos="0 0 0.1">
+      <geom type="cylinder" size="0.05 0.05" rgba="0.3 0.3 0.8 1"/>
+      <joint name="shoulder_pan" type="hinge" axis="0 0 1" range="-3.14 3.14"/>
+      <body name="link1" pos="0 0 0.1">
+        <geom type="capsule" size="0.03" fromto="0 0 0 0 0 0.2" rgba="0.8 0.3 0.3 1"/>
+        <joint name="elbow" type="hinge" axis="0 1 0" range="-1.57 1.57"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="shoulder_pan_act" joint="shoulder_pan" kp="50"/>
+    <position name="elbow_act" joint="elbow" kp="50"/>
+  </actuator>
+</mujoco>
+"""
+
+
+class _ProbeBenchmark(BenchmarkProtocol):
+    """Minimal spec: runs the full horizon, never succeeds/fails early."""
+
+    max_steps = 4
+
+    @property
+    def supported_robots(self) -> list[str]:
+        return []  # any loaded robot
+
+    @property
+    def default_robot(self) -> str:
+        return "arm1"
+
+    def on_step(self, sim, obs, action) -> StepInfo:
+        return StepInfo(reward=0.0)
+
+    def is_success(self, sim) -> bool:
+        return False
+
+    def is_failure(self, sim) -> bool:
+        return False
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    snapshot = dict(_BENCHMARK_REGISTRY)
+    _BENCHMARK_REGISTRY.clear()
+    yield
+    _BENCHMARK_REGISTRY.clear()
+    _BENCHMARK_REGISTRY.update(snapshot)
+
+
+@pytest.fixture
+def sim_with_robot():
+    tmpdir = tempfile.mkdtemp()
+    path = os.path.join(tmpdir, "arm.xml")
+    with open(path, "w") as f:
+        f.write(ROBOT_XML)
+    s = Simulation(tool_name="bench_parity_sim", mesh=False)
+    s.create_world()
+    s.add_robot("arm1", urdf_path=path)
+    yield s
+    s.cleanup()
+    shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def _capture_substeps(sim) -> list[int]:
+    """Wrap sim.send_action to record the n_substeps it is driven with."""
+    captured: list[int] = []
+    orig = sim.send_action
+
+    def _spy(action, robot_name=None, n_substeps: int = 1):
+        captured.append(int(n_substeps))
+        return orig(action, robot_name=robot_name, n_substeps=n_substeps)
+
+    sim.send_action = _spy  # type: ignore[method-assign]
+    return captured
+
+
+def test_policy_object_runs_benchmark_without_create_policy(sim_with_robot, monkeypatch):
+    """A pre-built policy is evaluated as-is; create_policy is never called."""
+    register_benchmark("probe", _ProbeBenchmark())
+
+    def _boom(*_a: Any, **_k: Any):
+        raise AssertionError("create_policy must not be called on the policy_object path")
+
+    # create_policy is imported lazily inside evaluate_benchmark from this module.
+    monkeypatch.setattr("strands_robots.policies.create_policy", _boom)
+
+    policy = MockPolicy()
+    result = sim_with_robot.evaluate_benchmark(
+        benchmark_name="probe",
+        robot_name="arm1",
+        n_episodes=1,
+        policy_object=policy,
+    )
+    assert result["status"] == "success", result
+
+
+def test_control_frequency_sets_physics_substeps(sim_with_robot):
+    """control_frequency derives substeps/action = round(1/cf / dt), dt=0.002."""
+    register_benchmark("probe", _ProbeBenchmark())
+
+    for control_frequency, expected in ((25.0, 20), (50.0, 10)):
+        captured = _capture_substeps(sim_with_robot)
+        result = sim_with_robot.evaluate_benchmark(
+            benchmark_name="probe",
+            robot_name="arm1",
+            n_episodes=1,
+            policy_object=MockPolicy(),
+            control_frequency=control_frequency,
+        )
+        assert result["status"] == "success", result
+        assert captured, "send_action was never called"
+        assert set(captured) == {expected}, (
+            f"control_frequency={control_frequency} -> expected n_substeps={expected}, got {sorted(set(captured))}"
+        )
+
+
+def test_control_substeps_override(sim_with_robot):
+    """control_substeps overrides the control_frequency-derived value."""
+    register_benchmark("probe", _ProbeBenchmark())
+    captured = _capture_substeps(sim_with_robot)
+    result = sim_with_robot.evaluate_benchmark(
+        benchmark_name="probe",
+        robot_name="arm1",
+        n_episodes=1,
+        policy_object=MockPolicy(),
+        control_frequency=50.0,
+        control_substeps=7,
+    )
+    assert result["status"] == "success", result
+    assert set(captured) == {7}, sorted(set(captured))
+
+
+def test_non_positive_control_frequency_rejected(sim_with_robot):
+    """A non-positive control_frequency returns a structured error, not a raise."""
+    register_benchmark("probe", _ProbeBenchmark())
+    result = sim_with_robot.evaluate_benchmark(
+        benchmark_name="probe",
+        robot_name="arm1",
+        n_episodes=1,
+        policy_object=MockPolicy(),
+        control_frequency=0,
+    )
+    assert result["status"] == "error"
+    assert "control_frequency" in result["content"][0]["text"]


### PR DESCRIPTION
## Problem

`evaluate_benchmark` was the sole policy-evaluation entry point missing two capabilities its siblings `run_policy` and `eval_policy` already have:

1. **No `policy_object=`** — it always built a fresh policy via `create_policy(...)`. Benchmarking an already-loaded checkpoint (e.g. a multi-GB VLA) forced a full model reload on every call.
2. **No `control_frequency` / `control_substeps`** — it stepped physics at a hardcoded 50 Hz. A benchmark's `max_steps` maps to a wall-clock episode length that depends on the control rate, so a policy trained/evaluated at a different frequency was scored over a mismatched effective horizon (and the per-action physics integration differed from how the policy is actually driven).

The underlying `PolicyRunner.evaluate` / `_evaluate_with_spec` plumbing **already** supports all three arguments; only the `evaluate_benchmark` facade did not thread them.

## Change

Add `policy_object`, `control_frequency`, and `control_substeps` to `evaluate_benchmark`, mirroring `eval_policy`:

- `policy_object` (pre-built `Policy`) skips the `create_policy` round-trip.
- `control_frequency` / `control_substeps` flow through to `PolicyRunner.evaluate`, deriving the physics substeps stepped per action (`round(1 / control_frequency / physics_timestep)`) so the benchmark loop steps a full control period at the policy's rate.
- A non-positive `control_frequency` is rejected with a structured error via the shared `_validate_positive_frequency`.
- `async_rtc` is intentionally **not** added — the benchmark spec path (`_evaluate_with_spec`) does not implement it, and the `eval_policy` docstring already steers latency-masking evals to `run_policy`.
- No `tool_spec` change: `control_frequency` is already a shared tool parameter, so the agent-dispatch path now forwards it to `evaluate_benchmark` automatically; `control_substeps` is Python-API-only (as on `run_policy`/`eval_policy`) and `policy_object` is a live object, not a JSON param.

## Tests

New `tests/simulation/mujoco/test_evaluate_benchmark_control_and_policy_object.py` drives a **real MuJoCo physics benchmark** (inline MJCF, dt=0.002, no rendering):

- `policy_object=` runs the benchmark against a pre-built `MockPolicy` with `create_policy` monkeypatched to raise — proving no reload.
- `control_frequency` 25 Hz vs 50 Hz derives `n_substeps` 20 vs 10 (spied on `send_action`).
- `control_substeps` overrides the derived value.
- non-positive `control_frequency` returns a structured error, not a raise.

All four **fail before** the change (`TypeError: evaluate_benchmark() got an unexpected keyword argument ...`) and pass after. Existing benchmark/eval/dispatch suites remain green (161 + 69 passed locally); `ruff`/`ruff format`/`mypy` clean.

## Visual

Same `MockPolicy` evaluated through `evaluate_benchmark` on an SO-101 at 25 Hz vs 50 Hz (identical `max_steps`, seed) reaches physically different final poses (`||q25 - q50|| = 0.0593 rad`), confirming `control_frequency` genuinely changes the rollout. Rendered headless (MuJoCo EGL):

![evaluate_benchmark at 25 Hz vs 50 Hz](https://github.com/cagataycali/robots/releases/download/eval-bench-cf-1783153164/eval_bench_cf.png)