### PR TITLE
test(sim): pin rough terrain collapses to a flat field on degenerate noise

### DIFF
--- a/tests/simulation/test_terrain.py
+++ b/tests/simulation/test_terrain.py
@@ -11,6 +11,8 @@ are pure stdlib (no mujoco / numpy) and exercise the module in isolation.
 
 from __future__ import annotations
 
+import types
+
 import pytest
 
 from strands_robots.simulation import terrain
@@ -162,3 +164,23 @@ def test_pyramid_is_radially_isotropic_unlike_the_plus_x_staircase() -> None:
     s_row = sg[ci]
     s_col = [sg[i][ci] for i in range(n)]
     assert s_row != s_col
+
+
+def test_rough_field_collapses_to_flat_when_noise_is_degenerate(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Normalization divides by (max - min); a uniform value-noise field (every
+    # cell identical) has a zero span and would divide by zero. The generator
+    # guards that degenerate case by returning a flat field of zeros instead of
+    # crashing. Simulate uniform noise with a constant rng and assert the field
+    # is well-formed and flush with the floor.
+    class _ConstRandom:
+        def __init__(self, seed: int) -> None:
+            self._seed = seed
+
+        def random(self) -> float:
+            return 0.42
+
+    monkeypatch.setattr(terrain, "random", types.SimpleNamespace(Random=_ConstRandom))
+    n = 8
+    h = terrain.generate_heightfield("rough", resolution=n, seed=0)
+    assert len(h) == n * n
+    assert h == [0.0] * (n * n)  # flat, no NaN / no ZeroDivisionError


### PR DESCRIPTION
## Problem
The rough-terrain generator (`simulation/terrain.py`, behind `create_world(terrain="rough")`) builds smoothed value-noise bumps and normalizes them to `[0, 1]` by dividing by the field's span (`max - min`). A **uniform** field (every cell identical after blurring) has a zero span, so the naive normalization would divide by zero. `generate_heightfield` guards that degenerate case and returns a flat field of zeros instead of crashing -- but that guard had no test pinning it, leaving the only uncovered line in the module.

## Change
Add one focused regression test: a constant rng produces a uniform noise field, and the generator must return a well-formed flat field (correct length, every value `0.0`) rather than raising `ZeroDivisionError`.

## Regression evidence
- With the `span <= 0.0` guard removed (pre-fix behavior), the test fails with `ZeroDivisionError: float division by zero` at the normalization line.
- With the guard in place, the field is flat and flush with the floor (all zeros).

## Coverage
`strands_robots/simulation/terrain.py`: 99% -> **100%** (closes the last uncovered line).

## Testing
- `ruff check` / `ruff format --check` clean; `mypy strands_robots tests tests_integ`: no issues.
- Full suite: `MUJOCO_GL=egl pytest tests/` -> 10477 passed, 182 skipped.

Test-only change; no runtime behavior is modified.