### PR TITLE
feat(policies): lerobot_async provider - remote inference over lerobot's gRPC async transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,6 +566,7 @@ create_policy("lerobot/act_aloha_sim_transfer_cube")   # local HF inference
 | `groot` | NVIDIA GR00T N1.5/N1.6/N1.7 | Service mode (ZMQ to a Docker container) or local in-process (`model_path=`) |
 | `cosmos3` | NVIDIA Cosmos 3 omnimodal VLA | Service mode (WebSocket to a Cosmos Framework RoboLab policy server); embodiments: `droid`, `umi`, `av`, `bridge` |
 | `lerobot_local` | HuggingFace | Direct ACT / Pi0 / SmolVLA / Diffusion inference, no server |
+| `lerobot_async` | HuggingFace via gRPC | Offload a LeRobot policy to a remote `PolicyServer` over lerobot's native async-inference gRPC transport (edge/light robot host) |
 | `vera` | MIT VERA (DFoT/WAN planner + Jacobian IDM) | Two-stage video-to-action over a WebSocket GPU server (Docker); PushT + MimicGen, IK for eef-delta arms. **Git-only** (not on PyPI, no extra): `pip install 'vera @ git+https://github.com/sizhe-li/VERA.git'` plus `websockets msgpack numpy` |
 
 ```mermaid

--- a/docs/policies/lerobot-async.md
+++ b/docs/policies/lerobot-async.md
@@ -1,0 +1,101 @@
+# LeRobot Async (gRPC inference)
+
+`create_policy("lerobot_async", ...)` returns a `LerobotAsyncPolicy` - a drop-in
+[`Policy`](overview.md) that offloads inference to a remote LeRobot
+`PolicyServer` over LeRobot's **native async-inference gRPC transport**
+(`lerobot.async_inference.policy_server`). Every `get_actions` call forwards the
+current observation to the server, which runs the configured LeRobot policy
+(ACT, SmolVLA, diffusion, pi0/pi0.5, VQBeT, ...) on its own GPU and streams back
+an action chunk.
+
+Use it when the robot host is light (e.g. a Jetson) and a separate GPU box holds
+the weights. Unlike [`lerobot_local`](lerobot-local.md) (which loads the
+checkpoint in-process), the async client keeps the control loop off the GPU that
+runs the model - the same split as LeRobot's own `robot_client` / `policy_server`.
+
+For a WebSocket-based alternative served by this library's own
+`strands_robots.inference` server, see [`remote`](remote.md). `lerobot_async`
+differs in that it speaks LeRobot's gRPC protocol directly, so it interoperates
+with a stock `lerobot.async_inference.policy_server`.
+
+## Install
+
+```bash
+pip install 'strands-robots[lerobot-async]'   # adds grpcio on top of [lerobot]
+```
+
+## Start the server (GPU host)
+
+```bash
+pip install 'lerobot[async]'
+python -m lerobot.async_inference.policy_server --host=0.0.0.0 --port=8080
+```
+
+The server is generic: the **client** selects which checkpoint it loads (via the
+`SendPolicyInstructions` handshake), so `policy_type` and
+`pretrained_name_or_path` are required on the client.
+
+## Use it (robot host)
+
+```python
+from strands_robots import create_policy
+
+policy = create_policy(
+    "lerobot_async",
+    server_address="gpu-box:8080",
+    policy_type="act",
+    pretrained_name_or_path="lerobot/act_so101",
+)
+# smart string is equivalent (server_address parsed from the URL):
+policy = create_policy(
+    "grpc://gpu-box:8080",
+    policy_type="act",
+    pretrained_name_or_path="lerobot/act_so101",
+)
+```
+
+In simulation or a control loop it is a normal provider:
+
+```python
+from strands_robots import Robot
+
+sim = Robot("so101")  # sim by default
+sim.run_policy(
+    robot_name="so101",
+    policy_provider="lerobot_async",
+    policy_config={
+        "server_address": "gpu-box:8080",
+        "policy_type": "act",
+        "pretrained_name_or_path": "lerobot/act_so101",
+    },
+    instruction="pick up the cube",
+    duration=10.0,
+)
+```
+
+## Config keys
+
+| Config key                 | Default       | Meaning                                                     |
+|----------------------------|---------------|-------------------------------------------------------------|
+| `server_address`           | `127.0.0.1:8080` | Server `host:port` (gRPC); wins over `host`/`port`. `grpc://` scheme stripped |
+| `host`                     | `127.0.0.1`   | Server host (when `server_address` is omitted)              |
+| `port`                     | `8080`        | Server port (when `server_address` is omitted)              |
+| `policy_type`              | -             | **Required.** LeRobot policy type the server loads (`act`, `smolvla`, `diffusion`, `tdmpc`, `vqbet`, `pi0`, `pi05`, `groot`) |
+| `pretrained_name_or_path`  | -             | **Required.** HuggingFace id or path the server loads       |
+| `device`                   | `cuda`        | Device for **server-side** inference; set `cpu` for a CPU server |
+| `actions_per_chunk`        | `50`          | Max actions the server returns per chunk                    |
+| `actions_per_step`         | `actions_per_chunk` | Actions executed from one chunk before re-querying (the re-query interval) |
+| `connect_timeout`          | `10.0`        | Seconds to wait for the gRPC `Ready` handshake              |
+| `request_timeout`          | `60.0`        | Seconds to wait for each observation/action RPC             |
+
+## Notes
+
+- The connection is established lazily on the first `get_actions`, so
+  constructing the policy does not require the server to be up yet.
+- If the server returns no actions for an observation (filtered out, or a
+  server-side inference error), the client **raises** rather than fabricating a
+  zero action - check the `PolicyServer` logs.
+- `set_robot_state_keys([...])` must be called with the robot's joint/motor
+  names before inference; those scalars are concatenated into
+  `observation.state` and any RGB/depth camera arrays are declared as image
+  features in the handshake.

