### PR TITLE
fix(dataset): add overwrite= to DatasetRecorder.create() for existing dirs

### DIFF
--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -24,6 +24,7 @@ Usage:
 import json
 import logging
 import re
+import shutil
 import sys
 from pathlib import Path
 from typing import Any
@@ -201,6 +202,52 @@ def _get_lerobot_dataset_class():
         ) from exc
 
 
+def _resolve_dataset_dir(repo_id: str, root: str | None) -> Path | None:
+    """Resolve the on-disk directory ``LeRobotDataset.create`` will write to.
+
+    LeRobot writes a dataset to ``root`` when given, else to
+    ``HF_LEROBOT_HOME / repo_id`` (the ``~/.cache/huggingface/lerobot`` default,
+    overridable via the ``HF_LEROBOT_HOME`` env var). :meth:`DatasetRecorder.create`
+    needs this path to honor ``overwrite=`` before handing off to LeRobot, whose
+    ``create`` does ``mkdir(exist_ok=False)`` and raises ``FileExistsError`` on a
+    pre-existing dir.
+
+    Returns ``None`` when ``root`` is not given and ``HF_LEROBOT_HOME`` cannot be
+    imported (e.g. a minimal env without lerobot). Callers treat ``None`` as
+    "cannot pre-check" and fall back to catching LeRobot's ``FileExistsError``,
+    so the overwrite handling degrades gracefully rather than crashing on import.
+
+    Args:
+        repo_id: HuggingFace dataset ID (e.g. "user/my_dataset").
+        root: Explicit local dataset directory, or None to use the LeRobot default.
+
+    Returns:
+        The resolved dataset directory, or None if it cannot be determined.
+    """
+    if root is not None:
+        return Path(root)
+    try:
+        from lerobot.constants import HF_LEROBOT_HOME
+    except Exception:  # noqa: BLE001 - any import failure -> "cannot pre-check"
+        return None
+    return Path(HF_LEROBOT_HOME) / repo_id
+
+
+def _dataset_exists_message(dataset_dir: "Path | str") -> str:
+    """Actionable error text for a create() blocked by an existing dataset dir.
+
+    Names both escape hatches so the message points at parameters that actually
+    exist: ``overwrite=True`` (replace with a fresh dataset) and
+    :meth:`DatasetRecorder.resume` (append episodes to the existing one).
+    """
+    return (
+        f"Dataset directory already exists: {dataset_dir}. DatasetRecorder.create() "
+        "builds a NEW dataset and will not replace or append to an existing one. "
+        "Pass overwrite=True to replace it with a fresh dataset, or use "
+        "DatasetRecorder.resume() to append episodes to the existing dataset."
+    )
+
+
 class DatasetRecorder:
     """Bridge between strands-robots control loops and LeRobotDataset.
 
@@ -286,6 +333,7 @@ class DatasetRecorder:
         extra_state_specs: list[tuple[str, list[str]]] | None = None,
         task: str = "",
         root: str | None = None,
+        overwrite: bool = False,
         use_videos: bool = True,
         vcodec: str = "h264",
         streaming_encoding: bool = True,
@@ -319,6 +367,13 @@ class DatasetRecorder:
                 these; add_frame reads the source keys, not the expanded names.
             task: Default task description
             root: Local directory for dataset storage
+            overwrite: When True, replace an existing dataset directory
+                (``root`` or the ``HF_LEROBOT_HOME/repo_id`` default) with a
+                fresh dataset. When False (default) and the directory already
+                exists, create() raises a clear ``FileExistsError`` naming
+                ``overwrite=`` and :meth:`resume` instead of leaving LeRobot to
+                fail with a bare ``FileExistsError``. To APPEND episodes to an
+                existing dataset use :meth:`resume`, not ``overwrite=True``.
             use_videos: Encode camera frames as video (True) or keep as images
             vcodec: Video codec for the per-camera MP4 streams. Defaults to
                 "h264" (H.264), which is universally decodable - including
@@ -383,7 +438,34 @@ class DatasetRecorder:
             create_kwargs["streaming_encoding"] = streaming_encoding
         if "video_backend" in create_params:
             create_kwargs["video_backend"] = video_backend
-        dataset = LeRobotDatasetCls.create(**create_kwargs)
+        # Honor overwrite= before LeRobot's create() (which mkdir(exist_ok=False)s
+        # and raises a bare FileExistsError on a pre-existing dir). When the dir
+        # cannot be pre-resolved (root=None and HF_LEROBOT_HOME unavailable), fall
+        # back to catching that FileExistsError below and re-raising it with the
+        # same actionable guidance.
+        dataset_dir = _resolve_dataset_dir(repo_id, root)
+        if dataset_dir is not None and dataset_dir.exists():
+            if overwrite:
+                if dataset_dir.is_dir():
+                    shutil.rmtree(dataset_dir)
+                else:
+                    dataset_dir.unlink()
+                logger.info("Removed existing dataset target for overwrite=True: %s", dataset_dir)
+            else:
+                raise FileExistsError(_dataset_exists_message(dataset_dir))
+
+        try:
+            dataset = LeRobotDatasetCls.create(**create_kwargs)
+        except FileExistsError as exc:
+            # The dir existed but we could not pre-resolve it (root=None with
+            # HF_LEROBOT_HOME unimportable). Re-raise with actionable guidance
+            # rather than the bare LeRobot FileExistsError.
+            if overwrite:
+                raise FileExistsError(
+                    f"Could not resolve the dataset directory to honor overwrite=True "
+                    f"for {repo_id}; remove it manually or pass an explicit root=."
+                ) from exc
+            raise FileExistsError(_dataset_exists_message(dataset_dir or repo_id)) from exc
 
         recorder = cls(dataset=dataset, task=task, camera_key_map=camera_key_map)
         # When vector state specs expand the schema (e.g. a floating base),
@@ -410,10 +492,10 @@ class DatasetRecorder:
     ) -> "DatasetRecorder":
         """Resume recording into an EXISTING LeRobotDataset (append episodes).
 
