### PR TITLE
fix(sim): don't surface a floating base's free joint as a degenerate scalar in get_observation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: `get_observation` no longer emits a floating base's free joint as a degenerate scalar
+
+A robot whose root is a 6-DoF free joint (a humanoid's named
+`floating_base_joint`, or a mobile base's `<freejoint>`) surfaces its full base
+pose + twist through `get_observation` as the structured `base_pos` /
+`base_quat` / `base_lin_vel` / `base_ang_vel` keys. But `get_observation` (both
+the MuJoCo and Newton backends) ALSO emitted the free joint itself as a scalar
+`"<joint_name>"` entry equal to `qpos[jnt_qposadr]` -- the base x-coordinate
+reported as a joint angle, silently dropping the y/z position and the entire
+orientation + velocity. That degenerate scalar duplicates `base_pos.x`, and
+because the LeRobotDataset recorder derives its `observation.state` schema from
+the joint list, it became a junk `floating_base_joint` column in every recorded
+floating-base dataset (a misleading input dimension for any policy trained on
+it). `get_robot_state` was already fixed to exclude the free joint from its
+scalar per-joint state; this brings `get_observation` and the dataset recorder
+to the same contract on both backends. The free joint is now excluded from the
+scalar joint schema everywhere; its 6-DoF state remains available through the
+structured `base_*` keys / `base` entry. Fixed-base arms are unaffected. A
+regression test asserts `get_observation` and a reopened recorded dataset carry
+no `floating_base_joint` scalar (fails before, passes after) on both backends,
+with a no-regression guard that the structured base state is still present.
+
 ### Added: `describe()` advertises the teleoperation surface (`attach_teleop` / `teleoperate` / `stop_teleoperate` / `get_teleoperate_status` / `list_teleops` / `detach_teleop`)
 
 `SimEngine.describe()["methods"]` is the single-call discovery surface an agent

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -492,6 +492,16 @@ class SimEngine(ABC):
               camera associated with the robot, keyed by camera name.
               Shape ``(H, W, 3)``. Cameras whose render fails MAY be
               omitted; joint state MUST still be returned.
+            - Floating base: a robot whose root is a 6-DoF free joint (a
+              humanoid's named ``floating_base_joint`` or a mobile base's
+              unnamed ``<freejoint>``) does NOT report that free joint as a
+              scalar ``"<joint_name>"`` entry - its qpos is [xyz + quat], so a
+              scalar would report the base x-coordinate as a joint angle and
+              drop the rest. Instead it surfaces the full base pose + twist as
+              ``"base_pos"`` (world x,y,z incl. height), ``"base_quat"``
+              (w,x,y,z), ``"base_lin_vel"`` and ``"base_ang_vel"``, matching
+              :meth:`get_robot_state`'s ``"base"`` entry. Absent for fixed-base
+              arms.
 
         Single-camera rendering is :meth:`render`'s job, not this method's.
         For batched multi-robot observation (future Isaac / Newton), add a

--- a/strands_robots/simulation/mujoco/recording.py
+++ b/strands_robots/simulation/mujoco/recording.py
@@ -182,16 +182,33 @@ class RecordingMixin(DatasetRecordingMixin):
             camera_keys: list[str] = []
             robot_type = "unknown"
             multi_robot = len(self._world.robots) > 1
+            mj = _ensure_mujoco()
+            model = self._world._model
             for rname, robot in self._world.robots.items():
+                # Exclude a floating base's 6-DoF free joint from the scalar
+                # joint schema: its full state is recorded as the structured
+                # base_pos / base_quat / base_lin_vel / base_ang_vel columns
+                # below, and get_observation no longer emits it as a scalar
+                # (its qpos is [xyz+quat], not a single angle), so declaring a
+                # floating_base_joint scalar column would record a degenerate /
+                # dead value. Mirrors get_observation / get_robot_state.
+                pfx = robot.namespace or ""
+                scalar_joint_names: list[str] = []
+                for jn in robot.joint_names:
+                    jid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, (pfx + jn) if pfx else jn)
+                    if jid < 0 and pfx:
+                        jid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, jn)
+                    if jid >= 0 and model.jnt_type[jid] == mj.mjtJoint.mjJNT_FREE:
+                        continue
+                    scalar_joint_names.append(jn)
                 if multi_robot:
