### PR TITLE
docs(sim): cross-reference MuJoCo backend siblings by module, not source filename

### DIFF
--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -135,7 +135,7 @@ class PhysicsMixin:
     reads/writes MuJoCo arrays directly for checkpointing, raycasts,
     jacobians, joint control, sensor readout, etc.
 
-    **Coupling** (see simulation.py top-level docstring): mixin reaches
+    **Coupling** (see the :mod:`simulation` top-level docstring): mixin reaches
     into ``self._world``, ``self._lock``, and the host's
     ``_require_no_running_policy`` / ``_require_world`` / ``_prune_done_futures``
     helpers. ``TYPE_CHECKING`` stubs below exist so mypy accepts those

--- a/strands_robots/simulation/mujoco/randomization.py
+++ b/strands_robots/simulation/mujoco/randomization.py
@@ -17,7 +17,7 @@ class RandomizationMixin:
     inertia scale, so randomized bodies stay physically consistent) and geom
     friction by a random factor inside a user-supplied range.
 
-    **Coupling** (see simulation.py top-level docstring): mixin reaches
+    **Coupling** (see the :mod:`simulation` top-level docstring): mixin reaches
     into ``self._world``, ``self._lock``, and the host's
     ``_require_no_running_policy`` / ``_require_world`` helpers. ``TYPE_CHECKING``
     stubs below exist so mypy accepts those lookups; they are a

--- a/strands_robots/simulation/mujoco/recording.py
+++ b/strands_robots/simulation/mujoco/recording.py
@@ -26,10 +26,10 @@ class RecordingMixin(DatasetRecordingMixin):
     ``start_recording`` reads the live ``MjModel`` to enumerate joints and
     cameras (with their real render resolutions) before creating/resuming the
     LeRobotDataset. Per-step frames are fed by the ``on_frame`` hook built in
-    ``simulation.py``. Separately, ``start_cameras_recording`` dumps raw
+    :mod:`simulation`. Separately, ``start_cameras_recording`` dumps raw
     per-camera MP4s.
 
-    **Coupling** (see simulation.py top-level docstring): mixin reaches
+    **Coupling** (see the :mod:`simulation` top-level docstring): mixin reaches
     into ``self._world`` (trajectory buffer + dataset_recorder live in
     ``_world._backend_state``). ``TYPE_CHECKING`` stub below exists so mypy
     accepts the ``_world`` lookup; it is a documentary contract, not an

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -95,7 +95,7 @@ class RenderingMixin:
     Owns ``render``, ``render_depth``, ``render_all``, ``get_contacts``, and
     the low-level ``_apply_sim_action`` (MuJoCo ``ctrl[]`` write + mj_step).
 
-    **Coupling** (see simulation.py top-level docstring): mixin reaches
+    **Coupling** (see the :mod:`simulation` top-level docstring): mixin reaches
     into ``self._world``, ``self._renderer_tls``, ``self._renderer_model``,
     ``self.default_width`` / ``self.default_height``, ``self._lock`` and
     ``self._viewer_handle``. ``TYPE_CHECKING`` stubs below exist so mypy
@@ -1567,7 +1567,7 @@ class RenderingMixin:
         distinct from the script main).
 
         Symptoms of the daemon-thread bug this fixes (#191):
-        ``run_mujoco_agent.py --policy=groot`` measured 2-3% frame
+        a threaded MuJoCo agent driver measured 2-3% frame
         capture rate vs the programmatic single-thread driver, with
         visible greenish GL clear-colour gradient frames at episode
         boundaries. The synchronous mode trades the daemon thread for a

--- a/strands_robots/simulation/mujoco/scene_ops.py
+++ b/strands_robots/simulation/mujoco/scene_ops.py
@@ -22,7 +22,7 @@ Public API:
 
 Every function takes a ``SimWorld`` whose ``_backend_state["spec"]`` holds the
 live ``MjSpec``. They return ``True`` on success, ``False`` on failure (matching
-the legacy API) so call sites in ``simulation.py`` don't need to change.
+the legacy API) so call sites in :mod:`simulation` don't need to change.
 """
 
 from __future__ import annotations

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -5,8 +5,8 @@ Architecture notes (honest version, see GH #118)
 The ``Simulation`` class uses multiple-inheritance to compose four mixins
 (``PhysicsMixin``, ``RenderingMixin``, ``RecordingMixin``, ``RandomizationMixin``)
 on top of the ``SimEngine`` ABC and the Strands ``AgentTool`` base. The
-split keeps each file navigable (physics.py ~1150 lines, rendering.py ~730,
-etc.) but the mixin boundaries describe *where code lives*, NOT the
+split keeps each module navigable (:mod:`physics` ~1150 lines,
+:mod:`rendering` ~730, etc.) but the mixin boundaries describe *where code lives*, NOT the
 coupling graph.
 
 Every mixin reaches back into this class for the same shared state:
@@ -331,7 +331,7 @@ class MuJoCoSimEngine(
         rather than silently truncated.
 
         Thread-safety: acquires self._lock around ctrl writes + mj_step,
-        as documented in base.py's SimEngine contract. Concurrent calls
+        as documented in the :class:`~strands_robots.simulation.base.SimEngine` contract. Concurrent calls
         from the agent's dispatch thread and a PolicyRunner worker are
         serialized here.
 
@@ -623,7 +623,7 @@ class MuJoCoSimEngine(
         Stashes the live ``MjSpec`` in ``_backend_state["spec"]`` so every
         subsequent scene mutation uses ``spec.recompile(model, data)`` in
         place - that preserves existing joint state automatically, replacing
-        the legacy XML-round-trip helpers in ``scene_ops.py``.
+        the legacy XML-round-trip helpers in :mod:`scene_ops`.
 
         Also exports ``spec.to_xml()`` to ``_backend_state["xml"]`` for any
         consumer that still reads the raw MJCF string (e.g. ``load_scene``
@@ -658,7 +658,7 @@ class MuJoCoSimEngine(
         This is the "nuke and pave" path used when the world config changes
         in a way that can't be expressed as a spec mutation (e.g. clearing
         every body). For incremental changes (add/remove body, camera),
-        prefer ``_recompile_preserving_state`` in ``scene_ops.py`` which
+        prefer ``_recompile_preserving_state`` in :mod:`scene_ops` which
         goes through ``spec.recompile(model, data)`` and preserves joint
         state.
         """

