### PR TITLE
fix(inference): publish PolicyServer port before marking the server bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1238,6 +1238,10 @@ name-resolution degradation.
 
 - The reward DSL had `base_velocity`, a floating base's heading-relative twist tracked as an UNBOUNDED negative-L2 error (`-weight * ||twist - command||`). For an RL locomotion reward that error term is dominated by the large initial tracking error and can swamp the bounded regularizer terms (`base_height` / `base_orientation` / `base_lin_vel_z` / `base_ang_vel_xy`), which is why legged_gym / IsaacLab express the primary velocity-tracking reward as a POSITIVE, BOUNDED exponential kernel instead. `base_velocity_tracking(vx, vy, wz, lin_weight=1.0, ang_weight=0.5, tracking_sigma=0.25, robot=None)` is that canonical term: `lin_weight * exp(-lin_err / tracking_sigma) + ang_weight * exp(-ang_err / tracking_sigma)` -- the sum of legged_gym's `tracking_lin_vel` (planar) and `tracking_ang_vel` (yaw-rate) kernels with their standard defaults. It reads the same body-frame twist `base_velocity` does (heading-relative), is bounded to `[0, lin_weight + ang_weight]` and peaks at perfect tracking, and weights planar-velocity and yaw-rate tracking separately (which the single combined `base_velocity` norm cannot). It degrades to `0.0` (and warns once) on a fixed-base arm. Composed with the base regularizer terms it is a faithful, well-scaled velocity-tracking reward for a locomotion spec.
 
+### Fixed: PolicyServer published its bound socket before its port, racing background pollers
+
+- `PolicyServer.serve()` (and the background-thread `start()`) set `self._server` to the bound server *before* reading the OS-assigned port into `self.port`. A caller that treats `_server is not None` as the "server is bound, port is readable" signal (the documented contract for reading back a `port=0` OS-assigned port) could observe the constructor default `0` in the window between the two writes -- an intermittent race under load. Both entry points now publish the port *before* publishing `_server`, so any thread that sees a non-None `_server` always reads the real bound port.
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/inference/server.py
+++ b/strands_robots/inference/server.py
@@ -193,11 +193,15 @@ class PolicyServer:
         # frame limit must be lifted or the server 1009-closes every real image
         # observation. Compression is disabled too (base64 binary barely compresses
         # and deflate wastes CPU at control rate); the client already opts out.
-        self._server = serve(self._handle, self.host, self.port, max_size=None, compression=None)
-        # Read back the OS-assigned port when the caller passed 0.
-        self.port = self._server.socket.getsockname()[1]
+        server = serve(self._handle, self.host, self.port, max_size=None, compression=None)
+        # Read back the OS-assigned port BEFORE publishing ``_server``: a
+        # background caller polling ``_server is not None`` as the "bound"
+        # signal must then always observe the real port, never the
+        # constructor default (see serve() for the same ordering).
+        self.port = server.socket.getsockname()[1]
+        self._server = server
         self._thread = threading.Thread(
-            target=self._server.serve_forever,
+            target=server.serve_forever,
             name=f"policy-server-{self.port}",
             daemon=True,
         )
@@ -225,8 +229,11 @@ class PolicyServer:
         # See start(): lift the default 1 MiB frame limit (and disable compression)
         # so large multi-camera observations stream in, matching the client.
         with serve(self._handle, self.host, self.port, max_size=None, compression=None) as server:
-            self._server = server
+            # Publish the bound port BEFORE marking the server as bound so a
+            # concurrent poller of ``_server is not None`` never reads the
+            # constructor default 0 in the window between the two writes.
             self.port = server.socket.getsockname()[1]
+            self._server = server
             logger.info("PolicyServer serving on ws://%s:%d", self.host, self.port)
             try:
                 server.serve_forever()

--- a/tests/inference/test_policy_server_lifecycle.py
+++ b/tests/inference/test_policy_server_lifecycle.py
@@ -141,3 +141,55 @@ def test_main_serves_constructed_provider(monkeypatch):
     server_mod.main(["--provider", "mock", "--host", "127.0.0.1", "--port", "9123"])
 
     assert served == {"provider": "mock", "host": "127.0.0.1", "port": 9123}