-                    joint_names.extend(f"{rname}__{jn}" for jn in robot.joint_names)
+                    joint_names.extend(f"{rname}__{jn}" for jn in scalar_joint_names)
                     action_names.extend(f"{rname}__{ak}" for ak in self.robot_action_keys(rname))
                 else:
-                    joint_names.extend(robot.joint_names)
+                    joint_names.extend(scalar_joint_names)
                     action_names.extend(self.robot_action_keys(rname))
                 robot_type = robot.data_config or rname
 
-            mj = _ensure_mujoco()
             # A floating-base robot (humanoid / mobile) exposes full base
             # kinematics via get_observation - position (base_pos, world x,y,z
             # incl. height), orientation (base_quat, w,x,y,z), linear velocity

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -324,15 +324,23 @@ class RenderingMixin:
             if jnt_id < 0 and pfx:
                 jnt_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, jnt_name)
             if jnt_id >= 0:
-                obs[jnt_name] = float(data.qpos[model.jnt_qposadr[jnt_id]])
                 # A FREE joint (6-DoF floating base) has no single hinge/slide
-                # position; its qpos is [xyz(3) + quat(4)] and qvel is
-                # [linvel(3) + angvel(3)]. Record its id so we can surface the
-                # base orientation + angular velocity below, and skip the
-                # scalar ``.vel`` for it (it isn't a 1-DoF joint).
+                # position: its qpos is [xyz(3) + quat(4)] and qvel is
+                # [linvel(3) + angvel(3)]. Emitting obs[<free-joint>] =
+                # qpos[jnt_qposadr] reports the base x-coordinate as a joint
+                # angle and silently drops the y/z position + the full
+                # orientation and twist - a degenerate, misleading scalar (and a
+                # duplicate of base_pos.x that pollutes a recorded
+                # observation.state). Record its id so the full base pose +
+                # twist is surfaced below as the structured base_pos /
+                # base_quat / base_lin_vel / base_ang_vel keys, and skip the
+                # scalar (and its ``.vel``) entirely - matching get_robot_state,
+                # which likewise excludes the free joint from the per-joint
+                # scalar state.
                 if model.jnt_type[jnt_id] == mj.mjtJoint.mjJNT_FREE:
                     free_jnt_id = jnt_id
                     continue
+                obs[jnt_name] = float(data.qpos[model.jnt_qposadr[jnt_id]])
                 # Per-joint velocity (hinge/slide): dof index addresses qvel.
                 # Additive key (``<name>.vel``) - existing position-only
                 # consumers (dataset recording, arm policies) are unaffected;

--- a/strands_robots/simulation/newton/recording.py
+++ b/strands_robots/simulation/newton/recording.py
@@ -293,11 +293,19 @@ class NewtonRecordingMixin(DatasetRecordingMixin):
         joint_names: list[str] = []
         robot_type = "unknown"
         multi_robot = len(world.robots) > 1
+        free_base = getattr(self, "_robot_free_base_joint", {})
         for rname, robot in world.robots.items():
+            # Exclude the floating base's free joint from the scalar joint
+            # schema: its 6-DoF state is recorded as the structured base_*
+            # columns below and get_observation no longer emits it as a scalar,
+            # so a floating_base_joint scalar column would be dead/degenerate.
+            # Mirrors get_observation / get_robot_state.
+            free_short = free_base.get(rname)
+            scalar_jn = [jn for jn in robot.joint_names if jn != free_short]
             if multi_robot:
-                joint_names.extend(f"{rname}__{jn}" for jn in robot.joint_names)
+                joint_names.extend(f"{rname}__{jn}" for jn in scalar_jn)
             else:
-                joint_names.extend(robot.joint_names)
+                joint_names.extend(scalar_jn)
             robot_type = robot.data_config or rname
 
         camera_keys: list[str] = []

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -201,8 +201,9 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         self._joint_dof_index: dict[tuple[str, str], int] = {}
         # Short name of each robot's floating-base free joint (a humanoid's
         # named ``floating_base_joint``), when it has one. Used to surface the
