### PR TITLE
fix(sim): Newton surfaces a floating base as a structured pose, not a garbage scalar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -921,6 +921,21 @@ passes `max_size=None` (and, matching the client, `compression=None`) to both
 end to end by serving a SmolVLA policy over the wire and driving a MuJoCo
 rollout to a recorded LeRobotDataset.
 
+### Fixed: Newton backend surfaces a floating base as a structured pose, not a garbage scalar
+
+On the Newton backend, `get_robot_state` reported a floating-base robot's free
+root joint (a humanoid's named `floating_base_joint`) as a scalar joint
+`{position, velocity}` -- reading its base x-coordinate as a "position" and
+linear-velocity-x as a "velocity", silently dropping the orientation and the
+rest of the twist -- and `get_observation` never surfaced the base at all. A
+real `unitree_g1` therefore reported garbage for its base and no orientation to
+a WBC / locomotion controller. Both now mirror the MuJoCo backend: the free
+joint is excluded from the scalar `state` map and a structured `base` entry
+(`position`, `quaternion` w,x,y,z, `linear_velocity`, `angular_velocity`) is
+surfaced, and `get_observation` gains `base_quat` / `base_ang_vel`. Newton
+stores the free joint's coordinates as `[xyz, quat_xyzw]`, so the quaternion is
+reordered `xyzw -> wxyz` to match the MuJoCo (w,x,y,z) contract.
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -174,6 +174,11 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         # Distinct from _joint_coord_index because free joints have more
         # coordinates (quaternion) than DOFs; arm joints are 1:1.
         self._joint_dof_index: dict[tuple[str, str], int] = {}
+        # Short name of each robot's floating-base free joint (a humanoid's
+        # named ``floating_base_joint``), when it has one. Used to surface the
+        # 6-DoF base pose/twist instead of reporting the base x-coordinate as a
+        # scalar joint value (parity with the MuJoCo backend).
+        self._robot_free_base_joint: dict[str, str] = {}
         # Ordered full body labels per robot (rebuilt with the model).
         self._robot_body_map: dict[str, list[str]] = {}
         # Parsed mesh geometry keyed by resolved mesh_path, so rebuilds do not
@@ -618,8 +623,10 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         Returns:
             Mapping of short joint name to joint position (float), plus one
             entry per registered camera (name -> RGB ndarray) when
-            ``skip_images`` is False. Empty when no world exists or the robot
-            is unknown.
+            ``skip_images`` is False. A robot with a floating base additionally
+            carries ``base_quat`` (orientation, w,x,y,z) and ``base_ang_vel``
+            (rad/s) for locomotion controllers. Empty when no world exists or
+            the robot is unknown.
         """
         if self._world is None or self._model is None:
             return {}
@@ -638,6 +645,7 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
             skip_images = False
         with self._lock:
             joint_q = self._state_0.joint_q.numpy()
+            joint_qd = self._state_0.joint_qd.numpy()
             robot_joints = self._world.robots[robot_name].joint_names
             obs: dict[str, Any] = {}
             for jname in robot_joints:
@@ -648,6 +656,15 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         # camera frames are added afterwards (and carry their own jitter via the
         # render path), so the result holds mixed float/ndarray values.
         obs_out: dict[str, Any] = dict(self._apply_joint_pos_noise(obs))
+        # Floating-base IMU-style signals for a robot with a free root (a
+        # humanoid / mobile base): ``base_quat`` (orientation, w,x,y,z) and
+        # ``base_ang_vel`` (rad/s), consumed by WBC / locomotion controllers.
+        # Additive and absent for fixed-base arms; left un-noised, matching the
+        # MuJoCo backend's contract.
+        base = self._free_base_pose(robot_name, joint_q, joint_qd)
+        if base is not None:
+            obs_out["base_quat"] = base["quaternion"]
+            obs_out["base_ang_vel"] = base["angular_velocity"]
         if not skip_images:
             from strands_robots.simulation.policy_runner import _extract_frame_ndarray
 
@@ -1267,6 +1284,45 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
 
     # Robot / scene discovery
 
+    def _free_base_pose(self, robot_name: str, joint_q: Any, joint_qd: Any) -> dict[str, list[float]] | None:
+        """Return a robot's floating-base 6-DoF pose + twist, or None.
+
+        For a robot whose root is a free joint (a humanoid's named
+        ``floating_base_joint``), returns a dict with ``position`` (xyz),
+        ``quaternion`` (w,x,y,z), ``linear_velocity`` and ``angular_velocity``,
+        mirroring the MuJoCo backend's ``base`` entry. Newton stores the free
+        joint's coordinates as ``[xyz, quat_xyzw]`` and its DOFs as
+        ``[linear(3), angular(3)]``, so the quaternion is reordered
+        ``xyzw -> wxyz`` to match the MuJoCo (w,x,y,z) contract while the twist
+        slots map directly. Returns None for a fixed-base robot (an arm).
+
+        Args:
+            robot_name: The robot to query.
+            joint_q: The world's ``joint_q`` array (already ``.numpy()``).
+            joint_qd: The world's ``joint_qd`` array (already ``.numpy()``).
+
+        Returns:
+            The base pose/twist dict, or None when the robot has no free root.
+        """
+        base_jname = self._robot_free_base_joint.get(robot_name)
+        if base_jname is None:
+            return None
+        q = self._joint_coord_index.get((robot_name, base_jname))
+        d = self._joint_dof_index.get((robot_name, base_jname))
+        if q is None or d is None or q + 7 > len(joint_q) or d + 6 > len(joint_qd):
+            return None
+        return {
+            "position": [float(v) for v in joint_q[q : q + 3]],
+            "quaternion": [
+                float(joint_q[q + 6]),
+                float(joint_q[q + 3]),
+                float(joint_q[q + 4]),
+                float(joint_q[q + 5]),
+            ],
+            "linear_velocity": [float(v) for v in joint_qd[d : d + 3]],
+            "angular_velocity": [float(v) for v in joint_qd[d + 3 : d + 6]],
+        }
+
     def get_robot_state(self, robot_name: str | None = None) -> dict[str, Any]:
         """Return per-joint position and velocity for a robot.
 
@@ -1276,6 +1332,14 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         ``joint_q`` via the per-joint coordinate index and velocities from
         ``joint_qd`` via the per-joint DOF index (the two indices differ once
         a free-floating object adds a quaternion coordinate).
+
+        A robot with a floating base (a 6-DoF free root, e.g. a humanoid's
+        named ``floating_base_joint``) additionally carries a ``"base"`` entry
+        with ``position`` (xyz), ``quaternion`` (w,x,y,z), ``linear_velocity``
+        and ``angular_velocity``. The free joint is NOT reported as a scalar
+        joint (its coordinates are [xyz + quat], not a single angle), and the
+        base ``quaternion``/``angular_velocity`` match get_observation's
+        ``base_quat``/``base_ang_vel`` for the same robot.
 
         Args:
             robot_name: Robot to query. ``None`` resolves to the sole robot
@@ -1298,18 +1362,41 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
             joint_q = self._state_0.joint_q.numpy()
             joint_qd = self._state_0.joint_qd.numpy()
             state: dict[str, dict[str, float]] = {}
+            base_jname = self._robot_free_base_joint.get(robot_name)
             for jname in self._world.robots[robot_name].joint_names:
+                # A FREE joint (6-DoF floating base) has no scalar hinge value:
+                # its coordinates are [xyz + quaternion]. Reading joint_q[start]
+                # as a "position" reports the base x-coordinate and drops the
+                # orientation, so skip it and surface a structured ``base`` below.
+                if jname == base_jname:
+                    continue
                 q_idx = self._joint_coord_index.get((robot_name, jname))
                 d_idx = self._joint_dof_index.get((robot_name, jname))
                 pos = float(joint_q[q_idx]) if q_idx is not None and q_idx < len(joint_q) else 0.0
                 vel = float(joint_qd[d_idx]) if d_idx is not None and d_idx < len(joint_qd) else 0.0
                 state[jname] = {"position": pos, "velocity": vel}
         state = self._apply_state_noise(state)
+        # Floating base: surface the full 6-DoF pose + twist under a ``base``
+        # key (sibling of ``state``, left un-noised), consistent with
+        # get_observation's base_quat / base_ang_vel and the MuJoCo backend.
+        base = self._free_base_pose(robot_name, joint_q, joint_qd)
 
         text = f"'{robot_name}' state (t={self._world.sim_time:.3f}s):\n"
         for jnt, vals in state.items():
             text += f"{jnt}: pos={vals['position']:.4f}, vel={vals['velocity']:.4f}\n"
-        return {"status": "success", "content": [{"text": text}, {"json": {"state": state}}]}
+        if base is not None:
+            p_, q_ = base["position"], base["quaternion"]
+            lv_, av_ = base["linear_velocity"], base["angular_velocity"]
+            text += (
+                f"base: pos=[{p_[0]:.4f}, {p_[1]:.4f}, {p_[2]:.4f}], "
+                f"quat=[{q_[0]:.4f}, {q_[1]:.4f}, {q_[2]:.4f}, {q_[3]:.4f}], "
+                f"lin_vel=[{lv_[0]:.4f}, {lv_[1]:.4f}, {lv_[2]:.4f}], "
+                f"ang_vel=[{av_[0]:.4f}, {av_[1]:.4f}, {av_[2]:.4f}]\n"
+            )
+        json_payload: dict[str, Any] = {"state": state}
+        if base is not None:
+            json_payload["base"] = base
+        return {"status": "success", "content": [{"text": text}, {"json": json_payload}]}
 
     def list_robots_info(self) -> dict[str, Any]:
         """Pretty-printed robot listing (dict-shaped, for agent display).
@@ -1765,6 +1852,7 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         self._joint_coord_index = {}
         self._joint_dof_index = {}
         self._robot_joint_map = {}
+        self._robot_free_base_joint = {}
         self._robot_body_map = {}
 
         for robot_name, robot in self._world.robots.items():
@@ -1802,6 +1890,14 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
                 joint_index = label_before + offset
                 self._joint_coord_index[(robot_name, short)] = int(q_start[joint_index])
                 self._joint_dof_index[(robot_name, short)] = int(qd_start[joint_index])
+                # A free root (6-DoF floating base) is not a scalar joint: its
+                # coordinates are [xyz + quaternion]. Remember it so state/obs
+                # queries surface a structured base pose (see _free_base_pose).
+                if (
+                    builder.joint_type[joint_index] == self._nt.JointType.FREE
+                    and robot_name not in self._robot_free_base_joint
+                ):
+                    self._robot_free_base_joint[robot_name] = short
             self._robot_joint_map[robot_name] = short_names
             self._robot_body_map[robot_name] = list(builder.body_label[body_before:])
 

--- a/tests/simulation/newton/test_discovery_and_state.py
+++ b/tests/simulation/newton/test_discovery_and_state.py
@@ -156,6 +156,72 @@ class TestFloatingBaseJointIndices:
         assert dofs == list(range(len(names)))
 
 
+class TestFloatingBaseSurfacing:
+    """A floating base must surface as a structured pose, not a garbage scalar.
+
+    Parity with the MuJoCo backend (get_observation ``base_quat``/``base_ang_vel``
+    and get_robot_state ``base``): a robot whose root is a free joint (a
+    humanoid's named ``floating_base_joint``) must NOT report the base
+    x-coordinate as a scalar joint value. The 6-DoF base pose + twist is
+    surfaced instead, with the quaternion reordered from Newton's native xyzw to
+    the MuJoCo (w,x,y,z) contract and the free-joint scalar removed from
+    get_robot_state's per-joint ``state`` map.
+    """
+
+    # A distinctive base pose (+90deg about Z) and twist; hinge sentinels.
+    _S = 0.7071067811865476  # sin(45) == cos(45)
+
+    def _set_base_and_hinges(self, engine):
+        q = engine._state_0.joint_q.numpy().copy()
+        q[0:3] = [0.3, 0.4, 0.9]  # base position
+        q[3:7] = [0.0, 0.0, self._S, self._S]  # xyzw: +90 about Z
+        q[7] = 0.55  # j1 sentinel
+        q[8] = -0.22  # j2 sentinel
+        engine._state_0.joint_q.assign(q)
+        qd = engine._state_0.joint_qd.numpy().copy()
+        qd[:] = 0.0
+        qd[0:3] = [1.1, 2.2, 3.3]  # base linear velocity
+        qd[3:6] = [4.4, 5.5, 6.6]  # base angular velocity
+        qd[6] = 0.7  # j1 velocity
+        qd[7] = -0.3  # j2 velocity
+        engine._state_0.joint_qd.assign(qd)
+
+    def test_get_robot_state_surfaces_base_not_a_scalar_joint(self, engine_floater):
+        self._set_base_and_hinges(engine_floater)
+        payload = engine_floater.get_robot_state("floater")["content"][1]["json"]
+        state = payload["state"]
+        # The free joint is NOT a scalar joint in ``state`` (its coordinates are
+        # [xyz + quat], not a single angle).
+        assert "root" not in state
+        assert set(state) == {"j1", "j2"}
+        # A structured ``base`` entry carries the 6-DoF pose + twist.
+        base = payload["base"]
+        assert base["position"] == pytest.approx([0.3, 0.4, 0.9], abs=1e-4)
+        # Quaternion is reordered xyzw -> wxyz to match the MuJoCo contract.
+        assert base["quaternion"] == pytest.approx([self._S, 0.0, 0.0, self._S], abs=1e-4)
+        assert base["linear_velocity"] == pytest.approx([1.1, 2.2, 3.3], abs=1e-4)
+        assert base["angular_velocity"] == pytest.approx([4.4, 5.5, 6.6], abs=1e-4)
+        # Child hinges still read their own coordinates (not shifted / dropped).
+        assert state["j1"]["position"] == pytest.approx(0.55, abs=1e-4)
+        assert state["j2"]["position"] == pytest.approx(-0.22, abs=1e-4)
+
+    def test_get_observation_surfaces_base_quat_and_ang_vel(self, engine_floater):
+        self._set_base_and_hinges(engine_floater)
+        obs = engine_floater.get_observation("floater", skip_images=True)
+        # Orientation (w,x,y,z) and angular velocity (rad/s) for locomotion.
+        assert obs["base_quat"] == pytest.approx([self._S, 0.0, 0.0, self._S], abs=1e-4)
+        assert obs["base_ang_vel"] == pytest.approx([4.4, 5.5, 6.6], abs=1e-4)
+
+    def test_fixed_base_arm_has_no_base_entry(self, engine_so100):
+        # A fixed-base arm (no free root) must be unchanged: no base pose, no
+        # base_quat / base_ang_vel keys.
+        payload = engine_so100.get_robot_state("so100")["content"][1]["json"]
+        assert "base" not in payload
+        obs = engine_so100.get_observation("so100", skip_images=True)
+        assert "base_quat" not in obs
+        assert "base_ang_vel" not in obs
+
+
 class TestListBodies:
     def test_scoped_lists_only_robot_bodies_with_gripper(self, engine_so100):
         result = engine_so100.list_bodies("so100")


### PR DESCRIPTION
## Problem

On the Newton backend, a floating-base robot's free root joint (a humanoid's named `floating_base_joint`) was read as if it were a scalar hinge joint. A free joint's coordinates are `[xyz + quaternion]` and its DOFs are `[linear(3), angular(3)]`, not a single angle, so:

- **`get_robot_state`** reported the base **x-coordinate** as the joint `"position"` and **linear-velocity-x** as the `"velocity"`, silently dropping the base orientation and the rest of the twist.
- **`get_observation`** never surfaced the base pose/orientation at all.

A real `unitree_g1` (30 joints, `joint_type[0] == FREE`) therefore reported garbage base state and gave a WBC / locomotion controller no base orientation or angular velocity. Ground truth on current `main`:

```
get_robot_state("unitree_g1")["state"]["floating_base_joint"] == {"position": 0.0, "velocity": 0.0}   # base x / lin-vel-x, orientation dropped
get_observation("unitree_g1")  # no base_quat / base_ang_vel
```

The MuJoCo backend already handles this correctly (`get_observation` surfaces `base_quat`/`base_ang_vel`; `get_robot_state` surfaces a structured `base` entry) — this brings the Newton backend to parity.

## Change

Mirror the MuJoCo contract exactly:

- `get_robot_state` **excludes** the free joint from the scalar `state` map and surfaces a structured `base` entry: `position` (xyz), `quaternion` (w,x,y,z), `linear_velocity`, `angular_velocity` (sibling of `state`, left un-noised).
- `get_observation` gains `base_quat` (w,x,y,z) and `base_ang_vel` (rad/s), additive and absent for fixed-base arms.

Newton stores the free joint's coordinates as `[xyz, quat_xyzw]` (Warp-native XYZW), so the quaternion is reordered **`xyzw -> wxyz`** to match the MuJoCo `(w,x,y,z)` contract. The free-joint DOFs are `[linear(3), angular(3)]` and map directly (verified empirically — a spatial twist probe with gravity off showed slot `[0:3]` produces pure translation and slot `[3:6]` pure rotation). The free-base joint is detected once at model-build time (`joint_type == JointType.FREE`) and both queries share a `_free_base_pose` helper. Fixed-base arms are unchanged (no `base`, no `base_quat`/`base_ang_vel`).

## Verification

On a real Newton build (an inline floating-base MJCF and `unitree_g1`), a known base pose (+90° about Z) and twist round-trip correctly: `state` excludes the free joint and reports the child hinges' own coordinates; `base.quaternion` is the WXYZ `[0.707, 0, 0, 0.707]`; `base.linear_velocity`/`angular_velocity` match; `get_observation` surfaces the same `base_quat`/`base_ang_vel`.

## Tests

`tests/simulation/newton/test_discovery_and_state.py::TestFloatingBaseSurfacing` (real Newton build, gated on `newton`/`warp`):

- `get_robot_state` surfaces `base` (WXYZ) and no free-joint scalar; child hinges unchanged.
- `get_observation` surfaces `base_quat` (WXYZ) + `base_ang_vel`.
- Fixed-base arm (`so100`) guard: no `base`, no `base_quat`/`base_ang_vel`.

The two floating-base tests **fail before** this change (`assert 'root' not in state` fails because the pre-fix code leaks `{'root': {'position': base_x, 'velocity': lin_vel_x}}`) and pass after. Full `tests/simulation/newton/` state + domain-randomization suite is green (65 passed); `ruff` + `mypy` clean.