### PR TITLE
fix(sim): base_height reward measures clearance above local terrain, not absolute z

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: `base_height` reward measures the base's clearance above the LOCAL terrain, not an absolute world z
+
+`base_height` is the legged_gym / IsaacLab base-height regularizer paired with
+`base_velocity` in a locomotion `dense_reward`: it rewards a floating base for
+holding its torso/pelvis near a target height and penalises crouching/diving so
+a velocity-tracking policy cannot cheat the forward-velocity reward by folding
+down. It scored the error against the base's ABSOLUTE world `z`, which is
+correct only on a flat ground plane. On a raised-terrain heightfield
+(`create_world(terrain=...)`, the terrain curriculum) an absolute test is wrong
+on two counts: a robot standing at its proper posture on a raised plateau has an
+absolute base `z` above the target, so it is spuriously penalised
+(`-(terrain height)^2` even at perfect posture); and the absolute zero-reward
+pose on the plateau is a deep CROUCH (clearance = target minus the terrain
+height), so the term actively REWARDS crouching on terrain, inverting the very
+anti-crouch incentive it exists to provide. `base_height` now measures the
+base's clearance ABOVE THE LOCAL GROUND beneath it (`base z` minus the terrain
+surface height at the base's `(x, y)`) via the `_ground_height_at` backend hook,
+mirroring the `base_below_z` fix. On a flat ground plane / a backend without a
+heightfield the local ground height is `0.0`, so flat-ground behaviour is
+byte-for-byte unchanged. With `base_below_z`, this makes the floating-base
+reward/predicate DSL correct on the terrain curriculum end to end.
+
 ### Fixed: `base_below_z` measures the base's clearance above the LOCAL terrain, not an absolute world z
 
 `base_below_z` is the height-collapse half of a floating-base fall termination

--- a/strands_robots/simulation/predicates.py
+++ b/strands_robots/simulation/predicates.py
@@ -1239,8 +1239,9 @@ def _base_height(target: float, weight: float = 1.0, robot: str | None = None) -
     """Negative squared base-height error - a locomotion-regularizer reward.
 
     Rewards a floating-base robot for keeping its base (torso/pelvis) near a
-    target WORLD height: ``-weight * (base_z - target) ** 2`` - 0 at the target
-    and growing more negative as the base deviates. Composed alongside
+    target height ABOVE THE LOCAL GROUND beneath it:
+    ``-weight * ((base_z - ground_z) - target) ** 2`` - 0 at the target and
+    growing more negative as the base deviates. Composed alongside
     ``base_velocity`` in a ``dense_reward`` list, it is the standard regularizer
     that stops a velocity-tracking policy from cheating the forward-velocity
     reward by crouching or diving (the legged_gym / IsaacLab ``base_height``
@@ -1248,12 +1249,22 @@ def _base_height(target: float, weight: float = 1.0, robot: str | None = None) -
     dive forward to maximise it - so a viable velocity-tracking reward pairs the
     two.
 
+    The height is measured ABOVE THE LOCAL GROUND, not as an absolute world z:
+    on a raised-terrain heightfield (``create_world(terrain=...)``, the terrain
+    curriculum) a robot standing at its proper posture on a plateau has an
+    absolute base z above the target, so an absolute test spuriously penalises
+    it - worse, it makes the reward *reward crouching* to the flat-ground
+    absolute height while on the plateau, inverting the anti-crouch incentive
+    this term exists to provide. The local terrain height is subtracted (``0.0``
+    on a flat ground plane / a backend with no heightfield, so flat-ground
+    behaviour is byte-for-byte unchanged).
+
     Reads ``get_observation``'s ``base_pos`` (world frame). ``target`` is the
-    desired base height in metres (task-specific: a G1 pelvis ~0.74 m, a Go2
-    trunk ~0.34 m). Requires a robot with a floating base; a fixed-base arm has
-    no base position, so the term degrades to ``0.0`` and the missing base is
-    logged once. ``robot`` selects the robot in a multi-robot scene (default:
-    the sole robot).
+    desired base height in metres, measured above the ground beneath the base
+    (task-specific: a G1 pelvis ~0.74 m, a Go2 trunk ~0.34 m). Requires a robot
+    with a floating base; a fixed-base arm has no base position, so the term
+    degrades to ``0.0`` and the missing base is logged once. ``robot`` selects
+    the robot in a multi-robot scene (default: the sole robot).
     """
     w = float(weight)
     tgt = float(target)
