### PR TITLE
feat(sim): create_world(terrain="rough") - rough-ground heightfield for locomotion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,30 @@ satisfies a yaw goal (distinguishing it from `base_tipped`); pairing it with
 `base_tipped` in `failure` vetoes a "turned then fell" rollout, whose yaw would
 be ill-defined.
 
+### Added: `create_world(terrain="rough")` - rough-ground heightfield for locomotion
+
+The floating-base locomotion benchmarks (`go2_walk_forward` / `g1_walk_forward`
+/ `t1_walk_forward` and the omnidirectional Go2 tasks) all spawned their robot
+on a flat ground plane, so they measured command tracking but never robustness
+to terrain - the whole reason legged locomotion is hard. `create_world` gains a
+`terrain` argument: `terrain="rough"` lays down a deterministic rough-ground
+heightfield (a smoothed value-noise `<hfield>`) instead of the flat plane, so a
+floating-base robot settles onto and walks over bumps. The new
+`strands_robots.simulation.terrain` module generates the field (backend- and
+MuJoCo-independent, pure stdlib) deterministically given `(kind, resolution,
+seed)`, so the same terrain regenerates on every `reset()` and a rough-ground
+benchmark eval is reproducible. The field shares the flat plane's +/-5 m
+footprint (unchanged reachable workspace), ranges from 0 up to ~8 cm on a solid
+base slab (flush with `z=0` at its lowest point - no hole under the robot), and
+reuses the `"ground"` geom name so `attach_robot`'s floor-strip and any name
+lookup stay terrain-agnostic (an attached robot's own z=0 plane is stripped
+over terrain, as over the flat plane). `terrain` only applies when
+`ground_plane=True` (the master floor switch); an unknown kind is rejected with
+an actionable error listing the supported kinds. It is the ground-generation
+primitive a terrain curriculum builds on. MuJoCo backend; the Newton backend
+rejects a non-`None` `terrain` with an actionable error (heightfields are
+MuJoCo-only) rather than silently spawning on a flat plane.
+
 ### Fixed: `get_observation` no longer emits a floating base's free joint as a degenerate scalar
 
 A robot whose root is a 6-DoF free joint (a humanoid's named

--- a/docs/simulation/world-building.md
+++ b/docs/simulation/world-building.md
@@ -57,6 +57,30 @@ is an error that lists the model's available keyframes. `keyframe=None` (the
 default) keeps the zero-pose spawn. (MuJoCo backend; the Newton backend rejects
 `keyframe=` as not-yet-supported.)
 
