### PR TITLE
test(training): pin actionable error when a reward-config constructor rejects forwarded fields

### DIFF
--- a/tests/training/test_reward_model_parity.py
+++ b/tests/training/test_reward_model_parity.py
@@ -170,3 +170,44 @@ class TestRewardModelConfigParity:
         )
         problems = LerobotTrainer(device="cpu").validate(spec)
         assert any("does not support field" in p and "annotation_mode" in p for p in problems)
+
+    def test_ctor_rejection_becomes_actionable_error(self, dataset_root, tmp_path, monkeypatch):
+        """A field the reward-config CONSTRUCTOR rejects surfaces an actionable
+        ValueError naming the fields, not a raw TypeError.
+
+        ``_reward_friendly_fields`` introspects the resolved config dataclass to
+        decide which ``extra['reward_model']`` keys to forward. If the installed
+        lerobot's constructor and that introspection ever diverge (an API drift),
+        the forwarded kwargs can be rejected by ``make_reward_model_config`` with
+        a ``TypeError``. The trainer must translate that into a ``ValueError``
+        that names the rejected fields so the drift is diagnosable, and chain the
+        original ``TypeError`` as the cause - not leak a bare, contextless error.
+        """
+        pytest.importorskip("lerobot.rewards")
+        import lerobot.rewards as lr
+
+        def _reject(rtype, **kwargs):
+            raise TypeError("unexpected keyword argument 'device'")
+
+        # The trainer imports make_reward_model_config from lerobot.rewards at
+        # call time, so patching the module attribute intercepts the real call.
+        monkeypatch.setattr(lr, "make_reward_model_config", _reject)
+
+        spec = TrainSpec(
+            dataset_root=dataset_root,
+            base_model="",
+            output_dir=str(tmp_path / "sarm_out"),
+            steps=100,
+            extra={"reward_model": {"type": "sarm"}},
+        )
+        trainer = LerobotTrainer(device="cpu")
+        with pytest.raises(ValueError) as excinfo:
+            trainer.build_config(spec)
+
+        msg = str(excinfo.value)
+        assert "reward_model type 'sarm' rejected field(s)" in msg
+        # The forwarded-field list (always includes the managed 'device') is
+        # named so the drift is diagnosable from the message alone.
+        assert "device" in msg
+        # The original TypeError is chained for debugging, not swallowed.
+        assert isinstance(excinfo.value.__cause__, TypeError)


### PR DESCRIPTION
## Problem

`LerobotTrainer._build_reward_model_config` forwards the `extra['reward_model']` keys that `_reward_friendly_fields` introspects off the resolved config dataclass, then calls `make_reward_model_config(rtype, **reward_kwargs)`. When the installed lerobot's constructor and that field introspection diverge (an API drift), the constructor raises a raw `TypeError`. The trainer already guards this by translating it into a `ValueError` that names the rejected fields and chains the original error:

```python
try:
    reward_cfg = make_reward_model_config(rtype, **reward_kwargs)
except TypeError as e:
    raise ValueError(f"reward_model type '{rtype}' rejected field(s) {sorted(reward_kwargs)}: {e}") from e
```

That translation branch had no test coverage, so a refactor could silently drop it and start leaking bare, contextless `TypeError`s from the config-build path.

## Change

Add one focused regression test to `TestRewardModelConfigParity` that patches `make_reward_model_config` to raise `TypeError`, builds a reward-model config, and asserts the actionable contract:
- the `ValueError` names the reward type and the forwarded-field list (always includes the managed `device`), and
- the original `TypeError` is chained as `__cause__` (not swallowed).

Removing the `try/except` translation makes the test fail with a bare `TypeError`, so it genuinely guards the contract.

## Tests

Test-only change. `tests/training/test_reward_model_parity.py` passes (11 tests), and the full suite is green (`MUJOCO_GL=egl pytest tests/ -k "not Rendering"`: 9880 passed, 178 skipped). The previously-uncovered translation branch in `strands_robots/training/lerobot.py` is now exercised. ruff + mypy clean.