### PR TITLE
feat(sim): base_yaw_beyond turn-progress predicate + go2_turn_left benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Added: yaw locomotion vocabulary - `base_yaw_beyond` predicate + `go2_turn_left` benchmark
+
+The floating-base locomotion DSL could command a yaw-rate (`base_velocity_tracking`
+already accepts `wz`) but had no way to SCORE reaching a turn: the progress
+predicates `base_beyond_x` / `base_beyond_y` read only `base_pos`, so a
+turn-in-place task could reward a `wz` command yet had no terminal for "the base
+actually turned", and `base_tipped` fires on any tilt (roll/pitch), not a
+deliberate turn about the vertical. This adds `base_yaw_beyond(yaw, robot=None)`
+-- TRUE once the base's world yaw heading (extracted from `base_quat`) passes
+`yaw` radians (positive = left/counter-clockwise from the identity spawn) --
+reading the same embodiment-agnostic floating-base surface the other `base_*`
+terms read (no base body name; works on a mobile base whose free joint is
+unnamed) and degrading to `False` on a fixed-base arm. It ships `go2_turn_left`,
+the first built-in to command a pure yaw (`vx=0`, `vy=0`, `wz=0.5`) body twist
+and score it with `base_yaw_beyond`, completing the omnidirectional
+velocity-tracking vocabulary: the three shipped Go2 tasks now exercise all three
+command axes (`vx`/`vy`/`wz`) and all three progress predicates
+(`base_beyond_x`/`base_beyond_y`/`base_yaw_beyond`). A pure roll/pitch tilt never
+satisfies a yaw goal (distinguishing it from `base_tipped`); pairing it with
+`base_tipped` in `failure` vetoes a "turned then fell" rollout, whose yaw would
+be ill-defined.
+
 ### Fixed: `get_observation` no longer emits a floating base's free joint as a degenerate scalar
 
 A robot whose root is a 6-DoF free joint (a humanoid's named

--- a/strands_robots/simulation/builtin_benchmarks.py
+++ b/strands_robots/simulation/builtin_benchmarks.py
@@ -16,9 +16,12 @@ quadruped task (``go2_strafe_left``) - so a floating-base robot has a runnable,
 discoverable eval out of the box, and to show the same embodiment-agnostic DSL
 transfers unchanged across morphologies, across two bipeds of different scale,
 AND across command directions: ``go2_strafe_left`` commands a pure lateral
-(``vy``) body twist and scores it with ``base_beyond_y``, exercising the
-lateral half of the velocity-tracking vocabulary that the walk-forward tasks
-(pure ``vx`` + ``base_beyond_x``) never touch.
+(``vy``) body twist and scores it with ``base_beyond_y``, and
+``go2_turn_left`` commands a pure yaw-rate (``wz``) twist and scores it with
+``base_yaw_beyond`` - so the three shipped Go2 tasks exercise all three axes
+of the velocity-tracking command (forward ``vx``, lateral ``vy``, yaw ``wz``)
+and all three progress predicates (``base_beyond_x`` / ``base_beyond_y`` /
+``base_yaw_beyond``), the full omnidirectional locomotion vocabulary.
 
 Registration is opt-in - a caller invokes :func:`register_builtin_benchmarks`
 (mirroring how the LIBERO suite registers on demand via
@@ -224,6 +227,57 @@ _GO2_STRAFE_LEFT: dict[str, Any] = {
 }
 
 
+# ``go2_turn_left``: the YAW (turn-in-place) velocity-tracking counterpart of
+# ``go2_walk_forward`` / ``go2_strafe_left`` - turn the Unitree Go2 in place to
+# its left at 0.5 rad/s and stay standing. It is the first shipped benchmark to
+# command a non-zero yaw-rate (``wz``) twist and to score a HEADING goal,
+# completing the omnidirectional velocity-tracking vocabulary (the walk-forward
+# tasks command ``vx``, ``go2_strafe_left`` commands ``vy``, and this commands
+# ``wz`` - all three axes of ``base_velocity_tracking``):
+#
+#   - success: the base turns past a 1.0 rad (~57 deg) heading to the left
+#     (``base_yaw_beyond``) - world yaw is measured from the identity spawn, so
+#     positive is a left (counter-clockwise) turn. A standing-still or
+#     translating-but-not-turning policy never satisfies it (it scores heading
+#     progress, not "did not fall" and not linear displacement).
+#   - failure: the same fall modes as the other Go2 tasks - topple past ~53 deg
+#     (``base_tipped``, tol=0.7) OR height collapse below 0.18 m
+#     (``base_below_z``, the Go2 stands at ~0.32 m). Pairing the fall predicate
+#     with the yaw success is deliberate: a toppled base has an ill-defined yaw,
+#     so ``base_tipped`` vetoes a "turned then fell" rollout.
+#   - dense_reward: the same legged_gym-style stack, but the tracked twist is a
+#     PURE yaw command (vx=0.0, vy=0.0, wz=0.5) - the ``wz`` term of
+#     ``base_velocity_tracking`` (with vx=vy=0 also rewarding zero drift, i.e.
+#     turning IN PLACE) that the walk-forward and strafe tasks leave at zero -
+#     plus the 0.32 m base-height and flat-orientation regularizers.
+_GO2_TURN_LEFT: dict[str, Any] = {
+    "name": "go2_turn_left",
+    "default_robot": "unitree_go2",
+    "supported_robots": ["unitree_go2"],
+    "max_steps": 1000,
+    "success": {"all": [{"predicate": "base_yaw_beyond", "yaw": 1.0}]},
+    "failure": {
+        "any": [
+            {"predicate": "base_tipped", "tol": 0.7},
+            {"predicate": "base_below_z", "z": 0.18},
+        ]
+    },
+    "dense_reward": [
+        {
+            "predicate": "base_velocity_tracking",
+            "vx": 0.0,
+            "vy": 0.0,
+            "wz": 0.5,
+            "lin_weight": 1.0,
+            "ang_weight": 0.5,
+            "tracking_sigma": 0.25,
+        },
+        {"predicate": "base_height", "target": 0.32, "weight": 0.5},
+        {"predicate": "base_orientation", "weight": 0.5},
+    ],
+}
+
+
 # Registry of shipped built-in specs, keyed by their canonical registry name.
 # Extend this dict to ship more; every entry reuses the same embodiment-agnostic
 # floating-base DSL, differing only in the robot, thresholds, and reward stack.
@@ -232,6 +286,7 @@ _BUILTIN_SPECS: dict[str, dict[str, Any]] = {
     "g1_walk_forward": _G1_WALK_FORWARD,
     "t1_walk_forward": _T1_WALK_FORWARD,
     "go2_strafe_left": _GO2_STRAFE_LEFT,
+    "go2_turn_left": _GO2_TURN_LEFT,
 }
 
 

--- a/strands_robots/simulation/predicates.py
+++ b/strands_robots/simulation/predicates.py
@@ -42,6 +42,7 @@ Available predicates (bool):
     base_below_z(z, robot=None)
     base_beyond_x(x, robot=None)
     base_beyond_y(y, robot=None)
+    base_yaw_beyond(yaw, robot=None)
 
 Available reward terms (float):
 
@@ -981,6 +982,71 @@ def _base_beyond_y(y: float, robot: str | None = None) -> BoolPredicate:
     return check
 
 
+def _base_yaw_beyond(yaw: float, robot: str | None = None) -> BoolPredicate:
+    """True when a floating base has turned past a heading of ``yaw`` radians.
+
+    The YAW (turn-in-place) SUCCESS counterpart of :func:`_base_beyond_x`
+    (forward) and :func:`_base_beyond_y` (lateral): those score a *position*
+    goal off ``base_pos``, while ``base_yaw_beyond`` scores a *heading* goal off
+    ``base_quat``. It is the missing rotational third of the omnidirectional
+    velocity-tracking vocabulary - the reward term ``base_velocity_tracking``
+    already accepts a yaw-rate command ``wz``, but until now no predicate could
+    SCORE reaching a turn goal, so a turn-in-place benchmark could reward a
+    ``wz`` command yet had no terminal for "the base actually turned". It drops
+    straight into a ``success`` clause next to the fall predicates in
+    ``failure``::
+
+        success:
+          all:
+            - {predicate: base_yaw_beyond, yaw: 1.0}
+        failure:
+          any:
+            - {predicate: base_tipped, tol: 0.7}
+            - {predicate: base_below_z, z: 0.18}
+
+    The heading is the base's yaw about the world vertical, extracted from the
+    ``base_quat`` (``w, x, y, z``) surface the ``base_*`` reward terms,
+    ``base_tipped``, ``base_beyond_x`` and ``base_beyond_y`` read - so it needs
+    no base body name and works on a mobile base whose free joint is unnamed::
+
+        yaw = atan2(2 * (w * z + x * y), 1 - 2 * (y * y + z * z))
+
+    ``yaw`` is an ABSOLUTE world heading in radians, single-signed and measured
+    from the spawn heading (the locomotion scenes spawn at the identity
+    orientation -> yaw 0), exactly as ``base_beyond_x`` reads an absolute world x
+    from a +x-facing spawn: positive is a LEFT (counter-clockwise) turn, so
+    ``base_yaw_beyond(yaw=1.0)`` reads "turned ~1 rad (~57 deg) to the left". A
+    turn-in-place task targets a sub-pi heading (a single turn of less than a
+    half-revolution); the yaw wraps at +-pi, so a goal at or beyond pi is not a
+    well-defined single-turn heading (measuring cumulative revolutions would
+    need integrated-angle tracking, out of scope here just as ``base_beyond_x``
+    does not track total path length). It is a pure heading test - roll and
+    pitch do NOT affect the yaw, so a base that merely tips (without turning
+    about the vertical) never satisfies a yaw goal; position and height do not
+    affect it either. Because the yaw of a fully toppled base is ill-defined,
+    pair it with ``base_tipped`` in a ``failure`` clause so a "turned then fell"
+    rollout is rejected on the tilt, not scored as a valid turn.
+
+    Requires a robot with a floating base; a fixed-base arm has no base
+    orientation, so the predicate degrades to ``False`` (never turned -> never
+    spuriously succeeds) and the missing base is logged once. ``robot`` selects
+    the robot in a multi-robot scene (default: the sole robot).
+    """
+    yt = float(yaw)
+    rname = robot
+
+    def check(sim: SimEngine) -> bool:
+        quat = _base_quaternion(sim, rname)
+        if quat is None:
+            return False
+        # base_quat layout is (w, x, y, z) on both backends.
+        w, x, y, z = quat
+        heading = math.atan2(2.0 * (w * z + x * y), 1.0 - 2.0 * (y * y + z * z))
+        return heading > yt
+
+    return check
+
+
 # Reward terms (float-valued)
 
 
@@ -1460,6 +1526,7 @@ PREDICATE_REGISTRY: dict[str, PredicateFactory] = {
     "base_below_z": _base_below_z,
     "base_beyond_x": _base_beyond_x,
     "base_beyond_y": _base_beyond_y,
+    "base_yaw_beyond": _base_yaw_beyond,
     # float-valued
     "distance_neg": _distance_neg,
     "joint_progress": _joint_progress,

--- a/tests/simulation/test_base_yaw_beyond_predicate.py
+++ b/tests/simulation/test_base_yaw_beyond_predicate.py
@@ -1,0 +1,256 @@
+"""Regression tests for the ``base_yaw_beyond`` floating-base heading predicate.
+
+The predicate/reward DSL grew FORWARD- and LATERAL-progress success predicates
+(``base_beyond_x`` / ``base_beyond_y``) alongside the velocity-tracking reward
+(``base_velocity_tracking``, which already accepts a yaw-rate ``wz`` command) and
+the fall predicates (``base_tipped`` / ``base_below_z``). The YAW success half -
+"the base actually turned" - was still inexpressible: ``base_beyond_x`` /
+``base_beyond_y`` read only ``base_pos``, so a turn-in-place benchmark could
+reward a ``wz`` command but had no way to SCORE reaching a heading goal, and
+``base_tipped`` fires on ANY tilt (roll/pitch), not a deliberate turn about the
+vertical.
+
+``base_yaw_beyond(yaw, robot)`` closes that gap: TRUE when the base's world yaw
+heading (extracted from ``base_quat``) has passed ``yaw`` radians (positive is a
+left / counter-clockwise turn from the identity spawn). These tests set a KNOWN
+base pose directly on the sim and assert the threshold, that it reads the YAW
+axis (a pure roll/pitch does NOT trip it, distinguishing it from ``base_tipped``),
+position/height independence, that x-position does NOT trip it (distinct from
+``base_beyond_x``), live tracking, fixed-base degradation, and that a real
+``DeclarativeBenchmark`` whose success is ``base_yaw_beyond`` and failure is
+``base_tipped`` + ``base_below_z`` succeeds once the base turns and is vetoed if
+it falls. They are GL-free (``get_observation`` with ``skip_images``) so they run
+in CI without a display.
+"""
+
+import logging
+import math
+import os
+import tempfile
+
+import mujoco
+import pytest
+
+from strands_robots.simulation.benchmark_spec import DeclarativeBenchmark
+from strands_robots.simulation.mujoco.simulation import Simulation
+from strands_robots.simulation.predicates import (
+    PREDICATE_REGISTRY,
+    _reset_resolution_warnings,
+    make_predicate,
+    predicate_kind,
+)
+
+# Floating base with a NAMED free joint (a humanoid's floating_base_joint) plus
+# one actuated hinge. get_observation surfaces base_quat for this robot.
+NAMED_BASE_XML = """
+<mujoco model="test_named_base">
+  <compiler angle="radian" autolimits="true"/>
+  <option timestep="0.002"/>
+  <worldbody>
+    <light name="main" pos="0 0 3" dir="0 0 -1"/>
+    <geom name="ground" type="plane" size="5 5 0.01" rgba="0.9 0.9 0.9 1"/>
+    <body name="pelvis" pos="0 0 0.8">
+      <freejoint name="floating_base_joint"/>
+      <geom type="box" size="0.1 0.1 0.1" rgba="0.3 0.3 0.8 1"/>
+      <body name="thigh" pos="0 0 -0.1">
+        <geom type="capsule" size="0.03" fromto="0 0 0 0 0 -0.3" rgba="0.8 0.3 0.3 1"/>
+        <joint name="hip" type="hinge" axis="0 1 0" range="-1.5 1.5"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <motor name="hip_act" joint="hip"/>
+  </actuator>
+</mujoco>
+"""
+
+# Fixed-base arm: no free joint anywhere -> no base orientation. base_yaw_beyond
+# must degrade to False (and warn) rather than crash or invent a heading.
+FIXED_ARM_XML = """
+<mujoco model="test_fixed">
+  <compiler angle="radian" autolimits="true"/>
+  <worldbody>
+    <light name="main" pos="0 0 3" dir="0 0 -1"/>
+    <body name="link" pos="0 0 0.1">
+      <geom type="capsule" size="0.02" fromto="0 0 0 0 0 0.2"/>
+      <joint name="j0" type="hinge" axis="0 0 1"/>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="j0_act" joint="j0" kp="10"/>
+  </actuator>
+</mujoco>
+"""
+
+
+def _axis_quat(axis: str, deg: float) -> list[float]:
+    """Unit (w, x, y, z) quaternion for a rotation of ``deg`` about a world axis."""
+    h = math.radians(deg) / 2.0
+    c, sn = math.cos(h), math.sin(h)
+    return {
+        "x": [c, sn, 0.0, 0.0],
+        "y": [c, 0.0, sn, 0.0],
+        "z": [c, 0.0, 0.0, sn],
+    }[axis]
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="test_base_yaw_beyond", mesh=False)
+    s.create_world(ground_plane=False)
+    yield s
+    s.cleanup()
+
+
+def _write(xml: str) -> str:
+    d = tempfile.mkdtemp()
+    p = os.path.join(d, "model.xml")
+    with open(p, "w") as f:
+        f.write(xml)
+    return p
+
+
+def _set_base_pose(sim, quat_wxyz: list[float] | None = None, x: float = 0.0, y: float = 0.0, z: float = 0.8) -> None:
+    """Set the robot's (only) free joint to world (x, y, z) with orientation quat."""
+    model, data = sim._world._model, sim._world._data
+    jid = next(j for j in range(model.njnt) if model.jnt_type[j] == mujoco.mjtJoint.mjJNT_FREE)
+    qadr = int(model.jnt_qposadr[jid])
+    q = quat_wxyz if quat_wxyz is not None else [1.0, 0.0, 0.0, 0.0]
+    data.qpos[qadr : qadr + 7] = [x, y, z, *q]
+    mujoco.mj_forward(model, data)
+
+
+def test_base_yaw_beyond_is_registered_as_a_bool_predicate():
+    """It must classify as bool so the DSL accepts it in success/failure clauses."""
+    assert "base_yaw_beyond" in PREDICATE_REGISTRY
+    assert predicate_kind("base_yaw_beyond") == "bool"
+
+
+def test_base_yaw_beyond_trips_once_the_base_turns_past_the_threshold(sim):
+    """FALSE while the heading is at/behind the threshold, TRUE once it passes it."""
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    pred = make_predicate("base_yaw_beyond", yaw=1.0)  # ~57 deg left
+    _set_base_pose(sim, _axis_quat("z", 0.0))
+    assert pred(sim) is False
+    _set_base_pose(sim, _axis_quat("z", 50.0))  # ~0.87 rad, short of the 1.0 rad line
+    assert pred(sim) is False
+    _set_base_pose(sim, _axis_quat("z", 60.0))  # ~1.05 rad, past the line
+    assert pred(sim) is True
+    _set_base_pose(sim, _axis_quat("z", 120.0))  # turned well left
+    assert pred(sim) is True
+
+
+def test_base_yaw_beyond_reads_yaw_not_a_roll_or_pitch_tilt(sim):
+    """It is a heading test, NOT a tilt test: a base that merely rolls or pitches
+    (about a horizontal axis) has an unchanged yaw and must NOT satisfy a turn
+    goal - the property that distinguishes it from base_tipped."""
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    pred = make_predicate("base_yaw_beyond", yaw=0.1)  # a tiny turn goal
+    for tilt in (_axis_quat("x", 80.0), _axis_quat("y", 80.0)):  # large roll / pitch
+        _set_base_pose(sim, tilt)
+        assert pred(sim) is False, "a pure roll/pitch tilt is not a yaw turn"
+    # but a genuine turn about the vertical does satisfy it
+    _set_base_pose(sim, _axis_quat("z", 30.0))
+    assert pred(sim) is True
+
+
+def test_base_yaw_beyond_reads_heading_not_position(sim):
+    """It is distinct from base_beyond_x/y: linear displacement (with no turn)
+    must NOT satisfy a heading goal, and a turn (at the origin) must NOT satisfy
+    a forward-position read."""
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    yaw_pred = make_predicate("base_yaw_beyond", yaw=0.5)
+    x_pred = make_predicate("base_beyond_x", x=1.0)
+    # Walked far forward + left but never turned: heading-goal not met, x-goal met.
+    _set_base_pose(sim, _axis_quat("z", 0.0), x=3.0, y=3.0)
+    assert yaw_pred(sim) is False
+    assert x_pred(sim) is True
+    # Turned in place at the origin: heading-goal met, x-goal not met.
+    _set_base_pose(sim, _axis_quat("z", 45.0), x=0.0, y=0.0)
+    assert yaw_pred(sim) is True
+    assert x_pred(sim) is False
+
+
+def test_base_yaw_beyond_is_independent_of_position_and_height(sim):
+    """It reads only the yaw heading: the same heading at any world x/y/z reads
+    identically (a base that turned but drifted or dropped still counts as having
+    reached the heading - the fall predicates reject a dropped base)."""
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    pred = make_predicate("base_yaw_beyond", yaw=1.0)
+    for x, y, z in ((0.0, 0.0, 0.8), (2.5, -1.5, 0.1)):
+        _set_base_pose(sim, _axis_quat("z", 0.0), x=x, y=y, z=z)
+        assert pred(sim) is False, "not turned -> not beyond (any position/height)"
+        _set_base_pose(sim, _axis_quat("z", 90.0), x=x, y=y, z=z)
+        assert pred(sim) is True, "turned 90 deg -> beyond (any position/height)"
+
+
+def test_base_yaw_beyond_tracks_the_live_base_heading(sim):
+    """The predicate reads the CURRENT base heading: turning the base flips it."""
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    pred = make_predicate("base_yaw_beyond", yaw=0.5)
+    _set_base_pose(sim, _axis_quat("z", 0.0))
+    assert pred(sim) is False
+    _set_base_pose(sim, _axis_quat("z", 45.0))
+    assert pred(sim) is True
+
+
+def test_base_yaw_beyond_accepts_a_negative_threshold(sim):
+    """yaw is an unvalidated world heading (mirrors base_beyond_x/y): a negative
+    threshold is a right-of-spawn heading a base at the identity spawn already
+    reads True on."""
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    pred = make_predicate("base_yaw_beyond", yaw=-0.5)
+    _set_base_pose(sim, _axis_quat("z", 0.0))
+    assert pred(sim) is True
+    _set_base_pose(sim, _axis_quat("z", -45.0))  # turned right, below -0.5 rad
+    assert pred(sim) is False
+
+
+def test_base_yaw_beyond_degrades_to_false_on_fixed_base_arm(sim, caplog):
+    """A fixed-base arm has no base orientation: the predicate degrades to False
+    (never turned -> never spuriously succeeds) and warns once."""
+    sim.add_robot("arm", urdf_path=_write(FIXED_ARM_XML))
+    _reset_resolution_warnings()
+    with caplog.at_level(logging.WARNING, logger="strands_robots.simulation.predicates"):
+        val = make_predicate("base_yaw_beyond", yaw=1.0)(sim)
+    assert val is False
+    assert any("base" in r.message.lower() for r in caplog.records)
+
+
+def test_declarative_turn_benchmark_succeeds_on_turn_and_is_vetoed_by_a_fall(sim):
+    """End to end: a DeclarativeBenchmark whose success is base_yaw_beyond and
+    whose failure is base_tipped + base_below_z - the yaw velocity-tracking task
+    vocabulary (tracking reward with a wz command shapes HOW to turn, fall
+    predicates end a bad rollout, base_yaw_beyond scores the GOAL) - compiles and
+    reports success only once the base turns past the heading, never while it is
+    standing un-turned, and a topple vetoes the run via the failure clause."""
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    bench = DeclarativeBenchmark.from_dict(
+        {
+            "name": "turn-left",
+            "default_robot": "humanoid",
+            "max_steps": 1000,
+            "dense_reward": [
+                {"predicate": "base_velocity_tracking", "wz": 0.5, "lin_weight": 1.0},
+            ],
+            "success": {"all": [{"predicate": "base_yaw_beyond", "yaw": 1.0}]},
+            "failure": {
+                "any": [
+                    {"predicate": "base_tipped", "tol": 0.7},
+                    {"predicate": "base_below_z", "z": 0.3},
+                ]
+            },
+        }
+    )
+    # Standing upright, not turned: not fallen, but has NOT reached the heading.
+    _set_base_pose(sim, _axis_quat("z", 0.0), z=0.8)
+    assert bench.is_failure(sim) is False
+    assert bench.is_success(sim) is False, "standing un-turned must not score the turn goal"
+    # Turned past the line, still upright: the goal is reached.
+    _set_base_pose(sim, _axis_quat("z", 90.0), z=0.8)
+    assert bench.is_failure(sim) is False
+    assert bench.is_success(sim) is True
+    # Toppled (pitched onto its side): the fall predicate fires and vetoes the
+    # rollout (a toppled base's yaw is ill-defined, so the tilt is the terminal).
+    _set_base_pose(sim, _axis_quat("y", 90.0), z=0.8)
+    assert bench.is_failure(sim) is True

--- a/tests/simulation/test_builtin_benchmarks.py
+++ b/tests/simulation/test_builtin_benchmarks.py
@@ -72,6 +72,12 @@ def _quat_pitch(deg: float) -> list[float]:
     return [math.cos(h), 0.0, math.sin(h), 0.0]
 
 
+def _quat_yaw(deg: float) -> list[float]:
+    """Unit (w, x, y, z) quaternion for a yaw turn (rotation about world +z)."""
+    h = math.radians(deg) / 2.0
+    return [math.cos(h), 0.0, 0.0, math.sin(h)]
+
+
 @pytest.fixture
 def sim():
     s = Simulation(tool_name="test_builtin_benchmarks", mesh=False)
@@ -83,10 +89,10 @@ def sim():
 @pytest.fixture(autouse=True)
 def _clean_registry():
     """Keep the module-global benchmark registry clean around each test."""
-    for _n in ("go2_walk_forward", "g1_walk_forward", "t1_walk_forward", "go2_strafe_left"):
+    for _n in ("go2_walk_forward", "g1_walk_forward", "t1_walk_forward", "go2_strafe_left", "go2_turn_left"):
         unregister_benchmark(_n)
     yield
-    for _n in ("go2_walk_forward", "g1_walk_forward", "t1_walk_forward", "go2_strafe_left"):
+    for _n in ("go2_walk_forward", "g1_walk_forward", "t1_walk_forward", "go2_strafe_left", "go2_turn_left"):
         unregister_benchmark(_n)
 
 
@@ -458,6 +464,92 @@ def test_go2_strafe_left_dense_reward_is_finite_and_tracks_vy(sim):
     bench = get_benchmark("go2_strafe_left")
     sim.add_robot("floater", urdf_path=_write(NAMED_BASE_XML))
     _set_base_y(sim, y=0.0, z=0.32)
+    info = bench.on_step(sim, {}, {})
+    assert math.isfinite(info.reward)
+    assert info.done is False
+
+
+# ---------------------------------------------------------------------------
+# go2_turn_left: the YAW counterpart - same quadruped/thresholds, a wz command
+# and a base_yaw_beyond heading goal (completes the vx/vy/wz vocabulary)
+# ---------------------------------------------------------------------------
+def _set_base_yaw(sim, deg: float, z: float = 0.32) -> None:
+    """Set the free joint to a KNOWN yaw heading at the origin (turn-in-place)."""
+    model, data = sim._world._model, sim._world._data
+    jid = next(j for j in range(model.njnt) if model.jnt_type[j] == mujoco.mjtJoint.mjJNT_FREE)
+    qadr = int(model.jnt_qposadr[jid])
+    data.qpos[qadr : qadr + 7] = [0.0, 0.0, float(z), *_quat_yaw(deg)]
+    mujoco.mj_forward(model, data)
+
+
+def test_register_builtin_benchmarks_registers_go2_turn_left():
+    """go2_turn_left is absent until registered, then discoverable + runnable."""
+    assert "go2_turn_left" not in list_benchmarks()
+    names = register_builtin_benchmarks()
+    assert "go2_turn_left" in names
+    assert "go2_turn_left" in list_benchmarks()
+    assert get_benchmark("go2_turn_left") is not None
+
+
+def test_builtin_specs_include_go2_turn_left_with_a_pure_yaw_command():
+    """The shipped turn spec commands a PURE yaw twist (vx=vy=0, wz>0) and scores
+    a heading goal with base_yaw_beyond - the wz axis the walk/strafe tasks leave
+    at zero."""
+    spec = builtin_benchmark_specs()["go2_turn_left"]
+    succ = spec["success"]["all"][0]
+    assert succ["predicate"] == "base_yaw_beyond"
+    assert succ["yaw"] == 1.0
+    track = next(r for r in spec["dense_reward"] if r["predicate"] == "base_velocity_tracking")
+    assert track["vx"] == 0.0 and track["vy"] == 0.0 and track["wz"] == 0.5
+
+
+def test_go2_turn_left_success_fires_on_yaw_progress(sim):
+    """success = base_yaw_beyond(1.0): False until the base turns past ~1 rad left,
+    and pure forward displacement (no turn) never satisfies it."""
+    register_builtin_benchmarks()
+    bench = get_benchmark("go2_turn_left")
+    sim.add_robot("floater", urdf_path=_write(NAMED_BASE_XML))
+    _set_base_yaw(sim, deg=0.0)
+    assert bench.is_success(sim) is False
+    _set_base_yaw(sim, deg=45.0)  # ~0.79 rad, short of the 1.0 rad line
+    assert bench.is_success(sim) is False
+    _set_base_pose(sim, x=3.0)  # walked far forward but never turned
+    assert bench.is_success(sim) is False
+    _set_base_yaw(sim, deg=90.0)  # turned well left
+    assert bench.is_success(sim) is True
+
+
+def test_go2_turn_left_failure_fires_on_topple(sim):
+    """failure includes base_tipped(0.7): a level (turned) base continues, a
+    toppled one terminates - vetoing a 'turned then fell' rollout."""
+    register_builtin_benchmarks()
+    bench = get_benchmark("go2_turn_left")
+    sim.add_robot("floater", urdf_path=_write(NAMED_BASE_XML))
+    _set_base_yaw(sim, deg=90.0)  # turned, upright
+    assert bench.is_failure(sim) is False
+    _set_base_pose(sim, x=0.0, quat_wxyz=_quat_pitch(90.0))  # on its side
+    assert bench.is_failure(sim) is True
+
+
+def test_go2_turn_left_failure_fires_on_height_collapse(sim):
+    """failure includes base_below_z(0.18): a standing base continues, a
+    collapsed one terminates."""
+    register_builtin_benchmarks()
+    bench = get_benchmark("go2_turn_left")
+    sim.add_robot("floater", urdf_path=_write(NAMED_BASE_XML))
+    _set_base_yaw(sim, deg=90.0, z=0.32)  # nominal Go2 stance, turned
+    assert bench.is_failure(sim) is False
+    _set_base_yaw(sim, deg=90.0, z=0.1)  # collapsed below 0.18
+    assert bench.is_failure(sim) is True
+
+
+def test_go2_turn_left_dense_reward_is_finite_and_tracks_wz(sim):
+    """on_step sums the yaw base_velocity_tracking + base_height + base_orientation
+    into a finite dense reward the RL/BC loop can shape on."""
+    register_builtin_benchmarks()
+    bench = get_benchmark("go2_turn_left")
+    sim.add_robot("floater", urdf_path=_write(NAMED_BASE_XML))
+    _set_base_yaw(sim, deg=0.0, z=0.32)
     info = bench.on_step(sim, {}, {})
     assert math.isfinite(info.reward)
     assert info.done is False


### PR DESCRIPTION
## What

Complete the omnidirectional velocity-tracking vocabulary in the floating-base locomotion DSL.

`base_velocity_tracking` already accepts a yaw-rate command (`wz`), but **no predicate could SCORE reaching a turn**: `base_beyond_x` / `base_beyond_y` read only `base_pos`, so a turn-in-place task could reward a `wz` command yet had no terminal for *"the base actually turned"*, and `base_tipped` fires on any tilt (roll/pitch), not a deliberate turn about the vertical. The three Go2 built-ins exercised only `vx` (walk-forward) and `vy` (strafe); the `wz` axis and a heading success predicate were the missing rotational third.

## Changes

- **`base_yaw_beyond(yaw, robot=None)`** — new bool predicate. TRUE once the base's world yaw heading, extracted from `base_quat` via `atan2(2(wz+xy), 1-2(yy+zz))`, passes `yaw` radians (positive = left / counter-clockwise from the identity spawn). Reads the same embodiment-agnostic floating-base surface (`base_quat`) the other `base_*` terms read — no base body name, so it works on a mobile base whose free joint is unnamed — and degrades to `False` (+ warn once) on a fixed-base arm, exactly like `base_beyond_x` / `base_beyond_y`. A pure roll/pitch tilt leaves the yaw unchanged and never satisfies a turn goal (the property that distinguishes it from `base_tipped`); position and height do not affect it. Registered in `PREDICATE_REGISTRY`, classified `bool` by `predicate_kind`, and listed in the module docstring discovery surface.
- **`go2_turn_left`** — new built-in benchmark: the first to command a **pure yaw twist** (`vx=0`, `vy=0`, `wz=0.5`) and score a heading goal with `base_yaw_beyond(yaw=1.0)`, with the same `base_tipped` / `base_below_z` fall failures the other Go2 tasks use. The three shipped Go2 tasks now exercise **all three command axes** (`vx`/`vy`/`wz`) and **all three progress predicates** (`base_beyond_x`/`base_beyond_y`/`base_yaw_beyond`).

Pairing `base_yaw_beyond` with `base_tipped` in `failure` is deliberate: a toppled base's yaw is ill-defined, so the tilt vetoes a *"turned then fell"* rollout rather than scoring it as a valid turn. A single turn-in-place targets a sub-π heading; the yaw wraps at ±π, so (like `base_beyond_x` not tracking total path length) a full-revolution goal is out of scope for this single-signed heading test — documented in the docstring.

## Verified on a real Unitree Go2 (MuJoCo, `MUJOCO_GL=egl`)

`register_builtin_benchmarks()` → `add_robot('unitree_go2')` → `evaluate_benchmark('go2_turn_left', ...)`:

- yaw 0° → `is_success=False` (not turned); yaw 90° → `is_success=True` (turned past the 1.0 rad line); both `is_failure=False` at the 0.32 m stance; dense reward finite (1.184).
- pitched 90° (turned-then-fell) → `is_failure=True` — `base_tipped` vetoes.
- `evaluate_benchmark` runs end to end: `status=success`, finite `avg_reward`, 1 episode completed.

## Tests

- `tests/simulation/test_base_yaw_beyond_predicate.py` (new): threshold, reads-yaw-not-tilt (roll/pitch don't trip it), reads-heading-not-position (distinct from `base_beyond_x`), position/height independence, live tracking, negative threshold, fixed-base degradation, and an end-to-end `DeclarativeBenchmark` (success `base_yaw_beyond`, failure `base_tipped`+`base_below_z`) that succeeds on a turn and is vetoed by a fall. GL-free (real inline floating-base MuJoCo, `skip_images`).
- `tests/simulation/test_builtin_benchmarks.py` (extended): `go2_turn_left` registration/discovery, pure-yaw-command spec content, success on yaw progress (and NOT on pure forward displacement), topple/height-collapse failures, finite dense reward.
- `test_predicate_docstring_completeness` / `test_predicate_kind_guard` / `test_builtin_benchmark_robots_registered` cover the new predicate + benchmark automatically and pass.

All new/edited assertions fail on pre-fix source (`Unknown predicate 'base_yaw_beyond'` / `go2_turn_left` absent) and pass after. `ruff check`, `ruff format --check`, and `mypy` clean; 230 predicate/DSL/benchmark tests pass locally.