### PR TITLE
test(sim): pin set_geom_properties rejects a bare scalar vector arg

### DIFF
--- a/tests/simulation/mujoco/test_setter_input_type_validation.py
+++ b/tests/simulation/mujoco/test_setter_input_type_validation.py
@@ -178,3 +178,37 @@ class TestSetGeomPropertiesRejectsInvalid:
         assert res["status"] == "success"
         assert abs(float(sim_with_box._world._model.geom_size[gid][0]) - 0.06) < 1e-6
         assert abs(float(sim_with_box._world._model.geom_friction[gid][0]) - 0.8) < 1e-4
+
+    @pytest.mark.parametrize(
+        ("kwargs", "param"),
+        [
+            ({"color": 0.5}, "color"),
+            ({"friction": 1.0}, "friction"),
+            ({"size": 0.05}, "size"),
+        ],
+    )
+    def test_bare_scalar_vector_arg_rejected_and_model_untouched(self, sim_with_box, kwargs, param):
+        """A bare scalar where a numeric *sequence* is expected is rejected.
+
+        ``color`` / ``friction`` / ``size`` are vector-valued. Passing a single
+        number (a common agent mistake, e.g. ``color=0.5`` instead of
+        ``color=[0.5, 0.5, 0.5, 1.0]``) is not iterable, so it hits the
+        sequence-level coercion guard rather than crashing with a bare
+        ``TypeError``. The call returns a structured error naming the parameter
+        and leaves the model buffers untouched.
+        """
+        gid = self._geom_id(sim_with_box)
+        model = sim_with_box._world._model
+        before = {
+            "rgba": model.geom_rgba[gid].copy(),
+            "friction": model.geom_friction[gid].copy(),
+            "size": model.geom_size[gid].copy(),
+        }
+        res = sim_with_box.set_geom_properties(geom_name="box", **kwargs)
+        assert res["status"] == "error"
+        text = res["content"][0]["text"]
+        assert param in text
+        assert "sequence of numbers" in text
+        assert (model.geom_rgba[gid] == before["rgba"]).all()
+        assert (model.geom_friction[gid] == before["friction"]).all()
+        assert (model.geom_size[gid] == before["size"]).all()


### PR DESCRIPTION
## Problem

`set_geom_properties(color=..., friction=..., size=...)` takes vector-valued arguments. A very common mistake is to pass a bare scalar (e.g. `color=0.5` instead of `color=[0.5, 0.5, 0.5, 1.0]`). The numeric-coercion helper handles this: a non-iterable value hits the sequence-level guard (`list(values)` raises `TypeError`) and returns a structured `status="error"` naming the parameter, rather than letting a `TypeError` escape past dispatch.

The element-level coercion paths (NaN/Inf, negative friction, non-positive size, non-numeric *entries* inside a well-shaped list) were already covered, but the sequence-level branch (a bare scalar where a sequence is expected) had no regression test.

## Change

Adds one parametrized test to `TestSetGeomPropertiesRejectsInvalid` in `tests/simulation/mujoco/test_setter_input_type_validation.py` covering `color` / `friction` / `size` scalars. It asserts:

- the call returns `status="error"` with a message that names the parameter and states it must be a `sequence of numbers` (no unhandled `TypeError`), and
- the model buffers (`geom_rgba` / `geom_friction` / `geom_size`) are left untouched.

This pins the input-validation contract for the vector-valued geom mutators and closes the last uncovered branch in the shared numeric-vector coercion guard.

## Tests

Test-only change.

- `MUJOCO_GL=egl pytest tests/simulation/mujoco/test_setter_input_type_validation.py` -> 18 passed (was 15).
- Full `tests/simulation/mujoco/` -> 1384 passed.
- `ruff check` / `ruff format --check` clean; `mypy strands_robots tests tests_integ` -> no issues.
- Confirmed the newly-covered guard was previously unexercised (coverage of the sequence-level `TypeError` branch went from missing to covered).