### PR TITLE
fix(sim): set_geom_properties rejects non-finite/invalid color, friction, size

### DIFF
--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -30,6 +30,66 @@ from strands_robots.simulation.mujoco.backend import (
 logger = logging.getLogger(__name__)
 
 
+def _coerce_finite_vector(
+    values: Any,
+    name: str,
+    method: str,
+    *,
+    min_value: float | None = None,
+    strict_min: bool = False,
+) -> tuple[list[float] | None, dict[str, Any] | None]:
+    """Coerce a numeric vector to ``float`` and validate every element.
+
+    Each element must be a real number (Python or NumPy scalar) and finite --
+    ``nan`` / ``inf`` are rejected because they slip silently into the MuJoCo
+    model buffers and corrupt the solver while the tool still reports success.
+    An optional lower bound enforces physics invariants (non-negative friction,
+    positive geom extent).
+
+    Args:
+        values: The input sequence (list / tuple / NumPy array).
+        name: Parameter name, used in error text.
+        method: Calling method name, used in error text.
+        min_value: If set, every element must be ``>= min_value`` (or ``>`` when
+            ``strict_min`` is True).
+        strict_min: Use a strict ``>`` comparison against ``min_value``.
+
+    Returns:
+        ``(floats, None)`` on success, or ``(None, error_dict)`` on the first
+        invalid element -- matching the structured-error tool contract so the
+        caller never raises past dispatch.
+    """
+    try:
+        seq = list(values)
+    except TypeError:
+        return None, {
+            "status": "error",
+            "content": [{"text": f"{method}: '{name}' must be a sequence of numbers, got {values!r}"}],
+        }
+    out: list[float] = []
+    for elem in seq:
+        try:
+            f = float(elem)
+        except (TypeError, ValueError):
+            return None, {
+                "status": "error",
+                "content": [{"text": f"{method}: '{name}' elements must be numbers, got {values!r}"}],
+            }
+        if not math.isfinite(f):
+            return None, {
+                "status": "error",
+                "content": [{"text": f"{method}: '{name}' must contain finite numbers (no nan/inf), got {values!r}"}],
+            }
+        if min_value is not None and ((f <= min_value) if strict_min else (f < min_value)):
+            rel = ">" if strict_min else ">="
+            return None, {
+                "status": "error",
+                "content": [{"text": f"{method}: '{name}' values must be {rel} {min_value}, got {values!r}"}],
+            }
+        out.append(f)
+    return out, None
+
+
 def _full_mass_matrix(mj: Any, model: Any, data: Any) -> np.ndarray:
     """Return the dense ``nv x nv`` mass matrix M(q), robust to MuJoCo drift.
 
@@ -1116,6 +1176,13 @@ class PhysicsMixin:
         mid-phase) are recomputed so a grown geom collides correctly instead of
         letting other bodies pass through it. Mesh/plane/height-field geoms take
         their extent from asset data, so a ``size`` write is inert for them.
+
+        All numeric inputs are validated before any model write: ``color``,
+        ``friction`` and ``size`` must contain only finite numbers (``nan`` /
+        ``inf`` are rejected), ``friction`` coefficients must be ``>= 0`` and
+        ``size`` half-extents must be ``> 0``. An invalid value returns a
+        structured ``status="error"`` result and leaves the model untouched,
+        rather than silently corrupting the solver or broadphase bounds.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
@@ -1134,6 +1201,25 @@ class PhysicsMixin:
                 gid = self._resolve_mj_name(mj.mjtObj.mjOBJ_GEOM, f"{geom_name}_geom")
         if gid is None or gid < 0 or gid >= model.ngeom:
             return {"status": "error", "content": [{"text": f"Geom '{geom_name or geom_id}' not found."}]}
+
+        # Validate numeric inputs before any model write. Without this a nan/inf
+        # (or negative) value lands directly in geom_rgba / geom_friction /
+        # geom_size and silently corrupts rendering, the contact solver, or the
+        # broadphase bounds (geom_rbound becomes inf) while the tool still
+        # reports success. Friction coefficients are non-negative and a geom's
+        # size (half-extent) must be strictly positive.
+        if color is not None:
+            color, err = _coerce_finite_vector(color, "color", "set_geom_properties")
+            if err:
+                return err
+        if friction is not None:
+            friction, err = _coerce_finite_vector(friction, "friction", "set_geom_properties", min_value=0.0)
+            if err:
+                return err
+        if size is not None:
+            size, err = _coerce_finite_vector(size, "size", "set_geom_properties", min_value=0.0, strict_min=True)
+            if err:
+                return err
 
         label = geom_name or f"geom_{gid}"
         changes = []

--- a/tests/simulation/mujoco/test_setter_input_type_validation.py
+++ b/tests/simulation/mujoco/test_setter_input_type_validation.py
@@ -101,3 +101,80 @@ class TestSetGravityNumpyScalar:
         res = sim_with_world.set_gravity(np.bool_(True))
         assert res["status"] == "error"
         assert "numbers" in res["content"][0]["text"]
+
+
+class TestSetGeomPropertiesRejectsInvalid:
+    """``set_geom_properties`` must reject physically invalid numeric inputs.
+
+    Unlike ``set_gravity`` / ``set_body_properties`` / ``set_timestep``, the
+    geom mutator historically wrote ``color`` / ``friction`` / ``size`` straight
+    into the MuJoCo model with no validation. A ``nan`` / ``inf`` -- or a
+    negative friction / non-positive size -- landed directly in ``geom_rgba``,
+    ``geom_friction`` or ``geom_size`` (making ``geom_rbound`` inf, silently
+    breaking broadphase collision) while the call still returned
+    ``status="success"``. These pin that such inputs are rejected with a
+    structured error and leave the model untouched, and that valid values
+    (including NumPy scalars) still apply.
+    """
+
+    @pytest.fixture
+    def sim_with_box(self):
+        sim = Simulation()
+        sim.create_world()
+        sim.add_object("box", shape="box", position=[0.3, 0.0, 0.1], size=[0.05, 0.05, 0.05])
+        yield sim
+        sim.destroy()
+
+    def _geom_id(self, sim):
+        import mujoco
+
+        return sim._resolve_mj_name(mujoco.mjtObj.mjOBJ_GEOM, "box_geom")
+
+    def test_nan_friction_rejected_and_model_untouched(self, sim_with_box):
+        gid = self._geom_id(sim_with_box)
+        before = sim_with_box._world._model.geom_friction[gid].copy()
+        res = sim_with_box.set_geom_properties(geom_name="box", friction=[float("nan"), 0.005, 0.0001])
+        assert res["status"] == "error"
+        assert "finite" in res["content"][0]["text"]
+        assert (sim_with_box._world._model.geom_friction[gid] == before).all()
+
+    def test_inf_size_rejected_and_rbound_stays_finite(self, sim_with_box):
+        import numpy as np
+
+        gid = self._geom_id(sim_with_box)
+        res = sim_with_box.set_geom_properties(geom_name="box", size=[float("inf"), 0.05, 0.05])
+        assert res["status"] == "error"
+        assert "finite" in res["content"][0]["text"]
+        assert bool(np.isfinite(sim_with_box._world._model.geom_rbound[gid]))
+
+    def test_non_positive_size_rejected(self, sim_with_box):
+        for bad in ([-0.05, 0.05, 0.05], [0.0, 0.05, 0.05]):
+            res = sim_with_box.set_geom_properties(geom_name="box", size=bad)
+            assert res["status"] == "error"
+            assert "> 0" in res["content"][0]["text"]
+
+    def test_negative_friction_rejected(self, sim_with_box):
+        res = sim_with_box.set_geom_properties(geom_name="box", friction=[-1.0, 0.005, 0.0001])
+        assert res["status"] == "error"
+        assert ">= 0" in res["content"][0]["text"]
+
+    def test_nan_color_rejected(self, sim_with_box):
+        res = sim_with_box.set_geom_properties(geom_name="box", color=[float("nan"), 0.0, 0.0, 1.0])
+        assert res["status"] == "error"
+        assert "finite" in res["content"][0]["text"]
+
+    def test_non_numeric_entry_rejected_not_raised(self, sim_with_box):
+        res = sim_with_box.set_geom_properties(geom_name="box", friction=["a", "b", "c"])
+        assert res["status"] == "error"
+        assert "numbers" in res["content"][0]["text"]
+
+    def test_valid_numpy_scalar_values_still_apply(self, sim_with_box):
+        import numpy as np
+
+        gid = self._geom_id(sim_with_box)
+        res = sim_with_box.set_geom_properties(
+            geom_name="box", friction=[np.float32(0.8), 0.01, 0.001], size=[0.06, 0.06, 0.06]
+        )
+        assert res["status"] == "success"
+        assert abs(float(sim_with_box._world._model.geom_size[gid][0]) - 0.06) < 1e-6
+        assert abs(float(sim_with_box._world._model.geom_friction[gid][0]) - 0.8) < 1e-4


### PR DESCRIPTION
## Problem

`set_geom_properties` wrote `color`, `friction` and `size` straight into the MuJoCo model (`geom_rgba` / `geom_friction` / `geom_size`) with **no validation**, so physically invalid input silently corrupted the model while the tool still returned `status="success"`:

- `nan` / `inf` `friction` -> lands in `geom_friction`, corrupting the contact solver.
- `inf` `size` -> `geom_size` becomes `inf`, so `geom_rbound` (broadphase bound) becomes `inf` and collision silently breaks.
- negative `friction` / non-positive `size` -> physically invalid geoms accepted.
- a non-numeric entry (e.g. `["a", "b", "c"]`) raised `ValueError` **past** the structured-error dispatch contract.

Reproduction on `main` (all four return `status="success"`):

```python
sim.set_geom_properties(geom_name="box", friction=[float("nan"), 0.005, 0.0001])  # success, nan in geom_friction
sim.set_geom_properties(geom_name="box", size=[float("inf"), 0.05, 0.05])          # success, geom_rbound -> inf
sim.set_geom_properties(geom_name="box", size=[-0.05, 0.05, 0.05])                 # success, negative half-extent
sim.set_geom_properties(geom_name="box", friction=["a", "b", "c"])                 # raises ValueError
```

## Change

Validate all numeric inputs before any model write, via a small shared helper `_coerce_finite_vector`:

- every element must be a real number and **finite** (`nan`/`inf` rejected);
- `friction` coefficients must be `>= 0`;
- `size` half-extents must be `> 0`.

Invalid input now returns a structured `status="error"` and **leaves the model untouched**. Valid values (including NumPy scalars such as `np.float32`) still apply unchanged. This brings `set_geom_properties` in line with the existing `set_gravity` / `set_body_properties` / `set_timestep` guards.

## Tests

Adds `TestSetGeomPropertiesRejectsInvalid` in `tests/simulation/mujoco/test_setter_input_type_validation.py` covering nan friction (model untouched), inf size (`geom_rbound` stays finite), non-positive size, negative friction, nan color, non-numeric entry, and a positive control that valid NumPy-scalar values still apply. The rejection tests fail on pre-fix code (6/7 fail: the values slip through as `success`, and the non-numeric case raises `ValueError`) and pass after. Full `MUJOCO_GL=egl` sim suite and `ruff` + `mypy` (`strands_robots tests tests_integ`) are green.

## Visual verification

Rollout in MuJoCo (headless, `MUJOCO_GL=egl`): a gray 5 cm cube (left) recolored + grown to a red 9 cm cube (right) through the guarded setter -- `geom_rbound` stays finite so broadphase collision remains correct -- while a follow-up `size=[inf, ...]` attempt is rejected and leaves the model intact.

![set_geom_properties before/after](https://github.com/cagataycali/robots/releases/download/set-geom-properties-guard-artifacts/set_geom_properties_demo.png)