@@ -1263,7 +1274,12 @@ def _base_height(target: float, weight: float = 1.0, robot: str | None = None) -
         pos = _base_position(sim, rname)
         if pos is None:
             return 0.0
-        d = pos[2] - tgt
+        # Height ABOVE THE LOCAL GROUND, not absolute world z: on raised terrain
+        # (create_world(terrain=...)) a robot standing at its target posture on
+        # a plateau has an absolute base z above the target, so an absolute test
+        # spuriously penalises it (and rewards a crouch on the plateau). On flat
+        # ground _ground_height is 0.0 and this reduces to the world height.
+        d = (pos[2] - _ground_height(sim, pos[0], pos[1])) - tgt
         return -w * d * d
 
     return term

--- a/tests/simulation/test_base_height_reward_terrain.py
+++ b/tests/simulation/test_base_height_reward_terrain.py
@@ -1,0 +1,156 @@
+"""Regression tests: ``base_height`` measures clearance above the LOCAL ground.
+
+``base_height`` (the legged_gym / IsaacLab base-height regularizer) is the
+anti-crouch companion to ``base_velocity`` in a locomotion ``dense_reward``:
+``-weight * (clearance - target) ** 2`` rewards a floating base for holding its
+torso/pelvis near a target height and penalises crouching/diving so a policy
+cannot cheat the forward-velocity reward by folding down.
+
+It read an ABSOLUTE world z, which is correct only on a flat ground plane. Once
+a locomotion task runs on a raised-terrain heightfield
+(``create_world(terrain=...)``, the terrain curriculum) an absolute test is
+wrong on TWO counts: a robot standing at its proper posture on a raised plateau
+has an absolute base z above the target, so it is spuriously penalised; and the
+absolute zero-reward pose on the plateau is a deep CROUCH (clearance =
+target - terrain height), so the term actively REWARDS crouching on terrain -
+inverting the very anti-crouch incentive it exists to provide.
+
+The term now measures the base's height ABOVE THE LOCAL GROUND beneath it
+(``(base_z - ground_z) - target``). On flat ground / a backend without a
+heightfield the local ground height is ``0.0`` and behaviour is byte-for-byte
+unchanged; on a heightfield it samples the terrain so proper posture on a
+plateau scores 0 and a crouch is penalised. These tests are GL-free
+(``get_observation`` with ``skip_images``) so they run in CI without a display.
+This mirrors the ``base_below_z`` terrain fix (#1364) for the reward side.
+"""
+
+import os
+import tempfile
+
+import mujoco
+import pytest
+
+from strands_robots.simulation.mujoco.simulation import Simulation
+from strands_robots.simulation.predicates import make_predicate
+
+# A floating base (NAMED free joint) + one actuated hinge; get_observation
+# surfaces base_pos for it. No own ground plane: the strands world supplies the
+# (flat or terrain) ground.
+NAMED_BASE_XML = """
+<mujoco model="test_named_base_height_terrain">
+  <compiler angle="radian" autolimits="true"/>
+  <option timestep="0.002"/>
+  <worldbody>
+    <light name="main" pos="0 0 3" dir="0 0 -1"/>
+    <body name="pelvis" pos="0 0 0.8">
+      <freejoint name="floating_base_joint"/>
+      <geom type="box" size="0.1 0.1 0.1" rgba="0.3 0.3 0.8 1"/>
+      <body name="thigh" pos="0 0 -0.1">
+        <geom type="capsule" size="0.03" fromto="0 0 0 0 0 -0.3" rgba="0.8 0.3 0.3 1"/>
+        <joint name="hip" type="hinge" axis="0 1 0" range="-1.5 1.5"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <motor name="hip_act" joint="hip"/>
+  </actuator>
+</mujoco>
+"""
+
+_TARGET = 0.74  # a G1-pelvis-like target clearance above the ground beneath it
+
+
+def _write(xml: str) -> str:
+    d = tempfile.mkdtemp()
+    p = os.path.join(d, "model.xml")
+    with open(p, "w") as f:
+        f.write(xml)
+    return p
+
+
+def _set_base_xy_z(sim, x: float, y: float, z: float) -> None:
+    """Place the (only) free joint at world ``(x, y, z)``, upright."""
+    model, data = sim._world._model, sim._world._data
+    jid = -1
+    for j in range(model.njnt):
+        if model.jnt_type[j] == mujoco.mjtJoint.mjJNT_FREE:
+            jid = j
+            break
+    assert jid >= 0
+    qadr = int(model.jnt_qposadr[jid])
+    data.qpos[qadr : qadr + 7] = [x, y, z, 1.0, 0.0, 0.0, 0.0]
+    mujoco.mj_forward(model, data)
+
+
+def test_base_height_zero_at_proper_posture_on_raised_terrain():
+    """Standing at the target clearance ABOVE a plateau scores ~0 (missed by absolute z)."""
+    sim = Simulation(tool_name="test_bh_terrain", mesh=False)
+    sim.create_world(ground_plane=True, terrain="pyramid", difficulty=2.0)
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    try:
+        ground = sim._ground_height_at(0.0, 0.0)
+        assert ground > 0.1  # a genuinely raised plateau
+        term = make_predicate("base_height", target=_TARGET)
+        # Proper posture: base sits target metres ABOVE the plateau. The absolute
+        # base z (ground + target) is above target, so an absolute test scores
+        # -(ground ** 2); the terrain-relative term scores 0.
+        _set_base_xy_z(sim, 0.0, 0.0, ground + _TARGET)
+        assert term(sim) == pytest.approx(0.0, abs=1e-6)
+    finally:
+        sim.cleanup()
+
+
+def test_base_height_penalises_a_crouch_on_terrain_by_local_clearance():
+    """A crouch on the plateau is penalised by its local clearance error, not absolute z."""
+    sim = Simulation(tool_name="test_bh_crouch", mesh=False)
+    sim.create_world(ground_plane=True, terrain="pyramid", difficulty=2.0)
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    try:
+        ground = sim._ground_height_at(0.0, 0.0)
+        term = make_predicate("base_height", target=_TARGET)
+        # Crouched 0.1 m below the target CLEARANCE while on the plateau.
+        _set_base_xy_z(sim, 0.0, 0.0, ground + _TARGET - 0.1)
+        assert term(sim) == pytest.approx(-(0.1**2), abs=1e-6)
+        # weight scales the penalty linearly.
+        term5 = make_predicate("base_height", target=_TARGET, weight=5.0)
+        assert term5(sim) == pytest.approx(-5.0 * (0.1**2), abs=1e-6)
+    finally:
+        sim.cleanup()
+
+
+def test_base_height_rewards_proper_posture_over_a_crouch_on_terrain():
+    """The anti-crouch incentive holds on terrain: standing tall scores higher than a crouch.
+
+    This is the decisive semantic guard. Under the absolute-z bug the zero-reward
+    pose on a plateau is a deep crouch (clearance = target - terrain height), so
+    standing at proper posture scores WORSE than crouching - the incentive is
+    inverted. The terrain-relative term restores the correct ordering.
+    """
+    sim = Simulation(tool_name="test_bh_order", mesh=False)
+    sim.create_world(ground_plane=True, terrain="pyramid", difficulty=2.0)
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    try:
+        ground = sim._ground_height_at(0.0, 0.0)
+        term = make_predicate("base_height", target=_TARGET)
+        _set_base_xy_z(sim, 0.0, 0.0, ground + _TARGET)  # proper posture
+        proper = term(sim)
+        _set_base_xy_z(sim, 0.0, 0.0, ground + _TARGET - 0.15)  # crouched
+        crouch = term(sim)
+        assert proper > crouch  # proper posture is rewarded over a crouch on terrain
+    finally:
+        sim.cleanup()
+
+
+def test_base_height_unchanged_on_flat_ground():
+    """Flat-ground behaviour is byte-for-byte the absolute-z term (backward compat)."""
+    sim = Simulation(tool_name="test_bh_flat", mesh=False)
+    sim.create_world(ground_plane=True)
+    sim.add_robot("humanoid", urdf_path=_write(NAMED_BASE_XML))
+    try:
+        term = make_predicate("base_height", target=_TARGET)
+        _set_base_xy_z(sim, 0.0, 0.0, _TARGET)  # at target on flat ground
+        assert term(sim) == pytest.approx(0.0, abs=1e-6)
+        _set_base_xy_z(sim, 0.0, 0.0, 0.50)  # 0.24 m below target on flat ground
+        assert term(sim) == pytest.approx(-((0.50 - _TARGET) ** 2), abs=1e-6)
+    finally:
+        sim.cleanup()


