### PR TITLE
feat(sim): create_world(terrain=..., difficulty=...) - terrain elevation curriculum knob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,27 @@ satisfies a yaw goal (distinguishing it from `base_tipped`); pairing it with
 `base_tipped` in `failure` vetoes a "turned then fell" rollout, whose yaw would
 be ill-defined.
 
+### Added: `create_world(terrain=..., difficulty=...)` - terrain elevation curriculum knob
+
+The three terrain heightfields (`rough`/`stairs`/`pyramid`) shipped as
+"ground-generation primitives a terrain *curriculum* (progressive difficulty
+across resets) is built on", but the curriculum knob itself did not exist: a
+caller could switch the terrain *kind* but not its *magnitude*, so a locomotion
+curriculum could only step between three fixed heights (~8 cm) and could not
+start a policy on gentle ground and grow it. `create_world` gains a `difficulty`
+scalar that multiplies the heightfield's peak elevation: `difficulty=1.0` (the
+default) is the full-height terrain, byte-identical to omitting it; `<1` is
+gentler (a robot settles onto shallower bumps/steps), `>1` harsher. It is
+kind-agnostic (the generator's normalized `[0, 1]` field is unchanged - only the
+metre scale it maps to changes, via the new `terrain.terrain_elevation`
+single-source-of-truth helper) so it composes with every terrain kind, and a
+benchmark/trainer ramps it across resets to grow the terrain the policy must
+handle. `difficulty` must be a finite value `> 0` (a non-positive/NaN value is
+rejected actionably) and only applies with a `terrain`: setting
+`difficulty != 1.0` on a flat world (no `terrain`) is rejected with an error
+rather than silently having no effect. It exists on the Newton backend for
+signature parity but is inert there (Newton rejects `terrain` outright).
+
 ### Added: `create_world(terrain="rough")` - rough-ground heightfield for locomotion
 
 The floating-base locomotion benchmarks (`go2_walk_forward` / `g1_walk_forward`

--- a/docs/simulation/world-building.md
+++ b/docs/simulation/world-building.md
@@ -81,6 +81,24 @@ is the ground-generation primitive a terrain *curriculum* (progressive
 difficulty across resets) builds on. (MuJoCo backend; the Newton backend
 rejects `terrain=` as not-yet-supported.)
 
+That curriculum knob is `difficulty`, which scales the terrain's peak
+elevation (the metre height its normalized `[0, 1]` field maps to) without
+changing the terrain *kind*:
+
+```python
+sim.create_world(terrain="rough", difficulty=0.3)  # gentle bumps (early stage)
+# ... later, harder stages ...
+sim.create_world(terrain="rough", difficulty=1.0)  # full ~8 cm bumps (default)
+sim.create_world(terrain="rough", difficulty=2.0)  # exaggerated ~16 cm bumps
+```
+
+`difficulty=1.0` (the default) is the full-height terrain, byte-identical to
+omitting it; `<1` is gentler, `>1` harsher. It must be a finite value `> 0`,
+and it only applies with a `terrain` - setting `difficulty != 1.0` on a flat
+world (no `terrain`) is rejected with an error rather than silently having no
+effect. A locomotion curriculum ramps `difficulty` across resets to grow the
+terrain the policy must handle.
+
 ## Procedural objects
 
 ```python

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -262,6 +262,7 @@ class SimEngine(ABC):
         gravity: list[float] | None = None,
         ground_plane: bool = True,
         terrain: str | None = None,
+        difficulty: float = 1.0,
     ) -> dict[str, Any]:
         """Create a new simulation world.
 
@@ -274,6 +275,13 @@ class SimEngine(ABC):
         only meaningful when ``ground_plane=True`` and defaults to ``None`` (a
         flat plane). Backends without heightfield support reject a non-None
         ``terrain`` with an actionable error rather than silently ignoring it.
+
+        ``difficulty`` scales the terrain's peak elevation (``1.0`` = full
+        height, ``<1`` gentler, ``>1`` harsher) so a curriculum can ramp
+        terrain magnitude across resets without changing the terrain *kind*.
+        It is only meaningful with a ``terrain``; setting ``difficulty != 1.0``
+        with no ``terrain`` is rejected with an actionable error rather than
+        silently having no effect. Must be a finite value ``> 0``.
         """
         ...
 

--- a/strands_robots/simulation/models.py
+++ b/strands_robots/simulation/models.py
@@ -171,6 +171,10 @@ class SimWorld:
     # Heightfield terrain kind (e.g. "rough"/"stairs"/"pyramid"); None -> flat plane. See
     # strands_robots.simulation.terrain. Only meaningful when ground_plane=True.
     terrain: str | None = None
+    # Curriculum difficulty scaling the terrain's peak elevation (1.0 = full
+    # height); only meaningful when terrain is set. See
+    # strands_robots.simulation.terrain.terrain_elevation.
+    terrain_difficulty: float = 1.0
     status: SimStatus = SimStatus.IDLE
     sim_time: float = 0.0
     step_count: int = 0

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -89,7 +89,7 @@ from strands_robots.simulation.mujoco.scene_ops import (
 )
 from strands_robots.simulation.mujoco.spec_builder import SpecBuilder, _validate_size
 from strands_robots.simulation.policy_runner import CooperativeStop
-from strands_robots.simulation.terrain import validate_terrain
+from strands_robots.simulation.terrain import validate_difficulty, validate_terrain
 from strands_robots.teleop_mixin import TeleopMixin
 
 if TYPE_CHECKING:
@@ -420,6 +420,7 @@ class MuJoCoSimEngine(
         gravity: list[float] | None = None,
         ground_plane: bool = True,
         terrain: str | None = None,
+        difficulty: float = 1.0,
     ) -> dict[str, Any]:
         """Create a new simulation world.
 
@@ -430,6 +431,12 @@ class MuJoCoSimEngine(
         ``"pyramid"`` = concentric step plateaus rising toward the centre (see
         :mod:`strands_robots.simulation.terrain`). Only applies when
         ``ground_plane=True``.
+
+        ``difficulty`` scales the terrain's peak elevation (``1.0`` = full
+        height, ``<1`` gentler, ``>1`` harsher) - the curriculum knob a
+        trainer ramps across resets. It is only meaningful with a ``terrain``;
+        ``difficulty != 1.0`` with no ``terrain`` is rejected (it would have no
+        effect) and must be a finite value ``> 0``.
         """
         # mujoco verified at __init__
 
@@ -438,6 +445,23 @@ class MuJoCoSimEngine(
                 validate_terrain(terrain)
             except ValueError as exc:
                 return {"status": "error", "content": [{"text": str(exc)}]}
+        try:
+            validate_difficulty(difficulty)
+        except ValueError as exc:
+            return {"status": "error", "content": [{"text": str(exc)}]}
+        if terrain is None and float(difficulty) != 1.0:
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            f"difficulty={difficulty!r} has no effect without a terrain "
+                            "(it scales a heightfield's elevation); pass terrain='rough'/'stairs'/"
+                            "'pyramid' as well, or omit difficulty for a flat ground plane."
+                        )
+                    }
+                ],
+            }
 
         if self._world is not None and self._world._model is not None:
             return {
@@ -457,6 +481,7 @@ class MuJoCoSimEngine(
             gravity=_gravity,
             ground_plane=ground_plane,
             terrain=terrain,
+            terrain_difficulty=float(difficulty),
         )
 
         self._world.cameras["default"] = SimCamera(
@@ -1823,7 +1848,7 @@ class MuJoCoSimEngine(
         # registry trio -- register_urdf / list_urdfs / remove_robot -- is
         # advertised with the robot-registry family earlier in describe().)
         base["methods"]["create_world"] = (
-            "(timestep=None, gravity=None, ground_plane=True, terrain=None) -> dict  # create "
+            "(timestep=None, gravity=None, ground_plane=True, terrain=None, difficulty=1.0) -> dict  # create "
             "a fresh empty simulation world; the lifecycle entry point that precedes "
             "add_robot/add_object (gravity is [gx,gy,gz], ground_plane adds a floor, "
             "terrain='rough'|'stairs'|'pyramid' makes it a locomotion heightfield)"

--- a/strands_robots/simulation/mujoco/spec_builder.py
+++ b/strands_robots/simulation/mujoco/spec_builder.py
@@ -29,11 +29,11 @@ from strands_robots.simulation.models import SimCamera, SimObject, SimRobot, Sim
 from strands_robots.simulation.mujoco.backend import _ensure_mujoco
 from strands_robots.simulation.terrain import (
     TERRAIN_BASE,
-    TERRAIN_ELEVATION,
     TERRAIN_RADIUS,
     TERRAIN_RESOLUTION,
     TERRAIN_SEED,
     generate_heightfield,
+    terrain_elevation,
 )
 
 logger = logging.getLogger(__name__)
@@ -324,15 +324,18 @@ class SpecBuilder:
         # share the checker material and the "ground" geom name so downstream
         # ground-plane detection (attach_robot floor-strip) and any name lookup
         # are terrain-agnostic. The hfield surface spans z in
-        # [0, TERRAIN_ELEVATION] on a solid base slab -> flush with z=0 at its
+        # [0, terrain_elevation(difficulty)] on a solid base slab -> flush with z=0 at its
         # lowest point (no hole under the robot), same +/-5 m footprint as the
         # flat plane so the reachable workspace is unchanged.
         if world.ground_plane:
             if world.terrain:
                 heights = generate_heightfield(world.terrain, resolution=TERRAIN_RESOLUTION, seed=TERRAIN_SEED)
+                # difficulty scales the hfield PEAK elevation (kind-agnostic): the
+                # normalized [0, 1] heights are the same, only the metre scale changes.
+                elevation = terrain_elevation(world.terrain_difficulty)
                 spec.add_hfield(
                     name="terrain_hfield",
-                    size=[TERRAIN_RADIUS, TERRAIN_RADIUS, TERRAIN_ELEVATION, TERRAIN_BASE],
+                    size=[TERRAIN_RADIUS, TERRAIN_RADIUS, elevation, TERRAIN_BASE],
                     nrow=TERRAIN_RESOLUTION,
                     ncol=TERRAIN_RESOLUTION,
                     userdata=heights,

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -230,6 +230,7 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         gravity: list[float] | None = None,
         ground_plane: bool = True,
         terrain: str | None = None,
+        difficulty: float = 1.0,
     ) -> dict[str, Any]:
         """Create an empty Newton world.
 
@@ -242,6 +243,9 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
                 MuJoCo backend only). The Newton backend has no heightfield
                 ground yet, so a non-None value is rejected with an actionable
                 error.
+            difficulty: Terrain curriculum elevation scale (MuJoCo backend
+                only, alongside ``terrain``); accepted for signature parity but
+                inert here since Newton rejects ``terrain`` outright.
 
         Returns:
             Status dict with a human-readable confirmation.

--- a/strands_robots/simulation/terrain.py
+++ b/strands_robots/simulation/terrain.py
@@ -15,7 +15,14 @@ not test); ``create_world(terrain="pyramid")`` lays concentric square step
 plateaus rising toward the centre from every direction (an omnidirectional climb
 the +x-only staircase cannot express, matching the omnidirectional strafe/turn
 velocity-tracking commands). All three are ground-generation primitives a
-terrain *curriculum* (progressive difficulty across resets) is built on.
+terrain *curriculum* (progressive difficulty across resets) is built on. That
+curriculum knob is the ``difficulty`` scalar (``terrain_elevation``): the
+heightfield the generator returns is normalized to ``[0, 1]`` and scaled to
+metres by a peak elevation, so ``create_world(terrain=..., difficulty=d)``
+multiplies that peak by ``d`` (``d=1.0`` full height, smaller = gentler,
+larger = harsher) to ramp terrain magnitude across resets without changing
+the terrain *kind* -- a robot settles onto shallower bumps/steps at a lower
+difficulty and taller ones as it is raised.
 
 The generator is intentionally backend- and MuJoCo-independent (pure stdlib, no
 numpy / mujoco import) so the height data is trivially unit-testable and
@@ -25,6 +32,7 @@ policy on ``terrain="rough"`` regenerates the identical field on every reset.
 
 from __future__ import annotations
 
+import math
 import random
 
 # Supported terrain kinds. ``"rough"`` is smoothed value-noise bumps; ``"stairs"``
@@ -68,6 +76,35 @@ def validate_terrain(kind: str | None) -> None:
     raise ValueError(
         f"Unknown terrain {kind!r}. Supported: {sorted(SUPPORTED_TERRAINS)} (or None / omit for a flat ground plane)."
     )
+
+
+def validate_difficulty(difficulty: float) -> None:
+    """Raise ``ValueError`` unless ``difficulty`` is a finite value ``> 0``.
+
+    ``difficulty`` scales the terrain's peak elevation (``1.0`` = full height);
+    ``0`` would collapse the heightfield to a flat plane (a degenerate hfield
+    with zero elevation, which MuJoCo rejects) and a negative/NaN value is
+    meaningless, so both are rejected actionably rather than silently producing
+    broken ground.
+    """
+    d = float(difficulty)
+    if not math.isfinite(d) or d <= 0.0:
+        raise ValueError(f"terrain difficulty must be a finite value > 0 (1.0 = full height), got {difficulty!r}.")
+
+
+def terrain_elevation(difficulty: float = 1.0) -> float:
+    """Peak terrain elevation in metres for a curriculum ``difficulty``.
+
+    The heightfield generator returns normalized ``[0, 1]`` heights; this maps
+    them to metres. At ``difficulty=1.0`` it returns :data:`TERRAIN_ELEVATION`
+    (the default full-height terrain, unchanged); ``difficulty=0.5`` halves the
+    peak (gentler curriculum stage), ``difficulty=2.0`` doubles it (harsher).
+    The single source of truth both the surface scale and any future consumer
+    agree on. Raises via :func:`validate_difficulty` for a non-positive/NaN
+    value.
+    """
+    validate_difficulty(difficulty)
+    return TERRAIN_ELEVATION * float(difficulty)
 
 
 def _box_blur(grid: list[list[float]], n: int) -> list[list[float]]:
@@ -187,5 +224,7 @@ __all__ = [
     "TERRAIN_STAIR_STEPS",
     "TERRAIN_PYRAMID_STEPS",
     "validate_terrain",
+    "validate_difficulty",
+    "terrain_elevation",
     "generate_heightfield",
 ]

--- a/tests/simulation/mujoco/test_create_world_terrain.py
+++ b/tests/simulation/mujoco/test_create_world_terrain.py
@@ -65,6 +65,114 @@ def _box_rest_z(terrain_kind: str | None, x: float, y: float) -> float:
         sim.destroy()
 
 
+def _box_center_rest_z(terrain_kind: str, difficulty: float) -> float:
+    """Rest z of a box dropped at the pyramid centre for a given difficulty."""
+    sim = MuJoCoSimEngine()
+    try:
+        r = sim.create_world(terrain=terrain_kind, difficulty=difficulty)
+        assert r["status"] == "success", r
+        sim.add_object("blk", shape="box", size=[0.1, 0.1, 0.04], position=[0, 0, 0.6], color=[1, 0, 0, 1])
+        assert sim._world is not None
+        m, d = sim._world._model, sim._world._data
+        for _ in range(2500):
+            mujoco.mj_step(m, d)
+        bid = mujoco.mj_name2id(m, mujoco.mjtObj.mjOBJ_BODY, "blk")
+        return float(d.xpos[bid][2])
+    finally:
+        sim.destroy()
+
+
+def _hfield_peak_elevation(**kw: object) -> float:
+    sim = MuJoCoSimEngine()
+    try:
+        assert sim.create_world(terrain="pyramid", **kw)["status"] == "success"  # type: ignore[arg-type]
+        assert sim._world is not None
+        return float(sim._world._model.hfield_size[0][2])
+    finally:
+        sim.destroy()
+
+
+def test_difficulty_default_matches_full_height_terrain() -> None:
+    # difficulty=1.0 (default) is byte-identical to omitting it: same peak
+    # elevation AND the same normalized heightfield (difficulty scales only the
+    # metre-scale peak, never the [0, 1] field the generator returns).
+    import numpy as np
+
+    assert _hfield_peak_elevation() == _hfield_peak_elevation(difficulty=1.0) == terrain.TERRAIN_ELEVATION
+    a = MuJoCoSimEngine()
+    b = MuJoCoSimEngine()
+    try:
+        a.create_world(terrain="pyramid", difficulty=1.0)
+        b.create_world(terrain="pyramid", difficulty=0.5)
+        assert a._world is not None and b._world is not None
+        assert np.array_equal(np.array(a._world._model.hfield_data), np.array(b._world._model.hfield_data))
+    finally:
+        a.destroy()
+        b.destroy()
+
+
+def test_difficulty_scales_peak_elevation_linearly() -> None:
+    assert abs(_hfield_peak_elevation(difficulty=0.5) - terrain.TERRAIN_ELEVATION * 0.5) < 1e-9
+    assert abs(_hfield_peak_elevation(difficulty=2.0) - terrain.TERRAIN_ELEVATION * 2.0) < 1e-9
+
+
+def test_difficulty_scales_the_settled_terrain_height() -> None:
+    # A box at the pyramid centre settles meaningfully LOWER on a lower-difficulty
+    # (shorter) terrain and higher on a taller one - the curriculum physically
+    # changes the ground the robot walks on, not just a stored number.
+    z_full = _box_center_rest_z("pyramid", 1.0)
+    z_half = _box_center_rest_z("pyramid", 0.5)
+    assert z_full > z_half + 0.02, (z_full, z_half)
+
+
+def test_bad_difficulty_is_rejected_without_half_building_a_world() -> None:
+    for bad in (-1.0, 0.0, float("inf")):
+        sim = MuJoCoSimEngine()
+        try:
+            r = sim.create_world(terrain="rough", difficulty=bad)
+            assert r["status"] == "error"
+            assert "difficulty" in r["content"][0]["text"]
+            assert sim._world is None or sim._world._model is None
+        finally:
+            if sim._world is not None:
+                sim.destroy()
+
+
+def test_difficulty_without_terrain_is_rejected_as_a_no_op() -> None:
+    # difficulty scales a heightfield; setting it != 1.0 with no terrain would
+    # silently do nothing, so it is rejected actionably rather than ignored.
+    sim = MuJoCoSimEngine()
+    try:
+        r = sim.create_world(difficulty=0.5)
+        assert r["status"] == "error"
+        assert "terrain" in r["content"][0]["text"]
+        assert sim._world is None or sim._world._model is None
+    finally:
+        if sim._world is not None:
+            sim.destroy()
+
+
+def test_flat_world_default_difficulty_still_succeeds() -> None:
+    # The common flat-world path (no terrain, default difficulty) is unaffected.
+    sim = MuJoCoSimEngine()
+    try:
+        assert sim.create_world()["status"] == "success"
+        assert _ground_geom_type(sim) == _PLANE
+    finally:
+        sim.destroy()
+
+
+def test_router_dispatch_accepts_difficulty_kwarg() -> None:
+    sim = MuJoCoSimEngine()
+    try:
+        r = sim(action="create_world", terrain="pyramid", difficulty=0.5)
+        assert r["status"] == "success", r
+        assert sim._world is not None
+        assert abs(float(sim._world._model.hfield_size[0][2]) - terrain.TERRAIN_ELEVATION * 0.5) < 1e-9
+    finally:
+        sim.destroy()
+
+
 def test_terrain_builds_a_heightfield_ground() -> None:
     sim = MuJoCoSimEngine()
     try:

--- a/tests/simulation/newton/test_create_world_terrain_reject.py
+++ b/tests/simulation/newton/test_create_world_terrain_reject.py
@@ -52,3 +52,14 @@ def test_newton_terrain_none_is_not_rejected() -> None:
     eng._rebuild = lambda: None  # type: ignore[method-assign]
     r = eng.create_world(terrain=None)
     assert r["status"] == "success"
+
+
+def test_newton_accepts_difficulty_kwarg_and_still_rejects_terrain() -> None:
+    # ``difficulty`` exists on both backends for signature parity; on Newton it
+    # is inert (terrain is rejected outright), but passing it must not raise a
+    # TypeError - the terrain rejection still fires with difficulty supplied.
+    assert _engine_cls is not None
+    eng = _engine_cls.__new__(_engine_cls)
+    r = eng.create_world(terrain="rough", difficulty=0.5)
+    assert r["status"] == "error"
+    assert "Newton" in r["content"][0]["text"] and "rough" in r["content"][0]["text"]

--- a/tests/simulation/test_foundation.py
+++ b/tests/simulation/test_foundation.py
@@ -40,6 +40,7 @@ def _make_dummy_engine_class() -> type[SimEngine]:
             gravity: list[float] | None = None,
             ground_plane: bool = True,
             terrain: str | None = None,
+            difficulty: float = 1.0,
         ) -> dict[str, Any]:
             return {}
 

--- a/tests/simulation/test_sim_engine_describe_discovery.py
+++ b/tests/simulation/test_sim_engine_describe_discovery.py
@@ -32,6 +32,7 @@ def _make_minimal_engine():
             gravity: list[float] | None = None,
             ground_plane: bool = True,
             terrain: str | None = None,
+            difficulty: float = 1.0,
         ) -> dict[str, Any]:
             return {}
 

--- a/tests/simulation/test_terrain.py
+++ b/tests/simulation/test_terrain.py
@@ -184,3 +184,29 @@ def test_rough_field_collapses_to_flat_when_noise_is_degenerate(monkeypatch: pyt
     h = terrain.generate_heightfield("rough", resolution=n, seed=0)
     assert len(h) == n * n
     assert h == [0.0] * (n * n)  # flat, no NaN / no ZeroDivisionError
+
+
+def test_terrain_elevation_default_is_the_module_constant() -> None:
+    # difficulty=1.0 (the default) is the full-height terrain, unchanged.
+    assert terrain.terrain_elevation() == terrain.TERRAIN_ELEVATION
+    assert terrain.terrain_elevation(1.0) == terrain.TERRAIN_ELEVATION
+
+
+def test_terrain_elevation_scales_linearly_with_difficulty() -> None:
+    # The curriculum knob: peak elevation is a linear multiple of difficulty, so
+    # a trainer ramps terrain magnitude across resets without changing the kind.
+    assert terrain.terrain_elevation(0.5) == terrain.TERRAIN_ELEVATION * 0.5
+    assert terrain.terrain_elevation(2.0) == terrain.TERRAIN_ELEVATION * 2.0
+
+
+@pytest.mark.parametrize("bad", [0.0, -1.0, -0.01, float("inf"), float("nan")])
+def test_validate_difficulty_rejects_non_positive_or_nonfinite(bad: float) -> None:
+    with pytest.raises(ValueError) as exc:
+        terrain.validate_difficulty(bad)
+    assert "difficulty" in str(exc.value)  # actionable: names the offending argument
+
+
+@pytest.mark.parametrize("good", [0.1, 0.5, 1.0, 2.0, 5.0])
+def test_validate_difficulty_accepts_positive_finite(good: float) -> None:
+    terrain.validate_difficulty(good)  # no raise
+    assert terrain.terrain_elevation(good) > 0.0


### PR DESCRIPTION
## Summary

The three terrain heightfields (`rough`/`stairs`/`pyramid`) shipped as "ground-generation primitives a terrain *curriculum* (progressive difficulty across resets) is built on", but that curriculum knob did not actually exist. A caller could switch the terrain *kind* but not its *magnitude*, so a locomotion curriculum could only step between three fixed ~8 cm heights and could not start a policy on gentle ground and grow it.

`create_world` gains a `difficulty` scalar that multiplies the heightfield's peak elevation:

```python
sim.create_world(terrain="rough", difficulty=0.3)  # gentle early-stage bumps
sim.create_world(terrain="rough", difficulty=1.0)  # full ~8 cm bumps (default)
sim.create_world(terrain="rough", difficulty=2.0)  # exaggerated ~16 cm bumps
```

- **Kind-agnostic.** The generator's normalized `[0, 1]` field is unchanged - only the metre scale it maps to changes, via a new `terrain.terrain_elevation(difficulty)` single-source-of-truth helper - so `difficulty` composes with every terrain kind.
- **`difficulty=1.0` (default) is byte-identical to omitting it** (same peak elevation *and* the same compiled `hfield_data`); `<1` gentler, `>1` harsher.
- **No silent no-ops.** `difficulty` must be a finite value `> 0` (a non-positive/NaN value is rejected actionably), and it only applies with a `terrain`: setting `difficulty != 1.0` on a flat world (no `terrain`) is rejected with an error rather than silently having no effect - matching the existing terrain-rejection philosophy.
- **Backend parity.** Present on the Newton `create_world` signature but inert there (Newton rejects `terrain` outright); MuJoCo applies it.

This is the atomic primitive a terrain curriculum ramps across resets to grow the ground a locomotion policy must handle (the reward DSL + `go2/g1/t1_walk_forward` velocity-tracking benchmarks already exist; this adds the terrain-magnitude axis).

## Verification

Real MuJoCo physics (no mocks). A red marker box dropped on the pyramid centre settles progressively higher as the terrain is scaled - the curriculum physically changes the ground, not just a stored number:

![terrain difficulty](https://github.com/cagataycali/robots/releases/download/artifacts-terrain-difficulty-1783961940/terrain_difficulty.png)

| difficulty | peak elevation | box rest z |
|---|---|---|
| 0.5 | 4 cm | 8.9 cm |
| 1.0 | 8 cm | 12.9 cm |
| 2.0 | 16 cm | 20.9 cm |

## Tests

Regression tests fail on `main` (no `validate_difficulty`/`terrain_elevation`, `create_world()` rejects the `difficulty` kwarg) and pass with the change:

- `tests/simulation/test_terrain.py` - `terrain_elevation` scales linearly, default equals the module constant, `validate_difficulty` rejects `<=0`/`inf`/`nan` and accepts positive finite values.
- `tests/simulation/mujoco/test_create_world_terrain.py` - peak elevation scales linearly, `difficulty=1.0` is byte-identical to the default (same normalized `hfield_data`), a box settles measurably lower at lower difficulty, bad difficulty is rejected without half-building a world, `difficulty` without `terrain` is rejected as a no-op, the flat default is unaffected, and the agent-dispatch router accepts the `difficulty` kwarg.
- `tests/simulation/newton/test_create_world_terrain_reject.py` - Newton accepts the `difficulty` kwarg (signature parity) and still rejects `terrain`.

Green gate: `ruff check` + `ruff format` + `mypy` clean; the full terrain / create_world_terrain / newton-reject / describe-discovery / tool_spec suites pass (96 selected). Docs updated in `docs/simulation/world-building.md`.