### PR TITLE
docs(examples): list notebook 05 in the notebook indexes

### DIFF
--- a/docs/examples/overview.md
+++ b/docs/examples/overview.md
@@ -16,6 +16,7 @@ hardware, no GPU, no Hugging Face credentials.
 | [`02_record_and_stream.ipynb`](https://github.com/strands-labs/robots/blob/main/examples/notebooks/02_record_and_stream.ipynb) | Record a LeRobotDataset, then stream it back with `stream_dataset()`. |
 | [`03_record_train_deploy.ipynb`](https://github.com/strands-labs/robots/blob/main/examples/notebooks/03_record_train_deploy.ipynb) | The full loop: record, train an ACT policy on CPU, export, and load it back. |
 | [`04_discover_lerobot.ipynb`](https://github.com/strands-labs/robots/blob/main/examples/notebooks/04_discover_lerobot.ipynb) | Discover the LeRobot API with `use_lerobot`: list robots, policies, teleoperators, cameras, and inspect any class. |
+| [`05_streaming_data_loop.ipynb`](https://github.com/strands-labs/robots/blob/main/examples/notebooks/05_streaming_data_loop.ipynb) | The streaming data loop: record, render, stream back, train, and load in one notebook (the optional Storage Bucket sync needs LeRobot >= 0.6.1). |
 
 ```bash
 uv pip install "strands-robots[sim-mujoco,lerobot]" jupyterlab

--- a/examples/notebooks/README.md
+++ b/examples/notebooks/README.md
@@ -23,6 +23,7 @@ Linux they fall back to the environment's default (set `MUJOCO_GL=egl` if needed
 | 2 | [`02_record_and_stream.ipynb`](02_record_and_stream.ipynb) | Record a LeRobotDataset, then stream it back with `stream_dataset()` |
 | 3 | [`03_record_train_deploy.ipynb`](03_record_train_deploy.ipynb) | The full loop: record, train an ACT policy on CPU, export, and load it back |
 | 4 | [`04_discover_lerobot.ipynb`](04_discover_lerobot.ipynb) | Discover the LeRobot API with `use_lerobot`: list robots, policies, teleoperators, cameras, and inspect any class |
+| 5 | [`05_streaming_data_loop.ipynb`](05_streaming_data_loop.ipynb) | The streaming data loop: record, render, stream back, train, and load, in one notebook (the optional Storage Bucket sync needs LeRobot >= 0.6.1) |
 
 Read them in order; each builds on the previous one. Notebook 3 trains a real
 policy on CPU with a tiny dataset and two steps - raise the step count and run on


### PR DESCRIPTION
## What

Notebook `05_streaming_data_loop.ipynb` shipped in #1331 but both notebook index tables stopped at notebook 04. This adds the row to:
- `examples/notebooks/README.md`
- `docs/examples/overview.md`

## Note

The row flags that the optional Storage Bucket sync step needs LeRobot >= 0.6.1. The notebook's default local-root path (record -> stream -> train -> load) runs today with no bucket, so it's usable now.

Docs only, no code changes.