### PR TITLE
test(sim): pin render_depth dimension safety-cap parity with render

### DIFF
--- a/tests/simulation/mujoco/test_render_dimension_limits.py
+++ b/tests/simulation/mujoco/test_render_dimension_limits.py
@@ -1,11 +1,17 @@
 """Render dimension + payload-size safety caps.
 
-``render()`` is an LLM-callable tool, so the width/height and the
-``STRANDS_ROBOTS_RENDER_MAX_BYTES`` size cap are attacker-influenced. These
-tests pin the out-of-memory / bad-input guardrails: non-integer dimensions, the
-absolute 4096x4096 framebuffer ceiling, the per-model offscreen framebuffer cap,
-and a non-positive byte budget. The dimension guards short-circuit before any
-GL context is created, so they are deterministic even on a headless host.
+``render()`` and ``render_depth()`` are LLM-callable tools, so the width/height
+and the ``STRANDS_ROBOTS_RENDER_MAX_BYTES`` size cap are attacker-influenced.
+These tests pin the out-of-memory / bad-input guardrails: non-integer
+dimensions, the absolute 4096x4096 framebuffer ceiling, the per-model offscreen
+framebuffer cap, and a non-positive byte budget. The dimension guards
+short-circuit before any GL context is created, so they are deterministic even
+on a headless host.
+
+``render_depth`` shares the same ``_validate_render_dims`` guard as ``render``
+but through an independent call site, so it is pinned with its own parity
+suite: a refactor that drops the depth-path guard (letting a 8000x8000 depth
+request reach the offscreen framebuffer) would slip past the RGB tests alone.
 """
 
 import pytest
@@ -48,6 +54,44 @@ class TestRenderDimensionCaps:
         res = sim_with_world.render(camera_name="default", width=cap_w + 1, height=48)
         assert res["status"] == "error"
         assert "offscreen framebuffer cap" in res["content"][0]["text"]
+
+
+class TestRenderDepthDimensionCaps:
+    """``render_depth`` must enforce the same dimension safety caps as ``render``.
+
+    The depth path has its own ``_validate_render_dims`` call site, so these
+    mirror the RGB caps to guarantee the two paths cannot drift: a bad-dimension
+    depth request is rejected before any offscreen framebuffer is allocated.
+    """
+
+    def test_non_integer_dimensions_rejected(self, sim_with_world):
+        res = sim_with_world.render_depth(camera_name="default", width="640", height=480)
+        assert res["status"] == "error"
+        assert "must be int" in res["content"][0]["text"]
+
+    def test_dimensions_over_absolute_ceiling_rejected(self, sim_with_world):
+        res = sim_with_world.render_depth(camera_name="default", width=8000, height=480)
+        assert res["status"] == "error"
+        text = res["content"][0]["text"]
+        assert "absolute maximum" in text
+        assert "4096x4096" in text
+
+    def test_dimensions_over_model_offscreen_cap_rejected(self, sim_with_world):
+        cap_w = int(sim_with_world._world._model.vis.global_.offwidth)
+        assert cap_w < 4096  # precondition: model cap is below the hard ceiling
+        res = sim_with_world.render_depth(camera_name="default", width=cap_w + 1, height=48)
+        assert res["status"] == "error"
+        assert "offscreen framebuffer cap" in res["content"][0]["text"]
+
+    def test_depth_and_rgb_agree_on_bad_dimensions(self, sim_with_world):
+        """The two render paths reject identical bad dimensions identically -
+        the parity contract that keeps the shared guard from drifting."""
+        for width, height in (("640", 480), (8000, 480), (0, 480), (640, -1)):
+            rgb = sim_with_world.render(camera_name="default", width=width, height=height)
+            depth = sim_with_world.render_depth(camera_name="default", width=width, height=height)
+            assert rgb["status"] == "error"
+            assert depth["status"] == "error"
+            assert rgb["content"][0]["text"] == depth["content"][0]["text"]
 
 
 class TestRenderMaxBytesCap:


### PR DESCRIPTION
## Problem

`render_depth()` and `render()` are both LLM-callable tools whose `width`/`height` are attacker-influenced. They share the `_validate_render_dims` guard (non-integer dims, the absolute 4096x4096 framebuffer ceiling, and the per-model offscreen framebuffer cap), but through two independent call sites. Only the RGB `render()` path had that guard pinned by tests (`tests/simulation/mujoco/test_render_dimension_limits.py::TestRenderDimensionCaps`); the depth path was untested, leaving the depth-side `_validate_render_dims` call uncovered.

## Change

Add `TestRenderDepthDimensionCaps` mirroring the RGB dimension caps for `render_depth`:
- non-integer dimensions rejected with the type-explicit message,
- dimensions over the absolute 4096 ceiling rejected,
- dimensions over the model's offscreen framebuffer cap rejected,
- a parity assertion that `render` and `render_depth` reject identical bad dimensions with byte-identical error text.

The module docstring is updated to document why the depth path gets its own parity suite. No production code changes.

## Why this is a real contract, not just a coverage number

With the depth-path `_validate_render_dims` guard neutralized, `render_depth` leaks a raw MuJoCo framebuffer error (`Image width 8000 > framebuffer width 1280 ...`) or a Python `TypeError` (`'>' not supported between instances of 'str' and 'int'`) instead of the actionable `render: ...` validation message. All four new depth tests fail in that state, while the existing RGB-only tests still pass - so a refactor that drops the depth guard can no longer slip through.

## Tests

```
MUJOCO_GL=egl pytest tests/simulation/mujoco/test_render_dimension_limits.py
9 passed
```

The dimension guards short-circuit before any GL context is created, so the suite is deterministic on a headless host. Lint clean (ruff check + ruff format --check + mypy).