### PR TITLE
fix(sim): warn when a floating base's orientation + angular velocity are dropped from a recorded dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -936,6 +936,26 @@ surfaced, and `get_observation` gains `base_quat` / `base_ang_vel`. Newton
 stores the free joint's coordinates as `[xyz, quat_xyzw]`, so the quaternion is
 reordered `xyzw -> wxyz` to match the MuJoCo (w,x,y,z) contract.
 
+### Fixed: warn when a floating base's orientation + angular velocity are dropped from a recorded dataset
+
+`get_observation` surfaces `base_quat` (orientation, w,x,y,z) and `base_ang_vel`
+(rad/s) for a floating-base robot -- a humanoid's named `floating_base_joint` or
+a mobile base's unnamed `<freejoint>` -- so a locomotion / whole-body-control
+policy can read its base state. But `start_recording` derives the LeRobotDataset
+`observation.state` schema from the robot's scalar joint names, so those base
+signals never reached the dataset: the free base contributed only a single
+scalar slot (its x-position) when its joint was named, and nothing at all when
+it was unnamed. A dataset recorded from a humanoid/mobile rollout was therefore
+silently base-blind, and a policy trained on it would be missing the exact
+orientation/angular-velocity signals a locomotion controller needs. Both
+backends (MuJoCo and Newton) now warn once at `start_recording` when a
+floating-base robot is being recorded, naming the affected robot(s) and the
+dropped signals, per the project's "no silent data loss" contract. The dataset
+schema is intentionally unchanged (existing datasets are stable); this surfaces
+the omission instead of dropping it silently. A new shared
+`_robot_free_base_joint_id` helper centralizes the named+unnamed free-joint
+detection.
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/simulation/mujoco/recording.py
+++ b/strands_robots/simulation/mujoco/recording.py
@@ -46,6 +46,9 @@ class RecordingMixin(DatasetRecordingMixin):
         def robot_action_keys(self, robot_name: str) -> list[str]:
             """Actuator-ordered action keys for ``robot_name`` (concrete on SimEngine)."""
 
