### PR TITLE
fix(sim): reject a non-scalar send_action dict value instead of crashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -995,6 +995,21 @@ known base position + linear velocity read back byte-for-byte after
 arms (no schema growth); multi-robot base columns are prefixed like joint ids
 (`alice__base_pos.x`). Completes the base-state surfacing begun in #1134/#1172.
 
+### Fixed: `send_action` crashed on a non-scalar dict action value instead of returning an error
+
+`send_action` returns a structured `{"status": "error", ...}` for every other
+malformed input (a wrong-length vector, a non-numeric vector entry, a scalar, a
+string, unresolved keys, no world), but a `{name: value}` mapping whose value was
+non-scalar - a list / tuple / multi-element array, exactly what a policy emitting
+a vector-valued key such as `base_velocity: [vx, vy, omega]` produces - slipped
+past the contract and raised an unhandled `TypeError` deep in the actuator-apply
+loop (`float(value)`), crashing the caller mid-rollout after already writing
+`data.ctrl` for the earlier keys. The shared `_coerce_action` now validates that
+every mapping value coerces to a scalar float up front, so the whole action is
+rejected atomically with an actionable message naming the offending key - on both
+the MuJoCo and Newton backends. Scalars, numeric strings and `numpy` float
+scalars are accepted unchanged.
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -458,7 +458,11 @@ class SimEngine(ABC):
         vector to joint names there mis-maps or drops commanded DOFs. A mapping
         is returned unchanged. The vector length must match the robot's actuator
         count exactly; a mismatch is reported as a caller error rather than
-        silently truncated (which would drop commands - e.g. a gripper axis).
+        silently truncated (which would drop commands - e.g. a gripper axis). A
+        mapping is returned unchanged once every value is confirmed to coerce to
+        a scalar float; a non-scalar value (a list / multi-element array) is
+        rejected with an actionable error rather than raised as an unhandled
+        ``TypeError`` deep in the actuator-application loop.
 
         Args:
             action: A ``{name: value}`` mapping, or an ordered numeric vector
