### PR TITLE
fix(lerobot_local): degrade to passthrough on corrupt model.safetensors

### DIFF
--- a/strands_robots/policies/lerobot_local/processor.py
+++ b/strands_robots/policies/lerobot_local/processor.py
@@ -44,15 +44,20 @@ def _load_checkpoint_state_dict(pretrained_name_or_path: str) -> dict[str, Any] 
     import os
 
     try:
+        from safetensors import SafetensorError
         from safetensors.torch import load_file
     except ImportError:
         return None
 
+    # A truncated / corrupt model.safetensors (e.g. an interrupted Hub download)
+    # raises safetensors' own SafetensorError, which is NOT an OSError/ValueError.
+    # Catch it too so the best-effort loader degrades to passthrough instead of
+    # crashing the ACT/diffusion load path (see the module and function docstring).
     local = os.path.join(pretrained_name_or_path, "model.safetensors")
     if os.path.isfile(local):
         try:
             return load_file(local)
-        except (OSError, ValueError) as exc:
+        except (OSError, ValueError, SafetensorError) as exc:
             logger.debug("Could not read %s: %s", local, exc)
             return None
 
@@ -64,8 +69,8 @@ def _load_checkpoint_state_dict(pretrained_name_or_path: str) -> dict[str, Any] 
         return load_file(path)
     except ImportError:
         return None
-    except (HfHubHTTPError, OSError, ValueError) as exc:
-        # No single-file weights on the Hub (sharded), offline, or unreadable.
+    except (HfHubHTTPError, OSError, ValueError, SafetensorError) as exc:
+        # No single-file weights on the Hub (sharded), offline, corrupt, or unreadable.
         logger.debug("No single-file model.safetensors for %s: %s", pretrained_name_or_path, exc)
         return None
 

