### PR TITLE
fix(sim): base_below_z measures clearance above the local terrain, not an absolute world z

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: `base_below_z` measures the base's clearance above the LOCAL terrain, not an absolute world z
+
+`base_below_z` is the height-collapse half of a floating-base fall termination
+(the counterpart of `base_tipped`): it ends a locomotion episode when the
+robot's torso/pelvis has dropped to the ground. It compared the base's world
+`z` against an absolute threshold, which is correct only on a flat ground
+plane. Once a locomotion task runs on a raised-terrain heightfield
+(`create_world(terrain=...)`, the terrain curriculum), an absolute test
+silently MISSES a collapse: a robot that has fallen onto a raised plateau (e.g.
+a 0.16 m pyramid step) still has an absolute base `z` (~0.26 m) above the
+flat-ground collapse threshold (0.18 m for the Go2), so the failure predicate
+never fires and the episode never terminates on the fall. `base_below_z` now
+measures the base's height ABOVE THE LOCAL GROUND beneath it (`base z` minus
+the terrain surface height at the base's `(x, y)`) via a new backend hook
+`_ground_height_at`. The MuJoCo backend bilinearly samples the
+`create_world(terrain=...)` heightfield; the base default (and any backend
+without a heightfield) returns `0.0`, so flat-ground behaviour is byte-for-byte
+unchanged. This is groundwork for a terrain-difficulty locomotion benchmark: a
+fall predicate that works on raised terrain is a prerequisite for running the
+`*_walk_forward` benchmarks on the terrain curriculum.
+
 ### Fixed: Isaac `add_robot` honours the base `keyframe` contract instead of raising a bare `TypeError`
 
 `SimEngine.add_robot` declares a `keyframe` parameter (spawn the robot in a

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -538,6 +538,20 @@ class SimEngine(ABC):
         """
         ...
 
+    def _ground_height_at(self, x: float, y: float) -> float:
+        """Terrain surface height (world z) beneath world ``(x, y)``; ``0.0`` on flat ground.
+
+        Default ``0.0`` -- a flat ground plane, and any backend without a
+        heightfield. The MuJoCo backend overrides this to sample a
+        ``create_world(terrain=...)`` heightfield so that height-based locomotion
+        predicates (:func:`~strands_robots.simulation.predicates.base_below_z`)
+        measure a base's clearance above the *local* ground instead of an
+        absolute world z -- an absolute test silently misses a collapse on a
+        raised terrain plateau (the base still sits above a flat-ground
+        threshold). Not a public tool action.
+        """
+        return 0.0
+
     def _coerce_action(
         self, action: dict[str, Any] | Sequence[float], robot_name: str
     ) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:

--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -1393,6 +1393,65 @@ class PhysicsMixin:
             ],
         }
 
+    def _ground_height_at(self, x: float, y: float) -> float:
+        """Terrain surface height (world z) beneath world ``(x, y)``.
+
+        Samples a ``create_world(terrain=...)`` MuJoCo ``<hfield>`` so a
+        height-based locomotion predicate measures a base's clearance above the
+        *local* terrain rather than an absolute world z. Returns ``0.0`` when no
+        heightfield is present (a flat ground plane) and the hfield's base level
+        for a point outside the terrain patch. Bilinearly interpolates the grid.
+        The terrain ground geom is static (world-aligned, welded to the
+        worldbody), so its pose and heightfield are constant after compile.
+        """
+        world = self._world
+        if world is None or world._model is None or world._data is None:
+            return 0.0
+        model, data = world._model, world._data
+        if model.nhfield == 0:
+            return 0.0
+        mj = _ensure_mujoco()
+        hgeom = -1
+        for g in range(model.ngeom):
+            if model.geom_type[g] == mj.mjtGeom.mjGEOM_HFIELD:
+                hgeom = g
+                break
+        if hgeom < 0:
+            return 0.0
+        hid = int(model.geom_dataid[hgeom])
+        if hid < 0:
+            return 0.0
+        gx, gy, gz = (float(v) for v in data.geom_xpos[hgeom])
+        rx, ry, elev = (float(v) for v in model.hfield_size[hid][:3])
+        nrow = int(model.hfield_nrow[hid])
+        ncol = int(model.hfield_ncol[hid])
+        if nrow < 2 or ncol < 2 or rx <= 0.0 or ry <= 0.0:
+            return gz
+        adr = int(model.hfield_adr[hid])
+        grid = np.asarray(model.hfield_data[adr : adr + nrow * ncol], dtype=float).reshape(nrow, ncol)
+        # MuJoCo <hfield> userdata is row-major, row 0 -> min y and col 0 -> min
+        # x, the grid spanning +-radius about the geom origin. Map (x, y) to a
+        # fractional (row, col) and bilinearly interpolate the normalized height.
+        u = (x - gx + rx) / (2.0 * rx)  # 0..1 across x (columns)
+        v = (y - gy + ry) / (2.0 * ry)  # 0..1 across y (rows)
+        if u < 0.0 or u > 1.0 or v < 0.0 or v > 1.0:
+            return gz  # off the terrain patch -> its flush (base) level
+        fc = u * (ncol - 1)
+        fr = v * (nrow - 1)
+        c0 = int(math.floor(fc))
+        r0 = int(math.floor(fr))
+        c1 = min(c0 + 1, ncol - 1)
+        r1 = min(r0 + 1, nrow - 1)
+        tc = fc - c0
+        tr = fr - r0
+        h = (
+            grid[r0, c0] * (1.0 - tc) * (1.0 - tr)
+            + grid[r0, c1] * tc * (1.0 - tr)
+            + grid[r1, c0] * (1.0 - tc) * tr
+            + grid[r1, c1] * tc * tr
+        )
+        return gz + elev * float(h)
+
     # Export Model XML
 
     def export_xml(self, output_path: str | None = None) -> dict[str, Any]:

--- a/strands_robots/simulation/predicates.py
+++ b/strands_robots/simulation/predicates.py
@@ -829,8 +829,30 @@ def _base_tipped(tol: float = 0.15, robot: str | None = None) -> BoolPredicate:
     return check
 
 
+def _ground_height(sim: SimEngine, x: float, y: float) -> float:
+    """Local terrain surface height (world z) beneath ``(x, y)``; ``0.0`` on flat ground.
+
+    A height/fall predicate must measure a base's clearance above the ground
+    *beneath it*, not an absolute world z: on a raised-terrain heightfield
+    (``create_world(terrain=...)``) a collapsed robot on a plateau still has an
+    absolute base z above a flat-ground threshold, so an absolute test silently
+    misses the fall. Reads the backend's ``_ground_height_at`` hook (``0.0`` for
+    flat ground / a backend with no heightfield); a sim lacking the hook
+    degrades to ``0.0`` so flat-ground behaviour is unchanged and the predicate
+    never raises.
+    """
+    fn = getattr(sim, "_ground_height_at", None)
+    if fn is None:
+        return 0.0
+    try:
+        return float(fn(x, y))
+    except Exception as e:  # noqa: BLE001 - predicates never raise
+        logger.debug("_ground_height_at(%.3f, %.3f) failed: %s", x, y, e)
+        return 0.0
+
+
 def _base_below_z(z: float, robot: str | None = None) -> BoolPredicate:
-    """True when a floating base's world height has dropped below ``z``.
+    """True when a floating base's height ABOVE THE LOCAL GROUND drops below ``z``.
 
     The height counterpart of :func:`_base_tipped`, and the second half of a
     complete floating-base fall termination: ``base_tipped`` fires when the base
@@ -845,17 +867,23 @@ def _base_below_z(z: float, robot: str | None = None) -> BoolPredicate:
             - {predicate: base_tipped, tol: 0.7}
             - {predicate: base_below_z, z: 0.3}
 
-    Reads ``get_observation``'s ``base_pos`` z (world frame) - the same
-    embodiment-agnostic floating-base surface the ``base_*`` reward terms and
-    ``base_tipped`` read - so it needs no base body name and works on a mobile
-    base whose free joint is unnamed, unlike ``body_below_z`` which resolves a
-    specific body by name (a name a mobile base's unnamed free joint does not
-    expose). It is the base-surface, name-free analogue of
-    ``body_below_z(<base body>, z)``.
+    Reads ``get_observation``'s ``base_pos`` - the same embodiment-agnostic
+    floating-base surface the ``base_*`` reward terms and ``base_tipped`` read -
+    so it needs no base body name and works on a mobile base whose free joint is
+    unnamed, unlike ``body_below_z`` which resolves a specific body by name (a
+    name a mobile base's unnamed free joint does not expose). It is the
+    base-surface, name-free analogue of ``body_below_z(<base body>, z)``.
 
-    ``z`` is the collapse height in metres; a fall termination sets it well
-    below the standing base height (a G1 pelvis stands ~0.74 m, so ``z=0.3``
-    catches a collapse). Requires a robot with a floating base; a fixed-base arm
+    The height is measured ABOVE THE LOCAL GROUND beneath the base, not as an
+    absolute world z: on a raised-terrain heightfield (``create_world(terrain=
+    ...)``, the terrain curriculum) a collapse onto a plateau leaves the base
+    above a flat-ground threshold, so an absolute test would silently miss the
+    fall. The local terrain height is subtracted (``0.0`` on a flat ground plane
+    / a backend with no heightfield, so flat-ground behaviour is unchanged).
+
+    ``z`` is the collapse clearance in metres (height of the base above the
+    ground beneath it); a fall termination sets it well below the standing base
+    height (a G1 pelvis stands ~0.74 m, so ``z=0.3`` catches a collapse). Requires a robot with a floating base; a fixed-base arm
     has no base position, so the predicate degrades to ``False`` (never
     collapsed -> never spuriously fails an episode) and the missing base is
     logged once. ``robot`` selects the robot in a multi-robot scene (default:
@@ -868,7 +896,11 @@ def _base_below_z(z: float, robot: str | None = None) -> BoolPredicate:
         pos = _base_position(sim, rname)
         if pos is None:
             return False
-        return pos[2] < zt
+        # Height ABOVE THE LOCAL GROUND, not absolute world z: on raised terrain
+        # (create_world(terrain=...)) a collapse leaves the base above a
+        # flat-ground threshold, so an absolute test misses the fall. On flat
+        # ground _ground_height is 0.0 and this reduces to the world height.
+        return (pos[2] - _ground_height(sim, pos[0], pos[1])) < zt
 
     return check
 

--- a/tests/simulation/test_base_below_z_terrain.py
+++ b/tests/simulation/test_base_below_z_terrain.py
@@ -1,0 +1,138 @@
+"""Regression tests: ``base_below_z`` measures clearance above the LOCAL ground.
+
+``base_below_z`` (#1233) is the height-collapse half of a floating-base fall
+termination -- "the torso dropped to the floor, end the episode". It read an
+ABSOLUTE world z, which is correct only on a flat ground plane. Once a
+locomotion task runs on a raised-terrain heightfield
+(``create_world(terrain=...)``, the terrain curriculum) an absolute test
+silently MISSES a collapse: a robot that has fallen onto a 0.16 m pyramid
+plateau still has an absolute base z (~0.26 m) above the flat-ground collapse
+threshold (0.18 m for the Go2), so the episode never terminates.
+
+The predicate now measures the base's height ABOVE THE LOCAL GROUND beneath it
+(``base z - _ground_height_at(x, y)``). On flat ground / a backend without a
+heightfield the local ground height is ``0.0`` and the behaviour is byte-for-byte
+unchanged; on a heightfield it samples the terrain so a collapse on a plateau is
+detected. These tests pin both the ``_ground_height_at`` heightfield sampling
+(ground truth against a known pyramid) and the terrain-relative predicate, and
+guard the flat-ground backward-compatibility. They are GL-free
+(``get_observation`` with ``skip_images``) so they run in CI without a display.
+"""
+
+import os
+import tempfile
+
+import mujoco
+import pytest
+
+from strands_robots.simulation.mujoco.simulation import Simulation
+from strands_robots.simulation.predicates import make_predicate
+from strands_robots.simulation.terrain import terrain_elevation
+
+# A floating base (NAMED free joint) + one actuated hinge; get_observation
+# surfaces base_pos for it. No own ground plane: the strands world supplies the
+# (flat or terrain) ground.
+NAMED_BASE_XML = """
+<mujoco model="test_named_base_terrain">
+  <compiler angle="radian" autolimits="true"/>
+  <option timestep="0.002"/>
+  <worldbody>
+    <light name="main" pos="0 0 3" dir="0 0 -1"/>
+    <body name="pelvis" pos="0 0 0.8">
+      <freejoint name="floating_base_joint"/>
+      <geom type="box" size="0.1 0.1 0.1" rgba="0.3 0.3 0.8 1"/>
+      <body name="thigh" pos="0 0 -0.1">
+        <geom type="capsule" size="0.03" fromto="0 0 0 0 0 -0.3" rgba="0.8 0.3 0.3 1"/>
+        <joint name="hip" type="hinge" axis="0 1 0" range="-1.5 1.5"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <motor name="hip_act" joint="hip"/>
+  </actuator>
+</mujoco>
+"""
+
+
+def _write(xml: str) -> str:
+    d = tempfile.mkdtemp()
+    p = os.path.join(d, "model.xml")
+    with open(p, "w") as f:
+        f.write(xml)
+    return p
+
+
+def _set_base_xy_z(sim, x: float, y: float, z: float) -> None:
+    """Place the (only) free joint at world ``(x, y, z)``, upright."""
+    model, data = sim._world._model, sim._world._data
+    jid = -1
+    for j in range(model.njnt):
+        if model.jnt_type[j] == mujoco.mjtJoint.mjJNT_FREE:
+            jid = j
+            break
+    assert jid >= 0
+    qadr = int(model.jnt_qposadr[jid])
+    data.qpos[qadr : qadr + 7] = [x, y, z, 1.0, 0.0, 0.0, 0.0]
+    mujoco.mj_forward(model, data)
+
+
+def test_ground_height_at_is_zero_on_flat_ground():
+    """A flat ground plane (no heightfield) reports local ground height 0.0."""
+    sim = Simulation(tool_name="test_ground_flat", mesh=False)
+    sim.create_world(ground_plane=True)
+    try:
+        assert sim._ground_height_at(0.0, 0.0) == 0.0
+        assert sim._ground_height_at(3.0, -2.0) == 0.0
+    finally:
+        sim.cleanup()
+
+
+def test_ground_height_at_samples_the_terrain_heightfield():
+    """On a pyramid the centre sits at the peak elevation, the edge / off-field at 0."""
+    sim = Simulation(tool_name="test_ground_terrain", mesh=False)
+    sim.create_world(ground_plane=True, terrain="pyramid", difficulty=2.0)
+    try:
+        peak = terrain_elevation(2.0)  # pyramid centre is the highest plateau (1.0)
+        assert sim._ground_height_at(0.0, 0.0) == pytest.approx(peak, abs=1e-6)
+        # The outer ring / off-field is flush with z=0 (the base slab top).
+        assert sim._ground_height_at(4.9, 4.9) == pytest.approx(0.0, abs=1e-6)
+        assert sim._ground_height_at(100.0, 0.0) == pytest.approx(0.0, abs=1e-6)
+        # Peak scales with the difficulty curriculum knob.
+        assert peak == pytest.approx(2.0 * terrain_elevation(1.0), abs=1e-9)
+    finally:
+        sim.cleanup()
+
+
+def test_base_below_z_detects_a_collapse_on_raised_terrain():
+    """A base collapsed onto a raised plateau trips base_below_z (missed by an absolute z)."""
+    sim = Simulation(tool_name="test_collapse_terrain", mesh=False)
+    sim.create_world(ground_plane=True, terrain="pyramid", difficulty=2.0)
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    try:
+        ground = sim._ground_height_at(0.0, 0.0)
+        assert ground > 0.1  # a genuinely raised plateau
+        pred = make_predicate("base_below_z", z=0.18)
+        # Collapsed onto the plateau: absolute z (ground + 0.1) is ABOVE 0.18 --
+        # an absolute test would miss the fall -- but the clearance (0.1) is below.
+        _set_base_xy_z(sim, 0.0, 0.0, ground + 0.1)
+        assert pred(sim) is True
+        # Standing tall on the same plateau is not a collapse.
+        _set_base_xy_z(sim, 0.0, 0.0, ground + 0.8)
+        assert pred(sim) is False
+    finally:
+        sim.cleanup()
+
+
+def test_base_below_z_unchanged_on_flat_ground():
+    """Flat-ground behaviour is byte-for-byte the absolute-z test (backward compat)."""
+    sim = Simulation(tool_name="test_flat_compat", mesh=False)
+    sim.create_world(ground_plane=True)
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    try:
+        pred = make_predicate("base_below_z", z=0.18)
+        _set_base_xy_z(sim, 0.0, 0.0, 0.26)  # above threshold on flat ground
+        assert pred(sim) is False
+        _set_base_xy_z(sim, 0.0, 0.0, 0.10)  # below threshold on flat ground
+        assert pred(sim) is True
+    finally:
+        sim.cleanup()


### PR DESCRIPTION
## Problem

`base_below_z` is the height-collapse half of a floating-base fall termination (the counterpart of `base_tipped`): it ends a locomotion episode when the robot's torso/pelvis has dropped to the ground. It compared the base's world `z` against an **absolute** threshold, which is correct only on a flat ground plane.

Once a locomotion task runs on a raised-terrain heightfield (`create_world(terrain=...)`, the terrain curriculum), an absolute test silently **misses** a collapse. Concretely, on a `pyramid` at `difficulty=2.0` the Go2 stands on a 0.16 m central plateau; a robot that has fallen there still has an absolute base `z` of ~0.26 m, which is **above** the Go2 collapse threshold `base_below_z(z=0.18)` — so the `failure` predicate never fires and the episode never terminates on the fall. `terrain.py`'s own `pyramid` docstring frames that terrain as being for exactly these omnidirectional locomotion tasks, so the intersection is intended.

## Fix

`base_below_z` now measures the base's height **above the local ground beneath it** (`base z − terrain_height(x, y)`) via a new backend hook `_ground_height_at(x, y)`:

- **MuJoCo backend** bilinearly samples the `create_world(terrain=...)` `<hfield>` (row-major, row 0 → min y / col 0 → min x, spanning ±radius; surface z = `geom_z + elevation * height`).
- **Base default** (and any backend without a heightfield — Newton/Isaac, or flat MuJoCo where `nhfield == 0`) returns `0.0`, so the predicate reduces to the previous absolute-z test and **flat-ground behaviour is byte-for-byte unchanged**.
- A point outside the terrain patch returns the hfield's flush base level; the predicate helper degrades to `0.0` if a sim lacks the hook, so predicates never raise.

Only the height-collapse predicate needs this; `base_tipped` (orientation) and `base_beyond_x/y` (horizontal progress) are terrain-independent and are untouched. This is prerequisite groundwork for running the `*_walk_forward` locomotion benchmarks on the terrain curriculum.

## Verification (real MuJoCo, `MUJOCO_GL=egl`)

`_ground_height_at` on a `pyramid` `difficulty=2.0` heightfield: centre `(0,0)` = **0.1600 m** (peak), edge `(4.9,4.9)` = 0.0, off-field = 0.0, flat ground = 0.0 (matches `terrain_elevation(2.0)` and the compiled `hfield_size[2]`).

`base_below_z(z=0.18)` on that plateau: a base collapsed at `z=0.26` (clearance 0.10) now reads **True** (was False — the missed fall); standing at `z=0.96` reads False; and on flat ground `z=0.26 → False` / `z=0.10 → True`, identical to before.

## Tests

New `tests/simulation/test_base_below_z_terrain.py` (GL-free, real inline floating-base MJCF):
- `_ground_height_at` heightfield sampling ground truth (pyramid centre/edge/off-field; flat = 0; scales with the `difficulty` knob).
- Collapse-on-raised-terrain detection — **fails before this change** (`assert False is True`, the missed fall), passes after.
- Standing-on-plateau is not a collapse.
- Flat-ground backward-compatibility (unchanged).

Local gate green: `ruff check` + `ruff format --check` + `mypy` clean on the changed files; the base-predicate / reward / benchmark / cross-backend suites (100 tests, incl. Newton parity) pass.