### PR TITLE
test(sim): cover action-by-name feedback edge cases (degenerate ctrlrange, stale actuator id, prefixed valid-key hint)

### DIFF
--- a/tests/simulation/mujoco/test_ctrl_clamp_warning.py
+++ b/tests/simulation/mujoco/test_ctrl_clamp_warning.py
@@ -107,3 +107,37 @@ def test_warn_once_dedup(model, caplog):
         _apply(model, {"grip_act": 0.8}, mixin)
     hits = [r for r in caplog.records if "grip_act" in r.getMessage() and "ctrlrange" in r.getMessage()]
     assert len(hits) == 1, f"expected exactly one dedup'd warning, got {len(hits)}"
+
+
+def test_no_warning_for_degenerate_ctrlrange(model, caplog):
+    """A ctrl-limited actuator whose range is degenerate ([v, v]) never clamps
+    meaningfully, so an out-of-range command must not warn.
+
+    A ``[0, 0]`` (or any ``lo >= hi``) ctrlrange is a sentinel, not a real
+    limit: MuJoCo would pin every command to the single point, but the warning
+    is about *unit mismatch*, not about a legitimately degenerate actuator.
+    Emitting it here would be noise. The range is forced on the compiled model
+    (the MJCF compiler auto-clears ``ctrllimited`` for a zero range) to mirror
+    the sentinel state seen in the wild.
+    """
+    grip_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, "grip_act")
+    model.actuator_ctrlrange[grip_id] = [5.0, 5.0]
+    model.actuator_ctrllimited[grip_id] = 1
+    with caplog.at_level(logging.WARNING, logger=_LOGGER):
+        _apply(model, {"grip_act": 100.0})
+    assert not [r for r in caplog.records if "grip_act" in r.getMessage() and "ctrlrange" in r.getMessage()]
+
+
+def test_no_crash_for_stale_actuator_id(model, caplog):
+    """A stale/out-of-range actuator id must be swallowed, not crash the loop.
+
+    After a scene recompile an actuator id can outlive the model it indexed
+    (fewer actuators than before). Indexing ``actuator_ctrllimited`` with it
+    raises ``IndexError``; the 50Hz control loop must survive that -- the warn
+    is best-effort diagnostics, never a hard dependency. No warning is emitted
+    and no exception escapes.
+    """
+    mixin = RenderingMixin()
+    with caplog.at_level(logging.WARNING, logger=_LOGGER):
+        mixin._warn_ctrl_clamp(model, model.nu + 99, "", "grip_act", 100.0, mujoco)
+    assert not [r for r in caplog.records if "ctrlrange" in r.getMessage()]

--- a/tests/simulation/mujoco/test_robot_action_keys.py
+++ b/tests/simulation/mujoco/test_robot_action_keys.py
@@ -135,3 +135,62 @@ class TestRobotActionKeysDefault:
 
     def test_missing_robot_returns_empty(self, sim):
         assert sim.robot_action_keys("does_not_exist") == []
+
+
+class TestValidActionKeyHint:
+    """The valid-key hint shown when an action key is dropped must return the
+    short (prefix-stripped) form callers pass to ``send_action``.
+
+    When a key cannot be applied, ``_warn_unresolved_action_key`` surfaces the
+    actuators the scene accepts via ``_get_valid_action_keys(pfx)``. In a
+    multi-robot world actuators are namespaced (``armA/shoulder``); the hint
+    must strip the active robot's prefix so the operator sees exactly the keys
+    ``send_action`` expects, not the internal fully-qualified names. Unnamed
+    actuators have no addressable key and are omitted from the hint.
+    """
+
+    _XML = """
+    <mujoco>
+      <worldbody>
+        <body name="l">
+          <joint name="j1" type="hinge" axis="0 0 1"/>
+          <geom type="box" size="0.02 0.02 0.02"/>
+          <body name="l2" pos="0 0 0.1">
+            <joint name="j2" type="hinge" axis="0 1 0"/>
+            <geom type="box" size="0.02 0.02 0.02"/>
+            <body name="l3" pos="0 0 0.1">
+              <joint name="j3" type="hinge" axis="1 0 0"/>
+              <geom type="box" size="0.02 0.02 0.02"/>
+            </body>
+          </body>
+        </body>
+      </worldbody>
+      <actuator>
+        <position name="armA/shoulder" joint="j1"/>
+        <position name="armA/elbow" joint="j2"/>
+        <position joint="j3"/>
+      </actuator>
+    </mujoco>
+    """
+
+    def _mixin(self):
+        import mujoco
+
+        from strands_robots.simulation.mujoco.rendering import RenderingMixin
+
+        model = mujoco.MjModel.from_xml_string(self._XML)
+
+        class _World:
+            _model = model
+
+        mixin = RenderingMixin()
+        mixin._world = _World()
+        return mixin
+
+    def test_prefix_is_stripped_for_matching_robot(self):
+        """A robot prefix yields the short keys send_action resolves."""
+        assert self._mixin()._get_valid_action_keys("armA/") == ["shoulder", "elbow"]
+
+    def test_no_prefix_returns_fully_qualified_names(self):
+        """Without a prefix the raw namespaced actuator names are returned."""
+        assert self._mixin()._get_valid_action_keys("") == ["armA/shoulder", "armA/elbow"]


### PR DESCRIPTION
## Problem

The MuJoCo backend gives an agent driving actuators *by name* two feedback surfaces: `_warn_ctrl_clamp` (warns once when a value written to a ctrl-limited actuator falls outside its `ctrlrange`, so silent MuJoCo clamping of mismatched action units is surfaced) and `_get_valid_action_keys` (lists the actuators a scene accepts, used to build the hint shown when a key is dropped). Their happy paths are tested, but three defensive/observability branches were not, leaving real robustness guarantees unpinned:

1. **Degenerate `ctrlrange`** (`lo >= hi`, e.g. a `[0, 0]` sentinel): the clamp warning is about unit mismatch, not about a legitimately degenerate actuator, so it must stay quiet here.
2. **Stale/out-of-range actuator id**: after a scene recompile an actuator id can outlive the model it indexed. Indexing `actuator_ctrllimited` with it raises `IndexError`; the 50Hz control loop must survive that since the warning is best-effort diagnostics, never a hard dependency.
3. **Prefixed valid-key hint**: in a multi-robot world actuators are namespaced (`armA/shoulder`). The hint must strip the active robot's prefix so the operator sees exactly the short keys `send_action` expects, and unnamed actuators (no addressable key) must be omitted.

## Change

Tests only, no production changes.

- `tests/simulation/mujoco/test_ctrl_clamp_warning.py`: add `test_no_warning_for_degenerate_ctrlrange` and `test_no_crash_for_stale_actuator_id`.
- `tests/simulation/mujoco/test_robot_action_keys.py`: add `TestValidActionKeyHint` covering prefix stripping, fully-qualified passthrough with no prefix, and omission of unnamed actuators.

These exercise the previously-uncovered branches of `RenderingMixin._warn_ctrl_clamp` (the `except (IndexError, TypeError, ValueError)` guard and the `hi <= lo` early return) and `RenderingMixin._get_valid_action_keys` (prefix-strip, no-prefix, and unnamed-skip paths).

## Verification

- New tests pass; targeted lines that were uncovered on `main` are now covered.
- Full `tests/simulation/mujoco/` suite green: 1208 passed, 1 skipped (`MUJOCO_GL=egl`).
- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` all clean.

Synthetic in-memory MJCF models only, no asset downloads.