+## Rough terrain
+
+By default `create_world()` lays down a flat ground plane. A locomotion
+policy is only interesting on ground it can trip on, so pass
+`terrain="rough"` to lay down a deterministic rough-ground heightfield
+instead - a floating-base robot then settles onto and walks over bumps:
+
+```python
+sim.create_world(terrain="rough")        # bumpy heightfield ground
+sim.add_robot("unitree_go2", keyframe="home")
+```
+
+The field spans the same +/-5 m footprint as the flat plane (the reachable
+workspace is unchanged), its surface ranges from 0 up to ~8 cm on a solid
+base slab (flush with `z=0` at its lowest point, so a robot never falls
+below the nominal floor), and it is regenerated identically on every
+`reset()` (deterministic given the terrain kind), so a benchmark that
+evaluates a policy on rough ground is reproducible. `terrain` only applies
+when `ground_plane=True` (the default, which is the master floor switch);
+an unknown kind is rejected with an error listing the supported kinds. It
+is the ground-generation primitive a terrain *curriculum* (progressive
+difficulty across resets) builds on. (MuJoCo backend; the Newton backend
+rejects `terrain=` as not-yet-supported.)
+
 ## Procedural objects
 
 ```python

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -261,8 +261,18 @@ class SimEngine(ABC):
         timestep: float | None = None,
         gravity: list[float] | None = None,
         ground_plane: bool = True,
+        terrain: str | None = None,
     ) -> dict[str, Any]:
-        """Create a new simulation world."""
+        """Create a new simulation world.
+
+        ``terrain`` (e.g. ``"rough"``, see
+        :mod:`strands_robots.simulation.terrain`) lays down a deterministic
+        rough-ground heightfield instead of the flat ground plane so a
+        locomotion policy can be spawned/evaluated on non-flat ground; it is
+        only meaningful when ``ground_plane=True`` and defaults to ``None`` (a
+        flat plane). Backends without heightfield support reject a non-None
+        ``terrain`` with an actionable error rather than silently ignoring it.
+        """
         ...
 
     @abstractmethod

--- a/strands_robots/simulation/models.py
+++ b/strands_robots/simulation/models.py
@@ -168,6 +168,9 @@ class SimWorld:
     timestep: float = 0.002  # 500Hz physics
     gravity: list[float] = field(default_factory=lambda: [0.0, 0.0, -9.81])
     ground_plane: bool = True
+    # Rough-ground terrain kind (e.g. "rough"); None -> flat plane. See
+    # strands_robots.simulation.terrain. Only meaningful when ground_plane=True.
+    terrain: str | None = None
     status: SimStatus = SimStatus.IDLE
     sim_time: float = 0.0
     step_count: int = 0

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -89,6 +89,7 @@ from strands_robots.simulation.mujoco.scene_ops import (
 )
 from strands_robots.simulation.mujoco.spec_builder import SpecBuilder, _validate_size
 from strands_robots.simulation.policy_runner import CooperativeStop
+from strands_robots.simulation.terrain import validate_terrain
 from strands_robots.teleop_mixin import TeleopMixin
 
 if TYPE_CHECKING:
@@ -414,10 +415,26 @@ class MuJoCoSimEngine(
             return 0
 
     def create_world(
-        self, timestep: float | None = None, gravity: list[float] | None = None, ground_plane: bool = True
+        self,
+        timestep: float | None = None,
+        gravity: list[float] | None = None,
+        ground_plane: bool = True,
+        terrain: str | None = None,
     ) -> dict[str, Any]:
-        """Create a new simulation world."""
+        """Create a new simulation world.
+
+        ``terrain='rough'`` lays down a deterministic rough-ground heightfield
+        (see :mod:`strands_robots.simulation.terrain`) instead of the flat
+        ground plane, so a floating-base/locomotion robot is spawned and
+        evaluated on non-flat ground. Only applies when ``ground_plane=True``.
+        """
         # mujoco verified at __init__
+
+        if terrain is not None:
+            try:
+                validate_terrain(terrain)
+            except ValueError as exc:
+                return {"status": "error", "content": [{"text": str(exc)}]}
 
         if self._world is not None and self._world._model is not None:
             return {
@@ -436,6 +453,7 @@ class MuJoCoSimEngine(
             timestep=timestep or self.default_timestep,
             gravity=_gravity,
             ground_plane=ground_plane,
+            terrain=terrain,
         )
 
         self._world.cameras["default"] = SimCamera(
@@ -1802,9 +1820,10 @@ class MuJoCoSimEngine(
         # registry trio -- register_urdf / list_urdfs / remove_robot -- is
         # advertised with the robot-registry family earlier in describe().)
         base["methods"]["create_world"] = (
-            "(timestep=None, gravity=None, ground_plane=True) -> dict  # create a "
-            "fresh empty simulation world; the lifecycle entry point that precedes "
-            "add_robot/add_object (gravity is [gx,gy,gz], ground_plane adds a floor)"
+            "(timestep=None, gravity=None, ground_plane=True, terrain=None) -> dict  # create "
+            "a fresh empty simulation world; the lifecycle entry point that precedes "
+            "add_robot/add_object (gravity is [gx,gy,gz], ground_plane adds a floor, "
+            "terrain='rough' makes it a rough heightfield for locomotion)"
         )
         base["methods"]["destroy"] = (
             "() -> dict  # tear down the world and release all resources (joins any "

--- a/strands_robots/simulation/mujoco/spec_builder.py
+++ b/strands_robots/simulation/mujoco/spec_builder.py
@@ -27,6 +27,14 @@ import numpy as np
 
 from strands_robots.simulation.models import SimCamera, SimObject, SimRobot, SimWorld
 from strands_robots.simulation.mujoco.backend import _ensure_mujoco
+from strands_robots.simulation.terrain import (
+    TERRAIN_BASE,
+    TERRAIN_ELEVATION,
+    TERRAIN_RADIUS,
+    TERRAIN_RESOLUTION,
+    TERRAIN_SEED,
+    generate_heightfield,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -311,16 +319,41 @@ class SpecBuilder:
         )
         main_light.type = mujoco.mjtLightType.mjLIGHT_DIRECTIONAL
 
-        # Ground plane.
+        # Ground. A rough-terrain heightfield (``create_world(terrain=...)``)
+        # replaces the flat plane so a locomotion policy walks over bumps; both
+        # share the checker material and the "ground" geom name so downstream
+        # ground-plane detection (attach_robot floor-strip) and any name lookup
+        # are terrain-agnostic. The hfield surface spans z in
+        # [0, TERRAIN_ELEVATION] on a solid base slab -> flush with z=0 at its
+        # lowest point (no hole under the robot), same +/-5 m footprint as the
+        # flat plane so the reachable workspace is unchanged.
         if world.ground_plane:
-            spec.worldbody.add_geom(
-                name="ground",
-                type=mujoco.mjtGeom.mjGEOM_PLANE,
-                size=[5.0, 5.0, 0.01],
-                material="grid_mat",
-                conaffinity=1,
-                condim=3,
-            )
+            if world.terrain:
+                heights = generate_heightfield(world.terrain, resolution=TERRAIN_RESOLUTION, seed=TERRAIN_SEED)
+                spec.add_hfield(
+                    name="terrain_hfield",
+                    size=[TERRAIN_RADIUS, TERRAIN_RADIUS, TERRAIN_ELEVATION, TERRAIN_BASE],
+                    nrow=TERRAIN_RESOLUTION,
+                    ncol=TERRAIN_RESOLUTION,
+                    userdata=heights,
+                )
+                spec.worldbody.add_geom(
+                    name="ground",
+                    type=mujoco.mjtGeom.mjGEOM_HFIELD,
+                    hfieldname="terrain_hfield",
+                    material="grid_mat",
+                    conaffinity=1,
+                    condim=3,
+                )
+            else:
+                spec.worldbody.add_geom(
+                    name="ground",
+                    type=mujoco.mjtGeom.mjGEOM_PLANE,
+                    size=[5.0, 5.0, 0.01],
+                    material="grid_mat",
+                    conaffinity=1,
+                    condim=3,
+                )
 
         # Cameras. Skip cameras that were discovered inside a robot's URDF -
         # they'll come back automatically via ``spec.attach(robot_spec)``.
@@ -683,7 +716,9 @@ class SpecBuilder:
         #      angled/elevated plane, e.g. a ramp or wall, which must survive).
         #   3. Debug log -- record which geoms were stripped so a disappearing
         #      (or surviving) robot floor is diagnosable.
-        world_has_ground = any(g.type == mujoco.mjtGeom.mjGEOM_PLANE for g in scene_spec.geoms)
+        world_has_ground = any(
+            g.type in (mujoco.mjtGeom.mjGEOM_PLANE, mujoco.mjtGeom.mjGEOM_HFIELD) for g in scene_spec.geoms
+        )
         stripped: list[str] = []
         if world_has_ground:
             for plane in [

--- a/strands_robots/simulation/mujoco/tool_spec.json
+++ b/strands_robots/simulation/mujoco/tool_spec.json
@@ -90,6 +90,10 @@
     "ground_plane": {
       "type": "boolean"
     },
+    "terrain": {
+      "type": "string",
+      "description": "create_world: rough-ground heightfield kind ('rough'); omit for a flat ground plane. MuJoCo backend only."
+    },
     "urdf_path": {
       "type": "string",
       "description": "Path to URDF/MJCF file"

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -229,6 +229,7 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         timestep: float | None = None,
         gravity: list[float] | None = None,
         ground_plane: bool = True,
+        terrain: str | None = None,
     ) -> dict[str, Any]:
         """Create an empty Newton world.
 
@@ -237,10 +238,27 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
                 ``default_timestep``).
             gravity: Gravity vector ``[x, y, z]`` (default ``[0, 0, -9.81]``).
             ground_plane: Whether to add a ground plane.
+            terrain: Rough-ground heightfield kind (MuJoCo backend only). The
+                Newton backend has no heightfield ground yet, so a non-None
+                value is rejected with an actionable error.
 
         Returns:
             Status dict with a human-readable confirmation.
         """
+        if terrain is not None:
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            f"terrain={terrain!r} is not supported on the Newton backend "
+                            "(rough-ground heightfields are MuJoCo-only); use "
+                            "create_simulation(backend='mujoco') for terrain, or omit terrain "
+                            "for a flat ground plane."
+                        )
+                    }
+                ],
+            }
         with self._lock:
             self._world = SimWorld(
                 timestep=timestep or self.default_timestep,

--- a/strands_robots/simulation/terrain.py
+++ b/strands_robots/simulation/terrain.py
@@ -1,0 +1,118 @@
+"""Procedural terrain generation for rough-ground simulation worlds.
+
+A flat ground plane is enough to smoke-test a manipulator, but a locomotion
+policy is only interesting on ground it can trip on. The velocity-tracking
+locomotion benchmarks (``go2_walk_forward`` / ``g1_walk_forward`` /
+``t1_walk_forward`` and the omnidirectional Go2 tasks) all spawn their robot on
+a flat plane, so they measure command tracking but never *robustness to
+terrain* -- the whole reason legged locomotion is hard. This module generates a
+deterministic rough-terrain heightfield that
+:meth:`~strands_robots.simulation.base.SimEngine.create_world` can lay down
+instead of the flat plane (``create_world(terrain="rough")``), so a floating-base
+robot settles onto and walks over bumps. It is the ground-generation primitive a
+terrain *curriculum* (progressive difficulty across resets) is built on.
+
+The generator is intentionally backend- and MuJoCo-independent (pure stdlib, no
+numpy / mujoco import) so the height data is trivially unit-testable and
+deterministic given ``(kind, resolution, seed)`` -- a benchmark that evaluates a
+policy on ``terrain="rough"`` regenerates the identical field on every reset.
+"""
+
+from __future__ import annotations
+
+import random
+
+# Supported terrain kinds. ``"rough"`` is smoothed value-noise bumps; the tuple
+# is the single source of truth both backends validate against and is easy to
+# extend (e.g. ``"stairs"``) without touching the create_world signature.
+SUPPORTED_TERRAINS: tuple[str, ...] = ("rough",)
+
+# Heightfield geometry (metres). The field spans +/-``TERRAIN_RADIUS`` in x and y
+# (matching the flat ground plane's 5 m half-size so the reachable workspace is
+# unchanged), rises up to ``TERRAIN_ELEVATION`` at its highest bump, and rests on
+# a ``TERRAIN_BASE``-thick solid slab so there is never a hole under the robot.
+# The surface height therefore ranges over ``[0, TERRAIN_ELEVATION]`` -- flush
+# with z=0 at its lowest point, so a robot never falls below the nominal floor.
+TERRAIN_RADIUS = 5.0
+TERRAIN_ELEVATION = 0.08
+TERRAIN_BASE = 0.1
+TERRAIN_RESOLUTION = 40  # nrow == ncol grid cells (25 cm cells over the 10 m field)
+TERRAIN_SEED = 0
+
+
+def validate_terrain(kind: str | None) -> None:
+    """Raise ``ValueError`` for an unsupported terrain kind (``None`` is a flat ground)."""
+    if kind is None or kind in SUPPORTED_TERRAINS:
+        return
+    raise ValueError(
+        f"Unknown terrain {kind!r}. Supported: {sorted(SUPPORTED_TERRAINS)} (or None / omit for a flat ground plane)."
+    )
+
+
+def _box_blur(grid: list[list[float]], n: int) -> list[list[float]]:
+    """One 3x3 box-blur pass (edge-clamped) -- turns spiky noise into walkable bumps."""
+    out = [[0.0] * n for _ in range(n)]
+    for i in range(n):
+        for j in range(n):
+            acc = 0.0
+            cnt = 0
+            for di in (-1, 0, 1):
+                for dj in (-1, 0, 1):
+                    ii, jj = i + di, j + dj
+                    if 0 <= ii < n and 0 <= jj < n:
+                        acc += grid[ii][jj]
+                        cnt += 1
+            out[i][j] = acc / cnt
+    return out
+
+
+def _rough(n: int, seed: int) -> list[float]:
+    rng = random.Random(seed)
+    grid = [[rng.random() for _ in range(n)] for _ in range(n)]
+    # Two blur passes -> smooth, walkable bumps rather than single-cell spikes
+    # that would flip a robot on contact and render as noise.
+    for _ in range(2):
+        grid = _box_blur(grid, n)
+    flat = [v for row in grid for v in row]
+    lo, hi = min(flat), max(flat)
+    span = hi - lo
+    if span <= 0.0:  # degenerate (all-equal); flat field
+        return [0.0] * (n * n)
+    # Normalize to [0, 1]; MuJoCo scales it by the hfield's elevation size.
+    return [(v - lo) / span for v in flat]
+
+
+def generate_heightfield(
+    kind: str,
+    resolution: int = TERRAIN_RESOLUTION,
+    seed: int = TERRAIN_SEED,
+) -> list[float]:
+    """Return a normalized ``[0, 1]`` heightfield as ``resolution * resolution`` floats.
+
+    Row-major (``userdata`` order for a MuJoCo ``<hfield>``). Deterministic given
+    ``(kind, resolution, seed)``. Raises ``ValueError`` for an unknown/None kind
+    or a resolution below 2.
+    """
+    validate_terrain(kind)
+    if kind is None:
+        raise ValueError("generate_heightfield requires a terrain kind, got None.")
+    n = int(resolution)
+    if n < 2:
+        raise ValueError(f"terrain resolution must be >= 2, got {resolution}.")
+    if kind == "rough":
+        return _rough(n, seed)
+    # validate_terrain accepts only SUPPORTED_TERRAINS; a kind reaching here
+    # means the tuple grew without a generator branch.
+    raise ValueError(f"terrain kind {kind!r} has no generator implementation.")  # pragma: no cover
+
+
+__all__ = [
+    "SUPPORTED_TERRAINS",
+    "TERRAIN_RADIUS",
+    "TERRAIN_ELEVATION",
+    "TERRAIN_BASE",
+    "TERRAIN_RESOLUTION",
+    "TERRAIN_SEED",
+    "validate_terrain",
+    "generate_heightfield",
+]

--- a/tests/simulation/mujoco/test_create_world_terrain.py
+++ b/tests/simulation/mujoco/test_create_world_terrain.py
@@ -1,0 +1,171 @@
+"""Integration tests for ``create_world(terrain="rough")`` on the MuJoCo backend.
+
+A flat ground plane measures a locomotion policy's command tracking but never
+its robustness to terrain. ``create_world(terrain="rough")`` lays down a
+deterministic rough-ground heightfield (:mod:`strands_robots.simulation.terrain`)
+instead of the flat plane so a floating-base robot is spawned and evaluated on
+non-flat ground - the ground-generation primitive a terrain curriculum builds
+on. These tests build a real world and step real physics (GL-free - no
+rendering) to verify the heightfield ground is laid down, actually collides
+(an object rests higher on a bump than on flat ground), the flat default is
+unchanged, an unknown kind is rejected, ``ground_plane=False`` stays the master
+floor switch, an attached robot's own ground plane is stripped over terrain,
+and the agent-dispatch router accepts the ``terrain`` kwarg.
+"""
+
+from __future__ import annotations
+
+import tempfile
+
+import mujoco
+
+from strands_robots.simulation import terrain
+from strands_robots.simulation.mujoco.simulation import MuJoCoSimEngine
+
+_PLANE = int(mujoco.mjtGeom.mjGEOM_PLANE)
+_HFIELD = int(mujoco.mjtGeom.mjGEOM_HFIELD)
+
+
+def _ground_geom_type(sim: MuJoCoSimEngine) -> int:
+    m = sim._world._model
+    gid = mujoco.mj_name2id(m, mujoco.mjtObj.mjOBJ_GEOM, "ground")
+    return -1 if gid < 0 else int(m.geom_type[gid])
+
+
+def _interior_peak_xy() -> tuple[float, float]:
+    """World (x, y) of the highest heightfield cell well inside the field rim."""
+    n = terrain.TERRAIN_RESOLUTION
+    h = terrain.generate_heightfield("rough", resolution=n, seed=terrain.TERRAIN_SEED)
+    best_v, best_i, best_j = -1.0, 0, 0
+    for i in range(6, n - 6):
+        for j in range(6, n - 6):
+            v = h[i * n + j]
+            if v > best_v:
+                best_v, best_i, best_j = v, i, j
+    # MuJoCo hfield: row-major, row 0 -> min y, col 0 -> min x, spanning +/-radius.
+    y = -terrain.TERRAIN_RADIUS + (best_i / (n - 1)) * 2 * terrain.TERRAIN_RADIUS
+    x = -terrain.TERRAIN_RADIUS + (best_j / (n - 1)) * 2 * terrain.TERRAIN_RADIUS
+    return x, y
+
+
+def _box_rest_z(terrain_kind: str | None, x: float, y: float) -> float:
+    sim = MuJoCoSimEngine()
+    try:
+        r = sim.create_world(terrain=terrain_kind)
+        assert r["status"] == "success", r
+        sim.add_object("blk", shape="box", size=[0.1, 0.1, 0.04], position=[x, y, 0.5], color=[1, 0, 0, 1])
+        m, d = sim._world._model, sim._world._data
+        for _ in range(2500):
+            mujoco.mj_step(m, d)
+        bid = mujoco.mj_name2id(m, mujoco.mjtObj.mjOBJ_BODY, "blk")
+        return float(d.xpos[bid][2])
+    finally:
+        sim.destroy()
+
+
+def test_terrain_builds_a_heightfield_ground() -> None:
+    sim = MuJoCoSimEngine()
+    try:
+        assert sim.create_world(terrain="rough")["status"] == "success"
+        m = sim._world._model
+        assert _ground_geom_type(sim) == _HFIELD
+        assert int(m.nhfield) == 1
+        # the compiled heightfield is genuinely non-flat
+        assert float(m.hfield_data.max()) - float(m.hfield_data.min()) > 0.5
+    finally:
+        sim.destroy()
+
+
+def test_flat_ground_default_is_a_plane() -> None:
+    sim = MuJoCoSimEngine()
+    try:
+        assert sim.create_world()["status"] == "success"
+        assert _ground_geom_type(sim) == _PLANE
+        assert int(sim._world._model.nhfield) == 0
+    finally:
+        sim.destroy()
+
+
+def test_terrain_collides_and_lifts_object_above_flat() -> None:
+    x, y = _interior_peak_xy()
+    z_terrain = _box_rest_z("rough", x, y)
+    z_flat = _box_rest_z(None, x, y)
+    # The object rests on the heightfield bump, meaningfully higher than on the
+    # flat plane at the identical (x, y) -> the terrain both renders AND collides.
+    assert z_terrain > z_flat + 0.03, (z_terrain, z_flat)
+
+
+def test_unknown_terrain_is_rejected() -> None:
+    sim = MuJoCoSimEngine()
+    try:
+        r = sim.create_world(terrain="bogus")
+        assert r["status"] == "error"
+        assert "rough" in r["content"][0]["text"]
+        # no world was left half-built
+        assert sim._world is None or sim._world._model is None
+    finally:
+        if sim._world is not None:
+            sim.destroy()
+
+
+def test_ground_plane_false_is_the_master_switch() -> None:
+    sim = MuJoCoSimEngine()
+    try:
+        assert sim.create_world(terrain="rough", ground_plane=False)["status"] == "success"
+        assert _ground_geom_type(sim) == -1  # no ground geom at all
+        assert int(sim._world._model.nhfield) == 0
+    finally:
+        sim.destroy()
+
+
+_PLANEBOT_MJCF = """<mujoco model="planebot">
+  <worldbody>
+    <geom name="floor" type="plane" size="2 2 0.1"/>
+    <body name="link" pos="0 0 0.4">
+      <joint name="j" type="hinge" axis="0 1 0"/>
+      <geom name="link_g" type="capsule" fromto="0 0 0 0.2 0 0" size="0.02"/>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+
+def test_attached_robot_ground_plane_is_stripped_over_terrain() -> None:
+    sim = MuJoCoSimEngine()
+    try:
+        assert sim.create_world(terrain="rough")["status"] == "success"
+        with tempfile.NamedTemporaryFile("w", suffix=".xml", delete=False) as fh:
+            fh.write(_PLANEBOT_MJCF)
+            path = fh.name
+        assert sim.add_robot("planebot", urdf_path=path)["status"] == "success"
+        m = sim._world._model
+        plane_geoms = [g for g in range(m.ngeom) if int(m.geom_type[g]) == _PLANE]
+        hfield_geoms = [g for g in range(m.ngeom) if int(m.geom_type[g]) == _HFIELD]
+        # The world owns the (heightfield) ground, so the robot's own z=0 plane
+        # is stripped -> exactly one hfield ground, no leftover flat plane
+        # coplanar with (and hiding) the terrain.
+        assert len(hfield_geoms) == 1, hfield_geoms
+        assert len(plane_geoms) == 0, plane_geoms
+    finally:
+        sim.destroy()
+
+
+def test_router_dispatch_accepts_terrain_kwarg() -> None:
+    sim = MuJoCoSimEngine()
+    try:
+        r = sim(action="create_world", terrain="rough")
+        assert r["status"] == "success", r
+        assert _ground_geom_type(sim) == _HFIELD
+    finally:
+        sim.destroy()
+
+
+def test_router_dispatch_rejects_unknown_terrain() -> None:
+    sim = MuJoCoSimEngine()
+    try:
+        r = sim(action="create_world", terrain="stairs")
+        assert r["status"] == "error"
+        assert "rough" in r["content"][0]["text"]
+    finally:
+        if sim._world is not None:
+            sim.destroy()

--- a/tests/simulation/mujoco/test_create_world_terrain.py
+++ b/tests/simulation/mujoco/test_create_world_terrain.py
@@ -27,6 +27,7 @@ _HFIELD = int(mujoco.mjtGeom.mjGEOM_HFIELD)
 
 
 def _ground_geom_type(sim: MuJoCoSimEngine) -> int:
+    assert sim._world is not None
     m = sim._world._model
     gid = mujoco.mj_name2id(m, mujoco.mjtObj.mjOBJ_GEOM, "ground")
     return -1 if gid < 0 else int(m.geom_type[gid])
@@ -54,6 +55,7 @@ def _box_rest_z(terrain_kind: str | None, x: float, y: float) -> float:
         r = sim.create_world(terrain=terrain_kind)
         assert r["status"] == "success", r
         sim.add_object("blk", shape="box", size=[0.1, 0.1, 0.04], position=[x, y, 0.5], color=[1, 0, 0, 1])
+        assert sim._world is not None
         m, d = sim._world._model, sim._world._data
         for _ in range(2500):
             mujoco.mj_step(m, d)
@@ -67,6 +69,7 @@ def test_terrain_builds_a_heightfield_ground() -> None:
     sim = MuJoCoSimEngine()
     try:
         assert sim.create_world(terrain="rough")["status"] == "success"
+        assert sim._world is not None
         m = sim._world._model
         assert _ground_geom_type(sim) == _HFIELD
         assert int(m.nhfield) == 1
@@ -81,6 +84,7 @@ def test_flat_ground_default_is_a_plane() -> None:
     try:
         assert sim.create_world()["status"] == "success"
         assert _ground_geom_type(sim) == _PLANE
+        assert sim._world is not None
         assert int(sim._world._model.nhfield) == 0
     finally:
         sim.destroy()
@@ -113,6 +117,7 @@ def test_ground_plane_false_is_the_master_switch() -> None:
     try:
         assert sim.create_world(terrain="rough", ground_plane=False)["status"] == "success"
         assert _ground_geom_type(sim) == -1  # no ground geom at all
+        assert sim._world is not None
         assert int(sim._world._model.nhfield) == 0
     finally:
         sim.destroy()
@@ -138,6 +143,7 @@ def test_attached_robot_ground_plane_is_stripped_over_terrain() -> None:
             fh.write(_PLANEBOT_MJCF)
             path = fh.name
         assert sim.add_robot("planebot", urdf_path=path)["status"] == "success"
+        assert sim._world is not None
         m = sim._world._model
         plane_geoms = [g for g in range(m.ngeom) if int(m.geom_type[g]) == _PLANE]
         hfield_geoms = [g for g in range(m.ngeom) if int(m.geom_type[g]) == _HFIELD]

--- a/tests/simulation/newton/test_create_world_terrain_reject.py
+++ b/tests/simulation/newton/test_create_world_terrain_reject.py
@@ -1,0 +1,47 @@
+"""Newton ``create_world(terrain=...)`` rejects an unsupported terrain kind.
+
+Rough-ground heightfields are a MuJoCo-backend capability; the Newton backend
+has no heightfield ground yet. Rather than silently ignoring a ``terrain=``
+request (which would spawn a locomotion robot on a flat plane while the caller
+believes it is on terrain), Newton rejects a non-None ``terrain`` with an
+actionable error pointing at the MuJoCo backend. That rejection is a pure
+Python contract that returns before any GPU/model build, so it is exercised
+here via ``__new__`` (no Warp / GPU required, runs in CI).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+_engine_cls = None
+try:  # NewtonSimEngine imports without Warp (Warp is lazily loaded at build time)
+    from strands_robots.simulation.newton.simulation import NewtonSimEngine as _engine_cls
+except Exception:  # pragma: no cover - newton package genuinely absent
+    _engine_cls = None
+
+pytestmark = pytest.mark.skipif(_engine_cls is None, reason="newton package not importable")
+
+
+def test_newton_rejects_terrain_before_any_build() -> None:
+    # __new__ bypasses __init__ (no solver/GPU); the reject returns before the
+    # lock/_rebuild, so no engine state is needed.
+    eng = _engine_cls.__new__(_engine_cls)
+    r = eng.create_world(terrain="rough")
+    assert r["status"] == "error"
+    text = r["content"][0]["text"]
+    assert "Newton" in text and "MuJoCo" in text and "rough" in text
+
+
+def test_newton_terrain_none_is_not_rejected() -> None:
+    # A flat (terrain=None) create_world must NOT hit the reject path; it falls
+    # through to the real build (which __new__ cannot run), so we only assert
+    # the reject branch does not fire by patching _rebuild/_lock to no-ops.
+    import threading
+
+    eng = _engine_cls.__new__(_engine_cls)
+    eng._lock = threading.RLock()
+    eng.default_timestep = 0.002
+    eng._solver_name = "mujoco"
+    eng._rebuild = lambda: None  # type: ignore[method-assign]
+    r = eng.create_world(terrain=None)
+    assert r["status"] == "success"

--- a/tests/simulation/newton/test_create_world_terrain_reject.py
+++ b/tests/simulation/newton/test_create_world_terrain_reject.py
@@ -11,9 +11,14 @@ here via ``__new__`` (no Warp / GPU required, runs in CI).
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 
-_engine_cls = None
+if TYPE_CHECKING:
+    from strands_robots.simulation.newton.simulation import NewtonSimEngine
+
+_engine_cls: type[NewtonSimEngine] | None
 try:  # NewtonSimEngine imports without Warp (Warp is lazily loaded at build time)
     from strands_robots.simulation.newton.simulation import NewtonSimEngine as _engine_cls
 except Exception:  # pragma: no cover - newton package genuinely absent
@@ -25,6 +30,7 @@ pytestmark = pytest.mark.skipif(_engine_cls is None, reason="newton package not 
 def test_newton_rejects_terrain_before_any_build() -> None:
     # __new__ bypasses __init__ (no solver/GPU); the reject returns before the
     # lock/_rebuild, so no engine state is needed.
+    assert _engine_cls is not None
     eng = _engine_cls.__new__(_engine_cls)
     r = eng.create_world(terrain="rough")
     assert r["status"] == "error"
@@ -38,6 +44,7 @@ def test_newton_terrain_none_is_not_rejected() -> None:
     # the reject branch does not fire by patching _rebuild/_lock to no-ops.
     import threading
 
+    assert _engine_cls is not None
     eng = _engine_cls.__new__(_engine_cls)
     eng._lock = threading.RLock()
     eng.default_timestep = 0.002

--- a/tests/simulation/test_foundation.py
+++ b/tests/simulation/test_foundation.py
@@ -39,6 +39,7 @@ def _make_dummy_engine_class() -> type[SimEngine]:
             timestep: float | None = None,
             gravity: list[float] | None = None,
             ground_plane: bool = True,
+            terrain: str | None = None,
         ) -> dict[str, Any]:
             return {}
 

--- a/tests/simulation/test_sim_engine_describe_discovery.py
+++ b/tests/simulation/test_sim_engine_describe_discovery.py
@@ -31,6 +31,7 @@ def _make_minimal_engine():
             timestep: float | None = None,
             gravity: list[float] | None = None,
             ground_plane: bool = True,
+            terrain: str | None = None,
         ) -> dict[str, Any]:
             return {}
 

--- a/tests/simulation/test_terrain.py
+++ b/tests/simulation/test_terrain.py
@@ -1,0 +1,73 @@
+"""Unit tests for the procedural terrain heightfield generator.
+
+``strands_robots.simulation.terrain.generate_heightfield`` is the backend- and
+MuJoCo-independent ground-generation primitive behind
+``create_world(terrain="rough")``. It must be deterministic given
+``(kind, resolution, seed)`` (so a benchmark regenerates the identical field on
+every reset), produce a genuinely non-flat normalized ``[0, 1]`` field for a
+rough kind, and reject an unknown kind with an actionable error. These tests
+are pure stdlib (no mujoco / numpy) and exercise the module in isolation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from strands_robots.simulation import terrain
+
+
+def test_rough_field_has_correct_length_and_range() -> None:
+    n = 16
+    h = terrain.generate_heightfield("rough", resolution=n, seed=terrain.TERRAIN_SEED)
+    assert len(h) == n * n
+    assert all(0.0 <= v <= 1.0 for v in h)
+
+
+def test_rough_field_is_deterministic_for_same_seed() -> None:
+    a = terrain.generate_heightfield("rough", resolution=20, seed=3)
+    b = terrain.generate_heightfield("rough", resolution=20, seed=3)
+    assert a == b
+
+
+def test_rough_field_varies_with_seed() -> None:
+    a = terrain.generate_heightfield("rough", resolution=20, seed=1)
+    b = terrain.generate_heightfield("rough", resolution=20, seed=2)
+    assert a != b
+
+
+def test_rough_field_is_genuinely_non_flat() -> None:
+    h = terrain.generate_heightfield("rough", resolution=32, seed=0)
+    # A rough field must span most of the [0, 1] range (normalization pins the
+    # min to 0 and max to 1), i.e. it is not a near-flat plane.
+    assert max(h) - min(h) > 0.5
+
+
+def test_default_resolution_matches_module_constant() -> None:
+    h = terrain.generate_heightfield("rough")
+    assert len(h) == terrain.TERRAIN_RESOLUTION * terrain.TERRAIN_RESOLUTION
+
+
+@pytest.mark.parametrize("bad", ["stairs", "flat", "ROUGH", ""])
+def test_unknown_terrain_kind_is_rejected_actionably(bad: str) -> None:
+    with pytest.raises(ValueError) as exc:
+        terrain.generate_heightfield(bad)
+    msg = str(exc.value)
+    assert "Supported" in msg and "rough" in msg  # actionable: lists what IS valid
+
+
+def test_none_kind_is_rejected_by_generator() -> None:
+    with pytest.raises(ValueError):
+        terrain.generate_heightfield(None)  # type: ignore[arg-type]
+
+
+def test_resolution_below_two_is_rejected() -> None:
+    with pytest.raises(ValueError):
+        terrain.generate_heightfield("rough", resolution=1)
+
+
+def test_validate_terrain_accepts_none_and_supported_rejects_unknown() -> None:
+    terrain.validate_terrain(None)  # flat ground; no raise
+    for kind in terrain.SUPPORTED_TERRAINS:
+        terrain.validate_terrain(kind)  # no raise
+    with pytest.raises(ValueError):
+        terrain.validate_terrain("bogus")


### PR DESCRIPTION
## Problem

The floating-base locomotion benchmarks (`go2_walk_forward` / `g1_walk_forward` / `t1_walk_forward` and the omnidirectional Go2 `go2_strafe_left` / `go2_turn_left` tasks) all spawn their robot on a **flat** ground plane. They measure how well a policy tracks a velocity command, but never its **robustness to terrain** - the whole reason legged locomotion is hard. There was no way to lay down non-flat ground: `create_world()` only ever built a flat `mjGEOM_PLANE`.

## Change

`create_world` gains a `terrain` argument. `create_world(terrain="rough")` lays down a deterministic rough-ground **heightfield** (a smoothed value-noise `<hfield>`) instead of the flat plane, so a floating-base robot settles onto and walks over bumps.

- **New `strands_robots.simulation.terrain` module** generates the height data. It is backend- and MuJoCo-independent (pure stdlib) and **deterministic** given `(kind, resolution, seed)`, so the same terrain regenerates on every `reset()` and a rough-ground benchmark eval is reproducible. `generate_heightfield` returns a normalized `[0, 1]` field; an unknown kind raises an actionable `ValueError` listing the supported kinds.
- **Same footprint as the flat plane** (+/-5 m, so the reachable workspace is unchanged); the surface ranges `0 .. ~8 cm` on a solid base slab (flush with `z=0` at its lowest point - no hole under the robot).
- **Terrain-agnostic ground handling**: the heightfield reuses the `"ground"` geom name, and `attach_robot`'s floor-strip now recognizes an `mjGEOM_HFIELD` ground, so an attached robot's own `z=0` plane is stripped over terrain exactly as over the flat plane (no coplanar plane hiding the terrain).
- **`ground_plane=True` stays the master floor switch**: `terrain` only applies when a ground exists; `ground_plane=False` yields no ground at all.
- **MuJoCo backend.** The Newton backend rejects a non-`None` `terrain` with an actionable error (heightfields are MuJoCo-only) rather than silently spawning on a flat plane.

This is the ground-generation primitive a terrain *curriculum* (progressive difficulty across resets) is built on - the named next step for the G1/T1/Go1 locomotion task spec now that the omnidirectional velocity-tracking vocabulary is complete.

## Verification

**Physics (real sim, MUJOCO_GL=egl, no mocks):** a box dropped over the field's interior peak rests at `z=0.091` vs `0.020` on the flat plane at the identical `(x, y)` - a clean **7.1 cm lift**, proving the heightfield both renders and collides. A real Unitree Go2 spawned with `keyframe="home"` settles higher on the terrain (base `z=0.107`) than on flat ground (`0.079`).

**Tests** (fail before this change - the module and the `terrain` kwarg don't exist - and pass after):
- `tests/simulation/test_terrain.py` - generator unit tests (deterministic, seed-varying, correct length, `[0,1]` range, non-flat, unknown/`None`/too-small-resolution rejected).
- `tests/simulation/mujoco/test_create_world_terrain.py` - integration: heightfield ground is laid down (and is genuinely non-flat), the flat default is unchanged, an object rests higher on a bump than on flat, unknown kind rejected, `ground_plane=False` master switch, an attached robot's ground plane is stripped over terrain, and the agent-dispatch router accepts/rejects `terrain`.
- `tests/simulation/newton/test_create_world_terrain_reject.py` - Newton rejects a non-`None` terrain before any build (pure contract, no Warp needed) and does not reject `terrain=None`.

Green gate: `ruff` + `mypy` clean; the terrain, tool_spec anti-drift, `describe()` discovery, `test_simulation`, and `test_spec_builder` suites all pass. Docs (`docs/simulation/world-building.md`) + `create_world` docstrings + `tool_spec.json` + CHANGELOG updated.

## Visual

Go2 (`keyframe="home"`) on the flat plane (left) vs the rough heightfield (right), same camera:

![flat vs rough](https://github.com/cagataycali/robots/releases/download/artifacts-terrain-1783931215/go2_flat_vs_rough.png)

Heightfield surface close-up (a box for scale) - the bumps a locomotion policy must handle:

![terrain closeup](https://github.com/cagataycali/robots/releases/download/artifacts-terrain-1783931215/terrain_closeup.png)

Go2 settling onto the rough terrain (headless MuJoCo rollout):

![go2 on rough terrain](https://github.com/cagataycali/robots/releases/download/artifacts-terrain-1783931215/go2_rough_settle.gif)

---

## Changelog

**Round 1 (post-approval CI fix):** The `mypy strands_robots tests tests_integ` gate failed after the `terrain` kwarg widened the abstract `SimEngine.create_world` signature. Fixed with test-only, behavior-preserving changes:
- Synced the two pre-existing concrete `SimEngine` test subclasses (`test_foundation.py`, `test_sim_engine_describe_discovery.py`) to the new 4-arg override contract (they still declared the 3-arg form -> `[override]`).
- Narrowed `sim._world` (`SimWorld | None`) with `assert` guards before attribute access in `test_create_world_terrain.py` (`[union-attr]`).
- Annotated the Newton `_engine_cls` sentinel via a `TYPE_CHECKING` import so the `None` fallback no longer collapses it to `object` (`[assignment]` / `[var-annotated]` / `[arg-type]`).

No production code changed; only type-checker facts. `ruff` + `mypy` verified locally on all four touched files.