### PR TITLE
fix(sim): actionable 'robot not found' on run_policy/eval_policy/evaluate_benchmark

### DIFF
--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -228,6 +228,31 @@ class SimEngine(ABC):
             raise ValueError("No robots registered in the simulation. Add a robot first (add_robot or Robot factory).")
         raise ValueError(f"Multiple robots registered; specify robot_name. Available: {names}")
 
+    def _unknown_robot_msg(self, requested: str) -> str:
+        """Actionable 'robot not found' message for the backend-agnostic facade.
+
+        Keeps the "Robot 'X' not found." prefix (the consistent error shape the
+        concrete backends also emit via their own ``_unknown_robot_msg``), then
+        appends a difflib close-match, the robots currently in the world, and the
+        discovery action so an agent driving the API by name can recover a typo in
+        zero extra calls instead of hitting a dead-end string. Uses the abstract
+        :meth:`list_robots` primitive, so every backend inherits it; the MuJoCo
+        engine overrides with a ``self._world.robots``-backed variant. Mirrors the
+        ``_unknown_object_msg`` / ``_unknown_camera_msg`` pattern (#1299/#1303/#1306).
+        """
+        known = self.list_robots()
+        msg = f"Robot '{requested}' not found."
+        if known:
+            import difflib
+
+            matches = difflib.get_close_matches(requested, known, n=3, cutoff=0.4)
+            if matches:
+                msg += " Did you mean: " + ", ".join(matches) + "?"
+            msg += f" Available robots: {known}. Use action='list_robots' to see all."
+        else:
+            msg += " No robots in the scene; add one with action='add_robot'."
+        return msg
+
     # World lifecycle
 
     @abstractmethod
@@ -960,7 +985,7 @@ class SimEngine(ABC):
         if robot_name not in self.list_robots():
             return {
                 "status": "error",
-                "content": [{"text": f"Robot '{robot_name}' not found."}],
+                "content": [{"text": self._unknown_robot_msg(robot_name)}],
             }
 
         if policy_object is None:
@@ -1644,7 +1669,7 @@ class SimEngine(ABC):
         if resolved_robot not in robots:
             return {
                 "status": "error",
-                "content": [{"text": f"Robot '{resolved_robot}' not found."}],
+                "content": [{"text": self._unknown_robot_msg(resolved_robot)}],
             }
 
         if err := self._validate_action_horizon(action_horizon, "eval_policy"):
@@ -1859,7 +1884,7 @@ class SimEngine(ABC):
         if resolved_robot not in robots:
             return {
                 "status": "error",
-                "content": [{"text": f"Robot '{resolved_robot}' not found. Loaded: {robots}"}],
+                "content": [{"text": self._unknown_robot_msg(resolved_robot)}],
             }
 
         if policy_object is None:

--- a/tests/simulation/test_simengine_facade_guardrails.py
+++ b/tests/simulation/test_simengine_facade_guardrails.py
@@ -358,3 +358,65 @@ def test_get_contacts_not_implemented_on_base_facade():
     """Contact queries require a concrete physics backend to override the hook."""
     with pytest.raises(NotImplementedError, match="get_contacts"):
         FakeSim().get_contacts()
