### PR TITLE
feat(sim): base_tipped fall-over predicate for the benchmark/reward DSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Added: `base_tipped` locomotion fall-over predicate for the benchmark/reward DSL
+
+The predicate DSL grew a `base_tipped(tol, robot)` BOOL predicate on the floating-base `get_observation` surface (the same `base_quat` the `base_*` reward terms read): True when the base has tilted more than `tol` from level. It is the failure-clause counterpart of the `base_orientation` reward term - `base_orientation` penalises tilt in `dense_reward`, `base_tipped` terminates the episode on a fall in a `failure` clause - which is the canonical legged_gym / IsaacLab locomotion fall-over termination. Previously a locomotion spec could not express "the robot fell over, end the episode": the DSL has no `not` to negate `body_upright`, and `body_upright` reaches the base only by an embodiment-specific body name (unavailable for a mobile base whose free joint is unnamed). `base_tipped` needs no body name and is identical across the MuJoCo and Newton backends.
+
 ### Fixed: norm-stats FeatureNormalizer silently passed values through on an unrecognized mode
 
 `FeatureNormalizer.normalize` / `.unnormalize`

--- a/strands_robots/simulation/predicates.py
+++ b/strands_robots/simulation/predicates.py
@@ -38,6 +38,7 @@ Available predicates (bool):
     body_inside(body, container, xy_tol=0.15, z_tol=0.15)
     body_upright(body, tol=0.15)
     grasped(body, gripper_prefix)
+    base_tipped(tol=0.15, robot=None)
 
 Available reward terms (float):
 
@@ -771,6 +772,57 @@ def _grasped(body: str, gripper_prefix: str) -> BoolPredicate:
     return check
 
 
+def _base_tipped(tol: float = 0.15, robot: str | None = None) -> BoolPredicate:
+    """True when a floating base has tilted more than ``tol`` from level.
+
+    The failure-clause counterpart of the ``base_orientation`` reward term: while
+    ``base_orientation`` *penalises* tilt in ``dense_reward`` (a dense shaping
+    signal), ``base_tipped`` *terminates* the episode when the base falls over -
+    the canonical legged_gym / IsaacLab locomotion fall-over termination. Put it
+    in a ``failure`` clause
+    (``failure: {any: [{predicate: base_tipped, tol: 0.7}]}``) so a
+    velocity-tracking rollout ends the instant the robot topples instead of
+    flailing on the ground to ``max_steps``.
+
+    Reads ``get_observation``'s ``base_quat`` - the same embodiment-agnostic
+    floating-base surface the ``base_*`` reward terms read, so it needs no base
+    body name (it works on a mobile base whose free joint is unnamed) and is
+    identical across the MuJoCo and Newton backends, unlike ``body_upright``
+    which resolves a specific body by name. The tilt test is the exact
+    complement of ``body_upright``'s upright check applied to the base
+    quaternion (MuJoCo/Newton layout ``(w, x, y, z)``) - the fall-over
+    counterpart of ``body_upright``'s ``2*(x**2+y**2) < tol`` upright test:
+
+        R[2,2] = 1 - 2 * (x ** 2 + y ** 2)  ->  tipped when 2 * (x ** 2 + y ** 2) > tol
+
+    monotonic in how far the base is tipped, so ``tol`` is the maximum tilt the
+    base may reach before it counts as fallen. ``tol`` shares ``body_upright``'s
+    scale: ``2 * (x ** 2 + y ** 2) = 1 - cos(theta)`` for a roll/pitch of
+    ``theta``, so ``tol=0.15`` trips at ~32 deg (a tight "leaning" bound) and
+    ``tol=1.0`` trips at 90 deg (fully on its side) - a fall-over termination
+    typically uses a larger ``tol`` (~0.7-1.0) than the default.
+
+    Requires a robot with a floating base; a fixed-base arm has no base
+    orientation, so the predicate degrades to ``False`` (never tipped) and the
+    missing base is logged once. ``robot`` selects the robot in a multi-robot
+    scene (default: the sole robot).
+    """
+    t = float(tol)
+    if t < 0:
+        raise ValueError(f"base_tipped: 'tol' must be >= 0, got {t}")
+    rname = robot
+
+    def check(sim: SimEngine) -> bool:
+        quat = _base_quaternion(sim, rname)
+        if quat is None:
+            return False
+        # base_quat layout is (w, x, y, z) on both backends.
+        _, x, y, _ = quat
+        return 2.0 * (x * x + y * y) > t
+
+    return check
+
+
 # Reward terms (float-valued)
 
 
