### PR TITLE
fix(sim): Isaac add_object honours the base mesh_path/material contract instead of silently swallowing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: Isaac `add_object` honours the base `mesh_path` / `material` contract instead of silently swallowing them
+
+`SimEngine.add_object` declares `mesh_path` and `material`, and its docstring is
+explicit that a backend which does not support `material` "should reject a
+non-`None` `material` loudly rather than silently ignore it". The MuJoCo backend
+attaches a real material; the Newton backend rejects a non-`None` `material` with
+an actionable error and loads `mesh_path` for `shape="mesh"`. The Isaac override,
+however, kept a narrower signature with a trailing `**kwargs` (used for the
+`scale` alias) that **silently swallowed** `material=` and `mesh_path=`: a caller
+scoping a matte/textured surface or a custom mesh on Isaac got `status: "success"`
+with the request quietly dropped (or, on a host without Isaac Sim, an unrelated
+"No world created" error) -- never the documented rejection, and the agent tool
+router could not pass these params uniformly across backends. The Isaac
+`add_object` now accepts `mesh_path` / `material` for signature parity with the
+base contract and rejects a non-`None` value of either with an actionable error
+(pointing to `create_simulation(backend="mujoco")`) before the stage boots,
+mirroring the Newton reject and the existing Isaac `create_world(terrain=...)`
+rejection. The `scale` alias path is unchanged.
+
 ### Fixed: `create_world(difficulty=...)` is discoverable in the sim tool_spec + the terrain-kind hint stays in sync
 
 `create_world` grew a `difficulty` curriculum knob (it scales a terrain

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -1275,6 +1275,8 @@ class IsaacSimulation(SimEngine):
         color: list[float] | None = None,
         mass: float = 0.1,
         is_static: bool = False,
+        mesh_path: str | None = None,
+        material: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         """Add an object (shape primitive) to the scene.
@@ -1332,6 +1334,17 @@ class IsaacSimulation(SimEngine):
             Sphere, Cylinder, Capsule}`` and stays pinned in space. If
             ``False`` (default), uses the ``Dynamic*`` counterpart and
             participates in physics with ``mass``.
+        mesh_path : str, optional
+            Path to a custom mesh asset. Loading custom meshes is not
+            supported by the Isaac backend yet; a non-``None`` value is
+            rejected with an actionable error rather than being silently
+            ignored (honouring the
+            :class:`~strands_robots.simulation.base.SimEngine` ``add_object``
+            contract). Use ``create_simulation(backend='mujoco')`` for meshes.
+        material : dict, optional
+            Visual material/texture spec. NOT supported by the Isaac backend
+            yet; a non-``None`` value is rejected loudly rather than silently
+            dropped (use the MuJoCo backend for matte/textured surfaces).
 
         Returns
         -------
@@ -1342,6 +1355,34 @@ class IsaacSimulation(SimEngine):
             ``mass``, and ``is_static`` so an agent can confirm what
             actually landed on the stage without re-querying.
         """
+        if material is not None:
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            "add_object: material= is not supported on the "
+                            "Isaac backend yet (matte/textured surfaces); use "
+                            "create_simulation(backend='mujoco') for materials, "
+                            "or omit material for a flat color."
+                        )
+                    }
+                ],
+            }
+        if mesh_path is not None:
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            "add_object: mesh_path=/custom mesh objects are not "
+                            "supported on the Isaac backend yet; use "
+                            "create_simulation(backend='mujoco') for meshes, or a "
+                            "primitive shape (box/sphere/capsule/cylinder)."
+                        )
+                    }
+                ],
+            }
         with self._lock:
             if not self._world_created:
                 return {"status": "error", "content": [{"text": "No world created."}]}

--- a/tests/simulation/isaac/test_isaac_backend.py
+++ b/tests/simulation/isaac/test_isaac_backend.py
@@ -303,6 +303,47 @@ class TestIsaacSimulationConstruction:
         assert result["status"] == "error"
         assert "terrain" not in result["content"][0]["text"].lower()
 
