### PR TITLE
docs(datasets): make dataset IO docstrings self-contained

### DIFF
--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -1,7 +1,8 @@
 """LeRobotDataset recorder bridge for strands-robots.
 
-Wraps LeRobotDataset so that both robot.py (real hardware) and
-simulation.py (MuJoCo) can produce training-ready datasets with
+Wraps LeRobotDataset so that both real hardware (:mod:`strands_robots.robot`)
+and simulation (:mod:`strands_robots.simulation`) can produce training-ready
+datasets with
 a single add_frame() call per control step.
 
 Usage:
@@ -186,7 +187,8 @@ class DatasetRecorder:
     3. save_episode() - finalize episode (encodes video, writes parquet)
     4. push_to_hub() - upload to HuggingFace
 
-    Works for both real hardware (robot.py) and simulation (simulation.py).
+    Works for both real hardware (:mod:`strands_robots.robot`) and
+    simulation (:mod:`strands_robots.simulation`).
     """
 
     def __init__(
@@ -871,9 +873,8 @@ class DatasetRecorder:
         path is agent-reachable via ``stop_recording(bucket=, run_id=)``. A
         rejected value returns ``{"status": "error", ...}`` without running ``hf``.
 
-        See reports/STREAMING_DATA_LOOP_DEEP_DIVE.md Appendix A.1 (shard layout
-        is already Xet/bucket-friendly at the 100 MB default) and F.2 (meta/
-        MUST ship or downstream loses normalization stats).
+        The shard layout is already Xet/bucket-friendly at the 100 MB default,
+        and ``meta/`` MUST ship or downstream loses normalization stats.
         """
         import shutil
         import subprocess
@@ -893,7 +894,7 @@ class DatasetRecorder:
             }
 
         local_root = str(self.dataset.root)
-        # meta/ must ship or downstream loses normalization stats (App. F.2).
+        # meta/ must ship or downstream loses normalization stats.
         if not (Path(local_root) / "meta").exists():
             return {
                 "status": "error",

--- a/strands_robots/simulation/recording.py
+++ b/strands_robots/simulation/recording.py
@@ -171,7 +171,7 @@ class DatasetRecordingMixin:
             bucket: If set (e.g. ``"my-org/robot-fave"``), sync the dataset into
                 a mutable HF Storage Bucket instead of/in addition to the dataset
                 repo - the Phase 1/2 collection target (Xet-deduped, overwrite in
-                place). See reports/STREAMING_DATA_LOOP_DEEP_DIVE.md §2.4 / App. A.
+                place).
             run_id: Optional subpath inside the bucket (defaults to dataset name).
         """
         if self._world is None or not self._world._backend_state.get("recording", False):
@@ -246,7 +246,7 @@ class DatasetRecordingMixin:
         root = recorder.root
 
         # Finalize FIRST so meta/ (stats/info) is written before any bucket sync
-        # - streaming/training downstream needs it (App. F.2).
+        # - streaming/training downstream needs it.
         recorder.finalize()
 
         # #708 - parquet-truth gate. The recorder's ``episode_count`` is the
@@ -445,7 +445,7 @@ class DatasetRecordingMixin:
         READS one back lazily for eval / replay / inspection (Phase 3 of the
         physical-AI data loop). Training scripts can instead use
         ``python -m lerobot.scripts.train dataset.streaming=true`` which uses
-        the same underlying StreamingLeRobotDataset (deep-dive Appendix D).
+        the same underlying StreamingLeRobotDataset.
 
         Args:
             repo_id: HF dataset id (e.g. ``"lerobot/svla_so100_pickplace"``) or

--- a/strands_robots/streaming_dataset.py
+++ b/strands_robots/streaming_dataset.py
@@ -4,12 +4,11 @@
 Primary use: in-process eval / replay / notebooks / agent loops (NOT a
 precondition for streamed *training* - ``python -m lerobot.scripts.train
 dataset.streaming=true`` already uses StreamingLeRobotDataset via
-``lerobot.datasets.factory.make_dataset``; see
-reports/STREAMING_DATA_LOOP_DEEP_DIVE.md Appendix D).
+``lerobot.datasets.factory.make_dataset``).
 
