### PR TITLE
fix(inference): lift the server WebSocket frame limit for image observations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -869,6 +869,21 @@ are now built from Newton's authoritative per-joint coordinate/DOF starts
 fixed-base arm (all revolute joints) is unaffected -- its indices are already
 the joint ordinals.
 
+### Fixed: remote inference server rejected every image observation over 1 MiB
+
+`PolicyServer` opened its WebSocket with `serve(...)` at the library default
+1 MiB (`2**20`) frame limit, while `RemotePolicy` correctly passes
+`max_size=None` to `connect(...)`. A real VLA observation carries camera
+frames -- a single 640x480 RGB frame base64-encodes to ~1.2 MiB and a
+multi-camera observation is several MiB -- so the server closed the
+connection with `1009 (message too big)` on the first image-carrying
+`get_actions` request, before the wrapped policy ever ran. The whole remote
+path was therefore usable only with an image-free policy. The server now
+passes `max_size=None` (and, matching the client, `compression=None`) to both
+`serve(...)` call sites so large multi-camera observations stream in. Verified
+end to end by serving a SmolVLA policy over the wire and driving a MuJoCo
+rollout to a recorded LeRobotDataset.
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/inference/server.py
+++ b/strands_robots/inference/server.py
@@ -187,7 +187,13 @@ class PolicyServer:
 
         from websockets.sync.server import serve
 
