### PR TITLE
fix(sim): Newton joint index maps shift every joint after a floating base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -833,6 +833,22 @@ base information at all. The free joint is now surfaced under a structured
 unnamed, with the `quaternion` / `angular_velocity` matching `get_observation`.
 A fixed-base arm still reports only its scalar joints (no `base` entry).
 
+### Fixed: Newton `get_observation` / `get_robot_state` shifted every joint after a floating base
+
+The Newton backend built its per-joint coordinate/DOF index maps
+(`_joint_coord_index` / `_joint_dof_index`) from a per-joint ordinal offset --
+one coordinate and one DOF per joint. That assumption breaks for any robot with
+a multi-coordinate joint: a floating base (a free joint) spans 7 coordinates
+(xyz + quaternion) and 6 DOFs, so every child joint after it was read from the
+wrong index. A humanoid whose root is a free joint (e.g. Unitree G1/H1) reported
+a base coordinate for its first leg joint and shifted the reading of every joint
+after -- so `get_robot_state` and the policy-facing `get_observation` returned
+garbage joint positions/velocities for the entire floating-base robot. The maps
+are now built from Newton's authoritative per-joint coordinate/DOF starts
+(`joint_q_start` / `joint_qd_start`), so each joint reads its own value. A
+fixed-base arm (all revolute joints) is unaffected -- its indices are already
+the joint ordinals.
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -1762,8 +1762,6 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         self._robot_body_map = {}
 
         for robot_name, robot in self._world.robots.items():
