### PR TITLE
docs(datasets): document steerable dataset annotation with lerobot-annotate

### DIFF
--- a/docs/data/annotation.md
+++ b/docs/data/annotation.md
@@ -1,0 +1,123 @@
+---
+description: Add steerable language annotations (language_persistent / language_events) to a LeRobot dataset with lerobot-annotate, then train a language-conditioned VLA.
+---
+
+# Steerable dataset annotation
+
+Steerable policies accept a language and preference conditioning signal at
+inference time (subtasks, interjections, VQA-style grounding) on top of the
+usual task string. Training one needs a dataset whose frames carry those
+language signals. LeRobot 0.6 ships the pipeline that produces them,
+`lerobot-annotate`, and `strands-robots` datasets are ordinary LeRobot v3
+datasets, so the two compose directly:
+
+```
+record (strands-robots)  ->  annotate (lerobot-annotate)  ->  train steerable VLA
+```
+
+`strands-robots` does not reimplement the annotation pipeline. It is a
+GPU-heavy, fast-moving research module in LeRobot; mirroring it would duplicate
+a moving target. This page documents how to drive the upstream tool against a
+dataset you recorded with `strands-robots` and what it writes.
+
+## What `lerobot-annotate` actually is
+
+It is an **automated Vision-Language-Model labeling pipeline**, not a
+human-in-the-loop UI. It reads each episode's frames, sends sampled
+contact-sheets to a Qwen-VL model served over an OpenAI-compatible endpoint
+(vLLM, auto-spawned by default), and rewrites the dataset's parquet shards in
+place with two new language columns. There is no interactive editor and no
+manual review step; a human only sets the config and inspects the result.
+
+The pipeline runs six phases in dependency order:
+
+1. **plan** module - subtasks, plan, memory, optional task augmentation
+2. **interjections** module - interjections plus paired speech
+3. **plan update** - re-emit plan rows at each interjection timestamp
+4. **vqa** module - general visual-question-answer pairs
+5. **validator** - schema and coverage checks on the staged output
+6. **writer** - rewrite `data/chunk-*/file-*.parquet` and update `meta/info.json`
+
+## Requirements
+
+- `lerobot>=0.6` (already pinned by `strands-robots`) with the annotation deps
+  (`datasets`, `pyarrow`, `av`/`torchcodec`, `openai`).
+- A Qwen-VL model served on an OpenAI-compatible endpoint. `lerobot-annotate`
+  auto-spawns a local vLLM server by default (`--vlm.auto_serve=true`), which
+  needs a GPU; point `--vlm.api_base` at an existing server to reuse one.
+- For dataset-scale runs, distribute with Hugging Face Jobs - see
+  `examples/annotations/run_hf_job.py` in the LeRobot repository.
+
+## Running it on a strands-robots dataset
+
+Record a dataset the usual way (see [Recording & datasets](../recording.md)):
+
+```python
+from strands_robots import Robot
+
+sim = Robot("so100")
+sim.start_recording(repo_id="user/pick_place", task="pick up the cube", fps=30)
+sim.run_policy(robot_name="so100", instruction="pick up the cube",
+               policy_provider="mock", duration=10.0)
+sim.stop_recording()
+```
+
+Then annotate it in place with the LeRobot console script:
+
+```bash
+lerobot-annotate \
+    --root=~/.strands_robots/datasets/user/pick_place \
+    --vlm.model_id=Qwen/Qwen2.5-VL-7B-Instruct
+```
+
+Common flags:
+
+- `--repo_id=user/pick_place` - download the source from the Hub instead of `--root`.
+- `--new_repo_id=user/pick_place_annotated` - write to a separate target.
+- `--push_to_hub=true` - upload the annotated dataset when finished.
+- `--vlm.api_base=http://host:8000/v1` with `--vlm.auto_serve=false` - reuse a
+  running vLLM server instead of spawning one.
+- `--only_episodes=0,1,2` - annotate a subset while iterating.
+- toggle modules with `--plan.enabled`, `--interjections.enabled`, `--vqa.enabled`.
+
+## What it writes: the language columns
+
+Two columns are added to every frame row (and advertised in `meta/info.json`
+via `language_feature_info()`, so non-streaming loads keep working):
+
+| Column | Shape | Meaning |
+| --- | --- | --- |
+| `language_persistent` | list of rows, each with a `timestamp` | A state that becomes active at a moment and stays active until superseded (subtasks, plan, memory, motion, task_aug). |
+| `language_events` | list of rows, no `timestamp` | An instantaneous event stored on the frame whose timestamp is its firing time (interjection, vqa, trace). |
+
+Row fields:
+
+- persistent row: `role`, `content`, `style`, `timestamp` (float32), `camera`, `tool_calls`
+- event row: `role`, `content`, `style`, `camera`, `tool_calls`
+
+Styles are drawn from a fixed registry:
+
+- persistent styles: `subtask`, `plan`, `memory`, `motion`, `task_aug`
+- event-only styles: `interjection`, `vqa`, `trace`
+- view-dependent styles (`camera` must reference an `observation.images.*`
+  key): `vqa`, `trace`. Every other style carries `camera=None`.
+
+The pipeline also appends a canonical `say` tool schema (`SAY_TOOL_SCHEMA`) to
+`meta/info.json`'s `tools` so speech interjections have a declared call surface.
+
+## Feeding a steerable VLA
+
+An annotated dataset is a superset of the original: policies that ignore the
+language columns train unchanged, while a language-conditioned VLA consumes
+`language_persistent`/`language_events` as extra conditioning. Point the
+existing training workflow (see [VLA-on-G1 Workflow](../training/vla_workflow.md))
+at the annotated `repo_id`; no `strands-robots` code changes are needed to carry
+the columns through recording, since they are added after recording by the
+annotation step.
+
+## References
+
+- LeRobot annotation pipeline: `lerobot/annotations/steerable_pipeline/`
+- CLI: `lerobot-annotate` (`lerobot/scripts/lerobot_annotate.py`)
+- Column schema: `lerobot/datasets/language.py`
+- Distributed example: `examples/annotations/run_hf_job.py`

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -382,4 +382,5 @@ python -m lerobot.scripts.train policy=act \
 ## See also
 
 - [Training](training/overview.md) - what to do with the data.
