### PR TITLE
feat(lerobot_async): forward rename_map to the remote PolicyServer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Added: `lerobot_async` honors a `rename_map` for remote observation-key remapping
+
+`LerobotAsyncPolicy` (the gRPC client to a LeRobot `PolicyServer`) built its
+`RemotePolicyConfig` without a `rename_map`, so a caller-supplied `rename_map=`
+landed in the ignored-kwargs bag and was silently dropped (warned, then
+discarded). That left the async provider unable to drive a checkpoint whose
+expected camera/state feature keys differ from the ones the robot exposes -- the
+exact remapping the in-process [`lerobot_local`] provider already supports via
+`obs_rename`. A stock checkpoint trained with, say, `observation.images.laptop`
+was therefore unreachable from a robot whose camera is named `front`.
+
+`create_policy("lerobot_async", ..., rename_map={robot_obs_key: model_feature_key})`
+now forwards the map verbatim to the server's `RemotePolicyConfig.rename_map`,
+which the server applies as a `RenameObservationsProcessorStep` (renaming each
+matching observation key before the policy sees it). The default stays `{}` (no
+remap), and a non-dict `rename_map` is rejected client-side with a clear error.
+
 ### Added: `get_ground_height(x, y)` -- query the local terrain surface height
 
 `create_world(terrain=...)` raises the local ground up to

