### PR TITLE
feat(sim): advertise the interactive-viewer family in MuJoCo describe()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,29 @@ and the existing `test_describe_methods_resolve_to_real_attributes` guard
 confirms each newly advertised name is a live callable on the engine.
 
 
+### Added: `describe()` advertises the interactive-viewer family (`open_viewer` / `close_viewer`)
+
+`SimEngine.describe()["methods"]` is the single-call discovery surface an agent
+reads to learn a sim's contract without guessing method names. The MuJoCo
+backend advertises how to build a scene, drive it with a policy, and
+read/checkpoint the result, but gave no way to discover how to open a live
+window on the running model for human inspection (watch a rollout, debug a
+pose, hand-verify a scene) -- even though `open_viewer` and `close_viewer` are
+first-class `tool_spec.json` + action-dispatcher actions. A caller enumerating
+the sim's contract from `describe()` alone had to guess their names. Both are
+now advertised in the MuJoCo backend's `describe()["methods"]` as the
+human-inspection sibling of the render family, with `open_viewer`'s signature
+documenting the headless caveat (it launches an interactive OpenGL window via
+`mujoco.viewer.launch_passive`, so it needs a local display and errors on a
+headless host, where `render()` / `render_all()` capture frames instead). The
+two MuJoCo viewer methods also gained the docstrings they lacked. Additive only
+-- no change to the `tool_spec.json` enum, the action dispatcher, or any runtime
+behavior; this purely completes the discovery surface. A regression test asserts
+the pair is advertised with the display caveat named (fails before, passes
+after), and the existing `test_describe_methods_resolve_to_real_attributes`
+guard confirms each newly advertised name is a live callable on the engine.
+
+
 ### Added: `describe()` advertises the plain-MP4 camera-recording family (`start_cameras_recording` / `stop_cameras_recording` / `get_cameras_recording_status`)
 
 `SimEngine.describe()["methods"]` is the single-call discovery surface an agent

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1750,6 +1750,28 @@ class MuJoCoSimEngine(
             "if it would be left with no devices. The inverse of attach_teleop"
         )
 
+        # Live interactive viewer. describe() teaches how to build a scene, drive
+        # it with a policy, and read/checkpoint the result, but gave no way to
+        # discover how to OPEN a live window on the running model for human
+        # inspection (watch a rollout, debug a pose, hand-verify a scene). Both
+        # are first-class actions in the tool spec + action dispatcher, so a
+        # caller enumerating the sim's contract from describe() alone had to
+        # guess their names. open_viewer launches a passive MuJoCo viewer (an
+        # interactive OpenGL window that requires a local display -- it errors on
+        # a headless host, where render()/render_all() capture frames instead)
+        # and close_viewer is its teardown, completing the discovery surface with
+        # the human-inspection sibling of the render family.
+        base["methods"]["open_viewer"] = (
+            "() -> dict  # launch a passive interactive MuJoCo viewer window bound "
+            "to the running model (mujoco.viewer.launch_passive); requires a local "
+            "display -- errors on a headless host, where render()/render_all() "
+            "capture frames instead. Idempotent ('Viewer already open' if one is up)"
+        )
+        base["methods"]["close_viewer"] = (
+            "() -> dict  # close the interactive viewer opened by open_viewer; "
+            "idempotent (succeeds even if none is open). The inverse of open_viewer"
+        )
+
         if self._world is not None:
             base["sim_time"] = self._world.sim_time
             base["world_created"] = True
