### PR TITLE
fix(calibrate): strip orphan whitespace from lerobot_calibrate header lines

### DIFF
--- a/strands_robots/tools/lerobot_calibrate.py
+++ b/strands_robots/tools/lerobot_calibrate.py
@@ -417,7 +417,7 @@ def lerobot_calibrate(
                 }
 
             # Format output
-            content_lines = [" **LeRobot Calibrations**", f"Location: `{manager.base_path}`", ""]
+            content_lines = ["**LeRobot Calibrations**", f"Location: `{manager.base_path}`", ""]
             total_count = 0
 
             for dev_type, models in structure.items():
@@ -427,13 +427,13 @@ def lerobot_calibrate(
                 if not models:
                     continue
 
-                content_lines.append(f"##  **{dev_type.title()}**")
+                content_lines.append(f"## **{dev_type.title()}**")
 
                 for model, calibrations in models.items():
                     if device_model and device_model != model:
                         continue
 
-                    content_lines.append(f"###  **{model}** ({len(calibrations)} calibrations)")
+                    content_lines.append(f"### **{model}** ({len(calibrations)} calibrations)")
 
                     for calib_id in calibrations:
                         info = manager.get_calibration_info(dev_type, model, calib_id)
@@ -526,7 +526,7 @@ def lerobot_calibrate(
 
                 content_lines.extend(
                     [
-                        f"###  **{result['device_type']}/{result['device_model']}/{result['device_id']}**",
+                        f"### **{result['device_type']}/{result['device_model']}/{result['device_id']}**",
                         f"  - **Modified:** {modified}",
                         f"  - **Size:** {size_kb:.1f} KB",
                         f"  - **Motors:** {motor_info}",
@@ -549,14 +549,14 @@ def lerobot_calibrate(
 
             if success:
                 content_lines = [
-                    " **Backup Completed Successfully**",
+                    "**Backup Completed Successfully**",
                     f"**Location:** `{message}`",
                     f"**Files copied:** {count}",
                     "",
                 ]
 
                 if device_type or device_model or device_id:
-                    content_lines.append(" **Filters applied:**")
+                    content_lines.append("**Filters applied:**")
                     if device_type:
                         content_lines.append(f"  - Device Type: `{device_type}`")
                     if device_model:
@@ -658,10 +658,10 @@ def lerobot_calibrate(
                         }
 
             content_lines = [
-                " **Calibration Analysis**",
+                "**Calibration Analysis**",
                 f"**Base Path:** `{manager.base_path}`",
                 "",
-                "###  **Summary Statistics**",
+                "### **Summary Statistics**",
                 f"  - **Total Calibrations:** {total_calibrations}",
                 f"  - **Teleoperators:** {device_counts['teleoperators']}",
                 f"  - **Robots:** {device_counts['robots']}",
@@ -670,7 +670,7 @@ def lerobot_calibrate(
             ]
 
             if model_stats:
-                content_lines.extend(["###  **Device Model Breakdown**"])
+                content_lines.extend(["### **Device Model Breakdown**"])
                 for model_key, count in sorted(model_stats.items()):
                     motor_info = ""
                     if model_key in motor_stats:

--- a/tests/tools/test_lerobot_calibrate.py
+++ b/tests/tools/test_lerobot_calibrate.py
@@ -13,6 +13,7 @@ structures, round-trips) rather than implementation details.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any
 
@@ -641,3 +642,66 @@ def test_list_marks_unreadable_calibration_without_failing(populated: Path, monk
     result = lerobot_calibrate(action="list", base_path=str(populated))
     assert result["status"] == "success"
     assert "error reading file" in result["content"][0]["text"]
+
+
+# --- Well-formed markdown headers (no orphan whitespace) --------------------
+# Emoji sweeps that stripped a leading icon from a header line ("## icon Foo")
+# leave orphan whitespace behind ("##  Foo", " **Foo**"), which renders as a
+# malformed heading with a stray leading space or a double space after the
+# hashes. These tests pin the rendered heading lines of the list-heavy actions
+# so that regression cannot silently reappear.
+
+
+def _assert_no_orphan_header_whitespace(text: str) -> None:
+    """Fail if any rendered line has orphan markdown-header whitespace.
+
+    Rejects a line that leads with a space before a bold ``**`` title
+    (e.g. ``" **Foo**"``) and a heading whose hashes are followed by more than
+    one space (e.g. ``"##  Foo"``). Nested list items (``"  - ..."``) are
+    legitimately indented and are left untouched.
+    """
+    for line in text.splitlines():
+        stripped = line.lstrip(" ")
+        if stripped.startswith("- "):
+            continue  # nested list item; indentation is intentional
+        assert not (line.startswith(" ") and stripped.startswith("**")), (
+            f"header line leads with orphan whitespace: {line!r}"
+        )
+        assert not re.match(r"#{1,6}\s{2,}", stripped), f"heading has double space after hashes: {line!r}"
+
+
+def test_list_headers_have_no_orphan_whitespace(populated: Path) -> None:
+    """``list`` renders its title and per-type/model headings without orphan gaps."""
+    result = lerobot_calibrate(action="list", base_path=str(populated))
+    assert result["status"] == "success"
+    text = result["content"][0]["text"]
+    _assert_no_orphan_header_whitespace(text)
+    # The section headings must render as clean single-space markdown.
+    assert "## **Teleoperators**" in text or "## **Robots**" in text
+    assert text.startswith("**LeRobot Calibrations**")
+
+
+def test_analyze_headers_have_no_orphan_whitespace(populated: Path) -> None:
+    """``analyze`` renders its title and stat sub-headings without orphan gaps."""
+    result = lerobot_calibrate(action="analyze", base_path=str(populated))
+    assert result["status"] == "success"
+    text = result["content"][0]["text"]
+    _assert_no_orphan_header_whitespace(text)
+    assert text.startswith("**Calibration Analysis**")
+    assert "### **Summary Statistics**" in text
+    assert "### **Device Model Breakdown**" in text
+
+
+def test_backup_summary_headers_have_no_orphan_whitespace(populated: Path, tmp_path: Path) -> None:
+    """``backup`` renders its completion and filter headings without orphan gaps."""
+    result = lerobot_calibrate(
+        action="backup",
+        output_dir=str(tmp_path / "bk"),
+        device_type="robots",
+        base_path=str(populated),
+    )
+    assert result["status"] == "success"
+    text = result["content"][0]["text"]
+    _assert_no_orphan_header_whitespace(text)
+    assert text.startswith("**Backup Completed Successfully**")
+    assert "**Filters applied:**" in text


### PR DESCRIPTION
## Problem

The `lerobot_calibrate` tool renders several of its section headings with orphan whitespace. The `list`, `analyze`, and `backup` actions emit heading lines like:

```
 **LeRobot Calibrations**
##  **Teleoperators**
###  **Summary Statistics**
 **Backup Completed Successfully**
```

Title lines lead with a stray space and the `##`/`###` sub-headings carry a double space after the hashes. Both render as malformed markdown - a heading that starts with a space, or with a gap between the hashes and the text. The gap is an emoji-sweep leftover (a leading icon was removed but its trailing space was not).

## Change

Normalize all nine affected heading lines across the `list`, detail, `backup`, and `analyze` outputs to clean single-space markdown:

```
**LeRobot Calibrations**
## **Teleoperators**
### **Summary Statistics**
**Backup Completed Successfully**
```

Nested list-item indentation (`  - **Modified:** ...`) is intentionally preserved - only heading/title lines change. No behavior change beyond the rendered text.

## Tests

Adds three regression tests over the `list`, `analyze`, and `backup` actions that assert rendered heading lines carry no orphan whitespace (no leading space before a bold title, no double space after heading hashes), while allowing legitimately-indented list items. The shared assertion helper fails on the pre-fix strings; verified the new tests fail before the source change and pass after.

Full `tests/tools/test_lerobot_calibrate.py` passes (68 tests). `ruff check`, `ruff format --check`, and `mypy` over `strands_robots tests tests_integ` are clean.