### PR TITLE
fix(sim): move_object validates pose is finite numbers before mutating state

### DIFF
--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -134,6 +134,41 @@ def _jnt_qpos_width(mj: Any, jnt_type: int) -> int:
     return 1
 
 
+def _validate_pose_vector(param_name: str, vec: Any, expected_len: int) -> str | None:
+    """Return an error message if ``vec`` is not ``expected_len`` finite numbers.
+
+    Guards ``move_object`` (and any caller writing a pose straight into
+    ``data.qpos``) against the two silent-corruption / contract-break classes
+    the numeric-input campaign targets:
+
+    * A wrong-length or non-numeric vector (e.g. ``["a", "b", "c"]`` or a
+      2-element position) otherwise raises a bare ``ValueError`` inside the
+      numpy assignment - escaping the structured ``{"status": "error"}``
+      tool-result contract.
+    * A ``nan``/``inf`` component is written verbatim into ``data.qpos`` and
+      then propagated through the whole physics state by ``mj_forward``,
+      reporting ``success`` while silently poisoning the simulation.
+
+    A numpy real scalar per element is accepted (``float(np.float64(...))``
+    succeeds), matching the "accept NumPy scalar components" behaviour of the
+    other sim setters. Returns ``None`` when ``vec`` is acceptable.
+    """
+    try:
+        length = len(vec)
+    except TypeError:
+        return f"move_object: '{param_name}' must be a list/tuple of {expected_len} numbers, got {vec!r}"
+    if length != expected_len:
+        return f"move_object: '{param_name}' must be a {expected_len}-element vector, got {length} ({vec!r})"
+    for _elem in vec:
+        try:
+            _f = float(_elem)
+        except (TypeError, ValueError):
+            return f"move_object: '{param_name}' elements must be numbers, got {vec!r}"
+        if not math.isfinite(_f):
+            return f"move_object: '{param_name}' must contain finite numbers (no nan/inf), got {vec!r}"
+    return None
+
+
 _TOOL_SPEC_PATH = Path(__file__).parent / "tool_spec.json"
 
 # Tool schema is 357 lines of JSON. `tool_spec` property is on the LLM hot path