-        self._server = serve(self._handle, self.host, self.port)
+        # Match the client's connect() options: an observation carrying camera
+        # frames is large (a single 640x480 RGB frame base64-encodes to ~1.2 MiB,
+        # and a multi-camera VLA observation is several MiB), so the default 1 MiB
+        # frame limit must be lifted or the server 1009-closes every real image
+        # observation. Compression is disabled too (base64 binary barely compresses
+        # and deflate wastes CPU at control rate); the client already opts out.
+        self._server = serve(self._handle, self.host, self.port, max_size=None, compression=None)
         # Read back the OS-assigned port when the caller passed 0.
         self.port = self._server.socket.getsockname()[1]
         self._thread = threading.Thread(
@@ -216,7 +222,9 @@ class PolicyServer:
         """
         from websockets.sync.server import serve
 
-        with serve(self._handle, self.host, self.port) as server:
+        # See start(): lift the default 1 MiB frame limit (and disable compression)
+        # so large multi-camera observations stream in, matching the client.
+        with serve(self._handle, self.host, self.port, max_size=None, compression=None) as server:
             self._server = server
             self.port = server.socket.getsockname()[1]
             logger.info("PolicyServer serving on ws://%s:%d", self.host, self.port)

--- a/tests/inference/test_remote_policy_large_observation.py
+++ b/tests/inference/test_remote_policy_large_observation.py
@@ -1,0 +1,104 @@
+"""Regression: the server must accept a realistically-sized image observation.
+
+A real VLA observation carries camera frames. A single 640x480 RGB frame
+base64-encodes to ~1.2 MiB and a multi-camera observation is several MiB, so
+the WebSocket frame-size limit must be lifted on BOTH ends. The client already
+passes ``max_size=None`` to ``connect()``; the server must pass it to ``serve()``
+too, or every image-carrying ``get_actions`` request is rejected with a
+``1009 (message too big)`` close before the wrapped policy ever runs.
+
+The pre-existing round-trip tests use an image-free policy (``requires_images``
+is ``False``), so their tiny state-only messages never approached the limit and
+this gap was invisible. These tests stream an over-1-MiB observation through the
+live loopback WebSocket and assert the wrapped policy receives it intact.
+"""
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.inference import PolicyServer, RemotePolicy
+from strands_robots.policies.base import Policy
+
+# A single 640x480 RGB uint8 frame: 921,600 raw bytes -> ~1.23 MiB base64,
+# comfortably over the websockets default 1 MiB (2**20) frame limit.
+_IMG_H, _IMG_W = 480, 640
+_LIMIT_BYTES = 1 << 20
+
+
+class ImageObservingPolicy(Policy):
+    """Chunk-emitting policy that READS (never mutates) the received image.
+
+    Records the sum of the last image it was handed so a test can assert the
+    full frame arrived intact server-side. It only reads the array, so this
+    test isolates the frame-size contract from the array-writability contract.
+    """
+
+    def __init__(self) -> None:
+        self.actions_per_step = 4
+        self.supports_rtc = False
+        self.robot_state_keys: list[str] = ["j0", "j1"]
+        self.seen_image_sums: list[float] = []
+        self.seen_image_shapes: list[tuple[int, ...]] = []
+
+    @property
+    def provider_name(self) -> str:
+        return "image-observer"
+
+    @property
+    def requires_images(self) -> bool:
+        return True
+
+    def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
+        self.robot_state_keys = list(robot_state_keys)
+
+    async def get_actions(
+        self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any
+    ) -> list[dict[str, Any]]:
+        image = observation_dict["observation.images.cam"]
+        arr = np.asarray(image)
+        self.seen_image_shapes.append(arr.shape)
+        self.seen_image_sums.append(float(arr.sum()))
+        return [{key: 0.0 for key in self.robot_state_keys} for _ in range(self.actions_per_step)]
+
+
+def _big_observation(seed: int = 0) -> tuple[dict[str, Any], float]:
+    rng = np.random.default_rng(seed)
+    image = rng.integers(0, 256, size=(_IMG_H, _IMG_W, 3), dtype=np.uint8)
+    obs = {
+        "observation.images.cam": image,
+        "observation.state": np.array([0.1, 0.2], dtype=np.float32),
+    }
+    return obs, float(image.sum())
+
+
+def test_observation_frame_exceeds_default_websocket_limit():
+    """Guard the premise: the encoded observation really is over 1 MiB."""
+    from strands_robots.inference import protocol
+
+    obs, _ = _big_observation()
+    encoded = protocol.dumps({"type": protocol.MSG_GET_ACTIONS, "observation": obs})
+    assert len(encoded.encode("utf-8")) > _LIMIT_BYTES, (
+        "the test image must exceed the default 1 MiB frame limit to exercise the bug"
+    )
+
+
+def test_server_accepts_over_1mib_image_observation():
+    """A >1 MiB image observation round-trips instead of a 1009 close."""
+    policy = ImageObservingPolicy()
+    server = PolicyServer(policy=policy, host="127.0.0.1", port=0).start()
+    client = RemotePolicy(endpoint=f"ws://127.0.0.1:{server.port}")
+    try:
+        obs, expected_sum = _big_observation(seed=7)
+        # Pre-fix this raises (server 1009-closes the oversize frame); post-fix
+        # the wrapped policy runs and returns its chunk.
+        chunk = client.get_actions_sync(obs, "pick up the red cube")
+        assert len(chunk) == policy.actions_per_step
+        assert set(chunk[0].keys()) == {"j0", "j1"}
+        # The full frame reached the wrapped policy byte-intact.
+        assert policy.seen_image_shapes[-1] == (_IMG_H, _IMG_W, 3)
+        assert policy.seen_image_sums[-1] == pytest.approx(expected_sum)
+    finally:
+        client.close()
+        server.stop()


### PR DESCRIPTION
## Problem

The remote inference server cannot serve any realistic VLA observation. `PolicyServer` opens its WebSocket via `serve(self._handle, host, port)` at the `websockets` library default frame limit of **1 MiB** (`2**20`), while `RemotePolicy` correctly passes `max_size=None` to `connect(...)`. A real observation carries camera frames:

| frame | base64 size |
|---|---|
| 1x 640x480 RGB | ~1.2 MiB |
| 3x 256x256 RGB (multi-cam VLA) | ~3 MiB |

So on the first image-carrying `get_actions` request the server closes the connection with `1009 (message too big)` **before the wrapped policy ever runs**:

```
websockets.exceptions.ConnectionClosedError: received 1009 (message too big) frame
with 1229104 bytes exceeds limit of 1048576 bytes
```

The whole client/server split — whose entire purpose is to stream camera observations from an edge robot to a remote VLA — is therefore usable only with an image-free policy (e.g. `MockPolicy`, a classical planner). The existing end-to-end test happened to use an image-free policy, so its tiny state-only messages never approached the limit and the gap was invisible.

## Fix

Pass `max_size=None` (and, matching the client's `connect(...)`, `compression=None`) to both `serve(...)` call sites in `PolicyServer` — `start()` and the foreground `serve()`. Base64-encoded binary barely compresses and per-message deflate wastes CPU at control rate, so disabling compression matches the client's intent; the client already opts out of both.

## Test

`tests/inference/test_remote_policy_large_observation.py` streams an over-1-MiB (640x480x3) image observation through a live loopback WebSocket to a real `Policy` subclass and asserts the wrapped policy receives the full frame byte-intact. A premise-guard test confirms the observation genuinely exceeds 1 MiB. The main test **fails before** the change with the exact `1009` close and **passes after**. The policy only reads the image (no in-place mutation), so it isolates this frame-size contract from the array-writability contract.

## Verification

Beyond the unit test, the full path was exercised end to end: a SmolVLA policy wrapped in a `PolicyServer` driving a MuJoCo `so101` rollout over `ws://` with a 3-camera rig — 48 steps, 0 action errors, recording both an MP4 and a LeRobotDataset that reopens with all three `observation.images.*` features decoding to non-empty `(3, 256, 256)` frames. On `main` this path 1009-closes on the first step; with the fix it completes.

Gate: `ruff check` / `ruff format` clean, `mypy` clean on the changed files, full `tests/inference/` suite (22) green.