### PR TITLE
feat(sim): base_beyond_y lateral-progress predicate + go2_strafe_left benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1552,6 +1552,32 @@ paths and asserts the close-match + available list + discovery action (fails
 before, passes after) with a no-regression guard on a valid robot query.
 
 
+### Added: lateral locomotion vocabulary - `base_beyond_y` predicate + `go2_strafe_left` benchmark
+
+The shipped built-in locomotion benchmarks (`go2_walk_forward`,
+`g1_walk_forward`, `t1_walk_forward`) all command a pure FORWARD twist (`vx`)
+and score it with `base_beyond_x` -- the floating-base success family had a
+forward-progress predicate but no LATERAL one, so a strafe task could reward a
+`vy` command (`base_velocity_tracking` already accepts one) yet had no way to
+SCORE reaching a sideways goal, and no shipped benchmark ever exercised the
+`vy` term of the tracking reward. This adds `base_beyond_y(y, robot=None)` --
+the lateral-progress mirror of `base_beyond_x`, reading `base_pos` y off the
+same embodiment-agnostic `get_observation` surface (no base body name, works on
+an unnamed mobile-base free joint), degrading to `False` + warn-once on a
+fixed-base arm -- and ships `go2_strafe_left`, the first built-in to command a
+pure lateral (`vx=0`, `vy=0.5`) body twist and score it with `base_beyond_y`,
+reusing the Go2 fall/height thresholds. The reward/predicate DSL now expresses
+omnidirectional velocity-tracking, not forward-only. Verified end-to-end on a
+real Unitree Go2 in MuJoCo (`evaluate_benchmark`): the base observation
+surfaces, the standing spawn neither trips the fall predicates nor satisfies
+the lateral goal, and the dense reward composes finite. Regression tests set
+known base poses and assert the y-threshold, the y-vs-x axis distinction
+(forward progress must not score a strafe goal), height/orientation
+independence, live tracking, fixed-base degradation, and a full
+`DeclarativeBenchmark` that succeeds only once the base strafes past the line
+(fails before, passes after).
+
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/simulation/builtin_benchmarks.py
+++ b/strands_robots/simulation/builtin_benchmarks.py
@@ -3,18 +3,22 @@
 The predicate/reward DSL (:mod:`strands_robots.simulation.predicates`) grew a
 complete floating-base locomotion vocabulary - the ``base_velocity_tracking``
 exponential-kernel tracking reward, the ``base_height`` / ``base_orientation``
-posture regularizers, and the ``base_beyond_x`` (forward-progress success),
+posture regularizers, and the ``base_beyond_x`` / ``base_beyond_y`` (forward- / lateral-progress success),
 ``base_tipped`` (topple) and ``base_below_z`` (height-collapse) predicates - all
 reading the embodiment-agnostic floating-base surface from ``get_observation``.
 Those primitives, however, wired into no runnable benchmark:
 :func:`~strands_robots.simulation.benchmark.list_benchmarks` was empty until a
 caller hand-authored a spec (``register_benchmark_from_file``) or loaded the
 LIBERO suite. This module ships canonical velocity-tracking locomotion benchmarks composed