@@ -2371,9 +2406,17 @@ class MuJoCoSimEngine(
           by editing the spec body pose and recompiling the scene (preserving
           other joints' state), just like ``add_object`` / ``remove_object``.
 
-        Returns ``status="error"`` if the object is unknown or the static-body
-        recompile fails - it never reports success without actually moving the
-        object.
+        ``position`` must be a 3-element vector and ``orientation`` a 4-element
+        wxyz quaternion; each must contain only finite real numbers (NumPy
+        scalars accepted). A wrong-length, non-numeric, or nan/inf pose is
+        rejected up front rather than raising a bare ``ValueError`` past the
+        tool-result contract or silently writing a non-finite value into
+        ``data.qpos`` (which ``mj_forward`` would propagate through the whole
+        physics state).
+
+        Returns ``status="error"`` if the object is unknown, the pose is
+        invalid, or the static-body recompile fails - it never reports success
+        without actually moving the object.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
@@ -2382,6 +2425,18 @@ class MuJoCoSimEngine(
         # Guard: move_object writes qpos + calls mj_forward, racing a running policy.
         if err := self._require_no_running_policy("move_object"):
             return err
+
+        # Validate the pose BEFORE mutating any state. Both the dynamic path
+        # (raw data.qpos write) and the static path (spec reposition) otherwise
+        # let a wrong-length / non-numeric vector raise a bare ValueError past
+        # the tool-result contract, or write a nan/inf straight into qpos where
+        # mj_forward silently poisons the whole physics state. Only validate a
+        # component that is actually supplied (None leaves it unchanged; the
+        # move logic below treats a falsy value as "no change").
+        if position and (perr := _validate_pose_vector("position", position, 3)) is not None:
+            return {"status": "error", "content": [{"text": perr}]}
+        if orientation and (oerr := _validate_pose_vector("orientation", orientation, 4)) is not None:
+            return {"status": "error", "content": [{"text": oerr}]}
 
         mj = self._mj
         model, data = self._world._model, self._world._data

--- a/tests/simulation/mujoco/test_move_object_pose_validation.py
+++ b/tests/simulation/mujoco/test_move_object_pose_validation.py
@@ -1,0 +1,114 @@
+"""Regression tests: ``move_object`` rejects a non-finite / malformed pose.
+
+``move_object`` moves a dynamic object by writing its ``[x, y, z, qw..qz]``
+slice straight into ``data.qpos`` (then a forward pass), and a static object by
+editing the spec body pose and recompiling. Neither path validated the caller's
+``position`` / ``orientation`` before mutating state, so two failure classes
+slipped through:
+
+* A ``nan`` / ``inf`` component was written verbatim into ``data.qpos``;
+  ``mj_forward`` then propagated the non-finite value across the whole physics
+  state while ``move_object`` still reported ``status="success"`` - a silent
+  corruption.
+* A non-numeric (``["a", "b", "c"]``) or wrong-length (``[1.0, 2.0]``) vector
+  raised a bare ``ValueError`` from inside the numpy assignment / broadcast,
+  escaping the structured ``{"status": "error"}`` tool-result contract.
+
+These pin the fix: an invalid pose is rejected up front with a structured error
+and leaves the simulation state finite, while a valid pose (including NumPy
+scalar components) still moves the object.
+"""
+
+import math
+
+import numpy as np
+import pytest
+
+mj = pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="test_move_object_pose_validation_sim", mesh=False)
+    s.create_world(gravity=[0, 0, -9.81])
+    s.add_object("cube", shape="box", size=[0.03, 0.03, 0.03], position=[0.0, 0.0, 0.5], is_static=False)
+    s.add_object("wall", shape="box", size=[0.1, 0.1, 0.1], position=[1.0, 0.0, 0.5], is_static=True)
+    yield s
+    s.cleanup()
+
+
+@pytest.mark.parametrize(
+    "position",
+    [
+        [float("nan"), 0.0, 0.5],
+        [0.0, float("inf"), 0.5],
+        [0.0, 0.0, -float("inf")],
+    ],
+)
+def test_move_object_rejects_nonfinite_position(sim, position):
+    """A nan/inf position is rejected and never poisons qpos.
+
+    Before the guard this returned ``success`` and left ``data.qpos`` holding
+    the non-finite value.
+    """
+    result = sim.move_object("cube", position=position)
+    assert result["status"] == "error", result
+    assert "finite" in result["content"][0]["text"]
+    assert np.all(np.isfinite(sim._world._data.qpos))
+
+
+def test_move_object_rejects_nonfinite_orientation(sim):
+    """A nan/inf quaternion component is rejected and qpos stays finite."""
+    result = sim.move_object("cube", orientation=[float("inf"), 0.0, 0.0, 0.0])
+    assert result["status"] == "error", result
+    assert "finite" in result["content"][0]["text"]
+    assert np.all(np.isfinite(sim._world._data.qpos))
+
+
+def test_move_object_rejects_nonnumeric_position(sim):
+    """A non-numeric vector returns a structured error, not a bare ValueError."""
+    result = sim.move_object("cube", position=["a", "b", "c"])
+    assert result["status"] == "error", result
+    assert "must be numbers" in result["content"][0]["text"]
+
+
+@pytest.mark.parametrize(
+    ("position", "orientation"),
+    [
+        ([1.0, 2.0], None),
+        ([1.0, 2.0, 3.0, 4.0], None),
+        (None, [1.0, 0.0, 0.0]),
+        (None, [1.0, 0.0, 0.0, 0.0, 0.0]),
+    ],
+)
+def test_move_object_rejects_wrong_length(sim, position, orientation):
+    """A wrong-length position (!=3) or orientation (!=4) is a structured error."""
+    result = sim.move_object("cube", position=position, orientation=orientation)
+    assert result["status"] == "error", result
+    assert "element vector" in result["content"][0]["text"]
+
+
+def test_move_object_rejects_nonfinite_position_static_object(sim):
+    """The static-object reposition path is guarded too (no spec mutation)."""
+    result = sim.move_object("wall", position=[1.0, float("nan"), 0.5])
+    assert result["status"] == "error", result
+    assert "finite" in result["content"][0]["text"]
+    assert np.all(np.isfinite(sim._world._data.qpos))
+    # State untouched: the wall is still at its spawn position.
+    assert sim._world.objects["wall"].position == [1.0, 0.0, 0.5]
+
+
+def test_move_object_accepts_valid_pose_with_numpy_scalars(sim):
+    """A valid pose still succeeds, and NumPy scalar components are accepted."""
+    quat = [math.cos(math.pi / 4), 0.0, 0.0, math.sin(math.pi / 4)]
+    result = sim.move_object(
+        "cube",
+        position=[np.float64(0.2), np.float32(0.0), 0.6],
+        orientation=quat,
+    )
+    assert result["status"] == "success", result
+    assert np.all(np.isfinite(sim._world._data.qpos))
+    bid = mj.mj_name2id(sim._world._model, mj.mjtObj.mjOBJ_BODY, "cube")
+    assert [float(x) for x in sim._world._data.xpos[bid]] == pytest.approx([0.2, 0.0, 0.6], abs=1e-6)


### PR DESCRIPTION
## Problem
`move_object` was the last scene-mutation entry point that wrote a caller-supplied pose without validating it. It moves a **dynamic** object by writing its `[x, y, z, qw, qx, qy, qz]` freejoint slice straight into `data.qpos` (then a `mj_forward`), and a **static** object by editing the spec body pose and recompiling. Neither path checked `position` / `orientation` first, so two failure classes slipped through:

- A `nan` / `inf` component was written verbatim into `data.qpos`; `mj_forward` then propagated the non-finite value across the whole physics state while `move_object` still returned `status="success"` — a silent corruption that only surfaces later as `nan` observations/rewards.
- A non-numeric (`["a", "b", "c"]`) or wrong-length (`[1.0, 2.0]`) vector raised a bare `ValueError` from inside the numpy assignment / broadcast, escaping the structured `{"status": "error"}` tool-result contract.

Reproduced on both paths before the fix:

```
sim.move_object("cube", position=[float("nan"), 0, 0.5])   # -> status="success", qpos now non-finite
sim.move_object("cube", position=["a", "b", "c"])          # -> ValueError: could not convert string to float: 'a'
sim.move_object("cube", position=[1.0, 2.0])               # -> ValueError: could not broadcast (2,) into (3,)
```

## Change
Validate the pose up front (before mutating any state), mirroring `apply_force` and the other sim numeric guards:

- `position` must be a 3-element vector, `orientation` a 4-element wxyz quaternion.
- Every component must be a finite real number; NumPy scalar components are accepted (`float(np.float64(...))` succeeds), matching the "accept NumPy scalar" behaviour of the other setters.
- An invalid pose returns a structured `{"status": "error", ...}` and leaves the simulation state untouched and finite.

Both the dynamic (`data.qpos`) and static (spec reposition) paths are guarded by the single up-front check. Valid moves — including NumPy scalar components — are unchanged.

## Tests
`tests/simulation/mujoco/test_move_object_pose_validation.py` (11 cases): nan/inf position (dynamic + static), nan/inf orientation, non-numeric vector, wrong-length position/orientation, and a valid move with NumPy scalar components. 10 of the 11 fail on pre-fix `main` (bare `ValueError` or `success` + non-finite `qpos`); all pass after. Full `tests/simulation/mujoco/` suite green (1314 passed); `ruff` + `mypy` clean over `strands_robots tests tests_integ`.

## Visual
Headless MuJoCo (EGL) before/after render — a dynamic cube and a static wall repositioned by valid `move_object` calls, with the invalid poses above rejected in between (state stays finite):

![move_object before/after](https://github.com/cagataycali/robots/releases/download/move-object-pose-validation-artifacts/move_object_demo.png)
