### PR TITLE
fix(sim): Newton/Isaac create_world rejects a non-default difficulty with no terrain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: Newton / Isaac `create_world(difficulty=...)` rejects a non-default difficulty with no terrain instead of silently ignoring it
+
+The base `SimEngine.create_world` contract (and the MuJoCo backend) reject a
+`difficulty != 1.0` supplied with no `terrain` with an actionable error --
+`difficulty` only scales a heightfield terrain's peak elevation, so setting it
+without a terrain has no effect, and the contract surfaces that rather than
+silently having none. The Newton and Isaac backends accepted `difficulty` for
+signature parity but only rejected a non-None `terrain`; a non-default
+`difficulty` with no terrain was silently ignored and `create_world` returned
+`status: success` -- a caller ramping a terrain curriculum on the GPU (Newton)
+or Isaac backend got no terrain and no error. Both backends now reject it with
+an actionable message pointing at `create_simulation(backend="mujoco")` (the
+only backend with heightfield terrain) or omitting `difficulty`. A non-None
+`terrain` is still rejected first (the primary error on these backends), and
+the default `difficulty=1.0` is unchanged (a flat-ground no-op). Completes the
+`create_world(terrain=/difficulty=)` contract parity across all three backends.
+
 ### Fixed: `base_height` reward measures the base's clearance above the LOCAL terrain, not an absolute world z
 
 `base_height` is the legged_gym / IsaacLab base-height regularizer paired with

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -660,8 +660,12 @@ class IsaacSimulation(SimEngine):
             contract). Use ``create_simulation(backend="mujoco")`` for terrain.
         difficulty : float
             Terrain curriculum elevation scale (only meaningful together with
-            ``terrain``). Accepted for signature parity with the base contract
-            but inert here since the Isaac backend rejects ``terrain`` outright.
+            ``terrain``). Accepted for signature parity with the base contract.
+            Since the Isaac backend has no heightfield terrain, ``difficulty``
+            can never take effect, so a non-default (``!= 1.0``) value is
+            rejected with an actionable error (the base ``create_world``
+            contract: reject rather than silently ignore it) rather than
+            silently having no effect.
 
         Returns
         -------
@@ -678,6 +682,25 @@ class IsaacSimulation(SimEngine):
                             "(heightfield terrain, e.g. 'rough'/'stairs'/'pyramid'/'slope', is "
                             "currently MuJoCo-only); use create_simulation(backend='mujoco') for "
                             "terrain, or omit terrain for a flat ground plane."
+                        )
+                    }
+                ],
+            }
+        # Base create_world contract: reject a non-default difficulty with no
+        # terrain rather than silently ignoring it. On Isaac difficulty is
+        # doubly inert - there is no heightfield terrain for it to scale (a
+        # non-None terrain is already rejected above) - so any != 1.0 value is
+        # meaningless here; surface that instead of a status=success no-op.
+        if float(difficulty) != 1.0:
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            f"difficulty={difficulty!r} has no effect on the Isaac backend "
+                            "(it scales a heightfield terrain's elevation, and this backend "
+                            "has no heightfield terrain); use create_simulation(backend='mujoco') "
+                            "for a terrain curriculum, or omit difficulty for a flat ground plane."
                         )
                     }
                 ],

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -244,8 +244,12 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
                 ground yet, so a non-None value is rejected with an actionable
                 error.
             difficulty: Terrain curriculum elevation scale (MuJoCo backend
-                only, alongside ``terrain``); accepted for signature parity but
-                inert here since Newton rejects ``terrain`` outright.
+                only, alongside ``terrain``); accepted for signature parity with
+                the base contract. Since Newton has no heightfield terrain,
+                ``difficulty`` can never take effect, so a non-default
+                (``!= 1.0``) value is rejected with an actionable error (the base
+                ``create_world`` contract: reject rather than silently ignore it)
+                rather than silently having no effect.
 
         Returns:
             Status dict with a human-readable confirmation.
@@ -260,6 +264,25 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
                             "(heightfield terrain, e.g. 'rough'/'stairs'/'pyramid'/'slope', is MuJoCo-only); use "
                             "create_simulation(backend='mujoco') for terrain, or omit terrain "
                             "for a flat ground plane."
