### PR TITLE
feat(sim): advertise the robot-registry + remove_robot surface in MuJoCo describe()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Added: `describe()` advertises the robot-registry + `remove_robot` surface (`list_urdfs` / `register_urdf` / `remove_robot`)
+
+`SimEngine.describe()["methods"]` is the single-call discovery surface an agent
+reads to learn a sim's contract without guessing method names. The MuJoCo
+backend's `describe()` calls `add_robot` "the first scene-construction step" and
+advertises the object/camera remove halves (`remove_object` / `remove_camera`),
+but the robot inverse `remove_robot` -- and the registry methods that feed
+`add_robot(name=...)` (`list_urdfs` to enumerate the registered robot
+descriptions, `register_urdf` to register a custom URDF under a `data_config`
+name) -- were undiscoverable from `describe()` alone, even though all three are
+first-class MuJoCo `tool_spec.json` + action-dispatcher actions. A caller who
+built a scene with `add_robot` could not learn how to remove a robot, or how to
+register a custom URDF so `add_robot` can spawn it by name, without guessing
+these names. They are now advertised in the MuJoCo backend's
+`describe()["methods"]`, completing the add/remove symmetry that
+`remove_object` / `remove_camera` already establish, each with a signature that
+names its distinguishing parameters. Additive only -- no change to the
+`tool_spec.json` enum, the action dispatcher, or any runtime behavior; this
+purely completes the robot-registry discovery surface. (Newton exposes the same
+trio and has the same gap; deferred to keep this diff MuJoCo-scoped like the
+sibling `describe()` families.) A regression test asserts the trio is advertised
+with `data_config=` / `urdf_path=` / `name=` named (fails before, passes after),
+and the existing `test_describe_methods_resolve_to_real_attributes` guard
+confirms each newly advertised name is a live callable on the engine.
+
+
 ### Added: `describe()` advertises the plain-MP4 camera-recording family (`start_cameras_recording` / `stop_cameras_recording` / `get_cameras_recording_status`)
 
 `SimEngine.describe()["methods"]` is the single-call discovery surface an agent

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1421,6 +1421,36 @@ class MuJoCoSimEngine(
             "an existing object; position is [x, y, z] meters, orientation is a "
             "[w, x, y, z] quaternion (either may be omitted to leave it unchanged)"
         )
