### PR TITLE
fix(sim): control_frequency rejects non-finite values and accepts NumPy scalars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2023,6 +2023,24 @@ type is `SupportsFloat` so a NumPy-scalar call type-checks as well as runs.
 `add_camera` rejected a NumPy scalar field-of-view (`np.float32(58.0)`, `np.int64(58)`) with a misleading "'fov' must be a finite number in degrees" error, even though the value is a finite real number, because the guard used `isinstance(fov, (int, float))` (`False` for every NumPy scalar except `np.float64`). A fov computed from a config array or `np.degrees(...)` was therefore refused. The check now uses `numbers.Real`, accepting any real scalar (including NumPy types) while still rejecting `bool` / `np.bool_`, non-finite values, and angles outside the open interval `(0, 180)` -- matching the `get_ground_height` coordinate contract.
 
 
+### Fixed: `control_frequency` rejects non-finite values and accepts NumPy scalars
+
+`run_policy` / `start_policy` / `eval_policy` / `evaluate_benchmark` share
+`_validate_positive_frequency`, which guards `control_frequency` before it is used
+as a divisor (`1 / control_frequency` action period, `n_steps / control_frequency`
+duration). The guard used `isinstance(control_frequency, (int, float))` with
+`control_frequency > 0`, which (a) let a non-finite frequency through -- `nan <= 0`
+and `inf <= 0` are both `False`, so `nan` / `inf` slipped the check and reached
+`int(duration * control_frequency)` in the runner, surfacing the bare
+`ValueError("cannot convert float NaN to integer")` this guard exists to replace
+instead of a structured error naming the parameter, and (b) refused a NumPy-scalar
+frequency (`np.float32(50.0)` / `np.int64(30)` read from a config array) as
+non-numeric even though it is a finite real. The guard now uses `numbers.Real` +
+`math.isfinite`, so non-finite frequencies are rejected up front with the
+structured `control_frequency must be > 0` error and NumPy scalars are accepted --
+matching the `get_ground_height`, `set_gravity`, and `add_camera(fov=...)`
+coordinate/scalar contract.
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -889,7 +889,14 @@ class SimEngine(ABC):
         raises a bare ``ValueError``/``TypeError``/``ZeroDivisionError`` rather
         than the structured tool-error dict the public API contracts. ``bool`` is
         rejected explicitly: it is an ``int`` subclass, so ``True`` would slip
-        through the numeric check and act as a silent 1 Hz. Returns a structured
+        through the numeric check and act as a silent 1 Hz. A non-finite value
+        (``nan`` / ``inf``) is rejected too: it passes ``<= 0`` (both ``nan <= 0``
+        and ``inf <= 0`` are ``False``), so it would otherwise slip through and
+        reach ``int(duration * control_frequency)`` in the runner as the very
+        bare ``ValueError`` ("cannot convert float NaN to integer") this guard
+        exists to replace. Any real scalar is accepted, including a NumPy scalar
+        (``np.float32`` / ``np.int64``, e.g. a frequency read from a config
+        array), rather than being refused as non-numeric. Returns a structured
         error dict to surface, or ``None`` when valid.
 
         Args:
@@ -901,7 +908,8 @@ class SimEngine(ABC):
         """
         if (
             isinstance(control_frequency, bool)
-            or not isinstance(control_frequency, (int, float))
+            or not isinstance(control_frequency, numbers.Real)
+            or not math.isfinite(float(control_frequency))
             or control_frequency <= 0
         ):
             return {

--- a/tests/simulation/test_run_policy_horizon_validation.py
+++ b/tests/simulation/test_run_policy_horizon_validation.py
@@ -16,9 +16,11 @@ alias is asserted to behave identically to ``n_steps`` (it is normalized to
 
 from __future__ import annotations
 
+import numpy as np
 import pytest
 
 from strands_robots.simulation import create_simulation
+from strands_robots.simulation.base import SimEngine
 
 
 @pytest.fixture
@@ -298,4 +300,49 @@ class TestEvalPolicyCountGuards:
         result = sim.eval_policy(
             robot_name="arm1", policy_provider="mock", n_episodes=1, max_steps=2, control_frequency=50.0
         )
+        assert result["status"] == "success", result
+
+
+class TestControlFrequencyFiniteAndNumpyScalar:
+    """control_frequency must be a FINITE real; a NumPy scalar is a valid real.
+
+    ``_validate_positive_frequency`` is the single chokepoint run_policy /
+    start_policy / eval_policy / evaluate_benchmark share. Per its docstring it
+    exists so a bad frequency is refused with a structured error naming the
+    parameter *before* it reaches ``int(duration * control_frequency)`` in the
+    runner. A non-finite frequency (``nan`` / ``inf``) defeated that: ``nan <= 0``
+    and ``inf <= 0`` are both ``False``, so it slipped the guard and surfaced as
+    the bare ``ValueError('cannot convert float NaN to integer')`` the guard was
+    meant to replace. A NumPy-scalar frequency (``np.float32(50.0)`` read from a
+    config array) was conversely refused as "not a number" though it is a
+    perfectly good real. Both are now handled via ``numbers.Real`` +
+    ``math.isfinite``.
+    """
+
+    @pytest.mark.parametrize("bad_freq", [float("nan"), float("inf"), float("-inf")])
+    def test_guard_rejects_non_finite(self, bad_freq):
+        err = SimEngine._validate_positive_frequency(bad_freq, "run_policy")
+        assert err is not None, f"{bad_freq!r} must be rejected"
+        assert "control_frequency must be > 0" in err["content"][0]["text"]
+
+    @pytest.mark.parametrize("good_freq", [np.float32(50.0), np.int64(30), np.float64(25.0)])
+    def test_guard_accepts_numpy_real_scalar(self, good_freq):
+        assert SimEngine._validate_positive_frequency(good_freq, "run_policy") is None
+
+    @pytest.mark.parametrize("bad_freq", [float("nan"), float("inf")])
+    def test_run_policy_rejects_non_finite_control_frequency(self, sim, bad_freq):
+        # Before the fix these slipped the guard and reached
+        # int(duration * control_frequency), surfacing the cryptic
+        # "Policy failed: cannot convert float NaN to integer" instead of the
+        # guard's structured "control_frequency must be > 0" message.
+        text = _err_text(sim.run_policy("arm1", n_steps=5, control_frequency=bad_freq))
+        assert "control_frequency must be > 0" in text
+
+    def test_eval_policy_rejects_nan_control_frequency(self, sim):
+        text = _err_text(sim.eval_policy(robot_name="arm1", max_steps=3, control_frequency=float("nan")))
+        assert "control_frequency must be > 0" in text
+
+    def test_run_policy_accepts_numpy_scalar_control_frequency(self, sim):
+        # A NumPy scalar frequency flows all the way through the rollout.
+        result = sim.run_policy("arm1", n_steps=2, control_frequency=np.float32(50.0), fast_mode=True)
         assert result["status"] == "success", result


### PR DESCRIPTION
## Problem

`_validate_positive_frequency` is the single guard `run_policy`, `start_policy`, `eval_policy`, and `evaluate_benchmark` share to reject a bad `control_frequency` before it is used as a divisor (`1 / control_frequency` action period, `n_steps / control_frequency` duration). It used `isinstance(control_frequency, (int, float))` with `control_frequency > 0`, which had two failure modes:

1. **Non-finite frequencies slipped through.** `nan <= 0` and `inf <= 0` are both `False`, so `control_frequency=nan` / `inf` passed the guard and reached `int(duration * control_frequency)` in `PolicyRunner.run` (policy_runner.py:915), raising a bare `ValueError: cannot convert float NaN to integer` — surfaced to the caller as the cryptic `Policy failed: cannot convert float NaN to integer`, i.e. exactly the bare-`ValueError` the guard's own docstring says it exists to replace with a structured error naming the parameter.
2. **NumPy scalars were wrongly rejected.** `isinstance(np.float32(50.0), (int, float))` is `False` for every NumPy scalar except `np.float64`, so a frequency read from a config array (`np.float32` / `np.int64`) was refused as non-numeric even though it is a finite real.

Reproduced on a real MuJoCo sim (so100):

```python
sim.run_policy("arm1", n_steps=5, control_frequency=float("nan"))
# before: status=error, "Policy failed: cannot convert float NaN to integer"
sim.run_policy("arm1", n_steps=5, control_frequency=float("inf"))
# before: status=error, "Policy failed: cannot convert float NaN to integer"
SimEngine._validate_positive_frequency(np.float32(50.0), "run_policy")
# before: rejected ("control_frequency must be > 0")
```

## Change

The guard now uses `numbers.Real` + `math.isfinite` (short-circuiting, so a non-real value never reaches `math.isfinite`):

- `nan` / `inf` / `-inf` → rejected up front with the structured `control_frequency must be > 0` error (naming the parameter), before any physics.
- Any real scalar is accepted, including NumPy scalars (`np.float32`, `np.int64`, `np.float64`).
- `bool` / `np.bool_` / non-numeric junk / `0` / negatives stay rejected with the same message.

Mirrors the `numbers.Real` + `math.isfinite` contract already applied to `get_ground_height`, `set_gravity`, and `add_camera(fov=...)`. Error-message string is unchanged, so existing guard tests are unaffected.

## Tests

`tests/simulation/test_run_policy_horizon_validation.py::TestControlFrequencyFiniteAndNumpyScalar` (8 cases): the static guard rejects `nan`/`inf`/`-inf` and accepts `np.float32`/`np.int64`/`np.float64`; `run_policy` returns the structured `control_frequency must be > 0` error (not the cryptic runner `ValueError`) for `nan`/`inf`; `eval_policy` likewise; `run_policy` runs to completion with a `np.float32` frequency. All fail on the pre-fix code and pass after. Full 53-test guard file green; ruff + mypy clean.

Validation/error-contract fix (no policy/sim/render behavior change), so no visual artifact — the fails-before repros + tests are the proof.