### PR TITLE
test(sim): pin keyframe home-pose slicing for free and ball joints

### DIFF
--- a/tests/simulation/mujoco/test_add_robot_keyframe.py
+++ b/tests/simulation/mujoco/test_add_robot_keyframe.py
@@ -216,3 +216,90 @@ class TestAddRobotKeyframe:
         assert "Cannot read keyframe from" in text
         assert "malformed_arm.xml" in text
         assert "a" not in sim._world.robots
+
+
+# A floating-base robot whose qpos mixes all three MuJoCo joint widths in one
+# model: a free root (7 = 3 translation + 4 quaternion), a ball joint (4 = a
+# quaternion), and a hinge (1). Humanoids and quadrupeds (unitree g1/go2/h1,
+# etc.) spawn exactly this way - a free base plus articulated joints - and ship
+# their standing pose in a ``<keyframe>``. The keyframe home pose must be
+# sliced out of the flat qpos vector using the correct per-joint width, or the
+# base position/orientation and every downstream joint land in the wrong slot.
+_FLOAT_MJCF = """
+<mujoco model="kf_float">
+  <compiler angle="radian"/>
+  <option timestep="0.002" gravity="0 0 -9.81"/>
+  <worldbody>
+    <body name="base" pos="0 0 0">
+      <freejoint name="root"/>
+      <geom type="box" size="0.05 0.05 0.05" mass="1"/>
+      <body name="link1" pos="0.1 0 0">
+        <joint name="ball1" type="ball"/>
+        <geom type="capsule" fromto="0 0 0 0.1 0 0" size="0.02" mass="0.2"/>
+        <body name="link2" pos="0.1 0 0">
+          <joint name="hinge1" type="hinge" axis="0 0 1"/>
+          <geom type="capsule" fromto="0 0 0 0.1 0 0" size="0.02" mass="0.1"/>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+  <keyframe>
+    <key name="home" qpos="0 0 0.5 1 0 0 0  0.7071 0 0.7071 0  0.3"/>
+  </keyframe>
+</mujoco>
+"""
+
+# free(7): x y z + wxyz quat | ball(4): wxyz quat | hinge(1): angle
+_FLOAT_HOME = [0.0, 0.0, 0.5, 1.0, 0.0, 0.0, 0.0, 0.7071, 0.0, 0.7071, 0.0, 0.3]
+
+
+@pytest.fixture
+def float_xml(tmp_path):
+    p = tmp_path / "kf_float.xml"
+    p.write_text(_FLOAT_MJCF)
+    return str(p)
+
+
+class TestFloatingBaseKeyframe:
+    """Keyframe spawn must slice the home pose with the correct per-joint qpos
+    width for every joint type - free (7) and ball (4), not just hinge/slide
+    (1). This is the floating-base humanoid/quadruped spawn path.
+    """
+
+    def test_free_and_ball_joint_home_pose_applied(self, sim, float_xml):
+        result = sim.add_robot(name="fb", urdf_path=float_xml, keyframe="home")
+        assert result["status"] == "success"
+        # The flat qpos vector is the free base pose, the ball quaternion, and
+        # the hinge angle laid out in joint order - proving each was written to
+        # its own slice at the right width rather than bleeding into the next.
+        assert np.allclose(_qpos(sim), _FLOAT_HOME)
+
+    def test_home_pose_captured_with_correct_per_joint_widths(self, sim, float_xml):
+        sim.add_robot(name="fb", urdf_path=float_xml, keyframe="home")
+        home = sim._world.robots["fb"].home_qpos
+        # Namespaced joint names, each carrying exactly its joint-type width:
+        # a wrong width here (e.g. treating the free root as a 1-wide slide)
+        # would truncate the base pose and shift every later joint.
+        assert set(home) == {"fb/root", "fb/ball1", "fb/hinge1"}
+        assert len(home["fb/root"]) == 7
+        assert len(home["fb/ball1"]) == 4
+        assert len(home["fb/hinge1"]) == 1
+        assert np.allclose(home["fb/root"], [0.0, 0.0, 0.5, 1.0, 0.0, 0.0, 0.0])
+        assert np.allclose(home["fb/ball1"], [0.7071, 0.0, 0.7071, 0.0])
+        assert np.allclose(home["fb/hinge1"], [0.3])
+
+    def test_observation_reflects_free_base_keyframe_pose(self, sim, float_xml):
+        sim.add_robot(name="fb", urdf_path=float_xml, keyframe="home")
+        obs = sim.get_observation(robot_name="fb", skip_images=True)
+        # The free base spawns at the keyframe height/orientation, not the
+        # zero-pose origin.
+        assert np.allclose(obs["base_pos"], [0.0, 0.0, 0.5])
+        assert np.allclose(obs["base_quat"], [1.0, 0.0, 0.0, 0.0])
+
+    def test_reset_restores_floating_base_home_pose(self, sim, float_xml):
+        sim.add_robot(name="fb", urdf_path=float_xml, keyframe="home")
+        # Gravity pulls the un-actuated free base off the home pose.
+        sim.step(40)
+        assert not np.allclose(_qpos(sim), _FLOAT_HOME)
+        assert sim.reset()["status"] == "success"
+        assert np.allclose(_qpos(sim), _FLOAT_HOME)


### PR DESCRIPTION
## Problem

`add_robot(keyframe=...)` applies a source `<keyframe>`'s home pose by slicing each joint's values out of the flat `qpos` vector using a per-joint-type width: free=7 (xyz + wxyz quat), ball=4 (wxyz quat), hinge/slide=1. The existing keyframe test suite (`tests/simulation/mujoco/test_add_robot_keyframe.py`) only exercises **hinge** joints, so the **free-base** and **ball-joint** width branches were unverified.

Those are exactly the branches the floating-base spawn path depends on: humanoids and quadrupeds (unitree g1/go2/h1, etc.) spawn as a free root plus articulated joints and ship their standing pose in a `<keyframe>`. If the width is computed wrong for a free or ball joint, the home pose is silently truncated and every downstream joint's slice shifts - the base lands at the wrong height/orientation and the arms/legs at the wrong angles, with no error.

## Change

Add a `TestFloatingBaseKeyframe` class backed by a tiny inline MJCF that mixes all three joint widths in one model (free root + ball + hinge) with a `home` keyframe, and pin:

- the flat `qpos` layout after a keyframe spawn (proves each joint was written to its own slice at the right width, not bleeding into the next);
- the captured per-joint `home_qpos` carries exactly its joint-type width (7 / 4 / 1);
- `get_observation` reflects the free base at the keyframe pose (not the zero-pose origin);
- `reset()` restores the floating-base home pose after gravity pulls it off.

Runs offline and GL-free (no mesh download, no render), matching the rest of the file.

## Verification

Each new assertion fails if the free/ball width is anything other than 7/4 (verified by mutating the width helper to return 1 for all joint types - all four new tests fail; they pass on the correct implementation).

- `tests/simulation/mujoco/test_add_robot_keyframe.py`: 16 passed (12 existing + 4 new)
- `tests/simulation/mujoco/`: 1233 passed, 1 skipped
- `ruff check` / `ruff format --check` clean; `mypy strands_robots tests tests_integ`: no issues in 756 files.

Test-only change; no library behavior is modified.