### PR TITLE
test(sim): cover the resume-schema action-column mismatch guard

### DIFF
--- a/tests/simulation/mujoco/test_resume_schema.py
+++ b/tests/simulation/mujoco/test_resume_schema.py
@@ -19,11 +19,18 @@ class _FakeRecorder:
         self.dataset = type("_DS", (), {"features": features})()
 
 
-def _features(joint_names, cams):
-    """Build a minimal on-disk feature dict: cams maps name -> (h, w)."""
+def _features(joint_names, cams, actions=None):
+    """Build a minimal on-disk feature dict: cams maps name -> (h, w).
+
+    When ``actions`` is given, an ``action`` feature is added carrying those
+    column names, mirroring what ``DatasetRecorder`` writes for the actuator
+    command vector.
+    """
     feats = {
         "observation.state": {"dtype": "float32", "shape": (len(joint_names),), "names": list(joint_names)},
     }
+    if actions is not None:
+        feats["action"] = {"dtype": "float32", "shape": (len(actions),), "names": list(actions)}
     for name, (h, w) in cams.items():
         feats[f"observation.images.{name}"] = {"dtype": "video", "shape": (3, h, w)}
     return feats
@@ -70,3 +77,23 @@ def test_resume_schema_error_message_is_ascii():
     with pytest.raises(ValueError) as exc:
         verify(None, rec, ["shoulder_pan", "elbow"], [], {})
     str(exc.value).encode("ascii")  # raises if any non-ASCII glyph leaked
+
+
+def test_resume_schema_action_columns_mismatch_raises():
+    """A resumed dataset whose action columns diverge from the scene is rejected.
+
+    Guards the actuator-command half of the schema check: joints/cameras can
+    match while the action vector silently changed (e.g. a robot swapped for one
+    with different actuators), which would otherwise only surface as a cryptic
+    per-frame shape error on the next add_frame.
+    """
+    rec = _FakeRecorder(_features(["j"], {}, actions=["shoulder_pan", "elbow"]))
+    with pytest.raises(ValueError, match="action columns differ"):
+        verify(None, rec, ["j"], [], {}, action_names=["shoulder_pan", "wrist"])
+
+
+def test_resume_schema_matching_action_columns_passes():
+    """Matching action columns must not raise when action_names is supplied."""
+    rec = _FakeRecorder(_features(["j"], {}, actions=["shoulder_pan", "elbow"]))
+    # No raise -> the action feature matches the scene's actuator columns.
+    verify(None, rec, ["j"], [], {}, action_names=["shoulder_pan", "elbow"])


### PR DESCRIPTION
## What
`RecordingMixin._verify_resume_schema` compares a resumed dataset's on-disk schema against the live scene so a divergence is rejected with a clear diff instead of a cryptic per-frame shape error on the next `add_frame`. It checks `observation.state` joints, each camera's presence and resolution, and the `action` column names (the `action_names` argument the MuJoCo recorder passes at `mujoco/recording.py`). Every branch had a test except the action-column one, leaving the actuator-command half of the guard unexercised.

## Why it matters
Joints and cameras can match while the action vector silently changes, e.g. a robot swapped for one with different actuators between episodes. Without the action-column check that mismatch would only surface later as an opaque shape error mid-recording. Pinning it keeps the guard honest.

## Change
Test-only. Adds two focused tests that bind the pure helper to a dummy `self` (no mujoco/lerobot needed):
- mismatched action columns raise `ValueError("action columns differ")`
- matching action columns pass without raising

Extends the local `_features` helper with an optional `actions=` argument that mirrors the `action` feature `DatasetRecorder` writes. No production code changes.

## Verification
- `pytest tests/simulation/mujoco/test_resume_schema.py` -> 9 passed; the action-column branch (`recording.py` lines 547-551) goes from uncovered to covered (`strands_robots/simulation/recording.py` 99% -> 100%).
- `hatch run lint` clean (ruff + ruff format + mypy, no issues in 795 files).
- Removing the action-column check from `_verify_resume_schema` makes the mismatch test fail, so it pins the behavior.