### PR TITLE
feat(inference): remote policy inference client/server split (WS-JSON)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Added: remote policy inference (client/server split) for edge robots + remote GPU
+
+A resource-constrained robot host (edge device / laptop CPU) often cannot run a
+large VLA (pi0, SmolVLA, MolmoAct2) at control rate. The new
+`strands_robots.inference` package splits inference across two machines over a
+portable WS-JSON WebSocket protocol: `PolicyServer` wraps ANY `Policy` and
+serves it (run it on the GPU box), and `RemotePolicy` is a drop-in `Policy` that
+forwards observations to the server and returns the action chunk (construct it
+on the robot host). `RemotePolicy` is wired into `create_policy` as the `remote`
+provider, so `create_policy("remote", endpoint="ws://gpu-box:8765")` -- or the
+smart string `create_policy("ws://gpu-box:8765")` -- yields one, usable anywhere
+a local policy is (`run_policy`, `eval_policy`, hardware loops). The client
+mirrors the server policy's `requires_images` / `execution_horizon` /
+`actions_per_step` / `supports_rtc` metadata, and the Real-Time Chunking
+contract is preserved end to end: the runner-counted `rtc_observed_delay_steps`
+is forwarded per request and applied server-side before chunk-seam blending.
+Install with `pip install 'strands-robots[inference]'` (pulls only
+`websockets`). See `docs/inference/remote.md`.
+
+
 ### Fixed: session `status` tool results dropped their telemetry via a `**spread` top-level smuggle
 
 The `status` action of `lerobot_teleoperate` and `lerobot_train` returned the

--- a/docs/inference/remote.md
+++ b/docs/inference/remote.md
@@ -1,0 +1,130 @@
+# Remote Policy Inference (client/server split)
+
+A resource-constrained robot host - an edge device or a laptop CPU - often
+cannot run a large vision-language-action policy (pi0, SmolVLA, MolmoAct2) at
+control rate. `strands_robots.inference` splits inference across two machines:
+the robot host streams observations to a **remote GPU box** and receives action
+chunks back, over a portable WebSocket protocol.
+
+```
+   robot host (CPU / edge)                         GPU box
+ +-------------------------+                +-----------------------+
+ |  control loop           |   observation  |  PolicyServer         |
+ |  RemotePolicy  ------------- ws://  ----> |    wraps any Policy   |
+ |  (Policy ABC)  <------------ chunk  ----- |    (pi0 / SmolVLA...) |
+ |  applies actions        |                |    runs on GPU        |
+ +-------------------------+                +-----------------------+
+```
+
+`RemotePolicy` is a drop-in [`Policy`](../policies/overview.md): anywhere a
+local policy works - `sim.run_policy(...)`, `sim.eval_policy(...)`, or a
+hardware control loop - a remote one works too.
+
+## Install
+
+```bash
+pip install 'strands-robots[inference]'   # pulls websockets (numpy-agnostic)
+```
+
+The extra depends only on `websockets`, so it composes cleanly with `lerobot`
+(`numpy>=2`) in the same environment.
+
+## 1. Start the server (GPU box)
+
+Serve any policy provider over a WebSocket:
+
+```bash
+python -m strands_robots.inference.server \
+    --provider lerobot/act_so101 \
+    --host 0.0.0.0 --port 8765
+```
+
+Or programmatically, wrapping a provider or an already-loaded policy:
+
+```python
+from strands_robots.inference import PolicyServer
+
+# Build the policy on the server from a provider string:
+PolicyServer(policy_provider="lerobot/act_so101", host="0.0.0.0", port=8765).serve()
+
+# ...or serve a policy object you already hold:
+PolicyServer(policy=my_policy, port=8765).serve()
+```
+
+`serve()` blocks. For programmatic control (tests, embedding in a larger
+process) use `start()` / `stop()`:
+
+```python
+server = PolicyServer(policy=my_policy, port=0).start()  # port=0 -> OS picks one
+print(server.port)
+...
+server.stop()
+```
+
+The server binds `127.0.0.1` by default. Set `host="0.0.0.0"` to accept remote
+connections and wrap the link in tailscale / wireguard for production - the v1
+transport is plaintext (auth/TLS is out of scope, see Non-goals).
+
+## 2. Connect from the robot host
+
+```python
+from strands_robots import create_policy
+
+# Named provider with an explicit endpoint:
+policy = create_policy("remote", endpoint="ws://gpu-box:8765")
+
+# ...or the smart string, which resolves to the same RemotePolicy:
+policy = create_policy("ws://gpu-box:8765")
+```
+
+Then drive it exactly like a local policy. In simulation:
+
+```python
+import strands_robots as sr
+
+sim = sr.Robot("so101", mode="sim")
+sim.run_policy(policy_provider="ws://gpu-box:8765", instruction="pick the cube", n_steps=300)
+```
+
+The connection is established lazily on first use, so constructing the policy
+does not require the server to already be running.
+
+## What the client mirrors
+
+On connect, the server advertises the wrapped policy's introspection metadata
+and `RemotePolicy` mirrors it locally, so the runtime behaves identically to
+running the policy in-process:
+
+| Property             | Effect on the robot host                                   |
+|----------------------|------------------------------------------------------------|
+| `requires_images`    | skip camera rendering when the remote policy does not need frames |
+| `execution_horizon`  | size action chunks / re-query interval correctly           |
+| `actions_per_step`   | the remote policy's trained chunk length                   |
+| `supports_rtc`       | whether Real-Time Chunking blending runs server-side       |
+
+## Real-Time Chunking across the wire
+
+The RTC contract is preserved end to end. The runner counts how many control
+steps elapse during inference and sets it via
+`Policy.set_rtc_observed_delay(steps)`; `RemotePolicy` forwards that count on
+every request, and the server applies it to the wrapped policy immediately
+before inference. Chunk-seam blending therefore happens server-side against the
+correct, deterministic step offset - identical to a local rollout. Per-episode
+`reset(seed)` and `set_control_frequency(hz)` are forwarded too, so seeded
+episodes stay reproducible.
+
+## Error handling
+
+Inference failures on the server are marshalled back as an `error` message and
+re-raised on the client as a `RuntimeError` carrying the server traceback - the
+client never silently substitutes a zero action. An unreachable server raises a
+`ConnectionError` with a hint on how to start one.
+
+## Non-goals (v1)
+
+- **Auth / TLS**: the transport is plaintext. Run it over tailscale / wireguard
+  or an SSH tunnel for anything beyond a trusted LAN.
+- **Multi-client fan-out**: one client per server. The wrapped policy holds
+  per-episode state (RTC seams, diffusion RNG); the server serializes inference
+  so concurrent clients cannot corrupt each other, but a dedicated server per
+  robot is the intended topology.