--- a/docs/policies/overview.md
+++ b/docs/policies/overview.md
@@ -1,5 +1,5 @@
 ---
-description: The Policy ABC and every provider that ships - mock, groot, lerobot_local, cosmos3, vera, remote, curobo, moveit2, wbc, wbc_gait, motionbricks.
+description: The Policy ABC and every provider that ships - mock, groot, lerobot_local, lerobot_async, cosmos3, vera, remote, curobo, moveit2, wbc, wbc_gait, motionbricks.
 ---
 
 # Policy providers
@@ -9,7 +9,7 @@ truth - list every provider that `create_policy("<name>")` accepts with:
 
 ```bash
 python -c 'from strands_robots.policies import list_providers; print(list_providers())'
-# ['cosmos3', 'curobo', 'groot', 'lerobot_local', 'mock', 'motionbricks', 'moveit2', 'remote', 'vera', 'wbc', 'wbc_gait']
+# ['cosmos3', 'curobo', 'groot', 'lerobot_async', 'lerobot_local', 'mock', 'motionbricks', 'moveit2', 'remote', 'vera', 'wbc', 'wbc_gait']
 ```
 
 ```python
@@ -36,6 +36,7 @@ is kept in sync with `list_providers()` by a regression test
 | [`mock`](custom-policies.md) | `MockPolicy` | _(core)_ | Tests, smoke checks; sinusoidal joints, no GPU. Reference minimal `Policy` (documented inline + custom-policies) |
 | [`groot`](groot.md) | `Gr00tPolicy` | `groot-service` | NVIDIA GR00T N1.5/N1.6/N1.7 over ZMQ |
 | [`lerobot_local`](lerobot-local.md) | `LerobotLocalPolicy` | `lerobot` | HF LeRobot in-process (ACT, Pi0, SmolVLA, MolmoAct2, ...) |
+| [`lerobot_async`](lerobot-async.md) | `LerobotAsyncPolicy` | `lerobot-async` | Offload a LeRobot policy to a GPU box over lerobot's native async-inference gRPC transport; the robot host stays light. Edge-device inference |
 | [`cosmos3`](cosmos3.md) | `Cosmos3Policy` | `cosmos3-service` | NVIDIA Cosmos 3 omnimodal VLA over WebSocket |
 | [`vera`](vera.md) | `VeraPolicy` | `vera` | MIT VERA video-to-action (DFoT/WAN planner + Jacobian IDM) over a containerized GPU server |
 | [`remote`](remote.md) | `RemotePolicy` | `inference` | Offload a large policy to a GPU box: forward observations to a remote `PolicyServer` over WebSocket, get back action chunks. Edge-device inference |
@@ -96,6 +97,7 @@ sim.run_policy(robot_name="so100", instruction="pick up the cube",
 
 - [GR00T](groot.md) - ZMQ server, 27 embodiments, container lifecycle.
 - [LeRobot Local](lerobot-local.md) - in-process HF models, RTC.
+- [LeRobot Async](lerobot-async.md) - offload a LeRobot policy to a gRPC `PolicyServer` (edge offload).
 - [MolmoAct2 (SO-100/101)](molmoact2.md) - action/observation contract for the SO-arm checkpoints.
 - [Persistent worker](persistent-worker.md) - load once, reuse across rollouts; cache controls + telemetry.
 - [Cosmos 3](cosmos3.md) - NVIDIA Cosmos 3 omnimodal VLA.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
   - WBC Gait-Clock Variant: policies/wbc_gait.md
   - MotionBricks (G1 generative motion): policies/motionbricks.md
   - LeRobot Local: policies/lerobot-local.md
+  - LeRobot Async (gRPC inference): policies/lerobot-async.md
   - MolmoAct2 (SO-100/101): policies/molmoact2.md
   - Remote (WebSocket inference): policies/remote.md
   - Camera Naming: policies/camera-naming.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,6 +181,16 @@ lerobot = [
     # index -- see the README Installation section for the Thor/Jetson caveat.
     "lerobot[feetech,dataset]>=0.6.0,<0.7.0",
 ]
+# Remote/offloaded inference via lerobot's native async-inference gRPC
+# transport (the `lerobot_async` policy provider, LerobotAsyncPolicy). Layers
+# grpcio on top of the base lerobot stack so a light robot host can drive a
+# policy running on a separate GPU server (lerobot.async_inference.policy_server).
+# Mirrors lerobot's own [async] extra dependency (grpcio) rather than pinning
+# it here, so the gRPC/protobuf floor tracks lerobot.
+lerobot-async = [
+    "strands-robots[lerobot]",
+    "lerobot[async]>=0.6.0,<0.7.0",
+]
 # MolmoAct2 transformers-native VLA (e.g. allenai/MolmoAct2-SO100_101). The
 # MolmoAct2Policy class ships in lerobot >= 0.6 (it landed via lerobot PR #3604
 # after the 0.5.1 PyPI release), so `strands-robots[molmoact2]` now resolves it
@@ -338,6 +348,7 @@ all = [
     "strands-robots[groot-service]",
     "strands-robots[moveit2]",
     "strands-robots[lerobot]",
+    "strands-robots[lerobot-async]",
     "strands-robots[sim-mujoco]",
     "strands-robots[mesh]",
     "strands-robots[mesh-iot]",

--- a/strands_robots/policies/lerobot_async/__init__.py
+++ b/strands_robots/policies/lerobot_async/__init__.py
@@ -1,0 +1,12 @@
+"""LeRobot async-inference client policy (gRPC bridge to a lerobot PolicyServer).
+
+Exposes :class:`LerobotAsyncPolicy`, a :class:`~strands_robots.policies.base.Policy`
+that offloads inference to a remote lerobot ``PolicyServer`` over gRPC. The heavy
+gRPC / lerobot transport imports are deferred to first use, so importing this
+package is cheap and does not require ``lerobot[async]`` to be installed until
+the policy is actually run.
+"""
+
+from strands_robots.policies.lerobot_async.policy import LerobotAsyncPolicy
+
+__all__ = ["LerobotAsyncPolicy"]

--- a/strands_robots/policies/lerobot_async/policy.py
+++ b/strands_robots/policies/lerobot_async/policy.py
@@ -1,0 +1,423 @@
+"""Remote lerobot inference over gRPC - client to a lerobot ``PolicyServer``.
+
+:class:`LerobotAsyncPolicy` is a drop-in :class:`~strands_robots.policies.base.Policy`
+that offloads inference to a remote lerobot ``PolicyServer`` (lerobot's native
+async-inference gRPC transport, ``lerobot.async_inference.policy_server``).
+Every :meth:`get_actions` call forwards the current observation to the server,
+which runs the configured lerobot policy (ACT, SmolVLA, diffusion, pi0/pi0.5,
+VQBeT, ...) on its own GPU and streams back an action chunk. Because it
+satisfies the ``Policy`` ABC it works anywhere a local policy does:
+``sim.run_policy(policy_provider="lerobot_async", ...)``,
+``sim.eval_policy(...)``, or a hardware control loop that calls
+:func:`~strands_robots.policies.create_policy`.
+
+Unlike ``lerobot_local`` (which loads the checkpoint in-process, tying the
+robot loop to the GPU that holds the weights), the async client keeps the robot
+side light: it sends observations and applies returned actions while the
+heavyweight model lives on a separate server. This mirrors lerobot's own
+``robot_client`` / ``policy_server`` split and is the right shape for edge
+robots (e.g. a Jetson) driven by a policy running on a datacentre GPU.
+
+Start the server first (on the GPU host)::
+
+    pip install 'lerobot[async]'
+    python -m lerobot.async_inference.policy_server --host=0.0.0.0 --port=8080
+
+Then point the client at it::
+
+    from strands_robots import create_policy
+
+    policy = create_policy(
+        "lerobot_async",
+        server_address="gpu-box:8080",
+        policy_type="act",
+        pretrained_name_or_path="lerobot/act_so101",
+    )
+    # or via a smart string (server_address parsed from the URL):
+    policy = create_policy(
+        "grpc://gpu-box:8080",
+        policy_type="act",
+        pretrained_name_or_path="lerobot/act_so101",
+    )
+
+The client selects which checkpoint the server loads (via lerobot's
+``SendPolicyInstructions`` handshake), so ``policy_type`` and
+``pretrained_name_or_path`` are required. The connection is established lazily
+on first :meth:`get_actions`, so constructing the policy does not require the
+server to be up yet.
+"""
+
+from __future__ import annotations
+
+import logging
+import pickle  # nosec B403 - lerobot's async transport serializes obs/actions with pickle
+import threading
+import time
+from typing import Any
+
+import numpy as np
+
+from strands_robots.policies.base import Policy
+from strands_robots.utils import require_optional
+
+logger = logging.getLogger(__name__)
+
+#: Policy types a lerobot ``PolicyServer`` can serve, mirroring
+#: ``lerobot.async_inference.constants.SUPPORTED_POLICIES``. Validated
+#: client-side so a typo fails fast with the valid set instead of only
+#: surfacing after the gRPC handshake.
+SUPPORTED_POLICY_TYPES: tuple[str, ...] = (
+    "act",
+    "smolvla",
+    "diffusion",
+    "tdmpc",
+    "vqbet",
+    "pi0",
+    "pi05",
+    "groot",
+)
+
+#: Default gRPC handshake timeout (seconds).
+DEFAULT_CONNECT_TIMEOUT = 10.0
+#: Default per-request timeout (seconds). A remote VLA chunk can take a while.
+DEFAULT_REQUEST_TIMEOUT = 60.0
+
+
+class LerobotAsyncPolicy(Policy):
+    """Client-side policy that runs inference on a remote lerobot ``PolicyServer``.
+
+    Args:
+        server_address: Server address as ``host:port`` (gRPC). When given it
+            takes precedence over ``host``/``port``. A ``grpc://`` scheme is
+            stripped if present.
+        host: Server host (used when ``server_address`` is not given).
+        port: Server port (used when ``server_address`` is not given).
+        policy_type: lerobot policy type the server should load (one of
+            :data:`SUPPORTED_POLICY_TYPES`). Required.
+        pretrained_name_or_path: HuggingFace model id or path the server loads.
+            Required.
+        device: Device string for **server-side** inference (e.g. ``"cuda"`` or
+            ``"cpu"``). Defaults to ``"cuda"`` - the async provider exists to
+            offload inference to a GPU host; override with ``device="cpu"`` for a
+            CPU server.
+        actions_per_chunk: Max number of actions the server returns per chunk.
+        actions_per_step: Number of actions the consumer executes from one chunk
+            before re-querying (the :attr:`execution_horizon`). Defaults to
+            ``actions_per_chunk`` so a chunked open-loop policy (ACT, diffusion)
+            executes the whole chunk per network round-trip instead of paying a
+            round-trip per control step.
+        connect_timeout: Seconds to wait for the gRPC ``Ready`` handshake.
+        request_timeout: Seconds to wait for each observation/action RPC.
+
+    Unrecognized kwargs are ignored (for forward-compatible ``policy_config``
+    passthrough via :func:`~strands_robots.policies.create_policy`) but logged
+    at WARNING, so a mistyped connection kwarg does not silently leave the
+    client pointed at the default address.
+
+    Raises:
+        ValueError: If ``policy_type`` / ``pretrained_name_or_path`` are missing
+            or ``policy_type`` is not server-supported.
+        ConnectionError: On first use, if the server cannot be reached.
+    """
+
+    def __init__(
+        self,
+        server_address: str | None = None,
+        *,
+        host: str = "127.0.0.1",
+        port: int = 8080,
+        policy_type: str | None = None,
+        pretrained_name_or_path: str | None = None,
+        device: str = "cuda",
+        actions_per_chunk: int = 50,
+        actions_per_step: int | None = None,
+        connect_timeout: float = DEFAULT_CONNECT_TIMEOUT,
+        request_timeout: float = DEFAULT_REQUEST_TIMEOUT,
+        **ignored_kwargs: Any,
+    ) -> None:
+        address = server_address or f"{host}:{port}"
+        if "://" in address:
+            address = address.split("://", 1)[1]
+        self.server_address = address
+
+        if not policy_type:
+            raise ValueError(
+                "lerobot_async requires policy_type=... (the lerobot policy the "
+                f"server loads); one of {SUPPORTED_POLICY_TYPES}."
+            )
+        if policy_type not in SUPPORTED_POLICY_TYPES:
+            raise ValueError(
+                f"policy_type {policy_type!r} is not served by a lerobot PolicyServer; "
+                f"choose one of {SUPPORTED_POLICY_TYPES}."
+            )
+        if not pretrained_name_or_path:
+            raise ValueError(
+                "lerobot_async requires pretrained_name_or_path=... (the checkpoint "
+                "the server loads via SendPolicyInstructions)."
+            )
+
+        self.policy_type = policy_type
+        self.pretrained_name_or_path = pretrained_name_or_path
+        self.device = device
+        self.actions_per_chunk = int(actions_per_chunk)
+        self.actions_per_step = int(actions_per_step) if actions_per_step is not None else self.actions_per_chunk
+        self.connect_timeout = connect_timeout
+        self.request_timeout = request_timeout
+
+        if ignored_kwargs:
+            logger.warning(
+                "LerobotAsyncPolicy ignoring unexpected constructor kwarg(s) %s; "
+                "connecting to %s. Set the server via server_address= (or host=/port=); "
+                "server-side policy config belongs on the PolicyServer, not the client.",
+                sorted(ignored_kwargs),
+                self.server_address,
+            )
+
+        self.robot_state_keys: list[str] = []
+
+        # Lazily initialised gRPC state (typed Any: modules imported on demand).
+        self._grpc: Any = None
+        self._pb2: Any = None
+        self._pb2_grpc: Any = None
+        self._channel: Any = None
+        self._stub: Any = None
+
+        self._instructions_sent = False
+        self._timestep = 0
+        self._lock = threading.Lock()
+
+    # -- Policy metadata ------------------------------------------------------
+
+    @property
+    def provider_name(self) -> str:
+        return "lerobot_async"
+
+    def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
+        self.robot_state_keys = list(robot_state_keys)
+
+    def reset(self, seed: int | None = None) -> None:
+        """Reset for a new episode.
+
+        Restarts the client timestep counter and, if already connected, calls
+        the server's ``Ready`` RPC. ``Ready`` flushes the server's observation
+        queue and predicted-timestep set (its per-episode state) while keeping
+        the loaded policy resident - so fresh observations in the next episode
+        are not deduped against the previous one's timesteps.
+
+        Args:
+            seed: Accepted for interface compatibility; the loaded policy's RNG
+                lives server-side and is not seedable through this transport.
+        """
+        self._timestep = 0
+        if self._stub is not None:
+            try:
+                self._stub.Ready(self._pb2.Empty(), timeout=self.request_timeout)
+            except self._grpc.RpcError as exc:  # pragma: no cover - network dependent
+                logger.warning("lerobot_async: server Ready() during reset failed: %s", exc)
+
+    # -- Connection lifecycle -------------------------------------------------
+
+    def _ensure_connected(self) -> None:
+        """Open the gRPC channel and complete the ``Ready`` handshake (idempotent)."""
+        if self._stub is not None:
+            return
+
+        grpc: Any = require_optional(
+            "grpc",
+            pip_install="grpcio",
+            extra="lerobot-async",
+            purpose="the lerobot async-inference gRPC transport",
+        )
+        from lerobot.transport import services_pb2, services_pb2_grpc
+        from lerobot.transport.utils import grpc_channel_options
+
+        self._grpc = grpc
+        self._pb2 = services_pb2
+        self._pb2_grpc = services_pb2_grpc
+        self._channel = grpc.insecure_channel(self.server_address, grpc_channel_options())
+        stub = services_pb2_grpc.AsyncInferenceStub(self._channel)
+        try:
+            stub.Ready(services_pb2.Empty(), timeout=self.connect_timeout)
+        except grpc.RpcError as exc:
+            self._channel.close()
+            self._channel = None
+            raise ConnectionError(
+                f"LerobotAsyncPolicy could not reach a lerobot PolicyServer at "
+                f"{self.server_address}. Start one first, e.g.:\n"
+                f"  python -m lerobot.async_inference.policy_server "
+                f"--host=0.0.0.0 --port={self.server_address.rsplit(':', 1)[-1]}\n"
+                f"Underlying error: {type(exc).__name__}: {exc}"
+            ) from exc
+        self._stub = stub
+        logger.info("LerobotAsyncPolicy connected to lerobot PolicyServer at %s", self.server_address)
+
+    def _send_instructions(self, lerobot_features: dict[str, Any]) -> None:
+        """Tell the server which checkpoint to load (lerobot ``SendPolicyInstructions``)."""
+        from lerobot.async_inference.helpers import RemotePolicyConfig
+
+        cfg = RemotePolicyConfig(
+            policy_type=self.policy_type,
+            pretrained_name_or_path=self.pretrained_name_or_path,
+            lerobot_features=lerobot_features,
+            actions_per_chunk=self.actions_per_chunk,
+            device=self.device,
+        )
+        self._stub.SendPolicyInstructions(
+            self._pb2.PolicySetup(data=pickle.dumps(cfg)),  # nosec B301
+            timeout=self.request_timeout,
+        )
+        self._instructions_sent = True
+        logger.info(
+            "lerobot_async: server loading %s (%s) on %s",
+            self.pretrained_name_or_path,
+            self.policy_type,
+            self.device,
+        )
+
+    def close(self) -> None:
+        """Close the gRPC channel. Safe to call more than once."""
+        with self._lock:
+            if self._channel is not None:
+                try:
+                    self._channel.close()
+                finally:
+                    self._channel = None
+                    self._stub = None
+
+    # -- Observation / action wire conversion ---------------------------------
+
+    def _camera_items(self, observation_dict: dict[str, Any]) -> list[tuple[str, np.ndarray]]:
+        """Return ``(key, HWC array)`` pairs for RGB/depth camera entries."""
+        cams: list[tuple[str, np.ndarray]] = []
+        for key, value in observation_dict.items():
+            if key in self.robot_state_keys or key == "task":
+                continue
+            arr = np.asarray(value)
+            if arr.ndim == 3 and arr.shape[2] in (1, 3):
+                cams.append((key, arr))
+        return cams
+
+    def _build_lerobot_features(self, observation_dict: dict[str, Any]) -> dict[str, Any]:
+        """Build the lerobot feature spec the server uses to decode observations.
+
+        Mirrors lerobot's ``hw_to_dataset_features`` over a hardware-feature map
+        assembled from the declared joint state keys (scalars concatenated into
+        ``observation.state``) and the camera keys present in the observation
+        (``observation.images.<name>``).
+        """
+        from lerobot.utils.constants import OBS_STR
+        from lerobot.utils.feature_utils import hw_to_dataset_features
+
+        if not self.robot_state_keys:
+            raise RuntimeError(
+                "lerobot_async: robot_state_keys is empty; call set_robot_state_keys() "
+                "with the robot's joint/motor names before inference."
+            )
+
+        hw_features: dict[str, Any] = {key: float for key in self.robot_state_keys}
+        for key, arr in self._camera_items(observation_dict):
+            hw_features[key] = tuple(int(d) for d in arr.shape)
+        return hw_to_dataset_features(hw_features, OBS_STR, use_video=False)
+
+    def _to_raw_observation(self, observation_dict: dict[str, Any], instruction: str) -> dict[str, Any]:
+        """Build the lerobot ``RawObservation`` the server expects."""
+        raw: dict[str, Any] = {}
+        for key in self.robot_state_keys:
+            if key not in observation_dict:
+                raise RuntimeError(
+                    f"lerobot_async: observation is missing declared state key {key!r}. "
+                    f"Declared keys: {self.robot_state_keys}; observation keys: "
+                    f"{sorted(observation_dict)}."
+                )
+            raw[key] = float(observation_dict[key])
+        for key, arr in self._camera_items(observation_dict):
+            raw[key] = arr
+        if instruction:
+            raw["task"] = instruction
+        return raw
+
+    def _request_action_chunk(self, raw_obs: dict[str, Any]) -> list[Any]:
+        """Send one observation and return the server's ``list[TimedAction]`` chunk."""
+        from lerobot.async_inference.helpers import TimedObservation
+        from lerobot.transport.utils import send_bytes_in_chunks
+
+        timed = TimedObservation(
+            timestamp=time.time(),
+            timestep=self._timestep,
+            observation=raw_obs,
+            must_go=True,
+        )
+        self._timestep += 1
+        payload = pickle.dumps(timed)  # nosec B301
+
+        self._stub.SendObservations(
+            send_bytes_in_chunks(payload, self._pb2.Observation),
+            timeout=self.request_timeout,
+        )
+        actions = self._stub.GetActions(self._pb2.Empty(), timeout=self.request_timeout)
+        data = getattr(actions, "data", b"")
+        if not data:
+            raise RuntimeError(
+                "lerobot_async: server returned no actions for the observation. The "
+                "observation was filtered out or server-side inference failed; check "
+                "the PolicyServer logs."
+            )
+        return pickle.loads(data)  # nosec B301
+
+    def _chunk_to_action_dicts(self, chunk: list[Any]) -> list[dict[str, Any]]:
+        """Convert the server's ``list[TimedAction]`` into per-tick action dicts.
+
+        Each ``TimedAction.action`` is a 1D tensor over the policy's action
+        dimensions; values are mapped to :attr:`robot_state_keys` by index and
+        the chunk is capped at :attr:`execution_horizon` (the re-query interval
+        the consumer drives).
+        """
+        if not self.robot_state_keys:
+            raise RuntimeError(
+                "lerobot_async: robot_state_keys is empty; call set_robot_state_keys() before inference."
+            )
+
+        result: list[dict[str, Any]] = []
+        for timed_action in chunk[: self.execution_horizon]:
+            action = timed_action.get_action() if hasattr(timed_action, "get_action") else timed_action.action
+            values = np.asarray(action.detach().cpu().numpy() if hasattr(action, "detach") else action).flatten()
+            result.append(
+                {key: (float(values[i]) if i < len(values) else 0.0) for i, key in enumerate(self.robot_state_keys)}
+            )
+        if not result:
+            raise RuntimeError("lerobot_async: server returned an empty action chunk.")
+        return result
+
+    # -- Inference ------------------------------------------------------------
+
+    async def get_actions(
+        self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any
+    ) -> list[dict[str, Any]]:
+        """Forward the observation to the remote server and return its action chunk.
+
+        On the first call the client connects, completes the ``Ready``
+        handshake, and sends the checkpoint-load instructions (built from the
+        declared state keys plus the cameras present in this observation).
+
+        Args:
+            observation_dict: Robot observation (per-joint scalars keyed by name
+                plus bare camera-name RGB/depth arrays).
+            instruction: Natural-language task, forwarded to the server policy.
+            **kwargs: Ignored (forward-compatible passthrough).
+
+        Returns:
+            List of action dicts, each mapping every robot state key to a python
+            ``float`` target for that tick.
+
+        Raises:
+            ConnectionError: If the server cannot be reached on first use.
+            RuntimeError: If state keys are undeclared, the observation is
+                missing a declared key, or the server returns no actions.
+        """
+        with self._lock:
+            self._ensure_connected()
+            if not self._instructions_sent:
+                self._send_instructions(self._build_lerobot_features(observation_dict))
+            raw_obs = self._to_raw_observation(observation_dict, instruction)
+            chunk = self._request_action_chunk(raw_obs)
+        return self._chunk_to_action_dicts(chunk)

--- a/strands_robots/registry/policies.json
+++ b/strands_robots/registry/policies.json
@@ -81,6 +81,34 @@
         "class": "LerobotTrainer"
       }
     },
+    "lerobot_async": {
+      "module": "strands_robots.policies.lerobot_async",
+      "class": "LerobotAsyncPolicy",
+      "description": "Remote lerobot inference over gRPC - forwards observations to a lerobot async_inference PolicyServer and returns action chunks",
+      "requires": [
+        "policy_type",
+        "pretrained_name_or_path"
+      ],
+      "config_keys": [
+        "server_address",
+        "host",
+        "port",
+        "policy_type",
+        "pretrained_name_or_path",
+        "device",
+        "actions_per_chunk",
+        "actions_per_step",
+        "connect_timeout",
+        "request_timeout"
+      ],
+      "defaults": {},
+      "shorthands": [
+        "lerobot_async"
+      ],
+      "url_patterns": [
+        "^grpc://"
+      ]
+    },
     "cosmos3": {
       "module": "strands_robots.policies.cosmos3",
       "class": "Cosmos3Policy",

--- a/strands_robots/registry/policies.py
+++ b/strands_robots/registry/policies.py
@@ -76,6 +76,9 @@ def resolve_policy(policy: str, **extra_kwargs) -> tuple[str, dict[str, Any]]:
         resolve_policy("zmq://localhost:5555")
         # → ("groot", {"host": "localhost", "port": 5555})
 
+        resolve_policy("grpc://gpu-box:8080")
+        # → ("lerobot_async", {"server_address": "gpu-box:8080"})
+
         resolve_policy("mock")
         # → ("mock", {})
     """

--- a/strands_robots/simulation/mujoco/tool_spec.json
+++ b/strands_robots/simulation/mujoco/tool_spec.json
@@ -190,7 +190,7 @@
     },
     "policy_provider": {
       "type": "string",
-      "description": "Policy provider name (e.g. groot, lerobot_local, cosmos3, mock). See list_providers()."
+      "description": "Policy provider name (e.g. groot, lerobot_local, lerobot_async, cosmos3, mock). See list_providers()."
     },
     "instruction": {
       "type": "string"

--- a/tests/policies/lerobot_async/test_lerobot_async_roundtrip.py
+++ b/tests/policies/lerobot_async/test_lerobot_async_roundtrip.py
@@ -1,0 +1,280 @@
+"""Regression tests for the ``lerobot_async`` policy provider.
+
+``LerobotAsyncPolicy`` is a gRPC client to a lerobot ``async_inference``
+``PolicyServer``. These tests pin two layers:
+
+* Construction / validation and registry resolution (no gRPC needed) - so the
+  provider is discoverable via ``create_policy`` and rejects a bad config early.
+* A full wire round-trip against a real in-process gRPC ``AsyncInference``
+  server (a stand-in that returns a canned action chunk). This proves the
+  client speaks lerobot's actual protocol: the ``SendPolicyInstructions``
+  handshake carries a well-formed ``RemotePolicyConfig`` (state + camera
+  features), the observation is streamed as a ``must_go`` ``TimedObservation``,
+  and the returned ``TimedAction`` chunk is decoded into per-joint action dicts.
+
+Before this provider existed, ``create_policy("lerobot_async", ...)`` raised
+``Unknown policy provider`` (the name was advertised but phantom), so every
+assertion here fails on pre-fix code.
+"""
+
+from __future__ import annotations
+
+import pickle
+import time
+from concurrent import futures
+
+import numpy as np
+import pytest
+
+from strands_robots.policies import create_policy, list_providers
+from strands_robots.policies.lerobot_async import LerobotAsyncPolicy
+
+STATE_KEYS = [f"joint_{i}" for i in range(6)]
+
+
+# -- Construction / validation (no gRPC) --------------------------------------
+
+
+def test_provider_is_registered() -> None:
+    assert "lerobot_async" in list_providers()
+
+
+def test_create_via_name() -> None:
+    policy = create_policy(
+        "lerobot_async",
+        server_address="gpu-box:8080",
+        policy_type="act",
+        pretrained_name_or_path="lerobot/act_so101",
+    )
+    assert isinstance(policy, LerobotAsyncPolicy)
+    assert policy.provider_name == "lerobot_async"
+    assert policy.server_address == "gpu-box:8080"
+
+
+def test_create_via_grpc_smart_string_parses_address() -> None:
+    policy = create_policy(
+        "grpc://gpu-box:9000",
+        policy_type="act",
+        pretrained_name_or_path="lerobot/act_so101",
+    )
+    assert isinstance(policy, LerobotAsyncPolicy)
+    assert policy.server_address == "gpu-box:9000"
+
+
+def test_actions_per_step_defaults_to_chunk_size() -> None:
+    policy = create_policy(
+        "lerobot_async",
+        server_address="h:1",
+        policy_type="act",
+        pretrained_name_or_path="x/y",
+        actions_per_chunk=32,
+    )
+    assert isinstance(policy, LerobotAsyncPolicy)
+    assert policy.actions_per_step == 32
+    assert policy.execution_horizon == 32
+
+
+def test_missing_policy_type_raises() -> None:
+    with pytest.raises(ValueError, match="policy_type"):
+        create_policy("lerobot_async", server_address="h:1", pretrained_name_or_path="x/y")
+
+
+def test_unsupported_policy_type_raises() -> None:
+    with pytest.raises(ValueError, match="not served"):
+        create_policy("lerobot_async", server_address="h:1", policy_type="bogus", pretrained_name_or_path="x/y")
+
+
+def test_missing_checkpoint_raises() -> None:
+    with pytest.raises(ValueError, match="pretrained_name_or_path"):
+        create_policy("lerobot_async", server_address="h:1", policy_type="act")
+
+
+# -- Full gRPC round-trip against a real in-process AsyncInference server ------
+
+grpc = pytest.importorskip("grpc")
+pytest.importorskip("lerobot.transport")
+pytest.importorskip("lerobot.async_inference.helpers")
+
+from lerobot.async_inference.helpers import (  # noqa: E402
+    RemotePolicyConfig,
+    TimedAction,
+    TimedObservation,
+)
+from lerobot.transport import services_pb2, services_pb2_grpc  # noqa: E402
+from lerobot.transport.utils import receive_bytes_in_chunks  # noqa: E402
+
+CHUNK_LEN = 4
+ACTION_DIM = 6
+
+
+class _RecordingServicer(services_pb2_grpc.AsyncInferenceServicer):
+    """Minimal real gRPC AsyncInference server that returns a canned chunk.
+
+    Records the ``RemotePolicyConfig`` and ``TimedObservation`` the client
+    sends so the test can assert the client built the wire messages correctly,
+    then returns a deterministic ``list[TimedAction]`` on ``GetActions``.
+    """
+
+    def __init__(self) -> None:
+        self.policy_config: RemotePolicyConfig | None = None
+        self.observation: TimedObservation | None = None
+        self.ready_calls = 0
+        self.return_empty_actions = False
+
+    def Ready(self, request, context):  # noqa: N802
+        self.ready_calls += 1
+        return services_pb2.Empty()
+
+    def SendPolicyInstructions(self, request, context):  # noqa: N802
+        self.policy_config = pickle.loads(request.data)  # nosec B301
+        return services_pb2.Empty()
+
+    def SendObservations(self, request_iterator, context):  # noqa: N802
+        import threading
+
+        payload = receive_bytes_in_chunks(request_iterator, None, threading.Event(), "test")
+        self.observation = pickle.loads(payload)  # nosec B301
+        return services_pb2.Empty()
+
+    def GetActions(self, request, context):  # noqa: N802
+        import torch
+
+        if self.return_empty_actions:
+            return services_pb2.Empty()
+
+        chunk = [
+            TimedAction(
+                timestamp=time.time(),
+                timestep=i,
+                action=torch.arange(ACTION_DIM, dtype=torch.float32) + float(i),
+            )
+            for i in range(CHUNK_LEN)
+        ]
+        return services_pb2.Actions(data=pickle.dumps(chunk))  # nosec B301
+
+
+@pytest.fixture()
+def running_server():
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=2))
+    servicer = _RecordingServicer()
+    services_pb2_grpc.add_AsyncInferenceServicer_to_server(servicer, server)
+    port = server.add_insecure_port("127.0.0.1:0")
+    server.start()
+    try:
+        yield servicer, f"127.0.0.1:{port}"
+    finally:
+        server.stop(grace=None)
+
+
+def _client(address: str, **kwargs) -> LerobotAsyncPolicy:
+    """Create the provider via the registry and narrow the type for the checker."""
+    policy = create_policy("lerobot_async", server_address=address, **kwargs)
+    assert isinstance(policy, LerobotAsyncPolicy)
+    return policy
+
+
+def _observation() -> dict:
+    obs: dict = {key: 0.1 * i for i, key in enumerate(STATE_KEYS)}
+    obs["top"] = np.zeros((8, 8, 3), dtype=np.uint8)
+    return obs
+
+
+def test_roundtrip_returns_decoded_action_chunk(running_server) -> None:
+    servicer, address = running_server
+    policy = _client(
+        address,
+        policy_type="act",
+        pretrained_name_or_path="lerobot/act_so101",
+        device="cpu",
+        actions_per_chunk=CHUNK_LEN,
+    )
+    policy.set_robot_state_keys(STATE_KEYS)
+
+    actions = policy.get_actions_sync(_observation(), "pick up the cube")
+
+    # The canned chunk had CHUNK_LEN actions of [0..5]+i; decoded to dicts.
+    assert len(actions) == CHUNK_LEN
+    for i, action in enumerate(actions):
+        assert set(action) == set(STATE_KEYS)
+        assert action["joint_0"] == pytest.approx(float(i))
+        assert action["joint_5"] == pytest.approx(5.0 + i)
+    policy.close()
+
+
+def test_roundtrip_sends_wellformed_instructions_and_observation(running_server) -> None:
+    servicer, address = running_server
+    policy = _client(
+        address,
+        policy_type="act",
+        pretrained_name_or_path="lerobot/act_so101",
+        device="cpu",
+        actions_per_chunk=CHUNK_LEN,
+    )
+    policy.set_robot_state_keys(STATE_KEYS)
+    policy.get_actions_sync(_observation(), "pick up the cube")
+
+    cfg = servicer.policy_config
+    assert isinstance(cfg, RemotePolicyConfig)
+    assert cfg.policy_type == "act"
+    assert cfg.pretrained_name_or_path == "lerobot/act_so101"
+    assert cfg.actions_per_chunk == CHUNK_LEN
+    assert cfg.device == "cpu"
+    # State scalars concatenated into observation.state (order preserved) +
+    # the camera declared as an image feature.
+    assert cfg.lerobot_features["observation.state"]["names"] == STATE_KEYS
+    assert "observation.images.top" in cfg.lerobot_features
+
+    obs = servicer.observation
+    assert isinstance(obs, TimedObservation)
+    assert obs.must_go is True
+    assert obs.observation["task"] == "pick up the cube"
+    assert obs.observation["joint_3"] == pytest.approx(0.3)
+    assert obs.observation["top"].shape == (8, 8, 3)
+    policy.close()
+
+
+def test_server_empty_response_raises(running_server) -> None:
+    """If the server yields no actions, the client must raise, never fabricate zeros."""
+    servicer, address = running_server
+    servicer.return_empty_actions = True
+
+    policy = _client(
+        address,
+        policy_type="act",
+        pretrained_name_or_path="x/y",
+        device="cpu",
+    )
+    policy.set_robot_state_keys(STATE_KEYS)
+    with pytest.raises(RuntimeError, match="no actions"):
+        policy.get_actions_sync(_observation(), "task")
+    policy.close()
+
+
+def test_missing_state_key_in_observation_raises(running_server) -> None:
+    servicer, address = running_server
+    policy = _client(
+        address,
+        policy_type="act",
+        pretrained_name_or_path="x/y",
+        device="cpu",
+    )
+    policy.set_robot_state_keys(STATE_KEYS)
+    incomplete = {key: 0.0 for key in STATE_KEYS[:-1]}  # drop last joint
+    with pytest.raises(RuntimeError, match="missing declared state key"):
+        policy.get_actions_sync(incomplete, "task")
+    policy.close()
+
+
+def test_unreachable_server_raises_connectionerror() -> None:
+    # Reserved TEST-NET address / closed port -> Ready handshake fails fast.
+    policy = _client(
+        "127.0.0.1:1",
+        policy_type="act",
+        pretrained_name_or_path="x/y",
+        device="cpu",
+        connect_timeout=2.0,
+    )
+    policy.set_robot_state_keys(STATE_KEYS)
+    with pytest.raises(ConnectionError, match="could not reach a lerobot PolicyServer"):
+        policy.get_actions_sync(_observation(), "task")
+    policy.close()


### PR DESCRIPTION
## What

Adds a first-class `lerobot_async` policy provider: a `Policy` that offloads inference to a remote LeRobot `PolicyServer` over LeRobot's **native async-inference gRPC transport** (`lerobot.async_inference.policy_server` / `robot_client`). The robot host stays light - it sends observations and applies returned actions while the heavyweight checkpoint runs on a separate GPU server. This is the gRPC counterpart to the existing WebSocket `remote` provider, and it interoperates with a stock `lerobot.async_inference.policy_server`.

`lerobot_async` was already advertised in the registry/tool-spec surface but had no implementation (it was previously stubbed out as a phantom name). This ships the real thing so callers who reach for it - directly or via the MuJoCo `run_policy` tool spec - get a working provider instead of an unknown-provider error.

## How it works

`LerobotAsyncPolicy`:
- Connects lazily on first `get_actions` and completes the gRPC `Ready` handshake (constructing the policy does not require the server to be up).
- Selects the server-side checkpoint via `SendPolicyInstructions` (a `RemotePolicyConfig` built from the declared joint state keys + the cameras present in the observation).
- Streams each observation as a `must_go` `TimedObservation`, calls `GetActions`, and decodes the returned `TimedAction` chunk into per-joint action dicts (values mapped to `robot_state_keys` by index, capped at `execution_horizon`).
- Raises on an unreachable server (`ConnectionError` with a start-the-server hint) or an empty server response - never fabricates a zero action.

`policy_type` and `pretrained_name_or_path` are required (the client owns checkpoint selection, matching LeRobot's async design). A `grpc://host:port` smart string resolves to this provider with `server_address` parsed out.