@@ -2623,6 +2645,19 @@ class MuJoCoSimEngine(
     # Viewer
 
     def open_viewer(self) -> dict[str, Any]:
+        """Launch a passive interactive MuJoCo viewer window bound to the running model.
+
+        Opens ``mujoco.viewer.launch_passive`` on the live model/data so a human
+        can watch a rollout, debug a pose, or hand-verify a scene. The viewer is
+        an interactive OpenGL window and therefore **requires a local display**:
+        on a headless host it fails with a viewer error, where
+        :meth:`render` / :meth:`render_all` capture frames instead. Idempotent --
+        succeeds with "Viewer already open" if one is already up. The inverse is
+        :meth:`close_viewer`.
+
+        Returns:
+            Agent-tool ``status``/``content`` dict.
+        """
         if self._world is None or self._world._model is None:
             return {"status": "error", "content": [{"text": "No simulation to view."}]}
         from strands_robots.simulation.mujoco.backend import _mujoco_viewer
@@ -2646,6 +2681,14 @@ class MuJoCoSimEngine(
             self._viewer_handle = None
 
     def close_viewer(self) -> dict[str, Any]:
+        """Close the interactive viewer opened by :meth:`open_viewer`.
+
+        Idempotent -- succeeds even when no viewer is open. The inverse of
+        :meth:`open_viewer`.
+
+        Returns:
+            Agent-tool ``status``/``content`` dict.
+        """
         self._close_viewer()
         return {"status": "success", "content": [{"text": "Viewer closed."}]}
 

--- a/tests/simulation/test_sim_engine_describe_discovery.py
+++ b/tests/simulation/test_sim_engine_describe_discovery.py
@@ -15,6 +15,7 @@ from typing import Any
 
 import pytest
 
+
 def _make_minimal_engine():
     """Create a minimal SimEngine with one robot for describe() testing."""
     from strands_robots.simulation.base import SimEngine
@@ -106,6 +107,7 @@ def _make_minimal_engine():
             return {}
 
     return MinimalEngine()
+
 
 class TestDescribeABC:
     """Tests for SimEngine.describe() on the abstract base class."""
@@ -234,6 +236,7 @@ class TestDescribeABC:
         # caller can invoke them without reading the source.
         assert "benchmark_name" in methods["evaluate_benchmark"]
         assert "spec_path" in methods["register_benchmark_from_file"]
+
 
 @pytest.mark.skipif(
     not pytest.importorskip("mujoco", reason="MuJoCo not installed"),
@@ -695,6 +698,7 @@ class TestDescribeMuJoCo:
                 )
         finally:
             sim.destroy()
+
 
 class TestNoAlias:
     """Code is the single source of truth: no duplicate-name aliases.

--- a/tests/simulation/test_sim_engine_describe_discovery.py
+++ b/tests/simulation/test_sim_engine_describe_discovery.py
@@ -15,7 +15,6 @@ from typing import Any
 
 import pytest
 
-
 def _make_minimal_engine():
     """Create a minimal SimEngine with one robot for describe() testing."""
     from strands_robots.simulation.base import SimEngine
@@ -107,7 +106,6 @@ def _make_minimal_engine():
             return {}
 
     return MinimalEngine()
-
 
 class TestDescribeABC:
     """Tests for SimEngine.describe() on the abstract base class."""
@@ -236,7 +234,6 @@ class TestDescribeABC:
         # caller can invoke them without reading the source.
         assert "benchmark_name" in methods["evaluate_benchmark"]
         assert "spec_path" in methods["register_benchmark_from_file"]
-
 
 @pytest.mark.skipif(
     not pytest.importorskip("mujoco", reason="MuJoCo not installed"),
@@ -647,6 +644,36 @@ class TestDescribeMuJoCo:
         finally:
             sim.destroy()
 
+    def test_describe_lists_viewer_family(self):
+        """describe() advertises the interactive-viewer surface.
+
+        describe() taught how to build a scene, drive it with a policy, and read
+        the result, but gave no way to discover how to OPEN a live window on the
+        running model for human inspection (watch a rollout, debug a pose,
+        hand-verify a scene). open_viewer / close_viewer are first-class actions
+        in the tool spec + action dispatcher, so a caller enumerating the sim's
+        contract from describe() alone had to guess their names. The advertised
+        open_viewer signature also documents the headless caveat (needs a local
+        display; render()/render_all() capture frames instead).
+        """
+        import os
+
+        os.environ.setdefault("MUJOCO_GL", "egl")
+        from strands_robots.simulation import Simulation
+
+        sim = Simulation()
+        try:
+            methods = sim.describe()["methods"]
+            for name in ("open_viewer", "close_viewer"):
+                assert name in methods, f"describe() omits viewer method {name!r}"
+            # The advertised open_viewer signature warns of the display
+            # requirement so a caller does not blindly invoke it on a headless
+            # host (where render()/render_all() are the right frame source).
+            assert "display" in methods["open_viewer"]
+            assert "render" in methods["open_viewer"]
+        finally:
+            sim.destroy()
+
     def test_describe_methods_resolve_to_real_attributes(self):
         """Every method MuJoCo describe() advertises must be a real callable.
 
@@ -668,7 +695,6 @@ class TestDescribeMuJoCo:
                 )
         finally:
             sim.destroy()
-
 
 class TestNoAlias:
     """Code is the single source of truth: no duplicate-name aliases.


### PR DESCRIPTION
## Problem

`SimEngine.describe()["methods"]` is the single-call discovery surface an agent reads to learn a sim's contract without guessing method names. The MuJoCo backend advertises how to **build** a scene, **drive** it with a policy (`run_policy` / `start_policy`), and **read/checkpoint** the result -- but gave no way to discover how to open a live window on the running model for human inspection (watch a rollout, debug a pose, hand-verify a scene).

`open_viewer` and `close_viewer` are first-class `tool_spec.json` + action-dispatcher actions (they are already named in the tool-spec action list and the `[Rendering]` group), yet they were the **last two enum actions still missing from `describe()["methods"]`** -- so a caller enumerating the sim's contract from `describe()` alone had to guess their names. The two MuJoCo viewer methods also lacked docstrings.

## Change

Advertise both in the MuJoCo backend's `describe()["methods"]` as the human-inspection sibling of the render family, and give the two viewer methods the docstrings they lacked:

- `open_viewer() -> dict` -- launch a passive interactive MuJoCo viewer (`mujoco.viewer.launch_passive`) bound to the running model. The advertised signature **documents the headless caveat**: it is an interactive OpenGL window that requires a local display and errors on a headless host, where `render()` / `render_all()` capture frames instead. Idempotent.
- `close_viewer() -> dict` -- the teardown / inverse of `open_viewer`; idempotent.

**Additive only** -- no change to the `tool_spec.json` enum, the action dispatcher, the "Actions (67 total)" count, or any runtime behavior. This completes the discovery surface, following the same pattern as the recently-advertised recording, physics-introspection, physics-tuning, sim-state, background-policy, robot-registry, and world-lifecycle/MJCF-editing families. It is the final enum action reaching the discovery surface (`open_viewer` / `close_viewer` were the only two enum actions not in `describe()["methods"]`).

## Tests

- New `test_describe_lists_viewer_family` asserts both are advertised and that `open_viewer`'s signature names the display/headless caveat (`display` + `render`). It **fails before** this change (`describe() omits viewer method 'open_viewer'`) and passes after.
- The existing `test_describe_methods_resolve_to_real_attributes` guard confirms each newly advertised name is a live callable on the engine.
- The existing `test_tool_spec` count invariant (`Actions (N total)` == `len(enum)`) is unaffected (no enum/count change).
- Local gate green: `ruff check` + `ruff format --check` clean, `mypy` clean on the changed module, and `test_sim_engine_describe_discovery.py` + `test_tool_spec.py` (37 tests) pass under `MUJOCO_GL=egl`.

No behavior/render/recording/asset change, so no visual artifact -- the fails-before/passes-after discovery-contract test is the proof.

---

## §13 Changelog

**Round 2 — rebase on main (mechanical, no scope change):** The sibling teleop-family PR landed on `main` first, and because both PRs add a new discovery test after the same anchor in `test_sim_engine_describe_discovery.py`, this branch went `CONFLICTING`. Rebased onto the new `main` and resolved the single test-file conflict by keeping **both** additive test methods (`test_describe_lists_teleop_family` from main + `test_describe_lists_viewer_family` from this PR) as independent methods. `simulation.py` and `CHANGELOG.md` auto-merged cleanly. Diff vs main is unchanged in intent: +43 `simulation.py`, +23 `CHANGELOG.md`, +34 test — no teleop churn, no new scope. The prior approval was dismissed by the force-push; a fresh review is required.