### PR TITLE
fix(sim): report a floating base's angular velocity in the body frame on Newton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1033,6 +1033,27 @@ rejected atomically with an actionable message naming the offending key - on bot
 the MuJoCo and Newton backends. Scalars, numeric strings and `numpy` float
 scalars are accepted unchanged.
 
+### Fixed: Newton reported a floating base's angular velocity in the world frame, not the body frame
+
+`get_observation` / `get_robot_state` are a cross-backend contract, but the two
+backends surfaced a floating base's `base_ang_vel` in different frames for the
+same physical motion. The MuJoCo backend returns it in the BODY frame (its
+free-joint `qvel` angular block is local) - the IMU-gyro convention a WBC /
+locomotion controller consumes (the WBC observation builder feeds `base_ang_vel`
+straight in alongside a body-frame projected-gravity cue). The Newton backend
+returned the RAW world-frame angular velocity, so once the base yawed away from
+identity the two backends disagreed by up to the full magnitude of the signal
+(a base spinning about world-X at 2 rad/s reads `[2, 0, 0]` on Newton vs
+`[0, -2, 0]` on MuJoCo at a 90-degree yaw). A humanoid/mobile policy evaluated
+across backends - or a G1 WBC controller driven on Newton - was silently fed a
+mis-framed gyro signal that destabilises the gait as the base turns. Newton's
+`_free_base_pose` now rotates the angular velocity world -> body via the base
+quaternion so `base_ang_vel` matches MuJoCo (verified equal to 1e-6 across a
+0-90 degree yaw sweep on a real G1). The linear velocity stays world-frame on
+both backends (already consistent); the frame of each base signal is now
+documented on both backends' `get_observation`.
+
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -352,8 +352,10 @@ class RenderingMixin:
         # angvel(3)], so we surface the full base pose + twist:
         #   base_pos     - world position x,y,z (incl. HEIGHT, m)
         #   base_quat    - orientation w,x,y,z
-        #   base_lin_vel - linear velocity x,y,z (m/s)
-        #   base_ang_vel - angular velocity x,y,z (rad/s)
+        #   base_lin_vel - linear velocity x,y,z (m/s, WORLD frame)
+        #   base_ang_vel - angular velocity x,y,z (rad/s, BODY frame; MuJoCo's
+        #                  free-joint qvel angular block is local, matching the
+        #                  IMU-gyro frame WBC/locomotion controllers consume)
         # WBC / locomotion / velocity-tracking / mobile-manip controllers need
         # base_pos (height for fall/height tracking) and base_lin_vel (the
         # tracked quantity in a velocity-tracking reward) in addition to the

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -89,6 +89,28 @@ def _short_joint_name(label: str) -> str:
     return label.rsplit("/", 1)[-1]
 
 
+def _quat_rotate_inverse_wxyz(quat_wxyz: list[float], vec: list[float]) -> list[float]:
+    """Express a WORLD-frame 3-vector in the body frame given a (w,x,y,z) quaternion.
+
+    Computes ``R(q)^T @ vec`` (the standard "rotate by the inverse"), used to
+    turn Newton's world-frame free-joint angular velocity into the BODY frame so
+    ``base_ang_vel`` matches the MuJoCo backend and the IMU-gyro convention WBC /
+    locomotion controllers consume. The quaternion is normalised internally; a
+    ~zero-norm quaternion returns ``vec`` unchanged.
+    """
+    q = np.asarray(quat_wxyz, dtype=np.float64)
+    norm = float(np.linalg.norm(q))
+    if norm < 1e-8:
+        return [float(v) for v in vec]
+    w, x, y, z = q / norm
+    v = np.asarray(vec, dtype=np.float64)
+    q_vec = np.array([x, y, z], dtype=np.float64)
+    a = v * (2.0 * w * w - 1.0)
+    b = np.cross(q_vec, v) * (w * 2.0)
+    c = q_vec * (float(np.dot(q_vec, v)) * 2.0)
+    return [float(t) for t in (a - b + c)]
+
+
 class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine):
     """GPU-native simulation backend built on Newton (Warp / MuJoCo-Warp).
 
@@ -625,9 +647,11 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
             entry per registered camera (name -> RGB ndarray) when
             ``skip_images`` is False. A robot with a floating base additionally
             carries ``base_pos`` (world x,y,z incl. height), ``base_quat``
-            (orientation, w,x,y,z), ``base_lin_vel`` (m/s) and ``base_ang_vel``
-            (rad/s) for locomotion controllers. Empty when no world exists or
-            the robot is unknown.
+            (orientation, w,x,y,z), ``base_lin_vel`` (m/s, WORLD frame) and
+            ``base_ang_vel`` (rad/s, BODY frame - matching the MuJoCo backend and
+            the IMU-gyro frame WBC / locomotion controllers consume) for
+            locomotion controllers. Empty when no world exists or the robot is
+            unknown.
         """
         if self._world is None or self._model is None:
             return {}
