### PR TITLE
test(docs): guard shipped source against dead-end test-file citations

### DIFF
--- a/strands_robots/mesh/_acl_config.py
+++ b/strands_robots/mesh/_acl_config.py
@@ -5,8 +5,7 @@ serialised ``access_control`` block ready for
 ``zenoh.Config.insert_json5``. When the env var is unset, returns the
 permissive :func:`default_acl` skeleton.
 
-Zenoh 1.x quirks (each verified against a live session in
-``tests/mesh/test_zenoh_transport_security.py``):
+Zenoh 1.x quirks (each verified against a live session):
 
 * ``enabled: true`` is required -- without it the entire block is a
   no-op even if rules and subjects are populated.

--- a/strands_robots/mesh/audit.py
+++ b/strands_robots/mesh/audit.py
@@ -977,8 +977,8 @@ def _ensure_paths(path: Path) -> None:
         # create with O_NOFOLLOW so an attacker who races a
         # symlink in between the is_symlink check above and this open
         # cannot redirect the create. ``Path.touch`` follows symlinks
-        # (the symlink-refusal and fail-soft contracts are pinned in
-        # tests/mesh/test_audit_log_symlink_refused.py). On Windows where
+        # (the symlink-refusal and fail-soft contracts are exercised by the
+        # mesh audit test suite). On Windows where
         # O_NOFOLLOW is 0 the static check above is the only line of
         # defence; this matches the residual-risk note in the module
         # docstring.

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -65,8 +65,7 @@ def _parse_positive_float_env(name: str, default: str, *, minimum: float = 0.0) 
 
     Catches the case where an operator sets ``STRANDS_MESH_RESUME_FRESHNESS_S=abc``
     or a negative value. The module would otherwise fail to import with an opaque
-    ``ValueError`` (found by running the module under bad env locally; see
-    ``test_resume_env_validation.py``).
+    ``ValueError`` (found by running the module under bad env locally).
     """
     raw = os.getenv(name, default)
     try:
@@ -898,7 +897,6 @@ class Mesh(SensorLoopsMixin):
             # Clauses Must Be Narrow". Same tuple as the four other
             # wire-input handlers (_on_cmd, _on_response,
             # _on_safety_estop, _on_safety_resume).
-            # Pin: tests/mesh/test_wire_handler_narrow_except.py
             return
         if not isinstance(data, dict):
             return

--- a/strands_robots/mesh/iot/camera_offload.py
+++ b/strands_robots/mesh/iot/camera_offload.py
@@ -118,9 +118,8 @@ class CameraOffloader:
         if ttl_raw < 1:
             # Issue #262: WARN on any sub-1 value EXCEPT exactly 0.
             # ``presign_ttl=0`` is the documented kwarg-vs-env-precedence
-            # sentinel pinned by ``test_presign_ttl_none_vs_zero.py`` (R1
-            # fix). ``presign_ttl=-99`` is unambiguously a bug at the call
-            # site -- no caller deliberately wants a negative TTL clamped
+            # sentinel (R1 fix). ``presign_ttl=-99`` is unambiguously a
+            # bug at the call site -- no caller deliberately wants a negative TTL clamped
             # to 1 -- and we surface it. The env-var path always WARNs
             # (operator-side bug if STRANDS_MESH_CAMERA_PRESIGN_TTL=-99).
             if presign_ttl is None or presign_ttl != 0:

--- a/strands_robots/mesh/iot/provision.py
+++ b/strands_robots/mesh/iot/provision.py
@@ -294,9 +294,8 @@ _OPERATOR_POLICY_DOC: dict[str, Any] = {
             # reads, and operational audit (``mesh_audit.jsonl`` logs
             # every command dispatch). A per-robot operator scope would
             # require a per-robot policy document, which explodes the
-            # policy count linearly with fleet size. Pinned as
-            # intentional by test_iot_policy_scope.py::TestOperatorPolicy
-            # ::test_publish_to_fleet_wildcard_is_deliberate.
+            # policy count linearly with fleet size. This fleet-wildcard
+            # scope is deliberate, not an oversight.
             "Sid": "OperatorPublishToFleet",
             "Effect": "Allow",
             "Action": ["iot:Publish", "iot:RetainPublish"],

--- a/strands_robots/mesh/transport/bridge_transport.py
+++ b/strands_robots/mesh/transport/bridge_transport.py
@@ -695,8 +695,7 @@ class BridgeTransport:
                     # Learnings (#86) > "Exception Clauses Must Be Narrow".
                     # Same tuple as the four wire handlers in core.py
                     # (_on_cmd, _on_response, _on_safety_estop,
-                    # _on_safety_resume). Pinned by
-                    # ``test_wire_handler_narrow_except.py``.
+                    # _on_safety_resume).
                     payload = None
 
                 # Use the actual delivered topic (sample.key_expr), not the

--- a/strands_robots/mesh/transport/zenoh_transport.py
+++ b/strands_robots/mesh/transport/zenoh_transport.py
@@ -5,9 +5,9 @@ This wrapper deliberately delegates to the legacy ``session.get_session()`` /
 ``session.put()`` / ``session.release_session()`` functions instead of
 reimplementing them. That keeps:
 
-1. **Zero behaviour change for existing callers.** Every test in
-   ``tests/mesh/test_mesh_session.py`` that pokes
-   ``session._SESSION`` / ``_SESSION_REFS`` keeps working - the legacy
+1. **Zero behaviour change for existing callers.** Every existing
+   caller that pokes ``session._SESSION`` / ``_SESSION_REFS`` keeps
+   working - the legacy
    module is the single source of truth for Zenoh state.
 2. **A single connect/teardown path.** Multiple :class:`ZenohTransport`
    instances in the same process all funnel into the same ref-counted

--- a/strands_robots/policies/moveit2/server/__init__.py
+++ b/strands_robots/policies/moveit2/server/__init__.py
@@ -20,8 +20,7 @@ Two recommended ways to run the sidecar:
    This is the recommended dev-loop setup; the docker path is for
    pinned reproducible deployments.
 
-The wire protocol is documented in :mod:`strands_robots.policies.moveit2.client`
-and pinned by tests under ``tests/policies/moveit2/test_policy.py``.
+The wire protocol is documented in :mod:`strands_robots.policies.moveit2.client`.
 """
 
 # Note: importing the server module here would force-import rclpy /

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -2203,9 +2203,8 @@ class IsaacSimulation(SimEngine):
         -------
         dict
             Standard Strands tool-result envelope carrying ONLY ``status`` and
