### PR TITLE
docs(training/rl): document public trainer/env methods and properties

### DIFF
--- a/strands_robots/training/rl/fast_sac.py
+++ b/strands_robots/training/rl/fast_sac.py
@@ -107,10 +107,12 @@ def _build_actor_critic(num_actor_obs: int, num_critic_obs: int, num_actions: in
             return torch.tanh(mean)
 
         def q_values(self, critic_obs: torch.Tensor, action: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+            """Twin-critic Q-values ``(Q1, Q2)`` for a state-action pair (clipped double-Q)."""
             x = torch.cat([critic_obs, action], dim=-1)
             return self.q1(x), self.q2(x)
 
         def q_target(self, critic_obs: torch.Tensor, action: torch.Tensor) -> torch.Tensor:
+            """Conservative target value ``min(Q1_target, Q2_target)`` for the TD backup."""
             x = torch.cat([critic_obs, action], dim=-1)
             return torch.min(self.q1_target(x), self.q2_target(x))
 
@@ -122,6 +124,7 @@ class FastSacTrainer(BaseRLAlgo):
 
     @property
     def provider_name(self) -> str:
+        """Registry key for this trainer (``"fast_sac"``)."""
         return "fast_sac"
 
     def validate(self, spec: TrainSpec) -> list[str]:

--- a/strands_robots/training/rl/gym_env.py
+++ b/strands_robots/training/rl/gym_env.py
@@ -146,9 +146,11 @@ def _make_gym_env_class() -> type:
             return self._to_numpy_obs(obs_dict), reward, terminated, truncated, out_info
 
         def render(self) -> None:  # pragma: no cover - no render mode advertised
+            """No-op: this wrapper advertises no render mode (always returns ``None``)."""
             return None
 
         def close(self) -> None:
+            """No-op: SimEnv teardown is owned by the caller / Robot, not this wrapper."""
             # SimEnv does not own engine teardown (the caller / Robot owns it),
             # so there is nothing to release here.
             return None

--- a/strands_robots/training/rl/ppo.py
+++ b/strands_robots/training/rl/ppo.py
@@ -60,6 +60,7 @@ def _build_actor_critic(num_actor_obs: int, num_critic_obs: int, num_actions: in
             return Normal(mean, std)
 
         def act(self, actor_obs: torch.Tensor, critic_obs: torch.Tensor) -> dict[str, torch.Tensor]:
+            """Sample an action for rollout collection; returns ``{action, log_prob, value, mean}``."""
             dist = self._distribution(actor_obs)
             action = dist.sample()
             return {
@@ -72,6 +73,7 @@ def _build_actor_critic(num_actor_obs: int, num_critic_obs: int, num_actions: in
         def evaluate(
             self, actor_obs: torch.Tensor, critic_obs: torch.Tensor, action: torch.Tensor
         ) -> dict[str, torch.Tensor]:
+            """Re-score stored actions under the current policy for the PPO update; returns ``{log_prob, value, entropy}``."""
             dist = self._distribution(actor_obs)
             return {
                 "log_prob": dist.log_prob(action).sum(-1),
@@ -133,6 +135,7 @@ class PpoTrainer(BaseRLAlgo):
 
     @property
     def provider_name(self) -> str:
+        """Registry key for this trainer (``"ppo"``)."""
         return "ppo"
 
     def validate(self, spec: TrainSpec) -> list[str]:

--- a/strands_robots/training/rl/vec_env.py
+++ b/strands_robots/training/rl/vec_env.py
@@ -103,18 +103,22 @@ class VecSimEnv:
 
     @property
     def actor_obs_keys(self) -> list[str]:
+        """Actor observation keys, proxied from sub-env 0 (identical across homogeneous sub-envs)."""
         return self.envs[0].actor_obs_keys
 
     @property
     def critic_obs_keys(self) -> list[str]:
+        """Critic observation keys, proxied from sub-env 0 (identical across homogeneous sub-envs)."""
         return self.envs[0].critic_obs_keys
 
     @property
     def engine(self) -> Any:
+        """Simulation engine of sub-env 0 (authoritative for homogeneous sub-envs)."""
         return self.envs[0].engine
 
     @property
     def robot_name(self) -> str | None:
+        """Robot name of sub-env 0, or ``None`` if unset (identical across homogeneous sub-envs)."""
         return self.envs[0].robot_name
 
     # --- helpers -------------------------------------------------------------


### PR DESCRIPTION
## Problem

The `strands_robots/training/rl` package documents most of its public surface, but a handful of public methods and properties were missing docstrings, leaving the package inconsistent. In several cases a documented method sat directly beside undocumented siblings (e.g. `SacActorCritic.act_inference` has a docstring while `q_values` / `q_target` did not).

## Change

Adds concise summary-line docstrings to the remaining undocumented public symbols so every public def in the package is documented:

- `fast_sac`: `SacActorCritic.q_values`, `SacActorCritic.q_target`, `FastSacTrainer.provider_name`
- `ppo`: `ActorCritic.act`, `ActorCritic.evaluate`, `PpoTrainer.provider_name`
- `gym_env`: `GymSimEnv.render`, `GymSimEnv.close` (no-op semantics were previously only in inline comments)
- `vec_env`: `VecSimEnv.actor_obs_keys`, `critic_obs_keys`, `engine`, `robot_name` metadata proxies

Documentation-only; no code behavior changes. Descriptions were written from the code (twin-critic clipped double-Q, GAE rollout `act`/`evaluate` return dicts, sub-env-0 metadata proxying) so docstrings match implementation.

## Verification

- `ruff check` + `ruff format --check` clean on `strands_robots/training/rl`
- `mypy strands_robots/training/rl`: no issues in 9 source files
- `pytest tests/training` RL suites: 88 passed, 1 skipped
- AST audit confirms zero remaining undocumented public defs in the package