### PR TITLE
test(sim): pin eval cooperative-stop finalizes the in-progress episode video

### DIFF
--- a/tests/simulation/test_policy_runner.py
+++ b/tests/simulation/test_policy_runner.py
@@ -35,6 +35,7 @@ from strands_robots.simulation.policy_runner import (
     PolicyRunner,
     VideoConfig,
     _extract_frame_ndarray,
+    _RolloutVideoWriter,
 )
 from tests.simulation.mujoco._gl_probe import requires_gl
 
@@ -247,6 +248,78 @@ def test_evaluate_without_cooperative_stop_is_not_flagged():
     assert payload["stopped_early"] is False
     assert payload["episodes_completed"] == 3
     assert payload["n_episodes"] == 3
+
+
+@requires_gl
+def test_evaluate_cooperative_stop_finalizes_in_progress_episode_video(tmp_path, monkeypatch):
+    """A cooperative stop must finalize the in-progress episode's video writer.
+
+    ``evaluate`` opens a fresh per-episode :class:`_RolloutVideoWriter` and
+    closes it when the episode finishes. When an ``on_frame`` hook raises
+    :class:`CooperativeStop` mid-episode, the loop unwinds before that normal
+    close runs, so the ``except CooperativeStop`` handler is responsible for
+    finalizing the writer of the interrupted episode. If it does not, the
+    imageio/ffmpeg writer (and its child process) leaks. This pins that every
+    opened writer is closed exactly once even on the early-stop path.
+    """
+    pytest.importorskip("mujoco")
+    pytest.importorskip("imageio_ffmpeg")
+
+    opened: list[str] = []
+    closed: list[str] = []
+    orig_open = _RolloutVideoWriter.open.__func__
+    orig_close = _RolloutVideoWriter.close
+
+    def spy_open(cls, sim, video, control_frequency):
+        writer, err = orig_open(cls, sim, video, control_frequency)
+        if writer is not None:
+            opened.append(writer.path)
+        return writer, err
+
+    def spy_close(self):
+        closed.append(self.path)
+        return orig_close(self)
+
+    monkeypatch.setattr(_RolloutVideoWriter, "open", classmethod(spy_open))
+    monkeypatch.setattr(_RolloutVideoWriter, "close", spy_close)
+
+    sim = Simulation()
+    sim.create_world()
+    sim.add_robot("arm", data_config="so101", position=[0.0, 0.0, 0.0])
+    sim.add_camera("cam", position=[0.0, 0.0, 0.8], target=[0.0, 0.2, 0.05])
+
+    # global_step is monotonic across episodes. With max_steps=4 each episode
+    # spans 4 steps: ep0 -> global 0..3 (completes and closes its writer),
+    # ep1 -> global 4,5 then step 6 raises. So the stop fires while ep1's
+    # writer is open, exercising the handler's writer-cleanup branch.
+    def hook(step, obs, action):
+        if step >= 6:
+            raise CooperativeStop("user stopped eval")
+
+    result = sim.eval_policy(
+        robot_name="arm",
+        policy_provider="mock",
+        n_episodes=4,
+        max_steps=4,
+        control_frequency=20.0,
+        success_fn=lambda obs: False,
+        on_frame=hook,
+        video={"path": str(tmp_path / "eval.mp4"), "fps": 20, "camera": "cam"},
+    )
+    sim.destroy()
+
+    assert result["status"] == "success"
+    payload = next(c["json"] for c in result["content"] if isinstance(c, dict) and "json" in c)
+    assert payload["stopped_early"] is True
+    # Exactly one episode fully completed before the mid-episode stop.
+    assert payload["episodes_completed"] == 1
+
+    # Two writers were opened (ep0 completed, ep1 interrupted). Both must be
+    # closed - the interrupted one via the CooperativeStop handler.
+    assert len(opened) == 2
+    assert set(opened) == set(closed), "in-progress episode video writer was not finalized on cooperative stop"
+    # The interrupted episode's partial MP4 was still written to disk.
+    assert (tmp_path / "eval_ep1.mp4").exists()
 
 
 def test_evaluate_calls_reset_per_episode():


### PR DESCRIPTION
## Problem

`evaluate` (the engine behind `eval_policy`) opens a fresh per-episode `_RolloutVideoWriter` and closes it when the episode finishes. When an `on_frame` hook raises `CooperativeStop` mid-episode, the loop unwinds *before* that normal per-episode close runs, so the `except CooperativeStop` handler is solely responsible for finalizing the interrupted episode's writer. If it does not, the imageio/ffmpeg writer and its child ffmpeg process leak.

The existing cooperative-stop eval tests (`test_evaluate_cooperative_stop_ends_eval_gracefully`) run against `FakeSim` with **no** video config, so the handler's writer-cleanup branch was never exercised.

## Change

Adds a real-backend (MuJoCo, headless) regression that:

- runs `eval_policy(..., video={...}, on_frame=hook)` where the hook raises `CooperativeStop` mid-episode 1 (after episode 0 completes),
- spies `_RolloutVideoWriter.open`/`close` and asserts **every** opened per-episode writer is closed exactly once even on the early-stop path,
- asserts the graceful-stop contract (`status=success`, `stopped_early=True`, `episodes_completed=1`) and that the interrupted episode's partial MP4 is still written.

Verified the test **fails** on pre-change behaviour (removing the handler's `writer.close()` leaves the interrupted episode's writer unclosed) and **passes** with it, so it locks the contract against regression. Test only; no library behaviour change.

## Test

`tests/simulation/test_policy_runner.py::test_evaluate_cooperative_stop_finalizes_in_progress_episode_video` — full file green (`38 passed in 4.83s`, `MUJOCO_GL=egl`). `ruff check`, `ruff format --check`, and `mypy strands_robots tests tests_integ` all clean.

## Rollout artifact

Headless MuJoCo eval rollout (so101, mock policy) driving the recorded eval loop this test pins — the operator interrupts mid-run and the interrupted episode's video is still finalized:

![eval rollout](https://github.com/cagataycali/robots/releases/download/artifact-eval-coopstop-1784067661/cooperative_stop_ep0.gif)

MP4s: [completed episode](https://github.com/cagataycali/robots/releases/download/artifact-eval-coopstop-1784067661/eval_ep0.mp4) - [interrupted-but-finalized episode](https://github.com/cagataycali/robots/releases/download/artifact-eval-coopstop-1784067661/eval_ep1.mp4).