### PR TITLE
feat(sim): base_orientation flat-orientation reward term for the predicate/reward DSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1150,6 +1150,23 @@ and stilting cost the same. On a fixed-base arm (no floating base) the term
 degrades to `0.0` and logs the missing base once, consistent with the DSL's
 other name-resolution degradation.
 
+### Added: base_orientation locomotion-regularizer reward term for the predicate/reward DSL
+
+The dense-reward DSL grew a `base_orientation` term: `-weight * (g_x ** 2 + g_y ** 2)`,
+where `(g_x, g_y, g_z)` is the world gravity direction expressed in a floating
+base's frame (the "projected gravity" a legged controller reads), derived from
+`get_observation`'s `base_quat` signal. It is the standard legged_gym / IsaacLab
+`orientation` regularizer and the third piece of a minimal velocity-tracking
+reward: `base_velocity` alone is degenerate (a policy can crouch OR lean to cheat
+the forward-velocity reward), so a viable locomotion reward pairs `base_velocity`
+with `base_height` (which stops crouch-cheating) AND `base_orientation` (which
+stops lean/tilt-cheating) in one `dense_reward` list (the terms sum per step). The
+penalty is 0 when the base is level, grows as `-weight * sin(theta) ** 2` for a
+roll/pitch of `theta`, and is invariant to yaw -- a policy may turn freely while
+walking upright, only roll/pitch off level is penalised. On a fixed-base arm (no
+floating base) the term degrades to `0.0` and logs the missing base once,
+consistent with the DSL's other name-resolution degradation.
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/simulation/predicates.py
+++ b/strands_robots/simulation/predicates.py
@@ -344,6 +344,30 @@ def _base_position(sim: SimEngine, robot: str | None) -> list[float] | None:
     return [float(pos[0]), float(pos[1]), float(pos[2])]
 
 
+def _base_quaternion(sim: SimEngine, robot: str | None) -> list[float] | None:
+    """Return a floating base's orientation quaternion ``[w, x, y, z]``, or None.
+
+    Reads ``get_observation``'s ``base_quat`` floating-base signal (MuJoCo and
+    Newton both report ``[w, x, y, z]``). Returns None (and warns once) when the
+    robot exposes no floating base (a fixed-base arm) - almost always a spec
+    referencing a base term on a robot that has no base orientation.
+    """
+    try:
+        obs = sim.get_observation(robot_name=robot, skip_images=True)
+    except Exception as e:  # noqa: BLE001 - defensive: predicates never raise
+        logger.debug("base_orientation get_observation(%r) failed: %s", robot, e)
+        return None
+    if not isinstance(obs, dict):
+        return None
+    quat = obs.get("base_quat")
+    if not (isinstance(quat, list) and len(quat) == 4):
+        # A floating base surfaces base_quat; its absence means this robot has
+        # no floating base (a fixed-base arm) - almost always a spec error.
+        _warn_unresolved("robot base", robot or "<sole robot>")
+        return None
+    return [float(quat[0]), float(quat[1]), float(quat[2]), float(quat[3])]
+
+
 # Predicate factories
 
 
@@ -825,6 +849,43 @@ def _base_height(target: float, weight: float = 1.0, robot: str | None = None) -
     return term
 
 
+def _base_orientation(weight: float = 1.0, robot: str | None = None) -> RewardTerm:
+    """Negative flat-orientation error - the locomotion base-orientation regularizer.
+
+    Penalises a floating-base robot for tilting (roll/pitch) away from level:
+    ``-weight * (g_x ** 2 + g_y ** 2)`` where ``(g_x, g_y, g_z)`` is the world
+    gravity direction expressed in the base frame (the "projected gravity" a
+    legged controller reads). When the base is level the projected gravity is
+    ``(0, 0, -1)`` so the penalty is 0; a roll or pitch of ``theta`` makes the xy
+    magnitude ``sin(theta)`` so the penalty grows as ``-weight * sin(theta) ** 2``.
+    This is the standard legged_gym / IsaacLab ``orientation`` term and the third
+    piece of a minimal velocity-tracking reward: ``base_velocity`` alone is
+    degenerate (a policy can crouch OR lean to cheat the forward-velocity
+    reward), so a viable locomotion reward pairs it with ``base_height`` (which
+    stops crouch-cheating) AND ``base_orientation`` (which stops lean/tilt-
+    cheating) in one ``dense_reward`` list.
+
+    Crucially the penalty is invariant to YAW (heading): a robot may turn freely
+    while walking upright, only roll/pitch off level is penalised. Reads
+    ``get_observation``'s ``base_quat`` (``[w, x, y, z]`` on both backends).
+    Requires a robot with a floating base; a fixed-base arm has no base
+    orientation, so the term degrades to ``0.0`` and the missing base is logged
+    once. ``robot`` selects the robot in a multi-robot scene (default: the sole
+    robot).
+    """
+    w = float(weight)
+    rname = robot
+
+    def term(sim: SimEngine) -> float:
+        quat = _base_quaternion(sim, rname)
+        if quat is None:
+            return 0.0
+        gx, gy, _gz = _quat_rotate_inverse_wxyz(quat, [0.0, 0.0, -1.0])
+        return -w * float(gx * gx + gy * gy)
+
+    return term
+
+
 # Stateful reward terms (declarative phase machine)
 #
 # A plain RewardTerm is stateless: ``(SimEngine) -> float``. Some rewards need
