### PR TITLE
test(lerobot_local): cover processor-bridge load-failure fallback and fail-fast

### DIFF
--- a/tests/policies/lerobot_local/test_embodiment_config_failure_diagnostics.py
+++ b/tests/policies/lerobot_local/test_embodiment_config_failure_diagnostics.py
@@ -120,3 +120,50 @@ def test_active_bridge_without_postprocessor_still_warns(monkeypatch, caplog):
     assert pol._processor_bridge is bridge
     msgs = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
     assert any("policy_postprocessor.json" in m for m in msgs), msgs
+
+
+def _patch_from_pretrained_raises(monkeypatch, exc: Exception) -> None:
+    """Make ``ProcessorBridge.from_pretrained`` raise -- the checkpoint ships
+    no loadable processor pipeline (missing configs / optional import)."""
+
+    def _boom(cls, *a, **k):
+        raise exc
+
+    monkeypatch.setattr(
+        "strands_robots.policies.lerobot_local.policy.ProcessorBridge.from_pretrained",
+        classmethod(_boom),
+    )
+
+
+def test_from_pretrained_failure_falls_back_to_raw_flow(monkeypatch, caplog):
+    """When ``ProcessorBridge.from_pretrained`` raises and no overrides were
+    requested, the checkpoint legitimately has no pipeline: fall back to the
+    raw obs/action flow (bridge is None, no embodiment-config failure) and
+    still emit the missing-postprocessor warning so a raw-action checkpoint
+    is not mistaken for a frozen policy."""
+    _patch_from_pretrained_raises(monkeypatch, FileNotFoundError("no processor configs"))
+    pol = _make_policy(embodiment=None)
+
+    with caplog.at_level(logging.WARNING):
+        pol._load_processor_bridge()
+
+    assert pol._processor_bridge is None
+    assert pol._embodiment_config_failed is False
+    msgs = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    # The generic missing-postprocessor diagnostic still fires for the raw flow.
+    assert any("policy_postprocessor.json" in m for m in msgs), msgs
+
+
+def test_from_pretrained_failure_raises_when_overrides_requested(monkeypatch):
+    """A caller that passes ``processor_overrides`` has opted into the
+    processor pipeline; if ``from_pretrained`` cannot load it, silently
+    dropping the overrides would be a hidden behaviour change. The load must
+    fail-fast with a RuntimeError naming the real cause instead."""
+    _patch_from_pretrained_raises(monkeypatch, ValueError("incompatible processor config"))
+    pol = _make_policy(
+        embodiment=None,
+        processor_overrides={"normalizer_processor": {"stats": {}}},
+    )
+
+    with pytest.raises(RuntimeError, match="Processor bridge failed to load"):
+        pol._load_processor_bridge()


### PR DESCRIPTION
## What

`LerobotLocalPolicy._load_processor_bridge` has two independent failure modes, documented in its own docstring. The `_configure_embodiment` `ValueError` branch is already pinned by `test_embodiment_config_failure_diagnostics.py`, but the earlier branch, `ProcessorBridge.from_pretrained` itself raising, had no coverage. This adds two focused tests for it.

## Behavior pinned

When `ProcessorBridge.from_pretrained` raises (`FileNotFoundError`/`ValueError`/`ImportError`, i.e. the checkpoint ships no loadable processor pipeline):

- **No overrides requested** -> fall back to the raw obs/action flow: `_processor_bridge` becomes `None`, `_embodiment_config_failed` stays `False`, and the generic missing-postprocessor warning still fires so a raw-action checkpoint is not mistaken for a frozen policy.
- **`processor_overrides` requested** -> fail-fast with a `RuntimeError`. The caller explicitly opted into the processor pipeline, so silently discarding their overrides would be a hidden behavior change.

The second test guards the no-silent-defaults contract: if the `if self.processor_overrides: raise` guard were dropped, it would fail.

## Tests

Added to `tests/policies/lerobot_local/test_embodiment_config_failure_diagnostics.py`:
- `test_from_pretrained_failure_falls_back_to_raw_flow`
- `test_from_pretrained_failure_raises_when_overrides_requested`

They reuse the existing `_make_policy` scaffold (patches `_load_model`) and monkeypatch `ProcessorBridge.from_pretrained` to raise, so no model weights or network are needed. This covers the previously-uncovered `except (FileNotFoundError, ValueError, ImportError)` block in `_load_processor_bridge`.

Local gate: `ruff check` + `ruff format --check` clean; full `tests/policies/lerobot_local/` suite green (525 passed).