### PR TITLE
fix(inference): bind port before exposing PolicyServer._server (readiness-flag race)

### DIFF
--- a/strands_robots/inference/server.py
+++ b/strands_robots/inference/server.py
@@ -193,11 +193,15 @@ class PolicyServer:
         # frame limit must be lifted or the server 1009-closes every real image
         # observation. Compression is disabled too (base64 binary barely compresses
         # and deflate wastes CPU at control rate); the client already opts out.
-        self._server = serve(self._handle, self.host, self.port, max_size=None, compression=None)
-        # Read back the OS-assigned port when the caller passed 0.
-        self.port = self._server.socket.getsockname()[1]
+        server = serve(self._handle, self.host, self.port, max_size=None, compression=None)
+        # Read back the OS-assigned port (when the caller passed 0) and publish
+        # it BEFORE exposing ``self._server``, so ``self._server is not None``
+        # implies ``self.port`` already holds the real bound port for any
+        # observer (matching serve()'s ordering).
+        self.port = server.socket.getsockname()[1]
+        self._server = server
         self._thread = threading.Thread(
-            target=self._server.serve_forever,
+            target=server.serve_forever,
             name=f"policy-server-{self.port}",
             daemon=True,
         )
@@ -225,8 +229,14 @@ class PolicyServer:
         # See start(): lift the default 1 MiB frame limit (and disable compression)
         # so large multi-camera observations stream in, matching the client.
         with serve(self._handle, self.host, self.port, max_size=None, compression=None) as server:
-            self._server = server
+            # Read back the OS-assigned port BEFORE publishing ``self._server``.
+            # ``self._server is not None`` is the server's readiness flag; a
+            # background observer that sees it set immediately reads ``self.port``
+            # (see start()'s contract). Publishing the handle first would expose
+            # a window where the server exists but ``port`` is still the pre-bind
+            # placeholder (0), so the observer reads a bogus port.
             self.port = server.socket.getsockname()[1]
+            self._server = server
             logger.info("PolicyServer serving on ws://%s:%d", self.host, self.port)
             try:
                 server.serve_forever()

--- a/tests/inference/test_policy_server_lifecycle.py
+++ b/tests/inference/test_policy_server_lifecycle.py
@@ -141,3 +141,67 @@ def test_main_serves_constructed_provider(monkeypatch):
     server_mod.main(["--provider", "mock", "--host", "127.0.0.1", "--port", "9123"])
 
     assert served == {"provider": "mock", "host": "127.0.0.1", "port": 9123}
+
+
+def test_serve_publishes_port_before_exposing_server(monkeypatch):
+    """``serve()`` must bind the port before exposing ``._server``.
+
+    ``._server is not None`` is the server's readiness flag: callers (and the
+    context manager) treat a non-None ``._server`` as "bound, ``.port`` is
+    valid". If the handle were published before the OS port is read back, a
+    background observer could see ``._server`` set while ``.port`` is still the
+    pre-bind placeholder (0). This pins the publish ordering deterministically
+    by blocking inside ``getsockname`` and asserting the handle is not yet
+    visible at that instant.
+    """
+    import websockets.sync.server as ws_server
+
+    getsockname_entered = threading.Event()
+    port_release = threading.Event()
+    shutdown_event = threading.Event()
+
+    class _FakeSocket:
+        def getsockname(self):
+            # serve() has reached the port readback; hold here so the test can
+            # probe the window before the real port is assigned.
+            getsockname_entered.set()
+            port_release.wait(2.0)
+            return ("127.0.0.1", 54321)
+
+    class _FakeServer:
+        def __init__(self):
+            self.socket = _FakeSocket()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def serve_forever(self):
+            shutdown_event.wait(3.0)
+
+        def shutdown(self):
+            shutdown_event.set()
+
+    monkeypatch.setattr(ws_server, "serve", lambda *a, **k: _FakeServer())
+
+    server = PolicyServer(policy_provider="mock", port=0)
+    thread = threading.Thread(target=server.serve, daemon=True)
+    thread.start()
+    try:
+        # Wait until serve() is blocked inside getsockname (port not yet read).
+        assert getsockname_entered.wait(2.0), "serve() never reached port readback"
+        # The handle must NOT be visible while the port is still unbound.
+        assert server._server is None, "._server exposed before port was bound"
+        assert server.port == 0
+
+        # Release the port readback; now the server becomes visible WITH a port.
+        port_release.set()
+        assert _wait_until(lambda: server._server is not None)
+        assert server.port == 54321
+    finally:
+        port_release.set()
+        shutdown_event.set()
+        thread.join(timeout=5.0)
+    assert not thread.is_alive()


### PR DESCRIPTION
## Problem

`PolicyServer` treats `self._server is not None` as its readiness flag: once set, callers (and the context manager) assume the server is bound and `self.port` holds the real, OS-assigned port. But both `serve()` and `start()` published `self._server` **before** reading the port back via `getsockname()`:

```python
# serve() - before
with serve(...) as server:
    self._server = server                          # published first
    self.port = server.socket.getsockname()[1]     # port set after
```

A background observer that polls for `self._server is not None` and then reads `self.port` can catch the window in between and see the pre-bind placeholder (`0`). This surfaced as a flaky failure in `test_serve_foreground_binds_and_shuts_down`:

```
>           assert server.port > 0
E           assert 0 > 0
```

The test waits for `_server` to appear (the documented readiness signal) and then asserts the port is valid; the ordering made that assertion racy.

## Change

Assign `self.port` first, then publish `self._server`, in both `serve()` and `start()`. Publishing the handle last makes the readiness flag imply a valid bound port for any observer, matching the contract already stated in `start()`'s docstring ("after this returns, `port` holds the actual bound port"). No behavior change beyond the ordering; no public API change.

## Test

Added `test_serve_publishes_port_before_exposing_server`, a deterministic regression test (no sleeps): it substitutes a fake server whose `getsockname()` blocks, then asserts `self._server` is still `None` at the instant the port readback is in flight, and only becomes visible once the port is set. It fails on the old ordering:

```
assert server._server is None, "._server exposed before port was bound"
E   AssertionError: ._server exposed before port was bound
```

and passes after the fix. Full `tests/inference/` suite (45 tests) green, ruff + mypy clean.