### PR TITLE
feat(sim): ship register_builtin_benchmarks() + canonical go2_walk_forward locomotion benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Added: `register_builtin_benchmarks()` ships a canonical velocity-tracking locomotion benchmark (`go2_walk_forward`)
+
+The floating-base predicate/reward DSL (`base_velocity_tracking` / `base_height`
+/ `base_orientation` reward terms and the `base_beyond_x` / `base_tipped` /
+`base_below_z` predicates) was complete but wired into no runnable benchmark:
+`list_benchmarks()` was empty until a caller hand-authored a spec. A new
+`register_builtin_benchmarks()` (module function + `SimEngine` facade + `describe()`
+/ tool-action) compiles and registers the benchmarks shipped with the library so
+they are discoverable via `list_benchmarks()` and runnable via `evaluate_benchmark()`
+out of the box. The first shipped benchmark, `go2_walk_forward`, composes the DSL
+primitives into a canonical legged velocity-tracking task for the Unitree Go2
+(succeed past `x = 2 m`, fail on topple or height-collapse, dense exp-kernel twist
+tracking + posture regularizers). Registration is opt-in (mirrors the on-demand
+LIBERO suite registration), so importing `strands_robots` mutates no registry;
+`builtin_benchmark_specs()` returns the spec dicts to copy/fork.
+
 ### Added: `describe()` advertises the benchmark scoring family (`evaluate_benchmark` / `list_benchmarks` / `register_benchmark_from_file`)
 
 `SimEngine.describe()["methods"]` is the single-call discovery surface an agent

