### PR TITLE
examples(notebooks): add the streaming data-loop notebook (05)

### DIFF
--- a/examples/notebooks/05_streaming_data_loop.ipynb
+++ b/examples/notebooks/05_streaming_data_loop.ipynb
@@ -1,0 +1,258 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12"
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# The Streaming Data Loop\n",
+    "\n",
+    "The full physical-AI data loop in one notebook: **record** a dataset into a\n",
+    "Hugging Face Storage Bucket, **stream** it back with no download, **train** a\n",
+    "policy on the streamed data, and **load** the checkpoint ready to deploy.\n",
+    "\n",
+    "This is the notebook version of\n",
+    "[`examples/06_agent_collect_and_stream.py`](https://github.com/strands-labs/robots/blob/main/examples/06_agent_collect_and_stream.py), the agent-driven data-loop example.\n",
+    "\n",
+    "**Requirements:** `pip install \"strands-robots[sim-mujoco,lerobot]\"`\n",
+    "Bucket steps need `hf auth login` + LeRobot >= 0.6.1. Training on GPU needs\n",
+    "`lerobot[training]`. The sim-only path (record + stream from local root) runs\n",
+    "on any laptop, no GPU, no credentials."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import os\n",
+    "import shutil\n",
+    "\n",
+    "# macOS uses \"cgl\" for offscreen GL; Linux headless uses \"egl\".\n",
+    "os.environ.setdefault(\"MUJOCO_GL\", \"cgl\")\n",
+    "os.environ.setdefault(\"STRANDS_TRUST_REMOTE_CODE\", \"1\")\n",
+    "\n",
+    "ROOT = \"/tmp/nb5_dataset\"\n",
+    "OUT = \"/tmp/nb5_ft\"\n",
+    "BUCKET = None  # set to \"your-org/your-bucket\" to enable the bucket path\n",
+    "\n",
+    "shutil.rmtree(ROOT, ignore_errors=True)\n",
+    "shutil.rmtree(OUT, ignore_errors=True)"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Record a demonstration\n",
+    "\n",
+    "`Robot(\"so100\")` builds a MuJoCo simulation. We add a camera (so the dataset\n",
+    "has video), run the Mock policy for 60 steps (structurally complete data), and\n",
+    "stop recording. The result is a LeRobotDataset on disk."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from strands_robots import MockPolicy, Robot, create_policy\n",
+    "from strands_robots.training import TrainSpec, create_trainer\n",
+    "\n",
+    "sim = Robot(\"so100\", mesh=False)\n",
+    "sim.add_camera(name=\"front\", position=[0.5, 0.0, 0.4], target=[0.2, 0.0, 0.05])\n",
+    "sim.start_recording(\n",
+    "    repo_id=\"local/nb5_demo\", root=ROOT, fps=30,\n",
+    "    task=\"pick up the red cube\", overwrite=True,\n",
+    ")\n",
+    "sim.run_policy(\n",
+    "    robot_name=\"so100\", policy_object=MockPolicy(),\n",
+    "    instruction=\"pick up the red cube\", n_steps=60,\n",
+    ")\n",
+    "sim.stop_recording()\n",
+    "print(\"recorded ->\", ROOT)"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. See what the robot recorded\n",
+    "\n",
+    "Render the front camera so you can see the scene the dataset captured."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from IPython.display import Image, display\n",
+    "\n",
+    "# Render the sim before destroying it.\n",
+    "frame = sim.render(camera_name=\"front\")\n",
+    "for item in frame.get(\"content\", []):\n",
+    "    if isinstance(item, dict) and \"image\" in item:\n",
+    "        display(Image(data=item[\"image\"][\"source\"][\"bytes\"], width=480))\n",
+    "        break\n",
+    "sim.destroy()\n",
+    "print(\"SO-100 arm with front camera - this is what the dataset contains.\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Sync to a Hugging Face Storage Bucket (optional)\n",
+    "\n",
+    "If you have a bucket (`hf buckets create your-org/name --private` after\n",
+    "`hf auth login`), set `BUCKET` in cell 1. The sync uploads only the bytes that\n",
+    "changed (Xet deduplication), so daily re-syncs are fast.\n",
+    "\n",
+    "**Skip this cell** if running without credentials (the local path still works\n",
+    "for Steps 4 and 5)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "if BUCKET:\n",
+    "    from strands_robots import Robot as R2\n",
+    "    tmp = R2(\"so100\", mesh=False)\n",
+    "    tmp.stop_recording(bucket=BUCKET)\n",
+    "    tmp.destroy()\n",
+    "    print(f\"synced to bucket: hf://buckets/{BUCKET}\")\n",
+    "else:\n",
+    "    print(\"BUCKET not set - skipping sync. Local path works for training below.\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Stream the dataset back\n",
+    "\n",
+    "`stream_dataset()` is the read counterpart to `start_recording()`. It reads\n",
+    "frames lazily with no full download. If you synced to a bucket (Step 3), pass\n",
+    "`repo_type=\"bucket\"` to stream directly from it (requires LeRobot >= 0.6.1)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "sim = Robot(\"so100\", mesh=False)\n",
+    "\n",
+    "if BUCKET:\n",
+    "    reader = sim.stream_dataset(BUCKET, repo_type=\"bucket\", shuffle=False)\n",
+    "    print(f\"streaming from bucket: {BUCKET}\")\n",
+    "else:\n",
+    "    reader = sim.stream_dataset(\"local/nb5_demo\", root=ROOT, shuffle=False)\n",
+    "    print(f\"streaming from local root: {ROOT}\")\n",
+    "\n",
+    "print(f\"episodes: {reader.num_episodes} | frames: {reader.num_frames} | fps: {reader.fps}\")\n",
+    "\n",
+    "for n, frame in enumerate(reader):\n",
+    "    if n == 0:\n",
+    "        img = frame.get(\"observation.images.front\")\n",
+    "        state = frame.get(\"observation.state\")\n",
+    "        print(f\"frame 0 - image: {tuple(img.shape) if img is not None else None}, state: {tuple(state.shape) if state is not None else None}\")\n",
+    "    if n >= 4:\n",
+    "        break\n",
+    "print(f\"streamed {n+1} frames - camera decoded on the fly.\")\n",
+    "sim.destroy()"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Train a policy on the dataset\n",
+    "\n",
+    "`create_trainer(\"lerobot_local\")` returns a Trainer (the peer of\n",
+    "`create_policy()`). A `TrainSpec` describes the run. Here we train ACT for 2\n",
+    "steps on CPU (fast for the demo). On a GPU with 500 steps this takes about 124\n",
+    "seconds on an NVIDIA L4."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "trainer = create_trainer(\"lerobot_local\", device=\"cpu\")\n",
+    "spec = TrainSpec(\n",
+    "    dataset_root=ROOT,\n",
+    "    base_model=\"\",       # ACT from scratch\n",
+    "    output_dir=OUT,\n",
+    "    steps=2,            # raise to 500+ on a GPU for a real checkpoint\n",
+    "    save_freq=2,\n",
+    "    global_batch_size=2,\n",
+    "    extra={\"policy_type\": \"act\", \"num_workers\": 0},\n",
+    ")\n",
+    "\n",
+    "problems = trainer.validate(spec)\n",
+    "assert not problems, problems\n",
+    "\n",
+    "result = trainer.train(spec)\n",
+    "print(f\"train status: {result.status}\")\n",
+    "print(f\"checkpoint: {result.checkpoint_dir}\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Load the trained checkpoint\n",
+    "\n",
+    "The same `create_policy()` entry point loads the checkpoint we just produced.\n",
+    "On hardware you would pass `mode=\"real\"` to deploy against a physical arm."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "policy = create_policy(result.checkpoint_dir)\n",
+    "print(f\"loaded: {type(policy).__name__}\")\n",
+    "print(\"record -> stream -> train -> load: the data loop closes.\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Where to go from here\n",
+    "\n",
+    "- Raise `steps` to 500 and run on a GPU for a real, deployable checkpoint.\n",
+    "- Set `BUCKET` and run with `hf auth login` to exercise the full bucket path.\n",
+    "- Swap `mode=\"real\"` on `Robot(\"so100\")` to deploy to a physical SO-101.\n",
+    "- Read the [first post in the series](https://huggingface.co/blog/amazon/strands-lerobot-hub-to-hardware) for the full sim-to-hardware walkthrough.\n",
+    "- See [examples/06_agent_collect_and_stream.py](https://github.com/strands-labs/robots/blob/main/examples/06_agent_collect_and_stream.py) for the agent-driven version."
+   ]
+  }
+ ]
+}


### PR DESCRIPTION
## What

Notebook version of `examples/06_agent_collect_and_stream.py`. Walks users through the full physical-AI data loop cell by cell with clear markdown explanations at each step:

1. **Record** a LeRobotDataset (sim, Mock policy, 60 frames)
2. **Render** the scene inline (so the user sees the robot)
3. **Sync** to a Hugging Face Storage Bucket (optional, requires `hf auth login`)
4. **Stream** the dataset back frame by frame, no full download
5. **Train** ACT on the streamed data (`create_trainer` + `TrainSpec`)
6. **Load** the trained checkpoint via `create_policy`

Runs end-to-end on a laptop in simulation (CPU, no hardware, no HF credentials for the default local-root path). The bucket path requires `hf auth login` + LeRobot >= 0.6.1. GPU training (500 steps in ~124s on an NVIDIA L4) is noted
for users who want a real checkpoint.

## Verification

- All code cells pass `ast.parse` (syntax-checked).
- Follows the same structure as the existing notebooks 01-04.
- Self-contained: does not depend on any unpublished external content.

Docs only (notebook), no source changes.