### PR TITLE
fix(lerobot_local): zero-fill a missing embodiment state_key in place; use aloha's 14 actuator keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -688,6 +688,32 @@ boundary rounding; unlimited actuators (which never clamp) are skipped; the
 warning is de-duplicated so a 50Hz control loop never spams the log. No
 trajectory behaviour changes.
 
+### Fixed: the `aloha` embodiment mis-aligned `observation.state` and mapped gripper actions onto non-actuators
+
+The declarative-embodiment state builder (`PackStateProcessorStep.observation()`)
+appended a value only for `state_keys` *found* in the observation and skipped the
+absent ones, so a missing key DROPPED its slot and shifted every following joint
+up one index before the trailing pad -- the embodiment-path analog of the
+generic-path fix from "a partial `robot_state_keys` mismatch silently mis-aligned
+`observation.state`" above. A missing `state_key` is now zero-filled IN PLACE so
+the present joints keep their model index, with a one-time warning naming the
+absent keys.
+
+The `aloha` config compounded this: it declared the 16 finger-JOINT names
+(`left/left_finger`, `left/right_finger`, ...) for both `state_keys` and
+`action_keys`, but the model's 14 ACTUATORS follow the canonical gym-aloha /
+LeRobot ACT convention `[6 arm + 1 gripper] x 2` (`left/gripper` / `right/gripper`
+at indices 6 and 13, each driving both fingers). Against a canonical 14-D ACT the
+16-key state build raised `observation.state dim 16 > model expected 14`, and the
+finger-joint `action_keys` mapped the policy's gripper command onto non-actuators
+(the gripper was never driven). The config now uses the 14 actuator keys, so the
+action maps 1:1 onto actuators and the arm proprioception is index-aligned; the
+two gripper STATE slots -- absent from the sim observation, which exposes finger
+joints -- are zero-filled in place (a units-correct finger->gripper state mapping
+is a checkpoint-specific follow-up). Loading the canonical
+`lerobot/act_aloha_sim_transfer_cube_human` through `embodiment="aloha"` now runs
+a rollout instead of crashing.
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/policies/lerobot_local/embodiment.py
+++ b/strands_robots/policies/lerobot_local/embodiment.py
@@ -261,6 +261,27 @@ class ZeroActionMonitor:
 
 # Imported lazily so this module is importable without lerobot (e.g. for unit
 # testing EmbodimentMap loading/validation in a minimal env).
