### PR TITLE
fix(sim): set_body_properties rejects a non-finite mass (nan/+inf slipped the positivity guard)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2027,6 +2027,21 @@ type is `SupportsFloat` so a NumPy-scalar call type-checks as well as runs.
 `add_camera` rejected a NumPy scalar field-of-view (`np.float32(58.0)`, `np.int64(58)`) with a misleading "'fov' must be a finite number in degrees" error, even though the value is a finite real number, because the guard used `isinstance(fov, (int, float))` (`False` for every NumPy scalar except `np.float64`). A fov computed from a config array or `np.degrees(...)` was therefore refused. The check now uses `numbers.Real`, accepting any real scalar (including NumPy types) while still rejecting `bool` / `np.bool_`, non-finite values, and angles outside the open interval `(0, 180)` -- matching the `get_ground_height` coordinate contract.
 
 
+### Fixed: `set_body_properties(mass=...)` rejects a non-finite mass
+
+`set_body_properties` documents `mass` as a positive physics invariant, but its
+guard used only `if mass <= 0`. `float('nan') <= 0` and `float('inf') <= 0` are
+both `False`, so a NaN or `+Inf` mass slipped through: the body's `body_mass`
+was set to NaN/Inf and its `body_inertia` (which is scaled by `mass / old_mass`
+to stay consistent) became NaN/Inf as well, so the next `mj_step` produced a
+non-finite `qacc` -- a silent physics corruption reported as
+`status="success"`. (`-Inf` was already caught because `-Inf <= 0` is `True`.)
+
+The guard now rejects any non-finite value (`not math.isfinite(mass) or mass
+<= 0`) before mutating the model, matching the finiteness contract already
+enforced by `set_timestep` and `set_gravity`. Finite positive masses (including
+NumPy scalars, which `float()` still coerces) are unaffected.
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -1041,12 +1041,12 @@ class PhysicsMixin:
 
         Args:
             body_name: Name of the body to modify.
-            mass: New absolute mass (kg); must be ``> 0``. When set, the body's
+            mass: New absolute mass (kg); must be a finite number ``> 0``. When set, the body's
                 inertia is scaled by ``mass / old_mass`` to preserve consistency.
 
         Returns:
             A tool-result dict; ``status="error"`` if the world is missing, a
-            policy is running, ``mass`` is not a positive number, or the body is
+            policy is running, ``mass`` is not a finite positive number, or the body is
             not found, otherwise ``status="success"`` summarizing the change.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
@@ -1063,10 +1063,10 @@ class PhysicsMixin:
                     "status": "error",
                     "content": [{"text": f"set_body_properties: 'mass' must be a positive number, got {mass!r}"}],
                 }
-            if mass <= 0:
+            if not math.isfinite(mass) or mass <= 0:
                 return {
                     "status": "error",
-                    "content": [{"text": f"set_body_properties: 'mass' must be > 0, got {mass}"}],
+                    "content": [{"text": f"set_body_properties: 'mass' must be a finite number > 0, got {mass}"}],
                 }
 
         mj = _ensure_mujoco()

--- a/tests/simulation/mujoco/test_input_validation.py
+++ b/tests/simulation/mujoco/test_input_validation.py
@@ -200,7 +200,16 @@ class TestMassAndTimestepValidation:
     def test_set_body_properties_negative_mass_errors(self, sim_with_robot):
         res = sim_with_robot.set_body_properties(body_name="link1", mass=-1.0)
         assert res["status"] == "error"
-        assert "must be > 0" in res["content"][0]["text"]
+        assert "must be a finite number > 0" in res["content"][0]["text"]
+
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf"), -float("inf")])
+    def test_set_body_properties_nonfinite_mass_errors(self, sim_with_robot, bad):
+        """NaN/Inf must be rejected: ``nan <= 0`` and ``inf <= 0`` are both False,
+        so a bare positivity guard would let them corrupt ``body_mass`` /
+        ``body_inertia`` while reporting success."""
+        res = sim_with_robot.set_body_properties(body_name="link1", mass=bad)
+        assert res["status"] == "error"
+        assert "finite" in res["content"][0]["text"]
 
     def test_set_body_properties_zero_mass_errors(self, sim_with_robot):
         res = sim_with_robot.set_body_properties(body_name="link1", mass=0.0)

--- a/tests/simulation/mujoco/test_physics.py
+++ b/tests/simulation/mujoco/test_physics.py
@@ -584,6 +584,36 @@ class TestRuntimeModification:
         assert model.body_mass[body_id] == pytest.approx(2.0)
         assert model.body_inertia[body_id] == pytest.approx([0.0, 0.0, 0.0])
 
