### PR TITLE
docs(policies): list all 11 providers in overview + regression test guard

### DIFF
--- a/docs/policies/overview.md
+++ b/docs/policies/overview.md
@@ -1,32 +1,49 @@
 ---
-description: The Policy ABC and the providers that ship - MockPolicy, Gr00tPolicy, LerobotLocalPolicy, Cosmos3Policy, CuroboPolicy, MoveIt2Policy.
+description: The Policy ABC and every provider that ships - mock, groot, lerobot_local, cosmos3, vera, remote, curobo, moveit2, wbc, wbc_gait, motionbricks.
 ---
 
 # Policy providers
 
+`strands_robots` ships several policy providers. The registry is the ground
+truth - list every provider that `create_policy("<name>")` accepts with:
+
+```bash
+python -c 'from strands_robots.policies import list_providers; print(list_providers())'
+# ['cosmos3', 'curobo', 'groot', 'lerobot_local', 'mock', 'motionbricks', 'moveit2', 'remote', 'vera', 'wbc', 'wbc_gait']
+```
+
 ```python
 from strands_robots.policies import create_policy, list_policy_types, list_providers
 
-print(list_providers())   # sorted: ['cosmos3', 'curobo', 'groot', 'lerobot_local', 'mock', 'motionbricks', 'moveit2', 'remote', 'vera', 'wbc', 'wbc_gait']
+print(list_providers())     # sorted provider names (registry ground truth)
 print(list_policy_types())  # lerobot_local policy_type strings: ['act', 'diffusion', 'smolvla', ...]
 
 policy = create_policy("mock")                                                     # always works, no model
 policy = create_policy("groot", port=5555, data_config="so100_dualcam")
 policy = create_policy("lerobot_local", pretrained_name_or_path="lerobot/pi0_so100")
 policy = create_policy("cosmos3", embodiment="droid", port=8000)
+policy = create_policy("remote", endpoint="ws://gpu-box:8765")
 ```
 
 ## Providers
 
+Every row below is a registered provider (`create_policy("<name>")`). The table
+is kept in sync with `list_providers()` by a regression test
+(`tests/test_docs_policy_coverage.py`), so it can never silently drift.
+
 | Provider | Class | Install extra | When to use |
 |----------|-------|---------------|-------------|
-| `mock` | `MockPolicy` | _(core)_ | Tests, smoke checks; sinusoidal joints, no GPU |
-| `groot` | `Gr00tPolicy` | `groot-service` | NVIDIA GR00T N1.5/N1.6/N1.7 over ZMQ |
-| `lerobot_local` | `LerobotLocalPolicy` | `lerobot` | HF LeRobot in-process (ACT, Pi0, SmolVLA, …) |
-| `cosmos3` | `Cosmos3Policy` | `cosmos3-service` | NVIDIA Cosmos 3 VLA over WebSocket |
-| `vera` | `VeraPolicy` | `vera` | MIT VERA video-to-action (DFoT/WAN planner + Jacobian IDM) over a containerized GPU server |
-| `curobo` | `CuroboPolicy` | `curobo` | NVIDIA cuRobo collision-aware planning, in-process CUDA |
-| `moveit2` | `MoveIt2Policy` | `moveit2` | MoveIt2 motion planning over a ROS 2 sidecar (ZMQ), no in-venv ROS 2 deps |
+| [`mock`](custom-policies.md) | `MockPolicy` | _(core)_ | Tests, smoke checks; sinusoidal joints, no GPU. Reference minimal `Policy` (documented inline + custom-policies) |
+| [`groot`](groot.md) | `Gr00tPolicy` | `groot-service` | NVIDIA GR00T N1.5/N1.6/N1.7 over ZMQ |
+| [`lerobot_local`](lerobot-local.md) | `LerobotLocalPolicy` | `lerobot` | HF LeRobot in-process (ACT, Pi0, SmolVLA, MolmoAct2, ...) |
+| [`cosmos3`](cosmos3.md) | `Cosmos3Policy` | `cosmos3-service` | NVIDIA Cosmos 3 omnimodal VLA over WebSocket |
+| [`vera`](vera.md) | `VeraPolicy` | `vera` | MIT VERA video-to-action (DFoT/WAN planner + Jacobian IDM) over a containerized GPU server |
+| [`remote`](remote.md) | `RemotePolicy` | `inference` | Offload a large policy to a GPU box: forward observations to a remote `PolicyServer` over WebSocket, get back action chunks. Edge-device inference |
+| [`curobo`](curobo.md) | `CuroboPolicy` | `curobo` | NVIDIA cuRobo collision-aware motion planning, in-process CUDA (non-VLA) |
+| [`moveit2`](moveit2.md) | `MoveIt2Policy` | `moveit2` | MoveIt2 motion planning over a ROS 2 sidecar (ZMQ), no in-venv ROS 2 deps (non-VLA) |
+| [`wbc`](wbc.md) | `WBCPolicy` | `wbc` | NVIDIA GR00T Whole-Body-Control (SONIC) Unitree G1 humanoid locomotion, in-process ONNX, no GPU (non-VLA) |
+| [`wbc_gait`](wbc_gait.md) | `WBCGaitPolicy` | `wbc` | WBC gait-clock variant: single ONNX policy, 95-dim obs + bipedal phase clock (non-VLA) |
+| [`motionbricks`](motionbricks.md) | `MotionBricksPolicy` | `motionbricks` | Generative kinematic Unitree G1 motion (style-driven: walk/stealth_walk/...), in-process torch (non-VLA) |
 
 ## Policy ABC
 
