### PR TITLE
docs(training): document concrete Trainer provider public methods

### DIFF
--- a/strands_robots/training/cosmos3.py
+++ b/strands_robots/training/cosmos3.py
@@ -89,11 +89,12 @@ class Cosmos3Trainer(Trainer):
 
     @property
     def provider_name(self) -> str:
+        """Provider identity - pairs with the ``cosmos3`` inference policy."""
         return "cosmos3"
 
     @property
     def hardware_floor(self) -> dict[str, Any]:
-        # SFT tested on 8xH100 80GB; HSDP multi-node beyond.
+        """Advisory floor: Cosmos3 SFT is validated on 8xH100 80 GB (HSDP multi-node beyond)."""
         return {"min_gpus": 8, "min_vram_gb": 80, "multinode": True}
 
     def _resolve_cosmos_root(self, spec: TrainSpec) -> str | None:
@@ -123,6 +124,16 @@ class Cosmos3Trainer(Trainer):
         return output_dir if entries else None
 
     def validate(self, spec: TrainSpec) -> list[str]:
+        """Pure preflight for a Cosmos3 SFT run.
+
+        Runs the shared input-safety gate, then checks a LeRobotDataset v3
+        ``dataset_root``, a ``base_model`` to convert to DCP, an
+        ``output_dir``, a supported ``method``, positive ``steps``, an
+        ``extra['sft_toml']`` recipe that exists, and a resolvable
+        ``cosmos_framework`` checkout (COSMOS_ROOT / ``cosmos_root`` /
+        ``extra['cosmos_root']``). Returns the problem list; empty means
+        launchable. Read-only - no filesystem writes, no GPUs.
+        """
         problems: list[str] = self._security_problems(spec)
 
         if not spec.dataset_root:
@@ -269,6 +280,14 @@ class Cosmos3Trainer(Trainer):
         return out
 
     def train(self, spec: TrainSpec) -> TrainResult:
