### PR TITLE
test(sim): pin fail-fast on a dict action with a non-scalar value

### DIFF
--- a/tests/simulation/mujoco/test_action_resolution_fail_fast.py
+++ b/tests/simulation/mujoco/test_action_resolution_fail_fast.py
@@ -209,3 +209,43 @@ class TestFailFastOnActionVectorShapeMismatch:
         # The diagnostic points at the embodiment fix and names valid joints.
         assert "get_features" in text
         assert "1" in text and "6" in text
+
+
+class TestFailFastOnDictVectorValuedKey:
+    """A dict action whose VALUE is non-scalar (a vector on one key, e.g. a
+    policy emitting ``{"base_velocity": [vx, vy, omega]}`` or a wrongly-shaped
+    per-joint chunk) is rejected atomically by ``send_action`` with a plain
+    scalar-value error that carries NO per-key breakdown - unlike a dict whose
+    KEYS are unresolvable, which enumerates ``unresolved_keys``.
+
+    The key itself may be a perfectly valid actuator name; it is the value shape
+    that is wrong, so nothing on that step drives the robot. The runner must
+    still count the whole step as a 100% failure - crediting the dict's own keys
+    as unresolved from the unstructured error - so the fail-fast probe surfaces a
+    structurally-dead rollout instead of silently running the full episode with
+    an arm that never moves. Pre-pin, this unstructured-error branch (dict form,
+    no json breakdown) was the one action-failure path with no coverage.
+    """
+
+    def test_dict_with_vector_valued_key_fails_fast_within_probe_window(self, sim):
+        # "1" IS a valid so101 actuator, but its value is a 2-vector, not a
+        # scalar target, so send_action rejects the whole action with no
+        # per-key breakdown.
+        policy = _FixedKeysPolicy({"1": [0.1, 0.2]})
+        result = sim.run_policy(
+            robot_name="so101",
+            policy_object=policy,
+            n_steps=50,  # would run 50 steps if the dead step were miscounted
+            control_frequency=20.0,
+            fast_mode=True,
+        )
+        assert result["status"] == "error", result
+        text = result["content"][0]["text"]
+        # Bailed in the probe window; did NOT run the full 50-step episode.
+        assert "first 3 action steps" in text
+        assert "50 steps" not in text
+        # The unstructured error is attributed to the dict's own key: the
+        # runner records "1" as unresolved for the dead step so the diagnostic
+        # names the offending key rather than reporting an empty key set.
+        assert "'1'" in text
+        assert "get_features" in text


### PR DESCRIPTION
## Problem

`PolicyRunner`'s action-resolution accounting turns a silently-broken rollout into an actionable signal: if every action step in the opening probe window drives zero actuators, the run raises at the probe boundary instead of burning the whole episode on an arm that never moves.

That accounting has one unstructured-error branch with no test coverage. A dict action whose **value** is non-scalar (a vector bound to a single key, e.g. a policy emitting `{"base_velocity": [vx, vy, omega]}`, or a wrongly-shaped per-joint chunk) is rejected atomically by `send_action` with a plain scalar-value error that carries **no** per-key breakdown. This differs from a dict whose **keys** are unresolvable, which enumerates `unresolved_keys` in a json block.

The key itself may be a perfectly valid actuator name; only the value shape is wrong, so nothing drives the robot on that step. `PolicyRunner` must still count the whole step as a 100% failure by crediting the dict's own keys as unresolved from the unstructured error, so the fail-fast probe surfaces a structurally-dead rollout. If that crediting regressed, the dead step would be miscounted and the episode would run to completion with an arm that never moved (a silent no-op rollout that looks healthy).

## Change

Adds `TestFailFastOnDictVectorValuedKey` to `tests/simulation/mujoco/test_action_resolution_fail_fast.py`, alongside the existing `TestFailFastOnActionVectorShapeMismatch` (the numeric-vector sibling of the same contract). A policy emits `{"1": [0.1, 0.2]}` on `so101` (`"1"` is a valid actuator; the value is a 2-vector) with `n_steps=50`; the test asserts the run bails inside the 3-step probe window (`"first 3 action steps"`, no `"50 steps"`), attributes the dead step to the dict's own key (`'1'` in the diagnostic), and points at the `get_features` fix.

This pins the previously-uncovered dict-form unstructured-error branch in `_apply` (`policy_runner.py`); the numeric-vector form (list action, no `.keys()`) was already covered, but the dict form was not.

## Tests

```
MUJOCO_GL=egl pytest tests/simulation/mujoco/test_action_resolution_fail_fast.py
6 passed
```

Ran headless in MuJoCo sim. Confirmed the target branch goes from uncovered to covered (module missing-line count drops by one) and `ruff check` / `ruff format --check` are clean. Test-only change; no library behavior is modified.