### PR TITLE
feat(deps): add [isaac] optional-dependency extra (closes #1147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ extras you need:
 |-------|----------|---------|
 | `sim-mujoco` | MuJoCo, robot_descriptions, imageio | Simulation (recommended starting point) |
 | `sim-newton` | Newton, Warp, MuJoCo-Warp, trimesh | GPU-native simulation (NVIDIA GPU; batched envs, headless ray-traced render) |
+| `isaac` | usd-core (Isaac Sim installed out-of-band) | Isaac Sim GPU backend - RTX photoreal eval, USD-native scenes (NVIDIA RTX GPU; not in `[all]`) |
 | `lerobot` | LeRobot | Real hardware, local VLA inference, dataset recording |
 | `molmoact2` | LeRobot + transformers, peft, scipy | MolmoAct2 transformers-native VLA (resolves from PyPI via lerobot >= 0.6) |
 | `groot-service` | pyzmq, msgpack | NVIDIA GR00T inference client |
@@ -171,7 +172,7 @@ extras you need:
 | `mesh-iot` | awsiotsdk, awscrt, boto3 | AWS IoT Core mesh transport for fleets |
 | `device-connect` | device-connect-edge, device-connect-agent-tools | Device-aware networking - discovery, RPC, events, safety (falls back to the built-in mesh if absent) |
 | `benchmark-libero` | libero | LIBERO benchmark evaluation |
-| `all` | everything above | Kitchen sink |
+| `all` | everything above except the GPU-only `isaac` extra | Kitchen sink |
 
 ```bash
 # Most users start here:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,6 +223,32 @@ sim-newton = [
     "mujoco-warp>=3.8.0",
     "trimesh>=4.0.0,<5.0.0",
 ]
+# Isaac Sim GPU backend (create_simulation("isaac") / Robot(..., backend="isaac")).
+# Mirrors the sibling strands-robots-sim `[isaac]` extra so the backend's
+# pip-installable companion dep resolves once the in-tree Isaac backend lands
+# (parent epic #1144). GPU/heavy - kept OUT of `[all]` (like sim-newton's spirit
+# but even more so: Isaac Sim needs an RTX GPU + an out-of-band Kit runtime).
+#
+# Isaac Sim itself is NOT installed by this extra. It is an Omniverse Kit
+# application provisioned out-of-band - via the NVIDIA Omniverse Launcher,
+# Isaac Lab (`./isaaclab.sh -i`), or the NGC docker image
+# (`nvcr.io/nvidia/isaac-sim:6.0`). Those images/launchers ship a complete,
+# bootable Kit (Python 3.12 interpreter + the full `isaacsim-*` /
+# `isaacsim-extscache-*` extension set that `SimulationApp` needs to boot).
+# We do NOT pin `isaacsim` here: the PyPI `isaacsim[all]` metapackage is
+# incomplete on its own (it omits the `isaacsim-extscache-*` packages, so
+# `SimulationApp` aborts resolving its extension graph), and every other
+# surface documents Isaac Sim as "installed separately". `isaaclab` is
+# likewise not pinned (out-of-band source install; only a pre-release exists
+# on the index, which a `>=3.0,<4.0` pin would exclude per PEP 440).
+#
+#   * `usd-core` - pure-Python USD runtime used by the procedural scene
+#     builders / loaders even when Kit isn't booted. This is the one genuinely
+#     pip-installable companion dep, so it is the only pin here. usd-core uses
+#     CalVer (25.x/26.x); per AGENTS.md `>=1.0` deps cap the major.
+isaac = [
+    "usd-core>=25.5,<27.0.0",
+]
 benchmark-libero = [
     "libero>=0.1.0,<1.0.0",
 ]


### PR DESCRIPTION
## What

Adds the `[isaac]` optional-dependency extra to `pyproject.toml`, mirroring the
sibling `strands-robots-sim`'s `[isaac]` extra. Closes #1147 (child of the
"absorb Isaac Sim backend" epic #1144).

```toml
isaac = [
    "usd-core>=25.5,<27.0.0",
]
```

Also documents the new extra in the README Installation table.

## Why

The parent epic (#1144) moves the Isaac Sim backend in-tree. This child ships
the packaging half: the extra that carries the backend's one genuinely
pip-installable companion dep, `usd-core` (the pure-Python USD runtime used by
the procedural scene builders/loaders even when Kit isn't booted).

Design mirrors robots-sim exactly:

- **Isaac Sim itself is NOT installed by the extra.** It is an out-of-band
  Omniverse Kit application (NVIDIA Omniverse Launcher / Isaac Lab
  `./isaaclab.sh -i` / NGC docker `nvcr.io/nvidia/isaac-sim:6.0`). Those
  images/launchers ship a complete, bootable Kit.
- **`isaacsim` is deliberately not pinned.** The PyPI `isaacsim[all]`
  metapackage is incomplete on its own (it omits the `isaacsim-extscache-*`
  packages, so `SimulationApp` aborts resolving its extension graph). Pinning it
  would send users down an unsupported, non-booting path.
- **`isaaclab` is deliberately not pinned.** Out-of-band source install; only a
  pre-release exists on the index, which a `>=3.0,<4.0` pin would exclude per
  PEP 440.

## Dependency-bound compliance (AGENTS.md)

`usd-core` uses CalVer (`25.x` / `26.x`), i.e. a `>=1.0` package, so per the
AGENTS.md rule ("`>=1.0` deps: cap major") it is pinned `>=25.5,<27.0.0`. The
robots-sim source left it unpinned; this PR applies robots' stricter bound rule
as the issue requested.

## Kept out of `[all]`

Per the issue ("Keep out of `[all]` if GPU/heavy"), `isaac` is **not** added to
the `[all]` extra: Isaac Sim needs an RTX GPU + an out-of-band Kit runtime. The
README `[all]` row is updated to say "everything above except the GPU-only
`isaac` extra".

## Env vars

No new environment variables are introduced by this change, so the README
Configuration section is unchanged.

## Test surface

- `hatch run format` - clean (no source files changed).
- `hatch run lint` - clean (ruff check, ruff format --check, mypy: "Success: no
  issues found in 700 source files").
- `hatch run test` (with `MUJOCO_GL=egl PYOPENGL_PLATFORM=egl`) - **9795 passed,
  166 skipped, 1 failed**. The dependency-audit / customer-workflow / robot-factory
  suites that parse `[project.optional-dependencies]` all pass.

### Pre-existing / environmental note (not caused by this PR)

- `tests/simulation/test_planning_package_removed.py::test_planning_package_not_importable`
  fails on this dev box because an **untracked** `strands_robots/planning/`
  directory (only `__pycache__` + an `inputs/` subdir, dated Jun 30) is present
  in the working tree, making `strands_robots.planning` importable as a
  namespace package. It is not tracked in `upstream/main` and is unrelated to
  this diff (which only touches `pyproject.toml` + `README.md`). It fails
  identically on clean `upstream/main`.
- Without `MUJOCO_GL=egl` set, the render tests
  (`test_sim_camera_mesh_publish`, `test_rendering.py`, `test_policy_runner.py`)
  segfault headlessly - the documented no-X11/OpenGL dev-box quirk. They pass
  once EGL is selected.

## Acceptance criteria checklist (#1147)

- [x] Mirror robots-sim's `[isaac]` extra (`usd-core`)
- [x] Follow AGENTS.md dependency-bound rules (`>=1.0` cap major -> `usd-core>=25.5,<27.0.0`)
- [x] Keep out of `[all]` (GPU/heavy)
- [x] Document any new env vars in README Configuration (none introduced -> no change)
- [x] Document the extra in the README Installation table

## Out-of-scope follow-ups (tracked under epic #1144)

- Vendoring Isaac source into `strands_robots/simulation/isaac/`
- Registering `isaac` as a builtin backend (uncommenting `factory.py:57`)
- Porting Isaac integration tests into `tests_integ/`
- Backward-compat shim for the entry-point plugin

## Project board

Please move #1147 to "In review" on the
[Strands Labs - Robots board](https://github.com/orgs/strands-labs/projects/2).
