### PR TITLE
fix(sim): advertise get_features in describe() so the method run_policy recommends is discoverable

### DIFF
--- a/docs/simulation/overview.md
+++ b/docs/simulation/overview.md
@@ -200,7 +200,14 @@ Destructive - writes into model arrays. Recompile scene to undo.
 |--------|-------|
 | `list_urdfs` | Loaded URDFs/MJCFs in current world |
 | `register_urdf(name, path)` | Register additional asset |
-| `get_features(robot_name=None)` | Observation/action feature schema for recording |
+| `get_features(robot_name=None)` | Joint / actuator / camera / robot names of the scene (scoped to one robot with `robot_name`) - the source of truth for the action keys a policy must emit, and the feature schema used for recording |
+
+!!! tip "Discover the expected action keys"
+    `get_features` is listed in `sim.describe()["methods"]`, so an agent can
+    find it from one `describe()` call. When a policy's emitted action keys
+    resolve to no actuator, `run_policy` fails fast with an error that names
+    `get_features(robot_name=...)` as the way to inspect the keys the robot
+    actually expects - the recommended method and the discovery surface agree.
 
 ## See also
 

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -2059,6 +2059,13 @@ class SimEngine(ABC):
                     "LeRobotDataset episode through the sim"
                 ),
                 "list_robots": "() -> list[str]",
+                "get_features": (
+                    "(robot_name: str | None = None) -> dict  # joint / "
+                    "actuator / camera / robot names of the scene (scoped to "
+                    "one robot when robot_name is given) - the source of truth "
+                    "for the action keys a policy must emit; consult it when "
+                    "run_policy reports unresolved keys"
+                ),
                 "render": "(camera_name='default', width=None, height=None) -> dict",
                 "reset": "() -> dict  # during recording, flushes the buffered rollout as one episode before resetting",
                 "step": "(n_steps: int = 1) -> dict",

--- a/tests/simulation/mujoco/test_simulation.py
+++ b/tests/simulation/mujoco/test_simulation.py
@@ -776,6 +776,60 @@ class TestListBodies:
         assert "arm1/base" in described["bodies"]
         assert "list_bodies" in described["methods"]
 
+    def test_describe_advertises_get_features_the_action_key_source(self, sim_with_robot):
+        """describe() must advertise get_features -- the joint/actuator/camera-
+        name discovery method that is the source of truth for the action keys a
+        policy must emit. The advertisement is only useful if the method it names
+        is real and returns those names, so assert both: the signature is on the
+        discovery surface, and calling it yields a non-empty actuator listing."""
+        described = sim_with_robot.describe()
+        assert "get_features" in described["methods"]
+        assert "robot_name" in described["methods"]["get_features"]
+
+        feats = sim_with_robot.get_features(robot_name="arm1")
+        assert feats["status"] == "success", feats
+        payload = next(c["json"] for c in feats["content"] if isinstance(c, dict) and "json" in c)
+        assert payload["features"]["actuator_names"], "get_features must list actuator names"
+
+    def test_fail_fast_recommended_method_is_discoverable_via_describe(self, sim_with_robot):
+        """Closed loop: when a policy's action keys resolve to no actuator,
+        run_policy's fail-fast error tells the caller to inspect the expected
+        keys via get_features(robot_name=...). The method that error names must
+        be discoverable on the primary discovery surface (describe), so an agent
+        recovering from the error does not have to scrape a method name out of an
+        error string only to find describe() never listed it."""
+        from strands_robots.policies.base import Policy
+
+        class _WrongKeysPolicy(Policy):
+            @property
+            def provider_name(self) -> str:
+                return "wrong_keys_test"
+
+            @property
+            def requires_images(self) -> bool:
+                return False
+
+            def set_robot_state_keys(self, robot_state_keys):
+                pass
+
+            async def get_actions(self, observation_dict, instruction, **kwargs):
+                # A key no actuator can absorb -> 100% unresolved every step.
+                return [{"definitely_not_a_joint": 0.5}]
+
+        result = sim_with_robot.run_policy(
+            robot_name="arm1",
+            policy_object=_WrongKeysPolicy(),
+            n_steps=50,
+            control_frequency=20.0,
+            fast_mode=True,
+        )
+        assert result["status"] == "error", result
+        err_text = result["content"][0]["text"]
+        # The diagnostic recommends get_features by name...
+        assert "get_features" in err_text
+        # ...and that method is discoverable on describe()'s method surface.
+        assert "get_features" in sim_with_robot.describe()["methods"]
+
     def test_list_bodies_reports_gripper_mount_when_present(self, sim_with_gripper_robot):
         """A robot with a gripper-like body gets its wrist/EEF mount resolved
         automatically. This is the payoff of the discovery surface: the agent


### PR DESCRIPTION
## Problem

When a policy emits action keys that resolve to no actuator, `PolicyRunner`'s fail-fast probe raises a helpful diagnostic that ends with:

> ... inspect the expected keys via `sim.get_features(robot_name='...')`.

`get_features` is a real, valuable method: it returns the joint / actuator / camera / robot names of the scene — the source of truth for the action keys a policy must emit. But `describe()` — the primary discovery surface an agent reads to learn the sim API in one call — never advertised it.

So an agent that hits the unresolved-keys error, then consults `describe()` to find `get_features`, could not find it. The recommended method and the discovery surface disagreed: the only way to learn `get_features` existed was to scrape the name out of an error string.

## Change

Advertise `get_features` in `SimEngine.describe()`'s `methods` map. It lives in the base `describe()` (not a backend override) because both the MuJoCo and Newton backends implement `get_features` and inherit the shared facade surface, matching how `run_policy` / `eval_policy` / `replay_episode` are already advertised there.

No behavior change to `get_features` or the runner — this only makes an existing method discoverable.

## Tests (fail on pre-fix code)

- `test_describe_advertises_get_features_the_action_key_source`: `describe()["methods"]` advertises `get_features`, and calling the advertised method returns a non-empty actuator listing (the advertisement points at a real, working method).
- `test_fail_fast_recommended_method_is_discoverable_via_describe`: closed loop — a policy emitting a key no actuator can absorb triggers the fail-fast error; the exact method that error recommends (`get_features`) must be present in `describe()["methods"]`.

Both assertions fail on the current code (confirmed by reverting the one-line source change) and pass after. Full `tests/simulation` suite: 2160 passed, 134 skipped. Lint/format/mypy clean on `strands_robots tests`.

## Docs

`docs/simulation/overview.md`: enriched the `get_features` row and added a "Discover the expected action keys" tip noting it is listed in `describe()["methods"]` and is the method the unresolved-keys error recommends.