### PR TITLE
fix(sim): add_robot validates base pose before baking it into the scene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: `add_robot` rejects a non-finite / malformed base pose instead of baking it into the scene
+
+`add_robot` writes the caller-supplied `position` (3) / `orientation`
+(4-element wxyz quaternion) straight into the injected robot's frame pos/quat,
+but did not validate that pose -- so it shared the numeric-vector failure
+classes already guarded on `add_object`, `move_object`, and `add_camera`:
+
+* A `nan` / `inf` `position` / `orientation` was written verbatim into the base
+  transform and propagated across the whole physics state by `mj_forward` while
+  `add_robot` still reported `status="success"` -- a silent corruption
+  (`data.xpos` went non-finite).
+* A wrong-length vector produced a generic "Failed to inject robot" with no hint
+  that the length was the problem.
+* A non-numeric element raised a bare MuJoCo `add_frame(): incompatible function
+  arguments` `TypeError` that escaped the structured `{"status": "error"}`
+  tool-result contract.
+
+`add_robot` now validates `position` (finite, numeric, length 3) and
+`orientation` (finite, numeric, length 4) up front via the same
+`_validate_pose_vector` helper the sibling scene methods use, returning an
+actionable structured error and leaving the simulation state finite / the robot
+unregistered. NumPy scalar components are accepted.
+
 ### Fixed: sim action router accepts NumPy scalar components in vector parameters
 
 The MuJoCo agent-tool dispatch router (`sim(action=..., **kwargs)` ->

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1064,11 +1064,36 @@ class MuJoCoSimEngine(
         ``data_config=``/``urdf_path=`` options) -- not a dead-end "supply a
         model source". The bare model-source message is kept only when no
         ``name`` was supplied at all.
+
+        ``position`` (3 elements) and ``orientation`` (4-element wxyz quaternion)
+        are validated up front: a wrong-length, non-numeric, or non-finite
+        (nan/inf) vector returns an actionable ``{"status": "error"}`` and
+        leaves the simulation unchanged, rather than baking a degenerate pose
+        into the robot's base transform. NumPy scalar components are accepted.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
         if err := self._require_no_running_policy("add_robot"):
             return err
+
+        # Validate the caller-supplied base pose before it is baked into the
+        # robot's frame pos/quat. Without this, `add_robot` shares the numeric
+        # -vector failure classes already guarded on `add_object` / `move_object`
+        # / `add_camera`: a nan/inf `position`/`orientation` is written verbatim
+        # into the base transform and propagated across the whole physics state
+        # by `mj_forward` while `add_robot` still reports `status="success"`
+        # (silent corruption); a wrong-length vector yields a generic "Failed to
+        # inject robot" with no hint that the length was wrong; and a non-numeric
+        # element raises a bare MuJoCo `add_frame(): incompatible function
+        # arguments` TypeError that escapes the structured-error contract. NumPy
+        # scalar components are accepted.
+        if position is not None and (e := _validate_pose_vector("add_robot", "position", position, 3)) is not None:
+            return {"status": "error", "content": [{"text": e}]}
+        if (
+            orientation is not None
+            and (e := _validate_pose_vector("add_robot", "orientation", orientation, 4)) is not None
+        ):
+            return {"status": "error", "content": [{"text": e}]}
 
         # Remember whether the caller supplied a `name` (vs an auto-derived
         # label): an explicit name that resolves to no model is a

--- a/tests/simulation/mujoco/test_add_robot_pose_vector_validation.py
+++ b/tests/simulation/mujoco/test_add_robot_pose_vector_validation.py
@@ -1,0 +1,107 @@
+"""Regression tests: ``add_robot`` rejects a non-finite / malformed base pose.
+
+``add_robot`` bakes the caller-supplied ``position`` (3) / ``orientation``
+(4-element wxyz quaternion) straight into the injected robot's frame pos/quat.
+It shared the numeric-vector failure classes already guarded on ``add_object`` /
+``move_object`` / ``add_camera`` but did not validate the pose itself, so three
+failures slipped through:
+
+* A ``nan`` / ``inf`` ``position`` / ``orientation`` was written verbatim into
+  the base transform and propagated across the whole physics state by
+  ``mj_forward`` while ``add_robot`` still reported ``status="success"`` -- a
+  silent corruption (``data.xpos`` went non-finite).
+* A wrong-length vector produced a generic "Failed to inject robot" with no hint
+  that the length was the problem.
+* A non-numeric element raised a bare MuJoCo ``add_frame(): incompatible
+  function arguments`` ``TypeError`` that escaped the structured
+  ``{"status": "error"}`` tool-result contract.
+
+These pin the fix: an invalid pose is rejected up front with a structured,
+actionable error and leaves the simulation state finite / the robot
+unregistered, while a valid pose (including NumPy scalar components) still adds
+the robot.
+"""
+
+import numpy as np
+import pytest
+
+mj = pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="test_add_robot_pose_validation_sim", mesh=False)
+    s.create_world(gravity=[0, 0, -9.81])
+    yield s
+    s.cleanup()
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expect"),
+    [
+        ({"position": [float("nan"), 0.0, 0.0]}, "finite"),
+        ({"position": [0.0, float("inf"), 0.0]}, "finite"),
+        ({"orientation": [1.0, 0.0, float("inf"), 0.0]}, "finite"),
+        ({"orientation": [float("nan"), 0.0, 0.0, 0.0]}, "finite"),
+    ],
+)
+def test_add_robot_rejects_nonfinite_pose(sim, kwargs, expect):
+    """A nan/inf pose is rejected, the robot is not added, and xpos stays finite.
+
+    Before the guard, a nan/inf position/orientation returned ``success`` and
+    poisoned ``data.xpos`` through ``mj_forward``.
+    """
+    result = sim.add_robot(data_config="so101", **kwargs)
+    assert result["status"] == "error", result
+    assert expect in result["content"][0]["text"]
+    assert "so101" not in sim._world.robots
+    assert np.all(np.isfinite(sim._world._data.xpos))
+    assert np.all(np.isfinite(sim._world._data.qpos))
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expect"),
+    [
+        ({"position": ["a", "b", "c"]}, "must be numbers"),
+        ({"orientation": ["a", "b", "c", "d"]}, "must be numbers"),
+        ({"position": [[1], [2], [3]]}, "must be numbers"),
+    ],
+)
+def test_add_robot_rejects_nonnumeric_pose(sim, kwargs, expect):
+    """A non-numeric element returns a structured error, not a bare TypeError."""
+    result = sim.add_robot(data_config="so101", **kwargs)
+    assert result["status"] == "error", result
+    assert expect in result["content"][0]["text"]
+    assert "so101" not in sim._world.robots
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"position": [1.0, 2.0]},
+        {"position": [1.0, 2.0, 3.0, 4.0]},
+        {"orientation": [1.0, 0.0, 0.0]},
+        {"orientation": [1.0, 0.0, 0.0, 0.0, 0.0]},
+    ],
+)
+def test_add_robot_rejects_wrong_length_pose(sim, kwargs):
+    """A wrong-length position (!=3) / orientation (!=4) is a structured error."""
+    result = sim.add_robot(data_config="so101", **kwargs)
+    assert result["status"] == "error", result
+    assert "element vector" in result["content"][0]["text"]
+    assert "so101" not in sim._world.robots
+
+
+def test_add_robot_accepts_valid_pose_with_numpy_scalars(sim):
+    """A valid pose still adds the robot, and NumPy scalar components are accepted."""
+    result = sim.add_robot(
+        data_config="so101",
+        position=[np.float64(0.1), np.float32(0.2), 0.0],
+        orientation=[1.0, 0.0, 0.0, 0.0],
+    )
+    assert result["status"] == "success", result
+    assert "so101" in sim._world.robots
+    assert np.all(np.isfinite(sim._world._data.xpos))
+    assert np.all(np.isfinite(sim._world._data.qpos))


