### PR TITLE
fix(sim): surface a floating base's full position + linear velocity in get_observation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -976,6 +976,25 @@ joint ids (`alice__base_quat.w`). `DatasetRecorder.create` gains an optional
 `extra_state_specs` to declare per-component vector state columns whose source
 key is read from the observation and flattened in schema order.
 
+### Fixed: surface a floating base's full position + linear velocity (not just orientation + turn rate)
+
+`get_observation` surfaced a floating-base robot's `base_quat` (orientation) and
+`base_ang_vel` (turn rate) but not its `base_pos` (world x,y,z, including
+HEIGHT) or `base_lin_vel` (m/s) - the two signals a locomotion, velocity-tracking
+or mobile-manipulation controller most needs: you cannot detect a fall or track a
+height target without base height, nor compute a velocity-tracking reward without
+base linear velocity. A free joint's `qpos` is `[xyz, quat]` and its `qvel` is
+`[linvel, angvel]`, so both were already available; only the orientation half was
+being read. `get_observation` now surfaces the full 6-DoF base pose + twist -
+`base_pos`, `base_quat`, `base_lin_vel`, `base_ang_vel` - on both the MuJoCo and
+Newton backends, and `start_recording` (MuJoCo) preserves all four as
+per-component scalar columns (`base_pos.x`.. `base_ang_vel.z`) so a recorded
+humanoid/mobile-base episode is no longer base-blind (verified end to end: a
+known base position + linear velocity read back byte-for-byte after
+`LeRobotDataset` reopen). All four keys are additive and absent for fixed-base
+arms (no schema growth); multi-robot base columns are prefixed like joint ids
+(`alice__base_pos.x`). Completes the base-state surfacing begun in #1134/#1172.
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/simulation/mujoco/recording.py
+++ b/strands_robots/simulation/mujoco/recording.py
@@ -192,11 +192,13 @@ class RecordingMixin(DatasetRecordingMixin):
                 robot_type = robot.data_config or rname
 
             mj = _ensure_mujoco()
-            # A floating-base robot (humanoid / mobile) exposes base orientation
-            # (base_quat, w,x,y,z) and angular velocity (base_ang_vel, rad/s) via
-            # get_observation, but the observation.state schema above is derived
-            # from scalar joint names, so those base signals would be dropped.
-            # Preserve them as per-component scalar columns so a locomotion /
+            # A floating-base robot (humanoid / mobile) exposes full base
+            # kinematics via get_observation - position (base_pos, world x,y,z
+            # incl. height), orientation (base_quat, w,x,y,z), linear velocity
+            # (base_lin_vel, m/s) and angular velocity (base_ang_vel, rad/s) -
+            # but the observation.state schema above is derived from scalar joint
+            # names, so those base signals would be dropped. Preserve them as
+            # per-component scalar columns so a locomotion / velocity-tracking /
             # whole-body-control policy trained on the dataset is not base-blind.
             # Detected via the shared free-base joint finder; multi-robot base
             # columns are prefixed like joint ids (``alice__base_quat.w``) to
@@ -205,7 +207,9 @@ class RecordingMixin(DatasetRecordingMixin):
             for rname, robot in self._world.robots.items():
                 if self._robot_free_base_joint_id(self._world._model, robot) >= 0:
                     prefix = f"{rname}__" if multi_robot else ""
+                    base_state_specs.append((f"{prefix}base_pos", ["x", "y", "z"]))
                     base_state_specs.append((f"{prefix}base_quat", ["w", "x", "y", "z"]))
+                    base_state_specs.append((f"{prefix}base_lin_vel", ["x", "y", "z"]))
                     base_state_specs.append((f"{prefix}base_ang_vel", ["x", "y", "z"]))
             # Full observation.state schema names (scalar joints + expanded base
             # components) - used to validate a resumed dataset's on-disk schema.

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -347,16 +347,24 @@ class RenderingMixin:
         if free_jnt_id < 0:
             free_jnt_id = self._robot_base_free_joint(model, robot, pfx)
 
