### PR TITLE
test(policies): pin lerobot_local processor optional-import degradation

### DIFF
--- a/tests/policies/lerobot_local/test_checkpoint_state_dict_load_failsoft.py
+++ b/tests/policies/lerobot_local/test_checkpoint_state_dict_load_failsoft.py
@@ -74,6 +74,17 @@ class TestHubCheckpoint:
         monkeypatch.setattr("huggingface_hub.hf_hub_download", lambda *_a, **_k: str(bad))
         assert _load_checkpoint_state_dict(str(tmp_path)) is None
 
+    def test_absent_huggingface_hub_degrades_to_none(self, tmp_path, monkeypatch):
+        # No local checkpoint and huggingface_hub is not importable (the [hub]
+        # dependency was never installed): the guarded Hub import must swallow
+        # the ImportError and return None instead of crashing the load path.
+        import sys
+        import types
+
+        stub = types.ModuleType("huggingface_hub")  # bare module: no hf_hub_download
+        monkeypatch.setitem(sys.modules, "huggingface_hub", stub)
+        assert _load_checkpoint_state_dict(str(tmp_path)) is None
+
 
 class TestSafetensorsUnavailable:
     def test_missing_safetensors_returns_none(self, tmp_path, monkeypatch):

--- a/tests/policies/lerobot_local/test_norm_stats_fallback.py
+++ b/tests/policies/lerobot_local/test_norm_stats_fallback.py
@@ -312,6 +312,17 @@ class TestProcessorBridgeFallback:
             pytest.skip("installed lerobot has no ProcessorMigrationError")
         assert migration_error in _missing_config_errors()
 
+    def test_missing_migration_error_falls_back_to_builtin_errors(self, monkeypatch):
+        # On an older lerobot that predates ProcessorMigrationError the set must
+        # degrade to the built-in (FileNotFoundError, ValueError) rather than
+        # raise ImportError while classifying a missing processor config.
+        from lerobot.processor import pipeline as lr_pipeline
+
+        from strands_robots.policies.lerobot_local.processor import _missing_config_errors
+
+        monkeypatch.delattr(lr_pipeline, "ProcessorMigrationError", raising=False)
+        assert _missing_config_errors() == (FileNotFoundError, ValueError)
+
 
 @_requires_lerobot_pipeline
 class TestUpstreamLerobotParity:


### PR DESCRIPTION
## Problem

Two best-effort fallback branches in the `lerobot_local` processor bridge (`strands_robots/policies/lerobot_local/processor.py`) were uncovered. Both encode a graceful-degradation contract that a refactor could silently break, turning a missing optional dependency or a lerobot version drift into a hard failure in the policy load path.

1. `_load_checkpoint_state_dict` reaches for `huggingface_hub.hf_hub_download` only to fetch a single-file `model.safetensors` from the Hub. When `huggingface_hub` is not importable (the Hub dependency was never installed), the guarded import must swallow the `ImportError` and return `None` so the policy degrades to passthrough instead of crashing the ACT/diffusion load path. Existing tests covered the safetensors-missing branch and the Hub *download-error* branch, but not the Hub *import-missing* branch.

2. `_missing_config_errors` folds lerobot's `ProcessorMigrationError` into the "no standard processor config" exception set when the installed lerobot exposes it (>= 0.5.2). On an older lerobot that predates the symbol, the set must fall back to `(FileNotFoundError, ValueError)` without raising `ImportError`. Only the present-branch was pinned.

## Change

Two focused regression tests added to the existing behavior-named files:

- `test_checkpoint_state_dict_load_failsoft.py::TestHubCheckpoint::test_absent_huggingface_hub_degrades_to_none` — stubs `huggingface_hub` in `sys.modules` with a bare module so the guarded `from huggingface_hub import hf_hub_download` raises `ImportError`; asserts the loader returns `None`.
- `test_norm_stats_fallback.py::TestProcessorBridgeFallback::test_missing_migration_error_falls_back_to_builtin_errors` — deletes `ProcessorMigrationError` off `lerobot.processor.pipeline`; asserts `_missing_config_errors()` degrades to `(FileNotFoundError, ValueError)`.

Both reuse the modules' existing `importorskip` guards so they run only where the real deps are present. No source changes.

## Verification

- `strands_robots/policies/lerobot_local/processor.py` lines 71 and 118-127 move from uncovered to covered; both new tests fail-safe under the repo's torch mock via the pre-existing guards.
- Full suite (headless, `MUJOCO_GL=egl`): 10797 passed, 193 skipped, 0 failed; total coverage 93.02% -> 93.03%.
- Lint clean: `ruff check`, `ruff format --check`, `mypy strands_robots tests tests_integ` all pass.