### PR TITLE
feat(sim): ship g1_walk_forward humanoid locomotion benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,21 @@ tracking + posture regularizers). Registration is opt-in (mirrors the on-demand
 LIBERO suite registration), so importing `strands_robots` mutates no registry;
 `builtin_benchmark_specs()` returns the spec dicts to copy/fork.
 
+### Added: `g1_walk_forward` humanoid locomotion benchmark in `register_builtin_benchmarks()`
+
+`register_builtin_benchmarks()` now also ships `g1_walk_forward`, the humanoid
+(bipedal) counterpart of `go2_walk_forward` for the Unitree G1, so a humanoid has a
+runnable, discoverable velocity-tracking eval out of the box and the same
+floating-base predicate/reward DSL is shown to transfer unchanged from a quadruped
+to a biped. Only the thresholds and the regularizer stack differ, both grounded in
+the G1's real model: the G1 stands at base height ~0.79 m (vs the Go2's ~0.32 m), so
+`base_height` targets 0.78 m and the height-collapse failure fires below 0.4 m (well
+clear of the standing spawn, yet high enough to catch a folded humanoid that the
+Go2's 0.18 m threshold would miss). The dense stack adds the `base_lin_vel_z`
+(anti-bounce) and `base_ang_vel_xy` (anti-wobble) regularizers on top of the Go2
+stack, because bipedal walking is far more sensitive to base vertical bounce and
+roll/pitch wobble than a statically-stable quadruped.
+
 ### Added: `describe()` advertises the benchmark scoring family (`evaluate_benchmark` / `list_benchmarks` / `register_benchmark_from_file`)
 
 `SimEngine.describe()["methods"]` is the single-call discovery surface an agent

--- a/strands_robots/simulation/builtin_benchmarks.py
+++ b/strands_robots/simulation/builtin_benchmarks.py
@@ -9,9 +9,11 @@ reading the embodiment-agnostic floating-base surface from ``get_observation``.
 Those primitives, however, wired into no runnable benchmark:
 :func:`~strands_robots.simulation.benchmark.list_benchmarks` was empty until a
 caller hand-authored a spec (``register_benchmark_from_file``) or loaded the
-LIBERO suite. This module ships a canonical velocity-tracking locomotion
-benchmark composed from those primitives so a floating-base robot has a
-runnable, discoverable eval out of the box.
+LIBERO suite. This module ships canonical velocity-tracking locomotion benchmarks composed
+from those primitives - a quadruped (``go2_walk_forward``) and a humanoid
+(``g1_walk_forward``) - so a floating-base robot has a runnable, discoverable
+eval out of the box, and to show the same embodiment-agnostic DSL transfers
+unchanged across morphologies.
 
 Registration is opt-in - a caller invokes :func:`register_builtin_benchmarks`
 (mirroring how the LIBERO suite registers on demand via
@@ -74,11 +76,60 @@ _GO2_WALK_FORWARD: dict[str, Any] = {
     ],
 }
 
+# ``g1_walk_forward``: the humanoid (bipedal) counterpart of ``go2_walk_forward``
+# for the Unitree G1 - walk the G1 forward at 1 m/s and stay upright. It shows
+# the same floating-base DSL transfers unchanged to a biped; only the thresholds
+# and the regularizer stack differ, both grounded in the G1's real model:
+#
+#   - The G1 stands at base height ~0.79 m (measured; ``add_object``-free spawn),
+#     vs the Go2's ~0.32 m - so ``base_height`` targets 0.78 m and the
+#     height-collapse failure fires below 0.4 m (a fallen humanoid drops the
+#     pelvis well under half its standing height, with wide margin above 0 so a
+#     standing spawn never trips it).
+#   - ``base_tipped`` (tol=0.7, ~53 deg off level) terminates a topple, as for
+#     the quadruped: a walking biped tilts far less, so >53 deg is an
+#     unambiguous fall for either morphology.
+#   - The dense stack adds the ``base_lin_vel_z`` (anti-bounce) and
+#     ``base_ang_vel_xy`` (anti-wobble) regularizers on top of the Go2 stack:
+#     bipedal walking is far more sensitive to vertical bounce and roll/pitch
+#     wobble of the base than a statically-stable quadruped, so those
+#     regularizers (added for exactly this in the DSL) belong in a humanoid task.
+_G1_WALK_FORWARD: dict[str, Any] = {
+    "name": "g1_walk_forward",
+    "default_robot": "unitree_g1",
+    "supported_robots": ["unitree_g1"],
+    "max_steps": 1000,
+    "success": {"all": [{"predicate": "base_beyond_x", "x": 2.0}]},
+    "failure": {
+        "any": [
+            {"predicate": "base_tipped", "tol": 0.7},
+            {"predicate": "base_below_z", "z": 0.4},
+        ]
+    },
+    "dense_reward": [
+        {
+            "predicate": "base_velocity_tracking",
+            "vx": 1.0,
+            "vy": 0.0,
+            "wz": 0.0,
+            "lin_weight": 1.0,
+            "ang_weight": 0.5,
+            "tracking_sigma": 0.25,
+        },
+        {"predicate": "base_height", "target": 0.78, "weight": 0.5},
+        {"predicate": "base_orientation", "weight": 0.5},
+        {"predicate": "base_lin_vel_z", "weight": 0.1},
+        {"predicate": "base_ang_vel_xy", "weight": 0.1},
+    ],
+}
+
+
 # Registry of shipped built-in specs, keyed by their canonical registry name.
-# Extend this dict to ship more (e.g. a humanoid ``g1_walk_forward``); the same
-# floating-base DSL applies with different height/orientation thresholds.
+# Extend this dict to ship more; every entry reuses the same embodiment-agnostic
+# floating-base DSL, differing only in the robot, thresholds, and reward stack.
 _BUILTIN_SPECS: dict[str, dict[str, Any]] = {
     "go2_walk_forward": _GO2_WALK_FORWARD,
+    "g1_walk_forward": _G1_WALK_FORWARD,
 }
 
 

--- a/tests/simulation/test_builtin_benchmarks.py
+++ b/tests/simulation/test_builtin_benchmarks.py
@@ -83,9 +83,11 @@ def sim():
 @pytest.fixture(autouse=True)
 def _clean_registry():
     """Keep the module-global benchmark registry clean around each test."""
-    unregister_benchmark("go2_walk_forward")
+    for _n in ("go2_walk_forward", "g1_walk_forward"):
+        unregister_benchmark(_n)
     yield
-    unregister_benchmark("go2_walk_forward")
+    for _n in ("go2_walk_forward", "g1_walk_forward"):
+        unregister_benchmark(_n)
 
 
 def _write(xml: str) -> str:
@@ -204,6 +206,90 @@ def test_go2_walk_forward_dense_reward_is_finite(sim):
     bench = get_benchmark("go2_walk_forward")
     sim.add_robot("floater", urdf_path=_write(NAMED_BASE_XML))
     _set_base_pose(sim, x=0.0, z=0.32)
+    info = bench.on_step(sim, {}, {})
+    assert math.isfinite(info.reward)
+    assert info.done is False
+
+
+# ---------------------------------------------------------------------------
+# g1_walk_forward: the humanoid counterpart - same DSL, biped thresholds
+# ---------------------------------------------------------------------------
+def test_register_builtin_benchmarks_ships_both_go2_and_g1():
+    """register_builtin_benchmarks ships the quadruped AND humanoid tasks; both
+    are absent until registered, then discoverable with the right metadata."""
+    assert "g1_walk_forward" not in list_benchmarks()
+    names = register_builtin_benchmarks()
+    assert set(names) >= {"go2_walk_forward", "g1_walk_forward"}
+    assert names == sorted(names)  # returned sorted
+    snap = list_benchmarks()
+    meta = snap["g1_walk_forward"]
+    assert meta["class"] == "DeclarativeBenchmark"
+    assert meta["supported_robots"] == ["unitree_g1"]
+    assert meta["default_robot"] == "unitree_g1"
+    assert meta["max_steps"] == 1000
+
+
+def test_builtin_specs_include_g1_with_biped_thresholds():
+    """The shipped g1 spec uses the humanoid height/collapse thresholds and the
+    fuller anti-bounce / anti-wobble regularizer stack (grounded in the G1's
+    ~0.79 m standing base height), not the Go2's quadruped thresholds."""
+    specs = builtin_benchmark_specs()
+    g1 = specs["g1_walk_forward"]
+    # height-collapse failure well below the ~0.79 m stance, well above 0
+    collapse = next(p for p in g1["failure"]["any"] if p["predicate"] == "base_below_z")
+    assert collapse["z"] == 0.4
+    height = next(r for r in g1["dense_reward"] if r["predicate"] == "base_height")
+    assert height["target"] == 0.78
+    # the biped-specific regularizers are present (Go2 stack does not use them)
+    reward_terms = {r["predicate"] for r in g1["dense_reward"]}
+    assert {"base_lin_vel_z", "base_ang_vel_xy"} <= reward_terms
+
+
+def test_g1_walk_forward_success_fires_on_forward_progress(sim):
+    """success = base_beyond_x(2.0): False until the base walks past x=2 m."""
+    register_builtin_benchmarks()
+    bench = get_benchmark("g1_walk_forward")
+    sim.add_robot("floater", urdf_path=_write(NAMED_BASE_XML))
+    _set_base_pose(sim, x=0.0, z=0.78)
+    assert bench.is_success(sim) is False
+    _set_base_pose(sim, x=1.5, z=0.78)
+    assert bench.is_success(sim) is False  # short of the 2 m line
+    _set_base_pose(sim, x=3.0, z=0.78)
+    assert bench.is_success(sim) is True
+
+
+def test_g1_walk_forward_failure_fires_on_topple(sim):
+    """failure includes base_tipped(0.7): a level humanoid base continues, a
+    toppled one terminates the episode."""
+    register_builtin_benchmarks()
+    bench = get_benchmark("g1_walk_forward")
+    sim.add_robot("floater", urdf_path=_write(NAMED_BASE_XML))
+    _set_base_pose(sim, x=0.0, z=0.78, quat_wxyz=[1.0, 0.0, 0.0, 0.0])
+    assert bench.is_failure(sim) is False
+    _set_base_pose(sim, x=0.0, z=0.78, quat_wxyz=_quat_pitch(90.0))  # on its side
+    assert bench.is_failure(sim) is True
+
+
+def test_g1_walk_forward_failure_fires_on_height_collapse(sim):
+    """failure includes base_below_z(0.4): the ~0.79 m standing G1 continues, a
+    collapsed pelvis (below 0.4 m) terminates. The Go2's 0.18 m threshold would
+    NOT catch a humanoid that has folded to ~0.3 m - hence the biped threshold."""
+    register_builtin_benchmarks()
+    bench = get_benchmark("g1_walk_forward")
+    sim.add_robot("floater", urdf_path=_write(NAMED_BASE_XML))
+    _set_base_pose(sim, x=0.0, z=0.78)  # nominal G1 stance
+    assert bench.is_failure(sim) is False
+    _set_base_pose(sim, x=0.0, z=0.3)  # collapsed below 0.4 (Go2's 0.18 would miss this)
+    assert bench.is_failure(sim) is True
+
+
+def test_g1_walk_forward_dense_reward_is_finite(sim):
+    """on_step sums the full biped stack (velocity tracking + height +
+    orientation + lin_vel_z + ang_vel_xy) into a finite dense reward."""
+    register_builtin_benchmarks()
+    bench = get_benchmark("g1_walk_forward")
+    sim.add_robot("floater", urdf_path=_write(NAMED_BASE_XML))
+    _set_base_pose(sim, x=0.0, z=0.78)
     info = bench.on_step(sim, {}, {})
     assert math.isfinite(info.reward)
     assert info.done is False


### PR DESCRIPTION
## Problem

`register_builtin_benchmarks()` shipped a single task, `go2_walk_forward` (#1259) - a quadruped velocity-tracking benchmark. The floating-base predicate/reward DSL it composes is embodiment-agnostic (it reads `base_pos` / `base_quat` / `base_lin_vel` / `base_ang_vel` from `get_observation`, with no per-embodiment base body name), yet there was **no humanoid task**: a biped had no runnable, discoverable locomotion eval out of the box, and nothing shipped demonstrated that the same DSL transfers unchanged across morphologies (the module docstring literally left `g1_walk_forward` as a suggested extension).

## Change

Add `g1_walk_forward`, the humanoid (bipedal) counterpart for the Unitree G1: walk forward at 1 m/s and stay upright - success past `x = 2 m` (`base_beyond_x`), fail on topple (`base_tipped`) or height collapse (`base_below_z`), dense exp-kernel twist tracking + posture regularizers. It reuses the exact same DSL primitives; only the thresholds and the regularizer stack differ, and both are **grounded in the G1's real model** rather than copied from the quadruped:

- The G1 stands at base height **~0.79 m** (measured on the real model in MuJoCo) vs the Go2's ~0.32 m, so `base_height` targets 0.78 m and the height-collapse failure fires below **0.4 m** - well clear of the standing spawn (no step-0 false trip), yet high enough to catch a folded humanoid that the Go2's 0.18 m threshold would silently miss.
- `base_tipped(tol=0.7, ~53 deg off level)` terminates a topple for either morphology (a walking biped tilts far less, so >53 deg is an unambiguous fall).
- The dense stack adds the `base_lin_vel_z` (anti-bounce) and `base_ang_vel_xy` (anti-wobble) regularizers on top of the Go2 stack, because bipedal walking is far more sensitive to base vertical bounce and roll/pitch wobble than a statically-stable quadruped - which is exactly what those two DSL terms exist for.

A design note worth recording: the G1 uses **position servos** (unlike the Go2's torque actuators), so it holds its stance under a zero/mock policy instead of collapsing - the humanoid thresholds had to be measured, not inherited.

## Verified on the real Unitree G1 (MuJoCo)

```
register_builtin_benchmarks() -> ['g1_walk_forward', 'go2_walk_forward']
g1_walk_forward discoverable via list_benchmarks: True
  metadata: {'class': 'DeclarativeBenchmark', 'supported_robots': ['unitree_g1'],
             'default_robot': 'unitree_g1', 'max_steps': 1000}

shipped g1_walk_forward predicates on the REAL Unitree G1 floating base:
  standing  (z=0.793, level, x=0):   is_failure=False  is_success=False  reward=0.5182
  walked 3m (x=3.0):                 is_success=True
  collapsed (z=0.30 < 0.4):          is_failure=True
  toppled   (pitch 90deg on side):   is_failure=True
```

The compiled success/failure predicates fire correctly on the actual biped floating base, confirming the embodiment-agnostic DSL transfers from the quadruped unchanged.

## Tests

Extends `tests/simulation/test_builtin_benchmarks.py` with the g1 registration/discovery contract, the biped-threshold spec assertions, and success / topple / height-collapse / dense-reward predicate tests, mirroring the go2 suite on the inline floating-base fixture (GL-free, `skip_images`, no downloaded asset). All 6 new tests **fail before this change** (the spec is absent from the registry -> `get_benchmark("g1_walk_forward")` is `None`) and pass after; the 8 existing go2 tests are unchanged (14 passed). `ruff check` + `ruff format` + `mypy` clean.

No visual artifact: this is a benchmark-spec / eval-scoring addition composing existing predicates (no policy / rendering / recording / asset change), matching the `go2_walk_forward` (#1259) and base_* reward-DSL PR precedent - the fails-before regression test and the real-G1 predicate table are the proof.

Direct groundwork for #873 (G1/T1/Go1 locomotion task spec).