### PR TITLE
test(simulation): pin add_object scalar color/size rejection contract

### DIFF
--- a/tests/simulation/mujoco/test_add_object_camera_vector_validation.py
+++ b/tests/simulation/mujoco/test_add_object_camera_vector_validation.py
@@ -12,7 +12,10 @@ through:
   cryptic "spec recompile refused", and a non-numeric ``color`` / ``size``
   raised a bare ``TypeError`` from inside MuJoCo's ``add_geom`` / the
   ``size <= 0`` comparison - escaping the structured ``{"status": "error"}``
-  tool-result contract.
+  tool-result contract. A bare scalar ``color`` / ``size`` (a non-iterable
+  passed where a vector is expected) is the same class of malformed input and
+  is likewise rejected up front rather than raising a bare ``TypeError`` from
+  ``add_geom``.
 * ``add_camera`` baked a ``nan`` / ``inf`` ``position`` / ``target`` into the
   camera's ``xyaxes`` (``fwd /= flen`` divides by ``nan`` -> a silently
   degenerate camera that renders garbage while reporting ``success``), and a
@@ -80,6 +83,33 @@ def test_add_object_rejects_nonnumeric(sim, kwargs, expect):
     result = sim.add_object("bad", shape="box", **kwargs)
     assert result["status"] == "error", result
     assert expect in result["content"][0]["text"]
+    assert "bad" not in sim._world.objects
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"color": 5},
+        {"color": np.float64(1.0)},
+        {"size": 0.05},
+        {"size": np.float32(0.05)},
+    ],
+)
+def test_add_object_rejects_scalar_color_size(sim, kwargs):
+    """A bare scalar ``color`` / ``size`` is rejected, not raised as a TypeError.
+
+    ``color`` and ``size`` are variable-length vectors (color is 3-or-4, size is
+    shape-dependent), so they are content-validated without a fixed length. A
+    caller passing a single number instead of a vector is a non-iterable that
+    would otherwise reach ``iter(vec)`` / MuJoCo's ``add_geom`` and raise a bare
+    ``TypeError``, escaping the ``{"status": "error"}`` tool-result contract.
+    The guard turns it into a structured error naming the offending parameter.
+    """
+    result = sim.add_object("bad", shape="box", **kwargs)
+    assert result["status"] == "error", result
+    text = result["content"][0]["text"]
+    assert "must be a list/tuple of numbers" in text
+    assert next(iter(kwargs)) in text
     assert "bad" not in sim._world.objects
 
 


### PR DESCRIPTION
## Problem

`Simulation.add_object` content-validates its `color` / `size` vectors through the finite-vector guard so a malformed value returns a structured `{"status": "error"}` instead of raising a bare `TypeError` from `iter(vec)` / MuJoCo's `add_geom` and escaping the tool-result contract.

The existing `add_object` / `add_camera` vector-validation regression tests exercised only *iterable* malformed inputs: `nan`/`inf` components, non-numeric strings, nested lists, and wrong-length pose vectors. The non-iterable branch of the guard - a bare scalar passed where a variable-length vector is expected (e.g. `color=5`, `size=0.05`) - was never covered, so a regression that mishandled scalars (raising instead of returning a structured error) would slip through CI.

## Change

Add `test_add_object_rejects_scalar_color_size` to the existing validation suite, parametrized over Python and NumPy 0-d scalars for both `color` and `size`. It pins that a scalar returns a structured error naming the offending parameter (`"... 'color' must be a list/tuple of numbers ..."`), and that the object is not registered. NumPy 0-d scalars are included because they are likewise non-iterable and hit the same branch.

The module docstring gains one sentence documenting the scalar/non-iterable case alongside the existing failure classes.

## Tests

This closes the last uncovered branch of the finite-vector guard reached from `add_object`. Verified locally (headless MuJoCo, `MUJOCO_GL=egl`):

- `test_add_object_camera_vector_validation.py`: 20 -> 24 passing.
- Coverage of `simulation.py` lines 161-162 (the `iter(vec)` `TypeError` branch): uncovered -> covered.
- `ruff check` / `ruff format --check` clean; `mypy strands_robots tests tests_integ` clean.

Behaviour is unchanged - this is a test-only change pinning existing error-handling.