### PR TITLE
fix(sim): grasped predicate matches LIBERO <body>_g<idx> geom convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -474,6 +474,19 @@ policy types are still rejected.
   than on a rendered caption. The `start_recording` signature in `describe()`
   also now names its `cameras=` dataset-scope parameter, which was omitted.
 
+### Fixed
+
+- The `grasped` benchmark/DSL predicate now matches the grasped body's geoms
+  across the `<body>_g<idx>` LIBERO/robosuite multi-geom convention, not only
+  the exact `body` / `<body>_geom` names. LIBERO objects (a BDDL object
+  `cube_1` owns collision geoms `cube_1_g0` / `cube_1_g1` ...) were never
+  matched, so `(grasped cube_1)` BDDL goals silently resolved to `False` even
+  when the gripper was in contact - a successful grasp was scored as a failure.
+  Body-geom matching now mirrors `_body_contact`'s `<body>_g` prefix so the two
+  contact predicates agree on what counts as a body's geom; strands-native
+  `add_object` (`<body>_geom`) and single-geom scenes are unchanged.
+
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/simulation/predicates.py
+++ b/strands_robots/simulation/predicates.py
@@ -463,13 +463,39 @@ def _body_upright(body: str, tol: float = 0.15) -> BoolPredicate:
     return check
 
 
