### PR TITLE
test(docs): guard dead-end test-file citations under both pytest naming conventions

### DIFF
--- a/examples/notebooks/05_streaming_data_loop.ipynb
+++ b/examples/notebooks/05_streaming_data_loop.ipynb
@@ -1,20 +1,8 @@
 {
- "nbformat": 4,
- "nbformat_minor": 5,
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "name": "python",
-   "version": "3.12"
-  }
- },
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "7fb27b941602401d91542211134fc71a",
    "metadata": {},
    "source": [
     "# The Streaming Data Loop\n",
@@ -34,7 +22,10 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "acae54e37e7d407bbb7b55eff062a284",
    "metadata": {},
+   "outputs": [],
    "source": [
     "import os\n",
     "import shutil\n",
@@ -49,12 +40,11 @@
     "\n",
     "shutil.rmtree(ROOT, ignore_errors=True)\n",
     "shutil.rmtree(OUT, ignore_errors=True)"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "9a63283cbaf04dbcab1f6479b197f3a8",
    "metadata": {},
    "source": [
     "## 1. Record a demonstration\n",
@@ -66,7 +56,10 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "8dd0d8092fe74a7c96281538738b07e2",
    "metadata": {},
+   "outputs": [],
    "source": [
     "from strands_robots import MockPolicy, Robot, create_policy\n",
     "from strands_robots.training import TrainSpec, create_trainer\n",
@@ -74,21 +67,25 @@
     "sim = Robot(\"so100\", mesh=False)\n",
     "sim.add_camera(name=\"front\", position=[0.5, 0.0, 0.4], target=[0.2, 0.0, 0.05])\n",
     "sim.start_recording(\n",
-    "    repo_id=\"local/nb5_demo\", root=ROOT, fps=30,\n",
-    "    task=\"pick up the red cube\", overwrite=True,\n",
+    "    repo_id=\"local/nb5_demo\",\n",
+    "    root=ROOT,\n",
+    "    fps=30,\n",
+    "    task=\"pick up the red cube\",\n",
+    "    overwrite=True,\n",
     ")\n",
     "sim.run_policy(\n",
-    "    robot_name=\"so100\", policy_object=MockPolicy(),\n",
-    "    instruction=\"pick up the red cube\", n_steps=60,\n",
+    "    robot_name=\"so100\",\n",
+    "    policy_object=MockPolicy(),\n",
+    "    instruction=\"pick up the red cube\",\n",
+    "    n_steps=60,\n",
     ")\n",
     "sim.stop_recording()\n",
     "print(\"recorded ->\", ROOT)"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "72eea5119410473aa328ad9291626812",
    "metadata": {},
    "source": [
     "## 2. See what the robot recorded\n",
@@ -98,7 +95,10 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "8edb47106e1a46a883d545849b8ab81b",
    "metadata": {},
+   "outputs": [],
    "source": [
     "from IPython.display import Image, display\n",
     "\n",
@@ -110,12 +110,11 @@
     "        break\n",
     "sim.destroy()\n",
     "print(\"SO-100 arm with front camera - this is what the dataset contains.\")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "10185d26023b46108eb7d9f57d49d2b3",
    "metadata": {},
    "source": [
     "## 3. Sync to a Hugging Face Storage Bucket (optional)\n",
@@ -130,22 +129,25 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "8763a12b2bbd4a93a75aff182afb95dc",
    "metadata": {},
+   "outputs": [],
    "source": [
     "if BUCKET:\n",
     "    from strands_robots import Robot as R2\n",
+    "\n",
     "    tmp = R2(\"so100\", mesh=False)\n",
     "    tmp.stop_recording(bucket=BUCKET)\n",
     "    tmp.destroy()\n",
     "    print(f\"synced to bucket: hf://buckets/{BUCKET}\")\n",
     "else:\n",
     "    print(\"BUCKET not set - skipping sync. Local path works for training below.\")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "7623eae2785240b9bd12b16a66d81610",
    "metadata": {},
    "source": [
     "## 4. Stream the dataset back\n",
@@ -157,7 +159,10 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "7cdc8c89c7104fffa095e18ddfef8986",
    "metadata": {},
+   "outputs": [],
    "source": [
     "sim = Robot(\"so100\", mesh=False)\n",
     "\n",
@@ -174,17 +179,18 @@
     "    if n == 0:\n",
     "        img = frame.get(\"observation.images.front\")\n",
     "        state = frame.get(\"observation.state\")\n",
-    "        print(f\"frame 0 - image: {tuple(img.shape) if img is not None else None}, state: {tuple(state.shape) if state is not None else None}\")\n",
+    "        print(\n",
+    "            f\"frame 0 - image: {tuple(img.shape) if img is not None else None}, state: {tuple(state.shape) if state is not None else None}\"\n",
+    "        )\n",
     "    if n >= 4:\n",
     "        break\n",
-    "print(f\"streamed {n+1} frames - camera decoded on the fly.\")\n",
+    "print(f\"streamed {n + 1} frames - camera decoded on the fly.\")\n",
     "sim.destroy()"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "b118ea5561624da68c537baed56e602f",
    "metadata": {},
    "source": [
     "## 5. Train a policy on the dataset\n",
@@ -197,14 +203,17 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "938c804e27f84196a10c8828c723f798",
    "metadata": {},
+   "outputs": [],
    "source": [
     "trainer = create_trainer(\"lerobot_local\", device=\"cpu\")\n",
     "spec = TrainSpec(\n",
     "    dataset_root=ROOT,\n",
-    "    base_model=\"\",       # ACT from scratch\n",
+    "    base_model=\"\",  # ACT from scratch\n",
     "    output_dir=OUT,\n",
-    "    steps=2,            # raise to 500+ on a GPU for a real checkpoint\n",
+    "    steps=2,  # raise to 500+ on a GPU for a real checkpoint\n",
     "    save_freq=2,\n",
     "    global_batch_size=2,\n",
     "    extra={\"policy_type\": \"act\", \"num_workers\": 0},\n",
@@ -216,12 +225,11 @@
     "result = trainer.train(spec)\n",
     "print(f\"train status: {result.status}\")\n",
     "print(f\"checkpoint: {result.checkpoint_dir}\")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "504fb2a444614c0babb325280ed9130a",
    "metadata": {},
    "source": [
     "## 6. Load the trained checkpoint\n",
@@ -232,17 +240,19 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "59bbdb311c014d738909a11f9e486628",
    "metadata": {},
+   "outputs": [],
    "source": [
     "policy = create_policy(result.checkpoint_dir)\n",
     "print(f\"loaded: {type(policy).__name__}\")\n",
     "print(\"record -> stream -> train -> load: the data loop closes.\")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "b43b363d81ae4b689946ece5c682cd59",
    "metadata": {},
    "source": [
     "## Where to go from here\n",
@@ -254,5 +264,18 @@
     "- See [examples/06_agent_collect_and_stream.py](https://github.com/strands-labs/robots/blob/main/examples/06_agent_collect_and_stream.py) for the agent-driven version."
    ]
   }
- ]
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/strands_robots/tools/run_policy.py
+++ b/strands_robots/tools/run_policy.py
@@ -48,7 +48,7 @@ Design notes (the contract this tool pins):
   tests where the goal is just to exercise the policy.
 
 See ``strands-labs/robots#708`` for the full root-cause analysis and the
-e2e_agent_test.py fix history (HB#352 -> #716 -> this tool).
+end-to-end agent-test fix history (HB#352 -> #716 -> this tool).
 """
 
 from __future__ import annotations

--- a/tests/test_docstrings_no_dangling_doc_refs.py
+++ b/tests/test_docstrings_no_dangling_doc_refs.py
@@ -11,9 +11,10 @@ Three dangling-reference classes are pinned here:
    distribution - every such pointer is a dead end for a reader.
 2. ``~L<line>`` self-references, which silently drift out of date as soon as
    the surrounding file changes.
-3. Citations of a test file by name (``test_foo.py``). The published wheel
-   ships no test tree, so the pointer is a dead end for a package reader, and
-   it rots the moment that test is renamed.
+3. Citations of a test file by name, under either pytest naming convention -
+   the ``test_foo.py`` prefix and the ``foo_test.py`` suffix. The published
+   wheel ships no test tree, so the pointer is a dead end for a package
+   reader, and it rots the moment that test is renamed.
 
 All three fail loudly here so they cannot creep back into the package.
 """
@@ -61,12 +62,14 @@ def test_no_rotting_line_number_self_references() -> None:
     )
 
 
-# A shipped-source citation of a test file (``test_foo.py``) is a third
-# dangling-reference class: the published wheel/sdist ships no test tree, so
-# the pointer is a dead end for a package reader, and it silently rots the
-# moment that test is renamed. The invariant a test pins belongs described
-# inline, next to the code that upholds it - never behind a test filename.
-_TEST_FILE_REF = re.compile(r"\btest_[A-Za-z0-9_]+\.py\b")
+# A shipped-source citation of a test file is a third dangling-reference
+# class: the published wheel/sdist ships no test tree, so the pointer is a
+# dead end for a package reader, and it silently rots the moment that test is
+# renamed. The invariant a test pins belongs described inline, next to the
+# code that upholds it - never behind a test filename. Both pytest naming
+# conventions are dead ends and are matched: the ``test_foo.py`` prefix and
+# the ``foo_test.py`` suffix (e.g. an end-to-end ``*_agent_test.py`` harness).
+_TEST_FILE_REF = re.compile(r"\b(?:test_[A-Za-z0-9_]+|[A-Za-z0-9_]+_test)\.py\b")
 
 
 def test_no_reference_to_test_files_by_name() -> None:
@@ -81,3 +84,18 @@ def test_no_reference_to_test_files_by_name() -> None:
         "end that also rots when the test is renamed. Describe the invariant "
         "inline next to the code instead of citing a test filename."
     )
+
+
+def test_test_file_ref_matches_both_pytest_naming_conventions() -> None:
+    """Pin that the guard catches both pytest test-file naming conventions.
+
+    The package scan above passes trivially once the tree is clean, so it would
+    not notice a narrowing of the pattern back to prefix-only. This pins the
+    contract directly: a ``test_foo.py`` prefix and a ``foo_test.py`` suffix are
+    both dead-end citations and must match, while an ordinary sibling module
+    (``factory.py``) must not.
+    """
+    assert _TEST_FILE_REF.findall("see test_run_policy.py for the pin") == ["test_run_policy.py"]
+    assert _TEST_FILE_REF.findall("the e2e_agent_test.py fix history") == ["e2e_agent_test.py"]
+    assert _TEST_FILE_REF.findall("the smolvla_test.py harness") == ["smolvla_test.py"]
+    assert _TEST_FILE_REF.findall("delegates to factory.py at import") == []


### PR DESCRIPTION
## Summary

The shipped-source dead-end-citation guard (`tests/test_docstrings_no_dangling_doc_refs.py::test_no_reference_to_test_files_by_name`) pins that published `strands_robots` source never cites a test file by name: the wheel/sdist ships no test tree, so any such pointer is a dead end for a package reader and rots the moment the test is renamed.

It matched only the pytest **prefix** convention (`test_foo.py`) via `\btest_[A-Za-z0-9_]+\.py\b`. The **suffix** convention (`foo_test.py`) slipped through, and one such dead end was live in shipped source: `strands_robots/tools/run_policy.py`'s module docstring cited `e2e_agent_test.py` (an end-to-end agent-test harness that is not in the tree).

## Change

- Widen `_TEST_FILE_REF` to `\b(?:test_[A-Za-z0-9_]+|[A-Za-z0-9_]+_test)\.py\b` so both naming conventions are caught, and update the guard docstring/comment to name both.
- Drop the dead-end `e2e_agent_test.py` filename from `run_policy.py`'s module docstring. The meaningful pointers it carried (the `#708` root-cause analysis and the `#716` recorder-side fix) stay as prose.
- Add `test_test_file_ref_matches_both_pytest_naming_conventions`, a regex-contract test pinning that both `test_foo.py` and `foo_test.py` match while an ordinary sibling module (`factory.py`) does not. The package scan passes trivially once the tree is clean, so this contract test is what stops the pattern silently narrowing back to prefix-only.

## Tests

Regression is genuine: with the widened regex the guard **fails on pre-change source** (`{'tools/run_policy.py': ['e2e_agent_test.py']}`) and **passes** after the docstring fix. The new contract test fails on the old prefix-only regex (which does not match `e2e_agent_test.py`) and passes on the new one.

Full-tree scan confirms `run_policy.py` was the sole `*_test.py` offender, so the blast radius is bounded. Local gate green: `ruff check` + `ruff format --check` clean, `mypy strands_robots tests tests_integ` reports no issues, and the affected test set (`tests/tools/test_run_policy.py`, the dead-ref + review-archaeology + module-xref guards) passes.

Docs-guard only, no runtime behavior change.