### PR TITLE
test(simulation): pin single-robot run_multi_policy recording to un-namespaced columns

### DIFF
--- a/tests/simulation/mujoco/test_recording_paths.py
+++ b/tests/simulation/mujoco/test_recording_paths.py
@@ -1013,3 +1013,73 @@ def test_start_recording_existing_empty_root_records(sim_with_two_robots, tmp_pa
     ds = LeRobotDataset(repo_id="local/empty_root_probe", root=root)
     assert ds.meta.total_episodes == 1, f"expected 1 episode, got {ds.meta.total_episodes}"
     assert ds.meta.total_frames > 0
+
+
+def test_run_multi_policy_single_robot_records_unnamespaced_columns(tmp_path):
+    """A single-robot world driven via ``run_multi_policy`` records BARE
+    (un-prefixed) action/observation columns.
+
+    ``run_multi_policy`` accepts a one-entry ``policies`` dict (e.g. a bimanual
+    rig temporarily driving a single arm). When the world holds exactly one
+    robot, ``multi_robot`` is False and the merged frame must carry the robot's
+    plain actuator/joint keys - NOT ``<name>__`` prefixed - so the dataset
+    schema is identical to a single-robot ``run_policy`` recording and a policy
+    trained on one layout can consume the other. This pins the un-namespaced
+    merge branch of the synchronized loop (the multi-robot namespaced branch is
+    covered by ``test_b4_synchronized_multi_robot_recording``).
+    """
+    from strands_robots.dataset_recorder import has_lerobot_dataset
+
+    if not has_lerobot_dataset():
+        pytest.skip("lerobot not installed")
+
+    import numpy as np
+
+    from strands_robots.policies import create_policy
+    from strands_robots.simulation import Simulation
+
+    tmpdir = tempfile.mkdtemp()
+    path = os.path.join(tmpdir, "test_arm.xml")
+    with open(path, "w") as f:
+        f.write(_ROBOT_XML)
+
+    sim = Simulation()
+    sim.create_world()
+    sim.add_robot("solo", urdf_path=path, position=[0, 0, 0])
+    sim.step(5)
+    try:
+        root = str(tmp_path / "solo")
+        r = sim.start_recording(repo_id="local/solo_multi", fps=20, root=root, overwrite=True)
+        assert r["status"] == "success", r
+
+        r = sim.run_multi_policy(
+            policies={"solo": create_policy("mock")},
+            instructions="wave",
+            duration=0.5,
+            control_frequency=20.0,
+        )
+        assert r["status"] == "success", r
+        assert tool_json(r)["steps"] > 0
+        sim.stop_recording()
+
+        from lerobot.datasets.lerobot_dataset import LeRobotDataset
+
+        ds = LeRobotDataset(repo_id="local/solo_multi", root=root)
+
+        af = ds.features["action"]
+        names = af["names"] if isinstance(af, dict) else getattr(af, "names", None)
+        assert names, names
+        # Single-robot world: columns are the bare actuator keys, un-prefixed.
+        assert all("__" not in n for n in names), f"expected un-namespaced columns, got {names}"
+        assert set(names) == {"shoulder_pan_act", "shoulder_lift_act", "elbow_act"}, names
+
+        # Frames were actually written with non-zero commanded actions.
+        assert len(ds) > 0
+        moved = 0
+        for i in range(len(ds)):
+            if float(np.abs(np.asarray(ds[i]["action"])).sum()) > 1e-6:
+                moved += 1
+        assert moved == len(ds), f"only {moved}/{len(ds)} frames carried a commanded action"
+    finally:
+        sim.destroy()
+        shutil.rmtree(tmpdir, ignore_errors=True)


### PR DESCRIPTION
## What
`run_multi_policy` accepts a one-entry `policies` dict, so a single-robot world is a valid driver target (e.g. a bimanual rig temporarily driving one arm). In that case `multi_robot` (`len(world.robots) > 1`) is `False` and the synchronized loop takes the un-namespaced merge branch: the recorded frame carries the robot's bare actuator/observation keys rather than `<name>__`-prefixed ones. This keeps the dataset schema identical to a single-robot `run_policy` recording so a policy trained on one layout can consume the other.

The multi-robot namespaced branch is already pinned by `test_b4_synchronized_multi_robot_recording`; the single-robot merge branch had no coverage. This adds one focused round-trip test for it.

## Test
`test_run_multi_policy_single_robot_records_unnamespaced_columns` does a full start -> run_multi_policy -> stop -> reopen round-trip on a one-robot world and asserts:
- the recorded `action` columns are the bare actuator keys (`shoulder_pan_act`, `shoulder_lift_act`, `elbow_act`) with no `__` prefix, and
- every written frame carries a non-zero commanded action (no dead/zero frames).

Gate (CI scope `strands_robots tests tests_integ`): `ruff check` clean, `ruff format --check` clean, `mypy` clean, and `MUJOCO_GL=egl pytest tests/simulation/mujoco/test_recording_paths.py` -> 28 passed. Coverage of `simulation/mujoco/simulation.py` confirms the previously-uncovered un-namespaced merge branch is now exercised.

## Rollout artifact
Headless MuJoCo (`MUJOCO_GL=egl`) rollout of the single-robot arm used by the test, recorded via `run_policy(video=...)`:

![single-robot rollout](https://github.com/cagataycali/robots/releases/download/artifact-multi-policy-solo-1784370040/solo_rollout.gif)

MP4: https://github.com/cagataycali/robots/releases/download/artifact-multi-policy-solo-1784370040/solo_rollout.mp4

Test-only change; no library behavior is modified.