### PR TITLE
test: reject PR-review-round provenance in the source-string guard

### DIFF
--- a/strands_robots/benchmarks/libero/adapter.py
+++ b/strands_robots/benchmarks/libero/adapter.py
@@ -1775,11 +1775,9 @@ class LiberoAdapter(BenchmarkProtocol):
 
         Walks the BDDL predicate tree compiled at construction time
         (:func:`compile_goal`) against the current sim state. The
-        evaluator was hardened in #170 / #173 / #175 to match
-        upstream LIBERO's ``check_ontop`` / ``check_contact``
-        semantics byte-for-byte at the moment of contact (#171
-        sub-task 3e contact check, #175 round 46d body-name
-        ``_main`` suffix fallback).
+        evaluator matches upstream LIBERO's ``check_ontop`` /
+        ``check_contact`` semantics byte-for-byte at the moment of
+        contact, including the ``_main`` body-name suffix fallback.
         """
         return bool(self._success_fn(sim))
 

--- a/strands_robots/mesh/audit.py
+++ b/strands_robots/mesh/audit.py
@@ -950,8 +950,7 @@ def _ensure_paths(path: Path) -> None:
     Defence: if the audit log path is a SYMLINK (potentially pointing
     to attacker-controlled territory like ``/dev/null`` or another
     process's file), refuse to operate. The audit log must always be
-    a real regular file at the canonical location. See
-    review feedback round 4 (symlink-swap defence).
+    a real regular file at the canonical location.
     """
     parent = path.parent
     parent.mkdir(parents=True, exist_ok=True)

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -92,9 +92,9 @@ def set_eval_seed(seed: int) -> None:
     Public since #179: standalone integration tests
     (``tests_integ/.../test_libero_10_scene5_mujoco_engine_success_rate``)
     bypass :meth:`evaluate_benchmark` and need to call this directly to
-    get reproducible policy rollouts. The leading ``_`` was an oversight
-    from #168 round 38; the function is the supported way to seed an
-    eval and is part of the public API.
+    get reproducible policy rollouts. Despite the leading ``_``, this
+    function is the supported way to seed an eval and is part of the
+    public API.
 
     NumPy / torch are imported lazily so this helper works on minimal
     installs that don't have torch (e.g. ``policy_provider="mock"``

--- a/tests/test_source_strings_no_review_archaeology.py
+++ b/tests/test_source_strings_no_review_archaeology.py
@@ -12,19 +12,27 @@ provenance ("a reviewer asked for this in thread X at line Y") is noise that
 belongs in git history, not the source.
 
 This scan walks every Python module under the ``strands_robots`` package and
