### PR TITLE
feat(sim): base_velocity velocity-tracking reward term for the predicate/reward DSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1101,6 +1101,27 @@ decode was the lone site left aliasing the recv buffer. It now copies to a
 writable, owning array, matching both -- round-trip dtype/shape/value fidelity
 is unchanged.
 
+### Added: base_velocity velocity-tracking reward term for the predicate/reward DSL
+
+The declarative predicate/reward DSL (`strands_robots.simulation.predicates`,
+consumed by `DeclarativeBenchmark` specs and RL `SimEnv` reward stacks) grew a
+`base_velocity(vx, vy, wz, weight=1.0, robot=None)` reward term -- the canonical
+dense locomotion reward, previously impossible to express because the DSL could
+only reference body positions, quaternions and scalar joint positions, never a
+floating base's velocity.
+
+It rewards a floating-base robot for matching a commanded BODY-frame velocity
+(`vx` forward, `vy` lateral in the robot's own heading, `wz` yaw rate) as
+`-weight * ||(v_body_x, v_body_y, w_body_z) - (vx, vy, wz)||`. It consumes the
+floating-base observation surfaced by `get_observation`: `base_lin_vel` (world
+frame) is rotated into the base frame via `base_quat`, and `base_ang_vel` is
+already body-frame, so the tracked velocity is heading-relative -- matching the
+IsaacLab / legged_gym locomotion-command convention rather than a fixed world
+axis. On a fixed-base arm (no floating base) the term degrades to `0.0` and logs
+the missing base once, consistent with the DSL's other name-resolution
+degradation. Works on both the MuJoCo and Newton backends (both surface the base
+twist with the same frame convention).
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/simulation/predicates.py
+++ b/strands_robots/simulation/predicates.py
@@ -43,6 +43,7 @@ Available reward terms (float):
 
     distance_neg(body_a, body_b, weight=1.0)
     joint_progress(joint, target, weight=1.0)
+    base_velocity(vx=0.0, vy=0.0, wz=0.0, weight=1.0, robot=None)
     constant(value)
 
 Register custom predicates with :func:`register_predicate`.
@@ -250,6 +251,72 @@ def _euclidean_distance(a: list[float], b: list[float]) -> float:
     dy = a[1] - b[1]
     dz = a[2] - b[2]
     return float((dx * dx + dy * dy + dz * dz) ** 0.5)
+
+
+def _quat_rotate_inverse_wxyz(quat_wxyz: list[float], vec: list[float]) -> list[float]:
+    """Express a WORLD-frame 3-vector in the body frame given a (w,x,y,z) quaternion.
+
+    Computes ``R(q)^T @ vec`` - the standard "rotate by the inverse". Pure Python
+    (no numpy) so predicates stay dependency-free. A near-zero-norm quaternion
+    returns ``vec`` unchanged. Matches the Newton backend's
+    ``_quat_rotate_inverse_wxyz`` used to body-frame the base angular velocity.
+    """
+    w, x, y, z = (float(c) for c in quat_wxyz)
+    norm = (w * w + x * x + y * y + z * z) ** 0.5
+    if norm < 1e-8:
+        return [float(v) for v in vec]
+    w, x, y, z = w / norm, x / norm, y / norm, z / norm
+    vx, vy, vz = (float(c) for c in vec)
+    two_w = 2.0 * w
+    s = 2.0 * w * w - 1.0
+    # b = cross(q_vec, v); term = v * s - b * 2w + q_vec * (q_vec . v) * 2
+    cx = y * vz - z * vy
+    cy = z * vx - x * vz
+    cz = x * vy - y * vx
+    d = 2.0 * (x * vx + y * vy + z * vz)
+    return [
+        vx * s - cx * two_w + x * d,
+        vy * s - cy * two_w + y * d,
+        vz * s - cz * two_w + z * d,
+    ]
+
+
+def _base_twist(sim: SimEngine, robot: str | None) -> tuple[float, float, float] | None:
+    """Return a floating base's BODY-frame planar twist ``(vx, vy, wz)``, or None.
+
+    Reads ``get_observation``'s floating-base signals: ``base_lin_vel`` (world
+    frame) is rotated into the base frame via ``base_quat`` so ``vx``/``vy`` are
+    the forward/lateral velocity in the robot's own heading; ``base_ang_vel`` is
+    already body-frame (the IMU-gyro convention on both backends) so its z
+    component is the yaw rate directly. This is the frame a locomotion velocity
+    command is expressed against (IsaacLab / legged_gym convention). Returns None
+    (and warns once) when the robot exposes no floating base - almost always a
+    spec referencing ``base_velocity`` on a fixed-base arm.
+    """
+    try:
+        obs = sim.get_observation(robot_name=robot, skip_images=True)
+    except Exception as e:  # noqa: BLE001 - defensive: predicates never raise
+        logger.debug("base_velocity get_observation(%r) failed: %s", robot, e)
+        return None
+    if not isinstance(obs, dict):
+        return None
+    lin = obs.get("base_lin_vel")
+    quat = obs.get("base_quat")
+    ang = obs.get("base_ang_vel")
+    if not (
+        isinstance(lin, list)
+        and len(lin) == 3
+        and isinstance(quat, list)
+        and len(quat) == 4
+        and isinstance(ang, list)
+        and len(ang) == 3
+    ):
+        # A floating base surfaces all three; their absence means this robot has
+        # no floating base (a fixed-base arm) - almost always a spec error.
+        _warn_unresolved("robot base", robot or "<sole robot>")
+        return None
+    v_body = _quat_rotate_inverse_wxyz(quat, lin)
+    return float(v_body[0]), float(v_body[1]), float(ang[2])
 
 
 # Predicate factories
@@ -657,6 +724,48 @@ def _constant(value: float) -> RewardTerm:
     return term
 
 
+def _base_velocity(
+    vx: float = 0.0,
+    vy: float = 0.0,
+    wz: float = 0.0,
+    weight: float = 1.0,
+    robot: str | None = None,
+) -> RewardTerm:
+    """Negative base velocity-tracking error - the canonical locomotion reward.
+
+    Rewards a floating-base robot for matching a commanded BODY-frame velocity
+    ``(vx, vy, wz)``: ``vx`` forward, ``vy`` lateral (both in the robot's own
+    heading, m/s) and ``wz`` the yaw rate (rad/s). The reward is
+    ``-weight * ||(v_body_x, v_body_y, w_body_z) - (vx, vy, wz)||`` so it is 0 at
+    perfect tracking and grows more negative with error - a dense, monotonic
+    signal for a velocity-tracking / locomotion task (G1, Go2, T1, mobile bases),
+    directly composable in a :class:`DeclarativeBenchmark` spec or an RL
+    ``SimEnv`` reward.
+
+    Reads the floating-base twist from ``get_observation``: ``base_lin_vel``
+    (world frame) is rotated into the base frame via ``base_quat``, and
+    ``base_ang_vel`` is already body-frame, so the tracked quantity is
+    heading-relative (walking "forward at vx" tracks the robot's own +x, not a
+    fixed world axis). Requires a robot with a floating base; a fixed-base arm
+    has no base twist, so the term degrades to ``0.0`` and the missing base is
+    logged once. ``robot`` selects the robot in a multi-robot scene (default:
+    the sole robot).
+    """
+    w = float(weight)
+    tvx, tvy, twz = float(vx), float(vy), float(wz)
+    rname = robot
+
+    def term(sim: SimEngine) -> float:
+        twist = _base_twist(sim, rname)
+        if twist is None:
+            return 0.0
+        bvx, bvy, bwz = twist
+        dvx, dvy, dwz = bvx - tvx, bvy - tvy, bwz - twz
+        return -w * float((dvx * dvx + dvy * dvy + dwz * dwz) ** 0.5)
+
+    return term
+
+
 # Stateful reward terms (declarative phase machine)
 #
 # A plain RewardTerm is stateless: ``(SimEngine) -> float``. Some rewards need
@@ -831,6 +940,7 @@ PREDICATE_REGISTRY: dict[str, PredicateFactory] = {
     # float-valued
     "distance_neg": _distance_neg,
     "joint_progress": _joint_progress,
+    "base_velocity": _base_velocity,
     "constant": _constant,
     # stateful (phase machine)
     "staged_reward": _staged_reward,

--- a/tests/simulation/test_base_velocity_reward.py
+++ b/tests/simulation/test_base_velocity_reward.py
@@ -1,0 +1,168 @@
+"""Regression tests for the ``base_velocity`` velocity-tracking reward term.
+
+The predicate/reward DSL grew a ``base_velocity`` reward term: a floating base's
+BODY-frame planar twist ``(vx, vy, wz)`` tracked against a commanded velocity,
+the canonical dense locomotion reward. It consumes ``get_observation``'s
+floating-base signals - ``base_lin_vel`` (world frame, rotated into the base
+frame via ``base_quat``) and ``base_ang_vel`` (already body-frame) - so the
+tracked velocity is heading-relative, matching the IsaacLab / legged_gym
+locomotion-command convention.
+
+These tests set a KNOWN base pose + twist directly on the sim (a rotated base
+with a known world-frame linear velocity), then assert the term computes the
+correct body-frame tracking error - and that the world->body rotation actually
+fires (the same world velocity yields a different body-frame reward under a
+different base orientation). They are GL-free (get_observation with
+skip_images) so they run in CI without a display.
+"""
+
+import math
+import os
+import tempfile
+
+import mujoco
+import pytest
+
+from strands_robots.simulation.mujoco.simulation import Simulation
+from strands_robots.simulation.predicates import (
+    _quat_rotate_inverse_wxyz,
+    make_predicate,
+)
+
+# Floating base with a NAMED free joint (a humanoid's floating_base_joint) plus
+# one actuated hinge. get_observation surfaces base_pos/base_quat/base_lin_vel/
+# base_ang_vel for this robot.
+NAMED_BASE_XML = """
+<mujoco model="test_named_base">
+  <compiler angle="radian" autolimits="true"/>
+  <option timestep="0.002"/>
+  <worldbody>
+    <light name="main" pos="0 0 3" dir="0 0 -1"/>
+    <geom name="ground" type="plane" size="5 5 0.01" rgba="0.9 0.9 0.9 1"/>
+    <body name="pelvis" pos="0 0 0.8">
+      <freejoint name="floating_base_joint"/>
+      <geom type="box" size="0.1 0.1 0.1" rgba="0.3 0.3 0.8 1"/>
+      <body name="thigh" pos="0 0 -0.1">
+        <geom type="capsule" size="0.03" fromto="0 0 0 0 0 -0.3" rgba="0.8 0.3 0.3 1"/>
+        <joint name="hip" type="hinge" axis="0 1 0" range="-1.5 1.5"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <motor name="hip_act" joint="hip"/>
+  </actuator>
+</mujoco>
+"""
+
+# Fixed-base arm: no free joint anywhere -> no base twist. base_velocity must
+# degrade to 0.0 (and warn) rather than crash or invent a value.
+FIXED_ARM_XML = """
+<mujoco model="test_fixed">
+  <compiler angle="radian" autolimits="true"/>
+  <worldbody>
+    <light name="main" pos="0 0 3" dir="0 0 -1"/>
+    <body name="link" pos="0 0 0.1">
+      <geom type="capsule" size="0.02" fromto="0 0 0 0 0 0.2"/>
+      <joint name="j0" type="hinge" axis="0 0 1"/>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="j0_act" joint="j0" kp="10"/>
+  </actuator>
+</mujoco>
+"""
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="test_base_velocity", mesh=False)
+    s.create_world(ground_plane=False)
+    yield s
+    s.cleanup()
+
+
+def _write(xml: str) -> str:
+    d = tempfile.mkdtemp()
+    p = os.path.join(d, "model.xml")
+    with open(p, "w") as f:
+        f.write(xml)
+    return p
+
+
+def _set_free_joint(sim, qpos7, qvel6):
+    """Set the robot's (only) free joint pose + twist and forward the model."""
+    model, data = sim._world._model, sim._world._data
+    jid = -1
+    for j in range(model.njnt):
+        if model.jnt_type[j] == mujoco.mjtJoint.mjJNT_FREE:
+            jid = j
+            break
+    assert jid >= 0
+    qadr = int(model.jnt_qposadr[jid])
+    vadr = int(model.jnt_dofadr[jid])
+    data.qpos[qadr : qadr + 7] = qpos7
+    data.qvel[vadr : vadr + 6] = qvel6
+    mujoco.mj_forward(model, data)
+
+
+# 90 deg about world +z. Body +x points along world +y.
+_Q_YAW90 = [math.sqrt(0.5), 0.0, 0.0, math.sqrt(0.5)]
+_LIN_WORLD = [1.1, 2.2, 3.3]  # base linear velocity in the WORLD frame
+_ANG = [4.4, 5.5, 6.6]  # base angular velocity (body frame); yaw rate = z = 6.6
+# World->body rotation of _LIN_WORLD under _Q_YAW90 is [2.2, -1.1, 3.3], so the
+# body-frame planar twist the reward tracks is (vx=2.2, vy=-1.1, wz=6.6).
+_BODY_VX, _BODY_VY, _BODY_WZ = 2.2, -1.1, 6.6
+
+
+def test_quat_rotate_inverse_matches_hand_computation():
+    """The pure-Python world->body rotation is correct for a 90-deg-about-z base."""
+    out = _quat_rotate_inverse_wxyz(_Q_YAW90, _LIN_WORLD)
+    assert out == pytest.approx([2.2, -1.1, 3.3], abs=1e-6)
+    # Identity quaternion is a no-op.
+    assert _quat_rotate_inverse_wxyz([1.0, 0.0, 0.0, 0.0], _LIN_WORLD) == pytest.approx(_LIN_WORLD, abs=1e-9)
+
+
+def test_base_velocity_is_zero_at_perfect_body_frame_tracking(sim):
+    """Reward is 0 when the command equals the base's body-frame twist."""
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    _set_free_joint(sim, [0.0, 0.0, 0.8, *_Q_YAW90], [*_LIN_WORLD, *_ANG])
+    term = make_predicate("base_velocity", vx=_BODY_VX, vy=_BODY_VY, wz=_BODY_WZ)
+    assert term(sim) == pytest.approx(0.0, abs=1e-6)
+
+
+def test_base_velocity_is_negative_l2_error(sim):
+    """Reward is -weight * L2(body-frame twist - command) when they differ."""
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    _set_free_joint(sim, [0.0, 0.0, 0.8, *_Q_YAW90], [*_LIN_WORLD, *_ANG])
+    # Command (0,0,0): error is the full body-frame twist magnitude.
+    expected = -((_BODY_VX**2 + _BODY_VY**2 + _BODY_WZ**2) ** 0.5)
+    assert make_predicate("base_velocity")(sim) == pytest.approx(expected, abs=1e-5)
+    # weight scales the error linearly.
+    assert make_predicate("base_velocity", weight=2.0)(sim) == pytest.approx(2.0 * expected, abs=1e-5)
+
+
+def test_base_velocity_tracks_the_body_frame_not_the_world_frame(sim):
+    """The world->body rotation actually fires: the SAME world velocity yields a
+    zero reward for a DIFFERENT command depending on the base orientation."""
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    # Identity orientation: body frame == world frame, so command == world lin.
+    _set_free_joint(sim, [0.0, 0.0, 0.8, 1.0, 0.0, 0.0, 0.0], [*_LIN_WORLD, *_ANG])
+    term_world = make_predicate("base_velocity", vx=1.1, vy=2.2, wz=6.6)
+    assert term_world(sim) == pytest.approx(0.0, abs=1e-6)
+    # Same world velocity, rotated base: the world-frame command is NO LONGER a
+    # perfect match (proves the reward is heading-relative, not world-frame).
+    _set_free_joint(sim, [0.0, 0.0, 0.8, *_Q_YAW90], [*_LIN_WORLD, *_ANG])
+    assert term_world(sim) < -1.0
+    # The body-frame command IS a perfect match under the rotated base.
+    assert make_predicate("base_velocity", vx=_BODY_VX, vy=_BODY_VY, wz=_BODY_WZ)(sim) == pytest.approx(0.0, abs=1e-6)
+
+
+def test_base_velocity_degrades_to_zero_on_fixed_base_arm(sim, caplog):
+    """A fixed-base arm has no base twist: the term degrades to 0.0 and warns."""
+    import logging
+
+    sim.add_robot("arm", urdf_path=_write(FIXED_ARM_XML))
+    with caplog.at_level(logging.WARNING, logger="strands_robots.simulation.predicates"):
+        val = make_predicate("base_velocity", vx=0.5)(sim)
+    assert val == 0.0
+    assert any("robot base" in r.message or "base" in r.message.lower() for r in caplog.records)


### PR DESCRIPTION
## Problem

The declarative predicate/reward DSL (`strands_robots.simulation.predicates`, consumed by `DeclarativeBenchmark` specs and RL `SimEnv` reward stacks) can reference body positions, quaternions and scalar joint positions, but never a floating base's velocity. So the single most common locomotion reward -- track a commanded base velocity -- could not be expressed as a spec/RL reward term, even though `get_observation` now surfaces the full floating-base twist (`base_pos`/`base_quat`/`base_lin_vel`/`base_ang_vel`) on both backends.

## Change

Adds a `base_velocity(vx, vy, wz, weight=1.0, robot=None)` reward term:

```
reward = -weight * ||(v_body_x, v_body_y, w_body_z) - (vx, vy, wz)||
```

It rewards a floating-base robot for matching a commanded **body-frame** velocity (`vx` forward, `vy` lateral in the robot's own heading, `wz` yaw rate) -- 0 at perfect tracking, growing more negative with error (dense, monotonic).

The frame handling is the substance: `get_observation` reports `base_lin_vel` in the **world** frame and `base_ang_vel` in the **body** frame (the IMU-gyro convention, consistent across the MuJoCo and Newton backends). The term rotates `base_lin_vel` into the base frame via `base_quat` and uses `base_ang_vel.z` directly, so the tracked velocity is heading-relative -- walking "forward at `vx`" tracks the robot's own +x, not a fixed world axis. This matches the IsaacLab / legged_gym velocity-command convention and is exactly why both `base_quat` and `base_lin_vel` are surfaced together.

On a fixed-base arm (no floating base) the term degrades to `0.0` and logs the missing base once, consistent with the DSL's existing name-resolution degradation for unresolvable bodies/joints. Backend-agnostic: it only reads `get_observation`, which surfaces the base twist with the same frame convention on MuJoCo and Newton.

Implementation notes:
- Pure-Python quaternion rotate-inverse helper (no numpy, matching the module's dependency-free convention; mirrors the Newton backend's `_quat_rotate_inverse_wxyz`).
- Registered as a float-valued term alongside `distance_neg` / `joint_progress` / `constant`, and documented in the module's reward-term list.

## Tests

`tests/simulation/test_base_velocity_reward.py` drives a **real** floating-base sim (inline-MJCF humanoid with a named free joint, no mock): it sets a known base pose + world-frame twist directly on the model, then asserts the term computes the correct body-frame tracking error. Coverage:
- zero reward at perfect body-frame tracking;
- `-weight * L2` error when command and twist differ (+ weight scaling);
- the world->body rotation actually fires -- the same world velocity yields a zero reward for a *different* command depending on base orientation (heading-relative, not world-frame);
- fixed-base arm degrades to `0.0` and warns;
- a unit check of the pure-Python quaternion helper against a hand-computed 90-deg-about-z rotation.

The suite fails before the change (the term/helper do not exist) and passes after. Gate: `ruff check`, `ruff format --check`, `mypy` clean on the changed module; 219 predicate/DSL/benchmark/eval tests pass under `MUJOCO_GL=egl`.
