### PR TITLE
test(mesh): pin source_zid extractor degradation contract

### DIFF
--- a/tests/mesh/test_safety_source_zid_binding.py
+++ b/tests/mesh/test_safety_source_zid_binding.py
@@ -137,6 +137,43 @@ def test_extract_zid_rejects_overlong_string():
     assert _extract_sample_source_zid(sample) is None
 
 
+def test_extract_zid_returns_none_when_source_id_missing():
+    """A sample that attaches ``source_info`` but no ``source_id`` (a partial
+    SourceInfo from a transport shim) degrades to None rather than crashing
+    the safety handler."""
+    sample = SimpleNamespace(
+        payload=SimpleNamespace(to_bytes=lambda: b"{}"),
+        source_info=SimpleNamespace(source_id=None),
+    )
+    assert _extract_sample_source_zid(sample) is None
+
+
+def test_extract_zid_returns_none_when_zid_missing():
+    """A ``source_id`` present but carrying no ``zid`` (an incomplete
+    EntityGlobalId) yields None, not an empty/garbage identity."""
+    sample = SimpleNamespace(
+        payload=SimpleNamespace(to_bytes=lambda: b"{}"),
+        source_info=SimpleNamespace(source_id=SimpleNamespace(zid=None)),
+    )
+    assert _extract_sample_source_zid(sample) is None
+
+
+def test_extract_zid_returns_none_when_extraction_raises():
+    """Defence in depth: if stringifying the zid raises (a hostile or broken
+    sample object), the extractor treats it as \"no zid available\" and
+    returns None instead of propagating into the safety handler."""
+
+    class _ExplodingZid:
+        def __str__(self) -> str:
+            raise TypeError("zid str() blew up")
+
+    sample = SimpleNamespace(
+        payload=SimpleNamespace(to_bytes=lambda: b"{}"),
+        source_info=SimpleNamespace(source_id=SimpleNamespace(zid=_ExplodingZid())),
+    )
+    assert _extract_sample_source_zid(sample) is None
+
+
 # Receiver-side: estop ----------------------------------------------------
 
 


### PR DESCRIPTION
## Problem

`_extract_sample_source_zid` in `strands_robots.mesh.core` returns the wire-level, TLS-bound publisher ZID (`sample.source_info.source_id.zid`) that the safety handlers pin HMAC inputs and replay caches to. Its docstring documents that it returns `None` on several malformed-sample conditions, but only some of those degradation branches were exercised by tests:

- source-info-absent, non-hex, uppercase, and overlong were pinned;
- `source_info` present but `source_id` missing, `source_id` present but `zid` missing, and the defence-in-depth `except (AttributeError, TypeError)` path were **not** covered.

These are the exact partial-SourceInfo / hostile-sample cases the helper exists to survive, so leaving them untested means a refactor could silently turn a graceful `None` into a crash inside a safety handler (or an accepted garbage identity) without any test failing.

## Change

Test-only. Adds three focused cases to `tests/mesh/test_safety_source_zid_binding.py` in the extractor section:

- `test_extract_zid_returns_none_when_source_id_missing` - `source_info` present, `source_id=None`.
- `test_extract_zid_returns_none_when_zid_missing` - `source_id` present, `zid=None`.
- `test_extract_zid_returns_none_when_extraction_raises` - a sample whose `zid.__str__` raises `TypeError`, verifying the extractor treats it as 'no zid available' rather than propagating.

Each asserts the documented `None` output (behavior, not internals), completing the helper's 'returns None when...' contract.

## Verification

The three lines were previously uncovered; the helper is now fully covered. Local run:

```
pytest tests/mesh/test_safety_source_zid_binding.py -> 23 passed (was 20)
```

Lint/format clean (ruff check, ruff format). No source changes, so no behavior/rendering change applies.