### PR TITLE
docs(getting-started): point the quickstart at the notebook series

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -48,6 +48,14 @@ agent = Agent(tools=[robot])
 agent("Add a red cube and pick it up using the mock policy")
 ```
 
+## Next: the notebook series
+
+For a guided, click-and-run path, work through the
+[getting-started notebooks](../examples/overview.md), five notebooks that run
+end-to-end in simulation with no hardware, no GPU, and no Hugging Face
+credentials. They take you from `Robot("so100")` through recording a dataset,
+training a policy, and the full streaming data loop, each building on the last.
+
 ## See also
 
 - [Policy providers](../policies/overview.md) - GR00T, LeRobot Local, Cosmos 3.


### PR DESCRIPTION
## What

The getting-started [quickstart](https://github.com/strands-labs/robots/blob/main/docs/getting-started/quickstart.md) had no link to the click-and-run notebook series (`examples/notebooks/`). A new user finishing the quickstart was never directed to the guided learning path.

This adds a short "Next: the notebook series" section linking the [notebooks overview](https://github.com/strands-labs/robots/blob/main/docs/examples/overview.md), so the quickstart flows into the notebooks.

Docs only, no code changes.