### PR TITLE
fix(sim): get_ground_height accepts NumPy scalar coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1995,7 +1995,8 @@ is accepted but inert, mirroring the Newton backend.
 so the natural call `get_ground_height(*obs["base_pos"][:2])` on a float32 observation was
 rejected with a misleading "must be a finite number" error even though the value is a finite
 real number. The check now uses `numbers.Real`, accepting any real scalar (including NumPy
-scalar types) while still rejecting `bool` / `np.bool_` / non-finite values.
+scalar types) while still rejecting `bool` / `np.bool_` / non-finite values. The parameter
+type is `SupportsFloat` so a NumPy-scalar call type-checks as well as runs.
 
 
 ## [0.4.1] - 2026-07-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1987,6 +1987,17 @@ rejection holds on any host, with or without an Omniverse install); `difficulty`
 is accepted but inert, mirroring the Newton backend.
 
 
+### Fixed: `get_ground_height(x, y)` accepts NumPy scalar coordinates
+
+`get_ground_height` validated its coordinates with `isinstance(val, (int, float))`, which is
+`False` for `np.float32` / `np.int64` / `np.int32` (only `np.float64` subclasses Python
+`float`). Terrain coordinates naturally come from `mj_data` / an observation (a NumPy array),
+so the natural call `get_ground_height(*obs["base_pos"][:2])` on a float32 observation was
+rejected with a misleading "must be a finite number" error even though the value is a finite
+real number. The check now uses `numbers.Real`, accepting any real scalar (including NumPy
+scalar types) while still rejecting `bool` / `np.bool_` / non-finite values.
+
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -24,7 +24,7 @@ import numbers
 import os
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping, Sequence
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, SupportsFloat
 
 if TYPE_CHECKING:
     from strands_robots.policies import Policy
@@ -559,7 +559,7 @@ class SimEngine(ABC):
         """
         return 0.0
 
-    def get_ground_height(self, x: float, y: float) -> dict[str, Any]:
+    def get_ground_height(self, x: SupportsFloat, y: SupportsFloat) -> dict[str, Any]:
         """Query the terrain surface height (world z) beneath world ``(x, y)``.
 
         Public counterpart of the internal :meth:`_ground_height_at` hook: a
@@ -578,8 +578,10 @@ class SimEngine(ABC):
         heightfield, so a non-terrain world reports a flat surface.
 
         Args:
-            x: World x coordinate.
-            y: World y coordinate.
+            x: World x coordinate. Any object convertible to ``float``
+                (``SupportsFloat``), including NumPy scalars, that is a finite
+                real number.
+            y: World y coordinate. Same accepted types as ``x``.
 
         Returns:
             Agent-tool status dict. On success ``content`` carries a

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import logging
 import math
+import numbers
 import os
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping, Sequence
@@ -584,10 +585,13 @@ class SimEngine(ABC):
             Agent-tool status dict. On success ``content`` carries a
             ``{"json": {"x": ..., "y": ..., "height": ...}}`` block with the
             surface height in meters. Errors when ``x`` / ``y`` is not a finite