+# Warn-once dedup for state_keys absent from the observation (keyed by the
+# missing-key tuple, which is stable across the 50Hz control loop).
+_WARNED_MISSING_STATE_KEYS: set[tuple[str, ...]] = set()
+
+
+def _warn_missing_state_keys(missing: list[str]) -> None:
+    """Warn once that some declared ``state_keys`` were absent (zero-filled in place)."""
+    sig = tuple(missing)
+    if sig in _WARNED_MISSING_STATE_KEYS:
+        return
+    _WARNED_MISSING_STATE_KEYS.add(sig)
+    logger.warning(
+        "lerobot_local: state_key(s) %s absent from the observation; zero-filled IN "
+        "PLACE so the present joints keep their model index (the missing dims read 0). "
+        "The canonical trigger is a mimic/tendon gripper actuator (e.g. left/gripper) "
+        "whose sim observation exposes finger joints instead -- the arm proprioception "
+        "stays aligned while the gripper state reads 0.",
+        missing,
+    )
+
+
 def register_pack_state_step() -> type | None:
     """Define + register :class:`PackStateProcessorStep` against lerobot.
 
@@ -322,8 +343,11 @@ def register_pack_state_step() -> type | None:
                 return observation  # already packed -> passthrough
 
             vals: list[float] = []
+            missing: list[str] = []
+            present = 0
             for k in self.state_keys:
                 if k in observation:
+                    present += 1
                     v = observation[k]
                     if isinstance(v, np.ndarray):
                         if v.ndim == 0:
@@ -334,11 +358,23 @@ def register_pack_state_step() -> type | None:
                         vals.extend(float(x) for x in v)
                     else:
                         vals.append(float(v))
+                else:
+                    # Zero-fill the missing key IN PLACE so it holds its slot.
+                    # Skipping it (the previous behavior) collapsed the vector and
+                    # shifted every following joint out of its model index -- the
+                    # embodiment-path analog of the generic-path fix in
+                    # LerobotLocalPolicy._collect_state_values.
+                    vals.append(0.0)
+                    missing.append(k)
 
-            if not vals:
-                # No declared state keys present; leave obs alone so a clearer
-                # downstream error (or a state-less policy) can handle it.
+            if present == 0:
+                # No declared state key present at all; leave obs alone so a
+                # clearer downstream error (or a state-less policy) can handle
+                # it, rather than emitting an all-zero state vector.
                 return observation
+
+            if missing:
+                _warn_missing_state_keys(missing)
 
             # Convert sim units (radians + gripper joint range) to the model's
             # training units (arm degrees, gripper 0..100) BEFORE packing, so the

--- a/strands_robots/policies/lerobot_local/embodiments.json
+++ b/strands_robots/policies/lerobot_local/embodiments.json
@@ -414,7 +414,7 @@
       "dim_policy": "pad"
     },
     "aloha": {
-      "__note__": "SIM: mujoco_menagerie/aloha/aloha.xml. Bimanual: left/* + right/* (16 joints incl. 2 fingers/arm). Cameras vary by scene; default top cam mapped to observation.images.top. Previously this entry had EMPTY state_keys (no-op bug) - now fully populated.",
+      "__note__": "SIM: mujoco_menagerie/aloha/aloha.xml. Bimanual 14-DOF control matching the canonical gym-aloha / LeRobot ACT convention [6 arm + 1 gripper] x 2 arms: the model's 14 ACTUATORS are left/{waist,shoulder,elbow,forearm_roll,wrist_angle,wrist_rotate,gripper} and the right/* mirror; each gripper actuator drives both fingers. These are robot_action_keys, so the policy's action maps 1:1 onto actuators (previously the entry declared the 16 finger-JOINT names, which are not actuators and crash/mis-align a 14-D ACT). The sim observation exposes the finger JOINTS (left/left_finger, ...) not a gripper value, so the two gripper STATE slots are zero-filled IN PLACE (arm proprioception stays index-aligned; a warning is emitted once). A units-correct finger->gripper state mapping is a checkpoint-specific follow-up. Cameras vary by scene; default top cam -> observation.images.top.",
       "obs_rename": {
         "top": "observation.images.top"
       },
@@ -425,16 +425,14 @@
         "left/forearm_roll",
         "left/wrist_angle",
         "left/wrist_rotate",
-        "left/left_finger",
-        "left/right_finger",
+        "left/gripper",
         "right/waist",
         "right/shoulder",
         "right/elbow",
         "right/forearm_roll",
         "right/wrist_angle",
         "right/wrist_rotate",
-        "right/left_finger",
-        "right/right_finger"
+        "right/gripper"
       ],
       "action_keys": [
         "left/waist",
@@ -443,16 +441,14 @@
         "left/forearm_roll",
         "left/wrist_angle",
         "left/wrist_rotate",
-        "left/left_finger",
-        "left/right_finger",
+        "left/gripper",
         "right/waist",
         "right/shoulder",
         "right/elbow",
         "right/forearm_roll",
         "right/wrist_angle",
         "right/wrist_rotate",
-        "right/left_finger",
-        "right/right_finger"
+        "right/gripper"
       ],
       "dim_policy": "pad"
     },

--- a/tests/policies/lerobot_local/test_embodiment_state_zerofill_alignment.py
+++ b/tests/policies/lerobot_local/test_embodiment_state_zerofill_alignment.py
@@ -30,7 +30,6 @@ import pytest
 pytest.importorskip("lerobot")
 
 import strands_robots.policies.lerobot_local.embodiment as E
-from strands_robots.policies.lerobot_local.embodiment import load_embodiment, register_pack_state_step
 
 # The aloha bimanual actuator convention: 6 arm + 1 gripper actuator per side,
 # gripper actuators interspersed at indices 6 and 13.
@@ -74,7 +73,7 @@ def _sim_obs_no_gripper() -> dict[str, float]:
 
 
 def _step(state_keys, expected_dim, **kw):
-    Step = register_pack_state_step()
+    Step = E.register_pack_state_step()
     assert Step is not None, "lerobot processor framework unavailable"
     return Step(state_keys=list(state_keys), expected_dim=expected_dim, dim_policy=kw.pop("dim_policy", "pad"), **kw)
 
@@ -132,7 +131,7 @@ class TestAlohaEmbodimentActuatorConvention:
         """The shipped aloha embodiment uses the 14 actuator convention (matching
         the model's actuators / robot_action_keys), not the 16 finger-JOINT
         names that crash/mis-align a canonical 14-D ACT."""
-        emb = load_embodiment("aloha")
+        emb = E.load_embodiment("aloha")
         assert emb.state_keys == ALOHA_14
         assert emb.action_keys == ALOHA_14
         # the old 16-finger-joint layout is gone
@@ -143,7 +142,7 @@ class TestAlohaEmbodimentActuatorConvention:
         """End-to-end: build observation.state from a gripper-less sim obs through
         the real aloha embodiment config; arm stays aligned, grippers zero-filled."""
         E._WARNED_MISSING_STATE_KEYS.clear()
-        emb = load_embodiment("aloha")
+        emb = E.load_embodiment("aloha")
         step = _step(emb.state_keys, 14, dim_policy=emb.dim_policy)
         state = step.observation(_sim_obs_no_gripper())["observation.state"].numpy()
         expected = LEFT_ARM + [0.0] + RIGHT_ARM + [0.0]

--- a/tests/policies/lerobot_local/test_embodiment_state_zerofill_alignment.py
+++ b/tests/policies/lerobot_local/test_embodiment_state_zerofill_alignment.py
@@ -1,0 +1,150 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""Declarative-embodiment state build must zero-fill a missing state_key IN PLACE.
+
+This is the embodiment-path sibling of the generic-path fix pinned in
+``test_partial_state_key_alignment.py``. ``PackStateProcessorStep.observation()``
+(the step a declarative embodiment installs on the preprocessor) previously
+appended a value only for state_keys *found* in the observation and skipped the
+absent ones, so a missing key DROPPED its slot and shifted every following joint
+up one index before the trailing pad -- the model received a garbage
+``observation.state`` while the run reported success.
+
+The canonical trigger is the aloha bimanual embodiment: its 14 actuators follow
+the gym-aloha / LeRobot ACT convention ``[6 arm + 1 gripper] x 2`` with the
+gripper ACTUATORS ``left/gripper`` / ``right/gripper`` at indices 6 and 13, but
+the sim observation exposes the finger JOINTS (``left/left_finger`` ...), never a
+``*/gripper`` value. With the old skip logic the right-arm joints slid into the
+left gripper slot; and because the shipped config declared the 16 finger-JOINT
+names (not the 14 actuators), a canonical 14-D ACT crashed outright
+(``observation.state dim 16 > model expected 14``).
+
+These tests pin the corrected behaviour: a missing state_key is zero-filled IN
+PLACE (present joints keep their model index), the degradation is warned once,
+a fully-present key set is unchanged, an all-missing set is left untouched for a
+clearer downstream error, and the aloha embodiment declares the 14 actuator keys.
+"""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("lerobot")
+
+import strands_robots.policies.lerobot_local.embodiment as E
+from strands_robots.policies.lerobot_local.embodiment import load_embodiment, register_pack_state_step
+
+# The aloha bimanual actuator convention: 6 arm + 1 gripper actuator per side,
+# gripper actuators interspersed at indices 6 and 13.
+ALOHA_14 = [
+    "left/waist",
+    "left/shoulder",
+    "left/elbow",
+    "left/forearm_roll",
+    "left/wrist_angle",
+    "left/wrist_rotate",
+    "left/gripper",
+    "right/waist",
+    "right/shoulder",
+    "right/elbow",
+    "right/forearm_roll",
+    "right/wrist_angle",
+    "right/wrist_rotate",
+    "right/gripper",
+]
+LEFT_ARM = [100.0, 101.0, 102.0, 103.0, 104.0, 105.0]
+RIGHT_ARM = [108.0, 109.0, 110.0, 111.0, 112.0, 113.0]
+ARM_KEYS_L = ALOHA_14[0:6]
+ARM_KEYS_R = ALOHA_14[7:13]
+
+
+def _sim_obs_no_gripper() -> dict[str, float]:
+    """A sim observation exposing the arm joints + finger joints but NOT the
+    gripper actuator keys ``left/gripper`` / ``right/gripper`` (mirrors what the
+    real MuJoCo aloha's ``get_observation`` returns)."""
+    obs: dict[str, float] = {}
+    for k, v in zip(ARM_KEYS_L, LEFT_ARM):
+        obs[k] = v
+    for k, v in zip(ARM_KEYS_R, RIGHT_ARM):
+        obs[k] = v
+    # finger joints present but NOT declared as state_keys (so they are ignored):
+    obs["left/left_finger"] = 0.02
+    obs["left/right_finger"] = 0.02
+    obs["right/left_finger"] = 0.02
+    obs["right/right_finger"] = 0.02
+    return obs
+
+
+def _step(state_keys, expected_dim, **kw):
+    Step = register_pack_state_step()
+    assert Step is not None, "lerobot processor framework unavailable"
+    return Step(state_keys=list(state_keys), expected_dim=expected_dim, dim_policy=kw.pop("dim_policy", "pad"), **kw)
+
+
+class TestPackStateZeroFillInPlace:
+    def test_missing_gripper_keys_zero_filled_in_place(self):
+        """Arm joints keep their canonical model index; the two absent gripper
+        actuator slots read 0.0. FAILS pre-fix: the right arm slid into the
+        left-gripper slot and both zeros landed at the tail."""
+        E._WARNED_MISSING_STATE_KEYS.clear()
+        out = _step(ALOHA_14, 14).observation(_sim_obs_no_gripper())
+        state = out["observation.state"].numpy()
+        assert len(state) == 14
+        np.testing.assert_allclose(state[0:6], LEFT_ARM, atol=1e-5)
+        assert state[6] == 0.0  # left/gripper slot held in place
+        np.testing.assert_allclose(state[7:13], RIGHT_ARM, atol=1e-5)  # <- shifted pre-fix
+        assert state[13] == 0.0  # right/gripper slot held in place
+
+    def test_missing_keys_warn_once(self, caplog):
+        """The degradation is surfaced once (naming the absent keys), then
+        deduplicated across the hot control loop."""
+        E._WARNED_MISSING_STATE_KEYS.clear()
+        step = _step(ALOHA_14, 14)
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="strands_robots.policies.lerobot_local.embodiment"):
+            step.observation(_sim_obs_no_gripper())
+            step.observation(_sim_obs_no_gripper())
+        warns = [r for r in caplog.records if "absent from the observation" in r.getMessage()]
+        assert len(warns) == 1
+        assert "left/gripper" in warns[0].getMessage() and "right/gripper" in warns[0].getMessage()
+
+    def test_all_present_unchanged(self):
+        """A fully-present key set is packed verbatim with no zero-fill (the
+        so101-style path); this must not regress."""
+        E._WARNED_MISSING_STATE_KEYS.clear()
+        keys = ["a", "b", "c"]
+        out = _step(keys, 3).observation({"a": 1.0, "b": 2.0, "c": 3.0})
+        state = out["observation.state"].numpy()
+        np.testing.assert_allclose(state, [1.0, 2.0, 3.0], atol=1e-5)
+        assert not E._WARNED_MISSING_STATE_KEYS  # no missing -> no warn recorded
+
+    def test_all_missing_passthrough(self):
+        """When NONE of the declared keys are present, leave the observation
+        untouched so a clearer downstream error can fire (do not emit all-zero)."""
+        E._WARNED_MISSING_STATE_KEYS.clear()
+        obs = {"unrelated": 5.0}
+        out = _step(["a", "b"], 2).observation(dict(obs))
+        assert "observation.state" not in out
+        assert out == obs
+
+
+class TestAlohaEmbodimentActuatorConvention:
+    def test_aloha_declares_14_actuator_keys(self):
+        """The shipped aloha embodiment uses the 14 actuator convention (matching
+        the model's actuators / robot_action_keys), not the 16 finger-JOINT
+        names that crash/mis-align a canonical 14-D ACT."""
+        emb = load_embodiment("aloha")
+        assert emb.state_keys == ALOHA_14
+        assert emb.action_keys == ALOHA_14
+        # the old 16-finger-joint layout is gone
+        assert "left/left_finger" not in emb.state_keys
+        assert "left/left_finger" not in emb.action_keys
+
+    def test_aloha_state_build_is_canonically_aligned(self):
+        """End-to-end: build observation.state from a gripper-less sim obs through
+        the real aloha embodiment config; arm stays aligned, grippers zero-filled."""
+        E._WARNED_MISSING_STATE_KEYS.clear()
+        emb = load_embodiment("aloha")
+        step = _step(emb.state_keys, 14, dim_policy=emb.dim_policy)
+        state = step.observation(_sim_obs_no_gripper())["observation.state"].numpy()
+        expected = LEFT_ARM + [0.0] + RIGHT_ARM + [0.0]
+        np.testing.assert_allclose(state, expected, atol=1e-5)


