### PR TITLE
test(tools): cover gr00t image allowlist literal-match branch

### DIFF
--- a/tests/tools/test_gr00t_container_hardening.py
+++ b/tests/tools/test_gr00t_container_hardening.py
@@ -78,6 +78,19 @@ def test_image_allowlist_env_extends(monkeypatch):
     assert gi._is_allowed_image("myreg/gr00t:v1") is True
 
 
+def test_image_allowlist_literal_pattern_pins_exact_ref(monkeypatch):
+    # An operator pattern with NO trailing "*" is matched literally, not as a
+    # prefix. Pinning "myreg/gr00t:v1.0" must admit that exact ref only -- a
+    # sibling tag ("myreg/gr00t:v1.0-evil") or a longer image sharing the
+    # prefix must be rejected, so a literal pin cannot be silently widened into
+    # a wildcard. The wildcard branch is exercised above; this locks in the
+    # complementary literal-match branch that guards the exact-pin contract.
+    monkeypatch.setenv("STRANDS_GR00T_IMAGE_ALLOW", "myreg/gr00t:v1.0")
+    assert gi._is_allowed_image("myreg/gr00t:v1.0") is True
+    assert gi._is_allowed_image("myreg/gr00t:v1.0-evil") is False
+    assert gi._is_allowed_image("myreg/gr00t:v2.0") is False
+
+
 # --- _start_container guards (defence in depth) ------------------------
 
 


### PR DESCRIPTION
## Problem
The gr00t container-image allowlist (`_is_allowed_image` in `strands_robots.tools.gr00t_inference`) accepts two pattern kinds:

- a trailing-`*` **tag/suffix wildcard** (`gr00t:*`), and
- a **literal exact match** for any pattern without a trailing `*` (documented in the function docstring: "Other patterns match literally").

The existing hardening tests only exercise wildcard patterns: both built-in defaults (`gr00t:*`, `nvcr.io/nvidia/isaac-gr00t:*`) and the env-extend case (`myreg/gr00t:*`) end in `*`. The literal-match branch was therefore never executed by the suite, leaving the exact-pin security contract unverified.

## Change
Add one focused test, `test_image_allowlist_literal_pattern_pins_exact_ref`, that configures an operator pattern with **no** trailing `*` (`myreg/gr00t:v1.0`) and asserts the exact-pin contract:

- the exact ref (`myreg/gr00t:v1.0`) is admitted;
- a sibling tag (`myreg/gr00t:v1.0-evil`) is rejected;
- a different tag sharing the prefix (`myreg/gr00t:v2.0`) is rejected.

This locks in that a literal pin cannot be silently widened into a prefix wildcard, complementing the already-covered wildcard branch.

## Tests
- New test passes; the two lines of the literal-match branch were uncovered before this test and covered after (verified by diffing `--cov-report=term-missing` for the module with and without the new test).
- Full gr00t tool suite green: `test_gr00t_container_hardening.py`, `test_gr00t_inference.py`, `test_gr00t_pentest_regressions.py` -> 202 passed.
- `ruff check` / `ruff format --check` clean.

Test-only change; no runtime behavior modified.