### PR TITLE
docs(factory): correct create_simulation() isaac backend examples to builtin (closes #1146)

### DIFF
--- a/strands_robots/simulation/factory.py
+++ b/strands_robots/simulation/factory.py
@@ -13,8 +13,8 @@ Usage::
     # Explicit backend
     sim = create_simulation("mujoco", timestep=0.001)
 
-    # Future backends
-    sim = create_simulation("isaac", gpu_id=0)
+    # GPU-native built-in backends
+    sim = create_simulation("isaac", num_envs=1, headless=True)
     sim = create_simulation("newton")
 
     # Custom backend (runtime-registered)
@@ -310,7 +310,7 @@ def create_simulation(
     Resolution order for ``backend``:
 
     1. Runtime-registered backends (see ``register_backend``).
-    2. Built-in backends (currently ``mujoco``, ``newton``). Built-ins always
+    2. Built-in backends (currently ``mujoco``, ``newton``, ``isaac``). Built-ins always
        win over entry-point plugins of the same name, so a third-party
        plugin can never accidentally shadow a built-in backend.
     3. Entry-point plugins. Third-party packages (e.g.
@@ -320,7 +320,6 @@ def create_simulation(
        ``pyproject.toml``::
 
            [project.entry-points."strands_robots.backends"]
-           isaac = "strands_robots_sim.isaac.simulation:IsaacSimulation"
            newton = "strands_robots_sim.newton.simulation:NewtonSimulation"
            warp = "strands_robots_sim.newton.simulation:NewtonSimulation"
 
@@ -363,8 +362,8 @@ def create_simulation(
         # Pass kwargs to backend constructor
         sim = create_simulation("mujoco", tool_name="my_sim")
 
-        # Entry-point plugin (requires strands-robots-sim installed)
-        sim = create_simulation("isaac", gpu_id=0)
+        # GPU-native built-in backend (requires strands-robots[sim-isaac])
+        sim = create_simulation("isaac", num_envs=1, headless=True)
     """
     canonical = _resolve_name(backend)
     logger.info("Creating simulation: %s (resolved from %r)", canonical, backend)


### PR DESCRIPTION
## Summary

`isaac` has been absorbed in-tree as a **builtin** simulation backend (registered in `_BUILTIN_BACKENDS`, module vendored under `strands_robots/simulation/isaac/`), superseding the `strands-robots-sim` entry-point plugin which `_load_plugin_backends` now explicitly shadows. The three code edits requested in #1146 (enable the builtin, add aliases, drop the plugin-install hint) already landed. This PR closes the remaining loose end: the `create_simulation()` docstrings still described `isaac` as a *future / entry-point-plugin* backend and used an **invalid** `gpu_id=0` kwarg that `IsaacSimulation.__init__` rejects at construction (strict kwarg validation; `gpu_id` is not an `IsaacConfig` field).

## Changes (docs-only)

- **Resolution-order note** now lists `isaac` among the current builtins alongside `mujoco`/`newton`.
- **Entry-point plugin example** drops the stale `isaac = "strands_robots_sim.isaac.simulation:IsaacSimulation"` line -- a builtin of the same name is always preferred and the plugin is skipped before load, so advertising it as the registration path is misleading.
- **Both `create_simulation("isaac", ...)` examples** replace the invalid `gpu_id=0` with `num_envs=1, headless=True`, which map to real `IsaacConfig` fields (validated as shortcut kwargs).
- **Module-level usage example** relabelled from `# Future backends` to `# GPU-native built-in backends`.

## Why no test

Docstring prose is not asserted by any test (verified: no `tests/` reference to the changed strings). This is a pure drift correction with no behavior change -- `git diff` is 5 insertions / 6 deletions, all inside docstrings. The `isaac` builtin resolution itself is already covered by the factory backend-registry tests.

## Verification

- `ast.parse` clean.
- `grep` confirms no `strands_robots_sim.isaac` / `gpu_id=0` / `# Future backends` remain in `factory.py`.

Closes #1146.