### PR TITLE
test(training): pin GR00T multi-GPU elastic-launch dispatch + worker log routing

### DIFF
--- a/tests/training/test_groot.py
+++ b/tests/training/test_groot.py
@@ -507,3 +507,104 @@ class TestResolveTune:
         assert merged["llm"] is False
         assert merged["visual"] is False
         assert merged["diffusion"] is True
+
+
+class TestTrainMultiGpu:
+    """train(num_gpus > 1) dispatches to torch elastic, not the in-process run.
+
+    The single-GPU path builds the config and calls ``experiment.run()``
+    directly; the multi-GPU path must instead hand ``_groot_worker`` to
+    ``elastic_launch_callable`` so torch's elastic agent spawns one worker per
+    GPU. A regression that ran ``experiment.run()`` in-process for num_gpus > 1
+    would DataParallel-wrap on a single process (the StopIteration crash the
+    single-GPU CUDA_VISIBLE_DEVICES pin exists to avoid) instead of sharding.
+    """
+
+    def test_multi_gpu_hands_worker_to_elastic_launch(self, spec, monkeypatch):
+        from strands_robots.training import groot as groot_mod
+
+        _install_fake_gr00t(monkeypatch)
+        spec.num_gpus = 2
+        os.makedirs(spec.output_dir, exist_ok=True)
+        (Path(spec.output_dir) / "checkpoint-42").mkdir()
+
+        launches: list = []
+
+        def _fake_elastic(fn, *, nproc_per_node, nnodes, run_id, fn_args):
+            launches.append((fn, nproc_per_node, nnodes, run_id, fn_args))
+
+        monkeypatch.setattr(groot_mod, "elastic_launch_callable", _fake_elastic)
+
+        # The in-process run must NOT be invoked on the multi-GPU path.
+        def _boom(*a, **k):
+            raise AssertionError("call_callable must not run for num_gpus > 1")
+
+        monkeypatch.setattr(groot_mod, "call_callable", _boom)
+
+        result = groot_mod.Gr00tTrainer().train(spec)
+
+        assert result.status == "success"
+        assert result.checkpoint_dir == str(Path(spec.output_dir) / "checkpoint-42")
+        assert len(launches) == 1
+        fn, nproc_per_node, nnodes, run_id, fn_args = launches[0]
+        assert fn is groot_mod._groot_worker
+        assert nproc_per_node == 2  # one worker per GPU
+        assert nnodes == 1
+        assert run_id == result.job_id
+        groot_root, forwarded_spec, log_path = fn_args
+        assert groot_root == spec.extra["groot_root"]
+        assert forwarded_spec is spec
+        assert log_path.endswith(".log")
+
+
+class TestGrootWorker:
+    """``_groot_worker``: the per-GPU elastic-launch worker body.
+
+    Pins the "only local rank 0 tees to the shared log" contract. Each worker
+    builds the FinetuneConfig + run Config from Python objects (no argv) and
+    calls ``experiment.run()`` via ``call_callable``. If a non-zero rank also
+    received the log path, every worker would open the same file and interleave
+    writes, corrupting the RUNNING-vs-learning verdict the log exists to support.
+    """
+
+    def test_rank0_tees_to_shared_log(self, spec, tmp_path, monkeypatch):
+        from strands_robots.training import groot as groot_mod
+
+        _install_fake_gr00t(monkeypatch)
+        monkeypatch.delenv("LOCAL_RANK", raising=False)  # unset defaults to rank 0
+
+        calls: list = []
+        monkeypatch.setattr(
+            groot_mod,
+            "call_callable",
+            lambda fn, cfg, log_path=None: calls.append((fn, cfg, log_path)),
+        )
+
+        log = str(tmp_path / "train.log")
+        groot_mod._groot_worker(spec.extra["groot_root"], spec, log)
+
+        assert len(calls) == 1
+        fn, _cfg, log_path = calls[0]
+        assert log_path == log
+        # experiment.run() was resolved from the (fake) GR00T package and forwarded.
+        import gr00t.experiment.experiment as exp  # noqa: PLC0415
+
+        assert fn is exp.run
+
+    def test_nonzero_rank_suppresses_log(self, spec, tmp_path, monkeypatch):
+        from strands_robots.training import groot as groot_mod
+
+        _install_fake_gr00t(monkeypatch)
+        monkeypatch.setenv("LOCAL_RANK", "1")
+
+        calls: list = []
+        monkeypatch.setattr(
+            groot_mod,
+            "call_callable",
+            lambda fn, cfg, log_path=None: calls.append((fn, cfg, log_path)),
+        )
+
+        groot_mod._groot_worker(spec.extra["groot_root"], spec, str(tmp_path / "train.log"))
+
+        assert len(calls) == 1
+        assert calls[0][2] is None  # non-rank-0 worker must not touch the shared log


### PR DESCRIPTION
## Problem
The multi-GPU branch of `Gr00tTrainer.train` (`num_gpus > 1`) and the `_groot_worker` body it hands to `elastic_launch_callable` had no test coverage. That left the single-node distributed training path unpinned: a regression in how workers are launched, or in which rank writes the shared log, would ship silently.

## Change
Add three focused, offline tests (no GPU, checkpoints, or Isaac-GR00T install — reuses the existing `_install_fake_gr00t` seam):

- `TestTrainMultiGpu.test_multi_gpu_hands_worker_to_elastic_launch` — `train(num_gpus=2)` hands `_groot_worker` to `elastic_launch_callable` with `nproc_per_node=num_gpus` (one worker per GPU), `nnodes=1`, and the job id as `run_id`; and asserts `call_callable` (the in-process `experiment.run()` path) is NOT invoked. Running in-process for `num_gpus > 1` would DataParallel-wrap a single process instead of sharding across GPUs.
- `TestGrootWorker.test_rank0_tees_to_shared_log` — with `LOCAL_RANK` unset (rank 0), the worker resolves `experiment.run` and forwards the shared log path to `call_callable`.
- `TestGrootWorker.test_nonzero_rank_suppresses_log` — with `LOCAL_RANK=1`, the worker passes `log_path=None`, so non-zero ranks do not open the same file and interleave writes into the RUNNING-vs-learning log.

## Coverage
`strands_robots/training/groot.py`: 96% -> 99% (covers the previously-missed lines 425-426 and 489-497). No production code changed.

## Testing
`ruff check` + `ruff format --check` + `mypy` clean on `strands_robots tests tests_integ`; `tests/training/` passes (399 passed, 4 skipped).