### PR TITLE
test(mesh): cover IoT transport fail-soft when awsiotsdk is missing

### DIFF
--- a/tests/mesh/test_transport.py
+++ b/tests/mesh/test_transport.py
@@ -217,6 +217,30 @@ class TestIotMqttTransportConfig:
         t = IotMqttTransport()
         assert t.connect() is False
 
+    def test_missing_awsiotsdk_returns_false(self, monkeypatch, tmp_path, caplog):
+        """connect() fail-softs to False when awsiotsdk is not installed.
+
+        The IoT transport is an optional dependency (``strands-robots[mesh-iot]``);
+        with the SDK absent it must behave as a no-op - returning False and
+        logging an install hint - just like ZenohTransport when Zenoh is
+        missing, never crashing the host. Config is otherwise valid here so the
+        SDK-presence check is the only branch that can fail.
+        """
+        import logging
+        import sys
+
+        monkeypatch.setenv("STRANDS_IOT_THING_NAME", "test-thing")
+        monkeypatch.setenv("STRANDS_IOT_ENDPOINT", "x.iot.us-west-2.amazonaws.com")
+        monkeypatch.setenv("STRANDS_IOT_CERT_DIR", str(tmp_path))
+        # A None entry in sys.modules makes ``from awsiot import ...`` raise
+        # ImportError, simulating the SDK not being installed even when it is.
+        monkeypatch.setitem(sys.modules, "awsiot", None)
+
+        t = IotMqttTransport()
+        with caplog.at_level(logging.ERROR, logger="strands_robots.mesh.transport.iot_transport"):
+            assert t.connect() is False
+        assert any("awsiotsdk not installed" in r.message for r in caplog.records)
+
     def test_thing_name_property(self):
         t = IotMqttTransport(
             thing_name="so100-spike-01",


### PR DESCRIPTION
## Problem

`IotMqttTransport.connect()` documents a fail-soft contract in its module docstring: when the optional `awsiotsdk` dependency is not installed, `connect()` must return `False` and log an install hint, behaving as a no-op just like `ZenohTransport` does without Zenoh, never crashing the host.

That first branch of `connect()` (the `from awsiot import mqtt5_client_builder` / `except ImportError` guard) was the only returns-`False` path in `TestIotMqttTransportConfig` with no test. The reason is subtle: `awsiotsdk` is installed in the test environment, so the import always succeeds and the guard is never exercised by the existing config-validation tests (missing thing name / endpoint / cert files), which all reach the checks *after* the import.

## Change

Add `test_missing_awsiotsdk_returns_false` to `TestIotMqttTransportConfig`. It forces the `ImportError` by inserting a `None` entry for `awsiot` into `sys.modules` (the standard CPython way to make an import fail on demand), with config otherwise valid so the SDK-presence check is the only branch that can fail. It asserts `connect()` returns `False` and that the install hint is logged.

## Verification

- Regression guard confirmed: removing the `try/except ImportError` guard so the error propagates makes the test fail with a propagating `ModuleNotFoundError`; restoring it makes the test pass.
- `ruff check` / `ruff format --check` clean; `mypy strands_robots tests tests_integ` reports no issues.
- `tests/mesh/test_transport.py`: 81 passed.
- The previously-uncovered import-guard lines in `connect()` are now covered.

Test-only change; no library behavior is modified.