### PR TITLE
test(loaders): pin fail-fast rejection of duplicate kinematic tree edges

### DIFF
--- a/tests/simulation/isaac/test_description_loader_geometry.py
+++ b/tests/simulation/isaac/test_description_loader_geometry.py
@@ -196,6 +196,33 @@ class TestMjcfRobotLoader:
         with pytest.raises(ValueError, match="root element must be <mujoco>"):
             load_mjcf(_write(tmp_path, "b.xml", "<foo/>"))
 
+    def test_two_dof_joint_on_one_body_is_rejected_as_duplicate_edge(self, tmp_path):
+        # A single <body> carrying two <joint> children (an idiomatic MJCF
+        # 2-DOF compound joint, e.g. a hip with a roll and a pitch axis)
+        # produces two joints that share the same (parent, child) body edge.
+        # A tree articulation requires each non-root link to have exactly one
+        # inbound joint, so the loader must reject this fail-fast at load time
+        # rather than let it surface as a cryptic articulation error two layers
+        # down. The 2-DOF axis must instead be split with an intermediate
+        # massless link body (the pattern _build_unitree_g1 uses).
+        mjcf = """<mujoco model="two_dof"><worldbody>
+          <body name="base"><geom type="sphere" size="0.1"/>
+            <body name="hip" pos="0 0 0.1">
+              <joint name="hip_roll" type="hinge" axis="1 0 0"/>
+              <joint name="hip_pitch" type="hinge" axis="0 1 0"/>
+              <geom type="box" size="0.03 0.03 0.03"/>
+            </body>
+          </body>
+        </worldbody></mujoco>"""
+        with pytest.raises(ValueError, match="duplicate parent->child body edges") as exc:
+            load_mjcf(_write(tmp_path, "two_dof.xml", mjcf))
+        # The message names both offending joints so the author can locate and
+        # split the compound joint from the traceback alone.
+        msg = str(exc.value)
+        assert "hip_roll" in msg
+        assert "hip_pitch" in msg
+        assert "intermediate" in msg
+
 
 class TestUrdfRobotLoader:
     """``load_urdf`` -> link/joint topology, shape extraction, fail-loud guards."""


### PR DESCRIPTION
## Problem
The description loaders (`load_mjcf`, `load_urdf`, `load_usd`) all run `_validate_kinematic_tree`, a fail-fast guard that rejects duplicate `(parent, child)` body edges. A tree articulation requires each non-root link to have exactly one inbound joint; two joints sharing an edge would otherwise surface two layers down as a cryptic articulation error at instantiation time.

The reject branch had **no test coverage**: every built-in procedural robot (`_build_so100`, `_build_panda`, `_build_unitree_g1`) and every loader fixture is a valid tree, so the guard never fired in the suite.

## Change
Add one focused behavior test that drives the guard through the public `load_mjcf` entry point. A single `<body>` carrying two `<joint>` children models an idiomatic MJCF 2-DOF compound joint (e.g. a hip with roll + pitch axes) authored without an intermediate link body. This produces two joints on the same `(parent, child)` edge and must be rejected at load time.

The test asserts the `ValueError` names **both** offending joints and points at the intermediate-link remedy, so the offender is obvious from the traceback alone. This is the exact failure mode `_build_unitree_g1` avoids by splitting compound axes with massless link bodies.

## Verification
- New test covers the previously-untested duplicate-edge branch in `simulation/isaac/procedural.py`.
- `tests/simulation/isaac/test_description_loader_geometry.py`: 32 passed.
- Green local gate: `ruff check` + `ruff format --check` clean; `mypy strands_robots tests tests_integ` -> no issues found in 797 source files.

Test-only change; no production code touched.