### PR TITLE
feat(sim): base_lin_vel_z / base_ang_vel_xy reward terms complete the velocity-tracking reward set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1167,6 +1167,27 @@ walking upright, only roll/pitch off level is penalised. On a fixed-base arm (no
 floating base) the term degrades to `0.0` and logs the missing base once,
 consistent with the DSL's other name-resolution degradation.
 
+### Added: base_lin_vel_z / base_ang_vel_xy locomotion-regularizer reward terms for the predicate/reward DSL
+
+The dense-reward DSL grew the two remaining pure-observation legged_gym /
+IsaacLab locomotion regularizers -- the ones that damp a floating base's
+UNCOMMANDED velocity (both default-nonzero scales in `LeggedRobotCfg`):
+`base_lin_vel_z` = `-weight * v_body_z ** 2` (penalise vertical bouncing) and
+`base_ang_vel_xy` = `-weight * (w_body_x ** 2 + w_body_y ** 2)` (penalise
+roll/pitch wobble). Both read the base twist from `get_observation`: the
+world-frame `base_lin_vel` is rotated into the base frame via `base_quat` for the
+vertical velocity, and the already-body-frame `base_ang_vel` supplies the
+roll/pitch rates (`base_ang_vel_xy` is invariant to the yaw rate, so a policy may
+turn freely). They complete the minimal velocity-tracking reward set alongside
+`base_velocity` (planar + yaw tracking), `base_height` (crouch regularizer) and
+`base_orientation` (tilt regularizer): the height/orientation terms penalise a
+static OFFSET, while these two directly damp the RATE. A policy that porpoises
+around the exact target height, or oscillates around level, has ~0 mean offset --
+`base_height`/`base_orientation` read 0 -- yet is caught by `base_lin_vel_z` /
+`base_ang_vel_xy`. On a fixed-base arm (no floating base) both terms degrade to
+`0.0` and log the missing base once, consistent with the DSL's other
+name-resolution degradation.
+
 ### Fixed:
 
 - `lerobot_local`: observation-history policies (Diffusion `n_obs_steps=2`, VQBeT `n_obs_steps=5`) crashed with `AssertionError` when run through `Simulation.run_policy`. `_auto_detect_actions_per_step` adopted the model's `n_action_steps` chunk and routed inference to `predict_action_chunk()`, whose offline branch stacks a single live observation frame as `n_obs_steps=1`; LeRobot's `generate_actions()` then trips `assert n_obs_steps == config.n_obs_steps`. These checkpoints now keep `actions_per_step=1` so inference runs through `select_action()`, which maintains the required observation-history queue and still replays the model's `n_action_steps` chunk from its internal queue (open-loop chunk replay is preserved). Single-history policies (ACT, SmolVLA, pi0, MolmoAct2) are unaffected.

--- a/strands_robots/simulation/predicates.py
+++ b/strands_robots/simulation/predicates.py
@@ -319,6 +319,48 @@ def _base_twist(sim: SimEngine, robot: str | None) -> tuple[float, float, float]
     return float(v_body[0]), float(v_body[1]), float(ang[2])
 
 
