### PR TITLE
test(tools): pin use_lerobot missing-optional-dependency dispatch hint

### DIFF
--- a/tests/tools/test_use_lerobot.py
+++ b/tests/tools/test_use_lerobot.py
@@ -597,6 +597,57 @@ def test_dispatch_import_error_suggests_install(monkeypatch: pytest.MonkeyPatch)
     assert "pip install lerobot" in text
 
 
+def test_dispatch_missing_optional_dependency_suggests_extra(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A resolve that fails because a path exists but an optional dependency is
+    missing must return an actionable "install the extra" hint, not a dead-end.
+
+    ``_import_from_lerobot`` classifies this case by carrying the underlying
+    third-party ImportError on ``LeRobotResolveError.real_error``. The
+    dispatcher branches on that marker: when present it tells the agent which
+    ``lerobot[...]`` extra to install (distinct from the genuinely-missing-path
+    branch, which points at ``__discovery__``). This pins the exact user-facing
+    message so the two failure modes never collapse into one generic error.
+    """
+
+    def resolver(path: str) -> Any:
+        raise M.LeRobotResolveError(
+            "'datasets.lerobot_dataset' exists but failed to import: No module named 'datasets'",
+            real_error=ImportError("No module named 'datasets'"),
+        )
+
+    monkeypatch.setattr(M, "_import_from_lerobot", resolver)
+    result = _fn(module="datasets.lerobot_dataset", method="LeRobotDataset")
+    assert result["status"] == "error"
+    text = _texts(result)
+    _assert_ascii(text)
+    # Carries the real import failure and an actionable extra to install ...
+    assert "exists but failed to import" in text
+    assert "optional dependency is missing" in text
+    assert "lerobot[dataset]" in text
+    # ... and does NOT collapse into the genuinely-missing __discovery__ tip.
+    assert "__discovery__" not in text
+
+
+def test_dispatch_genuinely_missing_path_points_at_discovery(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A resolve that fails with no underlying dependency error (the path simply
+    does not exist) must point the agent at ``__discovery__`` -- and must NOT
+    emit the misleading "install an extra" hint reserved for the missing-dep
+    branch. This is the sibling contract to the missing-dependency case.
+    """
+
+    def resolver(path: str) -> Any:
+        raise M.LeRobotResolveError("Cannot resolve 'does.not.exist' in lerobot")
+
+    monkeypatch.setattr(M, "_import_from_lerobot", resolver)
+    result = _fn(module="does.not.exist", method="")
+    assert result["status"] == "error"
+    text = _texts(result)
+    _assert_ascii(text)
+    assert "Cannot resolve" in text
+    assert "__discovery__" in text
+    assert "optional dependency is missing" not in text
+
+
 # ----------------------------------------------------------------------------
 # security guards: the dispatcher must refuse dangerous calls
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`use_lerobot` is the universal dispatcher into the `lerobot` package (analogous to `use_aws` over boto3). To keep an agent from hitting dead-end errors, it classifies a failed path resolution into three distinct modes:

1. **genuinely missing** path -> point the caller at `module="__discovery__"`;
2. **exists but an optional dependency is missing** -> surface the real import failure plus an actionable `uv pip install 'lerobot[...]'` hint;
3. **attribute-not-found** on a resolved object -> list what is available.

The low-level classification in `_import_from_lerobot` (which tags the underlying third-party `ImportError` onto `LeRobotResolveError.real_error`) was already pinned. But the **dispatcher's user-facing rendering** of mode (2) — the branch keyed off `e.real_error is not None` that produces the install-the-extra hint — was never asserted. A regression there could silently collapse the missing-dependency case into the generic `__discovery__` tip, sending an agent chasing a nonexistent path instead of installing the extra it actually needs.

## Change

Test-only. Adds two focused dispatch-level regression tests to `tests/tools/test_use_lerobot.py`, both hardware- and extra-free via a `_import_from_lerobot` resolver stub:

- `test_dispatch_missing_optional_dependency_suggests_extra` — a resolve failing with `real_error` set returns `status=error`, surfaces `exists but failed to import`, states an `optional dependency is missing`, names a concrete extra (`lerobot[dataset]`), and does **not** mention `__discovery__`.
- `test_dispatch_genuinely_missing_path_points_at_discovery` — the sibling contract: a resolve with no underlying dependency error points at `__discovery__` and does **not** claim a missing optional dependency.

Together they lock the two `LeRobotResolveError` dispatch branches so the failure modes can never merge.

## Verification

- Fails pre-fix: mutating the source branch to `if False:` (dropping the `real_error` path) makes `test_dispatch_missing_optional_dependency_suggests_extra` fail (it collapses into the `__discovery__` tip); the sibling test correctly still passes.
- `strands_robots/tools/use_lerobot.py` coverage 98% -> 99% (the missing-dependency dispatch branch is now exercised).
- `MUJOCO_GL=egl pytest tests/tools/test_use_lerobot.py`: 65 passed, 1 skipped.
- `ruff check` / `ruff format --check` clean; ASCII-only output asserted per the repo no-emoji rule.