### PR TITLE
fix(sim): action router accepts NumPy scalar components in vector params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: sim action router accepts NumPy scalar components in vector parameters
+
+The MuJoCo agent-tool dispatch router (`sim(action=..., **kwargs)` ->
+`_validate_and_build_kwargs`) length- and dtype-checks every vector parameter
+(`position`, `force`, `torque`, `gravity`, `direction`, `point`, `orientation`,
+`color`) before the value reaches NumPy / MuJoCo. The per-component guard used
+`isinstance(component, (int, float))`, which is `False` for every NumPy scalar
+except `np.float64` (only it subclasses Python `float`). Vector params routinely
+originate from an observation or `mj_data` -- a NumPy array whose elements are
+`np.float32` / `np.int64` -- so a natural
+`sim(action="add_object", position=[obs[0], obs[1], obs[2]])` on a float32
+observation was rejected with `Parameter 'position'[0] must be numeric, got
+float32.` even though every component is a finite real number.
+
+The guard now uses `numbers.Real`, so NumPy scalar components pass while Python
+`bool`, `np.bool_` (neither is a `numbers.Real` once `bool` is excluded), and
+non-numeric junk stay rejected with the same structured error. This mirrors the
+`numbers.Real` coercion contract already applied to `get_ground_height`,
+`set_gravity`, and `add_camera(fov=...)`.
+
 ### Added: `DatasetRecorder.create(overwrite=...)` for honest re-recording into an existing `repo_id`
 
 `DatasetRecorder.create()` calls `LeRobotDataset.create()`, which `mkdir`s its

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -45,6 +45,7 @@ import inspect
 import json
 import logging
 import math
+import numbers
 import os
 import re
 import threading
@@ -3919,7 +3920,14 @@ class MuJoCoSimEngine(
                     ],
                 }
             for i, component in enumerate(val):