-        # 6-DoF base pose/twist instead of reporting the base x-coordinate as a
-        # scalar joint value (parity with the MuJoCo backend).
+        # 6-DoF base pose/twist as the structured base_* keys and to EXCLUDE the
+        # free joint from the scalar joint state (its qpos is [xyz+quat], not a
+        # single angle) - matching get_robot_state and the MuJoCo backend.
         self._robot_free_base_joint: dict[str, str] = {}
         # Ordered full body labels per robot (rebuilt with the model).
         self._robot_body_map: dict[str, list[str]] = {}
@@ -675,8 +676,18 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
             joint_q = self._state_0.joint_q.numpy()
             joint_qd = self._state_0.joint_qd.numpy()
             robot_joints = self._world.robots[robot_name].joint_names
+            free_short = self._robot_free_base_joint.get(robot_name)
             obs: dict[str, Any] = {}
             for jname in robot_joints:
+                # A 6-DoF free joint (floating base) is not a scalar joint: its
+                # coordinate 0 is the base x-position, so obs[jname] =
+                # joint_q[idx] would report base-x as a joint angle (dropping the
+                # rest of the pose + twist) - a degenerate scalar and a duplicate
+                # of base_pos.x. Its full state is surfaced below as the
+                # structured base_pos/base_quat/base_lin_vel/base_ang_vel keys,
+                # matching get_robot_state and the MuJoCo backend.
+                if jname == free_short:
+                    continue
                 idx = self._joint_coord_index.get((robot_name, jname))
                 if idx is not None and idx < len(joint_q):
                     obs[jname] = float(joint_q[idx])

--- a/tests/simulation/mujoco/test_mobile_base_observation.py
+++ b/tests/simulation/mujoco/test_mobile_base_observation.py
@@ -218,6 +218,11 @@ def test_get_observation_surfaces_full_base_kinematics(sim):
     assert obs["base_quat"] == pytest.approx([0.7071, 0.0, 0.0, 0.7071], abs=1e-3)
     assert obs["base_lin_vel"] == pytest.approx([1.1, 2.2, 3.3], abs=1e-3)
     assert obs["base_ang_vel"] == pytest.approx([4.4, 5.5, 6.6], abs=1e-3)
+    # The 6-DoF free joint is NOT emitted as a degenerate scalar joint entry
+    # (it would report base-x as a joint angle) - its full state is the
+    # structured base_* keys above, matching get_robot_state.
+    assert "floating_base_joint" not in obs
+    assert "floating_base_joint.vel" not in obs
 
 
 def test_get_robot_state_named_free_base_reports_base_pose_not_scalar(sim):

--- a/tests/simulation/mujoco/test_recording_preserves_floating_base_state.py
+++ b/tests/simulation/mujoco/test_recording_preserves_floating_base_state.py
@@ -156,6 +156,12 @@ def test_named_floating_base_preserved_in_schema(sim):
     names, shape = _state_names(sim)
     for col in _BASE_COLS:
         assert col in names, f"{col} missing from recorded observation.state schema"
+    # The free joint is NOT recorded as a degenerate scalar joint column
+    # (its 6-DoF state is the structured base_* columns above); matching
+    # get_observation / get_robot_state.
+    assert "floating_base_joint" not in names, (
+        "the free joint must not be a scalar observation.state column"
+    )
     # shape length must match the flat per-element name count.
     assert tuple(shape)[0] == len(names)
     sim.stop_recording()

--- a/tests/simulation/mujoco/test_recording_preserves_floating_base_state.py
+++ b/tests/simulation/mujoco/test_recording_preserves_floating_base_state.py
@@ -159,9 +159,7 @@ def test_named_floating_base_preserved_in_schema(sim):
     # The free joint is NOT recorded as a degenerate scalar joint column
     # (its 6-DoF state is the structured base_* columns above); matching
     # get_observation / get_robot_state.