--- a/strands_robots/simulation/mujoco/spec_builder.py
+++ b/strands_robots/simulation/mujoco/spec_builder.py
@@ -2,7 +2,7 @@
 
 This is the ONLY path for building / mutating MuJoCo scenes in strands-robots.
 It replaces the string-concat ``MJCFBuilder`` (deleted) and the XML-round-trip
-helpers in ``scene_ops.py``:
+helpers in :mod:`scene_ops`:
 
 - ``SpecBuilder.build(world)``: build a fresh ``MjSpec`` from a ``SimWorld``.
 - ``add_object`` / ``remove_body`` / ``add_camera``: mutate an existing spec.

--- a/tests/simulation/mujoco/test_docstring_module_xrefs.py
+++ b/tests/simulation/mujoco/test_docstring_module_xrefs.py
@@ -1,0 +1,54 @@
+"""Docstrings in the MuJoCo backend package must cross-reference sibling code by
+module, never by source filename.
+
+Referencing a source file (``scene_ops.py``, ``simulation.py``, ...) in a
+docstring is documentation archaeology: the name breaks silently the moment a
+file is renamed or split, and it points a reader at a path instead of an
+importable symbol. The project convention (see the cosmos3 policy package) is
+to use Sphinx cross-reference roles - ``:mod:``, ``:class:``, ``:func:`` - that
+name the actual API object, so the reference is checkable and survives refactors.
+
+This guard walks every module/class/function docstring under
+``strands_robots.simulation.mujoco`` and fails if any of them embeds a
+``<something>.py`` filename token.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import strands_robots.simulation.mujoco as mujoco_pkg
+
+# A bare source-filename token such as ``scene_ops.py`` or ``run_agent.py``.
+_FILENAME_RE = re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*\.py\b")
+
+_PACKAGE_DIR = Path(mujoco_pkg.__file__).parent
+
+
+def _docstrings_with_offenders() -> dict[str, list[str]]:
+    """Map ``module.py::qualname`` -> filename tokens found in that docstring."""
+    offenders: dict[str, list[str]] = {}
+    for source_file in sorted(_PACKAGE_DIR.glob("*.py")):
+        tree = ast.parse(source_file.read_text(encoding="utf-8"), filename=str(source_file))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Module | ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            doc = ast.get_docstring(node, clean=False)
+            if not doc:
+                continue
+            hits = _FILENAME_RE.findall(doc)
+            if hits:
+                qualname = getattr(node, "name", "<module>")
+                offenders[f"{source_file.name}::{qualname}"] = hits
+    return offenders
+
+
+def test_mujoco_docstrings_reference_modules_not_filenames() -> None:
+    offenders = _docstrings_with_offenders()
+    assert not offenders, (
+        "MuJoCo backend docstrings must cross-reference siblings by module "
+        "(:mod:`scene_ops`) not source filename (``scene_ops.py``). Offending "
+        f"docstrings: {offenders}"
+    )


### PR DESCRIPTION
## Problem
Docstrings across the MuJoCo backend package (`strands_robots/simulation/mujoco/`) referenced sibling code by **source filename** rather than by module. Concretely:

- `physics.py`, `randomization.py`, `recording.py`, `rendering.py` mixins: `see simulation.py top-level docstring`
- `scene_ops.py` / `spec_builder.py` module docstrings: `call sites in simulation.py` / `helpers in scene_ops.py`
- `simulation.py`: `physics.py ~1150 lines, rendering.py ~730`, `base.py's SimEngine contract`, `_recompile_preserving_state in scene_ops.py`
- `rendering.py::start_cameras_recording_synchronous`: cited `run_mujoco_agent.py` — a script that no longer exists anywhere in the tree.

A filename reference breaks silently the moment a file is renamed or split, and points a reader at a path instead of an importable symbol.

## Change
Replace the filename references with Sphinx cross-reference roles (`:mod:`, `:class:`) that name the actual API object, so references are checkable and survive refactors. This matches the convention already used in the cosmos3 policy package. The phantom `run_mujoco_agent.py` mention is rephrased to describe the threaded driver generically (no fictional path).

No code behavior changes — docstrings only, plus one guard test.

## Regression test
`tests/simulation/mujoco/test_docstring_module_xrefs.py` walks every module/class/function docstring under `strands_robots.simulation.mujoco` and fails if any embeds a `<name>.py` filename token. It fails on the pre-change tree (catches all 11 offending docstrings) and passes after, locking in the convention package-wide.

## Verification
- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ`: clean (no issues found in 670 source files).
- `MUJOCO_GL=egl pytest tests/simulation/mujoco/` (headless): the new guard passes; all other tests unaffected.