+                        )
+                    }
+                ],
+            }
+        # Base create_world contract: reject a non-default difficulty with no
+        # terrain rather than silently ignoring it. On Newton difficulty is
+        # doubly inert - there is no heightfield terrain for it to scale (a
+        # non-None terrain is already rejected above) - so any != 1.0 value is
+        # meaningless here; surface that instead of a status=success no-op.
+        if float(difficulty) != 1.0:
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            f"difficulty={difficulty!r} has no effect on the Newton backend "
+                            "(it scales a heightfield terrain's elevation, and this backend "
+                            "has no heightfield terrain); use create_simulation(backend='mujoco') "
+                            "for a terrain curriculum, or omit difficulty for a flat ground plane."
                         )
                     }
                 ],

--- a/tests/simulation/isaac/test_isaac_backend.py
+++ b/tests/simulation/isaac/test_isaac_backend.py
@@ -293,15 +293,31 @@ class TestIsaacSimulationConstruction:
 
     def test_create_world_difficulty_accepted_for_signature_parity(self):
         # ``difficulty`` is accepted (signature parity with the base contract);
-        # passing it must not raise TypeError. It is inert on Isaac (which
-        # rejects terrain outright), so with no terrain the call still degrades
-        # to the structured Isaac-Sim-absent error rather than crashing.
+        # passing it must not raise TypeError. A default ``difficulty=1.0`` is a
+        # no-op that falls through to the world build (here the structured
+        # Isaac-Sim-absent error on a host without Isaac Sim), not a crash.
+        from strands_robots.simulation.isaac.simulation import IsaacSimulation
+
+        sim = IsaacSimulation(num_envs=1, headless=True)
+        result = sim.create_world(difficulty=1.0)
+        assert result["status"] == "error"  # Isaac Sim absent -> structured error
+        assert "difficulty" not in result["content"][0]["text"].lower()
+
+    def test_create_world_difficulty_without_terrain_rejected(self):
+        # Base create_world contract: a non-default ``difficulty`` with no
+        # ``terrain`` is rejected with an actionable error rather than silently
+        # having no effect. Isaac has no heightfield terrain for difficulty to
+        # scale, so any != 1.0 value is doubly inert here; the reject fires
+        # before Isaac Sim boots, so it holds on any host (and takes precedence
+        # over the Isaac-Sim-absent error). Was a status=success / silent no-op
+        # on a host with Isaac Sim before this contract landed.
         from strands_robots.simulation.isaac.simulation import IsaacSimulation
 
         sim = IsaacSimulation(num_envs=1, headless=True)
         result = sim.create_world(difficulty=2.0)
         assert result["status"] == "error"
-        assert "terrain" not in result["content"][0]["text"].lower()
+        text = result["content"][0]["text"].lower()
+        assert "difficulty" in text and "mujoco" in text, text
 
     def test_add_object_signature_parity_with_base(self):
         # The base SimEngine.add_object declares ``mesh_path`` / ``material``

--- a/tests/simulation/newton/test_create_world_terrain_reject.py
+++ b/tests/simulation/newton/test_create_world_terrain_reject.py
@@ -1,12 +1,10 @@
-"""Newton ``create_world(terrain=...)`` rejects an unsupported terrain kind.
+"""Newton ``create_world`` rejects the terrain/difficulty contract it cannot honor.
 
 Rough-ground heightfields are a MuJoCo-backend capability; the Newton backend
