### PR TITLE
fix(policies): is_molmoact2 respects an explicit policy_type without a Hub probe

### DIFF
--- a/strands_robots/policies/lerobot_local/molmoact2.py
+++ b/strands_robots/policies/lerobot_local/molmoact2.py
@@ -120,9 +120,18 @@ def is_molmoact2(pretrained_name_or_path: str, policy_type: str | None) -> bool:
     """Return True if this checkpoint should use the MolmoAct2 wrapper path.
 
     Detection (cheap → expensive):
-      1. Explicit ``policy_type == "molmoact2"``.
-      2. ``config.json`` has ``model_type == "molmoact2"`` (transformers-native)
+      1. An explicit ``policy_type`` is authoritative and short-circuits with no
+         I/O: ``"molmoact2"`` (case-insensitive) -> True, any other declared type
+         -> False. A caller who names a lerobot-native type (e.g. ``"act"``) has
+         already told us this is not a transformers-native MolmoAct2 checkpoint.
+      2. Only in auto-detect mode (``policy_type`` is ``None`` / empty):
+         ``config.json`` has ``model_type == "molmoact2"`` (transformers-native)
          AND no lerobot ``type`` key. Reads local file or HF Hub config.json.
+
+    The config.json probe in step 2 is a Hub round-trip, so it MUST NOT run when
+    the caller already declared the type -- otherwise every explicitly-typed load
+    (the common case) pays a needless network request that stalls or fails when
+    the Hub is slow/unreachable.
 
     Args:
         pretrained_name_or_path: HF repo id or local dir.
@@ -131,8 +140,8 @@ def is_molmoact2(pretrained_name_or_path: str, policy_type: str | None) -> bool:
     Returns:
         True if the MolmoAct2 wrapper path applies.
     """
-    if policy_type and policy_type.lower() == MOLMOACT2_TYPE:
-        return True
+    if policy_type:
+        return policy_type.lower() == MOLMOACT2_TYPE
     if not pretrained_name_or_path:
         return False
 

--- a/tests/policies/lerobot_local/test_molmoact2.py
+++ b/tests/policies/lerobot_local/test_molmoact2.py
@@ -44,6 +44,31 @@ def test_is_molmoact2_empty_path_no_type():
     assert molmoact2.is_molmoact2("", None) is False
 
 
+def test_is_molmoact2_explicit_nonmolmoact2_type_skips_hub_probe(monkeypatch):
+    """An explicit non-molmoact2 policy_type is authoritative: return False
+    WITHOUT any config.json probe.
+
+    A declared lerobot-native type (``"act"``, ``"diffusion"``, ...) already
+    tells us this is not a transformers-native MolmoAct2 checkpoint. The
+    config.json read is a Hub round-trip, so falling through to it on every
+    explicitly-typed load stalls (or fails) whenever the Hub is slow/unreachable
+    -- e.g. loading ``LerobotLocalPolicy(pretrained_name_or_path="user/act_ckpt",
+    policy_type="act")`` must not touch the network just to rule out molmoact2.
+    """
+    probed: list[str] = []
+
+    def _tracking_read(path):
+        probed.append(path)
+        return {"type": "act"}
+
+    monkeypatch.setattr(molmoact2, "_read_config_json", _tracking_read)
+
+    for declared in ("act", "diffusion", "pi0", "smolvla"):
+        assert molmoact2.is_molmoact2("user/some-checkpoint", declared) is False
+
+    assert probed == [], f"explicit type must not probe config.json, but read {probed}"
+
+
 def test_is_molmoact2_from_config_transformers_native(monkeypatch):
     """A transformers-native ckpt (model_type=molmoact2, no lerobot type) → True."""
     monkeypatch.setattr(


### PR DESCRIPTION
## Problem

`is_molmoact2(pretrained_name_or_path, policy_type)` decides whether a checkpoint takes the transformers-native MolmoAct2 load path or the standard lerobot resolve path. Its documented order is cheap -> expensive: (1) an explicit `policy_type`, then (2) a `config.json` probe.

Only the `policy_type == "molmoact2"` case short-circuited. Every *other* explicit type fell through to `_read_config_json`, which does an `hf_hub_download(repo, "config.json")` -- a live Hub round-trip. So a completely ordinary load like:

```python
LerobotLocalPolicy(pretrained_name_or_path="user/act_ckpt", policy_type="act")
```

paid a needless network request at construction just to rule out molmoact2, even though the caller already declared the type. When the Hub is slow or unreachable the load stalls (or fails) far from the real cause -- the traceback points at `config.json` resolution deep in the load path, not at the detection helper.

## Change

An explicit `policy_type` is authoritative and short-circuits with no I/O:

- `"molmoact2"` (case-insensitive) -> `True`
- any other declared type (`"act"`, `"diffusion"`, `"pi0"`, ...) -> `False`

The `config.json` probe now runs only in auto-detect mode (`policy_type` is `None`/empty), which is the only case that actually needs to disambiguate a transformers-native MolmoAct2 checkpoint (no lerobot draccus `type` key) from a standard one. This matches the docstring's stated cheap-to-expensive intent -- a named type is the cheapest, most authoritative signal.

## Tests

New `test_is_molmoact2_explicit_nonmolmoact2_type_skips_hub_probe` pins that an explicit non-molmoact2 type (`act`/`diffusion`/`pi0`/`smolvla`) returns `False` and never calls `_read_config_json`. It fails pre-fix (4 spurious probes) and passes post-fix. Existing explicit-`molmoact2` and auto-detect (`policy_type=None`) tests are unchanged and still green.

The existing `tests/policies/lerobot_local/test_load_telemetry.py` (which constructs `LerobotLocalPolicy(policy_type="act")` with the weight load stubbed) no longer reaches the network at all -- verified by running the `lerobot_local` detection/telemetry/cache suites under `HF_HUB_OFFLINE=1` (58 passed).

Local gate: `ruff check` + `ruff format --check` + `mypy` over `strands_robots tests tests_integ` all clean.

## Visual artifact

Not applicable: this is a load-time dispatch/network fix in a detection helper. It changes whether a Hub request is made while routing a checkpoint to its load path, not any policy inference, rendering, recording, or robot asset -- a sim rollout would be byte-for-byte identical before and after.