### PR TITLE
test(doctor): pin environment-dependent diagnostic branches

### DIFF
--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -284,6 +284,20 @@ class TestDoctorDegradedPaths:
         result = check_cuda()
         assert "  WARN  " in result
 
+    def test_cuda_cpu_only_build_warns(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A CPU-only torch build (no ``torch.version.cuda``) is diagnosed as a
+        WARN pointing at the CUDA-enabled install, distinct from a CUDA build
+        whose runtime is merely unavailable."""
+        import torch
+
+        from strands_robots.doctor import check_cuda
+
+        monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+        monkeypatch.setattr(torch.version, "cuda", None, raising=False)
+        result = check_cuda()
+        assert "  WARN  " in result
+        assert "CPU-only" in result
+
     def test_sim_smoke_empty_observation_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
         import strands_robots
         from strands_robots.doctor import check_sim_smoke
@@ -418,6 +432,25 @@ class TestDoctorSerialPermissions:
         result = check_serial_permissions()
         assert "  PASS  " in result
 
+    def test_in_dialout_accessible_device_passes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """User in dialout with a readable/writable serial device passes and
+        names the device - the fully-healthy hardware verdict."""
+        import grp
+        import os
+        import platform
+        from pathlib import Path
+
+        from strands_robots.doctor import check_serial_permissions
+
+        monkeypatch.setattr(platform, "system", lambda: "Linux")
+        monkeypatch.setenv("USER", "robotuser")
+        monkeypatch.setattr(grp, "getgrnam", lambda _n: self._fake_group(["robotuser"], gid=20))
+        monkeypatch.setattr(Path, "glob", lambda self, pat: iter([Path("/dev/ttyACM0")]) if "ACM" in pat else iter([]))
+        monkeypatch.setattr(os, "access", lambda _p, _m: True)
+        result = check_serial_permissions()
+        assert "  PASS  " in result
+        assert "/dev/ttyACM0" in result
+
     def test_in_dialout_device_not_accessible_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
         import grp
         import os
@@ -499,3 +532,21 @@ class TestDoctorVersionResolution:
 
         # Neither an installed distribution nor an importable module exists.
         assert _resolve_version("strands_robots_nope_xyz", "strands-robots-nope-xyz") == "unknown"
+
+    def test_resolve_version_falls_back_to_module_attribute(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When distribution metadata is absent but the module is importable, the
+        version comes from the module's ``__version__`` attribute (source-tree
+        install path)."""
+        import importlib
+        import importlib.metadata
+        import types
+
+        from strands_robots.doctor import _resolve_version
+
+        def _no_metadata(_dist: str) -> str:
+            raise importlib.metadata.PackageNotFoundError(_dist)
+
+        fake_module = types.SimpleNamespace(__version__="9.9.9-src")
+        monkeypatch.setattr(importlib.metadata, "version", _no_metadata)
+        monkeypatch.setattr(importlib, "import_module", lambda _name: fake_module)
+        assert _resolve_version("some_module", "some-dist") == "9.9.9-src"

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -538,15 +538,15 @@ class TestDoctorVersionResolution:
         version comes from the module's ``__version__`` attribute (source-tree
         install path)."""
         import importlib
-        import importlib.metadata
         import types
+        from importlib import metadata
 
         from strands_robots.doctor import _resolve_version
 
         def _no_metadata(_dist: str) -> str:
-            raise importlib.metadata.PackageNotFoundError(_dist)
+            raise metadata.PackageNotFoundError(_dist)
 
         fake_module = types.SimpleNamespace(__version__="9.9.9-src")
-        monkeypatch.setattr(importlib.metadata, "version", _no_metadata)
+        monkeypatch.setattr(metadata, "version", _no_metadata)
         monkeypatch.setattr(importlib, "import_module", lambda _name: fake_module)
         assert _resolve_version("some_module", "some-dist") == "9.9.9-src"

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -538,15 +538,15 @@ class TestDoctorVersionResolution:
         version comes from the module's ``__version__`` attribute (source-tree
         install path)."""
         import importlib
+        import importlib.metadata
         import types
-        from importlib import metadata
 
         from strands_robots.doctor import _resolve_version
 
         def _no_metadata(_dist: str) -> str:
-            raise metadata.PackageNotFoundError(_dist)
+            raise importlib.metadata.PackageNotFoundError(_dist)
 
         fake_module = types.SimpleNamespace(__version__="9.9.9-src")
-        monkeypatch.setattr(metadata, "version", _no_metadata)
+        monkeypatch.setattr(importlib.metadata, "version", _no_metadata)
         monkeypatch.setattr(importlib, "import_module", lambda _name: fake_module)
         assert _resolve_version("some_module", "some-dist") == "9.9.9-src"


### PR DESCRIPTION
## What
`strands_robots doctor` had three verdict branches that a typical dev/CI host can never organically reach, so they were the only uncovered lines in `doctor.py` (98%). This adds three focused, isolated tests that mock the environment to pin those verdicts, taking the module to 99% (the sole remaining line is the `__main__` guard).

## Branches pinned
- **`check_cuda` CPU-only torch build** — when `torch.cuda.is_available()` is `False` and `torch.version.cuda is None`, the check must WARN with the CUDA-enabled-install hint, distinct from the existing 'CUDA build present but runtime unavailable' WARN. Hosts either ship a CUDA build or no torch, so this middle case was never exercised.
- **`check_serial_permissions` fully-healthy path** — user in `dialout` with a readable/writable serial device must PASS and name the device. Existing tests cover no-device (PASS) and device-not-accessible (FAIL) but not the accessible-device PASS.
- **`_resolve_version` module-attribute fallback** — when distribution metadata is absent (`PackageNotFoundError`) but the module is importable, the version comes from the module's `__version__` (source-tree install path). Existing tests cover the metadata-present and fully-absent paths, not this middle fallback.

## Testing
- `mypy strands_robots tests tests_integ`: clean (no issues, 762 files).
- `ruff check` / `ruff format --check`: clean.
- `MUJOCO_GL=egl pytest tests/test_doctor.py`: 44 passed.
- Coverage: `strands_robots/doctor.py` 98% -> 99%; lines 94, 168, 210 now covered.

Tests only; no source change.

---

### Round 2 changes
- Resolved a static-analysis flag on `test_resolve_version_falls_back_to_module_attribute`: `importlib.metadata` was imported via both `import importlib.metadata` and (in sibling tests) `from importlib.metadata import version`, mixing import styles for the same module. Switched to `from importlib import metadata` so access is consistent with the file's import-from convention, keeping the plain `import importlib` needed to monkeypatch `import_module`.
- No behavioral change; `TestDoctorVersionResolution` still passes 5/5, ruff check/format clean.

### Round 3 changes
- Follow-up to the round 2 fix: switching that test to `from importlib import metadata` left the `importlib` module itself imported with both styles in the same function (`import importlib` + `from importlib import metadata`), surfacing a second mixed-import static-analysis finding on `importlib`.
- Unified to pure `import`-style: `import importlib` + `import importlib.metadata`, referencing `importlib.metadata.PackageNotFoundError` / `.version` directly. `importlib.metadata` is the same singleton module object as the prior `metadata` alias, so the `monkeypatch.setattr` targets the identical attribute the SUT reads at call time — behavior is unchanged.
- `TestDoctorVersionResolution` still passes 5/5 (3/3 for the version-resolution subset run directly); `ruff check` clean, import order isort-compliant.