### PR TITLE
test(use_lerobot): pin integer-frame clip semantics in _array_to_image_block

### DIFF
--- a/tests/tools/test_use_lerobot.py
+++ b/tests/tools/test_use_lerobot.py
@@ -466,6 +466,37 @@ def test_grayscale_frame_encodes() -> None:
     assert block["image"]["source"]["bytes"]
 
 
+def test_integer_frame_clipped_not_scaled_and_round_trips() -> None:
+    """Non-uint8 integer frames are clipped into [0, 255], not magnitude-scaled.
+
+    Float frames are rescaled by their magnitude (a [0, 1] image becomes
+    [0, 255]), but a plain integer buffer is assumed to already be in pixel
+    units, so out-of-range values must saturate rather than wrap or rescale.
+    The encoded block must round-trip back through cv2 to a valid uint8 image
+    of the same spatial shape.
+    """
+    cv2 = pytest.importorskip("cv2")
+    # int16 RGB frame with values deliberately outside [0, 255]. Per-pixel
+    # values are channel-symmetric so the RGB->BGR swap does not reorder them.
+    frame = np.full((8, 8, 3), 4095, dtype=np.int16)
+    frame[0, 0] = -50  # must saturate to 0, not wrap
+    frame[1, 1] = 200  # in range -> passes through unchanged
+    block = M._array_to_image_block(frame)
+    assert block is not None
+    assert block["image"]["format"] == "png"  # small frame -> lossless PNG
+    raw = block["image"]["source"]["bytes"]
+    assert raw
+    decoded = cv2.imdecode(np.frombuffer(raw, dtype=np.uint8), cv2.IMREAD_COLOR)
+    assert decoded is not None
+    assert decoded.dtype == np.uint8
+    assert decoded.shape == (8, 8, 3)
+    # Clip semantics (PNG is lossless): -50 saturates to 0, 4095 to 255, and the
+    # in-range 200 survives -- a magnitude rescale would have crushed 200 instead.
+    assert decoded.min() == 0
+    assert decoded.max() == 255
+    assert 200 in decoded
+
+
 def test_collect_images_finds_frames_in_list() -> None:
     """Images one level inside a list are collected; non-images are ignored."""
     pytest.importorskip("cv2")


### PR DESCRIPTION
## Problem

`_array_to_image_block` in `strands_robots/tools/use_lerobot.py` normalizes incoming frames to uint8 before encoding, with two distinct paths:

- **float** frames are magnitude-rescaled (a `[0, 1]` image becomes `[0, 255]`);
- **non-uint8 integer** frames are assumed to already be in pixel units and are *clipped* (saturated) into `[0, 255]`, not rescaled.

The existing image tests only exercised `uint8` and `float` inputs, so the integer clip branch was uncovered. That branch encodes a real, load-bearing contract: an `int16` buffer with out-of-range values must saturate rather than wrap or get crushed by a magnitude rescale.

## Change

Add one focused behavior test, `test_integer_frame_clipped_not_scaled_and_round_trips`:

- feeds an `int16` RGB frame with values deliberately outside `[0, 255]` (a negative pixel, an in-range `200`, and `4095`);
- asserts the block encodes as lossless PNG (small frame) and round-trips back through `cv2.imdecode` to a `uint8` image of the same spatial shape;
- pins the clip semantics: the negative pixel saturates to `0`, `4095` saturates to `255`, and the in-range `200` passes through unchanged (a magnitude rescale would have crushed it).

Per-pixel values are channel-symmetric so the RGB->BGR swap does not reorder them, keeping the assertions unambiguous.

## Tests

`MUJOCO_GL=egl python -m pytest tests/tools/test_use_lerobot.py` -> 66 passed, 1 skipped. The new test closes the previously-uncovered clip line in `_array_to_image_block` (the integer normalization path goes from uncovered to covered). Test-only change; ruff, ruff-format, and mypy are clean on the touched file.