### PR TITLE
chore(mesh): strip rot-prone review-thread line-pointers from comments

### DIFF
--- a/strands_robots/mesh/_acl_config.py
+++ b/strands_robots/mesh/_acl_config.py
@@ -100,7 +100,7 @@ def _parse_json5(raw: str, path: Path) -> Any:
     boundary: a malformed file does NOT silently degrade to the
     permissive default.
     """
-    # Review thread _acl_config.py:85 -- use the project-standard
+    # Use the project-standard
     # ``require_optional`` helper so the operator-facing import error
     # carries the canonical install-hint format used elsewhere in the
     # SDK (groot, libero, etc.). This still lazy-imports
@@ -205,8 +205,8 @@ def _load_acl_file(path: Path) -> dict[str, Any]:
         # ``allow`` + non-empty ``rules``. The built-in ``default_acl()``
         # (used when STRANDS_MESH_ACL_FILE is unset) ships ``allow +
         # empty rules/subjects/policies``; warning operators who copy
-        # that shape into a file is asymmetric scolding. Per review
-        # thread _acl_config.py:199, scope the trigger to ``rules``
+        # that shape into a file is asymmetric scolding. Scope
+        # the trigger to ``rules``
         # specifically (the load-bearing part of the blacklist
         # anti-pattern) and phrase the warning to match: "allow +
         # rules" is the foot-gun, not "allow + anything".
@@ -352,7 +352,7 @@ def _validate_acl_shape(data: dict[str, Any], path: Path) -> None:
                 f"ACL file {path}: subjects[{i}={sid!r}].cert_common_names must be a list "
                 f"(or omitted), got {type(cns).__name__}. Common typo: cert_common_name (singular)."
             )
-        # Review thread _acl_config.py:279/293 -- HARD-REJECT subjects
+        # HARD-REJECT subjects
         # that constrain neither ``interfaces`` nor
         # ``cert_common_names``. A subject with only an ``id`` (or
         # with both fields explicitly empty) maps to
@@ -451,7 +451,7 @@ def default_acl(namespace: str) -> dict[str, Any]:
     # special-casing ``default_acl``. The built-in default ACL itself is
     # namespace-independent (Zenoh's namespace config does the routing
     # isolation; ACL key_exprs are RELATIVE to the active namespace and
-    # do not need a namespace prefix). Review thread PR#224 _acl_config.py:343.
+    # do not need a namespace prefix).
     _ = namespace  # noqa: F841 -- kept for API symmetry
     return {
         "enabled": True,
@@ -510,7 +510,7 @@ def _load_acl_cached(path: Path) -> dict[str, Any]:
     with _ACL_CACHE_LOCK:
         cached = _ACL_CACHE.get(identity)
         if cached is not None:
-            # Review thread _acl_config.py:429 -- return a deep copy so
+            # Return a deep copy so
             # caller mutation does not poison the cache for subsequent
             # callers. The cost is a small dict copy on every hit (ACL
             # files are tiny by ACL_FILE_MAX_BYTES = 256KiB).
@@ -523,10 +523,10 @@ def _load_acl_cached(path: Path) -> dict[str, Any]:
         if len(_ACL_CACHE) >= 4:
             _ACL_CACHE.pop(next(iter(_ACL_CACHE)))
         # Store a deep copy in the cache so caller mutation of the
-        # returned dict does NOT poison the cached entry (review
-        # _acl_config.py:429). Symmetric with the deep-copy on hit.
+        # returned dict does NOT poison the cached entry. Symmetric
+        # with the deep-copy on hit.
         _ACL_CACHE[identity] = copy.deepcopy(loaded)
-    # Review thread _acl_config.py:458 -- return a deep copy on miss
+    # Return a deep copy on miss
     # too, so the FIRST caller for a given file identity sees the same
     # immutability contract subsequent callers get from the hit branch.
     # The previous code returned ``loaded`` directly, giving the first
@@ -545,7 +545,7 @@ def _clear_acl_cache_for_test() -> None:
         _ACL_CACHE.clear()
 
 
-# Issue #218 / review session.py:296 -- thread-local single-flight ACL
+# Issue #218 -- thread-local single-flight ACL
 # snapshot. ``Mesh.start`` calls ``snapshot_acl`` once at the gate, then
 # ``session._build_config`` runs inside the same call stack and would
 # call ``snapshot_acl`` AGAIN. The previous identity-tuple cache could
@@ -571,7 +571,7 @@ def _set_thread_snapshot(
     """Stash a resolved ACL dict (and optional ``auth_mode``) on the
     current thread for downstream reuse.
 