-    assert "floating_base_joint" not in names, (
-        "the free joint must not be a scalar observation.state column"
-    )
+    assert "floating_base_joint" not in names, "the free joint must not be a scalar observation.state column"
     # shape length must match the flat per-element name count.
     assert tuple(shape)[0] == len(names)
     sim.stop_recording()

--- a/tests/simulation/newton/test_dataset_recording.py
+++ b/tests/simulation/newton/test_dataset_recording.py
@@ -357,9 +357,7 @@ def test_start_recording_excludes_free_joint_scalar_from_schema(tmp_path):
     assert started["status"] == "success", started
     names, _shape = _recorder_state_names(engine)
     # The degenerate free-joint scalar is excluded from the scalar joint schema.
-    assert "floating_base_joint" not in names, (
-        "the free joint must not be a scalar observation.state column"
-    )
+    assert "floating_base_joint" not in names, "the free joint must not be a scalar observation.state column"
     # The actuated scalar joints and the structured base columns remain.
     for j in _SO100_JOINTS:
         assert j in names

--- a/tests/simulation/newton/test_dataset_recording.py
+++ b/tests/simulation/newton/test_dataset_recording.py
@@ -335,6 +335,39 @@ def test_start_recording_preserves_floating_base_state_schema(tmp_path, caplog):
     engine.stop_recording()
 
 
+def test_start_recording_excludes_free_joint_scalar_from_schema(tmp_path):
+    """A NAMED free joint enumerated in ``robot.joint_names`` (as a real Newton
+    floating-base build produces, e.g. ``floating_base_joint``) must NOT be
+    recorded as a scalar observation.state column: its qpos is [xyz + quat], so
+    a scalar would report the base x-coordinate as a joint angle (a degenerate
+    duplicate of ``base_pos.x``). Its 6-DoF state is preserved as the structured
+    base_* columns instead, matching get_observation / get_robot_state."""
+    world = SimWorld()
+    world.robots["humanoid"] = SimRobot(
+        name="humanoid",
+        urdf_path="g1.xml",
+        data_config="humanoid",
+        joint_names=["floating_base_joint", *_SO100_JOINTS],
+    )
+    engine = _make_engine(world)
+    engine._robot_free_base_joint = {"humanoid": "floating_base_joint"}
+    started = engine.start_recording(
+        repo_id="local/newton_free_joint_excluded", root=str(tmp_path / "ds"), fps=20, overwrite=True
+    )
+    assert started["status"] == "success", started
+    names, _shape = _recorder_state_names(engine)
+    # The degenerate free-joint scalar is excluded from the scalar joint schema.
+    assert "floating_base_joint" not in names, (
+        "the free joint must not be a scalar observation.state column"
+    )
+    # The actuated scalar joints and the structured base columns remain.
+    for j in _SO100_JOINTS:
+        assert j in names
+    for col in _BASE_COLS:
+        assert col in names
+    engine.stop_recording()
+
+
 def test_start_recording_fixed_arm_has_no_base_columns(tmp_path, caplog):
     """A fixed-base arm (no floating base recorded) gains NO base columns - the
     schema is unchanged - and detection degrades gracefully when

--- a/tests/simulation/newton/test_discovery_and_state.py
+++ b/tests/simulation/newton/test_discovery_and_state.py
@@ -225,6 +225,13 @@ class TestFloatingBaseSurfacing:
         # [4.4, 5.5, 6.6] rotated into the +90deg-about-Z body frame is
         # [5.5, -4.4, 6.6]. See test_base_ang_vel_is_body_frame_matching_mujoco.
         assert obs["base_ang_vel"] == pytest.approx([5.5, -4.4, 6.6], abs=1e-4)
+        # The 6-DoF free joint ("root") is NOT emitted as a degenerate scalar
+        # joint entry (it would report base-x as a joint angle) - its full state
+        # is the structured base_* keys above, matching get_robot_state and the
+        # MuJoCo backend. The hinge joints past the free joint are still read.
+        assert "root" not in obs
+        assert obs["j1"] == pytest.approx(0.55, abs=1e-4)
+        assert obs["j2"] == pytest.approx(-0.22, abs=1e-4)
 
     def test_base_ang_vel_is_body_frame_matching_mujoco(self, engine_floater):
         """base_ang_vel is the body-frame angular velocity, not the raw world twist.


