### PR TITLE
test(hardware): pin fail-soft OSError swallow in calibration auto-migration

### DIFF
--- a/tests/test_hardware_ros_telemetry_and_calibration_migration.py
+++ b/tests/test_hardware_ros_telemetry_and_calibration_migration.py
@@ -12,6 +12,8 @@ booleans, and never lets a bridge failure interrupt the control loop.
 ``_migrate_legacy_calibration`` copies a pre-0.5 ``so100_follower/`` /
 ``so101_follower/`` calibration file to the unified ``so_follower/`` path,
 refusing to guess when the source is ambiguous and no-op'ing for non-SO robots.
+Any copy failure (OSError) is logged and swallowed so a migration that
+cannot complete leaves the robot uncalibrated rather than aborting connect.
 """
 
 from __future__ import annotations
@@ -20,6 +22,7 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
+import pytest
 
 from strands_robots.hardware_robot import Robot as HwRobot
 
@@ -172,3 +175,24 @@ class TestLegacyCalibrationMigration:
         hw = _migration_robot(None)
         # robot exposes no calibration path -> nothing to migrate, must not raise.
         hw._migrate_legacy_calibration()
+
+    def test_copy_failure_is_logged_and_swallowed(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A single valid legacy source is found, so migration reaches the copy
+        # step. If ``shutil.copy2`` raises OSError (permission denied, disk
+        # full, read-only mount), the documented contract is fail-soft: log a
+        # warning and leave the robot in its pre-existing uncalibrated state
+        # rather than aborting connect with a traceback.
+        new_path = self._seed(tmp_path, "so_follower", ["so100_follower"])
+        hw = _migration_robot(str(new_path))
+
+        def _raise_oserror(*_args: object, **_kwargs: object) -> None:
+            raise OSError("disk full")
+
+        monkeypatch.setattr("strands_robots.hardware_robot.shutil.copy2", _raise_oserror)
+
+        # Must not propagate the OSError...
+        hw._migrate_legacy_calibration()
+
+        # ...and the shared path stays absent -> robot remains uncalibrated,
+        # which the connect path reports clearly on its own.
+        assert not new_path.is_file()


### PR DESCRIPTION
## Problem

`Robot._migrate_legacy_calibration` (`strands_robots/hardware_robot.py`) best-effort copies a pre-0.5 SO-family calibration file into the unified `so_follower/` / `so_leader/` path. Its docstring promises a fail-soft contract:

> Any failure is logged and swallowed -- a calibration that can't be migrated simply leaves the robot in its pre-existing (uncalibrated) state, which the connect path already reports clearly.

The happy path and every guard branch (already-calibrated, ambiguous sources, no source, non-SO family, missing `calibration_fpath`) are pinned, but the `except OSError` swallow itself was the one uncovered branch of the method. A regression that turned the swallow into a re-raise (e.g. a refactor that lets a read-only mount / disk-full error escape) would abort `connect` with a traceback and go unnoticed by the suite.

## Change

Add one focused behavior test that seeds a single valid legacy source (so migration reaches `shutil.copy2`), monkeypatches `copy2` to raise `OSError`, and asserts the method does not propagate and leaves the shared path absent (robot stays uncalibrated). Extends the existing `TestLegacyCalibrationMigration` class; module docstring updated to state the fail-soft contract.

Test-only, no production code change.

## Verification

- Fails pre-fix: turning the `except OSError` swallow into a re-raise makes the new test fail with `OSError: disk full`; passes with the current fail-soft code.
- `ruff check` / `ruff format --check` / `mypy` clean over `strands_robots tests tests_integ`.
- `MUJOCO_GL=egl pytest tests/test_hardware_ros_telemetry_and_calibration_migration.py` -> 11 passed.
- Uses `monkeypatch`, `tmp_path`, no host paths, no emojis; matches the file's existing `__new__`-wired no-hardware pattern.