--- a/docs/policies/lerobot-async.md
+++ b/docs/policies/lerobot-async.md
@@ -87,6 +87,7 @@ sim.run_policy(
 | `actions_per_step`         | `actions_per_chunk` | Actions executed from one chunk before re-querying (the re-query interval) |
 | `connect_timeout`          | `10.0`        | Seconds to wait for the gRPC `Ready` handshake              |
 | `request_timeout`          | `60.0`        | Seconds to wait for each observation/action RPC             |
+| `rename_map`               | `{}`          | `{robot_obs_key: model_feature_key}` forwarded to the server; renames observation keys before the policy sees them (async analog of `lerobot_local`'s `obs_rename`) |
 
 ## Notes
 
@@ -99,3 +100,20 @@ sim.run_policy(
   names before inference; those scalars are concatenated into
   `observation.state` and any RGB/depth camera arrays are declared as image
   features in the handshake.
+- When the checkpoint expects camera/state keys that differ from the ones the
+  robot exposes, pass `rename_map={robot_obs_key: model_feature_key}`. The
+  server applies it as a `RenameObservationsProcessorStep` before inference, so
+  a stock checkpoint (e.g. one trained with `observation.images.laptop`) is
+  reachable from a robot whose camera is named `front` without re-exporting the
+  model - the remote counterpart of the [`lerobot_local`](lerobot-local.md)
+  provider's `obs_rename`:
+
+  ```python
+  policy = create_policy(
+      "lerobot_async",
+      server_address="gpu-box:8080",
+      policy_type="act",
+      pretrained_name_or_path="lerobot/act_so101",
+      rename_map={"observation.images.front": "observation.images.laptop"},
+  )
+  ```

--- a/strands_robots/policies/lerobot_async/policy.py
+++ b/strands_robots/policies/lerobot_async/policy.py
@@ -108,6 +108,15 @@ class LerobotAsyncPolicy(Policy):
             round-trip per control step.
         connect_timeout: Seconds to wait for the gRPC ``Ready`` handshake.
         request_timeout: Seconds to wait for each observation/action RPC.
+        rename_map: Optional ``{robot_obs_key: model_feature_key}`` map forwarded
+            to the server's ``RemotePolicyConfig.rename_map``. The server applies
+            it as a ``RenameObservationsProcessorStep`` (renaming each matching
+            observation key to its mapped name) before the policy sees the
+            observation - the async analog of the ``lerobot_local`` provider's
+            ``obs_rename``. Use it when the checkpoint expects camera/state keys
+            that differ from the ones the robot exposes (e.g.
+            ``{"observation.images.front": "observation.images.laptop"}``); keys
+            not present in the map pass through unchanged.
 
     Unrecognized kwargs are ignored (for forward-compatible ``policy_config``
     passthrough via :func:`~strands_robots.policies.create_policy`) but logged
@@ -133,6 +142,7 @@ class LerobotAsyncPolicy(Policy):
         actions_per_step: int | None = None,
         connect_timeout: float = DEFAULT_CONNECT_TIMEOUT,
         request_timeout: float = DEFAULT_REQUEST_TIMEOUT,
+        rename_map: dict[str, str] | None = None,
         **ignored_kwargs: Any,
     ) -> None:
         address = server_address or f"{host}:{port}"
@@ -163,6 +173,12 @@ class LerobotAsyncPolicy(Policy):
         self.actions_per_step = int(actions_per_step) if actions_per_step is not None else self.actions_per_chunk
         self.connect_timeout = connect_timeout
         self.request_timeout = request_timeout
+        if rename_map is not None and not isinstance(rename_map, dict):
+            raise ValueError(
+                "lerobot_async: rename_map must be a dict mapping each robot observation "
+                f"key to the model's expected feature key, got {type(rename_map).__name__}."
+            )
+        self.rename_map: dict[str, str] = dict(rename_map) if rename_map else {}
 
         if ignored_kwargs:
             logger.warning(
@@ -261,6 +277,7 @@ class LerobotAsyncPolicy(Policy):
             lerobot_features=lerobot_features,
             actions_per_chunk=self.actions_per_chunk,
             device=self.device,
+            rename_map=self.rename_map,
         )
         self._stub.SendPolicyInstructions(
             self._pb2.PolicySetup(data=pickle.dumps(cfg)),  # nosec B301

--- a/tests/policies/lerobot_async/test_lerobot_async_roundtrip.py
+++ b/tests/policies/lerobot_async/test_lerobot_async_roundtrip.py
@@ -74,6 +74,44 @@ def test_actions_per_step_defaults_to_chunk_size() -> None:
     assert policy.execution_horizon == 32
 
 
+def test_rename_map_defaults_to_empty() -> None:
+    policy = create_policy(
+        "lerobot_async",
+        server_address="h:1",
+        policy_type="act",
+        pretrained_name_or_path="x/y",
+    )
+    assert isinstance(policy, LerobotAsyncPolicy)
+    assert policy.rename_map == {}
+
+
+def test_rename_map_is_stored() -> None:
+    """A supplied rename_map is honored (not swallowed by the ignored-kwargs bag)."""
+    mapping = {"observation.images.front": "observation.images.laptop"}
+    policy = create_policy(
+        "lerobot_async",
+        server_address="h:1",
+        policy_type="act",
+        pretrained_name_or_path="x/y",
+        rename_map=mapping,
+    )
+    assert isinstance(policy, LerobotAsyncPolicy)
+    assert policy.rename_map == mapping
+    # A copy, not the caller's object.
+    assert policy.rename_map is not mapping
+
+
+def test_rename_map_invalid_type_raises() -> None:
+    with pytest.raises(ValueError, match="rename_map must be a dict"):
+        create_policy(
+            "lerobot_async",
+            server_address="h:1",
+            policy_type="act",
+            pretrained_name_or_path="x/y",
+            rename_map=["observation.images.front"],
+        )
+
+
 def test_missing_policy_type_raises() -> None:
     with pytest.raises(ValueError, match="policy_type"):
         create_policy("lerobot_async", server_address="h:1", pretrained_name_or_path="x/y")
@@ -294,6 +332,50 @@ def test_roundtrip_sends_wellformed_instructions_and_observation(running_server)
     assert obs.observation["task"] == "pick up the cube"
     assert obs.observation["joint_3"] == pytest.approx(0.3)
     assert obs.observation["top"].shape == (8, 8, 3)
+    policy.close()
+
+
+def test_roundtrip_forwards_rename_map_to_server(running_server) -> None:
+    """rename_map reaches the server's RemotePolicyConfig so it can remap obs keys.
+
+    The async transport applies rename_map server-side (as a
+    RenameObservationsProcessorStep), so a checkpoint that expects different
+    camera/state keys than the robot exposes is only reachable if the client
+    forwards the map. Without forwarding, the server receives the empty default
+    and cannot decode a mismatched observation.
+    """
+    servicer, address = running_server
+    mapping = {"top": "observation.images.laptop"}
+    policy = _client(
+        address,
+        policy_type="act",
+        pretrained_name_or_path="lerobot/act_so101",
+        device="cpu",
+        actions_per_chunk=CHUNK_LEN,
+        rename_map=mapping,
+    )
+    policy.set_robot_state_keys(STATE_KEYS)
+    policy.get_actions_sync(_observation(), "pick up the cube")
+
+    cfg = servicer.policy_config
+    assert isinstance(cfg, RemotePolicyConfig)
+    assert cfg.rename_map == mapping
+    policy.close()
+
+
+def test_roundtrip_default_rename_map_is_empty(running_server) -> None:
+    """With no rename_map the server receives the empty default (no accidental remap)."""
+    servicer, address = running_server
+    policy = _client(
+        address,
+        policy_type="act",
+        pretrained_name_or_path="lerobot/act_so101",
+        device="cpu",
+        actions_per_chunk=CHUNK_LEN,
+    )
+    policy.set_robot_state_keys(STATE_KEYS)
+    policy.get_actions_sync(_observation(), "task")
+    assert servicer.policy_config.rename_map == {}
     policy.close()
 
 


### PR DESCRIPTION
## Problem

`LerobotAsyncPolicy` (the gRPC client to a LeRobot `PolicyServer`) built its `RemotePolicyConfig` **without** a `rename_map`. `create_policy` forwards a shared kwargs bag to every provider, so a caller-supplied `rename_map=` fell into the client's `**ignored_kwargs` and was silently dropped (warned, then discarded).

That left the async provider unable to drive a checkpoint whose expected observation feature keys differ from the ones the robot actually exposes — a real deployment case (a stock checkpoint trained with, say, `observation.images.laptop` is unreachable from a robot whose camera is named `front`). The in-process [`lerobot_local`](../blob/main/docs/policies/lerobot-local.md) provider already supports exactly this remapping via `obs_rename`, and LeRobot's own async transport supports it via `RemotePolicyConfig.rename_map` — the async provider just never plumbed it through.

## Change

Expose `rename_map={robot_obs_key: model_feature_key}` on `LerobotAsyncPolicy` and thread it into `RemotePolicyConfig.rename_map`. On the `SendPolicyInstructions` handshake the server wires it into a `RenameObservationsProcessorStep`, which renames each matching observation key before the policy sees it (keys not in the map pass through unchanged) — the remote counterpart of `lerobot_local`'s `obs_rename`.

- Default stays `{}` (no remap), so existing behaviour is unchanged.
- A non-dict `rename_map` is rejected client-side with a clear error (matches the provider's existing fail-fast-on-the-client philosophy).
- Class docstring + `docs/policies/lerobot-async.md` (config table + a remapping example) updated.

## Tests

Extended `tests/policies/lerobot_async/test_lerobot_async_roundtrip.py` (5 new tests, using the existing **real in-process gRPC `AsyncInference` server** — no mocks):

- construction: `rename_map` defaults to `{}`, is stored (as a copy), and a non-dict raises `ValueError`;
- full wire round-trip: the server's captured `RemotePolicyConfig.rename_map` equals the supplied map, and is `{}` when none is given.

Fails-before / passes-after (source reverted, new tests present):
```
test_rename_map_defaults_to_empty            AttributeError: 'LerobotAsyncPolicy' object has no attribute 'rename_map'
test_rename_map_is_stored                    AttributeError: ...
test_rename_map_invalid_type_raises          DID NOT RAISE ValueError
test_roundtrip_forwards_rename_map_to_server assert {} == {'top': 'observation.images.laptop'}
(the captured pre-fix WARNING literally reads: "ignoring unexpected constructor kwarg(s) ['rename_map']")
```
After the fix the full suite is `22 passed`. `ruff check` / `ruff format --check` / `mypy` clean on the changed module.