### PR TITLE
test(training): cover FastSAC preflight validation, fixed-alpha, and warmup update

### DIFF
--- a/tests/training/test_rl_fast_sac.py
+++ b/tests/training/test_rl_fast_sac.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import os
+from typing import Any
 
 import pytest
 
@@ -105,6 +106,35 @@ def test_validate_rejects_bad_specs() -> None:
     # tau out of range.
     problems = trainer.validate(RLTrainSpec(output_dir="/tmp/x", tau=2.0))
     assert any("tau" in p for p in problems)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "expected"),
+    [
+        ({"output_dir": ""}, "output_dir is required"),
+        ({"total_timesteps": 0}, "total_timesteps must be > 0"),
+        ({"rollout_steps": 0}, "rollout_steps must be > 0"),
+        ({"buffer_size": 0}, "buffer_size must be > 0"),
+        ({"batch_size": 0}, "batch_size must be > 0"),
+        ({"gradient_steps": 0}, "gradient_steps must be > 0"),
+    ],
+)
+def test_validate_flags_each_out_of_range_field(overrides: dict[str, Any], expected: str) -> None:
+    """Each numeric guard in the FastSAC preflight names the offending field.
+
+    ``validate`` is a pure, read-only preflight the ``train`` entry point runs
+    before touching torch or the env, so a misconfigured spec fails with an
+    actionable message instead of a deep stack trace. One otherwise-valid spec
+    per case isolates a single bad field; a non-None ``env_factory`` keeps the
+    env-factory guard quiet so only the field under test is exercised.
+    """
+    from strands_robots.training.rl import RLTrainSpec
+
+    trainer = create_trainer("fast_sac")
+    base: dict[str, Any] = {"output_dir": "/tmp/x", "env_factory": lambda: None}
+    base.update(overrides)
+    problems = trainer.validate(RLTrainSpec(**base))
+    assert any(expected in p for p in problems), problems
 
 
 def test_train_rejects_non_rl_spec() -> None:
@@ -220,3 +250,63 @@ def test_setup_reconciles_env_device_to_learner_device() -> None:
     assert trainer.env.device == trainer.device
     assert trainer._obs["actor_obs"].device == trainer.device
     assert trainer.buffer.device == trainer.device
+
+
+def test_setup_without_autotune_uses_fixed_alpha() -> None:
+    """``autotune_alpha=False`` pins alpha as a constant, not a learnable temp.
+
+    With autotuning off the learner must not build a temperature optimizer and
+    ``log_alpha`` must be a plain (non-grad) tensor, so ``alpha`` stays at
+    ``init_alpha`` for the whole run rather than drifting toward the entropy
+    target. This is the SAC-without-auto-entropy contract users opt into when
+    they want a hand-tuned temperature.
+    """
+    from strands_robots.training.rl import RLTrainSpec
+    from strands_robots.training.rl.fast_sac import FastSacTrainer
+
+    trainer = FastSacTrainer()
+    spec = RLTrainSpec(
+        env_factory=_make_reach_env,
+        output_dir="/tmp/sac_fixed_alpha",
+        device="cpu",
+        autotune_alpha=False,
+        init_alpha=0.5,
+        rollout_steps=4,
+        batch_size=16,
+        learning_starts=16,
+    )
+    trainer.setup(spec)
+
+    assert trainer.autotune_alpha is False
+    assert trainer.log_alpha.requires_grad is False
+    assert not hasattr(trainer, "alpha_optimizer")
+    assert trainer.alpha.item() == pytest.approx(0.5)
+
+
+def test_update_is_noop_until_buffer_reaches_batch_size() -> None:
+    """``update`` returns zero-loss metrics while the buffer is below a batch.
+
+    The learner cannot form a full minibatch until the replay buffer holds at
+    least ``batch_size`` transitions, so a freshly-set-up trainer (empty buffer)
+    must short-circuit to zero losses rather than sampling an undersized batch.
+    """
+    from strands_robots.training.rl import RLTrainSpec
+    from strands_robots.training.rl.fast_sac import FastSacTrainer
+
+    trainer = FastSacTrainer()
+    spec = RLTrainSpec(
+        env_factory=_make_reach_env,
+        output_dir="/tmp/sac_warmup_noop",
+        device="cpu",
+        rollout_steps=4,
+        batch_size=16,
+        learning_starts=16,
+    )
+    trainer.setup(spec)
+    assert trainer.buffer.size < spec.batch_size  # nothing collected yet
+
+    metrics = trainer.update()
+    assert metrics["critic_loss"] == 0.0
+    assert metrics["actor_loss"] == 0.0
+    assert metrics["latest_loss"] == 0.0
+    assert metrics["alpha"] == pytest.approx(trainer.alpha.item())


### PR DESCRIPTION
## What

Adds focused unit coverage for three untested behaviors of the off-policy `FastSacTrainer` (`strands_robots/training/rl/fast_sac.py`):

1. **Preflight validation branches** - `validate()` is the pure, read-only preflight that `train()` runs before touching torch or the env. One parametrized test isolates each numeric guard (`output_dir`, `total_timesteps`, `rollout_steps`, `buffer_size`, `batch_size`, `gradient_steps`), asserting the rejection message names the offending field. Previously only `num_envs`, `tau`, `env_factory`, and the wrong-spec-type branches were exercised; these six guards had no regression guard.
2. **Fixed-alpha setup** (`autotune_alpha=False`) - verifies the learner pins alpha as a plain non-grad tensor and builds no temperature optimizer, so `alpha` stays at `init_alpha`. This is the SAC-without-auto-entropy contract users opt into for a hand-tuned temperature.
3. **Warmup no-op update** - `update()` must short-circuit to zero-loss metrics while the replay buffer holds fewer than `batch_size` transitions, rather than sampling an undersized batch.

## Why

These are behavioral contracts (actionable preflight errors, constant-temperature mode, warmup safety) with no prior regression guard. Tests assert observable outputs (problem messages, tensor grad-mode, metric values), not internals.

## Coverage

`strands_robots/training/rl/fast_sac.py`: **96% -> ~99%**. The eight previously-uncovered lines (six preflight branches, fixed-alpha setup, warmup no-op) are now covered; the two remaining lines live inside the `train()` gradient loop (exercised by the integration smoke test).

## Testing

- `MUJOCO_GL=egl pytest tests/training/` -> 390 passed, 4 skipped.
- `tests/training/test_rl_fast_sac.py` -> 17 passed.
- ruff check / ruff format / mypy: clean.

Test-only change; no library behavior modified.