### PR TITLE
fix(sim): warn when an action value is clamped by a ctrl-limited actuator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -669,6 +669,25 @@ telemetry flag (surfaced in the `run_policy` / `eval_policy` result alongside
 `generic_state_keys_used`). Robots whose keys are all present (e.g. `so101`)
 are unaffected.
 
+### Fixed: warn when an action value is clamped by a ctrl-limited actuator
+
+`send_action` (and therefore `replay_episode`) wrote an action value verbatim
+to `data.ctrl` for an actuator addressed by name. When that actuator is
+`ctrllimited` and the value falls outside its `ctrlrange`, MuJoCo clamps it
+inside `mj_step` -- so the commanded value is silently NOT reproduced for that
+actuator while the call still reports success. Replaying a dataset whose action
+units differ from the target robot's actuator ctrl units hit this hard: a
+normalized gripper action (e.g. the ALOHA convention, values in `[0.19, 1.12]`)
+replayed onto a joint-position gripper whose ctrlrange is `[0.002, 0.037]`
+clamps every value to the maximum, pinning the gripper fully open and silently
+destroying the grasp channel while `replay_episode` reports `Frames: N/N`. The
+direct-actuator ctrl write now warns once per `(prefix, key)` when the value is
+meaningfully outside the actuator's `ctrlrange`, naming the actuator and range
+so the unit mismatch is actionable instead of silent. A small tolerance absorbs
+boundary rounding; unlimited actuators (which never clamp) are skipped; the
+warning is de-duplicated so a 50Hz control loop never spams the log. No
+trajectory behaviour changes.
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -479,7 +479,9 @@ class RenderingMixin:
         for key, value in action_dict.items():
             act_id = _lookup(mj.mjtObj.mjOBJ_ACTUATOR, key)
             if act_id >= 0:
-                data.ctrl[act_id] = float(value)
+                fval = float(value)
+                self._warn_ctrl_clamp(model, act_id, pfx, key, fval, mj)
+                data.ctrl[act_id] = fval
                 continue
 
             # Fallback: key is a joint name. Find the actuator that drives
@@ -543,6 +545,59 @@ class RenderingMixin:
             pfx,
             reason,
             hint,
+        )
+
+    def _warn_ctrl_clamp(self, model: Any, act_id: int, pfx: str, key: str, value: float, mj: Any) -> None:
+        """Warn once when a value written to a ctrl-limited actuator is out of range.
+
+        The direct-actuator branch of :meth:`_apply_action_by_name` writes the
+        action value verbatim to ``data.ctrl``. When that actuator is
+        ``ctrllimited`` and the value falls outside its ``ctrlrange``, MuJoCo
+        clamps it inside ``mj_step`` - so the commanded trajectory is silently
+        NOT reproduced for that actuator while the call still reports success.
+
+        This is exactly the failure mode of replaying a dataset whose action
+        units differ from this robot's actuator ctrl units (e.g. a normalized
+        gripper action in ``[0, 1]`` replayed onto a joint-position gripper
+        whose ctrlrange is a few radians), or of a policy emitting
+        out-of-distribution commands. Surface it once per ``(prefix, key)`` so
+        a 50Hz control loop never spams the log. A small tolerance absorbs
+        boundary rounding, and unlimited actuators (which never clamp) are
+        skipped.
+        """
+        try:
+            if not bool(model.actuator_ctrllimited[act_id]):
+                return
+            lo = float(model.actuator_ctrlrange[act_id][0])
+            hi = float(model.actuator_ctrlrange[act_id][1])
+        except (IndexError, TypeError, ValueError):
+            return
+        if hi <= lo:
+            # [0, 0] sentinel or degenerate range: not a meaningful limit.
+            return
+        tol = (hi - lo) * 0.01
+        if lo - tol <= value <= hi + tol:
+            return
+        warned = getattr(self, "_warned_ctrl_clamp_keys", None)
+        if warned is None:
+            warned = set()
+            self._warned_ctrl_clamp_keys = warned
+        dedup = (pfx, key)
+        if dedup in warned:
+            return
+        warned.add(dedup)
+        logger.warning(
+            "[sim] action value %.4g for ctrl-limited actuator %r (prefix=%r) is outside "
+            "its ctrlrange [%.4g, %.4g]; MuJoCo will clamp it, so the commanded value is "
+            "NOT reproduced for this actuator. This usually means the action units do not "
+            "match the actuator - e.g. a normalized gripper action replayed onto a "
+            "joint-position gripper, or an out-of-distribution policy command. Rescale the "
+            "action to the actuator's units (or pass a matching action_key_map to replay).",
+            value,
+            key,
+            pfx,
+            lo,
+            hi,
         )
 
     def _get_valid_action_keys(self, pfx: str) -> list[str]:

