### PR TITLE
docs(training): cross-reference MockTrainer by module, not source filename

### DIFF
--- a/strands_robots/training/base.py
+++ b/strands_robots/training/base.py
@@ -29,7 +29,7 @@ A ``Trainer`` is selected by the SAME provider name as its ``Policy``
 owns both the inference class and the training class. Adding a new policy =
 add a ``Policy`` + a ``Trainer`` under one provider entry.
 
-See :class:`MockTrainer` (``strands_robots/training/mock.py``) for the canonical
+See :class:`~strands_robots.training.mock.MockTrainer` for the canonical
 no-dependency reference implementation.
 """
 

--- a/tests/training/test_docstring_module_xrefs.py
+++ b/tests/training/test_docstring_module_xrefs.py
@@ -1,0 +1,67 @@
+"""Top-level trainer modules must cross-reference *sibling* code by module, never
+by source filename.
+
+Citing a sibling source file (``mock.py``, ``factory.py``, ...) in a docstring is
+documentation archaeology: the name breaks silently the moment a file is renamed
+or split, and it points a reader at a path instead of an importable symbol. The
+project convention (already guarded for the policy package by
+``tests/policies/test_docstring_module_xrefs.py`` and for the MuJoCo backend by
+``tests/simulation/mujoco/test_docstring_module_xrefs.py``) is to use Sphinx
+cross-reference roles - ``:mod:``, ``:class:``, ``:func:`` - that name the actual
+API object, so the reference is checkable and survives refactors.
+
+This guard walks every module/class/function docstring in the *top-level*
+``strands_robots.training`` modules (``base.py``, ``factory.py``, ``mock.py``,
+``reward.py``, ...) and fails if any embeds a ``<name>.py`` token that names an
+actual sibling module. It is intentionally sibling-aware rather than flagging
+every ``.py`` token: the provider trainers legitimately cite *upstream*
+reference scripts by filename (``launch_finetune.py`` from GR00T, ``train.py``
+from the Cosmos framework, ``parser.py`` from lerobot), which name real files in
+other repositories and are not internal siblings.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import strands_robots.training as training_pkg
+
+# A bare source-filename token such as ``mock.py`` or ``factory.py``.
+_FILENAME_RE = re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*\.py\b")
+
+_PACKAGE_DIR = Path(training_pkg.__file__).parent
+_SIBLING_MODULES = {p.name for p in _PACKAGE_DIR.glob("*.py")}
+
+
+def _docstrings_with_sibling_filename_refs() -> dict[str, list[str]]:
+    """Map ``module.py::qualname`` -> sibling-filename tokens found in its docstring."""
+    offenders: dict[str, list[str]] = {}
+    for source_file in sorted(_PACKAGE_DIR.glob("*.py")):
+        tree = ast.parse(source_file.read_text(encoding="utf-8"), filename=str(source_file))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Module | ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            doc = ast.get_docstring(node, clean=False)
+            if not doc:
+                continue
+            hits = [tok for tok in _FILENAME_RE.findall(doc) if tok in _SIBLING_MODULES]
+            if hits:
+                qualname = getattr(node, "name", "<module>")
+                offenders[f"{source_file.name}::{qualname}"] = hits
+    return offenders
+
+
+def test_top_level_training_modules_scanned() -> None:
+    """Guard: the scan actually walked the top-level training modules."""
+    assert {"base.py", "factory.py", "mock.py"} <= _SIBLING_MODULES
+
+
+def test_training_docstrings_reference_modules_not_sibling_filenames() -> None:
+    offenders = _docstrings_with_sibling_filename_refs()
+    assert not offenders, (
+        "Top-level training docstrings must cross-reference siblings by module "
+        "(:class:`~strands_robots.training.mock.MockTrainer`) not source filename "
+        f"(``mock.py``). Offending docstrings: {offenders}"
+    )


### PR DESCRIPTION
## Problem

The `Trainer` ABC module docstring points readers at `MockTrainer` by its source filename:

```
See :class:`MockTrainer` (``strands_robots/training/mock.py``) for the canonical
no-dependency reference implementation.
```

Citing a sibling by source path is documentation archaeology: the reference breaks silently the moment the file is renamed or split, and it points at a path instead of an importable symbol. The project already treats this as a hygiene rule for the policy package (`tests/policies/test_docstring_module_xrefs.py`) and the MuJoCo backend (`tests/simulation/mujoco/test_docstring_module_xrefs.py`), which enforce Sphinx cross-reference roles (`:mod:`/`:class:`/`:func:`). The `training` package had no equivalent guard, and `base.py` carried the one remaining sibling-filename reference.

## Change

- `strands_robots/training/base.py`: replace the `mock.py` filename reference with a checkable class xref:

```
See :class:`~strands_robots.training.mock.MockTrainer` for the canonical
no-dependency reference implementation.
```

- Add `tests/training/test_docstring_module_xrefs.py` mirroring the policy/backend guards, so the convention is now pinned for the top-level `strands_robots.training` modules too.

## Test design

The guard is **sibling-aware** rather than flagging every `<name>.py` token: it only fails on a filename that names an actual sibling module in the `training/` package. This is deliberate - the provider trainers legitimately cite *upstream* reference scripts by filename (`launch_finetune.py` from GR00T, `train.py` from the Cosmos framework, `parser.py`/`logging_utils.py` from lerobot), which name files in other repositories and are not internal siblings. A blanket `.py` scan would false-positive on those.

The regression test fails on the pre-fix docstring:

```
AssertionError: ... Offending docstrings: {'base.py::<module>': ['mock.py']}
```

and passes after the fix.

## Validation

- `ruff check` + `ruff format --check` clean on `strands_robots tests tests_integ`
- `mypy strands_robots tests tests_integ`: no issues found
- `MUJOCO_GL=egl pytest tests/training/ tests/policies/test_docstring_module_xrefs.py tests/simulation/mujoco/test_docstring_module_xrefs.py tests/test_docstrings_no_dangling_doc_refs.py`: 408 passed, 4 skipped

Docs/test-only change; no runtime behavior is affected.