### PR TITLE
docs: correct stale list_providers() example output (11 providers, sorted)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -120,7 +120,7 @@ from strands_robots.policies.cosmos3 import Cosmos3Policy
 | `MockPolicy` | Sinusoidal mock. `requires_images=False`. |
 | `create_policy(provider, **kw)` | Resolve + construct. Accepts `zmq://`, `cosmos3://`, HF `org/model`. |
 | `register_policy(name, loader, aliases)` | Runtime registration. |
-| `list_providers()` | `['cosmos3', 'groot', 'lerobot_local', 'mock', + aliases]`. |
+| `list_providers()` | Sorted names of every JSON-registered provider (`cosmos3`, `curobo`, `groot`, `lerobot_local`, `mock`, `motionbricks`, `moveit2`, `remote`, `vera`, `wbc`, `wbc_gait`) plus any runtime `register_policy` names and their aliases. |
 | `list_policy_types()` | `policy_type` strings the installed lerobot resolves; `[]` without lerobot. Discovery peer of `list_providers`. |
 | `UntrustedRemoteCodeError` | Raised when `STRANDS_TRUST_REMOTE_CODE` is required but unset. |
 | `Gr00tPolicy` | GR00T N1.5/N1.6/N1.7 via ZMQ (service) or in-process. |

--- a/docs/policies/overview.md
+++ b/docs/policies/overview.md
@@ -7,7 +7,7 @@ description: The Policy ABC and the providers that ship - MockPolicy, Gr00tPolic
 ```python
 from strands_robots.policies import create_policy, list_policy_types, list_providers
 
-print(list_providers())   # ['cosmos3', 'groot', 'lerobot_local', 'mock', 'vera', ...]
+print(list_providers())   # sorted: ['cosmos3', 'curobo', 'groot', 'lerobot_local', 'mock', 'motionbricks', 'moveit2', 'remote', 'vera', 'wbc', 'wbc_gait']
 print(list_policy_types())  # lerobot_local policy_type strings: ['act', 'diffusion', 'smolvla', ...]
 
 policy = create_policy("mock")                                                     # always works, no model


### PR DESCRIPTION
## Problem

Two docs examples of `list_providers()` output are stale and under-list the registered providers:

- `docs/api-reference.md:123` showed `['cosmos3', 'groot', 'lerobot_local', 'mock', + aliases]` -- only 4 of the 11 first-class providers.
- `docs/policies/overview.md:10` showed `['cosmos3', 'groot', 'lerobot_local', 'mock', 'vera', ...]` -- 5 providers behind an ellipsis, and not in the sorted order the function actually returns.

`list_providers()` (`strands_robots/policies/factory.py:42`) returns `sorted(set(...))` of **every** JSON-registered provider key plus any runtime `register_policy` names and aliases. The registry (`strands_robots/registry/policies.json`) currently defines 11 first-class providers: `cosmos3, curobo, groot, lerobot_local, mock, motionbricks, moveit2, remote, vera, wbc, wbc_gait`. The seven beyond the documented four are genuine providers (each has its own `module`/`class`/`description`), not aliases -- so both examples materially misrepresent the output.

## Change

- `api-reference.md`: replace the incomplete literal with an accurate description -- sorted names of every JSON-registered provider (all 11 named) plus any runtime `register_policy` names and aliases. This removes the hardcoded partial list that drifted, describing the source of truth instead.
- `overview.md`: update the sample-output comment to the true sorted 11-provider list.

Docs-only; no behavioural change, so no CHANGELOG entry (CHANGELOG tracks behavioural changes only).

## Verification

- `strands_robots/registry/policies.json` -> 11 provider keys; each of the 7 previously-omitted keys carries `module`/`class`/`description` (first-class, not aliases).
- `list_providers()` impl returns `sorted(set(json_keys + runtime_registry + runtime_aliases))`, so the sorted full list is the correct minimum output.

## Follow-up (out of scope)

The Providers **table** in `docs/policies/overview.md` documents 7 of 11 providers (missing `motionbricks`, `remote`, `wbc`, `wbc_gait`). That is a separate, larger doc gap (needs each provider's class/extra/use-case) and is intentionally not bundled here to keep this diff surgical.