### PR TITLE
test(hardware): cover get_status camera listing, fail-soft stop(), teleop receiver teardown

### DIFF
--- a/tests/test_hardware_robot_lifecycle.py
+++ b/tests/test_hardware_robot_lifecycle.py
@@ -721,6 +721,21 @@ class TestStatusSurface:
         assert status["task_error"] == "gripper stalled"
         hw.cleanup()
 
+    def test_get_status_lists_the_devices_configured_cameras(self):
+        """The operator health probe enumerates the arm's configured cameras.
+
+        A follower with wrist/front cameras must surface those camera names
+        under ``cameras`` so a supervising agent knows which image streams
+        exist before starting a policy run. An arm with no cameras reports an
+        empty list (already covered by the connection-status test).
+        """
+        fake = _FakeLeRobot(connected=True)
+        fake.config = type("Cfg", (), {"cameras": {"wrist_cam": object(), "front_cam": object()}})()
+        hw = _make_robot(fake)
+        status = asyncio.run(hw.get_status())
+        assert status["cameras"] == ["wrist_cam", "front_cam"]
+        hw.cleanup()
+
     def test_tool_spec_advertises_actions(self):
         hw = _make_robot()
         spec = hw.tool_spec
@@ -873,6 +888,25 @@ class TestTeleopStopAndStatus:
         assert "gamepad" in hw._input_publishers
         hw.cleanup()
 
+    def test_stop_named_device_removes_only_the_matching_receiver_by_suffix(self):
+        """``stop_teleop(device_name=...)`` tears down the receiver whose
+        ``<source>/<device>`` key ends in that device and leaves other
+        sources' receivers running, so a follower can drop one operator's
+        input stream without disturbing another live session.
+        """
+        hw = _make_robot()
+        leader = _FakeReceiver()
+        gamepad = _FakeReceiver()
+        hw._input_publishers = {}
+        hw._input_receivers = {"opA/leader": leader, "opB/gamepad": gamepad}
+        result = hw.stop_teleop(device_name="leader")
+        assert result["status"] == "success"
+        assert "opA/leader" not in hw._input_receivers
+        assert "opB/gamepad" in hw._input_receivers
+        assert leader.stopped is True
+        assert gamepad.stopped is False
+        hw.cleanup()
+
     def test_stop_with_no_sessions(self):
         hw = _make_robot()
         result = hw.stop_teleop()
@@ -931,6 +965,21 @@ class TestCleanup:
         hw = _make_robot(fake)
         asyncio.run(hw.stop())
         assert fake.is_connected is False
+
+    def test_async_stop_is_fail_soft_when_disconnect_raises(self):
+        """``stop()`` is the operator teardown path; a device whose
+        ``disconnect()`` raises (e.g. the USB cable was already pulled) must
+        not propagate the fault out of ``stop()`` and abort the shutdown.
+        """
+
+        class _RaisingDisconnect(_FakeLeRobot):
+            def disconnect(self) -> None:
+                raise RuntimeError("device already gone")
+
+        hw = _make_robot(_RaisingDisconnect(connected=True))
+        # Must not raise despite the disconnect fault.
+        asyncio.run(hw.stop())
+        hw.cleanup()
 
 
 class TestExecuteTaskSync:


### PR DESCRIPTION
## Problem

Three operator hot-path branches in `strands_robots.hardware_robot.Robot` had no test coverage:

- **`get_status()` camera listing** — the loop that enumerates a device's configured cameras was dead in tests. The in-memory fake device always exposes an empty camera set, so the branch that appends camera names to the status payload never ran. An operator health probe on an arm *with* cameras was unverified.
- **Async `stop()` fail-soft teardown** — the happy path (successful `disconnect()`) was covered, but the `except` branch was not. `stop()`'s contract is that a device whose `disconnect()` raises (e.g. a USB cable pulled mid-session) must not propagate the fault and abort shutdown — that robustness guarantee was unpinned.
- **`stop_teleop(device_name=...)` receiver suffix match** — existing tests only populated `_input_publishers`, so the branch that removes a receiver by its `<source>/<device>` key suffix never executed. Dropping one operator's input receiver while leaving another source's session running was untested.

## Change

Add three focused behavior tests to `tests/test_hardware_robot_lifecycle.py`, asserting observable outputs only (status payload contents, receiver-dict membership, no-raise), reusing the existing `_make_robot` / `_FakeLeRobot` / `_FakeReceiver` harness:

- `test_get_status_lists_the_devices_configured_cameras`
- `test_async_stop_is_fail_soft_when_disconnect_raises`
- `test_stop_named_device_removes_only_the_matching_receiver_by_suffix`

Each test exercises a branch that is uncovered on `main` and passes here; `hardware_robot.py` coverage rises accordingly (the camera loop body, the `stop()` exception handler, and the receiver suffix-match loop are now hit).

## Verification

- `ruff check`, `ruff format --check`, `mypy` clean on the changed file.
- `MUJOCO_GL=egl pytest tests/test_hardware_robot_lifecycle.py` — 69 passed (66 existing + 3 new).

Test-only change; no production code touched.