-            coord_before = builder.joint_coord_count
-            dof_before = builder.joint_dof_count
             label_before = len(builder.joint_label)
             body_before = builder.body_count
             xform = wp.transform(
@@ -1778,12 +1776,26 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
             else:
                 builder.add_mjcf(model_path, xform=xform, collapse_fixed_joints=True)
             new_labels = builder.joint_label[label_before:]
+            # Map each joint to its coordinate index in joint_q and its DOF index
+            # in joint_qd. These are NOT the joint's ordinal position: a floating
+            # base (a free joint) spans 7 coordinates (xyz + quaternion) and 6
+            # DOFs, a ball joint 4/3, while a revolute/prismatic joint spans 1/1.
+            # So once a robot has a multi-coordinate joint (e.g. a humanoid whose
+            # root is a free joint), every joint after it is offset. Read the
+            # authoritative per-joint coordinate/DOF starts the builder tracks
+            # (joint_q_start / joint_qd_start) instead of assuming one coordinate
+            # and one DOF per joint - otherwise get_observation and
+            # get_robot_state report the base coordinates for the first child
+            # joint and shift the reading of every joint after it.
+            q_start = builder.joint_q_start
+            qd_start = builder.joint_qd_start
             short_names: list[str] = []
             for offset, label in enumerate(new_labels):
                 short = _short_joint_name(label)
                 short_names.append(short)
-                self._joint_coord_index[(robot_name, short)] = coord_before + offset
-                self._joint_dof_index[(robot_name, short)] = dof_before + offset
+                joint_index = label_before + offset
+                self._joint_coord_index[(robot_name, short)] = int(q_start[joint_index])
+                self._joint_dof_index[(robot_name, short)] = int(qd_start[joint_index])
             self._robot_joint_map[robot_name] = short_names
             self._robot_body_map[robot_name] = list(builder.body_label[body_before:])
 

--- a/tests/simulation/newton/test_discovery_and_state.py
+++ b/tests/simulation/newton/test_discovery_and_state.py
@@ -63,6 +63,99 @@ class TestGetRobotState:
         assert engine_so100.get_robot_state("ghost")["status"] == "error"
 
 
+# A minimal floating-base model: a free-jointed root body carrying two hinge
+# children. The root's free joint spans 7 coordinates (xyz + quaternion) and 6
+# DOFs, so ``j1``/``j2`` live at coordinate indices 7/8 and DOF indices 6/7 -
+# NOT the ordinal 1/2 a naive per-joint offset would assign. Kept inline (no
+# downloaded asset) so the test runs anywhere Newton is importable.
+_FLOATER_MJCF = """<mujoco model="floater">
+  <compiler angle="radian"/>
+  <worldbody>
+    <body name="base" pos="0 0 0.5">
+      <freejoint name="root"/>
+      <geom type="box" size="0.1 0.1 0.05" mass="1"/>
+      <body name="link1" pos="0.1 0 0">
+        <joint name="j1" type="hinge" axis="0 0 1"/>
+        <geom type="capsule" fromto="0 0 0 0.2 0 0" size="0.02" mass="0.2"/>
+        <body name="link2" pos="0.2 0 0">
+          <joint name="j2" type="hinge" axis="0 1 0"/>
+          <geom type="capsule" fromto="0 0 0 0.2 0 0" size="0.02" mass="0.2"/>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+</mujoco>"""
+
+
+@pytest.fixture
+def engine_floater(engine, tmp_path):
+    """Real Newton build of the inline floating-base model above."""
+    path = tmp_path / "floater.xml"
+    path.write_text(_FLOATER_MJCF)
+    assert engine.add_robot("floater", urdf_path=str(path))["status"] == "success"
+    return engine
+
+
+class TestFloatingBaseJointIndices:
+    """A free-jointed root must not shift every child joint's state reading.
+
+    Regression for the Newton index maps: ``_joint_coord_index`` /
+    ``_joint_dof_index`` were built from a per-joint ordinal offset (one
+    coordinate and one DOF per joint), which is wrong once a robot has a
+    multi-coordinate joint. A floating base (free joint: 7 coordinates, 6 DOFs)
+    made every child joint read the base's coordinates instead of its own, so
+    get_robot_state / get_observation reported garbage for a humanoid's leg and
+    arm joints (and the policy observation path saw the same garbage).
+    """
+
+    def test_index_maps_use_authoritative_joint_starts(self, engine_floater):
+        model = engine_floater._model
+        q_start = model.joint_q_start.numpy()
+        qd_start = model.joint_qd_start.numpy()
+        names = engine_floater._world.robots["floater"].joint_names
+        assert names == ["root", "j1", "j2"]
+        for i, jname in enumerate(names):
+            assert engine_floater._joint_coord_index[("floater", jname)] == int(q_start[i])
+            assert engine_floater._joint_dof_index[("floater", jname)] == int(qd_start[i])
+        # The hinges live past the free joint's 7 coordinates / 6 DOFs, not at
+        # the ordinal 1/2 that the buggy mapping produced.
+        assert engine_floater._joint_coord_index[("floater", "j1")] == 7
+        assert engine_floater._joint_dof_index[("floater", "j1")] == 6
+        assert engine_floater._joint_coord_index[("floater", "j2")] == 8
+        assert engine_floater._joint_dof_index[("floater", "j2")] == 7
+
+    def _set_position_sentinels(self, engine_floater):
+        """Write joint_q[i] = 100 + i so each position value encodes its coord index."""
+        q = engine_floater._state_0.joint_q.numpy().copy()
+        for i in range(len(q)):
+            q[i] = 100.0 + i
+        engine_floater._state_0.joint_q.assign(q)
+        return engine_floater._model.joint_q_start.numpy()
+
+    def test_get_robot_state_reads_hinge_coordinates_past_free_joint(self, engine_floater):
+        q_start = self._set_position_sentinels(engine_floater)
+        state = engine_floater.get_robot_state("floater")["content"][1]["json"]["state"]
+        # Each hinge must report the sentinel at ITS own coordinate index, not
+        # the base coordinate a per-joint offset would read.
+        assert state["j1"]["position"] == pytest.approx(100.0 + int(q_start[1]))
+        assert state["j2"]["position"] == pytest.approx(100.0 + int(q_start[2]))
+
+    def test_get_observation_reads_hinge_coordinates_past_free_joint(self, engine_floater):
+        q_start = self._set_position_sentinels(engine_floater)
+        obs = engine_floater.get_observation("floater", skip_images=True)
+        assert obs["j1"] == pytest.approx(100.0 + int(q_start[1]))
+        assert obs["j2"] == pytest.approx(100.0 + int(q_start[2]))
+
+    def test_fixed_base_arm_index_maps_are_the_identity(self, engine_so100):
+        # A robot with no multi-coordinate joint (an all-revolute arm) must be
+        # unchanged: coordinate/DOF index == ordinal position.
+        names = engine_so100._world.robots["so100"].joint_names
+        coords = [engine_so100._joint_coord_index[("so100", j)] for j in names]
+        dofs = [engine_so100._joint_dof_index[("so100", j)] for j in names]
+        assert coords == list(range(len(names)))
+        assert dofs == list(range(len(names)))
+
+
 class TestListBodies:
     def test_scoped_lists_only_robot_bodies_with_gripper(self, engine_so100):
         result = engine_so100.list_bodies("so100")


### PR DESCRIPTION
## Problem

The Newton backend builds its per-joint coordinate/DOF index maps (`_joint_coord_index` / `_joint_dof_index`) from a per-joint **ordinal** offset in `_build_model` -- one coordinate and one DOF per joint:

```python
for offset, label in enumerate(new_labels):
    self._joint_coord_index[(robot_name, short)] = coord_before + offset
    self._joint_dof_index[(robot_name, short)] = dof_before + offset
```

That assumption is wrong for any robot with a **multi-coordinate joint**. A floating base (a free joint) spans **7 coordinates** (xyz + quaternion) and **6 DOFs**; a ball joint 4/3. So once a robot has a free root, every joint after it is read from the wrong index. A humanoid whose root is a free joint (Unitree G1/H1) reports a *base* coordinate for its first leg joint and shifts the reading of every joint after it. Both `get_robot_state` **and** the policy-facing `get_observation` (which reads the same map) return garbage joint positions/velocities for the entire floating-base robot.

This is the Newton mirror of the same free-joint class fixed for the MuJoCo backend in the get_observation / get_robot_state floating-base work, but more severe: the MuJoCo backend addresses `qpos` via per-joint `jnt_qposadr` (already correct for the scalar joints) so only the free joint itself was misread; the Newton index map miscomputes the indices of *all* the scalar joints.

## Reproduction (real Unitree G1, Newton `mujoco` solver)

With a distinctive pose set on the true coordinates of a few G1 joints, `get_robot_state` reports:

| joint | true | before | after |
|---|--:|--:|--:|
| left_hip_pitch_joint | 0.30 | 0.000 | 0.300 |
| left_knee_joint | 1.05 | 0.000 | 1.050 |
| right_ankle_pitch_joint | -0.22 | 0.000 | -0.220 |
| left_shoulder_pitch_joint | 0.60 | 0.000 | 0.600 |

Before the fix every joint reads `0.000` -- it is reading into the free joint's base position / quaternion block, not its own coordinate. G1 has 30 joints: `joint_type[0]=FREE`, `joint_coord_count=36` (7 free + 29 revolute), `joint_dof_count=35` (6 free + 29 revolute), while the old maps assigned the first hip joint coord `1` / dof `1` instead of `7` / `6`.

## Fix

Build the maps from Newton's authoritative per-joint coordinate/DOF starts that the builder already tracks (`joint_q_start` / `joint_qd_start`) instead of assuming one coordinate and one DOF per joint. Each joint then reads its own value regardless of what precedes it. A fixed-base arm (all revolute joints) is unaffected -- its coordinate/DOF indices are already the joint ordinals, verified byte-identical for `so100` / `so101` (`coords == dofs == [0..n-1]`).

## Tests

`tests/simulation/newton/test_discovery_and_state.py::TestFloatingBaseJointIndices` -- a real Newton build of an inline floating-base model (free-jointed root + two hinge children, no downloaded asset):
- `test_index_maps_use_authoritative_joint_starts` -- the hinges map to coordinate 7/8 and DOF 6/7, not the ordinal 1/2.
- `test_get_robot_state_reads_hinge_coordinates_past_free_joint` / `test_get_observation_reads_hinge_coordinates_past_free_joint` -- with `joint_q[i] = 100 + i` sentinels (so each reported position encodes its own coordinate index), both methods report each hinge's own coordinate.
- `test_fixed_base_arm_index_maps_are_the_identity` -- no-regression guard: an all-revolute arm's indices stay the ordinals.

The three floating-base tests fail before the fix (index `1 != 7`; positions read `101` = base y instead of `107` = the hinge's own coordinate) and pass after; the fixed-base guard passes both. Full Newton suite: 208 passed, 1 skipped. `ruff` + `mypy` clean.