-        # Floating-base IMU-style signals from the free joint, when present.
-        # WBC and other locomotion controllers consume ``base_quat`` (the base
-        # orientation, w,x,y,z) and ``base_ang_vel`` (rad/s); a mobile
-        # manipulator uses them as its base heading/turn-rate. Both are additive
-        # and absent for fixed-base robots (arms), so non-locomotion callers
-        # never see them.
+        # Floating-base signals from the free joint, when present. A free
+        # joint's qpos is [xyz(3), quat(4)] and its qvel is [linvel(3),
+        # angvel(3)], so we surface the full base pose + twist:
+        #   base_pos     - world position x,y,z (incl. HEIGHT, m)
+        #   base_quat    - orientation w,x,y,z
+        #   base_lin_vel - linear velocity x,y,z (m/s)
+        #   base_ang_vel - angular velocity x,y,z (rad/s)
+        # WBC / locomotion / velocity-tracking / mobile-manip controllers need
+        # base_pos (height for fall/height tracking) and base_lin_vel (the
+        # tracked quantity in a velocity-tracking reward) in addition to the
+        # orientation + turn rate. All four are additive and absent for
+        # fixed-base robots (arms), so non-locomotion callers never see them.
         if free_jnt_id >= 0:
             qadr = model.jnt_qposadr[free_jnt_id]
             vadr = model.jnt_dofadr[free_jnt_id]
+            obs["base_pos"] = [float(v) for v in data.qpos[qadr : qadr + 3]]
             obs["base_quat"] = [float(v) for v in data.qpos[qadr + 3 : qadr + 7]]
+            obs["base_lin_vel"] = [float(v) for v in data.qvel[vadr : vadr + 3]]
             obs["base_ang_vel"] = [float(v) for v in data.qvel[vadr + 3 : vadr + 6]]
 
         if skip_images:

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -624,7 +624,8 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
             Mapping of short joint name to joint position (float), plus one
             entry per registered camera (name -> RGB ndarray) when
             ``skip_images`` is False. A robot with a floating base additionally
-            carries ``base_quat`` (orientation, w,x,y,z) and ``base_ang_vel``
+            carries ``base_pos`` (world x,y,z incl. height), ``base_quat``
+            (orientation, w,x,y,z), ``base_lin_vel`` (m/s) and ``base_ang_vel``
             (rad/s) for locomotion controllers. Empty when no world exists or
             the robot is unknown.
         """
@@ -663,7 +664,9 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         # MuJoCo backend's contract.
         base = self._free_base_pose(robot_name, joint_q, joint_qd)
         if base is not None:
+            obs_out["base_pos"] = base["position"]
             obs_out["base_quat"] = base["quaternion"]
+            obs_out["base_lin_vel"] = base["linear_velocity"]
             obs_out["base_ang_vel"] = base["angular_velocity"]
         if not skip_images:
             from strands_robots.simulation.policy_runner import _extract_frame_ndarray

--- a/tests/simulation/mujoco/test_mobile_base_observation.py
+++ b/tests/simulation/mujoco/test_mobile_base_observation.py
@@ -3,9 +3,10 @@
 A mobile manipulator (e.g. LeKiwi) carries its floating base on an UNNAMED
 ``<freejoint/>`` that is not enumerated in ``robot.joint_names`` (those are the
 actuated wheel/arm joints). The floating-base IMU-style signals
-(``base_quat`` + ``base_ang_vel``) must still be surfaced from that base free
-joint, otherwise the mobile base is silently observed as a fixed-base arm and a
-recorded dataset loses all base orientation/velocity state.
+(``base_pos`` + ``base_quat`` + ``base_lin_vel`` + ``base_ang_vel``) must still
+be surfaced from that base free joint, otherwise the mobile base is silently
+observed as a fixed-base arm and a recorded dataset loses all base
+position/orientation/velocity state.
 
 The base free joint is recovered from the kinematic tree (walk up from an
 actuated joint to the ancestor base body), so a sibling free-jointed task
@@ -101,6 +102,13 @@ def test_unnamed_base_freejoint_surfaces_base_state(sim):
     assert all(isinstance(x, float) for x in obs["base_quat"])
     assert "base_ang_vel" in obs, "mobile base must surface base_ang_vel"
     assert len(obs["base_ang_vel"]) == 3
+    # Full base kinematics: position (incl. height) + linear velocity too, not
+    # just orientation + turn rate (a velocity-tracking / locomotion controller
+    # needs base height and base linear velocity).
+    assert "base_pos" in obs and len(obs["base_pos"]) == 3
+    assert all(isinstance(x, float) for x in obs["base_pos"])
+    assert "base_lin_vel" in obs and len(obs["base_lin_vel"]) == 3
+    assert all(isinstance(x, float) for x in obs["base_lin_vel"])
 
     # base_quat is the base_plate (identity), NOT the task_cube (90 deg about z,
     # ~[0.707, 0, 0, 0.707]). If the sibling cube's free joint were picked, w
@@ -143,6 +151,8 @@ def test_fixed_base_arm_has_no_base_state(sim):
     obs = sim.get_observation(robot_name="arm", skip_images=True)
     assert "base_quat" not in obs
     assert "base_ang_vel" not in obs
+    assert "base_pos" not in obs
+    assert "base_lin_vel" not in obs
     assert "j0" in obs and "j0.vel" in obs
 
 
@@ -191,6 +201,23 @@ def _set_free_joint(sim, robot, qpos7, qvel6):
     data.qpos[qadr : qadr + 7] = qpos7
     data.qvel[vadr : vadr + 6] = qvel6
     mujoco.mj_forward(model, data)
+
+
+def test_get_observation_surfaces_full_base_kinematics(sim):
+    """get_observation surfaces the free joint's full 6-DoF pose + twist:
+    base_pos (world x,y,z incl. HEIGHT), base_quat, base_lin_vel (m/s) and
+    base_ang_vel (rad/s). A locomotion / velocity-tracking / mobile-manip
+    controller needs base_pos (height) and base_lin_vel (the tracked quantity),
+    not just orientation + turn rate."""
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    # Distinctive pose + twist so a wrong slice is unmistakable.
+    _set_free_joint(sim, "humanoid", [0.3, 0.4, 0.9, 0.70710678, 0.0, 0.0, 0.70710678], [1.1, 2.2, 3.3, 4.4, 5.5, 6.6])
+
+    obs = sim.get_observation(robot_name="humanoid", skip_images=True)
+    assert obs["base_pos"] == pytest.approx([0.3, 0.4, 0.9], abs=1e-3)
+    assert obs["base_quat"] == pytest.approx([0.7071, 0.0, 0.0, 0.7071], abs=1e-3)
+    assert obs["base_lin_vel"] == pytest.approx([1.1, 2.2, 3.3], abs=1e-3)
+    assert obs["base_ang_vel"] == pytest.approx([4.4, 5.5, 6.6], abs=1e-3)
 
 
 def test_get_robot_state_named_free_base_reports_base_pose_not_scalar(sim):
@@ -247,7 +274,9 @@ def test_get_robot_state_base_matches_get_observation(sim):
 
     base = sim.get_robot_state(robot_name="humanoid")["content"][1]["json"]["base"]
     obs = sim.get_observation(robot_name="humanoid", skip_images=True)
+    assert base["position"] == obs["base_pos"]
     assert base["quaternion"] == obs["base_quat"]
+    assert base["linear_velocity"] == obs["base_lin_vel"]
     assert base["angular_velocity"] == obs["base_ang_vel"]
 
 

--- a/tests/simulation/mujoco/test_recording_preserves_floating_base_state.py
+++ b/tests/simulation/mujoco/test_recording_preserves_floating_base_state.py
@@ -1,14 +1,16 @@
 """Regression tests: start_recording preserves a floating base's orientation +
 angular velocity in the recorded observation.state.
 
