### PR TITLE
test(sim): pin IsaacConfig rendering_dt and camera-dimension validation

### DIFF
--- a/tests/simulation/isaac/test_isaac_backend.py
+++ b/tests/simulation/isaac/test_isaac_backend.py
@@ -151,6 +151,20 @@ class TestIsaacConfig:
         with pytest.raises(ValueError, match="physics_dt"):
             IsaacConfig(physics_dt=0.0)
 
+    def test_rejects_nonpositive_rendering_dt(self):
+        from strands_robots.simulation.isaac.config import IsaacConfig
+
+        with pytest.raises(ValueError, match="rendering_dt"):
+            IsaacConfig(rendering_dt=0.0)
+
+    def test_rejects_nonpositive_camera_dimensions(self):
+        from strands_robots.simulation.isaac.config import IsaacConfig
+
+        with pytest.raises(ValueError, match="camera dimensions"):
+            IsaacConfig(camera_width=0)
+        with pytest.raises(ValueError, match="camera dimensions"):
+            IsaacConfig(camera_height=-1)
+
     def test_env_headless_override(self, monkeypatch):
         from strands_robots.simulation.isaac.config import IsaacConfig
 


### PR DESCRIPTION
## Problem

`IsaacConfig.__post_init__` validates every construction-time field and raises `ValueError` on bad input (the "raise on fatal, no silent default" convention). But `TestIsaacConfig` only exercised four of the guards - `render_mode`, `device`, `num_envs`, and `physics_dt`. Two guards had **no coverage**:

- `rendering_dt > 0` (`simulation/isaac/config.py:98`)
- `camera_width >= 1 and camera_height >= 1` (`simulation/isaac/config.py:102`)

A regression that silently dropped either check - e.g. accepting `rendering_dt=0.0` or a zero-width camera - would sail through CI unnoticed.

## Change

Add two focused tests to `TestIsaacConfig`, mirroring the existing rejection-test pattern:

- `test_rejects_nonpositive_rendering_dt` - `IsaacConfig(rendering_dt=0.0)` must raise `ValueError`.
- `test_rejects_nonpositive_camera_dimensions` - zero width and negative height must each raise `ValueError`.

Test-only; no production code changes. They run on any host - no Isaac Sim or CUDA required (the config dataclass is pure Python).

## Result

`strands_robots/simulation/isaac/config.py`: **96% -> 100%** line coverage (lines 98 and 102 now exercised).

```
strands_robots/simulation/isaac/config.py      47      0   100%
```

## Tests

```
MUJOCO_GL=egl python -m pytest tests/simulation/isaac/test_isaac_backend.py -q
35 passed in 0.58s
```

Lint gate clean: `ruff check`, `ruff format --check`, and `mypy strands_robots tests tests_integ` all pass (no issues found in 750 source files).