### PR TITLE
fix(sim): raycast/multi_raycast validate origin/direction are finite numbers

### DIFF
--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -533,11 +533,24 @@ class PhysicsMixin:
                 "content": [{"text": "raycast: 'origin' and 'direction' must be lists of 3 numbers"}],
             }
 
+        # Every element must be a finite real number. Without this, a
+        # non-numeric element (e.g. ["a", ...]) raises ValueError inside
+        # np.array(dtype=float64) -- escaping the structured-error contract --
+        # and nan/inf slip silently into mj_ray (nan direction survives the
+        # zero-length guard because ``nan < 1e-10`` is False, then poisons the
+        # normalized vector fed to the C solver).
+        origin_f, err = _coerce_finite_vector(origin, "origin", "raycast")
+        if err is not None:
+            return err
+        direction_f, err = _coerce_finite_vector(direction, "direction", "raycast")
+        if err is not None:
+            return err
+
         mj = _ensure_mujoco()
         model, data = self._world._model, self._world._data
 
-        pnt = np.array(origin, dtype=np.float64)
-        vec = np.array(direction, dtype=np.float64)
+        pnt = np.array(origin_f, dtype=np.float64)
+        vec = np.array(direction_f, dtype=np.float64)
         # Normalize direction
         norm = np.linalg.norm(vec)
         if norm < 1e-10:
@@ -1422,7 +1435,13 @@ class PhysicsMixin:
         except TypeError:
             return {"status": "error", "content": [{"text": "multi_raycast: 'origin' must be a list of 3 numbers"}]}
 
-        pnt = np.array(origin, dtype=np.float64)
+        # See raycast: reject non-numeric / nan / inf origin before np.array so
+        # a bad element cannot raise past the tool contract or poison mj_ray.
+        origin_f, err = _coerce_finite_vector(origin, "origin", "multi_raycast")
+        if err is not None:
+            return err
+
+        pnt = np.array(origin_f, dtype=np.float64)
         results: list[dict[str, Any]] = []
 
         # Refresh geom world poses once, then serialize every mj_ray against a
@@ -1450,7 +1469,11 @@ class PhysicsMixin:
                         }
                     )
                     continue
-                vec = np.array(d, dtype=np.float64)
+                d_floats, d_err = _coerce_finite_vector(d, "direction", f"ray[{idx}]")
+                if d_err is not None:
+                    results.append({"distance": None, "geom_id": None, "error": d_err["content"][0]["text"]})
+                    continue
+                vec = np.array(d_floats, dtype=np.float64)
                 norm = np.linalg.norm(vec)
                 if norm < 1e-10:
                     results.append({"distance": None, "geom_id": None, "error": f"ray[{idx}]: zero-length direction"})