## API

```python
from strands_robots import create_policy

policy = create_policy(
    "lerobot_async",
    server_address="gpu-box:8080",
    policy_type="act",
    pretrained_name_or_path="lerobot/act_so101",
)
# equivalent smart string:
policy = create_policy("grpc://gpu-box:8080", policy_type="act", pretrained_name_or_path="lerobot/act_so101")
```

Server side (GPU host):
```bash
pip install 'lerobot[async]'
python -m lerobot.async_inference.policy_server --host=0.0.0.0 --port=8080
```

## Tests

`tests/policies/lerobot_async/test_lerobot_async_roundtrip.py`:
- Construction / validation (no gRPC): registered in `list_providers()`, resolves via name and `grpc://`, required-kwarg and unsupported-`policy_type` errors, `actions_per_step` defaulting.
- Full wire round-trip against a **real in-process gRPC `AsyncInference` server** (a stand-in returning a canned chunk): asserts the client sends a well-formed `RemotePolicyConfig` (state feature order + camera image feature), a `must_go` `TimedObservation` carrying the task + raw obs, decodes the `TimedAction` chunk into per-joint dicts, raises on an empty response, on a missing declared state key, and `ConnectionError` on an unreachable server.

Green locally: `ruff`/`ruff format`/`mypy` clean on `strands_robots tests tests_integ`; `pytest tests/policies tests/registry` = 2085 passed, 2 skipped (`MUJOCO_GL=egl`).

## Rollout in MuJoCo (headless)

End-to-end proof: the `so101` arm in MuJoCo driven through `lerobot_async` by `lerobot/smolvla_base` served over the lerobot async-inference gRPC transport (server ran 15 inferences, action shape `[1, 50, 6]` per chunk; the arm moves under the remotely-served policy).

![lerobot_async so101 rollout](https://github.com/cagataycali/robots/releases/download/lerobot-async-demo/lerobot_async_so101.gif)

Full-resolution MP4: https://github.com/cagataycali/robots/releases/download/lerobot-async-demo/lerobot_async_so101.mp4

## Docs

- New `docs/policies/lerobot-async.md` (install, server/client usage, config-key table, notes).
- `docs/policies/overview.md` provider table + list, `README.md` provider table, `mkdocs.yml` nav.
- New `[lerobot-async]` extra (adds `grpcio` via `lerobot[async]`); added to `[all]`.