### PR TITLE
docs(sim): update Isaac backend docs to in-tree strands-robots[sim-isaac]

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ Robot("my_arm", urdf_path="arm.xml") # bring your own MJCF/URDF
 |-----------|------|---------|-------------|
 | `name` | `str` | required | Robot name or alias (see [Supported robots](#supported-robots)) |
 | `mode` | `str` | `"sim"` | `"sim"`, `"real"`, or `"auto"` (case-insensitive) |
-| `backend` | `str` | `"mujoco"` | Sim backend: `"mujoco"`, `"newton"` (built-in), or `"isaac"` (via the [`strands-robots-sim`](https://github.com/strands-labs/robots-sim) plugin) |
+| `backend` | `str` | `"mujoco"` | Sim backend: `"mujoco"`, `"newton"`, or `"isaac"` (all built-in; `isaac` needs the `sim-isaac` extra) |
 | `urdf_path` | `str` | `None` | Explicit MJCF/URDF path (skips registry lookup) |
 | `cameras` | `dict` | `None` | Camera config (**`mode="real"` only**) |
 | `position` | `list[float]` | `[0,0,0]` | Spawn position in the sim world |
@@ -1086,10 +1086,10 @@ touches ROS 2.
 </details>
 
 <details>
-<summary><b>Isaac Sim backend env vars (<code>strands-robots-sim</code> plugin)</b></summary>
+<summary><b>Isaac Sim backend env vars (<code>strands-robots[sim-isaac]</code>)</b></summary>
 
-These are read by the out-of-tree [`strands-robots-sim`](https://github.com/strands-labs/robots-sim)
-Isaac Sim backend (`pip install 'strands-robots-sim[isaac]'`) when it builds its
+These are read by the built-in, in-tree Isaac Sim backend
+(`pip install 'strands-robots[sim-isaac]'`) when it builds its
 `IsaacConfig`; an explicit `create_simulation("isaac", ...)` kwarg always wins.
 See [`docs/simulation/isaac.md`](docs/simulation/isaac.md).
 

--- a/docs/simulation/isaac.md
+++ b/docs/simulation/isaac.md
@@ -2,16 +2,16 @@
 
 The Isaac Sim backend runs the simulation on
 [NVIDIA Isaac Sim](https://developer.nvidia.com/isaac-sim) (PhysX GPU physics +
-RTX path-traced rendering). It ships **out-of-tree** in the sibling package
-[`strands-robots-sim`](https://github.com/strands-labs/robots-sim) and registers
-an `IsaacSimulation` under the `strands_robots.backends` entry-point group. It
-implements the same `SimEngine` contract as the built-in MuJoCo backend, so the
+RTX path-traced rendering). It is a **built-in, in-tree** backend that lives at
+`strands_robots.simulation.isaac`, a peer of the `mujoco` and `newton` backends.
+It implements the same `SimEngine` contract as the MuJoCo backend, so the
 `Robot()` / `Simulation` / policy APIs are identical - only the physics and
 rendering run on the GPU through Isaac Sim.
 
-`strands-robots` has **no hard dependency** on Isaac Sim: install the plugin and
-`create_simulation("isaac")` discovers it through entry points, exactly like
-`create_simulation("mujoco")`.
+`strands-robots` has **no hard dependency** on Isaac Sim: the `sim-isaac` extra
+provides the pip-installable helpers, and `create_simulation("isaac")` resolves
+the **built-in** backend, exactly like `create_simulation("mujoco")`. Isaac Sim
+itself is a ~30 GB non-PyPI install you provision out-of-band (see below).
 
 ## When to use it
 
@@ -29,7 +29,8 @@ Sim is a ~30 GB install and requires an NVIDIA GPU.
 
 ## Install
 
-Isaac Sim itself is **not on PyPI** - install it first, then the Python plugin:
+Isaac Sim itself is **not on PyPI** - install it first, then the `sim-isaac`
+extra:
 
 ```bash
 # Step 1 - install Isaac Sim 6.0 (Python 3.12) via one of:
@@ -37,14 +38,14 @@ Isaac Sim itself is **not on PyPI** - install it first, then the Python plugin:
 #   - Isaac Lab: git clone IsaacLab && ./isaaclab.sh -i, OR
 #   - NGC Docker: docker pull nvcr.io/nvidia/isaac-sim:6.0
 
-# Step 2 - install the Python plugin (pulls in strands-robots transitively):
-pip install 'strands-robots-sim[isaac]'
+# Step 2 - install the sim-isaac extra (helpers for the built-in backend):
+pip install 'strands-robots[sim-isaac]'
 ```
 
-The `[isaac]` extra lives in `strands-robots-sim`, not in `strands-robots`.
-Requesting `create_simulation("isaac")` without the plugin installed raises a
-`ValueError` whose message carries the exact install hint
-(`pip install 'strands-robots-sim[isaac]'`). Backend discovery is lazy, so
+The `sim-isaac` extra lives in **`strands-robots`** (a peer of `sim-mujoco` and
+`sim-newton`). Requesting `create_simulation("isaac")` without the extra
+installed raises a `ValueError` whose message carries the exact install hint
+(`pip install 'strands-robots[sim-isaac]'`). Backend discovery is lazy, so
 MuJoCo-only users never pay the Isaac Sim import cost.
 
 ## Usage
@@ -52,8 +53,7 @@ MuJoCo-only users never pay the Isaac Sim import cost.
 ```python
 from strands_robots.simulation import create_simulation
 
-# Kwargs flow into IsaacConfig. "isaac" resolves via the
-# strands_robots.backends entry point.
+# Kwargs flow into IsaacConfig. "isaac" resolves as a built-in backend.
 sim = create_simulation("isaac", render_mode="rtx_realtime", headless=True)
 sim.create_world()
 sim.add_robot("so100")                          # procedural; no asset files needed
@@ -93,8 +93,8 @@ rejected eagerly. The commonly used fields:
 
 ### Environment variables
 
-The plugin reads three `STRANDS_ISAAC_*` variables (resolved when `IsaacConfig`
-is constructed). An explicit kwarg always wins over the env var.
+The Isaac backend reads three `STRANDS_ISAAC_*` variables (resolved when
+`IsaacConfig` is constructed). An explicit kwarg always wins over the env var.
 
 | Variable | Description | Default |
 |----------|-------------|---------|
@@ -133,9 +133,11 @@ sim.destroy()
 
 ## Where to go next
 
-The plugin ships its own MkDocs site with a Quickstart, architecture, backend
-reference, and troubleshooting:
+The Isaac backend was originally prototyped in the `strands-robots-sim`
+project, which still hosts a MkDocs site with additional architecture notes and
+troubleshooting. It is kept here as background reference; the backend itself now
+ships in-tree in `strands-robots`:
 
-- Plugin docs: <https://strands-labs.github.io/robots-sim/>
+- Background docs: <https://strands-labs.github.io/robots-sim/>
 - Backend reference: <https://strands-labs.github.io/robots-sim/backends/isaac/>
-- Source: <https://github.com/strands-labs/robots-sim>
+- Source (historical): <https://github.com/strands-labs/robots-sim>


### PR DESCRIPTION
## What changed

Docs-only follow-up to #1153 / epic #1144. The Isaac Sim backend was absorbed
**in-tree** (now a built-in backend at `strands_robots.simulation.isaac`, a peer
of `mujoco` and `newton`), but the Isaac **documentation** still described it as
an out-of-tree plugin installed via `pip install 'strands-robots-sim[isaac]'`.
That guidance was stale and, in places, factually wrong. This PR updates the
docs to reflect current reality: Isaac is a **built-in backend** installed via
**`pip install 'strands-robots[sim-isaac]'`**.

### `docs/simulation/isaac.md`
- Intro: reframed from "ships out-of-tree in `strands-robots-sim` and registers
  under the `strands_robots.backends` entry-point group" to an **in-tree
  built-in** backend at `strands_robots.simulation.isaac`.
- No-hard-dependency paragraph: the `sim-isaac` extra provides the
  pip-installable helpers; `create_simulation("isaac")` resolves the **built-in**
  backend. Isaac Sim itself is still described as a non-PyPI ~30 GB out-of-band
  install.
- Install Step 2: `strands-robots-sim[isaac]` -> `strands-robots[sim-isaac]`.
- "The `[isaac]` extra lives in `strands-robots-sim`" -> the `sim-isaac` extra
  lives in **`strands-robots`** (peer of `sim-mujoco` / `sim-newton`); install
  hint corrected.
- Env-var and usage sections: "the plugin" -> "the Isaac backend"; usage comment
  now says "resolves as a built-in backend."
- "Where to go next": reframed the `strands-robots-sim` links as historical /
  background references rather than "the plugin ships its own site."

### `README.md`
- "Isaac Sim backend env vars" `<details>` block: summary label and body use
  `strands-robots[sim-isaac]` and describe the **in-tree** backend; dropped the
  out-of-tree-plugin framing. Now consistent with the Simulation section
  (~L197, already correct).
- `backend` param row: `isaac` is now described as built-in (needs the
  `sim-isaac` extra) instead of "via the `strands-robots-sim` plugin".

## Why
Completes the out-of-scope follow-up explicitly flagged in PR #1153. The extra
is `sim-isaac` (matching the `sim-mujoco` / `sim-newton` convention);
`strands-robots[isaac]` does not exist and would error.

## Test surface
- `hatch run lint` — clean (ruff + mypy, no issues in 801 source files).
- Docs hygiene tests — `test_docs_brand_visuals.py`,
  `test_docs_home_navigation.py`, `test_docstrings_no_dangling_doc_refs.py`,
  `test_no_host_paths.py` all pass.
- `mkdocs build --strict` — exits 0.
- `grep -rn "strands-robots-sim\[isaac\]" docs/ README.md` — clean.

## Acceptance criteria
- [x] No remaining `strands-robots-sim[isaac]` install references in `docs/` or
  `README.md` (grep clean).
- [x] `docs/simulation/isaac.md` describes Isaac as an in-tree built-in backend
  and uses `pip install 'strands-robots[sim-isaac]'`.
- [x] `README.md` Isaac env-var section uses `strands-robots[sim-isaac]` and no
  longer calls it an out-of-tree plugin; consistent with the Simulation section.
- [x] Isaac Sim itself remains described as a non-PyPI, out-of-band ~30 GB
  install (unchanged).
- [x] `hatch run lint`, docs/nav hygiene tests, and `mkdocs build --strict` pass.

## Out of scope
- No changes to `factory.py`, `pyproject.toml`, or any Python — they already
  reflect the in-tree backend.
- Broader `strands-robots-sim` deprecation messaging beyond the Isaac install /
  env-var references above. Remaining `robots-sim` links are retained as
  historical/background references.

## Project board
Please move #1440 to "In review" on the
[Strands Labs - Robots board](https://github.com/orgs/strands-labs/projects/2).

Closes #1440.
