### PR TITLE
fix(sim): move_object places a dynamic object at rest at the new pose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -579,6 +579,21 @@ purpose. Each row now carries an ASCII marker: `[ok]` when the robot's assets
 are present, `[--]` when missing. The summary count line and cache path are
 unchanged.
 
+### Fixed: `move_object` retained a dynamic object's velocity, so a repositioned object kept its prior momentum
+
+The dynamic-object path of `move_object` (objects with a freejoint) wrote the
+new pose into `data.qpos` but never touched the freejoint's 6 velocity DOF, so
+a bare position/orientation write left the object's prior linear and angular
+velocity intact. A repositioned object therefore kept whatever momentum it had:
+a settling object teleported to its new pose and immediately shot off, and an
+eval/benchmark loop that repositions objects between episodes started each
+episode with the object drifting from its "placed" pose (silently
+non-reproducible). The dynamic path now zeroes the freejoint velocity so the
+object is placed **at rest** at the new pose, matching `add_object` (spawns at
+rest), `reset` (zeroes velocities), and the Newton backend (rebuilds from the
+builder at rest). A `move_object` call with neither `position` nor `orientation`
+remains a true no-op and leaves velocity untouched.
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1650,7 +1650,9 @@ class MuJoCoSimEngine(
         Two paths, transparent to the caller:
 
         * **Dynamic objects** (``is_static=False``, created with a freejoint)
-          are moved cheaply by writing ``data.qpos`` + a forward pass.
+          are moved cheaply by writing ``data.qpos`` + a forward pass. The
+          object is placed **at rest** at the new pose (its freejoint velocity
+          is zeroed), consistent with ``add_object`` and ``reset``.
         * **Static objects** (``is_static=True``, welded to the worldbody with
           no DOF) cannot be moved through ``data.qpos``; they are repositioned
           by editing the spec body pose and recompiling the scene (preserving
@@ -1676,12 +1678,27 @@ class MuJoCoSimEngine(
             # Dynamic object: a freejoint carries its pose, so move it cheaply
             # through data.qpos + a forward pass (no recompile).
             qpos_addr = model.jnt_qposadr[jnt_id]
+            moved = False
             if position:
                 data.qpos[qpos_addr : qpos_addr + 3] = position
                 self._world.objects[name].position = position
+                moved = True
             if orientation:
                 data.qpos[qpos_addr + 3 : qpos_addr + 7] = orientation
                 self._world.objects[name].orientation = orientation
+                moved = True
+            if moved:
+                # Place the object AT REST at the new pose. A freejoint retains
+                # its 6-DOF linear+angular velocity across a bare data.qpos
+                # write, so without this a repositioned object keeps its prior
+                # momentum: a settling object teleports and immediately shoots
+                # off, and an eval/benchmark loop that repositions objects
+                # between episodes starts each episode with the object drifting
+                # (silently non-reproducible). This matches add_object (spawns
+                # at rest), reset (zeroes velocities), and the Newton backend
+                # (rebuilds from the builder at rest).
+                dof_addr = model.jnt_dofadr[jnt_id]
+                data.qvel[dof_addr : dof_addr + 6] = 0.0
             mj.mj_forward(model, data)
         elif position is not None or orientation is not None:
             # Static object: welded to the worldbody with no freejoint, so it

--- a/tests/simulation/mujoco/test_move_object_places_at_rest.py
+++ b/tests/simulation/mujoco/test_move_object_places_at_rest.py
@@ -1,0 +1,98 @@
+"""Regression tests: ``move_object`` places a dynamic object AT REST at the new pose.
+
+A dynamic object (``is_static=False``) carries its pose on a freejoint whose
+6 velocity DOF (3 linear + 3 angular) live at ``data.qvel[dof_addr : dof_addr+6]``.
+Writing ``data.qpos`` to reposition the body does NOT touch that velocity, so a
+freejoint retains whatever momentum it had. Without an explicit reset,
+``move_object`` teleports the body's *position* while leaving its prior velocity
+intact - a settling object shoots off the instant it is "placed", and an
+eval/benchmark loop that repositions objects between episodes starts each
+episode with the object drifting (silently non-reproducible).
+
+The contract these pin: ``move_object`` places the object at rest at the new
+pose, matching ``add_object`` (spawns at rest), ``reset`` (zeroes velocities),
+and the Newton backend (rebuilds from the builder at rest). They assert the
+observable physical state (``data.qvel`` and the post-step trajectory), not the
+internal write.
+"""
+
+import math
+
+import pytest
+
+mj = pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="test_move_object_at_rest_sim", mesh=False)
+    s.create_world(gravity=[0, 0, -9.81])
+    yield s
+    s.cleanup()
+
+
+def _freejoint_qvel(world, name):
+    """Return the 6-DOF freejoint velocity [vx,vy,vz, wx,wy,wz] of an object."""
+    m, d = world._model, world._data
+    jid = mj.mj_name2id(m, mj.mjtObj.mjOBJ_JOINT, f"{name}_joint")
+    assert jid >= 0, f"freejoint for {name!r} not found"
+    adr = m.jnt_dofadr[jid]
+    return [float(v) for v in d.qvel[adr : adr + 6]]
+
+
+def test_position_move_zeroes_velocity(sim):
+    """A position move zeroes the object's velocity so it is placed at rest.
+
+    Let a cube fall to build a real downward velocity, then reposition it. Its
+    freejoint velocity must be zero afterwards, so it starts falling FROM REST
+    rather than continuing at its prior speed.
+    """
+    sim.add_object("cube", shape="box", size=[0.03, 0.03, 0.03], position=[0.0, 0.0, 0.6], is_static=False)
+    sim.step(40)
+    vel_before = _freejoint_qvel(sim._world, "cube")
+    assert abs(vel_before[2]) > 0.3, f"cube should have gained downward velocity, got {vel_before}"
+
+    result = sim.move_object("cube", position=[0.0, 0.0, 0.6])
+    assert result["status"] == "success", result
+
+    vel_after = _freejoint_qvel(sim._world, "cube")
+    assert vel_after == pytest.approx([0.0] * 6, abs=1e-9), f"expected at rest, got {vel_after}"
+
+    # One step of free fall from rest imparts only g*dt (~0.0196 m/s at dt=2ms),
+    # not the ~0.8 m/s the object carried before the move.
+    sim.step(1)
+    assert abs(_freejoint_qvel(sim._world, "cube")[2]) < 0.1
+
+
+def test_orientation_move_zeroes_angular_velocity(sim):
+    """An orientation move zeroes angular (and linear) velocity too."""
+    sim.add_object("cube", shape="box", size=[0.03, 0.03, 0.03], position=[0.0, 0.0, 0.6], is_static=False)
+    # Inject a spin + drift directly onto the freejoint, then settle one step.
+    m, d = sim._world._model, sim._world._data
+    jid = mj.mj_name2id(m, mj.mjtObj.mjOBJ_JOINT, "cube_joint")
+    adr = m.jnt_dofadr[jid]
+    d.qvel[adr : adr + 6] = [0.5, 0.0, 0.0, 0.0, 0.0, 3.0]
+    mj.mj_forward(m, d)
+    assert any(abs(v) > 0.1 for v in _freejoint_qvel(sim._world, "cube"))
+
+    quat = [math.cos(math.pi / 4), 0.0, 0.0, math.sin(math.pi / 4)]
+    result = sim.move_object("cube", orientation=quat)
+    assert result["status"] == "success", result
+
+    assert _freejoint_qvel(sim._world, "cube") == pytest.approx([0.0] * 6, abs=1e-9)
+
+
+def test_no_arg_move_does_not_zero_velocity(sim):
+    """A move_object call with neither position nor orientation leaves velocity
+    untouched - it is a genuine no-op, not a stealth 'freeze'."""
+    sim.add_object("cube", shape="box", size=[0.03, 0.03, 0.03], position=[0.0, 0.0, 0.6], is_static=False)
+    sim.step(40)
+    vel_before = _freejoint_qvel(sim._world, "cube")
+    assert abs(vel_before[2]) > 0.3
+
+    result = sim.move_object("cube")
+    assert result["status"] == "success", result
+
+    assert _freejoint_qvel(sim._world, "cube")[2] == pytest.approx(vel_before[2], abs=1e-6)


### PR DESCRIPTION
## Problem

The dynamic-object path of `Simulation.move_object` (objects carried on a freejoint) writes the new pose into `data.qpos` but never touches the freejoint's 6 velocity DOF. A bare position/orientation write therefore leaves the object's prior linear and angular velocity intact, so a repositioned object keeps whatever momentum it had:

- a settling / falling object teleports to its new pose and immediately shoots off from it;
- an eval/benchmark loop that repositions objects between episodes starts each episode with the object drifting away from its "placed" pose, making episode initial conditions silently non-reproducible.

Meanwhile `world.objects[name].position` is updated to the new pose, so the reported state claims the object is placed there while the physics has it moving.

### Ground truth (real MuJoCo sim, `MUJOCO_GL=egl`)

Give a cube a lateral velocity, let it travel, then reposition it to a fixed point and step 60 frames:

| | final drift from placement point |
|---|---|
| before | `+0.168 m` |
| after  | `+0.000 m` |

## Fix

When a pose is actually applied, zero the moved freejoint's 6 velocity DOF so the object is placed **at rest** at the new pose. This matches the contract of the sibling code paths:

- `add_object` spawns objects at rest;
- `reset` zeroes all velocities;
- the Newton backend's `move_object` rebuilds from the builder (at rest).

A `move_object` call with neither `position` nor `orientation` remains a true no-op and leaves velocity untouched (not a stealth freeze). The static-object path is unaffected (welded, no freejoint).

## Tests

`tests/simulation/mujoco/test_move_object_places_at_rest.py` (asserts observable `data.qvel` + post-step trajectory, not the internal write):
- position move zeroes velocity (object starts from rest, not its prior ~0.8 m/s) — **fails before, passes after**;
- orientation move zeroes angular+linear velocity — **fails before, passes after**;
- no-arg move leaves velocity untouched (true no-op) — passes before and after.

Gate: `ruff` + `ruff format` + `mypy` clean; `tests/simulation/mujoco/` + facade/foundation suites = 1183 passed, 1 skipped.

## Rollout (MuJoCo sim, headless)

LEFT = before (retains velocity, drifts off the placement point); RIGHT = after (placed at rest, stays put). Same setup, same lateral kick.

![move_object at-rest demo](https://github.com/cagataycali/robots/releases/download/artifacts-move-object-at-rest/move_object_at_rest.gif)