### PR TITLE
docs(sim): correct the async_rtc seam-blending claim for non-RTC chunk policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -423,6 +423,25 @@ policy types are still rejected.
   the agent-dispatch path.
 
 
+### Docs: `run_policy(async_rtc=...)` no longer claims SmolVLA/MolmoAct2 blend the chunk seam internally
+
+- The `PolicyRunner.run` `async_rtc` docstring stated that "RTC-capable
+  policies (pi0, pi0.5, SmolVLA, MolmoAct2) blend the seam internally through
+  their own prev-chunk state (`rtc_config.execution_horizon`)". That conflates
+  two independent things and is wrong for the checkpoints most users load.
+  The async OVERLAP (latency masking) auto-enables for *any* chunk-emitting
+  policy via `is_chunk_emitting()`; RTC SEAM BLENDING is a separate,
+  checkpoint-level property (`supports_rtc`) that requires an enabled
+  `rtc_config`. The public `lerobot/smolvla_base` checkpoint ships
+  `rtc_config=None` and MolmoAct2 has no `rtc_config` at all, so both report
+  `supports_rtc=False`: they get the overlap but a plain chunk swap at the
+  seam, not a blended one. Reading the old text, a user would deploy
+  `smolvla_base` expecting a smoothly-joined trajectory and instead get a
+  velocity discontinuity at every chunk boundary. The docstring now describes
+  overlap and seam-blending as the two distinct capabilities they are, and a
+  regression test pins that `rtc_async_enabled` can be `True` while
+  `supports_rtc` is `False`.
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -719,11 +719,18 @@ class PolicyRunner:
                 latency is at most the chunk's execution time then pays
                 (almost) zero visible stall at the chunk seam - the same way an
                 async real-time controller hides inference latency on real
-                hardware. RTC-capable policies (pi0, pi0.5, SmolVLA, MolmoAct2)
-                blend the seam internally through their own prev-chunk state
-                (``rtc_config.execution_horizon``); this flag only schedules the
-                overlap and never touches the policy's RTC machinery, so it is
-                provider-agnostic. ``False`` keeps the historical
+                hardware. Whether the chunk SEAM is additionally blended is a
+                separate, checkpoint-level property (``supports_rtc``): a policy
+                loaded from a checkpoint with an enabled ``rtc_config`` (e.g.
+                pi0 / pi0.5, or a SmolVLA checkpoint configured for RTC) carries
+                prev-chunk state across the seam and joins consecutive chunks
+                smoothly, whereas a chunk-emitting policy WITHOUT an
+                ``rtc_config`` - MolmoAct2, ACT, diffusion, and the public
+                ``lerobot/smolvla_base`` checkpoint - gets the overlap (latency
+                masking) but a plain chunk swap at the seam. This flag only
+                schedules the overlap; it never enables or touches the policy's
+                RTC machinery, so it is provider-agnostic. ``False`` keeps the
+                historical
                 synchronous chunk-then-drain loop, which is correct for
                 single-step policies and any policy whose ``get_actions`` reads
                 live sim state. ``None`` (default) auto-resolves the flag from

--- a/tests/simulation/test_policy_runner_async_rtc.py
+++ b/tests/simulation/test_policy_runner_async_rtc.py
@@ -308,6 +308,39 @@ def test_async_rtc_auto_disabled_for_single_step_policy() -> None:
     assert result["content"][1]["json"]["rtc_async_enabled"] is False
 
 
