### PR TITLE
feat(sim): advertise the physics-tuning / domain-perturbation family in MuJoCo describe()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,28 @@ engine and Newton (each fails before, passes after), and the existing
 resolve-to-real-attributes guard confirms each advertised name is a live callable
 on the MuJoCo engine.
 
+### Added: `describe()` advertises the physics-tuning / domain-perturbation surface (`set_gravity` / `set_timestep` / `set_body_properties` / `set_geom_properties` / `apply_force`)
+
+`SimEngine.describe()["methods"]` is the single-call discovery surface an agent
+reads to learn a sim's contract without guessing method names. It advertised the
+physics-introspection READ family (`get_body_state` / `get_contacts` /
+`get_sensor_data` / ... - how to *verify* a rollout) but omitted the write
+complement: the physics-tuning / domain-perturbation methods that *vary* the
+engine. `set_gravity` and `set_timestep` retune the engine (randomize gravity,
+simulate reduced/zero-g, change the integration step), `set_body_properties` and
+`set_geom_properties` perturb per-body mass or per-geom color/friction/size for
+domain randomization + sim2real, and `apply_force` applies an external wrench for
+push-recovery / disturbance-rejection perturbation testing. All five are
+first-class actions in the MuJoCo tool spec and action dispatcher - the engine's
+own guidance even points a caller at "set_gravity, set_timestep, etc." - yet an
+agent setting up a domain-randomization scene from `describe()` alone had to guess
+them. They are now listed in the MuJoCo backend's `describe()` methods dict as the
+write siblings of the coarse-grained `randomize()` facade and the physics-read
+surface, with signatures naming their distinguishing parameters. A regression test
+asserts the family is advertised (fails before, passes after) and the existing
+resolve-to-real-attributes guard confirms each advertised name is a live callable
+on the engine.
+
 ### Fixed: mypy import-untyped failures from pyarrow dropping its py.typed marker
 
 `pyarrow` 25.0.0 stopped shipping the `py.typed` marker it previously carried,

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1522,6 +1522,44 @@ class MuJoCoSimEngine(
             "exclude_body=-1) -> dict  # batch raycast from one origin (e.g. a lidar fan)"
         )
 
+        # Physics-tuning / domain-perturbation WRITE surface -- the complement
+        # of the physics-introspection READ family above. describe() teaches how
+        # to build a scene, run a policy, read the physics result, and checkpoint
+        # state, but previously listed no way to discover how to VARY the physics
+        # engine itself: randomize gravity or the integration timestep, perturb a
+        # body's mass or a geom's color/friction/size for domain randomization +
+        # sim2real, or apply an external wrench for push-recovery / perturbation
+        # testing. These are public MuJoCo methods the tool spec + action
+        # dispatcher already expose (the engine's own guidance points a caller at
+        # "set_gravity, set_timestep, etc."), and they are the write siblings of
+        # the coarse-grained randomize() facade; listing them here reveals the
+        # physics-write surface from one describe() call instead of by guessing.
+        base["methods"]["set_gravity"] = (
+            "(gravity: list[float] | float | int) -> dict  # set the world "
+            "gravity vector [gx, gy, gz] (a scalar is taken as the -z magnitude); "
+            "domain-randomize gravity or simulate reduced/zero-g"
+        )
+        base["methods"]["set_timestep"] = (
+            "(timestep: float) -> dict  # set the physics integration timestep "
+            "in seconds (smaller = more accurate, slower); the per-action substep "
+            "count run_policy derives from control_frequency rescales with it"
+        )
+        base["methods"]["set_body_properties"] = (
+            "(body_name: str, mass: float | None = None) -> dict  # set a body's "
+            "mass (its inertia scales with the mass); domain-randomize dynamics"
+        )
+        base["methods"]["set_geom_properties"] = (
+            "(geom_name=None, geom_id=None, color=None, friction=None, size=None) "
+            "-> dict  # set a geom's color (RGBA), friction, or size; "
+            "domain-randomize appearance + contact dynamics (identify the geom by "
+            "name or id)"
+        )
+        base["methods"]["apply_force"] = (
+            "(body_name: str, force=None, torque=None, point=None) -> dict  # "
+            "apply an external force/torque wrench to a body for the next step "
+            "(push-recovery / disturbance-rejection perturbation testing)"
+        )
+
         # Sim-state checkpoint + direct pose-setting surface. describe() teaches
         # how to build a scene, run a policy, and read the physics result, but
         # previously gave no way to discover how to CHECKPOINT/RESTORE the whole

