### PR TITLE
feat(sim): advertise the teleoperation family in MuJoCo describe()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Added: `describe()` advertises the teleoperation surface (`attach_teleop` / `teleoperate` / `stop_teleoperate` / `get_teleoperate_status` / `list_teleops` / `detach_teleop`)
+
+`SimEngine.describe()["methods"]` is the single-call discovery surface an agent
+reads to learn a sim's contract without guessing method names. The MuJoCo
+backend advertises how to build a scene and drive it with a policy (`run_policy`
+/ `start_policy`), but gave no way to discover the OTHER actuation source:
+driving a sim robot from an attached teleoperator (a real leader arm, gamepad,
+or keyboard) -- the leader->follower / human-demonstration workflow that feeds
+data collection. The six `TeleopMixin` facades (shared with the hardware
+`Robot`) -- `attach_teleop` -> `teleoperate` -> `stop_teleoperate`, plus
+`detach_teleop` / `list_teleops` / `get_teleoperate_status` -- are public
+methods on the sim, yet a caller enumerating the sim's contract from
+`describe()` alone had to guess their names. They are now advertised in the
+MuJoCo backend's `describe()["methods"]` as the human-driven sibling of the
+policy-rollout family, each with a signature that names its distinguishing
+parameters (`attach_teleop(..., map_fn=...)`, `teleoperate(..., publish=...,
+block=..., duration=...)`). Additive only -- no change to any runtime behavior;
+this purely completes the discovery surface, following the same pattern as the
+recording, physics-introspection, physics-tuning, sim-state, background-policy,
+and robot-registry families. A regression test asserts the six are advertised
+with `map_fn=` / `publish=` / `duration=` / `name=` named (fails before, passes
+after), and the existing `test_describe_methods_resolve_to_real_attributes`
+guard confirms each newly advertised name is a live callable on the engine.
+
+
 ### Added: `describe()` advertises the robot-registry + `remove_robot` surface (`list_urdfs` / `register_urdf` / `remove_robot`)
 
 `SimEngine.describe()["methods"]` is the single-call discovery surface an agent

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1705,6 +1705,50 @@ class MuJoCoSimEngine(
             "writes to output_path when given, else returns the XML inline. The "
             "read sibling of replace_scene_mjcf"
         )
+        # Teleoperation surface (TeleopMixin, shared with the hardware Robot).
+        # describe() teaches how to build a scene and drive it with a policy,
+        # but gave no way to discover the OTHER actuation source: driving a sim
+        # robot from an attached teleoperator (a real leader arm, gamepad, or
+        # keyboard) - the leader->follower / human-demonstration workflow that
+        # feeds data collection. All six are public facade methods on the sim;
+        # without them a caller could not learn from describe() how to attach an
+        # input device, run the teleop loop, or stop it, and had to guess these
+        # names. Listing them here reveals the teleop lifecycle (attach ->
+        # teleoperate -> stop) as the human-driven sibling of run_policy.
+        base["methods"]["attach_teleop"] = (
+            "(device_or_spec, *, name=None, method=None, map_fn=None, **kwargs) "
+            "-> Simulation  # attach a teleoperator (lazy - no hardware touched "
+            "until teleoperate). device_or_spec is a built lerobot Teleoperator "
+            "or a type string ('so101_leader', 'gamepad', 'keyboard'); map_fn "
+            "remaps a real leader's joint names onto the sim robot's actuators. "
+            "Returns self for chaining"
+        )
+        base["methods"]["teleoperate"] = (
+            "(*, names=None, robot_name=None, hz=50.0, publish=False, "
+            "block=False, duration=None) -> dict  # drive the sim from its "
+            "attached teleoperator(s): each tick polls get_action(), applies "
+            "map_fn, merges (last-wins), and send_action()s the result. "
+            "block=False runs a background loop and returns immediately; "
+            "duration stops it after N seconds; publish=True also mirrors the "
+            "stream to the mesh. The human-driven sibling of run_policy"
+        )
+        base["methods"]["stop_teleoperate"] = (
+            "() -> dict  # stop the background teleop loop, any mesh publishers, "
+            "and disconnect every device; frame/error stats. The inverse of teleoperate"
+        )
+        base["methods"]["get_teleoperate_status"] = (
+            "() -> dict  # local teleop-loop status (running, frames, errors, "
+            "actual hz, attached devices); distinct from the mesh teleop status"
+        )
+        base["methods"]["list_teleops"] = (
+            "() -> dict  # attached teleoperators and their connection state "
+            "(the teleop sibling of list_robots / list_cameras)"
+        )
+        base["methods"]["detach_teleop"] = (
+            "(name: str | None = None) -> dict  # detach one teleoperator by "
+            "name, or all when name is None; disconnects each and stops the loop "
+            "if it would be left with no devices. The inverse of attach_teleop"
+        )
 
         if self._world is not None:
             base["sim_time"] = self._world.sim_time

