### PR TITLE
test(sim): pin start_recording camera scoping by schema-safe name

### DIFF
--- a/tests/simulation/mujoco/test_recording_camera_scoping.py
+++ b/tests/simulation/mujoco/test_recording_camera_scoping.py
@@ -192,3 +192,67 @@ def test_recording_scoped_cameras_does_not_warn(sim_with_cameras, tmp_path, capl
     assert not any("observation.images.default" in m for m in warnings), (
         f"scoped recording must not warn about default, got: {warnings}"
     )
+
+
+@pytest.fixture
+def sim_with_namespaced_camera():
+    """A sim whose sensor camera carries a namespaced MuJoCo name (``arm0/wrist_cam``).
+
+    Robots that inject a namespace prefix produce camera names containing ``/``,
+    which LeRobot cannot use as a feature key (``/`` is reserved for nested
+    features), so ``start_recording`` collapses the separator to ``__`` for the
+    dataset schema. This fixture reproduces that shape so the raw name and the
+    schema-safe name genuinely differ.
+    """
+    from strands_robots.simulation import Simulation
+
+    tmpdir = tempfile.mkdtemp()
+    path = os.path.join(tmpdir, "test_arm.xml")
+    with open(path, "w") as f:
+        f.write(_ROBOT_XML)
+
+    s = Simulation()
+    s.create_world()
+    s.add_robot("arm", urdf_path=path)
+    s.add_camera(name="arm0/wrist_cam", position=[0.5, 0.0, 0.3], target=[0.0, 0.0, 0.1], width=64, height=64)
+    yield s
+    s.destroy()
+
+
+def test_cameras_selectable_by_schema_safe_name(sim_with_namespaced_camera, tmp_path):
+    """A namespaced camera can be scoped by its schema-safe (``__``) name.
+
+    ``start_recording`` documents that ``cameras=`` names may be given in either
+    the raw MuJoCo form (``arm0/wrist_cam``) or the collapsed schema-safe form
+    (``arm0__wrist_cam``). This pins the schema-safe alias path: requesting the
+    ``__`` form resolves to the same camera and produces the collapsed feature
+    key, and the raw name is what gets stashed for the frame filter.
+    """
+    sim = sim_with_namespaced_camera
+    res = sim.start_recording(
+        repo_id="local/scope_safe_name",
+        root=str(tmp_path / "safe"),
+        cameras=["arm0__wrist_cam"],
+        overwrite=True,
+    )
+    assert res["status"] == "success"
+    # The schema-safe key is what lands in the dataset; the stray implicit
+    # ``default`` overview camera is excluded.
+    assert _recorder_image_features(sim) == {"observation.images.arm0__wrist_cam"}
+    # The frame filter is keyed on the RAW MuJoCo name (what observations carry).
+    assert sim._world._backend_state["recording_cameras"] == {"arm0/wrist_cam"}
+
+
+def test_cameras_raw_and_schema_safe_names_are_equivalent(sim_with_namespaced_camera, tmp_path):
+    """Selecting a namespaced camera by raw or schema-safe name yields the same schema."""
+    sim = sim_with_namespaced_camera
+    res = sim.start_recording(
+        repo_id="local/scope_raw_name",
+        root=str(tmp_path / "raw"),
+        cameras=["arm0/wrist_cam"],
+        overwrite=True,
+    )
+    assert res["status"] == "success"
+    # Raw request collapses to the same schema-safe feature key as the ``__`` form.
+    assert _recorder_image_features(sim) == {"observation.images.arm0__wrist_cam"}
+    assert sim._world._backend_state["recording_cameras"] == {"arm0/wrist_cam"}


### PR DESCRIPTION
## Problem

`Simulation.start_recording(cameras=...)` documents that camera names may be given in **either** the raw MuJoCo form (`arm0/wrist_cam`) or the collapsed schema-safe form (`arm0__wrist_cam`):

```python
# Names may be given in either the raw MuJoCo form
# (``arm0/wrist_cam``) or the schema-safe form (``arm0__wrist_cam``);
# an unknown name fails loudly (no silent drop) listing what exists.
```

The schema-safe alias branch (`elif requested in safe_to_raw`) had no regression guard. Every existing camera-scoping test uses non-namespaced cameras (`cam_a`, `cam_b`) where the raw name and the schema-safe name are identical, so the `/` -> `__` resolution path was never exercised. A regression that dropped the alias branch would silently reject valid schema-safe names as unknown, and no test would catch it.

## Change

Add a fixture with a namespaced sensor camera (`arm0/wrist_cam`, matching what a robot with a namespace prefix injects) and two focused tests:

- `test_cameras_selectable_by_schema_safe_name` - scope by `arm0__wrist_cam` (schema-safe form) and assert the collapsed feature key `observation.images.arm0__wrist_cam` lands in the dataset schema, the stray implicit `default` overview camera is excluded, and the **raw** name `arm0/wrist_cam` is what gets stashed in `recording_cameras` for the frame filter.
- `test_cameras_raw_and_schema_safe_names_are_equivalent` - scope the same camera by its raw `arm0/wrist_cam` name and assert it yields the identical schema, pinning that both spellings are equivalent.

Test-only change; no library behavior is modified.

## Proof it guards the branch

Deleting the `elif requested in safe_to_raw` branch makes `test_cameras_selectable_by_schema_safe_name` fail - the schema-safe name is then treated as an unknown camera and `start_recording` returns `status == "error"` instead of `"success"`.

## Tests

```
MUJOCO_GL=egl pytest tests/simulation/mujoco/ -k "recording or scoping or camera"
209 passed, 1 skipped, 997 deselected
```

Ruff check + format clean; mypy clean on the changed file.