+def _geom_belongs_to_body(geom: str, body: str) -> bool:
+    """True when geom name ``geom`` is one of ``body``'s geoms.
+
+    Handles the geom-naming conventions across the supported scene sources:
+
+    - exact ``body`` (single-geom scenes whose geom is named after the body),
+    - ``<body>_geom`` (strands :meth:`add_object`), and
+    - ``<body>_g<idx>`` (LIBERO / robosuite multi-geom objects).
+
+    The ``<body>_g`` prefix subsumes both ``<body>_geom`` and ``<body>_g<idx>``;
+    it mirrors the prefix :func:`_body_contact` uses so contact-based
+    predicates agree on what counts as a body's geom. The ``_g`` boundary
+    keeps distinct names apart (``cube_1_g`` does not match ``cube_10_g0``).
+    """
+    return geom == body or geom.startswith(f"{body}_g")
+
+
 def _grasped(body: str, gripper_prefix: str) -> BoolPredicate:
     """True when ``body`` is in contact with any geom whose name starts with ``gripper_prefix``.
 
     Treats the gripper as a *set* of geoms (fingers, pads, tip sites) so
     the caller only has to specify the common prefix - e.g. ``"robot0_gripper"``
     for Panda covers both fingers. A body is "grasped" as long as any one
-    gripper geom is in contact with any geom matching the body name.
+    gripper geom is in contact with any geom belonging to ``body``.
+
+    Body-geom matching follows the same naming conventions as
+    :func:`_body_contact`, so ``grasped`` fires on real LIBERO/robosuite
+    scenes (where a BDDL object ``cube_1`` owns collision geoms
+    ``cube_1_g0`` / ``cube_1_g1`` ...) as well as on strands-native
+    ``add_object`` scenes (``<body>_geom``) and single-geom scenes whose
+    geom is named exactly after the body. Previously only the exact
+    ``body`` / ``<body>_geom`` names matched, so ``(grasped cube_1)`` BDDL
+    goals silently never fired on LIBERO scenes.
 
     Backends must implement ``get_contacts()`` returning the MuJoCo
     ``{"contacts": [{"geom1", "geom2", ...}]}`` shape. Other backends are
@@ -494,9 +520,15 @@ def _grasped(body: str, gripper_prefix: str) -> BoolPredicate:
                 continue
             g1 = c.get("geom1") or ""
             g2 = c.get("geom2") or ""
-            # One side must be the grasped body (bare name or "_geom" suffix);
-            # the other must start with the gripper prefix.
-            body_match = {g1, g2} & {body, f"{body}_geom"}
+            # One side must be a geom of the grasped body; the other must
+            # start with the gripper prefix. Match the body's geoms across
+            # the naming conventions in play: an exact ``body`` name, the
+            # strands ``add_object`` ``<body>_geom`` name, and the
+            # LIBERO/robosuite ``<body>_g<idx>`` multi-geom convention
+            # (``<body>_geom`` is itself covered by the ``<body>_g`` prefix).
+            # This mirrors :func:`_body_contact`'s prefix matching so a
+            # LIBERO ``(grasped cube_1)`` goal fires on ``cube_1_g0`` etc.
+            body_match = _geom_belongs_to_body(g1, body) or _geom_belongs_to_body(g2, body)
             gripper_match = any(isinstance(g, str) and g.startswith(gripper_prefix) for g in (g1, g2))
             if body_match and gripper_match:
                 return True

--- a/tests/simulation/test_benchmark_predicates.py
+++ b/tests/simulation/test_benchmark_predicates.py
@@ -455,6 +455,47 @@ class TestGrasped:
         pred = make_predicate("grasped", body="cube", gripper_prefix="robot0_gripper")
         assert pred(sim) is False
 
+    def test_detects_libero_multi_geom_object(self):
+        # LIBERO / robosuite name a BDDL object ``cube_1``'s collision
+        # geoms ``cube_1_g0`` / ``cube_1_g1`` ... (the same ``<body>_g<idx>``
+        # convention _body_contact matches). ``(grasped cube_1)`` must fire
+        # when a gripper geom touches such a geom - previously it silently
+        # returned False because only exact ``cube_1`` / ``cube_1_geom``
+        # names were matched.
+        sim = _ContactSim(
+            [
+                {"geom1": "robot0_gripper_finger_l", "geom2": "cube_1_g0"},
+            ]
+        )
+        pred = make_predicate("grasped", body="cube_1", gripper_prefix="robot0_gripper")
+        assert pred(sim) is True
+
+    def test_detects_libero_multi_geom_object_higher_index(self):
+        sim = _ContactSim(
+            [
+                {"geom1": "cube_1_g3", "geom2": "robot0_gripper_finger_r"},
+            ]
+        )
+        pred = make_predicate("grasped", body="cube_1", gripper_prefix="robot0_gripper")
+        assert pred(sim) is True
+
+    def test_detects_bare_body_geom_name(self):
+        # A single-geom scene whose geom is named exactly after the body.
+        sim = _ContactSim([{"geom1": "cube", "geom2": "robot0_gripper_pad"}])
+        pred = make_predicate("grasped", body="cube", gripper_prefix="robot0_gripper")
+        assert pred(sim) is True
+
+    def test_prefix_does_not_bleed_across_distinct_bodies(self):
+        # ``cube_1`` must not match ``cube_10``'s geoms - the ``_g`` boundary
+        # keeps distinct names apart.
+        sim = _ContactSim(
+            [
+                {"geom1": "robot0_gripper_finger_l", "geom2": "cube_10_g0"},
+            ]
+        )
+        pred = make_predicate("grasped", body="cube_1", gripper_prefix="robot0_gripper")
+        assert pred(sim) is False
+
 
 # Degradation / defensive contract
 #


### PR DESCRIPTION
## Problem

The `grasped` benchmark/DSL predicate (`strands_robots/simulation/predicates.py`) decided which geoms belong to the grasped body with an **exact set membership** test:

```python
body_match = {g1, g2} & {body, f"{body}_geom"}
```

That only matches a geom named exactly `body` or `<body>_geom` (the strands `add_object` convention). It **misses the `<body>_g<idx>` multi-geom convention that LIBERO / robosuite objects use** — a BDDL object `cube_1` owns collision geoms `cube_1_g0`, `cube_1_g1`, ... (this is the very convention the sibling `_body_contact` predicate matches via a `<body>_g` prefix, and `_body_position` already handles the related `<name>_main` root-body convention).

The BDDL parser maps `(grasped cube_1)` straight onto `_grasped(body="cube_1", gripper_prefix="robot0_gripper")`, with no geom-name transformation. So on real LIBERO scenes `grasped` silently returned `False` even while the gripper was in contact with the object — a **successful grasp was scored as a failure**, and any `(grasped X)` BDDL goal could never be satisfied. Because the predicate returns a well-formed `False` (no error), the mis-scoring was silent.

## Fix

Match the grasped body's geoms with a small shared helper `_geom_belongs_to_body(geom, body)` that mirrors `_body_contact`'s prefix rule, so the two contact predicates agree on what counts as a body's geom:

```python
geom == body or geom.startswith(f"{body}_g")
```

This covers:
- exact `body` (single-geom scenes),
- `<body>_geom` (strands `add_object`; subsumed by the `<body>_g` prefix), and
- `<body>_g<idx>` (LIBERO / robosuite multi-geom objects) — the previously-missed case.

The `_g` boundary keeps distinct names apart (`cube_1_g` does not match `cube_10_g0`). `_body_contact` is intentionally left untouched (it already handles the LIBERO convention and its byte-for-byte On() semantics are pinned).

## Tests

Added to `TestGrasped` in `tests/simulation/test_benchmark_predicates.py` (contact records in the real `get_contacts()` shape):
- `test_detects_libero_multi_geom_object` / `_higher_index` — gripper contact on `cube_1_g0` / `cube_1_g3` now registers a grasp. **Both fail before the fix** (`assert False is True`) and pass after.
- `test_detects_bare_body_geom_name` — exact-body-name geom still matches.
- `test_prefix_does_not_bleed_across_distinct_bodies` — `cube_1` does not match `cube_10_g0`.

All existing grasped tests (`cube_geom`) and the full predicate / DSL / staged-reward / LIBERO suites remain green (202 predicate+DSL+staged, 389 LIBERO). `ruff`, `ruff format`, and `mypy` are clean on the changed module.

## Notes

`add_object`-based scenes and single-geom scenes are unchanged; only the LIBERO/robosuite multi-geom case flips from a false negative to a correct detection.