-        Unlike :meth:`create` (which calls ``LeRobotDataset.create`` and
-        hard-fails with ``FileExistsError`` if the dataset dir already
-        exists), this opens an on-disk dataset via ``LeRobotDataset.resume``
-        so further ``add_frame``/``save_episode`` calls append new episodes.
+        Unlike :meth:`create` (which builds a NEW dataset and either errors
+        on an existing dir or, with ``overwrite=True``, replaces it), this
+        opens an on-disk dataset via ``LeRobotDataset.resume`` so further
+        ``add_frame``/``save_episode`` calls append new episodes.
 
         This is the multi-episode data-collection path: ``start_recording``
         with ``overwrite=False`` on an existing dataset routes here instead of

--- a/tests/test_dataset_recorder.py
+++ b/tests/test_dataset_recorder.py
@@ -1184,6 +1184,164 @@ def test_create_builds_features_from_joints_and_cameras(monkeypatch):
     assert features["observation.images.top"]["shape"] == (3, 240, 320)
 
 
+
+# DatasetRecorder.create(overwrite=...) -- existing-dataset-directory handling.
+#
+# LeRobotDataset.create() does mkdir(exist_ok=False) and raises a bare
+# FileExistsError when its target directory already exists, and create() used to
+# expose no way to force a fresh dataset. These tests pin the overwrite contract
+# without a real lerobot install: they inject a fake LeRobotDataset (whose
+# create() must / must not run) and pass root=tmp_path so _resolve_dataset_dir
+# takes the explicit-root branch (no lerobot.constants import needed).
+
+
+class _RecordingCreateDataset:
+    """Fake LeRobotDataset whose create() records whether it was invoked.
+
+    Used to assert that create() is short-circuited (never called) when an
+    existing directory blocks a non-overwrite create, and called exactly once
+    on the overwrite / absent-dir paths.
+    """
+
+    create_calls: int = 0
+
+    def __init__(self, repo_id, root=None) -> None:
+        self.repo_id = repo_id
+        self.root = root
+
+    @classmethod
+    def create(cls, repo_id, fps=30, root=None, robot_type="unknown", features=None,
+               use_videos=True, image_writer_threads=4, vcodec="libsvtav1"):
+        cls.create_calls += 1
+        return cls(repo_id, root=root)
+
+
+def test_create_without_overwrite_raises_clear_error_on_existing_dir(monkeypatch, tmp_path):
+    """create() on an existing dir (no overwrite) raises a clear FileExistsError.
+
+    The message must name the escape hatches that actually exist -- overwrite=
+    and resume() -- instead of leaving LeRobot to raise a bare FileExistsError.
+    The underlying dataset create() must never run (the dir pre-check
+    short-circuits before it).
+    """
+    _RecordingCreateDataset.create_calls = 0
+    _patch_lerobot_dataset(monkeypatch, _RecordingCreateDataset)
+
+    # A populated dataset directory already on disk.
+    (tmp_path / "meta").mkdir()
+    (tmp_path / "meta" / "info.json").write_text("{}")
+
+    with pytest.raises(FileExistsError, match="overwrite=True"):
+        DatasetRecorder.create("user/data", root=str(tmp_path), joint_names=["j1"])
+
+    # The message also points at resume() as the append path.
+    with pytest.raises(FileExistsError, match="resume"):
+        DatasetRecorder.create("user/data", root=str(tmp_path), joint_names=["j1"])
+
+    assert _RecordingCreateDataset.create_calls == 0  # never reached LeRobot
+
+
+def test_create_overwrite_true_replaces_existing_dir(monkeypatch, tmp_path):
+    """create(overwrite=True) removes an existing dir, then creates fresh."""
+    _RecordingCreateDataset.create_calls = 0
+    _patch_lerobot_dataset(monkeypatch, _RecordingCreateDataset)
+
+    # A pre-existing dataset dir with a sentinel that must be gone afterward.
+    (tmp_path / "meta").mkdir()
+    sentinel = tmp_path / "meta" / "old.parquet"
+    sentinel.write_text("stale")
+
+    recorder = DatasetRecorder.create("user/data", root=str(tmp_path), joint_names=["j1"], overwrite=True)
+
+    assert not sentinel.exists()  # the stale dataset dir was removed
+    assert not tmp_path.exists()  # rmtree removed the target entirely
+    assert _RecordingCreateDataset.create_calls == 1  # fresh create() ran once
+    assert recorder.dataset.repo_id == "user/data"
+
+
+def test_create_overwrite_true_replaces_existing_file_target(monkeypatch, tmp_path):
+    """overwrite=True also clears a plain file sitting at the dataset path."""
+    _RecordingCreateDataset.create_calls = 0
+    _patch_lerobot_dataset(monkeypatch, _RecordingCreateDataset)
+
+    file_target = tmp_path / "dataset_root"
+    file_target.write_text("not a directory")
+
+    DatasetRecorder.create("user/data", root=str(file_target), joint_names=["j1"], overwrite=True)
+
+    assert not file_target.exists()  # the file was unlinked
+    assert _RecordingCreateDataset.create_calls == 1
+
+
+def test_create_no_precheck_when_dir_absent(monkeypatch, tmp_path):
+    """An absent dataset dir skips the overwrite pre-check and creates normally."""
+    _RecordingCreateDataset.create_calls = 0
+    _patch_lerobot_dataset(monkeypatch, _RecordingCreateDataset)
+
+    absent = tmp_path / "does_not_exist_yet"
+    recorder = DatasetRecorder.create("user/data", root=str(absent), joint_names=["j1"])
+
+    assert _RecordingCreateDataset.create_calls == 1
+    assert recorder.dataset.repo_id == "user/data"
+
+
+def test_create_reraises_bare_fileexists_with_guidance(monkeypatch, tmp_path):
+    """When the dir cannot be pre-resolved, a LeRobot FileExistsError is re-raised
+    with the actionable overwrite=/resume() guidance rather than left bare.
+
+    Simulates the root=None + HF_LEROBOT_HOME-unavailable edge: the pre-check
+    resolver returns None, so the guard cannot fire, and LeRobot's create()
+    raises FileExistsError. create() must translate that into the same clear
+    message naming overwrite= and resume().
+    """
+    class _FileExistsCreateDataset:
+        @classmethod
+        def create(cls, repo_id, **kwargs):
+            raise FileExistsError(f"[Errno 17] File exists: {repo_id}")
+
+    _patch_lerobot_dataset(monkeypatch, _FileExistsCreateDataset)
+    # Force the resolver to return None (cannot pre-check) by leaving root=None
+    # and making lerobot.constants unimportable.
+    import sys
+    monkeypatch.setitem(sys.modules, "lerobot.constants", None)
+
+    with pytest.raises(FileExistsError, match="overwrite=True"):
+        DatasetRecorder.create("user/data", joint_names=["j1"])
+
+
+def test_create_overwrite_true_surfaces_unresolvable_dir(monkeypatch):
+    """overwrite=True but the dir is unresolvable -> a clear FileExistsError that
+    says the directory could not be resolved (not the bare LeRobot error)."""
+    class _FileExistsCreateDataset:
+        @classmethod
+        def create(cls, repo_id, **kwargs):
+            raise FileExistsError("[Errno 17] File exists")
+
+    _patch_lerobot_dataset(monkeypatch, _FileExistsCreateDataset)
+    import sys
+    monkeypatch.setitem(sys.modules, "lerobot.constants", None)
+
+    with pytest.raises(FileExistsError, match="[Cc]ould not resolve"):
+        DatasetRecorder.create("user/data", joint_names=["j1"], overwrite=True)
+
+
+def test_resolve_dataset_dir_prefers_explicit_root():
+    """_resolve_dataset_dir returns Path(root) verbatim when root is given."""
+    from strands_robots.dataset_recorder import _resolve_dataset_dir
+    from pathlib import Path
+
+    assert _resolve_dataset_dir("user/data", "/tmp/explicit") == Path("/tmp/explicit")
+
+
+def test_resolve_dataset_dir_returns_none_when_unresolvable(monkeypatch):
+    """With no root and no importable HF_LEROBOT_HOME, the resolver returns None
+    so create() falls back to catching LeRobot's own FileExistsError."""
+    import sys
+    from strands_robots.dataset_recorder import _resolve_dataset_dir
+
+    monkeypatch.setitem(sys.modules, "lerobot.constants", None)
+    assert _resolve_dataset_dir("user/data", None) is None
+
 # camera_key_map remap + camera-key-mismatch diagnostic
 #
 # Regression coverage for the silent data-loss mode where a policy declares


