### PR TITLE
fix(lerobot_local): run observation-history policies (Diffusion/VQBeT) via select_action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1150,6 +1150,10 @@ and stilting cost the same. On a fixed-base arm (no floating base) the term
 degrades to `0.0` and logs the missing base once, consistent with the DSL's
 other name-resolution degradation.
 
+### Fixed:
+
+- `lerobot_local`: observation-history policies (Diffusion `n_obs_steps=2`, VQBeT `n_obs_steps=5`) crashed with `AssertionError` when run through `Simulation.run_policy`. `_auto_detect_actions_per_step` adopted the model's `n_action_steps` chunk and routed inference to `predict_action_chunk()`, whose offline branch stacks a single live observation frame as `n_obs_steps=1`; LeRobot's `generate_actions()` then trips `assert n_obs_steps == config.n_obs_steps`. These checkpoints now keep `actions_per_step=1` so inference runs through `select_action()`, which maintains the required observation-history queue and still replays the model's `n_action_steps` chunk from its internal queue (open-loop chunk replay is preserved). Single-history policies (ACT, SmolVLA, pi0, MolmoAct2) are unaffected.
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -978,12 +978,22 @@ class LerobotLocalPolicy(Policy):
             Many policies declare ``config.n_action_steps`` - the number of
             actions emitted per inference that the model was trained to replay
             open-loop before requerying observation (e.g. MolmoAct2 SO-100/101 =
-            30, ACT = 100, Diffusion = 32). The default ``actions_per_step=1`` is
+            30, ACT = 100). The default ``actions_per_step=1`` is
             a closed-loop convention that re-queries every step; for a chunk-
             trained model that is out of distribution and the shift compounds
             every chunk. When left at the default ``1`` we adopt
             ``n_action_steps`` so the chunk is consumed as trained. An explicit
             ``actions_per_step > 1`` from the caller is respected here.
+
+        Observation history (``config.n_obs_steps > 1``):
+            Diffusion (2) and VQBeT (5) consume a short observation history and
+            MUST run through ``select_action()`` (it maintains the obs-history
+            queue). Their ``predict_action_chunk()`` offline branch stacks a
+            single live frame as ``n_obs_steps=1`` and ``generate_actions()``
+            asserts, so the ``actions_per_step > 1`` regime crashes them. We keep
+            ``actions_per_step=1`` for these checkpoints; ``select_action()``
+            still replays the ``n_action_steps`` chunk from its internal queue,
+            so open-loop chunk replay is preserved - just correctly.
 
         Logged at INFO so the active regime is always visible.
         """
@@ -1015,6 +1025,29 @@ class LerobotLocalPolicy(Policy):
             return
         if self.actions_per_step != 1:
             return  # caller pinned an explicit horizon - never override it
+        # Observation-history policies (``n_obs_steps > 1``, e.g. Diffusion=2,
+        # VQBeT=5) MUST be driven per-step through ``select_action()``. That path
+        # maintains the required ``n_obs_steps`` observation queue AND still
+        # caches the model's ``n_action_steps`` chunk internally (re-querying the
+        # model only when the queue drains - the same open-loop chunk replay,
+        # done correctly). The ``actions_per_step > 1`` regime instead calls
+        # ``predict_action_chunk()`` on a SINGLE live observation frame; its
+        # offline branch stacks that lone frame as ``n_obs_steps=1``, so
+        # ``generate_actions()`` trips ``assert n_obs_steps == config.n_obs_steps``
+        # and crashes. Keep ``actions_per_step=1`` for these checkpoints so the
+        # per-step ``select_action()`` path is used.
+        n_obs_steps = getattr(config, "n_obs_steps", 1)
+        if isinstance(n_obs_steps, int) and n_obs_steps > 1:
+            logger.info(
+                "lerobot_local: %s consumes an observation history "
+                "(n_obs_steps=%d) - driving per-step via select_action() (which "
+                "keeps the obs-history queue and still replays the model's "
+                "n_action_steps chunk from its internal queue). Keeping "
+                "actions_per_step=1.",
+                type(self._policy).__name__,
+                n_obs_steps,
+            )
+            return
         n_action_steps = getattr(config, "n_action_steps", None)
         if isinstance(n_action_steps, int) and n_action_steps > 1:
             self.actions_per_step = n_action_steps

--- a/tests/policies/lerobot_local/test_obs_history_chunk_regime.py
+++ b/tests/policies/lerobot_local/test_obs_history_chunk_regime.py
@@ -1,0 +1,86 @@
+"""Observation-history policies must run per-step via ``select_action()``.
+
+Diffusion (``n_obs_steps=2``) and VQBeT (``n_obs_steps=5``) consume a short
+observation history. LeRobot builds that history inside ``select_action()``'s
+queue; ``predict_action_chunk()``'s offline branch stacks a SINGLE live frame as
+``n_obs_steps=1`` and ``generate_actions()`` trips
+``assert n_obs_steps == config.n_obs_steps`` -> crash.
+
+``LerobotLocalPolicy._auto_detect_actions_per_step`` therefore must keep
+``actions_per_step=1`` (the ``select_action()`` regime) for any checkpoint whose
+config declares ``n_obs_steps > 1``, instead of adopting ``n_action_steps`` and
+routing to the crashing ``predict_action_chunk()`` path.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from strands_robots.policies.lerobot_local.policy import LerobotLocalPolicy
+
+
+class _Cfg:
+    """Minimal loaded-policy config stub read by _auto_detect_actions_per_step."""
+
+    def __init__(self, *, n_obs_steps=1, n_action_steps=1, temporal_ensemble_coeff=None):
+        self.n_obs_steps = n_obs_steps
+        self.n_action_steps = n_action_steps
+        self.temporal_ensemble_coeff = temporal_ensemble_coeff
+
+
+class _Pol:
+    def __init__(self, cfg):
+        self.config = cfg
+
+
+def _unloaded(**kw) -> LerobotLocalPolicy:
+    with patch.object(LerobotLocalPolicy, "_load_model"):
+        return LerobotLocalPolicy(pretrained_name_or_path="test/model", **kw)
+
+
+def test_obs_history_policy_keeps_actions_per_step_1():
+    """n_obs_steps>1 (Diffusion=2) -> stay at 1 so select_action() is used."""
+    pol = _unloaded()
+    pol._policy = _Pol(_Cfg(n_obs_steps=2, n_action_steps=32))
+    assert pol.actions_per_step == 1  # default
+    pol._auto_detect_actions_per_step()
+    # Must NOT adopt n_action_steps (that routes to predict_action_chunk and
+    # crashes on a single-frame obs). Stay at 1 -> per-step select_action().
+    assert pol.actions_per_step == 1
+
+
+def test_vqbet_style_obs_history_keeps_actions_per_step_1():
+    """VQBeT's larger history (n_obs_steps=5) is handled the same way."""
+    pol = _unloaded()
+    pol._policy = _Pol(_Cfg(n_obs_steps=5, n_action_steps=8))
+    pol._auto_detect_actions_per_step()
+    assert pol.actions_per_step == 1
+
+
+def test_single_obs_chunk_policy_still_auto_adopts_horizon():
+    """Control: ACT-style (n_obs_steps=1, chunk=100) is unchanged -> 100."""
+    pol = _unloaded()
+    pol._policy = _Pol(_Cfg(n_obs_steps=1, n_action_steps=100))
+    pol._auto_detect_actions_per_step()
+    assert pol.actions_per_step == 100
+
+
+def test_missing_n_obs_steps_defaults_to_chunk_replay():
+    """A config with no n_obs_steps attr behaves as before (adopts chunk)."""
+    pol = _unloaded()
+
+    class _NoObs:
+        def __init__(self):
+            self.n_action_steps = 30
+
+    pol._policy = _Pol(_NoObs())
+    pol._auto_detect_actions_per_step()
+    assert pol.actions_per_step == 30
+
+
+def test_explicit_horizon_respected_even_with_obs_history():
+    """An explicit caller horizon is never overridden by the obs-history guard."""
+    pol = _unloaded(actions_per_step=4)
+    pol._policy = _Pol(_Cfg(n_obs_steps=2, n_action_steps=32))
+    pol._auto_detect_actions_per_step()
+    assert pol.actions_per_step == 4