-    Review thread core.py:139 -- the ``auth_mode`` env var
+    The ``auth_mode`` env var
     (``STRANDS_MESH_AUTH_MODE``) is read independently by
     ``Mesh._refuse_under_permissive_default_acl`` and
     ``session._build_config``. A flip between the two reads (concurrent
@@ -644,7 +644,7 @@ def _is_permissive_acl_shape(data: dict[str, Any]) -> bool:
        ``SubjectProperty::Wildcard`` on every dimension), AND that
        subject is referenced by the wildcard rule's policy.
 
-       This is the gap flagged in review at _acl_config.py:456 --
+       This is the permissive-bypass gap:
        ``default_permission: "deny"`` plus a single ``key_exprs:
        ["**"]/permission: "allow"`` rule plus a wildcard subject
        ("any CA-signed peer publishes/subscribes everywhere") was
@@ -774,7 +774,7 @@ def resolve_acl(namespace: str) -> dict[str, Any]:
 def snapshot_acl(namespace: str = "strands") -> tuple[bool, dict[str, Any]]:
     """Atomically resolve the ACL and report its permissive-by-shape state.
 
-    Issue #218 + review thread session.py:296: closes the TOCTOU window
+    Issue #218: closes the TOCTOU window
     between the ``Mesh.start`` refuse-to-start gate and the
     ``session._build_config`` wire-config builder.
 

--- a/strands_robots/mesh/_zenoh_config.py
+++ b/strands_robots/mesh/_zenoh_config.py
@@ -145,7 +145,7 @@ from pathlib import Path
 # Windows process would emit the same WARNING per peer connection. The
 # module-level dict (rather than a plain bool) keeps mutation explicit at
 # the call site without needing a ``global`` declaration.
-# Review thread _zenoh_config.py:540 -- key the one-shot WARNING on
+# Key the one-shot WARNING on
 # the resolved key path (with mtime fingerprint for rotation detection)
 # rather than a single boolean cell. A long-running process that
 # rotates ``STRANDS_MESH_TLS_KEY`` to a different file used to see
@@ -618,7 +618,7 @@ def _resolve_tls_paths() -> tuple[Path, Path, Path]:
     if not _is_posix():
         # Atomic check-and-set under lock so concurrent _build_config
         # calls (e.g. multi-threaded test harness) don't both fire the
-        # WARNING. Per review thread _zenoh_config.py:540, key the
+        # WARNING. Key the
         # one-shot on (key_path, mtime_ns) so rotating
         # ``STRANDS_MESH_TLS_KEY`` to a different file (or replacing
         # the file in-place) re-arms the warning.

--- a/strands_robots/mesh/audit.py
+++ b/strands_robots/mesh/audit.py
@@ -494,8 +494,7 @@ def _load_seq_counters() -> None:
                 # dict (or a dict with no valid entries) must NOT flip
                 # sidecar_loaded=True, otherwise the audit-log fallback
                 # is skipped and an attacker writing ``{}`` gets every
-                # peer's seq reset. (R3 follow-up - review thread on
-                # PR#221 audit.py:531).
+                # peer's seq reset.
                 merged_any = False
                 for key, value in payload.items():
                     if not (isinstance(key, str) and isinstance(value, int) and value >= 0):

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -442,8 +442,7 @@ class Mesh(SensorLoopsMixin):
         :func:`_acl_config.snapshot_acl` and stashes the result on
         ``self._acl_snapshot`` so :func:`session._build_config`
         downstream can reuse the SAME dict (closes the
-        ``Mesh.start`` -> ``_build_config`` TOCTOU window flagged in
-        review at session.py:296).
+        ``Mesh.start`` -> ``_build_config`` TOCTOU window).
         """
         from strands_robots.mesh import _acl_config, _zenoh_config
 
@@ -468,7 +467,7 @@ class Mesh(SensorLoopsMixin):
         # Stash the snapshot AND auth_mode on a thread-local used by
         # ``session._build_config`` so the wire-config builder picks up
         # the SAME dict the gate inspected AND the SAME auth_mode value.
