### PR TITLE
fix(sim): Isaac create_world honours the base terrain/difficulty contract instead of raising TypeError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1739,6 +1739,25 @@ independence, live tracking, fixed-base degradation, and a full
 (fails before, passes after).
 
 
+### Fixed: Isaac backend `create_world(terrain=...)` honours the base contract instead of raising `TypeError`
+
+`create_world` grew `terrain` / `difficulty` parameters (the heightfield
+terrain-curriculum knob), and the base `SimEngine.create_world` abstractmethod
+documents that a backend without heightfield support must reject a non-None
+`terrain` with an actionable error rather than silently ignoring it. The MuJoCo
+backend implements terrain and the Newton backend rejects it with exactly such
+an error, but the Isaac backend's `create_world` override kept the older,
+narrower signature (no `terrain` / `difficulty`), so `create_world(terrain=...)`
+on an Isaac sim raised a bare `TypeError: unexpected keyword argument 'terrain'`
+instead of the contract's structured error -- and the drift slipped past mypy
+because the extra base parameters carry defaults. The Isaac override now accepts
+`terrain` / `difficulty` for signature parity and rejects a non-None `terrain`
+with an actionable "heightfield terrain is currently MuJoCo-only; use
+`create_simulation(backend='mujoco')`" error *before* booting Isaac Sim (so the
+rejection holds on any host, with or without an Omniverse install); `difficulty`
+is accepted but inert, mirroring the Newton backend.
+
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -634,6 +634,8 @@ class IsaacSimulation(SimEngine):
         timestep: float | None = None,
         gravity: list[float] | None = None,
         ground_plane: bool = True,
+        terrain: str | None = None,
+        difficulty: float = 1.0,
     ) -> dict[str, Any]:
         """Create a new simulation world in Isaac Sim.
 
@@ -648,12 +650,38 @@ class IsaacSimulation(SimEngine):
             Override gravity vector from config. [gx, gy, gz].
         ground_plane : bool
             Whether to add a ground plane. Default True.
+        terrain : str, optional
+            Heightfield terrain kind (e.g. ``"rough"``/``"stairs"``/
+            ``"pyramid"``/``"slope"``). The Isaac backend has no heightfield
+            ground yet, so a non-None value is rejected with an actionable
+            error rather than raising ``TypeError`` or being silently ignored
+            (honouring the
+            :class:`~strands_robots.simulation.base.SimEngine` ``create_world``
+            contract). Use ``create_simulation(backend="mujoco")`` for terrain.
+        difficulty : float
+            Terrain curriculum elevation scale (only meaningful together with
+            ``terrain``). Accepted for signature parity with the base contract
+            but inert here since the Isaac backend rejects ``terrain`` outright.
 
         Returns
         -------
         dict
             Status dict with world info.
         """
