### PR TITLE
fix(sim): physics/introspection lookups give an actionable not-found for unknown body/site/geom/sensor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2092,6 +2092,24 @@ simulation state finite and the entity unregistered. NumPy scalar components
 are accepted, matching the finiteness contract already enforced by
 `move_object`, `set_geom_properties`, `set_gravity` and `add_camera`'s `fov`.
 
+### Fixed: physics/introspection lookups return an actionable "not found" for an unknown body/site/geom/sensor
+
+`get_body_state`, `get_jacobian`, `set_body_properties`, `set_geom_properties`,
+`apply_force`, and `get_sensor_data` resolve a caller-supplied body/site/geom/
+sensor name and, on a miss, returned a dead-end `"<Kind> 'X' not found."` with
+no list of what *is* in the model and no close-match -- the last holdouts of the
+actionable-error class the camera / object / robot facade paths already cover
+(`_unknown_camera_msg` / `_unknown_object_msg` / `_unknown_robot_msg`). An agent
+(or human) driving these blind hit a dead end on every typo and had to guess or
+run a separate discovery round-trip.
+
+These lookups now route through a shared `_unknown_mj_entity_msg(kind, name)`
+that preserves the `"<Kind> 'X' not found."` prefix (so the consistent
+error-shape contract is unchanged), appends a difflib close-match over the
+model's *named* entities, lists the available names (capped), and -- for bodies
+-- points at the real `list_bodies` discovery action. The informative
+`get_sensor_data` "Model has no sensors." branch is preserved.
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -428,7 +428,7 @@ class PhysicsMixin:
 
         body_id = self._resolve_mj_name(mj.mjtObj.mjOBJ_BODY, body_name)
         if body_id < 0:
-            return {"status": "error", "content": [{"text": f"Body '{body_name}' not found."}]}
+            return {"status": "error", "content": [{"text": self._unknown_mj_entity_msg("Body", body_name)}]}
 
         f = np.array(force or [0, 0, 0], dtype=np.float64)
         t = np.array(torque or [0, 0, 0], dtype=np.float64)
@@ -491,6 +491,48 @@ class PhysicsMixin:
                 if mid >= 0:
                     return int(mid)
         return -1