-            real number.
+            real number. Accepts any real scalar, including NumPy scalar
+            types (``np.float32`` / ``np.int64`` / ...), since terrain
+            coordinates naturally come from ``mj_data`` / an observation
+            (a NumPy array), not hand-typed Python floats.
         """
         for label, val in (("x", x), ("y", y)):
-            if isinstance(val, bool) or not isinstance(val, (int, float)) or not math.isfinite(float(val)):
+            if isinstance(val, bool) or not isinstance(val, numbers.Real) or not math.isfinite(float(val)):
                 return {
                     "status": "error",
                     "content": [{"text": f"get_ground_height: {label} must be a finite number, got {val!r}."}],

--- a/tests/simulation/mujoco/test_ground_height_query.py
+++ b/tests/simulation/mujoco/test_ground_height_query.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 
 import math
 
+import numpy as np
+
 from strands_robots.simulation.mujoco.simulation import MuJoCoSimEngine
 
 
@@ -87,5 +89,40 @@ def test_get_ground_height_is_discoverable() -> None:
         enum = sim.tool_spec["inputSchema"]["json"]["properties"]["action"]["enum"]
         assert "get_ground_height" in enum
         assert "get_ground_height" in sim.describe()["methods"]
+    finally:
+        sim.destroy()
+
+
+def test_get_ground_height_accepts_numpy_scalars() -> None:
+    """Terrain coordinates come from ``mj_data`` / an observation (NumPy arrays),
+    so a NumPy scalar must be accepted as a finite real number.
+
+    The validation previously used ``isinstance(val, (int, float))``, which is
+    False for ``np.float32`` / ``np.int64`` / ``np.int32`` (only ``np.float64``
+    subclasses Python ``float``). That spuriously rejected the natural call
+    ``get_ground_height(*obs["base_pos"][:2])`` on a float32 observation with a
+    misleading "must be a finite number" error, even though the value IS finite.
+    """
+    sim = MuJoCoSimEngine()
+    try:
+        sim.create_world(ground_plane=True, terrain="pyramid", difficulty=2.0)
+        expected = sim._ground_height_at(0.0, 0.0)
+        # A scalar sliced from a float32 array is the realistic case (an
+        # observation / mj_data coordinate), alongside the bare NumPy scalars.
+        xy32 = np.array([0.0, 0.0], dtype=np.float32)
+        for x, y in (
+            (np.float32(0.0), np.float32(0.0)),
+            (np.float64(0.0), np.float64(0.0)),
+            (np.int64(0), np.int64(0)),
+            (np.int32(0), np.int32(0)),
+            (xy32[0], xy32[1]),
+        ):
+            r = sim.get_ground_height(x, y)
+            assert r["status"] == "success", (type(x).__name__, r)
+            assert math.isclose(r["content"][1]["json"]["height"], expected, abs_tol=1e-9)
+        # NumPy booleans and non-finite NumPy scalars are still rejected.
+        assert sim.get_ground_height(np.bool_(True), 0.0)["status"] == "error"  # type: ignore[arg-type]
+        assert sim.get_ground_height(np.float32("nan"), 0.0)["status"] == "error"
+        assert sim.get_ground_height(np.float64("inf"), 0.0)["status"] == "error"
     finally:
         sim.destroy()

--- a/tests/simulation/mujoco/test_ground_height_query.py
+++ b/tests/simulation/mujoco/test_ground_height_query.py
@@ -121,7 +121,7 @@ def test_get_ground_height_accepts_numpy_scalars() -> None:
             assert r["status"] == "success", (type(x).__name__, r)
             assert math.isclose(r["content"][1]["json"]["height"], expected, abs_tol=1e-9)
         # NumPy booleans and non-finite NumPy scalars are still rejected.
-        assert sim.get_ground_height(np.bool_(True), 0.0)["status"] == "error"  # type: ignore[arg-type]
+        assert sim.get_ground_height(np.bool_(True), 0.0)["status"] == "error"
         assert sim.get_ground_height(np.float32("nan"), 0.0)["status"] == "error"
         assert sim.get_ground_height(np.float64("inf"), 0.0)["status"] == "error"
     finally:


### PR DESCRIPTION
## Problem

`SimEngine.get_ground_height(x, y)` -- the public terrain-surface query (added so a caller can place an object/camera/goal *on* a `create_world(terrain=...)` heightfield instead of buried in it) -- validated its coordinates with:

```python
if isinstance(val, bool) or not isinstance(val, (int, float)) or not math.isfinite(float(val)):
```

`isinstance(val, (int, float))` is `False` for `np.float32` / `np.int64` / `np.int32` -- only `np.float64` happens to subclass Python `float`. But terrain coordinates naturally come from `mj_data` / an observation, which are NumPy arrays (commonly `float32`). So the natural call

```python
get_ground_height(*obs["base_pos"][:2])   # base_pos is a float32 array
```

is rejected with a misleading `get_ground_height: x must be a finite number, got np.float32(...)` -- even though the value *is* a finite real number. A `np.float64` coordinate slips through only by the accident of subclassing `float`, so the accept/reject behaviour is inconsistent across NumPy dtypes.

## Change

Runtime: validate with `numbers.Real` instead of `(int, float)`. NumPy scalar types register as `numbers.Real`, so `np.float32` / `np.float64` / `np.int64` / `np.int32` are accepted; the explicit `bool` reject (kept first) still excludes Python `True`/`False`; and `np.bool_` (not a `Real`) plus non-finite values (`math.isfinite`) remain rejected.

Static type: the `x` / `y` parameters are annotated `SupportsFloat` rather than `float`, so a NumPy-scalar coordinate type-checks as well as runs -- the static contract now matches the documented, runtime one. (Previously the parameter type still said `float`, so the very calls this fix enables failed `mypy` with an `arg-type` error, which is not a contract you want to leave documented as broken.) The docstring states the accepted types.

## Tests

`test_get_ground_height_accepts_numpy_scalars` in `tests/simulation/mujoco/test_ground_height_query.py`: bare `np.float32`/`np.float64`/`np.int64`/`np.int32` and a scalar sliced from a `float32` array (the realistic observation case) all return `success` with the correct height (matching the internal `_ground_height_at` sampler); `np.bool_` and NumPy `nan`/`inf` are still rejected. It fails before the fix (float32 rejected at runtime) and passes after; the full file is green (6 tests). `ruff` + `mypy strands_robots tests tests_integ` clean.

## Note

The same `isinstance(val, (int, float))` idiom appears in a few sibling numeric-input validators (`add_camera(fov=)`, `control_frequency`, `replay(speed=)`), which reject NumPy scalars identically. This change is deliberately scoped to the terrain coordinate query -- whose docstring most directly invites NumPy sim coordinates -- leaving the siblings as a straightforward follow-up.