### PR DESCRIPTION
## Problem

`base_height` is the legged_gym / IsaacLab base-height regularizer paired with `base_velocity` in a locomotion `dense_reward` — it rewards a floating base for holding its torso/pelvis near a target height and penalises crouching/diving so a velocity-tracking policy cannot cheat the forward-velocity reward by folding down.

It scored the error against the base's **absolute world `z`**, which is correct only on a flat ground plane. On a raised-terrain heightfield (`create_world(terrain=...)`, the terrain curriculum) an absolute test is wrong on two counts:

1. A robot standing at its **proper posture** on a raised plateau has an absolute base `z` above the target, so it is spuriously penalised.
2. The absolute zero-reward pose on the plateau is a deep **crouch** (clearance = target minus terrain height), so the term actively **rewards crouching** on terrain — inverting the very anti-crouch incentive it exists to provide.

Ground truth on a 0.16 m pyramid plateau, target 0.74 m (before the fix):

| pose (above the plateau) | reward |
|---|---|
| proper posture (clearance = target) | `-0.0256` = `-(0.16)^2` (should be ~0) |
| crouched 0.1 m below target | `-0.0036` (a *smaller* penalty than standing tall) |

Standing at proper posture scores **worse** than crouching — the incentive is inverted.

## Fix

`base_height` now measures the base's clearance **above the local ground beneath it** — `(base_z - ground_z) - target` — via the existing `_ground_height_at` backend hook, mirroring the `base_below_z` fix. The MuJoCo backend bilinearly samples the `create_world(terrain=...)` heightfield; the base default (and any backend without a heightfield) returns `0.0`, so **flat-ground behaviour is byte-for-byte unchanged**.

`base_height` was the last floating-base reward term reading an absolute `z` (`base_orientation` reads the quaternion; `base_velocity` / `base_beyond_{x,y}` are horizontal), so with `base_below_z` the floating-base reward/predicate DSL is now correct on the terrain curriculum end to end — a prerequisite for running the `*_walk_forward` benchmarks with a terrain-difficulty curriculum.

## Tests

New `tests/simulation/test_base_height_reward_terrain.py` (GL-free, real MuJoCo, `create_world(terrain="pyramid")`) — all fail before the fix, pass after:

- proper posture on a raised plateau scores ~0 (was `-(terrain height)^2`)
- a crouch on the plateau is penalised by its **local clearance** error, weight-scaled
- **anti-crouch ordering** guard: proper posture scores higher than a crouch on terrain (the inverted-incentive regression)
- flat-ground behaviour unchanged (backward compat)

Full base-reward / predicate / benchmark / cross-backend suite green (131 passed, incl. Newton parity); `ruff` + `mypy` clean.