### PR TITLE
test(package): pin import-time resilience for the GL and dyld autoconfig shims

### DIFF
--- a/tests/test_package_lazy_imports.py
+++ b/tests/test_package_lazy_imports.py
@@ -267,3 +267,62 @@ class TestPolicyTypeDiscoveryReexported:
         )
         proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
         assert proc.returncode == 0, proc.stderr
+
+
+class TestImportResilience:
+    """``import strands_robots`` must never fail because an optional import-time
+    autoconfig step raised.
+
+    The package body runs two best-effort autoconfig blocks at import:
+
+    - a MuJoCo GL-backend probe (headless EGL/OSMesa selection), which can
+      raise ``OSError`` when no usable GL device is present, and
+    - a macOS dyld-path shim for torchcodec's ffmpeg discovery.
+
+    Both are convenience shims, not correctness invariants, so a failure in
+    either must be swallowed and leave ``import strands_robots`` succeeding.
+    These tests reload the package with each shim forced to raise and assert
+    the import still completes and the light API stays usable.
+    """
+
+    def test_import_survives_gl_backend_configure_failure(self):
+        # The GL autoconfig block only runs when mujoco is importable.
+        pytest.importorskip("mujoco")
+        import importlib
+
+        import strands_robots.simulation.mujoco.backend as backend_mod
+
+        real = backend_mod._configure_gl_backend
+
+        def _raise_oserror():
+            # Mirrors a headless box with no usable GL device: EGL/OSMesa
+            # initialisation surfaces as an OSError.
+            raise OSError("simulated EGL device-open failure")
+
+        backend_mod._configure_gl_backend = _raise_oserror  # type: ignore[assignment]
+        try:
+            # Reload re-runs the package body, which now calls the raising
+            # shim. The except-guard must swallow it: reload must not raise.
+            reloaded = importlib.reload(strands_robots)
+            assert callable(reloaded.create_policy)
+        finally:
+            backend_mod._configure_gl_backend = real  # type: ignore[assignment]
+            importlib.reload(strands_robots)
+
+    def test_import_survives_dyld_shim_failure(self):
+        import importlib
+
+        import strands_robots._dyld as dyld_mod
+
+        real = dyld_mod.ensure_ffmpeg_on_dyld_path
+
+        def _raise_runtime(*args, **kwargs):
+            raise RuntimeError("simulated dyld shim failure")
+
+        dyld_mod.ensure_ffmpeg_on_dyld_path = _raise_runtime  # type: ignore[assignment]
+        try:
+            reloaded = importlib.reload(strands_robots)
+            assert callable(reloaded.create_policy)
+        finally:
+            dyld_mod.ensure_ffmpeg_on_dyld_path = real  # type: ignore[assignment]
+            importlib.reload(strands_robots)


### PR DESCRIPTION
## Problem

The `strands_robots` package body runs two best-effort autoconfig blocks at import time:

- a MuJoCo GL-backend probe (`_configure_gl_backend()`), gated on `mujoco` being importable, that selects a headless GL backend (EGL/OSMesa); and
- a macOS dyld-path shim (`ensure_ffmpeg_on_dyld_path()`) for torchcodec's ffmpeg discovery.

Both are convenience shims, not correctness invariants, so each is wrapped in an except-guard (`except (ImportError, AttributeError, OSError)` for the GL probe, `except Exception` for the dyld shim) whose entire point is that a failure must be swallowed and leave `import strands_robots` succeeding. On a headless box with no usable GL device the GL probe legitimately raises `OSError`, and the guard is what keeps the package importable there.

Neither failure branch had any test coverage, so a regression that let one of these shims propagate its exception would pass CI and only surface later as a hard `ImportError` at `import strands_robots` on exactly the headless machines the guard exists to protect.

## Change

Test-only. Adds a `TestImportResilience` class to `tests/test_package_lazy_imports.py` (the canonical home for the package-root import contract) with two regression tests that reload the package with each shim forced to raise and assert the import still completes and the light API (`create_policy`) stays usable:

- `test_import_survives_gl_backend_configure_failure` - patches `_configure_gl_backend` to raise `OSError` (mirrors an EGL/OSMesa device-open failure), reloads, asserts no raise. Skips when `mujoco` is not installed (the block is gated on it).
- `test_import_survives_dyld_shim_failure` - patches `ensure_ffmpeg_on_dyld_path` to raise `RuntimeError`, reloads, asserts no raise.

Both restore the real shims and reload once more in a `finally`, so there is no cross-test contamination (verified by running the sibling top-level import tests in the same process).

## Regression-guard proof

Narrowing the GL guard to `except ImportError` (so `OSError` escapes) and the dyld guard to `except ImportError` (so `RuntimeError` escapes) makes both new tests fail; with the real guards both pass. So they genuinely pin the swallow contract rather than just executing the lines.

## Tests / gate

- `strands_robots/__init__.py` coverage: 87% -> 100% (the two except-branches were the only gap).
- Local gate green over `strands_robots tests tests_integ`: `ruff check` + `ruff format --check` clean, `mypy` reports no issues in 716 files.
- `tests/test_package_lazy_imports.py` passes headless (`MUJOCO_GL=egl`), 21 tests; sibling import tests pass alongside (45 total, no reload contamination).

No production code changed, so there is no behavior, wire-format, schema, CLI or env-var surface change and no visual artifact applies.