### PR TITLE
test(lerobot_local): pin VLA tokenizer resolution order and preload guard

### DIFF
--- a/tests/policies/lerobot_local/test_policy.py
+++ b/tests/policies/lerobot_local/test_policy.py
@@ -289,6 +289,54 @@ class TestResolveTokenizer:
         result = policy._resolve_tokenizer()
         assert result is None
 
+    def test_returns_none_before_model_loaded(self):
+        """Preload guard: probing the tokenizer before load() returns None.
+
+        Language-token capability can be queried before a model is loaded (e.g.
+        during policy setup); the resolver must return None rather than
+        dereference the unset policy handle.
+        """
+        policy = _make_policy()  # _load_model patched out -> _loaded stays False
+        assert policy._loaded is False
+        assert policy._resolve_tokenizer() is None
+
+    def test_tokenizer_name_resolves_via_autotokenizer_and_short_circuits(self):
+        """Strategy 1 wins: a resolvable ``tokenizer_name`` is loaded through
+        ``AutoTokenizer`` and the built-in processor (Strategy 3) is never
+        consulted.
+
+        The resolved tokenizer is cached, stamped with the config's padding
+        side, and the config's ``tokenizer_max_length`` override is captured. A
+        stand-in ``transformers`` module makes the success path deterministic
+        whether or not transformers is installed.
+        """
+        policy = _make_loaded_policy()
+        policy._policy.config = MagicMock(
+            tokenizer_name="some-org/some-tokenizer",
+            vlm_model_name="should-not-be-used",
+            tokenizer_max_length=77,
+            tokenizer_padding_side="left",
+        )
+        # Strategy 3 target: must NOT be returned when Strategy 1 succeeds.
+        sentinel_processor_tok = MagicMock(name="processor_tokenizer")
+        policy._policy.processor = MagicMock()
+        policy._policy.processor.tokenizer = sentinel_processor_tok
+
+        resolved_tok = MagicMock(name="autotokenizer")
+        fake_transformers = types.ModuleType("transformers")
+        fake_transformers.AutoTokenizer = MagicMock()
+        fake_transformers.AutoTokenizer.from_pretrained.return_value = resolved_tok
+
+        with patch.dict("sys.modules", {"transformers": fake_transformers}):
+            result = policy._resolve_tokenizer()
+
+        assert result is resolved_tok
+        assert policy._tokenizer is resolved_tok  # cached for reuse
+        assert result is not sentinel_processor_tok  # Strategy 3 skipped
+        fake_transformers.AutoTokenizer.from_pretrained.assert_called_once_with("some-org/some-tokenizer")
+        assert resolved_tok.padding_side == "left"  # stamped from config
+        assert policy._tokenizer_max_length == 77  # config override captured
+
 
 class TestTokenizeInstruction:
     def test_returns_none_without_tokenizer(self):


### PR DESCRIPTION
## Problem

`LerobotLocalPolicy._resolve_tokenizer` documents a 3-strategy resolution order for the VLA language-token tokenizer (explicit `tokenizer_name` -> `vlm_model_name` -> the policy's built-in `processor.tokenizer`), but two paths were untested:

- The **preload guard** (`not self._loaded or not self._policy -> return None`) had no coverage, so a regression could turn a pre-load capability probe into an `AttributeError` on the unset policy handle.
- The **Strategy 1 success path** (a resolvable `tokenizer_name` loaded through `AutoTokenizer`) was never exercised: the existing test only drove the fall-through case (transformers absent) and the processor fallback. The lines that load, cache, and stamp the tokenizer, and the short-circuit that skips the processor fallback, were unpinned.

## Change

Two focused tests added to `TestResolveTokenizer` in `tests/policies/lerobot_local/test_policy.py`:

- `test_returns_none_before_model_loaded` - a tokenizer probe before `load()` returns `None` rather than dereferencing the unset policy.
- `test_tokenizer_name_resolves_via_autotokenizer_and_short_circuits` - a resolvable `tokenizer_name` is loaded via `AutoTokenizer`, cached, stamped with the config's padding side, and the `tokenizer_max_length` override is captured; the built-in processor (Strategy 3) is **not** consulted once Strategy 1 resolves.

The success path patches a stand-in `transformers` module into `sys.modules`, so it runs deterministically whether or not `transformers` is installed (the suite is designed to run without the heavy inference deps).

No production code changes - this pins existing, documented behavior on previously-uncovered lines (`policy.py` 580, 601-604).

## Tests

`ruff check` / `ruff format --check` clean; `mypy strands_robots tests tests_integ` -> no issues in 688 source files. `pytest tests/policies/lerobot_local/test_policy.py` -> 153 passed (2 new).