### PR TITLE
fix(tools): session status dropped telemetry via **spread top-level keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: session `status` tool results dropped their telemetry via a `**spread` top-level smuggle
+
+The `status` action of `lerobot_teleoperate` and `lerobot_train` returned the
+session telemetry (`session_name`, `pid`, `uptime`, `is_running`, and every
+key of the persisted `session_info`) as *extra top-level keys* on the result
+dict via `**session_info`. Per the tool-result contract only `status` and
+`content` survive into the agent turn, so an agent that asked for session
+status received only the human-readable text block -- the structured fields
+it needs to decide whether a session is healthy were silently dropped by the
+runtime. The telemetry now rides in a `{"json": {...}}` content block. The
+static contract guard missed this because a `**spread` key made it skip the
+whole dict; it now flags any `**spread` inside a tool-result-shaped dict as a
+violation, closing the smuggling loophole.
+
 ### Fixed: `get_energy` reported the energy of a stale pose after a direct `qpos`/`qvel` write
 
 `get_energy` called `mj_energyPos` / `mj_energyVel` on whatever derived state

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -75,6 +75,9 @@ return {
 
 `tests/test_tool_result_contract.py` statically scans every tool-result-shaped
 dict literal in the package and fails if any carries an extra top-level key, so
-the contract cannot regress silently. The `assert_strands_tool_result` helper in
+the contract cannot regress silently. A `**spread` inside a tool-result dict is
+flagged too: it can inject arbitrary top-level keys the runtime drops, so it is
+never valid at the top level (spread the telemetry into a `{"json": {...}}`
+content block instead). The `assert_strands_tool_result` helper in
 `tests/tool_result_contract.py` validates a live result and can be applied in any
 test that exercises a tool method.

--- a/strands_robots/tools/lerobot_teleoperate.py
+++ b/strands_robots/tools/lerobot_teleoperate.py
@@ -826,12 +826,18 @@ def lerobot_teleoperate(
 
             return {
                 "status": "success",
-                "content": [{"text": "\n".join(content_lines)}],
-                "session_name": session_name,
-                "pid": pid,
-                "uptime": uptime,
-                "is_running": is_running,
-                **session_info,
+                "content": [
+                    {"text": "\n".join(content_lines)},
+                    {
+                        "json": {
+                            **session_info,
+                            "session_name": session_name,
+                            "pid": pid,
+                            "uptime": uptime,
+                            "is_running": is_running,
+                        }
+                    },
+                ],
             }
 
         elif action == "replay":

--- a/strands_robots/tools/lerobot_train.py
+++ b/strands_robots/tools/lerobot_train.py
@@ -570,12 +570,18 @@ def lerobot_train(
                     lines.append(f"Error reading log: {e}")
             return {
                 "status": "success",
-                "content": [{"text": "\n".join(lines)}],
-                "session_name": session_name,
-                "pid": pid,
-                "uptime": uptime,
-                "is_running": is_running,
-                **session_info,
+                "content": [
+                    {"text": "\n".join(lines)},
+                    {
+                        "json": {
+                            **session_info,
+                            "session_name": session_name,
+                            "pid": pid,
+                            "uptime": uptime,
+                            "is_running": is_running,
+                        }
+                    },
+                ],
             }
 
         else:

--- a/tests/test_tool_result_contract.py
+++ b/tests/test_tool_result_contract.py
@@ -7,7 +7,10 @@ extras are dropped by the agent runtime and never reach ``agent.messages``.
 
 The repo-wide ``test_no_extra_top_level_keys`` test is the standing guard: it
 statically scans every tool-result-shaped dict literal in the package and
-fails if any carries extra top-level keys. The remaining tests apply
+fails if any carries extra top-level keys. A ``**spread`` inside such a dict is
+itself a violation: it can inject arbitrary top-level keys that the runtime
+drops, and it previously let smuggled telemetry slip past the scan. The
+remaining tests apply
 ``assert_strands_tool_result`` to live results from representative call sites
 (teleop stats, simulation policy rollout, action dispatch).
 """
@@ -25,17 +28,27 @@ from strands_robots.teleop_mixin import TeleopMixin
 from tests.tool_result_contract import (
     VALID_TOP_LEVEL_KEYS,
     assert_strands_tool_result,
+    tool_json,
 )
 
 _PKG_ROOT = Path(strands_robots.__file__).resolve().parent
 
 
 def _tool_result_violations() -> list[str]:
-    """Statically find tool-result dict literals with extra top-level keys.
+    """Statically find tool-result dict literals that break the top-level contract.
 
     A dict literal counts as tool-result-shaped when it has constant string
-    keys including both ``status`` and ``content``. Any key outside
-    ``{"status", "content", "toolUseId"}`` is a contract violation.
+    keys including both ``status`` and ``content``. Such a dict violates the
+    contract when it carries either:
+
+    * an extra constant key outside ``{"status", "content", "toolUseId"}``, or
+    * a ``**spread`` entry -- a spread can inject arbitrary top-level keys that
+      the runtime silently drops, so it is never valid at the top level of a
+      tool result (telemetry belongs inside a ``content`` json block instead).
+
+    The spread case is the subtle one: a spread key appears in
+    ``ast.Dict.keys`` as ``None``, so a naive "all keys are constant strings"
+    filter skips the whole dict and lets the smuggled keys through.
     """
     violations: list[str] = []
     for path in _PKG_ROOT.rglob("*.py"):
@@ -43,15 +56,18 @@ def _tool_result_violations() -> list[str]:
         for node in ast.walk(tree):
             if not isinstance(node, ast.Dict):
                 continue
-            keys = [k.value for k in node.keys if isinstance(k, ast.Constant) and isinstance(k.value, str)]
-            if len(keys) != len(node.keys):  # non-constant / **spread keys present
+            const_keys = {k.value for k in node.keys if isinstance(k, ast.Constant) and isinstance(k.value, str)}
+            if not ({"status", "content"} <= const_keys):
                 continue
-            ks = set(keys)
-            if {"status", "content"} <= ks:
-                extra = ks - set(VALID_TOP_LEVEL_KEYS)
-                if extra:
-                    rel = path.relative_to(_PKG_ROOT.parent)
-                    violations.append(f"{rel}:{node.lineno} extra_keys={sorted(extra)}")
+            problems: list[str] = []
+            extra = const_keys - set(VALID_TOP_LEVEL_KEYS)
+            if extra:
+                problems.append(f"extra_keys={sorted(extra)}")
+            if any(k is None for k in node.keys):  # a **spread entry
+                problems.append("**spread (may inject dropped top-level keys)")
+            if problems:
+                rel = path.relative_to(_PKG_ROOT.parent)
+                violations.append(f"{rel}:{node.lineno} " + " ".join(problems))
     return violations
 
 
@@ -144,3 +160,56 @@ def test_dispatch_action_results_contract(sim):
         ("get_gravity", {}),
     ]:
         assert_strands_tool_result(sim._dispatch_action(action, params))
+
+
+# ---------------------------------------------------------------------------
+# Regression: session "status" tool results must keep telemetry inside a json
+# content block, not as extra top-level keys. These used to smuggle
+# ``session_name/pid/uptime/is_running`` (plus ``**session_info``) at the top
+# level via a ``**spread``, which the static scan skipped and the runtime
+# dropped -- so the agent asked for session status and saw only the text block.
+# ---------------------------------------------------------------------------
+
+
+def test_teleoperate_status_keeps_telemetry_in_json_block(tmp_path, monkeypatch):
+    import os
+
+    import strands_robots.tools.lerobot_teleoperate as tele_mod
+
+    pid = os.getpid()  # a real, running pid so the session is not pruned as dead
+    monkeypatch.setattr(tele_mod, "SESSION_DIR", tmp_path)
+    tele_mod.SessionManager().add_session(
+        "live",
+        {"pid": pid, "action": "record", "start_time": 0.0, "robot_type": "so101_follower"},
+    )
+
+    result = tele_mod.lerobot_teleoperate(action="status", session_name="live")
+
+    assert_strands_tool_result(result)
+    telemetry = tool_json(result)
+    assert telemetry["session_name"] == "live"
+    assert telemetry["pid"] == pid
+    assert telemetry["is_running"] is True
+    assert "uptime" in telemetry
+
+
+def test_train_status_keeps_telemetry_in_json_block(tmp_path, monkeypatch):
+    import os
+
+    import strands_robots.tools.lerobot_train as train_mod
+
+    pid = os.getpid()  # a real, running pid so the session is not pruned as dead
+    monkeypatch.setattr(train_mod, "SESSION_DIR", tmp_path)
+    train_mod.SessionManager().add_session(
+        "live",
+        {"pid": pid, "action": "train", "start_time": 0.0, "policy_type": "act"},
+    )
+
+    result = train_mod.lerobot_train(action="status", dataset_root="/x", session_name="live")
+
+    assert_strands_tool_result(result)
+    telemetry = tool_json(result)
+    assert telemetry["session_name"] == "live"
+    assert telemetry["pid"] == pid
+    assert telemetry["is_running"] is True
+    assert "uptime" in telemetry

--- a/tests/tools/test_lerobot_teleoperate.py
+++ b/tests/tools/test_lerobot_teleoperate.py
@@ -433,7 +433,7 @@ def test_status_running_session_is_ascii(monkeypatch: pytest.MonkeyPatch) -> Non
     mgr.add_session("live", {"pid": os.getpid(), "action": "record", "start_time": 0.0, "robot_type": "so101_follower"})
     result = lerobot_teleoperate(action="status", session_name="live")
     assert result["status"] == "success"
-    assert result["is_running"]
+    assert tool_json(result)["is_running"]
     _assert_ascii(_texts(result))
 
 

--- a/tests/tools/test_lerobot_train.py
+++ b/tests/tools/test_lerobot_train.py
@@ -299,8 +299,8 @@ def test_session_lifecycle_round_trips(tmp_path: Path, monkeypatch: pytest.Monke
 
     status = lerobot_train(action="status", dataset_root=str(root), session_name="t1")
     assert status["status"] == "success"
-    assert status["is_running"] is True
-    assert status["pid"] == 9999
+    assert tool_json(status)["is_running"] is True
+    assert tool_json(status)["pid"] == 9999
     _assert_ascii(_texts(status))
 
     # Stop: capture the kill calls instead of touching a real process.
@@ -493,7 +493,7 @@ def test_status_reports_log_tail(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     monkeypatch.setattr(train_mod.psutil, "Process", _RunningProcess)
     result = lerobot_train(action="status", dataset_root="/x", session_name="live")
     assert result["status"] == "success"
-    assert result["is_running"] is True
+    assert tool_json(result)["is_running"] is True
     assert "loss 0.01" in _texts(result)
     assert "Recent Log Output" in _texts(result)
 


### PR DESCRIPTION
## Problem

The `status` action of `lerobot_teleoperate` and `lerobot_train` returned session telemetry as **extra top-level keys** on the result dict:

```python
return {
    "status": "success",
    "content": [{"text": "\n".join(content_lines)}],
    "session_name": session_name,
    "pid": pid,
    "uptime": uptime,
    "is_running": is_running,
    **session_info,
}
```

The Strands tool-result contract (`docs/contracts.md`) carries only `status` and `content` into the agent turn; anything else is silently dropped by the runtime. So an agent that asked for a teleop/train session's status received only the human-readable text block and **none** of the structured fields (`is_running`, `pid`, `uptime`, ...) it needs to reason about session health.

The standing static guard `test_no_extra_top_level_keys` missed this: a `**spread` key appears as `None` in `ast.Dict.keys`, so the guard's `len(constant_keys) != len(node.keys)` filter treated the dict as "has non-constant keys" and **skipped it entirely** -- the exact dicts smuggling extra keys were the ones the scan bailed on.

## Change

- Move the telemetry into a `{"json": {...}}` content block on both tools, so the two-key contract holds and the fields actually reach the agent.
- Strengthen the static guard: a tool-result-shaped dict (constant `status` + `content` keys) is now flagged if it carries an extra constant key **or** a `**spread` entry. The spread can inject arbitrary dropped top-level keys, so it is never valid at the top level of a tool result.
- Update `docs/contracts.md` Enforcement section to document the spread rule.

No behavior change beyond where the telemetry rides; `status`/text output is unchanged.

## Test

- Strengthened `test_no_extra_top_level_keys` fails on the pre-change tree with both offenders reported:

```
strands_robots/tools/lerobot_train.py:571 extra_keys=['is_running','pid','session_name','uptime'] **spread (may inject dropped top-level keys)
strands_robots/tools/lerobot_teleoperate.py:827 extra_keys=['is_running','pid','session_name','uptime'] **spread (may inject dropped top-level keys)
```

- Added live regression tests `test_teleoperate_status_keeps_telemetry_in_json_block` / `test_train_status_keeps_telemetry_in_json_block`: assert the status result conforms to `assert_strands_tool_result` and that `session_name`/`pid`/`uptime`/`is_running` are readable via the `json` content block.
- Updated the existing status tests to read telemetry through `tool_json(...)` (they previously asserted on the dropped top-level keys).

Local gate: `ruff check` + `ruff format --check` clean; `mypy strands_robots tests tests_integ` reports no issues; the contract, teleoperate, train, changelog-format, and source-string guard suites pass (103 passed).