### PR TITLE
test(vera): pin config env robustness + full server_env overlay

### DIFF
--- a/tests/policies/vera/test_vera_unit.py
+++ b/tests/policies/vera/test_vera_unit.py
@@ -51,6 +51,44 @@ class TestConfig:
         assert env["VERA_CKPT_ROOT"] == "/data/ckpts"
         assert env["VERA_TRACKER_BACKEND"] == "cotracker"
 
+    def test_server_env_overlay_forwards_wan_ckpt_and_dynamics_run(self):
+        """server_env() must forward every checkpoint/tracker knob the server
+        subprocess reads, including the frozen WAN base and the IDM run id."""
+        c = VeraConfig(
+            embodiment="mimicgen",
+            wan_ckpt_root="/data/wan",
+            dynamics_run_id="idm-run-42",
+        )
+        env = c.server_env()
+        assert env["VERA_WAN_CKPT_ROOT"] == "/data/wan"
+        assert env["VERA_DYNAMICS_RUN_ID"] == "idm-run-42"
+
+    def test_malformed_numeric_env_degrades_to_defaults(self, monkeypatch):
+        """A non-numeric env override must be ignored, not crash construction.
+
+        Deploy/CI environments frequently carry typo'd or empty numeric knobs
+        (e.g. VERA_SERVER_PORT=""). The int/float env parsers swallow the
+        ValueError and return None so config falls back to the per-embodiment
+        default instead of raising on import of the policy.
+        """
+        monkeypatch.setenv("VERA_SERVER_PORT", "not-a-port")
+        monkeypatch.setenv("VERA_VIS_PORT", "xyz")
+        monkeypatch.setenv("VERA_RENDER_WIDTH", "wide")
+        monkeypatch.setenv("VERA_SAMPLE_STEPS", "ten")
+        monkeypatch.setenv("VERA_N_ACTION_STEPS", "")
+        monkeypatch.setenv("VERA_MOTION_PLAN_SCALE", "fast")
+
+        c = VeraConfig(embodiment="pusht")
+
+        # Non-numeric int knobs fall back to the pusht per-embodiment defaults.
+        assert c.server_port == 8820
+        assert c.vis_port == 8821
+        assert c.render_width == 252  # pusht per-embodiment default
+        # Non-numeric optional knobs stay unset (planner yaml decides).
+        assert c.sample_steps is None
+        assert c.n_action_steps is None
+        assert c.motion_plan_scale is None
+
 
 # --------------------------------------------------------------------------- #
 # Factory registration


### PR DESCRIPTION
## Problem

`VeraConfig` had two untested behavioral contracts that are easy to regress and painful when they break at deploy time:

1. **Malformed numeric env overrides.** `__post_init__` reads several numeric knobs from the environment via `_env_int` / `_env_float` (`VERA_SERVER_PORT`, `VERA_VIS_PORT`, `VERA_RENDER_WIDTH`, `VERA_SAMPLE_STEPS`, `VERA_N_ACTION_STEPS`, `VERA_MOTION_PLAN_SCALE`). Those parsers swallow a `ValueError` and return `None` so a typo'd or empty value (e.g. `VERA_SERVER_PORT=""`) falls back to the per-embodiment default instead of crashing while the policy is being constructed. That graceful-degradation path had no test.
2. **`server_env()` overlay completeness.** The subprocess env overlay forwards checkpoint/tracker knobs to the VERA server. Only `VERA_CKPT_ROOT` and `VERA_TRACKER_BACKEND` were exercised; the frozen WAN base (`VERA_WAN_CKPT_ROOT`) and the IDM run id (`VERA_DYNAMICS_RUN_ID`) branches were never hit, so a regression that dropped either from the overlay would ship silently.

## Change

Two focused tests added to `TestConfig` in `tests/policies/vera/test_vera_unit.py`:

- `test_malformed_numeric_env_degrades_to_defaults` - sets all six numeric env knobs to non-numeric/empty values and asserts construction does not raise and falls back to the pusht per-embodiment defaults (ports 8820/8821, render_width 252) with the optional knobs left unset.
- `test_server_env_overlay_forwards_wan_ckpt_and_dynamics_run` - asserts `server_env()` includes `VERA_WAN_CKPT_ROOT` and `VERA_DYNAMICS_RUN_ID`.

Tests only; no runtime behavior change.

## Coverage

`strands_robots/policies/vera/config.py`: **95% -> 100%** (6 previously-uncovered lines: the `_env_int`/`_env_float` `except ValueError` fallbacks and the two `server_env` overlay branches).

## Verification

- `MUJOCO_GL=egl pytest tests/policies/vera/` -> 146 passed, 1 skipped.
- `ruff check` / `ruff format --check` clean; `mypy` clean (no issues in 743 source files).