@@ -1292,12 +1316,15 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
 
         For a robot whose root is a free joint (a humanoid's named
         ``floating_base_joint``), returns a dict with ``position`` (xyz),
-        ``quaternion`` (w,x,y,z), ``linear_velocity`` and ``angular_velocity``,
-        mirroring the MuJoCo backend's ``base`` entry. Newton stores the free
-        joint's coordinates as ``[xyz, quat_xyzw]`` and its DOFs as
-        ``[linear(3), angular(3)]``, so the quaternion is reordered
-        ``xyzw -> wxyz`` to match the MuJoCo (w,x,y,z) contract while the twist
-        slots map directly. Returns None for a fixed-base robot (an arm).
+        ``quaternion`` (w,x,y,z), ``linear_velocity`` (world frame) and
+        ``angular_velocity`` (BODY frame), mirroring the MuJoCo backend's
+        ``base`` entry. Newton stores the free joint's coordinates as
+        ``[xyz, quat_xyzw]`` and its DOFs as ``[linear(3), angular(3)]`` in the
+        WORLD frame, so the quaternion is reordered ``xyzw -> wxyz`` to match the
+        MuJoCo (w,x,y,z) contract, the linear velocity maps directly (world on
+        both backends), and the angular velocity is rotated world -> body so it
+        matches MuJoCo's body-frame convention (the IMU-gyro frame WBC /
+        locomotion controllers consume). Returns None for a fixed-base robot.
 
         Args:
             robot_name: The robot to query.
@@ -1314,16 +1341,24 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         d = self._joint_dof_index.get((robot_name, base_jname))
         if q is None or d is None or q + 7 > len(joint_q) or d + 6 > len(joint_qd):
             return None
+        quat_wxyz = [
+            float(joint_q[q + 6]),
+            float(joint_q[q + 3]),
+            float(joint_q[q + 4]),
+            float(joint_q[q + 5]),
+        ]
+        # Newton stores the free joint's angular velocity in the WORLD frame,
+        # while the MuJoCo backend reports it in the BODY frame (MuJoCo's
+        # free-joint qvel angular block is local) - the IMU-gyro convention WBC /
+        # locomotion controllers consume via get_observation's base_ang_vel.
+        # Rotate world -> body so base_ang_vel agrees across both backends; the
+        # linear velocity stays world-frame on both, so it maps directly.
+        ang_world = [float(joint_qd[d + 3]), float(joint_qd[d + 4]), float(joint_qd[d + 5])]
         return {
             "position": [float(v) for v in joint_q[q : q + 3]],
-            "quaternion": [
-                float(joint_q[q + 6]),
-                float(joint_q[q + 3]),
-                float(joint_q[q + 4]),
-                float(joint_q[q + 5]),
-            ],
+            "quaternion": quat_wxyz,
             "linear_velocity": [float(v) for v in joint_qd[d : d + 3]],
-            "angular_velocity": [float(v) for v in joint_qd[d + 3 : d + 6]],
+            "angular_velocity": _quat_rotate_inverse_wxyz(quat_wxyz, ang_world),
         }
 
     def get_robot_state(self, robot_name: str | None = None) -> dict[str, Any]:
@@ -1342,7 +1377,9 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         and ``angular_velocity``. The free joint is NOT reported as a scalar
         joint (its coordinates are [xyz + quat], not a single angle), and the
         base ``quaternion``/``angular_velocity`` match get_observation's