+        def _robot_free_base_joint_id(self, model: Any, robot: Any) -> int:
+            """Free-base joint id for ``robot`` or -1 (concrete on RenderingMixin)."""
+
     def start_recording(
         self,
         repo_id: str = "local/sim_recording",
@@ -189,6 +192,20 @@ class RecordingMixin(DatasetRecordingMixin):
                 robot_type = robot.data_config or rname
 
             mj = _ensure_mujoco()
+            # Doctrine: warn loudly, never silently surprise. A floating-base
+            # robot (humanoid/mobile) has base orientation + angular velocity
+            # surfaced by get_observation (base_quat/base_ang_vel), but the
+            # observation.state schema above is derived from scalar joint names,
+            # so those base signals are dropped from the recorded dataset. Flag
+            # it at recording start rather than yielding a silently base-blind
+            # training set. (Non-breaking: the schema is unchanged.)
+            floating_base_robots = [
+                rname
+                for rname, robot in self._world.robots.items()
+                if self._robot_free_base_joint_id(self._world._model, robot) >= 0
+            ]
+            self._warn_floating_base_state_dropped(floating_base_robots)
+
             # Declare each camera in the dataset schema at the SAME
             # resolution it actually renders at. Cameras added via add_camera
             # carry their own width/height (e.g. 256x256 for a LIBERO VLA),

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -276,6 +276,28 @@ class RenderingMixin:
             break
         return -1
 
+    def _robot_free_base_joint_id(self, model: Any, robot: Any) -> int:
+        """Return the id of ``robot``'s floating-base free joint, or ``-1``.
+
+        Combined detection shared by observation surfacing and dataset
+        recording: first scans ``robot.joint_names`` for a NAMED free joint (a
+        humanoid's ``floating_base_joint``), then falls back to the
+        kinematic-tree walk (:meth:`_robot_base_free_joint`) for an UNNAMED
+        ``<freejoint>`` (a mobile base like LeKiwi). A fixed-base arm has
+        neither and returns ``-1``. Mirrors the free-joint detection inlined in
+        :meth:`_get_sim_observation`.
+        """
+        mj = _ensure_mujoco()
+        pfx = robot.namespace or ""
+        for jnt_name in robot.joint_names:
+            lookup = pfx + jnt_name if pfx else jnt_name
+            jnt_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, lookup)
+            if jnt_id < 0 and pfx:
+                jnt_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, jnt_name)
+            if jnt_id >= 0 and model.jnt_type[jnt_id] == mj.mjtJoint.mjJNT_FREE:
+                return int(jnt_id)
+        return self._robot_base_free_joint(model, robot, pfx)
+
     def _get_sim_observation(self, robot_name: str, *, skip_images: bool = False) -> dict[str, Any]:
         """Get observation from sim: joint state + cameras (unless skipped).
 

--- a/strands_robots/simulation/newton/recording.py
+++ b/strands_robots/simulation/newton/recording.py
@@ -47,6 +47,7 @@ class NewtonRecordingMixin(DatasetRecordingMixin):
     if TYPE_CHECKING:
         _world: SimWorld | None
         _model: Any
+        _robot_free_base_joint: dict[str, str]
         default_width: int
         default_height: int
 
@@ -157,6 +158,16 @@ class NewtonRecordingMixin(DatasetRecordingMixin):
             resume_existing = self._prepare_dataset_target(dataset_dir, overwrite)
 
             joint_names, camera_keys, camera_dims, robot_type, recording_cameras = self._collect_recording_schema()
+
+            # Doctrine parity with the MuJoCo backend: a floating-base robot
+            # (humanoid/mobile) surfaces base_quat/base_ang_vel via
+            # get_observation, but the joint-name-derived observation.state
+            # schema drops them from the recorded dataset. Flag it at recording
+            # start rather than yielding a silently base-blind training set.
+            # (Non-breaking: the schema is unchanged.)
+            free_base_joints = getattr(self, "_robot_free_base_joint", {})
+            floating_base_robots = [rname for rname in world.robots if free_base_joints.get(rname)]
+            self._warn_floating_base_state_dropped(floating_base_robots)
 
             # Optional camera scoping (parity with the MuJoCo backend). By
             # default every named scene camera is recorded; when ``cameras`` is

--- a/strands_robots/simulation/recording.py
+++ b/strands_robots/simulation/recording.py
@@ -47,6 +47,39 @@ class DatasetRecordingMixin:
         default_width: int
         default_height: int
 
+    def _warn_floating_base_state_dropped(self, robot_names: list[str]) -> None:
+        """Warn that a floating base's orientation + angular velocity are not
+        captured in the recorded ``observation.state``.
+
+        ``get_observation`` surfaces ``base_quat`` (orientation, w,x,y,z) and
+        ``base_ang_vel`` (rad/s) for a floating-base robot (a humanoid or a
+        mobile base), but the dataset's ``observation.state`` schema is derived
+        from the robot's scalar joint names, so those base signals are dropped
+        from every recorded frame - the free base contributes only a single
+        scalar slot (its x-position) when its joint is named, and nothing at
+        all when it is an unnamed ``<freejoint>``. A locomotion / whole-body
+        control policy trained on the resulting dataset would be missing its
+        base state.
+
+        This does NOT change the schema (existing datasets are unchanged); it
+        surfaces the omission at recording start instead of dropping the base
+        state silently, per the "no silent data loss" contract. Called once per
+        :meth:`start_recording` (both backends) - not on the per-frame path.
+        """
+        if not robot_names:
+            return
+        logger.warning(
+            "start_recording: robot(s) %s have a floating base, but the "
+            "recorded observation.state captures only scalar joint positions - "
+            "the base orientation (base_quat) and angular velocity "
+            "(base_ang_vel) that get_observation surfaces are NOT written to "
+            "the dataset. A locomotion/whole-body-control policy needs that "
+            "base state; if you are training on the floating base, record it "
+            "through a base-aware pipeline or extend the dataset schema with "
+            "the base features explicitly.",
+            robot_names,
+        )
+
     @staticmethod
     def _prepare_dataset_target(dataset_dir: Path, overwrite: bool) -> bool:
         """Resolve create-vs-resume and make ``dataset_dir`` safe for create().

