### PR TITLE
fix(registry): raise on unknown list_robots(mode=...) instead of silently returning every robot

### DIFF
--- a/strands_robots/registry/__init__.py
+++ b/strands_robots/registry/__init__.py
@@ -44,6 +44,7 @@ from .policies import (
     resolve_policy,
 )
 from .robots import (
+    LIST_ROBOTS_MODES,
     format_robot_table,
     get_hardware_type,
     get_robot,
@@ -69,6 +70,7 @@ __all__ = [
     "has_hardware",
     "get_hardware_type",
     "list_robots",
+    "LIST_ROBOTS_MODES",
     "list_robots_by_category",
     "list_aliases",
     "format_robot_table",

--- a/strands_robots/registry/robots.py
+++ b/strands_robots/registry/robots.py
@@ -12,6 +12,12 @@ from .loader import _load
 
 logger = logging.getLogger(__name__)
 
+# Recognised filter values for ``list_robots(mode=...)``. Any other value is
+# rejected with a ``ValueError`` rather than silently returning every robot,
+# so a typo or an unsupported filter fails loudly instead of yielding a
+# misleading unfiltered list (e.g. ``mode="hardware"`` returning sim-only arms).
+LIST_ROBOTS_MODES = ("all", "sim", "real", "both")
+
 
 def _build_alias_map() -> dict[str, str]:
     """Build alias → canonical name mapping from robot entries.
@@ -103,11 +109,23 @@ def list_robots(mode: str = "all") -> list[dict[str, Any]]:
     """List available robots, optionally filtered.
 
     Args:
-        mode: Filter - "all", "sim", "real", or "both" (has sim AND real).
+        mode: Filter, one of :data:`LIST_ROBOTS_MODES`:
+
+            - ``"all"``: every registered robot (no filter).
+            - ``"sim"``: robots with a simulation asset (``has_sim``).
+            - ``"real"``: robots with a hardware backend (``has_real``).
+            - ``"both"``: robots that have BOTH sim and real.
 
     Returns:
-        List of dicts with name, description, has_sim, has_real.
+        List of dicts with name, description, category, joints, has_sim, has_real.
+
+    Raises:
+        ValueError: If ``mode`` is not one of :data:`LIST_ROBOTS_MODES`. An
+            unrecognized filter is rejected loudly instead of silently
+            returning the full, unfiltered list.
     """
+    if mode not in LIST_ROBOTS_MODES:
+        raise ValueError(f"Unknown list_robots mode {mode!r}. Valid modes: {', '.join(LIST_ROBOTS_MODES)}.")
     reg = _load("robots")
     results = []
     for name, info in sorted(reg.get("robots", {}).items()):

--- a/tests/registry/test_public_api.py
+++ b/tests/registry/test_public_api.py
@@ -6,6 +6,7 @@ from strands_robots.registry import get_policy_provider, list_policy_providers, 
 from strands_robots.registry.loader import _load, _validate, reload
 from strands_robots.registry.policies import build_policy_kwargs, import_policy_class
 from strands_robots.registry.robots import (
+    LIST_ROBOTS_MODES,
     format_robot_table,
     get_hardware_type,
     get_robot,
@@ -394,6 +395,28 @@ class TestRobotRegistry:
         assert "lekiwi" in names  # sim + real
         assert "reachy2" not in names
         assert "ur5e" not in names
+
+    def test_list_robots_unknown_mode_raises(self):
+        # A plausible-but-unsupported filter (hardware-capable robots) must not
+        # silently return the full, unfiltered list - that would mislead a
+        # caller into thinking every robot is hardware-backed. It raises instead.
+        with pytest.raises(ValueError, match="Unknown list_robots mode 'hardware'"):
+            list_robots("hardware")
+
+    def test_list_robots_typo_mode_raises_and_lists_valid_modes(self):
+        # A typo is rejected loudly, and the message enumerates the valid modes
+        # so the caller can self-correct without reading the source.
+        with pytest.raises(ValueError) as excinfo:
+            list_robots("sims")
+        msg = str(excinfo.value)
+        for valid in ("all", "sim", "real", "both"):
+            assert valid in msg
+
+    def test_list_robots_all_documented_modes_accepted(self):
+        # Every value advertised in LIST_ROBOTS_MODES must be accepted without
+        # raising, guarding the constant and the validation set against drift.
+        for mode in LIST_ROBOTS_MODES:
+            assert isinstance(list_robots(mode), list)
 
     def test_list_robots_by_category(self):
         by_cat = list_robots_by_category()


### PR DESCRIPTION
## Problem

`list_robots(mode=...)` only recognised `"sim"`, `"real"`, and `"both"` as filters. Any other value fell through every guard and silently returned the full, unfiltered list:

```python
>>> from strands_robots.registry import list_robots
>>> len(list_robots("all"))
73
>>> len(list_robots("hardware"))   # not a supported filter
73                                   # <- silently returns everything
>>> len(list_robots("sims"))        # typo for "sim"
73                                   # <- silently returns everything
```

This is a silent wrong-result. A caller asking for `"hardware"` (a plausible guess, given `has_hardware()` / `get_hardware_type()` exist) gets all 73 robots and would reasonably conclude every one is hardware-backed. A typo (`"sims"`) is indistinguishable from a valid unfiltered call. Both contradict the library contract of raising on fatal input rather than warn-and-continue with a silent default.

## Change

Validate `mode` against a new public `LIST_ROBOTS_MODES = ("all", "sim", "real", "both")` tuple at function entry and raise `ValueError` enumerating the valid filters:

```python
>>> list_robots("hardware")
ValueError: Unknown list_robots mode 'hardware'. Valid modes: all, sim, real, both.
```

The constant is exported from `strands_robots.registry` so callers can introspect the allowed values instead of reading the source. The docstring now lists each mode and documents the raise. All internal callers already pass `mode="sim"`, so no call sites change.

## Tests

`tests/registry/test_public_api.py`:
- `test_list_robots_unknown_mode_raises` - `"hardware"` raises `ValueError` (fails on pre-fix code, which returned all 73 robots).
- `test_list_robots_typo_mode_raises_and_lists_valid_modes` - a typo raises and the message enumerates every valid mode.
- `test_list_robots_all_documented_modes_accepted` - guards `LIST_ROBOTS_MODES` and the validation set against drift.

Both error-path tests fail against the pre-fix implementation (`DID NOT RAISE ValueError`) and pass after. Full `tests/registry/` suite (519 tests) green; ruff + mypy clean.

No behavior change to sim/rendering/recording/policies/assets - this is a registry-query input-validation fix, so no rollout artifact applies.