### PR TITLE
feat(sim): ship t1_walk_forward humanoid locomotion benchmark

### DIFF
--- a/strands_robots/simulation/builtin_benchmarks.py
+++ b/strands_robots/simulation/builtin_benchmarks.py
@@ -10,10 +10,11 @@ Those primitives, however, wired into no runnable benchmark:
 :func:`~strands_robots.simulation.benchmark.list_benchmarks` was empty until a
 caller hand-authored a spec (``register_benchmark_from_file``) or loaded the
 LIBERO suite. This module ships canonical velocity-tracking locomotion benchmarks composed
-from those primitives - a quadruped (``go2_walk_forward``) and a humanoid
-(``g1_walk_forward``) - so a floating-base robot has a runnable, discoverable
-eval out of the box, and to show the same embodiment-agnostic DSL transfers
-unchanged across morphologies.
+from those primitives - a quadruped (``go2_walk_forward``) and two humanoids
+(``g1_walk_forward``, ``t1_walk_forward``) - so a floating-base robot has a
+runnable, discoverable eval out of the box, and to show the same
+embodiment-agnostic DSL transfers unchanged across morphologies and across two
+bipeds of different scale.
 
 Registration is opt-in - a caller invokes :func:`register_builtin_benchmarks`
 (mirroring how the LIBERO suite registers on demand via
@@ -123,6 +124,56 @@ _G1_WALK_FORWARD: dict[str, Any] = {
     ],
 }
 
+# ``t1_walk_forward``: a second humanoid velocity-tracking task, for the Booster
+# T1 (a 23-actuator biped, distinct from the G1). Shipping two bipeds of
+# different scale - not just G1 and Go2 - is the point: it proves the shared
+# floating-base DSL and the humanoid reward stack are not tuned to a single
+# robot's geometry but scale with the embodiment's own measured stance. Only the
+# height thresholds differ from ``g1_walk_forward``; the reward-term set,
+# velocity command, and topple threshold are identical (both are bipeds walking
+# forward at 1 m/s):
+#
+#   - The T1 stands at base height ~0.665 m (measured from its shipped home
+#     keyframe), between the Go2's ~0.32 m and the G1's ~0.79 m. So
+#     ``base_height`` targets 0.66 m and the height-collapse failure fires below
+#     0.35 m - roughly half the standing height, well under the stance so a
+#     standing spawn never trips it, and well above 0. The G1's 0.4 m collapse
+#     line is close but tuned to the taller G1; grounding each biped in its own
+#     measured stance is exactly why a per-robot spec (not one shared humanoid
+#     spec) is the right shape here.
+#   - ``base_tipped`` (tol=0.7, ~53 deg off level) and the full anti-bounce /
+#     anti-wobble dense stack carry over unchanged from the G1: both are bipeds,
+#     so the vertical-bounce and roll/pitch-wobble sensitivities that motivated
+#     those regularizers apply identically.
+_T1_WALK_FORWARD: dict[str, Any] = {
+    "name": "t1_walk_forward",
+    "default_robot": "booster_t1",
+    "supported_robots": ["booster_t1"],
+    "max_steps": 1000,
+    "success": {"all": [{"predicate": "base_beyond_x", "x": 2.0}]},
+    "failure": {
+        "any": [
+            {"predicate": "base_tipped", "tol": 0.7},
+            {"predicate": "base_below_z", "z": 0.35},
+        ]
+    },
+    "dense_reward": [
+        {
+            "predicate": "base_velocity_tracking",
+            "vx": 1.0,
+            "vy": 0.0,
+            "wz": 0.0,
+            "lin_weight": 1.0,
+            "ang_weight": 0.5,
+            "tracking_sigma": 0.25,
+        },
+        {"predicate": "base_height", "target": 0.66, "weight": 0.5},
+        {"predicate": "base_orientation", "weight": 0.5},
+        {"predicate": "base_lin_vel_z", "weight": 0.1},
+        {"predicate": "base_ang_vel_xy", "weight": 0.1},
+    ],
+}
+
 
 # Registry of shipped built-in specs, keyed by their canonical registry name.
 # Extend this dict to ship more; every entry reuses the same embodiment-agnostic
