### PR TITLE
docs(policies): cross-reference MockPolicy by module, not source filename

### DIFF
--- a/strands_robots/policies/base.py
+++ b/strands_robots/policies/base.py
@@ -17,7 +17,7 @@ their goal from the well-known ``**kwargs`` keys documented on
 :meth:`Policy.get_actions` rather than parsing the natural-language
 ``instruction`` string.
 
-See ``MockPolicy`` (``strands_robots/policies/mock.py``) for the canonical
+See :class:`~strands_robots.policies.mock.MockPolicy` for the canonical
 non-VLA reference implementation.
 """
 

--- a/tests/policies/test_docstring_module_xrefs.py
+++ b/tests/policies/test_docstring_module_xrefs.py
@@ -1,0 +1,67 @@
+"""Top-level policy modules must cross-reference sibling code by module, never by
+source filename.
+
+Referencing a source file (``mock.py``, ``factory.py``, ...) in a docstring is
+documentation archaeology: the name breaks silently the moment a file is
+renamed or split, and it points a reader at a path instead of an importable
+symbol. The project convention (see the cosmos3 policy package and the MuJoCo
+backend, guarded by ``tests/simulation/mujoco/test_docstring_module_xrefs.py``)
+is to use Sphinx cross-reference roles - ``:mod:``, ``:class:``, ``:func:`` -
+that name the actual API object, so the reference is checkable and survives
+refactors.
+
+This guard walks every module/class/function docstring in the *top-level*
+``strands_robots.policies`` modules (``base.py``, ``factory.py``, ``mock.py``,
+``composite.py``, ``registry.py``, ...) and fails if any embeds a
+``<something>.py`` filename token. It is intentionally non-recursive: the
+provider subpackages (``wbc/``, ``lerobot_local/``, ``cosmos3/``,
+``motionbricks/``, ...) legitimately cite *upstream* reference scripts by
+filename (``run_mujoco_gear_wbc.py``, ``launch_finetune.py``), which name real
+files in other repositories and are not internal siblings.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import strands_robots.policies as policies_pkg
+
+# A bare source-filename token such as ``mock.py`` or ``factory.py``.
+_FILENAME_RE = re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*\.py\b")
+
+_PACKAGE_DIR = Path(policies_pkg.__file__).parent
+
+
+def _docstrings_with_offenders() -> dict[str, list[str]]:
+    """Map ``module.py::qualname`` -> filename tokens found in that docstring."""
+    offenders: dict[str, list[str]] = {}
+    for source_file in sorted(_PACKAGE_DIR.glob("*.py")):
+        tree = ast.parse(source_file.read_text(encoding="utf-8"), filename=str(source_file))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Module | ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            doc = ast.get_docstring(node, clean=False)
+            if not doc:
+                continue
+            hits = _FILENAME_RE.findall(doc)
+            if hits:
+                qualname = getattr(node, "name", "<module>")
+                offenders[f"{source_file.name}::{qualname}"] = hits
+    return offenders
+
+
+def test_top_level_policy_modules_scanned() -> None:
+    """Guard: the scan actually walked the top-level policy modules."""
+    scanned = {p.name for p in _PACKAGE_DIR.glob("*.py")}
+    assert {"base.py", "factory.py", "mock.py"} <= scanned
+
+
+def test_policy_docstrings_reference_modules_not_filenames() -> None:
+    offenders = _docstrings_with_offenders()
+    assert not offenders, (
+        "Top-level policy docstrings must cross-reference siblings by module "
+        "(:class:`~strands_robots.policies.mock.MockPolicy`) not source filename "
+        f"(``mock.py``). Offending docstrings: {offenders}"
+    )


### PR DESCRIPTION
## Summary

The `Policy` ABC module docstring (`strands_robots/policies/base.py`) pointed at the canonical non-VLA reference implementation with a raw source path:

```
See ``MockPolicy`` (``strands_robots/policies/mock.py``) for the canonical
non-VLA reference implementation.
```

A filename token in a docstring is documentation archaeology: it breaks silently the moment a file is renamed or split, and it points the reader at a path instead of an importable symbol. Every other cross-reference in this same module already uses a Sphinx role (`:class:`Policy``, `:meth:`Policy.get_actions``, `:attr:`Policy.requires_images``) - the lone filename was the odd one out, and it renders as dead monospace text in the generated API docs instead of a navigable link to `MockPolicy`.

## Change

- Rewrite the reference as `:class:`~strands_robots.policies.mock.MockPolicy`` so it resolves to the actual API object, matching the project convention (the cosmos3 policy package and the MuJoCo backend already follow this).
- Add `tests/policies/test_docstring_module_xrefs.py`, a guard mirroring the existing `tests/simulation/mujoco/test_docstring_module_xrefs.py`. It walks the module/class/function docstrings of the **top-level** `strands_robots.policies` modules and fails if any embeds a `` <file>.py `` filename token.

The scan is intentionally **non-recursive**: the provider subpackages (`wbc/`, `lerobot_local/`, `cosmos3/`, `motionbricks/`, ...) legitimately cite *upstream* reference scripts by filename (`run_mujoco_gear_wbc.py`, `launch_finetune.py`), which name real files in other repositories and are not internal siblings - so a blanket recursive ban would produce false positives there.

## Tests

The new guard **fails on the pre-fix docstring** and passes after:

```
# pre-fix
E  AssertionError: ... Offending docstrings: {'base.py::<module>': ['mock.py']}
1 failed, 1 passed

# post-fix
2 passed in 0.04s
```

Full local gate is green: `ruff check` / `ruff format --check` clean, `mypy strands_robots tests tests_integ` -> `Success: no issues found in 764 source files`, and the full `tests/policies/` suite passes (1617 passed, 2 skipped).

Docs-only + a regression guard; no runtime behavior, signature, or wire-format change.