### PR TITLE
docs(examples): add declarative-benchmark authoring example (11_author_a_benchmark.py)

### DIFF
--- a/examples/11_author_a_benchmark.py
+++ b/examples/11_author_a_benchmark.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Author your own benchmark from a spec dict and evaluate a policy on it.
+
+Goal: Show the declarative benchmark DSL - how to define a *new* task (success
+condition, failure conditions, dense shaping reward) as a plain dict of named
+predicates, with no Python subclass and no ``eval`` of untrusted strings. This
+is the same path the built-in benchmarks use, and because the spec is pure data
+it is safe to load from JSON/YAML an agent produced.
+
+The task defined here is a harder curriculum variant of the built-in
+``go2_walk_forward``: walk the Go2 past 4 m (not 2 m) at a faster 1.5 m/s target,
+failing if it tips or its base drops. ``DeclarativeBenchmark.from_dict(spec)``
+compiles the dict against the closed predicate registry (an unknown predicate or
+a bad argument is rejected at compile time, not at eval time), ``register_benchmark``
+adds it to the registry, and ``evaluate_benchmark`` scores it - identical to the
+built-ins.
+
+Runs on the ``mock`` policy so it needs no GPU, checkpoint, or hardware; mock
+does not actually walk, so success is expected to be false - the point is
+authoring and scoring a custom task. Point ``--policy`` at a trained provider to
+score it on your task.
+
+Dependencies: pip install "strands-robots[sim-mujoco]"
+Expected output: the compiled benchmark's metadata, then its evaluation metrics.
+Runtime: ~10 seconds on CPU.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from strands_robots import Robot
+from strands_robots.simulation.benchmark import register_benchmark
+from strands_robots.simulation.benchmark_spec import DeclarativeBenchmark
+
+# The whole task, as data. Every "predicate" name is resolved against the closed
+# registry in strands_robots.simulation.predicates - there is no arbitrary code
+# here, so a spec like this is safe to load from an untrusted JSON/YAML source.
+BENCHMARK_SPEC = {
+    "name": "go2_walk_far_fast",
+    "instruction": "Walk forward at 1.5 m/s and cover at least 4 meters without tipping.",
+    "default_robot": "unitree_go2",
+    "supported_robots": ["unitree_go2"],
+    "max_steps": 800,
+    # SUCCESS: base travels past x = 4 m.
+    "success": {"all": [{"predicate": "base_beyond_x", "x": 4.0}]},
+    # FAILURE: tips over, or the base collapses below 0.18 m.
+    "failure": {
+        "any": [
+            {"predicate": "base_tipped", "tol": 0.7},
+            {"predicate": "base_below_z", "z": 0.18},
+        ]
+    },
+    # DENSE REWARD: track a 1.5 m/s forward twist, hold nominal height + upright.
+    "dense_reward": [
+        {"predicate": "base_velocity_tracking", "vx": 1.5, "lin_weight": 1.0, "ang_weight": 0.5},
+        {"predicate": "base_height", "target": 0.32, "weight": 0.5},
+        {"predicate": "base_orientation", "weight": 0.5},
+    ],
+}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--episodes", type=int, default=2, help="number of evaluation episodes")
+    parser.add_argument("--policy", default="mock", help="policy provider to score (mock needs no GPU)")
+    args = parser.parse_args()
+
+    # Compile the spec: an unknown predicate name or a wrong argument raises here,
+    # before anything runs, rather than failing mid-episode.
+    benchmark = DeclarativeBenchmark.from_dict(BENCHMARK_SPEC)
+    register_benchmark(benchmark.name, benchmark)
+    print(f"Registered custom benchmark: {benchmark.name}")
+    print(f"  robot       : {benchmark.default_robot}")
+    print(f"  instruction : {benchmark.instruction}")
+
+    # Evaluate it exactly like a built-in benchmark.
+    sim = Robot(benchmark.default_robot, mesh=False)
+    result = sim.evaluate_benchmark(benchmark.name, policy_provider=args.policy, n_episodes=args.episodes)
+    if result.get("status") == "error":
+        msg = "; ".join(c.get("text", "") for c in result.get("content", []))
+        raise RuntimeError(f"evaluate_benchmark failed: {msg}")
+
+    metrics = next((c["json"] for c in result.get("content", []) if "json" in c), {})
+    print(f"\n{benchmark.name} with the {args.policy!r} policy:")
+    print(f"  success_rate : {metrics.get('success_rate')}")
+    print(f"  avg_reward   : {metrics.get('avg_reward')}")
+    print(f"  avg_steps    : {metrics.get('avg_steps')}")
+    print("\n(mock does not walk, so success_rate is expected to be 0 - the point is that")
+    print(" you authored and scored a new task with a dict. Point --policy at a trained")
+    print(" locomotion provider to score it for real.)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/README.md
+++ b/examples/README.md
@@ -28,6 +28,7 @@ record→train→deploy loop) as Jupyter notebooks - all CPU-only, no hardware o
 | 07 | [`07_post_tune_any_policy.py`](07_post_tune_any_policy.py) | `create_trainer` + `TrainSpec` (record→train→load) | No | No |
 | 08 | [`08_discover_lerobot.py`](08_discover_lerobot.py) | `use_lerobot` tool: discover LeRobot robots, policies, teleoperators, cameras | No | No |
 | 09 | [`09_procedural_terrain.py`](09_procedural_terrain.py) | `create_world(terrain=...)` heightfield ground + `difficulty` curriculum | No | No |
+| 11 | [`11_author_a_benchmark.py`](11_author_a_benchmark.py) | `DeclarativeBenchmark.from_dict` + predicate DSL (author a task) | No | No |
 | -- | [`vla_g1_workflow.py`](vla_g1_workflow.py) | VLA-on-G1: record -> GR00T fine-tune -> WBC deploy | No | Optional (tune) |
 | — | [`vera_mimicgen_panda/`](vera_mimicgen_panda/) | VERA MimicGen → Panda (eef-delta + IK bridge) | No | **Yes** (server) |
 | -- | [`lerobot_hardware_catalog.py`](lerobot_hardware_catalog.py) | `Robot()` covers the whole LeRobot hardware catalog (name -> lerobot_type) | No | No |


### PR DESCRIPTION
## What

Adds `examples/11_author_a_benchmark.py` — a CPU-only example for the **declarative benchmark DSL**, a headline capability with no example coverage.

Users can define a *new* task entirely as data — success condition, failure conditions, and a dense shaping reward — as a dict of named predicates, then compile and score it with no Python subclass and no `eval` of untrusted strings. Because the spec is pure data validated against the closed predicate registry, it's safe to load from JSON/YAML an agent produced.

The example authors a harder curriculum variant of the built-in `go2_walk_forward` (walk past 4 m at 1.5 m/s, fail on tip/collapse):
1. `DeclarativeBenchmark.from_dict(spec)` — compiles + validates against the predicate registry (unknown predicate or bad arg is rejected at compile time).
2. `register_benchmark(...)` — adds it to the registry.
3. `evaluate_benchmark(...)` — scores it, identical to the built-ins.

Uses the `mock` policy so it runs with no GPU, checkpoint, or hardware.

## Testing

- Runs end-to-end on CPU (macOS, `MUJOCO_GL=cgl`), ~10s. Verified against current `main`.
- `ruff check` + `ruff format --check` clean, ASCII-only, no host paths.
- Adds row 11 to `examples/README.md`.

Pairs naturally with the benchmark-evaluation example in #1390 (running the built-ins vs authoring your own).