### PR DESCRIPTION
## Problem
A canonical LeRobot Diffusion Policy checkpoint (and VQBeT) crashes with `AssertionError` the first time it is queried through `Simulation.run_policy`:

```
File ".../lerobot/policies/diffusion/modeling_diffusion.py", line 319, in generate_actions
    assert n_obs_steps == self.config.n_obs_steps
AssertionError
```

`run_policy` logs `PolicyRunner.run failed` and the rollout produces no actions. There is no supported workaround: `actions_per_step=1` is the default and is auto-overridden at load, so `create_policy(policy_type="diffusion") + run_policy` cannot succeed.

## Root cause
`LerobotLocalPolicy._auto_detect_actions_per_step` picks the inference regime at load time. For a checkpoint declaring `config.n_action_steps > 1` it adopts that chunk (`actions_per_step = n_action_steps`, e.g. Diffusion 32), which routes inference through `predict_action_chunk()`. But Diffusion (`n_obs_steps=2`) and VQBeT (`n_obs_steps=5`) also consume a short **observation history**. LeRobot builds that history inside `select_action()`'s queue; `predict_action_chunk()`'s offline branch stacks a single live frame as `n_obs_steps=1`, so `generate_actions()` trips `assert n_obs_steps == config.n_obs_steps`.

## Fix
Keep `actions_per_step=1` for any checkpoint whose config declares `n_obs_steps > 1`, so inference runs through `select_action()`. `select_action()` maintains the required observation-history queue **and** still caches the model's `n_action_steps` chunk internally (re-querying the model only when the queue drains) — open-loop chunk replay is preserved, just correctly. Single-history policies (ACT, SmolVLA, pi0, MolmoAct2; all `n_obs_steps=1`) are unaffected.

## Test
`tests/policies/lerobot_local/test_obs_history_chunk_regime.py` pins the regime selection: `n_obs_steps>1` (Diffusion=2, VQBeT=5) keeps `actions_per_step==1`; ACT-style single-history still adopts its chunk (100); a config with no `n_obs_steps` behaves as before; an explicit caller horizon is respected. The two obs-history assertions FAIL on `main` (`assert 32 == 1`, `assert 8 == 1`) and pass with the fix.

Gate: `ruff check`/`ruff format` clean, `mypy` clean on changed files, full `tests/policies/lerobot_local/` suite (531) + `tests/simulation/test_policy_runner.py` green.

## Verification
A trained Diffusion checkpoint (SO-101, front+top cameras, 6-DOF) now runs cleanly through `run_policy` (`actions_per_step` auto-kept at 1, no `AssertionError`, reaches the target to ~5 mm). Two rollouts in MuJoCo (headless, `MUJOCO_GL=egl`):

![diffusion rollouts in MuJoCo](https://github.com/cagataycali/robots/releases/download/artifacts-diffusion-obs-history/diffusion_bimodal_rollouts.gif)