@@ -1001,6 +1062,7 @@ PREDICATE_REGISTRY: dict[str, PredicateFactory] = {
     "joint_progress": _joint_progress,
     "base_velocity": _base_velocity,
     "base_height": _base_height,
+    "base_orientation": _base_orientation,
     "constant": _constant,
     # stateful (phase machine)
     "staged_reward": _staged_reward,

--- a/tests/simulation/test_base_orientation_reward.py
+++ b/tests/simulation/test_base_orientation_reward.py
@@ -1,0 +1,181 @@
+"""Regression tests for the ``base_orientation`` locomotion-regularizer reward term.
+
+The predicate/reward DSL grew a ``base_orientation`` reward term:
+``-weight * (g_x ** 2 + g_y ** 2)``, where ``(g_x, g_y, g_z)`` is the world
+gravity direction expressed in the floating base's frame (the "projected
+gravity" a legged controller reads), derived from ``get_observation``'s
+``base_quat`` signal. It is the standard legged_gym / IsaacLab ``orientation``
+regularizer and the third piece of a minimal velocity-tracking reward:
+``base_velocity`` alone is degenerate (a policy can crouch OR lean to cheat the
+forward velocity), so a viable locomotion reward pairs ``base_velocity`` with
+``base_height`` (stops crouch-cheating) AND ``base_orientation`` (stops
+lean/tilt-cheating) in one ``dense_reward`` list (they sum per step).
+
+These tests set a KNOWN base orientation directly on the sim and assert the
+term computes the correct negative squared projected-gravity error - 0 when
+level, ``-sin(theta) ** 2`` at a roll/pitch of ``theta``, symmetric across roll
+and pitch, INVARIANT to yaw (heading), scaled by ``weight`` - and that it
+degrades to ``0.0`` (with a warning) on a fixed-base arm that has no base
+orientation. They are GL-free (get_observation with skip_images) so they run in
+CI without a display.
+"""
+
+import logging
+import math
+import os
+import tempfile
+
+import mujoco
+import pytest
+
+from strands_robots.simulation.mujoco.simulation import Simulation
+from strands_robots.simulation.predicates import (
+    _reset_resolution_warnings,
+    make_predicate,
+)
+
+# Floating base with a NAMED free joint (a humanoid's floating_base_joint) plus
+# one actuated hinge. get_observation surfaces base_quat for this robot.
+NAMED_BASE_XML = """
+<mujoco model="test_named_base">
+  <compiler angle="radian" autolimits="true"/>
+  <option timestep="0.002"/>
+  <worldbody>
+    <light name="main" pos="0 0 3" dir="0 0 -1"/>
+    <geom name="ground" type="plane" size="5 5 0.01" rgba="0.9 0.9 0.9 1"/>
+    <body name="pelvis" pos="0 0 0.8">
+      <freejoint name="floating_base_joint"/>
+      <geom type="box" size="0.1 0.1 0.1" rgba="0.3 0.3 0.8 1"/>
+      <body name="thigh" pos="0 0 -0.1">
+        <geom type="capsule" size="0.03" fromto="0 0 0 0 0 -0.3" rgba="0.8 0.3 0.3 1"/>
+        <joint name="hip" type="hinge" axis="0 1 0" range="-1.5 1.5"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <motor name="hip_act" joint="hip"/>
+  </actuator>
+</mujoco>
+"""
+
+# Fixed-base arm: no free joint anywhere -> no base orientation. base_orientation
+# must degrade to 0.0 (and warn) rather than crash or invent a value.
+FIXED_ARM_XML = """
+<mujoco model="test_fixed">
+  <compiler angle="radian" autolimits="true"/>
+  <worldbody>
+    <light name="main" pos="0 0 3" dir="0 0 -1"/>
+    <body name="link" pos="0 0 0.1">
+      <geom type="capsule" size="0.02" fromto="0 0 0 0 0 0.2"/>
+      <joint name="j0" type="hinge" axis="0 0 1"/>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="j0_act" joint="j0" kp="10"/>
+  </actuator>
+</mujoco>
+"""
+
+
+def _axis_quat(axis: str, deg: float) -> list[float]:
+    """Unit (w, x, y, z) quaternion for a rotation of ``deg`` about a world axis."""
+    h = math.radians(deg) / 2.0
+    c, sn = math.cos(h), math.sin(h)
+    return {
+        "x": [c, sn, 0.0, 0.0],
+        "y": [c, 0.0, sn, 0.0],
+        "z": [c, 0.0, 0.0, sn],
+    }[axis]
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="test_base_orientation", mesh=False)
+    s.create_world(ground_plane=False)
+    yield s
+    s.cleanup()
+
+
+def _write(xml: str) -> str:
+    d = tempfile.mkdtemp()
+    p = os.path.join(d, "model.xml")
+    with open(p, "w") as f:
+        f.write(xml)
+    return p
+
+
+def _set_base_quat(sim, quat_wxyz: list[float]) -> None:
+    """Set the robot's (only) free joint to a fixed world height with orientation quat."""
+    model, data = sim._world._model, sim._world._data
+    jid = -1
+    for j in range(model.njnt):
+        if model.jnt_type[j] == mujoco.mjtJoint.mjJNT_FREE:
+            jid = j
+            break
+    assert jid >= 0
+    qadr = int(model.jnt_qposadr[jid])
+    data.qpos[qadr : qadr + 7] = [0.0, 0.0, 0.8, *quat_wxyz]
+    mujoco.mj_forward(model, data)
+
+
+def test_base_orientation_is_zero_when_level(sim):
+    """Reward is 0 when the base is perfectly level (projected gravity = (0,0,-1))."""
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    _set_base_quat(sim, [1.0, 0.0, 0.0, 0.0])
+    assert make_predicate("base_orientation")(sim) == pytest.approx(0.0, abs=1e-6)
+
+
+def test_base_orientation_is_negative_squared_projected_gravity(sim):
+    """A roll of theta gives projected-gravity xy magnitude sin(theta):
+    reward = -weight * sin(theta)**2."""
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    _set_base_quat(sim, _axis_quat("x", 30.0))
+    expected = -(math.sin(math.radians(30.0)) ** 2)  # = -0.25
+    assert make_predicate("base_orientation")(sim) == pytest.approx(expected, abs=1e-6)
+    # weight scales the penalty linearly.
+    assert make_predicate("base_orientation", weight=4.0)(sim) == pytest.approx(4.0 * expected, abs=1e-6)
+
+
+def test_base_orientation_penalty_is_symmetric_roll_and_pitch(sim):
+    """A pitch of theta is penalised identically to a roll of theta (isotropic tilt)."""
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    term = make_predicate("base_orientation")
+    _set_base_quat(sim, _axis_quat("x", 20.0))
+    roll = term(sim)
+    _set_base_quat(sim, _axis_quat("y", 20.0))
+    pitch = term(sim)
+    assert roll == pytest.approx(pitch, abs=1e-6)
+    assert roll == pytest.approx(-(math.sin(math.radians(20.0)) ** 2), abs=1e-6)
+
+
+def test_base_orientation_is_invariant_to_yaw(sim):
+    """Pure yaw (heading change) keeps the base level -> zero penalty. This is what
+    makes it a flat-orientation regularizer and not a heading penalty: a walking
+    policy may turn freely, only roll/pitch off level costs reward."""
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    term = make_predicate("base_orientation")
+    for yaw in (45.0, 90.0, 179.0):
+        _set_base_quat(sim, _axis_quat("z", yaw))
+        assert term(sim) == pytest.approx(0.0, abs=1e-6), f"yaw {yaw} should not be penalised"
+
+
+def test_base_orientation_tracks_the_live_base_orientation(sim):
+    """The reward reads the CURRENT base orientation: tipping the base changes it."""
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    term = make_predicate("base_orientation")
+    _set_base_quat(sim, [1.0, 0.0, 0.0, 0.0])
+    assert term(sim) == pytest.approx(0.0, abs=1e-6)
+    _set_base_quat(sim, _axis_quat("y", 45.0))
+    assert term(sim) == pytest.approx(-(math.sin(math.radians(45.0)) ** 2), abs=1e-6)
+
+
+def test_base_orientation_degrades_to_zero_on_fixed_base_arm(sim, caplog):
+    """A fixed-base arm has no base orientation: the term degrades to 0.0 and warns."""
+    sim.add_robot("arm", urdf_path=_write(FIXED_ARM_XML))
+    # Reset the module-global warn-once dedup so this assertion is independent of
+    # what other predicate tests warned first (the "robot base" key is shared).
+    _reset_resolution_warnings()
+    with caplog.at_level(logging.WARNING, logger="strands_robots.simulation.predicates"):
+        val = make_predicate("base_orientation")(sim)
+    assert val == 0.0
+    assert any("base" in r.message.lower() for r in caplog.records)


