### PR TITLE
test(policies): guard the lerobot policy resolver covers every registered policy family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,26 @@ is forwarded per request and applied server-side before chunk-seam blending.
 Install with `pip install 'strands-robots[inference]'` (pulls only
 `websockets`). See `docs/inference/remote.md`.
 
+### Added: regression guard that the lerobot policy resolver covers every registered policy family
+
+The `lerobot_local` policy-class resolver enumerates policy types dynamically:
+`_ensure_policy_configs_registered` walks `lerobot.policies` at import time and
+lets each `@PreTrainedConfig.register_subclass("<type>")` decorator populate
+lerobot's draccus choice registry, which `list_policy_types()` reports. This
+means a new policy family a future lerobot release ships is picked up with no
+strands-side edit -- but nothing pinned that the dynamic walk actually reaches
+every registered family, so a future lerobot layout change that made the walk
+under-populate would surface only as a runtime `create_policy(policy_type=...)`
+resolver miss for a user. A new version-agnostic test derives the ground-truth
+set of families directly from the installed lerobot source (the
+`register_subclass` decorator arguments under
+`lerobot/policies/*/configuration_*.py`) and asserts `list_policy_types()`
+covers all of them. It never hard-codes a policy count or name list, so it
+tracks whatever lerobot the environment resolves (currently 19 families in
+lerobot 0.6.x). Verified the resolver already covers the full lerobot 0.6.x
+roster; `rtc` (an inference-time action-chunking wrapper, `RTCProcessor`) is
+correctly excluded because it is not a `PreTrainedPolicy` and registers no
+config.
 
 ### Fixed: session `status` tool results dropped their telemetry via a `**spread` top-level smuggle
 

