### PR TITLE
fix(recorder): resolve hf CLI from the interpreter env in sync_to_bucket

### DIFF
--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -114,6 +114,28 @@ def _codec_create_kwargs(sig_params: Any, vcodec: str, *, context: str = "create
 _BUCKET_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*(/[A-Za-z0-9][A-Za-z0-9._-]*)?$")
 _RUN_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 
+
+def _hf_executable() -> str | None:
+    """Resolve the ``hf`` CLI, preferring the one in the running interpreter's
+    environment before falling back to PATH.
+
+    ``huggingface_hub`` installs the ``hf`` entry point next to the active
+    Python (e.g. inside a virtualenv's ``bin``/``Scripts``). A bare ``hf`` on
+    PATH is only found when that environment is also on PATH, which is often not
+    the case for a subprocess launched from a venv whose ``bin`` was never
+    activated. Checking ``sys.executable``'s directory first makes
+    ``sync_to_bucket`` work from any environment where ``huggingface_hub`` is
+    installed, not just an activated one. Returns ``None`` if no ``hf`` is found.
+    """
+    import shutil
+
+    exe_dir = Path(sys.executable).parent
+    for name in ("hf", "hf.exe"):
+        candidate = exe_dir / name
+        if candidate.exists():
+            return str(candidate)
+    return shutil.which("hf")
+
 # Lazy check for LeRobot availability.
 # We must NOT import lerobot at module level because it pulls in
 # `datasets` -> `pandas`, which can crash with a numpy ABI mismatch on
@@ -916,10 +938,10 @@ class DatasetRecorder:
         The shard layout is already Xet/bucket-friendly at the 100 MB default,
         and ``meta/`` MUST ship or downstream loses normalization stats.
         """
-        import shutil
         import subprocess
 
-        if shutil.which("hf") is None:
+        hf = _hf_executable()
+        if hf is None:
             return {
                 "status": "error",
                 "message": "`hf` CLI not found. pip install -U huggingface_hub (>=1.x) and run `hf auth login`.",
@@ -954,7 +976,7 @@ class DatasetRecorder:
 
         if create:
             cp = subprocess.run(
-                ["hf", "buckets", "create", bucket] + (["--private"] if private else []),
+                [hf, "buckets", "create", bucket] + (["--private"] if private else []),
                 capture_output=True,
                 text=True,
             )
@@ -965,7 +987,7 @@ class DatasetRecorder:
                     "message": f"bucket create failed: {cp.stderr.strip()}",
                 }
 
-        cmd = ["hf", "sync", local_root, dest]
+        cmd = [hf, "sync", local_root, dest]
         if delete:
             cmd.append("--delete")
         logger.info("Syncing %s -> %s", local_root, dest)

--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -136,6 +136,7 @@ def _hf_executable() -> str | None:
             return str(candidate)
     return shutil.which("hf")
 
+
 # Lazy check for LeRobot availability.
 # We must NOT import lerobot at module level because it pulls in
 # `datasets` -> `pandas`, which can crash with a numpy ABI mismatch on

--- a/tests/test_dataset_recorder.py
+++ b/tests/test_dataset_recorder.py
@@ -1546,11 +1546,12 @@ def _write_meta(root) -> None:
 
 def test_sync_to_bucket_missing_hf_cli_errors(tmp_path, monkeypatch):
     """No ``hf`` CLI on PATH -> actionable error, never a subprocess call."""
-    import shutil
     import subprocess
 
+    from strands_robots import dataset_recorder as dr
+
     _write_meta(tmp_path)
-    monkeypatch.setattr(shutil, "which", lambda _name: None)
+    monkeypatch.setattr(dr, "_hf_executable", lambda: None)
 
     def _boom(*_a, **_k):
         raise AssertionError("subprocess must not run when hf CLI is absent")
@@ -1580,11 +1581,12 @@ def test_sync_to_bucket_rejects_unsafe_bucket(tmp_path, monkeypatch, bad_bucket)
     from an agent tool (``stop_recording(bucket=...)``), so a weakened bucket
     regex would let shell metacharacters / path traversal reach ``hf``.
     """
-    import shutil
     import subprocess
 
+    from strands_robots import dataset_recorder as dr
+
     _write_meta(tmp_path)
-    monkeypatch.setattr(shutil, "which", lambda _name: "/usr/bin/hf")
+    monkeypatch.setattr(dr, "_hf_executable", lambda: "hf")
 
     def _boom(*_a, **_k):
         raise AssertionError(f"subprocess must not run for unsafe bucket {bad_bucket!r}")
@@ -1599,9 +1601,9 @@ def test_sync_to_bucket_rejects_unsafe_bucket(tmp_path, monkeypatch, bad_bucket)
 
 def test_sync_to_bucket_requires_finalized_meta_dir(tmp_path, monkeypatch):
     """A dataset with no ``meta/`` (never finalized) is refused."""
-    import shutil
+    from strands_robots import dataset_recorder as dr
 
-    monkeypatch.setattr(shutil, "which", lambda _name: "/usr/bin/hf")
+    monkeypatch.setattr(dr, "_hf_executable", lambda: "hf")
     # No _write_meta: meta/ is absent.
 
     result = _sync_recorder(tmp_path).sync_to_bucket("my-org/robot-fave")
@@ -1614,11 +1616,12 @@ def test_sync_to_bucket_requires_finalized_meta_dir(tmp_path, monkeypatch):
 @pytest.mark.parametrize("bad_run_id", ["bad/id", "run;id", ".."])
 def test_sync_to_bucket_rejects_unsafe_run_id(tmp_path, monkeypatch, bad_run_id):
     """run_id must be a single safe path segment (no '/', traversal, metachars)."""
-    import shutil
     import subprocess
 
+    from strands_robots import dataset_recorder as dr
+
     _write_meta(tmp_path)
-    monkeypatch.setattr(shutil, "which", lambda _name: "/usr/bin/hf")
+    monkeypatch.setattr(dr, "_hf_executable", lambda: "hf")
 
     def _boom(*_a, **_k):
         raise AssertionError(f"subprocess must not run for unsafe run_id {bad_run_id!r}")
@@ -1633,11 +1636,12 @@ def test_sync_to_bucket_rejects_unsafe_run_id(tmp_path, monkeypatch, bad_run_id)
 
 def test_sync_to_bucket_success_creates_and_syncs(tmp_path, monkeypatch):
     """Happy path: creates the bucket then syncs to the derived HF URI."""
-    import shutil
     import subprocess
 
+    from strands_robots import dataset_recorder as dr
+
     _write_meta(tmp_path)
-    monkeypatch.setattr(shutil, "which", lambda _name: "/usr/bin/hf")
+    monkeypatch.setattr(dr, "_hf_executable", lambda: "hf")
 
     calls: list[list[str]] = []
 
@@ -1662,11 +1666,12 @@ def test_sync_to_bucket_success_creates_and_syncs(tmp_path, monkeypatch):
 
 def test_sync_to_bucket_preexisting_bucket_is_not_an_error(tmp_path, monkeypatch):
     """`hf buckets create` failing because the bucket already exists is tolerated."""
-    import shutil
     import subprocess
 
+    from strands_robots import dataset_recorder as dr
+
     _write_meta(tmp_path)
-    monkeypatch.setattr(shutil, "which", lambda _name: "/usr/bin/hf")
+    monkeypatch.setattr(dr, "_hf_executable", lambda: "hf")
 
     def _fake_run(cmd, *_a, **_k):
         if cmd[:3] == ["hf", "buckets", "create"]:
@@ -1683,11 +1688,12 @@ def test_sync_to_bucket_preexisting_bucket_is_not_an_error(tmp_path, monkeypatch
 
 def test_sync_to_bucket_create_failure_surfaced(tmp_path, monkeypatch):
     """A genuine `hf buckets create` failure is surfaced, not swallowed."""
-    import shutil
     import subprocess
 
+    from strands_robots import dataset_recorder as dr
+
     _write_meta(tmp_path)
-    monkeypatch.setattr(shutil, "which", lambda _name: "/usr/bin/hf")
+    monkeypatch.setattr(dr, "_hf_executable", lambda: "hf")
 
     def _fake_run(cmd, *_a, **_k):
         if cmd[:3] == ["hf", "buckets", "create"]:
@@ -1704,11 +1710,12 @@ def test_sync_to_bucket_create_failure_surfaced(tmp_path, monkeypatch):
 
 def test_sync_to_bucket_sync_failure_surfaced(tmp_path, monkeypatch):
     """A non-zero `hf sync` return code is surfaced with its stderr."""
-    import shutil
     import subprocess
 
+    from strands_robots import dataset_recorder as dr
+
     _write_meta(tmp_path)
-    monkeypatch.setattr(shutil, "which", lambda _name: "/usr/bin/hf")
+    monkeypatch.setattr(dr, "_hf_executable", lambda: "hf")
 
     def _fake_run(cmd, *_a, **_k):
         if cmd[:3] == ["hf", "buckets", "create"]:
@@ -1725,11 +1732,12 @@ def test_sync_to_bucket_sync_failure_surfaced(tmp_path, monkeypatch):
 
 def test_sync_to_bucket_delete_flag_forwards_to_sync(tmp_path, monkeypatch):
     """delete=True appends --delete to the `hf sync` command (mirror semantics)."""
-    import shutil
     import subprocess
 
+    from strands_robots import dataset_recorder as dr
+
     _write_meta(tmp_path)
-    monkeypatch.setattr(shutil, "which", lambda _name: "/usr/bin/hf")
+    monkeypatch.setattr(dr, "_hf_executable", lambda: "hf")
 
     calls: list[list[str]] = []
 
@@ -1746,3 +1754,36 @@ def test_sync_to_bucket_delete_flag_forwards_to_sync(tmp_path, monkeypatch):
     assert len(calls) == 1
     assert calls[0][:2] == ["hf", "sync"]
     assert "--delete" in calls[0]
+
+
+def test_hf_executable_prefers_interpreter_env_over_path(tmp_path, monkeypatch):
+    """`_hf_executable` finds the ``hf`` next to the running interpreter before
+    falling back to PATH, so sync works from a venv whose bin is not activated.
+    """
+    import shutil
+
+    from strands_robots import dataset_recorder as dr
+
+    # A fake venv layout: <venv>/bin/python and <venv>/bin/hf.
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    (bin_dir / "hf").write_text("#!/bin/sh\n")
+    monkeypatch.setattr(dr.sys, "executable", str(bin_dir / "python"))
+    # PATH lookup would resolve elsewhere; the interpreter-env hit must win.
+    monkeypatch.setattr(shutil, "which", lambda _name: "/somewhere/else/hf")
+
+    assert dr._hf_executable() == str(bin_dir / "hf")
+
+
+def test_hf_executable_falls_back_to_path(tmp_path, monkeypatch):
+    """When no ``hf`` sits next to the interpreter, fall back to PATH lookup."""
+    import shutil
+
+    from strands_robots import dataset_recorder as dr
+
+    empty = tmp_path / "bin"
+    empty.mkdir()
+    monkeypatch.setattr(dr.sys, "executable", str(empty / "python"))
+    monkeypatch.setattr(shutil, "which", lambda _name: "/usr/bin/hf")
+
+    assert dr._hf_executable() == "/usr/bin/hf"

--- a/tests/test_streaming_dataset.py
+++ b/tests/test_streaming_dataset.py
@@ -12,6 +12,7 @@ import subprocess
 
 import pytest
 
+import strands_robots.dataset_recorder as dr
 import strands_robots.streaming_dataset as sd
 from strands_robots.dataset_recorder import DatasetRecorder
 
@@ -137,9 +138,7 @@ def test_sync_to_bucket_builds_cli(tmp_path, monkeypatch):
     (tmp_path / "meta").mkdir()  # satisfy the meta/ guard
     rec = _recorder(tmp_path)
 
-    import shutil
-
-    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/hf")
+    monkeypatch.setattr(dr, "_hf_executable", lambda: "hf")
 
     calls = []
 
@@ -164,9 +163,7 @@ def test_sync_to_bucket_builds_cli(tmp_path, monkeypatch):
 
 def test_sync_to_bucket_requires_meta(tmp_path, monkeypatch):
     rec = _recorder(tmp_path)  # NO meta/ dir
-    import shutil
-
-    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/hf")
+    monkeypatch.setattr(dr, "_hf_executable", lambda: "hf")
     res = rec.sync_to_bucket("my-org/robot-fave")
     assert res["status"] == "error"
     assert "meta/" in res["message"]
@@ -175,9 +172,7 @@ def test_sync_to_bucket_requires_meta(tmp_path, monkeypatch):
 def test_sync_to_bucket_missing_hf_cli(tmp_path, monkeypatch):
     (tmp_path / "meta").mkdir()
     rec = _recorder(tmp_path)
-    import shutil
-
-    monkeypatch.setattr(shutil, "which", lambda _: None)
+    monkeypatch.setattr(dr, "_hf_executable", lambda: None)
     res = rec.sync_to_bucket("my-org/robot-fave")
     assert res["status"] == "error"
     assert "hf` CLI" in res["message"] or "hf CLI" in res["message"]
@@ -188,9 +183,7 @@ def _guard_recorder(tmp_path, monkeypatch):
     subprocess call would be a security regression (the fake raises)."""
     (tmp_path / "meta").mkdir()
     rec = _recorder(tmp_path)
-    import shutil
-
-    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/hf")
+    monkeypatch.setattr(dr, "_hf_executable", lambda: "hf")
 
     def boom(*a, **k):  # subprocess must never run with a rejected target
         raise AssertionError(f"subprocess.run reached with {a!r}")
@@ -245,9 +238,7 @@ def test_sync_to_bucket_bucket_create_failure_surfaces_error(tmp_path, monkeypat
     never fall through to ``hf sync`` (a silent success would upload nowhere)."""
     (tmp_path / "meta").mkdir()
     rec = _recorder(tmp_path)
-    import shutil
-
-    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/hf")
+    monkeypatch.setattr(dr, "_hf_executable", lambda: "hf")
 
     calls = []
 
@@ -276,9 +267,7 @@ def test_sync_to_bucket_existing_bucket_proceeds_to_sync(tmp_path, monkeypatch):
     exists is idempotent: sync proceeds and the call succeeds."""
     (tmp_path / "meta").mkdir()
     rec = _recorder(tmp_path)
-    import shutil
-
-    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/hf")
+    monkeypatch.setattr(dr, "_hf_executable", lambda: "hf")
 
     calls = []
 
@@ -306,9 +295,7 @@ def test_sync_to_bucket_sync_failure_surfaces_stderr(tmp_path, monkeypatch):
     not a false success."""
     (tmp_path / "meta").mkdir()
     rec = _recorder(tmp_path)
-    import shutil
-
-    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/hf")
+    monkeypatch.setattr(dr, "_hf_executable", lambda: "hf")
 
     def fake_run(cmd, capture_output=True, text=True):
         is_create = cmd[:3] == ["hf", "buckets", "create"]
@@ -332,9 +319,7 @@ def test_sync_to_bucket_delete_flag_forwarded(tmp_path, monkeypatch):
     mirrored (removed-locally files are pruned remotely)."""
     (tmp_path / "meta").mkdir()
     rec = _recorder(tmp_path)
-    import shutil
-
-    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/hf")
+    monkeypatch.setattr(dr, "_hf_executable", lambda: "hf")
 
     calls = []
 

--- a/tests/test_streaming_dataset.py
+++ b/tests/test_streaming_dataset.py
@@ -14,7 +14,6 @@ import pytest
 
 import strands_robots.dataset_recorder as dr
 import strands_robots.streaming_dataset as sd
-from strands_robots.dataset_recorder import DatasetRecorder
 
 
 class _FakeStreaming:
@@ -128,7 +127,7 @@ class _FakeDataset:
 
 
 def _recorder(tmp_path):
-    rec = DatasetRecorder(dataset=_FakeDataset(str(tmp_path)))
+    rec = dr.DatasetRecorder(dataset=_FakeDataset(str(tmp_path)))
     rec.episode_count = 3
     rec.frame_count = 300
     return rec


### PR DESCRIPTION
## Problem

`DatasetRecorder.sync_to_bucket` (reachable from an agent via `stop_recording(bucket=...)`) shells out to a bare `hf` resolved with `shutil.which`, i.e. PATH only. The `hf` entry point from `huggingface_hub` is installed next to the active Python (a virtualenv's `bin`/`Scripts`). When a process runs from a venv whose `bin` was never put on PATH, `shutil.which("hf")` returns `None` and the sync fails with:

```
Bucket sync FAILED: `hf` CLI not found. pip install -U huggingface_hub (>=1.x) and run `hf auth login`.
```

even though `huggingface_hub` is installed in that same environment. This was hit in a real run: recording succeeded but the bucket sync silently failed.

## Fix

Add `_hf_executable()`, which prefers the `hf` sitting next to `sys.executable` (the running interpreter's env) before falling back to `shutil.which("hf")`. Use its result for the presence check, `hf buckets create`, and `hf sync`. Returns `None` (unchanged error path) when no `hf` is found anywhere.

Behavior is unchanged when `hf` is on PATH; it additionally works from an unactivated venv.

## Tests

- Updated the existing `sync_to_bucket` tests to patch `_hf_executable` (the new seam) instead of `shutil.which`.
- Added `test_hf_executable_prefers_interpreter_env_over_path` (interpreter-env hit wins over a PATH hit) and `test_hf_executable_falls_back_to_path` (no interpreter-env `hf` -> PATH lookup).
- `pytest -k "sync_to_bucket or hf_executable"`: 17 passed. `ruff check` clean on both files.

No public API change; `_hf_executable` is a private module helper.