### PR TITLE
test(vera): pin set_ik_target overrides + autoconfigure_ik contracts

### DIFF
--- a/tests/policies/vera/test_vera_autoconfig_ik.py
+++ b/tests/policies/vera/test_vera_autoconfig_ik.py
@@ -229,3 +229,98 @@ def test_discover_returns_none_when_chain_has_no_leaf():
     sites = []
     model = _install_fake_mujoco(bodies, sites, {0: 1, 1: 0})
     assert ee_frame.discover_ee_frame(model, "robot/") is None
+
+
+def test_set_ik_target_applies_rotation_dim_and_translation_scale_overrides():
+    """set_ik_target stores explicit rotation_dim + translation_scale overrides.
+
+    The embodiment defaults are axis-angle (rotation_dim=3, translation_scale=1.0);
+    a caller driving a rot6d server must be able to override both, and doing so
+    forces the IK bridge to rebuild so the new encoding takes effect.
+    """
+    from strands_robots.policies.vera.provider import VeraPolicy
+
+    class FakeClient:
+        def get_server_metadata(self):
+            return {"action_space": "eef_delta", "view_keys": ["image"]}
+
+        def reset(self, i):
+            pass
+
+        def configure(self, p):
+            return {}
+
+        def close(self):
+            pass
+
+        def infer(self, r):
+            return {"action": np.zeros((1, 7), np.float32)}
+
+    p = VeraPolicy(client=FakeClient(), auto_launch_server=False)
+    # Defaults before any override.
+    assert p._rotation_dim == 3
+    assert p._translation_scale == 1.0
+
+    p.set_ik_target(object(), "hand", "body", rotation_dim=6, translation_scale=2.5)
+
+    assert p._rotation_dim == 6
+    assert p._translation_scale == 2.5
+    assert p._ee_frame_name == "hand"
+    assert p._ee_frame_type == "body"
+    assert p._ik_bridge is None, "set_ik_target must reset the bridge so it rebuilds"
+
+
+def test_autoconfigure_ik_returns_false_without_model():
+    """autoconfigure_ik declines (False) when no MjModel is available yet.
+
+    The sim passes its compiled model into the handshake; before that arrives
+    there is nothing to discover, so auto-config is a no-op rather than an error.
+    """
+    from strands_robots.policies.vera.provider import VeraPolicy
+
+    p = VeraPolicy(client=None, auto_launch_server=False)
+    assert p.autoconfigure_ik(None) is False
+    assert p._ee_frame_name is None
+
+
+def test_autoconfigure_ik_is_idempotent_once_configured():
+    """A second autoconfigure_ik call short-circuits to True without rediscovery.
+
+    Once an ee-frame is set (explicitly or by a prior auto-config) the method is
+    idempotent unless force=True, so repeated sim handshakes do not re-run
+    discovery or clobber an explicit frame.
+    """
+    import importlib
+
+    from strands_robots.policies.vera import ee_frame
+
+    importlib.reload(ee_frame)
+    from strands_robots.policies.vera.provider import VeraPolicy
+
+    p = VeraPolicy(client=None, auto_launch_server=False)
+    p._ee_frame_name = "explicit/tcp"
+    p._ee_frame_type = "site"
+    # A model with no discoverable frame would return False if discovery ran;
+    # idempotency must short-circuit before that, keeping the explicit frame.
+    model = _install_fake_mujoco(["world"], [], {})
+    assert p.autoconfigure_ik(model, "robot/") is True
+    assert p._ee_frame_name == "explicit/tcp", "explicit frame must be preserved"
+
+
+def test_autoconfigure_ik_returns_false_when_discovery_finds_nothing():
+    """autoconfigure_ik returns False when the model exposes no ee-frame.
+
+    A model whose namespace holds no site/body hint and no leaf body yields no
+    discovery result, so auto-config declines and leaves IK unconfigured.
+    """
+    import importlib
+
+    from strands_robots.policies.vera import ee_frame
+
+    importlib.reload(ee_frame)
+    from strands_robots.policies.vera.provider import VeraPolicy
+
+    p = VeraPolicy(client=None, auto_launch_server=False)
+    model = _install_fake_mujoco(["world"], [], {})  # nothing under 'panda/'
+    assert p.autoconfigure_ik(model, "panda/") is False
+    assert p._ee_frame_name is None


### PR DESCRIPTION
## What
Adds four focused tests for `VeraPolicy` IK configuration behavior that was previously uncovered, raising `strands_robots/policies/vera/provider.py` coverage (the `set_ik_target` override path and the `autoconfigure_ik` decline/idempotency branches at lines 249-251, 270, 272, 277 were untested).

## Why
The eef/cartesian-delta embodiments (mimicgen/droid) rely on these contracts to wire IK correctly. The existing `test_vera_autoconfig_ik.py` exercised `ee_frame.discover_ee_frame` and the `set_sim_context` happy path, but never pinned:

- `set_ik_target(..., rotation_dim=, translation_scale=)` applying explicit overrides and resetting the bridge so the new encoding rebuilds.
- `autoconfigure_ik(None)` declining with `False` before the sim model handshake.
- `autoconfigure_ik` being idempotent (short-circuit `True`, explicit frame preserved) unless `force=True`.
- `autoconfigure_ik` returning `False` when the model exposes no discoverable ee-frame.

These are behavioral assertions (public return values + stored config), not implementation details, so they guard the IK-config contract against regression.

## Tests
Appended to `tests/policies/vera/test_vera_autoconfig_ik.py` (reuses the existing autouse `sys.modules['mujoco']` snapshot fixture and `_install_fake_mujoco`, so nothing leaks into later tests that import real mujoco).

- `test_set_ik_target_applies_rotation_dim_and_translation_scale_overrides`
- `test_autoconfigure_ik_returns_false_without_model`
- `test_autoconfigure_ik_is_idempotent_once_configured`
- `test_autoconfigure_ik_returns_false_when_discovery_finds_nothing`

Local gate: `ruff check`/`ruff format --check` clean, `mypy` clean (745 files), `MUJOCO_GL=egl pytest tests/policies/vera tests/policies/wbc/test_torque_harness.py` -> 154 passed, 1 skipped (no fake-mujoco cross-test contamination).

Test-only change; no runtime behavior modified.