### PR TITLE
test(sim): pin _extract_frame_ndarray fail-soft + RGB-shape contract

### DIFF
--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -141,8 +141,12 @@ def _extract_frame_ndarray(render_result: dict) -> np.ndarray | None:
     ``{"image": {"format": "png", "source": {"bytes": <str|bytes>}}}``.
     The ``bytes`` field may contain raw bytes (legacy) or a base64-encoded
     string (current). This helper walks that structure, decodes the PNG,
-    and returns a (H, W, 3|4) numpy array. Returns ``None`` if no image is
-    found - the recorder then skips the frame rather than aborting the rollout.
+    and returns a contiguous (H, W, 3) RGB numpy array - the source is
+    always run through ``PIL.Image.convert("RGB")`` so any alpha channel
+    is dropped and the shape is a fixed 3-channel array. Returns ``None``
+    if no decodable image is found (missing/malformed content blocks, an
+    empty ``bytes`` field, or a PNG that fails to decode) - the recorder
+    then skips the frame rather than aborting the rollout.
     """
     if not isinstance(render_result, dict):
         return None

--- a/tests/simulation/test_policy_runner.py
+++ b/tests/simulation/test_policy_runner.py
@@ -352,6 +352,52 @@ def test_extract_frame_ndarray_handles_render_shape() -> None:
     assert _extract_frame_ndarray({"content": [{"text": "no image here"}]}) is None
 
 
+def test_extract_frame_ndarray_skips_non_dict_blocks_and_recovers() -> None:
+    """A malformed ``content`` list (non-dict entries interleaved with the real
+    image block) must not abort extraction: the scanner skips the junk and still
+    returns the decodable frame. This pins the recorder's fail-soft contract -
+    a stray ``None``/string in the render response should never crash a rollout.
+    """
+    img = Image.new("RGB", (4, 6), color=(10, 20, 30))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    png_bytes = buf.getvalue()
+
+    result = {
+        "status": "success",
+        "content": [
+            None,
+            "stray string block",
+            {"text": "cam0"},
+            {"image": {"format": "png", "source": {"bytes": png_bytes}}},
+        ],
+    }
+    arr = _extract_frame_ndarray(result)
+    assert isinstance(arr, np.ndarray)
+    assert arr.shape == (6, 4, 3)
+
+
+def test_extract_frame_ndarray_always_returns_three_channels() -> None:
+    """An RGBA (4-channel) PNG source is normalized to a fixed (H, W, 3) RGB
+    array - the alpha channel is dropped by ``PIL.Image.convert("RGB")``. This
+    pins the return-shape contract the video writer depends on (imageio expects
+    a stable channel count) so a future change to a 4-channel decode is caught.
+    """
+    rgba = Image.new("RGBA", (5, 7), color=(200, 100, 50, 128))
+    buf = io.BytesIO()
+    rgba.save(buf, format="PNG")
+
+    result = {
+        "content": [
+            {"image": {"format": "png", "source": {"bytes": buf.getvalue()}}},
+        ],
+    }
+    arr = _extract_frame_ndarray(result)
+    assert isinstance(arr, np.ndarray)
+    assert arr.shape == (7, 5, 3)
+    assert arr.dtype == np.uint8
+
+
 #
 # policy_object kwarg regression
 #


### PR DESCRIPTION
## What
Pin two unpinned behavioral contracts of `_extract_frame_ndarray` (the helper the in-loop video recorder uses to decode each `render()` frame into an ndarray), and correct its return-shape docstring to match the code.

## Why
`_extract_frame_ndarray` walks the `render()` content-block structure and must be fail-soft: a malformed frame should be skipped so the rollout keeps recording rather than crashing mid-run. Two paths were not covered:

1. **Non-dict entry in the `content` list.** The `isinstance(block, dict)` guard is the only thing standing between a stray `None`/string in a render response and an `AttributeError` on `block.get("image")`. If that guard ever regressed, a recording rollout would abort with an unhandled exception. Nothing pinned it.
2. **Return channel count.** The source is always run through `PIL.Image.convert("RGB")`, so the result is a fixed `(H, W, 3)` array regardless of the source PNG's channels. The MP4 writer (imageio) depends on a stable channel count. This was untested, and the docstring incorrectly advertised `(H, W, 3|4)`.

## Change
- Add `test_extract_frame_ndarray_skips_non_dict_blocks_and_recovers`: interleaves `None` and a bare string before the real image block and asserts the decodable frame is still returned. Verified this fails (`AttributeError`) if the `isinstance(block, dict)` guard is removed.
- Add `test_extract_frame_ndarray_always_returns_three_channels`: feeds an RGBA PNG source and asserts the output is `(H, W, 3)` uint8, pinning the alpha-drop contract.
- Correct the docstring: return is always contiguous `(H, W, 3)` RGB (alpha dropped by `convert("RGB")`); documents the `None` conditions.

No runtime behavior change — tests + docstring only.

## Test
```
MUJOCO_GL=egl python -m pytest tests/simulation/test_policy_runner.py -q
# 33 passed, 2 skipped
```
Lint gate green (CI scope): `ruff check`, `ruff format --check`, `mypy strands_robots tests tests_integ` all clean.