### PR DESCRIPTION
## Summary

`DatasetRecorder.create()` called `LeRobotDataset.create()`, which does `mkdir(exist_ok=False)` and hard-fails with a bare `FileExistsError` when the dataset directory already exists. `create()` exposed **no `overwrite` parameter**, so re-recording into an existing `repo_id` crashed with no in-API way to force a fresh dataset. Worse, `resume()`'s docstring and its no-resume `RuntimeError` both referenced an `overwrite=True` that did not exist on `create()`, so the error text pointed callers at a parameter they could not pass.

Fixes #1404.

## Change

Adds `overwrite: bool = False` to `DatasetRecorder.create()` (option 1 from the issue):

- **`overwrite=True`** removes any existing dataset directory (resolved via `root`, else the `HF_LEROBOT_HOME/repo_id` default) and creates a fresh dataset.
- **`overwrite=False`** on an existing directory raises a clear `FileExistsError` that names `overwrite=` and `resume()`, instead of a bare LeRobot `FileExistsError`.
- When the directory cannot be pre-resolved (`root=None` and `HF_LEROBOT_HOME` unimportable, e.g. a minimal env), LeRobot's own `FileExistsError` is caught and re-raised with the same actionable guidance, so the behavior degrades gracefully rather than crashing on import.

Directory resolution goes through a small `_resolve_dataset_dir()` helper that honors the `HF_LEROBOT_HOME` env var (rather than hard-coding `~/.cache/huggingface/lerobot`). The `resume()` docstring is updated so its description of `create()` stays accurate (drift-free docs).

