### PR TITLE
fix(simulation): surface unresolvable body/joint names in the predicate & reward DSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -594,6 +594,25 @@ rest), `reset` (zeroes velocities), and the Newton backend (rebuilds from the
 builder at rest). A `move_object` call with neither `position` nor `orientation`
 remains a true no-op and leaves velocity untouched.
 
+### Fixed: benchmark/reward DSL silently swallowed unresolvable body/joint names
+
+A typo (or otherwise unresolvable name) in a benchmark success predicate or a
+reward-term body/joint used to be completely silent. On a backend that
+*supports* the lookup (`get_body_state` / `get_observation`), an unresolvable
+name made the term degrade to a constant with no diagnostic: a bool predicate
+to `False` (the episode silently never succeeds, indistinguishable from a
+failing policy) and a `distance_neg` / `joint_progress` reward to `0.0` -- which
+is that term's *maximum* (`-w * dist <= 0`), so a dead term pins at its ceiling
+and inflates the reported return. During a multi-hour RL run or a benchmark
+eval this quietly corrupts success rates and reward signals. The lookup helpers
+now log the unresolvable name once at `WARNING` (deduplicated so the hot loop
+never spams); returned values are unchanged. A missing lookup *method*
+(unsupported backend) stays silent -- that is a capability gap, not a spec typo.
+Additionally, `body_upright` now resolves the LIBERO `<name>_main` root-body
+convention (the `_body_position` fallback was never mirrored to the quaternion
+path), so `(upright X)` on a procedurally-generated LIBERO object no longer
+silently evaluates to `False`.
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/simulation/predicates.py
+++ b/strands_robots/simulation/predicates.py
@@ -18,6 +18,12 @@ backend does not support them. A predicate that silently evaluates to
 ``False`` because of an unimplemented backend call is a bug in the
 predicate, not the benchmark - file an issue.
 
+When the backend *does* support a lookup but the referenced ``body`` /
+``joint`` name cannot be resolved (almost always a spec typo), the term still
+degrades to a constant (``False`` / ``0.0``) but the offending name is logged
+once at ``WARNING`` (see :func:`_warn_unresolved`), so a broken spec surfaces
+instead of silently preventing episode success or emitting a dead reward.
+
 Available predicates (bool):
 
     body_above_z(body, z)
@@ -56,6 +62,45 @@ logger = logging.getLogger(__name__)
 BoolPredicate = Callable[["SimEngine"], bool]
 RewardTerm = Callable[["SimEngine"], float]
 PredicateFactory = Callable[..., Callable[["SimEngine"], Any]]
+
+
+# Names the DSL has already warned about, so a broken spec cannot spam the
+# reward/eval hot loop. Keyed by (kind, name); process-global and deduplicated.
+_RESOLUTION_WARNED: set[tuple[str, str]] = set()
+
+
+def _warn_unresolved(kind: str, name: str, tried: tuple[str, ...] = ()) -> None:
+    """Warn once that a spec references an entity the sim cannot resolve.
+
+    Called from the body/joint lookup helpers only when the backend *supports*
+    the lookup (``get_body_state`` / ``get_observation`` present) but the named
+    ``body``/``joint`` is not found - almost always a spec typo. The offending
+    term then degrades to a constant (a bool predicate to ``False``, a reward
+    term to ``0.0``), which silently prevents episode success or yields a dead,
+    return-inflating reward. Surfacing the name once turns that silent
+    corruption into an actionable log line without changing any returned value.
+    A missing lookup *method* (unsupported backend) is a capability gap, not a
+    typo, and stays silent.
+    """
+    key = (kind, name)
+    if key in _RESOLUTION_WARNED:
+        return
+    _RESOLUTION_WARNED.add(key)
+    extra = f" (tried {list(tried)})" if len(tried) > 1 else ""
+    logger.warning(
+        "predicate/reward DSL: %s %r is not present in the simulation%s; the "
+        "referencing term degrades to a constant (bool predicate -> False, "
+        "reward -> 0.0), which silently prevents success / yields a dead reward. "
+        "Check the name against the loaded scene / benchmark spec.",
+        kind,
+        name,
+        extra,
+    )
+
+
+def _reset_resolution_warnings() -> None:
+    """Clear the one-time-warning dedup cache (test isolation)."""
+    _RESOLUTION_WARNED.clear()
 
 
 # Helpers for digging values out of the structured ``{"status", "content"}``
