### PR TITLE
fix(sim): preserve a floating base's state in Newton-recorded datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -282,6 +282,29 @@ those views, names may be given in raw or schema-safe (`/` -> `__`) form, and
 an unknown name fails loudly listing the available cameras. `dataset_cameras`
 now behaves identically on both engines.
 
+### Fixed: the Newton recorder dropped a floating base's state from the dataset
+
+A floating-base robot (a humanoid or a mobile base) exposes its full base
+kinematics via `get_observation` on both backends -- position (`base_pos`,
+world x/y/z including height), orientation (`base_quat`, w/x/y/z), linear
+velocity (`base_lin_vel`, m/s) and angular velocity (`base_ang_vel`, rad/s).
+The MuJoCo recorder preserves these as per-component `observation.state`
+columns, but the Newton recorder derived its schema from scalar joint names
+only and merely *warned* that the base state was being dropped -- so a
+dataset recorded on the Newton backend was silently base-blind, and a
+locomotion / velocity-tracking / whole-body-control policy trained on it was
+missing exactly the base state it needs.
+
+`NewtonSimEngine.start_recording` now preserves the floating base as the same
+per-component scalar columns (`base_pos.x` .. `base_ang_vel.z`) as the MuJoCo
+backend, reusing the `DatasetRecorder` `extra_state_specs` machinery that
+flattens the vector observation keys into `observation.state` each frame.
+Multi-robot base columns are namespaced (`alice__base_quat.w`) to match the
+recorded observation keys, a resumed dataset is validated against the full
+(joints + base) schema, and a fixed-base arm gains no base columns (the schema
+is unchanged). The now-superseded base-state-dropped warning is removed from
+both backends.
+
 ### Fixed: `render_depth` ignored a camera's configured resolution
 
 `render()` and `render_all()` honor a named camera's configured resolution

--- a/strands_robots/simulation/newton/recording.py
+++ b/strands_robots/simulation/newton/recording.py
@@ -159,15 +159,35 @@ class NewtonRecordingMixin(DatasetRecordingMixin):
 
             joint_names, camera_keys, camera_dims, robot_type, recording_cameras = self._collect_recording_schema()
 
-            # Doctrine parity with the MuJoCo backend: a floating-base robot
-            # (humanoid/mobile) surfaces base_quat/base_ang_vel via
-            # get_observation, but the joint-name-derived observation.state
-            # schema drops them from the recorded dataset. Flag it at recording
-            # start rather than yielding a silently base-blind training set.
-            # (Non-breaking: the schema is unchanged.)
+            # Backend parity with the MuJoCo recorder: a floating-base robot
+            # (humanoid / mobile) exposes full base kinematics via
+            # get_observation - position (base_pos, world x,y,z incl. height),
+            # orientation (base_quat, w,x,y,z), linear velocity (base_lin_vel,
+            # m/s) and angular velocity (base_ang_vel, rad/s) - but the
+            # observation.state schema above is derived from scalar joint names,
+            # so those base signals would be dropped and a locomotion /
+            # velocity-tracking / whole-body-control policy trained on the
+            # dataset would be base-blind. Preserve them as per-component scalar
+            # columns (base_pos.x .. base_ang_vel.z); the DatasetRecorder
+            # extra_state_specs / _state_source_keys machinery flattens the
+            # vector observation keys into observation.state each frame with no
+            # recorder changes. Multi-robot base columns are prefixed like the
+            # joint ids (``alice__base_quat.w``) to match the prefixed
+            # observation keys the recording hook emits. A fixed-base arm has no
+            # free base joint -> no base columns (schema unchanged).
             free_base_joints = getattr(self, "_robot_free_base_joint", {})
