### PR TITLE
test(sim): pin base-frame reward degradation + the unknown predicate kind

### DIFF
--- a/tests/simulation/test_benchmark_predicates.py
+++ b/tests/simulation/test_benchmark_predicates.py
@@ -581,6 +581,13 @@ class TestDegradationContract:
         term = make_predicate("joint_progress", joint="elbow", target=1.0)
         assert term(sim) == 0.0
 
+    def test_base_orientation_reward_zero_when_observation_raises(self):
+        # _base_quaternion: get_observation raises -> None -> the floating-base
+        # orientation regularizer degrades to 0.0 rather than crashing the eval.
+        sim = _RaisingBodyStateSim()
+        term = make_predicate("base_orientation", weight=1.0)
+        assert term(sim) == 0.0
+
     def test_contact_between_swallows_get_contacts_exception(self):
         sim = _RaisingContactSim()
         pred = make_predicate("contact_between", geom_a="g1", geom_b="g2")
@@ -773,6 +780,13 @@ class TestPayloadShapeGuards:
         sim = _NonDictObsSim()
         pred = make_predicate("joint_above", joint="elbow", value=0.0)
         assert pred(sim) is False
+
+    def test_base_orientation_reward_zero_when_observation_is_not_a_dict(self):
+        # _base_quaternion: get_observation returns a list -> guarded to None ->
+        # the base-orientation reward term degrades to 0.0.
+        sim = _NonDictObsSim()
+        term = make_predicate("base_orientation", weight=1.0)
+        assert term(sim) == 0.0
 
     def test_body_upright_false_when_backend_lacks_get_body_state(self):
         # _body_quaternion: backend exposes no get_body_state -> None -> the

--- a/tests/simulation/test_predicate_kind_guard.py
+++ b/tests/simulation/test_predicate_kind_guard.py
@@ -15,7 +15,12 @@ from __future__ import annotations
 import pytest
 
 from strands_robots.simulation.benchmark_spec import DeclarativeBenchmark
-from strands_robots.simulation.predicates import make_predicate, predicate_kind
+from strands_robots.simulation.predicates import (
+    PREDICATE_REGISTRY,
+    make_predicate,
+    predicate_kind,
+    register_predicate,
+)
 
 
 def _spec(**overrides):
@@ -38,6 +43,22 @@ class TestPredicateKind:
     def test_unknown_name_raises(self):
         with pytest.raises(ValueError, match="Unknown predicate"):
             predicate_kind("totally_made_up")
+
+    def test_custom_predicate_without_return_annotation_classifies_as_unknown(self):
+        # A predicate registered without a recognizable BoolPredicate /
+        # RewardTerm return annotation classifies as "unknown" and is exempt
+        # from kind validation - it may sit in a bool "success" clause without
+        # the reward-term rejection firing (the caller opted in by registering).
+        def factory():  # deliberately no -> annotation
+            return lambda _sim: True
+
+        try:
+            register_predicate("unannotated_probe", factory)
+            assert predicate_kind("unannotated_probe") == "unknown"
+            bench = DeclarativeBenchmark.from_dict(_spec(success={"all": [{"predicate": "unannotated_probe"}]}))
+            assert bench is not None
+        finally:
+            PREDICATE_REGISTRY.pop("unannotated_probe", None)
 
 
 class TestRewardTermRejectedInBoolClause:


### PR DESCRIPTION
## What

The predicate/reward DSL promises that predicates never crash the eval loop and "degrade gracefully" - a bool predicate to `False`, a reward term to `0.0` - when a backend method raises or returns a malformed payload. Two rungs of that contract were unpinned:

1. **Floating-base reward terms** (`base_orientation` and the other base-frame regularizers) read orientation through a shared `base_quat` observation lookup. That helper has two failure rungs the existing suite never exercised - `get_observation` raising, and `get_observation` returning a non-dict payload. Existing coverage only reached the third rung (a fixed-base arm whose observation simply carries no `base_quat`). A regression in either of the first two would let a transient backend fault propagate straight out of a `dense_reward` eval instead of quietly scoring `0.0`.

2. **`predicate_kind`'s `"unknown"` classification.** The classifier documents that a predicate registered via `register_predicate` without a recognizable `BoolPredicate` / `RewardTerm` return annotation classifies as `"unknown"` and is exempt from kind validation - it may sit in a bool `success` clause without the reward-term rejection firing. Both the branch and the exemption were uncovered.

## Change

Three focused tests, reusing the existing degradation fakes (`_RaisingBodyStateSim`, `_NonDictObsSim`) so no new scaffolding is introduced:

- `base_orientation` scores `0.0` when `get_observation` raises.
- `base_orientation` scores `0.0` when `get_observation` returns a non-dict.
- a custom predicate registered without a return annotation classifies as `"unknown"` and compiles unrejected in a `success` clause.

The tests assert observable outputs (verdict values, classifier result, successful compile) rather than internal state, and each exercises a real degradation path a backend can hit at runtime.

## Test

`MUJOCO_GL=egl pytest tests/simulation/test_benchmark_predicates.py tests/simulation/test_predicate_kind_guard.py` - 117 passed. This brings `strands_robots/simulation/predicates.py` from 99% to 100% line coverage (the 5 remaining lines - the two base_quat degradation rungs and the `"unknown"` classification - are now covered). Test-only change; no runtime code touched. `ruff check` / `ruff format --check` / `mypy` all clean.