+- [Steerable annotation](data/annotation.md) - add language conditioning columns to a recorded dataset.
 - [LeRobot dataset docs](https://huggingface.co/docs/lerobot) - upstream spec.

--- a/docs/training/vla_workflow.md
+++ b/docs/training/vla_workflow.md
@@ -86,6 +86,9 @@ For data collection from a different source, swap the WBC policy for a LeRobot
 teleop driver, a VR controller, or `MockPolicy` (synthetic, runs with no weights
 or hardware - the quick-demo default). The dataset format is identical either way.
 
+To train a **language-conditioned (steerable)** policy, annotate the recorded
+dataset with language columns first - see [Steerable annotation](../data/annotation.md).
+
 ### 2. Fine-tune  - post-train Isaac-GR00T N1.7
 
 Use the [`Trainer` abstraction](overview.md) with the `"groot"` provider to

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,7 +54,9 @@ nav:
   - Overview: training/overview.md
   - VLA-on-G1 Workflow: training/vla_workflow.md
   - Reinforcement Learning: training/rl.md
-- Recording & Datasets: recording.md
+- Datasets:
+  - Recording: recording.md
+  - Steerable Annotation: data/annotation.md
 - Remote Inference: inference/remote.md
 - Examples:
   - Overview: examples/overview.md


### PR DESCRIPTION
## Problem

LeRobot 0.6 shipped `lerobot-annotate` (the `steerable_pipeline`), which produces the `language_persistent` / `language_events` columns a steerable, language-conditioned VLA trains on. `strands-robots` records plain LeRobot v3 datasets, so this tool composes directly, but nothing in the docs told users that the path exists or how the pieces fit.

## Change

Adds `docs/data/annotation.md` documenting the annotation step and wires it into the docs:

- **What the tool actually is**: an automated Vision-Language-Model labeling pipeline (Qwen-VL over an OpenAI-compatible vLLM endpoint, auto-spawned), *not* a human-in-the-loop UI. Documents the six phases (plan / interjections / plan-update / vqa / validator / writer).
- **How to run it** on a `strands-robots`-recorded dataset (`lerobot-annotate --root=... --vlm.model_id=...`), plus the common flags and the GPU / HF Jobs requirements.
- **Output schema**: the `language_persistent` and `language_events` columns, their row fields (`role`/`content`/`style`/`timestamp`/`camera`/`tool_calls`), the persistent vs event-only styles, and the view-dependent styles that must carry a `camera` key.
- **How it feeds a steerable VLA**: an annotated dataset is a superset, so existing policies train unchanged.

Nav: converts the lone `Recording & Datasets` entry into a `Datasets` section (`Recording` + `Steerable Annotation`), and cross-links from `recording.md` and the VLA-on-G1 workflow.

## Why no code is mirrored

The annotation pipeline is a GPU-heavy, fast-moving research module (Qwen-VL + vLLM + HF Jobs) that lives upstream as a first-class console script. Reimplementing a `SteerablePolicy` provider or a tool that wraps the CLI would duplicate a moving target and add a subprocess surface, while `strands-robots` datasets already flow into it unchanged. Documenting the composition is the correct, non-duplicative wiring; a native surface only becomes worthwhile if a browser annotation UI is ever shipped.

## Testing

`mkdocs build --strict` passes (0 warnings from the new page, nav, and cross-links). Docs-only change; no code paths touched.