+    def test_set_body_mass_rejects_nonfinite(self, sim):
+        """A non-finite mass is rejected instead of silently corrupting the model.
+
+        ``float('nan') <= 0`` and ``float('inf') <= 0`` are both ``False``, so a
+        bare ``mass <= 0`` guard lets NaN/+Inf slip through: the body's mass and
+        (mass-tracking) inertia would be set to NaN/Inf and the next ``mj_step``
+        would produce a non-finite ``qacc`` -- a silent physics corruption
+        reported as ``status="success"``. The guard must also reject non-finite
+        values, matching the finiteness contract already enforced by
+        ``set_timestep`` / ``set_gravity``.
+        """
+        model = sim._world._model
+        body_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_BODY, "box1")
+        good_mass = float(model.body_mass[body_id])
+        good_inertia = model.body_inertia[body_id].copy()
+        assert good_mass > 0 and (good_inertia > 0).all()
+
+        for bad in (float("nan"), float("inf"), -float("inf")):
+            result = sim.set_body_properties(body_name="box1", mass=bad)
+            assert result["status"] == "error", f"mass={bad!r} was not rejected"
+            assert "finite" in result["content"][0]["text"]
+            # Neither mass nor inertia was mutated by the rejected call.
+            assert model.body_mass[body_id] == pytest.approx(good_mass)
+            assert model.body_inertia[body_id] == pytest.approx(good_inertia)
+            # And the world remains integrable (no NaN leaked into the model).
+            mj.mj_forward(model, sim._world._data)
+            import numpy as np
+
+            assert np.all(np.isfinite(sim._world._data.qacc))
+
     def test_set_geom_color(self, sim):
         result = sim.set_geom_properties(geom_name="box_geom", color=[0, 1, 0, 1])
         assert result["status"] == "success"


### PR DESCRIPTION
## Problem

`Simulation.set_body_properties(body_name, mass=...)` documents `mass` as a positive physics invariant ("must be a positive number", "physics invariant") and guards it with `if mass <= 0`. But `float('nan') <= 0` and `float('inf') <= 0` are **both `False`**, so a `NaN` or `+Inf` mass slipped straight through the guard:

- `body_mass[body]` was set to `NaN` / `Inf`;
- `body_inertia[body]` (deliberately scaled by `mass / old_mass` so translational and rotational dynamics stay consistent) also became `NaN` / `Inf`;
- the next `mj_step` then produced a **non-finite `qacc`** — a silent physics corruption reported as `status="success"`.

`-Inf` was already rejected because `-Inf <= 0` is `True`; only `NaN` and `+Inf` slipped.

Reproduced on a real MuJoCo world:

```
set mass=nan -> status=success   body_mass now: nan   body_inertia now: [nan, nan, nan]
  after mj_forward: qacc finite? False
set mass=inf -> status=success   body_mass now: inf   body_inertia now: [inf, inf, inf]
  after mj_forward: qacc finite? False
set mass=-inf -> status=error (already caught)
```

## Fix

Guard against any non-finite value before mutating the model:

```python
if not math.isfinite(mass) or mass <= 0:
    return {"status": "error", ..."'mass' must be a finite number > 0"...}
```

This mirrors the finiteness contract **already enforced by `set_timestep`** (`if not math.isfinite(timestep) or timestep <= 0`) and `set_gravity` in the same tree. Finite positive masses — including NumPy scalars, which `float()` still coerces — are unaffected.

## Tests

- `tests/simulation/mujoco/test_physics.py::TestRuntimeModification::test_set_body_mass_rejects_nonfinite` — asserts NaN/±Inf are rejected, that neither `body_mass` nor `body_inertia` is mutated by the rejected call, and that `mj_forward` still yields a finite `qacc`. **Fails before** the fix (`mass=nan` returned `status=success`), passes after.
- `tests/simulation/mujoco/test_input_validation.py::TestMassAndTimestepValidation` — added a parametrized `test_set_body_properties_nonfinite_mass_errors` (nan/inf/-inf) and updated the negative-mass assertion to the improved message.

Green gate: `ruff check` + `ruff format --check` + `mypy` clean on the changed files; full `MUJOCO_GL=egl test_physics.py` (83) and `TestMassAndTimestepValidation` (16) pass. No visual artifact (error-contract fix; the fails-before physics test is the proof).