### PR TITLE
test(sim): make async-RTC overlap assertion deterministic via rendezvous

### DIFF
--- a/tests/simulation/test_policy_runner_async_rtc.py
+++ b/tests/simulation/test_policy_runner_async_rtc.py
@@ -159,15 +159,71 @@ def _run(
 
 
 def test_async_rtc_starts_next_inference_mid_chunk() -> None:
-    """The prefetched chunk-N+1 inference fires while chunk N is still draining."""
-    result, policy, sim = _run(async_rtc=True)
+    """The prefetched chunk-(N+1) inference genuinely overlaps chunk-N execution.
+
+    Proven by a rendezvous, NOT a wall-clock timing race: the consumer blocks
+    the final action of the first chunk until the prefetch worker has entered
+    ``get_actions``, so the step index captured at inference start is guaranteed
+    to be observed strictly before the chunk drains - deterministically,
+    independent of thread-scheduling latency under CPU load. (Reading
+    ``send_count`` on the worker thread and asserting ``< chunk`` without this
+    handshake flaked under load: the worker could be scheduled only after the
+    consumer had already drained the chunk, reading a boundary value.)
+
+    The rendezvous also pins the mid-chunk trigger itself: were the prefetch
+    submitted only at the chunk boundary (no overlap), the worker would never
+    start before the blocked final send and the wait would time out.
+    """
+    infer_started = threading.Event()
+
+    class _RendezvousSim(_CountingSim):
+        def send_action(self, action, robot_name=None, n_substeps=1):
+            # Block the final action of the first chunk until the prefetch
+            # worker has begun inference. The worker is submitted at the
+            # mid-chunk trigger (strictly before this step), so it cannot
+            # deadlock; if overlap regressed to boundary-only prefetch this
+            # wait times out and fails the test.
+            with self._lock:
+                about_to_send = self.send_count + 1
+            if about_to_send == _CHUNK:
+                assert infer_started.wait(timeout=5.0), "prefetch worker did not start before the first chunk drained"
+            with self._lock:
+                self.send_count += 1
+            if self._exec_sleep:
+                time.sleep(self._exec_sleep)
+
+    class _RendezvousPolicy(_ChunkPolicy):
+        async def get_actions(
+            self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any
+        ) -> list[dict[str, Any]]:
+            with self._lock:
+                is_first_prefetch = len(self.infer_starts) == 1
+                self.infer_starts.append(self._sim.send_count)
+                self.observed_delays.append(self.rtc_observed_delay_steps)
+            if is_first_prefetch:
+                infer_started.set()
+            if self._infer_sleep:
+                time.sleep(self._infer_sleep)
+            keys = self.robot_state_keys or ["j0", "j1", "j2"]
+            return [{k: 0.0 for k in keys} for _ in range(self._chunk)]
+
+    sim = _RendezvousSim(exec_sleep=_EXEC_SLEEP)
+    policy = _RendezvousPolicy(sim)
+    policy.set_robot_state_keys(sim.robot_joint_names("arm"))
+    result = PolicyRunner(sim).run(
+        "arm",
+        policy,
+        duration=16 / 50.0,
+        control_frequency=50.0,
+        action_horizon=_CHUNK,
+        fast_mode=True,
+        async_rtc=True,
+    )
     assert result["status"] == "success"
-    # More than one chunk was consumed, so prefetch had to fire.
+    # More than one chunk was consumed, so the prefetch had to fire.
     assert len(policy.infer_starts) >= 2
-    # At least one inference began at a non-chunk-boundary step index -> the
-    # query overlapped execution rather than waiting for a full drain.
-    assert any(c % _CHUNK != 0 for c in policy.infer_starts), policy.infer_starts
-    # Specifically the first prefetch starts strictly before chunk 1 drains.
+    # The first prefetch's inference began strictly before the first chunk's
+    # final action drained - genuine overlap, guaranteed by the rendezvous.
     assert policy.infer_starts[1] < _CHUNK, policy.infer_starts
 
 


### PR DESCRIPTION
## Problem

`test_async_rtc_starts_next_inference_mid_chunk` verifies that the async-RTC pipeline in `PolicyRunner.run` fires the chunk-(N+1) inference while chunk N is still draining. It proved this by reading `sim.send_count` on the **prefetch worker thread** and asserting the value was `< chunk_size`.

That cross-thread read is a scheduling race. Under CPU contention the single prefetch worker can be scheduled only *after* the consumer has already drained the current chunk, so it observes a boundary value even though the pipeline behaved correctly (it simply blocked on the seam, which is the designed fallback and is logged as `prefetch_blocks`). Observed failure:

```
infer_starts = [0, 4, 7, 11, 15]
assert policy.infer_starts[1] < _CHUNK   # 4 < 4 -> AssertionError
```

The test passes in isolation and only flakes when the machine is loaded (e.g. running the full suite), which makes it an intermittent CI failure rather than a real defect signal.

## Change

Replace the wall-clock / scheduling-dependent `send_count` read with a **rendezvous**: the consumer blocks the *final* action of the first chunk until the prefetch worker has entered `get_actions`. The step index captured at inference start is then guaranteed to be observed strictly before the chunk drains — deterministically, regardless of thread-scheduling latency.

This preserves the test's original intent (prove genuine concurrent overlap, not just that the prefetch was *submitted* mid-chunk) and additionally pins the mid-chunk trigger itself: were the prefetch submitted only at the chunk boundary (no overlap), the worker would never start before the blocked send and the `wait(timeout=...)` would fire.

The complementary deterministic contract — that prefetched chunks carry the exact `len(chunk) - prefetch_trigger` observed-delay — remains covered by `test_async_rtc_supplies_deterministic_observed_delay`, and wall-time masking by `test_async_rtc_masks_inference_latency`. This change is test-only; no production behavior changes.

## Verification

- Passes in isolation (5/5) and under a 12-process CPU-burn load (6/6) where the previous version flaked.
- Full file green: `18 passed`.
- **Regression guard proven**: temporarily forcing `prefetch_trigger = len(cur_chunk)` (boundary-only, no overlap) makes the rendezvous time out and the test fail deterministically (`assert 'error' == 'success'`); reverting restores green.
- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` clean for the changed file.

Run locally with `MUJOCO_GL=egl python -m pytest tests/simulation/test_policy_runner_async_rtc.py -v`.