@@ -121,10 +166,13 @@ def _body_position(sim: SimEngine, body: str) -> list[float] | None:
     # 2. LIBERO ``<name>_main`` convention (the root body of
     # procedurally-generated objects). Skip if the name already has
     # the suffix to avoid double-suffixing on retries.
+    tried = [body]
     if not body.endswith("_main"):
+        tried.append(f"{body}_main")
         pos = _try(f"{body}_main")
         if pos is not None:
             return pos
+    _warn_unresolved("body", body, tuple(tried))
     return None
 
 
@@ -146,6 +194,11 @@ def _joint_position(sim: SimEngine, joint: str) -> float | None:
     val = obs.get(joint)
     if isinstance(val, (int, float)) and not isinstance(val, bool):
         return float(val)
+    # The backend produced an observation but this joint is not in it: almost
+    # always a spec typo (an empty obs is a backend/capability gap, not a name
+    # error, so stay silent there).
+    if obs and joint not in obs:
+        _warn_unresolved("joint", joint)
     return None
 
 
@@ -159,17 +212,35 @@ def _body_quaternion(sim: SimEngine, body: str) -> list[float] | None:
     get_body_state = getattr(sim, "get_body_state", None)
     if get_body_state is None:
         return None
-    try:
-        result = get_body_state(body_name=body)
-    except Exception as e:  # noqa: BLE001 - defensive
-        logger.debug("body_quaternion(%r) failed: %s", body, e)
+
+    def _try(name: str) -> list[float] | None:
+        try:
+            result = get_body_state(body_name=name)
+        except Exception as e:  # noqa: BLE001 - defensive: predicates never raise
+            logger.debug("body_quaternion(%r) failed: %s", name, e)
+            return None
+        if not isinstance(result, dict) or result.get("status") != "success":
+            return None
+        payload = _extract_json(result)
+        quat = payload.get("quaternion")
+        if isinstance(quat, list) and len(quat) == 4 and all(isinstance(c, (int, float)) for c in quat):
+            return [float(c) for c in quat]
         return None
-    if not isinstance(result, dict) or result.get("status") != "success":
-        return None
-    payload = _extract_json(result)
-    quat = payload.get("quaternion")
-    if isinstance(quat, list) and len(quat) == 4 and all(isinstance(c, (int, float)) for c in quat):
-        return [float(c) for c in quat]
+
+    # Mirror _body_position's resolution: bare BDDL name first, then the LIBERO
+    # ``<name>_main`` root-body convention (#176). Without the fallback,
+    # body_upright(<bddl_name>) resolved to None -> silently False for every
+    # procedurally-generated LIBERO object, whose MJCF root body is _main-suffixed.
+    quat = _try(body)
+    if quat is not None:
+        return quat
+    tried = [body]
+    if not body.endswith("_main"):
+        tried.append(f"{body}_main")
+        quat = _try(f"{body}_main")
+        if quat is not None:
+            return quat
+    _warn_unresolved("body", body, tuple(tried))
     return None
 
 

--- a/tests/simulation/test_benchmark_predicates.py
+++ b/tests/simulation/test_benchmark_predicates.py
@@ -8,6 +8,7 @@ tests under ``tests/simulation/mujoco/``.
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 import pytest
@@ -15,6 +16,7 @@ import pytest
 from strands_robots.simulation.predicates import (
     PREDICATE_REGISTRY,
     _extract_json,
+    _reset_resolution_warnings,
     make_predicate,
     register_predicate,
 )
@@ -812,3 +814,99 @@ class TestExtractJsonHelperGuard:
     def test_extract_json_returns_empty_for_non_dict_result(self):
         assert _extract_json(None) == {}
         assert _extract_json("not a dict") == {}  # type: ignore[arg-type]
