### PR TITLE
test(sim): gate MuJoCo render tests on a runtime GL probe, not a blanket CI opt-out

### DIFF
--- a/tests/simulation/mujoco/_gl_probe.py
+++ b/tests/simulation/mujoco/_gl_probe.py
@@ -1,0 +1,61 @@
+"""Shared runtime OpenGL-availability probe for MuJoCo render tests.
+
+MuJoCo render tests need a working offscreen GL context. Historically these
+tests were gated behind a blunt ``skipif(CI == "true" and not
+ROBOT_TEST_MUJOCO)`` opt-out, which skipped them on *every* CI runner - even
+runners that do have a usable GL context (EGL/OSMesa). The result was that
+GL-backed contracts (render sandboxing, camera-resolution behaviour, video
+capture) went unverified anywhere ``CI`` was set unless a human remembered to
+export ``ROBOT_TEST_MUJOCO=1``.
+
+Instead, probe once whether a tiny offscreen render actually succeeds under the
+ambient ``MUJOCO_GL`` backend and skip only when it genuinely fails. The probe
+result is cached so the cost is a single 1x1 renderer construction per session.
+Setting ``ROBOT_TEST_MUJOCO=0`` forces the skip (e.g. to keep a known-bad
+runner from attempting GL at all).
+
+Usage::
+
+    from tests.simulation.mujoco._gl_probe import requires_gl
+
+    @requires_gl
+    def test_something_that_renders(): ...
+"""
+
+from __future__ import annotations
+
+import functools
+import os
+
+import pytest
+
+
+@functools.cache
+def gl_available() -> bool:
+    """Return True when a minimal offscreen MuJoCo render context can be built.
+
+    Cached: the underlying 1x1 renderer construction runs at most once per test
+    session. ``ROBOT_TEST_MUJOCO=0`` forces a negative result without probing.
+    """
+    if os.environ.get("ROBOT_TEST_MUJOCO") == "0":
+        return False
+    try:
+        import mujoco as mj
+    except ImportError:
+        return False
+    try:
+        model = mj.MjModel.from_xml_string("<mujoco><worldbody/></mujoco>")
+        renderer = mj.Renderer(model, height=1, width=1)
+    except Exception:
+        # Any failure (no EGL/OSMesa, no display, driver error) means the host
+        # cannot render offscreen; the dependent tests must skip cleanly.
+        return False
+    else:
+        del renderer
+        return True
+
+
+requires_gl = pytest.mark.skipif(
+    not gl_available(),
+    reason="no usable OpenGL context (headless without EGL/OSMesa); force-skip with ROBOT_TEST_MUJOCO=0",
+)

--- a/tests/simulation/mujoco/test_e2e.py
+++ b/tests/simulation/mujoco/test_e2e.py
@@ -18,26 +18,10 @@ import pytest
 mj = pytest.importorskip("mujoco")
 
 
-def _has_opengl() -> bool:
-    """Check if OpenGL rendering is available."""
-    try:
-        model = mj.MjModel.from_xml_string("<mujoco><worldbody/></mujoco>")
-        renderer = mj.Renderer(model, height=1, width=1)
-        del renderer
-        return True
-    except Exception:
-        return False
-
-
-requires_gl = pytest.mark.skipif(
-    not _has_opengl(),
-    reason="No OpenGL context available (headless environment without EGL/OSMesa)",
-)
-
-
 from strands_robots.policies import MockPolicy  # noqa: E402
 from strands_robots.simulation.base import SimEngine  # noqa: E402
 from strands_robots.simulation.models import SimObject, SimRobot, SimStatus, SimWorld  # noqa: E402
+from tests.simulation.mujoco._gl_probe import requires_gl  # noqa: E402
 
 # Fixtures
 

--- a/tests/simulation/mujoco/test_gl_probe.py
+++ b/tests/simulation/mujoco/test_gl_probe.py
@@ -1,0 +1,36 @@
+"""Contract tests for the shared MuJoCo GL-availability probe.
+
+These pin the behaviour that the render-test gating relies on: the probe
+reports a boolean, honours the ``ROBOT_TEST_MUJOCO=0`` force-skip escape hatch,
+and exposes a reusable ``requires_gl`` skip marker. They run without a GL
+context (the force-skip and marker-shape assertions never touch a renderer).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.simulation.mujoco import _gl_probe
+from tests.simulation.mujoco._gl_probe import gl_available, requires_gl
+
+
+def test_gl_available_returns_bool() -> None:
+    """The probe result is a plain bool the skipif condition can consume."""
+    assert isinstance(gl_available(), bool)
+
+
+def test_robot_test_mujoco_zero_forces_no_gl(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ROBOT_TEST_MUJOCO=0 forces a negative result without probing hardware."""
+    monkeypatch.setenv("ROBOT_TEST_MUJOCO", "0")
+    _gl_probe.gl_available.cache_clear()
+    try:
+        assert gl_available() is False
+    finally:
+        # Do not leak the forced-negative result into other tests.
+        _gl_probe.gl_available.cache_clear()
+
+
+def test_requires_gl_is_a_skip_marker() -> None:
+    """requires_gl is a usable skipif MarkDecorator (applies cleanly to tests)."""
+    assert isinstance(requires_gl, pytest.MarkDecorator)
+    assert requires_gl.name == "skipif"

