### PR TITLE
feat(sim): add_robot(keyframe=...) spawns a robot in its canonical home pose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -688,6 +688,26 @@ boundary rounding; unlimited actuators (which never clamp) are skipped; the
 warning is de-duplicated so a 50Hz control loop never spams the log. No
 trajectory behaviour changes.
 
+### Added: `add_robot(keyframe=...)` spawns a robot in its canonical home pose
+
+MuJoCo Menagerie robots ship a canonical start pose in a MJCF `<keyframe>`
+(panda/ur5e/fr3/kuka `home`, aloha `neutral_pose`, quadruped/humanoid standing
+`home`). `add_robot` and `reset` ran `mj_resetData` -- the all-zero
+configuration -- so that shipped pose was unreachable outside the LIBERO
+benchmark adapter, and a robot spawned folded/collapsed rather than in its
+ready pose. A policy trained from the home pose then saw an out-of-distribution
+start that measurably suppressed its rollout. `add_robot(keyframe="home")` (or
+an integer index) now reads the named keyframe from the robot's source model,
+applies its `qpos` to the robot's joints by name at spawn, and records it so
+`reset()` restores it -- a keyframe spawn is sticky across resets, mirroring how
+a benchmark restores its canonical start each episode. `keyframe=None` (the
+default) keeps the historical zero-pose spawn byte-for-byte; an unknown
+keyframe name/index is a hard error that names the available keyframes rather
+than silently falling back to zeros. Newton `add_robot` accepts the argument
+for signature parity and rejects a non-`None` value with a clear
+not-yet-supported error. Exposed on the `simulation` agent tool as a `keyframe`
+string.
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/docs/simulation/world-building.md
+++ b/docs/simulation/world-building.md
@@ -25,6 +25,25 @@ sim.add_camera(name="overhead", position=[0.0, 0.0, 1.5], target=[0.0, 0.0, 0.0]
 | Procedural scene | loop over `add_object` |
 | Raw MJCF tweak without recompile | `patch_scene_mjcf(ops)` |
 
+## Spawn pose (keyframes)
+
+By default a robot spawns at the all-zero joint configuration. Many MuJoCo
+Menagerie models ship a canonical ready pose in a MJCF `<keyframe>` (panda,
+ur5e, fr3, kuka `home`; aloha `neutral_pose`; quadrupeds/humanoids a standing
+`home`). Pass `keyframe=` to spawn in that pose instead - important when a
+policy was trained from the home pose, since the zero configuration is
+out-of-distribution:
+
+```python
+sim.add_robot(name="panda", data_config="panda", keyframe="home")  # or keyframe=0
+```
+
+The pose is applied to the robot's joints by name and is restored by `reset()`,
+so a keyframe spawn is sticky across episodes. An unknown keyframe name/index
+is an error that lists the model's available keyframes. `keyframe=None` (the
+default) keeps the zero-pose spawn. (MuJoCo backend; the Newton backend rejects
+`keyframe=` as not-yet-supported.)
+
 ## Procedural objects
 
 ```python

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -214,7 +214,10 @@ class SimEngine(ABC):
         first action, so a backend that leaves derived state stale would feed
         the policy's first inference of every episode a degenerate observation.
         The MuJoCo backend enforces this by running ``mj_forward`` after
-        ``mj_resetData`` (which alone zeroes all derived quantities).
+        ``mj_resetData`` (which alone zeroes all derived quantities). It also
+        re-applies any per-robot home pose captured from an
+        ``add_robot(keyframe=...)`` spawn, so a keyframe pose survives a reset
+        instead of collapsing to the zero configuration.
         """
         ...
 
@@ -238,8 +241,21 @@ class SimEngine(ABC):
         data_config: str | None = None,
         position: list[float] | None = None,
         orientation: list[float] | None = None,
+        keyframe: str | int | None = None,
     ) -> dict[str, Any]:
-        """Add a robot to the simulation."""
+        """Add a robot to the simulation.
+
+        ``keyframe`` optionally spawns the robot in a canonical pose declared
+        by a ``<keyframe>`` in its source model (e.g. panda ``"home"``, aloha
+        ``"neutral_pose"``) instead of the default all-zero configuration.
+        Pass the keyframe name (``str``) or index (``int``). The pose is
+        applied to the robot's joints by name and stored so :meth:`reset`
+        restores it (a keyframe spawn is sticky across resets, matching how a
+        benchmark restores its canonical start each episode). ``None`` (the
+        default) keeps the historical zero-pose spawn. An unknown keyframe
+        name/index is a hard error that names the available keyframes; it
+        never silently falls back to zeros.
+        """
         ...
 
     @abstractmethod

--- a/strands_robots/simulation/models.py
+++ b/strands_robots/simulation/models.py
@@ -52,6 +52,11 @@ class SimRobot:
     joint_names: list[str] = field(default_factory=list)
     actuator_ids: list[int] = field(default_factory=list)
     namespace: str = ""
+    # Canonical home pose applied by ``add_robot(keyframe=...)`` and re-applied
+    # on ``reset()``. Maps each (namespaced) joint name to its qpos slice. Empty
+    # for robots spawned without a keyframe (the default zero pose), so reset()
+    # stays byte-identical for those robots.
+    home_qpos: dict[str, list[float]] = field(default_factory=dict)
     policy_running: bool = False
     policy_steps: int = 0
     policy_instruction: str = ""

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -123,6 +123,15 @@ def _drop_unrecorded_cameras(observation: dict[str, Any], recorded: set[str] | N
     }
 
 
+def _jnt_qpos_width(mj: Any, jnt_type: int) -> int:
+    """qpos slice width for a MuJoCo joint type (free=7, ball=4, slide/hinge=1)."""
+    if jnt_type == int(mj.mjtJoint.mjJNT_FREE):
+        return 7
+    if jnt_type == int(mj.mjtJoint.mjJNT_BALL):
+        return 4
+    return 1
+
+
 _TOOL_SPEC_PATH = Path(__file__).parent / "tool_spec.json"
 
 # Tool schema is 357 lines of JSON. `tool_spec` property is on the LLM hot path
@@ -852,6 +861,7 @@ class MuJoCoSimEngine(
         data_config: str | None = None,
         position: list[float] | None = None,
         orientation: list[float] | None = None,
+        keyframe: str | int | None = None,
     ) -> dict[str, Any]:
         """Add a robot to the simulation via XML round-trip composition.
 
@@ -866,6 +876,12 @@ class MuJoCoSimEngine(
         URDF filename), with a numeric suffix appended if that label is already
         taken -- so ``add_robot(data_config="so101")`` twice yields ``so101``
         and ``so101_2`` instead of erroring.
+
+        ``keyframe`` (name ``str`` or index ``int``) spawns the robot in a
+        canonical pose declared by a ``<keyframe>`` in its source model
+        (e.g. panda ``"home"``) instead of the all-zero configuration, and the
+        pose is restored by ``reset()``. An unknown keyframe is a hard error
+        naming the available keyframes; ``None`` (default) keeps the zero pose.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
@@ -954,6 +970,16 @@ class MuJoCoSimEngine(
                 self._world.robots.pop(name, None)
                 return mesh_err
 
+            # Resolve the requested spawn keyframe from the robot's SOURCE
+            # model BEFORE mutating the scene, so an unknown keyframe fails
+            # cleanly (naming the available keyframes) without leaving a
+            # half-added robot behind.
+            home_by_short: dict[str, list[float]] | None = None
+            if keyframe is not None:
+                home_by_short, kf_err = self._keyframe_home_qpos(resolved_path, keyframe)
+                if kf_err is not None:
+                    return kf_err
+
             # Register the robot BEFORE attach so scene_ops can re-discover
             # its joint/actuator IDs inside the merged model.
             self._world.robots[name] = robot
@@ -997,15 +1023,16 @@ class MuJoCoSimEngine(
                         origin_robot=name,
                     )
 
-            # leave the freshly-added robot in a clean, deterministic
-            # zero state (qpos=qvel=ctrl=0) rather than silently settling
-            # under gravity for 100 steps. Callers that want a pre-settled
-            # pose should call step()/reset() explicitly. This makes
-            # `add_robot` -> `get_robot_state` observations meaningful for
-            # learning pipelines that expect t=0 to be a canonical start.
+            # Leave the freshly-added robot in a clean, deterministic state:
+            # the zero configuration by default, or -- when a spawn keyframe was
+            # requested -- that keyframe's canonical home pose. Either way t=0 is
+            # a well-defined start for learning/eval pipelines (no silent settle
+            # under gravity). Callers that want a pre-settled pose call step().
             mj.mj_resetData(self._world._model, self._world._data)
             self._world.sim_time = 0.0
             self._world.step_count = 0
+            if home_by_short:
+                self._apply_home_qpos_to_robot(robot, home_by_short)
             mj.mj_forward(self._world._model, self._world._data)
 
             # Attach the robot to the mesh as its own peer so the agent can
@@ -1044,6 +1071,120 @@ class MuJoCoSimEngine(
             self._world.robots.pop(name, None)
             logger.error("Failed to add robot '%s': %s", name, e)
             return {"status": "error", "content": [{"text": f"Failed to load: {e}"}]}
+
+    def _keyframe_home_qpos(
+        self, resolved_path: str, keyframe: str | int
+    ) -> tuple[dict[str, list[float]] | None, dict[str, Any] | None]:
+        """Read a robot's ``<keyframe>`` home pose from its SOURCE model.
+
+        Returns ``(home_by_short_joint, None)`` mapping each source joint's
+        short name to its qpos slice, or ``(None, error_result)`` when the
+        source model cannot be compiled or the keyframe name/index is unknown
+        (the error names the available keyframes so the caller can fix it).
+        """
+        mj = self._mj
+        fname = os.path.basename(resolved_path)
+        # ``bool`` is an ``int`` subclass; reject it explicitly so True/False is
+        # never silently taken as keyframe index 1/0.
+        if isinstance(keyframe, bool):
+            return None, {
+                "status": "error",
+                "content": [{"text": "keyframe must be a keyframe name (str) or index (int), not a bool."}],
+            }
+        try:
+            src = mj.MjModel.from_xml_path(resolved_path)
+        except Exception as e:  # noqa: BLE001 - surface any compile failure to the caller
+            return None, {
+                "status": "error",
+                "content": [{"text": f"Cannot read keyframe from '{fname}': {e}"}],
+            }
+        names = [mj.mj_id2name(src, mj.mjtObj.mjOBJ_KEY, i) for i in range(src.nkey)]
+        if src.nkey == 0:
+            return None, {
+                "status": "error",
+                "content": [{"text": f"Model '{fname}' declares no <keyframe>; cannot apply keyframe={keyframe!r}."}],
+            }
+        if isinstance(keyframe, int):
+            if keyframe < 0 or keyframe >= src.nkey:
+                return None, {
+                    "status": "error",
+                    "content": [
+                        {
+                            "text": (
+                                f"keyframe index {keyframe} out of range; '{fname}' has "
+                                f"{src.nkey} keyframe(s): {names}."
+                            )
+                        }
+                    ],
+                }
+            idx = keyframe
+        else:
+            if keyframe not in names:
+                avail = ", ".join(repr(n) for n in names)
+                return None, {
+                    "status": "error",
+                    "content": [{"text": f"Keyframe {keyframe!r} not found in '{fname}'. Available: {avail}."}],
+                }
+            idx = names.index(keyframe)
+        kq = src.key_qpos[idx]
+        home: dict[str, list[float]] = {}
+        for j in range(src.njnt):
+            jn = mj.mj_id2name(src, mj.mjtObj.mjOBJ_JOINT, j)
+            if not jn:
+                continue
+            adr = int(src.jnt_qposadr[j])
+            width = _jnt_qpos_width(mj, int(src.jnt_type[j]))
+            home[jn] = [float(x) for x in kq[adr : adr + width]]
+        return home, None
+
+    def _apply_home_qpos_to_robot(self, robot: SimRobot, home_by_short: dict[str, list[float]]) -> None:
+        """Write ``home_by_short`` onto ``robot``'s joints in the live model and
+        record the applied pose (keyed by namespaced joint name) on the robot so
+        :meth:`reset` can restore it. The caller runs ``mj_forward`` afterwards.
+        """
+        mj = self._mj
+        assert self._world is not None and self._world._model is not None and self._world._data is not None
+        model = self._world._model
+        data = self._world._data
+        pfx = robot.namespace or ""
+        stored: dict[str, list[float]] = {}
+        for j in range(model.njnt):
+            jn = mj.mj_id2name(model, mj.mjtObj.mjOBJ_JOINT, j)
+            if not jn:
+                continue
+            short = jn[len(pfx) :] if pfx and jn.startswith(pfx) else jn
+            vals = home_by_short.get(short)
+            if vals is None:
+                continue
+            adr = int(model.jnt_qposadr[j])
+            width = _jnt_qpos_width(mj, int(model.jnt_type[j]))
+            if len(vals) != width:
+                # width mismatch (unexpected for a matching source model): skip
+                # defensively rather than corrupt an adjacent joint's slice.
+                continue
+            data.qpos[adr : adr + width] = vals
+            stored[jn] = vals
+        robot.home_qpos = stored
+
+    def _restore_home_poses(self) -> None:
+        """Re-apply every robot's captured keyframe home pose onto the live
+        ``qpos`` (a no-op for robots spawned without a keyframe). The caller
+        holds the model lock and runs ``mj_forward`` afterwards.
+        """
+        mj = self._mj
+        assert self._world is not None and self._world._model is not None and self._world._data is not None
+        model = self._world._model
+        data = self._world._data
+        for robot in self._world.robots.values():
+            hq = getattr(robot, "home_qpos", None)
+            if not hq:
+                continue
+            for jn, vals in hq.items():
+                jid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, jn)
+                if jid < 0:
+                    continue
+                adr = int(model.jnt_qposadr[jid])
+                data.qpos[adr : adr + len(vals)] = vals
 
     def remove_robot(self, name: str) -> dict[str, Any]:
         """Remove a robot and every element it injected (bodies, actuators,
@@ -2033,6 +2174,12 @@ class MuJoCoSimEngine(
             # here so reset() leaves a fully consistent, render-ready state,
             # matching the mj_resetData -> mj_forward idiom used by
             # _compile_world and load_scene.
+            #
+            # Re-apply any per-robot keyframe home pose captured at add_robot
+            # time (mj_resetData alone drops it back to the zero configuration),
+            # so a keyframe spawn is sticky across resets -- mirroring how a
+            # benchmark restores its canonical start pose each episode.
+            self._restore_home_poses()
             mj.mj_forward(self._world._model, self._world._data)
             self._world.sim_time = 0.0
             self._world.step_count = 0

--- a/strands_robots/simulation/mujoco/tool_spec.json
+++ b/strands_robots/simulation/mujoco/tool_spec.json
@@ -100,6 +100,10 @@
       "type": "string",
       "description": "Robot model registry key for add_robot (e.g. 'so101', 'panda', 'aloha'). Use the BARE name from list_urdfs -- not 'so101_default'/'so101_sim' (those are auto-stripped but the bare key is canonical). Auto-resolves to the MJCF/URDF on disk."
     },
+    "keyframe": {
+      "type": "string",
+      "description": "Optional add_robot spawn pose: the name of a <keyframe> in the robot's source model (e.g. 'home' for panda/ur5e/fr3, 'neutral_pose' for aloha) to spawn in that canonical configuration instead of all-zeros. Restored on reset(). Omit for the default zero pose; an unknown name errors and lists the available keyframes."
+    },
     "name": {
       "type": "string",
       "description": "Instance label. For add_object/add_camera it's the object/camera name. For add_robot it's OPTIONAL -- the label you'll use later in run_policy(robot_name=...); if omitted it's auto-derived from data_config and auto-numbered on collision (so101, so101_2, ...)."

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -317,6 +317,7 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         data_config: str | None = None,
         position: list[float] | None = None,
         orientation: list[float] | None = None,
+        keyframe: str | int | None = None,
         source: str | None = None,
     ) -> dict[str, Any]:
         """Add a robot to the world from a registered name, MJCF, or URDF.
@@ -342,6 +343,10 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
                 the registry; ``"robot_descriptions"`` resolves the URDF directly
                 via ``robot_descriptions.<name>_description.URDF_PATH``. See
                 :func:`~strands_robots.registry.discovery.list_urdf_discoverable`.
+            keyframe: Canonical spawn pose. Not yet supported on the Newton
+                backend (the MuJoCo backend applies a source ``<keyframe>``);
+                passing a non-``None`` value is a clean error rather than a
+                silent ignore.
 
         Returns:
             Status dict including the resolved joint names.
@@ -358,6 +363,18 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
                         "text": (
                             f"Unknown source {source!r}. "
                             f"Valid: {[s for s in _ROBOT_SOURCES if s is not None]} or None (default)."
+                        )
+                    }
+                ],
+            }
+        if keyframe is not None:
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            "keyframe= is not yet supported on the Newton backend; "
+                            "spawn keyframe home poses are a MuJoCo-backend feature."
                         )
                     }
                 ],

--- a/tests/simulation/mujoco/test_add_robot_keyframe.py
+++ b/tests/simulation/mujoco/test_add_robot_keyframe.py
@@ -1,0 +1,146 @@
+"""``add_robot(keyframe=...)`` spawns a robot in a source ``<keyframe>`` pose.
+
+MuJoCo Menagerie robots ship a canonical home pose in a ``<keyframe>`` (panda
+``home``, ur5e/fr3/kuka ``home``, aloha ``neutral_pose``, quadrupeds/humanoids
+a standing ``home``). ``add_robot`` historically ran ``mj_resetData`` (the
+all-zero configuration) and ``reset()`` does the same, so that shipped home
+pose was unreachable outside the LIBERO benchmark adapter. A policy trained
+from the home pose then sees an out-of-distribution start (a folded/collapsed
+arm), which measurably degrades its rollout.
+
+``add_robot(keyframe=...)`` applies the named/indexed keyframe's qpos to the
+robot's joints by name at spawn and stores it so ``reset()`` restores it (a
+keyframe spawn is sticky across resets, matching how a benchmark restores its
+canonical start each episode). ``keyframe=None`` (the default) keeps the
+historical zero-pose spawn byte-for-byte.
+
+These tests use a tiny inline two-hinge MJCF with a ``<keyframe>`` so they run
+offline and GL-free in CI (no mesh download, no render).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+mj = pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+# Two hinge joints; the ``home`` keyframe bends them to a non-zero pose that is
+# distinct from the all-zero default and from what gravity/servos settle to.
+_ARM_MJCF = """
+<mujoco model="kf_arm">
+  <compiler angle="radian"/>
+  <option timestep="0.002" gravity="0 0 -9.81"/>
+  <worldbody>
+    <body name="l1" pos="0 0 0.1">
+      <joint name="shoulder" type="hinge" axis="0 1 0"/>
+      <geom type="capsule" fromto="0 0 0 0 0 0.3" size="0.03" mass="1"/>
+      <body name="l2" pos="0 0 0.3">
+        <joint name="elbow" type="hinge" axis="0 1 0"/>
+        <geom type="capsule" fromto="0 0 0 0 0 0.3" size="0.03" mass="1"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="s_act" joint="shoulder" kp="50"/>
+    <position name="e_act" joint="elbow" kp="50"/>
+  </actuator>
+  <keyframe>
+    <key name="home" qpos="0.5 -1.2"/>
+  </keyframe>
+</mujoco>
+"""
+
+_HOME = [0.5, -1.2]
+
+
+@pytest.fixture
+def arm_xml(tmp_path):
+    p = tmp_path / "kf_arm.xml"
+    p.write_text(_ARM_MJCF)
+    return str(p)
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="devx_add_robot_keyframe", mesh=False)
+    s.create_world()
+    try:
+        yield s
+    finally:
+        s.cleanup(policy_stop_timeout=0.5)
+
+
+def _qpos(sim):
+    return sim._world._data.qpos.copy()
+
+
+class TestAddRobotKeyframe:
+    def test_default_spawn_is_zero_pose(self, sim, arm_xml):
+        # No keyframe -> historical all-zero spawn, and no home pose captured.
+        sim.add_robot(name="a", urdf_path=arm_xml)
+        assert np.allclose(_qpos(sim), [0.0, 0.0])
+        assert sim._world.robots["a"].home_qpos == {}
+
+    def test_keyframe_by_name_applies_home_pose(self, sim, arm_xml):
+        result = sim.add_robot(name="a", urdf_path=arm_xml, keyframe="home")
+        assert result["status"] == "success"
+        assert np.allclose(_qpos(sim), _HOME)
+        # Home pose captured under the namespaced joint names for reset().
+        assert sim._world.robots["a"].home_qpos == {
+            "a/shoulder": [0.5],
+            "a/elbow": [-1.2],
+        }
+
+    def test_keyframe_by_index_applies_home_pose(self, sim, arm_xml):
+        result = sim.add_robot(name="a", urdf_path=arm_xml, keyframe=0)
+        assert result["status"] == "success"
+        assert np.allclose(_qpos(sim), _HOME)
+
+    def test_reset_restores_keyframe_home_pose(self, sim, arm_xml):
+        sim.add_robot(name="a", urdf_path=arm_xml, keyframe="home")
+        # Drive the arm off the home pose, then reset.
+        sim.step(40)
+        assert not np.allclose(_qpos(sim), _HOME)
+        reset_result = sim.reset()
+        assert reset_result["status"] == "success"
+        # reset() must restore the keyframe home pose, not collapse to zeros.
+        assert np.allclose(_qpos(sim), _HOME)
+
+    def test_reset_without_keyframe_stays_zero(self, sim, arm_xml):
+        # Guard the no-regression path: a robot added without a keyframe must
+        # reset to the zero configuration exactly as before.
+        sim.add_robot(name="a", urdf_path=arm_xml)
+        sim.step(40)
+        sim.reset()
+        assert np.allclose(_qpos(sim), [0.0, 0.0])
+
+    def test_unknown_keyframe_errors_and_leaks_nothing(self, sim, arm_xml):
+        result = sim.add_robot(name="a", urdf_path=arm_xml, keyframe="does_not_exist")
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert "does_not_exist" in text
+        # Names the available keyframe so the caller can fix the call.
+        assert "'home'" in text
+        # No half-added robot left behind; the same name is reusable.
+        assert "a" not in sim._world.robots
+        ok = sim.add_robot(name="a", urdf_path=arm_xml, keyframe="home")
+        assert ok["status"] == "success"
+
+    def test_bool_keyframe_rejected(self, sim, arm_xml):
+        # bool is an int subclass; True/False must not be taken as index 1/0.
+        result = sim.add_robot(name="a", urdf_path=arm_xml, keyframe=True)
+        assert result["status"] == "error"
+        assert "bool" in result["content"][0]["text"]
+        assert "a" not in sim._world.robots
+
+    def test_keyframe_via_tool_router(self, sim, arm_xml):
+        # The agent-facing dispatch path forwards the keyframe param.
+        result = sim._dispatch_action(
+            "add_robot",
+            {"action": "add_robot", "name": "a", "urdf_path": arm_xml, "keyframe": "home"},
+        )
+        assert result["status"] == "success"
+        assert np.allclose(_qpos(sim), _HOME)

--- a/tests/simulation/test_foundation.py
+++ b/tests/simulation/test_foundation.py
@@ -61,6 +61,7 @@ def _make_dummy_engine_class() -> type[SimEngine]:
             data_config: str | None = None,
             position: list[float] | None = None,
             orientation: list[float] | None = None,
+            keyframe: str | int | None = None,
         ) -> dict[str, Any]:
             return {}
 

--- a/tests/simulation/test_sim_engine_describe_discovery.py
+++ b/tests/simulation/test_sim_engine_describe_discovery.py
@@ -53,7 +53,7 @@ def _make_minimal_engine():
             data_config: str | None = None,
             position: list[float] | None = None,
             orientation: list[float] | None = None,
-            **kwargs: Any,
+            keyframe: str | int | None = None,
         ) -> dict[str, Any]:
             self._robots.append(name)
             return {}


### PR DESCRIPTION
## Problem

Most MuJoCo Menagerie robots ship a canonical *ready* pose in a MJCF `<keyframe>` -- panda/ur5e/fr3/kuka `home`, aloha `neutral_pose`, quadrupeds/humanoids a standing `home`. But `MuJoCoSimEngine.add_robot` runs `mj_resetData` (the all-zero configuration) at spawn, and `reset()` does the same, so that shipped pose was **unreachable outside the LIBERO benchmark adapter** (which already special-cases `mj_resetDataKeyframe`). A robot therefore spawns folded/collapsed instead of in its ready pose.

This matters for policy fidelity: a policy trained from the home pose (e.g. a gym-aloha ACT, or any Menagerie-standard checkpoint) sees the zero configuration as an out-of-distribution start state, which measurably suppresses its rollout. There was no facade way to spawn -- or reset to -- the model's own home pose.

## Change

`add_robot(keyframe="home")` (or an integer index) reads the named keyframe from the robot's **source** model, applies its `qpos` to the robot's joints **by name** (robust to namespacing / joint reordering during scene composition) at spawn, and records the applied pose on the `SimRobot` so `reset()` restores it. A keyframe spawn is thus **sticky across resets**, mirroring how a benchmark restores its canonical start each episode.

- `keyframe=None` (default) keeps the historical zero-pose spawn **byte-for-byte** -- `home_qpos` stays empty and `reset()` is unchanged for those robots.
- An unknown keyframe name/index is a **hard error that names the available keyframes** (no silent fallback to zeros); the robot is not half-added and the same name is immediately reusable.
- `bool` is rejected explicitly (it is an `int` subclass, so `True/False` must not be taken as index 1/0).
- Keyframe resolution happens **before** the scene is mutated, so an invalid keyframe fails cleanly.
- Exposed on the `simulation` agent tool as a `keyframe` string.
- The Newton backend accepts the argument for signature parity and rejects a non-`None` value with a clear *not-yet-supported* error rather than silently ignoring it.

## Visual proof (MuJoCo sim, headless EGL)

Panda spawned with the default zero pose vs `keyframe="home"` -- the latter is the standard ready pose `qpos=[0, 0, 0, -1.57, 0, 1.57, -0.79, 0.04, 0.04]`:

![panda zero pose vs keyframe home](https://github.com/cagataycali/robots/releases/download/artifacts-add-robot-keyframe/kf_panda.png)

## Tests

`tests/simulation/mujoco/test_add_robot_keyframe.py` (inline two-hinge MJCF fixture with a `<keyframe>`, offline + GL-free):

- keyframe by name / by index applies the home pose;
- `reset()` restores the home pose after the arm is driven off it;
- default spawn (no keyframe) is the zero pose and `reset()` stays zero (no-regression guard);
- unknown keyframe errors, lists available keyframes, and leaks no robot;
- `bool` rejected;
- the agent tool-dispatch path forwards `keyframe`.

The keyframe tests fail on unpatched `main` (`TypeError: add_robot() got an unexpected keyword argument 'keyframe'`) and pass after; the no-regression guard passes both. Full `tests/simulation/mujoco` + `tests/simulation/newton` suites pass (1366 passed, 2 skipped); ruff + ruff-format + mypy clean on the changed files.

---

## §13 Review Rounds

| Round | Concern | Fix Commit | Pin Test |
|-------|---------|------------|----------|
| R1 | Merge conflict with upstream/main (CHANGELOG.md) | `d4cebcd` | N/A (conflict resolution only) |