-        ``base_quat``/``base_ang_vel`` for the same robot.
+        ``base_quat``/``base_ang_vel`` for the same robot (``angular_velocity``
+        is in the BODY frame, ``linear_velocity`` in the WORLD frame, matching
+        the MuJoCo backend).
 
         Args:
             robot_name: Robot to query. ``None`` resolves to the sole robot

--- a/tests/simulation/newton/test_discovery_and_state.py
+++ b/tests/simulation/newton/test_discovery_and_state.py
@@ -165,7 +165,10 @@ class TestFloatingBaseSurfacing:
     x-coordinate as a scalar joint value. The 6-DoF base pose + twist is
     surfaced instead, with the quaternion reordered from Newton's native xyzw to
     the MuJoCo (w,x,y,z) contract and the free-joint scalar removed from
-    get_robot_state's per-joint ``state`` map.
+    get_robot_state's per-joint ``state`` map. The base angular velocity is
+    reported in the BODY frame (Newton stores it world-frame; it is rotated
+    by the base orientation) so ``base_ang_vel`` matches the MuJoCo backend
+    and the IMU-gyro convention WBC / locomotion controllers consume.
     """
 
     # A distinctive base pose (+90deg about Z) and twist; hinge sentinels.
@@ -200,7 +203,11 @@ class TestFloatingBaseSurfacing:
         # Quaternion is reordered xyzw -> wxyz to match the MuJoCo contract.
         assert base["quaternion"] == pytest.approx([self._S, 0.0, 0.0, self._S], abs=1e-4)
         assert base["linear_velocity"] == pytest.approx([1.1, 2.2, 3.3], abs=1e-4)
-        assert base["angular_velocity"] == pytest.approx([4.4, 5.5, 6.6], abs=1e-4)
+        # angular_velocity is in the BODY frame (MuJoCo parity / IMU-gyro
+        # convention). Newton stores it world-frame; at the +90deg-about-Z base
+        # the world twist [4.4, 5.5, 6.6] expressed in the body frame is
+        # R(quat)^T @ [4.4, 5.5, 6.6] == [5.5, -4.4, 6.6].
+        assert base["angular_velocity"] == pytest.approx([5.5, -4.4, 6.6], abs=1e-4)
         # Child hinges still read their own coordinates (not shifted / dropped).
         assert state["j1"]["position"] == pytest.approx(0.55, abs=1e-4)
         assert state["j2"]["position"] == pytest.approx(-0.22, abs=1e-4)
@@ -214,7 +221,40 @@ class TestFloatingBaseSurfacing:
         assert obs["base_pos"] == pytest.approx([0.3, 0.4, 0.9], abs=1e-4)
         assert obs["base_quat"] == pytest.approx([self._S, 0.0, 0.0, self._S], abs=1e-4)
         assert obs["base_lin_vel"] == pytest.approx([1.1, 2.2, 3.3], abs=1e-4)
-        assert obs["base_ang_vel"] == pytest.approx([4.4, 5.5, 6.6], abs=1e-4)
+        # base_ang_vel is BODY-frame (MuJoCo parity); the world twist
+        # [4.4, 5.5, 6.6] rotated into the +90deg-about-Z body frame is
+        # [5.5, -4.4, 6.6]. See test_base_ang_vel_is_body_frame_matching_mujoco.
+        assert obs["base_ang_vel"] == pytest.approx([5.5, -4.4, 6.6], abs=1e-4)
+
+    def test_base_ang_vel_is_body_frame_matching_mujoco(self, engine_floater):
+        """base_ang_vel is the body-frame angular velocity, not the raw world twist.
+
+        Newton stores a free joint's angular velocity in the WORLD frame, but the
+        MuJoCo backend (and the IMU-gyro convention the WBC / locomotion
+        observation builder consumes) reports it in the BODY frame. For a base
+        yawed +90deg about Z spinning about WORLD x, the body frame sees that as
+        a spin about body -y, so base_ang_vel must be [0, -w, 0], NOT the raw
+        [w, 0, 0]. An identity-oriented base leaves world == body unchanged.
+        """
+        S = self._S
+        q = engine_floater._state_0.joint_q.numpy().copy()
+        q[0:3] = [0.0, 0.0, 0.9]
+        q[3:7] = [0.0, 0.0, S, S]  # xyzw: +90 about Z
+        engine_floater._state_0.joint_q.assign(q)
+        qd = engine_floater._state_0.joint_qd.numpy().copy()
+        qd[:] = 0.0
+        qd[3:6] = [2.0, 0.0, 0.0]  # pure WORLD-x angular velocity
+        engine_floater._state_0.joint_qd.assign(qd)
+        obs = engine_floater.get_observation("floater", skip_images=True)
+        assert obs["base_ang_vel"] == pytest.approx([0.0, -2.0, 0.0], abs=1e-4)
+
+        # Identity orientation: world frame == body frame, value passes through.
+        q[3:7] = [0.0, 0.0, 0.0, 1.0]  # xyzw identity
+        engine_floater._state_0.joint_q.assign(q)
+        qd[3:6] = [0.3, 0.4, 0.5]
+        engine_floater._state_0.joint_qd.assign(qd)
+        obs2 = engine_floater.get_observation("floater", skip_images=True)
+        assert obs2["base_ang_vel"] == pytest.approx([0.3, 0.4, 0.5], abs=1e-4)
 
     def test_fixed_base_arm_has_no_base_entry(self, engine_so100):
         # A fixed-base arm (no free root) must be unchanged: no base pose, no


### PR DESCRIPTION
## Problem

`get_observation` / `get_robot_state` are a cross-backend contract, but the MuJoCo and Newton backends surfaced a floating base's `base_ang_vel` in **different frames** for the same physical motion.

- **MuJoCo** returns it in the **body frame** (a MuJoCo free joint's `qvel` angular block is expressed in the local body frame). This is the IMU-gyro convention a WBC / locomotion controller consumes: `WBCPolicy._extract_state` reads `base_ang_vel` straight from the observation and feeds it into the observation builder alongside a body-frame projected-gravity cue, with no frame rotation of its own.
- **Newton** returned the **raw world-frame** angular velocity.

So once the base yaws away from identity the two backends disagree by up to the full magnitude of the signal. For a base spinning about world-X at 2 rad/s, at a 90-degree yaw:

| backend | `base_ang_vel` |
|---|---|
| MuJoCo (body frame) | `[0, -2, 0]` |
| Newton (before) | `[2, 0, 0]` |

A humanoid / mobile policy evaluated across backends -- or a G1 WBC controller driven on the Newton backend -- is silently fed a mis-framed gyro signal that grows wrong as the base turns and destabilises the gait. Because recorded datasets capture `base_ang_vel` from `get_observation`, a locomotion dataset recorded on Newton inherited the same world-frame error.

## Change

Newton's `_free_base_pose` now rotates the free joint's angular velocity from the world frame into the body frame via the base quaternion (`R(q)^T @ w`, a small local numpy helper), so `base_ang_vel` matches the MuJoCo backend and the IMU-gyro convention. The linear velocity stays world-frame on both backends (already consistent, so it maps directly). The frame of each base signal (`base_lin_vel` world, `base_ang_vel` body) is now documented on both backends' `get_observation`.

## Verification

Real G1 sweep on both backends -- the base yawed 0->90 degrees while spinning about world-X at 2 rad/s. Newton (post-fix) is **identical to MuJoCo to 1e-6** across the whole sweep; the pre-fix world-frame reading is flat and diverges to a full 2 rad/s of error:

![base_ang_vel frame parity](https://github.com/cagataycali/robots/releases/download/artifacts-newton-base-angvel-frame-1783518768/newton_base_angvel_frame_parity.png)

- **Regression tests** (`tests/simulation/newton/test_discovery_and_state.py`): the existing `TestFloatingBaseSurfacing` cases pinned the raw world-frame value at a +90-degree-yawed base; they now assert the body-frame value (`[5.5, -4.4, 6.6]` = `R(q)^T @ [4.4, 5.5, 6.6]`), plus a new `test_base_ang_vel_is_body_frame_matching_mujoco` (world-X spin -> `[0, -2, 0]`, and an identity-orientation passthrough). All three fail on the pre-fix source and pass after.
- An identity-oriented base is unchanged (world == body), so existing upright-stance behaviour is untouched.
- Green gate: `ruff check` + `ruff format` + `mypy` clean on the changed modules; the Newton discovery/state + dataset-recording suites and the MuJoCo mobile-base / floating-base-recording + WBC suites all pass (53 + 162 tests).