### PR TITLE
feat(sim): get_ground_height(x, y) - query the local terrain surface height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Added: `get_ground_height(x, y)` -- query the local terrain surface height
+
+`create_world(terrain=...)` raises the local ground up to
+`TERRAIN_ELEVATION * difficulty` above `z=0`, and the terrain-relative
+locomotion predicates (`base_below_z` / `base_height`) plus the spawn/reset
+base-seating already sample that local surface internally. But there was no
+*public* way for a caller to ask where the terrain surface actually is, so a
+scene builder placing an object / camera / goal at a flat-ground `z` on a raised
+plateau spawned it BURIED in the heightfield -- a dynamic object then sinks
+through the terrain instead of resting on it (e.g. a 5 cm cube added at
+`z=0.03` on a `difficulty=2.0` pyramid whose local surface is at `z=0.16`
+penetrates 13 cm and settles below the ground).
+
+`get_ground_height(x, y)` exposes that surface as a facade query (and an
+agent-dispatch action): it returns the local terrain height in a
+`{"json": {"x", "y", "height"}}` block, `0.0` on a flat ground plane and for
+any backend without a heightfield. A caller can now place things on terrain
+correctly, e.g.
+`add_object("cube", position=[x, y, get_ground_height(x, y)["content"][1]["json"]["height"] + size_z / 2])`.
+The `add_object` docstring's flat-support rest-height guidance now points at it
+for terrain worlds. Non-finite coordinates are rejected.
+
 ### Fixed: a floating-base robot spawns SEATED on the terrain surface instead of buried below it
 
 `create_world(terrain=...)` lays a heightfield so a locomotion robot can be

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -19,6 +19,7 @@ Usage::
 from __future__ import annotations
 
 import logging
