### PR TITLE
fix(sim): replay_episode accepts a NumPy scalar speed and rejects non-finite

### DIFF
--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -32,6 +32,8 @@ methods (e.g. MuJoCo acquires a lock inside ``send_action`` / ``step``).
 from __future__ import annotations
 
 import logging
+import math
+import numbers
 import os
 import random
 import time
@@ -1409,8 +1411,10 @@ class PolicyRunner:
             episode: Episode index in the dataset (non-negative).
             root: Optional local dataset root override.
             speed: Playback speed multiplier (1.0 = real time). Must be a
-                positive number; a non-positive or non-numeric value is
-                rejected with a structured error.
+                positive, finite number (any real scalar, including a NumPy
+                scalar such as ``np.float32(2.0)``); a non-positive,
+                non-finite or non-numeric value is rejected with a structured
+                error.
             action_key_map: Optional list of action keys, one per action
                 vector index. Required when dataset action ordering differs
                 from ``robot_action_keys(robot_name)``. If ``None``, positional
@@ -1423,19 +1427,41 @@ class PolicyRunner:
             Standard status dict with per-frame stats.
         """
         # ``speed`` is a playback-rate multiplier used as the divisor in
-        # ``frame_interval = 1 / (dataset_fps * speed)``. A value of 0 raised a
-        # bare ZeroDivisionError (breaking the documented "returns a status
-        # dict" contract) and a negative value silently played the episode
-        # forward at full speed while reporting success with a meaningless
-        # "Speed: -1.0x". Reject a non-positive or non-numeric speed up front,
-        # before the (potentially multi-minute) dataset download. ``bool`` is
-        # an ``int`` subclass, so ``True`` is rejected explicitly rather than
-        # acting as a silent 1.0x.
-        if isinstance(speed, bool) or not isinstance(speed, (int, float)) or speed <= 0:
+        # ``frame_interval = 1 / (dataset_fps * speed)`` and, once computed,
+        # flows into ``time.sleep(frame_interval - elapsed)`` on the real-time
+        # playback path. A value of 0 raised a bare ZeroDivisionError (breaking
+        # the documented "returns a status dict" contract) and a negative value
+        # silently played the episode forward at full speed while reporting
+        # success with a meaningless "Speed: -1.0x". Reject a non-positive or
+        # non-numeric speed up front, before the (potentially multi-minute)
+        # dataset download. Accept any real scalar (``numbers.Real``) so a
+        # NumPy-scalar speed such as ``np.float32(2.0)`` or ``np.int64(2)``
+        # (e.g. read from a config array) is not rejected:
+        # ``isinstance(x, (int, float))`` is ``False`` for every NumPy scalar
+        # except ``np.float64``. ``bool`` is still rejected explicitly (an
+        # ``int`` subclass, so ``True`` would act as a silent 1.0x), and
+        # non-finite values (``nan``/``inf``) are rejected via ``math.isfinite``
+        # before the ``<= 0`` comparison so a ``nan`` -- which is never
+        # ``<= 0`` -- cannot slip through into the ``1 / (fps * speed)``
+        # arithmetic and reach ``time.sleep(nan)``. Mirrors the ``numbers.Real``
+        # + finiteness contract applied to ``control_frequency`` and
+        # ``add_camera(fov=...)``.
+        if (
+            isinstance(speed, bool)
+            or not isinstance(speed, numbers.Real)
+            or not math.isfinite(float(speed))
+            or float(speed) <= 0
+        ):
             return {
                 "status": "error",
                 "content": [{"text": f"replay: speed must be a positive number (got {speed!r})."}],
             }
+        # Coerce to a plain Python float: a validated NumPy scalar still flows
+        # into ``time.sleep(frame_interval - ...)`` and the returned
+        # ``"speed": speed`` status field, where a ``numpy.float32`` raises a
+        # bare "object cannot be interpreted as an integer" TypeError in
+        # ``time.sleep`` and is not natively JSON-serialisable.
+        speed = float(speed)
 
         try:
             from strands_robots.dataset_recorder import load_lerobot_episode

--- a/tests/simulation/test_policy_runner_paths.py
+++ b/tests/simulation/test_policy_runner_paths.py
@@ -159,6 +159,69 @@ def test_replay_bool_speed_rejected(monkeypatch):
     assert "positive" in r["content"][0]["text"]
 
 
+def test_replay_nan_speed_rejected_before_loading(monkeypatch):
+    """A non-finite ``speed`` (``nan``/``inf``) must be rejected up front.
+
+    ``nan`` is never ``<= 0``, so it slipped past a bare ``speed <= 0`` guard
+    into ``frame_interval = 1 / (dataset_fps * speed)`` (= ``nan``) and then
+    ``time.sleep(nan - elapsed)``, which raises a bare ``ValueError`` deep in
+    the playback loop -- breaking replay()'s documented "returns a status dict"
+    contract -- while also reporting a meaningless "Speed: nanx". The guard must
+    reject it before the dataset loader runs.
+    """
+    sim = _MinimalSim(robots=["r0"])
+
+    import strands_robots.dataset_recorder as dr
+
+    def _must_not_load(*args, **kwargs):
+        raise AssertionError("load_lerobot_episode reached despite non-finite speed")
+
+    monkeypatch.setattr(dr, "load_lerobot_episode", _must_not_load, raising=False)
+
+    for bad in (float("nan"), float("inf")):
+        r = PolicyRunner(sim).replay(repo_id="some/dataset", robot_name="r0", speed=bad)
+        assert r["status"] == "error"
+        assert "positive" in r["content"][0]["text"]
+
+
+def test_replay_numpy_scalar_speed_accepted(monkeypatch):
+    """A NumPy-scalar ``speed`` (e.g. read from a config array) is a valid
+    positive rate and must not be rejected.
+
+    ``isinstance(x, (int, float))`` is ``False`` for every NumPy scalar except
+    ``np.float64``, so a ``np.float32(2.0)`` speed was wrongly rejected with
+    "speed must be a positive number" even though 2.0 is valid. Once accepted,
+    the scalar must be coerced to a plain ``float`` so it does not raise a
+    ``TypeError`` in ``time.sleep`` on the playback path, and the returned
+    ``"speed"`` status field is a plain float.
+    """
+
+    class _TinyDataset:
+        fps = 30
+
+        def __len__(self):
+            return 2
+
+        def __getitem__(self, idx):
+            return {"action": [0.1 * idx, 0.2, 0.3]}
+
+    def loader(repo_id, episode, root):
+        return _TinyDataset(), 0, 2
+
+    sim = _MinimalSim(robots=["r0"])
+
+    import strands_robots.dataset_recorder as dr
+
+    monkeypatch.setattr(dr, "load_lerobot_episode", loader, raising=False)
+
+    # speed=100.0 magnitude keeps the test fast; use a NumPy float32 scalar.
+    r = PolicyRunner(sim).replay(repo_id="fake/tiny", robot_name="r0", speed=np.float32(100.0))
+    assert r["status"] == "success"
+    reported = r["content"][1]["json"]["speed"]
+    assert reported == 100.0
+    assert type(reported) is float
+
+
 def test_replay_with_tensor_like_actions(monkeypatch):
     """Dataset actions may be torch tensors; replay must call .numpy().tolist()."""
 


### PR DESCRIPTION
## Problem

`replay_episode(speed=...)` validated the playback-speed multiplier with:

```python
if isinstance(speed, bool) or not isinstance(speed, (int, float)) or speed <= 0:
    return {"status": "error", ...}
```

`isinstance(x, (int, float))` is `False` for every NumPy scalar except `np.float64` (the only one that subclasses Python `float`). A playback speed read from a config array or computed as a NumPy value -- `np.float32(2.0)` or `np.int64(2)` -- was therefore rejected with the misleading `speed must be a positive number` error even though it is a perfectly valid positive rate.

There is also a coupled non-finite bug: `nan` is never `<= 0`, so a `nan`/`inf` speed slipped past the guard into `frame_interval = 1 / (dataset_fps * speed)` (= `nan`) and then `time.sleep(nan - elapsed)`, raising a bare `ValueError` deep in the playback loop -- breaking `replay()`'s documented "returns a status dict" contract -- while reporting a meaningless `Speed: nanx`.

## Change

Mirrors the `numbers.Real` + finiteness contract already applied to `control_frequency`, `add_camera(fov=...)` and `get_ground_height`:

1. Widen the type check to `numbers.Real`, accepting any real scalar (including NumPy types) while still rejecting `bool` / `np.bool_` (an `int` subclass that would act as a silent 1.0x).
2. Reject non-finite values via `math.isfinite` **before** the `<= 0` comparison, so `nan`/`inf` can no longer reach the `1 / (fps * speed)` arithmetic and `time.sleep`.
3. Coerce the validated value to a plain Python `float`: a NumPy scalar otherwise flows into `time.sleep(...)` (which rejects `numpy.float32` with a bare "object cannot be interpreted as an integer" `TypeError`) and into the returned `"speed"` status field (not natively JSON-serialisable).

## Tests

Added to `tests/simulation/test_policy_runner_paths.py` (both fail on pre-fix code, pass after):

- `test_replay_numpy_scalar_speed_accepted` -- a `np.float32` speed replays successfully and the returned `"speed"` status field is a plain `float`.
- `test_replay_nan_speed_rejected_before_loading` -- `nan` and `inf` are rejected up front with a structured error, before the dataset loader runs.

Full local gate is clean: `ruff check` / `ruff format --check` clean, `mypy strands_robots tests tests_integ` -> "no issues found in 797 source files", and the replay test modules pass under `MUJOCO_GL=egl`.

## Verification (headless MuJoCo)

End-to-end record -> replay round-trip at a NumPy `float32` speed on `so100` (headless sim). Pre-fix this call returned `speed must be a positive number (got np.float32(2.0))`; now:

```
Replayed episode 0 from harness/replay_speed_demo on 'so100'
Frames: 60/60 | Duration: 1.0s | Speed: 2.0x
replay json speed: 2.0 <class 'float'>
```

Rollout on the same real-time `PolicyRunner` playback/timing path that `speed` feeds into (`time.sleep` pacing), rendered headless:

![replay rollout](https://github.com/cagataycali/robots/releases/download/replay-speed-numpy-artifacts-v1/replay_speed_rollout.gif)

<video src="https://github.com/cagataycali/robots/releases/download/replay-speed-numpy-artifacts-v1/replay_speed_rollout.mp4"></video>