+        """Run Cosmos3 SFT in-process: validate -> DCP prepare -> launch.
+
+        Fails closed on any :meth:`validate` problem, converts the base
+        checkpoint to PyTorch DCP via :meth:`prepare`, verifies
+        ``cosmos_framework.scripts.train`` imports, then launches the run
+        from the ``extra['sft_toml']`` recipe plus scalar overrides. Blocks
+        until the run terminates and returns a terminal ``TrainResult``.
+        """
         problems = self.validate(spec)
         if problems:
             return TrainResult(

--- a/strands_robots/training/groot.py
+++ b/strands_robots/training/groot.py
@@ -95,11 +95,12 @@ class Gr00tTrainer(Trainer):
 
     @property
     def provider_name(self) -> str:
+        """Provider identity - pairs with the ``groot`` inference policy."""
         return "groot"
 
     @property
     def hardware_floor(self) -> dict[str, Any]:
-        # N1.x fine-tune fits one modern GPU (lite); multi-GPU recommended.
+        """Advisory floor: a GR00T N1.x fine-tune fits one 24 GB GPU (multi-GPU recommended)."""
         return {"min_gpus": 1, "min_vram_gb": 24, "multinode": False}
 
     def _resolve_groot_root(self, spec: TrainSpec) -> str | None:
@@ -118,6 +119,16 @@ class Gr00tTrainer(Trainer):
         return merged
 
     def validate(self, spec: TrainSpec) -> list[str]:
+        """Pure preflight for a GR00T N1.x fine-tune.
+
+        Runs the shared input-safety gate, then checks a LeRobotDataset v3
+        ``dataset_root``, a ``base_model``, an ``output_dir``, a required
+        ``embodiment`` tag, a supported ``method``, positive ``steps``,
+        single-node only (``num_nodes == 1``), a resolvable Isaac-GR00T
+        checkout (GR00T_ROOT / ``groot_root`` / ``extra['groot_root']``),
+        and an optional ``extra['modality_config_path']`` that exists.
+        Returns the problem list; empty means launchable. Read-only.
+        """
         problems: list[str] = self._security_problems(spec)
 
         if not spec.dataset_root:
@@ -389,6 +400,15 @@ class Gr00tTrainer(Trainer):
             raise FileNotFoundError(f"Modality config path does not exist: {modality_config_path}")
 
     def train(self, spec: TrainSpec) -> TrainResult:
+        """Run a GR00T fine-tune in-process by calling the experiment runner.
+
+        Fails closed on any :meth:`validate` problem, then builds a
+        ``FinetuneConfig`` + ``Config`` and calls
+        ``gr00t.experiment.experiment.run`` directly (no subprocess). Single
+        GPU pins one CUDA device to avoid the HF Trainer DataParallel wrap;
+        ``num_gpus > 1`` spawns workers via torch ``elastic_launch``. Blocks
+        until the run terminates and returns a terminal ``TrainResult``.
+        """
         problems = self.validate(spec)
         if problems:
             return TrainResult(

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -248,11 +248,12 @@ class LerobotTrainer(Trainer):
 
     @property
     def provider_name(self) -> str:
+        """Provider identity - pairs with the ``lerobot_local`` inference policy."""
         return "lerobot_local"
 
     @property
     def hardware_floor(self) -> dict[str, Any]:
-        # ACT fits a consumer GPU; large VLAs (pi05) want an L40S. Advisory.
+        """Advisory floor: ACT fits a consumer 8 GB GPU; large VLAs (pi05) want an L40S."""
         return {"min_gpus": 1, "min_vram_gb": 8, "multinode": False}
 
     # ---- helpers -----------------------------------------------------------
@@ -420,6 +421,17 @@ class LerobotTrainer(Trainer):
     # ---- ABC ---------------------------------------------------------------
 
     def validate(self, spec: TrainSpec) -> list[str]:
+        """Pure preflight for a LeRobot policy- or reward-model run.
+
+        Runs the shared input-safety gate, then checks a data source -
+        exactly one of a local LeRobotDataset v3 ``dataset_root`` or a Hub
+        ``dataset_repo_id`` (for streaming) - an ``output_dir``, positive
+        ``steps``, single-node only (``num_nodes == 1``), a ``val_episodes``
+        split below the dataset total, and that ``lerobot.scripts.lerobot_train``
+        is importable. ``extra['reward_model']`` switches to reward-model
+        preflight; otherwise the default policy path is checked. Returns the
+        problem list; empty means launchable. Read-only.
+        """
         problems: list[str] = self._security_problems(spec)
 
         # Data source: either a local v3 root, or a Hub repo id (streaming the
@@ -885,6 +897,15 @@ class LerobotTrainer(Trainer):
         return cfg
 
     def train(self, spec: TrainSpec) -> TrainResult:
+        """Run LeRobot training in-process via ``lerobot_train.train(cfg)``.
+
+        Fails closed on any :meth:`validate` problem, builds the
+        ``TrainPipelineConfig`` from the spec (policy or reward-model path,
+        resume, learning rate), and calls lerobot's own training function
+        directly. ``num_gpus > 1`` spawns workers via torch
+        ``elastic_launch``. Blocks until the run terminates and returns a
+        terminal ``TrainResult`` with the checkpoint dir + metrics verdict.
+        """
         problems = self.validate(spec)
         if problems:
             return TrainResult(

--- a/strands_robots/training/mock.py
+++ b/strands_robots/training/mock.py
@@ -25,6 +25,7 @@ class MockTrainer(Trainer):
 
     @property
     def provider_name(self) -> str:
+        """Provider identity - the dependency-free ``mock`` reference trainer."""
         return "mock"
 
     def validate(self, spec: TrainSpec) -> list[str]:

--- a/tests/training/test_trainer_provider_docstrings.py
+++ b/tests/training/test_trainer_provider_docstrings.py
@@ -1,0 +1,78 @@
+"""Concrete ``Trainer`` providers must document every public method/property.
+
+The :class:`~strands_robots.training.base.Trainer` ABC documents its lifecycle
+contract (``validate`` / ``prepare`` / ``train`` / ``export`` / ``status`` /
+``provider_name`` / ``hardware_floor``) with rich docstrings, and the reference
+:class:`~strands_robots.training.mock.MockTrainer` follows suit. The real
+providers (:class:`~strands_robots.training.cosmos3.Cosmos3Trainer`,
+:class:`~strands_robots.training.groot.Gr00tTrainer`,
+:class:`~strands_robots.training.lerobot.LerobotTrainer`) genuinely differ per
+backend - each ``validate`` checks backend-specific inputs and each ``train``
+drives a different in-process training function - so every public override needs
+its own docstring rather than silently leaning on the inherited one.
+
+This guard walks the provider modules and fails if any concrete ``Trainer``
+subclass defines a public method or property with no docstring.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import strands_robots.training as training_pkg
+
+_PACKAGE_DIR = Path(training_pkg.__file__).parent
+
+# Provider modules that define a concrete Trainer subclass (mock is the
+# dependency-free reference; the other three are the real backends).
+_PROVIDER_MODULES = ("mock.py", "cosmos3.py", "groot.py", "lerobot.py")
+
+
+def _public_members_without_docstring(class_node: ast.ClassDef) -> list[str]:
+    """Return names of public methods/properties in the class body lacking a docstring."""
+    offenders: list[str] = []
+    for node in class_node.body:
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        if node.name.startswith("_"):
+            continue
+        if ast.get_docstring(node) is None:
+            offenders.append(node.name)
+    return offenders
+
+
+def _concrete_trainer_classes() -> dict[str, ast.ClassDef]:
+    """Map ``module.py::ClassName`` -> ClassDef for every ``*Trainer`` subclass."""
+    classes: dict[str, ast.ClassDef] = {}
+    for module in _PROVIDER_MODULES:
+        source_file = _PACKAGE_DIR / module
+        tree = ast.parse(source_file.read_text(encoding="utf-8"), filename=str(source_file))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef) and node.name.endswith("Trainer"):
+                classes[f"{module}::{node.name}"] = node
+    return classes
+
+
+def test_provider_modules_define_concrete_trainers() -> None:
+    """Guard: the scan actually found the four concrete Trainer subclasses."""
+    found = set(_concrete_trainer_classes())
+    assert found == {
+        "mock.py::MockTrainer",
+        "cosmos3.py::Cosmos3Trainer",
+        "groot.py::Gr00tTrainer",
+        "lerobot.py::LerobotTrainer",
+    }, found
+
+
+def test_concrete_trainer_public_members_have_docstrings() -> None:
+    offenders = {
+        qualname: missing
+        for qualname, node in _concrete_trainer_classes().items()
+        if (missing := _public_members_without_docstring(node))
+    }
+    assert not offenders, (
+        "Every public method/property of a concrete Trainer provider must have a "
+        "docstring describing its provider-specific behavior (the base ABC and "
+        "MockTrainer already do). Undocumented members: " + repr(offenders)
+    )


### PR DESCRIPTION
## Problem

The `Trainer` ABC (`strands_robots.training.base`) documents its lifecycle contract with rich docstrings, and the reference `MockTrainer` follows suit. The real provider trainers had drifted: their public overrides carried no docstrings even though the behavior genuinely differs per backend.

```
cosmos3.py::Cosmos3Trainer: provider_name, hardware_floor, validate, train
groot.py::Gr00tTrainer:     provider_name, hardware_floor, validate, train
lerobot.py::LerobotTrainer: provider_name, hardware_floor, validate, train
mock.py::MockTrainer:       provider_name
```

Each `validate` checks backend-specific inputs (GR00T requires an `embodiment` tag; Cosmos3 requires an `sft_toml` recipe + a `cosmos_framework` checkout; LeRobot accepts a local root or a Hub repo id and branches on `extra['reward_model']`), and each `train` drives a different in-process training function. A reader at the API surface saw no documentation of any of that.

## Change

- Add provider-specific docstrings to every public override in `Cosmos3Trainer`, `Gr00tTrainer`, `LerobotTrainer`, and the one missing `provider_name` on `MockTrainer`. Each documents the actual per-backend preflight / training path, using Sphinx cross-reference roles for internal APIs.
- Drop the one-line comments on the three `hardware_floor` properties that the new docstrings supersede (no duplicated prose).
- No behavior change: docstrings and a comment removal only.

## Test

New guard `tests/training/test_trainer_provider_docstrings.py` walks the provider modules and fails if any concrete `Trainer` subclass defines a public method/property without a docstring. It matches the existing docstring cross-reference guards in the package (`tests/training/test_docstring_module_xrefs.py`).

Verified the guard fails on the pre-change tree (all 13 undocumented members reported) and passes after. Full `strands_robots.training` suite green: 420 passed, 4 skipped. Lint clean (ruff + `mypy strands_robots tests tests_integ`: no issues in 804 source files).