### PR TITLE
fix(norm-stats): raise on unrecognized mode instead of silent passthrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: norm-stats FeatureNormalizer silently passed values through on an unrecognized mode
+
+`FeatureNormalizer.normalize` / `.unnormalize`
+(`strands_robots.policies.lerobot_local.norm_stats`) fell through to an identity
+`else` branch for any mode outside the five recognized ones (`none`,
+`mean_std`, `min_max`, `q01_q99`, `q10_q90`), returning the input unchanged.
+That is exactly the silent-passthrough failure this module exists to prevent:
+un-normalized state reaching the policy and un-unnormalized actions reaching the
+motors, with no error to explain the off-policy motion. `from_stats` already
+rejected unknown modes, but a directly-constructed or future-mode normalizer
+bypassed that guard. Both transforms now raise `ValueError` on an unrecognized
+mode instead of degrading to identity. The five valid modes are unaffected.
+
 ### Fixed: scene mutations silently swallowed a cached-XML refresh failure
 
 Every MuJoCo scene mutation keeps a legacy XML string in

--- a/strands_robots/policies/lerobot_local/norm_stats.py
+++ b/strands_robots/policies/lerobot_local/norm_stats.py
@@ -92,7 +92,9 @@ class FeatureNormalizer:
     normalization modes. ``normalize`` maps raw robot units into the model's
     normalized space; ``unnormalize`` inverts it. Both preserve the input
     container type (numpy in -> numpy out, tensor in -> tensor out on the same
-    device/dtype).
+    device/dtype). An unrecognized ``mode`` raises :class:`ValueError` in both
+    directions rather than silently passing values through un-normalized (the
+    passthrough failure this module exists to prevent).
     """
 
     def __init__(
@@ -176,7 +178,12 @@ class FeatureNormalizer:
         raise ValueError(f"Unsupported robot normalization mode {mode!r}.")
 
     def normalize(self, x: Any) -> Any:
-        """Map raw values into the model's normalized space."""
+        """Map raw values into the model's normalized space.
+
+        Raises:
+            ValueError: If ``mode`` is not a recognized normalization mode
+                (refusing to send un-normalized state to the policy).
+        """
         arr = _to_array(x)
         if arr is None:
             return None
@@ -192,7 +199,11 @@ class FeatureNormalizer:
             assert self.q_low is not None and self.q_high is not None
             normed = 2.0 * (arr - self.q_low) / np.maximum(self.q_high - self.q_low, _EPS) - 1.0
         else:
-            normed = arr
+            raise ValueError(
+                f"FeatureNormalizer.normalize: unsupported mode {self.mode!r}. Refusing to "
+                "pass state through un-normalized -- silent passthrough sends un-normalized "
+                "state to the policy (the single biggest cause of off-policy arm motion)."
+            )
         if self.mode in {"min_max", "q01_q99", "q10_q90"}:
             normed = np.clip(normed, -1.0, 1.0)
         if self.mask is not None:
@@ -202,7 +213,12 @@ class FeatureNormalizer:
         return self._restore_like(normed, x)
 
     def unnormalize(self, x: Any) -> Any:
-        """Invert :meth:`normalize`, mapping normalized values back to robot units."""
+        """Invert :meth:`normalize`, mapping normalized values back to robot units.
+
+        Raises:
+            ValueError: If ``mode`` is not a recognized normalization mode
+                (refusing to send un-unnormalized actions to the motors).
+        """
         arr = _to_array(x)
         if arr is None:
             return None
@@ -220,7 +236,11 @@ class FeatureNormalizer:
             assert self.q_low is not None and self.q_high is not None
             out = (arr + 1.0) * (self.q_high - self.q_low) / 2.0 + self.q_low
         else:
-            out = arr
+            raise ValueError(
+                f"FeatureNormalizer.unnormalize: unsupported mode {self.mode!r}. Refusing to "
+                "pass actions through un-unnormalized -- silent passthrough sends "
+                "un-unnormalized actions to the motors."
+            )
         if self.mask is not None:
             out = np.where(self.mask, out, arr)
         return self._restore_like(out, x)

