### PR TITLE
chore(deps): track lerobot 0.6 — require lerobot>=0.6.0 and drop the 0.5.1-era torch/torchcodec overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -734,6 +734,26 @@ is a checkpoint-specific follow-up). Loading the canonical
 `lerobot/act_aloha_sim_transfer_cube_human` through `embodiment="aloha"` now runs
 a rollout instead of crashing.
 
+### Changed: track lerobot 0.6 -- require `lerobot>=0.6.0` and drop the 0.5.1-era torch/torchcodec overrides
+
+The `[lerobot]` / `[molmoact2]` extras now require `lerobot>=0.6.0,<0.7.0`
+(was `>=0.5.0,<0.6.0`). lerobot 0.6 ships mature, platform-correct dependency
+markers -- `torch>=2.7,<2.12` with a `torchcodec>=0.11,<0.12` marker on linux
+aarch64 -- so the codec/decoder stack now resolves ABI-consistently
+(torch 2.11 + torchcodec 0.11.x + torchvision 0.26) on linux x86_64/aarch64 and
+macOS arm64 without any strands override. The per-platform torchcodec pins in
+the `[lerobot]` extra and the `torch`/`torchvision` entries in
+`[tool.uv].override-dependencies` -- all added to compensate for lerobot 0.5.1's
+deficient markers (its `torch<2.11` cap that skipped the NVIDIA Thor/Jetson
+sm_110 cuBLAS fix, and its torchcodec marker that excluded linux aarch64) -- are
+removed; the sole remaining uv override is the diffusers security floor. The
+aarch64 torch 2.11 requirement (the Thor sm_110 fix) now falls out of lerobot
+0.6's own torchcodec marker rather than a strands override, and the previously
+unbounded aarch64 `torchcodec>=0.11` pin (which resolved a torch-ABI-mismatched
+torchcodec 0.14) is bounded by lerobot 0.6's `<0.12`. `MolmoAct2Policy` (added
+to lerobot after the 0.5.1 PyPI release) now resolves straight from PyPI via the
+`[molmoact2]` extra -- the "install lerobot from source" step is gone.
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ extras you need:
 | `sim-mujoco` | MuJoCo, robot_descriptions, imageio | Simulation (recommended starting point) |
 | `sim-newton` | Newton, Warp, MuJoCo-Warp, trimesh | GPU-native simulation (NVIDIA GPU; batched envs, headless ray-traced render) |
 | `lerobot` | LeRobot | Real hardware, local VLA inference, dataset recording |
-| `molmoact2` | LeRobot + transformers, peft, scipy | MolmoAct2 transformers-native VLA (needs lerobot from source until PyPI >= 0.5.2) |
+| `molmoact2` | LeRobot + transformers, peft, scipy | MolmoAct2 transformers-native VLA (resolves from PyPI via lerobot >= 0.6) |
 | `groot-service` | pyzmq, msgpack | NVIDIA GR00T inference client |
 | `cosmos3-service` | websockets, msgpack | NVIDIA Cosmos 3 policy-server client |
 | `curobo` | _(empty; install cuRobo from source)_ | In-process collision-aware motion planning (CUDA GPU) |
@@ -180,9 +180,8 @@ uv pip install "strands-robots[sim-mujoco]"
 # Real hardware + local policies:
 uv pip install "strands-robots[sim-mujoco,lerobot]"
 
