### PR TITLE
feat(sim): declarative benchmark spec accepts a natural-language instruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,27 @@ rejected actionably) and only applies with a `terrain`: setting
 rather than silently having no effect. It exists on the Newton backend for
 signature parity but is inert there (Newton rejects `terrain` outright).
 
+### Added: `instruction` field on the declarative benchmark spec DSL
+
+`DeclarativeBenchmark` (the YAML/JSON benchmark spec loader) could not express a
+natural-language task command: `instruction` was not an allowed top-level spec
+key, and the class did not override `BenchmarkProtocol.instruction`, so every
+spec-authored benchmark reported `instruction == ""`. Only a hand-written Python
+subclass (e.g. the LIBERO adapter, which reads the BDDL `:language` clause) could
+carry one. The `PolicyRunner` eval loop falls back to `spec.instruction` when the
+caller passes no `instruction=` to `evaluate_benchmark`, so a spec-driven
+benchmark fed a language-conditioned policy (the shipped GR00T `WBCPolicy`,
+OpenVLA, ...) an empty task description -- the #187 off-task failure mode -- and
+`evaluate_benchmark` emitted a spurious empty-instruction warning on every run.
+The spec DSL now accepts an optional `instruction: string` (validated as a string,
+default `""` for backward compatibility) that `DeclarativeBenchmark` surfaces
+through its `instruction` property. The shipped velocity-tracking locomotion
+benchmarks now declare their command as the instruction -- `go2_walk_forward` /
+`g1_walk_forward` / `t1_walk_forward` "Walk forward at 1 m/s.", `go2_strafe_left`
+"Strafe left at 0.5 m/s.", `go2_turn_left` "Turn left in place at 0.5 rad/s." --
+so a language-conditioned locomotion policy receives the command instead of an
+empty string, and the spurious warning no longer fires on a loco eval.
+
 ### Added: `create_world(terrain="rough")` - rough-ground heightfield for locomotion
 
 The floating-base locomotion benchmarks (`go2_walk_forward` / `g1_walk_forward`

--- a/strands_robots/simulation/benchmark_spec.py
+++ b/strands_robots/simulation/benchmark_spec.py
@@ -15,6 +15,8 @@ Spec schema (top-level keys)::
     supported_robots: list[str]           # default [] (any)
     default_robot: string                 # required - registry data_config
     scene: string                         # optional MJCF/URDF path for sim.load_scene()
+    instruction: string                   # optional natural-language task command
+                                          #   for language-conditioned policies (GR00T, ...)
     success:
       all: [<bool predicate_call>, ...]   # all must be true (reward terms rejected)
       any: [<bool predicate_call>, ...]   # at least one must be true
@@ -84,6 +86,7 @@ _ALLOWED_TOP_LEVEL = frozenset(
         "supported_robots",
         "default_robot",
         "scene",
+        "instruction",
         "success",
         "failure",
         "dense_reward",
@@ -208,6 +211,7 @@ class DeclarativeBenchmark(BenchmarkProtocol):
         failure_fn: Callable[[SimEngine], bool],
         reward_terms: list[Callable[[SimEngine], float]],
         scene: str | None = None,
+        instruction: str = "",
     ):
         self._name = name
         self._supported_robots = list(supported_robots)
@@ -217,6 +221,7 @@ class DeclarativeBenchmark(BenchmarkProtocol):
         self._failure_fn = failure_fn
         self._reward_terms = list(reward_terms)
         self._scene = scene
+        self._instruction = instruction
 
     @property
     def name(self) -> str:
@@ -229,6 +234,19 @@ class DeclarativeBenchmark(BenchmarkProtocol):
     @property
     def default_robot(self) -> str:
         return self._default_robot
+
+    @property
+    def instruction(self) -> str:
+        """Natural-language task command declared in the spec (default ``""``).
+
+        Overrides :attr:`BenchmarkProtocol.instruction` so a spec-authored
+        (declarative) benchmark can carry a task description without a Python
+        subclass -- the ``PolicyRunner`` eval loop falls back to this when the
+        caller passes no ``instruction=`` to ``evaluate_benchmark``, so a
+        language-conditioned policy (GR00T, OpenVLA, ...) receives the command
+        instead of an empty string (the #187 off-task failure mode).
+        """
+        return self._instruction
 
     def on_episode_start(self, sim: SimEngine, rng: random.Random) -> None:
         """Load the declared scene (if any) before delegating to the base impl.
@@ -316,6 +334,10 @@ class DeclarativeBenchmark(BenchmarkProtocol):
         if scene is not None and not isinstance(scene, str):
             raise ValueError(f"spec.scene: must be a string path or omitted, got {type(scene).__name__}")
 
+        instruction = spec.get("instruction", "")
+        if not isinstance(instruction, str):
+            raise ValueError(f"spec.instruction: must be a string or omitted, got {type(instruction).__name__}")
+
         success_fn = _compile_bool_group(spec.get("success"), default=False, context="success")
         failure_fn = _compile_bool_group(spec.get("failure"), default=False, context="failure")
         reward_terms = _compile_reward_terms(spec.get("dense_reward"))
@@ -329,6 +351,7 @@ class DeclarativeBenchmark(BenchmarkProtocol):
             failure_fn=failure_fn,
             reward_terms=reward_terms,
             scene=scene,
+            instruction=instruction,
         )
 
 

--- a/strands_robots/simulation/builtin_benchmarks.py
+++ b/strands_robots/simulation/builtin_benchmarks.py
@@ -59,6 +59,7 @@ from strands_robots.simulation.benchmark_spec import DeclarativeBenchmark
 # ``default_robot`` / ``supported_robots`` and the height thresholds.
 _GO2_WALK_FORWARD: dict[str, Any] = {
     "name": "go2_walk_forward",
+    "instruction": "Walk forward at 1 m/s.",
     "default_robot": "unitree_go2",
     "supported_robots": ["unitree_go2"],
     "max_steps": 1000,
@@ -104,6 +105,7 @@ _GO2_WALK_FORWARD: dict[str, Any] = {
 #     regularizers (added for exactly this in the DSL) belong in a humanoid task.
 _G1_WALK_FORWARD: dict[str, Any] = {
     "name": "g1_walk_forward",
+    "instruction": "Walk forward at 1 m/s.",
     "default_robot": "unitree_g1",
     "supported_robots": ["unitree_g1"],
     "max_steps": 1000,
@@ -154,6 +156,7 @@ _G1_WALK_FORWARD: dict[str, Any] = {
 #     those regularizers apply identically.
 _T1_WALK_FORWARD: dict[str, Any] = {
     "name": "t1_walk_forward",
+    "instruction": "Walk forward at 1 m/s.",
     "default_robot": "booster_t1",
     "supported_robots": ["booster_t1"],
     "max_steps": 1000,
@@ -201,6 +204,7 @@ _T1_WALK_FORWARD: dict[str, Any] = {
 #     zero - plus the 0.32 m base-height and flat-orientation regularizers.
 _GO2_STRAFE_LEFT: dict[str, Any] = {
     "name": "go2_strafe_left",
+    "instruction": "Strafe left at 0.5 m/s.",
     "default_robot": "unitree_go2",
     "supported_robots": ["unitree_go2"],
     "max_steps": 1000,
@@ -252,6 +256,7 @@ _GO2_STRAFE_LEFT: dict[str, Any] = {
 #     plus the 0.32 m base-height and flat-orientation regularizers.
 _GO2_TURN_LEFT: dict[str, Any] = {
     "name": "go2_turn_left",
+    "instruction": "Turn left in place at 0.5 rad/s.",
     "default_robot": "unitree_go2",
     "supported_robots": ["unitree_go2"],
     "max_steps": 1000,

--- a/tests/simulation/test_benchmark_dsl.py
+++ b/tests/simulation/test_benchmark_dsl.py
@@ -100,6 +100,40 @@ class TestFromDictValidation:
         bench = DeclarativeBenchmark.from_dict({"name": "x", "default_robot": "anything", "supported_robots": []})
         assert bench.default_robot == "anything"
 
+    def test_accepts_instruction(self):
+        """A spec may declare a natural-language ``instruction`` and it is
+        surfaced on the compiled benchmark. Before this was supported the key
+        was rejected as an unknown top-level key, so a spec-authored benchmark
+        could not carry a task command for a language-conditioned policy."""
+        bench = DeclarativeBenchmark.from_dict(
+            {
+                "name": "x",
+                "default_robot": "so100",
+                "supported_robots": ["so100"],
+                "instruction": "walk forward at 1 m/s",
+            }
+        )
+        assert bench.instruction == "walk forward at 1 m/s"
+
+    def test_instruction_defaults_to_empty(self):
+        """A spec that omits ``instruction`` compiles to the empty-string
+        default (backward compatible with every pre-existing spec)."""
+        bench = DeclarativeBenchmark.from_dict({"name": "x", "default_robot": "so100", "supported_robots": ["so100"]})
+        assert bench.instruction == ""
+
+    def test_rejects_non_string_instruction(self):
+        """A non-string ``instruction`` is a clear error, not a silent coerce."""
+        with pytest.raises(ValueError) as exc:
+            DeclarativeBenchmark.from_dict(
+                {
+                    "name": "x",
+                    "default_robot": "so100",
+                    "supported_robots": ["so100"],
+                    "instruction": 123,
+                }
+            )
+        assert "instruction" in str(exc.value)
+
     def test_rejects_non_positive_max_steps(self):
         for bad in (-1, 0, "300", True):
             with pytest.raises(ValueError):

--- a/tests/simulation/test_builtin_benchmarks.py
+++ b/tests/simulation/test_builtin_benchmarks.py
@@ -645,3 +645,26 @@ def test_builtin_spec_is_structurally_complete(bench_name: str):
     assert _clause_predicates(spec, "success"), f"{bench_name}: no success predicates"
     assert _clause_predicates(spec, "failure"), f"{bench_name}: no failure predicates"
     assert spec.get("dense_reward"), f"{bench_name}: no dense_reward terms"
+
+
+@pytest.mark.parametrize("bench_name", sorted(builtin_benchmark_specs()))
+def test_builtin_spec_declares_language_instruction(bench_name: str):
+    """Every shipped velocity-tracking locomotion benchmark declares a
+    natural-language ``instruction`` describing its command, and it compiles
+    through to the benchmark's ``instruction`` property.
+
+    A locomotion benchmark's command IS its task ("walk forward", "strafe
+    left", "turn left"), so the spec carries it as the instruction. Without it
+    a language-conditioned policy (the shipped GR00T ``WBCPolicy``) evaluated on
+    the benchmark receives an empty string - the #187 off-task failure mode -
+    and ``evaluate_benchmark`` emits a spurious empty-instruction warning on
+    every eval. Before ``instruction`` was a spec key these all defaulted to
+    ``""``."""
+    spec = builtin_benchmark_specs()[bench_name]
+    instruction = spec.get("instruction")
+    assert isinstance(instruction, str) and instruction.strip(), (
+        f"{bench_name}: must declare a non-empty natural-language instruction; got {instruction!r}"
+    )
+    # The declared instruction compiles through to the benchmark instance.
+    bench = DeclarativeBenchmark.from_dict(dict(spec))
+    assert bench.instruction == instruction


### PR DESCRIPTION
## Problem

`DeclarativeBenchmark` (the YAML/JSON benchmark spec loader, `strands_robots.simulation.benchmark_spec`) could not express a natural-language task command:

- `instruction` was not in `_ALLOWED_TOP_LEVEL`, so a spec declaring it was **rejected** (`Unknown top-level keys: ['instruction']`).
- The class did not override `BenchmarkProtocol.instruction`, so every spec-authored benchmark reported `instruction == ""`.

Only a hand-written Python subclass (e.g. the LIBERO adapter, which reads the BDDL `:language` clause) could carry one. But `PolicyRunner._evaluate_with_spec` **falls back to `spec.instruction`** when the caller passes no `instruction=` to `evaluate_benchmark` (the #187 fix). So every spec-driven benchmark:

1. fed a language-conditioned policy (the repo's shipped GR00T `WBCPolicy`, OpenVLA, ...) an **empty task description** — the exact #187 off-task failure mode the fallback exists to prevent; and
2. emitted a spurious `evaluate_benchmark: instruction is empty ... Language-conditioned policies will receive an empty string` **warning on every run** of the freshly-shipped velocity-tracking locomotion benchmarks (`go2_walk_forward` / `g1_walk_forward` / `t1_walk_forward` / `go2_strafe_left` / `go2_turn_left`), whose command *is* their task.

A locomotion velocity-tracking benchmark's command ("walk forward", "strafe left", "turn left") is semantically its instruction, yet the spec DSL had no way to say so.

## Change

- Add an optional `instruction: string` top-level spec key (validated as a string; default `""`, backward compatible with every existing spec) that `DeclarativeBenchmark` surfaces through an `instruction` property overriding `BenchmarkProtocol.instruction`.
- Declare the shipped locomotion benchmarks' commands as their instruction: `go2/g1/t1_walk_forward` = `"Walk forward at 1 m/s."`, `go2_strafe_left` = `"Strafe left at 0.5 m/s."`, `go2_turn_left` = `"Turn left in place at 0.5 rad/s."`.

A language-conditioned locomotion policy now receives the command instead of `""`, and the spurious empty-instruction warning no longer fires on a loco eval. Purely additive (106 insertions, 0 deletions).

## Tests (fail before, pass after)

- `tests/simulation/test_benchmark_dsl.py`: `test_accepts_instruction` (spec key accepted + surfaced — **failed before** with `Unknown top-level keys: ['instruction']`), `test_instruction_defaults_to_empty` (backward-compat guard), `test_rejects_non_string_instruction`.
- `tests/simulation/test_builtin_benchmarks.py::test_builtin_spec_declares_language_instruction` (parametrized over all 5 shipped specs — **failed before** with `got None`; asserts each declares a non-empty instruction that compiles through to the benchmark).

Verified with the source reverted: 6 tests fail before, all pass after. Full benchmark / policy-runner / predicate / describe-discovery suites: **313 passed**. Empirically on a real MuJoCo Unitree Go2 `evaluate_benchmark("go2_walk_forward")`, the previously-emitted empty-instruction warning is now silenced. `ruff check` / `ruff format` / `mypy` clean.