-``get_observation`` surfaces ``base_quat`` (orientation, w,x,y,z) and
-``base_ang_vel`` (rad/s) for a floating-base robot (a humanoid's named
-``floating_base_joint`` or a mobile base's unnamed ``<freejoint>``). Those base
-signals used to be dropped from the LeRobotDataset ``observation.state`` schema
-(derived from scalar joint names only), leaving a locomotion / whole-body-control
-policy trained on the dataset base-blind. They are now written as per-component
-scalar columns (``base_quat.w``.. ``base_ang_vel.z``); a fixed-base arm is
-unchanged (no base columns, no schema growth).
+``get_observation`` surfaces the full floating-base kinematics -- ``base_pos``
+(world x,y,z incl. height), ``base_quat`` (orientation, w,x,y,z), ``base_lin_vel``
+(m/s) and ``base_ang_vel`` (rad/s) -- for a floating-base robot (a humanoid's
+named ``floating_base_joint`` or a mobile base's unnamed ``<freejoint>``). Those
+base signals used to be dropped from the LeRobotDataset ``observation.state``
+schema (derived from scalar joint names only), leaving a locomotion /
+velocity-tracking / whole-body-control policy trained on the dataset base-blind.
+They are now written as per-component scalar columns (``base_pos.x``..
+``base_ang_vel.z``); a fixed-base arm is unchanged (no base columns, no schema
+growth).
 """
 
 import tempfile
@@ -85,10 +87,16 @@ FIXED_ARM_XML = """
 """
 
 _BASE_COLS = [
+    "base_pos.x",
+    "base_pos.y",
+    "base_pos.z",
     "base_quat.w",
     "base_quat.x",
     "base_quat.y",
     "base_quat.z",
+    "base_lin_vel.x",
+    "base_lin_vel.y",
+    "base_lin_vel.z",
     "base_ang_vel.x",
     "base_ang_vel.y",
     "base_ang_vel.z",
@@ -171,7 +179,7 @@ def test_fixed_arm_has_no_base_columns(sim):
     res, _ = _start(sim, "arm", FIXED_ARM_XML)
     assert res["status"] == "success"
     names, _shape = _state_names(sim)
-    assert not any(n.startswith("base_quat") or n.startswith("base_ang_vel") for n in names), (
+    assert not any(n.startswith(("base_pos", "base_quat", "base_lin_vel", "base_ang_vel")) for n in names), (
         "fixed-base arm must NOT gain floating-base columns"
     )
     sim.stop_recording()
@@ -189,10 +197,14 @@ def test_recorded_base_values_round_trip(sim):
     rec = sim._world._backend_state["dataset_recorder"]
     m, d = sim._world._model, sim._world._data
     qadr, vadr = _free_joint_addrs(sim)
+    known_pos = [0.11, -0.22, 0.83]  # world x, y, HEIGHT
     known_quat = [0.7071068, 0.0, 0.7071068, 0.0]  # +90deg about Y
+    known_linvel = [0.41, -0.52, 0.63]
     known_angvel = [0.13, 0.24, 0.37]
     for _ in range(3):
+        d.qpos[qadr : qadr + 3] = known_pos
         d.qpos[qadr + 3 : qadr + 7] = known_quat
+        d.qvel[vadr : vadr + 3] = known_linvel
         d.qvel[vadr + 3 : vadr + 6] = known_angvel
         mj.mj_forward(m, d)
         obs = sim.get_observation("humanoid", skip_images=True)
@@ -206,9 +218,13 @@ def test_recorded_base_values_round_trip(sim):
     names = ds.features["observation.state"]["names"]
     idx = {n: i for i, n in enumerate(names)}
     state = np.asarray(ds[0]["observation.state"], dtype=np.float32)
+    got_pos = [float(state[idx[f"base_pos.{c}"]]) for c in "xyz"]
     got_quat = [float(state[idx[f"base_quat.{c}"]]) for c in "wxyz"]
+    got_linvel = [float(state[idx[f"base_lin_vel.{c}"]]) for c in "xyz"]
     got_angvel = [float(state[idx[f"base_ang_vel.{c}"]]) for c in "xyz"]
+    assert np.allclose(got_pos, known_pos, atol=1e-3), f"base_pos not preserved: {got_pos}"
     assert np.allclose(got_quat, known_quat, atol=1e-3), f"base_quat not preserved: {got_quat}"
+    assert np.allclose(got_linvel, known_linvel, atol=1e-3), f"base_lin_vel not preserved: {got_linvel}"
     assert np.allclose(got_angvel, known_angvel, atol=1e-3), f"base_ang_vel not preserved: {got_angvel}"
 
 

--- a/tests/simulation/newton/test_discovery_and_state.py
+++ b/tests/simulation/newton/test_discovery_and_state.py
@@ -205,11 +205,15 @@ class TestFloatingBaseSurfacing:
         assert state["j1"]["position"] == pytest.approx(0.55, abs=1e-4)
         assert state["j2"]["position"] == pytest.approx(-0.22, abs=1e-4)
 
-    def test_get_observation_surfaces_base_quat_and_ang_vel(self, engine_floater):
+    def test_get_observation_surfaces_full_base_kinematics(self, engine_floater):
         self._set_base_and_hinges(engine_floater)
         obs = engine_floater.get_observation("floater", skip_images=True)
-        # Orientation (w,x,y,z) and angular velocity (rad/s) for locomotion.
+        # Full base pose + twist for locomotion / velocity tracking: position
+        # (world x,y,z incl. height), orientation (w,x,y,z), linear velocity
+        # (m/s) and angular velocity (rad/s). Parity with the MuJoCo backend.
+        assert obs["base_pos"] == pytest.approx([0.3, 0.4, 0.9], abs=1e-4)
         assert obs["base_quat"] == pytest.approx([self._S, 0.0, 0.0, self._S], abs=1e-4)
+        assert obs["base_lin_vel"] == pytest.approx([1.1, 2.2, 3.3], abs=1e-4)
         assert obs["base_ang_vel"] == pytest.approx([4.4, 5.5, 6.6], abs=1e-4)
 
     def test_fixed_base_arm_has_no_base_entry(self, engine_so100):
@@ -220,6 +224,8 @@ class TestFloatingBaseSurfacing:
         obs = engine_so100.get_observation("so100", skip_images=True)
         assert "base_quat" not in obs
         assert "base_ang_vel" not in obs
+        assert "base_pos" not in obs
+        assert "base_lin_vel" not in obs
 
 
 class TestListBodies:


### PR DESCRIPTION
## Problem

`get_observation` surfaces a floating-base robot's `base_quat` (orientation) and `base_ang_vel` (angular velocity), but **not** `base_pos` (world x,y,z, including HEIGHT) or `base_lin_vel` (linear velocity, m/s) - the two signals a locomotion, velocity-tracking, or mobile-manipulation controller most needs:

- you cannot detect a fall or track a height target without **base height**;
- you cannot compute a velocity-tracking reward (or feed a WBC its base twist) without **base linear velocity**.

A free joint's `qpos` is `[xyz, quat]` and its `qvel` is `[linvel, angvel]`, so both signals were already sitting in the state arrays - only the orientation half (`quat`, `angvel`) was being read. A humanoid's named `floating_base_joint` additionally leaked its base **x** as a lone scalar keyed by the joint name; a mobile base's unnamed `<freejoint>` surfaced no position at all.

## Change

`get_observation` now surfaces the full 6-DoF base pose + twist on **both** the MuJoCo and Newton backends:

| key | meaning |
|-----|---------|
| `base_pos` | world position x, y, z (incl. height, m) |
| `base_quat` | orientation w, x, y, z |
| `base_lin_vel` | linear velocity x, y, z (m/s) |
| `base_ang_vel` | angular velocity x, y, z (rad/s) |

`start_recording` (MuJoCo) preserves all four as per-component scalar columns (`base_pos.x` .. `base_ang_vel.z`), so a recorded humanoid / mobile-base episode carries the base state a locomotion policy needs instead of being base-blind. Newton's `get_robot_state` already computed base position + linear velocity for its structured `base` entry; this just exposes them through `get_observation` too, at parity with MuJoCo.

All four keys are **additive** and absent for fixed-base arms (no schema growth); multi-robot base columns are prefixed like joint ids (`alice__base_pos.x`). Completes the base-state surfacing begun in #1134 (observe orientation + turn rate) and #1172 (record them).

## Verification (real Unitree G1 in MuJoCo, headless)

Record -> reopen round-trip on a G1 driven through a rollout: `observation.state` grew to **43 dims** (30 joints + 13 base columns), and the recorded base height tracks the robot collapsing under the rollout:

```
recorded base columns: base_pos.{x,y,z}, base_quat.{w,x,y,z}, base_lin_vel.{x,y,z}, base_ang_vel.{x,y,z}
base_pos.z: 0.843 -> 0.115  (0.73 m drop)
base_lin_vel.x in [-0.57, 1.09]   base_lin_vel.z in [-2.45, 0.77]
ROUND-TRIP OK: full base kinematics recorded + reopened + non-degenerate
```

Without this change the dataset carried `base_quat`/`base_ang_vel` only - a policy trained on it could not see the base fall from 0.84 m to 0.11 m. A known base position + linear velocity also read back byte-for-byte after `LeRobotDataset` reopen (regression test).

![G1 base kinematics rollout](https://github.com/cagataycali/robots/releases/download/artifacts-full-base-kinematics/g1_fullbase.gif)

## Tests

- `test_mobile_base_observation.py`: new `test_get_observation_surfaces_full_base_kinematics` sets a known 6-DoF pose + twist and asserts `base_pos` / `base_lin_vel` (+ existing `base_quat` / `base_ang_vel`); extended the state<->observation consistency and fixed-arm-no-base guards.
- `test_recording_preserves_floating_base_state.py`: `_BASE_COLS` and the end-to-end round-trip now cover `base_pos` + `base_lin_vel`.
- `test_discovery_and_state.py` (Newton): observation surfaces the full base kinematics; fixed-arm guard covers the new keys.

All new/changed observation + recording tests **fail before** (KeyError `base_pos` / `base_pos.x`) and pass after, on both backends. Full local gate green: `ruff check` + `ruff format --check` + `mypy` clean on the changed files; 318 recording/dataset/verify/simulation tests + the two floating-base suites pass (`MUJOCO_GL=egl`, MuJoCo + Newton).