### PR TITLE
fix(inference): warn on a mistyped RemotePolicy endpoint instead of silently defaulting to localhost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1054,6 +1054,22 @@ both backends (already consistent); the frame of each base signal is now
 documented on both backends' `get_observation`.
 
 
+### Fixed: surface a mistyped RemotePolicy connection endpoint instead of silently defaulting to localhost
+
+`RemotePolicy` (the `remote` inference client) tolerates unrecognized
+constructor kwargs so a shared `policy_config` superset can be forwarded through
+`create_policy` unchanged -- the cross-provider ignore-unknown-kwargs contract.
+But it dropped them SILENTLY, so passing the server endpoint under the wrong
+name (e.g. `RemotePolicy(uri=...)` -- `uri` is the object's own attribute name,
+an easy slip) left the client connected to the default `ws://127.0.0.1:8765`
+with no hint that the intended endpoint never took effect; the only symptom was
+a confusing "connection refused" to a port the user never chose. `RemotePolicy`
+now logs a WARNING naming the ignored kwarg(s) and the endpoint actually in use,
+so the misconfiguration is visible at construction. Unknown kwargs are still
+tolerated (no behavioural break); the normal `endpoint=`/`host=`/`port=` and
+smart-string (`create_policy("ws://...")`) paths stay silent. Mirrors the
+earlier no-silent-localhost-default fix for `cosmos3://` URLs.
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/docs/inference/remote.md
+++ b/docs/inference/remote.md
@@ -77,6 +77,12 @@ policy = create_policy("remote", endpoint="ws://gpu-box:8765")
 policy = create_policy("ws://gpu-box:8765")
 ```
 
+The server endpoint is set via `endpoint=` (with a `host=`/`port=` fallback).
+`RemotePolicy` tolerates unrecognized kwargs so a shared `policy_config` can be
+forwarded unchanged, but passing the endpoint under any other name (e.g. `uri=`)
+logs a WARNING naming the ignored kwarg and the endpoint actually in use, rather
+than silently connecting to the default `ws://127.0.0.1:8765`.
+
 Then drive it exactly like a local policy. In simulation:
 
 ```python

--- a/strands_robots/inference/client.py
+++ b/strands_robots/inference/client.py
@@ -59,6 +59,11 @@ class RemotePolicy(Policy):
         connect_timeout: Seconds to wait for the WebSocket handshake.
         request_timeout: Seconds to wait for a reply to each request.
 
+    Unrecognized kwargs are ignored (for forward-compatible ``policy_config``
+    passthrough via :func:`~strands_robots.policies.create_policy`) but logged
+    at WARNING, since a mistyped connection kwarg (e.g. ``uri=``) would
+    otherwise leave the client silently connected to the default endpoint.
+
     Raises:
         ConnectionError: On first use, if the server cannot be reached.
     """
@@ -71,11 +76,32 @@ class RemotePolicy(Policy):
         port: int = 8765,
         connect_timeout: float = DEFAULT_CONNECT_TIMEOUT,
         request_timeout: float = DEFAULT_REQUEST_TIMEOUT,
-        **_ignored: Any,
+        **ignored_kwargs: Any,
     ) -> None:
         self.uri = endpoint if endpoint else f"ws://{host}:{port}"
         if not self.uri.startswith(("ws://", "wss://")):
             self.uri = f"ws://{self.uri}"
+        # A remote client forwards a shared policy_config superset (via
+        # create_policy), so unrecognized kwargs are tolerated rather than
+        # rejected - the cross-provider "ignore unknown constructor kwargs"
+        # contract. But dropping them SILENTLY hides a connection
+        # misconfiguration: the server endpoint is set via ``endpoint`` (with
+        # a ``host``/``port`` fallback), and passing it under any other name
+        # (e.g. ``uri=`` - also this object's own attribute name, an easy
+        # slip) leaves the client silently pointed at the default
+        # ws://127.0.0.1:8765, surfacing only as a confusing "connection
+        # refused" to a port the user never chose. Warn so the endpoint
+        # actually in use is visible (mirrors the #317 no-silent-localhost
+        # -default fix for cosmos3:// URLs).
+        if ignored_kwargs:
+            logger.warning(
+                "RemotePolicy ignoring unexpected constructor kwarg(s) %s; "
+                "connecting to %s. Set the server endpoint via endpoint= "
+                "(or host=/port=); server-side policy config belongs on the "
+                "PolicyServer, not the client.",
+                sorted(ignored_kwargs),
+                self.uri,
+            )
         self.connect_timeout = connect_timeout
         self.request_timeout = request_timeout
 

--- a/tests/inference/test_remote_policy_roundtrip.py
+++ b/tests/inference/test_remote_policy_roundtrip.py
@@ -7,6 +7,7 @@ observation->chunk round-trip, config/reset/RTC forwarding, and loud error
 propagation - not internal state.
 """
 
+import logging
 import socket
 from typing import Any
 
@@ -231,6 +232,36 @@ def test_create_policy_named_remote_provider_with_endpoint():
     policy = create_policy("remote", endpoint="wss://secure-box:9000")
     assert isinstance(policy, RemotePolicy)
     assert policy.uri == "wss://secure-box:9000"
+
+
+def test_wrong_named_endpoint_kwarg_warns_instead_of_silently_defaulting(caplog):
+    """A connection endpoint passed under the wrong kwarg name is tolerated (the
+    cross-provider ignore-unknown-constructor-kwargs contract) but MUST NOT be
+    dropped silently: the client would otherwise connect to the default
+    ws://127.0.0.1:8765 with no hint that the intended endpoint never took
+    effect, surfacing only as a confusing "connection refused" to a port the
+    user never chose (cf. the #317 no-silent-localhost-default fix). ``uri`` is
+    this object's own attribute name -> the single most likely such slip.
+    """
+    with caplog.at_level(logging.WARNING, logger="strands_robots.inference.client"):
+        policy = RemotePolicy(uri="ws://gpu-box:9000")
+    # The mistyped endpoint was ignored -> the client fell back to the default.
+    assert policy.uri == "ws://127.0.0.1:8765"
+    # ...but the drop is now surfaced, naming the offending kwarg + the endpoint.
+    warnings = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("uri" in m and "ws://127.0.0.1:8765" in m for m in warnings), warnings
+
+
+def test_known_constructor_kwargs_do_not_warn(caplog):
+    """The warning fires only for genuinely-unrecognized kwargs; the documented
+    endpoint/host/port/timeout kwargs stay quiet so the diagnostic is high-signal
+    (the normal ``create_policy("ws://...")`` path passes only known kwargs)."""
+    with caplog.at_level(logging.WARNING, logger="strands_robots.inference.client"):
+        policy = RemotePolicy(endpoint="ws://gpu-box:9000", connect_timeout=2.0, request_timeout=5.0)
+    assert policy.uri == "ws://gpu-box:9000"
+    assert not any("ignoring unexpected constructor" in r.getMessage() for r in caplog.records), [
+        r.getMessage() for r in caplog.records
+    ]
 
 
 def test_policy_server_requires_exactly_one_policy_source():


### PR DESCRIPTION
## Problem

`RemotePolicy` (the `remote` inference client) accepts `**kwargs` and silently ignores unrecognized ones. That tolerance is intentional and matches the cross-provider ignore-unknown-constructor-kwargs contract (`tests/policies/test_base.py::test_unknown_kwargs_are_silently_ignored`, and the motionbricks/wbc/lerobot/groot analogues) — it lets a shared `policy_config` superset forward cleanly through `create_policy`.

But it dropped them **silently**, which hides a connection misconfiguration. The server endpoint kwarg is `endpoint` (with a `host`/`port` fallback); passing it under any other name is swallowed and the client falls back to the default `ws://127.0.0.1:8765`:

```python
RemotePolicy(uri="ws://gpu-box:8765")   # 'uri' silently ignored
# -> .uri == "ws://127.0.0.1:8765"      # connected to localhost, not gpu-box
```

`uri` is especially easy to reach for — it is the object's own attribute name (`self.uri`). The only symptom is a later `ConnectionError: could not reach a PolicyServer at ws://127.0.0.1:8765` — a confusing "connection refused" to a port the user never chose, pointing them at the wrong place while their intended endpoint never took effect.

This is the same class the resolver already guards elsewhere: the `cosmos3://` branch in `resolve_policy` carries the note *"Without this branch the pattern matches but no parser populates host/port, so `create_policy("cosmos3://prod:9000")` silently falls back to the default localhost:8000"* — a no-silent-localhost-default fix. `RemotePolicy`'s constructor is the same latent footgun on the direct/typo path.

## Change

`RemotePolicy.__init__` now logs a `WARNING` when it ignores constructor kwargs, naming the ignored key(s) and the endpoint actually in use:

```
RemotePolicy ignoring unexpected constructor kwarg(s) ['uri']; connecting to
ws://127.0.0.1:8765. Set the server endpoint via endpoint= (or host=/port=);
server-side policy config belongs on the PolicyServer, not the client.
```

- **No behavioural break**: unknown kwargs are still tolerated (the ignore-unknown-kwargs contract is preserved — `tests/policies/test_base.py` stays green). The fix only makes the drop *visible*.
- **High-signal**: the documented `endpoint=`/`host=`/`port=` kwargs and the normal smart-string path (`create_policy("ws://...")`, which passes only known kwargs) stay silent — the warning fires only for a genuinely-unrecognized kwarg.
- Docstring + `docs/inference/remote.md` updated to state the endpoint kwarg name and the ignore-with-warning behaviour.

## Tests

`tests/inference/test_remote_policy_roundtrip.py`:
- `test_wrong_named_endpoint_kwarg_warns_instead_of_silently_defaulting` — pins both the footgun (`RemotePolicy(uri=...).uri == "ws://127.0.0.1:8765"`) and the new diagnostic. **Fails before** the fix (no warning emitted), passes after.
- `test_known_constructor_kwargs_do_not_warn` — no-regression guard: `endpoint=`/`connect_timeout=`/`request_timeout=` stay quiet.

Full `tests/inference/` suite: 37 passed. `tests/policies/test_base.py` (the ignore-unknown-kwargs contract): 45 passed. `ruff check`/`ruff format --check` clean; `mypy` clean on the changed source.

Exercised end to end against a live loopback `PolicyServer` wrapping a real `lerobot/smolvla_base` policy: with the correct `endpoint=` the client connects, mirrors metadata (`execution_horizon=50`, `actions_per_step=50`, `supports_rtc=False`, `requires_images=True`), and drives a MuJoCo `so101` rollout — confirming the wire path itself is sound and the sole defect was the silent endpoint drop.