### PR TITLE
feat(sim): advertise create_world/destroy on the base describe() contract

### DIFF
--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -2179,6 +2179,24 @@ class SimEngine(ABC):
                     "run_policy reports unresolved keys"
                 ),
                 "render": "(camera_name='default', width=None, height=None) -> dict",
+                "create_world": (
+                    "(timestep=None, gravity=None, ground_plane=True, terrain=None, "
+                    "difficulty=1.0) -> dict  # create a fresh simulation world - the "
+                    "world-lifecycle entry point that precedes add_robot / add_object. "
+                    "gravity is [gx, gy, gz]; ground_plane lays a floor; terrain lays a "
+                    "deterministic locomotion heightfield instead of the flat plane "
+                    "('rough' value-noise bumps, 'stairs' step plateaus rising +x, "
+                    "'pyramid' concentric steps rising to the centre, 'slope' a "
+                    "constant-grade ramp); difficulty (finite, > 0; 1.0 = full height) "
+                    "scales the terrain peak elevation for a curriculum without changing "
+                    "the terrain kind. Backends without heightfield support reject a "
+                    "non-None terrain rather than ignoring it"
+                ),
+                "destroy": (
+                    "() -> dict  # tear down the world and release all resources "
+                    "(joins any running background policy first); the inverse of "
+                    "create_world, called at session end"
+                ),
                 "reset": "() -> dict  # during recording, flushes the buffered rollout as one episode before resetting",
                 "step": "(n_steps: int = 1) -> dict",
                 "get_state": (

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1835,29 +1835,15 @@ class MuJoCoSimEngine(
             "reads (the observation sibling of robot_action_keys' action side)"
         )
 
-        # Scene / world lifecycle + MJCF editing surface. describe() teaches how
-        # to build a scene (add_robot/add_object/add_camera/load_scene), run a
-        # policy, and read/checkpoint the result, but previously gave no way to
-        # discover the world lifecycle itself -- create_world (the fresh-world
-        # entry point that precedes add_robot) and destroy (release resources at
-        # session end, which the tool-spec guidance explicitly asks callers to
-        # do) -- or the MJCF-editing family: patch or wholesale-replace the live
-        # MJCF and serialize the scene back to XML. All five are first-class
-        # actions in the tool spec + action dispatcher; listing them completes
-        # the discovery surface with the world-lifecycle and MJCF-authoring
-        # operations alongside the build / act / read surfaces. (The URDF/model
-        # registry trio -- register_urdf / list_urdfs / remove_robot -- is
-        # advertised with the robot-registry family earlier in describe().)
-        base["methods"]["create_world"] = (
-            "(timestep=None, gravity=None, ground_plane=True, terrain=None, difficulty=1.0) -> dict  # create "
-            "a fresh empty simulation world; the lifecycle entry point that precedes "
-            "add_robot/add_object (gravity is [gx,gy,gz], ground_plane adds a floor, "
-            "terrain='rough'|'stairs'|'pyramid'|'slope' makes it a locomotion heightfield)"
-        )
-        base["methods"]["destroy"] = (
-            "() -> dict  # tear down the world and release all resources (joins any "
-            "running background policy first); call at session end. The inverse of create_world"
-        )
+        # MJCF-editing surface. create_world / destroy (the world lifecycle) are
+        # advertised on the base SimEngine.describe() contract; here we add the
+        # MuJoCo-specific MJCF-editing family: patch or wholesale-replace the
+        # live MjSpec and serialize the scene back to XML. All three are
+        # first-class actions in the tool spec + action dispatcher, completing
+        # the discovery surface with MJCF-authoring operations alongside the
+        # build / act / read surfaces. (The URDF/model registry trio --
+        # register_urdf / list_urdfs / remove_robot -- is advertised with the
+        # robot-registry family earlier in describe().)
         base["methods"]["patch_scene_mjcf"] = (
             "(ops: list[dict]) -> dict  # apply structured edits to the live "
             "MjSpec atomically then recompile once (rolled back if any op fails). "

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -1764,6 +1764,16 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
                     "(joint_pos_std=0.0, joint_vel_std=0.0, camera_jitter_px=0.0, seed=None) -> dict "
                     "(additive Gaussian sensor noise on observations + rendered frames)"
                 ),
+                "create_world": (
+                    "(timestep=None, gravity=None, ground_plane=True, terrain=None, "
+                    "difficulty=1.0) -> dict  (create a fresh simulation world - the "
+                    "world-lifecycle entry point that precedes add_robot / add_object; "
+                    "gravity is [gx, gy, gz], ground_plane lays a floor)"
+                ),
+                "destroy": (
+                    "() -> dict  (tear down the world and release all resources, joining "
+                    "any running background policy first; the inverse of create_world)"
+                ),
                 "reset": "() -> dict (restore baseline joint configuration)",
                 "step": "(n_steps: int = 1) -> dict",
                 "start_recording": (

--- a/tests/simulation/test_sim_engine_describe_discovery.py
+++ b/tests/simulation/test_sim_engine_describe_discovery.py
@@ -298,6 +298,32 @@ class TestDescribeABC:
         assert "scene_path" in methods["load_scene"]
         assert "contact" in methods["get_contacts"].lower()
 
+    def test_describe_lists_world_lifecycle_entry_points(self):
+        """describe() advertises create_world and destroy on the BASE contract.
+
+        create_world (the fresh-world entry point that precedes add_robot /
+        add_object) and destroy (its teardown inverse) are abstract methods
+        every backend must implement, and their lifecycle siblings reset / step
+        / get_state were already advertised. But the base discovery surface
+        listed neither create_world nor destroy -- so a caller enumerating
+        ``describe()["methods"]`` on any backend that does not separately re-add
+        them (the Newton engine builds its surface from scratch and omitted them
+        too) could not learn how to CREATE the world it must populate, nor how
+        to tear it down, without guessing. They belong on the base contract
+        beside reset / step / get_state as the world-lifecycle entry points.
+        """
+        engine = _make_minimal_engine()
+        methods = engine.describe()["methods"]
+        for name in ("create_world", "destroy"):
+            assert name in methods, f"describe() omits world-lifecycle method {name!r}"
+        # The advertised create_world signature names the real knobs (the flat
+        # floor toggle and the locomotion-terrain curriculum) so a caller can
+        # spawn a robot on non-flat ground without reading the source.
+        blurb = methods["create_world"]
+        assert "ground_plane" in blurb
+        assert "terrain" in blurb
+        assert "difficulty" in blurb
+
 
 @pytest.mark.skipif(
     not pytest.importorskip("mujoco", reason="MuJoCo not installed"),


### PR DESCRIPTION
## Problem

`SimEngine.describe()` is the single-call discovery surface an agent reads to learn an engine's contract without guessing method names. It already advertises the world-lifecycle siblings `reset` / `step` / `get_state`, but omitted the two most fundamental abstract methods every backend must implement: `create_world` (the fresh-world entry point that precedes `add_robot` / `add_object`) and its teardown inverse `destroy`.

Both concrete backends papered over the gap in different ways, which is exactly why it went unnoticed:

- The **MuJoCo** override re-added `create_world` / `destroy` locally.
- The **Newton** engine builds its discovery surface from scratch (it does not call `super().describe()`) and omitted both entirely.

So an agent driving a Newton sim, or reading the base contract through any engine that does not separately re-add them, could enumerate `describe()["methods"]` and still not learn how to CREATE the world it must populate, nor how to tear it down.

## Change

Put `create_world` and `destroy` on the base `SimEngine.describe()` methods dict, beside their lifecycle siblings `reset` / `step` / `get_state`, so every backend advertises them from one `describe()` call. The `create_world` blurb names its real knobs, including the locomotion-terrain curriculum (`terrain='rough'|'stairs'|'pyramid'|'slope'`, `difficulty` scaling), so a caller can spawn a robot on non-flat ground without reading the source.

To keep code the single source of truth, the now-redundant duplicates are dropped from the MuJoCo override (base provides them; the override keeps only the MuJoCo-specific MJCF-editing family), and both are added to Newton's from-scratch surface.

Live MuJoCo `describe()` after the change:

```
create_world: (timestep=None, gravity=None, ground_plane=True, terrain=None, difficulty=1.0) -> dict  # create a fresh simulation world - the world-lifecycle entry point that precedes add_robot / add_object. gravity is [gx, gy, gz]; ground_plane lays a floor; terrain lays a deterministic locomotion heightfield instead of the flat plane ('rough' value-noise bumps, 'stairs' step plateaus rising +x, 'pyramid' concentric steps rising to the centre, 'slope' a constant-grade ramp); difficulty (finite, > 0; 1.0 = full height) scales the terrain peak elevation for a curriculum without changing the terrain kind. Backends without heightfield support reject a non-None terrain rather than ignoring it

destroy: () -> dict  # tear down the world and release all resources (joins any running background policy first); the inverse of create_world, called at session end
```

## Tests

`test_describe_lists_world_lifecycle_entry_points` pins `create_world` and `destroy` on the base ABC discovery surface (via the minimal concrete engine) and asserts the `create_world` blurb names `ground_plane` / `terrain` / `difficulty`. It fails pre-fix (`create_world` absent from the base) and passes after. The pre-existing MuJoCo scene-lifecycle test still passes.

Green locally: `ruff check` + `ruff format --check` + `mypy strands_robots tests tests_integ` clean; full `tests/simulation/` suite passes (2327 passed, headless `MUJOCO_GL=egl`).