### PR TITLE
test(training): pin reward-model base_model warm-start into pretrained_path

### DIFF
--- a/tests/training/test_lerobot.py
+++ b/tests/training/test_lerobot.py
@@ -1020,6 +1020,21 @@ class TestRewardModelTraining:
         assert cfg.reward_model.annotation_mode == "single_stage"
         assert cfg.reward_model.image_key == "observation.images.base"
 
+    def test_build_config_forwards_base_model_to_reward_pretrained_path(self, dataset_root, tmp_path):
+        """A reward-model spec's base_model warm-starts cfg.reward_model.pretrained_path.
+
+        A reward model can resume from a pretrained checkpoint the same way a
+        policy does. When TrainSpec.base_model is set on a reward-model run, it
+        must land on cfg.reward_model.pretrained_path so the checkpoint is
+        actually loaded - never silently dropped (which would train from scratch
+        despite the caller asking to warm-start).
+        """
+        pytest.importorskip("lerobot.rewards")
+        spec = self._sarm_spec(dataset_root, tmp_path, image_key="observation.images.base")
+        spec.base_model = "lerobot/sarm_pretrained"
+        cfg = LerobotTrainer(device="cpu").build_config(spec)
+        assert str(cfg.reward_model.pretrained_path) == "lerobot/sarm_pretrained"
+
     def test_build_command_emits_reward_model_flags(self, dataset_root, tmp_path):
         spec = self._sarm_spec(dataset_root, tmp_path, image_key="observation.images.base")
         cmd = LerobotTrainer(device="cpu").build_command(spec)


### PR DESCRIPTION
## Problem

`LerobotTrainer.build_config` forwards `TrainSpec.base_model` onto `cfg.reward_model.pretrained_path` so a reward model (SARM et al.) can warm-start from a pretrained checkpoint the same way a policy does:

```python
if spec.base_model and hasattr(reward_cfg, "pretrained_path"):
    reward_cfg.pretrained_path = spec.base_model
```

This branch was untested. Every existing reward-model test built its spec with an empty `base_model`, so the forwarding line never executed. A refactor could silently drop the warm-start — training a reward model from scratch despite the caller asking to resume — with no test to catch it.

## Change

Add one focused test to `TestRewardModelTraining` that builds a SARM spec with `base_model` set and asserts it lands on `cfg.reward_model.pretrained_path`. Guards the reward-model warm-start contract; complements the existing empty-`base_model` cases.

## Tests

- New: `test_build_config_forwards_base_model_to_reward_pretrained_path` (executes the previously-uncovered forwarding line; `pytest.importorskip("lerobot.rewards")`).
- `tests/training/test_lerobot.py`: 116 passed.
- `ruff check` / `ruff format --check` / `mypy` over `strands_robots tests tests_integ`: clean (no issues in 760 source files).

Test-only; no behavior change.