### PR TITLE
fix(lerobot_local): reconstruct OLD-FORMAT in-model normalization dropped on load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -613,6 +613,31 @@ convention (the `_body_position` fallback was never mirrored to the quaternion
 path), so `(upright X)` on a procedurally-generated LIBERO object no longer
 silently evaluates to `False`.
 
+### Fixed: OLD-FORMAT in-model normalization was silently dropped -> canonical checkpoints ran un-normalized
+
+Loading a pre-processor-era lerobot checkpoint through the `lerobot_local`
+provider ran it with normalization dropped. Those checkpoints (the canonical
+zoo -- `lerobot/act_aloha_sim_transfer_cube_human`, `diffusion_pusht`, and the
+tdmpc/vqbet entries a user grabs first) store their Normalize modules *inside*
+the policy, so `model.safetensors` carries `normalize_inputs.*` /
+`unnormalize_outputs.*` buffers and `config.json` carries a
+`normalization_mapping`, with no `policy_preprocessor.json` /
+`policy_postprocessor.json`. Current lerobot no longer registers those modules,
+so `PreTrainedPolicy.from_pretrained` drops the buffers as "unexpected keys"
+(only a `WARNING:root` line) and, with no processor JSON to replace them, the
+policy ran with normalization dropped: observations reached the model raw and
+predicted actions reached the robot un-unnormalized. For a MEAN_STD checkpoint
+that is not an "arm barely moves" under-motion -- raw z-scored actions applied
+as robot units make the arm *flail* (measured on `act_aloha_sim_transfer_cube_human`:
+right-gripper path 3.36 m spanning z [0.03, 0.90] m, vs 0.62 m spanning
+z [0.16, 0.32] m once normalized). `ProcessorBridge` now reconstructs the
+pre/post pipelines from those same in-model buffers using lerobot's own
+`extract_normalization_stats` + `make_pre_post_processors` factory (the exact
+machinery of `migrate_policy_normalization`), so an old-format checkpoint runs
+normalized with zero user action. The reconstruction is best-effort and only
+fires when a checkpoint ships no processor configs, no `norm_stats.json`, but
+does carry in-model buffers -- modern checkpoints are untouched.
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -636,7 +636,12 @@ pre/post pipelines from those same in-model buffers using lerobot's own
 machinery of `migrate_policy_normalization`), so an old-format checkpoint runs
 normalized with zero user action. The reconstruction is best-effort and only
 fires when a checkpoint ships no processor configs, no `norm_stats.json`, but
-does carry in-model buffers -- modern checkpoints are untouched.
+does carry in-model buffers -- modern checkpoints are untouched. The
+reconstruction also degrades to passthrough when the lerobot recovery
+helpers cannot be imported for any reason (not only `ImportError`): an
+unrelated broken sibling policy module -- e.g. a dataclass that fails at
+definition time while importing the `lerobot.policies` package -- must not
+crash an ACT/diffusion checkpoint load.
 
 ## [0.4.1] - 2026-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -641,7 +641,11 @@ reconstruction also degrades to passthrough when the lerobot recovery
 helpers cannot be imported for any reason (not only `ImportError`): an
 unrelated broken sibling policy module -- e.g. a dataclass that fails at
 definition time while importing the `lerobot.policies` package -- must not
-crash an ACT/diffusion checkpoint load.
+crash an ACT/diffusion checkpoint load. The `make_pre_post_processors`
+factory is imported from its canonical module `lerobot.policies.factory`
+(where lerobot's own `migrate_policy_normalization` sources it) rather than
+the `lerobot.policies` top-level re-export, which is not stable across
+lerobot releases.
 
 ## [0.4.1] - 2026-07-01
 

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -844,6 +844,7 @@ class LerobotLocalPolicy(Policy):
                 device=str(self._device) if self._device else None,
                 overrides=self.processor_overrides or {},
                 policy_type=self.policy_type,
+                policy_config=getattr(self._policy, "config", None),
             )
         except (FileNotFoundError, ValueError, ImportError) as exc:
             # Processor bridge is optional - models work without it via the raw

