### PR TITLE
test(training): pin LerobotTrainer offline-registry and held-out-split contracts

### DIFF
--- a/tests/training/test_lerobot.py
+++ b/tests/training/test_lerobot.py
@@ -1109,3 +1109,98 @@ class TestLearningRate:
         )
         with pytest.raises(ValueError, match="optimizer_lr"):
             LerobotTrainer(device="cpu").build_config(spec)
+
+
+class TestOfflineRegistryFallbacks:
+    """Graceful degradation when lerobot's config ChoiceRegistry is unavailable.
+
+    Type/field discovery reads live off lerobot's draccus registries, which are
+    populated as an import side effect of ``lerobot.policies`` / ``lerobot.rewards``.
+    When those imports fail (lerobot not installed, or lerobot < 0.5.2 with no
+    ``lerobot.rewards``), discovery must fall back to the documented static sets
+    instead of raising, so ``validate`` still produces an actionable message
+    offline. Import failure is simulated by binding the submodule to ``None`` in
+    ``sys.modules`` (makes ``import`` raise ``ImportError``).
+    """
+
+    def test_policy_registry_is_none_when_lerobot_policies_unimportable(self, monkeypatch):
+        import sys
+
+        from strands_robots.training import lerobot as mod
+
+        monkeypatch.setitem(sys.modules, "lerobot.policies", None)
+        assert mod._policy_registry() is None
+
+    def test_policy_types_use_static_fallback_offline(self, monkeypatch):
+        import sys
+
+        from strands_robots.training import lerobot as mod
+
+        monkeypatch.setitem(sys.modules, "lerobot.policies", None)
+        assert mod._lerobot_policy_types() == set(mod._LEROBOT_POLICY_TYPES_FALLBACK)
+
+    def test_relative_action_support_uses_static_fallback_offline(self, monkeypatch):
+        import sys
+
+        from strands_robots.training import lerobot as mod
+
+        monkeypatch.setitem(sys.modules, "lerobot.policies", None)
+        # The pi0 family is in the documented fallback set; act is not.
+        assert mod._policy_supports_relative_actions("pi0") is True
+        assert mod._policy_supports_relative_actions("act") is False
+
+    def test_reward_registry_is_none_when_lerobot_rewards_unimportable(self, monkeypatch):
+        import sys
+
+        from strands_robots.training import lerobot as mod
+
+        monkeypatch.setitem(sys.modules, "lerobot.rewards", None)
+        assert mod._reward_registry() is None
+
+    def test_reward_model_types_use_static_fallback_offline(self, monkeypatch):
+        import sys
+
+        from strands_robots.training import lerobot as mod
+
+        monkeypatch.setitem(sys.modules, "lerobot.rewards", None)
+        assert mod._reward_model_types() == set(mod._REWARD_MODEL_TYPES_FALLBACK)
+
+
+class TestRunTypeLabel:
+    """``_run_type_label`` distinguishes a reward-model run from a policy run."""
+
+    def test_labels_reward_model_run(self):
+        spec = TrainSpec(extra={"reward_model": {"type": "sarm"}})
+        assert LerobotTrainer(device="cpu")._run_type_label(spec) == "reward_model:sarm"
+
+    def test_labels_policy_run(self):
+        spec = TrainSpec(extra={"policy_type": "diffusion"})
+        assert LerobotTrainer(device="cpu")._run_type_label(spec) == "policy:diffusion"
+
+
+class TestValSplitEpisodesFallthrough:
+    """The held-out split is a no-op (use the full dataset) when it can't be computed.
+
+    ``_val_split_episodes`` returns ``None`` -- meaning "train on every episode" --
+    rather than raising or emitting a malformed ``episodes`` range when the episode
+    count is unknown (no readable ``meta/info.json``) or the requested holdout is
+    not strictly inside ``(0, total)``.
+    """
+
+    def test_no_op_when_episode_count_unknown(self, tmp_path):
+        # dataset_root set but no meta/info.json -> total unknown -> no split.
+        spec = TrainSpec(dataset_root=str(tmp_path), val_episodes=2)
+        assert LerobotTrainer(device="cpu")._val_split_episodes(spec) is None
+
+    def test_no_op_when_holdout_not_smaller_than_total(self, dataset_root):
+        # info.json reports total_episodes=10; a holdout >= total is out of range.
+        spec = TrainSpec(dataset_root=dataset_root, val_episodes=10)
+        assert LerobotTrainer(device="cpu")._val_split_episodes(spec) is None
+
+
+class TestHardwareFloor:
+    """``hardware_floor`` advertises the advisory minimum compute for LeRobot tuning."""
+
+    def test_advisory_single_consumer_gpu(self):
+        floor = LerobotTrainer(device="cpu").hardware_floor
+        assert floor == {"min_gpus": 1, "min_vram_gb": 8, "multinode": False}


### PR DESCRIPTION
## What
Adds focused regression tests for `LerobotTrainer`'s graceful-degradation paths, which had no coverage.

The trainer discovers policy/reward-model types and their configurable fields live off lerobot's draccus `ChoiceRegistry`, populated as an import side effect of `lerobot.policies` / `lerobot.rewards`. When those imports fail (lerobot not installed, or lerobot < 0.5.2 with no `lerobot.rewards`), discovery must fall back to the documented static sets rather than raise, so `validate()` still returns an actionable message offline. That fallback plus a couple of adjacent pure-Python contracts were untested.

## Tests added
- `TestOfflineRegistryFallbacks` - simulate the import failure via `monkeypatch.setitem(sys.modules, ...)` and assert:
  - `_policy_registry()` / `_reward_registry()` return `None`.
  - `_lerobot_policy_types()` / `_reward_model_types()` return the documented static fallback sets.
  - `_policy_supports_relative_actions()` uses the static fallback (pi0 family True, act False).
- `TestRunTypeLabel` - `_run_type_label` labels a reward-model run vs a policy run.
- `TestValSplitEpisodesFallthrough` - `_val_split_episodes` is a no-op (returns `None`, i.e. train on the full dataset) when the episode count is unknown (no readable `meta/info.json`) or the requested holdout is not strictly inside `(0, total)`, rather than raising or emitting a malformed `episodes` range.
- `TestHardwareFloor` - `hardware_floor` advertises the advisory single-consumer-GPU minimum.

## Coverage
`strands_robots/training/lerobot.py`: closes the previously-uncovered offline/degraded-input lines (registry `ImportError` fallbacks, `_reward_model_types` fallback, `_run_type_label` reward branch, `_val_split_episodes` fall-through, `hardware_floor`).

## Notes
Behavior-only assertions (outputs, not internals). Tests are pure and order-independent - they do not import heavy lerobot/accelerate paths. Local gate green: `ruff check`, `ruff format --check`, `mypy` clean; `tests/training/test_lerobot.py` 108 passed.