### PR TITLE
docs(readme): mention procedural terrain in the simulation-tool feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ sim.step(100)   # publishes /so101/joint_states + camera image_raw on the ROS 2 
 - **Mesh networking built in.** Every robot is a Zenoh peer. `tell()` another
   robot what to do; broadcast an E-STOP; bridge to AWS IoT Core for fleets.
 - **67-action simulation tool.** World building, physics, rendering, domain
-  randomization, and LeRobotDataset recording - all agent-callable.
+  randomization, procedural terrain (`create_world(terrain="rough"|"stairs"|"pyramid"|"slope")`
+  for locomotion), and LeRobotDataset recording - all agent-callable.
 - **ROS 2 interop.** Observe + command any ROS 2 graph (`use_ros`), act as a
   robot with no rclpy (`use_rtps`), or expose a running sim as a ROS node.
 - **One mental model.** Sim and hardware share the same policy interface,


### PR DESCRIPTION
## What

`create_world(terrain="rough"|"stairs"|"pyramid"|"slope")` shipped for locomotion (#1336, #1338, #1339, #1340, with the `difficulty` curriculum knob in #1344), but the README had zero mention of it. This adds it to the simulation-tool feature bullet alongside domain randomization.

## Verification

Terrain kinds confirmed against `docs/simulation/world-building.md` (the full reference) and `strands_robots/simulation/terrain.py` (`SUPPORTED_TERRAINS`). Kept to one accurate bullet; the detailed docs already live in world-building.md.

Docs only, no code changes.