### PR TITLE
feat(sim): advertise the world-lifecycle + MJCF-editing family in MuJoCo describe()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,33 @@ before, passes after), and the existing `test_describe_methods_resolve_to_real_a
 guard confirms each newly advertised name is a live callable on the engine.
 
 
+### Added: `describe()` advertises the world-lifecycle + MJCF-editing family (`create_world` / `destroy` / `patch_scene_mjcf` / `replace_scene_mjcf` / `export_xml`)
+
+`SimEngine.describe()["methods"]` teaches an agent how to build a scene
+(`add_robot` / `add_object` / `add_camera` / `load_scene`), run a policy, and
+read or checkpoint the result, but previously gave no way to discover the world
+lifecycle itself or the MJCF-editing operations -- so a caller enumerating how
+to create, edit, and tear down a scene from `describe()` alone had to guess
+these names. Five first-class MuJoCo `tool_spec.json` + action-dispatcher
+actions are now advertised in the backend's `describe()["methods"]`, each with a
+signature that names its distinguishing parameters: `create_world` (the
+fresh-world entry point that precedes `add_robot`), `destroy` (release all
+resources at session end, which the tool-spec guidance already asks callers to
+run), and the MJCF-editing family `patch_scene_mjcf` / `replace_scene_mjcf`
+(surgical vs wholesale live-MJCF editing) and `export_xml` (serialize the scene
+back to canonical MJCF). The URDF/model registry trio (`register_urdf` /
+`list_urdfs` / `remove_robot`) is advertised separately with the robot-registry
+family. `list_urdfs` -- which had no docstring -- also gains one so the method
+is self-describing. Additive only: no change to the `tool_spec.json` enum, the
+action dispatcher, or any runtime behavior; this purely completes the discovery
+surface with the world-lifecycle and MJCF-authoring operations alongside the
+existing build / act / read / record families. A regression test asserts the
+five are advertised with `ground_plane=` / `ops` / `xml` / `output_path` named
+(fails before, passes after), and the existing
+`test_describe_methods_resolve_to_real_attributes` guard confirms each newly
+advertised name is a live callable on the engine.
+
+
 ### Added: `register_builtin_benchmarks()` ships a canonical velocity-tracking locomotion benchmark (`go2_walk_forward`)
 
 The floating-base predicate/reward DSL (`base_velocity_tracking` / `base_height`

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1664,6 +1664,44 @@ class MuJoCoSimEngine(
             "(inspect concurrent-policy state when driving two or more arms in one scene)"
         )
 
+        # Scene / world lifecycle + MJCF editing surface. describe() teaches how
+        # to build a scene (add_robot/add_object/add_camera/load_scene), run a
+        # policy, and read/checkpoint the result, but previously gave no way to
+        # discover the world lifecycle itself -- create_world (the fresh-world
+        # entry point that precedes add_robot) and destroy (release resources at
+        # session end, which the tool-spec guidance explicitly asks callers to
+        # do) -- or the MJCF-editing family: patch or wholesale-replace the live
+        # MJCF and serialize the scene back to XML. All five are first-class
+        # actions in the tool spec + action dispatcher; listing them completes
+        # the discovery surface with the world-lifecycle and MJCF-authoring
+        # operations alongside the build / act / read surfaces. (The URDF/model
+        # registry trio -- register_urdf / list_urdfs / remove_robot -- is
+        # advertised with the robot-registry family earlier in describe().)
+        base["methods"]["create_world"] = (
+            "(timestep=None, gravity=None, ground_plane=True) -> dict  # create a "
+            "fresh empty simulation world; the lifecycle entry point that precedes "
+            "add_robot/add_object (gravity is [gx,gy,gz], ground_plane adds a floor)"
+        )
+        base["methods"]["destroy"] = (
+            "() -> dict  # tear down the world and release all resources (joins any "
+            "running background policy first); call at session end. The inverse of create_world"
+        )
+        base["methods"]["patch_scene_mjcf"] = (
+            "(ops: list[dict]) -> dict  # apply a list of structured edit ops to the "
+            "live MJCF spec atomically then recompile (add/remove/set-attr on "
+            "bodies/geoms/joints); surgical scene editing without a full replace"
+        )
+        base["methods"]["replace_scene_mjcf"] = (
+            "(xml: str) -> dict  # atomically replace the entire scene with "
+            "agent-authored MJCF (compiled + validated before it takes effect; "
+            "errors leave the old scene intact). The wholesale sibling of patch_scene_mjcf"
+        )
+        base["methods"]["export_xml"] = (
+            "(output_path=None) -> dict  # serialize the current scene as canonical "
+            "MJCF via spec.to_xml() (round-trips a scene built with "
+            "add_robot/add_object/patch_scene_mjcf; writes to output_path or returns the XML)"
+        )
+
         if self._world is not None:
             base["sim_time"] = self._world.sim_time
             base["world_created"] = True
@@ -2566,6 +2604,13 @@ class MuJoCoSimEngine(
     # URDF Registry
 
     def list_urdfs(self) -> dict[str, Any]:
+        """List every robot/URDF known to the registry (built-in + user-registered).
+
+        The names returned here are exactly the identifiers ``add_robot`` and
+        ``load_scene`` accept; ``register_urdf`` adds a new one. This is the
+        discovery entry point an agent uses to learn what it can spawn without
+        guessing a model name.
+        """
         return {"status": "success", "content": [{"text": list_available_models()}]}
 
     def register_urdf(self, data_config: str, urdf_path: str) -> dict[str, Any]:

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1687,19 +1687,23 @@ class MuJoCoSimEngine(
             "running background policy first); call at session end. The inverse of create_world"
         )
         base["methods"]["patch_scene_mjcf"] = (
-            "(ops: list[dict]) -> dict  # apply a list of structured edit ops to the "
-            "live MJCF spec atomically then recompile (add/remove/set-attr on "
-            "bodies/geoms/joints); surgical scene editing without a full replace"
+            "(ops: list[dict]) -> dict  # apply structured edits to the live "
+            "MjSpec atomically then recompile once (rolled back if any op fails). "
+            "ops: add_body/add_geom/add_site/set_body_pos/set_body_quat/delete_body. "
+            "The fast iterative-edit sibling of replace_scene_mjcf"
         )
         base["methods"]["replace_scene_mjcf"] = (
-            "(xml: str) -> dict  # atomically replace the entire scene with "
-            "agent-authored MJCF (compiled + validated before it takes effect; "
-            "errors leave the old scene intact). The wholesale sibling of patch_scene_mjcf"
+            "(xml: str) -> dict  # atomically replace the whole scene with "
+            "agent-authored MJCF (compiled + validated; MuJoCo's compiler error "
+            "returned verbatim on failure). Escape hatch when add_robot/add_object "
+            "cannot express an element; leaves world.robots/objects/cameras "
+            "registries untouched (caller reconciles)"
         )
         base["methods"]["export_xml"] = (
-            "(output_path=None) -> dict  # serialize the current scene as canonical "
-            "MJCF via spec.to_xml() (round-trips a scene built with "
-            "add_robot/add_object/patch_scene_mjcf; writes to output_path or returns the XML)"
+            "(output_path: str | None = None) -> dict  # serialise the current "
+            "scene (incl. runtime mutations) to canonical MJCF via spec.to_xml(); "
+            "writes to output_path when given, else returns the XML inline. The "
+            "read sibling of replace_scene_mjcf"
         )
 
         if self._world is not None:

--- a/tests/simulation/test_sim_engine_describe_discovery.py
+++ b/tests/simulation/test_sim_engine_describe_discovery.py
@@ -568,6 +568,45 @@ class TestDescribeMuJoCo:
         finally:
             sim.destroy()
 
+    def test_describe_lists_scene_lifecycle_methods(self):
+        """describe() advertises the world-lifecycle + MJCF-editing surface.
+
+        describe() taught how to build a scene, run a policy, and read the
+        result, but previously omitted the world lifecycle itself (create_world,
+        the fresh-world entry point that precedes add_robot; destroy, which the
+        tool-spec guidance explicitly asks callers to run at session end) and the
+        MJCF-editing family (patch_scene_mjcf / replace_scene_mjcf, export_xml).
+        All five are first-class actions in the tool spec + action dispatcher, so
+        a caller enumerating how to create, edit, and tear down a scene from
+        describe() alone had to guess these names. (The URDF/model registry trio
+        -- register_urdf / list_urdfs / remove_robot -- is covered by
+        test_describe_lists_robot_registry_family.)
+        """
+        import os
+
+        os.environ.setdefault("MUJOCO_GL", "egl")
+        from strands_robots.simulation import Simulation
+
+        sim = Simulation()
+        try:
+            methods = sim.describe()["methods"]
+            for name in (
+                "create_world",
+                "destroy",
+                "patch_scene_mjcf",
+                "replace_scene_mjcf",
+                "export_xml",
+            ):
+                assert name in methods, f"describe() omits scene-lifecycle method {name!r}"
+            # Advertised signatures name the real distinguishing parameters so a
+            # caller can invoke them without reading the source.
+            assert "ground_plane" in methods["create_world"]
+            assert "ops" in methods["patch_scene_mjcf"]
+            assert "xml" in methods["replace_scene_mjcf"]
+            assert "output_path" in methods["export_xml"]
+        finally:
+            sim.destroy()
+
     def test_describe_methods_resolve_to_real_attributes(self):
         """Every method MuJoCo describe() advertises must be a real callable.
 


### PR DESCRIPTION
## Problem

`SimEngine.describe()["methods"]` is the single-call discovery surface an agent reads to learn a sim's contract without guessing method names. It already advertises the build (`add_robot` / `add_object` / `add_camera` / `load_scene`), act (`run_policy` / `start_policy` / ...), read (`get_body_state` / `get_contacts` / ...), physics-tuning, state-checkpoint, and recording families. But five first-class MuJoCo `tool_spec.json` + action-dispatcher actions were dispatchable yet **absent from `describe()["methods"]`**, so a caller enumerating how to *create, edit, and tear down* a scene from `describe()` alone had to guess their names:

- **World lifecycle** — `create_world` (the fresh-world entry point that precedes `add_robot`), `destroy` (release all resources at session end — which the tool-spec guidance already asks callers to run).
- **MJCF editing** — `patch_scene_mjcf` / `replace_scene_mjcf` (surgical vs wholesale live-MJCF editing), `export_xml` (serialize the scene back to canonical MJCF).

These are the operations every scene uses (world creation/teardown, MJCF authoring), yet an agent driving the sim blind could not discover them.

## Change

- Advertise all five in the MuJoCo backend's `describe()["methods"]`, each with a signature that names its distinguishing parameters (e.g. `create_world(timestep=None, gravity=None, ground_plane=True)`, `patch_scene_mjcf(ops: list[dict])`, `replace_scene_mjcf(xml: str)`, `export_xml(output_path=None)`).
- Give `list_urdfs` the docstring it lacked, so the method is self-describing rather than relying only on the discovery-surface string.

The URDF/model registry trio (`register_urdf` / `list_urdfs` / `remove_robot`) is advertised separately with the robot-registry family (#1266) and is intentionally not duplicated here.

**Additive only** — no change to the `tool_spec.json` enum, the action dispatcher, or any runtime behavior. This purely completes the discovery surface, following the same pattern as the recently-advertised recording, physics-introspection, physics-tuning, sim-state, and background-policy families.

## Tests

- New `test_describe_lists_scene_lifecycle_methods` asserts the five are advertised with `ground_plane=` / `ops` / `xml` / `output_path` named. It **fails before** this change (`describe() omits scene-lifecycle method 'create_world'`) and passes after.
- The existing `test_describe_methods_resolve_to_real_attributes` guard confirms each newly advertised name is a live callable on the engine.
- Local gate green: `ruff check` + `ruff format --check` clean, `mypy` clean on the changed module, and the `test_sim_engine_describe_discovery.py` suite passes (`MUJOCO_GL=egl`).

No behavior/render/recording/asset change, so no visual artifact — the fails-before/passes-after discovery-contract test is the proof.

---

### Round 2 changelog

- Rebased onto `main` after #1266 (robot-registry family) merged. #1266 now owns `register_urdf` / `list_urdfs` / `remove_robot` on the discovery surface, so this PR's scope is **narrowed from eight methods to five**: it drops the three registry methods (which would have been duplicate `base["methods"][...]` writes) and keeps only its unique contributions — `create_world`, `destroy`, `patch_scene_mjcf`, `replace_scene_mjcf`, `export_xml`.
- Updated the `describe()` block, its comment, the regression test (`test_describe_lists_scene_lifecycle_methods` now asserts the five and cross-references `test_describe_lists_robot_registry_family` for the registry trio), the CHANGELOG entry, and the PR title/body to match the narrowed scope.
- The `list_urdfs` docstring addition is retained — `main` still has none, so it is a genuine non-duplicate improvement.
- Conflict resolution touched only the overlap; no new behavior. Format + lint + the discovery-surface tests all pass on the rebased branch.
- **Harvested the more precise MJCF-editing discovery strings from the now-superseded #1265**: `patch_scene_mjcf` now names the exact supported ops (`add_body`/`add_geom`/`add_site`/`set_body_pos`/`set_body_quat`/`delete_body`, verified against the implementation) and its rollback-on-failure semantics instead of the vaguer 'add/remove/set-attr on bodies/geoms/joints'; `replace_scene_mjcf` documents that it leaves the world registries untouched; `export_xml` notes it captures runtime mutations. This closes #1265's method surface into this PR so no unique value is lost by its closure.