--- a/tests/policies/lerobot_local/test_norm_stats_fallback.py
+++ b/tests/policies/lerobot_local/test_norm_stats_fallback.py
@@ -593,3 +593,33 @@ class TestProcessorStepEdgeCases:
         pre, _ = ns.build_norm_stats_processors(_load_fixture())
         obs = {"observation.images.top": "frame"}
         assert pre.steps[0].observation(obs) == obs
+
+
+class TestUnknownModeRaises:
+    """An unrecognized mode must raise, never silently pass values through.
+
+    Silent passthrough is the exact failure this module exists to prevent:
+    un-normalized state reaching the policy and un-unnormalized actions reaching
+    the motors. ``from_stats`` already rejects unknown modes; these guard the
+    public transform hot-path (a directly-constructed or future-mode normalizer)
+    so it fails loudly instead of degrading to identity.
+    """
+
+    def test_normalize_raises_on_unknown_mode(self):
+        fn = ns.FeatureNormalizer(mode="totally-bogus")
+        with pytest.raises(ValueError, match="unsupported mode"):
+            fn.normalize(np.array([1.0, 2.0], dtype=np.float32))
+
+    def test_unnormalize_raises_on_unknown_mode(self):
+        fn = ns.FeatureNormalizer(mode="totally-bogus")
+        with pytest.raises(ValueError, match="unsupported mode"):
+            fn.unnormalize(np.array([0.0, 0.5], dtype=np.float32))
+
+    def test_none_and_recognized_modes_still_transform(self):
+        # Regression fence: the raise must not leak into the five valid modes.
+        none_fn = ns.FeatureNormalizer.from_stats({"mean": [1.0]}, "none")
+        x = np.array([7.0], dtype=np.float32)
+        assert np.allclose(none_fn.normalize(x), x)
+        assert np.allclose(none_fn.unnormalize(x), x)
+        mm = ns.FeatureNormalizer.from_stats({"min": [0.0], "max": [10.0]}, "min_max")
+        assert np.allclose(mm.unnormalize(mm.normalize(np.array([5.0], dtype=np.float32))), [5.0], atol=1e-5)


### PR DESCRIPTION
## Problem

`FeatureNormalizer.normalize` / `.unnormalize` in `strands_robots.policies.lerobot_local.norm_stats` fell through to an identity `else` branch for any mode outside the five recognized ones (`none`, `mean_std`, `min_max`, `q01_q99`, `q10_q90`), returning the input **unchanged**:

```python
else:
    normed = arr   # normalize
...
else:
    out = arr      # unnormalize
```

That is precisely the silent-passthrough failure this module exists to prevent, as its own docstring states: un-normalized state reaching the policy and un-unnormalized actions reaching the motors, the single biggest cause of off-policy arm motion, with no error to explain it. It also contradicts the project convention to raise on fatal conditions rather than degrade to a silent default.

`from_stats` (the intended constructor) already rejects unknown modes with `ValueError`, but a directly-constructed `FeatureNormalizer(mode=...)` or a future mode wired into `__init__` but not into the transform dispatch would bypass that guard and silently pass data through.

## Change

Both transforms now `raise ValueError` on an unrecognized mode instead of returning the input unchanged, mirroring the existing `from_stats` contract. The five valid modes are byte-for-byte unaffected (`none` is still an explicit identity; `mean_std` / `min_max` / `q01_q99` / `q10_q90` unchanged). Method + class docstrings document the new `Raises` contract.

## Tests

New `TestUnknownModeRaises`:
- `test_normalize_raises_on_unknown_mode` / `test_unnormalize_raises_on_unknown_mode` construct `FeatureNormalizer(mode="totally-bogus")` and assert `ValueError`. **Both fail on pre-fix code** (`Failed: DID NOT RAISE ValueError` -- the silent passthrough) and pass after.
- `test_none_and_recognized_modes_still_transform` fences that the raise does not leak into `none` / `min_max`.

Full `tests/policies/lerobot_local/` suite: 526 passed. `norm_stats.py` coverage 97% -> 98% (the two former passthrough lines are now the covered raise path). ruff + mypy clean.

Error-path hardening in a numeric normalization utility; no rollout/render behavior changes for any valid checkpoint, so the regression test (fails pre-fix) is the proof rather than a sim video.