### PR TITLE
test(mock): add flatten/tolist to MockTensor so reward_progress runs torch-free

### DIFF
--- a/tests/mocks/torch_mock.py
+++ b/tests/mocks/torch_mock.py
@@ -81,6 +81,9 @@ class MockTensor:
     def item(self):
         return float(self._data.flat[0])
 
+    def tolist(self):
+        return self._data.tolist()
+
     def numpy(self):
         return self._data.copy()
 
@@ -123,6 +126,9 @@ class MockTensor:
 
     def reshape(self, *shape):
         return MockTensor(self._data.reshape(shape))
+
+    def flatten(self, *args, **kwargs):
+        return MockTensor(self._data.reshape(-1))
 
     def permute(self, *dims):
         return MockTensor(np.transpose(self._data, dims))

--- a/tests/training/test_reward.py
+++ b/tests/training/test_reward.py
@@ -173,6 +173,23 @@ class TestRewardProgress:
 
         assert reward_progress(Model(), {}) == [0.5]
 
+    def test_torch_mock_models_the_detach_chain(self):
+        # reward_progress() normalizes a torch return via the chain
+        # ``rewards.detach().to("cpu").flatten().tolist()``. When real torch is
+        # absent, tests/conftest.py installs tests/mocks/torch_mock.MockTensor as
+        # ``torch``; ``pytest.importorskip("torch")`` above therefore resolves to
+        # the mock rather than skipping (the mock IS a torch module). The mock
+        # must implement every method in that chain or the "run all unit tests
+        # without PyTorch installed" contract in conftest breaks -- a
+        # torch-return test would fail with AttributeError only in the mocked
+        # (no-real-torch) environment. Pin that ``flatten``/``tolist`` (the two
+        # links the mock previously lacked) survive on MockTensor and that the
+        # full chain a torch tensor takes through reward_progress still yields
+        # the right floats.
+        torch = pytest.importorskip("torch")
+        t = torch.tensor([[0.1], [0.9]])
+        assert t.detach().to("cpu").flatten().tolist() == pytest.approx([0.1, 0.9], abs=1e-6)
+
 
 class TestLoadRewardModel:
     """load_reward_model() builds the reward config and delegates the load to lerobot."""


### PR DESCRIPTION
## Problem

`tests/conftest.py` installs a numpy-backed `MockTensor` as `torch` when real PyTorch is unavailable, so the unit suite can run without the heavy dep (its docstring: *"run all unit tests without PyTorch installed"*). But `reward_progress()` normalizes a reward model's `compute_reward` return via the chain:

```python
rewards.detach().to("cpu").flatten().tolist()
```

`MockTensor` had `detach`/`to`/`cpu` but **lacked `flatten()` and `tolist()`**. So `TestRewardProgress::test_normalizes_tensor` -- which does `torch = pytest.importorskip("torch")` and returns `torch.tensor(...)` from a model -- resolves `torch` to the *mock* (the mock IS a `torch` module, so `importorskip` does not skip), then hits:

```
AttributeError: 'MockTensor' object has no attribute 'flatten'
```

This breaks conftest's stated torch-free contract. It is masked in the main CI lane because `.[all,dev]` installs real CPU torch (which has both methods); it only surfaces on the mock-fallback path (e.g. a runner where the torch wheel fails to resolve -- exactly the fallback conftest exists to serve).

## Fix

Add the two missing links to `MockTensor`, faithfully modelling the `torch.Tensor` API the shipped code depends on:

- `flatten(*args, **kwargs)` -> `MockTensor` wrapping a 1-D `reshape(-1)` (chainable, like `torch.Tensor.flatten`)
- `tolist()` -> `ndarray.tolist()` (nested Python lists, like `torch.Tensor.tolist`)

Both sit next to the existing reshaping / conversion methods.

## Regression pin

`test_torch_mock_models_the_detach_chain` asserts the full `detach().to("cpu").flatten().tolist()` chain a torch tensor takes through `reward_progress` survives on the mock. Verified it **fails on the pre-fix mock** (`AttributeError: ... no attribute 'flatten'`) and **passes with the fix**.

## Scope

Test-infrastructure only -- no `strands_robots/` runtime change.

```
 tests/mocks/torch_mock.py     |  6 ++++++
 tests/training/test_reward.py | 17 +++++++++++++++++
```

## Validation

- `tests/training/test_reward.py`: 16 passed (was 15 passed + 1 failed under the mock).
- Change is purely additive (2 methods + 1 test); no existing behavior altered.
- `ruff check` + `ruff format --check` clean on both files.

Aligns with the AGENTS.md testing tenet: *test mocks must match production* -- a mock that omits an API the production path exercises silently masks (or, here, breaks) coverage.

---

### Round 1
Initial submission.