-# MolmoAct2 VLA (lerobot from source until a PyPI >= 0.5.2 ships PR #3604):
-uv pip install "strands-robots[molmoact2]" \
-    "lerobot[feetech] @ git+https://github.com/huggingface/lerobot.git"
+# MolmoAct2 VLA (transformers-native; resolves from PyPI via lerobot >= 0.6):
+uv pip install "strands-robots[molmoact2]"
 
 # Everything:
 uv pip install "strands-robots[all]"

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -13,7 +13,7 @@ Requires **Python >= 3.12**. Examples use [`uv`](https://docs.astral.sh/uv/) (`c
 | (none) | core only - Robot factory, registry, lazy imports | Inspect the catalog, write tools |
 | `[sim]` | `robot_descriptions` | Sim asset resolution without MuJoCo |
 | `[sim-mujoco]` | `sim` + `mujoco`, `imageio`, `imageio-ffmpeg` | Any `Robot()` with default `mode="sim"` |
-| `[lerobot]` | `lerobot>=0.5.0,<0.6.0` | `LerobotLocalPolicy` + dataset recording |
+| `[lerobot]` | `lerobot>=0.6.0,<0.7.0` | `LerobotLocalPolicy` + dataset recording |
 | `[groot-service]` | `pyzmq`, `msgpack` | `Gr00tPolicy` (ZMQ to a GR00T container) |
 | `[cosmos3-service]` | `msgpack`, `websockets` | `Cosmos3Policy` (WebSocket to Cosmos 3 server) |
 | `[mesh]` | `eclipse-zenoh`, `json5` | Multi-robot mesh discovery + RPC |
@@ -47,33 +47,28 @@ uv pip install "numpy<2" "pandas==2.1.4"
 uv pip install "strands-robots[sim-mujoco,lerobot]"
 ```
 
-The `[lerobot]` extra includes `torchcodec` on aarch64 (required because
-torchvision 0.26 removed `VideoReader` and lerobot's own torchcodec marker
-excludes aarch64). If torch CUDA is needed on Jetson, ensure you install from
-NVIDIA's index or set `UV_TORCH_BACKEND=auto`:
+lerobot 0.6 pulls `torchcodec` on aarch64 itself (its dependency marker now
+covers linux aarch64 and pins the torch-ABI-matched torchcodec 0.11), so the
+video decoder resolves without a strands override. If torch CUDA is needed on
+Jetson, ensure you install from NVIDIA's index or set `UV_TORCH_BACKEND=auto`:
 
 ```bash
 export UV_TORCH_BACKEND=auto   # resolves +cu130 wheels for Thor/Jetson
 uv pip install "strands-robots[sim-mujoco,lerobot]"
 ```
 
-### MolmoAct2 on Jetson (lerobot from source)
+### MolmoAct2 on Jetson
 
-MolmoAct2 checkpoints (e.g. `allenai/MolmoAct2-SO100_101`) require lerobot
-**from source** (git main) because `MolmoAct2Policy` was added after lerobot
-0.5.1 (the latest PyPI release). See
-[LeRobot Local: MolmoAct2](../policies/lerobot-local.md#molmoact2) for full
-instructions. Quick path:
+MolmoAct2 checkpoints (e.g. `allenai/MolmoAct2-SO100_101`) resolve straight from
+PyPI now that lerobot >= 0.6 ships `MolmoAct2Policy` (it was added after lerobot
+0.5.1). See [LeRobot Local: MolmoAct2](../policies/lerobot-local.md#molmoact2)
+for full instructions. Quick path:
 
 ```bash
-# Install the [molmoact2] extra (transformers, peft, scipy on top of lerobot)
-# plus lerobot from source (skips pyav if it fails on aarch64):
-uv pip install "strands-robots[molmoact2]" \
-    "lerobot[feetech] @ git+https://github.com/huggingface/lerobot.git" --no-build-isolation
-uv pip install torchcodec>=0.7   # video decode backend for aarch64
+# The [molmoact2] extra layers transformers, peft, scipy on top of lerobot >= 0.6;
+# lerobot 0.6 pulls the aarch64 torchcodec decoder itself:
+uv pip install "strands-robots[molmoact2]"
 ```
-
-This will be unnecessary once lerobot >= 0.5.2 is published to PyPI.
 
 ## Headless rendering
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,47 +168,27 @@ lerobot = [
     # Declaring it here makes `sim.stream_dataset(...)` work out of the box
     # instead of pushing torchcodec/av plumbing onto user code. See
     # reports/STREAMING_DATA_LOOP_DEEP_DIVE.md Appendix C.
-    "lerobot[feetech,dataset]>=0.5.0,<0.6.0",
-    # torchcodec wheels are built against a specific torch C++ ABI, so the
-    # version MUST track the resolved torch:
-    #   torch 2.9  -> torchcodec 0.7
-    #   torch 2.10 -> torchcodec 0.10  (verified working on macOS arm64 +
-    #                 system ffmpeg via /opt/homebrew/lib; 0.10 == "system-wide
-    #                 ffmpeg support" per lerobot's matrix note)
-    #   torch 2.11 -> torchcodec 0.11   torch 2.12 -> torchcodec 0.12
-    # lerobot's own marker only special-cases aarch64; on macOS arm64 a plain
-    # `pip install strands-robots[lerobot]` resolves torch 2.10, which needs
-    # torchcodec 0.10 (0.7/0.8 mismatch the c10 ABI -> dlopen "Symbol not found:
-    # c10::MessageLogger"). Pin the matching minor on darwin arm64 so video
-    # streaming read-back works without manual intervention.
-    "torchcodec>=0.10,<0.11; sys_platform == 'darwin' and platform_machine == 'arm64'",
-    # #378: lerobot 0.5.1's pyav video fallback calls torchvision.io.VideoReader,
-    # which torchvision 0.26 (resolved on linux+aarch64 via the torch 2.11 Thor
-    # override below) removed -- crashing dataset video read-back. lerobot's own
-    # torchcodec dependency marker EXCLUDES aarch64, so a `pip install
-    # strands-robots[lerobot]` on Thor/Jetson gets no decoder. Add torchcodec
-    # explicitly on linux+aarch64 so lerobot uses its preferred (working)
-    # torchcodec decoder instead of the removed VideoReader. (The hatch dev env
-    # carries the same pin; this makes the public extra self-sufficient too.)
-    # NOTE: torchcodec ships as +cuXXX wheels resolved by UV_TORCH_BACKEND; a
-    # plain `pip install` on Thor may need the matching CUDA index -- see the
-    # README Installation section for the Thor/Jetson caveat.
-    "torchcodec>=0.11; platform_machine == 'aarch64' and sys_platform == 'linux'",
+    #
+    # lerobot 0.6 ships mature, platform-correct torch/torchvision/torchcodec
+    # dependency markers, so the codec/decoder stack resolves ABI-consistently
+    # on every platform (torch 2.11 + torchcodec 0.11.x + torchvision 0.26 on
+    # linux x86_64/aarch64 and macOS arm64) WITHOUT the per-platform torchcodec
+    # overrides the 0.5.1 range needed. The aarch64 torch>=2.11 requirement --
+    # which fixes the NVIDIA Thor/Jetson sm_110 cuBLAS bug present in torch 2.10
+    # -- now falls out of lerobot 0.6's own `torchcodec>=0.11,<0.12; aarch64`
+    # marker. NOTE: torch/torchcodec ship as +cuXXX wheels resolved by
+    # UV_TORCH_BACKEND; a plain `pip install` on Thor may need the matching CUDA
+    # index -- see the README Installation section for the Thor/Jetson caveat.
+    "lerobot[feetech,dataset]>=0.6.0,<0.7.0",
 ]
 # MolmoAct2 transformers-native VLA (e.g. allenai/MolmoAct2-SO100_101). The