-Design mirrors ``dataset_recorder.py``:
+Design mirrors :mod:`strands_robots.dataset_recorder`:
   * lerobot is NEVER imported at module top-level (numpy/pandas ABI safety on
-    Jetson; see dataset_recorder.py header).
+    Jetson; see the :mod:`strands_robots.dataset_recorder` header).
   * Constructor kwargs are forwarded via ``inspect.signature`` introspection so
     a lerobot version bump can't break us (lerobot's dataset API drifted across
     0.5.0->0.5.2; streaming is newer and still changing - upstream has a
@@ -72,7 +71,7 @@ def _get_streaming_cls() -> Any:
             f"StreamingLeRobotDataset unavailable ({exc}). "
             "Install with: pip install 'strands-robots[lerobot]' "
             "(needs torchcodec for video keys; on aarch64/Jetson that means "
-            "torch>=2.11 + torchcodec>=0.11 - see deep-dive Appendix C). "
+            "torch>=2.11 + torchcodec>=0.11). "
             "For proprio-only streaming without torchcodec, use drop_videos=True."
         ) from exc
 
@@ -111,7 +110,7 @@ class StreamingDatasetReader:
         seed: int = 42,
         shuffle: bool = True,
         return_uint8: bool = True,  # halves frame bandwidth; policies normalize
-        validate_deltas: bool = True,  # parity with materialized path (App. A.2)
+        validate_deltas: bool = True,  # parity with the materialized dataset path
         drop_videos: bool = False,  # proprio-only streaming (no torchcodec)
     ) -> StreamingDatasetReader:
         StreamingCls = _get_streaming_cls()
@@ -121,7 +120,7 @@ class StreamingDatasetReader:
 
         # Proprio-only: strip video keys from delta_timestamps so video decode
         # (torchcodec) is never invoked - lets constrained edge devices stream
-        # state/action without a torchcodec wheel (App. C.2).
+        # state/action without a torchcodec wheel.
         if drop_videos and delta_timestamps:
             delta_timestamps = {
                 k: v for k, v in delta_timestamps.items() if not k.startswith("observation.images.")
@@ -157,8 +156,8 @@ class StreamingDatasetReader:
         )
         ds = StreamingCls(**kwargs)
 
-        # Tolerance grid-check - the streaming path skips check_delta_timestamps
-        # (App. A.2); replicate it for parity with the materialized dataset.
+        # Tolerance grid-check - the streaming path skips check_delta_timestamps;
+        # replicate it for parity with the materialized dataset.
         if delta_timestamps and validate_deltas:
             try:
                 from lerobot.datasets.feature_utils import check_delta_timestamps
@@ -176,12 +175,12 @@ class StreamingDatasetReader:
         IterableDataset that shuffles INTERNALLY (reservoir buffer). Do NOT pass
         shuffle=True here. With num_workers>0, video decode parallelizes across
         worker processes - the documented mitigation for the single-thread
-        bottleneck (streaming_dataset.py ~L312 TODO). Never decode video in the
-        main process while workers>0 (segfault - _query_videos docstring).
+        decode bottleneck. Never decode video in the main process while
+        num_workers>0 (a known lerobot segfault).
 