-from those primitives - a quadruped (``go2_walk_forward``) and two humanoids
-(``g1_walk_forward``, ``t1_walk_forward``) - so a floating-base robot has a
-runnable, discoverable eval out of the box, and to show the same
-embodiment-agnostic DSL transfers unchanged across morphologies and across two
-bipeds of different scale.
+from those primitives - a forward-walk quadruped (``go2_walk_forward``) and two
+humanoids (``g1_walk_forward``, ``t1_walk_forward``), plus a lateral strafe
+quadruped task (``go2_strafe_left``) - so a floating-base robot has a runnable,
+discoverable eval out of the box, and to show the same embodiment-agnostic DSL
+transfers unchanged across morphologies, across two bipeds of different scale,
+AND across command directions: ``go2_strafe_left`` commands a pure lateral
+(``vy``) body twist and scores it with ``base_beyond_y``, exercising the
+lateral half of the velocity-tracking vocabulary that the walk-forward tasks
+(pure ``vx`` + ``base_beyond_x``) never touch.
 
 Registration is opt-in - a caller invokes :func:`register_builtin_benchmarks`
 (mirroring how the LIBERO suite registers on demand via
@@ -175,6 +179,51 @@ _T1_WALK_FORWARD: dict[str, Any] = {
 }
 
 
+# ``go2_strafe_left``: the LATERAL velocity-tracking counterpart of
+# ``go2_walk_forward`` - strafe the Unitree Go2 sideways to its left at 0.5 m/s
+# and stay standing. It is the first shipped benchmark to command a non-zero
+# lateral (``vy``) twist and to score a non-forward position goal, proving the
+# velocity-tracking vocabulary is omnidirectional, not forward-only:
+#
+#   - success: the base strafes past y = 1 m (``base_beyond_y``) - world +y is
+#     the robot's left for the identity spawn orientation, so this reads
+#     "strafed ~1 m left". A standing-still or purely-forward policy never
+#     satisfies it (it scores lateral progress, not "did not fall").
+#   - failure: the same fall modes as the forward task - topple past ~53 deg
+#     (``base_tipped``, tol=0.7) OR height collapse below 0.18 m
+#     (``base_below_z``, the Go2 stands at ~0.32 m).
+#   - dense_reward: the same legged_gym-style stack, but the tracked twist is a
+#     PURE lateral command (vx=0.0, vy=0.5, wz=0.0) - the ``vy`` term of
+#     ``base_velocity_tracking`` that the pure-``vx`` walk-forward tasks leave at
+#     zero - plus the 0.32 m base-height and flat-orientation regularizers.
+_GO2_STRAFE_LEFT: dict[str, Any] = {
+    "name": "go2_strafe_left",
+    "default_robot": "unitree_go2",
+    "supported_robots": ["unitree_go2"],
+    "max_steps": 1000,
+    "success": {"all": [{"predicate": "base_beyond_y", "y": 1.0}]},
+    "failure": {
+        "any": [
+            {"predicate": "base_tipped", "tol": 0.7},
+            {"predicate": "base_below_z", "z": 0.18},
+        ]
+    },
+    "dense_reward": [
+        {
+            "predicate": "base_velocity_tracking",
+            "vx": 0.0,
+            "vy": 0.5,
+            "wz": 0.0,
+            "lin_weight": 1.0,
+            "ang_weight": 0.5,
+            "tracking_sigma": 0.25,
+        },
+        {"predicate": "base_height", "target": 0.32, "weight": 0.5},
+        {"predicate": "base_orientation", "weight": 0.5},
+    ],
+}
+
+
 # Registry of shipped built-in specs, keyed by their canonical registry name.
 # Extend this dict to ship more; every entry reuses the same embodiment-agnostic
 # floating-base DSL, differing only in the robot, thresholds, and reward stack.
@@ -182,6 +231,7 @@ _BUILTIN_SPECS: dict[str, dict[str, Any]] = {
     "go2_walk_forward": _GO2_WALK_FORWARD,
     "g1_walk_forward": _G1_WALK_FORWARD,
     "t1_walk_forward": _T1_WALK_FORWARD,
+    "go2_strafe_left": _GO2_STRAFE_LEFT,
 }
 
 

--- a/strands_robots/simulation/predicates.py
+++ b/strands_robots/simulation/predicates.py
@@ -41,6 +41,7 @@ Available predicates (bool):
     base_tipped(tol=0.15, robot=None)
     base_below_z(z, robot=None)
     base_beyond_x(x, robot=None)
+    base_beyond_y(y, robot=None)
 
 Available reward terms (float):
 
@@ -928,6 +929,58 @@ def _base_beyond_x(x: float, robot: str | None = None) -> BoolPredicate:
     return check
 
 
+def _base_beyond_y(y: float, robot: str | None = None) -> BoolPredicate:
+    """True when a floating base's world y-position has passed beyond ``y``.
+
+    The LATERAL-progress SUCCESS counterpart of :func:`_base_beyond_x`: where
+    ``base_beyond_x`` scores a walk-FORWARD goal off ``base_pos`` x,
+    ``base_beyond_y`` scores a strafe-LEFT goal off ``base_pos`` y (world +y is
+    the robot's left for the identity spawn orientation the locomotion scenes
+    use). It is the missing lateral half of the position-success family - the
+    reward terms (``base_velocity_tracking`` with a non-zero ``vy`` command +
+    the base regularizers) shape *how* to strafe, the fall predicates
+    (``base_tipped`` / ``base_below_z``) end a *bad* rollout, and this predicate
+    scores the *goal* ("the base reached lateral distance ``y``")::
+
+        success:
+          all:
+            - {predicate: base_beyond_y, y: 1.0}
+        failure:
+          any:
+            - {predicate: base_tipped, tol: 0.7}
+            - {predicate: base_below_z, z: 0.18}
+
+    Reads ``get_observation``'s ``base_pos`` y (world frame) - the same
+    embodiment-agnostic floating-base surface the ``base_*`` reward terms,
+    ``base_tipped``, ``base_below_z``, and ``base_beyond_x`` read - so it needs
+    no base body name and works on a mobile base whose free joint is unnamed.
+
+    ``y`` is an ABSOLUTE world y-threshold in metres, not a displacement
+    (mirroring ``base_beyond_x``): the canonical locomotion scenes spawn the
+    base near the origin, so ``base_beyond_y(y=D)`` reads "strafed ~D metres to
+    the left". The author sets ``y`` relative to the known spawn y. It is a pure
+    y-position test - height and orientation do not affect it (a base that
+    strafed but then toppled still reads True on y, so pair it with the fall
+    predicates in a ``failure`` clause to reject that outcome).
+
+    Requires a robot with a floating base; a fixed-base arm has no base
+    position, so the predicate degrades to ``False`` (never made lateral
+    progress -> never spuriously succeeds) and the missing base is logged once.
+    ``robot`` selects the robot in a multi-robot scene (default: the sole
+    robot).
+    """
+    yt = float(y)
+    rname = robot
+
+    def check(sim: SimEngine) -> bool:
+        pos = _base_position(sim, rname)
+        if pos is None:
+            return False
+        return pos[1] > yt
+
+    return check
+
+
 # Reward terms (float-valued)
 
 
@@ -1406,6 +1459,7 @@ PREDICATE_REGISTRY: dict[str, PredicateFactory] = {
     "base_tipped": _base_tipped,
     "base_below_z": _base_below_z,
     "base_beyond_x": _base_beyond_x,
+    "base_beyond_y": _base_beyond_y,
     # float-valued
     "distance_neg": _distance_neg,
     "joint_progress": _joint_progress,

--- a/tests/simulation/test_base_beyond_y_predicate.py
+++ b/tests/simulation/test_base_beyond_y_predicate.py
@@ -1,0 +1,248 @@
+"""Regression tests for the ``base_beyond_y`` floating-base lateral-progress predicate.
+
+The predicate/reward DSL grew the FORWARD-progress success predicate
+(``base_beyond_x``) alongside the velocity-tracking reward
+(``base_velocity_tracking``, which already accepts a lateral ``vy`` command) and
+the fall predicates (``base_tipped`` / ``base_below_z``). The LATERAL success
+half - "the base actually strafed sideways" - was still inexpressible:
+``base_beyond_x`` reads only ``base_pos`` x, so a strafe benchmark could reward
+a ``vy`` command but had no way to SCORE reaching a lateral goal, and
+``inside_region`` / ``body_above_z`` need a base body name a mobile base's
+unnamed free joint does not expose.
+
+``base_beyond_y(y, robot)`` closes that gap: TRUE when the base's world y has
+passed beyond ``y`` (world +y is the robot's left for the identity spawn
+orientation), reading the same ``base_pos`` signal ``base_beyond_x`` reads, so
+it drops straight into a ``success`` clause next to the fall predicates in
+``failure``. These tests set a KNOWN base pose directly on the sim and assert
+the threshold, height/orientation independence (it is a pure y-position
+predicate), that x-position does NOT trip it (the axis is distinct from
+``base_beyond_x``), live tracking, fixed-base degradation, and that a real
+``DeclarativeBenchmark`` whose success is ``base_beyond_y`` and failure is
+``base_tipped`` + ``base_below_z`` succeeds only once the base strafes past the
+line. They are GL-free (``get_observation`` with ``skip_images``) so they run in
+CI without a display.
+"""
+
+import logging
+import math
+import os
+import tempfile
+
+import mujoco
+import pytest
+
+from strands_robots.simulation.benchmark_spec import DeclarativeBenchmark
+from strands_robots.simulation.mujoco.simulation import Simulation
+from strands_robots.simulation.predicates import (
+    PREDICATE_REGISTRY,
+    _reset_resolution_warnings,
+    make_predicate,
+    predicate_kind,
+)
+
+# Floating base with a NAMED free joint (a humanoid's floating_base_joint) plus
+# one actuated hinge. get_observation surfaces base_pos for this robot.
+NAMED_BASE_XML = """
+<mujoco model="test_named_base">
+  <compiler angle="radian" autolimits="true"/>
+  <option timestep="0.002"/>
+  <worldbody>
+    <light name="main" pos="0 0 3" dir="0 0 -1"/>
+    <geom name="ground" type="plane" size="5 5 0.01" rgba="0.9 0.9 0.9 1"/>
+    <body name="pelvis" pos="0 0 0.8">
+      <freejoint name="floating_base_joint"/>
+      <geom type="box" size="0.1 0.1 0.1" rgba="0.3 0.3 0.8 1"/>
+      <body name="thigh" pos="0 0 -0.1">
+        <geom type="capsule" size="0.03" fromto="0 0 0 0 0 -0.3" rgba="0.8 0.3 0.3 1"/>
+        <joint name="hip" type="hinge" axis="0 1 0" range="-1.5 1.5"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <motor name="hip_act" joint="hip"/>
+  </actuator>
+</mujoco>
+"""
+
+# Fixed-base arm: no free joint anywhere -> no base position. base_beyond_y must
+# degrade to False (and warn) rather than crash or invent a value.
+FIXED_ARM_XML = """
+<mujoco model="test_fixed">
+  <compiler angle="radian" autolimits="true"/>
+  <worldbody>
+    <light name="main" pos="0 0 3" dir="0 0 -1"/>
+    <body name="link" pos="0 0 0.1">
+      <geom type="capsule" size="0.02" fromto="0 0 0 0 0 0.2"/>
+      <joint name="j0" type="hinge" axis="0 0 1"/>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="j0_act" joint="j0" kp="10"/>
+  </actuator>
+</mujoco>
+"""
+
+
+def _axis_quat(axis: str, deg: float) -> list[float]:
+    """Unit (w, x, y, z) quaternion for a rotation of ``deg`` about a world axis."""
+    h = math.radians(deg) / 2.0
+    c, sn = math.cos(h), math.sin(h)
+    return {
+        "x": [c, sn, 0.0, 0.0],
+        "y": [c, 0.0, sn, 0.0],
+        "z": [c, 0.0, 0.0, sn],
+    }[axis]
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="test_base_beyond_y", mesh=False)
+    s.create_world(ground_plane=False)
+    yield s
+    s.cleanup()
+
+
+def _write(xml: str) -> str:
+    d = tempfile.mkdtemp()
+    p = os.path.join(d, "model.xml")
+    with open(p, "w") as f:
+        f.write(xml)
+    return p
+
+
+def _set_base_pose(sim, y: float, x: float = 0.0, z: float = 0.8, quat_wxyz: list[float] | None = None) -> None:
+    """Set the robot's (only) free joint to world (x, y, z) with orientation quat."""
+    model, data = sim._world._model, sim._world._data
+    jid = -1
+    for j in range(model.njnt):
+        if model.jnt_type[j] == mujoco.mjtJoint.mjJNT_FREE:
+            jid = j
+            break
+    assert jid >= 0
+    qadr = int(model.jnt_qposadr[jid])
+    q = quat_wxyz if quat_wxyz is not None else [1.0, 0.0, 0.0, 0.0]
+    data.qpos[qadr : qadr + 7] = [x, y, z, *q]
+    mujoco.mj_forward(model, data)
+
+
+def test_base_beyond_y_is_registered_as_a_bool_predicate():
+    """It must classify as bool so the DSL accepts it in success/failure clauses."""
+    assert "base_beyond_y" in PREDICATE_REGISTRY
+    assert predicate_kind("base_beyond_y") == "bool"
+
+
+def test_base_beyond_y_trips_once_the_base_passes_the_threshold(sim):
+    """FALSE while the base y is at/behind the threshold, TRUE once it passes it."""
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    pred = make_predicate("base_beyond_y", y=1.0)
+    _set_base_pose(sim, 0.0)
+    assert pred(sim) is False
+    _set_base_pose(sim, 1.0)  # exactly at the threshold is not "beyond"
+    assert pred(sim) is False
+    _set_base_pose(sim, 1.01)
+    assert pred(sim) is True
+    _set_base_pose(sim, 2.5)  # strafed well left
+    assert pred(sim) is True
+
+
+def test_base_beyond_y_reads_the_y_axis_not_the_x_axis(sim):
+    """It is distinct from base_beyond_x: forward x-progress must NOT satisfy a
+    lateral y-goal, and lateral y-progress must NOT satisfy a forward x-read."""
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    y_pred = make_predicate("base_beyond_y", y=1.0)
+    x_pred = make_predicate("base_beyond_x", x=1.0)
+    # Walked far forward (x=3) but zero lateral: y-goal not met, x-goal met.
+    _set_base_pose(sim, 0.0, x=3.0)
+    assert y_pred(sim) is False
+    assert x_pred(sim) is True
+    # Strafed far left (y=3) but zero forward: y-goal met, x-goal not met.
+    _set_base_pose(sim, 3.0, x=0.0)
+    assert y_pred(sim) is True
+    assert x_pred(sim) is False
+
+
+def test_base_beyond_y_is_independent_of_height_and_orientation(sim):
+    """It reads only lateral y-position: the same y at any height / orientation
+    reads identically (a base that strafed but toppled or dropped still counts
+    as having reached the line - the fall predicates reject that)."""
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    pred = make_predicate("base_beyond_y", y=1.0)
+    for quat in ([1.0, 0.0, 0.0, 0.0], _axis_quat("y", 90.0), _axis_quat("z", 120.0)):
+        for z in (0.8, 0.1):
+            _set_base_pose(sim, 0.0, z=z, quat_wxyz=quat)
+            assert pred(sim) is False, "behind the line -> not beyond"
+            _set_base_pose(sim, 2.0, z=z, quat_wxyz=quat)
+            assert pred(sim) is True, "past the line -> beyond (any height/orientation)"
+
+
+def test_base_beyond_y_tracks_the_live_base_position(sim):
+    """The predicate reads the CURRENT base y: strafing the base left flips it."""
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    pred = make_predicate("base_beyond_y", y=0.5)
+    _set_base_pose(sim, 0.0)
+    assert pred(sim) is False
+    _set_base_pose(sim, 0.9)
+    assert pred(sim) is True
+
+
+def test_base_beyond_y_accepts_a_negative_threshold(sim):
+    """y is an unvalidated world threshold (mirrors base_beyond_x): a negative y
+    is a right-of-origin line a base spawned at the origin already reads True on."""
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    pred = make_predicate("base_beyond_y", y=-0.5)
+    _set_base_pose(sim, 0.0)
+    assert pred(sim) is True
+    _set_base_pose(sim, -1.0)
+    assert pred(sim) is False
+
+
+def test_base_beyond_y_degrades_to_false_on_fixed_base_arm(sim, caplog):
+    """A fixed-base arm has no base position: the predicate degrades to False
+    (never made lateral progress -> never spuriously succeeds) and warns once."""
+    sim.add_robot("arm", urdf_path=_write(FIXED_ARM_XML))
+    _reset_resolution_warnings()
+    with caplog.at_level(logging.WARNING, logger="strands_robots.simulation.predicates"):
+        val = make_predicate("base_beyond_y", y=1.0)(sim)
+    assert val is False
+    assert any("base" in r.message.lower() for r in caplog.records)
+
+
+def test_declarative_strafe_benchmark_succeeds_only_past_the_line(sim):
+    """End to end: a DeclarativeBenchmark whose success is base_beyond_y and whose
+    failure is base_tipped + base_below_z - the lateral velocity-tracking task
+    vocabulary (tracking reward with a vy command shapes HOW to strafe, fall
+    predicates end a bad rollout, base_beyond_y scores the GOAL) - compiles and
+    reports success only once the base strafes past the line, and never succeeds
+    while it is still behind it (even if standing perfectly)."""
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    bench = DeclarativeBenchmark.from_dict(
+        {
+            "name": "strafe-left",
+            "default_robot": "humanoid",
+            "max_steps": 1000,
+            "dense_reward": [
+                {"predicate": "base_velocity_tracking", "vy": 0.5, "lin_weight": 1.0},
+            ],
+            "success": {"all": [{"predicate": "base_beyond_y", "y": 1.0}]},
+            "failure": {
+                "any": [
+                    {"predicate": "base_tipped", "tol": 0.7},
+                    {"predicate": "base_below_z", "z": 0.3},
+                ]
+            },
+        }
+    )
+    # Standing upright at the origin: not fallen, but has NOT strafed.
+    _set_base_pose(sim, 0.0, z=0.8, quat_wxyz=[1.0, 0.0, 0.0, 0.0])
+    assert bench.is_failure(sim) is False
+    assert bench.is_success(sim) is False, "standing still must not score the strafe goal"
+    # Strafed past the line, still upright: the goal is reached.
+    _set_base_pose(sim, 2.5, z=0.8, quat_wxyz=[1.0, 0.0, 0.0, 0.0])
+    assert bench.is_failure(sim) is False
+    assert bench.is_success(sim) is True
+    # Reached the line but toppled on the way: success on y, but failure fires
+    # too, so the fall predicates correctly veto a "strafed then fell" run.
+    _set_base_pose(sim, 2.5, z=0.8, quat_wxyz=_axis_quat("y", 90.0))
+    assert bench.is_success(sim) is True
+    assert bench.is_failure(sim) is True

--- a/tests/simulation/test_builtin_benchmarks.py
+++ b/tests/simulation/test_builtin_benchmarks.py
@@ -83,10 +83,10 @@ def sim():
 @pytest.fixture(autouse=True)
 def _clean_registry():
     """Keep the module-global benchmark registry clean around each test."""
-    for _n in ("go2_walk_forward", "g1_walk_forward", "t1_walk_forward"):
+    for _n in ("go2_walk_forward", "g1_walk_forward", "t1_walk_forward", "go2_strafe_left"):
         unregister_benchmark(_n)
     yield
-    for _n in ("go2_walk_forward", "g1_walk_forward", "t1_walk_forward"):
+    for _n in ("go2_walk_forward", "g1_walk_forward", "t1_walk_forward", "go2_strafe_left"):
         unregister_benchmark(_n)
 
 
@@ -380,6 +380,84 @@ def test_t1_walk_forward_dense_reward_is_finite(sim):
     bench = get_benchmark("t1_walk_forward")
     sim.add_robot("floater", urdf_path=_write(NAMED_BASE_XML))
     _set_base_pose(sim, x=0.0, z=0.66)
+    info = bench.on_step(sim, {}, {})
+    assert math.isfinite(info.reward)
+    assert info.done is False
+
+
+# ---------------------------------------------------------------------------
+# go2_strafe_left: the LATERAL counterpart - same quadruped/thresholds, but a
+# pure vy command scored by base_beyond_y (the vx/base_beyond_x tasks never
+# exercise the lateral axis).
+# ---------------------------------------------------------------------------
+def _set_base_y(sim, y: float, x: float = 0.0, z: float = 0.32, quat_wxyz=None) -> None:
+    """Set the (only) free joint to world (x, y, z) - a y-aware pose setter for
+    the strafe task (the shared _set_base_pose fixes y=0)."""
+    if quat_wxyz is None:
+        quat_wxyz = [1.0, 0.0, 0.0, 0.0]
+    model, data = sim._world._model, sim._world._data
+    jid = next(j for j in range(model.njnt) if model.jnt_type[j] == mujoco.mjtJoint.mjJNT_FREE)
+    qadr = int(model.jnt_qposadr[jid])
+    data.qpos[qadr : qadr + 7] = [float(x), float(y), float(z), *quat_wxyz]
+    mujoco.mj_forward(model, data)
+
+
+def test_register_builtin_benchmarks_registers_go2_strafe_left():
+    """go2_strafe_left is absent until registered, then discoverable + runnable."""
+    assert "go2_strafe_left" not in list_benchmarks()
+    names = register_builtin_benchmarks()
+    assert "go2_strafe_left" in names
+    assert "go2_strafe_left" in list_benchmarks()
+    assert get_benchmark("go2_strafe_left") is not None
+
+
+def test_go2_strafe_left_success_fires_on_lateral_progress(sim):
+    """success = base_beyond_y(1.0): False until the base strafes past y=1 m, and
+    forward x-progress alone must NOT satisfy it (distinct from go2_walk_forward)."""
+    register_builtin_benchmarks()
+    bench = get_benchmark("go2_strafe_left")
+    sim.add_robot("floater", urdf_path=_write(NAMED_BASE_XML))
+    _set_base_y(sim, y=0.0)
+    assert bench.is_success(sim) is False
+    _set_base_y(sim, y=0.5)
+    assert bench.is_success(sim) is False  # short of the 1 m lateral line
+    _set_base_y(sim, y=0.0, x=3.0)  # walked far FORWARD but zero lateral
+    assert bench.is_success(sim) is False, "forward progress must not score a strafe goal"
+    _set_base_y(sim, y=2.0)  # strafed well left
+    assert bench.is_success(sim) is True
+
+
+def test_go2_strafe_left_failure_fires_on_topple(sim):
+    """failure includes base_tipped(0.7): a level base continues, a toppled one
+    terminates - the same fall vocabulary as the forward task."""
+    register_builtin_benchmarks()
+    bench = get_benchmark("go2_strafe_left")
+    sim.add_robot("floater", urdf_path=_write(NAMED_BASE_XML))
+    _set_base_y(sim, y=0.0, quat_wxyz=[1.0, 0.0, 0.0, 0.0])
+    assert bench.is_failure(sim) is False
+    _set_base_y(sim, y=0.0, quat_wxyz=_quat_pitch(90.0))  # on its side
+    assert bench.is_failure(sim) is True
+
+
+def test_go2_strafe_left_failure_fires_on_height_collapse(sim):
+    """failure includes base_below_z(0.18): a standing base continues, a
+    collapsed one terminates."""
+    register_builtin_benchmarks()
+    bench = get_benchmark("go2_strafe_left")
+    sim.add_robot("floater", urdf_path=_write(NAMED_BASE_XML))
+    _set_base_y(sim, y=0.0, z=0.32)  # nominal Go2 stance
+    assert bench.is_failure(sim) is False
+    _set_base_y(sim, y=0.0, z=0.1)  # collapsed below 0.18
+    assert bench.is_failure(sim) is True
+
+
+def test_go2_strafe_left_dense_reward_is_finite_and_tracks_vy(sim):
+    """on_step sums the lateral base_velocity_tracking + base_height +
+    base_orientation into a finite dense reward the RL/BC loop can shape on."""
+    register_builtin_benchmarks()
+    bench = get_benchmark("go2_strafe_left")
+    sim.add_robot("floater", urdf_path=_write(NAMED_BASE_XML))
+    _set_base_y(sim, y=0.0, z=0.32)
     info = bench.on_step(sim, {}, {})
     assert math.isfinite(info.reward)
     assert info.done is False


### PR DESCRIPTION
## Problem

The shipped built-in locomotion benchmarks (`go2_walk_forward`, `g1_walk_forward`, `t1_walk_forward`) all command a pure **forward** twist (`vx`) and score it with `base_beyond_x`. The floating-base success family therefore had a forward-progress predicate but **no lateral one**: a strafe task could *reward* a `vy` command (`base_velocity_tracking` already accepts one) yet had no way to *score* reaching a sideways goal, and `inside_region` / `body_above_z` need a base body name a mobile base's unnamed free joint does not expose. No shipped benchmark ever exercised the `vy` term of the tracking reward. The module's own docstring claimed a "complete floating-base locomotion vocabulary" while the lateral half of position-success was missing.

## Change

- **`base_beyond_y(y, robot=None)`** — the lateral-progress `SUCCESS` mirror of `base_beyond_x`. `True` once the base's world y passes `y` (world +y is the robot's left for the identity spawn orientation the locomotion scenes use), reading the same embodiment-agnostic `base_pos` signal off `get_observation` — no base body name, works on an unnamed mobile-base free joint, and degrades to `False` + warn-once on a fixed-base arm (never made lateral progress → never spuriously succeeds). Classified `bool` so the DSL accepts it in `success`/`failure` clauses; added to the module docstring's predicate list.
- **`go2_strafe_left`** — the first shipped benchmark to command a pure lateral body twist (`vx=0`, `vy=0.5`, `wz=0`) and score it with `base_beyond_y(y=1.0)`, reusing the Go2 fall/height thresholds (`base_tipped` tol=0.7, `base_below_z` 0.18). It exercises the `vy` term of `base_velocity_tracking` that the pure-`vx` walk-forward tasks leave at zero, so the velocity-tracking vocabulary is now omnidirectional rather than forward-only. Shipped with a consuming benchmark (not a lone predicate), so it carries no removal risk.

