### PR TITLE
fix(policy): surface embodiment-config failures instead of a silent discard + misleading diagnostic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -517,6 +517,25 @@ so far, exactly like `run()`. The eval result payload gains `stopped_early`
 computed over the completed episodes when a stop fires. Normal evaluations are
 unchanged (`stopped_early=False`, `episodes_completed == n_episodes`).
 
+### Fixed: an incompatible embodiment silently discarded a working normalization pipeline and misdirected the diagnostic
+
+When a `lerobot_local` policy's processor pipeline loaded and was *active* but
+its declarative embodiment / `image_keys` did not match the model's declared
+features, `_configure_embodiment` raised a `ValueError` that was swallowed at
+`debug` level: the entire (working) preprocessor + postprocessor -- including
+normalization -- was silently discarded and the policy fell back to the raw
+obs/action flow. The load-time diagnostic below then fired the generic
+"loaded WITHOUT an action postprocessor (no `policy_postprocessor.json`)"
+warning, which is *false* for these checkpoints (they ship a postprocessor; it
+was discarded here) and sends the user down the wrong debugging path when the
+arm barely moves. The embodiment-configuration failure is now surfaced as a
+warning that names the real cause (or raised as a `RuntimeError` when
+`processor_overrides` were supplied, mirroring the bridge-load path), and the
+misleading missing-postprocessor message is suppressed for that case. A
+malformed embodiment *spec* still raises loudly. Behaviour is unchanged for a
+correctly-configured policy and for a checkpoint that genuinely ships no
+processor configs.
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -340,6 +340,10 @@ class LerobotLocalPolicy(Policy):
         self.load_time_s: float = 0.0
         self.load_cache_hit: bool = False
         self._processor_bridge: ProcessorBridge | None = None
+        # Set True when the pipeline loaded and was active but the caller's
+        # embodiment / image_keys were incompatible with the model's declared
+        # features, so the bridge was discarded (see _load_processor_bridge).
+        self._embodiment_config_failed = False
         self._tokenizer: Any = None
         self._tokenizer_max_length: int = tokenizer_max_length
         self._tokenizer_padding_side: str = tokenizer_padding_side
@@ -798,34 +802,92 @@ class LerobotLocalPolicy(Policy):
                     action_dim - 1,
                 )
 
-        # Load processor pipeline (preprocessor + postprocessor)
-        if self.use_processor and self.pretrained_name_or_path:
-            try:
-                self._processor_bridge = ProcessorBridge.from_pretrained(
-                    self.pretrained_name_or_path,
-                    device=str(self._device) if self._device else None,
-                    overrides=self.processor_overrides or {},
-                    policy_type=self.policy_type,
-                )
-                if self._processor_bridge.is_active:
-                    logger.info("Processor bridge loaded: %s", self._processor_bridge)
-                    # SOLUTION.md: configure the declarative embodiment map into
-                    # the pipeline ONCE (rename_map + pack-state step), validated
-                    # fail-fast against the model's declared features. After this,
-                    # the hot path feeds RAW obs straight to preprocess().
+        # Load processor pipeline (preprocessor + postprocessor), configure the
+        # declarative embodiment map, and emit load-time diagnostics.
+        self._load_processor_bridge()
+
+        # Initialize RTC if supported by this policy
+        self._init_rtc()
+
+    def _load_processor_bridge(self) -> None:
+        """Load the processor pipeline, configure the embodiment, and emit load-time diagnostics.
+
+        Two distinct failure modes were previously conflated into one silent,
+        debug-level discard of the whole pipeline:
+
+        * ``ProcessorBridge.from_pretrained`` raises (no processor configs are
+          shipped, or an optional import is missing): the checkpoint legitimately
+          has no pipeline, so fall back to the raw obs/action flow. This is a
+          common, benign shape - logged at debug, and the missing-postprocessor
+          warning below still fires so a raw-action checkpoint is not mistaken for
+          a frozen policy.
+        * ``_configure_embodiment`` raises ``ValueError``: the pipeline loaded and
+          was ACTIVE, but the caller's embodiment / ``image_keys`` are incompatible
+          with the model's declared features. Discarding it silently degrades a
+          WORKING normalization pipeline to the raw flow AND misdirects the
+          downstream "no policy_postprocessor.json" diagnostic (the checkpoint
+          shipped one - it was discarded here). Surface the real cause as a
+          warning, or raise when ``processor_overrides`` were given (mirroring the
+          from_pretrained path).
+
+        A malformed embodiment *spec* (bad name / dict) raises ``RuntimeError``
+        from ``load_embodiment`` and is intentionally NOT caught here - that is a
+        caller error that should abort the load loudly.
+        """
+        self._embodiment_config_failed = False
+        if not (self.use_processor and self.pretrained_name_or_path):
+            return
+
+        try:
+            self._processor_bridge = ProcessorBridge.from_pretrained(
+                self.pretrained_name_or_path,
+                device=str(self._device) if self._device else None,
+                overrides=self.processor_overrides or {},
+                policy_type=self.policy_type,
+            )
+        except (FileNotFoundError, ValueError, ImportError) as exc:
+            # Processor bridge is optional - models work without it via the raw
+            # obs/action flow. Fail-fast only if the caller requested overrides.
+            if self.processor_overrides:
+                raise RuntimeError(
+                    f"Processor bridge failed to load but processor_overrides were specified: {exc}"
+                ) from exc
+            logger.debug("Processor bridge not loaded: %s", exc)
+            self._processor_bridge = None
+        else:
+            if self._processor_bridge.is_active:
+                logger.info("Processor bridge loaded: %s", self._processor_bridge)
+                # SOLUTION.md: configure the declarative embodiment map into the
+                # pipeline ONCE (rename_map + pack-state step), validated fail-fast
+                # against the model's declared features. After this, the hot path
+                # feeds RAW obs straight to preprocess().
+                try:
                     self._configure_embodiment()
