### PR TITLE
docs(sim): cross-reference simulation modules by module path, not filename

### DIFF
--- a/strands_robots/simulation/__init__.py
+++ b/strands_robots/simulation/__init__.py
@@ -1,25 +1,14 @@
 """Strands Robots Simulation - multi-backend simulation framework.
 
-Architecture::
-
-    simulation/
-    ├ __init__.py          ← this file (re-exports, lazy loading)
-    ├ base.py              ← SimEngine ABC
-    ├ factory.py           ← create_simulation() + backend registration
-    ├ models.py            ← shared dataclasses (SimWorld, SimRobot, ...)
-    ├ model_registry.py    ← URDF/MJCF resolution (shared across backends)
-    └ mujoco/              ← MuJoCo CPU backend
-        ├ __init__.py
-        ├ backend.py       ← lazy mujoco import + GL config
-        ├ spec_builder.py  ← MjSpec-based scene builder/mutator
-        ├ physics.py       ← advanced physics (raycasting, jacobians, forces)
-        ├ scene_ops.py     ← live scene mutation via spec.recompile()
-        ├ rendering.py     ← render RGB/depth, observations
-        ├ policy_runner.py ← run_policy, eval_policy, replay
-        ├ randomization.py ← domain randomization
-        ├ recording.py     ← LeRobotDataset recording
-        ├ tool_spec.json   ← AgentTool input schema
-        └ simulation.py    ← Simulation (AgentTool orchestrator)
+A backend-agnostic layer built around the :class:`~strands_robots.simulation.base.SimEngine`
+ABC, shared dataclasses (:class:`~strands_robots.simulation.models.SimWorld`,
+:class:`~strands_robots.simulation.models.SimRobot`,
+:class:`~strands_robots.simulation.models.SimObject`, ...), a shared
+URDF/MJCF resolver (:mod:`strands_robots.simulation.model_registry`), and a
+:func:`~strands_robots.simulation.factory.create_simulation` factory that
+selects a registered backend. The default backend is
+:mod:`strands_robots.simulation.mujoco` (CPU physics + offscreen rendering, no
+GPU required); the Isaac Sim and Newton backends load lazily on demand.
 
 Usage::
 

--- a/tests/simulation/test_docstring_module_xrefs.py
+++ b/tests/simulation/test_docstring_module_xrefs.py
@@ -1,0 +1,69 @@
+"""Top-level simulation modules must cross-reference sibling code by module,
+never by source filename.
+
+Referencing an internal sibling by its source file (``base.py``, ``factory.py``,
+...) in a docstring is documentation archaeology: the name breaks silently the
+moment a file is renamed or split, and it points a reader at a path instead of
+an importable symbol. The project convention (see the MuJoCo backend guard,
+``tests/simulation/mujoco/test_docstring_module_xrefs.py``, and the policy and
+training guards) is to use Sphinx cross-reference roles - ``:mod:``, ``:class:``,
+``:func:`` - that name the actual API object, so the reference is checkable and
+survives refactors.
+
+This guard walks every module/class/function docstring in the *top-level*
+``strands_robots.simulation`` modules and fails if any embeds a ``<name>.py``
+token that names a real sibling module in the package directory. The scan is
+intentionally restricted to sibling filenames: top-level modules legitimately
+cite *upstream* reference scripts by filename (LIBERO's ``bddl_base_domain.py``,
+GR00T's ``standalone_inference_script.py``), which name real files in other
+repositories and are not internal siblings.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import strands_robots.simulation as simulation_pkg
+
+# A bare source-filename token such as ``base.py`` or ``factory.py``.
+_FILENAME_RE = re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*\.py\b")
+
+_PACKAGE_DIR = Path(simulation_pkg.__file__).parent
+
+# The set of real top-level sibling modules. Only filename tokens naming one of
+# these are internal archaeology; anything else is an external upstream file.
+_SIBLING_MODULES = {p.name for p in _PACKAGE_DIR.glob("*.py")}
+
+
+def _docstrings_with_offenders() -> dict[str, list[str]]:
+    """Map ``module.py::qualname`` -> sibling filename tokens found in that docstring."""
+    offenders: dict[str, list[str]] = {}
+    for source_file in sorted(_PACKAGE_DIR.glob("*.py")):
+        tree = ast.parse(source_file.read_text(encoding="utf-8"), filename=str(source_file))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Module | ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            doc = ast.get_docstring(node, clean=False)
+            if not doc:
+                continue
+            hits = [h for h in _FILENAME_RE.findall(doc) if h in _SIBLING_MODULES]
+            if hits:
+                qualname = getattr(node, "name", "<module>")
+                offenders[f"{source_file.name}::{qualname}"] = hits
+    return offenders
+
+
+def test_top_level_simulation_modules_scanned() -> None:
+    """Guard: the scan actually walked the top-level simulation modules."""
+    assert {"base.py", "factory.py", "models.py"} <= _SIBLING_MODULES
+
+
+def test_simulation_docstrings_reference_modules_not_filenames() -> None:
+    offenders = _docstrings_with_offenders()
+    assert not offenders, (
+        "Top-level simulation docstrings must cross-reference siblings by module "
+        "(:class:`~strands_robots.simulation.base.SimEngine`) not source filename "
+        f"(``base.py``). Offending docstrings: {offenders}"
+    )


### PR DESCRIPTION
## Problem

The `strands_robots.simulation` package docstring documented its layout with an ASCII file tree that named every module by source filename (`base.py`, `factory.py`, `models.py`, `model_registry.py`, `policy_runner.py`, `recording.py`, plus the `mujoco/` backend files).

A filename token in a docstring is documentation archaeology: it breaks silently the moment a file is renamed or split, and it points a reader at a path instead of an importable symbol. It also renders as dead monospace text in the API docs instead of a navigable cross-reference link. Every other package docstring in this area (the MuJoCo backend, the policy ABC, the training providers) already uses Sphinx roles; this file tree was the odd one out.

## Change

- Replace the file tree with a prose overview that cross-references the key objects via Sphinx roles: `:class:`~...base.SimEngine``, the `SimWorld`/`SimRobot`/`SimObject` dataclasses, `:mod:`~...model_registry``, `:func:`~...factory.create_simulation``, and the `:mod:`~...mujoco`` backend. This matches the filename-free convention already used by the MuJoCo backend package docstring. The Usage and Future-backends examples (which reference importable symbols, not filenames) are unchanged.
- Add `tests/simulation/test_docstring_module_xrefs.py`, a guard mirroring the existing policy/training/mujoco docstring xref tests. It walks the top-level `strands_robots.simulation` module docstrings and rejects any `<name>.py` token that names a real sibling module.

The scan is deliberately restricted to *sibling* filenames rather than any `.py` token: top-level simulation modules legitimately cite upstream reference scripts by filename (LIBERO's `bddl_base_domain.py` in `predicates.py`, GR00T's `standalone_inference_script.py` in `policy_runner.py`), which name files in other repositories and are not internal archaeology. Matching those tokens against the actual package directory keeps the guard precise and self-maintaining.

## Tests

`test_simulation_docstrings_reference_modules_not_filenames` fails on the pre-fix docstring (offenders: `base.py`, `factory.py`, `models.py`, `model_registry.py`, `policy_runner.py`, `recording.py`) and passes after. The existing MuJoCo/policy/training guards continue to pass. Full CI-scoped gate is clean locally: `ruff check`, `ruff format --check`, and `mypy strands_robots tests tests_integ` (Success: no issues found in 773 source files).