--- a/tests/simulation/test_sim_engine_describe_discovery.py
+++ b/tests/simulation/test_sim_engine_describe_discovery.py
@@ -460,6 +460,46 @@ class TestDescribeMuJoCo:
         finally:
             sim.destroy()
 
+    def test_describe_lists_physics_tuning_methods(self):
+        """describe() advertises the physics-tuning / domain-perturbation WRITE surface.
+
+        The complement of the physics-introspection READ family: ``set_gravity``
+        / ``set_timestep`` (retune the engine), ``set_body_properties`` /
+        ``set_geom_properties`` (per-body / per-geom domain randomization), and
+        ``apply_force`` (an external wrench for push-recovery / perturbation
+        testing) are all first-class actions in the MuJoCo tool spec and action
+        dispatcher, and the engine's own guidance points a caller at
+        "set_gravity, set_timestep, etc." -- but the discovery surface listed
+        none of them, so an agent setting up a domain-randomization / sim2real
+        scene had to guess these names. They belong on the discovery surface
+        alongside the randomize() facade and the physics-read surface.
+        """
+        import os
+
+        os.environ.setdefault("MUJOCO_GL", "egl")
+        from strands_robots.simulation import Simulation
+
+        sim = Simulation()
+        try:
+            methods = sim.describe()["methods"]
+            for name in (
+                "set_gravity",
+                "set_timestep",
+                "set_body_properties",
+                "set_geom_properties",
+                "apply_force",
+            ):
+                assert name in methods, f"describe() omits physics-tuning method {name!r}"
+            # Advertised signatures name the real distinguishing parameters so a
+            # caller can invoke them without reading the source.
+            assert "gravity" in methods["set_gravity"]
+            assert "timestep" in methods["set_timestep"]
+            assert "body_name" in methods["set_body_properties"]
+            assert "friction" in methods["set_geom_properties"]
+            assert "torque" in methods["apply_force"]
+        finally:
+            sim.destroy()
+
     def test_describe_methods_resolve_to_real_attributes(self):
         """Every method MuJoCo describe() advertises must be a real callable.
 


### PR DESCRIPTION
## Problem

`SimEngine.describe()["methods"]` is the single-call discovery surface an agent reads to learn a sim's contract without probe-and-fail guessing. It already advertises how to build a scene, run a policy, record a dataset, checkpoint state, and — via the physics-introspection READ family (`get_body_state` / `get_contacts` / `get_sensor_data` / `get_jacobian` / `raycast` / ...) — how to *verify* a rollout.

But it omits the write complement: the physics-tuning / domain-perturbation methods that *vary* the engine. Diffing `describe()["methods"]` against the MuJoCo `tool_spec.json` action enum shows five dispatchable actions that were undiscoverable from `describe()` alone:

- `set_gravity` / `set_timestep` — retune the engine (randomize gravity, simulate reduced/zero-g, change the integration step)
- `set_body_properties` / `set_geom_properties` — perturb per-body mass or per-geom color/friction/size for domain randomization + sim2real
- `apply_force` — apply an external force/torque wrench for push-recovery / disturbance-rejection perturbation testing

All five are first-class MuJoCo tool-spec + action-dispatcher actions, and the engine's own guidance even points a caller at *"set_gravity, set_timestep, etc."* — yet an agent setting up a domain-randomization scene from `describe()` had to guess these names.

## Change

Advertise the five methods in the MuJoCo backend's `describe()["methods"]` as the write siblings of the coarse-grained `randomize()` facade and the physics-read surface, each with a signature that names its distinguishing parameters. Additive only — no change to the `tool_spec.json` enum, the action dispatcher, or any runtime behavior; this purely completes the discovery surface (the same pattern as the physics-introspection READ family and the sim-state / background-policy families already advertised).

## Tests

- New `test_describe_lists_physics_tuning_methods` asserts all five are advertised with their distinguishing parameters named. It **fails before** the change (`AssertionError: describe() omits physics-tuning method 'set_gravity'`) and passes after.
- The existing `test_describe_methods_resolve_to_real_attributes` guard confirms each newly advertised name is a live callable on the engine.
- `tests/simulation/test_sim_engine_describe_discovery.py` (22) + `tests/simulation/mujoco/test_tool_spec.py` (11) + `test_list_cameras_discovery.py` (6) all green under `MUJOCO_GL=egl`; the tool-spec enum/count parity is unaffected (only `describe()["methods"]` changed).
- `ruff check` / `ruff format` clean; `mypy` clean on the changed files.

CHANGELOG updated under `[Unreleased]`.