### PR TITLE
fix(recording): add overwrite= to DatasetRecorder.create() for honest re-recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Added: `DatasetRecorder.create(overwrite=...)` for honest re-recording into an existing `repo_id`
+
+`DatasetRecorder.create()` calls `LeRobotDataset.create()`, which `mkdir`s its
+target with `exist_ok=False` and raises a bare `FileExistsError` when the
+dataset directory already exists. `create()` exposed no `overwrite` parameter,
+so re-running a capture script into the same `repo_id` dead-ended with a cryptic
+crash and no in-API way to force a fresh dataset -- while `resume()`'s docstring
+and its no-resume `RuntimeError` both pointed callers at an `overwrite=True` that
+only existed on the `Simulation.start_recording` facade.
+
+`create()` now takes `overwrite: bool = False` and resolves an existing target up
+front, matching the facade: `overwrite=True` wipes and recreates a fresh dataset;
+`overwrite=False` on an existing dataset (a dir containing `meta/`) raises a clear
+`FileExistsError` naming `overwrite=True` and `resume()`; an existing empty
+directory (e.g. `tempfile.mkdtemp()`) is cleared so `create()` does not trip over
+its own existence guard; and a non-empty non-dataset directory raises `ValueError`
+rather than clobbering unrelated files. The dataset-directory resolution is now a
+shared `resolve_dataset_dir()` helper used by both `create()` and the sim facade
+(honouring `$HF_LEROBOT_HOME`), so the two surfaces can no longer diverge.
+
 ### Fixed: notebooks and the lerobot e2e test fixture no longer hard-default `MUJOCO_GL` to the macOS-only `cgl`
 
 The four `.py` examples became platform-aware in #973, but the notebooks under

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -308,6 +308,32 @@ recorder.save_episode()
 recorder.finalize()
 ```
 
+### Re-recording into an existing `repo_id`
+
+`DatasetRecorder.create()` builds a **fresh** dataset. If the resolved dataset
+directory already exists, LeRobot's `create()` would raise a bare
+`FileExistsError` (its `mkdir` uses `exist_ok=False`). `create()` resolves this
+up front, matching the `start_recording` facade:
+
+- `overwrite=True` wipes the existing directory and creates a fresh dataset.
+- `overwrite=False` (default) on an existing dataset (a dir containing `meta/`)
+  raises a clear `FileExistsError` naming `overwrite=True` (fresh) and
+  `resume()` (append) - not a cryptic LeRobot error, and never a silent clobber.
+- An existing **empty** directory (e.g. from `tempfile.mkdtemp()`) is cleared so
+  `create()` does not dead-end on its own existence guard.
+- A non-empty **non-dataset** directory raises `ValueError` rather than deleting
+  unrelated files.
+
+```python
+# Re-run a capture script into the same repo_id, replacing the old dataset:
+recorder = DatasetRecorder.create(
+    repo_id="user/my_dataset", fps=30, joint_names=[...], overwrite=True,
+)
+```
+
+Use `resume()` (not `create(overwrite=True)`) when you want to **append**
+episodes to the existing dataset instead of replacing it.
+
 ## Instance methods
 
 | Method | What |

--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -201,6 +201,108 @@ def _get_lerobot_dataset_class():
         ) from exc
 
 
+def _lerobot_home() -> Path:
+    """Return LeRobot's on-disk dataset home (``$HF_LEROBOT_HOME``).
+
+    Uses lerobot's own ``HF_LEROBOT_HOME`` constant when importable so the
+    resolved path matches exactly where ``LeRobotDataset`` reads/writes
+    (honouring the ``HF_LEROBOT_HOME`` environment override). Falls back to the
+    documented default ``~/.cache/huggingface/lerobot`` when lerobot is absent.
+    """
+    try:
+        from lerobot.utils.constants import HF_LEROBOT_HOME
+
+        return Path(HF_LEROBOT_HOME)
+    except (ImportError, ValueError, RuntimeError):
+        return Path.home() / ".cache" / "huggingface" / "lerobot"
+
+
+def resolve_dataset_dir(repo_id: str, root: str | None = None) -> Path:
+    """Resolve the on-disk directory a dataset will live in.
+
+    Mirrors ``LeRobotDataset`` root resolution so callers can inspect the
+    target before ``create``/``resume``:
+
+    * explicit ``root`` -> used verbatim;
+    * a ``repo_id`` that is itself a path (absolute, ``./`` prefixed, or with no
+      ``owner/name`` slash) -> treated as a local directory;
+    * otherwise ``$HF_LEROBOT_HOME/{repo_id}``.
+
+    Args:
+        repo_id: HuggingFace dataset id (``owner/name``) or a local path.
+        root: Explicit local dataset directory, if any.
+
+    Returns:
+        The resolved dataset directory as a :class:`~pathlib.Path`.
+    """
+    if root:
+        return Path(root)
+    if "/" not in repo_id or repo_id.startswith("/") or repo_id.startswith("./"):
+        return Path(repo_id)
+    return _lerobot_home() / repo_id
+
+
+def _prepare_create_target(dataset_dir: Path, *, overwrite: bool) -> None:
+    """Make ``dataset_dir`` safe for a fresh ``LeRobotDataset.create()``.
+
+    ``LeRobotDataset.create()`` calls ``mkdir(exist_ok=False)`` and raises a
+    bare ``FileExistsError`` whenever its target directory already exists - even
+    when empty. This resolves the situation up front with an actionable error:
+
+    * ``overwrite=True``: remove any existing target, then create() fresh.
+    * existing dataset (contains a ``meta/`` dir): raise ``FileExistsError``
+      naming ``overwrite=True`` (fresh) and :meth:`DatasetRecorder.resume`
+      (append) - ``create`` never silently appends or clobbers a real dataset.
+    * existing EMPTY dir (e.g. ``tempfile.mkdtemp()``): remove it so create()
+      does not trip over its own pre-existing-directory guard.
+    * existing NON-empty, non-dataset dir: raise ``ValueError`` instead of
+      clobbering unrelated files.
+
+    Args:
+        dataset_dir: Resolved on-disk dataset root.
+        overwrite: When True, replace any existing target.
+
+    Raises:
+        FileExistsError: Target is an existing LeRobotDataset and
+            ``overwrite`` is False.
+        ValueError: Target exists, is not a LeRobotDataset, is not empty, and
+            ``overwrite`` is False.
+    """
+    import shutil
+
+    if not dataset_dir.exists():
+        return
+    if overwrite:
+        if dataset_dir.is_dir():
+            shutil.rmtree(dataset_dir)
+        else:
+            dataset_dir.unlink()
+        logger.info("Removed existing dataset target for overwrite: %s", dataset_dir)
+        return
+    if not dataset_dir.is_dir():
+        raise ValueError(
+            f"Recording target {dataset_dir} exists and is not a directory. "
+            "Pass a directory path as root=, or overwrite=True to replace it."
+        )
+    if (dataset_dir / "meta").exists():
+        raise FileExistsError(
+            f"A LeRobotDataset already exists at {dataset_dir}. Pass overwrite=True "
+            "to replace it with a fresh dataset, or use DatasetRecorder.resume() "
+            "to append new episodes to it."
+        )
+    if not any(dataset_dir.iterdir()):
+        # Empty dir (e.g. from tempfile.mkdtemp()): clear it so create() does
+        # not trip over LeRobot's exist_ok=False guard.
+        shutil.rmtree(dataset_dir)
+        logger.info("Cleared empty recording target for fresh dataset: %s", dataset_dir)
+        return
+    raise ValueError(
+        f"Recording target {dataset_dir} already exists, is not a LeRobotDataset "
+        "(no meta/ directory), and is not empty. Refusing to overwrite unrelated "
+        "files. Pass overwrite=True to replace it, or choose a new/empty root=."
+    )
+
+
 class DatasetRecorder:
     """Bridge between strands-robots control loops and LeRobotDataset.
 
@@ -294,6 +396,7 @@ class DatasetRecorder:
         video_width: int = 640,
         video_height: int = 480,
         camera_key_map: dict[str, str] | None = None,
+        overwrite: bool = False,
     ) -> "DatasetRecorder":
         """Create a new DatasetRecorder with auto-detected features.
 
@@ -336,6 +439,18 @@ class DatasetRecorder:
                 "observation.images.*" keys are accepted on either side. Use it
                 when a policy declares image_keys that differ from the names the
                 sim/hardware streams emit, otherwise those frames are dropped.
+            overwrite: When the resolved dataset directory already exists,
+                ``LeRobotDataset.create`` raises a bare ``FileExistsError`` (its
+                ``mkdir`` uses ``exist_ok=False``). With ``overwrite=True`` the
+                existing directory is removed first so a fresh dataset is
+                created. With ``overwrite=False`` (default) an existing dataset
+                (a directory containing ``meta/``) raises a clear
+                ``FileExistsError`` naming ``overwrite=True`` (fresh) and
+                :meth:`resume` (append) instead of the cryptic LeRobot error; an
+                existing EMPTY directory (e.g. from ``tempfile.mkdtemp()``) is
+                cleared so ``create`` does not dead-end on its own existence
+                guard; a non-empty NON-dataset directory raises ``ValueError``
+                rather than clobbering unrelated files.
         """
         # Lazy import - this is where we actually need lerobot
         LeRobotDatasetCls = _get_lerobot_dataset_class()
@@ -383,6 +498,14 @@ class DatasetRecorder:
             create_kwargs["streaming_encoding"] = streaming_encoding
         if "video_backend" in create_params:
             create_kwargs["video_backend"] = video_backend
+
+        # Resolve create-vs-crash for an existing target BEFORE calling
+        # LeRobotDataset.create(), which mkdir()s with exist_ok=False and would
+        # otherwise dead-end on a bare FileExistsError. This also keeps the
+        # resume() docstring and its no-resume RuntimeError message honest: both
+        # point callers at an ``overwrite=`` parameter that now exists here.
+        _prepare_create_target(resolve_dataset_dir(repo_id, root), overwrite=overwrite)
+
         dataset = LeRobotDatasetCls.create(**create_kwargs)
 
         recorder = cls(dataset=dataset, task=task, camera_key_map=camera_key_map)

--- a/strands_robots/simulation/mujoco/recording.py
+++ b/strands_robots/simulation/mujoco/recording.py
@@ -9,7 +9,6 @@ resume-schema guard.
 """
 
 import logging
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from strands_robots.simulation.mujoco.backend import _NO_WORLD_MSG, _ensure_mujoco
@@ -145,12 +144,12 @@ class RecordingMixin(DatasetRecordingMixin):
         self._world._backend_state["push_to_hub"] = push_to_hub
 
         # Resolve the on-disk dataset dir (shared by overwrite + resume logic).
-        if root:
-            dataset_dir = Path(root)
-        elif "/" not in repo_id or repo_id.startswith("/") or repo_id.startswith("./"):
-            dataset_dir = Path(repo_id)
-        else:
-            dataset_dir = Path.home() / ".cache" / "huggingface" / "lerobot" / repo_id
+        # Delegates to the same resolver DatasetRecorder.create() uses so the
+        # facade and the low-level recorder agree on where a dataset lives
+        # (honouring $HF_LEROBOT_HOME).
+        from strands_robots.dataset_recorder import resolve_dataset_dir
+
+        dataset_dir = resolve_dataset_dir(repo_id, root)
         # Stash the resolved root so verify_dataset_episodes can read the parquet
         # after stop_recording has finalized the dataset and dropped the recorder.
         self._world._backend_state["last_dataset_root"] = str(dataset_dir)

--- a/tests/simulation/mujoco/test_recording_paths.py
+++ b/tests/simulation/mujoco/test_recording_paths.py
@@ -605,14 +605,15 @@ def test_start_recording_without_lerobot_points_at_mp4_fallback(sim_with_two_rob
 
 def test_start_recording_resolves_namespaced_repo_id_under_hf_cache(sim_with_two_robots, monkeypatch, tmp_path):
     """With root=None and a 'user/name' repo_id, the dataset dir resolves under
-    the HuggingFace lerobot cache. We pin this by pointing Path.home at a temp
+    the HuggingFace lerobot cache. We pin this by pointing the resolver's HF-cache home at a temp
     dir, pre-seeding the resolved cache dir, and asserting overwrite=True wipes
     exactly that resolved path."""
     import strands_robots.dataset_recorder as dr
-    import strands_robots.simulation.mujoco.recording as rec
 
     monkeypatch.setattr(dr, "has_lerobot_dataset", lambda: True)
-    monkeypatch.setattr(rec.Path, "home", classmethod(lambda cls: tmp_path))
+    # Path resolution lives in dataset_recorder.resolve_dataset_dir(); pin the
+    # HF-cache home it uses so the resolved dir is deterministic under tmp_path.
+    monkeypatch.setattr(dr, "_lerobot_home", lambda: tmp_path / ".cache" / "huggingface" / "lerobot")
     monkeypatch.setattr(dr.DatasetRecorder, "create", classmethod(lambda cls, **kw: object()))
 
     cache_dir = tmp_path / ".cache" / "huggingface" / "lerobot" / "user" / "name"

--- a/tests/test_dataset_recorder.py
+++ b/tests/test_dataset_recorder.py
@@ -8,6 +8,7 @@ normalization, drop accounting), plus episode/finalize/push lifecycle.
 """
 
 import logging
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -1787,3 +1788,102 @@ def test_hf_executable_falls_back_to_path(tmp_path, monkeypatch):
     monkeypatch.setattr(shutil, "which", lambda _name: "/usr/bin/hf")
 
     assert dr._hf_executable() == "/usr/bin/hf"
+
+
+# create(overwrite=...) makes re-recording into an existing repo_id honest:
+# LeRobotDataset.create() mkdir()s with exist_ok=False and raises a bare
+# FileExistsError on an existing dir. create() now resolves that up front -
+# overwrite=True wipes and recreates; overwrite=False raises a clear error
+# naming overwrite= / resume() (never a cryptic FileExistsError, never a silent
+# clobber). resolve_dataset_dir() is the shared root resolver the sim facade
+# also uses.
+
+
+class _FakeDatasetOverwriteCreate:
+    """create() records that it ran; it does not touch the filesystem."""
+
+    created = 0
+
+    def __init__(self, repo_id, root=None) -> None:
+        self.repo_id = repo_id
+        self.root = root
+
+    @classmethod
+    def create(
+        cls, repo_id, fps=30, root=None, robot_type="unknown", features=None, use_videos=True, image_writer_threads=4
+    ):
+        cls.created += 1
+        return cls(repo_id, root=root)
+
+
+def test_resolve_dataset_dir_prefers_explicit_root():
+    from strands_robots.dataset_recorder import resolve_dataset_dir
+
+    assert resolve_dataset_dir("user/data", root="/tmp/somewhere") == Path("/tmp/somewhere")
+
+
+def test_resolve_dataset_dir_treats_bare_repo_id_as_local_path():
+    from strands_robots.dataset_recorder import resolve_dataset_dir
+
+    # No owner/name slash -> a local directory path, not $HF_LEROBOT_HOME/<id>.
+    assert resolve_dataset_dir("my_local_dataset") == Path("my_local_dataset")
+
+
+def test_create_raises_clear_error_on_existing_dataset_without_overwrite(tmp_path, monkeypatch):
+    """create() on an existing LeRobotDataset dir (has meta/) and no overwrite
+    raises a clear FileExistsError naming overwrite= and resume() - not a bare
+    LeRobot FileExistsError and not a silent append."""
+    _FakeDatasetOverwriteCreate.created = 0
+    _patch_lerobot_dataset(monkeypatch, _FakeDatasetOverwriteCreate)
+    root = tmp_path / "ds"
+    (root / "meta").mkdir(parents=True)
+
+    with pytest.raises(FileExistsError, match="overwrite=True.*resume|resume.*overwrite"):
+        DatasetRecorder.create("user/data", root=str(root), joint_names=["j1"])
+    # create() must NOT have run, and the existing dataset is left untouched.
+    assert _FakeDatasetOverwriteCreate.created == 0
+    assert (root / "meta").exists()
+
+
+def test_create_overwrite_removes_existing_dataset_then_creates_fresh(tmp_path, monkeypatch):
+    """overwrite=True wipes an existing dataset dir before create() runs."""
+    _FakeDatasetOverwriteCreate.created = 0
+    _patch_lerobot_dataset(monkeypatch, _FakeDatasetOverwriteCreate)
+    root = tmp_path / "ds"
+    (root / "meta").mkdir(parents=True)
+    (root / "meta" / "info.json").write_text("{}")
+
+    recorder = DatasetRecorder.create("user/data", root=str(root), joint_names=["j1"], overwrite=True)
+
+    # The stale dataset content was removed before create() ran fresh.
+    assert not (root / "meta" / "info.json").exists()
+    assert _FakeDatasetOverwriteCreate.created == 1
+    assert recorder.dataset.repo_id == "user/data"
+
+
+def test_create_clears_existing_empty_dir(tmp_path, monkeypatch):
+    """An existing EMPTY dir (e.g. tempfile.mkdtemp()) is cleared so create()
+    does not dead-end on LeRobot's exist_ok=False guard."""
+    _FakeDatasetOverwriteCreate.created = 0
+    _patch_lerobot_dataset(monkeypatch, _FakeDatasetOverwriteCreate)
+    root = tmp_path / "empty_ds"
+    root.mkdir()
+
+    recorder = DatasetRecorder.create("user/data", root=str(root), joint_names=["j1"])
+
+    assert _FakeDatasetOverwriteCreate.created == 1
+    assert recorder.dataset.repo_id == "user/data"
+
+
+def test_create_refuses_nonempty_non_dataset_dir(tmp_path, monkeypatch):
+    """A non-empty dir that is not a LeRobotDataset is never clobbered."""
+    _FakeDatasetOverwriteCreate.created = 0
+    _patch_lerobot_dataset(monkeypatch, _FakeDatasetOverwriteCreate)
+    root = tmp_path / "notes"
+    root.mkdir()
+    (root / "important.txt").write_text("do not delete")
+
+    with pytest.raises(ValueError, match="not a LeRobotDataset"):
+        DatasetRecorder.create("user/data", root=str(root), joint_names=["j1"])
+    assert _FakeDatasetOverwriteCreate.created == 0
+    assert (root / "important.txt").exists()


### PR DESCRIPTION
## Problem

`DatasetRecorder.create()` (`strands_robots/dataset_recorder.py`) calls
`LeRobotDataset.create()`, which `mkdir`s its target with `exist_ok=False` and
raises a bare `FileExistsError` when the dataset directory already exists — even
when empty. `create()` exposed **no `overwrite` parameter**, so re-running a
capture script into the same `repo_id` dead-ended with a cryptic crash and no
in-API way to force a fresh dataset.

The surfaces also disagreed: `resume()`'s docstring and its no-resume
`RuntimeError` both referenced an `overwrite=True` that only existed on the
`Simulation.start_recording` facade — the direct `DatasetRecorder` API had no
such flag, so those messages pointed callers at a parameter they could not pass.

Closes #1404.

## Change

Add `overwrite: bool = False` to `DatasetRecorder.create()` and resolve an
existing target up front, matching the facade:

- `overwrite=True` — wipe the existing directory and create a fresh dataset.
- `overwrite=False` (default) on an existing dataset (a dir containing `meta/`)
  — raise a clear `FileExistsError` naming `overwrite=True` (fresh) and
  `resume()` (append), never a cryptic error and never a silent clobber.
- existing **empty** dir (e.g. `tempfile.mkdtemp()`) — cleared so `create()`
  does not dead-end on its own existence guard.
- non-empty **non-dataset** dir — `ValueError` rather than deleting unrelated
  files.

Dataset-directory resolution is factored into a shared `resolve_dataset_dir()`
helper used by both `create()` and the `start_recording` facade (honouring
`$HF_LEROBOT_HOME`), so the two surfaces can no longer diverge. This makes the
`resume()` docstring and its `RuntimeError` message honest.

## Tests

New regression tests in `tests/test_dataset_recorder.py` (all fail on pre-change
code):

- existing dataset dir + `overwrite=False` -> clear `FileExistsError` (create
  not invoked, dataset untouched);
- existing dataset dir + `overwrite=True` -> stale content removed, fresh
  `create()` runs;
- existing empty dir -> cleared, `create()` succeeds;
- non-empty non-dataset dir -> `ValueError`, files preserved;
- `resolve_dataset_dir()` root/repo_id resolution.

Full `ruff` + `mypy` + `pytest` gate green
(`tests/test_dataset_recorder.py`, `tests/simulation/mujoco/test_recording_paths.py`,
`tests/simulation/test_recording_target_resolution.py` — 125 passed).