### PR TITLE
test(mesh): exercise malformed-payload drop in response + estop wire handlers

### DIFF
--- a/tests/mesh/test_wire_handler_malformed_payload_dropped.py
+++ b/tests/mesh/test_wire_handler_malformed_payload_dropped.py
@@ -1,0 +1,100 @@
+"""Regression tests: the response + safety-estop wire handlers DROP a
+malformed or non-dict payload at runtime without crashing or acting on it.
+
+Wire authentication (mTLS + ACL) only proves a sample came from a fleet
+member; it does not prove the *body* is well-formed. A CA-signed but buggy
+(or hostile) peer can publish non-JSON bytes or a valid-JSON-but-non-dict
+body (a bare list / number / string) on ``strands/response`` or
+``strands/safety/estop``. Both handlers guard this with
+
+    try:
+        data = json.loads(sample.payload.to_bytes().decode())
+    except (AttributeError, UnicodeDecodeError, json.JSONDecodeError):
+        return
+    if not isinstance(data, dict):
+        return
+
+so a malformed body is dropped silently rather than raising out of the Zenoh
+callback (which runs on a transport thread) or being acted upon.
+
+``tests/mesh/test_wire_handler_narrow_except.py`` pins the *source shape* of
+that guard (the narrow exception tuple); these tests pin its *runtime
+behavior*: the drop branches were previously unexercised, so removing either
+guard leaves the tests green there while reintroducing a crash-on-hostile-input
+here. Pre-fix verification -- delete the ``except``/``not isinstance`` return
+in ``_on_response`` or ``_on_safety_estop``:
+
+* non-JSON body -> ``json.JSONDecodeError`` escapes the handler,
+* JSON list body -> ``AttributeError`` from ``[...].get(...)`` escapes,
+
+and every test below fails.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from strands_robots.mesh import Mesh
+
+
+class _FakeRobot:
+    """Minimal duck-typed robot; dispatch is never reached in these tests."""
+
+    def __init__(self) -> None:
+        self.tool_name_str = "fakebot"
+
+
+def _sample(raw: bytes) -> Any:
+    """A fake zenoh sample whose payload decodes to ``raw`` bytes."""
+    sample = MagicMock()
+    sample.payload.to_bytes.return_value = raw
+    return sample
+
+
+# Two flavours of malformed body, one per guard branch:
+#   * non-JSON text   -> the ``except (... json.JSONDecodeError)`` return
+#   * valid JSON list -> the ``if not isinstance(data, dict)`` return
+_MALFORMED = {
+    "non_json": b"{not valid json",
+    "json_non_dict": json.dumps([1, 2, 3]).encode(),
+}
+
+
+@pytest.fixture
+def mesh() -> Mesh:
+    """A Mesh instance (not started -- handlers are driven directly)."""
+    return Mesh(_FakeRobot(), peer_id="peer-a", peer_type="robot")
+
+
+@pytest.mark.parametrize("flavour", sorted(_MALFORMED))
+def test_on_response_drops_malformed_body(mesh: Mesh, flavour: str) -> None:
+    """A malformed response body is dropped: no crash, waiter untouched, nothing recorded."""
+    turn = "turn-1"
+    event = threading.Event()
+    with mesh._rpc_lock:
+        mesh._pending[turn] = event
+        mesh._responses[turn] = []
+        mesh._expected_responders[turn] = "peer-b"
+
+    # Must not raise out of the transport callback.
+    mesh._on_response(_sample(_MALFORMED[flavour]))
+
+    with mesh._rpc_lock:
+        assert mesh._responses[turn] == []
+    assert not event.is_set()
+
+
+@pytest.mark.parametrize("flavour", sorted(_MALFORMED))
+def test_on_safety_estop_drops_malformed_body(mesh: Mesh, flavour: str) -> None:
+    """A malformed estop body is dropped: no crash and the local lockout stays clear."""
+    assert not mesh._estop_lockout.is_set()
+
+    # Must not raise, and must not engage the emergency-stop lockout.
+    mesh._on_safety_estop(_sample(_MALFORMED[flavour]))
+
+    assert not mesh._estop_lockout.is_set()


### PR DESCRIPTION
## Problem

The five mesh Zenoh wire-input handlers (`_on_cmd`, `_on_response`, `_on_safety_estop`, `_on_safety_resume`, `_on_presence` in `strands_robots/mesh/core.py`) all guard their body parse with the same shape:

```python
try:
    data = json.loads(sample.payload.to_bytes().decode())
except (AttributeError, UnicodeDecodeError, json.JSONDecodeError):
    return
if not isinstance(data, dict):
    return
```

Wire authentication (mTLS + ACL) only proves a sample came from a fleet member; it does not prove the body is well-formed. A CA-signed but buggy (or hostile) peer can publish non-JSON bytes or a valid-JSON-but-non-dict body (a bare list / number / string). The guard drops such bodies without raising out of the transport-thread callback or acting on them.

`tests/mesh/test_wire_handler_narrow_except.py` pins the *source shape* of that guard (the narrow exception tuple via `inspect.getsource`), but nothing drove a malformed sample through the handlers at runtime. For `_on_response` and `_on_safety_estop` the drop branches were entirely unexercised, so a future refactor could remove a guard, keep the source-inspection test green, and silently reintroduce a crash-on-hostile-input on the transport thread.

## Change

Add `tests/mesh/test_wire_handler_malformed_payload_dropped.py` with four focused runtime tests (test-only; no production change): a non-JSON body and a JSON-list body for each of `_on_response` and `_on_safety_estop`. Each asserts *behavior*, not internals:

- the handler does not raise out of the callback;
- `_on_response`: the pending turn's waiter is not released and nothing is recorded for the turn;
- `_on_safety_estop`: the local emergency-stop lockout stays clear.

Handlers are driven directly with a fake sample (the existing pattern from `test_response_hijack_rejection.py`), so no zenoh session is required.

## Verification

- Pre-fix (delete the `except`/`not isinstance` returns in either handler): all four fail — `UnboundLocalError` for the non-JSON body (`data` never bound) and `AttributeError: 'list' object has no attribute 'get'` for the JSON-list body. With the guards in place: 4 passed.
- Coverage: `mesh/core.py` lines 1797-1800 (`_on_response`) and 1885-1888 (`_on_safety_estop`) — previously uncovered — are now exercised (46 -> 40 missing lines).
- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ`: clean.
- Full `tests/mesh/` suite (`MUJOCO_GL=egl`): 2070 passed, 3 skipped.