### PR TITLE
feat(sim): advertise create_world(difficulty=...) in the tool_spec + keep the terrain-kind hint in sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: `create_world(difficulty=...)` is discoverable in the sim tool_spec + the terrain-kind hint stays in sync
+
+`create_world` grew a `difficulty` curriculum knob (it scales a terrain
+heightfield's peak elevation so a locomotion curriculum can ramp terrain
+magnitude across resets) alongside `terrain`, but only `terrain` was advertised
+in the agent-facing `tool_spec.json`. The dispatch router validates against the
+method signature, so a caller that already knew the name could pass `difficulty`
+-- but an LLM forms tool calls from the tool_spec schema it is handed, and with
+`difficulty` absent it had no way to discover the knob, leaving the curriculum
+scaling unreachable through the `sim` tool. `difficulty` is now declared in the
+tool_spec beside `terrain` / `ground_plane`. Relatedly, the "difficulty has no
+effect without a terrain" guidance error now derives its terrain-kind list from
+`SUPPORTED_TERRAINS` instead of a hardcoded `'rough'/'stairs'/'pyramid'` literal,
+so it lists every supported kind (the literal had gone stale and omitted the
+newer `'slope'`) and cannot drift out of sync again.
+
 ### Added: yaw locomotion vocabulary - `base_yaw_beyond` predicate + `go2_turn_left` benchmark
 
 The floating-base locomotion DSL could command a yaw-rate (`base_velocity_tracking`

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -89,7 +89,7 @@ from strands_robots.simulation.mujoco.scene_ops import (
 )
 from strands_robots.simulation.mujoco.spec_builder import SpecBuilder, _validate_size
 from strands_robots.simulation.policy_runner import CooperativeStop
-from strands_robots.simulation.terrain import validate_difficulty, validate_terrain
+from strands_robots.simulation.terrain import SUPPORTED_TERRAINS, validate_difficulty, validate_terrain
 from strands_robots.teleop_mixin import TeleopMixin
 
 if TYPE_CHECKING:
@@ -457,8 +457,9 @@ class MuJoCoSimEngine(
                     {
                         "text": (
                             f"difficulty={difficulty!r} has no effect without a terrain "
-                            "(it scales a heightfield's elevation); pass terrain='rough'/'stairs'/"
-                            "'pyramid' as well, or omit difficulty for a flat ground plane."
+                            "(it scales a heightfield's elevation); pass a terrain "
+                            f"({'/'.join(repr(t) for t in sorted(SUPPORTED_TERRAINS))}) as well, "
+                            "or omit difficulty for a flat ground plane."
                         )
                     }
                 ],

--- a/strands_robots/simulation/mujoco/tool_spec.json
+++ b/strands_robots/simulation/mujoco/tool_spec.json
@@ -94,6 +94,10 @@
       "type": "string",
       "description": "create_world: heightfield terrain kind ('rough' = bumps, 'stairs' = step plateaus along +x, 'pyramid' = concentric step plateaus toward the centre, 'slope' = constant-grade incline); omit for a flat ground plane. MuJoCo backend only."
     },