--- a/strands_robots/policies/lerobot_local/processor.py
+++ b/strands_robots/policies/lerobot_local/processor.py
@@ -26,6 +26,50 @@ PREPROCESSOR_CONFIG = "policy_preprocessor.json"
 POSTPROCESSOR_CONFIG = "policy_postprocessor.json"
 
 
+def _load_checkpoint_state_dict(pretrained_name_or_path: str) -> dict[str, Any] | None:
+    """Load a checkpoint's single-file ``model.safetensors`` state dict.
+
+    Resolves a local directory first, then the HF Hub (cached). Returns ``None``
+    when no single-file ``model.safetensors`` is present (e.g. a sharded VLA
+    checkpoint) or safetensors is unavailable -- the OLD-FORMAT checkpoints this
+    supports (ACT / diffusion / tdmpc / vqbet zoo) are all single-file, so this
+    stays best-effort and never raises into the load path.
+
+    Args:
+        pretrained_name_or_path: HF model ID or local checkpoint path.
+
+    Returns:
+        The loaded state dict, or ``None``.
+    """
+    import os
+
+    try:
+        from safetensors.torch import load_file
+    except ImportError:
+        return None
+
+    local = os.path.join(pretrained_name_or_path, "model.safetensors")
+    if os.path.isfile(local):
+        try:
+            return load_file(local)
+        except (OSError, ValueError) as exc:
+            logger.debug("Could not read %s: %s", local, exc)
+            return None
+
+    try:
+        from huggingface_hub import hf_hub_download
+        from huggingface_hub.errors import HfHubHTTPError
+
+        path = hf_hub_download(pretrained_name_or_path, "model.safetensors")
+        return load_file(path)
+    except ImportError:
+        return None
+    except (HfHubHTTPError, OSError, ValueError) as exc:
+        # No single-file weights on the Hub (sharded), offline, or unreadable.
+        logger.debug("No single-file model.safetensors for %s: %s", pretrained_name_or_path, exc)
+        return None
+
+
 def _try_import_processor() -> Any | None:
     """Import LeRobot processor pipeline class.
 
@@ -156,6 +200,7 @@ class ProcessorBridge:
         overrides: dict[str, Any] | None = None,
         policy_type: str | None = None,
         norm_tag: str | None = None,
+        policy_config: Any | None = None,
     ) -> "ProcessorBridge":
         """Load processor pipelines from a pretrained model.
 
@@ -173,6 +218,9 @@ class ProcessorBridge:
                 processor steps before loading the standard pipeline configs.
             norm_tag: Embodiment tag selecting which stats to apply from a
                 ``norm_stats.json`` fallback (auto-resolved when None).
+            policy_config: The loaded policy's ``PreTrainedConfig``. Enables the
+                in-model-normalization fallback (see Notes) for OLD-FORMAT
+                checkpoints; when None that fallback is skipped.
 
         Returns:
             ProcessorBridge instance with loaded pipelines.
@@ -184,6 +232,21 @@ class ProcessorBridge:
             bridge falls back to building quantile/min-max/mean-std normalizers
             from those stats instead of silently passing data through
             un-normalized. See :mod:`.norm_stats`.