### PR DESCRIPTION
## What

Adds a `base_orientation` dense-reward term to the predicate/reward DSL:

```
-weight * (g_x ** 2 + g_y ** 2)
```

where `(g_x, g_y, g_z)` is the world gravity direction expressed in a floating base's frame (the "projected gravity" a legged controller reads), derived from `get_observation`'s `base_quat` signal.

## Why

This is the standard legged_gym / IsaacLab `orientation` regularizer and the **third and final piece of a minimal velocity-tracking locomotion reward**. The DSL already ships `base_velocity` (lin/yaw velocity tracking) and `base_height` (crouch/dive regularizer). But `base_velocity` alone is degenerate on **two** axes: a policy can *crouch* to cheat the forward-velocity reward (which `base_height` fixes) **or** *lean/tilt* to cheat it (which nothing currently fixes). `base_orientation` is the direct sibling of `base_height`: it stops lean/tilt-cheating exactly as `base_height` stops crouch-cheating. A viable velocity-tracking reward composes all three in one `dense_reward` list (they sum per step).

## Behaviour

- Penalty is **0 when the base is level** (projected gravity `(0, 0, -1)`).
- Grows as `-weight * sin(theta) ** 2` for a roll/pitch of `theta`.
- **Invariant to yaw (heading)** -- a policy may turn freely while walking upright; only roll/pitch off level is penalised. This is what makes it a *flat-orientation* regularizer and not a heading penalty.
- Requires a robot with a floating base. On a fixed-base arm (no `base_quat`) it degrades to `0.0` and logs the missing base once, consistent with the DSL's other name-resolution degradations.

