### PR TITLE
fix(sim): warn on out-of-ctrlrange clamp for joint-name-addressed actions

### DIFF
--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -582,7 +582,18 @@ class RenderingMixin:
             # transmission is a tendon (gripper ctrlrange is e.g. [0, 255]
             # tendon units, not a finger-joint position). Direct JOINT
             # actuators keep the raw value (positions/torques in joint units).
-            data.ctrl[ai] = self._scale_ctrl_for_actuator(model, ai, float(value), mj)
+            ctrl_value = self._scale_ctrl_for_actuator(model, ai, float(value), mj)
+            # A direct JOINT actuator writes the value verbatim, so an
+            # out-of-ctrlrange joint-addressed command is silently clamped by
+            # MuJoCo exactly as the actuator-addressed branch above is - apply
+            # the same no-silent-clamp warning here so the contract does not
+            # depend on whether the caller keyed by actuator or by joint name.
+            # Tendon drives are skipped: _scale_ctrl_for_actuator has already
+            # mapped/clamped the command into the ctrlrange on purpose, so a
+            # clamp warning would be spurious.
+            if int(model.actuator_trntype[ai]) != int(mj.mjtTrn.mjTRN_TENDON):
+                self._warn_ctrl_clamp(model, ai, pfx, key, ctrl_value, mj)
+            data.ctrl[ai] = ctrl_value
 
         return unresolved
 

--- a/tests/simulation/mujoco/test_ctrl_clamp_warning_joint_addressing.py
+++ b/tests/simulation/mujoco/test_ctrl_clamp_warning_joint_addressing.py
@@ -1,0 +1,87 @@
+"""No-silent-clamp contract for joint-name-addressed actions.
+
+The MuJoCo backend writes an action value to ``data.ctrl`` through two code
+paths in ``_apply_action_by_name``:
+
+* the caller keys by ACTUATOR name (direct lookup), or
+* the caller keys by JOINT name, which is resolved to the actuator that drives
+  that joint.
+
+Both ultimately write to the same ``data.ctrl`` slot, so a value outside the
+actuator's ``ctrlrange`` is silently clamped by MuJoCo inside ``mj_step`` in
+either case - the commanded trajectory is NOT reproduced. The backend surfaces
+this once per ``(prefix, key)`` via a clamp warning so a 50Hz control loop is
+not spammed. This module pins that the warning fires regardless of which name
+the caller used, so the contract does not depend on the addressing style.
+
+``panda`` is used because its joint names (``joint1`` ...) differ from its
+actuator names (``actuator1`` ...), so keying by joint name genuinely exercises
+the joint-name resolution fallback rather than the direct-actuator branch.
+"""
+
+import logging
+
+import pytest
+
+from strands_robots.simulation.mujoco.simulation import Simulation
+
+_CLAMP_LOGGER = "strands_robots.simulation.mujoco.rendering"
+
+
+def _clamp_warnings(records: list[logging.LogRecord]) -> list[str]:
+    return [r.getMessage() for r in records if "ctrlrange" in r.getMessage()]
+
+
+@pytest.fixture
+def sim():
+    s = Simulation()
+    s.create_world()
+    s.add_robot("panda")
+    try:
+        yield s
+    finally:
+        s.cleanup()
+
+
+def test_out_of_range_joint_name_action_warns(sim, caplog):
+    """An out-of-range value keyed by JOINT name surfaces the clamp warning.
+
+    Regression: this path previously wrote ``data.ctrl`` verbatim with no
+    warning, so a joint-addressed out-of-distribution command was clamped
+    silently while the identical actuator-addressed command warned.
+    """
+    with caplog.at_level(logging.WARNING, logger=_CLAMP_LOGGER):
+        result = sim.send_action({"joint1": 100.0})
+
+    assert result["status"] == "success"
+    warnings = _clamp_warnings(caplog.records)
+    assert len(warnings) == 1
+    assert "joint1" in warnings[0]
+    assert "clamp" in warnings[0]
+
+
+def test_out_of_range_actuator_name_action_warns(sim, caplog):
+    """The direct actuator-name branch warns too (the contract's other half)."""
+    with caplog.at_level(logging.WARNING, logger=_CLAMP_LOGGER):
+        result = sim.send_action({"actuator1": 100.0})
+
+    assert result["status"] == "success"
+    assert len(_clamp_warnings(caplog.records)) == 1
+
+
+def test_in_range_joint_name_action_does_not_warn(sim, caplog):
+    """A value inside the actuator ctrlrange must not raise a false clamp warning."""
+    with caplog.at_level(logging.WARNING, logger=_CLAMP_LOGGER):
+        result = sim.send_action({"joint2": 0.5})
+
+    assert result["status"] == "success"
+    assert _clamp_warnings(caplog.records) == []
+
+
+def test_repeated_out_of_range_joint_name_deduplicated(sim, caplog):
+    """The clamp warning is emitted once per (prefix, key), not once per step."""
+    with caplog.at_level(logging.WARNING, logger=_CLAMP_LOGGER):
+        for _ in range(5):
+            sim.send_action({"joint1": 100.0})
+
+    assert len(_clamp_warnings(caplog.records)) == 1