+
+            When a checkpoint ships no processor configs AND no
+            ``norm_stats.json`` but DOES carry OLD-FORMAT in-model normalization
+            buffers in its ``model.safetensors`` (``normalize_inputs.*`` /
+            ``unnormalize_outputs.*`` -- the pre-processor-era lerobot format
+            still used by the canonical zoo checkpoints, e.g.
+            ``lerobot/act_aloha_sim_transfer_cube_human``), those buffers are
+            silently DROPPED by ``PreTrainedPolicy.from_pretrained`` under
+            current lerobot (the modules moved to the processor pipeline). The
+            bridge then reconstructs the pre/post pipelines from those buffers
+            via lerobot's own ``extract_normalization_stats`` +
+            ``make_pre_post_processors`` (requires ``policy_config``). Without
+            this, a MEAN_STD checkpoint runs UN-normalized -- raw z-scored
+            actions applied as robot units make the arm flail. See
+            :meth:`_load_in_model_normalization_fallback`.
         """
         DataProcessorPipeline = _try_import_processor()
         if DataProcessorPipeline is None:
@@ -221,6 +284,16 @@ class ProcessorBridge:
         # such checkpoints. Build quantile/min-max/mean-std normalizers instead.
         if preprocessor is None and postprocessor is None:
             preprocessor, postprocessor = cls._load_norm_stats_fallback(pretrained_name_or_path, norm_tag=norm_tag)
+
+        # Third fallback: an OLD-FORMAT checkpoint ships no processor configs and
+        # no norm_stats.json, but carries in-model normalization buffers that
+        # current lerobot drops on load (see the class-level Notes). Reconstruct
+        # the pre/post pipelines from those buffers so the policy runs normalized
+        # instead of flailing on raw MEAN_STD actions. Needs the policy config.
+        if preprocessor is None and postprocessor is None and policy_config is not None:
+            preprocessor, postprocessor = cls._load_in_model_normalization_fallback(
+                pretrained_name_or_path, policy_config, device
+            )
 
         return cls(
             preprocessor=preprocessor,
@@ -336,6 +409,100 @@ class ProcessorBridge:
             pretrained_name_or_path,
         )
         return _norm_stats.build_norm_stats_processors(payload, norm_tag=norm_tag)
+
+    @staticmethod
+    def _load_in_model_normalization_fallback(
+        pretrained_name_or_path: str,
+        policy_config: Any,
+        device: str | None = None,
+    ) -> tuple[Any | None, Any | None]:
+        """Rebuild pre/post pipelines from OLD-FORMAT in-model normalization buffers.
+
+        Pre-processor-era lerobot checkpoints (the canonical zoo: ``act_aloha_*``,
+        ``diffusion_pusht``, tdmpc/vqbet entries) stored their Normalize modules
+        *inside* the policy, so ``model.safetensors`` carries
+        ``normalize_inputs.*`` / ``normalize_targets.*`` / ``unnormalize_outputs.*``
+        buffers and ``config.json`` carries ``normalization_mapping``. Current
+        lerobot's policy classes no longer register those modules, so
+        ``_load_as_safetensor(strict=False)`` drops the buffers as "unexpected
+        keys" (only a ``WARNING:root`` is logged) and no processor JSON exists to
+        replace them -- the policy then runs with normalization dropped. For a
+        MEAN_STD checkpoint that means raw z-scored actions applied as robot
+        units, i.e. the arm FLAILS.
+
+        This reconstructs the pipelines from those same buffers using lerobot's
+        own recovery machinery -- ``extract_normalization_stats`` (the exact
+        scanner ``migrate_policy_normalization`` uses) + the public
+        ``make_pre_post_processors`` factory -- so the checkpoint runs normalized
+        with zero user action, equivalent to running lerobot's migration script.
+
+        Best-effort: returns ``(None, None)`` (leaving the bridge a passthrough,
+        so the caller's missing-postprocessor diagnostic still fires) when the
+        recovery API is unavailable, no single-file ``model.safetensors`` is
+        present, or it carries no in-model normalization buffers. When buffers
+        ARE present but reconstruction fails, warns with the exact manual
+        migration command rather than failing silently.
+
+        Args:
+            pretrained_name_or_path: HF model ID or local checkpoint path.
+            policy_config: The loaded policy's ``PreTrainedConfig`` (supplies
+                ``input_features`` / ``output_features`` / ``normalization_mapping``
+                to the factory).
+            device: Resolved target device (unused directly -- the built pipeline
+                inherits ``policy_config.device`` and the bridge moves tensors).
+
+        Returns:
+            ``(preprocessor, postprocessor)`` reconstructed pipelines, or
+            ``(None, None)``.
+        """
+        try:
+            from lerobot.policies import make_pre_post_processors
+            from lerobot.processor.migrate_policy_normalization import (
+                extract_normalization_stats,
+            )
+        except ImportError as exc:
+            # Older lerobot without the migration helpers: cannot reconstruct.
+            logger.debug("In-model normalization recovery unavailable: %s", exc)
+            return None, None
+
+        state_dict = _load_checkpoint_state_dict(pretrained_name_or_path)
+        if not state_dict:
+            return None, None
+        stats = extract_normalization_stats(state_dict)
+        if not stats:
+            # No in-model normalization buffers -> genuinely no normalization to
+            # recover; let the passthrough diagnostic handle it.
+            return None, None
+
+        try:
+            preprocessor, postprocessor = make_pre_post_processors(policy_cfg=policy_config, dataset_stats=stats)
+        except Exception as exc:  # noqa: BLE001 - recovery is best-effort
+            logger.warning(
+                "lerobot_local: %s ships OLD-FORMAT in-model normalization (%d buffers "
+                "in model.safetensors: %s) that current lerobot drops on load, and "
+                "automatic reconstruction failed (%s). Migrate it once with: "
+                "python -m lerobot.processor.migrate_policy_normalization "
+                "--pretrained-path %s --output-dir <dir>  then load <dir>. Until then "
+                "the policy runs UN-normalized (raw MEAN_STD actions applied as robot "
+                "units make the arm flail).",
+                pretrained_name_or_path,
+                len(stats),
+                sorted(stats),
+                exc,
+                pretrained_name_or_path,
+            )
+            return None, None
+
+        logger.info(
+            "lerobot_local: %s ships no processor configs but carries OLD-FORMAT "
+            "in-model normalization; reconstructed pre/post pipelines from its "
+            "%d in-model buffer group(s) %s (equivalent to lerobot's "
+            "migrate_policy_normalization). The policy runs normalized.",
+            pretrained_name_or_path,
+            len(stats),
+            sorted(stats),
+        )
+        return preprocessor, postprocessor
 
     def apply_embodiment(self, embodiment, input_features: dict | None = None) -> None:
         """Inject a declarative :class:`EmbodimentMap` into the loaded pipeline.

