### PR TITLE
test(mesh): pin audit-log walker skips a malformed JSON line

### DIFF
--- a/tests/mesh/test_audit_read_walker_defenses.py
+++ b/tests/mesh/test_audit_read_walker_defenses.py
@@ -16,6 +16,12 @@ That dual role makes its file-handling discipline security-relevant:
   timestamp (and records with a non-numeric ``ts``) while keeping newer
   ones, so a time-bounded forensic query returns only the window asked
   for.
+* A corrupt line that is not valid JSON (a torn write, or a
+  forward-compatibility line from a newer writer) must be skipped so
+  the whole read is not aborted, while a DEBUG breadcrumb is emitted --
+  the skipped line is invisible to the ``_load_seq_counters`` seq-seed
+  walk, so the breadcrumb is the operator's only signal the seed may be
+  incomplete.
 
 These behaviors had no direct regression coverage; this file pins them.
 """
@@ -128,3 +134,37 @@ def test_read_audit_log_since_filters_old_and_non_numeric_ts(tmp_path, monkeypat
     records = audit.read_audit_log(since=150.0)
     events = [r.get("event") for r in records]
     assert events == ["new"], f"since= should keep only records at/after the cutoff, got {events}"
+
+
+def test_read_audit_log_skips_malformed_json_line(tmp_path, monkeypatch, caplog):
+    """A corrupt (non-JSON) line is skipped; surrounding valid records survive.
+
+    A torn write (process killed mid-append) or a forward-compat line from a
+    newer writer can leave a line that is not valid JSON. The forensic walker
+    must skip that single line rather than abort the entire read, so the valid
+    records around it remain recoverable. A DEBUG breadcrumb is emitted because
+    a skipped line is invisible to the ``_load_seq_counters`` seq-seed walk,
+    which would otherwise silently under-seed the per-peer counter.
+    """
+    active = audit.audit_log_path()
+    active.parent.mkdir(parents=True, exist_ok=True)
+    active.write_text(
+        "\n".join(
+            [
+                '{"event": "before", "payload": {"i": 1}}',
+                "{ this is not valid json",
+                '{"event": "after", "payload": {"i": 2}}',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with caplog.at_level("DEBUG", logger="strands_robots.mesh.audit"):
+        records = audit.read_audit_log()
+
+    events = [r.get("event") for r in records]
+    assert events == ["before", "after"], f"malformed line must be skipped while valid records are kept, got {events}"
+    assert any("skipping malformed line" in m for m in caplog.messages), (
+        f"expected a DEBUG breadcrumb for the skipped line, got {caplog.messages}"
+    )


### PR DESCRIPTION
## Problem

`read_audit_log` in `strands_robots/mesh/audit.py` is both the operator-facing forensic reader and the seq-seed source for `_load_seq_counters` when the seq sidecar is corrupt. That dual role makes its line-parsing discipline security-relevant.

A corrupt line that is not valid JSON can end up in the log two ways in practice:
- a torn write (the process is killed mid-append), or
- a forward-compatibility line written by a newer writer.

The walker already handles this: it skips the single malformed line rather than aborting the entire read, and emits a DEBUG breadcrumb. The breadcrumb matters because a skipped line is invisible to the `_load_seq_counters` seq-seed walk, so on the next restart the per-peer counter could silently under-seed and produce a duplicate `seq`; the DEBUG line is the operator's only signal the seed may be incomplete.

This skip-and-continue path had **no direct regression coverage**. The sibling walker defenses in the same module are already pinned (symlink refusal of rotated files, non-numeric-suffix sibling exclusion, `since=` filtering), so the malformed-line path was the one gap in the set.

## Change

Adds one behavior-level regression test to `tests/mesh/test_audit_read_walker_defenses.py`:

- Writes an active log with a valid record, a non-JSON line, then another valid record.
- Asserts both valid records are returned in order (the malformed line is skipped, the read is not aborted).
- Asserts the DEBUG breadcrumb (`skipping malformed line`) is emitted.

The module docstring's contract list is extended with the malformed-line behavior so the file's intent stays self-documenting.

## Regression semantics

Replacing the guarded `json.loads` with an unguarded one makes the new test fail with `JSONDecodeError` (the exception propagates out of `read_audit_log`), so the test genuinely pins the skip-and-continue contract rather than restating current behavior.

## Verification

- `ruff check` / `ruff format --check`: clean.
- `mypy strands_robots tests tests_integ`: no issues (801 source files).
- `pytest tests/mesh/test_audit_read_walker_defenses.py`: 4 passed.

Test-only change; no runtime code, docs (beyond the test module docstring), or dependencies touched.