### PR TITLE
fix(sim): get_robot_state surfaces a floating base as a structured `base` entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -816,6 +816,23 @@ surfaces base state regardless of whether its free joint is named. A sibling
 free-jointed task object (a cube) is never mistaken for the base, and a
 fixed-base arm still surfaces no base state.
 
+### Fixed: `get_robot_state` misreported a floating base's free joint as a scalar joint
+
+For a robot with a floating base (a 6-DoF free joint), `get_robot_state` read
+`qpos[jnt_qposadr]` as a scalar joint "position" and `qvel[jnt_dofadr]` as a
+"velocity". A free joint's qpos is `[xyz(3) + quat(4)]` and qvel is
+`[linvel(3) + angvel(3)]`, so this reported the base's x-coordinate as a joint
+angle and silently dropped the orientation and the rest of the twist -- while
+`get_observation` (its policy-facing counterpart) already surfaces the base
+correctly as `base_quat` / `base_ang_vel`. A humanoid's named
+`floating_base_joint` hit the wrong-scalar path; a mobile base's unnamed
+`<freejoint/>` (e.g. LeKiwi) was skipped entirely, so `get_robot_state` had no
+base information at all. The free joint is now surfaced under a structured
+`base` entry -- `position` (xyz), `quaternion` (w,x,y,z), `linear_velocity`,
+`angular_velocity` -- recovered from the kinematic tree when the free joint is
+unnamed, with the `quaternion` / `angular_velocity` matching `get_observation`.
+A fixed-base arm still reports only its scalar joints (no `base` entry).
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1500,9 +1500,22 @@ class MuJoCoSimEngine(
         return base
 
     def get_robot_state(self, robot_name: str | None = None) -> dict[str, Any]:
-        """canonical name parameter is ``robot_name``. The router
-        accepts ``name`` as an alias (bidirectional) so legacy LLM calls
-        keep working, but new tool specs should document only robot_name."""
+        """Return a robot's per-joint position/velocity, plus base pose for a floating base.
+
+        The canonical name parameter is ``robot_name``. The router accepts
+        ``name`` as an alias (bidirectional) so legacy LLM calls keep working,
+        but new tool specs should document only robot_name.
+
+        The ``json`` payload carries ``{"state": {joint: {"position", "velocity"}}}``
+        for the scalar (hinge/slide) joints. A robot with a floating base (a
+        6-DoF free joint - a humanoid's named ``floating_base_joint`` or a mobile
+        base's unnamed ``<freejoint/>`` like LeKiwi) additionally carries a
+        ``"base"`` entry with ``position`` (xyz), ``quaternion`` (w,x,y,z),
+        ``linear_velocity`` and ``angular_velocity``. The free joint is NOT
+        reported as a scalar joint (its qpos is [xyz+quat], not a single angle),
+        and the base ``quaternion``/``angular_velocity`` match get_observation's
+        ``base_quat``/``base_ang_vel`` for the same robot.
+        """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         try:
@@ -1519,26 +1532,68 @@ class MuJoCoSimEngine(
         # Namespace-aware joint lookup (see add_robot / _apply_sim_action).
         pfx = robot.namespace or ""
         state = {}
+        free_jnt_id = -1  # the robot's floating-base free joint, if any
         for jnt_name in robot.joint_names:
             jnt_id = -1
             if pfx:
                 jnt_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, pfx + jnt_name)
             if jnt_id < 0:
                 jnt_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, jnt_name)
-            if jnt_id >= 0:
-                state[jnt_name] = {
-                    "position": float(data.qpos[model.jnt_qposadr[jnt_id]]),
-                    "velocity": float(data.qvel[model.jnt_dofadr[jnt_id]]),
-                }
+            if jnt_id < 0:
+                continue
+            # A FREE joint (6-DoF floating base, e.g. a humanoid's named
+            # ``floating_base_joint``) has no scalar hinge/slide value: its qpos
+            # is [xyz(3) + quat(4)] and qvel is [linvel(3) + angvel(3)]. Reading
+            # qpos[jnt_qposadr] as a "position" reports the base x-coordinate as a
+            # joint angle and silently drops the orientation, so record it and
+            # surface a structured ``base`` entry below instead.
+            if model.jnt_type[jnt_id] == mj.mjtJoint.mjJNT_FREE:
+                free_jnt_id = jnt_id
+                continue
+            state[jnt_name] = {
+                "position": float(data.qpos[model.jnt_qposadr[jnt_id]]),
+                "velocity": float(data.qvel[model.jnt_dofadr[jnt_id]]),
+            }
 