-# MolmoAct2Policy class shipped in lerobot AFTER the 0.5.1 PyPI release (merged
-# in lerobot PR #3604), so a plain `pip install strands-robots[lerobot]`
-# resolves lerobot 0.5.1, which lacks it. Until a lerobot release that contains
-# the PR lands on PyPI, install lerobot FROM SOURCE alongside this extra:
-#   uv pip install strands-robots[molmoact2] \
-#       'lerobot[feetech] @ git+https://github.com/huggingface/lerobot.git'
-# PyPI rejects direct git URLs in a published package's dependency table, so the
-# git pin lives in the install command (same pattern as cosmos3-diffusers), not
-# here. This extra layers the auxiliary deps MolmoAct2's modeling/processor code
-# needs on top of lerobot core -- transformers (Qwen2Tokenizer + the sharded
-# safetensors loader), peft, scipy -- mirroring lerobot's own [molmoact2] extra.
-# Once a tagged lerobot >= 0.5.2 is on PyPI, the first entry can pin
-# `lerobot[feetech]>=0.5.2` directly and the git-source step drops away.
+# MolmoAct2Policy class ships in lerobot >= 0.6 (it landed via lerobot PR #3604
+# after the 0.5.1 PyPI release), so `strands-robots[molmoact2]` now resolves it
+# straight from PyPI through the `strands-robots[lerobot]` (>=0.6) pin -- no
+# git-source step. This extra layers the auxiliary deps MolmoAct2's
+# modeling/processor code needs on top of lerobot core -- transformers
+# (Qwen2Tokenizer + the sharded safetensors loader), peft, scipy -- mirroring
+# lerobot's own [molmoact2] extra.
 molmoact2 = [
     "strands-robots[lerobot]",
     # Mirror lerobot's own [molmoact2] dep pins exactly. The transformers
@@ -368,51 +348,27 @@ dependencies = [
     # sim-mujoco (already in `all`).
     "mink>=0.0.4",
     "qpsolvers[quadprog]>=4.0.0",
-    # torchvision 0.26 (from the aarch64 torch>=2.11 override below) removed
-    # torchvision.io.VideoReader, which lerobot 0.5.1's pyav fallback still calls,
-    # crashing dataset video read-back. lerobot's torchcodec dep marker EXCLUDES
-    # aarch64, so add torchcodec explicitly on linux+aarch64 -> lerobot uses its
-    # preferred (working) torchcodec decoder instead of the removed VideoReader.
-    "torchcodec>=0.7; platform_machine == 'aarch64' and sys_platform == 'linux'",
 ]
 
 # ---------------------------------------------------------------------------
-# torch 2.11 override for NVIDIA Thor / Jetson (linux + aarch64).
+# uv resolution overrides.
 #
-# The PyPI torch 2.10.0 aarch64 build has a bug in its sm_110 (Thor, compute
-# capability 11.0) cuBLAS call path: every cublasSgemm returns
-# CUBLAS_STATUS_INVALID_VALUE, so real policy inference crashes even though
-# torch.cuda.is_available() is True. This is fixed in torch 2.11 (verified on
-# NVIDIA Thor: native cuBLAS matmul + lerobot ACTPolicy inference both work).
-#
-# lerobot 0.5.1 declares torch<2.11 / torchvision<0.26, but that cap is
-# conservative -- lerobot 0.5.1 imports and runs ACTPolicy fine on torch 2.11
-# (empirically verified). We override the cap ONLY on linux+aarch64 so x86_64
-# and macOS keep lerobot's resolved versions untouched.
-#
-# Paired with UV_TORCH_BACKEND=auto above, a Thor `hatch env` resolves
-# torch==2.11.x+cu130 / torchvision==0.26.x+cu130 and inference runs on GPU
-# with no shim or LD_PRELOAD workaround.
+# lerobot 0.6 declares platform-correct torch/torchvision/torchcodec markers
+# (torch>=2.7,<2.12; on linux aarch64 its `torchcodec>=0.11,<0.12` marker pulls
+# torch 2.11 -- the build that fixes the NVIDIA Thor/Jetson sm_110 cuBLAS bug
+# that afflicts torch 2.10), so the whole torch/torchvision/torchcodec stack
+# resolves ABI-consistently on every platform (torch 2.11 + torchcodec 0.11.x +
+# torchvision 0.26) with NO strands torch override. Paired with
+# UV_TORCH_BACKEND=auto below, a Thor `hatch env` resolves the +cu130 wheels and
+# inference runs on GPU. The sole remaining override is the diffusers security
+# floor.
 [tool.uv]
 override-dependencies = [
-    # On NVIDIA Thor/Jetson (linux+aarch64) bump torch past lerobot's <2.11 cap
-    # (2.11 fixes the sm_110 cuBLAS bug). On every OTHER platform, mirror
-    # lerobot's own bound so x86/macOS resolve the same torch they would
-    # WITHOUT this override. NOTE: a uv override-dependency for `torch` with
-    # ONLY an aarch64 marker REMOVES torch from non-aarch64 resolutions
-    # entirely (proven: x86 resolved no torch -> tests/conftest.py installed
-    # the numpy mock -> bfloat16 failures). The complementary marker is
-    # mandatory, not cosmetic.
-    "torch>=2.11,<2.12; platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "torch>=2.2,<2.11; platform_machine != 'aarch64' or sys_platform != 'linux'",
-    "torchvision>=0.26,<0.27; platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "torchvision<0.26; platform_machine != 'aarch64' or sys_platform != 'linux'",
-    # SECURITY: lerobot 0.5.1 transitively caps diffusers <0.36.0, which pins
-    # the resolution to 0.35.2 -- vulnerable to GHSA trust_remote_code bypass
-    # + TOCTOU RCE (fixed in 0.38.0). diffusers is only exercised by the
+    # SECURITY: diffusers <0.36 is vulnerable to a GHSA trust_remote_code bypass
+    # + a TOCTOU RCE (fixed in 0.38.0). diffusers is only exercised by the
     # cosmos3-diffusers extra (Cosmos3Policy backend="diffusers"); lerobot core
-    # does not import diffusers at runtime, so forcing >=0.38 past lerobot's
-    # conservative cap is safe and clears the Dependabot alerts.
+    # does not import it at runtime, so forcing >=0.38 is safe and clears the
+    # Dependabot alerts.
     "diffusers>=0.38.0",
 ]
 

--- a/tests/test_dependency_audit.py
+++ b/tests/test_dependency_audit.py
@@ -133,3 +133,72 @@ def test_direct_reference_check_ignores_extras_specifiers_and_markers(tmp_path):
         encoding="utf-8",
     )
     assert audit_deps.check_direct_references(pyproject) == []