-            floating_base_robots = [rname for rname in world.robots if free_base_joints.get(rname)]
-            self._warn_floating_base_state_dropped(floating_base_robots)
+            multi_robot = len(world.robots) > 1
+            base_state_specs: list[tuple[str, list[str]]] = []
+            for rname in world.robots:
+                if free_base_joints.get(rname):
+                    prefix = f"{rname}__" if multi_robot else ""
+                    base_state_specs.append((f"{prefix}base_pos", ["x", "y", "z"]))
+                    base_state_specs.append((f"{prefix}base_quat", ["w", "x", "y", "z"]))
+                    base_state_specs.append((f"{prefix}base_lin_vel", ["x", "y", "z"]))
+                    base_state_specs.append((f"{prefix}base_ang_vel", ["x", "y", "z"]))
+            # Full observation.state schema (scalar joints + expanded base
+            # components) - used to validate a resumed dataset's on-disk schema.
+            state_names_full = list(joint_names) + [f"{src}.{c}" for src, comps in base_state_specs for c in comps]
 
             # Optional camera scoping (parity with the MuJoCo backend). By
             # default every named scene camera is recorded; when ``cameras`` is
@@ -218,7 +238,7 @@ class NewtonRecordingMixin(DatasetRecordingMixin):
             if resume_existing:
                 logger.info("Resuming existing dataset for append: %s", dataset_dir)
                 resumed = _DatasetRecorder.resume(repo_id=repo_id, root=root, task=task, vcodec=vcodec)