--- a/tests/simulation/mujoco/test_input_validation.py
+++ b/tests/simulation/mujoco/test_input_validation.py
@@ -131,6 +131,61 @@ class TestRaycastValidation:
         assert rays[1].get("error") is not None
         assert "zero-length" in rays[1]["error"]
 
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+    def test_nonfinite_direction_errors(self, sim_with_robot, bad):
+        """A nan/inf direction survives the zero-length guard (``nan < 1e-10`` is
+        False) and would poison the normalized vector fed to mj_ray. Reject it."""
+        res = sim_with_robot.raycast(origin=[0, 0, 1], direction=[bad, 0.0, 0.0])
+        assert res["status"] == "error"
+        assert "finite" in res["content"][0]["text"].lower()
+        assert "direction" in res["content"][0]["text"]
+
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf")])
+    def test_nonfinite_origin_errors(self, sim_with_robot, bad):
+        res = sim_with_robot.raycast(origin=[bad, 0.0, 1.0], direction=[0, 0, -1])
+        assert res["status"] == "error"
+        assert "finite" in res["content"][0]["text"].lower()
+        assert "origin" in res["content"][0]["text"]
+
+    def test_non_numeric_origin_errors_not_raises(self, sim_with_robot):
+        """A non-numeric element must return a structured error, not raise
+        ValueError from np.array(dtype=float64) past the tool contract."""
+        res = sim_with_robot.raycast(origin=["a", "b", "c"], direction=[0, 0, -1])
+        assert res["status"] == "error"
+        assert "number" in res["content"][0]["text"].lower()
+
+    def test_non_numeric_direction_errors_not_raises(self, sim_with_robot):
+        res = sim_with_robot.raycast(origin=[0, 0, 1], direction=["x", 0, 0])
+        assert res["status"] == "error"
+        assert "number" in res["content"][0]["text"].lower()
+
+    def test_multi_raycast_non_numeric_origin_errors_not_raises(self, sim_with_robot):
+        res = sim_with_robot.multi_raycast(origin=["x", 0, 1], directions=[[0, 0, -1]])
+        assert res["status"] == "error"
+        assert "number" in res["content"][0]["text"].lower()
+
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf")])
+    def test_multi_raycast_nonfinite_origin_errors(self, sim_with_robot, bad):
+        res = sim_with_robot.multi_raycast(origin=[bad, 0, 1], directions=[[0, 0, -1]])
+        assert res["status"] == "error"
+        assert "finite" in res["content"][0]["text"].lower()
+
+    def test_multi_raycast_nonfinite_direction_isolates_error(self, sim_with_robot):
+        """A nan direction in one ray must be reported per-ray, not abort the
+        batch or silently pass a poisoned vector to mj_ray."""
+        res = sim_with_robot.multi_raycast(
+            origin=[0, 0, 5],
+            directions=[[0, 0, -1], [float("nan"), 0.0, 0.0], [1, 0, -1]],
+        )
+        assert res["status"] == "success"
+        rays = res["content"][1]["json"]["rays"]
+        assert len(rays) == 3
+        assert rays[1].get("error") is not None
+        assert "finite" in rays[1]["error"].lower()
+        # Valid rays around the bad one are unaffected.
+        assert rays[0].get("error") is None
+        assert rays[2].get("error") is None
+
 
 class TestApplyForceValidation:
     def test_missing_both_force_and_torque_errors(self, sim_with_robot):


### PR DESCRIPTION
## Problem

`MuJoCoSimEngine.raycast` and `multi_raycast` validate the *length* of `origin`/`direction` (must be 3 elements) and reject a zero-length direction, but they do not validate that the elements are finite real numbers. Two failure modes result:

1. **Structured-error contract escape.** A non-numeric element (e.g. `origin=["a", "b", "c"]`) raises `ValueError: could not convert string to float` from inside `np.array(..., dtype=np.float64)`, propagating past the tool dispatch instead of returning the `{"status": "error", ...}` contract every other physics method honors.

2. **nan/inf poisons `mj_ray`.** A `nan`/`inf` element slips silently through: `nan` survives the zero-length guard because `nan < 1e-10` is `False`, then flows into the normalized direction vector handed to the `mj_ray` C routine. The call reports `success` while feeding non-finite state into the solver.

Reproduction on `main`:

```python
sim.raycast(origin=["a", "b", "c"], direction=[0, 0, -1])   # raises ValueError
sim.raycast(origin=[0, 0, 1], direction=[float("nan"), 0, 0])  # returns success (poisoned)
sim.multi_raycast(origin=["x", 0, 1], directions=[[0, 0, -1]]) # raises ValueError
```

## Change

Both methods now run the existing `_coerce_finite_vector` helper (already used by `set_geom_properties`, `apply_force`, etc.) on `origin`/`direction` before any `np.array` conversion or `mj_ray` call:

- `raycast`: validates `origin` and `direction` after the length guard, before conversion. Non-numeric or non-finite input returns a structured error.
- `multi_raycast`: validates `origin` up front; per-ray directions are validated inside the batch loop and reported as a per-ray `error` entry (consistent with the existing zero-length-direction handling), so one bad ray never aborts the batch or crashes.

Valid rays are unchanged. This extends the finite-input hardening already applied to the other scene/physics mutators to the ray-query surface.

## Tests

Added to `TestRaycastValidation` in `tests/simulation/mujoco/test_input_validation.py`:

- nan/inf/-inf `direction` and nan/inf `origin` rejected with a `finite` error message (`raycast` and `multi_raycast`).
- non-numeric `origin`/`direction` return a structured error instead of raising `ValueError`.
- multi_raycast isolates a nan direction to its own per-ray error while neighboring valid rays still resolve.

All 11 new cases fail on pre-fix code (7 assertion mismatches, 3 uncaught `ValueError`s, 1 missing per-ray error) and pass after the fix. Full `tests/simulation/mujoco/test_physics.py` + `test_input_validation.py` suites: 214 passed. `ruff check`, `ruff format --check`, and `mypy` over `strands_robots tests tests_integ` are clean.