### PR TITLE
fix(sim): base describe() advertises remove_robot + scene-variation facades

### DIFF
--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -2074,6 +2074,12 @@ class SimEngine(ABC):
                     "(checker|gradient|flat) + rgb1/rgb2/texdim, texrepeat [u,v]"
                 ),
                 "remove_object": "(name: str) -> dict  # remove a previously added object",
+                "remove_robot": (
+                    "(name: str) -> dict  # remove a robot (and every scene "
+                    "element it introduced) from the world; the inverse of "
+                    "add_robot, completing the add/remove pair alongside "
+                    "remove_object"
+                ),
                 "run_policy": "(robot_name: str, policy_provider='mock', n_episodes=1, reset_between=True, ...) -> dict",
                 "start_policy": "(robot_name: str, policy_provider='mock', ...) -> dict",
                 "eval_policy": (
@@ -2125,6 +2131,27 @@ class SimEngine(ABC):
                     "count, timestep, gravity, and robot / object / camera / "
                     "body / joint / actuator counts (the whole-world sibling of "
                     "get_robot_state / get_observation)"
+                ),
+                "load_scene": (
+                    "(scene_path: str) -> dict  # load a complete scene from "
+                    "an MJCF/URDF file; the alternative scene-construction "
+                    "entry point to building it up with add_robot / add_object"
+                ),
+                "randomize": (
+                    "(**kwargs) -> dict  # domain randomization (colors, "
+                    "lighting, physics, positions); each backend defines its "
+                    "own opt-in axes - see the backend describe() for the "
+                    "concrete signature"
+                ),
+                "set_obs_noise": (
+                    "(**kwargs) -> dict  # configure additive Gaussian sensor "
+                    "noise on joint observations and rendered frames so a "
+                    "policy is not evaluated on noise-free observations"
+                ),
+                "get_contacts": (
+                    "() -> dict  # active contacts at the current step - the "
+                    "physics-grounding read used to verify a grasp or detect "
+                    "a collision instead of trusting a rendered caption"
                 ),
             },
             "note": (

--- a/tests/simulation/test_sim_engine_describe_discovery.py
+++ b/tests/simulation/test_sim_engine_describe_discovery.py
@@ -256,6 +256,46 @@ class TestDescribeABC:
         assert "t1_walk_forward" in blurb
         assert "humanoid" in blurb.lower()
 
+    def test_describe_lists_scene_mutation_inverse(self):
+        """describe() advertises remove_robot, completing the add/remove pair.
+
+        The base contract advertised ``add_robot`` ("the first
+        scene-construction step") and the object inverse ``remove_object``, but
+        not ``remove_robot`` -- even though it is an abstract method every
+        backend must implement. A caller enumerating ``describe()["methods"]``
+        who built a scene with add_robot could not learn how to tear a robot
+        back out without guessing the name. It belongs on the base discovery
+        surface as the inverse of add_robot, mirroring the add_object /
+        remove_object pair already advertised.
+        """
+        engine = _make_minimal_engine()
+        methods = engine.describe()["methods"]
+        assert "remove_robot" in methods, "describe() omits the base remove_robot method"
+        assert "name" in methods["remove_robot"]
+
+    def test_describe_lists_scene_variation_and_grounding(self):
+        """describe() advertises the scene-variation + physics-grounding facades.
+
+        ``load_scene`` (the alternative scene-construction entry point),
+        ``randomize`` and ``set_obs_noise`` (domain randomization + sensor-noise
+        variation), and ``get_contacts`` (the physics-grounding read used to
+        verify a grasp / detect a collision) are all public methods declared on
+        the base ``SimEngine`` contract, but describe() listed none of them -- so
+        a caller enumerating ``describe()["methods"]`` could build a scene and
+        run a policy, yet could not discover how to load a scene from file, vary
+        it for sim2real, or verify the physics result without guessing the
+        names. They belong on the base discovery surface; each backend documents
+        its concrete signature via its own describe() override.
+        """
+        engine = _make_minimal_engine()
+        methods = engine.describe()["methods"]
+        for name in ("load_scene", "randomize", "set_obs_noise", "get_contacts"):
+            assert name in methods, f"describe() omits base scene/grounding method {name!r}"
+        # Advertised signatures name the real distinguishing details so a caller
+        # can invoke them (or know where to read the concrete backend signature).
+        assert "scene_path" in methods["load_scene"]
+        assert "contact" in methods["get_contacts"].lower()
+
 
 @pytest.mark.skipif(
     not pytest.importorskip("mujoco", reason="MuJoCo not installed"),


### PR DESCRIPTION
## Problem

`SimEngine.describe()` is the single-call discovery surface an agent reads to learn an engine's contract in one call, instead of guessing method names and probe-and-failing. The **base** surface (`strands_robots/simulation/base.py`) advertised `add_robot` ("the first scene-construction step") and the object inverse `remove_object`, but omitted five public methods declared on the same base contract:

- `remove_robot` - an abstract method every backend must implement, and the inverse of `add_robot`. Its absence breaks the add/remove symmetry that `add_object` / `remove_object` already establish.
- `load_scene` - the alternative scene-construction entry point (load a complete MJCF/URDF scene from file).
- `randomize` / `set_obs_noise` - domain randomization and additive sensor-noise variation (sim2real).
- `get_contacts` - the physics-grounding read used to verify a grasp or detect a collision, rather than trusting a rendered caption.

A caller enumerating `describe()["methods"]` on a backend that relies on the base surface could build a scene and run a policy, but could not discover how to tear a robot back out, load a scene from file, vary it, or verify the physics result without guessing the names.

## Change

Add these five methods to the base `describe()` methods dict with signature + intent hints. The MuJoCo override already documents all five (and pins them on the live engine); this lifts them to the shared base contract so every backend inherits the same discovery baseline. Backends document their concrete `randomize` / `set_obs_noise` signatures via their own `describe()` override; unsupported ops raise a clean `NotImplementedError` per the existing contract.

Purely additive to the returned metadata dict - no behavior, policy, rendering, or recording change.

## Tests

Adds two base-ABC regression tests (minimal concrete engine) in `tests/simulation/test_sim_engine_describe_discovery.py`, both of which fail on pre-change code:

- `test_describe_lists_scene_mutation_inverse` - `remove_robot` is advertised, completing the add/remove pair.
- `test_describe_lists_scene_variation_and_grounding` - `load_scene` / `randomize` / `set_obs_noise` / `get_contacts` are advertised with signature hints.

The existing live-MuJoCo `test_describe_methods_resolve_to_real_attributes` (every advertised method resolves to a callable) continues to pass, confirming the base additions all resolve on a real backend.

Gate: `ruff check` + `ruff format --check` + `mypy strands_robots tests tests_integ` clean; the full `test_sim_engine_describe_discovery.py` suite plus neighboring discovery tests pass (MUJOCO_GL=egl, headless).