-        # Issue #218 + review threads session.py:296 / core.py:139.
+        # Issue #218.
         self._acl_snapshot = resolved
         _acl_config._set_thread_snapshot(resolved, auth_mode=auth_mode)
         if auth_mode != "mtls":
@@ -590,8 +589,8 @@ class Mesh(SensorLoopsMixin):
                 session = get_session()
             finally:
                 # Snapshot has been consumed by ``session._build_config``
-                # via the thread-local single-flight (issue #218 +
-                # review session.py:296), or we refused to start before
+                # via the thread-local single-flight (issue #218), or
+                # we refused to start before
                 # ``get_session`` was reached -- either way, clear it so
                 # the next ``Mesh.start`` (different instance, same
                 # thread) or direct ``get_session()`` call sees fresh

--- a/strands_robots/mesh/session.py
+++ b/strands_robots/mesh/session.py
@@ -266,7 +266,7 @@ def clear_peers() -> None:
 # Session lifecycle
 
 
-# Review thread session.py:270 -- endpoint scheme validation. Under
+# Endpoint scheme validation. Under
 # ``STRANDS_MESH_AUTH_MODE=mtls`` the wire-config builder restricts
 # transports to TLS via ``link_protocols_block``; an operator who sets
 # ``ZENOH_LISTEN=tcp/...`` (the documented format) gets a confusing
@@ -352,7 +352,7 @@ def _build_config() -> Any:
     config = zenoh.Config()
 
     # Explicit endpoints from env vars (legacy ZENOH_CONNECT / ZENOH_LISTEN).
-    # Review thread session.py:270 -- validate endpoint schemes against
+    # Validate endpoint schemes against
     # auth_mode BEFORE inserting them, so an operator who set
     # ``ZENOH_LISTEN=tcp/0.0.0.0:7447`` under the default
     # ``STRANDS_MESH_AUTH_MODE=mtls`` posture gets a loud
@@ -364,7 +364,7 @@ def _build_config() -> Any:
     # endpoint validation and the later mTLS/none branch selection see
     # the SAME value, even when no ``Mesh.start`` thread-local is in
     # play (direct ``get_session()`` callers, integration tests).
-    # Review thread session.py:357 -- two independent reads of
+    # Two independent reads of
     # ``os.environ['STRANDS_MESH_AUTH_MODE']`` between scheme
     # validation and block selection used to allow a concurrent test
     # fixture / plugin mutating env to put the two halves of the
@@ -396,13 +396,13 @@ def _build_config() -> Any:
 
     # mTLS + ACL when auth_mode=mtls. The "none" mode emits everything
     # above except the auth + ACL blocks; it is dev-only. ``auth_mode``
-    # was resolved once at the top of ``_build_config`` (review thread
-    # session.py:357) so endpoint validation and block selection share
+    # was resolved once at the top of ``_build_config`` so endpoint
+    # validation and block selection share
     # the same value.
     if auth_mode == "mtls":
         blocks.append(_zenoh_config.link_protocols_block())
         blocks.append(_zenoh_config.tls_block())
-        # Issue #218 / review session.py:296: take ONE snapshot of the
+        # Issue #218: take ONE snapshot of the
         # ACL state and thread it through both the wire-config-build
         # path AND the refuse-to-start shape gate at Mesh.start. The
         # previous two-call pattern (``acl_block`` +
@@ -560,7 +560,7 @@ def get_session() -> Any | None:
             # Aligns with the loud-on-misconfig posture of _float_env
             # and _load_acl_file. Addressed in PR-224 R1.
             #
-            # R4 (review thread session.py:517): prefer the thread-local
+            # Prefer the thread-local
             # ``auth_mode`` stash from ``Mesh.start``. This is the same
             # one-resolve-per-Mesh.start invariant ``_build_config``
             # already honours at line 328-329; without it, the listener
@@ -580,8 +580,7 @@ def get_session() -> Any | None:
             # Build config OUTSIDE the listener try so a bad ACL /
             # TLS configuration (ValueError from _build_config) propagates
             # loudly to Mesh.start rather than being silently downgraded
-            # to client-mode as if it were a port-already-bound error
-            # (review thread at session.py:445).
+            # to client-mode as if it were a port-already-bound error.
             cfg = _build_config()
             cfg.insert_json5("listen/endpoints", json.dumps([local_ep]))
             cfg.insert_json5("connect/endpoints", json.dumps([local_ep]))