### PR DESCRIPTION
## Problem

The declarative-embodiment state builder `PackStateProcessorStep.observation()` built `observation.state` by appending a value only for `state_keys` **found** in the observation and **skipping** the absent ones. A missing key therefore *dropped its slot* and shifted every following joint up one index before the trailing pad, so the model silently received a mis-aligned state vector while the rollout reported success.

This is the embodiment-path analog of the generic-path defect already fixed in `LerobotLocalPolicy._collect_state_values` ("a partial `robot_state_keys` mismatch silently mis-aligned `observation.state`"). The generic path was corrected; this parallel path was not.

The `aloha` embodiment compounded it. Its config declared the **16 finger-JOINT** names (`left/left_finger`, `left/right_finger`, ...) for both `state_keys` and `action_keys`, but the model's **14 actuators** follow the canonical gym-aloha / LeRobot ACT convention `[6 arm + 1 gripper] x 2` — `left/gripper` / `right/gripper` at indices 6 and 13, each driving both fingers (empirically: `robot_action_keys("aloha")` returns exactly those 14). Consequences for a canonical 14-D ACT (e.g. `lerobot/act_aloha_sim_transfer_cube_human`):

- **State:** the 16-key build hit `reconcile_dim(16, expected 14, "pad")` → `ValueError: observation.state dim 16 > model expected 14; cannot pad` → the rollout **crashes** at the first observation.
- **Action:** the finger-joint `action_keys` become `robot_state_keys`, so the policy's gripper command is mapped onto `left/left_finger` / `right/left_finger`, which are **not actuators** — the gripper is never driven (contra the actuator-keying contract).

