### PR TITLE
security(device_connect): deny-by-default when no allowlist configured

### DIFF
--- a/strands_robots/device_connect/_authz.py
+++ b/strands_robots/device_connect/_authz.py
@@ -114,10 +114,20 @@ def is_authorized_caller(caller: str | None, *, scope: str = "rpc") -> bool:
 
     patterns = _parse_allowlist(raw)
     if patterns is None:
-        # No allowlist configured - preserve out-of-the-box dev usability but
-        # make the permissive posture loud so operators notice.
-        _warn_permissive_once(env_scope)
-        return True
+        # No allowlist configured. Deny by default to prevent unintentional
+        # open access. Operators must explicitly set an allowlist (use "*" for
+        # the old permit-all behavior during development).
+        if env_scope not in _warned_permissive:
+            _warned_permissive.add(env_scope)
+            logger.error(
+                "Device Connect %s DENIED: no %s allowlist configured. "
+                "Set %s="*" to permit all callers (dev/lab only), or list "
+                "specific device ids to restrict access.",
+                env_scope,
+                _RPC_ALLOW_ENV if env_scope == "rpc" else _ESTOP_ALLOW_ENV,
+                _RPC_ALLOW_ENV if env_scope == "rpc" else _ESTOP_ALLOW_ENV,
+            )
+        return False
 
     # An allowlist is configured. If the transport is insecure the caller id is
     # self-asserted, so the allowlist is advisory - say so once, loudly.


### PR DESCRIPTION
## Summary

Change `is_authorized_caller()` to return `False` (instead of `True`) when no `DEVICE_CONNECT_RPC_ALLOW` allowlist is configured.

- When `DEVICE_CONNECT_RPC_ALLOW` is unset, callers are now **denied** instead of permitted
- Error message directs operators to configure the allowlist
- Operators set `DEVICE_CONNECT_RPC_ALLOW=*` for the previous permit-all behavior (dev/lab)

## Design choice caveat — BREAKING CHANGE against documented behavior

**The current permit-all default is an explicitly documented and tested design choice:**

1. **Code comment** (`_authz.py:117`): `"No allowlist configured - preserve out-of-the-box dev usability but make the permissive posture loud so operators notice."`
2. **Test** (`test_device_connect_hardening.py:269`): `test_permissive_when_no_allowlist` — `"Out-of-the-box: no allowlist => allowed (with a logged warning)."`
3. **`docs/security.md`** mesh section: `"The example scripts run the mesh without authentication or access controls so they work out of the box."`

The project deliberately chose default-open with a loud warning for out-of-box developer experience. This PR reverses that choice in favor of fail-closed security.

**This is a proposal for the project team to evaluate.** The tradeoff:

| Approach | Pro | Con |
|----------|-----|-----|
| Current (default-open + warning) | Zero-config dev experience, examples work immediately | Any network peer can execute/stop/reset robots without auth |
| This PR (default-deny) | Fail-closed — no unintentional open access | Breaking change: existing deployments with no allowlist will fail. `test_permissive_when_no_allowlist` will need updating. |

**If the team prefers the current behavior**, the security impact to be aware of: out of the box, `is_authorized_caller(None)` returns `True`, meaning any unauthenticated caller (including anonymous/spoofed identities under insecure transport) can invoke `execute()`, `stop()`, `reset()`, and `emergencyStop` on physical robots.

**A middle ground** would be: keep default-open for `STRANDS_MESH_LOCAL_DEV=1` only, and default-deny otherwise. This preserves the dev experience for localhost work while closing the gap for deployments that forgot to configure an allowlist.

## Finding detail

| Severity | CWE | Attack |
|----------|-----|--------|
| HIGH (CWE-276) | Incorrect default permissions | PoC: `is_authorized_caller(None)` → `True` by default. Any network peer sends `execute("move arm to [0,0,0,0,0,0]")` without auth |

## Test plan

- [ ] Verify `is_authorized_caller(None)` returns `False` when env unset
- [ ] Verify `DEVICE_CONNECT_RPC_ALLOW=*` permits all (backwards compat)
- [ ] Verify `DEVICE_CONNECT_RPC_ALLOW=robot-1,robot-2` permits only listed callers
- [ ] Update `test_permissive_when_no_allowlist` to expect denial

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)