+import math
 import os
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping, Sequence
@@ -556,6 +557,50 @@ class SimEngine(ABC):
         threshold). Not a public tool action.
         """
         return 0.0
+
+    def get_ground_height(self, x: float, y: float) -> dict[str, Any]:
+        """Query the terrain surface height (world z) beneath world ``(x, y)``.
+
+        Public counterpart of the internal :meth:`_ground_height_at` hook: a
+        ``create_world(terrain=...)`` heightfield raises the local ground up to
+        ``TERRAIN_ELEVATION * difficulty`` above ``z=0``, and there was no public
+        way to ask where that surface is. Callers building a terrain scene need
+        it to place an object / camera / goal *on* the surface -- an object added
+        at a flat-ground ``z`` (computed as if the support were at ``z=0``) on a
+        raised plateau spawns *buried* in the heightfield and sinks through
+        instead of resting on it. The same local-height sampler already backs the
+        terrain-relative locomotion predicates
+        (:func:`~strands_robots.simulation.predicates.base_below_z`) and the
+        spawn/reset base-seating; this exposes it as a facade query.
+
+        Returns ``0.0`` for a flat ground plane and for any backend without a
+        heightfield, so a non-terrain world reports a flat surface.
+
+        Args:
+            x: World x coordinate.
+            y: World y coordinate.
+
+        Returns:
+            Agent-tool status dict. On success ``content`` carries a
+            ``{"json": {"x": ..., "y": ..., "height": ...}}`` block with the
+            surface height in meters. Errors when ``x`` / ``y`` is not a finite
+            real number.
+        """
+        for label, val in (("x", x), ("y", y)):
+            if isinstance(val, bool) or not isinstance(val, (int, float)) or not math.isfinite(float(val)):
+                return {
+                    "status": "error",
+                    "content": [{"text": f"get_ground_height: {label} must be a finite number, got {val!r}."}],
+                }
+        fx, fy = float(x), float(y)
+        height = float(self._ground_height_at(fx, fy))
+        return {
+            "status": "success",
+            "content": [
+                {"text": f"Ground height at ({fx:.4f}, {fy:.4f}) = {height:.4f}m"},
+                {"json": {"x": fx, "y": fy, "height": height}},
+            ],
+        }
 
     def _coerce_action(
         self, action: dict[str, Any] | Sequence[float], robot_name: str

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1755,6 +1755,10 @@ class MuJoCoSimEngine(
             "translational + rotational Jacobian of a body/site/geom for IK/control"
         )
         base["methods"]["get_total_mass"] = "() -> dict  # total mass of the model"
+        base["methods"]["get_ground_height"] = (
+            "(x, y) -> dict  # local terrain surface height (world z) beneath (x, y); "
+            "0.0 on flat ground -- place objects/cameras/goals on create_world(terrain=...) ground"
+        )
         base["methods"]["raycast"] = (
             "(origin: list[float], direction: list[float], exclude_body=-1, "
             "include_static=True) -> dict  # first geom hit along a world-frame "
@@ -2205,6 +2209,15 @@ class MuJoCoSimEngine(
         whose top is at ``z = 0.75`` settles with its body origin at
         ``z = 0.775``. Assuming half-extent makes objects look like they "sink
         into" a support when the rest height was simply mis-computed.
+
+        On a ``create_world(terrain=...)`` world the local ground beneath
+        ``(x, y)`` is *elevated* (up to ``TERRAIN_ELEVATION * difficulty`` above
+        ``z = 0``), so this flat-support formula -- which assumes a support at
+        ``z = 0`` -- leaves an object spawned there buried in the heightfield
+        (it then sinks through instead of resting on the surface). Query the
+        local surface with :meth:`get_ground_height` and add the shape's rest
+        offset (e.g. ``size_z / 2`` for a box) to place the object on the
+        terrain: ``position=[x, y, get_ground_height(x, y)["content"][1]["json"]["height"] + size_z / 2]``.
 
         Args:
             name: Unique object name. Its geom is injected as ``"<name>_geom"``.
@@ -3212,7 +3225,7 @@ class MuJoCoSimEngine(
                 "(direct path or auto-resolve from data_config name), add objects, run VLA policies, "
                 "render cameras, record trajectories, domain randomize. "
                 "Same Policy ABC as real robot control - sim and real with zero code changes. "
-                "Actions (67 total): "
+                "Actions (68 total): "
                 "[World] create_world, load_scene, reset, get_state, destroy, export_xml; "
                 "[Robots] add_robot, remove_robot, list_robots, get_robot_state, list_bodies; "
                 "[Objects] add_object, remove_object, move_object, list_objects; "
@@ -3221,7 +3234,7 @@ class MuJoCoSimEngine(
                 "[Rendering] render, render_depth, render_all, open_viewer, close_viewer; "
                 "[Physics] step, set_gravity, set_timestep, set_joint_positions, set_joint_velocities, "
                 "apply_force, get_contacts, get_contact_forces, get_body_state, get_energy, "
-                "get_total_mass, get_sensor_data, get_jacobian, get_mass_matrix, inverse_dynamics, "
+                "get_total_mass, get_ground_height, get_sensor_data, get_jacobian, get_mass_matrix, inverse_dynamics, "
                 "forward_kinematics, save_state, load_state, set_body_properties, set_geom_properties; "
                 "[Scene MJCF] replace_scene_mjcf, patch_scene_mjcf, raycast, multi_raycast; "
                 "[Recording] start_recording, save_episode, stop_recording, get_recording_status, "

--- a/strands_robots/simulation/mujoco/tool_spec.json
+++ b/strands_robots/simulation/mujoco/tool_spec.json
@@ -63,6 +63,7 @@
         "get_contact_forces",
         "forward_kinematics",
         "get_total_mass",
+        "get_ground_height",
         "export_xml",
         "render_all",
         "start_cameras_recording",
@@ -289,6 +290,14 @@
     "fast_mode": {
       "type": "boolean",
       "description": "Skip sleep between actions for faster data collection"
+    },
+    "x": {
+      "type": "number",
+      "description": "World x coordinate (for get_ground_height)"
+    },
+    "y": {
+      "type": "number",
+      "description": "World y coordinate (for get_ground_height)"
     },
     "body_name": {
       "type": "string",

--- a/tests/simulation/mujoco/test_ground_height_query.py
+++ b/tests/simulation/mujoco/test_ground_height_query.py
@@ -1,0 +1,91 @@
+"""Regression tests for the public ``get_ground_height(x, y)`` terrain query.
+
+``create_world(terrain=...)`` raises the local ground up to
+``TERRAIN_ELEVATION * difficulty`` above ``z = 0``, and the terrain-relative
+locomotion predicates + the spawn/reset base-seating already sample that local
+surface internally (``_ground_height_at``). But there was no *public* way for a
+caller to ask where the terrain surface is, so an object/camera/goal added at a
+flat-ground ``z`` on a raised plateau spawns buried in the heightfield and sinks
+through instead of resting on it. ``get_ground_height`` exposes the surface as a
+facade query (and agent-dispatch action). These tests build real worlds and read
+real geometry (GL-free -- no rendering): flat ground reports ``0.0``, a terrain
+world reports the elevated local surface (matching the internal sampler), the
+value is finite-validated, and it dispatches through the agent-tool router.
+"""
+
+from __future__ import annotations
+
+import math
+
+from strands_robots.simulation.mujoco.simulation import MuJoCoSimEngine
+
+
+def test_get_ground_height_flat_ground_returns_zero() -> None:
+    sim = MuJoCoSimEngine()
+    try:
+        sim.create_world(ground_plane=True)
+        r = sim.get_ground_height(0.13, -0.21)
+        assert r["status"] == "success"
+        payload = r["content"][1]["json"]
+        assert payload["x"] == 0.13 and payload["y"] == -0.21
+        assert payload["height"] == 0.0
+    finally:
+        sim.destroy()
+
+
+def test_get_ground_height_reports_elevated_terrain_surface() -> None:
+    """On a raised terrain world the query returns the local surface z (not 0),
+    matching the internal sampler that backs the locomotion predicates."""
+    sim = MuJoCoSimEngine()
+    try:
+        sim.create_world(ground_plane=True, terrain="pyramid", difficulty=2.0)
+        # Centre plateau of the pyramid is the highest ground.
+        r = sim.get_ground_height(0.0, 0.0)
+        assert r["status"] == "success"
+        height = r["content"][1]["json"]["height"]
+        # Elevated well above the flat-ground z=0 (the whole point of the query).
+        assert height > 0.1, f"expected an elevated centre plateau, got {height}"
+        # Public query must agree with the internal sampler the predicates use.
+        assert math.isclose(height, sim._ground_height_at(0.0, 0.0), abs_tol=1e-9)
+    finally:
+        sim.destroy()
+
+
+def test_get_ground_height_rejects_non_finite() -> None:
+    sim = MuJoCoSimEngine()
+    try:
+        sim.create_world(ground_plane=True)
+        for x, y in ((float("nan"), 0.0), (0.0, float("inf")), (0.0, float("-inf"))):
+            r = sim.get_ground_height(x, y)
+            assert r["status"] == "error"
+        # non-numeric / bool are not valid coordinates
+        assert sim.get_ground_height("a", 0.0)["status"] == "error"  # type: ignore[arg-type]
+        assert sim.get_ground_height(True, 0.0)["status"] == "error"  # type: ignore[arg-type]
+    finally:
+        sim.destroy()
+
+
+def test_get_ground_height_dispatches_via_tool_router() -> None:
+    sim = MuJoCoSimEngine()
+    try:
+        sim.create_world(ground_plane=True, terrain="pyramid", difficulty=2.0)
+        ok = sim(action="get_ground_height", x=0.0, y=0.0)
+        assert ok["status"] == "success"
+        assert ok["content"][1]["json"]["height"] > 0.1
+        # both coordinates are required
+        missing = sim(action="get_ground_height", x=0.0)
+        assert missing["status"] == "error"
+        assert "y" in missing["content"][0]["text"]
+    finally:
+        sim.destroy()
+
+
+def test_get_ground_height_is_discoverable() -> None:
+    """Advertised in the tool_spec enum and the describe() methods surface."""
+    sim = MuJoCoSimEngine()
+    try:
+        enum = sim.tool_spec["inputSchema"]["json"]["properties"]["action"]["enum"]
+        assert "get_ground_height" in enum
+        assert "get_ground_height" in sim.describe()["methods"]
+    finally:
+        sim.destroy()


### PR DESCRIPTION
## Summary

`create_world(terrain=...)` raises the local ground up to `TERRAIN_ELEVATION * difficulty` above `z=0`, and the terrain-relative locomotion predicates (`base_below_z` / `base_height`) plus the spawn/reset base-seating already sample that local surface internally (`_ground_height_at`). But there was **no public way** for a caller to ask where the terrain surface actually is.

That gap silently breaks scene-building on terrain: an object/camera/goal placed at a flat-ground `z` on a raised plateau spawns **buried in the heightfield**, and a dynamic object then sinks *through* the terrain instead of resting on it. Confirmed empirically on a `difficulty=2.0` pyramid (local centre surface `z=0.16`):

```
add_object('cube', position=[0, 0, 0.03], size=[0.05]*3)
  -> penetration = 0.13 m (buried); after 200 steps cube z = -0.022 (sunk through, below the surface)
```

## Change

Expose the surface as a facade query (and an agent-dispatch action):

```python
sim.get_ground_height(x, y)
# -> {"status": "success", "content": [{"text": ...}, {"json": {"x", "y", "height"}}]}
```

- Returns the local terrain height in meters; **`0.0` on a flat ground plane and for any backend without a heightfield** (so a non-terrain world reports a flat surface).
- **Concrete on the `SimEngine` base** (wraps the existing `_ground_height_at` hook), so it works across MuJoCo / Newton with one implementation; Newton reports `0.0` (it has no heightfield support), MuJoCo bilinearly samples the `create_world(terrain=...)` field.
- Advertised in the MuJoCo `tool_spec` enum (67 -> 68) + the `describe()` methods surface + the `[Physics]` group, so an agent driving the sim tool can discover it.
- Non-finite coordinates (`NaN`/`inf`) and non-numeric / bool are rejected with an actionable error.

A caller can now place things on terrain correctly, e.g.

```python
h = sim.get_ground_height(x, y)["content"][1]["json"]["height"]
sim.add_object("cube", position=[x, y, h + size_z / 2])  # rests ON the terrain
```

The `add_object` docstring's flat-support rest-height guidance (which assumed a support at `z=0`) now documents the terrain case and points at `get_ground_height`.

## Tests

`tests/simulation/mujoco/test_ground_height_query.py` (GL-free -- builds real worlds, reads real geometry):
- flat ground returns `0.0`;
- a `difficulty=2.0` pyramid reports the elevated local surface and **matches the internal sampler** that backs the locomotion predicates;
- non-finite / non-numeric coordinates are rejected;
- dispatches through the agent-tool router and requires both coordinates;
- discoverable in the `tool_spec` enum + `describe()`.

All 5 fail before the change (method absent, not in the enum) and pass after. Green gate: `ruff check` + `ruff format` clean; `mypy` clean on the changed sources; the `tool_spec` / `describe()` anti-drift wards and the terrain suite pass (70 passed across the touched suites).

Additive, non-breaking (a new query + one tool action; no existing behaviour changes).