### PR TITLE
ci: retry apt-get update to survive transient third-party mirror failures

### DIFF
--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -30,7 +30,20 @@ jobs:
 
       - name: Install system dependencies (OpenGL for MuJoCo)
         run: |
-          sudo apt-get update
+          # The GitHub runner image preconfigures third-party apt repos (e.g.
+          # the packages.microsoft.com azure-cli feed) whose mirrors sometimes
+          # serve a corrupt InRelease file ("Clearsigned file isn't valid, got
+          # 'NOSPLIT'"), making a plain `apt-get update` exit 100 and fail the
+          # whole build. The packages we actually need (libosmesa6-dev, ffmpeg)
+          # come from the standard Ubuntu archive, so retry a few times with a
+          # short backoff to ride out transient mirror hiccups before failing.
+          for attempt in 1 2 3; do
+            if sudo apt-get update; then
+              break
+            fi
+            echo "apt-get update failed (attempt ${attempt}/3), retrying in 5s..."
+            sleep 5
+          done
           sudo apt-get install -y libosmesa6-dev ffmpeg
 
       # The Device Connect integration (strands_robots/device_connect) can


### PR DESCRIPTION
## Problem

The `Test and Lint` workflow (`.github/workflows/test-lint.yml`) installs system dependencies with a bare `sudo apt-get update`. The GitHub-hosted runner image preconfigures third-party apt repos (notably the `packages.microsoft.com` azure-cli / prod feeds) whose mirrors intermittently serve a corrupt `InRelease` file:

```
E: Failed to fetch https://packages.microsoft.com/repos/azure-cli/dists/noble/InRelease  Clearsigned file isn't valid, got 'NOSPLIT' (does the network require authentication?)
##[error]Process completed with exit code 100.
```

When this happens, `apt-get update` exits 100 and the whole build fails **before a single test runs**. This is currently flaking `main` (commit `2901a72`) and blocking the entire PR merge queue (approved PRs sit in `BLOCKED` merge state).

## Fix

The packages we actually need (`libosmesa6-dev`, `ffmpeg`) come from the standard Ubuntu archive, which is unaffected by the flaky Microsoft mirror. Wrap `apt-get update` in a bounded 3-attempt retry with a short backoff so transient mirror hiccups no longer fail the build. The happy path is unchanged and the `apt-get install` line is untouched.

## Scope

- One file, one step. No behavior change when the first `apt-get update` succeeds.
- Documented inline so the intent survives future edits.

## Verification

- YAML parses cleanly (`yaml.safe_load`).
- Retry snippet passes `bash -n`.
- Diagnosed from the failing run log on both `main` and PR #1166 (identical root cause).