+
+
+# ---------------------------------------------------------------------------
+# lerobot 0.6 floor + torch/torchvision override-removal invariant.
+#
+# strands_robots used to carry per-platform torch/torchvision/torchcodec
+# overrides in the ``[lerobot]`` extra and ``[tool.uv].override-dependencies``
+# to compensate for lerobot 0.5.1's deficient dependency markers (its torch<2.11
+# cap that skipped the NVIDIA Thor/Jetson sm_110 cuBLAS fix, and its torchcodec
+# marker that excluded linux aarch64, leaving Thor/Jetson with no video decoder).
+# lerobot 0.6 fixed those markers upstream: torch>=2.7,<2.12 with a
+# ``torchcodec>=0.11,<0.12`` aarch64 marker that pulls the ABI-matched torch 2.11
+# on every platform. Requiring lerobot >= 0.6.0 is therefore what lets those
+# overrides be dropped: the codec/decoder stack now resolves ABI-consistently
+# (torch 2.11 + torchcodec 0.11.x + torchvision 0.26) on linux x86_64/aarch64 and
+# macOS arm64 with no strands override.
+#
+# These two invariants are coupled: reverting the lerobot floor below 0.6 WITHOUT
+# restoring the overrides would silently break the video decoder on aarch64/macOS,
+# and re-adding a torch<2.11 override would conflict with lerobot 0.6's torch 2.11
+# resolution. This guard fails if either half regresses.
+import tomllib  # noqa: E402
+
+from packaging.requirements import Requirement  # noqa: E402
+from packaging.version import Version  # noqa: E402
+
+
+def _lerobot_extra_requirement() -> Requirement:
+    data = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
+    extra = data["project"]["optional-dependencies"]["lerobot"]
+    for spec in extra:
+        req = Requirement(spec)
+        if req.name == "lerobot":
+            return req
+    raise AssertionError("no `lerobot` requirement found in the [lerobot] extra")
+
+
+def test_lerobot_extra_requires_at_least_0_6() -> None:
+    """The ``[lerobot]`` extra must floor lerobot at >= 0.6.0.
+
+    The 0.5.1-era torch/torchcodec overrides were removed because lerobot 0.6's
+    own markers resolve the decoder stack correctly; that only holds for
+    lerobot >= 0.6, so the floor must not regress below it.
+    """
+    req = _lerobot_extra_requirement()
+    assert Version("0.6.0") in req.specifier, f"lerobot floor must admit 0.6.0, got {req.specifier}"
+    assert Version("0.5.9") not in req.specifier, (
+        f"lerobot floor must exclude 0.5.x (the overrides that compensated for "
+        f"lerobot 0.5.1's decoder markers were removed), got {req.specifier}"
+    )
+
+
+def test_no_torch_or_torchvision_uv_override() -> None:
+    """No ``torch``/``torchvision`` pin may live in ``[tool.uv].override-dependencies``.
+
+    lerobot 0.6 resolves torch 2.11 + torchvision 0.26 (the ABI-matched pair, and
+    the torch build that fixes the Thor sm_110 cuBLAS bug) on every platform
+    unaided. A strands ``torch``/``torchvision`` override -- in particular a
+    ``torch<2.11`` cap like the 0.5.1-era one -- would conflict with that
+    resolution, so it must stay removed. (The diffusers security-floor override
+    is unrelated and intentionally retained.)
+    """
+    data = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
+    overrides = data.get("tool", {}).get("uv", {}).get("override-dependencies", [])
+    offenders = [o for o in overrides if Requirement(o).name in ("torch", "torchvision")]
+    assert not offenders, (
+        "torch/torchvision uv overrides must stay removed (they compensated for "
+        f"lerobot 0.5.1 and conflict with lerobot 0.6's torch 2.11): {offenders}"
+    )