### PR DESCRIPTION
## Problem

The MuJoCo backend applies an action value through two paths in `_apply_action_by_name`:

- the caller keys by **actuator name** (direct lookup), or
- the caller keys by **joint name**, which is resolved to the actuator that drives that joint.

Both ultimately write the same `data.ctrl` slot, so a value outside the actuator's `ctrlrange` is silently clamped by MuJoCo inside `mj_step` in either case - the commanded trajectory is not reproduced. The direct-actuator branch already surfaces this once per `(prefix, key)` via `_warn_ctrl_clamp`, but the joint-name branch wrote `data.ctrl` verbatim with no warning.

The result is an inconsistent no-silent-clamp contract for the same actuator:

```python
sim.send_action({"actuator1": 100.0})  # -> emits the clamp warning
sim.send_action({"joint1":    100.0})  # -> clamped silently, no warning
```

Joint-name addressing is the common case when replaying a dataset or driving by joint (the keys are joint names, not the MJCF actuator names), so the silent path is the one most likely to be hit in practice.

## Change

Emit the same once-per-`(prefix, key)` clamp warning for **direct joint actuators** on the joint-name path. Tendon drives are skipped because `_scale_ctrl_for_actuator` already maps the command into `ctrlrange` on purpose, so a clamp warning there would be spurious. Motion is unchanged - MuJoCo clamps identically either way; this only surfaces the diagnostic that was previously missing on one of the two addressing styles.

## Tests

`tests/simulation/mujoco/test_ctrl_clamp_warning_joint_addressing.py` pins the contract via the public `send_action` API + `caplog` on `panda` (its joint names differ from its actuator names, so keying by joint name genuinely exercises the resolution fallback):

- out-of-range joint-name action -> exactly one clamp warning (**fails on pre-fix code**)
- out-of-range actuator-name action -> one warning (the contract's other half)
- in-range joint-name action -> no false-positive warning
- repeated out-of-range joint-name actions -> deduplicated to a single warning (no 50Hz log spam)

Pre-fix the two joint-name tests fail (`0 == 1`); post-fix all four pass. Full local gate green: `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` clean, and the mujoco action/replay suites pass.

## Verification (headless MuJoCo, egl)

Out-of-range command keyed by joint name now surfaces:

```
[sim] action value 100 for ctrl-limited actuator 'joint1' (prefix='panda/') is
outside its ctrlrange [-2.897, 2.897]; MuJoCo will clamp it, so the commanded
value is NOT reproduced for this actuator. ...
```

Render still confirming the sim action path executes headless under the change:

![panda headless render](https://github.com/cagataycali/robots/releases/download/artifact-clamp-warn-1783714877/panda_still.png)