-                else:
+                except ValueError as exc:
+                    # The pipeline loaded and was active, but the embodiment /
+                    # image_keys do not match the model's declared features. Do NOT
+                    # swallow this at debug: discarding an otherwise-working
+                    # normalization pipeline is a silent behaviour change, and the
+                    # missing-postprocessor warning below would misattribute it to a
+                    # checkpoint lacking a policy_postprocessor.json.
+                    if self.processor_overrides:
+                        raise RuntimeError(
+                            f"Embodiment configuration failed but processor_overrides were specified: {exc}"
+                        ) from exc
+                    logger.warning(
+                        "lerobot_local: %s loaded an ACTIVE processor pipeline but its "
+                        "embodiment could not be configured (%s). The pipeline (including "
+                        "normalization) was discarded and the policy falls back to the raw "
+                        "obs/action flow -- align the embodiment / image_keys with the "
+                        "model's declared input/output features.",
+                        self.pretrained_name_or_path or "<model>",
+                        exc,
+                    )
                     self._processor_bridge = None
-                    logger.debug("No processor configs found, using raw obs/action flow")
-            except (FileNotFoundError, ValueError, ImportError) as exc:
-                # Processor bridge is optional - models work without it via raw obs/action flow.
-                # Fail-fast only if the user explicitly requested processor overrides.
-                if self.processor_overrides:
-                    raise RuntimeError(
-                        f"Processor bridge failed to load but processor_overrides were specified: {exc}"
-                    ) from exc
-                logger.debug("Processor bridge not loaded: %s", exc)
+                    self._embodiment_config_failed = True
+            else:
                 self._processor_bridge = None
+                logger.debug("No processor configs found, using raw obs/action flow")
 
         # Action unnormalization only happens when a postprocessor pipeline is
         # present (get_actions: ``if self._processor_bridge.has_postprocessor``).
@@ -833,7 +895,10 @@ class LerobotLocalPolicy(Policy):
         # normalized actions (~[-1, 1] or z-scored) straight to the robot. Fed
         # to a radian-joint sim those are micro-motions and the arm barely
         # moves. Warn once at load so this isn't debugged as a frozen policy.
-        if self.use_processor:
+        # Skipped when the pipeline was discarded by an embodiment-config failure
+        # above (already warned with the accurate cause), so we do not emit the
+        # misleading "no policy_postprocessor.json" message for that case.
+        if self.use_processor and not self._embodiment_config_failed:
             bridge = self._processor_bridge
             if bridge is None or not bridge.has_postprocessor:
                 logger.warning(
@@ -875,9 +940,6 @@ class LerobotLocalPolicy(Policy):
                         self.pretrained_name_or_path or "<model>",
                         inert,
                     )
