### PR TITLE
feat(sim): create_world(terrain="stairs") - stepped-ground heightfield for locomotion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,22 @@ primitive a terrain curriculum builds on. MuJoCo backend; the Newton backend
 rejects a non-`None` `terrain` with an actionable error (heightfields are
 MuJoCo-only) rather than silently spawning on a flat plane.
 
+### Added: `create_world(terrain="stairs")` - stepped-ground heightfield for locomotion
+
+`create_world(terrain=...)` gains a second heightfield kind alongside `"rough"`:
+`terrain="stairs"` lays down a flight of discrete flat step plateaus (rising
+along +x) instead of smooth value-noise bumps. Stairs test the foot-placement
+and climbing a smoothly-undulating field never does, so they are the canonical
+next terrain in a locomotion curriculum. Like `"rough"` the field is generated
+by the pure-stdlib, backend-independent `strands_robots.simulation.terrain`
+module, is deterministic (a stepped field is seed-independent), shares the flat
+plane's +/-5 m footprint, and rises from 0 up to the same ~8 cm on a solid base
+slab (flush with `z=0` at its lowest step - no hole under the robot). A box
+dropped on a higher step rests measurably higher than one on a lower step. New
+terrain kinds are added by appending to `SUPPORTED_TERRAINS` and a generator
+branch - no `create_world` signature change. MuJoCo backend; the Newton backend
+rejects any non-`None` `terrain` with an actionable error.
+
 ### Fixed: `get_observation` no longer emits a floating base's free joint as a degenerate scalar
 
 A robot whose root is a 6-DoF free joint (a humanoid's named

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -265,9 +265,9 @@ class SimEngine(ABC):
     ) -> dict[str, Any]:
         """Create a new simulation world.
 
-        ``terrain`` (e.g. ``"rough"``, see
-        :mod:`strands_robots.simulation.terrain`) lays down a deterministic
-        rough-ground heightfield instead of the flat ground plane so a
+        ``terrain`` (``"rough"`` = value-noise bumps, ``"stairs"`` = discrete
+        step plateaus; see :mod:`strands_robots.simulation.terrain`) lays down a
+        deterministic heightfield instead of the flat ground plane so a
         locomotion policy can be spawned/evaluated on non-flat ground; it is
         only meaningful when ``ground_plane=True`` and defaults to ``None`` (a
         flat plane). Backends without heightfield support reject a non-None

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -423,10 +423,12 @@ class MuJoCoSimEngine(
     ) -> dict[str, Any]:
         """Create a new simulation world.
 
-        ``terrain='rough'`` lays down a deterministic rough-ground heightfield
-        (see :mod:`strands_robots.simulation.terrain`) instead of the flat
+        ``terrain`` lays down a deterministic heightfield instead of the flat
         ground plane, so a floating-base/locomotion robot is spawned and
