### PR TITLE
docs(cosmos3): cross-reference sibling modules with :mod: roles, not source filenames

### DIFF
--- a/strands_robots/policies/cosmos3/__init__.py
+++ b/strands_robots/policies/cosmos3/__init__.py
@@ -4,7 +4,7 @@ Wraps the Cosmos 3 Generator *action* surface (e.g.
 ``nvidia/Cosmos3-Nano-Policy-DROID``) as a robots :class:`Policy`. Service mode
 speaks to the Cosmos Framework RoboLab WebSocket policy server using a
 self-contained msgpack+NumPy wire client (no ``openpi-client`` dependency
-- see ``client.py`` for the rationale).
+- see :mod:`strands_robots.policies.cosmos3.client` for the rationale).
 
 Quickstart::
 
@@ -36,7 +36,8 @@ In MuJoCo (the ``droid`` embodiment drives a Franka/DROID-class arm - use the
                    control_frequency=15.0)
 
 See ``examples/cosmos3_sim_rollout.py`` for a complete, runnable rollout +
-recording. Available embodiments: droid, umi, av, bridge (see ``embodiments.py``).
+recording. Available embodiments: droid, umi, av, bridge
+(see :mod:`strands_robots.policies.cosmos3.embodiments`).
 """
 
 from .action_decode import decode_pose_trajectory, denormalize_quantile, load_action_stats

--- a/strands_robots/policies/cosmos3/policy.py
+++ b/strands_robots/policies/cosmos3/policy.py
@@ -8,7 +8,7 @@ The Cosmos 3 ``policy`` action mode takes ``image + instruction`` and returns an
 contract. We talk to the Cosmos Framework RoboLab WebSocket policy server
 (``cosmos_framework.scripts.action_policy_server_robolab``) over a
 self-contained msgpack+NumPy WebSocket protocol (no ``openpi-client``
-dependency - see ``client.py``), mirroring
+dependency - see :mod:`strands_robots.policies.cosmos3.client`), mirroring
 :class:`~strands_robots.policies.groot.Gr00tPolicy` service mode.
 
 Observation flow


### PR DESCRIPTION
## Problem

The cosmos3 policy package docstrings consistently use Sphinx cross-reference roles for symbols (`:class:`strands_robots.policies.groot.Gr00tPolicy``, `:attr:`~Cosmos3Embodiment.camera_keys``, `:meth:`solve_trajectory``), but three references to sibling modules within the same package drop to bare source filenames:

- `strands_robots/policies/cosmos3/__init__.py` - ``see ``client.py`` for the rationale`` and ``(see ``embodiments.py``)``
- `strands_robots/policies/cosmos3/policy.py` - ``see ``client.py```

A bare filename is not importable and is not a navigable cross-reference: a reader (or an agent following the docs) cannot copy `client.py` into an import or resolve it under Sphinx. The rest of the repo already standardises on `:mod:` with the full dotted path (e.g. `strands_robots/benchmarks/libero/__init__.py`, `strands_robots/simulation/predicates.py`, `strands_robots/tools/robot_mesh.py`).

## Change

Docstring-only. Converts the three sibling-module references to `:mod:` roles with the full dotted path, matching both the repo-wide convention and this package's own `:class:`/`:attr:`/`:meth:` usage:

- ``client.py`` -> `:mod:`strands_robots.policies.cosmos3.client`` (x2)
- ``embodiments.py`` -> `:mod:`strands_robots.policies.cosmos3.embodiments``

External-repo provenance citations in the same files (e.g. `cosmos_framework.scripts.action_policy_server_robolab`, `examples/cosmos3_sim_rollout.py`) are intentionally left as-is - they document upstream sources, not importable package modules.

## Verification

- `ruff check` / `ruff format --check` clean; `mypy strands_robots/policies/cosmos3/{__init__,policy}.py` reports no issues.
- `pytest tests/policies/cosmos3/` - 144 passed, 1 skipped (package imports unchanged).

No code or behavior change.