### PR TITLE
test(sim): pin load_scene structured-error contract for malformed MJCF

### DIFF
--- a/tests/simulation/mujoco/test_simulation.py
+++ b/tests/simulation/mujoco/test_simulation.py
@@ -360,6 +360,27 @@ class TestWorldLifecycle:
         result = sim.load_scene("/nonexistent/path.xml")
         assert result["status"] == "error"
 
+    def test_load_scene_malformed_mjcf_returns_error(self, sim, tmp_path):
+        """A syntactically-present but semantically-invalid MJCF must resolve to
+        a structured error dict, not an escaped exception.
+
+        ``load_scene`` guards the missing-file case up front, but a file that
+        exists and passes that guard can still fail deep in the MuJoCo compile
+        (bad attribute value, inconsistent joints, unknown element). That failure
+        must be converted into the ``{"status": "error"}`` contract every facade
+        method upholds so a caller/agent never has to catch a raw compile
+        exception mid-dispatch.
+        """
+        bad = tmp_path / "malformed.xml"
+        bad.write_text(
+            '<mujoco model="bad"><worldbody><body><geom type="box" size="not-a-number"/></body></worldbody></mujoco>'
+        )
+
+        result = sim.load_scene(str(bad))
+
+        assert result["status"] == "error"
+        assert "Failed to load scene" in result["content"][0]["text"]
+
 
 # Object Management
 


### PR DESCRIPTION
## Problem

`Simulation.load_scene` guards the missing-file case up front and returns a structured `{"status": "error"}` dict for it. But a file that exists and clears that guard can still fail deep in the MuJoCo compile step - a bad attribute value, inconsistent joints, or an unknown element. That failure is caught by the method's outer `except` and converted to the same structured-error contract every facade method upholds, so a caller/agent never has to catch a raw compile exception mid-dispatch.

The nonexistent-path branch was already regression-guarded (`test_load_scene_nonexistent`), but the malformed-but-present branch had no test, leaving half of the `load_scene` error contract unpinned. A future refactor could let a compile exception escape past the facade without any test catching the regression.

## Change

Add `test_load_scene_malformed_mjcf_returns_error`: writes an existing MJCF whose geom `size` attribute is non-numeric (passes the file-exists guard, fails at compile), calls `load_scene`, and asserts the returned dict is `status == "error"` with a `Failed to load scene` message - i.e. the error is surfaced structurally, not raised.

Test-only, behavioral (asserts the public return contract, not internals). Co-located with the existing `load_scene` tests in `TestWorldLifecycle`.

## Coverage

The malformed-MJCF error path in `simulation/mujoco/simulation.py` (the `load_scene` outer `except`) was previously uncovered; it is now exercised, completing the `load_scene` error-contract coverage alongside the pre-existing not-found case.

## Verification

- `MUJOCO_GL=egl pytest tests/simulation/mujoco/test_simulation.py`: 153 passed.
- `hatch run lint` (ruff check + ruff format + mypy): clean, no issues in 729 source files.