+    "difficulty": {
+      "type": "number",
+      "description": "create_world: terrain curriculum knob - scales the heightfield's peak elevation (1.0 = full height, <1 gentler, >1 harsher) to ramp terrain magnitude across resets without changing the terrain kind. Only meaningful together with 'terrain'; difficulty != 1.0 with no terrain is rejected. MuJoCo backend only."
+    },
     "urdf_path": {
       "type": "string",
       "description": "Path to URDF/MJCF file"

--- a/tests/simulation/mujoco/test_create_world_terrain.py
+++ b/tests/simulation/mujoco/test_create_world_terrain.py
@@ -152,6 +152,21 @@ def test_difficulty_without_terrain_is_rejected_as_a_no_op() -> None:
             sim.destroy()
 
 
+def test_difficulty_without_terrain_error_names_every_supported_kind() -> None:
+    # The actionable "difficulty needs a terrain" error steers the caller to a
+    # real terrain kind; it must list EVERY supported kind (derived from
+    # SUPPORTED_TERRAINS) so a kind added later (e.g. "slope") is never silently
+    # dropped from the guidance and left undiscoverable in the message.
+    sim = MuJoCoSimEngine()
+    try:
+        msg = sim.create_world(difficulty=0.5)["content"][0]["text"]
+        for kind in terrain.SUPPORTED_TERRAINS:
+            assert repr(kind) in msg, f"error omits supported terrain kind {kind!r}: {msg}"
+    finally:
+        if sim._world is not None:
+            sim.destroy()
+
+
 def test_flat_world_default_difficulty_still_succeeds() -> None:
     # The common flat-world path (no terrain, default difficulty) is unaffected.
     sim = MuJoCoSimEngine()

--- a/tests/simulation/mujoco/test_tool_spec.py
+++ b/tests/simulation/mujoco/test_tool_spec.py
@@ -235,6 +235,23 @@ def test_every_tool_spec_action_has_a_public_method_or_documented_alias():
     assert not offenders, "tool_spec actions must resolve to PUBLIC methods:\n  - " + "\n  - ".join(offenders)
 
 
+def test_tool_spec_declares_create_world_curriculum_knobs() -> None:
+    """The LLM-facing tool_spec must advertise create_world's world/terrain knobs.
+
+    The router accepts any create_world signature param at runtime (it validates
+    against the method signature), but an LLM only forms tool calls from the
+    tool_spec schema it is handed. ``terrain`` + its curriculum companion
+    ``difficulty`` (the terrain-elevation curriculum knob) must both be
+    discoverable there, alongside ``ground_plane``, or an agent driving the sim
+    tool cannot spawn a robot on non-flat / curriculum-scaled ground.
+    """
+    spec_path = Path(__file__).resolve().parents[3] / "strands_robots/simulation/mujoco/tool_spec.json"
+    props = json.loads(spec_path.read_text())["properties"]
+    for knob in ("ground_plane", "terrain", "difficulty"):
+        assert knob in props, f"tool_spec.json must advertise create_world's {knob!r} knob"
+    assert props["difficulty"]["type"] == "number"
+
+
 # Schema-load performance contract
 
 


### PR DESCRIPTION
## Problem

`create_world` grew a `difficulty` curriculum knob (it scales a terrain heightfield's peak elevation, so a locomotion curriculum can ramp terrain magnitude across resets without changing the terrain kind) alongside `terrain`. But only `terrain` was declared in the agent-facing `tool_spec.json`, so the two knobs were out of parity on the discovery surface an LLM actually sees.

The dispatch router validates a tool call against the **method signature** (not the tool_spec), so a caller who already knew the name could pass `difficulty` and it worked (`test_router_dispatch_accepts_difficulty_kwarg` covers that). But an LLM forms tool calls from the `tool_spec` schema it is handed — and with `difficulty` absent from `properties`, the curriculum knob was **unreachable through schema-driven discovery**. `describe()` already advertised it (it introspects the signature); the LLM-facing tool schema was the one surface still missing it.

Separately, the actionable *"difficulty has no effect without a terrain"* guidance error hardcoded its terrain-kind list as `'rough'/'stairs'/'pyramid'`, which had gone **stale** — it omitted the `'slope'` kind, so the message steered callers to an incomplete set.

## Change

- Declare `difficulty` (a `number`) in `tool_spec.json`, beside `terrain` / `ground_plane`, with a description explaining it scales the heightfield peak and is only meaningful together with a `terrain`.
- Derive the guidance error's terrain-kind list from `SUPPORTED_TERRAINS` (sorted) instead of a hardcoded literal, so it always lists every supported kind (now includes `'slope'`) and cannot drift out of sync again.

No behavior change to the runtime path — the router already accepted `difficulty`; this makes it **discoverable** and keeps the guidance consistent.

## Tests (fail before, pass after)

- `test_tool_spec_declares_create_world_curriculum_knobs` — asserts `tool_spec.json` advertises `ground_plane` / `terrain` / `difficulty` (fails before: `difficulty` absent). Guards this drift class for the world-lifecycle entry point.
- `test_difficulty_without_terrain_error_names_every_supported_kind` — asserts the guidance error names every `SUPPORTED_TERRAINS` kind (fails before: `'slope'` omitted).

Both verified failing on the pre-change source and passing after. Full `test_tool_spec.py`, `test_create_world_terrain.py`, `test_sim_engine_describe_discovery.py`, and `test_agenttool_contract.py` suites pass; `ruff check` / `ruff format --check` / `mypy` clean on the changed files.