### PR TITLE
fix(inference): decode remote observations into writable arrays (local-path parity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,23 @@ Install with `pip install 'strands-robots[inference]'` (pulls only
 `websockets`). See `docs/inference/remote.md`.
 
 
+### Fixed: remote inference delivered read-only observation arrays to the wrapped policy
+
+`RemotePolicy` / `PolicyServer` decoded NumPy observations (camera frames, the
+state vector) with `np.frombuffer` over the immutable `bytes` returned by
+`base64.b64decode`, so every array handed to the server-side policy was
+read-only. That silently diverged from the local-inference path, where a freshly
+rendered observation is always writable: a VLA preprocessor that normalizes the
+image/state in place (`image /= 255`, joint rescaling) raised
+`ValueError: output array is read-only`, and `torch.from_numpy(obs)` (zero-copy,
+as pi0/SmolVLA/MolmoAct2 pipelines do) produced a tensor whose in-place mutation
+is undefined behavior. Decoding now wraps the bytes in a mutable `bytearray` so
+the reconstructed array is writable (one allocation, no extra copy, still
+byte-exact), making the remote path transparent to the wrapped policy. The
+MuJoCo rollout test used a `MockPolicy` (`requires_images=False`) so it never
+decoded an observation array and missed this.
+
+
 ### Fixed: session `status` tool results dropped their telemetry via a `**spread` top-level smuggle
 
 The `status` action of `lerobot_teleoperate` and `lerobot_train` returned the

--- a/strands_robots/inference/protocol.py
+++ b/strands_robots/inference/protocol.py
@@ -88,13 +88,26 @@ def encode_ndarray(arr: np.ndarray) -> dict[str, Any]:
 def decode_ndarray(envelope: dict[str, Any]) -> np.ndarray:
     """Reconstruct a NumPy array from an :func:`encode_ndarray` envelope.
 
+    The reconstructed array is WRITABLE, matching what a locally-run policy
+    receives: a freshly rendered observation (camera frame or state vector) is
+    always writable, and a policy legitimately relies on that. VLA preprocessors
+    routinely normalize the observation in place (``image /= 255``, joint-state
+    rescaling) or hand it to ``torch.from_numpy`` (zero-copy, then mutated), both
+    of which raise ``ValueError: output array is read-only`` or invoke undefined
+    behavior on a read-only buffer. Because :func:`base64.b64decode` returns
+    immutable ``bytes``, decoding through ``np.frombuffer`` directly would yield
+    a read-only array and silently diverge from the local-inference contract; we
+    wrap the decoded bytes in a mutable ``bytearray`` so the view is writable
+    (one allocation, no extra copy of the array data, still byte-exact).
+
     Args:
         envelope: A dict produced by :func:`encode_ndarray`.
 
     Returns:
-        The reconstructed array with the original ``dtype`` and ``shape``.
+        The reconstructed writable array with the original ``dtype`` and
+        ``shape``.
     """
-    raw = base64.b64decode(envelope[_NDARRAY_TAG])
+    raw = bytearray(base64.b64decode(envelope[_NDARRAY_TAG]))
     dtype = np.dtype(envelope["dtype"])
     array = np.frombuffer(raw, dtype=dtype)
     return array.reshape(envelope["shape"])

--- a/tests/inference/test_protocol.py
+++ b/tests/inference/test_protocol.py
@@ -44,6 +44,37 @@ def test_observation_message_roundtrip_preserves_arrays_and_scalars():
     assert decoded_obs["instruction"] == "pick the cube"
 
 
+def test_decoded_array_is_writable_for_in_place_preprocessing():
+    """A decoded observation array must be writable, matching the local path.
+
+    A locally-run policy receives a freshly rendered (writable) observation and
+    VLA preprocessors normalize it in place; a read-only array raises
+    ``output array is read-only``.
+    """
+    image = np.random.randint(0, 256, size=(16, 16, 3), dtype=np.uint8)
+    restored = protocol.decode_ndarray(protocol.encode_ndarray(image))
+    assert restored.flags.writeable is True
+    restored += 1  # in-place op must not raise
+
+    state = np.array([0.1, 0.2, 0.3], dtype=np.float32)
+    restored_state = protocol.decode_ndarray(protocol.encode_ndarray(state))
+    assert restored_state.flags.writeable is True
+    restored_state *= 2.0
+
+
+def test_observation_arrays_writable_after_full_message_roundtrip():
+    """Arrays decoded from a full loads(dumps(...)) message are writable too."""
+    obs = {
+        "observation.state": np.array([0.1, 0.2], dtype=np.float64),
+        "observation.images.top": np.zeros((8, 8, 3), dtype=np.uint8),
+    }
+    decoded = protocol.loads(protocol.dumps({"type": protocol.MSG_GET_ACTIONS, "observation": obs}))
+    decoded_obs = decoded["observation"]
+    assert decoded_obs["observation.state"].flags.writeable is True
+    assert decoded_obs["observation.images.top"].flags.writeable is True
+    decoded_obs["observation.images.top"][0, 0, 0] = 42  # must not raise
+
+
 def test_action_chunk_passes_through_untouched():
     # Action chunks are already JSON-native (dict[str, float | list[float]]).
     actions = [{"joint_0": 0.5, "gripper": [0.1, 0.2]}, {"joint_0": 0.6, "gripper": [0.15, 0.25]}]

--- a/tests/inference/test_remote_policy_roundtrip.py
+++ b/tests/inference/test_remote_policy_roundtrip.py
@@ -65,6 +65,39 @@ class RecordingPolicy(Policy):
         return [{key: base + i * 0.01 for key in self.robot_state_keys} for i in range(self.actions_per_step)]
 
 
+class WritabilityAssertingPolicy(Policy):
+    """Records whether observation arrays received over the wire are writable.
+
+    A locally-run policy always receives writable observation arrays (a freshly
+    rendered camera frame / state vector); the remote path must not silently
+    deliver a read-only array, which breaks in-place normalization.
+    """
+
+    def __init__(self) -> None:
+        self.image_writable: bool | None = None
+
+    @property
+    def provider_name(self) -> str:
+        return "writability-asserting"
+
+    @property
+    def requires_images(self) -> bool:
+        return True
+
+    def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
+        pass
+
+    async def get_actions(
+        self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any
+    ) -> list[dict[str, Any]]:
+        image = observation_dict["observation.images.cam"]
+        self.image_writable = bool(image.flags.writeable)
+        # In-place normalization is the common VLA preprocessing step; it raises
+        # "output array is read-only" if the wire delivered a read-only buffer.
+        image += 1
+        return [{"j0": 0.0}]
+
+
 def _free_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.bind(("127.0.0.1", 0))
@@ -205,3 +238,23 @@ def test_policy_server_requires_exactly_one_policy_source():
         PolicyServer()
     with pytest.raises(ValueError, match="exactly one"):
         PolicyServer(policy=RecordingPolicy(), policy_provider="mock")
+
+
+def test_observation_delivered_to_server_policy_is_writable():
+    """The observation the server hands the wrapped policy must be writable.
+
+    Regression: the wire codec decoded arrays via ``np.frombuffer`` on immutable
+    ``bytes``, yielding read-only observations. In-place normalization inside the
+    policy then raised on the server and propagated as a RuntimeError to the
+    client - a divergence from the transparent local-inference path.
+    """
+    policy = WritabilityAssertingPolicy()
+    server = PolicyServer(policy=policy, host="127.0.0.1", port=0).start()
+    client = RemotePolicy(endpoint=f"ws://127.0.0.1:{server.port}")
+    try:
+        obs = {"observation.images.cam": np.zeros((8, 8, 3), dtype=np.uint8)}
+        client.get_actions_sync(obs, "")
+        assert policy.image_writable is True
+    finally:
+        client.close()
+        server.stop()


### PR DESCRIPTION
## Problem

The WS-JSON remote-inference codec (`strands_robots/inference/protocol.py`) reconstructs NumPy observation arrays (camera frames, the state vector) with:

```python
raw = base64.b64decode(envelope[_NDARRAY_TAG])   # -> immutable bytes
array = np.frombuffer(raw, dtype=dtype)          # -> READ-ONLY view
```

`np.frombuffer` over immutable `bytes` yields a **read-only** array, so every observation `PolicyServer` hands the wrapped policy over the wire is not writable. That silently diverges from the local-inference path, where a freshly rendered observation is always writable and a policy legitimately relies on it:

- an in-place preprocessing step (`image /= 255`, joint-state rescaling — standard in VLA pipelines) raises `ValueError: output array is read-only`;
- `torch.from_numpy(obs)` (zero-copy, as pi0 / SmolVLA / MolmoAct2 pipelines do) produces a tensor whose in-place mutation is undefined behavior and emits `The given NumPy array is not writable...`.

This is exactly the big-VLA use case the remote split exists to serve, and `RemotePolicy` is meant to be a transparent drop-in for a local policy — writability is an observable part of that contract.

The existing MuJoCo rollout test drives the wire path with `MockPolicy` (`requires_images=False`), so it never decodes an observation array and never exercised this.

## Fix

Wrap the decoded bytes in a mutable `bytearray` before `np.frombuffer`:

```python
raw = bytearray(base64.b64decode(envelope[_NDARRAY_TAG]))
array = np.frombuffer(raw, dtype=dtype)
return array.reshape(envelope["shape"])
```

The reconstructed array is now writable (one allocation, no extra copy of the array data) and remains byte-exact. Both the server-side observation decode and the client-side action decode go through `decode_ndarray`, so both benefit.

## Tests (fail before, pass after)

- **Codec level** (`test_protocol.py`): decoded arrays are writable and support in-place ops; arrays decoded from a full `loads(dumps(...))` message are writable too. (Before: `assert restored.flags.writeable is True` fails.)
- **Wire level** (`test_remote_policy_roundtrip.py`): a live `PolicyServer`/`RemotePolicy` loopback where the wrapped policy normalizes the delivered camera frame in place. (Before: `image += 1` raises `output array is read-only` on the server and propagates to the client as a `RuntimeError`.)

Full `tests/inference/` suite (23 tests incl. the MuJoCo rollout) passes after the fix; `ruff` + `mypy` clean on the changed files.
