### PR TITLE
test(sim): pin synchronous recorder no-op-after-stop + undecodable-frame branches

### DIFF
--- a/tests/simulation/mujoco/test_recording_synchronous.py
+++ b/tests/simulation/mujoco/test_recording_synchronous.py
@@ -305,6 +305,72 @@ class TestStartCamerasRecordingSynchronous:
         finally:
             sim.destroy()
 
+    def test_on_frame_after_finalize_is_noop(self):
+        """A straggler ``on_frame`` call that arrives after the recording has
+        been finalized must be a silent no-op: no render, no buffered frame,
+        no error increment, no exception.
+
+        The eval loop drives ``on_frame`` from the control thread while the
+        recorder can be stopped from another path (``finalize`` /
+        ``stop_cameras_recording``). Finalize flips ``state["running"]`` to
+        False, so the very next ``on_frame`` invocation must short-circuit
+        before touching the (now flushed) buffers. Pinned so a refactor that
+        drops the running-flag guard can't resurrect writes into a closed
+        recording.
+        """
+        sim = _make_sim_with_fake_render()
+        try:
+            result = sim.start_cameras_recording_synchronous(cameras=["cam_a"], fps=15, name="t_noop")
+            json_block = next(c["json"] for c in result["content"] if "json" in c)
+            on_frame = json_block["on_frame"]
+            finalize = json_block["finalize"]
+
+            for step in range(3):
+                on_frame(step, {}, {})
+            assert len(sim._test_render_calls) == 3
+
+            final = finalize()
+            assert final["status"] == "success", final
+
+            # Recording is stopped; a late frame must not render or mutate state.
+            on_frame(99, {}, {})
+            assert len(sim._test_render_calls) == 3, "on_frame after finalize must not render"
+        finally:
+            sim.destroy()
+
+    def test_on_frame_counts_undecodable_render_as_error(self):
+        """A render that returns *successfully* but carries no decodable image
+        must be counted as an error, not buffered as a frame.
+
+        This is distinct from the exception path: ``render`` does not raise,
+        but ``_extract_frame_ndarray`` returns ``None`` (an error-status dict,
+        a content block with no image payload, or PNG bytes that fail to
+        decode). The recorder increments ``state["errors"][cam]`` and skips
+        the frame so a silently-broken camera surfaces in the error tally
+        instead of masquerading as captured frames.
+        """
+        sim = _make_sim_with_fake_render()
+        try:
+
+            def _imageless_render(camera_name: str, width: int | None = None, height: int | None = None, **_kw):
+                # Valid result shape, but no image block -> _extract_frame_ndarray
+                # returns None without raising.
+                return {"status": "success", "content": [{"text": "no frame available"}]}
+
+            sim.render = _imageless_render  # type: ignore[assignment,method-assign]
+
+            result = sim.start_cameras_recording_synchronous(cameras=["cam_a"], fps=15, name="t_noimg")
+            on_frame = next(c["json"] for c in result["content"] if "json" in c)["on_frame"]
+
+            for step in range(5):
+                on_frame(step, {}, {})
+
+            state = sim._cams_rec_state
+            assert len(state["buffers"]["cam_a"]) == 0, "undecodable renders must not be buffered"
+            assert state["errors"]["cam_a"] == 5, "each undecodable render must increment the error tally"
+        finally:
+            sim.destroy()
+
     def test_already_recording_returns_error(self):
         """Concurrent recordings (sync vs daemon, or sync vs sync) are
         rejected. Caller must explicitly stop the active recording first.


### PR DESCRIPTION
## What
Adds two focused regression tests for the synchronous camera recorder's per-frame closure (`Simulation.start_cameras_recording_synchronous`), covering two branches that were previously untested.

## Why
The `_on_frame` closure had two live-but-unpinned branches:

1. **No-op after stop** - a straggler `on_frame` call arriving after the recording is finalized must short-circuit on the running flag: no render, no buffered frame, no error increment, no exception. The eval loop drives `on_frame` from the control thread while the recorder can be stopped from another path, so a late frame into a closed recording must be a silent no-op.
2. **Undecodable render counted as error** - a render that returns *successfully* but carries no decodable image (an error-status dict, a content block with no image payload, or PNG bytes that fail to decode) must increment `state["errors"][cam]` and skip the frame. This is distinct from the existing exception-path test: `render` does not raise, but `_extract_frame_ndarray` returns `None`. Without this pin, a silently-broken camera could masquerade as captured frames.

## Tests
- `test_on_frame_after_finalize_is_noop`
- `test_on_frame_counts_undecodable_render_as_error`

Both use the existing GL-free fixture (`render` monkey-patched on the instance), so they run headless. Full module: `17 passed`. Lint (ruff check + format) and mypy clean on `strands_robots tests tests_integ`.

No production change - test-only.