### PR TITLE
test(tools): pin lerobot_camera dispatch catch-all error contract

### DIFF
--- a/tests/tools/test_lerobot_camera.py
+++ b/tests/tools/test_lerobot_camera.py
@@ -685,3 +685,71 @@ def test_frame_to_image_content_passes_through_non_rgb_frame() -> None:
     assert "image" in content
     assert content["image"]["format"] == "png"
     assert content["image"]["source"]["bytes"]
+
+
+# --- dispatch catch-all: the tool never raises past dispatch ---------------
+#
+# Every action branch and helper is wrapped in a top-level ``try/except`` so an
+# unexpected failure (a lerobot API drift, a driver crash) is turned into the
+# ``{"status": "error"}`` tool-result contract rather than propagating out of
+# the ``@tool`` and killing the agent turn. These pin that guarantee for each of
+# the three catch-all wrappers.
+
+
+def test_dispatch_catch_all_wraps_unexpected_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unexpected error inside an action branch becomes an error result.
+
+    The ``discover`` branch delegates to ``_discover_cameras``; if that raises
+    something the helper itself does not handle, the dispatcher's outer guard
+    must still return the two-key error contract, never re-raise.
+    """
+
+    def boom() -> dict[str, Any]:
+        raise RuntimeError("driver exploded")
+
+    monkeypatch.setattr(cam_mod, "_discover_cameras", boom)
+
+    result = lerobot_camera(action="discover")
+
+    assert result["status"] == "error"
+    assert set(result) == {"status", "content"}
+    body = _texts(result)
+    assert "Camera operation failed" in body
+    assert "driver exploded" in body
+    _assert_ascii(body)
+
+
+def test_discover_catch_all_wraps_probe_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failing OpenCV probe surfaces as a discovery error, not an exception."""
+
+    def boom() -> list[dict[str, Any]]:
+        raise OSError("v4l2 enumeration failed")
+
+    monkeypatch.setattr(cam_mod.OpenCVCamera, "find_cameras", staticmethod(boom))
+
+    result = cam_mod._discover_cameras()
+
+    assert result["status"] == "error"
+    assert set(result) == {"status", "content"}
+    body = _texts(result)
+    assert "Camera discovery failed" in body
+    assert "v4l2 enumeration failed" in body
+    _assert_ascii(body)
+
+
+def test_details_catch_all_wraps_backend_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failure while assembling OpenCV details is returned as an error result."""
+
+    def boom() -> str:
+        raise RuntimeError("backend query failed")
+
+    monkeypatch.setattr(cam_mod, "_get_opencv_backend_name", boom)
+
+    result = cam_mod._list_camera_details("opencv")
+
+    assert result["status"] == "error"
+    assert set(result) == {"status", "content"}
+    body = _texts(result)
+    assert "Camera details failed" in body
+    assert "backend query failed" in body
+    _assert_ascii(body)


### PR DESCRIPTION
## Problem

The `lerobot_camera` agent tool wraps each action branch, `_discover_cameras`, and `_list_camera_details` in a top-level `try/except` that turns an unexpected failure (a lerobot camera-API drift, a driver crash, a v4l2 enumeration error) into the `{status: error}` tool-result contract instead of letting the exception propagate out of the `@tool` and abort the agent turn. This is the project's `Tools return {status: error} - never raise past dispatch` invariant.

Those three catch-all wrappers had no test coverage, so a future refactor could silently let an exception escape dispatch and no test would notice. The existing suite covers the inner, expected error paths (RealSense probe failure, per-camera connect failure) but not the outer guards.

## Change

Add three behavior tests to `tests/tools/test_lerobot_camera.py` that force each wrapper's `except` path and assert the two-key error contract plus ASCII output:

- `test_dispatch_catch_all_wraps_unexpected_error` - a raising `_discover_cameras` is caught by the dispatcher and returned as `Camera operation failed`.
- `test_discover_catch_all_wraps_probe_error` - a failing `OpenCVCamera.find_cameras` surfaces as `Camera discovery failed`, not an exception.
- `test_details_catch_all_wraps_backend_error` - a failing `_get_opencv_backend_name` is returned as `Camera details failed`.

Each asserts `result["status"] == "error"`, that the result dict has exactly the `{status, content}` keys (no smuggled sibling keys), that the underlying error message is surfaced, and that the text is plain ASCII.

## Tests

- `pytest tests/tools/test_lerobot_camera.py` - 54 passed.
- `lerobot_camera` line coverage 97% -> 99% (the three catch-all branches now covered; the only remaining gap is the module-level RealSense import fallback, reachable only when the RealSense SDK is absent at import time).
- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` all clean.

No production code changed; these are regression guards for an existing contract.