### PR TITLE
docs: point streamed-training instructions at renamed lerobot.scripts.lerobot_train

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2126,6 +2126,10 @@ set, mirroring the policy path. (`push_to_hub` is intentionally not emitted:
 `RewardModelConfig.push_to_hub` already defaults to `False`, so `build_config`
 setting it `False` is a no-op the CLI need not restate.)
 
+### Docs: point the streamed-training instructions at the current `lerobot.scripts.lerobot_train` module
+
+`strands_robots/streaming_dataset.py`'s module docstring and the `docs/recording.md` streamed-training example instructed `python -m lerobot.scripts.train ...` -- but lerobot renamed that module to `lerobot.scripts.lerobot_train` (the old path is removed, so the command now raises `ModuleNotFoundError`). The rest of the codebase already uses the current name (`strands_robots.training.lerobot`, `strands_robots.tools.lerobot_train`, `docs/training/overview.md`); these two user-facing spots lagged. Corrected both to `python -m lerobot.scripts.lerobot_train` and updated the `recording.md` example to the draccus `--dotted.flags` form (`--policy.type=act --dataset.repo_id=... --dataset.streaming=true --num_workers=4`), matching how the trainer is invoked everywhere else.
+
 ## [0.4.1] - 2026-07-01
 
 ### Security: Removed the unregistered `mimicgen` dependency (dependency-confusion RCE, CVE-pending)

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -396,8 +396,8 @@ edge devices without a torchcodec wheel).
 For **training**, the upstream trainer uses the same engine:
 
 ```bash
-python -m lerobot.scripts.train policy=act \
-  dataset.repo_id=user/my_dataset dataset.streaming=true num_workers=4
+python -m lerobot.scripts.lerobot_train --policy.type=act \
+  --dataset.repo_id=user/my_dataset --dataset.streaming=true --num_workers=4
 ```
 
 > **macOS:** video streaming needs Homebrew ffmpeg on the dyld path. `import

--- a/strands_robots/streaming_dataset.py
+++ b/strands_robots/streaming_dataset.py
@@ -2,8 +2,8 @@
 """Streaming read-back for LeRobotDataset - read frames directly from the Hub.
 
 Primary use: in-process eval / replay / notebooks / agent loops (NOT a
-precondition for streamed *training* - ``python -m lerobot.scripts.train
-dataset.streaming=true`` already uses StreamingLeRobotDataset via
+precondition for streamed *training* - ``python -m lerobot.scripts.lerobot_train
+--dataset.streaming=true`` already uses StreamingLeRobotDataset via
 ``lerobot.datasets.factory.make_dataset``).
 
 Design mirrors :mod:`strands_robots.dataset_recorder`:

--- a/tests/test_lerobot_dependency_docs.py
+++ b/tests/test_lerobot_dependency_docs.py
@@ -159,3 +159,30 @@ def test_molmoact2_doc_install_line_is_not_from_source() -> None:
     text = _MOLMOACT2.read_text()
     assert "lerobot from source" not in text
     assert "[molmoact2]" in text
+
+
+# --- negative contract: lerobot renamed the training entrypoint module
+#     ``lerobot.scripts.train`` -> ``lerobot.scripts.lerobot_train`` (the script
+#     rename wave; the old module is removed, so ``python -m
+#     lerobot.scripts.train`` now raises ``ModuleNotFoundError``). The rest of the
+#     codebase already uses the current name (``strands_robots.training.lerobot``,
+#     ``strands_robots.tools.lerobot_train``, ``docs/training/overview.md``); these
+#     two user-facing "how to train" spots lagged. Pin the dead module out and
+#     require the current one. ---
+
+_STREAMING_DATASET = _REPO_ROOT / "strands_robots" / "streaming_dataset.py"
+_RECORDING = _REPO_ROOT / "docs" / "recording.md"
+
+
+def test_no_userfacing_file_invokes_removed_lerobot_scripts_train() -> None:
+    for path in (_STREAMING_DATASET, _RECORDING):
+        text = path.read_text()
+        assert "lerobot.scripts.train" not in text, (
+            f"{path.name} instructs the removed `python -m lerobot.scripts.train`; "
+            "lerobot renamed the trainer module to `lerobot.scripts.lerobot_train`"
+        )
+        # each file documents a train invocation, so the current module name must
+        # be the one it points at
+        assert "lerobot.scripts.lerobot_train" in text, (
+            f"{path.name} lost its `lerobot.scripts.lerobot_train` reference"
+        )


### PR DESCRIPTION
## Problem

lerobot renamed its trainer entrypoint module `lerobot.scripts.train` -> `lerobot.scripts.lerobot_train` (the script-rename wave). The old module is **removed** — `python -m lerobot.scripts.train` now raises `ModuleNotFoundError`.

Two user-facing "how to train" spots still instructed the dead module:

- `strands_robots/streaming_dataset.py` module docstring: `python -m lerobot.scripts.train dataset.streaming=true`
- `docs/recording.md` streamed-training example: `python -m lerobot.scripts.train policy=act ...`

The `docs/recording.md` example also used the old **hydra** `key=value` flag style, whereas lerobot moved to **draccus** `--dotted.flags` (the line directly above it already uses `lerobot-train --dataset.streaming=true`).

Everywhere else in the repo already uses the current name + flag style — `strands_robots.training.lerobot`, `strands_robots.tools.lerobot_train`, `docs/training/overview.md`, `docs/hardware/tools.md` — so these two spots simply lagged.

## Change

- `streaming_dataset.py`: `python -m lerobot.scripts.lerobot_train --dataset.streaming=true`
- `docs/recording.md`: `python -m lerobot.scripts.lerobot_train --policy.type=act --dataset.repo_id=... --dataset.streaming=true --num_workers=4` (draccus flags — verified against the current `TrainPipelineConfig`/`DatasetConfig` fields and `strands_robots.training.lerobot.build_command`).
- Docs-only + a regression test (no runtime/behavior change).

## Test

Extends the existing `tests/test_lerobot_dependency_docs.py` doc-contract suite with `test_no_userfacing_file_invokes_removed_lerobot_scripts_train`: pins the removed `lerobot.scripts.train` module out of both user-facing files and requires the current `lerobot.scripts.lerobot_train`. **Fails-before** (both files cited the dead module), **passes-after**; full file 11 passed; ruff/format/mypy clean.

Docs-only change → no visual artifact (item 11 covers policy/sim/render/asset changes).