### PR TITLE
test(mesh): pin sim-camera publish guard + render-failure resilience contracts

### DIFF
--- a/tests/mesh/test_sim_camera_mesh_publish.py
+++ b/tests/mesh/test_sim_camera_mesh_publish.py
@@ -195,6 +195,172 @@ class TestSimCameraPublish:
             sim_cam.assert_not_called()
 
 
+class TestSimCameraPublishGuards:
+    """Guard + resilience contracts for the _publish_sim_cameras path.
+
+    A sim child peer must publish camera frames without ever crashing the
+    background camera loop: partially-attached worlds, nameless robots, a
+    missing mujoco install, unnamed cameras, and per-camera render failures
+    are all tolerated and result in a silent no-op rather than an exception.
+    """
+
+    @staticmethod
+    def _mesh_for(robot):
+        from strands_robots.mesh.core import Mesh
+
+        mesh = Mesh.__new__(Mesh)
+        mesh.robot = robot
+        mesh.peer_id = "sim__arm"
+        mesh._running = True
+        published: list = []
+        mesh.publish = lambda k, p: published.append((k, p))
+        return mesh, published
+
+    def test_noop_when_world_not_built(self):
+        """World attached but MuJoCo model/data not built yet -> no-op.
+
+        A SimRobot gets its _world back-reference on attach, but the world's
+        _model/_data are only populated once the sim is constructed. Publishing
+        before that must short-circuit instead of dereferencing None.
+        """
+        from strands_robots.simulation.models import SimRobot, SimWorld
+
+        world = SimWorld()
+        world._model = None
+        world._data = None
+
+        robot = SimRobot(name="arm", urdf_path="/tmp/x.urdf", namespace="arm/")
+        robot._world = world
+
+        mesh, published = self._mesh_for(robot)
+        mesh._publish_sim_cameras()
+
+        assert published == []
+
+    def test_noop_without_robot_name(self):
+        """A SimRobot with no name cannot scope its cameras -> no-op."""
+        from strands_robots.simulation.models import SimRobot, SimWorld
+
+        xml = """
+        <mujoco>
+          <worldbody>
+            <camera name="arm/top_cam" pos="0 0 1" xyaxes="1 0 0 0 1 0"/>
+            <body name="arm/base">
+              <geom type="box" size="0.1 0.1 0.1"/>
+            </body>
+          </worldbody>
+        </mujoco>
+        """
+        model = mujoco.MjModel.from_xml_string(xml)
+        data = mujoco.MjData(model)
+        mujoco.mj_forward(model, data)
+
+        world = SimWorld()
+        world._model = model
+        world._data = data
+
+        robot = SimRobot(name="", urdf_path="/tmp/x.urdf", namespace="arm/")
+        robot._world = world
+
+        mesh, published = self._mesh_for(robot)
+        mesh._publish_sim_cameras()
+
+        assert published == []
+
+    def test_noop_without_mujoco_installed(self, monkeypatch):
+        """When mujoco is not importable the sim camera path is a silent no-op.
+
+        [mesh] does not depend on [sim-mujoco]; a mesh peer running without the
+        sim extra must degrade gracefully rather than raise ImportError.
+        """
+        import sys
+
+        from strands_robots.simulation.models import SimRobot, SimWorld
+
+        world = SimWorld()
+        world._model = MagicMock()
+        world._data = MagicMock()
+
+        robot = SimRobot(name="arm", urdf_path="/tmp/x.urdf", namespace="arm/")
+        robot._world = world
+
+        mesh, published = self._mesh_for(robot)
+        # Setting the cached module entry to None makes `import mujoco` raise
+        # ImportError, simulating a peer without the [sim-mujoco] extra.
+        monkeypatch.setitem(sys.modules, "mujoco", None)
+        mesh._publish_sim_cameras()
+
+        assert published == []
+
+    def test_skips_unnamed_camera(self):
+        """A camera with no name attribute is skipped (mj_id2name -> empty)."""
+        from strands_robots.simulation.models import SimRobot, SimWorld
+
+        # Unnamed camera in an un-namespaced robot: cam_name resolves to empty,
+        # so it is skipped before any render is attempted.
+        xml = """
+        <mujoco>
+          <worldbody>
+            <camera pos="0 0 1" xyaxes="1 0 0 0 1 0"/>
+            <body name="base">
+              <geom type="box" size="0.1 0.1 0.1"/>
+            </body>
+          </worldbody>
+        </mujoco>
+        """
+        model = mujoco.MjModel.from_xml_string(xml)
+        data = mujoco.MjData(model)
+        mujoco.mj_forward(model, data)
+
+        world = SimWorld()
+        world._model = model
+        world._data = data
+
+        robot = SimRobot(name="arm", urdf_path="/tmp/x.urdf", namespace="")
+        robot._world = world
+
+        mesh, published = self._mesh_for(robot)
+        mesh._publish_sim_cameras()
+
+        assert published == []
+
+    def test_survives_per_camera_render_failure(self):
+        """A render failure on one camera is swallowed; nothing is published.
+
+        One flaky camera must not crash the background publish loop nor leak a
+        partial frame. The render error is logged at debug and the method
+        returns normally with an empty frame set.
+        """
+        from strands_robots.simulation.models import SimRobot, SimWorld
+
+        xml = """
+        <mujoco>
+          <worldbody>
+            <camera name="arm/top_cam" pos="0 0 1" xyaxes="1 0 0 0 1 0"/>
+            <body name="arm/base">
+              <geom type="box" size="0.1 0.1 0.1"/>
+            </body>
+          </worldbody>
+        </mujoco>
+        """
+        model = mujoco.MjModel.from_xml_string(xml)
+        data = mujoco.MjData(model)
+        mujoco.mj_forward(model, data)
+
+        world = SimWorld()
+        world._model = model
+        world._data = data
+
+        robot = SimRobot(name="arm", urdf_path="/tmp/x.urdf", namespace="arm/")
+        robot._world = world
+
+        mesh, published = self._mesh_for(robot)
+        with patch("mujoco.Renderer", side_effect=RuntimeError("EGL context lost")):
+            mesh._publish_sim_cameras()  # must not raise
+
+        assert published == []
+
+
 class TestEncodeAndPublishFrames:
     """Unit tests for the shared _encode_and_publish_frames helper."""
 


