### PR TITLE
test(verify_dataset): cover mixed-length packed video frame-count skip

### DIFF
--- a/tests/test_verify_dataset.py
+++ b/tests/test_verify_dataset.py
@@ -416,6 +416,46 @@ class TestVideoFrameCountIntegrity:
         assert report["status"] == "error"
         assert any("6 frame(s)" in p and "maps 7 frame(s)" in p for p in report["problems"]), report["problems"]
 
+    def test_packed_file_with_one_null_length_skips_frame_check(self, tmp_path: Path) -> None:
+        pytest.importorskip("av")
+        # Two episodes packed into ONE shared file, but the second episode's
+        # ``length`` is null (some writers omit it per-row). The packed file's
+        # expected frame count is therefore only partially known (3 from ep0,
+        # unknown from ep1), so the total the parquet "maps" to the file cannot
+        # be computed confidently. The verifier must SKIP the frame-count
+        # comparison for that file rather than compare the real 5-frame video
+        # against the partial expected 3 and cry truncation. Removing that
+        # skip guard turns this into a false-positive "5 frame(s) but maps
+        # 3 frame(s)" error, so this pins the guard.
+        ep_dir = tmp_path / "meta" / "episodes" / "chunk-000"
+        ep_dir.mkdir(parents=True, exist_ok=True)
+        vk = "observation.images.cam1"
+        columns = {
+            "episode_index": [0, 1],
+            "length": [3, None],  # ep1 carries no length -> partial expected
+            f"videos/{vk}/chunk_index": [0, 0],
+            f"videos/{vk}/file_index": [0, 0],  # both episodes -> file 0
+        }
+        pq.write_table(pa.table(columns), ep_dir / "episodes_000.parquet")
+        info = {
+            "total_episodes": 2,
+            "total_frames": 3,
+            "features": {vk: {"dtype": "video", "shape": [3, 64, 64], "names": ["channels", "height", "width"]}},
+            "video_path": "videos/{video_key}/chunk-{chunk_index:03d}/file-{file_index:03d}.mp4",
+        }
+        (tmp_path / "meta" / "info.json").write_text(json.dumps(info), encoding="utf-8")
+        rel = tmp_path / "videos/observation.images.cam1/chunk-000/file-000.mp4"
+        # A frame count that would mismatch the partial expected (3) if compared.
+        _write_real_mp4(rel, n_frames=5)
+
+        # min_frames=0 disables the unrelated per-episode length check (the null
+        # length reads as a 0-frame episode) so this isolates the video
+        # frame-count path: the packed file's partial expected count must not be
+        # compared against the real 5-frame video.
+        report = verify_dataset(tmp_path, min_frames=0)
+        assert report["status"] == "success", report
+        assert not any("frame(s)" in p for p in report["problems"]), report["problems"]
+
     def test_missing_length_column_skips_frame_check(self, tmp_path: Path) -> None:
         pytest.importorskip("av")
         # No ``length`` column -> expected frames are unknown, so the frame-count


### PR DESCRIPTION
## Problem

The LeRobot v3 layout packs multiple episodes into one shared MP4 per camera. `_verify_video_frame_counts` sums each episode's `length` to get the frames the parquet maps into a file, then flags a truncated encode when the decoded frame count is lower. To avoid false positives it skips any file whose expected total can't be computed confidently: if any referencing episode carries a null `length`, the file's key is recorded in `unknown_len_files` and the frame-count comparison is skipped.

That skip was covered only at its extremes:
- all lengths present for a packed file (`test_packed_multi_episode_file_sums_lengths`), and
- the entire `length` column absent (`test_missing_length_column_skips_frame_check`).

The mixed case — one episode with a length and one with a null length, both mapped to the **same** packed file — was untested. That is exactly the branch that keeps a partially-known expected count from being compared against a complete decoded frame count and crying truncation.

## Change

Adds `test_packed_file_with_one_null_length_skips_frame_check`: two episodes packed into file 0, `length = [3, None]`, backed by a real 5-frame MP4. The verifier must return `success` with no frame-count problem — comparing the real 5 frames against the partial expected 3 would be a false truncation report. `min_frames=0` isolates the video frame-count path from the unrelated per-episode length check (a null length reads as a 0-frame episode).

Proven to be a real guard: removing the `if key in unknown_len_files: continue` skip makes the new test fail with a spurious `5 frame(s) but maps 3 frame(s)` error; it passes with the guard present.

## Testing

- `pytest tests/test_verify_dataset.py` — 48 passed.
- Coverage of `strands_robots/verify_dataset.py` rises to 99% (only the `__main__` `sys.exit(main())` line remains); the previously-uncovered mixed-length skip branch is now pinned.
- ruff check + format clean; mypy clean on the changed file.

Test-only change; no production code or behavior is modified.