+        # Robot-registry + robot-removal surface. describe() calls add_robot
+        # "the first scene-construction step" and advertises the object/camera
+        # remove halves (remove_object / remove_camera), but not the robot
+        # inverse remove_robot, nor how a caller discovers or extends the set of
+        # names add_robot(name=...) accepts. All three are first-class MuJoCo
+        # tool-spec + action-dispatcher actions: list_urdfs enumerates the
+        # registered robot descriptions, register_urdf adds a new one so
+        # add_robot can spawn it by name, and remove_robot ejects a robot (and
+        # every MJCF element it injected) - completing the add/remove symmetry
+        # that remove_object / remove_camera already establish. Listing them
+        # here reveals the robot-registry surface from one describe() call
+        # instead of by guessing. (Newton exposes the same trio and has the same
+        # gap; deferred here to keep this diff MuJoCo-scoped like the sibling
+        # describe() families.)
+        base["methods"]["list_urdfs"] = (
+            "() -> dict  # enumerate the robot descriptions registered for "
+            "add_robot(name=...) (the source of truth for the names add_robot "
+            "accepts, the robot-registry sibling of list_robots)"
+        )
+        base["methods"]["register_urdf"] = (
+            "(data_config: str, urdf_path: str) -> dict  # register a URDF under "
+            "a data_config name so add_robot(name=data_config) can spawn it; the "
+            "way to extend the add_robot registry with a custom robot"
+        )
+        base["methods"]["remove_robot"] = (
+            "(name: str) -> dict  # remove a robot and every MJCF element it "
+            "injected (bodies, actuators, sensors), then recompile; the inverse "
+            "of add_robot (cooperatively stops that robot's policy first, and "
+            "requires no other robot is running a policy)"
+        )
         base["methods"]["randomize"] = (
             "(randomize_colors=True, randomize_lighting=True, "
             "randomize_physics=False, randomize_positions=False, "

--- a/tests/simulation/test_sim_engine_describe_discovery.py
+++ b/tests/simulation/test_sim_engine_describe_discovery.py
@@ -535,6 +535,39 @@ class TestDescribeMuJoCo:
         finally:
             sim.destroy()
 
+    def test_describe_lists_robot_registry_family(self):
+        """describe() advertises the robot-registry + remove_robot surface.
+
+        describe() calls ``add_robot`` "the first scene-construction step" and
+        advertises the object/camera remove halves (``remove_object`` /
+        ``remove_camera``), but the robot inverse ``remove_robot`` -- and the
+        registry methods that feed ``add_robot(name=...)`` (``list_urdfs`` to
+        discover the registered names, ``register_urdf`` to add one) -- were
+        undiscoverable from describe() alone, even though all three are
+        first-class MuJoCo ``tool_spec.json`` + action-dispatcher actions. A
+        caller who built a scene with add_robot could not learn how to remove a
+        robot, or how to register a custom URDF, without guessing these names.
+        They belong on the discovery surface, completing the add/remove symmetry
+        that remove_object / remove_camera already establish.
+        """
+        import os
+
+        os.environ.setdefault("MUJOCO_GL", "egl")
+        from strands_robots.simulation import Simulation
+
+        sim = Simulation()
+        try:
+            methods = sim.describe()["methods"]
+            for name in ("list_urdfs", "register_urdf", "remove_robot"):
+                assert name in methods, f"describe() omits robot-registry method {name!r}"
+            # Advertised signatures name the real distinguishing parameters so a
+            # caller can invoke them without reading the source.
+            assert "data_config" in methods["register_urdf"]
+            assert "urdf_path" in methods["register_urdf"]
+            assert "name" in methods["remove_robot"]
+        finally:
+            sim.destroy()
+
     def test_describe_methods_resolve_to_real_attributes(self):
         """Every method MuJoCo describe() advertises must be a real callable.
 


### PR DESCRIPTION
## What

`SimEngine.describe()["methods"]` is the single-call discovery surface an agent reads to learn a sim's contract without guessing method names. The MuJoCo backend's `describe()` calls `add_robot` "the first scene-construction step" and advertises the object/camera remove halves (`remove_object` / `remove_camera`), but three sibling robot-authoring actions were undiscoverable from `describe()` alone:

| Method | Role | Advertised before |
|--------|------|-------------------|
| `remove_robot` | inverse of `add_robot` (ejects the robot + every MJCF element it injected, then recompiles) | no |
| `register_urdf` | register a URDF under a `data_config` name so `add_robot(name=...)` can spawn it | no |
| `list_urdfs` | enumerate the registered robot descriptions `add_robot` accepts | no |

All three are first-class MuJoCo `tool_spec.json` + action-dispatcher actions (verified against the 67-action enum). A caller who built a scene with `add_robot` could not learn how to remove a robot, or how to register/discover a custom URDF, without guessing these names. This advertises them, completing the add/remove symmetry that `remove_object` / `remove_camera` already establish.

This follows the same incremental `describe()` discovery-surface expansion as the recently-merged sibling families (`load_scene`/object-manipulation, physics-introspection, physics-tuning, sim-state checkpoint, background-policy lifecycle, and the plain-MP4 camera-recording family in #1264).

## Why these three (and not the other unadvertised actions)

A programmatic diff of the `tool_spec.json` action enum against the base + MuJoCo `describe()` surfaces showed 10 unadvertised actions. The remaining seven are intentionally deferred:

- `create_world` / `destroy` / `open_viewer` / `close_viewer` -- world + interactive-viewer lifecycle, not part of the headless build -> run -> record discovery path.
- `export_xml` / `patch_scene_mjcf` / `replace_scene_mjcf` -- a distinct MJCF-serialization/surgery family (and MuJoCo-only); a better fit for a separate coherent PR than spliced into a registry change.

## Scope note

Newton exposes the same `list_urdfs` / `register_urdf` / `remove_robot` trio and has the identical `describe()` gap. Deferred here to keep this diff MuJoCo-scoped, matching the cadence of the sibling `describe()` family PRs. Happy to follow up with the Newton parity change if preferred.

## Safety

Additive only -- no change to the `tool_spec.json` enum, the action dispatcher, or any runtime behavior. Purely completes the robot-registry discovery surface.

## Test

`tests/simulation/test_sim_engine_describe_discovery.py::TestDescribeMuJoCo::test_describe_lists_robot_registry_family` asserts the trio is advertised with `data_config=` / `urdf_path=` / `name=` named in their signatures (fails before, passes after). The existing `test_describe_methods_resolve_to_real_attributes` guard confirms each newly advertised name resolves to a live callable on the engine.

---

### §13 Changelog

- **Round 0 (initial):** advertise `list_urdfs` / `register_urdf` / `remove_robot` in MuJoCo `describe()["methods"]` + regression test + CHANGELOG entry.