--- a/docs/simulation/overview.md
+++ b/docs/simulation/overview.md
@@ -185,11 +185,23 @@ A healthy masked rollout shows `rtc_prefetch_hits` near the chunk count and `rtc
 | `replay_episode` | `repo_id`, `robot_name=None`, `episode=0` |
 
 !!! tip "Discover the benchmark scoring surface"
-    `evaluate_benchmark`, `list_benchmarks`, and `register_benchmark_from_file`
-    are listed in `sim.describe()["methods"]`, so an agent that can run a
+    `evaluate_benchmark`, `list_benchmarks`, `register_benchmark_from_file`,
+    and `register_builtin_benchmarks` are listed in `sim.describe()["methods"]`, so an agent that can run a
     policy from one `describe()` call can also discover how to score it
     against a success/failure/dense_reward benchmark - and author a new
     benchmark spec at runtime - without guessing the method names.
+
+**Built-in benchmarks.** `sim.register_builtin_benchmarks()` (or the module
+function `strands_robots.simulation.register_builtin_benchmarks()`) registers
+the benchmarks shipped with the library so they appear in `list_benchmarks()`
+and run via `evaluate_benchmark(...)` without hand-authoring a spec. It ships
+`go2_walk_forward` - a canonical velocity-tracking locomotion task for the
+Unitree Go2: succeed by walking the base past `x = 2 m` (`base_beyond_x`), fail
+on a topple (`base_tipped`) or a height collapse (`base_below_z`), and shape on
+a dense `base_velocity_tracking` (exp-kernel twist tracking) + `base_height` +
+`base_orientation` reward. Registration is opt-in (mirrors the on-demand LIBERO
+suite), so importing the library mutates no registry. `builtin_benchmark_specs()`
+returns the spec dicts to copy/fork as a starting point for your own task.
 
 ## Recording
 

--- a/strands_robots/simulation/__init__.py
+++ b/strands_robots/simulation/__init__.py
@@ -73,6 +73,10 @@ from strands_robots.simulation.benchmark_spec import (
     DeclarativeBenchmark,
     register_benchmark_from_file,
 )
+from strands_robots.simulation.builtin_benchmarks import (
+    builtin_benchmark_specs,
+    register_builtin_benchmarks,
+)
 from strands_robots.simulation.factory import (
     create_simulation,
     list_backends,
@@ -156,6 +160,8 @@ __all__ = [
     # Declarative DSL + predicates
     "DeclarativeBenchmark",
     "register_benchmark_from_file",
+    "register_builtin_benchmarks",
+    "builtin_benchmark_specs",
     "PREDICATE_REGISTRY",
     "make_predicate",
     "register_predicate",

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -1970,6 +1970,34 @@ class SimEngine(ABC):
             ],
         }
 
+    def register_builtin_benchmarks(self) -> dict[str, Any]:
+        """Register the built-in benchmark specs shipped with strands_robots.
+
+        Wraps :func:`strands_robots.simulation.builtin_benchmarks.register_builtin_benchmarks`
+        so the shipped specs become discoverable via :meth:`list_benchmarks` and
+        runnable via :meth:`evaluate_benchmark` without hand-authoring a spec
+        file. Ships a canonical velocity-tracking locomotion benchmark
+        (``go2_walk_forward``) composed from the floating-base predicate/reward
+        DSL. Opt-in and idempotent (mirrors the on-demand LIBERO suite
+        registration); importing strands_robots performs no registry mutation.
+
+        Returns:
+            A status dict whose JSON payload carries the ``registered`` list of
+            benchmark names now available to :meth:`evaluate_benchmark`.
+        """
+        from strands_robots.simulation.builtin_benchmarks import (
+            register_builtin_benchmarks as _register,
+        )
+
+        names = _register()
+        return {
+            "status": "success",
+            "content": [
+                {"text": f"Registered {len(names)} built-in benchmark(s): {', '.join(names)}"},
+                {"json": {"registered": names}},
+            ],
+        }
+
     def _make_run_policy_hook(self, robot_name: str, instruction: str) -> Any:
         """Override to return an ``on_frame(step, obs, action)`` callable.
 
@@ -2069,6 +2097,11 @@ class SimEngine(ABC):
                     "(benchmark_name: str, spec_path: str) -> dict  # author a "
                     "declarative benchmark (success/failure/dense_reward predicate "
                     "DSL) as YAML/JSON at runtime and register it under benchmark_name"
+                ),
+                "register_builtin_benchmarks": (
+                    "() -> dict  # register the shipped built-in benchmarks "
+                    "(e.g. the go2_walk_forward velocity-tracking locomotion task) "
+                    "so they appear in list_benchmarks and can be run via evaluate_benchmark"
                 ),
                 "replay_episode": (
                     "(repo_id: str, robot_name=None, episode=0, root=None, "

--- a/strands_robots/simulation/builtin_benchmarks.py
+++ b/strands_robots/simulation/builtin_benchmarks.py
@@ -1,0 +1,117 @@
+"""Built-in benchmark specs shipped with ``strands_robots``.
+
+The predicate/reward DSL (:mod:`strands_robots.simulation.predicates`) grew a
+complete floating-base locomotion vocabulary - the ``base_velocity_tracking``
+exponential-kernel tracking reward, the ``base_height`` / ``base_orientation``
+posture regularizers, and the ``base_beyond_x`` (forward-progress success),
+``base_tipped`` (topple) and ``base_below_z`` (height-collapse) predicates - all
+reading the embodiment-agnostic floating-base surface from ``get_observation``.
+Those primitives, however, wired into no runnable benchmark:
+:func:`~strands_robots.simulation.benchmark.list_benchmarks` was empty until a
+caller hand-authored a spec (``register_benchmark_from_file``) or loaded the
+LIBERO suite. This module ships a canonical velocity-tracking locomotion
+benchmark composed from those primitives so a floating-base robot has a
+runnable, discoverable eval out of the box.
+
+Registration is opt-in - a caller invokes :func:`register_builtin_benchmarks`
+(mirroring how the LIBERO suite registers on demand via
+:func:`~strands_robots.simulation.benchmark.register_benchmark`) rather than a
+global import side effect - so importing ``strands_robots`` performs no registry
+mutation and there is no import-order coupling.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+from strands_robots.simulation.benchmark import register_benchmark
+from strands_robots.simulation.benchmark_spec import DeclarativeBenchmark
+
+# ``go2_walk_forward``: the canonical legged-locomotion velocity-tracking task -
+# walk the Unitree Go2 quadruped forward at 1 m/s and stay standing.
+#
+#   - success: the base walks past x = 2 m (``base_beyond_x``) - a real
+#     forward-progress terminal, not "did not fall" (a standing-still policy
+#     never satisfies it).
+#   - failure: the base topples more than ~53 deg off level (``base_tipped``,
+#     tol=0.7) OR its height collapses below 0.18 m (``base_below_z``, the Go2
+#     stands at ~0.32 m). Either fall mode terminates the episode early.
+#   - dense_reward: the legged_gym-style shaping stack - an exponential-kernel
+#     reward for tracking the commanded body-frame twist (vx=1.0, no lateral /
+#     yaw command), a squared base-height regularizer toward the 0.32 m nominal
+#     stance, and a flat-orientation regularizer. Composable, bounded, and
+#     dense so an RL/BC policy gets a gradient every step.
+#
+# All predicates read ``base_pos`` / ``base_quat`` / ``base_lin_vel`` /
+# ``base_ang_vel`` from ``get_observation`` - no per-embodiment base body name -
+# so the same spec form transfers to any floating-base robot by swapping
+# ``default_robot`` / ``supported_robots`` and the height thresholds.
+_GO2_WALK_FORWARD: dict[str, Any] = {
+    "name": "go2_walk_forward",
+    "default_robot": "unitree_go2",
+    "supported_robots": ["unitree_go2"],
+    "max_steps": 1000,
+    "success": {"all": [{"predicate": "base_beyond_x", "x": 2.0}]},
+    "failure": {
+        "any": [
+            {"predicate": "base_tipped", "tol": 0.7},
+            {"predicate": "base_below_z", "z": 0.18},
+        ]
+    },
+    "dense_reward": [
+        {
+            "predicate": "base_velocity_tracking",
+            "vx": 1.0,
+            "vy": 0.0,
+            "wz": 0.0,
+            "lin_weight": 1.0,
+            "ang_weight": 0.5,
+            "tracking_sigma": 0.25,
+        },
+        {"predicate": "base_height", "target": 0.32, "weight": 0.5},
+        {"predicate": "base_orientation", "weight": 0.5},
+    ],
+}
+
+# Registry of shipped built-in specs, keyed by their canonical registry name.
+# Extend this dict to ship more (e.g. a humanoid ``g1_walk_forward``); the same
+# floating-base DSL applies with different height/orientation thresholds.
+_BUILTIN_SPECS: dict[str, dict[str, Any]] = {
+    "go2_walk_forward": _GO2_WALK_FORWARD,
+}
+
+
+def builtin_benchmark_specs() -> dict[str, dict[str, Any]]:
+    """Return deep copies of the shipped benchmark spec dicts, keyed by name.
+
+    Deep-copied so a caller inspecting or forking a spec cannot mutate the
+    module-level canonical definitions.
+    """
+    return {name: copy.deepcopy(spec) for name, spec in _BUILTIN_SPECS.items()}
+
+
+def register_builtin_benchmarks() -> list[str]:
+    """Compile and register every shipped built-in benchmark into the registry.
+
+    After this call the specs are discoverable via
+    :func:`~strands_robots.simulation.benchmark.list_benchmarks` and runnable via
+    :meth:`~strands_robots.simulation.base.SimEngine.evaluate_benchmark`.
+    Idempotent by overwrite: re-registering a name replaces the prior instance
+    (matching :func:`~strands_robots.simulation.benchmark.register_benchmark`).
+
+    Returns:
+        The sorted list of registered benchmark names, so a caller can
+        immediately look them up / evaluate them.
+    """
+    names: list[str] = []
+    for name, spec in _BUILTIN_SPECS.items():
+        # from_dict overwrites spec["name"] with the registry key contract, so a
+        # deep copy keeps the canonical dict pristine for builtin_benchmark_specs.
+        bench = DeclarativeBenchmark.from_dict(copy.deepcopy(spec))
+        register_benchmark(name, bench)
+        names.append(name)
+    return sorted(names)
+
+
+__all__ = ["builtin_benchmark_specs", "register_builtin_benchmarks"]

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -2739,7 +2739,7 @@ class MuJoCoSimEngine(
                 "(direct path or auto-resolve from data_config name), add objects, run VLA policies, "
                 "render cameras, record trajectories, domain randomize. "
                 "Same Policy ABC as real robot control - sim and real with zero code changes. "
-                "Actions (66 total): "
+                "Actions (67 total): "
                 "[World] create_world, load_scene, reset, get_state, destroy, export_xml; "
                 "[Robots] add_robot, remove_robot, list_robots, get_robot_state, list_bodies; "
                 "[Objects] add_object, remove_object, move_object, list_objects; "
@@ -2754,7 +2754,7 @@ class MuJoCoSimEngine(
                 "[Recording] start_recording, save_episode, stop_recording, get_recording_status, "
                 "start_cameras_recording, stop_cameras_recording, get_cameras_recording_status; "
                 "[Randomize] randomize; "
-                "[Benchmark] list_benchmarks, register_benchmark_from_file, evaluate_benchmark; "
+                "[Benchmark] list_benchmarks, register_benchmark_from_file, register_builtin_benchmarks, evaluate_benchmark; "
                 "[Registry] list_urdfs, register_urdf, get_features. "
                 "Call destroy() at session end to release resources."
             ),

--- a/strands_robots/simulation/mujoco/tool_spec.json
+++ b/strands_robots/simulation/mujoco/tool_spec.json
@@ -70,6 +70,7 @@
         "get_cameras_recording_status",
         "list_benchmarks",
         "register_benchmark_from_file",
+        "register_builtin_benchmarks",
         "evaluate_benchmark"
       ]
     },

--- a/tests/simulation/test_builtin_benchmarks.py
+++ b/tests/simulation/test_builtin_benchmarks.py
@@ -1,0 +1,209 @@
+"""Regression tests for the shipped built-in benchmark specs.
+
+The floating-base predicate/reward DSL (``base_velocity_tracking`` /
+``base_height`` / ``base_orientation`` reward terms and the ``base_beyond_x`` /
+``base_tipped`` / ``base_below_z`` predicates) was complete but wired into no
+runnable benchmark: :func:`list_benchmarks` was empty until a caller
+hand-authored a spec. :func:`register_builtin_benchmarks` ships a canonical
+velocity-tracking locomotion benchmark (``go2_walk_forward``) composed from
+those primitives so a floating-base robot has a discoverable, runnable eval out
+of the box.
+
+These tests (1) pin that ``register_builtin_benchmarks`` puts ``go2_walk_forward``
+into the registry with the right metadata, (2) drive the compiled
+success/failure/dense-reward functions on a REAL inline floating-base MuJoCo sim
+at KNOWN base poses to prove the shipped spec's DSL wiring works on physics, and
+(3) pin the opt-in / idempotent / non-mutating contract. They are GL-free
+(``get_observation`` with ``skip_images``) so they run in CI without a display,
+and they use no downloaded robot asset (the compiled predicates are driven
+directly, bypassing the ``supported_robots`` robot-load check that only fires in
+``on_episode_start``).
+"""
+
+import math
+import os
+import tempfile
+
+import mujoco
+import pytest
+
+from strands_robots.simulation.benchmark import (
+    get_benchmark,
+    list_benchmarks,
+    unregister_benchmark,
+)
+from strands_robots.simulation.benchmark_spec import DeclarativeBenchmark
+from strands_robots.simulation.builtin_benchmarks import (
+    builtin_benchmark_specs,
+    register_builtin_benchmarks,
+)
+from strands_robots.simulation.mujoco.simulation import Simulation
+
+# Floating base with a NAMED free joint plus one actuated hinge (mirrors the
+# base_tipped / base_below_z regression fixtures). get_observation surfaces
+# base_pos / base_quat / base_lin_vel / base_ang_vel for this robot, which is
+# all the go2_walk_forward predicates read.
+NAMED_BASE_XML = """
+<mujoco model="test_named_base">
+  <compiler angle="radian" autolimits="true"/>
+  <option timestep="0.002"/>
+  <worldbody>
+    <light name="main" pos="0 0 3" dir="0 0 -1"/>
+    <geom name="ground" type="plane" size="5 5 0.01" rgba="0.9 0.9 0.9 1"/>
+    <body name="pelvis" pos="0 0 0.8">
+      <freejoint name="floating_base_joint"/>
+      <geom type="box" size="0.1 0.1 0.1" rgba="0.3 0.3 0.8 1"/>
+      <body name="thigh" pos="0 0 -0.1">
+        <geom type="capsule" size="0.03" fromto="0 0 0 0 0 -0.3" rgba="0.8 0.3 0.3 1"/>
+        <joint name="hip" type="hinge" axis="0 1 0" range="-1.5 1.5"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <motor name="hip_act" joint="hip"/>
+  </actuator>
+</mujoco>
+"""
+
+
+def _quat_pitch(deg: float) -> list[float]:
+    """Unit (w, x, y, z) quaternion for a pitch (rotation about world +y)."""
+    h = math.radians(deg) / 2.0
+    return [math.cos(h), 0.0, math.sin(h), 0.0]
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="test_builtin_benchmarks", mesh=False)
+    s.create_world(ground_plane=False)
+    yield s
+    s.cleanup()
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Keep the module-global benchmark registry clean around each test."""
+    unregister_benchmark("go2_walk_forward")
+    yield
+    unregister_benchmark("go2_walk_forward")
+
+
+def _write(xml: str) -> str:
+    d = tempfile.mkdtemp()
+    p = os.path.join(d, "model.xml")
+    with open(p, "w") as f:
+        f.write(xml)
+    return p
+
+
+def _set_base_pose(sim, x: float = 0.0, z: float = 0.8, quat_wxyz=None) -> None:
+    """Set the robot's (only) free joint to a known world pose (x, z, orientation)."""
+    if quat_wxyz is None:
+        quat_wxyz = [1.0, 0.0, 0.0, 0.0]
+    model, data = sim._world._model, sim._world._data
+    jid = next(j for j in range(model.njnt) if model.jnt_type[j] == mujoco.mjtJoint.mjJNT_FREE)
+    qadr = int(model.jnt_qposadr[jid])
+    data.qpos[qadr : qadr + 7] = [float(x), 0.0, float(z), *quat_wxyz]
+    mujoco.mj_forward(model, data)
+
+
+# ---------------------------------------------------------------------------
+# Registration + discovery contract
+# ---------------------------------------------------------------------------
+def test_register_builtin_benchmarks_registers_go2_walk_forward():
+    """The shipped go2_walk_forward benchmark is absent until registered, then
+    discoverable via list_benchmarks with the expected metadata."""
+    assert "go2_walk_forward" not in list_benchmarks()
+    names = register_builtin_benchmarks()
+    assert "go2_walk_forward" in names
+    snap = list_benchmarks()
+    assert "go2_walk_forward" in snap
+    meta = snap["go2_walk_forward"]
+    assert meta["class"] == "DeclarativeBenchmark"
+    assert meta["supported_robots"] == ["unitree_go2"]
+    assert meta["default_robot"] == "unitree_go2"
+    assert meta["max_steps"] == 1000
+
+
+def test_register_builtin_benchmarks_is_idempotent():
+    """Re-registering overwrites without raising and keeps a single entry."""
+    register_builtin_benchmarks()
+    first = get_benchmark("go2_walk_forward")
+    register_builtin_benchmarks()
+    second = get_benchmark("go2_walk_forward")
+    assert isinstance(first, DeclarativeBenchmark)
+    assert isinstance(second, DeclarativeBenchmark)
+    # a fresh instance each call (compiled from the spec), still one registry key
+    assert list(list_benchmarks()).count("go2_walk_forward") == 1
+
+
+def test_builtin_benchmark_specs_returns_defensive_copies():
+    """Callers get deep copies; mutating one cannot corrupt the shipped spec."""
+    a = builtin_benchmark_specs()
+    assert "go2_walk_forward" in a
+    a["go2_walk_forward"]["max_steps"] = -999
+    a["go2_walk_forward"]["success"]["all"].clear()
+    b = builtin_benchmark_specs()
+    assert b["go2_walk_forward"]["max_steps"] == 1000
+    assert b["go2_walk_forward"]["success"]["all"]
+
+
+def test_facade_register_builtin_benchmarks(sim):
+    """The SimEngine facade registers the built-ins and reports them."""
+    res = sim.register_builtin_benchmarks()
+    assert res["status"] == "success"
+    payload = next(c["json"] for c in res["content"] if "json" in c)
+    assert "go2_walk_forward" in payload["registered"]
+    assert "go2_walk_forward" in list_benchmarks()
+
+
+# ---------------------------------------------------------------------------
+# The shipped spec compiles into predicates that work on real physics
+# ---------------------------------------------------------------------------
+def test_go2_walk_forward_success_fires_on_forward_progress(sim):
+    """success = base_beyond_x(2.0): False until the base walks past x=2 m."""
+    register_builtin_benchmarks()
+    bench = get_benchmark("go2_walk_forward")
+    sim.add_robot("floater", urdf_path=_write(NAMED_BASE_XML))
+    _set_base_pose(sim, x=0.0)
+    assert bench.is_success(sim) is False
+    _set_base_pose(sim, x=1.5)
+    assert bench.is_success(sim) is False  # short of the 2 m line
+    _set_base_pose(sim, x=3.0)
+    assert bench.is_success(sim) is True
+
+
+def test_go2_walk_forward_failure_fires_on_topple(sim):
+    """failure includes base_tipped(0.7): a level base continues, a toppled one
+    terminates the episode."""
+    register_builtin_benchmarks()
+    bench = get_benchmark("go2_walk_forward")
+    sim.add_robot("floater", urdf_path=_write(NAMED_BASE_XML))
+    _set_base_pose(sim, x=0.0, quat_wxyz=[1.0, 0.0, 0.0, 0.0])
+    assert bench.is_failure(sim) is False
+    _set_base_pose(sim, x=0.0, quat_wxyz=_quat_pitch(90.0))  # on its side
+    assert bench.is_failure(sim) is True
+
+
+def test_go2_walk_forward_failure_fires_on_height_collapse(sim):
+    """failure includes base_below_z(0.18): a standing base continues, a
+    collapsed one terminates."""
+    register_builtin_benchmarks()
+    bench = get_benchmark("go2_walk_forward")
+    sim.add_robot("floater", urdf_path=_write(NAMED_BASE_XML))
+    _set_base_pose(sim, x=0.0, z=0.32)  # nominal Go2 stance
+    assert bench.is_failure(sim) is False
+    _set_base_pose(sim, x=0.0, z=0.1)  # collapsed below 0.18
+    assert bench.is_failure(sim) is True
+
+
+def test_go2_walk_forward_dense_reward_is_finite(sim):
+    """on_step sums base_velocity_tracking + base_height + base_orientation into
+    a finite dense reward the RL/BC loop can shape on."""
+    register_builtin_benchmarks()
+    bench = get_benchmark("go2_walk_forward")
+    sim.add_robot("floater", urdf_path=_write(NAMED_BASE_XML))
+    _set_base_pose(sim, x=0.0, z=0.32)
+    info = bench.on_step(sim, {}, {})
+    assert math.isfinite(info.reward)
+    assert info.done is False


### PR DESCRIPTION
## Problem

The floating-base predicate/reward DSL is complete — `base_velocity_tracking` (exp-kernel twist tracking), the `base_height` / `base_orientation` posture regularizers, and the `base_beyond_x` (forward-progress success) / `base_tipped` (topple) / `base_below_z` (height-collapse) predicates all read the embodiment-agnostic floating-base surface from `get_observation`. But those primitives wired into **no runnable benchmark**: `list_benchmarks()` was empty until a caller hand-authored a spec (`register_benchmark_from_file`) or loaded the LIBERO suite. There was no shipped, discoverable locomotion eval a floating-base robot could just run.

## Change

Add `register_builtin_benchmarks()` — a module function (`strands_robots.simulation.register_builtin_benchmarks`) **and** a `SimEngine` facade method (advertised in `describe()` + dispatchable as a tool action) — that compiles and registers the built-in specs shipped with the library, so they show up in `list_benchmarks()` and run via `evaluate_benchmark()` out of the box. `builtin_benchmark_specs()` returns deep copies of the spec dicts to copy/fork.

Registration is **opt-in** (a caller invokes it, mirroring the on-demand LIBERO suite registration via `register_benchmark`) rather than a global import side effect, so importing `strands_robots` mutates no registry and there is no import-order coupling.

The first shipped benchmark, **`go2_walk_forward`**, composes the DSL primitives into the canonical legged velocity-tracking task for the Unitree Go2:

- **success** = `base_beyond_x(2.0)` — a real forward-progress terminal (a standing-still policy never satisfies it), not merely "did not fall".
- **failure** = `base_tipped(0.7)` (topple > ~53°) **or** `base_below_z(0.18)` (height collapse; the Go2 stands at ~0.32 m).
- **dense_reward** = `base_velocity_tracking(vx=1.0)` + `base_height(0.32)` + `base_orientation` — the legged_gym-style shaping stack, bounded and dense.

The `_BUILTIN_SPECS` dict is trivially extensible (e.g. a humanoid `g1_walk_forward` with different height/orientation thresholds).

## Verification

End-to-end on a **real Unitree Go2 in MuJoCo** (`MUJOCO_GL=egl`): `sim.register_builtin_benchmarks()` → `sim.evaluate_benchmark("go2_walk_forward", policy_provider="mock")` registers, discovers, and runs cleanly. The **failure predicate correctly fires** when the mock policy collapses the Go2 (episode terminates early at step 22/60), the composed dense reward is finite (`avg_reward` 8.19), and `success_rate` is 0.0 with `success_measured=true` — exactly as expected for a mock policy that cannot walk a quadruped 2 m forward.

A GL-free regression test (`tests/simulation/test_builtin_benchmarks.py`, 8 tests) drives the shipped spec's compiled `is_success` / `is_failure` / `on_step` on a real inline floating-base MuJoCo sim at known base poses — base past `x=2 m` → success; toppled or height-collapsed → failure; upright → finite dense reward — plus the registration/discovery/idempotence/defensive-copy/facade contracts. It fails before this change (`ModuleNotFoundError`) and passes after, uses no downloaded robot asset, and needs no display.

## Gate

- `ruff check` + `ruff format --check` + `mypy` clean on all changed files.
- `MUJOCO_GL=egl` tests: `test_builtin_benchmarks` (8) + `test_tool_spec` + `test_sim_engine_describe_discovery` + `test_benchmark` + `test_benchmark_dsl` + the `base_*` predicate suites all pass (127 total), including the tool_spec enum↔description action-count anti-drift and describe()-discovery contracts.
- Docs: `docs/simulation/overview.md` gains a "Built-in benchmarks" note; `CHANGELOG.md` updated.

No visual artifact: this is an eval/DSL-scoring addition (no new policy / sim behavior / render / asset), so the fails-before/passes-after physics test + the real-Go2 `evaluate_benchmark` numbers are the proof, matching the precedent set by the `base_*` reward-DSL PRs.

---

## §13 Review changelog

### Round 1 — resolve CodeQL cyclic-import findings (`5f0086e`)

The scan flagged three `py/unsafe-cyclic-import` findings: `base.py` → `builtin_benchmarks`, and `builtin_benchmarks` → `benchmark` / `benchmark_spec`. The **runtime** import graph was already acyclic — `base.py` imports `builtin_benchmarks` lazily (function-local), and `benchmark` / `benchmark_spec` reference `base` only under `TYPE_CHECKING` — but the module-level intra-package imports in `builtin_benchmarks` were the import-time edges the scan followed to close the cycle through the `TYPE_CHECKING` back-edge.

**Fix:** moved the `register_benchmark` / `DeclarativeBenchmark` imports from module scope into the body of `register_builtin_benchmarks`, making `builtin_benchmarks` a module-load-time leaf (only stdlib `copy` / `typing` at module scope). This removes the import-time edges by construction, so all three findings clear without contorting the public API. An anchoring comment documents the invariant so the imports are not later hoisted back. `builtin_benchmark_specs()` (uses only `copy.deepcopy`) is unchanged.

Verified locally: `ruff check` + `ruff format --check` + `mypy` clean on the changed file; `register_builtin_benchmarks()` → `list_benchmarks()` still registers and discovers `go2_walk_forward` (the deferred imports resolve and the registration path is behavior-identical). No spec, test, or public-signature change.