### PR TITLE
fix(sim): seat floating-base robots on the terrain surface at spawn/reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: a floating-base robot spawns SEATED on the terrain surface instead of buried below it
+
+`create_world(terrain=...)` lays a heightfield so a locomotion robot can be
+spawned and evaluated on non-flat ground -- the feature's stated purpose. But a
+robot's model spawns its free base at the flat-ground keyframe height (e.g. the
+Unitree Go2 base at `z=0.445`, feet ~`z=0.02`), so on a raised heightfield the
+feet started BELOW the terrain surface: the robot spawned partially buried in
+the ground, with penetration that grew with the curriculum `difficulty` (a
+pyramid at `difficulty=4.0` buried the feet ~0.3 m). This is exactly the
+initial state a terrain curriculum resets into every episode.
+
+`add_robot` and `reset()` now seat every floating-base robot on the local
+terrain -- offsetting its base `z` by the heightfield height beneath its
+`(x, y)` -- so its feet rest on the surface at the start of every episode.
+A flat ground plane is a no-op (the local height is `0.0`, so non-terrain
+worlds are byte-for-byte unchanged) and a fixed-base arm (no free joint) is
+skipped. Both a NAMED floating base (a humanoid's `floating_base_joint`) and
+an UNNAMED `<freejoint>` (a mobile base) are handled.
+
+
 ### Fixed: `add_robot(keyframe=...)` no longer collapses an earlier keyframe-spawned robot to the zero pose
 
 Adding a robot runs `mj_resetData` (which zeroes the entire model) before it

--- a/docs/simulation/world-building.md
+++ b/docs/simulation/world-building.md
@@ -110,6 +110,13 @@ world (no `terrain`) is rejected with an error rather than silently having no
 effect. A locomotion curriculum ramps `difficulty` across resets to grow the
 terrain the policy must handle.
 
+A floating-base robot added to a terrain world (or reset in one) spawns
+SEATED on the local terrain surface: its base is raised by the heightfield
+height beneath its `(x, y)` so its feet rest on the ground, rather than at
+the flat-ground keyframe height (which would leave them buried below a raised
+heightfield). A flat ground plane and a fixed-base arm (no free joint) are
+unaffected.
+
 ## Procedural objects
 
 ```python

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -282,6 +282,11 @@ class SimEngine(ABC):
         It is only meaningful with a ``terrain``; setting ``difficulty != 1.0``
         with no ``terrain`` is rejected with an actionable error rather than
         silently having no effect. Must be a finite value ``> 0``.
+
+        A floating-base robot added to a terrain world is spawned seated on
+        the local terrain surface (raised by the heightfield height beneath
+        it) at ``add_robot`` and on ``reset()``, so its feet are not buried
+        below the raised terrain.
         """
         ...
 

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -438,6 +438,12 @@ class MuJoCoSimEngine(
         trainer ramps across resets. It is only meaningful with a ``terrain``;
         ``difficulty != 1.0`` with no ``terrain`` is rejected (it would have no
         effect) and must be a finite value ``> 0``.
+
+        A floating-base robot added to a terrain world is spawned SEATED on
+        the local terrain surface (its base is raised by the heightfield
+        height beneath it) at ``add_robot`` and on every ``reset()``, rather
+        than at the flat-ground keyframe height that would leave its feet
+        buried below the raised terrain.
         """
         # mujoco verified at __init__
 
@@ -1176,6 +1182,7 @@ class MuJoCoSimEngine(
             # keeps each arm at its canonical home pose instead of silently
             # collapsing all but the most recently added robot.
             self._restore_home_poses()
+            self._seat_floating_bases_on_terrain()
             mj.mj_forward(self._world._model, self._world._data)
 
             # Attach the robot to the mesh as its own peer so the agent can
@@ -1328,6 +1335,47 @@ class MuJoCoSimEngine(
                     continue
                 adr = int(model.jnt_qposadr[jid])
                 data.qpos[adr : adr + len(vals)] = vals
+
+    def _seat_floating_bases_on_terrain(self) -> None:
+        """Raise each floating-base robot onto the local terrain surface.
+
+        ``create_world(terrain=...)`` lays a heightfield whose surface rises up
+        to ``TERRAIN_ELEVATION * difficulty`` above ``z=0``, but a robot's model
+        spawns its free base at the flat-ground keyframe height (e.g. the
+        Unitree Go2 base at ``z=0.445``, feet ~``z=0.02``). On a terrain world
+        that leaves the feet BELOW the heightfield -- the robot spawns *buried*
+        in the ground, with penetration that grows with the curriculum
+        ``difficulty`` -- contradicting the terrain feature's stated purpose of
+        spawning a locomotion robot ON non-flat ground. Offset each floating
+        base's ``z`` by the terrain height beneath its ``(x, y)`` so it is
+        seated on the surface (feet just clear of it), the correct initial
+        state for a locomotion policy and a terrain-difficulty curriculum.
+
+        A flat ground plane (``_ground_height_at`` returns ``0.0``) is a no-op,
+        so non-terrain worlds are byte-for-byte unchanged; a fixed-base arm (no
+        free joint) is skipped. Called once per spawn / reset cycle right after
+        the home-pose restore (which returns each base to its flat keyframe z),
+        so it starts from a known base height and is idempotent. Handles both a
+        NAMED floating base (a humanoid's ``floating_base_joint``) and an
+        UNNAMED ``<freejoint>`` (a mobile base) via
+        :meth:`_robot_free_base_joint_id`. The caller holds the model lock and
+        runs ``mj_forward`` afterwards.
+        """
+        world = self._world
+        if world is None or world._model is None or world._data is None:
+            return
+        model = world._model
+        data = world._data
+        if model.nhfield == 0:  # flat ground plane -- nothing to seat onto
+            return
+        for robot in world.robots.values():
+            jid = self._robot_free_base_joint_id(model, robot)
+            if jid < 0:  # fixed-base arm: no floating base to seat
+                continue
+            adr = int(model.jnt_qposadr[jid])
+            ground = self._ground_height_at(float(data.qpos[adr]), float(data.qpos[adr + 1]))
+            if ground:
+                data.qpos[adr + 2] = float(data.qpos[adr + 2]) + ground
 
     def remove_robot(self, name: str) -> dict[str, Any]:
         """Remove a robot and every element it injected (bodies, actuators,
@@ -2692,6 +2740,7 @@ class MuJoCoSimEngine(
             # so a keyframe spawn is sticky across resets -- mirroring how a
             # benchmark restores its canonical start pose each episode.
             self._restore_home_poses()
+            self._seat_floating_bases_on_terrain()
             mj.mj_forward(self._world._model, self._world._data)
             self._world.sim_time = 0.0
             self._world.step_count = 0

--- a/tests/simulation/test_add_robot_seats_on_terrain.py
+++ b/tests/simulation/test_add_robot_seats_on_terrain.py
@@ -1,0 +1,178 @@
+"""Regression tests: a floating-base robot spawns SEATED on the local terrain.
+
+``create_world(terrain=...)`` (#1336/#1338/#1339/#1340) lays a heightfield so a
+locomotion robot can be spawned and evaluated on non-flat ground -- that is the
+feature's stated purpose. But a robot's model spawns its free base at the
+flat-ground keyframe height (e.g. the Unitree Go2 base at ``z=0.445``, feet
+~``z=0.02``), which on a raised heightfield leaves the feet BELOW the terrain
+surface: the robot spawns *buried* in the ground, with penetration that grows
+with the curriculum ``difficulty``. Worse, a naive one-shot fix in ``add_robot``
+would not survive ``reset()`` (which ``run_policy`` / ``eval_policy`` call before
+and between episodes), snapping the base back to the buried flat-ground height.
+
+The engine now seats every floating base on the local terrain -- offsetting its
+``z`` by ``_ground_height_at(x, y)`` -- at ``add_robot`` spawn AND on every
+``reset()``, so the robot rests on the surface (feet just clear of it) at the
+start of every episode. A flat ground plane is a no-op (the height is ``0.0``)
+and a fixed-base arm (no free joint) is skipped. These tests are GL-free
+(``mesh=False``, no render) so they run in CI without a display.
+"""
+
+import os
+import tempfile
+
+import mujoco
+import pytest
+
+from strands_robots.simulation.mujoco.simulation import Simulation
+from strands_robots.simulation.terrain import terrain_elevation
+
+# A LOW floating base (base at z=0.4, foot sphere bottom at z=0.02) -- like a
+# quadruped, its feet sit well below a raised heightfield peak at the flat
+# spawn, so the burying is unambiguous. Two variants exercise the NAMED-free-
+# joint (humanoid ``floating_base_joint``) and UNNAMED-``<freejoint>`` (mobile
+# base, e.g. Go2) detection paths.
+_NAMED_LOW_BASE = """
+<mujoco model="seat_named">
+  <compiler angle="radian" autolimits="true"/>
+  <option timestep="0.002"/>
+  <worldbody>
+    <light name="main" pos="0 0 3" dir="0 0 -1"/>
+    <body name="base" pos="0 0 0.4">
+      <freejoint name="floating_base_joint"/>
+      <geom name="torso" type="box" size="0.1 0.05 0.03" rgba="0.3 0.3 0.8 1"/>
+      <body name="leg" pos="0 0 -0.35">
+        <joint name="knee" type="hinge" axis="0 1 0" range="-1.5 1.5"/>
+        <geom name="foot" type="sphere" size="0.03" rgba="0.8 0.3 0.3 1"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator><motor name="knee_act" joint="knee"/></actuator>
+</mujoco>
+"""
+
+_UNNAMED_LOW_BASE = _NAMED_LOW_BASE.replace(
+    '<freejoint name="floating_base_joint"/>', "<freejoint/>"
+).replace("seat_named", "seat_unnamed")
+
+# A fixed-base arm (no free joint): the seat must skip it without error.
+_FIXED_ARM = """
+<mujoco model="seat_fixed_arm">
+  <compiler angle="radian" autolimits="true"/>
+  <option timestep="0.002"/>
+  <worldbody>
+    <light name="main" pos="0 0 3" dir="0 0 -1"/>
+    <body name="link0" pos="0 0 0.0">
+      <geom type="box" size="0.05 0.05 0.05" rgba="0.5 0.5 0.5 1"/>
+      <body name="link1" pos="0 0 0.1">
+        <joint name="j0" type="hinge" axis="0 1 0" range="-1.5 1.5"/>
+        <geom type="capsule" size="0.02" fromto="0 0 0 0 0 0.2"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator><motor name="j0_act" joint="j0"/></actuator>
+</mujoco>
+"""
+
+
+def _write(xml: str) -> str:
+    d = tempfile.mkdtemp()
+    p = os.path.join(d, "model.xml")
+    with open(p, "w") as f:
+        f.write(xml)
+    return p
+
+
+def _lowest_collision_geom_z(sim) -> float:
+    """World z of the lowest collidable robot geom (skips the ground plane / hfield)."""
+    model, data = sim._world._model, sim._world._data
+    zs = []
+    for gid in range(model.ngeom):
+        if model.geom_contype[gid] == 0 and model.geom_conaffinity[gid] == 0:
+            continue
+        if model.geom_type[gid] in (mujoco.mjtGeom.mjGEOM_HFIELD, mujoco.mjtGeom.mjGEOM_PLANE):
+            continue
+        zs.append(float(data.geom_xpos[gid][2]))
+    assert zs, "no collidable robot geoms found"
+    return min(zs)
+
+
+def _base_z(sim) -> float:
+    model, data = sim._world._model, sim._world._data
+    for j in range(model.njnt):
+        if model.jnt_type[j] == mujoco.mjtJoint.mjJNT_FREE:
+            return float(data.qpos[int(model.jnt_qposadr[j]) + 2])
+    raise AssertionError("no free joint")
+
+
+@pytest.mark.parametrize("xml", [_NAMED_LOW_BASE, _UNNAMED_LOW_BASE], ids=["named_base", "unnamed_base"])
+def test_floating_base_spawns_seated_on_terrain(xml):
+    """A floating base spawns with its feet ON the terrain, not buried below it."""
+    sim = Simulation(tool_name="seat_terrain_spawn", mesh=False)
+    sim.create_world(ground_plane=True, terrain="pyramid", difficulty=2.0)
+    sim.add_robot("floater", urdf_path=_write(xml))
+    try:
+        ground = sim._ground_height_at(0.0, 0.0)
+        assert ground > 0.1  # a genuinely raised plateau (pyramid peak at the centre)
+        # The robot's flat-spawn feet (~0.02) would sit BELOW this plateau; the
+        # seat must have raised the base so the lowest geom clears the surface.
+        assert _lowest_collision_geom_z(sim) >= ground - 1e-6
+    finally:
+        sim.cleanup()
+
+
+def test_terrain_seat_survives_reset():
+    """The seat is re-applied on reset() -- run_policy/eval_policy reset each episode."""
+    sim = Simulation(tool_name="seat_terrain_reset", mesh=False)
+    sim.create_world(ground_plane=True, terrain="pyramid", difficulty=2.0)
+    sim.add_robot("floater", urdf_path=_write(_NAMED_LOW_BASE))
+    try:
+        ground = sim._ground_height_at(0.0, 0.0)
+        assert _lowest_collision_geom_z(sim) >= ground - 1e-6  # seated at spawn
+        assert sim.reset()["status"] == "success"
+        # After reset the base must still be seated (a one-shot add_robot fix
+        # would snap back to the buried flat-ground height here).
+        assert _lowest_collision_geom_z(sim) >= ground - 1e-6
+    finally:
+        sim.cleanup()
+
+
+def test_seat_offset_scales_with_difficulty():
+    """The base is raised by exactly the local terrain height (curriculum knob)."""
+    for difficulty in (0.5, 1.0, 2.0):
+        sim = Simulation(tool_name="seat_terrain_diff", mesh=False)
+        sim.create_world(ground_plane=True, terrain="pyramid", difficulty=difficulty)
+        sim.add_robot("floater", urdf_path=_write(_NAMED_LOW_BASE))
+        try:
+            ground = sim._ground_height_at(0.0, 0.0)
+            assert ground == pytest.approx(terrain_elevation(difficulty), abs=1e-6)
+            # base z == flat spawn (0.4) + the local terrain height.
+            assert _base_z(sim) == pytest.approx(0.4 + ground, abs=1e-6)
+        finally:
+            sim.cleanup()
+
+
+def test_flat_ground_spawn_is_unchanged():
+    """No heightfield -> the seat is a no-op (byte-for-byte flat behaviour)."""
+    sim = Simulation(tool_name="seat_flat_noop", mesh=False)
+    sim.create_world(ground_plane=True)
+    sim.add_robot("floater", urdf_path=_write(_NAMED_LOW_BASE))
+    try:
+        assert sim._ground_height_at(0.0, 0.0) == 0.0
+        assert _base_z(sim) == pytest.approx(0.4, abs=1e-9)  # flat keyframe z, no offset
+        sim.reset()
+        assert _base_z(sim) == pytest.approx(0.4, abs=1e-9)
+    finally:
+        sim.cleanup()
+
+
+def test_fixed_base_arm_on_terrain_is_skipped():
+    """A fixed-base arm has no free joint -> the seat skips it without error."""
+    sim = Simulation(tool_name="seat_fixed_arm", mesh=False)
+    sim.create_world(ground_plane=True, terrain="rough", difficulty=1.0)
+    result = sim.add_robot("arm", urdf_path=_write(_FIXED_ARM))
+    try:
+        assert result["status"] == "success"
+        assert sim.reset()["status"] == "success"  # no crash on the free-joint-less arm
+    finally:
+        sim.cleanup()

--- a/tests/simulation/test_add_robot_seats_on_terrain.py
+++ b/tests/simulation/test_add_robot_seats_on_terrain.py
@@ -51,9 +51,9 @@ _NAMED_LOW_BASE = """
 </mujoco>
 """
 
-_UNNAMED_LOW_BASE = _NAMED_LOW_BASE.replace(
-    '<freejoint name="floating_base_joint"/>', "<freejoint/>"
-).replace("seat_named", "seat_unnamed")
+_UNNAMED_LOW_BASE = _NAMED_LOW_BASE.replace('<freejoint name="floating_base_joint"/>', "<freejoint/>").replace(
+    "seat_named", "seat_unnamed"
+)
 
 # A fixed-base arm (no free joint): the seat must skip it without error.
 _FIXED_ARM = """


### PR DESCRIPTION
## Problem

`create_world(terrain=...)` lays a heightfield so a locomotion robot can be spawned and evaluated on non-flat ground -- the feature's stated purpose. But a robot's model spawns its free base at the **flat-ground keyframe height** (e.g. the Unitree Go2 base at `z=0.445`, feet ~`z=0.02`), so on a raised heightfield the feet start **below the terrain surface**: the robot spawns partially buried in the ground, with penetration that grows with the curriculum `difficulty`.

Ground truth on a pyramid (Go2, `add_robot("unitree_go2")`):

| difficulty | terrain peak | feet @ spawn | buried? | spawn contacts |
|---|---|---|---|---|
| 1.0 | 0.08 | 0.019 | yes | 12 |
| 2.0 | 0.16 | 0.019 | yes | 16 |
| 4.0 | 0.32 | 0.019 | yes (~0.30 m) | 20 |

Worse, a naive one-shot offset in `add_robot` would **not survive `reset()`** (which `run_policy` / `eval_policy` call before and between episodes) -- verified: a manual base-z offset is dropped back to `0.445` on the next `reset()`. So every episode of a terrain-difficulty curriculum would reset into a buried, mis-posed initial state.

## Change

`add_robot` and `reset()` now **seat every floating-base robot on the local terrain** via a shared `_seat_floating_bases_on_terrain()` helper: after the home-pose restore (which returns each base to its flat keyframe `z`), each free base's `z` is offset by `_ground_height_at(x, y)` so its feet rest on the surface at the start of **every** episode.

- **Flat ground plane is a no-op** (`_ground_height_at` returns `0.0`) -> non-terrain worlds are byte-for-byte unchanged.
- **Fixed-base arm is skipped** (no free joint).
- Handles both a **NAMED** floating base (a humanoid's `floating_base_joint`) and an **UNNAMED** `<freejoint>` (a mobile base) via the existing `_robot_free_base_joint_id` detection.
- Idempotent (starts from the restored flat keyframe `z` each spawn/reset cycle).

Verified on the Go2/pyramid: `d=1.0` base `0.445->0.525` (feet `0.099>=0.08`), `d=2.0` `0.445->0.605` (feet `0.179>=0.16`), `d=4.0` `0.445->0.765` (feet `0.339>=0.32`), and the seat survives `reset()`.

## Tests

New GL-free regression `tests/simulation/test_add_robot_seats_on_terrain.py` (6 tests): floating base spawns seated on terrain (named + unnamed free joint), the seat survives `reset()`, the offset equals the local terrain height and scales with `difficulty`, flat ground is a byte-for-byte no-op, and a fixed-base arm is skipped without error. The 4 terrain-seat assertions **fail before** this change (feet at `0.05` < the `0.16` plateau; base `0.4` not `0.44`) and pass after; the flat/fixed-arm guards pass both.

Green gate: ruff + mypy clean; **1410 simulation tests pass** (the new test + all terrain / benchmark / reset / add_robot / floating-base / recording / MuJoCo-backend suites). The existing terrain-relative predicate tests (`test_base_below_z_terrain`, `test_base_height_reward_terrain`) are unaffected -- they set an absolute base `z` via `_set_base_xy_z` after `add_robot` and don't `reset()`.

Docstrings (`create_world` on both the base contract and the MuJoCo backend) and `docs/simulation/world-building.md` updated to describe the seating behavior.

## Visual

Go2 on a pyramid (`difficulty=4.0`, peak `0.32 m`), rendered from the same view -- before (base `z=0.445`, feet buried) vs after (base `z=0.765`, seated on the surface). The seated render is a clean, coherent quadruped-on-terrain (no clipping / missing parts).

![before/after](https://github.com/cagataycali/robots/releases/download/artifacts-seat-terrain/seat_terrain_before_after.png)