+
+
+def _capture_port_when_bound(server_cls):
+    """Return a ``server_cls`` subclass that snapshots ``.port`` at the instant
+    ``_server`` first becomes non-None (i.e. the moment the instance is
+    published as "bound")."""
+    captured: dict[str, int] = {}
+
+    class _Capturing(server_cls):
+        def __setattr__(self, name, value):
+            if name == "_server" and value is not None and "port" not in captured:
+                captured["port"] = self.port
+            super().__setattr__(name, value)
+
+    return _Capturing, captured
+
+
+def test_serve_publishes_port_before_marking_bound():
+    """``serve()`` sets ``.port`` before publishing ``_server``.
+
+    A background caller uses ``_server is not None`` as the "server is bound"
+    signal and then reads ``.port``. If ``serve()`` published ``_server`` first
+    and the port second, that caller could observe the constructor default
+    ``0`` in the window between the two writes. Capture the port at the exact
+    instant ``_server`` becomes non-None and assert it is already the real
+    bound port. Regression for a publish-ordering race.
+    """
+    capturing_cls, captured = _capture_port_when_bound(PolicyServer)
+    server = capturing_cls(policy_provider="mock", port=0)
+    thread = threading.Thread(target=server.serve, daemon=True)
+    thread.start()
+    try:
+        assert _wait_until(lambda: server._server is not None), "serve() never bound"
+        assert captured.get("port", 0) > 0, "port was still 0 when _server was published as bound"
+    finally:
+        if server._server is not None:
+            server._server.shutdown()
+    thread.join(timeout=5.0)
+    assert not thread.is_alive()
+
+
+def test_start_publishes_port_before_marking_bound():
+    """``start()`` sets ``.port`` before publishing ``_server`` too, so the
+    same non-None-``_server``-implies-real-port invariant holds for the
+    background-thread entry point."""
+    capturing_cls, captured = _capture_port_when_bound(PolicyServer)
+    server = capturing_cls(policy_provider="mock", port=0).start()
+    try:
+        assert captured.get("port", 0) > 0, "port was still 0 when _server was published as bound"
+        assert server.port == captured["port"]
+    finally:
+        server.stop()


### PR DESCRIPTION
## Problem

`PolicyServer` exposes its bound port via `self.port` (read back after binding, especially when constructed with `port=0` for an OS-assigned port). Both entry points published the internal `_server` handle *before* reading the port:

```python
# serve()
with serve(...) as server:
    self._server = server                       # (1) mark bound
    self.port = server.socket.getsockname()[1]  # (2) read port
```

A consumer that treats `_server is not None` as the "server is bound, port is readable" signal (the documented way to wait for a background `serve()`/`start()` to come up) can observe the constructor default `0` in the window between (1) and (2). Under load this is an intermittent race: `_server` is visible but `port` is still `0`.

This surfaces as a flaky failure in `test_serve_foreground_binds_and_shuts_down`:

```
assert server.port > 0
E  assert 0 > 0   # _server bound, port not yet published
```

which intermittently reddens `call-test-lint` on unrelated PRs.

## Change

Publish the port **before** publishing `_server` in both `serve()` and the background-thread `start()`. Since a single writer sets the port first and then the handle, any reader that observes a non-None `_server` is guaranteed to also see the real bound port. No behavioural change to a caller that reads `port` after `start()` returns synchronously; this only closes the concurrent-observer window.

## Tests

Adds two deterministic regression tests (no timing dependence): a `PolicyServer` subclass overrides `__setattr__` to snapshot `.port` at the exact instant `_server` first becomes non-None, then asserts that snapshot is already the real bound port. This reproduces the exact ordering the flaky test races on, without any sleeps. Both fail on the pre-fix code (`port was still 0 when _server was published as bound`, for `serve()` and `start()`) and pass after.

Green locally: `ruff check` / `ruff format --check` clean, `mypy strands_robots/inference/server.py` clean, and the full inference suite passes (`MUJOCO_GL=egl`, 46 passed) including the previously-flaky `test_serve_foreground_binds_and_shuts_down`.