### PR TITLE
test(sim): pin base_velocity/base_height reward-term degradation contract

### DIFF
--- a/tests/simulation/test_reward_term_degradation.py
+++ b/tests/simulation/test_reward_term_degradation.py
@@ -1,0 +1,85 @@
+"""Robustness/degradation contract for the locomotion reward-DSL terms.
+
+The ``base_velocity`` and ``base_height`` reward terms read a floating base's
+state from ``get_observation``. Their documented contract is that they NEVER
+propagate an error and NEVER invent a value: when the backend cannot supply a
+usable observation - it raises, or returns something that is not a dict - the
+term degrades to ``0.0`` (the same constant a fixed-base arm produces). This
+mirrors the wider DSL rule that "predicates never raise".
+
+Separately, the pure-Python world->body rotation ``_quat_rotate_inverse_wxyz``
+guards a degenerate (near-zero-norm) quaternion by returning the input vector
+unchanged rather than dividing by ~0.
+
+These paths are exercised through the public ``make_predicate`` reward-term
+surface with a minimal stub engine, plus a direct call to the documented
+degenerate-quaternion guard. They are GL-free and need no display.
+"""
+
+import pytest
+
+from strands_robots.simulation.predicates import (
+    _quat_rotate_inverse_wxyz,
+    make_predicate,
+)
+
+
+class _RaisingEngine:
+    """Minimal engine stub whose ``get_observation`` always raises.
+
+    A reward term must swallow this and degrade to 0.0 - it may not let a
+    backend fault escape into the reward/benchmark loop.
+    """
+
+    def get_observation(self, robot_name=None, skip_images=False):
+        raise RuntimeError("backend observation unavailable")
+
+
+class _NonDictEngine:
+    """Engine stub whose ``get_observation`` returns a non-dict.
+
+    Some backends can return ``None`` (or another non-mapping) before a world
+    is fully initialised; the term must treat that as "no base" and degrade.
+    """
+
+    def __init__(self, value):
+        self._value = value
+
+    def get_observation(self, robot_name=None, skip_images=False):
+        return self._value
+
+
+@pytest.mark.parametrize(
+    "term_name, kwargs",
+    [
+        ("base_velocity", {"vx": 0.5}),
+        ("base_height", {"target": 0.74}),
+    ],
+)
+def test_reward_term_degrades_to_zero_when_observation_raises(term_name, kwargs):
+    """A backend error inside get_observation degrades the term to 0.0, not a raise."""
+    term = make_predicate(term_name, **kwargs)
+    assert term(_RaisingEngine()) == 0.0
+
+
+@pytest.mark.parametrize(
+    "term_name, kwargs",
+    [
+        ("base_velocity", {"vx": 0.5}),
+        ("base_height", {"target": 0.74}),
+    ],
+)
+@pytest.mark.parametrize("bad_obs", [None, [1, 2, 3], "not-a-dict"])
+def test_reward_term_degrades_to_zero_when_observation_not_a_dict(term_name, kwargs, bad_obs):
+    """A non-dict observation is treated as "no floating base": the term is 0.0."""
+    term = make_predicate(term_name, **kwargs)
+    assert term(_NonDictEngine(bad_obs)) == 0.0
+
+
+def test_quat_rotate_inverse_returns_input_unchanged_for_degenerate_quaternion():
+    """A near-zero-norm quaternion cannot define a rotation, so the vector is
+    returned unchanged instead of dividing by ~0 (documented guard)."""
+    vec = [1.1, -2.2, 3.3]
+    assert _quat_rotate_inverse_wxyz([0.0, 0.0, 0.0, 0.0], vec) == pytest.approx(vec, abs=1e-12)
+    # A sub-threshold-norm quaternion takes the same guard.
+    assert _quat_rotate_inverse_wxyz([1e-12, 0.0, 0.0, 0.0], vec) == pytest.approx(vec, abs=1e-12)


### PR DESCRIPTION
## What

Adds GL-free regression tests pinning the documented robustness contract of the locomotion reward-DSL terms (`base_velocity`, `base_height`) and the pure-Python `_quat_rotate_inverse_wxyz` guard. These paths were unexercised, leaving `strands_robots/simulation/predicates.py` at 98% (9 uncovered lines): the observation-fault degradation branches and the degenerate-quaternion guard.

## Contract under test

The `base_velocity` and `base_height` reward terms read a floating base's state from `get_observation`. Their documented contract is that they never propagate an error and never invent a value: when the backend cannot supply a usable observation the term degrades to `0.0` (the same constant a fixed-base arm yields), consistent with the wider DSL rule that predicates never raise. Two previously-untested fault modes:

- `get_observation` raises -> term returns `0.0` (a backend fault must not escape into the reward/benchmark loop).
- `get_observation` returns a non-dict (`None`, a list, a string) -> treated as no floating base -> `0.0`.

Separately, `_quat_rotate_inverse_wxyz` guards a near-zero-norm quaternion by returning the input vector unchanged instead of dividing by ~0; this guard had no direct assertion.

## Tests

New `tests/simulation/test_reward_term_degradation.py` (9 cases):

- `test_reward_term_degrades_to_zero_when_observation_raises` (parametrized over both terms) - exercised through the public `make_predicate` surface with a minimal stub engine.
- `test_reward_term_degrades_to_zero_when_observation_not_a_dict` (both terms x {None, list, str}).
- `test_quat_rotate_inverse_returns_input_unchanged_for_degenerate_quaternion` (zero-norm and sub-threshold-norm).

All assert observable outputs, not internal state; no display / GL required.

## Coverage

`strands_robots/simulation/predicates.py`: 98% -> 100% (9 uncovered lines: 267, 298-300, 302, 333-335, 337 -> 0). No source change; behavior is unchanged.

## Verification

`python -m pytest tests/simulation/test_reward_term_degradation.py tests/simulation/test_base_velocity_reward.py tests/simulation/test_base_height_reward.py tests/simulation/test_benchmark_predicates.py` -> 121 passed, predicates.py at 100%. `ruff check`, `ruff format --check`, and `mypy` clean.