### PR TITLE
test(lerobot_train): make extra_flags gate tests hermetic to ambient consent env

### DIFF
--- a/tests/test_lerobot_train_blocklist.py
+++ b/tests/test_lerobot_train_blocklist.py
@@ -117,6 +117,21 @@ class TestNormalizeHydraKey:
 class TestGateExtraFlags:
     """Pin the HIL gate contract: allowlist, bypass, interrupt, decline."""
 
+    @pytest.fixture(autouse=True)
+    def _hermetic_gate_env(self, monkeypatch):
+        """Neutralize ambient env that short-circuits the gate.
+
+        Both BYPASS_TOOL_CONSENT and STRANDS_TRAIN_EXTRA_FLAGS_ALLOW cause the
+        gate to allow blocked flags without prompting. A developer or CI shell
+        that exports BYPASS_TOOL_CONSENT=true (common in agent/automation
+        contexts) would otherwise make the no-context, allowlist, and interrupt
+        cases pass silently and fail their assertions. Clearing both per-test
+        makes each case deterministic regardless of the ambient environment;
+        tests that exercise those paths opt in explicitly via monkeypatch.setenv.
+        """
+        monkeypatch.delenv("BYPASS_TOOL_CONSENT", raising=False)
+        monkeypatch.delenv("STRANDS_TRAIN_EXTRA_FLAGS_ALLOW", raising=False)
+
     def test_benign_flags_pass(self):
         assert _gate_extra_flags({"lr": "1e-4"}, None) is None
 


### PR DESCRIPTION
## Problem
The `lerobot_train` extra_flags HIL gate (`_gate_extra_flags`) intentionally short-circuits when either `BYPASS_TOOL_CONSENT=true` or `STRANDS_TRAIN_EXTRA_FLAGS_ALLOW` covers the blocked flag. Five `TestGateExtraFlags` cases assert the *prompting* path (no-context error, partial allowlist, interrupt approved/declined/failed) but never neutralize those env vars.

As a result the tests are non-hermetic: in any shell that exports `BYPASS_TOOL_CONSENT=true` (common in agent/automation/CI-runner contexts) the gate allows the flag silently and the five tests fail with `assert None is not None` / `interrupt Called 0 times`. They only pass on a shell where the var happens to be unset.

Reproduce on current main:
```
BYPASS_TOOL_CONSENT=true pytest tests/test_lerobot_train_blocklist.py::TestGateExtraFlags
# 5 failed, 44 passed
```

## Change
Add a class-scoped autouse fixture to `TestGateExtraFlags` that clears both `BYPASS_TOOL_CONSENT` and `STRANDS_TRAIN_EXTRA_FLAGS_ALLOW` per test via `monkeypatch.delenv(..., raising=False)`. Cases that exercise the bypass/allowlist paths (`test_bypass_consent_allows`, `test_allowlist_skips_gate`, `test_allowlist_partial`) still opt in explicitly with `monkeypatch.setenv`, so the contract under test is unchanged.

Test-only change; no production behavior is modified.

## Verification
- Pre-fix, hostile env (`BYPASS_TOOL_CONSENT=true`): 5 failed, 44 passed.
- Post-fix, hostile env (`BYPASS_TOOL_CONSENT=true STRANDS_TRAIN_EXTRA_FLAGS_ALLOW=output_dir`): 49 passed.
- `ruff check` / `ruff format --check` clean; `mypy strands_robots tests tests_integ` -> no issues in 749 files.