-                self._verify_resume_schema(resumed, joint_names, camera_keys, camera_dims)
+                self._verify_resume_schema(resumed, state_names_full, camera_keys, camera_dims)
                 world._backend_state["dataset_recorder"] = resumed
             else:
                 world._backend_state["dataset_recorder"] = _DatasetRecorder.create(
@@ -226,6 +246,7 @@ class NewtonRecordingMixin(DatasetRecordingMixin):
                     fps=fps,
                     robot_type=robot_type,
                     joint_names=joint_names,
+                    extra_state_specs=base_state_specs,
                     camera_keys=camera_keys,
                     camera_dims=camera_dims,
                     task=task,

--- a/strands_robots/simulation/recording.py
+++ b/strands_robots/simulation/recording.py
@@ -47,39 +47,6 @@ class DatasetRecordingMixin:
         default_width: int
         default_height: int
 
-    def _warn_floating_base_state_dropped(self, robot_names: list[str]) -> None:
-        """Warn that a floating base's orientation + angular velocity are not
-        captured in the recorded ``observation.state``.
-
-        ``get_observation`` surfaces ``base_quat`` (orientation, w,x,y,z) and
-        ``base_ang_vel`` (rad/s) for a floating-base robot (a humanoid or a
-        mobile base), but the dataset's ``observation.state`` schema is derived
-        from the robot's scalar joint names, so those base signals are dropped
-        from every recorded frame - the free base contributes only a single
-        scalar slot (its x-position) when its joint is named, and nothing at
-        all when it is an unnamed ``<freejoint>``. A locomotion / whole-body
-        control policy trained on the resulting dataset would be missing its
-        base state.
-
-        This does NOT change the schema (existing datasets are unchanged); it
-        surfaces the omission at recording start instead of dropping the base
-        state silently, per the "no silent data loss" contract. Called once per
-        :meth:`start_recording` (both backends) - not on the per-frame path.
-        """
-        if not robot_names:
-            return
-        logger.warning(
-            "start_recording: robot(s) %s have a floating base, but the "
-            "recorded observation.state captures only scalar joint positions - "
-            "the base orientation (base_quat) and angular velocity "
-            "(base_ang_vel) that get_observation surfaces are NOT written to "
-            "the dataset. A locomotion/whole-body-control policy needs that "
-            "base state; if you are training on the floating base, record it "
-            "through a base-aware pipeline or extend the dataset schema with "
-            "the base features explicitly.",
-            robot_names,
-        )
-
     @staticmethod
     def _prepare_dataset_target(dataset_dir: Path, overwrite: bool) -> bool:
         """Resolve create-vs-resume and make ``dataset_dir`` safe for create().

--- a/tests/simulation/newton/test_dataset_recording.py
+++ b/tests/simulation/newton/test_dataset_recording.py
@@ -293,7 +293,9 @@ _BASE_COLS = [
 
 
 def _recorder_state_names(engine: NewtonSimEngine) -> tuple[list[str], tuple[int, ...] | None]:
-    rec = engine._world._backend_state["dataset_recorder"]
+    world = engine._world
+    assert world is not None
+    rec = world._backend_state["dataset_recorder"]
     feat = rec.dataset.features.get("observation.state", {})
     names = feat.get("names", []) if isinstance(feat, dict) else getattr(feat, "names", [])
     shape = feat.get("shape") if isinstance(feat, dict) else getattr(feat, "shape", None)

--- a/tests/simulation/newton/test_dataset_recording.py
+++ b/tests/simulation/newton/test_dataset_recording.py
@@ -275,11 +275,36 @@ def test_start_recording_unknown_camera_errors(tmp_path):
     assert world._backend_state.get("recording") is False
 
 
-def test_start_recording_warns_when_floating_base_state_dropped(tmp_path, caplog):
-    """A floating-base robot (``_robot_free_base_joint`` populated) whose
-    base_quat/base_ang_vel are not in the joint-name-derived observation.state
-    schema triggers the base-drop warning at recording start (parity with the
-    MuJoCo backend)."""
+_BASE_COLS = [
+    "base_pos.x",
+    "base_pos.y",
+    "base_pos.z",
+    "base_quat.w",
+    "base_quat.x",
+    "base_quat.y",
+    "base_quat.z",
+    "base_lin_vel.x",
+    "base_lin_vel.y",
+    "base_lin_vel.z",
+    "base_ang_vel.x",
+    "base_ang_vel.y",
+    "base_ang_vel.z",
+]
+
+
+def _recorder_state_names(engine: NewtonSimEngine) -> tuple[list[str], tuple[int, ...] | None]:
+    rec = engine._world._backend_state["dataset_recorder"]
+    feat = rec.dataset.features.get("observation.state", {})
+    names = feat.get("names", []) if isinstance(feat, dict) else getattr(feat, "names", [])
+    shape = feat.get("shape") if isinstance(feat, dict) else getattr(feat, "shape", None)
+    return list(names), shape
+
+
+def test_start_recording_preserves_floating_base_state_schema(tmp_path, caplog):
+    """A floating-base robot (``_robot_free_base_joint`` populated) records its
+    full base kinematics as per-component observation.state columns
+    (``base_pos.x`` .. ``base_ang_vel.z``), matching the MuJoCo backend, and no
+    longer emits the legacy base-state-dropped warning."""
     import logging
 
     world = _world_with_robot("humanoid")
@@ -290,19 +315,29 @@ def test_start_recording_warns_when_floating_base_state_dropped(tmp_path, caplog
 
     with caplog.at_level(logging.WARNING, logger="strands_robots.simulation.recording"):
         started = engine.start_recording(
-            repo_id="local/newton_fb_warn", root=str(tmp_path / "ds"), fps=20, overwrite=True
+            repo_id="local/newton_fb_preserve", root=str(tmp_path / "ds"), fps=20, overwrite=True
         )
-    engine.stop_recording()
     assert started["status"] == "success", started
-    base_warnings = [r for r in caplog.records if "have a floating base" in r.getMessage()]
-    assert base_warnings, "floating-base state-drop warning was not emitted"
-    assert "humanoid" in base_warnings[0].getMessage()
+    names, shape = _recorder_state_names(engine)
+    for col in _BASE_COLS:
+        assert col in names, f"{col} missing from recorded observation.state schema"
+    # The scalar joints are preserved alongside the base columns, and the flat
+    # feature shape matches the per-element name count.
+    for j in _SO100_JOINTS:
+        assert j in names
+    assert tuple(shape)[0] == len(names)
+    # The base state is now preserved, so the legacy drop-warning is superseded.
+    assert not any("have a floating base" in r.getMessage() for r in caplog.records), (
+        "the base-drop warning must not fire now that base state is preserved"
+    )
+    engine.stop_recording()
 
 
-def test_start_recording_no_base_warning_for_fixed_arm(tmp_path, caplog):
-    """A fixed-base arm (no floating base recorded) must NOT warn - and the
-    detection must degrade gracefully when ``_robot_free_base_joint`` is absent
-    entirely (the __new__ harness leaves it unset)."""
+def test_start_recording_fixed_arm_has_no_base_columns(tmp_path, caplog):
+    """A fixed-base arm (no floating base recorded) gains NO base columns - the
+    schema is unchanged - and detection degrades gracefully when
+    ``_robot_free_base_joint`` is absent entirely (the __new__ harness leaves it
+    unset)."""
     import logging
 
     engine = _make_engine(_world_with_robot("so100"))
@@ -310,8 +345,58 @@ def test_start_recording_no_base_warning_for_fixed_arm(tmp_path, caplog):
 
     with caplog.at_level(logging.WARNING, logger="strands_robots.simulation.recording"):
         started = engine.start_recording(
-            repo_id="local/newton_arm_nowarn", root=str(tmp_path / "ds"), fps=20, overwrite=True
+            repo_id="local/newton_arm_nobase", root=str(tmp_path / "ds"), fps=20, overwrite=True
         )
-    engine.stop_recording()
     assert started["status"] == "success", started
+    names, _shape = _recorder_state_names(engine)
+    assert not any(n.startswith(("base_pos", "base_quat", "base_lin_vel", "base_ang_vel")) for n in names), (
+        "fixed-base arm must NOT gain floating-base columns"
+    )
     assert not any("have a floating base" in r.getMessage() for r in caplog.records)
+    engine.stop_recording()
+
+
+def test_recorded_floating_base_values_round_trip(tmp_path):
+    """End-to-end: a known base pose + twist fed through the real on_frame hook
+    is written to the dataset and read back after reopen - the base state is no
+    longer silently dropped on the Newton backend."""
+    from lerobot.datasets.lerobot_dataset import LeRobotDataset
+
+    world = _world_with_robot("humanoid")
+    engine = _make_engine(world)
+    engine._robot_free_base_joint = {"humanoid": "floating_base_joint"}
+    root = str(tmp_path / "ds")
+    started = engine.start_recording(repo_id="local/newton_fb_roundtrip", root=root, fps=20, overwrite=True)
+    assert started["status"] == "success", started
+
+    known_pos = [0.11, -0.22, 0.83]  # world x, y, HEIGHT
+    known_quat = [0.7071068, 0.0, 0.7071068, 0.0]  # +90deg about Y
+    known_linvel = [0.41, -0.52, 0.63]
+    known_angvel = [0.13, 0.24, 0.37]
+    hook = engine._make_run_policy_hook("humanoid", "t")
+    assert hook is not None
+    for step in range(3):
+        # A floating-base get_observation surfaces the base kinematics as vector
+        # keys alongside the scalar joints; feed exactly that shape to the hook.
+        obs: dict[str, object] = {j: float(step) * 0.01 for j in _SO100_JOINTS}
+        obs["base_pos"] = list(known_pos)
+        obs["base_quat"] = list(known_quat)
+        obs["base_lin_vel"] = list(known_linvel)
+        obs["base_ang_vel"] = list(known_angvel)
+        action = {j: 0.0 for j in _SO100_JOINTS}
+        hook(step, obs, action)
+    engine.save_episode()
+    engine.stop_recording()
+
+    ds = LeRobotDataset("local/newton_fb_roundtrip", root=root)
+    names = ds.features["observation.state"]["names"]
+    idx = {n: i for i, n in enumerate(names)}
+    state = np.asarray(ds[0]["observation.state"], dtype=np.float32)
+    got_pos = [float(state[idx[f"base_pos.{c}"]]) for c in "xyz"]
+    got_quat = [float(state[idx[f"base_quat.{c}"]]) for c in "wxyz"]
+    got_linvel = [float(state[idx[f"base_lin_vel.{c}"]]) for c in "xyz"]
+    got_angvel = [float(state[idx[f"base_ang_vel.{c}"]]) for c in "xyz"]
+    assert np.allclose(got_pos, known_pos, atol=1e-3), f"base_pos not preserved: {got_pos}"
+    assert np.allclose(got_quat, known_quat, atol=1e-3), f"base_quat not preserved: {got_quat}"
+    assert np.allclose(got_linvel, known_linvel, atol=1e-3), f"base_lin_vel not preserved: {got_linvel}"
+    assert np.allclose(got_angvel, known_angvel, atol=1e-3), f"base_ang_vel not preserved: {got_angvel}"


### PR DESCRIPTION
## Problem

A floating-base robot (a humanoid or a mobile base) exposes its full base kinematics via `get_observation` on both backends -- `base_pos` (world x/y/z incl. height), `base_quat` (w/x/y/z), `base_lin_vel` (m/s) and `base_ang_vel` (rad/s). The MuJoCo recorder preserves these as per-component `observation.state` columns (`base_pos.x` .. `base_ang_vel.z`), but the **Newton** recorder derived its `observation.state` schema from scalar joint names only and merely *warned* that the base state was being dropped. A dataset recorded on the Newton backend was therefore silently base-blind, and a locomotion / velocity-tracking / whole-body-control policy trained on it was missing exactly the base state it needs.

## Change

`NewtonSimEngine.start_recording` now preserves the floating base as the same per-component scalar columns as the MuJoCo backend, reusing the existing `DatasetRecorder` `extra_state_specs` / `_state_source_keys` machinery that flattens the vector observation keys into `observation.state` each frame -- no recorder changes required (the Newton `on_frame` hook already forwards the full observation, incl. the base keys, to `add_frame`).

- Multi-robot base columns are namespaced (`alice__base_quat.w`) to match the recorded observation keys.
- A resumed dataset is validated against the full (joints + base) schema.
- A fixed-base arm gains no base columns (the schema is unchanged).
- The now-superseded base-state-dropped warning is removed from both backends (both preserve the base state now).

## Tests

`tests/simulation/newton/test_dataset_recording.py`:
- `test_start_recording_preserves_floating_base_state_schema` -- the 13 base columns appear in the recorded schema alongside the scalar joints, and the drop-warning no longer fires.
- `test_start_recording_fixed_arm_has_no_base_columns` -- a fixed-base arm gains no base columns (no false-positive schema growth).
- `test_recorded_floating_base_values_round_trip` -- a known base pose + twist fed through the real `on_frame` hook is read back byte-for-byte after reopen.

The first and third **fail before this change** (`base_pos.x missing from recorded observation.state schema` / `KeyError: 'base_pos.x'`, plus the pre-change drop-warning fires) and pass after. Local gate green: `ruff` + `mypy` clean; the Newton recording + MuJoCo floating-base suites pass.

## End-to-end verification (real Newton engine, `unitree_g1`)

A real Newton rollout records and reopens a `LeRobotDataset` whose `observation.state` is 43-dim (30 G1 joints + 13 base columns). The recorded `base_pos.z` collapses 0.79 -> 0.18 m as the G1 falls under gravity (real base motion that was previously dropped) and `base_quat` stays unit-norm:

![Newton G1 recorded floating-base trajectory](https://github.com/cagataycali/robots/releases/download/artifacts-newton-fb-state-1783510303/newton_g1_floating_base_traj.png)

## Round 1 changes

- Fix a strict-mypy `union-attr` failure in the `_recorder_state_names` test helper: `engine._world` is typed `SimWorld | None`, so the direct `._backend_state` access failed type checking. Bind to a local and assert non-None before use, matching the narrowing pattern used throughout the Newton backend. Test-only; behavior unchanged.