### PR TITLE
fix(lerobot): correct stale from-source install hints for the >=0.6.0 PyPI floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -783,6 +783,22 @@ description and the in-process run, and a hole in the parity guard. It is now
 emitted (only when set, mirroring `--peft.r` / `--peft.target_modules`), and a
 regression test pins the emitted flag to `cfg.peft.lora_alpha`.
 
+### Fixed: lerobot "too old / absent" install hints recommended a from-source install after the `>=0.6.0` bump
+
+The user-facing error hints for a missing/too-old lerobot -- MolmoAct2's
+`_LEROBOT_VERSION_HINT` and the `lerobot.rewards` gates in `training.reward` /
+`LerobotTrainer.validate` -- still claimed lerobot was "not yet on PyPI (latest
+release 0.5.1)" and told the caller to install it from source
+(`lerobot @ git+https://github.com/huggingface/lerobot.git`). Since the core
+dependency is now pinned to `lerobot[feetech,dataset]>=0.6.0`, lerobot 0.6 --
+including `MolmoAct2Policy` (lerobot PR #3604) and the `lerobot.rewards`
+package -- ships straight from PyPI through the `strands-robots[lerobot]` /
+`[molmoact2]` extras, so a from-source `git+` install is both unnecessary and
+liable to conflict with the pinned floor. The hints now point at a plain PyPI
+(re)install of the extra and name the correct `>= 0.6.0` floor. This is the
+runtime-error counterpart of the docstring/docs guidance corrected in the
+post-0.6 dependency-guidance pass, which left these `.py` strings stale.
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/policies/lerobot_local/molmoact2.py
+++ b/strands_robots/policies/lerobot_local/molmoact2.py
@@ -58,17 +58,17 @@ MOLMOACT2_TYPE = "molmoact2"
 _MOLMOACT2_RUNTIME_DEPS = ("transformers", "peft", "scipy")
 
 #: Install hint for when lerobot itself is too old / absent. MolmoAct2Policy and
-#: the ``lerobot.configs`` feature symbols only exist in lerobot >= 0.5.2 (merged
-#: in lerobot PR #3604), which is not yet on PyPI -- so the fix is a from-source
-#: install. This is NOT the right advice when a *transitive* dependency is the
-#: thing missing (see ``_factory_import_error``).
+#: the ``lerobot.configs`` feature symbols ship in lerobot >= 0.6.0 (merged in
+#: lerobot PR #3604), which ``strands-robots[molmoact2]`` pulls straight from
+#: PyPI via the ``strands-robots[lerobot]`` (>=0.6.0) pin -- no from-source
+#: install is needed. This is NOT the right advice when a *transitive*
+#: dependency is the thing missing (see ``_factory_import_error``).
 _LEROBOT_VERSION_HINT = (
-    "MolmoAct2 requires lerobot >= 0.5.2 (PR #3604), which is not yet on "
-    "PyPI (latest release 0.5.1 lacks MolmoAct2Policy). Install the extra "
-    "plus lerobot from source:\n"
-    "  uv pip install 'strands-robots[molmoact2]' "
-    "'lerobot[feetech] @ git+https://github.com/huggingface/lerobot.git'\n"
-    "On Jetson/aarch64, add --no-build-isolation if pyav fails to build."
+    "MolmoAct2 requires lerobot >= 0.6.0 (which ships MolmoAct2Policy via "
+    "lerobot PR #3604). Install (or reinstall) the extra -- it pulls a "
+    "compatible lerobot from PyPI:\n"
+    "  uv pip install 'strands-robots[molmoact2]'\n"
+    "On Jetson/aarch64, add --no-build-isolation if a wheel fails to build."
 )
 
 
@@ -81,7 +81,8 @@ def _factory_import_error(exc: ImportError) -> ImportError:
 
     * lerobot itself is too old or absent -- the ``lerobot`` package is missing,
       or the MolmoAct2-era symbols it should expose are not there yet. The fix
-      is a lerobot >= 0.5.2 from-source install (:data:`_LEROBOT_VERSION_HINT`).
+      is to (re)install ``strands-robots[molmoact2]``, which pulls lerobot
+      >= 0.6.0 from PyPI (:data:`_LEROBOT_VERSION_HINT`).
     * a *transitive* dependency that the factory pulls in is missing -- here
       ``exc.name`` names a non-lerobot package. The fix is to install THAT
       package; telling the caller to reinstall lerobot is a dead end that sends

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -572,7 +572,7 @@ class LerobotTrainer(Trainer):
         if importlib.util.find_spec("lerobot.rewards") is None:
             problems.append(
                 "the installed lerobot has no reward-model support (no 'lerobot.rewards'); "
-                "requires lerobot >= 0.5.2 (install from source)"
+                "requires lerobot >= 0.6.0 -- reinstall 'strands-robots[lerobot]'"
             )
         return problems
 

--- a/strands_robots/training/reward.py
+++ b/strands_robots/training/reward.py
@@ -59,9 +59,10 @@ def _require_sarm_progress() -> Any:
         from lerobot.rewards.sarm.compute_rabc_weights import compute_sarm_progress
     except ImportError as e:
         raise ImportError(
-            "SARM RA-BC progress computation requires lerobot >= 0.5.2 (the "
-            "'lerobot.rewards.sarm' package). Install lerobot from source:\n"
-            "  uv pip install 'lerobot @ git+https://github.com/huggingface/lerobot.git'"
+            "SARM RA-BC progress computation requires lerobot >= 0.6.0 (the "
+            "'lerobot.rewards.sarm' package). Reinstall the extra -- it pulls "
+            "lerobot from PyPI:\n"
+            "  uv pip install 'strands-robots[lerobot]'"
         ) from e
     return compute_sarm_progress
 
@@ -177,8 +178,8 @@ def load_reward_model(
     """
     if importlib.util.find_spec("lerobot.rewards") is None:
         raise ImportError(
-            "reward-model inference requires lerobot >= 0.5.2 (the 'lerobot.rewards' "
-            "package). Install lerobot from source."
+            "reward-model inference requires lerobot >= 0.6.0 (the 'lerobot.rewards' "
+            "package). Reinstall 'strands-robots[lerobot]'."
         )
     from lerobot.rewards import make_reward_model, make_reward_model_config
 

--- a/tests/test_lerobot_install_hints_pypi.py
+++ b/tests/test_lerobot_install_hints_pypi.py
@@ -1,0 +1,98 @@
+"""Currency contract for the lerobot "too old / absent" install hints.
+
+Since ``strands-robots`` pins ``lerobot[feetech,dataset]>=0.6.0`` (pyproject),
+lerobot 0.6 -- including ``MolmoAct2Policy`` (lerobot PR #3604) and the
+``lerobot.rewards`` package -- ships straight from PyPI through the
+``strands-robots[lerobot]`` / ``[molmoact2]`` extras. The user-facing "your
+lerobot is too old / missing" error hints must therefore point the caller at a
+plain PyPI (re)install of the extra, NOT a from-source / ``git+`` install of an
+"unreleased" lerobot. These are the runtime-error siblings of the docs corrected
+in the >=0.6 dependency-guidance pass; this pins that they stay in sync so a
+broken-install user is never sent chasing a remedy that no longer applies (and
+would conflict with the pinned >=0.6.0 floor).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+_STALE = ("from source", "git+", "not yet on PyPI", "0.5.1", "0.5.2")
+
+
+def _assert_currency(text: str) -> None:
+    """A lerobot install hint must name the >=0.6 PyPI floor, not from-source."""
+    assert "lerobot >= 0.6" in text, f"hint should name the >=0.6 floor: {text!r}"
+    for token in _STALE:
+        assert token not in text, f"stale install advice ({token!r}) in hint: {text!r}"
+
+
+class TestMolmoAct2VersionHint:
+    def test_constant_names_pypi_extra_not_from_source(self) -> None:
+        from strands_robots.policies.lerobot_local import molmoact2
+
+        hint = molmoact2._LEROBOT_VERSION_HINT
+        _assert_currency(hint)
+        # The remedy is the PyPI extra, not a git+ lerobot install.
+        assert "strands-robots[molmoact2]" in hint
+
+    def test_factory_import_error_for_missing_lerobot_uses_currency_hint(self) -> None:
+        from strands_robots.policies.lerobot_local import molmoact2
+
+        # A missing/too-old lerobot reports name "lerobot" (or "lerobot.*"),
+        # which routes to the version hint (not the transitive-dep branch).
+        err = molmoact2._factory_import_error(ImportError("no lerobot", name="lerobot"))
+        _assert_currency(str(err))
+
+    def test_factory_import_error_transitive_dep_is_unaffected(self) -> None:
+        from strands_robots.policies.lerobot_local import molmoact2
+
+        # A missing transitive dep keeps its own targeted remedy (regression guard
+        # that the currency edit did not collapse the two distinct branches).
+        err = molmoact2._factory_import_error(ImportError("no einops", name="einops"))
+        msg = str(err)
+        # Remedy is to install the named transitive dep, not (re)install lerobot.
+        assert "pip install einops" in msg
+        assert "strands-robots" not in msg
+        assert "git+" not in msg
+
+
+class TestRewardModelHints:
+    def test_load_reward_model_missing_rewards_uses_currency_hint(self, monkeypatch) -> None:
+        from strands_robots.training import reward as reward_mod
+
+        real = importlib.util.find_spec
+        monkeypatch.setattr(
+            reward_mod.importlib.util,
+            "find_spec",
+            lambda name: None if name == "lerobot.rewards" else real(name),
+        )
+        with pytest.raises(ImportError) as excinfo:
+            reward_mod.load_reward_model("/ckpt/sarm", device="cpu")
+        _assert_currency(str(excinfo.value))
+
+    def test_trainer_validate_missing_rewards_uses_currency_hint(self, tmp_path, monkeypatch) -> None:
+        from strands_robots.training.base import TrainSpec
+        from strands_robots.training.lerobot import LerobotTrainer
+
+        real = importlib.util.find_spec
+        monkeypatch.setattr(
+            importlib.util,
+            "find_spec",
+            lambda name: None if name == "lerobot.rewards" else real(name),
+        )
+        spec = TrainSpec(
+            dataset_root=str(tmp_path),
+            base_model="",
+            output_dir=str(tmp_path / "out"),
+            steps=100,
+            extra={"reward_model": {"type": "sarm", "annotation_mode": "single_stage"}},
+        )
+        problems = LerobotTrainer().validate(spec)
+        reward_problems = [p for p in problems if "lerobot.rewards" in p]
+        assert reward_problems, f"expected a reward-support problem, got: {problems}"
+        for p in reward_problems:
+            assert "lerobot >= 0.6" in p
+            assert "from source" not in p
+            assert "0.5.2" not in p

--- a/tests/training/test_reward.py
+++ b/tests/training/test_reward.py
@@ -126,11 +126,17 @@ class TestRequireSarmProgress:
             reward_mod._require_sarm_progress()
 
     def test_old_lerobot_raises_clear_error(self, monkeypatch):
-        # matplotlib present, but the SARM module is absent (pre-0.5.2 lerobot).
+        # matplotlib present, but the SARM module is absent (too-old lerobot).
         monkeypatch.setattr(reward_mod, "require_optional", lambda *a, **k: None)
         monkeypatch.setitem(sys.modules, _SARM_MOD, None)
-        with pytest.raises(ImportError, match="lerobot >= 0.5.2"):
+        with pytest.raises(ImportError, match=r"lerobot >= 0\.6") as excinfo:
             reward_mod._require_sarm_progress()
+        # lerobot 0.6 (incl. the rewards package) ships from PyPI, so the hint
+        # must NOT send the caller chasing a from-source / git+ install.
+        msg = str(excinfo.value)
+        assert "from source" not in msg
+        assert "git+" not in msg
+        assert "0.5.2" not in msg
 
 
 class TestRewardProgress:
@@ -201,5 +207,9 @@ class TestLoadRewardModel:
 
     def test_old_lerobot_raises_clear_error(self, monkeypatch):
         monkeypatch.setattr(reward_mod.importlib.util, "find_spec", lambda name: None)
-        with pytest.raises(ImportError, match="lerobot >= 0.5.2"):
+        with pytest.raises(ImportError, match=r"lerobot >= 0\.6") as excinfo:
             load_reward_model("/ckpt/sarm", device="cpu")
+        msg = str(excinfo.value)
+        assert "from source" not in msg
+        assert "git+" not in msg
+        assert "0.5.2" not in msg


### PR DESCRIPTION
## Problem

The `lerobot>=0.6.0` dependency bump obsoleted the "install lerobot from source" remediation advice, but that advice still lives in four **user-facing runtime error strings** (only the docstrings/docs were corrected in the post-0.6 dependency-guidance pass; these `.py` strings were missed):

- `policies/lerobot_local/molmoact2.py` `_LEROBOT_VERSION_HINT` (+ its comment and the `_factory_import_error` docstring): claimed MolmoAct2 is "not yet on PyPI (latest release 0.5.1 lacks MolmoAct2Policy)" and told the caller to `uv pip install '...' 'lerobot[feetech] @ git+https://github.com/huggingface/lerobot.git'`.
- `training/lerobot.py` `LerobotTrainer.validate` reward-model branch: "requires lerobot >= 0.5.2 (install from source)".
- `training/reward.py` `_require_sarm_progress` + `load_reward_model`: "requires lerobot >= 0.5.2 ... Install lerobot from source" (one with a `git+` recipe).

All of these are now factually wrong. The core dependency is pinned to `lerobot[feetech,dataset]>=0.6.0`, and lerobot 0.6.1 (the current PyPI release) ships **both** `MolmoAct2Policy` (via lerobot PR #3604) and the `lerobot.rewards` package. Verified locally: latest PyPI lerobot is `0.6.1`, `from lerobot.policies.molmoact2.modeling_molmoact2 import MolmoAct2Policy` imports cleanly, and `import lerobot.rewards` resolves. So a broken/partial-install user who hits these errors is sent chasing a from-source `git+` install that is unnecessary and would conflict with the pinned `>=0.6.0` floor.

## Change

All four hints now point at a plain PyPI (re)install of the relevant extra (`strands-robots[molmoact2]` / `strands-robots[lerobot]`) and name the correct `>= 0.6.0` floor. The distinct transitive-dependency branch of `_factory_import_error` (which correctly tells the caller to install the named missing package, not lerobot) is untouched.

Out of scope by design: the RA-BC `sample_weighting` version-gate messages (`requires lerobot >= 0.5.2, or drop extra['sample_weighting']`) are pure lower-bound statements with an actionable alternative and do **not** recommend a from-source install, so they are left as-is.

## Tests

- New `tests/test_lerobot_install_hints_pypi.py` pins the currency contract behaviorally across all four sites: the MolmoAct2 constant, `_factory_import_error` for a missing lerobot (and a regression guard that the transitive-dep branch is unaffected), `load_reward_model`, and the trainer-validate reward-model branch. Each asserts the hint names `lerobot >= 0.6` and no longer contains `from source` / `git+` / `not yet on PyPI` / `0.5.1` / `0.5.2`.
- The two existing `test_reward.py` too-old-lerobot tests (which pinned the stale `lerobot >= 0.5.2` text) are updated to the corrected contract.
- **Fails before / passes after**: with the source reverted, the currency assertions fail against the old strings (7 failures); after the fix all pass. Full `tests/training/test_lerobot.py` + `tests/policies/lerobot_local/` + the new module: 629 passed. `ruff check`/`format` clean; `mypy` clean on the changed files.