### PR TITLE
test(simulation): pin move_object dynamic-object orientation contract

### DIFF
--- a/tests/simulation/mujoco/test_move_object_dynamic_orientation.py
+++ b/tests/simulation/mujoco/test_move_object_dynamic_orientation.py
@@ -1,0 +1,78 @@
+"""Regression tests: ``move_object`` must apply ORIENTATION to dynamic objects.
+
+A dynamic object (``is_static=False``) carries its pose on a freejoint, whose
+``data.qpos`` slice is laid out as ``[x, y, z, qw, qx, qy, qz]``. ``move_object``
+takes the cheap path for these: it writes ``data.qpos`` directly and runs a
+forward pass (no recompile). The position half of that path is exercised
+elsewhere; these pin the orientation half - writing the quaternion into
+``qpos[3:7]`` and mirroring it onto the stored :class:`SimObject`.
+
+The contract these guard (mirroring the static-object tests): ``move_object``
+never reports success without the object actually moving. For orientation that
+means the *compiled body's* world quaternion (``data.xquat``) must reflect the
+requested rotation after the forward pass - asserting the observable physical
+effect, not the internal ``qpos`` write.
+"""
+
+import math
+
+import pytest
+
+mj = pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="test_move_dynamic_orientation_sim", mesh=False)
+    s.create_world(gravity=[0, 0, -9.81])
+    yield s
+    s.cleanup()
+
+
+def _body_xquat(world, name):
+    bid = mj.mj_name2id(world._model, mj.mjtObj.mjOBJ_BODY, name)
+    assert bid >= 0, f"body {name!r} not found in compiled model"
+    return [float(x) for x in world._data.xquat[bid]]
+
+
+def _body_xpos(world, name):
+    bid = mj.mj_name2id(world._model, mj.mjtObj.mjOBJ_BODY, name)
+    assert bid >= 0, f"body {name!r} not found in compiled model"
+    return [float(x) for x in world._data.xpos[bid]]
+
+
+def test_move_dynamic_object_orientation_only(sim):
+    """An orientation-only move rotates the compiled body and stores the quat.
+
+    A 90 deg rotation about +Z is ``[cos45, 0, 0, sin45]`` in MuJoCo's
+    ``[w, x, y, z]`` convention. The body's world quaternion must match after
+    the forward pass, and the stored ``SimObject.orientation`` must be updated
+    (not left at its spawn identity).
+    """
+    sim.add_object("cube", shape="box", size=[0.03, 0.03, 0.03], position=[0.0, 0.0, 0.5], is_static=False)
+    quat = [math.cos(math.pi / 4), 0.0, 0.0, math.sin(math.pi / 4)]
+
+    result = sim.move_object("cube", orientation=quat)
+    assert result["status"] == "success", result
+
+    assert _body_xquat(sim._world, "cube") == pytest.approx(quat, abs=1e-6)
+    assert list(sim._world.objects["cube"].orientation) == pytest.approx(quat)
+
+
+def test_move_dynamic_object_position_and_orientation(sim):
+    """Position and orientation supplied together are both applied in one call."""
+    sim.add_object("cube", shape="box", size=[0.03, 0.03, 0.03], position=[0.0, 0.0, 0.5], is_static=False)
+    target_pos = [0.2, 0.1, 0.4]
+    identity = [1.0, 0.0, 0.0, 0.0]
+
+    # First rotate away from identity so the reset-to-identity is observable.
+    sim.move_object("cube", orientation=[math.cos(math.pi / 4), 0.0, 0.0, math.sin(math.pi / 4)])
+    result = sim.move_object("cube", position=target_pos, orientation=identity)
+    assert result["status"] == "success", result
+
+    assert _body_xpos(sim._world, "cube") == pytest.approx(target_pos, abs=1e-6)
+    assert _body_xquat(sim._world, "cube") == pytest.approx(identity, abs=1e-6)
+    assert list(sim._world.objects["cube"].position) == pytest.approx(target_pos)
+    assert list(sim._world.objects["cube"].orientation) == pytest.approx(identity)


### PR DESCRIPTION
## What

`move_object` moves a dynamic (freejoint) object through the cheap path: it writes the pose straight into `data.qpos` and runs a forward pass, no recompile. The `qpos` slice for a freejoint is `[x, y, z, qw, qx, qy, qz]`, so position lands in `qpos[0:3]` and orientation in `qpos[3:7]`.

The position half of that path was already exercised (`test_move_dynamic_object_uses_qpos_path`), but the **orientation** half was unverified: writing the quaternion into `qpos[3:7]` and mirroring it onto the stored `SimObject.orientation`.

## Change

Two focused tests in `tests/simulation/mujoco/test_move_object_dynamic_orientation.py`:

- `test_move_dynamic_object_orientation_only` - a 90 deg rotation about +Z (`[cos45, 0, 0, sin45]`) is reflected in the compiled body's world quaternion (`data.xquat`) after the forward pass, and the stored `SimObject.orientation` is updated.
- `test_move_dynamic_object_position_and_orientation` - position and orientation supplied in one call are both applied (position in `data.xpos`, orientation reset to identity in `data.xquat`).

Both assert the **observable physical effect** (the compiled body's world pose), not the internal `qpos` write - mirroring the contract the existing static-object tests pin: `move_object` never reports success without the object actually moving.

## Coverage

Closes the previously-uncovered orientation branch of the dynamic path in `simulation/mujoco/simulation.py` (the `qpos[3:7] = orientation` write and the `SimObject.orientation` mirror).

## Visual proof

Elongated box rendered in MuJoCo (headless, `MUJOCO_GL=egl`) before (left) and after (right) an orientation-only `move_object` of +90 deg about Z:

![move_object orientation before/after](https://github.com/cagataycali/robots/releases/download/viz-move-object-orientation-1783155746/move_object_orientation.png)

## Test

`MUJOCO_GL=egl pytest tests/simulation/mujoco/test_move_object_dynamic_orientation.py` - 2 passed. Full `tests/simulation/mujoco/` suite green (the only failures locally are the pre-existing torchcodec/video-decode env issue in `test_recording_paths.py`, unrelated to this change). Lint/format clean.