### PR TITLE
feat(sim): advertise the raw-MJCF / URDF scene-authoring family in MuJoCo describe()

### DIFF
--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1437,6 +1437,44 @@ class MuJoCoSimEngine(
         )
         base["methods"]["remove_camera"] = "(name: str) -> dict  # remove a camera added via add_camera"
         base["methods"]["list_cameras"] = "() -> list[str]  # renderable camera names incl. the built-in 'default' view"
+        # Raw-MJCF / URDF scene-authoring escape hatch. The structured
+        # add_robot / add_object / add_camera / load_scene surface covers the
+        # common vocabulary, but an agent that needs an element those
+        # dataclasses can't express (<tendon>, <equality>, <pair>, ...), a fast
+        # iterative spec edit, a serialised snapshot of the live scene, or a
+        # URDF the built-in registry does not ship had no way to discover the
+        # authoring surface from describe() alone -- it had to guess these
+        # names. All five are first-class actions in the MuJoCo tool spec +
+        # action dispatcher; listing them completes the scene-construction
+        # surface with its raw-MJCF complement.
+        base["methods"]["replace_scene_mjcf"] = (
+            "(xml: str) -> dict  # atomically replace the whole scene with "
+            "agent-authored MJCF (compiled + validated; MuJoCo's compiler error "
+            "returned verbatim on failure). Escape hatch when add_robot/add_object "
+            "cannot express an element; leaves world.robots/objects/cameras "
+            "registries untouched (caller reconciles)"
+        )
+        base["methods"]["patch_scene_mjcf"] = (
+            "(ops: list[dict]) -> dict  # apply structured edits to the live "
+            "MjSpec atomically then recompile once (rolled back if any op fails). "
+            "ops: add_body/add_geom/add_site/set_body_pos/set_body_quat/delete_body. "
+            "The fast iterative-edit sibling of replace_scene_mjcf"
+        )
+        base["methods"]["export_xml"] = (
+            "(output_path: str | None = None) -> dict  # serialise the current "
+            "scene (incl. runtime mutations) to canonical MJCF via spec.to_xml(); "
+            "writes to output_path when given, else returns the XML inline. The "
+            "read sibling of replace_scene_mjcf"
+        )
+        base["methods"]["register_urdf"] = (
+            "(data_config: str, urdf_path: str) -> dict  # register a URDF file "
+            "on disk under a data_config name so add_robot can then instantiate "
+            "it; validates the path is a readable file before registering"
+        )
+        base["methods"]["list_urdfs"] = (
+            "() -> dict  # enumerate the model / URDF names resolvable by "
+            "add_robot (built-in registry entries + those added via register_urdf)"
+        )
         # Rendering siblings of "render" (advertised in tool_spec.json + the
         # action dispatcher) that the base discovery surface omits. Listing
         # them here lets an agent enumerate the full render surface from

--- a/tests/simulation/test_sim_engine_describe_discovery.py
+++ b/tests/simulation/test_sim_engine_describe_discovery.py
@@ -535,6 +535,44 @@ class TestDescribeMuJoCo:
         finally:
             sim.destroy()
 
+    def test_describe_lists_scene_mjcf_authoring_methods(self):
+        """describe() advertises the raw-MJCF / URDF scene-authoring escape hatch.
+
+        The structured add_robot / add_object / add_camera / load_scene surface
+        covers the common vocabulary, but ``replace_scene_mjcf`` /
+        ``patch_scene_mjcf`` (author or iteratively edit raw MJCF, incl.
+        elements the dataclasses can't express), ``export_xml`` (serialise the
+        live scene back to MJCF), and ``register_urdf`` / ``list_urdfs`` (add
+        and enumerate URDFs the built-in registry does not ship) are all
+        first-class actions in the MuJoCo tool spec and action dispatcher --
+        yet the discovery surface listed none of them, so an agent authoring a
+        scene beyond the structured vocabulary had to guess these names.
+        """
+        import os
+
+        os.environ.setdefault("MUJOCO_GL", "egl")
+        from strands_robots.simulation import Simulation
+
+        sim = Simulation()
+        try:
+            methods = sim.describe()["methods"]
+            for name in (
+                "replace_scene_mjcf",
+                "patch_scene_mjcf",
+                "export_xml",
+                "register_urdf",
+                "list_urdfs",
+            ):
+                assert name in methods, f"describe() omits scene-authoring method {name!r}"
+            # Advertised signatures name the real distinguishing parameters so a
+            # caller can invoke them without reading the source.
+            assert "xml" in methods["replace_scene_mjcf"]
+            assert "ops" in methods["patch_scene_mjcf"]
+            assert "output_path" in methods["export_xml"]
+            assert "data_config" in methods["register_urdf"]
+            assert "urdf_path" in methods["register_urdf"]
+        finally:
+            sim.destroy()
     def test_describe_methods_resolve_to_real_attributes(self):
         """Every method MuJoCo describe() advertises must be a real callable.
 

--- a/tests/simulation/test_sim_engine_describe_discovery.py
+++ b/tests/simulation/test_sim_engine_describe_discovery.py
@@ -573,6 +573,7 @@ class TestDescribeMuJoCo:
             assert "urdf_path" in methods["register_urdf"]
         finally:
             sim.destroy()
+
     def test_describe_methods_resolve_to_real_attributes(self):
         """Every method MuJoCo describe() advertises must be a real callable.
 


