### PR TITLE
test(policies): cover norm-stats builder optional-dep degradation seams

### DIFF
--- a/tests/policies/lerobot_local/test_norm_stats_fallback.py
+++ b/tests/policies/lerobot_local/test_norm_stats_fallback.py
@@ -510,6 +510,54 @@ class TestBuildProcessorsGuards:
         assert ns.build_norm_stats_processors(payload, "t") == (None, None)
 
 
+class TestOptionalDepDegradation:
+    """``build_norm_stats_processors`` degrades to ``(None, None)`` -- never
+    raises -- when LeRobot's processor framework is unavailable.
+
+    The norm-stats fallback runs during policy load. LeRobot's processor
+    pipeline is an optional surface: an install that ships the pure-numpy
+    ``FeatureNormalizer`` math but not the ``ProcessorStep`` /
+    ``DataProcessorPipeline`` classes (older/partial lerobot) must still load
+    the policy and simply skip the pipeline wiring, rather than crashing the
+    whole ``ProcessorBridge.from_pretrained`` path. These lock that contract
+    at each import seam the builder crosses.
+    """
+
+    def test_make_step_classes_none_when_processor_framework_absent(self, monkeypatch):
+        # ``_make_step_classes`` imports its ProcessorStep bases lazily. When
+        # that import fails (framework absent) it returns None so the caller can
+        # degrade -- masking the submodule in sys.modules forces the ImportError.
+        import sys
+
+        monkeypatch.setitem(sys.modules, "lerobot.processor.pipeline", None)
+        assert ns._make_step_classes() is None
+
+    def test_build_degrades_when_step_classes_unavailable(self, monkeypatch):
+        # Valid, resolvable payload, but the ProcessorStep framework cannot be
+        # built: the builder must return the (None, None) pair, not raise.
+        monkeypatch.setattr(ns, "_make_step_classes", lambda: None)
+        assert ns.build_norm_stats_processors(_load_fixture()) == (None, None)
+
+    @_requires_lerobot_pipeline
+    def test_build_degrades_when_pipeline_class_unimportable(self, monkeypatch):
+        # The ProcessorStep bases resolve, but ``DataProcessorPipeline`` itself
+        # is missing from the installed lerobot: the deferred import inside the
+        # builder raises ImportError, which must fall through to (None, None).
+        import lerobot.processor.pipeline as pipeline_mod
+
+        monkeypatch.delattr(pipeline_mod, "DataProcessorPipeline", raising=False)
+        assert ns.build_norm_stats_processors(_load_fixture()) == (None, None)
+
+    def test_build_degrades_when_normalizer_fails_to_build(self, monkeypatch):
+        # Defensive contract at the normalizer seam: the stats dicts are present
+        # and well-formed, but ``FeatureNormalizer.from_stats`` yields None (an
+        # unusable normalizer). The builder must return the (None, None) pair
+        # rather than wire a None normalizer into a ProcessorStep -- guarding the
+        # degradation path if from_stats ever gains a dict-input None return.
+        monkeypatch.setattr(ns.FeatureNormalizer, "from_stats", staticmethod(lambda *a, **k: None))
+        assert ns.build_norm_stats_processors(_load_fixture()) == (None, None)
+
+
 class TestHubLoader:
     """load_norm_stats Hub path: config.json filename override + fetch."""
 


### PR DESCRIPTION
## What

`build_norm_stats_processors` (`strands_robots.policies.lerobot_local.norm_stats`) runs during LeRobot policy load and wires the `norm_stats.json` fallback into `ProcessorBridge`. LeRobot's processor pipeline (`ProcessorStep` / `DataProcessorPipeline`) is an optional surface: an install that ships the pure-numpy `FeatureNormalizer` math but not the processor framework must still load the policy and simply skip the pipeline wiring, returning `(None, None)` rather than crashing the `ProcessorBridge.from_pretrained` path.

That degradation contract was previously untested. This adds `TestOptionalDepDegradation` locking `(None, None)` at each import/build seam the builder crosses:

- `_make_step_classes` returns `None` when the `ProcessorStep` bases cannot be imported.
- builder degrades when step classes are unavailable.
- builder degrades when `DataProcessorPipeline` itself is unimportable.
- builder degrades when `FeatureNormalizer.from_stats` yields `None` for present-but-unusable stats (defensive normalizer seam).

## Why

These seams are exactly where a partial/older LeRobot install would otherwise raise mid-load. The tests fence the graceful-degradation behavior so a future change that turns any of them into a hard failure is caught, matching the module's existing no-silent-failure discipline.

## Tests

Test-only change. Uses `monkeypatch` (sys.modules masking / `delattr`), matching the file's existing torch-absent convention (`test_normalizes_without_torch_installed`). Takes `norm_stats.py` coverage from 98% to 100%.

Full suite green locally (`MUJOCO_GL=egl`, hardware/GPU/live markers deselected): 10664 passed, 189 skipped. `ruff check`, `ruff format --check`, and `mypy` all clean.