### PR TITLE
fix(sim): reject robot-setup kwargs in backend constructors instead of silently dropping them

### DIFF
--- a/docs/simulation/world-building.md
+++ b/docs/simulation/world-building.md
@@ -16,6 +16,19 @@ sim.add_object(name="table", shape="box", size=[0.5, 0.5, 0.02],
 sim.add_camera(name="overhead", position=[0.0, 0.0, 1.5], target=[0.0, 0.0, 0.0])
 ```
 
+## Setup entry points
+
+`Robot("so100")` is the one-step way to get a ready-to-drive engine: it builds
+the world and adds the named robot for you. Constructing a backend directly -
+`create_simulation("mujoco")` or `Simulation()` - gives an **empty** engine; you
+then call `create_world()` and `add_robot("so100")` yourself.
+
+`robot_name` therefore belongs to `Robot(...)` and `add_robot(...)`, never to a
+backend constructor. Passing it to the constructor
+(`Simulation(robot_name="so100")`) is rejected with a `TypeError` rather than
+silently ignored, so the mistake is caught up front instead of surfacing later
+as an unrelated `No world` error.
+
 ## Strategies
 
 | Need | Approach |

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -46,6 +46,49 @@ from strands_robots.simulation.policy_runner import PolicyRunner, VideoConfig
 logger = logging.getLogger(__name__)
 
 
+# Robot-setup keyword arguments that identify a caller who confused a backend
+# *constructor* with the robot-setup entry points. A constructor builds only an
+# empty engine; a robot is added afterwards via ``add_robot`` (or in one step by
+# the ``Robot(name, mode="sim")`` factory). Backend constructors accept
+# ``**kwargs`` for cross-backend forward compatibility - so a single call can
+# carry GPU-backend options such as ``num_envs`` / ``device`` that non-GPU
+# backends simply drop - but that sink must not silently swallow an argument
+# that names a *robot to set up*. Matching the "no silent swallow of unknown
+# kwargs" contract already enforced for ``add_object``, these are rejected
+# loudly instead of being dropped and failing far downstream with an unrelated
+# "No world" error.
+_SETUP_KWARGS: tuple[str, ...] = ("robot_name", "robot")
+
+
+def reject_setup_kwargs(kwargs: Mapping[str, Any]) -> None:
+    """Reject robot-setup keyword arguments passed to a backend constructor.
+
+    A backend ``__init__`` accepts ``**kwargs`` only as a forward-compatibility
+    sink for backend-specific options. Passing ``robot_name`` (or ``robot``)
+    there is always a mistake: the constructor creates an empty engine, so the
+    argument is meaningless and would otherwise be silently dropped, leaving a
+    robot-less engine that fails later with a confusing "No world" error.
+
+    Args:
+        kwargs: The residual keyword arguments a backend ``__init__`` is about
+            to drop into its forward-compatibility sink.
+
+    Raises:
+        TypeError: If ``kwargs`` names a robot-setup argument. The message
+            points at the ``Robot(name, mode="sim")`` factory (one-step setup)
+            and the ``create_world()`` + ``add_robot(name)`` sequence.
+    """
+    offending = [k for k in _SETUP_KWARGS if k in kwargs]
+    if not offending:
+        return
+    names = ", ".join(repr(k) for k in offending)
+    raise TypeError(
+        f"Simulation backend constructor does not accept {names}: a constructor "
+        'builds an empty engine, not a robot. Use Robot("so101", mode="sim") for '
+        'one-step setup, or create_world() then add_robot("so101").'
+    )
+
+
 class SimEngine(ABC):
     """Abstract base class for simulation engines.
 

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -58,7 +58,7 @@ from strands.tools.tools import AgentTool
 from strands.types._events import ToolResultEvent
 from strands.types.tools import ToolSpec, ToolUse
 
-from strands_robots.simulation.base import SimEngine
+from strands_robots.simulation.base import SimEngine, reject_setup_kwargs
 from strands_robots.simulation.model_registry import (
     count_sim_robots,
     list_available_models,
@@ -203,8 +203,12 @@ class MuJoCoSimEngine(
                 GPU backends) so an identical call resolves across backends.
                 Mirrors ``NewtonSimEngine``'s forward-compatible contract. Note
                 they are NOT passed to ``super().__init__()`` (``AgentTool``
-                takes no constructor arguments).
+                takes no constructor arguments). Robot-setup arguments
+                (``robot_name`` / ``robot``) are rejected here rather than
+                dropped - a constructor builds an empty engine, so use
+                ``Robot("so101", mode="sim")`` or ``add_robot`` instead.
         """
+        reject_setup_kwargs(kwargs)
         super().__init__()
         self._init_ros_bridge(ros2_bridge=ros2_bridge, ros2_domain=ros2_domain)
         self.tool_name_str = tool_name

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -37,7 +37,7 @@ import numpy as np
 
 from strands_robots.assets import resolve_model_path, resolve_robot_name
 from strands_robots.registry.discovery import discover_urdf_path, list_urdf_discoverable
-from strands_robots.simulation.base import SimEngine
+from strands_robots.simulation.base import SimEngine, reject_setup_kwargs
 from strands_robots.simulation.model_registry import (
     list_available_models,
     resolve_model,
@@ -145,11 +145,14 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
                 ``None`` selects Warp's default device (GPU when available).
             default_width: Default render width in pixels.
             default_height: Default render height in pixels.
-            **kwargs: Ignored; accepted for forward compatibility.
+            **kwargs: Ignored; accepted for forward compatibility. Robot-setup
+                arguments (``robot_name`` / ``robot``) are rejected rather than
+                dropped - use ``Robot("so101", mode="sim")`` or ``add_robot``.
 
         Raises:
             ValueError: If ``solver`` is not a known solver name.
         """
+        reject_setup_kwargs(kwargs)
         super().__init__()
         # State that teardown (destroy/cleanup/__del__) touches must be set
         # before any fallible construction step. Otherwise a partially built

--- a/tests/simulation/test_constructor_rejects_setup_kwargs.py
+++ b/tests/simulation/test_constructor_rejects_setup_kwargs.py
@@ -1,0 +1,93 @@
+"""Regression: a simulation backend constructor must not silently swallow a
+robot-setup keyword argument.
+
+Backend constructors accept ``**kwargs`` purely as a cross-backend
+forward-compatibility sink (so one call can carry GPU-backend options like
+``num_envs`` / ``device`` that non-GPU backends drop). Before this contract was
+pinned, passing ``robot_name`` there - a very natural mistake, since
+``robot_name`` is the ubiquitous parameter of ``run_policy`` / ``eval_policy`` /
+``get_observation`` / ``send_action`` - was silently dropped. The caller got a
+robot-less engine that only failed much later, and far from the cause, with an
+unrelated "No world" error. That is the same "success/failure contract, wrong
+effect, no signal" footgun the project already fixed for ``add_object``.
+
+These pin the corrected contract:
+
+* the shared ``reject_setup_kwargs`` helper raises ``TypeError`` naming the
+  offending argument and pointing at the ``Robot(name, mode="sim")`` factory and
+  ``add_robot``;
+* genuine forward-compatibility kwargs (``num_envs`` / ``device``) are still
+  tolerated and dropped;
+* both the direct MuJoCo constructor and the ``create_simulation`` factory that
+  forwards to it fail loudly instead of returning a robot-less engine;
+* the Newton backend shares the identical contract (gated on the extra).
+"""
+
+import pytest
+
+from strands_robots.simulation.base import reject_setup_kwargs
+
+
+def test_helper_rejects_robot_name() -> None:
+    with pytest.raises(TypeError) as exc:
+        reject_setup_kwargs({"robot_name": "so101"})
+    msg = str(exc.value)
+    assert "robot_name" in msg
+    # Message must be actionable: point at the factory and add_robot.
+    assert "Robot(" in msg
+    assert "add_robot" in msg
+
+
+def test_helper_rejects_robot() -> None:
+    with pytest.raises(TypeError, match="robot"):
+        reject_setup_kwargs({"robot": "so101"})
+
+
+def test_helper_reports_all_offending_names() -> None:
+    with pytest.raises(TypeError) as exc:
+        reject_setup_kwargs({"robot_name": "a", "robot": "b"})
+    msg = str(exc.value)
+    assert "robot_name" in msg
+    assert "'robot'" in msg
+
+
+def test_helper_ignores_forward_compat_kwargs() -> None:
+    """Genuine backend-specific kwargs must pass through untouched (no raise)."""
+    reject_setup_kwargs({"num_envs": 4, "device": "cpu"})
+    reject_setup_kwargs({})
+
+
+def test_mujoco_constructor_rejects_robot_name() -> None:
+    pytest.importorskip("mujoco")
+    from strands_robots.simulation.mujoco.simulation import Simulation
+
+    with pytest.raises(TypeError) as exc:
+        Simulation(robot_name="so101")
+    assert "robot_name" in str(exc.value)
+
+
+def test_create_simulation_factory_rejects_robot_name() -> None:
+    pytest.importorskip("mujoco")
+    from strands_robots.simulation import create_simulation
+
+    with pytest.raises(TypeError, match="robot_name"):
+        create_simulation("mujoco", robot_name="so101")
+
+
+def test_mujoco_constructor_tolerates_forward_compat_kwargs() -> None:
+    pytest.importorskip("mujoco")
+    from strands_robots.simulation.mujoco.simulation import Simulation
+
+    sim = Simulation(num_envs=4, device="cpu", tool_name="fc_probe")
+    try:
+        assert sim is not None
+    finally:
+        sim.cleanup()
+
+
+def test_newton_constructor_rejects_robot_name() -> None:
+    pytest.importorskip("newton")
+    from strands_robots.simulation.newton.simulation import NewtonSimEngine
+
+    with pytest.raises(TypeError, match="robot_name"):
+        NewtonSimEngine(robot_name="so101")


### PR DESCRIPTION
## Problem

A simulation backend constructor builds an *empty* engine; a robot is added afterwards via `add_robot`, or in one step by the `Robot(name, mode="sim")` factory. The constructors accept `**kwargs` purely as a cross-backend forward-compatibility sink, so a single call can carry GPU-backend options like `num_envs` / `device` that non-GPU backends drop.

That sink silently swallowed `robot_name` — a very natural mistake, since `robot_name` is the ubiquitous parameter of `run_policy` / `eval_policy` / `get_observation` / `send_action`. So:

```python
sim = Simulation(robot_name="so101")   # robot_name silently dropped
sim.run_policy(policy_provider="mock", instruction="wave", n_steps=10)
# -> {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
```

The caller gets a robot-less engine that only fails much later, far from the cause, with an unrelated `No world` error — the same "contract says OK/generic-fail, wrong effect, no signal" footgun already fixed for `add_object` (`test_add_object_rejects_unknown_kwargs`).

## Change

Add a shared `reject_setup_kwargs()` guard in `strands_robots.simulation.base` and call it from both backend constructors (MuJoCo + Newton):

- `robot_name` / `robot` now raise a `TypeError` that names the offending argument and points at `Robot("so101", mode="sim")` (one-step setup) and `create_world()` + `add_robot("so101")`.
- Genuine forward-compat kwargs (`num_envs` / `device`) still pass through untouched — the forward-compatibility contract is preserved.
- The `Robot(...)` factory is unaffected: it consumes `name` separately and never forwards `robot_name` to the constructor.

## Tests

`tests/simulation/test_constructor_rejects_setup_kwargs.py` pins the contract (fails on pre-fix code — the helper does not exist):

- helper raises `TypeError` on `robot_name` / `robot` with an actionable message (names the factory + `add_robot`);
- helper reports all offending names and ignores forward-compat kwargs;
- MuJoCo constructor and the `create_simulation("mujoco", ...)` factory that forwards to it both raise;
- MuJoCo constructor still tolerates `num_envs` / `device`;
- Newton shares the identical contract (gated on the `newton` extra).

Green locally: `ruff check` / `ruff format --check` / `mypy` clean on `strands_robots tests tests_integ`; full `tests/simulation/` suite passes (1955 passed, 123 skipped) headless (`MUJOCO_GL=egl`).

## Docs

`docs/simulation/world-building.md` gains a "Setup entry points" note clarifying the constructor-vs-factory distinction and that `robot_name` belongs to `Robot(...)` / `add_robot(...)`, never a backend constructor.