-        # Additive sensor noise (set_obs_noise); no-op when unconfigured.
+        # Additive sensor noise (set_obs_noise); no-op when unconfigured. Runs
+        # over the scalar joints only; the floating-base pose/twist below is left
+        # un-noised, matching get_observation's base_quat / base_ang_vel contract.
         state = self._apply_state_noise(state)
+
+        # Floating base: surface the full 6-DoF pose + twist under a ``base`` key,
+        # consistent with get_observation's base_quat / base_ang_vel. Recovered
+        # from the kinematic tree when the free joint is unnamed and therefore
+        # absent from ``joint_names`` (e.g. a mobile base like LeKiwi).
+        if free_jnt_id < 0:
+            free_jnt_id = self._robot_base_free_joint(model, robot, pfx)
+        base: dict[str, list[float]] | None = None
+        if free_jnt_id >= 0:
+            qadr = int(model.jnt_qposadr[free_jnt_id])
+            vadr = int(model.jnt_dofadr[free_jnt_id])
+            base = {
+                "position": [float(v) for v in data.qpos[qadr : qadr + 3]],
+                "quaternion": [float(v) for v in data.qpos[qadr + 3 : qadr + 7]],
+                "linear_velocity": [float(v) for v in data.qvel[vadr : vadr + 3]],
+                "angular_velocity": [float(v) for v in data.qvel[vadr + 3 : vadr + 6]],
+            }
 
         text = f"'{robot_name}' state (t={self._world.sim_time:.3f}s):\n"
         for jnt, vals in state.items():
             text += f"{jnt}: pos={vals['position']:.4f}, vel={vals['velocity']:.4f}\n"
+        if base is not None:
+            p_, q_ = base["position"], base["quaternion"]
+            lv_, av_ = base["linear_velocity"], base["angular_velocity"]
+            text += (
+                f"base: pos=[{p_[0]:.4f}, {p_[1]:.4f}, {p_[2]:.4f}], "
+                f"quat=[{q_[0]:.4f}, {q_[1]:.4f}, {q_[2]:.4f}, {q_[3]:.4f}], "
+                f"lin_vel=[{lv_[0]:.4f}, {lv_[1]:.4f}, {lv_[2]:.4f}], "
+                f"ang_vel=[{av_[0]:.4f}, {av_[1]:.4f}, {av_[2]:.4f}]\n"
+            )
 