--- a/tests/simulation/mujoco/test_ctrl_clamp_warning.py
+++ b/tests/simulation/mujoco/test_ctrl_clamp_warning.py
@@ -1,0 +1,109 @@
+"""Regression: warn when an action value is clamped by a ctrl-limited actuator.
+
+The direct-actuator branch of ``_apply_action_by_name`` writes the action
+value verbatim to ``data.ctrl``. When the actuator is ``ctrllimited`` and the
+value is outside its ``ctrlrange``, MuJoCo clamps it inside ``mj_step`` - so
+the commanded trajectory is silently NOT reproduced for that actuator while the
+call still reports success. This is the failure mode of replaying a dataset
+whose action units differ from the robot's actuator ctrl units (e.g. a
+normalized gripper action in ``[0.19, 1.12]`` replayed onto a joint-position
+gripper whose ctrlrange is ``[0.002, 0.037]``): every value clamps to the max,
+pinning the gripper open and destroying the grasp channel.
+
+These tests build a tiny synthetic model (no asset download) with a wide-range
+arm actuator, a small-range ("gripper") ctrl-limited actuator, and an
+unlimited actuator, and pin that ``_apply_action_by_name`` warns exactly when a
+value is meaningfully outside a ctrl-limited actuator's range.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+mujoco = pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.rendering import RenderingMixin  # noqa: E402
+
+_LOGGER = "strands_robots.simulation.mujoco.rendering"
+
+# arm_act: wide ctrlrange; grip_act: small ctrlrange mirroring the ALOHA
+# gripper ([0.002, 0.037]); free_act: no ctrlrange -> ctrllimited=0.
+_XML = """
+<mujoco model="clamp_test">
+  <worldbody>
+    <body name="link">
+      <joint name="arm_joint" type="hinge" axis="0 0 1" range="-3 3"/>
+      <geom type="capsule" size="0.02 0.1" fromto="0 0 0 0 0 0.2"/>
+      <body name="finger" pos="0 0 0.2">
+        <joint name="grip_joint" type="slide" axis="1 0 0" range="0 0.041"/>
+        <geom type="box" size="0.01 0.01 0.02"/>
+      </body>
+      <body name="spin" pos="0.1 0 0">
+        <joint name="free_joint" type="hinge" axis="0 1 0"/>
+        <geom type="box" size="0.01 0.01 0.02"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="arm_act" joint="arm_joint" ctrlrange="-3 3"/>
+    <position name="grip_act" joint="grip_joint" ctrlrange="0.002 0.037" kp="10"/>
+    <position name="free_act" joint="free_joint" kp="1"/>
+  </actuator>
+</mujoco>
+"""
+
+
+@pytest.fixture
+def model():
+    return mujoco.MjModel.from_xml_string(_XML)
+
+
+def _apply(model, action, mixin=None):
+    data = mujoco.MjData(model)
+    mixin = mixin or RenderingMixin()
+    mixin._apply_action_by_name(model, data, action, "", mujoco)
+    return mixin, data
+
+
+def test_warns_when_gripper_value_outside_ctrlrange(model, caplog):
+    """A normalized gripper action (0.5) far above ctrlrange [0.002, 0.037] warns."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER):
+        _apply(model, {"grip_act": 0.5})
+    msgs = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    hit = [m for m in msgs if "grip_act" in m and "ctrlrange" in m]
+    assert hit, f"expected a clamp warning naming grip_act; got {msgs}"
+    # Names the actuator's actual ctrlrange so the user can self-correct.
+    assert "0.002" in hit[0] and "0.037" in hit[0]
+
+
+def test_no_warning_when_gripper_value_in_range(model, caplog):
+    """An in-range gripper command (0.02) does not warn."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER):
+        _apply(model, {"grip_act": 0.02})
+    assert not [r for r in caplog.records if "grip_act" in r.getMessage() and "ctrlrange" in r.getMessage()]
+
+
+def test_no_warning_for_in_range_arm_value(model, caplog):
+    """A wide-range arm actuator commanded within range does not warn."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER):
+        _apply(model, {"arm_act": 1.0})
+    assert not [r for r in caplog.records if "arm_act" in r.getMessage() and "ctrlrange" in r.getMessage()]
+
+
+def test_no_warning_for_unlimited_actuator(model, caplog):
+    """An actuator with no ctrlrange (ctrllimited=0) never clamps -> no warning."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER):
+        _apply(model, {"free_act": 999.0})
+    assert not [r for r in caplog.records if "free_act" in r.getMessage() and "ctrlrange" in r.getMessage()]
+
+
+def test_warn_once_dedup(model, caplog):
+    """Two out-of-range commands for the same key warn only once (no 50Hz spam)."""
+    mixin = RenderingMixin()
+    with caplog.at_level(logging.WARNING, logger=_LOGGER):
+        _apply(model, {"grip_act": 0.5}, mixin)
+        _apply(model, {"grip_act": 0.8}, mixin)
+    hits = [r for r in caplog.records if "grip_act" in r.getMessage() and "ctrlrange" in r.getMessage()]
+    assert len(hits) == 1, f"expected exactly one dedup'd warning, got {len(hits)}"


### PR DESCRIPTION
## Problem

The direct-actuator branch of `_apply_action_by_name` writes an action value verbatim to `data.ctrl` when the key resolves to an actuator name:

```python
act_id = _lookup(mj.mjtObj.mjOBJ_ACTUATOR, key)
if act_id >= 0:
    data.ctrl[act_id] = float(value)   # raw write
    continue
```

When that actuator is `ctrllimited` and the value falls outside its `ctrlrange`, MuJoCo clamps it inside `mj_step` (the actuator force uses the clamped value; `data.ctrl` keeps the raw number). So the commanded value is silently **not reproduced** for that actuator, while `send_action` / `replay_episode` report success. This is the same "replay silently doesn't reproduce a channel" class already addressed for the control period and the actuator-vector mapping.

It bites hardest when the recorded action units differ from the target robot's actuator ctrl units. Replaying `lerobot/aloha_sim_transfer_cube_human` onto the MuJoCo ALOHA is a clean example:

| action key | ctrllimited | ctrlrange | recorded range | frac. outside |
|---|---|---|---|---|
| `right/waist` … `right/wrist_rotate` (12 arm joints) | True | wide (radians) | in range | **0.00** |
| `left/gripper` | True | `[0.002, 0.037]` | `[0.164, 1.119]` | **1.00** |
| `right/gripper` | True | `[0.002, 0.037]` | `[0.190, 1.116]` | **1.00** |

The recorded gripper action uses a normalized convention (`[~0.19, ~1.12]`); the target gripper is a joint-position actuator limited to `[0.002, 0.037]`. Every recorded gripper value is far above the range, so MuJoCo clamps them all to the maximum. The right-finger joint qpos confirms it — it snaps to `0.037` (fully open) at the start and stays there for the whole episode, including the frames where the demonstration commands the grasp (`0.21`):

```
frame:  action  finger_qpos      finger_sep
   0:   0.19    0.012 (home)     0.0225
  50:   0.48    0.037 (max)      0.0722
 190:   0.51    0.037 (max)      0.0722
 250:   0.21    0.037 (max)      0.0724   <- demonstrated grasp-close, still pinned open
 399:   0.87    0.037 (max)      0.0722
```

The arm reach is reproduced faithfully (right TCP descends `z 0.32 -> 0.03` then lifts to `0.28`), but the gripper is pinned fully open, so a cube placed at the demonstrated grasp point is never grasped (`d.xpos` delta: `dxy = 0.000 m`, `max z lift = 0.001 m`) — and `replay_episode` still reports `Frames: 400/400`.

![replay of the ALOHA transfer_cube demonstration: the arm reaches down but the gripper stays open the whole time, so the red cube is never grasped](https://github.com/cagataycali/robots/releases/download/artifacts-ctrl-clamp-warn/aloha_replay_gripper_open.gif)

## Fix

Add a warn-once diagnostic at the direct-actuator ctrl write. When the actuator is `ctrllimited` and the value is meaningfully outside its `ctrlrange`, log once per `(prefix, key)`, naming the actuator and its range and the consequence:

```
[sim] action value 0.19 for ctrl-limited actuator 'right/gripper' (prefix='aloha/') is
outside its ctrlrange [0.002, 0.037]; MuJoCo will clamp it, so the commanded value is
NOT reproduced for this actuator. This usually means the action units do not match the
actuator - e.g. a normalized gripper action replayed onto a joint-position gripper, or
an out-of-distribution policy command. Rescale the action to the actuator's units (or
pass a matching action_key_map to replay).
```

- Fires exactly on the two gripper dimensions in the case above; **zero** false positives on the 12 in-range arm joints.
- A 1%-of-span tolerance absorbs boundary rounding; unlimited actuators (which never clamp) are skipped; de-duplicated per `(prefix, key)` so a 50Hz loop never spams.
- **No trajectory behaviour change** — this only surfaces a silent clamp; it does not attempt to rescale units (which would risk corrupting correct trajectories).

Verified end to end: `sim.replay_episode('lerobot/aloha_sim_transfer_cube_human', 'aloha', 0)` now emits the warning for both grippers.

## Tests

`tests/simulation/mujoco/test_ctrl_clamp_warning.py` (synthetic model, no asset download, GL-free): out-of-range value warns and names the range; in-range gripper / in-range arm / unlimited actuator do not warn; two out-of-range commands warn once (dedup). The two positive tests fail before the fix (no warning emitted) and pass after; the negative guards pass in both states.

Gate: `ruff check` + `ruff format --check` + `mypy` clean on the changed files; the send_action / tendon / action-key / backend suites pass (62 tests).