### PR TITLE
fix(sim): keep earlier keyframe-spawned robots posed when adding more robots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: `add_robot(keyframe=...)` no longer collapses an earlier keyframe-spawned robot to the zero pose
+
+Adding a robot runs `mj_resetData` (which zeroes the entire model) before it
+poses the freshly-added robot, then re-applied only that robot's keyframe home
+pose. When an earlier robot had already been spawned from a `<keyframe>`, this
+reset silently dropped it back to the all-zero configuration -- only the most
+recently added robot kept its home pose, until an unrelated `reset()` happened
+to restore everyone. Incrementally building a multi-arm scene one `add_robot`
+call at a time (e.g. a leader/follower pair) is the common path, so this left
+all-but-the-last arm in an out-of-distribution pose for policy rollout/eval.
+
+`add_robot` now re-applies every robot's captured home pose after the reset (a
+no-op for robots spawned without a keyframe), so each arm stays at its
+canonical home pose across subsequent additions. The home pose remains scoped
+to its own robot -- it is never applied to another robot's identically-named
+joints across the namespace boundary.
+
+
 ### Fixed: Newton / Isaac `create_world(difficulty=...)` rejects a non-default difficulty with no terrain instead of silently ignoring it
 
 The base `SimEngine.create_world` contract (and the MuJoCo backend) reject a