-        return {"status": "success", "content": [{"text": text}, {"json": {"state": state}}]}
+        json_payload: dict[str, Any] = {"state": state}
+        if base is not None:
+            json_payload["base"] = base
+        return {"status": "success", "content": [{"text": text}, {"json": json_payload}]}
 
     def list_bodies(self, robot_name: str | None = None) -> dict[str, Any]:
         """List MuJoCo body names available as camera/sensor mount points.

--- a/tests/simulation/mujoco/test_mobile_base_observation.py
+++ b/tests/simulation/mujoco/test_mobile_base_observation.py
@@ -144,3 +144,117 @@ def test_fixed_base_arm_has_no_base_state(sim):
     assert "base_quat" not in obs
     assert "base_ang_vel" not in obs
     assert "j0" in obs and "j0.vel" in obs
+
+
+# Floating base whose free joint IS named and therefore enumerated in
+# ``robot.joint_names`` (like a humanoid's ``floating_base_joint``). This is the
+# case where get_robot_state previously misread the 6-DoF free joint as a scalar
+# hinge - reporting the base x-coordinate as a joint "position".
+NAMED_BASE_XML = """
+<mujoco model="test_named_base">
+  <compiler angle="radian" autolimits="true"/>
+  <option timestep="0.002"/>
+  <worldbody>
+    <light name="main" pos="0 0 3" dir="0 0 -1"/>
+    <geom name="ground" type="plane" size="5 5 0.01" rgba="0.9 0.9 0.9 1"/>
+    <body name="pelvis" pos="0 0 0.8">
+      <freejoint name="floating_base_joint"/>
+      <geom type="box" size="0.1 0.1 0.1" rgba="0.3 0.3 0.8 1"/>
+      <body name="thigh" pos="0 0 -0.1">
+        <geom type="capsule" size="0.03" fromto="0 0 0 0 0 -0.3" rgba="0.8 0.3 0.3 1"/>
+        <joint name="hip" type="hinge" axis="0 1 0" range="-1.5 1.5"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <motor name="hip_act" joint="hip"/>
+  </actuator>
+</mujoco>
+"""
+
+
+def _set_free_joint(sim, robot, qpos7, qvel6):
+    """Set a robot's (only) free joint pose+twist and forward the model."""
+    import mujoco
+
+    model, data = sim._world._model, sim._world._data
+    jid = -1
+    for j in range(model.njnt):
+        if model.jnt_type[j] == mujoco.mjtJoint.mjJNT_FREE:
+            name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, j) or ""
+            if name.startswith(f"{robot}/") or name in ("floating_base_joint", f"{robot}/floating_base_joint"):
+                jid = j
+                break
+    assert jid >= 0, "expected a free joint on the robot"
+    qadr = int(model.jnt_qposadr[jid])
+    vadr = int(model.jnt_dofadr[jid])
+    data.qpos[qadr : qadr + 7] = qpos7
+    data.qvel[vadr : vadr + 6] = qvel6
+    mujoco.mj_forward(model, data)
+
+
+def test_get_robot_state_named_free_base_reports_base_pose_not_scalar(sim):
+    """A floating base's NAMED free joint (``floating_base_joint``, enumerated in
+    joint_names) must NOT be reported as a scalar joint. Its qpos is [xyz+quat],
+    so reading qpos[jnt_qposadr] as a joint "position" reports the base
+    x-coordinate and silently drops the orientation. get_robot_state must
+    instead surface a structured ``base`` entry with the full 6-DoF pose+twist."""
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    assert "floating_base_joint" in sim._world.robots["humanoid"].joint_names
+
+    # Distinctive base pose so a scalar misread (base-x as a joint angle) is
+    # unmistakable: x=0.3, y=0.4, z=0.9, 90-deg-about-z quat, and a full twist.
+    _set_free_joint(sim, "humanoid", [0.3, 0.4, 0.9, 0.70710678, 0.0, 0.0, 0.70710678], [1.1, 2.2, 3.3, 4.4, 5.5, 6.6])
+
+    result = sim.get_robot_state(robot_name="humanoid")
+    assert result["status"] == "success"
+    payload = result["content"][1]["json"]
+
+    # The free joint is NOT a scalar joint entry (no misread base-x as "position").
+    assert "floating_base_joint" not in payload["state"]
+    # The scalar hinge is still reported as usual.
+    assert "hip" in payload["state"] and isinstance(payload["state"]["hip"]["position"], float)
+
+    # A structured base entry carries the full 6-DoF pose + twist.
+    base = payload["base"]
+    assert base["position"] == pytest.approx([0.3, 0.4, 0.9], abs=1e-3)
+    assert base["quaternion"] == pytest.approx([0.7071, 0.0, 0.0, 0.7071], abs=1e-3)
+    assert base["linear_velocity"] == pytest.approx([1.1, 2.2, 3.3], abs=1e-3)
+    assert base["angular_velocity"] == pytest.approx([4.4, 5.5, 6.6], abs=1e-3)
+
+
+def test_get_robot_state_unnamed_free_base_reports_base(sim):
+    """A mobile base whose free joint is UNNAMED (not in joint_names, like
+    LeKiwi) still surfaces a ``base`` entry - recovered from the kinematic tree,
+    never the sibling free-jointed task cube."""
+    sim.add_robot("mob", urdf_path=_write(MOBILE_BASE_XML))
+    assert sim._world.robots["mob"].joint_names == ["shoulder"]
+
+    payload = sim.get_robot_state(robot_name="mob")["content"][1]["json"]
+    base = payload["base"]
+    # base is the base_plate (identity quat), NOT the task_cube (~[0.707,0,0,0.707]).
+    assert base["quaternion"][0] == pytest.approx(1.0, abs=1e-3)
+    assert base["quaternion"][3] == pytest.approx(0.0, abs=1e-3)
+    assert len(base["position"]) == 3 and len(base["linear_velocity"]) == 3
+
+
+def test_get_robot_state_base_matches_get_observation(sim):
+    """The base orientation/angular-velocity from get_robot_state agree with
+    get_observation's base_quat / base_ang_vel for the same robot - the two
+    state paths are consistent."""
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    _set_free_joint(sim, "humanoid", [0.1, 0.2, 0.7, 0.70710678, 0.0, 0.0, 0.70710678], [0.5, 0.0, 0.0, 0.0, 0.0, 1.5])
+
+    base = sim.get_robot_state(robot_name="humanoid")["content"][1]["json"]["base"]
+    obs = sim.get_observation(robot_name="humanoid", skip_images=True)
+    assert base["quaternion"] == obs["base_quat"]
+    assert base["angular_velocity"] == obs["base_ang_vel"]
+
+
+def test_get_robot_state_fixed_base_arm_has_no_base_entry(sim):
+    """A fixed-base arm (no free joint) reports scalar joints and NO ``base``
+    entry - the floating-base detection must not false-positive."""
+    sim.add_robot("arm", urdf_path=_write(FIXED_ARM_XML))
+    payload = sim.get_robot_state(robot_name="arm")["content"][1]["json"]
+    assert "base" not in payload
+    assert "j0" in payload["state"] and isinstance(payload["state"]["j0"]["position"], float)