--- a/strands_robots/policies/lerobot_local/processor.py
+++ b/strands_robots/policies/lerobot_local/processor.py
@@ -456,7 +456,7 @@ class ProcessorBridge:
             ``(None, None)``.
         """
         try:
-            from lerobot.policies import make_pre_post_processors
+            from lerobot.policies.factory import make_pre_post_processors
             from lerobot.processor.migrate_policy_normalization import (
                 extract_normalization_stats,
             )

--- a/strands_robots/policies/lerobot_local/processor.py
+++ b/strands_robots/policies/lerobot_local/processor.py
@@ -460,8 +460,13 @@ class ProcessorBridge:
             from lerobot.processor.migrate_policy_normalization import (
                 extract_normalization_stats,
             )
-        except ImportError as exc:
-            # Older lerobot without the migration helpers: cannot reconstruct.
+        except Exception as exc:  # noqa: BLE001 - recovery is best-effort
+            # The helpers may be genuinely absent (older lerobot -> ImportError)
+            # or unimportable because an unrelated sibling policy module fails at
+            # definition time (e.g. a broken dataclass in lerobot.policies.groot
+            # raises TypeError while importing the policies package). Either way
+            # reconstruction is impossible, so degrade to passthrough instead of
+            # letting an unrelated lerobot defect crash ACT/diffusion loads.
             logger.debug("In-model normalization recovery unavailable: %s", exc)
             return None, None
 

--- a/tests/policies/lerobot_local/test_in_model_normalization_fallback.py
+++ b/tests/policies/lerobot_local/test_in_model_normalization_fallback.py
@@ -24,6 +24,7 @@ synthetic OLD-FORMAT checkpoint on disk (real safetensors buffers + a real
 from __future__ import annotations
 
 import builtins
+import importlib
 
 import pytest
 import torch
@@ -39,8 +40,8 @@ from strands_robots.policies.lerobot_local.processor import ProcessorBridge
 # failure so an unrelated lerobot defect does not fail collection here (the
 # production fallback degrades to passthrough for the same failure modes).
 try:
-    import lerobot.policies  # noqa: F401
-    import lerobot.processor.migrate_policy_normalization  # noqa: F401
+    importlib.import_module("lerobot.policies")
+    importlib.import_module("lerobot.processor.migrate_policy_normalization")
 except Exception as exc:  # noqa: BLE001 - mirror the production best-effort guard
     pytest.skip(
         f"lerobot migration helpers unimportable: {exc}",

--- a/tests/policies/lerobot_local/test_in_model_normalization_fallback.py
+++ b/tests/policies/lerobot_local/test_in_model_normalization_fallback.py
@@ -159,7 +159,12 @@ def test_reconstruction_degrades_when_lerobot_import_raises_non_import_error(mon
     real_import = builtins.__import__
 
     def fake_import(name, *args, **kwargs):
-        if name == "lerobot.policies" or name.startswith("lerobot.processor.migrate_policy_normalization"):
+        # Match the two imports the reconstruction performs:
+        # ``from lerobot.policies.factory import make_pre_post_processors`` and
+        # ``from lerobot.processor.migrate_policy_normalization import ...``.
+        if name.startswith("lerobot.policies.factory") or name.startswith(
+            "lerobot.processor.migrate_policy_normalization"
+        ):
             raise TypeError("non-default argument 'backbone_cfg' follows default argument")
         return real_import(name, *args, **kwargs)
 

--- a/tests/policies/lerobot_local/test_in_model_normalization_fallback.py
+++ b/tests/policies/lerobot_local/test_in_model_normalization_fallback.py
@@ -1,0 +1,127 @@
+"""Regression tests for the OLD-FORMAT in-model normalization fallback.
+
+Covers :meth:`ProcessorBridge._load_in_model_normalization_fallback` and its
+wiring into :meth:`ProcessorBridge.from_pretrained` via ``policy_config``.
+
+The bug these guard against: pre-processor-era lerobot checkpoints (the
+canonical zoo -- ``act_aloha_*``, ``diffusion_pusht``, tdmpc/vqbet entries)
+store their Normalize modules *inside* the policy, so ``model.safetensors``
+carries ``normalize_inputs.*`` / ``unnormalize_outputs.*`` buffers and
+``config.json`` carries ``normalization_mapping``, with no processor JSON.
+Current lerobot no longer registers those modules, so
+``PreTrainedPolicy.from_pretrained`` drops the buffers as "unexpected keys"
+(only a ``WARNING:root`` is logged) and the policy runs with normalization
+dropped. For a MEAN_STD checkpoint this makes the arm FLAIL (raw z-scored
+actions applied as robot units), not merely under-move.
+
+The fix reconstructs the pre/post pipelines from those same buffers using
+lerobot's own ``extract_normalization_stats`` + ``make_pre_post_processors``,
+so the checkpoint runs normalized with zero user action. These tests build a
+synthetic OLD-FORMAT checkpoint on disk (real safetensors buffers + a real
+``ACTConfig``) and drive the real lerobot machinery -- no mocks.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from safetensors.torch import save_file
+
+from strands_robots.policies.lerobot_local.processor import ProcessorBridge
+
+# The reconstruction rides lerobot's migration helper + factory; skip cleanly on
+# an install that predates them (the fallback itself degrades to passthrough).
+pytest.importorskip("lerobot.processor.migrate_policy_normalization")
+pytest.importorskip("lerobot.policies")
+
+
+def _act_config():
+    """Minimal real ACTConfig with STATE+ACTION MEAN_STD features."""
+    from lerobot.configs.types import FeatureType, NormalizationMode, PolicyFeature
+    from lerobot.policies.act.configuration_act import ACTConfig
+
+    return ACTConfig(
+        input_features={"observation.state": PolicyFeature(FeatureType.STATE, (4,))},
+        output_features={"action": PolicyFeature(FeatureType.ACTION, (4,))},
+        normalization_mapping={
+            "STATE": NormalizationMode.MEAN_STD,
+            "ACTION": NormalizationMode.MEAN_STD,
+        },
+        device="cpu",
+    )
+
+
+def _write_old_format_checkpoint(path, *, with_norm_buffers: bool = True) -> None:
+    """Write a synthetic single-file checkpoint (in-model norm buffers, no JSON)."""
+    state_dict = {"model.core.weight": torch.zeros(2, 2)}
+    if with_norm_buffers:
+        state_dict.update(
+            {
+                "normalize_inputs.buffer_observation_state.mean": torch.arange(4.0),
+                "normalize_inputs.buffer_observation_state.std": torch.ones(4),
+                "normalize_targets.buffer_action.mean": torch.tensor([2.0, 3.0, 4.0, 5.0]),
+                "normalize_targets.buffer_action.std": torch.ones(4),
+                "unnormalize_outputs.buffer_action.mean": torch.tensor([2.0, 3.0, 4.0, 5.0]),
+                "unnormalize_outputs.buffer_action.std": torch.ones(4),
+            }
+        )
+    save_file(state_dict, str(path / "model.safetensors"))
+
+
+def _action_unnorm_mean(postprocessor):
+    """Return the postprocessor's ``action`` unnormalization mean, or None."""
+    for step in postprocessor.steps:
+        stats = getattr(step, "stats", None) or getattr(step, "_stats", None)
+        if stats and "action" in stats and "mean" in stats["action"]:
+            return stats["action"]["mean"]
+    return None
+
+
+def test_reconstructs_postprocessor_from_in_model_buffers(tmp_path):
+    """An OLD-FORMAT checkpoint (no processor JSON) gets its pipelines rebuilt.
+
+    Fails before the fix: ``from_pretrained`` had no ``policy_config`` parameter,
+    so this call raised ``TypeError`` and no reconstruction happened.
+    """
+    _write_old_format_checkpoint(tmp_path, with_norm_buffers=True)
+
+    bridge = ProcessorBridge.from_pretrained(str(tmp_path), policy_config=_act_config(), device="cpu")
+
+    assert bridge.has_postprocessor, "postprocessor should be reconstructed"
+    assert bridge.has_preprocessor, "preprocessor should be reconstructed"
+    mean = _action_unnorm_mean(bridge._postprocessor)
+    assert mean is not None, "reconstructed postprocessor must carry action stats"
+    # The exact in-model unnormalize_outputs.buffer_action.mean must survive.
+    assert torch.allclose(mean.cpu().float(), torch.tensor([2.0, 3.0, 4.0, 5.0]))
+    # And those stats cover the action key -> not reported as inert.
+    assert "action" not in bridge.inert_normalization_features()
+
+
+def test_reconstruction_requires_policy_config(tmp_path):
+    """Without a policy config the fallback is skipped (stays a passthrough).
+
+    Guards backward compatibility: callers that never pass ``policy_config``
+    keep the old passthrough behaviour rather than reconstructing from a config
+    the bridge does not have.
+    """
+    _write_old_format_checkpoint(tmp_path, with_norm_buffers=True)
+
+    bridge = ProcessorBridge.from_pretrained(str(tmp_path), policy_config=None, device="cpu")
+
+    assert not bridge.has_postprocessor
+    assert not bridge.has_preprocessor
+
+
+def test_no_buffers_stays_passthrough(tmp_path):
+    """A checkpoint with no in-model norm buffers is not touched by the fallback.
+
+    Ensures the reconstruction only fires for genuine OLD-FORMAT checkpoints and
+    never fabricates a pipeline for a modern checkpoint that legitimately ships
+    none (which must remain a passthrough so the caller's diagnostic fires).
+    """
+    _write_old_format_checkpoint(tmp_path, with_norm_buffers=False)
+
+    bridge = ProcessorBridge.from_pretrained(str(tmp_path), policy_config=_act_config(), device="cpu")
+
+    assert not bridge.has_postprocessor
+    assert not bridge.has_preprocessor