-has no heightfield ground yet. Rather than silently ignoring a ``terrain=``
-request (which would spawn a locomotion robot on a flat plane while the caller
-believes it is on terrain), Newton rejects a non-None ``terrain`` with an
-actionable error pointing at the MuJoCo backend. That rejection is a pure
-Python contract that returns before any GPU/model build, so it is exercised
-here via ``__new__`` (no Warp / GPU required, runs in CI).
+has no heightfield ground, so it rejects both a non-None ``terrain`` and a
+non-default ``difficulty`` (which only scales a heightfield, so it is inert
+here) with actionable errors rather than silently ignoring them - the base
+``create_world`` contract.
 """
 
 from __future__ import annotations
@@ -63,3 +61,46 @@ def test_newton_accepts_difficulty_kwarg_and_still_rejects_terrain() -> None:
     r = eng.create_world(terrain="rough", difficulty=0.5)
     assert r["status"] == "error"
     assert "Newton" in r["content"][0]["text"] and "rough" in r["content"][0]["text"]
+
+
+def test_newton_rejects_difficulty_without_terrain() -> None:
+    # Base create_world contract: a non-default ``difficulty`` with no
+    # ``terrain`` is rejected with an actionable error rather than silently
+    # having no effect. On Newton there is no heightfield terrain for
+    # difficulty to scale, so any != 1.0 value is doubly inert here; the reject
+    # is a pure Python guard returning before the lock/_rebuild, so __new__
+    # exercises it (no Warp / GPU). Was a status=success / silent no-op before
+    # this contract landed.
+    assert _engine_cls is not None
+    eng = _engine_cls.__new__(_engine_cls)
+    r = eng.create_world(difficulty=2.0)
+    assert r["status"] == "error"
+    text = r["content"][0]["text"].lower()
+    assert "difficulty" in text and "newton" in text and "mujoco" in text, text
+
+
+def test_newton_terrain_reject_precedes_difficulty_reject() -> None:
+    # When both an unsupported terrain AND a non-default difficulty are passed,
+    # the terrain rejection (the primary user error on this backend) fires
+    # first, not the difficulty one.
+    assert _engine_cls is not None
+    eng = _engine_cls.__new__(_engine_cls)
+    r = eng.create_world(terrain="rough", difficulty=2.0)
+    assert r["status"] == "error"
+    text = r["content"][0]["text"]
+    assert "rough" in text and "difficulty" not in text.lower()
+
+
+def test_newton_default_difficulty_not_rejected() -> None:
+    # difficulty=1.0 (the default) is a no-op that must fall through to the real
+    # build, not the reject path. Patch _rebuild/_lock so __new__ can reach it.
+    import threading
+
+    assert _engine_cls is not None
+    eng = _engine_cls.__new__(_engine_cls)
+    eng._lock = threading.RLock()
+    eng.default_timestep = 0.002
+    eng._solver_name = "mujoco"
+    eng._rebuild = lambda: None  # type: ignore[method-assign]
+    r = eng.create_world(difficulty=1.0)
+    assert r["status"] == "success"


### PR DESCRIPTION
## Problem

The base `SimEngine.create_world` contract documents that a `difficulty != 1.0` supplied with **no** `terrain` is *"rejected with an actionable error rather than silently having no effect"* -- `difficulty` only scales a heightfield terrain's peak elevation, so it is meaningless without a terrain. The MuJoCo backend honors this. The **Newton** and **Isaac** backends accepted `difficulty` for signature parity but only rejected a non-None `terrain`; a non-default `difficulty` with no terrain was **silently ignored** and `create_world` returned `status: success`.

So a caller ramping a terrain curriculum on the GPU (Newton) or Isaac backend -- exactly the audience for the `difficulty` knob -- got no terrain and no error. Reproduced on the real Newton engine:

```
>>> NewtonSimEngine(...).create_world(difficulty=2.0)   # no terrain
{'status': 'success', ...}   # difficulty silently dropped
```

vs MuJoCo, which rejects it with an actionable message.

## Fix

Both backends now reject a non-default `difficulty` (with no terrain) with an actionable message pointing at `create_simulation(backend="mujoco")` (the only backend with heightfield terrain) or omitting `difficulty`:

```
difficulty=2.0 has no effect on the Newton backend (it scales a heightfield
terrain's elevation, and this backend has no heightfield terrain); use
create_simulation(backend='mujoco') for a terrain curriculum, or omit
difficulty for a flat ground plane.
```

Unlike MuJoCo (which can suggest "pass a terrain"), these backends support no terrain at all, so the remediation points at the MuJoCo backend. Precedence and no-op behavior are preserved:

- a non-None `terrain` is still rejected **first** (the primary error on these backends);
- `difficulty=1.0` (the default) is unchanged -- a flat-ground no-op that falls through to the normal build.

This completes the `create_world(terrain=/difficulty=)` contract parity across all three backends (the `terrain` reject already landed for Isaac in #1354).

## Tests

- `tests/simulation/newton/test_create_world_terrain_reject.py`: new `test_newton_rejects_difficulty_without_terrain` (via `__new__`, before the lock/build -- no Warp/GPU) + `test_newton_terrain_reject_precedes_difficulty_reject` + `test_newton_default_difficulty_not_rejected`.
- `tests/simulation/isaac/test_isaac_backend.py`: new `test_create_world_difficulty_without_terrain_rejected` (the reject fires before Isaac Sim boots, so it runs on any host) + corrected the existing difficulty-parity test (it previously asserted a bug-masking behavior).

The two reject tests **fail before** the fix (Newton: control flow reaches the world build with the guard absent; Isaac: falls through to the Isaac-Sim-absent error, which lacks the difficulty message) and **pass after**. Full `tests/simulation/newton/` + `tests/simulation/isaac/` = 320 passed, 1 skipped; `ruff check` / `ruff format --check` / `mypy` clean on the changed files.

Input-validation / error-contract fix -- no policy/render/recording/asset behavior changes, so no visual artifact (matching the sibling Isaac reject fixes).