### PR TITLE
feat(sim): advertise the benchmark scoring family in describe()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Added: `describe()` advertises the benchmark scoring family (`evaluate_benchmark` / `list_benchmarks` / `register_benchmark_from_file`)
+
+`SimEngine.describe()["methods"]` is the single-call discovery surface an agent
+reads to learn a sim's contract without guessing method names. It advertised the
+rollout family (`run_policy` / `start_policy` / `eval_policy` / `replay_episode`)
+but omitted the DSL-driven benchmark scoring family - the three concrete
+backend-agnostic facades `evaluate_benchmark` (score a registered
+success/failure/dense_reward benchmark over a rollout), `list_benchmarks`
+(enumerate the registered benchmark names it accepts), and
+`register_benchmark_from_file` (author a benchmark spec as YAML/JSON at runtime).
+So an agent enumerating `describe()` could run a policy but could not discover how
+to score it against a benchmark, dead-ending the predicate/reward DSL those
+methods drive behind names it had to already know. They are now listed in the base
+`describe()` (which the MuJoCo backend inherits) and in the Newton backend's own
+`describe()` methods dict, with signatures that name their distinguishing
+parameters. Regression tests assert the family is advertised on both the base
+engine and Newton (each fails before, passes after), and the existing
+resolve-to-real-attributes guard confirms each advertised name is a live callable
+on the MuJoCo engine.
+
 ### Fixed: mypy import-untyped failures from pyarrow dropping its py.typed marker
 
 `pyarrow` 25.0.0 stopped shipping the `py.typed` marker it previously carried,