@@ -79,8 +96,14 @@ sim.run_policy(robot_name="so100", instruction="pick up the cube",
 
 - [GR00T](groot.md) - ZMQ server, 27 embodiments, container lifecycle.
 - [LeRobot Local](lerobot-local.md) - in-process HF models, RTC.
+- [MolmoAct2 (SO-100/101)](molmoact2.md) - action/observation contract for the SO-arm checkpoints.
 - [Persistent worker](persistent-worker.md) - load once, reuse across rollouts; cache controls + telemetry.
 - [Cosmos 3](cosmos3.md) - NVIDIA Cosmos 3 omnimodal VLA.
+- [VERA](vera.md) - MIT video-to-action planner + Jacobian IDM over a GPU server.
+- [Remote](remote.md) - forward observations to a remote `PolicyServer` over WebSocket (edge offload).
 - [cuRobo](curobo.md) - in-process collision-aware motion planning (non-VLA, GPU).
 - [MoveIt2](moveit2.md) - ROS 2 sidecar collision-aware planning (non-VLA, no in-venv ROS 2).
+- [WBC](wbc.md) - GR00T Whole-Body-Control (SONIC) G1 locomotion (non-VLA, in-process ONNX).
+- [WBC gait-clock variant](wbc_gait.md) - single-ONNX gait-clock G1 controller (non-VLA).
+- [MotionBricks](motionbricks.md) - generative kinematic G1 motion (non-VLA, in-process torch).
 - [Custom policies](custom-policies.md) - implement the ABC.

--- a/tests/test_docs_policy_coverage.py
+++ b/tests/test_docs_policy_coverage.py
@@ -5,8 +5,17 @@
 ``create_policy("<name>")`` accepts. If a provider is added to
 ``strands_robots/registry/policies.json`` but not to the table (or vice versa),
 the docs silently drift and users - and agent LLMs reading the docs - never
-discover the provider. This guard ties the table to ``list_providers()`` so the
+discover the provider. This guard ties the table to the JSON registry so the
 two can never disagree.
+
+The registry is read directly from ``policies.json`` (not via
+``list_providers()``) because ``list_providers()`` also returns providers
+registered at runtime via ``register_policy()``. Other tests in the suite
+register throwaway providers into that process-global runtime registry and do
+not always tear them down, so ``list_providers()`` is order-dependent under a
+full ``pytest`` run. The JSON file is the canonical, stable catalogue the
+overview table documents. This mirrors ``_registered_providers()`` in the
+companion guard.
 
 Companion guard: ``tests/test_docs_policy_nav_coverage.py`` ties the registry to
 the mkdocs nav (one page per provider). This file ties it to the overview table.
@@ -14,13 +23,23 @@ the mkdocs nav (one page per provider). This file ties it to the overview table.
 
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
 
-from strands_robots.policies import list_providers
-
 REPO_ROOT = Path(__file__).resolve().parent.parent
 OVERVIEW_MD = REPO_ROOT / "docs" / "policies" / "overview.md"
+POLICIES_JSON = REPO_ROOT / "strands_robots" / "registry" / "policies.json"
+
+
+def _registered_providers() -> set[str]:
+    """Return the canonical provider names from the JSON registry.
+
+    Reads ``policies.json`` directly so the set is stable regardless of what
+    other tests register into the runtime registry during a full suite run.
+    """
+    data = json.loads(POLICIES_JSON.read_text(encoding="utf-8"))
+    return set(data["providers"].keys())
 
 
 def _table_providers() -> set[str]:
@@ -56,16 +75,16 @@ def _table_providers() -> set[str]:
 
 
 def test_overview_table_matches_registered_providers() -> None:
-    """The Providers table lists exactly the providers ``list_providers()`` returns."""
+    """The Providers table lists exactly the providers in the JSON registry."""
     documented = _table_providers()
-    registered = set(list_providers())
+    registered = _registered_providers()
 
     missing_from_docs = sorted(registered - documented)
     stale_in_docs = sorted(documented - registered)
 
     assert not missing_from_docs and not stale_in_docs, (
         "docs/policies/overview.md Providers table is out of sync with "
-        "list_providers().\n"
+        "strands_robots/registry/policies.json.\n"
         f"  Registered but missing from the table: {missing_from_docs}\n"
         f"  In the table but not registered:       {stale_in_docs}\n"
         "Update the table (name, class, install extra, when-to-use) so it "

--- a/tests/test_docs_policy_coverage.py
+++ b/tests/test_docs_policy_coverage.py
@@ -1,0 +1,82 @@
+"""Repo hygiene: the policy overview table lists exactly the registered providers.
+
+``docs/policies/overview.md`` is the entry point for choosing a
+``policy_provider``. Its "Providers" table is the human-facing catalogue of what
+``create_policy("<name>")`` accepts. If a provider is added to
+``strands_robots/registry/policies.json`` but not to the table (or vice versa),
+the docs silently drift and users - and agent LLMs reading the docs - never
+discover the provider. This guard ties the table to ``list_providers()`` so the
+two can never disagree.
+
+Companion guard: ``tests/test_docs_policy_nav_coverage.py`` ties the registry to
+the mkdocs nav (one page per provider). This file ties it to the overview table.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from strands_robots.policies import list_providers
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+OVERVIEW_MD = REPO_ROOT / "docs" / "policies" / "overview.md"
+
+
+def _table_providers() -> set[str]:
+    """Extract provider names from the Providers table in overview.md.
+
+    Scoped to the ``## Providers`` section so unrelated tables elsewhere on the
+    page cannot leak in. Provider names are the backtick-wrapped token in the
+    first column (they may be wrapped in a markdown link, e.g. ``[`mock`](...)``).
+    """
+    text = OVERVIEW_MD.read_text(encoding="utf-8")
+
+    # Isolate the "## Providers" section (up to the next top-level "## ").
+    match = re.search(r"\n## Providers\b(.*?)(?:\n## |\Z)", text, re.DOTALL)
+    assert match, "overview.md is missing a '## Providers' section"
+    section = match.group(1)
+
+    providers: set[str] = set()
+    for line in section.splitlines():
+        line = line.strip()
+        if not line.startswith("|"):
+            continue
+        cells = [c.strip() for c in line.strip("|").split("|")]
+        if len(cells) < 2:
+            continue
+        first = cells[0]
+        # Skip the header and the |---| separator rows.
+        if first in {"Provider", ""} or set(first) <= {"-", ":"}:
+            continue
+        name = re.search(r"`([a-z0-9_]+)`", first)
+        if name:
+            providers.add(name.group(1))
+    return providers
+
+
+def test_overview_table_matches_registered_providers() -> None:
+    """The Providers table lists exactly the providers ``list_providers()`` returns."""
+    documented = _table_providers()
+    registered = set(list_providers())
+
+    missing_from_docs = sorted(registered - documented)
+    stale_in_docs = sorted(documented - registered)
+
+    assert not missing_from_docs and not stale_in_docs, (
+        "docs/policies/overview.md Providers table is out of sync with "
+        "list_providers().\n"
+        f"  Registered but missing from the table: {missing_from_docs}\n"
+        f"  In the table but not registered:       {stale_in_docs}\n"
+        "Update the table (name, class, install extra, when-to-use) so it "
+        "matches the registry."
+    )
+
+
+def test_overview_has_discovery_snippet() -> None:
+    """Overview keeps a runnable ``list_providers()`` snippet for ground-truthing."""
+    text = OVERVIEW_MD.read_text(encoding="utf-8")
+    assert "list_providers" in text, (
+        "overview.md must show a runnable list_providers() snippet so users can "
+        "always ground-truth the available providers against the registry."
+    )


### PR DESCRIPTION
## Problem

`docs/policies/overview.md` is the entry point for choosing a `policy_provider`, but its Providers table listed only **7** of the **11** providers that `list_providers()` actually returns. The four missing ones are fully implemented and already have dedicated docs pages:

- `remote` (`RemotePolicy`) - the edge-inference answer (offload to a GPU box over WebSocket), and it was undiscoverable from the overview
- `motionbricks` (`MotionBricksPolicy`)
- `wbc` (`WBCPolicy`)
- `wbc_gait` (`WBCGaitPolicy`)

A developer (or an agent LLM) browsing the overview to pick a provider would only ever see 7 of the 11 shipping options.

```
$ python -c 'from strands_robots.policies import list_providers; print(list_providers())'
['cosmos3', 'curobo', 'groot', 'lerobot_local', 'mock', 'motionbricks', 'moveit2', 'remote', 'vera', 'wbc', 'wbc_gait']
```

## Change

- **Complete the Providers table**: add the four missing rows with class name, install extra, and a one-line when-to-use. Every provider name now links to its dedicated docs page. Install extras verified against `pyproject.toml` optional-dependencies (`remote` -> `inference`, `wbc`/`wbc_gait` -> `wbc`, `motionbricks` -> `motionbricks`).
- **Discovery snippet**: add a runnable `python -c '...list_providers()...'` one-liner near the top so users can always ground-truth the catalogue against the registry.
- **See also**: link the previously-unlinked pages (`vera`, `remote`, `wbc`, `wbc_gait`, `motionbricks`, `molmoact2`).
- **Regression guard** `tests/test_docs_policy_coverage.py`: parses the Providers table (scoped to the `## Providers` section) and asserts set equality with the JSON registry. A provider added to the registry but not the table - or vice versa - now fails CI. Complements the existing `test_docs_policy_nav_coverage.py`, which ties the registry to the mkdocs nav.

`mock` remains documented inline (linked to `custom-policies.md` as the reference minimal `Policy`), matching the existing nav-coverage convention that exempts it from a standalone page.

## Tests

The new test **fails on the pre-fix table** (flags exactly the four missing providers) and **passes after**:

```
Registered but missing from the table: ['motionbricks', 'remote', 'wbc', 'wbc_gait']
```

Local gate green: `ruff check`, `ruff format --check`, `mypy` clean on the new test; full docs test suite passes.

Docs-only change plus a hygiene test - no runtime behavior changes, so no rollout artifact applies.

---

## Round 2 changelog

**CI fix (`call-test-lint`): registry-pollution flake in the new guard.**

The guard failed only in the full-suite CI run, not in isolation. Root cause: it compared the table against `list_providers()`, which merges the JSON registry with a **process-global runtime registry**. Other suite tests (`tests/policies/test_factory.py`, `tests/simulation/test_multi_episode_policy_reuse.py`) call `register_policy()` with throwaway names (`ct`, `custom_test`, `kwarg_test`, `counting_reuse`, `runtime_only_provider`, `safe_custom`, ...) and do not tear them down, so `list_providers()` is order-dependent under `pytest` and leaked those names into the "registered" set - which can never appear in the docs table.

**Fix:** read `strands_robots/registry/policies.json` directly for the canonical, stable provider set, mirroring `_registered_providers()` in the companion `test_docs_policy_nav_coverage.py`. The overview table documents the built-in registry, so the JSON is also the correct semantic source of truth. Verified order-independent by running the polluting tests in the same process ahead of this guard: green.