### PR TITLE
fix(training): source expert_only supported-policy set live from lerobot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable behavioural changes to `strands-robots` are logged here. Follows
 
 ## [Unreleased]
 
+### Fixed: training `expert_only` supported-policy set sourced live from lerobot
+
+`LerobotTrainer` gated `method="expert_only"` (freeze the VLM, train only the
+action expert) against a HARD-CODED tuple `{pi0, pi05, pi0_fast, smolvla}`, and
+the `lerobot_train` tool's `build_train_command` used a separate hard-copied
+set. That is the stale-allowlist drift class (sibling of the `lerobot_async`
+and reward-model registry fixes): lerobot's `PI0FASTConfig` exposes NO
+`train_expert_only` field, so an `expert_only` pi0_fast run passed `validate`,
+then `build_config`'s `hasattr` guard silently SKIPPED the flag and
+full-finetuned the whole backbone (a far more expensive, different run) while
+reporting success; conversely a policy lerobot later GAINS the field would be
+wrongly rejected. The supported set is now sourced live -- a policy supports
+`expert_only` iff its lerobot config declares a `train_expert_only` field
+(`dataclasses.fields`) -- with a static fallback used only when lerobot is not
+importable, and drift-guard tests keep the fallback a faithful snapshot. The
+docstrings no longer claim a fixed `pi0/pi05/pi0_fast/smolvla` list.
+
 ### Changed: `lerobot_async` sources its server-supported policy set live from lerobot
 
 `LerobotAsyncPolicy` validates `policy_type` client-side against the set of

