### PR TITLE
test(hardware): pin Robot input-validation and get_status fail-soft contracts

### DIFF
--- a/tests/test_hardware_robot_lifecycle.py
+++ b/tests/test_hardware_robot_lifecycle.py
@@ -643,6 +643,45 @@ class TestStatusSurface:
         assert status["task_status"] == "idle"
         hw.cleanup()
 
+    def test_get_status_is_fail_soft_when_the_device_read_raises(self):
+        """A device read that raises must degrade to a structured error dict.
+
+        ``get_status`` is the operator's health probe; a raising serial/USB
+        backend must never propagate out of it and crash the caller. Instead
+        it reports ``task_status="error"`` with the failure text and a safe
+        ``is_connected=False``, so a supervising agent can react rather than
+        take an unhandled exception.
+        """
+
+        class _RaisingDevice:
+            name = "raising_arm"
+
+            @property
+            def is_connected(self) -> bool:
+                raise RuntimeError("serial bus fault")
+
+        hw = _make_robot()
+        hw.robot = _RaisingDevice()
+        status = asyncio.run(hw.get_status())
+        assert status["task_status"] == "error"
+        assert status["is_connected"] is False
+        assert status["robot_name"] == "test_arm"
+        assert "serial bus fault" in status["error"]
+        hw.cleanup()
+
+    def test_get_status_surfaces_task_error_message(self):
+        """A recorded task error is surfaced under ``task_error`` in the healthy
+        status dict, so an operator sees *why* the last run failed without a
+        separate call."""
+        fake = _FakeLeRobot(connected=True)
+        hw = _make_robot(fake)
+        hw._task_state.status = TaskStatus.ERROR
+        hw._task_state.error_message = "gripper stalled"
+        status = asyncio.run(hw.get_status())
+        assert status["task_status"] == "error"
+        assert status["task_error"] == "gripper stalled"
+        hw.cleanup()
+
     def test_tool_spec_advertises_actions(self):
         hw = _make_robot()
         spec = hw.tool_spec
@@ -651,6 +690,23 @@ class TestStatusSurface:
         assert set(enum) == {"execute", "start", "status", "stop"}
         assert hw.tool_type == "robot"
         assert hw.tool_name == "test_arm"
+        hw.cleanup()
+
+
+# ---------------------------------------------------------------------------
+# Robot construction: input validation
+# ---------------------------------------------------------------------------
+
+
+class TestInitializeRobotValidation:
+    def test_unsupported_robot_argument_is_rejected(self):
+        """``_initialize_robot`` accepts a lerobot Robot, a RobotConfig, or a
+        robot-type string; anything else is an operator mistake and must raise
+        rather than be silently coerced or ignored.
+        """
+        hw = _make_robot()
+        with pytest.raises(ValueError, match="Unsupported robot type"):
+            hw._initialize_robot(123, None)  # type: ignore[arg-type]
         hw.cleanup()
 
 

--- a/tests/test_hardware_ros_bridge.py
+++ b/tests/test_hardware_ros_bridge.py
@@ -551,3 +551,17 @@ def test_inert_safety_config_without_bridge_is_rejected(fake_ros: dict[str, Any]
     hw = _make_robot({"j0.pos": 0.0})
     with pytest.raises(ValueError, match="require ros2_bridge=True"):
         hw._init_ros_bridge(ros2_bridge=False, joint_limits={"j0.pos": (-1.0, 1.0)})
+
+
+def test_init_ros_bridge_rejects_unknown_transport(fake_ros: dict[str, Any]) -> None:
+    """``_init_ros_bridge`` guards the transport itself, not just ``__init__``.
+
+    ``__init__`` validates the transport up front via ``_check_ros2_bridge_deps``,
+    but ``_init_ros_bridge`` is a public plain method the test doubles (and any
+    future re-init path) call directly. It must reject an unknown transport with
+    the documented message before it tries to import a bridge backend, rather
+    than fail later with an opaque ImportError.
+    """
+    hw = _make_robot({"j0.pos": 0.0})
+    with pytest.raises(ValueError, match="must be 'rclpy' or 'rtps'"):
+        hw._init_ros_bridge(ros2_bridge=True, ros2_transport="zenoh")


### PR DESCRIPTION
## What

Adds behavior tests pinning four previously-untested contracts on the hardware `Robot` (`strands_robots/hardware_robot.py`), the driver that fronts a real lerobot arm. All are exercised through the existing lightweight `__new__` test doubles, so no serial/USB hardware is required.

- **`_initialize_robot` rejects an unsupported robot argument.** It accepts a lerobot `Robot`, a `RobotConfig`, or a robot-type string; anything else (e.g. an `int`) is an operator mistake and must raise `ValueError`, not be silently coerced or ignored.
- **`_init_ros_bridge` guards the transport itself.** `__init__` validates the transport up front via `_check_ros2_bridge_deps`, but `_init_ros_bridge` is a plain method callers invoke directly. An unknown transport must raise the documented `must be 'rclpy' or 'rtps'` error before any bridge backend import, rather than fail later with an opaque `ImportError`.
- **`get_status` is fail-soft.** It is the operator's health probe; a device read that raises must degrade to a structured error dict (`task_status="error"`, `is_connected=False`, plus the failure text) instead of propagating and crashing the caller.
- **`get_status` surfaces a recorded task error.** A prior task failure is reported under `task_error` in the healthy status dict, so the reason is visible without a second call.

## Why

These are the input-validation and fail-soft error surfaces an autonomous operator depends on. They were the untested branches on an otherwise well-covered module; pinning them prevents a regression from silently turning a loud validation error into a coerced value or an unhandled crash.

## Tests

Tests only; no source change. Added to `tests/test_hardware_robot_lifecycle.py` (init validation + `get_status` fail-soft / task-error) and `tests/test_hardware_ros_bridge.py` (transport guard). Coverage of `strands_robots/hardware_robot.py` rises 93% -> 94%.

```
ruff check strands_robots tests tests_integ    # All checks passed
ruff format --check ...                         # clean
mypy strands_robots tests tests_integ           # Success: no issues found in 667 source files
MUJOCO_GL=egl pytest tests/test_hardware_robot_lifecycle.py tests/test_hardware_ros_bridge.py   # 89 passed
```