### PR TITLE
chore(tools): drop the unused _ok helper in the run_policy tool

### DIFF
--- a/strands_robots/tools/run_policy.py
+++ b/strands_robots/tools/run_policy.py
@@ -64,12 +64,6 @@ from strands.tools.decorator import tool
 logger = logging.getLogger(__name__)
 
 
-def _ok(text: str, **extra: Any) -> dict[str, Any]:
-    out: dict[str, Any] = {"status": "success", "content": [{"text": text}]}
-    out.update(extra)
-    return out
-
-
 def _err(text: str) -> dict[str, Any]:
     return {"status": "error", "content": [{"text": text}]}
 

--- a/tests/tools/test_run_policy.py
+++ b/tests/tools/test_run_policy.py
@@ -661,3 +661,46 @@ class TestVideoPassthrough:
         # Dict without a usable path is forwarded (facade treats it as "off").
         assert sim.run_policy_calls[0]["video"] == {"fps": 30}
         assert result["content"][1]["json"]["video_paths"] == []
+
+
+# --------------------------------------------------------------------------
+# Success-payload content contract
+# --------------------------------------------------------------------------
+
+
+class TestSuccessPayloadContentShape:
+    """Pin the two-part ``content`` contract of a successful rollout.
+
+    A successful ``run_policy`` result carries EXACTLY two content parts: a
+    human-readable ``{"text": summary}`` followed by a machine-readable
+    ``{"json": payload}`` whose keys downstream verifiers parse (episode /
+    frame counts, warnings, dataset root). Locking this shape guards against
+    a regression to a single ``{"text": ...}`` payload, which would strand the
+    parquet-truth fields the fabrication guard depends on.
+    """
+
+    def test_success_content_is_text_then_json(self) -> None:
+        sim = _FakeSim()
+        result = run_policy(sim, n_episodes=2, n_steps=5, dataset_root=None)
+
+        assert result["status"] == "success"
+        content = result["content"]
+        assert len(content) == 2, "success payload must be [text, json], not a single text part"
+
+        assert set(content[0]) == {"text"}
+        assert isinstance(content[0]["text"], str) and content[0]["text"].strip()
+
+        assert set(content[1]) == {"json"}
+        payload = content[1]["json"]
+        assert isinstance(payload, dict)
+        # The parquet-truth / accounting keys a verifier reads off the payload.
+        for key in (
+            "n_episodes_requested",
+            "n_episodes_actual",
+            "n_frames_actual",
+            "n_episodes_ok",
+            "dataset_root",
+            "warnings",
+            "episodes",
+        ):
+            assert key in payload, f"success payload missing contract key {key!r}"


### PR DESCRIPTION
## What
The `run_policy` agent tool defines a module-level `_ok(text, **extra)` helper that has no callers. It is dead code, so this PR removes it.

## Why
The tool builds its success result inline as a **two-part** content payload:

```python
return {
    "status": out_status,
    "content": [{"text": summary_line}, {"json": payload}],
}
```

The `{"json": payload}` part is what downstream verifiers parse for parquet-truth (`n_episodes_actual`, `n_frames_actual`, `warnings`, ...). The orphaned `_ok` helper returns the older single-`{"text": ...}` form and predates that shape. Keeping a defined-but-unused private helper around invites a future caller to reach for the wrong (single-text) result shape. `_err` is still used and is left untouched.

## Tests
Added `TestSuccessPayloadContentShape.test_success_content_is_text_then_json`, which pins the two-part `content` contract (a non-empty `text` summary followed by a `json` payload carrying the accounting/parquet-truth keys). This locks the shape so a refactor cannot silently collapse the success result back to a single text part and strand the machine-readable fields the fabrication guard relies on.

## Verification
- `strands_robots/tools/run_policy.py` reaches **100% line coverage** after this change (was 97%, with lines 67-70 -- the dead helper -- previously uncovered).
- `tests/tools/test_run_policy.py`: 35 passed.
- `ruff check` / `ruff format --check` clean; `mypy` clean.

No behavior change: the tool's runtime output is unchanged; only unreachable code is removed and its result contract is now asserted.