### PR TITLE
fix(mesh): catch zenoh.ZError in best-effort lifecycle cleanup

### DIFF
--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -35,6 +35,7 @@ from strands_robots.mesh.session import (
     put,
     release_session,
     update_peer,
+    zenoh_error_types,
 )
 from strands_robots.mesh.session import (
     get_peers as _session_get_peers,
@@ -615,19 +616,17 @@ class Mesh(SensorLoopsMixin):
                 # task.
                 declared.append(session.declare_subscriber("strands/safety/estop", self._on_safety_estop))
                 declared.append(session.declare_subscriber("strands/safety/resume", self._on_safety_resume))
-            except (RuntimeError, OSError) as exc:
-                # narrow the lifecycle cleanup catch from bare ``Exception``
-                # to the tuple Zenoh's ``declare_subscriber`` actually raises
-                # (``ZError`` is a subclass of ``RuntimeError``; transport-layer
-                # failures surface as ``OSError``). This mirrors the wire-handler
-                # tuple established earlier for ``_on_cmd`` / ``_on_safety_estop``
-                # so programmer errors (``TypeError``, ``AttributeError``,
-                # ``MemoryError``) on the partial-failure cleanup path surface
-                # in tests rather than being silently swallowed.
+            except zenoh_error_types() as exc:
+                # ``zenoh_error_types()`` names the transport-side failures a
+                # ``declare_subscriber`` realistically raises -- including
+                # ``zenoh.ZError`` (an ``Exception`` subclass, NOT a
+                # ``RuntimeError``) -- while still letting programmer errors
+                # (``TypeError`` / ``AttributeError`` / ``MemoryError``) surface
+                # instead of being silently swallowed on this cleanup path.
                 for sub in declared:
                     try:
                         sub.undeclare()
-                    except (RuntimeError, OSError):
+                    except zenoh_error_types():
                         # Best-effort cleanup; an undeclare failure here
                         # cannot recover the parent failure that put us in
                         # this branch and surfacing it would mask the
@@ -713,8 +712,11 @@ class Mesh(SensorLoopsMixin):
         for sub in subs_to_drop:
             try:
                 sub.undeclare()
-            except Exception:
-                pass
+            except zenoh_error_types():
+                # Best-effort teardown; a Zenoh undeclare failure here cannot
+                # recover state (we are already stopping) and a programmer
+                # error must still surface rather than be swallowed.
+                logger.debug("[mesh] %s: subscriber undeclare failed during stop()", self.peer_id)
 
         # Undeclare any safety publishers we lazily declared so the
         # underlying Zenoh entity is released cleanly when the
@@ -728,7 +730,7 @@ class Mesh(SensorLoopsMixin):
         for pub in pubs_to_drop:
             try:
                 pub.undeclare()
-            except (RuntimeError, OSError):
+            except zenoh_error_types():
                 logger.debug(
                     "[mesh] %s: safety publisher undeclare failed during stop()",
                     self.peer_id,

--- a/strands_robots/mesh/session.py
+++ b/strands_robots/mesh/session.py
@@ -136,6 +136,37 @@ def _is_transport_backend() -> bool:
     return _backend_choice() in ("iot", "bridge")
 
 
+def zenoh_error_types() -> tuple[type[BaseException], ...]:
+    """Exception types a best-effort Zenoh lifecycle op may raise.
+
+    Covers ``open`` / ``declare_subscriber`` / ``declare_publisher`` /
+    ``undeclare`` / ``close`` failures on the realistic transport-side paths
+    (port already bound, bad interface, broker drop, entity already released):
+
+      - ``zenoh.ZError`` -- the native Zenoh error. On real ``eclipse-zenoh`` it
+        subclasses ``Exception`` directly (NOT ``RuntimeError``), so it must be
+        named explicitly or a genuine transport failure escapes best-effort
+        cleanup. When the ``zenoh`` module is mocked in tests, ``zenoh.ZError``
+        is a ``MagicMock`` (not a class) and cannot go in an ``except`` tuple,
+        so it is dropped and the benign builtins below still apply.
+      - ``OSError`` / ``ConnectionError`` -- socket / broker transport faults.
+      - ``RuntimeError`` -- internal binding faults.
+
+    Programmer errors (``TypeError`` / ``AttributeError`` / ``MemoryError``) are
+    deliberately excluded so they surface loudly instead of being swallowed by a
+    best-effort cleanup path.
+    """
+    base: tuple[type[BaseException], ...] = (RuntimeError, OSError, ConnectionError)
+    try:
+        import zenoh
+    except ImportError:
+        return base
+    zerr = getattr(zenoh, "ZError", None)
+    if isinstance(zerr, type) and issubclass(zerr, BaseException):
+        return (*base, zerr)
+    return base
+
+
 # PeerInfo
 
 
@@ -584,19 +615,12 @@ def get_session() -> Any | None:
             cfg = _build_config()
             cfg.insert_json5("listen/endpoints", json.dumps([local_ep]))
             cfg.insert_json5("connect/endpoints", json.dumps([local_ep]))
-            # Resolve zenoh.ZError dynamically -- when tests mock the
-            # zenoh module, ``zenoh.ZError`` is a MagicMock (not a class)
-            # and including it directly in the except tuple raises
-            # TypeError. Fall back to a benign placeholder when zenoh is
-            # mocked or ZError is not a real class.
-            _ZError = getattr(zenoh, "ZError", None)
-            _ZError = _ZError if isinstance(_ZError, type) and issubclass(_ZError, BaseException) else RuntimeError
             try:
                 _SESSION = zenoh.open(cfg)
                 _SESSION_REFS = 1
                 logger.info("Zenoh mesh session opened (listener on %s)", local_ep)
                 return _SESSION
-            except (RuntimeError, OSError, ConnectionError, _ZError) as exc:
+            except zenoh_error_types() as exc:
                 # Narrow tuple per AGENTS.md > Review Learnings (#86):
                 # ``RuntimeError`` / ``OSError`` / ``ConnectionError`` /
                 # ``zenoh.ZError`` cover the realistic transport-side
@@ -624,7 +648,7 @@ def get_session() -> Any | None:
                 _SESSION_REFS = 1
                 logger.info("Zenoh mesh session opened (client -> %s)", local_ep)
                 return _SESSION
-            except (RuntimeError, OSError, ConnectionError, _ZError) as exc:
+            except zenoh_error_types() as exc:
                 # Narrow tuple per AGENTS.md > Review Learnings (#86):
                 # transport-level failures only; config-shape ValueError
                 # propagates to caller so misconfigured mTLS surfaces loudly.
@@ -635,17 +659,12 @@ def get_session() -> Any | None:
         # Build cfg outside the try (same loud-on-misconfig discipline
         # as the auto-listener path).
         cfg = _build_config()
-        # Re-resolve _ZError under the explicit-endpoints branch (reached
-        # when _LOCAL_LISTEN env var is unset, so the listener-block
-        # binding above never executed).
-        _ZError = getattr(zenoh, "ZError", None)
-        _ZError = _ZError if isinstance(_ZError, type) and issubclass(_ZError, BaseException) else RuntimeError
         try:
             _SESSION = zenoh.open(cfg)
             _SESSION_REFS = 1
             logger.info("Zenoh mesh session opened")
             return _SESSION
-        except (RuntimeError, OSError, ConnectionError, _ZError) as exc:
+        except zenoh_error_types() as exc:
             logger.warning("Zenoh session open failed: %s", exc)
             return None
 
@@ -721,14 +740,12 @@ def _get_zenoh_session_directly() -> Any | None:
             cfg = _build_config()
             cfg.insert_json5("listen/endpoints", json.dumps([local_ep]))
             cfg.insert_json5("connect/endpoints", json.dumps([local_ep]))
-            _ZError = getattr(zenoh, "ZError", None)
-            _ZError = _ZError if isinstance(_ZError, type) and issubclass(_ZError, BaseException) else RuntimeError
             try:
                 _SESSION = zenoh.open(cfg)
                 _SESSION_REFS = 1
                 logger.info("Zenoh mesh session opened (listener on %s)", local_ep)
                 return _SESSION
-            except (RuntimeError, OSError, ConnectionError, _ZError) as exc:
+            except zenoh_error_types() as exc:
                 # Narrow tuple mirroring the narrowing applied in
                 # get_session() upstairs. Config-shape
                 # ValueError now propagates instead of being swallowed at DEBUG.
@@ -746,19 +763,17 @@ def _get_zenoh_session_directly() -> Any | None:
                 _SESSION_REFS = 1
                 logger.info("Zenoh mesh session opened (client -> %s)", local_ep)
                 return _SESSION
-            except (RuntimeError, OSError, ConnectionError, _ZError) as exc:
+            except zenoh_error_types() as exc:
                 logger.warning("Zenoh session open failed (client mode): %s", exc)
                 return None
 
         cfg = _build_config()
-        _ZError = getattr(zenoh, "ZError", None)
-        _ZError = _ZError if isinstance(_ZError, type) and issubclass(_ZError, BaseException) else RuntimeError
         try:
             _SESSION = zenoh.open(cfg)
             _SESSION_REFS = 1
             logger.info("Zenoh mesh session opened")
             return _SESSION
-        except (RuntimeError, OSError, ConnectionError, _ZError) as exc:
+        except zenoh_error_types() as exc:
             logger.warning("Zenoh session open failed: %s", exc)
             return None
 

--- a/tests/mesh/test_zenoh_lifecycle_error_classification.py
+++ b/tests/mesh/test_zenoh_lifecycle_error_classification.py
@@ -1,0 +1,110 @@
+"""Zenoh lifecycle error classification for the mesh session and node.
+
+Best-effort Zenoh lifecycle operations (``open`` / ``declare_subscriber`` /
+``undeclare`` / ``close``) must catch the errors real ``eclipse-zenoh`` raises
+so a transport-side failure cannot escape partial-failure cleanup or
+``Mesh.stop()``. The native ``zenoh.ZError`` subclasses ``Exception`` directly
+- NOT ``RuntimeError`` - so it has to be named explicitly in the ``except``
+tuple. :func:`strands_robots.mesh.session.zenoh_error_types` centralises that
+tuple; these tests pin the contract and the fail-soft teardown behaviour.
+"""
+
+from __future__ import annotations
+
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+
+from strands_robots.mesh.core import Mesh
+from strands_robots.mesh.session import zenoh_error_types
+
+
+def test_error_tuple_always_includes_transport_builtins():
+    types = zenoh_error_types()
+    assert isinstance(types, tuple)
+    for builtin in (RuntimeError, OSError, ConnectionError):
+        assert builtin in types
+    # Programmer errors must NOT be swallowed by best-effort cleanup.
+    assert TypeError not in types
+    assert AttributeError not in types
+
+
+def test_error_tuple_names_zenoh_zerror_explicitly():
+    zenoh = pytest.importorskip("zenoh")
+    zerr = getattr(zenoh, "ZError", None)
+    if not isinstance(zerr, type):
+        pytest.skip("zenoh.ZError is not a real class in this environment")
+    # The whole reason ZError is named explicitly: it is an Exception subclass,
+    # NOT a RuntimeError, so (RuntimeError, OSError) alone would let it escape.
+    assert not issubclass(zerr, RuntimeError)
+    assert zerr in zenoh_error_types()
+
+
+def _bare_mesh_for_stop(subs=None, safety_publishers=None):
+    """A ``Mesh`` carrying only the attributes ``stop()`` touches.
+
+    Built with ``Mesh.__new__`` (the shared mesh-unit-test pattern) so no zenoh
+    transport or live robot is required.
+    """
+    mesh = Mesh.__new__(Mesh)
+    mesh.peer_id = "test__arm"
+    mesh._running = True
+    mesh._lifecycle_lock = threading.RLock()
+    mesh._stop_event = MagicMock()
+    mesh._subs_lock = threading.RLock()
+    mesh._subs = list(subs or [])
+    mesh._user_subs = set()
+    mesh._inbox_lock = threading.RLock()
+    mesh.inbox = []
+    mesh._safety_publishers_lock = threading.RLock()
+    mesh._safety_publishers = dict(safety_publishers or {})
+    mesh._rpc_lock = threading.RLock()
+    mesh._pending = {}
+    mesh._responses = {}
+    mesh._has_session_ref = False
+    return mesh
+
+
+def _zerror_raiser():
+    """A publisher/subscriber whose ``undeclare`` raises a real ``zenoh.ZError``."""
+    zenoh = pytest.importorskip("zenoh")
+    zerr = getattr(zenoh, "ZError", None)
+    if not isinstance(zerr, type):
+        pytest.skip("zenoh.ZError is not a real class in this environment")
+    obj = MagicMock()
+    obj.undeclare.side_effect = zerr("simulated broker drop during teardown")
+    return obj
+
+
+def test_stop_is_fail_soft_when_safety_publisher_undeclare_raises_zerror():
+    pub = _zerror_raiser()
+    mesh = _bare_mesh_for_stop(safety_publishers={"estop": pub})
+
+    mesh.stop()  # pre-fix: ZError escapes the (RuntimeError, OSError) catch
+
+    pub.undeclare.assert_called_once()
+    assert mesh.alive is False
+    assert mesh._safety_publishers == {}
+
+
+def test_stop_is_fail_soft_when_subscriber_undeclare_raises_zerror():
+    sub = _zerror_raiser()
+    mesh = _bare_mesh_for_stop(subs=[sub])
+
+    mesh.stop()
+
+    sub.undeclare.assert_called_once()
+    assert mesh.alive is False
+    assert mesh._subs == []
+
+
+def test_stop_does_not_swallow_programmer_error_from_undeclare():
+    # A TypeError is a bug, not a transport failure: it must surface rather than
+    # be silently swallowed by best-effort teardown.
+    sub = MagicMock()
+    sub.undeclare.side_effect = TypeError("undeclare() takes no arguments")
+    mesh = _bare_mesh_for_stop(subs=[sub])
+
+    with pytest.raises(TypeError):
+        mesh.stop()


### PR DESCRIPTION
## Problem

Real `eclipse-zenoh` raises `zenoh.ZError`, which subclasses `Exception` **directly** — it is *not* a `RuntimeError`:

```python
>>> import zenoh
>>> zenoh.ZError.__mro__
(<class 'zenoh.ZError'>, <class 'Exception'>, <class 'BaseException'>, <class 'object'>)
>>> issubclass(zenoh.ZError, RuntimeError)
False
```

`Mesh`'s best-effort Zenoh lifecycle cleanup caught only `(RuntimeError, OSError)` (and, in `stop()`, a bare `except Exception`), guided by a comment that incorrectly claimed `ZError` is a `RuntimeError` subclass. So a genuine transport-side `undeclare()` failure (broker drop, entity already released) raised `ZError`, which **escaped** the handler and propagated out of `Mesh.stop()`, leaving teardown half-done (RPC waiters unset, session reference not released).

`session.py` already handled this correctly — but via five inline copies of the same `_ZError = getattr(zenoh, "ZError", ...)` resolution. `core.py` never reused that pattern and drifted to the wrong, too-narrow tuple. The duplication is what let the two diverge.

## Change

- Extract a single `zenoh_error_types()` helper in `strands_robots/mesh/session.py` that returns `(RuntimeError, OSError, ConnectionError, zenoh.ZError)`, naming `zenoh.ZError` explicitly and degrading gracefully when the module is absent or mocked (a `MagicMock` `ZError` cannot go in an `except` tuple). Programmer errors (`TypeError` / `AttributeError` / `MemoryError`) are deliberately excluded so real bugs surface loudly instead of being swallowed by a best-effort path.
- Use the helper at every Zenoh lifecycle `except` site: the five session-open sites (replacing the inline resolution) and the four `core.py` sites — the `declare_subscriber` partial-failure cleanup, the subscriber `undeclare()` in that cleanup, and the subscriber + safety-publisher `undeclare()` in `stop()`. Now classification lives in one place and cannot drift again.
- Correct the inaccurate `ZError is a subclass of RuntimeError` comment.

Net: transport-side `ZError` from `declare`/`undeclare` is now caught by the best-effort handlers so cleanup and `stop()` complete; programmer errors still propagate.

## Tests

`tests/mesh/test_zenoh_lifecycle_error_classification.py`:

- `zenoh_error_types()` always includes the transport builtins and never `TypeError`/`AttributeError`.
- It names the real `zenoh.ZError` explicitly, and pins *why* (`not issubclass(zenoh.ZError, RuntimeError)`).
- `stop()` stays fail-soft when a safety-publisher **and** a subscriber `undeclare()` raise a real `zenoh.ZError`.
- A programmer error (`TypeError`) from `undeclare()` surfaces rather than being swallowed.

Regression proof (helper present, `core.py` reverted to pre-fix): the safety-publisher `ZError`-escape test and the programmer-error test both **fail** (`ZError` propagates out of `stop()`; `TypeError` was swallowed by the bare `except Exception`); both pass after the fix.

Gate: `ruff check` / `ruff format --check` clean; `mypy strands_robots tests tests_integ` → `Success: no issues found in 803 source files`; full `tests/mesh/` suite `2096 passed, 3 skipped`.