### PR TITLE
feat(sim): advertise the sim-state checkpoint + pose-setting family in describe()

### DIFF
--- a/docs/simulation/overview.md
+++ b/docs/simulation/overview.md
@@ -102,8 +102,17 @@ Newton backend, so a rollout rig can be enumerated instead of guessed.
 | `inverse_dynamics` | - (compensation torques to hold the current `qpos`/`qvel`) |
 | `forward_kinematics` | `body_name` (optional) |
 | `save_state` / `load_state` | snapshot/restore full physics |
+| `set_joint_positions` | `positions` (dict or ordered list), `robot_name` (optional) - write `qpos` directly + run FK (teleport / set an initial pose, bypassing actuators) |
+| `set_joint_velocities` | `velocities` (dict or ordered list), `robot_name` (optional) - write `qvel` directly (set an initial dynamic state) |
 | `get_energy` | - |
 | `get_sensor_data` | `sensor_name` (optional) |
+
+!!! tip "Discover the sim-state surface"
+    `get_state` plus the checkpoint (`save_state` / `load_state`) and
+    direct pose-setting (`set_joint_positions` / `set_joint_velocities`)
+    methods are all listed in `sim.describe()["methods"]`, so an agent can
+    learn how to snapshot/restore the world and set a deterministic initial
+    condition from one `describe()` call - no method-name guessing.
 
 ## Actions
 

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -2069,6 +2069,12 @@ class SimEngine(ABC):
                 "render": "(camera_name='default', width=None, height=None) -> dict",
                 "reset": "() -> dict  # during recording, flushes the buffered rollout as one episode before resetting",
                 "step": "(n_steps: int = 1) -> dict",
+                "get_state": (
+                    "() -> dict  # snapshot of the live world: sim time, step "
+                    "count, timestep, gravity, and robot / object / camera / "
+                    "body / joint / actuator counts (the whole-world sibling of "
+                    "get_robot_state / get_observation)"
+                ),
             },
             "note": (
                 "robot_name defaults to the sole robot when only one exists "

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1522,6 +1522,36 @@ class MuJoCoSimEngine(
             "exclude_body=-1) -> dict  # batch raycast from one origin (e.g. a lidar fan)"
         )
 
+        # Sim-state checkpoint + direct pose-setting surface. describe() teaches
+        # how to build a scene, run a policy, and read the physics result, but
+        # previously gave no way to discover how to CHECKPOINT/RESTORE the whole
+        # physics state or teleport the robot to a pose without stepping the
+        # actuators -- so an agent setting up a deterministic initial condition
+        # (or A/B-testing two rollouts from the same start) had to guess these
+        # names. All four are first-class actions in the tool spec + action
+        # dispatcher; listing them here reveals the state-management surface
+        # alongside the act / read surfaces.
+        base["methods"]["save_state"] = (
+            "(name='default') -> dict  # checkpoint the full physics state "
+            "(qpos/qvel/act/ctrl + sim time + step count) under a name; restore "
+            "it later with load_state"
+        )
+        base["methods"]["load_state"] = (
+            "(name='default') -> dict  # restore a checkpoint saved by save_state "
+            "(errors if the name is unknown or a policy is running)"
+        )
+        base["methods"]["set_joint_positions"] = (
+            "(positions: dict[str, float] | list[float], robot_name=None) -> dict "
+            "# write qpos directly and run forward kinematics (teleport / set an "
+            "initial pose, bypassing the actuators). dict is per-joint; list is "
+            "ordered and must match one robot's joint count (see get_features)"
+        )
+        base["methods"]["set_joint_velocities"] = (
+            "(velocities: dict[str, float] | list[float], robot_name=None) -> dict "
+            "# write qvel directly (set an initial dynamic state); dict or "
+            "ordered-list form mirrors set_joint_positions"
+        )
+
         if self._world is not None:
             base["sim_time"] = self._world.sim_time
             base["world_created"] = True

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -1677,6 +1677,10 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
                 ),
                 "remove_object": "(name: str) -> dict  (remove a previously added object)",
                 "get_robot_state": "(robot_name: str | None = None) -> dict (per-joint position + velocity)",
+                "get_state": (
+                    "() -> dict (whole-world snapshot: sim time, step count, timestep, gravity, "
+                    "robot / object / camera / body / joint / actuator counts)"
+                ),
                 "get_observation": "(robot_name: str | None = None, *, skip_images: bool = False) -> dict",
                 "send_action": "(action: dict, robot_name: str | None = None, n_substeps: int = 1) -> dict",
                 "run_policy": "(robot_name: str, policy_provider='mock', n_episodes=1, ...) -> dict",