--- a/strands_robots/tools/lerobot_train.py
+++ b/strands_robots/tools/lerobot_train.py
@@ -13,6 +13,7 @@ background process tracked in an on-disk session store, and ``status``/``stop``/
 ``list`` manage it.
 """
 
+import dataclasses
 import json
 import logging
 import os
@@ -35,9 +36,36 @@ SESSION_DIR = Path.cwd() / ".strands_robots/.sessions"
 SESSION_DIR.mkdir(parents=True, exist_ok=True)
 
 # Policy families that train an action expert on top of a frozen VLM. Only these
-# accept ``--policy.train_expert_only``; emitting it elsewhere is a hard error in
-# lerobot, so callers that pass it on an unsupported policy should be told why.
-_EXPERT_ONLY_POLICIES = {"pi0", "pi05", "pi0_fast", "smolvla"}
+# accept ``--policy.train_expert_only``; emitting it on any other policy is a hard
+# error in lerobot, so callers that pass it on an unsupported policy are told why.
+# The supported set is sourced LIVE from lerobot (the policy configs that declare a
+# ``train_expert_only`` field) so it tracks lerobot instead of drifting against a
+# hardcoded copy; the static snapshot below is the FALLBACK when lerobot is not
+# importable. pi0_fast is intentionally absent - its config has no such field.
+_EXPERT_ONLY_POLICIES_FALLBACK = frozenset({"pi0", "pi05", "smolvla"})
+
+
+def _expert_only_policy_types() -> frozenset[str]:
+    """LeRobot policy types whose config declares ``train_expert_only``.
+
+    Read live from lerobot's ``PreTrainedConfig`` registry so this tracks
+    lerobot (a policy that gains or loses expert-only support is picked up with
+    no change here) instead of drifting against a hardcoded copy. Falls back to
+    the documented static snapshot when lerobot is not importable.
+    """
+    try:
+        import lerobot.policies  # noqa: F401  (register_subclass side effect)
+        from lerobot.configs.policies import PreTrainedConfig
+
+        return frozenset(
+            name
+            for name, cfg_cls in PreTrainedConfig.get_known_choices().items()
+            if any(f.name == "train_expert_only" for f in dataclasses.fields(cfg_cls))
+        )
+    except Exception:  # noqa: BLE001 - offline / lerobot missing -> static fallback
+        return _EXPERT_ONLY_POLICIES_FALLBACK
+
+
 # Security: flags that must not be overridden via extra_flags passthrough.
 # These control file output paths, remote telemetry, and code-loading paths
 # that an LLM agent (or prompt injection) could abuse. Gated by a HIL
@@ -290,9 +318,10 @@ def build_train_command(
         raise ValueError(
             "lora and train_expert_only are mutually exclusive (both freeze the VLM). Pick one fine-tuning strategy."
         )
-    if train_expert_only and policy_type not in _EXPERT_ONLY_POLICIES:
+    expert_only_policies = _expert_only_policy_types()
+    if train_expert_only and policy_type not in expert_only_policies:
         raise ValueError(
-            f"train_expert_only is only valid for {sorted(_EXPERT_ONLY_POLICIES)} policies, not '{policy_type}'."
+            f"train_expert_only is only valid for {sorted(expert_only_policies)} policies, not '{policy_type}'."
         )
     if num_gpus < 1:
         raise ValueError(f"num_gpus must be >= 1, got {num_gpus}")
@@ -418,8 +447,9 @@ def lerobot_train(
     Memory-fit levers:
         ``lora`` and ``train_expert_only`` both freeze the VLM and are mutually
         exclusive; setting both fails fast. ``lora`` emits ``--peft.method_type=LORA``
-        plus the supplied ``--peft.*`` overrides. ``train_expert_only`` only
-        applies to pi0/pi05/pi0_fast/smolvla.
+        plus the supplied ``--peft.*`` overrides. ``train_expert_only`` applies
+        only to policies whose lerobot config exposes it (currently pi0/pi05/
+        smolvla; sourced live so it tracks lerobot).
 
     Overfit guard:
         ``val_episodes=N`` reserves the LAST N episodes for evaluation by training
@@ -457,7 +487,8 @@ def lerobot_train(
         lora_r: LoRA rank.
         lora_alpha: LoRA alpha (scaling = lora_alpha / r).
         lora_target_modules: PEFT target module spec (e.g. "all-linear").
-        train_expert_only: Freeze the VLM, train only the action expert (pi-family).
+        train_expert_only: Freeze the VLM, train only the action expert
+            (policies exposing train_expert_only: pi0/pi05/smolvla).
         val_episodes: Reserve the LAST N episodes as a held-out validation split.
         num_gpus: Number of GPUs; >1 launches via accelerate --multi_gpu.
         push_to_hub: Push the trained checkpoint to the HF Hub at the end.

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -88,6 +88,13 @@ _SUPPORTED_METHODS = {"full", "lora", "expert_only"}
 # FALLBACK. Currently the pi0 family and groot expose the field.
 _RELATIVE_ACTION_POLICY_TYPES_FALLBACK = frozenset({"pi0", "pi05", "pi0_fast", "groot"})
 
+# LeRobot policy types whose config exposes ``train_expert_only`` (freeze the
+# (V)LM backbone, train only the action expert - the cheap VLA finetune recipe).
+# Discovered live per policy type off the config class (see
+# :func:`_policy_supports_expert_only`); the static set is the offline FALLBACK.
+# Currently pi0, pi05, and smolvla expose the field (pi0_fast does NOT).
+_EXPERT_ONLY_POLICY_TYPES_FALLBACK = frozenset({"pi0", "pi05", "smolvla"})
+
 # RA-BC (Reward-Aligned Behavior Cloning) is surfaced to the agent through the
 # ``extra['sample_weighting']`` dict. lerobot >= 0.5.2 configures sample
 # weighting via a NESTED ``SampleWeightingConfig`` on ``TrainPipelineConfig``
@@ -165,6 +172,28 @@ def _policy_supports_relative_actions(ptype: str) -> bool:
     if reg is not None and ptype in reg:
         return any(f.name == "use_relative_actions" for f in dataclasses.fields(reg[ptype]))
     return ptype in _RELATIVE_ACTION_POLICY_TYPES_FALLBACK
+
+
+def _policy_supports_expert_only(ptype: str) -> bool:
+    """Whether ``ptype``'s lerobot config exposes ``train_expert_only``.
+
+    ``method="expert_only"`` freezes the VLM and trains only the action expert -
+    the standard cheap VLA finetune. lerobot implements it as a per-policy
+    ``config.train_expert_only`` field; requesting it on a policy whose config
+    lacks the field is either a silent no-op (in-process ``build_config`` guards
+    on ``hasattr`` and never flips the flag, so the run silently full-finetunes
+    the backbone while reporting success) or a hard draccus error (the CLI
+    ``--policy.train_expert_only`` flag), so it must be gated by the policy's
+    actual capability. Probed live off the registry's config *class* (a
+    dataclass field lookup, no instantiation - so no device warnings or
+    construction cost), so any policy lerobot adds with expert-only support is
+    recognized with zero per-type maintenance. Falls back to the documented
+    static set when lerobot's registry is unavailable offline.
+    """
+    reg = _policy_registry()
+    if reg is not None and ptype in reg:
+        return any(f.name == "train_expert_only" for f in dataclasses.fields(reg[ptype]))
+    return ptype in _EXPERT_ONLY_POLICY_TYPES_FALLBACK
 
 
 def _reward_registry() -> dict[str, type] | None:
@@ -515,6 +544,14 @@ class LerobotTrainer(Trainer):
                 f"relative_actions is not supported by policy_type '{ptype}' "
                 f"(only {supported} expose use_relative_actions); "
                 "drop extra['relative_actions'] or pick a supporting policy"
+            )
+
+        if spec.method == "expert_only" and not _policy_supports_expert_only(ptype):
+            supported = sorted(t for t in _lerobot_policy_types() if _policy_supports_expert_only(t))
+            problems.append(
+                f"method 'expert_only' is not supported by policy_type '{ptype}' "
+                f"(only {supported} expose train_expert_only); "
+                "use method='full' or pick a supporting policy"
             )
 
         sw = spec.extra.get("sample_weighting")

--- a/tests/tools/test_lerobot_train.py
+++ b/tests/tools/test_lerobot_train.py
@@ -179,11 +179,11 @@ def test_expert_only_policy_types_tracks_lerobot_registry() -> None:
     # that actually declare a train_expert_only field, so it tracks lerobot.
     import dataclasses
 
-    try:
-        import lerobot.policies  # noqa: F401
-        from lerobot.configs.policies import PreTrainedConfig
-    except Exception:  # noqa: BLE001
-        pytest.skip("lerobot registry unavailable offline")
+    # importorskip both registers the policy configs (side-effect import) and
+    # binds PreTrainedConfig unconditionally, so it is always initialized on the
+    # path that uses it below (CodeQL: no use-before-init).
+    pytest.importorskip("lerobot.policies")
+    PreTrainedConfig = pytest.importorskip("lerobot.configs.policies").PreTrainedConfig
     expected = {
         name
         for name, cfg_cls in PreTrainedConfig.get_known_choices().items()

--- a/tests/tools/test_lerobot_train.py
+++ b/tests/tools/test_lerobot_train.py
@@ -162,6 +162,38 @@ def test_expert_only_rejected_for_non_expert_policy() -> None:
         )
 
 
+def test_expert_only_rejected_for_pi0_fast() -> None:
+    # pi0_fast's lerobot config exposes NO train_expert_only field, so the CLI
+    # flag is a hard draccus error. The supported set is sourced live from
+    # lerobot (not a hardcoded copy that once wrongly listed pi0_fast).
+    with pytest.raises(ValueError, match="train_expert_only is only valid"):
+        build_train_command(
+            dataset_root="/data/cubes",
+            policy_type="pi0_fast",
+            train_expert_only=True,
+        )
+
+
+def test_expert_only_policy_types_tracks_lerobot_registry() -> None:
+    # Drift guard: the live supported set must equal the lerobot policy configs
+    # that actually declare a train_expert_only field, so it tracks lerobot.
+    import dataclasses
+
+    try:
+        import lerobot.policies  # noqa: F401
+        from lerobot.configs.policies import PreTrainedConfig
+    except Exception:  # noqa: BLE001
+        pytest.skip("lerobot registry unavailable offline")
+    expected = {
+        name
+        for name, cfg_cls in PreTrainedConfig.get_known_choices().items()
+        if any(f.name == "train_expert_only" for f in dataclasses.fields(cfg_cls))
+    }
+    assert set(train_mod._expert_only_policy_types()) == expected
+    # pi0_fast has no such field on current lerobot.
+    assert "pi0_fast" not in expected
+
+
 def test_val_episodes_reserves_last_n_episodes(tmp_path: Path) -> None:
     root = _write_dataset(tmp_path / "ds", total_episodes=10)
     cmd = build_train_command(

--- a/tests/training/test_lerobot.py
+++ b/tests/training/test_lerobot.py
@@ -880,6 +880,34 @@ class TestExpertOnlyMethod:
         # A plain (non-expert_only) run must not silently flip the flag on.
         assert cfg.policy.train_expert_only is False
 
+    def test_validate_rejects_expert_only_for_unsupported_policy(self, dataset_root, tmp_path):
+        # pi0_fast's lerobot config has NO train_expert_only field: build_config
+        # silently full-finetunes the backbone (hasattr guard) while reporting
+        # success, so validate() must surface it up front.
+        spec = self._expert_spec(dataset_root, tmp_path, ptype="pi0_fast")
+        problems = LerobotTrainer().validate(spec)
+        assert any("method 'expert_only' is not supported" in p for p in problems)
+
+    def test_validate_accepts_expert_only_for_supported_policy(self, dataset_root, tmp_path):
+        for ptype in ("pi0", "pi05", "smolvla"):
+            spec = self._expert_spec(dataset_root, tmp_path, ptype=ptype)
+            assert LerobotTrainer().validate(spec) == []
+
+    def test_policy_supports_expert_only_tracks_config_field(self):
+        # Drift guard: the capability must reflect each config's ACTUAL
+        # train_expert_only field, not a hardcoded copy - so a lerobot policy
+        # that gains/loses the field is tracked with zero maintenance here.
+        import dataclasses
+
+        from strands_robots.training.lerobot import _policy_registry, _policy_supports_expert_only
+
+        reg = _policy_registry()
+        if reg is None:
+            pytest.skip("lerobot registry unavailable offline")
+        for ptype, cfg_cls in reg.items():
+            has_field = any(f.name == "train_expert_only" for f in dataclasses.fields(cfg_cls))
+            assert _policy_supports_expert_only(ptype) is has_field, ptype
+
 
 class TestSampleWeightingRABC:
     """RA-BC sample-weighting wiring: extra['sample_weighting'] -> nested SampleWeightingConfig.