@@ -1181,6 +1233,7 @@ PREDICATE_REGISTRY: dict[str, PredicateFactory] = {
     "body_inside": _body_inside,
     "body_upright": _body_upright,
     "grasped": _grasped,
+    "base_tipped": _base_tipped,
     # float-valued
     "distance_neg": _distance_neg,
     "joint_progress": _joint_progress,

--- a/tests/simulation/test_base_tipped_predicate.py
+++ b/tests/simulation/test_base_tipped_predicate.py
@@ -1,0 +1,233 @@
+"""Regression tests for the ``base_tipped`` locomotion fall-over predicate.
+
+The predicate/reward DSL grew all five legged_gym reward terms
+(``base_velocity`` / ``base_height`` / ``base_orientation`` / ``base_lin_vel_z``
+/ ``base_ang_vel_xy``) reading the embodiment-agnostic floating-base surface
+from ``get_observation``, but it had no BOOL predicate on that surface. So a
+locomotion benchmark's canonical *termination* - "the robot fell over, end the
+episode" - was inexpressible: the DSL has no ``not`` operator to negate
+``body_upright``, and ``body_upright`` in a ``success`` clause is the wrong
+polarity for a survival task (it would report instant success on step 0). The
+only workaround was ``body_below_z(<base body name>)`` / ``body_upright(<base
+body name>)``, which needs a per-embodiment base body name and cannot reach a
+mobile base whose free joint is unnamed.
+
+``base_tipped(tol, robot)`` closes that gap. It is TRUE when the floating base
+has tilted more than ``tol`` from level - the exact complement of
+``body_upright``'s upright check applied to the ``base_quat`` signal - so it
+drops straight into a ``failure`` clause. These tests set a KNOWN base
+orientation directly on the sim and assert the tilt threshold, yaw invariance,
+roll/pitch symmetry, live tracking, fixed-base degradation, ``tol`` validation,
+and that a real ``DeclarativeBenchmark`` failure clause built from it terminates
+the episode when the base tips. They are GL-free (``get_observation`` with
+``skip_images``) so they run in CI without a display.
+"""
+
+import logging
+import math
+import os
+import tempfile
+
+import mujoco
+import pytest
+
+from strands_robots.simulation.benchmark_spec import DeclarativeBenchmark
+from strands_robots.simulation.mujoco.simulation import Simulation
+from strands_robots.simulation.predicates import (
+    PREDICATE_REGISTRY,
+    _reset_resolution_warnings,
+    make_predicate,
+    predicate_kind,
+)
+
+# Floating base with a NAMED free joint (a humanoid's floating_base_joint) plus
+# one actuated hinge. get_observation surfaces base_quat for this robot.
+NAMED_BASE_XML = """
+<mujoco model="test_named_base">
+  <compiler angle="radian" autolimits="true"/>
+  <option timestep="0.002"/>
+  <worldbody>
+    <light name="main" pos="0 0 3" dir="0 0 -1"/>
+    <geom name="ground" type="plane" size="5 5 0.01" rgba="0.9 0.9 0.9 1"/>
+    <body name="pelvis" pos="0 0 0.8">
+      <freejoint name="floating_base_joint"/>
+      <geom type="box" size="0.1 0.1 0.1" rgba="0.3 0.3 0.8 1"/>
+      <body name="thigh" pos="0 0 -0.1">
+        <geom type="capsule" size="0.03" fromto="0 0 0 0 0 -0.3" rgba="0.8 0.3 0.3 1"/>
+        <joint name="hip" type="hinge" axis="0 1 0" range="-1.5 1.5"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <motor name="hip_act" joint="hip"/>
+  </actuator>
+</mujoco>
+"""
+
+# Fixed-base arm: no free joint anywhere -> no base orientation. base_tipped
+# must degrade to False (and warn) rather than crash or invent a value.
+FIXED_ARM_XML = """
+<mujoco model="test_fixed">
+  <compiler angle="radian" autolimits="true"/>
+  <worldbody>
+    <light name="main" pos="0 0 3" dir="0 0 -1"/>
+    <body name="link" pos="0 0 0.1">
+      <geom type="capsule" size="0.02" fromto="0 0 0 0 0 0.2"/>
+      <joint name="j0" type="hinge" axis="0 0 1"/>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="j0_act" joint="j0" kp="10"/>
+  </actuator>
+</mujoco>
+"""
+
+
+def _axis_quat(axis: str, deg: float) -> list[float]:
+    """Unit (w, x, y, z) quaternion for a rotation of ``deg`` about a world axis."""
+    h = math.radians(deg) / 2.0
+    c, sn = math.cos(h), math.sin(h)
+    return {
+        "x": [c, sn, 0.0, 0.0],
+        "y": [c, 0.0, sn, 0.0],
+        "z": [c, 0.0, 0.0, sn],
+    }[axis]
+
+
+def _tilt_metric(deg: float) -> float:
+    """The predicate's tilt quantity 2*(x^2+y^2) for a roll/pitch of ``deg`` = 1 - cos(deg)."""
+    return 1.0 - math.cos(math.radians(deg))
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="test_base_tipped", mesh=False)
+    s.create_world(ground_plane=False)
+    yield s
+    s.cleanup()
+
+
+def _write(xml: str) -> str:
+    d = tempfile.mkdtemp()
+    p = os.path.join(d, "model.xml")
+    with open(p, "w") as f:
+        f.write(xml)
+    return p
+
+
+def _set_base_quat(sim, quat_wxyz: list[float]) -> None:
+    """Set the robot's (only) free joint to a fixed world height with orientation quat."""
+    model, data = sim._world._model, sim._world._data
+    jid = -1
+    for j in range(model.njnt):
+        if model.jnt_type[j] == mujoco.mjtJoint.mjJNT_FREE:
+            jid = j
+            break
+    assert jid >= 0
+    qadr = int(model.jnt_qposadr[jid])
+    data.qpos[qadr : qadr + 7] = [0.0, 0.0, 0.8, *quat_wxyz]
+    mujoco.mj_forward(model, data)
+
+
+def test_base_tipped_is_registered_as_a_bool_predicate():
+    """It must classify as bool so the DSL accepts it in success/failure clauses."""
+    assert "base_tipped" in PREDICATE_REGISTRY
+    assert predicate_kind("base_tipped") == "bool"
+
+
+def test_base_tipped_is_false_when_level(sim):
+    """A perfectly level base is not tipped at any tol >= 0."""
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    _set_base_quat(sim, [1.0, 0.0, 0.0, 0.0])
+    assert make_predicate("base_tipped")(sim) is False
+    assert make_predicate("base_tipped", tol=0.0)(sim) is False
+
+
+def test_base_tipped_trips_past_the_tol_threshold(sim):
+    """TRUE once the tilt quantity 2*(x^2+y^2) reaches tol; FALSE just below it."""
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    # tol=0.5 (1 - cos(theta) > 0.5): 45 deg (0.293) is below, 70 deg (0.658) is above.
+    below = make_predicate("base_tipped", tol=0.5)
+    _set_base_quat(sim, _axis_quat("x", 45.0))
+    assert _tilt_metric(45.0) < 0.5 and below(sim) is False
+    _set_base_quat(sim, _axis_quat("x", 70.0))
+    assert _tilt_metric(70.0) > 0.5 and below(sim) is True
+    # The default tol=0.15 trips at ~32 deg: a 10 deg lean is upright, 45 deg is tipped.
+    default = make_predicate("base_tipped")
+    _set_base_quat(sim, _axis_quat("x", 10.0))
+    assert _tilt_metric(10.0) < 0.15 and default(sim) is False
+    _set_base_quat(sim, _axis_quat("x", 45.0))
+    assert _tilt_metric(45.0) >= 0.15 and default(sim) is True
+
+
+def test_base_tipped_is_symmetric_roll_and_pitch(sim):
+    """A pitch of theta trips identically to a roll of theta (isotropic tilt)."""
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    term = make_predicate("base_tipped", tol=0.4)  # 1 - cos(theta) > 0.4 -> theta > ~53 deg
+    _set_base_quat(sim, _axis_quat("x", 65.0))
+    roll = term(sim)
+    _set_base_quat(sim, _axis_quat("y", 65.0))
+    pitch = term(sim)
+    assert roll is True and pitch is True
+    _set_base_quat(sim, _axis_quat("x", 40.0))
+    roll_lo = term(sim)
+    _set_base_quat(sim, _axis_quat("y", 40.0))
+    pitch_lo = term(sim)
+    assert roll_lo is False and pitch_lo is False
+
+
+def test_base_tipped_is_invariant_to_yaw(sim):
+    """Pure yaw (heading change) keeps the base level -> never tipped, so a
+    turning-in-place walker is not spuriously terminated."""
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    term = make_predicate("base_tipped", tol=0.05)  # tight bound
+    for yaw in (45.0, 90.0, 179.0):
+        _set_base_quat(sim, _axis_quat("z", yaw))
+        assert term(sim) is False, f"yaw {yaw} must not count as tipped"
+
+
+def test_base_tipped_tracks_the_live_base_orientation(sim):
+    """The predicate reads the CURRENT base orientation: tipping the base flips it."""
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    term = make_predicate("base_tipped", tol=0.5)
+    _set_base_quat(sim, [1.0, 0.0, 0.0, 0.0])
+    assert term(sim) is False
+    _set_base_quat(sim, _axis_quat("y", 90.0))  # fully on its side, 2*(x^2+y^2)=1.0
+    assert term(sim) is True
+
+
+def test_base_tipped_degrades_to_false_on_fixed_base_arm(sim, caplog):
+    """A fixed-base arm has no base orientation: the predicate degrades to False
+    (never tipped -> never spuriously fails an episode) and warns once."""
+    sim.add_robot("arm", urdf_path=_write(FIXED_ARM_XML))
+    _reset_resolution_warnings()
+    with caplog.at_level(logging.WARNING, logger="strands_robots.simulation.predicates"):
+        val = make_predicate("base_tipped")(sim)
+    assert val is False
+    assert any("base" in r.message.lower() for r in caplog.records)
+
+
+def test_base_tipped_rejects_negative_tol():
+    with pytest.raises(ValueError, match="tol"):
+        make_predicate("base_tipped", tol=-0.1)
+
+
+def test_declarative_benchmark_terminates_on_base_tipped(sim):
+    """End to end: a DeclarativeBenchmark failure clause built from base_tipped
+    compiles (it did not before this predicate existed) and its is_failure()
+    fires only once the base tips past tol - the locomotion fall-over
+    termination a velocity-tracking spec needs."""
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    bench = DeclarativeBenchmark.from_dict(
+        {
+            "name": "walk-forward",
+            "default_robot": "humanoid",
+            "max_steps": 1000,
+            "dense_reward": [{"predicate": "base_velocity", "vx": 1.0, "weight": 1.0}],
+            "failure": {"any": [{"predicate": "base_tipped", "tol": 0.7}]},
+        }
+    )
+    _set_base_quat(sim, [1.0, 0.0, 0.0, 0.0])
+    assert bench.is_failure(sim) is False  # upright: episode continues
+    _set_base_quat(sim, _axis_quat("y", 90.0))
+    assert bench.is_failure(sim) is True  # toppled: episode terminates


