### PR TITLE
fix(cosmos3): decode msgpack arrays into writable, owning buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1085,6 +1085,22 @@ tolerated (no behavioural break); the normal `endpoint=`/`host=`/`port=` and
 smart-string (`create_policy("ws://...")`) paths stay silent. Mirrors the
 earlier no-silent-localhost-default fix for `cosmos3://` URLs.
 
+### Fixed: Cosmos 3 msgpack decode returned read-only, buffer-aliasing arrays
+
+The vendored NumPy msgpack codec the Cosmos 3 RoboLab client uses to unpack the
+server's action chunk (and any returned observation) reconstructed each array
+with `np.ndarray(buffer=<recv bytes>, ...)`. Because msgpack hands back an
+immutable `bytes` object, that array is **read-only** and does **not own its
+data** -- it aliases the transient wire buffer. Normalizing a decoded array in
+place (e.g. `image /= 255`) then raises `output array is read-only`, and handing
+it to `torch.from_numpy` (zero-copy) trips torch's "given NumPy array is not
+writable ... undefined behavior" hazard. The sibling VERA packer
+(`policies/vera/_msgpack_numpy.py`) already copies for exactly this reason, and
+the remote-inference protocol decodes into a writable `bytearray`; the Cosmos 3
+decode was the lone site left aliasing the recv buffer. It now copies to a
+writable, owning array, matching both -- round-trip dtype/shape/value fidelity
+is unchanged.
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/policies/cosmos3/_msgpack_numpy.py
+++ b/strands_robots/policies/cosmos3/_msgpack_numpy.py
@@ -46,7 +46,12 @@ def pack_array(obj):
 
 def unpack_array(obj):
     if b"__ndarray__" in obj:
-        return np.ndarray(buffer=obj[b"data"], dtype=np.dtype(obj[b"dtype"]), shape=obj[b"shape"])
+        # copy: a ``np.ndarray(buffer=...)`` view over the transient msgpack recv
+        # bytes is read-only and does not own its data, so normalizing it in place
+        # or handing it to ``torch.from_numpy`` (zero-copy) crashes or hits the
+        # "not writable -> undefined behavior" hazard. Copy to a writable, owning
+        # array - matching the sibling VERA packer and the inference protocol.
+        return np.frombuffer(obj[b"data"], dtype=np.dtype(obj[b"dtype"])).reshape(tuple(obj[b"shape"])).copy()
 
     if b"__npgeneric__" in obj:
         return np.dtype(obj[b"dtype"]).type(obj[b"data"])

--- a/tests/policies/cosmos3/test_msgpack_numpy_wire_format.py
+++ b/tests/policies/cosmos3/test_msgpack_numpy_wire_format.py
@@ -121,3 +121,28 @@ def test_codec_is_interoperable_with_plain_msgpack_for_scalars():
     # protocol for primitives the server may send without the ndarray envelope.
     blob = mnp.packb({"reward": np.float64(1.25)})
     assert msgpack.unpackb(blob, raw=False) == {"reward": 1.25}
+
+
+def test_decoded_array_is_writable_and_owns_its_data():
+    # A ``np.ndarray(buffer=...)`` view over the transient msgpack recv bytes is
+    # read-only and non-owning, so normalizing a decoded observation in place or
+    # handing a decoded action chunk to ``torch.from_numpy`` (zero-copy) crashes
+    # or hits torch's "not writable -> undefined behavior" hazard. The decode
+    # must yield a writable, owning array (parity with the VERA packer and the
+    # inference protocol). Fails before the copy fix.
+    action = np.arange(8 * 10, dtype=np.float32).reshape(8, 10)
+    out = mnp.unpackb(mnp.packb({"action": action}))["action"]
+    assert out.flags.writeable, "decoded array must be writable"
+    assert out.flags.owndata, "decoded array must own its data (not alias recv bytes)"
+
+
+def test_decoded_array_supports_in_place_mutation_without_aliasing():
+    # In-place ops (e.g. image /= 255) must succeed and must not be a view over
+    # the transient wire buffer, so mutating the decoded array cannot corrupt a
+    # subsequent decode of the same wire payload.
+    arr = np.ones((2, 3), dtype=np.float32)
+    blob = mnp.packb({"image": arr})
+    first = mnp.unpackb(blob)["image"]
+    first += 5.0  # read-only view would raise here
+    second = mnp.unpackb(blob)["image"]
+    assert np.array_equal(second, arr), "decoded arrays must be independent copies"


### PR DESCRIPTION
## Problem

The vendored NumPy msgpack codec the Cosmos 3 RoboLab client uses to unpack the server's response (`policies/cosmos3/_msgpack_numpy.py`) reconstructed each decoded array with:

```python
np.ndarray(buffer=obj[b"data"], dtype=..., shape=...)
```

`msgpack` hands back an immutable `bytes` object, so the resulting array is **read-only** and does **not own its data** — it aliases the transient wire buffer. The Cosmos 3 client decodes the action chunk (and any returned observation) through this codec, so a caller cannot safely mutate the result:

- normalizing a decoded observation in place (e.g. `image /= 255`) raises `ValueError: output array is read-only`;
- handing a decoded action chunk to `torch.from_numpy` (zero-copy) trips torch's *"given NumPy array is not writable … undefined behavior"* hazard;
- the array aliases the transient msgpack recv buffer rather than owning its memory.

## Why this is the right fix

The two sibling decode sites in the tree already avoid this:

- `policies/vera/_msgpack_numpy.py` decodes with `np.frombuffer(...).reshape(...).copy()`, commented *"copy: frombuffer is read-only over the transient recv bytes."*
- `inference/protocol.py` decodes into a writable `bytearray` (parity fix in #1152, *"decode observations into writable arrays"*).

The Cosmos 3 codec was the lone remaining site aliasing the recv buffer. This brings it to parity: copy to a writable, owning array. Round-trip dtype / shape / value fidelity is unchanged (verified for f16→f64, int, uint8, 0-d, non-contiguous, and `np.generic` scalar payloads).

## Change

`unpack_array` now returns `np.frombuffer(data, dtype).reshape(tuple(shape)).copy()` — matching the VERA packer exactly.

## Tests

Extended `tests/policies/cosmos3/test_msgpack_numpy_wire_format.py` with two regression tests that **fail before** the fix and pass after:

- `test_decoded_array_is_writable_and_owns_its_data` — pre-fix `writeable=False` / `owndata=False`.
- `test_decoded_array_supports_in_place_mutation_without_aliasing` — pre-fix `output array is read-only` on `+=`; also asserts a decoded array is an independent copy (mutating it cannot corrupt a re-decode of the same payload).

Gate: `ruff check` + `ruff format --check` + `mypy` clean on the changed module; full `tests/policies/cosmos3/` (152 passed, 1 skipped) and `tests/policies/vera/` (unchanged, 144 passed) green under `MUJOCO_GL=egl`.