--- a/tests/simulation/mujoco/test_load_scene_interaction.py
+++ b/tests/simulation/mujoco/test_load_scene_interaction.py
@@ -24,6 +24,7 @@ import pytest
 pytest.importorskip("mujoco")
 
 from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+from tests.simulation.mujoco._gl_probe import gl_available  # noqa: E402
 
 # Minimal scene: a ground plane + a named block body. This is *not* a robot -
 # there are no joints/actuators/sensors. The original bug triggered when
@@ -346,8 +347,8 @@ def test_load_scene_render_returns_real_geometry_immediately(sim: Simulation, sc
     context.
     """
     pytest.importorskip("mujoco")
-    if os.environ.get("CI") == "true" and not os.environ.get("ROBOT_TEST_MUJOCO"):
-        pytest.skip("requires OpenGL; opt-in via ROBOT_TEST_MUJOCO=1")
+    if not gl_available():
+        pytest.skip("no usable OpenGL context; force-skip with ROBOT_TEST_MUJOCO=0")
 
     os.environ.setdefault("MUJOCO_GL", "glfw")
     import io

--- a/tests/simulation/mujoco/test_render_after_scene_edit.py
+++ b/tests/simulation/mujoco/test_render_after_scene_edit.py
@@ -32,6 +32,7 @@ os.environ.setdefault("MUJOCO_GL", "glfw")
 from PIL import Image  # noqa: E402
 
 from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+from tests.simulation.mujoco._gl_probe import gl_available  # noqa: E402
 
 
 def _black_fraction(img: np.ndarray) -> float:
@@ -62,17 +63,9 @@ def sim():
 
 
 def _skip_if_no_gl():
-    """Skip on headless CI without GL."""
-    try:
-        s = Simulation(tool_name="probe", mesh=False)
-        s.create_world()
-        r = s.render(camera_name="default", width=40, height=30)
-        s.cleanup(policy_stop_timeout=0.1)
-    except Exception as e:
-        pytest.skip(f"no GL available: {e}")
-    else:
-        if r.get("status") != "success":
-            pytest.skip(r.get("content", [{}])[0].get("text", "render unavailable"))
+    """Skip when no usable offscreen GL context is available."""
+    if not gl_available():
+        pytest.skip("no usable OpenGL context; force-skip with ROBOT_TEST_MUJOCO=0")
 
 
 class TestRenderAfterSceneEdit:

--- a/tests/simulation/mujoco/test_render_camera_resolution.py
+++ b/tests/simulation/mujoco/test_render_camera_resolution.py
@@ -19,10 +19,7 @@ import pytest
 
 pytest.importorskip("mujoco")
 
-_requires_mujoco = pytest.mark.skipif(
-    os.environ.get("CI") == "true" and not os.environ.get("ROBOT_TEST_MUJOCO"),
-    reason="requires OpenGL; opt-in via ROBOT_TEST_MUJOCO=1",
-)
+from tests.simulation.mujoco._gl_probe import requires_gl as _requires_mujoco  # noqa: E402
 
 
 def _rendered_size(result: dict) -> tuple[int, int]:

--- a/tests/simulation/mujoco/test_render_output_path_roundtrip.py
+++ b/tests/simulation/mujoco/test_render_output_path_roundtrip.py
@@ -18,10 +18,7 @@ import pytest
 
 pytest.importorskip("mujoco")
 
-_requires_mujoco = pytest.mark.skipif(
-    os.environ.get("CI") == "true" and not os.environ.get("ROBOT_TEST_MUJOCO"),
-    reason="requires OpenGL; opt-in via ROBOT_TEST_MUJOCO=1",
-)
+from tests.simulation.mujoco._gl_probe import requires_gl as _requires_mujoco  # noqa: E402
 
 
 @pytest.fixture

--- a/tests/simulation/mujoco/test_rendering.py
+++ b/tests/simulation/mujoco/test_rendering.py
@@ -12,10 +12,7 @@ import pytest
 
 pytest.importorskip("mujoco")
 
-_requires_mujoco = pytest.mark.skipif(
-    os.environ.get("CI") == "true" and not os.environ.get("ROBOT_TEST_MUJOCO"),
-    reason="requires OpenGL; opt-in via ROBOT_TEST_MUJOCO=1",
-)
+from tests.simulation.mujoco._gl_probe import requires_gl as _requires_mujoco  # noqa: E402
 
 
 @_requires_mujoco

--- a/tests/simulation/test_policy_runner.py
+++ b/tests/simulation/test_policy_runner.py
@@ -36,6 +36,7 @@ from strands_robots.simulation.policy_runner import (
     VideoConfig,
     _extract_frame_ndarray,
 )
+from tests.simulation.mujoco._gl_probe import requires_gl
 
 #
 # PolicyRunner against FakeSim (backend-agnostic)
@@ -331,10 +332,7 @@ def test_simengine_run_policy_validates_robot_exists():
 #
 
 
-@pytest.mark.skipif(
-    os.environ.get("CI") == "true" and not os.environ.get("ROBOT_TEST_MUJOCO"),
-    reason="requires OpenGL; opt-in via ROBOT_TEST_MUJOCO=1",
-)
+@requires_gl
 def test_run_policy_video_writes_mp4(tmp_path: Path) -> None:
     pytest.importorskip("mujoco")
     os.environ.setdefault("MUJOCO_GL", "glfw")
@@ -456,10 +454,7 @@ def test_extract_frame_ndarray_always_returns_three_channels() -> None:
 #
 
 
-@pytest.mark.skipif(
-    os.environ.get("CI") == "true" and not os.environ.get("ROBOT_TEST_MUJOCO"),
-    reason="requires OpenGL; opt-in via ROBOT_TEST_MUJOCO=1",
-)
+@requires_gl
 def test_run_policy_reuses_policy_object() -> None:
     pytest.importorskip("mujoco")
     """Two rollouts with a single pre-built MockPolicy should both succeed."""


### PR DESCRIPTION
## Problem

The MuJoCo render/video tests were gated behind a blanket opt-out:

```python
_requires_mujoco = pytest.mark.skipif(
    os.environ.get("CI") == "true" and not os.environ.get("ROBOT_TEST_MUJOCO"),
    reason="requires OpenGL; opt-in via ROBOT_TEST_MUJOCO=1",
)
```

This skips the tests on **every** runner where `CI=true`, including runners that *do* have a usable offscreen GL context (EGL/OSMesa). So GL-backed contracts silently went unverified in CI unless someone remembered to export `ROBOT_TEST_MUJOCO=1` by hand. The most valuable casualty was the `render(output_path=...)` sandbox/traversal **security** round-trip in `test_render_output_path_roundtrip.py` (both the happy-path PNG write and the traversal rejection), plus the camera-resolution behaviour in `test_render_camera_resolution.py`.

The suite had already drifted into three different gating styles for the same need: the blanket CI opt-out (5 modules), an ad-hoc `_has_opengl()` probe in `test_e2e.py`, and a `_skip_if_no_gl()` helper in `test_render_after_scene_edit.py` — the latter two *do* run whenever GL works, which is the correct behaviour.

## Change

Introduce one cached runtime probe, `tests/simulation/mujoco/_gl_probe.py`, that builds a 1x1 offscreen renderer once per session and reports whether GL actually works, exposed as a reusable `requires_gl` skip marker:

- Render tests now run wherever a GL context is available and skip **cleanly** only when it genuinely is not (headless without EGL/OSMesa).
- `ROBOT_TEST_MUJOCO=0` forces the skip as an escape hatch for known-bad runners.
- The three pre-existing gating styles are unified onto the shared probe (no blanket `CI`-based skip remains).

This is strictly safer than the old guard: where GL is present the contracts are now exercised; where it is absent the probe skips instead of erroring.

## Coverage impact

With a working GL context and `CI=true`, `strands_robots/simulation/mujoco/rendering.py` lines 888-902 (the `render(output_path=...)` integration: PNG persist, `saved_path` surfacing in the json block and summary, and the traversal-rejection error branch) are now covered by the round-trip test — previously dead in CI.

## Verification

Under `CI=true MUJOCO_GL=egl` the affected tests move from skipped to passing:

```
test_render_output_path_roundtrip.py ..
test_render_camera_resolution.py ........
test_e2e.py ..............
test_render_after_scene_edit.py ....
test_load_scene_interaction.py ...........
test_rendering.py (39 items) all pass
test_policy_runner.py GL video tests pass
=> tests/simulation/ : 1988 passed
```

Force-skip verified: `CI=true ROBOT_TEST_MUJOCO=0` cleanly skips with reason `no usable OpenGL context ... force-skip with ROBOT_TEST_MUJOCO=0`. New `test_gl_probe.py` pins the probe contract (bool result, force-skip env, marker shape). `ruff check`/`ruff format` clean.

Test-infra only; no production code changes.