### PR TITLE
fix(sim): add_camera(fov=...) accepts NumPy scalar angles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1998,6 +1998,10 @@ real number. The check now uses `numbers.Real`, accepting any real scalar (inclu
 scalar types) while still rejecting `bool` / `np.bool_` / non-finite values. The parameter
 type is `SupportsFloat` so a NumPy-scalar call type-checks as well as runs.
 
+### Fixed: `add_camera(fov=...)` accepts NumPy scalar angles
+
+`add_camera` rejected a NumPy scalar field-of-view (`np.float32(58.0)`, `np.int64(58)`) with a misleading "'fov' must be a finite number in degrees" error, even though the value is a finite real number, because the guard used `isinstance(fov, (int, float))` (`False` for every NumPy scalar except `np.float64`). A fov computed from a config array or `np.degrees(...)` was therefore refused. The check now uses `numbers.Real`, accepting any real scalar (including NumPy types) while still rejecting `bool` / `np.bool_`, non-finite values, and angles outside the open interval `(0, 180)` -- matching the `get_ground_height` coordinate contract.
+
 
 ## [0.4.1] - 2026-07-01
 

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -45,6 +45,7 @@ import inspect
 import json
 import logging
 import math
+import numbers
 import os
 import re
 import threading
@@ -2528,7 +2529,10 @@ class MuJoCoSimEngine(
         # cryptic "spec recompile refused", or - for fov <= 0 - silently
         # registers a degenerate camera that renders nothing useful. Reject it
         # here with an actionable message, mirroring the position/target checks.
-        if not isinstance(fov, (int, float)) or isinstance(fov, bool) or not math.isfinite(fov):
+        # Accept any real number (``numbers.Real``) so a NumPy scalar fov
+        # (e.g. ``np.float32(58.0)`` from a config array) is not rejected as
+        # "not a finite number"; only ``bool`` and non-finite values are refused.
+        if isinstance(fov, bool) or not isinstance(fov, numbers.Real) or not math.isfinite(float(fov)):
             return {
                 "status": "error",
                 "content": [{"text": f"add_camera: 'fov' must be a finite number in degrees, got {fov!r}."}],

--- a/tests/simulation/mujoco/test_input_validation.py
+++ b/tests/simulation/mujoco/test_input_validation.py
@@ -7,6 +7,8 @@ aborts that were caught by autonomous local testing on PR #85.
 import pytest
 
 pytest.importorskip("mujoco")
+import numpy as np  # noqa: E402
+
 from strands_robots.simulation.mujoco.backend import _can_render  # noqa: E402
 
 requires_gl = pytest.mark.skipif(
@@ -673,6 +675,32 @@ class TestAddCameraParamValidation:
         res = sim_with_world.add_camera(name="c", position=[0.5, 0, 0.3], target=[0.2, 0, 0.05], fov=True)
         assert res["status"] == "error"
         assert "finite number" in res["content"][0]["text"]
+
+    def test_fov_numpy_float32_accepted(self, sim_with_world):
+        # A NumPy scalar fov (e.g. np.float32 from a config array) is a finite
+        # real number; it must be accepted, not rejected as "not a finite number".
+        res = sim_with_world.add_camera(name="npf", position=[0.5, 0, 0.3], target=[0.2, 0, 0.05], fov=np.float32(58.0))
+        assert res["status"] == "success", res["content"][0]["text"]
+        assert "npf" in sim_with_world._world.cameras
+
+    def test_fov_numpy_int64_accepted(self, sim_with_world):
+        res = sim_with_world.add_camera(name="npi", position=[0.5, 0, 0.3], target=[0.2, 0, 0.05], fov=np.int64(58))
+        assert res["status"] == "success", res["content"][0]["text"]
+        assert "npi" in sim_with_world._world.cameras
+
+    def test_fov_numpy_bool_still_rejected(self, sim_with_world):
+        # np.bool_ is not numbers.Real; treat it like Python bool - a caller bug.
+        res = sim_with_world.add_camera(name="npb", position=[0.5, 0, 0.3], target=[0.2, 0, 0.05], fov=np.bool_(True))
+        assert res["status"] == "error"
+        assert "finite number" in res["content"][0]["text"]
+        assert "npb" not in sim_with_world._world.cameras
+
+    def test_fov_numpy_nan_still_rejected(self, sim_with_world):
+        res = sim_with_world.add_camera(
+            name="npn", position=[0.5, 0, 0.3], target=[0.2, 0, 0.05], fov=np.float32("nan")
+        )
+        assert res["status"] == "error"
+        assert "finite" in res["content"][0]["text"]
 
     def test_width_zero_errors(self, sim_with_world):
         res = sim_with_world.add_camera(name="c", position=[0.5, 0, 0.3], target=[0.2, 0, 0.05], width=0)


### PR DESCRIPTION
## Problem

`add_camera` rejected a NumPy scalar field-of-view with a misleading error even though the value is a finite real number:

```python
sim.add_camera(name="cam", position=[0.5, 0, 0.3], target=[0.2, 0, 0.05], fov=np.float32(58.0))
# -> {"status": "error", ... "add_camera: 'fov' must be a finite number in degrees, got np.float32(58.0)."}
```

The guard used `isinstance(fov, (int, float))`, which is `False` for every NumPy scalar except `np.float64` (only it subclasses Python `float`). So a fov computed from a config array or `np.degrees(...)` (`np.float32` / `np.int64`) was refused, while a plain Python `58.0` or `np.float64(58.0)` passed — an inconsistent, confusing paper-cut.

This is the same numeric-type gap that `get_ground_height(x, y)` had before it moved to `numbers.Real`; camera fov is another user-facing numeric input that naturally arrives as a NumPy scalar.

## Fix

Widen the check to `numbers.Real`, mirroring the `get_ground_height` coordinate contract:

```python
if isinstance(fov, bool) or not isinstance(fov, numbers.Real) or not math.isfinite(float(fov)):
```

This is a strict, safe widening:

| input | before | after |
|---|---|---|
| `np.float32(58.0)`, `np.int64(58)` | **rejected** | accepted |
| Python `58.0`, `np.float64(58.0)` | accepted | accepted |
| Python `True` / `np.bool_(True)` | rejected | rejected |
| `nan` / `inf` (any type) | rejected | rejected |
| fov outside `(0, 180)` | rejected | rejected |

No previously-accepted value changes behavior and no new value is rejected — the only difference is that NumPy real scalars are now accepted. `np.bool_` is not `numbers.Real`, so it stays refused like Python `bool` (a fov of `True` == 1° is almost certainly a caller bug).

## Tests

Extended `TestAddCameraParamValidation` in `tests/simulation/mujoco/test_input_validation.py`:

- `test_fov_numpy_float32_accepted` / `test_fov_numpy_int64_accepted` — **fail before** this change (rejected with the "must be a finite number" message), pass after.
- `test_fov_numpy_bool_still_rejected` / `test_fov_numpy_nan_still_rejected` — no-regression guards (pass both before and after), confirming `np.bool_` and non-finite NumPy scalars stay refused.

Local gate (`MUJOCO_GL=egl`): full `test_input_validation.py` = 93 passed; `ruff check` + `ruff format` clean; `mypy strands_robots/simulation/mujoco/simulation.py` = no issues.