### PR TITLE
docs(sim): describe() advertises the humanoid builtin benchmarks

### DIFF
--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -2099,9 +2099,10 @@ class SimEngine(ABC):
                     "DSL) as YAML/JSON at runtime and register it under benchmark_name"
                 ),
                 "register_builtin_benchmarks": (
-                    "() -> dict  # register the shipped built-in benchmarks "
-                    "(e.g. the go2_walk_forward velocity-tracking locomotion task) "
-                    "so they appear in list_benchmarks and can be run via evaluate_benchmark"
+                    "() -> dict  # register the shipped built-in velocity-tracking "
+                    "locomotion benchmarks - the go2_walk_forward quadruped task and "
+                    "the g1_walk_forward / t1_walk_forward humanoid tasks - so they "
+                    "appear in list_benchmarks and can be run via evaluate_benchmark"
                 ),
                 "replay_episode": (
                     "(repo_id: str, robot_name=None, episode=0, root=None, "

--- a/tests/simulation/test_sim_engine_describe_discovery.py
+++ b/tests/simulation/test_sim_engine_describe_discovery.py
@@ -237,6 +237,25 @@ class TestDescribeABC:
         assert "benchmark_name" in methods["evaluate_benchmark"]
         assert "spec_path" in methods["register_benchmark_from_file"]
 
+    def test_describe_register_builtin_benchmarks_advertises_humanoids(self):
+        """describe() advertises register_builtin_benchmarks as shipping BOTH the
+        quadruped and the humanoid locomotion tasks, not the quadruped alone.
+
+        register_builtin_benchmarks() ships three velocity-tracking tasks -
+        go2_walk_forward (quadruped) plus g1_walk_forward and t1_walk_forward
+        (two humanoids of different scale). The discovery-surface description
+        once named only go2_walk_forward as its example, so an agent enumerating
+        describe()["methods"] to decide whether a runnable HUMANOID locomotion
+        eval exists would be misled into thinking only the quadruped ships. Pin
+        the humanoid tasks into the advertised text so it cannot silently
+        regress to quadruped-only as more built-ins are added.
+        """
+        engine = _make_minimal_engine()
+        blurb = engine.describe()["methods"]["register_builtin_benchmarks"]
+        assert "g1_walk_forward" in blurb
+        assert "t1_walk_forward" in blurb
+        assert "humanoid" in blurb.lower()
+
 
 @pytest.mark.skipif(
     not pytest.importorskip("mujoco", reason="MuJoCo not installed"),


### PR DESCRIPTION
## Summary

`register_builtin_benchmarks()` ships three velocity-tracking locomotion tasks - `go2_walk_forward` (quadruped) plus `g1_walk_forward` and `t1_walk_forward` (two humanoids of different scale, #1287/#1288). But the `SimEngine.describe()` discovery-surface entry for the method still named **only** `go2_walk_forward` as its example:

```
register the shipped built-in benchmarks (e.g. the go2_walk_forward
velocity-tracking locomotion task) so they appear in list_benchmarks ...
```

An agent enumerating `describe()["methods"]` to decide whether a runnable **humanoid** locomotion eval exists would be misled into thinking only the quadruped ships - the discovery surface is the contract agents read instead of guessing, so this stale example is a genuine drift.

## Change

- **`base.py`**: the `register_builtin_benchmarks` blurb now names all three shipped tasks - the `go2_walk_forward` quadruped task and the `g1_walk_forward` / `t1_walk_forward` humanoid tasks. One entry edited; no behavior change.
- **test**: pins a regression test (`test_describe_register_builtin_benchmarks_advertises_humanoids`) asserting the advertised text contains `g1_walk_forward`, `t1_walk_forward`, and `humanoid`, so it cannot silently regress to quadruped-only as more built-ins are added.

This continues the established `describe()` discovery-surface hygiene lane (#1249/#1254/#1256/#1257/#1261/#1262/#1264).

## Verification

- New assertions **fail on pre-fix `base.py`** (blurb lacks `g1_walk_forward`/`humanoid`) and **pass on the fix** - verified by driving `describe()` on a minimal `SimEngine` subclass (no MuJoCo needed; the ABC discovery surface is backend-agnostic).
- `ruff check` clean on both files; no non-ASCII introduced (no-emoji rule).

Doc/discovery-surface only - no runtime behavior change.