### PR DESCRIPTION
## Problem

`Simulation.describe()` is the single-call discovery surface an agent consults to learn the engine's contract instead of guessing method names. The structured scene-construction vocabulary (`add_robot` / `add_object` / `add_camera` / `load_scene`) is advertised, but the **raw-MJCF / URDF authoring escape hatch was invisible** on it.

An agent that needed to:

- express an element the structured dataclasses can't (`<tendon>`, `<equality>`, `<pair>`, ...),
- make a fast iterative spec edit,
- serialise a snapshot of the live scene back to MJCF, or
- instantiate a URDF the built-in registry does not ship,

had to guess `replace_scene_mjcf`, `patch_scene_mjcf`, `export_xml`, `register_urdf`, `list_urdfs` by name. All five are first-class actions in the MuJoCo `tool_spec.json` and action dispatcher, yet `describe()` listed none of them, so discovery dead-ended and the caller fell back to reading source.

## Change

Add the five methods to `MuJoCoSimEngine.describe()` as a coherent scene-authoring block (the raw-MJCF complement of the structured construction surface), each with a signature that names its distinguishing parameters so a caller can invoke it without reading source:

```
replace_scene_mjcf: (xml: str) -> dict  # atomically replace the whole scene with agent-authored MJCF (compiled + validated; MuJoCo's compiler error returned verbatim on failure). Escape hatch when add_robot/add_object cannot express an element; leaves world.robots/objects/cameras registries untouched (caller reconciles)
patch_scene_mjcf: (ops: list[dict]) -> dict  # apply structured edits to the live MjSpec atomically then recompile once (rolled back if any op fails). ops: add_body/add_geom/add_site/set_body_pos/set_body_quat/delete_body. The fast iterative-edit sibling of replace_scene_mjcf
export_xml: (output_path: str | None = None) -> dict  # serialise the current scene (incl. runtime mutations) to canonical MJCF via spec.to_xml(); writes to output_path when given, else returns the XML inline. The read sibling of replace_scene_mjcf
register_urdf: (data_config: str, urdf_path: str) -> dict  # register a URDF file on disk under a data_config name so add_robot can then instantiate it; validates the path is a readable file before registering
list_urdfs: () -> dict  # enumerate the model / URDF names resolvable by add_robot (built-in registry entries + those added via register_urdf)
```

No behavior change: this is discovery-surface metadata only. The methods themselves are unchanged.

## Tests

- New regression test `test_describe_lists_scene_mjcf_authoring_methods` asserts all five names are present and that each advertised signature names its real distinguishing parameters. It **fails on the pre-change surface** (`AssertionError: describe() omits scene-authoring method 'replace_scene_mjcf'`) and passes after.
- The existing `test_describe_methods_resolve_to_real_attributes` invariant already guarantees every advertised name resolves to a real callable on the live engine, so these additions are covered against drift.
- `tests/simulation/test_sim_engine_describe_discovery.py`, `tests/simulation/mujoco/test_tool_spec.py`, `tests/simulation/mujoco/test_agenttool_contract.py`: 102 passed.
- Lint gate clean: `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` all pass.

---

### Round 2 changelog

- Applied `ruff format` to `test_sim_engine_describe_discovery.py`: added the single blank line the format gate flagged between two test methods. This resolves the `call-test-lint / Test and Lint` failure (the `ruff format --check` step exited 1). Whitespace only, no behavioral or assertion change.