### PR TITLE
fix(sim): add_camera rejects non-finite/non-numeric position/target components

### DIFF
--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -2544,7 +2544,11 @@ class MuJoCoSimEngine(
         mount points before placing a camera; robot bodies are namespaced
         ``<robot>/<body>`` (e.g. ``so101/gripper`` is the SO101 wrist mount).
 
-        Validation: ``fov`` must be a finite angle in ``(0, 180)`` degrees and
+        Validation: ``position`` and ``target`` must each be 3-element vectors
+        of finite real numbers (NumPy scalars are accepted); a nan/inf or
+        non-numeric component is rejected here rather than corrupting the
+        camera's look-direction basis or escaping the structured-error
+        contract. ``fov`` must be a finite angle in ``(0, 180)`` degrees and
         ``width``/``height`` must be positive ints within the offscreen
         framebuffer cap (same bounds ``render`` enforces). Invalid values are
         rejected here at config time with an actionable error rather than
@@ -2555,10 +2559,17 @@ class MuJoCoSimEngine(
         if err := self._require_no_running_policy("add_camera"):
             return err
 
-        # validate position / target shape before we bake them into XML.
-        pos = position or [1.0, 1.0, 1.0]
-        tgt = target or [0.0, 0.0, 0.0]
-        for _lbl, _vec in (("position", pos), ("target", tgt)):
+        # Validate position / target shape AND elements before we bake them
+        # into XML. Each must be a 3-element vector of finite real numbers.
+        # Without the element check a non-numeric element (e.g. ["a","b","c"])
+        # raises TypeError inside the degenerate-look comparison below --
+        # escaping the structured-error contract -- and a nan/inf component
+        # slips silently into the camera's xyaxes basis (a 0/0 division),
+        # registering a broken camera that renders nothing. Mirrors the
+        # per-element guard on apply_force. Coerce to clean float lists so the
+        # downstream look-direction check and SimCamera see plain floats.
+        _clean: dict[str, list[float]] = {}
+        for _lbl, _vec in (("position", position or [1.0, 1.0, 1.0]), ("target", target or [0.0, 0.0, 0.0])):
             try:
                 if len(_vec) != 3:
                     return {
@@ -2567,6 +2578,26 @@ class MuJoCoSimEngine(
                     }
             except TypeError:
                 return {"status": "error", "content": [{"text": f"add_camera: '{_lbl}' must be a list of 3 numbers"}]}
+            _vals: list[float] = []
+            for _elem in _vec:
+                try:
+                    _f = float(_elem)
+                except (TypeError, ValueError):
+                    return {
+                        "status": "error",
+                        "content": [{"text": f"add_camera: '{_lbl}' elements must be numbers, got {_vec!r}"}],
+                    }
+                if not math.isfinite(_f):
+                    return {
+                        "status": "error",
+                        "content": [
+                            {"text": f"add_camera: '{_lbl}' must contain finite numbers (no nan/inf), got {_vec!r}"}
+                        ],
+                    }
+                _vals.append(_f)
+            _clean[_lbl] = _vals
+        pos = _clean["position"]
+        tgt = _clean["target"]
         # Degenerate orientation: position == target means no well-defined look direction.
         if all(abs(pos[i] - tgt[i]) < 1e-9 for i in range(3)):
             return {

--- a/tests/simulation/mujoco/test_input_validation.py
+++ b/tests/simulation/mujoco/test_input_validation.py
@@ -819,6 +819,63 @@ class TestAddCameraParamValidation:
         assert "good" in sim_with_world._world.cameras
 
 
+class TestAddCameraPositionTargetValidation:
+    """add_camera validates position/target elements are finite real numbers.
+
+    Pre-fix, add_camera only checked that position/target were 3-element
+    vectors, not that each element was a finite number. A non-numeric element
+    (e.g. ["a", "b", "c"]) raised TypeError inside the degenerate-look
+    comparison -- escaping the structured-error tool contract -- and a nan/inf
+    component passed the length check and slipped silently into the camera's
+    xyaxes look-direction basis (a 0/0 division), registering a broken camera
+    that renders nothing. These pin the per-element guard, mirroring
+    apply_force, and confirm NumPy scalar components are still accepted.
+    """
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"position": ["a", "b", "c"], "target": [0.0, 0.0, 1.0]},
+            {"position": [0.5, 0.0, 0.3], "target": ["x", "y", "z"]},
+            # nested lists are length-3 but not scalar numbers.
+            {"position": [[1], 2, 3], "target": [0.0, 0.0, 1.0]},
+            # None is neither a number nor coercible.
+            {"position": [1.0, None, 3.0], "target": [0.0, 0.0, 1.0]},
+        ],
+    )
+    def test_non_numeric_elements_error(self, sim_with_world, kwargs):
+        res = sim_with_world.add_camera(name="bad", **kwargs)
+        assert res["status"] == "error"
+        assert "must be numbers" in res["content"][0]["text"]
+        assert "bad" not in sim_with_world._world.cameras
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"position": [float("nan"), 0.0, 0.3], "target": [0.0, 0.0, 1.0]},
+            {"position": [float("inf"), 0.0, 0.3], "target": [0.0, 0.0, 1.0]},
+            {"position": [0.5, 0.0, 0.3], "target": [float("-inf"), 0.0, 0.0]},
+            {"position": [0.5, 0.0, 0.3], "target": [0.0, float("nan"), 0.0]},
+        ],
+    )
+    def test_non_finite_elements_error(self, sim_with_world, kwargs):
+        res = sim_with_world.add_camera(name="bad", **kwargs)
+        assert res["status"] == "error"
+        assert "finite numbers" in res["content"][0]["text"]
+        assert "bad" not in sim_with_world._world.cameras
+
+    def test_numpy_scalar_components_accepted(self, sim_with_world):
+        # Components read from a config array arrive as NumPy scalars; they are
+        # finite real numbers and must be accepted like plain floats.
+        res = sim_with_world.add_camera(
+            name="npc",
+            position=[np.float32(0.5), np.float64(0.0), np.int64(1)],
+            target=[0.0, 0.0, 0.0],
+        )
+        assert res["status"] == "success", res["content"][0]["text"]
+        assert "npc" in sim_with_world._world.cameras
+
+
 # send_action ordered-vector normalization
 
 