### PR DESCRIPTION
## Problem

The predicate/reward DSL now has all five legged_gym reward terms (`base_velocity`, `base_height`, `base_orientation`, `base_lin_vel_z`, `base_ang_vel_xy`) reading the embodiment-agnostic floating-base surface from `get_observation` (`base_pos`/`base_quat`/`base_lin_vel`/`base_ang_vel`). But there was **no BOOL predicate on that surface**, so a locomotion benchmark's canonical *termination* -- "the robot fell over, end the episode" -- was inexpressible:

- the DSL has no `not` operator to negate `body_upright`;
- `body_upright` in a `success` clause is the wrong polarity for a survival task (it reports instant success on step 0 when the base starts upright);
- `body_upright` / `body_below_z` reach the base only by an **embodiment-specific body name**, which is exactly what the reward terms avoid -- and is unavailable for a mobile base whose free joint is unnamed (see the floating-base state work).

So a velocity-tracking rollout could only flail on the ground to `max_steps` (wasted sim + a meaningless `success_rate`) instead of terminating on a fall.

## Change

Add `base_tipped(tol=0.15, robot=None)` -- a BOOL predicate that is `True` when the floating base has tilted more than `tol` from level, computed from `get_observation`'s `base_quat` (the fall-over counterpart of `body_upright`'s upright check: `2*(x**2 + y**2) > tol`). It is the **failure-clause counterpart of the `base_orientation` reward term**:

```yaml
dense_reward:
  - {predicate: base_velocity, vx: 1.0, weight: 1.0}
  - {predicate: base_height, target: 0.74, weight: 5.0}
  - {predicate: base_orientation, weight: 5.0}   # penalise tilt
failure:
  any:
    - {predicate: base_tipped, tol: 0.7}          # terminate on a fall
```

`base_orientation` *penalises* tilt (dense shaping); `base_tipped` *terminates* the episode on a fall -- the standard legged_gym / IsaacLab locomotion termination. Because it reads the same `base_quat` surface the `base_*` reward terms read, it needs no base body name, works for a mobile base whose free joint is unnamed, and is identical across the MuJoCo and Newton backends. It degrades to `False` (never tipped -> never spuriously fails an episode) with a warn-once on a fixed-base arm. `tol` shares `body_upright`'s scale (`2*(x**2+y**2) = 1 - cos(theta)`), so `tol=0.15` trips at ~32 deg and `tol=1.0` at 90 deg; a fall-over termination typically uses a larger `tol` (~0.7-1.0).

`predicate_kind("base_tipped") == "bool"` (from its `-> BoolPredicate` return annotation) so the DSL accepts it in `success`/`failure` clauses and rejects it from `dense_reward`. It is added to the module docstring's `Available predicates (bool)` list (the discovery surface the completeness test pins).

## Tests

New `tests/simulation/test_base_tipped_predicate.py` (GL-free, real MuJoCo floating-base sim, no mocks): bool classification, level-is-not-tipped, trips past the `tol` threshold, roll/pitch symmetry, yaw invariance (a turning-in-place walker is not terminated), live tracking, fixed-base degradation + warning, `tol` validation, and an end-to-end `DeclarativeBenchmark` whose `failure` clause built from `base_tipped` terminates the episode when the base topples. All 9 fail before this predicate exists (`Unknown predicate 'base_tipped'`) and pass after. 166 predicate/benchmark/reward/docstring/kind-guard tests pass; ruff + mypy clean.