+        if terrain is not None:
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            f"terrain={terrain!r} is not supported on the Isaac backend yet "
+                            "(heightfield terrain, e.g. 'rough'/'stairs'/'pyramid'/'slope', is "
+                            "currently MuJoCo-only); use create_simulation(backend='mujoco') for "
+                            "terrain, or omit terrain for a flat ground plane."
+                        )
+                    }
+                ],
+            }
         with self._lock:
             if self._world_created:
                 return {

--- a/tests/simulation/isaac/test_isaac_backend.py
+++ b/tests/simulation/isaac/test_isaac_backend.py
@@ -263,6 +263,46 @@ class TestIsaacSimulationConstruction:
         assert result["status"] == "error"
         assert result["content"] and "text" in result["content"][0]
 
+    def test_create_world_signature_parity_with_base(self):
+        # The base SimEngine.create_world abstractmethod declares
+        # ``terrain`` / ``difficulty`` (the terrain-curriculum contract). Every
+        # backend override must accept them so a caller / the tool router can
+        # pass them uniformly; a narrower override raises a bare TypeError on a
+        # documented parameter instead of the contract's actionable error.
+        import inspect
+
+        from strands_robots.simulation.base import SimEngine
+        from strands_robots.simulation.isaac.simulation import IsaacSimulation
+
+        base = set(inspect.signature(SimEngine.create_world).parameters)
+        override = set(inspect.signature(IsaacSimulation.create_world).parameters)
+        assert {"terrain", "difficulty"} <= override, f"Isaac create_world drops base params: missing {base - override}"
+
+    def test_create_world_terrain_rejected_with_actionable_error(self):
+        # Base contract (SimEngine.create_world docstring): a backend without
+        # heightfield support rejects a non-None ``terrain`` with an actionable
+        # error - NOT a bare TypeError, NOT a silent ignore. The rejection is
+        # exercised before Isaac Sim boots, so it holds on any host.
+        from strands_robots.simulation.isaac.simulation import IsaacSimulation
+
+        sim = IsaacSimulation(num_envs=1, headless=True)
+        result = sim.create_world(terrain="rough")
+        assert result["status"] == "error"
+        text = result["content"][0]["text"].lower()
+        assert "terrain" in text and "mujoco" in text, text
+
+    def test_create_world_difficulty_accepted_for_signature_parity(self):
+        # ``difficulty`` is accepted (signature parity with the base contract);
+        # passing it must not raise TypeError. It is inert on Isaac (which
+        # rejects terrain outright), so with no terrain the call still degrades
+        # to the structured Isaac-Sim-absent error rather than crashing.
+        from strands_robots.simulation.isaac.simulation import IsaacSimulation
+
+        sim = IsaacSimulation(num_envs=1, headless=True)
+        result = sim.create_world(difficulty=2.0)
+        assert result["status"] == "error"
+        assert "terrain" not in result["content"][0]["text"].lower()
+
 
 class TestProceduralBuilders:
     def test_list_procedural_robots(self):


### PR DESCRIPTION
## Problem

`SimEngine.create_world` is an `@abstractmethod` whose signature and docstring define the terrain-curriculum contract:

```python
def create_world(self, timestep=None, gravity=None, ground_plane=True,
                 terrain: str | None = None, difficulty: float = 1.0) -> dict: ...
```

> Backends without heightfield support reject a non-None `terrain` with an actionable error rather than silently ignoring it.

The MuJoCo backend implements terrain; the **Newton** backend honours the full signature and returns a clean `{"status": "error", ...}` dict for a non-None `terrain`. The **Isaac** backend's `create_world` override, however, was left with the older, narrower signature (no `terrain` / `difficulty`), so:

```python
sim = create_simulation("isaac")
sim.create_world(terrain="rough")
# TypeError: IsaacSimulation.create_world() got an unexpected keyword argument 'terrain'
```

Instead of the contract's structured, actionable error, a caller (or the agent tool router, which forwards `terrain`/`difficulty` uniformly against the base signature) gets an uncaught `TypeError`. The drift slipped past mypy because the extra base parameters carry defaults, and it went unnoticed because the terrain params are recent and the Isaac backend's rollout tests live in `tests_integ` (real Isaac Sim + CUDA).

## Fix

Mirror the Newton backend's established terrain-parity handling on Isaac:

- Add `terrain: str | None = None` and `difficulty: float = 1.0` to the Isaac `create_world` override (signature parity with the base contract and the other backends).
- Reject a non-None `terrain` with an actionable `"heightfield terrain is currently MuJoCo-only; use create_simulation(backend='mujoco')"` error **before** booting Isaac Sim, so the rejection holds on any host (with or without an Omniverse install).
- `difficulty` is accepted for signature parity but inert (only meaningful with a `terrain`, which Isaac rejects outright) — identical to the Newton backend.

No behavioural change to the flat-ground path: `create_world()` / `create_world(difficulty=2.0)` still degrade to the existing structured Isaac-Sim-absent error rather than crashing.

## Tests

Added to `tests/simulation/isaac/test_isaac_backend.py` (no Isaac Sim required — the rejection is exercised before boot):

- `test_create_world_signature_parity_with_base` — the override accepts every param the base abstractmethod declares.
- `test_create_world_terrain_rejected_with_actionable_error` — `create_world(terrain="rough")` returns a structured error mentioning `terrain` + `mujoco`, not a `TypeError`.
- `test_create_world_difficulty_accepted_for_signature_parity` — `difficulty` is accepted (no `TypeError`) and inert.

All three **fail before** the fix (two `TypeError`, one missing-params `AssertionError`) and pass after. Full `tests/simulation/isaac/test_isaac_backend.py` is green (38 passed); `ruff check`, `ruff format --check`, and `mypy` are clean on both changed files.
