### PR TITLE
test(motionbricks): cover MotionBricksConfig error paths (empty result_dir, from_file rejections)

### DIFF
--- a/tests/policies/motionbricks/test_policy.py
+++ b/tests/policies/motionbricks/test_policy.py
@@ -145,6 +145,35 @@ def test_config_from_file_missing(tmp_path: Any) -> None:
         MotionBricksConfig.from_file(str(tmp_path / "nope.json"))
 
 
+def test_config_rejects_empty_result_dir() -> None:
+    # result_dir is the path to the checkpoint tree; an empty string would
+    # silently misbehave deep in the generator, so __post_init__ fails fast.
+    with pytest.raises(ValueError, match="result_dir must be a non-empty path"):
+        MotionBricksConfig(result_dir="")
+
+
+def test_config_from_file_rejects_non_json_extension(tmp_path: Any) -> None:
+    p = tmp_path / "mb.yaml"
+    p.write_text('{"result_dir": "out"}')
+    with pytest.raises(ValueError, match="unsupported extension"):
+        MotionBricksConfig.from_file(str(p))
+
+
+def test_config_from_file_rejects_invalid_json(tmp_path: Any) -> None:
+    p = tmp_path / "mb.json"
+    p.write_text("{not valid json,,,}")
+    with pytest.raises(ValueError, match="not valid JSON"):
+        MotionBricksConfig.from_file(str(p))
+
+
+def test_config_from_file_rejects_non_mapping(tmp_path: Any) -> None:
+    # Valid JSON, but a top-level array/scalar is not a config mapping.
+    p = tmp_path / "mb.json"
+    p.write_text('["result_dir", "out"]')
+    with pytest.raises(ValueError, match="must contain a mapping"):
+        MotionBricksConfig.from_file(str(p))
+
+
 # ---------------------------------------------------------------------------
 # Style resolution + control-signal assembly
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What
Adds targeted error-path tests for `MotionBricksConfig`, taking `strands_robots/policies/motionbricks/config.py` from 93% to 100% line coverage. These validation branches were previously unexercised.

Four failure modes are now pinned:

- `__post_init__` rejects an empty `result_dir` (fail-fast; an empty checkpoint path would otherwise misbehave deep inside the generator).
- `from_file` rejects a non-`.json` extension.
- `from_file` rejects a file that is not valid JSON.
- `from_file` rejects valid JSON whose top level is not a mapping (e.g. an array/scalar).

## Why
`from_file` / `from_dict` are the public config entry points; their happy path and the missing-file / bad-knob paths were already covered, but the extension-guard, JSON-decode, non-mapping, and empty-`result_dir` guards were not. These are the exact fail-fast contracts the loader promises in its docstring (`Raises: FileNotFoundError / ValueError`), so pinning them prevents silent regressions if the validation is ever refactored.

## Testing
Test-only change; no production code touched.

- `config.py` coverage: 93% -> 100% (5 lines: 97, 161, 164-165, 167).
- Each test asserts the specific error message the corresponding guard emits, so removing a guard fails the test.
- `pytest tests/policies/motionbricks/ -v` -> 57 passed.
- Lint gate clean (`ruff check`, `ruff format --check`, `mypy`: no issues found in 678 source files).