### PR TITLE
fix(mesh): anchor identifier allowlists with \Z so a trailing newline is rejected

### DIFF
--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -239,7 +239,7 @@ def _evict_replay_cache[K](
 #: to reject obviously-bogus stand-ins (test ``MagicMock``,
 #: third-party transport shims) without paying the cost of importing
 #: zenoh just to ``isinstance`` check.
-_ZENOH_ZID_PATTERN = re.compile(r"^[0-9a-f]{1,32}$")
+_ZENOH_ZID_PATTERN = re.compile(r"^[0-9a-f]{1,32}\Z")
 
 
 def _extract_sample_source_zid(sample: Any) -> str | None:
@@ -3307,7 +3307,7 @@ def init_mesh(
 
     # Validate peer_id - reject reserved names and MQTT-unsafe characters.
     _RESERVED_PEER_IDS = {"broadcast", "safety"}
-    _PEER_ID_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._\-]{0,127}$")
+    _PEER_ID_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._\-]{0,127}\Z")
     if peer_id in _RESERVED_PEER_IDS:
         raise ValueError(
             f"peer_id={peer_id!r} is reserved for system use. Reserved names: {sorted(_RESERVED_PEER_IDS)}"

--- a/tests/mesh/test_mesh_identifier_trailing_newline_rejected.py
+++ b/tests/mesh/test_mesh_identifier_trailing_newline_rejected.py
@@ -24,7 +24,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from strands_robots.mesh.core import _extract_sample_source_zid, init_mesh
+from strands_robots.mesh import core
 
 
 def _zid_obj(zid_str: str) -> Any:
@@ -63,7 +63,7 @@ def test_init_mesh_rejects_peer_id_with_trailing_newline(peer_id: str) -> None:
     newline lands in ``strands/{peer_id}/cmd`` MQTT topics.
     """
     with pytest.raises(ValueError, match="invalid characters"):
-        init_mesh(MagicMock(), peer_id=peer_id)
+        core.init_mesh(MagicMock(), peer_id=peer_id)
 
 
 def test_init_mesh_accepts_clean_peer_id_is_not_broken_by_the_fix(
@@ -75,21 +75,19 @@ def test_init_mesh_accepts_clean_peer_id_is_not_broken_by_the_fix(
     Mesh constructor to a no-op so the test exercises only the allowlist and
     never touches Zenoh.
     """
-    import strands_robots.mesh.core as core_module
-
-    monkeypatch.setattr(core_module, "Mesh", lambda *a, **k: MagicMock(alive=False))
+    monkeypatch.setattr(core, "Mesh", lambda *a, **k: MagicMock(alive=False))
     # Should not raise: a clean id passes the tightened anchor.
-    init_mesh(MagicMock(), peer_id="robot-1.arm_2")
+    core.init_mesh(MagicMock(), peer_id="robot-1.arm_2")
 
 
 def test_init_mesh_still_rejects_reserved_and_embedded_unsafe_chars() -> None:
     """Pin the surrounding allowlist contract (reserved names + MQTT chars)."""
     for reserved in ("broadcast", "safety"):
         with pytest.raises(ValueError, match="reserved"):
-            init_mesh(MagicMock(), peer_id=reserved)
+            core.init_mesh(MagicMock(), peer_id=reserved)
     for bad in ("a/b", "a+b", "a#b", "a\x00b", ".leadingdot", "a" * 130):
         with pytest.raises(ValueError, match="invalid characters"):
-            init_mesh(MagicMock(), peer_id=bad)
+            core.init_mesh(MagicMock(), peer_id=bad)
 
 
 @pytest.mark.parametrize(
@@ -99,10 +97,10 @@ def test_init_mesh_still_rejects_reserved_and_embedded_unsafe_chars() -> None:
 def test_extract_source_zid_rejects_trailing_newline(zid: str) -> None:
     """A wire ZID that differs from the hex shape only by a trailing newline
     is rejected (returns None) instead of being accepted as a valid identity."""
-    assert _extract_sample_source_zid(_make_sample(zid)) is None
+    assert core._extract_sample_source_zid(_make_sample(zid)) is None
 
 
 def test_extract_source_zid_accepts_clean_hex_is_not_broken_by_the_fix() -> None:
     """The tightened anchor must still accept a well-formed 32-hex ZID."""
     clean = "0123456789abcdef0123456789abcdef"
-    assert _extract_sample_source_zid(_make_sample(clean)) == clean
+    assert core._extract_sample_source_zid(_make_sample(clean)) == clean

--- a/tests/mesh/test_mesh_identifier_trailing_newline_rejected.py
+++ b/tests/mesh/test_mesh_identifier_trailing_newline_rejected.py
@@ -1,0 +1,108 @@
+"""Mesh identifier validators must reject a trailing newline.
+
+Both mesh identifier allowlists anchor with ``$``:
+
+* ``init_mesh``'s ``peer_id`` regex (rejects MQTT-unsafe / reserved names),
+* ``_extract_sample_source_zid``'s wire-level Zenoh-ZID hex shape.
+
+Python's ``$`` matches at the end of the string *or immediately before a
+single trailing newline*, so ``re.match(r"...$", "value\n")`` succeeds.
+That let an otherwise-valid identifier smuggle a trailing ``\n`` past the
+allowlist. A newline in ``peer_id`` is interpolated straight into MQTT
+topics (``strands/{peer_id}/cmd``) and AWS Thing-names -- exactly the topic
+structure the allowlist exists to protect. A newline in the wire ZID lets a
+malformed sample be accepted as a valid safety source identity.
+
+These tests pin that both validators anchor to the absolute end of the
+string (``\\Z``), so a trailing newline is rejected.
+"""
+
+import json
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from strands_robots.mesh.core import _extract_sample_source_zid, init_mesh
+
+
+def _zid_obj(zid_str: str) -> Any:
+    """Stand-in for ``zenoh.ZenohId`` whose ``str()`` returns the digest."""
+
+    class _Zid:
+        def __str__(self) -> str:
+            return zid_str
+
+    return _Zid()
+
+
+def _make_sample(source_zid: str) -> SimpleNamespace:
+    """Minimal Zenoh sample whose ``source_info.source_id.zid`` is *source_zid*."""
+    body = json.dumps({}).encode("utf-8")
+    return SimpleNamespace(
+        payload=SimpleNamespace(to_bytes=lambda: body),
+        source_info=SimpleNamespace(
+            source_id=SimpleNamespace(zid=_zid_obj(source_zid)),
+            source_sn=1,
+        ),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _mesh_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure STRANDS_MESH does not short-circuit init_mesh before validation."""
+    monkeypatch.delenv("STRANDS_MESH", raising=False)
+
+
+@pytest.mark.parametrize("peer_id", ["robot-1\n", "arm\r", "valid.peer\n"])
+def test_init_mesh_rejects_peer_id_with_trailing_newline(peer_id: str) -> None:
+    """A peer_id that is valid except for a trailing newline/CR is rejected.
+
+    Without ``\\Z`` anchoring the ``$`` regex accepts ``"robot-1\\n"`` and the
+    newline lands in ``strands/{peer_id}/cmd`` MQTT topics.
+    """
+    with pytest.raises(ValueError, match="invalid characters"):
+        init_mesh(MagicMock(), peer_id=peer_id)
+
+
+def test_init_mesh_accepts_clean_peer_id_is_not_broken_by_the_fix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tightening to ``\\Z`` must not reject a well-formed peer_id.
+
+    The validation runs before any transport is constructed; monkeypatch the
+    Mesh constructor to a no-op so the test exercises only the allowlist and
+    never touches Zenoh.
+    """
+    import strands_robots.mesh.core as core_module
+
+    monkeypatch.setattr(core_module, "Mesh", lambda *a, **k: MagicMock(alive=False))
+    # Should not raise: a clean id passes the tightened anchor.
+    init_mesh(MagicMock(), peer_id="robot-1.arm_2")
+
+
+def test_init_mesh_still_rejects_reserved_and_embedded_unsafe_chars() -> None:
+    """Pin the surrounding allowlist contract (reserved names + MQTT chars)."""
+    for reserved in ("broadcast", "safety"):
+        with pytest.raises(ValueError, match="reserved"):
+            init_mesh(MagicMock(), peer_id=reserved)
+    for bad in ("a/b", "a+b", "a#b", "a\x00b", ".leadingdot", "a" * 130):
+        with pytest.raises(ValueError, match="invalid characters"):
+            init_mesh(MagicMock(), peer_id=bad)
+
+
+@pytest.mark.parametrize(
+    "zid",
+    ["0123456789abcdef0123456789abcdef\n", "deadbeef\n", "abc\r"],
+)
+def test_extract_source_zid_rejects_trailing_newline(zid: str) -> None:
+    """A wire ZID that differs from the hex shape only by a trailing newline
+    is rejected (returns None) instead of being accepted as a valid identity."""
+    assert _extract_sample_source_zid(_make_sample(zid)) is None
+
+
+def test_extract_source_zid_accepts_clean_hex_is_not_broken_by_the_fix() -> None:
+    """The tightened anchor must still accept a well-formed 32-hex ZID."""
+    clean = "0123456789abcdef0123456789abcdef"
+    assert _extract_sample_source_zid(_make_sample(clean)) == clean


### PR DESCRIPTION
## Problem

Two mesh identifier validators anchor their allowlist regex with `$`:

- `init_mesh`'s `peer_id` allowlist (`^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$`)
- `_extract_sample_source_zid`'s wire-level Zenoh-ZID hex shape (`^[0-9a-f]{1,32}$`)

In Python, `$` matches at end-of-string **or immediately before a single trailing newline**, so `re.match(r"...$", "value\n")` succeeds. That let an otherwise-valid identifier smuggle a trailing `\n` past the allowlist:

```python
import re
re.match(r"^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$", "robot-1\n")   # -> match (bug)
re.match(r"^[0-9a-f]{1,32}$", "deadbeef\n")                     # -> match (bug)
```

A `peer_id` such as `"robot-1\n"` is interpolated straight into MQTT topics (`strands/{peer_id}/cmd`) and AWS Thing-names, breaking exactly the topic structure the allowlist exists to protect. The same flaw let a malformed wire ZID like `"deadbeef\n"` be accepted as a valid safety source identity in `_extract_sample_source_zid`, which pins HMAC inputs and replay caches to that value.

## Change

Switch both anchors from `$` to `\Z` (absolute end of string, no trailing-newline exception). Well-formed identifiers are unaffected; only the trailing-newline bypass is closed.

## Tests

New `tests/mesh/test_mesh_identifier_trailing_newline_rejected.py`:

- `init_mesh(peer_id="robot-1\n")` now raises `ValueError` (pre-fix it slipped past validation and proceeded to construct/start a real mesh).
- `_extract_sample_source_zid` returns `None` for a wire ZID differing from the hex shape only by a trailing newline.
- Regression guards that well-formed identifiers (`robot-1.arm_2`, a clean 32-hex ZID) still pass, plus the surrounding contract (reserved `broadcast`/`safety` names and embedded `/ + # NUL` chars, leading-dot, over-length).

Full `tests/mesh` suite green (96 selected id/zid/wiring tests pass); ruff + mypy clean on the changed files.

---

### Round 1 changes

Resolved the CodeQL mixed-import-style alert on the new test: it imported `strands_robots.mesh.core` both via a module-scope `from ... import` and a local `import ... as` inside the monkeypatch test. The test now imports the module once (`from strands_robots.mesh import core`) and references `init_mesh` / `_extract_sample_source_zid` / `Mesh` through it. The monkeypatch targets the same module object `init_mesh` resolves `Mesh` from, so test semantics are unchanged. No production-code change in this round.