## Verification

Verified end-to-end on a **real Unitree Go2** in MuJoCo via `evaluate_benchmark`: the floating-base observation surfaces (`base_pos [0, 0, 0.445]`), the standing spawn neither trips the fall predicates nor satisfies the lateral goal at t=0, the dense reward composes finite, and the full harness runs (mock policy → collapse → `base_below_z` fires → episode terminates, `success_measured=true`).

Regression tests (GL-free, set known base poses):
- `test_base_beyond_y_predicate.py` — y-threshold, the **y-vs-x axis distinction** (forward x-progress must NOT score a strafe goal, and vice-versa), height/orientation independence, live tracking, negative threshold, fixed-base degradation + warn, and a full `DeclarativeBenchmark` (success `base_beyond_y`, failure `base_tipped`+`base_below_z`) that succeeds only once the base strafes past the line.
- `test_builtin_benchmarks.py` — `go2_strafe_left` registers, its success fires only on lateral progress (forward progress alone does not satisfy it), failure fires on topple / height-collapse, and its dense reward is finite.

All fail before the fix (`Unknown predicate 'base_beyond_y'` / benchmark absent) and pass after; the existing predicate-docstring-completeness contract test stays green (docstring updated in step). `ruff` + `mypy` clean; 490 predicate/reward/benchmark/base/docstring/describe tests pass on both backends.