+    def test_add_object_signature_parity_with_base(self):
+        # The base SimEngine.add_object declares ``mesh_path`` / ``material``
+        # (the "reject a non-None material loudly rather than silently ignore
+        # it" contract). The Isaac override must accept them so the tool
+        # router / a caller can pass them uniformly instead of hitting a bare
+        # TypeError or, worse, a silent **kwargs swallow.
+        import inspect
+
+        from strands_robots.simulation.base import SimEngine
+        from strands_robots.simulation.isaac.simulation import IsaacSimulation
+
+        base = set(inspect.signature(SimEngine.add_object).parameters)
+        override = set(inspect.signature(IsaacSimulation.add_object).parameters)
+        assert {"mesh_path", "material"} <= override, f"Isaac add_object drops base params: missing {base - override}"
+
+    def test_add_object_material_rejected_with_actionable_error(self):
+        # Base contract (SimEngine.add_object docstring): a backend that does
+        # not support ``material`` rejects a non-None value loudly rather than
+        # silently ignoring it. The Isaac add_object only sets a flat color, so
+        # a material spec is rejected with an actionable error before the stage
+        # boots (holds on any host, Isaac Sim present or not).
+        from strands_robots.simulation.isaac.simulation import IsaacSimulation
+
+        sim = IsaacSimulation(num_envs=1, headless=True)
+        result = sim.add_object("block", material={"albedo": [0.2, 0.2, 0.2]})
+        assert result["status"] == "error"
+        text = result["content"][0]["text"].lower()
+        assert "material" in text and "mujoco" in text, text
+
+    def test_add_object_mesh_path_rejected_with_actionable_error(self):
+        # The Isaac add_object supports only primitive shapes; a custom
+        # ``mesh_path`` is rejected with an actionable error rather than being
+        # silently dropped into **kwargs.
+        from strands_robots.simulation.isaac.simulation import IsaacSimulation
+
+        sim = IsaacSimulation(num_envs=1, headless=True)
+        result = sim.add_object("part", mesh_path="/tmp/widget.obj")
+        assert result["status"] == "error"
+        text = result["content"][0]["text"].lower()
+        assert "mesh" in text and "mujoco" in text, text
+
 
 class TestProceduralBuilders:
     def test_list_procedural_robots(self):


### PR DESCRIPTION
## Problem

`SimEngine.add_object` declares `mesh_path` and `material`, and its docstring is explicit:

> `material` (optional): ... Backends that do not support it should reject a non-`None` `material` **loudly rather than silently ignore it**.

The MuJoCo backend attaches a real material; the Newton backend rejects a non-`None` `material` with an actionable error and loads `mesh_path` for `shape="mesh"`. The **Isaac** override, however, kept a narrower signature ending in `**kwargs` (used only for the `scale` alias) that **silently swallowed** `material=` and `mesh_path=`:

- With Isaac Sim booted, `add_object(..., material=...)` returned `status: "success"` with the material quietly dropped.
- Without Isaac Sim, it returned an unrelated `"No world created"` error.

Either way the caller never saw the documented rejection, and the agent tool router could not pass these params uniformly across backends (Isaac raised/ignored where MuJoCo/Newton handle them). This is the same class as the recently-fixed `create_world(terrain=...)` Isaac parity gap: an Isaac override lagging the base `SimEngine` contract.

## Change

The Isaac `add_object` now:
- accepts `mesh_path` / `material` for signature parity with the base contract (the `scale` alias `**kwargs` path is unchanged), and
- rejects a non-`None` value of either with an actionable structured error pointing at `create_simulation(backend="mujoco")`, evaluated **before** the stage boots so it holds on any host.

This mirrors the Newton reject and the existing Isaac `create_world(terrain=...)` rejection.

## Tests

Added to `tests/simulation/isaac/test_isaac_backend.py::TestIsaacSimulationConstruction`, mirroring the `create_world` parity/reject tests:
- `test_add_object_signature_parity_with_base` - asserts `{mesh_path, material}` are on the Isaac override.
- `test_add_object_material_rejected_with_actionable_error` / `..._mesh_path_...` - assert a non-`None` value returns a `status: "error"` naming the param + the MuJoCo alternative, exercised before Isaac Sim boots (holds on any host).

All three **fail before** the fix (missing params; pre-fix returns the unrelated `"No world created"` text instead of the rejection) and pass after.

## Gate

- `ruff check` / `ruff format --check` / `mypy` clean on the changed files.
- Full `tests/simulation/isaac/test_isaac_backend.py`: 41 passed.
- `tests/simulation/newton/` + describe-discovery + facade-guardrails: 290 passed, 1 skipped (no regression).

No visual artifact: this is a backend error-contract fix (a structured error string), not a policy/render/asset behaviour change; the fails-before test is the proof.