-        Note: lerobot's make_dataset couples max_num_shards = num_workers
-        (factory.py). If you need that coupling, pass the same N to
-        open(max_num_shards=N) and here num_workers=N.
+        Note: lerobot's ``make_dataset`` (``lerobot.datasets.factory``) couples
+        max_num_shards = num_workers. If you need that coupling, pass the same N
+        to open(max_num_shards=N) and here num_workers=N.
         """
         import torch
 

--- a/tests/test_docstrings_no_dangling_doc_refs.py
+++ b/tests/test_docstrings_no_dangling_doc_refs.py
@@ -1,0 +1,58 @@
+"""Guard: published ``strands_robots`` source must be self-contained.
+
+Docstrings and comments in the shipped package must not point readers at
+documents that are not part of the repository, nor at line-number
+self-references that rot the moment a file is edited.
+
+Two dangling-reference classes are pinned here:
+
+1. References to an internal design memo
+   (``reports/STREAMING_DATA_LOOP_DEEP_DIVE.md``) that is not shipped in the
+   distribution - every such pointer is a dead end for a reader.
+2. ``~L<line>`` self-references, which silently drift out of date as soon as
+   the surrounding file changes.
+
+Both fail loudly here so they cannot creep back into the package.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import strands_robots
+
+_PKG_ROOT = Path(strands_robots.__file__).resolve().parent
+
+# The unpublished internal memo earlier docstrings pointed at.
+_UNPUBLISHED_MEMO = "STREAMING_DATA_LOOP_DEEP_DIVE"
+# "~L1234"-style pointers into a file break the instant lines shift.
+_ROTTING_LINE_REF = re.compile(r"~L\d+")
+
+
+def _package_sources() -> list[Path]:
+    return sorted(_PKG_ROOT.rglob("*.py"))
+
+
+def test_no_reference_to_unpublished_deep_dive_memo() -> None:
+    offenders = [
+        str(path.relative_to(_PKG_ROOT))
+        for path in _package_sources()
+        if _UNPUBLISHED_MEMO in path.read_text(encoding="utf-8")
+    ]
+    assert not offenders, (
+        f"source references the unpublished '{_UNPUBLISHED_MEMO}' memo: {offenders}. "
+        "Inline the rationale instead of pointing at a doc that is not shipped."
+    )
+
+
+def test_no_rotting_line_number_self_references() -> None:
+    offenders = [
+        str(path.relative_to(_PKG_ROOT))
+        for path in _package_sources()
+        if _ROTTING_LINE_REF.search(path.read_text(encoding="utf-8"))
+    ]
+    assert not offenders, (
+        f"source uses rotting '~L<line>' self-references: {offenders}. "
+        "Describe the location by symbol or behavior, not a line number."
+    )


### PR DESCRIPTION
## Problem

The dataset IO docstrings and comments repeatedly pointed readers at an internal design memo, `reports/STREAMING_DATA_LOOP_DEEP_DIVE.md`, which is not shipped in the repository. Every `see Appendix X` / `App. Y.Z` / `deep-dive Appendix D` pointer was therefore a dead end for anyone reading the code. In addition:

- `StreamingDatasetReader.dataloader()` carried a rotted `streaming_dataset.py ~L312` self-reference (the module is only ~230 lines, so the pointer is already wrong and drifts with every edit).
- Several docstrings referenced filenames (`robot.py`, `simulation.py`, `dataset_recorder.py`) instead of module paths.

## Change

Docs/comments only, no behavior change:

- Drop the dangling references to the unpublished memo across `strands_robots/streaming_dataset.py`, `strands_robots/dataset_recorder.py`, and `strands_robots/simulation/recording.py`, inlining the load-bearing rationale where a pointer was doing real explanatory work (shard layout is Xet/bucket-friendly at the 100 MB default; `meta/` must ship or downstream loses normalization stats; streaming skips `check_delta_timestamps` so it is replicated for parity; the single-thread decode bottleneck is mitigated by `num_workers>0`).
- Remove the rotted `~L312` self-reference and describe the behavior directly.
- Switch filename mentions to module paths (`strands_robots.robot` / `.simulation` / `.dataset_recorder`).

## Test

Adds `tests/test_docstrings_no_dangling_doc_refs.py`, a hygiene guard over the shipped `strands_robots` package that fails if any source references the unpublished memo or uses a `~L<line>` self-reference. It fails on the pre-change tree (offenders: `dataset_recorder.py`, `simulation/recording.py`, `streaming_dataset.py`; and `streaming_dataset.py` for the line ref) and passes after.

Local gate: `ruff check` + `ruff format --check` clean; `mypy strands_robots tests tests_integ` reports no issues; the new guard and the surrounding dataset/recording suites pass (the two `test_recording_paths.py` failures present are a pre-existing torchcodec/`libc10_cuda.so` environment issue on this host, identical on `main`, unrelated to this change).