### PR TITLE
docs(sim): document the Isaac Sim backend (closes #1149)

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,14 @@ uv pip install "strands-robots[molmoact2]"
 uv pip install "strands-robots[all]"
 ```
 
+The **Isaac Sim** GPU backend ships out-of-tree in the sibling
+[`strands-robots-sim`](https://github.com/strands-labs/robots-sim) plugin
+package (it needs Isaac Sim, a ~30 GB non-PyPI install). Install it with
+`pip install 'strands-robots-sim[isaac]'`, then select it with
+`create_simulation("isaac")` - see
+[Simulation (MuJoCo)](#simulation-mujoco) and
+[`docs/simulation/isaac.md`](docs/simulation/isaac.md).
+
 From source:
 
 ```bash
@@ -387,7 +395,7 @@ Robot("my_arm", urdf_path="arm.xml") # bring your own MJCF/URDF
 |-----------|------|---------|-------------|
 | `name` | `str` | required | Robot name or alias (see [Supported robots](#supported-robots)) |
 | `mode` | `str` | `"sim"` | `"sim"`, `"real"`, or `"auto"` (case-insensitive) |
-| `backend` | `str` | `"mujoco"` | Sim backend (Isaac/Newton on the roadmap) |
+| `backend` | `str` | `"mujoco"` | Sim backend: `"mujoco"`, `"newton"` (built-in), or `"isaac"` (via the [`strands-robots-sim`](https://github.com/strands-labs/robots-sim) plugin) |
 | `urdf_path` | `str` | `None` | Explicit MJCF/URDF path (skips registry lookup) |
 | `cameras` | `dict` | `None` | Camera config (**`mode="real"` only**) |
 | `position` | `list[float]` | `[0,0,0]` | Spawn position in the sim world |
@@ -914,7 +922,11 @@ warp = "strands_robots_sim.newton.simulation:NewtonSimulation"
 
 Built-in backends always take precedence over plugins of the same name, plugin
 discovery is lazy (it never slows cold import), and `list_backends()` returns
-the merged builtin + plugin set.
+the merged builtin + plugin set. Requesting a known-but-uninstalled plugin
+backend (e.g. `create_simulation("isaac")` without the plugin) raises a
+`ValueError` carrying the exact install hint. See
+[`docs/simulation/isaac.md`](docs/simulation/isaac.md) for the Isaac Sim
+backend's install, usage, config, and `STRANDS_ISAAC_*` env vars.
 
 ## Mesh networking
 
@@ -1065,6 +1077,22 @@ touches ROS 2.
 | `STRANDS_MESH_BRIDGE_TOPICS_PREFIX` | Comma-separated topic suffixes the bridge matches as a path **prefix** (so `response` matches `response/<turn-id>`). Extend this (not `STRANDS_MESH_BRIDGE_TOPICS`) when adding an RPC-shape topic with a per-turn tail | `response` |
 | `STRANDS_GR00T_IMAGE` | Container image the `gr00t_inference` tool runs (must pass the image allowlist; agent cannot choose it) | `gr00t:latest` |
 | `STRANDS_GR00T_IMAGE_ALLOW` | Extra image-name patterns (trailing `*` = tag wildcard) added to the built-in allowlist (`gr00t:*`, `nvcr.io/nvidia/isaac-gr00t:*`) | built-in only |
+
+</details>
+
+<details>
+<summary><b>Isaac Sim backend env vars (<code>strands-robots-sim</code> plugin)</b></summary>
+
+These are read by the out-of-tree [`strands-robots-sim`](https://github.com/strands-labs/robots-sim)
+Isaac Sim backend (`pip install 'strands-robots-sim[isaac]'`) when it builds its
+`IsaacConfig`; an explicit `create_simulation("isaac", ...)` kwarg always wins.
+See [`docs/simulation/isaac.md`](docs/simulation/isaac.md).
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `STRANDS_ISAAC_NUCLEUS_URL` | Override the Omniverse Nucleus server URL (when `nucleus_url` is not passed) | unset (Isaac defaults) |
+| `STRANDS_ISAAC_HEADLESS` | Truthy (`1`/`true`/`yes`) forces headless; falsy forces a window | unset (uses `headless` kwarg) |
+| `STRANDS_ISAAC_RTX_PATHTRACING` | Truthy forces `render_mode="rtx_pathtracing"` | unset |
 
 </details>
 

--- a/docs/simulation/isaac.md
+++ b/docs/simulation/isaac.md
@@ -1,0 +1,141 @@
+# Isaac Sim Backend (GPU)
+
+The Isaac Sim backend runs the simulation on
+[NVIDIA Isaac Sim](https://developer.nvidia.com/isaac-sim) (PhysX GPU physics +
+RTX path-traced rendering). It ships **out-of-tree** in the sibling package
+[`strands-robots-sim`](https://github.com/strands-labs/robots-sim) and registers
+an `IsaacSimulation` under the `strands_robots.backends` entry-point group. It
+implements the same `SimEngine` contract as the built-in MuJoCo backend, so the
+`Robot()` / `Simulation` / policy APIs are identical - only the physics and
+rendering run on the GPU through Isaac Sim.
+
+`strands-robots` has **no hard dependency** on Isaac Sim: install the plugin and
+`create_simulation("isaac")` discovers it through entry points, exactly like
+`create_simulation("mujoco")`.
+
+## When to use it
+
+- You have an NVIDIA RTX GPU (Ubuntu 22.04+, CUDA 12+) and want photoreal,
+  path-traced observations for sim2real visuals or paper-grade frames.
+- You want USD-native scenes (real CAD assets, Nucleus, IsaacLab compatibility).
+- You want Replicator synthetic data - ground-truth depth, segmentation, and
+  bounding boxes alongside RGB.
+- You want fleet RL on PhysX GPU with 1024+ parallel environments.
+
+On macOS / Apple Silicon or CPU-only hosts, install the lightweight default
+[`strands-robots`](https://github.com/strands-labs/robots) and use the MuJoCo
+backend instead - it runs everywhere and the agent contract is identical. Isaac
+Sim is a ~30 GB install and requires an NVIDIA GPU.
+
+## Install
+
+Isaac Sim itself is **not on PyPI** - install it first, then the Python plugin:
+
+```bash
+# Step 1 - install Isaac Sim 6.0 (Python 3.12) via one of:
+#   - Omniverse Launcher -> Isaac Sim 6.0, OR
+#   - Isaac Lab: git clone IsaacLab && ./isaaclab.sh -i, OR
+#   - NGC Docker: docker pull nvcr.io/nvidia/isaac-sim:6.0
+
+# Step 2 - install the Python plugin (pulls in strands-robots transitively):
+pip install 'strands-robots-sim[isaac]'
+```
+
+The `[isaac]` extra lives in `strands-robots-sim`, not in `strands-robots`.
+Requesting `create_simulation("isaac")` without the plugin installed raises a
+`ValueError` whose message carries the exact install hint
+(`pip install 'strands-robots-sim[isaac]'`). Backend discovery is lazy, so
+MuJoCo-only users never pay the Isaac Sim import cost.
+
+## Usage
+
+```python
+from strands_robots.simulation import create_simulation
+
+# Kwargs flow into IsaacConfig. "isaac" resolves via the
+# strands_robots.backends entry point.
+sim = create_simulation("isaac", render_mode="rtx_realtime", headless=True)
+sim.create_world()
+sim.add_robot("so100")                          # procedural; no asset files needed
+sim.add_object(name="cube", shape="cuboid",
+               position=[0.4, 0.0, 0.05], scale=[0.05, 0.05, 0.05])
+sim.add_camera(name="front", position=[1.2, 0.0, 0.6], target=[0.0, 0.0, 0.1])
+sim.step(120)
+frame = sim.render(camera_name="front")          # RGB + depth
+sim.destroy()
+```
+
+`Robot("so100", backend="isaac", ...)` routes through the same factory, so the
+backend selection is identical whether you go through `Robot()` or
+`create_simulation()`.
+
+## Configuration (`IsaacConfig`)
+
+Keyword arguments to `create_simulation("isaac", ...)` (or
+`Robot(..., backend="isaac", ...)`) construct an `IsaacConfig`. Unknown keys are
+rejected eagerly. The commonly used fields:
+
+| Kwarg | Type | Default | Description |
+|-------|------|---------|-------------|
+| `num_envs` | `int` | `1` | Parallel environments. Set to `1024`+ for fleet RL. |
+| `device` | `str` | `"cuda:0"` | CUDA device (`cuda:N`). Must be a CUDA device. |
+| `headless` | `bool` | `True` | Run without a GUI (required for cloud/CI). |
+| `physics_dt` | `float` | `1/120` | Physics timestep (seconds). |
+| `rendering_dt` | `float` | `1/30` | Rendering timestep (seconds). |
+| `render_mode` | `str` | `"headless"` | `"headless"`, `"rtx_realtime"` (raster), or `"rtx_pathtracing"` (photoreal). |
+| `gravity` | `tuple` | `(0, 0, -9.81)` | Gravity vector (Z-up). |
+| `ground_plane` | `bool` | `True` | Add a ground plane on `create_world()`. |
+| `stage_path` | `str` | `"/World"` | USD stage path prefix. |
+| `nucleus_url` | `str \| None` | `None` | Override Omniverse Nucleus URL (env-resolvable). |
+| `camera_width` / `camera_height` | `int` | `640` / `480` | Default camera resolution. |
+| `enable_rtx_sensors` | `bool` | `True` | Enable RTX-accelerated camera / LiDAR sensors. |
+| `verbose` | `bool` | `False` | Verbose Isaac Sim / Kit logging. |
+
+### Environment variables
+
+The plugin reads three `STRANDS_ISAAC_*` variables (resolved when `IsaacConfig`
+is constructed). An explicit kwarg always wins over the env var.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `STRANDS_ISAAC_NUCLEUS_URL` | Override the Omniverse Nucleus server URL when `nucleus_url` is not passed | unset (Isaac defaults) |
+| `STRANDS_ISAAC_HEADLESS` | Truthy (`1`/`true`/`yes`) forces `headless`; falsy forces windowed | unset (uses `headless` kwarg) |
+| `STRANDS_ISAAC_RTX_PATHTRACING` | Truthy forces `render_mode="rtx_pathtracing"` | unset |
+
+## Capabilities and parity
+
+`IsaacSimulation` exposes the same `SimEngine` shape as the MuJoCo backend:
+
+- **World & lifecycle** - `create_world`, `destroy`, `reset`, `step`,
+  `get_state`, `cleanup`.
+- **Robots** - `add_robot` (procedural builders, or USD via `usd_path=`, or
+  URDF), `remove_robot`, `list_robots`, `robot_joint_names`, `send_action`,
+  `get_observation`.
+- **Objects** - `add_object` (`cuboid` / `sphere` / `cylinder` / `capsule`,
+  dynamic or static), `remove_object`.
+- **Cameras & rendering** - `add_camera` (look-at, FOV), `render` (RGB + depth).
+- **Loaders** - `load_urdf` / `load_mjcf` / `load_usd` resolve to a
+  `ProceduralRobot` dataclass.
+
+Because the joint-name and observation contract matches the MuJoCo backend,
+policies and observation mappings transfer unchanged between backends.
+
+## Fleet (IsaacLab-style) preview
+
+```python
+sim = create_simulation("isaac", num_envs=1024, headless=True,
+                        render_mode="headless")
+sim.create_world()
+sim.add_robot(name="panda", usd_path="/path/to/franka.usda")
+# ... RL training loop ...
+sim.destroy()
+```
+
+## Where to go next
+
+The plugin ships its own MkDocs site with a Quickstart, architecture, backend
+reference, and troubleshooting:
+
+- Plugin docs: <https://strands-labs.github.io/robots-sim/>
+- Backend reference: <https://strands-labs.github.io/robots-sim/backends/isaac/>
+- Source: <https://github.com/strands-labs/robots-sim>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ nav:
   - World Building: simulation/world-building.md
   - Domain Randomization: simulation/domain-randomization.md
   - Newton Backend (GPU): simulation/newton.md
+  - Isaac Sim Backend (GPU): simulation/isaac.md
 - Device Connect: device-connect.md
 - Multi-robot Mesh: mesh.md
 - ROS 2 Integration: ros2-integration.md


### PR DESCRIPTION
## What

Documents the **Isaac Sim** simulation backend across the README and the
MkDocs site. Closes #1149 (child of the epic #1144).

## Why

The Isaac Sim backend is selectable today via `create_simulation("isaac")` /
`Robot(..., backend="isaac")`, but there was no user-facing doc for how to
install it, select it, configure it, or which env vars it reads.

**Framing note (important for review):** the epic #1144 plans to eventually
*absorb* Isaac in-tree (adding a `strands-robots[isaac]` extra + a builtin
backend), but none of those children have landed yet. In the current tree,
`isaac` is **not** an in-tree builtin and there is **no** `strands-robots[isaac]`
extra — it resolves as an out-of-tree entry-point plugin from the sibling
[`strands-robots-sim`](https://github.com/strands-labs/robots-sim) package.
The factory itself emits `pip install 'strands-robots-sim[isaac]'` as its
install hint (`strands_robots/simulation/factory.py:77`).

So rather than document a `strands-robots[isaac]` command that doesn't exist and
would error, this PR documents the **actual current behavior**. When Isaac is
absorbed in-tree under #1144, the install command in these docs should be
updated to `strands-robots[isaac]` in that PR (flagged as an out-of-scope
follow-up below).

## Changes

- **`docs/simulation/isaac.md`** (new) — mirrors the `newton.md` per-backend
  template: when-to-use, install, usage, an `IsaacConfig` kwarg table,
  capabilities/parity with MuJoCo, a fleet preview, and links to the plugin's
  own docs site.
- **`mkdocs.yml`** — adds the page under the `Simulation:` nav section.
- **README Configuration** — new collapsed table documenting the three
  `STRANDS_ISAAC_*` env vars the plugin reads when constructing `IsaacConfig`
  (`STRANDS_ISAAC_NUCLEUS_URL`, `STRANDS_ISAAC_HEADLESS`,
  `STRANDS_ISAAC_RTX_PATHTRACING`), per the AGENTS.md "document every env var in
  the same PR" rule.
- **README Installation + Third-party backends** — notes the
  `pip install 'strands-robots-sim[isaac]'` command and cross-links the new page.
- **README `Robot()` table** — replaces the stale `backend` note
  ("Isaac/Newton on the roadmap") with current reality (newton built-in, isaac
  via plugin).

## Env var source of truth

The three `STRANDS_ISAAC_*` vars are resolved in
`strands_robots_sim/isaac/config.py` (`IsaacConfig.__post_init__`) in the
`strands-robots-sim` repo. They are attributed to the plugin in the README table
so it's clear they are read by the plugin, not this package.

## Test surface

Documentation-only change (`.md` + `mkdocs.yml`; no Python touched).

- `hatch run lint` — clean (700 source files, no issues).
- Doc/nav/hygiene guards pass:
  `test_docs_home_navigation`, `test_docs_policy_nav_coverage`,
  `test_docstrings_no_dangling_doc_refs`, `test_no_host_paths`,
  `test_docs_brand_visuals`, `test_lerobot_dependency_docs` (17 passed).
- New doc file verified ASCII-clean (no emojis / stray combining marks) per the
  AGENTS.md Unicode rule.

**Environmental note:** the full `hatch run test` run aborts with a core dump in
`tests/mesh/test_sim_camera_mesh_publish.py` (an EGL/OpenGL rendering test) on
this headless dev box — the same pre-existing X11/OpenGL environmental failure
class called out in the run instructions. This PR touches no rendering or
Python code, so it cannot introduce that crash.

## Acceptance criteria (from #1149)

- [x] `create_simulation("isaac")` usage documented (README + `docs/simulation/isaac.md`)
- [x] Install command documented — as `pip install 'strands-robots-sim[isaac]'`
      (the actual current path; `strands-robots[isaac]` does not exist yet — see
      framing note)
- [x] New `STRANDS_*` env vars added to the README Configuration section
      (`STRANDS_ISAAC_NUCLEUS_URL`, `STRANDS_ISAAC_HEADLESS`,
      `STRANDS_ISAAC_RTX_PATHTRACING`)

## Out-of-scope follow-ups (for the epic #1144)

- When the `[isaac]` extra + in-tree builtin land, update the install command in
  these docs from `strands-robots-sim[isaac]` to `strands-robots[isaac]`.
- Uncomment the `isaac` builtin slot / aliases in `factory.py` at that time.

## Board

Please move #1149 to **In review** on the
[Strands Labs - Robots board](https://github.com/orgs/strands-labs/projects/2).
