### PR TITLE
docs(mesh): cross-reference sibling modules by module path, not source filename

### DIFF
--- a/strands_robots/mesh/audit.py
+++ b/strands_robots/mesh/audit.py
@@ -179,9 +179,8 @@ _PSK_STATE_LOCK = threading.Lock()
 class _ProcessAuditState:
     """Container for module-level mutable flags.
 
-    Same rationale as ``mesh/security.py::_ProcessSecurityState``: we
-    keep the one-shot ``loaded`` flag on an instance attribute so static
-    analysers see a normal attribute read+write rather than a
+    We keep the one-shot ``loaded`` flag on an instance attribute so
+    static analysers see a normal attribute read+write rather than a
     ``global`` declaration on a module-level scalar (which CodeQL's
     "unused global variable" rule mis-classifies -- alert #222).
 

--- a/strands_robots/mesh/security.py
+++ b/strands_robots/mesh/security.py
@@ -130,8 +130,10 @@ def _env_pos_float(env_var: str, default: float) -> float:
     """Parse a positive float from *env_var*, falling back to *default*.
 
     Non-numeric / non-positive / NaN / inf values fall back to the default.
-    Local to security.py (the analogous helper in core.py is not importable
-    here without a cycle). Used for the teleop input safety bound (H-2).
+    Local to :mod:`~strands_robots.mesh.security`; the analogous helper
+    :func:`~strands_robots.mesh.core._parse_positive_float_env` is not
+    importable here without an import cycle. Used for the teleop input
+    safety bound (H-2).
     """
     raw = os.getenv(env_var)
     if raw is None:

--- a/tests/mesh/test_docstring_module_xrefs.py
+++ b/tests/mesh/test_docstring_module_xrefs.py
@@ -1,0 +1,70 @@
+"""Top-level mesh modules must cross-reference *sibling* code by module, never by
+source filename.
+
+Citing a sibling source file (``core.py``, ``security.py``, ...) in a docstring
+is documentation archaeology: the name breaks silently the moment a file is
+renamed or split, and it points a reader at a path instead of an importable
+symbol. This package already carried a *dead* example - an ``_ProcessAuditState``
+docstring pointed at ``mesh/security.py::_ProcessSecurityState``, a class that no
+longer exists - which is exactly the silent-breakage this rule prevents. The
+project convention (already guarded for the policy package by
+``tests/policies/test_docstring_module_xrefs.py``, the trainer package by
+``tests/training/test_docstring_module_xrefs.py``, and the MuJoCo backend by
+``tests/simulation/mujoco/test_docstring_module_xrefs.py``) is to use Sphinx
+cross-reference roles - ``:mod:``, ``:class:``, ``:func:`` - that name the actual
+API object, so the reference is checkable and survives refactors.
+
+This guard walks every module/class/function docstring in the *top-level*
+``strands_robots.mesh`` modules (``core.py``, ``security.py``, ``audit.py``, ...)
+and fails if any embeds a ``<name>.py`` token that names an actual sibling
+module. It is intentionally sibling-aware rather than flagging every ``.py``
+token: mesh docstrings legitimately cite *test* modules by filename (the guarding
+``test_*.py`` files that pin a behavior), which live under ``tests/`` and are not
+importable siblings of the package.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import strands_robots.mesh as mesh_pkg
+
+# A bare source-filename token such as ``core.py`` or ``security.py``.
+_FILENAME_RE = re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*\.py\b")
+
+_PACKAGE_DIR = Path(mesh_pkg.__file__).parent
+_SIBLING_MODULES = {p.name for p in _PACKAGE_DIR.glob("*.py")}
+
+
+def _docstrings_with_sibling_filename_refs() -> dict[str, list[str]]:
+    """Map ``module.py::qualname`` -> sibling-filename tokens found in its docstring."""
+    offenders: dict[str, list[str]] = {}
+    for source_file in sorted(_PACKAGE_DIR.glob("*.py")):
+        tree = ast.parse(source_file.read_text(encoding="utf-8"), filename=str(source_file))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Module | ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            doc = ast.get_docstring(node, clean=False)
+            if not doc:
+                continue
+            hits = [tok for tok in _FILENAME_RE.findall(doc) if tok in _SIBLING_MODULES]
+            if hits:
+                qualname = getattr(node, "name", "<module>")
+                offenders[f"{source_file.name}::{qualname}"] = hits
+    return offenders
+
+
+def test_top_level_mesh_modules_scanned() -> None:
+    """Guard: the scan actually walked the top-level mesh modules."""
+    assert {"core.py", "security.py", "audit.py"} <= _SIBLING_MODULES
+
+
+def test_mesh_docstrings_reference_modules_not_sibling_filenames() -> None:
+    offenders = _docstrings_with_sibling_filename_refs()
+    assert not offenders, (
+        "Top-level mesh docstrings must cross-reference siblings by module "
+        "(:func:`~strands_robots.mesh.core._parse_positive_float_env`) not source "
+        f"filename (``core.py``). Offending docstrings: {offenders}"
+    )


