### PR TITLE
docs(readme): correct simulation action count 65 -> 67

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ sim.step(100)   # publishes /so101/joint_states + camera image_raw on the ROS 2 
   plus classical motion planners, MPC, and scripted controllers behind one ABC.
 - **Mesh networking built in.** Every robot is a Zenoh peer. `tell()` another
   robot what to do; broadcast an E-STOP; bridge to AWS IoT Core for fleets.
-- **65-action simulation tool.** World building, physics, rendering, domain
+- **67-action simulation tool.** World building, physics, rendering, domain
   randomization, and LeRobotDataset recording - all agent-callable.
 - **ROS 2 interop.** Observe + command any ROS 2 graph (`use_ros`), act as a
   robot with no rclpy (`use_rtps`), or expose a running sim as a ROS node.
@@ -219,7 +219,7 @@ agent = Agent(tools=[robot])
 agent("Wave the arm using the mock policy for 200 steps, then render a top-down view")
 ```
 
-`Robot("so100")` returns a `Simulation` instance - the full 65-action
+`Robot("so100")` returns a `Simulation` instance - the full 67-action
 simulation AgentTool. Drive it in natural language through an `Agent`, call its
 methods directly (`robot.render(camera_name="topdown")`), or dispatch an action
 by calling it (`robot(action="render", camera_name="topdown")`). See
@@ -503,7 +503,7 @@ AgentTool returning `{"status", "content"}`.
 | `start` | `instruction`, `policy_port`, `duration` | Non-blocking async start |
 | `status` | - | Current task status |
 | `stop` | - | Interrupt running task (emergency stop) |
-In sim mode the same tool exposes the 65 Simulation actions - see Simulation (MuJoCo).
+In sim mode the same tool exposes the 67 Simulation actions - see Simulation (MuJoCo).
 </details>
 
 <details>
@@ -827,7 +827,7 @@ torch-free until an RL provider is resolved on first use.
 ## Simulation (MuJoCo)
 
 `Robot("so100")` (sim mode) returns a `Simulation` - a MuJoCo-backed AgentTool
-exposing **65 actions** for world composition, physics, rendering, policy
+exposing **67 actions** for world composition, physics, rendering, policy
 execution, and dataset recording. Build it directly when you want full control:
 
 ```python
@@ -1150,7 +1150,7 @@ strands_robots/
 │   ├── base.py            # SimEngine ABC
 │   ├── factory.py         # create_simulation() + backend registry
 │   ├── models.py          # SimWorld / SimRobot / SimObject / SimCamera
-│   └── mujoco/            # MuJoCo backend (65-action AgentTool)
+│   └── mujoco/            # MuJoCo backend (67-action AgentTool)
 ├── mesh/                  # Zenoh mesh: core, sensors, input, audit, transport, iot
 ├── benchmarks/libero/     # LIBERO suite + BDDL parser + adapter
 └── tools/                 # gr00t_inference, lerobot_*, pose, serial, robot_mesh


### PR DESCRIPTION
## What

The README describes the MuJoCo simulation AgentTool as a "65-action" tool in five places, but the tool_spec enum now has **67 actions**. Two actions were added since the count was last updated:
- `list_cameras` (via #1352, the unknown-camera error now hints it)
- `register_builtin_benchmarks`

This updates the five references to 67.

## Verification

```
strands_robots/simulation/mujoco/tool_spec.json -> action enum length = 67
```

Lines updated: features list, `Robot()` factory note, hardware-mode note, Simulation section intro, and the repo-tree comment.

## Not touched

The `STRANDS_MESH_CA_PINS` row ("comma-separated **64-char hex**") is unrelated to the action count and is intentionally left as-is.

Docs only, no code changes.