### PR TITLE
test: guard runtime log/error strings against non-ASCII glyphs

### DIFF
--- a/strands_robots/assets/download.py
+++ b/strands_robots/assets/download.py
@@ -92,7 +92,7 @@ def _resolve_robot_descriptions_module(name: str, info: dict) -> str | None:
         try:
             importlib.import_module(f"robot_descriptions.{candidate}")
             logger.warning(
-                "Resolved '%s' via naming heuristic → '%s'. "
+                "Resolved '%s' via naming heuristic -> '%s'. "
                 "Consider adding 'robot_descriptions_module' to the registry.",
                 name,
                 candidate,

--- a/strands_robots/assets/manager.py
+++ b/strands_robots/assets/manager.py
@@ -243,14 +243,14 @@ def resolve_model_path(
             candidates.extend(_resolve_candidates(asset_dir_name, xml_file, name))
 
     if not candidates:
-        logger.warning("Robot model not found: %s → %s/%s", name, asset_dir_name, xml_file)
+        logger.warning("Robot model not found: %s -> %s/%s", name, asset_dir_name, xml_file)
         return None
 
     # Prefer the candidate whose directory contains mesh files,
     # because an XML without meshes will fail to load in MuJoCo.
     for path in candidates:
         if _has_meshes(path.parent):
-            logger.debug("Resolved %s → %s (has meshes)", name, path)
+            logger.debug("Resolved %s -> %s (has meshes)", name, path)
             return Path(path)
 
     # XML found but no meshes - auto-download and re-check
@@ -260,11 +260,11 @@ def resolve_model_path(
         refreshed = _resolve_candidates(asset_dir_name, xml_file, name)
         for path in refreshed:
             if _has_meshes(path.parent):
-                logger.debug("Resolved %s → %s (auto-downloaded)", name, path)
+                logger.debug("Resolved %s -> %s (auto-downloaded)", name, path)
                 return Path(path)
 
     # Final fallback: return first candidate (some robots have no meshes)
-    logger.debug("Resolved %s → %s (no meshes available)", name, candidates[0])
+    logger.debug("Resolved %s -> %s (no meshes available)", name, candidates[0])
     return Path(candidates[0])
 
 

--- a/strands_robots/mesh/session.py
+++ b/strands_robots/mesh/session.py
@@ -622,7 +622,7 @@ def get_session() -> Any | None:
             try:
                 _SESSION = zenoh.open(cfg)
                 _SESSION_REFS = 1
-                logger.info("Zenoh mesh session opened (client → %s)", local_ep)
+                logger.info("Zenoh mesh session opened (client -> %s)", local_ep)
                 return _SESSION
             except (RuntimeError, OSError, ConnectionError, _ZError) as exc:
                 # Narrow tuple per AGENTS.md > Review Learnings (#86):
@@ -744,7 +744,7 @@ def _get_zenoh_session_directly() -> Any | None:
             try:
                 _SESSION = zenoh.open(cfg)
                 _SESSION_REFS = 1
-                logger.info("Zenoh mesh session opened (client → %s)", local_ep)
+                logger.info("Zenoh mesh session opened (client -> %s)", local_ep)
                 return _SESSION
             except (RuntimeError, OSError, ConnectionError, _ZError) as exc:
                 logger.warning("Zenoh session open failed (client mode): %s", exc)

--- a/strands_robots/policies/groot/policy.py
+++ b/strands_robots/policies/groot/policy.py
@@ -111,7 +111,7 @@ class ObservationMapping:
         for robot_key, model_key in self.video.items():
             if model_key not in model_video:
                 raise ValueError(
-                    f"Observation mapping: robot '{robot_key}' → model video "
+                    f"Observation mapping: robot '{robot_key}' -> model video "
                     f"'{model_key}', but model only has: {sorted(model_video)}"
                 )
 
@@ -119,7 +119,7 @@ class ObservationMapping:
         for robot_key, model_key in self.state.items():
             if model_key not in model_state:
                 raise ValueError(
-                    f"Observation mapping: robot '{robot_key}' → model state "
+                    f"Observation mapping: robot '{robot_key}' -> model state "
                     f"'{model_key}', but model only has: {sorted(model_state)}"
                 )
 
@@ -219,7 +219,7 @@ def _auto_infer_action_mapping(
         )
     for mdl, our in zip(remaining_model, remaining_ours):
         actions[mdl] = our
-        logger.info("Auto-mapped action: model '%s' → robot '%s' (positional)", mdl, our)
+        logger.info("Auto-mapped action: model '%s' -> robot '%s' (positional)", mdl, our)
     return ActionMapping(actions=actions)
 
 
@@ -256,7 +256,7 @@ def _match_keys(ours: list[str], model: list[str], label: str, strict_keys: bool
         )
     for our, mdl in zip(remaining_ours, remaining_model):
         mapping[our] = mdl
-        logger.info("Auto-mapped %s: '%s' → '%s' (positional)", label, our, mdl)
+        logger.info("Auto-mapped %s: '%s' -> '%s' (positional)", label, our, mdl)
     return mapping
 
 

--- a/strands_robots/registry/user_registry.py
+++ b/strands_robots/registry/user_registry.py
@@ -278,7 +278,7 @@ def register_robot(
     # Invalidate loader cache so next get_robot() picks up the merge
     _invalidate_cache()
 
-    logger.info("Registered robot '%s' → %s/%s", name, dir_name, model_xml)
+    logger.info("Registered robot '%s' -> %s/%s", name, dir_name, model_xml)
     return entry
 
 

--- a/strands_robots/simulation/factory.py
+++ b/strands_robots/simulation/factory.py
@@ -256,7 +256,7 @@ def _import_backend_class(name: str) -> type[SimEngine]:
     # 1. Runtime registry (user-registered)
     if name in _runtime_registry:
         cls: type[SimEngine] = _runtime_registry[name]()
-        logger.debug("Loaded runtime backend: %s → %s", name, cls.__name__)
+        logger.debug("Loaded runtime backend: %s -> %s", name, cls.__name__)
         return cls
 
     # 2. Built-in registry
@@ -278,7 +278,7 @@ def _import_backend_class(name: str) -> type[SimEngine]:
                 f"`strands_robots.simulation.factory.register_backend()` to proceed."
             ) from exc
         backend_cls: type[SimEngine] = getattr(module, class_name)  # type: ignore[assignment]
-        logger.debug("Loaded built-in backend: %s → %s.%s", name, module_path, class_name)
+        logger.debug("Loaded built-in backend: %s -> %s.%s", name, module_path, class_name)
         return backend_cls
 
     # 3. Entry-point plugins (third-party packages, e.g. strands-robots-sim).
@@ -289,7 +289,7 @@ def _import_backend_class(name: str) -> type[SimEngine]:
     plugins = _load_plugin_backends()
     if name in plugins:
         plugin_cls = plugins[name]
-        logger.debug("Loaded plugin backend: %s → %s", name, plugin_cls.__name__)
+        logger.debug("Loaded plugin backend: %s -> %s", name, plugin_cls.__name__)
         return plugin_cls
 
     available = ", ".join(list_backends())

--- a/tests/test_log_strings_are_ascii.py
+++ b/tests/test_log_strings_are_ascii.py
@@ -1,0 +1,103 @@
+"""Regression: runtime diagnostic strings in ``strands_robots`` stay ASCII.
+
+AGENTS.md mandates plain ASCII in logs, error messages, and tool-result text.
+Typographic glyphs (arrows like ``U+2192`` ``->``, ``U+2194`` ``<->``) render
+inconsistently across terminals and log pipelines and are tokenizer noise for
+the agents that read these strings programmatically. An ASCII rendering carries
+the same meaning everywhere.
+
+Unlike :mod:`tests.test_source_strings_no_emoji` and
+:mod:`tests.test_source_strings_no_unicode_dashes` -- which scan every source
+byte and therefore also police docstrings/comments -- this guard is deliberately
+*surgical*: it parses each module's AST and only inspects the string literals
+that are arguments to ``logger.<level>(...)`` / ``warnings.warn(...)`` calls or
+the message of a ``raise <Exception>(...)`` statement. That keeps intentional,
+semantic Unicode in docstrings (mapping arrows, math symbols) untouched while
+enforcing the ASCII rule exactly on the surface AGENTS.md names: what a human or
+agent reads out of a log or traceback.
+
+It would have failed when 15 ``logger``/``raise`` strings across 6 modules still
+carried ``U+2192``.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import strands_robots
+
+_PACKAGE_DIR = Path(strands_robots.__file__).resolve().parent
+
+# Standard-library ``logging.Logger`` emitters plus ``logging.log``. Matching on
+# the method name keeps the guard agnostic to the logger's binding name
+# (``logger``, ``LOGGER``, ``self._log``, ...); we additionally require the
+# receiver's root identifier to look logger-ish so an unrelated ``obj.info(...)``
+# is not swept in.
+_LOG_LEVELS = frozenset({"debug", "info", "warning", "warn", "error", "exception", "critical", "log"})
+
+
+def _python_sources() -> list[Path]:
+    return sorted(p for p in _PACKAGE_DIR.rglob("*.py") if "__pycache__" not in p.parts)
+
+
+def _string_constants(node: ast.AST) -> list[str]:
+    """All ``str`` constants reachable in an expression (f-strings, concat, ...)."""
+    return [n.value for n in ast.walk(node) if isinstance(n, ast.Constant) and isinstance(n.value, str)]
+
+
+def _root_name(expr: ast.expr) -> str:
+    """Left-most identifier of an attribute chain (``a.b.c`` -> ``a``)."""
+    while isinstance(expr, ast.Attribute):
+        expr = expr.value
+    return expr.id if isinstance(expr, ast.Name) else ""
+
+
+def _is_logger_call(call: ast.Call) -> bool:
+    func = call.func
+    if not isinstance(func, ast.Attribute) or func.attr not in _LOG_LEVELS:
+        return False
+    if func.attr == "warn" and _root_name(func) in {"warnings", "warning"}:
+        return True  # warnings.warn(...)
+    return "log" in _root_name(func).lower()
+
+
+def _diagnostic_strings(tree: ast.AST) -> list[tuple[int, str]]:
+    """(lineno, string) for every logger/raise/warn diagnostic literal."""
+    found: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and _is_logger_call(node):
+            for arg in node.args:
+                found.extend((node.lineno, s) for s in _string_constants(arg))
+        elif isinstance(node, ast.Raise) and node.exc is not None:
+            found.extend((node.lineno, s) for s in _string_constants(node.exc))
+    return found
+
+
+def test_package_sources_discovered() -> None:
+    """Guard the guard: the scan walked the whole package, not one subtree."""
+    sources = _python_sources()
+    assert len(sources) > 50
+    rel_dirs = {p.relative_to(_PACKAGE_DIR).parts[0] for p in sources if p.parent != _PACKAGE_DIR}
+    assert {"simulation", "tools", "registry", "policies", "assets"} <= rel_dirs
+
+
+def test_diagnostic_string_scan_finds_calls() -> None:
+    """Sanity: the AST walk actually locates diagnostic strings to inspect."""
+    total = sum(len(_diagnostic_strings(ast.parse(p.read_text(encoding="utf-8")))) for p in _python_sources())
+    assert total > 100, "AST scan found suspiciously few logger/raise strings"
+
+
+def test_log_and_error_strings_are_ascii() -> None:
+    """No ``logger``/``raise``/``warnings.warn`` string literal may be non-ASCII."""
+    offenders: list[str] = []
+    for path in _python_sources():
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for lineno, text in _diagnostic_strings(tree):
+            if not text.isascii():
+                bad = sorted({f"U+{ord(c):04X}" for c in text if ord(c) > 0x7F})
+                rel = path.relative_to(_PACKAGE_DIR.parent)
+                offenders.append(f"{rel}:{lineno}: {' '.join(bad)} in {text.strip()[:80]!r}")
+    assert not offenders, "Non-ASCII in logger/raise/warn strings (use ASCII, e.g. '->' for arrows):\n" + "\n".join(
+        offenders
+    )


### PR DESCRIPTION
## Problem

Diagnostic strings that surface in logs, tracebacks, and tool-result text are expected to be plain ASCII (see `AGENTS.md`: "No emojis in code/logs/errors (ASCII only)"). The repo already enforces this for emoji and Unicode dashes via `tests/test_source_strings_no_emoji.py` and `tests/test_source_strings_no_unicode_dashes.py`, but neither catches typographic **arrows**. Fifteen `logger`/`raise` strings across six modules still carried `U+2192` (`->`), which renders inconsistently across terminals and log pipelines and is tokenizer noise for programmatic consumers.

Offending modules: `assets/download.py`, `assets/manager.py`, `mesh/session.py`, `policies/groot/policy.py`, `registry/user_registry.py`, `simulation/factory.py`.

## Change

- Replace `U+2192` with the ASCII `->` in the 15 affected `logger.*` / `raise` strings. No behavior change; format specifiers and message meaning are identical.
- Add `tests/test_log_strings_are_ascii.py`, an AST-based guard that inspects **only** the string literals passed to `logger.<level>()` / `warnings.warn()` calls and `raise <Exception>()` messages. Unlike the existing whole-file emoji/dash scans, this is surgical: intentional semantic Unicode in docstrings and comments (mapping arrows, math symbols like `x`, `deg`) stays untouched, while the ASCII rule is enforced exactly on the diagnostic surface the convention names.

## Tests

The new `test_log_and_error_strings_are_ascii` fails on the fifteen pre-existing offenders and passes after the fix:

```
# pre-fix
FAILED tests/test_log_strings_are_ascii.py::test_log_and_error_strings_are_ascii
  strands_robots/assets/manager.py:246: U+2192 in 'Robot model not found: %s -> %s/%s'
  ... (15 offenders)
# post-fix
3 passed
```

Local gate clean: `ruff check` + `ruff format --check` pass; `mypy strands_robots tests tests_integ` -> `Success: no issues found in 780 source files`. Affected-module suites (`tests/policies/groot`, `tests/simulation/test_factory.py`, `tests/registry`, `tests/test_asset_download.py`, `tests/test_asset_manager.py`, `tests/mesh`) all pass, alongside the sibling emoji/dash guards.