### PR TITLE
fix(simulation): point warp/mjwarp install hints at strands-robots[sim-newton]

### DIFF
--- a/strands_robots/simulation/factory.py
+++ b/strands_robots/simulation/factory.py
@@ -72,17 +72,17 @@ _BUILTIN_ALIASES: dict[str, str] = {
 DEFAULT_BACKEND = "mujoco"
 
 # Suggested ``pip install`` hints surfaced in the "unknown backend" error so
-# users discover that heavy out-of-tree backends ship in the sibling
-# ``strands-robots-sim`` plugin package. Keyed by the entry-point name a
-# plugin is expected to register.
+# users discover that heavy GPU backends ship behind in-tree optional extras
+# (``strands-robots[sim-newton]``). Keyed by the backend name (or common alias)
+# a user is likely to reach for.
 _PLUGIN_INSTALL_HINTS: dict[str, str] = {
     "newton": "pip install 'strands-robots[sim-newton]'",
     # The warp-lang based GPU-parallel MuJoCo path is the built-in ``newton``
     # backend; ``warp`` and ``mjwarp`` are common names users reach for, so map
     # both to the same actionable install hint instead of a bare "unknown
     # backend" dead end.
-    "warp": "pip install 'strands-robots-sim[newton]'",
-    "mjwarp": "pip install 'strands-robots-sim[newton]'",
+    "warp": "pip install 'strands-robots[sim-newton]'",
+    "mjwarp": "pip install 'strands-robots[sim-newton]'",
 }
 
 # Plugin backends discovered via importlib.metadata entry points. Populated

--- a/tests/simulation/test_factory.py
+++ b/tests/simulation/test_factory.py
@@ -295,16 +295,21 @@ class TestEntryPointDiscovery:
         sim = create_simulation("isaac", num_envs=1, headless=True)
         assert type(sim).__name__ == "IsaacSimulation"
 
-    def test_mjwarp_and_warp_names_suggest_newton_plugin(self, monkeypatch):
+    def test_mjwarp_and_warp_names_suggest_newton_extra(self, monkeypatch):
         """The GPU-parallel warp/MuJoCo path is the built-in ``newton`` backend.
         ``warp`` and ``mjwarp`` are common names users reach for; both must
-        surface the ``strands-robots-sim[newton]`` install hint instead of a
-        bare unknown-backend dead end."""
+        surface the in-tree ``strands-robots[sim-newton]`` install hint instead
+        of a bare unknown-backend dead end. The hint must match the built-in
+        ``newton`` extra, not the deprecated ``strands-robots-sim`` sibling
+        package."""
         _patch_entry_points(monkeypatch, [])
         for name in ("warp", "mjwarp"):
-            with pytest.raises(ValueError, match="strands-robots-sim") as exc_info:
+            with pytest.raises(ValueError, match=r"strands-robots\[sim-newton\]") as exc_info:
                 create_simulation(name)
-            assert "newton" in str(exc_info.value)
+            msg = str(exc_info.value)
+            assert "newton" in msg
+            # The deprecated sibling package must not be referenced.
+            assert "strands-robots-sim" not in msg
 
 
 class TestIsaacBuiltinWinsOverPlugin:

--- a/tests/test_robot_factory.py
+++ b/tests/test_robot_factory.py
@@ -201,11 +201,15 @@ class TestRobotFactory:
     def test_mjwarp_backend_gives_plugin_install_hint(self):
         """The GPU-parallel warp/MuJoCo path is the built-in ``newton`` backend;
         ``mjwarp`` is a name users reach for. ``Robot(backend="mjwarp")`` must
-        point them at the warp/newton plugin rather than dead-ending on an
-        unhelpful unknown-backend error with no remedy."""
-        with pytest.raises(ValueError, match="strands-robots-sim") as exc_info:
+        point them at the in-tree ``strands-robots[sim-newton]`` extra rather
+        than dead-ending on an unhelpful unknown-backend error with no remedy.
+        The hint must not reference the deprecated ``strands-robots-sim``
+        sibling package."""
+        with pytest.raises(ValueError, match=r"strands-robots\[sim-newton\]") as exc_info:
             Robot("so100", mode="sim", backend="mjwarp", num_envs=128)
-        assert "pip install" in str(exc_info.value)
+        msg = str(exc_info.value)
+        assert "pip install" in msg
+        assert "strands-robots-sim" not in msg
 
     def test_invalid_mode_raises(self):
         with pytest.raises(ValueError, match="Invalid mode"):


### PR DESCRIPTION
## What changed

`_PLUGIN_INSTALL_HINTS` in `strands_robots/simulation/factory.py` mapped the
`warp` and `mjwarp` aliases at the soon-to-be-deprecated sibling package:

```python
"warp": "pip install 'strands-robots-sim[newton]'",
"mjwarp": "pip install 'strands-robots-sim[newton]'",
```

The warp-lang GPU-parallel MuJoCo path is now the **in-tree** `newton` backend
(`"newton": "pip install 'strands-robots[sim-newton]'"` in the same dict). Both
aliases now match:

```python
"warp": "pip install 'strands-robots[sim-newton]'",
"mjwarp": "pip install 'strands-robots[sim-newton]'",
```

Also refreshed the stale module comment above the dict, which still described
the hints as pointing at the out-of-tree `strands-robots-sim` plugin package.

## Why

Users who type `create_simulation("warp")` / `create_simulation("mjwarp")` (or
`Robot(backend="mjwarp")`) got an install hint pointing at the deprecated
`strands-robots-sim` package. The three aliases for the same GPU path
(`newton`, `warp`, `mjwarp`) should surface the same in-tree extra.

## Test surface

Three regression tests pinned the old `strands-robots-sim` hint string; updated
to assert the in-tree `strands-robots[sim-newton]` hint and to explicitly
reject any reference to the deprecated sibling package:

- `tests/simulation/test_factory.py::TestEntryPointDiscovery::test_mjwarp_and_warp_names_suggest_newton_extra` (renamed)
- `tests/test_robot_factory.py::TestRobotFactory::test_mjwarp_backend_gives_plugin_install_hint`

Validated locally:

- `hatch run lint` - clean (`Success: no issues found in 755 source files`)
- `hatch run test tests/simulation/test_factory.py tests/test_robot_factory.py` - **134 passed, 1 skipped**

Note: the full `hatch run test` run core-dumps on this dev box in the
rendering/policy-runner suites due to no X11/OpenGL (pre-existing, environmental,
not touched by this change). The affected tests are unrelated to the factory
install-hint logic.

## Acceptance criteria checklist

- [x] `warp` hint points at `strands-robots[sim-newton]`
- [x] `mjwarp` hint points at `strands-robots[sim-newton]`
- [x] Matches the existing in-tree `newton` hint
- [x] No remaining `strands-robots-sim[newton]` references in code or docs

## Sequencing / out-of-scope

Per the issue, this is best landed after robots-sim#170 (final release + PyPI
deprecation) so the hint change coincides with the sibling package going away.
Minor cleanup, non-blocking. Follow-up from the Isaac absorb epic #1144.

Closes #1268.

> Project board: please move #1268 to "In review" (Strands Labs - Robots board).