--- a/tests/policies/lerobot_local/test_resolver_registry_completeness.py
+++ b/tests/policies/lerobot_local/test_resolver_registry_completeness.py
@@ -1,0 +1,114 @@
+"""The dynamic policy resolver enumerates every policy family lerobot ships.
+
+``strands_robots.policies.lerobot_local.resolution`` does not hard-code a table
+of known lerobot policy types. It walks ``lerobot.policies`` at runtime,
+imports each subpackage's ``configuration_*`` module, and lets every
+``@PreTrainedConfig.register_subclass("<type>")`` decorator populate lerobot's
+own draccus choice registry -- which ``list_policy_types()`` then reports. That
+design means a new policy family a future lerobot release ships is picked up
+automatically, with no strands-side edit.
+
+This module pins that completeness contract against the *installed* lerobot so
+the guarantee cannot silently regress: derive the ground-truth set of policy
+families directly from lerobot's source (the ``register_subclass`` decorator
+arguments under ``lerobot/policies/*/configuration_*.py``) and assert the
+resolver enumerates every one of them. If a future lerobot layout change breaks
+the dynamic walk -- e.g. a subpackage stops being importable through the stub,
+or a policy moves such that ``_ensure_policy_configs_registered`` no longer
+reaches it -- ``list_policy_types()`` becomes a strict subset of what lerobot
+registers and this fails, surfacing the drift as a resolver gap rather than a
+runtime "could not resolve policy type" miss in a user's ``create_policy`` call.
+
+The test is version-agnostic on purpose: it never asserts a fixed policy count
+or a fixed name list, only that the resolver's coverage equals lerobot's own.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+# The registry is sourced from lerobot's own draccus choice registry, so the
+# whole module is meaningless without lerobot installed.
+pytest.importorskip("lerobot")
+
+from strands_robots.policies.lerobot_local import list_policy_types  # noqa: E402
+
+# Matches ``@PreTrainedConfig.register_subclass("act")`` and single-quoted /
+# whitespace variants. The captured group is the lerobot policy ``type`` string
+# -- exactly the token accepted as ``create_policy("lerobot_local",
+# policy_type=...)`` and as the ``policy_type`` argument to
+# ``resolve_policy_class_by_name``.
+_REGISTER_SUBCLASS = re.compile(
+    r"""@PreTrainedConfig\.register_subclass\(\s*["']([\w-]+)["']""",
+)
+
+
+def _registered_policy_families() -> set[str]:
+    """Ground-truth policy families the installed lerobot registers.
+
+    Scans every ``configuration_*.py`` under the installed lerobot's
+    ``policies/`` tree for the ``@PreTrainedConfig.register_subclass("<type>")``
+    decorator and collects the decorator argument. This reads lerobot's source
+    on disk rather than importing it, so it stays cheap and does not depend on
+    optional heavy VLA dependencies being importable.
+
+    Returns:
+        The set of policy ``type`` strings lerobot registers in this install.
+    """
+    import lerobot
+
+    policies_dir = Path(lerobot.__path__[0]) / "policies"
+    families: set[str] = set()
+    for config_file in policies_dir.glob("*/configuration_*.py"):
+        match = _REGISTER_SUBCLASS.search(config_file.read_text(encoding="utf-8"))
+        if match:
+            families.add(match.group(1))
+    return families
+
+
+def test_resolver_enumerates_every_registered_policy_family() -> None:
+    """``list_policy_types()`` covers every policy family lerobot registers.
+
+    The dynamic walk must never silently drop a registered policy: every type
+    lerobot exposes via ``@PreTrainedConfig.register_subclass`` has to appear in
+    the resolver's discovery surface. A missing entry would present to a user as
+    a ``create_policy(policy_type=...)`` resolver miss for a policy their
+    installed lerobot actually ships.
+    """
+    registered = _registered_policy_families()
+    assert registered, (
+        "expected to find at least one @PreTrainedConfig.register_subclass "
+        "decorator in the installed lerobot; the ground-truth scan found none, "
+        "which means the lerobot policies layout changed and this guard needs "
+        "updating"
+    )
+
+    listed = set(list_policy_types())
+    missing = registered - listed
+    assert not missing, (
+        f"the dynamic resolver dropped policy families that lerobot registers: "
+        f"{sorted(missing)}. list_policy_types() reported {sorted(listed)} but "
+        f"lerobot registers {sorted(registered)}. _ensure_policy_configs_registered "
+        f"is no longer reaching every configuration_* module."
+    )
+
+
+def test_ground_truth_scan_is_a_subset_of_the_resolver_surface() -> None:
+    """The resolver surface is a superset of the on-disk registration scan.
+
+    ``list_policy_types()`` sources from lerobot's live draccus registry, which
+    can legitimately hold entries the coarse source scan misses (e.g. a policy
+    registered from a module the regex does not match). The contract is
+    one-directional: the resolver must cover at least every family the scan
+    finds. This guards the direction that matters -- resolver completeness --
+    without over-constraining the resolver to the scan's exact spelling.
+    """
+    registered = _registered_policy_families()
+    listed = set(list_policy_types())
+    assert registered.issubset(listed), (
+        f"registered families {sorted(registered - listed)} are absent from the "
+        f"resolver discovery surface {sorted(listed)}"
+    )


### PR DESCRIPTION
## Problem

The `lerobot_local` policy-class resolver enumerates policy types *dynamically*. `_ensure_policy_configs_registered()` walks `lerobot.policies` at import time and lets each `@PreTrainedConfig.register_subclass("<type>")` decorator populate lerobot's draccus choice registry; `list_policy_types()` then reports whatever the registry holds. That design is deliberately version-agnostic: a new policy family a future lerobot release ships is picked up with no edit here.

But nothing pinned the invariant that actually matters: that the dynamic walk *reaches every registered family*. If a future lerobot layout change made the walk under-populate (a subpackage stops importing through the stub, a policy moves out of `_ensure_policy_configs_registered`'s reach), the gap would surface only downstream, as a runtime `create_policy("lerobot_local", policy_type=...)` resolver miss for a policy the user's installed lerobot actually ships.

## Change

Add `tests/policies/lerobot_local/test_resolver_registry_completeness.py`: a version-agnostic completeness guard. It derives the ground-truth set of policy families directly from the *installed* lerobot source — the `@PreTrainedConfig.register_subclass("<type>")` decorator arguments under `lerobot/policies/*/configuration_*.py` — and asserts `list_policy_types()` covers all of them.

The test hard-codes no policy count and no name list, so it tracks whatever lerobot the environment resolves (19 registered families in lerobot 0.6.x). It fails the moment the resolver drops a family lerobot registers, turning a latent version-drift gap into a caught regression.

Verified against lerobot 0.6.x: the resolver already covers the full roster (act, diffusion, tdmpc, vqbet, smolvla, pi0/pi05/pi0_fast, groot, molmoact2, xvla, wall_x, eo1, vla_jepa, lingbot_va, fastwam, evo1, gaussian_actor, multi_task_dit). `rtc` is correctly *excluded* — it is an inference-time action-chunking wrapper (`RTCProcessor`), not a `PreTrainedPolicy`, and registers no config, matching lerobot's own factory which rejects `rtc` as a policy name.

## Tests

Two cases: `list_policy_types()` is a superset of every registered family, and the one-directional subset guard. Confirmed teeth by simulating a resolver that drops `act` — the assertion fires with an actionable diff of registered-vs-listed.

```
tests/policies/lerobot_local/ .... 516 passed
```

lint (ruff check + format) and mypy clean. Test-only change; no runtime behavior modified.