### PR DESCRIPTION
## Problem

`LerobotTrainer.validate` gated `method="expert_only"` (freeze the (V)LM backbone, train only the action expert) against a **hard-coded** tuple `_EXPERT_ONLY_POLICY_TYPES = {pi0, pi05, pi0_fast, smolvla}`, and the `lerobot_train` tool's `build_train_command` used a **separate** hard-copied set for the same check. This is the stale-allowlist drift class already fixed for `lerobot_async` (#1458) and the reward-model registry.

The copy is not merely a latent landmine — it is **already wrong** against current lerobot:

* lerobot's `PI0FASTConfig` exposes **no** `train_expert_only` field. So an `expert_only` **pi0_fast** run:
  1. passes `validate` (pi0_fast was in the hardcoded allow set), then
  2. `build_config` applies the flag under a `hasattr(cfg, "train_expert_only")` guard → the field is **absent** → the flag is **silently skipped** → the run **full-finetunes the entire backbone** (a far more expensive, different run) while reporting success.
* Conversely, a policy lerobot later *gains* the field would be wrongly **rejected** by the frozen copy.

Empirically on the installed lerobot the configs that actually declare `train_expert_only` are `{pi0, pi05, smolvla}` — **not** the hardcoded four.

## Fix

Source the supported set **live**: a policy supports `expert_only` **iff** its lerobot config class declares a `train_expert_only` field (`dataclasses.fields`).