Implementation is numpy-free: a new `_base_quaternion` helper (mirrors `_base_position`) reads `base_quat`, and the term reuses the already-verified `_quat_rotate_inverse_wxyz` for the projected-gravity rotation.

## Verification

Projected-gravity math validated on a real MuJoCo floating base (`get_observation` -> `base_quat` -> `_quat_rotate_inverse_wxyz`):

| pose | projected-gravity xy^2 | expected |
|---|---|---|
| upright | 0.00000 | 0 |
| roll 30 deg | 0.25000 | sin^2(30) = 0.25 |
| pitch 30 deg | 0.25000 | sin^2(30) = 0.25 |
| yaw 90 deg | 0.00000 | 0 (yaw-invariant) |

Composition on a real `DeclarativeBenchmark.from_dict` with `dense_reward: [base_velocity, base_orientation]` -- both poses have identical (zero) velocity, so `base_velocity` alone cannot tell them apart:

| pose | base_velocity only | base_velocity + base_orientation |
|---|---|---|
| UPRIGHT | 0.0000 | 0.0000 |
| LEAN pitch 25 deg | 0.0000 | -0.1786 |
| LEAN roll 25 deg | 0.0000 | -0.1786 |

(`-0.1786 = -sin^2(25)`.) The composed reward is ideal `0.0` for upright and negative for the leaner, exactly the tie the orientation regularizer is meant to break.

## Tests

`tests/simulation/test_base_orientation_reward.py` (GL-free, sets a known base orientation directly on the sim): 0 when level, `-sin(theta)**2` at roll/pitch `theta`, symmetric across roll and pitch, **invariant to yaw**, tracks the live orientation, and degrades to `0.0` + warns on a fixed-base arm. All 6 fail before the change (`Unknown predicate 'base_orientation'`) and pass after; the full predicate/reward/benchmark suite (197 tests) stays green. `ruff` + `ruff format` + `mypy` clean.

No visual artifact: this is a reward-DSL scalar over `get_observation`, matching the `base_velocity` / `base_height` precedent -- the fails-before numeric table is the proof.

---

## S13 - Round changelog

| Round | Concern | Fix commit | Pin test |
|---|---|---|---|
| R1 | CHANGELOG.md merge conflict with upstream/main (observation-history fix merged after branch point) | `06cdf25` | tests/simulation/test_base_orientation_reward.py (unchanged, all 6 pass) |