### PR TITLE
fix(sim): set_gravity accepts a NumPy real scalar z-component

### DIFF
--- a/docs/simulation/overview.md
+++ b/docs/simulation/overview.md
@@ -93,7 +93,7 @@ Newton backend, so a rollout rig can be enumerated instead of guessed.
 | Action | Key params |
 |--------|-----------|
 | `step` | `n_steps=1` (max 100 000/call) |
-| `set_gravity` | `gravity=[x,y,z]` |
+| `set_gravity` | `gravity=[x,y,z]` or a scalar z-component |
 | `set_timestep` | `timestep` |
 | `get_contacts` / `get_contact_forces` | - |
 | `apply_force` | `body_name`, `force`, `torque`, `point` |

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -45,6 +45,7 @@ import inspect
 import json
 import logging
 import math
+import numbers
 import os
 import re
 import threading
@@ -52,7 +53,7 @@ import time
 from collections.abc import AsyncGenerator, Callable, Sequence
 from concurrent.futures import Future, ThreadPoolExecutor
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from strands.tools.tools import AgentTool
 from strands.types._events import ToolResultEvent
@@ -2822,37 +2823,61 @@ class MuJoCoSimEngine(
             tls.model = None
 
     def set_gravity(self, gravity: list[float] | float | int) -> dict[str, Any]:
+        """Set the world gravity vector.
+
+        Accepts either a 3-element ``[x, y, z]`` list or a bare real scalar,
+        which is interpreted as the z-component (``[0, 0, z]``). The scalar
+        may be any :class:`numbers.Real` -- a Python ``int`` / ``float`` or a
+        NumPy scalar such as ``np.float32`` / ``np.int64`` (e.g. a value read
+        from a config array or produced by ``np.degrees(...)``). A NumPy
+        array is treated as the vector form, not a scalar.
+
+        Args:
+            gravity: Gravity as ``[x, y, z]`` (m/s^2) or a real scalar z-component.
+
+        Returns:
+            Agent-tool ``status`` / ``content`` dict. Errors (structured, never
+            raised) on a missing world, a running policy, a non-3-element or
+            non-numeric vector, or non-finite components.
+        """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         # set_gravity during a running policy races the worker thread
         if err := self._require_no_running_policy("set_gravity"):
             return err
-        # validate length/dtype before numpy broadcast
-        if isinstance(gravity, (int, float)):
-            gravity = [0.0, 0.0, float(gravity)]
-        try:
-            if len(gravity) != 3:
+        # Accept any real scalar (numbers.Real) as a z-only gravity so a value
+        # computed as a NumPy scalar (np.float32 / np.int64 / np.degrees(...)) is
+        # treated like a plain float, not refused with a misleading "has no len()".
+        # A NumPy array is not numbers.Real, so it still takes the vector path.
+        if isinstance(gravity, numbers.Real):
+            components = [0.0, 0.0, float(gravity)]
+        else:
+            # Any other value must be a 3-element sized vector (list / tuple /
+            # NumPy array). Validate length/dtype before the numpy broadcast.
+            try:
+                vector = cast("Sequence[float]", gravity)
+                if len(vector) != 3:
+                    return {
+                        "status": "error",
+                        "content": [
+                            {"text": f"set_gravity: 'gravity' must be a 3-element list [x,y,z], got {len(vector)}"}
+                        ],
+                    }
+                components = [float(g) for g in vector]
+            except (TypeError, ValueError) as e:
                 return {
                     "status": "error",
-                    "content": [
-                        {"text": f"set_gravity: 'gravity' must be a 3-element list [x,y,z], got {len(gravity)}"}
-                    ],
+                    "content": [{"text": f"set_gravity: 'gravity' must be a 3-element list of numbers ({e})"}],
                 }
-            gravity = [float(g) for g in gravity]
-        except (TypeError, ValueError) as e:
+        if not all(math.isfinite(g) for g in components):
             return {
                 "status": "error",
-                "content": [{"text": f"set_gravity: 'gravity' must be a 3-element list of numbers ({e})"}],
-            }
-        if not all(math.isfinite(g) for g in gravity):
-            return {
-                "status": "error",
-                "content": [{"text": f"set_gravity: all components must be finite, got {gravity}"}],
+                "content": [{"text": f"set_gravity: all components must be finite, got {components}"}],
             }
         with self._lock:
-            self._world._model.opt.gravity[:] = gravity
-            self._world.gravity = gravity
-        return {"status": "success", "content": [{"text": f"Gravity: {gravity}"}]}
+            self._world._model.opt.gravity[:] = components
+            self._world.gravity = components
+        return {"status": "success", "content": [{"text": f"Gravity: {components}"}]}
 
     def set_timestep(self, timestep: float) -> dict[str, Any]:
         if self._world is None or self._world._model is None or self._world._data is None:

--- a/tests/simulation/mujoco/test_setter_input_type_validation.py
+++ b/tests/simulation/mujoco/test_setter_input_type_validation.py
@@ -54,3 +54,50 @@ class TestSetterInputTypeValidation:
         res = sim_with_world.add_camera(name="cam", position=5)
         assert res["status"] == "error"
         assert "list of 3 numbers" in res["content"][0]["text"]
+
+
+class TestSetGravityNumpyScalar:
+    """A scalar z-only gravity may arrive as a NumPy real scalar.
+
+    ``set_gravity`` accepts a bare number as z-only gravity. A value produced by
+    NumPy math (``np.float32``, ``np.int64``, ``np.degrees(...)`` etc.) is a real
+    scalar but is not an instance of Python ``int`` / ``float`` (only
+    ``np.float64`` subclasses ``float``), so the old ``(int, float)`` guard
+    skipped the scalar branch and the value fell through to ``len(gravity)`` --
+    raising ``TypeError`` internally and surfacing a misleading
+    "must be a 3-element list of numbers (... has no len())" error. These pin
+    that any ``numbers.Real`` scalar is treated like a plain float.
+    """
+
+    def test_numpy_float32_scalar_accepted(self, sim_with_world):
+        import numpy as np
+
+        res = sim_with_world.set_gravity(np.float32(-9.81))
+        assert res["status"] == "success"
+        gravity = sim_with_world._world._model.opt.gravity
+        assert list(gravity[:2]) == [0.0, 0.0]
+        assert gravity[2] == pytest.approx(-9.81, abs=1e-4)
+
+    def test_numpy_int64_scalar_accepted(self, sim_with_world):
+        import numpy as np
+
+        res = sim_with_world.set_gravity(np.int64(-3))
+        assert res["status"] == "success"
+        assert list(sim_with_world._world._model.opt.gravity) == [0.0, 0.0, -3.0]
+
+    def test_numpy_array_still_takes_vector_path(self, sim_with_world):
+        """A 3-element NumPy array is not a scalar and must set x/y/z directly."""
+        import numpy as np
+
+        res = sim_with_world.set_gravity(np.array([0.0, 0.0, -3.7]))
+        assert res["status"] == "success"
+        assert list(sim_with_world._world._model.opt.gravity) == [0.0, 0.0, -3.7]
+
+    def test_numpy_bool_scalar_still_rejected(self, sim_with_world):
+        """``np.bool_`` is not ``numbers.Real`` and has no ``len()`` -- it stays
+        refused with a structured error rather than becoming a 1.0 z-gravity."""
+        import numpy as np
+
+        res = sim_with_world.set_gravity(np.bool_(True))
+        assert res["status"] == "error"
+        assert "numbers" in res["content"][0]["text"]


### PR DESCRIPTION
## Problem

`set_gravity` accepts a bare number as a z-only gravity (`[0, 0, z]`). The scalar branch guarded on `isinstance(gravity, (int, float))`, which is `False` for every NumPy scalar except `np.float64` (only it subclasses Python `float`). So a z-gravity computed as a NumPy scalar was refused with a misleading error, while a plain `float` or `np.float64` passed:

```python
sim.set_gravity(-9.81)              # ok
sim.set_gravity(np.float64(-9.81))  # ok  (np.float64 IS a Python float)
sim.set_gravity(np.float32(-1.62))  # -> {"status": "error", ...
#   "set_gravity: 'gravity' must be a 3-element list of numbers
#    (object of type 'numpy.float32' has no len())"}
```

The `np.float32` value skipped the scalar branch, fell through to `len(gravity)`, raised `TypeError` internally, and surfaced a confusing "has no len()" message. A z-gravity read from a config array or produced by `np.degrees(...)` naturally arrives as `np.float32` / `np.int64`, so this is an inconsistent numeric-type paper-cut. It mirrors the `get_ground_height(x, y)` coordinate gap that was already moved to `numbers.Real`.

## Fix

Widen the scalar check to `numbers.Real`:

```python
if isinstance(gravity, numbers.Real):
    components = [0.0, 0.0, float(gravity)]
else:
    # 3-element sized vector (list / tuple / NumPy array)
    ...
```

Strict, safe widening -- no previously-accepted value changes behavior and no new value is rejected; the only difference is that NumPy real scalars are now accepted:

| input | before | after |
|---|---|---|
| `np.float32(-1.62)`, `np.int64(-3)` | **rejected** | accepted |
| `-9.81`, `np.float64(-9.81)` | accepted | accepted |
| Python `True` | accepted (z=1.0) | accepted (z=1.0) |
| `np.bool_(True)` | rejected | rejected |
| 3-element list / NumPy array | accepted | accepted |

`np.bool_` is not `numbers.Real`, so it stays on the vector path and is refused as before; a NumPy array is likewise not a `Real`, so it still takes the vector path. The vector branch is factored into an explicit `else` with a `cast("Sequence[float]", ...)` so the length/dtype validation stays type-clean. `set_gravity` also gains a docstring documenting the scalar/vector contract.

## Rollout (headless MuJoCo, EGL)

Gravity set via `sim.set_gravity(np.float32(-1.62))` (moon g) drives the dynamics -- a free box falls onto the ground plane:

![gravity set via np.float32 scalar](https://github.com/cagataycali/robots/releases/download/sim-gravity-numpy-scalar-artifacts/gravity_numpy_scalar.gif)

## Tests

Added `TestSetGravityNumpyScalar` in `tests/simulation/mujoco/test_setter_input_type_validation.py`:

- `test_numpy_float32_scalar_accepted` / `test_numpy_int64_scalar_accepted` -- **fail before** this change (rejected with the "has no len()" message), pass after; assert the model's `opt.gravity` is actually applied.
- `test_numpy_array_still_takes_vector_path` / `test_numpy_bool_scalar_still_rejected` -- no-regression guards (pass both before and after).

Local gate (`MUJOCO_GL=egl`): `TestSetGravityNumpyScalar` = 2 failed pre-fix / 8 passed post-fix; the MuJoCo simulation suites (`test_simulation`, `test_setter_input_type_validation`, `test_error_paths`, `test_agenttool_contract`, `test_input_validation`, `test_no_world_guard_contract`) = 460 passed; `ruff check` + `ruff format --check` clean; `mypy strands_robots/simulation/mujoco/simulation.py` = no issues.

Docs: `docs/simulation/overview.md` Physics table note updated to reflect the scalar z-component form.