### PR TITLE
test(training): pin PPO preflight-validation contract for each numeric guard

### DIFF
--- a/tests/training/test_rl_ppo.py
+++ b/tests/training/test_rl_ppo.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import os
+from typing import Any
 
 import pytest
 
@@ -99,6 +100,37 @@ def test_validate_rejects_bad_specs() -> None:
     # rollout_steps must divide into num_mini_batches.
     problems = trainer.validate(RLTrainSpec(output_dir="/tmp/x", rollout_steps=10, num_mini_batches=3))
     assert any("divisible" in p for p in problems)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "expected"),
+    [
+        ({"output_dir": ""}, "output_dir is required"),
+        ({"total_timesteps": 0}, "total_timesteps must be > 0"),
+        ({"total_timesteps": -1}, "total_timesteps must be > 0"),
+        ({"rollout_steps": 0}, "rollout_steps must be > 0"),
+        ({"num_envs": 0}, "num_envs must be >= 1"),
+        ({"rollout_steps": 10, "num_mini_batches": 3}, "divisible"),
+        ({"num_mini_batches": 0}, "divisible"),
+    ],
+)
+def test_validate_flags_each_out_of_range_field(overrides: dict[str, Any], expected: str) -> None:
+    """Each numeric guard in the PPO preflight names the offending field.
+
+    ``validate`` is a pure, read-only preflight the ``train`` entry point runs
+    before touching torch or the env, so a misconfigured spec fails with an
+    actionable message instead of a deep stack trace inside ``setup``. One
+    otherwise-valid spec per case isolates a single bad field; a non-None
+    ``env_factory`` keeps the env-factory guard quiet so only the field under
+    test is exercised. Mirrors the FastSAC preflight contract test.
+    """
+    from strands_robots.training.rl import RLTrainSpec
+
+    trainer = create_trainer("ppo")
+    base: dict[str, Any] = {"output_dir": "/tmp/x", "env_factory": lambda: None}
+    base.update(overrides)
+    problems = trainer.validate(RLTrainSpec(**base))
+    assert any(expected in p for p in problems), problems
 
 
 def test_train_rejects_non_rl_spec() -> None:


### PR DESCRIPTION
## Problem
`PPO.validate()` is a pure, read-only preflight that `train()` runs before touching torch or the env, so a misconfigured `RLTrainSpec` fails with an actionable, field-named message instead of a deep stack trace inside `setup()`. Three of its guards were unexercised by the test suite: empty `output_dir`, non-positive `total_timesteps`, and non-positive `rollout_steps`. A future refactor could silently drop any of these and no test would notice.

The sibling FastSAC trainer already has a parametrized `test_validate_flags_each_out_of_range_field` covering exactly this contract; PPO had only an ad-hoc partial check, leaving the two sibling RL trainers inconsistently covered.

## Change
Add a parametrized `test_validate_flags_each_out_of_range_field` to `tests/training/test_rl_ppo.py`, mirroring the FastSAC test's shape. Each case isolates a single bad field (a non-None `env_factory` keeps the env-factory guard quiet) and asserts the preflight names the offending field:

- `output_dir=""` -> `output_dir is required`
- `total_timesteps=0` / `-1` -> `total_timesteps must be > 0`
- `rollout_steps=0` -> `rollout_steps must be > 0`
- `num_envs=0` -> `num_envs must be >= 1`
- `rollout_steps=10, num_mini_batches=3` and `num_mini_batches=0` -> divisibility guard

Tests-only; no production code changes.

## Coverage
`strands_robots/training/rl/ppo.py`: the `output_dir` / `total_timesteps` / `rollout_steps` guard lines were previously uncovered and are now exercised. Full suite: 10652 -> 10659 passed (+7 parametrized cases), 0 failures.

## Test
`MUJOCO_GL=egl python -m pytest tests/ -k "not Rendering"` -> 10659 passed, 193 skipped. `ruff check` / `ruff format --check` / `mypy` clean on the changed file.