### PR DESCRIPTION
## Problem

`get_robot_state` iterates `robot.joint_names` and reads each as a scalar hinge/slide joint:

```python
state[jnt_name] = {
    "position": float(data.qpos[model.jnt_qposadr[jnt_id]]),
    "velocity": float(data.qvel[model.jnt_dofadr[jnt_id]]),
}
```

For a **floating base** (a 6-DoF free joint) this is a silent wrong value. A free joint's `qpos` is `[xyz(3) + quat(4)]` and its `qvel` is `[linvel(3) + angvel(3)]`, so `qpos[jnt_qposadr]` is the base **x-coordinate** and `qvel[jnt_dofadr]` is **linear-velocity-x** — reported as if they were a joint angle and angular rate, with the orientation and the rest of the twist silently dropped.

Meanwhile `get_observation` (the policy-facing counterpart) already surfaces the base correctly as `base_quat` / `base_ang_vel`. So the two state paths **disagree** for exactly the robot class the project is expanding into (humanoids, quadrupeds, mobile manipulators):

- A humanoid's **named** `floating_base_joint` (e.g. the Unitree G1) hit the wrong-scalar path.
- A mobile base's **unnamed** `<freejoint/>` (e.g. LeKiwi) is not in `joint_names`, so it was skipped entirely — `get_robot_state` returned no base information at all.

### Reproduction (real MuJoCo `unitree_g1`)

Base set to `pos=[0.3, 0.4, 0.9]`, `quat=[0.7071, 0, 0, 0.7071]` (90° about z), twist `lin=[1.1,2.2,3.3] ang=[4.4,5.5,6.6]`:

**Before**
```
get_robot_state → state["floating_base_joint"] = {"position": 0.3, "velocity": 1.1}   # base-x / linvel-x, no orientation
get_observation → base_quat=[0.7071,0,0,0.7071]  base_ang_vel=[4.4,5.5,6.6]           # correct
```

**After**
```
get_robot_state → state has NO "floating_base_joint"
                  base = {position:[0.3,0.4,0.9], quaternion:[0.7071,0,0,0.7071],
                          linear_velocity:[1.1,2.2,3.3], angular_velocity:[4.4,5.5,6.6]}
consistency: base.quaternion == get_observation.base_quat        → True
             base.angular_velocity == get_observation.base_ang_vel → True
```

## Change

`get_robot_state` now detects a free joint during the joint scan, skips the meaningless scalar, and surfaces the full 6-DoF pose+twist under a `base` entry: `position` (xyz), `quaternion` (w,x,y,z), `linear_velocity`, `angular_velocity`. When the free joint is unnamed (absent from `joint_names`) it is recovered from the kinematic tree via the same `_robot_base_free_joint` helper `get_observation` uses, so a sibling free-jointed task object (a cube) is never mistaken for the base. The `base` entry is a sibling of `state` in the JSON payload (so `state` stays an all-scalar `{joint: {position, velocity}}` map), and the base pose/twist is left un-noised — matching `get_observation`'s `base_quat`/`base_ang_vel` contract. A fixed-base arm is unchanged (scalar joints only, no `base` entry).

## Tests

`tests/simulation/mujoco/test_mobile_base_observation.py` (offline, GL-free inline MJCF; no asset download):

- `test_get_robot_state_named_free_base_reports_base_pose_not_scalar` — named `floating_base_joint` is no longer a scalar joint; `base` carries the full pose+twist. **Fails before** (`AssertionError: 'floating_base_joint' not in {... {'position': 0.3, 'velocity': 1.1} ...}`).
- `test_get_robot_state_unnamed_free_base_reports_base` — unnamed `<freejoint/>` (LeKiwi-style) now surfaces `base`, resolved from the tree not the sibling cube. **Fails before** (`KeyError: 'base'`).
- `test_get_robot_state_base_matches_get_observation` — the two state paths agree on `quaternion`/`angular_velocity`. **Fails before** (`KeyError: 'base'`).
- `test_get_robot_state_fixed_base_arm_has_no_base_entry` — guard: a fixed-base arm has no `base` entry (no false positive). Passes both ways.

Green local gate: `ruff check` + `ruff format --check` + `mypy` clean on the changed module; 501 passed across the mobile-base, simulation, obs-noise, agenttool-contract, describe-discovery, concurrency and WBC suites (`MUJOCO_GL=egl`).

No visual artifact: this is a state-query JSON-readout fix (not a policy / rendering / recording / asset change); the before→after JSON on the real G1 above is the decisive proof, matching the precedent for state-schema fixes.

Complements the recent `get_observation` base-state work (surfacing `base_quat`/`base_ang_vel` for named and unnamed free joints) by bringing the agent-facing `get_robot_state` tool to the same contract.