### PR TITLE
test(rtps): cover get_type resolver + unknown-type error contract

### DIFF
--- a/tests/rtps/test_idl_bundle.py
+++ b/tests/rtps/test_idl_bundle.py
@@ -59,3 +59,42 @@ def test_sensor_msgs_chain_present() -> None:
     ):
         cls = idl.get_type(ros_type)
         assert cls.__idl_typename__ == dds_type_name(ros_type), ros_type
+
+
+# --- get_type resolver contract, decoupled from the optional [ros2] extra ----
+# The lines below exercise get_type's resolution + unknown-type error formatting
+# WITHOUT requiring cyclonedds: the resolver reads the module-level REGISTRY and
+# _HAVE_CYCLONEDDS flag, so monkeypatching a stand-in registry pins the
+# user-facing contract on every CI matrix leg, not only the [ros2] one.
+
+
+def test_get_type_resolves_registered_type(monkeypatch: pytest.MonkeyPatch) -> None:
+    sentinel = object()
+    monkeypatch.setattr(idl, "_HAVE_CYCLONEDDS", True)
+    monkeypatch.setattr(idl, "REGISTRY", {"pkg_msgs/msg/Foo": sentinel})
+    assert idl.get_type("pkg_msgs/msg/Foo") is sentinel
+
+
+def test_get_type_unknown_lists_known_types_sorted(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(idl, "_HAVE_CYCLONEDDS", True)
+    monkeypatch.setattr(
+        idl,
+        "REGISTRY",
+        {"pkg_msgs/msg/Zed": object(), "pkg_msgs/msg/Alpha": object()},
+    )
+    with pytest.raises(KeyError) as excinfo:
+        idl.get_type("pkg_msgs/msg/Missing")
+    message = str(excinfo.value)
+    # Known types are listed sorted so the hint is deterministic, and the
+    # message points at use_ros for out-of-bundle (custom) messages.
+    assert message.index("Alpha") < message.index("Zed")
+    assert "use_ros" in message
+
+
+def test_get_type_unknown_with_empty_registry_reports_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Degenerate but real: backend present, bundle empty -> the hint must say
+    # "(none)" rather than dangle after "Known types: ".
+    monkeypatch.setattr(idl, "_HAVE_CYCLONEDDS", True)
+    monkeypatch.setattr(idl, "REGISTRY", {})
+    with pytest.raises(KeyError, match=r"Known types: \(none\)"):
+        idl.get_type("pkg_msgs/msg/Missing")


### PR DESCRIPTION
## Problem

The RTPS IDL bundle's `get_type()` resolution and unknown-type `KeyError` formatting (`strands_robots/rtps/idl/__init__.py`, lines 181-188) were only exercised under `@pytest.mark.skipif(not idl.have_cyclonedds())`. Because the default CI matrix does not install the `[ros2]` extra, those tests are skipped and the resolver's user-facing contract had **zero coverage** on every non-`[ros2]` leg:

- the registry read path,
- the sorted known-types listing in the error,
- the empty-bundle `"(none)"` hint (never hit even with cyclonedds, since the bundle is populated there).

## Change

`get_type()` reads the module-level `REGISTRY` and `_HAVE_CYCLONEDDS` flag, so a stand-in registry pins the contract without requiring cyclonedds. Adds three behavior tests to `tests/rtps/test_idl_bundle.py`:

- resolves a registered type;
- unknown type raises `KeyError` listing known types **sorted** + the `use_ros` guidance;
- empty bundle reports `"(none)"` rather than a dangling `"Known types: "`.

These assert observable behavior (return value / error text), not internals.

## Coverage

`strands_robots/rtps/idl/__init__.py`: **17% -> 23%** on the no-`[ros2]` CI matrix (lines 181-188 now covered). The remaining uncovered lines are the cyclonedds-gated imports and message dataclasses, which are unreachable without the extra.

## Testing

```
MUJOCO_GL=egl pytest tests/rtps/ tests/tools/test_use_rtps.py tests/test_hardware_rtps_bridge.py
# 70 passed, 3 skipped
```

Green local gate: `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` all clean. Tests-only; no behavior change.