### PR TITLE
test(mesh): pin numeric env-var parse rejection in zenoh config blocks

### DIFF
--- a/tests/mesh/test_zenoh_config.py
+++ b/tests/mesh/test_zenoh_config.py
@@ -205,7 +205,7 @@ class TestTransportCaps:
         typo silently fall back to the default cap.
         """
         monkeypatch.setenv("STRANDS_MESH_MAX_SESSIONS", "lots")
-        with pytest.raises(ValueError, match="is not an integer"):
+        with pytest.raises(ValueError, match=r"STRANDS_MESH_MAX_SESSIONS='lots' is not an integer"):
             zc.transport_caps_block()
 
 
@@ -244,7 +244,7 @@ class TestDownsampling:
         cap on a typo.
         """
         monkeypatch.setenv("STRANDS_MESH_CMD_RATE_HZ", "fast")
-        with pytest.raises(ValueError, match="is not a float"):
+        with pytest.raises(ValueError, match=r"STRANDS_MESH_CMD_RATE_HZ='fast' is not a float"):
             zc.downsampling_block()
 
 
@@ -314,6 +314,16 @@ class TestLowPassFilter:
     def test_oversize_cap_rejected(self, monkeypatch):
         monkeypatch.setenv("STRANDS_MESH_MAX_CMD_BYTES", "999999999999")
         with pytest.raises(ValueError):
+            zc.low_pass_filter_block()
+
+    def test_non_integer_byte_cap_rejected(self, monkeypatch):
+        """A non-numeric byte-cap env var raises an actionable
+        "is not an integer" ValueError at config-build time, naming the
+        env var and offending value, rather than an opaque failure deeper
+        in ``zenoh.open()``.
+        """
+        monkeypatch.setenv("STRANDS_MESH_MAX_CMD_BYTES", "big")
+        with pytest.raises(ValueError, match=r"STRANDS_MESH_MAX_CMD_BYTES='big' is not an integer"):
             zc.low_pass_filter_block()
 
 


### PR DESCRIPTION
## Problem

The integer/float env-var validators in `strands_robots/mesh/_zenoh_config.py` guard six published mesh env vars. On a malformed value they raise an actionable `ValueError` at config-build time naming the env var and offending value (e.g. `STRANDS_MESH_MAX_CMD_BYTES='big' is not an integer`) instead of letting a typo fall through to an opaque failure deep inside `zenoh.open()`.

Two gaps remained after the session/rate parse-rejection tests landed on main:

1. The **byte-cap** parse-error path (`STRANDS_MESH_MAX_*_BYTES` -> `low_pass_filter_block()`) had no malformed-input test.
2. The two already-merged session/rate parse-rejection tests asserted only the loose substring (`is not an integer` / `is not a float`), so a regression that dropped the named-var context from the message would still pass.

## Change

Single test-only diff to `tests/mesh/test_zenoh_config.py` (+14/-2):

- **Add** `TestLowPassFilter::test_non_integer_byte_cap_rejected` -> drives a non-numeric `STRANDS_MESH_MAX_CMD_BYTES` through the public `low_pass_filter_block()`, asserting the exact operator-facing message.
- **Tighten** the existing `TestTransportCaps::test_non_integer_rejected` and `TestDownsampling::test_non_float_rejected` assertions from the loose substring to the precise message (`STRANDS_MESH_MAX_SESSIONS='lots' is not an integer`, `STRANDS_MESH_CMD_RATE_HZ='fast' is not a float`), pinning the env-var-name + value contract.

## Testing

- `ruff check` / `ruff format --check`: clean.
- `pytest tests/mesh/test_zenoh_config.py`: 51 passed.

Test-only change; no runtime behavior modified.

---

### Round 2 changelog

Reconciled against `main` after the sibling env-parse PR merged. The original diff added `test_non_integer_rejected` / `test_non_float_rate_rejected`, which now overlapped the just-merged tests and produced a file-level conflict. Rebased onto current `main` and reduced scope to the single genuinely-new byte-cap test plus tightening the two existing parse-rejection assertions to the exact message. Net diff is now conflict-free and non-redundant (+14/-2).