### PR TITLE
test(hardware): pin stream never-raise-past-dispatch + fail-soft cleanup contracts

### DIFF
--- a/tests/test_hardware_robot_lifecycle.py
+++ b/tests/test_hardware_robot_lifecycle.py
@@ -627,6 +627,45 @@ class TestStreamDispatch:
         assert captured["instruction"] == "go"
         hw.cleanup()
 
+    def test_stream_never_raises_past_dispatch_on_handler_error(self):
+        # Tool contract: a handler blowing up must surface as a structured
+        # {"status": "error"} event, never propagate out of the async
+        # generator (which the agent runtime cannot recover from).
+        hw = _make_robot()
+
+        def _boom():
+            raise RuntimeError("kaboom")
+
+        hw.get_task_status = _boom  # type: ignore[assignment]
+        events = _drain(hw.stream({"toolUseId": "t6", "input": {"action": "status"}}, {}))
+        result = events[-1].tool_result
+        assert result["status"] == "error"
+        assert "kaboom" in result["content"][0]["text"]
+        hw.cleanup()
+
+
+class TestCleanupFailSoft:
+    def test_cleanup_continues_when_stop_teleoperate_raises(self):
+        # A teleop teardown failure must not abort the rest of cleanup: the
+        # mesh (and every later teardown step) still has to run so the process
+        # does not leak a live transport when teleop happens to be flaky.
+        hw = _make_robot()
+        hw._teleop_running = True
+
+        def _raise_teleop():
+            raise RuntimeError("teleop teardown failed")
+
+        hw.stop_teleoperate = _raise_teleop  # type: ignore[assignment]
+
+        stopped: list[str] = []
+        hw.mesh = types.SimpleNamespace(stop=lambda: stopped.append("mesh"))
+
+        # Must not raise despite stop_teleoperate blowing up...
+        hw.cleanup()
+
+        # ...and cleanup must have continued past the failure to tear the mesh down.
+        assert stopped == ["mesh"]
+
 
 # ---------------------------------------------------------------------------
 # Status / spec surface


### PR DESCRIPTION
## Problem
The hardware `Robot` tool relies on two defensive `try/except` blocks that had no test coverage, so a refactor could silently drop either guarantee:

1. `Robot.stream(...)` wraps its whole async dispatch in `except Exception` (`hardware_robot.py`) so an internal handler error surfaces as a structured `{"status": "error"}` `ToolResultEvent` instead of propagating out of the async generator - which the agent runtime cannot recover from. This is the standard tool-boundary contract (tools report errors, they never raise past dispatch).
2. `Robot.cleanup()` calls `stop_teleoperate()` inside a best-effort `try/except` so a flaky teleop teardown does not abort the remaining teardown steps (mesh stop, executor shutdown, ROS bridge), which would otherwise leak a live transport.

Both branches were uncovered.

## Change
Add two focused behavior tests in `tests/test_hardware_robot_lifecycle.py` (no production code change), built on the existing hardware-free `_make_robot` fixture:

- `test_stream_never_raises_past_dispatch_on_handler_error` - stubs a raising action handler and asserts `stream()` yields a structured error event (status `error`, message carried through) rather than propagating the exception.
- `TestCleanupFailSoft::test_cleanup_continues_when_stop_teleoperate_raises` - makes `stop_teleoperate()` raise, then asserts `cleanup()` does not raise and still tears the mesh down (proving teardown continued past the caught failure).

Each test fails if its corresponding resilience wrapper is removed, so they pin the contract as a regression guard.

## Tests
- `pytest tests/test_hardware_robot_lifecycle.py`: 66 passed.
- Covers the previously-uncovered `stream()` outer `except` and the `cleanup()` teleop-teardown `except` branches.
- Gate green: `ruff check` / `ruff format --check` clean; `mypy strands_robots tests tests_integ` -> no issues in 747 source files.

Test-only; no runtime behavior change.