### PR TITLE
fix(lerobot_local): keep observation.state index-aligned on a partial robot_state_keys mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -647,6 +647,28 @@ factory is imported from its canonical module `lerobot.policies.factory`
 the `lerobot.policies` top-level re-export, which is not stable across
 lerobot releases.
 
+### Fixed: a partial `robot_state_keys` mismatch silently mis-aligned `observation.state`
+
+When the configured `robot_state_keys` are keyed by a robot's actuator names
+but some of those names are absent from `get_observation()` -- the canonical
+case being a mimic/tendon gripper whose actuator (`left/gripper` /
+`right/gripper` on aloha) is not among the observation's finger-joint names
+while the arm joints are -- both state-build paths in the `lerobot_local`
+provider iterated the resolved key order and appended only the keys present in
+the observation. An absent key was therefore *dropped*, shifting every
+following joint value up one index before the trailing zero-pad, so the model
+received a garbage `observation.state` while the run reported success. On a real
+MuJoCo aloha sim this shifted 8 of the 14 state dims (the entire right arm slid
+into the wrong slots and both gripper dims landed wrong). `_resolve_state_order`
+already made the *all*-missing case loud (#897); the *partial*-missing case was
+still silent. A missing key is now zero-filled IN PLACE via a shared
+`_collect_state_values` helper, so present joints keep their model index, and
+the degradation is surfaced -- `strict_keys=True` raises naming the missing
+keys; otherwise it warns once and sets the new `missing_state_keys_used`
+telemetry flag (surfaced in the `run_policy` / `eval_policy` result alongside
+`generic_state_keys_used`). Robots whose keys are all present (e.g. `so101`)
+are unaffected.
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -379,6 +379,21 @@ class LerobotLocalPolicy(Policy):
         # vs named-joint mismatch). Keeps the state-key fallback loud, not
         # silent (see _resolve_state_order).
         self._state_key_mismatch_warned: bool = False
+        # Warn at most once per policy when SOME (but not all) configured
+        # robot_state_keys are absent from the observation - the
+        # partial-mismatch case. Previously the absent keys were silently
+        # dropped from the state vector, shifting every following joint
+        # value into the wrong index before a trailing zero-pad (the
+        # canonical trigger is a mimic/tendon gripper whose actuator name
+        # differs from the observation's finger-joint names, e.g. aloha).
+        # Missing dims are now zero-filled IN PLACE so present dims keep
+        # their model index, and the degradation is surfaced rather than
+        # silent (mirrors _resolve_state_order's all-missing guard).
+        self._state_missing_keys_warned: bool = False
+        # Telemetry parallel to generic_state_keys_used: flipped True the
+        # first time a resolved state key is missing from the observation
+        # so run_policy / eval_policy can surface a machine-checkable signal.
+        self.missing_state_keys_used = False
 
         # Action diagnostics: surface a model<->embodiment action-dim mismatch
         # (zero-filled actuators) and a persistent near-zero action stream
@@ -1962,6 +1977,78 @@ class LerobotLocalPolicy(Policy):
             self._state_key_mismatch_warned = True
         return scalar_keys
 
+    def _collect_state_values(self, observation_dict: dict[str, Any], order: list[str]) -> list[float]:
+        """Pull the joint-state vector from ``observation_dict`` in ``order``.
+
+        Every key in ``order`` contributes exactly one slot, in order, so the
+        emitted vector is index-aligned with the resolved key list. A key that
+        is present as a scalar (Python/NumPy number or 0-d array) contributes
+        its value; a key that is ABSENT from the observation (or present but
+        non-scalar) contributes ``0.0`` IN PLACE - it is never dropped.
+
+        Dropping an absent key instead (the prior behaviour) shifted every
+        following joint value up by one index before the caller's trailing
+        zero-pad, silently mis-aligning ``observation.state``. The canonical
+        trigger is a mimic/tendon gripper whose actuator name (e.g. aloha's
+        ``left/gripper``) is not among the observation's finger-joint names
+        while the arm joints are: the arm values slid into the gripper slots.
+        ``so101`` and any robot whose keys are all present are unaffected.
+
+        When ``order`` is ``robot_state_keys`` and some of them are missing
+        (a partial mismatch), the degradation is surfaced - ``strict_keys``
+        raises, otherwise it warns once and sets ``missing_state_keys_used`` -
+        mirroring :meth:`_resolve_state_order`'s all-missing guard. The
+        observation's own scalar-key fallback (``order`` != ``robot_state_keys``)
+        has no missing keys by construction, so this never double-fires with
+        the all-missing path.
+
+        Args:
+            observation_dict: Raw strands/sim observation for this step.
+            order: Resolved key ordering from :meth:`_resolve_state_order`.
+
+        Returns:
+            One float per key in ``order`` (missing keys zero-filled in place).
+
+        Raises:
+            ValueError: When ``strict_keys`` is set and a resolved
+                ``robot_state_keys`` entry is missing from the observation.
+        """
+        values: list[float] = []
+        missing: list[str] = []
+        for key in order:
+            v = observation_dict.get(key)
+            if isinstance(v, bool):
+                # bool is an int subclass but never a joint reading.
+                missing.append(key)
+                values.append(0.0)
+            elif isinstance(v, (int, float, np.floating, np.integer)):
+                values.append(float(v))
+            elif isinstance(v, np.ndarray) and v.ndim == 0:
+                values.append(float(v))
+            else:
+                missing.append(key)
+                values.append(0.0)
+        # Only a robot_state_keys ordering can contain a key absent from the
+        # observation; the scalar-key fallback is built from present keys.
+        if missing and order is self.robot_state_keys:
+            shown = missing[:8]
+            ellipsis = "..." if len(missing) > 8 else ""
+            msg = (
+                f"{len(missing)} configured robot_state_keys are not present in the "
+                f"observation: {shown}{ellipsis}. Present joints keep their index and the "
+                "missing dims are zero-filled in place, but the sim/robot does not report "
+                "those joints - commonly a mimic/tendon gripper whose actuator name differs "
+                "from the observation's finger-joint names. Pass embodiment='<name>' or call "
+                "set_robot_state_keys([...]) with names the observation actually contains."
+            )
+            if self.strict_keys:
+                raise ValueError("strict_keys=True: " + msg)
+            self.missing_state_keys_used = True
+            if not self._state_missing_keys_warned:
+                logger.warning(msg)
+                self._state_missing_keys_warned = True
+        return values
+
     def _to_lerobot_observation(self, observation_dict: dict[str, Any]) -> dict[str, Any]:
         """Remap a strands-native observation to LeRobot feature keys.
 
@@ -2065,14 +2152,10 @@ class LerobotLocalPolicy(Policy):
         # generic joint_0..N vs named-joint mismatch) instead of silently
         # producing a zero/empty state (see _resolve_state_order).
         order = self._resolve_state_order(observation_dict, scalar_keys)
-        state_vals = []
-        for k in order:
-            if k in observation_dict:
-                v = observation_dict[k]
-                if isinstance(v, (int, float, np.floating, np.integer)):
-                    state_vals.append(float(v))
-                elif isinstance(v, np.ndarray) and v.ndim == 0:
-                    state_vals.append(float(v))
+        # Build the vector index-aligned with ``order`` - a resolved key absent
+        # from the observation is zero-filled IN PLACE (not dropped, which would
+        # shift following joints into the wrong slots) and surfaced loudly.
+        state_vals = self._collect_state_values(observation_dict, order)
         if state_vals:
             # Adapt state dim to the model's declared observation.state shape.
             # The preprocessor's normalizer does element-wise ops against fixed
@@ -2393,18 +2476,11 @@ class LerobotLocalPolicy(Policy):
         ]
         order = self._resolve_state_order(observation_dict, scalar_keys)
 
-        # Collect state values in resolved order. Each key maps to a single
-        # float value representing one joint/motor position.
-        state_values = []
-        for key in order:
-            if key in observation_dict:
-                value = observation_dict[key]
-                if isinstance(value, (int, float)):
-                    state_values.append(float(value))
-                elif isinstance(value, (np.floating, np.integer)):
-                    state_values.append(float(value))
-                elif isinstance(value, np.ndarray) and value.ndim == 0:
-                    state_values.append(float(value))
+        # Collect state values index-aligned with the resolved order. A key in
+        # ``order`` absent from the observation is zero-filled IN PLACE (not
+        # dropped, which would shift following joints into the wrong slots) and
+        # surfaced loudly. Each key maps to one joint/motor position.
+        state_values = self._collect_state_values(observation_dict, order)
 
         if state_values:
             # Auto-adapt state dimension to match what the model expects.

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -837,7 +837,7 @@ class SimEngine(ABC):
             carries the rollout facts as typed fields (``n_steps``,
             ``elapsed_s``, ``stopped_early``, ``action_errors``, ``video_path``,
             ``video_frames``, ``positional_fallback_used``,
-            ``generic_state_keys_used``, ...) so callers can self-correct
+            ``generic_state_keys_used``, ``missing_state_keys_used``, ...) so callers can self-correct
             programmatically without parsing the text. The two routing-
             degradation flags are True when the driving policy could not bind
             the observation to the model's inputs by name and silently fell

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -1319,6 +1319,7 @@ class PolicyRunner:
             # Defaults False for policies without the attribute (e.g. MockPolicy).
             "positional_fallback_used": bool(getattr(policy, "positional_fallback_used", False)),
             "generic_state_keys_used": bool(getattr(policy, "generic_state_keys_used", False)),
+            "missing_state_keys_used": bool(getattr(policy, "missing_state_keys_used", False)),
             # Process RSS (MB) at result time: confirms a heavy model is resident
             # and, across a loop, that it stays resident instead of oscillating
             # as it would on a per-episode reload. None when unmeasurable.
@@ -1988,6 +1989,7 @@ class PolicyRunner:
                         "policy_load_cache_hit": bool(getattr(policy, "load_cache_hit", False)),
                         "positional_fallback_used": bool(getattr(policy, "positional_fallback_used", False)),
                         "generic_state_keys_used": bool(getattr(policy, "generic_state_keys_used", False)),
+                        "missing_state_keys_used": bool(getattr(policy, "missing_state_keys_used", False)),
                         **rtc_telemetry,
                         "policy_resident_rss_mb": process_rss_mb(),
                         "episodes": results,
@@ -2387,6 +2389,7 @@ class PolicyRunner:
                         "policy_load_cache_hit": bool(getattr(policy, "load_cache_hit", False)),
                         "positional_fallback_used": bool(getattr(policy, "positional_fallback_used", False)),
                         "generic_state_keys_used": bool(getattr(policy, "generic_state_keys_used", False)),
+                        "missing_state_keys_used": bool(getattr(policy, "missing_state_keys_used", False)),
                         "policy_resident_rss_mb": process_rss_mb(),
                         "episodes": results,
                         "video_paths": video_paths,

--- a/tests/policies/lerobot_local/test_partial_state_key_alignment.py
+++ b/tests/policies/lerobot_local/test_partial_state_key_alignment.py
@@ -1,0 +1,152 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""Partial state-key mismatch must keep present joints index-aligned, not shift them.
+
+``_resolve_state_order`` already makes the *all*-missing case loud (generic
+``joint_0..N`` vs named joints). The *partial* case - SOME configured
+``robot_state_keys`` present and some absent - was still silently wrong: both
+state-build paths iterated the resolved order and appended only the keys found
+in the observation, so an absent key was DROPPED, shifting every following
+joint value up one index before the trailing zero-pad.
+
+The canonical trigger is a mimic/tendon gripper whose actuator name
+(``left/gripper`` / ``right/gripper`` on aloha) is not among the observation's
+finger-joint names while the arm joints are: the right-arm joints slid into the
+gripper slots, so the model received a garbage ``observation.state`` while the
+run reported success.
+
+These tests pin the corrected behaviour: a missing key is zero-filled IN PLACE
+(present dims keep their model index), the degradation is surfaced
+(``strict_keys=True`` raises; ``strict_keys=False`` warns once and sets
+``missing_state_keys_used``), and a fully-present key set (so101) is unchanged.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+import torch
+
+from strands_robots.policies.lerobot_local.policy import LerobotLocalPolicy
+
+# aloha-style 14 actuator keys: 6 arm + 1 gripper actuator per side, gripper
+# actuators interspersed at indices 6 and 13.
+ALOHA_ACTUATOR_KEYS = [
+    "l0",
+    "l1",
+    "l2",
+    "l3",
+    "l4",
+    "l5",
+    "left/gripper",
+    "r0",
+    "r1",
+    "r2",
+    "r3",
+    "r4",
+    "r5",
+    "right/gripper",
+]
+LEFT_ARM = [0.10, 0.11, 0.12, 0.13, 0.14, 0.15]
+RIGHT_ARM = [0.20, 0.21, 0.22, 0.23, 0.24, 0.25]
+
+
+def _visual(shape=(3, 224, 224)):
+    return SimpleNamespace(type=SimpleNamespace(name="VISUAL"), shape=shape)
+
+
+def _state(dim):
+    return SimpleNamespace(type=SimpleNamespace(name="STATE"), shape=(dim,))
+
+
+def _policy(*, strict_keys=False, state_dim=14, keys=None):
+    with patch.object(LerobotLocalPolicy, "_load_model"):
+        policy = LerobotLocalPolicy(pretrained_name_or_path=None, policy_type="act", strict_keys=strict_keys)
+    policy._input_features = {"observation.images.top": _visual(), "observation.state": _state(state_dim)}
+    policy._device = torch.device("cpu")
+    policy.robot_state_keys = list(ALOHA_ACTUATOR_KEYS if keys is None else keys)
+    return policy
+
+
+def _aloha_obs():
+    """Observation with the 12 arm joints + finger joints, but NOT the two
+    ``*/gripper`` actuator names the policy is keyed by."""
+    obs = {"top": np.zeros((224, 224, 3), np.uint8)}
+    obs.update(dict(zip(["l0", "l1", "l2", "l3", "l4", "l5"], LEFT_ARM)))
+    obs.update(dict(zip(["r0", "r1", "r2", "r3", "r4", "r5"], RIGHT_ARM)))
+    # Finger joints exist but under names that don't match the actuator keys.
+    obs.update({"left/left_finger": 0.9, "left/right_finger": 0.9, "right/left_finger": 0.9})
+    return obs
+
+
+def _assert_aligned(state):
+    """The 14-dim vector must be arm-in-place with gripper slots zeroed."""
+    state = [round(float(v), 3) for v in state]
+    assert len(state) == 14
+    assert state[0:6] == LEFT_ARM  # left arm, indices 0..5
+    assert state[6] == 0.0  # left gripper slot (missing) zero-filled IN PLACE
+    assert state[7:13] == RIGHT_ARM  # right arm, indices 7..12 - NOT shifted into idx 6
+    assert state[13] == 0.0  # right gripper slot (missing) zero-filled IN PLACE
+
+
+class TestPartialMismatchAlignment:
+    """A missing interspersed key zero-fills in place instead of shifting."""
+
+    def test_vla_path_keeps_arm_joints_aligned(self):
+        policy = _policy()
+        out = policy._to_lerobot_observation(_aloha_obs())
+        _assert_aligned(out["observation.state"])
+
+    def test_strands_native_path_keeps_arm_joints_aligned(self):
+        policy = _policy()
+        batch = policy._build_batch_from_strands_format(_aloha_obs(), {})
+        _assert_aligned(batch["observation.state"][0].numpy())
+
+    def test_missing_keys_set_telemetry_and_warn_once(self, caplog):
+        policy = _policy()
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            policy._to_lerobot_observation(_aloha_obs())
+            policy._to_lerobot_observation(_aloha_obs())  # second step must NOT re-warn
+        assert policy.missing_state_keys_used is True
+        warnings = [r for r in caplog.records if "not present in the observation" in r.getMessage()]
+        assert len(warnings) == 1  # warn-once
+        assert "left/gripper" in warnings[0].getMessage()
+
+
+class TestStrictKeysRaisesOnPartialMismatch:
+    """strict_keys turns a partial mismatch into a clear, actionable error."""
+
+    def test_vla_path_raises_naming_missing_keys(self):
+        policy = _policy(strict_keys=True)
+        with pytest.raises(ValueError) as exc:
+            policy._to_lerobot_observation(_aloha_obs())
+        msg = str(exc.value)
+        assert "strict_keys=True" in msg
+        assert "left/gripper" in msg and "right/gripper" in msg
+        assert "set_robot_state_keys" in msg
+
+    def test_strands_native_path_raises_naming_missing_keys(self):
+        policy = _policy(strict_keys=True)
+        with pytest.raises(ValueError) as exc:
+            policy._build_batch_from_strands_format(_aloha_obs(), {})
+        assert "right/gripper" in str(exc.value)
+
+
+class TestAllPresentUnaffected:
+    """so101-like fully-present key set is unchanged - no warn, no telemetry flag."""
+
+    def test_no_missing_keys_no_warning(self, caplog):
+        keys = ["j0", "j1", "j2", "j3", "j4", "j5"]
+        policy = _policy(state_dim=6, keys=keys)
+        obs = {"top": np.zeros((224, 224, 3), np.uint8)}
+        obs.update(dict(zip(keys, [0.10, 0.11, 0.12, 0.13, 0.14, 0.15])))
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            out = policy._to_lerobot_observation(obs)
+        state = [round(float(v), 3) for v in out["observation.state"]]
+        assert state == [0.10, 0.11, 0.12, 0.13, 0.14, 0.15]
+        assert policy.missing_state_keys_used is False
+        assert not [r for r in caplog.records if "not present in the observation" in r.getMessage()]


### PR DESCRIPTION
## Problem

The `lerobot_local` provider builds `observation.state` by resolving `robot_state_keys` against the per-step observation. `_resolve_state_order` already makes the *all*-missing case loud (generic `joint_0..N` vs named joints, #897), but the **partial**-missing case was still silent: both state-build paths (`_to_lerobot_observation` and `_build_batch_from_strands_format`) iterated the resolved key order and appended **only** the keys found in the observation. An absent key was therefore *dropped*, shifting every following joint value up one index before the trailing zero-pad.

The canonical trigger is a robot whose `robot_state_keys` are keyed by actuator names, where a mimic/tendon gripper's actuator (`left/gripper` / `right/gripper` on aloha) is **not** among the observation's finger-joint names while the arm joints are. The policy then receives a garbage `observation.state` while the run reports `success`.

### Reproduced on a real MuJoCo aloha sim

`sim.robot_action_keys('aloha')` = 14 actuator names with the gripper actuators interspersed at indices 6 and 13, but `get_observation()` exposes `left/left_finger`, `left/right_finger`, ... (finger *joints*) and **not** `left/gripper` / `right/gripper`. Building the 14-dim state from that observation (joints perturbed to distinct values so the shift is visible):

```
idx  key                    PRE (drop+shift)   POST (in-place)
 0  left/waist                 0.100              0.100
 1  left/shoulder              0.110              0.110
 ...
 5  left/wrist_rotate          0.150              0.150
 6  left/gripper               0.180  <-- r-arm    0.000   (gripper slot, missing -> 0)
 7  right/waist                0.190  <-- shifted   0.180
 8  right/shoulder             0.200  <-- shifted   0.190
 9  right/elbow                0.210  <-- shifted   0.200
10  right/forearm_roll         0.220  <-- shifted   0.210
11  right/wrist_angle          0.230  <-- shifted   0.220
12  right/wrist_rotate         0.000  <-- dropped   0.230
13  right/gripper              0.000              0.000
```

Pre-fix, **8 of the 14 state dims are wrong** — the entire right arm slides into the wrong slots and both gripper dims land wrong — silently.

## Change

A shared `_collect_state_values(observation_dict, order)` helper (used by both state-build paths) now zero-fills a missing resolved key **in place** so present joints keep their model index, and surfaces the degradation instead of leaving it silent:

- `strict_keys=True` -> raises a `ValueError` naming the missing keys and pointing at `embodiment=` / `set_robot_state_keys()` (mirrors the existing all-missing guard).
- `strict_keys=False` -> warns once and sets a new `missing_state_keys_used` telemetry flag, surfaced in the `run_policy` / `eval_policy` result dict alongside `generic_state_keys_used`.

Robots whose `robot_state_keys` are all present (e.g. `so101`) are unaffected — the fully-present path produces the identical vector and no warning. This is the partial-case completion of #897.

## Tests

New `tests/policies/lerobot_local/test_partial_state_key_alignment.py`:
- both paths keep the arm joints index-aligned (idx6 = 0.0 gripper placeholder, idx7 = right-arm-0 **not** shifted into idx6) — **fails pre-fix** (`assert 0.2 == 0.0`).
- `strict_keys=True` raises naming the missing keys on both paths — **fails pre-fix** (`DID NOT RAISE`).
- `missing_state_keys_used` set + warn-once.
- fully-present key set (so101-like) unchanged, no warning, flag stays False.

Green locally: `ruff check` + `ruff format` clean; `mypy` clean on the changed package files; `MUJOCO_GL=egl` pytest across `tests/policies/lerobot_local/`, `tests/simulation/test_policy_runner.py`, and `tests/simulation/test_policy_runner_behaviour.py` = 573 passed / 2 skipped. The 6 new tests all fail on pre-fix code and pass after.