### PR TITLE
fix(sim): actionable 'Robot X not found' error across the facade (close match + list_robots)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1509,6 +1509,26 @@ Message-only; no change to the success paths or physical behavior. A regression
 test asserts each path names a close match + the discovery action (fails before,
 passes after) with a no-regression guard on the valid move/remove paths.
 
+### Fixed: unknown `robot_name` gives an actionable "not found" error across the sim facade (close match + available robots + `list_robots`)
+
+Every facade method that looks a robot up by name -- `get_robot_state`,
+`set_joint_positions`, `set_joint_velocities`, `remove_robot`, `run_multi_policy`,
+`stop_policy`, `get_features`, `list_bodies` and friends -- returned a dead-end
+`"Robot 'X' not found."` when the name was mistyped: no list of the robots that
+*are* in the world and no close-match, forcing an agent driving the API blind
+into a discovery round-trip on every typo. This was the last remaining bare
+`"... not found."` class after the model (`add_robot`) and object/camera
+(`move_object` / `remove_object` / `remove_camera`) paths were made actionable.
+The ~9 sites now share a single `_unknown_robot_msg` helper that keeps the
+`"Robot 'X' not found."` prefix (preserving the consistent error shape) and
+appends a difflib close-match (`Did you mean: arm1?`), the available robot names,
+and the discovery action (`list_robots`). An empty world points the caller at
+`add_robot` instead of a dead end. Message-only; no change to the success paths
+or physical behavior. A regression test drives both the `simulation.py`
+(`get_robot_state`, `remove_robot`) and `physics.py` (`set_joint_positions`)
+paths and asserts the close-match + available list + discovery action (fails
+before, passes after) with a no-regression guard on a valid robot query.
+
 
 ## [0.4.1] - 2026-07-01
 

--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -156,6 +156,7 @@ class PhysicsMixin:
             self, action_name: str, robot_name: str | None = None
         ) -> dict[str, Any] | None: ...
         def _require_world(self) -> dict[str, Any] | None: ...
+        def _unknown_robot_msg(self, requested: str) -> str: ...
 
     # State Checkpointing
 
@@ -788,7 +789,7 @@ class PhysicsMixin:
             if robot_name is not None:
                 robots = [r for r in robots if r.name == robot_name]
                 if not robots:
-                    return {"status": "error", "content": [{"text": f"Robot '{robot_name}' not found."}]}
+                    return {"status": "error", "content": [{"text": self._unknown_robot_msg(robot_name)}]}
             if len(robots) == 0:
                 return {
                     "status": "error",
@@ -890,7 +891,7 @@ class PhysicsMixin:
             if robot_name is not None:
                 robots = [r for r in robots if r.name == robot_name]
                 if not robots:
-                    return {"status": "error", "content": [{"text": f"Robot '{robot_name}' not found."}]}
+                    return {"status": "error", "content": [{"text": self._unknown_robot_msg(robot_name)}]}
             if len(robots) == 0:
                 return {
                     "status": "error",

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -362,7 +362,7 @@ class MuJoCoSimEngine(
                 return {"status": "error", "content": [{"text": "No robots in the world."}]}
             robot_name = next(iter(self._world.robots))
         if robot_name not in self._world.robots:
-            return {"status": "error", "content": [{"text": f"Robot '{robot_name}' not found."}]}
+            return {"status": "error", "content": [{"text": self._unknown_robot_msg(robot_name)}]}
         action_map, coerce_error = self._coerce_action(action, robot_name)
         if coerce_error is not None:
             return coerce_error
@@ -891,6 +891,25 @@ class MuJoCoSimEngine(
             msg += f" Available: {known}. Use action='list_cameras_info' to see all."
         return msg
 
+    def _unknown_robot_msg(self, requested: str) -> str:
+        """Actionable 'robot not found' message: name it, offer a close-match,
+        and list the robots in the world - consistent with ``_unknown_object_msg`` /
+        ``_unknown_camera_msg`` / ``_unknown_model_msg`` (#1299/#1303) rather than a
+        dead-end "Robot 'X' not found." that forces an agent driving the API blind
+        into a discovery round-trip on every typo."""
+        known = list(self._world.robots.keys()) if self._world is not None else []
+        msg = f"Robot '{requested}' not found."
+        if known:
+            import difflib
+
+            matches = difflib.get_close_matches(requested, known, n=3, cutoff=0.4)
+            if matches:
+                msg += " Did you mean: " + ", ".join(matches) + "?"
+            msg += f" Available robots: {known}. Use action='list_robots' to see all."
+        else:
+            msg += " No robots in the scene; add one with action='add_robot'."
+        return msg
+
     def add_robot(
         self,
         name: str | None = None,
@@ -1265,7 +1284,7 @@ class MuJoCoSimEngine(
         OTHER robot is running a policy.
         """
         if self._world is None or name not in self._world.robots:
-            return {"status": "error", "content": [{"text": f"Robot '{name}' not found."}]}
+            return {"status": "error", "content": [{"text": self._unknown_robot_msg(name)}]}
 
         # Step 1: cooperatively stop THIS robot's policy if running.
         # Has to happen before the global check so remove_robot works even
@@ -1909,7 +1928,7 @@ class MuJoCoSimEngine(
         except ValueError as e:
             return {"status": "error", "content": [{"text": str(e)}]}
         if robot_name not in self._world.robots:
-            return {"status": "error", "content": [{"text": f"Robot '{robot_name}' not found."}]}
+            return {"status": "error", "content": [{"text": self._unknown_robot_msg(robot_name)}]}
 
         mj = self._mj
         robot = self._world.robots[robot_name]
@@ -2879,7 +2898,7 @@ class MuJoCoSimEngine(
 
         if robot_name is not None:
             if robot_name not in self._world.robots:
-                return {"status": "error", "content": [{"text": f"Robot '{robot_name}' not found."}]}
+                return {"status": "error", "content": [{"text": self._unknown_robot_msg(robot_name)}]}
             robot = self._world.robots[robot_name]
             ns = (getattr(robot, "namespace", "") or "").rstrip("/")
             prefix = f"{ns}/" if ns else ""
@@ -3178,7 +3197,7 @@ class MuJoCoSimEngine(
         except ValueError as e:
             return {"status": "error", "content": [{"text": str(e)}]}
         if robot_name not in self._world.robots:
-            return {"status": "error", "content": [{"text": f"Robot '{robot_name}' not found."}]}
+            return {"status": "error", "content": [{"text": self._unknown_robot_msg(robot_name)}]}
 
         # Per-robot gate: another policy running on a DIFFERENT robot is fine.
         if err := self._require_no_running_policy("start_policy", robot_name=robot_name):
@@ -3452,7 +3471,7 @@ class MuJoCoSimEngine(
         # Validate every robot exists.
         for rname in policies:
             if rname not in self._world.robots:
-                return {"status": "error", "content": [{"text": f"Robot '{rname}' not found."}]}
+                return {"status": "error", "content": [{"text": self._unknown_robot_msg(rname)}]}
 
         # Reject if any of these robots already has a running async policy
         # (would double-step physics on that robot).
@@ -3896,7 +3915,7 @@ class MuJoCoSimEngine(
                 "content": [{"text": "stop_policy requires 'robot_name'."}],
             }
         if self._world is None or robot_name not in self._world.robots:
-            return {"status": "error", "content": [{"text": f"Robot '{robot_name}' not found."}]}
+            return {"status": "error", "content": [{"text": self._unknown_robot_msg(robot_name)}]}
         robot = self._world.robots[robot_name]
         was_running = robot.policy_running
         robot.policy_running = False

--- a/tests/simulation/mujoco/test_missing_entity_error_messages.py
+++ b/tests/simulation/mujoco/test_missing_entity_error_messages.py
@@ -1,4 +1,4 @@
-"""Regression tests: the ``move_object`` / ``remove_object`` / ``remove_camera``
+"""Regression tests: the ``move_object`` / ``remove_object`` / ``remove_camera`` / robot-name
 facade paths return an *actionable* error for an unknown entity instead of a
 dead-end ``"<Kind> 'X' not found."``.
 
@@ -10,7 +10,7 @@ round-trip on every typo. The camera *render*/*record* paths already listed
 close-match; these tests pin that the same actionable shape now covers the
 remove/move-by-name paths: the message names the entity, offers a close match,
 lists the available names, and points at the discovery action
-(``list_objects`` / ``list_cameras_info``).
+(``list_objects`` / ``list_cameras_info`` / ``list_robots``).
 
 The messages keep the ``"<Kind> 'X' not found."`` prefix so the consistent
 error shape (T15 in ``test_agenttool_contract``) is preserved. GL-free
@@ -79,3 +79,70 @@ def test_valid_move_and_remove_unaffected(sim):
     assert sim.move_object("cube", position=[0.2, -0.1, 0.03])["status"] == "success"
     assert sim.remove_camera("front_cam")["status"] == "success"
     assert sim.remove_object("cube")["status"] == "success"
+
+
+_ARM_XML = """<mujoco model="ded_arm">
+  <worldbody>
+    <body name="base" pos="0 0 0.1">
+      <geom type="cylinder" size="0.05 0.05"/>
+      <joint name="pan" type="hinge" axis="0 0 1" range="-3.14 3.14"/>
+      <body name="link1" pos="0 0 0.1">
+        <geom type="capsule" size="0.03" fromto="0 0 0 0 0 0.2"/>
+        <joint name="lift" type="hinge" axis="0 1 0" range="-1.57 1.57"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="pan_act" joint="pan" kp="50"/>
+    <position name="lift_act" joint="lift" kp="50"/>
+  </actuator>
+</mujoco>
+"""
+
+
+@pytest.fixture
+def sim_with_robot(tmp_path):
+    """A GL-free world holding one real robot named ``arm1`` (inline MJCF, no
+    downloaded assets) so the populated ``_unknown_robot_msg`` branch (close-match
+    + available-list) is exercised for real."""
+    xml = tmp_path / "ded_arm.xml"
+    xml.write_text(_ARM_XML)
+    s = Simulation(tool_name="test_missing_robot_msgs_sim", mesh=False)
+    s.create_world(gravity=[0, 0, -9.81])
+    assert s.add_robot("arm1", urdf_path=str(xml), position=[0, 0, 0])["status"] == "success"
+    yield s
+    s.cleanup()
+
+
+def test_get_robot_state_unknown_robot_is_actionable(sim_with_robot):
+    # simulation.py facade path (get_robot_state).
+    text = _err_text(sim_with_robot.get_robot_state("armm1"))
+    assert "Robot 'armm1' not found" in text  # preserved prefix (T15 shape)
+    assert "Did you mean: arm1" in text  # difflib close-match
+    assert "arm1" in text  # names the available robot
+    assert "list_robots" in text  # discovery surface
+
+
+def test_set_joint_positions_unknown_robot_is_actionable(sim_with_robot):
+    # physics.py facade path (set_joint_positions) shares the same helper.
+    text = _err_text(sim_with_robot.set_joint_positions([0.0, 0.0], robot_name="armm1"))
+    assert "Robot 'armm1' not found" in text
+    assert "Did you mean: arm1" in text
+    assert "list_robots" in text
+
+
+def test_remove_robot_unknown_in_empty_scene_points_to_add_robot():
+    # No robots in the world -> point at how to add one, not a dead-end.
+    s = Simulation(tool_name="test_missing_robot_empty_sim", mesh=False)
+    s.create_world(gravity=[0, 0, -9.81])
+    try:
+        text = _err_text(s.remove_robot("arm1"))
+        assert "Robot 'arm1' not found" in text
+        assert "add_robot" in text
+    finally:
+        s.cleanup()
+
+
+def test_valid_robot_query_unaffected(sim_with_robot):
+    # No-regression guard: a correct robot name is not intercepted.
+    assert sim_with_robot.get_robot_state("arm1")["status"] == "success"


### PR DESCRIPTION
## Problem

Every MuJoCo facade method that looks a robot up by name -- `get_robot_state`, `set_joint_positions`, `set_joint_velocities`, `remove_robot`, `run_multi_policy`, `stop_policy`, `get_features`, `list_bodies` and friends -- returned a dead-end `"Robot 'X' not found."` when the name was mistyped: no list of the robots that *are* in the world, and no close-match. An agent (or a human) driving the API blind then has to make a discovery round-trip on every typo.

This was the last remaining bare `"... not found."` class. The model path (`add_robot`, #1299) and the object/camera paths (`move_object` / `remove_object` / `remove_camera`, #1303) were already made actionable; the robot-name lookups -- the single most-repeated dead-end (~9 sites across `simulation.py` + `physics.py`) -- were the inconsistent holdout.

## Change

Route all ~9 sites through one shared `_unknown_robot_msg` helper (mirrors the existing `_unknown_object_msg` / `_unknown_camera_msg` / `_unknown_model_msg`). It:

- **keeps the `"Robot 'X' not found."` prefix** so the consistent error shape (T15 in `test_agenttool_contract`) is preserved,
- appends a difflib **close-match** (`Did you mean: arm1?`),
- lists the **available robot names**, and
- points at the **discovery action** (`list_robots`).

An empty world points the caller at `add_robot` instead of a dead end. The helper lives on the engine next to its siblings; `PhysicsMixin` gets the matching `TYPE_CHECKING` stub. Message-only -- success paths and physical behavior are unchanged.

### Before / after
```
Robot 'armm1' not found.
->
Robot 'armm1' not found. Did you mean: arm1? Available robots: ['arm1']. Use action='list_robots' to see all.
```

## Tests

Extends `tests/simulation/mujoco/test_missing_entity_error_messages.py` (the #1303 home) with a GL-free real robot (inline MJCF, no downloaded assets) and drives **both** the `simulation.py` path (`get_robot_state`, `remove_robot`) and the `physics.py` path (`set_joint_positions`). Asserts the close-match + available list + `list_robots`, the empty-world `add_robot` pointer, and a no-regression guard on a valid robot query. Verified fails-before (3 fail on the bare message) / passes-after.

Green gate: `ruff` clean, `mypy` clean on the changed files, `MUJOCO_GL=egl` 159 tests pass across `test_missing_entity_error_messages` + `test_agenttool_contract` (incl the T15 substring contract) + `test_physics`.