### PR TITLE
fix(sim): unknown-camera error hints the canonical list_cameras action

### DIFF
--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -927,7 +927,13 @@ class MuJoCoSimEngine(
     def _unknown_camera_msg(self, requested: str) -> str:
         """Actionable 'camera not found' message for ``remove_camera`` - lists the
         renderable cameras (like the render/record error paths already do) plus a
-        close-match, so a typo is fixable in-place without a discovery round-trip."""
+        close-match, so a typo is fixable in-place without a discovery round-trip.
+
+        The recovery hint names the canonical ``list_cameras`` action (the name
+        in ``tool_spec.json`` and ``describe()``), not the internal
+        ``list_cameras_info`` method the dispatcher aliases it to - so a blind
+        agent following the hint learns the same action the discovery surface
+        teaches, mirroring the ``list_objects`` hint in ``_unknown_object_msg``."""
         known = self._list_camera_names()
         msg = f"Camera '{requested}' not found."
         if known:
@@ -936,7 +942,7 @@ class MuJoCoSimEngine(
             matches = difflib.get_close_matches(requested, known, n=3, cutoff=0.4)
             if matches:
                 msg += " Did you mean: " + ", ".join(matches) + "?"
-            msg += f" Available: {known}. Use action='list_cameras_info' to see all."
+            msg += f" Available: {known}. Use action='list_cameras' to see all."
         return msg
 
     def _unknown_robot_msg(self, requested: str) -> str:

--- a/tests/simulation/mujoco/test_missing_entity_error_messages.py
+++ b/tests/simulation/mujoco/test_missing_entity_error_messages.py
@@ -10,7 +10,7 @@ round-trip on every typo. The camera *render*/*record* paths already listed
 close-match; these tests pin that the same actionable shape now covers the
 remove/move-by-name paths: the message names the entity, offers a close match,
 lists the available names, and points at the discovery action
-(``list_objects`` / ``list_cameras_info`` / ``list_robots``).
+(``list_objects`` / ``list_cameras`` / ``list_robots``).
 
 The messages keep the ``"<Kind> 'X' not found."`` prefix so the consistent
 error shape (T15 in ``test_agenttool_contract``) is preserved. GL-free
@@ -59,7 +59,11 @@ def test_remove_camera_unknown_lists_available_and_suggests(sim):
     assert "Camera 'frnt_cam' not found" in text
     assert "Did you mean: front_cam" in text
     assert "front_cam" in text  # names the available camera
-    assert "list_cameras_info" in text
+    # Recovery hint must name the canonical action the discovery surface
+    # teaches (tool_spec.json + describe() both list 'list_cameras'), not the
+    # internal 'list_cameras_info' method the dispatcher aliases it to.
+    assert "action='list_cameras'" in text
+    assert "list_cameras_info" not in text
 
 
 def test_missing_object_in_empty_scene_points_to_add_object():


### PR DESCRIPTION
## Problem

When `remove_camera` is called with an unknown camera name, the actionable "camera not found" recovery message ends with:

```
... Available: [...]. Use action='list_cameras_info' to see all.
```

But `list_cameras_info` is the *internal method name* the dispatcher aliases the canonical action `list_cameras` to (`_ACTION_ALIASES = {"list_cameras": "list_cameras_info", ...}`). Every other part of the discovery surface teaches the canonical name:

- `tool_spec.json` enumerates `list_cameras` (not `list_cameras_info`).
- `describe()["methods"]` advertises `list_cameras`.
- The sibling `_unknown_object_msg` correctly hints `Use action='list_objects' to see all.`

Because `_dispatch_action` resolves any method via `getattr`, both `list_cameras` and `list_cameras_info` happen to work — so an agent following the error hint learns a *second, non-canonical* action name for the same capability, contradicting the surface it discovers everywhere else. That is exactly the "one name per concept" ambiguity the codebase avoids elsewhere.

## Change

Point the `_unknown_camera_msg` recovery hint at the canonical `list_cameras` action so error-recovery and discovery agree on a single name, matching the `list_objects` hint in the sibling `_unknown_object_msg`. Docstring updated to record why the canonical name is used.

## Tests

Strengthened the existing `test_remove_camera_unknown_lists_available_and_suggests` regression:

```python
assert "action='list_cameras'" in text
assert "list_cameras_info" not in text
```

The `not in` / canonical-action assertions fail on pre-fix code (which emitted `action='list_cameras_info'`) and pass after. Verified locally by reverting the one-line code change and re-running the test (fails), then restoring (passes).

Green gate (CI scope): `ruff check`, `ruff format --check`, and `mypy strands_robots tests tests_integ` ("Success: no issues found in 778 source files") all clean. `MUJOCO_GL=egl pytest` over the affected suites (`test_missing_entity_error_messages`, `test_list_cameras_discovery`, `test_sim_engine_describe_discovery`, `test_agenttool_contract`) — 114 passed.

String-only discovery-surface fix; no simulation, rendering, or recording behavior changes.