### PR TITLE
test(sim): pin evaluate_benchmark degrades when spec.instruction raises

### DIFF
--- a/tests/simulation/test_policy_runner_benchmark.py
+++ b/tests/simulation/test_policy_runner_benchmark.py
@@ -1152,6 +1152,51 @@ class TestSpecInstructionFallback:
         warnings = [r for r in caplog.records if "instruction is empty" in r.getMessage()]
         assert warnings, "expected a warning about empty instruction"
 
+    def test_degrades_when_spec_instruction_property_raises(self, caplog):
+        """A spec whose ``instruction`` property *raises* (a custom
+        ``BenchmarkProtocol`` built against an older API, or one that computes
+        its instruction lazily and hits an error) must not crash the eval.
+        ``_evaluate_with_spec`` swallows the lookup error, degrades to the
+        empty instruction, and still emits the empty-instruction warning so
+        the operator knows a language-conditioned policy is running blind. Pin
+        so a future refactor does not drop the defensive fallback and turn a
+        broken property into an uncaught crash mid-benchmark."""
+        import logging as _logging
+
+        captured: list[str] = []
+
+        class _LangPolicy(MockPolicy):
+            async def get_actions(self, observation_dict, instruction, **kwargs):
+                captured.append(instruction)
+                return [{}]
+
+        class _SpecWithRaisingInstruction(_CountingBenchmark):
+            @property
+            def instruction(self) -> str:
+                raise RuntimeError("instruction backend not wired up")
+
+        sim = FakeSim()
+        policy = _LangPolicy()
+        policy.set_robot_state_keys(sim.robot_joint_names("fake_robot"))
+        with caplog.at_level(_logging.DEBUG, logger="strands_robots.simulation.policy_runner"):
+            result = PolicyRunner(sim).evaluate(
+                "fake_robot", policy, spec=_SpecWithRaisingInstruction(), n_episodes=1, seed=42
+            )
+
+        # Eval completed instead of crashing on the raising property.
+        assert result["status"] == "success", f"eval should survive a raising spec.instruction; got {result}"
+        # The policy ran with the degraded empty instruction, not a partial value.
+        assert captured, "expected at least one get_actions call"
+        assert all(c == "" for c in captured), f"expected empty instruction, got {captured!r}"
+        # The lookup failure is surfaced at DEBUG, not silently swallowed.
+        assert any("spec.instruction lookup raised" in r.getMessage() for r in caplog.records), (
+            "expected a DEBUG log noting the spec.instruction lookup raised"
+        )
+        # The operator still gets the empty-instruction WARNING after degrading.
+        assert any("instruction is empty" in r.getMessage() for r in caplog.records), (
+            "expected the empty-instruction warning after degrading"
+        )
+
 
 class TestOnFrameHookForSpec:
     """#191: ``policy_runner._evaluate_with_spec`` invokes ``on_frame``


### PR DESCRIPTION
## Problem

The spec-driven benchmark eval path resolves the task instruction from `spec.instruction` under a defensive `try/except` (see `PolicyRunner._evaluate_with_spec`):

```python
spec_instruction = ""
try:
    spec_instruction = spec.instruction or ""
except Exception as e:  # back-compat for specs without the property
    logger.debug("spec.instruction lookup raised %s; defaulting to empty", e)
```

This guards against a custom `BenchmarkProtocol` whose `instruction` property raises - e.g. a spec built against an older API, or one that computes its instruction lazily and hits an error. When that happens the eval must degrade to the empty instruction (plus the standard empty-instruction warning) rather than crash mid-benchmark.

`TestSpecInstructionFallback` already covered user-wins, spec-fallback, and both-empty-warns, but the raising-property branch had no regression test, so a future refactor could drop the `try/except` (it reads like dead defensive code) and silently reintroduce the crash.

## Change

Add `test_degrades_when_spec_instruction_property_raises`: run `evaluate` with a spec whose `instruction` property raises `RuntimeError`, then assert that

- the eval completes with `status == "success"` (no propagated crash),
- the policy runs with the degraded empty instruction (not a partial/garbage value),
- the lookup failure is surfaced at DEBUG (`"spec.instruction lookup raised"`), and
- the operator still gets the `"instruction is empty"` WARNING.

## Verification

- Fails pre-fix: removing the `try/except` (leaving `spec_instruction = spec.instruction or ""`) makes the `RuntimeError` propagate and the new test fails.
- Passes post-fix: full file green (57 passed).
- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` all clean (mypy: no issues found in 795 source files).

Test-only change; no runtime behavior change.