--- a/tests/test_lerobot_import_surface.py
+++ b/tests/test_lerobot_import_surface.py
@@ -38,21 +38,18 @@ _PACKAGE_DIR = Path(strands_robots.__file__).resolve().parent
 
 # Symbols strands imports for FORWARD compatibility with a future lerobot:
 # they exist on lerobot main but not in any wheel within the currently pinned
-# range (lerobot>=0.5.0,<0.6.0 resolves 0.5.x), and EVERY use is gated behind a
-# try/except (ImportError, TypeError) fallback that degrades gracefully when the
-# symbol is absent. Their absence on the pinned wheel is therefore expected, not
-# a rename/removal, so the drift guard must not flag them. Remove an entry once
-# the pinned lerobot range ships the symbol (it then resolves like any other).
-_FORWARD_COMPAT_SYMBOLS: frozenset[tuple[str, str]] = frozenset(
-    {
-        # reanchor_relative_rtc_prefix landed in lerobot after 0.5.1 (it lives in
-        # lerobot/policies/rtc/relative.py on main). LerobotLocalPolicy consumes
-        # it to re-anchor the RTC chunk-seam prefix for relative-action policies,
-        # falling back to a stale-frame prefix with a one-time warning when it is
-        # missing - so a 0.5.x install degrades rather than failing to import.
-        ("lerobot.policies.rtc", "reanchor_relative_rtc_prefix"),
-    }
-)
+# range, and EVERY use is gated behind a try/except (ImportError, TypeError)
+# fallback that degrades gracefully when the symbol is absent. Their absence on
+# the pinned wheel is therefore expected, not a rename/removal, so the drift
+# guard must not flag them. Remove an entry once the pinned lerobot range ships
+# the symbol (it then resolves like any other).
+#
+# Empty: the pinned range is now lerobot>=0.6.0, which ships every symbol
+# strands imports -- reanchor_relative_rtc_prefix (previously forward-compat)
+# lands in lerobot 0.6, so it is now checked like any other import. A new entry
+# belongs here only when strands starts importing a symbol that exists on
+# lerobot main but not yet in the pinned range.
+_FORWARD_COMPAT_SYMBOLS: frozenset[tuple[str, str]] = frozenset()
 
 
 def _python_sources() -> list[Path]:

--- a/tests/test_robot_factory.py
+++ b/tests/test_robot_factory.py
@@ -1270,18 +1270,31 @@ class TestHardwareConfigV040Followups:
             "the bare except Exception on plugin registration must be gone (#291)"
         )
 
-    def test_lerobot_extra_pins_torchcodec_on_aarch64(self):
-        """#378: the public [lerobot] extra must carry the aarch64 torchcodec
-        pin so a `pip install strands-robots[lerobot]` on Thor/Jetson gets a
-        working video decoder (not just the hatch dev env)."""
+    def test_lerobot_extra_provides_aarch64_video_decoder(self):
+        """#378: a `pip install strands-robots[lerobot]` on Thor/Jetson must get a
+        working aarch64 video decoder (torchcodec), not the removed
+        `torchvision.io.VideoReader`.
+
+        The [lerobot] extra used to carry an explicit aarch64 torchcodec pin
+        because lerobot 0.5.1's own marker excluded aarch64. lerobot 0.6 fixed
+        that upstream (its `torchcodec>=0.11,<0.12; aarch64` marker pulls the
+        torch-ABI-matched decoder), so the strands override was dropped and the
+        guarantee now rides on the `lerobot>=0.6.0` floor. This pins that floor
+        so a revert below 0.6 -- which would resurrect the missing-decoder bug
+        without the removed override -- fails here."""
         import tomllib
         from pathlib import Path