-
-        # Initialize RTC if supported by this policy
-        self._init_rtc()
 
     def _auto_detect_actions_per_step(self) -> None:
         """Select the inference regime the loaded checkpoint was trained for.

--- a/tests/policies/lerobot_local/test_embodiment_config_failure_diagnostics.py
+++ b/tests/policies/lerobot_local/test_embodiment_config_failure_diagnostics.py
@@ -1,0 +1,122 @@
+"""Load-time diagnostics when an ACTIVE processor pipeline cannot be configured.
+
+``LerobotLocalPolicy._load_processor_bridge`` loads the processor pipeline and
+wires the declarative embodiment into it. Two failure modes exist and must be
+reported differently:
+
+* ``ProcessorBridge.from_pretrained`` fails -> the checkpoint ships no pipeline;
+  fall back to the raw obs/action flow (debug), and the generic
+  missing-postprocessor warning still fires.
+* ``_configure_embodiment`` raises ``ValueError`` -> the pipeline loaded and was
+  ACTIVE, but the caller's embodiment / ``image_keys`` are incompatible with the
+  model's declared features. The (working) normalization pipeline is discarded,
+  which is a silent behaviour change. Previously this was swallowed at debug and
+  the downstream warning then falsely blamed a missing ``policy_postprocessor.json``.
+  It must now surface the real cause as a warning (or raise under
+  ``processor_overrides``), and must NOT emit the misleading missing-postprocessor
+  message.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from strands_robots.policies.lerobot_local.embodiment import EmbodimentMap
+from strands_robots.policies.lerobot_local.policy import LerobotLocalPolicy
+
+
+def _feature(dim: int) -> MagicMock:
+    feat = MagicMock()
+    feat.shape = (dim,)
+    return feat
+
+
+def _make_policy(**kwargs) -> LerobotLocalPolicy:
+    """Construct a policy without touching the heavy ``_load_model`` path."""
+    with patch.object(LerobotLocalPolicy, "_load_model"):
+        pol = LerobotLocalPolicy(pretrained_name_or_path="fake/ckpt", **kwargs)
+    pol._device = None
+    pol._input_features = {
+        "observation.images.top": _feature(3),
+        "observation.state": _feature(6),
+    }
+    pol._output_features = {"action": _feature(6)}
+    return pol
+
+
+def _fake_bridge(*, active: bool, has_postprocessor: bool) -> MagicMock:
+    bridge = MagicMock(name="ProcessorBridge")
+    bridge.is_active = active
+    bridge.has_postprocessor = has_postprocessor
+    bridge.inert_normalization_features.return_value = []
+    return bridge
+
+
+def _patch_from_pretrained(monkeypatch, bridge) -> None:
+    monkeypatch.setattr(
+        "strands_robots.policies.lerobot_local.policy.ProcessorBridge.from_pretrained",
+        classmethod(lambda cls, *a, **k: bridge),
+    )
+
+
+# An embodiment whose action_keys length (3) disagrees with the model's action
+# dim (6) -> EmbodimentMap.validate raises ValueError inside _configure_embodiment.
+def _incompatible_embodiment() -> EmbodimentMap:
+    return EmbodimentMap(
+        name="wrong_dims",
+        obs_rename={},
+        state_keys=[],
+        action_keys=["a", "b", "c"],
+        dim_policy="pad",
+    )
+
+
+def test_embodiment_config_failure_warns_with_real_cause_and_discards(monkeypatch, caplog):
+    """An active pipeline + incompatible embodiment -> accurate warning, bridge discarded."""
+    bridge = _fake_bridge(active=True, has_postprocessor=True)
+    _patch_from_pretrained(monkeypatch, bridge)
+    pol = _make_policy(embodiment=_incompatible_embodiment())
+
+    with caplog.at_level(logging.WARNING):
+        pol._load_processor_bridge()
+
+    # The working pipeline was discarded (falls back to raw flow) ...
+    assert pol._processor_bridge is None
+    assert pol._embodiment_config_failed is True
+    # ... with a warning that names the real cause (embodiment misconfiguration) ...
+    msgs = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("embodiment could not be configured" in m for m in msgs), msgs
+    # ... and NOT the misleading "no policy_postprocessor.json" message (the
+    # checkpoint shipped one; it was discarded here, not absent).
+    assert not any("policy_postprocessor.json" in m for m in msgs), msgs
+
+
+def test_embodiment_config_failure_raises_when_overrides_requested(monkeypatch):
+    """With processor_overrides the caller opted into fail-fast -> RuntimeError."""
+    bridge = _fake_bridge(active=True, has_postprocessor=True)
+    _patch_from_pretrained(monkeypatch, bridge)
+    pol = _make_policy(
+        embodiment=_incompatible_embodiment(),
+        processor_overrides={"normalizer_processor": {"stats": {}}},
+    )
+    with pytest.raises(RuntimeError, match="Embodiment configuration failed"):
+        pol._load_processor_bridge()
+
+
+def test_active_bridge_without_postprocessor_still_warns(monkeypatch, caplog):
+    """No embodiment failure -> the generic missing-postprocessor warning still fires."""
+    bridge = _fake_bridge(active=True, has_postprocessor=False)
+    _patch_from_pretrained(monkeypatch, bridge)
+    # No embodiment spec and no robot_state_keys -> _configure_embodiment is a no-op.
+    pol = _make_policy(embodiment=None)
+
+    with caplog.at_level(logging.WARNING):
+        pol._load_processor_bridge()
+
+    assert pol._embodiment_config_failed is False
+    assert pol._processor_bridge is bridge
+    msgs = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("policy_postprocessor.json" in m for m in msgs), msgs


