### PR TITLE
fix(training): build_command emits --reward_model.pretrained_path for warm-started reward runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2110,6 +2110,22 @@ model's *named* entities, lists the available names (capped), and -- for bodies
 -- points at the real `list_bodies` discovery action. The informative
 `get_sensor_data` "Model has no sensors." branch is preserved.
 
+### Fixed: `build_command` reward-model path emits `--reward_model.pretrained_path` for a warm-started run
+
+`LerobotTrainer.build_command` is the argv-parity helper documenting the
+draccus CLI the typed `build_config` maps to (and the contract
+`test_native_parity` guards). `build_config` warm-starts a reward-model run
+from `TrainSpec.base_model` by setting `reward_model.pretrained_path`, but
+`build_command` emitted `--policy.pretrained_path` only in the policy branch
+and never the `--reward_model.pretrained_path` equivalent. So the documented
+"equivalent CLI" for a warm-started reward-model (SARM) run trained from
+scratch (`pretrained_path` defaults to `None`) instead of loading
+`base_model` -- diverging from the in-process `train(cfg)` path. `build_command`
+now emits `--reward_model.pretrained_path=<base_model>` when `base_model` is
+set, mirroring the policy path. (`push_to_hub` is intentionally not emitted:
+`RewardModelConfig.push_to_hub` already defaults to `False`, so `build_config`
+setting it `False` is a no-op the CLI need not restate.)
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -590,7 +590,7 @@ class LerobotTrainer(Trainer):
         if root:
             cmd.append(f"--dataset.root={root}")
         if rm is not None:
-            cmd.extend(self._reward_model_command_flags(rm))
+            cmd.extend(self._reward_model_command_flags(rm, spec.base_model))
         else:
             ptype = self._resolve_policy_type(spec)
             cmd.append(f"--policy.type={ptype}")
@@ -647,11 +647,18 @@ class LerobotTrainer(Trainer):
             cmd.append(f"--{key}={value}")
         return cmd
 
-    def _reward_model_command_flags(self, rm: dict[str, Any]) -> list[str]:
+    def _reward_model_command_flags(self, rm: dict[str, Any], base_model: str = "") -> list[str]:
         """argv-parity flags for a reward-model run (``--reward_model.*``)."""
         rtype = self._reward_model_type(rm)
         friendly = _reward_friendly_fields(rtype)
         flags = [f"--reward_model.type={rtype}", f"--reward_model.device={self.device}"]
+        # Warm-start checkpoint: build_config sets reward_cfg.pretrained_path from
+        # spec.base_model, so the equivalent CLI must set it too (mirrors the policy
+        # path's --policy.pretrained_path). Omitting it left the documented
+        # reward-model CLI training from scratch (pretrained_path defaults to None)
+        # instead of warm-starting from base_model.
+        if base_model:
+            flags.append(f"--reward_model.pretrained_path={base_model}")
         for key, value in rm.items():
             if key != "type" and key in friendly:
                 flags.append(f"--reward_model.{key}={value}")

--- a/tests/training/test_lerobot.py
+++ b/tests/training/test_lerobot.py
@@ -1044,6 +1044,31 @@ class TestRewardModelTraining:
         # A reward-model run does not train a policy -> no --policy.* flags.
         assert not any(c.startswith("--policy.") for c in cmd)
 
+    def test_build_command_emits_reward_model_pretrained_path(self, dataset_root, tmp_path, monkeypatch):
+        """A reward-model spec's base_model must reach --reward_model.pretrained_path.
+
+        build_config warm-starts cfg.reward_model.pretrained_path from base_model
+        (test_build_config_forwards_base_model_to_reward_pretrained_path), but the
+        argv-parity helper only emitted --policy.pretrained_path (the policy
+        branch). For a warm-started reward-model run the documented "equivalent
+        CLI" therefore trained from scratch (pretrained_path defaults to None)
+        instead of loading base_model -- the exact build_command<->build_config
+        drift the policy path already avoids.
+
+        Forces the offline reward-registry fallback so the argv parity is asserted
+        without importing lerobot (the pretrained_path emission is
+        registry-independent), keeping the check fast and deterministic.
+        """
+        import sys
+
+        monkeypatch.setitem(sys.modules, "lerobot.rewards", None)
+        spec = self._sarm_spec(dataset_root, tmp_path, image_key="observation.images.base")
+        spec.base_model = "lerobot/sarm_pretrained"
+        cmd = LerobotTrainer(device="cpu").build_command(spec)
+        assert "--reward_model.pretrained_path=lerobot/sarm_pretrained" in cmd
+        # A reward-model run never trains a policy -> no --policy.pretrained_path.
+        assert not any(c.startswith("--policy.pretrained_path=") for c in cmd)
+
     def test_validate_rejects_unknown_reward_type(self, dataset_root, tmp_path):
         spec = self._sarm_spec(dataset_root, tmp_path, type="not_a_reward_model")
         problems = LerobotTrainer().validate(spec)


### PR DESCRIPTION
## Problem

`LerobotTrainer.build_command` is the argv-parity helper documenting the draccus CLI the typed `build_config` maps to (and the contract `test_native_parity` guards). For a **reward-model** run with `TrainSpec.base_model` set, `build_config` warm-starts `cfg.reward_model.pretrained_path` (covered by `test_build_config_forwards_base_model_to_reward_pretrained_path`), but `build_command` emitted `--policy.pretrained_path` only on the **policy** branch — never the `--reward_model.pretrained_path` equivalent.

So the documented "equivalent CLI" for a warm-started reward-model (SARM) run trained **from scratch** (`RewardModelConfig.pretrained_path` defaults to `None`) instead of loading `base_model`, diverging from the in-process `train(cfg)` path. Same `build_command`↔`build_config` drift class as the recent `--peft.lora_alpha` fix.

## Change

`build_command` now emits `--reward_model.pretrained_path=<base_model>` when `base_model` is set (via the reward-flag helper) — mirroring the policy path's `--policy.pretrained_path`.

`push_to_hub` is intentionally **not** emitted: `RewardModelConfig.push_to_hub` already defaults to `False` (unlike policy configs, which default `True`), so `build_config` setting it `False` is a no-op the CLI need not restate.

## Test

`test_build_command_emits_reward_model_pretrained_path` (fails-before): a warm-started reward-model spec must emit `--reward_model.pretrained_path` and never `--policy.pretrained_path`. Complements the existing `build_config` warm-start test. `TestRewardModelTraining` + `TestBuildCommand` + `TestRunTypeLabel`: 24 passed. ruff + `ruff format` + mypy clean.

No behavioural/render change (argv-parity training-config helper), so no visual artifact.