### PR TITLE
test(tools): cover calibration backup/restore filtering and discovery branches

### DIFF
--- a/tests/tools/test_lerobot_calibrate.py
+++ b/tests/tools/test_lerobot_calibrate.py
@@ -209,9 +209,7 @@ def test_structure_skips_absent_device_type_directory(tmp_path: Path) -> None:
 
 def test_backup_default_location_is_timestamped_directory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Backup with no explicit output_dir writes to a timestamped default dir."""
-    monkeypatch.setattr(
-        "strands_robots.tools.lerobot_calibrate.BACKUP_DIR", tmp_path / "default_backups"
-    )
+    monkeypatch.setattr("strands_robots.tools.lerobot_calibrate.BACKUP_DIR", tmp_path / "default_backups")
     mgr = LeRobotCalibrationManager(tmp_path / "src")
     mgr.save_calibration("robots", "so101_follower", "arm1", _calib(2))
 

--- a/tests/tools/test_lerobot_calibrate.py
+++ b/tests/tools/test_lerobot_calibrate.py
@@ -18,6 +18,7 @@ from typing import Any
 
 import pytest
 
+import strands_robots.tools.lerobot_calibrate as calib_mod
 from strands_robots.tools.lerobot_calibrate import (
     LeRobotCalibrationManager,
     lerobot_calibrate,
@@ -187,6 +188,65 @@ def test_restore_skips_existing_without_overwrite(populated: Path, tmp_path: Pat
     _ok3, _msg3, restored_ow = dest.restore_calibrations(Path(location), overwrite=True)
     assert restored_ow == 3
     assert dest.load_calibration("robots", "so101_follower", "orange_arm") == _calib(6)
+
+
+def test_structure_skips_absent_device_type_directory(tmp_path: Path) -> None:
+    """Discovery tolerates a missing top-level device-type directory.
+
+    The manager materializes ``teleoperators`` and ``robots`` on construction,
+    but a hand-managed tree may lack one. ``get_calibration_structure`` must
+    skip the absent directory and still report the other, rather than raising.
+    """
+    mgr = LeRobotCalibrationManager(tmp_path)
+    mgr.save_calibration("robots", "so101_follower", "arm1", _calib(3))
+    # Remove the (empty) teleoperators directory so the branch that skips a
+    # non-existent device-type path is exercised.
+    mgr.teleop_path.rmdir()
+
+    structure = mgr.get_calibration_structure()
+    assert structure["teleoperators"] == {}
+    assert structure["robots"] == {"so101_follower": ["arm1"]}
+
+
+def test_backup_default_location_is_timestamped_directory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Backup with no explicit output_dir writes to a timestamped default dir."""
+    monkeypatch.setattr(calib_mod, "BACKUP_DIR", tmp_path / "default_backups")
+    mgr = LeRobotCalibrationManager(tmp_path / "src")
+    mgr.save_calibration("robots", "so101_follower", "arm1", _calib(2))
+
+    ok, location, count = mgr.backup_calibrations()
+    assert ok is True
+    assert count == 1
+    dest = Path(location)
+    assert dest.parent == tmp_path / "default_backups"
+    assert dest.name.startswith("backup_")
+    assert (dest / "backup_manifest.json").is_file()
+
+
+def test_backup_filters_by_device_model(populated: Path, tmp_path: Path) -> None:
+    """A device_model filter backs up only matching models across every type."""
+    mgr = LeRobotCalibrationManager(populated)
+    ok, _location, count = mgr.backup_calibrations(
+        output_dir=tmp_path / "followers_only", device_model="so101_follower"
+    )
+    assert ok is True
+    # so101_follower has two calibrations; the so101_leader teleoperator is skipped.
+    assert count == 2
+
+
+def test_restore_ignores_nondirectory_entries(tmp_path: Path) -> None:
+    """Restore skips stray files at the model level and restores real dirs."""
+    backup = tmp_path / "backup_src"
+    (backup / "robots" / "so101_follower").mkdir(parents=True)
+    (backup / "robots" / "so101_follower" / "arm1.json").write_text('{"shoulder": {"id": 1}}')
+    # A regular file sitting where a model directory would be must be ignored.
+    (backup / "robots" / "stray.txt").write_text("not a model directory")
+
+    mgr = LeRobotCalibrationManager(tmp_path / "live")
+    ok, _message, restored = mgr.restore_calibrations(backup)
+    assert ok is True
+    assert restored == 1
+    assert mgr.calibration_exists("robots", "so101_follower", "arm1")
 
 
 # --- tool action contract --------------------------------------------------

--- a/tests/tools/test_lerobot_calibrate.py
+++ b/tests/tools/test_lerobot_calibrate.py
@@ -18,7 +18,6 @@ from typing import Any
 
 import pytest
 
-import strands_robots.tools.lerobot_calibrate as calib_mod
 from strands_robots.tools.lerobot_calibrate import (
     LeRobotCalibrationManager,
     lerobot_calibrate,
@@ -210,7 +209,9 @@ def test_structure_skips_absent_device_type_directory(tmp_path: Path) -> None:
 
 def test_backup_default_location_is_timestamped_directory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Backup with no explicit output_dir writes to a timestamped default dir."""
-    monkeypatch.setattr(calib_mod, "BACKUP_DIR", tmp_path / "default_backups")
+    monkeypatch.setattr(
+        "strands_robots.tools.lerobot_calibrate.BACKUP_DIR", tmp_path / "default_backups"
+    )
     mgr = LeRobotCalibrationManager(tmp_path / "src")
     mgr.save_calibration("robots", "so101_follower", "arm1", _calib(2))
 


### PR DESCRIPTION
## Summary

Test-only PR (+60/-0, one file) that lifts `strands_robots/tools/lerobot_calibrate.py` from 96% to 98% line coverage by pinning four previously-uncovered, real behaviors of `LeRobotCalibrationManager`. All tests drive a real temporary calibration tree (no hardware, no network) and assert observable behavior (counts, structure, round-trips) rather than internal state, matching the existing suite's style. No production code changes.

## Behaviors pinned

- **Discovery tolerates a missing device-type directory** (`get_calibration_structure`): the manager materializes `teleoperators/` and `robots/` on construction, but a hand-managed tree may lack one. When the directory is absent, discovery skips it and still reports the other, rather than raising.
- **Default backup location** (`backup_calibrations` with no `output_dir`): writes to a timestamped `backup_<ts>` directory under the module default; the manifest lands inside it. Uses `monkeypatch.setattr` on the module `BACKUP_DIR` so the test never touches the real cache.
- **`device_model` filter in backup**: a `device_model` filter backs up only matching models across every device type, skipping non-matching ones (parallels the existing `device_type` filter test).
- **Restore ignores non-directory entries**: a stray file sitting where a model directory would be is skipped; real model directories still restore.

## Verification

- `tests/tools/test_lerobot_calibrate.py`: 65 passed.
- Coverage of `lerobot_calibrate.py`: 96% -> 98% (remaining uncovered lines are the `ImportError` fallback that only fires when lerobot is absent, plus a few tool-wrapper format branches).
- `ruff check` / `ruff format --check` clean; `mypy` clean (`Success: no issues found in 703 source files`).

Scope discipline: tests only, no source or behavior change, no host paths, `monkeypatch` throughout, ASCII-only.

## Round 1 changelog

- Addressed a static-analysis note (module imported with both `import ... as` and `from ... import`). The module alias was used only once, to monkeypatch `BACKUP_DIR`; switched that call to `monkeypatch.setattr`'s string-target form and dropped the alias, leaving a single `from ... import` for the public symbols. Behavior-preserving; 65 tests still pass.