### PR TITLE
fix(sim): make NewtonSimEngine teardown safe when __init__ fails part-way

### DIFF
--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -129,6 +129,21 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
             ValueError: If ``solver`` is not a known solver name.
         """
         super().__init__()
+        # State that teardown (destroy/cleanup/__del__) touches must be set
+        # before any fallible construction step. Otherwise a partially built
+        # engine -- e.g. ensure_newton() raising when warp is absent, or an
+        # unknown solver -- leaves __del__ to acquire self._lock during GC and
+        # raise AttributeError, masking the real construction error with log
+        # noise. Initialising the lock and viewer handles first keeps destroy()
+        # a clean no-op on a half-constructed instance.
+        self._lock = threading.RLock()
+        self._world: SimWorld | None = None
+        # Interactive viewer handle (newton.viewer.ViewerGL/ViewerViser/
+        # ViewerNull). None until open_viewer() is called; synced once per
+        # control step from _advance() on the stepping thread.
+        self._viewer: Any = None
+        self._viewer_kind: str | None = None
+
         self._nt, self._wp = ensure_newton()
         if solver.lower() not in solver_registry():
             raise ValueError(f"Unknown Newton solver {solver!r}. Available: {sorted(solver_registry())}")
@@ -138,15 +153,6 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         self.device = device
         self.default_width = default_width
         self.default_height = default_height
-
-        self._world: SimWorld | None = None
-        self._lock = threading.RLock()
-
-        # Interactive viewer handle (newton.viewer.ViewerGL/ViewerViser/
-        # ViewerNull). None until open_viewer() is called; synced once per
-        # control step from _advance() on the stepping thread.
-        self._viewer: Any = None
-        self._viewer_kind: str | None = None
 
         # Newton handles (rebuilt on every scene mutation via _rebuild).
         self._model: Any = None

--- a/tests/simulation/newton/test_partial_init_teardown.py
+++ b/tests/simulation/newton/test_partial_init_teardown.py
@@ -1,0 +1,85 @@
+"""Teardown safety when NewtonSimEngine construction fails part-way.
+
+NewtonSimEngine.__init__ has fallible steps (importing the optional
+Newton/Warp stack, validating the solver name) that can raise before the
+engine is fully built. When that happens the half-constructed instance is
+still garbage-collected, so __del__ -> cleanup() -> destroy() runs against it.
+These tests pin that such teardown is a clean no-op instead of raising
+AttributeError for state (the lock, viewer handles) that a naive __init__
+ordering would not have set yet.
+
+They are dependency-free: ensure_newton is monkeypatched to raise, so the
+missing-Warp path is exercised even on machines without the Newton stack.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from strands_robots.simulation.newton import simulation as sim_mod
+from strands_robots.simulation.newton.simulation import NewtonSimEngine
+
+
+def _capture_partial_engine(**kwargs: object) -> NewtonSimEngine:
+    """Construct a NewtonSimEngine whose __init__ raises, returning the
+    half-built instance recovered from the exception traceback.
+
+    Fails the test if construction unexpectedly succeeds or the instance
+    cannot be recovered.
+    """
+    try:
+        NewtonSimEngine(**kwargs)  # type: ignore[arg-type]
+    except ImportError as exc:
+        tb = exc.__traceback__
+        engine: NewtonSimEngine | None = None
+        while tb is not None:
+            candidate = tb.tb_frame.f_locals.get("self")
+            if isinstance(candidate, NewtonSimEngine):
+                engine = candidate
+            tb = tb.tb_next
+        assert engine is not None, "could not recover the partially-built engine"
+        return engine
+    raise AssertionError("expected NewtonSimEngine.__init__ to raise ImportError")
+
+
+@pytest.fixture
+def force_missing_newton(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make ensure_newton() raise, simulating an absent Warp install."""
+
+    def _boom() -> tuple[object, object]:
+        raise ImportError("warp missing (simulated)")
+
+    monkeypatch.setattr(sim_mod, "ensure_newton", _boom)
+
+
+class TestPartialInitTeardown:
+    def test_lock_set_before_fallible_ensure_newton(self, force_missing_newton: None) -> None:
+        engine = _capture_partial_engine(solver="mujoco")
+        # The lock and viewer handles must exist even though __init__ aborted
+        # at ensure_newton(), so teardown can acquire the lock safely.
+        assert hasattr(engine, "_lock")
+        assert engine._viewer is None
+        assert engine._viewer_kind is None
+        assert engine._world is None
+
+    def test_destroy_is_clean_noop_on_partial_engine(self, force_missing_newton: None) -> None:
+        engine = _capture_partial_engine(solver="mujoco")
+        result = engine.destroy()
+        assert result["status"] == "success"
+
+    def test_cleanup_does_not_raise_on_partial_engine(self, force_missing_newton: None) -> None:
+        engine = _capture_partial_engine(solver="mujoco")
+        # cleanup() delegates to destroy(); must not raise.
+        engine.cleanup()
+
+    def test_del_logs_no_cleanup_error_for_partial_engine(
+        self, force_missing_newton: None, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        engine = _capture_partial_engine(solver="mujoco")
+        with caplog.at_level(logging.WARNING, logger="strands_robots.simulation.base"):
+            engine.__del__()
+        assert not any("Cleanup error during __del__" in record.getMessage() for record in caplog.records), (
+            "teardown of a partially-built engine must not log a cleanup error"
+        )


### PR DESCRIPTION
## Problem

`NewtonSimEngine.__init__` initialised `self._lock` and the viewer handles only *after* its fallible steps: the `ensure_newton()` import of the optional Newton/Warp stack, and solver-name validation. When either raised (Warp not installed, or an unknown `solver` name), the half-constructed instance was still garbage-collected, so `__del__` -> `cleanup()` -> `destroy()` ran against it and hit:

```
AttributeError: 'NewtonSimEngine' object has no attribute '_lock'
```

`SimEngine.__del__` swallows teardown exceptions and logs them, so this surfaced as repeated `WARNING ... Cleanup error during __del__: 'NewtonSimEngine' object has no attribute '_lock'` during GC. On any machine without the Newton/Warp extra (the common case), simply constructing the engine and letting it fall out of scope emits this noise and masks the real construction error.

## Reproduction

```python
import gc, logging
logging.basicConfig(level=logging.WARNING)
from strands_robots.simulation.newton.simulation import NewtonSimEngine
try:
    NewtonSimEngine()          # ensure_newton() raises when warp is absent
except ImportError:
    pass
gc.collect()
# -> WARNING strands_robots.simulation.base: Cleanup error during __del__:
#    'NewtonSimEngine' object has no attribute '_lock'
```

## Change

Initialise the teardown-critical state (`_lock`, `_world`, `_viewer`, `_viewer_kind`) at the very top of `__init__`, before any fallible step. `destroy()` acquires `_lock`, calls `_close_viewer()` (which reads `_viewer`), and otherwise only assigns attributes, so with these four set first it is a clean no-op on a half-constructed engine. No behaviour change on the success path - the same attributes end up with the same values.

## Tests

Adds `tests/simulation/newton/test_partial_init_teardown.py`: dependency-free regression tests that monkeypatch `ensure_newton` to raise, recover the half-built instance from the exception traceback, and assert the lock is present, `destroy()`/`cleanup()` do not raise, and `__del__` logs no cleanup error. All four fail on the pre-fix code (`AttributeError`/cleanup warning) and pass after.

```
tests/simulation/newton/  93 passed, 120 skipped
test_partial_init_teardown.py  4 passed
```

Ruff, ruff-format and mypy are clean on the changed files. Internal construction/teardown lifecycle fix only - no change to simulation output, rendering, policies, recording, or assets.