--- a/tests/policies/lerobot_local/test_in_model_normalization_fallback.py
+++ b/tests/policies/lerobot_local/test_in_model_normalization_fallback.py
@@ -23,6 +23,8 @@ synthetic OLD-FORMAT checkpoint on disk (real safetensors buffers + a real
 
 from __future__ import annotations
 
+import builtins
+
 import pytest
 import torch
 from safetensors.torch import save_file
@@ -30,9 +32,20 @@ from safetensors.torch import save_file
 from strands_robots.policies.lerobot_local.processor import ProcessorBridge
 
 # The reconstruction rides lerobot's migration helper + factory; skip cleanly on
-# an install that predates them (the fallback itself degrades to passthrough).
-pytest.importorskip("lerobot.processor.migrate_policy_normalization")
-pytest.importorskip("lerobot.policies")
+# an install where they cannot be imported. ``pytest.importorskip`` only catches
+# ImportError, but these modules can also fail at definition time -- e.g. a
+# broken dataclass in an unrelated sibling policy module (lerobot.policies.groot)
+# raises TypeError while importing the policies package. Skip on any import-time
+# failure so an unrelated lerobot defect does not fail collection here (the
+# production fallback degrades to passthrough for the same failure modes).
+try:
+    import lerobot.policies  # noqa: F401
+    import lerobot.processor.migrate_policy_normalization  # noqa: F401
+except Exception as exc:  # noqa: BLE001 - mirror the production best-effort guard
+    pytest.skip(
+        f"lerobot migration helpers unimportable: {exc}",
+        allow_module_level=True,
+    )
 
 
 def _act_config():
@@ -125,3 +138,35 @@ def test_no_buffers_stays_passthrough(tmp_path):
 
     assert not bridge.has_postprocessor
     assert not bridge.has_preprocessor
+
+
+def test_reconstruction_degrades_when_lerobot_import_raises_non_import_error(monkeypatch, tmp_path):
+    """A definition-time failure while importing the lerobot helpers degrades to
+    passthrough instead of crashing the load.
+
+    The reconstruction imports ``lerobot.policies`` (for ``make_pre_post_processors``)
+    and ``lerobot.processor.migrate_policy_normalization``. An unrelated broken
+    sibling policy module -- e.g. a dataclass with a non-default field after a
+    default one in ``lerobot.policies.groot`` -- raises ``TypeError`` (not
+    ``ImportError``) while importing the policies package. The fallback must
+    treat that as "recovery unavailable" and return ``(None, None)`` so an
+    unrelated lerobot defect cannot take down an ACT/diffusion checkpoint load.
+    """
+    _write_old_format_checkpoint(tmp_path, with_norm_buffers=True)
+    policy_config = _act_config()
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "lerobot.policies" or name.startswith("lerobot.processor.migrate_policy_normalization"):
+            raise TypeError("non-default argument 'backbone_cfg' follows default argument")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    pre, post = ProcessorBridge._load_in_model_normalization_fallback(
+        str(tmp_path), policy_config=policy_config, device="cpu"
+    )
+
+    assert pre is None
+    assert post is None


### PR DESCRIPTION
## Problem

Loading a canonical **pre-processor-era** lerobot checkpoint through the `lerobot_local` provider runs it with **normalization dropped**. These checkpoints (the zoo a user grabs first to try `lerobot_local` -- `lerobot/act_aloha_sim_transfer_cube_human`, `diffusion_pusht`, the tdmpc/vqbet entries) store their `Normalize` modules *inside* the policy, so `model.safetensors` carries `normalize_inputs.*` / `normalize_targets.*` / `unnormalize_outputs.*` buffers and `config.json` carries a `normalization_mapping`, with **no** `policy_preprocessor.json` / `policy_postprocessor.json`.

Current lerobot no longer registers those in-model modules (normalization moved to the processor pipeline), so `PreTrainedPolicy.from_pretrained` -> `_load_as_safetensor(strict=False)` drops the 8 buffers as *unexpected keys* (only a `WARNING:root` line). With no processor JSON to replace them, `ProcessorBridge` had nothing to load and the policy ran raw: observations reached the model un-normalized **and** predicted actions reached the robot un-unnormalized.

For a `MEAN_STD` checkpoint this is not an "arm barely moves" under-motion -- raw z-scored actions applied as robot units make the arm **flail**.

## Fix

`ProcessorBridge` now reconstructs the pre/post pipelines from those same in-model buffers using lerobot's own recovery machinery -- `extract_normalization_stats` (the exact scanner `migrate_policy_normalization` uses) + the public `make_pre_post_processors` factory -- so an old-format checkpoint runs normalized with **zero user action**, equivalent to running lerobot's migration script.

The reconstruction is a third, best-effort fallback in `ProcessorBridge.from_pretrained`, added after the existing `policy_*.json` and `norm_stats.json` paths. It fires **only** when a checkpoint ships no processor configs, no `norm_stats.json`, but *does* carry in-model buffers -- modern checkpoints are untouched. It requires the policy config (threaded from the loaded policy); when the config is absent or the recovery API is unavailable it degrades to the prior passthrough so the existing missing-postprocessor diagnostic still fires. When buffers are present but reconstruction fails, it warns with the exact manual migration command instead of failing silently.

## Rollout evidence (MuJoCo, `act_aloha_sim_transfer_cube_human`)

Identical scene / home keyframe / cube / `seed=42`; only normalization differs. Right-gripper trajectory over a 400-step rollout, ground-truthed on `data.site_xpos`:

| condition | right-gripper path | right-gripper z-range | left-gripper path |
|---|---|---|---|
| **before** (normalization dropped) | 3.36 m | [0.03, **0.90**] m (flails ~90 cm up) | 1.76 m |
| **after** (reconstructed) | 0.62 m | [0.16, 0.32] m (controlled reach-down) | 0.17 m (stays home) |

Side-elevation view (world-z -> screen-vertical) of the same two rollouts -- left = after, right = before:

![before vs after](https://github.com/cagataycali/robots/releases/download/artifacts-in-model-norm-reconstruction/aloha_ab.gif)

Load-time log after the fix (no more misleading warning):
```
lerobot_local: lerobot/act_aloha_sim_transfer_cube_human ships no processor configs but carries OLD-FORMAT in-model normalization; reconstructed pre/post pipelines from its 3 in-model buffer group(s) ['action', 'observation.images.top', 'observation.state'] (equivalent to lerobot's migrate_policy_normalization). The policy runs normalized.
```

## Tests

`tests/policies/lerobot_local/test_in_model_normalization_fallback.py` builds a synthetic OLD-FORMAT checkpoint on disk (real `safetensors` in-model buffers + a real `ACTConfig`) and drives the real lerobot machinery -- no mocks:
- reconstruction rebuilds a postprocessor carrying the exact in-model `action` unnormalization stats;
- the fallback is skipped without a policy config (backward-compat passthrough preserved);
- a checkpoint with no in-model buffers stays a passthrough (no false positives on modern checkpoints).

All three fail before the fix (the `policy_config` path did not exist) and pass after. Full `lerobot_local` suite green; `ruff` + `mypy` clean.

## Scope

The fix corrects the action/state normalization *scale* (stops the flail). It does not by itself enable a task success in sim -- the render domain gap and per-embodiment state/gripper mapping are separate barriers -- but a policy running in its trained normalized space is the necessary first step.

## Robustness: import-guard degradation

The reconstruction imports `lerobot.policies` (for `make_pre_post_processors`) and `lerobot.processor.migrate_policy_normalization`. These can fail at **definition time**, not only with `ImportError` -- an unrelated broken sibling policy module (e.g. a dataclass with a non-default field after a default one in `lerobot.policies.groot` raises `TypeError` while importing the `lerobot.policies` package) takes down the whole import. The guard now degrades to passthrough on **any** import-time failure so an unrelated lerobot defect cannot crash an ACT/diffusion checkpoint load. The test module guard is broadened the same way (`pytest.importorskip` only catches `ImportError`).

A fourth regression test (`test_reconstruction_degrades_when_lerobot_import_raises_non_import_error`) pins this: with `lerobot.policies` import monkeypatched to raise `TypeError`, `_load_in_model_normalization_fallback` returns `(None, None)` instead of propagating. It fails on the prior `except ImportError` guard and passes after. Full `lerobot_local` suite green (489 passed); `ruff` + `mypy` clean.

---

## Round 2 changelog

- **CodeQL unused-import (2 findings, test file lines 42-43):** the two module-level lerobot probe imports were bound-name imports used only for their side effect of executing the package bodies at collection time (so the skip guard fires on any import-time failure, including a definition-time `TypeError`, not just `ImportError`). Their bound name was never referenced, which the scanner flagged and the `# noqa: F401` did not silence. Switched both to `importlib.import_module(...)`: identical import machinery (module body still executes, definition-time errors still propagate into the `except` guard and skip the module) with no unused binding. Finding cleared at source rather than suppressed. `ruff check` / `ruff format` clean, ASCII-only. (commit `6461eef`)

## lerobot API-drift fix

`make_pre_post_processors` is not a stable member of the `lerobot.policies` top-level re-export (current lerobot no longer exports it there). The deferred import now sources it from its canonical module `lerobot.policies.factory` — the exact module lerobot's own `migrate_policy_normalization` imports it from — so it resolves across lerobot releases and clears the static `lerobot`-import-surface drift guard.