### PR DESCRIPTION
## Problem

`add_camera` validated that `position`/`target` were 3-element vectors but never checked that each *component* was a finite real number. Two failure modes slipped through the shape-only guard:

- **Non-numeric element escapes the tool contract.** `add_camera(name="c", position=["a", "b", "c"], target=[0, 0, 1])` raised `TypeError: unsupported operand type(s) for -: 'str' and 'float'` inside the degenerate-look comparison (`abs(pos[i] - tgt[i])`), instead of returning the structured `{"status": "error", ...}` dict every other add_camera rejection returns.
- **nan/inf silently registers a broken camera.** `add_camera(name="c", position=[float("nan"), 0, 0], target=[0, 0, 1])` passed the length check and was baked into the camera's `xyaxes` look-direction basis, where normalizing the forward vector divides by a nan/zero length (`RuntimeWarning: invalid value encountered in divide`). The call returned `status=success` and left a camera that renders nothing useful.

This is the same class of gap already closed on `apply_force`, `set_gravity`, `set_body_properties`, the joint setters, and `move_object`: sized-vector setters must reject non-finite/non-numeric components at config time.

## Change

Validate each `position`/`target` component up front (float-coercible and `math.isfinite`), returning an actionable structured error, and coerce to clean `float` lists so the downstream look-direction check and `SimCamera` see plain floats. This mirrors the per-element guard on `apply_force`. NumPy scalar components (e.g. `np.float32`/`np.int64` read from a config array) remain accepted as finite reals. Docstring updated to document the contract.

## Tests

New `TestAddCameraPositionTargetValidation` in `tests/simulation/mujoco/test_input_validation.py`:

- Non-numeric components (`str`, nested list, `None`) -> structured `error` containing `must be numbers` (pre-fix: `TypeError` or silent success).
- nan/inf in `position` or `target` -> structured `error` containing `finite numbers` (pre-fix: silent `success` + corrupt basis).
- NumPy scalar components still accepted (`success`).

Against pre-fix production these fail 8/9 (the numpy-happy case passes both); post-fix all 9 pass. Full `tests/simulation/mujoco/test_input_validation.py` (120 tests) green; `mypy strands_robots tests tests_integ` and `ruff` clean.

## Visual proof

Render still from a camera added via `add_camera(target=...)` (so100, MuJoCo headless, `MUJOCO_GL=egl`), confirming the guarded happy path still produces a valid view:

![add_camera render still](https://github.com/cagataycali/robots/releases/download/add-camera-position-target-finite-artifacts/add_camera_still.png)