### PR TITLE
feat(sim): advertise the background-policy stop/list lifecycle in describe()

### DIFF
--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1552,6 +1552,24 @@ class MuJoCoSimEngine(
             "ordered-list form mirrors set_joint_positions"
         )
 
+        # Background-policy lifecycle. MuJoCo overrides start_policy to run in a
+        # background thread (non-blocking), unlike the base engine's synchronous
+        # passthrough -- so an agent that discovers start_policy here and launches
+        # a rollout has no way to discover how to STOP it or see WHAT is running
+        # without guessing these names. Both are first-class actions in the tool
+        # spec + action dispatcher; listing them completes the start/stop/list
+        # lifecycle on the discovery surface (the resource-management sibling of
+        # run_policy's blocking rollout).
+        base["methods"]["stop_policy"] = (
+            "(robot_name: str) -> dict  # cooperatively stop the background "
+            "policy started by start_policy on robot_name; idempotent (succeeds "
+            "with 'Was not running' when none is active). The inverse of start_policy"
+        )
+        base["methods"]["list_policies_running"] = (
+            "() -> dict  # names of robots currently running a background policy "
+            "(inspect concurrent-policy state when driving two or more arms in one scene)"
+        )
+
         if self._world is not None:
             base["sim_time"] = self._world.sim_time
             base["world_created"] = True

--- a/tests/simulation/mujoco/test_simulation.py
+++ b/tests/simulation/mujoco/test_simulation.py
@@ -1139,6 +1139,37 @@ class TestPolicyExecution:
         result = sim_with_world.start_policy("ghost")
         assert result["status"] == "error"
 
+    def test_describe_advertises_background_policy_lifecycle(self, sim_with_robot):
+        """describe() advertises the whole start/stop/list background-policy
+        lifecycle, not just start_policy.
+
+        The MuJoCo backend overrides start_policy to run in a background thread
+        (non-blocking), unlike the base engine's synchronous passthrough, and
+        provides stop_policy + list_policies_running to manage it. describe()
+        already advertised start_policy (inherited from the base surface), but
+        omitted its lifecycle siblings -- so an agent that discovered
+        start_policy here and launched a rollout could not learn how to stop it
+        or inspect what is running without guessing the names, a resource-leak
+        trap. Both are first-class actions in the tool spec + dispatcher and
+        belong on the discovery surface alongside start_policy.
+        """
+        methods = sim_with_robot.describe()["methods"]
+        for name in ("start_policy", "stop_policy", "list_policies_running"):
+            assert name in methods, f"describe() omits policy-lifecycle method {name!r}"
+        # Advertised signatures name the real parameters / return shape so a
+        # caller can invoke them without reading the source.
+        assert "robot_name" in methods["stop_policy"]
+        assert "-> dict" in methods["list_policies_running"]
+
+        # The advertisement is only useful if the methods it names are real and
+        # invocable: list before start reports none, stop is idempotent.
+        listed = sim_with_robot.list_policies_running()
+        assert listed["status"] == "success"
+        assert "No policies running" in listed["content"][0]["text"]
+        idempotent = sim_with_robot.stop_policy("arm1")
+        assert idempotent["status"] == "success"
+        assert "Was not running" in idempotent["content"][0]["text"]
+
 
 # Action Dispatch
 


### PR DESCRIPTION
## Problem
The MuJoCo backend overrides `start_policy` to run in a background thread (non-blocking), unlike the base engine's synchronous passthrough, and provides `stop_policy` + `list_policies_running` to manage that lifecycle. `describe()` already advertised `start_policy` (inherited from the base discovery surface) but omitted its lifecycle siblings.

So an agent that discovered `start_policy` from `describe()` and launched a background rollout had no way to discover how to stop it or inspect what was running without guessing the method names - a resource-leak trap. This mirrors the discovery gaps recently closed for the rollout/benchmark/pose families.

## Change
List `stop_policy` and `list_policies_running` in the MuJoCo `describe()` override with their real signatures, so a single `describe()` call reveals the complete start/stop/list lifecycle alongside `run_policy`'s blocking rollout. No runtime behavior changes - `describe()` returns method-signature metadata only.

## Tests
Adds `test_describe_advertises_background_policy_lifecycle` (in `TestPolicyExecution`) that:
- asserts `describe()['methods']` advertises all three lifecycle methods (`start_policy`, `stop_policy`, `list_policies_running`) with their real parameters/return shape;
- verifies the advertised methods are actually invocable: `list_policies_running()` reports none before any start, and `stop_policy()` is idempotent (`Was not running`).

The test fails on pre-change code (`describe() omits policy-lifecycle method 'stop_policy'`) and passes after.

Gate: `ruff check`/`ruff format --check` clean, `mypy strands_robots tests tests_integ` clean (no issues in 752 source files), and the simulation + discovery test modules pass (183 passed) under `MUJOCO_GL=egl`.

Docs already document both methods in `docs/api-reference.md` and `docs/simulation/overview.md`; this aligns the machine-readable discovery surface with them.