### PR TITLE
fix(sim): surface cached-XML refresh failures in scene mutations instead of swallowing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: scene mutations silently swallowed a cached-XML refresh failure
+
+Every MuJoCo scene mutation keeps a legacy XML string in
+`_backend_state["xml"]` in sync with the live `MjSpec` so the `load_scene` +
+`add_robot` round-trip can read it. That refresh calls `spec.to_xml()`, which
+can fail on specs MuJoCo cannot serialise. Two of the four mutation paths
+(`replace_scene_mjcf` and `patch_scene_mjcf`) wrapped it in a bare
+`except Exception: pass`, so a failure left the cache stale and diverged from
+the live spec with no diagnostic -- a subsequent XML-cache reader would see
+outdated scene contents and nothing explained why. The other two paths
+(`add_object`/recompile and `eject_robot_from_scene`) already logged the reason.
+All four now funnel through one `_sync_cached_xml` helper that logs the failure
+at debug and leaves the prior cache intact: still never fatal (the live
+model/spec are already updated), but no longer silent.
+
 ### Added: remote policy inference (client/server split) for edge robots + remote GPU
 
 A resource-constrained robot host (edge device / laptop CPU) often cannot run a

--- a/strands_robots/simulation/mujoco/scene_ops.py
+++ b/strands_robots/simulation/mujoco/scene_ops.py
@@ -50,6 +50,24 @@ def _get_spec(world: SimWorld) -> Any | None:
     return world._backend_state.get("spec")
 
 
