### PR TITLE
test(tools): pin use_lerobot describe/serialize totality on introspection-hostile inputs

### DIFF
--- a/tests/tools/test_use_lerobot.py
+++ b/tests/tools/test_use_lerobot.py
@@ -190,6 +190,24 @@ def test_describe_separates_properties_from_methods() -> None:
     assert "find_cameras" not in info.get("methods", [])
 
 
+def test_describe_class_without_introspectable_init_omits_params() -> None:
+    """A class whose ``__init__`` exposes no introspectable signature (as some
+    C-extension-backed lerobot types do) is still described: the method list is
+    populated and ``init_params`` is simply omitted rather than the whole
+    describe call raising."""
+
+    class NoInitSignature:
+        # Accessing the class attribute yields the property descriptor itself,
+        # which ``inspect.signature`` cannot introspect (raises TypeError) -- the
+        # same failure mode as a builtin ``__init__`` slot wrapper.
+        __init__ = property(lambda self: None)
+
+    info = M._describe_object(NoInitSignature)
+    assert info["name"] == "NoInitSignature"
+    assert "methods" in info
+    assert "init_params" not in info
+
+
 # ----------------------------------------------------------------------------
 # serializer -- totality under hostile input
 # ----------------------------------------------------------------------------
@@ -236,6 +254,26 @@ def test_serializer_survives_hostile_repr() -> None:
     # Must not raise -- the tool stays alive even on pathological objects.
     out = M._serialize_result({"x": Hostile()})
     assert isinstance(out, str)
+
+
+def test_serializer_falls_back_when_dataclass_expansion_fails() -> None:
+    """A dataclass whose fields cannot be expanded (``asdict`` raises while
+    deep-copying a hostile field) degrades to a repr string instead of
+    propagating the error -- the serializer stays total on config-like objects."""
+    import dataclasses
+
+    class Uncopyable:
+        def __deepcopy__(self, memo: dict) -> Uncopyable:
+            raise RuntimeError("cannot copy")
+
+    @dataclasses.dataclass
+    class Config:
+        field: object
+
+    out = M._serialize_value(Config(field=Uncopyable()))
+    # asdict blew up, so no structured __dataclass__ wrapper -- but no raise either.
+    assert isinstance(out, str)
+    assert "Config" in out
 
 
 def test_serializer_depth_guard() -> None:


### PR DESCRIPTION
## Problem

`use_lerobot` is the universal dispatcher agents use to introspect and call any lerobot API, so its `_describe_object` and `_serialize_value` helpers must be *total* -- never raising, even on pathological inputs. The existing suite already pins this contract for circular refs, bytes, numpy scalars/arrays, hostile `__repr__`, and depth runaway, but two robustness fallbacks in those same helpers were unexercised:

- `_describe_object` on a class whose `__init__` exposes **no introspectable signature** (`inspect.signature` raises `ValueError`/`TypeError`, as some C-extension-backed lerobot types do). The intended behavior is to still return the method list and simply omit `init_params`, not to let the whole describe call raise.
- `_serialize_value` on a **dataclass whose `asdict()` raises** while deep-copying a field. The intended behavior is to degrade to a repr string, not to propagate the error -- config-like dataclasses are a common describe target, so this path matters.

## Change

Two focused behavior tests, added next to their topical peers in `tests/tools/test_use_lerobot.py`:

- `test_describe_class_without_introspectable_init_omits_params` -- a class whose `__init__` resolves to a property descriptor (same signature-less failure mode as a builtin slot wrapper); asserts `methods` is present and `init_params` is omitted, with no exception.
- `test_serializer_falls_back_when_dataclass_expansion_fails` -- a dataclass holding a field with a `__deepcopy__` that raises, so `asdict()` blows up; asserts the serializer returns a repr string containing the class name rather than raising.

Both tests assert observable outputs (not internal state) and need no optional extras or hardware.

## Tests

```
pytest tests/tools/test_use_lerobot.py -q
63 passed, 1 skipped
```

Coverage of `strands_robots/tools/use_lerobot.py`: the previously-uncovered fallback branches (the signature-less `except (ValueError, TypeError)` in `_describe_object` and the `except Exception` after `asdict` in `_serialize_value`) are now exercised. `ruff check`, `ruff format --check`, and `mypy` are clean.