### PR DESCRIPTION
## Problem

`Mesh._publish_sim_cameras()` renders a sim child peer's MuJoCo cameras and publishes JPEG frames on the mesh camera topic. It runs inside the background camera loop, so a raised exception there kills camera streaming for that peer. Several of its guard and resilience branches were untested:

- world attached but MuJoCo `model`/`data` not built yet (peer attached before the sim is constructed)
- `SimRobot` with no `name` (cannot scope cameras)
- `mujoco` not importable (a `[mesh]` peer without the `[sim-mujoco]` extra)
- a camera with no `name` attribute (`mj_id2name` -> empty)
- a per-camera render failure (`RuntimeError`/`ValueError` from the renderer)

The render-failure branch is the important one: one flaky camera must not crash the publish loop nor leak a partial frame.

## Change

Add `TestSimCameraPublishGuards` (five focused tests) to `tests/mesh/test_sim_camera_mesh_publish.py`, each asserting the observable outcome (nothing published / no exception) rather than internal state. This mirrors the existing hardware-path resilience test (`test_noop_when_every_fallback_camera_read_fails`).

Behavior is unchanged; the tests pin existing contracts and close the coverage gap in this method (the guard/resilience branches at the model/data check, the name check, the mujoco import, the unnamed-camera skip, and the render `except`).

## Tests

```
MUJOCO_GL=egl pytest tests/mesh/test_sim_camera_mesh_publish.py -> 18 passed
MUJOCO_GL=egl pytest tests/mesh/                              -> 2054 passed, 3 skipped
ruff check / ruff format --check / mypy (strands_robots tests tests_integ) -> clean
```

The five new tests exercise the previously-uncovered lines in `_publish_sim_cameras`; scoped coverage of that method goes from partial to complete.