### PR TITLE
feat(sim): describe() advertises the physics-introspection / grounding surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -457,6 +457,23 @@ policy types are still rejected.
   rollout always plays back at real time; the common default
   (`control_frequency=50`, `fps=30`) is unchanged.
 
+### Added: `describe()` advertises the physics-introspection / grounding surface
+
+- `MuJoCoSimEngine.describe()` -- the single-call discovery surface an agent
+  reads first to learn the engine's contract -- taught how to build a scene, run
+  a policy, and record a dataset, but listed no way to READ the physics result.
+  An agent that ran a rollout could not discover how to verify it (read a body's
+  world pose, check gripper-object contact, query a sensor) without guessing
+  method names, even though `get_body_state`, `forward_kinematics`,
+  `get_contacts`, `get_contact_forces`, `get_sensor_data`, `get_energy`,
+  `get_mass_matrix`, `inverse_dynamics`, `get_jacobian`, `get_total_mass`,
+  `raycast`, and `multi_raycast` are all public methods the tool spec and action
+  dispatcher already dispatch. `describe()` now advertises this read/verify
+  surface alongside the act/record surface, so one call reveals how to ground a
+  claim on a body-state delta (the documented way to verify a rollout) rather
+  than on a rendered caption. The `start_recording` signature in `describe()`
+  also now names its `cameras=` dataset-scope parameter, which was omitted.
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1284,7 +1284,9 @@ class MuJoCoSimEngine(
         # instead of guessing method names.
         base["methods"]["start_recording"] = (
             "(repo_id='local/sim_recording', task='', fps=30, root=None, "
-            "push_to_hub=False, vcodec='h264', overwrite=False) -> dict"
+            "push_to_hub=False, vcodec='h264', overwrite=False, cameras=None) -> dict  "
+            "(cameras= scopes the recorded LeRobotDataset to a subset of the "
+            "scene's cameras; None records every camera)"
         )
         base["methods"]["save_episode"] = (
             "() -> dict  (flush current rollout as one episode; call once per "
@@ -1298,6 +1300,54 @@ class MuJoCoSimEngine(
             "(expected: int) -> dict  (after stop_recording, read the parquet "
             "and confirm the dataset holds exactly `expected` episodes; "
             "status=error on mismatch)"
+        )
+
+        # Physics-introspection / grounding surface. The discovery surface
+        # teaches how to build a scene, run a policy, and record a dataset, but
+        # previously gave no way to discover how to READ the physics result --
+        # so an agent that ran a rollout could not learn how to verify it (read
+        # a body's world pose, check whether the gripper is in contact, query a
+        # sensor) without guessing method names. These are public MuJoCo methods
+        # the tool spec + action dispatcher already expose; listing them here
+        # lets one describe() call reveal the read/verify surface alongside the
+        # act/record surface.
+        base["methods"]["get_body_state"] = (
+            "(body_name: str) -> dict  # world pose (xpos/xquat/xmat) + linear "
+            "and angular velocity of a body; ground grasp/lift/move claims on "
+            "this delta, not on a caption"
+        )
+        base["methods"]["forward_kinematics"] = (
+            "(body_name: str | None = None) -> dict  # world poses of every "
+            "body (or one) computed from the current qpos"
+        )
+        base["methods"]["get_contacts"] = (
+            "() -> dict  # active geom-geom contacts at the current step (verify a grasp / detect a collision)"
+        )
+        base["methods"]["get_contact_forces"] = "() -> dict  # per-contact normal + friction force magnitudes"
+        base["methods"]["get_sensor_data"] = (
+            "(sensor_name: str | None = None) -> dict  # MuJoCo sensor readouts "
+            "(jointpos/jointvel, accelerometer, gyro, force, torque, touch, "
+            "rangefinder, framequat, ...)"
+        )
+        base["methods"]["get_energy"] = "() -> dict  # kinetic + potential energy of the system"
+        base["methods"]["get_mass_matrix"] = "() -> dict  # joint-space inertia matrix M(q)"
+        base["methods"]["inverse_dynamics"] = (
+            "() -> dict  # gravity + Coriolis/bias compensation torques for the "
+            "current pose (mj_inverse at zero desired acceleration)"
+        )
+        base["methods"]["get_jacobian"] = (
+            "(body_name=None, site_name=None, geom_name=None) -> dict  # "
+            "translational + rotational Jacobian of a body/site/geom for IK/control"
+        )
+        base["methods"]["get_total_mass"] = "() -> dict  # total mass of the model"
+        base["methods"]["raycast"] = (
+            "(origin: list[float], direction: list[float], exclude_body=-1, "
+            "include_static=True) -> dict  # first geom hit along a world-frame "
+            "ray + hit distance"
+        )
+        base["methods"]["multi_raycast"] = (
+            "(origin: list[float], directions: list[list[float]], "
+            "exclude_body=-1) -> dict  # batch raycast from one origin (e.g. a lidar fan)"
         )
 
         if self._world is not None:

--- a/tests/simulation/test_sim_engine_describe_discovery.py
+++ b/tests/simulation/test_sim_engine_describe_discovery.py
@@ -294,6 +294,69 @@ class TestDescribeMuJoCo:
         finally:
             sim.destroy()
 
+    def test_describe_lists_physics_introspection_methods(self):
+        """describe() advertises the read/verify surface, not just act/record.
+
+        The discovery surface teaches how to build a scene, run a policy, and
+        record a dataset, but previously listed no way to READ the physics
+        result -- so an agent that ran a rollout could not learn how to verify
+        it (read a body's world pose, check gripper-object contact, query a
+        sensor) from one describe() call. These are public MuJoCo methods the
+        tool spec + action dispatcher already expose; grounding a claim on a
+        body-state delta (rather than a rendered caption) is the documented way
+        to verify a rollout, so the primitives that produce that delta belong on
+        the discovery surface alongside run_policy / start_recording.
+        """
+        import os
+
+        os.environ.setdefault("MUJOCO_GL", "egl")
+        from strands_robots.simulation import Simulation
+
+        sim = Simulation()
+        try:
+            methods = sim.describe()["methods"]
+            for name in (
+                "get_body_state",
+                "forward_kinematics",
+                "get_contacts",
+                "get_contact_forces",
+                "get_sensor_data",
+                "get_energy",
+                "get_mass_matrix",
+                "inverse_dynamics",
+                "get_jacobian",
+                "get_total_mass",
+                "raycast",
+                "multi_raycast",
+            ):
+                assert name in methods, f"describe() omits physics-introspection method {name!r}"
+            # Advertised signatures name the real distinguishing parameters so a
+            # caller can invoke them without reading the source.
+            assert "body_name" in methods["get_body_state"]
+            assert "sensor_name" in methods["get_sensor_data"]
+            assert "origin" in methods["raycast"]
+        finally:
+            sim.destroy()
+
+    def test_describe_start_recording_signature_includes_camera_scope(self):
+        """describe()'s start_recording signature names the cameras= scope.
+
+        start_recording grew a ``cameras=`` parameter that scopes the recorded
+        LeRobotDataset to a subset of the scene's cameras, but the advertised
+        signature omitted it -- so an agent enumerating describe() could not
+        learn how to record a camera-scoped dataset without reading the source.
+        """
+        import os
+
+        os.environ.setdefault("MUJOCO_GL", "egl")
+        from strands_robots.simulation import Simulation
+
+        sim = Simulation()
+        try:
+            assert "cameras" in sim.describe()["methods"]["start_recording"]
+        finally:
+            sim.destroy()
+
     def test_describe_methods_resolve_to_real_attributes(self):
         """Every method MuJoCo describe() advertises must be a real callable.
 


### PR DESCRIPTION
## Problem

`MuJoCoSimEngine.describe()` is the single-call discovery surface an agent reads first to learn the engine's contract without guessing method names. It already teaches how to **build** a scene (`add_robot`/`add_object`/`add_camera`), **run** a policy (`run_policy`/`eval_policy`/`replay_episode`), and **record** a dataset (`start_recording`/`save_episode`/`verify_dataset_episodes`) — but it listed **no way to READ the physics result**.

So an agent that ran a rollout could not discover *how to verify it* — read a body's world pose, check whether the gripper is in contact with an object, query a sensor — without reading the source and guessing names. The verify verbs are all public methods the tool spec and action dispatcher already expose:

```
describe()['methods'] listed: 26
dispatchable actions:       66
read/verify verbs missing from describe(): get_body_state, forward_kinematics,
  get_contacts, get_contact_forces, get_sensor_data, get_energy, get_mass_matrix,
  inverse_dynamics, get_jacobian, get_total_mass, raycast, multi_raycast
```

This is the same discovery-surface completeness gap already closed for the rollout family (`eval_policy`/`replay_episode`), the render family (`render_depth`/`render_all`), and scene construction (`add_camera`/`remove_camera`) in `test_sim_engine_describe_discovery.py` — the read/verify family was the remaining hole. Grounding a claim on a body-state delta (rather than a rendered caption) is the documented way to verify a rollout, so the primitives that produce that delta belong on the discovery surface alongside `run_policy`/`start_recording`.

Separately, `describe()`'s advertised `start_recording` signature was stale — it omitted the `cameras=` parameter that scopes a recorded `LeRobotDataset` to a subset of the scene's cameras.

## Change

- `MuJoCoSimEngine.describe()` now advertises the physics-introspection / grounding surface (`get_body_state`, `forward_kinematics`, `get_contacts`, `get_contact_forces`, `get_sensor_data`, `get_energy`, `get_mass_matrix`, `inverse_dynamics`, `get_jacobian`, `get_total_mass`, `raycast`, `multi_raycast`) with real parameter signatures, so one `describe()` call reveals the read/verify surface next to the act/record surface.
- Corrected the `start_recording` signature string in `describe()` to name its `cameras=` dataset-scope parameter.
- Purely additive metadata on the discovery dict — no runtime/behavior change to any method.

## Tests

- `test_describe_lists_physics_introspection_methods` — asserts describe() advertises the 12 read/verify verbs and that the signatures name real parameters (`body_name`, `sensor_name`, `origin`). **Fails before** (`describe() omits physics-introspection method 'get_body_state'`), passes after.
- `test_describe_start_recording_signature_includes_camera_scope` — asserts `cameras` appears in the advertised `start_recording` signature. **Fails before**, passes after.
- Covered by the existing `test_describe_methods_resolve_to_real_attributes` invariant (every advertised name must be a real callable on the engine).
- Green locally: `ruff check`/`ruff format` clean, `mypy` clean on the changed module, `tests/simulation/test_sim_engine_describe_discovery.py` (17) + `test_tool_spec.py` + `test_simulation.py` (162 total) all pass under `MUJOCO_GL=egl`.