--- a/docs/simulation/overview.md
+++ b/docs/simulation/overview.md
@@ -175,6 +175,13 @@ A healthy masked rollout shows `rtc_prefetch_hits` near the chunk count and `rtc
 `eval_policy` accepts the same `video={...}` recording config as `run_policy` (`path` enables it, plus `fps` / `camera` / `width` / `height`), but writes **one MP4 per episode** with `_ep{i}` inserted into the filename (`eval.mp4` -> `eval_ep0.mp4`, `eval_ep1.mp4`, ...), so a multi-episode evaluation can be *watched* to see why episodes fail rather than only read as an aggregate `success_rate`. The written files are listed in the result json `video_paths`; the output path is validated and the camera probed up-front, so a bad camera fails the eval immediately instead of after N episodes of empty MP4s. `evaluate_benchmark` accepts the same `video={...}` config and records one MP4 per episode too, so a benchmark evaluation can be watched to see why episodes fail. Frames are captured synchronously on the eval thread (render is read-only over `mjData`), so recording does not perturb the bit-stable benchmark rollout.
 | `replay_episode` | `repo_id`, `robot_name=None`, `episode=0` |
 
+!!! tip "Discover the benchmark scoring surface"
+    `evaluate_benchmark`, `list_benchmarks`, and `register_benchmark_from_file`
+    are listed in `sim.describe()["methods"]`, so an agent that can run a
+    policy from one `describe()` call can also discover how to score it
+    against a success/failure/dense_reward benchmark - and author a new
+    benchmark spec at runtime - without guessing the method names.
+
 ## Recording
 
 | Action | Notes |

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -2053,6 +2053,23 @@ class SimEngine(ABC):
                     "max_steps=300, success_fn=None, ...) -> dict  # multi-episode "
                     "success-rate evaluation (the rollout sibling of run_policy)"
                 ),
+                "evaluate_benchmark": (
+                    "(benchmark_name: str, robot_name=None, policy_provider='mock', "
+                    "n_episodes=1, seed=None, video=None, ...) -> dict  # score a "
+                    "registered benchmark's success/failure/dense-reward DSL over a "
+                    "rollout (max_steps comes from the benchmark, not a parameter); "
+                    "the DSL-scored sibling of eval_policy's success_fn"
+                ),
+                "list_benchmarks": (
+                    "() -> dict  # enumerate registered benchmarks (names, "
+                    "supported robots, default robot, max_steps) - the source of the "
+                    "benchmark_name evaluate_benchmark expects"
+                ),
+                "register_benchmark_from_file": (
+                    "(benchmark_name: str, spec_path: str) -> dict  # author a "
+                    "declarative benchmark (success/failure/dense_reward predicate "
+                    "DSL) as YAML/JSON at runtime and register it under benchmark_name"
+                ),
                 "replay_episode": (
                     "(repo_id: str, robot_name=None, episode=0, root=None, "
                     "speed=1.0, action_key_map=None) -> dict  # replay a recorded "

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -1680,6 +1680,20 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
                 "get_observation": "(robot_name: str | None = None, *, skip_images: bool = False) -> dict",
                 "send_action": "(action: dict, robot_name: str | None = None, n_substeps: int = 1) -> dict",
                 "run_policy": "(robot_name: str, policy_provider='mock', n_episodes=1, ...) -> dict",
+                "evaluate_benchmark": (
+                    "(benchmark_name: str, robot_name=None, policy_provider='mock', "
+                    "n_episodes=1, seed=None, video=None, ...) -> dict  (score a registered "
+                    "success/failure/dense_reward benchmark over a rollout; max_steps comes "
+                    "from the benchmark, not a parameter)"
+                ),
+                "list_benchmarks": (
+                    "() -> dict  (enumerate registered benchmarks -- names, supported robots, "
+                    "default robot, max_steps -- the source of the benchmark_name evaluate_benchmark expects)"
+                ),
+                "register_benchmark_from_file": (
+                    "(benchmark_name: str, spec_path: str) -> dict  (author a declarative "
+                    "success/failure/dense_reward benchmark spec as YAML/JSON at runtime and register it)"
+                ),
                 "list_robots_info": "() -> dict (pretty robot listing)",
                 "list_bodies": "(robot_name: str | None = None) -> dict (body labels + gripper_body)",
                 "list_objects": "() -> dict",

--- a/tests/simulation/newton/test_discovery_and_state.py
+++ b/tests/simulation/newton/test_discovery_and_state.py
@@ -362,3 +362,20 @@ class TestDescribeSurface:
         assert described["cameras"] == ["default"]
         assert described["bodies"]
         assert described["world_created"] is True
+
+    def test_describe_lists_benchmark_family_methods(self, engine_so100):
+        """describe() advertises the DSL-driven benchmark scoring family.
+
+        ``evaluate_benchmark`` / ``list_benchmarks`` /
+        ``register_benchmark_from_file`` are concrete facades on the base
+        engine that Newton inherits as real callables, so the Newton discovery
+        surface must name them too - otherwise a caller enumerating
+        ``describe()["methods"]`` could run a policy but not discover how to
+        score it against a benchmark.
+        """
+        methods = engine_so100.describe()["methods"]
+        for name in ("evaluate_benchmark", "list_benchmarks", "register_benchmark_from_file"):
+            assert name in methods, f"describe() omits benchmark-family method {name!r}"
+            assert callable(getattr(engine_so100, name, None))
+        assert "benchmark_name" in methods["evaluate_benchmark"]
+        assert "spec_path" in methods["register_benchmark_from_file"]

--- a/tests/simulation/test_sim_engine_describe_discovery.py
+++ b/tests/simulation/test_sim_engine_describe_discovery.py
@@ -200,6 +200,28 @@ class TestDescribeABC:
         assert "urdf_path" in methods["add_robot"]
         assert "shape" in methods["add_object"]
 
+    def test_describe_lists_benchmark_family_methods(self):
+        """describe() advertises the DSL-driven benchmark scoring surface.
+
+        ``run_policy``/``eval_policy`` were discoverable, but their DSL-scored
+        siblings were not: ``evaluate_benchmark`` (score a registered
+        success/failure/dense_reward benchmark over a rollout),
+        ``list_benchmarks`` (enumerate the registered benchmark names it
+        accepts), and ``register_benchmark_from_file`` (author a benchmark spec
+        as YAML/JSON at runtime). These are concrete backend-agnostic facades on
+        the base engine, so a caller enumerating ``describe()["methods"]`` could
+        run a policy but could not discover how to score it against a benchmark
+        without guessing the names.
+        """
+        engine = _make_minimal_engine()
+        methods = engine.describe()["methods"]
+        for name in ("evaluate_benchmark", "list_benchmarks", "register_benchmark_from_file"):
+            assert name in methods, f"describe() omits benchmark-family method {name!r}"
+        # Advertised signatures name the real distinguishing parameters so a
+        # caller can invoke them without reading the source.
+        assert "benchmark_name" in methods["evaluate_benchmark"]
+        assert "spec_path" in methods["register_benchmark_from_file"]
+
 
 @pytest.mark.skipif(
     not pytest.importorskip("mujoco", reason="MuJoCo not installed"),


### PR DESCRIPTION
## Problem

`SimEngine.describe()["methods"]` is the single-call discovery surface an agent reads to learn a sim's contract without guessing method names. It advertised the rollout family (`run_policy` / `start_policy` / `eval_policy` / `replay_episode`) but omitted the DSL-driven benchmark scoring family:

- `evaluate_benchmark(benchmark_name, ...)` - score a registered success/failure/dense_reward benchmark over a rollout,
- `list_benchmarks()` - enumerate the registered benchmark names it accepts,
- `register_benchmark_from_file(name, spec_path)` - author a benchmark spec as YAML/JSON at runtime.

So an agent enumerating `describe()` could run a policy but could not discover how to score it against a benchmark - dead-ending the predicate/reward DSL those methods drive behind names it had to already know. (The rollout family and scene-construction / render / recording surfaces are already advertised; this closes the remaining scoring gap.)

## Change

Advertise the three facades where `describe()` lists methods:

- **Base `describe()`** (`SimEngine`, which the MuJoCo backend inherits) - added `evaluate_benchmark`, `list_benchmarks`, `register_benchmark_from_file` right after `eval_policy` (their scoring sibling), with signatures that name the distinguishing parameters.
- **Newton backend** builds its own `methods` dict (it does not call `super().describe()`), so the same three entries are added there too, keeping the two backends' discovery surfaces consistent.

Pure discovery-surface addition: `describe()` returns descriptive strings, so there is no policy / simulation / rendering / recording behaviour change - the advertised methods themselves are unchanged public facades.

## Verification

- `tests/simulation/test_sim_engine_describe_discovery.py::TestDescribeABC::test_describe_lists_benchmark_family_methods` - asserts the family is advertised on the base engine and that the signatures name `benchmark_name` / `spec_path`. Fails before (`describe() omits benchmark-family method 'evaluate_benchmark'`), passes after.
- `tests/simulation/newton/test_discovery_and_state.py::TestDescribeSurface::test_describe_lists_benchmark_family_methods` - same assertion on a live Newton engine (gated on newton/warp), also confirming each advertised name is a real callable.
- The existing `test_describe_methods_resolve_to_real_attributes` guard already confirms every advertised name resolves to a live callable on the MuJoCo engine, so the additions cannot dead-end a caller in an `AttributeError`.
- Full describe-discovery suite green locally (`MUJOCO_GL=egl`): 19 passed, Newton cases skipped where warp is absent.

Docs (`docs/simulation/overview.md` discovery tip) and CHANGELOG updated in the same change.