### PR TITLE
test(mesh): pin ACL loader fail-closed + cache-bound contracts

### DIFF
--- a/tests/mesh/test_acl_config.py
+++ b/tests/mesh/test_acl_config.py
@@ -112,6 +112,17 @@ class TestACLFileLoader:
         with pytest.raises(ValueError, match="not valid JSON5"):
             ac.resolve_acl("strands")
 
+    def test_invalid_utf8_rejected(self, monkeypatch, tmp_path):
+        # A non-UTF-8 ACL file must fail closed with an operator-facing
+        # error naming the file, not a raw UnicodeDecodeError from deep
+        # in the loader. Byte-level sibling of the oversize/invalid-JSON
+        # rejections above.
+        path = tmp_path / "latin1.json"
+        path.write_bytes(b'{"enabled": true, "note": "\xff\xfe not utf-8"}')
+        monkeypatch.setenv("STRANDS_MESH_ACL_FILE", str(path))
+        with pytest.raises(ValueError, match="not valid UTF-8"):
+            ac.resolve_acl("strands")
+
     def test_missing_required_field_rejected(self, monkeypatch, tmp_path):
         path = tmp_path / "incomplete.json"
         path.write_text(json.dumps({"enabled": True, "default_permission": "deny", "rules": []}))
@@ -519,6 +530,24 @@ class TestJSON5DepSwap:
         result = ac._parse_json5('{"foo": "bar"}', Path("/dev/null"))
         assert result == {"foo": "bar"}
 
+    def test_json5_missing_raises_actionable_import_error(self, monkeypatch, tmp_path):
+        """When json5 is not installed, the loader surfaces an actionable
+        ImportError naming the [mesh] extra rather than a bare
+        ModuleNotFoundError from deep in the parser. The dep is optional
+        (only paid when an ACL file is actually parsed), so the operator
+        needs to know exactly what to install."""
+
+        def _no_json5(*args, **kwargs):
+            raise ImportError("No module named 'json5'")
+
+        monkeypatch.setattr("strands_robots.utils.require_optional", _no_json5)
+        path = tmp_path / "acl.json5"
+        path.write_text('{"enabled": true}')
+        monkeypatch.setenv("STRANDS_MESH_ACL_FILE", str(path))
+        ac._clear_acl_cache_for_test()
+        with pytest.raises(ImportError, match="json5 is required"):
+            ac.resolve_acl("strands")
+
 
 # ---------------------------------------------------------------------
 # the prior fix-1: bare except on permissive-ACL warning narrowed
@@ -749,3 +778,36 @@ class TestACLShapeValidation:
         data["policies"][0]["subjects"] = ["ghost"]
         with pytest.raises(ValueError, match=r"references unknown subject id 'ghost'"):
             self._resolve(monkeypatch, tmp_path, data)
+
+
+class TestACLLoadCacheBounded:
+    """The identity-keyed ACL load cache is capped so an attacker who can
+    rewrite the ACL file repeatedly cannot inflate process memory by
+    forcing an unbounded number of distinct cache entries.
+    """
+
+    @staticmethod
+    def _good_acl() -> dict:
+        return {
+            "enabled": True,
+            "default_permission": "deny",
+            "rules": [],
+            "subjects": [{"id": "x", "interfaces": ["lo"], "cert_common_names": ["foo-*"]}],
+            "policies": [],
+        }
+
+    def test_cache_evicts_beyond_four_entries(self, monkeypatch, tmp_path):
+        # Load six DISTINCT ACL files (distinct identity tuples). The cache
+        # is capped at four entries, so the oldest are evicted rather than
+        # the map growing without bound.
+        ac._clear_acl_cache_for_test()
+        try:
+            for i in range(6):
+                path = tmp_path / f"acl_{i}.json"
+                path.write_text(json.dumps(self._good_acl()))
+                monkeypatch.setenv("STRANDS_MESH_ACL_FILE", str(path))
+                loaded = ac.resolve_acl("strands")
+                assert loaded["enabled"] is True
+            assert len(ac._ACL_CACHE) <= 4
+        finally:
+            ac._clear_acl_cache_for_test()


### PR DESCRIPTION
## Problem

The `STRANDS_MESH_ACL_FILE` loader (`strands_robots/mesh/_acl_config.py`) has three behaviours that gate wire authorisation and process memory but were not pinned by tests. Coverage of the module confirmed the branches were unexercised (lines 116-117, 179-180, 523-524):

- Non-UTF-8 file (`_load_acl_file`): decoding must fail closed with a `ValueError` naming the file, not leak a raw `UnicodeDecodeError` from deep in the loader. The existing suite pins the oversize and invalid-JSON5 rejections but not this byte-level sibling.
- json5 not installed (`_parse_json5`): the parser is lazy-imported (the dep is only paid when an ACL file is actually parsed), so a missing dep must surface an actionable `ImportError` naming the `[mesh]` extra rather than a bare `ModuleNotFoundError`.
- Identity-keyed load cache (`_load_acl_cached`): the cache is capped at four entries so an operator (or attacker) who rewrites the ACL file repeatedly cannot force an unbounded number of distinct cache entries and inflate memory.

## Change

Adds three focused regression tests, co-located with their sibling loader/parser tests in `tests/mesh/test_acl_config.py`:

- `TestACLFileLoader::test_invalid_utf8_rejected` - a non-UTF-8 file raises `ValueError` matching "not valid UTF-8" through the public `resolve_acl`.
- `TestJSON5DepSwap::test_json5_missing_raises_actionable_import_error` - with `require_optional` monkeypatched to fail, `resolve_acl` raises `ImportError` matching "json5 is required".
- `TestACLLoadCacheBounded::test_cache_evicts_beyond_four_entries` - loading six distinct ACL files leaves the cache bounded at 4 entries or fewer.

All three drive behaviour through the public `resolve_acl` entry point (assert observable outcomes, not internal state, except the cache bound which is itself the contract). No production code changes.

## Verification

- `_acl_config.py` coverage 96 percent -> ~98 percent (remaining gaps are a symlink TOCTOU race and defensive thread-snapshot branches).
- `ruff check` / `ruff format --check` clean; `mypy strands_robots tests tests_integ` reports no issues.
- `pytest tests/mesh/` - 2009 passed, 2 skipped.