+def _base_body_velocity(sim: SimEngine, robot: str | None) -> tuple[list[float], list[float]] | None:
+    """Return a floating base's BODY-frame ``(linear_velocity, angular_velocity)``, or None.
+
+    Reads ``get_observation``'s floating-base signals and expresses BOTH twists
+    in the base (body) frame - the frame a legged controller regularizes: the
+    world-frame ``base_lin_vel`` is rotated into the base frame via ``base_quat``
+    (so its z is the vertical velocity along the base's OWN up-axis), and
+    ``base_ang_vel`` is already body-frame (the IMU-gyro convention on both
+    backends) so its xy are the roll/pitch rates directly. Returns None (and
+    warns once) when the robot exposes no floating base - almost always a spec
+    referencing a base term on a fixed-base arm. Shared by the two uncommanded-
+    base-velocity regularizer terms (``base_lin_vel_z`` / ``base_ang_vel_xy``).
+    """
+    try:
+        obs = sim.get_observation(robot_name=robot, skip_images=True)
+    except Exception as e:  # noqa: BLE001 - defensive: predicates never raise
+        logger.debug("base motion get_observation(%r) failed: %s", robot, e)
+        return None
+    if not isinstance(obs, dict):
+        return None
+    lin = obs.get("base_lin_vel")
+    quat = obs.get("base_quat")
+    ang = obs.get("base_ang_vel")
+    if not (
+        isinstance(lin, list)
+        and len(lin) == 3
+        and isinstance(quat, list)
+        and len(quat) == 4
+        and isinstance(ang, list)
+        and len(ang) == 3
+    ):
+        # A floating base surfaces all three; their absence means this robot has
+        # no floating base (a fixed-base arm) - almost always a spec error.
+        _warn_unresolved("robot base", robot or "<sole robot>")
+        return None
+    v_body = _quat_rotate_inverse_wxyz(quat, lin)
+    return (
+        [float(v_body[0]), float(v_body[1]), float(v_body[2])],
+        [float(ang[0]), float(ang[1]), float(ang[2])],
+    )
+
+
 def _base_position(sim: SimEngine, robot: str | None) -> list[float] | None:
     """Return a floating base's WORLD position ``[x, y, z]`` (incl. height), or None.
 
@@ -886,6 +928,77 @@ def _base_orientation(weight: float = 1.0, robot: str | None = None) -> RewardTe
     return term
 
 
+def _base_lin_vel_z(weight: float = 1.0, robot: str | None = None) -> RewardTerm:
+    """Negative squared vertical base velocity - a locomotion-regularizer reward.
+
+    Penalises a floating-base robot for moving vertically (bouncing):
+    ``-weight * v_body_z ** 2`` where ``v_body_z`` is the base's linear velocity
+    along its OWN up-axis (the world-frame ``base_lin_vel`` rotated into the base
+    frame via ``base_quat``). 0 when the base holds a constant height, growing
+    more negative the faster it bounces. This is the standard legged_gym /
+    IsaacLab ``lin_vel_z`` term, and it complements ``base_height``:
+    ``base_height`` penalises a base-height OFFSET (a static crouch) while
+    ``base_lin_vel_z`` directly damps vertical bouncing whose mean height error
+    can be ~0 - a velocity-tracking policy that porpoises around the target
+    height is caught by this term but not by ``base_height`` alone. One of the
+    two uncommanded-base-velocity regularizers (with ``base_ang_vel_xy``) that a
+    viable velocity-tracking reward adds to ``base_velocity`` + ``base_height`` +
+    ``base_orientation`` (the default-nonzero legged_gym reward set).
+
+    Reads ``get_observation``'s ``base_lin_vel`` + ``base_quat``. Requires a
+    robot with a floating base; a fixed-base arm has no base velocity, so the
+    term degrades to ``0.0`` and the missing base is logged once. ``robot``
+    selects the robot in a multi-robot scene (default: the sole robot).
+    """
+    w = float(weight)
+    rname = robot
+
+    def term(sim: SimEngine) -> float:
+        motion = _base_body_velocity(sim, rname)
+        if motion is None:
+            return 0.0
+        vz = motion[0][2]
+        return -w * vz * vz
+
+    return term
+
+
+def _base_ang_vel_xy(weight: float = 1.0, robot: str | None = None) -> RewardTerm:
+    """Negative squared roll/pitch angular velocity - a locomotion-regularizer reward.
+
+    Penalises a floating-base robot for rolling/pitching (wobbling):
+    ``-weight * (w_body_x ** 2 + w_body_y ** 2)`` where ``(w_body_x, w_body_y)``
+    are the base's roll and pitch RATES (body-frame ``base_ang_vel``, the
+    IMU-gyro reading). 0 when the base is not tipping, growing more negative the
+    faster it wobbles. This is the standard legged_gym / IsaacLab ``ang_vel_xy``
+    term, and it complements ``base_orientation``: ``base_orientation`` penalises
+    a tilt OFFSET (a static lean) while ``base_ang_vel_xy`` directly damps
+    oscillatory roll/pitch whose mean tilt can be ~0. Crucially it is INVARIANT
+    to the yaw rate (``w_body_z``): a walking policy may turn freely, only
+    roll/pitch RATE is penalised. One of the two uncommanded-base-velocity
+    regularizers (with ``base_lin_vel_z``) that a viable velocity-tracking reward
+    adds to ``base_velocity`` + ``base_height`` + ``base_orientation`` (the
+    default-nonzero legged_gym reward set).
+
+    Reads ``get_observation``'s ``base_ang_vel`` (already body-frame on both
+    backends). Requires a robot with a floating base; a fixed-base arm has no
+    base velocity, so the term degrades to ``0.0`` and the missing base is
+    logged once. ``robot`` selects the robot in a multi-robot scene (default:
+    the sole robot).
+    """
+    w = float(weight)
+    rname = robot
+
+    def term(sim: SimEngine) -> float:
+        motion = _base_body_velocity(sim, rname)
+        if motion is None:
+            return 0.0
+        wx, wy = motion[1][0], motion[1][1]
+        return -w * (wx * wx + wy * wy)
+
+    return term
+
+
 # Stateful reward terms (declarative phase machine)
 #
 # A plain RewardTerm is stateless: ``(SimEngine) -> float``. Some rewards need
@@ -1063,6 +1176,8 @@ PREDICATE_REGISTRY: dict[str, PredicateFactory] = {
     "base_velocity": _base_velocity,
     "base_height": _base_height,
     "base_orientation": _base_orientation,
+    "base_lin_vel_z": _base_lin_vel_z,
+    "base_ang_vel_xy": _base_ang_vel_xy,
     "constant": _constant,
     # stateful (phase machine)
     "staged_reward": _staged_reward,

--- a/tests/simulation/test_base_body_velocity_reward.py
+++ b/tests/simulation/test_base_body_velocity_reward.py
@@ -1,0 +1,238 @@
+"""Regression tests for the ``base_lin_vel_z`` / ``base_ang_vel_xy`` reward terms.
+
+The predicate/reward DSL grew the two remaining pure-observation legged_gym /
+IsaacLab locomotion regularizers - the ones that damp a floating base's
+UNCOMMANDED velocity (both default-nonzero in ``LeggedRobotCfg``):
+
+* ``base_lin_vel_z``  : ``-weight * v_body_z ** 2`` - penalise vertical bouncing.
+* ``base_ang_vel_xy`` : ``-weight * (w_body_x ** 2 + w_body_y ** 2)`` - penalise
+  roll/pitch wobble.
+
+They complete the minimal velocity-tracking reward set alongside the previously
+landed ``base_velocity`` (planar + yaw tracking), ``base_height`` (crouch
+regularizer) and ``base_orientation`` (tilt regularizer): the position/orientation
+terms penalise a static OFFSET, these two directly damp the RATE (a policy that
+porpoises around the target height, or wobbles around level, averages ~0 offset
+yet is caught here). Both read the base twist from ``get_observation``:
+``base_lin_vel`` (world frame) rotated into the base frame via ``base_quat`` for
+``v_body_z``; ``base_ang_vel`` (already body-frame) for ``w_body_x``/``w_body_y``.
+
+These tests set a KNOWN base velocity directly on the sim (free-joint qvel:
+world-frame linear + body-frame angular) and assert the correct negative squared
+error, that ``base_lin_vel_z`` reads the BODY-frame vertical velocity (a
+horizontal WORLD velocity under a 90-degree pitch is a vertical BODY velocity),
+that ``base_ang_vel_xy`` is invariant to the yaw rate, and that both degrade to
+``0.0`` (with a warning) on a fixed-base arm. They are GL-free (get_observation
+with skip_images) so they run in CI without a display.
+"""
+
+import logging
+import math
+import os
+import tempfile
+
+import mujoco
+import pytest
+
+from strands_robots.simulation.mujoco.simulation import Simulation
+from strands_robots.simulation.predicates import (
+    _reset_resolution_warnings,
+    make_predicate,
+)
+
+# Floating base with a NAMED free joint (a humanoid's floating_base_joint) plus
+# one actuated hinge. get_observation surfaces base_lin_vel/base_quat/base_ang_vel.
+NAMED_BASE_XML = """
+<mujoco model="test_named_base">
+  <compiler angle="radian" autolimits="true"/>
+  <option timestep="0.002"/>
+  <worldbody>
+    <light name="main" pos="0 0 3" dir="0 0 -1"/>
+    <geom name="ground" type="plane" size="5 5 0.01" rgba="0.9 0.9 0.9 1"/>
+    <body name="pelvis" pos="0 0 0.8">
+      <freejoint name="floating_base_joint"/>
+      <geom type="box" size="0.1 0.1 0.1" rgba="0.3 0.3 0.8 1"/>
+      <body name="thigh" pos="0 0 -0.1">
+        <geom type="capsule" size="0.03" fromto="0 0 0 0 0 -0.3" rgba="0.8 0.3 0.3 1"/>
+        <joint name="hip" type="hinge" axis="0 1 0" range="-1.5 1.5"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <motor name="hip_act" joint="hip"/>
+  </actuator>
+</mujoco>
+"""
+
+# Fixed-base arm: no free joint anywhere -> no base twist. Both terms must
+# degrade to 0.0 (and warn) rather than crash or invent a value.
+FIXED_ARM_XML = """
+<mujoco model="test_fixed">
+  <compiler angle="radian" autolimits="true"/>
+  <worldbody>
+    <light name="main" pos="0 0 3" dir="0 0 -1"/>
+    <body name="link" pos="0 0 0.1">
+      <geom type="capsule" size="0.02" fromto="0 0 0 0 0 0.2"/>
+      <joint name="j0" type="hinge" axis="0 0 1"/>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="j0_act" joint="j0" kp="10"/>
+  </actuator>
+</mujoco>
+"""
+
+
+def _axis_quat(axis: str, deg: float) -> list[float]:
+    """Unit (w, x, y, z) quaternion for a rotation of ``deg`` about a world axis."""
+    h = math.radians(deg) / 2.0
+    c, sn = math.cos(h), math.sin(h)
+    return {
+        "x": [c, sn, 0.0, 0.0],
+        "y": [c, 0.0, sn, 0.0],
+        "z": [c, 0.0, 0.0, sn],
+    }[axis]
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="test_base_body_velocity", mesh=False)
+    s.create_world(ground_plane=False)
+    yield s
+    s.cleanup()
+
+
+def _write(xml: str) -> str:
+    d = tempfile.mkdtemp()
+    p = os.path.join(d, "model.xml")
+    with open(p, "w") as f:
+        f.write(xml)
+    return p
+
+
+def _set_base_vel(sim, quat_wxyz: list[float], lin_world: list[float], ang_body: list[float]) -> None:
+    """Set the robot's (only) free joint to a fixed height + orientation and a
+    known velocity. MuJoCo free-joint qvel is [linear (WORLD frame), angular
+    (BODY frame)] - exactly what get_observation surfaces as base_lin_vel (world)
+    and base_ang_vel (body)."""
+    model, data = sim._world._model, sim._world._data
+    jid = -1
+    for j in range(model.njnt):
+        if model.jnt_type[j] == mujoco.mjtJoint.mjJNT_FREE:
+            jid = j
+            break
+    assert jid >= 0
+    qadr = int(model.jnt_qposadr[jid])
+    vadr = int(model.jnt_dofadr[jid])
+    data.qpos[qadr : qadr + 7] = [0.0, 0.0, 0.8, *quat_wxyz]
+    data.qvel[vadr : vadr + 6] = [*lin_world, *ang_body]
+    mujoco.mj_forward(model, data)
+
+
+IDENT = [1.0, 0.0, 0.0, 0.0]
+
+
+# --- base_lin_vel_z -------------------------------------------------------
+
+
+def test_lin_vel_z_is_negative_squared_vertical_velocity(sim):
+    """A level base moving at world (0.3,-0.4,0.5) has body vertical velocity 0.5:
+    reward = -weight * 0.5**2."""
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    _set_base_vel(sim, IDENT, [0.3, -0.4, 0.5], [0.0, 0.0, 0.0])
+    assert make_predicate("base_lin_vel_z")(sim) == pytest.approx(-0.25, abs=1e-6)
+    assert make_predicate("base_lin_vel_z", weight=4.0)(sim) == pytest.approx(-1.0, abs=1e-6)
+
+
+def test_lin_vel_z_ignores_purely_horizontal_velocity_on_a_level_base(sim):
+    """A level base sliding horizontally has zero vertical velocity -> 0 penalty
+    (the term isolates the vertical component, not total speed)."""
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    _set_base_vel(sim, IDENT, [1.0, 2.0, 0.0], [0.0, 0.0, 0.0])
+    assert make_predicate("base_lin_vel_z")(sim) == pytest.approx(0.0, abs=1e-6)
+
+
+def test_lin_vel_z_uses_the_body_frame_not_the_world_frame(sim):
+    """Under a 90-degree pitch the base's up-axis points along world +x, so a
+    purely-horizontal WORLD velocity (0.6,0,0) is a vertical BODY velocity 0.6:
+    reward = -0.6**2. This proves the term reads the base-frame vertical
+    velocity, not world z."""
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    _set_base_vel(sim, _axis_quat("y", 90.0), [0.6, 0.0, 0.0], [0.0, 0.0, 0.0])
+    assert make_predicate("base_lin_vel_z")(sim) == pytest.approx(-0.36, abs=1e-6)
+
+
+def test_lin_vel_z_tracks_the_live_base_velocity(sim):
+    """The reward reads the CURRENT base velocity: changing it changes the term."""
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    term = make_predicate("base_lin_vel_z")
+    _set_base_vel(sim, IDENT, [0.0, 0.0, 0.0], [0.0, 0.0, 0.0])
+    assert term(sim) == pytest.approx(0.0, abs=1e-6)
+    _set_base_vel(sim, IDENT, [0.0, 0.0, 2.0], [0.0, 0.0, 0.0])
+    assert term(sim) == pytest.approx(-4.0, abs=1e-6)
+
+
+def test_lin_vel_z_degrades_to_zero_on_fixed_base_arm(sim, caplog):
+    """A fixed-base arm has no base velocity: the term degrades to 0.0 and warns."""
+    sim.add_robot("arm", urdf_path=_write(FIXED_ARM_XML))
+    _reset_resolution_warnings()
+    with caplog.at_level(logging.WARNING, logger="strands_robots.simulation.predicates"):
+        val = make_predicate("base_lin_vel_z")(sim)
+    assert val == 0.0
+    assert any("base" in r.message.lower() for r in caplog.records)
+
+
+# --- base_ang_vel_xy ------------------------------------------------------
+
+
+def test_ang_vel_xy_is_negative_squared_roll_pitch_rate(sim):
+    """Body angular velocity (0.1,0.2,0.3) has roll/pitch magnitude^2 0.01+0.04:
+    reward = -(0.05); the yaw rate 0.3 is not penalised."""
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    _set_base_vel(sim, IDENT, [0.0, 0.0, 0.0], [0.1, 0.2, 0.3])
+    assert make_predicate("base_ang_vel_xy")(sim) == pytest.approx(-0.05, abs=1e-6)
+    assert make_predicate("base_ang_vel_xy", weight=4.0)(sim) == pytest.approx(-0.20, abs=1e-6)
+
+
+def test_ang_vel_xy_is_invariant_to_yaw_rate(sim):
+    """A pure yaw rate (turning in place) is NOT penalised -> 0. This is what
+    makes it a roll/pitch-rate regularizer and not a turn penalty: a walking
+    policy may turn freely, only rolling/pitching costs reward."""
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    term = make_predicate("base_ang_vel_xy")
+    for wz in (0.5, -1.0, 3.0):
+        _set_base_vel(sim, IDENT, [0.0, 0.0, 0.0], [0.0, 0.0, wz])
+        assert term(sim) == pytest.approx(0.0, abs=1e-6), f"yaw rate {wz} should not be penalised"
+
+
+def test_ang_vel_xy_penalty_is_symmetric_roll_and_pitch(sim):
+    """A pure roll rate is penalised identically to a pure pitch rate of the same
+    magnitude (isotropic tip rate)."""
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    term = make_predicate("base_ang_vel_xy")
+    _set_base_vel(sim, IDENT, [0.0, 0.0, 0.0], [0.7, 0.0, 0.0])
+    roll = term(sim)
+    _set_base_vel(sim, IDENT, [0.0, 0.0, 0.0], [0.0, 0.7, 0.0])
+    pitch = term(sim)
+    assert roll == pytest.approx(pitch, abs=1e-6)
+    assert roll == pytest.approx(-(0.7**2), abs=1e-6)
+
+
+def test_ang_vel_xy_tracks_the_live_base_velocity(sim):
+    """The reward reads the CURRENT base angular velocity."""
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    term = make_predicate("base_ang_vel_xy")
+    _set_base_vel(sim, IDENT, [0.0, 0.0, 0.0], [0.0, 0.0, 0.0])
+    assert term(sim) == pytest.approx(0.0, abs=1e-6)
+    _set_base_vel(sim, IDENT, [0.0, 0.0, 0.0], [0.3, 0.4, 0.0])
+    assert term(sim) == pytest.approx(-0.25, abs=1e-6)
+
+
+def test_ang_vel_xy_degrades_to_zero_on_fixed_base_arm(sim, caplog):
+    """A fixed-base arm has no base velocity: the term degrades to 0.0 and warns."""
+    sim.add_robot("arm", urdf_path=_write(FIXED_ARM_XML))
+    _reset_resolution_warnings()
+    with caplog.at_level(logging.WARNING, logger="strands_robots.simulation.predicates"):
+        val = make_predicate("base_ang_vel_xy")(sim)
+    assert val == 0.0
+    assert any("base" in r.message.lower() for r in caplog.records)

--- a/tests/simulation/test_reward_term_degradation.py
+++ b/tests/simulation/test_reward_term_degradation.py
@@ -54,6 +54,8 @@ class _NonDictEngine:
     [
         ("base_velocity", {"vx": 0.5}),
         ("base_height", {"target": 0.74}),
+        ("base_lin_vel_z", {}),
+        ("base_ang_vel_xy", {}),
     ],
 )
 def test_reward_term_degrades_to_zero_when_observation_raises(term_name, kwargs):
@@ -67,6 +69,8 @@ def test_reward_term_degrades_to_zero_when_observation_raises(term_name, kwargs)
     [
         ("base_velocity", {"vx": 0.5}),
         ("base_height", {"target": 0.74}),
+        ("base_lin_vel_z", {}),
+        ("base_ang_vel_xy", {}),
     ],
 )
 @pytest.mark.parametrize("bad_obs", [None, [1, 2, 3], "not-a-dict"])


### PR DESCRIPTION
## What

Add the two remaining pure-observation legged_gym / IsaacLab locomotion regularizers to the predicate/reward DSL:

| term | reward | penalises |
|------|--------|-----------|
| `base_lin_vel_z` | `-weight * v_body_z ** 2` | vertical bouncing (base linear velocity along its own up-axis) |
| `base_ang_vel_xy` | `-weight * (w_body_x ** 2 + w_body_y ** 2)` | roll/pitch wobble (base roll/pitch angular rate) |

## Why

The velocity-tracking reward DSL already has `base_velocity` (planar + yaw tracking), `base_height` (crouch regularizer) and `base_orientation` (tilt regularizer). But the canonical minimal legged_gym reward has two more regularizers that are **default-nonzero** in `LeggedRobotCfg.rewards.scales` (`lin_vel_z` = -2.0, `ang_vel_xy` = -0.05) and were missing here: the ones that damp the base's **uncommanded velocity**.

They are genuinely distinct from the existing terms, not redundant. `base_height` / `base_orientation` penalise a static **offset** (a crouch, a lean); the two new terms directly damp the **rate**. A velocity-tracking policy that porpoises around the exact target height, or oscillates around level, has ~0 mean offset and is invisible to the offset terms, yet is caught here. Concretely, for a base sitting **at** the target height and perfectly level but bouncing (`vz=1.0`) and wobbling (`wx=wy=0.5`):

```
base_height(target=0.8)    = -0.0000   <- sees no offset
base_orientation           = -0.0000   <- sees no offset
base_lin_vel_z             = -1.0000   <- catches the bounce
base_ang_vel_xy            = -0.5000   <- catches the wobble
```

Together the five terms are the minimal viable velocity-tracking reward (groundwork for the G1/T1/Go1 locomotion task spec, #873).

## How

Both terms are pure-observation, reusing a small shared helper `_base_body_velocity`:
- the world-frame `base_lin_vel` is rotated into the base frame via `base_quat` (the existing numpy-free `_quat_rotate_inverse_wxyz`) for the vertical component;
- `base_ang_vel` is already body-frame on both backends, so its xy are the roll/pitch rates directly. `base_ang_vel_xy` is therefore **invariant to the yaw rate** -- a walking policy may turn freely, only rolling/pitching costs reward.

On a fixed-base arm (no floating base) both terms degrade to `0.0` and log the missing base once, consistent with the DSL's other name-resolution degradation. Registered in `PREDICATE_REGISTRY`, directly composable in a `DeclarativeBenchmark` `dense_reward` list or an RL `SimEnv` reward.

## Tests

`tests/simulation/test_base_body_velocity_reward.py` (10 tests) sets a **known** base velocity directly on the sim (free-joint qvel = world-frame linear + body-frame angular) and asserts:
- the negative squared error and weight scaling;
- `base_lin_vel_z` reads the **body-frame** vertical velocity (a purely-horizontal world velocity under a 90-degree pitch is a vertical body velocity -> nonzero penalty), and ignores horizontal velocity on a level base;
- `base_ang_vel_xy` is invariant to the yaw rate and symmetric in roll/pitch;
- both track the live base velocity and degrade to `0.0` + warn on a fixed-base arm.

Each test fails before the change with `ValueError: Unknown predicate` and passes after. `tests/simulation/test_reward_term_degradation.py` is extended to cover both new terms in its raise / non-dict degradation contract.

GL-free (`get_observation(skip_images=True)`), so they run in CI without a display.

## Gate

- `ruff check` + `ruff format --check`: clean.
- `mypy strands_robots/simulation/predicates.py`: clean.
- `MUJOCO_GL=egl pytest tests/simulation/test_base_body_velocity_reward.py tests/simulation/test_base_orientation_reward.py tests/simulation/test_base_height_reward.py tests/simulation/test_base_velocity_reward.py tests/simulation/test_reward_term_degradation.py tests/simulation/test_staged_reward.py tests/simulation/test_benchmark_predicates.py`: **161 passed**.

Purely additive (`+115` in `predicates.py`, no signature or behavior change to existing terms).