### PR TITLE
fix(sim): add_robot reports an actionable error for an unknown model instead of a dead-end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1463,6 +1463,34 @@ cube on the ground, lifts it via a direct `qpos` write (no forward), and asserts
 the airborne cube no longer appears in `get_contact_forces` (fails before,
 passes after).
 
+### Fixed: `add_robot` reports an actionable error for an unknown/unresolvable model instead of a dead-end
+
+The MuJoCo `add_robot` had two exits with unequal error quality. When a
+caller passed a `data_config` that resolved to no model, the error routed
+through the `_unknown_model_msg` helper -- naming the robot, offering
+difflib close-match suggestions, and pointing at `list_urdfs`. But when a
+caller named a robot positionally (`add_robot("panda_typo")`, the deprecated
+name-as-registry-key short form) or gave an instance label without a model
+source (`add_robot(name="myarm")`), the same unresolvable-model case fell
+through to a dead-end `"Either urdf_path or data_config is required."` that
+never named the robot, offered no suggestion, and did not point at
+discovery -- inconsistent with both the `data_config` exit and the
+top-level `Robot()` factory (which already raises a clean `Unknown robot`).
+An agent (or human) driving the API blind with a mistyped name hit a wall.
+
+`add_robot` now surfaces the actionable `_unknown_model_msg` for any
+caller-supplied `name`/`data_config` that resolves to no model -- naming the
+robot, suggesting close matches, and pointing at `list_urdfs` plus the
+`data_config=`/`urdf_path=` options -- so the error is actionable whether the
+name was a mistyped registry key or an instance label missing its model.
+The bare `"Either urdf_path or data_config is required."` message is
+preserved for the genuine no-name case (`add_robot()` with nothing to
+resolve). The deprecated positional name-as-registry-key fallback still
+resolves a VALID name unchanged. A regression test asserts the positional
+typo and the instance-label cases name the robot + point at `list_urdfs` +
+the model-source options (fails before, passes after), that the no-name case
+keeps the generic message, and that a valid positional name still resolves.
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -886,12 +886,23 @@ class MuJoCoSimEngine(
         (e.g. panda ``"home"``) instead of the all-zero configuration, and the
         pose is restored by ``reset()``. An unknown keyframe is a hard error
         naming the available keyframes; ``None`` (default) keeps the zero pose.
+
+        A ``name``/``data_config`` that resolves to no model is reported as an
+        actionable error naming the requested robot, offering close-match
+        suggestions and pointing at ``list_urdfs`` (plus the
+        ``data_config=``/``urdf_path=`` options) -- not a dead-end "supply a
+        model source". The bare model-source message is kept only when no
+        ``name`` was supplied at all.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         if err := self._require_no_running_policy("add_robot"):
             return err
 
+        # Remember whether the caller supplied a `name` (vs an auto-derived
+        # label): an explicit name that resolves to no model is a
+        # mistyped/unknown robot, not a 'you forgot a model source' case.
+        explicit_name = name
         # Auto-derive an instance label when the caller didn't supply one.
         # Friction fix: ``name`` used to be required, so a natural
         # ``add_robot(data_config="so101")`` failed with "requires parameter
@@ -950,6 +961,21 @@ class MuJoCoSimEngine(
                 )
 
         if not resolved_path:
+            # A caller-provided `name` that resolves to no model is almost
+            # always a mistyped/unknown robot (the deprecated
+            # name-as-registry-key short form). Surface the same actionable
+            # "no model found (did you mean ...?) / list_urdfs" error the
+            # data_config path and the Robot() factory give, instead of a
+            # dead-end "supply urdf_path or data_config". The bare
+            # "supply a model source" message is kept only for the no-name
+            # case (auto-derived label, nothing to resolve).
+            if explicit_name:
+                msg = self._unknown_model_msg(explicit_name)
+                msg += (
+                    f" Or pass data_config=<registered model> or urdf_path=<file> "
+                    f"to add '{explicit_name}' as an instance under that label."
+                )
+                return {"status": "error", "content": [{"text": msg}]}
             return {"status": "error", "content": [{"text": "Either urdf_path or data_config is required."}]}
         if not os.path.exists(resolved_path):
             return {"status": "error", "content": [{"text": f"File not found: {resolved_path}"}]}

--- a/tests/simulation/mujoco/test_add_robot_unknown_model_message.py
+++ b/tests/simulation/mujoco/test_add_robot_unknown_model_message.py
@@ -1,0 +1,70 @@
+"""add_robot surfaces an actionable error for an unknown/unresolvable model.
+
+Contract: when a caller names a robot that resolves to no model (a mistyped
+registry key, or an instance label given without a model source), the engine
+returns the same actionable "no model found (did you mean ...?) / list_urdfs /
+pass data_config= or urdf_path=" error that the ``data_config`` exit and the
+top-level ``Robot()`` factory give - not a dead-end "Either urdf_path or
+data_config is required" that never names the robot nor points at discovery.
+
+The bare "supply a model source" message is preserved for the genuine no-name
+case (``add_robot()`` with nothing to resolve), and the deprecated positional
+name-as-registry-key short form still resolves a VALID name.
+"""
+
+import os
+
+import pytest
+
+os.environ.setdefault("MUJOCO_GL", "egl")
+
+
+@pytest.fixture
+def world():
+    from strands_robots.simulation.mujoco.simulation import MuJoCoSimEngine
+
+    sim = MuJoCoSimEngine(tool_name="test_add_robot_unknown_model")
+    sim.create_world()
+    yield sim
+    sim.cleanup()
+
+
+def _msg(result):
+    assert result["status"] == "error", f"expected error, got: {result}"
+    return result["content"][0]["text"]
+
+
+class TestUnknownModelMessage:
+    def test_positional_typo_is_actionable(self, world):
+        """A mistyped positional robot name names the robot + offers discovery."""
+        msg = _msg(world.add_robot("panda_typo"))
+        assert "panda_typo" in msg, msg
+        assert "list_urdfs" in msg, msg
+        # dead-end message must NOT be what a named typo gets
+        assert "Either urdf_path or data_config is required" not in msg, msg
+
+    def test_typo_offers_close_match_suggestion(self, world):
+        """A near-miss of a real robot suggests the correct name (difflib)."""
+        msg = _msg(world.add_robot("panda_typo"))
+        assert "panda" in msg, msg  # 'Did you mean: panda, ...'
+
+    def test_instance_label_without_model_points_at_both_options(self, world):
+        """A name given without a model source explains BOTH interpretations:
+        pick a registered model (list_urdfs) OR supply data_config=/urdf_path=."""
+        msg = _msg(world.add_robot(name="myarm"))
+        assert "myarm" in msg, msg
+        assert "list_urdfs" in msg, msg
+        assert "data_config" in msg and "urdf_path" in msg, msg
+
+    def test_no_args_keeps_generic_model_source_message(self, world):
+        """No caller-provided name -> the generic 'supply a model source' error
+        is preserved (the actionable unknown-robot message is name-specific)."""
+        msg = _msg(world.add_robot())
+        assert msg == "Either urdf_path or data_config is required.", msg
+
+    def test_deprecated_positional_valid_name_still_resolves(self, world):
+        """The deprecated name-as-registry-key short form still resolves a VALID
+        name past the unknown-model gate (regression guard on the fallback)."""
+        result = world.add_robot("so100")
+        txt = result["content"][0]["text"] if result.get("content") else ""
+        assert "No model found" not in txt, txt


### PR DESCRIPTION
## Problem

The MuJoCo `add_robot` had two exits with unequal error quality for the same "model can't be resolved" condition:

- `add_robot(data_config="badcfg")` routes through the `_unknown_model_msg` helper -> names the robot, offers difflib close-match suggestions, and points at `list_urdfs`.
- `add_robot("panda_typo")` (a positional name -- the deprecated name-as-registry-key short form) or `add_robot(name="myarm")` (an instance label with no model source) fell through to a **dead-end**:

  ```
  Either urdf_path or data_config is required.
  ```

  which never names the robot, offers no suggestion, and does not point at discovery. This is also inconsistent with the top-level `Robot()` factory, which already raises a clean `Unknown robot 'panda_typo' ... (see list_robots())`. A caller (or an agent) driving the API blind with a mistyped robot name hit a wall.

## Change

Route any caller-supplied `name`/`data_config` that resolves to no model through the existing `_unknown_model_msg` helper, extended with the `data_config=`/`urdf_path=` instance option so the error is actionable whether the name was a mistyped registry key **or** an instance label missing its model:

```
Before: sim.add_robot("panda_typo")
  -> "Either urdf_path or data_config is required."

After:  sim.add_robot("panda_typo")
  -> "No model found for 'panda_typo'. Did you mean: panda, adam_lite, leap_hand?
      Use action='list_urdfs' to see all available robots. Or pass
      data_config=<registered model> or urdf_path=<file> to add 'panda_typo'
      as an instance under that label."
```

The bare `"Either urdf_path or data_config is required."` message is **preserved** for the genuine no-name case (`add_robot()` with nothing to resolve -- an auto-derived label, so no robot name to report). The deprecated positional valid-name fallback (`add_robot("so100")`) still resolves and adds the robot unchanged. Scoped to the MuJoCo backend (the default; Newton resolves models on a separate path where `data_config` is unused for ABC parity).

## Tests

New `tests/simulation/mujoco/test_add_robot_unknown_model_message.py` (GL-free):
- positional typo -> names the robot + `list_urdfs` + not the dead-end message (**fails before, passes after**)
- typo offers a difflib close-match suggestion (`panda`)
- instance-label-without-model -> names the robot + `list_urdfs` + both `data_config`/`urdf_path` options (**fails before, passes after**)
- no-name `add_robot()` -> generic model-source message preserved
- deprecated positional VALID name (`so100`) still resolves past the unknown-model gate

Green locally: 5/5 new tests, 102 neighbouring `add_robot` tests (`test_robot_name_optional`, `test_input_validation`), ruff + ruff-format + mypy clean. CHANGELOG + docstring updated.