### PR TITLE
docs(examples): add domain-randomization example (12_domain_randomization.py)

### DIFF
--- a/examples/12_domain_randomization.py
+++ b/examples/12_domain_randomization.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Randomize appearance, physics, and sensor noise for sim2real robustness.
+
+Goal: Show the two sim2real primitives that make a recorded dataset (or an
+in-sim eval) robust instead of overfit to one pristine scene:
+
+  - ``randomize`` perturbs the world: geom colors, lighting, per-geom friction,
+    and per-body mass - seeded, so a run is reproducible.
+  - ``set_obs_noise`` adds sensor noise to observations: joint position/velocity
+    Gaussian noise and camera pixel jitter, mimicking real encoders/cameras.
+
+Training on randomized episodes teaches a policy to generalize across the
+appearance and dynamics gap between sim and hardware. This example renders a
+baseline frame, randomizes, renders again to show the change, then applies
+observation noise and prints the perturbed joint reading.
+
+Runs on CPU, no GPU/checkpoint/hardware. On macOS the offscreen renderer needs
+``MUJOCO_GL=cgl``; on headless Linux use ``MUJOCO_GL=egl``.
+
+Dependencies: pip install "strands-robots[sim-mujoco]"
+Expected output: two PNGs (baseline + randomized) under the output dir, plus a
+before/after joint reading showing the injected noise. Runtime: ~5 seconds.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+
+import imageio.v3 as iio
+
+from strands_robots import Robot
+
+
+def _check(result: dict, what: str) -> dict:
+    """Raise if a sim action returned an error dict - never continue silently."""
+    if isinstance(result, dict) and result.get("status") == "error":
+        msg = "; ".join(c.get("text", "") for c in result.get("content", []))
+        raise RuntimeError(f"{what} failed: {msg}")
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--seed", type=int, default=0, help="randomization seed (reproducible)")
+    parser.add_argument("--out", default="/tmp/strands_domain_rand", help="directory for the PNG frames")
+    args = parser.parse_args()
+
+    out_dir = pathlib.Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    sim = Robot("so100", mesh=False)
+    sim.add_object(
+        name="cube",
+        shape="box",
+        size=[0.025, 0.025, 0.025],
+        position=[0.2, 0.0, 0.05],
+        color=[1, 0, 0, 1],
+        mass=0.05,
+    )
+    sim.add_camera(name="view", position=[0.5, 0.0, 0.4], target=[0.2, 0.0, 0.05])
+
+    # Baseline frame (pristine scene).
+    baseline = out_dir / "01_baseline.png"
+    iio.imwrite(baseline, sim.get_observation("so100")["view"])
+    print(f"baseline frame           -> {baseline}")
+
+    # Perturb the world: colors + lighting + per-geom friction + per-body mass.
+    r = _check(
+        sim._dispatch_action(
+            "randomize",
+            {"randomize_colors": True, "randomize_lighting": True, "randomize_physics": True, "seed": args.seed},
+        ),
+        "randomize",
+    )
+    print("randomize:", (r.get("content") or [{}])[0].get("text", "").splitlines()[0])
+
+    randomized = out_dir / "02_randomized.png"
+    iio.imwrite(randomized, sim.get_observation("so100")["view"])
+    print(f"randomized frame (seed={args.seed}) -> {randomized}")
+
+    # Read a clean joint value, then turn on sensor noise and read again. A
+    # scalar joint reading is any float obs key that is not a velocity (.vel),
+    # a camera image, or a floating-base pose field.
+    obs = sim.get_observation("so100")
+    joint_key = next(
+        k for k, v in obs.items() if not k.endswith(".vel") and not k.startswith("base") and isinstance(v, float)
+    )
+    clean = float(sim.get_observation("so100")[joint_key])
+    _check(
+        sim._dispatch_action("set_obs_noise", {"joint_pos_std": 0.02, "joint_vel_std": 0.05, "camera_jitter_px": 1.0}),
+        "set_obs_noise",
+    )
+    noisy = float(sim.get_observation("so100")[joint_key])
+    print(f"\njoint {joint_key!r}: clean={clean:.4f} rad  noisy={noisy:.4f} rad  (delta={noisy - clean:+.4f})")
+    print("Sensor noise is now applied to every observation until reset.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/README.md
+++ b/examples/README.md
@@ -28,6 +28,7 @@ record→train→deploy loop) as Jupyter notebooks - all CPU-only, no hardware o
 | 07 | [`07_post_tune_any_policy.py`](07_post_tune_any_policy.py) | `create_trainer` + `TrainSpec` (record→train→load) | No | No |
 | 08 | [`08_discover_lerobot.py`](08_discover_lerobot.py) | `use_lerobot` tool: discover LeRobot robots, policies, teleoperators, cameras | No | No |
 | 09 | [`09_procedural_terrain.py`](09_procedural_terrain.py) | `create_world(terrain=...)` heightfield ground + `difficulty` curriculum | No | No |
+| 12 | [`12_domain_randomization.py`](12_domain_randomization.py) | `randomize` + `set_obs_noise` (sim2real appearance/physics/sensor noise) | No | No |
 | -- | [`vla_g1_workflow.py`](vla_g1_workflow.py) | VLA-on-G1: record -> GR00T fine-tune -> WBC deploy | No | Optional (tune) |
 | — | [`vera_mimicgen_panda/`](vera_mimicgen_panda/) | VERA MimicGen → Panda (eef-delta + IK bridge) | No | **Yes** (server) |
 | -- | [`lerobot_hardware_catalog.py`](lerobot_hardware_catalog.py) | `Robot()` covers the whole LeRobot hardware catalog (name -> lerobot_type) | No | No |


### PR DESCRIPTION
## What

Adds `examples/12_domain_randomization.py` — a CPU-only example for the two **sim2real** primitives, which no example covers despite being central to the record->train->deploy story:

- `randomize` — seeded perturbation of geom **colors**, **lighting**, per-geom **friction**, and per-body **mass**.
- `set_obs_noise` — Gaussian **joint pos/vel** noise + **camera pixel jitter** on observations, mimicking real encoders/cameras.

The example renders a baseline frame, randomizes, renders again to show the appearance change, then reads a joint value before/after enabling sensor noise to show the injected perturbation. Training on randomized episodes is what makes a policy generalize across the sim-to-hardware gap.

## Testing

- Runs end-to-end on CPU (macOS, `MUJOCO_GL=cgl`), ~5s. Verified against current `main`; visually confirmed the randomized frame is recolored/re-lit.
- `ruff check` + `ruff format --check` clean, ASCII-only, no host paths.
- Adds row 12 to `examples/README.md`.