### PR TITLE
test(wbc): pin control-law input-validation + bad-action degrade contracts

### DIFF
--- a/tests/policies/wbc/test_policy.py
+++ b/tests/policies/wbc/test_policy.py
@@ -176,6 +176,22 @@ class TestControlMath:
         with pytest.raises(ValueError, match="zero norm"):
             quat_rotate_inverse(np.array([0.0, 0, 0, 0]), np.array([1.0, 0, 0]))
 
+    def test_compute_targets_shape_mismatch_raises(self) -> None:
+        # A raw action of the wrong length must not silently broadcast into a
+        # wrong-shape target; it is a fatal config/model mismatch.
+        with pytest.raises(ValueError, match="must match"):
+            compute_targets(np.array([0.1, 0.2]), np.array([0.04, -0.04, 0.01]), 0.25)
+
+    def test_quat_rotate_inverse_bad_quat_length_raises(self) -> None:
+        # A 3-vector is not a quaternion; reject rather than index past the end.
+        with pytest.raises(ValueError, match=r"length-4 \[w,x,y,z\]"):
+            quat_rotate_inverse(np.array([1.0, 0.0, 0.0]), np.array([1.0, 0.0, 0.0]))
+
+    def test_quat_rotate_inverse_bad_vec_length_raises(self) -> None:
+        # The vector to rotate must be 3-D; a 2-vector is a caller bug.
+        with pytest.raises(ValueError, match="length-3"):
+            quat_rotate_inverse(np.array([1.0, 0.0, 0.0, 0.0]), np.array([1.0, 0.0]))
+
 
 # ---------------------------------------------------------------------------
 # Observation layout

--- a/tests/policies/wbc/test_sim_control.py
+++ b/tests/policies/wbc/test_sim_control.py
@@ -17,7 +17,7 @@ weights and lives in the gated integration suite.
 
 from __future__ import annotations
 
-from typing import cast
+from typing import Any, cast
 
 import numpy as np
 import pytest
@@ -183,5 +183,37 @@ class TestWBCTorqueController:
         assert abs((float(data.time) - t0) - expected_dt) < 1e-6
 
         # At least one driven actuator received a finite torque command.
+        ctrls = np.array([float(data.ctrl[ai]) for ai in ctrl.leg_waist_actuator_ids])
+        assert np.all(np.isfinite(ctrls))
+
+    def test_apply_non_numeric_action_value_holds_previous_target(self) -> None:
+        # One malformed action value (e.g. a NaN string leaking from a policy)
+        # must degrade to holding that joint's previous target, not abort the
+        # whole control step - the remaining joints still track their commands.
+        from strands_robots.policies.wbc import (
+            WBC_G1_LEG_WAIST_JOINTS,
+            install_wbc_torque_control,
+        )
+
+        model, data = _build_min_g1()
+        ns = _namespace_for(model)
+        sim = _FakeSim(_FakeWorld(model, data, ns))
+        policy = _g1_policy()
+        ctrl = install_wbc_torque_control(cast(SimEngine, sim), policy, "unitree_g1")
+
+        stance = {name: float(policy.default_angles[i]) for i, name in enumerate(WBC_G1_LEG_WAIST_JOINTS)}
+        ctrl.apply(stance, model, data, "unitree_g1")
+        held = float(ctrl._target_q[0])
+
+        # Poison joint 0 with a non-numeric value; give joint 1 a fresh command.
+        corrupt: dict[str, Any] = dict(stance)
+        corrupt[WBC_G1_LEG_WAIST_JOINTS[0]] = "not-a-number"
+        corrupt[WBC_G1_LEG_WAIST_JOINTS[1]] = 0.123
+        ctrl.apply(corrupt, model, data, "unitree_g1")
+
+        # Bad key held its prior target; the good key still updated.
+        assert float(ctrl._target_q[0]) == held
+        assert abs(float(ctrl._target_q[1]) - 0.123) < 1e-12
+        # And the step still produced finite torques (no abort / NaN spill).
         ctrls = np.array([float(data.ctrl[ai]) for ai in ctrl.leg_waist_actuator_ids])
         assert np.all(np.isfinite(ctrls))


### PR DESCRIPTION
## Problem

The WBC control stack has explicit malformed-input handling that was never exercised by a test:

- The pure-NumPy control helpers in `policies/wbc/control.py` raise `ValueError` on shape/length mismatches (`compute_targets` default/action length, `quat_rotate_inverse` quaternion-must-be-4 / vector-must-be-3), so a config/model mismatch fails loudly instead of silently broadcasting a wrong-shape target or indexing past the end of a 3-vector "quaternion".
- `WBCTorqueController.apply` in `policies/wbc/sim_control.py` degrades a single non-numeric action value to holding that joint's previous target rather than aborting the whole control step.

Both behaviors were uncovered: `control.py` lines 90/117/119 and `sim_control.py` lines 285-289.

## Change

Adds focused regression tests (test-only, no source change):

- `tests/policies/wbc/test_policy.py::TestControlMath` - three error-path tests for `compute_targets` shape mismatch and `quat_rotate_inverse` bad quaternion / bad vector length. Brings `control.py` to 100%.
- `tests/policies/wbc/test_sim_control.py::TestWBCTorqueController` - a non-numeric action value for one joint holds that joint's previous target while another joint still tracks its fresh command, and the step still writes finite torques to `data.ctrl` (no whole-step abort / NaN spill). Covers the degrade-to-hold branch.

Coverage: `policies/wbc/control.py` 92% -> 100%; the `sim_control.py` non-numeric degrade branch is now pinned.

## Verification

`MUJOCO_GL=egl python -m pytest tests/policies/wbc/` -> 146 passed. `ruff check`, `ruff format --check`, and `mypy` over `strands_robots tests tests_integ` are clean. The controller tests reuse the existing `unitree_g1` model harness and `pytest.importorskip("mujoco")`, so they skip cleanly where the model/assets are unavailable.