### PR TITLE
test(streaming): pin the positive-caching contract of has_streaming_dataset()

### DIFF
--- a/tests/test_streaming_dataset.py
+++ b/tests/test_streaming_dataset.py
@@ -485,6 +485,28 @@ def test_has_streaming_dataset_does_not_negatively_cache(monkeypatch):
     assert sd.has_streaming_dataset() is True
 
 
+def test_has_streaming_dataset_positively_caches(monkeypatch):
+    """A successful availability probe is memoized: once the streaming symbol
+    resolves, later calls short-circuit and never re-import lerobot.
+
+    The mirror of :func:`test_has_streaming_dataset_does_not_negatively_cache`.
+    Hot-loop callers (agent / eval / replay loops) call this repeatedly, and on
+    Jetson the ``from lerobot.datasets import ...`` probe is expensive (numpy /
+    torch ABI). The contract is proven behaviorally by breaking the import
+    AFTER the first success: a fresh probe of that broken state returns False
+    (see the negative test above), so a warmed cache returning True can only be
+    the memoized short-circuit - not a re-probe.
+    """
+    monkeypatch.setattr(sd, "_HAS_STREAMING_DATASET", [], raising=False)
+    # First probe resolves the symbol and caches the positive result.
+    _install_fake_lerobot_datasets(monkeypatch, with_streaming=True)
+    assert sd.has_streaming_dataset() is True
+    # Break the import. A cold probe of this exact state returns False; the
+    # warmed cache must short-circuit past it and still report True.
+    _install_fake_lerobot_datasets(monkeypatch, with_streaming=False)
+    assert sd.has_streaming_dataset() is True
+
+
 def test_get_streaming_cls_resolves_via_import(monkeypatch):
     """With no test-injected attribute override, _get_streaming_cls falls
     through to the real import and returns the resolved class."""


### PR DESCRIPTION
## Problem

`has_streaming_dataset()` in `strands_robots.streaming_dataset` memoizes a *successful* availability probe and short-circuits on subsequent calls:

```python
def has_streaming_dataset() -> bool:
    if _HAS_STREAMING_DATASET:
        return True
    try:
        from lerobot.datasets import StreamingLeRobotDataset  # noqa: F401
    except (ImportError, ValueError, RuntimeError) as exc:
        logger.debug("StreamingLeRobotDataset unavailable: %s", exc)
        return False
    _HAS_STREAMING_DATASET.append(True)
    return True
```

The fast path exists because hot-loop callers (agent / eval / replay loops) call this repeatedly, and `from lerobot.datasets import ...` is expensive to resolve (it pulls the numpy / torch ABI on first import). The module docstring documents both halves of the contract: *a successful probe is cached; a failed probe is re-attempted.*

The suite already pinned the negative half (`test_has_streaming_dataset_does_not_negatively_cache` — a transient `False` must not freeze streaming off). The positive half was never exercised: every existing test starts with an empty cache and never calls again once it is warm, so the `if _HAS_STREAMING_DATASET: return True` short-circuit was the last uncovered line in the module. A refactor that dropped or broke the memoization (re-importing lerobot on every check) would slip through CI silently.

## Change

Add `test_has_streaming_dataset_positively_caches`, the mirror of the existing negative-cache test:

1. Warm the cache with a resolving probe (`with_streaming=True`) and assert `True`.
2. Break the import (`with_streaming=False`) and assert the next call *still* returns `True`.

A cold probe of that broken state returns `False` (proven by `test_has_streaming_dataset_false_when_import_breaks`), so a warmed `True` can only be the memoized short-circuit. The contract is proven behaviorally — through the public function's observable result — not by asserting the private cache cell.

## Verification

- Test fails on a mutant that neuters the fast path (`if _HAS_STREAMING_DATASET:` -> `if False:`) with `assert False is True`, and passes on `main` — so it genuinely locks the short-circuit rather than tautologically passing.
- `streaming_dataset.py` coverage: 99% -> 100% (the last uncovered line, the cache-hit `return True`).
- Full gate green locally: `ruff check` / `ruff format --check` clean; `mypy strands_robots tests tests_integ` -> no issues; `tests/test_streaming_dataset.py` 41 passed.

Test-only change; no runtime behavior touched.