@@ -471,6 +475,33 @@ class SimEngine(ABC):
             be ignored. Otherwise ``action_dict`` is the normalized mapping.
         """
         if isinstance(action, Mapping):
+            # Each value is applied downstream as ``float(value)`` per actuator
+            # with no guard, so a non-scalar value (a list / tuple / multi-element
+            # array - e.g. a policy emitting a vector-valued key such as a
+            # ``base_velocity`` [vx, vy, omega]) would raise an unhandled
+            # ``TypeError`` past send_action's structured-error contract and crash
+            # the caller mid-rollout, after partially applying the earlier keys.
+            # Validate every value coerces to a scalar float up front so the whole
+            # action is rejected atomically with an actionable message, symmetric
+            # with the vector-form non-numeric-entry validation below. Values are
+            # returned unchanged (the downstream ``float(value)`` accepts scalars,
+            # numeric strings, and length-1 arrays exactly as before).
+            for key, value in action.items():
+                try:
+                    float(value)
+                except (TypeError, ValueError):
+                    return None, {
+                        "status": "error",
+                        "content": [
+                            {
+                                "text": (
+                                    f"send_action: action value for key '{key}' must be a "
+                                    "scalar number (one value per actuator/joint), got "
+                                    f"{type(value).__name__}."
+                                )
+                            }
+                        ],
+                    }
             return dict(action), None
 
         # ``str``/``bytes`` are iterable but never a valid multi-joint action;

--- a/tests/simulation/mujoco/test_send_action_vector.py
+++ b/tests/simulation/mujoco/test_send_action_vector.py
@@ -81,3 +81,49 @@ class TestSendActionVector:
         result = sim.send_action("oops", robot_name="so101")
         assert result["status"] == "error"
         assert "mapping" in result["content"][0]["text"]
+
+
+class TestSendActionScalarValues:
+    """A dict action value must be a scalar the actuator loop can ``float()``.
+
+    ``_apply_action_by_name`` applies each value as ``float(value)`` with no
+    guard, so a mapping carrying a non-scalar value (a list / tuple /
+    multi-element array - exactly what a policy emitting a vector-valued key
+    like ``base_velocity: [vx, vy, omega]`` produces) raised an unhandled
+    ``TypeError`` out of ``send_action`` and crashed the caller mid-rollout,
+    after partially writing ``data.ctrl`` for the earlier keys. ``send_action``
+    returns a structured error for every other malformed input (bad vector
+    length, non-numeric vector entry, scalar, string, unresolved keys) - a
+    non-scalar dict value is now rejected the same way, atomically.
+    """
+
+    def test_list_value_is_actionable_error_not_a_crash(self, sim):
+        result = sim.send_action({"1": [0.1, 0.2, 0.3]}, robot_name="so101")
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert "scalar" in text and "'1'" in text and "list" in text
+
+    def test_multielement_array_value_is_actionable_error(self, sim):
+        result = sim.send_action({"1": np.array([0.1, 0.2])}, robot_name="so101")
+        assert result["status"] == "error"
+        assert "scalar" in result["content"][0]["text"]
+
+    def test_bad_value_rejects_the_whole_action_atomically(self, sim):
+        """A good key alongside a bad key applies neither (no partial ctrl write)."""
+        model = sim.mj_model
+        act_id = model.actuator("so101/1").id  # the good key's actuator
+        before_ctrl = float(sim.mj_data.ctrl[act_id])
+        result = sim.send_action({"1": 0.5, "2": [0.1, 0.2]}, robot_name="so101")
+        assert result["status"] == "error"
+        # The whole action is rejected before any ctrl write: the good key's
+        # actuator command is untouched.
+        assert float(sim.mj_data.ctrl[act_id]) == before_ctrl
+
+    def test_scalar_like_values_still_accepted(self, sim):
+        """np.float64, a python float and a numeric string all coerce cleanly."""
+        result = sim.send_action(
+            {"1": np.float64(0.1), "2": 0.2, "3": "0.05"},
+            robot_name="so101",
+            n_substeps=2,
+        )
+        assert result["status"] == "success", result

--- a/tests/simulation/newton/test_newton_engine.py
+++ b/tests/simulation/newton/test_newton_engine.py
@@ -88,6 +88,19 @@ class TestObservationAction:
         payload = result["content"][-1]["json"]
         assert payload["unresolved_keys"] == ["NotAJoint"]
 
+    def test_send_action_nonscalar_value_is_actionable_error(self, engine_with_so100):
+        """A non-scalar dict value returns a clean error, not an uncaught TypeError.
+
+        Backend parity with the MuJoCo path: the shared ``_coerce_action``
+        validates every mapping value coerces to a scalar float before the
+        per-actuator apply loop, so a vector-valued key (e.g. a policy emitting
+        ``base_velocity: [vx, vy, omega]``) is rejected atomically instead of
+        crashing the caller mid-rollout.
+        """
+        result = engine_with_so100.send_action({"Rotation": [0.1, 0.2, 0.3]}, robot_name="so100")
+        assert result["status"] == "error"
+        assert "scalar" in result["content"][0]["text"]
+
     def test_physics_timestep_positive(self, engine_with_so100):
         assert engine_with_so100.physics_timestep() > 0
 


### PR DESCRIPTION
## Problem

`send_action` documents (and honors) a structured-error contract: it returns `{"status": "error", ...}` with an actionable message for every malformed input it knows about - a wrong-length action vector, a non-numeric vector entry, a scalar, a string, unresolved keys, no world. But a `{name: value}` **mapping** whose value is *non-scalar* - a `list` / `tuple` / multi-element `numpy` array - slipped past the contract:

```python
sim.send_action({"1": [0.1, 0.2, 0.3]}, robot_name="so101")
# TypeError: float() argument must be a string or a real number, not 'list'
sim.send_action({"1": np.array([0.1, 0.2])}, robot_name="so101")
# TypeError: only length-1 arrays can be converted to Python scalars
```

The value is applied downstream as `float(value)` in the actuator-apply loop (`rendering.py`) with no guard, so it raised an unhandled `TypeError` **out of `send_action`**, crashing the caller mid-rollout - and worse, after the loop had already written `data.ctrl` for the earlier keys (a partial, non-atomic application).

This is exactly the value a wheeled mobile-base policy emits (a vector-valued key such as `base_velocity: [vx, vy, omega]`), so the crash sits directly on the mobile-base action path, but it applies to any mapping with a non-scalar value.

## Fix

The shared `SimEngine._coerce_action` (used by both the MuJoCo and Newton `send_action`) now validates that **every** mapping value coerces to a scalar `float` up front, before any lock / `data.ctrl` write / step. A non-scalar value rejects the **whole** action atomically with a message naming the offending key, symmetric with the existing vector-form non-numeric-entry validation. Scalars, numeric strings and `numpy` float scalars are accepted unchanged (values are returned as-is; only validated).

```
send_action: action value for key '1' must be a scalar number (one value per actuator/joint), got list.
```

## Tests

- `tests/simulation/mujoco/test_send_action_vector.py::TestSendActionScalarValues` - list value and multi-element-array value return a structured error (not a crash); a good-key-plus-bad-key action applies **neither** (`data.ctrl` untouched - the atomic-rejection contract); scalars / floats / numeric strings still succeed. The two crash cases fail-before with the exact `TypeError` and pass after.
- `tests/simulation/newton/test_newton_engine.py` - backend-parity: the Newton path returns the same clean error (verified on the real Newton engine).

Gate: `ruff` + `mypy` clean; the send_action / replay / policy-runner suites pass (no rollout regression - the guard is a no-op for every scalar action).

No behavior/render/record change - `send_action` simply returns its documented structured error where it previously raised.