### PR TITLE
fix(registry): reject policy alias/shorthand that shadows another provider's canonical name

### DIFF
--- a/docs/policies/custom-policies.md
+++ b/docs/policies/custom-policies.md
@@ -55,6 +55,8 @@ Add to `strands_robots/registry/policies.json`:
 
 The factory imports lazily on first use.
 
+Aliases and shorthands are validated on load: each must be unique across providers and must not collide with a *different* provider's canonical name (that would silently shadow it, since lookups resolve through the alias/shorthand map before the canonical name). Listing a provider's own name in its `shorthands` is allowed and idiomatic -- it is how the bare name resolves. A colliding entry raises `ValueError` at registry load.
+
 ## ABC contract
 
 | Method / property | Abstract | Default |

--- a/strands_robots/registry/loader.py
+++ b/strands_robots/registry/loader.py
@@ -137,16 +137,29 @@ def _validate_robots(data: dict) -> None:
 
 
 def _validate_policies(data: dict) -> None:
-    """Ensure no two providers share the same alias, shorthand, or URL pattern."""
+    """Ensure no two providers share the same alias, shorthand, or URL pattern.
+
+    Also rejects an alias or shorthand that collides with a *different*
+    provider's canonical name. ``get_policy_provider`` resolves a lookup key
+    through the alias/shorthand map before falling back to the canonical name
+    (``alias_map.get(name, name)``), so such a collision silently shadows the
+    real provider - its own name would resolve to the alias owner instead.
+    A provider naming *itself* in its shorthands is allowed and idiomatic
+    (every provider lists its canonical name as a shorthand so the bare name
+    resolves), hence the ``!= provider_name`` guard.
+    """
     seen_aliases: dict[str, str] = {}
     seen_url_patterns: dict[str, str] = {}
+    providers = data.get("providers", {})
 
-    for provider_name, info in data.get("providers", {}).items():
+    for provider_name, info in providers.items():
         for alias in info.get("aliases", []):
             if alias in seen_aliases:
                 raise ValueError(
                     f"Duplicate policy alias '{alias}': claimed by both '{seen_aliases[alias]}' and '{provider_name}'"
                 )
+            if alias != provider_name and alias in providers:
+                raise ValueError(f"Policy alias '{alias}' in '{provider_name}' collides with a canonical provider name")
             seen_aliases[alias] = provider_name
 
         for shorthand in info.get("shorthands", []):
@@ -154,6 +167,10 @@ def _validate_policies(data: dict) -> None:
                 raise ValueError(
                     f"Duplicate policy shorthand '{shorthand}': claimed by both "
                     f"'{seen_aliases[shorthand]}' and '{provider_name}'"
+                )
+            if shorthand != provider_name and shorthand in providers:
+                raise ValueError(
+                    f"Policy shorthand '{shorthand}' in '{provider_name}' collides with a canonical provider name"
                 )
             seen_aliases[shorthand] = provider_name
 

--- a/tests/registry/test_public_api.py
+++ b/tests/registry/test_public_api.py
@@ -97,6 +97,45 @@ class TestLoader:
         with pytest.raises(ValueError, match="Duplicate URL pattern"):
             _validate("policies", bad_data)
 