--- a/docs/policies/remote.md
+++ b/docs/policies/remote.md
@@ -1,0 +1,30 @@
+# Remote (WebSocket inference)
+
+`create_policy("remote", endpoint="ws://gpu-box:8765")` returns a
+`RemotePolicy` - a drop-in [`Policy`](overview.md) that forwards observations to
+a remote `PolicyServer` and returns the action chunk it computes. Use it when
+the robot host cannot run a large policy locally and a GPU box can.
+
+```python
+from strands_robots import create_policy
+
+policy = create_policy("remote", endpoint="ws://gpu-box:8765")
+# smart string is equivalent:
+policy = create_policy("ws://gpu-box:8765")
+```
+
+| Config key        | Default       | Meaning                                          |
+|-------------------|---------------|--------------------------------------------------|
+| `endpoint`        | -             | Full server URL (`ws://host:port`); wins over host/port |
+| `host`            | `127.0.0.1`   | Server host (when `endpoint` is omitted)         |
+| `port`            | `8765`        | Server port (when `endpoint` is omitted)         |
+| `connect_timeout` | `10.0`        | Seconds to wait for the WebSocket handshake      |
+| `request_timeout` | `60.0`        | Seconds to wait for each inference reply         |
+
+The client mirrors the server policy's `requires_images`, `execution_horizon`,
+`actions_per_step` and `supports_rtc`, and forwards the Real-Time Chunking
+observed-delay count on every request, so a remote rollout behaves like a local
+one. Install with `pip install 'strands-robots[inference]'`.
+
+See **[Remote Policy Inference](../inference/remote.md)** for the full
+two-machine setup, the server CLI, and the wire protocol.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
   - MotionBricks (G1 generative motion): policies/motionbricks.md
   - LeRobot Local: policies/lerobot-local.md
   - MolmoAct2 (SO-100/101): policies/molmoact2.md
+  - Remote (WebSocket inference): policies/remote.md
   - Camera Naming: policies/camera-naming.md
   - Custom Policies: policies/custom-policies.md
 - Real Hardware:
@@ -54,6 +55,7 @@ nav:
   - VLA-on-G1 Workflow: training/vla_workflow.md
   - Reinforcement Learning: training/rl.md
 - Recording & Datasets: recording.md
