### PR TITLE
fix(sim): strip stray leading space from render/render_depth no-GL error messages

### DIFF
--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -852,7 +852,7 @@ class RenderingMixin:
                     "content": [
                         {
                             "text": (
-                                " Rendering unavailable (no OpenGL context). "
+                                "Rendering unavailable (no OpenGL context). "
                                 "Install EGL or OSMesa for offscreen rendering: "
                                 "apt-get install libosmesa6-dev"
                             )
@@ -995,7 +995,7 @@ class RenderingMixin:
                     "content": [
                         {
                             "text": (
-                                " Depth rendering unavailable (no OpenGL context). "
+                                "Depth rendering unavailable (no OpenGL context). "
                                 "Install EGL or OSMesa for offscreen rendering."
                             )
                         }

--- a/tests/simulation/mujoco/test_render_no_gl_context_message.py
+++ b/tests/simulation/mujoco/test_render_no_gl_context_message.py
@@ -1,0 +1,58 @@
+"""render / render_depth surface a clean error when no OpenGL context exists.
+
+When the offscreen renderer cannot be built (no EGL/OSMesa GL context on the
+host), :meth:`render` and :meth:`render_depth` short-circuit with a structured
+``status=error`` agent-tool dict instead of raising. That message is read
+verbatim by an LLM caller, so it must be a clean sentence: no stray leading or
+trailing whitespace, and it must name the failure and the actionable fix
+(install EGL/OSMesa).
+
+The renderer-None branch is exercised deterministically by monkeypatching
+``_get_renderer`` to return ``None``, so the test runs on every runner
+regardless of the local GL driver.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="no_gl_context_test", mesh=False)
+    s.create_world()
+    yield s
+    s.cleanup()
+
+
+def _error_text(result: dict) -> str:
+    assert result["status"] == "error", result
+    return next(block["text"] for block in result["content"] if "text" in block)
+
+
+def test_render_reports_clean_message_when_no_gl_context(sim, monkeypatch):
+    monkeypatch.setattr(sim, "_get_renderer", lambda w, h: None)
+
+    text = _error_text(sim.render(camera_name="default", width=4, height=3))
+
+    # No orphaned whitespace (a leading space here is a real cosmetic defect
+    # left over from stripping a prefix glyph); actionable and self-describing.
+    assert text == text.strip()
+    assert "Rendering unavailable" in text
+    assert "OpenGL" in text
+    assert ("EGL" in text) or ("OSMesa" in text)
+
+
+def test_render_depth_reports_clean_message_when_no_gl_context(sim, monkeypatch):
+    monkeypatch.setattr(sim, "_get_renderer", lambda w, h: None)
+
+    text = _error_text(sim.render_depth(camera_name="default", width=4, height=3))
+
+    assert text == text.strip()
+    assert "Depth rendering unavailable" in text
+    assert "OpenGL" in text
+    assert ("EGL" in text) or ("OSMesa" in text)


### PR DESCRIPTION
## Problem

`Simulation.render()` and `Simulation.render_depth()` return a structured `status=error` agent-tool dict when the offscreen renderer cannot be built (no EGL/OSMesa GL context on the host). Both messages opened with a stray leading space:

```
" Rendering unavailable (no OpenGL context). Install EGL or OSMesa for offscreen rendering: apt-get install libosmesa6-dev"
" Depth rendering unavailable (no OpenGL context). Install EGL or OSMesa for offscreen rendering."
```

That leading space is orphaned whitespace (a prefix glyph was removed at some point but the space stayed). The text is read verbatim by an LLM caller, so the ragged leading space is a small but real quality defect in the error contract.

## Change

Strip the leading space from both strings so each reads as a clean sentence. No other behavior changes: this only touches the error text emitted on the renderer-None fallback path.

## Tests

New `tests/simulation/mujoco/test_render_no_gl_context_message.py` drives the renderer-None branch deterministically (monkeypatched `_get_renderer` returning `None`) for both `render()` and `render_depth()` and asserts the message:

- has no leading/trailing whitespace (`text == text.strip()`),
- names the failure (`Rendering unavailable` / `Depth rendering unavailable`),
- keeps the actionable install hint (`OpenGL`, `EGL`/`OSMesa`).

The test fails on the pre-fix strings (asserts the leading space away) and passes after. It also covers the previously-untested renderer-None branch in `render()` and `render_depth()`.

Local gate: `ruff check` + `ruff format --check` clean, `mypy strands_robots tests` clean on the changed files, and the full MuJoCo rendering suite (`MUJOCO_GL=egl pytest tests/simulation/mujoco -k render`) passes (159 passed).

Note: no visual artifact is applicable - this changes only the error text emitted when rendering is impossible (no GL context), so it produces no rendered pixels; the deterministic branch test is the proof.