### PR TITLE
fix(training): Gr00tTrainer.build_command augmentation parity with build_finetune_config

### DIFF
--- a/strands_robots/training/groot.py
+++ b/strands_robots/training/groot.py
@@ -210,10 +210,18 @@ class Gr00tTrainer(Trainer):
         cmd.append(f"--tune_diffusion_model={'true' if tune['diffusion'] else 'false'}")
 
         if spec.augmentation:
+            # Mirror build_finetune_config exactly: random_rotation_angle and
+            # color_jitter_params are native FinetuneConfig fields; every other
+            # augmentation key is bundled into --extra_augmentation_config JSON.
             if "random_rotation_angle" in spec.augmentation:
                 cmd.append(f"--random_rotation_angle={spec.augmentation['random_rotation_angle']}")
             if "color_jitter_params" in spec.augmentation:
-                cmd.append(f"--extra_augmentation_config={json.dumps(spec.augmentation)}")
+                cmd.append(f"--color_jitter_params={spec.augmentation['color_jitter_params']}")
+            extra_aug = {
+                k: v for k, v in spec.augmentation.items() if k not in ("random_rotation_angle", "color_jitter_params")
+            }
+            if extra_aug:
+                cmd.append(f"--extra_augmentation_config={json.dumps(extra_aug)}")
 
         mcfg = spec.extra.get("modality_config_path")
         if mcfg:

--- a/tests/training/test_groot.py
+++ b/tests/training/test_groot.py
@@ -169,6 +169,56 @@ class TestBuildCommand:
         # consumed keys must not leak
         assert not any(c.startswith("--groot_root=") for c in cmd)
 
+    def test_no_augmentation_emits_no_augmentation_flags(self, spec):
+        """With no augmentation, none of the augmentation flags appear."""
+        cmd = Gr00tTrainer().build_command(spec)
+        assert not any(c.startswith("--random_rotation_angle=") for c in cmd)
+        assert not any(c.startswith("--color_jitter_params=") for c in cmd)
+        assert not any(c.startswith("--extra_augmentation_config=") for c in cmd)
+
+    def test_augmentation_native_and_extra_map_to_distinct_flags(self, spec):
+        """build_command mirrors build_finetune_config: random_rotation_angle
+        and color_jitter_params are native flags; any other key is bundled into
+        --extra_augmentation_config JSON that excludes those native keys.
+        """
+        spec.augmentation = {
+            "random_rotation_angle": 30,
+            "color_jitter_params": [0.3, 0.3, 0.3, 0.1],
+            "mixup_alpha": 0.4,
+        }
+        cmd = Gr00tTrainer().build_command(spec)
+        assert "--random_rotation_angle=30" in cmd
+        # color_jitter_params is a native field: its own flag, NOT folded into
+        # --extra_augmentation_config.
+        assert "--color_jitter_params=[0.3, 0.3, 0.3, 0.1]" in cmd
+        extra_flags = [c for c in cmd if c.startswith("--extra_augmentation_config=")]
+        assert len(extra_flags) == 1
+        extra = json.loads(extra_flags[0].split("=", 1)[1])
+        assert extra == {"mixup_alpha": 0.4}
+        # native keys must NOT leak into the extra config bundle.
+        assert "random_rotation_angle" not in extra
+        assert "color_jitter_params" not in extra
+
+    def test_extra_only_augmentation_is_not_dropped(self, spec):
+        """An augmentation dict with only non-native keys still emits
+        --extra_augmentation_config (regression: it used to be silently dropped
+        unless color_jitter_params was also present).
+        """
+        spec.augmentation = {"mixup_alpha": 0.4}
+        cmd = Gr00tTrainer().build_command(spec)
+        extra_flags = [c for c in cmd if c.startswith("--extra_augmentation_config=")]
+        assert len(extra_flags) == 1
+        assert json.loads(extra_flags[0].split("=", 1)[1]) == {"mixup_alpha": 0.4}
+
+    def test_color_jitter_only_emits_native_flag_no_extra(self, spec):
+        """color_jitter_params alone emits its native flag and no extra bundle
+        (regression: --extra_augmentation_config used to dump the whole dict).
+        """
+        spec.augmentation = {"color_jitter_params": [0.2, 0.2, 0.2, 0.05]}
+        cmd = Gr00tTrainer().build_command(spec)
+        assert "--color_jitter_params=[0.2, 0.2, 0.2, 0.05]" in cmd
+        assert not any(c.startswith("--extra_augmentation_config=") for c in cmd)
+
 
 # ---------------------------------------------------------------------------
 # Fake Isaac-GR00T package tree so the config-lowering + in-process launch


### PR DESCRIPTION
## Problem

`Gr00tTrainer.build_command` is the documented argv-parity helper: its whole purpose (per its docstring and `test_native_parity`) is to emit exactly the flags that map to the real `FinetuneConfig` dataclass fields that `build_finetune_config` sets. For augmentation it diverged from `build_finetune_config` in three ways:

1. **`--color_jitter_params` was never emitted.** `color_jitter_params` is a native `FinetuneConfig` field (`build_finetune_config` sets it as `kwargs["color_jitter_params"]`), but `build_command` folded it into `--extra_augmentation_config` instead of giving it its own flag.
2. **`--extra_augmentation_config` dumped the entire augmentation dict.** It serialized all of `spec.augmentation` (including the native `random_rotation_angle` / `color_jitter_params` keys) rather than only the non-native extras, so the extra-config bundle was polluted with keys that already have dedicated native flags.
3. **Extra-only augmentation was silently dropped.** An augmentation dict with only non-native keys (e.g. `{"mixup_alpha": 0.4}`) emitted no flag at all, because `--extra_augmentation_config` was only appended when `color_jitter_params` happened to be present.

The module docstring already documents the correct contract (`augmentation -> --random_rotation_angle / --color_jitter_params / --extra_augmentation_config`); the code was the outlier.

## Change

`build_command` now mirrors `build_finetune_config` exactly:
- `random_rotation_angle` -> `--random_rotation_angle`
- `color_jitter_params` -> `--color_jitter_params` (native flag)
- every remaining key -> `--extra_augmentation_config` JSON, excluding the two native keys

## Tests

Added four `TestBuildCommand` regression tests. Three fail on the pre-fix code and pass after; the fourth is a happy-path guard:
- `test_augmentation_native_and_extra_map_to_distinct_flags` - native flags emitted separately; extra bundle contains only `{"mixup_alpha": 0.4}`, no native-key leakage.
- `test_extra_only_augmentation_is_not_dropped` - `{"mixup_alpha": 0.4}` still emits `--extra_augmentation_config` (was silently dropped).
- `test_color_jitter_only_emits_native_flag_no_extra` - `color_jitter_params` alone emits its native flag and no extra bundle.
- `test_no_augmentation_emits_no_augmentation_flags` - no augmentation -> none of the three flags appear.

`tests/training/` full suite: 375 passed, 4 skipped. Lint clean (`ruff check`, `ruff format --check`, `mypy strands_robots tests tests_integ` -> no issues). `strands_robots/training/groot.py` coverage 93% -> 95% (augmentation branch now exercised).