### PR TITLE
test(isaac): pin package-level lazy-export contract (__getattr__ re-exports)

### DIFF
--- a/tests/simulation/isaac/test_isaac_backend.py
+++ b/tests/simulation/isaac/test_isaac_backend.py
@@ -69,6 +69,53 @@ class TestLazyImport:
         assert not any(m.startswith("omni") or m.startswith("isaacsim") for m in sys.modules)
 
 
+class TestPackageLazyExport:
+    """The package-level public export surface resolves via PEP 562 ``__getattr__``.
+
+    ``strands_robots/simulation/isaac/__init__.py`` documents
+
+        from strands_robots.simulation.isaac import IsaacSimulation, IsaacConfig
+
+    as the public entry point and re-exports both names lazily through
+    ``__getattr__`` (so importing the subpackage never pulls omni/isaacsim).
+    The other tests reach the classes through their defining submodules
+    (``...isaac.config`` / ``...isaac.simulation``), which bypasses the
+    package accessor - these pin the accessor itself so a regression in the
+    lazy re-export (wrong name check, wrong target) is caught.
+    """
+
+    def test_isaac_config_resolves_through_package_getattr(self):
+        import strands_robots.simulation.isaac as isaac_pkg
+        from strands_robots.simulation.isaac.config import IsaacConfig as ConfigViaSubmodule
+
+        # Attribute access on the package triggers __getattr__ -> _lazy_isaac_config.
+        assert isaac_pkg.IsaacConfig is ConfigViaSubmodule
+        assert isaac_pkg.IsaacConfig.__module__ == "strands_robots.simulation.isaac.config"
+
+    def test_isaac_simulation_resolves_through_package_getattr(self):
+        import strands_robots.simulation.isaac as isaac_pkg
+        from strands_robots.simulation.isaac.simulation import IsaacSimulation as SimViaSubmodule
+
+        # Attribute access triggers __getattr__ -> _lazy_isaac_simulation; still
+        # no omni/isaacsim import (heavy imports live inside methods).
+        assert isaac_pkg.IsaacSimulation is SimViaSubmodule
+        assert not any(m.startswith("omni") or m.startswith("isaacsim") for m in sys.modules)
+
+    def test_public_names_match_all(self):
+        import strands_robots.simulation.isaac as isaac_pkg
+
+        # Everything promised by __all__ is resolvable through the package.
+        assert set(isaac_pkg.__all__) == {"IsaacSimulation", "IsaacConfig"}
+        for name in isaac_pkg.__all__:
+            assert getattr(isaac_pkg, name) is not None
+
+    def test_unknown_attribute_raises_attribute_error(self):
+        import strands_robots.simulation.isaac as isaac_pkg
+
+        with pytest.raises(AttributeError, match="no attribute 'NotAName'"):
+            isaac_pkg.NotAName
+
+
 class TestIsaacConfig:
     def test_defaults(self):
         from strands_robots.simulation.isaac.config import IsaacConfig


### PR DESCRIPTION
## Problem

The `strands_robots.simulation.isaac` subpackage documents

```python
from strands_robots.simulation.isaac import IsaacSimulation, IsaacConfig
```

as its public entry point and re-exports both names lazily via a PEP 562 `__getattr__`, so importing the subpackage never pulls in `omni`/`isaacsim`.

The existing tests reach those classes through their *defining submodules* (`...isaac.config` / `...isaac.simulation`), which bypasses the package accessor entirely. As a result `__getattr__`, `_lazy_isaac_config` and `_lazy_isaac_simulation` (`isaac/__init__.py` lines 36-54) had **zero** coverage. A regression that mis-wires the lazy re-export (wrong name check, wrong target) would silently break the documented public import path with no failing test.

## Change

Add `TestPackageLazyExport` to `tests/simulation/isaac/test_isaac_backend.py`, pinning the accessor as a behavior contract:

- `IsaacConfig` and `IsaacSimulation` resolve *through the package* to the same objects as their defining submodules (exercises `__getattr__` -> the lazy helpers, which the submodule-import tests skip).
- `IsaacSimulation` still resolves without importing `omni`/`isaacsim` (the lazy contract holds).
- `__all__` equals the set of names resolvable through the package.
- An unknown attribute raises `AttributeError` naming the module.

## Verification

- Regression guard: mutating `__getattr__` to return the wrong lazy target makes `test_isaac_config_resolves_through_package_getattr` fail; the unmodified accessor passes.
- Coverage: `strands_robots/simulation/isaac/__init__.py` goes from **40% to 100%**.
- Local gate green: `ruff check` + `ruff format --check` clean, `mypy strands_robots tests tests_integ` reports no issues; `tests/simulation/isaac/test_isaac_backend.py` -> 33 passed.

Test-only change; no runtime/behavior surface is modified.