### PR TITLE
fix(sim): registry name overrides spec-internal name in register_benchmark_from_file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: benchmark registered from a spec file reported the spec-internal name, not the registry name
+
+`register_benchmark_from_file(name, spec_path)` documents that the registry
+`name` "overrides any name declared inside the spec (so the same spec file can
+be registered under multiple names)", but it merged the name with
+`spec_dict.setdefault("name", name)` - which only applies when the spec omits a
+`name`. A spec that declared its own `name` kept it, so the resulting
+`DeclarativeBenchmark` instance reported the stale spec-internal name (the value
+`DeclarativeBenchmark.name` returns, which its own error/log messages quote),
+not the key it was registered under. Registering the same spec under two names
+then produced two instances that both reported the one spec-internal name and
+neither matched its registry key. The registry name now unconditionally
+overrides the spec-internal `name`, so an instance's `.name` always matches the
+key it is registered and looked up under. Specs that omit `name`, and the direct
+`DeclarativeBenchmark.from_dict` path, are unaffected.
+
 ### Added: `base_tipped` locomotion fall-over predicate for the benchmark/reward DSL
 
 The predicate DSL grew a `base_tipped(tol, robot)` BOOL predicate on the floating-base `get_observation` surface (the same `base_quat` the `base_*` reward terms read): True when the base has tilted more than `tol` from level. It is the failure-clause counterpart of the `base_orientation` reward term - `base_orientation` penalises tilt in `dense_reward`, `base_tipped` terminates the episode on a fall in a `failure` clause - which is the canonical legged_gym / IsaacLab locomotion fall-over termination. Previously a locomotion spec could not express "the robot fell over, end the episode": the DSL has no `not` to negate `body_upright`, and `body_upright` reaches the base only by an embodiment-specific body name (unavailable for a mobile base whose free joint is unnamed). `base_tipped` needs no body name and is identical across the MuJoCo and Newton backends.

--- a/strands_robots/simulation/benchmark_spec.py
+++ b/strands_robots/simulation/benchmark_spec.py
@@ -396,8 +396,13 @@ def register_benchmark_from_file(
     if not isinstance(name, str) or not name:
         raise ValueError(f"register_benchmark_from_file: name must be a non-empty string, got {name!r}")
     spec_dict = _load_spec_file(spec_path)
-    # Spec-internal name is informational; the registry name always wins.
-    spec_dict.setdefault("name", name)
+    # The registry name always wins: unconditionally override any spec-internal
+    # ``name`` so the instance's ``.name`` matches the key it is registered under
+    # (the documented contract). ``setdefault`` was insufficient - a spec that
+    # declared its own ``name`` kept it, so the same spec registered under two
+    # keys produced two instances that both reported the spec-internal name and
+    # neither matched its registry key.
+    spec_dict["name"] = name
     benchmark = DeclarativeBenchmark.from_dict(spec_dict)
     register_benchmark(name, benchmark)
     return benchmark

--- a/tests/simulation/test_benchmark_dsl.py
+++ b/tests/simulation/test_benchmark_dsl.py
@@ -285,7 +285,12 @@ success:
         assert ".toml" in str(exc.value) or "extension" in str(exc.value)
 
     def test_spec_name_internal_overridden_by_registry_name(self, tmp_path):
-        """Registry name wins over any ``name`` declared inside the spec file."""
+        """Registry name wins over any ``name`` declared inside the spec file.
+
+        The override applies to the instance's ``.name`` too, not just the
+        registry key - the documented contract is that the registry name wins,
+        and ``DeclarativeBenchmark.name`` is what error/log messages report.
+        """
         p = tmp_path / "s.json"
         p.write_text(
             json.dumps(
@@ -296,10 +301,36 @@ success:
                 }
             )
         )
-        register_benchmark_from_file("external-name", str(p))
-        assert get_benchmark("external-name") is not None
+        bench = register_benchmark_from_file("external-name", str(p))
+        assert get_benchmark("external-name") is bench
         # The spec's internal name doesn't end up in the registry.
         assert get_benchmark("internal-name") is None
+        # The instance reports the registry name, not the stale spec-internal one.
+        assert bench.name == "external-name"
+
+    def test_same_spec_registered_under_multiple_names(self, tmp_path):
+        """The documented use case: one spec file, many registry names.
+
+        Each registration must yield an instance whose ``.name`` matches its own
+        registry key so the two are distinguishable - a spec that declares its
+        own ``name`` must not make every registration report that one name.
+        """
+        p = tmp_path / "s.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "name": "declared-in-spec",
+                    "default_robot": "so100",
+                    "supported_robots": ["so100"],
+                }
+            )
+        )
+        first = register_benchmark_from_file("task-a", str(p))
+        second = register_benchmark_from_file("task-b", str(p))
+        assert first.name == "task-a"
+        assert second.name == "task-b"
+        assert get_benchmark("task-a").name == "task-a"
+        assert get_benchmark("task-b").name == "task-b"
 
     def test_rejects_empty_name(self, tmp_path):
         p = tmp_path / "s.json"


### PR DESCRIPTION
## Problem

`register_benchmark_from_file(name, spec_path)` documents that its `name` argument *"Overrides any name declared inside the spec (so the same spec file can be registered under multiple names)"* — and its own inline comment says *"the registry name always wins."* But it merged the name with:

```python
spec_dict.setdefault("name", name)
```

`setdefault` only writes when the key is **absent**. A spec that declares its own `name` keeps it, so the compiled `DeclarativeBenchmark` reports the **stale spec-internal name** — the value `DeclarativeBenchmark.name` returns, which the benchmark's own error/log messages quote (e.g. `DeclarativeBenchmark '<name>': load_scene(...) failed`). Only the registry **key** (`register_benchmark(name, ...)`) honored the argument; the instance's identity did not.

Consequences:
- `get_benchmark("external-name").name` returned `"internal-name"` — the instance reports a name that is not the key you registered/look it up under.
- The documented *"register the same spec file under multiple names"* use case was broken: every registration produced an instance reporting the single spec-internal name, so the instances were indistinguishable by `.name` and none matched its registry key.

## Fix

Unconditionally override the spec-internal `name` with the registry `name` so an instance's `.name` always matches the key it is registered and looked up under — the behavior the docstring and inline comment already promise. Specs that omit `name`, and the direct `DeclarativeBenchmark.from_dict(spec)` path (which correctly uses the spec's own name), are unaffected.

## Tests

- Strengthened the existing `test_spec_name_internal_overridden_by_registry_name` to also assert `bench.name == "external-name"` (the assertion its own name always implied but never checked).
- Added `test_same_spec_registered_under_multiple_names`: one spec file (declaring its own `name`) registered under `task-a` and `task-b` — each instance must report its own registry key.

Both fail before the fix (`assert 'internal-name' == 'external-name'`, `assert 'declared-in-spec' == 'task-a'`) and pass after.

## Gate

- `tests/simulation/test_benchmark_dsl.py` — 41 passed.
- Broader benchmark/predicate suites (`test_predicate_kind_guard`, `test_benchmark_dispatch`, `test_base_below_z_predicate`, `test_base_tipped_predicate`, `test_simengine_facade_guardrails`) — 68 passed.
- `ruff check` + `ruff format --check` clean; `mypy` clean on the changed module.