--- a/tests/simulation/mujoco/test_recording_floating_base_state_warn.py
+++ b/tests/simulation/mujoco/test_recording_floating_base_state_warn.py
@@ -1,0 +1,149 @@
+"""Regression tests: start_recording warns when a floating base's orientation +
+angular velocity are silently dropped from the recorded observation.state.
+
+``get_observation`` surfaces ``base_quat`` (orientation, w,x,y,z) and
+``base_ang_vel`` (rad/s) for a floating-base robot (a humanoid's named
+``floating_base_joint`` or a mobile base's unnamed ``<freejoint>``). The
+LeRobotDataset ``observation.state`` schema, however, is derived from the
+robot's scalar joint names, so those base signals never reach the dataset - a
+locomotion/whole-body-control policy trained on it would be base-blind. The
+schema is intentionally left unchanged (existing datasets are stable); the
+omission is surfaced at recording start instead of dropped silently, matching
+the project's "no silent data loss" contract.
+"""
+
+import logging
+import tempfile
+
+import pytest
+
+from strands_robots.simulation.mujoco.simulation import Simulation
+
+# Humanoid-style floating base: a NAMED free root joint (enumerated in
+# robot.joint_names, like a real ``floating_base_joint``) + one actuated hinge.
+NAMED_BASE_XML = """
+<mujoco model="test_named_base">
+  <compiler angle="radian" autolimits="true"/>
+  <option timestep="0.002"/>
+  <worldbody>
+    <light name="main" pos="0 0 3" dir="0 0 -1"/>
+    <geom name="ground" type="plane" size="5 5 0.01" rgba="0.9 0.9 0.9 1"/>
+    <body name="torso" pos="0 0 0.5">
+      <joint name="floating_base_joint" type="free"/>
+      <geom type="box" size="0.1 0.1 0.2" rgba="0.3 0.3 0.8 1"/>
+      <body name="thigh" pos="0 0 -0.2">
+        <geom type="capsule" size="0.03" fromto="0 0 0 0 0 -0.2" rgba="0.8 0.3 0.3 1"/>
+        <joint name="hip" type="hinge" axis="0 1 0" range="-1.57 1.57"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <motor name="hip_act" joint="hip"/>
+  </actuator>
+</mujoco>
+"""
+
+# Mobile base: an UNNAMED free joint (not in robot.joint_names) + an actuated
+# hinge. Exercises the kinematic-tree fallback detection (LeKiwi-style).
+UNNAMED_BASE_XML = """
+<mujoco model="test_unnamed_base">
+  <compiler angle="radian" autolimits="true"/>
+  <option timestep="0.002"/>
+  <worldbody>
+    <light name="main" pos="0 0 3" dir="0 0 -1"/>
+    <geom name="ground" type="plane" size="5 5 0.01" rgba="0.9 0.9 0.9 1"/>
+    <body name="base_plate" pos="0 0 0.1">
+      <freejoint/>
+      <geom type="box" size="0.15 0.15 0.03" rgba="0.3 0.3 0.8 1"/>
+      <body name="arm" pos="0 0 0.05">
+        <geom type="capsule" size="0.02" fromto="0 0 0 0 0 0.2" rgba="0.8 0.3 0.3 1"/>
+        <joint name="shoulder" type="hinge" axis="0 1 0" range="-1.57 1.57"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <motor name="shoulder_act" joint="shoulder"/>
+  </actuator>
+</mujoco>
+"""
+
+# Fixed-base arm: NO free joint anywhere. Must never trigger the base-drop
+# warning (guards against a false positive).
+FIXED_ARM_XML = """
+<mujoco model="test_fixed_arm">
+  <compiler angle="radian" autolimits="true"/>
+  <worldbody>
+    <light name="main" pos="0 0 3" dir="0 0 -1"/>
+    <body name="link" pos="0 0 0.1">
+      <geom type="capsule" size="0.02" fromto="0 0 0 0 0 0.2"/>
+      <joint name="j0" type="hinge" axis="0 0 1"/>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="j0_act" joint="j0" kp="10"/>
+  </actuator>
+</mujoco>
+"""
+
+_WARN_MARK = "have a floating base"
+
+
+def _write(xml: str) -> str:
+    import os
+
+    fd, path = tempfile.mkstemp(suffix=".xml")
+    with os.fdopen(fd, "w") as f:
+        f.write(xml)
+    return path
+
+
+@pytest.fixture
+def sim():
+    pytest.importorskip("lerobot")  # start_recording produces a LeRobotDataset
+    s = Simulation(tool_name="test_fb_warn", mesh=False)
+    s.create_world(ground_plane=False)
+    yield s
+    try:
+        s.cleanup()
+    except Exception:
+        pass
+
+
+def _start(sim, name, xml, caplog):
+    sim.add_robot(name, urdf_path=_write(xml))
+    root = tempfile.mkdtemp(prefix=f"fbwarn_{name}_")
+    with caplog.at_level(logging.WARNING, logger="strands_robots.simulation.recording"):
+        res = sim.start_recording(repo_id=f"local/{name}_fbwarn", task="t", fps=20, root=root, cameras=[])
+    sim.stop_recording()
+    return res
+
+
+def test_start_recording_warns_when_named_floating_base_state_dropped(sim, caplog):
+    """A humanoid with a NAMED floating_base_joint: base_quat/base_ang_vel are
+    dropped from observation.state -> start_recording must warn."""
+    res = _start(sim, "humanoid", NAMED_BASE_XML, caplog)
+    assert res["status"] == "success"
+    base_warnings = [r for r in caplog.records if _WARN_MARK in r.getMessage()]
+    assert base_warnings, "floating-base state-drop warning was not emitted"
+    msg = base_warnings[0].getMessage()
+    assert "humanoid" in msg
+    assert "base_quat" in msg and "base_ang_vel" in msg
+
+
+def test_start_recording_warns_for_unnamed_mobile_base(sim, caplog):
+    """A mobile base on an UNNAMED freejoint (detected via the kinematic-tree
+    fallback) must also warn."""
+    res = _start(sim, "mob", UNNAMED_BASE_XML, caplog)
+    assert res["status"] == "success"
+    assert any(_WARN_MARK in r.getMessage() for r in caplog.records), (
+        "unnamed-freejoint mobile base must trigger the base-drop warning"
+    )
+
+
+def test_start_recording_no_base_warning_for_fixed_arm(sim, caplog):
+    """A fixed-base arm has no floating base -> no warning (no false positive)."""
+    res = _start(sim, "arm", FIXED_ARM_XML, caplog)
+    assert res["status"] == "success"
+    assert not any(_WARN_MARK in r.getMessage() for r in caplog.records), (
+        "fixed-base arm must NOT trigger the floating-base warning"
+    )

