### PR TITLE
test(simulation): pin add_robot home-qpos width-mismatch guard against neighbor corruption

### DIFF
--- a/tests/simulation/mujoco/test_add_robot_keyframe.py
+++ b/tests/simulation/mujoco/test_add_robot_keyframe.py
@@ -356,3 +356,43 @@ class TestMultiRobotKeyframeSpawn:
         assert np.isclose(_joint_qpos(sim, "a/elbow"), 0.0)
         assert np.isclose(_joint_qpos(sim, "b/shoulder"), _HOME[0])
         assert np.isclose(_joint_qpos(sim, "b/elbow"), _HOME[1])
+
+
+class TestApplyHomeQposWidthGuard:
+    """``_apply_home_qpos_to_robot`` must skip a home entry whose value width
+    disagrees with the target joint's qpos width instead of writing a
+    wrong-length slice.
+
+    ``add_robot(keyframe=...)`` reads the home pose from the SAME model it
+    writes it back onto, so the per-joint widths always agree and the guard is
+    unreachable through the public spawn path. It exists as a defensive backstop
+    for callers that hand in an externally-sourced pose (e.g. a benchmark
+    reusing one robot's home pose on a structurally different model): a
+    mismatched entry must be dropped, never sliced into ``qpos``, because a
+    wrong-length assignment would either raise or spill into the adjacent
+    joint's slice and silently corrupt its state. This exercises that guard
+    directly.
+    """
+
+    def test_width_mismatch_entry_skipped_without_corrupting_neighbor(self, sim, arm_xml):
+        # A robot with no keyframe -> both joints start at the zero pose.
+        sim.add_robot(name="a", urdf_path=arm_xml)
+        robot = sim._world.robots["a"]
+        model = sim._world._model
+        data = sim._world._data
+
+        sh_adr = int(model.jnt_qposadr[mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, "a/shoulder")])
+        el_adr = int(model.jnt_qposadr[mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, "a/elbow")])
+
+        # "shoulder" is a 1-wide hinge but the supplied home value has width 2;
+        # "elbow" is correctly sized. Keys are the short (namespace-stripped)
+        # joint names the method matches against.
+        sim._apply_home_qpos_to_robot(robot, {"shoulder": [0.1, 0.2], "elbow": [0.9]})
+
+        # The mismatched shoulder entry is dropped: its qpos slice is untouched
+        # (still the zero pose) and the extra value did NOT spill into the
+        # adjacent elbow slice.
+        assert data.qpos[sh_adr] == 0.0
+        assert data.qpos[el_adr] == 0.9
+        # Only the correctly-sized joint is recorded for reset() to restore.
+        assert robot.home_qpos == {"a/elbow": [0.9]}


### PR DESCRIPTION
## Problem

`Simulation._apply_home_qpos_to_robot` (MuJoCo backend) writes a keyframe home pose onto a robot's joints, slicing each joint's value into `qpos` at its per-joint width. It carries a defensive guard that skips any home entry whose supplied value width disagrees with the target joint's `qpos` width:

```python
width = _jnt_qpos_width(mj, int(model.jnt_type[j]))
if len(vals) != width:
    # width mismatch (unexpected for a matching source model): skip
    # defensively rather than corrupt an adjacent joint's slice.
    continue
data.qpos[adr : adr + width] = vals
```

This guard had no test. `add_robot(keyframe=...)` reads the home pose from the SAME model it writes it back onto, so per-joint widths always agree and the branch is unreachable through the public spawn path. The existing `test_add_robot_keyframe.py` suite therefore exercises only the width-correct slicing (hinge/slide/ball/free), never the mismatch backstop.

Without the guard, a mismatched entry reaches `data.qpos[adr : adr + width] = vals` and either raises `ValueError: could not broadcast input array from shape (2,) into shape (1,)` or, for a wrong width that still fits, spills into the adjacent joint's slice and silently corrupts its state.

## Change

Test-only. Adds `TestApplyHomeQposWidthGuard` to `tests/simulation/mujoco/test_add_robot_keyframe.py` pinning the guard directly (the branch is unreachable via `add_robot`, so it is exercised through the helper):

- `test_width_mismatch_entry_skipped_without_corrupting_neighbor` - spawns a two-hinge arm at the zero pose, then applies a home map where `shoulder` carries a width-2 value (a 1-wide hinge) alongside a correctly-sized `elbow`. Asserts the mismatched `shoulder` entry is dropped (its `qpos` slice stays `0.0`, the extra value does NOT spill into the adjacent `elbow` slice), the correctly-sized `elbow` is written (`0.9`), and only `elbow` is recorded in `home_qpos` for `reset()` to restore.

Verified the test is a genuine regression guard: with the `if len(vals) != width: continue` branch removed, it fails with `ValueError: could not broadcast input array from shape (2,) into shape (1,)`; with the branch present it passes.

## Tests

Uses the file's existing offline inline two-hinge MJCF fixture (no mesh download, no render, GL-free). Coverage of `strands_robots/simulation/mujoco/simulation.py` gains the previously-uncovered width-mismatch branch (line drops out of the term-missing report).

Gate: `hatch run lint` clean ("Success: no issues found in 806 source files"); `tests/simulation/mujoco/` 1444 passed (`test_add_robot_keyframe.py` 18 -> 19). No behavior change (test-only).