-            ``content`` (the tool-result contract forbids extra top-level keys;
-            see tests/test_tool_result_contract.py). On success ``content``
-            holds a ``text`` block, a ``{"image": {"format": "png", ...}}``
+            ``content`` (the tool-result contract forbids extra top-level
+            keys). On success ``content`` holds a ``text`` block, a ``{"image": {"format": "png", ...}}``
             block with raw PNG bytes (matching the MuJoCo backend so the shared
             ``PolicyRunner._extract_frame_ndarray`` can pull frames for video
             recording, #127), and a ``{"json": {...}}`` block with pixel stats
@@ -2232,9 +2231,9 @@ class IsaacSimulation(SimEngine):
             content.append(block)
         # Structured telemetry (resolution, prim_path, rtx flag, pixel stats)
         # lives INSIDE a content json block, never as extra top-level keys -
-        # the Strands tool-result contract permits only {status, content}
-        # (see tests/test_tool_result_contract.py). Consumers that need the
-        # raw rgb/depth ndarrays use get_observation() or the internal
+        # the Strands tool-result contract permits only {status, content}.
+        # Consumers that need the raw rgb/depth ndarrays use get_observation()
+        # or the internal
         # _render_frame() helper; the PNG image block above feeds the shared
         # PolicyRunner video pipeline (#127).
         json_block: dict[str, Any] = dict(meta.get("json", {}))

--- a/tests/test_docstrings_no_dangling_doc_refs.py
+++ b/tests/test_docstrings_no_dangling_doc_refs.py
@@ -4,15 +4,18 @@ Docstrings and comments in the shipped package must not point readers at
 documents that are not part of the repository, nor at line-number
 self-references that rot the moment a file is edited.
 
-Two dangling-reference classes are pinned here:
+Three dangling-reference classes are pinned here:
 
 1. References to an internal design memo
    (``reports/STREAMING_DATA_LOOP_DEEP_DIVE.md``) that is not shipped in the
    distribution - every such pointer is a dead end for a reader.
 2. ``~L<line>`` self-references, which silently drift out of date as soon as
    the surrounding file changes.
+3. Citations of a test file by name (``test_foo.py``). The published wheel
+   ships no test tree, so the pointer is a dead end for a package reader, and
+   it rots the moment that test is renamed.
 
-Both fail loudly here so they cannot creep back into the package.
+All three fail loudly here so they cannot creep back into the package.
 """
 
 from __future__ import annotations
@@ -55,4 +58,26 @@ def test_no_rotting_line_number_self_references() -> None:
     assert not offenders, (
         f"source uses rotting '~L<line>' self-references: {offenders}. "
         "Describe the location by symbol or behavior, not a line number."
+    )
+
+
+# A shipped-source citation of a test file (``test_foo.py``) is a third
+# dangling-reference class: the published wheel/sdist ships no test tree, so
+# the pointer is a dead end for a package reader, and it silently rots the
+# moment that test is renamed. The invariant a test pins belongs described
+# inline, next to the code that upholds it - never behind a test filename.
+_TEST_FILE_REF = re.compile(r"\btest_[A-Za-z0-9_]+\.py\b")
+
+
+def test_no_reference_to_test_files_by_name() -> None:
+    offenders = {
+        str(path.relative_to(_PKG_ROOT)): sorted(set(matches))
+        for path in _package_sources()
+        if (matches := _TEST_FILE_REF.findall(path.read_text(encoding="utf-8")))
+    }
+    assert not offenders, (
+        f"shipped source cites test files by name: {offenders}. A package "
+        "consumer installs without the test tree, so each pointer is a dead "
+        "end that also rots when the test is renamed. Describe the invariant "
+        "inline next to the code instead of citing a test filename."
     )


### PR DESCRIPTION
## Problem

Shipped-source docstrings and comments cited test files by name, e.g.:

```
# ... Same tuple as the four wire handlers in core.py
# (_on_cmd, _on_response, _on_safety_estop, _on_safety_resume). Pinned by
# ``test_wire_handler_narrow_except.py``.
```

The published wheel/sdist ships no test tree, so every such pointer is a dead end for a package reader who never has `tests/` on disk. Worse, the citation silently rots the moment the test is renamed or moved, leaving a comment that points at nothing.

This is the exact failure mode `tests/test_docstrings_no_dangling_doc_refs.py` already guards against for two other reference classes (the unpublished `STREAMING_DATA_LOOP_DEEP_DIVE.md` design memo, and `~L<line>` self-references). Test-filename citations were simply an un-pinned third instance of the same class.

## Change

- Extend `test_docstrings_no_dangling_doc_refs.py` with a third pinned class, `test_no_reference_to_test_files_by_name`, that fails if any shipped `strands_robots/**.py` cites a `test_*.py` filename.
- Remove the 11 existing citations across `mesh/`, `policies/`, and `simulation/`, describing each pinned invariant inline next to the code that upholds it (which was already the useful part of every comment; only the brittle filename pointer was dropped).

Comments and docstrings only. No behavior change; no public API touched.

## Files

- `strands_robots/mesh/_acl_config.py`, `mesh/audit.py`, `mesh/core.py` (x2), `mesh/iot/camera_offload.py`, `mesh/iot/provision.py`, `mesh/transport/bridge_transport.py`, `mesh/transport/zenoh_transport.py`
- `strands_robots/policies/moveit2/server/__init__.py`
- `strands_robots/simulation/isaac/simulation.py` (x2)
- `tests/test_docstrings_no_dangling_doc_refs.py` (guard + docstring)

## Verification

The new guard **fails on pre-fix source** (lists all 11 offenders) and **passes after the fix**:

```
# pre-fix (source reverted, guard kept):
E  AssertionError: shipped source cites test files by name:
   {'mesh/_acl_config.py': ['test_zenoh_transport_security.py'],
    'mesh/audit.py': ['test_audit_log_symlink_refused.py'],
    'mesh/core.py': ['test_resume_env_validation.py', 'test_wire_handler_narrow_except.py'],
    'mesh/iot/camera_offload.py': ['test_presign_ttl_none_vs_zero.py'],
    'mesh/iot/provision.py': ['test_iot_policy_scope.py'],
    'mesh/transport/bridge_transport.py': ['test_wire_handler_narrow_except.py'],
    'mesh/transport/zenoh_transport.py': ['test_mesh_session.py'],
    'policies/moveit2/server/__init__.py': ['test_policy.py'],
    'simulation/isaac/simulation.py': ['test_tool_result_contract.py']}
1 failed

# post-fix:
tests/test_docstrings_no_dangling_doc_refs.py .... 3 passed
```

Full local gate green: `ruff check`, `ruff format --check`, and `mypy strands_robots tests tests_integ` (`Success: no issues found in 777 source files`).