### PR TITLE
fix(registry): render every robot in format_robot_table regardless of category

### DIFF
--- a/strands_robots/registry/robots.py
+++ b/strands_robots/registry/robots.py
@@ -173,6 +173,21 @@ _SIM_WIDTH = 5
 _REAL_WIDTH = 5
 # Width of the fixed prefix columns, including single-space separators.
 _FIXED_PREFIX_WIDTH = _NAME_WIDTH + 1 + _CAT_WIDTH + 1 + _JOINTS_WIDTH + 1 + _SIM_WIDTH + 1 + _REAL_WIDTH + 1
+# Preferred display order for the category groups in ``format_robot_table``.
+# It is only an ORDERING hint, not an allowlist: categories present in the
+# registry but absent here (e.g. a user-registered robot with a custom
+# category) are appended afterwards in sorted order so every robot still
+# gets a row - the table body must never under-count the footer Total.
+_CATEGORY_DISPLAY_ORDER = (
+    "arm",
+    "bimanual",
+    "hand",
+    "humanoid",
+    "expressive",
+    "mobile",
+    "mobile_manip",
+    "aerial",
+)
 
 
 def format_robot_table(max_width: int = 100) -> str:
@@ -191,7 +206,10 @@ def format_robot_table(max_width: int = 100) -> str:
 
     Returns:
         Multi-line string: a header row, a rule, one row per robot grouped
-        by category, then a totals footer.
+        by category (common categories first, then any custom categories in
+        sorted order), then a totals footer. Every registered robot gets
+        exactly one row, so the body row count always matches the footer
+        ``Total``.
     """
     desc_width = max(20, max_width - _FIXED_PREFIX_WIDTH)
 
@@ -206,9 +224,13 @@ def format_robot_table(max_width: int = 100) -> str:
     rule_width = min(max(max_width, len(header)), _FIXED_PREFIX_WIDTH + desc_width)
     lines = [header, "-" * rule_width]
 
-    for cat in ["arm", "bimanual", "hand", "humanoid", "expressive", "mobile", "mobile_manip", "aerial"]:
-        by_cat = list_robots_by_category()
-        for r in by_cat.get(cat, []):
+    by_cat = list_robots_by_category()
+    # Preferred groups first, then any remaining categories in sorted order
+    # so no robot is silently dropped from the body (see _CATEGORY_DISPLAY_ORDER).
+    ordered_cats = [c for c in _CATEGORY_DISPLAY_ORDER if c in by_cat]
+    ordered_cats += sorted(c for c in by_cat if c not in _CATEGORY_DISPLAY_ORDER)
+    for cat in ordered_cats:
+        for r in by_cat[cat]:
             sim = "yes" if r["has_sim"] else ""
             real = "yes" if r["has_real"] else ""
             joints = str(r["joints"]) if r["joints"] else "?"

--- a/tests/registry/test_format_robot_table.py
+++ b/tests/registry/test_format_robot_table.py
@@ -116,3 +116,50 @@ class TestAsciiOnlyAndAlignment:
         # so100 has sim support in the registry.
         so100_row = next(ln for ln in table.split("\n") if ln.startswith("so100 "))
         assert "yes" in so100_row
+
+
+class TestCustomCategoryNotDropped:
+    """A robot whose category is outside the common set must still get a row.
+
+    ``register_robot`` accepts an arbitrary ``category`` string, so a user can
+    register a robot under a category (e.g. ``"quadruped"``) that the table's
+    preferred display order does not enumerate. Such a robot must still appear
+    in the body - otherwise the visible rows under-count the footer ``Total``,
+    producing a misleading discovery surface.
+    """
+
+    def _register(self, tmp_path, name, category):
+        from strands_robots.registry import register_robot
+
+        robot_dir = tmp_path / name
+        robot_dir.mkdir(parents=True, exist_ok=True)
+        (robot_dir / "bot.xml").write_text(f'<mujoco model="{name}"><worldbody/></mujoco>')
+        register_robot(
+            name=name,
+            model_xml="bot.xml",
+            asset_dir=str(robot_dir),
+            category=category,
+            joints=4,
+            description=f"custom {category} robot",
+        )
+
+    def test_custom_category_robot_appears_in_body(self, tmp_path):
+        self._register(tmp_path, "quadbot", "quadruped")
+        table = format_robot_table(max_width=1000)
+        assert "quadbot" in table, "robot with a custom category was dropped from the table body"
+
+    def test_body_row_count_matches_total_with_custom_category(self, tmp_path):
+        """The consistency invariant must survive custom categories: one body
+        row per registered robot, matching the footer ``Total``."""
+        self._register(tmp_path, "quadbot", "quadruped")
+        table = format_robot_table(max_width=1000)
+        lines = table.split("\n")
+        non_empty_rows = [ln for ln in lines[2:-2] if ln.strip() and "Total:" not in ln]
+        assert len(non_empty_rows) == len(list_robots())
+
+    def test_missing_category_defaults_to_other_and_is_shown(self, tmp_path):
+        """A robot registered with an empty category groups under ``"other"``
+        (via ``list_robots_by_category``) and must still be rendered."""
+        self._register(tmp_path, "mysterybot", "")
+        table = format_robot_table(max_width=1000)
+        assert "mysterybot" in table


### PR DESCRIPTION
## Problem

`format_robot_table()` iterated a hardcoded list of eight category names:

```python
for cat in ["arm", "bimanual", "hand", "humanoid", "expressive", "mobile", "mobile_manip", "aerial"]:
    for r in list_robots_by_category().get(cat, []):
        ...
```

Any robot whose category is not in that list is silently dropped from the table body, yet still counted in the `Total: N robots` footer. `register_robot(category=...)` accepts an arbitrary string (its docstring documents `arm, humanoid, mobile, hand, aerial, bimanual, ...`), so:

- a user robot registered under a custom category (e.g. `"quadruped"`) never appears in the table, and
- a robot registered with an empty/missing category groups under `"other"` (via `list_robots_by_category`) and is likewise omitted.

The result is a discovery table whose visible rows under-count the stated `Total`, contradicting the docstring's "one row per robot" promise. All built-in robots happen to use the eight enumerated categories today, so the bug is latent for the shipped registry but reproducible the moment a custom robot is registered.

## Change

Iterate over the categories actually present instead of a fixed allowlist: the common categories first (preserving the curated display order), then any remaining categories in sorted order. Every registered robot now gets exactly one row, so the body row count always matches the footer `Total`. The per-category `list_robots_by_category()` call is also hoisted out of the loop (it was recomputed on every iteration).

## Tests

Adds `TestCustomCategoryNotDropped` to `tests/registry/test_format_robot_table.py`, which registers a custom-category robot (`quadruped`) and an empty-category robot and asserts:

- the robot appears in the table body, and
- `len(body rows) == len(list_robots())`.

Both fail on the pre-fix code (body shows 72 rows against a footer `Total: 73`) and pass after. Full `tests/registry` suite (634 tests) is green; ruff + mypy clean.