### PR TITLE
test(sim): cover the terrain-curriculum locomotion-benchmark composition on the real Go2

### DIFF
--- a/tests_integ/simulation/test_builtin_benchmark_load.py
+++ b/tests_integ/simulation/test_builtin_benchmark_load.py
@@ -47,6 +47,8 @@ import pytest
 
 os.environ.setdefault("MUJOCO_GL", "egl")
 
+import mujoco  # noqa: E402 - after the MUJOCO_GL default is set
+
 from strands_robots.registry import has_sim  # noqa: E402 - after MUJOCO_GL default
 from strands_robots.simulation import create_simulation  # noqa: E402
 from strands_robots.simulation.benchmark import (  # noqa: E402
@@ -136,5 +138,151 @@ def test_shipped_benchmark_runs_on_its_real_robot(bench_name: str) -> None:
         assert payload["episodes_completed"] == 1
         assert payload["success_measured"] is True
         assert math.isfinite(payload["avg_reward"]), f"{bench_name}: avg_reward is not finite"
+    finally:
+        sim.destroy()
+
+
+# ---------------------------------------------------------------------------
+# Terrain-curriculum composition: a shipped locomotion benchmark run on a
+# create_world(terrain=...) heightfield world -- the #873 terrain-curriculum
+# reset state a difficulty ramp would evaluate into every episode.
+#
+# The terrain heightfield kinds + difficulty knob (#1336/#1338/#1339/#1340/
+# #1344), the seat-on-terrain spawn (#1386), the terrain-relative fall/height
+# predicates that measure clearance above the LOCAL surface (#1364/#1368), and
+# the runnable benchmark composition (#1259) each landed with isolated coverage.
+# Nothing exercised them TOGETHER -- a real benchmark eval on raised ground:
+# tests/simulation/test_add_robot_seats_on_terrain.py checks the seat on a
+# SYNTHETIC base with no benchmark, and tests/simulation/test_base_below_z_terrain.py
+# checks the predicate in isolation on a flat-registered synthetic base. So a
+# regression in the seat, the terrain-relative predicate, or the eval-loop's
+# per-episode reset-seat could silently break a terrain-curriculum benchmark
+# while every existing test still passes. These two tests close that seam on the
+# real Unitree Go2 (the canonical quadruped-locomotion embodiment).
+_TERRAIN = "pyramid"
+_DIFFICULTY = 2.0
+
+
+def _lowest_collision_geom_z(sim: Any) -> float:
+    """World z of the lowest collidable robot geom (skips the ground plane / hfield)."""
+    model, data = sim._world._model, sim._world._data
+    zs = [
+        float(data.geom_xpos[g][2])
+        for g in range(model.ngeom)
+        if not (model.geom_contype[g] == 0 and model.geom_conaffinity[g] == 0)
+        and model.geom_type[g] not in (mujoco.mjtGeom.mjGEOM_HFIELD, mujoco.mjtGeom.mjGEOM_PLANE)
+    ]
+    assert zs, "no collidable robot geoms found"
+    return min(zs)
+
+
+def test_go2_walk_forward_seats_and_runs_on_terrain() -> None:
+    """go2_walk_forward composes with a raised-terrain world (the curriculum reset state).
+
+    On a ``create_world(terrain=..., difficulty=...)`` heightfield the shipped
+    benchmark must: (1) spawn the Go2 SEATED on the local surface -- its lowest
+    collidable geom on/above the plateau, not buried below it (the #1386 seat,
+    which the benchmark eval's per-episode ``reset`` relies on to start each
+    episode on the terrain); (2) hold the standing-spawn contract there (a
+    seated, upright Go2 on the plateau is neither already-``failure`` nor
+    already-``success``); and (3) run the whole ``evaluate_benchmark`` harness
+    end-to-end on the terrain world (a mock policy driving real physics), scoring
+    the episode without error. Reverting the seat leaves the feet ~one plateau
+    height (``TERRAIN_ELEVATION * difficulty``) below the surface, failing (1).
+    """
+    spec = _SHIPPED_SPECS["go2_walk_forward"]
+    robot = spec["default_robot"]
+    assert has_sim(robot), f"default_robot {robot!r} is not simulatable"
+
+    trimmed = copy.deepcopy(spec)
+    trimmed["max_steps"] = _SMOKE_STEPS
+    register_benchmark("go2_walk_forward", DeclarativeBenchmark.from_dict(trimmed))
+
+    sim: Any = create_simulation(backend="mujoco")
+    sim.create_world(ground_plane=True, terrain=_TERRAIN, difficulty=_DIFFICULTY)
+    sim.add_robot(robot)  # seats the free base on the terrain at spawn (#1386)
+    try:
+        ground = sim._ground_height_at(0.0, 0.0)
+        assert ground > 0.1, "expected a genuinely raised plateau (pyramid peak at the centre)"
+
+        # (1) SEATED: the Go2's lowest collidable geom clears the LOCAL surface;
+        # a reverted seat would leave it ~`ground` metres buried.
+        assert _lowest_collision_geom_z(sim) >= ground - 0.02, "Go2 spawned buried in the terrain"
+
+        bench = get_benchmark("go2_walk_forward")
+        assert bench is not None  # just registered above
+
+        # (2) valid terrain-curriculum start: a seated, upright Go2 is not scored.
+        assert bench.is_failure(sim) is False, "seated Go2 on the plateau spuriously trips a failure predicate"
+        assert bench.is_success(sim) is False, "seated Go2 on the plateau spuriously satisfies success"
+
+        # (3) full harness end-to-end on the terrain world.
+        res = sim.evaluate_benchmark("go2_walk_forward", policy_provider="mock", n_episodes=1)
+        assert res["status"] == "success", res
+        payload = next(c["json"] for c in res["content"] if "json" in c)
+        assert payload["episodes_completed"] == 1
+        assert payload["success_measured"] is True
+        assert math.isfinite(payload["avg_reward"]), "avg_reward is not finite on the terrain world"
+    finally:
+        sim.destroy()
+
+
+def test_go2_walk_forward_fall_predicate_is_terrain_relative() -> None:
+    """The shipped ``base_below_z`` fall predicate fires TERRAIN-RELATIVE on the plateau.
+
+    Places the Go2 base COLLAPSED but LEVEL on the raised plateau at a height
+    whose clearance ABOVE THE LOCAL GROUND is below the spec's ``base_below_z``
+    threshold, while its ABSOLUTE world z stays ABOVE that threshold. A
+    terrain-relative predicate (#1364) detects the collapse; an absolute-z test
+    would silently MISS it on raised ground -- so a robot could sink to the
+    terrain and flail to ``max_steps`` without the episode ever terminating. The
+    two branches are asserted on one scene: the real terrain-relative sim fires
+    the failure, and the same pose under a flat-ground (``_ground_height_at`` ->
+    0.0) reading does not.
+    """
+    spec = _SHIPPED_SPECS["go2_walk_forward"]
+    robot = spec["default_robot"]
+    assert has_sim(robot), f"default_robot {robot!r} is not simulatable"
+    threshold = next(
+        c["z"] for c in spec["failure"]["any"] if c["predicate"] == "base_below_z"
+    )  # 0.18 m for go2_walk_forward
+    register_benchmark("go2_walk_forward", DeclarativeBenchmark.from_dict(copy.deepcopy(spec)))
+
+    sim: Any = create_simulation(backend="mujoco")
+    sim.create_world(ground_plane=True, terrain=_TERRAIN, difficulty=_DIFFICULTY)
+    sim.add_robot(robot)
+    try:
+        model, data = sim._world._model, sim._world._data
+        ground = sim._ground_height_at(0.0, 0.0)
+        # A collapse whose clearance above the local plateau is below the
+        # threshold, but whose absolute z stays above it (isolates the terrain
+        # relativity). Requires a plateau taller than the threshold gap.
+        collapsed_z = ground + threshold / 2.0
+        assert collapsed_z > threshold, (
+            "test setup: absolute z must stay above the threshold so only a "
+            "terrain-relative predicate can fire (needs a tall enough plateau)"
+        )
+        jid = sim._robot_free_base_joint_id(model, sim._world.robots[robot])
+        adr = int(model.jnt_qposadr[jid])
+        data.qpos[adr : adr + 3] = [0.0, 0.0, collapsed_z]
+        data.qpos[adr + 3 : adr + 7] = [1.0, 0.0, 0.0, 0.0]  # level: base_tipped stays False
+        mujoco.mj_forward(model, data)
+
+        bench = get_benchmark("go2_walk_forward")
+        assert bench is not None
+        # Terrain-relative: clearance above the plateau < threshold -> fall detected.
+        assert bench.is_failure(sim) is True, "terrain-relative base_below_z did not fire for a collapse on the plateau"
+
+        # The same pose read as an ABSOLUTE-z world (no local terrain offset)
+        # would MISS the collapse -- the regression this composition guards.
+        original = type(sim)._ground_height_at
+        type(sim)._ground_height_at = lambda self, x, y: 0.0  # type: ignore[method-assign]
+        try:
+            assert bench.is_failure(sim) is False, (
+                "an absolute-z fall predicate would spuriously report the plateau "
+                "collapse as still-standing (the miss #1364 fixes)"
+            )
+        finally:
+            type(sim)._ground_height_at = original  # type: ignore[method-assign]
     finally:
         sim.destroy()


### PR DESCRIPTION
## Problem

The terrain-locomotion surface landed across separate PRs, each with isolated coverage:

- terrain heightfield kinds + `difficulty` knob (#1336/#1338/#1339/#1340/#1344)
- floating-base robots seated on the terrain surface at spawn/reset (#1386)
- terrain-relative fall/height predicates measuring clearance above the *local* surface (#1364/#1368)
- the runnable locomotion benchmark composition (`register_builtin_benchmarks()` / `go2_walk_forward`, #1259)

Nothing exercised these **together** on a real robot -- a benchmark eval on raised ground, which is exactly the terrain-curriculum reset state a difficulty ramp evaluates into every episode. The existing coverage is orthogonal: `tests/simulation/test_add_robot_seats_on_terrain.py` checks the seat on a *synthetic* base with no benchmark, and `tests/simulation/test_base_below_z_terrain.py` checks the predicate in isolation on a flat-registered synthetic base. So a regression in the seat, the terrain-relative predicate, or the eval loop's per-episode reset-seat could silently break a terrain-curriculum benchmark while every existing test still passes. `tests_integ/simulation/test_builtin_benchmark_load.py` -- the module that runs each shipped benchmark on its real robot -- only ever built a **flat** world.

## Change

Two integration tests added to `tests_integ/simulation/test_builtin_benchmark_load.py`, closing that seam on the real Unitree Go2 (the canonical quadruped-locomotion embodiment), following the module's existing pattern (real-robot auto-download, `evaluate_benchmark` end-to-end with a mock policy driving real physics, derived from `builtin_benchmark_specs`).

1. `test_go2_walk_forward_seats_and_runs_on_terrain` -- on a `create_world(terrain="pyramid", difficulty=2.0)` world the Go2 (1) spawns **seated** on the local surface (its lowest collidable geom on/above the plateau, not buried below it), (2) holds the standing-spawn contract there (`is_failure`/`is_success` both `False`), and (3) runs the whole `evaluate_benchmark` harness end-to-end on the terrain world (finite `avg_reward`, `success_measured`, `episodes_completed == 1`).
2. `test_go2_walk_forward_fall_predicate_is_terrain_relative` -- places the Go2 base collapsed-but-level on the raised plateau at a clearance *below* the spec's `base_below_z` threshold while its absolute world z stays *above* it, and asserts the shipped predicate fires **terrain-relative** (`is_failure` is `True`), whereas the same pose read as a flat-ground world (local ground height forced to `0.0`) does **not** fire -- the miss on raised ground that the terrain-relative predicate (#1364) exists to catch.

## Evidence (fails-before teeth)

- Test 1's seat assertion has teeth: with the seat disabled the Go2's lowest geom spawns at `z=0.019` on a `ground=0.160` plateau (buried ~0.14 m below), failing `>= ground - 0.02`.
- Test 2's discriminator is embedded and decisive: on the plateau (`ground=0.160`) a collapse at absolute `z=0.26` (clearance `0.10 < 0.18` threshold) fires `is_failure=True` terrain-relative, while the absolute-z reading of the identical pose returns `False`.

Both new tests pass on `main`; the full module is 7 passed. `ruff check` / `ruff format --check` / `mypy` clean on the changed file. Test-integ tier only (network + MuJoCo), so it is excluded from the GL-free unit gate, matching the module.