### PR TITLE
test(train): pin drop of training session whose PID vanishes mid-probe

### DIFF
--- a/tests/tools/test_lerobot_train.py
+++ b/tests/tools/test_lerobot_train.py
@@ -391,8 +391,8 @@ def test_session_manager_retains_finished_session_with_dead_pid(tmp_path: Path) 
 @pytest.mark.parametrize(
     "exc_factory",
     [
-        pytest.param(lambda pid: train_mod.psutil.NoSuchProcess(pid), id="no-such-process"),
-        pytest.param(lambda pid: train_mod.psutil.AccessDenied(pid), id="access-denied"),
+        pytest.param(train_mod.psutil.NoSuchProcess, id="no-such-process"),
+        pytest.param(train_mod.psutil.AccessDenied, id="access-denied"),
     ],
 )
 def test_session_with_pid_that_vanishes_mid_probe_is_dropped(monkeypatch: pytest.MonkeyPatch, exc_factory: Any) -> None:

--- a/tests/tools/test_lerobot_train.py
+++ b/tests/tools/test_lerobot_train.py
@@ -388,6 +388,45 @@ def test_session_manager_retains_finished_session_with_dead_pid(tmp_path: Path) 
     assert "done" in sessions
 
 
+@pytest.mark.parametrize(
+    "exc_factory",
+    [
+        pytest.param(lambda pid: train_mod.psutil.NoSuchProcess(pid), id="no-such-process"),
+        pytest.param(lambda pid: train_mod.psutil.AccessDenied(pid), id="access-denied"),
+    ],
+)
+def test_session_with_pid_that_vanishes_mid_probe_is_dropped(monkeypatch: pytest.MonkeyPatch, exc_factory: Any) -> None:
+    """A session whose PID still exists at check time but whose process object
+    raises while being probed (a race where the process exits between
+    ``pid_exists`` and ``is_running``, or a process we may not inspect) is
+    dropped from the active set. The load must never raise and must never
+    report such a session as running.
+
+    This is the complement of the dead-PID case above: there ``pid_exists`` is
+    already False and the finished session is retained for its log tail, whereas
+    here the PID reads live but the probe fails, so the session cannot be
+    confirmed running and is excluded.
+    """
+    mgr = SessionManager()
+    mgr.add_session("racy", {"pid": 4242, "action": "train"})
+
+    monkeypatch.setattr(train_mod.psutil, "pid_exists", lambda pid: True)
+
+    class _VanishingProcess:
+        def __init__(self, pid: int) -> None:
+            self._pid = pid
+
+        def is_running(self) -> bool:
+            raise exc_factory(self._pid)
+
+    monkeypatch.setattr(train_mod.psutil, "Process", _VanishingProcess)
+
+    sessions = mgr.list_sessions()
+    assert "racy" not in sessions, (
+        "a session whose process cannot be confirmed running must be dropped, not reported as active"
+    )
+
+
 def test_session_manager_get_and_remove_round_trip(tmp_path: Path) -> None:
     mgr = SessionManager()
     mgr.add_session("s", {"pid": 4242})


### PR DESCRIPTION
## Problem

`SessionManager._load_sessions` (in `strands_robots/tools/lerobot_train.py`) decides whether a tracked training session is still running by probing its PID in two steps: `psutil.pid_exists(pid)` and then `psutil.Process(pid).is_running()`. A process can exit in the window between those two calls, or be one the current user may not inspect. In that case the second probe raises `psutil.NoSuchProcess` / `psutil.AccessDenied`.

The loader guards that with a narrow `except (psutil.NoSuchProcess, psutil.AccessDenied): pass`, which drops the session that cannot be confirmed running. That branch had no test: deleting the guard lets the exception propagate out of `list_sessions()` / the `status` action and crash session listing, and nothing would catch the regression.

## Change

Add a parametrized regression test (over both exception types) that:

- registers a session, forces `pid_exists` True but makes `Process(pid).is_running()` raise, and
- asserts the session is excluded from the returned active set and the load never raises.

It is deliberately the complement of the existing dead-PID test (`pid_exists` False), where a finished session is intentionally retained so `status` can still surface its final log tail. Keeping the two adjacent documents the contract: PID gone -> retained for logs; PID live but unconfirmable -> dropped.

## Verification

- Removing the `except` guard makes both parametrizations fail (`NoSuchProcess` / `AccessDenied` propagate); restoring it makes them pass -- confirming the test pins the branch.
- `tests/tools/test_lerobot_train.py`: 40 passed.
- Green gate: `ruff check`, `ruff format --check`, and `mypy strands_robots tests tests_integ` all clean.

Test-only change; no runtime behavior or public API is modified.

---

## §13 Review Round Log

| Round | Concern | Fix Commit | Pin Test |
|-------|---------|------------|----------|
| R1 | CodeQL "unnecessary lambda" on lines 394-395 | `d7aa8a8` | `tests/tools/test_lerobot_train.py::test_session_with_pid_that_vanishes_mid_probe_is_dropped` |