-rejects three review-archaeology shapes:
+rejects these review-archaeology shapes:
 
   * ``review thread`` / ``review threads`` (the literal provenance framing),
   * ``flagged in review`` (its passive twin),
   * ``review <module>.py:<line>`` (a review citation carrying a rot-prone
-    internal source-location back-pointer).
+    internal source-location back-pointer),
+  * review-*round* provenance -- ``review [feedback] round N`` and a PR/issue
+    number narrating a ``round N`` (e.g. ``#168 round 38``, ``#175 round 46d``).
+    Which review pass produced a change is exactly the provenance that belongs
+    in git history, not the source; the number rots and misdirects the reader.
 
 References to *upstream* files (e.g. ``run_mujoco_gear_wbc.py:47-50``) and to
-stable, named anchors (``AGENTS.md > Review Learnings``, issue numbers) are not
-matched -- only the review-thread-by-line-pointer pattern is. The scan flattens
-comment continuations so a citation wrapped across ``#`` lines is still caught.
-It would have failed when 20+ comment blocks across the ``mesh`` package still
-carried ``review thread <file>.py:<line>`` pointers.
+stable, named anchors (``AGENTS.md > Review Learnings``, a bare issue number
+like ``#179``) are not matched -- only review-thread-by-line-pointer and
+review-round provenance are. The scan flattens comment continuations so a
+citation wrapped across ``#`` lines is still caught (the flattener also strips
+the leading ``#`` of a ``#NNN`` PR reference, so the round pattern matches the
+bare ``NNN round N`` that remains). It would have failed when 20+ comment
+blocks across the ``mesh`` package still carried ``review thread
+<file>.py:<line>`` pointers, and when ``mesh``/``simulation``/``benchmarks``
+sources narrated the PR review round that produced a change.
 """
 
 from __future__ import annotations
@@ -34,14 +42,25 @@ from pathlib import Path
 
 import strands_robots
 
-# Review-archaeology framing that cites an internal review thread. The third
-# alternative is the load-bearing one: a ``review`` citation immediately
-# followed by an internal ``<module>.py:<line>`` back-pointer that rots on the
-# next edit. Upstream ``<file>.py:<line>`` references (not preceded by
-# ``review``) and named anchors like ``Review Learnings`` are intentionally not
-# matched.
+# Review-archaeology framing that cites an internal review thread or PR review
+# round. Loaded alternatives:
+#   * ``review thread(s)`` / ``flagged in review`` -- literal provenance framing.
+#   * ``review <module>.py:<line>`` -- a review citation carrying a rot-prone
+#     internal source-location back-pointer.
+#   * ``review [feedback] round N`` and ``<digits> round N`` -- narration of the
+#     PR review pass that produced a change. The flattener strips the ``#`` of a
+#     ``#NNN`` PR reference, so ``#168 round 38`` arrives here as ``168 round
+#     38`` and is caught by the digits-prefixed alternative.
+# Upstream ``<file>.py:<line>`` references (not preceded by ``review``), named
+# anchors like ``Review Learnings``, and bare issue numbers are not matched.
 _REVIEW_ARCHAEOLOGY = re.compile(
-    r"(?i)(?:review\s+threads?\b|flagged\s+in\s+review|\breview\s+[A-Za-z_][A-Za-z0-9_]*\.py:\d+)"
+    r"(?i)(?:"
+    r"review\s+threads?\b"
+    r"|flagged\s+in\s+review"
+    r"|\breview\s+[A-Za-z_][A-Za-z0-9_]*\.py:\d+"
+    r"|review\s+(?:feedback\s+)?round\s+\d+"
+    r"|\b\d+\s+round\s+\d+[a-z]?\b"
+    r")"
 )
 
 # Collapse comment-continuation runs (`\n    # `) and other whitespace to a
@@ -73,7 +92,38 @@ def test_no_review_thread_line_pointers_in_package_sources() -> None:
             snippet = flattened[start : match.end() + 30].strip()
             offenders.append(f"{path.relative_to(_PACKAGE_DIR.parent)}: ...{snippet}...")
     assert not offenders, (
-        "Review-thread archaeology found in strands_robots sources. Explain WHY the "
-        "code is shaped this way and reference a stable symbol, not a rot-prone "
-        "``<file>.py:<line>`` review pointer:\n" + "\n".join(offenders)
+        "Review archaeology found in strands_robots sources. Explain WHY the code "
+        "is shaped this way and reference a stable symbol -- not a rot-prone "
+        "``<file>.py:<line>`` review pointer nor the PR review round that produced "
+        "the change:\n" + "\n".join(offenders)
     )
+
+
+def test_review_round_provenance_is_matched() -> None:
+    """The pattern rejects PR-review-round narration.
+
+    The flattener strips the ``#`` of a ``#NNN`` PR reference, so these are the
+    shapes the scan actually sees after flattening.
+    """
+    offenders = [
+        "168 round 38",  # was "#168 round 38"
+        "175 round 46d body-name",  # was "#175 round 46d ..."
+        "See review feedback round 4 (symlink-swap defence).",
+        "review round 2",
+    ]
+    for text in offenders:
+        assert _REVIEW_ARCHAEOLOGY.search(text), f"should be flagged: {text!r}"
+
+
+def test_legitimate_references_are_not_matched() -> None:
+    """Stable references and incidental prose must not trip the round pattern."""
+    allowed = [
+        "run_mujoco_gear_wbc.py:47-50",  # upstream file:line, not review-prefixed
+        "See AGENTS.md > Review Learnings for the rationale.",
+        "Public since #179: standalone integration tests bypass this.",
+        "round-trip the dataset and assert it is non-empty",
+        "round the value to the nearest integer",
+        "the first round of IK refinement converges quickly",  # 'round' without digits
+    ]
+    for text in allowed:
+        assert not _REVIEW_ARCHAEOLOGY.search(text), f"false positive: {text!r}"


### PR DESCRIPTION
## Problem

The source-string review-archaeology guard (`tests/test_source_strings_no_review_archaeology.py`) rejects review-thread-by-line-pointer citations (`review thread session.py:296`) but lets a second, equally rot-prone shape through: comments that narrate the **PR review round** that produced a change. Three sources carried it:

- `simulation/policy_runner.py` - ``the leading `_` was an oversight from #168 round 38``
- `benchmarks/libero/adapter.py` - ``#171 sub-task 3e contact check, #175 round 46d body-name``
- `mesh/audit.py` - ``See review feedback round 4 (symlink-swap defence)``

"Round 38" / "round 46d" / "review feedback round 4" is exactly the provenance that belongs in git history, not the source: the number means nothing to a future reader and misdirects rather than explaining *why* the code is shaped that way.

## Change

- Extend `_REVIEW_ARCHAEOLOGY` to also match `review [feedback] round N` and a digits-prefixed `round N`. The comment flattener collapses `[\s#]+`, so it strips the leading `#` of a `#NNN` PR reference - `#168 round 38` arrives at the scan as `168 round 38`, which the digits-prefixed alternative catches.
- Add two focused unit tests: one pinning that the round shapes are flagged, one guarding against false positives (`round-trip`, `round the value`, upstream `file.py:line`, `Review Learnings`, a bare issue number like `#179`, and prose `round` with no digits).
- Clean the three flagged comments, keeping the WHY and dropping the round narration (e.g. libero keeps "matches upstream LIBERO check_ontop/check_contact byte-for-byte at the moment of contact, including the `_main` body-name suffix fallback").

Stable references are intentionally still allowed: upstream `<file>.py:<line>`, named anchors (`AGENTS.md > Review Learnings`), and bare issue numbers.

## Regression evidence

With the regex tightened but the three comments un-cleaned, the package scan fails on exactly those three offenders; after cleaning, it passes:

```
test_no_review_thread_line_pointers_in_package_sources FAILED
  benchmarks/libero/adapter.py: ...sub-task 3e contact check, 175 round 46d body-name...
  mesh/audit.py: ...canonical location. See review feedback round 4 (symlink-swap defence)...
  simulation/policy_runner.py: ...`_` was an oversight from 168 round 38; the function...
```

## Tests

- `tests/test_source_strings_no_review_archaeology.py` - 4 passed (2 new)
- No-emoji guard, docstring module-xref guard, `test_policy_runner`, audit symlink-refusal - 51 passed
- `ruff check` / `ruff format --check` clean; `mypy strands_robots tests tests_integ` - no issues in 763 files

Comment/test-only; no library behavior changes.