### PR TITLE
test(sim): pin Newton get_state summary + register_urdf success/not-a-file contract

### DIFF
--- a/tests/simulation/newton/test_discovery_and_state.py
+++ b/tests/simulation/newton/test_discovery_and_state.py
@@ -348,6 +348,77 @@ class TestRegistryPassthrough:
     def test_register_urdf_empty_path_errors(self, engine):
         assert engine.register_urdf("xx", "")["status"] == "error"
 
+    def test_register_urdf_success_binds_and_resolves(self, engine, tmp_path):
+        """A readable asset registers and round-trips through resolve_model.
+
+        The success path validates the file, binds it under the given config
+        name, and reports the resolved path back so a caller can add_robot the
+        custom asset without re-reading the registry.
+        """
+        asset = tmp_path / "my_arm.xml"
+        asset.write_text("<mujoco/>")
+        result = engine.register_urdf("my_custom_arm", str(asset))
+        assert result["status"] == "success"
+        text = result["content"][0]["text"]
+        assert "my_custom_arm" in text
+        assert str(asset) in text
+        # resolve_model round-trips the just-registered path (not "NOT FOUND").
+        assert "NOT FOUND" not in text
+
+    def test_register_urdf_directory_errors_as_not_a_file(self, engine, tmp_path):
+        """An existing-but-not-a-file path (a directory) is rejected distinctly
+        from the missing-file case, so the caller knows the path resolved but
+        pointed at the wrong kind of node."""
+        result = engine.register_urdf("dircfg", str(tmp_path))
+        assert result["status"] == "error"
+        assert "not a file" in result["content"][0]["text"]
+
+
+class TestWorldStateSummary:
+    """get_state() world summary + the no-world guards on the step/reset/state
+    lifecycle methods.
+
+    get_state is the human-readable introspection facade at MuJoCo parity; the
+    guards ensure the lifecycle methods fail soft with an actionable message
+    instead of dereferencing a None model when create_world was skipped.
+    """
+
+    def test_get_state_summarises_solver_time_and_counts(self, engine_so100):
+        result = engine_so100.get_state()
+        assert result["status"] == "success"
+        text = result["content"][0]["text"]
+        assert "Newton Simulation State" in text
+        # Names the active solver and the world/robot inventory a caller needs
+        # to sanity-check what is loaded before stepping.
+        assert "solver=mujoco" in text
+        assert "step 0" in text
+        assert "Robots: 1" in text
+        assert "Objects: 0" in text
+        assert "DOFs: 6" in text
+
+    def test_get_state_reflects_added_object(self, engine_so100):
+        engine_so100.add_object("cube", shape="box", position=[0.3, 0.0, 0.05], mass=0.2)
+        text = engine_so100.get_state()["content"][0]["text"]
+        assert "Objects: 1" in text
+
+    def test_get_state_without_world_errors(self):
+        from strands_robots.simulation.newton.simulation import NewtonSimEngine
+
+        sim = NewtonSimEngine(solver="mujoco")
+        assert sim.get_state()["status"] == "error"
+
+    def test_reset_without_world_errors(self):
+        from strands_robots.simulation.newton.simulation import NewtonSimEngine
+
+        sim = NewtonSimEngine(solver="mujoco")
+        assert sim.reset()["status"] == "error"
+
+    def test_step_without_world_errors(self):
+        from strands_robots.simulation.newton.simulation import NewtonSimEngine
+
+        sim = NewtonSimEngine(solver="mujoco")
+        assert sim.step()["status"] == "error"
+
 
 class TestDescribeSurface:
     def test_describe_exposes_new_methods(self, engine_so100):


### PR DESCRIPTION
## Problem

Two user-facing surfaces on the Newton backend were untested at the call level:

- `get_state()` — the human-readable world-summary facade at MuJoCo parity — was never invoked by a test (only listed in `describe()`), so its output contract (solver, step count, robot/object/DOF inventory) was unpinned.
- `register_urdf()` only had coverage for the missing-file and empty-path error branches. Its **success path** (validate -> bind -> `resolve_model` round-trip) and the **directory / not-a-file** rejection were uncovered.

The `reset()`/`step()` no-world guards were also unpinned, so a regression that dereferenced a `None` model when `create_world` was skipped would slip past the suite.

## Change

Extends `tests/simulation/newton/test_discovery_and_state.py` (gated on Newton + Warp being importable) with a focused `TestWorldStateSummary` class and two additions to `TestRegistryPassthrough`:

- `get_state()` world summary asserts the solver name, step count, and robot/object/DOF inventory; a second test confirms the summary reflects an added object; plus the no-world error guard.
- `reset()` / `step()` no-world error guards (fail soft with an actionable message rather than dereferencing a `None` model).
- `register_urdf()` success path (validate -> bind -> resolve round-trip, reporting the resolved path) and the directory (not-a-file) rejection, distinct from the missing-file case.

Tests use `tmp_path` — no host paths, no network, deterministic.

## Verification

`MUJOCO_GL=egl pytest tests/simulation/newton/test_discovery_and_state.py` — 35 passed. Lint gate clean (`ruff check`, `ruff format --check`, `mypy` over `strands_robots tests tests_integ`: no issues in 783 source files). No production code changed; test-only.