@@ -616,7 +615,7 @@ def get_session() -> Any | None:
             # Build cfg OUTSIDE the try so a config-shape ValueError
             # (NaN env clamp, missing TLS file, bad ACL) propagates
             # loudly to Mesh.start instead of being silently downgraded
-            # to "session unavailable" (review threads session.py:465 and 489).
+            # to "session unavailable".
             cfg = _build_config()
             cfg.insert_json5("mode", '"client"')
             cfg.insert_json5("connect/endpoints", json.dumps([local_ep]))
@@ -634,7 +633,7 @@ def get_session() -> Any | None:
 
         # Explicit endpoints provided via env vars.
         # Build cfg outside the try (same loud-on-misconfig discipline
-        # as the auto-listener path; review thread session.py:500).
+        # as the auto-listener path).
         cfg = _build_config()
         # Re-resolve _ZError under the explicit-endpoints branch (reached
         # when _LOCAL_LISTEN env var is unset, so the listener-block
@@ -707,7 +706,7 @@ def _get_zenoh_session_directly() -> Any | None:
             # Aligns with the loud-on-misconfig posture of _float_env
             # and _load_acl_file. Addressed in PR-224 R1.
             #
-            # R4 (review thread session.py:517): prefer the thread-local
+            # Prefer the thread-local
             # ``auth_mode`` stash. Mirrors the same fix at the
             # ``get_session`` boundary upstairs and the
             # ``_build_config`` boundary at line 328-329. See full
@@ -718,7 +717,7 @@ def _get_zenoh_session_directly() -> Any | None:
             local_ep = f"{scheme}/127.0.0.1:{mesh_port}"
 
             # Build cfg outside the listener try so config-shape
-            # ValueError surfaces loudly (review thread session.py:568).
+            # ValueError surfaces loudly.
             cfg = _build_config()
             cfg.insert_json5("listen/endpoints", json.dumps([local_ep]))
             cfg.insert_json5("connect/endpoints", json.dumps([local_ep]))
@@ -730,8 +729,8 @@ def _get_zenoh_session_directly() -> Any | None:
                 logger.info("Zenoh mesh session opened (listener on %s)", local_ep)
                 return _SESSION
             except (RuntimeError, OSError, ConnectionError, _ZError) as exc:
-                # Narrow tuple per review thread session.py:568 -- mirror the
-                # narrowing applied in get_session() upstairs. Config-shape
+                # Narrow tuple mirroring the narrowing applied in
+                # get_session() upstairs. Config-shape
                 # ValueError now propagates instead of being swallowed at DEBUG.
                 logger.debug(
                     "Zenoh listener on %s unavailable (%s) - trying client mode",

--- a/tests/test_source_strings_no_review_archaeology.py
+++ b/tests/test_source_strings_no_review_archaeology.py
@@ -1,0 +1,79 @@
+"""Regression: no ``strands_robots`` module may cite an internal review thread
+by ``<module>.py:<line>`` back-pointer.
+
+AGENTS.md's review-archaeology rule (and the "code is the single source of
+truth" doctrine) both reject comments that narrate the pull-request review that
+produced a change. The worst offenders point at a sibling source location by
+line number -- ``review thread session.py:296`` -- which is guaranteed to rot:
+the referenced line moves on the very next edit, leaving a comment that
+misdirects the reader to unrelated code. The rationale a comment needs to
+convey is *why the code is shaped this way*, which stands on its own; the
+provenance ("a reviewer asked for this in thread X at line Y") is noise that
+belongs in git history, not the source.
+
+This scan walks every Python module under the ``strands_robots`` package and
+rejects three review-archaeology shapes:
+
+  * ``review thread`` / ``review threads`` (the literal provenance framing),
+  * ``flagged in review`` (its passive twin),
+  * ``review <module>.py:<line>`` (a review citation carrying a rot-prone
+    internal source-location back-pointer).
+
+References to *upstream* files (e.g. ``run_mujoco_gear_wbc.py:47-50``) and to
+stable, named anchors (``AGENTS.md > Review Learnings``, issue numbers) are not
+matched -- only the review-thread-by-line-pointer pattern is. The scan flattens
+comment continuations so a citation wrapped across ``#`` lines is still caught.
+It would have failed when 20+ comment blocks across the ``mesh`` package still
+carried ``review thread <file>.py:<line>`` pointers.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import strands_robots
+
+# Review-archaeology framing that cites an internal review thread. The third
+# alternative is the load-bearing one: a ``review`` citation immediately
+# followed by an internal ``<module>.py:<line>`` back-pointer that rots on the
+# next edit. Upstream ``<file>.py:<line>`` references (not preceded by
+# ``review``) and named anchors like ``Review Learnings`` are intentionally not
+# matched.
+_REVIEW_ARCHAEOLOGY = re.compile(
+    r"(?i)(?:review\s+threads?\b|flagged\s+in\s+review|\breview\s+[A-Za-z_][A-Za-z0-9_]*\.py:\d+)"
+)
+
+# Collapse comment-continuation runs (`\n    # `) and other whitespace to a
+# single space so a citation split across multiple ``#`` lines still matches.
+_FLATTEN = re.compile(r"[\s#]+")
+
+_PACKAGE_DIR = Path(strands_robots.__file__).resolve().parent
+
+
+def _python_sources() -> list[Path]:
+    return sorted(p for p in _PACKAGE_DIR.rglob("*.py") if "__pycache__" not in p.parts)
+
+
+def test_package_sources_discovered() -> None:
+    """Guard: the scan actually walked the whole package, not one subtree."""
+    sources = _python_sources()
+    assert len(sources) > 50
+    rel_dirs = {p.relative_to(_PACKAGE_DIR).parts[0] for p in sources if p.parent != _PACKAGE_DIR}
+    assert {"simulation", "tools", "registry", "mesh"} <= rel_dirs
+
+
+def test_no_review_thread_line_pointers_in_package_sources() -> None:
+    """No module may cite an internal review thread by ``<module>.py:<line>``."""
+    offenders: list[str] = []
+    for path in _python_sources():
+        flattened = _FLATTEN.sub(" ", path.read_text(encoding="utf-8"))
+        for match in _REVIEW_ARCHAEOLOGY.finditer(flattened):
+            start = max(match.start() - 30, 0)
+            snippet = flattened[start : match.end() + 30].strip()
+            offenders.append(f"{path.relative_to(_PACKAGE_DIR.parent)}: ...{snippet}...")
+    assert not offenders, (
+        "Review-thread archaeology found in strands_robots sources. Explain WHY the "
+        "code is shaped this way and reference a stable symbol, not a rot-prone "
+        "``<file>.py:<line>`` review pointer:\n" + "\n".join(offenders)
+    )


### PR DESCRIPTION
## Problem

Comments across the `mesh` package cite the pull-request review thread that produced a change by **internal source location** -- e.g. `review thread session.py:296`, `flagged in review at _acl_config.py:456`, `R4 (review thread session.py:517)`. A `<file>.py:<line>` back-pointer is guaranteed to rot: the referenced line moves on the very next edit, so the comment ends up misdirecting the reader to unrelated code. The provenance ("a reviewer asked for this in thread X at line Y") is git-history noise; the rationale a comment must carry is *why the code is shaped this way*, which stands on its own.

## Change

Removes the review-thread framing and stale line pointers from `_acl_config.py`, `core.py`, `session.py`, `_zenoh_config.py`, and `audit.py`, preserving every technical explanation verbatim. References that already name a stable anchor (issue numbers, symbol names like `get_session` / `_build_config`) are kept.

Adds `tests/test_source_strings_no_review_archaeology.py`, a package-wide guard (sibling of the existing `no-emoji` / `no-unicode-dash` source scans) that rejects three review-archaeology shapes:

- `review thread` / `review threads`
- `flagged in review`
- `review <module>.py:<line>`

The scan flattens comment continuations so a citation wrapped across `#` lines is still caught, and only matches the review-by-line-pointer pattern -- upstream file references (e.g. `run_mujoco_gear_wbc.py:47-50`) and named anchors such as `Review Learnings` are intentionally left alone.

## Tests

- New guard **fails on the pre-change tree** (20+ offending comment blocks across `mesh`) and **passes** after the cleanup.
- `pytest tests/mesh/` -> 2057 passed, 3 skipped (comments-only change; no behavior touched).
- Green gate: `ruff check` clean, `ruff format --check` clean, `mypy strands_robots tests tests_integ` -> Success, no issues.