### PR TITLE
test(sim): pin Isaac description-loader geometry extraction (URDF/MJCF/LIBERO scene)

### DIFF
--- a/tests/simulation/isaac/test_description_loader_geometry.py
+++ b/tests/simulation/isaac/test_description_loader_geometry.py
@@ -1,0 +1,284 @@
+"""Geometry extraction contracts for the Isaac description-file loaders.
+
+These pin the pure-stdlib parsing paths of
+:mod:`strands_robots.simulation.isaac.loaders` -- the halves that turn a
+URDF / MJCF / LIBERO scene into ``ProceduralRobot`` / ``SceneObject`` values
+without needing Isaac Sim, ``pxr``, or ``mujoco`` installed.
+
+Focus areas (verified against the shipped loader behavior):
+  * ``load_mjcf_scene_objects`` -- the LIBERO scene -> box-AABB extraction:
+    floor / robot skipping, static-vs-movable classification, nested-body
+    AABB folding, per-primitive AABB math, and the mesh-only fallback.
+  * ``load_mjcf`` / ``load_urdf`` -- per-primitive shape extraction across
+    box / sphere / cylinder / capsule / mesh, joint-type mapping, and the
+    explicit fail-loud guards (no silent phantom robots -- see the loader
+    module docstring).
+  * ``load_usd`` -- the file-existence guard and the ``pxr`` import gate.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from strands_robots.simulation.isaac.loaders import (
+    SceneObject,
+    load_mjcf,
+    load_mjcf_scene_objects,
+    load_urdf,
+    load_usd,
+)
+
+
+def _write(tmp_path, name: str, text: str) -> str:
+    path = tmp_path / name
+    path.write_text(text)
+    return str(path)
+
+
+# A robosuite-compiled LIBERO scene exercising every classification branch:
+# floor (exact skip), robot0_* (prefix skip), a nested static fixture whose
+# collision geom lives in a child body, a movable object via <freejoint>, a
+# movable object via <joint type="free">, and a mesh-only body (no analytic
+# geometry -> default-box fallback).
+_LIBERO_SCENE = """<mujoco model="libero_task">
+  <worldbody>
+    <body name="floor"><geom type="plane" size="5 5 0.1"/></body>
+    <body name="robot0_base" pos="0 0 0"><geom type="box" size="0.1 0.1 0.1" group="0"/></body>
+    <body name="living_room_table" pos="1 0 0.4" quat="0.707 0 0 0.707">
+      <geom type="box" size="0.5 0.3 0.02" group="1"/>
+      <body name="table_col" pos="0 0 -0.4">
+        <geom type="box" size="0.5 0.3 0.4" group="0"/>
+      </body>
+    </body>
+    <body name="porcelain_mug_1_main" pos="1 0 0.9">
+      <freejoint/>
+      <geom type="cylinder" size="0.04 0.05" group="0"/>
+    </body>
+    <body name="mesh_only_obj" pos="2 0 0.5">
+      <geom type="mesh" mesh="something"/>
+    </body>
+    <body name="ball_obj" pos="0 1 0.5">
+      <joint type="free"/>
+      <geom type="sphere" size="0.06" group="0"/>
+    </body>
+  </worldbody>
+</mujoco>"""
+
+
+class TestSceneObjectExtraction:
+    """``load_mjcf_scene_objects`` -> box-AABB approximation of LIBERO scenes."""
+
+    @pytest.fixture
+    def objects(self, tmp_path) -> dict[str, SceneObject]:
+        path = _write(tmp_path, "scene.xml", _LIBERO_SCENE)
+        return {o.name: o for o in load_mjcf_scene_objects(path)}
+
+    def test_floor_and_robot_bodies_are_skipped(self, objects):
+        # The floor is created by create_world; the robot is added separately.
+        assert "floor" not in objects
+        assert "robot0_base" not in objects
+        # Only the four real task bodies survive.
+        assert set(objects) == {
+            "living_room_table",
+            "porcelain_mug_1_main",
+            "mesh_only_obj",
+            "ball_obj",
+        }
+
+    def test_nested_fixture_aabb_folds_child_body_offset(self, objects):
+        # The table's collision geom lives in a child body offset by z=-0.4;
+        # the AABB must fold that offset in (union of parent group=1 box and
+        # the child group=0 box), and the world position is body pos + centre.
+        table = objects["living_room_table"]
+        assert table.is_static is True
+        assert table.size == pytest.approx((1.0, 0.6, 0.82))
+        assert table.position == pytest.approx((1.0, 0.0, 0.01))
+        # The body-level quat is preserved as [w, x, y, z].
+        assert table.quat == pytest.approx((0.707, 0.0, 0.0, 0.707))
+
+    def test_freejoint_body_is_movable_with_cylinder_aabb(self, objects):
+        mug = objects["porcelain_mug_1_main"]
+        assert mug.is_static is False
+        # cylinder size (radius=0.04, half-length=0.05) -> full box 0.08 x 0.08 x 0.10.
+        assert mug.size == pytest.approx((0.08, 0.08, 0.10))
+        assert mug.position == pytest.approx((1.0, 0.0, 0.9))
+
+    def test_free_joint_type_also_marks_movable(self, objects):
+        ball = objects["ball_obj"]
+        assert ball.is_static is False
+        # sphere radius 0.06 -> full box 0.12 on each axis.
+        assert ball.size == pytest.approx((0.12, 0.12, 0.12))
+
+    def test_mesh_only_body_falls_back_to_default_box(self, objects):
+        # No analytic collision geom -> a small default box at the body origin.
+        obj = objects["mesh_only_obj"]
+        assert obj.size == pytest.approx((0.05, 0.05, 0.05))
+        assert obj.position == pytest.approx((2.0, 0.0, 0.5))
+        assert obj.is_static is True
+
+    def test_capsule_extends_by_radius_ellipsoid_and_short_cylinder(self, tmp_path):
+        # These primitives are not covered by the main scene; pin their AABBs.
+        scene = """<mujoco model="prims"><worldbody>
+          <body name="cap"><freejoint/><geom type="capsule" size="0.1 0.2" group="0"/></body>
+          <body name="elli"><geom type="ellipsoid" size="0.1 0.2 0.3" group="0"/></body>
+          <body name="cyl1"><geom type="cylinder" size="0.05" group="0"/></body>
+        </worldbody></mujoco>"""
+        objs = {o.name: o for o in load_mjcf_scene_objects(_write(tmp_path, "p.xml", scene))}
+        # capsule half-length 0.2 grows by radius 0.1 along z -> full z = 0.6.
+        assert objs["cap"].size == pytest.approx((0.2, 0.2, 0.6))
+        # ellipsoid uses its three semi-axes directly.
+        assert objs["elli"].size == pytest.approx((0.2, 0.4, 0.6))
+        # a single-size cylinder degrades to a radius-cube.
+        assert objs["cyl1"].size == pytest.approx((0.1, 0.1, 0.1))
+
+    def test_malformed_scene_and_missing_worldbody_fail_loud(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            load_mjcf_scene_objects("/nonexistent/scene.xml")
+        with pytest.raises(ValueError, match="root element must be <mujoco>"):
+            load_mjcf_scene_objects(_write(tmp_path, "bad.xml", "<foo/>"))
+        with pytest.raises(ValueError, match="has no <worldbody>"):
+            load_mjcf_scene_objects(_write(tmp_path, "nowb.xml", "<mujoco/>"))
+
+
+class TestMjcfRobotLoader:
+    """``load_mjcf`` -> single-robot body/joint topology + shape extraction."""
+
+    def test_walks_bodies_and_maps_joint_types(self, tmp_path):
+        mjcf = """<mujoco model="arm"><worldbody>
+          <body name="base"><geom type="sphere" size="0.1"/>
+            <body name="link1" pos="0 0 0.1">
+              <joint name="j1" type="hinge" axis="0 0 1" range="-1 1" damping="0.5" armature="0.02"/>
+              <geom type="cylinder" size="0.02 0.1"/>
+              <body name="link2" pos="0 0 0.1">
+                <joint name="j2" type="slide" axis="1 0 0"/>
+                <geom type="box" size="0.03 0.03 0.03"/>
+              </body>
+            </body>
+          </body>
+        </worldbody></mujoco>"""
+        robot = load_mjcf(_write(tmp_path, "arm.xml", mjcf))
+        # A synthetic "world" root body precedes the file's bodies.
+        assert [b.name for b in robot.bodies] == ["world", "base", "link1", "link2"]
+        # hinge -> revolute, slide -> prismatic; parent/child resolved to indices.
+        jtypes = {j.name: j.joint_type for j in robot.joints}
+        assert jtypes == {"j1": "revolute", "j2": "prismatic"}
+        j1 = next(j for j in robot.joints if j.name == "j1")
+        assert (j1.limit_lower, j1.limit_upper) == pytest.approx((-1.0, 1.0))
+        # slide joint without a <range> keeps the default +/- pi limits.
+        j2 = next(j for j in robot.joints if j.name == "j2")
+        assert (j2.limit_lower, j2.limit_upper) == pytest.approx((-3.14159, 3.14159))
+
+    def test_geom_primitives_map_to_shapes(self, tmp_path):
+        mjcf = """<mujoco model="shapes"><worldbody>
+          <body name="a"><geom type="sphere" size="0.1"/></body>
+          <body name="b"><geom type="box" size="0.03 0.04 0.05"/></body>
+          <body name="c"><geom type="capsule" size="0.02 0.1"/></body>
+          <body name="d"><geom type="plane" size="1 1 1"/></body>
+        </worldbody></mujoco>"""
+        robot = load_mjcf(_write(tmp_path, "s.xml", mjcf))
+        shapes = {b.name: (b.shape, b.shape_size) for b in robot.bodies}
+        assert shapes["a"] == ("sphere", (0.1,))
+        assert shapes["b"] == ("box", (0.03, 0.04, 0.05))
+        assert shapes["c"] == ("capsule", (0.02, 0.1))
+        # non-analytic geoms (plane) degrade to a small kinematic box.
+        assert shapes["d"] == ("box", (0.05, 0.05, 0.05))
+
+    def test_unknown_joint_type_is_rejected(self, tmp_path):
+        mjcf = """<mujoco><worldbody><body name="b">
+          <joint name="j" type="weird"/><geom type="box" size="1 1 1"/>
+        </body></worldbody></mujoco>"""
+        with pytest.raises(ValueError, match="unknown joint type"):
+            load_mjcf(_write(tmp_path, "j.xml", mjcf))
+
+    def test_empty_worldbody_is_a_phantom_robot_guard(self, tmp_path):
+        with pytest.raises(ValueError, match="phantom robot guard"):
+            load_mjcf(_write(tmp_path, "e.xml", "<mujoco><worldbody/></mujoco>"))
+        with pytest.raises(ValueError, match="root element must be <mujoco>"):
+            load_mjcf(_write(tmp_path, "b.xml", "<foo/>"))
+
+
+class TestUrdfRobotLoader:
+    """``load_urdf`` -> link/joint topology, shape extraction, fail-loud guards."""
+
+    def test_joint_types_limits_and_shapes(self, tmp_path):
+        urdf = """<robot name="ur">
+          <link name="base"><inertial><mass value="2.0"/></inertial>
+            <collision><geometry><box size="0.1 0.1 0.1"/></geometry></collision></link>
+          <link name="l1"><visual><geometry><cylinder radius="0.02" length="0.3"/></geometry></visual></link>
+          <link name="l2"><collision><geometry><sphere radius="0.05"/></geometry></collision></link>
+          <link name="l3"><collision><geometry><mesh filename="x.stl"/></geometry></collision></link>
+          <joint name="j1" type="revolute"><parent link="base"/><child link="l1"/>
+            <axis xyz="0 1 0"/><limit lower="-2" upper="2"/><dynamics damping="0.3"/></joint>
+          <joint name="j2" type="continuous"><parent link="l1"/><child link="l2"/></joint>
+          <joint name="j3" type="prismatic"><parent link="l2"/><child link="l3"/>
+            <limit lower="0" upper="0.5"/></joint>
+        </robot>"""
+        robot = load_urdf(_write(tmp_path, "ur.urdf", urdf))
+        joints = {j.name: j for j in robot.joints}
+        # continuous collapses onto revolute; its limits stay at the default +/- pi.
+        assert joints["j2"].joint_type == "revolute"
+        assert (joints["j2"].limit_lower, joints["j2"].limit_upper) == pytest.approx((-3.14159, 3.14159))
+        assert joints["j3"].joint_type == "prismatic"
+        # j1 picks up its explicit axis, limits, and damping.
+        assert joints["j1"].axis == pytest.approx((0.0, 1.0, 0.0))
+        assert (joints["j1"].limit_lower, joints["j1"].limit_upper) == pytest.approx((-2.0, 2.0))
+        assert joints["j1"].damping == pytest.approx(0.3)
+        # Per-link shapes: box / cylinder / sphere primitives + mesh -> default box.
+        shapes = {b.name: (b.shape, b.shape_size) for b in robot.bodies}
+        assert shapes["base"] == ("box", (0.1, 0.1, 0.1))
+        assert shapes["l1"] == ("cylinder", (0.02, 0.3))
+        assert shapes["l2"] == ("sphere", (0.05,))
+        assert shapes["l3"] == ("box", (0.05, 0.05, 0.05))
+        # Inertial mass is read from the <mass> element (default 1.0 otherwise).
+        masses = {b.name: b.mass for b in robot.bodies}
+        assert masses["base"] == pytest.approx(2.0)
+        assert masses["l1"] == pytest.approx(1.0)
+
+    def test_fail_loud_guards(self, tmp_path):
+        with pytest.raises(ValueError, match="root element must be <robot>"):
+            load_urdf(_write(tmp_path, "root.urdf", "<foo/>"))
+        with pytest.raises(ValueError, match="duplicate <link"):
+            load_urdf(_write(tmp_path, "dup.urdf", '<robot name="r"><link name="a"/><link name="a"/></robot>'))
+        with pytest.raises(ValueError, match="phantom robot guard"):
+            load_urdf(_write(tmp_path, "empty.urdf", '<robot name="r"></robot>'))
+        with pytest.raises(ValueError, match="unknown joint type"):
+            load_urdf(
+                _write(
+                    tmp_path,
+                    "jt.urdf",
+                    '<robot name="r"><link name="a"/><link name="b"/>'
+                    '<joint name="j" type="screw"><parent link="a"/><child link="b"/></joint></robot>',
+                )
+            )
+        with pytest.raises(ValueError, match="unknown parent link"):
+            load_urdf(
+                _write(
+                    tmp_path,
+                    "pl.urdf",
+                    '<robot name="r"><link name="a"/>'
+                    '<joint name="j" type="fixed"><parent link="x"/><child link="a"/></joint></robot>',
+                )
+            )
+        with pytest.raises(ValueError, match="malformed XML"):
+            load_urdf(_write(tmp_path, "mal.urdf", "<robot name='r'><link"))
+
+
+class TestUsdLoaderGate:
+    """``load_usd`` guards run before any Isaac/pxr dependency is touched."""
+
+    def test_missing_file_raises_before_import(self):
+        with pytest.raises(FileNotFoundError, match="file not found"):
+            load_usd("/nonexistent/stage.usd")
+
+    def test_pxr_import_gate_has_install_hint(self, tmp_path):
+        # On hosts without pxr, loading an existing file must raise ImportError
+        # with an actionable install hint (never a silent phantom robot). When
+        # pxr is installed the gate does not apply, so skip.
+        try:
+            import pxr  # type: ignore[import-not-found]  # noqa: F401
+        except ImportError:
+            pass
+        else:
+            pytest.skip("pxr is installed; the import gate does not apply")
+        with pytest.raises(ImportError, match=r"usd-core"):
+            load_usd(_write(tmp_path, "stage.usda", "#usda 1.0\n"))


### PR DESCRIPTION
## Problem

The pure-stdlib parsing half of `strands_robots/simulation/isaac/loaders.py` was only 26% covered. Its module docstring explicitly advertises that these paths are "unit-testable on CPU-only CI without Isaac Sim installed", yet the geometry-extraction logic (`load_mjcf_scene_objects` and its AABB helpers, plus the `load_mjcf` / `load_urdf` shape+joint mappers) had no dedicated tests. That leaves the LIBERO-scene box-AABB approximation, the static-vs-movable classification, and the fail-loud phantom-robot guards unpinned - a regression in any of them (e.g. a sign error in the nested-body offset fold, or a silently-swallowed parse error) would ship undetected.

## Change

Adds `tests/simulation/isaac/test_description_loader_geometry.py` - a focused, behavior-pinning suite (no source changes). It exercises:

- **`load_mjcf_scene_objects`**: floor (exact) and `robot0_*` (prefix) skipping; `<freejoint>` and `<joint type="free">` both marking an object movable; nested-body collision-AABB folding with a child-body z offset; the mesh-only fallback to a default box; and per-primitive AABB math for box / sphere / cylinder / capsule (radius-extended) / ellipsoid.
- **`load_mjcf`**: depth-first body walk with the synthetic `world` root, `hinge->revolute` / `slide->prismatic` joint mapping, default `+/- pi` limits when `<range>` is absent, geom-primitive->shape extraction, and the `<worldbody>`-empty / wrong-root phantom-robot guards.
- **`load_urdf`**: `continuous->revolute` collapse, explicit axis/limit/damping extraction, per-link box/cylinder/sphere/mesh shapes, inertial mass, and the duplicate-link / unknown-joint-type / unknown-parent-link / malformed-XML / zero-link guards.
- **`load_usd`**: the file-existence guard and the `pxr` import gate with its actionable install hint (skipped when `pxr` is present).

Expected values were derived from the shipped loader behavior and the AABB math hand-checked.

## Coverage

`strands_robots/simulation/isaac/loaders.py`: **26% -> 75%** (303 -> 103 missing lines). The residual is the `load_usd` body, which requires the `[isaac]` extra (`pxr`) to exercise meaningfully.

## Tests

15 new tests, all green:

```
MUJOCO_GL=egl pytest tests/simulation/isaac/ -q
59 passed in 0.68s
```

`hatch run lint`: Success, no issues found in 786 source files.