### PR TITLE
test(sim): deterministically cover start_recording lerobot-unavailable error contract

### DIFF
--- a/tests/simulation/mujoco/test_recording_backends.py
+++ b/tests/simulation/mujoco/test_recording_backends.py
@@ -9,7 +9,6 @@
 
 from __future__ import annotations
 
-import importlib.util
 import os
 
 import pytest
@@ -24,8 +23,6 @@ requires_gl = pytest.mark.skipif(
 )
 from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
 
-has_lerobot = importlib.util.find_spec("lerobot") is not None
-
 
 @pytest.fixture
 def sim():
@@ -36,8 +33,40 @@ def sim():
 
 
 class TestStartRecordingErrorWithoutLerobot:
-    @pytest.mark.skipif(has_lerobot, reason="test targets the no-lerobot code path")
-    def test_error_message_points_to_start_cameras_recording(self, sim):
+    """start_recording must degrade to an actionable structured error - never a
+    raw ImportError traceback - when the [lerobot] extra is unavailable.
+
+    Both failure modes are exercised deterministically (independent of whether
+    lerobot happens to be installed in the test environment) because the
+    contract must hold in every environment:
+
+    * the extra is cleanly absent (``has_lerobot_dataset()`` returns False), and
+    * a partial/broken install where importing ``DatasetRecorder`` itself
+      raises ImportError (e.g. lerobot-from-source API drift).
+
+    Previously this was guarded by ``skipif(has_lerobot)``, so with lerobot
+    installed the whole error contract went untested and the ImportError
+    fallback was never covered.
+    """
+
+    def test_extra_absent_points_to_start_cameras_recording(self, sim, monkeypatch):
+        import strands_robots.dataset_recorder as dr
+
+        monkeypatch.setattr(dr, "has_lerobot_dataset", lambda: False)
+        result = sim.start_recording(repo_id="local/test_rec")
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert "start_cameras_recording" in text
+        assert "lerobot" in text.lower()
+
+    def test_broken_import_falls_through_to_structured_error(self, sim, monkeypatch):
+        import strands_robots.dataset_recorder as dr
+
+        # Simulate a partial/broken lerobot install: the symbol is gone, so the
+        # in-function ``from ... import DatasetRecorder`` raises ImportError,
+        # which must be swallowed into the same actionable error rather than
+        # propagating a traceback out of the tool call.
+        monkeypatch.delattr(dr, "DatasetRecorder", raising=False)
         result = sim.start_recording(repo_id="local/test_rec")
         assert result["status"] == "error"
         text = result["content"][0]["text"]


### PR DESCRIPTION
## Problem

`Simulation.start_recording` produces a LeRobotDataset and requires the `[lerobot]` extra. When that extra is unavailable it must degrade to an actionable structured error (pointing at `start_cameras_recording` for plain MP4 and at the `[lerobot]` extra for dataset recording) rather than propagating a raw `ImportError` traceback out of the tool call.

That contract was only exercised by a test guarded with `@pytest.mark.skipif(has_lerobot, ...)`. In the default CI/dev environment lerobot **is** installed, so the test was always skipped and the entire error path went untested. In particular the backend's `except ImportError` fallback in `start_recording` was uncovered:

```
strands_robots/simulation/mujoco/recording.py   104   3   97%   123-124, 234
```

Lines 123-124 are the `except ImportError: pass` fallback that guards against a partial/broken lerobot install (a realistic failure mode with lerobot-from-source API drift).

## Change

Replace the environment-dependent skip with two deterministic monkeypatch tests that hold in **every** environment regardless of whether lerobot is installed:

- `test_extra_absent_points_to_start_cameras_recording` — patches `has_lerobot_dataset()` to return `False` (extra cleanly absent).
- `test_broken_import_falls_through_to_structured_error` — `monkeypatch.delattr` removes `DatasetRecorder` so the in-function `from ... import DatasetRecorder` raises `ImportError`, exercising the fallback.

Both assert the tool returns `status == "error"` with a message pointing at `start_cameras_recording` and mentioning `lerobot`, never a traceback. This matches the deterministic pattern already used by the Newton backend's recording guard test.

## Coverage

`strands_robots/simulation/mujoco/recording.py`: lines 123-124 go from uncovered to covered; the `start_recording` lerobot-unavailable error contract is now verified in all environments instead of only when lerobot happens to be absent.

## Tests

`MUJOCO_GL=egl python -m pytest tests/simulation/mujoco/test_recording_backends.py` — 3 passed. Full mujoco recording group (`+ test_recording_paths.py`) — 30 passed. `ruff check`, `ruff format --check`, and `mypy` all clean.