### PR TITLE
test(mesh): cover built-in-mesh peer task_status listing + rpc-without-Device-Connect error

### DIFF
--- a/tests/mesh/test_robot_mesh_tool.py
+++ b/tests/mesh/test_robot_mesh_tool.py
@@ -609,3 +609,47 @@ def test_dc_emergency_stop_is_best_effort_across_unreachable_devices(fake_dc_con
     assert calls and calls[-1][0] == "emergency_stop"
     assert calls[-1][1] == "*"
     assert calls[-1][2] is True
+
+
+# --- built-in Zenoh mesh fallback: observability + no-Device-Connect contract
+# When Device Connect is absent, robot_mesh falls through to the built-in Zenoh
+# mesh. Two user-facing contracts on that path had no coverage: the peers
+# listing must surface a peer's in-flight task, and rpc must return an
+# actionable error (the Zenoh mesh has no device-native call) rather than crash.
+
+
+def test_peers_listing_surfaces_remote_task_status(fake_local_mesh):
+    """A discovered peer that reports a running task renders that task and its
+    instruction in the peers listing, so an agent can see what the fleet is
+    doing before issuing new commands."""
+    with patch(
+        "strands_robots.mesh.session.get_peers",
+        return_value=[
+            {
+                "peer_id": "remote-1",
+                "type": "robot",
+                "hostname": "host1",
+                "age": 3,
+                "task_status": "running",
+                "instruction": "pick up the red cube",
+            }
+        ],
+    ):
+        out = _strands_call(action="peers")
+
+    assert out["status"] == "success"
+    text = out["content"][0]["text"]
+    assert "task: running - pick up the red cube" in text
+
+
+def test_rpc_without_device_connect_returns_actionable_error(fake_local_mesh):
+    """rpc is a device-native function call with no Zenoh-mesh equivalent. With
+    a local mesh present but Device Connect unavailable, the tool returns an
+    actionable error dict (never raises) that names Device Connect as the
+    requirement instead of silently timing out."""
+    out = _strands_call(action="rpc", target="dev-1", function="nod")
+
+    assert out["status"] == "error"
+    text = out["content"][0]["text"]
+    assert "rpc" in text
+    assert "Device Connect" in text


### PR DESCRIPTION
## What
Adds two focused tests for `robot_mesh`'s built-in Zenoh-mesh fallback path (the path taken when Device Connect is not installed), pinning two user-facing contracts that had no coverage:

1. **Peer observability** - `action="peers"` renders a discovered peer's in-flight task and instruction (`task: <status> - <instruction>`) so an agent can see what the fleet is doing before issuing new commands. Existing peers tests only exercised peers without a `task_status`, leaving the task-rendering branch uncovered.
2. **rpc without Device Connect** - `action="rpc"` is a device-native function call with no Zenoh-mesh equivalent. With a local mesh present but Device Connect unavailable, the tool must return an actionable error dict that names Device Connect as the requirement, rather than crashing or silently timing out. This fallback branch was previously untested.

## Why
Both are agent-facing contracts on a public tool: the peers listing is the primary fleet-observability surface, and the rpc fallback is the difference between a clear "install Device Connect" message and a confusing timeout. Pinning them guards against regressions in the tool's error-return convention (tools return `{"status": "error", ...}`, never raise past dispatch) and its discovery/observability output.

## Tests
Test-only change. `tests/mesh/test_robot_mesh_tool.py`:
- `test_peers_listing_surfaces_remote_task_status`
- `test_rpc_without_device_connect_returns_actionable_error`

Both exercise previously-uncovered lines in `strands_robots/tools/robot_mesh.py` (the task_status render line and the rpc fallback error). Full mesh suite passes (42 passed in `tests/mesh/test_robot_mesh_tool.py`); repo lint/format/mypy clean.