### PR TITLE
test(rtps): pin HardwareRtpsBridge.publish_image drops non-RGB frames

### DIFF
--- a/tests/test_hardware_rtps_bridge.py
+++ b/tests/test_hardware_rtps_bridge.py
@@ -216,6 +216,31 @@ def test_publish_image_fields(fake_cyclonedds: dict[str, Any]) -> None:
     assert len(msg.data) == 4 * 6 * 3
 
 
+def test_publish_image_drops_non_rgb_frames(fake_cyclonedds: dict[str, Any]) -> None:
+    """publish_image silently drops frames that are not HxWx3 RGB.
+
+    A ``sensor_msgs/Image`` published with a mismatched shape/step would make a
+    downstream ROS 2 consumer misread the raw byte buffer, so the bridge rejects
+    grayscale (2D) and non-3-channel frames before it ever creates a writer.
+    """
+    b = _bridge(enable_commands=False)
+    topic = "rt/test_arm/wrist/image_raw"
+
+    # 2D grayscale, 4-channel RGBA, and a singleton channel are all malformed
+    # for an rgb8 Image -> each must be dropped without publishing.
+    b.publish_image("test_arm", "wrist", np.zeros((4, 6), dtype=np.uint8))
+    b.publish_image("test_arm", "wrist", np.zeros((4, 6, 4), dtype=np.uint8))
+    b.publish_image("test_arm", "wrist", np.zeros((4, 6, 1), dtype=np.uint8))
+    assert not any(w.topic == topic for w in fake_cyclonedds["writers"])
+
+    # A well-formed RGB frame afterwards still publishes -> the guard is
+    # specific to malformed frames, not a blanket mute of the camera topic.
+    b.publish_image("test_arm", "wrist", np.zeros((4, 6, 3), dtype=np.uint8))
+    writer = next(w for w in fake_cyclonedds["writers"] if w.topic == topic)
+    (msg,) = writer.samples
+    assert (msg.height, msg.width, msg.encoding) == (4, 6, "rgb8")
+
+
 def test_command_subscription_drives_send_action(fake_cyclonedds: dict[str, Any]) -> None:
     robot = _FakeRobot()
     b = _bridge(robot)


### PR DESCRIPTION
## What

`HardwareRtpsBridge.publish_image` early-returns for any frame that is not `HxWx3` RGB:

```python
if image.ndim != 3 or image.shape[2] != 3:
    return
```

This guard prevents a malformed `sensor_msgs/Image` (wrong `step`/`data` length) from ever reaching the DDS wire, where a downstream ROS 2 consumer would misread the raw byte buffer. Until now only the valid-RGB path had a test (`test_publish_image_fields`); the drop branch was unexercised.

## Change

Adds `test_publish_image_drops_non_rgb_frames`, which asserts that:

- a 2D grayscale frame, a 4-channel RGBA frame, and a singleton-channel `(H, W, 1)` frame are each dropped without lazily creating a writer or publishing anything, and
- a well-formed `HxWx3` RGB frame published afterwards still goes out on the topic - proving the guard is frame-specific, not a topic-wide mute.

Test-only; no production code changes. Reuses the existing `fake_cyclonedds` fixture and `_FakeWriter`, so it runs without a real cyclonedds install.

## Verification

- Regression-checked: removing the shape guard makes the new test fail (a writer is created for the grayscale frame); restoring it passes.
- `tests/test_hardware_rtps_bridge.py`: 21 passed. Module coverage for `hardware_rtps_bridge.py` 95% -> 96%.
- `ruff check` / `ruff format --check` / `mypy` clean on `strands_robots tests tests_integ`.