### PR TITLE
fix(sim): get_contact_forces reflects the current pose (mj_forward before reading)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1443,6 +1443,26 @@ name-resolution degradation.
 
 - `PolicyServer.serve()` (and the background-thread `start()`) set `self._server` to the bound server *before* reading the OS-assigned port into `self.port`. A caller that treats `_server is not None` as the "server is bound, port is readable" signal (the documented contract for reading back a `port=0` OS-assigned port) could observe the constructor default `0` in the window between the two writes -- an intermittent race under load. Both entry points now publish the port *before* publishing `_server`, so any thread that sees a non-None `_server` always reads the real bound port.
 
+### Fixed: `get_contact_forces` reported stale contacts + fabricated forces after a pose change
+
+`Simulation.get_contact_forces()` iterated `data.contact[]` / `data.ncon` and
+called `mj_contactForce` (which reads `data.efc_force`) without first running
+`mj_forward`. Those are all *derived* state that MuJoCo only recomputes on
+`mj_forward` / `mj_step`, so after a manual `qpos` write (a planning/IK loop),
+a pose set immediately after `reset` / `add_robot`, or a concurrent policy
+thread's `mj_step`, the query silently reported the *previous* configuration's
+contacts -- complete with fabricated normal/friction forces -- while still
+returning `status=success` (e.g. a 2.5 N ground contact on a cube already
+lifted 1 m into the air). Its sibling `get_contacts` already forwards for
+exactly this reason ("stale contacts from the previous step / uninitialised
+memory can appear as phantom penetrations"), so the two contact-query APIs
+disagreed. `get_contact_forces` now runs `mj_forward` under the sim lock before
+reading (matching `get_contacts`), so the reported contacts and forces reflect
+the current `qpos`/`qvel` and the two APIs agree. A regression test settles a
+cube on the ground, lifts it via a direct `qpos` write (no forward), and asserts
+the airborne cube no longer appears in `get_contact_forces` (fails before,
+passes after).
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -1168,8 +1168,17 @@ class PhysicsMixin:
     def get_contact_forces(self) -> dict[str, Any]:
         """Get detailed contact forces for all active contacts.
 
-        Uses mj_contactForce for each active contact pair.
-        Returns normal and friction forces.
+        Uses ``mj_contactForce`` for each active contact pair; returns
+        normal and friction forces.
+
+        Runs ``mj_forward`` first (under the sim lock) so the contact list
+        AND the constraint forces reflect the current ``qpos``/``qvel`` --
+        exactly like :meth:`get_contacts`. Without it, a manual ``qpos``
+        write (planning/IK loop), a pose set immediately after ``reset`` /
+        ``add_robot``, or a policy thread mid-``mj_step`` leaves
+        ``data.ncon`` / ``data.contact[]`` / ``data.efc_force`` stale, and
+        this method would silently report phantom contacts with fabricated
+        forces while still returning ``status=success``.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
@@ -1179,6 +1188,10 @@ class PhysicsMixin:
 
         contacts = []
         with self._lock:
+            # Refresh contacts + constraint forces to the current qpos/qvel
+            # (mirrors get_contacts). mj_contactForce reads data.efc_force,
+            # which only the forward's constraint solve populates.
+            mj.mj_forward(model, data)
             for i in range(data.ncon):
                 c = data.contact[i]
                 g1 = mj.mj_id2name(model, mj.mjtObj.mjOBJ_GEOM, c.geom1) or f"geom_{c.geom1}"

--- a/tests/simulation/mujoco/test_physics.py
+++ b/tests/simulation/mujoco/test_physics.py
@@ -1075,3 +1075,61 @@ class TestRaycastReflectsCurrentPose:
 
         after = _extract_json_block(sim.multi_raycast(origin=[0, 0, 2], directions=dirs), 1)["rays"]
         assert after[0]["distance"] == pytest.approx(2.0, abs=1e-3)  # now hits ground
+
+
+class TestContactForcesReflectsCurrentPose:
+    """get_contact_forces must reflect the CURRENT qpos, exactly like get_contacts.
+
+    ``mj_contactForce`` reads ``data.contact[]``/``data.ncon`` (collision output)
+    and ``data.efc_force`` (constraint solve) -- all recomputed only by
+    ``mj_forward``/``mj_step``. A manual ``qpos`` write (planning/IK loop), a
+    pose set right after ``reset``/``add_robot``, or a policy thread
+    mid-``mj_step`` leaves them stale, so without a forward the method reports
+    phantom contacts with fabricated forces while returning ``status=success``.
+    ``get_contacts`` already forwards; the two contact queries must agree.
+    """
+
+    @staticmethod
+    def _box_in_forces(result):
+        for block in result["content"]:
+            if "json" in block:
+                return any("box_geom" in (c["geom1"], c["geom2"]) for c in block["json"].get("contacts", []))
+        return False
+
+    @staticmethod
+    def _lift_box(sim):
+        model, data = sim._world._model, sim._world._data
+        jid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, "box_free")
+        adr = int(model.jnt_qposadr[jid])
+        data.qpos[adr : adr + 3] = [0.0, 0.0, 3.0]  # lift the box 3m into the air
+        data.qpos[adr + 3 : adr + 7] = [1.0, 0.0, 0.0, 0.0]
+        # deliberately NO mj_forward / mj_step here
+
+    def test_get_contact_forces_reflects_pose_change_without_forward(self, sim):
+        # Settle the box on the ground -> a real box_geom<->ground contact.
+        for _ in range(500):
+            mj.mj_step(sim._world._model, sim._world._data)
+        base = sim.get_contact_forces()
+        assert base["status"] == "success"
+        assert self._box_in_forces(base)
+
+        self._lift_box(sim)
+
+        # Query FIRST (before any other call forwards). The box is 3m up with no
+        # possible contact, so a correct query no longer reports box_geom.
+        # Pre-fix reads the stale contact list + fabricated force for the box.
+        after = sim.get_contact_forces()
+        assert after["status"] == "success"
+        assert not self._box_in_forces(after)
+
+    def test_contact_queries_agree_after_pose_change(self, sim):
+        for _ in range(500):
+            mj.mj_step(sim._world._model, sim._world._data)
+        self._lift_box(sim)
+        # get_contact_forces must be queried FIRST; get_contacts forwards and
+        # would otherwise clear the staleness for the second call. After the
+        # box is lifted, neither query may still report the airborne box.
+        forces_has_box = self._box_in_forces(sim.get_contact_forces())
+        contacts_text = sim.get_contacts()["content"][0]["text"]
+        assert forces_has_box is False
+        assert "box_geom" not in contacts_text


### PR DESCRIPTION
## Problem

`Simulation.get_contact_forces()` iterated `data.contact[]` / `data.ncon` and called `mj_contactForce` (which reads `data.efc_force`) **without first running `mj_forward`**. Those are all *derived* state that MuJoCo only recomputes on `mj_forward` / `mj_step`. So after a state change that did not itself forward -- a manual `qpos` write (a planning/IK loop), a pose set immediately after `reset` / `add_robot`, or a concurrent policy thread's `mj_step` -- the query silently reported the **previous** configuration's contacts, complete with fabricated normal/friction forces, while still returning `status=success`.

Its sibling `get_contacts` already forwards for exactly this reason (its docstring: *"stale contacts from the previous step / uninitialised memory can appear as phantom penetrations at t=0"*), so the two contact-query APIs disagreed.

### Reproduction (real MuJoCo, no mocks)

Settle a cube on the ground, then teleport it 1 m into the air via a direct `qpos` write (no forward), then query:

```
get_contact_forces (no forward): 4 contacts
   ground <-> cube_geom  normal_force=0.245 N  dist=-0.0001
   ground <-> cube_geom  normal_force=0.245 N  dist=-0.0001
get_contacts (forwards):         0 contacts   <- ground truth: cube is airborne
```

`get_contact_forces` reports 4 phantom contacts with fabricated 0.245 N normal forces on a cube that is 1 m off the ground.

## Fix

Run `mj_forward` under the sim lock before reading, exactly like `get_contacts` (the lock also prevents a concurrent policy thread's `mj_step` from mutating `data.ncon` / `data.contact[]` / `data.efc_force` mid-read). The reported contacts and forces now reflect the current `qpos`/`qvel`, and the two contact-query APIs agree.

## Test

`TestContactForcesReflectsCurrentPose` (in `tests/simulation/mujoco/test_physics.py`, real `MjSpec` fixture) settles a cube on the ground, lifts it via a direct `qpos` write, and asserts the airborne cube no longer appears in `get_contact_forces`, and that `get_contact_forces` and `get_contacts` agree. **Fails before** (reports the stale `ground <-> box_geom` contact), **passes after**.

## Gate

- `ruff check` / `ruff format` clean; `mypy` clean on the changed module.
- `MUJOCO_GL=egl` full `test_physics.py` (82) + contact/concurrency-lock-audit suites pass.
- Purely a query-correctness fix; no change to physics, rendering, recording, or any public signature.