## Change

1. `PackStateProcessorStep.observation()` now **zero-fills a missing `state_key` in place** so the present joints keep their model index (mirrors the generic-path fix). A one-time, de-duplicated warning names the absent keys. The all-missing case is still left untouched so a clearer downstream error can fire (no all-zero state).
2. The `aloha` config now declares the **14 actuator keys** `[left/{waist,shoulder,elbow,forearm_roll,wrist_angle,wrist_rotate,gripper}, right/*]` for `state_keys` and `action_keys`. The action now maps 1:1 onto actuators and the arm proprioception is index-aligned. The two gripper STATE slots — absent from the sim observation, which exposes the finger joints, not a `*/gripper` value — are zero-filled in place (arm stays aligned, grippers read 0). A units-correct finger→gripper *state* mapping is a checkpoint-specific follow-up documented in the config note.

Fully-present embodiments (so101, panda, ...) are unaffected — the zero-fill only triggers for a `state_key` genuinely absent from the observation, which previously mis-aligned.

## Verification

Grounded on the real MuJoCo `aloha` (14 actuators, 16 joints; observation exposes finger joints, not `*/gripper`):

- **Before (sentinel arm values, gripper keys absent):** state = `[L-arm…, R-arm shifted into the left-gripper slot, 0, 0]` — every dim from index 6 mis-aligned; and the 16-key config raises `observation.state dim 16 > model expected 14`.
- **After:** state = `[100,101,102,103,104,105, 0(L-grip), 108,109,110,111,112,113, 0(R-grip)]` — arm in canonical slots, gripper slots held.
- **End-to-end:** loading `lerobot/act_aloha_sim_transfer_cube_human` through `embodiment="aloha"` and calling `run_policy(...)` now returns `status: success` (this path previously raised at the first observation). `robot_state_keys` resolves to the 14 actuators and the zero-fill warning fires naming `left/gripper` / `right/gripper`.

Regression test `tests/policies/lerobot_local/test_embodiment_state_zerofill_alignment.py` (real `PackStateProcessorStep` + real embodiment config, no mocks): 4 behavior-defining tests fail on pre-fix source (right arm slides into the gripper slot; no warn; config still 16-key; canonical build raises `dim 16 > 14`) and pass after; 2 no-regression guards (all-present unchanged; all-missing passthrough) pass both.

Gate: `ruff check` + `ruff format --check` + `mypy` clean; `tests/policies/lerobot_local/` (508) and `tests/simulation/mujoco/test_robot_action_keys.py` (10) pass.

No visual artifact: this is a state-INPUT alignment fix — a rollout video cannot show a state-vector realignment (matching the sibling generic-path fix, which also shipped without one). The alignment table + the crash→runs end-to-end result are the proof.

---

## Review rounds

### Round 1

- Code-scanning flagged the regression test as importing `strands_robots.policies.lerobot_local.embodiment` with both `import ... as E` and `from ... import ...`. Collapsed to a single import style: the module is now pulled in only via the `E` alias (already required for the `E._WARNED_MISSING_STATE_KEYS` reset), and `E.load_embodiment` / `E.register_pack_state_step` are qualified accordingly. Imports-only; no test behaviour change (net -1 line).