### PR TITLE
test(benchmark): pin unknown-predicate rejection in dense_reward terms

### DIFF
--- a/tests/simulation/test_benchmark_dsl.py
+++ b/tests/simulation/test_benchmark_dsl.py
@@ -193,6 +193,26 @@ class TestPredicateCompilation:
             DeclarativeBenchmark.from_dict(self._base_spec(success={"all": [], "other": []}))
         assert "other" in str(exc.value)
 
+    def test_rejects_unknown_predicate_in_dense_reward(self):
+        """A typo'd predicate name in a ``dense_reward`` term surfaces the same
+        clear ``Unknown predicate ... Valid: [...]`` error as a success clause.
+
+        Success / failure clauses reject unknown names early via
+        ``predicate_kind`` kind-checking, but ``dense_reward`` terms compile
+        through a different path with no kind requirement and rely on
+        ``make_predicate`` to reject the name. This pins that a typo in a
+        reward-term predicate still fails loudly at compile time with a
+        discoverable list of valid predicates, rather than a cryptic
+        downstream crash at evaluation.
+        """
+        with pytest.raises(ValueError) as exc:
+            DeclarativeBenchmark.from_dict(
+                self._base_spec(dense_reward=[{"predicate": "totally_made_up", "value": 1.0}])
+            )
+        msg = str(exc.value)
+        assert "Unknown predicate" in msg
+        assert "totally_made_up" in msg
+
     def test_predicate_bad_kwargs_surface_compile_error(self):
         """Bad predicate kwargs (wrong types, missing required) surface as a
         compile-time error, not a runtime predicate crash."""


### PR DESCRIPTION
## Problem

The declarative benchmark DSL loader (`strands_robots.simulation.benchmark_spec`) rejects unknown predicate names, but via two different code paths depending on where the predicate appears:

- **success / failure clauses** call `predicate_kind(name)` first (to reject float-valued reward terms used as boolean success predicates). For an unknown name, `predicate_kind` itself raises `ValueError` early, so the name never reaches `make_predicate`.
- **`dense_reward` terms** compile through `_compile_call` with no `require_kind`, so the `predicate_kind` pre-check is skipped and rejection relies entirely on `make_predicate` raising `ValueError`, which `_compile_call` re-raises verbatim.

That re-raise branch (the `except ValueError: raise` in `_compile_call`) had no test: `test_rejects_unknown_predicate` only exercises the early success-clause path, so the `dense_reward` rejection guarantee was unverified. A typo in a reward-term predicate name is a common authoring mistake, and nothing pinned that it fails loudly at compile time rather than crashing cryptically later during evaluation.

## Change

Add `test_rejects_unknown_predicate_in_dense_reward`: a typo'd predicate name in a `dense_reward` term surfaces the same clear `Unknown predicate ... Valid: [...]` `ValueError` at `from_dict` compile time as a success clause, with the valid predicate list for discoverability.

Test-only; no library behavior change.

## Tests

`tests/simulation/test_benchmark_dsl.py::TestPredicateCompilation` now covers the `dense_reward` unknown-name path. Coverage of `strands_robots/simulation/benchmark_spec.py` goes from 99% (1 uncovered line: the `make_predicate` `ValueError` re-raise) to 100%.

```
MUJOCO_GL=egl pytest tests/simulation/test_benchmark_dsl.py -> 43 passed
```

Full local gate green: `ruff check`, `ruff format --check`, `mypy` (over `strands_robots tests tests_integ`) all clean.