### PR TITLE
test(training): pin expert_only build_config wiring (policy.train_expert_only)

### DIFF
--- a/tests/training/test_lerobot.py
+++ b/tests/training/test_lerobot.py
@@ -765,6 +765,47 @@ class TestRelativeActions:
             assert LerobotTrainer().validate(spec) == []
 
 
+class TestExpertOnlyMethod:
+    """expert_only training method -> policy.train_expert_only on the built config.
+
+    ``method="expert_only"`` trains only the action expert of a VLA while the
+    (V)LM backbone stays frozen - the standard cheap-finetune recipe for the pi0
+    family. build_command emits ``--policy.train_expert_only=true`` for the CLI
+    launch path, but an in-process run consumes the ``build_config`` object
+    directly, so the flag must also be applied to the policy config there.
+    Before this was pinned only the CLI path was exercised; a build_config
+    regression that dropped the flag would silently full-finetune the backbone
+    (a far more expensive, different run) while reporting success.
+    """
+
+    def _expert_spec(self, dataset_root, tmp_path, ptype="pi0"):
+        return TrainSpec(
+            dataset_root=dataset_root,
+            base_model="",
+            output_dir=str(tmp_path / "out"),
+            steps=200,
+            method="expert_only",
+            extra={"policy_type": ptype},
+        )
+
+    def test_build_config_sets_train_expert_only(self, dataset_root, tmp_path):
+        cfg = LerobotTrainer(device="cpu").build_config(self._expert_spec(dataset_root, tmp_path))
+        assert cfg.policy.train_expert_only is True
+
+    def test_default_method_leaves_train_expert_only_at_preset(self, dataset_root, tmp_path):
+        spec = TrainSpec(
+            dataset_root=dataset_root,
+            base_model="",
+            output_dir=str(tmp_path / "out"),
+            steps=200,
+            extra={"policy_type": "pi0"},
+        )
+        assert spec.method == "full"
+        cfg = LerobotTrainer(device="cpu").build_config(spec)
+        # A plain (non-expert_only) run must not silently flip the flag on.
+        assert cfg.policy.train_expert_only is False
+
+
 class TestSampleWeightingRABC:
     """RA-BC sample-weighting wiring: extra['sample_weighting'] -> nested SampleWeightingConfig.
 


### PR DESCRIPTION
## Problem

The `expert_only` training method (freeze the VLM backbone, tune only the action expert - the standard cheap-finetune recipe for the pi0 family) had asymmetric test coverage in `LerobotTrainer`:

- `build_command` was exercised for `expert_only` (it emits `--policy.train_expert_only=true`).
- `build_config` was **not**. That is the path an in-process trainer consumes directly (it hands the `TrainPipelineConfig` to `lerobot_train`, no CLI). A regression in `build_config` that dropped the flag would silently full-finetune the backbone - a far more expensive, materially different run - while reporting success. This is exactly the "success contract, no effect" failure mode the project forbids.

`build_config`'s `policy.train_expert_only = True` assignment (`training/lerobot.py`) was uncovered.

## Change

Add a focused, offline `TestExpertOnlyMethod` (no GPU, no `lerobot_train` launch, mirroring the neighbouring `build_config` tests) pinning both sides of the branch:

- `method="expert_only"` sets `policy.train_expert_only is True` on the built config;
- a default (`full`) run leaves the flag at the policy preset (`False`), so a plain run is unaffected and the flag is never silently flipped on.

Test-only; no library behavior change.

## Verification

- Regression proof: no-op'ing the `build_config` assignment (simulating the pre-fix drop) makes `test_build_config_sets_train_expert_only` fail (`assert False is True`); restored code passes.
- Full gate green locally: `ruff check` + `ruff format --check` clean, `mypy strands_robots tests tests_integ` -> no issues, `MUJOCO_GL=egl pytest tests/` -> 9642 passed / 181 skipped.
- Coverage of the module's `build_config` expert_only line flips covered (repo total 94.44% -> 94.45%).