### PR TITLE
fix(sim): add_object/add_camera reject a non-finite/malformed numeric vector before baking it into the MJCF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2042,6 +2042,33 @@ The guard now rejects any non-finite value (`not math.isfinite(mass) or mass
 enforced by `set_timestep` and `set_gravity`. Finite positive masses (including
 NumPy scalars, which `float()` still coerces) are unaffected.
 
+### Fixed: `add_object` / `add_camera` reject a non-finite / malformed numeric vector instead of baking it into the MJCF
+
+Both are scene-construction methods that write caller-supplied numeric vectors
+into the compiled MuJoCo model, but neither validated those vectors' contents,
+so two failure classes slipped through:
+
+* `add_object` wrote a `nan` / `inf` `position` or `orientation` verbatim into
+  the object's freejoint `qpos`; `mj_forward` then propagated the non-finite
+  value across the whole physics state while `add_object` still reported
+  `status="success"` -- a silent corruption. A `nan` `size` aborted the
+  recompile with a cryptic "spec recompile refused", and a non-numeric `color`
+  / `size` (e.g. `["r", "g", "b", "a"]`) raised a bare `TypeError` from inside
+  MuJoCo's `add_geom` / the `size <= 0` comparison -- escaping the structured
+  `{"status": "error"}` tool-result contract.
+* `add_camera` baked a `nan` / `inf` `position` / `target` into the camera's
+  `xyaxes` (`fwd /= flen` divides by NaN), silently registering a degenerate
+  camera that renders garbage while reporting `status="success"`; a non-numeric
+  element raised a bare `TypeError` from the degenerate-orientation
+  `abs(pos[i] - tgt[i])` comparison.
+
+Both methods now validate every caller-supplied numeric vector up front
+(finite, numeric, and -- for `position` / `orientation` / `target` -- the
+expected length) and return an actionable structured error, leaving the
+simulation state finite and the entity unregistered. NumPy scalar components
+are accepted, matching the finiteness contract already enforced by
+`move_object`, `set_geom_properties`, `set_gravity` and `add_camera`'s `fov`.
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -134,39 +134,62 @@ def _jnt_qpos_width(mj: Any, jnt_type: int) -> int:
     return 1
 
 
-def _validate_pose_vector(param_name: str, vec: Any, expected_len: int) -> str | None:
-    """Return an error message if ``vec`` is not ``expected_len`` finite numbers.
+def _validate_finite_vector(method: str, param_name: str, vec: Any) -> str | None:
+    """Return an error message if any element of ``vec`` is not a finite number.
 
-    Guards ``move_object`` (and any caller writing a pose straight into
-    ``data.qpos``) against the two silent-corruption / contract-break classes
-    the numeric-input campaign targets:
+    Guards the numeric vectors a scene-construction call bakes into the
+    compiled MJCF (``add_object`` color/size, ``add_camera`` position/target,
+    etc.) against the two classes the numeric-input campaign targets:
 
-    * A wrong-length or non-numeric vector (e.g. ``["a", "b", "c"]`` or a
-      2-element position) otherwise raises a bare ``ValueError`` inside the
-      numpy assignment - escaping the structured ``{"status": "error"}``
-      tool-result contract.
-    * A ``nan``/``inf`` component is written verbatim into ``data.qpos`` and
-      then propagated through the whole physics state by ``mj_forward``,
-      reporting ``success`` while silently poisoning the simulation.
+    * A non-numeric or non-iterable element (e.g. ``["a", "b", "c"]`` or a
+      nested list) otherwise raises a bare ``TypeError``/``ValueError`` deep
+      inside MuJoCo's ``add_geom`` or a ``size <= 0`` comparison - escaping the
+      structured ``{"status": "error"}`` tool-result contract.
+    * A ``nan``/``inf`` component is baked verbatim into the geom/camera and
+      either poisons the physics state on the next ``mj_forward`` or aborts the
+      spec recompile with a cryptic "spec recompile refused", reporting a
+      success/garbage result instead of an actionable error.
 
     A numpy real scalar per element is accepted (``float(np.float64(...))``
     succeeds), matching the "accept NumPy scalar components" behaviour of the
-    other sim setters. Returns ``None`` when ``vec`` is acceptable.
+    other sim setters. Length is NOT checked here (color is 3-or-4, size is
+    shape-dependent); use :func:`_validate_pose_vector` for a fixed length.
+    Returns ``None`` when every element is a finite real number.
     """
     try:
-        length = len(vec)
+        iter(vec)
     except TypeError:
-        return f"move_object: '{param_name}' must be a list/tuple of {expected_len} numbers, got {vec!r}"
-    if length != expected_len:
-        return f"move_object: '{param_name}' must be a {expected_len}-element vector, got {length} ({vec!r})"
+        return f"{method}: '{param_name}' must be a list/tuple of numbers, got {vec!r}"
     for _elem in vec:
         try:
             _f = float(_elem)
         except (TypeError, ValueError):
-            return f"move_object: '{param_name}' elements must be numbers, got {vec!r}"
+            return f"{method}: '{param_name}' elements must be numbers, got {vec!r}"
         if not math.isfinite(_f):
-            return f"move_object: '{param_name}' must contain finite numbers (no nan/inf), got {vec!r}"
+            return f"{method}: '{param_name}' must contain finite numbers (no nan/inf), got {vec!r}"
     return None
+
+
+def _validate_pose_vector(method: str, param_name: str, vec: Any, expected_len: int) -> str | None:
+    """Return an error message if ``vec`` is not ``expected_len`` finite numbers.
+
+    Fixed-length wrapper over :func:`_validate_finite_vector` for the pose
+    vectors written straight into ``data.qpos`` (``move_object`` /
+    ``add_object`` position+orientation, ``add_camera`` position+target). A
+    wrong-length vector otherwise raises a bare ``ValueError`` inside the numpy
+    assignment - escaping the structured ``{"status": "error"}`` tool-result
+    contract - and a ``nan``/``inf`` component is propagated through the whole
+    physics state by ``mj_forward``, reporting ``success`` while silently
+    poisoning the simulation. A numpy real scalar per element is accepted.
+    Returns ``None`` when ``vec`` is acceptable.
+    """
+    try:
+        length = len(vec)
+    except TypeError:
+        return f"{method}: '{param_name}' must be a list/tuple of {expected_len} numbers, got {vec!r}"
+    if length != expected_len:
+        return f"{method}: '{param_name}' must be a {expected_len}-element vector, got {length} ({vec!r})"
+    return _validate_finite_vector(method, param_name, vec)
 
 
 _TOOL_SPEC_PATH = Path(__file__).parent / "tool_spec.json"
@@ -2276,7 +2299,10 @@ class MuJoCoSimEngine(
         Returns:
             Agent-tool status dict. ``{"status": "success", ...}`` on success;
             ``{"status": "error", ...}`` when no world exists, a policy is
-            running, the name is taken, ``size`` has a non-positive extent,
+            running, the name is taken, ``position``/``orientation``/``color``/
+            ``size`` contains a non-finite (``nan``/``inf``) or non-numeric
+            element or ``position``/``orientation`` is the wrong length (3 / 4),
+            ``size`` has a non-positive extent,
             ``shape="mesh"`` is missing ``mesh_path``, or the recompile fails.
 
         Example:
@@ -2325,6 +2351,27 @@ class MuJoCoSimEngine(
                 "status": "error",
                 "content": [{"text": "add_object: shape='mesh' requires mesh_path (path to an STL/OBJ asset)."}],
             }
+
+        # Validate every caller-supplied numeric vector is finite BEFORE we bake
+        # it into the compiled MJCF. Without this: a nan/inf position or
+        # orientation is written verbatim into the object's freejoint qpos and
+        # mj_forward then propagates it through the whole physics state
+        # (reporting success while silently poisoning the sim); a nan/inf size
+        # aborts the recompile with a cryptic "spec recompile refused"; and a
+        # non-numeric element (e.g. ["a", ...]) raises a bare TypeError inside
+        # MuJoCo's add_geom or the size <= 0 comparison, escaping the
+        # structured-error contract. NumPy scalar components are accepted.
+        if position is not None and (e := _validate_pose_vector("add_object", "position", position, 3)) is not None:
+            return {"status": "error", "content": [{"text": e}]}
+        if (
+            orientation is not None
+            and (e := _validate_pose_vector("add_object", "orientation", orientation, 4)) is not None
+        ):
+            return {"status": "error", "content": [{"text": e}]}
+        if color is not None and (e := _validate_finite_vector("add_object", "color", color)) is not None:
+            return {"status": "error", "content": [{"text": e}]}
+        if size is not None and (e := _validate_finite_vector("add_object", "size", size)) is not None:
+            return {"status": "error", "content": [{"text": e}]}
 
         # 'size' is the full extent in meters per the docstring; reject a
         # non-positive (degenerate) extent before mutating scene state so the
@@ -2433,9 +2480,9 @@ class MuJoCoSimEngine(
         # mj_forward silently poisons the whole physics state. Only validate a
         # component that is actually supplied (None leaves it unchanged; the
         # move logic below treats a falsy value as "no change").
-        if position and (perr := _validate_pose_vector("position", position, 3)) is not None:
+        if position and (perr := _validate_pose_vector("move_object", "position", position, 3)) is not None:
             return {"status": "error", "content": [{"text": perr}]}
-        if orientation and (oerr := _validate_pose_vector("orientation", orientation, 4)) is not None:
+        if orientation and (oerr := _validate_pose_vector("move_object", "orientation", orientation, 4)) is not None:
             return {"status": "error", "content": [{"text": oerr}]}
 
         mj = self._mj
@@ -2544,60 +2591,32 @@ class MuJoCoSimEngine(
         mount points before placing a camera; robot bodies are namespaced
         ``<robot>/<body>`` (e.g. ``so101/gripper`` is the SO101 wrist mount).
 
-        Validation: ``position`` and ``target`` must each be 3-element vectors
-        of finite real numbers (NumPy scalars are accepted); a nan/inf or
-        non-numeric component is rejected here rather than corrupting the
-        camera's look-direction basis or escaping the structured-error
-        contract. ``fov`` must be a finite angle in ``(0, 180)`` degrees and
-        ``width``/``height`` must be positive ints within the offscreen
-        framebuffer cap (same bounds ``render`` enforces). Invalid values are
-        rejected here at config time with an actionable error rather than
-        deferring a cryptic spec-recompile or GL failure to the first render.
+        Validation: ``position`` and ``target`` must each be 3 finite numbers
+        (NumPy scalars accepted); ``fov`` must be a finite angle in ``(0, 180)``
+        degrees; and ``width``/``height`` must be positive ints within the
+        offscreen framebuffer cap (same bounds ``render`` enforces). Invalid
+        values are rejected here at config time with an actionable error rather
+        than deferring an uncaught ``TypeError`` (non-numeric), a silently
+        degenerate camera (``nan``/``inf`` baked into ``xyaxes``), or a cryptic
+        spec-recompile / GL failure to the first render.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         if err := self._require_no_running_policy("add_camera"):
             return err
 
-        # Validate position / target shape AND elements before we bake them
-        # into XML. Each must be a 3-element vector of finite real numbers.
-        # Without the element check a non-numeric element (e.g. ["a","b","c"])
-        # raises TypeError inside the degenerate-look comparison below --
-        # escaping the structured-error contract -- and a nan/inf component
-        # slips silently into the camera's xyaxes basis (a 0/0 division),
-        # registering a broken camera that renders nothing. Mirrors the
-        # per-element guard on apply_force. Coerce to clean float lists so the
-        # downstream look-direction check and SimCamera see plain floats.
-        _clean: dict[str, list[float]] = {}
-        for _lbl, _vec in (("position", position or [1.0, 1.0, 1.0]), ("target", target or [0.0, 0.0, 0.0])):
-            try:
-                if len(_vec) != 3:
-                    return {
-                        "status": "error",
-                        "content": [{"text": f"add_camera: '{_lbl}' must be 3 elements [x,y,z], got {len(_vec)}"}],
-                    }
-            except TypeError:
-                return {"status": "error", "content": [{"text": f"add_camera: '{_lbl}' must be a list of 3 numbers"}]}
-            _vals: list[float] = []
-            for _elem in _vec:
-                try:
-                    _f = float(_elem)
-                except (TypeError, ValueError):
-                    return {
-                        "status": "error",
-                        "content": [{"text": f"add_camera: '{_lbl}' elements must be numbers, got {_vec!r}"}],
-                    }
-                if not math.isfinite(_f):
-                    return {
-                        "status": "error",
-                        "content": [
-                            {"text": f"add_camera: '{_lbl}' must contain finite numbers (no nan/inf), got {_vec!r}"}
-                        ],
-                    }
-                _vals.append(_f)
-            _clean[_lbl] = _vals
-        pos = _clean["position"]
-        tgt = _clean["target"]
+        # validate position / target shape before we bake them into XML.
+        pos = position or [1.0, 1.0, 1.0]
+        tgt = target or [0.0, 0.0, 0.0]
+        for _lbl, _vec in (("position", pos), ("target", tgt)):
+            # Validate shape AND finiteness up front. The degenerate-orientation
+            # check below does ``abs(pos[i] - tgt[i])`` element-wise, so a
+            # non-numeric element (e.g. ["a", ...]) would otherwise raise a bare
+            # TypeError there, and a nan/inf slips silently into the camera's
+            # baked xyaxes (fwd /= flen divides by nan -> a degenerate camera
+            # that renders garbage while reporting success). NumPy scalars ok.
+            if (e := _validate_pose_vector("add_camera", _lbl, _vec, 3)) is not None:
+                return {"status": "error", "content": [{"text": e}]}
         # Degenerate orientation: position == target means no well-defined look direction.
         if all(abs(pos[i] - tgt[i]) < 1e-9 for i in range(3)):
             return {

--- a/tests/simulation/mujoco/test_add_object_camera_vector_validation.py
+++ b/tests/simulation/mujoco/test_add_object_camera_vector_validation.py
@@ -1,0 +1,171 @@
+"""Regression tests: ``add_object`` / ``add_camera`` reject non-finite / malformed vectors.
+
+Both are scene-construction methods that bake caller-supplied numeric vectors
+into the compiled MJCF. Neither validated those vectors' contents before doing
+so, letting the two failure classes the numeric-input campaign targets slip
+through:
+
+* ``add_object`` wrote a ``nan`` / ``inf`` ``position`` / ``orientation``
+  verbatim into the object's freejoint ``qpos``; ``mj_forward`` then propagated
+  the non-finite value across the whole physics state while ``add_object`` still
+  reported ``status="success"``. A ``nan`` ``size`` aborted the recompile with a
+  cryptic "spec recompile refused", and a non-numeric ``color`` / ``size``
+  raised a bare ``TypeError`` from inside MuJoCo's ``add_geom`` / the
+  ``size <= 0`` comparison - escaping the structured ``{"status": "error"}``
+  tool-result contract.
+* ``add_camera`` baked a ``nan`` / ``inf`` ``position`` / ``target`` into the
+  camera's ``xyaxes`` (``fwd /= flen`` divides by ``nan`` -> a silently
+  degenerate camera that renders garbage while reporting ``success``), and a
+  non-numeric element raised a bare ``TypeError`` from the degenerate-orientation
+  ``abs(pos[i] - tgt[i])`` comparison.
+
+These pin the fix: an invalid vector is rejected up front with a structured
+error and leaves the simulation state finite / the entity unregistered, while a
+valid vector (including NumPy scalar components) still adds the object/camera.
+"""
+
+import numpy as np
+import pytest
+
+mj = pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="test_add_vector_validation_sim", mesh=False)
+    s.create_world(gravity=[0, 0, -9.81])
+    yield s
+    s.cleanup()
+
+
+# --------------------------------------------------------------------------- #
+# add_object                                                                  #
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    ("kwargs", "expect"),
+    [
+        ({"position": [float("nan"), 0.0, 0.03]}, "finite"),
+        ({"position": [0.0, float("inf"), 0.03]}, "finite"),
+        ({"orientation": [1.0, 0.0, float("inf"), 0.0]}, "finite"),
+        ({"color": [float("nan"), 0.0, 0.0, 1.0]}, "finite"),
+        ({"size": [float("nan"), 0.05, 0.05]}, "finite"),
+    ],
+)
+def test_add_object_rejects_nonfinite(sim, kwargs, expect):
+    """A nan/inf vector is rejected, the object is not added, and qpos stays finite.
+
+    Before the guard, nan/inf position/orientation returned ``success`` and
+    poisoned ``data.qpos``; a nan size aborted with a cryptic recompile error.
+    """
+    result = sim.add_object("bad", shape="box", **kwargs)
+    assert result["status"] == "error", result
+    assert expect in result["content"][0]["text"]
+    assert "bad" not in sim._world.objects
+    assert np.all(np.isfinite(sim._world._data.qpos))
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expect"),
+    [
+        ({"position": ["a", "b", "c"]}, "must be numbers"),
+        ({"color": ["r", "g", "b", "a"]}, "must be numbers"),
+        ({"size": ["a", 0.05, 0.05]}, "must be numbers"),
+        ({"position": [[1], [2], [3]]}, "must be numbers"),
+    ],
+)
+def test_add_object_rejects_nonnumeric(sim, kwargs, expect):
+    """A non-numeric element returns a structured error, not a bare TypeError."""
+    result = sim.add_object("bad", shape="box", **kwargs)
+    assert result["status"] == "error", result
+    assert expect in result["content"][0]["text"]
+    assert "bad" not in sim._world.objects
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"position": [1.0, 2.0]},
+        {"position": [1.0, 2.0, 3.0, 4.0]},
+        {"orientation": [1.0, 0.0, 0.0]},
+        {"orientation": [1.0, 0.0, 0.0, 0.0, 0.0]},
+    ],
+)
+def test_add_object_rejects_wrong_length_pose(sim, kwargs):
+    """A wrong-length position (!=3) / orientation (!=4) is a structured error."""
+    result = sim.add_object("bad", shape="box", **kwargs)
+    assert result["status"] == "error", result
+    assert "element vector" in result["content"][0]["text"]
+    assert "bad" not in sim._world.objects
+
+
+def test_add_object_accepts_valid_vectors_with_numpy_scalars(sim):
+    """A valid object still adds, and NumPy scalar components are accepted."""
+    result = sim.add_object(
+        "cube",
+        shape="box",
+        position=[np.float64(0.2), np.float32(0.0), 0.03],
+        orientation=[1.0, 0.0, 0.0, 0.0],
+        color=[np.float32(1.0), 0.0, 0.0, 1.0],
+        size=[np.float64(0.05), 0.05, 0.05],
+    )
+    assert result["status"] == "success", result
+    assert "cube" in sim._world.objects
+    assert np.all(np.isfinite(sim._world._data.qpos))
+
+
+# --------------------------------------------------------------------------- #
+# add_camera                                                                  #
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    ("position", "target"),
+    [
+        ([float("nan"), 0.0, 0.3], [0.2, 0.0, 0.05]),
+        ([0.5, 0.0, 0.3], [float("inf"), 0.0, 0.05]),
+    ],
+)
+def test_add_camera_rejects_nonfinite(sim, position, target):
+    """A nan/inf position/target is rejected and the camera is not registered.
+
+    Before the guard this returned ``success`` and baked a degenerate camera
+    (nan xyaxes) that rendered garbage.
+    """
+    result = sim.add_camera("bad", position=position, target=target)
+    assert result["status"] == "error", result
+    assert "finite" in result["content"][0]["text"]
+    assert "bad" not in sim._world.cameras
+
+
+@pytest.mark.parametrize(
+    ("position", "target"),
+    [
+        (["a", "b", "c"], [0.2, 0.0, 0.05]),
+        ([[1], [2], [3]], [0.2, 0.0, 0.05]),
+    ],
+)
+def test_add_camera_rejects_nonnumeric(sim, position, target):
+    """A non-numeric element returns a structured error, not a bare TypeError."""
+    result = sim.add_camera("bad", position=position, target=target)
+    assert result["status"] == "error", result
+    assert "must be numbers" in result["content"][0]["text"]
+    assert "bad" not in sim._world.cameras
+
+
+def test_add_camera_rejects_wrong_length(sim):
+    """A non-3 position/target is a structured error."""
+    result = sim.add_camera("bad", position=[0.5, 0.3], target=[0.2, 0.0, 0.05])
+    assert result["status"] == "error", result
+    assert "element vector" in result["content"][0]["text"]
+    assert "bad" not in sim._world.cameras
+
+
+def test_add_camera_accepts_valid_vectors_with_numpy_scalars(sim):
+    """A valid camera still registers, and NumPy scalar components are accepted."""
+    result = sim.add_camera(
+        "front",
+        position=[np.float32(0.55), np.float64(0.0), 0.35],
+        target=[0.2, 0.0, 0.05],
+    )
+    assert result["status"] == "success", result
+    assert "front" in sim._world.cameras

--- a/tests/simulation/mujoco/test_input_validation.py
+++ b/tests/simulation/mujoco/test_input_validation.py
@@ -646,7 +646,7 @@ class TestAddCameraTargetOrients:
         try:
             res = sim.add_camera(name="bad_cam", position=[1, 2], target=[0, 0, 0])
             assert res["status"] == "error"
-            assert "3 elements" in res["content"][0]["text"]
+            assert "3-element" in res["content"][0]["text"]
         finally:
             sim.destroy()
 

--- a/tests/simulation/mujoco/test_setter_input_type_validation.py
+++ b/tests/simulation/mujoco/test_setter_input_type_validation.py
@@ -53,7 +53,7 @@ class TestSetterInputTypeValidation:
         branch of the shape check rather than raising to the caller."""
         res = sim_with_world.add_camera(name="cam", position=5)
         assert res["status"] == "error"
-        assert "list of 3 numbers" in res["content"][0]["text"]
+        assert "list/tuple of 3 numbers" in res["content"][0]["text"]
 
 
 class TestSetGravityNumpyScalar:


### PR DESCRIPTION
## Problem

`add_object` and `add_camera` are scene-construction methods that write caller-supplied numeric vectors into the compiled MuJoCo model, but neither validated those vectors' contents. Two failure classes slipped through — the same ones the recent numeric-input hardening closed for `move_object` (#1427), `set_geom_properties` (#1425) and `add_camera`'s own `fov` (#1417):

**`add_object`**
- A `nan`/`inf` `position` or `orientation` was written verbatim into the object's freejoint `qpos`; the next `mj_forward` then propagated the non-finite value across the whole physics state, while `add_object` still reported `status="success"` — a silent corruption.
- A `nan`/`inf` `size` aborted the recompile with a cryptic `"spec recompile refused"`.
- A non-numeric `color`/`size` (e.g. `["r","g","b","a"]`) raised a bare `TypeError` from inside MuJoCo's `add_geom` / the `size <= 0` comparison, escaping the structured `{"status": "error"}` tool-result contract.

**`add_camera`**
- A `nan`/`inf` `position`/`target` was baked into the camera's `xyaxes` (`fwd /= flen` divides by NaN), silently registering a degenerate camera that renders garbage while reporting `status="success"`.
- A non-numeric element raised a bare `TypeError` from the degenerate-orientation `abs(pos[i] - tgt[i])` comparison.

Reproduced on a real MuJoCo sim (`add_object(position=[nan,0,0.03])` → `success`; `add_camera(position=["a","b","c"])` → uncaught `TypeError`).

## Change

Generalize the existing `_validate_pose_vector` helper (from #1427) to take a method-name prefix and extract a no-length `_validate_finite_vector` sibling, then route both methods' numeric vectors through them:

- `add_object`: `position` (3), `orientation` (4), `color` (finite), `size` (finite, before the existing `_validate_size` positivity check).
- `add_camera`: `position`/`target` (3) — replacing the shape-only loop, so the subsequent degenerate-orientation check is safe.

Invalid vectors are now rejected up front with an actionable structured error, leaving the simulation state finite and the entity unregistered. NumPy scalar components are accepted, matching the finiteness contract already enforced by `move_object`, `set_geom_properties`, `set_gravity` and `add_camera`'s `fov`.

## Tests

New `tests/simulation/mujoco/test_add_object_camera_vector_validation.py` (20 cases, GL-free) pins: nan/inf rejected + state stays finite + entity unregistered; non-numeric → structured error (no bare `TypeError`); wrong-length pose rejected; valid vectors (incl. NumPy scalars) still succeed. Two existing `add_camera` assertions updated to the (strictly more actionable) shared-helper wording. `ruff` + `mypy` clean.

Docstrings for both methods and the CHANGELOG updated.

## Round 2 — rebase onto merged #1429

#1429 (`add_camera` non-finite/non-numeric position/target guard) merged into `main` first, landing an *inline* per-element guard in `add_camera`. That overlapped this branch and left it `CONFLICTING`. Rebased onto latest `main` and resolved the `simulation.py` conflict by keeping this branch's shared-helper approach: the inline guard added by #1429 is replaced by the generalized `_validate_pose_vector("add_camera", ...)` call, so `add_object`, `move_object` and `add_camera` all validate through the single method-prefixed helper rather than duplicating the logic inline. Net effect on `add_camera` behaviour is equivalent to #1429 (nan/inf and non-numeric position/target rejected with a structured, method-prefixed error); this PR additionally covers `add_object`'s `position`/`orientation`/`color`/`size` and consolidates the validation path. CHANGELOG entry unchanged and still accurate post-merge. Re-verified the touched validation suites locally after the rebase: `test_add_object_camera_vector_validation.py`, `test_input_validation.py`, `test_setter_input_type_validation.py`, `test_move_object_pose_validation.py`, `test_add_object_*` — all pass (GL-render cases skipped headless). Force-push was required to land the rebase; the prior approval was auto-dismissed as a result and needs a re-approve.