### PR TITLE
docs(readme): add the remote policy provider to the providers table

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,6 +568,7 @@ create_policy("lerobot/act_aloha_sim_transfer_cube")   # local HF inference
 | `cosmos3` | NVIDIA Cosmos 3 omnimodal VLA | Service mode (WebSocket to a Cosmos Framework RoboLab policy server); embodiments: `droid`, `umi`, `av`, `bridge` |
 | `lerobot_local` | HuggingFace | Direct ACT / Pi0 / SmolVLA / Diffusion inference, no server |
 | `lerobot_async` | HuggingFace via gRPC | Offload a LeRobot policy to a remote `PolicyServer` over lerobot's native async-inference gRPC transport (edge/light robot host) |
+| `remote` | any policy, over WebSocket | Drop-in client that forwards observations to a remote `PolicyServer` and returns its action chunk: `create_policy("remote", endpoint="ws://gpu-box:8765")` (or the smart string `create_policy("ws://gpu-box:8765")`). For a light robot host with a GPU box elsewhere; mirrors the server policy's RTC support |
 | `vera` | MIT VERA (DFoT/WAN planner + Jacobian IDM) | Two-stage video-to-action over a WebSocket GPU server (Docker); PushT + MimicGen, IK for eef-delta arms. **Git-only** (not on PyPI, no extra): `pip install 'vera @ git+https://github.com/sizhe-li/VERA.git'` plus `websockets msgpack numpy` |
 
 ```mermaid


### PR DESCRIPTION
## What

The `remote` policy provider (`create_policy("remote", endpoint="ws://gpu-box:8765")`, or the smart string `create_policy("ws://gpu-box:8765")`) forwards observations to a remote `PolicyServer` over WebSocket, for a light robot host with a GPU box elsewhere. It ships in `strands_robots/inference/` and is documented at `docs/policies/remote.md`, but the README providers table omitted it.

This adds the row next to `lerobot_async` (the other remote-inference path).

## Verification

Provider name, invocation, and behavior confirmed against `strands_robots/inference/__init__.py` and `docs/policies/remote.md`.

Docs only, no code changes.