### PR TITLE
fix(lerobot_async): source server-supported policy set live from lerobot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Changed: `lerobot_async` sources its server-supported policy set live from lerobot
+
+`LerobotAsyncPolicy` validates `policy_type` client-side against the set of
+policies a lerobot `PolicyServer` can serve. That set was a hand-copied tuple
+kept in sync with `lerobot.async_inference.constants.SUPPORTED_POLICIES` by
+hand -- a silent drift landmine: when lerobot adds an async-servable policy the
+client wrongly rejected it (only the frozen copy was accepted), and if lerobot
+dropped one the client accepted it only to fail after the gRPC handshake. It is
+now sourced live from that lerobot constant, with a static fallback used only
+when lerobot or its async extra is not importable, and a drift-guard test keeps
+the fallback a faithful snapshot.
+
 ### Fixed: `add_robot` rejects a non-finite / malformed base pose instead of baking it into the scene
 
 `add_robot` writes the caller-supplied `position` (3) / `orientation`

--- a/docs/policies/lerobot-async.md
+++ b/docs/policies/lerobot-async.md
@@ -80,7 +80,7 @@ sim.run_policy(
 | `server_address`           | `127.0.0.1:8080` | Server `host:port` (gRPC); wins over `host`/`port`. `grpc://` scheme stripped |
 | `host`                     | `127.0.0.1`   | Server host (when `server_address` is omitted)              |
 | `port`                     | `8080`        | Server port (when `server_address` is omitted)              |
-| `policy_type`              | -             | **Required.** LeRobot policy type the server loads (`act`, `smolvla`, `diffusion`, `tdmpc`, `vqbet`, `pi0`, `pi05`, `groot`) |
+| `policy_type`              | -             | **Required.** LeRobot policy type the server loads -- the async-servable set from lerobot's `SUPPORTED_POLICIES` (`act`, `smolvla`, `diffusion`, `tdmpc`, `vqbet`, `pi0`, `pi05`, `groot`, ...); validated client-side against the live lerobot constant |
 | `pretrained_name_or_path`  | -             | **Required.** HuggingFace id or path the server loads       |
 | `device`                   | `cuda`        | Device for **server-side** inference; set `cpu` for a CPU server |
 | `actions_per_chunk`        | `50`          | Max actions the server returns per chunk                    |

--- a/strands_robots/policies/lerobot_async/policy.py
+++ b/strands_robots/policies/lerobot_async/policy.py
@@ -62,11 +62,11 @@ from strands_robots.utils import require_optional
 
 logger = logging.getLogger(__name__)
 
-#: Policy types a lerobot ``PolicyServer`` can serve, mirroring
-#: ``lerobot.async_inference.constants.SUPPORTED_POLICIES``. Validated
-#: client-side so a typo fails fast with the valid set instead of only
-#: surfacing after the gRPC handshake.
-SUPPORTED_POLICY_TYPES: tuple[str, ...] = (
+#: Offline fallback for the policy types a lerobot ``PolicyServer`` can serve,
+#: used only when ``lerobot.async_inference.constants.SUPPORTED_POLICIES`` cannot
+#: be imported (lerobot or its async extra absent). A faithful snapshot of that
+#: constant; a drift-guard test keeps the two in sync.
+_SUPPORTED_POLICY_TYPES_FALLBACK: tuple[str, ...] = (
     "act",
     "smolvla",
     "diffusion",
@@ -76,6 +76,30 @@ SUPPORTED_POLICY_TYPES: tuple[str, ...] = (
     "pi05",
     "groot",
 )
+
+
+def _supported_policy_types() -> tuple[str, ...]:
+    """Policy types a lerobot ``PolicyServer`` can serve.
+
+    Sourced live from ``lerobot.async_inference.constants.SUPPORTED_POLICIES`` so
+    it tracks lerobot automatically - the client-side validation stays correct
+    when lerobot adds or drops an async-servable policy, instead of relying on a
+    hand-copied list that silently drifts (accepting a now-unsupported type only
+    to fail after the gRPC handshake, or rejecting a newly-supported one). Falls
+    back to :data:`_SUPPORTED_POLICY_TYPES_FALLBACK` when lerobot or its async
+    extra is not importable.
+    """
+    try:
+        from lerobot.async_inference.constants import SUPPORTED_POLICIES
+    except (ImportError, AttributeError):
+        return _SUPPORTED_POLICY_TYPES_FALLBACK
+    return tuple(sorted(SUPPORTED_POLICIES))
+
+
+#: Policy types a lerobot ``PolicyServer`` can serve (sourced live from lerobot;
+#: see :func:`_supported_policy_types`). Validated client-side so a typo fails
+#: fast with the valid set instead of only surfacing after the gRPC handshake.
+SUPPORTED_POLICY_TYPES: tuple[str, ...] = _supported_policy_types()
 
 #: Default gRPC handshake timeout (seconds).
 DEFAULT_CONNECT_TIMEOUT = 10.0
@@ -150,15 +174,14 @@ class LerobotAsyncPolicy(Policy):
             address = address.split("://", 1)[1]
         self.server_address = address
 
+        supported = _supported_policy_types()
         if not policy_type:
             raise ValueError(
-                "lerobot_async requires policy_type=... (the lerobot policy the "
-                f"server loads); one of {SUPPORTED_POLICY_TYPES}."
+                f"lerobot_async requires policy_type=... (the lerobot policy the server loads); one of {supported}."
             )
-        if policy_type not in SUPPORTED_POLICY_TYPES:
+        if policy_type not in supported:
             raise ValueError(
-                f"policy_type {policy_type!r} is not served by a lerobot PolicyServer; "
-                f"choose one of {SUPPORTED_POLICY_TYPES}."
+                f"policy_type {policy_type!r} is not served by a lerobot PolicyServer; choose one of {supported}."
             )
         if not pretrained_name_or_path:
             raise ValueError(

--- a/tests/policies/lerobot_async/test_lerobot_async_roundtrip.py
+++ b/tests/policies/lerobot_async/test_lerobot_async_roundtrip.py
@@ -474,3 +474,62 @@ def test_inference_without_state_keys_raises(running_server) -> None:
     with pytest.raises(RuntimeError, match="robot_state_keys is empty"):
         policy.get_actions_sync(_observation(), "task")
     policy.close()
+
+
+# -- lerobot drift guard: SUPPORTED_POLICY_TYPES is live-sourced -----------------
+#
+# The set of policy types a lerobot ``PolicyServer`` can serve lives in lerobot's
+# own ``async_inference.constants.SUPPORTED_POLICIES``. The client validation
+# must track that constant, not a hand-copied list: a stale copy either rejects a
+# newly-servable policy client-side or accepts a dropped one only to fail after
+# the gRPC handshake. These pin that the copy cannot silently drift.
+
+from strands_robots.policies.lerobot_async import policy as async_policy  # noqa: E402
+
+
+def test_supported_policy_types_sourced_live_from_lerobot() -> None:
+    """The client's supported set is the live lerobot constant, not a fixed copy."""
+    constants = pytest.importorskip("lerobot.async_inference.constants")
+    live = getattr(constants, "SUPPORTED_POLICIES", None)
+    if live is None:
+        pytest.skip("lerobot async SUPPORTED_POLICIES not available")
+    assert set(async_policy._supported_policy_types()) == set(live)
+    assert set(async_policy.SUPPORTED_POLICY_TYPES) == set(live)
+
+
+def test_fallback_is_a_faithful_snapshot_of_lerobot() -> None:
+    """The offline fallback stays in sync with lerobot; drift trips this test."""
+    constants = pytest.importorskip("lerobot.async_inference.constants")
+    live = getattr(constants, "SUPPORTED_POLICIES", None)
+    if live is None:
+        pytest.skip("lerobot async SUPPORTED_POLICIES not available")
+    assert set(async_policy._SUPPORTED_POLICY_TYPES_FALLBACK) == set(live), (
+        "_SUPPORTED_POLICY_TYPES_FALLBACK drifted from lerobot's SUPPORTED_POLICIES; "
+        "update the fallback tuple to match the current lerobot constant."
+    )
+
+
+def test_validation_tracks_a_newly_added_lerobot_policy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A policy type lerobot adds to SUPPORTED_POLICIES is accepted immediately.
+
+    Proves the client-side check reads lerobot live rather than a frozen copy: a
+    type that only exists in lerobot's (here monkeypatched) constant passes
+    validation instead of being wrongly rejected as "not served".
+    """
+    constants = pytest.importorskip("lerobot.async_inference.constants")
+    live = getattr(constants, "SUPPORTED_POLICIES", None)
+    if live is None:
+        pytest.skip("lerobot async SUPPORTED_POLICIES not available")
+    fake = "fake_async_policy_xyz"
+    monkeypatch.setattr(constants, "SUPPORTED_POLICIES", tuple(sorted({*live, fake})))
+
+    assert fake in async_policy._supported_policy_types()
+    # create_policy must NOT reject the freshly-supported type (lazy connect, so
+    # no server is contacted here).
+    policy = create_policy(
+        "lerobot_async",
+        server_address="gpu-box:8080",
+        policy_type=fake,
+        pretrained_name_or_path="x/y",
+    )
+    assert policy.policy_type == fake

--- a/tests/policies/lerobot_async/test_lerobot_async_roundtrip.py
+++ b/tests/policies/lerobot_async/test_lerobot_async_roundtrip.py
@@ -532,4 +532,5 @@ def test_validation_tracks_a_newly_added_lerobot_policy(monkeypatch: pytest.Monk
         policy_type=fake,
         pretrained_name_or_path="x/y",
     )
+    assert isinstance(policy, LerobotAsyncPolicy)
     assert policy.policy_type == fake


### PR DESCRIPTION
## Problem

`LerobotAsyncPolicy` validates `policy_type` client-side against the set of policies a lerobot `PolicyServer` can serve. That set was a hand-copied tuple in `strands_robots/policies/lerobot_async/policy.py`:

```python
SUPPORTED_POLICY_TYPES = ("act", "smolvla", "diffusion", "tdmpc", "vqbet", "pi0", "pi05", "groot")
```

whose own comment says it is "mirroring `lerobot.async_inference.constants.SUPPORTED_POLICIES`" — i.e. a copy that must be kept in sync by hand. It happens to match today, but that is a silent drift landmine:

- When lerobot **adds** an async-servable policy, the client **wrongly rejects** it (`policy_type ... is not served by a lerobot PolicyServer`) even though the server can serve it.
- When lerobot **drops/renames** one, the client **accepts** it and only fails after the gRPC `SendPolicyInstructions` handshake — the exact late failure the client-side check exists to prevent.

## Change

Source the supported set **live** from `lerobot.async_inference.constants.SUPPORTED_POLICIES` via a small `_supported_policy_types()` helper, falling back to a static `_SUPPORTED_POLICY_TYPES_FALLBACK` snapshot only when lerobot / its async extra is not importable. The `__init__` validation now consults the live set, so a policy lerobot adds is accepted immediately and one it drops is rejected up front. `SUPPORTED_POLICY_TYPES` is preserved (derived from the helper) for the public import + error messages.

Also de-froze the same hand-copied list in `docs/policies/lerobot-async.md` so the doc references the live lerobot set rather than becoming its own stale copy.

## Tests (`tests/policies/lerobot_async/test_lerobot_async_roundtrip.py`)

- `test_supported_policy_types_sourced_live_from_lerobot` — the client's supported set equals lerobot's live constant.
- `test_fallback_is_a_faithful_snapshot_of_lerobot` — **drift guard**: the offline fallback must equal lerobot's `SUPPORTED_POLICIES`; if lerobot drifts, this fails and forces the fallback to be updated.
- `test_validation_tracks_a_newly_added_lerobot_policy` — monkeypatches a fake type into lerobot's constant and asserts `create_policy("lerobot_async", policy_type=<fake>, ...)` is accepted (not rejected as "not served"), proving the check reads lerobot live rather than a frozen copy.

All three **fail before** the change (the `_supported_policy_types` helper / `_SUPPORTED_POLICY_TYPES_FALLBACK` do not exist, and the hardcoded tuple rejects the freshly-supported type) and pass after. Full `lerobot_async` suite: 25 passed. ruff + mypy clean.

No visual artifact (client-side validation contract, no policy/sim/render/asset behaviour change).