### PR TITLE
fix(sim): Isaac add_robot accepts + loudly rejects the base keyframe contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: Isaac `add_robot` honours the base `keyframe` contract instead of raising a bare `TypeError`
+
+`SimEngine.add_robot` declares a `keyframe` parameter (spawn the robot in a
+canonical `<keyframe>` pose such as panda `"home"` / aloha `"neutral_pose"`
+instead of the default all-zero configuration), and its docstring is explicit
+that an unknown/unsupported keyframe is a hard error that never silently falls
+back to zeros. The MuJoCo and Newton backends implement it; the Isaac override,
+however, kept a narrower signature that omitted `keyframe` entirely, so
+`add_robot(name, keyframe="home")` on the Isaac backend raised a bare
+`TypeError: add_robot() got an unexpected keyword argument 'keyframe'` on a
+documented base parameter, and the agent tool router could not pass `keyframe`
+uniformly across backends. The Isaac `add_robot` now accepts `keyframe` for
+signature parity with the base contract and rejects a non-`None` value with an
+actionable error (pointing to `create_simulation(backend="mujoco")`, since the
+Isaac backend does not parse the MuJoCo `<keyframe>` block) before the stage
+boots, mirroring the existing Isaac `create_world(terrain=...)` and
+`add_object(material=...)` rejections. `keyframe=None` (the default) is
+unchanged.
+
 ### Fixed: Isaac `add_object` honours the base `mesh_path` / `material` contract instead of silently swallowing them
 
 `SimEngine.add_object` declares `mesh_path` and `material`, and its docstring is

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -1036,6 +1036,7 @@ class IsaacSimulation(SimEngine):
         data_config: str | None = None,
         position: list[float] | None = None,
         orientation: list[float] | None = None,
+        keyframe: str | int | None = None,
     ) -> dict[str, Any]:
         """Add a robot to the simulation.
 
@@ -1055,12 +1056,38 @@ class IsaacSimulation(SimEngine):
             Base position [x, y, z].
         orientation : list[float], optional
             Base orientation as quaternion [w, x, y, z].
+        keyframe : str | int, optional
+            Canonical-pose keyframe (e.g. panda ``"home"``). The Isaac
+            backend does not parse the MuJoCo ``<keyframe>`` block this
+            refers to, so a non-None value is rejected with an actionable
+            error rather than raising ``TypeError`` or being silently
+            ignored (honouring the
+            :class:`~strands_robots.simulation.base.SimEngine` ``add_robot``
+            contract). Use ``create_simulation(backend="mujoco")`` to spawn
+            at a keyframe, or omit ``keyframe`` for the default zero-pose
+            spawn.
 
         Returns
         -------
         dict
             Status dict with robot info.
         """
