### PR TITLE
test(training): pin the hardware_floor advisory contract across all trainers

### DIFF
--- a/tests/training/test_factory.py
+++ b/tests/training/test_factory.py
@@ -159,6 +159,34 @@ class TestLifecycle:
         assert floor["multinode"] is False
 
 
+class TestHardwareFloorContract:
+    """Every registered trainer's ``hardware_floor`` honors the ABC contract.
+
+    ``Trainer.hardware_floor`` powers the ``plan`` advisor: :meth:`Trainer.validate`
+    checks a spec's requested resources against it, so a floor that omits a key
+    or returns the wrong type would break feasibility checking for the whole
+    provider family. The advisory keys are ``min_gpus`` (int), ``min_vram_gb``
+    (int), and ``multinode`` (bool); GPU/VRAM counts must be non-negative.
+    """
+
+    @pytest.mark.parametrize("provider", list_trainers())
+    def test_floor_shape_and_types(self, provider):
+        floor = create_trainer(provider).hardware_floor
+
+        assert isinstance(floor, dict), f"{provider} hardware_floor is not a dict"
+        assert {"min_gpus", "min_vram_gb", "multinode"} <= set(floor), (
+            f"{provider} hardware_floor is missing advisory keys: {sorted(floor)}"
+        )
+
+        # bool is a subclass of int, so reject it explicitly for the counts.
+        assert isinstance(floor["min_gpus"], int) and not isinstance(floor["min_gpus"], bool)
+        assert isinstance(floor["min_vram_gb"], int) and not isinstance(floor["min_vram_gb"], bool)
+        assert isinstance(floor["multinode"], bool)
+
+        assert floor["min_gpus"] >= 0
+        assert floor["min_vram_gb"] >= 0
+
+
 class TestSpecTolerance:
     def test_unknown_extra_keys_do_not_break_validate(self, spec):
         """The **kwargs-style tolerance rule: unknown extras are ignored."""


### PR DESCRIPTION
## Problem

`Trainer.hardware_floor` is an advisory contract that powers the `plan` advisor: `Trainer.validate` checks a spec's requested resources against it, so a floor that omits an advisory key or returns the wrong type would silently break hardware-feasibility checking for a whole provider family.

The contract (from the ABC docstring) is a dict with `min_gpus` (int), `min_vram_gb` (int), and `multinode` (bool). But only `cosmos3`, `groot`, and the mock/default were covered by tests. The `lerobot_local`, `fast_sac`, and `ppo` `hardware_floor` returns were untested, and no test asserted the shape/type contract itself, so a future trainer could ship a malformed floor unnoticed.

## Change

Add a parametrized contract test over `list_trainers()` in `tests/training/test_factory.py` that constructs each registered trainer and asserts `hardware_floor`:

- is a `dict` carrying the `min_gpus` / `min_vram_gb` / `multinode` advisory keys,
- `min_gpus` and `min_vram_gb` are non-negative `int` (with `bool` explicitly rejected, since `bool` is a subclass of `int`),
- `multinode` is a `bool`.

## Tests

```
pytest tests/training/test_factory.py::TestHardwareFloorContract -v
6 passed
```

Parametrizes over all six trainers (`cosmos3`, `fast_sac`, `groot`, `lerobot_local`, `mock`, `ppo`). This covers the previously-uncovered `hardware_floor` returns in `lerobot_local` (`lerobot.py:256`), `fast_sac` (`fast_sac.py:447`), and `ppo` (`ppo.py:495`), and guards the contract for any future trainer. Full `tests/training/test_factory.py` (29 tests) passes; ruff check, ruff format, and mypy are clean.