+
+
+# Name-resolution surfacing (#176 follow-up): a spec that references a body /
+# joint the backend supports looking up but cannot resolve (a typo) must not be
+# silent. It still degrades to a constant, but the name is logged once, and the
+# LIBERO ``<name>_main`` root-body fallback now also covers the quaternion path.
+
+_PRED_LOGGER = "strands_robots.simulation.predicates"
+
+
+class TestBodyUprightLiberoMainFallback:
+    """body_upright must resolve the LIBERO ``<name>_main`` root body.
+
+    BDDL ``(upright X)`` compiles to ``body_upright(body=X)`` with the bare
+    object name, but the MJCF root body of a procedurally-generated LIBERO
+    object is ``X_main``. Before the fix, ``_body_quaternion`` tried only the
+    bare name (unlike ``_body_position``, which has the fallback), so an upright
+    mug silently scored as not-upright and the goal was never satisfiable.
+    """
+
+    def test_upright_resolves_via_main_suffix(self):
+        # Only the _main root body exists (the bare BDDL name does not).
+        sim = _BodyStateWithQuatSim({"mug_main": {"quaternion": [1, 0, 0, 0]}})
+        pred = make_predicate("body_upright", body="mug")
+        assert pred(sim) is True  # FAILS pre-fix: no _main fallback -> False
+
+    def test_upright_tilted_via_main_suffix_is_false(self):
+        # Resolves via _main but genuinely tipped over -> correctly False.
+        sim = _BodyStateWithQuatSim({"mug_main": {"quaternion": [0.707, 0.707, 0.0, 0.0]}})
+        pred = make_predicate("body_upright", body="mug", tol=0.1)
+        assert pred(sim) is False
+
+
+class TestUnresolvedNameSurfacing:
+    def setup_method(self):
+        _reset_resolution_warnings()
+
+    def test_reward_term_warns_on_unresolved_body(self, caplog):
+        sim = _BodyStateSim({"a": [0, 0, 0]})
+        term = make_predicate("distance_neg", body_a="a", body_b="ghost_reach_1", weight=1.0)
+        with caplog.at_level(logging.WARNING, logger=_PRED_LOGGER):
+            value = term(sim)
+        assert value == 0.0  # value contract unchanged
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1  # FAILS pre-fix: silent, zero warnings
+        assert "ghost_reach_1" in warnings[0].getMessage()
+
+    def test_bool_predicate_warns_on_unresolved_body(self, caplog):
+        sim = _BodyStateSim({"a": [0, 0, 0]})
+        pred = make_predicate("distance_less_than", body_a="a", body_b="ghost_reach_2", threshold=1.0)
+        with caplog.at_level(logging.WARNING, logger=_PRED_LOGGER):
+            assert pred(sim) is False
+        assert any("ghost_reach_2" in r.getMessage() for r in caplog.records if r.levelno == logging.WARNING)
+
+    def test_joint_term_warns_on_unresolved_joint(self, caplog):
+        sim = _JointObsSim({"drawer": 0.1})
+        term = make_predicate("joint_progress", joint="ghost_joint_3", target=0.2, weight=1.0)
+        with caplog.at_level(logging.WARNING, logger=_PRED_LOGGER):
+            value = term(sim)
+        assert value == 0.0
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1  # FAILS pre-fix
+        assert "ghost_joint_3" in warnings[0].getMessage()
+
+    def test_upright_warns_on_unresolved_body(self, caplog):
+        sim = _BodyStateWithQuatSim({})
+        pred = make_predicate("body_upright", body="ghost_up_4")
+        with caplog.at_level(logging.WARNING, logger=_PRED_LOGGER):
+            assert pred(sim) is False
+        assert any("ghost_up_4" in r.getMessage() for r in caplog.records if r.levelno == logging.WARNING)
+
+    def test_no_warning_when_backend_lacks_introspection(self, caplog):
+        # Unsupported backend (no get_body_state) is a capability gap, not a
+        # spec typo -> must stay silent (pre-fix behaviour preserved).
+        sim = _NoHelpersSim()
+        term = make_predicate("distance_neg", body_a="a", body_b="b", weight=1.0)
+        with caplog.at_level(logging.WARNING, logger=_PRED_LOGGER):
+            assert term(sim) == 0.0
+        assert [r for r in caplog.records if r.levelno == logging.WARNING] == []
+
+    def test_no_warning_when_body_resolves(self, caplog):
+        sim = _BodyStateSim({"a": [0, 0, 0]})
+        term = make_predicate("distance_neg", body_a="a", body_b="a", weight=1.0)
+        with caplog.at_level(logging.WARNING, logger=_PRED_LOGGER):
+            assert term(sim) == 0.0
+        assert [r for r in caplog.records if r.levelno == logging.WARNING] == []
+
+    def test_warns_only_once_per_name(self, caplog):
+        sim = _BodyStateSim({"a": [0, 0, 0]})
+        term = make_predicate("distance_neg", body_a="a", body_b="ghost_dedup_5", weight=1.0)
+        with caplog.at_level(logging.WARNING, logger=_PRED_LOGGER):
+            term(sim)
+            term(sim)
+            term(sim)
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING and "ghost_dedup_5" in r.getMessage()]
+        assert len(warnings) == 1  # deduped across the hot loop


