### PR TITLE
docs: correct residual pre-0.6 lerobot install guidance (architecture / troubleshooting / molmoact2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,20 @@ which the server applies as a `RenameObservationsProcessorStep` (renaming each
 matching observation key before the policy sees it). The default stays `{}` (no
 remap), and a non-dict `rename_map` is rejected client-side with a clear error.
 
+### Docs: correct the remaining pre-0.6 lerobot install guidance (`architecture.md` / `troubleshooting.md` / `molmoact2.md`)
+
+The `lerobot>=0.6.0` floor bump (`lerobot[feetech,dataset]>=0.6.0,<0.7.0`) and the
+follow-up VLA dependency-guidance pass corrected most docs, but a few user-facing
+spots still carried the dead pre-0.6 narrative. The `architecture.md` dependency
+matrix advertised the obsolete `lerobot>=0.5.0,<0.6.0` cap; the `troubleshooting.md`
+version-skew row told users to `pip install "lerobot>=0.5.0,<0.6"` (a manual pin that
+*conflicts* with the declared `>=0.6.0` floor) and to install `MolmoAct2Policy` "from
+source" (it ships in lerobot >= 0.6 on PyPI, so `strands-robots[molmoact2]` resolves it),
+and its Jetson/pyav row linked to a broken `#molmoact2-on-jetson-lerobot-from-source`
+anchor. Corrected all of these (plus the `molmoact2.md` "lerobot from source" install
+line) to match the current PyPI floor, and extended `tests/test_lerobot_dependency_docs.py`
+to pin them -- including a heading-slug resolution check so the Jetson anchor stays live.
+
 ### Added: `get_ground_height(x, y)` -- query the local terrain surface height
 
 `create_world(terrain=...)` raises the local ground up to

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -104,7 +104,7 @@ graph TB
 | Extra | Pulls in | When |
 |-------|----------|------|
 | `[sim-mujoco]` | `mujoco`, `numpy`, `imageio`, `imageio-ffmpeg` | `Robot(mode="sim")` |
-| `[lerobot]` | `lerobot>=0.5.0,<0.6.0`, `torch` | Real hardware OR `LerobotLocalPolicy` |
+| `[lerobot]` | `lerobot>=0.6.0,<0.7.0`, `torch` | Real hardware OR `LerobotLocalPolicy` |
 | `[groot-service]` | `pyzmq`, `msgpack` | `Gr00tPolicy` ZMQ |
 | `[cosmos3-service]` | `msgpack`, `websockets` | `Cosmos3Policy` WebSocket |
 | `[mesh]` | `eclipse-zenoh`, `json5` | Multi-robot mesh |

--- a/docs/policies/molmoact2.md
+++ b/docs/policies/molmoact2.md
@@ -9,7 +9,7 @@ MolmoAct2 runs through the [LeRobot Local](lerobot-local.md) provider
 action/observation contract for the SO-100/101 checkpoints and how to debug the
 common "the policy runs but the arm does not move in MuJoCo" report.
 
-For install (lerobot from source + the `[molmoact2]` extra), caching, the
+For install (the `[molmoact2]` extra, which pulls lerobot >= 0.6 from PyPI), caching, the
 processor/`norm_stats.json` bridge and camera routing, see the
 [LeRobot Local](lerobot-local.md) page.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -10,9 +10,9 @@ description: Error → fix table for the most common gotchas across install, sim
 |---------|--------------|-----|
 | `ModuleNotFoundError: mujoco` | Missing `[sim-mujoco]` | `uv pip install "strands-robots[sim-mujoco]"` |
 | `ModuleNotFoundError: lerobot` | Missing `[lerobot]` | `uv pip install "strands-robots[lerobot]"` |
-| `ImportError: cannot import name '...' from 'lerobot'` | LeRobot version skew | `uv pip install "lerobot>=0.5.0,<0.6"` |
-| `ImportError: cannot import name 'MolmoAct2Policy'` | MolmoAct2 not in PyPI lerobot (added post-0.5.1) | Install from source: `uv pip install "lerobot[feetech] @ git+https://github.com/huggingface/lerobot.git"` |
-| pyav build fails on Jetson/aarch64 | No prebuilt wheel for sm_110 | Use `--no-build-isolation` or install `torchcodec>=0.7` and skip pyav. See [installation](getting-started/installation.md#molmoact2-on-jetson-lerobot-from-source) |
+| `ImportError: cannot import name '...' from 'lerobot'` | LeRobot version skew | `uv pip install "strands-robots[lerobot]"` (pins `lerobot>=0.6.0,<0.7.0`) |
+| `ImportError: cannot import name 'MolmoAct2Policy'` | `lerobot < 0.6` (`MolmoAct2Policy` ships in lerobot >= 0.6) | `uv pip install "strands-robots[molmoact2]"` |
+| pyav build fails on Jetson/aarch64 | No prebuilt wheel for sm_110 | Use `--no-build-isolation` or install `torchcodec>=0.7` and skip pyav. See [installation](getting-started/installation.md#molmoact2-on-jetson) |
 | numpy ABI mismatch on Jetson | System pandas vs pip numpy | `uv pip install "numpy<2" "pandas==2.1.4"` then reinstall |
 | `uv pip install -e .` errors | Wrong cwd | `cd` to repo root first |
 

--- a/tests/test_lerobot_dependency_docs.py
+++ b/tests/test_lerobot_dependency_docs.py
@@ -85,3 +85,77 @@ def test_lerobot_local_docs_do_not_claim_molmoact2_needs_source() -> None:
     assert "resolves lerobot 0.5.1, which does NOT" not in text
     # points at the PyPI extra instead
     assert "strands-robots[molmoact2]" in text
+
+
+# --- negative contract, extended: the pre-0.6 "lerobot from source / <0.6 pin"
+#     narrative also lingered in the architecture / troubleshooting / molmoact2
+#     pages after the >=0.6.0 floor bump. These pin it out. ---
+
+_ARCHITECTURE = _REPO_ROOT / "docs" / "architecture.md"
+_TROUBLESHOOTING = _REPO_ROOT / "docs" / "troubleshooting.md"
+_MOLMOACT2 = _REPO_ROOT / "docs" / "policies" / "molmoact2.md"
+_INSTALLATION = _REPO_ROOT / "docs" / "getting-started" / "installation.md"
+
+
+def _lerobot_floor_from_pyproject() -> str:
+    """The exact version specifier the ``[lerobot]`` extra declares (e.g. ``>=0.6.0,<0.7.0``)."""
+    for spec in _extras()["lerobot"]:
+        if spec.startswith("lerobot["):  # lerobot[feetech,dataset]>=0.6.0,<0.7.0
+            return spec.split("]", 1)[1]
+    raise AssertionError("no lerobot extra spec found in pyproject")
+
+
+def test_architecture_lerobot_extra_row_matches_pyproject_floor() -> None:
+    text = _ARCHITECTURE.read_text()
+    # the dependency-matrix row must not advertise the dead pre-0.6 cap
+    assert "lerobot>=0.5.0,<0.6.0" not in text, "architecture.md still cites the dead <0.6.0 lerobot cap"
+    # it must reflect the real floor (>=0.6.0)
+    assert ">=0.6.0" in text, "architecture.md [lerobot] row should name the >=0.6.0 floor"
+
+
+def test_troubleshooting_version_skew_remedy_does_not_conflict_with_floor() -> None:
+    text = _TROUBLESHOOTING.read_text()
+    # remedying a version-skew ImportError by pinning ``<0.6`` directly conflicts
+    # with the pyproject floor (``lerobot[...]>=0.6.0``); the remedy must (re)install
+    # the extra instead of a manual sub-floor pin.
+    assert "lerobot>=0.5.0,<0.6" not in text, "troubleshooting remedy pins lerobot below the required >=0.6.0 floor"
+    assert "strands-robots[lerobot]" in text
+
+
+def test_troubleshooting_molmoact2_is_pypi_not_from_source() -> None:
+    text = _TROUBLESHOOTING.read_text()
+    # MolmoAct2Policy ships in lerobot >= 0.6 (PyPI); no from-source git+ remedy.
+    assert "git+https://github.com/huggingface/lerobot" not in text
+    assert "not in PyPI lerobot" not in text
+    # the remedy is the [molmoact2] extra
+    assert "strands-robots[molmoact2]" in text
+
+
+def _md_heading_slugs(text: str) -> set[str]:
+    """GitHub/mkdocs heading slugs: lowercase, spaces->'-', drop non-alnum/non-space/non-hyphen."""
+    slugs: set[str] = set()
+    for line in text.splitlines():
+        s = line.strip()
+        if not s.startswith("#"):
+            continue
+        title = s.lstrip("#").strip()
+        slug = "".join(c for c in title.lower() if c.isalnum() or c in " -").replace(" ", "-")
+        slugs.add(slug)
+    return slugs
+
+
+def test_troubleshooting_jetson_anchor_resolves_to_a_real_heading() -> None:
+    """The Jetson/pyav row links into installation.md; that anchor must exist (was broken)."""
+    text = _TROUBLESHOOTING.read_text()
+    # the stale, non-existent anchor is gone
+    assert "molmoact2-on-jetson-lerobot-from-source" not in text
+    # and the anchor it now links to resolves to a real installation.md heading
+    slugs = _md_heading_slugs(_INSTALLATION.read_text())
+    assert "molmoact2-on-jetson" in slugs, "installation.md lost the '### MolmoAct2 on Jetson' heading"
+    assert "getting-started/installation.md#molmoact2-on-jetson" in text
+
+
+def test_molmoact2_doc_install_line_is_not_from_source() -> None:
+    text = _MOLMOACT2.read_text()
+    assert "lerobot from source" not in text
+    assert "[molmoact2]" in text


### PR DESCRIPTION
## Problem

The `lerobot>=0.6.0` floor bump (`lerobot[feetech,dataset]>=0.6.0,<0.7.0` in `pyproject.toml`) and the follow-up VLA dependency-guidance pass corrected most of the install docs, but a few user-facing spots still carried the dead pre-0.6 "lerobot from source / pin `<0.6`" narrative. These now actively mislead:

- **`docs/architecture.md`** dependency matrix advertised the obsolete `lerobot>=0.5.0,<0.6.0` cap (the extra actually pins `>=0.6.0,<0.7.0`).
- **`docs/troubleshooting.md`** version-skew row told users to `uv pip install "lerobot>=0.5.0,<0.6"` -- a manual sub-floor pin that **conflicts** with the declared `>=0.6.0` floor and breaks resolution.
- **`docs/troubleshooting.md`** `MolmoAct2Policy` row said to install lerobot **from source** via `git+https://...`. `MolmoAct2Policy` ships in lerobot >= 0.6 on PyPI (verified: it imports from an installed `lerobot==0.6.1`), so the remedy is simply `strands-robots[molmoact2]`.
- **`docs/troubleshooting.md`** Jetson/pyav row linked to a **broken anchor** `#molmoact2-on-jetson-lerobot-from-source`; the actual heading in `installation.md` is `### MolmoAct2 on Jetson` (slug `#molmoact2-on-jetson`).
- **`docs/policies/molmoact2.md`** install line still said "lerobot from source + the `[molmoact2]` extra".

The canonical corrected wording already lives in `docs/getting-started/installation.md` (`lerobot>=0.6.0,<0.7.0`; "resolve straight from PyPI now that lerobot >= 0.6 ships `MolmoAct2Policy`"; `strands-robots[molmoact2]`) and `docs/policies/lerobot-local.md`; these three pages were simply missed.

## Change

Correct all of the above to the current PyPI floor and the `strands-robots[molmoact2]` / `strands-robots[lerobot]` extras. Surgical: 3 docs (1-6 lines each) + one test file. The legitimate `lerobot>=0.5.2` *feature-floor* mentions (multi-episode append) are left untouched -- `0.6.1 >= 0.5.2` still holds; only the wrong `<0.6.0` caps / from-source-MolmoAct2 advice / broken anchor are changed.

## Tests

Extends `tests/test_lerobot_dependency_docs.py` (the existing dependency-doc currency contract) with 5 negative-contract tests pinning these spots, including a genuine broken-link check that parses `installation.md` headings into slugs and asserts the Jetson anchor resolves. Fail-before / pass-after verified:

```
# with the doc fix reverted (test file kept):
5 failed, 5 passed
# with the fix applied:
10 passed
```

Gate: `ruff check` + `ruff format --check` + `mypy` clean; the broader doc-contract group (`test_lerobot_dependency_docs`, `test_lerobot_install_hints_pypi`, `test_changelog_format`, `test_docstrings_no_dangling_doc_refs`, `test_docs_home_navigation`) = 24 passed. Docs-only change; no runtime code touched.