### PR TITLE
fix(sim): builtin backend wins over stale entry-point plugin of same name (closes #1150)

### DIFF
--- a/strands_robots/simulation/factory.py
+++ b/strands_robots/simulation/factory.py
@@ -108,16 +108,40 @@ def _load_plugin_backends() -> dict[str, type[SimEngine]]:
     is logged and skipped rather than crashing the factory, so a single bad
     plugin can't take down ``create_simulation`` for the working backends.
 
+    A plugin whose entry-point name collides with a **built-in** backend name
+    or alias is skipped entirely (never loaded into the cache) so that:
+
+    * the built-in always wins - a stale ``strands-robots-sim`` still on the
+      ``PYTHONPATH`` after a backend has been absorbed in-tree (e.g. ``isaac``
+      once it lands as a builtin) can neither shadow nor duplicate-register
+      the builtin, and
+    * the plugin's (often heavy - Isaac Sim, Newton) module import is avoided
+      up front when the builtin will be used anyway.
+
+    This skip is the backward-compat guarantee for the robots-sim -> in-tree
+    migration: resolution prefers the builtin and no conflict is ever raised.
+
     Returns:
-        Mapping of entry-point name -> backend class. Aliases are expressed
-        as multiple entry-point names pointing at the same class (e.g.
-        ``newton`` and ``warp`` both resolve to ``NewtonSimulation``); no
-        dedup is applied so whichever requested name resolves cleanly.
+        Mapping of entry-point name -> backend class, excluding any name that
+        collides with a built-in. Aliases are expressed as multiple
+        entry-point names pointing at the same class (e.g. ``newton`` and
+        ``warp`` both resolve to ``NewtonSimulation``); no dedup is applied
+        among plugins so whichever requested name resolves cleanly.
     """
     global _PLUGIN_BACKENDS_CACHE
     if _PLUGIN_BACKENDS_CACHE is None:
         cache: dict[str, type[SimEngine]] = {}
         for ep in entry_points(group=_ENTRY_POINT_GROUP):
+            # Built-ins win over plugins of the same name/alias. Skip the
+            # plugin before ``ep.load()`` so a stale sibling package can never
+            # shadow an absorbed-in-tree backend, and its heavy import is
+            # avoided entirely.
+            if ep.name in _BUILTIN_BACKENDS or ep.name in _BUILTIN_ALIASES:
+                logger.debug(
+                    "Skipping simulation backend plugin %r: shadowed by built-in of the same name.",
+                    ep.name,
+                )
+                continue
             try:
                 cache[ep.name] = ep.load()
             except Exception as exc:  # noqa: BLE001 - one bad plugin must not break the factory
@@ -257,8 +281,10 @@ def _import_backend_class(name: str) -> type[SimEngine]:
         return backend_cls
 
     # 3. Entry-point plugins (third-party packages, e.g. strands-robots-sim).
-    #    Built-ins win over plugins of the same name (checked above), so a
-    #    conflicting plugin can never shadow "mujoco".
+    #    Built-ins win over plugins of the same name: the built-in registry is
+    #    checked above, and ``_load_plugin_backends`` additionally drops any
+    #    plugin whose name/alias collides with a built-in, so a conflicting
+    #    plugin can never shadow "mujoco" (or an absorbed-in-tree "isaac").
     plugins = _load_plugin_backends()
     if name in plugins:
         plugin_cls = plugins[name]

--- a/tests/simulation/test_factory.py
+++ b/tests/simulation/test_factory.py
@@ -303,6 +303,108 @@ class TestEntryPointDiscovery:
             assert "newton" in str(exc_info.value)
 
 
+class TestIsaacBuiltinWinsOverPlugin:
+    """Backward-compat regression guard for issue #1150.
+
+    When the ``isaac`` backend is absorbed in-tree as a built-in (parent epic
+    #1144), a user who still has ``strands-robots-sim`` installed advertises an
+    ``isaac`` entry-point plugin. Resolution MUST prefer the built-in, the
+    plugin must never shadow or duplicate-register it, and no ``ValueError``
+    may fire from the ``register_backend`` conflict checks.
+
+    These tests simulate the post-#1146 state by injecting an ``isaac`` entry
+    into ``_BUILTIN_BACKENDS`` pointed at a real, importable stub module, so
+    they hold regardless of whether the isaac implementation has landed yet.
+    """
+
+    _STUB_MODULE = "strands_robots._test_isaac_builtin_stub"
+
+    @pytest.fixture
+    def isaac_builtin(self, monkeypatch):
+        """Register a stub ``isaac`` built-in backend for the duration of a test.
+
+        Yields the stub class the built-in ``isaac`` resolves to. Uses a real
+        module in ``sys.modules`` because ``_import_backend_class`` imports
+        built-ins via ``importlib.import_module`` (unlike runtime backends,
+        which are plain loader callables).
+        """
+        import sys
+        import types
+
+        stub_mod = types.ModuleType(self._STUB_MODULE)
+
+        class IsaacSimEngine(_FakeSim):
+            """Stand-in for the future in-tree Isaac built-in backend."""
+
+        stub_mod.IsaacSimEngine = IsaacSimEngine
+        monkeypatch.setitem(sys.modules, self._STUB_MODULE, stub_mod)
+        monkeypatch.setitem(
+            factory._BUILTIN_BACKENDS,
+            "isaac",
+            (self._STUB_MODULE, "IsaacSimEngine"),
+        )
+        monkeypatch.setitem(factory._BUILTIN_ALIASES, "isaacsim", "isaac")
+        yield IsaacSimEngine
+
+    def test_builtin_isaac_wins_over_entry_point_plugin(self, isaac_builtin, monkeypatch):
+        """A stale ``strands-robots-sim`` isaac plugin must not shadow the builtin."""
+        _patch_entry_points(monkeypatch, [_FakeEntryPoint("isaac", _PluginSimA)])
+        sim = create_simulation("isaac")
+        assert isinstance(sim, isaac_builtin)
+        assert not isinstance(sim, _PluginSimA)
+
+    def test_builtin_isaac_alias_wins_over_entry_point_plugin(self, isaac_builtin, monkeypatch):
+        """An entry-point named after a built-in *alias* is also shadowed."""
+        _patch_entry_points(monkeypatch, [_FakeEntryPoint("isaacsim", _PluginSimA)])
+        sim = create_simulation("isaacsim")
+        assert isinstance(sim, isaac_builtin)
+        assert not isinstance(sim, _PluginSimA)
+
+    def test_collided_isaac_plugin_is_not_loaded(self, isaac_builtin, monkeypatch):
+        """The plugin's (heavy) class is never even loaded when a builtin wins.
+
+        A plugin whose name collides with a built-in is dropped *before*
+        ``ep.load()`` runs, so the sibling package's Isaac import cost is
+        avoided entirely.
+        """
+        loaded = {"n": 0}
+
+        class _CountingEntryPoint(_FakeEntryPoint):
+            def load(self_inner):
+                loaded["n"] += 1
+                return super().load()
+
+        _patch_entry_points(monkeypatch, [_CountingEntryPoint("isaac", _PluginSimA)])
+        assert "isaac" not in factory._load_plugin_backends()
+        assert loaded["n"] == 0
+
+    def test_list_backends_reports_isaac_once(self, isaac_builtin, monkeypatch):
+        """Even with a colliding plugin, ``isaac`` appears exactly once."""
+        _patch_entry_points(monkeypatch, [_FakeEntryPoint("isaac", _PluginSimA)])
+        backends = list_backends()
+        assert backends.count("isaac") == 1
+        assert backends == sorted(set(backends))
+
+    def test_entry_point_plugin_never_hits_register_backend(self, isaac_builtin, monkeypatch):
+        """Resolving a colliding plugin fires no ``register_backend`` ValueError.
+
+        Entry-point discovery never routes through ``register_backend`` (it
+        populates the plugin cache directly), so the conflict checks that would
+        reject a duplicate ``isaac`` name are never reached. Guard it by making
+        ``register_backend`` explode if it is called at all during resolution.
+        """
+
+        def _boom(*args, **kwargs):
+            raise AssertionError("register_backend must not be called during plugin resolution")
+
+        monkeypatch.setattr(factory, "register_backend", _boom)
+        _patch_entry_points(monkeypatch, [_FakeEntryPoint("isaac", _PluginSimA)])
+        sim = create_simulation("isaac")
+        assert isinstance(sim, isaac_builtin)
+        # list_backends also must not trigger a register_backend call.
+        assert "isaac" in list_backends()
+
+
 class TestEntryPointLazyImport:
     def test_no_eager_plugin_scan_on_import(self):
         """Importing strands_robots.simulation must not scan entry points.


### PR DESCRIPTION
## What changed

Hardens `strands_robots/simulation/factory.py` so a **built-in** backend
always wins over an **entry-point plugin** of the same name/alias.
`_load_plugin_backends()` now drops any plugin whose entry-point name
collides with a built-in name or alias **before** calling `ep.load()`.

## Why

Backward-compat guarantee for the robots-sim -> in-tree migration
(epic #1144). When a backend such as `isaac` is absorbed into this repo
as a built-in (child #1146), a user who still has `strands-robots-sim`
installed advertises an `isaac` entry-point under the
`strands_robots.backends` group. That stale plugin must not shadow or
duplicate-register the new built-in.

`_import_backend_class` already checked the built-in registry before the
plugin cache, so resolution *preferred* the built-in. This PR moves the
guarantee to the source and adds the missing regression coverage:

- Built-in always wins, even against a stale sibling package.
- `list_backends()` reports the name exactly once (the collided plugin
  never enters the merged set).
- The plugin's often-heavy module import (Isaac Sim, Newton) is skipped
  entirely when the built-in will be used anyway.
- Entry-point discovery never routes through `register_backend`, so the
  conflict checks (which correctly still raise for direct user calls) are
  never triggered by a plugin - **no spurious `ValueError`** from
  `register_backend`'s conflict checks (factory.py:157-178).

## Test surface

New `TestIsaacBuiltinWinsOverPlugin` in `tests/simulation/test_factory.py`
simulates the post-#1146 state by injecting a stub `isaac` built-in
(real importable module, since built-ins load via `importlib.import_module`):

- `test_builtin_isaac_wins_over_entry_point_plugin` - built-in resolves, not the plugin.
- `test_builtin_isaac_alias_wins_over_entry_point_plugin` - alias collision is also shadowed.
- `test_collided_isaac_plugin_is_not_loaded` - the plugin's `.load()` is never called.
- `test_list_backends_reports_isaac_once` - `isaac` appears exactly once; list stays sorted/deduped.
- `test_entry_point_plugin_never_hits_register_backend` - `register_backend` explodes if called during resolution; it never is.

Existing `test_builtin_wins_over_plugin_of_same_name` (mujoco) and the
`register_backend` conflict tests are unchanged and still pass.

```
tests/simulation/test_factory.py .............................. (38 passed)
tests/simulation/test_foundation.py .......................... (all pass)
```

`hatch run lint` clean (ruff check + ruff format + mypy: no issues in 700 files).

## Acceptance criteria (from #1150)

- [x] Entry-point plugin (`strands_robots.backends`) must NOT shadow the new builtin - built-in wins.
- [x] Entry-point plugin must NOT duplicate-register the builtin - collided plugin is dropped from the cache.
- [x] Resolution prefers the builtin.
- [x] No `ValueError` fires from `register_backend` conflict checks (factory.py:157-178) - plugins never route through `register_backend`; pinned by a test that asserts it is never called.
- [x] Regression test added.

## Notes / out of scope

- This PR is the **backward-compat shim** child of epic #1144. It does
  not land the `isaac` built-in itself (child #1146) or vendor Isaac
  source (child #1145) - those are separate. The regression tests inject
  a stub `isaac` built-in so they hold regardless of whether the isaac
  implementation has landed yet.
- Environmental: `tests/mesh/test_sim_camera_mesh_publish.py`,
  `test_rendering.py`, and `test_policy_runner.py` abort/fail with
  MuJoCo OpenGL "no context" errors on this headless box; verified
  pre-existing (reproduce on unmodified `upstream/main`) and unrelated to
  this change, which only touches `factory.py`.

Please move #1150 to **In review** on the
[Strands Labs - Robots board](https://github.com/orgs/strands-labs/projects/2).