### PR DESCRIPTION
## Problem

When a `lerobot_local` policy's processor pipeline loads and is **active**, but the caller's declarative embodiment / `image_keys` do not match the model's declared input/output features, `_configure_embodiment()` raises a `ValueError` (from `EmbodimentMap.validate`). That `ValueError` was caught by the broad `except (FileNotFoundError, ValueError, ImportError)` around the bridge load and swallowed at **`debug`** level:

- the entire, otherwise-**working** preprocessor + postprocessor pipeline (including normalization) was silently discarded and the policy fell back to the raw obs/action flow;
- the load-time diagnostic just below then fired the generic `loaded WITHOUT an action postprocessor (no policy_postprocessor.json)` warning.

That message is **false** for these checkpoints — they *do* ship a `policy_postprocessor.json`; it was discarded here because the embodiment could not be configured. When the arm then barely moves (raw normalized actions in a radian-joint sim), the user is sent down the wrong debugging path ("my checkpoint lacks a postprocessor") instead of the real one ("my embodiment / image_keys don't match this model").

This was the one remaining *silent* (debug-level) degradation in a load block where every other failure mode already warns (missing postprocessor; present-but-inert normalization stats; action-dim mismatch; persistent near-zero actions).

## Change

Extract the bridge-load + embodiment-config + load-time diagnostics into `_load_processor_bridge()`, separating two distinct failure modes:

- **`from_pretrained` fails** (no processor configs shipped / optional import missing) → a genuinely-absent pipeline; fall back to raw flow at `debug`, and the generic missing-postprocessor warning still fires (unchanged).
- **`_configure_embodiment` raises `ValueError`** (pipeline was active, embodiment incompatible) → surface a **warning naming the real cause**, or raise `RuntimeError` when `processor_overrides` were supplied (mirroring the existing `from_pretrained` fail-fast). The misleading missing-postprocessor message is suppressed for this case.

A malformed embodiment *spec* still raises loudly (`load_embodiment` → `RuntimeError`, intentionally not caught). Behaviour is unchanged for a correctly-configured policy and for a checkpoint that genuinely ships no processor configs.

## Tests

`tests/policies/lerobot_local/test_embodiment_config_failure_diagnostics.py` (real, network-free):

- active pipeline + incompatible embodiment → accurate `embodiment could not be configured` warning, bridge discarded, and **no** `policy_postprocessor.json` message;
- same with `processor_overrides` → `RuntimeError`;
- active bridge without a postprocessor (no embodiment failure) → the generic missing-postprocessor warning still fires (no-regression guard).

Fails on pre-fix logic (verified by reverting only the fix inside the new method: the misleading `no policy_postprocessor.json` warning fires and `_embodiment_config_failed` stays `False`), passes after.

## Gate

- `ruff check` + `ruff format --check` + `mypy` clean on the changed files.
- Full `tests/policies/lerobot_local` suite green (483 passed).
- Verified the real `lerobot/smolvla_base` load path is unchanged end-to-end (bridge active, embodiment configured, the existing inert-normalization warning still fires, `_embodiment_config_failed=False`).

No behaviour change for a working policy, so no rollout artifact applies — this is a load-time diagnostics fix.