### PR TITLE
docs: correct post-lerobot-0.6 VLA dependency guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -754,6 +754,20 @@ torchcodec 0.14) is bounded by lerobot 0.6's `<0.12`. `MolmoAct2Policy` (added
 to lerobot after the 0.5.1 PyPI release) now resolves straight from PyPI via the
 `[molmoact2]` extra -- the "install lerobot from source" step is gone.
 
+### Docs: correct post-lerobot-0.6 VLA install guidance
+
+The `lerobot>=0.6.0` requirement obsoleted a body of pre-0.6 install lore that
+survived in the `train_policy` tool docstring and the training / lerobot-local
+docs: `pip install 'lerobot[smolvla]==0.5.1'`, a `transformers==5.3.0` pin, the
+"a newer transformers crashes the VLA import (`backbone_cfg`)" note, and
+"MolmoAct2 requires lerobot from source". lerobot 0.6's `[smolvla]`/`[pi]`/
+`[molmoact2]` extras now require `transformers>=5.4.0,<5.6.0`, so the old
+`transformers==5.3.0` pin is a hard resolution conflict rather than a fix, and
+`strands-robots[molmoact2]` resolves `MolmoAct2Policy` straight from PyPI (no
+git-from-source). The guidance now matches the declared extras; a regression
+test pins the docs to the pyproject requirements so the stale lore cannot
+return.
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -154,7 +154,7 @@ static list (see [Discovering supported policy types](#discovering-supported-pol
 | `smolvla` | SmolVLA - HuggingFace small VLA |
 | `pi0` / `pi05` / `pi0_fast` | Physical Intelligence VLA family |
 | `groot` | NVIDIA GR00T |
-| `molmoact2` | transformers-native SO100/SO101 VLA; **requires lerobot from source** (see below) |
+| `molmoact2` | transformers-native SO100/SO101 VLA; `pip install 'strands-robots[molmoact2]'` (see below) |
 | `eo1` | EO-1 VLA |
 | `xvla` | X-VLA |
 | `wall_x` | Wall-X VLA |
@@ -191,32 +191,18 @@ one-line fix instead of a dead end.
 
 ## MolmoAct2
 
-> **Important:** MolmoAct2 requires lerobot installed **from source** (git main).
-> The `MolmoAct2Policy` class was added after lerobot 0.5.1 (the latest PyPI
-> release as of June 2025; merged in lerobot PR #3604). A plain
-> `pip install strands-robots[lerobot]` resolves lerobot 0.5.1, which does NOT
-> include MolmoAct2.
-
-The `[molmoact2]` extra layers the auxiliary deps MolmoAct2's modeling and
-processor code needs on top of lerobot core (`transformers`, `peft`, `scipy`),
-but PyPI rejects direct git URLs in a published package, so you still install
-lerobot itself from source in the same command:
+MolmoAct2 ships in lerobot **>= 0.6** - its `MolmoAct2Policy` was merged in
+lerobot PR #3604 and first released in 0.6.0 - so it resolves straight from
+PyPI with no git-from-source install. The `[molmoact2]` extra layers the
+auxiliary deps MolmoAct2's modeling and processor code needs
+(`transformers>=5.4.0,<5.6.0`, `peft`, `scipy`) on top of
+`strands-robots[lerobot]` (which pins `lerobot>=0.6.0,<0.7.0`):
 
 ```bash
-# Standard (x86_64, macOS):
-uv pip install "strands-robots[molmoact2]" \
-    "lerobot[feetech] @ git+https://github.com/huggingface/lerobot.git"
-
-# Jetson / aarch64 (pyav wheel may fail to build - skip it, lerobot uses torchcodec):
-uv pip install "strands-robots[molmoact2]" \
-    "lerobot[feetech] @ git+https://github.com/huggingface/lerobot.git" --no-build-isolation
-# If pyav still blocks the install, exclude it and add torchcodec manually:
-uv pip install torchcodec>=0.7
-uv pip install "lerobot[feetech] @ git+https://github.com/huggingface/lerobot.git" --no-deps
-uv pip install -r <(pip show lerobot 2>/dev/null | grep Requires | sed 's/Requires: //;s/, /\n/g' | grep -v "^av$")
+uv pip install "strands-robots[molmoact2]"
 ```
 
-Once lerobot from source is installed, MolmoAct2 works:
+MolmoAct2 then works:
 
 ```python
 policy = create_policy(

--- a/docs/training/overview.md
+++ b/docs/training/overview.md
@@ -310,8 +310,8 @@ that matches your `extra["policy_type"]` / provider — verified on an L40S GPU:
 | Provider / policy | Install | Notes |
 |---|---|---|
 | `lerobot_local` + ACT / diffusion | `pip install 'strands-robots[lerobot]'` | works out of the box (torch + torchcodec + datasets) |
-| `lerobot_local` + `smolvla` | `pip install 'lerobot[smolvla]==0.5.1'` | **needs `transformers==5.3.0`** (lerobot's pinned `[smolvla]` extra). A newer transformers (e.g. 5.12) crashes smolvla import with `non-default argument 'backbone_cfg' follows default argument`. Pin it. |
-| `lerobot_local` + `pi0` / `pi05` | `pip install 'lerobot[pi]==0.5.1'` | same `transformers==5.3.0` pin via lerobot's `[pi]` extra |
+| `lerobot_local` + `smolvla` | `pip install 'strands-robots[lerobot]' 'lerobot[smolvla]'` | lerobot 0.6's `[smolvla]` extra layers `transformers>=5.4.0,<5.6.0` + num2words on top. Do **not** pin `transformers==5.3.0` - it conflicts with lerobot 0.6's transformers floor. |
+| `lerobot_local` + `pi0` / `pi05` | `pip install 'strands-robots[lerobot]' 'lerobot[pi]'` | lerobot 0.6's `[pi]` extra (same `transformers>=5.4.0,<5.6.0` range + scipy) |
 | `groot` | Isaac-GR00T checkout + its own venv (`omegaconf`, `tyro`, …); point `extra["groot_root"]` / `GR00T_ROOT` at it | launched as a subprocess, so it uses GR00T's interpreter, not ours |
 | `cosmos3` | cosmos-framework checkout (`uv sync --group=cu130-train`); point `extra["cosmos_root"]` / `COSMOS_ROOT` at it | torchrun-driven; same subprocess-interpreter rule |
 

--- a/strands_robots/tools/train_policy.py
+++ b/strands_robots/tools/train_policy.py
@@ -140,10 +140,12 @@ def train_policy(
     Dependencies (per provider - the base ``[lerobot]`` extra is not always
     enough):
         - ``lerobot_local`` + ACT/diffusion: ``pip install 'strands-robots[lerobot]'``.
-        - ``lerobot_local`` + ``smolvla``/``pi0``/``pi05``: needs lerobot's
-          ``[smolvla]``/``[pi]`` extra, which pins ``transformers==5.3.0``. A
-          newer transformers crashes the VLA import (``non-default argument
-          'backbone_cfg' follows default argument``) - pin it.
+        - ``lerobot_local`` + ``smolvla``/``pi0``/``pi05``: add lerobot's
+          ``[smolvla]``/``[pi]`` extra on top of ``strands-robots[lerobot]``
+          (which pins ``lerobot>=0.6.0``). Those extras layer
+          ``transformers>=5.4.0,<5.6.0`` (plus num2words / scipy); do NOT pin
+          ``transformers==5.3.0`` - it conflicts with lerobot 0.6's transformers
+          floor.
         - ``groot``/``cosmos3``: install the upstream package into THIS
           interpreter (the trainer imports it and calls its library functions
           in-process - no subprocess). Point ``extra['groot_root']``/``GR00T_ROOT``

--- a/tests/test_lerobot_dependency_docs.py
+++ b/tests/test_lerobot_dependency_docs.py
@@ -1,0 +1,87 @@
+"""Keep the VLA install docs consistent with the declared dependencies.
+
+The ``lerobot>=0.6.0`` bump obsoleted a body of pre-0.6 install guidance that
+lived in the ``train_policy`` tool docstring and the policy/training docs:
+
+* ``pip install 'lerobot[smolvla]==0.5.1'`` and a ``transformers==5.3.0`` pin -
+  lerobot 0.6's ``[smolvla]``/``[pi]``/``[molmoact2]`` extras now require
+  ``transformers>=5.4.0,<5.6.0`` (declared as ``transformers-dep``), so a
+  ``transformers==5.3.0`` pin is a hard resolution conflict, not a fix. The
+  historical "a newer transformers crashes the VLA import with
+  ``non-default argument 'backbone_cfg' follows default argument``" note no
+  longer applies to the supported range.
+* "MolmoAct2 requires lerobot **from source**" - ``MolmoAct2Policy`` ships in
+  lerobot >= 0.6, so ``strands-robots[molmoact2]`` (which pulls
+  ``strands-robots[lerobot]`` -> ``lerobot>=0.6.0``) resolves it straight from
+  PyPI; no ``git+`` install.
+
+These assertions pin the pyproject reality and forbid the stale guidance from
+creeping back into the user-facing docs.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_PYPROJECT = _REPO_ROOT / "pyproject.toml"
+
+
+def _extras() -> dict[str, list[str]]:
+    data = tomllib.loads(_PYPROJECT.read_text())
+    return data["project"]["optional-dependencies"]
+
+
+# --- positive contract: the pyproject reality the docs must reflect ---
+
+
+def test_lerobot_extra_requires_0_6() -> None:
+    joined = " ".join(_extras()["lerobot"])
+    assert "lerobot" in joined
+    assert ">=0.6.0" in joined, f"lerobot extra no longer pins >=0.6.0: {joined!r}"
+
+
+def test_molmoact2_extra_is_pure_pypi_with_transformers_5_4_plus() -> None:
+    joined = " ".join(_extras()["molmoact2"])
+    # transformers floor matches lerobot 0.6's transformers-dep (>=5.4.0), NOT 5.3.0
+    assert "transformers>=5.4.0" in joined, joined
+    # resolves from PyPI - no git-from-source URL
+    assert "git+" not in joined, f"molmoact2 extra should not need a git URL: {joined!r}"
+
+
+# --- negative contract: stale pre-0.6 guidance must be gone from the docs ---
+
+_TRAIN_POLICY = _REPO_ROOT / "strands_robots" / "tools" / "train_policy.py"
+_TRAINING_OVERVIEW = _REPO_ROOT / "docs" / "training" / "overview.md"
+_LEROBOT_LOCAL = _REPO_ROOT / "docs" / "policies" / "lerobot-local.md"
+
+
+def test_train_policy_tool_has_no_stale_transformers_pin() -> None:
+    text = _TRAIN_POLICY.read_text()
+    # the "a newer transformers crashes the VLA import (backbone_cfg)" crash lore
+    # only ever appeared in this stale bullet; it no longer applies to lerobot
+    # 0.6's supported transformers>=5.4.0 range.
+    assert "backbone_cfg" not in text
+    # no longer claims lerobot's extra "pins transformers==5.3.0"
+    assert "pins ``transformers==5.3.0``" not in text
+    # documents the current (lerobot 0.6) floor instead
+    assert "transformers>=5.4.0" in text
+
+
+def test_training_overview_has_no_stale_vla_install_lore() -> None:
+    text = _TRAINING_OVERVIEW.read_text()
+    # the pre-0.6 "pin transformers==5.3.0 / lerobot 0.5.1" recommendation +
+    # the backbone_cfg crash lore are gone; the current transformers floor stays.
+    assert "backbone_cfg" not in text
+    assert "lerobot[smolvla]==0.5.1" not in text
+    assert "lerobot[pi]==0.5.1" not in text
+    assert "transformers>=5.4.0" in text
+
+
+def test_lerobot_local_docs_do_not_claim_molmoact2_needs_source() -> None:
+    text = _LEROBOT_LOCAL.read_text()
+    assert "requires lerobot installed **from source**" not in text
+    assert "resolves lerobot 0.5.1, which does NOT" not in text
+    # points at the PyPI extra instead
+    assert "strands-robots[molmoact2]" in text


### PR DESCRIPTION
## What
The `lerobot>=0.6.0` bump left a body of pre-0.6 install guidance stale in three doc surfaces. Following it now actively breaks a setup (it recommends dependency pins that conflict with the declared extras) and contradicts `installation.md`. This corrects all three against the actual `pyproject` extras.

## Stale claims fixed
1. **`train_policy` tool docstring** and **`docs/training/overview.md`** told users to `pip install 'lerobot[smolvla]==0.5.1'` / `'lerobot[pi]==0.5.1'` and pin `transformers==5.3.0`, and warned that a newer transformers crashes the VLA import with `non-default argument 'backbone_cfg' follows default argument`.
   - lerobot 0.6's `[smolvla]`/`[pi]`/`[molmoact2]` extras now declare `transformers-dep = transformers>=5.4.0,<5.6.0`. A `transformers==5.3.0` pin is therefore a hard resolution conflict, not a fix. SmolVLA and pi0 both import cleanly on that supported range, so the `backbone_cfg` crash note no longer applies.
2. **`docs/policies/lerobot-local.md`** claimed *"MolmoAct2 requires lerobot installed from source"* and that `pip install strands-robots[lerobot]` *"resolves lerobot 0.5.1, which does NOT include MolmoAct2"*, with a multi-line `git+https` install recipe.
   - `MolmoAct2Policy` ships in lerobot >= 0.6 (merged in lerobot PR #3604). `strands-robots[molmoact2]` pulls `strands-robots[lerobot]` -> `lerobot>=0.6.0,<0.7.0`, so it resolves straight from PyPI with `uv pip install "strands-robots[molmoact2]"` and no git-from-source step. This section had drifted to the opposite of `installation.md`, which already documents the PyPI path; the two now agree.

## Left intentionally untouched
`policies/lerobot_local/resolution.py`'s graceful-degradation guard (and its tests) still defends against an import-time `TypeError` from *any* policy module -- that is a version-agnostic robustness path, not a claim about the current transformers, so it stays.

## Tests
Adds `tests/test_lerobot_dependency_docs.py`, which pins the docs to the declared `pyproject` extras: (a) the `[lerobot]` extra requires `>=0.6.0` and `[molmoact2]` is pure-PyPI with `transformers>=5.4.0` (no `git+`), and (b) the stale `backbone_cfg` crash lore, the `==0.5.1` recommendations, and the "MolmoAct2 requires lerobot from source" claim are absent from the three doc surfaces. The doc-content assertions fail on the pre-fix docs and pass after; the pyproject assertions ground the corrected guidance.

Gate: `ruff check` / `ruff format --check` / `mypy` clean on the changed sources; new + `test_dependency_audit` + the `backbone_cfg` graceful-degradation tests pass. Docs-only change, no behavior change.