### PR TITLE
feat(sim): advertise load_scene + object-manipulation siblings in MuJoCo describe()

### DIFF
--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1400,6 +1400,33 @@ class MuJoCoSimEngine(
                     bodies.append(body_name)
         base["bodies"] = bodies
         base["methods"]["list_bodies"] = "(robot_name: str | None = None) -> dict (camera mount points)"
+        # Scene-construction + object-manipulation siblings that the base
+        # discovery surface omits. describe() already advertises add_object /
+        # remove_object and add_robot, but an agent enumerating how to build
+        # and vary a scene from describe() alone could not discover the
+        # alternative scene entry point (load_scene), the object siblings
+        # (list_objects / move_object), or domain randomization - all
+        # first-class facades it would otherwise have to guess by name.
+        base["methods"]["load_scene"] = (
+            "(scene_path: str) -> dict  # load a complete scene from an MJCF "
+            "(or URDF) file; the alternative scene-construction entry point to "
+            "add_robot - downstream add_object/add_camera/add_robot then mutate "
+            "the loaded scene"
+        )
+        base["methods"]["list_objects"] = (
+            "() -> dict  # enumerate objects added to the scene (the object sibling of list_robots / list_cameras)"
+        )
+        base["methods"]["move_object"] = (
+            "(name: str, position=None, orientation=None) -> dict  # reposition "
+            "an existing object; position is [x, y, z] meters, orientation is a "
+            "[w, x, y, z] quaternion (either may be omitted to leave it unchanged)"
+        )
+        base["methods"]["randomize"] = (
+            "(randomize_colors=True, randomize_lighting=True, "
+            "randomize_physics=False, randomize_positions=False, "
+            "position_noise=0.02, seed=None, ...) -> dict  # domain randomization "
+            "(each axis opt-in; no flags = no-op). Destructive - recompile to undo"
+        )
         # Scene-construction cameras: the SO-101 rollout rig is built with
         # add_camera before run_policy, so the discovery surface must name it
         # (and its inverse) rather than leave a caller to guess.

--- a/tests/simulation/test_sim_engine_describe_discovery.py
+++ b/tests/simulation/test_sim_engine_describe_discovery.py
@@ -294,6 +294,35 @@ class TestDescribeMuJoCo:
         finally:
             sim.destroy()
 
+    def test_describe_lists_scene_and_object_manipulation_siblings(self):
+        """describe() advertises load_scene and the object-manipulation siblings.
+
+        describe() advertised add_object / remove_object and add_robot, but
+        omitted the alternative scene-construction entry point (load_scene), the
+        object siblings that complete the add/remove pair (list_objects,
+        move_object), and the domain-randomization facade (randomize) -- all
+        first-class public methods the tool spec + action dispatcher already
+        expose. An agent enumerating how to build and vary a scene from
+        describe() alone could not discover them and had to guess method names.
+        """
+        import os
+
+        os.environ.setdefault("MUJOCO_GL", "egl")
+        from strands_robots.simulation import Simulation
+
+        sim = Simulation()
+        try:
+            methods = sim.describe()["methods"]
+            for name in ("load_scene", "list_objects", "move_object", "randomize"):
+                assert name in methods, f"describe() omits scene/object method {name!r}"
+            # Advertised signatures name the real distinguishing parameters so a
+            # caller can invoke them without reading the source.
+            assert "scene_path" in methods["load_scene"]
+            assert "orientation" in methods["move_object"]
+            assert "randomize_physics" in methods["randomize"]
+        finally:
+            sim.destroy()
+
     def test_describe_lists_physics_introspection_methods(self):
         """describe() advertises the read/verify surface, not just act/record.
 


### PR DESCRIPTION
## Problem

`describe()` is the machine-readable discovery surface an agent calls first to learn the engine's live contract without guessing method names. On the MuJoCo backend it already advertises `add_object` / `remove_object` and `add_robot`, but it omitted several first-class public methods the tool spec and action dispatcher already expose:

- `load_scene` - the alternative scene-construction entry point to `add_robot` (load a full MJCF/URDF scene from disk)
- `list_objects` - the object sibling of `list_robots` / `list_cameras`
- `move_object` - the sibling that completes the `add_object` / `remove_object` pair
- `randomize` - the domain-randomization facade

So an agent enumerating how to build and vary a scene from `describe()` alone could not discover these and had to guess method names (or dead-end in an `AttributeError`). The add/remove object group and the two scene entry points were only partially represented on the discovery surface.

## Change

Add the four methods to the MuJoCo `describe()` override with concise signatures naming their distinguishing parameters (`scene_path`, `position`/`orientation`, `randomize_physics`, ...). This matches the existing precedent in the same method, where `render_depth` / `render_all` and the recording surface were already added as "siblings the base discovery surface omits". No runtime behavior changes - the methods already existed and behave identically; this only makes them discoverable in one `describe()` call.

## Tests

Adds `test_describe_lists_scene_and_object_manipulation_siblings` to `TestDescribeMuJoCo`, asserting the four methods are advertised with their key parameters. It fails on pre-change code (`describe() omits scene/object method 'load_scene'`) and passes after. The existing `test_describe_methods_resolve_to_real_attributes` already guarantees every advertised name resolves to a live callable, so the new entries are covered for correctness as well.

Green locally: `ruff check` / `ruff format --check` clean, `mypy strands_robots tests tests_integ` clean (750 files), and the sim discovery suite passes (`MUJOCO_GL=egl`, 24 passed).