+    def test_validate_policy_alias_collides_with_canonical_name_raises(self):
+        """An alias matching a different provider's canonical name should raise.
+
+        get_policy_provider resolves through the alias map before the canonical
+        name, so an alias equal to another provider's name silently shadows it.
+        """
+        bad_data = {
+            "providers": {
+                "prov_a": {"aliases": ["prov_b"], "shorthands": [], "url_patterns": []},
+                "prov_b": {"aliases": [], "shorthands": [], "url_patterns": []},
+            }
+        }
+        with pytest.raises(ValueError, match="collides with a canonical provider name"):
+            _validate("policies", bad_data)
+
+    def test_validate_policy_shorthand_collides_with_canonical_name_raises(self):
+        """A shorthand matching a different provider's canonical name should raise."""
+        bad_data = {
+            "providers": {
+                "prov_a": {"aliases": [], "shorthands": ["prov_b"], "url_patterns": []},
+                "prov_b": {"aliases": [], "shorthands": [], "url_patterns": []},
+            }
+        }
+        with pytest.raises(ValueError, match="collides with a canonical provider name"):
+            _validate("policies", bad_data)
+
+    def test_validate_policy_self_shorthand_allowed(self):
+        """A provider naming itself in its shorthands is idiomatic and must pass.
+
+        Every real provider lists its canonical name as a shorthand so the bare
+        name resolves; the canonical-collision guard must not reject that.
+        """
+        clean_data = {
+            "providers": {
+                "prov_a": {"aliases": [], "shorthands": ["prov_a"], "url_patterns": []},
+            }
+        }
+        _validate("policies", clean_data)
+
     def test_validate_clean_data_passes(self):
         """Well-formed data should pass validation without error."""
         clean_robots = {

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -96,6 +96,45 @@ class TestLoader:
         with pytest.raises(ValueError, match="Duplicate URL pattern"):
             _validate("policies", bad_data)
 
+    def test_validate_policy_alias_collides_with_canonical_name_raises(self):
+        """An alias matching a different provider's canonical name should raise.
+
+        get_policy_provider resolves through the alias map before the canonical
+        name, so an alias equal to another provider's name silently shadows it.
+        """
+        bad_data = {
+            "providers": {
+                "prov_a": {"aliases": ["prov_b"], "shorthands": [], "url_patterns": []},
+                "prov_b": {"aliases": [], "shorthands": [], "url_patterns": []},
+            }
+        }
+        with pytest.raises(ValueError, match="collides with a canonical provider name"):
+            _validate("policies", bad_data)
+
+    def test_validate_policy_shorthand_collides_with_canonical_name_raises(self):
+        """A shorthand matching a different provider's canonical name should raise."""
+        bad_data = {
+            "providers": {
+                "prov_a": {"aliases": [], "shorthands": ["prov_b"], "url_patterns": []},
+                "prov_b": {"aliases": [], "shorthands": [], "url_patterns": []},
+            }
+        }
+        with pytest.raises(ValueError, match="collides with a canonical provider name"):
+            _validate("policies", bad_data)
+
+    def test_validate_policy_self_shorthand_allowed(self):
+        """A provider naming itself in its shorthands is idiomatic and must pass.
+
+        Every real provider lists its canonical name as a shorthand so the bare
+        name resolves; the canonical-collision guard must not reject that.
+        """
+        clean_data = {
+            "providers": {
+                "prov_a": {"aliases": [], "shorthands": ["prov_a"], "url_patterns": []},
+            }
+        }
+        _validate("policies", clean_data)
+
     def test_validate_clean_data_passes(self):
         """Well-formed data should pass validation without error."""
         clean_robots = {


### PR DESCRIPTION
## Problem

`get_policy_provider` resolves a lookup key through the alias/shorthand map before falling back to the canonical name:

```python
canonical = alias_map.get(name, name)
```

So if provider **A** declares an alias or shorthand equal to a *different* provider **B**'s canonical name, that entry silently shadows **B**: `get_policy_provider("B")` resolves to **A**, and **B** becomes unreachable by its own name. `_validate_robots` already guards this exact case for robots (`alias ... collides with a canonical robot name`), but `_validate_policies` had no equivalent check — the asymmetry let a bad `policies.json` load without complaint and misresolve at runtime.

## Change

Add the symmetric canonical-name collision check to `_validate_policies` for both aliases and shorthands. The check excludes the idiomatic self-reference: every provider lists its own canonical name in `shorthands` so the bare name resolves (`mock` -> `mock`), which must stay valid — hence the `!= provider_name` guard. A collision with a *different* provider's name now raises `ValueError` at registry load, matching the robots side.

## Tests

Added to both registry test modules (mirroring the existing robots-canonical test):

- `test_validate_policy_alias_collides_with_canonical_name_raises` — fails pre-fix (DID NOT RAISE), passes after.
- `test_validate_policy_shorthand_collides_with_canonical_name_raises` — fails pre-fix, passes after.
- `test_validate_policy_self_shorthand_allowed` — pins the idiomatic self-shorthand as valid so the guard is not over-eager.

Verified the shipped `policies.json` still validates (every provider's self-shorthand is preserved). Full registry suite green (591 passed); `ruff check`/`ruff format` clean; `mypy` clean on the changed module.

Docs: added a short constraint note to the JSON-registration section of `docs/policies/custom-policies.md`.