### PR DESCRIPTION
## Problem

A typo (or otherwise unresolvable name) in a benchmark **success predicate** or a **reward-term** body/joint was completely silent. On a backend that *supports* the lookup (`get_body_state` / `get_observation`), an unresolvable name degraded the term to a constant with no diagnostic:

- a **bool predicate** to `False` — the episode silently never succeeds, indistinguishable from a genuinely failing policy (`success_rate = 0`);
- a **`distance_neg` / `joint_progress` reward** to `0.0` — which is that term's *maximum* (`-w * dist <= 0`, best at `dist = 0`). A dead term therefore pins at its ceiling and inflates the reported return, masking that the term produces no gradient.

Over a multi-hour RL run or a benchmark eval this quietly corrupts success rates and reward signals with zero signal to the operator. The module docstring already states that a silently-`False` predicate "is a bug" for the backend-unimplemented case; the unresolvable-*name* case (a spec typo) had the same failure mode but no such surfacing.

Demonstration on the real MuJoCo backend (so101 + a `cube`):

```
distance_neg(cube, cube)      = -0.0     # coincident -> genuinely max reward
distance_neg(cube, 'crube')   =  0.0     # typo -> SAME 0.0 as a solved reach
distance_less_than(cube,'targett') = False  # typo -> episode never succeeds
```

Both typo cases returned the same value as "task solved" / "task failed" with no diagnostic.

## Change

- The body/joint lookup helpers (`_body_position`, `_body_quaternion`, `_joint_position`) now log the unresolvable name **once** at `WARNING` (deduplicated so the reward/eval hot loop never spams). **Returned values are unchanged** — no behavior/contract change downstream, only the silence is removed. A missing lookup *method* (unsupported backend) stays silent: that is a capability gap, not a spec typo.
- Mirror `_body_position`'s LIBERO `<name>_main` root-body fallback into `_body_quaternion`. Without it, `body_upright(<bddl_name>)` resolved to `None` → silently `False` for every procedurally-generated LIBERO object (whose MJCF root body is `_main`-suffixed), even when the object was perfectly upright — the exact silent-`False` bug the `_body_position` fallback fixed, but never applied to the quaternion path.

## Tests

`tests/simulation/test_benchmark_predicates.py`:
- `TestBodyUprightLiberoMainFallback` — `body_upright` resolves the `<name>_main` root body (**fails pre-fix**: `False`); a tilted `_main` object is still correctly `False`.
- `TestUnresolvedNameSurfacing` — reward term, bool predicate, joint term, and `body_upright` each emit exactly one warning naming the unresolvable entity (**fail pre-fix**: silent), warns are deduplicated across repeated calls, and stay **silent** on an unsupported backend and on a name that resolves.

Rigorous fails-before/passes-after was verified by reverting only the behavioral changes (keeping the new symbols importable): 6 behavioral tests fail on pre-fix code, 3 guards pass; all 9 pass after.

Gate: `ruff check` + `ruff format` + `mypy` clean; `495 passed / 28 skipped` across `tests/simulation/test_benchmark_predicates.py`, `test_staged_reward.py`, and `tests/benchmarks/libero/` (MUJOCO_GL=egl); `predicates.py` remains at 100% line coverage.