### PR TITLE
feat(sim): advertise the plain-MP4 camera-recording family in MuJoCo describe()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Added: `describe()` advertises the plain-MP4 camera-recording family (`start_cameras_recording` / `stop_cameras_recording` / `get_cameras_recording_status`)
+
+`SimEngine.describe()["methods"]` is the single-call discovery surface an agent
+reads to learn a sim's contract without guessing method names. The MuJoCo
+backend already advertised the LeRobotDataset recording family
+(`start_recording` / `save_episode` / `stop_recording`), which needs the
+`[lerobot]` extra and writes a parquet+MP4 dataset. But the dependency-free
+recorder trio -- `start_cameras_recording` (background capture of one raw MP4
+per camera, no lerobot), `stop_cameras_recording` (flush buffers, report
+per-camera frame counts + paths), and `get_cameras_recording_status` (inspect an
+in-progress recording) -- was undiscoverable from `describe()` alone, even though
+all three are first-class MuJoCo `tool_spec.json` + action-dispatcher actions. An
+agent lacking the `[lerobot]` extra, or wanting a raw MP4 rather than a dataset,
+had to guess these names. They are now advertised in the MuJoCo backend's
+`describe()["methods"]` as the raw-MP4 sibling of the dataset trio, each with a
+signature that names its distinguishing parameters. Additive only -- no change to
+the `tool_spec.json` enum, the action dispatcher, or any runtime behavior; this
+purely completes the recording discovery surface. A regression test asserts the
+trio is advertised with `cameras=` / `max_frames_per_camera=` named (fails
+before, passes after), and the existing `test_describe_methods_resolve_to_real_attributes`
+guard confirms each newly advertised name is a live callable on the engine.
+
+
 ### Added: `register_builtin_benchmarks()` ships a canonical velocity-tracking locomotion benchmark (`go2_walk_forward`)
 
 The floating-base predicate/reward DSL (`base_velocity_tracking` / `base_height`

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1474,6 +1474,32 @@ class MuJoCoSimEngine(
             "status=error on mismatch)"
         )
 
+        # Plain-MP4 camera-recording surface ([sim-mujoco] extra, no lerobot).
+        # The block above advertises the LeRobotDataset recording family
+        # (start_recording -> save_episode -> stop_recording), which needs the
+        # [lerobot] extra and writes a parquet+MP4 dataset. But an agent that
+        # only wants a raw MP4 per camera -- or that lacks lerobot entirely --
+        # had no way to discover the dependency-free recorder from describe()
+        # alone. These three are first-class MuJoCo tool-spec + action-dispatcher
+        # actions; listing them completes the recording surface with the plain
+        # start/stop/status trio alongside the dataset trio.
+        base["methods"]["start_cameras_recording"] = (
+            "(cameras=None, output_dir=None, fps=30, width=None, height=None, "
+            "name=None, max_frames_per_camera=3000) -> dict  # start a "
+            "dependency-free background recorder that writes one MP4 per camera "
+            "(no lerobot / dataset); cameras=None records every camera. The "
+            "raw-MP4 sibling of start_recording's LeRobotDataset"
+        )
+        base["methods"]["stop_cameras_recording"] = (
+            "() -> dict  # stop start_cameras_recording, flush each camera's "
+            "buffer to an MP4, and report per-camera frame counts + paths; "
+            "idempotent. The inverse of start_cameras_recording"
+        )
+        base["methods"]["get_cameras_recording_status"] = (
+            "() -> dict  # inspect an in-progress start_cameras_recording "
+            "(elapsed time, per-camera frame counts); reports idle when none is active"
+        )
+
         # Physics-introspection / grounding surface. The discovery surface
         # teaches how to build a scene, run a policy, and record a dataset, but
         # previously gave no way to discover how to READ the physics result --

--- a/tests/simulation/test_sim_engine_describe_discovery.py
+++ b/tests/simulation/test_sim_engine_describe_discovery.py
@@ -500,6 +500,41 @@ class TestDescribeMuJoCo:
         finally:
             sim.destroy()
 
+    def test_describe_lists_cameras_recording_family(self):
+        """describe() advertises the plain-MP4 recorder, not only the dataset one.
+
+        The recording surface already advertises the LeRobotDataset family
+        (``start_recording`` / ``save_episode`` / ``stop_recording``), which
+        needs the ``[lerobot]`` extra and writes a parquet+MP4 dataset. But the
+        dependency-free ``start_cameras_recording`` / ``stop_cameras_recording``
+        / ``get_cameras_recording_status`` trio -- which writes one raw MP4 per
+        camera with no lerobot dependency -- was undiscoverable from describe()
+        alone, even though all three are first-class MuJoCo tool-spec and
+        action-dispatcher actions. An agent lacking lerobot, or wanting a raw
+        MP4, had to guess these names. They belong on the discovery surface as
+        the raw-MP4 sibling of the dataset trio.
+        """
+        import os
+
+        os.environ.setdefault("MUJOCO_GL", "egl")
+        from strands_robots.simulation import Simulation
+
+        sim = Simulation()
+        try:
+            methods = sim.describe()["methods"]
+            for name in (
+                "start_cameras_recording",
+                "stop_cameras_recording",
+                "get_cameras_recording_status",
+            ):
+                assert name in methods, f"describe() omits cameras-recording method {name!r}"
+            # Advertised signatures name the real distinguishing parameters so a
+            # caller can invoke them without reading the source.
+            assert "cameras" in methods["start_cameras_recording"]
+            assert "max_frames_per_camera" in methods["start_cameras_recording"]
+        finally:
+            sim.destroy()
+
     def test_describe_methods_resolve_to_real_attributes(self):
         """Every method MuJoCo describe() advertises must be a real callable.
 


### PR DESCRIPTION
## Problem

`SimEngine.describe()["methods"]` is the single-call discovery surface an agent reads to learn a sim's contract without probe-and-fail guessing. The MuJoCo backend already advertises the LeRobotDataset recording family (`start_recording` / `save_episode` / `stop_recording`), which requires the `[lerobot]` extra and writes a parquet+MP4 dataset.

But it omits the dependency-free recorder. Diffing `describe()["methods"]` against the MuJoCo `tool_spec.json` action enum shows three dispatchable actions that were undiscoverable from `describe()` alone:

- `start_cameras_recording` - start a background recorder that writes one raw MP4 per camera, with no lerobot dependency and no dataset
- `stop_cameras_recording` - flush each camera's buffer to MP4 and report per-camera frame counts + paths
- `get_cameras_recording_status` - inspect an in-progress recording (elapsed time, per-camera frame counts)

All three are first-class MuJoCo `tool_spec.json` + action-dispatcher actions. An agent lacking the `[lerobot]` extra, or one that just wants a raw MP4 instead of a dataset, had to guess these names.

## Change

Advertise the three methods in the MuJoCo backend's `describe()["methods"]` as the raw-MP4 sibling of the LeRobotDataset recording trio, each with a signature that names its distinguishing parameters (`cameras=`, `output_dir=`, `max_frames_per_camera=`, ...). Additive only - no change to the `tool_spec.json` enum, the action dispatcher, or any runtime behavior; this purely completes the recording discovery surface (the same pattern as the physics-introspection READ family and the sim-state / benchmark families already advertised).

## Tests

- New `test_describe_lists_cameras_recording_family` asserts all three are advertised with their distinguishing parameters named. It **fails before** the change (`AssertionError: describe() omits cameras-recording method 'start_cameras_recording'`) and passes after.
- The existing `test_describe_methods_resolve_to_real_attributes` guard confirms each newly advertised name is a live callable on the engine.
- `tests/simulation/test_sim_engine_describe_discovery.py` + `tests/simulation/mujoco/test_tool_spec.py` (33 total) green under `MUJOCO_GL=egl`; the tool-spec enum/count parity is unaffected (only `describe()["methods"]` changed).
- `ruff check` / `ruff format` clean; `mypy` clean on the changed source.

CHANGELOG updated under `[Unreleased]`.