### PR TITLE
feat(verify-dataset): flag truncated/partial-encode videos (fewer frames than recorded)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -552,6 +552,23 @@ omitting `video` records nothing (opt-in). The agent-tool router folds the flat
 `output_path`/`fps`/`camera_name` keys into `video` for `evaluate_benchmark`
 too.
 
+### Added: `verify-dataset` flags a truncated / partial-encode video (fewer frames than recorded)
+
+`verify_dataset` (`strands-robots verify-dataset`) already flagged missing and
+empty per-episode video files, but a *present, non-empty* MP4 whose decoded
+frame count is fewer than the frames the parquet maps into it passed silently -
+correct episode counts, a real file, but missing pixels (the encoder crashed
+mid-episode, the file was partially synced, or the write was interrupted). Check
+5 now also compares each video file's frame count, read from the container
+header via PyAV (`av`) without decoding, against the sum of the `length` of
+every episode packed into that file (LeRobot v3 concatenates whole episodes into
+one shared file per camera). The comparison is best-effort: it is skipped when
+`av` is unavailable, when a packed episode carries no `length`, or when the
+codec header omits the frame count, so it never yields a false positive on a
+header it cannot read - it reports only a confidently-read mismatch. This is the
+frame-count sibling of the existing missing/empty-video and dead-column
+integrity checks. Disable with `--no-check-videos`.
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/verify_dataset.py
+++ b/strands_robots/verify_dataset.py
@@ -18,10 +18,13 @@ Checks performed against a dataset root (the dir containing ``meta/``):
   5. every per-episode video file referenced by the dataset (one MP4 per
      camera per episode, resolved from ``meta/info.json``'s ``video_path``
      template and the episode parquet's ``videos/<key>/chunk_index`` /
-     ``file_index`` columns) exists on disk and is non-empty - flags the
-     video-modality sibling of mega-episode corruption, where the episode
-     count is correct but the pixels are missing/unwritten (disable with
-     ``--no-check-videos``).
+     ``file_index`` columns) exists on disk, is non-empty, and - when its
+     frame count can be read from the container header - holds exactly the
+     number of frames the parquet maps into it (the sum of the ``length`` of
+     every episode packed into that file). Flags the video-modality sibling
+     of mega-episode corruption: a correct episode count but missing pixels,
+     whether the file is absent/empty or a truncated/partial encode with
+     fewer frames than recorded (disable with ``--no-check-videos``).
   6. no ``action`` / ``observation.state`` column is identically zero across
      a multi-frame episode - the dead-control-column corruption (correct
      counts and pixels, but the proprioceptive/action signal was written as
@@ -177,11 +180,13 @@ def verify_dataset(
             "- the recording did not produce the intended number of distinct episodes"
         )
 
-    # Check 5: per-episode video files exist on disk and are non-empty. A
-    # dataset can pass every count check yet carry missing/empty MP4 streams
-    # (the recorder's video encoder failed, the files were partially synced, or
-    # frames were never captured) - correct episode counts, no pixels. This is
-    # the video-modality sibling of the mega-episode class above.
+    # Check 5: per-episode video files exist on disk, are non-empty, and hold
+    # the frame count the parquet maps into them. A dataset can pass every count
+    # check yet carry missing/empty MP4 streams, or a truncated/partial encode
+    # with fewer frames than recorded (the video encoder failed mid-episode, the
+    # files were partially synced, or frames were never captured) - correct
+    # episode counts, missing pixels. This is the video-modality sibling of the
+    # mega-episode class above.
     if check_videos:
         checked, video_problems = _verify_video_files(root_path)
         report["video_files_checked"] = checked
@@ -205,15 +210,47 @@ def verify_dataset(
     return report
 
 
+def _video_frame_count(path: Path) -> int | None:
+    """Best-effort decoded-frame count for a video file, read from the container
+    header (no full decode).
+
+    Returns the stream frame count when the container header carries it (the
+    common case for the finalized MP4s LeRobot writes), or ``None`` when it
+    cannot be read: PyAV (``av``) is not installed, the file is unreadable /
+    corrupt, or the codec header omits ``nb_frames``. ``None`` means "cannot
+    confirm", never "zero frames", so the caller only flags a genuine,
+    confidently-read mismatch and never false-positives on a header that lacks a
+    frame count.
+    """
+    try:
+        import av
+    except ImportError:
+        return None
+    try:
+        with av.open(str(path)) as container:
+            if not container.streams.video:
+                return None
+            n = container.streams.video[0].frames
+    except (OSError, ValueError, RuntimeError):
+        # Unreadable/corrupt header (incl. av.error.InvalidDataError, a
+        # ValueError subclass): treat as "cannot confirm" and skip the compare.
+        return None
+    return int(n) if isinstance(n, int) and n > 0 else None
+
+
 def _verify_video_files(root_path: Path) -> tuple[int, list[str]]:
     """Resolve and integrity-check every per-episode video file in a dataset.
 
     For each video feature declared in ``meta/info.json`` (``dtype == "video"``)
     and each episode, the on-disk MP4 path is resolved from the ``video_path``
     template and the episode parquet's ``videos/<key>/chunk_index`` /
-    ``file_index`` columns, then checked for existence and non-zero size. This
-    catches datasets whose episode counts are correct but whose pixels are
-    missing or were never written.
+    ``file_index`` columns, then checked for existence and non-zero size.
+    Additionally, when a file's frame count can be read from the container
+    header (via :func:`_video_frame_count`) and every episode packed into it
+    carries a ``length``, the decoded frame count is compared to the sum of
+    those lengths - flagging a truncated / partial encode (a present, non-empty
+    file with fewer frames than recorded). This catches datasets whose episode
+    counts are correct but whose pixels are missing, unwritten, or partial.
 
     Args:
         root_path: Dataset root directory (the dir that contains ``meta/``).
@@ -254,14 +291,22 @@ def _verify_video_files(root_path: Path) -> tuple[int, list[str]]:
         return 0, []
 
     parquet_files = sorted((root_path / "meta" / "episodes").glob("**/*.parquet"))
-    # (video_key, chunk_index, file_index) -> set of referencing episode_index.
+    # (video_key, chunk_index, file_index) -> first referencing episode_index.
     referenced: dict[tuple[str, int, int], int] = {}
+    # Same key -> total frames the parquet maps into that file (LeRobot v3 packs
+    # multiple whole episodes into one shared file per camera, so the file must
+    # hold exactly the sum of those episodes' ``length`` values).
+    expected_frames: dict[tuple[str, int, int], int] = {}
+    # Files a frame-count comparison must skip because at least one referencing
+    # episode carried no ``length`` (the column is optional in some writers).
+    unknown_len_files: set[tuple[str, int, int]] = set()
     keys_with_refs: set[str] = set()
     for pf in parquet_files:
         table = pq.read_table(pf)
         cols = set(table.column_names)
         data = table.to_pydict()
         episodes = data.get("episode_index", [])
+        lengths = data.get("length")
         for vk in video_keys:
             ci_col = f"videos/{vk}/chunk_index"
             fi_col = f"videos/{vk}/file_index"
@@ -274,8 +319,14 @@ def _verify_video_files(root_path: Path) -> tuple[int, list[str]]:
                 ci, fi = chunk_idx[i], file_idx[i]
                 if ci is None or fi is None:
                     continue
+                key = (vk, int(ci), int(fi))
                 ep = int(episodes[i]) if i < len(episodes) and episodes[i] is not None else -1
-                referenced.setdefault((vk, int(ci), int(fi)), ep)
+                referenced.setdefault(key, ep)
+                length = lengths[i] if lengths is not None and i < len(lengths) else None
+                if length is None:
+                    unknown_len_files.add(key)
+                else:
+                    expected_frames[key] = expected_frames.get(key, 0) + int(length)
 
     problems: list[str] = []
     for vk in video_keys:
@@ -292,6 +343,30 @@ def _verify_video_files(root_path: Path) -> tuple[int, list[str]]:
             problems.append(f"missing video file for '{vk}' (episode {ep}): {rel}")
         elif path.stat().st_size == 0:
             problems.append(f"empty video file for '{vk}' (episode {ep}): {rel}")
+
+    # Frame-count integrity: a present, non-empty video whose decoded frame
+    # count is fewer (or otherwise different) than the frames the parquet maps
+    # into it is a truncated / partial encode - correct episode counts, a
+    # non-empty file, but missing pixels (the encoder crashed mid-episode, the
+    # file was partially synced, or the write was interrupted). This is the
+    # frame-count sibling of the missing/empty-video class above. It is reported
+    # only when the count can be read confidently from the container header, so
+    # a codec whose header omits the frame count never yields a false positive.
+    for key in sorted(expected_frames):
+        if key in unknown_len_files:
+            continue  # a referencing episode lacked a length: cannot compute expected
+        vk, ci, fi = key
+        rel = template.format(video_key=vk, chunk_index=ci, file_index=fi)
+        path = root_path / rel
+        if not path.is_file() or path.stat().st_size == 0:
+            continue  # already reported as missing / empty above
+        actual = _video_frame_count(path)
+        if actual is not None and actual != expected_frames[key]:
+            problems.append(
+                f"video file for '{vk}' has {actual} frame(s) but the parquet maps "
+                f"{expected_frames[key]} frame(s) to it: {rel} - truncated / partial "
+                "encode (correct episode counts, non-empty file, but missing pixels)"
+            )
 
     return len(referenced), problems
 

--- a/tests/test_verify_dataset.py
+++ b/tests/test_verify_dataset.py
@@ -314,6 +314,138 @@ class TestVideoFileIntegrity:
         assert verify_main([str(tmp_path), "--no-check-videos"]) == 0  # opt out passes
 
 
+def _write_real_mp4(path: Path, n_frames: int, width: int = 64, height: int = 64) -> None:
+    """Encode a real ``n_frames``-frame H.264 MP4 whose container header carries
+    the frame count (so :func:`_video_frame_count` can read it back).
+    """
+    import av
+    import numpy as np
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with av.open(str(path), mode="w") as container:
+        stream = container.add_stream("libx264", rate=30)
+        stream.width = width
+        stream.height = height
+        stream.pix_fmt = "yuv420p"
+        for i in range(n_frames):
+            arr = np.full((height, width, 3), (i * 17) % 256, dtype=np.uint8)
+            frame = av.VideoFrame.from_ndarray(arr, format="rgb24")
+            for packet in stream.encode(frame):
+                container.mux(packet)
+        for packet in stream.encode():  # flush the encoder
+            container.mux(packet)
+
+
+class TestVideoFrameCountIntegrity:
+    """Check 5 (frame-count sub-check): a present, non-empty video whose decoded
+    frame count is fewer than the parquet records is a truncated / partial
+    encode - correct episode counts, a real file, but missing pixels. Pins that
+    the verifier catches it, that the count is compared against the SUM of the
+    lengths of every episode packed into a shared file (the real LeRobot v3
+    layout), and that it never false-positives when the count can't be read.
+    """
+
+    def test_matching_frame_count_passes(self, tmp_path: Path) -> None:
+        pytest.importorskip("av")
+        _write_video_dataset(
+            tmp_path,
+            episode_indices=[0],
+            video_keys=["observation.images.cam1"],
+            frames_per_episode=[5],
+            write_files=set(),  # write the real MP4 ourselves below
+        )
+        _write_real_mp4(
+            tmp_path / "videos/observation.images.cam1/chunk-000/file-000.mp4",
+            n_frames=5,
+        )
+        report = verify_dataset(tmp_path)
+        assert report["status"] == "success", report["problems"]
+        assert report["video_files_checked"] == 1
+
+    def test_truncated_video_fails(self, tmp_path: Path) -> None:
+        pytest.importorskip("av")
+        # Parquet records a 5-frame episode; the MP4 holds only 2 frames.
+        _write_video_dataset(
+            tmp_path,
+            episode_indices=[0],
+            video_keys=["observation.images.cam1"],
+            frames_per_episode=[5],
+            write_files=set(),
+        )
+        _write_real_mp4(
+            tmp_path / "videos/observation.images.cam1/chunk-000/file-000.mp4",
+            n_frames=2,
+        )
+        report = verify_dataset(tmp_path)
+        assert report["status"] == "error"
+        # The episode-count check still passes - only the frame count is wrong.
+        assert report["total_episodes"] == 1
+        assert any("2 frame(s)" in p and "maps 5 frame(s)" in p and "truncated" in p for p in report["problems"]), (
+            report["problems"]
+        )
+
+    def test_packed_multi_episode_file_sums_lengths(self, tmp_path: Path) -> None:
+        pytest.importorskip("av")
+        # Real recorder layout: two whole episodes packed into ONE shared file
+        # per camera. The file must hold length[0] + length[1] = 3 + 4 = 7.
+        ep_dir = tmp_path / "meta" / "episodes" / "chunk-000"
+        ep_dir.mkdir(parents=True, exist_ok=True)
+        vk = "observation.images.cam1"
+        columns = {
+            "episode_index": [0, 1],
+            "length": [3, 4],
+            f"videos/{vk}/chunk_index": [0, 0],
+            f"videos/{vk}/file_index": [0, 0],  # both episodes -> file 0
+        }
+        pq.write_table(pa.table(columns), ep_dir / "episodes_000.parquet")
+        info = {
+            "total_episodes": 2,
+            "total_frames": 7,
+            "features": {vk: {"dtype": "video", "shape": [3, 64, 64], "names": ["channels", "height", "width"]}},
+            "video_path": "videos/{video_key}/chunk-{chunk_index:03d}/file-{file_index:03d}.mp4",
+        }
+        (tmp_path / "meta" / "info.json").write_text(json.dumps(info), encoding="utf-8")
+        rel = tmp_path / "videos/observation.images.cam1/chunk-000/file-000.mp4"
+
+        _write_real_mp4(rel, n_frames=7)  # exactly the summed length
+        assert verify_dataset(tmp_path)["status"] == "success"
+
+        _write_real_mp4(rel, n_frames=6)  # one frame short of the packed total
+        report = verify_dataset(tmp_path)
+        assert report["status"] == "error"
+        assert any("6 frame(s)" in p and "maps 7 frame(s)" in p for p in report["problems"]), report["problems"]
+
+    def test_missing_length_column_skips_frame_check(self, tmp_path: Path) -> None:
+        pytest.importorskip("av")
+        # No ``length`` column -> expected frames are unknown, so the frame-count
+        # comparison is skipped even though the MP4 is "wrong" (2 frames).
+        _write_video_dataset(
+            tmp_path,
+            episode_indices=[0],
+            video_keys=["observation.images.cam1"],
+            frames_per_episode=None,
+            write_files=set(),
+        )
+        _write_real_mp4(
+            tmp_path / "videos/observation.images.cam1/chunk-000/file-000.mp4",
+            n_frames=2,
+        )
+        assert verify_dataset(tmp_path)["status"] == "success"
+
+    def test_unreadable_header_does_not_false_positive(self, tmp_path: Path) -> None:
+        # A non-empty file whose frame count can't be read (placeholder bytes /
+        # a codec header without nb_frames) must NOT be flagged - the check is
+        # best-effort and only reports a confidently-read mismatch.
+        _write_video_dataset(
+            tmp_path,
+            episode_indices=[0],
+            video_keys=["observation.images.cam1"],
+            frames_per_episode=[5],  # real count is unknowable from placeholder bytes
+        )
+        report = verify_dataset(tmp_path)
+        assert report["status"] == "success", report["problems"]
+
+
 class TestMetadataEdgeCases:
     """Metadata-side validation paths beyond count/drift on a healthy dataset.
 


### PR DESCRIPTION
## Problem

`verify_dataset` (`strands-robots verify-dataset`) is the dataset-integrity gate. Check 5 already catches the video-modality corruption class where a dataset has correct episode counts but the pixels are gone — **missing** files and **empty** (0-byte) files. But a **present, non-empty** MP4 whose decoded frame count is *fewer* than the frames the parquet records passed silently:

- correct episode counts, a real non-empty file, but **missing pixels** — the exact "correct counts, no pixels" class the module's own docstring says it exists to catch.
- happens when the video encoder crashes mid-episode, the files are partially synced/copied, or a write is interrupted, leaving a truncated stream.

This is the frame-count sibling of the missing/empty-video and dead-column checks the module already performs.

### Reproduction (real recorded dataset)

Record a 2-episode SO-101 dataset in MuJoCo (40 frames, cameras `camera1`/`camera2`), then re-encode `camera1`'s MP4 down to 5 frames (still a valid, non-empty file):

```
# before this change
verify_dataset(root) -> status='success', problems=[]   # truncation missed
```

The episode/length/info.json checks all pass; the pixels are 87% gone and nothing flags it.

## Change

Check 5 now also compares each video file's frame count against the frames the parquet maps into it:

- The expected count per `(camera, chunk, file)` is the **sum of the `length`** of every episode packed into that file. LeRobot v3 concatenates whole episodes into one shared file per camera, so a file must hold exactly that sum.
- The actual count is read from the **container header via PyAV (`av`)** — `stream.frames`, no full decode, so it's cheap. `av` ships with the lerobot extra alongside the `pyarrow` this module already uses.
- **Best-effort, no false positives:** the comparison is skipped when `av` is unavailable, when any packed episode carries no `length` (the column is optional in some writers), or when the codec header omits the frame count (`_video_frame_count` returns `None` = "cannot confirm", never "zero"). Only a confidently-read mismatch is reported.
- Gated by the existing `check_videos` flag (`--no-check-videos` opts out).

```
# after this change
verify_dataset(root) -> status='error'
  problems=["video file for 'observation.images.camera1' has 5 frame(s) but the
            parquet maps 40 frame(s) to it: .../file-000.mp4 - truncated /
            partial encode (correct episode counts, non-empty file, missing pixels)"]
```

A healthy dataset still passes with `status='success'`, `problems=[]`.

## Tests

`tests/test_verify_dataset.py::TestVideoFrameCountIntegrity` (real MP4s written with `av`, `pytest.importorskip("av")`):
- `test_matching_frame_count_passes` — frame count == recorded length passes.
- `test_truncated_video_fails` — a 2-frame MP4 for a 5-frame episode is flagged; the episode-count check still passes (proving it's the new frame-count check that catches it). **Fails before this change, passes after.**
- `test_packed_multi_episode_file_sums_lengths` — two whole episodes packed into one shared file (the real recorder layout): 7 frames pass, 6 fail against the summed length `3+4`. **Fails before, passes after.**
- `test_missing_length_column_skips_frame_check` — no `length` column ⇒ expected unknown ⇒ skipped (no false positive).
- `test_unreadable_header_does_not_false_positive` — a non-empty file whose header can't be read is not flagged.

Full `tests/test_verify_dataset.py` + `test_dataset_recorder.py` + `test_streaming_dataset.py`: 166 passed. `ruff check`/`ruff format --check`/`mypy` clean on the changed files.

## Notes

Docs updated: the module docstring (Check 5), `verify_dataset`'s inline check comment, and `_verify_video_files`'s docstring all describe the frame-count sub-check. No new dependency (`av` is already part of the lerobot extra); a graceful skip preserves behaviour where it's absent.

---

### Round 1 changelog

- Rebased onto `main` to resolve a `CHANGELOG.md` conflict introduced when #1076 merged (both PRs added an `### Added:` entry under `[Unreleased]`). Resolution keeps both entries in order; the code diff (`verify_dataset.py`, `test_verify_dataset.py`) is byte-identical to the previously approved revision. The force-push auto-dismissed the prior approval — re-approval (not a full re-review) is all that is needed.