+- Remote Inference: inference/remote.md
 - Examples:
   - Overview: examples/overview.md
 - Architecture: architecture.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -292,6 +292,14 @@ vera-sim = [
 ollama = [
     "strands-agents[ollama]>=1.0.0,<2.0.0",
 ]
+# Remote policy inference (client/server split): stream observations from a
+# CPU/edge robot host to a remote GPU PolicyServer and receive action chunks
+# back over a portable WS-JSON WebSocket protocol. Pulls only `websockets`
+# (numpy-version agnostic, so it composes with lerobot's numpy>=2). See
+# strands_robots/inference/ and docs/inference/remote.md.
+inference = [
+    "websockets>=12.0",
+]
 all = [
     "strands-robots[groot-service]",
     "strands-robots[moveit2]",
@@ -304,6 +312,7 @@ all = [
     "strands-robots[motionbricks]",
     "strands-robots[molmoact2]",
     "strands-robots[ollama]",
+    "strands-robots[inference]",
 ]
 dev = [
     "pytest>=6.0,<10.0.0",

--- a/strands_robots/inference/__init__.py
+++ b/strands_robots/inference/__init__.py
@@ -1,0 +1,27 @@
+"""Remote policy inference: client/server split for edge robots + remote GPU.
+
+A resource-constrained robot host (CPU / edge device) often cannot run a large
+VLA (pi0 / SmolVLA / MolmoAct2) at control rate. This package splits inference
+across two machines over a portable WS-JSON WebSocket protocol:
+
+* :class:`~strands_robots.inference.server.PolicyServer` wraps ANY
+  :class:`~strands_robots.policies.base.Policy` and serves it (run it on the
+  GPU box).
+* :class:`~strands_robots.inference.client.RemotePolicy` is a drop-in
+  ``Policy`` that forwards observations to the server and returns the action
+  chunk (construct it on the robot host). It is wired into
+  :func:`~strands_robots.policies.create_policy` as the ``remote`` provider, so
+  ``create_policy("remote", endpoint="ws://gpu-box:8765")`` (or the smart
+  string ``create_policy("ws://gpu-box:8765")``) yields one.
+
+Requires the ``inference`` extra::
+
+    pip install 'strands-robots[inference]'
+
+See ``docs/inference/remote.md`` for the two-machine setup.
+"""
+
+from strands_robots.inference.client import RemotePolicy
+from strands_robots.inference.server import PolicyServer
+
+__all__ = ["PolicyServer", "RemotePolicy"]

--- a/strands_robots/inference/client.py
+++ b/strands_robots/inference/client.py
@@ -1,0 +1,257 @@
+"""Remote policy inference client (robot side, typically a CPU/edge host).
+
+:class:`RemotePolicy` is a drop-in :class:`~strands_robots.policies.base.Policy`
+that forwards every observation to a :class:`PolicyServer` over a WebSocket and
+returns the action chunk the server computes. Because it satisfies the ``Policy``
+ABC, it works anywhere a local policy does: ``sim.run_policy(policy_provider=...)``,
+``sim.eval_policy(...)``, or a hardware control loop that calls
+:func:`~strands_robots.policies.create_policy`.
+
+Usage::
+
+    from strands_robots import create_policy
+
+    policy = create_policy("remote", endpoint="ws://gpu-box:8765")
+    # or via smart string:
+    policy = create_policy("ws://gpu-box:8765")
+
+The client mirrors the server policy's introspection metadata
+(``requires_images``, ``execution_horizon``, ``actions_per_step``,
+``supports_rtc``) so the local runtime sizes chunks and skips camera rendering
+exactly as it would for the real policy - and the Real-Time Chunking contract is
+preserved end-to-end: the runner-counted ``rtc_observed_delay_steps`` is
+forwarded on every request and applied to the wrapped policy before it blends
+chunk seams server-side.
+
+The connection is established lazily on first use so constructing the policy
+does not require the server to already be up.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+from typing import TYPE_CHECKING, Any
+
+from strands_robots.inference import protocol
+from strands_robots.policies.base import Policy
+
+if TYPE_CHECKING:
+    from websockets.sync.client import ClientConnection
+
+logger = logging.getLogger(__name__)
+
+#: Default request/receive timeout (seconds). A remote VLA can take a while, so
+#: this is generous; override via the ``request_timeout`` kwarg.
+DEFAULT_REQUEST_TIMEOUT = 60.0
+DEFAULT_CONNECT_TIMEOUT = 10.0
+
+
+class RemotePolicy(Policy):
+    """Client-side policy that runs inference on a remote :class:`PolicyServer`.
+
+    Args:
+        endpoint: Full server URL, e.g. ``ws://gpu-box:8765``. When given it
+            takes precedence over ``host``/``port``.
+        host: Server host (used when ``endpoint`` is not given).
+        port: Server port (used when ``endpoint`` is not given).
+        connect_timeout: Seconds to wait for the WebSocket handshake.
+        request_timeout: Seconds to wait for a reply to each request.
+
+    Raises:
+        ConnectionError: On first use, if the server cannot be reached.
+    """
+
+    def __init__(
+        self,
+        endpoint: str | None = None,
+        *,
+        host: str = "127.0.0.1",
+        port: int = 8765,
+        connect_timeout: float = DEFAULT_CONNECT_TIMEOUT,
+        request_timeout: float = DEFAULT_REQUEST_TIMEOUT,
+        **_ignored: Any,
+    ) -> None:
+        self.uri = endpoint if endpoint else f"ws://{host}:{port}"
+        if not self.uri.startswith(("ws://", "wss://")):
+            self.uri = f"ws://{self.uri}"
+        self.connect_timeout = connect_timeout
+        self.request_timeout = request_timeout
+
+        self._ws: ClientConnection | None = None
+        self._lock = threading.Lock()
+
+        # Config that may be set before the connection exists; flushed on connect.
+        self._robot_state_keys: list[str] = []
+        self._reset_pending: bool = False
+        self._reset_seed: int | None = None
+
+        # Mirrored server metadata (defaults until the ``ready`` handshake).
+        self._remote_provider_name: str = "unknown"
+        self._requires_images: bool = True
+        self._execution_horizon: int = 1
+        self.actions_per_step: int = 1
+        self.supports_rtc: bool = False
+
+    # -- connection lifecycle -------------------------------------------------
+
+    def _connect(self) -> None:
+        """Open the WebSocket, read the handshake, and flush pending config."""
+        from websockets.sync.client import connect
+
+        try:
+            self._ws = connect(
+                self.uri,
+                open_timeout=self.connect_timeout,
+                max_size=None,
+                compression=None,
+            )
+        except (OSError, TimeoutError) as exc:
+            raise ConnectionError(
+                f"RemotePolicy could not reach a PolicyServer at {self.uri}. "
+                f"Start one first, e.g.:\n"
+                f"  python -m strands_robots.inference.server --provider <name> "
+                f"--host 0.0.0.0 --port {self.uri.rsplit(':', 1)[-1]}\n"
+                f"Underlying error: {type(exc).__name__}: {exc}"
+            ) from exc
+
+        ready = protocol.loads(self._ws.recv(timeout=self.connect_timeout))
+        if ready.get("type") != protocol.MSG_READY:
+            raise ConnectionError(f"expected a '{protocol.MSG_READY}' handshake, got {ready.get('type')!r}")
+        server_version = ready.get("protocol_version")
+        if server_version != protocol.PROTOCOL_VERSION:
+            raise ConnectionError(
+                f"protocol version mismatch: client speaks {protocol.PROTOCOL_VERSION}, "
+                f"server speaks {server_version}. Upgrade the older peer."
+            )
+        self._apply_metadata(ready.get("metadata", {}))
+        logger.info("RemotePolicy connected to %s (remote provider=%s)", self.uri, self._remote_provider_name)
+
+        # Replay config that was set before the connection existed.
+        if self._robot_state_keys:
+            self._request({"type": protocol.MSG_SET_STATE_KEYS, "keys": self._robot_state_keys})
+        if self.control_frequency is not None:
+            self._request({"type": protocol.MSG_SET_CONTROL_FREQUENCY, "hz": self.control_frequency})
+        if self._reset_pending:
+            reply = self._request({"type": protocol.MSG_RESET, "seed": self._reset_seed})
+            self._apply_metadata(reply.get("metadata", {}))
+            self._reset_pending = False
+
+    def _ensure_connected(self) -> None:
+        if self._ws is None:
+            self._connect()
+
+    def _apply_metadata(self, metadata: dict[str, Any]) -> None:
+        """Mirror the server policy's introspection metadata locally."""
+        if not metadata:
+            return
+        self._remote_provider_name = metadata.get("provider_name", self._remote_provider_name)
+        self._requires_images = bool(metadata.get("requires_images", self._requires_images))
+        self.actions_per_step = int(metadata.get("actions_per_step", self.actions_per_step))
+        self.supports_rtc = bool(metadata.get("supports_rtc", self.supports_rtc))
+        self._execution_horizon = int(metadata.get("execution_horizon", self._execution_horizon))
+
+    def close(self) -> None:
+        """Close the WebSocket connection. Safe to call more than once."""
+        with self._lock:
+            if self._ws is not None:
+                try:
+                    self._ws.close()
+                finally:
+                    self._ws = None
+
+    # -- wire helpers (call while holding ``self._lock``) ---------------------
+
+    def _request(self, message: dict[str, Any]) -> dict[str, Any]:
+        """Send a message and return the decoded reply, raising on server error."""
+        assert self._ws is not None  # noqa: S101 - guarded by _ensure_connected
+        self._ws.send(protocol.dumps(message))
+        reply = protocol.loads(self._ws.recv(timeout=self.request_timeout))
+        if reply.get("type") == protocol.MSG_ERROR:
+            detail = reply.get("traceback") or reply.get("error", "unknown error")
+            raise RuntimeError(f"remote policy server error:\n{detail}")
+        return reply
+
+    # -- Policy ABC -----------------------------------------------------------
+
+    @property
+    def provider_name(self) -> str:
+        return "remote"
+
+    @property
+    def remote_provider_name(self) -> str:
+        """Provider name of the policy running on the server (for identification)."""
+        return self._remote_provider_name
+
+    @property
+    def requires_images(self) -> bool:
+        """Mirror the server policy: skip camera rendering when it does not need frames."""
+        self._ensure_connected()
+        return self._requires_images
+
+    @property
+    def execution_horizon(self) -> int:
+        """Mirror the server policy's re-query interval so RTC/chunking stays correct."""
+        self._ensure_connected()
+        return max(1, self._execution_horizon)
+
+    def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
+        self._robot_state_keys = list(robot_state_keys)
+        with self._lock:
+            if self._ws is not None:
+                self._request({"type": protocol.MSG_SET_STATE_KEYS, "keys": self._robot_state_keys})
+
+    def set_control_frequency(self, hz: float) -> None:
+        super().set_control_frequency(hz)  # validates hz > 0 and sets the attribute
+        with self._lock:
+            if self._ws is not None:
+                self._request({"type": protocol.MSG_SET_CONTROL_FREQUENCY, "hz": self.control_frequency})
+
+    def reset(self, seed: int | None = None) -> None:
+        """Forward the per-episode reset to the server policy.
+
+        Without this, seeding only the client leaves the server's per-episode
+        state (diffusion RNG, RTC chunk seams) drifting across episodes and
+        breaks reproducibility - the same failure mode as a local service-mode
+        policy that does not forward ``reset``.
+        """
+        with self._lock:
+            if self._ws is None:
+                self._reset_pending = True
+                self._reset_seed = seed
+                return
+            reply = self._request({"type": protocol.MSG_RESET, "seed": seed})
+            self._apply_metadata(reply.get("metadata", {}))
+
+    async def get_actions(
+        self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any
+    ) -> list[dict[str, Any]]:
+        """Forward the observation to the server and return the action chunk.
+
+        The blocking WebSocket round-trip runs in a worker thread so this
+        coroutine does not stall the event loop.
+        """
+        return await asyncio.to_thread(self._get_actions_blocking, observation_dict, instruction, kwargs)
+
+    def _get_actions_blocking(
+        self, observation_dict: dict[str, Any], instruction: str, kwargs: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        self._ensure_connected()
+        with self._lock:
+            reply = self._request(
+                {
+                    "type": protocol.MSG_GET_ACTIONS,
+                    "observation": observation_dict,
+                    "instruction": instruction,
+                    # Forwarded so the server applies the runner-counted RTC
+                    # delay before inference - deterministic chunk seams across
+                    # the wire (see Policy.set_rtc_observed_delay).
+                    "rtc_observed_delay_steps": self.rtc_observed_delay_steps,
+                    "kwargs": kwargs,
+                }
+            )
+        actions = reply.get("actions", [])
+        if not isinstance(actions, list):
+            raise RuntimeError(f"server returned a non-list action chunk: {type(actions).__name__}")
+        return actions

--- a/strands_robots/inference/protocol.py
+++ b/strands_robots/inference/protocol.py
@@ -1,0 +1,151 @@
+"""WS-JSON wire protocol for remote policy inference.
+
+This module defines the message schema and the (de)serialization helpers used
+by :class:`~strands_robots.inference.server.PolicyServer` and
+:class:`~strands_robots.inference.client.RemotePolicy` to stream observations
+to a remote inference host and receive action chunks back.
+
+The transport is deliberately plain JSON over a WebSocket: it is trivially
+portable (any language with a JSON + WebSocket client can drive the server) and
+has no NumPy-version constraints, so a remote rollout composes cleanly with
+``lerobot`` (``numpy>=2``) in the same environment. NumPy arrays that cannot be
+represented natively in JSON (camera frames, the state vector) are wrapped in a
+tagged envelope carrying the base64 raw buffer plus ``dtype`` and ``shape`` so
+they round-trip byte-exact. Action chunks returned by a policy are already
+JSON-native (``dict[str, float | list[float]]`` per the
+:meth:`~strands_robots.policies.base.Policy.get_actions` contract) and pass
+through untouched.
+
+Message types (each message is one JSON object with a ``type`` field):
+
+* ``ready`` (server -> client, once on connect): advertises the wrapped
+  policy's introspection metadata so the client can mirror it. Payload key
+  ``metadata`` -> ``provider_name``, ``requires_images``, ``actions_per_step``,
+  ``supports_rtc``, ``execution_horizon``.
+* ``set_state_keys`` (client -> server): forwards
+  :meth:`Policy.set_robot_state_keys`. Payload key ``keys``.
+* ``set_control_frequency`` (client -> server): forwards
+  :meth:`Policy.set_control_frequency`. Payload key ``hz``.
+* ``reset`` (client -> server): forwards :meth:`Policy.reset`. Payload key
+  ``seed`` (int or null).
+* ``get_actions`` (client -> server): one inference request. Payload keys
+  ``observation`` (encoded), ``instruction``, ``rtc_observed_delay_steps``
+  (int or null, applied server-side before inference to preserve the
+  Real-Time Chunking contract across the wire) and ``kwargs``.
+* ``actions`` (server -> client): the response to ``get_actions``. Payload key
+  ``actions`` (a JSON list of action dicts).
+* ``ok`` (server -> client): acknowledges a control message.
+* ``error`` (server -> client): a failure. Payload keys ``error`` and
+  optional ``traceback``. The client raises rather than silently substituting
+  a zero action.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any
+
+import numpy as np
+
+#: Wire-protocol version. Bumped on any breaking change to the message schema.
+#: The server advertises it in the ``ready`` handshake and the client refuses a
+#: mismatch rather than mis-decoding a newer/older peer.
+PROTOCOL_VERSION = 1
+
+# Message-type tags.
+MSG_READY = "ready"
+MSG_SET_STATE_KEYS = "set_state_keys"
+MSG_SET_CONTROL_FREQUENCY = "set_control_frequency"
+MSG_RESET = "reset"
+MSG_GET_ACTIONS = "get_actions"
+MSG_ACTIONS = "actions"
+MSG_OK = "ok"
+MSG_ERROR = "error"
+
+#: Envelope key marking a base64-encoded NumPy array in the JSON payload.
+_NDARRAY_TAG = "__ndarray__"
+
+
+def encode_ndarray(arr: np.ndarray) -> dict[str, Any]:
+    """Wrap a NumPy array in a JSON-safe, byte-exact envelope.
+
+    Args:
+        arr: Array to encode. Copied to C-contiguous layout so the raw buffer
+            matches the declared ``shape``/``dtype`` on decode.
+
+    Returns:
+        A dict with the base64 raw buffer plus ``dtype`` and ``shape``.
+    """
+    contiguous = np.ascontiguousarray(arr)
+    return {
+        _NDARRAY_TAG: base64.b64encode(contiguous.tobytes()).decode("ascii"),
+        "dtype": str(contiguous.dtype),
+        "shape": list(contiguous.shape),
+    }
+
+
+def decode_ndarray(envelope: dict[str, Any]) -> np.ndarray:
+    """Reconstruct a NumPy array from an :func:`encode_ndarray` envelope.
+
+    Args:
+        envelope: A dict produced by :func:`encode_ndarray`.
+
+    Returns:
+        The reconstructed array with the original ``dtype`` and ``shape``.
+    """
+    raw = base64.b64decode(envelope[_NDARRAY_TAG])
+    dtype = np.dtype(envelope["dtype"])
+    array = np.frombuffer(raw, dtype=dtype)
+    return array.reshape(envelope["shape"])
+
+
+def _encode(obj: Any) -> Any:
+    """Recursively convert an object graph into a JSON-serializable form.
+
+    NumPy arrays become tagged envelopes; NumPy scalars become python scalars;
+    dicts/lists are walked; everything else passes through unchanged.
+    """
+    if isinstance(obj, np.ndarray):
+        return encode_ndarray(obj)
+    if isinstance(obj, np.generic):
+        return obj.item()
+    if isinstance(obj, dict):
+        return {key: _encode(value) for key, value in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_encode(value) for value in obj]
+    return obj
+
+
+def _decode(obj: Any) -> Any:
+    """Inverse of :func:`_encode`: rebuild NumPy arrays from tagged envelopes."""
+    if isinstance(obj, dict):
+        if _NDARRAY_TAG in obj:
+            return decode_ndarray(obj)
+        return {key: _decode(value) for key, value in obj.items()}
+    if isinstance(obj, list):
+        return [_decode(value) for value in obj]
+    return obj
+
+
+def dumps(message: dict[str, Any]) -> str:
+    """Serialize a protocol message (with embedded NumPy arrays) to a JSON string."""
+    return json.dumps(_encode(message))
+
+
+def loads(text: str | bytes) -> dict[str, Any]:
+    """Parse a protocol message JSON string, rebuilding embedded NumPy arrays.
+
+    Args:
+        text: The raw WebSocket frame (``str`` or ``bytes``).
+
+    Returns:
+        The decoded message dict.
+
+    Raises:
+        ValueError: If the frame is not a JSON object.
+    """
+    decoded = _decode(json.loads(text))
+    if not isinstance(decoded, dict):
+        raise ValueError(f"protocol message must be a JSON object, got {type(decoded).__name__}")
+    return decoded

--- a/strands_robots/inference/server.py
+++ b/strands_robots/inference/server.py
@@ -1,0 +1,266 @@
+"""Remote policy inference server (host side, typically a GPU box).
+
+:class:`PolicyServer` wraps ANY :class:`~strands_robots.policies.base.Policy`
+and exposes it over a WebSocket so a resource-constrained robot host can stream
+observations in and receive action chunks back - the client/server split that
+lets an edge device drive a big VLA (pi0 / SmolVLA / MolmoAct2) running on
+remote GPU at control rate.
+
+Usage::
+
+    from strands_robots.inference import PolicyServer
+
+    # Wrap a provider by name (built via create_policy on the server):
+    PolicyServer(policy_provider="lerobot/act_so101", host="0.0.0.0").serve()
+
+    # Or wrap an already-loaded policy object:
+    PolicyServer(policy=my_policy, port=8765).serve()
+
+The server binds ``127.0.0.1`` by default; set ``host="0.0.0.0"`` explicitly to
+accept connections from other machines (wrap the link in tailscale/wireguard for
+production - transport auth/TLS is intentionally out of scope for v1).
+
+Concurrency: v1 serves ONE client at a time. The wrapped policy holds
+per-episode state (RTC chunk seams, diffusion RNG), so concurrent clients would
+corrupt each other; an internal lock serializes inference across connections.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import traceback
+from typing import TYPE_CHECKING, Any
+
+from strands_robots.inference import protocol
+from strands_robots.policies.base import Policy
+
+if TYPE_CHECKING:
+    from websockets.sync.server import Server, ServerConnection
+
+logger = logging.getLogger(__name__)
+
+
+class PolicyServer:
+    """Serve a :class:`Policy` over a WebSocket for remote inference.
+
+    Args:
+        policy: A pre-built policy to serve. Mutually exclusive with
+            ``policy_provider``.
+        policy_provider: Provider name or smart string built server-side via
+            :func:`~strands_robots.policies.create_policy`. Mutually exclusive
+            with ``policy``.
+        policy_config: Extra kwargs forwarded to ``create_policy`` when
+            ``policy_provider`` is used.
+        host: Bind address. Defaults to ``127.0.0.1`` (loopback only); use
+            ``0.0.0.0`` to accept remote connections.
+        port: Bind port. ``0`` asks the OS for a free port (read back from
+            :attr:`port` after :meth:`start`).
+
+    Raises:
+        ValueError: If neither or both of ``policy`` / ``policy_provider`` are
+            given.
+    """
+
+    def __init__(
+        self,
+        policy: Policy | None = None,
+        *,
+        policy_provider: str | None = None,
+        policy_config: dict[str, Any] | None = None,
+        host: str = "127.0.0.1",
+        port: int = 8765,
+    ) -> None:
+        if (policy is None) == (policy_provider is None):
+            raise ValueError("provide exactly one of 'policy' or 'policy_provider'")
+
+        if policy is None:
+            from strands_robots.policies import create_policy
+
+            # Guaranteed by the exactly-one check above (policy is None here
+            # implies policy_provider is not None); assert so mypy narrows.
+            assert policy_provider is not None
+            policy = create_policy(policy_provider, **(policy_config or {}))
+
+        self.policy: Policy = policy
+        self.host = host
+        self.port = port
+        self._server: Server | None = None
+        self._thread: threading.Thread | None = None
+        # Serialize inference so per-episode policy state is never interleaved
+        # across connections (v1 single-client contract).
+        self._lock = threading.Lock()
+
+    def _metadata(self) -> dict[str, Any]:
+        """Introspection payload advertised in the ``ready`` handshake."""
+        return {
+            "provider_name": self.policy.provider_name,
+            "requires_images": bool(self.policy.requires_images),
+            "actions_per_step": int(getattr(self.policy, "actions_per_step", 1)),
+            "supports_rtc": bool(getattr(self.policy, "supports_rtc", False)),
+            "execution_horizon": int(self.policy.execution_horizon),
+        }
+
+    def _handle(self, websocket: ServerConnection) -> None:
+        """Serve one client connection: handshake, then dispatch each message."""
+        peer = getattr(websocket, "remote_address", None)
+        logger.info("PolicyServer: client connected %s", peer)
+        websocket.send(
+            protocol.dumps(
+                {
+                    "type": protocol.MSG_READY,
+                    "protocol_version": protocol.PROTOCOL_VERSION,
+                    "metadata": self._metadata(),
+                }
+            )
+        )
+        for raw in websocket:
+            try:
+                message = protocol.loads(raw)
+                reply = self._dispatch(message)
+            except Exception as exc:  # noqa: BLE001 - marshal ANY failure back to the client
+                logger.exception("PolicyServer: error handling message")
+                reply = {
+                    "type": protocol.MSG_ERROR,
+                    "error": f"{type(exc).__name__}: {exc}",
+                    "traceback": traceback.format_exc(),
+                }
+            websocket.send(protocol.dumps(reply))
+        logger.info("PolicyServer: client disconnected %s", peer)
+
+    def _dispatch(self, message: dict[str, Any]) -> dict[str, Any]:
+        """Route one decoded message to the wrapped policy and build the reply.
+
+        Raises:
+            ValueError: On an unknown message type.
+        """
+        msg_type = message.get("type")
+
+        if msg_type == protocol.MSG_GET_ACTIONS:
+            with self._lock:
+                # Preserve the Real-Time Chunking contract across the wire: the
+                # runner-supplied step count is applied to the wrapped policy
+                # BEFORE inference, exactly as a local runner would.
+                self.policy.set_rtc_observed_delay(message.get("rtc_observed_delay_steps"))
+                actions = self.policy.get_actions_sync(
+                    message.get("observation", {}),
+                    message.get("instruction", ""),
+                    **(message.get("kwargs") or {}),
+                )
+            return {"type": protocol.MSG_ACTIONS, "actions": actions}
+
+        if msg_type == protocol.MSG_SET_STATE_KEYS:
+            with self._lock:
+                self.policy.set_robot_state_keys(list(message.get("keys", [])))
+            return {"type": protocol.MSG_OK}
+
+        if msg_type == protocol.MSG_SET_CONTROL_FREQUENCY:
+            with self._lock:
+                self.policy.set_control_frequency(float(message["hz"]))
+            return {"type": protocol.MSG_OK}
+
+        if msg_type == protocol.MSG_RESET:
+            with self._lock:
+                self.policy.reset(seed=message.get("seed"))
+            # Metadata (e.g. execution_horizon) can only firm up after the
+            # first reset for some providers; re-advertise so the client stays
+            # in sync without reconnecting.
+            return {"type": protocol.MSG_OK, "metadata": self._metadata()}
+
+        raise ValueError(f"unknown message type: {msg_type!r}")
+
+    def start(self) -> PolicyServer:
+        """Start serving in a background thread and return once bound.
+
+        After this returns, :attr:`port` holds the actual bound port (useful
+        when constructed with ``port=0``). Idempotent per instance: calling it
+        twice raises.
+
+        Returns:
+            ``self``, so callers can chain ``PolicyServer(...).start()``.
+
+        Raises:
+            RuntimeError: If the server is already running.
+        """
+        if self._server is not None:
+            raise RuntimeError("PolicyServer is already running")
+
+        from websockets.sync.server import serve
+
+        self._server = serve(self._handle, self.host, self.port)
+        # Read back the OS-assigned port when the caller passed 0.
+        self.port = self._server.socket.getsockname()[1]
+        self._thread = threading.Thread(
+            target=self._server.serve_forever,
+            name=f"policy-server-{self.port}",
+            daemon=True,
+        )
+        self._thread.start()
+        logger.info("PolicyServer serving on ws://%s:%d", self.host, self.port)
+        return self
+
+    def stop(self) -> None:
+        """Stop the background server and join its thread. Safe to call twice."""
+        if self._server is not None:
+            self._server.shutdown()
+            self._server = None
+        if self._thread is not None:
+            self._thread.join(timeout=5.0)
+            self._thread = None
+
+    def serve(self) -> None:
+        """Serve in the foreground (blocking) until interrupted.
+
+        Convenience entry point for a standalone server process. Blocks the
+        calling thread; use :meth:`start`/:meth:`stop` for programmatic control.
+        """
+        from websockets.sync.server import serve
+
+        with serve(self._handle, self.host, self.port) as server:
+            self._server = server
+            self.port = server.socket.getsockname()[1]
+            logger.info("PolicyServer serving on ws://%s:%d", self.host, self.port)
+            try:
+                server.serve_forever()
+            finally:
+                self._server = None
+
+    def __enter__(self) -> PolicyServer:
+        return self.start()
+
+    def __exit__(self, *exc: object) -> None:
+        self.stop()
+
+
+def main(argv: list[str] | None = None) -> None:
+    """CLI: serve a policy provider over a WebSocket.
+
+    Example::
+
+        python -m strands_robots.inference.server \\
+            --provider lerobot/act_so101 --host 0.0.0.0 --port 8765
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="strands_robots.inference.server",
+        description="Serve a strands-robots policy for remote inference over WebSocket.",
+    )
+    parser.add_argument(
+        "--provider",
+        required=True,
+        help="Policy provider name or smart string (e.g. 'mock', 'lerobot/act_so101').",
+    )
+    parser.add_argument("--host", default="127.0.0.1", help="Bind address (default: 127.0.0.1).")
+    parser.add_argument("--port", type=int, default=8765, help="Bind port (default: 8765).")
+    args = parser.parse_args(argv)
+
+    if not 1 <= args.port <= 65535:
+        parser.error(f"--port must be between 1 and 65535, got {args.port}")
+
+    logging.basicConfig(level=logging.INFO)
+    PolicyServer(policy_provider=args.provider, host=args.host, port=args.port).serve()
+
+
+if __name__ == "__main__":
+    main()

--- a/strands_robots/registry/policies.json
+++ b/strands_robots/registry/policies.json
@@ -272,6 +272,26 @@
         "motionbricks",
         "motion_bricks"
       ]
+    },
+    "remote": {
+      "module": "strands_robots.inference.client",
+      "class": "RemotePolicy",
+      "description": "Remote inference over WebSocket (WS-JSON) - forwards observations to a PolicyServer and returns action chunks",
+      "requires": [],
+      "config_keys": [
+        "endpoint",
+        "host",
+        "port",
+        "connect_timeout",
+        "request_timeout"
+      ],
+      "defaults": {},
+      "shorthands": [
+        "remote"
+      ],
+      "url_patterns": [
+        "^wss?://"
+      ]
     }
   }
 }

--- a/strands_robots/registry/policies.py
+++ b/strands_robots/registry/policies.py
@@ -89,7 +89,11 @@ def resolve_policy(policy: str, **extra_kwargs) -> tuple[str, dict[str, Any]]:
         for pattern in prov_info.get("url_patterns", []):
             if re.match(pattern, policy):
                 if pattern.startswith("^wss?://"):
-                    match = re.match(r"wss?://([^:]+):?(\d+)?", policy)
+                    # Pass the full URL through as ``endpoint`` so the scheme
+                    # (ws:// vs wss://) and any path survive; also split out
+                    # host/port for providers that consume them directly.
+                    kwargs["endpoint"] = policy
+                    match = re.match(r"wss?://([^:/]+):?(\d+)?", policy)
                     if match:
                         kwargs["host"] = match.group(1)
                         kwargs["port"] = int(match.group(2) or 8000)

--- a/tests/inference/__init__.py
+++ b/tests/inference/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the remote policy inference client/server split."""

--- a/tests/inference/test_protocol.py
+++ b/tests/inference/test_protocol.py
@@ -1,0 +1,62 @@
+"""WS-JSON wire protocol codec tests.
+
+Verify that observations containing NumPy arrays round-trip byte-exact through
+the JSON transport and that malformed frames are rejected loudly.
+"""
+
+import numpy as np
+import pytest
+
+from strands_robots.inference import protocol
+
+
+def test_ndarray_roundtrip_is_byte_exact():
+    arr = np.arange(24, dtype=np.float32).reshape(2, 3, 4)
+    restored = protocol.decode_ndarray(protocol.encode_ndarray(arr))
+    assert restored.dtype == arr.dtype
+    assert restored.shape == arr.shape
+    np.testing.assert_array_equal(restored, arr)
+
+
+def test_uint8_image_roundtrip():
+    image = np.random.randint(0, 256, size=(48, 64, 3), dtype=np.uint8)
+    restored = protocol.decode_ndarray(protocol.encode_ndarray(image))
+    assert restored.dtype == np.uint8
+    np.testing.assert_array_equal(restored, image)
+
+
+def test_observation_message_roundtrip_preserves_arrays_and_scalars():
+    obs = {
+        "observation.state": np.array([0.1, 0.2, 0.3], dtype=np.float64),
+        "observation.images.top": np.zeros((8, 8, 3), dtype=np.uint8),
+        "step": 5,
+        "instruction": "pick the cube",
+    }
+    message = {"type": protocol.MSG_GET_ACTIONS, "observation": obs, "instruction": "pick"}
+    decoded = protocol.loads(protocol.dumps(message))
+
+    assert decoded["type"] == protocol.MSG_GET_ACTIONS
+    assert decoded["instruction"] == "pick"
+    decoded_obs = decoded["observation"]
+    np.testing.assert_array_equal(decoded_obs["observation.state"], obs["observation.state"])
+    np.testing.assert_array_equal(decoded_obs["observation.images.top"], obs["observation.images.top"])
+    assert decoded_obs["step"] == 5
+    assert decoded_obs["instruction"] == "pick the cube"
+
+
+def test_action_chunk_passes_through_untouched():
+    # Action chunks are already JSON-native (dict[str, float | list[float]]).
+    actions = [{"joint_0": 0.5, "gripper": [0.1, 0.2]}, {"joint_0": 0.6, "gripper": [0.15, 0.25]}]
+    decoded = protocol.loads(protocol.dumps({"type": protocol.MSG_ACTIONS, "actions": actions}))
+    assert decoded["actions"] == actions
+
+
+def test_numpy_scalar_becomes_python_scalar():
+    decoded = protocol.loads(protocol.dumps({"type": protocol.MSG_OK, "value": np.float32(1.5)}))
+    assert decoded["value"] == 1.5
+    assert isinstance(decoded["value"], float)
+
+
+def test_loads_rejects_non_object_frame():
+    with pytest.raises(ValueError, match="must be a JSON object"):
+        protocol.loads("[1, 2, 3]")

--- a/tests/inference/test_remote_policy_roundtrip.py
+++ b/tests/inference/test_remote_policy_roundtrip.py
@@ -1,0 +1,207 @@
+"""End-to-end client/server tests for remote policy inference.
+
+A :class:`PolicyServer` wrapping a recording policy runs in a background
+thread; a :class:`RemotePolicy` client drives it over a real loopback
+WebSocket. These assert the observable contract - metadata mirroring, the
+observation->chunk round-trip, config/reset/RTC forwarding, and loud error
+propagation - not internal state.
+"""
+
+import socket
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.inference import PolicyServer, RemotePolicy
+from strands_robots.policies import create_policy
+from strands_robots.policies.base import Policy
+
+
+class RecordingPolicy(Policy):
+    """Chunk-emitting RTC policy that records everything the server forwards it."""
+
+    def __init__(self, *, fail: bool = False) -> None:
+        self.actions_per_step = 8
+        self.supports_rtc = True
+        self.robot_state_keys: list[str] = ["j0", "j1", "j2"]
+        self.reset_seeds: list[int | None] = []
+        self.seen_rtc_delays: list[int | None] = []
+        self.seen_instructions: list[str] = []
+        self.seen_kwargs: list[dict[str, Any]] = []
+        self._fail = fail
+
+    @property
+    def provider_name(self) -> str:
+        return "recording"
+
+    @property
+    def requires_images(self) -> bool:
+        return False
+
+    @property
+    def execution_horizon(self) -> int:
+        # RTC re-query interval, deliberately smaller than the trained chunk.
+        return 4
+
+    def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
+        self.robot_state_keys = list(robot_state_keys)
+
+    def reset(self, seed: int | None = None) -> None:
+        self.reset_seeds.append(seed)
+
+    async def get_actions(
+        self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any
+    ) -> list[dict[str, Any]]:
+        if self._fail:
+            raise RuntimeError("boom: deliberate inference failure")
+        # Record what the server handed us (RTC delay is set on the instance
+        # by the server immediately before this call).
+        self.seen_rtc_delays.append(self.rtc_observed_delay_steps)
+        self.seen_instructions.append(instruction)
+        self.seen_kwargs.append(dict(kwargs))
+        state = observation_dict.get("observation.state", [0.0] * len(self.robot_state_keys))
+        base = float(np.asarray(state).sum())
+        return [{key: base + i * 0.01 for key in self.robot_state_keys} for i in range(self.actions_per_step)]
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+@pytest.fixture
+def served_recording():
+    """Yield ``(server, policy, RemotePolicy)`` over a live loopback WebSocket."""
+    policy = RecordingPolicy()
+    server = PolicyServer(policy=policy, host="127.0.0.1", port=0).start()
+    client = RemotePolicy(endpoint=f"ws://127.0.0.1:{server.port}")
+    # Trigger the lazy connect + handshake so the config-forwarding tests below
+    # exercise the live path (pre-connect buffering is covered separately by
+    # test_config_set_before_connect_is_replayed_on_connect).
+    assert client.requires_images is False
+    try:
+        yield server, policy, client
+    finally:
+        client.close()
+        server.stop()
+
+
+def test_client_mirrors_server_metadata(served_recording):
+    _server, _policy, client = served_recording
+    # Accessing an introspection property triggers the lazy connect + handshake.
+    assert client.requires_images is False
+    assert client.execution_horizon == 4
+    assert client.actions_per_step == 8
+    assert client.supports_rtc is True
+    assert client.provider_name == "remote"
+    assert client.remote_provider_name == "recording"
+
+
+def test_observation_to_chunk_roundtrip(served_recording):
+    _server, policy, client = served_recording
+    client.set_robot_state_keys(["j0", "j1", "j2"])
+    obs = {"observation.state": np.array([1.0, 2.0, 3.0], dtype=np.float32)}
+    chunk = client.get_actions_sync(obs, "pick the red cube")
+
+    assert len(chunk) == policy.actions_per_step
+    assert set(chunk[0].keys()) == {"j0", "j1", "j2"}
+    # base == sum(state) == 6.0, first action offset 0.0
+    assert chunk[0]["j0"] == pytest.approx(6.0)
+    assert policy.seen_instructions[-1] == "pick the red cube"
+
+
+def test_set_robot_state_keys_forwarded(served_recording):
+    _server, policy, client = served_recording
+    client.set_robot_state_keys(["a", "b"])
+    assert policy.robot_state_keys == ["a", "b"]
+
+
+def test_set_control_frequency_forwarded_and_validated(served_recording):
+    _server, policy, client = served_recording
+    client.set_control_frequency(50.0)
+    assert policy.control_frequency == 50.0
+    with pytest.raises(ValueError, match="must be positive"):
+        client.set_control_frequency(0.0)
+
+
+def test_reset_forwarded_to_server_policy(served_recording):
+    _server, policy, client = served_recording
+    client.reset(seed=123)
+    assert policy.reset_seeds[-1] == 123
+
+
+def test_rtc_observed_delay_forwarded_per_request(served_recording):
+    """The runner-counted RTC delay must reach the server policy each request."""
+    _server, policy, client = served_recording
+    client.set_rtc_observed_delay(3)
+    client.get_actions_sync({"observation.state": [0.0, 0.0, 0.0]}, "")
+    assert policy.seen_rtc_delays[-1] == 3
+
+    client.set_rtc_observed_delay(None)
+    client.get_actions_sync({"observation.state": [0.0, 0.0, 0.0]}, "")
+    assert policy.seen_rtc_delays[-1] is None
+
+
+def test_extra_kwargs_forwarded(served_recording):
+    _server, policy, client = served_recording
+    client.get_actions_sync({"observation.state": [0.0, 0.0, 0.0]}, "", target_joints={"j0": 0.5})
+    assert policy.seen_kwargs[-1] == {"target_joints": {"j0": 0.5}}
+
+
+def test_server_error_propagates_to_client():
+    policy = RecordingPolicy(fail=True)
+    server = PolicyServer(policy=policy, host="127.0.0.1", port=0).start()
+    client = RemotePolicy(endpoint=f"ws://127.0.0.1:{server.port}")
+    try:
+        with pytest.raises(RuntimeError, match="deliberate inference failure"):
+            client.get_actions_sync({"observation.state": [0.0]}, "")
+    finally:
+        client.close()
+        server.stop()
+
+
+def test_config_set_before_connect_is_replayed_on_connect():
+    """State keys / control freq / reset set pre-connection must reach the server."""
+    policy = RecordingPolicy()
+    server = PolicyServer(policy=policy, host="127.0.0.1", port=0).start()
+    client = RemotePolicy(endpoint=f"ws://127.0.0.1:{server.port}")
+    try:
+        # No network yet: these are buffered client-side.
+        client.set_robot_state_keys(["x", "y"])
+        client.set_control_frequency(30.0)
+        client.reset(seed=7)
+        # First inference triggers connect, which must flush the buffered config.
+        client.get_actions_sync({"observation.state": [1.0, 1.0]}, "")
+        assert policy.robot_state_keys == ["x", "y"]
+        assert policy.control_frequency == 30.0
+        assert policy.reset_seeds[-1] == 7
+    finally:
+        client.close()
+        server.stop()
+
+
+def test_unreachable_server_raises_actionable_connection_error():
+    client = RemotePolicy(endpoint=f"ws://127.0.0.1:{_free_port()}", connect_timeout=1.0)
+    with pytest.raises(ConnectionError, match="could not reach a PolicyServer"):
+        client.get_actions_sync({"observation.state": [0.0]}, "")
+
+
+def test_create_policy_smart_string_builds_remote_policy():
+    policy = create_policy("ws://gpu-box:8765")
+    assert isinstance(policy, RemotePolicy)
+    assert policy.uri == "ws://gpu-box:8765"
+
+
+def test_create_policy_named_remote_provider_with_endpoint():
+    policy = create_policy("remote", endpoint="wss://secure-box:9000")
+    assert isinstance(policy, RemotePolicy)
+    assert policy.uri == "wss://secure-box:9000"
+
+
+def test_policy_server_requires_exactly_one_policy_source():
+    with pytest.raises(ValueError, match="exactly one"):
+        PolicyServer()
+    with pytest.raises(ValueError, match="exactly one"):
+        PolicyServer(policy=RecordingPolicy(), policy_provider="mock")

--- a/tests/inference/test_remote_policy_sim_rollout.py
+++ b/tests/inference/test_remote_policy_sim_rollout.py
@@ -1,0 +1,38 @@
+"""Integration test: drive a MuJoCo rollout through a remote PolicyServer.
+
+A :class:`PolicyServer` wrapping a :class:`MockPolicy` runs in one thread; the
+simulation resolves ``policy_provider="ws://..."`` to a :class:`RemotePolicy`
+and streams observations to it, executing the returned chunks. This exercises
+the full client/server path end to end (the same path a real edge robot +
+remote GPU would take), just with a cheap policy so it stays in the fast suite.
+"""
+
+import pytest
+
+from strands_robots.inference import PolicyServer
+from strands_robots.policies.mock import MockPolicy
+
+pytest.importorskip("mujoco", reason="sim rollout requires mujoco - pip install 'strands-robots[sim-mujoco]'")
+
+import strands_robots as sr  # noqa: E402
+
+
+def test_remote_policy_drives_mujoco_rollout():
+    server = PolicyServer(policy=MockPolicy(), host="127.0.0.1", port=0).start()
+    sim = sr.Robot("so101", mode="sim")
+    try:
+        result = sim.run_policy(
+            policy_provider=f"ws://127.0.0.1:{server.port}",
+            instruction="wave the arm",
+            n_steps=40,
+            control_frequency=30.0,
+        )
+        assert result["status"] == "success", result
+        payload = next(item["json"] for item in result["content"] if "json" in item)
+        assert payload["policy"] == "RemotePolicy"
+        assert payload["n_steps"] == 40
+        assert payload["action_errors"] == 0
+        assert payload["stopped_early"] is False
+    finally:
+        sim.cleanup()
+        server.stop()

--- a/tests/policies/test_factory.py
+++ b/tests/policies/test_factory.py
@@ -72,10 +72,17 @@ class TestCreatePolicy:
         with pytest.raises(Exception):
             create_policy("grpc://localhost:50051")
 
-    def test_create_via_ws_url_triggers_smart_resolution(self):
-        """A ws:// URL should trigger smart-string resolution."""
-        with pytest.raises(Exception):
-            create_policy("ws://localhost:8080")
+    def test_create_via_ws_url_resolves_to_remote_policy(self):
+        """A ws:// URL resolves to the remote-inference provider (RemotePolicy).
+
+        Construction is lazy (the WebSocket connects on first use), so this
+        succeeds without a running server and preserves the full endpoint URL.
+        """
+        from strands_robots.inference import RemotePolicy
+
+        policy = create_policy("ws://localhost:8080")
+        assert isinstance(policy, RemotePolicy)
+        assert policy.uri == "ws://localhost:8080"
 
 
 @pytest.mark.skipif(not _groot_available, reason="groot-service extras not installed")


### PR DESCRIPTION
## Problem

A resource-constrained robot host (an edge device or a laptop CPU) often cannot run a large vision-language-action policy (pi0, SmolVLA, MolmoAct2) at control rate. Today the only options are running the policy locally (fine for a laptop + so101, breaks for edge + big VLAs) or the peer-based zenoh mesh. There is no first-class client/server split where the robot host streams observations to a remote GPU box and receives action chunks back.

## Change

Add `strands_robots/inference/`, a remote policy inference client/server split over a portable WS-JSON WebSocket protocol:

- **`PolicyServer`** wraps ANY `Policy` and serves it (run it on the GPU box). Accepts a pre-built `policy=` or a `policy_provider=` string built server-side via `create_policy`. Binds `127.0.0.1` by default; `start()`/`stop()`/`serve()` plus a `python -m strands_robots.inference.server` CLI. Serializes inference with a lock (v1 is single-client, since the wrapped policy holds per-episode state).
- **`RemotePolicy(Policy)`** is a drop-in policy that forwards observations to the server and returns the action chunk. Lazy-connects on first use. Wired into `create_policy` as the `remote` provider, so it works anywhere a local policy does (`run_policy`, `eval_policy`, hardware loops):

```python
from strands_robots import create_policy
policy = create_policy("remote", endpoint="ws://gpu-box:8765")
policy = create_policy("ws://gpu-box:8765")  # smart string, equivalent
```

### Contract preserved end to end

- The client **mirrors the server policy's introspection metadata** (`requires_images`, `execution_horizon`, `actions_per_step`, `supports_rtc`) from the handshake, so the runtime sizes chunks and skips camera rendering exactly as it would for the real policy.
- **Real-Time Chunking is preserved across the wire**: the runner-counted `rtc_observed_delay_steps` is forwarded on every request and applied to the wrapped policy immediately before inference, so chunk-seam blending runs server-side against the correct deterministic step offset. `reset(seed)` and `set_control_frequency(hz)` are forwarded too, keeping seeded episodes reproducible.
- Server-side inference failures are marshalled back and re-raised on the client as a `RuntimeError` with the server traceback -- never a silent zero action.

### Wire protocol

Plain JSON over a WebSocket (`protocol.py`): trivially portable and numpy-version agnostic, so it composes with `lerobot` (numpy>=2). NumPy arrays (camera frames, state) ride in a base64 tagged envelope with `dtype`/`shape` for byte-exact round-trip; action chunks are already JSON-native and pass through untouched.

### Note on the integration point

`Robot(...)` does not own a policy in this library -- policies are supplied to `run_policy`/`eval_policy` or a hardware control loop, all of which go through `create_policy`. Wiring `remote` into `create_policy` (and the `ws://` smart string) is therefore the single, architecturally-honest seam that makes remote inference available everywhere, rather than adding a `Robot` kwarg that would only cover one call path.

## Tests

- `test_protocol.py`: NumPy codec byte-exact round-trip (arrays, uint8 images, scalars), observation-message round-trip, malformed-frame rejection.
- `test_remote_policy_roundtrip.py`: live loopback client/server -- metadata mirroring, observation->chunk round-trip, `set_robot_state_keys`/`set_control_frequency`/`reset`/RTC-delay/extra-kwargs forwarding, server-error propagation, pre-connect config replay, unreachable-server `ConnectionError`, and `create_policy` resolution (named + smart string).
- `test_remote_policy_sim_rollout.py`: a MuJoCo so101 rollout driven entirely over the wire (150 steps, 0 action errors).

Green locally: `ruff check` / `ruff format --check` clean, `mypy strands_robots/inference` clean, full `tests/inference` + `tests/registry` + factory/base/chunked-contract suites pass (627 tests). New `[inference]` extra (`websockets` only), added to `all`. Docs: `docs/inference/remote.md` (two-machine guide) + `docs/policies/remote.md` provider page, both wired into the nav; CHANGELOG updated.

## Demo

`RemotePolicy` driving an SO-101 in MuJoCo (headless), inference served over a WebSocket by a `PolicyServer` running in a separate thread -- 150 steps, 0 action errors:

![remote inference rollout](https://github.com/cagataycali/robots/releases/download/artifacts-remote-inference/remote_inference.gif)

[MP4](https://github.com/cagataycali/robots/releases/download/artifacts-remote-inference/remote_inference.mp4)

## Non-goals (v1)

- Auth/TLS: transport is plaintext (wrap in tailscale/wireguard/SSH for prod).
- Multi-client fan-out: one client per server.