### PR TITLE
test(mesh): cover RtpsRobot generated tool closures + repr

### DIFF
--- a/tests/mesh/test_rtps_robot.py
+++ b/tests/mesh/test_rtps_robot.py
@@ -69,3 +69,46 @@ def test_tools_are_uniquely_named(rec: _Recorder) -> None:
 def test_invalid_topic_rejected_at_construction() -> None:
     with pytest.raises(ValueError, match="invalid cmd_vel_topic"):
         RtpsRobot.from_rtps(node_name="bot", cmd_vel_topic="not absolute")
+
+
+def test_generated_drive_tool_publishes_over_rtps(rec: _Recorder) -> None:
+    """The agent-facing drive_<node> tool forwards to the RTPS publish path.
+
+    ``.tools`` builds per-instance ``@tool`` closures; invoking the drive tool
+    must produce the same Twist publish call as :meth:`RtpsRobot.drive`, so an
+    agent driving via the tool and code driving via the method are equivalent.
+    """
+    robot = RtpsRobot.from_rtps(node_name="turtlesim", cmd_vel_topic="/turtle1/cmd_vel")
+    drive_tool: Any = next(t for t in robot.tools if t.tool_name == "drive_turtlesim")
+
+    result = drive_tool(linear=2.0, angular=1.5)
+
+    assert result["status"] == "success"
+    call = rec.calls[0]
+    assert call["action"] == "publish"
+    assert call["topic"] == "/turtle1/cmd_vel"
+    assert call["type"] == "geometry_msgs/msg/Twist"
+    assert call["fields"] == {"linear": {"x": 2.0}, "angular": {"z": 1.5}}
+
+
+def test_generated_stop_tool_publishes_zero(rec: _Recorder) -> None:
+    """The agent-facing stop_<node> tool publishes a single zero-velocity Twist."""
+    robot = RtpsRobot.from_rtps(node_name="turtlesim", cmd_vel_topic="/turtle1/cmd_vel")
+    stop_tool: Any = next(t for t in robot.tools if t.tool_name == "stop_turtlesim")
+
+    result = stop_tool()
+
+    assert result["status"] == "success"
+    call = rec.calls[0]
+    assert call["action"] == "publish"
+    assert call["fields"] == {"linear": {"x": 0.0}, "angular": {"z": 0.0}}
+    assert call["count"] == 1
+
+
+def test_repr_shows_wiring() -> None:
+    """``repr`` surfaces the node name, cmd_vel topic, and interface type."""
+    robot = RtpsRobot.from_rtps(node_name="turtlesim", cmd_vel_topic="/turtle1/cmd_vel")
+    text = repr(robot)
+    assert text == (
+        "RtpsRobot(node_name='turtlesim', cmd_vel_topic='/turtle1/cmd_vel', cmd_vel_type='geometry_msgs/msg/Twist')"
+    )


### PR DESCRIPTION
## Summary

Raises `strands_robots/mesh/rtps_robot.py` coverage from 93% to 100%. The only uncovered lines were the per-instance `drive_<node>` / `stop_<node>` agent-tool closures built by `RtpsRobot.tools` and `__repr__`. `test_tools_are_uniquely_named` already asserted the tool *names*, but never invoked the closures, so the body that forwards each generated tool to the underlying `drive` / `stop` method was untested.

## Change

Pure test addition (no runtime change). Three behavior tests in `tests/mesh/test_rtps_robot.py`:

- `test_generated_drive_tool_publishes_over_rtps` - invoking the generated `drive_turtlesim` tool produces the same `Twist` publish call (`action=publish`, topic, type, `linear.x`/`angular.z` field mapping) as `RtpsRobot.drive`, so an agent driving via the tool and code driving via the method are equivalent.
- `test_generated_stop_tool_publishes_zero` - the generated `stop_turtlesim` tool publishes a single zero-velocity `Twist`.
- `test_repr_shows_wiring` - `repr` surfaces the node name, `cmd_vel` topic, and interface type.

`use_rtps` is monkeypatched via the existing `rec` fixture, so the tests stay ROS-free and cyclonedds-free like the rest of the suite. The generated tool is bound to `Any` before invocation, matching the established convention in `tests/mesh/test_ros_bridge.py`.

## Verification

```
MUJOCO_GL=egl pytest tests/mesh/test_rtps_robot.py -q
# 9 passed
```

Module coverage: `strands_robots/mesh/rtps_robot.py  42  0  100%` (was 3 lines missing). Local gate clean: `ruff check`, `ruff format --check`, `mypy` all pass.