### PR DESCRIPTION
## Problem

Top-level `strands_robots.mesh` docstrings cited sibling code by source filename. One of those references was already **dead**: `_ProcessAuditState` (in `audit.py`) pointed at ``mesh/security.py::_ProcessSecurityState`` - a class that no longer exists in `security.py`. That is exactly the silent breakage a filename token invites: the reference rots the moment a file is renamed or split, and it points a reader at a path instead of an importable symbol.

The project already treats this as a hygiene rule for the policy package (`tests/policies/test_docstring_module_xrefs.py`), the trainer package (`tests/training/test_docstring_module_xrefs.py`), and the MuJoCo backend (`tests/simulation/mujoco/test_docstring_module_xrefs.py`), which enforce Sphinx cross-reference roles (`:mod:`/`:class:`/`:func:`). The `mesh` package had no equivalent guard and carried the remaining sibling-filename references.

## Change

- `strands_robots/mesh/audit.py`: drop the dangling ``_ProcessSecurityState`` cross-reference. The one-shot-`loaded`-flag rationale it introduced (dodging CodeQL's unused-global misclassification) is self-contained and reads cleanly without the dead pointer.
- `strands_robots/mesh/security.py`: replace the ``security.py``/``core.py`` filename tokens in `_env_pos_float`'s docstring with checkable roles:

```
Local to :mod:`~strands_robots.mesh.security`; the analogous helper
:func:`~strands_robots.mesh.core._parse_positive_float_env` is not
importable here without an import cycle.
```

- `tests/mesh/test_docstring_module_xrefs.py`: add a **sibling-aware** guard mirroring the policy/training/backend guards, so the convention is now pinned for the top-level `strands_robots.mesh` modules too.

## Test design

The guard is sibling-aware rather than flagging every `<name>.py` token: it only fails on a filename that names an actual sibling module in `mesh/`. This is deliberate - mesh docstrings legitimately cite the guarding `test_*.py` files by name, which live under `tests/` and are not importable siblings of the package. A blanket `.py` scan would false-positive on those.

The regression test fails on the pre-fix docstrings:

```
AssertionError: ... Offending docstrings: {'audit.py::_ProcessAuditState': ['security.py'], 'security.py::_env_pos_float': ['security.py', 'core.py']}
```

and passes after the fix.

## Validation

- `ruff check` + `ruff format --check` clean on `strands_robots tests tests_integ`
- `mypy strands_robots tests tests_integ`: no issues found
- `MUJOCO_GL=egl pytest tests/mesh/ tests/policies/test_docstring_module_xrefs.py tests/training/test_docstring_module_xrefs.py tests/simulation/mujoco/test_docstring_module_xrefs.py tests/test_docstrings_no_dangling_doc_refs.py`: 2081 passed, 3 skipped

Docs/test-only change; no runtime behavior is affected.