### PR TITLE
feat(sim): base_height locomotion-regularizer reward term for the predicate/reward DSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1122,6 +1122,21 @@ the missing base once, consistent with the DSL's other name-resolution
 degradation. Works on both the MuJoCo and Newton backends (both surface the base
 twist with the same frame convention).
 
+### Added: base_height locomotion-regularizer reward term for the predicate/reward DSL
+
+The dense-reward DSL grew a `base_height` term: `-weight * (base_z - target) ** 2`,
+where `base_z` is a floating base's world height from `get_observation`'s
+`base_pos` signal. It is the standard legged_gym / IsaacLab companion to the
+`base_velocity` velocity-tracking reward: velocity tracking alone is a degenerate
+locomotion objective -- a policy can dive or crouch to maximise forward velocity
+-- so a viable velocity-tracking reward pairs the two in one `dense_reward` list
+(the terms sum per step), penalising the base for leaving its target torso/pelvis
+height. `target` is the desired height in metres (task-specific: a G1 pelvis
+~0.74 m, a Go2 trunk ~0.34 m); the penalty is symmetric (squared) so crouching
+and stilting cost the same. On a fixed-base arm (no floating base) the term
+degrades to `0.0` and logs the missing base once, consistent with the DSL's
+other name-resolution degradation.
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/simulation/predicates.py
+++ b/strands_robots/simulation/predicates.py
@@ -319,6 +319,31 @@ def _base_twist(sim: SimEngine, robot: str | None) -> tuple[float, float, float]
     return float(v_body[0]), float(v_body[1]), float(ang[2])
 
 
+def _base_position(sim: SimEngine, robot: str | None) -> list[float] | None:
+    """Return a floating base's WORLD position ``[x, y, z]`` (incl. height), or None.
+
+    Reads ``get_observation``'s ``base_pos`` floating-base signal - the base
+    body's world-frame position, whose z component is the base height a
+    locomotion controller regularizes (torso/pelvis height above the ground).
+    Returns None (and warns once) when the robot exposes no floating base -
+    almost always a spec referencing a base term on a fixed-base arm.
+    """
+    try:
+        obs = sim.get_observation(robot_name=robot, skip_images=True)
+    except Exception as e:  # noqa: BLE001 - defensive: predicates never raise
+        logger.debug("base_height get_observation(%r) failed: %s", robot, e)
+        return None
+    if not isinstance(obs, dict):
+        return None
+    pos = obs.get("base_pos")
+    if not (isinstance(pos, list) and len(pos) == 3):
+        # A floating base surfaces base_pos; its absence means this robot has no
+        # floating base (a fixed-base arm) - almost always a spec error.
+        _warn_unresolved("robot base", robot or "<sole robot>")
+        return None
+    return [float(pos[0]), float(pos[1]), float(pos[2])]
+
+
 # Predicate factories
 
 
