### PR TITLE
fix(sim): run_policy single-robot policy binding is fail-soft like the multi-robot path

### DIFF
--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -1031,8 +1031,18 @@ class SimEngine(ABC):
             # Caller is responsible for policy.set_robot_state_keys(...) if needed,
             # but we set it here defensively so the semantics match the provider path.
             policy = policy_object
-        policy.set_robot_state_keys(self.robot_action_keys(robot_name))
-        self.bind_policy_sim_context(policy, robot_name)
+        # set_robot_state_keys + sim-context binding are best-effort policy
+        # configuration: a raising robot_action_keys (a backend quirk, a world
+        # torn down mid-setup) must not crash the whole rollout. A genuine
+        # wrong-embodiment mismatch is surfaced far more actionably downstream
+        # by PolicyRunner's fail-fast probe ("the robot has not moved"). This
+        # matches the guarded binding in MujocoSimulation.run_policy's
+        # multi-robot path.
+        try:
+            policy.set_robot_state_keys(self.robot_action_keys(robot_name))
+            self.bind_policy_sim_context(policy, robot_name)
+        except Exception as exc:  # noqa: BLE001 - non-fatal policy configuration
+            logger.debug("policy binding for %r failed: %s", robot_name, exc)
 
         # Auto-install any action controller this policy needs to run correctly
         # on this scene (e.g. the WBC torque shim on a position-servo G1). The

--- a/tests/simulation/test_policy_runner_action_keys_probe_failsoft.py
+++ b/tests/simulation/test_policy_runner_action_keys_probe_failsoft.py
@@ -1,0 +1,91 @@
+"""Fail-soft contract: a raising ``robot_action_keys`` must not mask fail-fast.
+
+``PolicyRunner`` fails fast when EVERY step of the opening probe window drives
+zero actuators (100% unresolved keys -- the robot cannot move). While counting
+that failure and while building the diagnostic, the runner calls
+``SimEngine.robot_action_keys`` twice:
+
+* once up front to seed the per-actuator resolution counters, and
+* once again when the probe trips, to name the robot's valid actuator/joint
+  names in the raised error.
+
+Both calls are best-effort: the resolution stats and the diagnostic hint are a
+convenience, never a correctness invariant. If ``robot_action_keys`` itself
+raises (a backend quirk, a mid-rollout world teardown), that secondary failure
+must NOT replace the primary, actionable "the robot has not moved" signal with
+an opaque traceback. This pins that fail-soft guarantee end to end through the
+public MuJoCo ``run_policy`` surface: with ``robot_action_keys`` forced to raise,
+a wrong-embodiment policy still surfaces the fail-fast diagnostic (with an empty
+valid-keys list, the cached fallback) rather than the backend's raised error.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+from strands_robots.policies.base import Policy
+from strands_robots.simulation.mujoco.simulation import Simulation
+
+
+class _WrongEmbodimentPolicy(Policy):
+    """Emits a fixed key that resolves to no actuator on the target robot."""
+
+    @property
+    def provider_name(self) -> str:
+        return "wrong_embodiment_test"
+
+    @property
+    def requires_images(self) -> bool:
+        return False
+
+    def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
+        pass
+
+    async def get_actions(
+        self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any
+    ) -> list[dict[str, Any]]:
+        return [{"joint_that_does_not_exist": 0.5}]
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(mesh=False)
+    s.create_world()
+    s.add_robot("so101")
+    yield s
+    s.cleanup()
+
+
+def test_raising_robot_action_keys_does_not_mask_fail_fast(sim, monkeypatch):
+    """robot_action_keys raising -> still the fail-fast signal, not its error."""
+
+    def _boom(robot_name: str) -> list[str]:
+        raise RuntimeError("robot_action_keys probe unavailable")
+
+    # Patch both the stats-seeding call and the diagnostic-building call.
+    monkeypatch.setattr(sim, "robot_action_keys", _boom)
+
+    result = sim.run_policy(
+        robot_name="so101",
+        policy_object=_WrongEmbodimentPolicy(),
+        n_steps=50,  # would run 50 steps if the probe never tripped
+        control_frequency=20.0,
+        fast_mode=True,
+    )
+
+    assert result["status"] == "error", result
+    text = result["content"][0]["text"]
+    # The PRIMARY fail-fast diagnostic is what surfaces, not the secondary
+    # RuntimeError from the raising robot_action_keys.
+    assert "first 3 action steps" in text
+    assert "has not moved" in text
+    assert "get_features" in text
+    assert "probe unavailable" not in text
+    # The offending emitted key is still named (fail-soft did not lose it).
+    assert "joint_that_does_not_exist" in text
+    # Bailed in the probe window; did NOT run the full 50-step episode.
+    assert "50 steps" not in text


### PR DESCRIPTION
## Problem

`SimEngine.run_policy` binds a policy before the rollout:

```python
policy.set_robot_state_keys(self.robot_action_keys(robot_name))
self.bind_policy_sim_context(policy, robot_name)
```

The multi-robot binding in `MujocoSimulation.run_policy` wraps this exact pair in a `try/except` and logs at debug, with a comment stating it is non-fatal and "mirrors run_policy defensiveness". But the single-robot base path did **not** guard it. So a `robot_action_keys` that raises (a backend quirk, or a world torn down mid-setup) crashed the entire rollout with an opaque traceback instead of letting the runner's fail-fast probe surface the actionable `"...the robot has not moved..."` diagnostic. The two `run_policy` code paths diverged for the same failure, and the multi-robot comment's claim about mirroring did not actually hold.

## Change

Guard the single-robot binding the same way so both paths behave identically. Policy configuration here is best-effort: a genuine wrong-embodiment mismatch is still caught loudly downstream by `PolicyRunner`'s 100%-unresolved fail-fast probe, which names the offending keys and points at `get_features`.

## Test

`tests/simulation/test_policy_runner_action_keys_probe_failsoft.py` drives `run_policy` with `robot_action_keys` forced to raise and asserts the fail-fast diagnostic surfaces (`"first 3 action steps"`, `"has not moved"`, `get_features`, the offending key name) rather than the secondary `RuntimeError`. Pre-fix the test crashes with the raised `RuntimeError`; post-fix it passes. It also exercises `PolicyRunner`'s own best-effort `robot_action_keys` guards (per-actuator stats seeding + fail-fast diagnostic construction), which had no coverage before.

## Verification

- `hatch run lint` clean (785 files, no issues; ruff + mypy).
- `MUJOCO_GL=egl pytest tests/simulation/` -> 2405 passed, 141 skipped.

No behavior change for valid policies; only the error path is affected, so no rollout artifact applies.