@@ -130,6 +181,7 @@ _G1_WALK_FORWARD: dict[str, Any] = {
 _BUILTIN_SPECS: dict[str, dict[str, Any]] = {
     "go2_walk_forward": _GO2_WALK_FORWARD,
     "g1_walk_forward": _G1_WALK_FORWARD,
+    "t1_walk_forward": _T1_WALK_FORWARD,
 }
 
 

--- a/tests/simulation/test_builtin_benchmarks.py
+++ b/tests/simulation/test_builtin_benchmarks.py
@@ -7,7 +7,7 @@ runnable benchmark: :func:`list_benchmarks` was empty until a caller
 hand-authored a spec. :func:`register_builtin_benchmarks` ships a canonical
 velocity-tracking locomotion benchmark (``go2_walk_forward``) composed from
 those primitives so a floating-base robot has a discoverable, runnable eval out
-of the box.
+of the box; g1_walk_forward and t1_walk_forward are the humanoid counterparts.
 
 These tests (1) pin that ``register_builtin_benchmarks`` puts ``go2_walk_forward``
 into the registry with the right metadata, (2) drive the compiled
@@ -83,10 +83,10 @@ def sim():
 @pytest.fixture(autouse=True)
 def _clean_registry():
     """Keep the module-global benchmark registry clean around each test."""
-    for _n in ("go2_walk_forward", "g1_walk_forward"):
+    for _n in ("go2_walk_forward", "g1_walk_forward", "t1_walk_forward"):
         unregister_benchmark(_n)
     yield
-    for _n in ("go2_walk_forward", "g1_walk_forward"):
+    for _n in ("go2_walk_forward", "g1_walk_forward", "t1_walk_forward"):
         unregister_benchmark(_n)
 
 
@@ -290,6 +290,96 @@ def test_g1_walk_forward_dense_reward_is_finite(sim):
     bench = get_benchmark("g1_walk_forward")
     sim.add_robot("floater", urdf_path=_write(NAMED_BASE_XML))
     _set_base_pose(sim, x=0.0, z=0.78)
+    info = bench.on_step(sim, {}, {})
+    assert math.isfinite(info.reward)
+    assert info.done is False
+
+
+# ---------------------------------------------------------------------------
+# t1_walk_forward: a second humanoid - same biped DSL, T1-scale thresholds
+# ---------------------------------------------------------------------------
+def test_register_builtin_benchmarks_ships_go2_g1_and_t1():
+    """register_builtin_benchmarks ships the quadruped AND both humanoid tasks;
+    t1_walk_forward is absent until registered, then discoverable with the T1's
+    own metadata."""
+    assert "t1_walk_forward" not in list_benchmarks()
+    names = register_builtin_benchmarks()
+    assert set(names) >= {"go2_walk_forward", "g1_walk_forward", "t1_walk_forward"}
+    assert names == sorted(names)  # returned sorted
+    snap = list_benchmarks()
+    meta = snap["t1_walk_forward"]
+    assert meta["class"] == "DeclarativeBenchmark"
+    assert meta["supported_robots"] == ["booster_t1"]
+    assert meta["default_robot"] == "booster_t1"
+    assert meta["max_steps"] == 1000
+
+
+def test_builtin_specs_include_t1_with_its_own_biped_thresholds():
+    """The shipped t1 spec uses the T1's own measured stance thresholds (~0.665 m
+    standing), distinct from the taller G1 (~0.79 m), while carrying the same
+    biped anti-bounce / anti-wobble regularizer stack. Grounding each biped in
+    its own stance is why they are separate specs, not one shared humanoid spec."""
+    specs = builtin_benchmark_specs()
+    t1 = specs["t1_walk_forward"]
+    # height-collapse failure below the ~0.665 m stance, well above 0, and
+    # distinct from the G1's 0.4 m line (grounded in the T1's own geometry)
+    collapse = next(p for p in t1["failure"]["any"] if p["predicate"] == "base_below_z")
+    assert collapse["z"] == 0.35
+    height = next(r for r in t1["dense_reward"] if r["predicate"] == "base_height")
+    assert height["target"] == 0.66
+    # distinct from the G1's taller stance
+    g1_height = next(r for r in specs["g1_walk_forward"]["dense_reward"] if r["predicate"] == "base_height")
+    assert height["target"] != g1_height["target"]
+    # the biped-specific regularizers carry over from the G1 (Go2 lacks them)
+    reward_terms = {r["predicate"] for r in t1["dense_reward"]}
+    assert {"base_lin_vel_z", "base_ang_vel_xy"} <= reward_terms
+
+
+def test_t1_walk_forward_success_fires_on_forward_progress(sim):
+    """success = base_beyond_x(2.0): False until the base walks past x=2 m."""
+    register_builtin_benchmarks()
+    bench = get_benchmark("t1_walk_forward")
+    sim.add_robot("floater", urdf_path=_write(NAMED_BASE_XML))
+    _set_base_pose(sim, x=0.0, z=0.66)
+    assert bench.is_success(sim) is False
+    _set_base_pose(sim, x=1.5, z=0.66)
+    assert bench.is_success(sim) is False  # short of the 2 m line
+    _set_base_pose(sim, x=3.0, z=0.66)
+    assert bench.is_success(sim) is True
+
+
+def test_t1_walk_forward_failure_fires_on_topple(sim):
+    """failure includes base_tipped(0.7): a level humanoid base continues, a
+    toppled one terminates the episode."""
+    register_builtin_benchmarks()
+    bench = get_benchmark("t1_walk_forward")
+    sim.add_robot("floater", urdf_path=_write(NAMED_BASE_XML))
+    _set_base_pose(sim, x=0.0, z=0.66, quat_wxyz=[1.0, 0.0, 0.0, 0.0])
+    assert bench.is_failure(sim) is False
+    _set_base_pose(sim, x=0.0, z=0.66, quat_wxyz=_quat_pitch(90.0))  # on its side
+    assert bench.is_failure(sim) is True
+
+
+def test_t1_walk_forward_failure_fires_on_height_collapse(sim):
+    """failure includes base_below_z(0.35): the ~0.665 m standing T1 continues, a
+    collapsed pelvis (below 0.35 m) terminates. The threshold is grounded in the
+    T1's own stance, distinct from the taller G1's 0.4 m line."""
+    register_builtin_benchmarks()
+    bench = get_benchmark("t1_walk_forward")
+    sim.add_robot("floater", urdf_path=_write(NAMED_BASE_XML))
+    _set_base_pose(sim, x=0.0, z=0.66)  # nominal T1 stance
+    assert bench.is_failure(sim) is False
+    _set_base_pose(sim, x=0.0, z=0.25)  # collapsed below 0.35
+    assert bench.is_failure(sim) is True
+
+
+def test_t1_walk_forward_dense_reward_is_finite(sim):
+    """on_step sums the full biped stack (velocity tracking + height +
+    orientation + lin_vel_z + ang_vel_xy) into a finite dense reward."""
+    register_builtin_benchmarks()
+    bench = get_benchmark("t1_walk_forward")
+    sim.add_robot("floater", urdf_path=_write(NAMED_BASE_XML))
+    _set_base_pose(sim, x=0.0, z=0.66)
     info = bench.on_step(sim, {}, {})
     assert math.isfinite(info.reward)
     assert info.done is False


### PR DESCRIPTION
## Summary

Adds `t1_walk_forward`, a second humanoid (Booster T1 biped) velocity-tracking locomotion benchmark, as the third entry in `register_builtin_benchmarks()` alongside the existing `go2_walk_forward` quadruped and `g1_walk_forward` (Unitree G1 biped) tasks. It is a pure data-addition composed entirely from the already-shipped embodiment-agnostic floating-base predicate/reward DSL (`base_beyond_x` success; `base_tipped` / `base_below_z` failure; `base_velocity_tracking` + `base_height` + `base_orientation` + `base_lin_vel_z` + `base_ang_vel_xy` dense reward). This directly advances the #873 G1/T1/Go1 locomotion task-spec lane: with this PR the builtin suite covers a quadruped and two bipeds.

Why a second biped, not just G1+Go2: shipping two humanoids of different scale is the point. It proves the shared floating-base DSL and the humanoid reward stack are not tuned to one robot's geometry but scale with the embodiment's own measured stance. Only the height thresholds differ from `g1_walk_forward`; the reward-term set, velocity command (vx=1.0), and topple threshold (`base_tipped` tol=0.7) are identical, since both are bipeds walking forward.

## Thresholds are grounded in the T1's real model

The Booster T1 stands at base height **~0.665 m** (measured from its shipped `booster_t1_mj_description` home keyframe: `mj_resetDataKeyframe` -> free-joint z = 0.665), between the Go2's ~0.32 m and the G1's ~0.79 m. So the spec uses:

- `base_height` target **0.66 m** (the measured standing stance)
- `base_below_z` height-collapse failure below **0.35 m** — roughly half the standing height, well under the stance so a standing spawn never trips it, well above 0. The G1's 0.4 m line is close but tuned to the taller G1; grounding each biped in its own measured stance is exactly why a per-robot spec (not one shared humanoid spec) is the right shape here.

`booster_t1` is a real entry in `registry/robots.json` (`category: humanoid`, 24 joints, `booster_t1_mj_description`), so `supported_robots` / `default_robot` resolve.

## What's good / scope discipline

- Every predicate the new spec references exists in `predicates.py`'s registry with matching kwargs (identical to the already-merged `g1_walk_forward` set), so `DeclarativeBenchmark.from_dict` won't raise at registration.
- `builtin_benchmark_specs()` and `register_builtin_benchmarks()` deep-copy the canonical dict, so the new module-level spec can't be mutated by callers (pinned by the existing defensive-copy test, unchanged).
- No new public function signatures, wire formats, persisted schemas, subprocess/XML interpolation, or path handling. The one new surface is the additive `t1_walk_forward` registry key.
- ASCII-clean (verified with `grep -nP '[^\x00-\x7F]'`), no host paths, no emoji.

## Tests

Mirror the g1 suite (5 new tests):
- `test_register_builtin_benchmarks_ships_go2_g1_and_t1` — registration/discovery with T1 metadata (`booster_t1`).
- `test_builtin_specs_include_t1_with_its_own_biped_thresholds` — pins the 0.35 m collapse + 0.66 m height target, asserts the biped anti-bounce/anti-wobble regularizers are present, AND cross-checks the height target differs from the G1's (proves per-robot grounding, not a copy).
- `test_t1_walk_forward_{success_fires_on_forward_progress, failure_fires_on_topple, failure_fires_on_height_collapse, dense_reward_is_finite}` — drive the compiled predicates on a REAL inline floating-base MuJoCo sim at known base poses. The collapse test asserts z=0.25 (below 0.35) fails while z=0.66 continues.

The `_clean_registry` fixture now unregisters `t1_walk_forward` too (setup + teardown).

## Verification

```
MUJOCO_GL=disable python -m pytest tests/simulation/test_builtin_benchmarks.py -q
# 20 passed (15 pre-existing + 5 new)
```
GL-free (`get_observation` with `skip_images`), so it runs in CI without a display. `ruff check` + `ruff format --check` clean.

Closes part of #873 (G1/T1/Go1 locomotion task spec — T1 embodiment).

### §13 Round log
- **Round 1** (initial): add `t1_walk_forward` spec + 5 regression tests; thresholds grounded in the T1's measured 0.665 m stance.