### PR TITLE
test(policies): pin WBC observation input-edge contracts

### DIFF
--- a/tests/policies/wbc/test_policy.py
+++ b/tests/policies/wbc/test_policy.py
@@ -243,6 +243,77 @@ class TestObservationLayout:
                 prev_action=np.zeros(_N),
             )
 
+    def test_layout_overflow_raises_when_single_obs_dim_too_small(self) -> None:
+        # single_obs_dim is a stored scalar, NOT cross-checked against the
+        # command/joint/action dims by WBCConfig.__post_init__ - a stale or
+        # miscopied value (e.g. paired with the wrong checkpoint) would silently
+        # under-size the frame. build_single_frame catches it: the layout needs
+        # command_dim + 6 + 2*n_obs_joints + num_actions = 3+6+2+1 = 12 slots,
+        # but the config declares only 10, so it must raise rather than write
+        # past the frame or silently drop the action block.
+        cfg = _make_config(
+            num_actions=1,
+            n_obs_joints=1,
+            command_dim=3,
+            single_obs_dim=10,
+            default_angles=[0.0],
+            kps=[1.0],
+            kds=[1.0],
+        )
+        with pytest.raises(ValueError, match="observation layout needs 12 values"):
+            build_single_frame(
+                cfg,
+                command=np.zeros(3),
+                base_ang_vel=np.zeros(3),
+                proj_gravity=np.zeros(3),
+                qj=np.zeros(1),
+                dqj=np.zeros(1),
+                prev_action=np.zeros(1),
+            )
+
+    def test_wrong_base_ang_vel_length_raises(self) -> None:
+        # base_ang_vel/proj_gravity are the fixed-3 sensor sub-vectors; a length
+        # mismatch is a caller wiring bug (e.g. feeding a quaternion where an
+        # angular velocity is expected). _require_len rejects it by name rather
+        # than mis-slotting the value into the frame.
+        cfg = _make_config()
+        with pytest.raises(ValueError, match="base_ang_vel must have length 3, got 2"):
+            build_single_frame(
+                cfg,
+                command=np.zeros(3),
+                base_ang_vel=np.zeros(2),
+                proj_gravity=np.zeros(3),
+                qj=np.zeros(_NO),
+                dqj=np.zeros(_NO),
+                prev_action=np.zeros(_N),
+            )
+
+    def test_wrong_qj_length_raises(self) -> None:
+        # qj/dqj span ALL observed joints (n_obs_joints=29), NOT the controlled
+        # subset (num_actions=15). Passing 15-wide qj is the exact mistake the
+        # module docstring warns about ("Using 15 for qj/dqj would populate only
+        # 58 and misplace the data"); it must raise, not silently truncate.
+        cfg = _make_config()
+        with pytest.raises(ValueError, match=f"qj must have length {_NO}, got {_N}"):
+            build_single_frame(
+                cfg,
+                command=np.zeros(3),
+                base_ang_vel=np.zeros(3),
+                proj_gravity=np.zeros(3),
+                qj=np.zeros(_N),
+                dqj=np.zeros(_NO),
+                prev_action=np.zeros(_N),
+            )
+
+    def test_history_push_wrong_frame_width_raises(self) -> None:
+        # ObservationHistory.push feeds directly into the network input stack; a
+        # frame that is not exactly single_obs_dim wide would desync the stacked
+        # layout for every subsequent tick. Reject at push time rather than
+        # producing a mis-shaped num_obs vector downstream.
+        hist = ObservationHistory(_make_config())
+        with pytest.raises(ValueError, match="frame must have length single_obs_dim=86, got 85"):
+            hist.push(np.zeros(85))
+
     def test_history_zero_warm_start_and_width(self) -> None:
         """Upstream warm-start: the deque is pre-filled with ZERO frames, so the
         first push yields [zeros .. zeros, frame] (oldest-first), NOT copies of


### PR DESCRIPTION
## Problem
The WBC observation builder (`strands_robots/policies/wbc/observation.py`) has a thorough layout suite in `tests/policies/wbc/test_policy.py::TestObservationLayout`, but four input-edge guards were never exercised, leaving them unpinned against regression (module was at 94% line coverage):

- `build_single_frame` raising when `single_obs_dim` is too small for the layout it must write.
- `build_single_frame` rejecting a wrong-length fixed-3 sensor sub-vector (`base_ang_vel` / `proj_gravity`).
- `build_single_frame` rejecting a `num_actions`-wide `qj` where `n_obs_joints` is expected.
- `ObservationHistory.push` rejecting a frame that is not `single_obs_dim` wide.

## Change
Adds four focused tests to `tests/policies/wbc/test_policy.py` (pure-numpy, no GPU/ONNX/hardware), pinning:

- **Layout overflow**: `WBCConfig.__post_init__` validates each dim individually but does NOT cross-check `single_obs_dim` against `command_dim + 6 + 2*n_obs_joints + num_actions`. A stale/miscopied `single_obs_dim` (e.g. paired with the wrong checkpoint) would under-size the frame; `build_single_frame` raises `ValueError` ("observation layout needs N values") rather than writing past the frame or silently dropping the action block.
- **Wrong `base_ang_vel` length**: a length mismatch on a fixed-3 sensor sub-vector is a caller wiring bug (e.g. a quaternion fed where an angular velocity is expected); `_require_len` rejects it by name rather than mis-slotting the value.
- **Wrong `qj` length**: passing a 15-wide (`num_actions`) `qj` where 29 (`n_obs_joints`) is expected is the exact whole-body-vs-controlled-subset mistake the module docstring warns about; it raises rather than silently truncating.
- **`ObservationHistory.push` wrong frame width**: a non-`single_obs_dim` frame would desync the stacked network input for every later tick; rejected at push time.

Tests assert observable outputs (raised `ValueError`s), not internal state, per AGENTS.md "Test behavior, not implementation."

## Tests
`strands_robots/policies/wbc/observation.py`: 94% -> 99% line coverage.

```
tests/policies/wbc/test_policy.py::TestObservationLayout ......... 9 passed
tests/policies/wbc/ ............................................ 155 passed, 3 skipped
```

The single remaining uncovered line is a defensive `stacked width != num_obs` invariant that is structurally unreachable through the public API (since `num_obs == single_obs_dim * obs_history_len` by definition and the deque is always `maxlen`-full of `single_obs_dim` frames). Per AGENTS.md "Test behavior, not implementation" and "No dead code," it is left unpinned rather than forcing an artificial test.

Ruff check + format clean. ASCII-only. Test-only; no behavior change.