### PR TITLE
fix(registry): remove phantom lerobot_async/dreamgen provider references

### DIFF
--- a/strands_robots/registry/policies.py
+++ b/strands_robots/registry/policies.py
@@ -57,7 +57,7 @@ def resolve_policy(policy: str, **extra_kwargs) -> tuple[str, dict[str, Any]]:
 
     Resolution order:
         1. URL patterns (ws://, zmq://, grpc://, host:port)
-        2. Shorthand names (mock, groot, dreamgen, ...)
+        2. Shorthand names (mock, groot, lerobot_local, ...)
         3. HuggingFace model IDs (org/model)
         4. Registered provider name
         5. Fallback to lerobot_local
@@ -73,8 +73,8 @@ def resolve_policy(policy: str, **extra_kwargs) -> tuple[str, dict[str, Any]]:
         resolve_policy("lerobot/act_aloha_sim")
         # → ("lerobot_local", {"pretrained_name_or_path": "lerobot/act_aloha_sim"})
 
-        resolve_policy("localhost:8080")
-        # → ("lerobot_async", {"server_address": "localhost:8080"})
+        resolve_policy("zmq://localhost:5555")
+        # → ("groot", {"host": "localhost", "port": 5555})
 
         resolve_policy("mock")
         # → ("mock", {})
@@ -228,10 +228,10 @@ def build_policy_kwargs(
 
     Args:
         provider: Policy provider name.
-        policy_port: Port number (groot, lerobot_async).
+        policy_port: Port number (groot, cosmos3, moveit2, remote).
         policy_host: Hostname (default: "localhost").
         model_path: Local model path or HF ID.
-        server_address: Full gRPC address (lerobot_async).
+        server_address: Full server address host:port (grpc:// URLs, remote providers).
         policy_type: Sub-type (pi0, act, smolvla, ...).
         data_config: Data configuration for groot.
         **extra: Any additional provider-specific kwargs.

--- a/strands_robots/simulation/mujoco/tool_spec.json
+++ b/strands_robots/simulation/mujoco/tool_spec.json
@@ -190,7 +190,7 @@
     },
     "policy_provider": {
       "type": "string",
-      "description": "Policy provider name (e.g. groot, lerobot_async, lerobot_local, dreamgen, mock)"
+      "description": "Policy provider name (e.g. groot, lerobot_local, cosmos3, mock). See list_providers()."
     },
     "instruction": {
       "type": "string"

--- a/tests/registry/test_advertised_providers_are_registered.py
+++ b/tests/registry/test_advertised_providers_are_registered.py
@@ -1,0 +1,78 @@
+"""Guard against phantom policy providers advertised to agents and users.
+
+The MuJoCo ``run_policy`` tool spec (``tool_spec.json``) and the
+``strands_robots.registry.policies`` docstrings enumerate example policy
+provider names to guide LLM agents and library callers. If any advertised
+name is not actually registered, the caller gets an ``Unknown policy
+provider`` error late in a rollout (after world init / camera setup) or is
+silently redirected to the ``lerobot_local`` fallback -- a wasteful, confusing
+failure mode.
+
+These tests pin the invariant that every provider name advertised in the tool
+spec and in the resolver docstrings resolves to a registered provider, so
+documentation cannot drift ahead of the implementation again.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from strands_robots.registry.policies import list_policy_providers, resolve_policy
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL_SPEC = ROOT / "strands_robots" / "simulation" / "mujoco" / "tool_spec.json"
+
+
+def _registered() -> set[str]:
+    return set(list_policy_providers())
+
+
+def _eg_names(text: str) -> list[str]:
+    """Extract provider tokens from an ``e.g. a, b, c`` clause in ``text``."""
+    match = re.search(r"e\.g\.\s*([^).]*)", text)
+    if not match:
+        return []
+    return [tok.strip() for tok in re.split(r"[,/]", match.group(1)) if tok.strip()]
+
+
+def _tool_spec_provider_examples() -> list[str]:
+    spec = json.loads(TOOL_SPEC.read_text())
+    desc = spec["properties"]["policy_provider"]["description"]
+    return _eg_names(desc)
+
+
+def test_tool_spec_advertises_provider_examples() -> None:
+    """The tool spec description must list concrete example providers."""
+    assert _tool_spec_provider_examples(), "no 'e.g. ...' provider examples found in tool_spec description"
+
+
+def test_tool_spec_provider_examples_are_registered() -> None:
+    """Every provider named in the MuJoCo tool spec must be registered."""
+    registered = _registered()
+    unknown = [name for name in _tool_spec_provider_examples() if name not in registered]
+    assert not unknown, f"tool_spec advertises unregistered providers {unknown}; registered={sorted(registered)}"
+
+
+def test_tool_spec_provider_examples_resolve_to_themselves() -> None:
+    """Advertised names must resolve to their own provider, not the fallback.
+
+    ``resolve_policy`` redirects any unrecognised string to ``lerobot_local``.
+    A phantom name (e.g. ``lerobot_async``) therefore "resolves" but to the
+    wrong provider, silently misdirecting the caller. Asserting the resolved
+    provider equals the advertised name catches that.
+    """
+    for name in _tool_spec_provider_examples():
+        provider, _ = resolve_policy(name)
+        assert provider == name, f"advertised provider {name!r} resolves to {provider!r} (phantom/misdirecting)"
+
+
+def test_resolve_policy_docstring_examples_reference_registered_providers() -> None:
+    """The ``# -> ("name", ...)`` examples in resolve_policy's docstring must be real."""
+    doc = resolve_policy.__doc__ or ""
+    names = re.findall(r'#\s*\u2192\s*\("([^"]+)"', doc)
+    assert names, "no docstring resolution examples found in resolve_policy"
+    registered = _registered()
+    unknown = [name for name in names if name not in registered]
+    assert not unknown, f"resolve_policy docstring references unregistered providers {unknown}"


### PR DESCRIPTION
## Problem

The MuJoCo `run_policy` tool spec and the policy registry docstrings advertise `lerobot_async` and `dreamgen` as example policy providers, but neither is registered nor resolvable.

Registered providers (`list_providers()`):
```
['cosmos3', 'curobo', 'groot', 'lerobot_local', 'mock', 'motionbricks', 'moveit2', 'remote', 'vera', 'wbc', 'wbc_gait']
```

Phantom references found:
- `strands_robots/simulation/mujoco/tool_spec.json` L193 - `policy_provider` description lists `lerobot_async` and `dreamgen`.
- `strands_robots/registry/policies.py` - `resolve_policy` docstring (shorthand list + a `localhost:8080` example) and `build_policy_kwargs` docstring (`policy_port`, `server_address`).

### Why it matters

An LLM agent reading the tool spec, or a user following the docstring, passes `policy_provider='lerobot_async'`. `resolve_policy` doesn't recognise it, so it is silently redirected to the `lerobot_local` fallback (wrong provider, no error), or the caller hits `Unknown policy provider` late in a rollout after MuJoCo world init and camera setup. Fail-late, misdirecting.

The `resolve_policy("localhost:8080")` docstring example was also factually wrong independent of the phantom name: a bare `host:port` matches no `url_patterns` entry, so it falls through to the `lerobot_local` fallback - it never produces `{"server_address": "localhost:8080"}`.

## Change

- `tool_spec.json`: advertise only registered providers (`groot, lerobot_local, cosmos3, mock`) and point to `list_providers()` for the full set.
- `policies.py`: correct the docstrings. Replaced the wrong `localhost:8080` example with a real, resolvable one (`zmq://localhost:5555` -> `("groot", {"host": "localhost", "port": 5555})`, verified at runtime). `server_address` is a legitimate generic passthrough (`grpc://` URLs, remote providers) - re-attributed away from the phantom `lerobot_async`.
- Added `tests/registry/test_advertised_providers_are_registered.py`: asserts every provider advertised in the tool spec and in `resolve_policy`'s docstring examples is registered and resolves to itself (not the fallback), so docs cannot drift ahead of the registry again.

## Verification

- New regression test fails on pre-fix code (3/4 cases catch `lerobot_async`/`dreamgen`), passes after.
- `tests/registry/` + `tests/policies/lerobot_local/test_resolver_registry_completeness.py`: 518 passed.
- ruff check + format clean; mypy clean on changed files.

Docs-accuracy fix only (no policy/sim/asset behavior change), so no rollout artifact applies.