--- a/tests/simulation/newton/test_discovery_and_state.py
+++ b/tests/simulation/newton/test_discovery_and_state.py
@@ -348,6 +348,7 @@ class TestDescribeSurface:
         methods = described["methods"]
         for name in (
             "get_robot_state",
+            "get_state",
             "list_bodies",
             "move_object",
             "get_features",

--- a/tests/simulation/test_sim_engine_describe_discovery.py
+++ b/tests/simulation/test_sim_engine_describe_discovery.py
@@ -200,6 +200,21 @@ class TestDescribeABC:
         assert "urdf_path" in methods["add_robot"]
         assert "shape" in methods["add_object"]
 
+    def test_describe_lists_get_state(self):
+        """describe() advertises get_state, the whole-world snapshot method.
+
+        ``get_state`` is an abstract method every backend implements and a
+        first-class action in the tool spec, but the discovery surface listed
+        only the per-robot readers (``get_robot_state`` / ``get_observation``)
+        - so a caller enumerating ``describe()["methods"]`` could not learn how
+        to read the world-level snapshot (sim time, step count, entity counts)
+        without guessing the name. It belongs on the base contract alongside
+        the other read methods.
+        """
+        engine = _make_minimal_engine()
+        methods = engine.describe()["methods"]
+        assert "get_state" in methods, "describe() omits the base get_state method"
+
 
 @pytest.mark.skipif(
     not pytest.importorskip("mujoco", reason="MuJoCo not installed"),
@@ -383,6 +398,43 @@ class TestDescribeMuJoCo:
         sim = Simulation()
         try:
             assert "cameras" in sim.describe()["methods"]["start_recording"]
+        finally:
+            sim.destroy()
+
+    def test_describe_lists_sim_state_family(self):
+        """describe() advertises the sim-state checkpoint + pose-setting family.
+
+        ``save_state`` / ``load_state`` (checkpoint and restore the whole
+        physics state) and ``set_joint_positions`` / ``set_joint_velocities``
+        (write qpos/qvel directly to teleport the robot to a pose or set an
+        initial dynamic state) are first-class actions in the MuJoCo tool spec
+        and action dispatcher, plus ``get_state`` from the base contract. But
+        the discovery surface listed none of them -- so an agent setting up a
+        deterministic initial condition, or A/B-testing two rollouts from the
+        same checkpoint, had to guess these names. They belong on the discovery
+        surface alongside the act / read surfaces.
+        """
+        import os
+
+        os.environ.setdefault("MUJOCO_GL", "egl")
+        from strands_robots.simulation import Simulation
+
+        sim = Simulation()
+        try:
+            methods = sim.describe()["methods"]
+            for name in (
+                "save_state",
+                "load_state",
+                "set_joint_positions",
+                "set_joint_velocities",
+                "get_state",
+            ):
+                assert name in methods, f"describe() omits sim-state method {name!r}"
+            # Advertised signatures name the real distinguishing parameters so a
+            # caller can invoke them without reading the source.
+            assert "name" in methods["save_state"]
+            assert "positions" in methods["set_joint_positions"]
+            assert "velocities" in methods["set_joint_velocities"]
         finally:
             sim.destroy()
 


### PR DESCRIPTION
## Problem

`describe()` is the single-call discovery surface an agent reads to learn a sim engine's contract without guessing method names. It already advertises how to build a scene, run a policy, render, record, and read the physics result -- but it listed none of the **sim-state-management** methods, even though they are all first-class actions in the MuJoCo tool spec and action dispatcher:

- `get_state` -- whole-world snapshot (sim time, step count, timestep, gravity, entity counts); an abstract method every backend implements.
- `save_state` / `load_state` -- checkpoint and restore the full physics state (qpos/qvel/act/ctrl + time + step count).
- `set_joint_positions` / `set_joint_velocities` -- write qpos/qvel directly to teleport the robot to a pose or set an initial dynamic state, bypassing the actuators.

So an agent enumerating `describe()["methods"]` to set up a deterministic initial condition, or to A/B-test two rollouts from the same checkpoint, had to guess these names -- a dead-end the rest of the discovery surface was built to avoid.

## Change

- Advertise `get_state` on the base `SimEngine.describe()` contract (it flows into MuJoCo via `super().describe()`), and mirror it into the Newton discovery surface for parity (Newton implements `get_state` too).
- Advertise `save_state`, `load_state`, `set_joint_positions`, `set_joint_velocities` in the MuJoCo `describe()` override -- these live in the MuJoCo `PhysicsMixin`. Each entry names the real distinguishing parameters so a caller can invoke them without reading the source.
- Document the surface in `docs/simulation/overview.md` (Physics table rows + a discovery note).

Metadata-only change: no simulation behavior, policy, rendering, recording, or asset is altered -- `describe()` returns the same shape with additional advertised method entries.

## Tests

- `TestDescribeABC::test_describe_lists_get_state` -- base contract advertises `get_state`.
- `TestDescribeMuJoCo::test_describe_lists_sim_state_family` -- the live MuJoCo engine advertises all five with their key parameters.
- Extended the Newton `test_describe_exposes_new_methods` parity tuple with `get_state`.
- The existing `test_describe_methods_resolve_to_real_attributes` invariant auto-validates every new entry resolves to a real callable.

Both new tests fail on pre-change code (`describe() omits ...`) and pass after. Full local gate green: `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` clean; `MUJOCO_GL=egl` sim + discovery suites pass (`test_sim_engine_describe_discovery.py` 20 passed, `test_simulation.py` 161 passed).

---

## §13 Review Rounds

| Round | Concern | Commit | Pin test |
|-------|---------|--------|----------|
| R0 | Initial submission | `5a287e8` | `tests/simulation/test_sim_engine_describe_discovery.py::TestDescribeABC::test_describe_lists_get_state` |
| R1 | Merge conflict with #1256 (benchmark scoring family) | `32cd01e` | Both test methods retained: `test_describe_lists_get_state` + `test_describe_lists_benchmark_family_methods` |

---

Companion to: #1256 (benchmark scoring family, merged to main)