### PR TITLE
fix(sim): set_joint_positions/set_joint_velocities reject non-finite/non-numeric values

### DIFF
--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -90,6 +90,56 @@ def _coerce_finite_vector(
     return out, None
 
 
+def _coerce_finite_joint_map(
+    values: dict[str, Any],
+    name: str,
+    method: str,
+) -> tuple[dict[str, float], dict[str, Any] | None]:
+    """Coerce a ``{joint_name: value}`` map to finite floats before any write.
+
+    Each value must be a real number (Python or NumPy scalar) and finite. A
+    non-numeric value would otherwise raise ``ValueError`` from ``float(value)``
+    past the structured-error dispatch contract, and ``nan`` / ``inf`` would
+    slip straight into ``data.qpos`` / ``data.qvel`` -- ``mj_forward`` then
+    propagates the ``nan`` across the whole kinematic state (or an ``inf``
+    velocity blows up the integrator) while the tool still reports
+    ``status="success"``. Validating up front keeps the write atomic: an invalid
+    value leaves the model untouched.
+
+    Args:
+        values: The ``{joint_name: value}`` mapping to validate.
+        name: Parameter name (``"positions"`` / ``"velocities"``), used in error text.
+        method: Calling method name, used in error text.
+
+    Returns:
+        ``(coerced, None)`` on success, or ``({}, error_dict)`` on the first
+        invalid value -- matching the structured-error tool contract so the
+        caller never raises past dispatch.
+    """
+    out: dict[str, float] = {}
+    for jnt_name, value in values.items():
+        try:
+            f = float(value)
+        except (TypeError, ValueError):
+            return {}, {
+                "status": "error",
+                "content": [
+                    {"text": f"{method}: '{name}' value for joint '{jnt_name}' must be a number, got {value!r}"}
+                ],
+            }
+        if not math.isfinite(f):
+            return {}, {
+                "status": "error",
+                "content": [
+                    {
+                        "text": f"{method}: '{name}' value for joint '{jnt_name}' must be finite (no nan/inf), got {value!r}"
+                    }
+                ],
+            }
+        out[jnt_name] = f
+    return out, None
+
+
 def _full_mass_matrix(mj: Any, model: Any, data: Any) -> np.ndarray:
     """Return the dense ``nv x nv`` mass matrix M(q), robust to MuJoCo drift.
 
@@ -826,6 +876,12 @@ class PhysicsMixin:
         * list/tuple: [v0, v1, ...] - ordered positional. Must match a single robot's
           joint count (when ``robot_name`` is given, that robot's joints; otherwise the
           world must contain exactly one robot, or the call errors).
+
+        Every value must be a finite real number (Python or NumPy scalar). A
+        ``nan`` / ``inf`` or a non-numeric value returns a structured
+        ``status="error"`` and leaves ``qpos`` untouched, rather than corrupting
+        the kinematic state (``mj_forward`` propagates a ``nan`` everywhere) or
+        raising past the tool-dispatch contract.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
@@ -899,6 +955,14 @@ class PhysicsMixin:
                 ],
             }
 
+        # Validate every value is a finite number before any qpos write. Without
+        # this a non-numeric entry raises ValueError past the structured-error
+        # contract, and a nan/inf lands in data.qpos where mj_forward propagates
+        # it across the whole kinematic state while the tool still reports success.
+        positions, err = _coerce_finite_joint_map(positions, "positions", "set_joint_positions")
+        if err:
+            return err
+
         set_count = 0
         with self._lock:
             for jnt_name, value in positions.items():
@@ -930,6 +994,11 @@ class PhysicsMixin:
 
         Writes to qvel. Useful for initializing dynamics. Accepts dict or list
         (see set_joint_positions for list semantics).
+
+        Every value must be a finite real number (Python or NumPy scalar). A
+        ``nan`` / ``inf`` or a non-numeric value returns a structured
+        ``status="error"`` and leaves ``qvel`` untouched, rather than blowing up
+        the integrator on the next step or raising past the tool-dispatch contract.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
@@ -997,6 +1066,13 @@ class PhysicsMixin:
                     }
                 ],
             }
+
+        # Validate every value is a finite number before any qvel write (see
+        # set_joint_positions): a nan/inf velocity blows up the integrator on the
+        # next step and a non-numeric entry escapes the structured-error contract.
+        velocities, err = _coerce_finite_joint_map(velocities, "velocities", "set_joint_velocities")
+        if err:
+            return err
 
         set_count = 0
         with self._lock:

--- a/tests/simulation/mujoco/test_input_validation.py
+++ b/tests/simulation/mujoco/test_input_validation.py
@@ -407,6 +407,89 @@ class TestSetJointVelocitiesForms:
         assert "nope" in res["content"][0]["text"]
 
 
+# set_joint_positions / set_joint_velocities finite-value validation
+
+
+class TestSetJointFiniteValidation:
+    """Regression: joint setters must reject non-finite / non-numeric values.
+
+    ``set_joint_positions`` / ``set_joint_velocities`` wrote each value straight
+    into ``data.qpos`` / ``data.qvel`` via ``float(value)`` with no guard. A
+    ``nan`` / ``inf`` landed directly in the state buffer -- ``mj_forward`` then
+    propagates the ``nan`` across the whole kinematic tree (or an ``inf``
+    velocity blows up the integrator on the next step) while the tool still
+    returned ``status="success"``; a non-numeric value raised ``ValueError``
+    past the structured-error dispatch contract. Both must now return a
+    structured error and leave the state untouched.
+    """
+
+    def _first_joint(self, sim):
+        joint_names = list(sim._world.robots.values())[0].joint_names or []
+        if not joint_names:
+            pytest.skip("robot has no named joints")
+        return joint_names[0]
+
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+    def test_positions_nonfinite_rejected_and_qpos_untouched(self, sim_with_robot, bad):
+        jn = self._first_joint(sim_with_robot)
+        before = sim_with_robot._world._data.qpos.copy()
+        res = sim_with_robot.set_joint_positions(positions={jn: bad})
+        assert res["status"] == "error"
+        assert "finite" in res["content"][0]["text"]
+        # State must be left untouched (no nan/inf leaked into qpos).
+        assert np.array_equal(sim_with_robot._world._data.qpos, before)
+        assert np.all(np.isfinite(sim_with_robot._world._data.qpos))
+
+    def test_positions_non_numeric_returns_structured_error(self, sim_with_robot):
+        """A non-numeric value must NOT raise past dispatch."""
+        jn = self._first_joint(sim_with_robot)
+        res = sim_with_robot.set_joint_positions(positions={jn: "not-a-number"})
+        assert res["status"] == "error"
+        assert "must be a number" in res["content"][0]["text"]
+
+    def test_positions_nonfinite_in_list_form_rejected(self, sim_with_robot):
+        joint_names = list(sim_with_robot._world.robots.values())[0].joint_names or []
+        if not joint_names:
+            pytest.skip("robot has no named joints")
+        vals = [0.0] * len(joint_names)
+        vals[0] = float("nan")
+        before = sim_with_robot._world._data.qpos.copy()
+        res = sim_with_robot.set_joint_positions(positions=vals)
+        assert res["status"] == "error"
+        assert "finite" in res["content"][0]["text"]
+        assert np.array_equal(sim_with_robot._world._data.qpos, before)
+
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+    def test_velocities_nonfinite_rejected_and_qvel_untouched(self, sim_with_robot, bad):
+        jn = self._first_joint(sim_with_robot)
+        before = sim_with_robot._world._data.qvel.copy()
+        res = sim_with_robot.set_joint_velocities(velocities={jn: bad})
+        assert res["status"] == "error"
+        assert "finite" in res["content"][0]["text"]
+        assert np.array_equal(sim_with_robot._world._data.qvel, before)
+        assert np.all(np.isfinite(sim_with_robot._world._data.qvel))
+
+    def test_velocities_non_numeric_returns_structured_error(self, sim_with_robot):
+        jn = self._first_joint(sim_with_robot)
+        res = sim_with_robot.set_joint_velocities(velocities={jn: [1, 2, 3]})
+        assert res["status"] == "error"
+        assert "must be a number" in res["content"][0]["text"]
+
+    def test_bad_value_rejected_even_for_unknown_joint(self, sim_with_robot):
+        """Input is validated up front, so a bad value fails fast regardless of
+        whether the joint resolves -- an unknown joint no longer masks nan/inf."""
+        res = sim_with_robot.set_joint_positions(positions={"ghost": float("inf")})
+        assert res["status"] == "error"
+        assert "finite" in res["content"][0]["text"]
+
+    def test_valid_numpy_scalar_positions_still_apply(self, sim_with_robot):
+        """A finite NumPy scalar is a valid value and must still be written."""
+        jn = self._first_joint(sim_with_robot)
+        res = sim_with_robot.set_joint_positions(positions={jn: np.float64(0.2)})
+        assert res["status"] == "success"
+        assert "1/1" in res["content"][0]["text"]
+
+
 # Policy-running guards
 
 


### PR DESCRIPTION
## Problem

`set_joint_positions` and `set_joint_velocities` wrote each value straight into `data.qpos` / `data.qvel` via `float(value)` with no validation:

- A `nan` / `inf` value landed directly in the state buffer while the tool still returned `status="success"`. `mj_forward` then propagates the `nan` across the entire kinematic tree (every body pose becomes `nan`), and an `inf` velocity blows up the integrator on the next `mj_step`.
- A non-numeric value (a string, a nested list, ...) raised `ValueError` / `TypeError` from `float()` **past** the structured-error dispatch contract, so the tool crashed instead of returning a clean error.

This is the same silent-corruption / contract-escape class already fixed for `set_gravity`, `set_body_properties` and `set_geom_properties`.

## Change

Validate every value up front via a shared `_coerce_finite_joint_map` helper: each must be a finite real number (Python or NumPy scalar). Invalid input now returns a structured `status="error"` and leaves `qpos` / `qvel` untouched, rather than corrupting the state or raising past dispatch. Validation runs before joint-name resolution, so a bad value fails fast even when the joint does not resolve. Valid values (including finite NumPy scalars) still apply. Docstrings on both methods document the contract.

## Tests

New `TestSetJointFiniteValidation` in `tests/simulation/mujoco/test_input_validation.py` (11 cases): `nan`/`inf`/`-inf` rejection for positions and velocities with `qpos`/`qvel` asserted untouched and finite, non-numeric values returning a structured error (not raising), list-form `nan` rejection, bad-value rejection for an unknown joint, and a finite-NumPy-scalar happy path. 10 of 11 fail on pre-fix code (the 11th is the preserved happy path). Full lint (ruff + mypy on `strands_robots tests tests_integ`) is clean; `tests/simulation/mujoco/test_input_validation.py` + `test_physics.py` pass (194).

## Visual proof

Headless MuJoCo (`MUJOCO_GL=egl`) render of a Panda posed via `set_joint_positions({...})` — the valid-pose happy path is preserved. A subsequent `set_joint_positions({joint4: nan})` returns `status=error` (`... must be finite (no nan/inf), got nan`) with `qpos` verified unchanged and all-finite.

![posed panda via set_joint_positions](https://github.com/cagataycali/robots/releases/download/joint-setter-finite-guard-artifacts/joint_guard_pose.png)