--- a/tests/simulation/test_sim_engine_describe_discovery.py
+++ b/tests/simulation/test_sim_engine_describe_discovery.py
@@ -607,6 +607,47 @@ class TestDescribeMuJoCo:
         finally:
             sim.destroy()
 
+    def test_describe_lists_teleop_family(self):
+        """describe() advertises the teleoperation surface, not only run_policy.
+
+        describe() teaches how to build a scene and drive it with a policy
+        (``run_policy`` / ``start_policy``), but the OTHER actuation source --
+        driving a sim robot from an attached teleoperator (a real leader arm,
+        gamepad, or keyboard), the leader->follower / human-demonstration
+        workflow that feeds data collection -- was undiscoverable from
+        describe() alone. The six ``TeleopMixin`` facades (``attach_teleop`` ->
+        ``teleoperate`` -> ``stop_teleoperate``, plus ``detach_teleop`` /
+        ``list_teleops`` / ``get_teleoperate_status``) are public methods on the
+        sim, yet a caller had to guess their names. They belong on the discovery
+        surface as the human-driven sibling of the policy-rollout family.
+        """
+        import os
+
+        os.environ.setdefault("MUJOCO_GL", "egl")
+        from strands_robots.simulation import Simulation
+
+        sim = Simulation()
+        try:
+            methods = sim.describe()["methods"]
+            for name in (
+                "attach_teleop",
+                "teleoperate",
+                "stop_teleoperate",
+                "get_teleoperate_status",
+                "list_teleops",
+                "detach_teleop",
+            ):
+                assert name in methods, f"describe() omits teleop method {name!r}"
+            # Advertised signatures name the real distinguishing parameters so a
+            # caller can invoke them without reading the source.
+            assert "map_fn" in methods["attach_teleop"]
+            assert "publish" in methods["teleoperate"]
+            assert "duration" in methods["teleoperate"]
+            assert "name" in methods["detach_teleop"]
+        finally:
+            sim.destroy()
+
+
     def test_describe_methods_resolve_to_real_attributes(self):
         """Every method MuJoCo describe() advertises must be a real callable.
 

--- a/tests/simulation/test_sim_engine_describe_discovery.py
+++ b/tests/simulation/test_sim_engine_describe_discovery.py
@@ -647,7 +647,6 @@ class TestDescribeMuJoCo:
         finally:
             sim.destroy()
 
-
     def test_describe_methods_resolve_to_real_attributes(self):
         """Every method MuJoCo describe() advertises must be a real callable.
 


### PR DESCRIPTION
## Problem

`SimEngine.describe()["methods"]` is the single-call discovery surface an agent reads to learn a sim's contract without guessing method names. The MuJoCo backend advertises how to *build* a scene and *drive it with a policy* (`run_policy` / `start_policy`), but gave no way to discover the **other actuation source**: driving a sim robot from an attached teleoperator (a real leader arm, gamepad, or keyboard) - the leader->follower / human-demonstration workflow that feeds data collection.

The six `TeleopMixin` facades (shared with the hardware `Robot`) are public methods on the sim, yet a caller enumerating the sim's contract from `describe()` alone had to guess their names:

- `attach_teleop` -> `teleoperate` -> `stop_teleoperate` (the lifecycle)
- `detach_teleop` / `list_teleops` / `get_teleoperate_status` (manage + inspect)

## Change

Advertise all six in the MuJoCo backend's `describe()["methods"]` as the human-driven sibling of the policy-rollout family, each with a signature that names its distinguishing parameters:

- `attach_teleop(device_or_spec, *, name=None, method=None, map_fn=None, **kwargs) -> Simulation` (lazy; `map_fn` remaps a real leader's joint names onto the sim actuators)
- `teleoperate(*, names=None, robot_name=None, hz=50.0, publish=False, block=False, duration=None) -> dict`
- `stop_teleoperate()` / `get_teleoperate_status()` / `list_teleops()` / `detach_teleop(name=None)`

**Additive only** - no change to the `tool_spec.json` enum, the action dispatcher, or any runtime behavior. This purely completes the discovery surface, following the same pattern as the recently-advertised recording, physics-introspection, physics-tuning, sim-state, background-policy, and robot-registry families.

## Tests

- New `test_describe_lists_teleop_family` asserts the six are advertised with `map_fn=` / `publish=` / `duration=` / `name=` named. It **fails before** this change (`describe() omits teleop method 'attach_teleop'`) and passes after.
- The existing `test_describe_methods_resolve_to_real_attributes` guard confirms each newly advertised name is a live callable on the engine.
- Local gate green: `ruff check` + `ruff format --check` clean, `mypy strands_robots tests tests_integ` clean, and the `test_sim_engine_describe_discovery.py` suite (25 tests) + the MuJoCo `test_simulation.py` / `test_list_cameras_discovery.py` suites pass (`MUJOCO_GL=egl`).

No behavior/render/recording/asset change, so no visual artifact - the fails-before/passes-after discovery-contract test is the proof.