+        if keyframe is not None:
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            f"add_robot: keyframe={keyframe!r} is not supported on "
+                            "the Isaac backend (spawning at a MuJoCo <keyframe> pose "
+                            "is currently MuJoCo-only); use "
+                            "create_simulation(backend='mujoco') to spawn at a "
+                            "keyframe, or omit keyframe for the default zero-pose "
+                            "spawn."
+                        )
+                    }
+                ],
+            }
         with self._lock:
             if not self._world_created:
                 return {

--- a/tests/simulation/isaac/test_isaac_backend.py
+++ b/tests/simulation/isaac/test_isaac_backend.py
@@ -344,6 +344,48 @@ class TestIsaacSimulationConstruction:
         text = result["content"][0]["text"].lower()
         assert "mesh" in text and "mujoco" in text, text
 
+    def test_add_robot_signature_parity_with_base(self):
+        # The base SimEngine.add_robot declares ``keyframe`` (spawn at a
+        # canonical <keyframe> pose). Every backend override must accept it
+        # so a caller / the tool router can pass it uniformly; a narrower
+        # override raises a bare TypeError on a documented parameter instead
+        # of the contract's actionable error (cf. create_world terrain and
+        # add_object material/mesh_path parity).
+        import inspect
+
+        from strands_robots.simulation.base import SimEngine
+        from strands_robots.simulation.isaac.simulation import IsaacSimulation
+
+        base = set(inspect.signature(SimEngine.add_robot).parameters)
+        override = set(inspect.signature(IsaacSimulation.add_robot).parameters)
+        assert {"keyframe"} <= override, f"Isaac add_robot drops base params: missing {base - override}"
+
+    def test_add_robot_keyframe_rejected_with_actionable_error(self):
+        # Base contract (SimEngine.add_robot docstring): an unknown/unsupported
+        # keyframe is a hard error that never silently falls back to zeros. The
+        # Isaac backend does not parse the MuJoCo <keyframe> block, so a non-None
+        # keyframe is rejected with an actionable error - NOT a bare TypeError,
+        # NOT a silent zero-pose spawn. The rejection fires before Isaac Sim
+        # boots, so it holds on any host.
+        from strands_robots.simulation.isaac.simulation import IsaacSimulation
+
+        sim = IsaacSimulation(num_envs=1, headless=True)
+        result = sim.add_robot("panda", keyframe="home")
+        assert result["status"] == "error"
+        text = result["content"][0]["text"].lower()
+        assert "keyframe" in text and "mujoco" in text, text
+
+    def test_add_robot_keyframe_none_not_rejected(self):
+        # keyframe=None (the default) must NOT hit the reject path - a plain
+        # add_robot call still degrades to the structured Isaac-Sim-absent /
+        # no-world error rather than the keyframe rejection.
+        from strands_robots.simulation.isaac.simulation import IsaacSimulation
+
+        sim = IsaacSimulation(num_envs=1, headless=True)
+        result = sim.add_robot("panda")
+        assert result["status"] == "error"
+        assert "keyframe" not in result["content"][0]["text"].lower()
+
 
 class TestProceduralBuilders:
     def test_list_procedural_robots(self):


### PR DESCRIPTION
## Problem

`SimEngine.add_robot` declares a `keyframe: str | int | None` parameter — spawn the robot in a canonical `<keyframe>` pose (panda `"home"`, aloha `"neutral_pose"`, G1/Go2 `"home"`) instead of the default all-zero configuration — and its docstring is explicit that an unknown/unsupported keyframe is a **hard error that never silently falls back to zeros**.

The MuJoCo and Newton backends implement it. The **Isaac** override, however, kept a narrower signature that omitted `keyframe` entirely:

```python
# strands_robots/simulation/isaac/simulation.py (before)
def add_robot(self, name, urdf_path=None, mjcf_path=None, usd_path=None,
              data_config=None, position=None, orientation=None): ...
```

So `sim.add_robot("panda", keyframe="home")` on the Isaac backend raised a bare

```
TypeError: IsaacSimulation.add_robot() got an unexpected keyword argument 'keyframe'
```

on a **documented base parameter**, and the agent tool router could not forward `keyframe` uniformly across backends (a backend override with a narrower signature than the ABC is exactly the drift that trips the router).

## Change

The Isaac `add_robot` now accepts `keyframe` for signature parity with the base contract and **rejects a non-`None` value with an actionable structured error** — the Isaac backend does not parse the MuJoCo `<keyframe>` block this refers to, so it points the caller at `create_simulation(backend="mujoco")` rather than raising `TypeError` or silently spawning at zeros. The rejection fires **before the stage boots**, so it holds on any host (Isaac Sim present or not).

This mirrors the existing Isaac `create_world(terrain=...)` (#1354) and `add_object(mesh_path=/material=)` (#1357) rejections — same accept-for-parity-then-reject-loudly pattern. `keyframe=None` (the default zero-pose spawn) is unchanged.

```python
>>> sim.add_robot("panda", keyframe="home")
{'status': 'error', 'content': [{'text': "add_robot: keyframe='home' is not supported on the Isaac backend (spawning at a MuJoCo <keyframe> pose is currently MuJoCo-only); use create_simulation(backend='mujoco') to spawn at a keyframe, or omit keyframe for the default zero-pose spawn."}]}
```

## Tests

`tests/simulation/isaac/test_isaac_backend.py` (all GL-free, no Isaac Sim required — the guards run before the stage boots):

- `test_add_robot_signature_parity_with_base` — asserts `{"keyframe"} <= inspect.signature(IsaacSimulation.add_robot)` (fails-before: `AssertionError: Isaac add_robot drops base params: missing {'keyframe'}`).
- `test_add_robot_keyframe_rejected_with_actionable_error` — `add_robot("panda", keyframe="home")` returns a `status: error` naming `keyframe` + `mujoco` (fails-before: the bare `TypeError` above).
- `test_add_robot_keyframe_none_not_rejected` — the default path does not hit the reject branch.

Both behavioural tests fail on the pre-fix source and pass after. Full Isaac suite: 44 passed. `ruff check` / `ruff format --check` / `mypy` clean.

No behaviour change for MuJoCo/Newton or for `keyframe=None`.