### PR TITLE
feat(sim): advertise the multi-robot rollout family in MuJoCo describe()

### DIFF
--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1664,6 +1664,52 @@ class MuJoCoSimEngine(
             "(inspect concurrent-policy state when driving two or more arms in one scene)"
         )
 
+        # Multi-robot rollout + per-robot action/joint introspection. describe()
+        # advertises run_policy (drive ONE robot with a created policy) and the
+        # background start/stop/list lifecycle, but omits run_multi_policy -- the
+        # facade that drives SEVERAL robots, each with its OWN Policy, in one
+        # synchronized control loop that co-observes every robot into one merged
+        # frame per timestep (the correct path for bimanual / handover / multi-
+        # agent data collection; independent start_policy threads instead
+        # interleave single-robot frames into a shared recorder). A caller
+        # assembling its {robot_name: Policy} map also has to know exactly what
+        # each robot's policy must emit, so this block advertises the two
+        # per-robot introspection primitives alongside it: robot_action_keys
+        # (the actuator short-names send_action resolves -- NOT always the joint
+        # names, since passive/mimic fingers have no actuator and a tendon
+        # gripper is an actuator with no joint) and robot_joint_names (the
+        # ordered observation.state joint vector). Without these three an agent
+        # could drive one robot from describe() but had to guess how to drive
+        # many, or key a multi-robot policy by joint name and watch tendon/mimic
+        # DOFs silently no-op. (get_features exposes the whole-scene view; these
+        # return the exact per-robot lists a policy is keyed on. Newton exposes
+        # the same trio and has the same gap; deferred to keep this diff
+        # MuJoCo-scoped like the sibling describe() families.)
+        base["methods"]["run_multi_policy"] = (
+            "(policies: dict[str, Policy], instructions='' | dict, duration=10.0, "
+            "control_frequency=50.0, action_horizon=8 | dict, n_steps=None, "
+            "max_steps=None) -> dict  # drive MULTIPLE robots, each with its own "
+            "Policy, in one synchronized loop that records ALL robots into ONE "
+            "merged frame per timestep (prefixed state/action, e.g. "
+            "'alice__shoulder_pan'); the concurrent multi-robot sibling of "
+            "run_policy for bimanual / handover / multi-agent data collection. "
+            "policies keys and action_horizon dict keys are robot names from the "
+            "'robots' list; per-robot instructions/horizon are supported"
+        )
+        base["methods"]["robot_action_keys"] = (
+            "(robot_name: str) -> list[str]  # the actuator short-names a policy "
+            "should emit as its action-dict keys for robot_name -- the exact keys "
+            "send_action resolves. NOT always the joint names: passive/mimic "
+            "fingers have no driving actuator and a tendon gripper is an actuator "
+            "with no joint, so keying by robot_joint_names makes those DOFs "
+            "silently no-op. Use this to key each policy in a run_multi_policy map"
+        )
+        base["methods"]["robot_joint_names"] = (
+            "(robot_name: str) -> list[str]  # the ordered joint names for "
+            "robot_name -- the names of the observation.state vector a policy "
+            "reads (the observation sibling of robot_action_keys' action side)"
+        )
+
         # Scene / world lifecycle + MJCF editing surface. describe() teaches how
         # to build a scene (add_robot/add_object/add_camera/load_scene), run a
         # policy, and read/checkpoint the result, but previously gave no way to

--- a/tests/simulation/mujoco/test_simulation.py
+++ b/tests/simulation/mujoco/test_simulation.py
@@ -1170,6 +1170,45 @@ class TestPolicyExecution:
         assert idempotent["status"] == "success"
         assert "Was not running" in idempotent["content"][0]["text"]
 
