### PR TITLE
test(policies): drop dual-import of motionbricks.policy

### DIFF
--- a/tests/policies/motionbricks/test_agent_adapter_build.py
+++ b/tests/policies/motionbricks/test_agent_adapter_build.py
@@ -34,7 +34,6 @@ from typing import Any
 import pytest
 import torch
 
-import strands_robots.policies.motionbricks.policy as mb_policy
 from strands_robots.policies.motionbricks.policy import (
     MotionBricksPolicy,
     _MotionBricksAgentAdapter,
@@ -129,7 +128,10 @@ def _install_fake_motionbricks(
     for name, mod in modules.items():
         monkeypatch.setitem(sys.modules, name, mod)
     # require_optional would otherwise fail (real package absent).
-    monkeypatch.setattr(mb_policy, "require_optional", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "strands_robots.policies.motionbricks.policy.require_optional",
+        lambda *a, **k: None,
+    )
     return fake_agent
 
 


### PR DESCRIPTION
## Problem

The test module added in #1333 (`tests/policies/motionbricks/test_agent_adapter_build.py`, merged in `bec7fa5`) imports `strands_robots.policies.motionbricks.policy` two ways at once:

```python
import strands_robots.policies.motionbricks.policy as mb_policy
from strands_robots.policies.motionbricks.policy import (
    MotionBricksPolicy,
    _MotionBricksAgentAdapter,
)
```

CodeQL flags this dual-import style (code-scanning alert 751). The aliased module import existed solely to give the single `require_optional` monkeypatch a module object to target.

The fix was authored during #1333 review but a merge race landed the pre-fix commit on `main`; this is the tiny follow-up to close the alert.

## Change

Test-only, one file:

- Remove `import strands_robots.policies.motionbricks.policy as mb_policy`.
- Target the single `require_optional` patch by its fully-qualified string path, which `monkeypatch.setattr` resolves against the live module:

```python
monkeypatch.setattr(
    "strands_robots.policies.motionbricks.policy.require_optional",
    lambda *a, **k: None,
)
```

The explicit `from ... import (MotionBricksPolicy, _MotionBricksAgentAdapter)` used by the test bodies is unchanged.

## Tests

- `pytest tests/policies/motionbricks/test_agent_adapter_build.py` -> 2 passed (no behavioural change).
- `ruff check` and `ruff format --check` clean on the file.
- No production code touched, no emojis.