+
+
+# Actionable "robot not found" on the policy-execution sites (#1306 follow-up)
+#
+# run_policy / eval_policy / evaluate_benchmark used to emit a bare
+# "Robot 'X' not found." (or ".. Loaded: [...]") on a mistyped robot_name,
+# unlike the ~9 lookup sites #1306 routed through the backend helper. These pin
+# that all three now surface the close-match + available-list + discovery action
+# via the backend-agnostic SimEngine._unknown_robot_msg helper (list_robots-backed,
+# so every backend inherits it). They fail on the pre-fix bare strings.
+
+
+def test_unknown_robot_msg_offers_close_match_and_discovery_action():
+    """The base helper names the robot, suggests a close match, lists the world,
+    and points at the discovery action - not a dead-end string."""
+    msg = FakeSim(robots=("so100", "so101"))._unknown_robot_msg("so10")
+    assert "Robot 'so10' not found." in msg
+    assert "Did you mean:" in msg and "so100" in msg
+    assert "Available robots:" in msg
+    assert "list_robots" in msg
+
+
+def test_unknown_robot_msg_empty_world_points_at_add_robot():
+    """With no robots, the helper omits the close-match and points at add_robot."""
+    msg = FakeSim(robots=())._unknown_robot_msg("ghost")
+    assert "Robot 'ghost' not found." in msg
+    assert "add_robot" in msg
+    assert "Did you mean" not in msg
+
+
+def test_run_policy_unknown_robot_is_actionable():
+    """run_policy's not-found error carries the close-match + discovery action."""
+    result = FakeSim(robots=("so100",)).run_policy(robot_name="so10", policy_object=MockPolicy())
+    assert result["status"] == "error"
+    text = result["content"][0]["text"]
+    assert "Robot 'so10' not found." in text
+    assert "Did you mean:" in text and "so100" in text
+    assert "list_robots" in text
+
+
+def test_eval_policy_unknown_robot_is_actionable():
+    """eval_policy's not-found error carries the close-match + discovery action."""
+    result = FakeSim(robots=("so100",)).eval_policy(robot_name="so10", policy_object=MockPolicy())
+    assert result["status"] == "error"
+    text = result["content"][0]["text"]
+    assert "Robot 'so10' not found." in text
+    assert "Did you mean:" in text and "so100" in text
+    assert "list_robots" in text
+
+
+def test_evaluate_benchmark_unknown_robot_is_actionable(monkeypatch):
+    """evaluate_benchmark's not-found error carries the close-match + discovery
+    action (replacing the older bare 'Loaded: [...]' tail)."""
+    import strands_robots.simulation.benchmark as bench
+
+    monkeypatch.setattr(bench, "get_benchmark", lambda name: object())
+    result = FakeSim(robots=("so100", "so101")).evaluate_benchmark("any_bench", robot_name="so10")
+    assert result["status"] == "error"
+    text = result["content"][0]["text"]
+    assert "Robot 'so10' not found." in text
+    assert "Did you mean:" in text and "so100" in text
+    assert "list_robots" in text


### PR DESCRIPTION
## Summary

The three policy-execution entry points on the `SimEngine` facade
(`run_policy`, `eval_policy`, `evaluate_benchmark`) still returned a bare
`Robot 'X' not found.` on a mistyped `robot_name` (`evaluate_benchmark` appended
a raw `Loaded: [...]` tail). This was the last bare not-found class after #1306
routed the ~9 lookup sites (`get_robot_state`, `set_joint_positions`, ...) through
a backend helper. An agent driving the API by name hit a dead-end string in these
exact spots: no close-match, no discovery action on a typo.

## Change

- Add a **backend-agnostic** `_unknown_robot_msg` on `SimEngine`, built on the
  abstract `list_robots()` primitive so every backend inherits it. It keeps the
  `Robot 'X' not found.` prefix (consistent error shape), then appends a difflib
  close-match, the robots currently in the world, and the `list_robots` discovery
  action; an empty world points at `add_robot`. Mirrors the
  `_unknown_object_msg` / `_unknown_camera_msg` pattern (#1299/#1303/#1306).
- The MuJoCo engine keeps its richer `self._world.robots`-backed override
  (natural method resolution; no conflict).
- Route all three facade sites through the helper.

**Message-only.** Resolution logic, success paths, and physics are unchanged.
`evaluate_benchmark`'s error goes from `... not found. Loaded: [...]` to the
strictly-richer helper output (close-match + available list + discovery action).

## Testing

Added 5 regression tests in `test_simengine_facade_guardrails.py` (pure-Python
`FakeSim`, no MuJoCo/GPU):
- helper directly, populated world -> close-match + available list + `list_robots`
- helper directly, empty world -> points at `add_robot`, no close-match
- `run_policy` / `eval_policy` / `evaluate_benchmark` unknown-robot errors are actionable

All 5 **fail on pre-fix code** (bare strings / missing helper) and pass after.
Full `test_simengine_facade_guardrails.py` suite: 28 passed. `ruff check` +
`ruff format --check` clean. Diff is pure ASCII.

## §13 Changelog

- Round 1: initial implementation (helper + 3 site routings + 5 pinned regression tests).