+def _sync_cached_xml(world: SimWorld, spec: Any) -> None:
+    """Refresh the legacy XML cache in ``world._backend_state["xml"]`` from ``spec``.
+
+    Some readers (the ``load_scene`` + ``add_robot`` round-trip) consume the
+    cached XML string rather than the live ``MjSpec``, so it must be refreshed
+    after every recompile. ``spec.to_xml()`` can fail on specs MuJoCo cannot
+    serialise; that is never fatal to the mutation (the live model/spec are
+    already updated), so we leave the previous cache in place - but we always
+    log the reason at debug so a silently stale cache stays diagnosable rather
+    than being swallowed.
+    """
+    try:
+        with filter_mujoco_attach_noise():
+            world._backend_state["xml"] = spec.to_xml()
+    except Exception as xml_err:
+        logger.debug("spec.to_xml() failed; cached XML left stale: %s", xml_err)
+
+
 def _recompile_preserving_state(world: SimWorld, spec: Any) -> bool:
     """Recompile ``spec`` in place, replacing ``world._model`` and ``_data``.
 
@@ -80,11 +98,7 @@ def _recompile_preserving_state(world: SimWorld, spec: Any) -> bool:
 
     # Keep the cached XML in sync with the spec for legacy readers (e.g.
     # load_scene + add_robot round-trip).
-    try:
-        with filter_mujoco_attach_noise():
-            world._backend_state["xml"] = spec.to_xml()
-    except Exception as xml_err:
-        logger.debug("spec.to_xml() failed: %s", xml_err)
+    _sync_cached_xml(world, spec)
 
     # Re-discover per-robot IDs. Names inside MuJoCo are namespaced under
     # robot.namespace (e.g. "arm1/shoulder_pan") when robots were attached
@@ -446,11 +460,7 @@ def eject_robot_from_scene(world: SimWorld, robot_name: str) -> bool:
     world._model = new_model
     world._data = new_data
     world._backend_state["spec"] = new_spec
-    try:
-        with filter_mujoco_attach_noise():
-            world._backend_state["xml"] = new_spec.to_xml()
-    except Exception as xml_err:
-        logger.debug("spec.to_xml() failed: %s", xml_err)
+    _sync_cached_xml(world, new_spec)
 
     # Step 4: restore state for every joint that survived the rebuild. Joints
     # belonging to the ejected robot simply don't resolve and get skipped.
@@ -521,11 +531,7 @@ def replace_scene_mjcf(world: SimWorld, xml: str) -> bool:
     # _compile_world() which also calls mj_forward after MjData construction.
     mj.mj_forward(new_model, new_data)
 
-    try:
-        with filter_mujoco_attach_noise():
-            world._backend_state["xml"] = new_spec.to_xml()
-    except Exception:
-        pass
+    _sync_cached_xml(world, new_spec)
     return True
 
 
@@ -740,9 +746,5 @@ def patch_scene_mjcf(world: SimWorld, ops: list[dict[str, Any]]) -> int:
     mj = _ensure_mujoco()
     mj.mj_forward(world._model, world._data)
 
-    try:
-        with filter_mujoco_attach_noise():
-            world._backend_state["xml"] = spec.to_xml()
-    except Exception:
-        pass
+    _sync_cached_xml(world, spec)
     return applied

--- a/tests/simulation/mujoco/test_scene_ops_cached_xml_sync.py
+++ b/tests/simulation/mujoco/test_scene_ops_cached_xml_sync.py
@@ -1,0 +1,120 @@
+"""Regression tests for the cached-XML refresh in scene mutations.
+
+Scene mutations keep a legacy XML string in ``_backend_state["xml"]`` in sync
+with the live ``MjSpec`` so the ``load_scene`` + ``add_robot`` round-trip can
+read it. That refresh calls ``spec.to_xml()``, which can fail on specs MuJoCo
+cannot serialise. Two of the four mutation paths (``replace_scene_mjcf`` and
+``patch_scene_mjcf``) previously swallowed that failure with a bare
+``except Exception: pass``, so a stale cache diverged from the live spec with no
+diagnostic. All four paths now funnel through ``_sync_cached_xml`` which logs
+the reason at debug and leaves the prior cache intact - never fatal, never
+silent. These tests pin that contract.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Generator
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+import mujoco  # noqa: E402
+
+from strands_robots.simulation.mujoco.scene_ops import (  # noqa: E402
+    _sync_cached_xml,
+    replace_scene_mjcf,
+)
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+REPLACEMENT_XML = """
+<mujoco model="replacement_scene">
+  <option timestep="0.002"/>
+  <worldbody>
+    <light name="l" pos="0 0 3" dir="0 0 -1"/>
+    <geom name="ground" type="plane" size="5 5 0.01"/>
+    <body name="new_block" pos="0.5 0 0.1">
+      <geom name="new_block_geom" type="box" size="0.1 0.1 0.1"/>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+
+@pytest.fixture
+def sim() -> Generator[Simulation, None, None]:
+    s = Simulation()
+    try:
+        yield s
+    finally:
+        s.cleanup()
+
+
+def test_replace_scene_mjcf_refreshes_cache_on_success(sim: Simulation) -> None:
+    """A successful replace refreshes the cached XML to the new scene."""
+    sim.create_world()
+    assert sim._world is not None
+
+    assert replace_scene_mjcf(sim._world, REPLACEMENT_XML) is True
+
+    cached = sim._world._backend_state.get("xml")
+    assert cached is not None
+    assert "replacement_scene" in cached
+    assert "new_block" in cached
+
+
+def test_replace_scene_mjcf_surfaces_xml_cache_refresh_failure(
+    sim: Simulation, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A to_xml() failure during the cache refresh is logged, not swallowed.
+
+    Pre-fix this path used ``except Exception: pass`` - no diagnostic - so a
+    stale cache diverged silently. The mutation itself must still succeed
+    (model/spec are already swapped) and the prior cache must be left intact.
+    """
+    sim.create_world()
+    assert sim._world is not None
+    sim._world._backend_state["xml"] = "<sentinel/>"
+
+    def _boom(self: object, *args: object, **kwargs: object) -> str:
+        raise RuntimeError("cannot serialise this spec")
+
+    monkeypatch.setattr(mujoco.MjSpec, "to_xml", _boom)
+
+    with caplog.at_level(logging.DEBUG, logger="strands_robots.simulation.mujoco.scene_ops"):
+        result = replace_scene_mjcf(sim._world, REPLACEMENT_XML)
+
+    assert result is True, "a cache-refresh failure must not fail the mutation"
+    assert sim._world._backend_state["xml"] == "<sentinel/>", "prior cache must be preserved"
+    assert any("cached XML left stale" in rec.getMessage() for rec in caplog.records), (
+        "the to_xml() failure must be surfaced at debug, not silently swallowed"
+    )
+
+
+def test_sync_cached_xml_never_raises_and_logs_on_failure(caplog: pytest.LogCaptureFixture) -> None:
+    """The shared helper never raises, preserves the prior cache, and logs why."""
+    world = SimpleNamespace(_backend_state={"xml": "<prev/>"})
+
+    class _FailingSpec:
+        def to_xml(self) -> str:
+            raise RuntimeError("boom")
+
+    with caplog.at_level(logging.DEBUG, logger="strands_robots.simulation.mujoco.scene_ops"):
+        _sync_cached_xml(world, _FailingSpec())  # type: ignore[arg-type]
+
+    assert world._backend_state["xml"] == "<prev/>"
+    assert any("cached XML left stale" in rec.getMessage() for rec in caplog.records)
+
+
+def test_sync_cached_xml_writes_serialised_xml_on_success() -> None:
+    """On success the helper writes the serialised spec into the cache."""
+    world = SimpleNamespace(_backend_state={})
+
+    class _OkSpec:
+        def to_xml(self) -> str:
+            return "<mujoco model='ok'/>"
+
+    _sync_cached_xml(world, _OkSpec())  # type: ignore[arg-type]
+    assert world._backend_state["xml"] == "<mujoco model='ok'/>"