* `strands_robots/training/lerobot.py`: new `_policy_supports_expert_only(ptype)` (via the existing live `_policy_registry()`); `validate` now rejects `expert_only` for a policy whose config lacks the field, naming the live supported set; the reused `_EXPERT_ONLY_POLICY_TYPES` becomes an offline **fallback** only.
* `strands_robots/tools/lerobot_train.py`: `_expert_only_policy_types()` sources live from `PreTrainedConfig.get_known_choices()`, with a static `_EXPERT_ONLY_POLICIES_FALLBACK` used only when lerobot/`get_known_choices` is unimportable; `build_train_command` uses it.
* Docstrings no longer claim a fixed `pi0/pi05/pi0_fast/smolvla` list.

Backward compatible: the currently-supported policies (`pi0`, `pi05`, `smolvla`) behave identically; only the incorrectly-listed `pi0_fast` is now (correctly) rejected up front instead of silently dropping the flag.

## Tests (fail before, pass after)

`tests/training/test_lerobot.py::TestExpertOnlyMethod` and `tests/tools/test_lerobot_train.py`:

* `validate` rejects `expert_only` for pi0_fast (**fails-before**: returned `[]`), accepts it for pi0/pi05/smolvla.
* `build_train_command(policy_type="pi0_fast", train_expert_only=True)` raises (**fails-before**: built the argv fine, since pi0_fast was in the hardcoded set).
* **Drift guards** (version-agnostic, skip offline): `_policy_supports_expert_only` tracks each config's actual `train_expert_only` field, and the tool's live set equals lerobot's `train_expert_only`-declaring configs.

Gate: `ruff check`/`format` clean, `mypy` clean on both changed source files, 218 passed across `test_lerobot.py` + `test_lerobot_train.py` + `test_lerobot_policy_type_discovery.py` + `test_lerobot_train_blocklist.py`.

No visual artifact (a training-config validation/argv fix, no policy/sim/render/asset change; the fails-before tests are the proof).

---

### Round 2 changelog

* **Fix code-scanning finding** (`Potentially uninitialized local variable PreTrainedConfig`, `tests/tools/test_lerobot_train.py`): the drift-guard test bound `PreTrainedConfig` inside a `try` and used it after the `try/except`, where the `except` calls `pytest.skip()`. The analyzer does not model `pytest.skip()` as terminating, so it saw a path reaching the comprehension with `PreTrainedConfig` unbound. Switched to `pytest.importorskip` (the dominant idiom in this suite), which still performs the `lerobot.policies` side-effect registration import and skips offline, while binding `PreTrainedConfig` unconditionally. Offline behavior (skip) is unchanged; no source/behavior change. (`ff54ffb`)