### PR TITLE
test(inference): pin RemotePolicy bare-endpoint scheme normalization

### DIFF
--- a/tests/inference/test_remote_policy_roundtrip.py
+++ b/tests/inference/test_remote_policy_roundtrip.py
@@ -264,6 +264,37 @@ def test_known_constructor_kwargs_do_not_warn(caplog):
     ]
 
 
+def test_bare_host_port_endpoint_gets_ws_scheme_prepended():
+    """A ``host:port`` endpoint with no scheme is normalized to ``ws://``.
+
+    ``RemotePolicy("gpu-box:8765")`` (and the ``create_policy`` smart-string
+    path that forwards it) must reach ``ws://gpu-box:8765``, not fail or connect
+    to a schemeless URI the websockets client would reject. The scheme prefix is
+    added rather than demanded, so a caller need not know the transport spelling.
+    """
+    policy = RemotePolicy("gpu-box:8765")
+    assert policy.uri == "ws://gpu-box:8765"
+
+
+def test_bare_host_only_endpoint_gets_ws_scheme_prepended():
+    """A scheme-less host with no explicit port is still normalized to ``ws://``.
+
+    The ``host``/``port`` keyword fallback already yields a ``ws://`` URI, so the
+    only way to reach a schemeless value is a positional ``endpoint``; both the
+    ``host:port`` and bare-``host`` spellings take the prepend branch.
+    """
+    policy = RemotePolicy("gpu-box")
+    assert policy.uri == "ws://gpu-box"
+
+
+def test_wss_endpoint_scheme_is_preserved():
+    """An explicit secure scheme is left intact - the prepend fires only when a
+    recognized (``ws://``/``wss://``) scheme is absent, never double-prefixing.
+    """
+    policy = RemotePolicy("wss://secure-box:9000")
+    assert policy.uri == "wss://secure-box:9000"
+
+
 def test_policy_server_requires_exactly_one_policy_source():
     with pytest.raises(ValueError, match="exactly one"):
         PolicyServer()


### PR DESCRIPTION
## Summary

`RemotePolicy` normalizes a scheme-less endpoint by prepending `ws://`, so `RemotePolicy("gpu-box:8765")` reaches `ws://gpu-box:8765` rather than handing the `websockets` client a schemeless URI it rejects (`client.py`, the `if not self.uri.startswith(("ws://", "wss://"))` branch). Every existing URI-contract test in `test_remote_policy_roundtrip.py` passes an endpoint that **already** carries a `ws://`/`wss://` scheme, so this prepend branch was never exercised.

## What this adds

Three assertions pinning the observable endpoint-normalization contract:

| Input | Expected `policy.uri` |
|-------|----------------------|
| `RemotePolicy("gpu-box:8765")` (bare host:port) | `ws://gpu-box:8765` |
| `RemotePolicy("gpu-box")` (bare host) | `ws://gpu-box` |
| `RemotePolicy("wss://secure-box:9000")` (explicit scheme) | `wss://secure-box:9000` (preserved) |

The prepend fires only when a recognized scheme is absent, and never double-prefixes an explicit `wss://`.

## Verification

- **True regression pins**: neutralizing the prepend branch (making it a no-op) fails both bare-endpoint tests (`gpu-box:8765` != `ws://gpu-box:8765`) while the `wss://`-preserve test stays green -- confirmed, not tautologies.
- `inference/client.py` line coverage **98 -> 99%** (closes the last non-connection branch; the sole remaining uncovered line is the lazy first-use connect, out of scope here).
- `ruff check` + `ruff format --check` clean; no non-ASCII characters.
- Full `tests/inference/` suite: 43 passed, 1 skipped.

Single test file; no source changes.

## Test plan

```bash
pytest tests/inference/test_remote_policy_roundtrip.py -k scheme -v
```