-                if not isinstance(component, (int, float)) or isinstance(component, bool):
+                # Accept any real scalar, including NumPy types (np.float32 /
+                # np.int64 / ...): vector params like position / gravity / point
+                # naturally arrive from an observation or mj_data (a NumPy
+                # array), so `[float(x) for x in obs[...]]` is not required of
+                # the caller. isinstance(_, (int, float)) rejected those (only
+                # np.float64 subclasses float). numbers.Real still rejects
+                # bool / np.bool_ (np.bool_ is not a Real) and non-numeric junk.
+                if not isinstance(component, numbers.Real) or isinstance(component, bool):
                     return None, {
                         "status": "error",
                         "content": [

--- a/tests/simulation/mujoco/test_input_validation.py
+++ b/tests/simulation/mujoco/test_input_validation.py
@@ -837,3 +837,79 @@ class TestGetSensorDataContract:
         res = sim_with_sensors.get_sensor_data(sensor_name="nope")
         assert res["status"] == "error", res
         assert "Sensor 'nope' not found." in res["content"][0]["text"]
+
+
+class TestRouterVectorNumpyScalars:
+    """Router-level vector params accept NumPy scalar components.
+
+    The agent-tool dispatch router (``sim(action=..., **kwargs)`` ->
+    ``_validate_and_build_kwargs``) length- and dtype-checks every vector
+    parameter (position, force, torque, gravity, direction, point,
+    orientation, color) before the value reaches NumPy / MuJoCo. It used
+    ``isinstance(component, (int, float))``, which is ``False`` for NumPy
+    scalars (only ``np.float64`` subclasses ``float``). Vector params
+    routinely arrive from an observation or ``mj_data`` -- a NumPy array whose
+    elements are ``np.float32`` / ``np.int64`` -- so a natural
+    ``position=[obs[0], obs[1], obs[2]]`` was rejected as "must be numeric,
+    got float32" even though every component is a finite real number. The
+    guard now uses ``numbers.Real`` so NumPy scalars pass while ``bool`` /
+    ``np.bool_`` / non-numeric junk stay rejected.
+    """
+
+    @pytest.fixture
+    def sim_with_world(self):
+        sim = Simulation()
+        sim.create_world()
+        yield sim
+        sim.destroy()
+
+    def test_numpy_scalar_position_accepted(self, sim_with_world):
+        """A position built from NumPy scalars (as from an observation) is
+        accepted by the router instead of erroring on dtype."""
+        np = pytest.importorskip("numpy")
+        res = sim_with_world(
+            action="add_object",
+            shape="box",
+            size=[0.02, 0.02, 0.02],
+            position=[np.float32(0.3), np.int64(0), np.float64(0.5)],
+            name="np_cube",
+        )
+        assert res["status"] == "success", res
+
+    def test_python_bool_component_still_rejected(self, sim_with_world):
+        """``bool`` is an ``int`` subclass but is not a valid coordinate; it
+        must stay rejected even though the guard now accepts ``numbers.Real``."""
+        res = sim_with_world(
+            action="add_object",
+            shape="box",
+            size=[0.02, 0.02, 0.02],
+            position=[True, 0.0, 0.5],
+            name="bool_cube",
+        )
+        assert res["status"] == "error", res
+        assert "must be numeric" in res["content"][0]["text"]
+
+    def test_numpy_bool_component_still_rejected(self, sim_with_world):
+        """``np.bool_`` is not a ``numbers.Real`` and stays rejected."""
+        np = pytest.importorskip("numpy")
+        res = sim_with_world(
+            action="add_object",
+            shape="box",
+            size=[0.02, 0.02, 0.02],
+            position=[np.bool_(True), 0.0, 0.5],
+            name="npbool_cube",
+        )
+        assert res["status"] == "error", res
+        assert "must be numeric" in res["content"][0]["text"]
+
+    def test_non_numeric_component_still_rejected(self, sim_with_world):
+        """Non-numeric junk still returns the structured dtype error."""
+        res = sim_with_world(
+            action="add_object",
+            shape="box",
+            size=[0.02, 0.02, 0.02],
+            position=["a", "b", "c"],
+            name="str_cube",
+        )
+        assert res["status"] == "error", res
+        assert "must be numeric" in res["content"][0]["text"]


### PR DESCRIPTION
## Problem

The MuJoCo agent-tool dispatch router (`sim(action=..., **kwargs)` -> `_validate_and_build_kwargs`) length- and dtype-checks every vector parameter (`position`, `force`, `torque`, `gravity`, `direction`, `point`, `orientation`, `color`) before the value reaches NumPy / MuJoCo. The per-component guard used `isinstance(component, (int, float))`, which is `False` for every NumPy scalar except `np.float64` (only it subclasses Python `float`).

Vector params routinely originate from an observation or `mj_data` -- a NumPy array whose elements are `np.float32` / `np.int64`. So the natural call on a float32 observation:

```python
sim(action="add_object", position=[obs[0], obs[1], obs[2]])
```

was rejected with `Parameter 'position'[0] must be numeric, got float32.` even though every component is a finite real number. The caller was forced to defensively `float()`-cast every component.

## Change

The per-component guard now uses `numbers.Real`, so NumPy scalar components pass while Python `bool`, `np.bool_` (neither is a `numbers.Real` once `bool` is excluded), and non-numeric junk stay rejected with the same structured error. One-line semantic fix at the single validation site that covers all eight vector params.

This mirrors the `numbers.Real` coercion contract already applied to `get_ground_height`, `set_gravity`, and `add_camera(fov=...)`.

## Tests

`TestRouterVectorNumpyScalars` in `tests/simulation/mujoco/test_input_validation.py` drives the fix through the router path (`sim(action="add_object", ...)`):

- a `float32`/`int64`/`float64` position is accepted (fails pre-fix with `must be numeric, got float32`);
- Python `bool`, `np.bool_`, and string components stay rejected with the structured `must be numeric` error.

Verified pre-fix (numpy-scalar case fails) and post-fix (all pass). Full `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` clean; the sim input-validation / dispatch suites (117 tests) pass under `MUJOCO_GL=egl`.

## Visual artifact

Headless MuJoCo render (`MUJOCO_GL=egl`) of `add_object` placed at a `float32` observation position `[0.2, 0.0, 0.05]` with a NumPy-scalar RGBA color -- the exact call that was rejected pre-fix now renders the cube in-scene:

![add_object at a float32 observation position](https://github.com/cagataycali/robots/releases/download/sim-router-numpy-scalar-artifacts/sim_router_numpy_scalar_position.png)