### PR TITLE
docs(examples): add benchmark evaluation example (10_evaluate_benchmark.py)

### DIFF
--- a/examples/10_evaluate_benchmark.py
+++ b/examples/10_evaluate_benchmark.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Register the built-in locomotion benchmarks and evaluate a policy on one.
+
+Goal: Show the evaluation loop - how to score a policy on a task and read back
+success rate and reward, not just watch it move. ``register_builtin_benchmarks()``
+adds five ready-to-run velocity-tracking locomotion tasks (Go2 walk / strafe /
+turn, G1 walk, T1 walk); ``list_benchmarks()`` reports what is registered and
+which robot each one targets; ``evaluate_benchmark(...)`` runs N episodes and
+returns a metrics dict (``success_rate``, ``avg_reward``, ``avg_steps``, plus a
+per-episode breakdown).
+
+This uses the ``mock`` policy so it runs anywhere - no GPU, no checkpoint, no
+hardware. A mock policy will not actually walk, so expect a low success rate;
+the point is the eval harness and the numbers it produces. Swap
+``policy_provider`` (and a real checkpoint via ``policy_config``) to score a
+trained locomotion policy on the identical benchmark.
+
+Dependencies: pip install "strands-robots[sim-mujoco]"
+Expected output: the registered benchmark table, then a metrics line per episode
+set. Runtime: ~10 seconds on CPU.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from strands_robots import Robot
+from strands_robots.simulation import register_builtin_benchmarks
+from strands_robots.simulation.benchmark import list_benchmarks
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--benchmark", default="go2_walk_forward", help="benchmark to evaluate")
+    parser.add_argument("--episodes", type=int, default=2, help="number of evaluation episodes")
+    parser.add_argument("--policy", default="mock", help="policy provider to score (mock needs no GPU)")
+    args = parser.parse_args()
+
+    # Register the five built-in locomotion benchmarks (idempotent).
+    register_builtin_benchmarks()
+
+    # What is available, and which robot each benchmark targets.
+    print("Registered benchmarks:")
+    registry = list_benchmarks()
+    for name, meta in registry.items():
+        print(f"  {name:20} robot={meta['default_robot']:14} max_steps={meta['max_steps']}")
+
+    if args.benchmark not in registry:
+        raise SystemExit(f"unknown benchmark {args.benchmark!r}; choose one of {sorted(registry)}")
+
+    # Spawn the benchmark's target robot and evaluate. evaluate_benchmark builds
+    # the task scene, runs the policy for up to max_steps per episode, scores the
+    # success predicate, and accumulates the dense reward.
+    robot_name = registry[args.benchmark]["default_robot"]
+    sim = Robot(robot_name, mesh=False)
+
+    result = sim.evaluate_benchmark(
+        args.benchmark,
+        policy_provider=args.policy,
+        n_episodes=args.episodes,
+    )
+    if result.get("status") == "error":
+        msg = "; ".join(c.get("text", "") for c in result.get("content", []))
+        raise RuntimeError(f"evaluate_benchmark failed: {msg}")
+
+    metrics = next((c["json"] for c in result.get("content", []) if "json" in c), {})
+    print(f"\n{args.benchmark} on {robot_name} with the {args.policy!r} policy:")
+    print(f"  episodes      : {metrics.get('episodes_completed')}")
+    print(f"  success_rate  : {metrics.get('success_rate')}")
+    print(f"  avg_reward    : {metrics.get('avg_reward')}")
+    print(f"  avg_steps     : {metrics.get('avg_steps')}")
+    print("\n(The mock policy does not walk, so success_rate is expected to be low - the")
+    print(" point is the eval harness. Point --policy at a trained provider to score it.)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/README.md
+++ b/examples/README.md
@@ -28,6 +28,7 @@ record→train→deploy loop) as Jupyter notebooks - all CPU-only, no hardware o
 | 07 | [`07_post_tune_any_policy.py`](07_post_tune_any_policy.py) | `create_trainer` + `TrainSpec` (record→train→load) | No | No |
 | 08 | [`08_discover_lerobot.py`](08_discover_lerobot.py) | `use_lerobot` tool: discover LeRobot robots, policies, teleoperators, cameras | No | No |
 | 09 | [`09_procedural_terrain.py`](09_procedural_terrain.py) | `create_world(terrain=...)` heightfield ground + `difficulty` curriculum | No | No |
+| 10 | [`10_evaluate_benchmark.py`](10_evaluate_benchmark.py) | `register_builtin_benchmarks` + `evaluate_benchmark` (success rate / reward) | No | No |
 | -- | [`vla_g1_workflow.py`](vla_g1_workflow.py) | VLA-on-G1: record -> GR00T fine-tune -> WBC deploy | No | Optional (tune) |
 | — | [`vera_mimicgen_panda/`](vera_mimicgen_panda/) | VERA MimicGen → Panda (eef-delta + IK bridge) | No | **Yes** (server) |
 | -- | [`lerobot_hardware_catalog.py`](lerobot_hardware_catalog.py) | `Robot()` covers the whole LeRobot hardware catalog (name -> lerobot_type) | No | No |


### PR DESCRIPTION
## What

Adds `examples/10_evaluate_benchmark.py` — a CPU-only example for the **evaluation loop**, which no example currently covers.

The repo ships five built-in locomotion benchmarks and a full metrics subsystem, but examples only ever *run* a policy — none *score* one. This fills that gap:

1. `register_builtin_benchmarks()` — registers the five velocity-tracking tasks (Go2 walk/strafe/turn, G1 walk, T1 walk).
2. `list_benchmarks()` — reports what's registered and each benchmark's target robot.
3. `evaluate_benchmark(...)` — runs N episodes and returns `success_rate` / `avg_reward` / `avg_steps` plus a per-episode breakdown.

Uses the `mock` policy so it runs anywhere — no GPU, checkpoint, or hardware. (Mock doesn't walk, so success_rate is low by design; the point is the harness. Swap `--policy` to score a trained provider on the same benchmark.)

## Testing

- Runs end-to-end on CPU (macOS, `MUJOCO_GL=cgl`), ~10s. Verified against current `main`.
- `ruff check` + `ruff format --check` clean, ASCII-only, no host paths.
- Adds row 10 to `examples/README.md`.

Sample output:
```
Registered benchmarks:
  go2_walk_forward     robot=unitree_go2    max_steps=1000
  ...
go2_walk_forward on unitree_go2 with the 'mock' policy:
  success_rate  : 0.0
  avg_reward    : 8.19
  avg_steps     : 48.0
```