### PR TITLE
test(device-connect): pin that insecure transport emits a prominent warning

### DIFF
--- a/tests/test_device_connect_hardening.py
+++ b/tests/test_device_connect_hardening.py
@@ -553,6 +553,45 @@ def test_init_device_connect_uses_secure_default():
     assert captured["allow_insecure"] is False
 
 
+def test_init_device_connect_insecure_emits_prominent_warning(caplog):
+    """Opting into insecure transport must NEVER be silent.
+
+    The entrypoint logs a prominent WARNING whenever insecure (unencrypted,
+    unauthenticated) transport is active, so an insecure deployment is always
+    visible in the logs rather than a quiet default. This pins that invariant
+    against a regression that drops the warning.
+    """
+    import logging
+    from unittest.mock import patch
+
+    from strands_robots.device_connect import init_device_connect
+
+    captured = {}
+
+    class _FakeRuntime:
+        def __init__(self, **kw):
+            captured.update(kw)
+
+        def set_heartbeat_provider(self, *_a, **_k):
+            pass
+
+        async def run(self):
+            return None
+
+    async def _go():
+        with patch("strands_robots.device_connect.DeviceRuntime", _FakeRuntime):
+            await init_device_connect(_FakeRobot(), peer_id="p1", allow_insecure=True)
+
+    with caplog.at_level(logging.WARNING, logger="strands_robots.device_connect"):
+        _run(_go())
+
+    assert captured["allow_insecure"] is True
+    insecure_warnings = [
+        r for r in caplog.records if "INSECURE mode" in r.getMessage() and r.levelno == logging.WARNING
+    ]
+    assert insecure_warnings, "insecure transport must emit a prominent WARNING (never silent)"
+
+
 def test_no_forced_insecure_setdefault_in_source():
     # The agent-side connector must NOT force insecure mode process-wide.
     import strands_robots.tools.robot_mesh as rm


### PR DESCRIPTION
## Problem

`init_device_connect()` logs a prominent `WARNING` whenever insecure (unencrypted, unauthenticated) transport is active, so an insecure deployment is never a silent default. That security invariant had no test coverage: the secure-default construction path was pinned (`test_init_device_connect_uses_secure_default`), but the insecure branch that emits the warning was untested. A future refactor could silently drop the warning and no test would catch it.

## Change

Add a focused regression test that opts into insecure transport (`allow_insecure=True`) with a fake `DeviceRuntime` and asserts a `WARNING` record carrying `INSECURE mode` is emitted. It also confirms the runtime is still constructed with `allow_insecure=True`.

The test is a genuine guard, not a snapshot: neutralizing the `logger.warning(...)` block makes it fail (`assert []` — no insecure warning), and it passes on current code.

## Coverage

`strands_robots/device_connect/__init__.py`: the insecure-warning line was previously uncovered by the hardening suite. This closes that gap while pinning the "insecure is never silent" contract.

## Tests

`tests/test_device_connect_hardening.py` — 36 passed. Full lint gate clean (ruff check/format, mypy: no issues in 791 source files).