### PR TITLE
test(assets): pin _has_meshes graceful degradation on stat() failure

### DIFF
--- a/tests/test_asset_manager.py
+++ b/tests/test_asset_manager.py
@@ -196,6 +196,34 @@ class TestHasMeshes:
         os.utime(d, (d.stat().st_atime, key[1]))  # keep mtime stable
         assert manager._has_meshes(d) is False
 
+    def test_stat_oserror_falls_back_to_stable_cache_key(self, tmp_path, monkeypatch):
+        """A ``stat()`` failure after ``exists()`` must not crash mesh discovery.
+
+        There is a window between the ``directory.exists()`` guard and the
+        ``directory.stat().st_mtime`` cache-key read where the directory can
+        become un-stattable (a TOCTOU removal, or its permissions stripped).
+        Mesh detection degrades gracefully: it falls back to a stable
+        ``(path, 0.0)`` cache key and still walks the tree, rather than letting
+        the ``OSError`` escape and abort robot-asset resolution. Removing the
+        fallback would let the ``stat()`` raise propagate and break this.
+        """
+        d = tmp_path / "withmesh"
+        (d / "meshes").mkdir(parents=True)
+        (d / "meshes" / "link.obj").write_bytes(b"o")
+
+        def _raise_stat(self, *args, **kwargs):
+            raise OSError("stat unavailable")
+
+        # exists() stays truthy (the dir is really there); only the cache-key
+        # stat() read fails, exactly as a mid-call permission strip would look.
+        monkeypatch.setattr(Path, "exists", lambda self, *a, **k: True)
+        monkeypatch.setattr(Path, "stat", _raise_stat)
+
+        assert manager._has_meshes(d) is True
+        # The fallback key (mtime pinned to 0.0) was used, so the walk result
+        # is memoised there and served from cache on the next call.
+        assert manager._MESH_CACHE.get((str(d), 0.0)) is True
+
 
 class TestAutoDownloadFallback:
     """When no XML is found on disk, resolution attempts an auto-download."""


### PR DESCRIPTION
## What
Pin the graceful-degradation contract of `strands_robots.assets.manager._has_meshes` when a directory becomes un-stattable after the `exists()` guard.

## Why
`_has_meshes` checks `directory.exists()`, then reads `directory.stat().st_mtime` to build a per-`(path, mtime)` cache key. There is a window between those two calls where the directory can stop being stattable — a TOCTOU removal, or its permissions stripped mid-call. The code already guards this:

```python
try:
    cache_key = (str(directory), directory.stat().st_mtime)
except OSError:
    cache_key = (str(directory), 0.0)
```

so mesh detection falls back to a stable `(path, 0.0)` key and keeps walking the tree instead of letting the `OSError` escape and abort robot-asset resolution. That fallback branch was previously uncovered, so a regression that removed it (or narrowed the `except`) would pass CI silently.

## Change
Test-only. Adds `TestHasMeshes::test_stat_oserror_falls_back_to_stable_cache_key`: with `exists()` truthy and `stat()` raising `OSError`, `_has_meshes` still walks the mesh tree, returns the correct boolean, and memoises the result under the fallback key. No production code changes.

## Verification
- Full `tests/test_asset_manager.py`: 31 passed.
- Coverage of `strands_robots/assets/manager.py` lines 90-91 (the `except OSError` fallback) goes from uncovered to covered.
- Regression proof: removing the `try/except` fallback makes the `stat()` `OSError` propagate and this test fails.
- Green local gate: `ruff check`, `ruff format --check`, and `mypy strands_robots tests` all clean (`Success: no issues found in 768 source files`).