### PR DESCRIPTION
## Problem

`get_observation` surfaces a floating base's full 6-DoF pose + twist as the structured `base_pos` / `base_quat` / `base_lin_vel` / `base_ang_vel` keys. But it *also* emitted the free joint itself as a scalar `"<joint_name>"` entry equal to `qpos[jnt_qposadr]` -- i.e. **the base x-coordinate reported as a joint angle**, silently dropping the y/z position and the entire orientation + velocity.

On a real Unitree G1 (both backends):

```python
sim.add_robot("unitree_g1")
obs = sim.get_observation(skip_images=True)
obs["floating_base_joint"]   # 0.0 at spawn ...
# teleport base to x=1.0, y=0.5, z=0.9, yaw 90deg -> obs["floating_base_joint"] == 1.0
#   (exactly qpos[0]; the y/z + the whole quaternion/twist are gone)
```

That degenerate scalar is a duplicate of `base_pos.x`, and because the `LeRobotDataset` recorder derives its `observation.state` schema from the robot's joint list, it became a junk `floating_base_joint` column in **every recorded floating-base dataset** -- a misleading, always-degenerate input dimension for any policy trained on it.

`get_robot_state` was already fixed for exactly this (its own comment: *"Reading qpos[jnt_qposadr] as a 'position' reports the base x-coordinate as a joint angle and silently drops the orientation"*) and excludes the free joint from its scalar per-joint state. `get_observation` and the dataset recorder were simply never brought to that contract, leaving the three surfaces inconsistent (`get_robot_state`: 29 scalar joints for the G1; `get_observation` / recorded state: 29 + a junk `floating_base_joint`).

## Fix

Exclude the 6-DoF free joint from the **scalar** joint schema everywhere it leaked, mirroring `get_robot_state`. Its full state remains available as the structured `base_*` keys / `base` entry. Four sites, both backends:

- **MuJoCo `get_observation`** (`_get_sim_observation`): `continue` on the free joint *before* the scalar assignment (the assignment was running for every joint, then the free-joint branch only skipped the `.vel`).
- **Newton `get_observation`**: skip the free joint's short name in the scalar loop.
- **MuJoCo + Newton recorders**: exclude the free joint from the scalar `joint_names` schema (so no dead/degenerate `floating_base_joint` column, and the recorded schema matches the fixed observation).

Fixed-base arms are unaffected (no free joint -> the filter is a no-op; byte-identical schema). After the fix, all three surfaces agree: 29 actuated scalar joints + the structured 6-DoF base, and `observation.state` for the G1 drops from 43 -> 42 (the junk column removed).

## Verification

A real G1 rollout recorded to a `LeRobotDataset` and reopened -- the per-camera video feature and the 13 structured `base_*` columns survive, and `floating_base_joint` is gone; `base_pos.z` drops 0.793 -> 0.109 as the base falls (base state recorded correctly):

![G1 rollout](https://github.com/cagataycali/robots/releases/download/artifacts-fbjoint-1783874186/g1_art.gif)

Regression tests assert `get_observation` and a reopened recorded dataset carry **no** `floating_base_joint` scalar, on **both** backends, with no-regression guards that the structured base state and the actuated scalar joints are still present. All four new assertions **fail on the pre-fix code** (the failure shows the exact degenerate value, e.g. `'floating_base_joint': 0.3` / `'root': 0.30`) and pass after.

- MuJoCo: `test_mobile_base_observation.py`, `test_recording_preserves_floating_base_state.py`
- Newton: `test_discovery_and_state.py`, `test_dataset_recording.py`

Local gate: `ruff check` + `ruff format --check` + `mypy` clean on the changed files; targeted suites green (`212 passed` sim/newton, `220 passed` including WBC/MotionBricks + recording paths). No public tool-action contract change (additive/removal of an observation-dict key only).