+
+    def _unknown_mj_entity_msg(self, kind: str, requested: str) -> str:
+        """Actionable "<kind> not found" message for the physics/introspection
+        lookups (``get_body_state`` / ``get_jacobian`` / ``set_body_properties`` /
+        ``set_geom_properties`` / ``get_sensor_data`` ...): name the entity, offer
+        a difflib close-match over the model's *named* entities, list the
+        available names (capped), and - for bodies - point at the ``list_bodies``
+        discovery action. Consistent with ``_unknown_object_msg`` /
+        ``_unknown_camera_msg`` / ``_unknown_robot_msg`` (#1299/#1303/#1306)
+        rather than a dead-end "<Kind> 'X' not found." that forces an agent
+        driving the API blind into guesswork on every typo.
+
+        The ``"<Kind> 'X' not found."`` prefix is preserved so the consistent
+        error shape (T15 in ``test_agenttool_contract``) is unaffected.
+
+        ``kind`` is one of ``"Body" | "Site" | "Geom" | "Sensor"``.
+        """
+        import mujoco as _mj
+
+        model = self._world._model if self._world is not None else None
+        msg = f"{kind} '{requested}' not found."
+        if model is None:
+            return msg
+        obj_type, count = {
+            "Body": (_mj.mjtObj.mjOBJ_BODY, model.nbody),
+            "Site": (_mj.mjtObj.mjOBJ_SITE, model.nsite),
+            "Geom": (_mj.mjtObj.mjOBJ_GEOM, model.ngeom),
+            "Sensor": (_mj.mjtObj.mjOBJ_SENSOR, model.nsensor),
+        }[kind]
+        known = [nm for i in range(int(count)) if (nm := _mj.mj_id2name(model, obj_type, i)) and nm != "world"]
+        if known:
+            import difflib
+
+            matches = difflib.get_close_matches(requested, known, n=3, cutoff=0.4)
+            if matches:
+                msg += " Did you mean: " + ", ".join(matches) + "?"
+            shown = known if len(known) <= 30 else known[:30] + ["..."]
+            plural = {"Body": "bodies", "Site": "sites", "Geom": "geoms", "Sensor": "sensors"}[kind]
+            msg += f" Available {plural}: {shown}."
+            if kind == "Body":
+                msg += " Use action='list_bodies' to see all."
+        return msg
 
     def raycast(
         self,
@@ -639,19 +681,19 @@ class PhysicsMixin:
             if body_name:
                 obj_id = self._resolve_mj_name(mj.mjtObj.mjOBJ_BODY, body_name)
                 if obj_id < 0:
-                    return {"status": "error", "content": [{"text": f"Body '{body_name}' not found."}]}
+                    return {"status": "error", "content": [{"text": self._unknown_mj_entity_msg("Body", body_name)}]}
                 mj.mj_jacBody(model, data, jacp, jacr, obj_id)
                 label = f"body '{body_name}'"
             elif site_name:
                 obj_id = self._resolve_mj_name(mj.mjtObj.mjOBJ_SITE, site_name)
                 if obj_id < 0:
-                    return {"status": "error", "content": [{"text": f"Site '{site_name}' not found."}]}
+                    return {"status": "error", "content": [{"text": self._unknown_mj_entity_msg("Site", site_name)}]}
                 mj.mj_jacSite(model, data, jacp, jacr, obj_id)
                 label = f"site '{site_name}'"
             elif geom_name:
                 obj_id = self._resolve_mj_name(mj.mjtObj.mjOBJ_GEOM, geom_name)
                 if obj_id < 0:
-                    return {"status": "error", "content": [{"text": f"Geom '{geom_name}' not found."}]}
+                    return {"status": "error", "content": [{"text": self._unknown_mj_entity_msg("Geom", geom_name)}]}
                 mj.mj_jacGeom(model, data, jacp, jacr, obj_id)
                 label = f"geom '{geom_name}'"
             else:
@@ -824,7 +866,7 @@ class PhysicsMixin:
 
         body_id = self._resolve_mj_name(mj.mjtObj.mjOBJ_BODY, body_name)
         if body_id < 0:
-            return {"status": "error", "content": [{"text": f"Body '{body_name}' not found."}]}
+            return {"status": "error", "content": [{"text": self._unknown_mj_entity_msg("Body", body_name)}]}
 
         with self._lock:
             # Reflect the CURRENT qpos/qvel. This reads data.xpos/xquat/xmat/xipos
@@ -1161,7 +1203,7 @@ class PhysicsMixin:
             }
 
         if sensor_name and sensor_name not in sensors:
-            return {"status": "error", "content": [{"text": f"Sensor '{sensor_name}' not found."}]}
+            return {"status": "error", "content": [{"text": self._unknown_mj_entity_msg("Sensor", sensor_name)}]}
 
         lines = [f"Sensors ({len(sensors)}/{model.nsensor}):"]
         for name, info in sensors.items():
@@ -1222,7 +1264,7 @@ class PhysicsMixin:
         model = self._world._model
         body_id = self._resolve_mj_name(mj.mjtObj.mjOBJ_BODY, body_name)
         if body_id < 0:
-            return {"status": "error", "content": [{"text": f"Body '{body_name}' not found."}]}
+            return {"status": "error", "content": [{"text": self._unknown_mj_entity_msg("Body", body_name)}]}
 
         changes = []
         with self._lock:
@@ -1289,7 +1331,10 @@ class PhysicsMixin:
             if (gid is None or gid < 0) and not geom_name.endswith("_geom"):
                 gid = self._resolve_mj_name(mj.mjtObj.mjOBJ_GEOM, f"{geom_name}_geom")
         if gid is None or gid < 0 or gid >= model.ngeom:
-            return {"status": "error", "content": [{"text": f"Geom '{geom_name or geom_id}' not found."}]}
+            return {
+                "status": "error",
+                "content": [{"text": self._unknown_mj_entity_msg("Geom", str(geom_name or geom_id))}],
+            }
 
         # Validate numeric inputs before any model write. Without this a nan/inf
         # (or negative) value lands directly in geom_rgba / geom_friction /
@@ -1523,7 +1568,7 @@ class PhysicsMixin:
             if body_name is not None:
                 bid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_BODY, body_name)
                 if bid < 0:
-                    return {"status": "error", "content": [{"text": f"Body '{body_name}' not found."}]}
+                    return {"status": "error", "content": [{"text": self._unknown_mj_entity_msg("Body", body_name)}]}
                 body_payload = {
                     "position": data.xpos[bid].tolist(),
                     "quaternion": data.xquat[bid].tolist(),

--- a/tests/simulation/mujoco/test_missing_entity_error_messages.py
+++ b/tests/simulation/mujoco/test_missing_entity_error_messages.py
@@ -150,3 +150,106 @@ def test_remove_robot_unknown_in_empty_scene_points_to_add_robot():
 def test_valid_robot_query_unaffected(sim_with_robot):
     # No-regression guard: a correct robot name is not intercepted.
     assert sim_with_robot.get_robot_state("arm1")["status"] == "success"
+
+
+# --- physics.py Body / Site / Geom / Sensor lookups (get_body_state, get_jacobian,
+# set_body_properties, apply_force, set_geom_properties, get_sensor_data) ------------
+# These shared _resolve_mj_name lookups previously returned a dead-end
+# "<Kind> 'X' not found." with no available-list and no close-match - the last
+# holdouts of the actionable-error class the camera/object/robot paths already
+# cover. They now route through ``_unknown_mj_entity_msg`` (same shape:
+# preserved prefix + difflib close-match + available names, plus a
+# ``list_bodies`` discovery hint for bodies).
+
+
+def test_get_body_state_unknown_body_is_actionable(sim):
+    # sim fixture has an object 'cube' -> body 'cube'.
+    text = _err_text(sim.get_body_state("crube"))
+    assert "Body 'crube' not found" in text  # preserved prefix (T15 shape)
+    assert "Did you mean: cube" in text  # difflib close-match
+    assert "cube" in text  # names the available body
+    assert "list_bodies" in text  # discovery surface (a real action)
+
+
+def test_get_jacobian_unknown_body_is_actionable(sim):
+    # A different physics.py call site sharing the same helper.
+    text = _err_text(sim.get_jacobian(body_name="crube"))
+    assert "Body 'crube' not found" in text
+    assert "Did you mean: cube" in text
+    assert "list_bodies" in text
+
+
+def test_set_body_properties_unknown_body_is_actionable(sim):
+    text = _err_text(sim.set_body_properties("crube", mass=1.0))
+    assert "Body 'crube' not found" in text
+    assert "Did you mean: cube" in text
+    assert "list_bodies" in text
+
+
+def test_set_geom_properties_unknown_geom_is_actionable(sim):
+    # add_object names the geom '<object>_geom'.
+    text = _err_text(sim.set_geom_properties(geom_name="cube_geeom", color=[1, 0, 0, 1]))
+    assert "Geom 'cube_geeom' not found" in text  # preserved prefix
+    assert "Did you mean: cube_geom" in text  # close-match
+    assert "cube_geom" in text  # names the available geom
+    # geoms have no dedicated list_* action, so no discovery hint is emitted.
+    assert "list_bodies" not in text
+
+
+def test_get_sensor_data_no_sensors_message_preserved(sim):
+    # The sim fixture has no sensors: the informative "Model has no sensors."
+    # branch must be preserved (not replaced with a generic available-list).
+    text = _err_text(sim.get_sensor_data(sensor_name="anything"))
+    assert "Sensor 'anything' not found" in text
+    assert "Model has no sensors" in text
+
+
+_SITE_SENSOR_XML = """<mujoco model="probe">
+  <worldbody>
+    <body name="link" pos="0 0 0.3">
+      <joint name="j0" type="hinge" axis="0 0 1"/>
+      <geom name="pad" type="box" size="0.02 0.02 0.02"/>
+      <site name="tip" pos="0 0 0.05"/>
+    </body>
+  </worldbody>
+  <sensor>
+    <framepos name="tip_pos" objtype="site" objname="tip"/>
+  </sensor>
+</mujoco>
+"""
+
+
+@pytest.fixture
+def sim_with_site_sensor(tmp_path):
+    """A GL-free world holding a robot named ``probe`` with a named site and a
+    framepos sensor (inline MJCF), so the Site/Sensor branches of
+    ``_unknown_mj_entity_msg`` are exercised on real named entities."""
+    xml = tmp_path / "probe.xml"
+    xml.write_text(_SITE_SENSOR_XML)
+    s = Simulation(tool_name="test_missing_site_sensor_sim", mesh=False)
+    s.create_world(gravity=[0, 0, -9.81])
+    assert s.add_robot("probe", urdf_path=str(xml), position=[0, 0, 0])["status"] == "success"
+    yield s
+    s.cleanup()
+
+
+def test_get_jacobian_unknown_site_lists_available(sim_with_site_sensor):
+    # add_robot namespaces the site as 'probe/tip'; the available-list surfaces
+    # the exact (namespaced) name the caller must use.
+    text = _err_text(sim_with_site_sensor.get_jacobian(site_name="probe/tpi"))
+    assert "Site 'probe/tpi' not found" in text  # preserved prefix
+    assert "Did you mean: probe/tip" in text  # close-match on the real name
+    assert "probe/tip" in text  # names the available site
+
+
+def test_get_sensor_data_unknown_sensor_is_actionable(sim_with_site_sensor):
+    text = _err_text(sim_with_site_sensor.get_sensor_data(sensor_name="tip_poss"))
+    assert "Sensor 'tip_poss' not found" in text  # preserved prefix
+    assert "Did you mean: probe/tip_pos" in text  # close-match (namespaced)
+    assert "probe/tip_pos" in text  # names the available sensor
+
+
+def test_valid_physics_queries_unaffected(sim):
+    # No-regression guard: correct body/geom names are not intercepted.
+    assert sim.get_body_state("cube")["status"] == "success"
+    assert sim.set_geom_properties(geom_name="cube_geom", color=[0, 1, 0, 1])["status"] == "success"


### PR DESCRIPTION
## Problem

`get_body_state`, `get_jacobian`, `set_body_properties`, `set_geom_properties`, `apply_force`, and `get_sensor_data` resolve a caller-supplied **body / site / geom / sensor** name (via the shared `_resolve_mj_name`) and, on a miss, returned a dead-end `"<Kind> 'X' not found."` with no list of what *is* in the model and no close-match suggestion.

These were the last holdouts of the actionable-error class the camera / object / robot facade paths already cover (`_unknown_camera_msg` / `_unknown_object_msg` / `_unknown_robot_msg`). A caller driving the API blind hit a dead end on every typo and had to guess the exact (namespaced) name or run a separate discovery round-trip.

## Change

All these lookups now route through a shared `_unknown_mj_entity_msg(kind, name)` in `PhysicsMixin` that:

* **preserves the `"<Kind> 'X' not found."` prefix** so the consistent error-shape contract (T15 in `test_agenttool_contract`) is unchanged;
* appends a `difflib` **close-match** over the model's *named* entities (`Did you mean: cube?`);
* lists the **available names** (capped at 30 to avoid a wall of text);
* for **bodies**, points at the real `list_bodies` discovery action.

The informative `get_sensor_data` `"Model has no sensors."` branch is preserved (not replaced by a generic list). Geom/site/sensor have no dedicated `list_*` action, so they surface the available names without a discovery-action pointer — which is what a caller needs anyway (it teaches the exact namespaced name, e.g. `probe/tip`).

Example (before → after):
```
Body 'crube' not found.
  ->  Body 'crube' not found. Did you mean: cube? Available bodies: ['cube']. Use action='list_bodies' to see all.
Geom 'cube_geeom' not found.
  ->  Geom 'cube_geeom' not found. Did you mean: cube_geom? Available geoms: ['ground', 'cube_geom'].
```

## Tests

Extends `tests/simulation/mujoco/test_missing_entity_error_messages.py` (the #1303/#1306 home) with real, GL-free sims (no mocks): the `add_object` cube fixture exercises Body + Geom, and an inline-MJCF fixture with a named site + framepos sensor exercises Site + Sensor. Guards keep the `nsensor==0` "Model has no sensors." message and the happy paths unaffected.

The close-match assertions **fail before** this change (bare `"<Kind> 'X' not found."`) and pass after. Full green gate: `ruff check`/`format` + `mypy` clean on the changed module; `test_missing_entity_error_messages.py` (17), `test_physics.py`, `test_error_paths.py` (138 total) and `test_agenttool_contract.py` (68, T15 shape) all pass under `MUJOCO_GL=egl`.