### PR TITLE
test(libero): pin _extract_compiled_mjcf accessor-drift fallback and fail-loud contract

### DIFF
--- a/tests/benchmarks/libero/test_libero_adapter.py
+++ b/tests/benchmarks/libero/test_libero_adapter.py
@@ -2314,6 +2314,134 @@ class TestRenameMjcfCameras:
         assert 'name="image"' in out
 
 
+class TestExtractCompiledMjcf:
+    """``_extract_compiled_mjcf`` pulls the MJCF XML out of a libero
+    ControlEnv through a small ladder of robosuite accessors.
+
+    Robosuite renamed the accessor over the years, so the helper tries
+    ``env.env.model.get_xml()`` (pre-compile, preferred - preserves
+    ``<compiler>`` attributes like ``inertiagrouprange``), then
+    ``env.env.model.get_model_xml()``, then ``env.env.sim.model.get_xml()``
+    (post-compile, lossy) before giving up. These tests pin that
+    accessor-drift resilience and the fail-loud contract when every
+    accessor is unavailable - all dependency-free (no robosuite / mujoco).
+    """
+
+    @staticmethod
+    def _make_env(*, pre=None, model_xml=None, post=None):
+        """Build a fake libero ControlEnv exposing only the requested
+        accessors. A value that is an ``Exception`` instance makes that
+        accessor raise it; a string makes it return that string; omitting
+        it (None) means the attribute is absent so the call raises
+        ``AttributeError`` - exactly the robosuite-version-drift case.
+        """
+
+        def _accessor(value):
+            def _call():
+                if isinstance(value, BaseException):
+                    raise value
+                return value
+
+            return _call
+
+        class _Model:
+            pass
+
+        model = _Model()
+        if pre is not None:
+            model.get_xml = _accessor(pre)  # type: ignore[attr-defined]
+        if model_xml is not None:
+            model.get_model_xml = _accessor(model_xml)  # type: ignore[attr-defined]
+
+        class _SimModel:
+            pass
+
+        sim_model = _SimModel()
+        if post is not None:
+            sim_model.get_xml = _accessor(post)  # type: ignore[attr-defined]
+
+        class _Sim:
+            pass
+
+        sim = _Sim()
+        sim.model = sim_model  # type: ignore[attr-defined]
+
+        class _Inner:
+            pass
+
+        inner = _Inner()
+        inner.model = model  # type: ignore[attr-defined]
+        inner.sim = sim  # type: ignore[attr-defined]
+
+        class _Env:
+            pass
+
+        env = _Env()
+        env.env = inner  # type: ignore[attr-defined]
+        return env
+
+    def test_prefers_precompile_accessor(self):
+        """When ``env.env.model.get_xml()`` is available it wins, even if
+        the lossy post-compile accessor would also succeed."""
+        from strands_robots.benchmarks.libero.adapter import _extract_compiled_mjcf
+
+        env = self._make_env(pre="<mujoco>pre</mujoco>", post="<mujoco>post</mujoco>")
+        assert _extract_compiled_mjcf(env) == "<mujoco>pre</mujoco>"
+
+    def test_falls_back_to_get_model_xml(self):
+        """Missing ``get_xml`` (AttributeError) falls through to the older
+        ``get_model_xml`` accessor."""
+        from strands_robots.benchmarks.libero.adapter import _extract_compiled_mjcf
+
+        env = self._make_env(model_xml="<mujoco>model_xml</mujoco>")
+        assert _extract_compiled_mjcf(env) == "<mujoco>model_xml</mujoco>"
+
+    def test_falls_back_to_postcompile_accessor(self):
+        """When both pre-compile accessors raise, the last-resort
+        post-compile ``env.env.sim.model.get_xml()`` is used."""
+        from strands_robots.benchmarks.libero.adapter import _extract_compiled_mjcf
+
+        env = self._make_env(
+            pre=RuntimeError("robosuite drift"),
+            post="<mujoco>post</mujoco>",
+        )
+        assert _extract_compiled_mjcf(env) == "<mujoco>post</mujoco>"
+
+    def test_skips_empty_string_result(self):
+        """An accessor that returns an empty / whitespace string is not a
+        valid MJCF - the ladder continues to the next accessor."""
+        from strands_robots.benchmarks.libero.adapter import _extract_compiled_mjcf
+
+        env = self._make_env(pre="   ", post="<mujoco>post</mujoco>")
+        assert _extract_compiled_mjcf(env) == "<mujoco>post</mujoco>"
+
+    def test_skips_non_string_result(self):
+        """An accessor that returns a non-string (e.g. a robosuite model
+        object) is skipped rather than returned or coerced."""
+        from strands_robots.benchmarks.libero.adapter import _extract_compiled_mjcf
+
+        env = self._make_env(pre=object(), post="<mujoco>post</mujoco>")
+        assert _extract_compiled_mjcf(env) == "<mujoco>post</mujoco>"
+
+    def test_raises_when_all_accessors_fail(self):
+        """Every accessor unavailable -> fail loud with a RuntimeError that
+        names the last underlying error (never a silent empty string)."""
+        from strands_robots.benchmarks.libero.adapter import _extract_compiled_mjcf
+
+        env = self._make_env(post=ValueError("post boom"))
+        with pytest.raises(RuntimeError, match="could not extract MJCF"):
+            _extract_compiled_mjcf(env)
+
+    def test_raise_message_includes_last_error(self):
+        """The raised RuntimeError chains the most recent accessor failure
+        so the operator can see *why* extraction failed."""
+        from strands_robots.benchmarks.libero.adapter import _extract_compiled_mjcf
+
+        env = self._make_env(post=ValueError("post boom"))
+        with pytest.raises(RuntimeError, match="post boom"):
+            _extract_compiled_mjcf(env)
+
+
 class TestCacheTransformVersion:
     """The cache-key derivation includes ``_LIBERO_MJCF_TRANSFORM_VERSION``
     so a version bump invalidates stale on-disk caches generated by


### PR DESCRIPTION
## Problem

`_extract_compiled_mjcf` in `strands_robots/benchmarks/libero/adapter.py` pulls the compiled MJCF out of a LIBERO `ControlEnv` through a small ladder of robosuite accessors that have been renamed across robosuite versions:

1. `env.env.model.get_xml()` - pre-compile MJCF (preferred; preserves `<compiler>` attributes like `inertiagrouprange`).
2. `env.env.model.get_model_xml()` - older robosuite accessor.
3. `env.env.sim.model.get_xml()` - last-resort post-compile re-serialization (lossy).

The fallback ladder and the fail-loud `RuntimeError` (raised when every accessor is unavailable) were untested. That resilience is the entire reason the helper exists, so a silent regression - e.g. accidentally returning an empty string instead of raising, or not advancing past a raising accessor - would slip through CI.

## Change

Add `TestExtractCompiledMjcf` to `tests/benchmarks/libero/test_libero_adapter.py` pinning the accessor-drift contract with dependency-free fake envs (no robosuite / mujoco required):

- pre-compile accessor is preferred when available;
- a missing/raising accessor falls through to the next one (`AttributeError` from a renamed accessor, or an explicit raise);
- the post-compile accessor is used only as a last resort;
- empty/whitespace and non-string results are skipped rather than returned or coerced;
- when every accessor fails the helper raises `RuntimeError` and the message names the last underlying error (never a silent empty string).

## Tests

7 new tests, all passing. The previously-uncovered error/fallback lines in `_extract_compiled_mjcf` are now exercised; no production code changed.

```
tests/benchmarks/libero/test_libero_adapter.py::TestExtractCompiledMjcf .......  [7 passed]
396 passed, 28 skipped   # full tests/benchmarks/libero/
```

Lint clean: `ruff check`, `ruff format --check`, `mypy strands_robots tests tests_integ` (no issues in 677 source files).