### PR TITLE
fix(sim): actionable 'not found' errors for move_object / remove_object / remove_camera

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1491,6 +1491,25 @@ typo and the instance-label cases name the robot + point at `list_urdfs` +
 the model-source options (fails before, passes after), that the no-name case
 keeps the generic message, and that a valid positional name still resolves.
 
+### Fixed: `move_object` / `remove_object` / `remove_camera` give an actionable "not found" error (names the entity, offers a close match, points at discovery)
+
+When called with an unknown entity name, the MuJoCo facade's
+`move_object(name=...)`, `remove_object(name=...)`, and `remove_camera(name=...)`
+returned a dead-end `"Object 'X' not found."` / `"Camera 'X' not found."` -- no
+list of what *is* in the scene and no close-match, forcing an agent driving the
+API blind into a discovery round-trip on every typo. The camera *render* /
+*record* paths already listed `Available: [...]`, and `add_robot` already
+offered a difflib close-match for an unknown model, so these three remove/move
+paths were the inconsistent dead ends. They now return an actionable message
+that keeps the `"<Kind> 'X' not found."` prefix (preserving the consistent error
+shape) and appends a difflib close-match (`Did you mean: cube?`), the available
+names, and the discovery action (`list_objects` / `list_cameras_info`). An
+empty scene points the caller at `add_object` instead of listing nothing.
+Message-only; no change to the success paths or physical behavior. A regression
+test asserts each path names a close match + the discovery action (fails before,
+passes after) with a no-regression guard on the valid move/remove paths.
+
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -858,6 +858,39 @@ class MuJoCoSimEngine(
         msg += " Use action='list_urdfs' to see all available robots."
         return msg
 
+    def _unknown_object_msg(self, requested: str) -> str:
+        """Actionable 'object not found' message: name it, offer a close-match,
+        and point at the discovery surface - consistent with the camera
+        render/record error paths and ``_unknown_model_msg`` (#1299) rather
+        than a dead-end "Object 'X' not found."."""
+        known = list(self._world.objects.keys()) if self._world is not None else []
+        msg = f"Object '{requested}' not found."
+        if known:
+            import difflib
+
+            matches = difflib.get_close_matches(requested, known, n=3, cutoff=0.4)
+            if matches:
+                msg += " Did you mean: " + ", ".join(matches) + "?"
+            msg += f" Available objects: {known}. Use action='list_objects' to see all."
+        else:
+            msg += " No objects in the scene; add one with action='add_object'."
+        return msg
+
+    def _unknown_camera_msg(self, requested: str) -> str:
+        """Actionable 'camera not found' message for ``remove_camera`` - lists the
+        renderable cameras (like the render/record error paths already do) plus a
+        close-match, so a typo is fixable in-place without a discovery round-trip."""
+        known = self._list_camera_names()
+        msg = f"Camera '{requested}' not found."
+        if known:
+            import difflib
+
+            matches = difflib.get_close_matches(requested, known, n=3, cutoff=0.4)
+            if matches:
+                msg += " Did you mean: " + ", ".join(matches) + "?"
+            msg += f" Available: {known}. Use action='list_cameras_info' to see all."
+        return msg
+
     def add_robot(
         self,
         name: str | None = None,
@@ -2177,8 +2210,10 @@ class MuJoCoSimEngine(
         }
 
     def remove_object(self, name: str) -> dict[str, Any]:
-        if self._world is None or name not in self._world.objects:
-            return {"status": "error", "content": [{"text": f"Object '{name}' not found."}]}
+        if self._world is None:
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
+        if name not in self._world.objects:
+            return {"status": "error", "content": [{"text": self._unknown_object_msg(name)}]}
         if err := self._require_no_running_policy("remove_object"):
             return err
         del self._world.objects[name]
@@ -2214,7 +2249,7 @@ class MuJoCoSimEngine(
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         if name not in self._world.objects:
-            return {"status": "error", "content": [{"text": f"Object '{name}' not found."}]}
+            return {"status": "error", "content": [{"text": self._unknown_object_msg(name)}]}
         # Guard: move_object writes qpos + calls mj_forward, racing a running policy.
         if err := self._require_no_running_policy("move_object"):
             return err
@@ -2457,8 +2492,10 @@ class MuJoCoSimEngine(
         from the MjSpec via :func:`SpecBuilder.remove_camera` so future
         renders/compiles no longer see it.
         """
-        if self._world is None or name not in self._world.cameras:
-            return {"status": "error", "content": [{"text": f"Camera '{name}' not found."}]}
+        if self._world is None:
+            return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
+        if name not in self._world.cameras:
+            return {"status": "error", "content": [{"text": self._unknown_camera_msg(name)}]}
         if err := self._require_no_running_policy("remove_camera"):
             return err
         cam = self._world.cameras.pop(name)

--- a/tests/simulation/mujoco/test_missing_entity_error_messages.py
+++ b/tests/simulation/mujoco/test_missing_entity_error_messages.py
@@ -1,0 +1,81 @@
+"""Regression tests: the ``move_object`` / ``remove_object`` / ``remove_camera``
+facade paths return an *actionable* error for an unknown entity instead of a
+dead-end ``"<Kind> 'X' not found."``.
+
+Before this change these three paths returned a bare ``"Object 'X' not found."``
+or ``"Camera 'X' not found."`` with no list of what *is* available and no
+close-match suggestion - forcing an agent driving the API blind into a discovery
+round-trip on every typo. The camera *render*/*record* paths already listed
+``Available: [...]`` and ``add_robot`` (#1299) already offered a difflib
+close-match; these tests pin that the same actionable shape now covers the
+remove/move-by-name paths: the message names the entity, offers a close match,
+lists the available names, and points at the discovery action
+(``list_objects`` / ``list_cameras_info``).
+
+The messages keep the ``"<Kind> 'X' not found."`` prefix so the consistent
+error shape (T15 in ``test_agenttool_contract``) is preserved. GL-free
+(``mesh=False``, no rendering) so it runs in CI without a GPU.
+"""
+
+import pytest
+
+mj = pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="test_missing_entity_msgs_sim", mesh=False)
+    s.create_world(gravity=[0, 0, -9.81])
+    s.add_object("cube", shape="box", size=[0.03, 0.03, 0.03], position=[0.15, -0.12, 0.03], is_static=False)
+    s.add_camera(name="front_cam", position=[0.5, 0.0, 0.35], target=[0.15, 0.0, 0.05])
+    yield s
+    s.cleanup()
+
+
+def _err_text(result):
+    assert result["status"] == "error", result
+    return result["content"][0]["text"]
+
+
+def test_move_object_unknown_is_actionable(sim):
+    text = _err_text(sim.move_object("crube", position=[0.2, -0.1, 0.03]))
+    assert "Object 'crube' not found" in text  # preserved prefix (T15 shape)
+    assert "Did you mean: cube" in text  # close-match
+    assert "cube" in text  # names the available object
+    assert "list_objects" in text  # discovery surface
+
+
+def test_remove_object_unknown_is_actionable(sim):
+    text = _err_text(sim.remove_object("cubee"))
+    assert "Object 'cubee' not found" in text
+    assert "Did you mean: cube" in text
+    assert "list_objects" in text
+
+
+def test_remove_camera_unknown_lists_available_and_suggests(sim):
+    text = _err_text(sim.remove_camera("frnt_cam"))
+    assert "Camera 'frnt_cam' not found" in text
+    assert "Did you mean: front_cam" in text
+    assert "front_cam" in text  # names the available camera
+    assert "list_cameras_info" in text
+
+
+def test_missing_object_in_empty_scene_points_to_add_object():
+    s = Simulation(tool_name="test_missing_entity_empty_sim", mesh=False)
+    s.create_world(gravity=[0, 0, -9.81])
+    try:
+        text = _err_text(s.move_object("cube", position=[0, 0, 0.1]))
+        assert "Object 'cube' not found" in text
+        assert "add_object" in text  # no objects -> point at how to add one
+    finally:
+        s.cleanup()
+
+
+def test_valid_move_and_remove_unaffected(sim):
+    # No-regression guard: the happy paths still succeed and are not intercepted
+    # by the new missing-entity messaging.
+    assert sim.move_object("cube", position=[0.2, -0.1, 0.03])["status"] == "success"
+    assert sim.remove_camera("front_cam")["status"] == "success"
+    assert sim.remove_object("cube")["status"] == "success"


### PR DESCRIPTION
## Problem

When called with an unknown entity name, the MuJoCo facade returned a dead-end error:

```
sim.move_object("crube", ...)   -> "Object 'crube' not found."
sim.remove_object("cubee")       -> "Object 'cubee' not found."
sim.remove_camera("frnt_cam")    -> "Camera 'frnt_cam' not found."
```

No list of what *is* in the scene, no close-match — a caller (human or agent) driving the API by name has to make a `list_objects` / `list_cameras_info` discovery round-trip on every typo.

This is inconsistent with the rest of the surface: the camera **render**/**record** paths already append `Available: [...]`, and `add_robot` (`_unknown_model_msg`) already offers a difflib close-match for an unknown model. These three remove/move-by-name paths were the leftover dead ends.

## Change

All three now keep the `"<Kind> 'X' not found."` prefix (preserving the consistent error shape asserted by `test_agenttool_contract` T15) and append: a difflib close-match, the available names, and the discovery action.

```
move_object("crube")   -> Object 'crube' not found. Did you mean: cube? Available objects: ['cube']. Use action='list_objects' to see all.
remove_camera("frnt_cam") -> Camera 'frnt_cam' not found. Did you mean: front_cam? Available: ['default', 'front_cam']. Use action='list_cameras_info' to see all.
```

An empty scene points the caller at `add_object` instead of listing nothing. `remove_object` / `remove_camera` also now return the standard no-world message when there is no world, matching `move_object` and the rest of the facade (previously they returned a misleading `'X' not found.`).

Message-only: the success paths and all physical behavior are unchanged. Two small shared helpers (`_unknown_object_msg`, `_unknown_camera_msg`) mirror the existing `_unknown_model_msg`.

## Tests

New GL-free regression test `tests/simulation/mujoco/test_missing_entity_error_messages.py`:
- each path names a close match + lists the available names + points at the discovery action (fails before, passes after — 4 fail on the pre-fix code),
- empty-scene branch points at `add_object`,
- a no-regression guard confirms the valid move/remove paths still succeed.

Local gate green: `ruff check` + `ruff format` + `mypy` clean; the touched suites pass (`test_missing_entity_error_messages`, `test_agenttool_contract`, `test_move_object_*`, `test_list_cameras_discovery`, `test_simengine_facade_guardrails`, `test_sim_engine_describe_discovery` — 145 passed).