### PR TITLE
test(device-connect): pin fail-closed authorization across all Reachy Mini mutating RPCs

### DIFF
--- a/tests/test_reachy_mini_driver.py
+++ b/tests/test_reachy_mini_driver.py
@@ -12,7 +12,7 @@ end to end with all I/O mocked (no hardware, daemon, or network):
 - REST move/lifecycle RPCs (listMoves / wakeUp / sleep / stopMotion /
   getDaemonStatus) and the paths they hit.
 - Expression sequences (nod / shake / happy) with sleep stubbed out.
-- Caller authorization gating on a state-mutating RPC.
+- Caller-authorization fail-closed gating across the full mutating RPC surface.
 - ``onEmergencyStop`` acting only on an allowlisted source.
 
 These use the REAL device_connect_edge package so the @rpc caller-identity
@@ -296,13 +296,48 @@ def test_expression_returns_to_neutral(rmd, method, expression):
 # -- caller authorization ---------------------------------------------------
 
 
-def test_movement_rpc_denied_for_unlisted_caller(rmd, monkeypatch):
+# Every state-mutating RPC (real-time head/antenna/body commands, motor
+# torque toggles, recorded-move playback, expression sequences, and the
+# REST move/lifecycle calls) must consult the caller allowlist. Read-only
+# RPCs (getJoints / getImu / listMoves / getDaemonStatus) are intentionally
+# ungated and excluded here.
+_MUTATING_RPCS = [
+    ("look", {"pitch": 5}),
+    ("antennas", {"left": 10, "right": -10}),
+    ("body", {"yaw": 15}),
+    ("enableMotors", {"motor_ids": "1,2"}),
+    ("disableMotors", {"motor_ids": ""}),
+    ("playMove", {"move_name": "wave"}),
+    ("nod", {}),
+    ("shake", {}),
+    ("happy", {}),
+    ("wakeUp", {}),
+    ("sleep", {}),
+    ("stopMotion", {}),
+]
+
+
+@pytest.mark.parametrize(("method", "kwargs"), _MUTATING_RPCS, ids=[m for m, _ in _MUTATING_RPCS])
+def test_mutating_rpc_denied_for_unlisted_caller(rmd, monkeypatch, method, kwargs):
+    """Every mutating RPC fail-closes on an unauthorized caller.
+
+    With an allowlist configured and an anonymous caller (no source_device),
+    each state-mutating RPC must return the standard authorization error and
+    issue neither a real-time hardware command nor a daemon REST call. This
+    pins the contract for the whole mutating surface so a new RPC that forgets
+    the gate cannot slip through with only ``look`` covered.
+    """
     monkeypatch.setenv("DEVICE_CONNECT_RPC_ALLOW", "trusted-*")
     drv = _bare(rmd, _hw=AsyncMock())
-    res = _run(drv.look(pitch=5))
+    with patch.object(rmd, "api", MagicMock()) as fake_api, patch.object(rmd.asyncio, "sleep", AsyncMock()):
+        res = _run(getattr(drv, method)(**kwargs))
     assert res["status"] == "error"
     assert "not authorized" in res["reason"]
+    # The rejection names the specific RPC that was denied.
+    assert method in res["reason"]
+    # Fail-closed: no physical command and no daemon REST call may fire.
     drv._hw.send_cmd.assert_not_awaited()
+    fake_api.assert_not_called()
 
 
 # -- emergency stop ---------------------------------------------------------


### PR DESCRIPTION
## Problem

`ReachyMiniDriver` gates every state-mutating RPC on the caller allowlist:

```python
caller = get_rpc_source_device()
if not is_authorized_caller(caller, scope="rpc"):
    return authz_error(caller, "<rpc>")
```

But only `look()` had a regression test for the denial path. The other eleven mutating RPCs (`antennas`, `body`, `enableMotors`, `disableMotors`, `playMove`, `nod`, `shake`, `happy`, `wakeUp`, `sleep`, `stopMotion`) enforced the same gate with no test. That is a thin guard for a security-relevant contract: a newly added RPC that forgot the allowlist check could ship, and the suite would stay green because only `look()` was pinned.

## Change

Replace the single-RPC `test_movement_rpc_denied_for_unlisted_caller` with a parametrized `test_mutating_rpc_denied_for_unlisted_caller` that exercises the entire mutating surface. With `DEVICE_CONNECT_RPC_ALLOW` configured and an anonymous caller (fail-closed), each RPC must:

- return the standard authorization error (`status == "error"`, reason contains `not authorized` and names the specific RPC), and
- issue neither a real-time hardware command (`_hw.send_cmd`) nor a daemon REST call (`api`).

Read-only RPCs (`getJoints` / `getImu` / `listMoves` / `getDaemonStatus`) are intentionally ungated and excluded.

## Coverage

`strands_robots/device_connect/reachy_mini_driver.py`: the 11 previously-uncovered authorization branches (lines 143, 156, 201, 215, 232, 268, 282, 296, 312, 327, 342) are now exercised. Module coverage rises from 93% toward ~99% (only the abstract `onEmergencyStop` stub remains).

## Tests

```
python -m pytest tests/test_reachy_mini_driver.py -q
41 passed
```

Lint gate clean: `ruff check` + `ruff format --check` + `mypy` over `strands_robots tests tests_integ` pass. Test-only change; no production code touched.