--- a/tests/simulation/mujoco/test_recording_floating_base_state_warn.py
+++ b/tests/simulation/mujoco/test_recording_floating_base_state_warn.py
@@ -106,6 +106,7 @@ def sim():
     try:
         s.cleanup()
     except Exception:
+        # Best-effort teardown: cleanup failures must not mask the test result.
         pass
 
 

--- a/tests/simulation/newton/test_dataset_recording.py
+++ b/tests/simulation/newton/test_dataset_recording.py
@@ -273,3 +273,45 @@ def test_start_recording_unknown_camera_errors(tmp_path):
     assert "front" in text  # the available list is surfaced
     # A failed scope must not leave the session flagged as recording.
     assert world._backend_state.get("recording") is False
+
+
+def test_start_recording_warns_when_floating_base_state_dropped(tmp_path, caplog):
+    """A floating-base robot (``_robot_free_base_joint`` populated) whose
+    base_quat/base_ang_vel are not in the joint-name-derived observation.state
+    schema triggers the base-drop warning at recording start (parity with the
+    MuJoCo backend)."""
+    import logging
+
+    world = _world_with_robot("humanoid")
+    engine = _make_engine(world)
+    # NewtonSimEngine.__init__ records the base free joint per robot; the __new__
+    # harness skips it, so set what a floating-base build would produce.
+    engine._robot_free_base_joint = {"humanoid": "floating_base_joint"}
+
+    with caplog.at_level(logging.WARNING, logger="strands_robots.simulation.recording"):
+        started = engine.start_recording(
+            repo_id="local/newton_fb_warn", root=str(tmp_path / "ds"), fps=20, overwrite=True
+        )
+    engine.stop_recording()
+    assert started["status"] == "success", started
+    base_warnings = [r for r in caplog.records if "have a floating base" in r.getMessage()]
+    assert base_warnings, "floating-base state-drop warning was not emitted"
+    assert "humanoid" in base_warnings[0].getMessage()
+
+
+def test_start_recording_no_base_warning_for_fixed_arm(tmp_path, caplog):
+    """A fixed-base arm (no floating base recorded) must NOT warn - and the
+    detection must degrade gracefully when ``_robot_free_base_joint`` is absent
+    entirely (the __new__ harness leaves it unset)."""
+    import logging
+
+    engine = _make_engine(_world_with_robot("so100"))
+    assert not hasattr(engine, "_robot_free_base_joint")  # attr absent -> getattr default
+
+    with caplog.at_level(logging.WARNING, logger="strands_robots.simulation.recording"):
+        started = engine.start_recording(
+            repo_id="local/newton_arm_nowarn", root=str(tmp_path / "ds"), fps=20, overwrite=True
+        )
+    engine.stop_recording()
+    assert started["status"] == "success", started
+    assert not any("have a floating base" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Problem

`get_observation` surfaces a floating base's IMU-style signals so a locomotion / whole-body-control policy can read them: `base_quat` (orientation, w,x,y,z) and `base_ang_vel` (rad/s), for both a humanoid's *named* `floating_base_joint` and a mobile base's *unnamed* `<freejoint>`.

But `start_recording` derives the LeRobotDataset `observation.state` schema from the robot's **scalar joint names**, so those base signals never reach the recorded dataset:

- a *named* free joint contributes a single scalar slot (its base x-position) and drops the rest of the base pose + all of the base velocity;
- an *unnamed* freejoint is not in `joint_names` at all, so the base is entirely absent.

A dataset recorded from a humanoid/mobile rollout is therefore silently **base-blind**, and a policy trained on it is missing exactly the orientation/angular-velocity feedback a locomotion controller needs — with no signal to the user.

## Evidence (real Unitree G1 recording, MuJoCo)

```
get_observation(unitree_g1): base_quat (4,)  base_ang_vel (3,)  present
joint_names[0] == 'floating_base_joint'
recorded observation.state: shape (30,), names == joint_names
  -> 'floating_base_joint' is ONE scalar slot; 'base_quat'/'base_ang_vel' absent
```

## Change

Both backends (MuJoCo and Newton) now emit a single `logger.warning` at `start_recording` when a floating-base robot is being recorded, naming the affected robot(s) and the dropped signals — matching the project's existing "warn loudly, never silently surprise / no silent data loss" recording diagnostics (e.g. the implicit-`default`-camera and ctrl-clamp warnings).

This is **non-breaking**: the `observation.state` schema is intentionally unchanged (existing datasets are stable). It surfaces the omission instead of dropping it silently. Capturing the base signals into `observation.state` is a larger, schema-changing follow-up (it also needs `get_observation` to surface full base *position*, not just base-x) and is deliberately out of scope here.

Implementation:
- `RenderingMixin._robot_free_base_joint_id(model, robot)` — a shared helper that centralizes the named + unnamed free-joint detection (the named scan mirrors the inline detection in `_get_sim_observation`; the unnamed case reuses `_robot_base_free_joint`).
- `DatasetRecordingMixin._warn_floating_base_state_dropped(robot_names)` — the shared, engine-independent warning.
- MuJoCo `start_recording` detects via the helper; Newton detects via its existing `_robot_free_base_joint` map (`getattr` default so it degrades cleanly when the engine is built without the Warp stack).

## Tests (fail before, pass after)

- `tests/simulation/mujoco/test_recording_floating_base_state_warn.py` (GL-free, inline MJCF): named humanoid base warns, unnamed mobile base warns (kinematic-tree fallback), fixed-base arm does **not** warn (no false positive). The two positive tests fail before the fix (no warning emitted) and pass after.
- `tests/simulation/newton/test_dataset_recording.py`: adds the Newton wiring cases (floating base warns; fixed arm stays silent and degrades gracefully when `_robot_free_base_joint` is unset). Fails before, passes after.

## Local gate

- `ruff check` + `ruff format --check` clean; `mypy` clean on all four changed source files.
- `55 passed` across the MuJoCo recording + floating-base-observation + Newton recording suites (`MUJOCO_GL=egl`).
- Verified end to end that the warning fires for a real G1 (both MuJoCo and Newton engines) and is silent for an SO-101 arm.

---

## Round 1 changelog

- Address CodeQL empty-except finding on the `sim` fixture teardown: the `except Exception: pass` intentionally swallows cleanup errors so a teardown failure cannot mask the test result. Added an explanatory comment documenting that best-effort intent (no behavior change).