### PR DESCRIPTION
## Problem

`Simulation.add_robot` writes the caller-supplied `position` (3) / `orientation` (4-element wxyz quaternion) straight into the injected robot's frame `pos`/`quat`, but never validated that pose. It therefore shared the exact numeric-vector failure classes already guarded on `add_object`, `move_object`, and `add_camera`:

- **Silent corruption**: a `nan`/`inf` `position`/`orientation` was written verbatim into the base transform and propagated across the whole physics state by `mj_forward`, while `add_robot` still returned `status="success"`. `data.xpos` went non-finite with no error.
- **Unactionable length error**: a wrong-length vector produced a generic `"Failed to inject robot 'so101' into scene."` with no hint that the vector length was the problem.
- **Leaked MuJoCo internals**: a non-numeric element (e.g. `["a","b","c"]`) raised a bare `add_frame(): incompatible function arguments` `TypeError` from inside MuJoCo, escaping the structured `{"status": "error"}` tool-result contract.

Reproduction before the fix:

```python
sim.create_world()
r = sim.add_robot(data_config="so101", position=[float("nan"), 0.0, 0.0])
# r["status"] == "success"  and  np.isnan(sim._world._data.xpos).any() == True
```

## Change

`add_robot` now validates `position` (finite, numeric, length 3) and `orientation` (finite, numeric, length 4) up front via the same `_validate_pose_vector` helper the sibling scene-construction methods use, before any scene mutation. Invalid input returns an actionable structured error and leaves the simulation state finite and the robot unregistered. NumPy scalar components are still accepted.

Errors now read like the rest of the numeric-input campaign:

```
add_robot: 'position' must contain finite numbers (no nan/inf), got [nan, 0.0, 0.0]
add_robot: 'position' must be a 3-element vector, got 2 ([0.0, 0.0])
add_robot: 'orientation' elements must be numbers, got ['a', 'b', 'c', 'd']
```

## Tests

New `tests/simulation/mujoco/test_add_robot_pose_vector_validation.py` pins all three failure classes plus the happy path (12 cases). It fails on pre-fix code (11 of 12 cases: `success`+poisoned `xpos`, generic inject error, bare `TypeError`) and passes after. Existing `add_robot`/inject suite (77 tests) and the sibling `add_object`/`add_camera` validation suite stay green. Full lint gate clean (`ruff` + `mypy strands_robots tests tests_integ`).

## Visual

Happy path unaffected: two SO-101 arms added at distinct valid poses (`position=[0,-0.3,0]` and `position=[0,0.3,0]` with a 90-degree yaw), rendered headless in MuJoCo after 50 steps -- the validated poses are honored, not clobbered to the origin.

![add_robot valid-pose render](https://raw.githubusercontent.com/cagataycali/robots/assets-add-robot-pose/add_robot_valid_pose.png)