--- a/docs/simulation/world-building.md
+++ b/docs/simulation/world-building.md
@@ -52,7 +52,10 @@ sim.add_robot(name="panda", data_config="panda", keyframe="home")  # or keyframe
 ```
 
 The pose is applied to the robot's joints by name and is restored by `reset()`,
-so a keyframe spawn is sticky across episodes. An unknown keyframe name/index
+so a keyframe spawn is sticky across episodes. It also survives later
+`add_robot` calls, so incrementally building a multi-robot scene keeps every
+already-spawned arm at its home pose rather than collapsing it to zero. An
+unknown keyframe name/index
 is an error that lists the model's available keyframes. `keyframe=None` (the
 default) keeps the zero-pose spawn. (MuJoCo backend; the Newton backend rejects
 `keyframe=` as not-yet-supported.)

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1169,6 +1169,13 @@ class MuJoCoSimEngine(
             self._world.step_count = 0
             if home_by_short:
                 self._apply_home_qpos_to_robot(robot, home_by_short)
+            # ``mj_resetData`` above zeroed the entire model, which also drops
+            # any robot added earlier back to the zero configuration. Re-apply
+            # every robot's captured home pose (a no-op for robots spawned
+            # without a keyframe) so incrementally building a multi-robot scene
+            # keeps each arm at its canonical home pose instead of silently
+            # collapsing all but the most recently added robot.
+            self._restore_home_poses()
             mj.mj_forward(self._world._model, self._world._data)
 
             # Attach the robot to the mesh as its own peer so the agent can

--- a/tests/simulation/mujoco/test_add_robot_keyframe.py
+++ b/tests/simulation/mujoco/test_add_robot_keyframe.py
@@ -303,3 +303,56 @@ class TestFloatingBaseKeyframe:
         assert not np.allclose(_qpos(sim), _FLOAT_HOME)
         assert sim.reset()["status"] == "success"
         assert np.allclose(_qpos(sim), _FLOAT_HOME)
+
+
+def _joint_qpos(sim, joint_name: str) -> float:
+    """Read the scalar qpos of a named (namespaced) hinge joint from the live
+    compiled model - proves the pose landed on the intended robot's joint."""
+    model = sim._world._model
+    data = sim._world._data
+    jid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, joint_name)
+    assert jid >= 0, f"joint {joint_name!r} not found in compiled model"
+    adr = int(model.jnt_qposadr[jid])
+    return float(data.qpos[adr])
+
+
+class TestMultiRobotKeyframeSpawn:
+    """Incrementally adding robots must not disturb an already-spawned robot's
+    keyframe home pose.
+
+    ``add_robot`` runs ``mj_resetData`` (which zeroes the whole model) before
+    posing the freshly-added robot. When an earlier robot was spawned from a
+    ``<keyframe>``, that reset would silently collapse it back to the zero
+    configuration - only the most recently added robot kept its home pose until
+    an unrelated ``reset()`` happened to restore everyone. Building a multi-arm
+    scene one ``add_robot`` at a time is the common path (e.g. a leader/follower
+    pair), so each robot must stay at its canonical home pose across subsequent
+    additions.
+    """
+
+    def test_adding_second_robot_preserves_first_home_pose(self, sim, arm_xml):
+        # Spawn A from its keyframe: it lands at the home pose.
+        sim.add_robot(name="a", urdf_path=arm_xml, keyframe="home")
+        assert np.isclose(_joint_qpos(sim, "a/shoulder"), _HOME[0])
+        assert np.isclose(_joint_qpos(sim, "a/elbow"), _HOME[1])
+
+        # Add a SECOND keyframed robot. A's home pose must survive - the
+        # regression: pre-fix, mj_resetData zeroed A and only B was re-posed.
+        result = sim.add_robot(name="b", urdf_path=arm_xml, keyframe="home")
+        assert result["status"] == "success"
+        assert np.isclose(_joint_qpos(sim, "a/shoulder"), _HOME[0])
+        assert np.isclose(_joint_qpos(sim, "a/elbow"), _HOME[1])
+        assert np.isclose(_joint_qpos(sim, "b/shoulder"), _HOME[0])
+        assert np.isclose(_joint_qpos(sim, "b/elbow"), _HOME[1])
+
+    def test_keyframe_spawn_is_scoped_to_its_own_robot(self, sim, arm_xml):
+        # A added WITHOUT a keyframe stays at the zero configuration even when a
+        # later robot B IS spawned from a keyframe with identical short joint
+        # names ("shoulder"/"elbow"). The home pose must not bleed across the
+        # namespace into A's identically-named joints.
+        sim.add_robot(name="a", urdf_path=arm_xml)
+        sim.add_robot(name="b", urdf_path=arm_xml, keyframe="home")
+        assert np.isclose(_joint_qpos(sim, "a/shoulder"), 0.0)
+        assert np.isclose(_joint_qpos(sim, "a/elbow"), 0.0)
+        assert np.isclose(_joint_qpos(sim, "b/shoulder"), _HOME[0])
+        assert np.isclose(_joint_qpos(sim, "b/elbow"), _HOME[1])


### PR DESCRIPTION
## Problem

`add_robot` runs `mj_resetData` (which zeroes the entire compiled model) before it poses the freshly-added robot, then re-applied only *that* robot's keyframe home pose. When an earlier robot had already been spawned from a `<keyframe>`, this reset silently dropped it back to the all-zero configuration. Only the most recently added robot kept its home pose, until an unrelated `reset()` happened to restore everyone.

Building a multi-arm scene one `add_robot` call at a time (e.g. a leader/follower pair, or several arms on a bench) is the common path, so this left all-but-the-last arm in an out-of-distribution pose for policy rollout / eval.

Reproduction:

```python
sim.add_robot(name="a", urdf_path=arm, keyframe="home")   # a at home pose
sim.add_robot(name="b", urdf_path=arm, keyframe="home")   # a silently collapses to zeros
```

## Change

After the reset, `add_robot` now re-applies every robot's captured home pose via the existing `_restore_home_poses()` (the same mechanism `reset()` already uses). It is a no-op for robots spawned without a keyframe, so incrementally building a scene keeps each arm at its canonical home pose. The home pose stays scoped to its own robot -- it is never applied to another robot's identically-named joints across the namespace boundary.

One-line effective change in `add_robot`; the restore helper already existed.

## Tests

Added to `tests/simulation/mujoco/test_add_robot_keyframe.py`:

- `test_adding_second_robot_preserves_first_home_pose` -- the regression: fails on pre-fix code (the first arm reads `0.0` instead of its home value), passes after.
- `test_keyframe_spawn_is_scoped_to_its_own_robot` -- a robot added without a keyframe stays at zero when a later keyframed robot with identical short joint names is added (no cross-namespace bleed).

Full MuJoCo simulation suite green locally (`MUJOCO_GL=egl`); `ruff check`, `ruff format --check`, and `mypy strands_robots tests tests_integ` all clean.

## Visual (headless MuJoCo, EGL)

Two arms added one after another, each with `keyframe="home"`. Before: the second `add_robot` collapsed the first arm to the zero pose. After: both arms hold their keyframe home pose.

![before/after](https://github.com/cagataycali/robots/releases/download/kf-multirobot-artifact-1784071991/kf_multirobot_before_after.png)