@@ -766,6 +791,40 @@ def _base_velocity(
     return term
 
 
+def _base_height(target: float, weight: float = 1.0, robot: str | None = None) -> RewardTerm:
+    """Negative squared base-height error - a locomotion-regularizer reward.
+
+    Rewards a floating-base robot for keeping its base (torso/pelvis) near a
+    target WORLD height: ``-weight * (base_z - target) ** 2`` - 0 at the target
+    and growing more negative as the base deviates. Composed alongside
+    ``base_velocity`` in a ``dense_reward`` list, it is the standard regularizer
+    that stops a velocity-tracking policy from cheating the forward-velocity
+    reward by crouching or diving (the legged_gym / IsaacLab ``base_height``
+    term). ``base_velocity`` alone is degenerate for locomotion - a policy can
+    dive forward to maximise it - so a viable velocity-tracking reward pairs the
+    two.
+
+    Reads ``get_observation``'s ``base_pos`` (world frame). ``target`` is the
+    desired base height in metres (task-specific: a G1 pelvis ~0.74 m, a Go2
+    trunk ~0.34 m). Requires a robot with a floating base; a fixed-base arm has
+    no base position, so the term degrades to ``0.0`` and the missing base is
+    logged once. ``robot`` selects the robot in a multi-robot scene (default:
+    the sole robot).
+    """
+    w = float(weight)
+    tgt = float(target)
+    rname = robot
+
+    def term(sim: SimEngine) -> float:
+        pos = _base_position(sim, rname)
+        if pos is None:
+            return 0.0
+        d = pos[2] - tgt
+        return -w * d * d
+
+    return term
+
+
 # Stateful reward terms (declarative phase machine)
 #
 # A plain RewardTerm is stateless: ``(SimEngine) -> float``. Some rewards need
@@ -941,6 +1000,7 @@ PREDICATE_REGISTRY: dict[str, PredicateFactory] = {
     "distance_neg": _distance_neg,
     "joint_progress": _joint_progress,
     "base_velocity": _base_velocity,
+    "base_height": _base_height,
     "constant": _constant,
     # stateful (phase machine)
     "staged_reward": _staged_reward,

--- a/tests/simulation/test_base_height_reward.py
+++ b/tests/simulation/test_base_height_reward.py
@@ -1,0 +1,155 @@
+"""Regression tests for the ``base_height`` locomotion-regularizer reward term.
+
+The predicate/reward DSL grew a ``base_height`` reward term:
+``-weight * (base_z - target) ** 2``, where ``base_z`` is a floating base's
+world height from ``get_observation``'s ``base_pos`` signal. It is the standard
+legged_gym / IsaacLab companion to ``base_velocity`` - a velocity-tracking
+reward alone is degenerate (a policy can dive/crouch to cheat the forward
+velocity), so a viable locomotion reward pairs the two in one ``dense_reward``
+list (they sum per step).
+
+These tests set a KNOWN base height directly on the sim and assert the term
+computes the correct negative squared error - 0 at the target, symmetric above
+and below, scaled by ``weight`` - and that it degrades to ``0.0`` (with a
+warning) on a fixed-base arm that has no base position. They are GL-free
+(get_observation with skip_images) so they run in CI without a display.
+"""
+
+import logging
+import os
+import tempfile
+
+import mujoco
+import pytest
+
+from strands_robots.simulation.mujoco.simulation import Simulation
+from strands_robots.simulation.predicates import (
+    _reset_resolution_warnings,
+    make_predicate,
+)
+
+# Floating base with a NAMED free joint (a humanoid's floating_base_joint) plus
+# one actuated hinge. get_observation surfaces base_pos for this robot.
+NAMED_BASE_XML = """
+<mujoco model="test_named_base">
+  <compiler angle="radian" autolimits="true"/>
+  <option timestep="0.002"/>
+  <worldbody>
+    <light name="main" pos="0 0 3" dir="0 0 -1"/>
+    <geom name="ground" type="plane" size="5 5 0.01" rgba="0.9 0.9 0.9 1"/>
+    <body name="pelvis" pos="0 0 0.8">
+      <freejoint name="floating_base_joint"/>
+      <geom type="box" size="0.1 0.1 0.1" rgba="0.3 0.3 0.8 1"/>
+      <body name="thigh" pos="0 0 -0.1">
+        <geom type="capsule" size="0.03" fromto="0 0 0 0 0 -0.3" rgba="0.8 0.3 0.3 1"/>
+        <joint name="hip" type="hinge" axis="0 1 0" range="-1.5 1.5"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <motor name="hip_act" joint="hip"/>
+  </actuator>
+</mujoco>
+"""
+
+# Fixed-base arm: no free joint anywhere -> no base position. base_height must
+# degrade to 0.0 (and warn) rather than crash or invent a value.
+FIXED_ARM_XML = """
+<mujoco model="test_fixed">
+  <compiler angle="radian" autolimits="true"/>
+  <worldbody>
+    <light name="main" pos="0 0 3" dir="0 0 -1"/>
+    <body name="link" pos="0 0 0.1">
+      <geom type="capsule" size="0.02" fromto="0 0 0 0 0 0.2"/>
+      <joint name="j0" type="hinge" axis="0 0 1"/>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="j0_act" joint="j0" kp="10"/>
+  </actuator>
+</mujoco>
+"""
+
+_TARGET = 0.74  # a G1-pelvis-like target height
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="test_base_height", mesh=False)
+    s.create_world(ground_plane=False)
+    yield s
+    s.cleanup()
+
+
+def _write(xml: str) -> str:
+    d = tempfile.mkdtemp()
+    p = os.path.join(d, "model.xml")
+    with open(p, "w") as f:
+        f.write(xml)
+    return p
+
+
+def _set_base_height(sim, z: float) -> None:
+    """Set the robot's (only) free joint to an upright pose at world height z."""
+    model, data = sim._world._model, sim._world._data
+    jid = -1
+    for j in range(model.njnt):
+        if model.jnt_type[j] == mujoco.mjtJoint.mjJNT_FREE:
+            jid = j
+            break
+    assert jid >= 0
+    qadr = int(model.jnt_qposadr[jid])
+    data.qpos[qadr : qadr + 7] = [0.0, 0.0, z, 1.0, 0.0, 0.0, 0.0]
+    mujoco.mj_forward(model, data)
+
+
+def test_base_height_is_zero_at_the_target(sim):
+    """Reward is 0 when the base sits exactly at the target height."""
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    _set_base_height(sim, _TARGET)
+    assert make_predicate("base_height", target=_TARGET)(sim) == pytest.approx(0.0, abs=1e-6)
+
+
+def test_base_height_is_negative_squared_error(sim):
+    """Reward is -weight * (base_z - target)**2 when the base is off target."""
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    _set_base_height(sim, 0.50)  # 0.24 m below the target
+    expected = -((0.50 - _TARGET) ** 2)
+    assert make_predicate("base_height", target=_TARGET)(sim) == pytest.approx(expected, abs=1e-6)
+    # weight scales the penalty linearly.
+    assert make_predicate("base_height", target=_TARGET, weight=5.0)(sim) == pytest.approx(5.0 * expected, abs=1e-6)
+
+
+def test_base_height_penalty_is_symmetric_above_and_below(sim):
+    """A base the same distance ABOVE the target is penalised identically to BELOW
+    (the error is squared, not signed) - crouching and stilting cost the same."""
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    term = make_predicate("base_height", target=_TARGET)
+    _set_base_height(sim, _TARGET - 0.24)
+    below = term(sim)
+    _set_base_height(sim, _TARGET + 0.24)
+    above = term(sim)
+    assert below == pytest.approx(above, abs=1e-6)
+    assert below == pytest.approx(-(0.24**2), abs=1e-6)
+
+
+def test_base_height_tracks_the_live_base_position(sim):
+    """The reward reads the CURRENT base height: moving the base changes it."""
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    term = make_predicate("base_height", target=_TARGET)
+    _set_base_height(sim, _TARGET)
+    assert term(sim) == pytest.approx(0.0, abs=1e-6)
+    _set_base_height(sim, _TARGET - 0.3)
+    assert term(sim) == pytest.approx(-(0.3**2), abs=1e-6)
+
+
+def test_base_height_degrades_to_zero_on_fixed_base_arm(sim, caplog):
+    """A fixed-base arm has no base position: the term degrades to 0.0 and warns."""
+    sim.add_robot("arm", urdf_path=_write(FIXED_ARM_XML))
+    # Reset the module-global warn-once dedup so this assertion is independent of
+    # what other predicate tests warned first (the "robot base" key is shared).
+    _reset_resolution_warnings()
+    with caplog.at_level(logging.WARNING, logger="strands_robots.simulation.predicates"):
+        val = make_predicate("base_height", target=0.5)(sim)
+    assert val == 0.0
+    assert any("base" in r.message.lower() for r in caplog.records)

--- a/tests/simulation/test_base_velocity_reward.py
+++ b/tests/simulation/test_base_velocity_reward.py
@@ -26,6 +26,7 @@ import pytest
 from strands_robots.simulation.mujoco.simulation import Simulation
 from strands_robots.simulation.predicates import (
     _quat_rotate_inverse_wxyz,
+    _reset_resolution_warnings,
     make_predicate,
 )
 
@@ -162,6 +163,9 @@ def test_base_velocity_degrades_to_zero_on_fixed_base_arm(sim, caplog):
     import logging
 
     sim.add_robot("arm", urdf_path=_write(FIXED_ARM_XML))
+    # Reset the module-global warn-once dedup so this assertion is independent of
+    # what other predicate tests warned first (the "robot base" key is shared).
+    _reset_resolution_warnings()
     with caplog.at_level(logging.WARNING, logger="strands_robots.simulation.predicates"):
         val = make_predicate("base_velocity", vx=0.5)(sim)
     assert val == 0.0


### PR DESCRIPTION
## Problem

The dense-reward DSL has `base_velocity` (velocity-tracking, the canonical locomotion reward), but **velocity tracking alone is a degenerate objective**: a policy can dive forward or crouch to maximise the forward-velocity reward while collapsing. The standard legged_gym / IsaacLab locomotion reward pairs velocity tracking with a `base_height` regularizer that keeps the torso/pelvis near a target height. The DSL had no way to express that, so a `dense_reward` built only from `base_velocity` rewards the crouch-cheat.

The floating-base observation now surfaces the base's full world position (`base_pos`, incl. height), so this regularizer is expressible.

## Change

Adds a `base_height` reward term to the predicate/reward DSL:

```
-weight * (base_z - target) ** 2
```

where `base_z` is the floating base's world height from `get_observation`'s `base_pos`. `target` is the desired height in metres (task-specific: a G1 pelvis ~0.74 m, a Go2 trunk ~0.34 m); the penalty is symmetric (squared), so crouching and stilting cost the same. On a fixed-base arm (no floating base) the term degrades to `0.0` and logs the missing base once, consistent with the DSL's other name-resolution degradation. Reads the world base height surfaced in `get_observation`, so it works on both the MuJoCo and Newton backends.

## It composes into a non-degenerate locomotion reward

Verified through a real `DeclarativeBenchmark` spec (terms sum per step):

```yaml
dense_reward:
  - {predicate: base_velocity, vx: 1.0, weight: 1.0}
  - {predicate: base_height, target: 0.74, weight: 10.0}
```

| base state | reward |
|---|---|
| IDEAL        (h=0.74, vx=1.0) | `+0.000` |
| CROUCH-CHEAT (h=0.50, vx=1.0) | `-0.576`  (tracks vx but crouched 24 cm) |
| SLOW         (h=0.74, vx=0.0) | `-1.000` |
| DIVE         (h=0.40, vx=1.5) | `-1.656` |

Velocity-only would tie CROUCH-CHEAT with IDEAL (both track `vx=1.0`, so `base_velocity=0`); adding `base_height` breaks the tie.

## Tests

`tests/simulation/test_base_height_reward.py` (GL-free, real MuJoCo physics via an inline free-joint MJCF): `0` at the target, negative squared error scaled by `weight`, symmetric above/below, live base-position tracking, and fixed-base degrade-to-`0.0` (with the warning). All five **fail before** the change (`ValueError: Unknown predicate 'base_height'`) and pass after.

The new fixed-base test shares the `"robot base"` warn-once dedup key with the existing `base_velocity` fixed-base test; both now reset the module-global dedup (`_reset_resolution_warnings`) so each asserts its warning independently of collection order.

Gate: `ruff check` + `ruff format --check` + `mypy` clean on the changed files; the DSL suite (`test_base_height_reward`, `test_base_velocity_reward`, `test_benchmark_predicates`, `test_benchmark_dsl`, `test_staged_reward`) passes 168/168 under `MUJOCO_GL=egl`.

No visual artifact: this is reward-DSL math over `get_observation` (no policy/render/asset/recording behaviour change); the fails-before numeric benchmark table is the proof, matching the `base_velocity` term it complements.