### PR TITLE
test(mesh): pin _ensure_ca fail-closed on an unreadable existing CA

### DIFF
--- a/tests/mesh/test_iot_ca_pin.py
+++ b/tests/mesh/test_iot_ca_pin.py
@@ -6,7 +6,9 @@ SHA-256 fingerprint before writing the file to disk. These tests exercise:
 * :func:`_verify_ca_bytes` accepts the canonical bytes and rejects any
   one-byte modification.
 * :func:`_ensure_ca` raises on a rogue download, on a tampered on-disk
-  copy, and on responses larger than :data:`_CA_FETCH_MAX_BYTES`.
+  copy, on an unreadable existing copy (fail-closed on an O_NOFOLLOW
+  symlink-swap race), and on responses larger than
+  :data:`_CA_FETCH_MAX_BYTES`.
 * The :envvar:`STRANDS_MESH_DISABLE_CA_PIN` break-glass env var bypasses
   the check (with a WARNING log) for proxy environments that legitimately
   re-encode the cert.
@@ -14,6 +16,7 @@ SHA-256 fingerprint before writing the file to disk. These tests exercise:
 
 from __future__ import annotations
 
+import errno
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -103,6 +106,26 @@ class TestEnsureCA:
         with patch("strands_robots.mesh.iot.provision.urllib.request.urlopen") as mock_url:
             with patch("strands_robots.mesh.iot.provision.os.read", side_effect=chunked_read):
                 provision._ensure_ca(ca_path)
+            mock_url.assert_not_called()
+
+    def test_existing_file_unreadable_fails_closed(self, tmp_path):
+        # A regular, non-symlink CA file that becomes unreadable at open
+        # time (e.g. an O_NOFOLLOW symlink-swap race lands here with ELOOP,
+        # or the file is genuinely unreadable) MUST fail closed: raise a
+        # RuntimeError rather than silently skipping the pin check or
+        # falling through to download-and-trust. Regression guard for the
+        # ``except OSError`` catch in the existing-file re-use branch.
+        ca_path = tmp_path / "ca.pem"
+        ca_path.write_bytes(_REAL_CA)
+
+        def raise_eloop(*_args, **_kwargs):
+            raise OSError(errno.ELOOP, "Too many levels of symbolic links")
+
+        with patch("strands_robots.mesh.iot.provision.urllib.request.urlopen") as mock_url:
+            with patch("strands_robots.mesh.iot.provision.os.open", side_effect=raise_eloop):
+                with pytest.raises(RuntimeError, match="unreadable"):
+                    provision._ensure_ca(ca_path)
+            # Fail-closed: must NOT reach the download path.
             mock_url.assert_not_called()
 
     def test_existing_tampered_file_raises(self, tmp_path):


### PR DESCRIPTION
## Problem

`_ensure_ca` (IoT provisioning, `strands_robots/mesh/iot/provision.py`) re-verifies an on-disk `AmazonRootCA1.pem` against a pinned SHA-256 before re-using it. To defeat a TOCTOU symlink-swap, it opens the file with `O_NOFOLLOW` and catches `OSError`, re-raising it as a `RuntimeError`. This is the fail-closed guard: an attacker who plants a symlink between the `is_symlink()` check and `os.open` lands here with `ELOOP`, and a genuinely unreadable file lands here too. In both cases the provisioner must refuse to proceed rather than silently skip the pin check or fall through to the download-and-trust path.

The existing suite covered the neighbouring branches - explicit symlink rejection, pin mismatch, short-read draining, and the break-glass override - but not this `except OSError` fail-closed branch, leaving the security-critical race handling unpinned.

## Change

Add one focused regression test, `TestEnsureCA::test_existing_file_unreadable_fails_closed`, that:

- writes a valid, regular (non-symlink) CA file, then
- patches `os.open` to raise `OSError(ELOOP, ...)` (the symlink-swap race signature), and
- asserts the call fails closed with a `RuntimeError` matching `unreadable` and never reaches the download path (`urlopen` is asserted not called).

Proved to be a genuine guard: on current code the raised message is `AmazonRootCA1 at <path> unreadable: [Errno 40] ...`; if the fail-closed `raise` is removed the behaviour changes (falls through to the pin-check / download path), which this test forbids.

Test-only change, no behaviour change. Docstring at the top of the test module updated to list the newly-covered fail-closed case.

## Tests

`tests/mesh/test_iot_ca_pin.py`: 27 passed (was 26). The new test covers the previously-uncovered `except OSError` branch in `_ensure_ca`. Full lint gate clean: `ruff check`, `ruff format --check`, and `mypy` over `strands_robots tests tests_integ` all pass.