The direct API deliberately does **not** auto-route to `resume()`: `create()` is the fresh-dataset primitive, and silently appending would be surprising. The clear error points callers at `resume()` for the append path.

## Acceptance (from #1404)

- [x] `create(..., overwrite=True)` on an existing dataset dir succeeds with a fresh dataset.
- [x] `create(...)` on an existing dir without `overwrite` raises a clear error naming `overwrite=` / `resume()` (not a bare `FileExistsError`).
- [x] `resume()` docstring + the no-resume `RuntimeError` message reference a parameter that actually exists.
- [x] Regression test covers the existing-dir path for both `overwrite=False` (clear error) and `overwrite=True` (fresh dataset).

## Tests

Adds 8 regression tests to `tests/test_dataset_recorder.py`, following the existing fake-`LeRobotDataset` injection idiom (`_patch_lerobot_dataset`) and passing `root=tmp_path` so the resolver takes the explicit-`root` branch (no `lerobot` install needed):

- `test_create_without_overwrite_raises_clear_error_on_existing_dir` - clear error naming `overwrite=` and `resume()`; underlying `create()` never runs.
- `test_create_overwrite_true_replaces_existing_dir` - existing dir removed, fresh `create()` runs once.
- `test_create_overwrite_true_replaces_existing_file_target` - a plain file at the path is unlinked.
- `test_create_no_precheck_when_dir_absent` - absent dir skips the pre-check (happy-path guard).
- `test_create_reraises_bare_fileexists_with_guidance` - unresolvable dir + LeRobot `FileExistsError` re-raised with guidance.
- `test_create_overwrite_true_surfaces_unresolvable_dir` - `overwrite=True` but unresolvable dir surfaces a clear error.
- `test_resolve_dataset_dir_prefers_explicit_root` / `test_resolve_dataset_dir_returns_none_when_unresolvable` - helper contract.

Full `tests/test_dataset_recorder.py` run locally: existing tests unaffected (the only local failure is `test_has_lerobot_dataset_does_not_negatively_cache`, which needs a real `lerobot` install absent from the scratch env and is unrelated to this change).

## Scope

Surgical, single-purpose: `strands_robots/dataset_recorder.py` (+87/-5) and `tests/test_dataset_recorder.py` (+158). No public API removed; the new parameter is keyword-only in practice (all callers pass kwargs after the positional `repo_id`) and defaults to the prior behavior.