+def test_async_overlap_enabled_but_seam_not_blended_for_non_rtc_chunk_policy() -> None:
+    """Overlap auto-enable and RTC seam-blending are independent capabilities.
+
+    ``run_policy``'s docstring distinguishes two things that a reader can easily
+    conflate: the async OVERLAP (latency masking, auto-enabled for *any*
+    chunk-emitting policy via ``is_chunk_emitting()``) and RTC SEAM BLENDING (a
+    checkpoint-level property, ``supports_rtc``, that joins consecutive chunks
+    smoothly and requires an enabled ``rtc_config``). A chunk-emitting policy
+    that does NOT support RTC - the shape of the public ``lerobot/smolvla_base``
+    checkpoint (``rtc_config=None``), MolmoAct2 (no ``rtc_config``), ACT and
+    diffusion - must still get the overlap, but its seam is a plain chunk swap,
+    not a blended one. This pins that ``rtc_async_enabled`` can be ``True`` while
+    ``supports_rtc`` is ``False``, so the two never get collapsed back together.
+    """
+    sim = _CountingSim(exec_sleep=_EXEC_SLEEP)
+    policy = _ChunkPolicy(sim)
+    policy.set_robot_state_keys(sim.robot_joint_names("arm"))
+
+    # A plain chunk emitter declares no RTC support (no enabled rtc_config).
+    assert getattr(policy, "supports_rtc", False) is False
+    assert policy.is_chunk_emitting() is True
+
+    result = PolicyRunner(sim).run(
+        "arm", policy, duration=16 / 50.0, control_frequency=50.0, action_horizon=_CHUNK, fast_mode=True
+    )
+    assert result["status"] == "success"
+    telem = result["content"][1]["json"]
+    # Overlap auto-enabled (latency masking) ...
+    assert telem["rtc_async_enabled"] is True
+    # ... yet the policy still reports no internal RTC seam blending.
+    assert getattr(policy, "supports_rtc", False) is False
+
+
 # --- telemetry block ------------------------------------------------------
 
 _RTC_KEYS = {


### PR DESCRIPTION
## Problem

The `PolicyRunner.run` `async_rtc` docstring (reached from `Simulation.run_policy`) tells the reader:

> RTC-capable policies (pi0, pi0.5, SmolVLA, MolmoAct2) blend the seam internally through their own prev-chunk state (`rtc_config.execution_horizon`); this flag only schedules the overlap and never touches the policy's RTC machinery.

This conflates two independent capabilities and is wrong for the checkpoints most users actually load:

1. **Async overlap** (latency masking) — auto-enabled for *any* chunk-emitting policy via `is_chunk_emitting()`. It fires the next `get_actions()` ~50% into the current chunk and swaps it in at the seam.
2. **RTC seam blending** — a *checkpoint-level* property (`supports_rtc`) that carries prev-chunk state across the seam so consecutive chunks join smoothly. It requires an **enabled `rtc_config`** on the loaded model, and the code correctly gates it on exactly that (`LerobotLocalPolicy.supports_rtc` derives from `rtc_config is not None and rtc_config.enabled`).

The public `lerobot/smolvla_base` checkpoint ships `rtc_config: null` (`config.json`), and MolmoAct2 has no `rtc_config` at all (`RTC never applies to MolmoAct2 (no rtc_config)` per the loader). Both therefore report `supports_rtc=False`: they get the async overlap but a **plain chunk swap** at the seam, not a blended one.

A user reading the old text would deploy `smolvla_base` expecting a smoothly-joined trajectory and instead get a velocity discontinuity at every chunk boundary. The docstring — the stated justification for why the default is safe — contradicts the code.

## Change

- Rewrite the `async_rtc` docstring to describe the two capabilities as distinct: the overlap auto-enables for any chunk-emitting policy (latency masking), while seam *blending* is gated on the loaded checkpoint's `rtc_config` (`supports_rtc`). Names the concrete no-`rtc_config` cases — MolmoAct2, ACT, diffusion, and the public `lerobot/smolvla_base` checkpoint — as getting the overlap but a plain chunk swap. Phrasing is checkpoint-scoped, not provider-name-based, so a SmolVLA checkpoint that *is* configured for RTC is still covered.
- Add a regression test (`test_async_overlap_enabled_but_seam_not_blended_for_non_rtc_chunk_policy`) that pins the invariant the corrected docstring relies on: a chunk-emitting policy with `supports_rtc=False` auto-enables the overlap (`rtc_async_enabled=True`) while still reporting `supports_rtc=False`, so the two are never collapsed back together.

No behavior change — the runtime already gates seam blending on `supports_rtc`; only the documentation was misleading.

## Tests

`tests/simulation/test_policy_runner_async_rtc.py` + `tests/policies/test_chunked_policy_contract.py` — 44 passed (`MUJOCO_GL=egl`). `ruff check`, `ruff format --check`, and `mypy` clean on the changed files.