--- a/tests/policies/lerobot_local/test_checkpoint_state_dict_load_failsoft.py
+++ b/tests/policies/lerobot_local/test_checkpoint_state_dict_load_failsoft.py
@@ -1,0 +1,88 @@
+"""Fail-soft contract for the single-file checkpoint state-dict loader.
+
+``_load_checkpoint_state_dict`` backs the in-model normalization recovery path
+(``strands_robots.policies.lerobot_local.processor``). Its caller invokes it
+UNWRAPPED, so the function must be best-effort and never raise into the ACT /
+diffusion load path: on any unreadable local or Hub checkpoint it returns
+``None`` and lets the policy degrade to passthrough.
+
+A truncated / corrupt ``model.safetensors`` (e.g. an interrupted Hub download)
+raises safetensors' own ``SafetensorError`` -- which is neither ``OSError`` nor
+``ValueError`` -- so it must be caught explicitly. These tests pin that the
+loader returns outputs (a state dict or ``None``) rather than propagating.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("safetensors")
+
+from safetensors.torch import save_file  # noqa: E402
+
+from strands_robots.policies.lerobot_local import processor as processor_mod  # noqa: E402
+from strands_robots.policies.lerobot_local.processor import (  # noqa: E402
+    _load_checkpoint_state_dict,
+)
+
+
+def _write_valid_checkpoint(directory) -> str:
+    """Write a real single-file model.safetensors and return the file path."""
+    path = directory / "model.safetensors"
+    save_file({"w": torch.zeros(3)}, str(path))
+    return str(path)
+
+
+class TestLocalCheckpoint:
+    def test_valid_local_checkpoint_returns_state_dict(self, tmp_path):
+        _write_valid_checkpoint(tmp_path)
+        result = _load_checkpoint_state_dict(str(tmp_path))
+        assert result is not None
+        assert "w" in result
+
+    def test_corrupt_local_checkpoint_degrades_to_none(self, tmp_path):
+        # A truncated header raises SafetensorError; the loader must swallow it.
+        (tmp_path / "model.safetensors").write_bytes(b"corrupt-not-safetensors")
+        assert _load_checkpoint_state_dict(str(tmp_path)) is None
+
+    def test_no_local_file_unreachable_hub_returns_none(self, tmp_path, monkeypatch):
+        # No local model.safetensors and the Hub is unreachable (offline / IO
+        # error) -> None, never a failure escaping into the load path.
+        def _raise(*_a, **_k):
+            raise OSError("offline")
+
+        monkeypatch.setattr("huggingface_hub.hf_hub_download", _raise)
+        assert _load_checkpoint_state_dict(str(tmp_path)) is None
+
+
+class TestHubCheckpoint:
+    def test_hub_download_returns_state_dict(self, tmp_path, monkeypatch):
+        # tmp_path has no local checkpoint; the Hub yields a valid file.
+        weights_dir = tmp_path / "hub"
+        weights_dir.mkdir()
+        hub_path = _write_valid_checkpoint(weights_dir)
+        monkeypatch.setattr("huggingface_hub.hf_hub_download", lambda *_a, **_k: hub_path)
+
+        result = _load_checkpoint_state_dict(str(tmp_path))
+        assert result is not None
+        assert "w" in result
+
+    def test_corrupt_hub_download_degrades_to_none(self, tmp_path, monkeypatch):
+        bad = tmp_path / "bad.safetensors"
+        bad.write_bytes(b"corrupt-not-safetensors")
+        monkeypatch.setattr("huggingface_hub.hf_hub_download", lambda *_a, **_k: str(bad))
+        assert _load_checkpoint_state_dict(str(tmp_path)) is None
+
+
+class TestSafetensorsUnavailable:
+    def test_missing_safetensors_returns_none(self, tmp_path, monkeypatch):
+        # Simulate safetensors not installed: the guarded import returns None.
+        monkeypatch.setitem(__import__("sys").modules, "safetensors", None)
+        monkeypatch.setitem(__import__("sys").modules, "safetensors.torch", None)
+        assert _load_checkpoint_state_dict(str(tmp_path)) is None
+
+
+def test_loader_is_referenced_by_recovery_path():
+    """Guard that the recovery path still calls the loader unwrapped."""
+    assert hasattr(processor_mod, "_load_checkpoint_state_dict")


### PR DESCRIPTION
## Problem
The in-model normalization recovery path in `strands_robots.policies.lerobot_local.processor` calls `_load_checkpoint_state_dict(pretrained_name_or_path)` **unwrapped**, and the helper's own docstring promises it "stays best-effort and never raises into the load path." It only guards the local and Hub `load_file` calls with `except (OSError, ValueError)` / `except (HfHubHTTPError, OSError, ValueError)`.

A truncated or corrupt `model.safetensors` — a common outcome of an interrupted Hugging Face download — makes `safetensors.torch.load_file` raise `safetensors.SafetensorError`, which is a direct `Exception` subclass and is **neither** `OSError` **nor** `ValueError`. It therefore slips past both guards, propagates out of `_load_checkpoint_state_dict`, and crashes the ACT / diffusion policy load instead of degrading to passthrough as designed.

Reproduction (pre-fix):
```python
import tempfile, os
from strands_robots.policies.lerobot_local.processor import _load_checkpoint_state_dict
d = tempfile.mkdtemp()
open(os.path.join(d, "model.safetensors"), "wb").write(b"corrupt")
_load_checkpoint_state_dict(d)   # raises SafetensorError instead of returning None
```

## Change
Add `SafetensorError` to both read-error guards (imported from the public `safetensors` namespace alongside `load_file`, inside the same `ImportError`-guarded block). An unreadable local or Hub checkpoint now returns `None`, letting the caller fall back to the `norm_stats.json` / passthrough path exactly as the surrounding recovery code already documents for the sharded-VLA and offline cases.

## Tests
New `tests/policies/lerobot_local/test_checkpoint_state_dict_load_failsoft.py` pins the fail-soft contract across every branch:
- valid local `model.safetensors` -> returns the state dict (real safetensors round-trip)
- corrupt local `model.safetensors` -> `None` (**fails pre-fix**: `SafetensorError` escaped)
- unreachable Hub (offline / IO error) -> `None`
- valid Hub download -> returns the state dict
- corrupt Hub download -> `None` (**fails pre-fix**)
- safetensors unavailable -> `None`

Green locally: `hatch run lint` clean (ruff + ruff format + mypy, 677 source files) and `MUJOCO_GL=egl` pytest for `tests/policies/lerobot_local/` (496 passed). The two corrupt-checkpoint cases fail on pre-fix code and pass after.