### PR DESCRIPTION
## Problem

Every MuJoCo scene mutation keeps a legacy XML string in `world._backend_state["xml"]` in sync with the live `MjSpec`, so the `load_scene` + `add_robot` round-trip (and any other reader that consumes the cached XML rather than the live spec) sees current scene contents. That refresh calls `spec.to_xml()`, which can fail on specs MuJoCo cannot serialise.

Four code paths perform this refresh, but they handled failure inconsistently:

- `_recompile_preserving_state` (the `add_object` / `add_camera` / recompile path) and `eject_robot_from_scene` logged the failure at debug.
- `replace_scene_mjcf` and `patch_scene_mjcf` wrapped it in a bare `except Exception: pass`.

So in the latter two, a `to_xml()` failure left the cached XML **stale and silently diverged** from the live spec. A subsequent XML-cache reader would then see outdated scene contents with no diagnostic explaining why. This is the classic silent-swallow failure mode the repo's conventions warn against (raise on fatal; never warn-and-continue silently; no silent divergence).

## Change

Funnel all four refresh sites through one small helper, `_sync_cached_xml(world, spec)`, that:

- updates the cache on success,
- on `to_xml()` failure logs the reason at debug and leaves the prior cache intact (never fatal — the live model/spec are already updated), and is **never silent**.

This removes four duplicated try/except blocks and makes it structurally impossible to reintroduce the silent-swallow variant. No change to simulation dynamics, rendering, or recording — this is an error-handling/observability fix, so there is no visual artifact to attach.

## Tests

New `tests/simulation/mujoco/test_scene_ops_cached_xml_sync.py`:

- `test_replace_scene_mjcf_surfaces_xml_cache_refresh_failure` — forces `MjSpec.to_xml` to raise, asserts the mutation still succeeds, the prior cache is preserved, and the failure is logged. **Fails on pre-fix code** (silent `except Exception: pass` emits no log); passes after.
- `test_replace_scene_mjcf_refreshes_cache_on_success` — happy-path cache refresh still works.
- `test_sync_cached_xml_never_raises_and_logs_on_failure` / `test_sync_cached_xml_writes_serialised_xml_on_success` — pin the helper's contract directly.

Local gate green: `ruff check` + `ruff format --check` + `mypy` clean over `strands_robots tests tests_integ`; the affected `tests/simulation/mujoco/` suite (220 tests) passes headless (`MUJOCO_GL=egl`). CHANGELOG updated under `[Unreleased]`.