### PR TITLE
fix: platform-aware MUJOCO_GL default in the notebooks + lerobot e2e fixture (fixes #1017)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: notebooks and the lerobot e2e test fixture no longer hard-default `MUJOCO_GL` to the macOS-only `cgl`
+
+The four `.py` examples became platform-aware in #973, but the notebooks under
+`examples/notebooks/` (`01`, `02`, `03`, `05`) and the module fixture of
+`tests/training/test_lerobot_e2e.py` still planted `MUJOCO_GL=cgl`
+unconditionally in their first cell / setup. `cgl` is the macOS-only offscreen
+GL backend, so on headless Linux (CI, cloud GPUs, Jetson) the first offscreen
+render died with `RuntimeError: invalid value for environment variable
+MUJOCO_GL: cgl`. Since `setdefault(..., "cgl")` writes `cgl` precisely when
+nothing is exported, the `examples/notebooks/README.md` claim that the notebooks
+"fall back to the environment's default" on headless Linux was also false.
+
+All five sites now use the same platform-aware default as the `.py` examples --
+`os.environ.setdefault("MUJOCO_GL", "cgl" if sys.platform == "darwin" else "egl")`
+-- so `cgl` is selected only on macOS and a user-exported `MUJOCO_GL` still
+wins, and the README now describes the actual behaviour. A new
+`tests/test_examples_mujoco_gl.py` guard scans the notebooks plus every tracked
+`examples/` / `tests/` `.py` file and fails on any unguarded `MUJOCO_GL=cgl`
+default, so this regression cannot creep back in.
+
 ### Added: `lerobot_async` honors a `rename_map` for remote observation-key remapping
 
 `LerobotAsyncPolicy` (the gRPC client to a LeRobot `PolicyServer`) built its

--- a/examples/notebooks/01_getting_started.ipynb
+++ b/examples/notebooks/01_getting_started.ipynb
@@ -29,9 +29,10 @@
    "outputs": [],
    "source": [
     "import os\n",
+    "import sys\n",
     "\n",
     "# macOS uses the 'cgl' offscreen GL backend; Linux headless uses 'egl'.\n",
-    "os.environ.setdefault(\"MUJOCO_GL\", \"cgl\")"
+    "os.environ.setdefault(\"MUJOCO_GL\", \"cgl\" if sys.platform == \"darwin\" else \"egl\")"
    ]
   },
   {

--- a/examples/notebooks/02_record_and_stream.ipynb
+++ b/examples/notebooks/02_record_and_stream.ipynb
@@ -27,9 +27,10 @@
    "outputs": [],
    "source": [
     "import os\n",
+    "import sys\n",
     "\n",
     "# macOS uses the 'cgl' offscreen GL backend; Linux headless uses 'egl'.\n",
-    "os.environ.setdefault(\"MUJOCO_GL\", \"cgl\")\n",
+    "os.environ.setdefault(\"MUJOCO_GL\", \"cgl\" if sys.platform == \"darwin\" else \"egl\")\n",
     "\n",
     "ROOT, REPO = \"/tmp/nb2_dataset\", \"local/nb2_demo\""
    ]

--- a/examples/notebooks/03_record_train_deploy.ipynb
+++ b/examples/notebooks/03_record_train_deploy.ipynb
@@ -27,9 +27,10 @@
    "outputs": [],
    "source": [
     "import os\n",
+    "import sys\n",
     "\n",
     "# macOS uses the 'cgl' offscreen GL backend; Linux headless uses 'egl'.\n",
-    "os.environ.setdefault(\"MUJOCO_GL\", \"cgl\")\n",
+    "os.environ.setdefault(\"MUJOCO_GL\", \"cgl\" if sys.platform == \"darwin\" else \"egl\")\n",
     "os.environ.setdefault(\"STRANDS_TRUST_REMOTE_CODE\", \"1\")  # ACT loads through LeRobot\n",
     "import shutil\n",
     "\n",

--- a/examples/notebooks/05_streaming_data_loop.ipynb
+++ b/examples/notebooks/05_streaming_data_loop.ipynb
@@ -28,10 +28,11 @@
    "outputs": [],
    "source": [
     "import os\n",
+    "import sys\n",
     "import shutil\n",
     "\n",
     "# macOS uses \"cgl\" for offscreen GL; Linux headless uses \"egl\".\n",
-    "os.environ.setdefault(\"MUJOCO_GL\", \"cgl\")\n",
+    "os.environ.setdefault(\"MUJOCO_GL\", \"cgl\" if sys.platform == \"darwin\" else \"egl\")\n",
     "os.environ.setdefault(\"STRANDS_TRUST_REMOTE_CODE\", \"1\")\n",
     "\n",
     "ROOT = \"/tmp/nb5_dataset\"\n",

--- a/examples/notebooks/README.md
+++ b/examples/notebooks/README.md
@@ -12,8 +12,9 @@ uv pip install "strands-robots[sim-mujoco,lerobot]" jupyterlab
 jupyter lab
 ```
 
-On macOS the notebooks set `MUJOCO_GL=cgl` for offscreen rendering; on headless
-Linux they fall back to the environment's default (set `MUJOCO_GL=egl` if needed).
+On macOS the notebooks set `MUJOCO_GL=cgl` for offscreen rendering; everywhere
+else (e.g. headless Linux) they default to `egl`. An exported `MUJOCO_GL`
+always wins.
 
 ## The series
 

--- a/tests/test_examples_mujoco_gl.py
+++ b/tests/test_examples_mujoco_gl.py
@@ -1,0 +1,115 @@
+"""No tracked example, notebook, or test may hard-default MUJOCO_GL to "cgl".
+
+``cgl`` is the macOS-only offscreen GL backend; on headless Linux (CI, cloud
+GPUs, Jetson) ``MUJOCO_GL=cgl`` makes the first offscreen render die with
+``RuntimeError: invalid value for environment variable MUJOCO_GL: cgl``. The
+platform-appropriate default (matching the ``.py`` examples) is::
+
+    os.environ.setdefault("MUJOCO_GL", "cgl" if sys.platform == "darwin" else "egl")
+
+so ``cgl`` is only selected on macOS and a user-exported ``MUJOCO_GL`` always
+wins. This scans the notebooks' code cells plus every tracked ``.py`` under
+``tests/`` and ``examples/`` and flags any line that assigns the ``"cgl"``
+literal to ``MUJOCO_GL`` without a ``sys.platform`` / ``darwin`` guard.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_NOTEBOOKS_DIR = _REPO_ROOT / "examples" / "notebooks"
+
+# A line assigning the "cgl" string literal as the MUJOCO_GL value, e.g.
+#   os.environ.setdefault("MUJOCO_GL", "cgl")
+#   os.environ["MUJOCO_GL"] = "cgl"
+# The guarded form keeps "cgl" but also names the platform (darwin / sys.platform).
+_CGL_VALUE_RE = re.compile(r'MUJOCO_GL"[^\n]*?"cgl"')
+
+
+def _is_guarded(line: str) -> bool:
+    return "darwin" in line or "sys.platform" in line
+
+
+def _lines_of(text: str) -> list[str]:
+    return text.splitlines()
+
+
+def _scan_py(path: Path) -> list[str]:
+    """Return unguarded-cgl lines from a .py file (empty if clean)."""
+    return [
+        ln.strip()
+        for ln in _lines_of(path.read_text(encoding="utf-8"))
+        if _CGL_VALUE_RE.search(ln) and not _is_guarded(ln)
+    ]
+
+
+def _scan_notebook(path: Path) -> list[str]:
+    """Return unguarded-cgl lines from a notebook's code cells (empty if clean)."""
+    nb = json.loads(path.read_text(encoding="utf-8"))
+    offending: list[str] = []
+    for cell in nb.get("cells", []):
+        if cell.get("cell_type") != "code":
+            continue
+        for ln in _lines_of("".join(cell.get("source", []))):
+            if _CGL_VALUE_RE.search(ln) and not _is_guarded(ln):
+                offending.append(ln.strip())
+    return offending
+
+
+def _tracked_py() -> list[Path]:
+    # Exclude this scanner file: its docstring/regex mention the pattern verbatim.
+    self_path = Path(__file__).resolve()
+    files: list[Path] = []
+    for base in ("tests", "examples"):
+        root = _REPO_ROOT / base
+        if root.is_dir():
+            files.extend(p for p in sorted(root.rglob("*.py")) if p.resolve() != self_path)
+    return files
+
+
+def _notebooks() -> list[Path]:
+    return sorted(_NOTEBOOKS_DIR.glob("*.ipynb")) if _NOTEBOOKS_DIR.is_dir() else []
+
+
+def _count_cgl_sites() -> int:
+    """Total MUJOCO_GL="cgl" references (guarded or not) - scanner liveness."""
+    n = 0
+    for p in _tracked_py():
+        n += sum(1 for ln in _lines_of(p.read_text(encoding="utf-8")) if _CGL_VALUE_RE.search(ln))
+    for p in _notebooks():
+        nb = json.loads(p.read_text(encoding="utf-8"))
+        for cell in nb.get("cells", []):
+            if cell.get("cell_type") != "code":
+                continue
+            n += sum(1 for ln in _lines_of("".join(cell.get("source", []))) if _CGL_VALUE_RE.search(ln))
+    return n
+
+
+def test_no_unguarded_cgl_default():
+    """No tracked example/notebook/test may default MUJOCO_GL to cgl unconditionally."""
+    offenders: dict[str, list[str]] = {}
+    for p in _tracked_py():
+        bad = _scan_py(p)
+        if bad:
+            offenders[str(p.relative_to(_REPO_ROOT))] = bad
+    for p in _notebooks():
+        bad = _scan_notebook(p)
+        if bad:
+            offenders[str(p.relative_to(_REPO_ROOT))] = bad
+    assert not offenders, (
+        "MUJOCO_GL defaulted to the macOS-only 'cgl' without a platform guard "
+        "(breaks headless Linux). Use "
+        '\'os.environ.setdefault("MUJOCO_GL", "cgl" if sys.platform == "darwin" else "egl")\'. '
+        f"Offending sites: {offenders}"
+    )
+
+
+def test_scanner_sees_cgl_usage():
+    """Sanity: the scanner reaches the (now guarded) cgl sites, so the guard can't pass vacuously."""
+    assert _count_cgl_sites() >= 4, (
+        "expected to find the guarded MUJOCO_GL='cgl' notebook/test sites; "
+        "scanner found none - a path/glob regression may make the guard vacuous."
+    )

--- a/tests/training/test_lerobot_e2e.py
+++ b/tests/training/test_lerobot_e2e.py
@@ -6,6 +6,7 @@ Runs CPU-only, 2 steps - just enough to prove the record->train->load loop.
 """
 
 import os
+import sys
 
 import pytest
 
@@ -18,7 +19,7 @@ from strands_robots.training import TrainSpec, create_trainer  # noqa: E402
 @pytest.fixture(scope="module")
 def recorded_dataset(tmp_path_factory):
     """Record a tiny dataset in MuJoCo sim (one short episode)."""
-    os.environ.setdefault("MUJOCO_GL", "cgl")
+    os.environ.setdefault("MUJOCO_GL", "cgl" if sys.platform == "darwin" else "egl")
     from strands_robots import MockPolicy, Robot
 
     root = str(tmp_path_factory.mktemp("e2e_ds"))


### PR DESCRIPTION
Fixes #1017.

Follow-up to #973 (which made the four `.py` examples platform-aware). Four notebooks under `examples/notebooks/` -- `01_getting_started`, `02_record_and_stream`, `03_record_train_deploy`, and `05_streaming_data_loop` -- plus the module fixture of `tests/training/test_lerobot_e2e.py` still planted the macOS-only `cgl` backend unconditionally in their first cell / setup:

    os.environ.setdefault("MUJOCO_GL", "cgl")

`cgl` is the macOS-only offscreen GL backend, so on headless Linux (CI, cloud GPUs, Jetson) the first offscreen render dies with `RuntimeError: invalid value for environment variable MUJOCO_GL: cgl`. Because `setdefault(..., "cgl")` writes `cgl` precisely when nothing is exported, the `examples/notebooks/README.md` claim that the notebooks "fall back to the environment's default" on headless Linux was also false.

## Change

All five sites now use the same platform-aware line as the `.py` examples (plus the `import sys` it needs):

    os.environ.setdefault("MUJOCO_GL", "cgl" if sys.platform == "darwin" else "egl")

so `cgl` is selected only on macOS and a user-exported `MUJOCO_GL` always wins. `04_discover_lerobot.ipynb` is untouched (it does not use MUJOCO_GL). The README now describes the actual behaviour.

A new `tests/test_examples_mujoco_gl.py` scans the notebooks' code cells plus every tracked `examples/` / `tests/` `.py` file and fails on any line that defaults `MUJOCO_GL` to the `cgl` literal without a `sys.platform` / `darwin` guard -- so the last `cgl` regressions cannot creep back in.

## Notes

This completes the fix started in #1018, which covered only `01`/`02`/`03` (it predates `05_streaming_data_loop.ipynb`) and is now conflicting with main. With this change a full `git grep` finds no unguarded `cgl` default anywhere in the repo -- the library itself was always clean (`simulation/mujoco/backend.py` auto-detects and never picks `cgl`).

## Verification (Linux, no MUJOCO_GL exported)

- The new guard test fails on the pre-fix tree (5 unguarded sites: notebooks 01/02/03/05 + the e2e fixture) and passes after.
- `ruff check` / `ruff format --check` / `mypy` clean on the changed `.py` files.
- All notebooks remain valid JSON; `tests/training/test_lerobot_e2e.py` still collects.
- CHANGELOG format + source-string guards green.