### PR TITLE
fix(use_lerobot): screen the method blocklist against the module path

### DIFF
--- a/strands_robots/tools/use_lerobot.py
+++ b/strands_robots/tools/use_lerobot.py
@@ -510,6 +510,13 @@ def use_lerobot(
     frames (numpy HxW / HxWxC arrays) returned by a call are emitted as proper
     Strands ``image`` content blocks so the model can actually see them.
 
+    Calls under restricted namespaces (``lerobot.scripts``,
+    ``lerobot.common.datasets.push``) and side-effecting methods
+    (``push_to_hub``, ``upload_folder``, ``save_to_disk``, ...) are refused
+    before invocation - whether named via ``method`` or reached through the
+    ``module`` path - so a prompt-injected call cannot push to the Hub or
+    spawn a training subprocess.
+
     Args:
         module: Dotted path into lerobot (e.g. "cameras.opencv.OpenCVCamera",
                 "datasets.lerobot_dataset.LeRobotDataset", "policies.factory").
@@ -624,10 +631,20 @@ def use_lerobot(
                     "status": "error",
                     "content": [{"text": f"Blocked: {full_path} is in a restricted module namespace"}],
                 }
-        if method in _BLOCKED_METHODS:
+        # A blocked method can be reached either via the ``method`` argument or as
+        # a segment of ``module``: ``_import_from_lerobot`` walks attribute chains,
+        # so ``module="datasets.lerobot_dataset.LeRobotDataset.push_to_hub"`` with
+        # an empty ``method`` resolves straight to the callable. Screen the method
+        # name AND every module-path segment so the guard cannot be bypassed by
+        # moving the method name into the module path.
+        blocked_name = next(
+            (name for name in (method, *full_path.split(".")) if name in _BLOCKED_METHODS),
+            None,
+        )
+        if blocked_name is not None:
             return {
                 "status": "error",
-                "content": [{"text": f"Blocked: method '{method}' is not permitted via use_lerobot"}],
+                "content": [{"text": f"Blocked: method '{blocked_name}' is not permitted via use_lerobot"}],
             }
 
         # Call it

--- a/tests/tools/test_use_lerobot.py
+++ b/tests/tools/test_use_lerobot.py
@@ -745,6 +745,32 @@ def test_blocked_method_name_is_refused(monkeypatch: pytest.MonkeyPatch) -> None
     assert called["n"] == 0, "blocked method must not be invoked"
 
 
+def test_blocked_method_reached_through_module_path_is_refused(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The method blocklist must screen the module path, not just the ``method``
+    argument. ``_import_from_lerobot`` walks attribute chains, so an agent can
+    resolve a side-effecting callable directly by putting its name in ``module``
+    with an empty ``method`` (e.g. ``module="...LeRobotDataset.push_to_hub"``).
+    That callable must still be refused before invocation, otherwise the guard
+    is trivially bypassable."""
+    called = {"n": 0}
+
+    def resolver(path: str) -> Any:
+        # The dotted module path resolved straight to the callable itself.
+        def push_to_hub(**kwargs: Any) -> None:
+            called["n"] += 1  # must never run
+
+        return push_to_hub
+
+    monkeypatch.setattr(M, "_import_from_lerobot", resolver)
+    result = _fn(module="datasets.lerobot_dataset.LeRobotDataset.push_to_hub", method="")
+    assert result["status"] == "error"
+    text = _texts(result)
+    _assert_ascii(text)
+    assert "Blocked" in text
+    assert "push_to_hub" in text
+    assert called["n"] == 0, "blocked callable reached via module path must not be invoked"
+
+
 def test_safe_method_on_unblocked_module_is_allowed(monkeypatch: pytest.MonkeyPatch) -> None:
     """The guards are an allowlist, not a blanket denial: an ordinary method on
     an unrestricted module still dispatches and returns its result."""


### PR DESCRIPTION
## Problem

`use_lerobot` exposes the whole `lerobot` package to an LLM-driven agent, so two allowlists keep a prompt-injected call from spawning training subprocesses or pushing to the Hugging Face Hub: a blocked-module-prefix check and a blocked-method-name check (`push_to_hub`, `upload_folder`, `save_to_disk`, ...).

The method check only inspected the `method` argument. But `_import_from_lerobot` walks attribute chains, so a blocked callable can be reached entirely through the `module` path with an empty `method` - the guard is bypassed and the callable is invoked:

```python
# Correctly blocked (method arg):
use_lerobot(module="datasets.lerobot_dataset.LeRobotDataset", method="push_to_hub")
#   -> "Blocked: method 'push_to_hub' is not permitted"

# BYPASS (method name moved into the module path, empty method):
use_lerobot(module="datasets.lerobot_dataset.LeRobotDataset.push_to_hub", method="")
#   -> NOT blocked; falls through to target(**params) and invokes push_to_hub
```

The blocked-module-prefix check already screens the full resolved path, so `lerobot.scripts.*` stays blocked either way - only the method blocklist was evadable.

## Change

Screen the method blocklist against both the `method` argument **and** every segment of the resolved module path, so the guard cannot be evaded by moving the method name into the module path. The error message names the offending segment.

## Tests

Adds `test_blocked_method_reached_through_module_path_is_refused`, which resolves `push_to_hub` through the module path with an empty `method` and asserts the call is refused before invocation. It **fails on pre-fix code** (the stub callable is actually invoked and the tool returns `success`) and passes after. Full `tests/tools/test_use_lerobot.py` is green (67 passed, 1 skipped); `ruff check`, `ruff format --check`, and `mypy strands_robots tests tests_integ` are clean.

The tool docstring now documents that restricted namespaces and side-effecting methods are refused whether named via `method` or reached through the `module` path.