+
+        from packaging.requirements import Requirement
+        from packaging.version import Version
 
         root = Path(__file__).resolve().parents[1]
         data = tomllib.load(open(root / "pyproject.toml", "rb"))
         lerobot_extra = data["project"]["optional-dependencies"]["lerobot"]
-        assert any("torchcodec" in dep and "aarch64" in dep for dep in lerobot_extra), (
-            f"[lerobot] extra must pin torchcodec on linux+aarch64 (#378); got {lerobot_extra}"
+        lerobot_req = next(Requirement(d) for d in lerobot_extra if Requirement(d).name == "lerobot")
+        assert Version("0.6.0") in lerobot_req.specifier and Version("0.5.9") not in lerobot_req.specifier, (
+            f"[lerobot] extra must floor lerobot at >=0.6.0 so aarch64 gets torchcodec (#378); "
+            f"got {lerobot_req.specifier}"
         )
 
 


### PR DESCRIPTION
## Problem

lerobot released **0.6.0/0.6.1**, but the `[lerobot]`/`[molmoact2]` extras still pin `lerobot>=0.5.0,<0.6.0`, so a fresh `pip install` resolves 0.5.1. Consequences:

- **`MolmoAct2Policy` cannot be installed from PyPI.** It landed in lerobot after the 0.5.1 release (lerobot PR #3604) and ships in 0.6, but the `<0.6.0` cap forces the documented "install lerobot from source" workaround even though a tagged PyPI release now provides it.
- **The 0.5.1-era torch/torchcodec overrides are now stale and, on macOS, actively harmful.** strands carried per-platform torchcodec pins in the `[lerobot]` extra plus `torch`/`torchvision` `[tool.uv].override-dependencies`, all added to compensate for lerobot 0.5.1's deficient markers (its `torch<2.11` cap that skipped the NVIDIA Thor/Jetson sm_110 cuBLAS fix, and its torchcodec marker that excluded linux aarch64). lerobot 0.6 fixed those markers upstream (`torch>=2.7,<2.12`; `torchcodec>=0.11,<0.12` on linux aarch64). With the current overrides kept but the cap bumped, macOS arm64 would resolve **torch 2.11 + torchcodec 0.10** — an ABI mismatch (torchcodec 0.10 is built against torch 2.10's c10). The current aarch64 `torchcodec>=0.11` override is also unbounded and resolves torchcodec **0.14** against torch 2.11 (mismatched).

## Change

- Bump the `[lerobot]` / `[molmoact2]` extras to `lerobot>=0.6.0,<0.7.0`.
- Remove the per-platform `torchcodec` pins from the `[lerobot]` extra and the dev extra, and the `torch`/`torchvision` entries from `[tool.uv].override-dependencies`. lerobot 0.6's own markers resolve the ABI-matched stack; the aarch64 torch 2.11 requirement (the Thor sm_110 fix) now falls out of lerobot 0.6's `torchcodec>=0.11,<0.12; aarch64` marker.
- Keep the `diffusers>=0.38.0` security override (unrelated).
- Refresh the now-stale comments + docs (README + installation.md): MolmoAct2 resolves straight from PyPI, no git-source step.

## Multi-platform resolution (validated with `uv pip compile --python-platform`)

After the change, `strands-robots[lerobot]` and `strands-robots[molmoact2]` resolve to the **same ABI-consistent stack on every platform**:

| platform | lerobot | torch | torchcodec | torchvision |
|---|---|---|---|---|
| linux x86_64 | 0.6.0 | 2.11.0 | 0.11.1 | 0.26.0 |
| linux aarch64 (Jetson/Thor) | 0.6.0 | 2.11.0 | 0.11.1 | 0.26.0 |
| macOS arm64 | 0.6.0 | 2.11.0 | 0.11.1 | 0.26.0 |

torch 2.11 is the build that fixes the Thor sm_110 cuBLAS bug, so aarch64 gets it natively (previously via a strands override).

## Runtime validation

Verified end-to-end against the resolved stack (lerobot 0.6.1 + torch 2.11.0 + torchcodec 0.11.1 + torchvision 0.26.0) on linux x86_64:

- Full `tests/policies/lerobot_local` (512) + `tests/test_lerobot_import_surface.py` + `tests/test_dataset_recorder.py` + `tests/training` (454) suites pass.
- A real SmolVLA (`lerobot/smolvla_base`) rollout in MuJoCo through lerobot 0.6's processor pipeline runs to completion, records an MP4 (h264) + a LeRobotDataset, and the dataset reopens with the expected 3 per-camera image features `(3, 256, 256)` and non-degenerate state/action.
- The full import surface (`from lerobot ... import`) + all 19 registered policy types resolve cleanly.

x86 CI validates the resolved stack automatically; aarch64 keeps the same torch 2.11 it resolves today (only lerobot moves 0.5.1→0.6).

## Tests (fail before, pass after)

- `tests/test_dependency_audit.py::test_lerobot_extra_requires_at_least_0_6` — floors lerobot at >=0.6.0.
- `tests/test_dependency_audit.py::test_no_torch_or_torchvision_uv_override` — the removed torch/torchvision overrides must stay removed (they conflict with lerobot 0.6's torch 2.11).
- `tests/test_robot_factory.py::...::test_lerobot_extra_provides_aarch64_video_decoder` — the #378 aarch64-decoder guarantee, now expressed via the >=0.6 floor (lerobot 0.6's aarch64 torchcodec marker) instead of a strands override.

All three fail on the pre-change pyproject (floor 0.5.0, overrides present) and pass after. The now-obsolete `reanchor_relative_rtc_prefix` forward-compat allowlist entry is removed (it ships in 0.6, so the drift guard now checks it like any other import).

lint (ruff + format + mypy) clean on all changed files.