### PR TITLE
test(sim): pin the newton package lazy-export contract

### DIFF
--- a/tests/simulation/newton/test_package_lazy_export.py
+++ b/tests/simulation/newton/test_package_lazy_export.py
@@ -1,0 +1,52 @@
+"""Tests for the package-root lazy-export contract in
+``strands_robots/simulation/newton/__init__.py``.
+
+Importing the newton package must stay cheap: the ``NewtonSimEngine`` symbol is
+resolved on first attribute access via PEP 562 ``__getattr__`` so that
+``import strands_robots.simulation.newton`` does not pull in the heavy
+newton/warp stack. These tests pin the observable behavior of that loader:
+
+- ``NewtonSimEngine`` is the sole promised public name (``__all__``),
+- first attribute access resolves it, caches it in the module dict, and
+  returns the same object identity as the backing ``simulation`` submodule,
+- an unknown attribute raises ``AttributeError`` with the standard message.
+"""
+
+import importlib
+
+import pytest
+
+import strands_robots.simulation.newton as newton_pkg
+from strands_robots.simulation.newton.simulation import NewtonSimEngine
+
+
+class TestPublicSurface:
+    def test_all_promises_only_newton_sim_engine(self):
+        assert newton_pkg.__all__ == ["NewtonSimEngine"]
+
+
+class TestLazyResolution:
+    """First attribute access resolves, caches, and returns stable identity."""
+
+    def test_lazy_symbol_resolves_caches_and_matches_submodule(self):
+        # Reload the package so its namespace starts without the cached name,
+        # letting us observe the lazy __getattr__ populate globals() on first
+        # access rather than reading a value a prior test already resolved.
+        pkg = importlib.reload(newton_pkg)
+        assert "NewtonSimEngine" not in vars(pkg)
+
+        resolved = pkg.NewtonSimEngine
+
+        # Resolves to the very class defined in the backing submodule.
+        assert resolved is NewtonSimEngine
+
+        # First access caches the name in the module dict so __getattr__ is
+        # not invoked again; the identity stays stable.
+        assert "NewtonSimEngine" in vars(pkg)
+        assert pkg.NewtonSimEngine is resolved
+
+
+class TestUnknownAttribute:
+    def test_unknown_attribute_raises_standard_message(self):
+        with pytest.raises(AttributeError, match="has no attribute 'does_not_exist'"):
+            newton_pkg.does_not_exist


### PR DESCRIPTION
## Problem

`strands_robots/simulation/newton/__init__.py` exposes `NewtonSimEngine` via a PEP 562 `__getattr__` so that `import strands_robots.simulation.newton` stays cheap and does not pull in the heavy newton/warp stack. That lazy-export loader was the one package root in the simulation tree with no test coverage: the module sat at 62% (the `__getattr__` resolution/caching branch and the unknown-attribute `AttributeError` were never exercised), while the top-level package and the isaac package both have their lazy contracts pinned.

## Change

Add `tests/simulation/newton/test_package_lazy_export.py` pinning the observable behavior of the loader, matching the existing `tests/test_package_lazy_imports.py` convention:

- `__all__` promises exactly `["NewtonSimEngine"]`.
- First attribute access resolves the symbol, caches it in the module dict (so `__getattr__` is not re-invoked), and returns the same object identity as the backing `simulation` submodule. The test reloads the package first so the resolve-and-cache transition is observed deterministically rather than reading a value a sibling test already resolved.
- An unknown attribute raises `AttributeError` with the standard `has no attribute ...` message.

Test-only change; no runtime behavior is modified.

## Coverage

`strands_robots/simulation/newton/__init__.py`: 62% -> 100%.

## Tests

```
MUJOCO_GL=egl pytest tests/simulation/newton/test_package_lazy_export.py -q   # 3 passed
MUJOCO_GL=egl pytest tests/simulation/newton/ -q                              # 109 passed, 126 skipped
```

The suite runs without newton/warp installed: importing the `NewtonSimEngine` class does not require the backend runtime (warp is imported lazily inside methods), so the lazy-export path is fully exercisable in a dependency-light environment. `ruff check` and `ruff format --check` are clean.