### PR TITLE
fix(simulation): drop private helpers from SpecBuilder __all__

### DIFF
--- a/strands_robots/simulation/mujoco/spec_builder.py
+++ b/strands_robots/simulation/mujoco/spec_builder.py
@@ -796,9 +796,4 @@ def _is_z0_ground_plane(geom: Any) -> bool:
 
 __all__ = [
     "SpecBuilder",
-    "_is_z0_ground_plane",
-    "_geom_type",
-    "_normalize_size",
-    "_validate_size",
-    "_target_quat",
 ]

--- a/tests/simulation/mujoco/test_spec_builder.py
+++ b/tests/simulation/mujoco/test_spec_builder.py
@@ -978,3 +978,33 @@ class TestSpecAccessorDriftResilience:
         assert gripper.added_cameras[0]["name"] == "wrist"
         # The camera went to the scanned parent, not the worldbody fallback.
         assert spec.worldbody.added_cameras == []
+
+
+class TestPublicApiSurface:
+    """``__all__`` declares the public API; private helpers must stay out of it.
+
+    The underscore-prefixed module helpers (``_geom_type`` et al.) are internal
+    implementation detail consumed by sibling modules via explicit-name imports,
+    not through ``from spec_builder import *``. Listing them in ``__all__`` both
+    contradicts their private naming and pollutes the documented public surface.
+    """
+
+    def test_all_declares_only_public_names(self):
+        from strands_robots.simulation.mujoco import spec_builder
+
+        assert spec_builder.__all__ == ["SpecBuilder"]
+        assert all(not name.startswith("_") for name in spec_builder.__all__)
+
+    def test_private_helpers_remain_importable_by_name(self):
+        # Removing them from __all__ must not remove them as module attributes;
+        # scene_ops and simulation import them by explicit name.
+        from strands_robots.simulation.mujoco import spec_builder
+
+        for name in (
+            "_is_z0_ground_plane",
+            "_geom_type",
+            "_normalize_size",
+            "_validate_size",
+            "_target_quat",
+        ):
+            assert callable(getattr(spec_builder, name)), name


### PR DESCRIPTION
## Problem

`strands_robots/simulation/mujoco/spec_builder.py` declares five underscore-prefixed helpers in its `__all__` alongside the public `SpecBuilder`:

```python
__all__ = [
    "SpecBuilder",
    "_is_z0_ground_plane",
    "_geom_type",
    "_normalize_size",
    "_validate_size",
    "_target_quat",
]
```

`__all__` declares the module's public API (it drives `from spec_builder import *` and doc-tooling surfaces). Listing private, underscore-prefixed names there is contradictory and serves no functional purpose:

- The helpers' only consumers (`simulation.py`, `scene_ops.py`, and the test suite) import them **by explicit name**, which does not consult `__all__`.
- There are **no star-imports** of `spec_builder` anywhere in the tree.

So the entries are dead weight that pollute the documented public surface and violate the project convention that private names must not appear in `__all__`.

## Change

Reduce `__all__` to the public `SpecBuilder` only. The five helpers remain ordinary module attributes, so every explicit-name import is unaffected.

## Tests

Adds `TestPublicApiSurface` in `tests/simulation/mujoco/test_spec_builder.py`:

- `test_all_declares_only_public_names` - asserts `__all__ == ["SpecBuilder"]` and that no entry is underscore-prefixed. Fails on the pre-fix code (`__all__` had 6 entries), passes after.
- `test_private_helpers_remain_importable_by_name` - pins that the helpers stay importable as module attributes so sibling-module imports keep working.

Gate: `ruff check` + `ruff format --check` + `mypy strands_robots tests tests_integ` clean ("no issues found in 806 source files"); `tests/simulation/mujoco/test_spec_builder.py` 62 passed.

No behavior change (export-list hygiene only).