### PR TITLE
fix(sim): cap rollout video fps at control_frequency for real-time playback

### DIFF
--- a/.github/scripts/agent_api_snapshot.py
+++ b/.github/scripts/agent_api_snapshot.py
@@ -25,6 +25,7 @@ Modes:
 Backward-compatible additions (new actions, new parameters) are NOT breaking and
 are reported separately as informational.
 """
+
 from __future__ import annotations
 
 import inspect
@@ -85,10 +86,7 @@ def diff(old: dict[str, list[str]], new: dict[str, list[str]]) -> tuple[list[str
 
 def render_markdown(breaking: list[str], info: list[str]) -> str:
     if not breaking and not info:
-        return (
-            "## No AgentTool API Changes Detected\n\n"
-            + "No changes to the dispatched action contract in this PR."
-        )
+        return "## No AgentTool API Changes Detected\n\n" + "No changes to the dispatched action contract in this PR."
     lines: list[str] = []
     if breaking:
         # Built as a single explicit expression (not two adjacent literals in a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -442,6 +442,21 @@ policy types are still rejected.
   regression test pins that `rtc_async_enabled` can be `True` while
   `supports_rtc` is `False`.
 
+### Fixed: `run_policy`/`eval_policy` rollout video plays back at real time when `fps > control_frequency`
+
+- The MP4 recorder (`video=...`) renders at most one frame per applied control
+  step, so it cannot carry more than `control_frequency` unique frames per
+  second of sim time. When the requested `fps` exceeded `control_frequency` the
+  capture cadence still grabbed every step (it cannot up-sample) but the writer
+  used the requested `fps`, so the video played back FASTER than real time by
+  `fps / control_frequency` (e.g. a 110-step rollout at `control_frequency=15`
+  with the default `fps=30` produced a 3.7 s MP4 for 7.3 s of sim - a silent 2x
+  speed-up). The writer already down-samples to preserve real time when
+  `control_frequency >= fps`; the `fps > control_frequency` case was unhandled.
+  The writer fps is now capped at `control_frequency` (with a warning) so the
+  rollout always plays back at real time; the common default
+  (`control_frequency=50`, `fps=30`) is unchanged.
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -195,7 +195,10 @@ class VideoConfig:
             separators, shell metacharacters, or symlinked target) before a
             writer is opened; set ``STRANDS_ROBOTS_VIDEO_ROOT`` to confine it
             to a sandbox.
-        fps: Frames per second to write.
+        fps: Frames per second to write. Capped at ``control_frequency``
+            when it would exceed it, so the rollout always plays back at
+            real time (a rollout renders at most one frame per control
+            step and cannot be up-sampled).
         camera: Camera name to render from. ``None`` → backend default.
         width: Render width in pixels.
         height: Render height in pixels.
@@ -316,8 +319,30 @@ class _RolloutVideoWriter:
             purpose="video recording",
         )
         os.makedirs(os.path.dirname(os.path.abspath(resolved)), exist_ok=True)
+        # A rollout renders at most one frame per applied control step, so the
+        # video cannot carry more than ``control_frequency`` unique frames per
+        # second of sim time. When the requested ``fps`` exceeds
+        # ``control_frequency`` the capture cadence still grabs every step (it
+        # cannot up-sample), so writing the MP4 at the requested ``fps`` would
+        # play the rollout back FASTER than real time (by ``fps /
+        # control_frequency``). Cap the writer fps at ``control_frequency`` so
+        # the rollout always plays back at real time. When ``fps <=
+        # control_frequency`` the capture cadence down-samples and the video is
+        # already real time at the requested ``fps`` (unchanged).
+        write_fps = video.fps
+        if control_frequency > 0 and video.fps > control_frequency:
+            write_fps = max(1, round(control_frequency))
+            logger.warning(
+                "Video fps=%d exceeds control_frequency=%.1f Hz; a rollout can "
+                "render at most one frame per control step, so the MP4 is "
+                "written at %d fps to play back at real time (requesting a "
+                "higher fps would only speed the video up).",
+                video.fps,
+                control_frequency,
+                write_fps,
+            )
         writer = imageio.get_writer(  # type: ignore[attr-defined]
-            resolved, fps=video.fps, quality=8, macro_block_size=1
+            resolved, fps=write_fps, quality=8, macro_block_size=1
         )
         return cls(sim, video, writer, resolved, control_frequency), None
 

--- a/tests/simulation/test_rollout_video_realtime_fps.py
+++ b/tests/simulation/test_rollout_video_realtime_fps.py
@@ -1,0 +1,77 @@
+"""Rollout video plays back at real time regardless of control_frequency.
+
+A rollout renders at most one frame per applied control step, so the MP4 can
+carry at most ``control_frequency`` unique frames per second of sim time. If the
+writer used the requested ``fps`` when ``fps > control_frequency`` the video
+would play back FASTER than real time (by ``fps / control_frequency``) - a
+silent fidelity gap for a feature whose job is to faithfully show what the
+policy did. ``_RolloutVideoWriter.open`` must cap the writer fps at
+``control_frequency`` in that case, and leave it untouched when
+``fps <= control_frequency`` (the capture cadence already down-samples to real
+time there).
+"""
+
+from __future__ import annotations
+
+import types
+from typing import Any
+
+from strands_robots.simulation import policy_runner
+from strands_robots.simulation.policy_runner import VideoConfig, _RolloutVideoWriter
+
+
+class _FakeWriter:
+    def append_data(self, _frame: Any) -> None:  # pragma: no cover - unused here
+        pass
+
+    def close(self) -> None:  # pragma: no cover - unused here
+        pass
+
+
+class _FakeSim:
+    """Minimal sim whose render probe succeeds so open() reaches get_writer."""
+
+    def render(self, camera_name: str, width: int, height: int) -> dict[str, Any]:
+        return {"status": "success", "content": [{"text": "ok"}]}
+
+
+def _open_and_capture_fps(monkeypatch, tmp_path, requested_fps, control_frequency):
+    """Call _RolloutVideoWriter.open and return the fps handed to get_writer."""
+    captured: dict[str, Any] = {}
+
+    def _fake_get_writer(path: str, fps: int, **kwargs: Any) -> _FakeWriter:
+        captured["fps"] = fps
+        return _FakeWriter()
+
+    fake_imageio = types.SimpleNamespace(get_writer=_fake_get_writer)
+    monkeypatch.setattr(policy_runner, "require_optional", lambda *a, **k: fake_imageio)
+
+    video = VideoConfig(path=str(tmp_path / "out.mp4"), fps=requested_fps)
+    writer, err = _RolloutVideoWriter.open(_FakeSim(), video, control_frequency)
+    assert err is None, err
+    assert writer is not None
+    return captured["fps"]
+
+
+def test_video_fps_capped_to_control_frequency_when_lower(monkeypatch, tmp_path):
+    # cf < fps: requesting 30 fps at 15 Hz control would play back 2x too fast.
+    # The writer must be capped to 15 so the video is real time.
+    write_fps = _open_and_capture_fps(monkeypatch, tmp_path, requested_fps=30, control_frequency=15.0)
+    assert write_fps == 15
+
+
+def test_video_fps_capped_rounds_fractional_control_frequency(monkeypatch, tmp_path):
+    write_fps = _open_and_capture_fps(monkeypatch, tmp_path, requested_fps=30, control_frequency=12.4)
+    assert write_fps == 12
+
+
+def test_video_fps_unchanged_when_control_frequency_higher(monkeypatch, tmp_path):
+    # cf >= fps (the common default: cf=50, fps=30): the capture cadence
+    # down-samples, so the requested fps is already real time - leave it alone.
+    write_fps = _open_and_capture_fps(monkeypatch, tmp_path, requested_fps=30, control_frequency=50.0)
+    assert write_fps == 30
+
+
+def test_video_fps_unchanged_when_equal(monkeypatch, tmp_path):
+    write_fps = _open_and_capture_fps(monkeypatch, tmp_path, requested_fps=30, control_frequency=30.0)
+    assert write_fps == 30


### PR DESCRIPTION
## Problem

`run_policy(..., video=...)` (and `eval_policy`) records the rollout MP4 via `_RolloutVideoWriter`, which renders **at most one frame per applied control step**. It therefore cannot carry more than `control_frequency` unique frames per second of sim time.

The capture cadence (`_frame_interval = control_frequency / fps`) is designed to keep playback at real time: when `control_frequency >= fps` it down-samples (skips steps) so `fps` frames represent one sim-second. But the `fps > control_frequency` case was never handled. There the cadence grabs **every** step (it cannot up-sample), yet the writer still uses the requested `fps` — so the video plays back **faster than real time by `fps / control_frequency`**, silently.

Measured on a 110-step SO-101 rollout at `control_frequency=15` with the default `fps=30`:

| control_frequency | video duration | sim duration | playback |
|---|---|---|---|
| 15 | 3.67 s (110 fr @ 30 fps) | 7.33 s | **2.0x too fast** |
| 30 | 3.67 s | 3.67 s | real time |
| 60 | 1.87 s (56 fr @ 30 fps) | 1.83 s | real time |

The video's job is to faithfully show what the policy did; a silently 2x-sped-up clip misrepresents motion speed/smoothness and is easy to hit (a low-Hz policy recorded with the default `fps=30`).

## Fix

Cap the writer fps at `control_frequency` when `fps` would exceed it, with a `logger.warning`, so the rollout always plays back at real time. The frames captured are identical; only the MP4's declared fps changes in the `fps > control_frequency` case. The common default (`control_frequency=50`, `fps=30`) is unchanged — `control_frequency >= fps` still down-samples at the requested fps.

## Test

`tests/simulation/test_rollout_video_realtime_fps.py` pins the writer fps handed to `imageio.get_writer` (GL-free, CI-safe): capped to `control_frequency` when lower (incl. fractional rounding), unchanged when equal/higher. The two `fps > control_frequency` cases **fail before** the fix (writer gets 30 instead of 15/12) and pass after; the `fps <= control_frequency` cases pass both ways.

## Demo

Same 110-step rollout recorded at `control_frequency=15`. Left: before (30 fps requested → finishes in 3.7 s, 2x fast, then freezes). Right: after (capped to 15 fps → real-time 7.3 s).

![real-time video fix](https://github.com/cagataycali/robots/releases/download/isaac-artifacts/cf_video_realtime_fix_1783178022.gif)

Gate: `ruff` + `mypy` clean on the changed files; `tests/simulation/test_policy_runner_paths.py`, `test_eval_policy_video.py`, `test_video_camera_validation.py`, and the new test all pass (`MUJOCO_GL=egl`, 38 passed).