+    def test_describe_advertises_multi_robot_rollout_family(self, sim_with_robot):
+        """describe() advertises run_multi_policy and the per-robot action/joint
+        introspection a multi-policy caller needs to wire each robot.
+
+        describe() advertises run_policy (drive ONE robot with a created policy)
+        and the background start/stop/list lifecycle, but omitted
+        run_multi_policy -- the facade that drives SEVERAL robots, each with its
+        own Policy, in one synchronized loop (the correct path for bimanual /
+        multi-agent data collection). It also omitted the two per-robot
+        introspection primitives a caller uses to build that {robot_name:
+        Policy} map: robot_action_keys (the actuator short-names a policy must
+        emit -- NOT always the joint names) and robot_joint_names (the ordered
+        observation.state vector). An agent enumerating the sim from describe()
+        alone could drive one robot but had to guess how to drive many, or key a
+        policy by joint name and watch tendon/mimic DOFs silently no-op.
+        """
+        methods = sim_with_robot.describe()["methods"]
+        for name in ("run_multi_policy", "robot_action_keys", "robot_joint_names"):
+            assert name in methods, f"describe() omits multi-robot method {name!r}"
+        # Advertised signatures name the real parameters / return shape so a
+        # caller can invoke them without reading the source.
+        assert "policies" in methods["run_multi_policy"]
+        assert "-> dict" in methods["run_multi_policy"]
+        assert "-> list[str]" in methods["robot_action_keys"]
+        assert "-> list[str]" in methods["robot_joint_names"]
+        # The advertisement names actuator-vs-joint distinction that makes
+        # robot_action_keys the correct key source over robot_joint_names.
+        assert "send_action" in methods["robot_action_keys"]
+
+        # The advertisement is only useful if the methods it names are real and
+        # return the exact per-robot lists a policy is keyed on.
+        joints = sim_with_robot.robot_joint_names("arm1")
+        keys = sim_with_robot.robot_action_keys("arm1")
+        assert isinstance(joints, list) and joints, "robot_joint_names('arm1') is empty"
+        assert isinstance(keys, list) and keys, "robot_action_keys('arm1') is empty"
+        # Unknown robots return an empty list rather than raising.
+        assert sim_with_robot.robot_joint_names("ghost") == []
+        assert sim_with_robot.robot_action_keys("ghost") == []
+
 
 # Action Dispatch
 


### PR DESCRIPTION
## Problem

`describe()` is the discovery surface an agent calls first to learn a sim's contract without guessing method names. It advertises `run_policy` (drive ONE robot with a created policy) and the background `start_policy` / `stop_policy` / `list_policies_running` lifecycle, but omits the multi-robot rollout surface:

- **`run_multi_policy`** - the facade that drives SEVERAL robots, each with its OWN `Policy`, in a single synchronized control loop that co-observes every robot into ONE merged frame per timestep (prefixed state/action, e.g. `alice__shoulder_pan`). This is the correct path for bimanual / handover / multi-agent data collection; launching independent `start_policy` threads instead interleaves single-robot frames into a shared recorder.
- **`robot_action_keys`** / **`robot_joint_names`** - the two per-robot introspection primitives a caller uses to assemble the `{robot_name: Policy}` map. `robot_action_keys` returns the actuator short-names `send_action` actually resolves, which are **not always the joint names**: passive/mimic fingers have no driving actuator and a tendon gripper is an actuator with no matching joint, so keying a policy by `robot_joint_names` makes those DOFs silently no-op.

An agent enumerating the sim from `describe()` alone could drive one robot but had to guess how to drive many, or key a multi-robot policy by joint name and watch tendon/mimic DOFs silently no-op.

## Change

Advertise all three in the MuJoCo `describe()` override with real parameter / return-shape signatures, alongside the existing `run_policy` + background-lifecycle families. MuJoCo-scoped, matching the sibling `describe()` families; Newton exposes the same trio and has the same gap, deferred to keep this diff focused.

No behavior change - these methods already exist and are public; this only surfaces them on the discovery surface.

## Tests

`test_describe_advertises_multi_robot_rollout_family` (in `TestPolicyExecution`) asserts the three methods appear with their real signatures (`policies`, `-> dict`, `-> list[str]`, and the actuator-vs-joint distinction), and that the introspection primitives return the exact per-robot lists a policy is keyed on (non-empty for a loaded robot, empty list for an unknown robot with no raise). Fails pre-change (`describe() omits multi-robot method 'run_multi_policy'`), passes after.

Local gate green: `ruff check` + `ruff format --check` clean, `mypy strands_robots tests tests_integ` reports no issues, and the affected suites pass headless (`MUJOCO_GL=egl`, 208 passed across `test_simulation.py`, `test_sim_engine_describe_discovery.py`, `test_tool_spec.py`, `test_run_multi_policy_no_recording.py`).