### PR TITLE
fix(sim): surface base state for a mobile base whose free joint is unnamed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -799,6 +799,23 @@ liable to conflict with the pinned floor. The hints now point at a plain PyPI
 runtime-error counterpart of the docstring/docs guidance corrected in the
 post-0.6 dependency-guidance pass, which left these `.py` strings stale.
 
+### Fixed: mobile-base observation dropped all base state when the floating base is an unnamed free joint
+
+`get_observation` surfaces floating-base IMU-style signals (`base_quat`,
+`base_ang_vel`) only when the free joint was found while iterating
+`robot.joint_names`. That holds for a humanoid whose base joint is named (e.g.
+the Unitree G1's `floating_base_joint`), but a mobile manipulator such as
+LeKiwi carries its base on an **unnamed** `<freejoint/>` that is not in
+`joint_names` (those are the actuated wheel/arm joints). Such a robot was
+silently observed as a fixed-base arm -- its observation carried no base
+orientation or angular velocity -- so a locomotion/navigation controller (or a
+recorder configured to log base state) could not sense the base heading or turn
+rate. The base free joint is now recovered from the kinematic tree (walk
+up from an actuated joint to its ancestor base body), so any floating base
+surfaces base state regardless of whether its free joint is named. A sibling
+free-jointed task object (a cube) is never mistaken for the base, and a
+fixed-base arm still surfaces no base state.
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -248,6 +248,34 @@ class RenderingMixin:
             return None
         return state.get("viz_option")
 
+    def _robot_base_free_joint(self, model: Any, robot: Any, pfx: str) -> int:
+        """Return the id of the robot's floating-base free joint, or ``-1``.
+
+        Fallback for a floating base that is NOT a named entry in
+        ``robot.joint_names`` (e.g. a mobile base whose ``<freejoint>`` is
+        unnamed). Resolves the robot's first actuated joint, then walks up the
+        body tree and returns the free joint attached to an ancestor body. This
+        matches only the robot's OWN base: a sibling task object (a free-jointed
+        cube) is never on the ancestor chain of an actuated joint, and a
+        fixed-base arm has no ancestor free joint (returns ``-1``).
+        """
+        mj = _ensure_mujoco()
+        for jnt_name in robot.joint_names:
+            lookup = pfx + jnt_name if pfx else jnt_name
+            jnt_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, lookup)
+            if jnt_id < 0 and pfx:
+                jnt_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, jnt_name)
+            if jnt_id < 0:
+                continue
+            body = int(model.jnt_bodyid[jnt_id])
+            while body > 0:
+                for j in range(model.njnt):
+                    if int(model.jnt_bodyid[j]) == body and model.jnt_type[j] == mj.mjtJoint.mjJNT_FREE:
+                        return j
+                body = int(model.body_parentid[body])
+            break
+        return -1
+
     def _get_sim_observation(self, robot_name: str, *, skip_images: bool = False) -> dict[str, Any]:
         """Get observation from sim: joint state + cameras (unless skipped).
 
@@ -289,9 +317,18 @@ class RenderingMixin:
                 # velocity-feedback controllers (WBC) read it to close the loop.
                 obs[f"{jnt_name}.vel"] = float(data.qvel[model.jnt_dofadr[jnt_id]])
 
+        # A floating base that is NOT a named entry in ``robot.joint_names``
+        # (e.g. a mobile base whose ``<freejoint>`` is unnamed, like LeKiwi) is
+        # missed by the loop above. Recover it from the kinematic tree so a
+        # mobile manipulator surfaces base state instead of being silently
+        # treated as a fixed-base arm.
+        if free_jnt_id < 0:
+            free_jnt_id = self._robot_base_free_joint(model, robot, pfx)
+
         # Floating-base IMU-style signals from the free joint, when present.
         # WBC and other locomotion controllers consume ``base_quat`` (the base
-        # orientation, w,x,y,z) and ``base_ang_vel`` (rad/s). Both are additive
+        # orientation, w,x,y,z) and ``base_ang_vel`` (rad/s); a mobile
+        # manipulator uses them as its base heading/turn-rate. Both are additive
         # and absent for fixed-base robots (arms), so non-locomotion callers
         # never see them.
         if free_jnt_id >= 0:

--- a/tests/simulation/mujoco/test_mobile_base_observation.py
+++ b/tests/simulation/mujoco/test_mobile_base_observation.py
@@ -1,0 +1,146 @@
+"""Regression tests for mobile-base (unnamed-freejoint) observation state.
+
+A mobile manipulator (e.g. LeKiwi) carries its floating base on an UNNAMED
+``<freejoint/>`` that is not enumerated in ``robot.joint_names`` (those are the
+actuated wheel/arm joints). The floating-base IMU-style signals
+(``base_quat`` + ``base_ang_vel``) must still be surfaced from that base free
+joint, otherwise the mobile base is silently observed as a fixed-base arm and a
+recorded dataset loses all base orientation/velocity state.
+
+The base free joint is recovered from the kinematic tree (walk up from an
+actuated joint to the ancestor base body), so a sibling free-jointed task
+object (a cube) is never mistaken for the base.
+"""
+
+import os
+import tempfile
+
+import pytest
+
+from strands_robots.simulation.mujoco.simulation import Simulation
+
+# Mobile base: an UNNAMED free joint on ``base_plate`` (identity orientation),
+# an actuated hinge ``shoulder`` on a child arm body, and a SIBLING free-jointed
+# ``task_cube`` at a distinct 90-deg-about-z orientation. Mirrors LeKiwi, whose
+# base freejoint is unnamed and whose scene carries free-jointed task cubes.
+MOBILE_BASE_XML = """
+<mujoco model="test_mobile">
+  <compiler angle="radian" autolimits="true"/>
+  <option timestep="0.002"/>
+  <worldbody>
+    <light name="main" pos="0 0 3" dir="0 0 -1"/>
+    <geom name="ground" type="plane" size="5 5 0.01" rgba="0.9 0.9 0.9 1"/>
+    <body name="base_plate" pos="0 0 0.1" quat="1 0 0 0">
+      <freejoint/>
+      <geom type="box" size="0.15 0.15 0.03" rgba="0.3 0.3 0.8 1"/>
+      <body name="arm" pos="0 0 0.05">
+        <geom type="capsule" size="0.02" fromto="0 0 0 0 0 0.2" rgba="0.8 0.3 0.3 1"/>
+        <joint name="shoulder" type="hinge" axis="0 1 0" range="-1.57 1.57"/>
+      </body>
+    </body>
+    <body name="task_cube" pos="1 0 0.05" quat="0.707 0 0 0.707">
+      <freejoint/>
+      <geom type="box" size="0.05 0.05 0.05" rgba="0.2 0.8 0.2 1"/>
+    </body>
+  </worldbody>
+  <actuator>
+    <motor name="shoulder_act" joint="shoulder"/>
+  </actuator>
+</mujoco>
+"""
+
+# Fixed-base arm: a single hinge, NO free joint anywhere. Must never surface
+# base state (guards against a false-positive base pick).
+FIXED_ARM_XML = """
+<mujoco model="test_fixed">
+  <compiler angle="radian" autolimits="true"/>
+  <worldbody>
+    <light name="main" pos="0 0 3" dir="0 0 -1"/>
+    <body name="link" pos="0 0 0.1">
+      <geom type="capsule" size="0.02" fromto="0 0 0 0 0 0.2"/>
+      <joint name="j0" type="hinge" axis="0 0 1"/>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="j0_act" joint="j0" kp="10"/>
+  </actuator>
+</mujoco>
+"""
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="test_mobile_base", mesh=False)
+    s.create_world(ground_plane=False)
+    yield s
+    s.cleanup()
+
+
+def _write(xml: str) -> str:
+    tmpdir = tempfile.mkdtemp()
+    path = os.path.join(tmpdir, "model.xml")
+    with open(path, "w") as f:
+        f.write(xml)
+    return path
+
+
+def test_unnamed_base_freejoint_surfaces_base_state(sim):
+    """A mobile base whose floating base is an unnamed free joint (not in
+    ``robot.joint_names``) still surfaces ``base_quat`` + ``base_ang_vel``, and
+    the base is resolved from the kinematic tree - never the sibling free-jointed
+    task cube."""
+    sim.add_robot("mob", urdf_path=_write(MOBILE_BASE_XML))
+
+    # The unnamed base freejoint is not a named joint.
+    assert sim._world.robots["mob"].joint_names == ["shoulder"]
+
+    obs = sim.get_observation(robot_name="mob", skip_images=True)
+
+    assert "base_quat" in obs, "mobile base must surface base_quat"
+    assert len(obs["base_quat"]) == 4
+    assert all(isinstance(x, float) for x in obs["base_quat"])
+    assert "base_ang_vel" in obs, "mobile base must surface base_ang_vel"
+    assert len(obs["base_ang_vel"]) == 3
+
+    # base_quat is the base_plate (identity), NOT the task_cube (90 deg about z,
+    # ~[0.707, 0, 0, 0.707]). If the sibling cube's free joint were picked, w
+    # would be ~0.707 instead of ~1.0.
+    assert obs["base_quat"][0] == pytest.approx(1.0, abs=1e-3)
+    assert obs["base_quat"][3] == pytest.approx(0.0, abs=1e-3)
+
+    # The actuated hinge still gets a scalar .vel; the free joint does not.
+    assert "shoulder.vel" in obs and isinstance(obs["shoulder.vel"], float)
+
+
+def test_base_quat_is_live_read_of_the_base_free_joint(sim):
+    """``base_quat`` reflects the base free joint's CURRENT orientation (a live
+    read), so a driven/rotated base is observed - it is not a static or
+    wrong-joint value."""
+    import mujoco
+
+    sim.add_robot("mob", urdf_path=_write(MOBILE_BASE_XML))
+    model, data = sim._world._model, sim._world._data
+
+    # Locate the base_plate free joint and rotate it 90 deg about z.
+    bid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, "mob/base_plate")
+    jadr = None
+    for j in range(model.njnt):
+        if model.jnt_bodyid[j] == bid and model.jnt_type[j] == mujoco.mjtJoint.mjJNT_FREE:
+            jadr = int(model.jnt_qposadr[j])
+    assert jadr is not None
+    data.qpos[jadr + 3 : jadr + 7] = [0.70710678, 0.0, 0.0, 0.70710678]
+    mujoco.mj_forward(model, data)
+
+    obs = sim.get_observation(robot_name="mob", skip_images=True)
+    assert obs["base_quat"][0] == pytest.approx(0.7071, abs=1e-3)
+    assert obs["base_quat"][3] == pytest.approx(0.7071, abs=1e-3)
+
+
+def test_fixed_base_arm_has_no_base_state(sim):
+    """A fixed-base arm (no free joint) never surfaces base state - the mobile
+    detection must not false-positive on a robot that has no floating base."""
+    sim.add_robot("arm", urdf_path=_write(FIXED_ARM_XML))
+    obs = sim.get_observation(robot_name="arm", skip_images=True)
+    assert "base_quat" not in obs
+    assert "base_ang_vel" not in obs
+    assert "j0" in obs and "j0.vel" in obs


### PR DESCRIPTION
## Problem

`get_observation` surfaces the floating-base IMU-style signals `base_quat` (orientation, w,x,y,z) and `base_ang_vel` (rad/s) **only when the free joint is found while iterating `robot.joint_names`**. That holds for a humanoid whose base joint is named (e.g. the Unitree G1's `floating_base_joint`, which is a named entry in `joint_names`), but a mobile manipulator such as **LeKiwi** carries its base on an *unnamed* `<freejoint/>`. Its `joint_names` are the actuated wheel/arm joints only, so the base free joint is never encountered and `free_jnt_id` stays `-1`.

The result: a mobile base is silently observed as a **fixed-base arm** — its observation carries no base orientation or angular velocity — so a locomotion/navigation controller (or a recorder configured to log base state) cannot sense the base heading or turn rate.

Reproduction on the two floating-base robots in the registry:

| robot | base free joint | `base_quat` in `get_observation`? |
|-------|-----------------|-----------------------------------|
| `unitree_g1` | named `floating_base_joint` (in `joint_names`) | ✅ present |
| `lekiwi` | unnamed `<freejoint/>` on `base_plate_layer_1_link` | ❌ **missing** (before this PR) |

## Fix

When the named-joint scan finds no free joint, recover the robot's base free joint from the kinematic tree: resolve the robot's first actuated joint, then walk up the body tree and return the free joint attached to an ancestor body. This matches only the robot's **own** base — a sibling free-jointed task object (e.g. a free-jointed cube in the scene) is never on the ancestor chain of an actuated joint, and a fixed-base arm has no ancestor free joint (so it correctly keeps surfacing no base state). Robots whose base joint is already named (G1) are unaffected — the fallback only runs when the named scan found nothing.

After the fix, `lekiwi.get_observation()` includes `base_quat` + `base_ang_vel`, and both track the base live — driving the base yaws the quaternion and raises `base_ang_vel`.

## Rollout (MuJoCo, headless)

LeKiwi driven forward (~14 cm) then spun in place (~-86° yaw). `base_ang_vel_z` tracks the transition from translating (~-0.23 rad/s residual) to spinning (~-1.22 rad/s), and `base_quat` yaw sweeps accordingly — none of which was observable before this fix.

![LeKiwi mobile base driving then spinning in sim](https://github.com/cagataycali/robots/releases/download/artifacts-mobile-base-obs/lekiwi_drive.gif)

## Tests

`tests/simulation/mujoco/test_mobile_base_observation.py` (GL-free, network-free — inline MJCF mirroring LeKiwi: unnamed base free joint + actuated hinge + a sibling free-jointed cube at a distinct orientation):

- `test_unnamed_base_freejoint_surfaces_base_state` — base state present; `base_quat` is the base (identity), **not** the sibling cube (90° about z). **Fails before** this fix (`KeyError`/missing `base_quat`).
- `test_base_quat_is_live_read_of_the_base_free_joint` — rotating the base free joint is reflected in `base_quat`. **Fails before**.
- `test_fixed_base_arm_has_no_base_state` — a fixed-base arm still surfaces no base state (guard against a false-positive base pick). Passes before and after.

Green locally: `ruff` + `mypy` clean; `tests/simulation/mujoco/test_simulation.py` + the new test + `tests/policies/wbc/` (the main `base_quat`/`base_ang_vel` consumer) all pass (302), no regressions.