### PR TITLE
fix(training): build_command emits --peft.lora_alpha for LoRA parity with build_config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -768,6 +768,21 @@ git-from-source). The guidance now matches the declared extras; a regression
 test pins the docs to the pyproject requirements so the stale lore cannot
 return.
 
+### Fixed: `build_command` dropped `--peft.lora_alpha`, diverging from the LoRA config it trains
+
+`LerobotTrainer.build_command` is the argv-parity helper that documents the
+draccus CLI equivalent to the typed `TrainPipelineConfig` that `train(cfg)`
+consumes in-process, and it powers the native-parity drift check. Its LoRA
+branch emitted `--peft.method_type`, `--peft.r`, and `--peft.target_modules`
+but omitted `--peft.lora_alpha`, even though `build_config` wires
+`spec.lora_alpha` into `PeftConfig.lora_alpha`. `lora_alpha` sets the LoRA
+scaling numerator (scaling = `lora_alpha / r`), so the documented "equivalent
+command" for a LoRA fine-tune silently trained with lerobot's default alpha
+rather than the requested one -- a real behavioral divergence between the CLI
+description and the in-process run, and a hole in the parity guard. It is now
+emitted (only when set, mirroring `--peft.r` / `--peft.target_modules`), and a
+regression test pins the emitted flag to `cfg.peft.lora_alpha`.
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -622,6 +622,8 @@ class LerobotTrainer(Trainer):
                 cmd.append("--peft.method_type=LORA")
                 if spec.lora_r is not None:
                     cmd.append(f"--peft.r={spec.lora_r}")
+                if spec.lora_alpha is not None:
+                    cmd.append(f"--peft.lora_alpha={spec.lora_alpha}")
                 if spec.lora_target_modules is not None:
                     cmd.append(f"--peft.target_modules={spec.lora_target_modules}")
             elif spec.method == "expert_only":

--- a/tests/training/test_lerobot.py
+++ b/tests/training/test_lerobot.py
@@ -96,11 +96,24 @@ class TestBuildCommand:
     def test_lora_flags(self, spec):
         spec.method = "lora"
         spec.lora_r = 16
+        spec.lora_alpha = 32
         spec.lora_target_modules = "q_proj,v_proj"
         cmd = LerobotTrainer(device="cpu").build_command(spec)
         assert "--peft.method_type=LORA" in cmd
         assert "--peft.r=16" in cmd
+        # lora_alpha (the LoRA scaling numerator; scaling = lora_alpha / r) is a
+        # real PeftConfig field that build_config wires; the argv-parity helper
+        # must emit it too or the documented "equivalent CLI" trains with a
+        # different LoRA scale than the in-process train(cfg).
+        assert "--peft.lora_alpha=32" in cmd
         assert "--peft.target_modules=q_proj,v_proj" in cmd
+
+    def test_lora_alpha_omitted_when_unset(self, spec):
+        # Only emitted when requested, mirroring --peft.r / --peft.target_modules.
+        spec.method = "lora"
+        spec.lora_r = 16
+        cmd = LerobotTrainer(device="cpu").build_command(spec)
+        assert not any(c.startswith("--peft.lora_alpha") for c in cmd)
 
     def test_expert_only_flag(self, spec):
         spec.method = "expert_only"
@@ -335,6 +348,26 @@ class TestBuildConfigAdditionalBranches:
         cfg = LerobotTrainer(device="cpu").build_config(spec)
         assert cfg.peft.r == 8
         assert cfg.peft.lora_alpha == 32
+
+    def test_lora_alpha_build_command_matches_build_config(self, spec):
+        """build_command's argv-parity for --peft.lora_alpha must agree with the
+        value build_config wires into cfg.peft.lora_alpha (drift guard, the
+        contract build_command exists to uphold)."""
+        pytest.importorskip("lerobot")
+        import dataclasses
+
+        from lerobot.configs.default import PeftConfig
+
+        if "lora_alpha" not in {f.name for f in dataclasses.fields(PeftConfig)}:
+            pytest.skip("installed lerobot PeftConfig has no lora_alpha field")
+        spec.method = "lora"
+        spec.lora_r = 8
+        spec.lora_alpha = 32
+        trainer = LerobotTrainer(device="cpu")
+        cmd = trainer.build_command(spec)
+        cfg = trainer.build_config(spec)
+        emitted = [c for c in cmd if c.startswith("--peft.lora_alpha=")]
+        assert emitted == [f"--peft.lora_alpha={cfg.peft.lora_alpha}"]
 
     def test_unsupported_lora_option_raises_actionable_error(self, spec, monkeypatch):
         """A LoRA option the installed PeftConfig rejects must raise a clear


### PR DESCRIPTION
## Problem

`LerobotTrainer.build_command` is the argv-parity helper: it documents the draccus `lerobot.scripts.lerobot_train` CLI that corresponds to the typed `TrainPipelineConfig` `train(cfg)` consumes in-process, and it powers the native-parity drift check.

Its LoRA branch emitted `--peft.method_type`, `--peft.r`, and `--peft.target_modules` but **dropped `--peft.lora_alpha`**, even though `build_config` wires `spec.lora_alpha` into `PeftConfig.lora_alpha`. `lora_alpha` is a real `PeftConfig` field and sets the LoRA scaling numerator (scaling = `lora_alpha / r`), so the documented "equivalent command" for a LoRA fine-tune silently trained with lerobot's default alpha rather than the requested value -- a genuine behavioral divergence between the CLI description and the in-process run, and a blind spot in the parity guard.

Reproduction (`method='lora', lora_r=8, lora_alpha=32, lora_target_modules='all-linear'`, `pi0`):

```
build_command --peft flags: ['--peft.method_type=LORA', '--peft.r=8', '--peft.target_modules=all-linear']
lora_alpha emitted by build_command? False
build_config peft.r=8 lora_alpha=32 target_modules=all-linear
```

## Fix

Emit `--peft.lora_alpha=<v>` in the LoRA branch when set, mirroring the existing `--peft.r` / `--peft.target_modules` conditionals and matching `build_config`'s field order. Only emitted when `spec.lora_alpha is not None`, so the default path is unchanged.

## Tests

- `test_lora_flags` now sets `lora_alpha` and asserts `--peft.lora_alpha=32` is emitted (previously it only exercised `r` + `target_modules`, so the drop was uncaught).
- `test_lora_alpha_omitted_when_unset` guards that it is not emitted by default.
- `test_lora_alpha_build_command_matches_build_config` pins the emitted flag to `cfg.peft.lora_alpha`, upholding the argv-parity contract and closing the drift-guard hole.

Both positive tests fail before the change and pass after; the full `tests/training/test_lerobot.py` suite (110 tests) passes, and ruff + mypy are clean.

Same parity-drift class as the recent Gr00t `build_command` augmentation fix.