### PR TITLE
feat(streaming): forward repo_type through StreamingDatasetReader.open

### DIFF
--- a/strands_robots/simulation/recording.py
+++ b/strands_robots/simulation/recording.py
@@ -442,9 +442,8 @@ class DatasetRecordingMixin:
 
         This is the in-process counterpart to ``start_recording`` /
         ``stop_recording``: where those WRITE a dataset, ``stream_dataset``
-        READS one back lazily for eval / replay / inspection (Phase 3 of the
-        physical-AI data loop). Training scripts can instead use
-        ``python -m lerobot.scripts.train dataset.streaming=true`` which uses
+        READS one back lazily for eval / replay / inspection. Training scripts
+        can instead use ``lerobot-train --dataset.streaming=true`` which uses
         the same underlying StreamingLeRobotDataset.
 
         Args:
@@ -453,7 +452,8 @@ class DatasetRecordingMixin:
             **kwargs: Forwarded to
                 :meth:`StreamingDatasetReader.open` - e.g. ``root``,
                 ``delta_timestamps``, ``episodes``, ``shuffle``, ``buffer_size``,
-                ``max_num_shards``, ``drop_videos`` (proprio-only, torchcodec-free).
+                ``max_num_shards``, ``drop_videos`` (proprio-only, torchcodec-free),
+                ``repo_type`` (``"dataset"`` or ``"bucket"``).
 
         Returns:
             A :class:`~strands_robots.streaming_dataset.StreamingDatasetReader`.

--- a/strands_robots/streaming_dataset.py
+++ b/strands_robots/streaming_dataset.py
@@ -112,6 +112,7 @@ class StreamingDatasetReader:
         return_uint8: bool = True,  # halves frame bandwidth; policies normalize
         validate_deltas: bool = True,  # parity with the materialized dataset path
         drop_videos: bool = False,  # proprio-only streaming (no torchcodec)
+        repo_type: str = "dataset",  # "dataset" or "bucket"; forwarded only to a lerobot that accepts it
     ) -> StreamingDatasetReader:
         StreamingCls = _get_streaming_cls()
         init_sig = inspect.signature(StreamingCls).parameters
@@ -140,8 +141,12 @@ class StreamingDatasetReader:
             seed=seed,
             shuffle=shuffle,
             return_uint8=return_uint8,
+            repo_type=repo_type,
         )
         for k, v in candidate.items():
+            # repo_type (and any other candidate) is only forwarded to a
+            # StreamingLeRobotDataset that declares it; a version without the
+            # parameter drops it here rather than raising a TypeError.
             if not (accepts_var_kw or k in init_sig):
                 continue
             if k in ("streaming", "shuffle", "return_uint8") or v is not None:

--- a/tests/test_streaming_dataset.py
+++ b/tests/test_streaming_dataset.py
@@ -63,6 +63,39 @@ def test_open_drops_unknown_kwargs(monkeypatch):
     assert r.dataset.repo_id == "org/ds"
 
 
+def test_repo_type_forwarded_when_supported(monkeypatch):
+    """repo_type reaches a StreamingLeRobotDataset that declares the parameter."""
+
+    class _WithRepoType:
+        def __init__(self, repo_id, repo_type="dataset", **kw):
+            self.repo_id = repo_id
+            self.repo_type = repo_type
+            self.num_frames = self.num_episodes = self.fps = 0
+
+        def __iter__(self):
+            yield {}
+
+    monkeypatch.setattr(sd, "StreamingLeRobotDataset", _WithRepoType, raising=False)
+    r = sd.StreamingDatasetReader.open("org/ds", repo_type="bucket", validate_deltas=False)
+    assert r.dataset.repo_type == "bucket"
+
+
+def test_repo_type_dropped_when_unsupported(monkeypatch):
+    """A constructor without repo_type must not raise when repo_type is passed."""
+
+    class _Narrow:
+        def __init__(self, repo_id):
+            self.repo_id = repo_id
+            self.num_frames = self.num_episodes = self.fps = 0
+
+        def __iter__(self):
+            yield {}
+
+    monkeypatch.setattr(sd, "StreamingLeRobotDataset", _Narrow, raising=False)
+    r = sd.StreamingDatasetReader.open("org/ds", repo_type="bucket", validate_deltas=False)
+    assert r.dataset.repo_id == "org/ds"
+
+
 def test_drop_videos_strips_camera_deltas(monkeypatch):
     monkeypatch.setattr(sd, "StreamingLeRobotDataset", _FakeStreaming, raising=False)
     r = sd.StreamingDatasetReader.open(


### PR DESCRIPTION
## What

`StreamingDatasetReader.open` forwarded every `StreamingLeRobotDataset` constructor parameter except `repo_type`. A caller could not select a non-default repository type (for example a Storage Bucket) even on a lerobot version that supports `repo_type`, because `open` did not expose or pass it, and `Simulation.stream_dataset(repo_id, **kwargs)` had no channel for it to reach.

## Change

- `StreamingDatasetReader.open` gains a `repo_type: str = "dataset"` parameter and includes it in the forwarded candidate set.
- The existing version-tolerant filter (forward a candidate only when the constructor declares it or accepts `**kwargs`) drops `repo_type` for lerobot versions that do not define the parameter, so the change is backward compatible and raises no `TypeError` on older lerobot.
- `Simulation.stream_dataset` already forwards `**kwargs`, so `repo_type` reaches `open` unchanged. Its docstring now lists the parameter and replaces a stale `python -m lerobot.scripts.train` reference with the current `lerobot-train` entry point.

## Tests

Two regression tests in `tests/test_streaming_dataset.py`:
- `repo_type` is forwarded to a constructor that declares it.
- `repo_type` is dropped (no error) for a constructor that does not.

`ruff check`, `ruff format --check`, and `mypy` pass on the changed files; the streaming test module passes (43 tests).