-        evaluated on non-flat ground. Only applies when ``ground_plane=True``.
+        evaluated on non-flat ground: ``"rough"`` = smoothed value-noise bumps,
+        ``"stairs"`` = a flight of discrete step plateaus (see
+        :mod:`strands_robots.simulation.terrain`). Only applies when
+        ``ground_plane=True``.
         """
         # mujoco verified at __init__
 
@@ -1823,7 +1825,7 @@ class MuJoCoSimEngine(
             "(timestep=None, gravity=None, ground_plane=True, terrain=None) -> dict  # create "
             "a fresh empty simulation world; the lifecycle entry point that precedes "
             "add_robot/add_object (gravity is [gx,gy,gz], ground_plane adds a floor, "
-            "terrain='rough' makes it a rough heightfield for locomotion)"
+            "terrain='rough'|'stairs' makes it a locomotion heightfield)"
         )
         base["methods"]["destroy"] = (
             "() -> dict  # tear down the world and release all resources (joins any "

--- a/strands_robots/simulation/mujoco/tool_spec.json
+++ b/strands_robots/simulation/mujoco/tool_spec.json
@@ -92,7 +92,7 @@
     },
     "terrain": {
       "type": "string",
-      "description": "create_world: rough-ground heightfield kind ('rough'); omit for a flat ground plane. MuJoCo backend only."
+      "description": "create_world: heightfield terrain kind ('rough' = bumps, 'stairs' = step plateaus); omit for a flat ground plane. MuJoCo backend only."
     },
     "urdf_path": {
       "type": "string",

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -238,9 +238,10 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
                 ``default_timestep``).
             gravity: Gravity vector ``[x, y, z]`` (default ``[0, 0, -9.81]``).
             ground_plane: Whether to add a ground plane.
-            terrain: Rough-ground heightfield kind (MuJoCo backend only). The
-                Newton backend has no heightfield ground yet, so a non-None
-                value is rejected with an actionable error.
+            terrain: Heightfield terrain kind (e.g. ``"rough"``/``"stairs"``,
+                MuJoCo backend only). The Newton backend has no heightfield
+                ground yet, so a non-None value is rejected with an actionable
+                error.
 
         Returns:
             Status dict with a human-readable confirmation.
@@ -252,7 +253,7 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
                     {
                         "text": (
                             f"terrain={terrain!r} is not supported on the Newton backend "
-                            "(rough-ground heightfields are MuJoCo-only); use "
+                            "(heightfield terrain, e.g. 'rough'/'stairs', is MuJoCo-only); use "
                             "create_simulation(backend='mujoco') for terrain, or omit terrain "
                             "for a flat ground plane."
                         )

--- a/strands_robots/simulation/terrain.py
+++ b/strands_robots/simulation/terrain.py
@@ -8,9 +8,11 @@ a flat plane, so they measure command tracking but never *robustness to
 terrain* -- the whole reason legged locomotion is hard. This module generates a
 deterministic rough-terrain heightfield that
 :meth:`~strands_robots.simulation.base.SimEngine.create_world` can lay down
-instead of the flat plane (``create_world(terrain="rough")``), so a floating-base
-robot settles onto and walks over bumps. It is the ground-generation primitive a
-terrain *curriculum* (progressive difficulty across resets) is built on.
+instead of the flat plane. ``create_world(terrain="rough")`` lays smoothed
+value-noise bumps; ``create_world(terrain="stairs")`` lays a flight of discrete
+step plateaus (foot-placement + climbing, which smooth bumps do not test). Both
+are ground-generation primitives a terrain *curriculum* (progressive difficulty
+across resets) is built on.
 
 The generator is intentionally backend- and MuJoCo-independent (pure stdlib, no
 numpy / mujoco import) so the height data is trivially unit-testable and
@@ -22,10 +24,12 @@ from __future__ import annotations
 
 import random
 
-# Supported terrain kinds. ``"rough"`` is smoothed value-noise bumps; the tuple
-# is the single source of truth both backends validate against and is easy to
-# extend (e.g. ``"stairs"``) without touching the create_world signature.
-SUPPORTED_TERRAINS: tuple[str, ...] = ("rough",)
+# Supported terrain kinds. ``"rough"`` is smoothed value-noise bumps; ``"stairs"``
+# is a flight of discrete parallel step plateaus. The tuple is the single source
+# of truth both backends validate against and is easy to extend without touching
+# the create_world signature -- add a name here and a branch in
+# :func:`generate_heightfield`.
+SUPPORTED_TERRAINS: tuple[str, ...] = ("rough", "stairs")
 
 # Heightfield geometry (metres). The field spans +/-``TERRAIN_RADIUS`` in x and y
 # (matching the flat ground plane's 5 m half-size so the reachable workspace is
@@ -38,6 +42,12 @@ TERRAIN_ELEVATION = 0.08
 TERRAIN_BASE = 0.1
 TERRAIN_RESOLUTION = 40  # nrow == ncol grid cells (25 cm cells over the 10 m field)
 TERRAIN_SEED = 0
+
+# Number of discrete step plateaus for ``terrain="stairs"``. The staircase rises
+# in ``TERRAIN_STAIR_STEPS`` even levels from 0 (flush with z=0) to
+# ``TERRAIN_ELEVATION`` along +x, so each riser is ``TERRAIN_ELEVATION /
+# (TERRAIN_STAIR_STEPS - 1)`` tall (five plateaus -> 2 cm risers up to 8 cm).
+TERRAIN_STAIR_STEPS = 5
 
 
 def validate_terrain(kind: str | None) -> None:
@@ -82,6 +92,24 @@ def _rough(n: int, seed: int) -> list[float]:
     return [(v - lo) / span for v in flat]
 
 
+def _stairs(n: int) -> list[float]:
+    """Discrete parallel step plateaus rising along +x.
+
+    MuJoCo ``<hfield>`` ``userdata`` is row-major with row 0 at min-y and column
+    0 at min-x, so making the level a step function of the *column* index makes
+    the staircase rise along +x and stay constant across y (a flight of steps
+    you climb as x increases). Returns ``TERRAIN_STAIR_STEPS`` distinct
+    normalized plateaus ``{0, 1/(k-1), ..., 1}`` -- deterministic, no rng.
+    """
+    steps = TERRAIN_STAIR_STEPS
+    out: list[float] = []
+    for _i in range(n):  # row (y): every row is identical
+        for j in range(n):  # column (x): step level rises with x
+            level = min((j * steps) // n, steps - 1)  # 0 .. steps-1
+            out.append(level / (steps - 1))
+    return out
+
+
 def generate_heightfield(
     kind: str,
     resolution: int = TERRAIN_RESOLUTION,
@@ -101,6 +129,8 @@ def generate_heightfield(
         raise ValueError(f"terrain resolution must be >= 2, got {resolution}.")
     if kind == "rough":
         return _rough(n, seed)
+    if kind == "stairs":
+        return _stairs(n)
     # validate_terrain accepts only SUPPORTED_TERRAINS; a kind reaching here
     # means the tuple grew without a generator branch.
     raise ValueError(f"terrain kind {kind!r} has no generator implementation.")  # pragma: no cover
@@ -113,6 +143,7 @@ __all__ = [
     "TERRAIN_BASE",
     "TERRAIN_RESOLUTION",
     "TERRAIN_SEED",
+    "TERRAIN_STAIR_STEPS",
     "validate_terrain",
     "generate_heightfield",
 ]

--- a/tests/simulation/mujoco/test_create_world_terrain.py
+++ b/tests/simulation/mujoco/test_create_world_terrain.py
@@ -169,9 +169,34 @@ def test_router_dispatch_accepts_terrain_kwarg() -> None:
 def test_router_dispatch_rejects_unknown_terrain() -> None:
     sim = MuJoCoSimEngine()
     try:
-        r = sim(action="create_world", terrain="stairs")
+        r = sim(action="create_world", terrain="bogus")
         assert r["status"] == "error"
         assert "rough" in r["content"][0]["text"]
     finally:
         if sim._world is not None:
             sim.destroy()
+
+
+def test_stairs_builds_a_heightfield_ground() -> None:
+    sim = MuJoCoSimEngine()
+    try:
+        assert sim.create_world(terrain="stairs")["status"] == "success"
+        assert sim._world is not None
+        m = sim._world._model
+        assert _ground_geom_type(sim) == _HFIELD
+        assert int(m.nhfield) == 1
+        # discrete step plateaus -> the compiled heightfield still spans the
+        # full normalized range (flush at z=0, up to the top step).
+        assert float(m.hfield_data.max()) - float(m.hfield_data.min()) > 0.5
+    finally:
+        sim.destroy()
+
+
+def test_stairs_collides_and_climbs_along_x() -> None:
+    # A box dropped on a +x plateau rests meaningfully higher than one on a -x
+    # plateau: the staircase both renders AND collides, and rises along +x.
+    z_top = _box_rest_z("stairs", 4.0, 0.0)  # near the top step
+    z_bot = _box_rest_z("stairs", -4.0, 0.0)  # near the bottom step
+    assert z_top > z_bot + 0.04, (z_top, z_bot)
+    # ...and both settle on the terrain, not fallen through to a hole.
+    assert z_bot > -0.01, z_bot

--- a/tests/simulation/test_terrain.py
+++ b/tests/simulation/test_terrain.py
@@ -47,7 +47,7 @@ def test_default_resolution_matches_module_constant() -> None:
     assert len(h) == terrain.TERRAIN_RESOLUTION * terrain.TERRAIN_RESOLUTION
 
 
-@pytest.mark.parametrize("bad", ["stairs", "flat", "ROUGH", ""])
+@pytest.mark.parametrize("bad", ["flat", "ROUGH", "", "spiral", "steps"])
 def test_unknown_terrain_kind_is_rejected_actionably(bad: str) -> None:
     with pytest.raises(ValueError) as exc:
         terrain.generate_heightfield(bad)
@@ -71,3 +71,42 @@ def test_validate_terrain_accepts_none_and_supported_rejects_unknown() -> None:
         terrain.validate_terrain(kind)  # no raise
     with pytest.raises(ValueError):
         terrain.validate_terrain("bogus")
+
+
+def test_stairs_field_has_correct_length_and_discrete_levels() -> None:
+    n = 40
+    h = terrain.generate_heightfield("stairs", resolution=n)
+    assert len(h) == n * n
+    assert all(0.0 <= v <= 1.0 for v in h)
+    assert min(h) == 0.0 and max(h) == 1.0
+    # A staircase is DISCRETE: exactly TERRAIN_STAIR_STEPS distinct plateau
+    # levels (this is what distinguishes it from the continuous "rough" field).
+    assert len(set(h)) == terrain.TERRAIN_STAIR_STEPS
+
+
+def test_stairs_field_is_deterministic_and_seed_independent() -> None:
+    # Stairs are fully deterministic (no rng), so the seed must not change them.
+    a = terrain.generate_heightfield("stairs", resolution=24, seed=0)
+    b = terrain.generate_heightfield("stairs", resolution=24, seed=99)
+    assert a == b
+
+
+def test_stairs_climbs_along_x_and_is_constant_across_y() -> None:
+    n = 40
+    h = terrain.generate_heightfield("stairs", resolution=n)
+    rows = [h[i * n : (i + 1) * n] for i in range(n)]
+    # MuJoCo hfield userdata is row-major (row 0 -> min y, col 0 -> min x): the
+    # staircase rises along +x (columns), so every row is identical...
+    assert all(rows[i] == rows[0] for i in range(n))
+    # ...and each row is a monotonically non-decreasing step function of x.
+    row0 = rows[0]
+    assert all(row0[j] <= row0[j + 1] for j in range(n - 1))
+    assert row0[0] == 0.0 and row0[-1] == 1.0
+
+
+def test_stairs_is_genuinely_stepped_not_smooth() -> None:
+    # Distinguish stairs (few discrete plateaus) from rough (near-continuous).
+    stairs = terrain.generate_heightfield("stairs", resolution=32)
+    rough = terrain.generate_heightfield("rough", resolution=32, seed=0)
+    assert len(set(stairs)) == terrain.TERRAIN_STAIR_STEPS
+    assert len(set(rough)) > terrain.TERRAIN_STAIR_STEPS * 10


### PR DESCRIPTION
## What

`create_world(terrain=...)` gains a second heightfield kind alongside `"rough"`:

```python
sim.create_world(ground_plane=True, terrain="stairs")
```

`terrain="stairs"` lays down a flight of **discrete flat step plateaus** (rising along +x) instead of smoothed value-noise bumps. Stairs test the **foot-placement and climbing** that a continuously-undulating field never does, so they are the canonical next terrain in a locomotion curriculum, and the natural second primitive `create_world(terrain=)` (introduced with the `"rough"` heightfield) was designed to grow into.

![terrain stairs vs rough](https://github.com/cagataycali/robots/releases/download/artifacts-terrain-stairs-1783940631/terrain_stairs_vs_rough.png)

*(Both panels: five red marker blocks on the terrain, low-oblique view. On `"rough"` they settle over smooth bumps; on `"stairs"` their rest heights climb in discrete steps along +x.)*

## Why

The floating-base locomotion benchmarks all spawn on flat or (now) rough ground, so a curriculum has exactly one non-flat terrain type. A stepped terrain is the standard second rung: it exercises a qualitatively different locomotion skill (climbing discrete risers / placing feet on flat landings) that smooth `"rough"` bumps do not.

## How

One module + discoverability strings, **no `create_world` signature change** (new kinds are added by appending to `SUPPORTED_TERRAINS` + a generator branch):

- `strands_robots/simulation/terrain.py`: `"stairs"` in `SUPPORTED_TERRAINS`, a `_stairs` generator, and a `TERRAIN_STAIR_STEPS` (=5) constant. The stepped field is pure-stdlib and backend-independent, **deterministic** (a stepped field is seed-independent), shares the flat plane's ±5 m footprint, and rises from 0 up to the same ~8 cm on a solid base slab (flush with `z=0` at its lowest step -> no hole under the robot). MuJoCo's row-major `<hfield>` userdata (row 0 -> min y, col 0 -> min x) means making the level a step function of the *column* index makes the staircase rise along +x and stay constant across y.
- `spec_builder.build_scene` already lays the hfield terrain-kind-agnostically and `attach_robot` already counts `mjGEOM_HFIELD` as ground, so no wiring change was needed.
- Discoverability updated to list both kinds: the `terrain` tool_spec param, the `create_world` `describe()` method string, and the `create_world` docstrings (base / MuJoCo / Newton). The Newton backend still rejects any non-`None` `terrain` with an actionable error (heightfield terrain is MuJoCo-only).

## Tests

- **Generator unit tests** (`tests/simulation/test_terrain.py`, pure-stdlib): a stairs field is exactly `TERRAIN_STAIR_STEPS` distinct plateau levels `{0, 0.25, 0.5, 0.75, 1.0}` (discrete, unlike rough's near-continuous field), monotonically climbs along +x, is constant across y, and is seed-independent.
- **MuJoCo integration** (`tests/simulation/mujoco/test_create_world_terrain.py`): the stairs hfield ground compiles, and a box dropped on a +x plateau rests measurably higher than one on a -x plateau -- so the staircase both renders **and collides** and rises along +x. Ground-truth physics rest heights (3 cm cube, y=0): x=-4 -> `0.021`, x=0 -> `0.058`, x=+4 -> `0.100` (flat control: `0.015` everywhere).
- Two tests that previously used `"stairs"` as their *unknown-kind placeholder* now use a still-unknown kind, since `"stairs"` is a real kind.

Green locally: `ruff check` + `ruff format` clean, `mypy` clean on changed files, and `MUJOCO_GL=egl` terrain + create_world + newton-reject + describe-discovery + tool_spec + foundation suites all pass.